### PR TITLE
feat(desktop): polish inspector playback controls and mix builder UI

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -808,8 +808,10 @@ describe("Desktop app flows", () => {
     expect(
       within(screen.getByText("Source Key", { selector: "span" }).closest("div") as HTMLElement).getByText("Ebm"),
     ).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "Bb" })).toBeInTheDocument();
-    expect(screen.queryByRole("option", { name: "D#/Ebm" })).not.toBeInTheDocument();
+    await user.click(screen.getByLabelText("Target Key"));
+    const targetKeyList = screen.getByRole("listbox", { name: "Target key options" });
+    expect(within(targetKeyList).getAllByText("Bbm").length).toBeGreaterThan(0);
+    expect(within(targetKeyList).queryByText("D#/Ebm")).not.toBeInTheDocument();
   });
 
   it("applies enharmonic display overrides from settings", async () => {
@@ -854,9 +856,10 @@ describe("Desktop app flows", () => {
       within(sourceKeyCard).getByText("D#m"),
     ).toBeInTheDocument();
     expect(within(sourceKeyCard).queryByText("Ebm")).not.toBeInTheDocument();
-    const targetKeySelect = screen.getByLabelText("Target Key") as HTMLSelectElement;
-    expect(Array.from(targetKeySelect.options).some((option) => option.text === "D#m")).toBe(true);
-    expect(Array.from(targetKeySelect.options).some((option) => option.text === "Ebm")).toBe(false);
+    await user.click(screen.getByLabelText("Target Key"));
+    const targetKeyList = screen.getByRole("listbox", { name: "Target key options" });
+    expect(within(targetKeyList).getAllByText("D#m").length).toBeGreaterThan(0);
+    expect(within(targetKeyList).queryByText("Ebm")).not.toBeInTheDocument();
   });
 
   it("preserves the relative target shift when the detected source key is corrected", async () => {
@@ -904,6 +907,35 @@ describe("Desktop app flows", () => {
       expect.objectContaining({
         output_format: "wav",
         transpose: { semitones: 1 },
+      }),
+    );
+  });
+
+  it("caps target key stepping at one octave in either direction", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Show Inspector" }));
+
+    const raiseTargetKeyButton = screen.getByLabelText("Raise target key");
+    for (let index = 0; index < 16; index += 1) {
+      await user.click(raiseTargetKeyButton);
+    }
+
+    expect(raiseTargetKeyButton).toBeDisabled();
+    const targetKeyCard = screen
+      .getAllByText("Target Key", { selector: "span" })[0]
+      ?.closest(".key-shift__card") as HTMLElement;
+    expect(within(targetKeyCard).getByText("Shift +12 semitones")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Create Mix" }));
+
+    expect(mockCreatePreview).toHaveBeenCalledWith(
+      "proj_123",
+      expect.objectContaining({
+        output_format: "wav",
+        transpose: { semitones: 12 },
       }),
     );
   });

--- a/apps/desktop/src/features/projects/ProjectView.tsx
+++ b/apps/desktop/src/features/projects/ProjectView.tsx
@@ -16,12 +16,10 @@ import {
   DEFAULT_KEY,
   type EnharmonicDisplayMode,
   MUSICAL_KEYS,
-  deserializeKey,
   formatChordLabel,
   formatKey,
   parseKey,
   parseStoredKey,
-  semitoneDelta,
   serializeKey,
   transposePitchClass,
   transposeKey,
@@ -86,6 +84,28 @@ function fileNameFromPath(path: string) {
 function formatSemitoneShift(semitones: number) {
   return `Shift ${semitones > 0 ? "+" : ""}${semitones} semitone${Math.abs(semitones) === 1 ? "" : "s"}`;
 }
+
+const MIN_TARGET_TRANSPOSE = -12;
+const MAX_TARGET_TRANSPOSE = 12;
+
+function clampTargetTranspose(semitones: number) {
+  return Math.min(MAX_TARGET_TRANSPOSE, Math.max(MIN_TARGET_TRANSPOSE, semitones));
+}
+
+function formatTargetSelectionSummary(semitones: number) {
+  if (semitones === 0) {
+    return "Original";
+  }
+  if (Math.abs(semitones) === 12) {
+    return semitones > 0 ? "1 octave higher" : "1 octave lower";
+  }
+  return semitones > 0 ? "Higher pitch" : "Lower pitch";
+}
+
+type TargetShiftOption = {
+  semitones: number;
+  label: string;
+};
 
 function formatArtifactTimestamp(createdAt: string) {
   return formatLocalDateTime(createdAt, {
@@ -444,8 +464,9 @@ export function ProjectView() {
   const pendingPreviewSelection = useRef<{ previousLatestPreviewArtifactId: string | null } | null>(
     null,
   );
-  const previousSourceKeyRef = useRef<MusicalKey | null>(null);
   const persistedStemSourceArtifactId = useRef<string | null>(null);
+  const targetSelectorRef = useRef<HTMLDivElement | null>(null);
+  const targetOptionRefs = useRef<Record<number, HTMLButtonElement | null>>({});
   const [retuneMode, setRetuneMode] = useState<"off" | "reference" | "cents">("off");
   const [referenceHz, setReferenceHz] = useState("440");
   const [centsOffset, setCentsOffset] = useState("0");
@@ -453,8 +474,8 @@ export function ProjectView() {
     backward: 0,
     forward: 0,
   });
-  const [targetKeyState, setTargetKeyState] = useState<MusicalKey | null>(null);
-  const [targetDirty, setTargetDirty] = useState(false);
+  const [targetTransposeSemitones, setTargetTransposeSemitones] = useState(0);
+  const [targetSelectorOpen, setTargetSelectorOpen] = useState(false);
   const [selectedArtifactId, setSelectedArtifactId] = useState<string | null>(null);
   const [selectedPrimaryArtifactId, setSelectedPrimaryArtifactId] = useState<string | null>(null);
   const [hydratedProjectId, setHydratedProjectId] = useState<string | null>(null);
@@ -775,9 +796,8 @@ export function ProjectView() {
   const sourceKeyOverride = parseStoredKey(projectQuery.data?.source_key_override);
   const sourceKeyBasis = sourceKeyOverride ?? detectedKey ?? null;
   const sourceKey = sourceKeyBasis ?? DEFAULT_KEY;
-  const targetKey = targetDirty ? targetKeyState ?? sourceKey : sourceKey;
-  const transposeSemitones = semitoneDelta(sourceKey, targetKey);
-  const targetKeyOptions = MUSICAL_KEYS.filter((key) => key.mode === sourceKey.mode);
+  const transposeSemitones = clampTargetTranspose(targetTransposeSemitones);
+  const targetKey = transposeKey(sourceKey, transposeSemitones);
   const requestedRetune = buildRequestedRetune(retuneMode, referenceHz, centsOffset);
   const hasTransformChange = retuneMode !== "off" || transposeSemitones !== 0;
   const previewMatchesCurrentSettings = matchesPreviewSettings(
@@ -863,7 +883,44 @@ export function ProjectView() {
       : `Chord labels follow the selected playback (${formatSemitoneShift(
           chordTransposeSemitones,
         ).toLowerCase()}).`;
-  const capoSummary = transposeSemitones > 0 ? `${transposeSemitones}` : "Off";
+  const sourceKeyStatus = sourceKeyOverride ? "Corrected" : detectedKey ? "Detected" : "Default";
+  const targetShiftSummary =
+    transposeSemitones === 0 ? "Original key" : formatSemitoneShift(transposeSemitones);
+  const targetSelectionSummary = formatTargetSelectionSummary(transposeSemitones);
+  const lowerTargetPreview =
+    transposeSemitones > MIN_TARGET_TRANSPOSE
+      ? formatKey(transposeKey(sourceKey, transposeSemitones - 1), "short", {
+          mode: enharmonicDisplayMode,
+        })
+      : null;
+  const higherTargetPreview =
+    transposeSemitones < MAX_TARGET_TRANSPOSE
+      ? formatKey(transposeKey(sourceKey, transposeSemitones + 1), "short", {
+          mode: enharmonicDisplayMode,
+        })
+      : null;
+  const targetShiftOptions = useMemo<TargetShiftOption[]>(
+    () =>
+      Array.from(
+        { length: MAX_TARGET_TRANSPOSE - MIN_TARGET_TRANSPOSE + 1 },
+        (_, index) => MIN_TARGET_TRANSPOSE + index,
+      ).map((semitones) => {
+        const key = transposeKey(sourceKey, semitones);
+        return {
+          semitones,
+          label: formatKey(key, "short", { mode: enharmonicDisplayMode }),
+        };
+      }),
+    [enharmonicDisplayMode, sourceKey],
+  );
+  const lowerTargetShiftOptions = useMemo(
+    () => targetShiftOptions.filter((option) => option.semitones < 0).sort((a, b) => b.semitones - a.semitones),
+    [targetShiftOptions],
+  );
+  const higherTargetShiftOptions = useMemo(
+    () => targetShiftOptions.filter((option) => option.semitones > 0).sort((a, b) => b.semitones - a.semitones),
+    [targetShiftOptions],
+  );
 
   const soloedStemIds = visibleStemArtifacts
     .filter((artifact) => stemControls[artifact.id]?.solo)
@@ -998,15 +1055,39 @@ export function ProjectView() {
   }, [isRenaming, projectQuery.data?.display_name]);
 
   useEffect(() => {
-    const previousSourceKey = previousSourceKeyRef.current;
-    if (previousSourceKey && targetDirty) {
-      const delta = semitoneDelta(previousSourceKey, sourceKey);
-      if (delta !== 0) {
-        setTargetKeyState((current) => (current ? transposeKey(current, delta) : current));
+    if (!targetSelectorOpen) {
+      return;
+    }
+
+    const activeOption = targetOptionRefs.current[transposeSemitones];
+    activeOption?.scrollIntoView?.({ block: "center" });
+  }, [targetSelectorOpen, transposeSemitones]);
+
+  useEffect(() => {
+    if (!targetSelectorOpen) {
+      return;
+    }
+
+    function handlePointerDown(event: PointerEvent) {
+      if (!targetSelectorRef.current?.contains(event.target as Node)) {
+        setTargetSelectorOpen(false);
       }
     }
-    previousSourceKeyRef.current = sourceKey;
-  }, [sourceKey, targetDirty]);
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setTargetSelectorOpen(false);
+      }
+    }
+
+    window.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [targetSelectorOpen]);
 
   useEffect(() => {
     setInspectorOpen(defaultInspectorOpen);
@@ -1813,120 +1894,252 @@ export function ProjectView() {
                   <div className="subpanel__header">
                     <h3>Mix Builder</h3>
                   </div>
-                  <div className="controls">
-                    <label>
-                      Retune
-                      <select
-                        aria-label="Retune"
-                        value={retuneMode}
-                        onChange={(event) =>
-                          setRetuneMode(event.target.value as "off" | "reference" | "cents")
-                        }
-                      >
-                        <option value="off">Off</option>
-                        <option value="reference">Target Reference Hz</option>
-                        <option value="cents">Direct Cents Offset</option>
-                      </select>
-                    </label>
-
-                    {retuneMode === "reference" ? (
-                      <label>
-                        Target Reference Hz
-                        <input
-                          aria-label="Target Reference Hz"
-                          value={referenceHz}
-                          onChange={(event) => setReferenceHz(event.target.value)}
-                          type="number"
-                          step="0.1"
-                        />
-                      </label>
-                    ) : null}
-
-                    {retuneMode === "cents" ? (
-                      <label>
-                        Cents Offset
-                        <input
-                          aria-label="Cents Offset"
-                          value={centsOffset}
-                          onChange={(event) => setCentsOffset(event.target.value)}
-                          type="number"
-                          step="0.1"
-                        />
-                      </label>
-                    ) : null}
-                  </div>
-
-                  <div className="key-shift key-shift--compact">
-                    <div className="key-shift__header">
-                      <div>
-                        <span className="metric-label">Source Key</span>
-                        <strong>{formatKey(sourceKey, "short", { mode: enharmonicDisplayMode })}</strong>
-                        <small className="artifact-meta">
-                          {sourceKeyOverride
-                            ? "Corrected"
-                            : detectedKey
-                              ? "Detected"
-                              : "Default"}
-                        </small>
+                  <div className="mix-builder">
+                    <div className="mix-builder__retune">
+                      <div className="mix-builder__section-head">
+                        <span className="metric-label">Retune</span>
+                        <span className="artifact-meta">
+                          {retuneMode === "off" ? "No pitch retune" : tuningSummary}
+                        </span>
                       </div>
-                      <div>
-                        <span className="metric-label">Target Key</span>
-                        <strong>{formatKey(targetKey, "short", { mode: enharmonicDisplayMode })}</strong>
+                      <div className="mix-builder__mode-toggle" role="group" aria-label="Retune">
+                        {[
+                          { value: "off", label: "Off" },
+                          { value: "reference", label: "Reference Hz" },
+                          { value: "cents", label: "Cents Offset" },
+                        ].map((modeOption) => (
+                          <button
+                            key={modeOption.value}
+                            className="button button--small mix-builder__mode-button"
+                            aria-pressed={retuneMode === modeOption.value}
+                            onClick={() =>
+                              setRetuneMode(modeOption.value as "off" | "reference" | "cents")
+                            }
+                            type="button"
+                          >
+                            {modeOption.label}
+                          </button>
+                        ))}
                       </div>
-                      <div>
-                        <span className="metric-label">Capo</span>
-                        <strong>{capoSummary}</strong>
-                        <small className="artifact-meta">Practice cue</small>
-                      </div>
-                      <span className="key-shift__meta">{formatSemitoneShift(transposeSemitones)}</span>
+
+                      {retuneMode === "reference" ? (
+                        <label className="mix-builder__retune-field">
+                          <span>Target Reference Hz</span>
+                          <input
+                            aria-label="Target Reference Hz"
+                            value={referenceHz}
+                            onChange={(event) => setReferenceHz(event.target.value)}
+                            type="number"
+                            step="0.1"
+                          />
+                        </label>
+                      ) : null}
+
+                      {retuneMode === "cents" ? (
+                        <label className="mix-builder__retune-field">
+                          <span>Cents Offset</span>
+                          <input
+                            aria-label="Cents Offset"
+                            value={centsOffset}
+                            onChange={(event) => setCentsOffset(event.target.value)}
+                            type="number"
+                            step="0.1"
+                          />
+                        </label>
+                      ) : null}
                     </div>
 
-                    <div className="key-stepper">
-                      <button
-                        className="button"
-                        aria-label="Lower target key"
-                        onClick={() => {
-                          setTargetDirty(true);
-                          setTargetKeyState((current) =>
-                            transposeKey(current ?? sourceKey, -1),
-                          );
-                        }}
-                        type="button"
-                      >
-                        -
-                      </button>
-                      <label className="key-stepper__value">
-                        <span className="key-stepper__label">Target Key</span>
-                        <select
-                          aria-label="Target Key"
-                          value={serializeKey(targetKey)}
-                          onChange={(event) => {
-                            setTargetDirty(true);
-                            setTargetKeyState(deserializeKey(event.target.value));
+                    <div className="key-shift key-shift--compact">
+                      <div className="mix-builder__section-head">
+                        <span className="metric-label">Key Center</span>
+                        <span className="artifact-meta">{targetShiftSummary}</span>
+                      </div>
+                      <div className="key-shift__header">
+                        <div className="key-shift__card">
+                          <div>
+                            <span className="metric-label">Source Key</span>
+                            <strong>{formatKey(sourceKey, "short", { mode: enharmonicDisplayMode })}</strong>
+                          </div>
+                          <div className="key-shift__chips">
+                            <span className="key-shift__chip">{sourceKeyStatus}</span>
+                          </div>
+                        </div>
+                        <div className="key-shift__card key-shift__card--target">
+                          <div>
+                            <span className="metric-label">Target Key</span>
+                            <strong>{formatKey(targetKey, "short", { mode: enharmonicDisplayMode })}</strong>
+                          </div>
+                          <div className="key-shift__chips">
+                            <span className="key-shift__chip key-shift__chip--active">
+                              {targetShiftSummary}
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className="key-stepper__heading">
+                        <span className="metric-label">Target Selection</span>
+                        {showSupportingCopy ? (
+                          <span className="artifact-meta">
+                            Step through all shifts from 1 octave down to 1 octave up.
+                          </span>
+                        ) : null}
+                      </div>
+                      <div className="key-stepper">
+                        <button
+                          className="button"
+                          aria-label="Lower target key"
+                          disabled={transposeSemitones <= MIN_TARGET_TRANSPOSE}
+                          onClick={() => {
+                            setTargetSelectorOpen(false);
+                            setTargetTransposeSemitones((current) => clampTargetTranspose(current - 1));
                           }}
+                          type="button"
                         >
-                          {targetKeyOptions.map((key) => (
-                            <option key={key.value} value={key.value}>
-                              {formatKey(key, "short", { mode: enharmonicDisplayMode })}
-                            </option>
-                          ))}
-                        </select>
-                      </label>
-                      <button
-                        className="button"
-                        aria-label="Raise target key"
-                        onClick={() => {
-                          setTargetDirty(true);
-                          setTargetKeyState((current) =>
-                            transposeKey(current ?? sourceKey, 1),
-                          );
-                        }}
-                        type="button"
-                      >
-                        +
-                      </button>
-                    </div>
+                          -
+                        </button>
+                        <div className="key-stepper__value">
+                          <div className="target-selector" ref={targetSelectorRef}>
+                            <button
+                              className="target-selector__trigger"
+                              aria-label="Target Key"
+                              aria-expanded={targetSelectorOpen}
+                              aria-haspopup="listbox"
+                              onClick={() => setTargetSelectorOpen((current) => !current)}
+                              type="button"
+                            >
+                              <span
+                                className={`target-selector__preview target-selector__preview--lower${
+                                  !lowerTargetPreview ? " target-selector__preview--disabled" : ""
+                                }`}
+                              >
+                                <span>{lowerTargetPreview ?? ""}</span>
+                              </span>
+                              <span className="target-selector__current">
+                                <span className="target-selector__current-key">
+                                  {formatKey(targetKey, "short", { mode: enharmonicDisplayMode })}
+                                </span>
+                                <span className="target-selector__current-meta">
+                                  {targetSelectionSummary}
+                                </span>
+                              </span>
+                              <span
+                                className={`target-selector__preview target-selector__preview--higher${
+                                  !higherTargetPreview ? " target-selector__preview--disabled" : ""
+                                }`}
+                              >
+                                <span>{higherTargetPreview ?? ""}</span>
+                              </span>
+                              <span className="target-selector__chevron" aria-hidden="true">
+                                ⌄
+                              </span>
+                            </button>
 
+                            {targetSelectorOpen ? (
+                              <div
+                                className="target-selector__menu"
+                                role="listbox"
+                                aria-label="Target key options"
+                              >
+                                <div className="target-selector__group-label">Higher pitch</div>
+                                {higherTargetShiftOptions.map((option) => (
+                                  <button
+                                    key={option.semitones}
+                                    ref={(node) => {
+                                      targetOptionRefs.current[option.semitones] = node;
+                                    }}
+                                    className={`target-selector__option${
+                                      option.semitones === transposeSemitones
+                                        ? " target-selector__option--selected"
+                                        : ""
+                                    }`}
+                                    role="option"
+                                    aria-selected={option.semitones === transposeSemitones}
+                                    onClick={() => {
+                                      setTargetTransposeSemitones(option.semitones);
+                                      setTargetSelectorOpen(false);
+                                    }}
+                                    type="button"
+                                  >
+                                    <span className="target-selector__option-direction" aria-hidden="true">
+                                      ↑
+                                    </span>
+                                    <span className="target-selector__option-content">
+                                      <span className="target-selector__option-label">{option.label}</span>
+                                    </span>
+                                  </button>
+                                ))}
+                                <div className="target-selector__group-label">Original</div>
+                                <button
+                                  ref={(node) => {
+                                    targetOptionRefs.current[0] = node;
+                                  }}
+                                  className={`target-selector__option${
+                                    transposeSemitones === 0 ? " target-selector__option--selected" : ""
+                                  }`}
+                                  role="option"
+                                  aria-selected={transposeSemitones === 0}
+                                  onClick={() => {
+                                    setTargetTransposeSemitones(0);
+                                    setTargetSelectorOpen(false);
+                                  }}
+                                  type="button"
+                                >
+                                  <span className="target-selector__option-direction" aria-hidden="true">
+                                    •
+                                  </span>
+                                  <span className="target-selector__option-content">
+                                    <span className="target-selector__option-label">
+                                      {formatKey(sourceKey, "short", { mode: enharmonicDisplayMode })}
+                                    </span>
+                                  </span>
+                                </button>
+                                <div className="target-selector__group-label">Lower pitch</div>
+                                {lowerTargetShiftOptions.map((option) => (
+                                  <button
+                                    key={option.semitones}
+                                    ref={(node) => {
+                                      targetOptionRefs.current[option.semitones] = node;
+                                    }}
+                                    className={`target-selector__option${
+                                      option.semitones === transposeSemitones
+                                        ? " target-selector__option--selected"
+                                        : ""
+                                    }`}
+                                    role="option"
+                                    aria-selected={option.semitones === transposeSemitones}
+                                    onClick={() => {
+                                      setTargetTransposeSemitones(option.semitones);
+                                      setTargetSelectorOpen(false);
+                                    }}
+                                    type="button"
+                                  >
+                                    <span className="target-selector__option-direction" aria-hidden="true">
+                                      ↓
+                                    </span>
+                                    <span className="target-selector__option-content">
+                                      <span className="target-selector__option-label">{option.label}</span>
+                                    </span>
+                                  </button>
+                                ))}
+                              </div>
+                            ) : null}
+                          </div>
+                        </div>
+                        <button
+                          className="button"
+                          aria-label="Raise target key"
+                          disabled={transposeSemitones >= MAX_TARGET_TRANSPOSE}
+                          onClick={() => {
+                            setTargetSelectorOpen(false);
+                            setTargetTransposeSemitones((current) => clampTargetTranspose(current + 1));
+                          }}
+                          type="button"
+                        >
+                          +
+                        </button>
+                      </div>
+                    </div>
                   </div>
 
                   {previewMutation.isError ? (

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1328,24 +1328,122 @@ a {
   border-top: 1px solid var(--divider);
 }
 
+.mix-builder {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.mix-builder__retune {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.mix-builder__section-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.mix-builder__mode-toggle {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.45rem;
+  padding: 0.35rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 82%, transparent);
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--panel) 62%, var(--panel-strong) 38%);
+}
+
+.mix-builder__mode-button {
+  justify-content: center;
+  min-height: 2.75rem;
+}
+
+.mix-builder__mode-button[aria-pressed="true"] {
+  background: color-mix(in srgb, var(--chip-active-bg) 94%, transparent);
+  border-color: var(--chip-active-border);
+}
+
+.mix-builder__retune-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  color: var(--muted);
+}
+
+.mix-builder__retune-field input {
+  width: 100%;
+  border: 1px solid var(--input-border);
+  border-radius: 16px;
+  padding: 0.78rem 0.95rem;
+  background: var(--input-bg);
+  color: var(--input-text);
+}
+
 .key-shift__header {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1rem;
   align-items: start;
   margin-bottom: 1rem;
 }
 
-.key-shift__header strong {
-  display: block;
-  margin-top: 0.25rem;
-  font-size: 1.6rem;
-  line-height: 1;
+.key-shift__card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  min-height: 9rem;
+  padding: 1rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--panel) 72%, var(--panel-strong) 28%);
 }
 
-.key-shift__meta {
-  color: var(--muted);
-  font-size: 0.95rem;
+.key-shift__card strong {
+  display: block;
+  margin-top: 0.4rem;
+  font-size: clamp(2rem, 3vw, 2.4rem);
+  line-height: 0.95;
+}
+
+.key-shift__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: auto;
+}
+
+.key-shift__chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+  padding: 0.35rem 0.75rem;
+  border: 1px solid var(--chip-border);
+  border-radius: 999px;
+  background: var(--chip-bg);
+  color: var(--button-text);
+  font-size: 0.84rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.key-shift__chip--active {
+  background: var(--chip-active-bg);
+  border-color: var(--chip-active-border);
+}
+
+.key-stepper__heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
 }
 
 .key-stepper {
@@ -1353,31 +1451,348 @@ a {
   grid-template-columns: auto minmax(0, 1fr) auto;
   gap: 0.75rem;
   align-items: stretch;
+  padding: 0.9rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+  border-radius: 22px;
+  background:
+    radial-gradient(circle at top, color-mix(in srgb, var(--playback-accent) 10%, transparent), transparent 50%),
+    color-mix(in srgb, var(--panel) 70%, var(--panel-strong) 30%);
 }
 
 .key-stepper > .button {
-  min-width: 3.2rem;
+  min-width: 4.25rem;
+  min-height: 4.9rem;
   padding-inline: 0;
-  font-size: 1.3rem;
+  font-size: 1.8rem;
+  border-radius: 22px;
 }
 
 .key-stepper__value {
   display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
-  color: var(--muted);
+  min-width: 0;
 }
 
-.key-stepper__label {
-  font-size: 0.88rem;
+.target-selector {
+  position: relative;
+  width: 100%;
+  isolation: isolate;
 }
 
-.key-stepper__value select {
-  min-height: 3.5rem;
-  font-size: 1.05rem;
-  font-weight: 700;
+.target-selector__trigger {
+  width: 100%;
+  min-height: 4.8rem;
+  display: grid;
+  grid-template-columns: minmax(0, 0.78fr) minmax(0, 1.08fr) minmax(0, 0.78fr);
+  align-items: center;
+  gap: 0;
+  padding: 0.28rem;
+  border: 1px solid color-mix(in srgb, var(--chip-active-border) 36%, var(--input-border));
+  border-radius: 999px;
+  background:
+    radial-gradient(
+      circle at 50% 0%,
+      color-mix(in srgb, white 9%, transparent),
+      transparent 58%
+    ),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--panel-strong) 91%, var(--panel) 9%),
+      color-mix(in srgb, var(--panel) 88%, black 12%)
+    );
+  color: var(--text);
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 12%, transparent),
+    inset 0 -0.9rem 1.35rem color-mix(in srgb, black 15%, transparent),
+    0 0.65rem 1.5rem color-mix(in srgb, black 14%, transparent);
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease,
+    background 160ms ease;
+}
+
+.target-selector__trigger::before {
+  content: "";
+  position: absolute;
+  inset: 0.22rem;
+  border-radius: inherit;
+  border: 1px solid color-mix(in srgb, white 5%, transparent);
+  pointer-events: none;
+  opacity: 0.7;
+}
+
+.target-selector__trigger:hover {
+  border-color: var(--button-hover-border);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 13%, transparent),
+    inset 0 -1rem 1.5rem color-mix(in srgb, black 17%, transparent),
+    0 0.85rem 1.75rem color-mix(in srgb, black 17%, transparent);
+  transform: translateY(-1px);
+}
+
+.target-selector__preview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  color: color-mix(in srgb, var(--muted) 74%, var(--text) 26%);
+  min-height: 4.22rem;
+  padding: 0.45rem 0.65rem 0.9rem;
+  font-size: clamp(0.96rem, 1.55vw, 1.14rem);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.05;
   text-align: center;
-  text-align-last: center;
+}
+
+.target-selector__preview--lower {
+  border-right: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+}
+
+.target-selector__preview--higher {
+  border-left: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+}
+
+.target-selector__preview--disabled {
+  opacity: 0.2;
+}
+
+.target-selector__current {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.16rem;
+  min-width: 0;
+  min-height: 4.18rem;
+  margin: 0 0.16rem;
+  padding: 0.52rem 1rem 0.94rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--chip-active-border) 68%, transparent);
+  background:
+    radial-gradient(
+      circle at 50% 6%,
+      color-mix(in srgb, white 11%, transparent),
+      transparent 42%
+    ),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--playback-accent) 16%, var(--panel-strong) 84%),
+      color-mix(in srgb, var(--panel) 92%, black 8%)
+    );
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 10%, transparent),
+    inset 0 -0.8rem 1.25rem color-mix(in srgb, black 16%, transparent),
+    0 0.4rem 0.95rem color-mix(in srgb, black 10%, transparent);
+  text-align: center;
+}
+
+.target-selector__current-key {
+  font-size: clamp(2rem, 2.7vw, 2.45rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 0.9;
+}
+
+.target-selector__current-meta {
+  color: color-mix(in srgb, var(--playback-accent) 52%, var(--text));
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  line-height: 1.05;
+  text-transform: uppercase;
+}
+
+.target-selector__chevron {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  transform: translateX(-50%);
+  color: color-mix(in srgb, var(--chip-active-border) 82%, var(--text));
+  font-size: 1.08rem;
+  line-height: 1;
+  text-shadow: 0 0 0.75rem color-mix(in srgb, var(--playback-accent) 24%, transparent);
+}
+
+.target-selector__menu {
+  position: absolute;
+  left: 50%;
+  top: calc(100% + 0.65rem);
+  width: min(100%, 19.75rem);
+  z-index: 10;
+  max-height: 19.5rem;
+  overflow-y: auto;
+  padding: 0.58rem;
+  border: 1px solid color-mix(in srgb, var(--chip-active-border) 18%, var(--divider));
+  border-radius: 24px;
+  transform: translateX(-50%);
+  background:
+    radial-gradient(
+      circle at top,
+      color-mix(in srgb, var(--playback-accent) 9%, transparent),
+      transparent 43%
+    ),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--panel-strong) 96%, var(--panel) 4%),
+      color-mix(in srgb, var(--panel) 90%, black 10%)
+    );
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 8%, transparent),
+    0 1.25rem 3rem color-mix(in srgb, black 30%, transparent);
+  backdrop-filter: blur(14px);
+}
+
+.target-selector__group-label {
+  padding: 0.5rem 0.72rem 0.28rem;
+  color: var(--muted);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.target-selector__option {
+  width: 100%;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0.78rem 0.82rem;
+  border: 1px solid transparent;
+  border-radius: 18px;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+  box-shadow: inset 0 1px 0 transparent;
+  transition:
+    border-color 160ms ease,
+    background 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.target-selector__option:hover {
+  border-color: var(--button-hover-border);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--panel-strong) 78%, transparent),
+      color-mix(in srgb, var(--panel) 62%, transparent)
+    );
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 5%, transparent),
+    0 0.55rem 1.2rem color-mix(in srgb, black 10%, transparent);
+  transform: translateY(-1px);
+}
+
+.target-selector__option--selected {
+  border-color: color-mix(in srgb, var(--chip-active-border) 82%, var(--playback-accent) 18%);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--playback-accent) 12%, var(--panel-strong) 88%),
+      color-mix(in srgb, var(--panel) 84%, black 16%)
+    );
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 8%, transparent),
+    0 0.8rem 1.6rem color-mix(in srgb, black 12%, transparent);
+}
+
+.target-selector__option-direction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.55rem;
+  height: 1.55rem;
+  border: 1px solid color-mix(in srgb, var(--chip-active-border) 22%, transparent);
+  border-radius: 999px;
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, white 3%, var(--panel-strong) 97%),
+      color-mix(in srgb, var(--panel) 88%, black 12%)
+    );
+  color: color-mix(in srgb, var(--playback-accent) 62%, var(--text));
+  font-size: 0.9rem;
+  font-weight: 700;
+  line-height: 1;
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 5%, transparent);
+}
+
+.target-selector__option-label {
+  font-size: 1.04rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.target-selector__option-content {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+}
+
+.target-selector__option--selected .target-selector__option-label {
+  color: color-mix(in srgb, white 90%, var(--text));
+}
+
+.target-selector__option--selected .target-selector__option-direction {
+  border-color: color-mix(in srgb, var(--chip-active-border) 52%, transparent);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--playback-accent) 18%, var(--panel-strong) 82%),
+      color-mix(in srgb, var(--panel) 82%, black 18%)
+    );
+  color: color-mix(in srgb, white 86%, var(--playback-accent));
+}
+
+.target-selector__menu .target-selector__option + .target-selector__group-label {
+  margin-top: 0.42rem;
+}
+
+.target-selector__menu .target-selector__group-label:first-child {
+  padding-top: 0.18rem;
+}
+
+.target-selector__preview,
+.target-selector__option-label,
+.target-selector__option-content {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.target-selector__trigger:focus-visible,
+.target-selector__option:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.target-selector__trigger[aria-expanded="true"] {
+  border-color: var(--chip-active-border);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 14%, transparent),
+    inset 0 -1rem 1.55rem color-mix(in srgb, black 18%, transparent),
+    0 1rem 2rem color-mix(in srgb, black 18%, transparent);
+}
+
+.target-selector__trigger[aria-expanded="true"] .target-selector__current-key {
+  color: color-mix(in srgb, white 90%, var(--text));
+}
+
+.target-selector__trigger[aria-expanded="true"] .target-selector__current-meta {
+  color: color-mix(in srgb, var(--playback-accent) 42%, var(--text-secondary));
+}
+
+.target-selector__trigger[aria-expanded="true"] .target-selector__chevron {
+  color: color-mix(in srgb, var(--playback-accent) 68%, var(--text));
 }
 
 .inspector-panel {


### PR DESCRIPTION
## Summary
- polish the inspector mix builder layout with segmented retune controls, source/target key cards, and a denser target-selection presentation
- replace the target-key select with a custom octave-bounded stepper and dropdown that keeps enharmonic display preferences in sync
- update desktop tests to cover the new target-key UI and the one-octave stepping limits

## Testing
- `pnpm lint` (passes with pre-existing hook warnings in `apps/desktop/src/features/projects/playback.tsx`)
- `pnpm typecheck`
- `pnpm test`
