### PR TITLE
fix(stems): improve linux stem handling

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -51,7 +51,7 @@ All configuration is environment-driven (see [`app/config.py`](./app/config.py))
 | `TUNEFORGE_FFMPEG_PATH` | `ffmpeg` | Override the `ffmpeg` binary location. |
 | `TUNEFORGE_FFPROBE_PATH` | `ffprobe` | Override the `ffprobe` binary location. |
 | `TUNEFORGE_STEM_MODEL` | `htdemucs_ft` | Demucs model used for stem separation. |
-| `TUNEFORGE_STEM_DEVICE` | `auto` | One of `auto`, `cpu`, `mps`, `cuda`. `auto` prefers CUDA, then MPS, then CPU. |
+| `TUNEFORGE_STEM_DEVICE` | `auto` | One of `auto`, `cpu`, `mps`, `cuda`. `auto` prefers compatible CUDA, then MPS, then CPU. |
 
 Default data directory:
 

--- a/apps/backend/app/api/routes/projects.py
+++ b/apps/backend/app/api/routes/projects.py
@@ -37,6 +37,7 @@ from app.services.projects import (
     list_projects,
     rename_project,
 )
+from app.services.stems import resolve_stem_source_artifact
 
 router = APIRouter(prefix="/projects", tags=["projects"])
 
@@ -205,12 +206,19 @@ def project_stems(
     session: Session = Depends(get_db),
     runner=Depends(get_job_runner),
 ) -> JobResponse:
-    get_project(session, project_id)
+    project = get_project(session, project_id)
+    source_artifact = resolve_stem_source_artifact(
+        session,
+        project=project,
+        source_artifact_id=payload.source_artifact_id,
+    )
+    job_payload = payload.model_dump()
+    job_payload["source_artifact_id"] = source_artifact.id
     job = runner.create_job(
         session,
         project_id=project_id,
         job_type="stems",
-        payload=payload.model_dump(),
+        payload=job_payload,
     )
     session.commit()
     session.refresh(job)

--- a/apps/backend/app/models.py
+++ b/apps/backend/app/models.py
@@ -107,6 +107,11 @@ class Job(Base):
 
     project: Mapped[Project | None] = relationship(back_populates="jobs")
 
+    @property
+    def source_artifact_id(self) -> str | None:
+        value = self.payload_json.get("source_artifact_id")
+        return value if isinstance(value, str) else None
+
 
 class Setting(Base):
     __tablename__ = "settings"

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -130,6 +130,7 @@ class JobSchema(BaseModel):
     type: str
     status: str
     progress: int
+    source_artifact_id: str | None = None
     error_message: str | None
     created_at: datetime
     updated_at: datetime

