### PR TITLE
feat: improve playback continuity and controls

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -9,6 +9,8 @@ const {
   resetMockApiState,
   setProjects,
   setProjectAnalysis,
+  setDeferredPreviewCompletion,
+  flushPendingPreview,
   mockOpen,
   mockSave,
   mockConfirm,
@@ -35,10 +37,12 @@ const {
     analysisByProject: Record<string, Record<string, unknown> | null>;
     chordsByProject: Record<string, Record<string, unknown>>;
     artifactsByProject: Record<string, Array<Record<string, unknown>>>;
+    pendingPreviewArtifactsByProject: Record<string, Array<Record<string, unknown>>>;
     jobs: Array<Record<string, unknown>>;
     nextProjectId: number;
     nextArtifactId: number;
     nextJobId: number;
+    deferPreviewCompletion: boolean;
   };
 
   function clone<T>(value: T): T {
@@ -96,6 +100,27 @@ const {
     state.analysisByProject[projectId] = analysis ? clone(analysis) : null;
   }
 
+  function setDeferredPreviewCompletion(value: boolean) {
+    state.deferPreviewCompletion = value;
+  }
+
+  function flushPendingPreview(projectId: string) {
+    const pendingArtifacts = state.pendingPreviewArtifactsByProject[projectId] ?? [];
+    if (!pendingArtifacts.length) {
+      return;
+    }
+    state.artifactsByProject[projectId] = [
+      ...pendingArtifacts,
+      ...(state.artifactsByProject[projectId] ?? []),
+    ];
+    state.pendingPreviewArtifactsByProject[projectId] = [];
+    state.jobs = state.jobs.map((job) =>
+      job.project_id === projectId && job.type === "preview" && job.status !== "completed"
+        ? { ...job, status: "completed", progress: 100, updated_at: createdAt }
+        : job,
+    );
+  }
+
   function resetMockApiState() {
     const demoProject = makeProject("proj_123", "Demo Song", "/tmp/demo.wav");
     state = {
@@ -140,6 +165,7 @@ const {
           },
         ],
       },
+      pendingPreviewArtifactsByProject: {},
       jobs: [
         {
           id: "job_1",
@@ -165,6 +191,7 @@ const {
       nextProjectId: 200,
       nextArtifactId: 200,
       nextJobId: 200,
+      deferPreviewCompletion: false,
     };
   }
 
@@ -267,17 +294,24 @@ const {
       },
       created_at: createdAt,
     };
-    state.artifactsByProject[projectId] = [artifact, ...(state.artifactsByProject[projectId] ?? [])];
     const job = {
       id: `job_${state.nextJobId++}`,
       project_id: projectId,
       type: "preview",
-      status: "completed",
-      progress: 100,
+      status: state.deferPreviewCompletion ? "running" : "completed",
+      progress: state.deferPreviewCompletion ? 25 : 100,
       error_message: null,
       created_at: createdAt,
       updated_at: createdAt,
     };
+    if (state.deferPreviewCompletion) {
+      state.pendingPreviewArtifactsByProject[projectId] = [
+        artifact,
+        ...(state.pendingPreviewArtifactsByProject[projectId] ?? []),
+      ];
+    } else {
+      state.artifactsByProject[projectId] = [artifact, ...(state.artifactsByProject[projectId] ?? [])];
+    }
     state.jobs.unshift(job);
     return { job: clone(job) };
   });
@@ -401,6 +435,8 @@ const {
     resetMockApiState,
     setProjects,
     setProjectAnalysis,
+    setDeferredPreviewCompletion,
+    flushPendingPreview,
     mockOpen,
     mockSave,
     mockConfirm,
@@ -461,13 +497,14 @@ function renderApp(initialEntries: string[]) {
       queries: { retry: false },
     },
   });
-  return render(
+  const result = render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={initialEntries}>
         <App />
       </MemoryRouter>
     </QueryClientProvider>,
   );
+  return { ...result, queryClient };
 }
 
 function installMatchMediaMock(initialMatches = false) {
@@ -501,6 +538,25 @@ function installMatchMediaMock(initialMatches = false) {
   };
 }
 
