### PR TITLE
feat(desktop): polish project playback and library UI

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -493,6 +493,16 @@ vi.mock("./lib/api", async (importOriginal) => {
 });
 
 function renderApp(initialEntries: string[]) {
+  if (
+    initialEntries.some((entry) => entry.startsWith("/projects/")) &&
+    !window.localStorage.getItem("tuneforge.ui-preferences")
+  ) {
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({ defaultSourcesRailCollapsed: false }),
+    );
+  }
+
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -660,6 +670,50 @@ describe("Desktop app flows", () => {
     expect(screen.queryByText("Bass Drill")).not.toBeInTheDocument();
   });
 
+  it("renders project cards with local timestamps and without filename subtitles", async () => {
+    const updatedAt = "2026-04-21T02:59:00.000000";
+
+    setProjects([
+      {
+        id: "proj_1",
+        display_name: "Birds",
+        source_path: "/tmp/Birds [Sa-dxgZt4rY].webm",
+        imported_path: "/tmp/projects/birds.webm",
+        duration_seconds: 219,
+        sample_rate: 44100,
+        channels: 2,
+        created_at: updatedAt,
+        updated_at: updatedAt,
+      },
+    ]);
+
+    renderApp(["/"]);
+
+    const localizedUpdatedAt = new Intl.DateTimeFormat(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(new Date(Date.UTC(2026, 3, 21, 2, 59, 0, 0)));
+
+    const projectCard = (await screen.findByRole("heading", { name: "Birds", level: 2 })).closest(
+      "article",
+    );
+    expect(projectCard).not.toBeNull();
+    const timestamp = within(projectCard as HTMLElement).getByText(localizedUpdatedAt);
+    expect(timestamp).toBeInTheDocument();
+    expect(within(projectCard as HTMLElement).queryByText(/Updated/i)).not.toBeInTheDocument();
+    expect(within(projectCard as HTMLElement).queryByText("Open project")).not.toBeInTheDocument();
+
+    const timeElement = timestamp.closest("time");
+    expect(timeElement).toHaveAttribute("dateTime", "2026-04-21T02:59:00.000Z");
+
+    const openLink = within(projectCard as HTMLElement).getByRole("link", {
+      name: "Open Birds project",
+    });
+    expect(within(openLink).queryByText(/\[Sa-dxgZt4rY\]\.webm/i)).not.toBeInTheDocument();
+  });
+
   it("imports track from library and opens project", async () => {
     const user = userEvent.setup();
     mockOpen.mockResolvedValue("/tmp/new-song.mp4");
@@ -769,12 +823,12 @@ describe("Desktop app flows", () => {
 
     await user.click(screen.getAllByRole("link", { name: "Library" })[0]);
     expect(await screen.findByText("Background Playback")).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Stop" }));
+    await user.click(screen.getByRole("button", { name: "Stop background playback" }));
 
     const demoProjectCard = screen.getByText("Demo Song").closest("article");
     expect(demoProjectCard).not.toBeNull();
     await user.click(
-      within(demoProjectCard as HTMLElement).getByRole("link", { name: /Open project/i }),
+      within(demoProjectCard as HTMLElement).getByRole("link", { name: "Open Demo Song project" }),
     );
 
     expect(await screen.findByRole("heading", { name: "Vocals" })).toBeInTheDocument();
@@ -851,7 +905,9 @@ describe("Desktop app flows", () => {
     const secondProjectCard = screen.getByText("Bass Drill").closest("article");
     expect(secondProjectCard).not.toBeNull();
     await user.click(
-      within(secondProjectCard as HTMLElement).getByRole("link", { name: /Open project/i }),
+      within(secondProjectCard as HTMLElement).getByRole("link", {
+        name: "Open Bass Drill project",
+      }),
     );
 
     expect(await screen.findByRole("heading", { name: "Bass Drill" })).toBeInTheDocument();
@@ -860,7 +916,7 @@ describe("Desktop app flows", () => {
     const demoProjectCard = screen.getByText("Demo Song").closest("article");
     expect(demoProjectCard).not.toBeNull();
     await user.click(
-      within(demoProjectCard as HTMLElement).getByRole("link", { name: /Open project/i }),
+      within(demoProjectCard as HTMLElement).getByRole("link", { name: "Open Demo Song project" }),
     );
 
     expect(await screen.findByRole("heading", { name: "Vocals" })).toBeInTheDocument();
@@ -918,6 +974,29 @@ describe("Desktop app flows", () => {
     await waitFor(() => expect(previewAudio.currentTime).toBeCloseTo(47.253, 3));
     expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
     expect(screen.getByLabelText("Playback position")).toHaveAttribute("step", "0.001");
+  });
+
+  it("stops playback and rewinds transport to start", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    sourceAudio.currentTime = 32.417;
+    fireEvent.timeUpdate(sourceAudio);
+
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Playback position")).toHaveValue("32.417");
+
+    await user.click(screen.getByRole("button", { name: "Stop playback" }));
+
+    expect(sourceAudio.currentTime).toBe(0);
+    expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Playback position")).toHaveValue("0");
   });
 
   it("keeps playback position when a newly created mix becomes active", async () => {
@@ -1248,7 +1327,7 @@ describe("Desktop app flows", () => {
     );
     expect(demoProjectCard).not.toBeNull();
     await user.click(
-      within(demoProjectCard as HTMLElement).getByRole("link", { name: /Open project/i }),
+      within(demoProjectCard as HTMLElement).getByRole("link", { name: "Open Demo Song project" }),
     );
 
     expect(await screen.findByRole("heading", { name: "Practice Mix" })).toBeInTheDocument();
@@ -1315,14 +1394,82 @@ describe("Desktop app flows", () => {
     expect(screen.getByLabelText("Layout Density")).toHaveValue("compact");
     expect(screen.getByLabelText("Show helper text by default")).not.toBeChecked();
     expect(screen.getByLabelText("Open inspector by default")).not.toBeChecked();
+    expect(screen.getByLabelText("Collapse sources rail by default")).toBeChecked();
     expect(window.localStorage.getItem("tuneforge.theme-preference")).toBe("system");
     expect(JSON.parse(window.localStorage.getItem("tuneforge.ui-preferences") ?? "{}")).toMatchObject({
       informationDensity: "minimal",
       layoutDensity: "compact",
       helperTextVisible: false,
       defaultInspectorOpen: false,
+      defaultSourcesRailCollapsed: true,
       metadataRevealMode: "expand",
     });
+  });
+
+  it("starts with the sources rail collapsed by default and expands on demand", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({ defaultSourcesRailCollapsed: true }),
+    );
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Expand sources rail" })).toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: "Source and mix list" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Expand sources rail" }));
+
+    expect(screen.getByRole("button", { name: "Collapse sources rail" })).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Source and mix list" })).toBeInTheDocument();
+  });
+
+  it("counts total stems across source audio and saved mixes in the collapsed sources rail", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+
+    const savedMixList = screen.getByRole("group", { name: "Saved mix list" });
+    await user.click(within(savedMixList).getByRole("button", { name: /Practice Mix/i }));
+    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+
+    await user.click(screen.getByRole("button", { name: "Collapse sources rail" }));
+
+    const stemSummaryChip = screen.getByText("Stem").closest(".rail-summary-chip");
+    expect(stemSummaryChip).not.toBeNull();
+    expect(within(stemSummaryChip as HTMLElement).getByText("4")).toBeInTheDocument();
+  });
+
+  it("asks for confirmation before rebuilding existing stems", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    expect(mockCreateStems).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "Rebuild Stems" }));
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.stringContaining("Demucs selects GPU automatically when available"),
+      expect.objectContaining({
+        title: "Rebuild stems",
+        kind: "warning",
+        okLabel: "Rebuild",
+      }),
+    );
+    expect(mockCreateStems).toHaveBeenCalledTimes(2);
+    expect(mockCreateStems).toHaveBeenLastCalledWith(
+      "proj_123",
+      expect.objectContaining({
+        force: true,
+        source_artifact_id: "art_source",
+      }),
+    );
   });
 
   it("persists theme and UI visibility preferences", async () => {
@@ -1337,6 +1484,7 @@ describe("Desktop app flows", () => {
     await user.selectOptions(screen.getByLabelText("Layout Density"), "comfortable");
     await user.click(screen.getByLabelText("Show helper text by default"));
     await user.click(screen.getByLabelText("Open inspector by default"));
+    await user.click(screen.getByLabelText("Collapse sources rail by default"));
     await user.selectOptions(screen.getByLabelText("Metadata Reveal"), "hover");
 
     expect(document.documentElement).toHaveAttribute("data-theme", "light");
@@ -1348,6 +1496,7 @@ describe("Desktop app flows", () => {
       layoutDensity: "comfortable",
       helperTextVisible: true,
       defaultInspectorOpen: true,
+      defaultSourcesRailCollapsed: false,
       metadataRevealMode: "hover",
     });
   });
@@ -1363,6 +1512,7 @@ describe("Desktop app flows", () => {
     await user.selectOptions(screen.getByLabelText("Layout Density"), "comfortable");
     await user.click(screen.getByLabelText("Show helper text by default"));
     await user.click(screen.getByLabelText("Open inspector by default"));
+    await user.click(screen.getByLabelText("Collapse sources rail by default"));
     await user.selectOptions(screen.getByLabelText("Metadata Reveal"), "hover");
 
     await user.click(screen.getByRole("button", { name: "Reset Appearance" }));
@@ -1371,11 +1521,13 @@ describe("Desktop app flows", () => {
     expect(screen.getByLabelText("Layout Density")).toHaveValue("compact");
     expect(screen.getByLabelText("Show helper text by default")).toBeChecked();
     expect(screen.getByLabelText("Open inspector by default")).toBeChecked();
+    expect(screen.getByLabelText("Collapse sources rail by default")).not.toBeChecked();
     expect(screen.getByLabelText("Metadata Reveal")).toHaveValue("hover");
 
     await user.click(screen.getByRole("button", { name: "Reset Visibility" }));
     expect(screen.getByLabelText("Show helper text by default")).not.toBeChecked();
     expect(screen.getByLabelText("Open inspector by default")).not.toBeChecked();
+    expect(screen.getByLabelText("Collapse sources rail by default")).toBeChecked();
     expect(screen.getByLabelText("Metadata Reveal")).toHaveValue("expand");
 
     await user.selectOptions(screen.getByLabelText("Theme"), "dark");
@@ -1387,6 +1539,7 @@ describe("Desktop app flows", () => {
     expect(screen.getByLabelText("Layout Density")).toHaveValue("compact");
     expect(screen.getByLabelText("Show helper text by default")).not.toBeChecked();
     expect(screen.getByLabelText("Open inspector by default")).not.toBeChecked();
+    expect(screen.getByLabelText("Collapse sources rail by default")).toBeChecked();
     expect(screen.getByLabelText("Metadata Reveal")).toHaveValue("expand");
   });
 
@@ -1403,16 +1556,37 @@ describe("Desktop app flows", () => {
 
     expect(await screen.findByRole("heading", { name: "Playback Surface" })).toBeInTheDocument();
     expect(screen.getByText("Background Playback")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Pause" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Pause background playback" })).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Reset Appearance" }));
-    expect(screen.getByRole("button", { name: "Pause" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Pause background playback" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Pause" }));
+    await user.click(screen.getByRole("button", { name: "Pause background playback" }));
     expect(screen.getByText("Background Playback")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Play" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Play background playback" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Stop" }));
+    await user.click(screen.getByRole("button", { name: "Stop background playback" }));
+    expect(screen.queryByText("Background Playback")).not.toBeInTheDocument();
+  });
+
+  it("reopens the active project from background playback without stopping playback", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await user.click(screen.getByRole("link", { name: "Settings" }));
+
+    expect(await screen.findByRole("heading", { name: "Playback Surface" })).toBeInTheDocument();
+    expect(screen.getByText("Background Playback")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("link", { name: "Open Demo Song project" }));
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
     expect(screen.queryByText("Background Playback")).not.toBeInTheDocument();
   });
 
@@ -1456,7 +1630,9 @@ describe("Desktop app flows", () => {
     const secondProjectCard = screen.getByText("Bass Drill").closest("article");
     expect(secondProjectCard).not.toBeNull();
     await user.click(
-      within(secondProjectCard as HTMLElement).getByRole("link", { name: /Open project/i }),
+      within(secondProjectCard as HTMLElement).getByRole("link", {
+        name: "Open Bass Drill project",
+      }),
     );
 
     expect(await screen.findByRole("heading", { name: "Bass Drill" })).toBeInTheDocument();

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
-import { NavLink, Route, Routes, matchPath, useLocation } from "react-router-dom";
+import { useEffect, useId } from "react";
+import { Link, NavLink, Route, Routes, matchPath, useLocation } from "react-router-dom";
 import { LibraryView } from "./features/projects/LibraryView";
 import { ProjectView } from "./features/projects/ProjectView";
 import { usePlayback } from "./features/projects/playback-context";
@@ -8,6 +8,94 @@ import { SettingsView } from "./features/settings/SettingsView";
 import { ThemePreviewView } from "./features/settings/ThemePreviewView";
 import { PreferencesProvider, usePreferences } from "./lib/preferences";
 import { ThemeProvider } from "./lib/theme";
+
+function MiniMetallicGlyphDefs({ gradientId }: { gradientId: string }) {
+  return (
+    <defs>
+      <linearGradient id={gradientId} x1="8%" y1="8%" x2="92%" y2="92%">
+        <stop offset="0%" stopColor="#FFFBEB" />
+        <stop offset="20%" stopColor="#F8FAFC" />
+        <stop offset="48%" stopColor="#CBD5E1" />
+        <stop offset="76%" stopColor="#64748B" />
+        <stop offset="100%" stopColor="#F8FAFC" />
+      </linearGradient>
+    </defs>
+  );
+}
+
+function MiniPlayPauseGlyph({ isPlaying }: { isPlaying: boolean }) {
+  const gradientId = useId();
+  const fill = `url(#${gradientId})`;
+
+  return (
+    <svg
+      aria-hidden="true"
+      className="background-playback__icon background-playback__icon--playpause"
+      focusable="false"
+      viewBox="0 0 40 40"
+    >
+      <MiniMetallicGlyphDefs gradientId={gradientId} />
+      {isPlaying ? (
+        <>
+          <rect
+            fill={fill}
+            height="17"
+            rx="2.4"
+            stroke="rgba(255, 255, 255, 0.42)"
+            strokeWidth="1"
+            width="5.8"
+            x="11.45"
+            y="11.5"
+          />
+          <rect
+            fill={fill}
+            height="17"
+            rx="2.4"
+            stroke="rgba(255, 255, 255, 0.42)"
+            strokeWidth="1"
+            width="5.8"
+            x="22.75"
+            y="11.5"
+          />
+        </>
+      ) : (
+        <path
+          d="M13.2 10.2L28.9 20L13.2 29.8Z"
+          fill={fill}
+          stroke="rgba(255, 255, 255, 0.48)"
+          strokeLinejoin="round"
+          strokeWidth="1"
+        />
+      )}
+    </svg>
+  );
+}
+
+function MiniStopGlyph() {
+  const gradientId = useId();
+  const fill = `url(#${gradientId})`;
+
+  return (
+    <svg
+      aria-hidden="true"
+      className="background-playback__icon background-playback__icon--stop"
+      focusable="false"
+      viewBox="0 0 40 40"
+    >
+      <MiniMetallicGlyphDefs gradientId={gradientId} />
+      <rect
+        fill={fill}
+        height="14.5"
+        rx="4"
+        stroke="rgba(255, 255, 255, 0.42)"
+        strokeWidth="1"
+        width="14.5"
+        x="12.75"
+        y="12.75"
+      />
+    </svg>
+  );
+}
 
 function BackgroundPlaybackCard() {
   const location = useLocation();
@@ -21,25 +109,31 @@ function BackgroundPlaybackCard() {
 
   return (
     <div className="background-playback">
-      <div>
+      <Link
+        aria-label={`Open ${session.projectName} project`}
+        className="background-playback__resume"
+        to={`/projects/${session.projectId}`}
+      >
         <span className="metric-label">Background Playback</span>
         <strong>{session.projectName}</strong>
         <p className="artifact-meta">{session.stageTitle}</p>
-      </div>
+      </Link>
       <div className="background-playback__controls">
         <button
-          className="button button--small"
+          aria-label={isPlaying ? "Pause background playback" : "Play background playback"}
+          className="background-playback__control"
           type="button"
           onClick={() => void togglePlayback()}
         >
-          {isPlaying ? "Pause" : "Play"}
+          <MiniPlayPauseGlyph isPlaying={isPlaying} />
         </button>
         <button
-          className="button button--ghost button--small"
+          aria-label="Stop background playback"
+          className="background-playback__control"
           type="button"
           onClick={dismissSession}
         >
-          Stop
+          <MiniStopGlyph />
         </button>
       </div>
     </div>

--- a/apps/desktop/src/features/projects/LibraryView.tsx
+++ b/apps/desktop/src/features/projects/LibraryView.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { open } from "@tauri-apps/plugin-dialog";
 import { Link, useNavigate } from "react-router-dom";
 import { api, type ProjectSchema } from "../../lib/api";
+import { formatLocalDateTime, normalizeApiDateTime } from "../../lib/datetime";
 import { usePreferences } from "../../lib/preferences";
 
 function formatDuration(durationSeconds: number | null | undefined) {
@@ -15,50 +16,61 @@ function formatDuration(durationSeconds: number | null | undefined) {
 }
 
 function formatUpdatedAt(value: string) {
-  return new Intl.DateTimeFormat(undefined, {
+  return formatLocalDateTime(value, {
     month: "short",
     day: "numeric",
-  }).format(new Date(value));
-}
-
-function fileNameFromPath(path: string) {
-  return path.split(/[/\\]/).pop() ?? path;
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }
 
 function ProjectCard({ project }: { project: ProjectSchema }) {
   const { informationDensity, metadataRevealMode } = usePreferences();
-  const sourceFileName = fileNameFromPath(project.source_path);
+  const updatedAtLabel = formatUpdatedAt(project.updated_at);
+  const normalizedUpdatedAt = normalizeApiDateTime(project.updated_at);
 
   return (
     <article className="project-card">
-      <div className="project-card__meta-row">
-        <span className="pill">Updated {formatUpdatedAt(project.updated_at)}</span>
-        <span className="pill">{formatDuration(project.duration_seconds)}</span>
-      </div>
+      <Link
+        aria-label={`Open ${project.display_name} project`}
+        className="project-card__link"
+        to={`/projects/${project.id}`}
+      >
+        <div className="project-card__meta-row">
+          <span className="pill">
+            <time dateTime={normalizedUpdatedAt}>{updatedAtLabel}</time>
+          </span>
+        </div>
 
-      <Link className="project-card__link" to={`/projects/${project.id}`}>
         <div className="project-card__title-block">
           <h2>{project.display_name}</h2>
-          <p className="project-card__summary">{sourceFileName}</p>
         </div>
-        <span className="project-card__open">Open project</span>
-      </Link>
 
-      <div className="project-card__stats" role="list" aria-label={`${project.display_name} summary`}>
-        <span className="stat-chip" role="listitem">
-          {project.source_path.split(".").pop()?.toUpperCase() ?? "Audio"}
-        </span>
-        {informationDensity !== "minimal" ? (
+        <div className="project-card__stats" role="list" aria-label={`${project.display_name} summary`}>
           <span className="stat-chip" role="listitem">
-            {project.channels ? `${project.channels} ch` : "Channels n/a"}
+            {project.source_path.split(".").pop()?.toUpperCase() ?? "Audio"}
           </span>
-        ) : null}
-        {informationDensity === "detailed" ? (
           <span className="stat-chip" role="listitem">
-            {project.sample_rate ? `${project.sample_rate} Hz` : "Sample rate n/a"}
+            {formatDuration(project.duration_seconds)}
           </span>
+          {informationDensity !== "minimal" ? (
+            <span className="stat-chip" role="listitem">
+              {project.channels ? `${project.channels} ch` : "Channels n/a"}
+            </span>
+          ) : null}
+          {informationDensity === "detailed" ? (
+            <span className="stat-chip" role="listitem">
+              {project.sample_rate ? `${project.sample_rate} Hz` : "Sample rate n/a"}
+            </span>
+          ) : null}
+        </div>
+
+        {metadataRevealMode !== "expand" ? (
+          <p className="artifact-meta" title={project.source_path}>
+            Hover for source path
+          </p>
         ) : null}
-      </div>
+      </Link>
 
       {metadataRevealMode === "expand" ? (
         <details className="card-details">
@@ -74,11 +86,7 @@ function ProjectCard({ project }: { project: ProjectSchema }) {
             </div>
           </dl>
         </details>
-      ) : (
-        <p className="artifact-meta" title={project.source_path}>
-          Hover for source path
-        </p>
-      )}
+      ) : null}
     </article>
   );
 }

--- a/apps/desktop/src/features/projects/ProjectView.tsx
+++ b/apps/desktop/src/features/projects/ProjectView.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { confirm, save } from "@tauri-apps/plugin-dialog";
 import { api, type ArtifactSchema, type ChordSegmentSchema, type JobSchema } from "../../lib/api";
+import { formatLocalDateTime } from "../../lib/datetime";
 import { usePreferences } from "../../lib/preferences";
 import { usePlayback } from "./playback-context";
 import {
@@ -85,12 +86,12 @@ function formatSemitoneShift(semitones: number) {
 }
 
 function formatArtifactTimestamp(createdAt: string) {
-  return new Intl.DateTimeFormat(undefined, {
+  return formatLocalDateTime(createdAt, {
     month: "short",
     day: "numeric",
     hour: "2-digit",
     minute: "2-digit",
-  }).format(new Date(createdAt));
+  });
 }
 
 function formatPlaybackClock(totalSeconds: number) {
@@ -107,6 +108,118 @@ function formatPlaybackClock(totalSeconds: number) {
   }
 
   return `${minutes}:${remainder.toString().padStart(2, "0")}`;
+}
+
+type SeekDirection = "backward" | "forward";
+
+function MetallicGlyphDefs({ gradientId }: { gradientId: string }) {
+  return (
+    <defs>
+      <linearGradient id={gradientId} x1="8%" y1="8%" x2="92%" y2="92%">
+        <stop offset="0%" stopColor="#FFFBEB" />
+        <stop offset="20%" stopColor="#F8FAFC" />
+        <stop offset="48%" stopColor="#CBD5E1" />
+        <stop offset="76%" stopColor="#64748B" />
+        <stop offset="100%" stopColor="#F8FAFC" />
+      </linearGradient>
+    </defs>
+  );
+}
+
+function PlayPauseGlyph({ isPlaying }: { isPlaying: boolean }) {
+  const gradientId = useId();
+  const fill = `url(#${gradientId})`;
+
+  return (
+    <svg
+      aria-hidden="true"
+      className="transport__icon transport__icon--playpause"
+      focusable="false"
+      viewBox="0 0 40 40"
+    >
+      <MetallicGlyphDefs gradientId={gradientId} />
+      {isPlaying ? (
+        <>
+          <rect
+            fill={fill}
+            height="19"
+            rx="2.6"
+            stroke="rgba(255, 255, 255, 0.5)"
+            strokeWidth="1"
+            width="6.5"
+            x="10.75"
+            y="10.5"
+          />
+          <rect
+            fill={fill}
+            height="19"
+            rx="2.6"
+            stroke="rgba(255, 255, 255, 0.5)"
+            strokeWidth="1"
+            width="6.5"
+            x="22.75"
+            y="10.5"
+          />
+        </>
+      ) : (
+        <path
+          d="M13 9.75L29.5 20L13 30.25Z"
+          fill={fill}
+          stroke="rgba(255, 255, 255, 0.55)"
+          strokeLinejoin="round"
+          strokeWidth="1"
+        />
+      )}
+    </svg>
+  );
+}
+
+function StopGlyph() {
+  const gradientId = useId();
+  const fill = `url(#${gradientId})`;
+
+  return (
+    <svg
+      aria-hidden="true"
+      className="transport__icon transport__icon--stop"
+      focusable="false"
+      viewBox="0 0 40 40"
+    >
+      <MetallicGlyphDefs gradientId={gradientId} />
+      <rect
+        className="transport__stop-block"
+        fill={fill}
+        height="19"
+        rx="4.5"
+        stroke="rgba(255, 255, 255, 0.5)"
+        strokeWidth="1"
+        width="19"
+        x="10.5"
+        y="10.5"
+      />
+    </svg>
+  );
+}
+
+function SeekGlyph({ animate = false, direction }: { animate?: boolean; direction: SeekDirection }) {
+  const animationClass = animate ? ` transport__seek-glyph--animate-${direction}` : "";
+  const triangleClass = `transport__seek-triangle transport__seek-triangle--${direction}`;
+
+  return (
+    <span
+      aria-hidden="true"
+      className={`transport__icon transport__icon--seek transport__seek-glyph${animationClass}`}
+    >
+      <span className="transport__seek-slot">
+        <span className={triangleClass} />
+        <span className={`${triangleClass} transport__seek-triangle--overlay`} />
+      </span>
+      <span className="transport__seek-slot">
+        <span className={triangleClass} />
+        <span className={`${triangleClass} transport__seek-triangle--overlay`} />
+      </span>
+    </span>
+  );
 }
 
 function artifactSummary(artifact: ArtifactSchema) {
@@ -311,10 +424,12 @@ export function ProjectView() {
     registerProjectSession,
     seekBy,
     seekTo,
+    stopPlayback,
     togglePlayback,
   } = usePlayback();
   const {
     defaultInspectorOpen,
+    defaultSourcesRailCollapsed,
     helperTextVisible,
     informationDensity,
     metadataRevealMode,
@@ -328,6 +443,10 @@ export function ProjectView() {
   const [referenceHz, setReferenceHz] = useState("440");
   const [centsOffset, setCentsOffset] = useState("0");
   const [manualSourceKey, setManualSourceKey] = useState<MusicalKey | null>(null);
+  const [seekAnimationRevision, setSeekAnimationRevision] = useState<Record<SeekDirection, number>>({
+    backward: 0,
+    forward: 0,
+  });
   const [targetKeyState, setTargetKeyState] = useState<MusicalKey | null>(null);
   const [targetDirty, setTargetDirty] = useState(false);
   const [selectedArtifactId, setSelectedArtifactId] = useState<string | null>(null);
@@ -336,6 +455,7 @@ export function ProjectView() {
   const [isRenaming, setIsRenaming] = useState(false);
   const [draftName, setDraftName] = useState("");
   const [inspectorOpen, setInspectorOpen] = useState(defaultInspectorOpen);
+  const [sourcesRailCollapsed, setSourcesRailCollapsed] = useState(defaultSourcesRailCollapsed);
   const [stemControls, setStemControls] = useState<Record<string, StemControlState>>({});
   const [dismissedStemJobIds, setDismissedStemJobIds] = useState<string[]>([]);
   const showSupportingCopy = helperTextVisible && informationDensity !== "minimal";
@@ -635,7 +755,6 @@ export function ProjectView() {
       ? stemJob.error_message
       : null;
   const visibleJobs = projectJobs;
-  const recentJobs = projectJobs.slice(0, 3);
   const controlSummary = hasTransformChange ? formatKey(targetKey) : "Original key";
   const tuningSummary = formatRetuneSummary(retuneMode, referenceHz, centsOffset);
   const mixStatus = isStemPlayback
@@ -660,11 +779,6 @@ export function ProjectView() {
   const selectedArtifactTimestamp = selectedPlaybackArtifact
     ? formatArtifactTimestamp(selectedPlaybackArtifact.created_at)
     : "";
-  const playbackClockSummary = `${formatPlaybackClock(
-    playbackTimeSeconds,
-  )} / ${formatPlaybackClock(
-    playbackDurationSeconds || projectQuery.data?.duration_seconds || 0,
-  )}`;
   const chordTransposeSemitones = artifactTransposeSemitones(
     selectedPlaybackArtifact,
     selectableArtifacts,
@@ -720,7 +834,38 @@ export function ProjectView() {
   }
 
   function handleSeek(secondsDelta: number) {
+    const direction: SeekDirection = secondsDelta < 0 ? "backward" : "forward";
+    setSeekAnimationRevision((current) => ({
+      ...current,
+      [direction]: current[direction] + 1,
+    }));
     seekBy(secondsDelta);
+  }
+
+  async function handleStemAction() {
+    if (!selectedPrimaryArtifactId) {
+      return;
+    }
+
+    if (hasVisibleStems) {
+      const stemTargetLabel = selectedPrimaryArtifact
+        ? artifactLabel(selectedPrimaryArtifact)
+        : "selected audio";
+      const approved = await confirm(
+        `Rebuild stems for ${stemTargetLabel}? Existing stems will be replaced. Demucs selects GPU automatically when available, otherwise it falls back to CPU and may take longer.`,
+        {
+          title: "Rebuild stems",
+          kind: "warning",
+          okLabel: "Rebuild",
+          cancelLabel: "Cancel",
+        },
+      );
+      if (!approved) {
+        return;
+      }
+    }
+
+    stemMutation.mutate();
   }
 
   function toggleStemControl(
@@ -798,6 +943,10 @@ export function ProjectView() {
   useEffect(() => {
     setInspectorOpen(defaultInspectorOpen);
   }, [defaultInspectorOpen]);
+
+  useEffect(() => {
+    setSourcesRailCollapsed(defaultSourcesRailCollapsed);
+  }, [defaultSourcesRailCollapsed]);
 
   useEffect(() => {
     const storedPlaybackState = readProjectPlaybackState(projectId);
@@ -950,6 +1099,11 @@ export function ProjectView() {
   const stageSummary = isStemPlayback
     ? `${activeStemCount} of ${visibleStemArtifacts.length} stems audible`
     : selectedArtifactSummary || currentSourceSummary;
+  const sourcesRailSummary = [
+    { label: "Src", value: sourceArtifact ? "1" : "0" },
+    { label: "Mix", value: `${previewArtifacts.length}` },
+    { label: "Stem", value: `${stemArtifacts.length}` },
+  ];
 
   useEffect(() => {
     if (hydratedProjectId !== projectId || !projectId || !selectedPlaybackArtifact) {
@@ -1055,156 +1209,193 @@ export function ProjectView() {
         </div>
       </div>
 
-      <div className={`project-workbench${inspectorOpen ? "" : " project-workbench--wide"}`}>
-        <aside className="stack">
-          <div className="panel rail-panel">
-            <div className="rail-section">
-              <div className="rail-section__header">
-                <div>
+      <div
+        className={`project-workbench${inspectorOpen ? "" : " project-workbench--wide"}${
+          sourcesRailCollapsed ? " project-workbench--sources-collapsed" : ""
+        }`}
+      >
+        <aside className={`stack sources-rail${sourcesRailCollapsed ? " sources-rail--collapsed" : ""}`}>
+          <div className={`panel rail-panel${sourcesRailCollapsed ? " rail-panel--collapsed" : ""}`}>
+            <div className="rail-panel__top">
+              {sourcesRailCollapsed ? <span className="rail-panel__collapsed-spacer" aria-hidden="true" /> : (
+                <div className="rail-panel__identity">
                   <h2>Sources</h2>
                   {showSupportingCopy ? (
-                    <p className="subpanel__copy">Jump between the raw track and saved mixes.</p>
+                    <p className="subpanel__copy">Jump between the raw track, saved mixes, and stems.</p>
                   ) : null}
                 </div>
-              </div>
-              <div
-                className="artifact-selector artifact-selector--stacked"
-                role="group"
-                aria-label="Source and mix list"
+              )}
+              <button
+                aria-label={sourcesRailCollapsed ? "Expand sources rail" : "Collapse sources rail"}
+                className={`button button--ghost button--small rail-panel__toggle${
+                  sourcesRailCollapsed ? " rail-panel__toggle--collapsed" : ""
+                }`}
+                onClick={() => setSourcesRailCollapsed((current) => !current)}
+                type="button"
               >
-                {sourceArtifact ? (
-                  <button
-                    className={`artifact-pill${
-                      selectedArtifactId === sourceArtifact.id ? " artifact-pill--active" : ""
-                    }`}
-                    onClick={() => handleSelectPrimaryArtifact(sourceArtifact)}
-                    type="button"
-                  >
-                    <span className="artifact-pill__title">Source Track</span>
-                    <span className="artifact-pill__meta">
-                      {artifactSummary(sourceArtifact)}
-                    </span>
-                    {informationDensity === "detailed" ? (
-                      <span className="artifact-pill__meta">
-                        {fileNameFromPath(sourceArtifact.path)}
-                      </span>
-                    ) : null}
-                  </button>
-                ) : (
-                  <p className="artifact-meta">No source track available.</p>
-                )}
-              </div>
+                <span aria-hidden="true" className="rail-panel__toggle-icon">
+                  <span />
+                  <span />
+                  <span />
+                </span>
+                {sourcesRailCollapsed ? null : <span>Hide</span>}
+              </button>
             </div>
 
-            <div className="rail-section">
-              <div className="rail-section__header">
-                <div>
-                  <h3>Saved Mixes</h3>
-                  {showSupportingCopy ? (
-                    <p className="subpanel__copy">Practice variants stay one click away.</p>
-                  ) : null}
-                </div>
+            {sourcesRailCollapsed ? (
+              <div className="rail-panel__collapsed">
+                {sourcesRailSummary.map((item) => (
+                  <div key={item.label} className="rail-summary-chip">
+                    <span>{item.label}</span>
+                    <strong>{item.value}</strong>
+                  </div>
+                ))}
               </div>
-              {previewArtifacts.length ? (
-                <div
-                  className="artifact-selector artifact-selector--stacked"
-                  role="group"
-                  aria-label="Saved mix list"
-                >
-                  {previewArtifacts.map((artifact) => (
-                    <button
-                      key={artifact.id}
-                      className={`artifact-pill${
-                        selectedArtifactId === artifact.id ? " artifact-pill--active" : ""
-                      }`}
-                      onClick={() => handleSelectPrimaryArtifact(artifact)}
-                      type="button"
-                    >
-                      <span className="artifact-pill__title">{artifactLabel(artifact)}</span>
-                      <span className="artifact-pill__meta">
-                        {artifactSummary(artifact) || formatArtifactTimestamp(artifact.created_at)}
-                      </span>
-                      {informationDensity === "detailed" ? (
+            ) : (
+              <>
+                <div className="rail-section">
+                  <div
+                    className="artifact-selector artifact-selector--stacked"
+                    role="group"
+                    aria-label="Source and mix list"
+                  >
+                    {sourceArtifact ? (
+                      <button
+                        className={`artifact-pill${
+                          selectedArtifactId === sourceArtifact.id ? " artifact-pill--active" : ""
+                        }`}
+                        onClick={() => handleSelectPrimaryArtifact(sourceArtifact)}
+                        type="button"
+                      >
+                        <span className="artifact-pill__title">Source Track</span>
                         <span className="artifact-pill__meta">
-                          {formatArtifactTimestamp(artifact.created_at)}
+                          {artifactSummary(sourceArtifact)}
                         </span>
-                      ) : null}
-                    </button>
-                  ))}
+                        {informationDensity === "detailed" ? (
+                          <span className="artifact-pill__meta">
+                            {fileNameFromPath(sourceArtifact.path)}
+                          </span>
+                        ) : null}
+                      </button>
+                    ) : (
+                      <p className="artifact-meta">No source track available.</p>
+                    )}
+                  </div>
                 </div>
-              ) : (
-                <p className="artifact-meta">No saved mixes yet. Build one from inspector controls.</p>
-              )}
-            </div>
 
-            <div className="rail-section">
-              <div className="rail-section__header">
-                <div>
-                  <h3>Stems</h3>
-                  {showSupportingCopy ? (
-                    <p className="subpanel__copy">Stem playback stays scoped to the selected source or mix.</p>
-                  ) : null}
+                <div className="rail-section">
+                  <div className="rail-section__header">
+                    <div>
+                      <h3>Saved Mixes</h3>
+                      {showSupportingCopy ? (
+                        <p className="subpanel__copy">Practice variants stay one click away.</p>
+                      ) : null}
+                    </div>
+                  </div>
+                  {previewArtifacts.length ? (
+                    <div
+                      className="artifact-selector artifact-selector--stacked"
+                      role="group"
+                      aria-label="Saved mix list"
+                    >
+                      {previewArtifacts.map((artifact) => (
+                        <button
+                          key={artifact.id}
+                          className={`artifact-pill${
+                            selectedArtifactId === artifact.id ? " artifact-pill--active" : ""
+                          }`}
+                          onClick={() => handleSelectPrimaryArtifact(artifact)}
+                          type="button"
+                        >
+                          <span className="artifact-pill__title">{artifactLabel(artifact)}</span>
+                          <span className="artifact-pill__meta">
+                            {artifactSummary(artifact) || formatArtifactTimestamp(artifact.created_at)}
+                          </span>
+                          {informationDensity === "detailed" ? (
+                            <span className="artifact-pill__meta">
+                              {formatArtifactTimestamp(artifact.created_at)}
+                            </span>
+                          ) : null}
+                        </button>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="artifact-meta">No saved mixes yet. Build one from inspector controls.</p>
+                  )}
                 </div>
-                <button
-                  className="button button--small"
-                  onClick={() => stemMutation.mutate()}
-                  disabled={stemMutation.isPending || isStemRunning || !selectedPrimaryArtifactId}
-                  type="button"
-                >
-                  {stemMutation.isPending || isStemRunning
-                    ? "Generating..."
-                    : hasVisibleStems
-                      ? "Refresh Stems"
-                      : "Generate Stems"}
-                </button>
-              </div>
-              {visibleStemArtifacts.length ? (
-                <div
-                  className="artifact-selector artifact-selector--stacked"
-                  role="group"
-                  aria-label="Stem track list"
-                >
-                  {visibleStemArtifacts.map((artifact) => (
+
+                <div className="rail-section">
+                  <div className="rail-section__header">
+                    <div>
+                      <h3>Stems</h3>
+                      {showSupportingCopy ? (
+                        <p className="subpanel__copy">Stem playback stays scoped to the selected source or mix.</p>
+                      ) : null}
+                    </div>
                     <button
-                      key={artifact.id}
-                      className={`artifact-pill${
-                        selectedArtifactId === artifact.id ? " artifact-pill--active" : ""
-                      }`}
-                      onClick={() => handleSelectStemArtifact(artifact)}
+                      className="button button--small"
+                      onClick={() => void handleStemAction()}
+                      disabled={stemMutation.isPending || isStemRunning || !selectedPrimaryArtifactId}
                       type="button"
                     >
-                      <span className="artifact-pill__title">{artifactLabel(artifact)}</span>
-                      <span className="artifact-pill__meta">{stemOutputLabel(artifact.id)}</span>
-                      {informationDensity !== "minimal" ? (
-                        <span className="artifact-pill__meta">{artifactSummary(artifact)}</span>
-                      ) : null}
+                      {stemMutation.isPending || isStemRunning
+                        ? hasVisibleStems
+                          ? "Rebuilding..."
+                          : "Generating..."
+                        : hasVisibleStems
+                          ? "Rebuild Stems"
+                          : "Generate Stems"}
                     </button>
-                  ))}
+                  </div>
+                  {visibleStemArtifacts.length ? (
+                    <div
+                      className="artifact-selector artifact-selector--stacked"
+                      role="group"
+                      aria-label="Stem track list"
+                    >
+                      {visibleStemArtifacts.map((artifact) => (
+                        <button
+                          key={artifact.id}
+                          className={`artifact-pill${
+                            selectedArtifactId === artifact.id ? " artifact-pill--active" : ""
+                          }`}
+                          onClick={() => handleSelectStemArtifact(artifact)}
+                          type="button"
+                        >
+                          <span className="artifact-pill__title">{artifactLabel(artifact)}</span>
+                          <span className="artifact-pill__meta">{stemOutputLabel(artifact.id)}</span>
+                          {informationDensity !== "minimal" ? (
+                            <span className="artifact-pill__meta">{artifactSummary(artifact)}</span>
+                          ) : null}
+                        </button>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="artifact-meta">
+                      {selectedPrimaryArtifactId
+                        ? "No stems yet for selected audio."
+                        : "Select source audio or a saved mix first."}
+                    </p>
+                  )}
+                  {stemErrorMessage && stemJob ? (
+                    <div className="button-row" role="group" aria-label="Stem error">
+                      <span className="inline-error">{stemErrorMessage}</span>
+                      <button
+                        className="button button--ghost button--small"
+                        onClick={() =>
+                          setDismissedStemJobIds((current) =>
+                            current.includes(stemJob.id) ? current : [...current, stemJob.id],
+                          )
+                        }
+                        type="button"
+                      >
+                        Dismiss
+                      </button>
+                    </div>
+                  ) : null}
                 </div>
-              ) : (
-                <p className="artifact-meta">
-                  {selectedPrimaryArtifactId
-                    ? "No stems yet for selected audio."
-                    : "Select source audio or a saved mix first."}
-                </p>
-              )}
-              {stemErrorMessage && stemJob ? (
-                <div className="button-row" role="group" aria-label="Stem error">
-                  <span className="inline-error">{stemErrorMessage}</span>
-                  <button
-                    className="button button--ghost button--small"
-                    onClick={() =>
-                      setDismissedStemJobIds((current) =>
-                        current.includes(stemJob.id) ? current : [...current, stemJob.id],
-                      )
-                    }
-                    type="button"
-                  >
-                    Dismiss
-                  </button>
-                </div>
-              ) : null}
-            </div>
+              </>
+            )}
           </div>
         </aside>
 
@@ -1244,26 +1435,45 @@ export function ProjectView() {
               <div className="transport">
                 <div className="transport__controls">
                   <button
-                    className="button button--small"
+                    aria-label="Seek back 10 seconds"
+                    className="button transport__button transport__button--seek"
                     onClick={() => handleSeek(-10)}
                     type="button"
                   >
-                    -10s
+                    <SeekGlyph
+                      key={`backward-${seekAnimationRevision.backward}`}
+                      animate={seekAnimationRevision.backward > 0}
+                      direction="backward"
+                    />
                   </button>
                   <button
-                    className="button button--primary transport__play"
                     aria-label={isPlaying ? "Pause playback" : "Play playback"}
+                    aria-pressed={isPlaying}
+                    className="button transport__button transport__button--play"
                     onClick={() => void togglePlayback()}
                     type="button"
                   >
-                    {isPlaying ? "Pause" : "Play"}
+                    <PlayPauseGlyph isPlaying={isPlaying} />
                   </button>
                   <button
-                    className="button button--small"
+                    aria-label="Stop playback"
+                    className="button transport__button transport__button--stop"
+                    onClick={stopPlayback}
+                    type="button"
+                  >
+                    <StopGlyph />
+                  </button>
+                  <button
+                    aria-label="Seek forward 10 seconds"
+                    className="button transport__button transport__button--seek"
                     onClick={() => handleSeek(10)}
                     type="button"
                   >
-                    +10s
+                    <SeekGlyph
+                      key={`forward-${seekAnimationRevision.forward}`}
+                      animate={seekAnimationRevision.forward > 0}
+                      direction="forward"
+                    />
                   </button>
                 </div>
 
@@ -1464,28 +1674,6 @@ export function ProjectView() {
                 </div>
               </div>
             ) : null}
-
-            <div className="playback-stage__footer">
-              <div>
-                <span className="metric-label">Playback</span>
-                <strong>{playbackClockSummary}</strong>
-              </div>
-              <div role="group" aria-label="Recent processing summary">
-                <span className="metric-label">Recent Processing</span>
-                {recentJobs.length ? (
-                  <ul className="session-jobs">
-                    {recentJobs.map((job) => (
-                      <li key={job.id}>
-                        <span>{job.type}</span>
-                        <small>{job.status}</small>
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <p className="artifact-meta">No processing jobs yet.</p>
-                )}
-              </div>
-            </div>
           </div>
 
           <div className="panel">

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -41,11 +41,13 @@ export function SettingsView() {
     layoutDensity,
     helperTextVisible,
     defaultInspectorOpen,
+    defaultSourcesRailCollapsed,
     metadataRevealMode,
     setInformationDensity,
     setLayoutDensity,
     setHelperTextVisible,
     setDefaultInspectorOpen,
+    setDefaultSourcesRailCollapsed,
     setMetadataRevealMode,
     resetAppearancePreferences,
     resetVisibilityPreferences,
@@ -192,6 +194,16 @@ export function SettingsView() {
               Open inspector by default
             </label>
 
+            <label className="checkbox">
+              <input
+                aria-label="Collapse sources rail by default"
+                checked={defaultSourcesRailCollapsed}
+                onChange={(event) => setDefaultSourcesRailCollapsed(event.target.checked)}
+                type="checkbox"
+              />
+              Collapse sources rail by default
+            </label>
+
             <label>
               Metadata Reveal
               <select
@@ -213,6 +225,10 @@ export function SettingsView() {
             <div>
               <dt>Inspector Default</dt>
               <dd>{defaultInspectorOpen ? "Open" : "Closed"}</dd>
+            </div>
+            <div>
+              <dt>Sources Rail Default</dt>
+              <dd>{defaultSourcesRailCollapsed ? "Collapsed" : "Expanded"}</dd>
             </div>
             <div>
               <dt>Metadata Reveal</dt>

--- a/apps/desktop/src/features/settings/ThemePreviewView.tsx
+++ b/apps/desktop/src/features/settings/ThemePreviewView.tsx
@@ -184,7 +184,7 @@ function ThemeCanvas({ mode }: { mode: ThemeMode }) {
                 <div className="theme-preview__card-stack">
                   <article className="theme-preview__card">
                     <div className="theme-preview__card-meta">
-                      <span className="pill">Updated Apr 20</span>
+                      <span className="pill">Apr 20, 10:16</span>
                       <span className="pill">4:12</span>
                     </div>
                     <strong>Reference mix</strong>

--- a/apps/desktop/src/lib/datetime.ts
+++ b/apps/desktop/src/lib/datetime.ts
@@ -1,0 +1,42 @@
+const API_DATE_TIME_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,6}))?)?(?:([Zz])|([+-])(\d{2}):?(\d{2}))?$/;
+
+export function parseApiDateTime(value: string) {
+  const trimmed = value.trim();
+  const match = trimmed.match(API_DATE_TIME_PATTERN);
+
+  if (!match) {
+    return new Date(trimmed);
+  }
+
+  const [, year, month, day, hour, minute, second = "0", fraction = "0", zulu, sign, offsetHour = "0", offsetMinute = "0"] =
+    match;
+
+  const utcMilliseconds = Date.UTC(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+    Number(second),
+    Number(fraction.padEnd(3, "0").slice(0, 3)),
+  );
+
+  if (zulu || !sign) {
+    return new Date(utcMilliseconds);
+  }
+
+  const offsetMinutes = Number(offsetHour) * 60 + Number(offsetMinute);
+  const signedOffset = sign === "+" ? offsetMinutes : -offsetMinutes;
+
+  return new Date(utcMilliseconds - signedOffset * 60_000);
+}
+
+export function normalizeApiDateTime(value: string) {
+  const parsed = parseApiDateTime(value);
+  return Number.isNaN(parsed.getTime()) ? value : parsed.toISOString();
+}
+
+export function formatLocalDateTime(value: string, options: Intl.DateTimeFormatOptions) {
+  return new Intl.DateTimeFormat(undefined, options).format(parseApiDateTime(value));
+}

--- a/apps/desktop/src/lib/preferences.tsx
+++ b/apps/desktop/src/lib/preferences.tsx
@@ -17,13 +17,14 @@ export type UiPreferences = {
   layoutDensity: LayoutDensity;
   helperTextVisible: boolean;
   defaultInspectorOpen: boolean;
+  defaultSourcesRailCollapsed: boolean;
   metadataRevealMode: MetadataRevealMode;
 };
 
 export type AppearancePreferences = Pick<UiPreferences, "informationDensity" | "layoutDensity">;
 export type VisibilityPreferences = Pick<
   UiPreferences,
-  "helperTextVisible" | "defaultInspectorOpen" | "metadataRevealMode"
+  "helperTextVisible" | "defaultInspectorOpen" | "defaultSourcesRailCollapsed" | "metadataRevealMode"
 >;
 
 type PreferencesContextValue = UiPreferences & {
@@ -31,6 +32,7 @@ type PreferencesContextValue = UiPreferences & {
   setLayoutDensity: (value: LayoutDensity) => void;
   setHelperTextVisible: (value: boolean) => void;
   setDefaultInspectorOpen: (value: boolean) => void;
+  setDefaultSourcesRailCollapsed: (value: boolean) => void;
   setMetadataRevealMode: (value: MetadataRevealMode) => void;
   resetAppearancePreferences: () => void;
   resetVisibilityPreferences: () => void;
@@ -47,6 +49,7 @@ export const DEFAULT_APPEARANCE_PREFERENCES: AppearancePreferences = {
 export const DEFAULT_VISIBILITY_PREFERENCES: VisibilityPreferences = {
   helperTextVisible: false,
   defaultInspectorOpen: false,
+  defaultSourcesRailCollapsed: true,
   metadataRevealMode: "expand",
 };
 
@@ -90,6 +93,10 @@ function normalizePreferences(value: unknown): UiPreferences {
       typeof candidate.defaultInspectorOpen === "boolean"
         ? candidate.defaultInspectorOpen
         : DEFAULT_PREFERENCES.defaultInspectorOpen,
+    defaultSourcesRailCollapsed:
+      typeof candidate.defaultSourcesRailCollapsed === "boolean"
+        ? candidate.defaultSourcesRailCollapsed
+        : DEFAULT_PREFERENCES.defaultSourcesRailCollapsed,
     metadataRevealMode: isMetadataRevealMode(candidate.metadataRevealMode)
       ? candidate.metadataRevealMode
       : DEFAULT_PREFERENCES.metadataRevealMode,
@@ -147,6 +154,9 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
       },
       setDefaultInspectorOpen: (defaultInspectorOpen) => {
         setPreferences((current) => mergePreferences(current, { defaultInspectorOpen }));
+      },
+      setDefaultSourcesRailCollapsed: (defaultSourcesRailCollapsed) => {
+        setPreferences((current) => mergePreferences(current, { defaultSourcesRailCollapsed }));
       },
       setMetadataRevealMode: (metadataRevealMode) => {
         setPreferences((current) => mergePreferences(current, { metadataRevealMode }));

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -141,10 +141,74 @@ a {
   margin-top: 0.22rem;
 }
 
+.background-playback__resume {
+  display: grid;
+  gap: 0.2rem;
+  border-radius: 14px;
+  padding: 0.15rem;
+  text-align: justify;
+  text-justify: inter-word;
+  transition:
+    background 160ms ease,
+    transform 160ms ease;
+}
+
+.background-playback__resume:hover {
+  background: color-mix(in srgb, var(--surface-highlight) 16%, transparent);
+  transform: translateY(-1px);
+}
+
 .background-playback__controls {
   display: flex;
   flex-wrap: wrap;
   gap: 0.55rem;
+  justify-content: center;
+}
+
+.background-playback__control {
+  --background-playback-control-size: 2.65rem;
+  inline-size: var(--background-playback-control-size);
+  block-size: var(--background-playback-control-size);
+  display: inline-grid;
+  place-items: center;
+  padding: 0;
+  border: 1px solid color-mix(in srgb, var(--focus-ring) 22%, var(--divider));
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at 30% 24%, rgba(255, 255, 255, 0.07) 0, transparent 36%),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--panel-strong) 74%, var(--sidebar-bg)),
+      color-mix(in srgb, var(--sidebar-bg) 90%, black 10%)
+    );
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    inset 0 -0.45rem 0.8rem rgba(0, 0, 0, 0.18);
+  cursor: pointer;
+  transition:
+    border-color 160ms ease,
+    transform 160ms ease,
+    background 160ms ease;
+}
+
+.background-playback__control:hover {
+  border-color: color-mix(in srgb, var(--focus-ring) 34%, var(--divider));
+  transform: translateY(-1px);
+}
+
+.background-playback__icon {
+  pointer-events: none;
+  filter: drop-shadow(0 1px 1px rgba(15, 23, 42, 0.45));
+}
+
+.background-playback__icon--playpause {
+  inline-size: 1.28rem;
+  block-size: 1.28rem;
+}
+
+.background-playback__icon--stop {
+  inline-size: 1.12rem;
+  block-size: 1.12rem;
 }
 
 .brand__eyebrow,
@@ -246,7 +310,9 @@ a {
 .controls input:focus-visible,
 .controls select:focus-visible,
 .button:focus-visible,
-.nav a:focus-visible {
+.nav a:focus-visible,
+.background-playback__resume:focus-visible,
+.background-playback__control:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
 }
@@ -399,30 +465,21 @@ a {
 }
 
 .project-card__link {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
   gap: 1rem;
-  align-items: start;
+  color: inherit;
+}
+
+.project-card__title-block {
+  min-width: 0;
 }
 
 .project-card__title-block h2 {
   margin: 0;
   font-size: 1.55rem;
   line-height: 1.12;
-}
-
-.project-card__summary {
-  margin: 0.45rem 0 0;
-  color: var(--card-muted);
-  font-size: 1rem;
-  word-break: break-word;
-}
-
-.project-card__open {
-  align-self: start;
-  color: var(--project-card-text);
-  font-weight: 700;
-  white-space: nowrap;
 }
 
 .card-details {
@@ -454,13 +511,21 @@ a {
 
 .project-workbench {
   display: grid;
-  grid-template-columns: minmax(270px, 0.9fr) minmax(0, 1.6fr) minmax(320px, 0.95fr);
+  grid-template-columns: minmax(182px, 0.56fr) minmax(0, 1.86fr) minmax(320px, 0.95fr);
   gap: 1rem;
   align-items: start;
 }
 
 .project-workbench--wide {
-  grid-template-columns: minmax(270px, 0.95fr) minmax(0, 1.95fr);
+  grid-template-columns: minmax(182px, 0.6fr) minmax(0, 2.12fr);
+}
+
+.project-workbench--sources-collapsed {
+  grid-template-columns: 82px minmax(0, 1.98fr) minmax(320px, 0.95fr);
+}
+
+.project-workbench--sources-collapsed.project-workbench--wide {
+  grid-template-columns: 82px minmax(0, 2.22fr);
 }
 
 .stack,
@@ -471,22 +536,123 @@ a {
   gap: 1rem;
 }
 
+.sources-rail--collapsed {
+  position: sticky;
+  top: 1rem;
+}
+
+.rail-panel {
+  padding: 0.86rem;
+}
+
+.rail-panel--collapsed {
+  gap: 0.72rem;
+  align-items: center;
+  padding: 0.72rem 0.48rem;
+}
+
+.rail-panel--collapsed .rail-panel__top {
+  width: 100%;
+  justify-content: center;
+}
+
+.rail-panel__top {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.55rem;
+  align-items: center;
+}
+
+.rail-panel__identity {
+  min-width: 0;
+}
+
+.rail-panel__identity h2 {
+  font-size: 1.28rem;
+}
+
+.rail-panel__collapsed-spacer {
+  width: 1px;
+  height: 1px;
+}
+
+.rail-panel--collapsed .rail-panel__collapsed-spacer {
+  display: none;
+}
+
+.rail-panel__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.rail-panel__toggle--collapsed {
+  justify-content: center;
+  width: 2.35rem;
+  height: 2.35rem;
+  padding: 0;
+}
+
+.rail-panel__toggle-icon {
+  display: inline-grid;
+  gap: 0.18rem;
+}
+
+.rail-panel__toggle-icon span {
+  display: block;
+  width: 0.78rem;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.rail-panel__collapsed {
+  display: grid;
+  width: 100%;
+  gap: 0.4rem;
+}
+
+.rail-summary-chip {
+  border: 1px solid var(--chip-border);
+  border-radius: 14px;
+  padding: 0.42rem 0.2rem 0.48rem;
+  background: color-mix(in srgb, var(--panel-strong) 76%, transparent);
+  display: grid;
+  gap: 0.08rem;
+  justify-items: center;
+  text-align: center;
+}
+
+.rail-summary-chip span {
+  color: var(--muted);
+  font-size: 0.64rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  white-space: nowrap;
+}
+
+.rail-summary-chip strong {
+  font-size: 0.94rem;
+}
+
 .rail-section {
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
+  gap: 0.58rem;
 }
 
 .rail-section + .rail-section {
-  padding-top: 1rem;
+  padding-top: 0.72rem;
   border-top: 1px solid var(--divider);
 }
 
 .rail-section__header {
   display: flex;
   justify-content: space-between;
-  gap: 0.9rem;
-  align-items: start;
+  gap: 0.55rem;
+  align-items: center;
 }
 
 .subpanel {
@@ -584,11 +750,13 @@ a {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 0.2rem;
+  gap: 0.08rem;
   width: 100%;
-  padding: 0.9rem 1rem;
+  min-height: 0;
+  padding: 0.34rem 0.62rem;
   cursor: pointer;
   text-align: left;
+  border-radius: 14px;
 }
 
 .artifact-pill:hover,
@@ -605,11 +773,13 @@ a {
 
 .artifact-pill__title {
   font-weight: 700;
+  line-height: 1.08;
 }
 
 .artifact-pill__meta {
   color: var(--muted);
   font-size: 0.88rem;
+  line-height: 1.05;
 }
 
 .playback-focus__meta {
@@ -657,7 +827,6 @@ a {
 }
 
 .session-block strong,
-.playback-stage__footer strong,
 .stem-mixer__summary strong {
   display: block;
   margin-top: 0.25rem;
@@ -673,17 +842,209 @@ a {
 .transport__controls {
   display: flex;
   align-items: center;
-  gap: 0.6rem;
+  gap: 0.7rem;
+  flex-wrap: wrap;
 }
 
-.transport__play {
-  min-width: 8rem;
+.transport__button {
+  --transport-button-size: 3.35rem;
+  inline-size: var(--transport-button-size);
+  block-size: var(--transport-button-size);
+  display: inline-grid;
+  place-items: center;
+  padding: 0;
+  border-radius: 999px;
+  border-color: color-mix(in srgb, white 18%, var(--playback-accent) 82%);
+  background:
+    radial-gradient(
+      circle at 30% 26%,
+      color-mix(in srgb, white 56%, var(--playback-accent) 44%) 0,
+      transparent 34%
+    ),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, white 16%, var(--playback-accent) 84%) 0%,
+      var(--playback-accent) 56%,
+      color-mix(in srgb, black 14%, var(--playback-accent) 86%) 100%
+    );
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 38%, transparent),
+    inset 0 -0.5rem 0.95rem color-mix(in srgb, black 15%, transparent),
+    0 12px 22px color-mix(in srgb, var(--playback-accent) 22%, transparent);
+}
+
+.transport__button:hover {
+  border-color: color-mix(in srgb, white 28%, var(--playback-accent) 72%);
+}
+
+.transport__button[aria-pressed="true"] {
+  background:
+    radial-gradient(
+      circle at 30% 24%,
+      color-mix(in srgb, white 46%, var(--playback-accent) 54%) 0,
+      transparent 32%
+    ),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, white 10%, var(--playback-accent) 90%) 0%,
+      color-mix(in srgb, black 8%, var(--playback-accent) 92%) 54%,
+      color-mix(in srgb, black 20%, var(--playback-accent) 80%) 100%
+    );
+}
+
+.transport__button--play {
+  --transport-button-size: 4.85rem;
+}
+
+.transport__button--stop {
+  --transport-button-size: 4.85rem;
+}
+
+.transport__button--seek {
+  --transport-button-size: 3.35rem;
+}
+
+.transport__icon {
+  pointer-events: none;
+  filter: drop-shadow(0 1px 1px rgba(15, 23, 42, 0.45));
+}
+
+.transport__icon--playpause {
+  inline-size: 2.2rem;
+  block-size: 2.2rem;
+}
+
+.transport__icon--stop {
+  inline-size: 2rem;
+  block-size: 2rem;
+}
+
+.transport__icon--seek {
+  display: grid;
+  inline-size: 2rem;
+  block-size: 2rem;
+  place-items: center;
+}
+
+.transport__seek-glyph {
+  display: grid;
+  inline-size: 100%;
+  block-size: 100%;
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
+  place-content: center;
+  justify-items: center;
+  align-items: center;
+  column-gap: 0.06rem;
+  line-height: 0;
+}
+
+.transport__seek-slot {
+  position: relative;
+  inline-size: 0.58rem;
+  block-size: 0.74rem;
+  flex: 0 0 auto;
+}
+
+.transport__seek-triangle {
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(
+      135deg,
+      #fffbeb 0%,
+      #f8fafc 20%,
+      #cbd5e1 48%,
+      #64748b 76%,
+      #f8fafc 100%
+    );
+}
+
+.transport__seek-triangle--forward {
+  clip-path: polygon(0 0, 100% 50%, 0 100%);
+}
+
+.transport__seek-triangle--backward {
+  clip-path: polygon(100% 0, 0 50%, 100% 100%);
+}
+
+.transport__seek-triangle--overlay {
+  opacity: 0;
+  background-size: 180% 100%;
+}
+
+.transport__seek-glyph--animate-forward .transport__seek-triangle--overlay {
+  background-image:
+    linear-gradient(
+      90deg,
+      rgba(100, 116, 139, 0) 0%,
+      rgba(203, 213, 225, 0.18) 28%,
+      rgba(255, 255, 255, 0.96) 52%,
+      rgba(248, 250, 252, 0.68) 70%,
+      rgba(100, 116, 139, 0) 100%
+    );
+  animation: transport-seek-shift-forward 240ms ease-out 1;
+}
+
+.transport__seek-glyph--animate-backward .transport__seek-triangle--overlay {
+  background-image:
+    linear-gradient(
+      90deg,
+      rgba(248, 250, 252, 0) 0%,
+      rgba(100, 116, 139, 0.86) 34%,
+      rgba(71, 85, 105, 0.98) 52%,
+      rgba(148, 163, 184, 0.26) 72%,
+      rgba(248, 250, 252, 0) 100%
+    );
+  animation: transport-seek-shift-backward 240ms ease-out 1;
+}
+
+.transport__stop-block {
+  transform-box: fill-box;
+  transform-origin: center;
+  transition: transform 140ms ease;
+}
+
+.transport__button--stop:active .transport__stop-block {
+  transform: scale(0.84);
 }
 
 .transport__scrubber {
   display: flex;
   flex-direction: column;
   gap: 0.55rem;
+}
+
+@keyframes transport-seek-shift-forward {
+  0% {
+    opacity: 0;
+    background-position: -42% 50%;
+  }
+
+  24% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+    background-position: 118% 50%;
+  }
+}
+
+@keyframes transport-seek-shift-backward {
+  0% {
+    opacity: 0;
+    background-position: 142% 50%;
+  }
+
+  24% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+    background-position: -18% 50%;
+  }
 }
 
 .transport__scrubber input[type="range"] {
@@ -833,33 +1194,11 @@ a {
   cursor: pointer;
 }
 
-.playback-stage__footer {
-  display: grid;
-  grid-template-columns: minmax(0, 220px) minmax(0, 1fr);
-  gap: 1rem;
-  align-items: start;
-  border-top: 1px solid var(--divider);
-  padding-top: 1rem;
-}
-
-.session-jobs,
 .artifact-list,
 .job-list {
   list-style: none;
   margin: 0;
   padding: 0;
-}
-
-.session-jobs {
-  display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
-}
-
-.session-jobs li {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.75rem;
 }
 
 .details-block {
@@ -1328,7 +1667,6 @@ a {
   .details-grid,
   .details-stack,
   .playback-stage__summary,
-  .playback-stage__footer,
   .chord-preview-grid,
   .key-shift__header,
   .stem-row {
@@ -1337,14 +1675,6 @@ a {
 
   .playback-focus__meta {
     align-items: flex-start;
-  }
-
-  .project-card__link {
-    grid-template-columns: 1fr;
-  }
-
-  .project-card__open {
-    justify-self: start;
   }
 
   .theme-preview__topbar,


### PR DESCRIPTION
## Summary
- replace the main playback transport with icon-based play, pause, stop, and seek controls plus matching mini controls in background playback
- collapse the sources rail by default with a settings toggle, compact the rail cards, total stem counts, and add rebuild-stems confirmation
- streamline library cards by removing redundant copy, making the card body clickable, and normalizing API timestamps before local timezone formatting

## Testing
- `pnpm --filter @tuneforge/desktop test -- --run src/App.test.tsx`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint` (reports the existing intentional `react-hooks/exhaustive-deps` warnings in `apps/desktop/src/features/projects/playback.tsx`)
