### PR TITLE
feat: add editable project lyrics workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tuneforge
 
-Tuneforge is a local-first, open-source desktop app for musicians who want to learn, rehearse, and play along with songs. Drop in any track and Tuneforge will split it into vocals and backing instruments, work out the key, tempo, and chord progression, and let you shift the pitch, retune to a reference frequency, and export a custom version to practice with.
+Tuneforge is a local-first, open-source desktop app for musicians who want to learn, rehearse, and play along with songs. Drop in any track and Tuneforge will split it into vocals and backing instruments, work out the key, tempo, chord progression, and lyrics, and let you shift the pitch, retune to a reference frequency, follow the transcript during playback, and export a custom version to practice with.
 
 Think "AI-assisted song toolkit for the player at home" — but **fully local, single-user, and with no cloud component**. Every track stays on your machine, no account, no upload, no network round-trip after the initial model download.
 
@@ -12,6 +12,8 @@ Pre-1.0. The desktop dev flow (`pnpm dev`) is the supported way to run the app t
 
 - Import `mp3`, `wav`, `flac`, `m4a`, `aac`, `ogg`, `mp4`, and `webm`. `mp4` / `webm` are transcoded to a local WAV working file at import time.
 - Key, tempo, and chord-timeline analysis.
+- Local lyrics transcription with segment and word timestamps when available.
+- In-app lyrics editing with transcript refresh and playback follow.
 - Pitch transpose (semitones) and retune (target reference Hz).
 - Stem separation via a local Demucs backend (`htdemucs_ft` by default).
 - Preview rendering (cached) and export to `wav`, `mp3`, or `flac`.
