### PR TITLE
chore: prepare repository for public release

### DIFF
--- a/.github/ISSUE_TEMPLATE/audio_engine_issue.yml
+++ b/.github/ISSUE_TEMPLATE/audio_engine_issue.yml
@@ -1,0 +1,119 @@
+name: Audio engine issue
+description: Report incorrect or surprising output from analysis, chords, stems, transpose, retune, or export.
+title: "[engine] "
+labels: ["bug", "audio-engine"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template when an audio operation runs but produces wrong results
+        (e.g. wrong key detected, chord misidentified, distorted stems, off-pitch transpose).
+
+  - type: dropdown
+    id: engine
+    attributes:
+      label: Engine
+      options:
+        - analysis (key / tempo)
+        - chords
+        - stems (Demucs)
+        - transpose
+        - retune
+        - export / preview
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected output
+      description: What the engine should have produced and how you know.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual output
+      description: What the engine produced. Include numeric values when relevant.
+    validations:
+      required: true
+
+  - type: input
+    id: sample-rate
+    attributes:
+      label: Source sample rate
+      placeholder: "44100 / 48000 / ..."
+
+  - type: input
+    id: channels
+    attributes:
+      label: Source channels
+      placeholder: "mono / stereo"
+
+  - type: input
+    id: duration
+    attributes:
+      label: Source duration
+      placeholder: "e.g. 3:42"
+
+  - type: input
+    id: source-format
+    attributes:
+      label: Source container/codec
+      placeholder: "mp3 / wav / flac / m4a / mp4 / webm"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: device
+    attributes:
+      label: Compute device used
+      options:
+        - auto
+        - cpu
+        - mps (Apple)
+        - cuda (NVIDIA)
+    validations:
+      required: true
+
+  - type: input
+    id: stem-model
+    attributes:
+      label: Stem model (if engine = stems)
+      placeholder: "htdemucs_ft / htdemucs / ..."
+
+  - type: textarea
+    id: parameters
+    attributes:
+      label: Operation parameters
+      description: e.g. transpose semitones, retune target Hz, analysis flags.
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "macOS 14.5 (arm64)"
+    validations:
+      required: true
+
+  - type: input
+    id: commit
+    attributes:
+      label: Tuneforge commit
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Backend logs
+      render: shell
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I am not sharing copyrighted audio in this report
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,90 @@
+name: Bug report
+description: Report a defect in Tuneforge.
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in as much detail as you can.
+        Do **not** report security issues here — see [SECURITY.md](../SECURITY.md).
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A clear, concise description of what is wrong.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps. Include any commands run and UI actions taken.
+      placeholder: |
+        1. Import file X
+        2. Run analysis
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include any error messages or stack traces, in code blocks.
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system and version
+      placeholder: "macOS 14.5 (arm64) / Ubuntu 24.04 / ..."
+    validations:
+      required: true
+
+  - type: input
+    id: commit
+    attributes:
+      label: Tuneforge commit or version
+      description: Output of `git rev-parse --short HEAD` or the release version.
+    validations:
+      required: true
+
+  - type: input
+    id: ffmpeg
+    attributes:
+      label: ffmpeg version
+      description: Output of `ffmpeg -version | head -1`.
+
+  - type: input
+    id: source-format
+    attributes:
+      label: Source audio format (if relevant)
+      placeholder: "mp3 / wav / m4a / mp4 / ..."
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Backend or Tauri console output if available.
+      render: shell
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I have searched existing issues and this is not a duplicate
+          required: true
+        - label: I am not sharing copyrighted audio in this report
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/grazzolini/tuneforge/security/advisories/new
+    about: Please report security issues privately, not as public issues. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,46 @@
+name: Feature request
+description: Suggest an enhancement or new feature.
+title: "[feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Tuneforge has an opinionated scope: local-only, single-user, focused on learning, rehearsing, and playing along with songs.
+        Please make sure your idea fits before opening this. See [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is the practice scenario or pain point this addresses?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe what you would like Tuneforge to do.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about, and why they are worse or similar.
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope check
+      description: How does this fit a local-only, single-user, practice-focused tool?
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Mockups, links to similar features in other tools, references.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+## Summary
+
+<!-- One or two sentences describing what this PR changes. -->
+
+## Motivation
+
+<!-- Why is this change needed? Link issues with "Fixes #123" or "Refs #123". -->
+
+## Changes
+
+<!-- Bullet list of notable changes. Skip the obvious. -->
+
+-
+-
+
+## Test Plan
+
+<!-- How did you verify this change? Commands run, scenarios exercised, audio files used. -->
+
+-
+
+## Screenshots / Recordings
+
+<!-- For UI changes only. Drag and drop images or attach a short clip. Delete this section otherwise. -->
+
+## Checklist
+
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(backend): add chord smoothing window`) — it becomes the squash commit message on `main`
+- [ ] `pnpm lint` passes
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm test` passes (desktop + backend)
+- [ ] If backend routes or schemas changed, ran `pnpm contracts:generate` and committed the result
+- [ ] Updated relevant docs (README, backend README, THIRD_PARTY_NOTICES) if behavior changed
+- [ ] No secrets, credentials, or copyrighted audio added to the repository

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,60 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: "/apps/desktop"
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: "/packages/shared-types"
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: pip
+    directory: "/apps/backend"
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: cargo
+    directory: "/apps/desktop/src-tauri"
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,20 +6,63 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Check out code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Lint commits
+        uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1
+        with:
+          configFile: commitlint.config.cjs
+
+      - name: Set up pnpm
+        if: github.event_name == 'pull_request'
+        uses: pnpm/action-setup@a15d269cd4658e1107c09f1fabf4cbd7bd1f308a # v4.4.0
+        with:
+          version: 10.33.0
+
+      - name: Set up Node
+        if: github.event_name == 'pull_request'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install commitlint
+        if: github.event_name == 'pull_request'
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Lint PR title (squash commit message)
+        if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: echo "$PR_TITLE" | pnpm exec commitlint
+
   backend:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           python-version: "3.11"
 
@@ -48,27 +91,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a15d269cd4658e1107c09f1fabf4cbd7bd1f308a # v4.4.0
         with:
           version: 10.33.0
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           python-version: "3.11"
 

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,14 @@ apps/desktop/src-tauri/resources/*
 apps/desktop/src-tauri/gen/
 packages/shared-types/openapi.json
 data/
+
+# Secrets / credentials (defensive)
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+*.p12
+*.pfx
+*.cer
+*.crt

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+pnpm exec commitlint --edit "$1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,175 @@
+# AGENTS.md
+
+Guidance for AI coding agents (Claude Code, Cursor, Copilot, Aider, Codex, etc.) working in this repository.
+
+This file is the agent-facing companion to [CONTRIBUTING.md](./CONTRIBUTING.md). Humans should read CONTRIBUTING.md; agents should read both, but this file takes precedence on conventions specific to automated work.
+
+## Project Snapshot
+
+Tuneforge is a local-first desktop app for musicians learning songs: stem separation, chord/key/tempo detection, pitch shift, retune, export. No cloud, no account.
+
+- **Monorepo**: pnpm workspace.
+- **Backend**: `apps/backend` — FastAPI + SQLAlchemy 2 + Pydantic v2, Python 3.11, managed with `uv`. SQLite persistence, single-process job runner, audio engines (Demucs, FFmpeg, librosa-style analysis).
+- **Desktop**: `apps/desktop` — Tauri 2 (Rust) shell + React/Vite/TypeScript frontend, Vitest + Testing Library.
+- **Shared types**: `packages/shared-types` — TypeScript types generated from the backend OpenAPI schema. **Always regenerate after backend route/schema changes.**
+
+## Hard Rules
+
+These are non-negotiable. If a task seems to require breaking one, stop and ask.
+
+1. **Local-only stays local.** The backend binds `127.0.0.1`. Do not introduce network exposure, public binds, reverse-proxy assumptions, multi-user concepts, auth/session systems, telemetry, analytics, or external API calls (other than the Demucs model download that already exists).
+2. **No cloud, no accounts.** The app must keep working with no internet after first run.
+3. **Don't bundle FFmpeg.** It is a host-installed dependency by design. See [THIRD_PARTY_NOTICES.md](./THIRD_PARTY_NOTICES.md) for the licensing reason.
+4. **Respect the layering.** `routes/` → `services/` → `engines/`. Routes are thin; business logic lives in services; raw audio/ML work lives in engines. Don't bypass layers.
+5. **Don't commit generated files by hand.** Run the generator (see "Generated artifacts" below).
+6. **Don't disable lint/type/test rules to make CI pass.** Fix the underlying issue.
+7. **Don't bypass safety flags.** No `--no-verify`, no `git push --force` on shared branches, no destructive shell shortcuts.
+8. **MIT-compatible deps only.** Avoid GPL/AGPL/SSPL runtime dependencies. Note any new dep's license in [THIRD_PARTY_NOTICES.md](./THIRD_PARTY_NOTICES.md).
+
+## Repository Layout
+
+```
+apps/
+  backend/                FastAPI service
+    app/
+      api/routes/         HTTP handlers (thin)
+      services/           orchestration, persistence, caching
+      engines/            pure compute: analysis, chords, stems, transform
+      models.py           SQLAlchemy ORM
+      schemas.py          Pydantic request/response
+      errors.py           AppError + handlers
+      config.py           env-driven Settings
+    alembic/versions/     migrations (auto-run on startup)
+    tests/                pytest suite
+  desktop/
+    src/                  React frontend (Vitest)
+    src-tauri/            Rust shell (cargo)
+packages/
+  shared-types/           generated TS contracts
+scripts/                  packaging helpers
+```
+
+## Workflow Expectations
+
+When asked to implement a change:
+
+1. **Read before writing.** Inspect the surrounding files in the relevant layer. Match existing patterns.
+2. **Plan briefly.** For multi-step work, write a short plan or todo list before editing.
+3. **Edit narrowly.** Don't reformat unrelated code, don't add docstrings/comments to code you didn't touch, don't introduce new abstractions for one-time operations.
+4. **Run the gates locally.** From the workspace root:
+   ```sh
+   pnpm lint
+   pnpm typecheck
+   pnpm test
+   ```
+   And for the backend:
+   ```sh
+   cd apps/backend && uv run --python 3.11 pytest
+   ```
+5. **Regenerate contracts if backend HTTP surface changed:**
+   ```sh
+   pnpm contracts:generate
+   ```
+   Commit the resulting `packages/shared-types/src/generated/openapi.ts`. CI fails on drift.
+6. **Verify Tauri compiles** if you touched anything in `apps/desktop/src-tauri/`:
+   ```sh
+   cd apps/desktop/src-tauri && cargo check
+   ```
+7. **Update docs only when behavior changes.** Don't create new markdown files to describe what you did. The PR description is the right place for that.
+
+## Code Conventions
+
+### Python (backend)
+
+- Python 3.11. Use `uv run --python 3.11 ...` for everything; do not invoke a globally installed Python.
+- Type hints on all new function signatures. `mypy app` must pass.
+- `ruff check .` must pass. Fix lints, do not silence them.
+- Pydantic v2 syntax (`model_config`, `Field(...)`, `model_validate`).
+- SQLAlchemy 2 declarative + `Mapped[...]` style.
+- Raise `AppError` (see `app/errors.py`) for user-facing failures, not bare `HTTPException`.
+- Never call into engines from routes — go through a service.
+- New env-driven settings go in `app/config.py` and must be documented in [apps/backend/README.md](apps/backend/README.md#configuration).
+- Database schema changes require an Alembic revision in `apps/backend/alembic/versions/` (next sequential prefix, e.g. `0003_*.py`).
+
+### TypeScript / React (desktop)
+
+- Strict TypeScript. No `any` unless justified in a comment, and only at boundaries.
+- Use the generated types from `@tuneforge/shared-types` — never hand-write a type that mirrors a backend schema.
+- Functional components + hooks. No class components.
+- Co-locate component-specific state and effects; lift only when shared.
+- Existing React Hook exhaustive-deps warnings in `apps/desktop/src/features/projects/playback.tsx` are intentional and pre-existing — don't "fix" them as a drive-by.
+
+### Rust (Tauri shell)
+
+- Keep `apps/desktop/src-tauri/src/main.rs` minimal. The shell exists to launch the bundled backend and host the WebView; business logic stays in the Python backend.
+- Don't add Tauri capabilities without a concrete need. Current capabilities live in `apps/desktop/src-tauri/capabilities/default.json`.
+
+### Tests
+
+- Add tests for new behavior. Backend uses pytest with synthetic audio fixtures (sine waves, chord progressions) — prefer those over committing real audio files.
+- Frontend uses Vitest + Testing Library. Test user-visible behavior, not implementation details.
+- Don't commit copyrighted audio under any circumstances.
+
+## Generated Artifacts
+
+The following files are generated. **Do not edit by hand.**
+
+| File | Generator |
+| --- | --- |
+| `packages/shared-types/openapi.json` | `pnpm contracts:generate` (writes from backend OpenAPI export) |
+| `packages/shared-types/src/generated/openapi.ts` | `pnpm contracts:generate` |
+| `apps/desktop/src-tauri/gen/schemas/*` | Tauri build |
+| `apps/desktop/src-tauri/Cargo.lock` | cargo |
+| `pnpm-lock.yaml` | pnpm |
+
+## Security and Privacy
+
+- Treat the loopback bind as the only trust boundary. See [SECURITY.md](./SECURITY.md).
+- Never log file contents, audio data, or anything that could include user material.
+- Never add a feature that opens an outbound connection to a service the user hasn't explicitly configured.
+- Never ask the user to paste secrets into chat or commit them. The `.gitignore` already blocks the obvious patterns; if you need a new secret-bearing file pattern, extend `.gitignore` first.
+
+## Commit and PR Hygiene
+
+- **Conventional Commits required.** Format: `<type>(<optional scope>): <subject>`. Allowed types: `feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `build`, `ci`, `chore`, `revert`. Subject is imperative (`add ...`, not `Added`/`Adds`). Header ≤ 100 chars. The `commit-msg` Husky hook and a CI job (`commitlint`) enforce this on every commit and on the PR title.
+- Reference issues with `Fixes #123` / `Refs #123` in the body or footer.
+- One concern per commit and per PR. If a refactor and a feature are tangled, split them into separate PRs.
+- **Prefer one commit per PR.** A repository ruleset enforces squash merges and linear history on `main`, so any extra commits in a PR get folded into one at merge time anyway. The PR title becomes the squash commit message, so it must also pass commitlint. Recommended workflow: amend the existing commit and push with `git push --force-with-lease` rather than stacking fix-up commits.
+- Fill in the PR template. Be honest in the test plan — list the commands you actually ran.
+- Mark a PR as draft if any required gate fails locally.
+- Never use `--no-verify` and never `force-push` to `main` or to someone else's branch.
+
+## When to Stop and Ask
+
+Pause and surface the question to the human instead of guessing when:
+
+- A task implies network exposure, multi-user behavior, auth, telemetry, or cloud features.
+- A change requires adding a non-MIT-compatible dependency.
+- A migration would be destructive (drop column, drop table, irreversible data shape change).
+- Existing tests would need to be deleted or weakened to make the change pass.
+- The user's request conflicts with anything in this file.
+
+## Quick Reference
+
+```sh
+# Install
+pnpm install
+cd apps/backend && uv sync --python 3.11 --all-groups
+cd ../..
+pnpm contracts:generate
+
+# Develop
+pnpm dev                  # backend + desktop together
+pnpm dev:backend
+pnpm dev:desktop
+
+# Gate before opening a PR
+pnpm lint
+pnpm typecheck
+pnpm test
+cd apps/backend && uv run --python 3.11 pytest
+cd apps/desktop/src-tauri && cargo check
+
+# After backend HTTP changes
+pnpm contracts:generate
+```

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone's personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality.** Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials.** Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, contact the maintainers privately via GitHub's private vulnerability reporting form on this repository, or by reaching out to `@grazzolini` directly on GitHub. Reports will be handled confidentially.
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+## Addressing and Repairing Harm
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+1. **Warning**
+   1. Event: A violation involving a single incident or series of incidents.
+   2. Consequence: A private, written warning from the Community Moderators.
+   3. Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
+2. **Temporarily Limited Activities**
+   1. Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
+   2. Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.
+   3. Repair: Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
+3. **Temporary Suspension**
+   1. Event: A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
+   2. Consequence: A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
+   3. Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
+4. **Permanent Ban**
+   1. Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
+   2. Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
+   3. Repair: There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at <https://www.contributor-covenant.org/version/3/0/>.
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit <https://creativecommons.org/licenses/by-sa/4.0/>.
+
+For answers to common questions about Contributor Covenant, see the FAQ at <https://www.contributor-covenant.org/faq>. Translations are provided at <https://www.contributor-covenant.org/translations>. Additional enforcement and community guideline resources can be found at <https://www.contributor-covenant.org/resources>. The enforcement ladder was inspired by the work of [Mozilla's code of conduct team](https://github.com/mozilla/inclusion).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,137 @@
+# Contributing to Tuneforge
+
+Thanks for the interest. Tuneforge is a local-first toolkit for musicians learning and rehearsing songs at home, so feature scope is opinionated, but bug fixes, polish, and well-scoped feature contributions are welcome.
+
+By participating, you agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Scope and Philosophy
+
+- **Local-only, single-user.** The backend binds to `127.0.0.1` and has no authentication. Features that assume network exposure or multi-user state are out of scope.
+- **Built for players.** Features should help someone learn, rehearse, or play along with a song (stem isolation, key/tempo/chord detection, transpose, retune, looped playback, export). Generic DAW / production / mixing features are out of scope.
+- **No telemetry, no accounts, no cloud.** The app must keep working with no internet access after the initial Demucs model download.
+
+If unsure whether a feature fits, open a discussion or feature-request issue first before writing code.
+
+## Prerequisites
+
+- `pnpm` (version pinned in [package.json](./package.json))
+- `uv`
+- Python 3.11
+- `ffmpeg` and `ffprobe` on your `PATH`
+- Rust toolchain (for the Tauri shell)
+
+## Setup
+
+```sh
+pnpm install
+cd apps/backend && uv sync --python 3.11 --all-groups
+cd ../..
+pnpm contracts:generate
+```
+
+## Development Loop
+
+Two terminals:
+
+```sh
+pnpm dev:backend
+pnpm dev:desktop
+```
+
+Or both at once:
+
+```sh
+pnpm dev
+```
+
+The backend serves on `http://127.0.0.1:8765/api/v1`. The Tauri dev shell connects to it.
+
+## Before You Open a PR
+
+Run all of these locally and make sure they pass:
+
+```sh
+pnpm lint
+pnpm typecheck
+pnpm test
+```
+
+If you changed any FastAPI route, request schema, or response schema, regenerate the shared contracts and commit the result:
+
+```sh
+pnpm contracts:generate
+```
+
+CI will fail if `packages/shared-types/src/generated/openapi.ts` is out of sync.
+
+## Commit Messages
+
+Tuneforge enforces [Conventional Commits](https://www.conventionalcommits.org/) via `commitlint`. The `commit-msg` Husky hook is installed automatically by `pnpm install`, and CI re-checks every commit on a PR plus the PR title (because the PR title becomes the squash commit message on `main`).
+
+Format:
+
+```
+<type>(<optional scope>): <subject>
+```
+
+Allowed types: `feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `build`, `ci`, `chore`, `revert`.
+
+Examples:
+
+```
+feat(backend): add chord smoothing window
+fix(desktop): keep playback position on tab switch
+ci: pin commitlint action to v6.2.1
+docs: clarify ffmpeg prerequisite
+```
+
+Rules:
+
+- Use a concise, imperative subject (`add ...`, not `added ...` / `adds ...`).
+- Subject must not start with a capitalised word, PascalCase, or all-caps.
+- Header (full first line) must be ≤ 100 characters.
+- Reference issues in the body or footer with `Fixes #123` / `Refs #123`.
+- Keep unrelated changes in separate PRs.
+
+## Pull Requests
+
+- Open against `main`.
+- Fill in the PR template (summary, motivation, test plan).
+- Mark the PR as draft if it is not ready for review.
+- Keep PRs focused. Large refactors should be split or discussed first.
+
+### One Commit Per PR (Recommended)
+
+`main` is protected by a ruleset that enforces **squash merges** and **linear history**, so every PR ends up as a single commit on `main` regardless of how many commits were in the PR branch.
+
+To keep the PR diff and the eventual squash commit message clean, the recommended workflow is:
+
+1. Make your change in a branch.
+2. Commit it (one commit).
+3. If review feedback or your own follow-ups require changes, **amend** the existing commit instead of adding new ones:
+   ```sh
+   git add -A
+   git commit --amend --no-edit       # or omit --no-edit to also rewrite the message
+   git push --force-with-lease
+   ```
+4. Use `--force-with-lease` (not `--force`) so you don't clobber someone else's push.
+
+Multiple commits are still allowed — they will simply be squashed at merge time — but a single, well-described commit avoids any surprise about what the squash commit message becomes.
+
+## Reporting Bugs
+
+Use the bug report template. Include:
+
+- OS and version
+- Tuneforge commit SHA
+- Steps to reproduce
+- Expected vs. actual behavior
+- A minimal sample audio file when relevant (do not commit copyrighted material)
+
+## Security Issues
+
+Do **not** open a public issue. See [SECURITY.md](./SECURITY.md) for the private disclosure process.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](./LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Giancarlo Razzolini
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,98 +1,123 @@
 # Tuneforge
 
-Tuneforge is a local-first desktop music practice tool built with Tauri, React, FastAPI, SQLite, and FFmpeg.
+Tuneforge is a local-first, open-source desktop app for musicians who want to learn, rehearse, and play along with songs. Drop in any track and Tuneforge will split it into vocals and backing instruments, work out the key, tempo, and chord progression, and let you shift the pitch, retune to a reference frequency, and export a custom version to practice with.
 
-Supported import formats currently include `mp3`, `wav`, `flac`, `m4a`, `aac`, `ogg`, `mp4`, and `webm`.
-For `mp4` and `webm`, Tuneforge extracts a local WAV working file during import so analysis and transforms run against audio directly.
-Stem separation now uses a local Demucs backend for `vocals` and `instrumental` output.
+Think "AI-assisted song toolkit for the player at home" — but **fully local, single-user, and with no cloud component**. Every track stays on your machine, no account, no upload, no network round-trip after the initial model download.
+
+## Status
+
+Pre-1.0. The desktop dev flow (`pnpm dev`) is the supported way to run the app today. Packaged macOS builds are work in progress and currently broken; do not rely on `pnpm package:mac`.
+
+## Features
+
+- Import `mp3`, `wav`, `flac`, `m4a`, `aac`, `ogg`, `mp4`, and `webm`. `mp4` / `webm` are transcoded to a local WAV working file at import time.
+- Key, tempo, and chord-timeline analysis.
+- Pitch transpose (semitones) and retune (target reference Hz).
+- Stem separation via a local Demucs backend (`htdemucs_ft` by default).
+- Preview rendering (cached) and export to `wav`, `mp3`, or `flac`.
+- Per-project playback session with persistence across navigation.
+
+## Threat Model and Scope
+
+Tuneforge is **local-only by design**:
+
+- The backend binds to `127.0.0.1` only.
+- There is **no authentication, no authorization, and no per-user model**.
+- Treat the loopback bind as the only trust boundary. Do not expose the port to a network, do not put it behind a reverse proxy, and do not run it on a shared multi-user host without isolation.
+
+Security reports follow the process in [SECURITY.md](./SECURITY.md). "There is no auth" is not a vulnerability — it is the design.
 
 ## Workspace
 
-- `apps/backend`: FastAPI API, SQLite persistence, job runner, audio analysis/transforms, pytest suite
-- `apps/desktop`: Tauri desktop shell and React frontend
-- `packages/shared-types`: generated TypeScript contract from the backend OpenAPI schema
+- `apps/backend` — FastAPI API, SQLite persistence, job runner, audio analysis/transforms, pytest suite. See [apps/backend/README.md](apps/backend/README.md).
+- `apps/desktop` — Tauri desktop shell and React frontend.
+- `packages/shared-types` — TypeScript contract generated from the backend OpenAPI schema.
+
+## Prerequisites
+
+- `pnpm` (version pinned in [package.json](./package.json))
+- [`uv`](https://docs.astral.sh/uv/)
+- Python 3.11
+- `ffmpeg` and `ffprobe` available on `PATH` (install via `brew install ffmpeg`, `apt install ffmpeg`, etc.)
+- Rust toolchain for Tauri
+
+## Setup
+
+```sh
+pnpm install
+cd apps/backend && uv sync --python 3.11 --all-groups
+cd ../..
+pnpm contracts:generate
+```
+
+The first `uv sync` is heavy because it installs Demucs and Torch. The first stem-separation run will additionally download the Demucs model weights into the local Torch cache.
 
 ## Development
 
-Prerequisites:
+Two terminals:
 
-- `pnpm`
-- `uv`
-- `Python 3.11`
-- `FFmpeg` and `ffprobe`
-- Rust toolchain for Tauri
+```sh
+pnpm dev:backend
+pnpm dev:desktop
+```
 
-Commands:
+Or both at once:
 
-- `pnpm install`
-- `cd apps/backend && uv sync --python 3.11 --all-groups`
-- `pnpm contracts:generate`
-- `pnpm dev:backend`
-- `pnpm dev:desktop`
-- `pnpm dev`
-- `pnpm lint`
-- `pnpm test`
-- `pnpm package:mac`
+```sh
+pnpm dev
+```
 
 The backend serves the local API on `http://127.0.0.1:8765/api/v1`.
 
-Notes:
+## Configuration
 
-- `pnpm dev:desktop` runs the Tauri shell and starts the Vite frontend dev server. Run `pnpm dev:backend` separately if you are not using `pnpm dev`.
-- `pnpm dev` starts the backend and desktop flow together.
-- `pnpm bundle:prepare` is available if you want to inspect the staged packaging resources manually. It stages the backend source, Python runtime, site-packages, and local `ffmpeg` / `ffprobe` binaries into `apps/desktop/src-tauri/resources`.
-- `pnpm package:mac` builds the macOS app bundle and DMG with the backend bundled inside the app. Tauri runs the bundle prep step automatically during this build.
-- The backend dependency sync now installs Demucs and Torch, so the first `uv sync` is heavier than before.
-- The first real stem generation may download the selected Demucs model weights into the local cache before processing starts.
-- Stem behavior can be tuned with `TUNEFORGE_STEM_MODEL` and `TUNEFORGE_STEM_DEVICE`. Defaults are `htdemucs_ft` and `auto`.
-- `auto` prefers `cuda`, then `mps`, then `cpu`. The Demucs worker also enables PyTorch MPS CPU fallback for unsupported ops.
-- Packaged builds inject bundled `ffmpeg` and `ffprobe` through `TUNEFORGE_FFMPEG_PATH` and `TUNEFORGE_FFPROBE_PATH`, so the shipped app does not depend on your shell `PATH`.
+Backend behavior is environment-driven. Full table is in [apps/backend/README.md](apps/backend/README.md#configuration). The most relevant variables:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `TUNEFORGE_HOST` | `127.0.0.1` | Bind address. Do not change to a public address. |
+| `TUNEFORGE_PORT` | `8765` | Bind port. |
+| `TUNEFORGE_DATA_DIR` | OS-specific | Override the data directory. |
+| `TUNEFORGE_FFMPEG_PATH` / `TUNEFORGE_FFPROBE_PATH` | `ffmpeg` / `ffprobe` | Override binary lookup. |
+| `TUNEFORGE_STEM_MODEL` | `htdemucs_ft` | Demucs model. |
+| `TUNEFORGE_STEM_DEVICE` | `auto` | `auto` / `cpu` / `mps` / `cuda`. |
+
+Default data directory:
+
+- macOS: `~/Library/Application Support/Tuneforge`
+- Linux: `~/.local/share/tuneforge`
+
+## Quality Gates
+
+```sh
+pnpm lint
+pnpm typecheck
+pnpm test
+```
+
+If you change backend routes or schemas, regenerate the shared contracts and commit the result:
+
+```sh
+pnpm contracts:generate
+```
+
+CI fails if `packages/shared-types/src/generated/openapi.ts` drifts from the backend OpenAPI output.
 
 ## Packaging
 
-The development flow stays split on purpose:
-
-- `pnpm dev:backend`
-- `pnpm dev:desktop`
-
-The packaged macOS app is self-contained:
-
-- Tauri starts the bundled backend automatically
-- the frontend asks the Tauri shell for the resolved backend base URL at runtime
-- backend source, Python runtime, dependencies, `ffmpeg`, and `ffprobe` are bundled inside the app resources
-
-### Build And Run The Bundled macOS App
-
-1. Install workspace dependencies:
-   - `pnpm install`
-   - `cd apps/backend && uv sync --python 3.11 --all-groups`
-   - `cd ../..`
-2. Generate the shared API types:
-   - `pnpm contracts:generate`
-3. Build the packaged app:
-   - `pnpm package:mac`
-
-Build outputs:
-
-- App bundle: `apps/desktop/src-tauri/target/release/bundle/macos/Tuneforge.app`
-- DMG: `apps/desktop/src-tauri/target/release/bundle/dmg/Tuneforge_<version>_<arch>.dmg`
-
-Run options:
-
-- Launch the app bundle directly:
-  - `open apps/desktop/src-tauri/target/release/bundle/macos/Tuneforge.app`
-- Or open the DMG, drag `Tuneforge.app` into `/Applications`, then launch it from there:
-  - `open apps/desktop/src-tauri/target/release/bundle/dmg`
-
-Notes:
-
-- You do not need to start `pnpm dev:backend` or `pnpm dev:desktop` for the packaged app.
-- On first launch, macOS may warn because this is a local unsigned build. If that happens, right-click the app, choose `Open`, and confirm once.
-- The packaged app starts its own bundled backend on localhost automatically.
+`pnpm package:mac` and `pnpm bundle:prepare` exist but the packaged macOS build is **work in progress** and not currently functional. Use the development flow (`pnpm dev`) for now. Packaged builds will require `ffmpeg`/`ffprobe` to be installed on the host system; Tuneforge does not bundle them (see [THIRD_PARTY_NOTICES.md](./THIRD_PARTY_NOTICES.md)).
 
 ## CI
 
-GitHub Actions runs two jobs:
+GitHub Actions runs two jobs on every push and pull request:
 
 - `backend`: `uv sync`, `ruff`, `mypy`, `pytest`
-- `desktop`: `pnpm install`, `pnpm contracts:generate`, generated contract drift check, desktop `lint`, `typecheck`, `test`
+- `desktop`: `pnpm install`, `pnpm contracts:generate`, generated-contract drift check, desktop `lint`, `typecheck`, `test`
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md). Feature scope is opinionated; please open a feature-request issue before writing significant new code.
+
+## License
+
+[MIT](./LICENSE). Third-party components and their licenses are listed in [THIRD_PARTY_NOTICES.md](./THIRD_PARTY_NOTICES.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Supported Versions
+
+Tuneforge is pre-1.0 and ships from `main`. Only the latest commit on `main` receives security fixes.
+
+## Threat Model
+
+Tuneforge is a **local-only desktop application**. The backend binds to `127.0.0.1` and is intended to be reached only by the bundled Tauri shell on the same machine. There is **no authentication or authorization** by design — the loopback bind is the trust boundary.
+
+**Do not** expose the backend port to a network, run it on a multi-user host without isolation, or place it behind a reverse proxy reachable from outside the machine. Doing so removes every assumption this project relies on.
+
+In scope for security reports:
+
+- Path traversal, command injection, or arbitrary file read/write through the local API
+- Tauri sandbox or capability escapes
+- Supply-chain issues (compromised dependencies, malicious build artifacts)
+- Secrets accidentally committed to the repository
+- CI workflow weaknesses that could leak `GITHUB_TOKEN` or repo write access
+
+Out of scope:
+
+- Lack of authentication on the loopback API (intentional)
+- Information disclosure to processes already running on the same user account
+- Denial of service via unbounded local job submission (single-user tool)
+
+## Reporting a Vulnerability
+
+Please **do not** open a public issue for security problems.
+
+- Use GitHub's private vulnerability reporting: <https://github.com/grazzolini/tuneforge/security/advisories/new>
+- Or email the maintainer directly (see the GitHub profile for `@grazzolini`).
+
+Include:
+
+1. A description of the issue and its impact.
+2. Steps to reproduce, ideally with a minimal proof of concept.
+3. Affected commit SHA or tag.
+4. Any suggested mitigation.
+
+You can expect an initial response within a few days. There is no bounty program.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,58 @@
+# Third-Party Notices
+
+Tuneforge is distributed under the [MIT License](./LICENSE). It depends on third-party software with its own licensing terms. Significant runtime and build dependencies are listed below. This is not exhaustive — refer to each project's own license file for the authoritative text.
+
+## Runtime Dependencies (bundled or required)
+
+### Demucs
+
+- **License:** MIT
+- **Source:** <https://github.com/facebookresearch/demucs>
+- **Notes:** Used for source separation. Installed via `pip` as a normal Python dependency.
+
+### htdemucs / htdemucs_ft model weights
+
+- **License:** MIT
+- **Source:** <https://github.com/facebookresearch/demucs>
+- **Notes:** Pretrained weights are downloaded by Demucs at runtime into the local Torch cache on first use. Tuneforge does not redistribute them.
+
+### PyTorch
+
+- **License:** BSD-3-Clause
+- **Source:** <https://github.com/pytorch/pytorch>
+
+### librosa
+
+- **License:** ISC
+- **Source:** <https://github.com/librosa/librosa>
+
+### FastAPI, Pydantic, SQLAlchemy, Alembic, Uvicorn, soundfile
+
+- See each project's own license. All are permissively licensed (MIT / BSD / Apache-2.0 family).
+
+### FFmpeg / ffprobe
+
+- **License:** LGPL-2.1+ or GPL-2.0+ depending on the build
+- **Source:** <https://ffmpeg.org/>
+- **Notes:** **Tuneforge does not bundle FFmpeg.** It must be installed separately by the user (for example via Homebrew, apt, or winget) and discoverable on `PATH`. Users are responsible for the licensing terms of the FFmpeg build they install.
+
+## Desktop Shell
+
+### Tauri
+
+- **License:** Apache-2.0 / MIT (dual)
+- **Source:** <https://github.com/tauri-apps/tauri>
+
+### React, Vite, TanStack Query, openapi-fetch, openapi-typescript
+
+- See each project's own license. All are permissively licensed.
+
+## Generating a Full Inventory
+
+The lists above cover the dependencies that materially shape the user experience. For a complete machine-readable inventory:
+
+- JavaScript / TypeScript: `pnpm licenses list --recursive`
+- Rust: `cargo license` (run inside `apps/desktop/src-tauri`)
+- Python: `uv pip list` combined with each package's metadata
+
+If you spot a missing or incorrect attribution, please open a pull request.

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -2,3 +2,87 @@
 
 FastAPI backend for Tuneforge. It owns persistence, artifact management, audio analysis, transform orchestration, and the in-process background job queue.
 
+## Layout
+
+- `app/api/routes/` — HTTP route handlers (projects, jobs, artifacts, health)
+- `app/services/` — orchestration, persistence, caching
+- `app/engines/` — pure computation: analysis, chord detection, stems (Demucs), transforms (FFmpeg / pitch)
+- `app/models.py` / `app/schemas.py` — SQLAlchemy ORM models and Pydantic request/response schemas
+- `app/errors.py` — central `AppError` exception and FastAPI error handlers
+- `alembic/` — database migrations, run automatically on startup
+
+## Prerequisites
+
+- Python 3.11
+- [`uv`](https://docs.astral.sh/uv/)
+- `ffmpeg` and `ffprobe` available on `PATH`
+
+## Setup
+
+```sh
+uv sync --python 3.11 --all-groups
+```
+
+## Run (development)
+
+From the workspace root:
+
+```sh
+pnpm dev:backend
+```
+
+Or directly:
+
+```sh
+uv run --python 3.11 uvicorn app.main:app --reload --host 127.0.0.1 --port 8765
+```
+
+The API is served at `http://127.0.0.1:8765/api/v1`. OpenAPI documentation is at `http://127.0.0.1:8765/docs`.
+
+## Configuration
+
+All configuration is environment-driven (see [`app/config.py`](./app/config.py)):
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `TUNEFORGE_HOST` | `127.0.0.1` | Bind address. **Do not change to a public address.** |
+| `TUNEFORGE_PORT` | `8765` | Bind port. |
+| `TUNEFORGE_DATA_DIR` | OS-specific | Override for the data directory (database, projects, cache). |
+| `TUNEFORGE_FFMPEG_PATH` | `ffmpeg` | Override the `ffmpeg` binary location. |
+| `TUNEFORGE_FFPROBE_PATH` | `ffprobe` | Override the `ffprobe` binary location. |
+| `TUNEFORGE_STEM_MODEL` | `htdemucs_ft` | Demucs model used for stem separation. |
+| `TUNEFORGE_STEM_DEVICE` | `auto` | One of `auto`, `cpu`, `mps`, `cuda`. `auto` prefers CUDA, then MPS, then CPU. |
+
+Default data directory:
+
+- macOS: `~/Library/Application Support/Tuneforge`
+- Linux: `~/.local/share/tuneforge`
+
+## Migrations
+
+Alembic migrations live in `alembic/versions/`. They run automatically on application startup. To create a new migration after changing models:
+
+```sh
+uv run --python 3.11 alembic revision --autogenerate -m "describe change"
+```
+
+Review the generated file before committing.
+
+## Job system
+
+The job runner is single-process, in-memory, and persists job state to SQLite ([`app/services/jobs.py`](./app/services/jobs.py)). On startup, jobs left in `running` state from a previous shutdown are marked `failed`, and any `pending` jobs are re-enqueued. The default worker count is `1` to avoid GPU/CPU contention with Demucs.
+
+## Testing
+
+```sh
+uv run --python 3.11 pytest
+```
+
+Test fixtures generate synthetic audio (sine waves, chord progressions, multiple containers) so most tests run without external sample files.
+
+## Lint / type-check
+
+```sh
+uv run --python 3.11 ruff check .
+uv run --python 3.11 mypy app
+```

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3897,7 +3897,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 name = "tuneforge"
 version = "0.1.0"
 dependencies = [
- "flate2",
  "serde",
  "serde_json",
  "tauri",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 tauri-build = { version = "2.0.2", features = [] }
 
 [dependencies]
-flate2 = "1.1.5"
 tauri = { version = "2.5.0", features = [] }
 tauri-plugin-dialog = "2.2.1"
 serde = { version = "1", features = ["derive"] }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -2,10 +2,8 @@
 
 use std::{
     env,
-    fs::{self, File},
     io::{Read, Write},
     net::{TcpListener, TcpStream},
-    os::unix::fs::PermissionsExt,
     path::{Path, PathBuf},
     process::{Child, Command, Stdio},
     sync::Mutex,
@@ -13,7 +11,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use flate2::read::GzDecoder;
 use tauri::{AppHandle, Manager, State};
 
 struct BackendRuntime {
@@ -99,30 +96,11 @@ fn build_python_path(backend_root: &Path) -> Result<String, Box<dyn std::error::
     Ok(joined.to_string_lossy().into_owned())
 }
 
-fn stage_media_binary(
-    app: &AppHandle,
-    bundled_path: &Path,
-    filename: &str,
-) -> Result<PathBuf, Box<dyn std::error::Error>> {
-    let cache_root = app.path().app_cache_dir()?.join("backend-bin");
-    fs::create_dir_all(&cache_root)?;
-    let staged_path = cache_root.join(filename);
-    let mut decoder = GzDecoder::new(File::open(bundled_path)?);
-    let mut output = File::create(&staged_path)?;
-    std::io::copy(&mut decoder, &mut output)?;
-    let mut permissions = fs::metadata(&staged_path)?.permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(&staged_path, permissions)?;
-    Ok(staged_path)
-}
-
 fn spawn_packaged_backend(app: &AppHandle) -> Result<BackendRuntime, Box<dyn std::error::Error>> {
     let resources_root = app.path().resource_dir()?;
     let bundled_backend_root = resources_root.join("resources").join("backend");
     let bundled_python_root = bundled_backend_root.join("python");
     let backend_source_root = bundled_backend_root.join("src");
-    let ffmpeg_path = stage_media_binary(app, &bundled_backend_root.join("bin").join("ffmpeg.gz"), "ffmpeg")?;
-    let ffprobe_path = stage_media_binary(app, &bundled_backend_root.join("bin").join("ffprobe.gz"), "ffprobe")?;
     let python = python_executable(&bundled_python_root);
 
     if !python.exists() {
@@ -147,8 +125,6 @@ fn spawn_packaged_backend(app: &AppHandle) -> Result<BackendRuntime, Box<dyn std
         .env("PYTORCH_ENABLE_MPS_FALLBACK", "1")
         .env("TUNEFORGE_HOST", "127.0.0.1")
         .env("TUNEFORGE_PORT", port.to_string())
-        .env("TUNEFORGE_FFMPEG_PATH", ffmpeg_path)
-        .env("TUNEFORGE_FFPROBE_PATH", ffprobe_path)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["app", "dmg"],
     "resources": ["resources"],
     "icon": [
       "icons/32x32.png",

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,53 @@
+// @ts-check
+
+/**
+ * Commitlint configuration.
+ *
+ * Enforces Conventional Commits on every commit and on PR titles
+ * (since `main` uses squash merges, the PR title becomes the squash
+ * commit message). Keep types in sync with what auto-labelling and
+ * any future semantic-release config expect.
+ *
+ * Allowed types:
+ *   feat      new user-facing feature
+ *   fix       bug fix
+ *   perf      performance improvement
+ *   refactor  internal change, no behavior change
+ *   docs      documentation only
+ *   test      tests only
+ *   build     build system, packaging, dependencies
+ *   ci        CI/CD config
+ *   chore     other maintenance (no production code change)
+ *   revert    revert of a previous commit
+ *
+ * Optional scope examples: backend, desktop, shared-types, ci, docs,
+ * deps, alembic, demucs, ffmpeg.
+ */
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "perf",
+        "refactor",
+        "docs",
+        "test",
+        "build",
+        "ci",
+        "chore",
+        "revert",
+      ],
+    ],
+    "subject-case": [
+      2,
+      "never",
+      ["start-case", "pascal-case", "upper-case"],
+    ],
+    "header-max-length": [2, "always", 100],
+    "body-max-line-length": [1, "always", 100],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -11,9 +11,14 @@
     "lint": "pnpm --filter @tuneforge/desktop lint && cd apps/backend && uv run --python 3.11 ruff check . && uv run --python 3.11 mypy app",
     "package:mac": "pnpm --filter @tuneforge/desktop tauri build --bundles app && node scripts/package-dmg.mjs",
     "test": "pnpm --filter @tuneforge/desktop test --run && cd apps/backend && uv run --python 3.11 pytest",