--- a/apps/backend/app/utils/torch_runtime.py
+++ b/apps/backend/app/utils/torch_runtime.py
@@ -11,6 +11,30 @@ def with_mps_fallback_env(base_env: Mapping[str, str] | None = None) -> dict[str
     return env
 
 
+def _cuda_build_supports_visible_devices(torch_module: Any) -> bool:
+    cuda = getattr(torch_module, "cuda", None)
+    if cuda is None:
+        return False
+
+    get_arch_list = getattr(cuda, "get_arch_list", None)
+    device_count = getattr(cuda, "device_count", None)
+    get_device_capability = getattr(cuda, "get_device_capability", None)
+    if not callable(get_arch_list) or not callable(device_count) or not callable(get_device_capability):
+        return True
+
+    arch_list = [arch for arch in get_arch_list() if isinstance(arch, str) and arch.startswith("sm_")]
+    if not arch_list:
+        return True
+
+    supported_majors = {int(arch.removeprefix("sm_")) // 10 for arch in arch_list}
+    for device_index in range(max(0, int(device_count()))):
+        capability = get_device_capability(device_index)
+        cap_major = capability[0] if isinstance(capability, tuple) and capability else None
+        if cap_major in supported_majors:
+            return True
+    return False
+
+
 def choose_torch_device(requested: str = "auto", *, torch_module: Any) -> str:
     requested = requested.strip().lower()
     valid = {"auto", "cpu", "mps", "cuda"}
@@ -23,9 +47,10 @@ def choose_torch_device(requested: str = "auto", *, torch_module: Any) -> str:
     if mps_backend is not None and hasattr(mps_backend, "is_available"):
         has_mps = bool(mps_backend.is_available())
     has_cuda = bool(torch_module.cuda.is_available())
+    has_compatible_cuda = has_cuda and _cuda_build_supports_visible_devices(torch_module)
 
     if requested == "auto":
-        if has_cuda:
+        if has_compatible_cuda:
             return "cuda"
         if has_mps:
             return "mps"
@@ -35,4 +60,8 @@ def choose_torch_device(requested: str = "auto", *, torch_module: Any) -> str:
         raise RuntimeError("Requested MPS device, but MPS is unavailable on this machine.")
     if requested == "cuda" and not has_cuda:
         raise RuntimeError("Requested CUDA device, but CUDA is unavailable on this machine.")
+    if requested == "cuda" and not has_compatible_cuda:
+        raise RuntimeError(
+            "Requested CUDA device, but the current PyTorch build does not support the visible NVIDIA GPU architecture."
+        )
     return requested

--- a/apps/backend/tests/test_stem_flow.py
+++ b/apps/backend/tests/test_stem_flow.py
@@ -56,6 +56,8 @@ def test_stem_generation_creates_vocal_and_instrumental_artifacts(client, sample
     assert vocal_artifact["metadata"]["mode"] == "two_stem"
     assert instrumental_artifact["metadata"]["engine"] == "demucs"
     assert vocal_artifact["metadata"]["model"] == "htdemucs_ft"
+    assert stem_job["source_artifact_id"] == source_artifact["id"]
+    assert final_job["source_artifact_id"] == source_artifact["id"]
     assert vocal_artifact["metadata"]["source_artifact_id"] == source_artifact["id"]
     assert instrumental_artifact["metadata"]["source_artifact_id"] == source_artifact["id"]
     assert Path(vocal_artifact["path"]).exists()
@@ -96,7 +98,10 @@ def test_stem_generation_creates_vocal_and_instrumental_artifacts(client, sample
             "source_artifact_id": preview_artifact["id"],
         },
     ).json()["job"]
-    assert wait_for_job(client, preview_stem_job["id"])["status"] == "completed"
+    preview_final_job = wait_for_job(client, preview_stem_job["id"])
+    assert preview_final_job["status"] == "completed"
+    assert preview_stem_job["source_artifact_id"] == preview_artifact["id"]
+    assert preview_final_job["source_artifact_id"] == preview_artifact["id"]
 
     all_artifacts = client.get(f"/api/v1/projects/{project['id']}/artifacts").json()["artifacts"]
     preview_vocals = [

--- a/apps/backend/tests/test_torch_runtime.py
+++ b/apps/backend/tests/test_torch_runtime.py
@@ -7,8 +7,15 @@ import pytest
 from app.utils.torch_runtime import choose_torch_device
 
 
-def make_fake_torch(*, has_mps: bool, has_cuda: bool):
+def make_fake_torch(
+    *,
+    has_mps: bool,
+    has_cuda: bool,
+    supported_arches: list[str] | None = None,
+    device_capability: tuple[int, int] = (7, 5),
+):
     return SimpleNamespace(
+        version=SimpleNamespace(cuda="13.0" if has_cuda else None),
         backends=SimpleNamespace(
             mps=SimpleNamespace(
                 is_available=lambda: has_mps,
@@ -16,12 +23,23 @@ def make_fake_torch(*, has_mps: bool, has_cuda: bool):
         ),
         cuda=SimpleNamespace(
             is_available=lambda: has_cuda,
+            get_arch_list=lambda: list(supported_arches or []),
+            device_count=lambda: 1 if has_cuda else 0,
+            get_device_capability=lambda _index: device_capability,
         ),
     )
 
 
 def test_choose_torch_device_prefers_cuda_then_mps_then_cpu():
-    assert choose_torch_device("auto", torch_module=make_fake_torch(has_mps=True, has_cuda=True)) == "cuda"
+    assert choose_torch_device(
+        "auto",
+        torch_module=make_fake_torch(
+            has_mps=True,
+            has_cuda=True,
+            supported_arches=["sm_75", "sm_80"],
+            device_capability=(7, 5),
+        ),
+    ) == "cuda"
     assert choose_torch_device("auto", torch_module=make_fake_torch(has_mps=True, has_cuda=False)) == "mps"
     assert choose_torch_device("auto", torch_module=make_fake_torch(has_mps=False, has_cuda=False)) == "cpu"
 
@@ -32,6 +50,34 @@ def test_choose_torch_device_rejects_unavailable_requested_backend():
 
     with pytest.raises(RuntimeError, match="CUDA is unavailable"):
         choose_torch_device("cuda", torch_module=make_fake_torch(has_mps=True, has_cuda=False))
+
+
+def test_choose_torch_device_auto_falls_back_when_cuda_arch_is_unsupported():
+    assert (
+        choose_torch_device(
+            "auto",
+            torch_module=make_fake_torch(
+                has_mps=False,
+                has_cuda=True,
+                supported_arches=["sm_75", "sm_80"],
+                device_capability=(6, 1),
+            ),
+        )
+        == "cpu"
+    )
+
+
+def test_choose_torch_device_rejects_requested_cuda_when_arch_is_unsupported():
+    with pytest.raises(RuntimeError, match="does not support the visible NVIDIA GPU architecture"):
+        choose_torch_device(
+            "cuda",
+            torch_module=make_fake_torch(
+                has_mps=False,
+                has_cuda=True,
+                supported_arches=["sm_75", "sm_80"],
+                device_capability=(6, 1),
+            ),
+        )
 
 
 def test_choose_torch_device_rejects_unknown_backend():

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -359,6 +359,7 @@ const {
       type: "stems",
       status: "completed",
       progress: 100,
+      source_artifact_id: sourceArtifactId,
       error_message: null,
       created_at: createdAt,
       updated_at: createdAt,
@@ -1174,6 +1175,84 @@ describe("Desktop app flows", () => {
     expect(soloVocals).toHaveAttribute("aria-pressed", "true");
     expect(muteInstrumental).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByText("1 / 2")).toBeInTheDocument();
+  });
+
+  it("shows failed stem jobs inline and in processing history", async () => {
+    const user = userEvent.setup();
+    mockListJobs.mockResolvedValue({
+      jobs: [
+        {
+          id: "job_stem_failed",
+          project_id: "proj_123",
+          type: "stems",
+          status: "failed",
+          progress: 15,
+          source_artifact_id: "art_source",
+          error_message: "Demucs failed to separate the track.",
+          created_at: "2026-04-18T13:16:00.000Z",
+          updated_at: "2026-04-18T13:16:00.000Z",
+        },
+      ],
+    });
+
+    renderApp(["/projects/proj_123"]);
+
+    const stemError = await screen.findByRole("group", { name: "Stem error" });
+    expect(within(stemError).getByText("Demucs failed to separate the track.")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Show raw artifacts and processing history"));
+    const jobHistory = screen.getByText("Show raw artifacts and processing history").closest("details");
+    expect(jobHistory).not.toBeNull();
+
+    expect(within(jobHistory as HTMLElement).getByText("stems")).toBeInTheDocument();
+    expect(within(jobHistory as HTMLElement).getByText("failed")).toBeInTheDocument();
+    expect(
+      within(jobHistory as HTMLElement).getByText("Demucs failed to separate the track."),
+    ).toBeInTheDocument();
+  });
+
+  it("scopes stem errors to selected audio and lets user dismiss them", async () => {
+    const user = userEvent.setup();
+    mockListJobs.mockResolvedValue({
+      jobs: [
+        {
+          id: "job_stem_preview_failed",
+          project_id: "proj_123",
+          type: "stems",
+          status: "failed",
+          progress: 15,
+          source_artifact_id: "art_preview",
+          error_message: "Preview stems failed.",
+          created_at: "2026-04-18T13:16:00.000Z",
+          updated_at: "2026-04-18T13:16:00.000Z",
+        },
+      ],
+    });
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: "Stem error" })).not.toBeInTheDocument();
+
+    const savedMixList = screen.getByRole("group", { name: "Saved mix list" });
+    await user.click(within(savedMixList).getByRole("button", { name: /Practice Mix/i }));
+
+    const stemError = await screen.findByRole("group", { name: "Stem error" });
+    expect(within(stemError).getByText("Preview stems failed.")).toBeInTheDocument();
+    await user.click(within(stemError).getByRole("button", { name: "Dismiss" }));
+    expect(screen.queryByRole("group", { name: "Stem error" })).not.toBeInTheDocument();
+
+    await user.click(screen.getAllByRole("link", { name: "Library" })[0]);
+    const demoProjectCard = screen.getByRole("heading", { name: "Demo Song", level: 2 }).closest(
+      "article",
+    );
+    expect(demoProjectCard).not.toBeNull();
+    await user.click(
+      within(demoProjectCard as HTMLElement).getByRole("link", { name: /Open project/i }),
+    );
+
+    expect(await screen.findByRole("heading", { name: "Practice Mix" })).toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: "Stem error" })).not.toBeInTheDocument();
   });
 
   it("exports selected audio", async () => {

--- a/apps/desktop/src/features/projects/ProjectView.tsx
+++ b/apps/desktop/src/features/projects/ProjectView.tsx
@@ -303,6 +303,7 @@ export function ProjectView() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const {
+    activateStemPlayback,
     dismissSession,
     isPlaying,
     playbackDurationSeconds,
@@ -336,6 +337,7 @@ export function ProjectView() {
   const [draftName, setDraftName] = useState("");
   const [inspectorOpen, setInspectorOpen] = useState(defaultInspectorOpen);
   const [stemControls, setStemControls] = useState<Record<string, StemControlState>>({});
+  const [dismissedStemJobIds, setDismissedStemJobIds] = useState<string[]>([]);
   const showSupportingCopy = helperTextVisible && informationDensity !== "minimal";
 
   const projectQuery = useQuery({
@@ -504,7 +506,10 @@ export function ProjectView() {
   );
   const analyzeJob = projectJobs.find((job) => job.type === "analyze");
   const chordJob = projectJobs.find((job) => job.type === "chords");
-  const stemJob = projectJobs.find((job) => job.type === "stems");
+  const stemJobs = useMemo(
+    () => projectJobs.filter((job) => job.type === "stems"),
+    [projectJobs],
+  );
 
   const displayArtifacts = useMemo(() => {
     const artifacts = artifactsQuery.data ?? [];
@@ -565,6 +570,24 @@ export function ProjectView() {
       }),
     [selectedPrimaryArtifact?.id, stemArtifacts],
   );
+  const stemJob = useMemo(() => {
+    const selectedPrimaryId = selectedPrimaryArtifact?.id;
+    if (!selectedPrimaryId) {
+      return null;
+    }
+
+    const selectedSourceJob =
+      stemJobs.find((job) => job.source_artifact_id === selectedPrimaryId) ?? null;
+    if (selectedSourceJob) {
+      return selectedSourceJob;
+    }
+
+    if (selectedPrimaryArtifact?.type === "source_audio") {
+      return stemJobs.find((job) => job.source_artifact_id == null) ?? null;
+    }
+
+    return null;
+  }, [selectedPrimaryArtifact, stemJobs]);
   const focusedStemArtifact =
     isStemArtifact(selectedArtifact) ? selectedArtifact : visibleStemArtifacts[0] ?? null;
   const isStemSelected = isStemArtifact(selectedArtifact);
@@ -607,11 +630,12 @@ export function ProjectView() {
       ? "auto"
       : serializeKey(sourceKey);
   const hasVisibleStems = visibleStemArtifacts.length > 0;
-  const visibleJobs = useMemo(
-    () => projectJobs.filter((job) => job.type !== "stems"),
-    [projectJobs],
-  );
-  const recentJobs = visibleJobs.slice(0, 3);
+  const stemErrorMessage =
+    stemJob?.error_message && !dismissedStemJobIds.includes(stemJob.id)
+      ? stemJob.error_message
+      : null;
+  const visibleJobs = projectJobs;
+  const recentJobs = projectJobs.slice(0, 3);
   const controlSummary = hasTransformChange ? formatKey(targetKey) : "Original key";
   const tuningSummary = formatRetuneSummary(retuneMode, referenceHz, centsOffset);
   const mixStatus = isStemPlayback
@@ -686,7 +710,8 @@ export function ProjectView() {
     setSelectedArtifactId(artifact.id);
   }
 
-  function handleSelectStemArtifact(artifact: ArtifactSchema) {
+  async function handleSelectStemArtifact(artifact: ArtifactSchema) {
+    await activateStemPlayback();
     const sourceArtifactId = sourceArtifactIdForStems(artifact);
     if (sourceArtifactId) {
       setSelectedPrimaryArtifactId(sourceArtifactId);
@@ -781,6 +806,7 @@ export function ProjectView() {
     setSelectedArtifactId(storedPlaybackState.selectedArtifactId);
     setSelectedPrimaryArtifactId(storedPlaybackState.selectedPrimaryArtifactId);
     setStemControls(storedPlaybackState.stemControls);
+    setDismissedStemJobIds(storedPlaybackState.dismissedStemJobIds);
     setHydratedProjectId(projectId);
   }, [projectId]);
 
@@ -853,6 +879,18 @@ export function ProjectView() {
   }, [visibleStemArtifacts]);
 
   useEffect(() => {
+    if (hydratedProjectId !== projectId || !jobsQuery.data) {
+      return;
+    }
+
+    const activeStemJobIds = new Set(stemJobs.map((job) => job.id));
+    setDismissedStemJobIds((current) => {
+      const next = current.filter((jobId) => activeStemJobIds.has(jobId));
+      return next.length === current.length ? current : next;
+    });
+  }, [hydratedProjectId, jobsQuery.data, projectId, stemJobs]);
+
+  useEffect(() => {
     if (hydratedProjectId !== projectId) {
       return;
     }
@@ -863,8 +901,10 @@ export function ProjectView() {
       selectedPrimaryArtifactId,
       selectedStemSourceArtifactId,
       stemControls,
+      dismissedStemJobIds,
     });
   }, [
+    dismissedStemJobIds,
     hydratedProjectId,
     projectId,
     selectedArtifactId,
@@ -1148,6 +1188,22 @@ export function ProjectView() {
                     : "Select source audio or a saved mix first."}
                 </p>
               )}
+              {stemErrorMessage && stemJob ? (
+                <div className="button-row" role="group" aria-label="Stem error">
+                  <span className="inline-error">{stemErrorMessage}</span>
+                  <button
+                    className="button button--ghost button--small"
+                    onClick={() =>
+                      setDismissedStemJobIds((current) =>
+                        current.includes(stemJob.id) ? current : [...current, stemJob.id],
+                      )
+                    }
+                    type="button"
+                  >
+                    Dismiss
+                  </button>
+                </div>
+              ) : null}
             </div>
           </div>
         </aside>

--- a/apps/desktop/src/features/projects/playback-context.ts
+++ b/apps/desktop/src/features/projects/playback-context.ts
@@ -18,6 +18,7 @@ export type PlaybackContextValue = {
   playbackTimeSeconds: number;
   playbackDurationSeconds: number;
   isPlaying: boolean;
+  activateStemPlayback: () => Promise<void>;
   registerProjectSession: (session: ProjectPlaybackSession) => void;
   togglePlayback: () => Promise<void>;
   playPlayback: () => Promise<void>;

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -82,6 +82,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   const primaryAudioRef = useRef<HTMLAudioElement | null>(null);
   const stemAudioRefs = useRef<Record<string, HTMLAudioElement | null>>({});
   const stemAudioContextRef = useRef<AudioContext | null>(null);
+  const stemClockBlockedRef = useRef(false);
   const stemBufferCacheRef = useRef(new Map<string, Promise<AudioBuffer>>());
   const stemPlaybackRef = useRef<StemPlaybackState | null>(null);
   const pendingTransitionRef = useRef<PendingTransition | null>(
@@ -194,7 +195,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       .filter(Boolean) as HTMLAudioElement[];
   }
 
-  function getAudioContextConstructor() {
+  const getAudioContextConstructor = useCallback(() => {
     if (typeof window === "undefined") {
       return null;
     }
@@ -205,11 +206,15 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         .webkitAudioContext ??
       null
     );
-  }
+  }, []);
 
-  function canUseStemClock() {
-    return typeof fetch === "function" && Boolean(getAudioContextConstructor());
-  }
+  const canUseStemClock = useCallback(
+    () =>
+      !stemClockBlockedRef.current &&
+      typeof fetch === "function" &&
+      Boolean(getAudioContextConstructor()),
+    [getAudioContextConstructor],
+  );
 
   function syncStemElementTimes(artifactIds: string[], nextTime: number) {
     artifactIds.forEach((artifactId) => {
@@ -228,7 +233,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     });
   }
 
-  function getStemAudioContext() {
+  const getStemAudioContext = useCallback(() => {
     if (stemAudioContextRef.current) {
       return stemAudioContextRef.current;
     }
@@ -241,7 +246,32 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     const context = new AudioContextConstructor();
     stemAudioContextRef.current = context;
     return context;
-  }
+  }, [getAudioContextConstructor]);
+
+  const activateStemPlayback = useCallback(async () => {
+    if (!canUseStemClock()) {
+      return;
+    }
+
+    const context = getStemAudioContext();
+    if (!context || context.state === "running") {
+      return;
+    }
+
+    // WebKit on Linux is stricter about user-gesture timing for AudioContext resume.
+    try {
+      await context.resume();
+    } catch {
+      stemClockBlockedRef.current = true;
+      return;
+    }
+
+    const contextState = (context as AudioContext).state;
+    if (contextState !== "running") {
+      stemClockBlockedRef.current = true;
+      return;
+    }
+  }, [canUseStemClock, getStemAudioContext]);
 
   async function loadStemBuffer(artifactId: string) {
     const cachedBuffer = stemBufferCacheRef.current.get(artifactId);
@@ -451,7 +481,20 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       return false;
     }
 
-    await targetPlaybackState.context.resume();
+    try {
+      await targetPlaybackState.context.resume();
+    } catch {
+      stemClockBlockedRef.current = true;
+      disposeStemPlaybackState();
+      setIsPlaying(false);
+      return false;
+    }
+    if (targetPlaybackState.context.state !== "running") {
+      stemClockBlockedRef.current = true;
+      disposeStemPlaybackState();
+      setIsPlaying(false);
+      return false;
+    }
     stopStemSources(targetPlaybackState, false);
 
     const nextTime = clampTime(timeSeconds, targetPlaybackState.durationSeconds);
@@ -716,7 +759,26 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           return;
         }
 
-        await startStemPlayback(latestSession, nextTime);
+        const started = await startStemPlayback(latestSession, nextTime);
+        if (started) {
+          return;
+        }
+
+        const fallbackElements = getActiveMediaElements(latestSession);
+        if (!fallbackElements.length) {
+          return;
+        }
+
+        fallbackElements.forEach((element) => {
+          if (Math.abs(element.currentTime - nextTime) > SEEK_TOLERANCE_SECONDS) {
+            element.currentTime = nextTime;
+          }
+        });
+
+        const results = await Promise.allSettled(
+          fallbackElements.map((element) => Promise.resolve(element.play())),
+        );
+        setIsPlaying(results.some((result) => result.status === "fulfilled"));
       })();
       return;
     }
@@ -852,8 +914,10 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
     if (targetSession.isStemPlayback && canUseStemClock()) {
       const masterTime = readMasterTime(targetSession);
-      await startStemPlayback(targetSession, masterTime);
-      return;
+      const started = await startStemPlayback(targetSession, masterTime);
+      if (started) {
+        return;
+      }
     }
 
     const activeElements = getActiveMediaElements(targetSession);
@@ -1144,6 +1208,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       playbackTimeSeconds,
       playbackDurationSeconds,
       isPlaying,
+      activateStemPlayback,
       registerProjectSession,
       togglePlayback,
       playPlayback,
@@ -1155,6 +1220,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     }),
     [
       dismissSession,
+      activateStemPlayback,
       isPlaying,
       pausePlayback,
       playbackDurationSeconds,

--- a/apps/desktop/src/features/projects/projectPlaybackState.ts
+++ b/apps/desktop/src/features/projects/projectPlaybackState.ts
@@ -8,6 +8,7 @@ export type StoredProjectPlaybackState = {
   selectedPrimaryArtifactId: string | null;
   selectedStemSourceArtifactId: string | null;
   stemControls: Record<string, StemControlState>;
+  dismissedStemJobIds: string[];
 };
 
 const STORAGE_KEY = "tuneforge.project-playback-state";
@@ -17,6 +18,7 @@ const DEFAULT_STORED_PROJECT_PLAYBACK_STATE: StoredProjectPlaybackState = {
   selectedPrimaryArtifactId: null,
   selectedStemSourceArtifactId: null,
   stemControls: {},
+  dismissedStemJobIds: [],
 };
 
 function normalizeStemControlState(value: unknown): StemControlState {
@@ -47,6 +49,9 @@ function normalizeStoredProjectPlaybackState(value: unknown): StoredProjectPlayb
       normalizeStemControlState(controlState),
     ]),
   );