@@ -97,6 +99,8 @@ Backend behavior is environment-driven. Full table is in [apps/backend/README.md
 | `TUNEFORGE_FFMPEG_PATH` / `TUNEFORGE_FFPROBE_PATH` | `ffmpeg` / `ffprobe` | Override binary lookup. |
 | `TUNEFORGE_STEM_MODEL` | `htdemucs_ft` | Demucs model. |
 | `TUNEFORGE_STEM_DEVICE` | `auto` | `auto` / `cpu` / `mps` / `cuda`. |
+| `TUNEFORGE_LYRICS_MODEL` | `turbo` | Whisper model for lyrics transcription. |
+| `TUNEFORGE_LYRICS_DEVICE` | `auto` | `auto` / `cpu` / `mps` / `cuda`. |
 
 Default data directory:
 

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -82,11 +82,16 @@ All configuration is environment-driven (see [`app/config.py`](./app/config.py))
 | `TUNEFORGE_FFPROBE_PATH` | `ffprobe` | Override the `ffprobe` binary location. |
 | `TUNEFORGE_STEM_MODEL` | `htdemucs_ft` | Demucs model used for stem separation. |
 | `TUNEFORGE_STEM_DEVICE` | `auto` | One of `auto`, `cpu`, `mps`, `cuda`. `auto` prefers compatible CUDA, then MPS, then CPU. |
+| `TUNEFORGE_LYRICS_MODEL` | `turbo` | Whisper model used for lyrics generation. |
+| `TUNEFORGE_LYRICS_DEVICE` | `auto` | One of `auto`, `cpu`, `mps`, `cuda`. `auto` prefers compatible CUDA, then MPS, then CPU. |
+| `TUNEFORGE_LYRICS_CACHE_DIR` | `<data>/cache/lyrics` | Override where Whisper model weights are cached. |
 
 Default data directory:
 
 - macOS: `~/Library/Application Support/Tuneforge`
 - Linux: `~/.local/share/tuneforge`
+
+Lyrics models follow the same first-use download pattern as Demucs. The selected Whisper weights are downloaded on demand into the lyrics cache directory, then reused offline on later runs.
 
 ## Migrations
 

--- a/apps/backend/alembic/versions/0004_lyrics_transcripts.py
+++ b/apps/backend/alembic/versions/0004_lyrics_transcripts.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0004_lyrics_transcripts"
+down_revision = "0003_project_source_key_override"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "lyrics_transcripts",
+        sa.Column("project_id", sa.String(length=32), nullable=False),
+        sa.Column("backend", sa.String(length=64), nullable=False),
+        sa.Column("source_artifact_id", sa.String(length=32), nullable=True),
+        sa.Column("source_kind", sa.String(length=32), nullable=False),
+        sa.Column("source_segments_json", sa.JSON(), nullable=False),
+        sa.Column("segments_json", sa.JSON(), nullable=False),
+        sa.Column("has_user_edits", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("project_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("lyrics_transcripts")

--- a/apps/backend/app/api/routes/projects.py
+++ b/apps/backend/app/api/routes/projects.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from app.dependencies import get_db, get_job_runner
 from app.errors import AppError
-from app.models import AnalysisResult, Artifact, ChordTimeline
+from app.models import AnalysisResult, Artifact, ChordTimeline, LyricsTranscript
 from app.schemas import (
     AnalysisRequest,
     AnalysisResponse,
@@ -19,6 +19,9 @@ from app.schemas import (
     ExportRequest,
     JobResponse,
     JobSchema,
+    LyricsGenerateRequest,
+    LyricsResponse,
+    LyricsUpdateRequest,
     PreviewRequest,
     ProjectImportRequest,
     ProjectResponse,
@@ -30,6 +33,7 @@ from app.schemas import (
     TransposeRequest,
 )
 from app.services.artifacts import delete_project_artifact
+from app.services.lyrics import update_project_lyrics
 from app.services.projects import (
     delete_project,
     get_project,
@@ -161,6 +165,56 @@ def project_chords_detail(project_id: str, session: Session = Depends(get_db)) -
     if chords is None:
         return ChordResponse(project_id=project_id, timeline=[], backend=None, source_artifact_id=None, created_at=None)
     return ChordResponse.model_validate(chords)
+
+
+@router.post("/{project_id}/lyrics", response_model=JobResponse)
+def project_lyrics(
+    project_id: str,
+    payload: LyricsGenerateRequest,
+    session: Session = Depends(get_db),
+    runner=Depends(get_job_runner),
+) -> JobResponse:
+    get_project(session, project_id)
+    job = runner.create_job(
+        session,
+        project_id=project_id,
+        job_type="lyrics",
+        payload=payload.model_dump(),
+    )
+    session.commit()
+    session.refresh(job)
+    runner.enqueue(job.id)
+    return JobResponse(job=JobSchema.model_validate(job))
+
+
+@router.get("/{project_id}/lyrics", response_model=LyricsResponse)
+def project_lyrics_detail(project_id: str, session: Session = Depends(get_db)) -> LyricsResponse:
+    get_project(session, project_id)
+    lyrics = session.get(LyricsTranscript, project_id)
+    if lyrics is None:
+        return LyricsResponse(
+            project_id=project_id,
+            backend=None,
+            source_artifact_id=None,
+            source_kind=None,
+            source_segments=[],
+            segments=[],
+            has_user_edits=False,
+            created_at=None,
+            updated_at=None,
+        )
+    return LyricsResponse.model_validate(lyrics)
+
+
+@router.put("/{project_id}/lyrics", response_model=LyricsResponse)
+def project_lyrics_update(
+    project_id: str,
+    payload: LyricsUpdateRequest,
+    session: Session = Depends(get_db),
+) -> LyricsResponse:
+    project = get_project(session, project_id)
+    lyrics = update_project_lyrics(session, project=project, edits=payload.segments)
+    return LyricsResponse.model_validate(lyrics)
 
 
 @router.post("/{project_id}/retune", response_model=JobResponse)

--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -35,6 +35,9 @@ class Settings:
     ffprobe_path: str
     stem_model: str
     stem_device: str
+    lyrics_model: str
+    lyrics_device: str
+    lyrics_cache_dir: Path
     max_workers: int
     backend_root: Path
 
@@ -51,13 +54,14 @@ class Settings:
 def get_settings() -> Settings:
     backend_root = Path(__file__).resolve().parents[1]
     data_root = _default_data_root()
+    cache_root = data_root / "cache"
     return Settings(
         app_name="Tuneforge",
         api_prefix="/api/v1",
         data_root=data_root,
         database_path=data_root / "app.sqlite",
         projects_root=data_root / "projects",
-        cache_root=data_root / "cache",
+        cache_root=cache_root,
         backend_host=os.environ.get("TUNEFORGE_HOST", "127.0.0.1"),
         backend_port=int(os.environ.get("TUNEFORGE_PORT", "8765")),
         default_export_format="wav",
@@ -68,6 +72,9 @@ def get_settings() -> Settings:
         ffprobe_path=os.environ.get("TUNEFORGE_FFPROBE_PATH", "ffprobe"),
         stem_model=os.environ.get("TUNEFORGE_STEM_MODEL", "htdemucs_ft"),
         stem_device=os.environ.get("TUNEFORGE_STEM_DEVICE", "auto"),
+        lyrics_model=os.environ.get("TUNEFORGE_LYRICS_MODEL", "turbo"),
+        lyrics_device=os.environ.get("TUNEFORGE_LYRICS_DEVICE", "auto"),
+        lyrics_cache_dir=Path(os.environ.get("TUNEFORGE_LYRICS_CACHE_DIR", str(cache_root / "lyrics"))),
         max_workers=1,
         backend_root=backend_root,
     )
@@ -78,3 +85,4 @@ def ensure_data_dirs(settings: Settings | None = None) -> None:
     current.data_root.mkdir(parents=True, exist_ok=True)
     current.projects_root.mkdir(parents=True, exist_ok=True)
     current.cache_root.mkdir(parents=True, exist_ok=True)
+    current.lyrics_cache_dir.mkdir(parents=True, exist_ok=True)

--- a/apps/backend/app/engines/lyrics.py
+++ b/apps/backend/app/engines/lyrics.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+from fastapi import status
+
+from app.errors import AppError
+from app.utils.torch_runtime import choose_torch_device, with_mps_fallback_env
+
+
+@dataclass(frozen=True)
+class LyricsTranscription:
+    backend: str
+    requested_device: str
+    device: str
+    model: str
+    language: str | None
+    segments: list[dict[str, Any]]
+
+
+def _require_dependency(module_name: str, message: str) -> None:
+    if importlib.util.find_spec(module_name) is None:
+        raise AppError(
+            "DEPENDENCY_MISSING",
+            message,
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+
+
+def patch_whisper_timing_for_mps(timing_module: Any) -> None:
+    if getattr(timing_module.dtw, "_tuneforge_mps_patch", False):
+        return
+
+    original_dtw = timing_module.dtw
+
+    def _patched_dtw(x: Any) -> Any:
+        device_type = getattr(getattr(x, "device", None), "type", None)
+        if device_type == "mps":
+            return timing_module.dtw_cpu(x.float().cpu().numpy())
+        return original_dtw(x)
+
+    patched_dtw = cast(Any, _patched_dtw)
+    patched_dtw._tuneforge_mps_patch = True
+    timing_module.dtw = patched_dtw
+
+
+def _load_runtime() -> tuple[Any, Any]:
+    _require_dependency("torch", "PyTorch is required for lyrics generation. Install the backend dependencies first.")
+    _require_dependency(
+        "whisper",
+        "openai-whisper is required for lyrics generation. Install the backend dependencies first.",
+    )
+    os.environ.update(with_mps_fallback_env(os.environ))
+    import torch  # type: ignore[import-not-found]
+    import whisper  # type: ignore[import-not-found]
+    from whisper import timing as whisper_timing  # type: ignore[import-not-found]
+
+    patch_whisper_timing_for_mps(whisper_timing)
+
+    return torch, whisper
+
+
+def resolve_whisper_device_candidates(requested: str, *, torch_module: Any) -> list[str]:
+    normalized = requested.strip().lower()
+    if normalized == "auto":
+        primary = choose_torch_device("auto", torch_module=torch_module)
+        return [primary] if primary == "cpu" else [primary, "cpu"]
+    if normalized == "cpu":
+        return ["cpu"]
+    try:
+        resolved = choose_torch_device(normalized, torch_module=torch_module)
+        return [resolved] if resolved == "cpu" else [resolved, "cpu"]
+    except ValueError as exc:
+        raise AppError("INVALID_REQUEST", str(exc), status_code=status.HTTP_400_BAD_REQUEST) from exc
+    except RuntimeError:
+        return ["cpu"]
+
+
+def _coerce_float(value: object) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _normalize_segments(raw_segments: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    segments: list[dict[str, Any]] = []
+    for raw_segment in raw_segments:
+        text = str(raw_segment.get("text", "")).strip()
+        if not text:
+            continue
+
+        segment: dict[str, Any] = {
+            "start_seconds": _coerce_float(raw_segment.get("start")),
+            "end_seconds": _coerce_float(raw_segment.get("end")),
+            "text": text,
+        }
+
+        words: list[dict[str, Any]] = []
+        for raw_word in raw_segment.get("words") or []:
+            word_text = str(raw_word.get("word", "")).strip()
+            if not word_text:
+                continue
+            words.append(
+                {
+                    "text": word_text,
+                    "start_seconds": _coerce_float(raw_word.get("start")),
+                    "end_seconds": _coerce_float(raw_word.get("end")),
+                    "confidence": _coerce_float(raw_word.get("probability")),
+                }
+            )
+
+        if words:
+            segment["words"] = words
+        segments.append(segment)
+    return segments
+
+
+def _transcribe_with_device(
+    source_path: Path,
+    *,
+    model_name: str,
+    device: str,
+    download_root: Path,
+    whisper_module: Any,
+) -> LyricsTranscription:
+    model = whisper_module.load_model(model_name, device=device, download_root=str(download_root))
+    result = whisper_module.transcribe(
+        model,
+        str(source_path),
+        verbose=False,
+        condition_on_previous_text=False,
+        word_timestamps=True,
+        fp16=device == "cuda",
+    )
+    segments = _normalize_segments(result.get("segments", []))
+    return LyricsTranscription(
+        backend="openai-whisper",
+        requested_device=device,
+        device=device,
+        model=model_name,
+        language=result.get("language"),
+        segments=segments,
+    )
+
+
+def transcribe_project_lyrics(
+    source_path: Path,
+    *,
+    model_name: str,
+    requested_device: str,
+    download_root: Path,
+) -> LyricsTranscription:
+    torch_module, whisper_module = _load_runtime()
+    candidates = resolve_whisper_device_candidates(requested_device, torch_module=torch_module)
+    errors: list[dict[str, str]] = []
+
+    for device in candidates:
+        try:
+            return _transcribe_with_device(
+                source_path,
+                model_name=model_name,
+                device=device,
+                download_root=download_root,
+                whisper_module=whisper_module,
+            )
+        except AppError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive fallback around whisper runtime
+            errors.append({"device": device, "message": str(exc)})
+            if device == "cpu":
+                break
+
+    raise AppError(
+        "PROCESSING_FAILED",
+        "Lyrics generation failed.",
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        details={"errors": errors},
+    )

--- a/apps/backend/app/models.py
+++ b/apps/backend/app/models.py
@@ -35,6 +35,9 @@ class Project(Base):
     chords: Mapped[ChordTimeline | None] = relationship(
         back_populates="project", uselist=False, cascade="all, delete-orphan"
     )
+    lyrics: Mapped[LyricsTranscript | None] = relationship(
+        back_populates="project", uselist=False, cascade="all, delete-orphan"
+    )
     artifacts: Mapped[list[Artifact]] = relationship(
         back_populates="project", cascade="all, delete-orphan"
     )
@@ -70,6 +73,26 @@ class ChordTimeline(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
 
     project: Mapped[Project] = relationship(back_populates="chords")
+
+
+class LyricsTranscript(Base):
+    __tablename__ = "lyrics_transcripts"
+
+    project_id: Mapped[str] = mapped_column(
+        String(32), ForeignKey("projects.id", ondelete="CASCADE"), primary_key=True
+    )
+    backend: Mapped[str] = mapped_column(String(64), default="openai-whisper")
+    source_artifact_id: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    source_kind: Mapped[str] = mapped_column(String(32), default="ai")
+    source_segments_json: Mapped[list[dict[str, Any]]] = mapped_column(JSON(), default=list)
+    segments_json: Mapped[list[dict[str, Any]]] = mapped_column(JSON(), default=list)
+    has_user_edits: Mapped[bool] = mapped_column(Boolean(), default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow, onupdate=utcnow
+    )
+
+    project: Mapped[Project] = relationship(back_populates="lyrics")
 
 
 class Artifact(Base):

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -152,6 +152,48 @@ class ChordResponse(BaseModel):
     created_at: datetime | None = None
 
 
+class LyricsGenerateRequest(BaseModel):
+    force: bool = False
+
+
+class LyricsWordSchema(BaseModel):
+    text: str
+    start_seconds: float | None = None
+    end_seconds: float | None = None
+    confidence: float | None = None
+
+
+class LyricsSegmentSchema(BaseModel):
+    start_seconds: float | None = None
+    end_seconds: float | None = None
+    text: str
+    words: list[LyricsWordSchema] = Field(default_factory=list)
+
+
+class LyricsEditSegmentSchema(BaseModel):
+    text: str
+
+
+class LyricsUpdateRequest(BaseModel):
+    segments: list[LyricsEditSegmentSchema] = Field(default_factory=list)
+
+
+class LyricsResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    project_id: str
+    backend: str | None = None
+    source_artifact_id: str | None = None
+    source_kind: str | None = None
+    source_segments: list[LyricsSegmentSchema] = Field(
+        default_factory=list, validation_alias="source_segments_json"
+    )
+    segments: list[LyricsSegmentSchema] = Field(default_factory=list, validation_alias="segments_json")
+    has_user_edits: bool = False
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
 class JobSchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/apps/backend/app/services/jobs.py
+++ b/apps/backend/app/services/jobs.py
@@ -13,6 +13,7 @@ from app.errors import AppError, JobCancelledError
 from app.models import Job
 from app.services.analysis import analyze_project
 from app.services.chords import detect_project_chords
+from app.services.lyrics import generate_project_lyrics
 from app.services.projects import get_project
 from app.services.stems import generate_stems
 from app.services.transformations import (
@@ -63,6 +64,7 @@ class InProcessJobRunner:
         self._handlers: dict[str, JobHandler] = {
             "analyze": self._handle_analyze,
             "chords": self._handle_chords,
+            "lyrics": self._handle_lyrics,
             "preview": self._handle_preview,
             "retune": self._handle_single_transform,
             "transpose": self._handle_single_transform,
@@ -246,6 +248,13 @@ class InProcessJobRunner:
         project = get_project(session, job.project_id or "")
         context.set_progress(20)
         detect_project_chords(session, project, force=bool(job.payload_json.get("force", False)))
+        context.set_progress(90)
+        return []
+
+    def _handle_lyrics(self, context: JobExecutionContext, session: Session, job: Job) -> list[str]:
+        project = get_project(session, job.project_id or "")
+        context.set_progress(15)
+        generate_project_lyrics(session, project=project, force=bool(job.payload_json.get("force", False)))
         context.set_progress(90)
         return []
 

--- a/apps/backend/app/services/lyrics.py
+++ b/apps/backend/app/services/lyrics.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, cast
+
+from fastapi import status
+from sqlalchemy.orm import Session
+
+from app.config import get_settings
+from app.engines.lyrics import transcribe_project_lyrics
+from app.errors import AppError
+from app.models import Artifact, LyricsTranscript, Project
+from app.schemas import LyricsEditSegmentSchema
+from app.services.paths import project_analysis_dir
+
+
+def _source_artifact(project: Project) -> Artifact | None:
+    artifact = next((artifact for artifact in project.artifacts if artifact.type == "source_audio"), None)
+    return artifact if isinstance(artifact, Artifact) else None
+
+
+def _write_lyrics_snapshot(
+    *,
+    project_id: str,
+    lyrics: LyricsTranscript,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    payload: dict[str, Any] = {
+        "project_id": project_id,
+        "backend": lyrics.backend,
+        "source_artifact_id": lyrics.source_artifact_id,
+        "source_kind": lyrics.source_kind,
+        "source_segments": lyrics.source_segments_json,
+        "segments": lyrics.segments_json,
+        "has_user_edits": lyrics.has_user_edits,
+        "created_at": lyrics.created_at.isoformat(),
+        "updated_at": lyrics.updated_at.isoformat(),
+    }
+    if metadata:
+        payload["metadata"] = metadata
+
+    lyrics_path = project_analysis_dir(project_id) / "lyrics.json"
+    lyrics_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def generate_project_lyrics(session: Session, *, project: Project, force: bool = False) -> LyricsTranscript:
+    existing = session.get(LyricsTranscript, project.id)
+    if existing is not None and existing.segments_json and not force:
+        return existing
+
+    transcription = transcribe_project_lyrics(
+        Path(project.imported_path),
+        model_name=get_settings().lyrics_model,
+        requested_device=get_settings().lyrics_device,
+        download_root=get_settings().lyrics_cache_dir,
+    )
+    source_artifact = _source_artifact(project)
+
+    if existing is None:
+        existing = LyricsTranscript(project_id=project.id)
+        session.add(existing)
+
+    existing.backend = transcription.backend
+    existing.source_artifact_id = source_artifact.id if source_artifact else None
+    existing.source_kind = "ai"
+    existing.source_segments_json = cast(list[dict[str, Any]], deepcopy(transcription.segments))
+    existing.segments_json = cast(list[dict[str, Any]], deepcopy(transcription.segments))
+    existing.has_user_edits = False
+    session.flush()
+    session.refresh(existing)
+
+    _write_lyrics_snapshot(
+        project_id=project.id,
+        lyrics=existing,
+        metadata={
+            "device": transcription.device,
+            "model": transcription.model,
+            "requested_device": get_settings().lyrics_device,
+            "language": transcription.language,
+        },
+    )
+    return existing
+
+
+def update_project_lyrics(
+    session: Session,
+    *,
+    project: Project,
+    edits: list[LyricsEditSegmentSchema],
+) -> LyricsTranscript:
+    lyrics = session.get(LyricsTranscript, project.id)
+    if lyrics is None:
+        raise AppError("LYRICS_NOT_FOUND", "Lyrics have not been generated for this project.", status_code=404)
+
+    current_segments = lyrics.segments_json
+    source_segments = lyrics.source_segments_json
+    if len(edits) != len(current_segments):
+        raise AppError(
+            "INVALID_REQUEST",
+            "Lyrics edits must preserve the existing segment count in v1.",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    updated_segments: list[dict[str, Any]] = []
+    for index, edit in enumerate(edits):
+        current_segment = dict(current_segments[index])
+        source_segment = source_segments[index] if index < len(source_segments) else None
+        text = edit.text
+        current_segment["text"] = text
+        current_segment["start_seconds"] = current_segments[index].get("start_seconds")
+        current_segment["end_seconds"] = current_segments[index].get("end_seconds")
+
+        if isinstance(source_segment, dict) and text == source_segment.get("text"):
+            if "words" in source_segment:
+                current_segment["words"] = deepcopy(source_segment["words"])
+            else:
+                current_segment.pop("words", None)
+        elif text != current_segments[index].get("text"):
+            current_segment.pop("words", None)
+
+        updated_segments.append(current_segment)
+
+    lyrics.segments_json = cast(list[dict[str, Any]], updated_segments)
+    lyrics.has_user_edits = updated_segments != source_segments
+    session.flush()
+    session.refresh(lyrics)
+    _write_lyrics_snapshot(project_id=project.id, lyrics=lyrics)
+    return lyrics

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
   "fastapi>=0.115.12,<1.0.0",
   "librosa>=0.10.2.post1,<1.0.0",
   "numpy>=1.26.4,<3.0.0",
+  "openai-whisper>=20250625,<20260000",
   "pydantic>=2.11.3,<3.0.0",
   "soundfile>=0.13.1,<1.0.0",
   "sqlalchemy>=2.0.40,<3.0.0",

--- a/apps/backend/tests/test_lyrics_engine.py
+++ b/apps/backend/tests/test_lyrics_engine.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from app.engines.lyrics import (
+    LyricsTranscription,
+    patch_whisper_timing_for_mps,
+    resolve_whisper_device_candidates,
+    transcribe_project_lyrics,
+)
+
+
+def make_fake_torch(*, has_mps: bool, has_cuda: bool):
+    return SimpleNamespace(
+        version=SimpleNamespace(cuda="13.0" if has_cuda else None),
+        backends=SimpleNamespace(
+            mps=SimpleNamespace(
+                is_available=lambda: has_mps,
+            )
+        ),
+        cuda=SimpleNamespace(
+            is_available=lambda: has_cuda,
+            get_arch_list=lambda: ["sm_75"] if has_cuda else [],
+            device_count=lambda: 1 if has_cuda else 0,
+            get_device_capability=lambda _index: (7, 5),
+        ),
+    )
+
+
+def test_resolve_whisper_device_candidates_auto_prefers_mps_then_cpu():
+    candidates = resolve_whisper_device_candidates(
+        "auto",
+        torch_module=make_fake_torch(has_mps=True, has_cuda=False),
+    )
+    assert candidates == ["mps", "cpu"]
+
+
+def test_resolve_whisper_device_candidates_requested_unavailable_gpu_falls_back_to_cpu():
+    candidates = resolve_whisper_device_candidates(
+        "cuda",
+        torch_module=make_fake_torch(has_mps=False, has_cuda=False),
+    )
+    assert candidates == ["cpu"]
+
+
+def test_patch_whisper_timing_for_mps_uses_float32_cpu_dtw():
+    calls: list[tuple[str, object]] = []
+
+    class FakeTensor:
+        device = SimpleNamespace(type="mps")
+
+        def float(self):
+            calls.append(("float", None))
+            return self
+
+        def cpu(self):
+            calls.append(("cpu", None))
+            return self
+
+        def numpy(self):
+            calls.append(("numpy", None))
+            return "float32-array"
+
+    def fake_original_dtw(x: object):
+        calls.append(("original_dtw", x))
+        return "original-result"
+
+    def fake_dtw_cpu(x: object):
+        calls.append(("dtw_cpu", x))
+        return "patched-result"
+
+    timing_module = SimpleNamespace(
+        dtw=fake_original_dtw,
+        dtw_cpu=fake_dtw_cpu,
+    )
+
+    patch_whisper_timing_for_mps(timing_module)
+
+    result = timing_module.dtw(FakeTensor())
+
+    assert result == "patched-result"
+    assert calls == [
+        ("float", None),
+        ("cpu", None),
+        ("numpy", None),
+        ("dtw_cpu", "float32-array"),
+    ]
+
+
+def test_patch_whisper_timing_for_mps_keeps_original_dtw_for_non_mps():
+    calls: list[tuple[str, object]] = []
+
+    def fake_original_dtw(x: object):
+        calls.append(("original_dtw", x))
+        return "original-result"
+
+    def fake_dtw_cpu(x: object):
+        calls.append(("dtw_cpu", x))
+        return "patched-result"
+
+    timing_module = SimpleNamespace(
+        dtw=fake_original_dtw,
+        dtw_cpu=fake_dtw_cpu,
+    )
+
+    patch_whisper_timing_for_mps(timing_module)
+
+    tensor = SimpleNamespace(device=SimpleNamespace(type="cpu"))
+    result = timing_module.dtw(tensor)
+
+    assert result == "original-result"
+    assert calls == [("original_dtw", tensor)]
+
+
+def test_transcribe_project_lyrics_falls_back_to_cpu(monkeypatch):
+    attempted_devices: list[str] = []
+
+    monkeypatch.setattr(
+        "app.engines.lyrics._load_runtime",
+        lambda: (make_fake_torch(has_mps=True, has_cuda=False), object()),
+    )
+
+    def fake_transcribe_with_device(
+        source_path: Path,
+        *,
+        model_name: str,
+        device: str,
+        download_root: Path,
+        whisper_module: object,
+    ) -> LyricsTranscription:
+        attempted_devices.append(device)
+        if device == "mps":
+            raise RuntimeError("MPS kernel failed")
+        return LyricsTranscription(
+            backend="openai-whisper",
+            requested_device=device,
+            device=device,
+            model=model_name,
+            language="en",
+            segments=[
+                {
+                    "start_seconds": 0.0,
+                    "end_seconds": 1.5,
+                    "text": "Hello world",
+                }
+            ],
+        )
+
+    monkeypatch.setattr("app.engines.lyrics._transcribe_with_device", fake_transcribe_with_device)
+
+    result = transcribe_project_lyrics(
+        Path("/tmp/fake.wav"),
+        model_name="turbo",
+        requested_device="auto",
+        download_root=Path("/tmp/lyrics-cache"),
+    )
+
+    assert attempted_devices == ["mps", "cpu"]
+    assert result.device == "cpu"
+    assert result.segments[0]["text"] == "Hello world"

--- a/apps/backend/tests/test_lyrics_flow.py
+++ b/apps/backend/tests/test_lyrics_flow.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.engines.lyrics import LyricsTranscription
+from app.errors import AppError
+
+from .conftest import wait_for_job
+
+
+def _first_source_artifact_id(client, project_id: str) -> str:
+    artifacts = client.get(f"/api/v1/projects/{project_id}/artifacts").json()["artifacts"]
+    return next(artifact["id"] for artifact in artifacts if artifact["type"] == "source_audio")
+
+
+def test_get_lyrics_returns_empty_payload_until_generated(client, sample_audio_file: Path):
+    project = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_audio_file), "copy_into_project": True},
+    ).json()["project"]
+
+    payload = client.get(f"/api/v1/projects/{project['id']}/lyrics").json()
+    assert payload["project_id"] == project["id"]
+    assert payload["segments"] == []
+    assert payload["source_segments"] == []
+    assert payload["has_user_edits"] is False
+
+
+def test_lyrics_job_persists_transcript_and_update_preserves_timings(
+    client,
+    monkeypatch,
+    sample_audio_file: Path,
+):
+    def fake_transcription(*_args, **_kwargs):
+        return LyricsTranscription(
+            backend="openai-whisper",
+            requested_device="cpu",
+            device="cpu",
+            model="turbo",
+            language="en",
+            segments=[
+                {
+                    "start_seconds": 0.0,
+                    "end_seconds": 1.2,
+                    "text": "First line",
+                    "words": [
+                        {
+                            "text": "First",
+                            "start_seconds": 0.0,
+                            "end_seconds": 0.5,
+                            "confidence": 0.9,
+                        }
+                    ],
+                },
+                {
+                    "start_seconds": 1.2,
+                    "end_seconds": 2.4,
+                    "text": "Second line",
+                },
+            ],
+        )
+
+    monkeypatch.setattr("app.services.lyrics.transcribe_project_lyrics", fake_transcription)
+
+    project = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_audio_file), "copy_into_project": True},
+    ).json()["project"]
+
+    job = client.post(f"/api/v1/projects/{project['id']}/lyrics", json={"force": False}).json()["job"]
+    assert wait_for_job(client, job["id"])["status"] == "completed"
+
+    created = client.get(f"/api/v1/projects/{project['id']}/lyrics").json()
+    assert created["backend"] == "openai-whisper"
+    assert created["source_artifact_id"] == _first_source_artifact_id(client, project["id"])
+    assert created["segments"][0]["text"] == "First line"
+    assert created["segments"][0]["words"][0]["text"] == "First"
+
+    updated = client.put(
+        f"/api/v1/projects/{project['id']}/lyrics",
+        json={"segments": [{"text": "Edited first line"}, {"text": "Second line"}]},
+    ).json()
+
+    assert updated["segments"][0]["text"] == "Edited first line"
+    assert updated["segments"][0]["start_seconds"] == 0.0
+    assert updated["segments"][0]["end_seconds"] == 1.2
+    assert updated["segments"][0]["words"] == []
+    assert updated["source_segments"][0]["text"] == "First line"
+    assert updated["has_user_edits"] is True
+
+
+def test_force_regenerate_replaces_current_and_clears_edit_flag(client, monkeypatch, sample_audio_file: Path):
+    responses = iter(
+        [
+            LyricsTranscription(
+                backend="openai-whisper",
+                requested_device="cpu",
+                device="cpu",
+                model="turbo",
+                language="en",
+                segments=[
+                    {
+                        "start_seconds": 0.0,
+                        "end_seconds": 1.0,
+                        "text": "Original line",
+                    }
+                ],
+            ),
+            LyricsTranscription(
+                backend="openai-whisper",
+                requested_device="cpu",
+                device="cpu",
+                model="turbo",
+                language="en",
+                segments=[
+                    {
+                        "start_seconds": 0.0,
+                        "end_seconds": 1.0,
+                        "text": "Regenerated line",
+                    }
+                ],
+            ),
+        ]
+    )
+
+    monkeypatch.setattr("app.services.lyrics.transcribe_project_lyrics", lambda *_args, **_kwargs: next(responses))
+
+    project = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_audio_file), "copy_into_project": True},
+    ).json()["project"]
+
+    first_job = client.post(f"/api/v1/projects/{project['id']}/lyrics", json={"force": False}).json()["job"]
+    assert wait_for_job(client, first_job["id"])["status"] == "completed"
+
+    client.put(
+        f"/api/v1/projects/{project['id']}/lyrics",
+        json={"segments": [{"text": "Manual edit"}]},
+    )
+
+    second_job = client.post(f"/api/v1/projects/{project['id']}/lyrics", json={"force": True}).json()["job"]
+    assert wait_for_job(client, second_job["id"])["status"] == "completed"
+
+    refreshed = client.get(f"/api/v1/projects/{project['id']}/lyrics").json()
+    assert refreshed["segments"][0]["text"] == "Regenerated line"
+    assert refreshed["source_segments"][0]["text"] == "Regenerated line"
+    assert refreshed["has_user_edits"] is False
+
+
+def test_lyrics_job_failure_surfaces_error_message(client, monkeypatch, sample_audio_file: Path):
+    def fail_transcription(*_args, **_kwargs):
+        raise AppError("PROCESSING_FAILED", "Lyrics model download failed.", status_code=500)
+
+    monkeypatch.setattr("app.services.lyrics.transcribe_project_lyrics", fail_transcription)
+
+    project = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_audio_file), "copy_into_project": True},
+    ).json()["project"]
+
+    job = client.post(f"/api/v1/projects/{project['id']}/lyrics", json={"force": False}).json()["job"]
+    final_job = wait_for_job(client, job["id"])
+    assert final_job["status"] == "failed"
+    assert final_job["error_message"] == "Lyrics model download failed."

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -515,6 +515,15 @@ wheels = [
 ]
 
 [[package]]
+name = "more-itertools"
+version = "11.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804", size = 144659, upload-time = "2026-04-09T15:01:33.297Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4", size = 71939, upload-time = "2026-04-09T15:01:32.21Z" },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -785,6 +794,21 @@ wheels = [
 ]
 
 [[package]]
