### PR TITLE
feat: Refactor desktop practice workspace

### DIFF
--- a/apps/backend/app/api/routes/projects.py
+++ b/apps/backend/app/api/routes/projects.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -53,8 +53,11 @@ def create_project(payload: ProjectImportRequest, session: Session = Depends(get
 
 
 @router.get("", response_model=ProjectsResponse)
-def projects(session: Session = Depends(get_db)) -> ProjectsResponse:
-    projects_payload = [ProjectSchema.model_validate(project) for project in list_projects(session)]
+def projects(
+    search: str | None = Query(default=None, description="Filter projects by display name or path."),
+    session: Session = Depends(get_db),
+) -> ProjectsResponse:
+    projects_payload = [ProjectSchema.model_validate(project) for project in list_projects(session, search=search)]
     return ProjectsResponse(projects=projects_payload)
 
 

--- a/apps/backend/app/services/projects.py
+++ b/apps/backend/app/services/projects.py
@@ -4,7 +4,7 @@ import shutil
 from pathlib import Path
 
 from fastapi import status
-from sqlalchemy import select
+from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
 from app.config import get_settings
@@ -29,8 +29,20 @@ def _validate_import_path(source_path: Path) -> None:
         )
 
 
-def list_projects(session: Session) -> list[Project]:
-    stmt = select(Project).order_by(Project.updated_at.desc())
+def list_projects(session: Session, *, search: str | None = None) -> list[Project]:
+    stmt = select(Project)
+    normalized_search = (search or "").strip().lower()
+    if normalized_search:
+        like_term = f"%{normalized_search}%"
+        stmt = stmt.where(
+            or_(
+                func.lower(Project.display_name).like(like_term),
+                func.lower(Project.source_path).like(like_term),
+                func.lower(Project.imported_path).like(like_term),
+            )
+        )
+
+    stmt = stmt.order_by(Project.updated_at.desc())
     return list(session.scalars(stmt))
 
 

--- a/apps/backend/tests/test_projects.py
+++ b/apps/backend/tests/test_projects.py
@@ -44,6 +44,35 @@ def test_project_can_be_renamed(client, sample_audio_file: Path):
     assert response.json()["project"]["display_name"] == "Practice Version"
 
 
+def test_project_list_can_filter_by_search_term(client, sample_audio_file: Path, tmp_path: Path):
+    second_source = tmp_path / "bass-riff.wav"
+    second_source.write_bytes(sample_audio_file.read_bytes())
+
+    client.post(
+        "/api/v1/projects/import",
+        json={
+            "source_path": str(sample_audio_file),
+            "copy_into_project": True,
+            "display_name": "Choir Warmup",
+        },
+    )
+    client.post(
+        "/api/v1/projects/import",
+        json={
+            "source_path": str(second_source),
+            "copy_into_project": True,
+            "display_name": "Bass Drill",
+        },
+    )
+
+    response = client.get("/api/v1/projects", params={"search": "choir"})
+
+    assert response.status_code == 200
+    projects = response.json()["projects"]
+    assert len(projects) == 1
+    assert projects[0]["display_name"] == "Choir Warmup"
+
+
 def test_retune_request_rejects_invalid_payload(client, sample_audio_file: Path):
     project = client.post(
         "/api/v1/projects/import",

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -7,6 +7,8 @@ import App from "./App";
 
 const {
   resetMockApiState,
+  setProjects,
+  setProjectAnalysis,
   mockOpen,
   mockSave,
   mockConfirm,
@@ -25,9 +27,7 @@ const {
   mockCreateExport,
   mockDeleteArtifact,
   mockDeleteProject,
-  mockCancelJob,
   mockGetHealth,
-  setChordTimeline,
 } = vi.hoisted(() => {
   const createdAt = "2026-04-18T13:16:00.000Z";
   let state: {
@@ -88,12 +88,12 @@ const {
     };
   }
 
-  function setChordTimeline(projectId: string, timeline: Record<string, unknown> | null) {
-    if (timeline === null) {
-      delete state.chordsByProject[projectId];
-      return;
-    }
-    state.chordsByProject[projectId] = clone(timeline);
+  function setProjects(projects: Array<Record<string, unknown>>) {
+    state.projects = clone(projects);
+  }
+
+  function setProjectAnalysis(projectId: string, analysis: Record<string, unknown> | null) {
+    state.analysisByProject[projectId] = analysis ? clone(analysis) : null;
   }
 
   function resetMockApiState() {
@@ -126,7 +126,6 @@ const {
             metadata: {
               retune: {},
               transpose: { semitones: 2 },
-              total_cents: 200,
             },
             created_at: createdAt,
           },
@@ -189,23 +188,29 @@ const {
     default_export_format: "wav",
     preview_format: "wav",
   }));
-  const mockListProjects = vi.fn(async () => ({ projects: clone(state.projects) }));
+  const mockListProjects = vi.fn(async (search?: string) => {
+    const normalizedSearch = search?.trim().toLowerCase();
+    const filteredProjects = normalizedSearch
+      ? state.projects.filter((project) => {
+          const displayName = String(project.display_name ?? "").toLowerCase();
+          const sourcePath = String(project.source_path ?? "").toLowerCase();
+          const importedPath = String(project.imported_path ?? "").toLowerCase();
+          return (
+            displayName.includes(normalizedSearch) ||
+            sourcePath.includes(normalizedSearch) ||
+            importedPath.includes(normalizedSearch)
+          );
+        })
+      : state.projects;
+    return { projects: clone(filteredProjects) };
+  });
   const mockImportProject = vi.fn(async ({ source_path }: { source_path: string }) => {
     const id = `proj_${state.nextProjectId++}`;
     const baseName = source_path.split("/").pop() ?? "Imported Track";
     const displayName = titleize(baseName);
     const project = makeProject(id, displayName, source_path);
     state.projects.unshift(project);
-    state.analysisByProject[id] = {
-      project_id: id,
-      estimated_key: "D major",
-      key_confidence: 0.74,
-      estimated_reference_hz: 440,
-      tuning_offset_cents: 0,
-      tempo_bpm: null,
-      analysis_version: "v1",
-      created_at: createdAt,
-    };
+    state.analysisByProject[id] = null;
     state.artifactsByProject[id] = [
       {
         id: `art_${state.nextArtifactId++}`,
@@ -292,8 +297,6 @@ const {
       metadata: {
         mode: "two_stem",
         engine: "demucs",
-        model: "htdemucs_ft",
-        device: "cpu",
         source_artifact_id: sourceArtifactId,
       },
       created_at: createdAt,
@@ -307,8 +310,6 @@ const {
       metadata: {
         mode: "two_stem",
         engine: "demucs",
-        model: "htdemucs_ft",
-        device: "cpu",
         source_artifact_id: sourceArtifactId,
       },
       created_at: createdAt,
@@ -332,6 +333,16 @@ const {
     return { job: clone(job) };
   });
   const mockAnalyzeProject = vi.fn(async (projectId: string) => {
+    state.analysisByProject[projectId] = {
+      project_id: projectId,
+      estimated_key: "D major",
+      key_confidence: 0.74,
+      estimated_reference_hz: 440,
+      tuning_offset_cents: 0,
+      tempo_bpm: null,
+      analysis_version: "v1",
+      created_at: createdAt,
+    };
     const job = {
       id: `job_${state.nextJobId++}`,
       project_id: projectId,
@@ -385,17 +396,11 @@ const {
     state.jobs = state.jobs.filter((job) => job.project_id !== projectId);
     return { deleted: true };
   });
-  const mockCancelJob = vi.fn(async (jobId: string) => {
-    const job = state.jobs.find((item) => item.id === jobId);
-    if (job) {
-      job.status = "cancelled";
-      job.updated_at = createdAt;
-    }
-    return { job: clone(job ?? { id: jobId, status: "cancelled" }) };
-  });
 
   return {
     resetMockApiState,
+    setProjects,
+    setProjectAnalysis,
     mockOpen,
     mockSave,
     mockConfirm,
@@ -414,9 +419,7 @@ const {
     mockCreateExport,
     mockDeleteArtifact,
     mockDeleteProject,
-    mockCancelJob,
     mockGetHealth,
-    setChordTimeline,
   };
 });
 
@@ -448,7 +451,6 @@ vi.mock("./lib/api", async (importOriginal) => {
       createExport: mockCreateExport,
       deleteArtifact: mockDeleteArtifact,
       deleteProject: mockDeleteProject,
-      cancelJob: mockCancelJob,
     },
   };
 });
@@ -468,7 +470,38 @@ function renderApp(initialEntries: string[]) {
   );
 }
 
-describe("App flows", () => {
+function installMatchMediaMock(initialMatches = false) {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  let matches = initialMatches;
+
+  vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
+    get matches() {
+      return matches;
+    },
+    media: query,
+    onchange: null,
+    addEventListener: (_eventName: string, listener: EventListenerOrEventListenerObject) => {
+      listeners.add(listener as (event: MediaQueryListEvent) => void);
+    },
+    removeEventListener: (_eventName: string, listener: EventListenerOrEventListenerObject) => {
+      listeners.delete(listener as (event: MediaQueryListEvent) => void);
+    },
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+
+  return {
+    setMatches(nextMatches: boolean) {
+      matches = nextMatches;
+      listeners.forEach((listener) =>
+        listener({ matches: nextMatches } as MediaQueryListEvent),
+      );
+    },
+  };
+}
+
+describe("Desktop app flows", () => {
   beforeEach(() => {
     resetMockApiState();
     window.localStorage.clear();
@@ -493,8 +526,45 @@ describe("App flows", () => {
     mockCreateExport.mockClear();
     mockDeleteArtifact.mockClear();
     mockDeleteProject.mockClear();
-    mockCancelJob.mockClear();
     mockGetHealth.mockClear();
+    installMatchMediaMock(false);
+  });
+
+  it("filters library results with project search", async () => {
+    const user = userEvent.setup();
+    setProjects([
+      {
+        id: "proj_1",
+        display_name: "Choir Warmup",
+        source_path: "/tmp/choir-warmup.wav",
+        imported_path: "/tmp/projects/choir-warmup.wav",
+        duration_seconds: 95,
+        sample_rate: 44100,
+        channels: 2,
+        created_at: "2026-04-18T13:16:00.000Z",
+        updated_at: "2026-04-18T13:16:00.000Z",
+      },
+      {
+        id: "proj_2",
+        display_name: "Bass Drill",
+        source_path: "/tmp/bass-drill.wav",
+        imported_path: "/tmp/projects/bass-drill.wav",
+        duration_seconds: 120,
+        sample_rate: 48000,
+        channels: 2,
+        created_at: "2026-04-18T13:16:00.000Z",
+        updated_at: "2026-04-18T13:16:00.000Z",
+      },
+    ]);
+
+    renderApp(["/"]);
+
+    expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
+    await user.type(screen.getByLabelText("Search projects"), "choir");
+
+    await waitFor(() => expect(mockListProjects).toHaveBeenLastCalledWith("choir"));
+    expect(screen.getByText("Choir Warmup")).toBeInTheDocument();
+    expect(screen.queryByText("Bass Drill")).not.toBeInTheDocument();
   });
 
   it("imports track from library and opens project", async () => {
@@ -503,62 +573,42 @@ describe("App flows", () => {
 
     renderApp(["/"]);
 
-    expect(await screen.findByText("Practice Projects")).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Import Track" }));
 
     expect(mockImportProject).toHaveBeenCalledWith({
       source_path: "/tmp/new-song.mp4",
       copy_into_project: true,
     });
-    expect(await screen.findByRole("heading", { name: "New Song" })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mockGetProject).toHaveBeenCalledWith(expect.stringMatching(/^proj_/)),
+    );
+    expect(await screen.findByRole("button", { name: "Analyze Track" })).toBeInTheDocument();
   });
 
-  it("keeps selected mix in sync with summary and creates new mix from controls", async () => {
+  it("analyzes track from inspector", async () => {
+    const user = userEvent.setup();
+    setProjectAnalysis("proj_123", null);
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Analyze Track" }));
+
+    expect(mockAnalyzeProject).toHaveBeenCalledWith("proj_123");
+  });
+
+  it("creates a new mix from source-key controls", async () => {
     const user = userEvent.setup();
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
-    expect(await screen.findByText("Saved Mixes")).toBeInTheDocument();
-    const selectedMixSummary = screen.getByRole("group", { name: "Selected mix summary" });
-    const mixStatusSummary = screen.getByRole("group", { name: "Mix status summary" });
-    const savedMixList = await screen.findByRole("group", { name: "Saved mix list" });
-
-    expect(within(selectedMixSummary).getByText("Practice Mix")).toBeInTheDocument();
-    expect(within(selectedMixSummary).getByText("Shift +2 semitones")).toBeInTheDocument();
-    expect(within(mixStatusSummary).getByText("Using source settings")).toBeInTheDocument();
-    expect(within(mixStatusSummary).getByText("Selected mix differs from current source controls.")).toBeInTheDocument();
-
-    const targetKey = screen.getByLabelText("Target Key") as HTMLSelectElement;
-    expect(Array.from(targetKey.options).map((option) => option.text)).toEqual([
-      "C",
-      "C#/Db",
-      "D",
-      "D#/Eb",
-      "E",
-      "F",
-      "F#/Gb",
-      "G",
-      "G#/Ab",
-      "A",
-      "A#/Bb",
-      "B",
-    ]);
-
-    await user.click(within(savedMixList).getByRole("button", { name: /Source Track/i }));
-    expect(within(selectedMixSummary).getByText("Source Track")).toBeInTheDocument();
-    expect(within(selectedMixSummary).getByText("Original source file")).toBeInTheDocument();
-    expect(within(mixStatusSummary).getByText("Selected mix matches current controls.")).toBeInTheDocument();
-
-    await user.click(within(savedMixList).getByRole("button", { name: /Practice Mix/i }));
-    expect(within(selectedMixSummary).getByText("Practice Mix")).toBeInTheDocument();
-    expect(within(selectedMixSummary).getByText("Shift +2 semitones")).toBeInTheDocument();
-
-    const currentKey = screen.getByLabelText("Current Key");
-    const createMixButton = screen.getByRole("button", { name: "Create Mix" });
+    const sourceList = screen.getByRole("group", { name: "Source and mix list" });
+    await user.click(within(sourceList).getByRole("button", { name: /Source Track/i }));
     await user.click(screen.getByText("Correct source key if detection is wrong"));
-    await user.selectOptions(currentKey, "9:major");
+    await user.selectOptions(screen.getByLabelText("Current Key"), "9:major");
     await user.click(screen.getByLabelText("Raise target key"));
-    await user.click(createMixButton);
+    await user.click(screen.getByRole("button", { name: "Create Mix" }));
 
     expect(mockCreatePreview).toHaveBeenCalledWith(
       "proj_123",
@@ -569,59 +619,7 @@ describe("App flows", () => {
     );
   });
 
-  it("transposes chord display for the selected mix and source track", async () => {
-    const user = userEvent.setup();
-    renderApp(["/projects/proj_123"]);
-
-    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
-    expect(await screen.findByRole("group", { name: "Chord timeline" })).toBeInTheDocument();
-    const currentChordCard = screen.getByRole("group", { name: "Current chord card" });
-    const nextChordCard = screen.getByRole("group", { name: "Next chord card" });
-    expect(within(currentChordCard).getByText("A")).toBeInTheDocument();
-    expect(within(nextChordCard).getByText("E")).toBeInTheDocument();
-
-    const savedMixList = await screen.findByRole("group", { name: "Saved mix list" });
-    await user.click(within(savedMixList).getByRole("button", { name: /Source Track/i }));
-
-    expect(within(currentChordCard).getByText("G")).toBeInTheDocument();
-    expect(within(nextChordCard).getByText("D")).toBeInTheDocument();
-  });
-
-  it("recenters the chord lane when a later chord becomes active", async () => {
-    const user = userEvent.setup();
-    const scrollIntoViewMock = vi.mocked(window.HTMLElement.prototype.scrollIntoView);
-    scrollIntoViewMock.mockClear();
-    renderApp(["/projects/proj_123"]);
-
-    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
-    const chordTimeline = screen.getByRole("group", { name: "Chord timeline" });
-    const chordButtons = within(chordTimeline).getAllByRole("button");
-    await user.click(chordButtons[chordButtons.length - 1]);
-
-    await waitFor(() => {
-      const currentChordCard = screen.getByRole("group", { name: "Current chord card" });
-      const nextChordCard = screen.getByRole("group", { name: "Next chord card" });
-      expect(within(currentChordCard).getByText("D")).toBeInTheDocument();
-      expect(within(nextChordCard).getByText("—")).toBeInTheDocument();
-    });
-    expect(scrollIntoViewMock).toHaveBeenCalled();
-  });
-
-  it("queues chord detection when the project has no saved chord timeline", async () => {
-    const user = userEvent.setup();
-    setChordTimeline("proj_123", null);
-
-    renderApp(["/projects/proj_123"]);
-
-    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
-    expect(screen.getByText("Generate a chord timeline to jump around the song while you practice.")).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Generate Chords" }));
-
-    expect(mockCreateChords).toHaveBeenCalledWith("proj_123", { backend: "default", force: false });
-  });
-
-  it("generates stems and lets the app select them", async () => {
+  it("switches between source playback and stems", async () => {
     const user = userEvent.setup();
     renderApp(["/projects/proj_123"]);
 
@@ -641,14 +639,17 @@ describe("App flows", () => {
     const stemList = await screen.findByRole("group", { name: "Stem track list" });
     await user.click(within(stemList).getByRole("button", { name: /Vocals/i }));
 
-    const selectedSummary = screen.getByRole("group", { name: "Selected mix summary" });
-    const statusSummary = screen.getByRole("group", { name: "Mix status summary" });
-    expect(within(selectedSummary).getByText("Vocals")).toBeInTheDocument();
-    expect(within(selectedSummary).getByText(/Vocal stem/)).toBeInTheDocument();
-    expect(within(statusSummary).getByText("Stem tracks are independent from mix controls.")).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Vocals" })).toBeInTheDocument();
+    expect(screen.getAllByText("Stem monitor").length).toBeGreaterThan(0);
+
+    const sourceList = screen.getByRole("group", { name: "Source and mix list" });
+    await user.click(within(sourceList).getByRole("button", { name: /Source Track/i }));
+
+    expect(await screen.findByRole("heading", { name: "Source Track" })).toBeInTheDocument();
+    expect(screen.getByText("Full playback")).toBeInTheDocument();
   });
 
-  it("keeps stem lists scoped to selected audio", async () => {
+  it("supports mute and solo controls in stem monitor", async () => {
     const user = userEvent.setup();
     renderApp(["/projects/proj_123"]);
 
@@ -656,33 +657,41 @@ describe("App flows", () => {
     await user.click(screen.getByRole("button", { name: "Generate Stems" }));
 
     const stemList = await screen.findByRole("group", { name: "Stem track list" });
-    expect(within(stemList).getAllByRole("button")).toHaveLength(2);
+    await user.click(within(stemList).getByRole("button", { name: /Vocals/i }));
 
-    const savedMixList = await screen.findByRole("group", { name: "Saved mix list" });
-    await user.click(within(savedMixList).getByRole("button", { name: /Source Track/i }));
+    const soloVocals = screen.getByRole("button", { name: "Solo Vocals" });
+    const muteInstrumental = screen.getByRole("button", { name: "Mute Instrumental" });
+    await user.click(soloVocals);
+    await user.click(muteInstrumental);
 
-    expect(screen.getByText("No stems yet for selected audio.")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Generate Stems" })).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
-    expect(mockCreateStems).toHaveBeenLastCalledWith(
-      "proj_123",
-      expect.objectContaining({
-        mode: "two_stem",
-        output_format: "wav",
-        force: false,
-        source_artifact_id: "art_source",
-      }),
-    );
-
-    const sourceStemList = await screen.findByRole("group", { name: "Stem track list" });
-    expect(within(sourceStemList).getAllByRole("button")).toHaveLength(2);
-
-    await user.click(within(savedMixList).getByRole("button", { name: /Practice Mix/i }));
-    expect(screen.getByRole("button", { name: "Refresh Stems" })).toBeInTheDocument();
+    expect(soloVocals).toHaveAttribute("aria-pressed", "true");
+    expect(muteInstrumental).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByText("1 / 2")).toBeInTheDocument();
   });
 
-  it("renames project from project screen", async () => {
+  it("exports selected audio", async () => {
+    const user = userEvent.setup();
+    mockSave.mockResolvedValue("/tmp/exports/demo-source.flac");
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const sourceList = screen.getByRole("group", { name: "Source and mix list" });
+    await user.click(within(sourceList).getByRole("button", { name: /Source Track/i }));
+    await user.click(screen.getByRole("button", { name: "Export Selected Audio" }));
+
+    expect(mockSave).toHaveBeenCalled();
+    expect(mockCreateExport).toHaveBeenCalledWith(
+      "proj_123",
+      expect.objectContaining({
+        artifact_ids: ["art_source"],
+        output_format: "flac",
+        destination_path: "/tmp/exports",
+      }),
+    );
+  });
+
+  it("renames project from the title row", async () => {
     const user = userEvent.setup();
     renderApp(["/projects/proj_123"]);
 
@@ -697,66 +706,6 @@ describe("App flows", () => {
     expect(await screen.findByRole("heading", { name: "Practice Set" })).toBeInTheDocument();
   });
 
-  it("exports selected mix and uses selected artifact id", async () => {
-    const user = userEvent.setup();
-    mockSave.mockResolvedValue("/tmp/exports/demo-source.flac");
-
-    renderApp(["/projects/proj_123"]);
-
-    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
-    expect(await screen.findByText("Saved Mixes")).toBeInTheDocument();
-    const savedMixList = await screen.findByRole("group", { name: "Saved mix list" });
-    await user.click(within(savedMixList).getByRole("button", { name: /Source Track/i }));
-    await user.click(screen.getByRole("button", { name: "Export Selected Audio" }));
-
-    expect(mockSave).toHaveBeenCalled();
-    expect(mockCreateExport).toHaveBeenCalledWith(
-      "proj_123",
-      expect.objectContaining({
-        artifact_ids: ["art_source"],
-        output_format: "flac",
-        destination_path: "/tmp/exports",
-      }),
-    );
-  });
-
-  it("toggles inspector visibility without affecting playback selection", async () => {
-    const user = userEvent.setup();
-    renderApp(["/projects/proj_123"]);
-
-    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
-    expect(screen.getByText("Mix Builder")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Hide Inspector" })).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Hide Inspector" }));
-
-    expect(screen.queryByText("Mix Builder")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Show Inspector" })).toBeInTheDocument();
-    expect(screen.getByRole("group", { name: "Selected mix summary" })).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Show Inspector" }));
-
-    expect(screen.getByText("Mix Builder")).toBeInTheDocument();
-  });
-
-  it("requires confirmation before deleting a project", async () => {
-    const user = userEvent.setup();
-    mockConfirm.mockResolvedValue(false);
-    renderApp(["/projects/proj_123"]);
-
-    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Delete Project" }));
-
-    expect(mockConfirm).toHaveBeenCalledWith("Delete this project and all of its mixes, stems, and exports?", {
-      title: "Delete project",
-      kind: "warning",
-      okLabel: "Delete",
-      cancelLabel: "Cancel",
-    });
-    expect(mockDeleteProject).not.toHaveBeenCalled();
-    expect(screen.getByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
-  });
-
   it("deletes project after confirmation and returns to library", async () => {
     const user = userEvent.setup();
     renderApp(["/projects/proj_123"]);
@@ -765,63 +714,52 @@ describe("App flows", () => {
     await user.click(screen.getByRole("button", { name: "Delete Project" }));
 
     expect(mockDeleteProject).toHaveBeenCalledWith("proj_123");
-    expect(await screen.findByText("Practice Projects")).toBeInTheDocument();
-    expect(await screen.findByText("No projects yet")).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "No projects yet" })).toBeInTheDocument();
   });
 
-  it("deletes a practice mix with confirmation and removes its stems", async () => {
-    const user = userEvent.setup();
-    renderApp(["/projects/proj_123"]);
-
-    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
-
-    const savedMixList = await screen.findByRole("group", { name: "Saved mix list" });
-    expect(within(savedMixList).getByRole("button", { name: /Practice Mix/i })).toBeInTheDocument();
-    expect(await screen.findByRole("button", { name: "Delete Practice Mix" })).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Delete Practice Mix" }));
-
-    expect(mockConfirm).toHaveBeenCalledWith("Delete this practice mix and its stem tracks?", {
-      title: "Delete practice mix",
-      kind: "warning",
-      okLabel: "Delete",
-      cancelLabel: "Cancel",
-    });
-    expect(mockDeleteArtifact).toHaveBeenCalledWith("proj_123", "art_preview");
-    const selectedSummary = screen.getByRole("group", { name: "Selected mix summary" });
-    expect(await within(selectedSummary).findByText("Source Track")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Delete Practice Mix" })).not.toBeInTheDocument();
-    expect(screen.getByText("No stems yet for selected audio.")).toBeInTheDocument();
-  });
-
-  it("does not offer mix deletion for the source track", async () => {
-    const user = userEvent.setup();
-    renderApp(["/projects/proj_123"]);
-
-    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
-    const savedMixList = await screen.findByRole("group", { name: "Saved mix list" });
-    await user.click(within(savedMixList).getByRole("button", { name: /Source Track/i }));
-
-    expect(screen.queryByRole("button", { name: "Delete Practice Mix" })).not.toBeInTheDocument();
-  });
-
-  it("renders settings and persists theme changes", async () => {
+  it("persists theme and UI visibility preferences", async () => {
     const user = userEvent.setup();
     renderApp(["/settings"]);
 
-    expect(await screen.findByText("Backend and Storage")).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Playback Surface" })).toBeInTheDocument();
     expect(await screen.findByText("/tmp/tuneforge")).toBeInTheDocument();
 
-    const themeSelect = screen.getByLabelText("Theme");
-    expect(themeSelect).toHaveValue("dark");
-    expect(document.documentElement).toHaveAttribute("data-theme", "dark");
-    expect(window.localStorage.getItem("tuneforge.theme-preference")).toBe("dark");
+    await user.selectOptions(screen.getByLabelText("Theme"), "light");
+    await user.selectOptions(screen.getByLabelText("Information Density"), "detailed");
+    await user.selectOptions(screen.getByLabelText("Layout Density"), "compact");
+    await user.click(screen.getByLabelText("Show helper text"));
+    await user.click(screen.getByLabelText("Open inspector by default"));
+    await user.selectOptions(screen.getByLabelText("Metadata Reveal"), "hover");
 
-    await user.selectOptions(themeSelect, "light");
-
-    expect(themeSelect).toHaveValue("light");
     expect(document.documentElement).toHaveAttribute("data-theme", "light");
     expect(window.localStorage.getItem("tuneforge.theme-preference")).toBe("light");
+    expect(JSON.parse(window.localStorage.getItem("tuneforge.ui-preferences") ?? "{}")).toMatchObject({
+      informationDensity: "detailed",
+      layoutDensity: "compact",
+      helperTextVisible: false,
+      defaultInspectorOpen: false,
+      metadataRevealMode: "hover",
+    });
+  });
+
+  it("follows system theme when preference is set to system", async () => {
+    const user = userEvent.setup();
+    const mediaController = installMatchMediaMock(false);
+
+    renderApp(["/settings"]);
+
+    expect(await screen.findByRole("heading", { name: "Playback Surface" })).toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText("Theme"), "system");
+
+    expect(document.documentElement).toHaveAttribute("data-theme", "light");
+    await act(async () => {
+      mediaController.setMatches(true);
+    });
+
+    await waitFor(() =>
+      expect(document.documentElement).toHaveAttribute("data-theme", "dark"),
+    );
+    expect(window.localStorage.getItem("tuneforge.theme-preference")).toBe("system");
   });
 });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2,32 +2,43 @@ import { NavLink, Route, Routes } from "react-router-dom";
 import { LibraryView } from "./features/projects/LibraryView";
 import { ProjectView } from "./features/projects/ProjectView";
 import { SettingsView } from "./features/settings/SettingsView";
+import { PreferencesProvider, usePreferences } from "./lib/preferences";
 import { ThemeProvider } from "./lib/theme";
+
+function AppChrome() {
+  const { informationDensity, layoutDensity } = usePreferences();
+
+  return (
+    <div className="app-shell" data-information-density={informationDensity} data-layout-density={layoutDensity}>
+      <aside className="sidebar">
+        <div className="brand">
+          <span className="brand__eyebrow">Tuneforge</span>
+          <strong>Local Practice Rig</strong>
+        </div>
+        <nav className="nav">
+          <NavLink to="/" end>
+            Library
+          </NavLink>
+          <NavLink to="/settings">Settings</NavLink>
+        </nav>
+      </aside>
+      <main className="main-content">
+        <Routes>
+          <Route path="/" element={<LibraryView />} />
+          <Route path="/projects/:projectId" element={<ProjectView />} />
+          <Route path="/settings" element={<SettingsView />} />
+        </Routes>
+      </main>
+    </div>
+  );
+}
 
 export default function App() {
   return (
     <ThemeProvider>
-      <div className="app-shell">
-        <aside className="sidebar">
-          <div className="brand">
-            <span className="brand__eyebrow">Tuneforge</span>
-            <strong>Local Practice Rig</strong>
-          </div>
-          <nav className="nav">
-            <NavLink to="/" end>
-              Library
-            </NavLink>
-            <NavLink to="/settings">Settings</NavLink>
-          </nav>
-        </aside>
-        <main className="main-content">
-          <Routes>
-            <Route path="/" element={<LibraryView />} />
-            <Route path="/projects/:projectId" element={<ProjectView />} />
-            <Route path="/settings" element={<SettingsView />} />
-          </Routes>
-        </main>
-      </div>
+      <PreferencesProvider>
+        <AppChrome />
+      </PreferencesProvider>
     </ThemeProvider>
   );
 }

--- a/apps/desktop/src/features/projects/LibraryView.tsx
+++ b/apps/desktop/src/features/projects/LibraryView.tsx
@@ -1,10 +1,12 @@
+import { startTransition, useDeferredValue, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { open } from "@tauri-apps/plugin-dialog";
 import { Link, useNavigate } from "react-router-dom";
 import { api, type ProjectSchema } from "../../lib/api";
+import { usePreferences } from "../../lib/preferences";
 
 function formatDuration(durationSeconds: number | null | undefined) {
-  if (!durationSeconds) return "Unknown";
+  if (!durationSeconds) return "Unknown length";
   const minutes = Math.floor(durationSeconds / 60);
   const seconds = Math.round(durationSeconds % 60)
     .toString()
@@ -12,26 +14,86 @@ function formatDuration(durationSeconds: number | null | undefined) {
   return `${minutes}:${seconds}`;
 }
 
+function formatUpdatedAt(value: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+  }).format(new Date(value));
+}
+
+function fileNameFromPath(path: string) {
+  return path.split(/[/\\]/).pop() ?? path;
+}
+
 function ProjectCard({ project }: { project: ProjectSchema }) {
+  const { informationDensity, metadataRevealMode } = usePreferences();
+  const sourceFileName = fileNameFromPath(project.source_path);
+
   return (
-    <Link className="project-card" to={`/projects/${project.id}`}>
-      <div className="project-card__header">
-        <h3>{project.display_name}</h3>
-        <span>{formatDuration(project.duration_seconds)}</span>
+    <article className="project-card">
+      <div className="project-card__meta-row">
+        <span className="pill">Updated {formatUpdatedAt(project.updated_at)}</span>
+        <span className="pill">{formatDuration(project.duration_seconds)}</span>
       </div>
-      <p>{project.sample_rate ? `${project.sample_rate} Hz` : "Sample rate unknown"}</p>
-      <p>{project.channels ? `${project.channels} channels` : "Channels unknown"}</p>
-      <small>{project.source_path}</small>
-    </Link>
+
+      <Link className="project-card__link" to={`/projects/${project.id}`}>
+        <div className="project-card__title-block">
+          <h2>{project.display_name}</h2>
+          <p className="project-card__summary">{sourceFileName}</p>
+        </div>
+        <span className="project-card__open">Open project</span>
+      </Link>
+
+      <div className="project-card__stats" role="list" aria-label={`${project.display_name} summary`}>
+        <span className="stat-chip" role="listitem">
+          {project.source_path.split(".").pop()?.toUpperCase() ?? "Audio"}
+        </span>
+        {informationDensity !== "minimal" ? (
+          <span className="stat-chip" role="listitem">
+            {project.channels ? `${project.channels} ch` : "Channels n/a"}
+          </span>
+        ) : null}
+        {informationDensity === "detailed" ? (
+          <span className="stat-chip" role="listitem">
+            {project.sample_rate ? `${project.sample_rate} Hz` : "Sample rate n/a"}
+          </span>
+        ) : null}
+      </div>
+
+      {metadataRevealMode === "expand" ? (
+        <details className="card-details">
+          <summary>Show file details</summary>
+          <dl className="details-grid details-grid--single-column">
+            <div>
+              <dt>Original Source</dt>
+              <dd className="path">{project.source_path}</dd>
+            </div>
+            <div>
+              <dt>Imported Audio</dt>
+              <dd className="path">{project.imported_path}</dd>
+            </div>
+          </dl>
+        </details>
+      ) : (
+        <p className="artifact-meta" title={project.source_path}>
+          Hover for source path
+        </p>
+      )}
+    </article>
   );
 }
 
 export function LibraryView() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { helperTextVisible, informationDensity } = usePreferences();
+  const [searchDraft, setSearchDraft] = useState("");
+  const deferredSearch = useDeferredValue(searchDraft.trim());
+  const showSubtitle = helperTextVisible && informationDensity !== "minimal";
+
   const projectsQuery = useQuery({
-    queryKey: ["projects"],
-    queryFn: async () => (await api.listProjects()).projects,
+    queryKey: ["projects", deferredSearch],
+    queryFn: async () => (await api.listProjects(deferredSearch || undefined)).projects,
   });
 
   const importMutation = useMutation({
@@ -62,26 +124,64 @@ export function LibraryView() {
     },
   });
 
+  const resultCount = projectsQuery.data?.length ?? 0;
+
   return (
     <section className="screen">
-      <div className="screen__header">
-        <div>
+      <div className="screen__header screen__header--library">
+        <div className="screen__title-block">
           <p className="eyebrow">Library</p>
           <h1>Practice Projects</h1>
-          <p className="screen__subtitle">
-            Import a local song, save alternate mixes, and keep practice versions ready to play.
-          </p>
+          {showSubtitle ? (
+            <p className="screen__subtitle">
+              Keep songs, saved mixes, and stem-ready practice sessions close to playback.
+            </p>
+          ) : null}
         </div>
         <button
           className="button button--primary"
           onClick={() => importMutation.mutate()}
           disabled={importMutation.isPending}
         >
-          {importMutation.isPending ? "Importing…" : "Import Track"}
+          {importMutation.isPending ? "Importing..." : "Import Track"}
         </button>
       </div>
 
-      {projectsQuery.isLoading ? <div className="panel">Loading projects…</div> : null}
+      <div className="panel library-toolbar">
+        <label className="search-field">
+          <span className="search-field__label">Search library</span>
+          <input
+            aria-label="Search projects"
+            className="search-field__input"
+            placeholder="Search by name or file path"
+            type="search"
+            value={searchDraft}
+            onChange={(event) => {
+              const nextValue = event.target.value;
+              startTransition(() => {
+                setSearchDraft(nextValue);
+              });
+            }}
+          />
+        </label>
+        <div className="library-toolbar__summary" aria-live="polite">
+          {deferredSearch ? (
+            resultCount ? (
+              <span>
+                {resultCount} match{resultCount === 1 ? "" : "es"} for "{deferredSearch}"
+              </span>
+            ) : (
+              <span>No matches for "{deferredSearch}"</span>
+            )
+          ) : (
+            <span>
+              {resultCount} project{resultCount === 1 ? "" : "s"} ready
+            </span>
+          )}
+        </div>
+      </div>
+
+      {projectsQuery.isLoading ? <div className="panel">Loading projects...</div> : null}
       {projectsQuery.isError ? (
         <div className="panel panel--error">Could not load projects.</div>
       ) : null}
@@ -91,8 +191,12 @@ export function LibraryView() {
           projectsQuery.data.map((project) => <ProjectCard key={project.id} project={project} />)
         ) : (
           <div className="panel panel--empty">
-            <h2>No projects yet</h2>
-            <p>Use the import action to create the first project.</p>
+            <h2>{deferredSearch ? "No matching projects" : "No projects yet"}</h2>
+            <p>
+              {deferredSearch
+                ? "Try a different name or clear the search."
+                : "Import a track to create the first playback-ready project."}
+            </p>
           </div>
         )}
       </div>

--- a/apps/desktop/src/features/projects/ProjectView.tsx
+++ b/apps/desktop/src/features/projects/ProjectView.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { confirm, save } from "@tauri-apps/plugin-dialog";
 import { api, type ArtifactSchema, type ChordSegmentSchema, type JobSchema } from "../../lib/api";
+import { usePreferences } from "../../lib/preferences";
 import {
   DEFAULT_KEY,
   MUSICAL_KEYS,
@@ -17,11 +18,18 @@ import {
   type MusicalKey,
 } from "../../lib/music";
 
+type StemControlState = {
+  muted: boolean;
+  solo: boolean;
+};
+
 function useActiveJobPolling(projectId: string, jobs: JobSchema[] | undefined) {
   const queryClient = useQueryClient();
 
   useEffect(() => {
-    const active = jobs?.some((job) => job.project_id === projectId && ["pending", "running"].includes(job.status));
+    const active = jobs?.some(
+      (job) => job.project_id === projectId && ["pending", "running"].includes(job.status),
+    );
     if (!active) return;
 
     const interval = window.setInterval(async () => {
@@ -50,11 +58,15 @@ function artifactLabel(artifact: ArtifactSchema) {
 }
 
 function isPlayableArtifact(artifact: ArtifactSchema) {
-  return ["source_audio", "preview_mix", "export_mix", "vocal_stem", "instrumental_stem"].includes(artifact.type);
+  return ["source_audio", "preview_mix", "vocal_stem", "instrumental_stem"].includes(artifact.type);
 }
 
 function preferredArtifactSelection(artifacts: ArtifactSchema[]) {
   return artifacts.find((artifact) => artifact.type === "preview_mix") ?? artifacts[0] ?? null;
+}
+
+function fileNameFromPath(path: string) {
+  return path.split(/[/\\]/).pop() ?? path;
 }
 
 function formatSemitoneShift(semitones: number) {
@@ -93,7 +105,13 @@ function artifactSummary(artifact: ArtifactSchema) {
   if (artifact.type === "vocal_stem" || artifact.type === "instrumental_stem") {
     const engine = typeof artifact.metadata?.engine === "string" ? artifact.metadata.engine : null;
     const mode = typeof artifact.metadata?.mode === "string" ? artifact.metadata.mode : null;
-    return [artifact.type === "vocal_stem" ? "Vocal stem" : "Instrumental stem", mode, engine].filter(Boolean).join(" · ");
+    return [
+      artifact.type === "vocal_stem" ? "Vocal stem" : "Instrumental stem",
+      mode,
+      engine,
+    ]
+      .filter(Boolean)
+      .join(" / ");
   }
 
   const metadata = artifact.metadata ?? {};
@@ -105,8 +123,7 @@ function artifactSummary(artifact: ArtifactSchema) {
     "semitones" in transpose &&
     typeof transpose.semitones === "number"
   ) {
-    const semitones = transpose.semitones;
-    pieces.push(formatSemitoneShift(semitones));
+    pieces.push(formatSemitoneShift(transpose.semitones));
   }
 
   const retune = metadata.retune;
@@ -119,7 +136,7 @@ function artifactSummary(artifact: ArtifactSchema) {
     }
   }
 
-  return pieces.join(" · ");
+  return pieces.join(" / ");
 }
 
 function sourceArtifactIdForStems(artifact: ArtifactSchema | null) {
@@ -139,7 +156,11 @@ function artifactById(artifacts: ArtifactSchema[], artifactId: string | null | u
   return artifacts.find((artifact) => artifact.id === artifactId) ?? null;
 }
 
-function artifactTransposeSemitones(artifact: ArtifactSchema | null, artifacts: ArtifactSchema[], depth = 0): number {
+function artifactTransposeSemitones(
+  artifact: ArtifactSchema | null,
+  artifacts: ArtifactSchema[],
+  depth = 0,
+): number {
   if (!artifact || depth > 4) return 0;
   if (artifact.type === "preview_mix" || artifact.type === "export_mix") {
     const metadata = artifact.metadata ?? {};
@@ -150,13 +171,24 @@ function artifactTransposeSemitones(artifact: ArtifactSchema | null, artifacts: 
   }
   if (artifact.type === "vocal_stem" || artifact.type === "instrumental_stem") {
     const sourceArtifactId = artifact.metadata?.source_artifact_id;
-    return artifactTransposeSemitones(artifactById(artifacts, typeof sourceArtifactId === "string" ? sourceArtifactId : null), artifacts, depth + 1);
+    return artifactTransposeSemitones(
+      artifactById(
+        artifacts,
+        typeof sourceArtifactId === "string" ? sourceArtifactId : null,
+      ),
+      artifacts,
+      depth + 1,
+    );
   }
   return 0;
 }
 
 function transposeChordSegment(segment: ChordSegmentSchema, semitones: number): ChordSegmentSchema {
-  if (!semitones || typeof segment.pitch_class !== "number" || (segment.quality !== "major" && segment.quality !== "minor")) {
+  if (
+    !semitones ||
+    typeof segment.pitch_class !== "number" ||
+    (segment.quality !== "major" && segment.quality !== "minor")
+  ) {
     return segment;
   }
   const pitchClass = transposePitchClass(segment.pitch_class, semitones);
@@ -170,7 +202,10 @@ function transposeChordSegment(segment: ChordSegmentSchema, semitones: number): 
 function findActiveChordIndex(timeline: ChordSegmentSchema[], playbackTimeSeconds: number) {
   return timeline.findIndex((segment, index) => {
     const isLast = index === timeline.length - 1;
-    return playbackTimeSeconds >= segment.start_seconds && (playbackTimeSeconds < segment.end_seconds || isLast);
+    return (
+      playbackTimeSeconds >= segment.start_seconds &&
+      (playbackTimeSeconds < segment.end_seconds || isLast)
+    );
   });
 }
 
@@ -192,7 +227,10 @@ function buildRequestedRetune(
 
 function matchesPreviewSettings(
   artifact: ArtifactSchema | null,
-  requestedRetune: { target_reference_hz: number } | { target_cents_offset: number } | null,
+  requestedRetune:
+    | { target_reference_hz: number }
+    | { target_cents_offset: number }
+    | null,
   transposeSemitones: number,
 ) {
   if (!artifact || artifact.type !== "preview_mix") {
@@ -200,20 +238,33 @@ function matchesPreviewSettings(
   }
 
   const metadata = artifact.metadata ?? {};
-  const retune = typeof metadata.retune === "object" && metadata.retune !== null ? metadata.retune : {};
+  const retune =
+    typeof metadata.retune === "object" && metadata.retune !== null ? metadata.retune : {};
   const transpose =
-    typeof metadata.transpose === "object" && metadata.transpose !== null ? metadata.transpose : {};
+    typeof metadata.transpose === "object" && metadata.transpose !== null
+      ? metadata.transpose
+      : {};
 
   const requestedReferenceHz =
-    requestedRetune && "target_reference_hz" in requestedRetune ? requestedRetune.target_reference_hz : null;
+    requestedRetune && "target_reference_hz" in requestedRetune
+      ? requestedRetune.target_reference_hz
+      : null;
   const requestedCents =
-    requestedRetune && "target_cents_offset" in requestedRetune ? requestedRetune.target_cents_offset : null;
+    requestedRetune && "target_cents_offset" in requestedRetune
+      ? requestedRetune.target_cents_offset
+      : null;
   const artifactReferenceHz =
-    "target_reference_hz" in retune && typeof retune.target_reference_hz === "number" ? retune.target_reference_hz : null;
+    "target_reference_hz" in retune && typeof retune.target_reference_hz === "number"
+      ? retune.target_reference_hz
+      : null;
   const artifactCents =
-    "target_cents_offset" in retune && typeof retune.target_cents_offset === "number" ? retune.target_cents_offset : null;
+    "target_cents_offset" in retune && typeof retune.target_cents_offset === "number"
+      ? retune.target_cents_offset
+      : null;
   const artifactSemitones =
-    "semitones" in transpose && typeof transpose.semitones === "number" ? transpose.semitones : 0;
+    "semitones" in transpose && typeof transpose.semitones === "number"
+      ? transpose.semitones
+      : 0;
 
   return (
     artifactSemitones === transposeSemitones &&
@@ -228,7 +279,7 @@ function formatRetuneSummary(
   centsOffset: string,
 ) {
   if (retuneMode === "off") {
-    return "No fine retune applied";
+    return "No fine retune";
   }
   if (retuneMode === "reference") {
     return `Retuned to ${referenceHz} Hz`;
@@ -240,7 +291,14 @@ export function ProjectView() {
   const { projectId = "" } = useParams();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const {
+    defaultInspectorOpen,
+    helperTextVisible,
+    informationDensity,
+    metadataRevealMode,
+  } = usePreferences();
+  const primaryAudioRef = useRef<HTMLAudioElement | null>(null);
+  const stemAudioRefs = useRef<Record<string, HTMLAudioElement | null>>({});
   const chordSegmentRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const [retuneMode, setRetuneMode] = useState<"off" | "reference" | "cents">("off");
   const [referenceHz, setReferenceHz] = useState("440");
@@ -249,12 +307,16 @@ export function ProjectView() {
   const [targetKeyState, setTargetKeyState] = useState<MusicalKey | null>(null);
   const [targetDirty, setTargetDirty] = useState(false);
   const [selectedArtifactId, setSelectedArtifactId] = useState<string | null>(null);
+  const [selectedPrimaryArtifactId, setSelectedPrimaryArtifactId] = useState<string | null>(null);
   const [followLatestPreview, setFollowLatestPreview] = useState(true);
   const [isRenaming, setIsRenaming] = useState(false);
   const [draftName, setDraftName] = useState("");
-  const [inspectorOpen, setInspectorOpen] = useState(true);
+  const [inspectorOpen, setInspectorOpen] = useState(defaultInspectorOpen);
   const [playbackTimeSeconds, setPlaybackTimeSeconds] = useState(0);
   const [playbackDurationSeconds, setPlaybackDurationSeconds] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [stemControls, setStemControls] = useState<Record<string, StemControlState>>({});
+  const showSupportingCopy = helperTextVisible && informationDensity !== "minimal";
 
   const projectQuery = useQuery({
     queryKey: ["project", projectId],
@@ -340,8 +402,7 @@ export function ProjectView() {
 
   const stemMutation = useMutation({
     mutationFn: async () => {
-      const sourceArtifactId = sourceArtifactIdForStems(selectedArtifact);
-      if (!sourceArtifactId) {
+      if (!selectedPrimaryArtifactId) {
         throw new Error("Select source audio or practice mix first.");
       }
       setFollowLatestPreview(false);
@@ -349,7 +410,7 @@ export function ProjectView() {
         mode: "two_stem",
         output_format: "wav",
         force: hasVisibleStems,
-        source_artifact_id: sourceArtifactId,
+        source_artifact_id: selectedPrimaryArtifactId,
       });
     },
     onSuccess: async () => {
@@ -364,8 +425,8 @@ export function ProjectView() {
     mutationFn: async () => {
       const exportArtifact =
         selectedArtifact ??
-        artifactsQuery.data?.find((artifact) => artifact.type === "preview_mix") ??
-        artifactsQuery.data?.find((artifact) => artifact.type === "source_audio");
+        primaryArtifacts.find((artifact) => artifact.type === "preview_mix") ??
+        primaryArtifacts.find((artifact) => artifact.type === "source_audio");
       if (!exportArtifact) {
         throw new Error("Nothing available to export yet.");
       }
@@ -373,12 +434,15 @@ export function ProjectView() {
       const exportTarget = await save({
         defaultPath: `${projectQuery.data?.display_name ?? artifactLabel(exportArtifact)}.${suggestedFormat}`,
       });
-      const destinationPath = exportTarget ? exportTarget.slice(0, exportTarget.lastIndexOf("/")) : undefined;
+      const destinationPath = exportTarget
+        ? exportTarget.slice(0, exportTarget.lastIndexOf("/"))
+        : undefined;
       const extension = exportTarget?.split(".").pop()?.toLowerCase();
       return api.createExport(projectId, {
         artifact_ids: [exportArtifact.id],
         mixdown_mode: "copy",
-        output_format: extension === "mp3" || extension === "flac" ? extension : "wav",
+        output_format:
+          extension === "mp3" || extension === "flac" ? extension : "wav",
         destination_path: destinationPath,
       });
     },
@@ -394,6 +458,7 @@ export function ProjectView() {
       navigate("/");
     },
   });
+
   const deleteMixMutation = useMutation({
     mutationFn: async () => {
       if (!selectedArtifact || selectedArtifact.type !== "preview_mix") {
@@ -415,37 +480,83 @@ export function ProjectView() {
   const analyzeJob = projectJobs.find((job) => job.type === "analyze");
   const chordJob = projectJobs.find((job) => job.type === "chords");
   const stemJob = projectJobs.find((job) => job.type === "stems");
+
   const displayArtifacts = useMemo(() => {
     const artifacts = artifactsQuery.data ?? [];
     const source = artifacts.find((artifact) => artifact.type === "source_audio");
     const previews = artifacts.filter((artifact) => artifact.type === "preview_mix");
-    const stems = artifacts.filter((artifact) => artifact.type === "vocal_stem" || artifact.type === "instrumental_stem");
+    const stems = artifacts.filter(
+      (artifact) =>
+        artifact.type === "vocal_stem" || artifact.type === "instrumental_stem",
+    );
     const analysisJson = artifacts.find((artifact) => artifact.type === "analysis_json");
     const exports = artifacts.filter((artifact) => artifact.type === "export_mix");
     return [...previews, ...stems, ...exports, analysisJson, source].filter(Boolean) as ArtifactSchema[];
   }, [artifactsQuery.data]);
-  const mixArtifacts = useMemo(
-    () => displayArtifacts.filter((artifact) => artifact.type === "preview_mix" || artifact.type === "source_audio"),
+
+  const primaryArtifacts = useMemo(
+    () =>
+      displayArtifacts.filter(
+        (artifact) => artifact.type === "preview_mix" || artifact.type === "source_audio",
+      ),
     [displayArtifacts],
   );
+  const sourceArtifact = useMemo(
+    () => primaryArtifacts.find((artifact) => artifact.type === "source_audio") ?? null,
+    [primaryArtifacts],
+  );
+  const previewArtifacts = useMemo(
+    () => primaryArtifacts.filter((artifact) => artifact.type === "preview_mix"),
+    [primaryArtifacts],
+  );
   const stemArtifacts = useMemo(
-    () => displayArtifacts.filter((artifact) => artifact.type === "vocal_stem" || artifact.type === "instrumental_stem"),
+    () =>
+      displayArtifacts.filter(
+        (artifact) => artifact.type === "vocal_stem" || artifact.type === "instrumental_stem",
+      ),
     [displayArtifacts],
   );
   const selectableArtifacts = useMemo(
-    () => [...mixArtifacts, ...stemArtifacts].filter((artifact) => isPlayableArtifact(artifact)),
-    [mixArtifacts, stemArtifacts],
+    () => [...primaryArtifacts, ...stemArtifacts].filter((artifact) => isPlayableArtifact(artifact)),
+    [primaryArtifacts, stemArtifacts],
   );
-  const selectedArtifact = selectableArtifacts.find((artifact) => artifact.id === selectedArtifactId) ?? null;
-  const selectedStemSourceArtifactId = sourceArtifactIdForStems(selectedArtifact);
+  const latestPreviewArtifact = previewArtifacts[0] ?? null;
+  const defaultPrimaryArtifact = preferredArtifactSelection(primaryArtifacts);
+
+  const selectedArtifact =
+    selectableArtifacts.find((artifact) => artifact.id === selectedArtifactId) ?? null;
+  const selectedPrimaryArtifact =
+    primaryArtifacts.find((artifact) => artifact.id === selectedPrimaryArtifactId) ??
+    artifactById(primaryArtifacts, sourceArtifactIdForStems(selectedArtifact)) ??
+    defaultPrimaryArtifact;
   const visibleStemArtifacts = useMemo(
     () =>
       stemArtifacts.filter((artifact) => {
         const sourceArtifactId = artifact.metadata?.source_artifact_id;
-        return typeof sourceArtifactId === "string" && sourceArtifactId === selectedStemSourceArtifactId;
+        return (
+          typeof sourceArtifactId === "string" &&
+          sourceArtifactId === selectedPrimaryArtifact?.id
+        );
       }),
-    [selectedStemSourceArtifactId, stemArtifacts],
+    [selectedPrimaryArtifact?.id, stemArtifacts],
   );
+  const focusedStemArtifact =
+    selectedArtifact &&
+    (selectedArtifact.type === "vocal_stem" || selectedArtifact.type === "instrumental_stem")
+      ? selectedArtifact
+      : visibleStemArtifacts[0] ?? null;
+  const isStemSelected = Boolean(
+    selectedArtifact &&
+      (selectedArtifact.type === "vocal_stem" || selectedArtifact.type === "instrumental_stem"),
+  );
+  const isStemPlayback = isStemSelected && visibleStemArtifacts.length > 0;
+  const selectedPlaybackArtifact = isStemPlayback
+    ? focusedStemArtifact
+    : selectedArtifact ?? selectedPrimaryArtifact;
+  const selectedArtifactSummary = selectedPlaybackArtifact
+    ? artifactSummary(selectedPlaybackArtifact)
+    : "";
+
   const detectedKey = parseKey(analysisQuery.data?.estimated_key);
   const sourceKey = manualSourceKey ?? detectedKey ?? DEFAULT_KEY;
   const targetKey = targetDirty ? targetKeyState ?? sourceKey : sourceKey;
@@ -453,61 +564,75 @@ export function ProjectView() {
   const targetKeyOptions = MUSICAL_KEYS.filter((key) => key.mode === sourceKey.mode);
   const requestedRetune = buildRequestedRetune(retuneMode, referenceHz, centsOffset);
   const hasTransformChange = retuneMode !== "off" || transposeSemitones !== 0;
-  const isAnalysisRunning = Boolean(analyzeJob && ["pending", "running"].includes(analyzeJob.status));
-  const isChordRunning = Boolean(chordJob && ["pending", "running"].includes(chordJob.status));
+  const previewMatchesCurrentSettings = matchesPreviewSettings(
+    latestPreviewArtifact,
+    requestedRetune,
+    transposeSemitones,
+  );
+  const selectedArtifactMatchesCurrentSettings =
+    (selectedArtifact?.type === "source_audio" && !hasTransformChange) ||
+    matchesPreviewSettings(selectedArtifact, requestedRetune, transposeSemitones);
+  const isAnalysisRunning = Boolean(
+    analyzeJob && ["pending", "running"].includes(analyzeJob.status),
+  );
+  const isChordRunning = Boolean(
+    chordJob && ["pending", "running"].includes(chordJob.status),
+  );
   const isStemRunning = Boolean(stemJob && ["pending", "running"].includes(stemJob.status));
   const currentKeyValue = manualSourceKey
     ? serializeKey(manualSourceKey)
     : detectedKey
       ? "auto"
       : serializeKey(sourceKey);
-  const selectedArtifactSummary = selectedArtifact ? artifactSummary(selectedArtifact) : "";
-  const latestPreviewArtifact = displayArtifacts.find((artifact) => artifact.type === "preview_mix") ?? null;
-  const previewMatchesCurrentSettings = matchesPreviewSettings(latestPreviewArtifact, requestedRetune, transposeSemitones);
-  const isStemSelected = selectedArtifact ? ["vocal_stem", "instrumental_stem"].includes(selectedArtifact.type) : false;
-  const canGenerateStems = Boolean(selectedStemSourceArtifactId);
   const hasVisibleStems = visibleStemArtifacts.length > 0;
-  const selectedArtifactMatchesCurrentSettings =
-    (selectedArtifact?.type === "source_audio" && !hasTransformChange) ||
-    matchesPreviewSettings(selectedArtifact, requestedRetune, transposeSemitones);
-  const visibleJobs = useMemo(() => projectJobs.filter((job) => job.type !== "stems"), [projectJobs]);
+  const visibleJobs = useMemo(
+    () => projectJobs.filter((job) => job.type !== "stems"),
+    [projectJobs],
+  );
   const recentJobs = visibleJobs.slice(0, 3);
-  const selectedMixTitle = selectedArtifact ? artifactLabel(selectedArtifact) : "None selected";
-  const selectedMixSummary = selectedArtifact
-    ? selectedArtifactSummary || (selectedArtifact.type === "source_audio" ? "Original source file" : "Saved practice mix")
-    : "Choose a saved mix to play.";
   const controlSummary = hasTransformChange ? formatKey(targetKey) : "Original key";
   const tuningSummary = formatRetuneSummary(retuneMode, referenceHz, centsOffset);
-  const mixStatus = !hasTransformChange
-    ? latestPreviewArtifact
-      ? "Using source settings"
-      : "Source only"
-    : !latestPreviewArtifact
-      ? "No preview yet"
-      : previewMatchesCurrentSettings
-        ? "Up to date"
-        : "Needs update";
-  const mixStatusCopy = isStemSelected
-    ? "Stem tracks are independent from mix controls."
+  const mixStatus = isStemPlayback
+    ? "Stem monitor"
+    : !hasTransformChange
+      ? latestPreviewArtifact
+        ? "Source settings"
+        : "Source only"
+      : !latestPreviewArtifact
+        ? "No preview yet"
+        : previewMatchesCurrentSettings
+          ? "Up to date"
+          : "Needs update";
+  const mixStatusCopy = isStemPlayback
+    ? "Mute or solo stems without leaving the playback surface."
     : selectedArtifact
-    ? selectedArtifactMatchesCurrentSettings
-      ? "Selected mix matches current controls."
-      : !hasTransformChange
-        ? "Selected mix differs from current source controls."
-        : "Controls differ from selected mix. Create new mix if you want to save them."
-    : "Select a mix to compare it with current controls.";
+      ? selectedArtifactMatchesCurrentSettings
+        ? "Selected playback matches current controls."
+        : "Controls differ from selected playback."
+      : "Select source audio or a saved mix.";
   const canDeleteSelectedMix = selectedArtifact?.type === "preview_mix";
-  const selectedArtifactTimestamp = selectedArtifact ? formatArtifactTimestamp(selectedArtifact.created_at) : "";
-  const playbackClockSummary = `${formatPlaybackClock(playbackTimeSeconds)} / ${formatPlaybackClock(
+  const selectedArtifactTimestamp = selectedPlaybackArtifact
+    ? formatArtifactTimestamp(selectedPlaybackArtifact.created_at)
+    : "";
+  const playbackClockSummary = `${formatPlaybackClock(
+    playbackTimeSeconds,
+  )} / ${formatPlaybackClock(
     playbackDurationSeconds || projectQuery.data?.duration_seconds || 0,
   )}`;
-  const chordTransposeSemitones = artifactTransposeSemitones(selectedArtifact, selectableArtifacts);
+  const chordTransposeSemitones = artifactTransposeSemitones(
+    selectedPlaybackArtifact,
+    selectableArtifacts,
+  );
   const displayedChords = useMemo(
-    () => (chordsQuery.data?.timeline ?? []).map((segment) => transposeChordSegment(segment, chordTransposeSemitones)),
+    () =>
+      (chordsQuery.data?.timeline ?? []).map((segment) =>
+        transposeChordSegment(segment, chordTransposeSemitones),
+      ),
     [chordTransposeSemitones, chordsQuery.data?.timeline],
   );
   const activeChordIndex = findActiveChordIndex(displayedChords, playbackTimeSeconds);
-  const currentChord = activeChordIndex >= 0 ? displayedChords[activeChordIndex] : displayedChords[0] ?? null;
+  const currentChord =
+    activeChordIndex >= 0 ? displayedChords[activeChordIndex] : displayedChords[0] ?? null;
   const nextChord =
     activeChordIndex >= 0
       ? displayedChords[activeChordIndex + 1] ?? null
@@ -517,16 +642,137 @@ export function ProjectView() {
   const hasChordTimeline = displayedChords.length > 0;
   const chordContextCopy =
     chordTransposeSemitones === 0
-      ? "Chord names match the source arrangement."
-      : `Chord names follow the selected mix (${formatSemitoneShift(chordTransposeSemitones).toLowerCase()}).`;
+      ? "Chord labels follow the original arrangement."
+      : `Chord labels follow the selected playback (${formatSemitoneShift(
+          chordTransposeSemitones,
+        ).toLowerCase()}).`;
+  const capoSummary = transposeSemitones > 0 ? `${transposeSemitones}` : "Off";
+
+  const soloedStemIds = visibleStemArtifacts
+    .filter((artifact) => stemControls[artifact.id]?.solo)
+    .map((artifact) => artifact.id);
+  const activeStemCount = visibleStemArtifacts.filter((artifact) => {
+    const state = stemControls[artifact.id] ?? { muted: false, solo: false };
+    if (soloedStemIds.length > 0) {
+      return state.solo;
+    }
+    return !state.muted;
+  }).length;
+
+  function handleSelectPrimaryArtifact(artifact: ArtifactSchema) {
+    setSelectedPrimaryArtifactId(artifact.id);
+    setSelectedArtifactId(artifact.id);
+    setFollowLatestPreview(false);
+  }
+
+  function handleSelectStemArtifact(artifact: ArtifactSchema) {
+    const sourceArtifactId = sourceArtifactIdForStems(artifact);
+    if (sourceArtifactId) {
+      setSelectedPrimaryArtifactId(sourceArtifactId);
+    }
+    setSelectedArtifactId(artifact.id);
+    setFollowLatestPreview(false);
+  }
+
+  function setStemAudioRef(artifactId: string, element: HTMLAudioElement | null) {
+    if (element) {
+      stemAudioRefs.current[artifactId] = element;
+    } else {
+      delete stemAudioRefs.current[artifactId];
+    }
+  }
+
+  function getActiveMediaElements() {
+    if (isStemPlayback) {
+      return visibleStemArtifacts
+        .map((artifact) => stemAudioRefs.current[artifact.id])
+        .filter(Boolean) as HTMLAudioElement[];
+    }
+    return primaryAudioRef.current ? [primaryAudioRef.current] : [];
+  }
+
+  function syncPlaybackPosition(nextTime: number) {
+    getActiveMediaElements().forEach((element) => {
+      element.currentTime = nextTime;
+    });
+    setPlaybackTimeSeconds(nextTime);
+  }
+
+  async function togglePlayback() {
+    const activeElements = getActiveMediaElements();
+    if (!activeElements.length) return;
+
+    if (isPlaying) {
+      activeElements.forEach((element) => element.pause());
+      setIsPlaying(false);
+      return;
+    }
+
+    const masterTime = activeElements[0].currentTime;
+    activeElements.forEach((element) => {
+      if (Math.abs(element.currentTime - masterTime) > 0.05) {
+        element.currentTime = masterTime;
+      }
+    });
+
+    await Promise.all(
+      activeElements.map((element) =>
+        Promise.resolve(element.play()).catch(() => undefined),
+      ),
+    );
+    setIsPlaying(true);
+  }
+
+  function handleSeek(secondsDelta: number) {
+    const duration = playbackDurationSeconds || projectQuery.data?.duration_seconds || 0;
+    const nextTime = Math.max(0, Math.min(duration, playbackTimeSeconds + secondsDelta));
+    syncPlaybackPosition(nextTime);
+  }
+
+  function toggleStemControl(
+    artifact: ArtifactSchema,
+    mode: keyof StemControlState,
+  ) {
+    if (!isStemPlayback) {
+      handleSelectStemArtifact(artifact);
+    }
+
+    setStemControls((current) => {
+      const previous = current[artifact.id] ?? { muted: false, solo: false };
+      return {
+        ...current,
+        [artifact.id]: {
+          ...previous,
+          [mode]: !previous[mode],
+        },
+      };
+    });
+  }
+
+  function stemOutputLabel(artifactId: string) {
+    const state = stemControls[artifactId] ?? { muted: false, solo: false };
+    if (soloedStemIds.length > 0 && !state.solo) {
+      return "Muted by solo";
+    }
+    if (state.solo) {
+      return "Solo";
+    }
+    if (state.muted) {
+      return "Muted";
+    }
+    return "Live";
+  }
 
   async function handleDeleteProject() {
-    const approved = await confirm("Delete this project and all of its mixes, stems, and exports?", {
-      title: "Delete project",
-      kind: "warning",
-      okLabel: "Delete",
-      cancelLabel: "Cancel",
-    });
+    const approved = await confirm(
+      "Delete this project and all of its mixes, stems, and exports?",
+      {
+        title: "Delete project",
+        kind: "warning",
+        okLabel: "Delete",
+        cancelLabel: "Cancel",
+      },
+    );
     if (!approved) {
       return;
     }
@@ -550,55 +796,85 @@ export function ProjectView() {
   }
 
   useEffect(() => {
-    if (!projectQuery.data || analysisQuery.isLoading || analysisQuery.data || analyzeMutation.isPending) {
-      return;
-    }
-    const hasAttemptedAnalysis = projectJobs.some((job) => job.type === "analyze");
-    if (hasAttemptedAnalysis) {
-      return;
-    }
-    analyzeMutation.mutate();
-  }, [
-    analyzeMutation,
-    analysisQuery.data,
-    analysisQuery.isLoading,
-    projectJobs,
-    projectQuery.data,
-  ]);
-
-  useEffect(() => {
     if (!isRenaming) {
       setDraftName(projectQuery.data?.display_name ?? "");
     }
   }, [isRenaming, projectQuery.data?.display_name]);
 
   useEffect(() => {
-    if (!selectableArtifacts.length) {
+    setInspectorOpen(defaultInspectorOpen);
+  }, [defaultInspectorOpen]);
+
+  useEffect(() => {
+    if (!defaultPrimaryArtifact) {
+      setSelectedPrimaryArtifactId(null);
       setSelectedArtifactId(null);
       return;
     }
 
-    const currentArtifact = selectableArtifacts.find((artifact) => artifact.id === selectedArtifactId) ?? null;
-    if (!currentArtifact) {
-      setSelectedArtifactId(preferredArtifactSelection(selectableArtifacts)?.id ?? null);
-      return;
+    if (
+      !selectedPrimaryArtifactId ||
+      !primaryArtifacts.some((artifact) => artifact.id === selectedPrimaryArtifactId)
+    ) {
+      setSelectedPrimaryArtifactId(defaultPrimaryArtifact.id);
     }
 
-    if (followLatestPreview) {
-      const latestPreview = selectableArtifacts.find((artifact) => artifact.type === "preview_mix");
-      if (latestPreview && latestPreview.id !== currentArtifact.id) {
-        setSelectedArtifactId(latestPreview.id);
-      }
+    if (
+      !selectedArtifactId ||
+      !selectableArtifacts.some((artifact) => artifact.id === selectedArtifactId)
+    ) {
+      setSelectedArtifactId(defaultPrimaryArtifact.id);
     }
-  }, [followLatestPreview, selectableArtifacts, selectedArtifactId]);
+
+    if (followLatestPreview && latestPreviewArtifact) {
+      setSelectedPrimaryArtifactId(latestPreviewArtifact.id);
+      setSelectedArtifactId(latestPreviewArtifact.id);
+    }
+  }, [
+    defaultPrimaryArtifact,
+    followLatestPreview,
+    latestPreviewArtifact,
+    primaryArtifacts,
+    selectableArtifacts,
+    selectedArtifactId,
+    selectedPrimaryArtifactId,
+  ]);
 
   useEffect(() => {
+    setStemControls((current) => {
+      const next: Record<string, StemControlState> = {};
+      visibleStemArtifacts.forEach((artifact) => {
+        next[artifact.id] = current[artifact.id] ?? { muted: false, solo: false };
+      });
+      return next;
+    });
+  }, [visibleStemArtifacts]);
+
+  useEffect(() => {
+    const hasSolo = soloedStemIds.length > 0;
+    visibleStemArtifacts.forEach((artifact) => {
+      const element = stemAudioRefs.current[artifact.id];
+      if (!element) return;
+      const state = stemControls[artifact.id] ?? { muted: false, solo: false };
+      element.volume = hasSolo ? (state.solo ? 1 : 0) : state.muted ? 0 : 1;
+    });
+  }, [soloedStemIds, stemControls, visibleStemArtifacts]);
+
+  useEffect(() => {
+    primaryAudioRef.current?.pause();
+    Object.values(stemAudioRefs.current).forEach((element) => element?.pause());
+    setIsPlaying(false);
     setPlaybackTimeSeconds(0);
     setPlaybackDurationSeconds(0);
-    if (audioRef.current) {
-      audioRef.current.currentTime = 0;
+    if (primaryAudioRef.current) {
+      primaryAudioRef.current.currentTime = 0;
     }
-  }, [selectedArtifact?.id]);
+    Object.values(stemAudioRefs.current).forEach((element) => {
+      if (element) {
+        element.currentTime = 0;
+      }
+    });
+  }, [selectedArtifact?.id, selectedPrimaryArtifact?.id]);
 
   useEffect(() => {
     if (activeChordIndex < 0) {
@@ -608,13 +884,35 @@ export function ProjectView() {
     if (!activeSegment) {
       return;
     }
-    const activeElement = chordSegmentRefs.current[`${activeSegment.start_seconds}-${activeSegment.label}-${activeChordIndex}`];
+    const activeElement =
+      chordSegmentRefs.current[
+        `${activeSegment.start_seconds}-${activeSegment.label}-${activeChordIndex}`
+      ];
     activeElement?.scrollIntoView({
       behavior: "smooth",
       block: "nearest",
       inline: "center",
     });
   }, [activeChordIndex, displayedChords]);
+
+  const currentSourceLabel = selectedPrimaryArtifact
+    ? artifactLabel(selectedPrimaryArtifact)
+    : "Source Track";
+  const currentSourceSummary = selectedPrimaryArtifact
+    ? artifactSummary(selectedPrimaryArtifact) ||
+      fileNameFromPath(selectedPrimaryArtifact.path)
+    : "Select audio to start playback.";
+  const stageTitle = isStemPlayback
+    ? focusedStemArtifact
+      ? artifactLabel(focusedStemArtifact)
+      : "Stem Monitor"
+    : selectedPlaybackArtifact
+      ? artifactLabel(selectedPlaybackArtifact)
+      : "Playback";
+  const stageModeLabel = isStemPlayback ? "Stem monitor" : "Full playback";
+  const stageSummary = isStemPlayback
+    ? `${activeStemCount} of ${visibleStemArtifacts.length} stems audible`
+    : selectedArtifactSummary || currentSourceSummary;
 
   return (
     <section className="screen">
@@ -638,7 +936,7 @@ export function ProjectView() {
                   onClick={() => renameMutation.mutate()}
                   disabled={renameMutation.isPending || !draftName.trim()}
                 >
-                  {renameMutation.isPending ? "Saving…" : "Save"}
+                  {renameMutation.isPending ? "Saving..." : "Save"}
                 </button>
                 <button
                   className="button button--ghost button--small"
@@ -656,14 +954,20 @@ export function ProjectView() {
           ) : (
             <div className="title-row">
               <h1>{projectQuery.data?.display_name ?? "Project"}</h1>
-              <button className="button button--ghost button--small" type="button" onClick={() => setIsRenaming(true)}>
+              <button
+                className="button button--ghost button--small"
+                type="button"
+                onClick={() => setIsRenaming(true)}
+              >
                 Rename
               </button>
             </div>
           )}
-          <p className="screen__subtitle">
-            Keep alternate practice mixes ready to play, compare, and revisit inside the project.
-          </p>
+          {showSupportingCopy ? (
+            <p className="screen__subtitle">
+              Keep source audio, saved mixes, chords, and stems close to transport.
+            </p>
+          ) : null}
         </div>
 
         <div className="button-row">
@@ -672,246 +976,488 @@ export function ProjectView() {
             onClick={() => previewMutation.mutate()}
             disabled={previewMutation.isPending || !hasTransformChange}
           >
-            {previewMutation.isPending ? "Queueing…" : "Create Mix"}
+            {previewMutation.isPending ? "Queueing..." : "Create Mix"}
           </button>
-          <button className="button button--ghost" type="button" onClick={() => setInspectorOpen((current) => !current)}>
+          <button
+            className="button button--ghost"
+            type="button"
+            onClick={() => setInspectorOpen((current) => !current)}
+          >
             {inspectorOpen ? "Hide Inspector" : "Show Inspector"}
           </button>
         </div>
       </div>
 
       <div className={`project-workbench${inspectorOpen ? "" : " project-workbench--wide"}`}>
-        <div className="stack">
-          <div className="panel">
-            <div className="panel-heading">
-              <div>
-                <h2>Playables</h2>
-                <p className="subpanel__copy">Keep source, mixes, and stems ready to jump between while you practice.</p>
+        <aside className="stack">
+          <div className="panel rail-panel">
+            <div className="rail-section">
+              <div className="rail-section__header">
+                <div>
+                  <h2>Sources</h2>
+                  {showSupportingCopy ? (
+                    <p className="subpanel__copy">Jump between the raw track and saved mixes.</p>
+                  ) : null}
+                </div>
               </div>
-            </div>
-
-            <div className="library-section">
-              <div className="library-section__header">
-                <h3>Saved Mixes</h3>
-                {selectedArtifact ? <span className="artifact-meta">{selectedArtifact.format.toUpperCase()}</span> : null}
-              </div>
-              <div className="artifact-selector artifact-selector--stacked" role="group" aria-label="Saved mix list">
-                {mixArtifacts.map((artifact) => (
+              <div
+                className="artifact-selector artifact-selector--stacked"
+                role="group"
+                aria-label="Source and mix list"
+              >
+                {sourceArtifact ? (
                   <button
-                    key={artifact.id}
-                    className={`artifact-pill${selectedArtifactId === artifact.id ? " artifact-pill--active" : ""}`}
-                    onClick={() => {
-                      setSelectedArtifactId(artifact.id);
-                      setFollowLatestPreview(false);
-                    }}
+                    className={`artifact-pill${
+                      selectedArtifactId === sourceArtifact.id ? " artifact-pill--active" : ""
+                    }`}
+                    onClick={() => handleSelectPrimaryArtifact(sourceArtifact)}
                     type="button"
                   >
-                    <span className="artifact-pill__title">{artifactLabel(artifact)}</span>
+                    <span className="artifact-pill__title">Source Track</span>
                     <span className="artifact-pill__meta">
-                      {artifactSummary(artifact) || formatArtifactTimestamp(artifact.created_at)}
+                      {artifactSummary(sourceArtifact)}
                     </span>
+                    {informationDensity === "detailed" ? (
+                      <span className="artifact-pill__meta">
+                        {fileNameFromPath(sourceArtifact.path)}
+                      </span>
+                    ) : null}
                   </button>
-                ))}
+                ) : (
+                  <p className="artifact-meta">No source track available.</p>
+                )}
               </div>
             </div>
 
-            <div className="subpanel subpanel--compact">
-              <div className="subpanel__header">
-                <h3>Stem Tracks</h3>
-                <p className="subpanel__copy">Stem playback stays scoped to whichever source or mix is selected.</p>
+            <div className="rail-section">
+              <div className="rail-section__header">
+                <div>
+                  <h3>Saved Mixes</h3>
+                  {showSupportingCopy ? (
+                    <p className="subpanel__copy">Practice variants stay one click away.</p>
+                  ) : null}
+                </div>
               </div>
-              <div className="button-row">
-                <button
-                  className="button"
-                  onClick={() => stemMutation.mutate()}
-                  disabled={stemMutation.isPending || isStemRunning || !canGenerateStems}
+              {previewArtifacts.length ? (
+                <div
+                  className="artifact-selector artifact-selector--stacked"
+                  role="group"
+                  aria-label="Saved mix list"
                 >
-                  {stemMutation.isPending || isStemRunning ? "Generating…" : hasVisibleStems ? "Refresh Stems" : "Generate Stems"}
-                </button>
-              </div>
-              {visibleStemArtifacts.length ? (
-                <div className="artifact-selector artifact-selector--stacked" role="group" aria-label="Stem track list">
-                  {visibleStemArtifacts.map((artifact) => (
+                  {previewArtifacts.map((artifact) => (
                     <button
                       key={artifact.id}
-                      className={`artifact-pill${selectedArtifactId === artifact.id ? " artifact-pill--active" : ""}`}
-                      onClick={() => {
-                        setSelectedArtifactId(artifact.id);
-                        setFollowLatestPreview(false);
-                      }}
+                      className={`artifact-pill${
+                        selectedArtifactId === artifact.id ? " artifact-pill--active" : ""
+                      }`}
+                      onClick={() => handleSelectPrimaryArtifact(artifact)}
                       type="button"
                     >
                       <span className="artifact-pill__title">{artifactLabel(artifact)}</span>
                       <span className="artifact-pill__meta">
                         {artifactSummary(artifact) || formatArtifactTimestamp(artifact.created_at)}
                       </span>
+                      {informationDensity === "detailed" ? (
+                        <span className="artifact-pill__meta">
+                          {formatArtifactTimestamp(artifact.created_at)}
+                        </span>
+                      ) : null}
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <p className="artifact-meta">No saved mixes yet. Build one from inspector controls.</p>
+              )}
+            </div>
+
+            <div className="rail-section">
+              <div className="rail-section__header">
+                <div>
+                  <h3>Stems</h3>
+                  {showSupportingCopy ? (
+                    <p className="subpanel__copy">Stem playback stays scoped to the selected source or mix.</p>
+                  ) : null}
+                </div>
+                <button
+                  className="button button--small"
+                  onClick={() => stemMutation.mutate()}
+                  disabled={stemMutation.isPending || isStemRunning || !selectedPrimaryArtifactId}
+                  type="button"
+                >
+                  {stemMutation.isPending || isStemRunning
+                    ? "Generating..."
+                    : hasVisibleStems
+                      ? "Refresh Stems"
+                      : "Generate Stems"}
+                </button>
+              </div>
+              {visibleStemArtifacts.length ? (
+                <div
+                  className="artifact-selector artifact-selector--stacked"
+                  role="group"
+                  aria-label="Stem track list"
+                >
+                  {visibleStemArtifacts.map((artifact) => (
+                    <button
+                      key={artifact.id}
+                      className={`artifact-pill${
+                        selectedArtifactId === artifact.id ? " artifact-pill--active" : ""
+                      }`}
+                      onClick={() => handleSelectStemArtifact(artifact)}
+                      type="button"
+                    >
+                      <span className="artifact-pill__title">{artifactLabel(artifact)}</span>
+                      <span className="artifact-pill__meta">{stemOutputLabel(artifact.id)}</span>
+                      {informationDensity !== "minimal" ? (
+                        <span className="artifact-pill__meta">{artifactSummary(artifact)}</span>
+                      ) : null}
                     </button>
                   ))}
                 </div>
               ) : (
                 <p className="artifact-meta">
-                  {canGenerateStems ? "No stems yet for selected audio." : "Select source audio or practice mix first."}
+                  {selectedPrimaryArtifactId
+                    ? "No stems yet for selected audio."
+                    : "Select source audio or a saved mix first."}
                 </p>
               )}
             </div>
           </div>
-        </div>
+        </aside>
 
         <div className="stack">
           <div className="panel playback-stage">
-            {selectedArtifact ? (
-              <>
-                <div className="playback-stage__header">
-                  <div>
-                    <p className="metric-label">Now Playing</p>
-                    <h2>{selectedMixTitle}</h2>
-                    <p className="artifact-meta">{selectedMixSummary}</p>
-                  </div>
-                  <div className="playback-focus__meta">
-                    <span>{selectedArtifact.format.toUpperCase()}</span>
-                    <span>{selectedArtifactTimestamp}</span>
-                  </div>
+            <div className="playback-stage__header">
+              <div>
+                <p className="metric-label">Now Playing</p>
+                <h2>{stageTitle}</h2>
+                <p className="artifact-meta">{stageSummary}</p>
+              </div>
+              <div className="playback-focus__meta">
+                <span>{stageModeLabel}</span>
+                {selectedArtifactTimestamp ? <span>{selectedArtifactTimestamp}</span> : null}
+              </div>
+            </div>
+
+            <div className="stage-surface">
+              <div className="session-block playback-stage__summary">
+                <div role="group" aria-label="Current source summary">
+                  <p className="metric-label">Current Source</p>
+                  <strong>{currentSourceLabel}</strong>
+                  <p className="artifact-meta">{currentSourceSummary}</p>
+                </div>
+                <div role="group" aria-label="Current control summary">
+                  <p className="metric-label">Mix Controls</p>
+                  <strong>{controlSummary}</strong>
+                  <p className="artifact-meta">{tuningSummary}</p>
+                </div>
+                <div role="group" aria-label="Mix status summary">
+                  <p className="metric-label">Status</p>
+                  <strong>{mixStatus}</strong>
+                  <p className="artifact-meta">{mixStatusCopy}</p>
+                </div>
+              </div>
+
+              <div className="transport">
+                <div className="transport__controls">
+                  <button
+                    className="button button--small"
+                    onClick={() => handleSeek(-10)}
+                    type="button"
+                  >
+                    -10s
+                  </button>
+                  <button
+                    className="button button--primary transport__play"
+                    aria-label={isPlaying ? "Pause playback" : "Play playback"}
+                    onClick={() => void togglePlayback()}
+                    type="button"
+                  >
+                    {isPlaying ? "Pause" : "Play"}
+                  </button>
+                  <button
+                    className="button button--small"
+                    onClick={() => handleSeek(10)}
+                    type="button"
+                  >
+                    +10s
+                  </button>
                 </div>
 
-                <div className="session-block playback-stage__summary">
-                  <div role="group" aria-label="Selected mix summary">
-                    <p className="metric-label">Selected Audio</p>
-                    <strong>{selectedMixTitle}</strong>
-                    <p className="artifact-meta">{selectedMixSummary}</p>
-                  </div>
-                  <div role="group" aria-label="Current control summary">
-                    <p className="metric-label">Current Mix Controls</p>
-                    <strong>{controlSummary}</strong>
-                    <p className="artifact-meta">{tuningSummary}</p>
-                  </div>
-                  <div role="group" aria-label="Mix status summary">
-                    <p className="metric-label">Selection Status</p>
-                    <strong>{mixStatus}</strong>
-                    <p className="artifact-meta">{mixStatusCopy}</p>
-                  </div>
-                </div>
-
-                <div className="playback-stage__lane">
-                  <div className="playback-stage__lane-header">
-                    <div>
-                      <p className="metric-label">Chord Lane</p>
-                      <h3>Follow harmony while the mix plays</h3>
-                    </div>
-                    <div className="button-row">
-                      <button
-                        className="button button--small"
-                        type="button"
-                        onClick={() => chordMutation.mutate()}
-                        disabled={chordMutation.isPending || isChordRunning}
-                      >
-                        {chordMutation.isPending || isChordRunning
-                          ? "Generating…"
-                          : hasChordTimeline
-                            ? "Refresh Chords"
-                            : "Generate Chords"}
-                      </button>
-                    </div>
-                  </div>
-
-                  <div className="chord-preview-grid">
-                    <div className="chord-card" role="group" aria-label="Current chord card">
-                      <span className="metric-label">Current Chord</span>
-                      <strong>{currentChord?.label ?? "—"}</strong>
-                    </div>
-                    <div className="chord-card" role="group" aria-label="Next chord card">
-                      <span className="metric-label">Next Chord</span>
-                      <strong>{nextChord?.label ?? "—"}</strong>
-                    </div>
-                  </div>
-
-                  <div className="chord-context">
-                    <span className="artifact-meta">{chordContextCopy}</span>
-                  </div>
-
-                  {hasChordTimeline ? (
-                    <div className="chord-timeline" role="group" aria-label="Chord timeline">
-                      {displayedChords.map((segment, index) => {
-                        const durationWeight = Math.max(0.9, segment.end_seconds - segment.start_seconds);
-                        const isActive = index === activeChordIndex;
-                        return (
-                          <button
-                            key={`${segment.start_seconds}-${segment.label}-${index}`}
-                            className={`chord-segment${isActive ? " chord-segment--active" : ""}`}
-                            type="button"
-                            style={{ flexGrow: durationWeight }}
-                            aria-pressed={isActive}
-                            ref={(element) => {
-                              chordSegmentRefs.current[`${segment.start_seconds}-${segment.label}-${index}`] = element;
-                            }}
-                            onClick={() => {
-                              if (audioRef.current) {
-                                audioRef.current.currentTime = segment.start_seconds;
-                                setPlaybackTimeSeconds(segment.start_seconds);
-                              }
-                            }}
-                          >
-                            <span>{segment.label}</span>
-                            <small>{formatPlaybackClock(segment.start_seconds)}</small>
-                          </button>
-                        );
-                      })}
-                    </div>
-                  ) : (
-                    <div className="chord-lane-empty">
-                      <p className="artifact-meta">Generate a chord timeline to jump around the song while you practice.</p>
-                    </div>
-                  )}
-
-                  {chordsQuery.data?.created_at ? (
-                    <p className="artifact-meta">Last chord pass: {formatArtifactTimestamp(chordsQuery.data.created_at)}</p>
-                  ) : null}
-                  {chordJob?.error_message ? (
-                    <p className="inline-error">{chordJob.error_message}</p>
-                  ) : null}
-                </div>
-
-                <audio
-                  controls
-                  ref={audioRef}
-                  src={api.streamArtifactUrl(selectedArtifact.id)}
-                  className="player"
-                  onTimeUpdate={(event) => setPlaybackTimeSeconds(event.currentTarget.currentTime)}
-                  onLoadedMetadata={(event) => setPlaybackDurationSeconds(event.currentTarget.duration)}
-                  onDurationChange={(event) => setPlaybackDurationSeconds(event.currentTarget.duration)}
-                />
-
-                <div className="playback-stage__footer">
-                  <div>
-                    <span className="metric-label">Playback Position</span>
-                    <strong>{playbackClockSummary}</strong>
-                  </div>
-                  <div role="group" aria-label="Recent processing summary">
-                    <span className="metric-label">Recent Processing</span>
-                    {recentJobs.length ? (
-                      <ul className="session-jobs">
-                        {recentJobs.map((job) => (
-                          <li key={job.id}>
-                            <span>{job.type}</span>
-                            <small>{job.status}</small>
-                          </li>
-                        ))}
-                      </ul>
-                    ) : (
-                      <p className="artifact-meta">No processing jobs yet.</p>
+                <label className="transport__scrubber">
+                  <span className="metric-label">Playback position</span>
+                  <input
+                    aria-label="Playback position"
+                    max={playbackDurationSeconds || projectQuery.data?.duration_seconds || 0}
+                    min={0}
+                    onChange={(event) => syncPlaybackPosition(Number(event.target.value))}
+                    step={0.1}
+                    type="range"
+                    value={Math.min(
+                      playbackTimeSeconds,
+                      playbackDurationSeconds || projectQuery.data?.duration_seconds || 0,
                     )}
+                  />
+                  <div className="transport__times">
+                    <strong>{formatPlaybackClock(playbackTimeSeconds)}</strong>
+                    <span>
+                      {formatPlaybackClock(
+                        playbackDurationSeconds || projectQuery.data?.duration_seconds || 0,
+                      )}
+                    </span>
                   </div>
+                </label>
+              </div>
+            </div>
+
+            <div className="playback-stage__lane">
+              <div className="playback-stage__lane-header">
+                <div>
+                  <p className="metric-label">Chord Follow</p>
+                  <h3>Current harmony</h3>
                 </div>
-              </>
-            ) : (
-              <p>No practice mix yet. Set a tuning or target key, then create one.</p>
-            )}
+                <button
+                  className="button button--small"
+                  type="button"
+                  onClick={() => chordMutation.mutate()}
+                  disabled={chordMutation.isPending || isChordRunning}
+                >
+                  {chordMutation.isPending || isChordRunning
+                    ? "Generating..."
+                    : hasChordTimeline
+                      ? "Refresh Chords"
+                      : "Generate Chords"}
+                </button>
+              </div>
+
+              <div className="chord-preview-grid">
+                <div className="chord-card" role="group" aria-label="Current chord card">
+                  <span className="metric-label">Current</span>
+                  <strong>{currentChord?.label ?? "-"}</strong>
+                </div>
+                <div className="chord-card" role="group" aria-label="Next chord card">
+                  <span className="metric-label">Next</span>
+                  <strong>{nextChord?.label ?? "-"}</strong>
+                </div>
+              </div>
+
+              {showSupportingCopy ? (
+                <div className="chord-context">
+                  <span className="artifact-meta">{chordContextCopy}</span>
+                </div>
+              ) : null}
+
+              {hasChordTimeline ? (
+                <div className="chord-timeline" role="group" aria-label="Chord timeline">
+                  {displayedChords.map((segment, index) => {
+                    const durationWeight = Math.max(
+                      0.9,
+                      segment.end_seconds - segment.start_seconds,
+                    );
+                    const isActive = index === activeChordIndex;
+                    return (
+                      <button
+                        key={`${segment.start_seconds}-${segment.label}-${index}`}
+                        className={`chord-segment${isActive ? " chord-segment--active" : ""}`}
+                        type="button"
+                        style={{ flexGrow: durationWeight }}
+                        aria-pressed={isActive}
+                        ref={(element) => {
+                          chordSegmentRefs.current[
+                            `${segment.start_seconds}-${segment.label}-${index}`
+                          ] = element;
+                        }}
+                        onClick={() => syncPlaybackPosition(segment.start_seconds)}
+                      >
+                        <span>{segment.label}</span>
+                        <small>{formatPlaybackClock(segment.start_seconds)}</small>
+                      </button>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="chord-lane-empty">
+                  <p className="artifact-meta">
+                    Generate a chord pass to jump around the arrangement while you practice.
+                  </p>
+                </div>
+              )}
+
+              {chordsQuery.data?.created_at ? (
+                <p className="artifact-meta">
+                  Last chord pass: {formatArtifactTimestamp(chordsQuery.data.created_at)}
+                </p>
+              ) : null}
+              {chordJob?.error_message ? (
+                <p className="inline-error">{chordJob.error_message}</p>
+              ) : null}
+            </div>
+
+            {visibleStemArtifacts.length ? (
+              <div className="stage-subsection">
+                <div className="panel-heading">
+                  <div>
+                    <h3>Stem Monitor</h3>
+                    {showSupportingCopy ? (
+                      <p className="subpanel__copy">
+                        Mute or solo stems without leaving the transport surface.
+                      </p>
+                    ) : null}
+                  </div>
+                  {isStemPlayback ? (
+                    <button
+                      className="button button--small"
+                      onClick={() => {
+                        if (selectedPrimaryArtifact) {
+                          handleSelectPrimaryArtifact(selectedPrimaryArtifact);
+                        }
+                      }}
+                      type="button"
+                    >
+                      Return to Full Mix
+                    </button>
+                  ) : (
+                    <button
+                      className="button button--small"
+                      onClick={() => {
+                        if (visibleStemArtifacts[0]) {
+                          handleSelectStemArtifact(visibleStemArtifacts[0]);
+                        }
+                      }}
+                      type="button"
+                    >
+                      Switch to Stems
+                    </button>
+                  )}
+                </div>
+
+                <div className="stem-mixer">
+                  <div className="stem-mixer__summary">
+                    <span className="metric-label">Audible stems</span>
+                    <strong>
+                      {activeStemCount} / {visibleStemArtifacts.length}
+                    </strong>
+                  </div>
+                  {visibleStemArtifacts.map((artifact) => {
+                    const state = stemControls[artifact.id] ?? {
+                      muted: false,
+                      solo: false,
+                    };
+                    return (
+                      <div className="stem-row" key={artifact.id}>
+                        <button
+                          className={`stem-row__name${
+                            selectedArtifactId === artifact.id ? " stem-row__name--active" : ""
+                          }`}
+                          onClick={() => handleSelectStemArtifact(artifact)}
+                          type="button"
+                        >
+                          <span>{artifactLabel(artifact)}</span>
+                          <small>{stemOutputLabel(artifact.id)}</small>
+                        </button>
+                        <div className="stem-row__controls">
+                          <button
+                            className={`chip${state.muted ? " chip--active" : ""}`}
+                            aria-label={`Mute ${artifactLabel(artifact)}`}
+                            aria-pressed={state.muted}
+                            onClick={() => toggleStemControl(artifact, "muted")}
+                            type="button"
+                          >
+                            Mute
+                          </button>
+                          <button
+                            className={`chip${state.solo ? " chip--active" : ""}`}
+                            aria-label={`Solo ${artifactLabel(artifact)}`}
+                            aria-pressed={state.solo}
+                            onClick={() => toggleStemControl(artifact, "solo")}
+                            type="button"
+                          >
+                            Solo
+                          </button>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ) : null}
+
+            <audio
+              ref={primaryAudioRef}
+              src={
+                !isStemPlayback && selectedPlaybackArtifact
+                  ? api.streamArtifactUrl(selectedPlaybackArtifact.id)
+                  : undefined
+              }
+              preload="metadata"
+              className="player player--hidden"
+              onTimeUpdate={(event) => setPlaybackTimeSeconds(event.currentTarget.currentTime)}
+              onLoadedMetadata={(event) =>
+                setPlaybackDurationSeconds(event.currentTarget.duration)
+              }
+              onDurationChange={(event) =>
+                setPlaybackDurationSeconds(event.currentTarget.duration)
+              }
+              onEnded={() => setIsPlaying(false)}
+            />
+            {visibleStemArtifacts.map((artifact, index) => (
+              <audio
+                key={artifact.id}
+                ref={(element) => setStemAudioRef(artifact.id, element)}
+                src={api.streamArtifactUrl(artifact.id)}
+                preload="metadata"
+                className="player player--hidden"
+                onTimeUpdate={
+                  index === 0
+                    ? (event) => setPlaybackTimeSeconds(event.currentTarget.currentTime)
+                    : undefined
+                }
+                onLoadedMetadata={
+                  index === 0
+                    ? (event) => setPlaybackDurationSeconds(event.currentTarget.duration)
+                    : undefined
+                }
+                onDurationChange={
+                  index === 0
+                    ? (event) => setPlaybackDurationSeconds(event.currentTarget.duration)
+                    : undefined
+                }
+                onEnded={index === 0 ? () => setIsPlaying(false) : undefined}
+              />
+            ))}
+
+            <div className="playback-stage__footer">
+              <div>
+                <span className="metric-label">Playback</span>
+                <strong>{playbackClockSummary}</strong>
+              </div>
+              <div role="group" aria-label="Recent processing summary">
+                <span className="metric-label">Recent Processing</span>
+                {recentJobs.length ? (
+                  <ul className="session-jobs">
+                    {recentJobs.map((job) => (
+                      <li key={job.id}>
+                        <span>{job.type}</span>
+                        <small>{job.status}</small>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="artifact-meta">No processing jobs yet.</p>
+                )}
+              </div>
+            </div>
           </div>
 
           <div className="panel">
             <div className="panel-heading">
               <div>
                 <h2>Jobs and History</h2>
-                <p className="subpanel__copy">Processing stays out of the way until you need to inspect it.</p>
+                {showSupportingCopy ? (
+                  <p className="subpanel__copy">
+                    Raw artifacts and job logs stay available without crowding playback.
+                  </p>
+                ) : null}
               </div>
             </div>
 
@@ -925,7 +1471,9 @@ export function ProjectView() {
                         <span>{artifactLabel(artifact)}</span>
                         <small>{artifact.format.toUpperCase()}</small>
                         <small>{formatArtifactTimestamp(artifact.created_at)}</small>
-                        {artifactSummary(artifact) ? <small>{artifactSummary(artifact)}</small> : null}
+                        {artifactSummary(artifact) ? (
+                          <small>{artifactSummary(artifact)}</small>
+                        ) : null}
                       </li>
                     ))
                   ) : (
@@ -942,12 +1490,9 @@ export function ProjectView() {
                           <span>{job.status}</span>
                         </div>
                         <progress max={100} value={job.progress} />
-                        {["pending", "running"].includes(job.status) ? (
-                          <button className="button button--ghost button--small" onClick={() => api.cancelJob(job.id)} type="button">
-                            Cancel
-                          </button>
+                        {job.error_message ? (
+                          <small className="inline-error">{job.error_message}</small>
                         ) : null}
-                        {job.error_message ? <small className="inline-error">{job.error_message}</small> : null}
                       </li>
                     ))
                   ) : (
@@ -960,12 +1505,16 @@ export function ProjectView() {
         </div>
 
         {inspectorOpen ? (
-          <div className="stack">
+          <aside className="stack">
             <div className="panel inspector-panel">
               <div className="panel-heading">
                 <div>
                   <h2>Inspector</h2>
-                  <p className="subpanel__copy">Mix controls and project details stay nearby without taking over the practice surface.</p>
+                  {showSupportingCopy ? (
+                    <p className="subpanel__copy">
+                      Mix decisions stay compact and close to playback.
+                    </p>
+                  ) : null}
                 </div>
               </div>
 
@@ -973,7 +1522,6 @@ export function ProjectView() {
                 <div className="subpanel">
                   <div className="subpanel__header">
                     <h3>Mix Builder</h3>
-                    <p className="subpanel__copy">Build alternate practice mixes from tuning and key controls.</p>
                   </div>
                   <div className="controls">
                     <label>
@@ -981,7 +1529,9 @@ export function ProjectView() {
                       <select
                         aria-label="Retune"
                         value={retuneMode}
-                        onChange={(event) => setRetuneMode(event.target.value as "off" | "reference" | "cents")}
+                        onChange={(event) =>
+                          setRetuneMode(event.target.value as "off" | "reference" | "cents")
+                        }
                       >
                         <option value="off">Off</option>
                         <option value="reference">Target Reference Hz</option>
@@ -1023,15 +1573,20 @@ export function ProjectView() {
                         <strong>{formatKey(sourceKey)}</strong>
                         <small className="artifact-meta">
                           {manualSourceKey
-                            ? "Using manual source key"
+                            ? "Manual"
                             : detectedKey
-                              ? "Detected automatically"
-                              : "Set manually if the analysis is wrong"}
+                              ? "Detected"
+                              : "Set manually"}
                         </small>
                       </div>
                       <div>
                         <span className="metric-label">Target Key</span>
                         <strong>{formatKey(targetKey)}</strong>
+                      </div>
+                      <div>
+                        <span className="metric-label">Capo</span>
+                        <strong>{capoSummary}</strong>
+                        <small className="artifact-meta">Practice cue</small>
                       </div>
                       <span className="key-shift__meta">{formatSemitoneShift(transposeSemitones)}</span>
                     </div>
@@ -1042,7 +1597,9 @@ export function ProjectView() {
                         aria-label="Lower target key"
                         onClick={() => {
                           setTargetDirty(true);
-                          setTargetKeyState((current) => transposeKey(current ?? sourceKey, -1));
+                          setTargetKeyState((current) =>
+                            transposeKey(current ?? sourceKey, -1),
+                          );
                         }}
                         type="button"
                       >
@@ -1070,7 +1627,9 @@ export function ProjectView() {
                         aria-label="Raise target key"
                         onClick={() => {
                           setTargetDirty(true);
-                          setTargetKeyState((current) => transposeKey(current ?? sourceKey, 1));
+                          setTargetKeyState((current) =>
+                            transposeKey(current ?? sourceKey, 1),
+                          );
                         }}
                         type="button"
                       >
@@ -1087,10 +1646,18 @@ export function ProjectView() {
                             aria-label="Current Key"
                             value={currentKeyValue}
                             onChange={(event) =>
-                              setManualSourceKey(event.target.value === "auto" ? null : deserializeKey(event.target.value))
+                              setManualSourceKey(
+                                event.target.value === "auto"
+                                  ? null
+                                  : deserializeKey(event.target.value),
+                              )
                             }
                           >
-                            {detectedKey ? <option value="auto">Use detected key ({formatKey(detectedKey)})</option> : null}
+                            {detectedKey ? (
+                              <option value="auto">
+                                Use detected key ({formatKey(detectedKey)})
+                              </option>
+                            ) : null}
                             {MUSICAL_KEYS.map((key) => (
                               <option key={key.value} value={key.value}>
                                 {key.label}
@@ -1099,49 +1666,88 @@ export function ProjectView() {
                           </select>
                         </label>
                       </div>
-                      <p className="setting-copy">
-                        This does not change the audio by itself. It only changes how the target key is calculated.
-                      </p>
                     </details>
                   </div>
 
                   {previewMutation.isError ? (
                     <p className="inline-error">
-                      {previewMutation.error instanceof Error ? previewMutation.error.message : "Could not create preview."}
+                      {previewMutation.error instanceof Error
+                        ? previewMutation.error.message
+                        : "Could not create preview."}
                     </p>
                   ) : null}
                 </div>
 
                 <div className="subpanel">
-                  <div className="subpanel__header">
-                    <h3>Analysis</h3>
-                    <p className="subpanel__copy">Reference data for tuning and key decisions.</p>
+                  <div className="panel-heading panel-heading--compact">
+                    <div>
+                      <h3>Analysis</h3>
+                    </div>
+                    <button
+                      className="button button--small"
+                      onClick={() => analyzeMutation.mutate()}
+                      disabled={analyzeMutation.isPending || isAnalysisRunning}
+                      type="button"
+                    >
+                      {analyzeMutation.isPending || isAnalysisRunning
+                        ? "Analyzing..."
+                        : analysisQuery.data
+                          ? "Refresh Analysis"
+                          : "Analyze Track"}
+                    </button>
                   </div>
-                  {isAnalysisRunning ? <p className="setting-copy">Analyzing source track…</p> : null}
                   <div className="analysis-grid">
                     <div>
                       <span className="metric-label">Detected Tuning</span>
-                      <strong>{analysisQuery.data?.estimated_reference_hz?.toFixed(2) ?? "Pending"} Hz</strong>
+                      <strong>
+                        {analysisQuery.data?.estimated_reference_hz?.toFixed(2) ?? "Pending"} Hz
+                      </strong>
                     </div>
                     <div>
-                      <span className="metric-label">Offset from A440</span>
-                      <strong>{analysisQuery.data?.tuning_offset_cents?.toFixed(2) ?? "—"} cents</strong>
+                      <span className="metric-label">Offset</span>
+                      <strong>
+                        {analysisQuery.data?.tuning_offset_cents?.toFixed(2) ?? "-"} cents
+                      </strong>
                     </div>
                     <div>
                       <span className="metric-label">Estimated Key</span>
-                      <strong>{detectedKey ? formatKey(detectedKey) : isAnalysisRunning ? "Analyzing…" : "Unknown"}</strong>
+                      <strong>
+                        {detectedKey
+                          ? formatKey(detectedKey)
+                          : isAnalysisRunning
+                            ? "Analyzing..."
+                            : "Unknown"}
+                      </strong>
                     </div>
                     <div>
                       <span className="metric-label">Confidence</span>
-                      <strong>{analysisQuery.data?.key_confidence?.toFixed(2) ?? "—"}</strong>
+                      <strong>{analysisQuery.data?.key_confidence?.toFixed(2) ?? "-"}</strong>
                     </div>
                   </div>
+                </div>
+
+                <div className="subpanel subpanel--compact">
+                  <div className="subpanel__header">
+                    <h3>Export</h3>
+                    {showSupportingCopy ? (
+                      <p className="subpanel__copy">
+                        Export only when you need audio outside the app.
+                      </p>
+                    ) : null}
+                  </div>
+                  <button
+                    className="button"
+                    onClick={() => exportMutation.mutate()}
+                    disabled={exportMutation.isPending}
+                    type="button"
+                  >
+                    {exportMutation.isPending ? "Queueing..." : "Export Selected Audio"}
+                  </button>
                 </div>
 
                 <div className="subpanel">
                   <div className="subpanel__header">
                     <h3>Project Details</h3>
-                    <p className="subpanel__copy">Useful context when you need it, not center stage all the time.</p>
                   </div>
                   <dl className="meta-grid">
                     <div>
@@ -1156,37 +1762,36 @@ export function ProjectView() {
                       <dt>Channels</dt>
                       <dd>{projectQuery.data?.channels ?? "Unknown"}</dd>
                     </div>
+                    <div>
+                      <dt>Selected Source</dt>
+                      <dd>{selectedPrimaryArtifact ? fileNameFromPath(selectedPrimaryArtifact.path) : "-"}</dd>
+                    </div>
                   </dl>
 
-                  <details className="details-block">
-                    <summary>Show file details</summary>
-                    <dl className="details-grid">
-                      <div>
-                        <dt>Imported Path</dt>
-                        <dd className="path">{projectQuery.data?.imported_path ?? "Unknown"}</dd>
-                      </div>
-                      <div>
-                        <dt>Original Source</dt>
-                        <dd className="path">{projectQuery.data?.source_path ?? "Unknown"}</dd>
-                      </div>
-                    </dl>
-                  </details>
-                </div>
-
-                <div className="subpanel subpanel--compact">
-                  <div className="subpanel__header">
-                    <h3>Export</h3>
-                    <p className="subpanel__copy">Use this only when you need a file outside the app.</p>
-                  </div>
-                  <button className="button" onClick={() => exportMutation.mutate()} disabled={exportMutation.isPending}>
-                    {exportMutation.isPending ? "Queueing…" : "Export Selected Audio"}
-                  </button>
+                  {metadataRevealMode === "expand" ? (
+                    <details className="details-block">
+                      <summary>Show file details</summary>
+                      <dl className="details-grid details-grid--single-column">
+                        <div>
+                          <dt>Imported Path</dt>
+                          <dd className="path">{projectQuery.data?.imported_path ?? "Unknown"}</dd>
+                        </div>
+                        <div>
+                          <dt>Original Source</dt>
+                          <dd className="path">{projectQuery.data?.source_path ?? "Unknown"}</dd>
+                        </div>
+                      </dl>
+                    </details>
+                  ) : (
+                    <p className="artifact-meta" title={projectQuery.data?.source_path ?? ""}>
+                      Hover for file path
+                    </p>
+                  )}
                 </div>
 
                 <div className="subpanel subpanel--compact subpanel--danger">
                   <div className="subpanel__header">
                     <h3>Danger Zone</h3>
-                    <p className="subpanel__copy">Destructive actions stay separate from everyday practice actions.</p>
                   </div>
                   <div className="button-row">
                     {canDeleteSelectedMix ? (
@@ -1196,17 +1801,22 @@ export function ProjectView() {
                         disabled={deleteMixMutation.isPending}
                         type="button"
                       >
-                        {deleteMixMutation.isPending ? "Deleting…" : "Delete Practice Mix"}
+                        {deleteMixMutation.isPending ? "Deleting..." : "Delete Practice Mix"}
                       </button>
                     ) : null}
-                    <button className="button button--ghost button--small" onClick={handleDeleteProject} disabled={deleteMutation.isPending}>
+                    <button
+                      className="button button--ghost button--small"
+                      onClick={handleDeleteProject}
+                      disabled={deleteMutation.isPending}
+                      type="button"
+                    >
                       Delete Project
                     </button>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
+          </aside>
         ) : null}
       </div>
     </section>

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -1,5 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../../lib/api";
+import {
+  usePreferences,
+  type InformationDensity,
+  type LayoutDensity,
+  type MetadataRevealMode,
+} from "../../lib/preferences";
 import { useTheme, type ThemePreference } from "../../lib/theme";
 
 function themePreferenceLabel(themePreference: ThemePreference) {
@@ -9,8 +15,35 @@ function themePreferenceLabel(themePreference: ThemePreference) {
   return themePreference === "dark" ? "Dark" : "Light";
 }
 
+function densityLabel(value: InformationDensity) {
+  if (value === "minimal") return "Minimal";
+  if (value === "detailed") return "Detailed";
+  return "Balanced";
+}
+
+function layoutDensityLabel(value: LayoutDensity) {
+  return value === "compact" ? "Compact" : "Comfortable";
+}
+
+function metadataRevealLabel(value: MetadataRevealMode) {
+  return value === "hover" ? "Hover" : "Expand";
+}
+
 export function SettingsView() {
   const { effectiveTheme, themePreference, setThemePreference } = useTheme();
+  const {
+    informationDensity,
+    layoutDensity,
+    helperTextVisible,
+    defaultInspectorOpen,
+    metadataRevealMode,
+    setInformationDensity,
+    setLayoutDensity,
+    setHelperTextVisible,
+    setDefaultInspectorOpen,
+    setMetadataRevealMode,
+    resetPreferences,
+  } = usePreferences();
   const healthQuery = useQuery({
     queryKey: ["health"],
     queryFn: api.getHealth,
@@ -19,19 +52,24 @@ export function SettingsView() {
   return (
     <section className="screen">
       <div className="screen__header">
-        <div>
+        <div className="screen__title-block">
           <p className="eyebrow">Settings</p>
-          <h1>Backend and Storage</h1>
+          <h1>Playback Surface</h1>
           <p className="screen__subtitle">
-            Tuneforge keeps audio, analysis, and generated exports local by default.
+            TuneForge stays theme-aware while giving you control over density, metadata, and inspector defaults.
           </p>
         </div>
       </div>
 
-      <div className="layout-grid layout-grid--tight">
+      <div className="layout-grid settings-grid">
         <div className="panel">
-          <h2>Appearance</h2>
-          <div className="controls controls--compact">
+          <div className="panel-heading">
+            <div>
+              <h2>Appearance</h2>
+              <p className="subpanel__copy">Theme behavior stays compatible with light, dark, and follow-system modes.</p>
+            </div>
+          </div>
+          <div className="controls">
             <label>
               Theme
               <select
@@ -44,20 +82,115 @@ export function SettingsView() {
                 <option value="system">Follow system</option>
               </select>
             </label>
+
+            <label>
+              Information Density
+              <select
+                aria-label="Information Density"
+                value={informationDensity}
+                onChange={(event) => setInformationDensity(event.target.value as InformationDensity)}
+              >
+                <option value="minimal">Minimal</option>
+                <option value="balanced">Balanced</option>
+                <option value="detailed">Detailed</option>
+              </select>
+            </label>
+
+            <label>
+              Layout Density
+              <select
+                aria-label="Layout Density"
+                value={layoutDensity}
+                onChange={(event) => setLayoutDensity(event.target.value as LayoutDensity)}
+              >
+                <option value="comfortable">Comfortable</option>
+                <option value="compact">Compact</option>
+              </select>
+            </label>
           </div>
-          <p className="setting-copy">
-            Dark is the default. Choose system if you want Tuneforge to follow the operating system appearance.
-          </p>
+
           <dl className="meta-grid">
             <div>
-              <dt>Preference</dt>
+              <dt>Theme Preference</dt>
               <dd>{themePreferenceLabel(themePreference)}</dd>
             </div>
             <div>
               <dt>Active Theme</dt>
               <dd>{themePreferenceLabel(effectiveTheme)}</dd>
             </div>
+            <div>
+              <dt>Information Density</dt>
+              <dd>{densityLabel(informationDensity)}</dd>
+            </div>
+            <div>
+              <dt>Layout Density</dt>
+              <dd>{layoutDensityLabel(layoutDensity)}</dd>
+            </div>
           </dl>
+        </div>
+
+        <div className="panel">
+          <div className="panel-heading">
+            <div>
+              <h2>Visibility Defaults</h2>
+              <p className="subpanel__copy">Hide low-value copy by default while keeping technical detail one action away.</p>
+            </div>
+          </div>
+
+          <div className="controls">
+            <label className="checkbox">
+              <input
+                aria-label="Show helper text"
+                checked={helperTextVisible}
+                onChange={(event) => setHelperTextVisible(event.target.checked)}
+                type="checkbox"
+              />
+              Show helper text
+            </label>
+
+            <label className="checkbox">
+              <input
+                aria-label="Open inspector by default"
+                checked={defaultInspectorOpen}
+                onChange={(event) => setDefaultInspectorOpen(event.target.checked)}
+                type="checkbox"
+              />
+              Open inspector by default
+            </label>
+
+            <label>
+              Metadata Reveal
+              <select
+                aria-label="Metadata Reveal"
+                value={metadataRevealMode}
+                onChange={(event) => setMetadataRevealMode(event.target.value as MetadataRevealMode)}
+              >
+                <option value="expand">Expand on click</option>
+                <option value="hover">Hover for path</option>
+              </select>
+            </label>
+          </div>
+
+          <dl className="meta-grid">
+            <div>
+              <dt>Helper Text</dt>
+              <dd>{helperTextVisible ? "Visible" : "Hidden"}</dd>
+            </div>
+            <div>
+              <dt>Inspector Default</dt>
+              <dd>{defaultInspectorOpen ? "Open" : "Collapsed"}</dd>
+            </div>
+            <div>
+              <dt>Metadata Reveal</dt>
+              <dd>{metadataRevealLabel(metadataRevealMode)}</dd>
+            </div>
+          </dl>
+
+          <div className="button-row">
+            <button className="button button--ghost button--small" type="button" onClick={resetPreferences}>
+              Reset UI Defaults
+            </button>
+          </div>
         </div>
 
         <div className="panel">
@@ -85,7 +218,9 @@ export function SettingsView() {
         <div className="panel">
           <h2>Storage</h2>
           <p className="path">{healthQuery.data?.data_root ?? "Backend unavailable"}</p>
-          <p>Projects, previews, exported files, and the SQLite database are stored under this local data root.</p>
+          <p className="setting-copy">
+            Projects, previews, exported files, and the local database stay under this root.
+          </p>
         </div>
       </div>
     </section>

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -106,7 +106,12 @@ export function getApiBaseUrl() {
 
 export const api = {
   getHealth: () => unwrap(client.GET("/api/v1/health")),
-  listProjects: () => unwrap(client.GET("/api/v1/projects")),
+  listProjects: (search?: string) =>
+    unwrap(
+      client.GET("/api/v1/projects", {
+        params: search ? ({ query: { search } } as never) : undefined,
+      }),
+    ),
   importProject: (body: components["schemas"]["ProjectImportRequest"]) =>
     unwrap(client.POST("/api/v1/projects/import", { body })),
   getProject: (projectId: string) => unwrap(client.GET("/api/v1/projects/{project_id}", { params: { path: { project_id: projectId } } })),

--- a/apps/desktop/src/lib/preferences.tsx
+++ b/apps/desktop/src/lib/preferences.tsx
@@ -1,0 +1,158 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useMemo, useState, type ReactNode } from "react";
+
+export type InformationDensity = "minimal" | "balanced" | "detailed";
+export type LayoutDensity = "compact" | "comfortable";
+export type MetadataRevealMode = "hover" | "expand";
+
+export type UiPreferences = {
+  informationDensity: InformationDensity;
+  layoutDensity: LayoutDensity;
+  helperTextVisible: boolean;
+  defaultInspectorOpen: boolean;
+  metadataRevealMode: MetadataRevealMode;
+};
+
+type PreferencesContextValue = UiPreferences & {
+  setInformationDensity: (value: InformationDensity) => void;
+  setLayoutDensity: (value: LayoutDensity) => void;
+  setHelperTextVisible: (value: boolean) => void;
+  setDefaultInspectorOpen: (value: boolean) => void;
+  setMetadataRevealMode: (value: MetadataRevealMode) => void;
+  resetPreferences: () => void;
+};
+
+const STORAGE_KEY = "tuneforge.ui-preferences";
+
+const DEFAULT_PREFERENCES: UiPreferences = {
+  informationDensity: "balanced",
+  layoutDensity: "comfortable",
+  helperTextVisible: true,
+  defaultInspectorOpen: true,
+  metadataRevealMode: "expand",
+};
+
+const PreferencesContext = createContext<PreferencesContextValue | null>(null);
+
+function isInformationDensity(value: unknown): value is InformationDensity {
+  return value === "minimal" || value === "balanced" || value === "detailed";
+}
+
+function isLayoutDensity(value: unknown): value is LayoutDensity {
+  return value === "compact" || value === "comfortable";
+}
+
+function isMetadataRevealMode(value: unknown): value is MetadataRevealMode {
+  return value === "hover" || value === "expand";
+}
+
+function normalizePreferences(value: unknown): UiPreferences {
+  if (!value || typeof value !== "object") {
+    return DEFAULT_PREFERENCES;
+  }
+
+  const candidate = value as Partial<UiPreferences>;
+  return {
+    informationDensity: isInformationDensity(candidate.informationDensity)
+      ? candidate.informationDensity
+      : DEFAULT_PREFERENCES.informationDensity,
+    layoutDensity: isLayoutDensity(candidate.layoutDensity)
+      ? candidate.layoutDensity
+      : DEFAULT_PREFERENCES.layoutDensity,
+    helperTextVisible:
+      typeof candidate.helperTextVisible === "boolean"
+        ? candidate.helperTextVisible
+        : DEFAULT_PREFERENCES.helperTextVisible,
+    defaultInspectorOpen:
+      typeof candidate.defaultInspectorOpen === "boolean"
+        ? candidate.defaultInspectorOpen
+        : DEFAULT_PREFERENCES.defaultInspectorOpen,
+    metadataRevealMode: isMetadataRevealMode(candidate.metadataRevealMode)
+      ? candidate.metadataRevealMode
+      : DEFAULT_PREFERENCES.metadataRevealMode,
+  };
+}
+
+function readStoredPreferences(): UiPreferences {
+  if (typeof window === "undefined") {
+    return DEFAULT_PREFERENCES;
+  }
+
+  const storedValue = window.localStorage.getItem(STORAGE_KEY);
+  if (!storedValue) {
+    return DEFAULT_PREFERENCES;
+  }
+
+  try {
+    return normalizePreferences(JSON.parse(storedValue));
+  } catch {
+    return DEFAULT_PREFERENCES;
+  }
+}
+
+function persistPreferences(preferences: UiPreferences) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences));
+}
+
+export function PreferencesProvider({ children }: { children: ReactNode }) {
+  const [preferences, setPreferences] = useState<UiPreferences>(readStoredPreferences);
+
+  const value = useMemo<PreferencesContextValue>(
+    () => ({
+      ...preferences,
+      setInformationDensity: (informationDensity) => {
+        setPreferences((current) => {
+          const next = { ...current, informationDensity };
+          persistPreferences(next);
+          return next;
+        });
+      },
+      setLayoutDensity: (layoutDensity) => {
+        setPreferences((current) => {
+          const next = { ...current, layoutDensity };
+          persistPreferences(next);
+          return next;
+        });
+      },
+      setHelperTextVisible: (helperTextVisible) => {
+        setPreferences((current) => {
+          const next = { ...current, helperTextVisible };
+          persistPreferences(next);
+          return next;
+        });
+      },
+      setDefaultInspectorOpen: (defaultInspectorOpen) => {
+        setPreferences((current) => {
+          const next = { ...current, defaultInspectorOpen };
+          persistPreferences(next);
+          return next;
+        });
+      },
+      setMetadataRevealMode: (metadataRevealMode) => {
+        setPreferences((current) => {
+          const next = { ...current, metadataRevealMode };
+          persistPreferences(next);
+          return next;
+        });
+      },
+      resetPreferences: () => {
+        persistPreferences(DEFAULT_PREFERENCES);
+        setPreferences(DEFAULT_PREFERENCES);
+      },
+    }),
+    [preferences],
+  );
+
+  return <PreferencesContext.Provider value={value}>{children}</PreferencesContext.Provider>;
+}
+
+export function usePreferences() {
+  const context = useContext(PreferencesContext);
+  if (!context) {
+    throw new Error("usePreferences must be used within PreferencesProvider.");
+  }
+  return context;
+}

--- a/apps/desktop/src/setupTests.ts
+++ b/apps/desktop/src/setupTests.ts
@@ -49,3 +49,13 @@ Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
   writable: true,
   value: vi.fn(),
 });
+
+Object.defineProperty(window.HTMLMediaElement.prototype, "play", {
+  writable: true,
+  value: vi.fn().mockResolvedValue(undefined),
+});
+
+Object.defineProperty(window.HTMLMediaElement.prototype, "pause", {
+  writable: true,
+  value: vi.fn(),
+});

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -11,12 +11,15 @@
   --accent-strong: #67e8f9;
   --eyebrow-text: #83e7cb;
   --app-background:
-    radial-gradient(circle at top left, rgba(64, 131, 184, 0.2), transparent 28%),
+    radial-gradient(circle at top left, rgba(64, 131, 184, 0.18), transparent 28%),
     radial-gradient(circle at bottom right, rgba(52, 211, 153, 0.14), transparent 30%),
     linear-gradient(160deg, #07111d 0%, #0b1623 44%, #101b2b 100%);
   --panel: rgba(9, 18, 31, 0.82);
+  --panel-strong: rgba(7, 16, 27, 0.92);
   --panel-border: rgba(148, 163, 184, 0.18);
   --panel-shadow: rgba(2, 6, 23, 0.32);
+  --surface-muted: rgba(7, 16, 27, 0.64);
+  --surface-highlight: rgba(52, 211, 153, 0.12);
   --sidebar-bg: rgba(2, 6, 23, 0.88);
   --sidebar-text: #f8fafc;
   --sidebar-muted: rgba(226, 232, 240, 0.68);
@@ -30,10 +33,10 @@
   --input-bg: rgba(5, 13, 24, 0.9);
   --input-border: rgba(148, 163, 184, 0.24);
   --input-text: #f8fafc;
-  --project-card-bg: linear-gradient(165deg, rgba(10, 27, 46, 0.96), rgba(18, 76, 94, 0.84));
-  --project-card-shadow: rgba(2, 6, 23, 0.34);
+  --project-card-bg: linear-gradient(165deg, rgba(10, 27, 46, 0.94), rgba(15, 48, 67, 0.9));
+  --project-card-shadow: rgba(2, 6, 23, 0.28);
   --card-muted: rgba(226, 232, 240, 0.72);
-  --chip-bg: rgba(15, 23, 42, 0.76);
+  --chip-bg: rgba(15, 23, 42, 0.72);
   --chip-border: rgba(148, 163, 184, 0.2);
   --chip-active-bg: rgba(52, 211, 153, 0.14);
   --chip-active-border: rgba(52, 211, 153, 0.45);
@@ -42,7 +45,7 @@
 
 :root[data-theme="light"] {
   color-scheme: light;
-  --text: #111827;
+  --text: #102a43;
   --muted: #5b6470;
   --danger: #9b1c1c;
   --accent: #0f766e;
@@ -50,11 +53,14 @@
   --eyebrow-text: #0a4f4a;
   --app-background:
     radial-gradient(circle at top left, rgba(244, 199, 129, 0.32), transparent 30%),
-    radial-gradient(circle at bottom right, rgba(43, 86, 111, 0.18), transparent 28%),
+    radial-gradient(circle at bottom right, rgba(43, 86, 111, 0.14), transparent 28%),
     #f3eee8;
   --panel: rgba(255, 255, 255, 0.82);
+  --panel-strong: rgba(255, 255, 255, 0.94);
   --panel-border: rgba(17, 24, 39, 0.08);
   --panel-shadow: rgba(17, 24, 39, 0.08);
+  --surface-muted: rgba(241, 245, 249, 0.9);
+  --surface-highlight: rgba(15, 118, 110, 0.1);
   --sidebar-bg: rgba(14, 33, 50, 0.92);
   --sidebar-text: #f6f2eb;
   --sidebar-muted: rgba(246, 242, 235, 0.72);
@@ -68,10 +74,10 @@
   --input-bg: rgba(255, 255, 255, 0.92);
   --input-border: rgba(17, 24, 39, 0.12);
   --input-text: #102a43;
-  --project-card-bg: rgba(18, 52, 73, 0.9);
-  --project-card-shadow: rgba(18, 52, 73, 0.18);
-  --card-muted: rgba(246, 242, 235, 0.72);
-  --chip-bg: rgba(255, 255, 255, 0.78);
+  --project-card-bg: rgba(16, 54, 76, 0.96);
+  --project-card-shadow: rgba(18, 52, 73, 0.16);
+  --card-muted: rgba(246, 242, 235, 0.74);
+  --chip-bg: rgba(255, 255, 255, 0.82);
   --chip-border: rgba(15, 118, 110, 0.2);
   --chip-active-bg: rgba(15, 118, 110, 0.16);
   --chip-active-border: rgba(15, 118, 110, 0.45);
@@ -96,7 +102,8 @@ body {
 
 button,
 input,
-select {
+select,
+progress {
   font: inherit;
 }
 
@@ -109,6 +116,18 @@ a {
   display: grid;
   grid-template-columns: 240px minmax(0, 1fr);
   min-height: 100vh;
+}
+
+.app-shell[data-layout-density="compact"] {
+  --screen-gap: 1rem;
+  --screen-padding: 1.5rem;
+  --panel-padding: 1rem;
+}
+
+.app-shell[data-layout-density="comfortable"] {
+  --screen-gap: 1.35rem;
+  --screen-padding: 2rem;
+  --panel-padding: 1.25rem;
 }
 
 .sidebar {
@@ -160,13 +179,13 @@ a {
 }
 
 .main-content {
-  padding: 2rem;
+  padding: var(--screen-padding, 2rem);
 }
 
 .screen {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: var(--screen-gap, 1.35rem);
 }
 
 .screen__header {
@@ -178,69 +197,76 @@ a {
 
 .screen__header h1 {
   font-family: "Iowan Old Style", "Palatino Linotype", serif;
-  font-size: 2.3rem;
+  font-size: clamp(2.2rem, 4vw, 3.4rem);
   margin: 0;
+  line-height: 1.04;
+}
+
+.screen__header--library {
+  align-items: end;
 }
 
 .screen__title-block {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-}
-
-.title-row {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-}
-
-.title-edit {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-}
-
-.title-input {
-  min-width: min(36rem, 100%);
-  border: 1px solid var(--input-border);
-  border-radius: 18px;
-  padding: 0.8rem 1rem;
-  background: var(--input-bg);
-  color: var(--input-text);
-  font-size: 1.2rem;
-  font-weight: 700;
+  gap: 0.45rem;
 }
 
 .screen__subtitle {
   color: var(--muted);
-  max-width: 48rem;
-  margin: 0.5rem 0 0;
+  max-width: 52rem;
+  margin: 0;
 }
 
+.title-row,
+.title-edit,
 .button-row {
   display: flex;
-  flex-wrap: wrap;
+  align-items: center;
   gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.title-input,
+.search-field__input,
+.controls input,
+.controls select {
+  width: 100%;
+  border: 1px solid var(--input-border);
+  border-radius: 16px;
+  padding: 0.78rem 0.95rem;
+  background: var(--input-bg);
+  color: var(--input-text);
+}
+
+.title-input {
+  min-width: min(36rem, 100%);
+  font-size: 1.15rem;
+  font-weight: 700;
 }
 
 .button {
   border: 1px solid var(--button-border);
   background: var(--button-bg);
   color: var(--button-text);
-  padding: 0.8rem 1rem;
+  padding: 0.78rem 1rem;
   border-radius: 999px;
   cursor: pointer;
+  transition:
+    border-color 160ms ease,
+    transform 160ms ease,
+    background 160ms ease;
 }
 
 .button:hover {
   border-color: var(--button-hover-border);
+  transform: translateY(-1px);
 }
 
 .button:disabled {
   opacity: 0.65;
   cursor: wait;
+  transform: none;
 }
 
 .button--primary {
@@ -254,37 +280,36 @@ a {
 }
 
 .button--small {
-  padding: 0.55rem 0.9rem;
+  padding: 0.56rem 0.9rem;
 }
 
 .panel {
   background: var(--panel);
   backdrop-filter: blur(18px);
   border: 1px solid var(--panel-border);
-  border-radius: 24px;
-  padding: 1.25rem;
+  border-radius: 26px;
+  padding: var(--panel-padding, 1.25rem);
   box-shadow: 0 18px 40px var(--panel-shadow);
 }
 
-.panel h2 {
-  margin-top: 0;
-  margin-bottom: 1rem;
+.panel h2,
+.panel h3 {
+  margin: 0;
 }
 
 .panel-heading {
   display: flex;
   justify-content: space-between;
   gap: 1rem;
-  margin-bottom: 1rem;
+  align-items: flex-start;
 }
 
-.panel-heading h2,
-.panel-heading h3 {
-  margin: 0;
+.panel-heading--compact {
+  margin-bottom: 0.75rem;
 }
 
 .panel--error {
-  border-color: rgba(248, 113, 113, 0.35);
+  border-color: color-mix(in srgb, var(--danger) 55%, transparent);
   color: var(--danger);
 }
 
@@ -292,99 +317,194 @@ a {
   text-align: center;
 }
 
+.layout-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.settings-grid {
+  align-items: start;
+}
+
+.library-toolbar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: end;
+}
+
+.library-toolbar__summary {
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.search-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.search-field__label {
+  color: var(--muted);
+  font-size: 0.88rem;
+}
+
 .project-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: 1rem;
 }
 
 .project-card {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 1rem;
   padding: 1.25rem;
   background: var(--project-card-bg);
   color: #ffffff;
-  border-radius: 24px;
+  border-radius: 26px;
   box-shadow: 0 18px 36px var(--project-card-shadow);
-  min-height: 180px;
+  min-height: 260px;
 }
 
-.project-card__header {
+.project-card__meta-row,
+.project-card__stats {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 0.75rem;
+  flex-wrap: wrap;
+  gap: 0.55rem;
 }
 
-.project-card small {
+.pill,
+.stat-chip {
+  border: 1px solid color-mix(in srgb, var(--card-muted) 30%, transparent);
+  background: color-mix(in srgb, var(--panel-strong) 45%, transparent);
+  color: #ffffff;
+  padding: 0.35rem 0.72rem;
+  border-radius: 999px;
+  font-size: 0.83rem;
+}
+
+.project-card__link {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: start;
+}
+
+.project-card__title-block h2 {
+  margin: 0;
+  font-size: 1.55rem;
+  line-height: 1.12;
+}
+
+.project-card__summary {
+  margin: 0.45rem 0 0;
   color: var(--card-muted);
+  font-size: 1rem;
   word-break: break-word;
+}
+
+.project-card__open {
+  align-self: start;
+  color: #ffffff;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.card-details {
+  margin-top: auto;
+  border-top: 1px solid color-mix(in srgb, var(--card-muted) 18%, transparent);
+  padding-top: 0.85rem;
+}
+
+.card-details summary,
+.details-block summary {
+  cursor: pointer;
+  color: inherit;
+  font-weight: 600;
+}
+
+.artifact-meta,
+.path,
+.metric-label,
+.search-field__label,
+.meta-grid dt,
+.details-grid dt {
+  color: var(--muted);
 }
 
 .artifact-meta,
 .path {
-  color: var(--muted);
   word-break: break-word;
-}
-
-.layout-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
-  gap: 1rem;
-}
-
-.layout-grid--tight {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .project-workbench {
   display: grid;
-  grid-template-columns: minmax(280px, 0.9fr) minmax(0, 1.45fr) minmax(320px, 0.95fr);
+  grid-template-columns: minmax(270px, 0.9fr) minmax(0, 1.6fr) minmax(320px, 0.95fr);
   gap: 1rem;
   align-items: start;
 }
 
 .project-workbench--wide {
-  grid-template-columns: minmax(280px, 0.9fr) minmax(0, 1.7fr);
+  grid-template-columns: minmax(270px, 0.95fr) minmax(0, 1.95fr);
 }
 
-.stack {
+.stack,
+.section-stack,
+.rail-panel {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
-.meta-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
+.rail-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
 }
 
-.meta-grid dt,
-.metric-label {
+.rail-section + .rail-section {
+  padding-top: 1rem;
+  border-top: 1px solid var(--divider);
+}
+
+.rail-section__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.9rem;
+  align-items: start;
+}
+
+.subpanel {
+  border: 1px solid var(--divider);
+  border-radius: 20px;
+  padding: 1rem;
+  background: color-mix(in srgb, var(--panel-strong) 74%, transparent);
+}
+
+.subpanel--compact {
+  padding: 0.95rem 1rem;
+}
+
+.subpanel--danger {
+  border-color: color-mix(in srgb, var(--danger) 40%, transparent);
+}
+
+.subpanel__header {
+  margin-bottom: 0.85rem;
+}
+
+.subpanel__copy,
+.setting-copy {
   color: var(--muted);
-  font-size: 0.88rem;
-}
-
-.meta-grid dd {
-  margin: 0.25rem 0 0;
-}
-
-.analysis-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
+  margin: 0.3rem 0 0;
 }
 
 .controls {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 1rem;
-}
-
-.controls--compact {
-  grid-template-columns: minmax(0, 260px);
 }
 
 .controls--tight {
@@ -406,165 +526,45 @@ a {
   font-weight: 600;
 }
 
-.controls input,
-.controls select {
-  border: 1px solid var(--input-border);
-  border-radius: 14px;
-  padding: 0.75rem;
-  background: var(--input-bg);
-  color: var(--input-text);
+.controls .checkbox input {
+  width: auto;
 }
 
-.setting-copy {
-  color: var(--muted);
-  margin: 1rem 0 0;
-}
-
-.section-stack {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.subpanel {
-  border: 1px solid var(--divider);
-  border-radius: 18px;
-  padding: 1rem;
-}
-
-.subpanel--danger {
-  border-color: rgba(248, 113, 113, 0.2);
-}
-
-.subpanel__header {
-  margin-bottom: 1rem;
-}
-
-.subpanel__header h3 {
-  margin: 0;
-}
-
-.subpanel__copy {
-  color: var(--muted);
-  margin: 0.3rem 0 0;
-}
-
-.details-block {
-  margin-top: 1rem;
-  border-top: 1px solid var(--divider);
-  padding-top: 1rem;
-}
-
-.details-block summary {
-  cursor: pointer;
-  color: var(--muted);
-  font-weight: 600;
-}
-
-.details-block--flush {
-  margin-top: 0;
-  border-top: none;
-  padding-top: 0;
-}
-
-.details-grid {
+.meta-grid,
+.analysis-grid,
+.details-grid,
+.session-block {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1rem;
-  margin-top: 1rem;
 }
 
-.details-grid dt {
-  color: var(--muted);
-  font-size: 0.88rem;
+.details-grid--single-column {
+  grid-template-columns: 1fr;
 }
 
+.meta-grid dd,
 .details-grid dd {
-  margin: 0.3rem 0 0;
-}
-
-.key-shift {
-  margin-top: 1rem;
-  padding-top: 1rem;
-  border-top: 1px solid var(--divider);
-}
-
-.key-shift__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 1rem;
-  margin-bottom: 1rem;
-}
-
-.key-shift__header strong {
-  display: block;
-  margin-top: 0.25rem;
-  font-size: 1.8rem;
-  line-height: 1;
-}
-
-.key-shift__meta {
-  color: var(--muted);
-  font-size: 0.95rem;
-}
-
-.key-stepper {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  gap: 0.75rem;
-  align-items: stretch;
-}
-
-.key-stepper > .button {
-  min-width: 3.25rem;
-  padding-inline: 0;
-  font-size: 1.3rem;
-}
-
-.key-stepper__value {
-  display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
-  color: var(--muted);
-}
-
-.key-stepper__label {
-  font-size: 0.88rem;
-}
-
-.key-stepper__value select {
-  width: 100%;
-  min-height: 3.5rem;
-  font-size: 1.1rem;
-  font-weight: 700;
-  text-align: center;
-  text-align-last: center;
+  margin: 0.28rem 0 0;
 }
 
 .artifact-selector {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.55rem;
   flex-wrap: wrap;
-  margin-bottom: 1rem;
 }
 
 .artifact-selector--stacked {
   flex-direction: column;
 }
 
-.chip {
+.artifact-pill,
+.chip,
+.stem-row__name {
   border: 1px solid var(--chip-border);
   background: var(--chip-bg);
   color: var(--button-text);
-  border-radius: 999px;
-  padding: 0.4rem 0.8rem;
-  cursor: pointer;
-}
-
-.chip--active {
-  background: var(--chip-active-bg);
-  border-color: var(--chip-active-border);
+  border-radius: 18px;
 }
 
 .artifact-pill {
@@ -573,20 +573,19 @@ a {
   align-items: flex-start;
   gap: 0.2rem;
   width: 100%;
-  border: 1px solid var(--chip-border);
-  background: var(--chip-bg);
-  color: var(--button-text);
-  border-radius: 18px;
-  padding: 0.85rem 1rem;
+  padding: 0.9rem 1rem;
   cursor: pointer;
   text-align: left;
 }
 
-.artifact-pill:hover {
+.artifact-pill:hover,
+.stem-row__name:hover {
   border-color: var(--button-hover-border);
 }
 
-.artifact-pill--active {
+.artifact-pill--active,
+.chip--active,
+.stem-row__name--active {
   background: var(--chip-active-bg);
   border-color: var(--chip-active-border);
 }
@@ -600,51 +599,17 @@ a {
   font-size: 0.88rem;
 }
 
-.library-section {
-  display: flex;
-  flex-direction: column;
-  gap: 0.85rem;
-  margin-bottom: 1rem;
-}
-
-.library-section__header {
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  align-items: center;
-}
-
-.library-section__header h3 {
-  margin: 0;
-}
-
-.playback-focus {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 1rem;
-  margin-bottom: 0.5rem;
-}
-
-.playback-focus h3 {
-  margin: 0.15rem 0 0;
-}
-
 .playback-focus__meta {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 0.2rem;
+  gap: 0.25rem;
   color: var(--muted);
   font-size: 0.88rem;
 }
 
-.player {
-  width: 100%;
-}
-
 .playback-stage {
-  min-height: 640px;
+  min-height: 720px;
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -658,19 +623,74 @@ a {
 }
 
 .playback-stage__header h2 {
-  margin: 0.2rem 0 0;
-  font-size: 2.1rem;
+  margin-top: 0.2rem;
+  font-size: clamp(2rem, 3.3vw, 3rem);
+}
+
+.stage-surface {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.1rem;
+  border: 1px solid var(--divider);
+  border-radius: 24px;
+  background:
+    radial-gradient(circle at top left, color-mix(in srgb, var(--accent) 20%, transparent), transparent 36%),
+    linear-gradient(180deg, color-mix(in srgb, var(--panel-strong) 80%, transparent), transparent);
 }
 
 .playback-stage__summary {
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
-.playback-stage__lane {
+.session-block strong,
+.playback-stage__footer strong,
+.stem-mixer__summary strong {
+  display: block;
+  margin-top: 0.25rem;
+}
+
+.transport {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 1rem;
+  align-items: end;
+}
+
+.transport__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.transport__play {
+  min-width: 8rem;
+}
+
+.transport__scrubber {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.transport__scrubber input[type="range"] {
+  width: 100%;
+  accent-color: var(--accent);
+}
+
+.transport__times {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  color: var(--muted);
+}
+
+.playback-stage__lane,
+.stage-subsection {
   border: 1px solid var(--divider);
   border-radius: 22px;
   padding: 1rem;
-  background: rgba(8, 14, 24, 0.2);
+  background: color-mix(in srgb, var(--surface-muted) 76%, transparent);
 }
 
 .playback-stage__lane-header {
@@ -681,42 +701,24 @@ a {
   margin-bottom: 1rem;
 }
 
-.playback-stage__lane-header h3 {
-  margin: 0.25rem 0 0;
-}
-
-.playback-stage__footer {
-  display: grid;
-  grid-template-columns: minmax(0, 220px) minmax(0, 1fr);
-  gap: 1rem;
-  align-items: start;
-  border-top: 1px solid var(--divider);
-  padding-top: 1rem;
-}
-
-.playback-stage__footer strong {
-  display: block;
-  margin-top: 0.25rem;
-}
-
 .chord-preview-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.75rem;
-  margin-bottom: 1rem;
+  margin-bottom: 0.75rem;
 }
 
 .chord-card {
   border: 1px solid var(--divider);
   border-radius: 18px;
-  padding: 0.95rem 1rem;
-  background: rgba(5, 12, 22, 0.3);
+  padding: 1rem;
+  background: color-mix(in srgb, var(--panel-strong) 70%, transparent);
 }
 
 .chord-card strong {
   display: block;
   margin-top: 0.45rem;
-  font-size: 2rem;
+  font-size: clamp(2rem, 4vw, 2.6rem);
   line-height: 1;
 }
 
@@ -736,10 +738,10 @@ a {
 }
 
 .chord-segment {
-  min-width: 5.75rem;
+  min-width: 5.4rem;
   border-radius: 18px;
   border: 1px solid var(--divider);
-  background: rgba(15, 23, 42, 0.42);
+  background: color-mix(in srgb, var(--panel-strong) 68%, transparent);
   color: var(--text);
   padding: 0.85rem 0.95rem;
   display: flex;
@@ -764,9 +766,9 @@ a {
 }
 
 .chord-segment--active {
-  border-color: rgba(52, 211, 153, 0.55);
-  background: rgba(52, 211, 153, 0.16);
-  box-shadow: inset 0 0 0 1px rgba(52, 211, 153, 0.18);
+  border-color: color-mix(in srgb, var(--accent) 78%, transparent);
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent);
 }
 
 .chord-lane-empty {
@@ -775,40 +777,67 @@ a {
   padding: 1rem;
 }
 
-.inspector-panel {
-  position: sticky;
-  top: 2rem;
-}
-
-.panel-note {
-  margin-top: 1rem;
-  border-top: 1px solid var(--divider);
-  padding-top: 1rem;
+.stem-mixer {
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
+  gap: 0.75rem;
+}
+
+.stem-mixer__summary {
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--divider);
+}
+
+.stem-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.stem-row__name {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.2rem;
+  padding: 0.8rem 0.95rem;
+  cursor: pointer;
+  text-align: left;
+}
+
+.stem-row__name small {
   color: var(--muted);
 }
 
-.panel-note strong {
-  color: var(--text);
+.stem-row__controls {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
-.session-block {
+.chip {
+  padding: 0.45rem 0.85rem;
+  cursor: pointer;
+}
+
+.playback-stage__footer {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: minmax(0, 220px) minmax(0, 1fr);
   gap: 1rem;
+  align-items: start;
+  border-top: 1px solid var(--divider);
+  padding-top: 1rem;
 }
 
-.session-block strong {
-  display: block;
-  margin-bottom: 0.25rem;
-}
-
-.session-jobs {
+.session-jobs,
+.artifact-list,
+.job-list {
   list-style: none;
   margin: 0;
   padding: 0;
+}
+
+.session-jobs {
   display: flex;
   flex-direction: column;
   gap: 0.45rem;
@@ -820,6 +849,22 @@ a {
   gap: 0.75rem;
 }
 
+.details-block {
+  margin-top: 1rem;
+  border-top: 1px solid var(--divider);
+  padding-top: 1rem;
+}
+
+.details-block--flush {
+  margin-top: 0;
+  border-top: none;
+  padding-top: 0;
+}
+
+.details-block--inset {
+  margin-top: 1rem;
+}
+
 .details-stack {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -829,9 +874,6 @@ a {
 
 .artifact-list,
 .job-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
   display: flex;
   flex-direction: column;
   gap: 0.8rem;
@@ -858,8 +900,90 @@ a {
   gap: 1rem;
 }
 
+.key-shift {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--divider);
+}
+
+.key-shift__header {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
+  gap: 1rem;
+  align-items: start;
+  margin-bottom: 1rem;
+}
+
+.key-shift__header strong {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 1.6rem;
+  line-height: 1;
+}
+
+.key-shift__meta {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.key-stepper {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: stretch;
+}
+
+.key-stepper > .button {
+  min-width: 3.2rem;
+  padding-inline: 0;
+  font-size: 1.3rem;
+}
+
+.key-stepper__value {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  color: var(--muted);
+}
+
+.key-stepper__label {
+  font-size: 0.88rem;
+}
+
+.key-stepper__value select {
+  min-height: 3.5rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+  text-align: center;
+  text-align-last: center;
+}
+
+.inspector-panel {
+  position: sticky;
+  top: var(--screen-padding, 2rem);
+}
+
+.player--hidden {
+  position: absolute;
+  width: 0;
+  height: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
 .inline-error {
   color: var(--danger);
+}
+
+@media (max-width: 1200px) {
+  .project-workbench,
+  .project-workbench--wide {
+    grid-template-columns: 1fr;
+  }
+
+  .inspector-panel {
+    position: static;
+  }
 }
 
 @media (max-width: 1000px) {
@@ -877,48 +1001,39 @@ a {
     flex-direction: row;
   }
 
-  .layout-grid,
-  .layout-grid--tight,
-  .project-workbench,
-  .project-workbench--wide {
-    grid-template-columns: 1fr;
-  }
-
   .screen__header,
-  .playback-focus,
+  .screen__header--library,
   .playback-stage__header,
   .playback-stage__lane-header,
-  .session-block,
-  .details-grid {
+  .panel-heading,
+  .transport,
+  .library-toolbar {
     grid-template-columns: 1fr;
+    flex-direction: column;
   }
 
-  .screen__header,
-  .playback-focus,
-  .playback-stage__header,
-  .playback-stage__lane-header {
-    flex-direction: column;
+  .layout-grid,
+  .meta-grid,
+  .analysis-grid,
+  .details-grid,
+  .details-stack,
+  .playback-stage__summary,
+  .playback-stage__footer,
+  .chord-preview-grid,
+  .key-shift__header,
+  .stem-row {
+    grid-template-columns: 1fr;
   }
 
   .playback-focus__meta {
     align-items: flex-start;
   }
 
-  .playback-stage__footer,
-  .playback-stage__summary,
-  .chord-preview-grid {
+  .project-card__link {
     grid-template-columns: 1fr;
   }
 
-  .chord-timeline {
-    flex-direction: column;
-  }
-
-  .inspector-panel {
-    position: static;
-  }
-
-  .details-stack {
-    grid-template-columns: 1fr;
+  .project-card__open {
+    justify-self: start;
   }
 }

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -706,7 +706,10 @@ export interface operations {
     };
     projects_api_v1_projects_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Filter projects by display name or path. */
+                search?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -720,6 +723,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ProjectsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };


### PR DESCRIPTION
## Summary
- Refactor the desktop library, project, and settings screens into a calmer playback-first practice workspace.
- Add project search plus persisted UI visibility preferences while preserving theme switching behavior.
- Expand desktop user-flow coverage and backend project search coverage.

## Testing
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test --run`
- `cd apps/backend && uv run --python 3.11 pytest tests/test_projects.py`