+function findAudioByArtifactId(artifactId: string) {
+  const element = Array.from(document.querySelectorAll("audio")).find((candidate) =>
+    candidate.getAttribute("src")?.includes(`/artifacts/${artifactId}/stream`),
+  );
+  if (!element) {
+    throw new Error(`Audio element not found for artifact ${artifactId}`);
+  }
+  return element as HTMLAudioElement;
+}
+
+function markAudioReady(element: HTMLAudioElement, duration = 182) {
+  Object.defineProperty(element, "duration", {
+    configurable: true,
+    value: duration,
+  });
+  fireEvent.loadedMetadata(element);
+  fireEvent.canPlay(element);
+}
+
 describe("Desktop app flows", () => {
   beforeEach(() => {
     resetMockApiState();
@@ -527,6 +583,8 @@ describe("Desktop app flows", () => {
     mockDeleteArtifact.mockClear();
     mockDeleteProject.mockClear();
     mockGetHealth.mockClear();
+    vi.mocked(window.HTMLMediaElement.prototype.play).mockClear();
+    vi.mocked(window.HTMLMediaElement.prototype.pause).mockClear();
     installMatchMediaMock(false);
   });
 
@@ -635,7 +693,7 @@ describe("Desktop app flows", () => {
         mode: "two_stem",
         output_format: "wav",
         force: false,
-        source_artifact_id: "art_preview",
+        source_artifact_id: "art_source",
       }),
     );
 
@@ -650,6 +708,115 @@ describe("Desktop app flows", () => {
 
     expect(await screen.findByRole("heading", { name: "Source Track" })).toBeInTheDocument();
     expect(screen.getByText("Full playback")).toBeInTheDocument();
+  });
+
+  it("persists selected stem playback state across project reopen", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+
+    const stemList = await screen.findByRole("group", { name: "Stem track list" });
+    await user.click(within(stemList).getByRole("button", { name: /Vocals/i }));
+
+    expect(await screen.findByRole("heading", { name: "Vocals" })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        JSON.parse(window.localStorage.getItem("tuneforge.project-playback-state") ?? "{}"),
+      ).toMatchObject({
+        proj_123: {
+          selectedArtifactId: "art_200",
+          selectedPrimaryArtifactId: "art_source",
+        },
+      }),
+    );
+
+    await user.click(screen.getAllByRole("link", { name: "Library" })[0]);
+    expect(await screen.findByText("Background Playback")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Stop" }));
+
+    const demoProjectCard = screen.getByText("Demo Song").closest("article");
+    expect(demoProjectCard).not.toBeNull();
+    await user.click(
+      within(demoProjectCard as HTMLElement).getByRole("link", { name: /Open project/i }),
+    );
+
+    expect(await screen.findByRole("heading", { name: "Vocals" })).toBeInTheDocument();
+    expect(screen.getAllByText("Stem monitor").length).toBeGreaterThan(0);
+  });
+
+  it("toggles playback with spacebar and preserves time when switching mixes", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+
+    fireEvent.keyDown(window, { code: "Space", key: " " });
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument(),
+    );
+
+    sourceAudio.currentTime = 47.25;
+    fireEvent.timeUpdate(sourceAudio);
+
+    const savedMixList = screen.getByRole("group", { name: "Saved mix list" });
+    await user.click(within(savedMixList).getByRole("button", { name: /Practice Mix/i }));
+
+    const previewAudio = findAudioByArtifactId("art_preview");
+    markAudioReady(previewAudio);
+
+    await waitFor(() => expect(previewAudio.currentTime).toBeCloseTo(47.25, 2));
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+  });
+
+  it("keeps playback position when a newly created mix becomes active", async () => {
+    const user = userEvent.setup();
+    setDeferredPreviewCompletion(true);
+    const { queryClient } = renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Show Inspector" }));
+
+    const sourceList = screen.getByRole("group", { name: "Source and mix list" });
+    await user.click(within(sourceList).getByRole("button", { name: /Source Track/i }));
+
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    sourceAudio.currentTime = 61.4;
+    fireEvent.timeUpdate(sourceAudio);
+
+    await user.click(screen.getByLabelText("Raise target key"));
+    await user.click(screen.getByRole("button", { name: "Create Mix" }));
+
+    expect(mockCreatePreview).toHaveBeenCalledWith(
+      "proj_123",
+      expect.objectContaining({
+        output_format: "wav",
+        transpose: { semitones: 1 },
+      }),
+    );
+
+    await act(async () => {
+      flushPendingPreview("proj_123");
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["jobs"] }),
+        queryClient.invalidateQueries({ queryKey: ["artifacts", "proj_123"] }),
+      ]);
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "Practice Mix" })).toBeInTheDocument(),
+    );
+    const newestPreviewAudio = findAudioByArtifactId("art_200");
+    markAudioReady(newestPreviewAudio);
+    await waitFor(() => expect(newestPreviewAudio.currentTime).toBeCloseTo(61.4, 2));
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
   });
 
   it("supports mute and solo controls in stem monitor", async () => {
@@ -805,6 +972,79 @@ describe("Desktop app flows", () => {
     expect(screen.getByLabelText("Show helper text by default")).not.toBeChecked();
     expect(screen.getByLabelText("Open inspector by default")).not.toBeChecked();
     expect(screen.getByLabelText("Metadata Reveal")).toHaveValue("expand");
+  });
+
+  it("keeps background playback available on settings and clears it when stopped", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await user.click(screen.getByRole("link", { name: "Settings" }));
+
+    expect(await screen.findByRole("heading", { name: "Playback Surface" })).toBeInTheDocument();
+    expect(screen.getByText("Background Playback")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Pause" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Reset Appearance" }));
+    expect(screen.getByRole("button", { name: "Pause" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Pause" }));
+    expect(screen.getByText("Background Playback")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Play" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Stop" }));
+    expect(screen.queryByText("Background Playback")).not.toBeInTheDocument();
+  });
+
+  it("stops background playback when opening a different project from the library", async () => {
+    const user = userEvent.setup();
+    setProjects([
+      {
+        id: "proj_123",
+        display_name: "Demo Song",
+        source_path: "/tmp/demo.wav",
+        imported_path: "/tmp/projects/demo.wav",
+        duration_seconds: 182,
+        sample_rate: 44100,
+        channels: 2,
+        created_at: "2026-04-18T13:16:00.000Z",
+        updated_at: "2026-04-18T13:16:00.000Z",
+      },
+      {
+        id: "proj_456",
+        display_name: "Bass Drill",
+        source_path: "/tmp/bass-drill.wav",
+        imported_path: "/tmp/projects/bass-drill.wav",
+        duration_seconds: 120,
+        sample_rate: 48000,
+        channels: 2,
+        created_at: "2026-04-18T13:16:00.000Z",
+        updated_at: "2026-04-18T13:16:00.000Z",
+      },
+    ]);
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    await user.click(screen.getAllByRole("link", { name: "Library" })[0]);
+    expect(await screen.findByText("Background Playback")).toBeInTheDocument();
+
+    const secondProjectCard = screen.getByText("Bass Drill").closest("article");
+    expect(secondProjectCard).not.toBeNull();
+    await user.click(
+      within(secondProjectCard as HTMLElement).getByRole("link", { name: /Open project/i }),
+    );
+
+    expect(await screen.findByRole("heading", { name: "Bass Drill" })).toBeInTheDocument();
+    expect(screen.queryByText("Background Playback")).not.toBeInTheDocument();
   });
 
   it("follows system theme when preference is set to system", async () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,13 +1,64 @@
-import { NavLink, Route, Routes } from "react-router-dom";
+import { useEffect } from "react";
+import { NavLink, Route, Routes, matchPath, useLocation } from "react-router-dom";
 import { LibraryView } from "./features/projects/LibraryView";
 import { ProjectView } from "./features/projects/ProjectView";
+import { PlaybackProvider, usePlayback } from "./features/projects/playback";
 import { SettingsView } from "./features/settings/SettingsView";
 import { ThemePreviewView } from "./features/settings/ThemePreviewView";
 import { PreferencesProvider, usePreferences } from "./lib/preferences";
 import { ThemeProvider } from "./lib/theme";
 
+function BackgroundPlaybackCard() {
+  const location = useLocation();
+  const { dismissSession, isPlaying, session, togglePlayback } = usePlayback();
+  const routeProjectId =
+    matchPath("/projects/:projectId", location.pathname)?.params.projectId ?? null;
+
+  if (!session || routeProjectId === session.projectId) {
+    return null;
+  }
+
+  return (
+    <div className="background-playback">
+      <div>
+        <span className="metric-label">Background Playback</span>
+        <strong>{session.projectName}</strong>
+        <p className="artifact-meta">{session.stageTitle}</p>
+      </div>
+      <div className="background-playback__controls">
+        <button
+          className="button button--small"
+          type="button"
+          onClick={() => void togglePlayback()}
+        >
+          {isPlaying ? "Pause" : "Play"}
+        </button>
+        <button
+          className="button button--ghost button--small"
+          type="button"
+          onClick={dismissSession}
+        >
+          Stop
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function AppChrome() {
   const { informationDensity, layoutDensity } = usePreferences();
+  const location = useLocation();
+  const { dismissSession, session } = usePlayback();
+  const routeProjectId =
+    matchPath("/projects/:projectId", location.pathname)?.params.projectId ?? null;
+
+  useEffect(() => {
+    if (!routeProjectId || !session || routeProjectId === session.projectId) {
+      return;
+    }
+
+    dismissSession();
+  }, [dismissSession, routeProjectId, session]);
 
   return (
     <div className="app-shell" data-information-density={informationDensity} data-layout-density={layoutDensity}>
@@ -16,6 +67,7 @@ function AppChrome() {
           <span className="brand__eyebrow">Tuneforge</span>
           <strong>Local Practice Rig</strong>
         </div>
+        <BackgroundPlaybackCard />
         <nav className="nav">
           <NavLink to="/" end>
             Library
@@ -39,7 +91,9 @@ export default function App() {
   return (
     <ThemeProvider>
       <PreferencesProvider>
-        <AppChrome />
+        <PlaybackProvider>
+          <AppChrome />
+        </PlaybackProvider>
       </PreferencesProvider>
     </ThemeProvider>
   );

--- a/apps/desktop/src/features/projects/ProjectView.tsx
+++ b/apps/desktop/src/features/projects/ProjectView.tsx
@@ -4,6 +4,13 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import { confirm, save } from "@tauri-apps/plugin-dialog";
 import { api, type ArtifactSchema, type ChordSegmentSchema, type JobSchema } from "../../lib/api";
 import { usePreferences } from "../../lib/preferences";
+import { usePlayback } from "./playback";
+import {
+  clearProjectPlaybackState,
+  readProjectPlaybackState,
+  writeProjectPlaybackState,
+  type StemControlState,
+} from "./projectPlaybackState";
 import {
   DEFAULT_KEY,
   MUSICAL_KEYS,
@@ -17,11 +24,6 @@ import {
   transposeKey,
   type MusicalKey,
 } from "../../lib/music";
-
-type StemControlState = {
-  muted: boolean;
-  solo: boolean;
-};
 
 function useActiveJobPolling(projectId: string, jobs: JobSchema[] | undefined) {
   const queryClient = useQueryClient();
@@ -62,7 +64,12 @@ function isPlayableArtifact(artifact: ArtifactSchema) {
 }
 
 function preferredArtifactSelection(artifacts: ArtifactSchema[]) {
-  return artifacts.find((artifact) => artifact.type === "preview_mix") ?? artifacts[0] ?? null;
+  return (
+    artifacts.find((artifact) => artifact.type === "source_audio") ??
+    artifacts.find((artifact) => artifact.type === "preview_mix") ??
+    artifacts[0] ??
+    null
+  );
 }
 
 function fileNameFromPath(path: string) {
@@ -292,14 +299,25 @@ export function ProjectView() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const {
+    dismissSession,
+    isPlaying,
+    playbackDurationSeconds,
+    playbackTimeSeconds,
+    registerProjectSession,
+    seekBy,
+    seekTo,
+    togglePlayback,
+  } = usePlayback();
+  const {
     defaultInspectorOpen,
     helperTextVisible,
     informationDensity,
     metadataRevealMode,
   } = usePreferences();
-  const primaryAudioRef = useRef<HTMLAudioElement | null>(null);
-  const stemAudioRefs = useRef<Record<string, HTMLAudioElement | null>>({});
   const chordSegmentRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const pendingPreviewSelection = useRef<{ previousLatestPreviewArtifactId: string | null } | null>(
+    null,
+  );
   const [retuneMode, setRetuneMode] = useState<"off" | "reference" | "cents">("off");
   const [referenceHz, setReferenceHz] = useState("440");
   const [centsOffset, setCentsOffset] = useState("0");
@@ -308,13 +326,10 @@ export function ProjectView() {
   const [targetDirty, setTargetDirty] = useState(false);
   const [selectedArtifactId, setSelectedArtifactId] = useState<string | null>(null);
   const [selectedPrimaryArtifactId, setSelectedPrimaryArtifactId] = useState<string | null>(null);
-  const [followLatestPreview, setFollowLatestPreview] = useState(true);
+  const [hydratedProjectId, setHydratedProjectId] = useState<string | null>(null);
   const [isRenaming, setIsRenaming] = useState(false);
   const [draftName, setDraftName] = useState("");
   const [inspectorOpen, setInspectorOpen] = useState(defaultInspectorOpen);
-  const [playbackTimeSeconds, setPlaybackTimeSeconds] = useState(0);
-  const [playbackDurationSeconds, setPlaybackDurationSeconds] = useState(0);
-  const [isPlaying, setIsPlaying] = useState(false);
   const [stemControls, setStemControls] = useState<Record<string, StemControlState>>({});
   const showSupportingCopy = helperTextVisible && informationDensity !== "minimal";
 
@@ -379,7 +394,9 @@ export function ProjectView() {
         throw new Error("Choose a tuning or key change first.");
       }
 
-      setFollowLatestPreview(true);
+      pendingPreviewSelection.current = {
+        previousLatestPreviewArtifactId: latestPreviewArtifact?.id ?? null,
+      };
 
       return api.createPreview(projectId, {
         output_format: "wav",
@@ -398,6 +415,9 @@ export function ProjectView() {
         queryClient.invalidateQueries({ queryKey: ["artifacts", projectId] }),
       ]);
     },
+    onError: () => {
+      pendingPreviewSelection.current = null;
+    },
   });
 
   const stemMutation = useMutation({
@@ -405,7 +425,6 @@ export function ProjectView() {
       if (!selectedPrimaryArtifactId) {
         throw new Error("Select source audio or practice mix first.");
       }
-      setFollowLatestPreview(false);
       return api.createStems(projectId, {
         mode: "two_stem",
         output_format: "wav",
@@ -454,6 +473,8 @@ export function ProjectView() {
   const deleteMutation = useMutation({
     mutationFn: () => api.deleteProject(projectId),
     onSuccess: async () => {
+      dismissSession();
+      clearProjectPlaybackState(projectId);
       await queryClient.invalidateQueries({ queryKey: ["projects"] });
       navigate("/");
     },
@@ -468,7 +489,6 @@ export function ProjectView() {
     },
     onSuccess: async () => {
       setSelectedArtifactId(null);
-      setFollowLatestPreview(false);
       await queryClient.invalidateQueries({ queryKey: ["artifacts", projectId] });
     },
   });
@@ -662,7 +682,6 @@ export function ProjectView() {
   function handleSelectPrimaryArtifact(artifact: ArtifactSchema) {
     setSelectedPrimaryArtifactId(artifact.id);
     setSelectedArtifactId(artifact.id);
-    setFollowLatestPreview(false);
   }
 
   function handleSelectStemArtifact(artifact: ArtifactSchema) {
@@ -671,62 +690,10 @@ export function ProjectView() {
       setSelectedPrimaryArtifactId(sourceArtifactId);
     }
     setSelectedArtifactId(artifact.id);
-    setFollowLatestPreview(false);
-  }
-
-  function setStemAudioRef(artifactId: string, element: HTMLAudioElement | null) {
-    if (element) {
-      stemAudioRefs.current[artifactId] = element;
-    } else {
-      delete stemAudioRefs.current[artifactId];
-    }
-  }
-
-  function getActiveMediaElements() {
-    if (isStemPlayback) {
-      return visibleStemArtifacts
-        .map((artifact) => stemAudioRefs.current[artifact.id])
-        .filter(Boolean) as HTMLAudioElement[];
-    }
-    return primaryAudioRef.current ? [primaryAudioRef.current] : [];
-  }
-
-  function syncPlaybackPosition(nextTime: number) {
-    getActiveMediaElements().forEach((element) => {
-      element.currentTime = nextTime;
-    });
-    setPlaybackTimeSeconds(nextTime);
-  }
-
-  async function togglePlayback() {
-    const activeElements = getActiveMediaElements();
-    if (!activeElements.length) return;
-
-    if (isPlaying) {
-      activeElements.forEach((element) => element.pause());
-      setIsPlaying(false);
-      return;
-    }
-
-    const masterTime = activeElements[0].currentTime;
-    activeElements.forEach((element) => {
-      if (Math.abs(element.currentTime - masterTime) > 0.05) {
-        element.currentTime = masterTime;
-      }
-    });
-
-    await Promise.all(
-      activeElements.map((element) =>
-        Promise.resolve(element.play()).catch(() => undefined),
-      ),
-    );
-    setIsPlaying(true);
   }
 
   function handleSeek(secondsDelta: number) {
-    const duration = playbackDurationSeconds || projectQuery.data?.duration_seconds || 0;
-    const nextTime = Math.max(0, Math.min(duration, playbackTimeSeconds + secondsDelta));
-    syncPlaybackPosition(nextTime);
+    seekBy(secondsDelta);
   }
 
   function toggleStemControl(
@@ -806,35 +773,61 @@ export function ProjectView() {
   }, [defaultInspectorOpen]);
 
   useEffect(() => {
+    const storedPlaybackState = readProjectPlaybackState(projectId);
+    pendingPreviewSelection.current = null;
+    setSelectedArtifactId(storedPlaybackState.selectedArtifactId);
+    setSelectedPrimaryArtifactId(storedPlaybackState.selectedPrimaryArtifactId);
+    setStemControls(storedPlaybackState.stemControls);
+    setHydratedProjectId(projectId);
+  }, [projectId]);
+
+  useEffect(() => {
+    if (hydratedProjectId !== projectId) {
+      return;
+    }
+
     if (!defaultPrimaryArtifact) {
       setSelectedPrimaryArtifactId(null);
       setSelectedArtifactId(null);
       return;
     }
 
-    if (
-      !selectedPrimaryArtifactId ||
-      !primaryArtifacts.some((artifact) => artifact.id === selectedPrimaryArtifactId)
-    ) {
-      setSelectedPrimaryArtifactId(defaultPrimaryArtifact.id);
-    }
+    const shouldSelectNewPreview =
+      pendingPreviewSelection.current &&
+      latestPreviewArtifact &&
+      latestPreviewArtifact.id !== pendingPreviewSelection.current.previousLatestPreviewArtifactId;
 
-    if (
-      !selectedArtifactId ||
-      !selectableArtifacts.some((artifact) => artifact.id === selectedArtifactId)
-    ) {
-      setSelectedArtifactId(defaultPrimaryArtifact.id);
-    }
-
-    if (followLatestPreview && latestPreviewArtifact) {
+    if (shouldSelectNewPreview) {
       setSelectedPrimaryArtifactId(latestPreviewArtifact.id);
       setSelectedArtifactId(latestPreviewArtifact.id);
+      pendingPreviewSelection.current = null;
+      return;
+    }
+
+    const nextSelectedArtifact =
+      selectableArtifacts.find((artifact) => artifact.id === selectedArtifactId) ?? null;
+    const derivedPrimaryId = sourceArtifactIdForStems(nextSelectedArtifact);
+    const nextPrimaryArtifactId =
+      primaryArtifacts.some((artifact) => artifact.id === selectedPrimaryArtifactId)
+        ? selectedPrimaryArtifactId
+        : derivedPrimaryId && primaryArtifacts.some((artifact) => artifact.id === derivedPrimaryId)
+          ? derivedPrimaryId
+          : defaultPrimaryArtifact.id;
+    const nextSelectedArtifactId = nextSelectedArtifact?.id ?? nextPrimaryArtifactId;
+
+    if (selectedPrimaryArtifactId !== nextPrimaryArtifactId) {
+      setSelectedPrimaryArtifactId(nextPrimaryArtifactId);
+    }
+
+    if (selectedArtifactId !== nextSelectedArtifactId) {
+      setSelectedArtifactId(nextSelectedArtifactId);
     }
   }, [
     defaultPrimaryArtifact,
-    followLatestPreview,
+    hydratedProjectId,
     latestPreviewArtifact,
     primaryArtifacts,
+    projectId,
     selectableArtifacts,
     selectedArtifactId,
     selectedPrimaryArtifactId,
@@ -851,30 +844,22 @@ export function ProjectView() {
   }, [visibleStemArtifacts]);
 
   useEffect(() => {
-    const hasSolo = soloedStemIds.length > 0;
-    visibleStemArtifacts.forEach((artifact) => {
-      const element = stemAudioRefs.current[artifact.id];
-      if (!element) return;
-      const state = stemControls[artifact.id] ?? { muted: false, solo: false };
-      element.volume = hasSolo ? (state.solo ? 1 : 0) : state.muted ? 0 : 1;
-    });
-  }, [soloedStemIds, stemControls, visibleStemArtifacts]);
-
-  useEffect(() => {
-    primaryAudioRef.current?.pause();
-    Object.values(stemAudioRefs.current).forEach((element) => element?.pause());
-    setIsPlaying(false);
-    setPlaybackTimeSeconds(0);
-    setPlaybackDurationSeconds(0);
-    if (primaryAudioRef.current) {
-      primaryAudioRef.current.currentTime = 0;
+    if (hydratedProjectId !== projectId) {
+      return;
     }
-    Object.values(stemAudioRefs.current).forEach((element) => {
-      if (element) {
-        element.currentTime = 0;
-      }
+
+    writeProjectPlaybackState(projectId, {
+      selectedArtifactId,
+      selectedPrimaryArtifactId,
+      stemControls,
     });
-  }, [selectedArtifact?.id, selectedPrimaryArtifact?.id]);
+  }, [
+    hydratedProjectId,
+    projectId,
+    selectedArtifactId,
+    selectedPrimaryArtifactId,
+    stemControls,
+  ]);
 
   useEffect(() => {
     if (activeChordIndex < 0) {
@@ -913,6 +898,36 @@ export function ProjectView() {
   const stageSummary = isStemPlayback
     ? `${activeStemCount} of ${visibleStemArtifacts.length} stems audible`
     : selectedArtifactSummary || currentSourceSummary;
+
+  useEffect(() => {
+    if (hydratedProjectId !== projectId || !projectId || !selectedPlaybackArtifact) {
+      return;
+    }
+
+    registerProjectSession({
+      projectId,
+      projectName: projectQuery.data?.display_name ?? "Project",
+      stageTitle,
+      stageSummary,
+      selectedPlaybackArtifactId: selectedPlaybackArtifact.id,
+      isStemPlayback,
+      visibleStemArtifactIds: visibleStemArtifacts.map((artifact) => artifact.id),
+      stemControls,
+      durationHintSeconds: projectQuery.data?.duration_seconds ?? 0,
+    });
+  }, [
+    hydratedProjectId,
+    isStemPlayback,
+    projectId,
+    projectQuery.data?.display_name,
+    projectQuery.data?.duration_seconds,
+    registerProjectSession,
+    selectedPlaybackArtifact,
+    stageSummary,
+    stageTitle,
+    stemControls,
+    visibleStemArtifacts,
+  ]);
 
   return (
     <section className="screen">
@@ -1190,7 +1205,7 @@ export function ProjectView() {
                     aria-label="Playback position"
                     max={playbackDurationSeconds || projectQuery.data?.duration_seconds || 0}
                     min={0}
-                    onChange={(event) => syncPlaybackPosition(Number(event.target.value))}
+                    onChange={(event) => seekTo(Number(event.target.value))}
                     step={0.1}
                     type="range"
                     value={Math.min(
@@ -1267,7 +1282,7 @@ export function ProjectView() {
                             `${segment.start_seconds}-${segment.label}-${index}`
                           ] = element;
                         }}
-                        onClick={() => syncPlaybackPosition(segment.start_seconds)}
+                        onClick={() => seekTo(segment.start_seconds)}
                       >
                         <span>{segment.label}</span>
                         <small>{formatPlaybackClock(segment.start_seconds)}</small>
@@ -1381,50 +1396,6 @@ export function ProjectView() {
                 </div>
               </div>
             ) : null}
-
-            <audio
-              ref={primaryAudioRef}
-              src={
-                !isStemPlayback && selectedPlaybackArtifact
-                  ? api.streamArtifactUrl(selectedPlaybackArtifact.id)
-                  : undefined
-              }
-              preload="metadata"
-              className="player player--hidden"
-              onTimeUpdate={(event) => setPlaybackTimeSeconds(event.currentTarget.currentTime)}
-              onLoadedMetadata={(event) =>
-                setPlaybackDurationSeconds(event.currentTarget.duration)
-              }
-              onDurationChange={(event) =>
-                setPlaybackDurationSeconds(event.currentTarget.duration)
-              }
-              onEnded={() => setIsPlaying(false)}
-            />
-            {visibleStemArtifacts.map((artifact, index) => (
-              <audio
-                key={artifact.id}
-                ref={(element) => setStemAudioRef(artifact.id, element)}
-                src={api.streamArtifactUrl(artifact.id)}
-                preload="metadata"
-                className="player player--hidden"
-                onTimeUpdate={
-                  index === 0
-                    ? (event) => setPlaybackTimeSeconds(event.currentTarget.currentTime)
-                    : undefined
-                }
-                onLoadedMetadata={
-                  index === 0
-                    ? (event) => setPlaybackDurationSeconds(event.currentTarget.duration)
-                    : undefined
-                }
-                onDurationChange={
-                  index === 0
-                    ? (event) => setPlaybackDurationSeconds(event.currentTarget.duration)
-                    : undefined
-                }
-                onEnded={index === 0 ? () => setIsPlaying(false) : undefined}
-              />
-            ))}
 
             <div className="playback-stage__footer">
               <div>

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -1,0 +1,610 @@
+/* eslint-disable react-refresh/only-export-components */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { api } from "../../lib/api";
+import type { StemControlState } from "./projectPlaybackState";
+
+type PendingTransition = {
+  id: number;
+  signature: string;
+  shouldPlay: boolean;
+  targetTime: number;
+};
+
+export type ProjectPlaybackSession = {
+  projectId: string;
+  projectName: string;
+  stageTitle: string;
+  stageSummary: string;
+  selectedPlaybackArtifactId: string | null;
+  isStemPlayback: boolean;
+  visibleStemArtifactIds: string[];
+  stemControls: Record<string, StemControlState>;
+  durationHintSeconds: number;
+};
+
+type PlaybackContextValue = {
+  session: ProjectPlaybackSession | null;
+  playbackTimeSeconds: number;
+  playbackDurationSeconds: number;
+  isPlaying: boolean;
+  registerProjectSession: (session: ProjectPlaybackSession) => void;
+  togglePlayback: () => Promise<void>;
+  playPlayback: () => Promise<void>;
+  pausePlayback: () => void;
+  stopPlayback: () => void;
+  dismissSession: () => void;
+  seekBy: (secondsDelta: number) => void;
+  seekTo: (timeSeconds: number) => void;
+};
+
+const PlaybackContext = createContext<PlaybackContextValue | null>(null);
+
+function playbackSignature(session: ProjectPlaybackSession | null) {
+  if (!session) {
+    return "none";
+  }
+
+  const activeSignature = session.isStemPlayback
+    ? `stems:${session.visibleStemArtifactIds.join(",")}`
+    : `primary:${session.selectedPlaybackArtifactId ?? "none"}`;
+  return `${session.projectId}:${activeSignature}`;
+}
+
+function isInteractiveTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  return Boolean(
+    target.closest(
+      'input, textarea, select, button, a, summary, [contenteditable="true"], [role="button"]',
+    ),
+  );
+}
+
+function clampTime(value: number, duration: number) {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  if (!Number.isFinite(duration) || duration <= 0) {
+    return Math.max(0, value);
+  }
+  return Math.max(0, Math.min(duration, value));
+}
+
+export function PlaybackProvider({ children }: { children: ReactNode }) {
+  const primaryAudioRef = useRef<HTMLAudioElement | null>(null);
+  const stemAudioRefs = useRef<Record<string, HTMLAudioElement | null>>({});
+  const pendingTransitionRef = useRef<PendingTransition | null>(null);
+  const transitionCounterRef = useRef(0);
+  const sessionRef = useRef<ProjectPlaybackSession | null>(null);
+  const playbackTimeSecondsRef = useRef(0);
+  const playbackDurationSecondsRef = useRef(0);
+  const isPlayingRef = useRef(false);
+  const [session, setSession] = useState<ProjectPlaybackSession | null>(null);
+  const [playbackTimeSeconds, setPlaybackTimeSeconds] = useState(0);
+  const [playbackDurationSeconds, setPlaybackDurationSeconds] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  useEffect(() => {
+    sessionRef.current = session;
+  }, [session]);
+
+  useEffect(() => {
+    playbackTimeSecondsRef.current = playbackTimeSeconds;
+  }, [playbackTimeSeconds]);
+
+  useEffect(() => {
+    playbackDurationSecondsRef.current = playbackDurationSeconds;
+  }, [playbackDurationSeconds]);
+
+  useEffect(() => {
+    isPlayingRef.current = isPlaying;
+  }, [isPlaying]);
+
+  function setStemAudioRef(artifactId: string, element: HTMLAudioElement | null) {
+    if (element) {
+      stemAudioRefs.current[artifactId] = element;
+      return;
+    }
+    delete stemAudioRefs.current[artifactId];
+  }
+
+  function getStemElements(artifactIds: string[]) {
+    return artifactIds
+      .map((artifactId) => stemAudioRefs.current[artifactId])
+      .filter(Boolean) as HTMLAudioElement[];
+  }
+
+  function getRenderedMediaElements(targetSession = sessionRef.current) {
+    if (!targetSession) {
+      return [] as HTMLAudioElement[];
+    }
+
+    return [
+      ...(primaryAudioRef.current ? [primaryAudioRef.current] : []),
+      ...getStemElements(targetSession.visibleStemArtifactIds),
+    ];
+  }
+
+  function getActiveMediaElements(targetSession = sessionRef.current) {
+    if (!targetSession) {
+      return [] as HTMLAudioElement[];
+    }
+
+    if (targetSession.isStemPlayback) {
+      return getStemElements(targetSession.visibleStemArtifactIds);
+    }
+
+    return primaryAudioRef.current && targetSession.selectedPlaybackArtifactId
+      ? [primaryAudioRef.current]
+      : [];
+  }
+
+  function applyStemVolumes(targetSession = sessionRef.current) {
+    if (!targetSession) {
+      return;
+    }
+
+    const soloedStemIds = targetSession.visibleStemArtifactIds.filter(
+      (artifactId) => targetSession.stemControls[artifactId]?.solo,
+    );
+    const hasSolo = soloedStemIds.length > 0;
+    targetSession.visibleStemArtifactIds.forEach((artifactId) => {
+      const element = stemAudioRefs.current[artifactId];
+      if (!element) {
+        return;
+      }
+
+      const state = targetSession.stemControls[artifactId] ?? {
+        muted: false,
+        solo: false,
+      };
+      element.volume = hasSolo ? (state.solo ? 1 : 0) : state.muted ? 0 : 1;
+    });
+  }
+
+  function readMasterTime(targetSession = sessionRef.current) {
+    return getActiveMediaElements(targetSession)[0]?.currentTime ?? playbackTimeSecondsRef.current;
+  }
+
+  function updateDurationFromActiveMedia(targetSession = sessionRef.current) {
+    const duration = getActiveMediaElements(targetSession)[0]?.duration;
+    if (Number.isFinite(duration) && duration >= 0) {
+      setPlaybackDurationSeconds(duration);
+    } else if (targetSession) {
+      setPlaybackDurationSeconds(targetSession.durationHintSeconds || 0);
+    }
+  }
+
+  function clearPendingTransition() {
+    pendingTransitionRef.current = null;
+  }
+
+  function tryCompletePendingTransition() {
+    const pendingTransition = pendingTransitionRef.current;
+    const targetSession = sessionRef.current;
+    if (!pendingTransition || !targetSession) {
+      return;
+    }
+
+    const targetElements = getActiveMediaElements(targetSession);
+    if (!targetElements.length) {
+      return;
+    }
+
+    const ready = targetElements.every(
+      (element) =>
+        element.readyState >= HTMLMediaElement.HAVE_METADATA ||
+        (Number.isFinite(element.duration) && element.duration > 0),
+    );
+    if (!ready) {
+      return;
+    }
+
+    const nextTime = clampTime(
+      pendingTransition.targetTime,
+      targetElements[0]?.duration ?? playbackDurationSecondsRef.current,
+    );
+    targetElements.forEach((element) => {
+      if (Math.abs(element.currentTime - nextTime) > 0.01) {
+        element.currentTime = nextTime;
+      }
+    });
+    applyStemVolumes(targetSession);
+    setPlaybackTimeSeconds(nextTime);
+    updateDurationFromActiveMedia(targetSession);
+
+    const transitionId = pendingTransition.id;
+    const transitionSignature = pendingTransition.signature;
+    clearPendingTransition();
+
+    if (!pendingTransition.shouldPlay) {
+      targetElements.forEach((element) => element.pause());
+      setIsPlaying(false);
+      return;
+    }
+
+    void Promise.allSettled(
+      targetElements.map((element) => Promise.resolve(element.play())),
+    ).then((results) => {
+      if (pendingTransitionRef.current?.id === transitionId) {
+        return;
+      }
+      if (playbackSignature(sessionRef.current) !== transitionSignature) {
+        return;
+      }
+      setIsPlaying(results.some((result) => result.status === "fulfilled"));
+    });
+  }
+
+  const pausePlayback = useCallback(() => {
+    const pendingTransition = pendingTransitionRef.current;
+    if (pendingTransition) {
+      pendingTransition.shouldPlay = false;
+    }
+
+    getActiveMediaElements().forEach((element) => element.pause());
+    setIsPlaying(false);
+  }, []);
+
+  const playPlayback = useCallback(async () => {
+    const targetSession = sessionRef.current;
+    if (!targetSession) {
+      return;
+    }
+
+    tryCompletePendingTransition();
+
+    const activeElements = getActiveMediaElements(targetSession);
+    if (!activeElements.length) {
+      return;
+    }
+
+    const masterTime = readMasterTime(targetSession);
+    activeElements.forEach((element) => {
+      if (Math.abs(element.currentTime - masterTime) > 0.01) {
+        element.currentTime = masterTime;
+      }
+    });
+    applyStemVolumes(targetSession);
+
+    const results = await Promise.allSettled(
+      activeElements.map((element) => Promise.resolve(element.play())),
+    );
+    setIsPlaying(results.some((result) => result.status === "fulfilled"));
+  }, []);
+
+  const togglePlayback = useCallback(async () => {
+    if (isPlayingRef.current) {
+      pausePlayback();
+      return;
+    }
+    await playPlayback();
+  }, [pausePlayback, playPlayback]);
+
+  const seekTo = useCallback((timeSeconds: number) => {
+    const nextTime = clampTime(timeSeconds, playbackDurationSecondsRef.current);
+    const pendingTransition = pendingTransitionRef.current;
+    if (pendingTransition) {
+      pendingTransition.targetTime = nextTime;
+    }
+
+    getActiveMediaElements().forEach((element) => {
+      element.currentTime = nextTime;
+    });
+    setPlaybackTimeSeconds(nextTime);
+  }, []);
+
+  const seekBy = useCallback(
+    (secondsDelta: number) => {
+      seekTo(readMasterTime() + secondsDelta);
+    },
+    [seekTo],
+  );
+
+  const stopPlayback = useCallback(() => {
+    clearPendingTransition();
+    getRenderedMediaElements().forEach((element) => {
+      element.pause();
+      element.currentTime = 0;
+    });
+    setPlaybackTimeSeconds(0);
+    setIsPlaying(false);
+    updateDurationFromActiveMedia();
+  }, []);
+
+  const dismissSession = useCallback(() => {
+    stopPlayback();
+    setSession(null);
+    sessionRef.current = null;
+    setPlaybackDurationSeconds(0);
+  }, [stopPlayback]);
+
+  const registerProjectSession = useCallback((nextSession: ProjectPlaybackSession) => {
+    const previousSession = sessionRef.current;
+    const previousSignature = playbackSignature(previousSession);
+    const nextSignature = playbackSignature(nextSession);
+
+    if (previousSession && previousSession.projectId !== nextSession.projectId) {
+      clearPendingTransition();
+      getRenderedMediaElements(previousSession).forEach((element) => {
+        element.pause();
+        element.currentTime = 0;
+      });
+      setPlaybackTimeSeconds(0);
+      setPlaybackDurationSeconds(nextSession.durationHintSeconds || 0);
+      setIsPlaying(false);
+    } else if (previousSession && previousSignature !== nextSignature) {
+      const nextTime = readMasterTime(previousSession);
+      const shouldPlay = isPlayingRef.current;
+      if (shouldPlay) {
+        getActiveMediaElements(previousSession).forEach((element) => element.pause());
+      }
+      pendingTransitionRef.current = {
+        id: ++transitionCounterRef.current,
+        signature: nextSignature,
+        shouldPlay,
+        targetTime: nextTime,
+      };
+      setPlaybackTimeSeconds(nextTime);
+    } else if (!previousSession) {
+      setPlaybackTimeSeconds(0);
+      setPlaybackDurationSeconds(nextSession.durationHintSeconds || 0);
+      setIsPlaying(false);
+    }
+
+    sessionRef.current = nextSession;
+    setSession(nextSession);
+  }, []);
+
+  useEffect(() => {
+    applyStemVolumes(session);
+    tryCompletePendingTransition();
+    updateDurationFromActiveMedia(session);
+  }, [session]);
+
+  useEffect(() => {
+    if (typeof navigator === "undefined" || !("mediaSession" in navigator)) {
+      return;
+    }
+
+    if (!session) {
+      try {
+        navigator.mediaSession.metadata = null;
+        navigator.mediaSession.playbackState = "none";
+      } catch {
+        return;
+      }
+      return;
+    }
+
+    try {
+      if (typeof MediaMetadata !== "undefined") {
+        navigator.mediaSession.metadata = new MediaMetadata({
+          title: session.stageTitle || session.projectName,
+          artist: session.projectName,
+          album: session.stageSummary,
+        });
+      }
+
+      navigator.mediaSession.playbackState = isPlaying ? "playing" : "paused";
+      navigator.mediaSession.setActionHandler("play", () => {
+        void playPlayback();
+      });
+      navigator.mediaSession.setActionHandler("pause", () => {
+        pausePlayback();
+      });
+      navigator.mediaSession.setActionHandler("stop", () => {
+        stopPlayback();
+      });
+      navigator.mediaSession.setActionHandler("seekbackward", () => {
+        seekBy(-10);
+      });
+      navigator.mediaSession.setActionHandler("seekforward", () => {
+        seekBy(10);
+      });
+      navigator.mediaSession.setActionHandler("previoustrack", () => {
+        seekBy(-10);
+      });
+      navigator.mediaSession.setActionHandler("nexttrack", () => {
+        seekBy(10);
+      });
+
+      if (
+        typeof navigator.mediaSession.setPositionState === "function" &&
+        Number.isFinite(playbackDurationSeconds) &&
+        playbackDurationSeconds > 0
+      ) {
+        navigator.mediaSession.setPositionState({
+          duration: playbackDurationSeconds,
+          playbackRate: 1,
+          position: clampTime(playbackTimeSeconds, playbackDurationSeconds),
+        });
+      }
+    } catch {
+      return;
+    }
+
+    return () => {
+      try {
+        navigator.mediaSession.setActionHandler("play", null);
+        navigator.mediaSession.setActionHandler("pause", null);
+        navigator.mediaSession.setActionHandler("stop", null);
+        navigator.mediaSession.setActionHandler("seekbackward", null);
+        navigator.mediaSession.setActionHandler("seekforward", null);
+        navigator.mediaSession.setActionHandler("previoustrack", null);
+        navigator.mediaSession.setActionHandler("nexttrack", null);
+      } catch {
+        return;
+      }
+    };
+  }, [
+    isPlaying,
+    pausePlayback,
+    playbackDurationSeconds,
+    playbackTimeSeconds,
+    playPlayback,
+    seekBy,
+    session,
+    stopPlayback,
+  ]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (!sessionRef.current || event.defaultPrevented) {
+        return;
+      }
+      if (event.repeat || event.metaKey || event.ctrlKey || event.altKey) {
+        return;
+      }
+      if (event.code !== "Space" && event.key !== " ") {
+        return;
+      }
+      if (isInteractiveTarget(event.target)) {
+        return;
+      }
+
+      event.preventDefault();
+      void togglePlayback();
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [togglePlayback]);
+
+  const value = useMemo<PlaybackContextValue>(
+    () => ({
+      session,
+      playbackTimeSeconds,
+      playbackDurationSeconds,
+      isPlaying,
+      registerProjectSession,
+      togglePlayback,
+      playPlayback,
+      pausePlayback,
+      stopPlayback,
+      dismissSession,
+      seekBy,
+      seekTo,
+    }),
+    [
+      dismissSession,
+      isPlaying,
+      pausePlayback,
+      playbackDurationSeconds,
+      playbackTimeSeconds,
+      playPlayback,
+      registerProjectSession,
+      seekBy,
+      seekTo,
+      session,
+      stopPlayback,
+      togglePlayback,
+    ],
+  );
+
+  return (
+    <PlaybackContext.Provider value={value}>
+      {children}
+      <audio
+        ref={primaryAudioRef}
+        src={
+          session && !session.isStemPlayback && session.selectedPlaybackArtifactId
+            ? api.streamArtifactUrl(session.selectedPlaybackArtifactId)
+            : undefined
+        }
+        preload="metadata"
+        className="player player--hidden"
+        onTimeUpdate={(event) => {
+          if (!sessionRef.current || sessionRef.current.isStemPlayback) {
+            return;
+          }
+          setPlaybackTimeSeconds(event.currentTarget.currentTime);
+        }}
+        onLoadedMetadata={() => {
+          updateDurationFromActiveMedia();
+          tryCompletePendingTransition();
+        }}
+        onDurationChange={() => {
+          updateDurationFromActiveMedia();
+          tryCompletePendingTransition();
+        }}
+        onCanPlay={tryCompletePendingTransition}
+        onEnded={() => {
+          if (!sessionRef.current || sessionRef.current.isStemPlayback) {
+            return;
+          }
+          setIsPlaying(false);
+        }}
+      />
+      {session?.visibleStemArtifactIds.map((artifactId, index) => (
+        <audio
+          key={artifactId}
+          ref={(element) => setStemAudioRef(artifactId, element)}
+          src={api.streamArtifactUrl(artifactId)}
+          preload="metadata"
+          className="player player--hidden"
+          onTimeUpdate={(event) => {
+            if (!sessionRef.current || !sessionRef.current.isStemPlayback) {
+              return;
+            }
+            if (sessionRef.current.visibleStemArtifactIds[0] !== artifactId) {
+              return;
+            }
+            setPlaybackTimeSeconds(event.currentTarget.currentTime);
+          }}
+          onLoadedMetadata={() => {
+            if (sessionRef.current?.visibleStemArtifactIds[0] !== artifactId) {
+              return;
+            }
+            updateDurationFromActiveMedia();
+            tryCompletePendingTransition();
+          }}
+          onDurationChange={() => {
+            if (sessionRef.current?.visibleStemArtifactIds[0] !== artifactId) {
+              return;
+            }
+            updateDurationFromActiveMedia();
+            tryCompletePendingTransition();
+          }}
+          onCanPlay={() => {
+            if (index === 0) {
+              tryCompletePendingTransition();
+            }
+          }}
+          onEnded={() => {
+            if (!sessionRef.current || !sessionRef.current.isStemPlayback) {
+              return;
+            }
+            if (sessionRef.current.visibleStemArtifactIds[0] !== artifactId) {
+              return;
+            }
+            setIsPlaying(false);
+          }}
+        />
+      ))}
+    </PlaybackContext.Provider>
+  );
+}
+
+export function usePlayback() {
+  const context = useContext(PlaybackContext);
+  if (!context) {
+    throw new Error("usePlayback must be used within a PlaybackProvider.");
+  }
+  return context;
+}

--- a/apps/desktop/src/features/projects/projectPlaybackState.ts
+++ b/apps/desktop/src/features/projects/projectPlaybackState.ts
@@ -1,0 +1,108 @@
+export type StemControlState = {
+  muted: boolean;
+  solo: boolean;
+};
+
+export type StoredProjectPlaybackState = {
+  selectedArtifactId: string | null;
+  selectedPrimaryArtifactId: string | null;
+  stemControls: Record<string, StemControlState>;
+};
+
+const STORAGE_KEY = "tuneforge.project-playback-state";
+
+const DEFAULT_STORED_PROJECT_PLAYBACK_STATE: StoredProjectPlaybackState = {
+  selectedArtifactId: null,
+  selectedPrimaryArtifactId: null,
+  stemControls: {},
+};
+
+function normalizeStemControlState(value: unknown): StemControlState {
+  if (!value || typeof value !== "object") {
+    return { muted: false, solo: false };
+  }
+
+  const candidate = value as Partial<StemControlState>;
+  return {
+    muted: Boolean(candidate.muted),
+    solo: Boolean(candidate.solo),
+  };
+}
+
+function normalizeStoredProjectPlaybackState(value: unknown): StoredProjectPlaybackState {
+  if (!value || typeof value !== "object") {
+    return DEFAULT_STORED_PROJECT_PLAYBACK_STATE;
+  }
+
+  const candidate = value as Partial<StoredProjectPlaybackState>;
+  const stemControlsInput =
+    candidate.stemControls && typeof candidate.stemControls === "object"
+      ? candidate.stemControls
+      : {};
+  const stemControls = Object.fromEntries(
+    Object.entries(stemControlsInput).map(([artifactId, controlState]) => [
+      artifactId,
+      normalizeStemControlState(controlState),
+    ]),
+  );
+
+  return {
+    selectedArtifactId:
+      typeof candidate.selectedArtifactId === "string" ? candidate.selectedArtifactId : null,
+    selectedPrimaryArtifactId:
+      typeof candidate.selectedPrimaryArtifactId === "string"
+        ? candidate.selectedPrimaryArtifactId
+        : null,
+    stemControls,
+  };
+}
+
+function readPlaybackStateMap() {
+  if (typeof window === "undefined") {
+    return {} as Record<string, StoredProjectPlaybackState>;
+  }
+
+  const storedValue = window.localStorage.getItem(STORAGE_KEY);
+  if (!storedValue) {
+    return {} as Record<string, StoredProjectPlaybackState>;
+  }
+
+  try {
+    const parsed = JSON.parse(storedValue) as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.entries(parsed).map(([projectId, playbackState]) => [
+        projectId,
+        normalizeStoredProjectPlaybackState(playbackState),
+      ]),
+    );
+  } catch {
+    return {} as Record<string, StoredProjectPlaybackState>;
+  }
+}
+
+function writePlaybackStateMap(value: Record<string, StoredProjectPlaybackState>) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+}
+
+export function readProjectPlaybackState(projectId: string): StoredProjectPlaybackState {
+  return readPlaybackStateMap()[projectId] ?? DEFAULT_STORED_PROJECT_PLAYBACK_STATE;
+}
+
+export function writeProjectPlaybackState(
+  projectId: string,
+  playbackState: StoredProjectPlaybackState,
+) {
+  const next = readPlaybackStateMap();
+  next[projectId] = normalizeStoredProjectPlaybackState(playbackState);
+  writePlaybackStateMap(next);
+}
+
+export function clearProjectPlaybackState(projectId: string) {
+  const next = readPlaybackStateMap();
+  delete next[projectId];
+  writePlaybackStateMap(next);
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -125,6 +125,28 @@ a {
   gap: 0.25rem;
 }
 
+.background-playback {
+  display: grid;
+  gap: 0.8rem;
+  padding: 0.9rem;
+  border: 1px solid color-mix(in srgb, var(--playback-accent) 32%, transparent);
+  border-radius: 20px;
+  background:
+    radial-gradient(circle at top left, color-mix(in srgb, var(--playback-accent) 18%, transparent), transparent 42%),
+    color-mix(in srgb, var(--panel-strong) 84%, transparent);
+}
+
+.background-playback strong {
+  display: block;
+  margin-top: 0.22rem;
+}
+
+.background-playback__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
 .brand__eyebrow,
 .eyebrow {
   text-transform: uppercase;
@@ -1282,6 +1304,7 @@ a {
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
+    flex-wrap: wrap;
   }
 
   .nav {


### PR DESCRIPTION
## Summary
- move playback into an app-level transport so project navigation and source/mix/stem switches preserve position and pause/play state
- add project-scoped playback persistence for selected source or mix, stem mode, and stem mute or solo controls
- add global spacebar and media-session controls plus sidebar background playback controls and regression coverage for async mix handoff

## Testing
- `pnpm --filter @tuneforge/desktop test -- --runInBand`
- `pnpm --filter @tuneforge/desktop typecheck`
