### PR TITLE
feat(desktop): refine musical key controls and chord displays

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -531,6 +531,22 @@ function renderApp(initialEntries: string[]) {
   return { ...result, queryClient };
 }
 
+function hasAriaKeyLabel(element: Element | null, label: string) {
+  return element?.getAttribute("aria-label") === label;
+}
+
+function getByAriaKeyLabel(container: HTMLElement, label: string) {
+  return within(container).getByText((_, element) => hasAriaKeyLabel(element, label));
+}
+
+function getAllByAriaKeyLabel(container: HTMLElement, label: string) {
+  return within(container).getAllByText((_, element) => hasAriaKeyLabel(element, label));
+}
+
+function queryByAriaKeyLabel(container: HTMLElement, label: string) {
+  return within(container).queryByText((_, element) => hasAriaKeyLabel(element, label));
+}
+
 function installMatchMediaMock(initialMatches = false) {
   const listeners = new Set<(event: MediaQueryListEvent) => void>();
   let matches = initialMatches;
@@ -799,18 +815,18 @@ describe("Desktop app flows", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
-    expect(within(screen.getByRole("group", { name: "Current chord card" })).getByText("Ebm")).toBeInTheDocument();
-    expect(within(screen.getByRole("group", { name: "Next chord card" })).getByText("Bb")).toBeInTheDocument();
+    expect(getByAriaKeyLabel(screen.getByRole("group", { name: "Current chord card" }), "Ebm")).toBeInTheDocument();
+    expect(getByAriaKeyLabel(screen.getByRole("group", { name: "Next chord card" }), "Bb")).toBeInTheDocument();
     expect(screen.queryByText("D#/Ebm")).not.toBeInTheDocument();
     expect(screen.queryByText("A#/Bb")).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Show Inspector" }));
     expect(
-      within(screen.getByText("Source Key", { selector: "span" }).closest("div") as HTMLElement).getByText("Ebm"),
+      getByAriaKeyLabel(screen.getByText("Source Key", { selector: "span" }).closest("div") as HTMLElement, "Ebm"),
     ).toBeInTheDocument();
     await user.click(screen.getByLabelText("Target Key"));
     const targetKeyList = screen.getByRole("listbox", { name: "Target key options" });
-    expect(within(targetKeyList).getAllByText("Bbm").length).toBeGreaterThan(0);
+    expect(getAllByAriaKeyLabel(targetKeyList as HTMLElement, "Bbm").length).toBeGreaterThan(0);
     expect(within(targetKeyList).queryByText("D#/Ebm")).not.toBeInTheDocument();
   });
 
