### PR TITLE
feat: add metallic theme token system

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -506,7 +506,7 @@ describe("Desktop app flows", () => {
     resetMockApiState();
     window.localStorage.clear();
     delete document.documentElement.dataset.theme;
-    document.documentElement.style.colorScheme = "";
+    document.documentElement.removeAttribute("style");
     mockOpen.mockReset();
     mockSave.mockReset();
     mockConfirm.mockReset();
@@ -734,6 +734,8 @@ describe("Desktop app flows", () => {
 
     expect(document.documentElement).toHaveAttribute("data-theme", "light");
     expect(window.localStorage.getItem("tuneforge.theme-preference")).toBe("light");
+    expect(document.documentElement.style.getPropertyValue("--color-bg-app")).toBe("#F4F7FB");
+    expect(document.documentElement.style.getPropertyValue("--component-playback-active")).toBe("#D9861A");
     expect(JSON.parse(window.localStorage.getItem("tuneforge.ui-preferences") ?? "{}")).toMatchObject({
       informationDensity: "detailed",
       layoutDensity: "compact",
@@ -760,6 +762,17 @@ describe("Desktop app flows", () => {
     await waitFor(() =>
       expect(document.documentElement).toHaveAttribute("data-theme", "dark"),
     );
+    expect(document.documentElement.style.getPropertyValue("--color-bg-app")).toBe("#070B13");
     expect(window.localStorage.getItem("tuneforge.theme-preference")).toBe("system");
+  });
+
+  it("renders the theme preview with dark and light samples", async () => {
+    renderApp(["/settings/theme-preview"]);
+
+    expect(await screen.findByRole("heading", { name: "Metal / Heat System" })).toBeInTheDocument();
+    expect(screen.getByText("Cold base. Warm action.")).toBeInTheDocument();
+    expect(screen.getByText("Paper, metal, and control.")).toBeInTheDocument();
+    expect(screen.getAllByText("Playback Active")).toHaveLength(2);
+    expect(screen.getByRole("link", { name: "Back to Settings" })).toHaveAttribute("href", "/settings");
   });
 });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2,6 +2,7 @@ import { NavLink, Route, Routes } from "react-router-dom";
 import { LibraryView } from "./features/projects/LibraryView";
 import { ProjectView } from "./features/projects/ProjectView";
 import { SettingsView } from "./features/settings/SettingsView";
+import { ThemePreviewView } from "./features/settings/ThemePreviewView";
 import { PreferencesProvider, usePreferences } from "./lib/preferences";
 import { ThemeProvider } from "./lib/theme";
 
@@ -27,6 +28,7 @@ function AppChrome() {
           <Route path="/" element={<LibraryView />} />
           <Route path="/projects/:projectId" element={<ProjectView />} />
           <Route path="/settings" element={<SettingsView />} />
+          <Route path="/settings/theme-preview" element={<ThemePreviewView />} />
         </Routes>
       </main>
     </div>

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
 import { api } from "../../lib/api";
 import {
   usePreferences,
@@ -190,6 +191,9 @@ export function SettingsView() {
             <button className="button button--ghost button--small" type="button" onClick={resetPreferences}>
               Reset UI Defaults
             </button>
+            <Link className="button button--ghost button--small" to="/settings/theme-preview">
+              Open Theme Preview
+            </Link>
           </div>
         </div>
 

--- a/apps/desktop/src/features/settings/ThemePreviewView.tsx
+++ b/apps/desktop/src/features/settings/ThemePreviewView.tsx
@@ -1,0 +1,292 @@
+import { Link } from "react-router-dom";
+import type { CSSProperties } from "react";
+import { useTheme } from "../../lib/theme";
+import { getThemeCssVariables, themeTokens, type ThemeMode, type ThemeTokens } from "../../lib/themeTokens";
+
+type TokenSection = {
+  title: string;
+  items: Array<{
+    label: string;
+    value: (tokens: ThemeTokens) => string;
+  }>;
+};
+
+const semanticSections: TokenSection[] = [
+  {
+    title: "Background",
+    items: [
+      { label: "App", value: (tokens) => tokens.bg.app },
+      { label: "Canvas", value: (tokens) => tokens.bg.canvas },
+      { label: "Panel", value: (tokens) => tokens.bg.panel },
+      { label: "Elevated", value: (tokens) => tokens.bg.elevated },
+      { label: "Inset", value: (tokens) => tokens.bg.inset },
+    ],
+  },
+  {
+    title: "Text",
+    items: [
+      { label: "Primary", value: (tokens) => tokens.text.primary },
+      { label: "Secondary", value: (tokens) => tokens.text.secondary },
+      { label: "Muted", value: (tokens) => tokens.text.muted },
+      { label: "Inverse", value: (tokens) => tokens.text.inverse },
+    ],
+  },
+  {
+    title: "Border",
+    items: [
+      { label: "Subtle", value: (tokens) => tokens.border.subtle },
+      { label: "Default", value: (tokens) => tokens.border.default },
+      { label: "Strong", value: (tokens) => tokens.border.strong },
+    ],
+  },
+  {
+    title: "Accent",
+    items: [
+      { label: "Cool", value: (tokens) => tokens.accent.cool },
+      { label: "Cool Hover", value: (tokens) => tokens.accent.coolHover },
+      { label: "Cool Soft", value: (tokens) => tokens.accent.coolSoft },
+      { label: "Warm", value: (tokens) => tokens.accent.warm },
+      { label: "Warm Strong", value: (tokens) => tokens.accent.warmStrong },
+      { label: "Warm Deep", value: (tokens) => tokens.accent.warmDeep },
+      { label: "Warm Soft", value: (tokens) => tokens.accent.warmSoft },
+    ],
+  },
+  {
+    title: "State",
+    items: [
+      { label: "Success", value: (tokens) => tokens.state.success },
+      { label: "Warning", value: (tokens) => tokens.state.warning },
+      { label: "Danger", value: (tokens) => tokens.state.danger },
+      { label: "Info", value: (tokens) => tokens.state.info },
+      { label: "Hover", value: (tokens) => tokens.interaction.hover },
+      { label: "Focus Ring", value: (tokens) => tokens.interaction.focusRing },
+    ],
+  },
+];
+
+const componentSections: TokenSection[] = [
+  {
+    title: "Components",
+    items: [
+      { label: "Sidebar", value: (tokens) => tokens.component.sidebarBg },
+      { label: "Card", value: (tokens) => tokens.component.cardBg },
+      { label: "Card Selected", value: (tokens) => tokens.component.cardSelectedBg },
+      { label: "Inspector", value: (tokens) => tokens.component.inspectorBg },
+      { label: "Playback Active", value: (tokens) => tokens.component.playbackActive },
+      { label: "Playback Track", value: (tokens) => tokens.component.playbackTrack },
+      { label: "Chord Active", value: (tokens) => tokens.component.chordActive },
+      { label: "Stem Muted", value: (tokens) => tokens.component.stemMuted },
+      { label: "Stem Solo", value: (tokens) => tokens.component.stemSolo },
+      { label: "Button Primary", value: (tokens) => tokens.component.buttonPrimaryBg },
+      { label: "Button Secondary", value: (tokens) => tokens.component.buttonSecondaryBg },
+      { label: "Input", value: (tokens) => tokens.component.inputBg },
+      { label: "Focus Ring", value: (tokens) => tokens.component.focusRing },
+    ],
+  },
+];
+
+function previewStyle(mode: ThemeMode) {
+  return {
+    ...getThemeCssVariables(mode),
+    colorScheme: mode,
+  } as CSSProperties;
+}
+
+function TokenSwatches({ mode, sections }: { mode: ThemeMode; sections: TokenSection[] }) {
+  const tokens = themeTokens[mode];
+
+  return (
+    <div className="theme-preview__swatches">
+      {sections.map((section) => (
+        <section className="theme-preview__token-section" key={`${mode}-${section.title}`}>
+          <div className="panel-heading panel-heading--compact">
+            <div>
+              <h3>{section.title}</h3>
+            </div>
+          </div>
+          <div className="theme-preview__token-grid">
+            {section.items.map((item) => {
+              const hex = item.value(tokens);
+              return (
+                <div className="theme-preview__token" key={`${section.title}-${item.label}`}>
+                  <span className="theme-preview__token-swatch" style={{ background: hex }} aria-hidden="true" />
+                  <span className="theme-preview__token-label">{item.label}</span>
+                  <code>{hex}</code>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function ThemeCanvas({ mode }: { mode: ThemeMode }) {
+  const isDark = mode === "dark";
+  const libraryId = `${mode}-theme-preview-library`;
+  const sessionId = `${mode}-theme-preview-session`;
+  const inspectorId = `${mode}-theme-preview-inspector`;
+
+  return (
+    <section className={`theme-preview theme-preview--${mode}`} style={previewStyle(mode)}>
+      <div className="theme-preview__frame">
+        <div className="theme-preview__topbar">
+          <div>
+            <p className="eyebrow">{isDark ? "Dark / Steel Night" : "Light / Brushed Metal"}</p>
+            <h2>{isDark ? "Cold base. Warm action." : "Paper, metal, and control."}</h2>
+          </div>
+          <span className="pill">{isDark ? "Night / depth" : "Day / structure"}</span>
+        </div>
+
+        <div className="theme-preview__shell">
+          <aside className="theme-preview__sidebar">
+            <div className="brand">
+              <span className="brand__eyebrow">TuneForge</span>
+              <strong>Deliberate mix rig</strong>
+            </div>
+            <nav className="theme-preview__nav" aria-label={`${mode} theme navigation example`}>
+              <a className="active" href={`#${libraryId}`}>
+                Library
+              </a>
+              <a href={`#${sessionId}`}>Session</a>
+              <a href={`#${inspectorId}`}>Inspector</a>
+            </nav>
+          </aside>
+
+          <div className="theme-preview__workspace">
+            <div className="theme-preview__workspace-header">
+              <div>
+                <p className="eyebrow">Preview Surface</p>
+                <h3>Playback, cards, and inspector</h3>
+                <p className="screen__subtitle">
+                  Cool blue holds structure. Molten orange only marks live playback and high-emphasis actions.
+                </p>
+              </div>
+              <div className="button-row">
+                <button className="theme-preview__button theme-preview__button--secondary" type="button">
+                  Neutral Select
+                </button>
+                <button className="theme-preview__button theme-preview__button--primary" type="button">
+                  Render Mix
+                </button>
+              </div>
+            </div>
+
+            <div className="theme-preview__workspace-grid">
+              <section className="theme-preview__panel" id={libraryId}>
+                <div className="panel-heading panel-heading--compact">
+                  <div>
+                    <p className="metric-label">Sidebar + Cards</p>
+                    <h3>Project library</h3>
+                  </div>
+                </div>
+                <div className="theme-preview__card-stack">
+                  <article className="theme-preview__card">
+                    <div className="theme-preview__card-meta">
+                      <span className="pill">Updated Apr 20</span>
+                      <span className="pill">4:12</span>
+                    </div>
+                    <strong>Reference mix</strong>
+                    <p className="artifact-meta">Neutral state uses steel structure, not heat.</p>
+                  </article>
+                  <article className="theme-preview__card theme-preview__card--selected">
+                    <div className="theme-preview__card-meta">
+                      <span className="pill">Selected</span>
+                      <span className="pill">A / 440</span>
+                    </div>
+                    <strong>Retune pass</strong>
+                    <p className="artifact-meta">Selected cards stay cool until audio becomes active.</p>
+                  </article>
+                </div>
+              </section>
+
+              <section className="theme-preview__panel" id={sessionId}>
+                <div className="panel-heading panel-heading--compact">
+                  <div>
+                    <p className="metric-label">Playback</p>
+                    <h3>Heat stays localized</h3>
+                  </div>
+                  <span className="theme-preview__status">Live</span>
+                </div>
+                <div className="theme-preview__playback">
+                  <div className="theme-preview__playback-meta">
+                    <div>
+                      <span className="metric-label">Now playing</span>
+                      <strong>Molten focus lane</strong>
+                    </div>
+                    <button className="theme-preview__button theme-preview__button--primary" type="button">
+                      Play
+                    </button>
+                  </div>
+                  <div className="theme-preview__track" aria-label={`${mode} playback track example`}>
+                    <div className="theme-preview__track-progress" />
+                  </div>
+                  <div className="theme-preview__playback-footer">
+                    <span>01:24</span>
+                    <span>04:12</span>
+                  </div>
+                  <div className="theme-preview__chip-row">
+                    <span className="theme-preview__chip theme-preview__chip--muted">Stem muted</span>
+                    <span className="theme-preview__chip theme-preview__chip--solo">Stem solo</span>
+                    <span className="theme-preview__chip theme-preview__chip--active">Chord active</span>
+                  </div>
+                </div>
+              </section>
+
+              <section className="theme-preview__panel theme-preview__panel--inspector" id={inspectorId}>
+                <div className="panel-heading panel-heading--compact">
+                  <div>
+                    <p className="metric-label">Inspector</p>
+                    <h3>Decision surfaces</h3>
+                  </div>
+                </div>
+                <div className="theme-preview__text-block">
+                  <p className="theme-preview__text-primary">Primary text carries the read path.</p>
+                  <p className="theme-preview__text-secondary">Secondary text explains state without stealing focus.</p>
+                  <p className="theme-preview__text-muted">Muted text stays low-contrast for metadata and scaffolding.</p>
+                </div>
+                <label className="theme-preview__field">
+                  <span className="metric-label">Transpose</span>
+                  <input defaultValue="+2 semitones" readOnly type="text" />
+                </label>
+              </section>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <TokenSwatches mode={mode} sections={semanticSections} />
+      <TokenSwatches mode={mode} sections={componentSections} />
+    </section>
+  );
+}
+
+export function ThemePreviewView() {
+  const { effectiveTheme } = useTheme();
+
+  return (
+    <section className="screen theme-preview-page">
+      <div className="screen__header">
+        <div className="screen__title-block">
+          <p className="eyebrow">Theme</p>
+          <h1>Metal / Heat System</h1>
+          <p className="screen__subtitle">
+            Semantic tokens now drive dark, light, and follow-system modes from one TypeScript source. The live UI still
+            follows your active theme: <strong>{effectiveTheme}</strong>.
+          </p>
+        </div>
+        <div className="button-row">
+          <Link className="button button--ghost" to="/settings">
+            Back to Settings
+          </Link>
+        </div>
+      </div>
+
+      <div className="theme-preview-page__stack">
+        <ThemeCanvas mode="dark" />
+        <ThemeCanvas mode="light" />
+      </div>
+    </section>
+  );
+}

--- a/apps/desktop/src/lib/theme.tsx
+++ b/apps/desktop/src/lib/theme.tsx
@@ -7,9 +7,10 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { getThemeCssVariables, type ThemeMode } from "./themeTokens";
 
 export type ThemePreference = "dark" | "light" | "system";
-export type EffectiveTheme = "dark" | "light";
+export type EffectiveTheme = ThemeMode;
 
 type ThemeContextValue = {
   effectiveTheme: EffectiveTheme;
@@ -45,8 +46,13 @@ function applyTheme(theme: EffectiveTheme) {
   if (typeof document === "undefined") {
     return;
   }
-  document.documentElement.dataset.theme = theme;
-  document.documentElement.style.colorScheme = theme;
+  const root = document.documentElement;
+  root.dataset.theme = theme;
+  root.style.colorScheme = theme;
+
+  for (const [property, value] of Object.entries(getThemeCssVariables(theme))) {
+    root.style.setProperty(property, value);
+  }
 }
 
 export function ThemeProvider({ children }: { children: ReactNode }) {

--- a/apps/desktop/src/lib/themeTokens.ts
+++ b/apps/desktop/src/lib/themeTokens.ts
@@ -1,0 +1,219 @@
+export type ThemeMode = "dark" | "light";
+
+export type ThemeTokens = {
+  bg: {
+    app: string;
+    canvas: string;
+    panel: string;
+    elevated: string;
+    inset: string;
+  };
+  text: {
+    primary: string;
+    secondary: string;
+    muted: string;
+    inverse: string;
+  };
+  border: {
+    subtle: string;
+    default: string;
+    strong: string;
+  };
+  accent: {
+    cool: string;
+    coolHover: string;
+    coolSoft: string;
+    warm: string;
+    warmStrong: string;
+    warmDeep: string;
+    warmSoft: string;
+  };
+  interaction: {
+    hover: string;
+    focusRing: string;
+  };
+  state: {
+    success: string;
+    warning: string;
+    danger: string;
+    info: string;
+  };
+  component: {
+    sidebarBg: string;
+    cardBg: string;
+    cardSelectedBg: string;
+    inspectorBg: string;
+    playbackActive: string;
+    playbackTrack: string;
+    chordActive: string;
+    stemMuted: string;
+    stemSolo: string;
+    buttonPrimaryBg: string;
+    buttonSecondaryBg: string;
+    inputBg: string;
+    focusRing: string;
+  };
+};
+
+export const themeTokens: Record<ThemeMode, ThemeTokens> = {
+  dark: {
+    bg: {
+      app: "#070B13",
+      canvas: "#0A1020",
+      panel: "#0E1628",
+      elevated: "#13203A",
+      inset: "#0C1424",
+    },
+    text: {
+      primary: "#E8EEF9",
+      secondary: "#A7B4C8",
+      muted: "#73829A",
+      inverse: "#0A1020",
+    },
+    border: {
+      subtle: "#22314B",
+      default: "#30435F",
+      strong: "#4C6385",
+    },
+    accent: {
+      cool: "#4B6FAE",
+      coolHover: "#5D83C4",
+      coolSoft: "#1B2D4A",
+      warm: "#F59E0B",
+      warmStrong: "#FFB547",
+      warmDeep: "#C96B16",
+      warmSoft: "#3D2512",
+    },
+    interaction: {
+      hover: "#18253B",
+      focusRing: "#5D83C4",
+    },
+    state: {
+      success: "#3FAF7A",
+      warning: "#E7A23B",
+      danger: "#D65C5C",
+      info: "#6F8FC8",
+    },
+    component: {
+      sidebarBg: "#0A1020",
+      cardBg: "#0E1628",
+      cardSelectedBg: "#1B2D4A",
+      inspectorBg: "#101A2F",
+      playbackActive: "#F59E0B",
+      playbackTrack: "#3D2512",
+      chordActive: "#C96B16",
+      stemMuted: "#22314B",
+      stemSolo: "#4B6FAE",
+      buttonPrimaryBg: "#F59E0B",
+      buttonSecondaryBg: "#13203A",
+      inputBg: "#0C1424",
+      focusRing: "#5D83C4",
+    },
+  },
+  light: {
+    bg: {
+      app: "#F4F7FB",
+      canvas: "#EDF2F8",
+      panel: "#FFFFFF",
+      elevated: "#F8FAFD",
+      inset: "#E7EEF7",
+    },
+    text: {
+      primary: "#142033",
+      secondary: "#44546C",
+      muted: "#6C7B90",
+      inverse: "#FFFFFF",
+    },
+    border: {
+      subtle: "#D7E0EC",
+      default: "#C0CDDD",
+      strong: "#9BAECC",
+    },
+    accent: {
+      cool: "#44679D",
+      coolHover: "#35598E",
+      coolSoft: "#DCE7F6",
+      warm: "#D9861A",
+      warmStrong: "#F2A93B",
+      warmDeep: "#A95F11",
+      warmSoft: "#F6E3C8",
+    },
+    interaction: {
+      hover: "#E4ECF7",
+      focusRing: "#44679D",
+    },
+    state: {
+      success: "#3FAF7A",
+      warning: "#E7A23B",
+      danger: "#D65C5C",
+      info: "#6F8FC8",
+    },
+    component: {
+      sidebarBg: "#E7EEF7",
+      cardBg: "#FFFFFF",
+      cardSelectedBg: "#DCE7F6",
+      inspectorBg: "#F8FAFD",
+      playbackActive: "#D9861A",
+      playbackTrack: "#F6E3C8",
+      chordActive: "#D9861A",
+      stemMuted: "#D7E0EC",
+      stemSolo: "#44679D",
+      buttonPrimaryBg: "#D9861A",
+      buttonSecondaryBg: "#F8FAFD",
+      inputBg: "#FFFFFF",
+      focusRing: "#44679D",
+    },
+  },
+};
+
+function buildThemeCssVariables(tokens: ThemeTokens) {
+  return {
+    "--color-bg-app": tokens.bg.app,
+    "--color-bg-canvas": tokens.bg.canvas,
+    "--color-bg-panel": tokens.bg.panel,
+    "--color-bg-elevated": tokens.bg.elevated,
+    "--color-bg-inset": tokens.bg.inset,
+    "--color-text-primary": tokens.text.primary,
+    "--color-text-secondary": tokens.text.secondary,
+    "--color-text-muted": tokens.text.muted,
+    "--color-text-inverse": tokens.text.inverse,
+    "--color-border-subtle": tokens.border.subtle,
+    "--color-border-default": tokens.border.default,
+    "--color-border-strong": tokens.border.strong,
+    "--color-accent-cool": tokens.accent.cool,
+    "--color-accent-cool-hover": tokens.accent.coolHover,
+    "--color-accent-cool-soft": tokens.accent.coolSoft,
+    "--color-accent-warm": tokens.accent.warm,
+    "--color-accent-warm-strong": tokens.accent.warmStrong,
+    "--color-accent-warm-deep": tokens.accent.warmDeep,
+    "--color-accent-warm-soft": tokens.accent.warmSoft,
+    "--color-interaction-hover": tokens.interaction.hover,
+    "--color-interaction-focus-ring": tokens.interaction.focusRing,
+    "--color-state-success": tokens.state.success,
+    "--color-state-warning": tokens.state.warning,
+    "--color-state-danger": tokens.state.danger,
+    "--color-state-info": tokens.state.info,
+    "--component-sidebar-bg": tokens.component.sidebarBg,
+    "--component-card-bg": tokens.component.cardBg,
+    "--component-card-selected-bg": tokens.component.cardSelectedBg,
+    "--component-inspector-bg": tokens.component.inspectorBg,
+    "--component-playback-active": tokens.component.playbackActive,
+    "--component-playback-track": tokens.component.playbackTrack,
+    "--component-chord-active": tokens.component.chordActive,
+    "--component-stem-muted": tokens.component.stemMuted,
+    "--component-stem-solo": tokens.component.stemSolo,
+    "--component-button-primary-bg": tokens.component.buttonPrimaryBg,
+    "--component-button-secondary-bg": tokens.component.buttonSecondaryBg,
+    "--component-input-bg": tokens.component.inputBg,
+    "--component-focus-ring": tokens.component.focusRing,
+  } satisfies Record<string, string>;
+}
+
+export const themeCssVariables: Record<ThemeMode, Record<string, string>> = {
+  dark: buildThemeCssVariables(themeTokens.dark),
+  light: buildThemeCssVariables(themeTokens.light),
+};
+
+export function getThemeCssVariables(theme: ThemeMode) {
+  return themeCssVariables[theme];
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1,87 +1,67 @@
 :root,
-:root[data-theme="dark"] {
+.theme-preview {
   font-family: "Avenir Next", "Segoe UI", sans-serif;
   line-height: 1.5;
   font-weight: 400;
-  color-scheme: dark;
-  --text: #e6edf5;
-  --muted: #95a6b8;
-  --danger: #f87171;
-  --accent: #34d399;
-  --accent-strong: #67e8f9;
-  --eyebrow-text: #83e7cb;
+  --text: var(--color-text-primary);
+  --text-secondary: var(--color-text-secondary);
+  --muted: var(--color-text-muted);
+  --danger: var(--color-state-danger);
+  --accent: var(--color-accent-cool);
+  --accent-strong: var(--color-accent-cool-hover);
+  --eyebrow-text: var(--color-accent-cool-hover);
   --app-background:
-    radial-gradient(circle at top left, rgba(64, 131, 184, 0.18), transparent 28%),
-    radial-gradient(circle at bottom right, rgba(52, 211, 153, 0.14), transparent 30%),
-    linear-gradient(160deg, #07111d 0%, #0b1623 44%, #101b2b 100%);
-  --panel: rgba(9, 18, 31, 0.82);
-  --panel-strong: rgba(7, 16, 27, 0.92);
-  --panel-border: rgba(148, 163, 184, 0.18);
-  --panel-shadow: rgba(2, 6, 23, 0.32);
-  --surface-muted: rgba(7, 16, 27, 0.64);
-  --surface-highlight: rgba(52, 211, 153, 0.12);
-  --sidebar-bg: rgba(2, 6, 23, 0.88);
-  --sidebar-text: #f8fafc;
-  --sidebar-muted: rgba(226, 232, 240, 0.68);
-  --sidebar-active: rgba(148, 163, 184, 0.16);
-  --button-bg: rgba(15, 23, 42, 0.76);
-  --button-border: rgba(148, 163, 184, 0.18);
-  --button-text: #e6edf5;
-  --button-hover-border: rgba(52, 211, 153, 0.45);
-  --button-primary-background: linear-gradient(135deg, #0f766e, #1d4ed8);
-  --button-primary-text: #eff6ff;
-  --input-bg: rgba(5, 13, 24, 0.9);
-  --input-border: rgba(148, 163, 184, 0.24);
-  --input-text: #f8fafc;
-  --project-card-bg: linear-gradient(165deg, rgba(10, 27, 46, 0.94), rgba(15, 48, 67, 0.9));
-  --project-card-shadow: rgba(2, 6, 23, 0.28);
-  --card-muted: rgba(226, 232, 240, 0.72);
-  --chip-bg: rgba(15, 23, 42, 0.72);
-  --chip-border: rgba(148, 163, 184, 0.2);
-  --chip-active-bg: rgba(52, 211, 153, 0.14);
-  --chip-active-border: rgba(52, 211, 153, 0.45);
-  --divider: rgba(148, 163, 184, 0.18);
+    radial-gradient(circle at top left, color-mix(in srgb, var(--color-accent-cool) 18%, transparent), transparent 28%),
+    radial-gradient(circle at bottom right, color-mix(in srgb, var(--color-accent-warm-soft) 46%, transparent), transparent 32%),
+    linear-gradient(
+      160deg,
+      var(--color-bg-app) 0%,
+      var(--color-bg-canvas) 46%,
+      color-mix(in srgb, var(--color-bg-elevated) 82%, var(--color-bg-app)) 100%
+    );
+  --panel: color-mix(in srgb, var(--color-bg-panel) 94%, transparent);
+  --panel-strong: color-mix(in srgb, var(--color-bg-elevated) 96%, var(--color-bg-panel));
+  --panel-border: var(--color-border-subtle);
+  --panel-shadow: color-mix(in srgb, var(--color-bg-app) 62%, transparent);
+  --surface-muted: color-mix(in srgb, var(--color-bg-inset) 86%, transparent);
+  --surface-highlight: color-mix(in srgb, var(--color-accent-cool-soft) 76%, transparent);
+  --sidebar-bg: var(--component-sidebar-bg);
+  --sidebar-text: var(--color-text-primary);
+  --sidebar-muted: var(--color-text-secondary);
+  --sidebar-active: var(--component-card-selected-bg);
+  --button-bg: var(--component-button-secondary-bg);
+  --button-border: var(--color-border-default);
+  --button-text: var(--color-text-primary);
+  --button-hover-border: var(--color-accent-cool);
+  --button-primary-background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--component-button-primary-bg) 70%, var(--color-accent-warm-deep)),
+    var(--color-accent-warm-strong)
+  );
+  --button-primary-text: var(--color-text-inverse);
+  --input-bg: var(--component-input-bg);
+  --input-border: var(--color-border-default);
+  --input-text: var(--color-text-primary);
+  --project-card-bg: var(--component-card-bg);
+  --project-card-shadow: color-mix(in srgb, var(--color-bg-app) 44%, transparent);
+  --project-card-text: var(--color-text-primary);
+  --card-muted: var(--color-text-secondary);
+  --chip-bg: color-mix(in srgb, var(--color-bg-elevated) 88%, transparent);
+  --chip-border: var(--color-border-default);
+  --chip-active-bg: color-mix(in srgb, var(--component-card-selected-bg) 92%, transparent);
+  --chip-active-border: var(--color-accent-cool);
+  --divider: var(--color-border-subtle);
+  --playback-accent: var(--component-playback-active);
+  --playback-track: var(--component-playback-track);
+  --focus-ring: var(--component-focus-ring);
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
 }
 
 :root[data-theme="light"] {
   color-scheme: light;
-  --text: #102a43;
-  --muted: #5b6470;
-  --danger: #9b1c1c;
-  --accent: #0f766e;
-  --accent-strong: #0a4f4a;
-  --eyebrow-text: #0a4f4a;
-  --app-background:
-    radial-gradient(circle at top left, rgba(244, 199, 129, 0.32), transparent 30%),
-    radial-gradient(circle at bottom right, rgba(43, 86, 111, 0.14), transparent 28%),
-    #f3eee8;
-  --panel: rgba(255, 255, 255, 0.82);
-  --panel-strong: rgba(255, 255, 255, 0.94);
-  --panel-border: rgba(17, 24, 39, 0.08);
-  --panel-shadow: rgba(17, 24, 39, 0.08);
-  --surface-muted: rgba(241, 245, 249, 0.9);
-  --surface-highlight: rgba(15, 118, 110, 0.1);
-  --sidebar-bg: rgba(14, 33, 50, 0.92);
-  --sidebar-text: #f6f2eb;
-  --sidebar-muted: rgba(246, 242, 235, 0.72);
-  --sidebar-active: rgba(255, 255, 255, 0.12);
-  --button-bg: rgba(255, 255, 255, 0.72);
-  --button-border: rgba(15, 118, 110, 0.18);
-  --button-text: #102a43;
-  --button-hover-border: rgba(15, 118, 110, 0.4);
-  --button-primary-background: linear-gradient(135deg, #0f766e, #1d4e89);
-  --button-primary-text: #ffffff;
-  --input-bg: rgba(255, 255, 255, 0.92);
-  --input-border: rgba(17, 24, 39, 0.12);
-  --input-text: #102a43;
-  --project-card-bg: rgba(16, 54, 76, 0.96);
-  --project-card-shadow: rgba(18, 52, 73, 0.16);
-  --card-muted: rgba(246, 242, 235, 0.74);
-  --chip-bg: rgba(255, 255, 255, 0.82);
-  --chip-border: rgba(15, 118, 110, 0.2);
-  --chip-active-bg: rgba(15, 118, 110, 0.16);
-  --chip-active-border: rgba(15, 118, 110, 0.45);
-  --divider: rgba(17, 24, 39, 0.08);
 }
 
 * {
@@ -239,6 +219,16 @@ a {
   color: var(--input-text);
 }
 
+.title-input:focus-visible,
+.search-field__input:focus-visible,
+.controls input:focus-visible,
+.controls select:focus-visible,
+.button:focus-visible,
+.nav a:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
 .title-input {
   min-width: min(36rem, 100%);
   font-size: 1.15rem;
@@ -362,8 +352,9 @@ a {
   gap: 1rem;
   padding: 1.25rem;
   background: var(--project-card-bg);
-  color: #ffffff;
+  color: var(--project-card-text);
   border-radius: 26px;
+  border: 1px solid var(--panel-border);
   box-shadow: 0 18px 36px var(--project-card-shadow);
   min-height: 260px;
 }
@@ -379,7 +370,7 @@ a {
 .stat-chip {
   border: 1px solid color-mix(in srgb, var(--card-muted) 30%, transparent);
   background: color-mix(in srgb, var(--panel-strong) 45%, transparent);
-  color: #ffffff;
+  color: var(--project-card-text);
   padding: 0.35rem 0.72rem;
   border-radius: 999px;
   font-size: 0.83rem;
@@ -407,7 +398,7 @@ a {
 
 .project-card__open {
   align-self: start;
-  color: #ffffff;
+  color: var(--project-card-text);
   font-weight: 700;
   white-space: nowrap;
 }
@@ -635,7 +626,7 @@ a {
   border: 1px solid var(--divider);
   border-radius: 24px;
   background:
-    radial-gradient(circle at top left, color-mix(in srgb, var(--accent) 20%, transparent), transparent 36%),
+    radial-gradient(circle at top left, color-mix(in srgb, var(--playback-accent) 18%, transparent), transparent 34%),
     linear-gradient(180deg, color-mix(in srgb, var(--panel-strong) 80%, transparent), transparent);
 }
 
@@ -675,7 +666,7 @@ a {
 
 .transport__scrubber input[type="range"] {
   width: 100%;
-  accent-color: var(--accent);
+  accent-color: var(--playback-accent);
 }
 
 .transport__times {
@@ -766,9 +757,9 @@ a {
 }
 
 .chord-segment--active {
-  border-color: color-mix(in srgb, var(--accent) 78%, transparent);
-  background: color-mix(in srgb, var(--accent) 18%, transparent);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent);
+  border-color: color-mix(in srgb, var(--playback-accent) 72%, transparent);
+  background: color-mix(in srgb, var(--playback-track) 58%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--playback-accent) 18%, transparent);
 }
 
 .chord-lane-empty {
@@ -975,6 +966,297 @@ a {
   color: var(--danger);
 }
 
+.theme-preview-page__stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.theme-preview {
+  background: var(--app-background);
+  color: var(--text);
+  border: 1px solid var(--panel-border);
+  border-radius: 32px;
+  overflow: hidden;
+  box-shadow: 0 24px 60px var(--panel-shadow);
+}
+
+.theme-preview__frame {
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.theme-preview__topbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: start;
+}
+
+.theme-preview__topbar h2,
+.theme-preview__workspace-header h3,
+.theme-preview__token-section h3 {
+  margin: 0;
+}
+
+.theme-preview__shell {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr);
+  gap: 1rem;
+  min-height: 420px;
+}
+
+.theme-preview__sidebar {
+  background: var(--sidebar-bg);
+  color: var(--sidebar-text);
+  border: 1px solid var(--panel-border);
+  border-radius: 24px;
+  padding: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.theme-preview__sidebar .brand__eyebrow {
+  color: var(--sidebar-muted);
+}
+
+.theme-preview__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.theme-preview__nav a {
+  color: var(--sidebar-muted);
+  padding: 0.75rem 0.9rem;
+  border-radius: 16px;
+}
+
+.theme-preview__nav a.active {
+  background: var(--sidebar-active);
+  color: var(--sidebar-text);
+}
+
+.theme-preview__workspace {
+  background: color-mix(in srgb, var(--color-bg-canvas) 94%, transparent);
+  border: 1px solid var(--panel-border);
+  border-radius: 24px;
+  padding: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.theme-preview__workspace-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: start;
+}
+
+.theme-preview__workspace-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.theme-preview__panel {
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 24px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.theme-preview__panel--inspector {
+  background: var(--component-inspector-bg);
+}
+
+.theme-preview__button {
+  border: 1px solid var(--button-border);
+  background: var(--button-bg);
+  color: var(--button-text);
+  padding: 0.72rem 0.95rem;
+  border-radius: 999px;
+}
+
+.theme-preview__button--primary {
+  border-color: transparent;
+  background: var(--button-primary-background);
+  color: var(--button-primary-text);
+}
+
+.theme-preview__button--secondary {
+  background: var(--component-button-secondary-bg);
+}
+
+.theme-preview__card-stack {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.theme-preview__card {
+  background: var(--component-card-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 20px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.theme-preview__card--selected {
+  background: var(--component-card-selected-bg);
+  border-color: var(--chip-active-border);
+}
+
+.theme-preview__card-meta,
+.theme-preview__chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.theme-preview__status {
+  border: 1px solid color-mix(in srgb, var(--playback-accent) 45%, transparent);
+  background: color-mix(in srgb, var(--playback-track) 64%, transparent);
+  color: var(--playback-accent);
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  font-weight: 700;
+}
+
+.theme-preview__playback {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: 1rem;
+  border-radius: 20px;
+  border: 1px solid color-mix(in srgb, var(--playback-accent) 34%, transparent);
+  background:
+    radial-gradient(circle at top left, color-mix(in srgb, var(--playback-accent) 20%, transparent), transparent 34%),
+    color-mix(in srgb, var(--panel-strong) 92%, transparent);
+}
+
+.theme-preview__playback-meta,
+.theme-preview__playback-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+}
+
+.theme-preview__track {
+  height: 12px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--playback-track) 76%, var(--surface-muted));
+  overflow: hidden;
+}
+
+.theme-preview__track-progress {
+  width: 48%;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--color-accent-warm-deep), var(--playback-accent));
+}
+
+.theme-preview__chip {
+  border-radius: 999px;
+  padding: 0.45rem 0.72rem;
+  font-size: 0.85rem;
+  border: 1px solid transparent;
+}
+
+.theme-preview__chip--muted {
+  background: var(--component-stem-muted);
+}
+
+.theme-preview__chip--solo {
+  background: color-mix(in srgb, var(--component-stem-solo) 18%, transparent);
+  border-color: color-mix(in srgb, var(--component-stem-solo) 44%, transparent);
+}
+
+.theme-preview__chip--active {
+  background: color-mix(in srgb, var(--component-chord-active) 18%, transparent);
+  border-color: color-mix(in srgb, var(--component-chord-active) 38%, transparent);
+}
+
+.theme-preview__text-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.theme-preview__text-block p {
+  margin: 0;
+}
+
+.theme-preview__text-primary {
+  color: var(--text);
+}
+
+.theme-preview__text-secondary {
+  color: var(--text-secondary);
+}
+
+.theme-preview__text-muted {
+  color: var(--muted);
+}
+
+.theme-preview__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.theme-preview__field input {
+  border: 1px solid var(--input-border);
+  border-radius: 16px;
+  padding: 0.78rem 0.95rem;
+  background: var(--input-bg);
+  color: var(--input-text);
+}
+
+.theme-preview__swatches {
+  padding: 0 1.25rem 1.25rem;
+}
+
+.theme-preview__token-section + .theme-preview__token-section {
+  margin-top: 1rem;
+}
+
+.theme-preview__token-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+}
+
+.theme-preview__token {
+  background: color-mix(in srgb, var(--panel) 92%, transparent);
+  border: 1px solid var(--panel-border);
+  border-radius: 18px;
+  padding: 0.8rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.theme-preview__token-swatch {
+  width: 100%;
+  height: 2.25rem;
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--text) 14%, transparent);
+}
+
+.theme-preview__token-label {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
 @media (max-width: 1200px) {
   .project-workbench,
   .project-workbench--wide {
@@ -983,6 +1265,11 @@ a {
 
   .inspector-panel {
     position: static;
+  }
+
+  .theme-preview__shell,
+  .theme-preview__workspace-grid {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -1035,5 +1322,13 @@ a {
 
   .project-card__open {
     justify-self: start;
+  }
+
+  .theme-preview__topbar,
+  .theme-preview__workspace-header,
+  .theme-preview__playback-meta,
+  .theme-preview__playback-footer {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- add semantic dark and light theme token maps for the desktop app and apply them at runtime
- shift the desktop palette toward steel-blue neutrals with restrained molten-orange playback accents
- add a Settings theme preview screen that shows dark and light token usage across sidebar, cards, inspector, buttons, and playback state

## Testing
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test`
- `pnpm --filter @tuneforge/desktop lint`
