### PR TITLE
fix: preserve seamless mix and stem playback

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -555,6 +555,7 @@ function markAudioReady(element: HTMLAudioElement, duration = 182) {
   });
   fireEvent.loadedMetadata(element);
   fireEvent.canPlay(element);
+  fireEvent.seeked(element);
 }
 
 describe("Desktop app flows", () => {
@@ -746,6 +747,102 @@ describe("Desktop app flows", () => {
     expect(screen.getAllByText("Stem monitor").length).toBeGreaterThan(0);
   });
 
+  it("restores mix-owned stems after reopening the project", async () => {
+    const user = userEvent.setup();
+    setProjects([
+      {
+        id: "proj_123",
+        display_name: "Demo Song",
+        source_path: "/tmp/demo.wav",
+        imported_path: "/tmp/projects/demo.wav",
+        duration_seconds: 182,
+        sample_rate: 44100,
+        channels: 2,
+        created_at: "2026-04-18T13:16:00.000Z",
+        updated_at: "2026-04-18T13:16:00.000Z",
+      },
+      {
+        id: "proj_456",
+        display_name: "Bass Drill",
+        source_path: "/tmp/bass-drill.wav",
+        imported_path: "/tmp/projects/bass-drill.wav",
+        duration_seconds: 120,
+        sample_rate: 48000,
+        channels: 2,
+        created_at: "2026-04-18T13:16:00.000Z",
+        updated_at: "2026-04-18T13:16:00.000Z",
+      },
+    ]);
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+
+    const savedMixList = screen.getByRole("group", { name: "Saved mix list" });
+    await user.click(within(savedMixList).getByRole("button", { name: /Practice Mix/i }));
+    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+
+    expect(mockCreateStems).toHaveBeenLastCalledWith(
+      "proj_123",
+      expect.objectContaining({
+        mode: "two_stem",
+        output_format: "wav",
+        force: false,
+        source_artifact_id: "art_preview",
+      }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Switch to Stems" }));
+
+    expect(await screen.findByRole("heading", { name: "Vocals" })).toBeInTheDocument();
+    expect(
+      within(screen.getByRole("group", { name: "Current source summary" })).getByText(
+        "Practice Mix",
+      ),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        JSON.parse(window.localStorage.getItem("tuneforge.project-playback-state") ?? "{}"),
+      ).toMatchObject({
+        proj_123: {
+          selectedArtifactId: "art_202",
+          selectedPrimaryArtifactId: "art_preview",
+          selectedStemSourceArtifactId: "art_preview",
+        },
+      }),
+    );
+
+    await user.click(screen.getAllByRole("link", { name: "Library" })[0]);
+    const secondProjectCard = screen.getByText("Bass Drill").closest("article");
+    expect(secondProjectCard).not.toBeNull();
+    await user.click(
+      within(secondProjectCard as HTMLElement).getByRole("link", { name: /Open project/i }),
+    );
+
+    expect(await screen.findByRole("heading", { name: "Bass Drill" })).toBeInTheDocument();
+
+    await user.click(screen.getAllByRole("link", { name: "Library" })[0]);
+    const demoProjectCard = screen.getByText("Demo Song").closest("article");
+    expect(demoProjectCard).not.toBeNull();
+    await user.click(
+      within(demoProjectCard as HTMLElement).getByRole("link", { name: /Open project/i }),
+    );
+
+    expect(await screen.findByRole("heading", { name: "Vocals" })).toBeInTheDocument();
+    expect(screen.getAllByText("Stem monitor").length).toBeGreaterThan(0);
+    expect(
+      within(screen.getByRole("group", { name: "Current source summary" })).getByText(
+        "Practice Mix",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByRole("group", { name: "Current source summary" })).queryByText(
+        "Source Track",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
   it("toggles playback with spacebar and preserves time when switching mixes", async () => {
     const user = userEvent.setup();
     renderApp(["/projects/proj_123"]);
@@ -760,7 +857,7 @@ describe("Desktop app flows", () => {
       expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument(),
     );
 
-    sourceAudio.currentTime = 47.25;
+    sourceAudio.currentTime = 47.253;
     fireEvent.timeUpdate(sourceAudio);
 
     const savedMixList = screen.getByRole("group", { name: "Saved mix list" });
@@ -769,8 +866,9 @@ describe("Desktop app flows", () => {
     const previewAudio = findAudioByArtifactId("art_preview");
     markAudioReady(previewAudio);
 
-    await waitFor(() => expect(previewAudio.currentTime).toBeCloseTo(47.25, 2));
+    await waitFor(() => expect(previewAudio.currentTime).toBeCloseTo(47.253, 3));
     expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Playback position")).toHaveAttribute("step", "0.001");
   });
 
   it("keeps playback position when a newly created mix becomes active", async () => {
@@ -788,7 +886,7 @@ describe("Desktop app flows", () => {
     markAudioReady(sourceAudio);
     await user.click(screen.getByRole("button", { name: "Play playback" }));
 
-    sourceAudio.currentTime = 61.4;
+    sourceAudio.currentTime = 61.437;
     fireEvent.timeUpdate(sourceAudio);
 
     await user.click(screen.getByLabelText("Raise target key"));
@@ -811,11 +909,57 @@ describe("Desktop app flows", () => {
     });
 
     await waitFor(() =>
-      expect(screen.getByRole("heading", { name: "Practice Mix" })).toBeInTheDocument(),
+      expect(
+        document.querySelector('audio[src*="/artifacts/art_200/stream"]'),
+      ).toBeTruthy(),
     );
     const newestPreviewAudio = findAudioByArtifactId("art_200");
     markAudioReady(newestPreviewAudio);
-    await waitFor(() => expect(newestPreviewAudio.currentTime).toBeCloseTo(61.4, 2));
+    expect(screen.getByRole("heading", { name: "Practice Mix" })).toBeInTheDocument();
+    await waitFor(() => expect(newestPreviewAudio.currentTime).toBeCloseTo(61.437, 3));
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+  });
+
+  it("resumes playback when stem tracks become ready out of order", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    sourceAudio.currentTime = 18.789;
+    fireEvent.timeUpdate(sourceAudio);
+
+    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    const stemList = await screen.findByRole("group", { name: "Stem track list" });
+    const playCallsBeforeStemSwitch = vi.mocked(window.HTMLMediaElement.prototype.play).mock.calls.length;
+    await user.click(within(stemList).getByRole("button", { name: /Vocals/i }));
+
+    await waitFor(() =>
+      expect(
+        document.querySelector('audio[src*="/artifacts/art_200/stream"]'),
+      ).toBeTruthy(),
+    );
+
+    const vocalAudio = findAudioByArtifactId("art_200");
+    const instrumentalAudio = findAudioByArtifactId("art_201");
+    markAudioReady(vocalAudio);
+
+    expect(vi.mocked(window.HTMLMediaElement.prototype.play).mock.calls.length).toBe(
+      playCallsBeforeStemSwitch,
+    );
+
+    markAudioReady(instrumentalAudio);
+
+    await waitFor(() =>
+      expect(vi.mocked(window.HTMLMediaElement.prototype.play).mock.calls.length).toBeGreaterThan(
+        playCallsBeforeStemSwitch,
+      ),
+    );
+    await waitFor(() => expect(vocalAudio.currentTime).toBeCloseTo(18.789, 3));
+    await waitFor(() => expect(instrumentalAudio.currentTime).toBeCloseTo(18.789, 3));
     expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
   });
 

--- a/apps/desktop/src/features/projects/ProjectView.tsx
+++ b/apps/desktop/src/features/projects/ProjectView.tsx
@@ -63,6 +63,10 @@ function isPlayableArtifact(artifact: ArtifactSchema) {
   return ["source_audio", "preview_mix", "vocal_stem", "instrumental_stem"].includes(artifact.type);
 }
 
+function isStemArtifact(artifact: ArtifactSchema | null | undefined) {
+  return artifact?.type === "vocal_stem" || artifact?.type === "instrumental_stem";
+}
+
 function preferredArtifactSelection(artifacts: ArtifactSchema[]) {
   return (
     artifacts.find((artifact) => artifact.type === "source_audio") ??
@@ -318,6 +322,7 @@ export function ProjectView() {
   const pendingPreviewSelection = useRef<{ previousLatestPreviewArtifactId: string | null } | null>(
     null,
   );
+  const persistedStemSourceArtifactId = useRef<string | null>(null);
   const [retuneMode, setRetuneMode] = useState<"off" | "reference" | "cents">("off");
   const [referenceHz, setReferenceHz] = useState("440");
   const [centsOffset, setCentsOffset] = useState("0");
@@ -561,15 +566,12 @@ export function ProjectView() {
     [selectedPrimaryArtifact?.id, stemArtifacts],
   );
   const focusedStemArtifact =
-    selectedArtifact &&
-    (selectedArtifact.type === "vocal_stem" || selectedArtifact.type === "instrumental_stem")
-      ? selectedArtifact
-      : visibleStemArtifacts[0] ?? null;
-  const isStemSelected = Boolean(
-    selectedArtifact &&
-      (selectedArtifact.type === "vocal_stem" || selectedArtifact.type === "instrumental_stem"),
-  );
+    isStemArtifact(selectedArtifact) ? selectedArtifact : visibleStemArtifacts[0] ?? null;
+  const isStemSelected = isStemArtifact(selectedArtifact);
   const isStemPlayback = isStemSelected && visibleStemArtifacts.length > 0;
+  const selectedStemSourceArtifactId = isStemPlayback
+    ? sourceArtifactIdForStems(selectedArtifact) ?? selectedPrimaryArtifact?.id ?? selectedPrimaryArtifactId
+    : null;
   const selectedPlaybackArtifact = isStemPlayback
     ? focusedStemArtifact
     : selectedArtifact ?? selectedPrimaryArtifact;
@@ -775,6 +777,7 @@ export function ProjectView() {
   useEffect(() => {
     const storedPlaybackState = readProjectPlaybackState(projectId);
     pendingPreviewSelection.current = null;
+    persistedStemSourceArtifactId.current = storedPlaybackState.selectedStemSourceArtifactId;
     setSelectedArtifactId(storedPlaybackState.selectedArtifactId);
     setSelectedPrimaryArtifactId(storedPlaybackState.selectedPrimaryArtifactId);
     setStemControls(storedPlaybackState.stemControls);
@@ -807,8 +810,14 @@ export function ProjectView() {
     const nextSelectedArtifact =
       selectableArtifacts.find((artifact) => artifact.id === selectedArtifactId) ?? null;
     const derivedPrimaryId = sourceArtifactIdForStems(nextSelectedArtifact);
+    const preferredStemSourceArtifactId =
+      derivedPrimaryId ??
+      (nextSelectedArtifact || !selectedArtifactId ? null : persistedStemSourceArtifactId.current);
     const nextPrimaryArtifactId =
-      primaryArtifacts.some((artifact) => artifact.id === selectedPrimaryArtifactId)
+      preferredStemSourceArtifactId &&
+      primaryArtifacts.some((artifact) => artifact.id === preferredStemSourceArtifactId)
+        ? preferredStemSourceArtifactId
+        : primaryArtifacts.some((artifact) => artifact.id === selectedPrimaryArtifactId)
         ? selectedPrimaryArtifactId
         : derivedPrimaryId && primaryArtifacts.some((artifact) => artifact.id === derivedPrimaryId)
           ? derivedPrimaryId
@@ -848,9 +857,11 @@ export function ProjectView() {
       return;
     }
 
+    persistedStemSourceArtifactId.current = selectedStemSourceArtifactId;
     writeProjectPlaybackState(projectId, {
       selectedArtifactId,
       selectedPrimaryArtifactId,
+      selectedStemSourceArtifactId,
       stemControls,
     });
   }, [
@@ -858,6 +869,7 @@ export function ProjectView() {
     projectId,
     selectedArtifactId,
     selectedPrimaryArtifactId,
+    selectedStemSourceArtifactId,
     stemControls,
   ]);
 
@@ -1206,7 +1218,7 @@ export function ProjectView() {
                     max={playbackDurationSeconds || projectQuery.data?.duration_seconds || 0}
                     min={0}
                     onChange={(event) => seekTo(Number(event.target.value))}
-                    step={0.1}
+                    step={0.001}
                     type="range"
                     value={Math.min(
                       playbackTimeSeconds,

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -47,6 +47,7 @@ type PlaybackContextValue = {
 };
 
 const PlaybackContext = createContext<PlaybackContextValue | null>(null);
+const SEEK_TOLERANCE_SECONDS = 0.001;
 
 function playbackSignature(session: ProjectPlaybackSession | null) {
   if (!session) {
@@ -215,14 +216,24 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       pendingTransition.targetTime,
       targetElements[0]?.duration ?? playbackDurationSecondsRef.current,
     );
+    let awaitingSeekCompletion = false;
     targetElements.forEach((element) => {
-      if (Math.abs(element.currentTime - nextTime) > 0.01) {
+      if (Math.abs(element.currentTime - nextTime) > SEEK_TOLERANCE_SECONDS) {
         element.currentTime = nextTime;
+        awaitingSeekCompletion = true;
+        return;
+      }
+      if (element.seeking) {
+        awaitingSeekCompletion = true;
       }
     });
     applyStemVolumes(targetSession);
     setPlaybackTimeSeconds(nextTime);
     updateDurationFromActiveMedia(targetSession);
+
+    if (awaitingSeekCompletion) {
+      return;
+    }
 
     const transitionId = pendingTransition.id;
     const transitionSignature = pendingTransition.signature;
@@ -272,7 +283,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
     const masterTime = readMasterTime(targetSession);
     activeElements.forEach((element) => {
-      if (Math.abs(element.currentTime - masterTime) > 0.01) {
+      if (Math.abs(element.currentTime - masterTime) > SEEK_TOLERANCE_SECONDS) {
         element.currentTime = masterTime;
       }
     });
@@ -544,6 +555,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           tryCompletePendingTransition();
         }}
         onCanPlay={tryCompletePendingTransition}
+        onSeeked={tryCompletePendingTransition}
         onEnded={() => {
           if (!sessionRef.current || sessionRef.current.isStemPlayback) {
             return;
@@ -551,7 +563,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           setIsPlaying(false);
         }}
       />
-      {session?.visibleStemArtifactIds.map((artifactId, index) => (
+      {session?.visibleStemArtifactIds.map((artifactId) => (
         <audio
           key={artifactId}
           ref={(element) => setStemAudioRef(artifactId, element)}
@@ -568,24 +580,19 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
             setPlaybackTimeSeconds(event.currentTarget.currentTime);
           }}
           onLoadedMetadata={() => {
-            if (sessionRef.current?.visibleStemArtifactIds[0] !== artifactId) {
-              return;
+            if (sessionRef.current?.visibleStemArtifactIds[0] === artifactId) {
+              updateDurationFromActiveMedia();
             }
-            updateDurationFromActiveMedia();
             tryCompletePendingTransition();
           }}
           onDurationChange={() => {
-            if (sessionRef.current?.visibleStemArtifactIds[0] !== artifactId) {
-              return;
+            if (sessionRef.current?.visibleStemArtifactIds[0] === artifactId) {
+              updateDurationFromActiveMedia();
             }
-            updateDurationFromActiveMedia();
             tryCompletePendingTransition();
           }}
-          onCanPlay={() => {
-            if (index === 0) {
-              tryCompletePendingTransition();
-            }
-          }}
+          onCanPlay={tryCompletePendingTransition}
+          onSeeked={tryCompletePendingTransition}
           onEnded={() => {
             if (!sessionRef.current || !sessionRef.current.isStemPlayback) {
               return;

--- a/apps/desktop/src/features/projects/projectPlaybackState.ts
+++ b/apps/desktop/src/features/projects/projectPlaybackState.ts
@@ -6,6 +6,7 @@ export type StemControlState = {
 export type StoredProjectPlaybackState = {
   selectedArtifactId: string | null;
   selectedPrimaryArtifactId: string | null;
+  selectedStemSourceArtifactId: string | null;
   stemControls: Record<string, StemControlState>;
 };
 
@@ -14,6 +15,7 @@ const STORAGE_KEY = "tuneforge.project-playback-state";
 const DEFAULT_STORED_PROJECT_PLAYBACK_STATE: StoredProjectPlaybackState = {
   selectedArtifactId: null,
   selectedPrimaryArtifactId: null,
+  selectedStemSourceArtifactId: null,
   stemControls: {},
 };
 
@@ -52,6 +54,10 @@ function normalizeStoredProjectPlaybackState(value: unknown): StoredProjectPlayb
     selectedPrimaryArtifactId:
       typeof candidate.selectedPrimaryArtifactId === "string"
         ? candidate.selectedPrimaryArtifactId
+        : null,
+    selectedStemSourceArtifactId:
+      typeof candidate.selectedStemSourceArtifactId === "string"
+        ? candidate.selectedStemSourceArtifactId
         : null,
     stemControls,
   };


### PR DESCRIPTION
## Summary
- preserve sub-second playback position when switching between source, mixes, and stems
- resume playback cleanly when newly created mixes or stem tracks become ready
- persist the owning mix for stem monitor so reopening a project restores mix-owned stems instead of source stems

## Testing
- `pnpm --filter @tuneforge/desktop test -- --runInBand`
- `pnpm --filter @tuneforge/desktop typecheck`