+  const dismissedStemJobIds = Array.isArray(candidate.dismissedStemJobIds)
+    ? candidate.dismissedStemJobIds.filter((jobId): jobId is string => typeof jobId === "string")
+    : [];
 
   return {
     selectedArtifactId:
@@ -60,6 +65,7 @@ function normalizeStoredProjectPlaybackState(value: unknown): StoredProjectPlayb
         ? candidate.selectedStemSourceArtifactId
         : null,
     stemControls,
+    dismissedStemJobIds,
   };
 }
 

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -484,6 +484,8 @@ export interface components {
             status: string;
             /** Progress */
             progress: number;
+            /** Source Artifact Id */
+            source_artifact_id?: string | null;
             /** Error Message */
             error_message: string | null;
             /**

--- a/scripts/prepare-bundle.mjs
+++ b/scripts/prepare-bundle.mjs
@@ -56,7 +56,9 @@ function shouldIncludeBundledSitePackage(sourcePath) {
   }
 
   const segments = relativePath.split(path.sep);
-  if (segments.some((segment) => ["__pycache__", "tests", "test", "testing"].includes(segment))) {
+  // Keep runtime package submodules intact. Torch imports from torch/testing at runtime,
+  // so filtering generic names like "test" or "testing" breaks packaged builds.
+  if (segments.includes("__pycache__")) {
     return false;
   }
 


### PR DESCRIPTION
## Summary

- keep packaged builds from stripping `torch.testing`, which broke bundled stem separation on startup
- fall back to CPU automatically when the selected CUDA device is visible but unsupported for stem separation
- make Linux stem playback switch reliably by priming stem playback before selecting stems and falling back to synced media elements when the shared stem clock cannot start
- scope inline stem errors to the selected source or practice mix and allow dismissing stale messages without affecting other mixes

## Testing

- `UV_CACHE_DIR=/tmp/uv-cache pnpm contracts:generate`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop exec eslint src/features/projects/ProjectView.tsx src/features/projects/projectPlaybackState.ts src/App.test.tsx`
- `cd apps/backend && UV_CACHE_DIR=/tmp/uv-cache uv run --python 3.11 pytest tests/test_torch_runtime.py`
- manual verification on Linux: source import, analysis, chord detection, mix creation, stem generation on CPU fallback, stem playback switching
- not run: `pnpm lint`, `pnpm typecheck`, `pnpm test`, `cd apps/backend && uv run --python 3.11 pytest`, and `cd apps/desktop/src-tauri && cargo check`
- `pnpm --filter @tuneforge/desktop exec vitest run src/App.test.tsx -t "scopes stem errors to selected audio and lets user dismiss them"` still hits existing `React.act is not a function` failure in current tree
- `UV_CACHE_DIR=/tmp/uv-cache uv run --project apps/backend --python 3.11 pytest apps/backend/tests/test_stem_flow.py` timed out in current tree
