### PR TITLE
feat: add contextual key display and project key overrides

### DIFF
--- a/apps/backend/alembic/versions/0003_project_source_key_override.py
+++ b/apps/backend/alembic/versions/0003_project_source_key_override.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0003_project_source_key_override"
+down_revision = "0002_chord_timelines"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("projects", sa.Column("source_key_override", sa.String(length=32), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("projects", "source_key_override")

--- a/apps/backend/app/api/routes/projects.py
+++ b/apps/backend/app/api/routes/projects.py
@@ -35,7 +35,7 @@ from app.services.projects import (
     get_project,
     import_project,
     list_projects,
-    rename_project,
+    update_project,
 )
 from app.services.stems import resolve_stem_source_artifact
 
@@ -43,13 +43,33 @@ router = APIRouter(prefix="/projects", tags=["projects"])
 
 
 @router.post("/import", response_model=ProjectResponse)
-def create_project(payload: ProjectImportRequest, session: Session = Depends(get_db)) -> ProjectResponse:
+def create_project(
+    payload: ProjectImportRequest,
+    session: Session = Depends(get_db),
+    runner=Depends(get_job_runner),
+) -> ProjectResponse:
     project = import_project(
         session,
         source_path=payload.source_path,
         copy_into_project=payload.copy_into_project,
         display_name=payload.display_name,
     )
+    analyze_job = runner.create_job(
+        session,
+        project_id=project.id,
+        job_type="analyze",
+        payload=AnalysisRequest(include_tempo=False, force=False).model_dump(),
+    )
+    chords_job = runner.create_job(
+        session,
+        project_id=project.id,
+        job_type="chords",
+        payload=ChordRequest(backend="default", force=False).model_dump(),
+    )
+    session.commit()
+    session.refresh(project)
+    runner.enqueue(analyze_job.id)
+    runner.enqueue(chords_job.id)
     return ProjectResponse(project=ProjectSchema.model_validate(project))
 
 
@@ -73,7 +93,11 @@ def project_update(
     payload: ProjectUpdateRequest,
     session: Session = Depends(get_db),
 ) -> ProjectResponse:
-    project = rename_project(session, project_id, display_name=payload.display_name)
+    project = update_project(
+        session,
+        project_id,
+        updates=payload.model_dump(exclude_unset=True),
+    )
     return ProjectResponse(project=ProjectSchema.model_validate(project))
 
 

--- a/apps/backend/app/engines/analysis.py
+++ b/apps/backend/app/engines/analysis.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 
 import librosa
@@ -40,6 +41,15 @@ def _estimate_tuning(signal: np.ndarray, sample_rate: int) -> tuple[float | None
     return estimated_reference_hz, tuning_offset_cents
 
 
+def _safe_fft_size(signal_size: int, preferred_n_fft: int) -> int:
+    if signal_size <= 0:
+        return preferred_n_fft
+    if signal_size >= preferred_n_fft:
+        return preferred_n_fft
+    exponent = int(np.floor(np.log2(max(signal_size, 32))))
+    return max(32, 2**exponent)
+
+
 def analyze_track(source_path: Path) -> dict[str, float | str | None]:
     signal, sample_rate = _load_signal(source_path)
     if signal.size == 0:
@@ -53,7 +63,20 @@ def analyze_track(source_path: Path) -> dict[str, float | str | None]:
 
     estimated_reference_hz, tuning_offset_cents = _estimate_tuning(signal, sample_rate)
 
-    chroma = librosa.feature.chroma_stft(y=signal, sr=sample_rate, n_fft=4096, hop_length=1024)
+    n_fft = _safe_fft_size(signal.size, 4096)
+    hop_length = max(32, min(1024, n_fft // 4))
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"n_fft=.*too large for input signal of length=.*",
+            category=UserWarning,
+        )
+        chroma = librosa.feature.chroma_stft(
+            y=signal,
+            sr=sample_rate,
+            n_fft=n_fft,
+            hop_length=hop_length,
+        )
     chroma_mean = chroma.mean(axis=1)
     chroma_norm = chroma_mean / np.linalg.norm(chroma_mean, ord=2)
     major_scores = np.array([np.corrcoef(chroma_norm, np.roll(MAJOR_PROFILE, idx))[0, 1] for idx in range(12)])

--- a/apps/backend/app/engines/chords.py
+++ b/apps/backend/app/engines/chords.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TypedDict, cast
@@ -47,6 +48,15 @@ def _load_signal(source_path: Path) -> tuple[np.ndarray, int]:
 def _format_chord_label(pitch_class: int, quality: str) -> str:
     note_name = str(DISPLAY_NOTE_NAMES[pitch_class % 12])
     return f"{note_name}m" if quality == "minor" else note_name
+
+
+def _safe_fft_size(signal_size: int, preferred_n_fft: int) -> int:
+    if signal_size <= 0:
+        return preferred_n_fft
+    if signal_size >= preferred_n_fft:
+        return preferred_n_fft
+    exponent = int(np.floor(np.log2(max(signal_size, 32))))
+    return max(32, 2**exponent)
 
 
 def _build_templates() -> tuple[ChordTemplate, ...]:
@@ -119,9 +129,26 @@ def detect_chord_timeline(source_path: Path) -> list[ChordSegment]:
     if signal.size == 0:
         return []
 
-    hop_length = 2048
+    preferred_hop_length = 2048
     total_duration = float(signal.size / sample_rate)
-    chroma = librosa.feature.chroma_cqt(y=signal, sr=sample_rate, hop_length=hop_length)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"n_fft=.*too large for input signal of length=.*",
+            category=UserWarning,
+        )
+        if signal.size < 4096:
+            n_fft = _safe_fft_size(signal.size, 2048)
+            hop_length = max(32, min(preferred_hop_length, n_fft // 4))
+            chroma = librosa.feature.chroma_stft(
+                y=signal,
+                sr=sample_rate,
+                n_fft=n_fft,
+                hop_length=hop_length,
+            )
+        else:
+            hop_length = preferred_hop_length
+            chroma = librosa.feature.chroma_cqt(y=signal, sr=sample_rate, hop_length=hop_length)
     if chroma.size == 0:
         return []
     chroma = _smooth_chroma(chroma)

--- a/apps/backend/app/models.py
+++ b/apps/backend/app/models.py
@@ -18,6 +18,7 @@ class Project(Base):
 
     id: Mapped[str] = mapped_column(String(32), primary_key=True)
     display_name: Mapped[str] = mapped_column(String(255))
+    source_key_override: Mapped[str | None] = mapped_column(String(32), nullable=True)
     source_path: Mapped[str] = mapped_column(String(2048))
     imported_path: Mapped[str] = mapped_column(String(2048))
     duration_seconds: Mapped[float | None] = mapped_column(Float(), nullable=True)

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -31,6 +31,7 @@ class ProjectSchema(BaseModel):
 
     id: str
     display_name: str
+    source_key_override: str | None
     source_path: str
     imported_path: str
     duration_seconds: float | None
@@ -47,15 +48,44 @@ class ProjectImportRequest(BaseModel):
 
 
 class ProjectUpdateRequest(BaseModel):
-    display_name: str
+    display_name: str | None = None
+    source_key_override: str | None = None
 
     @field_validator("display_name")
     @classmethod
-    def validate_display_name(cls, value: str) -> str:
+    def validate_display_name(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         normalized = value.strip()
         if not normalized:
             raise ValueError("Project name cannot be empty.")
         return normalized
+
+    @field_validator("source_key_override")
+    @classmethod
+    def validate_source_key_override(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        parts = normalized.split(":")
+        if len(parts) != 2:
+            raise ValueError("Source key override must use serialized key format.")
+        pitch_class_raw, mode_raw = parts
+        try:
+            pitch_class = int(pitch_class_raw)
+        except ValueError as exc:
+            raise ValueError("Source key override pitch class must be an integer.") from exc
+        if pitch_class < 0 or pitch_class > 11:
+            raise ValueError("Source key override pitch class must be between 0 and 11.")
+        if mode_raw not in {"major", "minor"}:
+            raise ValueError("Source key override mode must be major or minor.")
+        return normalized
+
+    @model_validator(mode="after")
+    def validate_update_request(self) -> ProjectUpdateRequest:
+        if not self.model_fields_set:
+            raise ValueError("At least one project field must be updated.")
+        return self
 
 
 class ProjectResponse(BaseModel):

--- a/apps/backend/app/services/projects.py
+++ b/apps/backend/app/services/projects.py
@@ -122,8 +122,14 @@ def delete_project(session: Session, project_id: str) -> None:
         shutil.rmtree(root, ignore_errors=True)
 
 
-def rename_project(session: Session, project_id: str, *, display_name: str) -> Project:
+def update_project(session: Session, project_id: str, *, updates: dict[str, str | None]) -> Project:
     project = get_project(session, project_id)
-    project.display_name = display_name.strip()
+    if "display_name" in updates:
+        display_name = updates["display_name"]
+        if display_name is not None:
+            project.display_name = display_name.strip()
+    if "source_key_override" in updates:
+        source_key_override = updates["source_key_override"]
+        project.source_key_override = source_key_override.strip() if isinstance(source_key_override, str) else None
     session.flush()
     return project

--- a/apps/backend/tests/test_chord_flow.py
+++ b/apps/backend/tests/test_chord_flow.py
@@ -11,14 +11,21 @@ def test_chord_job_persists_timeline(client, sample_chord_audio_file: Path):
         json={"source_path": str(sample_chord_audio_file), "copy_into_project": True},
     ).json()["project"]
 
+    initial_jobs = client.get("/api/v1/jobs").json()["jobs"]
+    initial_chord_job = next(
+        job for job in initial_jobs if job["project_id"] == project["id"] and job["type"] == "chords"
+    )
+    assert wait_for_job(client, initial_chord_job["id"])["status"] == "completed"
+
     initial = client.get(f"/api/v1/projects/{project['id']}/chords").json()
     assert initial["project_id"] == project["id"]
-    assert initial["timeline"] == []
-    assert initial["backend"] is None
+    assert initial["backend"] == "default"
+    assert len(initial["timeline"]) >= 3
+    initial_created_at = initial["created_at"]
 
     job = client.post(
         f"/api/v1/projects/{project['id']}/chords",
-        json={"backend": "default", "force": False},
+        json={"backend": "default", "force": True},
     ).json()["job"]
     final_job = wait_for_job(client, job["id"])
     assert final_job["status"] == "completed"
@@ -30,6 +37,7 @@ def test_chord_job_persists_timeline(client, sample_chord_audio_file: Path):
     assert all(segment["end_seconds"] > segment["start_seconds"] for segment in chords["timeline"])
     assert all(segment["pitch_class"] is not None for segment in chords["timeline"])
     assert all(segment["quality"] in {"major", "minor"} for segment in chords["timeline"])
+    assert chords["created_at"] != initial_created_at
 
     labels = [segment["label"] for segment in chords["timeline"]]
     assert labels[0] == "C"

--- a/apps/backend/tests/test_projects.py
+++ b/apps/backend/tests/test_projects.py
@@ -17,6 +17,7 @@ def test_import_project_persists_metadata_and_source_artifact(client, sample_aud
     assert response.status_code == 200
     project = response.json()["project"]
     assert project["display_name"] == "fixture"
+    assert project["source_key_override"] is None
     assert project["sample_rate"] == 44100
     assert project["channels"] == 1
 
@@ -27,6 +28,29 @@ def test_import_project_persists_metadata_and_source_artifact(client, sample_aud
 
     artifacts = client.get(f"/api/v1/projects/{project['id']}/artifacts").json()["artifacts"]
     assert any(artifact["type"] == "source_audio" for artifact in artifacts)
+
+
+def test_import_project_enqueues_analysis_and_chords(client, sample_chord_audio_file: Path):
+    response = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_chord_audio_file), "copy_into_project": True},
+    )
+
+    assert response.status_code == 200
+    project = response.json()["project"]
+
+    jobs = client.get("/api/v1/jobs").json()["jobs"]
+    analyze_job = next(job for job in jobs if job["project_id"] == project["id"] and job["type"] == "analyze")
+    chord_job = next(job for job in jobs if job["project_id"] == project["id"] and job["type"] == "chords")
+
+    assert wait_for_job(client, analyze_job["id"])["status"] == "completed"
+    assert wait_for_job(client, chord_job["id"])["status"] == "completed"
+
+    analysis = client.get(f"/api/v1/projects/{project['id']}/analysis").json()["analysis"]
+    chords = client.get(f"/api/v1/projects/{project['id']}/chords").json()
+
+    assert analysis is not None
+    assert len(chords["timeline"]) >= 3
 
 
 def test_project_can_be_renamed(client, sample_audio_file: Path):
@@ -42,6 +66,29 @@ def test_project_can_be_renamed(client, sample_audio_file: Path):
 
     assert response.status_code == 200
     assert response.json()["project"]["display_name"] == "Practice Version"
+
+
+def test_project_source_key_override_can_be_updated_and_cleared(client, sample_audio_file: Path):
+    project = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_audio_file), "copy_into_project": True},
+    ).json()["project"]
+
+    update_response = client.patch(
+        f"/api/v1/projects/{project['id']}",
+        json={"source_key_override": "8:major"},
+    )
+
+    assert update_response.status_code == 200
+    assert update_response.json()["project"]["source_key_override"] == "8:major"
+
+    cleared_response = client.patch(
+        f"/api/v1/projects/{project['id']}",
+        json={"source_key_override": None},
+    )
+
+    assert cleared_response.status_code == 200
+    assert cleared_response.json()["project"]["source_key_override"] is None
 
 
 def test_project_list_can_filter_by_search_term(client, sample_audio_file: Path, tmp_path: Path):

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -9,6 +9,7 @@ const {
   resetMockApiState,
   setProjects,
   setProjectAnalysis,
+  setProjectChords,
   setDeferredPreviewCompletion,
   flushPendingPreview,
   mockOpen,
@@ -67,6 +68,7 @@ const {
     return {
       id,
       display_name: displayName,
+      source_key_override: null,
       source_path: sourcePath,
       imported_path: importedPath,
       duration_seconds: 182,
@@ -98,6 +100,10 @@ const {
 
   function setProjectAnalysis(projectId: string, analysis: Record<string, unknown> | null) {
     state.analysisByProject[projectId] = analysis ? clone(analysis) : null;
+  }
+
+  function setProjectChords(projectId: string, chords: Record<string, unknown>) {
+    state.chordsByProject[projectId] = clone(chords);
   }
 
   function setDeferredPreviewCompletion(value: boolean) {
@@ -266,7 +272,8 @@ const {
   );
   const mockListArtifacts = vi.fn(async (projectId: string) => ({ artifacts: clone(state.artifactsByProject[projectId] ?? []) }));
   const mockListJobs = vi.fn(async () => ({ jobs: clone(state.jobs) }));
-  const mockCreateChords = vi.fn(async (projectId: string) => {
+  const mockCreateChords = vi.fn(async (projectId: string, body?: Record<string, unknown>) => {
+    void body;
     state.chordsByProject[projectId] = makeChordTimeline(projectId);
     const job = {
       id: `job_${state.nextJobId++}`,
@@ -391,9 +398,14 @@ const {
     state.jobs.unshift(job);
     return { job: clone(job) };
   });
-  const mockUpdateProject = vi.fn(async (projectId: string, body: { display_name: string }) => {
+  const mockUpdateProject = vi.fn(async (projectId: string, body: { display_name?: string; source_key_override?: string | null }) => {
     const project = getProjectOrThrow(projectId);
-    project.display_name = body.display_name;
+    if (body.display_name !== undefined) {
+      project.display_name = body.display_name;
+    }
+    if ("source_key_override" in body) {
+      project.source_key_override = body.source_key_override ?? null;
+    }
     project.updated_at = createdAt;
     return { project: clone(project) };
   });
@@ -436,6 +448,7 @@ const {
     resetMockApiState,
     setProjects,
     setProjectAnalysis,
+    setProjectChords,
     setDeferredPreviewCompletion,
     flushPendingPreview,
     mockOpen,
@@ -747,7 +760,133 @@ describe("Desktop app flows", () => {
     expect(mockAnalyzeProject).toHaveBeenCalledWith("proj_123");
   });
 
-  it("creates a new mix from source-key controls", async () => {
+  it("refreshes existing chords with force enabled", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Refresh Chords" }));
+
+    expect(mockCreateChords).toHaveBeenCalledWith("proj_123", {
+      backend: "default",
+      force: true,
+    });
+  });
+
+  it("renders single-label enharmonic spellings by default", async () => {
+    const user = userEvent.setup();
+    setProjectAnalysis("proj_123", {
+      project_id: "proj_123",
+      estimated_key: "Eb minor",
+      key_confidence: 0.82,
+      estimated_reference_hz: 431.9,
+      tuning_offset_cents: -32,
+      tempo_bpm: null,
+      analysis_version: "v1",
+      created_at: "2026-04-18T13:16:00.000Z",
+    });
+    setProjectChords("proj_123", {
+      project_id: "proj_123",
+      backend: "default",
+      source_artifact_id: "art_source",
+      created_at: "2026-04-18T13:16:00.000Z",
+      timeline: [
+        { start_seconds: 0, end_seconds: 16, label: "legacy", confidence: 0.81, pitch_class: 3, quality: "minor" },
+        { start_seconds: 16, end_seconds: 32, label: "legacy", confidence: 0.79, pitch_class: 10, quality: "major" },
+      ],
+    });
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    expect(within(screen.getByRole("group", { name: "Current chord card" })).getByText("Ebm")).toBeInTheDocument();
+    expect(within(screen.getByRole("group", { name: "Next chord card" })).getByText("Bb")).toBeInTheDocument();
+    expect(screen.queryByText("D#/Ebm")).not.toBeInTheDocument();
+    expect(screen.queryByText("A#/Bb")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Show Inspector" }));
+    expect(
+      within(screen.getByText("Source Key", { selector: "span" }).closest("div") as HTMLElement).getByText("Ebm"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Bb" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "D#/Ebm" })).not.toBeInTheDocument();
+  });
+
+  it("applies enharmonic display overrides from settings", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({
+        defaultSourcesRailCollapsed: false,
+        enharmonicDisplayMode: "sharps",
+      }),
+    );
+    setProjectAnalysis("proj_123", {
+      project_id: "proj_123",
+      estimated_key: "Eb minor",
+      key_confidence: 0.82,
+      estimated_reference_hz: 431.9,
+      tuning_offset_cents: -32,
+      tempo_bpm: null,
+      analysis_version: "v1",
+      created_at: "2026-04-18T13:16:00.000Z",
+    });
+    setProjectChords("proj_123", {
+      project_id: "proj_123",
+      backend: "default",
+      source_artifact_id: "art_source",
+      created_at: "2026-04-18T13:16:00.000Z",
+      timeline: [
+        { start_seconds: 0, end_seconds: 16, label: "legacy", confidence: 0.81, pitch_class: 3, quality: "minor" },
+        { start_seconds: 16, end_seconds: 32, label: "legacy", confidence: 0.79, pitch_class: 10, quality: "major" },
+      ],
+    });
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    expect(within(screen.getByRole("group", { name: "Current chord card" })).getByText("D#m")).toBeInTheDocument();
+    expect(within(screen.getByRole("group", { name: "Next chord card" })).getByText("A#")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Show Inspector" }));
+
+    const sourceKeyCard = screen.getByText("Source Key", { selector: "span" }).closest("div") as HTMLElement;
+    expect(
+      within(sourceKeyCard).getByText("D#m"),
+    ).toBeInTheDocument();
+    expect(within(sourceKeyCard).queryByText("Ebm")).not.toBeInTheDocument();
+    const targetKeySelect = screen.getByLabelText("Target Key") as HTMLSelectElement;
+    expect(Array.from(targetKeySelect.options).some((option) => option.text === "D#m")).toBe(true);
+    expect(Array.from(targetKeySelect.options).some((option) => option.text === "Ebm")).toBe(false);
+  });
+
+  it("preserves the relative target shift when the detected source key is corrected", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({
+        defaultSourcesRailCollapsed: false,
+        enharmonicDisplayMode: "sharps",
+      }),
+    );
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Show Inspector" }));
+    await user.click(screen.getByLabelText("Raise target key"));
+
+    const targetKeyCard = screen.getAllByText("Target Key", { selector: "span" })[0]?.closest("div") as HTMLElement;
+    expect(within(targetKeyCard).getByText("G#")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Correct source key for this project"));
+    await user.selectOptions(screen.getByLabelText("Project Source Key"), "8:major");
+
+    const sourceKeyCard = screen.getByText("Source Key", { selector: "span" }).closest("div") as HTMLElement;
+    expect(mockUpdateProject).toHaveBeenCalledWith("proj_123", { source_key_override: "8:major" });
+    expect(within(sourceKeyCard).getByText("G#")).toBeInTheDocument();
+    expect(within(targetKeyCard).getByText("A")).toBeInTheDocument();
+  });
+
+  it("creates a new mix from the project source key override and target controls", async () => {
     const user = userEvent.setup();
     renderApp(["/projects/proj_123"]);
 
@@ -755,8 +894,8 @@ describe("Desktop app flows", () => {
     await user.click(screen.getByRole("button", { name: "Show Inspector" }));
     const sourceList = screen.getByRole("group", { name: "Source and mix list" });
     await user.click(within(sourceList).getByRole("button", { name: /Source Track/i }));
-    await user.click(screen.getByText("Correct source key if detection is wrong"));
-    await user.selectOptions(screen.getByLabelText("Current Key"), "9:major");
+    await user.click(screen.getByText("Correct source key for this project"));
+    await user.selectOptions(screen.getByLabelText("Project Source Key"), "9:major");
     await user.click(screen.getByLabelText("Raise target key"));
     await user.click(screen.getByRole("button", { name: "Create Mix" }));
 
@@ -1392,21 +1531,23 @@ describe("Desktop app flows", () => {
     expect(screen.getByLabelText("Theme")).toHaveValue("system");
     expect(screen.getByLabelText("Information Density")).toHaveValue("minimal");
     expect(screen.getByLabelText("Layout Density")).toHaveValue("compact");
+    expect(screen.getByLabelText("Enharmonic Display")).toHaveValue("auto");
     expect(screen.getByLabelText("Show helper text by default")).not.toBeChecked();
     expect(screen.getByLabelText("Open inspector by default")).not.toBeChecked();
-    expect(screen.getByLabelText("Collapse sources rail by default")).toBeChecked();
+    expect(screen.getByLabelText("Collapse sources rail by default")).not.toBeChecked();
     expect(window.localStorage.getItem("tuneforge.theme-preference")).toBe("system");
     expect(JSON.parse(window.localStorage.getItem("tuneforge.ui-preferences") ?? "{}")).toMatchObject({
       informationDensity: "minimal",
       layoutDensity: "compact",
+      enharmonicDisplayMode: "auto",
       helperTextVisible: false,
       defaultInspectorOpen: false,
-      defaultSourcesRailCollapsed: true,
+      defaultSourcesRailCollapsed: false,
       metadataRevealMode: "expand",
     });
   });
 
-  it("starts with the sources rail collapsed by default and expands on demand", async () => {
+  it("honors the collapsed sources rail preference and expands on demand", async () => {
     const user = userEvent.setup();
     window.localStorage.setItem(
       "tuneforge.ui-preferences",
@@ -1482,6 +1623,7 @@ describe("Desktop app flows", () => {
     await user.selectOptions(screen.getByLabelText("Theme"), "light");
     await user.selectOptions(screen.getByLabelText("Information Density"), "detailed");
     await user.selectOptions(screen.getByLabelText("Layout Density"), "comfortable");
+    await user.selectOptions(screen.getByLabelText("Enharmonic Display"), "sharps");
     await user.click(screen.getByLabelText("Show helper text by default"));
     await user.click(screen.getByLabelText("Open inspector by default"));
     await user.click(screen.getByLabelText("Collapse sources rail by default"));
@@ -1494,9 +1636,10 @@ describe("Desktop app flows", () => {
     expect(JSON.parse(window.localStorage.getItem("tuneforge.ui-preferences") ?? "{}")).toMatchObject({
       informationDensity: "detailed",
       layoutDensity: "comfortable",
+      enharmonicDisplayMode: "sharps",
       helperTextVisible: true,
       defaultInspectorOpen: true,
-      defaultSourcesRailCollapsed: false,
+      defaultSourcesRailCollapsed: true,
       metadataRevealMode: "hover",
     });
   });
@@ -1510,6 +1653,7 @@ describe("Desktop app flows", () => {
     await user.selectOptions(screen.getByLabelText("Theme"), "light");
     await user.selectOptions(screen.getByLabelText("Information Density"), "detailed");
     await user.selectOptions(screen.getByLabelText("Layout Density"), "comfortable");
+    await user.selectOptions(screen.getByLabelText("Enharmonic Display"), "sharps");
     await user.click(screen.getByLabelText("Show helper text by default"));
     await user.click(screen.getByLabelText("Open inspector by default"));
     await user.click(screen.getByLabelText("Collapse sources rail by default"));
@@ -1519,27 +1663,30 @@ describe("Desktop app flows", () => {
     expect(screen.getByLabelText("Theme")).toHaveValue("system");
     expect(screen.getByLabelText("Information Density")).toHaveValue("minimal");
     expect(screen.getByLabelText("Layout Density")).toHaveValue("compact");
+    expect(screen.getByLabelText("Enharmonic Display")).toHaveValue("auto");
     expect(screen.getByLabelText("Show helper text by default")).toBeChecked();
     expect(screen.getByLabelText("Open inspector by default")).toBeChecked();
-    expect(screen.getByLabelText("Collapse sources rail by default")).not.toBeChecked();
+    expect(screen.getByLabelText("Collapse sources rail by default")).toBeChecked();
     expect(screen.getByLabelText("Metadata Reveal")).toHaveValue("hover");
 
     await user.click(screen.getByRole("button", { name: "Reset Visibility" }));
     expect(screen.getByLabelText("Show helper text by default")).not.toBeChecked();
     expect(screen.getByLabelText("Open inspector by default")).not.toBeChecked();
-    expect(screen.getByLabelText("Collapse sources rail by default")).toBeChecked();
+    expect(screen.getByLabelText("Collapse sources rail by default")).not.toBeChecked();
     expect(screen.getByLabelText("Metadata Reveal")).toHaveValue("expand");
 
     await user.selectOptions(screen.getByLabelText("Theme"), "dark");
+    await user.selectOptions(screen.getByLabelText("Enharmonic Display"), "dual");
     await user.click(screen.getByLabelText("Show helper text by default"));
     await user.click(screen.getByRole("button", { name: "Reset All Settings" }));
 
     expect(screen.getByLabelText("Theme")).toHaveValue("system");
     expect(screen.getByLabelText("Information Density")).toHaveValue("minimal");
     expect(screen.getByLabelText("Layout Density")).toHaveValue("compact");
+    expect(screen.getByLabelText("Enharmonic Display")).toHaveValue("auto");
     expect(screen.getByLabelText("Show helper text by default")).not.toBeChecked();
     expect(screen.getByLabelText("Open inspector by default")).not.toBeChecked();
-    expect(screen.getByLabelText("Collapse sources rail by default")).toBeChecked();
+    expect(screen.getByLabelText("Collapse sources rail by default")).not.toBeChecked();
     expect(screen.getByLabelText("Metadata Reveal")).toHaveValue("expand");
   });
 

--- a/apps/desktop/src/features/projects/ProjectView.tsx
+++ b/apps/desktop/src/features/projects/ProjectView.tsx
@@ -2,7 +2,7 @@ import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { confirm, save } from "@tauri-apps/plugin-dialog";
-import { api, type ArtifactSchema, type ChordSegmentSchema, type JobSchema } from "../../lib/api";
+import { api, type ArtifactSchema, type ChordSegmentSchema, type JobSchema, type ProjectSchema } from "../../lib/api";
 import { formatLocalDateTime } from "../../lib/datetime";
 import { usePreferences } from "../../lib/preferences";
 import { usePlayback } from "./playback-context";
@@ -14,11 +14,13 @@ import {
 } from "./projectPlaybackState";
 import {
   DEFAULT_KEY,
+  type EnharmonicDisplayMode,
   MUSICAL_KEYS,
   deserializeKey,
   formatChordLabel,
   formatKey,
   parseKey,
+  parseStoredKey,
   semitoneDelta,
   serializeKey,
   transposePitchClass,
@@ -307,9 +309,12 @@ function artifactTransposeSemitones(
   return 0;
 }
 
-function transposeChordSegment(segment: ChordSegmentSchema, semitones: number): ChordSegmentSchema {
+function transposeChordSegment(
+  segment: ChordSegmentSchema,
+  semitones: number,
+  options: { activeKey: MusicalKey | null; mode: EnharmonicDisplayMode },
+): ChordSegmentSchema {
   if (
-    !semitones ||
     typeof segment.pitch_class !== "number" ||
     (segment.quality !== "major" && segment.quality !== "minor")
   ) {
@@ -319,7 +324,7 @@ function transposeChordSegment(segment: ChordSegmentSchema, semitones: number): 
   return {
     ...segment,
     pitch_class: pitchClass,
-    label: formatChordLabel(pitchClass, segment.quality),
+    label: formatChordLabel(pitchClass, segment.quality, options),
   };
 }
 
@@ -430,6 +435,7 @@ export function ProjectView() {
   const {
     defaultInspectorOpen,
     defaultSourcesRailCollapsed,
+    enharmonicDisplayMode,
     helperTextVisible,
     informationDensity,
     metadataRevealMode,
@@ -438,11 +444,11 @@ export function ProjectView() {
   const pendingPreviewSelection = useRef<{ previousLatestPreviewArtifactId: string | null } | null>(
     null,
   );
+  const previousSourceKeyRef = useRef<MusicalKey | null>(null);
   const persistedStemSourceArtifactId = useRef<string | null>(null);
   const [retuneMode, setRetuneMode] = useState<"off" | "reference" | "cents">("off");
   const [referenceHz, setReferenceHz] = useState("440");
   const [centsOffset, setCentsOffset] = useState("0");
-  const [manualSourceKey, setManualSourceKey] = useState<MusicalKey | null>(null);
   const [seekAnimationRevision, setSeekAnimationRevision] = useState<Record<SeekDirection, number>>({
     backward: 0,
     forward: 0,
@@ -505,8 +511,51 @@ export function ProjectView() {
     },
   });
 
+  const sourceKeyOverrideMutation = useMutation({
+    mutationFn: async (sourceKeyOverride: string | null) =>
+      api.updateProject(projectId, { source_key_override: sourceKeyOverride }),
+    onMutate: async (sourceKeyOverride) => {
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: ["project", projectId] }),
+        queryClient.cancelQueries({ queryKey: ["projects"] }),
+      ]);
+
+      const previousProject = queryClient.getQueryData<ProjectSchema>(["project", projectId]);
+      const previousProjects = queryClient.getQueryData<ProjectSchema[]>(["projects"]);
+
+      queryClient.setQueryData<ProjectSchema>(["project", projectId], (current) =>
+        current ? { ...current, source_key_override: sourceKeyOverride } : current,
+      );
+      queryClient.setQueryData<ProjectSchema[]>(["projects"], (current) =>
+        current?.map((project) =>
+          project.id === projectId ? { ...project, source_key_override: sourceKeyOverride } : project,
+        ) ?? current,
+      );
+
+      return { previousProject, previousProjects };
+    },
+    onError: (_error, _sourceKeyOverride, context) => {
+      if (context?.previousProject) {
+        queryClient.setQueryData(["project", projectId], context.previousProject);
+      }
+      if (context?.previousProjects) {
+        queryClient.setQueryData(["projects"], context.previousProjects);
+      }
+    },
+    onSettled: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["project", projectId] }),
+        queryClient.invalidateQueries({ queryKey: ["projects"] }),
+      ]);
+    },
+  });
+
   const chordMutation = useMutation({
-    mutationFn: async () => api.createChords(projectId, { backend: "default", force: false }),
+    mutationFn: async () =>
+      api.createChords(projectId, {
+        backend: "default",
+        force: (chordsQuery.data?.timeline?.length ?? 0) > 0,
+      }),
     onSuccess: async () => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ["jobs"] }),
@@ -723,7 +772,9 @@ export function ProjectView() {
     : "";
 
   const detectedKey = parseKey(analysisQuery.data?.estimated_key);
-  const sourceKey = manualSourceKey ?? detectedKey ?? DEFAULT_KEY;
+  const sourceKeyOverride = parseStoredKey(projectQuery.data?.source_key_override);
+  const sourceKeyBasis = sourceKeyOverride ?? detectedKey ?? null;
+  const sourceKey = sourceKeyBasis ?? DEFAULT_KEY;
   const targetKey = targetDirty ? targetKeyState ?? sourceKey : sourceKey;
   const transposeSemitones = semitoneDelta(sourceKey, targetKey);
   const targetKeyOptions = MUSICAL_KEYS.filter((key) => key.mode === sourceKey.mode);
@@ -744,8 +795,8 @@ export function ProjectView() {
     chordJob && ["pending", "running"].includes(chordJob.status),
   );
   const isStemRunning = Boolean(stemJob && ["pending", "running"].includes(stemJob.status));
-  const currentKeyValue = manualSourceKey
-    ? serializeKey(manualSourceKey)
+  const currentKeyValue = sourceKeyOverride
+    ? serializeKey(sourceKeyOverride)
     : detectedKey
       ? "auto"
       : serializeKey(sourceKey);
@@ -755,7 +806,7 @@ export function ProjectView() {
       ? stemJob.error_message
       : null;
   const visibleJobs = projectJobs;
-  const controlSummary = hasTransformChange ? formatKey(targetKey) : "Original key";
+  const controlSummary = hasTransformChange ? formatKey(targetKey, "short", { mode: enharmonicDisplayMode }) : "Original key";
   const tuningSummary = formatRetuneSummary(retuneMode, referenceHz, centsOffset);
   const mixStatus = isStemPlayback
     ? "Stem monitor"
@@ -783,12 +834,18 @@ export function ProjectView() {
     selectedPlaybackArtifact,
     selectableArtifacts,
   );
+  const activeEnharmonicKeyContext = sourceKeyBasis
+    ? transposeKey(sourceKeyBasis, chordTransposeSemitones)
+    : null;
   const displayedChords = useMemo(
     () =>
       (chordsQuery.data?.timeline ?? []).map((segment) =>
-        transposeChordSegment(segment, chordTransposeSemitones),
+        transposeChordSegment(segment, chordTransposeSemitones, {
+          activeKey: activeEnharmonicKeyContext,
+          mode: enharmonicDisplayMode,
+        }),
       ),
-    [chordTransposeSemitones, chordsQuery.data?.timeline],
+    [activeEnharmonicKeyContext, chordTransposeSemitones, chordsQuery.data?.timeline, enharmonicDisplayMode],
   );
   const activeChordIndex = findActiveChordIndex(displayedChords, playbackTimeSeconds);
   const currentChord =
@@ -939,6 +996,17 @@ export function ProjectView() {
       setDraftName(projectQuery.data?.display_name ?? "");
     }
   }, [isRenaming, projectQuery.data?.display_name]);
+
+  useEffect(() => {
+    const previousSourceKey = previousSourceKeyRef.current;
+    if (previousSourceKey && targetDirty) {
+      const delta = semitoneDelta(previousSourceKey, sourceKey);
+      if (delta !== 0) {
+        setTargetKeyState((current) => (current ? transposeKey(current, delta) : current));
+      }
+    }
+    previousSourceKeyRef.current = sourceKey;
+  }, [sourceKey, targetDirty]);
 
   useEffect(() => {
     setInspectorOpen(defaultInspectorOpen);
@@ -1576,11 +1644,6 @@ export function ProjectView() {
                 </div>
               )}
 
-              {chordsQuery.data?.created_at ? (
-                <p className="artifact-meta">
-                  Last chord pass: {formatArtifactTimestamp(chordsQuery.data.created_at)}
-                </p>
-              ) : null}
               {chordJob?.error_message ? (
                 <p className="inline-error">{chordJob.error_message}</p>
               ) : null}
@@ -1797,18 +1860,18 @@ export function ProjectView() {
                     <div className="key-shift__header">
                       <div>
                         <span className="metric-label">Source Key</span>
-                        <strong>{formatKey(sourceKey)}</strong>
+                        <strong>{formatKey(sourceKey, "short", { mode: enharmonicDisplayMode })}</strong>
                         <small className="artifact-meta">
-                          {manualSourceKey
-                            ? "Manual"
+                          {sourceKeyOverride
+                            ? "Corrected"
                             : detectedKey
                               ? "Detected"
-                              : "Set manually"}
+                              : "Default"}
                         </small>
                       </div>
                       <div>
                         <span className="metric-label">Target Key</span>
-                        <strong>{formatKey(targetKey)}</strong>
+                        <strong>{formatKey(targetKey, "short", { mode: enharmonicDisplayMode })}</strong>
                       </div>
                       <div>
                         <span className="metric-label">Capo</span>
@@ -1844,7 +1907,7 @@ export function ProjectView() {
                         >
                           {targetKeyOptions.map((key) => (
                             <option key={key.value} value={key.value}>
-                              {key.label}
+                              {formatKey(key, "short", { mode: enharmonicDisplayMode })}
                             </option>
                           ))}
                         </select>
@@ -1864,36 +1927,6 @@ export function ProjectView() {
                       </button>
                     </div>
 
-                    <details className="details-block details-block--inset">
-                      <summary>Correct source key if detection is wrong</summary>
-                      <div className="controls controls--tight">
-                        <label>
-                          Source Key
-                          <select
-                            aria-label="Current Key"
-                            value={currentKeyValue}
-                            onChange={(event) =>
-                              setManualSourceKey(
-                                event.target.value === "auto"
-                                  ? null
-                                  : deserializeKey(event.target.value),
-                              )
-                            }
-                          >
-                            {detectedKey ? (
-                              <option value="auto">
-                                Use detected key ({formatKey(detectedKey)})
-                              </option>
-                            ) : null}
-                            {MUSICAL_KEYS.map((key) => (
-                              <option key={key.value} value={key.value}>
-                                {key.label}
-                              </option>
-                            ))}
-                          </select>
-                        </label>
-                      </div>
-                    </details>
                   </div>
 
                   {previewMutation.isError ? (
@@ -1924,33 +1957,81 @@ export function ProjectView() {
                     </button>
                   </div>
                   <div className="analysis-grid">
-                    <div>
+                    <div className="analysis-stat">
                       <span className="metric-label">Detected Tuning</span>
                       <strong>
-                        {analysisQuery.data?.estimated_reference_hz?.toFixed(2) ?? "Pending"} Hz
+                        <span className="analysis-stat__value">
+                          {analysisQuery.data?.estimated_reference_hz?.toFixed(2) ?? "Pending"}
+                        </span>
+                        <span className="analysis-stat__unit">Hz</span>
                       </strong>
                     </div>
-                    <div>
+                    <div className="analysis-stat">
                       <span className="metric-label">Offset</span>
                       <strong>
-                        {analysisQuery.data?.tuning_offset_cents?.toFixed(2) ?? "-"} cents
+                        <span className="analysis-stat__value">
+                          {analysisQuery.data?.tuning_offset_cents?.toFixed(2) ?? "-"}
+                        </span>
+                        <span className="analysis-stat__unit">cents</span>
                       </strong>
                     </div>
-                    <div>
+                    <div className="analysis-stat">
                       <span className="metric-label">Estimated Key</span>
                       <strong>
-                        {detectedKey
-                          ? formatKey(detectedKey)
-                          : isAnalysisRunning
-                            ? "Analyzing..."
-                            : "Unknown"}
+                        <span className="analysis-stat__value">
+                          {detectedKey
+                            ? formatKey(detectedKey, "short", { mode: enharmonicDisplayMode })
+                            : isAnalysisRunning
+                              ? "Analyzing..."
+                              : "Unknown"}
+                        </span>
                       </strong>
                     </div>
-                    <div>
+                    <div className="analysis-stat">
                       <span className="metric-label">Confidence</span>
-                      <strong>{analysisQuery.data?.key_confidence?.toFixed(2) ?? "-"}</strong>
+                      <strong>
+                        <span className="analysis-stat__value">
+                          {analysisQuery.data?.key_confidence?.toFixed(2) ?? "-"}
+                        </span>
+                      </strong>
                     </div>
                   </div>
+                  <details className="details-block details-block--inset">
+                    <summary>Correct source key for this project</summary>
+                    <p className="artifact-meta">
+                      {sourceKeyOverride
+                        ? `Using ${formatKey(sourceKeyOverride, "short", { mode: enharmonicDisplayMode })} everywhere keys are derived in this project. Analysis data stays unchanged.`
+                        : "Use this to change the detected key, if you think analysis got it wrong. It updates the project key, and practice mixes."}
+                    </p>
+                    <div className="controls controls--tight">
+                      <label>
+                        Project Source Key
+                        <select
+                          aria-label="Project Source Key"
+                          value={currentKeyValue}
+                          onChange={(event) =>
+                            sourceKeyOverrideMutation.mutate(
+                              event.target.value === "auto" ? null : event.target.value,
+                            )
+                          }
+                          disabled={sourceKeyOverrideMutation.isPending}
+                        >
+                          {detectedKey ? (
+                            <option value="auto">
+                              Use analysis result ({formatKey(detectedKey, "short", { mode: enharmonicDisplayMode })})
+                            </option>
+                          ) : (
+                            <option value={serializeKey(sourceKey)}>No override</option>
+                          )}
+                          {MUSICAL_KEYS.map((key) => (
+                            <option key={key.value} value={key.value}>
+                              {formatKey(key, "short", { mode: enharmonicDisplayMode })}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                    </div>
+                  </details>
                 </div>
 
                 <div className="subpanel subpanel--compact">
@@ -1977,21 +2058,31 @@ export function ProjectView() {
                     <h3>Project Details</h3>
                   </div>
                   <dl className="meta-grid">
-                    <div>
+                    <div className="meta-stat">
                       <dt>Duration</dt>
-                      <dd>{projectQuery.data?.duration_seconds?.toFixed(2) ?? "Unknown"} s</dd>
+                      <dd>
+                        <span className="meta-stat__value">
+                          {projectQuery.data?.duration_seconds?.toFixed(2) ?? "Unknown"}
+                        </span>
+                        <span className="meta-stat__unit">s</span>
+                      </dd>
                     </div>
-                    <div>
+                    <div className="meta-stat">
                       <dt>Sample Rate</dt>
-                      <dd>{projectQuery.data?.sample_rate ?? "Unknown"} Hz</dd>
+                      <dd>
+                        <span className="meta-stat__value">
+                          {projectQuery.data?.sample_rate ?? "Unknown"}
+                        </span>
+                        <span className="meta-stat__unit">Hz</span>
+                      </dd>
                     </div>
-                    <div>
+                    <div className="meta-stat">
                       <dt>Channels</dt>
-                      <dd>{projectQuery.data?.channels ?? "Unknown"}</dd>
-                    </div>
-                    <div>
-                      <dt>Selected Source</dt>
-                      <dd>{selectedPrimaryArtifact ? fileNameFromPath(selectedPrimaryArtifact.path) : "-"}</dd>
+                      <dd>
+                        <span className="meta-stat__value">
+                          {projectQuery.data?.channels ?? "Unknown"}
+                        </span>
+                      </dd>
                     </div>
                   </dl>
 

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { api } from "../../lib/api";
 import {
   usePreferences,
+  type EnharmonicDisplayMode,
   type InformationDensity,
   type LayoutDensity,
   type MetadataRevealMode,
@@ -30,6 +31,14 @@ function layoutDensityLabel(value: LayoutDensity) {
   return value === "compact" ? "Compact" : "Comfortable";
 }
 
+function enharmonicDisplayLabel(value: EnharmonicDisplayMode) {
+  if (value === "sharps") return "Prefer sharps";
+  if (value === "flats") return "Prefer flats";
+  if (value === "neutral") return "Neutral mixed fallback";
+  if (value === "dual") return "Dual labels";
+  return "Auto by key";
+}
+
 function metadataRevealLabel(value: MetadataRevealMode) {
   return value === "hover" ? "Hover" : "Expand";
 }
@@ -39,12 +48,14 @@ export function SettingsView() {
   const {
     informationDensity,
     layoutDensity,
+    enharmonicDisplayMode,
     helperTextVisible,
     defaultInspectorOpen,
     defaultSourcesRailCollapsed,
     metadataRevealMode,
     setInformationDensity,
     setLayoutDensity,
+    setEnharmonicDisplayMode,
     setHelperTextVisible,
     setDefaultInspectorOpen,
     setDefaultSourcesRailCollapsed,
@@ -130,6 +141,21 @@ export function SettingsView() {
                 <option value="compact">Compact</option>
               </select>
             </label>
+
+            <label>
+              Enharmonic Display
+              <select
+                aria-label="Enharmonic Display"
+                value={enharmonicDisplayMode}
+                onChange={(event) => setEnharmonicDisplayMode(event.target.value as EnharmonicDisplayMode)}
+              >
+                <option value="auto">Auto by key</option>
+                <option value="sharps">Prefer sharps</option>
+                <option value="flats">Prefer flats</option>
+                <option value="neutral">Neutral mixed fallback</option>
+                <option value="dual">Dual labels</option>
+              </select>
+            </label>
           </div>
 
           <dl className="meta-grid">
@@ -148,6 +174,10 @@ export function SettingsView() {
             <div>
               <dt>Layout Density</dt>
               <dd>{layoutDensityLabel(layoutDensity)}</dd>
+            </div>
+            <div>
+              <dt>Enharmonic Display</dt>
+              <dd>{enharmonicDisplayLabel(enharmonicDisplayMode)}</dd>
             </div>
           </dl>
 

--- a/apps/desktop/src/lib/music.test.ts
+++ b/apps/desktop/src/lib/music.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatChordLabel,
+  formatKey,
+  formatPitchClass,
+  getEnharmonicContext,
+  type MusicalKey,
+} from "./music";
+
+describe("enharmonic formatting", () => {
+  it("uses neutral fallback when context is unknown", () => {
+    expect(formatPitchClass(1)).toBe("C#");
+    expect(formatPitchClass(3)).toBe("Eb");
+    expect(formatPitchClass(8)).toBe("Ab");
+    expect(formatPitchClass(10)).toBe("Bb");
+  });
+
+  it("uses sharp spellings in sharp key contexts", () => {
+    const sharpKey: MusicalKey = { pitchClass: 7, mode: "major" };
+    expect(getEnharmonicContext(sharpKey).family).toBe("sharp");
+    expect(formatPitchClass(6, { activeKey: sharpKey })).toBe("F#");
+    expect(formatPitchClass(10, { activeKey: sharpKey })).toBe("A#");
+  });
+
+  it("uses flat spellings in flat key contexts", () => {
+    const flatKey: MusicalKey = { pitchClass: 3, mode: "major" };
+    expect(getEnharmonicContext(flatKey).family).toBe("flat");
+    expect(formatPitchClass(8, { activeKey: flatKey })).toBe("Ab");
+    expect(formatPitchClass(10, { activeKey: flatKey })).toBe("Bb");
+  });
+
+  it("formats keys canonically in auto mode", () => {
+    expect(formatKey({ pitchClass: 3, mode: "minor" })).toBe("Ebm");
+    expect(formatKey({ pitchClass: 1, mode: "major" })).toBe("Db");
+    expect(formatKey({ pitchClass: 9, mode: "minor" })).toBe("Am");
+  });
+
+  it("supports explicit spelling overrides", () => {
+    expect(formatKey({ pitchClass: 3, mode: "minor" }, "short", { mode: "sharps" })).toBe("D#m");
+    expect(formatKey({ pitchClass: 1, mode: "major" }, "short", { mode: "flats" })).toBe("Db");
+    expect(formatPitchClass(8, { mode: "neutral" })).toBe("Ab");
+    expect(formatChordLabel(10, "major", { mode: "dual" })).toBe("A#/Bb");
+  });
+});

--- a/apps/desktop/src/lib/music.ts
+++ b/apps/desktop/src/lib/music.ts
@@ -1,9 +1,22 @@
 export type KeyMode = "major" | "minor";
 export type ChordQuality = "major" | "minor";
+export type EnharmonicDisplayMode = "auto" | "sharps" | "flats" | "neutral" | "dual";
 
 export type MusicalKey = {
   pitchClass: number;
   mode: KeyMode;
+};
+
+export type PitchFormatOptions = {
+  activeKey?: MusicalKey | null;
+  mode?: EnharmonicDisplayMode;
+};
+
+type AccidentalFamily = "sharp" | "flat" | "neutral";
+
+export type EnharmonicContext = {
+  mode: EnharmonicDisplayMode;
+  family: AccidentalFamily;
 };
 
 const ENHARMONIC_ALIASES: Record<string, number> = {
@@ -30,7 +43,10 @@ const ENHARMONIC_ALIASES: Record<string, number> = {
   Cb: 11,
 };
 
-const DISPLAY_PITCH_CLASSES = [
+const SHARP_PITCH_CLASSES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"] as const;
+const FLAT_PITCH_CLASSES = ["C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"] as const;
+const NEUTRAL_PITCH_CLASSES = ["C", "C#", "D", "Eb", "E", "F", "F#", "G", "Ab", "A", "Bb", "B"] as const;
+const DUAL_PITCH_CLASSES = [
   "C",
   "C#/Db",
   "D",
@@ -44,6 +60,11 @@ const DISPLAY_PITCH_CLASSES = [
   "A#/Bb",
   "B",
 ] as const;
+
+const AUTO_KEY_FAMILIES: Record<KeyMode, readonly AccidentalFamily[]> = {
+  major: ["neutral", "flat", "sharp", "flat", "sharp", "flat", "sharp", "sharp", "flat", "sharp", "flat", "sharp"],
+  minor: ["flat", "sharp", "flat", "flat", "sharp", "flat", "sharp", "flat", "sharp", "neutral", "flat", "sharp"],
+};
 
 const CHROMATIC_PITCH_CLASSES = Array.from({ length: 12 }, (_, pitchClass) => pitchClass);
 
@@ -94,6 +115,16 @@ export function parseKey(value: string | null | undefined): MusicalKey | null {
   };
 }
 
+export function parseStoredKey(value: string | null | undefined): MusicalKey | null {
+  if (!value) {
+    return null;
+  }
+  if (value.includes(":")) {
+    return deserializeKey(value);
+  }
+  return parseKey(value);
+}
+
 export function serializeKey(key: MusicalKey): string {
   return `${key.pitchClass}:${key.mode}`;
 }
@@ -110,21 +141,129 @@ export function deserializeKey(value: string): MusicalKey {
   };
 }
 
-export function formatKey(key: MusicalKey, format: "short" | "long" = "short"): string {
-  const noteName = formatPitchClass(key.pitchClass);
+export function getEnharmonicContext(
+  activeKey: MusicalKey | null | undefined,
+  mode: EnharmonicDisplayMode = "auto",
+): EnharmonicContext {
+  if (mode === "sharps") {
+    return { mode, family: "sharp" };
+  }
+  if (mode === "flats") {
+    return { mode, family: "flat" };
+  }
+  if (mode === "neutral" || mode === "dual") {
+    return { mode, family: "neutral" };
+  }
+  if (!activeKey) {
+    return { mode, family: "neutral" };
+  }
+  return {
+    mode,
+    family: AUTO_KEY_FAMILIES[activeKey.mode][normalizePitchClass(activeKey.pitchClass)] ?? "neutral",
+  };
+}
+
+export function formatKey(
+  key: MusicalKey,
+  format: "short" | "long" = "short",
+  options: PitchFormatOptions = {},
+): string {
+  const noteName =
+    options.mode === "dual"
+      ? formatDualPitchClass(key.pitchClass, format === "short" && key.mode === "minor" ? "m" : "")
+      : formatPitchClass(key.pitchClass, {
+          activeKey: options.activeKey ?? key,
+          mode: options.mode,
+        });
   if (format === "long") {
+    if (options.mode === "dual") {
+      const [sharpRoot, flatRoot] = noteName.split("/");
+      if (!flatRoot) {
+        return `${noteName} ${key.mode}`;
+      }
+      return `${sharpRoot} ${key.mode} / ${flatRoot} ${key.mode}`;
+    }
     return `${noteName} ${key.mode}`;
+  }
+  if (options.mode === "dual") {
+    return noteName;
   }
   return key.mode === "minor" ? `${noteName}m` : noteName;
 }
 
-export function formatPitchClass(pitchClass: number): string {
-  return DISPLAY_PITCH_CLASSES[((pitchClass % 12) + 12) % 12] ?? DISPLAY_PITCH_CLASSES[0];
+export function formatPitchClass(pitchClass: number, options: PitchFormatOptions = {}): string {
+  const normalizedPitchClass = normalizePitchClass(pitchClass);
+  const context = getEnharmonicContext(options.activeKey, options.mode);
+  if (context.mode === "dual") {
+    return DUAL_PITCH_CLASSES[normalizedPitchClass] ?? DUAL_PITCH_CLASSES[0];
+  }
+  if (context.family === "sharp") {
+    return SHARP_PITCH_CLASSES[normalizedPitchClass] ?? SHARP_PITCH_CLASSES[0];
+  }
+  if (context.family === "flat") {
+    return FLAT_PITCH_CLASSES[normalizedPitchClass] ?? FLAT_PITCH_CLASSES[0];
+  }
+  return NEUTRAL_PITCH_CLASSES[normalizedPitchClass] ?? NEUTRAL_PITCH_CLASSES[0];
 }
 
-export function formatChordLabel(pitchClass: number, quality: ChordQuality): string {
-  const noteName = formatPitchClass(pitchClass);
+export function formatAlternatePitchClass(pitchClass: number, options: PitchFormatOptions = {}): string | null {
+  const normalizedPitchClass = normalizePitchClass(pitchClass);
+  const sharpLabel = SHARP_PITCH_CLASSES[normalizedPitchClass];
+  const flatLabel = FLAT_PITCH_CLASSES[normalizedPitchClass];
+  if (sharpLabel === flatLabel || options.mode === "dual") {
+    return null;
+  }
+  const primaryLabel = formatPitchClass(normalizedPitchClass, options);
+  return primaryLabel === sharpLabel ? flatLabel : sharpLabel;
+}
+
+export function formatChordRoot(pitchClass: number, options: PitchFormatOptions = {}): string {
+  return formatPitchClass(pitchClass, options);
+}
+
+export function formatChordLabel(
+  pitchClass: number,
+  quality: ChordQuality,
+  options: PitchFormatOptions = {},
+): string {
+  const noteName =
+    options.mode === "dual"
+      ? formatDualPitchClass(pitchClass, quality === "minor" ? "m" : "")
+      : formatChordRoot(pitchClass, options);
+  if (options.mode === "dual") {
+    return noteName;
+  }
   return quality === "minor" ? `${noteName}m` : noteName;
+}
+
+export function formatAlternateKey(
+  key: MusicalKey,
+  format: "short" | "long" = "short",
+  options: PitchFormatOptions = {},
+): string | null {
+  const alternateRoot = formatAlternatePitchClass(key.pitchClass, {
+    activeKey: options.activeKey ?? key,
+    mode: options.mode,
+  });
+  if (!alternateRoot) {
+    return null;
+  }
+  if (format === "long") {
+    return `${alternateRoot} ${key.mode}`;
+  }
+  return key.mode === "minor" ? `${alternateRoot}m` : alternateRoot;
+}
+
+export function formatAlternateChordLabel(
+  pitchClass: number,
+  quality: ChordQuality,
+  options: PitchFormatOptions = {},
+): string | null {
+  const alternateRoot = formatAlternatePitchClass(pitchClass, options);
+  if (!alternateRoot) {
+    return null;
+  }
+  return quality === "minor" ? `${alternateRoot}m` : alternateRoot;
 }
 
 export function transposePitchClass(pitchClass: number, semitones: number): number {
@@ -147,4 +286,18 @@ export function semitoneDelta(source: MusicalKey, target: MusicalKey): number {
 function normalizeNoteName(noteName: string): string {
   const [letter, accidental = ""] = noteName.trim();
   return `${letter.toUpperCase()}${accidental}`;
+}
+
+function normalizePitchClass(pitchClass: number): number {
+  return ((pitchClass % 12) + 12) % 12;
+}
+
+function formatDualPitchClass(pitchClass: number, suffix = ""): string {
+  const normalizedPitchClass = normalizePitchClass(pitchClass);
+  const sharpLabel = SHARP_PITCH_CLASSES[normalizedPitchClass] ?? SHARP_PITCH_CLASSES[0];
+  const flatLabel = FLAT_PITCH_CLASSES[normalizedPitchClass] ?? FLAT_PITCH_CLASSES[0];
+  if (sharpLabel === flatLabel) {
+    return `${sharpLabel}${suffix}`;
+  }
+  return `${sharpLabel}${suffix}/${flatLabel}${suffix}`;
 }

--- a/apps/desktop/src/lib/preferences.tsx
+++ b/apps/desktop/src/lib/preferences.tsx
@@ -7,21 +7,27 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import type { EnharmonicDisplayMode } from "./music";
 
 export type InformationDensity = "minimal" | "balanced" | "detailed";
 export type LayoutDensity = "compact" | "comfortable";
 export type MetadataRevealMode = "hover" | "expand";
+export type { EnharmonicDisplayMode };
 
 export type UiPreferences = {
   informationDensity: InformationDensity;
   layoutDensity: LayoutDensity;
+  enharmonicDisplayMode: EnharmonicDisplayMode;
   helperTextVisible: boolean;
   defaultInspectorOpen: boolean;
   defaultSourcesRailCollapsed: boolean;
   metadataRevealMode: MetadataRevealMode;
 };
 
-export type AppearancePreferences = Pick<UiPreferences, "informationDensity" | "layoutDensity">;
+export type AppearancePreferences = Pick<
+  UiPreferences,
+  "informationDensity" | "layoutDensity" | "enharmonicDisplayMode"
+>;
 export type VisibilityPreferences = Pick<
   UiPreferences,
   "helperTextVisible" | "defaultInspectorOpen" | "defaultSourcesRailCollapsed" | "metadataRevealMode"
@@ -30,6 +36,7 @@ export type VisibilityPreferences = Pick<
 type PreferencesContextValue = UiPreferences & {
   setInformationDensity: (value: InformationDensity) => void;
   setLayoutDensity: (value: LayoutDensity) => void;
+  setEnharmonicDisplayMode: (value: EnharmonicDisplayMode) => void;
   setHelperTextVisible: (value: boolean) => void;
   setDefaultInspectorOpen: (value: boolean) => void;
   setDefaultSourcesRailCollapsed: (value: boolean) => void;
@@ -44,12 +51,13 @@ const STORAGE_KEY = "tuneforge.ui-preferences";
 export const DEFAULT_APPEARANCE_PREFERENCES: AppearancePreferences = {
   informationDensity: "minimal",
   layoutDensity: "compact",
+  enharmonicDisplayMode: "auto",
 };
 
 export const DEFAULT_VISIBILITY_PREFERENCES: VisibilityPreferences = {
   helperTextVisible: false,
   defaultInspectorOpen: false,
-  defaultSourcesRailCollapsed: true,
+  defaultSourcesRailCollapsed: false,
   metadataRevealMode: "expand",
 };
 
@@ -66,6 +74,10 @@ function isInformationDensity(value: unknown): value is InformationDensity {
 
 function isLayoutDensity(value: unknown): value is LayoutDensity {
   return value === "compact" || value === "comfortable";
+}
+
+function isEnharmonicDisplayMode(value: unknown): value is EnharmonicDisplayMode {
+  return value === "auto" || value === "sharps" || value === "flats" || value === "neutral" || value === "dual";
 }
 
 function isMetadataRevealMode(value: unknown): value is MetadataRevealMode {
@@ -85,6 +97,9 @@ function normalizePreferences(value: unknown): UiPreferences {
     layoutDensity: isLayoutDensity(candidate.layoutDensity)
       ? candidate.layoutDensity
       : DEFAULT_PREFERENCES.layoutDensity,
+    enharmonicDisplayMode: isEnharmonicDisplayMode(candidate.enharmonicDisplayMode)
+      ? candidate.enharmonicDisplayMode
+      : DEFAULT_PREFERENCES.enharmonicDisplayMode,
     helperTextVisible:
       typeof candidate.helperTextVisible === "boolean"
         ? candidate.helperTextVisible
@@ -148,6 +163,9 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
       },
       setLayoutDensity: (layoutDensity) => {
         setPreferences((current) => mergePreferences(current, { layoutDensity }));
+      },
+      setEnharmonicDisplayMode: (enharmonicDisplayMode) => {
+        setPreferences((current) => mergePreferences(current, { enharmonicDisplayMode }));
       },
       setHelperTextVisible: (helperTextVisible) => {
         setPreferences((current) => mergePreferences(current, { helperTextVisible }));

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -718,6 +718,76 @@ a {
   gap: 1rem;
 }
 
+.analysis-grid {
+  gap: 0.85rem;
+}
+
+.analysis-stat {
+  border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+  border-radius: 16px;
+  padding: 0.8rem 0.9rem;
+  background: color-mix(in srgb, var(--panel) 72%, var(--panel-strong) 28%);
+}
+
+.analysis-stat .metric-label {
+  display: block;
+  margin-bottom: 0.45rem;
+}
+
+.analysis-stat strong {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  flex-wrap: nowrap;
+  font-size: 1.18rem;
+  line-height: 1.1;
+  white-space: nowrap;
+}
+
+.analysis-stat__value {
+  color: var(--text);
+}
+
+.analysis-stat__unit {
+  color: var(--muted);
+  font-size: 0.84rem;
+  font-weight: 600;
+}
+
+.meta-stat {
+  border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+  border-radius: 16px;
+  padding: 0.8rem 0.9rem;
+  background: color-mix(in srgb, var(--panel) 72%, var(--panel-strong) 28%);
+}
+
+.meta-stat dt {
+  display: block;
+  margin-bottom: 0.45rem;
+}
+
+.meta-stat dd {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  flex-wrap: nowrap;
+  margin: 0;
+  font-size: 1.18rem;
+  line-height: 1.18;
+  color: var(--text);
+  white-space: nowrap;
+}
+
+.meta-stat__value {
+  color: var(--text);
+}
+
+.meta-stat__unit {
+  color: var(--muted);
+  font-size: 0.84rem;
+  font-weight: 600;
+}
+
 .details-grid--single-column {
   grid-template-columns: 1fr;
 }

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -548,6 +548,8 @@ export interface components {
             id: string;
             /** Display Name */
             display_name: string;
+            /** Source Key Override */
+            source_key_override: string | null;
             /** Source Path */
             source_path: string;
             /** Imported Path */
@@ -572,7 +574,9 @@ export interface components {
         /** ProjectUpdateRequest */
         ProjectUpdateRequest: {
             /** Display Name */
-            display_name: string;
+            display_name?: string | null;
+            /** Source Key Override */
+            source_key_override?: string | null;
         };
         /** ProjectsResponse */
         ProjectsResponse: {


### PR DESCRIPTION
## Summary
- add contextual enharmonic display modes and apply them across project key and chord surfaces
- persist a project-level source key override so users can correct detected keys without rerunning jobs
- auto-run analysis and chords on import, refine inspector analysis/project detail cards, and improve forced chord refresh behavior
- reduce backend test noise from benign short-clip librosa FFT warnings and extend backend and desktop coverage

## Testing
- pnpm contracts:generate
- uv run --python 3.11 pytest tests/test_projects.py -q
- uv run --python 3.11 pytest tests/test_chord_flow.py -q
- uv run --python 3.11 ruff check app/engines/analysis.py app/engines/chords.py
- pnpm --filter @tuneforge/desktop test -- --run src/App.test.tsx src/lib/music.test.ts
- pnpm --filter @tuneforge/desktop typecheck
- pnpm --filter @tuneforge/desktop lint
- Lint still reports the pre-existing react-hooks/exhaustive-deps warnings in apps/desktop/src/features/projects/playback.tsx.