-    "typecheck": "pnpm --filter @tuneforge/desktop typecheck"
+    "typecheck": "pnpm --filter @tuneforge/desktop typecheck",
+    "commitlint": "commitlint --edit",
+    "prepare": "husky"
   },
   "devDependencies": {
-    "concurrently": "^9.2.1"
+    "@commitlint/cli": "^19.6.1",
+    "@commitlint/config-conventional": "^19.6.0",
+    "concurrently": "^9.2.1",
+    "husky": "^9.1.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,18 @@ importers:
 
   .:
     devDependencies:
+      '@commitlint/cli':
+        specifier: ^19.6.1
+        version: 19.8.1(@types/node@22.19.17)(typescript@5.8.3)
+      '@commitlint/config-conventional':
+        specifier: ^19.6.0
+        version: 19.8.1
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
 
   apps/desktop:
     dependencies:
@@ -65,16 +74,16 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.4.1
-        version: 4.7.0(vite@6.4.2(@types/node@22.19.17))
+        version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1))
       eslint:
         specifier: ^9.25.0
-        version: 9.39.4
+        version: 9.39.4(jiti@2.6.1)
       eslint-plugin-react-hooks:
         specifier: ^5.2.0
-        version: 5.2.0(eslint@9.39.4)
+        version: 5.2.0(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-refresh:
         specifier: ^0.4.19
-        version: 0.4.26(eslint@9.39.4)
+        version: 0.4.26(eslint@9.39.4(jiti@2.6.1))
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
@@ -83,13 +92,13 @@ importers:
         version: 5.8.3
       typescript-eslint:
         specifier: ^8.30.1
-        version: 8.58.2(eslint@9.39.4)(typescript@5.8.3)
+        version: 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.3)
       vite:
         specifier: ^6.3.3
