### PR TITLE
feat: split appearance and visibility settings

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -583,7 +583,8 @@ describe("Desktop app flows", () => {
     await waitFor(() =>
       expect(mockGetProject).toHaveBeenCalledWith(expect.stringMatching(/^proj_/)),
     );
-    expect(await screen.findByRole("button", { name: "Analyze Track" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "New Song" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show Inspector" })).toBeInTheDocument();
   });
 
   it("analyzes track from inspector", async () => {
@@ -593,6 +594,7 @@ describe("Desktop app flows", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Show Inspector" }));
     await user.click(screen.getByRole("button", { name: "Analyze Track" }));
 
     expect(mockAnalyzeProject).toHaveBeenCalledWith("proj_123");
@@ -603,6 +605,7 @@ describe("Desktop app flows", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Show Inspector" }));
     const sourceList = screen.getByRole("group", { name: "Source and mix list" });
     await user.click(within(sourceList).getByRole("button", { name: /Source Track/i }));
     await user.click(screen.getByText("Correct source key if detection is wrong"));
@@ -676,6 +679,7 @@ describe("Desktop app flows", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Show Inspector" }));
     const sourceList = screen.getByRole("group", { name: "Source and mix list" });
     await user.click(within(sourceList).getByRole("button", { name: /Source Track/i }));
     await user.click(screen.getByRole("button", { name: "Export Selected Audio" }));
@@ -711,11 +715,31 @@ describe("Desktop app flows", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Show Inspector" }));
     await user.click(screen.getByRole("button", { name: "Delete Project" }));
 
     expect(mockDeleteProject).toHaveBeenCalledWith("proj_123");
     expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
     expect(await screen.findByRole("heading", { name: "No projects yet" })).toBeInTheDocument();
+  });
+
+  it("uses new default appearance and visibility settings", async () => {
+    renderApp(["/settings"]);
+
+    expect(await screen.findByRole("heading", { name: "Playback Surface" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Theme")).toHaveValue("system");
+    expect(screen.getByLabelText("Information Density")).toHaveValue("minimal");
+    expect(screen.getByLabelText("Layout Density")).toHaveValue("compact");
+    expect(screen.getByLabelText("Show helper text by default")).not.toBeChecked();
+    expect(screen.getByLabelText("Open inspector by default")).not.toBeChecked();
+    expect(window.localStorage.getItem("tuneforge.theme-preference")).toBe("system");
+    expect(JSON.parse(window.localStorage.getItem("tuneforge.ui-preferences") ?? "{}")).toMatchObject({
+      informationDensity: "minimal",
+      layoutDensity: "compact",
+      helperTextVisible: false,
+      defaultInspectorOpen: false,
+      metadataRevealMode: "expand",
+    });
   });
 
   it("persists theme and UI visibility preferences", async () => {
@@ -727,8 +751,8 @@ describe("Desktop app flows", () => {
 
     await user.selectOptions(screen.getByLabelText("Theme"), "light");
     await user.selectOptions(screen.getByLabelText("Information Density"), "detailed");
-    await user.selectOptions(screen.getByLabelText("Layout Density"), "compact");
-    await user.click(screen.getByLabelText("Show helper text"));
+    await user.selectOptions(screen.getByLabelText("Layout Density"), "comfortable");
+    await user.click(screen.getByLabelText("Show helper text by default"));
     await user.click(screen.getByLabelText("Open inspector by default"));
     await user.selectOptions(screen.getByLabelText("Metadata Reveal"), "hover");
 
@@ -738,11 +762,49 @@ describe("Desktop app flows", () => {
     expect(document.documentElement.style.getPropertyValue("--component-playback-active")).toBe("#D9861A");
     expect(JSON.parse(window.localStorage.getItem("tuneforge.ui-preferences") ?? "{}")).toMatchObject({
       informationDensity: "detailed",
-      layoutDensity: "compact",
-      helperTextVisible: false,
-      defaultInspectorOpen: false,
+      layoutDensity: "comfortable",
+      helperTextVisible: true,
+      defaultInspectorOpen: true,
       metadataRevealMode: "hover",
     });
+  });
+
+  it("resets appearance, visibility, and all settings independently", async () => {
+    const user = userEvent.setup();
+    renderApp(["/settings"]);
+
+    expect(await screen.findByRole("heading", { name: "Playback Surface" })).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText("Theme"), "light");
+    await user.selectOptions(screen.getByLabelText("Information Density"), "detailed");
+    await user.selectOptions(screen.getByLabelText("Layout Density"), "comfortable");
+    await user.click(screen.getByLabelText("Show helper text by default"));
+    await user.click(screen.getByLabelText("Open inspector by default"));
+    await user.selectOptions(screen.getByLabelText("Metadata Reveal"), "hover");
+
+    await user.click(screen.getByRole("button", { name: "Reset Appearance" }));
+    expect(screen.getByLabelText("Theme")).toHaveValue("system");
+    expect(screen.getByLabelText("Information Density")).toHaveValue("minimal");
+    expect(screen.getByLabelText("Layout Density")).toHaveValue("compact");
+    expect(screen.getByLabelText("Show helper text by default")).toBeChecked();
+    expect(screen.getByLabelText("Open inspector by default")).toBeChecked();
+    expect(screen.getByLabelText("Metadata Reveal")).toHaveValue("hover");
+
+    await user.click(screen.getByRole("button", { name: "Reset Visibility" }));
+    expect(screen.getByLabelText("Show helper text by default")).not.toBeChecked();
+    expect(screen.getByLabelText("Open inspector by default")).not.toBeChecked();
+    expect(screen.getByLabelText("Metadata Reveal")).toHaveValue("expand");
+
+    await user.selectOptions(screen.getByLabelText("Theme"), "dark");
+    await user.click(screen.getByLabelText("Show helper text by default"));
+    await user.click(screen.getByRole("button", { name: "Reset All Settings" }));
+
+    expect(screen.getByLabelText("Theme")).toHaveValue("system");
+    expect(screen.getByLabelText("Information Density")).toHaveValue("minimal");
+    expect(screen.getByLabelText("Layout Density")).toHaveValue("compact");
+    expect(screen.getByLabelText("Show helper text by default")).not.toBeChecked();
+    expect(screen.getByLabelText("Open inspector by default")).not.toBeChecked();
+    expect(screen.getByLabelText("Metadata Reveal")).toHaveValue("expand");
   });
 
   it("follows system theme when preference is set to system", async () => {

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -7,7 +7,11 @@ import {
   type LayoutDensity,
   type MetadataRevealMode,
 } from "../../lib/preferences";
-import { useTheme, type ThemePreference } from "../../lib/theme";
+import {
+  DEFAULT_THEME_PREFERENCE,
+  useTheme,
+  type ThemePreference,
+} from "../../lib/theme";
 
 function themePreferenceLabel(themePreference: ThemePreference) {
   if (themePreference === "system") {
@@ -43,12 +47,28 @@ export function SettingsView() {
     setHelperTextVisible,
     setDefaultInspectorOpen,
     setMetadataRevealMode,
+    resetAppearancePreferences,
+    resetVisibilityPreferences,
     resetPreferences,
   } = usePreferences();
   const healthQuery = useQuery({
     queryKey: ["health"],
     queryFn: api.getHealth,
   });
+
+  function handleResetAppearance() {
+    setThemePreference(DEFAULT_THEME_PREFERENCE);
+    resetAppearancePreferences();
+  }
+
+  function handleResetVisibility() {
+    resetVisibilityPreferences();
+  }
+
+  function handleResetAllSettings() {
+    setThemePreference(DEFAULT_THEME_PREFERENCE);
+    resetPreferences();
+  }
 
   return (
     <section className="screen">
@@ -128,6 +148,19 @@ export function SettingsView() {
               <dd>{layoutDensityLabel(layoutDensity)}</dd>
             </div>
           </dl>
+
+          <div className="button-row">
+            <Link className="button button--ghost button--small" to="/settings/theme-preview">
+              Open Theme Preview
+            </Link>
+            <button
+              className="button button--ghost button--small"
+              type="button"
+              onClick={handleResetAppearance}
+            >
+              Reset Appearance
+            </button>
+          </div>
         </div>
 
         <div className="panel">
@@ -141,12 +174,12 @@ export function SettingsView() {
           <div className="controls">
             <label className="checkbox">
               <input
-                aria-label="Show helper text"
+                aria-label="Show helper text by default"
                 checked={helperTextVisible}
                 onChange={(event) => setHelperTextVisible(event.target.checked)}
                 type="checkbox"
               />
-              Show helper text
+              Show helper text by default
             </label>
 
             <label className="checkbox">
@@ -175,11 +208,11 @@ export function SettingsView() {
           <dl className="meta-grid">
             <div>
               <dt>Helper Text</dt>
-              <dd>{helperTextVisible ? "Visible" : "Hidden"}</dd>
+              <dd>{helperTextVisible ? "Enabled" : "Disabled"}</dd>
             </div>
             <div>
               <dt>Inspector Default</dt>
-              <dd>{defaultInspectorOpen ? "Open" : "Collapsed"}</dd>
+              <dd>{defaultInspectorOpen ? "Open" : "Closed"}</dd>
             </div>
             <div>
               <dt>Metadata Reveal</dt>
@@ -188,12 +221,13 @@ export function SettingsView() {
           </dl>
 
           <div className="button-row">
-            <button className="button button--ghost button--small" type="button" onClick={resetPreferences}>
-              Reset UI Defaults
+            <button
+              className="button button--ghost button--small"
+              type="button"
+              onClick={handleResetVisibility}
+            >
+              Reset Visibility
             </button>
-            <Link className="button button--ghost button--small" to="/settings/theme-preview">
-              Open Theme Preview
-            </Link>
           </div>
         </div>
 
@@ -226,6 +260,16 @@ export function SettingsView() {
             Projects, previews, exported files, and the local database stay under this root.
           </p>
         </div>
+      </div>
+
+      <div className="button-row">
+        <button
+          className="button button--ghost button--small"
+          type="button"
+          onClick={handleResetAllSettings}
+        >
+          Reset All Settings
+        </button>
       </div>
     </section>
   );

--- a/apps/desktop/src/lib/preferences.tsx
+++ b/apps/desktop/src/lib/preferences.tsx
@@ -1,5 +1,12 @@
 /* eslint-disable react-refresh/only-export-components */
-import { createContext, useContext, useMemo, useState, type ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  useLayoutEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 
 export type InformationDensity = "minimal" | "balanced" | "detailed";
 export type LayoutDensity = "compact" | "comfortable";
@@ -13,23 +20,39 @@ export type UiPreferences = {
   metadataRevealMode: MetadataRevealMode;
 };
 
+export type AppearancePreferences = Pick<UiPreferences, "informationDensity" | "layoutDensity">;
+export type VisibilityPreferences = Pick<
+  UiPreferences,
+  "helperTextVisible" | "defaultInspectorOpen" | "metadataRevealMode"
+>;
+
 type PreferencesContextValue = UiPreferences & {
   setInformationDensity: (value: InformationDensity) => void;
   setLayoutDensity: (value: LayoutDensity) => void;
   setHelperTextVisible: (value: boolean) => void;
   setDefaultInspectorOpen: (value: boolean) => void;
   setMetadataRevealMode: (value: MetadataRevealMode) => void;
+  resetAppearancePreferences: () => void;
+  resetVisibilityPreferences: () => void;
   resetPreferences: () => void;
 };
 
 const STORAGE_KEY = "tuneforge.ui-preferences";
 
-const DEFAULT_PREFERENCES: UiPreferences = {
-  informationDensity: "balanced",
-  layoutDensity: "comfortable",
-  helperTextVisible: true,
-  defaultInspectorOpen: true,
+export const DEFAULT_APPEARANCE_PREFERENCES: AppearancePreferences = {
+  informationDensity: "minimal",
+  layoutDensity: "compact",
+};
+
+export const DEFAULT_VISIBILITY_PREFERENCES: VisibilityPreferences = {
+  helperTextVisible: false,
+  defaultInspectorOpen: false,
   metadataRevealMode: "expand",
+};
+
+export const DEFAULT_PREFERENCES: UiPreferences = {
+  ...DEFAULT_APPEARANCE_PREFERENCES,
+  ...DEFAULT_VISIBILITY_PREFERENCES,
 };
 
 const PreferencesContext = createContext<PreferencesContextValue | null>(null);
@@ -97,46 +120,42 @@ function persistPreferences(preferences: UiPreferences) {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences));
 }
 
+function mergePreferences(current: UiPreferences, partial: Partial<UiPreferences>) {
+  const next = { ...current, ...partial };
+  persistPreferences(next);
+  return next;
+}
+
 export function PreferencesProvider({ children }: { children: ReactNode }) {
   const [preferences, setPreferences] = useState<UiPreferences>(readStoredPreferences);
+
+  useLayoutEffect(() => {
+    persistPreferences(preferences);
+  }, [preferences]);
 
   const value = useMemo<PreferencesContextValue>(
     () => ({
       ...preferences,
       setInformationDensity: (informationDensity) => {
-        setPreferences((current) => {
-          const next = { ...current, informationDensity };
-          persistPreferences(next);
-          return next;
-        });
+        setPreferences((current) => mergePreferences(current, { informationDensity }));
       },
       setLayoutDensity: (layoutDensity) => {
-        setPreferences((current) => {
-          const next = { ...current, layoutDensity };
-          persistPreferences(next);
-          return next;
-        });
+        setPreferences((current) => mergePreferences(current, { layoutDensity }));
       },
       setHelperTextVisible: (helperTextVisible) => {
-        setPreferences((current) => {
-          const next = { ...current, helperTextVisible };
-          persistPreferences(next);
-          return next;
-        });
+        setPreferences((current) => mergePreferences(current, { helperTextVisible }));
       },
       setDefaultInspectorOpen: (defaultInspectorOpen) => {
-        setPreferences((current) => {
-          const next = { ...current, defaultInspectorOpen };
-          persistPreferences(next);
-          return next;
-        });
+        setPreferences((current) => mergePreferences(current, { defaultInspectorOpen }));
       },
       setMetadataRevealMode: (metadataRevealMode) => {
-        setPreferences((current) => {
-          const next = { ...current, metadataRevealMode };
-          persistPreferences(next);
-          return next;
-        });
+        setPreferences((current) => mergePreferences(current, { metadataRevealMode }));
+      },
+      resetAppearancePreferences: () => {
+        setPreferences((current) => mergePreferences(current, DEFAULT_APPEARANCE_PREFERENCES));
+      },
+      resetVisibilityPreferences: () => {
+        setPreferences((current) => mergePreferences(current, DEFAULT_VISIBILITY_PREFERENCES));
       },
       resetPreferences: () => {
         persistPreferences(DEFAULT_PREFERENCES);

--- a/apps/desktop/src/lib/theme.tsx
+++ b/apps/desktop/src/lib/theme.tsx
@@ -11,6 +11,7 @@ import { getThemeCssVariables, type ThemeMode } from "./themeTokens";
 
 export type ThemePreference = "dark" | "light" | "system";
 export type EffectiveTheme = ThemeMode;
+export const DEFAULT_THEME_PREFERENCE: ThemePreference = "system";
 
 type ThemeContextValue = {
   effectiveTheme: EffectiveTheme;
@@ -22,15 +23,15 @@ const STORAGE_KEY = "tuneforge.theme-preference";
 const ThemeContext = createContext<ThemeContextValue | null>(null);
 
 function normalizeThemePreference(value: string | null): ThemePreference {
-  if (value === "light" || value === "system") {
+  if (value === "dark" || value === "light" || value === "system") {
     return value;
   }
-  return "dark";
+  return DEFAULT_THEME_PREFERENCE;
 }
 
 function readThemePreference(): ThemePreference {
   if (typeof window === "undefined") {
-    return "dark";
+    return DEFAULT_THEME_PREFERENCE;
   }
   return normalizeThemePreference(window.localStorage.getItem(STORAGE_KEY));
 }


### PR DESCRIPTION
## Summary
- split settings resets into appearance-only, visibility-only, and reset-all actions
- move theme preview under appearance and update settings copy for the new disabled-by-default visibility behavior
- change the default theme and UI preference values to follow system, minimal, compact, hidden helper text, and closed inspector
- update desktop flow tests to match the new inspector default and cover the new reset behavior

## Testing
- `pnpm --filter @tuneforge/desktop test --run`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