+name = "openai-whisper"
+version = "20250625"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "tiktoken" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "triton", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'linux2'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/8e/d36f8880bcf18ec026a55807d02fe4c7357da9f25aebd92f85178000c0dc/openai_whisper-20250625.tar.gz", hash = "sha256:37a91a3921809d9f44748ffc73c0a55c9f366c85a3ef5c2ae0cc09540432eb96", size = 803191, upload-time = "2025-06-26T01:06:13.34Z" }
+
+[[package]]
 name = "openunmix"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -951,6 +975,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
     { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
     { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/0e/3a246dbf05666918bd3664d9d787f84a9108f6f43cc953a077e4a7dfdb7e/regex-2026.4.4.tar.gz", hash = "sha256:e08270659717f6973523ce3afbafa53515c4dc5dcad637dc215b6fd50f689423", size = 416000, upload-time = "2026-04-03T20:56:28.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/7a/617356cbecdb452812a5d42f720d6d5096b360d4a4c1073af700ea140ad2/regex-2026.4.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b4c36a85b00fadb85db9d9e90144af0a980e1a3d2ef9cd0f8a5bef88054657c6", size = 489415, upload-time = "2026-04-03T20:53:11.645Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e6/bf057227144d02e3ba758b66649e87531d744dda5f3254f48660f18ae9d8/regex-2026.4.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:dcb5453ecf9cd58b562967badd1edbf092b0588a3af9e32ee3d05c985077ce87", size = 291205, upload-time = "2026-04-03T20:53:13.289Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/3b/637181b787dd1a820ba1c712cee2b4144cd84a32dc776ca067b12b2d70c8/regex-2026.4.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6aa809ed4dc3706cc38594d67e641601bd2f36d5555b2780ff074edfcb136cf8", size = 289225, upload-time = "2026-04-03T20:53:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/05/21/bac05d806ed02cd4b39d9c8e5b5f9a2998c94c3a351b7792e80671fa5315/regex-2026.4.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:33424f5188a7db12958246a54f59a435b6cb62c5cf9c8d71f7cc49475a5fdada", size = 792434, upload-time = "2026-04-03T20:53:17.414Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/17/c65d1d8ae90b772d5758eb4014e1e011bb2db353fc4455432e6cc9100df7/regex-2026.4.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d346fccdde28abba117cc9edc696b9518c3307fbfcb689e549d9b5979018c6d", size = 861730, upload-time = "2026-04-03T20:53:18.903Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/64/933321aa082a2c6ee2785f22776143ba89840189c20d3b6b1d12b6aae16b/regex-2026.4.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:415a994b536440f5011aa77e50a4274d15da3245e876e5c7f19da349caaedd87", size = 906495, upload-time = "2026-04-03T20:53:20.561Z" },
+    { url = "https://files.pythonhosted.org/packages/01/ea/4c8d306e9c36ac22417336b1e02e7b358152c34dc379673f2d331143725f/regex-2026.4.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21e5eb86179b4c67b5759d452ea7c48eb135cd93308e7a260aa489ed2eb423a4", size = 799810, upload-time = "2026-04-03T20:53:22.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ce/7605048f00e1379eba89d610c7d644d8f695dc9b26d3b6ecfa3132b872ff/regex-2026.4.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:312ec9dd1ae7d96abd8c5a36a552b2139931914407d26fba723f9e53c8186f86", size = 774242, upload-time = "2026-04-03T20:53:25.015Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/77/283e0d5023fde22cd9e86190d6d9beb21590a452b195ffe00274de470691/regex-2026.4.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a0d2b28aa1354c7cd7f71b7658c4326f7facac106edd7f40eda984424229fd59", size = 781257, upload-time = "2026-04-03T20:53:26.918Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/fb/7f3b772be101373c8626ed34c5d727dcbb8abd42a7b1219bc25fd9a3cc04/regex-2026.4.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:349d7310eddff40429a099c08d995c6d4a4bfaf3ff40bd3b5e5cb5a5a3c7d453", size = 854490, upload-time = "2026-04-03T20:53:29.065Z" },
+    { url = "https://files.pythonhosted.org/packages/85/30/56547b80f34f4dd2986e1cdd63b1712932f63b6c4ce2f79c50a6cd79d1c2/regex-2026.4.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:e7ab63e9fe45a9ec3417509e18116b367e89c9ceb6219222a3396fa30b147f80", size = 763544, upload-time = "2026-04-03T20:53:30.917Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/2f/ce060fdfea8eff34a8997603532e44cdb7d1f35e3bc253612a8707a90538/regex-2026.4.4-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:fe896e07a5a2462308297e515c0054e9ec2dd18dfdc9427b19900b37dfe6f40b", size = 844442, upload-time = "2026-04-03T20:53:32.463Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/44/810cb113096a1dacbe82789fbfab2823f79d19b7f1271acecb7009ba9b88/regex-2026.4.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:eb59c65069498dbae3c0ef07bbe224e1eaa079825a437fb47a479f0af11f774f", size = 789162, upload-time = "2026-04-03T20:53:34.039Z" },
+    { url = "https://files.pythonhosted.org/packages/20/96/9647dd7f2ecf6d9ce1fb04dfdb66910d094e10d8fe53e9c15096d8aa0bd2/regex-2026.4.4-cp311-cp311-win32.whl", hash = "sha256:2a5d273181b560ef8397c8825f2b9d57013de744da9e8257b8467e5da8599351", size = 266227, upload-time = "2026-04-03T20:53:35.601Z" },
+    { url = "https://files.pythonhosted.org/packages/33/80/74e13262460530c3097ff343a17de9a34d040a5dc4de9cf3a8241faab51c/regex-2026.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:9542ccc1e689e752594309444081582f7be2fdb2df75acafea8a075108566735", size = 278399, upload-time = "2026-04-03T20:53:37.021Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/39f19f47f19dcefa3403f09d13562ca1c0fd07ab54db2bc03148f3f6b46a/regex-2026.4.4-cp311-cp311-win_arm64.whl", hash = "sha256:b5f9fb784824a042be3455b53d0b112655686fdb7a91f88f095f3fee1e2a2a54", size = 270473, upload-time = "2026-04-03T20:53:38.633Z" },
 ]
 
 [[package]]
@@ -1160,6 +1208,25 @@ wheels = [
 ]
 
 [[package]]
+name = "tiktoken"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/4d017d0f76ec3171d469d80fc03dfbb4e48a4bcaddaa831b31d526f05edc/tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931", size = 37806, upload-time = "2025-10-06T20:22:45.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/46/21ea696b21f1d6d1efec8639c204bdf20fde8bafb351e1355c72c5d7de52/tiktoken-0.12.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:6e227c7f96925003487c33b1b32265fad2fbcec2b7cf4817afb76d416f40f6bb", size = 1051565, upload-time = "2025-10-06T20:21:44.566Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d9/35c5d2d9e22bb2a5f74ba48266fb56c63d76ae6f66e02feb628671c0283e/tiktoken-0.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c06cf0fcc24c2cb2adb5e185c7082a82cba29c17575e828518c2f11a01f445aa", size = 995284, upload-time = "2025-10-06T20:21:45.622Z" },
+    { url = "https://files.pythonhosted.org/packages/01/84/961106c37b8e49b9fdcf33fe007bb3a8fdcc380c528b20cc7fbba80578b8/tiktoken-0.12.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:f18f249b041851954217e9fd8e5c00b024ab2315ffda5ed77665a05fa91f42dc", size = 1129201, upload-time = "2025-10-06T20:21:47.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d0/3d9275198e067f8b65076a68894bb52fd253875f3644f0a321a720277b8a/tiktoken-0.12.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:47a5bc270b8c3db00bb46ece01ef34ad050e364b51d406b6f9730b64ac28eded", size = 1152444, upload-time = "2025-10-06T20:21:48.139Z" },
+    { url = "https://files.pythonhosted.org/packages/78/db/a58e09687c1698a7c592e1038e01c206569b86a0377828d51635561f8ebf/tiktoken-0.12.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:508fa71810c0efdcd1b898fda574889ee62852989f7c1667414736bcb2b9a4bd", size = 1195080, upload-time = "2025-10-06T20:21:49.246Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1b/a9e4d2bf91d515c0f74afc526fd773a812232dd6cda33ebea7f531202325/tiktoken-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a1af81a6c44f008cba48494089dd98cccb8b313f55e961a52f5b222d1e507967", size = 1255240, upload-time = "2025-10-06T20:21:50.274Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/15/963819345f1b1fb0809070a79e9dd96938d4ca41297367d471733e79c76c/tiktoken-0.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:3e68e3e593637b53e56f7237be560f7a394451cb8c11079755e80ae64b9e6def", size = 879422, upload-time = "2025-10-06T20:21:51.734Z" },
+]
+
+[[package]]
 name = "torch"
 version = "2.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1237,6 +1304,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "librosa" },
     { name = "numpy" },