-        version: 6.4.2(@types/node@22.19.17)
+        version: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)
       vitest:
         specifier: ^3.1.2
-        version: 3.2.4(@types/node@22.19.17)(jsdom@26.1.0)
+        version: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)(jsdom@26.1.0)
 
   packages/shared-types:
     devDependencies:
@@ -191,6 +200,75 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@commitlint/cli@19.8.1':
+    resolution: {integrity: sha512-LXUdNIkspyxrlV6VDHWBmCZRtkEVRpBKxi2Gtw3J54cGWhLCTouVD/Q6ZSaSvd2YaDObWK8mDjrz3TIKtaQMAA==}
+    engines: {node: '>=v18'}
+    hasBin: true
+
+  '@commitlint/config-conventional@19.8.1':
+    resolution: {integrity: sha512-/AZHJL6F6B/G959CsMAzrPKKZjeEiAVifRyEwXxcT6qtqbPwGw+iQxmNS+Bu+i09OCtdNRW6pNpBvgPrtMr9EQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/config-validator@19.8.1':
+    resolution: {integrity: sha512-0jvJ4u+eqGPBIzzSdqKNX1rvdbSU1lPNYlfQQRIFnBgLy26BtC0cFnr7c/AyuzExMxWsMOte6MkTi9I3SQ3iGQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/ensure@19.8.1':
+    resolution: {integrity: sha512-mXDnlJdvDzSObafjYrOSvZBwkD01cqB4gbnnFuVyNpGUM5ijwU/r/6uqUmBXAAOKRfyEjpkGVZxaDsCVnHAgyw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/execute-rule@19.8.1':
+    resolution: {integrity: sha512-YfJyIqIKWI64Mgvn/sE7FXvVMQER/Cd+s3hZke6cI1xgNT/f6ZAz5heND0QtffH+KbcqAwXDEE1/5niYayYaQA==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/format@19.8.1':
+    resolution: {integrity: sha512-kSJj34Rp10ItP+Eh9oCItiuN/HwGQMXBnIRk69jdOwEW9llW9FlyqcWYbHPSGofmjsqeoxa38UaEA5tsbm2JWw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/is-ignored@19.8.1':
+    resolution: {integrity: sha512-AceOhEhekBUQ5dzrVhDDsbMaY5LqtN8s1mqSnT2Kz1ERvVZkNihrs3Sfk1Je/rxRNbXYFzKZSHaPsEJJDJV8dg==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/lint@19.8.1':
+    resolution: {integrity: sha512-52PFbsl+1EvMuokZXLRlOsdcLHf10isTPlWwoY1FQIidTsTvjKXVXYb7AvtpWkDzRO2ZsqIgPK7bI98x8LRUEw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/load@19.8.1':
+    resolution: {integrity: sha512-9V99EKG3u7z+FEoe4ikgq7YGRCSukAcvmKQuTtUyiYPnOd9a2/H9Ak1J9nJA1HChRQp9OA/sIKPugGS+FK/k1A==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/message@19.8.1':
+    resolution: {integrity: sha512-+PMLQvjRXiU+Ae0Wc+p99EoGEutzSXFVwQfa3jRNUZLNW5odZAyseb92OSBTKCu+9gGZiJASt76Cj3dLTtcTdg==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/parse@19.8.1':
+    resolution: {integrity: sha512-mmAHYcMBmAgJDKWdkjIGq50X4yB0pSGpxyOODwYmoexxxiUCy5JJT99t1+PEMK7KtsCtzuWYIAXYAiKR+k+/Jw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/read@19.8.1':
+    resolution: {integrity: sha512-03Jbjb1MqluaVXKHKRuGhcKWtSgh3Jizqy2lJCRbRrnWpcM06MYm8th59Xcns8EqBYvo0Xqb+2DoZFlga97uXQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/resolve-extends@19.8.1':
+    resolution: {integrity: sha512-GM0mAhFk49I+T/5UCYns5ayGStkTt4XFFrjjf0L4S26xoMTSkdCf9ZRO8en1kuopC4isDFuEm7ZOm/WRVeElVg==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/rules@19.8.1':
+    resolution: {integrity: sha512-Hnlhd9DyvGiGwjfjfToMi1dsnw1EXKGJNLTcsuGORHz6SS9swRgkBsou33MQ2n51/boIDrbsg4tIBbRpEWK2kw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/to-lines@19.8.1':
+    resolution: {integrity: sha512-98Mm5inzbWTKuZQr2aW4SReY6WUukdWXuZhrqf1QdKPZBCCsXuG87c+iP0bwtD6DBnmVVQjgp4whoHRVixyPBg==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/top-level@19.8.1':
+    resolution: {integrity: sha512-Ph8IN1IOHPSDhURCSXBz44+CIu+60duFwRsg6HqaISFHQHbmBtxVw4ZrFNIYUzEP7WwrNPxa2/5qJ//NK1FGcw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/types@19.8.1':
+    resolution: {integrity: sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw==}
+    engines: {node: '>=v18'}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -738,6 +816,9 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/conventional-commits-parser@5.0.2':
+    resolution: {integrity: sha512-BgT2szDXnVypgpNxOK8aL5SGjUdaQbC++WZNjF1Qge3Og2+zhHj+RWhmehLhYyvQwqAmvezruVfOf8+3m74W+g==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -852,6 +933,10 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  JSONStream@1.3.5:
+    resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
+    hasBin: true
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -868,6 +953,9 @@ packages:
 
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -894,6 +982,9 @@ packages:
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
+
+  array-ify@1.0.0:
+    resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -945,6 +1036,10 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
 
@@ -966,6 +1061,9 @@ packages:
   colorette@1.4.0:
     resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
 
+  compare-func@2.0.0:
+    resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -974,12 +1072,42 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  conventional-changelog-angular@7.0.0:
+    resolution: {integrity: sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==}
+    engines: {node: '>=16'}
+
+  conventional-changelog-conventionalcommits@7.0.2:
+    resolution: {integrity: sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==}
+    engines: {node: '>=16'}
+
+  conventional-commits-parser@5.0.0:
+    resolution: {integrity: sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cosmiconfig-typescript-loader@6.3.0:
+    resolution: {integrity: sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==}
+    engines: {node: '>=v18'}
+    peerDependencies:
+      '@types/node': '*'
+      cosmiconfig: '>=9'
+      typescript: '>=5'
+
+  cosmiconfig@9.0.1:
+    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -994,6 +1122,10 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  dargs@8.1.0:
+    resolution: {integrity: sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==}
+    engines: {node: '>=12'}
 
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
@@ -1028,6 +1160,10 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dot-prop@5.3.0:
+    resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
+    engines: {node: '>=8'}
+
   electron-to-chromium@1.5.340:
     resolution: {integrity: sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==}
 
@@ -1037,6 +1173,13 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -1127,6 +1270,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1143,6 +1289,10 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  find-up@7.0.0:
+    resolution: {integrity: sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==}
+    engines: {node: '>=18'}
 
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
@@ -1164,9 +1314,19 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  git-raw-commits@4.0.0:
+    resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
+    engines: {node: '>=16'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    hasBin: true
+
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  global-directory@4.0.1:
+    resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
+    engines: {node: '>=18'}
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -1188,6 +1348,11 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -1204,6 +1369,9 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -1215,6 +1383,13 @@ packages:
   index-to-position@1.2.0:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
+
+  ini@4.1.1:
+    resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1228,11 +1403,23 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-obj@2.0.0:
+    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
+    engines: {node: '>=8'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-text-path@2.0.0:
+    resolution: {integrity: sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==}
+    engines: {node: '>=8'}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
 
   js-levenshtein@1.1.6:
     resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
@@ -1265,6 +1452,9 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -1279,6 +1469,10 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonparse@1.3.1:
+    resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
+    engines: {'0': node >= 0.2.0}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -1286,12 +1480,43 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  locate-path@7.2.0:
+    resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.kebabcase@4.1.1:
+    resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.mergewith@4.6.2:
+    resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
+
+  lodash.snakecase@4.1.1:
+    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
+
+  lodash.startcase@4.4.0:
+    resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+
+  lodash.uniq@4.5.0:
+    resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
+
+  lodash.upperfirst@4.3.1:
+    resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -1309,6 +1534,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  meow@12.1.1:
+    resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
+    engines: {node: '>=16.10'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -1323,6 +1552,9 @@ packages:
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1361,13 +1593,25 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-limit@4.0.0:
+    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  p-locate@6.0.0:
+    resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
 
   parse-json@8.3.0:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
@@ -1379,6 +1623,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-exists@5.0.0:
+    resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -1467,6 +1715,10 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
   rollup@4.60.1:
     resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -1519,6 +1771,10 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -1559,11 +1815,22 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  text-extensions@2.4.0:
+    resolution: {integrity: sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==}
+    engines: {node: '>=8'}
+
+  through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
@@ -1631,6 +1898,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unicorn-magic@0.1.0:
+    resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
+    engines: {node: '>=18'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -1797,6 +2068,10 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
+
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
@@ -1923,6 +2198,116 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@commitlint/cli@19.8.1(@types/node@22.19.17)(typescript@5.8.3)':
+    dependencies:
+      '@commitlint/format': 19.8.1
+      '@commitlint/lint': 19.8.1
+      '@commitlint/load': 19.8.1(@types/node@22.19.17)(typescript@5.8.3)
+      '@commitlint/read': 19.8.1
+      '@commitlint/types': 19.8.1
+      tinyexec: 1.1.1
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - typescript
+
+  '@commitlint/config-conventional@19.8.1':
+    dependencies:
+      '@commitlint/types': 19.8.1
+      conventional-changelog-conventionalcommits: 7.0.2
+
+  '@commitlint/config-validator@19.8.1':
+    dependencies:
+      '@commitlint/types': 19.8.1
+      ajv: 8.18.0
+
+  '@commitlint/ensure@19.8.1':
+    dependencies:
+      '@commitlint/types': 19.8.1
+      lodash.camelcase: 4.3.0
+      lodash.kebabcase: 4.1.1
+      lodash.snakecase: 4.1.1
+      lodash.startcase: 4.4.0
+      lodash.upperfirst: 4.3.1
+
+  '@commitlint/execute-rule@19.8.1': {}
+
+  '@commitlint/format@19.8.1':
+    dependencies:
+      '@commitlint/types': 19.8.1
+      chalk: 5.6.2
+
+  '@commitlint/is-ignored@19.8.1':
+    dependencies:
+      '@commitlint/types': 19.8.1
+      semver: 7.7.4
+
+  '@commitlint/lint@19.8.1':
+    dependencies:
+      '@commitlint/is-ignored': 19.8.1
+      '@commitlint/parse': 19.8.1
+      '@commitlint/rules': 19.8.1
+      '@commitlint/types': 19.8.1
+
+  '@commitlint/load@19.8.1(@types/node@22.19.17)(typescript@5.8.3)':
+    dependencies:
+      '@commitlint/config-validator': 19.8.1
+      '@commitlint/execute-rule': 19.8.1
+      '@commitlint/resolve-extends': 19.8.1
+      '@commitlint/types': 19.8.1
+      chalk: 5.6.2
+      cosmiconfig: 9.0.1(typescript@5.8.3)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@22.19.17)(cosmiconfig@9.0.1(typescript@5.8.3))(typescript@5.8.3)
+      lodash.isplainobject: 4.0.6
+      lodash.merge: 4.6.2
+      lodash.uniq: 4.5.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - typescript
+
+  '@commitlint/message@19.8.1': {}
+
+  '@commitlint/parse@19.8.1':
+    dependencies:
+      '@commitlint/types': 19.8.1
+      conventional-changelog-angular: 7.0.0
+      conventional-commits-parser: 5.0.0
+
+  '@commitlint/read@19.8.1':
+    dependencies:
+      '@commitlint/top-level': 19.8.1
+      '@commitlint/types': 19.8.1
+      git-raw-commits: 4.0.0
+      minimist: 1.2.8
+      tinyexec: 1.1.1
+
+  '@commitlint/resolve-extends@19.8.1':
+    dependencies:
+      '@commitlint/config-validator': 19.8.1
+      '@commitlint/types': 19.8.1
+      global-directory: 4.0.1
+      import-meta-resolve: 4.2.0
+      lodash.mergewith: 4.6.2
+      resolve-from: 5.0.0
+
+  '@commitlint/rules@19.8.1':
+    dependencies:
+      '@commitlint/ensure': 19.8.1
+      '@commitlint/message': 19.8.1
+      '@commitlint/to-lines': 19.8.1
+      '@commitlint/types': 19.8.1
+
+  '@commitlint/to-lines@19.8.1': {}
+
+  '@commitlint/top-level@19.8.1':
+    dependencies:
+      find-up: 7.0.0
+
+  '@commitlint/types@19.8.1':
+    dependencies:
+      '@types/conventional-commits-parser': 5.0.2
+      chalk: 5.6.2
+
   '@csstools/color-helpers@5.1.0': {}
 
   '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
@@ -2021,9 +2406,9 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
     dependencies:
-      eslint: 9.39.4
+      eslint: 9.39.4(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -2324,6 +2709,10 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/conventional-commits-parser@5.0.2':
+    dependencies:
+      '@types/node': 22.19.17
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
@@ -2342,15 +2731,15 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4)(typescript@5.8.3))(eslint@9.39.4)(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.58.2(eslint@9.39.4)(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.58.2
-      '@typescript-eslint/type-utils': 8.58.2(eslint@9.39.4)(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.58.2(eslint@9.39.4)(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.58.2
-      eslint: 9.39.4
+      eslint: 9.39.4(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.8.3)
@@ -2358,14 +2747,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.58.2(eslint@9.39.4)(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.58.2
       '@typescript-eslint/types': 8.58.2
       '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.58.2
       debug: 4.4.3(supports-color@10.2.2)
-      eslint: 9.39.4
+      eslint: 9.39.4(jiti@2.6.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -2388,13 +2777,13 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  '@typescript-eslint/type-utils@8.58.2(eslint@9.39.4)(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 8.58.2
       '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.58.2(eslint@9.39.4)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.3)
       debug: 4.4.3(supports-color@10.2.2)
-      eslint: 9.39.4
+      eslint: 9.39.4(jiti@2.6.1)
       ts-api-utils: 2.5.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -2417,13 +2806,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.58.2(eslint@9.39.4)(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.58.2
       '@typescript-eslint/types': 8.58.2
       '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.8.3)
-      eslint: 9.39.4
+      eslint: 9.39.4(jiti@2.6.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -2433,7 +2822,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.2
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.17))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -2441,7 +2830,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.2(@types/node@22.19.17)
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -2453,13 +2842,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.4.2(@types/node@22.19.17))':
+  '@vitest/mocker@3.2.4(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.2(@types/node@22.19.17)
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -2487,6 +2876,11 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  JSONStream@1.3.5:
+    dependencies:
+      jsonparse: 1.3.1
+      through: 2.3.8
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -2501,6 +2895,13 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-colors@4.1.3: {}
 
@@ -2519,6 +2920,8 @@ snapshots:
       dequal: 2.0.3
 
   aria-query@5.3.2: {}
+
+  array-ify@1.0.0: {}
 
   assertion-error@2.0.1: {}
 
@@ -2568,6 +2971,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
   change-case@5.4.4: {}
 
   check-error@2.1.3: {}
@@ -2586,6 +2991,11 @@ snapshots:
 
   colorette@1.4.0: {}
 
+  compare-func@2.0.0:
+    dependencies:
+      array-ify: 1.0.0
+      dot-prop: 5.3.0
+
   concat-map@0.0.1: {}
 
   concurrently@9.2.1:
@@ -2597,9 +3007,40 @@ snapshots:
       tree-kill: 1.2.2
       yargs: 17.7.2
 
+  conventional-changelog-angular@7.0.0:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-changelog-conventionalcommits@7.0.2:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-commits-parser@5.0.0:
+    dependencies:
+      JSONStream: 1.3.5
+      is-text-path: 2.0.0
+      meow: 12.1.1
+      split2: 4.2.0
+
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
+
+  cosmiconfig-typescript-loader@6.3.0(@types/node@22.19.17)(cosmiconfig@9.0.1(typescript@5.8.3))(typescript@5.8.3):
+    dependencies:
+      '@types/node': 22.19.17
+      cosmiconfig: 9.0.1(typescript@5.8.3)
+      jiti: 2.6.1
+      typescript: 5.8.3
+
+  cosmiconfig@9.0.1(typescript@5.8.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.8.3
 
   cross-spawn@7.0.6:
     dependencies:
@@ -2615,6 +3056,8 @@ snapshots:
       rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
+
+  dargs@8.1.0: {}
 
   data-urls@5.0.0:
     dependencies:
@@ -2639,11 +3082,21 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dot-prop@5.3.0:
+    dependencies:
+      is-obj: 2.0.0
+
   electron-to-chromium@1.5.340: {}
 
   emoji-regex@8.0.0: {}
 
   entities@6.0.1: {}
+
+  env-paths@2.2.1: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
 
   es-module-lexer@1.7.0: {}
 
@@ -2680,13 +3133,13 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-react-hooks@5.2.0(eslint@9.39.4):
+  eslint-plugin-react-hooks@5.2.0(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
-      eslint: 9.39.4
+      eslint: 9.39.4(jiti@2.6.1)
 
-  eslint-plugin-react-refresh@0.4.26(eslint@9.39.4):
+  eslint-plugin-react-refresh@0.4.26(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
-      eslint: 9.39.4
+      eslint: 9.39.4(jiti@2.6.1)
 
   eslint-scope@8.4.0:
     dependencies:
@@ -2699,9 +3152,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@9.39.4:
+  eslint@9.39.4(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.2
       '@eslint/config-helpers': 0.4.2
@@ -2735,6 +3188,8 @@ snapshots:
       minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -2768,6 +3223,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-uri@3.1.0: {}
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -2780,6 +3237,12 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  find-up@7.0.0:
+    dependencies:
+      locate-path: 7.2.0
+      path-exists: 5.0.0
+      unicorn-magic: 0.1.0
 
   flat-cache@4.0.1:
     dependencies:
@@ -2795,9 +3258,19 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  git-raw-commits@4.0.0:
+    dependencies:
+      dargs: 8.1.0
+      meow: 12.1.1
+      split2: 4.2.0
+
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  global-directory@4.0.1:
+    dependencies:
+      ini: 4.1.1
 
   globals@14.0.0: {}
 
@@ -2821,6 +3294,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  husky@9.1.7: {}
+
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -2834,11 +3309,17 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-meta-resolve@4.2.0: {}
+
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
 
   index-to-position@1.2.0: {}
+
+  ini@4.1.1: {}
+
+  is-arrayish@0.2.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -2848,9 +3329,17 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-obj@2.0.0: {}
+
   is-potential-custom-element-name@1.0.1: {}
 
+  is-text-path@2.0.0:
+    dependencies:
+      text-extensions: 2.4.0
+
   isexe@2.0.0: {}
+
+  jiti@2.6.1: {}
 
   js-levenshtein@1.1.6: {}
 
@@ -2893,6 +3382,8 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-parse-even-better-errors@2.3.1: {}
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -2900,6 +3391,8 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
+
+  jsonparse@1.3.1: {}
 
   keyv@4.5.4:
     dependencies:
@@ -2910,11 +3403,33 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lines-and-columns@1.2.4: {}
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
 
+  locate-path@7.2.0:
+    dependencies:
+      p-locate: 6.0.0
+
+  lodash.camelcase@4.3.0: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.kebabcase@4.1.1: {}
+
   lodash.merge@4.6.2: {}
+
+  lodash.mergewith@4.6.2: {}
+
+  lodash.snakecase@4.1.1: {}
+
+  lodash.startcase@4.4.0: {}
+
+  lodash.uniq@4.5.0: {}
+
+  lodash.upperfirst@4.3.1: {}
 
   loupe@3.2.1: {}
 
@@ -2930,6 +3445,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  meow@12.1.1: {}
+
   min-indent@1.0.1: {}
 
   minimatch@10.2.5:
@@ -2943,6 +3460,8 @@ snapshots:
   minimatch@5.1.9:
     dependencies:
       brace-expansion: 2.1.0
+
+  minimist@1.2.8: {}
 
   ms@2.1.3: {}
 
@@ -2983,13 +3502,28 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-limit@4.0.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
 
+  p-locate@6.0.0:
+    dependencies:
+      p-limit: 4.0.0
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
 
   parse-json@8.3.0:
     dependencies:
@@ -3002,6 +3536,8 @@ snapshots:
       entities: 6.0.1
 
   path-exists@4.0.0: {}
+
+  path-exists@5.0.0: {}
 
   path-key@3.1.1: {}
 
@@ -3067,6 +3603,8 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
+  resolve-from@5.0.0: {}
+
   rollup@4.60.1:
     dependencies:
       '@types/estree': 1.0.8
@@ -3130,6 +3668,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  split2@4.2.0: {}
+
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
@@ -3166,9 +3706,15 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
+  text-extensions@2.4.0: {}
+
+  through@2.3.8: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
+
+  tinyexec@1.1.1: {}
 
   tinyglobby@0.2.16:
     dependencies:
@@ -3209,13 +3755,13 @@ snapshots:
 
   type-fest@4.41.0: {}
 
-  typescript-eslint@8.58.2(eslint@9.39.4)(typescript@5.8.3):
+  typescript-eslint@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4)(typescript@5.8.3))(eslint@9.39.4)(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.58.2(eslint@9.39.4)(typescript@5.8.3)
+      '@typescript-eslint/eslint-plugin': 8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.3)
       '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.58.2(eslint@9.39.4)(typescript@5.8.3)
-      eslint: 9.39.4
+      '@typescript-eslint/utils': 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.3)
+      eslint: 9.39.4(jiti@2.6.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -3223,6 +3769,8 @@ snapshots:
   typescript@5.8.3: {}
 
   undici-types@6.21.0: {}
+
+  unicorn-magic@0.1.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
@@ -3236,13 +3784,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-node@3.2.4(@types/node@22.19.17):
+  vite-node@3.2.4(@types/node@22.19.17)(jiti@2.6.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@10.2.2)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.2(@types/node@22.19.17)
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3257,7 +3805,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.4.2(@types/node@22.19.17):
+  vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -3268,12 +3816,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.17
       fsevents: 2.3.3
+      jiti: 2.6.1
 
-  vitest@3.2.4(@types/node@22.19.17)(jsdom@26.1.0):
+  vitest@3.2.4(@types/node@22.19.17)(jiti@2.6.1)(jsdom@26.1.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.2(@types/node@22.19.17))
+      '@vitest/mocker': 3.2.4(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -3291,8 +3840,8 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.2(@types/node@22.19.17)
-      vite-node: 3.2.4(@types/node@22.19.17)
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)
+      vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
@@ -3370,3 +3919,5 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  yocto-queue@1.2.2: {}

--- a/scripts/prepare-bundle.mjs
+++ b/scripts/prepare-bundle.mjs
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import {
   cpSync,
   existsSync,
@@ -9,7 +8,6 @@ import {
 } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { gzipSync } from "node:zlib";
 
 const __filename = fileURLToPath(import.meta.url);
 const scriptDir = path.dirname(__filename);
@@ -21,7 +19,6 @@ const stagedBackendRoot = path.join(resourcesRoot, "backend");
 const stagedBackendSourceRoot = path.join(stagedBackendRoot, "src");
 const stagedPythonRoot = path.join(stagedBackendRoot, "python");
 const stagedSitePackagesRoot = path.join(stagedBackendRoot, "site-packages");
-const stagedBinRoot = path.join(stagedBackendRoot, "bin");
 
 function requirePath(targetPath, description) {
   if (!existsSync(targetPath)) {
@@ -52,13 +49,6 @@ function parsePythonHome(venvConfigPath) {
   return homeLine.replace("home = ", "").trim();
 }
 
-function findExecutable(binaryName) {
-  return execFileSync("which", [binaryName], {
-    cwd: workspaceRoot,
-    encoding: "utf8",
-  }).trim();
-}
-
 function shouldIncludeBundledSitePackage(sourcePath) {
   const relativePath = path.relative(sitePackagesRootForFilter, sourcePath);
   if (!relativePath || relativePath === "") {
@@ -86,13 +76,9 @@ function main() {
   const pythonInstallRoot = path.resolve(pythonHomeBin, "..");
   requirePath(pythonInstallRoot, "Bundled Python runtime source");
 
-  const ffmpegBinary = findExecutable("ffmpeg");
-  const ffprobeBinary = findExecutable("ffprobe");
-
   rmSync(resourcesRoot, { recursive: true, force: true });
   mkdirSync(resourcesRoot, { recursive: true });
   mkdirSync(stagedBackendSourceRoot, { recursive: true });
-  mkdirSync(stagedBinRoot, { recursive: true });
 
   copyInto(path.join(backendRoot, "app"), path.join(stagedBackendSourceRoot, "app"));
   copyInto(path.join(backendRoot, "alembic"), path.join(stagedBackendSourceRoot, "alembic"));
@@ -100,8 +86,6 @@ function main() {
   copyInto(path.join(backendRoot, "pyproject.toml"), path.join(stagedBackendSourceRoot, "pyproject.toml"));
   copyInto(pythonInstallRoot, stagedPythonRoot, { dereference: true });
   copyInto(sitePackagesRoot, stagedSitePackagesRoot, { filter: shouldIncludeBundledSitePackage });
-  writeFileSync(path.join(stagedBinRoot, "ffmpeg.gz"), gzipSync(readFileSync(ffmpegBinary)));
-  writeFileSync(path.join(stagedBinRoot, "ffprobe.gz"), gzipSync(readFileSync(ffprobeBinary)));
 
   writeFileSync(
     path.join(stagedBackendRoot, "manifest.json"),
@@ -111,8 +95,6 @@ function main() {
         python_root: path.relative(resourcesRoot, stagedPythonRoot),
         site_packages: path.relative(resourcesRoot, stagedSitePackagesRoot),
         backend_source: path.relative(resourcesRoot, stagedBackendSourceRoot),
-        ffmpeg: path.relative(resourcesRoot, path.join(stagedBinRoot, "ffmpeg.gz")),
-        ffprobe: path.relative(resourcesRoot, path.join(stagedBinRoot, "ffprobe.gz")),
       },
       null,
       2,


### PR DESCRIPTION
## Summary

Hardening pass before flipping the repository public. No runtime behavior changes — this PR is licensing, governance, CI, docs, and the ffmpeg-bundling drop.

## Motivation

The repo was previously private. Going public requires: a license, a security disclosure path, a code of conduct, contributor guidance, dependency hygiene, hardened CI, and clean licensing for any bundled binaries.

The biggest substantive change here is **dropping FFmpeg from the bundle**. The Homebrew default `ffmpeg` is built `--enable-gpl` (x264/x265), and shipping it inside an MIT app would GPL-contaminate the distribution. Tuneforge now requires `ffmpeg`/`ffprobe` on the host's `PATH`.

## Changes

### Licensing & governance
- `LICENSE` — MIT.
- `SECURITY.md` — explicit local-only threat model and private-disclosure process via GitHub Security Advisories.
- `CODE_OF_CONDUCT.md` — Contributor Covenant 3.0.
- `CONTRIBUTING.md` — scope, prerequisites (incl. host ffmpeg), dev loop, PR checklist, Conventional Commits format, one-commit-per-PR guidance.
- `THIRD_PARTY_NOTICES.md` — Demucs, FastAPI/Pydantic/etc., Tauri, plus the explicit "Tuneforge does not bundle FFmpeg" statement.
- `AGENTS.md` — guidance for AI coding agents (Claude Code, Cursor, Copilot, Aider, etc.) covering hard rules, layering, generated artifacts, and when to escalate.

### GitHub surface
- Issue forms: `bug_report.yml`, `feature_request.yml`, `audio_engine_issue.yml` + `config.yml` (blank issues disabled, security advisory link).
- `PULL_REQUEST_TEMPLATE.md` with a Conventional-Commits checklist item (PR title becomes the squash commit message on `main`).
- `dependabot.yml` covering all five package ecosystems weekly with grouped minor/patch updates: github-actions, npm root, npm `apps/desktop`, npm `packages/shared-types`, pip `apps/backend`, cargo `apps/desktop/src-tauri`.

### CI hardening (`.github/workflows/ci.yml`)
- Top-level `permissions: contents: read`.
- All third-party actions SHA-pinned (`actions/checkout`, `actions/setup-python`, `actions/setup-node`, `astral-sh/setup-uv`, `pnpm/action-setup`, `wagoid/commitlint-github-action`).
- New `commitlint` job that lints every commit on push/PR and additionally lints the PR title on `pull_request` events.

### Conventional Commits enforcement
- `commitlint.config.cjs` extending `@commitlint/config-conventional` with explicit type enum, casing rules, and 100-char header cap.
- Husky `commit-msg` hook (`.husky/commit-msg`) that runs commitlint locally on every `git commit`.
- `prepare` script wired in `package.json` so `husky` is set up automatically on `pnpm install`.

### Drop FFmpeg bundling
- `scripts/prepare-bundle.mjs` — removed staging of `ffmpeg`/`ffprobe` (no more `execFileSync`/`gzipSync`/`findExecutable`/manifest entries).
- `apps/desktop/src-tauri/src/main.rs` — removed `stage_media_binary` and the `TUNEFORGE_FFMPEG_PATH`/`TUNEFORGE_FFPROBE_PATH` env injection from `spawn_packaged_backend`. Dropped now-unused `flate2`/`File`/`PermissionsExt` imports.
- `apps/desktop/src-tauri/Cargo.toml` — removed `flate2` dependency.
- `apps/desktop/src-tauri/tauri.conf.json` — `targets` narrowed from `"all"` to `["app", "dmg"]`.

### Docs / policy
- `README.md` rewritten: positioning as a local-first app for musicians learning songs (no Moises wording), threat model, env-vars table, host-ffmpeg prereq, default data dirs per OS, packaging-WIP note.
- `apps/backend/README.md` rewritten: layout, prerequisites, setup, run, full env-vars table, migrations, job system, testing, lint.
- `.gitignore` extended with secrets/keys patterns.

## Test Plan

Run from the workspace root, all green locally:

```sh
pnpm lint
pnpm typecheck
pnpm --filter @tuneforge/desktop test --run
cd apps/backend && uv run --python 3.11 pytest
cd apps/desktop/src-tauri && cargo check
pnpm contracts:generate && git diff --exit-code -- packages/shared-types
```

Commitlint smoke-tested against:
- ✅ `feat(backend): add chord smoothing window`
- ❌ `Add CONTRIBUTING` (rejected — not Conventional)
- ❌ `bad message` (rejected — missing type and subject)

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) — it becomes the squash commit message on `main`
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (desktop + backend)
- [x] No backend route/schema changes; contracts unchanged
- [x] Updated relevant docs
- [x] No secrets, credentials, or copyrighted audio added to the repository