@@ -847,19 +863,62 @@ describe("Desktop app flows", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
-    expect(within(screen.getByRole("group", { name: "Current chord card" })).getByText("D#m")).toBeInTheDocument();
-    expect(within(screen.getByRole("group", { name: "Next chord card" })).getByText("A#")).toBeInTheDocument();
+    expect(getByAriaKeyLabel(screen.getByRole("group", { name: "Current chord card" }), "D#m")).toBeInTheDocument();
+    expect(getByAriaKeyLabel(screen.getByRole("group", { name: "Next chord card" }), "A#")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Show Inspector" }));
 
     const sourceKeyCard = screen.getByText("Source Key", { selector: "span" }).closest("div") as HTMLElement;
-    expect(
-      within(sourceKeyCard).getByText("D#m"),
-    ).toBeInTheDocument();
-    expect(within(sourceKeyCard).queryByText("Ebm")).not.toBeInTheDocument();
+    expect(getByAriaKeyLabel(sourceKeyCard, "D#m")).toBeInTheDocument();
+    expect(queryByAriaKeyLabel(sourceKeyCard, "Ebm")).not.toBeInTheDocument();
     await user.click(screen.getByLabelText("Target Key"));
     const targetKeyList = screen.getByRole("listbox", { name: "Target key options" });
-    expect(within(targetKeyList).getAllByText("D#m").length).toBeGreaterThan(0);
-    expect(within(targetKeyList).queryByText("Ebm")).not.toBeInTheDocument();
+    expect(getAllByAriaKeyLabel(targetKeyList as HTMLElement, "D#m").length).toBeGreaterThan(0);
+    expect(queryByAriaKeyLabel(targetKeyList as HTMLElement, "Ebm")).not.toBeInTheDocument();
+  });
+
+  it("uses sharp-first dual labels across key and chord surfaces", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({
+        defaultSourcesRailCollapsed: false,
+        enharmonicDisplayMode: "dual",
+      }),
+    );
+    setProjectAnalysis("proj_123", {
+      project_id: "proj_123",
+      estimated_key: "Eb minor",
+      key_confidence: 0.82,
+      estimated_reference_hz: 431.9,
+      tuning_offset_cents: -32,
+      tempo_bpm: null,
+      analysis_version: "v1",
+      created_at: "2026-04-18T13:16:00.000Z",
+    });
+    setProjectChords("proj_123", {
+      project_id: "proj_123",
+      backend: "default",
+      source_artifact_id: "art_source",
+      created_at: "2026-04-18T13:16:00.000Z",
+      timeline: [
+        { start_seconds: 0, end_seconds: 16, label: "legacy", confidence: 0.81, pitch_class: 3, quality: "minor" },
+      ],
+    });
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    expect(getByAriaKeyLabel(screen.getByRole("group", { name: "Current chord card" }), "D#m / Ebm")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Show Inspector" }));
+    const sourceKeyCard = screen.getByText("Source Key", { selector: "span" }).closest("div") as HTMLElement;
+    expect(getByAriaKeyLabel(sourceKeyCard, "D#m / Ebm")).toBeInTheDocument();
+    const estimatedKeyCard = screen.getByText("Estimated Key", { selector: "span" }).closest("div") as HTMLElement;
+    expect(getByAriaKeyLabel(estimatedKeyCard, "D#m / Ebm")).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Target Key"));
+    const targetKeyList = screen.getByRole("listbox", { name: "Target key options" });
+    expect(getAllByAriaKeyLabel(targetKeyList as HTMLElement, "D#m / Ebm").length).toBeGreaterThan(0);
   });
 
   it("preserves the relative target shift when the detected source key is corrected", async () => {
@@ -881,7 +940,8 @@ describe("Desktop app flows", () => {
     expect(within(targetKeyCard).getByText("G#")).toBeInTheDocument();
 
     await user.click(screen.getByText("Correct source key for this project"));
-    await user.selectOptions(screen.getByLabelText("Project Source Key"), "8:major");
+    await user.click(screen.getByLabelText("Project Source Key"));
+    await user.click(screen.getByRole("option", { name: "G#" }));
 
     const sourceKeyCard = screen.getByText("Source Key", { selector: "span" }).closest("div") as HTMLElement;
     expect(mockUpdateProject).toHaveBeenCalledWith("proj_123", { source_key_override: "8:major" });
@@ -898,7 +958,8 @@ describe("Desktop app flows", () => {
     const sourceList = screen.getByRole("group", { name: "Source and mix list" });
     await user.click(within(sourceList).getByRole("button", { name: /Source Track/i }));
     await user.click(screen.getByText("Correct source key for this project"));
-    await user.selectOptions(screen.getByLabelText("Project Source Key"), "9:major");
+    await user.click(screen.getByLabelText("Project Source Key"));
+    await user.click(screen.getByRole("option", { name: "A" }));
     await user.click(screen.getByLabelText("Raise target key"));
     await user.click(screen.getByRole("button", { name: "Create Mix" }));
 
@@ -909,6 +970,84 @@ describe("Desktop app flows", () => {
         transpose: { semitones: 1 },
       }),
     );
+  });
+
+  it("shifts displayed chords when the detected source key is corrected", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({
+        defaultSourcesRailCollapsed: false,
+        enharmonicDisplayMode: "sharps",
+      }),
+    );
+    setProjectAnalysis("proj_123", {
+      project_id: "proj_123",
+      estimated_key: "G major",
+      key_confidence: 0.82,
+      estimated_reference_hz: 431.9,
+      tuning_offset_cents: -32,
+      tempo_bpm: null,
+      analysis_version: "v1",
+      created_at: "2026-04-18T13:16:00.000Z",
+    });
+    setProjectChords("proj_123", {
+      project_id: "proj_123",
+      backend: "default",
+      source_artifact_id: "art_source",
+      created_at: "2026-04-18T13:16:00.000Z",
+      timeline: [
+        { start_seconds: 0, end_seconds: 16, label: "legacy", confidence: 0.81, pitch_class: 7, quality: "major" },
+      ],
+    });
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    expect(getByAriaKeyLabel(screen.getByRole("group", { name: "Current chord card" }), "G")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Show Inspector" }));
+    await user.click(screen.getByText("Correct source key for this project"));
+    await user.click(screen.getByLabelText("Project Source Key"));
+    await user.click(screen.getByRole("option", { name: "A" }));
+
+    expect(getByAriaKeyLabel(screen.getByRole("group", { name: "Current chord card" }), "A")).toBeInTheDocument();
+
+    const savedMixList = screen.getByRole("group", { name: "Saved mix list" });
+    await user.click(within(savedMixList).getByRole("button", { name: /Practice Mix/i }));
+
+    expect(getByAriaKeyLabel(screen.getByRole("group", { name: "Current chord card" }), "B")).toBeInTheDocument();
+  });
+
+  it("does not duplicate the detected key inside the project source key selector", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({
+        defaultSourcesRailCollapsed: false,
+        enharmonicDisplayMode: "sharps",
+      }),
+    );
+    setProjectAnalysis("proj_123", {
+      project_id: "proj_123",
+      estimated_key: "G# minor",
+      key_confidence: 0.82,
+      estimated_reference_hz: 431.9,
+      tuning_offset_cents: -32,
+      tempo_bpm: null,
+      analysis_version: "v1",
+      created_at: "2026-04-18T13:16:00.000Z",
+    });
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Show Inspector" }));
+    await user.click(screen.getByText("Correct source key for this project"));
+    await user.click(screen.getByLabelText("Project Source Key"));
+
+    const sourceKeyList = screen.getByRole("listbox", { name: "Project Source Key options" });
+    expect(getAllByAriaKeyLabel(sourceKeyList as HTMLElement, "G#m").length).toBe(1);
   });
 
   it("caps target key stepping at one octave in either direction", async () => {
@@ -1055,11 +1194,6 @@ describe("Desktop app flows", () => {
     await user.click(screen.getByRole("button", { name: "Switch to Stems" }));
 
     expect(await screen.findByRole("heading", { name: "Vocals" })).toBeInTheDocument();
-    expect(
-      within(screen.getByRole("group", { name: "Current source summary" })).getByText(
-        "Practice Mix",
-      ),
-    ).toBeInTheDocument();
     await waitFor(() =>
       expect(
         JSON.parse(window.localStorage.getItem("tuneforge.project-playback-state") ?? "{}"),
@@ -1092,16 +1226,6 @@ describe("Desktop app flows", () => {
 
     expect(await screen.findByRole("heading", { name: "Vocals" })).toBeInTheDocument();
     expect(screen.getAllByText("Stem monitor").length).toBeGreaterThan(0);
-    expect(
-      within(screen.getByRole("group", { name: "Current source summary" })).getByText(
-        "Practice Mix",
-      ),
-    ).toBeInTheDocument();
-    expect(
-      within(screen.getByRole("group", { name: "Current source summary" })).queryByText(
-        "Source Track",
-      ),
-    ).not.toBeInTheDocument();
   });
 
   it("toggles playback with spacebar and preserves time when switching mixes", async () => {

--- a/apps/desktop/src/components/MusicalLabel.tsx
+++ b/apps/desktop/src/components/MusicalLabel.tsx
@@ -1,0 +1,94 @@
+import {
+  formatChordDisplay,
+  formatKeyDisplay,
+  formatRawMusicalLabel,
+  type ChordQuality,
+  type EnharmonicDisplayMode,
+  type FormattedMusicalLabel,
+  type MusicalKey,
+  type PitchFormatOptions,
+} from "../lib/music";
+
+export type MusicalLabelVariant =
+  | "key-card"
+  | "source-selector-current"
+  | "source-selector-option"
+  | "selector-current"
+  | "selector-preview"
+  | "selector-option"
+  | "chord-card"
+  | "chord-chip";
+
+function RenderMusicalLabel({
+  label,
+  variant,
+}: {
+  label: FormattedMusicalLabel;
+  variant: MusicalLabelVariant;
+}) {
+  return (
+    <span
+      aria-label={label.ariaLabel}
+      className={`musical-label musical-label--${variant}${label.secondary ? " musical-label--dual" : ""}`}
+      title={label.ariaLabel}
+    >
+      <span className="musical-label__primary">
+        <span className="musical-label__root">{label.primary.root}</span>
+        {label.primary.suffix ? (
+          <span className="musical-label__suffix">{label.primary.suffix}</span>
+        ) : null}
+      </span>
+      {label.secondary ? (
+        <span className="musical-label__secondary">
+          <span className="musical-label__root">{label.secondary.root}</span>
+          {label.secondary.suffix ? (
+            <span className="musical-label__suffix">{label.secondary.suffix}</span>
+          ) : null}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+export function MusicalKeyLabel({
+  activeKey,
+  keyValue,
+  mode,
+  variant,
+}: {
+  activeKey?: MusicalKey | null;
+  keyValue: MusicalKey;
+  mode: EnharmonicDisplayMode;
+  variant: MusicalLabelVariant;
+}) {
+  return (
+    <RenderMusicalLabel
+      label={formatKeyDisplay(keyValue, { activeKey: activeKey ?? keyValue, mode })}
+      variant={variant}
+    />
+  );
+}
+
+export function MusicalChordLabel({
+  activeKey,
+  fallbackLabel,
+  mode,
+  pitchClass,
+  quality,
+  variant,
+}: {
+  activeKey?: MusicalKey | null;
+  fallbackLabel: string;
+  mode: EnharmonicDisplayMode;
+  pitchClass?: number | null;
+  quality?: string | null;
+  variant: MusicalLabelVariant;
+}) {
+  const isSupportedChord = typeof pitchClass === "number" && (quality === "major" || quality === "minor");
+  const options: PitchFormatOptions = { activeKey: activeKey ?? null, mode };
+  const label = isSupportedChord
+    ? formatChordDisplay(pitchClass, quality as ChordQuality, options)
+    : formatRawMusicalLabel(fallbackLabel);
+
+  return <RenderMusicalLabel label={label} variant={variant} />;
+}

--- a/apps/desktop/src/features/projects/ProjectView.tsx
+++ b/apps/desktop/src/features/projects/ProjectView.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { confirm, save } from "@tauri-apps/plugin-dialog";
 import { api, type ArtifactSchema, type ChordSegmentSchema, type JobSchema, type ProjectSchema } from "../../lib/api";
+import { MusicalChordLabel, MusicalKeyLabel } from "../../components/MusicalLabel";
 import { formatLocalDateTime } from "../../lib/datetime";
 import { usePreferences } from "../../lib/preferences";
 import { usePlayback } from "./playback-context";
@@ -16,10 +17,11 @@ import {
   DEFAULT_KEY,
   type EnharmonicDisplayMode,
   MUSICAL_KEYS,
-  formatChordLabel,
   formatKey,
+  formatChordLabel,
   parseKey,
   parseStoredKey,
+  semitoneDelta,
   serializeKey,
   transposePitchClass,
   transposeKey,
@@ -104,7 +106,13 @@ function formatTargetSelectionSummary(semitones: number) {
 
 type TargetShiftOption = {
   semitones: number;
-  label: string;
+  key: MusicalKey;
+};
+
+type SourceKeyOption = {
+  badge: string | null;
+  key: MusicalKey;
+  value: string;
 };
 
 function formatArtifactTimestamp(createdAt: string) {
@@ -358,70 +366,6 @@ function findActiveChordIndex(timeline: ChordSegmentSchema[], playbackTimeSecond
   });
 }
 
-function buildRequestedRetune(
-  retuneMode: "off" | "reference" | "cents",
-  referenceHz: string,
-  centsOffset: string,
-) {
-  if (retuneMode === "reference") {
-    const parsed = Number(referenceHz);
-    return Number.isFinite(parsed) ? { target_reference_hz: parsed } : null;
-  }
-  if (retuneMode === "cents") {
-    const parsed = Number(centsOffset);
-    return Number.isFinite(parsed) ? { target_cents_offset: parsed } : null;
-  }
-  return null;
-}
-
-function matchesPreviewSettings(
-  artifact: ArtifactSchema | null,
-  requestedRetune:
-    | { target_reference_hz: number }
-    | { target_cents_offset: number }
-    | null,
-  transposeSemitones: number,
-) {
-  if (!artifact || artifact.type !== "preview_mix") {
-    return false;
-  }
-
-  const metadata = artifact.metadata ?? {};
-  const retune =
-    typeof metadata.retune === "object" && metadata.retune !== null ? metadata.retune : {};
-  const transpose =
-    typeof metadata.transpose === "object" && metadata.transpose !== null
-      ? metadata.transpose
-      : {};
-
-  const requestedReferenceHz =
-    requestedRetune && "target_reference_hz" in requestedRetune
-      ? requestedRetune.target_reference_hz
-      : null;
-  const requestedCents =
-    requestedRetune && "target_cents_offset" in requestedRetune
-      ? requestedRetune.target_cents_offset
-      : null;
-  const artifactReferenceHz =
-    "target_reference_hz" in retune && typeof retune.target_reference_hz === "number"
-      ? retune.target_reference_hz
-      : null;
-  const artifactCents =
-    "target_cents_offset" in retune && typeof retune.target_cents_offset === "number"
-      ? retune.target_cents_offset
-      : null;
-  const artifactSemitones =
-    "semitones" in transpose && typeof transpose.semitones === "number"
-      ? transpose.semitones
-      : 0;
-
-  return (
-    artifactSemitones === transposeSemitones &&
-    artifactReferenceHz === requestedReferenceHz &&
-    artifactCents === requestedCents
-  );
-}
-
 function formatRetuneSummary(
   retuneMode: "off" | "reference" | "cents",
   referenceHz: string,
@@ -467,6 +411,8 @@ export function ProjectView() {
   const persistedStemSourceArtifactId = useRef<string | null>(null);
   const targetSelectorRef = useRef<HTMLDivElement | null>(null);
   const targetOptionRefs = useRef<Record<number, HTMLButtonElement | null>>({});
+  const sourceKeySelectorRef = useRef<HTMLDivElement | null>(null);
+  const sourceKeyOptionRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const [retuneMode, setRetuneMode] = useState<"off" | "reference" | "cents">("off");
   const [referenceHz, setReferenceHz] = useState("440");
   const [centsOffset, setCentsOffset] = useState("0");
@@ -476,6 +422,7 @@ export function ProjectView() {
   });
   const [targetTransposeSemitones, setTargetTransposeSemitones] = useState(0);
   const [targetSelectorOpen, setTargetSelectorOpen] = useState(false);
+  const [sourceKeySelectorOpen, setSourceKeySelectorOpen] = useState(false);
   const [selectedArtifactId, setSelectedArtifactId] = useState<string | null>(null);
   const [selectedPrimaryArtifactId, setSelectedPrimaryArtifactId] = useState<string | null>(null);
   const [hydratedProjectId, setHydratedProjectId] = useState<string | null>(null);
@@ -798,16 +745,7 @@ export function ProjectView() {
   const sourceKey = sourceKeyBasis ?? DEFAULT_KEY;
   const transposeSemitones = clampTargetTranspose(targetTransposeSemitones);
   const targetKey = transposeKey(sourceKey, transposeSemitones);
-  const requestedRetune = buildRequestedRetune(retuneMode, referenceHz, centsOffset);
   const hasTransformChange = retuneMode !== "off" || transposeSemitones !== 0;
-  const previewMatchesCurrentSettings = matchesPreviewSettings(
-    latestPreviewArtifact,
-    requestedRetune,
-    transposeSemitones,
-  );
-  const selectedArtifactMatchesCurrentSettings =
-    (selectedArtifact?.type === "source_audio" && !hasTransformChange) ||
-    matchesPreviewSettings(selectedArtifact, requestedRetune, transposeSemitones);
   const isAnalysisRunning = Boolean(
     analyzeJob && ["pending", "running"].includes(analyzeJob.status),
   );
@@ -815,57 +753,37 @@ export function ProjectView() {
     chordJob && ["pending", "running"].includes(chordJob.status),
   );
   const isStemRunning = Boolean(stemJob && ["pending", "running"].includes(stemJob.status));
-  const currentKeyValue = sourceKeyOverride
-    ? serializeKey(sourceKeyOverride)
-    : detectedKey
-      ? "auto"
-      : serializeKey(sourceKey);
+  const currentKeyValue = sourceKeyOverride ? serializeKey(sourceKeyOverride) : "auto";
   const hasVisibleStems = visibleStemArtifacts.length > 0;
   const stemErrorMessage =
     stemJob?.error_message && !dismissedStemJobIds.includes(stemJob.id)
       ? stemJob.error_message
       : null;
   const visibleJobs = projectJobs;
-  const controlSummary = hasTransformChange ? formatKey(targetKey, "short", { mode: enharmonicDisplayMode }) : "Original key";
   const tuningSummary = formatRetuneSummary(retuneMode, referenceHz, centsOffset);
-  const mixStatus = isStemPlayback
-    ? "Stem monitor"
-    : !hasTransformChange
-      ? latestPreviewArtifact
-        ? "Source settings"
-        : "Source only"
-      : !latestPreviewArtifact
-        ? "No preview yet"
-        : previewMatchesCurrentSettings
-          ? "Up to date"
-          : "Needs update";
-  const mixStatusCopy = isStemPlayback
-    ? "Mute or solo stems without leaving the playback surface."
-    : selectedArtifact
-      ? selectedArtifactMatchesCurrentSettings
-        ? "Selected playback matches current controls."
-        : "Controls differ from selected playback."
-      : "Select source audio or a saved mix.";
   const canDeleteSelectedMix = selectedArtifact?.type === "preview_mix";
   const selectedArtifactTimestamp = selectedPlaybackArtifact
     ? formatArtifactTimestamp(selectedPlaybackArtifact.created_at)
     : "";
+  const correctedSourceChordSemitones =
+    detectedKey && sourceKeyOverride ? semitoneDelta(detectedKey, sourceKeyOverride) : 0;
   const chordTransposeSemitones = artifactTransposeSemitones(
     selectedPlaybackArtifact,
     selectableArtifacts,
   );
+  const displayedChordSemitones = chordTransposeSemitones + correctedSourceChordSemitones;
   const activeEnharmonicKeyContext = sourceKeyBasis
     ? transposeKey(sourceKeyBasis, chordTransposeSemitones)
     : null;
   const displayedChords = useMemo(
     () =>
       (chordsQuery.data?.timeline ?? []).map((segment) =>
-        transposeChordSegment(segment, chordTransposeSemitones, {
+        transposeChordSegment(segment, displayedChordSemitones, {
           activeKey: activeEnharmonicKeyContext,
           mode: enharmonicDisplayMode,
         }),
       ),
-    [activeEnharmonicKeyContext, chordTransposeSemitones, chordsQuery.data?.timeline, enharmonicDisplayMode],
+    [activeEnharmonicKeyContext, chordsQuery.data?.timeline, displayedChordSemitones, enharmonicDisplayMode],
   );
   const activeChordIndex = findActiveChordIndex(displayedChords, playbackTimeSeconds);
   const currentChord =
@@ -878,26 +796,30 @@ export function ProjectView() {
         : null;
   const hasChordTimeline = displayedChords.length > 0;
   const chordContextCopy =
-    chordTransposeSemitones === 0
+    correctedSourceChordSemitones === 0 && chordTransposeSemitones === 0
       ? "Chord labels follow the original arrangement."
-      : `Chord labels follow the selected playback (${formatSemitoneShift(
+      : correctedSourceChordSemitones !== 0 && chordTransposeSemitones === 0
+        ? "Chord labels follow the corrected source key."
+        : correctedSourceChordSemitones === 0
+          ? `Chord labels follow the selected playback (${formatSemitoneShift(
+              chordTransposeSemitones,
+            ).toLowerCase()}).`
+          : `Chord labels follow corrected source key and selected playback (${formatSemitoneShift(
           chordTransposeSemitones,
         ).toLowerCase()}).`;
   const sourceKeyStatus = sourceKeyOverride ? "Corrected" : detectedKey ? "Detected" : "Default";
   const targetShiftSummary =
     transposeSemitones === 0 ? "Original key" : formatSemitoneShift(transposeSemitones);
   const targetSelectionSummary = formatTargetSelectionSummary(transposeSemitones);
+  const sourceKeySelectorCurrentKey = sourceKeyOverride ?? detectedKey ?? sourceKey;
+  const sourceKeySelectorCurrentBadge = sourceKeyOverride ? null : detectedKey ? "Original" : "No override";
   const lowerTargetPreview =
     transposeSemitones > MIN_TARGET_TRANSPOSE
-      ? formatKey(transposeKey(sourceKey, transposeSemitones - 1), "short", {
-          mode: enharmonicDisplayMode,
-        })
+      ? transposeKey(sourceKey, transposeSemitones - 1)
       : null;
   const higherTargetPreview =
     transposeSemitones < MAX_TARGET_TRANSPOSE
-      ? formatKey(transposeKey(sourceKey, transposeSemitones + 1), "short", {
-          mode: enharmonicDisplayMode,
-        })
+      ? transposeKey(sourceKey, transposeSemitones + 1)
       : null;
   const targetShiftOptions = useMemo<TargetShiftOption[]>(
     () =>
@@ -908,10 +830,10 @@ export function ProjectView() {
         const key = transposeKey(sourceKey, semitones);
         return {
           semitones,
-          label: formatKey(key, "short", { mode: enharmonicDisplayMode }),
+          key,
         };
       }),
-    [enharmonicDisplayMode, sourceKey],
+    [sourceKey],
   );
   const lowerTargetShiftOptions = useMemo(
     () => targetShiftOptions.filter((option) => option.semitones < 0).sort((a, b) => b.semitones - a.semitones),
@@ -920,6 +842,23 @@ export function ProjectView() {
   const higherTargetShiftOptions = useMemo(
     () => targetShiftOptions.filter((option) => option.semitones > 0).sort((a, b) => b.semitones - a.semitones),
     [targetShiftOptions],
+  );
+  const sourceKeyOptions = useMemo<SourceKeyOption[]>(
+    () => [
+      {
+        badge: detectedKey ? "Original" : "No override",
+        key: detectedKey ?? sourceKey,
+        value: "auto",
+      },
+      ...MUSICAL_KEYS.filter((key) =>
+        detectedKey ? key.value !== serializeKey(detectedKey) : true,
+      ).map((key) => ({
+        badge: null,
+        key,
+        value: key.value,
+      })),
+    ],
+    [detectedKey, sourceKey],
   );
 
   const soloedStemIds = visibleStemArtifacts
@@ -1064,19 +1003,34 @@ export function ProjectView() {
   }, [targetSelectorOpen, transposeSemitones]);
 
   useEffect(() => {
-    if (!targetSelectorOpen) {
+    if (!sourceKeySelectorOpen) {
+      return;
+    }
+
+    const activeOption = sourceKeyOptionRefs.current[currentKeyValue];
+    activeOption?.scrollIntoView?.({ block: "center" });
+  }, [currentKeyValue, sourceKeySelectorOpen]);
+
+  useEffect(() => {
+    if (!targetSelectorOpen && !sourceKeySelectorOpen) {
       return;
     }
 
     function handlePointerDown(event: PointerEvent) {
-      if (!targetSelectorRef.current?.contains(event.target as Node)) {
+      const targetInside = targetSelectorRef.current?.contains(event.target as Node) ?? false;
+      const sourceInside = sourceKeySelectorRef.current?.contains(event.target as Node) ?? false;
+      if (!targetInside) {
         setTargetSelectorOpen(false);
+      }
+      if (!sourceInside) {
+        setSourceKeySelectorOpen(false);
       }
     }
 
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {
         setTargetSelectorOpen(false);
+        setSourceKeySelectorOpen(false);
       }
     }
 
@@ -1087,7 +1041,7 @@ export function ProjectView() {
       window.removeEventListener("pointerdown", handlePointerDown);
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [targetSelectorOpen]);
+  }, [sourceKeySelectorOpen, targetSelectorOpen]);
 
   useEffect(() => {
     setInspectorOpen(defaultInspectorOpen);
@@ -1230,9 +1184,6 @@ export function ProjectView() {
     });
   }, [activeChordIndex, displayedChords]);
 
-  const currentSourceLabel = selectedPrimaryArtifact
-    ? artifactLabel(selectedPrimaryArtifact)
-    : "Source Track";
   const currentSourceSummary = selectedPrimaryArtifact
     ? artifactSummary(selectedPrimaryArtifact) ||
       fileNameFromPath(selectedPrimaryArtifact.path)
@@ -1563,24 +1514,6 @@ export function ProjectView() {
             </div>
 
             <div className="stage-surface">
-              <div className="session-block playback-stage__summary">
-                <div role="group" aria-label="Current source summary">
-                  <p className="metric-label">Current Source</p>
-                  <strong>{currentSourceLabel}</strong>
-                  <p className="artifact-meta">{currentSourceSummary}</p>
-                </div>
-                <div role="group" aria-label="Current control summary">
-                  <p className="metric-label">Mix Controls</p>
-                  <strong>{controlSummary}</strong>
-                  <p className="artifact-meta">{tuningSummary}</p>
-                </div>
-                <div role="group" aria-label="Mix status summary">
-                  <p className="metric-label">Status</p>
-                  <strong>{mixStatus}</strong>
-                  <p className="artifact-meta">{mixStatusCopy}</p>
-                </div>
-              </div>
-
               <div className="transport">
                 <div className="transport__controls">
                   <button
@@ -1675,11 +1608,37 @@ export function ProjectView() {
               <div className="chord-preview-grid">
                 <div className="chord-card" role="group" aria-label="Current chord card">
                   <span className="metric-label">Current</span>
-                  <strong>{currentChord?.label ?? "-"}</strong>
+                  <strong>
+                    {currentChord ? (
+                      <MusicalChordLabel
+                        activeKey={activeEnharmonicKeyContext}
+                        fallbackLabel={currentChord.label ?? "-"}
+                        mode={enharmonicDisplayMode}
+                        pitchClass={currentChord.pitch_class}
+                        quality={currentChord.quality}
+                        variant="chord-card"
+                      />
+                    ) : (
+                      "-"
+                    )}
+                  </strong>
                 </div>
                 <div className="chord-card" role="group" aria-label="Next chord card">
                   <span className="metric-label">Next</span>
-                  <strong>{nextChord?.label ?? "-"}</strong>
+                  <strong>
+                    {nextChord ? (
+                      <MusicalChordLabel
+                        activeKey={activeEnharmonicKeyContext}
+                        fallbackLabel={nextChord.label ?? "-"}
+                        mode={enharmonicDisplayMode}
+                        pitchClass={nextChord.pitch_class}
+                        quality={nextChord.quality}
+                        variant="chord-card"
+                      />
+                    ) : (
+                      "-"
+                    )}
+                  </strong>
                 </div>
               </div>
 
@@ -1711,7 +1670,16 @@ export function ProjectView() {
                         }}
                         onClick={() => seekTo(segment.start_seconds)}
                       >
-                        <span>{segment.label}</span>
+                        <span>
+                          <MusicalChordLabel
+                            activeKey={activeEnharmonicKeyContext}
+                            fallbackLabel={segment.label}
+                            mode={enharmonicDisplayMode}
+                            pitchClass={segment.pitch_class}
+                            quality={segment.quality}
+                            variant="chord-chip"
+                          />
+                        </span>
                         <small>{formatPlaybackClock(segment.start_seconds)}</small>
                       </button>
                     );
@@ -1958,7 +1926,13 @@ export function ProjectView() {
                         <div className="key-shift__card">
                           <div>
                             <span className="metric-label">Source Key</span>
-                            <strong>{formatKey(sourceKey, "short", { mode: enharmonicDisplayMode })}</strong>
+                            <strong>
+                              <MusicalKeyLabel
+                                keyValue={sourceKey}
+                                mode={enharmonicDisplayMode}
+                                variant="key-card"
+                              />
+                            </strong>
                           </div>
                           <div className="key-shift__chips">
                             <span className="key-shift__chip">{sourceKeyStatus}</span>
@@ -1967,7 +1941,13 @@ export function ProjectView() {
                         <div className="key-shift__card key-shift__card--target">
                           <div>
                             <span className="metric-label">Target Key</span>
-                            <strong>{formatKey(targetKey, "short", { mode: enharmonicDisplayMode })}</strong>
+                            <strong>
+                              <MusicalKeyLabel
+                                keyValue={targetKey}
+                                mode={enharmonicDisplayMode}
+                                variant="key-card"
+                              />
+                            </strong>
                           </div>
                           <div className="key-shift__chips">
                             <span className="key-shift__chip key-shift__chip--active">
@@ -2001,7 +1981,9 @@ export function ProjectView() {
                         <div className="key-stepper__value">
                           <div className="target-selector" ref={targetSelectorRef}>
                             <button
-                              className="target-selector__trigger"
+                              className={`target-selector__trigger${
+                                enharmonicDisplayMode === "dual" ? " target-selector__trigger--dual" : ""
+                              }`}
                               aria-label="Target Key"
                               aria-expanded={targetSelectorOpen}
                               aria-haspopup="listbox"
@@ -2013,11 +1995,29 @@ export function ProjectView() {
                                   !lowerTargetPreview ? " target-selector__preview--disabled" : ""
                                 }`}
                               >
-                                <span>{lowerTargetPreview ?? ""}</span>
+                                {lowerTargetPreview ? (
+                                  <MusicalKeyLabel
+                                    keyValue={lowerTargetPreview}
+                                    mode={enharmonicDisplayMode}
+                                    variant="selector-preview"
+                                  />
+                                ) : null}
                               </span>
-                              <span className="target-selector__current">
-                                <span className="target-selector__current-key">
-                                  {formatKey(targetKey, "short", { mode: enharmonicDisplayMode })}
+                              <span
+                                className={`target-selector__current${
+                                  enharmonicDisplayMode === "dual" ? " target-selector__current--dual" : ""
+                                }`}
+                              >
+                                <span
+                                  className={`target-selector__current-key${
+                                    enharmonicDisplayMode === "dual" ? " target-selector__current-key--dual" : ""
+                                  }`}
+                                >
+                                  <MusicalKeyLabel
+                                    keyValue={targetKey}
+                                    mode={enharmonicDisplayMode}
+                                    variant="selector-current"
+                                  />
                                 </span>
                                 <span className="target-selector__current-meta">
                                   {targetSelectionSummary}
@@ -2028,7 +2028,13 @@ export function ProjectView() {
                                   !higherTargetPreview ? " target-selector__preview--disabled" : ""
                                 }`}
                               >
-                                <span>{higherTargetPreview ?? ""}</span>
+                                {higherTargetPreview ? (
+                                  <MusicalKeyLabel
+                                    keyValue={higherTargetPreview}
+                                    mode={enharmonicDisplayMode}
+                                    variant="selector-preview"
+                                  />
+                                ) : null}
                               </span>
                               <span className="target-selector__chevron" aria-hidden="true">
                                 ⌄
@@ -2065,7 +2071,13 @@ export function ProjectView() {
                                       ↑
                                     </span>
                                     <span className="target-selector__option-content">
-                                      <span className="target-selector__option-label">{option.label}</span>
+                                      <span className="target-selector__option-label">
+                                        <MusicalKeyLabel
+                                          keyValue={option.key}
+                                          mode={enharmonicDisplayMode}
+                                          variant="selector-option"
+                                        />
+                                      </span>
                                     </span>
                                   </button>
                                 ))}
@@ -2090,7 +2102,11 @@ export function ProjectView() {
                                   </span>
                                   <span className="target-selector__option-content">
                                     <span className="target-selector__option-label">
-                                      {formatKey(sourceKey, "short", { mode: enharmonicDisplayMode })}
+                                      <MusicalKeyLabel
+                                        keyValue={sourceKey}
+                                        mode={enharmonicDisplayMode}
+                                        variant="selector-option"
+                                      />
                                     </span>
                                   </span>
                                 </button>
@@ -2118,7 +2134,13 @@ export function ProjectView() {
                                       ↓
                                     </span>
                                     <span className="target-selector__option-content">
-                                      <span className="target-selector__option-label">{option.label}</span>
+                                      <span className="target-selector__option-label">
+                                        <MusicalKeyLabel
+                                          keyValue={option.key}
+                                          mode={enharmonicDisplayMode}
+                                          variant="selector-option"
+                                        />
+                                      </span>
                                     </span>
                                   </button>
                                 ))}
@@ -2191,13 +2213,17 @@ export function ProjectView() {
                     <div className="analysis-stat">
                       <span className="metric-label">Estimated Key</span>
                       <strong>
-                        <span className="analysis-stat__value">
-                          {detectedKey
-                            ? formatKey(detectedKey, "short", { mode: enharmonicDisplayMode })
-                            : isAnalysisRunning
-                              ? "Analyzing..."
-                              : "Unknown"}
-                        </span>
+                        {detectedKey ? (
+                          <MusicalKeyLabel
+                            keyValue={detectedKey}
+                            mode={enharmonicDisplayMode}
+                            variant="key-card"
+                          />
+                        ) : (
+                          <span className="analysis-stat__value">
+                            {isAnalysisRunning ? "Analyzing..." : "Unknown"}
+                          </span>
+                        )}
                       </strong>
                     </div>
                     <div className="analysis-stat">
@@ -2214,35 +2240,96 @@ export function ProjectView() {
                     <p className="artifact-meta">
                       {sourceKeyOverride
                         ? `Using ${formatKey(sourceKeyOverride, "short", { mode: enharmonicDisplayMode })} everywhere keys are derived in this project. Analysis data stays unchanged.`
-                        : "Use this to change the detected key, if you think analysis got it wrong. It updates the project key, and practice mixes."}
+                        : "Use this to change the detected key, if you think analysis got it wrong. It updates the project key, chords and practice mixes."}
                     </p>
                     <div className="controls controls--tight">
-                      <label>
-                        Project Source Key
-                        <select
-                          aria-label="Project Source Key"
-                          value={currentKeyValue}
-                          onChange={(event) =>
-                            sourceKeyOverrideMutation.mutate(
-                              event.target.value === "auto" ? null : event.target.value,
-                            )
-                          }
-                          disabled={sourceKeyOverrideMutation.isPending}
-                        >
-                          {detectedKey ? (
-                            <option value="auto">
-                              Use analysis result ({formatKey(detectedKey, "short", { mode: enharmonicDisplayMode })})
-                            </option>
-                          ) : (
-                            <option value={serializeKey(sourceKey)}>No override</option>
-                          )}
-                          {MUSICAL_KEYS.map((key) => (
-                            <option key={key.value} value={key.value}>
-                              {formatKey(key, "short", { mode: enharmonicDisplayMode })}
-                            </option>
-                          ))}
-                        </select>
-                      </label>
+                      <div className="source-key-selector-field">
+                        <span className="source-key-selector-field__label">Project Source Key</span>
+                        <div className="source-key-selector" ref={sourceKeySelectorRef}>
+                          <button
+                            className={`source-key-selector__trigger${
+                              sourceKeySelectorOpen ? " source-key-selector__trigger--open" : ""
+                            }`}
+                            aria-label="Project Source Key"
+                            aria-expanded={sourceKeySelectorOpen}
+                            aria-haspopup="listbox"
+                            disabled={sourceKeyOverrideMutation.isPending}
+                            onClick={() => {
+                              setTargetSelectorOpen(false);
+                              setSourceKeySelectorOpen((current) => !current);
+                            }}
+                            type="button"
+                          >
+                            <span className="source-key-selector__current">
+                              <span className="source-key-selector__current-indicator" aria-hidden="true" />
+                              <span className="source-key-selector__current-label">
+                                <MusicalKeyLabel
+                                  keyValue={sourceKeySelectorCurrentKey}
+                                  mode={enharmonicDisplayMode}
+                                  variant="source-selector-current"
+                                />
+                              </span>
+                              {sourceKeySelectorCurrentBadge ? (
+                                <span className="source-key-selector__current-badge">
+                                  {sourceKeySelectorCurrentBadge}
+                                </span>
+                              ) : null}
+                            </span>
+                            <span className="source-key-selector__chevron" aria-hidden="true">
+                              ⌄
+                            </span>
+                          </button>
+
+                          {sourceKeySelectorOpen ? (
+                            <div
+                              className="source-key-selector__menu"
+                              role="listbox"
+                              aria-label="Project Source Key options"
+                            >
+                              {sourceKeyOptions.map((option) => {
+                                const isSelected = option.value === currentKeyValue;
+                                return (
+                                  <button
+                                    key={`${option.value}-${option.badge ?? "key"}`}
+                                    ref={(node) => {
+                                      sourceKeyOptionRefs.current[option.value] = node;
+                                    }}
+                                    aria-selected={isSelected}
+                                    className={`source-key-selector__option${
+                                      isSelected ? " source-key-selector__option--selected" : ""
+                                    }`}
+                                    disabled={sourceKeyOverrideMutation.isPending}
+                                    onClick={() => {
+                                      sourceKeyOverrideMutation.mutate(
+                                        option.value === "auto" ? null : option.value,
+                                      );
+                                      setSourceKeySelectorOpen(false);
+                                    }}
+                                    role="option"
+                                    type="button"
+                                  >
+                                    <span className="source-key-selector__option-content">
+                                      <span className="source-key-selector__option-indicator" aria-hidden="true" />
+                                      <span className="source-key-selector__option-label">
+                                        <MusicalKeyLabel
+                                          keyValue={option.key}
+                                          mode={enharmonicDisplayMode}
+                                          variant="source-selector-option"
+                                        />
+                                      </span>
+                                      {option.badge ? (
+                                        <span className="source-key-selector__option-badge">
+                                          {option.badge}
+                                        </span>
+                                      ) : null}
+                                    </span>
+                                  </button>
+                                );
+                              })}
+                            </div>
+                          ) : null}
+                        </div>
+                      </div>
                     </div>
                   </details>
                 </div>

--- a/apps/desktop/src/lib/music.test.ts
+++ b/apps/desktop/src/lib/music.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  formatChordDisplay,
   formatChordLabel,
   formatKey,
+  formatKeyDisplay,
   formatPitchClass,
   getEnharmonicContext,
   type MusicalKey,
@@ -40,5 +42,18 @@ describe("enharmonic formatting", () => {
     expect(formatKey({ pitchClass: 1, mode: "major" }, "short", { mode: "flats" })).toBe("Db");
     expect(formatPitchClass(8, { mode: "neutral" })).toBe("Ab");
     expect(formatChordLabel(10, "major", { mode: "dual" })).toBe("A#/Bb");
+  });
+
+  it("renders dual labels in fixed note order with minor suffixes preserved", () => {
+    expect(formatKeyDisplay({ pitchClass: 3, mode: "minor" }, { mode: "dual" })).toEqual({
+      ariaLabel: "D#m / Ebm",
+      primary: { root: "D#", suffix: "m" },
+      secondary: { root: "Eb", suffix: "m" },
+    });
+    expect(formatChordDisplay(3, "minor", { mode: "dual" })).toEqual({
+      ariaLabel: "D#m / Ebm",
+      primary: { root: "D#", suffix: "m" },
+      secondary: { root: "Eb", suffix: "m" },
+    });
   });
 });

--- a/apps/desktop/src/lib/music.ts
+++ b/apps/desktop/src/lib/music.ts
@@ -19,6 +19,17 @@ export type EnharmonicContext = {
   family: AccidentalFamily;
 };
 
+export type MusicalLabelPart = {
+  root: string;
+  suffix: string;
+};
+
+export type FormattedMusicalLabel = {
+  ariaLabel: string;
+  primary: MusicalLabelPart;
+  secondary: MusicalLabelPart | null;
+};
+
 const ENHARMONIC_ALIASES: Record<string, number> = {
   C: 0,
   "B#": 0,
@@ -191,6 +202,25 @@ export function formatKey(
   return key.mode === "minor" ? `${noteName}m` : noteName;
 }
 
+export function formatKeyDisplay(
+  key: MusicalKey,
+  options: PitchFormatOptions = {},
+): FormattedMusicalLabel {
+  const { primaryLabel, secondaryLabel } =
+    options.mode === "dual"
+      ? formatDualKeyLabels(key)
+      : {
+          primaryLabel: formatKey(key, "short", options),
+          secondaryLabel: null,
+        };
+
+  return {
+    ariaLabel: secondaryLabel ? `${primaryLabel} / ${secondaryLabel}` : primaryLabel,
+    primary: splitMusicalLabel(primaryLabel),
+    secondary: secondaryLabel ? splitMusicalLabel(secondaryLabel) : null,
+  };
+}
+
 export function formatPitchClass(pitchClass: number, options: PitchFormatOptions = {}): string {
   const normalizedPitchClass = normalizePitchClass(pitchClass);
   const context = getEnharmonicContext(options.activeKey, options.mode);
@@ -236,6 +266,26 @@ export function formatChordLabel(
   return quality === "minor" ? `${noteName}m` : noteName;
 }
 
+export function formatChordDisplay(
+  pitchClass: number,
+  quality: ChordQuality,
+  options: PitchFormatOptions = {},
+): FormattedMusicalLabel {
+  const { primaryLabel, secondaryLabel } =
+    options.mode === "dual"
+      ? formatDualChordLabels(pitchClass, quality)
+      : {
+          primaryLabel: formatChordLabel(pitchClass, quality, options),
+          secondaryLabel: null,
+        };
+
+  return {
+    ariaLabel: secondaryLabel ? `${primaryLabel} / ${secondaryLabel}` : primaryLabel,
+    primary: splitMusicalLabel(primaryLabel),
+    secondary: secondaryLabel ? splitMusicalLabel(secondaryLabel) : null,
+  };
+}
+
 export function formatAlternateKey(
   key: MusicalKey,
   format: "short" | "long" = "short",
@@ -266,6 +316,14 @@ export function formatAlternateChordLabel(
   return quality === "minor" ? `${alternateRoot}m` : alternateRoot;
 }
 
+export function formatRawMusicalLabel(label: string): FormattedMusicalLabel {
+  return {
+    ariaLabel: label,
+    primary: splitMusicalLabel(label),
+    secondary: null,
+  };
+}
+
 export function transposePitchClass(pitchClass: number, semitones: number): number {
   return ((pitchClass + semitones) % 12 + 12) % 12;
 }
@@ -288,8 +346,50 @@ function normalizeNoteName(noteName: string): string {
   return `${letter.toUpperCase()}${accidental}`;
 }
 
+function splitMusicalLabel(label: string): MusicalLabelPart {
+  const match = label.match(/^([A-G](?:#|b)?)(.*)$/);
+  if (!match) {
+    return { root: label, suffix: "" };
+  }
+  return {
+    root: match[1],
+    suffix: match[2] ?? "",
+  };
+}
+
 function normalizePitchClass(pitchClass: number): number {
   return ((pitchClass % 12) + 12) % 12;
+}
+
+function formatDualKeyLabels(key: MusicalKey): { primaryLabel: string; secondaryLabel: string | null } {
+  const { primaryRoot, secondaryRoot } = getDualPitchClassParts(key.pitchClass);
+  const suffix = key.mode === "minor" ? "m" : "";
+  return {
+    primaryLabel: `${primaryRoot}${suffix}`,
+    secondaryLabel: secondaryRoot ? `${secondaryRoot}${suffix}` : null,
+  };
+}
+
+function formatDualChordLabels(
+  pitchClass: number,
+  quality: ChordQuality,
+): { primaryLabel: string; secondaryLabel: string | null } {
+  const { primaryRoot, secondaryRoot } = getDualPitchClassParts(pitchClass);
+  const suffix = quality === "minor" ? "m" : "";
+  return {
+    primaryLabel: `${primaryRoot}${suffix}`,
+    secondaryLabel: secondaryRoot ? `${secondaryRoot}${suffix}` : null,
+  };
+}
+
+function getDualPitchClassParts(pitchClass: number): { primaryRoot: string; secondaryRoot: string | null } {
+  const normalizedPitchClass = normalizePitchClass(pitchClass);
+  const dualLabel = DUAL_PITCH_CLASSES[normalizedPitchClass] ?? DUAL_PITCH_CLASSES[0];
+  const [primaryRoot, secondaryRoot] = dualLabel.split("/");
+  return {
+    primaryRoot,
+    secondaryRoot: secondaryRoot ?? null,
+  };
 }
 
 function formatDualPitchClass(pitchClass: number, suffix = ""): string {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -711,8 +711,7 @@ a {
 
 .meta-grid,
 .analysis-grid,
-.details-grid,
-.session-block {
+.details-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1rem;
@@ -741,6 +740,7 @@ a {
   flex-wrap: nowrap;
   font-size: 1.18rem;
   line-height: 1.1;
+  min-width: 0;
   white-space: nowrap;
 }
 
@@ -892,11 +892,6 @@ a {
     linear-gradient(180deg, color-mix(in srgb, var(--panel-strong) 80%, transparent), transparent);
 }
 
-.playback-stage__summary {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.session-block strong,
 .stem-mixer__summary strong {
   display: block;
   margin-top: 0.25rem;
@@ -1160,10 +1155,11 @@ a {
 }
 
 .chord-card strong {
-  display: block;
+  display: flex;
   margin-top: 0.45rem;
   font-size: clamp(2rem, 4vw, 2.6rem);
   line-height: 1;
+  min-width: 0;
 }
 
 .chord-context {
@@ -1200,9 +1196,10 @@ a {
 }
 
 .chord-segment span {
+  display: flex;
   font-size: 1.2rem;
   font-weight: 700;
-  white-space: nowrap;
+  min-width: 0;
 }
 
 .chord-segment small {
@@ -1404,10 +1401,173 @@ a {
 }
 
 .key-shift__card strong {
-  display: block;
+  display: flex;
   margin-top: 0.4rem;
   font-size: clamp(2rem, 3vw, 2.4rem);
   line-height: 0.95;
+  min-width: 0;
+}
+
+.musical-label {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.12em;
+  width: 100%;
+  min-width: 0;
+}
+
+.musical-label__primary,
+.musical-label__secondary {
+  display: block;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.musical-label__root {
+  display: inline;
+}
+
+.musical-label__suffix {
+  display: inline;
+  font-size: 0.54em;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  line-height: inherit;
+  margin-left: 0.01em;
+  vertical-align: baseline;
+}
+
+.musical-label__secondary {
+  color: color-mix(in srgb, var(--muted) 86%, var(--text) 14%);
+  font-size: 0.44em;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  line-height: 0.96;
+}
+
+.musical-label--key-card,
+.musical-label--chord-card {
+  align-items: flex-start;
+  gap: 0.18em;
+}
+
+.musical-label--key-card .musical-label__primary,
+.musical-label--key-card .musical-label__secondary,
+.musical-label--chord-card .musical-label__primary,
+.musical-label--chord-card .musical-label__secondary,
+.musical-label--selector-option .musical-label__primary,
+.musical-label--selector-option .musical-label__secondary,
+.musical-label--chord-chip .musical-label__primary,
+.musical-label--chord-chip .musical-label__secondary {
+  justify-content: flex-start;
+  text-align: left;
+}
+
+.musical-label--selector-preview {
+  gap: 0.08em;
+}
+
+.musical-label--selector-preview .musical-label__primary {
+  font-size: 0.94em;
+  overflow: visible;
+  text-overflow: clip;
+}
+
+.musical-label--selector-preview .musical-label__secondary {
+  font-size: 0.54em;
+  overflow: visible;
+  text-overflow: clip;
+}
+
+.musical-label--selector-current {
+  gap: 0.08em;
+}
+
+.musical-label--source-selector-current,
+.musical-label--source-selector-option {
+  align-items: flex-start;
+  gap: 0.08em;
+  width: auto;
+}
+
+.musical-label--source-selector-current .musical-label__primary,
+.musical-label--source-selector-current .musical-label__secondary,
+.musical-label--source-selector-option .musical-label__primary,
+.musical-label--source-selector-option .musical-label__secondary {
+  justify-content: flex-start;
+  text-align: left;
+}
+
+.musical-label--source-selector-current .musical-label__primary {
+  font-size: 1.02em;
+  overflow: visible;
+  text-overflow: clip;
+}
+
+.musical-label--source-selector-current .musical-label__secondary {
+  color: color-mix(in srgb, var(--text-secondary) 74%, var(--playback-accent) 26%);
+  font-size: 0.42em;
+  overflow: visible;
+  text-overflow: clip;
+}
+
+.musical-label--source-selector-option .musical-label__primary {
+  font-size: 1em;
+  overflow: visible;
+  text-overflow: clip;
+}
+
+.musical-label--source-selector-option .musical-label__secondary {
+  font-size: 0.54em;
+  overflow: visible;
+  text-overflow: clip;
+}
+
+.musical-label--selector-current .musical-label__primary {
+  font-size: 0.88em;
+}
+
+.musical-label--selector-current .musical-label__secondary {
+  color: color-mix(in srgb, var(--text-secondary) 72%, var(--playback-accent) 28%);
+  font-size: 0.34em;
+  font-weight: 650;
+}
+
+.musical-label--selector-option {
+  align-items: flex-start;
+  gap: 0.08em;
+}
+
+.musical-label--selector-option .musical-label__secondary {
+  font-size: 0.72em;
+}
+
+.musical-label--key-card .musical-label__root,
+.musical-label--source-selector-current .musical-label__root,
+.musical-label--source-selector-option .musical-label__root,
+.musical-label--selector-current .musical-label__root,
+.musical-label--selector-preview .musical-label__root,
+.musical-label--selector-option .musical-label__root {
+  overflow: visible;
+  text-overflow: clip;
+}
+
+.musical-label--chord-chip {
+  align-items: flex-start;
+  gap: 0.08em;
+}
+
+.musical-label--chord-chip .musical-label__primary {
+  font-size: 0.98em;
+}
+
+.musical-label--chord-chip .musical-label__secondary {
+  font-size: 0.56em;
 }
 
 .key-shift__chips {
@@ -1472,6 +1632,255 @@ a {
   min-width: 0;
 }
 
+.source-key-selector-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.source-key-selector-field__label {
+  color: var(--muted);
+}
+
+.source-key-selector {
+  position: relative;
+  width: min(100%, 18rem);
+}
+
+.source-key-selector__trigger {
+  width: 100%;
+  min-height: 4rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.85rem;
+  padding: 0.55rem 0.85rem;
+  border: 1px solid color-mix(in srgb, var(--chip-active-border) 36%, var(--input-border));
+  border-radius: 999px;
+  background:
+    radial-gradient(
+      circle at 50% 0%,
+      color-mix(in srgb, white 9%, transparent),
+      transparent 58%
+    ),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--panel-strong) 91%, var(--panel) 9%),
+      color-mix(in srgb, var(--panel) 88%, black 12%)
+    );
+  color: var(--text);
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 12%, transparent),
+    inset 0 -0.9rem 1.35rem color-mix(in srgb, black 15%, transparent),
+    0 0.65rem 1.5rem color-mix(in srgb, black 14%, transparent);
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease,
+    background 160ms ease;
+}
+
+.source-key-selector__trigger::before {
+  content: "";
+  position: absolute;
+  inset: 0.22rem;
+  border-radius: inherit;
+  border: 1px solid color-mix(in srgb, white 5%, transparent);
+  pointer-events: none;
+  opacity: 0.7;
+}
+
+.source-key-selector__trigger:hover {
+  border-color: var(--button-hover-border);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 13%, transparent),
+    inset 0 -1rem 1.5rem color-mix(in srgb, black 17%, transparent),
+    0 0.85rem 1.75rem color-mix(in srgb, black 17%, transparent);
+  transform: translateY(-1px);
+}
+
+.source-key-selector__trigger:focus-visible,
+.source-key-selector__option:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.source-key-selector__trigger--open {
+  border-color: var(--chip-active-border);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 14%, transparent),
+    inset 0 -1rem 1.55rem color-mix(in srgb, black 18%, transparent),
+    0 1rem 2rem color-mix(in srgb, black 18%, transparent);
+}
+
+.source-key-selector__current {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.source-key-selector__current-indicator,
+.source-key-selector__option-indicator {
+  width: 1.1rem;
+  height: 1.1rem;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--chip-active-border) 28%, var(--divider));
+  background:
+    radial-gradient(circle at 35% 30%, color-mix(in srgb, white 24%, transparent), transparent 48%),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--panel-strong) 88%, transparent),
+      color-mix(in srgb, var(--panel) 78%, black 22%)
+    );
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 10%, transparent);
+  position: relative;
+}
+
+.source-key-selector__current-indicator::after,
+.source-key-selector__option--selected .source-key-selector__option-indicator::after {
+  content: "";
+  position: absolute;
+  inset: 0.24rem;
+  border-radius: inherit;
+  background: color-mix(in srgb, var(--playback-accent) 74%, var(--text));
+  box-shadow: 0 0 0.55rem color-mix(in srgb, var(--playback-accent) 24%, transparent);
+}
+
+.source-key-selector__current-label {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  flex: 1;
+}
+
+.source-key-selector__current-badge,
+.source-key-selector__option-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 1.65rem;
+  padding: 0.15rem 0.55rem;
+  border: 1px solid color-mix(in srgb, var(--chip-active-border) 58%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--chip-active-bg) 86%, transparent);
+  color: color-mix(in srgb, white 88%, var(--text));
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.source-key-selector__chevron {
+  color: color-mix(in srgb, var(--chip-active-border) 82%, var(--text));
+  font-size: 1.08rem;
+  line-height: 1;
+  flex: 0 0 auto;
+}
+
+.source-key-selector__menu {
+  position: absolute;
+  left: 0;
+  top: calc(100% + 0.65rem);
+  width: 100%;
+  z-index: 10;
+  max-height: 19.5rem;
+  overflow-y: auto;
+  padding: 0.58rem;
+  border: 1px solid color-mix(in srgb, var(--chip-active-border) 18%, var(--divider));
+  border-radius: 24px;
+  background:
+    radial-gradient(
+      circle at top,
+      color-mix(in srgb, var(--playback-accent) 9%, transparent),
+      transparent 43%
+    ),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--panel-strong) 96%, var(--panel) 4%),
+      color-mix(in srgb, var(--panel) 90%, black 10%)
+    );
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 8%, transparent),
+    0 1.25rem 3rem color-mix(in srgb, black 30%, transparent);
+  backdrop-filter: blur(14px);
+}
+
+.source-key-selector__option {
+  width: 100%;
+  display: flex;
+  margin: 0;
+  padding: 0.7rem 0.82rem;
+  border: 1px solid transparent;
+  border-radius: 18px;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+  box-shadow: inset 0 1px 0 transparent;
+  transition:
+    border-color 160ms ease,
+    background 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.source-key-selector__option:hover {
+  border-color: var(--button-hover-border);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--panel-strong) 78%, transparent),
+      color-mix(in srgb, var(--panel) 62%, transparent)
+    );
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 5%, transparent),
+    0 0.55rem 1.2rem color-mix(in srgb, black 10%, transparent);
+  transform: translateY(-1px);
+}
+
+.source-key-selector__option--selected {
+  border-color: color-mix(in srgb, var(--chip-active-border) 82%, var(--playback-accent) 18%);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--playback-accent) 12%, var(--panel-strong) 88%),
+      color-mix(in srgb, var(--panel) 84%, black 16%)
+    );
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 8%, transparent),
+    0 0.8rem 1.6rem color-mix(in srgb, black 12%, transparent);
+}
+
+.source-key-selector__option-content {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  width: 100%;
+  min-width: 0;
+}
+
+.source-key-selector__option-label {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  flex: 1;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.source-key-selector__option--selected .source-key-selector__option-label {
+  color: color-mix(in srgb, white 90%, var(--text));
+}
+
 .target-selector {
   position: relative;
   width: 100%;
@@ -1482,7 +1891,7 @@ a {
   width: 100%;
   min-height: 4.8rem;
   display: grid;
-  grid-template-columns: minmax(0, 0.78fr) minmax(0, 1.08fr) minmax(0, 0.78fr);
+  grid-template-columns: minmax(0, 0.7fr) minmax(0, 1.26fr) minmax(0, 0.7fr);
   align-items: center;
   gap: 0;
   padding: 0.28rem;
@@ -1514,6 +1923,10 @@ a {
     background 160ms ease;
 }
 
+.target-selector__trigger--dual {
+  grid-template-columns: minmax(0, 0.64fr) minmax(0, 1.42fr) minmax(0, 0.64fr);
+}
+
 .target-selector__trigger::before {
   content: "";
   position: absolute;
@@ -1540,20 +1953,28 @@ a {
   min-width: 0;
   color: color-mix(in srgb, var(--muted) 74%, var(--text) 26%);
   min-height: 4.22rem;
-  padding: 0.45rem 0.65rem 0.9rem;
-  font-size: clamp(0.96rem, 1.55vw, 1.14rem);
+  padding: 0.45rem 0.35rem 0.9rem;
+  font-size: clamp(0.88rem, 1.35vw, 1.02rem);
   font-weight: 600;
   letter-spacing: -0.01em;
   line-height: 1.05;
   text-align: center;
+  overflow: visible;
+}
+
+.target-selector__preview > .musical-label {
+  width: auto;
+  max-width: 100%;
 }
 
 .target-selector__preview--lower {
   border-right: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+  justify-content: flex-start;
 }
 
 .target-selector__preview--higher {
   border-left: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+  justify-content: flex-end;
 }
 
 .target-selector__preview--disabled {
@@ -1569,7 +1990,7 @@ a {
   min-width: 0;
   min-height: 4.18rem;
   margin: 0 0.16rem;
-  padding: 0.52rem 1rem 0.94rem;
+  padding: 0.52rem 0.72rem 0.94rem;
   border-radius: 999px;
   border: 1px solid color-mix(in srgb, var(--chip-active-border) 68%, transparent);
   background:
@@ -1590,11 +2011,52 @@ a {
   text-align: center;
 }
 
+.target-selector__current--dual {
+  padding-inline: 0.58rem;
+}
+
 .target-selector__current-key {
-  font-size: clamp(2rem, 2.7vw, 2.45rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-width: 0;
+  font-size: clamp(1.88rem, 2.45vw, 2.28rem);
   font-weight: 700;
-  letter-spacing: -0.03em;
+  letter-spacing: -0.01em;
   line-height: 0.9;
+}
+
+.target-selector__current-key--dual {
+  font-size: clamp(1.72rem, 2.18vw, 2.02rem);
+}
+
+.target-selector__current-key > .musical-label {
+  width: auto;
+  max-width: 100%;
+}
+
+.musical-label--selector-current .musical-label__primary,
+.musical-label--selector-current .musical-label__secondary {
+  overflow: visible;
+  text-overflow: clip;
+}
+
+.musical-label--selector-current.musical-label--dual {
+  gap: 0.04em;
+  width: 100%;
+}
+
+.musical-label--selector-current.musical-label--dual .musical-label__primary {
+  font-size: 0.78em;
+  overflow: visible;
+  text-overflow: clip;
+}
+
+.musical-label--selector-current.musical-label--dual .musical-label__secondary {
+  font-size: 0.3em;
+  overflow: visible;
+  text-overflow: clip;
 }
 
 .target-selector__current-meta {
@@ -1726,6 +2188,10 @@ a {
 }
 
 .target-selector__option-label {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
   font-size: 1.04rem;
   font-weight: 700;
   letter-spacing: -0.01em;
@@ -1762,7 +2228,6 @@ a {
 }
 
 .target-selector__preview,
-.target-selector__option-label,
 .target-selector__option-content {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2151,7 +2616,6 @@ a {
   .analysis-grid,
   .details-grid,
   .details-stack,
-  .playback-stage__summary,
   .chord-preview-grid,
   .key-shift__header,
   .stem-row {


### PR DESCRIPTION
## Summary
- add shared musical key and chord label rendering across inspector, selectors, chord follow, and analysis surfaces
- polish mix-builder and source-key correction selectors for single-label and dual-label enharmonic display without duplicated detected-key entries
- simplify playback panel by removing duplicated playback summaries and make source-key overrides shift displayed chords visually without rerunning analysis

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter @tuneforge/desktop test -- --run src/App.test.tsx`