+    { name = "openai-whisper" },
     { name = "pydantic" },
     { name = "soundfile" },
     { name = "sqlalchemy" },
@@ -1258,6 +1326,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.12,<1.0.0" },
     { name = "librosa", specifier = ">=0.10.2.post1,<1.0.0" },
     { name = "numpy", specifier = ">=1.26.4,<3.0.0" },
+    { name = "openai-whisper", specifier = ">=20250625,<20260000" },
     { name = "pydantic", specifier = ">=2.11.3,<3.0.0" },
     { name = "soundfile", specifier = ">=0.13.1,<1.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.40,<3.0.0" },

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -10,6 +10,7 @@ const {
   setProjects,
   setProjectAnalysis,
   setProjectChords,
+  setProjectLyrics,
   setDeferredPreviewCompletion,
   flushPendingPreview,
   mockOpen,
@@ -21,12 +22,15 @@ const {
   mockGetProject,
   mockGetAnalysis,
   mockGetChords,
+  mockGetLyrics,
   mockListArtifacts,
   mockListJobs,
   mockCreateChords,
+  mockCreateLyrics,
   mockCreatePreview,
   mockCreateStems,
   mockAnalyzeProject,
+  mockUpdateLyrics,
   mockUpdateProject,
   mockCreateExport,
   mockDeleteArtifact,
@@ -38,6 +42,7 @@ const {
     projects: Array<Record<string, unknown>>;
     analysisByProject: Record<string, Record<string, unknown> | null>;
     chordsByProject: Record<string, Record<string, unknown>>;
+    lyricsByProject: Record<string, Record<string, unknown>>;
     artifactsByProject: Record<string, Array<Record<string, unknown>>>;
     pendingPreviewArtifactsByProject: Record<string, Array<Record<string, unknown>>>;
     jobs: Array<Record<string, unknown>>;
@@ -96,6 +101,47 @@ const {
     };
   }
 
+  function makeLyricsTranscript(projectId: string) {
+    const segments = [
+      {
+        start_seconds: 0,
+        end_seconds: 8,
+        text: "Hello from the first line",
+        words: [
+          { text: "Hello", start_seconds: 0, end_seconds: 1, confidence: 0.92 },
+          { text: "from", start_seconds: 1, end_seconds: 2, confidence: 0.88 },
+          { text: "the", start_seconds: 2, end_seconds: 3, confidence: 0.9 },
+          { text: "first", start_seconds: 3, end_seconds: 4.5, confidence: 0.91 },
+          { text: "line", start_seconds: 4.5, end_seconds: 6, confidence: 0.9 },
+        ],
+      },
+      {
+        start_seconds: 8,
+        end_seconds: 16,
+        text: "Second lyric line stays steady",
+        words: [
+          { text: "Second", start_seconds: 8, end_seconds: 9.4, confidence: 0.87 },
+          { text: "lyric", start_seconds: 9.4, end_seconds: 10.8, confidence: 0.85 },
+          { text: "line", start_seconds: 10.8, end_seconds: 12, confidence: 0.9 },
+          { text: "stays", start_seconds: 12, end_seconds: 13.4, confidence: 0.84 },
+          { text: "steady", start_seconds: 13.4, end_seconds: 15.2, confidence: 0.86 },
+        ],
+      },
+    ];
+
+    return {
+      project_id: projectId,
+      backend: "openai-whisper",
+      source_artifact_id: "art_source",
+      source_kind: "ai",
+      source_segments: clone(segments),
+      segments: clone(segments),
+      has_user_edits: false,
+      created_at: createdAt,
+      updated_at: createdAt,
+    };
+  }
+
   function setProjects(projects: Array<Record<string, unknown>>) {
     state.projects = clone(projects);
   }
@@ -106,6 +152,10 @@ const {
 
   function setProjectChords(projectId: string, chords: Record<string, unknown>) {
     state.chordsByProject[projectId] = clone(chords);
+  }
+
+  function setProjectLyrics(projectId: string, lyrics: Record<string, unknown>) {
+    state.lyricsByProject[projectId] = clone(lyrics);
   }
 
   function setDeferredPreviewCompletion(value: boolean) {
@@ -147,6 +197,9 @@ const {
       },
       chordsByProject: {
         proj_123: makeChordTimeline("proj_123"),
+      },
+      lyricsByProject: {
+        proj_123: makeLyricsTranscript("proj_123"),
       },
       artifactsByProject: {
         proj_123: [
@@ -295,6 +348,21 @@ const {
       },
     ),
   );
+  const mockGetLyrics = vi.fn(async (projectId: string) =>
+    clone(
+      state.lyricsByProject[projectId] ?? {
+        project_id: projectId,
+        backend: null,
+        source_artifact_id: null,
+        source_kind: null,
+        source_segments: [],
+        segments: [],
+        has_user_edits: false,
+        created_at: null,
+        updated_at: null,
+      },
+    ),
+  );
   const mockListArtifacts = vi.fn(async (projectId: string) => ({ artifacts: clone(state.artifactsByProject[projectId] ?? []) }));
   const mockListJobs = vi.fn(async () => ({ jobs: clone(state.jobs) }));
   const mockCreateChords = vi.fn(async (projectId: string, body?: Record<string, unknown>) => {
@@ -304,6 +372,22 @@ const {
       id: `job_${state.nextJobId++}`,
       project_id: projectId,
       type: "chords",
+      status: "completed",
+      progress: 100,
+      error_message: null,
+      created_at: createdAt,
+      updated_at: createdAt,
+    };
+    state.jobs.unshift(job);
+    return { job: clone(job) };
+  });
+  const mockCreateLyrics = vi.fn(async (projectId: string, body?: { force?: boolean }) => {
+    void body;
+    state.lyricsByProject[projectId] = makeLyricsTranscript(projectId);
+    const job = {
+      id: `job_${state.nextJobId++}`,
+      project_id: projectId,
+      type: "lyrics",
       status: "completed",
       progress: 100,
       error_message: null,
@@ -434,6 +518,47 @@ const {
     project.updated_at = createdAt;
     return { project: clone(project) };
   });
+  const mockUpdateLyrics = vi.fn(async (projectId: string, body: { segments: Array<{ text: string }> }) => {
+    const current = clone(
+      state.lyricsByProject[projectId] ?? {
+        project_id: projectId,
+        backend: "openai-whisper",
+        source_artifact_id: "art_source",
+        source_kind: "ai",
+        source_segments: [],
+        segments: [],
+        has_user_edits: false,
+        created_at: createdAt,
+        updated_at: createdAt,
+      },
+    ) as {
+      source_segments: Array<Record<string, unknown>>;
+      segments: Array<Record<string, unknown>>;
+      has_user_edits: boolean;
+      updated_at: string;
+    };
+
+    current.segments = current.segments.map((segment, index) => {
+      const nextText = body.segments[index]?.text ?? String(segment.text ?? "");
+      const sourceSegment = current.source_segments[index] ?? null;
+      const nextSegment: Record<string, unknown> & { text: string; words?: unknown } = {
+        ...segment,
+        text: nextText,
+      };
+      if (sourceSegment && nextText === sourceSegment.text) {
+        return clone(sourceSegment);
+      }
+      if (nextText !== segment.text) {
+        delete nextSegment.words;
+      }
+      return nextSegment;
+    });
+    current.has_user_edits =
+      JSON.stringify(current.segments) !== JSON.stringify(current.source_segments);
+    current.updated_at = createdAt;
+    state.lyricsByProject[projectId] = current;
+    return clone(current);
+  });
   const mockCreateExport = vi.fn(async (projectId: string, body: Record<string, unknown>) => {
     const job = {
       id: `job_${state.nextJobId++}`,
@@ -474,6 +599,7 @@ const {
     setProjects,
     setProjectAnalysis,
     setProjectChords,
+    setProjectLyrics,
     setDeferredPreviewCompletion,
     flushPendingPreview,
     mockOpen,
@@ -485,12 +611,15 @@ const {
     mockGetProject,
     mockGetAnalysis,
     mockGetChords,
+    mockGetLyrics,
     mockListArtifacts,
     mockListJobs,
     mockCreateChords,
+    mockCreateLyrics,
     mockCreatePreview,
     mockCreateStems,
     mockAnalyzeProject,
+    mockUpdateLyrics,
     mockUpdateProject,
     mockCreateExport,
     mockDeleteArtifact,
@@ -521,12 +650,15 @@ vi.mock("./lib/api", async (importOriginal) => {
       getProject: mockGetProject,
       getAnalysis: mockGetAnalysis,
       getChords: mockGetChords,
+      getLyrics: mockGetLyrics,
       listArtifacts: mockListArtifacts,
       listJobs: mockListJobs,
       createChords: mockCreateChords,
+      createLyrics: mockCreateLyrics,
       createPreview: mockCreatePreview,
       createStems: mockCreateStems,
       analyzeProject: mockAnalyzeProject,
+      updateLyrics: mockUpdateLyrics,
       updateProject: mockUpdateProject,
       createExport: mockCreateExport,
       deleteArtifact: mockDeleteArtifact,
@@ -675,12 +807,15 @@ describe("Desktop app flows", () => {
     mockGetProject.mockClear();
     mockGetAnalysis.mockClear();
     mockGetChords.mockClear();
+    mockGetLyrics.mockClear();
     mockListArtifacts.mockClear();
     mockListJobs.mockClear();
     mockCreateChords.mockClear();
+    mockCreateLyrics.mockClear();
     mockCreatePreview.mockClear();
     mockCreateStems.mockClear();
     mockAnalyzeProject.mockClear();
+    mockUpdateLyrics.mockClear();
     mockUpdateProject.mockClear();
     mockCreateExport.mockClear();
     mockDeleteArtifact.mockClear();
@@ -818,6 +953,95 @@ describe("Desktop app flows", () => {
       backend: "default",
       force: true,
     });
+  });
+
+  it("generates lyrics when transcript is empty", async () => {
+    const user = userEvent.setup();
+    setProjectLyrics("proj_123", {
+      project_id: "proj_123",
+      backend: null,
+      source_artifact_id: null,
+      source_kind: null,
+      source_segments: [],
+      segments: [],
+      has_user_edits: false,
+      created_at: null,
+      updated_at: null,
+    });
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Generate Lyrics" }));
+
+    expect(mockCreateLyrics).toHaveBeenCalledWith("proj_123", { force: false });
+  });
+
+  it("renders active lyrics and saves in-app edits", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const lyricsTranscript = screen.getByRole("group", { name: "Lyrics transcript" });
+    const activeLyric = within(lyricsTranscript).getByRole("button", { name: /0:00/i });
+    expect(activeLyric.className).toContain("lyrics-segment--active");
+
+    await user.click(screen.getByRole("button", { name: "Edit Lyrics" }));
+    const firstTextarea = screen.getByLabelText("Lyric segment 1");
+    await user.clear(firstTextarea);
+    await user.type(firstTextarea, "Edited lyric line");
+    await user.click(screen.getByRole("button", { name: "Save Lyrics" }));
+
+    expect(mockUpdateLyrics).toHaveBeenCalledWith("proj_123", {
+      segments: [
+        { text: "Edited lyric line" },
+        { text: "Second lyric line stays steady" },
+      ],
+    });
+    expect(await screen.findByText("Edited lyric line")).toBeInTheDocument();
+  });
+
+  it("refreshes edited lyrics with confirmation", async () => {
+    const user = userEvent.setup();
+    setProjectLyrics("proj_123", {
+      project_id: "proj_123",
+      backend: "openai-whisper",
+      source_artifact_id: "art_source",
+      source_kind: "ai",
+      source_segments: [
+        {
+          start_seconds: 0,
+          end_seconds: 8,
+          text: "Original lyric line",
+          words: [],
+        },
+      ],
+      segments: [
+        {
+          start_seconds: 0,
+          end_seconds: 8,
+          text: "Edited lyric line",
+          words: [],
+        },
+      ],
+      has_user_edits: true,
+      created_at: "2026-04-18T13:16:00.000Z",
+      updated_at: "2026-04-18T13:16:00.000Z",
+    });
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Refresh Lyrics" }));
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      "Refresh lyrics? This replaces the current transcript and discards your edits.",
+      expect.objectContaining({
+        title: "Refresh lyrics",
+        kind: "warning",
+      }),
+    );
+    expect(mockCreateLyrics).toHaveBeenCalledWith("proj_123", { force: true });
   });
 
   it("renders single-label enharmonic spellings by default", async () => {

--- a/apps/desktop/src/features/projects/ProjectView.tsx
+++ b/apps/desktop/src/features/projects/ProjectView.tsx
@@ -2,7 +2,15 @@ import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { confirm, save } from "@tauri-apps/plugin-dialog";
-import { api, type ArtifactSchema, type ChordSegmentSchema, type JobSchema, type ProjectSchema } from "../../lib/api";
+import {
+  api,
+  type ArtifactSchema,
+  type ChordSegmentSchema,
+  type JobSchema,
+  type LyricsSegmentSchema,
+  type LyricsWordSchema,
+  type ProjectSchema,
+} from "../../lib/api";
 import { MusicalChordLabel, MusicalKeyLabel } from "../../components/MusicalLabel";
 import { formatLocalDateTime } from "../../lib/datetime";
 import { usePreferences } from "../../lib/preferences";
@@ -42,6 +50,7 @@ function useActiveJobPolling(projectId: string, jobs: JobSchema[] | undefined) {
         queryClient.invalidateQueries({ queryKey: ["jobs"] }),
         queryClient.invalidateQueries({ queryKey: ["analysis", projectId] }),
         queryClient.invalidateQueries({ queryKey: ["chords", projectId] }),
+        queryClient.invalidateQueries({ queryKey: ["lyrics", projectId] }),
         queryClient.invalidateQueries({ queryKey: ["artifacts", projectId] }),
         queryClient.invalidateQueries({ queryKey: ["project", projectId] }),
         queryClient.invalidateQueries({ queryKey: ["projects"] }),
@@ -366,6 +375,38 @@ function findActiveChordIndex(timeline: ChordSegmentSchema[], playbackTimeSecond
   });
 }
 
+function hasTimedLyrics(
+  segment: LyricsSegmentSchema,
+): segment is LyricsSegmentSchema & { start_seconds: number; end_seconds: number } {
+  return typeof segment.start_seconds === "number" && typeof segment.end_seconds === "number";
+}
+
+function findActiveLyricsIndex(timeline: LyricsSegmentSchema[], playbackTimeSeconds: number) {
+  return timeline.findIndex((segment, index) => {
+    if (!hasTimedLyrics(segment)) {
+      return false;
+    }
+    const isLast = index === timeline.length - 1;
+    return (
+      playbackTimeSeconds >= segment.start_seconds &&
+      (playbackTimeSeconds < segment.end_seconds || isLast)
+    );
+  });
+}
+
+function findActiveLyricsWordIndex(words: LyricsWordSchema[], playbackTimeSeconds: number) {
+  return words.findIndex((word, index) => {
+    if (typeof word.start_seconds !== "number" || typeof word.end_seconds !== "number") {
+      return false;
+    }
+    const isLast = index === words.length - 1;
+    return (
+      playbackTimeSeconds >= word.start_seconds &&
+      (playbackTimeSeconds < word.end_seconds || isLast)
+    );
+  });
+}
+
 function formatRetuneSummary(
   retuneMode: "off" | "reference" | "cents",
   referenceHz: string,
@@ -403,6 +444,7 @@ export function ProjectView() {
     informationDensity,
   } = usePreferences();
   const chordSegmentRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const lyricsSegmentRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const pendingPreviewSelection = useRef<{ previousLatestPreviewArtifactId: string | null } | null>(
     null,
   );
@@ -430,6 +472,8 @@ export function ProjectView() {
   const [sourcesRailCollapsed, setSourcesRailCollapsed] = useState(defaultSourcesRailCollapsed);
   const [stemControls, setStemControls] = useState<Record<string, StemControlState>>({});
   const [dismissedStemJobIds, setDismissedStemJobIds] = useState<string[]>([]);
+  const [isEditingLyrics, setIsEditingLyrics] = useState(false);
+  const [lyricsDraft, setLyricsDraft] = useState<string[]>([]);
   const showSupportingCopy = informationDensity !== "minimal";
 
   const projectQuery = useQuery({
@@ -445,6 +489,11 @@ export function ProjectView() {
   const chordsQuery = useQuery({
     queryKey: ["chords", projectId],
     queryFn: async () => api.getChords(projectId),
+    enabled: Boolean(projectId),
+  });
+  const lyricsQuery = useQuery({
+    queryKey: ["lyrics", projectId],
+    queryFn: async () => api.getLyrics(projectId),
     enabled: Boolean(projectId),
   });
   const artifactsQuery = useQuery({
@@ -527,6 +576,28 @@ export function ProjectView() {
         queryClient.invalidateQueries({ queryKey: ["jobs"] }),
         queryClient.invalidateQueries({ queryKey: ["chords", projectId] }),
       ]);
+    },
+  });
+
+  const lyricsMutation = useMutation({
+    mutationFn: async (force: boolean) => api.createLyrics(projectId, { force }),
+    onSuccess: async () => {
+      setIsEditingLyrics(false);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["jobs"] }),
+        queryClient.invalidateQueries({ queryKey: ["lyrics", projectId] }),
+      ]);
+    },
+  });
+
+  const lyricsSaveMutation = useMutation({
+    mutationFn: async () =>
+      api.updateLyrics(projectId, {
+        segments: lyricsDraft.map((text) => ({ text })),
+      }),
+    onSuccess: async () => {
+      setIsEditingLyrics(false);
+      await queryClient.invalidateQueries({ queryKey: ["lyrics", projectId] });
     },
   });
 
@@ -641,6 +712,7 @@ export function ProjectView() {
   );
   const analyzeJob = projectJobs.find((job) => job.type === "analyze");
   const chordJob = projectJobs.find((job) => job.type === "chords");
+  const lyricsJob = projectJobs.find((job) => job.type === "lyrics");
   const stemJobs = useMemo(
     () => projectJobs.filter((job) => job.type === "stems"),
     [projectJobs],
@@ -750,6 +822,9 @@ export function ProjectView() {
   const isChordRunning = Boolean(
     chordJob && ["pending", "running"].includes(chordJob.status),
   );
+  const isLyricsRunning = Boolean(
+    lyricsJob && ["pending", "running"].includes(lyricsJob.status),
+  );
   const isStemRunning = Boolean(stemJob && ["pending", "running"].includes(stemJob.status));
   const currentKeyValue = sourceKeyOverride ? serializeKey(sourceKeyOverride) : "auto";
   const hasVisibleStems = visibleStemArtifacts.length > 0;
@@ -793,6 +868,19 @@ export function ProjectView() {
         ? displayedChords[1]
         : null;
   const hasChordTimeline = displayedChords.length > 0;
+  const displayedLyrics = useMemo(
+    () => lyricsQuery.data?.segments ?? [],
+    [lyricsQuery.data?.segments],
+  );
+  const hasLyricsTranscript = displayedLyrics.length > 0;
+  const hasTimedLyricsTranscript = displayedLyrics.some((segment) => hasTimedLyrics(segment));
+  const activeLyricsIndex = findActiveLyricsIndex(displayedLyrics, playbackTimeSeconds);
+  const activeLyricsSegment =
+    activeLyricsIndex >= 0 ? displayedLyrics[activeLyricsIndex] : null;
+  const activeLyricsWordIndex =
+    activeLyricsSegment?.words?.length
+      ? findActiveLyricsWordIndex(activeLyricsSegment.words, playbackTimeSeconds)
+      : -1;
   const chordContextCopy =
     correctedSourceChordSemitones === 0 && chordTransposeSemitones === 0
       ? "Chord labels follow the original arrangement."
@@ -893,6 +981,28 @@ export function ProjectView() {
     seekBy(secondsDelta);
   }
 
+  async function handleLyricsAction() {
+    const hasExistingLyrics = (lyricsQuery.data?.segments?.length ?? 0) > 0;
+    if (hasExistingLyrics) {
+      const approved = await confirm(
+        lyricsQuery.data?.has_user_edits
+          ? "Refresh lyrics? This replaces the current transcript and discards your edits."
+          : "Refresh lyrics? This replaces the current transcript with a new pass.",
+        {
+          title: "Refresh lyrics",
+          kind: "warning",
+          okLabel: "Refresh",
+          cancelLabel: "Cancel",
+        },
+      );
+      if (!approved) {
+        return;
+      }
+    }
+
+    lyricsMutation.mutate(hasExistingLyrics);
+  }
+
   async function handleStemAction() {
     if (!selectedPrimaryArtifactId) {
       return;
@@ -990,6 +1100,12 @@ export function ProjectView() {
       setDraftName(projectQuery.data?.display_name ?? "");
     }
   }, [isRenaming, projectQuery.data?.display_name]);
+
+  useEffect(() => {
+    if (!isEditingLyrics) {
+      setLyricsDraft(displayedLyrics.map((segment) => segment.text));
+    }
+  }, [displayedLyrics, isEditingLyrics]);
 
   useEffect(() => {
     if (!targetSelectorOpen) {
@@ -1181,6 +1297,24 @@ export function ProjectView() {
       inline: "center",
     });
   }, [activeChordIndex, displayedChords]);
+
+  useEffect(() => {
+    if (isEditingLyrics || activeLyricsIndex < 0) {
+      return;
+    }
+    const activeSegment = displayedLyrics[activeLyricsIndex];
+    if (!activeSegment) {
+      return;
+    }
+    const activeElement =
+      lyricsSegmentRefs.current[
+        `${activeSegment.start_seconds}-${activeSegment.end_seconds}-${activeLyricsIndex}`
+      ];
+    activeElement?.scrollIntoView({
+      behavior: "smooth",
+      block: "nearest",
+    });
+  }, [activeLyricsIndex, displayedLyrics, isEditingLyrics]);
 
   const currentSourceSummary = selectedPrimaryArtifact
     ? artifactSummary(selectedPrimaryArtifact) ||
@@ -1693,6 +1827,161 @@ export function ProjectView() {
 
               {chordJob?.error_message ? (
                 <p className="inline-error">{chordJob.error_message}</p>
+              ) : null}
+            </div>
+
+            <div className="playback-stage__lane">
+              <div className="playback-stage__lane-header">
+                <div>
+                  <p className="metric-label">Lyrics Follow</p>
+                  <h3>Current lyrics</h3>
+                </div>
+                <div className="button-row">
+                  {hasLyricsTranscript && !isEditingLyrics ? (
+                    <button
+                      className="button button--ghost button--small"
+                      type="button"
+                      onClick={() => setIsEditingLyrics(true)}
+                      disabled={lyricsMutation.isPending || isLyricsRunning}
+                    >
+                      Edit Lyrics
+                    </button>
+                  ) : null}
+                  <button
+                    className="button button--small"
+                    type="button"
+                    onClick={() => void handleLyricsAction()}
+                    disabled={lyricsMutation.isPending || isLyricsRunning}
+                  >
+                    {lyricsMutation.isPending || isLyricsRunning
+                      ? "Generating..."
+                      : hasLyricsTranscript
+                        ? "Refresh Lyrics"
+                        : "Generate Lyrics"}
+                  </button>
+                </div>
+              </div>
+
+              {isEditingLyrics ? (
+                <div className="lyrics-editor">
+                  {displayedLyrics.map((segment, index) => (
+                    <label className="lyrics-editor__row" key={`${segment.start_seconds}-${index}`}>
+                      <span className="lyrics-editor__time">
+                        {hasTimedLyrics(segment) ? formatPlaybackClock(segment.start_seconds ?? 0) : "Static"}
+                      </span>
+                      <textarea
+                        aria-label={`Lyric segment ${index + 1}`}
+                        className="lyrics-editor__input"
+                        value={lyricsDraft[index] ?? ""}
+                        onChange={(event) =>
+                          setLyricsDraft((current) =>
+                            current.map((value, valueIndex) =>
+                              valueIndex === index ? event.target.value : value,
+                            ),
+                          )
+                        }
+                      />
+                    </label>
+                  ))}
+                  <div className="button-row">
+                    <button
+                      className="button button--primary button--small"
+                      type="button"
+                      onClick={() => lyricsSaveMutation.mutate()}
+                      disabled={lyricsSaveMutation.isPending}
+                    >
+                      {lyricsSaveMutation.isPending ? "Saving..." : "Save Lyrics"}
+                    </button>
+                    <button
+                      className="button button--ghost button--small"
+                      type="button"
+                      onClick={() => {
+                        setIsEditingLyrics(false);
+                        setLyricsDraft(displayedLyrics.map((currentSegment) => currentSegment.text));
+                      }}
+                      disabled={lyricsSaveMutation.isPending}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : hasLyricsTranscript ? (
+                <div className="lyrics-panel" role="group" aria-label="Lyrics transcript">
+                  {displayedLyrics.map((segment, index) => {
+                    const isActive = index === activeLyricsIndex;
+                    const segmentKey = `${segment.start_seconds}-${segment.end_seconds}-${index}`;
+                    const canSeek = hasTimedLyrics(segment);
+                    const content =
+                      isActive && (segment.words?.length ?? 0) > 0 ? (
+                        <span className="lyrics-segment__words">
+                          {(segment.words ?? []).map((word, wordIndex) => (
+                            <span
+                              key={`${segmentKey}-${wordIndex}-${word.start_seconds}`}
+                              className={`lyrics-word${
+                                wordIndex === activeLyricsWordIndex ? " lyrics-word--active" : ""
+                              }`}
+                            >
+                              {word.text}
+                            </span>
+                          ))}
+                        </span>
+                      ) : (
+                        <span className="lyrics-segment__text">{segment.text}</span>
+                      );
+
+                    if (canSeek) {
+                      return (
+                        <button
+                          key={segmentKey}
+                          className={`lyrics-segment${isActive ? " lyrics-segment--active" : ""}`}
+                          type="button"
+                          ref={(element) => {
+                            lyricsSegmentRefs.current[segmentKey] = element;
+                          }}
+                          onClick={() => seekTo(segment.start_seconds ?? 0)}
+                        >
+                          <small>{formatPlaybackClock(segment.start_seconds ?? 0)}</small>
+                          {content}
+                        </button>
+                      );
+                    }
+
+                    return (
+                      <div
+                        key={segmentKey}
+                        className={`lyrics-segment lyrics-segment--static${
+                          isActive ? " lyrics-segment--active" : ""
+                        }`}
+                      >
+                        <small>Static</small>
+                        {content}
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="chord-lane-empty">
+                  <p className="artifact-meta">
+                    Generate a lyrics pass to keep transcription and playback together while you practice.
+                  </p>
+                </div>
+              )}
+
+              {!isEditingLyrics && hasLyricsTranscript && !hasTimedLyricsTranscript ? (
+                <div className="chord-context">
+                  <span className="artifact-meta">This transcript has no timing data, so follow mode stays static.</span>
+                </div>
+              ) : null}
+
+              {lyricsSaveMutation.error ? (
+                <p className="inline-error">
+                  {lyricsSaveMutation.error instanceof Error
+                    ? lyricsSaveMutation.error.message
+                    : "Lyrics could not be saved."}
+                </p>
+              ) : null}
+              {lyricsJob?.error_message ? (
+                <p className="inline-error">{lyricsJob.error_message}</p>
               ) : null}
             </div>
 

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -27,6 +27,9 @@ export type ProjectSchema = components["schemas"]["ProjectSchema"];
 export type AnalysisSchema = components["schemas"]["AnalysisSchema"];
 export type ChordResponse = components["schemas"]["ChordResponse"];
 export type ChordSegmentSchema = components["schemas"]["ChordSegmentSchema"];
+export type LyricsResponse = components["schemas"]["LyricsResponse"];
+export type LyricsSegmentSchema = components["schemas"]["LyricsSegmentSchema"];
+export type LyricsWordSchema = components["schemas"]["LyricsWordSchema"];
 export type ArtifactSchema = components["schemas"]["ArtifactSchema"];
 export type JobSchema = components["schemas"]["JobSchema"];
 export type PreviewRequest = components["schemas"]["PreviewRequest"];
@@ -35,6 +38,8 @@ export type ExportRequest = components["schemas"]["ExportRequest"];
 export type ProjectUpdateRequest = components["schemas"]["ProjectUpdateRequest"];
 export type StemRequest = components["schemas"]["StemRequest"];
 export type ChordRequest = components["schemas"]["ChordRequest"];
+export type LyricsGenerateRequest = components["schemas"]["LyricsGenerateRequest"];
+export type LyricsUpdateRequest = components["schemas"]["LyricsUpdateRequest"];
 
 let client = createClient<paths>({ baseUrl: apiBaseUrl });
 
@@ -132,6 +137,12 @@ export const api = {
     unwrap(client.POST("/api/v1/projects/{project_id}/chords", { params: { path: { project_id: projectId } }, body })),
   getChords: (projectId: string) =>
     unwrap(client.GET("/api/v1/projects/{project_id}/chords", { params: { path: { project_id: projectId } } })),
+  createLyrics: (projectId: string, body: LyricsGenerateRequest) =>
+    unwrap(client.POST("/api/v1/projects/{project_id}/lyrics", { params: { path: { project_id: projectId } }, body })),
+  getLyrics: (projectId: string) =>
+    unwrap(client.GET("/api/v1/projects/{project_id}/lyrics", { params: { path: { project_id: projectId } } })),
+  updateLyrics: (projectId: string, body: LyricsUpdateRequest) =>
+    unwrap(client.PUT("/api/v1/projects/{project_id}/lyrics", { params: { path: { project_id: projectId } }, body })),
   createPreview: (projectId: string, body: PreviewRequest) =>
     unwrap(client.POST("/api/v1/projects/{project_id}/preview", { params: { path: { project_id: projectId } }, body })),
   createStems: (projectId: string, body: StemRequest) =>

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1807,6 +1807,79 @@ a {
   padding: 1rem;
 }
 
+.lyrics-panel,
+.lyrics-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.lyrics-panel {
+  max-height: 20rem;
+  overflow-y: auto;
+  padding-right: 0.2rem;
+}
+
+.lyrics-segment {
+  border: 1px solid var(--divider);
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--panel-strong) 68%, transparent);
+  color: var(--text);
+  padding: 0.85rem 0.95rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  text-align: left;
+}
+
+.lyrics-segment small,
+.lyrics-editor__time {
+  color: var(--muted);
+}
+
+.lyrics-segment--active {
+  border-color: color-mix(in srgb, var(--playback-accent) 72%, transparent);
+  background: color-mix(in srgb, var(--playback-track) 48%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--playback-accent) 18%, transparent);
+}
+
+.lyrics-segment--static {
+  cursor: default;
+}
+
+.lyrics-segment__text {
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.lyrics-segment__words {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.4rem;
+  line-height: 1.5;
+}
+
+.lyrics-word {
+  padding: 0.05rem 0.2rem;
+  border-radius: 8px;
+}
+
+.lyrics-word--active {
+  background: color-mix(in srgb, var(--playback-accent) 16%, transparent);
+  color: var(--playback-accent);
+}
+
+.lyrics-editor__row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.lyrics-editor__input {
+  min-height: 5.5rem;
+  resize: vertical;
+}
+
 .stem-mixer {
   display: flex;
   flex-direction: column;

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -126,6 +126,25 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/projects/{project_id}/lyrics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Project Lyrics Detail */
+        get: operations["project_lyrics_detail_api_v1_projects__project_id__lyrics_get"];
+        /** Project Lyrics Update */
+        put: operations["project_lyrics_update_api_v1_projects__project_id__lyrics_put"];
+        /** Project Lyrics */
+        post: operations["project_lyrics_api_v1_projects__project_id__lyrics_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/projects/{project_id}/retune": {
         parameters: {
             query?: never;
@@ -503,6 +522,70 @@ export interface components {
         JobsResponse: {
             /** Jobs */
             jobs: components["schemas"]["JobSchema"][];
+        };
+        /** LyricsEditSegmentSchema */
+        LyricsEditSegmentSchema: {
+            /** Text */
+            text: string;
+        };
+        /** LyricsGenerateRequest */
+        LyricsGenerateRequest: {
+            /**
+             * Force
+             * @default false
+             */
+            force: boolean;
+        };
+        /** LyricsResponse */
+        LyricsResponse: {
+            /** Project Id */
+            project_id: string;
+            /** Backend */
+            backend?: string | null;
+            /** Source Artifact Id */
+            source_artifact_id?: string | null;
+            /** Source Kind */
+            source_kind?: string | null;
+            /** Source Segments */
+            source_segments?: components["schemas"]["LyricsSegmentSchema"][];
+            /** Segments */
+            segments?: components["schemas"]["LyricsSegmentSchema"][];
+            /**
+             * Has User Edits
+             * @default false
+             */
+            has_user_edits: boolean;
+            /** Created At */
+            created_at?: string | null;
+            /** Updated At */
+            updated_at?: string | null;
+        };
+        /** LyricsSegmentSchema */
+        LyricsSegmentSchema: {
+            /** Start Seconds */
+            start_seconds?: number | null;
+            /** End Seconds */
+            end_seconds?: number | null;
+            /** Text */
+            text: string;
+            /** Words */
+            words?: components["schemas"]["LyricsWordSchema"][];
+        };
+        /** LyricsUpdateRequest */
+        LyricsUpdateRequest: {
+            /** Segments */
+            segments?: components["schemas"]["LyricsEditSegmentSchema"][];
+        };
+        /** LyricsWordSchema */
+        LyricsWordSchema: {
+            /** Text */
+            text: string;
+            /** Start Seconds */
+            start_seconds?: number | null;
+            /** End Seconds */
+            end_seconds?: number | null;
+            /** Confidence */
+            confidence?: number | null;
         };
         /** PreviewRequest */
         PreviewRequest: {
@@ -948,6 +1031,107 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["ChordRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    project_lyrics_detail_api_v1_projects__project_id__lyrics_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LyricsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    project_lyrics_update_api_v1_projects__project_id__lyrics_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LyricsUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LyricsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    project_lyrics_api_v1_projects__project_id__lyrics_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LyricsGenerateRequest"];
             };
         };
         responses: {


### PR DESCRIPTION
## Summary
- Add project-level Whisper lyrics generation, persistence, and editable transcripts.
- Add lyrics follow UI, API contracts, and job wiring across backend and desktop.
- Keep word timestamps on Apple Silicon by patching Whisper's MPS DTW path to use float32.

## Testing
- pnpm contracts:generate
- pnpm lint
- pnpm typecheck
- pnpm test
- Manual Apple Silicon check: verified lyrics transcription stays on MPS with word timestamps enabled.
