### PR TITLE
fix(desktop): force vitest NODE_ENV to test

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -10,8 +10,10 @@ export default defineConfig({
   },
   test: {
     environment: "jsdom",
+    env: {
+      NODE_ENV: "test",
+    },
     globals: true,
     setupFiles: "./src/setupTests.ts",
   },
 });
-


### PR DESCRIPTION
## Summary

- force the desktop Vitest runtime to use `NODE_ENV=test`
- prevent local shells exporting `NODE_ENV=production` from loading React's production build during desktop tests

## Testing

- `pnpm --filter @tuneforge/desktop exec eslint src/App.test.tsx vite.config.ts`
- `pnpm --filter @tuneforge/desktop typecheck`
- `NODE_ENV=production pnpm --filter @tuneforge/desktop exec vitest run src/App.test.tsx -t "shows failed stem jobs inline and in processing history"`
- `NODE_ENV=production pnpm --filter @tuneforge/desktop exec vitest run src/App.test.tsx`
- not run: `pnpm lint`, `pnpm typecheck`, `pnpm test`, `cd apps/backend && uv run --python 3.11 pytest`, and `cd apps/desktop/src-tauri && cargo check`
