### PR TITLE
feat: add optional advanced chord backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,10 +153,7 @@ Pause and surface the question to the human instead of guessing when:
 
 ```sh
 # Install
-pnpm install
-cd apps/backend && uv sync --python 3.11 --all-groups
-cd ../..
-pnpm contracts:generate
+pnpm setup:dev
 
 # Develop
 pnpm dev                  # backend + desktop together

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,16 +23,23 @@ If unsure whether a feature fits, open a discussion or feature-request issue fir
 ## Setup
 
 ```sh
-pnpm install
-cd apps/backend && uv sync --python 3.11 --all-groups
-cd ../..
-pnpm contracts:generate
+pnpm setup:dev
 ```
+
+This installs workspace dependencies, syncs the backend Python environment, and regenerates shared API contracts.
+
+To install the optional experimental crema/TensorFlow Advanced Chords backend for local desktop development:
+
+```sh
+pnpm setup:dev -- --advanced-chords
+```
+
+`--crema` is accepted as an alias. Default setup and mobile paths do not install crema or TensorFlow.
 
 For Linux `x86_64` machines with older NVIDIA GPUs that are unsupported by the default PyTorch build, you can opt into the backend's local legacy CUDA override instead:
 
 ```sh
-pnpm sync:backend:legacy-nvidia
+pnpm setup:dev -- --legacy-nvidia
 ```
 
 This is a local developer override for `apps/backend/.venv`; it does not change the committed lockfile or the default CI setup. Reset back to the locked default backend environment with:
@@ -42,6 +49,12 @@ pnpm sync:backend:default
 ```
 
 Both helper commands rebuild `apps/backend/.venv` from scratch so switching between the default and legacy CUDA stacks stays deterministic while still reusing the shared `uv` cache.
+
+To combine the legacy NVIDIA profile with Advanced Chords:
+
+```sh
+pnpm setup:dev -- --legacy-nvidia --advanced-chords
+```
 
 ## Development Loop
 

--- a/README.md
+++ b/README.md
@@ -47,26 +47,37 @@ Security reports follow the process in [SECURITY.md](./SECURITY.md). "There is n
 ## Setup
 
 ```sh
-pnpm install
-cd apps/backend && uv sync --python 3.11 --all-groups
-cd ../..
-pnpm contracts:generate
+pnpm setup:dev
 ```
 
-The first `uv sync` is heavy because it installs Demucs and Torch. The first stem-separation run will additionally download the Demucs model weights into the local Torch cache.
+That command installs workspace dependencies, syncs the backend Python environment, and regenerates shared API contracts. The first backend sync is heavy because it installs Demucs and Torch. The first stem-separation run will additionally download the Demucs model weights into the local Torch cache.
+
+To install the optional experimental crema/TensorFlow Advanced Chords backend for local desktop development:
+
+```sh
+pnpm setup:dev -- --advanced-chords
+```
+
+`--crema` is accepted as an alias. Advanced Chords remains optional; default setup and mobile paths do not install crema or TensorFlow.
 
 ### Linux legacy NVIDIA profile
 
 If you are on Linux `x86_64` with an older NVIDIA GPU that the default PyTorch build rejects at runtime, use the backend's opt-in legacy NVIDIA sync:
 
 ```sh
-pnpm sync:backend:legacy-nvidia
+pnpm setup:dev -- --legacy-nvidia
 ```
 
 That command first performs the normal backend sync, then locally overrides `torch` / `torchaudio` inside `apps/backend/.venv` with the official CUDA 12.6 wheels. The local backend commands (`pnpm dev:backend`, backend test/lint steps inside `pnpm test` / `pnpm lint`) will keep using that override until you reset the backend env:
 
 ```sh
 pnpm sync:backend:default
+```
+
+To combine the legacy NVIDIA profile with Advanced Chords:
+
+```sh
+pnpm setup:dev -- --legacy-nvidia --advanced-chords
 ```
 
 Both backend sync helpers recreate `apps/backend/.venv` from scratch to avoid stale mixed CUDA stacks when switching profiles. `uv` still reuses its shared cache, so after the first install, switching is usually much faster than a cold download. It is intended for cards like the GTX 1050 Ti. macOS, CI, and the default Linux setup remain unchanged.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -26,6 +26,12 @@ Tuneforge is distributed under the [MIT License](./LICENSE). It depends on third
 - **License:** ISC
 - **Source:** <https://github.com/librosa/librosa>
 
+### crema (optional Advanced Chords backend)
+
+- **License:** PyPI metadata lists ISC; upstream `LICENSE.md` currently contains BSD-2-Clause terms.
+- **Source:** <https://github.com/bmcfee/crema>
+- **Notes:** Optional desktop-only experimental chord-recognition backend. It is not installed by default, not required for normal app startup, and not part of the mobile build path. Primary transitive licenses checked for the optional stack include TensorFlow (Apache-2.0), Keras (Apache-2.0), and JAMS (ISC); review the full resolved dependency tree before bundling this optional backend into a packaged desktop app.
+
 ### FastAPI, Pydantic, SQLAlchemy, Alembic, Uvicorn, soundfile
 
 - See each project's own license. All are permissively licensed (MIT / BSD / Apache-2.0 family).

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -23,6 +23,30 @@ FastAPI backend for Tuneforge. It owns persistence, artifact management, audio a
 uv sync --python 3.11 --all-groups
 ```
 
+From the workspace root, `pnpm setup:dev` also runs the full developer setup: `pnpm install`, backend sync, and shared contract generation.
+
+### Optional Advanced Chords backend
+
+Built-in Chords is the default TuneForge chord backend. It uses TuneForge's built-in librosa/chroma/template pipeline and stays available on every supported backend path.
+
+Advanced Chords is an experimental desktop-only backend backed by [`crema`](https://github.com/bmcfee/crema). It can preserve richer chord labels from crema, including sevenths and inversion/slash-chord bass notes, but it pulls in TensorFlow/Keras and may start and run more slowly. It is optional and is not installed by the default backend sync. The optional extra pins the crema stack to TensorFlow/Keras 2.15, scikit-learn `<1.6`, and setuptools `<81` because crema 0.2.0 uses legacy model-loading, encoder, and `pkg_resources` APIs that are not compatible with newer releases.
+
+Built-in Chords and Advanced Chords both analyze the source track first. When a matching source instrumental stem exists, chord refresh also analyzes that stem and augments the source timeline, so chord jobs can report `source+stem`.
+
+For local desktop development:
+
+```sh
+uv sync --python 3.11 --all-groups --extra advanced-chords
+```
+
+From the workspace root:
+
+```sh
+pnpm setup:dev -- --advanced-chords
+```
+
+If `crema`, TensorFlow, Keras, or JAMS are missing, `/api/v1/chord-backends` reports `crema-advanced` as unavailable and normal Built-in Chords detection keeps working.
+
 ### Linux legacy NVIDIA profile
 
 If you are on Linux `x86_64` and the default PyTorch build does not support your NVIDIA GPU architecture (for example, Pascal cards like the GTX 1050 Ti), start from the standard sync above and then locally override `torch` / `torchaudio` with the older CUDA 12.6 wheels:
@@ -40,8 +64,10 @@ uv pip install \
 From the workspace root, the helper command is:
 
 ```sh
-pnpm sync:backend:legacy-nvidia
+pnpm setup:dev -- --legacy-nvidia
 ```
+
+Use `pnpm setup:dev -- --legacy-nvidia --advanced-chords` to combine this profile with Advanced Chords.
 
 This profile is an opt-in local override for Linux `x86_64`. The committed lockfile and the default macOS / Linux setup stay unchanged. When the override is active, use the repository commands (`pnpm dev:backend`, `pnpm test`, `pnpm lint`) so the backend keeps using the overridden `.venv` instead of asking `uv` to resync it.
 
@@ -85,6 +111,8 @@ All configuration is environment-driven (see [`app/config.py`](./app/config.py))
 | `TUNEFORGE_LYRICS_MODEL` | `turbo` | Whisper model used for lyrics generation. |
 | `TUNEFORGE_LYRICS_DEVICE` | `auto` | One of `auto`, `cpu`, `mps`, `cuda`. `auto` prefers compatible CUDA, then MPS, then CPU. |
 | `TUNEFORGE_LYRICS_CACHE_DIR` | `<data>/cache/lyrics` | Override where Whisper model weights are cached. |
+| `TUNEFORGE_DEFAULT_CHORD_BACKEND` | `tuneforge-fast` | Default chord backend for `backend: "default"`. Use `crema-advanced` only in desktop environments with optional dependencies installed. |
+| `TUNEFORGE_RUNTIME_PLATFORM` | `desktop` | Runtime platform marker. `android`, `ios`, or `mobile` disables the advanced chord backend. |
 
 Default data directory:
 
@@ -92,6 +120,38 @@ Default data directory:
 - Linux: `~/.local/share/tuneforge`
 
 Lyrics models follow the same first-use download pattern as Demucs. The selected Whisper weights are downloaded on demand into the lyrics cache directory, then reused offline on later runs.
+
+## Chord backends
+
+List available backends:
+
+```sh
+curl http://127.0.0.1:8765/api/v1/chord-backends
+```
+
+Generate chords with an explicit backend:
+
+```json
+{
+  "backend": "tuneforge-fast",
+  "force": false,
+  "overwrite_user_edits": false
+}
+```
+
+Accepted backend aliases are `fast` / `tuneforge-fast` and `advanced` / `crema-advanced`. User-edited chord timelines are preserved unless `overwrite_user_edits` is explicitly true.
+
+Benchmark Built-in Chords against Advanced Chords:
+
+```sh
+uv run --python 3.11 python -m app.benchmarks.chords --audio /path/to/song.mp3
+```
+
+The command writes machine-readable JSON to stdout and a short summary to stderr. Use `--json-only` for JSON-only output.
+
+### Licensing note
+
+The optional crema package metadata on PyPI lists ISC, while the upstream repository currently shows a BSD-2-Clause license file. Both are permissive. Primary optional-stack transitive licenses checked here are TensorFlow (Apache-2.0), Keras (Apache-2.0), and JAMS (ISC), but the full resolved dependency tree should still be reviewed before bundling Advanced Chords into a packaged desktop build. TuneForge does not install or bundle crema in the default backend or mobile path.
 
 ## Migrations
 

--- a/apps/backend/alembic/versions/0009_chord_backend_metadata.py
+++ b/apps/backend/alembic/versions/0009_chord_backend_metadata.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0009_chord_backend_metadata"
+down_revision = "0008_chord_edit_segments"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("chord_timelines") as batch_op:
+        batch_op.add_column(
+            sa.Column("source_kind", sa.String(length=32), nullable=False, server_default="generated")
+        )
+        batch_op.add_column(sa.Column("metadata_json", sa.JSON(), nullable=False, server_default="{}"))
+
+    op.execute("UPDATE chord_timelines SET source_kind = 'user-edited' WHERE has_user_edits = 1")
+    op.execute("UPDATE chord_timelines SET source_kind = 'generated' WHERE has_user_edits = 0")
+    op.execute("UPDATE chord_timelines SET metadata_json = '{}'")
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("chord_timelines") as batch_op:
+        batch_op.drop_column("metadata_json")
+        batch_op.drop_column("source_kind")

--- a/apps/backend/app/api/routes/chord_backends.py
+++ b/apps/backend/app/api/routes/chord_backends.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.schemas import ChordBackendSchema, ChordBackendsResponse
+from app.services.chord_backends import list_chord_backend_infos
+
+router = APIRouter(prefix="/chord-backends", tags=["chord-backends"])
+
+
+@router.get("", response_model=ChordBackendsResponse)
+def chord_backends() -> ChordBackendsResponse:
+    return ChordBackendsResponse(
+        backends=[ChordBackendSchema.model_validate(backend) for backend in list_chord_backend_infos()]
+    )

--- a/apps/backend/app/api/routes/projects.py
+++ b/apps/backend/app/api/routes/projects.py
@@ -33,6 +33,7 @@ from app.schemas import (
     TransposeRequest,
 )
 from app.services.artifacts import delete_project_artifact
+from app.services.chord_backends import FAST_CHORD_BACKEND_ID, resolve_chord_backend
 from app.services.chords import project_chord_detection_source
 from app.services.lyrics import update_project_lyrics
 from app.services.projects import (
@@ -71,6 +72,7 @@ def create_project(
         job_type="chords",
         payload={
             **ChordRequest(backend="default", force=False).model_dump(),
+            "chord_backend": FAST_CHORD_BACKEND_ID,
             "chord_source": "source",
         },
     )
@@ -150,8 +152,10 @@ def project_chords(
     runner=Depends(get_job_runner),
 ) -> JobResponse:
     project = get_project(session, project_id)
+    selected_backend = resolve_chord_backend(payload.backend, require_available=True)
     job_payload = payload.model_dump()
-    job_payload["chord_source"] = project_chord_detection_source(project)
+    job_payload["chord_backend"] = selected_backend.id
+    job_payload["chord_source"] = project_chord_detection_source(project, backend=selected_backend.id)
     job = runner.create_job(
         session,
         project_id=project_id,
@@ -297,6 +301,8 @@ def project_stems(
         source_artifact_id=payload.source_artifact_id,
     )
     job_payload = payload.model_dump()
+    selected_chord_backend = resolve_chord_backend(payload.chord_backend, require_available=False)
+    job_payload["chord_backend"] = selected_chord_backend.id
     job_payload["source_artifact_id"] = source_artifact.id
     job = runner.create_job(
         session,

--- a/apps/backend/app/benchmarks/__init__.py
+++ b/apps/backend/app/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/apps/backend/app/benchmarks/chords.py
+++ b/apps/backend/app/benchmarks/chords.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+from typing import Any
+
+import soundfile as sf
+
+from app.engines.crema_chords import clear_crema_model_cache
+from app.services.chord_backends import (
+    CREMA_CHORD_BACKEND_ID,
+    FAST_CHORD_BACKEND_ID,
+    detect_with_chord_backend,
+    resolve_chord_backend,
+    resolve_chord_backend_id,
+)
+
+DEFAULT_BENCHMARK_BACKENDS = (FAST_CHORD_BACKEND_ID, CREMA_CHORD_BACKEND_ID)
+SEVENTH_QUALITIES = {"7", "maj7", "m7", "dim7", "hdim7"}
+
+
+def build_benchmark_report(audio_path: Path, backend_ids: list[str] | None = None) -> dict[str, Any]:
+    resolved_audio_path = audio_path.expanduser().resolve()
+    selected_backend_ids = backend_ids or list(DEFAULT_BENCHMARK_BACKENDS)
+    return {
+        "audio_path": str(resolved_audio_path),
+        "track_duration_seconds": _track_duration_seconds(resolved_audio_path),
+        "results": [_benchmark_backend(resolved_audio_path, backend_id) for backend_id in selected_backend_ids],
+    }
+
+
+def summarize_report(report: dict[str, Any]) -> str:
+    lines = [
+        f"Chord benchmark: {report['audio_path']}",
+        f"Track duration: {report['track_duration_seconds']}",
+    ]
+    for result in report["results"]:
+        if not result["available"]:
+            lines.append(f"- {result['backend_id']}: unavailable ({result['unavailable_reason']})")
+            continue
+        lines.append(
+            "- {backend_id}: cold {cold:.3f}s, warm {warm:.3f}s, {segments} segments, "
+            "{qualities} qualities, sevenths {sevenths}, slash {slashes}, no-chord {no_chord}".format(
+                backend_id=result["backend_id"],
+                cold=result["cold_runtime_seconds"],
+                warm=result["warm_runtime_seconds"],
+                segments=result["number_of_chord_segments"],
+                qualities=result["number_of_unique_chord_qualities"],
+                sevenths=result["number_of_seventh_chords"],
+                slashes=result["number_of_slash_or_inversion_chords"],
+                no_chord=result["contains_no_chord_segments"],
+            )
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Benchmark TuneForge chord detection backends.")
+    parser.add_argument("--audio", required=True, type=Path, help="Path to an audio file.")
+    parser.add_argument(
+        "--backend",
+        action="append",
+        dest="backends",
+        help="Backend id or alias. Repeat to benchmark multiple backends. Defaults to built-in and advanced.",
+    )
+    parser.add_argument("--json-only", action="store_true", help="Only write machine-readable JSON to stdout.")
+    args = parser.parse_args(argv)
+
+    backend_ids = [resolve_chord_backend_id(backend) for backend in args.backends] if args.backends else None
+    report = build_benchmark_report(args.audio, backend_ids)
+    sys.stdout.write(json.dumps(report, indent=2))
+    sys.stdout.write("\n")
+    if not args.json_only:
+        sys.stderr.write(summarize_report(report))
+        sys.stderr.write("\n")
+    return 0
+
+
+def _benchmark_backend(audio_path: Path, backend_id: str) -> dict[str, Any]:
+    backend = resolve_chord_backend(backend_id, require_available=False)
+    availability = backend.availability()
+    base: dict[str, Any] = {
+        "backend_id": backend.id,
+        "backend_label": backend.label,
+        "available": availability.available,
+        "unavailable_reason": availability.unavailable_reason,
+    }
+    if not availability.available:
+        return {
+            **base,
+            "cold_runtime_seconds": None,
+            "warm_runtime_seconds": None,
+            "cold_peak_memory_bytes": None,
+            "warm_peak_memory_bytes": None,
+            "peak_memory_bytes": None,
+            "number_of_chord_segments": 0,
+            "number_of_unique_chord_qualities": 0,
+            "number_of_seventh_chords": 0,
+            "number_of_slash_or_inversion_chords": 0,
+            "contains_no_chord_segments": False,
+            "error": None,
+        }
+
+    if backend.id == CREMA_CHORD_BACKEND_ID:
+        clear_crema_model_cache()
+
+    try:
+        cold = _timed_detect(audio_path, backend.id)
+        warm = _timed_detect(audio_path, backend.id)
+    except Exception as exc:  # pragma: no cover - command should report backend failures.
+        return {
+            **base,
+            "available": False,
+            "unavailable_reason": str(exc),
+            "cold_runtime_seconds": None,
+            "warm_runtime_seconds": None,
+            "cold_peak_memory_bytes": None,
+            "warm_peak_memory_bytes": None,
+            "peak_memory_bytes": None,
+            "number_of_chord_segments": 0,
+            "number_of_unique_chord_qualities": 0,
+            "number_of_seventh_chords": 0,
+            "number_of_slash_or_inversion_chords": 0,
+            "contains_no_chord_segments": False,
+            "error": str(exc),
+        }
+
+    return {
+        **base,
+        "cold_runtime_seconds": cold["runtime_seconds"],
+        "warm_runtime_seconds": warm["runtime_seconds"],
+        "cold_peak_memory_bytes": cold["peak_memory_bytes"],
+        "warm_peak_memory_bytes": warm["peak_memory_bytes"],
+        "peak_memory_bytes": max(cold["peak_memory_bytes"], warm["peak_memory_bytes"]),
+        **_segment_metrics(warm["segments"]),
+        "error": None,
+    }
+
+
+def _timed_detect(audio_path: Path, backend_id: str) -> dict[str, Any]:
+    tracemalloc.start()
+    started_at = time.perf_counter()
+    result = detect_with_chord_backend(audio_path, backend_id)
+    runtime_seconds = time.perf_counter() - started_at
+    _, peak_memory_bytes = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return {
+        "runtime_seconds": round(runtime_seconds, 6),
+        "peak_memory_bytes": peak_memory_bytes,
+        "segments": result.segments,
+    }
+
+
+def _segment_metrics(segments: list[dict[str, Any]]) -> dict[str, Any]:
+    qualities = {
+        quality
+        for quality in (segment.get("quality") for segment in segments)
+        if isinstance(quality, str) and quality != "no_chord"
+    }
+    return {
+        "number_of_chord_segments": len(segments),
+        "number_of_unique_chord_qualities": len(qualities),
+        "number_of_seventh_chords": sum(1 for segment in segments if segment.get("quality") in SEVENTH_QUALITIES),
+        "number_of_slash_or_inversion_chords": sum(1 for segment in segments if _has_bass_note(segment)),
+        "contains_no_chord_segments": any(_is_no_chord(segment) for segment in segments),
+    }
+
+
+def _has_bass_note(segment: dict[str, Any]) -> bool:
+    bass_pitch_class = segment.get("bass_pitch_class")
+    root_pitch_class = segment.get("root_pitch_class", segment.get("pitch_class"))
+    return isinstance(bass_pitch_class, int) and bass_pitch_class != root_pitch_class
+
+
+def _is_no_chord(segment: dict[str, Any]) -> bool:
+    return segment.get("quality") == "no_chord" or segment.get("label") == "N.C."
+
+
+def _track_duration_seconds(audio_path: Path) -> float | None:
+    try:
+        info = sf.info(str(audio_path))
+    except RuntimeError:
+        return None
+    if info.samplerate <= 0:
+        return None
+    return round(float(info.frames / info.samplerate), 3)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -38,6 +38,8 @@ class Settings:
     lyrics_model: str
     lyrics_device: str
     lyrics_cache_dir: Path
+    default_chord_backend: str
+    runtime_platform: str
     max_workers: int
     backend_root: Path
 
@@ -75,6 +77,8 @@ def get_settings() -> Settings:
         lyrics_model=os.environ.get("TUNEFORGE_LYRICS_MODEL", "turbo"),
         lyrics_device=os.environ.get("TUNEFORGE_LYRICS_DEVICE", "auto"),
         lyrics_cache_dir=Path(os.environ.get("TUNEFORGE_LYRICS_CACHE_DIR", str(cache_root / "lyrics"))),
+        default_chord_backend=os.environ.get("TUNEFORGE_DEFAULT_CHORD_BACKEND", "tuneforge-fast"),
+        runtime_platform=os.environ.get("TUNEFORGE_RUNTIME_PLATFORM", "desktop").strip().lower(),
         max_workers=1,
         backend_root=backend_root,
     )

--- a/apps/backend/app/engines/chord_labels.py
+++ b/apps/backend/app/engines/chord_labels.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+NOTE_TO_PITCH_CLASS: dict[str, int] = {
+    "C": 0,
+    "B#": 0,
+    "C#": 1,
+    "DB": 1,
+    "D": 2,
+    "D#": 3,
+    "EB": 3,
+    "E": 4,
+    "FB": 4,
+    "F": 5,
+    "E#": 5,
+    "F#": 6,
+    "GB": 6,
+    "G": 7,
+    "G#": 8,
+    "AB": 8,
+    "A": 9,
+    "A#": 10,
+    "BB": 10,
+    "B": 11,
+    "CB": 11,
+}
+
+PITCH_CLASS_TO_SHARP = ("C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B")
+NO_CHORD_LABELS = {"N", "NC", "N.C.", "NO_CHORD", "NO-CHORD"}
+UNKNOWN_CHORD_LABELS = {"X"}
+
+QUALITY_ALIASES: dict[str, str] = {
+    "": "major",
+    "maj": "major",
+    "major": "major",
+    "min": "minor",
+    "minor": "minor",
+    "m": "minor",
+    "dim": "dim",
+    "diminished": "dim",
+    "aug": "aug",
+    "augmented": "aug",
+    "+": "aug",
+    "sus2": "sus2",
+    "sus4": "sus4",
+    "7": "7",
+    "dom7": "7",
+    "maj7": "maj7",
+    "major7": "maj7",
+    "min7": "m7",
+    "minor7": "m7",
+    "m7": "m7",
+    "dim7": "dim7",
+    "hdim7": "hdim7",
+    "half-diminished": "hdim7",
+    "half-diminished7": "hdim7",
+    "min7(b5)": "hdim7",
+    "m7(b5)": "hdim7",
+    "min7b5": "hdim7",
+    "m7b5": "hdim7",
+}
+
+QUALITY_SUFFIXES: dict[str, str] = {
+    "major": "",
+    "minor": "m",
+    "dim": "dim",
+    "aug": "aug",
+    "sus2": "sus2",
+    "sus4": "sus4",
+    "7": "7",
+    "maj7": "maj7",
+    "m7": "m7",
+    "dim7": "dim7",
+    "hdim7": "m7b5",
+    "no_chord": "",
+}
+
+DEGREE_TO_SEMITONE: dict[str, int] = {
+    "1": 0,
+    "b2": 1,
+    "#1": 1,
+    "2": 2,
+    "#2": 3,
+    "b3": 3,
+    "3": 4,
+    "4": 5,
+    "#4": 6,
+    "b5": 6,
+    "5": 7,
+    "#5": 8,
+    "b6": 8,
+    "6": 9,
+    "#6": 10,
+    "b7": 10,
+    "7": 11,
+}
+
+HARTE_LABEL_RE = re.compile(r"^([A-Ga-g](?:#|b)?)(?::([^/]+))?(?:/(.+))?$")
+
+
+@dataclass(frozen=True)
+class ParsedChordLabel:
+    raw_label: str
+    root_pitch_class: int | None
+    quality: str | None
+    bass_pitch_class: int | None
+    bass_degree: str | None
+    display_label: str
+    is_no_chord: bool = False
+    is_unknown: bool = False
+
+
+def parse_chord_label(raw_label: str) -> ParsedChordLabel:
+    normalized = raw_label.strip()
+    compact = normalized.upper().replace(" ", "")
+    if compact in NO_CHORD_LABELS:
+        return ParsedChordLabel(
+            raw_label=raw_label,
+            root_pitch_class=None,
+            quality="no_chord",
+            bass_pitch_class=None,
+            bass_degree=None,
+            display_label="N.C.",
+            is_no_chord=True,
+        )
+    if compact in UNKNOWN_CHORD_LABELS:
+        return ParsedChordLabel(
+            raw_label=raw_label,
+            root_pitch_class=None,
+            quality=None,
+            bass_pitch_class=None,
+            bass_degree=None,
+            display_label=normalized or raw_label,
+            is_unknown=True,
+        )
+
+    match = HARTE_LABEL_RE.match(normalized)
+    if not match:
+        return ParsedChordLabel(
+            raw_label=raw_label,
+            root_pitch_class=None,
+            quality=None,
+            bass_pitch_class=None,
+            bass_degree=None,
+            display_label=normalized or raw_label,
+            is_unknown=True,
+        )
+
+    root_name, quality_raw, bass_raw = match.groups()
+    root_pitch_class = NOTE_TO_PITCH_CLASS.get(_normalize_note_name(root_name))
+    if root_pitch_class is None:
+        return ParsedChordLabel(
+            raw_label=raw_label,
+            root_pitch_class=None,
+            quality=None,
+            bass_pitch_class=None,
+            bass_degree=None,
+            display_label=normalized or raw_label,
+            is_unknown=True,
+        )
+
+    quality = normalize_chord_quality(quality_raw)
+    bass_pitch_class, bass_degree = _parse_bass(bass_raw, root_pitch_class)
+    display_label = format_chord_display(root_pitch_class, quality, bass_pitch_class)
+    return ParsedChordLabel(
+        raw_label=raw_label,
+        root_pitch_class=root_pitch_class,
+        quality=quality,
+        bass_pitch_class=bass_pitch_class,
+        bass_degree=bass_degree,
+        display_label=display_label,
+    )
+
+
+def normalize_chord_quality(quality: str | None) -> str | None:
+    if quality is None:
+        return "major"
+    normalized = quality.strip().lower().replace(" ", "")
+    if normalized in QUALITY_ALIASES:
+        return QUALITY_ALIASES[normalized]
+    if normalized.startswith("maj7"):
+        return "maj7"
+    if normalized.startswith(("min7", "m7")):
+        return "m7"
+    if normalized.startswith("maj"):
+        return "major"
+    if normalized.startswith(("min", "m")):
+        return "minor"
+    if normalized.startswith("dim7"):
+        return "dim7"
+    if normalized.startswith("dim"):
+        return "dim"
+    if normalized.startswith("aug"):
+        return "aug"
+    if normalized.startswith("sus2"):
+        return "sus2"
+    if normalized.startswith("sus4"):
+        return "sus4"
+    if normalized.startswith("7"):
+        return "7"
+    return normalized or None
+
+
+def chord_label_to_segment(
+    raw_label: str,
+    *,
+    start_seconds: float,
+    end_seconds: float,
+    confidence: float | None = None,
+) -> dict[str, Any]:
+    parsed = parse_chord_label(raw_label)
+    return {
+        "start_seconds": round(start_seconds, 3),
+        "end_seconds": round(end_seconds, 3),
+        "label": parsed.display_label,
+        "display_label": parsed.display_label,
+        "raw_label": parsed.raw_label,
+        "confidence": confidence,
+        "pitch_class": parsed.root_pitch_class,
+        "root_pitch_class": parsed.root_pitch_class,
+        "quality": parsed.quality,
+        "bass_pitch_class": parsed.bass_pitch_class,
+        "bass_degree": parsed.bass_degree,
+    }
+
+
+def format_chord_display(
+    root_pitch_class: int | None,
+    quality: str | None,
+    bass_pitch_class: int | None = None,
+) -> str:
+    if root_pitch_class is None:
+        return "N.C." if quality == "no_chord" else "X"
+    root = PITCH_CLASS_TO_SHARP[root_pitch_class % 12]
+    suffix = QUALITY_SUFFIXES.get(quality or "major", quality or "")
+    label = f"{root}{suffix}"
+    if bass_pitch_class is not None and bass_pitch_class % 12 != root_pitch_class % 12:
+        label = f"{label}/{PITCH_CLASS_TO_SHARP[bass_pitch_class % 12]}"
+    return label
+
+
+def _parse_bass(bass_raw: str | None, root_pitch_class: int) -> tuple[int | None, str | None]:
+    if bass_raw is None or not bass_raw.strip():
+        return None, None
+    normalized = bass_raw.strip()
+    note_pitch_class = NOTE_TO_PITCH_CLASS.get(_normalize_note_name(normalized))
+    if note_pitch_class is not None:
+        return note_pitch_class, None
+
+    degree = normalized.lower().replace(" ", "")
+    semitone = DEGREE_TO_SEMITONE.get(degree)
+    if semitone is None:
+        return None, normalized
+    return (root_pitch_class + semitone) % 12, degree
+
+
+def _normalize_note_name(note_name: str) -> str:
+    stripped = note_name.strip()
+    if not stripped:
+        return stripped
+    return f"{stripped[0].upper()}{stripped[1:]}".replace("b", "B")

--- a/apps/backend/app/engines/crema_chords.py
+++ b/apps/backend/app/engines/crema_chords.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import importlib.metadata
+import importlib.util
+import io
+import warnings
+from collections.abc import Iterator
+from contextlib import contextmanager, redirect_stdout
+from pathlib import Path
+from typing import Any
+
+from app.engines.chord_labels import chord_label_to_segment
+
+CREMA_BACKEND_ID = "crema-advanced"
+_CREMA_MODEL: Any | None = None
+
+
+def crema_dependency_status(*, runtime_platform: str = "desktop") -> tuple[bool, str | None]:
+    if runtime_platform in {"android", "ios", "mobile"}:
+        return False, "advanced chord backend is disabled on mobile"
+    for module_name, display_name in (
+        ("crema", "crema"),
+        ("tensorflow", "TensorFlow backend"),
+        ("keras", "Keras"),
+        ("jams", "JAMS"),
+    ):
+        if importlib.util.find_spec(module_name) is None:
+            return False, f"{display_name} is not installed"
+    keras_version = _package_version("keras")
+    keras_major_version = _major_version(keras_version)
+    if keras_major_version is not None and keras_major_version >= 3:
+        return False, f"crema 0.2.0 is incompatible with installed Keras {keras_version}; install Keras < 3"
+    scikit_learn_version = _package_version("scikit-learn")
+    scikit_learn_major_minor = _major_minor_version(scikit_learn_version)
+    if scikit_learn_major_minor is not None and scikit_learn_major_minor >= (1, 6):
+        return (
+            False,
+            "crema 0.2.0 is incompatible with installed scikit-learn "
+            f"{scikit_learn_version}; install scikit-learn < 1.6",
+        )
+    return True, None
+
+
+def detect_crema_chord_timeline(
+    source_path: Path,
+    *,
+    merge_adjacent: bool = True,
+    min_segment_seconds: float = 0.0,
+) -> list[dict[str, Any]]:
+    model = _get_crema_model()
+    with _suppress_crema_runtime_noise(), redirect_stdout(io.StringIO()):
+        annotation = model.predict(filename=str(source_path))
+    segments = crema_annotation_to_timeline(annotation)
+    if min_segment_seconds > 0:
+        segments = _drop_short_segments(segments, min_segment_seconds=min_segment_seconds)
+    if merge_adjacent:
+        segments = merge_adjacent_chord_segments(segments)
+    return segments
+
+
+def crema_annotation_to_timeline(annotation: Any) -> list[dict[str, Any]]:
+    segments: list[dict[str, Any]] = []
+    for row in _annotation_rows(annotation):
+        start_seconds = _float_or_none(row.get("time"))
+        duration_seconds = _float_or_none(row.get("duration"))
+        raw_label = row.get("value")
+        if start_seconds is None or duration_seconds is None or raw_label is None:
+            continue
+        end_seconds = start_seconds + duration_seconds
+        if end_seconds <= start_seconds:
+            continue
+        confidence = _float_or_none(row.get("confidence"))
+        segments.append(
+            chord_label_to_segment(
+                str(raw_label),
+                start_seconds=start_seconds,
+                end_seconds=end_seconds,
+                confidence=round(confidence, 3) if confidence is not None else None,
+            )
+        )
+    return segments
+
+
+def merge_adjacent_chord_segments(segments: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not segments:
+        return []
+    merged = [dict(segments[0])]
+    for segment in segments[1:]:
+        previous = merged[-1]
+        if not _same_internal_chord(previous, segment):
+            merged.append(dict(segment))
+            continue
+        previous["end_seconds"] = segment["end_seconds"]
+        previous["confidence"] = _weighted_confidence(previous, segment)
+    return merged
+
+
+def clear_crema_model_cache() -> None:
+    global _CREMA_MODEL
+    _CREMA_MODEL = None
+
+
+def crema_model_metadata() -> dict[str, Any]:
+    return {
+        "backend_id": CREMA_BACKEND_ID,
+        "output_format": "jams",
+        "model": "crema.models.chord.ChordModel",
+        "crema_version": _package_version("crema"),
+        "tensorflow_version": _package_version("tensorflow"),
+        "license_note": "PyPI metadata lists ISC; upstream LICENSE.md is BSD-2-Clause.",
+    }
+
+
+def _get_crema_model() -> Any:
+    global _CREMA_MODEL
+    if _CREMA_MODEL is None:
+        with _suppress_crema_runtime_noise():
+            from crema.models.chord import ChordModel
+
+            _CREMA_MODEL = ChordModel()
+    return _CREMA_MODEL
+
+
+@contextmanager
+def _suppress_crema_runtime_noise() -> Iterator[None]:
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="pkg_resources is deprecated as an API.*",
+            category=UserWarning,
+        )
+        warnings.filterwarnings(
+            "ignore",
+            message=r"get_duration\(\) keyword argument 'filename' has been renamed.*",
+            category=FutureWarning,
+        )
+        yield
+
+
+def _annotation_rows(annotation: Any) -> list[dict[str, Any]]:
+    if hasattr(annotation, "to_dataframe"):
+        dataframe = annotation.to_dataframe()
+        records = dataframe.to_dict("records")
+        return [dict(record) for record in records]
+
+    data = getattr(annotation, "data", None)
+    if data is not None:
+        return [_observation_to_row(observation) for observation in data]
+
+    try:
+        return [_observation_to_row(observation) for observation in annotation]
+    except TypeError:
+        return []
+
+
+def _observation_to_row(observation: Any) -> dict[str, Any]:
+    if isinstance(observation, dict):
+        return observation
+    return {
+        "time": getattr(observation, "time", None),
+        "duration": getattr(observation, "duration", None),
+        "value": getattr(observation, "value", None),
+        "confidence": getattr(observation, "confidence", None),
+    }
+
+
+def _drop_short_segments(segments: list[dict[str, Any]], *, min_segment_seconds: float) -> list[dict[str, Any]]:
+    if len(segments) <= 1:
+        return segments
+    return [
+        segment
+        for segment in segments
+        if float(segment["end_seconds"]) - float(segment["start_seconds"]) >= min_segment_seconds
+    ]
+
+
+def _same_internal_chord(first: dict[str, Any], second: dict[str, Any]) -> bool:
+    return (
+        first.get("root_pitch_class", first.get("pitch_class"))
+        == second.get("root_pitch_class", second.get("pitch_class"))
+        and first.get("quality") == second.get("quality")
+        and first.get("bass_pitch_class") == second.get("bass_pitch_class")
+    )
+
+
+def _weighted_confidence(first: dict[str, Any], second: dict[str, Any]) -> float | None:
+    first_confidence = _float_or_none(first.get("confidence"))
+    second_confidence = _float_or_none(second.get("confidence"))
+    if first_confidence is None:
+        return second_confidence
+    if second_confidence is None:
+        return first_confidence
+    first_duration = float(first["end_seconds"]) - float(first["start_seconds"])
+    second_duration = float(second["end_seconds"]) - float(second["start_seconds"])
+    total_duration = max(first_duration + second_duration, 1e-6)
+    return round((first_confidence * first_duration + second_confidence * second_duration) / total_duration, 3)
+
+
+def _float_or_none(value: Any) -> float | None:
+    if isinstance(value, int | float):
+        return float(value)
+    return None
+
+
+def _package_version(package_name: str) -> str | None:
+    try:
+        return importlib.metadata.version(package_name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _major_version(version: str | None) -> int | None:
+    if version is None:
+        return None
+    try:
+        return int(version.split(".", 1)[0])
+    except ValueError:
+        return None
+
+
+def _major_minor_version(version: str | None) -> tuple[int, int] | None:
+    if version is None:
+        return None
+    parts = version.split(".", 2)
+    if len(parts) < 2:
+        return None
+    try:
+        return int(parts[0]), int(parts[1])
+    except ValueError:
+        return None

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse
 
 from app import __version__
 from app.api.routes.artifacts import router as artifacts_router
+from app.api.routes.chord_backends import router as chord_backends_router
 from app.api.routes.health import router as health_router
 from app.api.routes.jobs import router as jobs_router
 from app.api.routes.projects import router as projects_router
@@ -70,6 +71,7 @@ async def validation_error_handler(_: Request, exc: RequestValidationError) -> J
 
 
 app.include_router(health_router, prefix=get_settings().api_prefix)
+app.include_router(chord_backends_router, prefix=get_settings().api_prefix)
 app.include_router(projects_router, prefix=get_settings().api_prefix)
 app.include_router(jobs_router, prefix=get_settings().api_prefix)
 app.include_router(artifacts_router, prefix=get_settings().api_prefix)

--- a/apps/backend/app/models.py
+++ b/apps/backend/app/models.py
@@ -73,6 +73,8 @@ class ChordTimeline(Base):
     timeline_json: Mapped[list[dict[str, Any]]] = mapped_column(JSON(), default=list)
     source_segments_json: Mapped[list[dict[str, Any]]] = mapped_column(JSON(), default=list)
     segments_json: Mapped[list[dict[str, Any]]] = mapped_column(JSON(), default=list)
+    source_kind: Mapped[str] = mapped_column(String(32), default="generated")
+    metadata_json: Mapped[dict[str, Any]] = mapped_column(JSON(), default=dict)
     has_user_edits: Mapped[bool] = mapped_column(Boolean(), default=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
     updated_at: Mapped[datetime | None] = mapped_column(
@@ -160,6 +162,28 @@ class Job(Base):
         if self.type != "chords":
             return None
         value = self.payload_json.get("chord_source")
+        return value if isinstance(value, str) else None
+
+    @property
+    def chord_backend(self) -> str | None:
+        if self.type != "chords":
+            return None
+        value = self.payload_json.get("chord_backend")
+        if isinstance(value, str):
+            return value
+        fallback = self.payload_json.get("backend")
+        if fallback == "default":
+            return "tuneforge-fast"
+        return fallback if isinstance(fallback, str) else None
+
+    @property
+    def chord_backend_fallback_from(self) -> str | None:
+        if self.type != "chords":
+            return None
+        value = self.payload_json.get("backend_fallback_from")
+        if isinstance(value, str):
+            return value
+        value = self.payload_json.get("chord_backend_fallback_from")
         return value if isinstance(value, str) else None
 
 

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -125,13 +125,17 @@ class AnalysisResponse(BaseModel):
 
 class ChordRequest(BaseModel):
     backend: str = "default"
+    backend_fallback_from: str | None = None
     force: bool = False
     overwrite_user_edits: bool = False
 
     @model_validator(mode="after")
     def validate_backend(self) -> ChordRequest:
-        if self.backend != "default":
-            raise ValueError("Only the default chord backend is supported in v1.")
+        supported = {"default", "fast", "tuneforge-fast", "librosa", "advanced", "crema", "crema-advanced"}
+        if self.backend not in supported or (
+            self.backend_fallback_from is not None and self.backend_fallback_from not in supported
+        ):
+            raise ValueError("Unsupported chord backend.")
         return self
 
 
@@ -139,9 +143,14 @@ class ChordSegmentSchema(BaseModel):
     start_seconds: float
     end_seconds: float
     label: str
+    display_label: str | None = None
+    raw_label: str | None = None
     confidence: float | None = None
     pitch_class: int | None = None
+    root_pitch_class: int | None = None
     quality: str | None = None
+    bass_pitch_class: int | None = None
+    bass_degree: str | None = None
 
 
 class ChordResponse(BaseModel):
@@ -156,8 +165,40 @@ class ChordResponse(BaseModel):
     backend: str | None = None
     source_artifact_id: str | None = None
     has_user_edits: bool = False
+    source_kind: str = "generated"
+    metadata: dict[str, Any] = Field(default_factory=dict, validation_alias="metadata_json")
     created_at: datetime | None = None
     updated_at: datetime | None = None
+
+
+class ChordBackendCapabilitiesSchema(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    supports_sevenths: bool = Field(alias="supportsSevenths")
+    supports_inversions: bool = Field(alias="supportsInversions")
+    supports_confidence: bool = Field(alias="supportsConfidence")
+    supports_no_chord: bool = Field(alias="supportsNoChord")
+    estimated_speed: str = Field(alias="estimatedSpeed")
+    desktop_only: bool = Field(alias="desktopOnly")
+    experimental: bool
+
+
+class ChordBackendSchema(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    label: str
+    description: str
+    availability: str
+    available: bool
+    unavailable_reason: str | None = None
+    capabilities: ChordBackendCapabilitiesSchema
+    experimental: bool
+    desktop_only: bool = Field(alias="desktopOnly")
+
+
+class ChordBackendsResponse(BaseModel):
+    backends: list[ChordBackendSchema]
 
 
 class LyricsGenerateRequest(BaseModel):
@@ -215,6 +256,8 @@ class JobSchema(BaseModel):
     status: str
     progress: int
     source_artifact_id: str | None = None
+    chord_backend: str | None = None
+    chord_backend_fallback_from: str | None = None
     chord_source: str | None = None
     error_message: str | None
     runtime_device: str | None = None
@@ -306,6 +349,8 @@ class StemRequest(BaseModel):
     output_format: str = "wav"
     force: bool = False
     source_artifact_id: str | None = None
+    chord_backend: str = "default"
+    chord_backend_fallback_from: str | None = None
     overwrite_chord_edits: bool = False
 
     @model_validator(mode="after")
@@ -314,6 +359,11 @@ class StemRequest(BaseModel):
             raise ValueError("Only two_stem mode is supported in v1.")
         if self.output_format != "wav":
             raise ValueError("Stem output must be wav in v1.")
+        supported = {"default", "fast", "tuneforge-fast", "librosa", "advanced", "crema", "crema-advanced"}
+        if self.chord_backend not in supported or (
+            self.chord_backend_fallback_from is not None and self.chord_backend_fallback_from not in supported
+        ):
+            raise ValueError("Unsupported chord backend.")
         return self
 
 

--- a/apps/backend/app/services/chord_backends.py
+++ b/apps/backend/app/services/chord_backends.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Literal, Protocol, cast
+
+from app.config import get_settings
+from app.engines.chords import detect_chord_timeline
+from app.engines.crema_chords import (
+    crema_dependency_status,
+    crema_model_metadata,
+    detect_crema_chord_timeline,
+)
+from app.errors import AppError
+
+ChordBackendSpeed = Literal["fast", "medium", "slow"]
+
+FAST_CHORD_BACKEND_ID = "tuneforge-fast"
+CREMA_CHORD_BACKEND_ID = "crema-advanced"
+DEFAULT_CHORD_BACKEND_ID = FAST_CHORD_BACKEND_ID
+
+
+@dataclass(frozen=True)
+class ChordBackendCapabilities:
+    supports_sevenths: bool
+    supports_inversions: bool
+    supports_confidence: bool
+    supports_no_chord: bool
+    estimated_speed: ChordBackendSpeed
+    desktop_only: bool
+    experimental: bool
+
+
+@dataclass(frozen=True)
+class ChordBackendAvailability:
+    available: bool
+    unavailable_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class ChordDetectionResult:
+    segments: list[dict[str, Any]]
+    backend_id: str
+    metadata: dict[str, Any]
+
+
+class ChordDetectionBackend(Protocol):
+    id: str
+    label: str
+    description: str
+    capabilities: ChordBackendCapabilities
+
+    def availability(self) -> ChordBackendAvailability:
+        ...
+
+    def detect(self, source_path: Path) -> ChordDetectionResult:
+        ...
+
+
+@dataclass(frozen=True)
+class FastChordBackend:
+    id: str = FAST_CHORD_BACKEND_ID
+    label: str = "Built-in Chords"
+    description: str = "TuneForge's built-in librosa/chroma chord detector. Default and lightweight."
+    capabilities: ChordBackendCapabilities = ChordBackendCapabilities(
+        supports_sevenths=True,
+        supports_inversions=False,
+        supports_confidence=True,
+        supports_no_chord=True,
+        estimated_speed="medium",
+        desktop_only=False,
+        experimental=False,
+    )
+
+    def availability(self) -> ChordBackendAvailability:
+        return ChordBackendAvailability(available=True)
+
+    def detect(self, source_path: Path) -> ChordDetectionResult:
+        segments = [_normalize_fast_segment(segment) for segment in detect_chord_timeline(source_path)]
+        return ChordDetectionResult(
+            segments=segments,
+            backend_id=self.id,
+            metadata={
+                "backend_id": self.id,
+                "engine": "librosa-chroma-template-viterbi",
+                "analysis_version": "v2",
+            },
+        )
+
+
+@dataclass(frozen=True)
+class CremaChordBackend:
+    id: str = CREMA_CHORD_BACKEND_ID
+    label: str = "Advanced Chords"
+    description: str = "Optional crema chord detector with richer chord vocabulary and inversion estimates."
+    capabilities: ChordBackendCapabilities = ChordBackendCapabilities(
+        supports_sevenths=True,
+        supports_inversions=True,
+        supports_confidence=True,
+        supports_no_chord=True,
+        estimated_speed="slow",
+        desktop_only=True,
+        experimental=True,
+    )
+
+    def availability(self) -> ChordBackendAvailability:
+        available, reason = crema_dependency_status(runtime_platform=get_settings().runtime_platform)
+        return ChordBackendAvailability(available=available, unavailable_reason=reason)
+
+    def detect(self, source_path: Path) -> ChordDetectionResult:
+        availability = self.availability()
+        if not availability.available:
+            raise AppError(
+                "ADVANCED_CHORD_BACKEND_UNAVAILABLE",
+                availability.unavailable_reason or "Advanced chord backend is unavailable.",
+                status_code=409,
+            )
+        return ChordDetectionResult(
+            segments=detect_crema_chord_timeline(source_path),
+            backend_id=self.id,
+            metadata=crema_model_metadata(),
+        )
+
+
+_BACKENDS: dict[str, ChordDetectionBackend] = {
+    FAST_CHORD_BACKEND_ID: cast(ChordDetectionBackend, FastChordBackend()),
+    CREMA_CHORD_BACKEND_ID: cast(ChordDetectionBackend, CremaChordBackend()),
+}
+
+_ALIASES = {
+    "default": "default",
+    "fast": FAST_CHORD_BACKEND_ID,
+    "librosa": FAST_CHORD_BACKEND_ID,
+    "tuneforge-fast": FAST_CHORD_BACKEND_ID,
+    "advanced": CREMA_CHORD_BACKEND_ID,
+    "crema": CREMA_CHORD_BACKEND_ID,
+    "crema-advanced": CREMA_CHORD_BACKEND_ID,
+}
+
+
+def list_chord_backend_infos() -> list[dict[str, Any]]:
+    return [_backend_info(backend) for backend in _BACKENDS.values()]
+
+
+def resolve_chord_backend(requested_backend: str | None, *, require_available: bool = False) -> ChordDetectionBackend:
+    backend_id = resolve_chord_backend_id(requested_backend)
+    backend = _BACKENDS[backend_id]
+    availability = backend.availability()
+    if require_available and not availability.available:
+        _raise_unavailable(backend, availability)
+    return backend
+
+
+def resolve_chord_backend_id(requested_backend: str | None) -> str:
+    requested = (requested_backend or "default").strip()
+    alias = _ALIASES.get(requested)
+    if alias is None:
+        raise AppError(
+            "UNSUPPORTED_CHORD_BACKEND",
+            f"Unsupported chord backend: {requested}.",
+            status_code=422,
+            details={"supported_backends": sorted(_ALIASES)},
+        )
+    if alias != "default":
+        return alias
+
+    configured = _ALIASES.get(get_settings().default_chord_backend, DEFAULT_CHORD_BACKEND_ID)
+    if configured == "default":
+        configured = DEFAULT_CHORD_BACKEND_ID
+    backend = _BACKENDS.get(configured, _BACKENDS[DEFAULT_CHORD_BACKEND_ID])
+    availability = backend.availability()
+    if availability.available:
+        return backend.id
+    return DEFAULT_CHORD_BACKEND_ID
+
+
+def detect_with_chord_backend(source_path: Path, backend_id: str) -> ChordDetectionResult:
+    backend = resolve_chord_backend(backend_id, require_available=True)
+    return backend.detect(source_path)
+
+
+def chord_backend_is_fast(backend_id: str) -> bool:
+    return resolve_chord_backend_id(backend_id) == FAST_CHORD_BACKEND_ID
+
+
+def chord_backend_uses_source_instrumental_stem(backend_id: str) -> bool:
+    return resolve_chord_backend_id(backend_id) in {
+        FAST_CHORD_BACKEND_ID,
+        CREMA_CHORD_BACKEND_ID,
+    }
+
+
+def _backend_info(backend: ChordDetectionBackend) -> dict[str, Any]:
+    availability = backend.availability()
+    capabilities = asdict(backend.capabilities)
+    return {
+        "id": backend.id,
+        "label": backend.label,
+        "description": backend.description,
+        "availability": "available" if availability.available else "unavailable",
+        "available": availability.available,
+        "unavailable_reason": availability.unavailable_reason,
+        "capabilities": capabilities,
+        "experimental": backend.capabilities.experimental,
+        "desktopOnly": backend.capabilities.desktop_only,
+        "desktop_only": backend.capabilities.desktop_only,
+    }
+
+
+def _raise_unavailable(backend: ChordDetectionBackend, availability: ChordBackendAvailability) -> None:
+    code = (
+        "ADVANCED_CHORD_BACKEND_UNAVAILABLE"
+        if backend.id == CREMA_CHORD_BACKEND_ID
+        else "CHORD_BACKEND_UNAVAILABLE"
+    )
+    raise AppError(
+        code,
+        availability.unavailable_reason or f"{backend.label} is unavailable.",
+        status_code=409,
+        details={"backend": backend.id},
+    )
+
+
+def _normalize_fast_segment(segment: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = dict(segment)
+    pitch_class = normalized.get("pitch_class")
+    normalized["root_pitch_class"] = pitch_class if isinstance(pitch_class, int) else None
+    normalized["bass_pitch_class"] = None
+    normalized["bass_degree"] = None
+    normalized["display_label"] = normalized.get("label")
+    normalized["raw_label"] = normalized.get("label")
+    return cast(dict[str, Any], normalized)

--- a/apps/backend/app/services/chords.py
+++ b/apps/backend/app/services/chords.py
@@ -7,33 +7,55 @@ from typing import Any, cast
 
 from sqlalchemy.orm import Session
 
-from app.engines.chords import detect_chord_timeline
+from app.errors import AppError
 from app.models import Artifact, ChordTimeline, Project, utcnow
+from app.services.chord_backends import (
+    ChordDetectionResult,
+    chord_backend_uses_source_instrumental_stem,
+    detect_with_chord_backend,
+    resolve_chord_backend,
+    resolve_chord_backend_id,
+)
 from app.services.paths import project_analysis_dir
-
-CHORD_DETECTION_ENGINE = "librosa"
 
 
 def detect_project_chords(
     session: Session,
     project: Project,
     *,
+    backend: str = "default",
+    backend_fallback_from: str | None = None,
     force: bool = False,
     overwrite_user_edits: bool = False,
 ) -> ChordTimeline:
+    selected_backend = resolve_chord_backend(backend, require_available=True)
+    selected_backend_id = selected_backend.id
     existing = session.get(ChordTimeline, project.id)
-    if existing is not None and existing.segments_json and not force:
-        return existing
     if existing is not None and existing.has_user_edits and not overwrite_user_edits:
+        existing.source_kind = "user-edited"
+        return existing
+    if (
+        existing is not None
+        and existing.segments_json
+        and not force
+        and not overwrite_user_edits
+        and _same_backend(existing.backend, selected_backend_id)
+    ):
         return existing
 
     source_artifact = _source_audio_artifact(project)
     source_path = Path(source_artifact.path) if source_artifact is not None else Path(project.imported_path)
-    source_timeline = cast(list[dict[str, Any]], detect_chord_timeline(source_path))
-    augmented_timeline = _augment_with_source_instrumental_stem(
-        project,
-        source_artifact=source_artifact,
-        source_timeline=source_timeline,
+    source_result = _detect_timeline(source_path, selected_backend_id)
+    source_timeline = source_result.segments
+    augmented_timeline = (
+        _augment_with_source_instrumental_stem(
+            project,
+            backend_id=selected_backend_id,
+            source_artifact=source_artifact,
+            source_timeline=source_timeline,
+        )
+        if chord_backend_uses_source_instrumental_stem(selected_backend_id)
+        else source_timeline
     )
     updated_at = utcnow()
 
@@ -41,12 +63,20 @@ def detect_project_chords(
         existing = ChordTimeline(project_id=project.id, created_at=updated_at)
         session.add(existing)
 
-    existing.backend = CHORD_DETECTION_ENGINE
+    existing.backend = selected_backend_id
     existing.source_artifact_id = source_artifact.id if isinstance(source_artifact, Artifact) else None
     existing.source_segments_json = cast(list[dict[str, Any]], deepcopy(source_timeline))
     existing.segments_json = cast(list[dict[str, Any]], deepcopy(augmented_timeline))
     existing.timeline_json = cast(list[dict[str, Any]], deepcopy(augmented_timeline))
     existing.has_user_edits = False
+    existing.source_kind = "generated"
+    existing.metadata_json = {
+        "backend_id": selected_backend_id,
+        "backend_label": selected_backend.label,
+        "backend_capabilities": selected_backend.capabilities.__dict__,
+        "backend_fallback_from": backend_fallback_from,
+        "detection": source_result.metadata,
+    }
     existing.updated_at = updated_at
     session.flush()
     session.refresh(existing)
@@ -61,6 +91,8 @@ def detect_project_chords(
                 "source_segments": existing.source_segments_json,
                 "timeline": existing.segments_json,
                 "has_user_edits": existing.has_user_edits,
+                "source_kind": existing.source_kind,
+                "metadata": existing.metadata_json,
                 "created_at": existing.created_at.isoformat(),
                 "updated_at": existing.updated_at.isoformat() if existing.updated_at else None,
             },
@@ -76,7 +108,9 @@ def _source_audio_artifact(project: Project) -> Artifact | None:
     return next((artifact for artifact in project.artifacts if artifact.type == "source_audio"), None)
 
 
-def project_chord_detection_source(project: Project) -> str:
+def project_chord_detection_source(project: Project, backend: str = "default") -> str:
+    if not chord_backend_uses_source_instrumental_stem(backend):
+        return "source"
     source_artifact = _source_audio_artifact(project)
     return "source+stem" if _source_instrumental_stem(project, source_artifact) is not None else "source"
 
@@ -99,6 +133,7 @@ def _source_instrumental_stem(project: Project, source_artifact: Artifact | None
 def _augment_with_source_instrumental_stem(
     project: Project,
     *,
+    backend_id: str,
     source_artifact: Artifact | None,
     source_timeline: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
@@ -106,7 +141,7 @@ def _augment_with_source_instrumental_stem(
     if instrumental_stem is None or not source_timeline:
         return source_timeline
 
-    stem_timeline = cast(list[dict[str, Any]], detect_chord_timeline(Path(instrumental_stem.path)))
+    stem_timeline = _detect_timeline(Path(instrumental_stem.path), backend_id).segments
     if not stem_timeline:
         return source_timeline
 
@@ -212,3 +247,16 @@ def _confidence_value(segment: dict[str, Any]) -> float:
     if isinstance(confidence, int | float):
         return float(confidence)
     return 0.0
+
+
+def _detect_timeline(source_path: Path, backend_id: str) -> ChordDetectionResult:
+    return detect_with_chord_backend(source_path, backend_id)
+
+
+def _same_backend(existing_backend: str | None, selected_backend_id: str) -> bool:
+    if existing_backend is None:
+        return False
+    try:
+        return resolve_chord_backend_id(existing_backend) == selected_backend_id
+    except AppError:
+        return existing_backend == selected_backend_id

--- a/apps/backend/app/services/jobs.py
+++ b/apps/backend/app/services/jobs.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from app.errors import AppError, JobCancelledError
 from app.models import Artifact, ChordTimeline, Job, utcnow
 from app.services.analysis import analyze_project
+from app.services.chord_backends import resolve_chord_backend
 from app.services.chords import detect_project_chords, project_chord_detection_source
 from app.services.lyrics import generate_project_lyrics
 from app.services.projects import get_project
@@ -281,15 +282,22 @@ class InProcessJobRunner:
 
     def _handle_chords(self, context: JobExecutionContext, session: Session, job: Job) -> JobExecutionResult:
         project = get_project(session, job.project_id or "")
+        backend = str(job.payload_json.get("backend", "default"))
+        selected_backend = resolve_chord_backend(backend, require_available=True)
         job.payload_json = {
             **job.payload_json,
-            "chord_source": project_chord_detection_source(project),
+            "chord_backend": selected_backend.id,
+            "chord_source": project_chord_detection_source(project, backend=selected_backend.id),
         }
         session.flush()
         context.set_progress(20)
         detect_project_chords(
             session,
             project,
+            backend=backend,
+            backend_fallback_from=job.payload_json.get("backend_fallback_from")
+            if isinstance(job.payload_json.get("backend_fallback_from"), str)
+            else None,
             force=bool(job.payload_json.get("force", False)),
             overwrite_user_edits=bool(job.payload_json.get("overwrite_user_edits", False)),
         )
@@ -346,14 +354,22 @@ class InProcessJobRunner:
             unregister_process=context.unregister_process,
         )
         if _should_enqueue_chord_refresh_after_stems(job, artifacts, session.get(ChordTimeline, project.id)):
+            selected_chord_backend = resolve_chord_backend(
+                str(payload.get("chord_backend", "default")),
+                require_available=False,
+            )
             chord_job = self.create_job(
                 session,
                 project_id=project.id,
                 job_type="chords",
                 payload={
-                    "backend": "default",
+                    "backend": selected_chord_backend.id,
+                    "backend_fallback_from": payload.get("chord_backend_fallback_from")
+                    if isinstance(payload.get("chord_backend_fallback_from"), str)
+                    else None,
                     "force": True,
                     "overwrite_user_edits": bool(payload.get("overwrite_chord_edits", False)),
+                    "chord_backend": selected_chord_backend.id,
                     "chord_source": "source+stem",
                 },
             )

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -17,6 +17,15 @@ dependencies = [
   "uvicorn>=0.34.2,<1.0.0",
 ]
 
+[project.optional-dependencies]
+advanced-chords = [
+  "crema>=0.2.0,<0.3.0",
+  "keras>=2.15,<2.16",
+  "scikit-learn>=1.3,<1.6",
+  "setuptools<81",
+  "tensorflow>=2.15,<2.16",
+]
+
 [dependency-groups]
 dev = [
   "httpx>=0.28.1,<1.0.0",

--- a/apps/backend/tests/test_chord_backends.py
+++ b/apps/backend/tests/test_chord_backends.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import json
+import warnings
+from pathlib import Path
+from typing import Any
+
+from app.benchmarks.chords import main as benchmark_main
+from app.engines.chord_labels import chord_label_to_segment, parse_chord_label
+from app.engines.crema_chords import crema_annotation_to_timeline, detect_crema_chord_timeline
+from app.services.chord_backends import list_chord_backend_infos, resolve_chord_backend
+
+
+class FakeDataFrame:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+
+    def to_dict(self, orient: str) -> list[dict[str, Any]]:
+        assert orient == "records"
+        return self.rows
+
+
+class FakeAnnotation:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+
+    def to_dataframe(self) -> FakeDataFrame:
+        return FakeDataFrame(self.rows)
+
+
+def test_chord_label_parser_handles_harte_sevenths_and_inversions():
+    parsed = parse_chord_label("D:maj/3")
+    assert parsed.root_pitch_class == 2
+    assert parsed.quality == "major"
+    assert parsed.bass_pitch_class == 6
+    assert parsed.bass_degree == "3"
+    assert parsed.display_label == "D/F#"
+
+    segment = chord_label_to_segment("C:min/5", start_seconds=0, end_seconds=2, confidence=0.72)
+    assert segment["label"] == "Cm/G"
+    assert segment["quality"] == "minor"
+    assert segment["bass_pitch_class"] == 7
+    assert segment["raw_label"] == "C:min/5"
+
+    assert chord_label_to_segment("C:maj7", start_seconds=0, end_seconds=1)["quality"] == "maj7"
+    assert chord_label_to_segment("C:min7", start_seconds=0, end_seconds=1)["label"] == "Cm7"
+    assert chord_label_to_segment("C:min7(b5)", start_seconds=0, end_seconds=1)["label"] == "Cm7b5"
+
+
+def test_chord_label_parser_handles_no_chord_and_unknown():
+    no_chord = chord_label_to_segment("N", start_seconds=1.0, end_seconds=2.0)
+    assert no_chord["label"] == "N.C."
+    assert no_chord["quality"] == "no_chord"
+    assert no_chord["pitch_class"] is None
+
+    unknown = chord_label_to_segment("X", start_seconds=1.0, end_seconds=2.0)
+    assert unknown["label"] == "X"
+    assert unknown["quality"] is None
+
+
+def test_crema_annotation_conversion_preserves_confidence_and_bass():
+    annotation = FakeAnnotation(
+        [
+            {"time": 0.0, "duration": 1.5, "value": "D:maj/3", "confidence": 0.81},
+            {"time": 1.5, "duration": 1.0, "value": "N", "confidence": 0.2},
+        ]
+    )
+
+    timeline = crema_annotation_to_timeline(annotation)
+
+    assert timeline[0] == {
+        "start_seconds": 0.0,
+        "end_seconds": 1.5,
+        "label": "D/F#",
+        "display_label": "D/F#",
+        "raw_label": "D:maj/3",
+        "confidence": 0.81,
+        "pitch_class": 2,
+        "root_pitch_class": 2,
+        "quality": "major",
+        "bass_pitch_class": 6,
+        "bass_degree": "3",
+    }
+    assert timeline[1]["label"] == "N.C."
+    assert timeline[1]["quality"] == "no_chord"
+
+
+def test_crema_detection_suppresses_known_runtime_noise(monkeypatch, capsys, recwarn):
+    class FakeModel:
+        def predict(self, filename: str):
+            assert filename == "/tmp/source.wav"
+            print("1/1 [==============================] - 1s 512ms/step")
+            warnings.warn(
+                "get_duration() keyword argument 'filename' has been renamed to 'path' in version 0.10.0.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            return FakeAnnotation([{"time": 0.0, "duration": 1.0, "value": "C:maj", "confidence": 0.7}])
+
+    monkeypatch.setattr("app.engines.crema_chords._get_crema_model", lambda: FakeModel())
+
+    timeline = detect_crema_chord_timeline(Path("/tmp/source.wav"))
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert len(recwarn) == 0
+    assert timeline[0]["label"] == "C"
+
+
+def test_backend_registry_reports_fast_and_missing_crema(monkeypatch):
+    def fake_find_spec(module_name: str):
+        return None if module_name == "crema" else object()
+
+    monkeypatch.setattr("app.engines.crema_chords.importlib.util.find_spec", fake_find_spec)
+
+    backends = {backend["id"]: backend for backend in list_chord_backend_infos()}
+
+    assert backends["tuneforge-fast"]["availability"] == "available"
+    assert backends["tuneforge-fast"]["capabilities"]["supports_sevenths"] is True
+    assert backends["crema-advanced"]["availability"] == "unavailable"
+    assert backends["crema-advanced"]["unavailable_reason"] == "crema is not installed"
+
+
+def test_resolving_missing_advanced_backend_returns_structured_error(monkeypatch):
+    def fake_find_spec(module_name: str):
+        return None if module_name == "crema" else object()
+
+    monkeypatch.setattr("app.engines.crema_chords.importlib.util.find_spec", fake_find_spec)
+
+    backend = resolve_chord_backend("crema-advanced")
+    assert backend.availability().available is False
+
+
+def test_crema_backend_detects_keras_three_incompatibility(monkeypatch):
+    monkeypatch.setattr("app.engines.crema_chords.importlib.util.find_spec", lambda _: object())
+
+    def fake_version(package_name: str) -> str:
+        versions = {"keras": "3.14.0", "scikit-learn": "1.5.2"}
+        return versions.get(package_name, "0.2.0")
+
+    monkeypatch.setattr(
+        "app.engines.crema_chords.importlib.metadata.version",
+        fake_version,
+    )
+
+    backend = resolve_chord_backend("crema-advanced")
+    availability = backend.availability()
+
+    assert availability.available is False
+    assert availability.unavailable_reason == (
+        "crema 0.2.0 is incompatible with installed Keras 3.14.0; install Keras < 3"
+    )
+
+
+def test_crema_backend_detects_scikit_learn_incompatibility(monkeypatch):
+    monkeypatch.setattr("app.engines.crema_chords.importlib.util.find_spec", lambda _: object())
+
+    def fake_version(package_name: str) -> str:
+        versions = {"keras": "2.15.0", "scikit-learn": "1.8.0"}
+        return versions.get(package_name, "0.2.0")
+
+    monkeypatch.setattr(
+        "app.engines.crema_chords.importlib.metadata.version",
+        fake_version,
+    )
+
+    backend = resolve_chord_backend("crema-advanced")
+    availability = backend.availability()
+
+    assert availability.available is False
+    assert availability.unavailable_reason == (
+        "crema 0.2.0 is incompatible with installed scikit-learn 1.8.0; install scikit-learn < 1.6"
+    )
+
+
+def test_chord_backends_api_marks_crema_unavailable(client, monkeypatch):
+    def fake_find_spec(module_name: str):
+        return None if module_name == "crema" else object()
+
+    monkeypatch.setattr("app.engines.crema_chords.importlib.util.find_spec", fake_find_spec)
+
+    response = client.get("/api/v1/chord-backends")
+
+    assert response.status_code == 200
+    payload = response.json()
+    backends = {backend["id"]: backend for backend in payload["backends"]}
+    assert backends["tuneforge-fast"]["availability"] == "available"
+    assert backends["crema-advanced"]["availability"] == "unavailable"
+    assert backends["crema-advanced"]["unavailable_reason"] == "crema is not installed"
+    assert backends["crema-advanced"]["capabilities"]["supportsSevenths"] is True
+    assert backends["crema-advanced"]["desktopOnly"] is True
+
+
+def test_advanced_chords_request_fails_if_crema_missing(client, sample_chord_audio_file: Path, monkeypatch):
+    def fake_find_spec(module_name: str):
+        return None if module_name == "crema" else object()
+
+    monkeypatch.setattr("app.engines.crema_chords.importlib.util.find_spec", fake_find_spec)
+    project = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_chord_audio_file), "copy_into_project": True},
+    ).json()["project"]
+
+    response = client.post(
+        f"/api/v1/projects/{project['id']}/chords",
+        json={"backend": "crema-advanced", "force": True},
+    )
+
+    assert response.status_code == 409
+    payload = response.json()
+    assert payload["error"]["code"] == "ADVANCED_CHORD_BACKEND_UNAVAILABLE"
+    assert payload["error"]["message"] == "crema is not installed"
+
+
+def test_chord_benchmark_command_emits_json(sample_chord_audio_file: Path, capsys):
+    exit_code = benchmark_main(["--audio", str(sample_chord_audio_file), "--backend", "tuneforge-fast", "--json-only"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert payload["results"][0]["backend_id"] == "tuneforge-fast"
+    assert payload["results"][0]["available"] is True
+    assert payload["results"][0]["number_of_chord_segments"] >= 1

--- a/apps/backend/tests/test_chord_flow.py
+++ b/apps/backend/tests/test_chord_flow.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
+
+import pytest
 
 from app.db import SessionLocal
 from app.services.artifacts import register_artifact
+from app.services.chord_backends import ChordDetectionResult
 from app.services.chords import detect_project_chords
 from app.services.projects import get_project
 
@@ -36,7 +40,7 @@ def test_chord_job_persists_timeline(client, sample_chord_audio_file: Path):
 
     initial = client.get(f"/api/v1/projects/{project['id']}/chords").json()
     assert initial["project_id"] == project["id"]
-    assert initial["backend"] == "librosa"
+    assert initial["backend"] == "tuneforge-fast"
     assert len(initial["timeline"]) >= 3
     assert initial["source_segments"] == initial["timeline"]
     assert initial["has_user_edits"] is False
@@ -45,19 +49,21 @@ def test_chord_job_persists_timeline(client, sample_chord_audio_file: Path):
 
     job = client.post(
         f"/api/v1/projects/{project['id']}/chords",
-        json={"backend": "default", "force": True},
+        json={"backend": "default", "backend_fallback_from": "crema-advanced", "force": True},
     ).json()["job"]
     final_job = wait_for_job(client, job["id"])
     assert final_job["status"] == "completed"
+    assert final_job["chord_backend_fallback_from"] == "crema-advanced"
     assert final_job["runtime_device"] is None
     assert final_job["duration_seconds"] is not None
 
     chords = client.get(f"/api/v1/projects/{project['id']}/chords").json()
     assert chords["project_id"] == project["id"]
-    assert chords["backend"] == "librosa"
+    assert chords["backend"] == "tuneforge-fast"
     assert len(chords["timeline"]) >= 3
     assert len(chords["source_segments"]) >= 3
     assert chords["has_user_edits"] is False
+    assert chords["metadata"]["backend_fallback_from"] == "crema-advanced"
     assert all(segment["end_seconds"] > segment["start_seconds"] for segment in chords["timeline"])
     assert all(segment["pitch_class"] is not None for segment in chords["timeline"])
     supported_qualities = {"major", "minor", "7", "maj7", "m7", "sus2", "sus4", "dim", None}
@@ -72,11 +78,13 @@ def test_chord_job_persists_timeline(client, sample_chord_audio_file: Path):
     assert any(label == "F" for label in labels)
 
 
+@pytest.mark.parametrize("backend_id", ["tuneforge-fast", "crema-advanced"])
 def test_chord_refresh_uses_source_stems_only_for_augmentation(
     client,
     sample_chord_audio_file: Path,
     tmp_path: Path,
     monkeypatch,
+    backend_id: str,
 ):
     project = client.post(
         "/api/v1/projects/import",
@@ -128,20 +136,35 @@ def test_chord_refresh_uses_source_stems_only_for_augmentation(
         )
         session.commit()
 
-    def fake_detect_chord_timeline(path: Path) -> list[dict[str, Any]]:
-        if path == source_stem_path:
-            return [_segment("G", confidence=0.88, pitch_class=7, quality="major")]
-        if path == mix_stem_path:
-            return [_segment("F", confidence=0.95, pitch_class=5, quality="major")]
-        return [_segment("Em", confidence=0.35, pitch_class=4, quality="minor")]
+    def fake_resolve_chord_backend(requested_backend: str, *, require_available: bool = False):
+        del require_available
+        selected_backend_id = "crema-advanced" if requested_backend == "crema-advanced" else "tuneforge-fast"
+        return SimpleNamespace(
+            id=selected_backend_id,
+            label="Advanced Chords" if selected_backend_id == "crema-advanced" else "Built-in Chords",
+            capabilities=SimpleNamespace(),
+        )
 
-    monkeypatch.setattr("app.services.chords.detect_chord_timeline", fake_detect_chord_timeline)
+    def fake_detect_timeline(path: Path, selected_backend_id: str) -> ChordDetectionResult:
+        assert selected_backend_id == backend_id
+        if path == source_stem_path:
+            segments = [_segment("G", confidence=0.88, pitch_class=7, quality="major")]
+            return ChordDetectionResult(segments=segments, backend_id=selected_backend_id, metadata={})
+        if path == mix_stem_path:
+            segments = [_segment("F", confidence=0.95, pitch_class=5, quality="major")]
+            return ChordDetectionResult(segments=segments, backend_id=selected_backend_id, metadata={})
+        segments = [_segment("Em", confidence=0.35, pitch_class=4, quality="minor")]
+        return ChordDetectionResult(segments=segments, backend_id=selected_backend_id, metadata={})
+
+    monkeypatch.setattr("app.services.chords.resolve_chord_backend", fake_resolve_chord_backend)
+    monkeypatch.setattr("app.services.chords._detect_timeline", fake_detect_timeline)
 
     with SessionLocal() as session:
         project_model = get_project(session, project["id"])
-        chords = detect_project_chords(session, project_model, force=True)
+        chords = detect_project_chords(session, project_model, backend=backend_id, force=True)
         session.commit()
 
+    assert chords.backend == backend_id
     assert chords.source_artifact_id == source_artifact.id
     assert [segment["label"] for segment in chords.source_segments_json] == ["Em"]
     assert [segment["label"] for segment in chords.segments_json] == ["G"]
@@ -173,11 +196,13 @@ def test_chord_refresh_preserves_user_edits_without_overwrite(
 
     calls: list[Path] = []
 
-    def fake_detect_chord_timeline(path: Path) -> list[dict[str, Any]]:
+    def fake_detect_timeline(path: Path, backend_id: str) -> ChordDetectionResult:
+        assert backend_id == "tuneforge-fast"
         calls.append(path)
-        return [_segment("G", confidence=0.88, pitch_class=7, quality="major")]
+        segments = [_segment("G", confidence=0.88, pitch_class=7, quality="major")]
+        return ChordDetectionResult(segments=segments, backend_id=backend_id, metadata={})
 
-    monkeypatch.setattr("app.services.chords.detect_chord_timeline", fake_detect_chord_timeline)
+    monkeypatch.setattr("app.services.chords._detect_timeline", fake_detect_timeline)
 
     with SessionLocal() as session:
         project_model = get_project(session, project["id"])
@@ -186,6 +211,7 @@ def test_chord_refresh_preserves_user_edits_without_overwrite(
 
     assert calls == []
     assert chords.has_user_edits is True
+    assert chords.source_kind == "user-edited"
     assert chords.segments_json == [edited_segment]
 
     with SessionLocal() as session:

--- a/apps/backend/tests/test_projects.py
+++ b/apps/backend/tests/test_projects.py
@@ -50,6 +50,7 @@ def test_import_project_enqueues_analysis_and_chords(client, sample_chord_audio_
     assert wait_for_job(client, analyze_job["id"])["status"] == "completed"
     completed_chord_job = wait_for_job(client, chord_job["id"])
     assert completed_chord_job["status"] == "completed"
+    assert completed_chord_job["chord_backend"] == "tuneforge-fast"
     assert completed_chord_job["chord_source"] == "source"
 
     analysis = client.get(f"/api/v1/projects/{project['id']}/analysis").json()["analysis"]

--- a/apps/backend/tests/test_stem_flow.py
+++ b/apps/backend/tests/test_stem_flow.py
@@ -201,6 +201,7 @@ def test_source_stem_generation_enqueues_chord_refresh_job(
         if job["project_id"] == project["id"] and job["type"] == "chords" and job["id"] != initial_chord_job["id"]
     ]
     assert len(chord_refresh_jobs) == 1
+    assert chord_refresh_jobs[0]["chord_backend"] == "tuneforge-fast"
     assert chord_refresh_jobs[0]["chord_source"] == "source+stem"
     assert wait_for_job(client, chord_refresh_jobs[0]["id"])["status"] == "completed"
 

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -1,6 +1,20 @@
 version = 1
 revision = 3
 requires-python = "==3.11.*"
+resolution-markers = [
+    "sys_platform == 'win32'",
+    "sys_platform == 'emscripten'",
+    "sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "absl-py"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/c7/8de93764ad66968d19329a7e0c147a2bb3c7054c554d4a119111b8f9440f/absl_py-2.4.0.tar.gz", hash = "sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4", size = 116543, upload-time = "2026-01-28T10:17:05.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl", hash = "sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d", size = 135750, upload-time = "2026-01-28T10:17:04.19Z" },
+]
 
 [[package]]
 name = "alembic"
@@ -51,6 +65,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "astunparse"
+version = "1.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+    { name = "wheel" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/af/4182184d3c338792894f34a62672919db7ca008c89abee9b564dd34d8029/astunparse-1.6.3.tar.gz", hash = "sha256:5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872", size = 18290, upload-time = "2019-12-22T18:12:13.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/03/13dde6512ad7b4557eb792fbcf0c653af6076b81e5941d36ec61f7ce6028/astunparse-1.6.3-py2.py3-none-any.whl", hash = "sha256:c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8", size = 12732, upload-time = "2019-12-22T18:12:11.297Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
 ]
 
 [[package]]
@@ -151,11 +187,76 @@ wheels = [
 ]
 
 [[package]]
+name = "crema"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h5py" },
+    { name = "jams" },
+    { name = "keras" },
+    { name = "librosa" },
+    { name = "mir-eval" },
+    { name = "pumpp" },
+    { name = "scikit-learn" },
+    { name = "six" },
+    { name = "tensorflow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/7e/3ae5507a9b6762a0118509160477d34683223e6d8c0200fbf1912af0fbf3/crema-0.2.0.tar.gz", hash = "sha256:97680928e932f9ce198e785dc387826bef8a514abfb6b286f673f3f4d43d3b00", size = 5891996, upload-time = "2022-04-21T16:44:10.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/4a/6a7eeb9313680e7cc16324423816e563d0505029505da94342bfaeab1a1d/crema-0.2.0-py3-none-any.whl", hash = "sha256:b2787afd0367463438ca2b9b2944c490308eee1f307e5796078ec540a6281484", size = 5893392, upload-time = "2022-04-21T16:44:07.966Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "47.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/b2/7ffa7fe8207a8c42147ffe70c3e360b228160c1d85dc3faff16aaa3244c0/cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb", size = 830863, upload-time = "2026-04-24T19:54:57.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/98/40dfe932134bdcae4f6ab5927c87488754bf9eb79297d7e0070b78dd58e9/cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0", size = 7912214, upload-time = "2026-04-24T19:53:03.864Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c6/2733531243fba725f58611b918056b277692f1033373dcc8bd01af1c05d4/cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973", size = 4644617, upload-time = "2026-04-24T19:53:06.909Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e3/b27be1a670a9b87f855d211cf0e1174a5d721216b7616bd52d8581d912ed/cryptography-47.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8", size = 4668186, upload-time = "2026-04-24T19:53:09.053Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b9/8443cfe5d17d482d348cee7048acf502bb89a51b6382f06240fd290d4ca3/cryptography-47.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b", size = 4651244, upload-time = "2026-04-24T19:53:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/5e/13ed0cdd0eb88ba159d6dd5ebfece8cb901dbcf1ae5ac4072e28b55d3153/cryptography-47.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92", size = 5252906, upload-time = "2026-04-24T19:53:13.532Z" },
+    { url = "https://files.pythonhosted.org/packages/64/16/ed058e1df0f33d440217cd120d41d5dda9dd215a80b8187f68483185af82/cryptography-47.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7", size = 4701842, upload-time = "2026-04-24T19:53:15.618Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3d30986b30fdbd9e969abbdf8ba00ed0618615144341faeb57f395a084fe/cryptography-47.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93", size = 4289313, upload-time = "2026-04-24T19:53:17.755Z" },
+    { url = "https://files.pythonhosted.org/packages/df/fd/32db38e3ad0cb331f0691cb4c7a8a6f176f679124dee746b3af6633db4d9/cryptography-47.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac", size = 4650964, upload-time = "2026-04-24T19:53:20.062Z" },
+    { url = "https://files.pythonhosted.org/packages/86/53/5395d944dfd48cb1f67917f533c609c34347185ef15eb4308024c876f274/cryptography-47.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f", size = 5207817, upload-time = "2026-04-24T19:53:22.498Z" },
+    { url = "https://files.pythonhosted.org/packages/34/4f/e5711b28e1901f7d480a2b1b688b645aa4c77c73f10731ed17e7f7db3f0d/cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8", size = 4701544, upload-time = "2026-04-24T19:53:24.356Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/c8ddc25de3010fc8da447648f5a092c40e7a8fadf01dd6d255d9c0b9373d/cryptography-47.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318", size = 4783536, upload-time = "2026-04-24T19:53:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/66/b6/d4a68f4ea999c6d89e8498579cba1c5fcba4276284de7773b17e4fa69293/cryptography-47.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001", size = 4926106, upload-time = "2026-04-24T19:53:28.686Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ed/5f524db1fade9c013aa618e1c99c6ed05e8ffc9ceee6cda22fed22dda3f4/cryptography-47.0.0-cp311-abi3-win32.whl", hash = "sha256:7fda2f02c9015db3f42bb8a22324a454516ed10a8c29ca6ece6cdbb5efe2a203", size = 3258581, upload-time = "2026-04-24T19:53:31.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dc/1b901990b174786569029f67542b3edf72ac068b6c3c8683c17e6a2f5363/cryptography-47.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:f5c3296dab66202f1b18a91fa266be93d6aa0c2806ea3d67762c69f60adc71aa", size = 3775309, upload-time = "2026-04-24T19:53:33.054Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/34/a4fae8ae7c3bc227460c9ae43f56abf1b911da0ec29e0ebac53bb0a4b6b7/cryptography-47.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4", size = 7904072, upload-time = "2026-04-24T19:54:06.411Z" },
+    { url = "https://files.pythonhosted.org/packages/01/64/d7b1e54fdb69f22d24a64bb3e88dc718b31c7fb10ef0b9691a3cf7eeea6e/cryptography-47.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27", size = 4635767, upload-time = "2026-04-24T19:54:08.519Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/7b/cca826391fb2a94efdcdfe4631eb69306ee1cff0b22f664a412c90713877/cryptography-47.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10", size = 4654350, upload-time = "2026-04-24T19:54:10.795Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/65/4b57bcc823f42a991627c51c2f68c9fd6eb1393c1756aac876cba2accae2/cryptography-47.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b", size = 4643394, upload-time = "2026-04-24T19:54:13.275Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/2c5fbeea70adbbca2bbae865e1d605d6a4a7f8dbd9d33eaf69645087f06c/cryptography-47.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74", size = 5225777, upload-time = "2026-04-24T19:54:15.18Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/b8/ac57107ef32749d2b244e36069bb688792a363aaaa3acc9e3cf84c130315/cryptography-47.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515", size = 4688771, upload-time = "2026-04-24T19:54:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fc/9f1de22ff8be99d991f240a46863c52d475404c408886c5a38d2b5c3bb26/cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc", size = 4270753, upload-time = "2026-04-24T19:54:19.963Z" },
+    { url = "https://files.pythonhosted.org/packages/00/68/d70c852797aa68e8e48d12e5a87170c43f67bb4a59403627259dd57d15de/cryptography-47.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca", size = 4642911, upload-time = "2026-04-24T19:54:21.818Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/51/661cbee74f594c5d97ff82d34f10d5551c085ca4668645f4606ebd22bd5d/cryptography-47.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76", size = 5181411, upload-time = "2026-04-24T19:54:24.376Z" },
+    { url = "https://files.pythonhosted.org/packages/94/87/f2b6c374a82cf076cfa1416992ac8e8ec94d79facc37aec87c1a5cb72352/cryptography-47.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe", size = 4688262, upload-time = "2026-04-24T19:54:26.946Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e2/8b7462f4acf21ec509616f0245018bb197194ab0b65c2ea21a0bdd53c0eb/cryptography-47.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31", size = 4775506, upload-time = "2026-04-24T19:54:28.926Z" },
+    { url = "https://files.pythonhosted.org/packages/70/75/158e494e4c08dc05e039da5bb48553826bd26c23930cf8d3cd5f21fa8921/cryptography-47.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7", size = 4912060, upload-time = "2026-04-24T19:54:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bd/0a9d3edbf5eadbac926d7b9b3cd0c4be584eeeae4a003d24d9eda4affbbd/cryptography-47.0.0-cp38-abi3-win32.whl", hash = "sha256:ed67ea4e0cfb5faa5bc7ecb6e2b8838f3807a03758eec239d6c21c8769355310", size = 3248487, upload-time = "2026-04-24T19:54:33.494Z" },
+    { url = "https://files.pythonhosted.org/packages/60/80/5681af756d0da3a599b7bdb586fac5a1540f1bcefd2717a20e611ddade45/cryptography-47.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:835d2d7f47cdc53b3224e90810fb1d36ca94ea29cc1801fb4c1bc43876735769", size = 3755737, upload-time = "2026-04-24T19:54:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a0/928c9ce0d120a40a81aa99e3ba383e87337b9ac9ef9f6db02e4d7822424d/cryptography-47.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:7f1207974a904e005f762869996cf620e9bf79ecb4622f148550bb48e0eb35a7", size = 3909893, upload-time = "2026-04-24T19:54:38.334Z" },
+    { url = "https://files.pythonhosted.org/packages/81/75/d691e284750df5d9569f2b1ce4a00a71e1d79566da83b2b3e5549c84917f/cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:1a405c08857258c11016777e11c02bacbe7ef596faf259305d282272a3a05cbe", size = 4587867, upload-time = "2026-04-24T19:54:40.619Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d6/1b90f1a4e453009730b4545286f0b39bb348d805c11181fc31544e4f9a65/cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:20fdbe3e38fb67c385d233c89371fa27f9909f6ebca1cecc20c13518dae65475", size = 4627192, upload-time = "2026-04-24T19:54:42.849Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/53/cb358a80e9e359529f496870dd08c102aa8a4b5b9f9064f00f0d6ed5b527/cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:f7db373287273d8af1414cf95dc4118b13ffdc62be521997b0f2b270771fef50", size = 4587486, upload-time = "2026-04-24T19:54:44.908Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/57/aaa3d53876467a226f9a7a82fd14dd48058ad2de1948493442dfa16e2ffd/cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:9fe6b7c64926c765f9dff301f9c1b867febcda5768868ca084e18589113732ab", size = 4626327, upload-time = "2026-04-24T19:54:47.813Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/9c/51f28c3550276bcf35660703ba0ab829a90b88be8cd98a71ef23c2413913/cryptography-47.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:cffbba3392df0fa8629bb7f43454ee2925059ee158e23c54620b9063912b86c8", size = 3698916, upload-time = "2026-04-24T19:54:49.782Z" },
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/3a8241c6e19483ac1f1dcf5c10238205dcb8a6e9d0d4d4709240dff28ff4/cuda_bindings-13.2.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:721104c603f059780d287969be3d194a18d0cc3b713ed9049065a1107706759d", size = 5730273, upload-time = "2026-03-11T00:12:37.18Z" },
@@ -180,37 +281,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
 ]
 cufile = [
     { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -287,12 +388,67 @@ wheels = [
 ]
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
 name = "fsspec"
 version = "2026.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e1/cf/b50ddf667c15276a9ab15a70ef5f257564de271957933ffea49d2cdbcdfb/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41", size = 313547, upload-time = "2026-03-27T19:11:14.892Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4", size = 202595, upload-time = "2026-03-27T19:11:13.595Z" },
+]
+
+[[package]]
+name = "gast"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/f6/e73969782a2ecec280f8a176f2476149dd9dba69d5f8779ec6108a7721e6/gast-0.7.0.tar.gz", hash = "sha256:0bb14cd1b806722e91ddbab6fb86bba148c22b40e7ff11e248974e04c8adfdae", size = 33630, upload-time = "2025-11-29T15:30:05.266Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/33/f1c6a276de27b7d7339a34749cc33fa87f077f921969c47185d34a887ae2/gast-0.7.0-py3-none-any.whl", hash = "sha256:99cbf1365633a74099f69c59bd650476b96baa5ef196fec88032b00b31ba36f7", size = 22966, upload-time = "2025-11-29T15:30:03.983Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.49.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/fc/e925290a1ad95c975c459e2df070fac2b90954e13a0370ac505dff78cb99/google_auth-2.49.2.tar.gz", hash = "sha256:c1ae38500e73065dcae57355adb6278cf8b5c8e391994ae9cbadbcb9631ab409", size = 333958, upload-time = "2026-04-10T00:41:21.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl", hash = "sha256:c2720924dfc82dedb962c9f52cabb2ab16714fd0a6a707e40561d217574ed6d5", size = 240638, upload-time = "2026-04-10T00:41:14.501Z" },
+]
+
+[[package]]
+name = "google-auth-oauthlib"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "requests-oauthlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/82/62482931dcbe5266a2680d0da17096f2aab983ecb320277d9556700ce00e/google_auth_oauthlib-1.3.1.tar.gz", hash = "sha256:14c22c7b3dd3d06dbe44264144409039465effdd1eef94f7ce3710e486cc4bfa", size = 21663, upload-time = "2026-03-30T22:49:56.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/e0/cb454a95f460903e39f101e950038ec24a072ca69d0a294a6df625cc1627/google_auth_oauthlib-1.3.1-py3-none-any.whl", hash = "sha256:1a139ef23f1318756805b0e95f655c238bffd29655329a2978218248da4ee7f8", size = 19247, upload-time = "2026-03-30T20:02:23.894Z" },
+]
+
+[[package]]
+name = "google-pasta"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/4a/0bd53b36ff0323d10d5f24ebd67af2de10a1117f5cf4d7add90df92756f1/google-pasta-0.2.0.tar.gz", hash = "sha256:c9f2c8dfc8f96d0d5808299920721be30c9eec37f2389f28904f454565c8a16e", size = 40430, upload-time = "2020-03-13T18:57:50.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/de/c648ef6835192e6e2cc03f40b19eeda4382c49b5bafb43d88b931c4c74ac/google_pasta-0.2.0-py3-none-any.whl", hash = "sha256:b32482794a366b5366a32c92a9a9201b107821889935a02b3e51f6b432ea84ed", size = 57471, upload-time = "2020-03-13T18:57:48.872Z" },
 ]
 
 [[package]]
@@ -312,12 +468,52 @@ wheels = [
 ]
 
 [[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/db/1d56e5f5823257b291962d6c0ce106146c6447f405b60b234c4f222a7cde/grpcio-1.80.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:dfab85db094068ff42e2a3563f60ab3dddcc9d6488a35abf0132daec13209c8a", size = 6055009, upload-time = "2026-03-30T08:46:46.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/18/c83f3cad64c5ca63bca7e91e5e46b0d026afc5af9d0a9972472ceba294b3/grpcio-1.80.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5c07e82e822e1161354e32da2662f741a4944ea955f9f580ec8fb409dd6f6060", size = 12035295, upload-time = "2026-03-30T08:46:49.099Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8e/e14966b435be2dda99fbe89db9525ea436edc79780431a1c2875a3582644/grpcio-1.80.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba0915d51fd4ced2db5ff719f84e270afe0e2d4c45a7bdb1e8d036e4502928c2", size = 6610297, upload-time = "2026-03-30T08:46:52.123Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/26/d5eb38f42ce0e3fdc8174ea4d52036ef8d58cc4426cb800f2610f625dd75/grpcio-1.80.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3cb8130ba457d2aa09fa6b7c3ed6b6e4e6a2685fce63cb803d479576c4d80e21", size = 7300208, upload-time = "2026-03-30T08:46:54.859Z" },
+    { url = "https://files.pythonhosted.org/packages/25/51/bd267c989f85a17a5b3eea65a6feb4ff672af41ca614e5a0279cc0ea381c/grpcio-1.80.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09e5e478b3d14afd23f12e49e8b44c8684ac3c5f08561c43a5b9691c54d136ab", size = 6813442, upload-time = "2026-03-30T08:46:57.056Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d9/d80eef735b19e9169e30164bbf889b46f9df9127598a83d174eb13a48b26/grpcio-1.80.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:00168469238b022500e486c1c33916acf2f2a9b2c022202cf8a1885d2e3073c1", size = 7414743, upload-time = "2026-03-30T08:46:59.682Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f2/567f5bd5054398ed6b0509b9a30900376dcf2786bd936812098808b49d8d/grpcio-1.80.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8502122a3cc1714038e39a0b071acb1207ca7844208d5ea0d091317555ee7106", size = 8426046, upload-time = "2026-03-30T08:47:02.474Z" },
+    { url = "https://files.pythonhosted.org/packages/62/29/73ef0141b4732ff5eacd68430ff2512a65c004696997f70476a83e548e7e/grpcio-1.80.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ce1794f4ea6cc3ca29463f42d665c32ba1b964b48958a66497917fe9069f26e6", size = 7851641, upload-time = "2026-03-30T08:47:05.462Z" },
+    { url = "https://files.pythonhosted.org/packages/46/69/abbfa360eb229a8623bab5f5a4f8105e445bd38ce81a89514ba55d281ad0/grpcio-1.80.0-cp311-cp311-win32.whl", hash = "sha256:51b4a7189b0bef2aa30adce3c78f09c83526cf3dddb24c6a96555e3b97340440", size = 4154368, upload-time = "2026-03-30T08:47:08.027Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d4/ae92206d01183b08613e846076115f5ac5991bae358d2a749fa864da5699/grpcio-1.80.0-cp311-cp311-win_amd64.whl", hash = "sha256:02e64bb0bb2da14d947a49e6f120a75e947250aebe65f9629b62bb1f5c14e6e9", size = 4894235, upload-time = "2026-03-30T08:47:10.839Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h5py"
+version = "3.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/33/acd0ce6863b6c0d7735007df01815403f5589a21ff8c2e1ee2587a38f548/h5py-3.16.0.tar.gz", hash = "sha256:a0dbaad796840ccaa67a4c144a0d0c8080073c34c76d5a6941d6818678ef2738", size = 446526, upload-time = "2026-03-06T13:49:08.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/95/a825894f3e45cbac7554c4e97314ce886b233a20033787eda755ca8fecc7/h5py-3.16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:719439d14b83f74eeb080e9650a6c7aa6d0d9ea0ca7f804347b05fac6fbf18af", size = 3721663, upload-time = "2026-03-06T13:47:49.599Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3b/38ff88b347c3e346cda1d3fc1b65a7aa75d40632228d8b8a5d7b58508c24/h5py-3.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c3f0a0e136f2e95dd0b67146abb6668af4f1a69c81ef8651a2d316e8e01de447", size = 3087630, upload-time = "2026-03-06T13:47:51.249Z" },
+    { url = "https://files.pythonhosted.org/packages/98/a8/2594cef906aee761601eff842c7dc598bea2b394a3e1c00966832b8eeb7c/h5py-3.16.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:a6fbc5367d4046801f9b7db9191b31895f22f1c6df1f9987d667854cac493538", size = 4823472, upload-time = "2026-03-06T13:47:53.085Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a0/c1f604538ff6db22a0690be2dc44ab59178e115f63c917794e529356ab23/h5py-3.16.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:fb1720028d99040792bb2fb31facb8da44a6f29df7697e0b84f0d79aff2e9bd3", size = 5027150, upload-time = "2026-03-06T13:47:55.043Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fd/301739083c2fc4fd89950f9bcfce75d6e14b40b0ca3d40e48a8993d1722c/h5py-3.16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:314b6054fe0b1051c2b0cb2df5cbdab15622fb05e80f202e3b6a5eee0d6fe365", size = 4814544, upload-time = "2026-03-06T13:47:56.893Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/42/2193ed41ccee78baba8fcc0cff2c925b8b9ee3793305b23e1f22c20bf4c7/h5py-3.16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ffbab2fedd6581f6aa31cf1639ca2cb86e02779de525667892ebf4cc9fd26434", size = 5034013, upload-time = "2026-03-06T13:47:59.01Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/20/e6c0ff62ca2ad1a396a34f4380bafccaaf8791ff8fccf3d995a1fc12d417/h5py-3.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:17d1f1630f92ad74494a9a7392ab25982ce2b469fc62da6074c0ce48366a2999", size = 3191673, upload-time = "2026-03-06T13:48:00.626Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/48/239cbe352ac4f2b8243a8e620fa1a2034635f633731493a7ff1ed71e8658/h5py-3.16.0-cp311-cp311-win_arm64.whl", hash = "sha256:85b9c49dd58dc44cf70af944784e2c2038b6f799665d0dcbbc812a26e0faa859", size = 2673834, upload-time = "2026-03-06T13:48:02.579Z" },
 ]
 
 [[package]]
@@ -367,6 +563,24 @@ wheels = [
 ]
 
 [[package]]
+name = "jams"
+version = "0.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "decorator" },
+    { name = "jsonschema" },
+    { name = "mir-eval" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "six" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/91/1df6b53375bd1f45821cbce864ab451a869c2714756dd852085e10373878/jams-0.3.5.tar.gz", hash = "sha256:260b1922f0fac0b30d82f750e0b1d240905070db4e500b52efa8f3202409d0fe", size = 72767, upload-time = "2025-06-18T15:14:06.09Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/a8/79e80fef627eedf196c7e4efe758306eae46b1bc2b8411b8992c6d600eb4/jams-0.3.5-py3-none-any.whl", hash = "sha256:b9f17ff2d95deb125e13001a50bafe338b68a9bf0c6df217f5b0f9e153041d0d", size = 67291, upload-time = "2025-06-18T15:14:04.768Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -388,6 +602,33 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
 name = "julius"
 version = "0.2.7"
 source = { registry = "https://pypi.org/simple" }
@@ -395,6 +636,15 @@ dependencies = [
     { name = "torch" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/19/c9e1596b5572c786b93428d0904280e964c930fae7e6c9368ed9e1b63922/julius-0.2.7.tar.gz", hash = "sha256:3c0f5f5306d7d6016fcc95196b274cae6f07e2c9596eed314e4e7641554fbb08", size = 59640, upload-time = "2022-09-19T16:13:34.2Z" }
+
+[[package]]
+name = "keras"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/03/80072f4ee46e3c77e95b06d684fadf90a67759e4e9f1d86a563e0965c71a/keras-2.15.0.tar.gz", hash = "sha256:81871d298c064dc4ac6b58440fdae67bfcf47c8d7ad28580fab401834c06a575", size = 1252015, upload-time = "2023-11-07T00:39:57.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/a7/0d4490de967a67f68a538cc9cdb259bff971c4b5787f7765dc7c8f118f71/keras-2.15.0-py3-none-any.whl", hash = "sha256:2dcc6d2e30cf9c951064b63c1f4c404b966c59caf09e01f3549138ec8ee0dd1f", size = 1710438, upload-time = "2023-11-07T00:39:55.57Z" },
+]
 
 [[package]]
 name = "lameenc"
@@ -424,6 +674,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/49/ac/21a1f8aa3777f5658576777ea76bfb124b702c520bbe90edf4ae9915eafa/lazy_loader-0.5.tar.gz", hash = "sha256:717f9179a0dbed357012ddad50a5ad3d5e4d9a0b8712680d4e687f5e6e6ed9b3", size = 15294, upload-time = "2026-03-06T15:45:09.054Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl", hash = "sha256:ab0ea149e9c554d4ffeeb21105ac60bed7f3b4fd69b1d2360a4add51b170b005", size = 8044, upload-time = "2026-03-06T15:45:07.668Z" },
+]
+
+[[package]]
+name = "libclang"
+version = "18.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/5c/ca35e19a4f142adffa27e3d652196b7362fa612243e2b916845d801454fc/libclang-18.1.1.tar.gz", hash = "sha256:a1214966d08d73d971287fc3ead8dfaf82eb07fb197680d8b3859dbbbbf78250", size = 39612, upload-time = "2024-03-17T16:04:37.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/49/f5e3e7e1419872b69f6f5e82ba56e33955a74bd537d8a1f5f1eff2f3668a/libclang-18.1.1-1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:0b2e143f0fac830156feb56f9231ff8338c20aecfe72b4ffe96f19e5a1dbb69a", size = 25836045, upload-time = "2024-06-30T17:40:31.646Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e5/fc61bbded91a8830ccce94c5294ecd6e88e496cc85f6704bf350c0634b70/libclang-18.1.1-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:6f14c3f194704e5d09769108f03185fce7acaf1d1ae4bbb2f30a72c2400cb7c5", size = 26502641, upload-time = "2024-03-18T15:52:26.722Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ed/1df62b44db2583375f6a8a5e2ca5432bbdc3edb477942b9b7c848c720055/libclang-18.1.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:83ce5045d101b669ac38e6da8e58765f12da2d3aafb3b9b98d88b286a60964d8", size = 26420207, upload-time = "2024-03-17T15:00:26.63Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/fc/716c1e62e512ef1c160e7984a73a5fc7df45166f2ff3f254e71c58076f7c/libclang-18.1.1-py2.py3-none-manylinux2010_x86_64.whl", hash = "sha256:c533091d8a3bbf7460a00cb6c1a71da93bffe148f172c7d03b1c31fbf8aa2a0b", size = 24515943, upload-time = "2024-03-17T16:03:45.942Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/3d/f0ac1150280d8d20d059608cf2d5ff61b7c3b7f7bcf9c0f425ab92df769a/libclang-18.1.1-py2.py3-none-manylinux2014_aarch64.whl", hash = "sha256:54dda940a4a0491a9d1532bf071ea3ef26e6dbaf03b5000ed94dd7174e8f9592", size = 23784972, upload-time = "2024-03-17T16:12:47.677Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/2f/d920822c2b1ce9326a4c78c0c2b4aa3fde610c7ee9f631b600acb5376c26/libclang-18.1.1-py2.py3-none-manylinux2014_armv7l.whl", hash = "sha256:cf4a99b05376513717ab5d82a0db832c56ccea4fd61a69dbb7bccf2dfb207dbe", size = 20259606, upload-time = "2024-03-17T16:17:42.437Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c2/de1db8c6d413597076a4259cea409b83459b2db997c003578affdd32bf66/libclang-18.1.1-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:69f8eb8f65c279e765ffd28aaa7e9e364c776c17618af8bff22a8df58677ff4f", size = 24921494, upload-time = "2024-03-17T16:14:20.132Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2d/3f480b1e1d31eb3d6de5e3ef641954e5c67430d5ac93b7fa7e07589576c7/libclang-18.1.1-py2.py3-none-win_amd64.whl", hash = "sha256:4dd2d3b82fab35e2bf9ca717d7b63ac990a3519c7e312f19fa8e86dcc712f7fb", size = 26415083, upload-time = "2024-03-17T16:42:21.703Z" },
+    { url = "https://files.pythonhosted.org/packages/71/cf/e01dc4cc79779cd82d77888a88ae2fa424d93b445ad4f6c02bfc18335b70/libclang-18.1.1-py2.py3-none-win_arm64.whl", hash = "sha256:3f0e1f49f04d3cd198985fea0511576b0aee16f9ff0e0f0cad7f9c57ec3c20e8", size = 22361112, upload-time = "2024-03-17T16:42:59.565Z" },
 ]
 
 [[package]]
@@ -496,6 +763,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -512,6 +788,35 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
     { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
     { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+]
+
+[[package]]
+name = "mir-eval"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "decorator" },
+    { name = "numpy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/db/3bf39fc9ab0fb757f297f9a0da7207e823688291f9e61bb67b44fa17bc2f/mir_eval-0.8.2.tar.gz", hash = "sha256:141a3e1193276889fc32e911547e73dcb3e829ee8cfea60f7bbcd633c0792569", size = 117649, upload-time = "2025-02-25T18:09:57.505Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/5a/69ce896a32ebc8c75deae00b1fba9837567405fa6ef37b377f2e85b856ae/mir_eval-0.8.2-py3-none-any.whl", hash = "sha256:114cda33d8e17408c170598e0b36ed0d71ff4a2fee8eaf9e165b58ecf1c87170", size = 102794, upload-time = "2025-02-25T18:09:56.012Z" },
+]
+
+[[package]]
+name = "ml-dtypes"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/7d/8d85fcba868758b3a546e6914e727abd8f29ea6918079f816975c9eecd63/ml_dtypes-0.3.2.tar.gz", hash = "sha256:533059bc5f1764fac071ef54598db358c167c51a718f68f5bb55e3dee79d2967", size = 692014, upload-time = "2024-01-03T19:21:23.615Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/a4/6aabb78f1569550fd77c74d2c1d008b502c8ce72776bd88b14ea6c182c9e/ml_dtypes-0.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:763697ab8a88d47443997a7cdf3aac7340049aed45f7521f6b0ec8a0594821fe", size = 389791, upload-time = "2024-01-03T19:21:02.844Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/ed/211bf2e1c66e4ec9b712c3be848a876185c7f0d5e94bf647b60e64ef32eb/ml_dtypes-0.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b89b194e9501a92d289c1ffd411380baf5daafb9818109a4f49b0a1b6dce4462", size = 2185796, upload-time = "2024-01-03T19:21:04.291Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a0/d4ee9e3aca5b9101c590b58555820618e8201c2ccb7004eabb417ec046ac/ml_dtypes-0.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c34f2ba9660b21fe1034b608308a01be82bbef2a92fb8199f24dc6bad0d5226", size = 2164071, upload-time = "2024-01-03T19:21:05.78Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/db/1784b87285588788170f87e987bfb4bda218d62a70a81ebb66c94e7f9b95/ml_dtypes-0.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:6604877d567a29bfe7cc02969ae0f2425260e5335505cf5e7fefc3e5465f5655", size = 127681, upload-time = "2024-01-03T19:21:07.337Z" },
 ]
 
 [[package]]
@@ -607,28 +912,18 @@ wheels = [
 
 [[package]]
 name = "numpy"
-version = "2.4.4"
+version = "1.26.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010", size = 15786129, upload-time = "2024-02-06T00:26:44.495Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/c6/4218570d8c8ecc9704b5157a3348e486e84ef4be0ed3e38218ab473c83d2/numpy-2.4.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f983334aea213c99992053ede6168500e5f086ce74fbc4acc3f2b00f5762e9db", size = 16976799, upload-time = "2026-03-29T13:18:15.438Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/92/b4d922c4a5f5dab9ed44e6153908a5c665b71acf183a83b93b690996e39b/numpy-2.4.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:72944b19f2324114e9dc86a159787333b77874143efcf89a5167ef83cfee8af0", size = 14971552, upload-time = "2026-03-29T13:18:18.606Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/dc/df98c095978fa6ee7b9a9387d1d58cbb3d232d0e69ad169a4ce784bde4fd/numpy-2.4.4-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:86b6f55f5a352b48d7fbfd2dbc3d5b780b2d79f4d3c121f33eb6efb22e9a2015", size = 5476566, upload-time = "2026-03-29T13:18:21.532Z" },
-    { url = "https://files.pythonhosted.org/packages/28/34/b3fdcec6e725409223dd27356bdf5a3c2cc2282e428218ecc9cb7acc9763/numpy-2.4.4-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:ba1f4fc670ed79f876f70082eff4f9583c15fb9a4b89d6188412de4d18ae2f40", size = 6806482, upload-time = "2026-03-29T13:18:23.634Z" },
-    { url = "https://files.pythonhosted.org/packages/68/62/63417c13aa35d57bee1337c67446761dc25ea6543130cf868eace6e8157b/numpy-2.4.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a87ec22c87be071b6bdbd27920b129b94f2fc964358ce38f3822635a3e2e03d", size = 15973376, upload-time = "2026-03-29T13:18:26.677Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/c5/9fcb7e0e69cef59cf10c746b84f7d58b08bc66a6b7d459783c5a4f6101a6/numpy-2.4.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df3775294accfdd75f32c74ae39fcba920c9a378a2fc18a12b6820aa8c1fb502", size = 16925137, upload-time = "2026-03-29T13:18:30.14Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/43/80020edacb3f84b9efdd1591120a4296462c23fd8db0dde1666f6ef66f13/numpy-2.4.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0d4e437e295f18ec29bc79daf55e8a47a9113df44d66f702f02a293d93a2d6dd", size = 17329414, upload-time = "2026-03-29T13:18:33.733Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/06/af0658593b18a5f73532d377188b964f239eb0894e664a6c12f484472f97/numpy-2.4.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6aa3236c78803afbcb255045fbef97a9e25a1f6c9888357d205ddc42f4d6eba5", size = 18658397, upload-time = "2026-03-29T13:18:37.511Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/ce/13a09ed65f5d0ce5c7dd0669250374c6e379910f97af2c08c57b0608eee4/numpy-2.4.4-cp311-cp311-win32.whl", hash = "sha256:30caa73029a225b2d40d9fae193e008e24b2026b7ee1a867b7ee8d96ca1a448e", size = 6239499, upload-time = "2026-03-29T13:18:40.372Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/63/05d193dbb4b5eec1eca73822d80da98b511f8328ad4ae3ca4caf0f4db91d/numpy-2.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:6bbe4eb67390b0a0265a2c25458f6b90a409d5d069f1041e6aff1e27e3d9a79e", size = 12614257, upload-time = "2026-03-29T13:18:42.95Z" },
-    { url = "https://files.pythonhosted.org/packages/87/c5/8168052f080c26fa984c413305012be54741c9d0d74abd7fbeeccae3889f/numpy-2.4.4-cp311-cp311-win_arm64.whl", hash = "sha256:fcfe2045fd2e8f3cb0ce9d4ba6dba6333b8fa05bb8a4939c908cd43322d14c7e", size = 10486775, upload-time = "2026-03-29T13:18:45.835Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/33/8fae8f964a4f63ed528264ddf25d2b683d0b663e3cba26961eb838a7c1bd/numpy-2.4.4-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:58c8b5929fcb8287cbd6f0a3fae19c6e03a5c48402ae792962ac465224a629a4", size = 16854491, upload-time = "2026-03-29T13:21:38.03Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/d0/1aabee441380b981cf8cdda3ae7a46aa827d1b5a8cce84d14598bc94d6d9/numpy-2.4.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:eea7ac5d2dce4189771cedb559c738a71512768210dc4e4753b107a2048b3d0e", size = 14895830, upload-time = "2026-03-29T13:21:41.509Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/b8/aafb0d1065416894fccf4df6b49ef22b8db045187949545bced89c034b8e/numpy-2.4.4-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:51fc224f7ca4d92656d5a5eb315f12eb5fe2c97a66249aa7b5f562528a3be38c", size = 5400927, upload-time = "2026-03-29T13:21:44.747Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/77/063baa20b08b431038c7f9ff5435540c7b7265c78cf56012a483019ca72d/numpy-2.4.4-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:28a650663f7314afc3e6ec620f44f333c386aad9f6fc472030865dc0ebb26ee3", size = 6715557, upload-time = "2026-03-29T13:21:47.406Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/a8/379542d45a14f149444c5c4c4e7714707239ce9cc1de8c2803958889da14/numpy-2.4.4-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19710a9ca9992d7174e9c52f643d4272dcd1558c5f7af7f6f8190f633bd651a7", size = 15804253, upload-time = "2026-03-29T13:21:50.753Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/c8/f0a45426d6d21e7ea3310a15cf90c43a14d9232c31a837702dba437f3373/numpy-2.4.4-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b2aec6af35c113b05695ebb5749a787acd63cafc83086a05771d1e1cd1e555f", size = 16753552, upload-time = "2026-03-29T13:21:54.344Z" },
-    { url = "https://files.pythonhosted.org/packages/04/74/f4c001f4714c3ad9ce037e18cf2b9c64871a84951eaa0baf683a9ca9301c/numpy-2.4.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f2cf083b324a467e1ab358c105f6cad5ea950f50524668a80c486ff1db24e119", size = 12509075, upload-time = "2026-03-29T13:21:57.644Z" },
+    { url = "https://files.pythonhosted.org/packages/11/57/baae43d14fe163fa0e4c47f307b6b2511ab8d7d30177c491960504252053/numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71", size = 20630554, upload-time = "2024-02-05T23:51:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/2e/151484f49fd03944c4a3ad9c418ed193cfd02724e138ac8a9505d056c582/numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef", size = 13997127, upload-time = "2024-02-05T23:52:15.314Z" },
+    { url = "https://files.pythonhosted.org/packages/79/ae/7e5b85136806f9dadf4878bf73cf223fe5c2636818ba3ab1c585d0403164/numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e", size = 14222994, upload-time = "2024-02-05T23:52:47.569Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/d0/edc009c27b406c4f9cbc79274d6e46d634d139075492ad055e3d68445925/numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5", size = 18252005, upload-time = "2024-02-05T23:53:15.637Z" },
+    { url = "https://files.pythonhosted.org/packages/09/bf/2b1aaf8f525f2923ff6cfcf134ae5e750e279ac65ebf386c75a0cf6da06a/numpy-1.26.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a", size = 13885297, upload-time = "2024-02-05T23:53:42.16Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a0/4e0f14d847cfc2a633a1c8621d00724f3206cfeddeb66d35698c4e2cf3d2/numpy-1.26.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a", size = 18093567, upload-time = "2024-02-05T23:54:11.696Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b7/a734c733286e10a7f1a8ad1ae8c90f2d33bf604a96548e0a4a3a6739b468/numpy-1.26.4-cp311-cp311-win32.whl", hash = "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20", size = 5968812, upload-time = "2024-02-05T23:54:26.453Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/6b/5610004206cf7f8e7ad91c5a85a8c71b2f2f8051a0c0c4d5916b76d6cbb2/numpy-1.26.4-cp311-cp311-win_amd64.whl", hash = "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2", size = 15811913, upload-time = "2024-02-05T23:54:53.933Z" },
 ]
 
 [[package]]
@@ -672,7 +967,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
@@ -684,7 +979,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -714,9 +1009,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -728,7 +1023,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -781,6 +1076,15 @@ wheels = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
 name = "omegaconf"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -824,12 +1128,42 @@ wheels = [
 ]
 
 [[package]]
+name = "opt-einsum"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/b9/2ac072041e899a52f20cf9510850ff58295003aa75525e58343591b0cbfb/opt_einsum-3.4.0.tar.gz", hash = "sha256:96ca72f1b886d148241348783498194c577fa30a8faac108586b14f1ba4473ac", size = 63004, upload-time = "2024-09-26T14:33:24.483Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl", hash = "sha256:69bb92469f86a1565195ece4ac0323943e83477171b91d24c35afe028a90d7cd", size = 71932, upload-time = "2024-09-26T14:33:23.039Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/35/6411db530c618e0e0005187e35aa02ce60ae4c4c4d206964a2f978217c27/pandas-3.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a727a73cbdba2f7458dc82449e2315899d5140b449015d822f515749a46cbbe0", size = 10326926, upload-time = "2026-03-31T06:46:08.29Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/d3/b7da1d5d7dbdc5ef52ed7debd2b484313b832982266905315dad5a0bf0b1/pandas-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dbbd4aa20ca51e63b53bbde6a0fa4254b1aaabb74d2f542df7a7959feb1d760c", size = 9926987, upload-time = "2026-03-31T06:46:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/52/77/9b1c2d6070b5dbe239a7bc889e21bfa58720793fb902d1e070695d87c6d0/pandas-3.0.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:339dda302bd8369dedeae979cb750e484d549b563c3f54f3922cb8ff4978c5eb", size = 10757067, upload-time = "2026-03-31T06:46:14.903Z" },
+    { url = "https://files.pythonhosted.org/packages/20/17/ec40d981705654853726e7ac9aea9ddbb4a5d9cf54d8472222f4f3de06c2/pandas-3.0.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:61c2fd96d72b983a9891b2598f286befd4ad262161a609c92dc1652544b46b76", size = 11258787, upload-time = "2026-03-31T06:46:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/90/e3/3f1126d43d3702ca8773871a81c9f15122a1f412342cc56284ffda5b1f70/pandas-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c934008c733b8bbea273ea308b73b3156f0181e5b72960790b09c18a2794fe1e", size = 11771616, upload-time = "2026-03-31T06:46:20.532Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/cf/0f4e268e1f5062e44a6bda9f925806721cd4c95c2b808a4c82ebe914f96b/pandas-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:60a80bb4feacbef5e1447a3f82c33209c8b7e07f28d805cfd1fb951e5cb443aa", size = 12337623, upload-time = "2026-03-31T06:46:23.754Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/97a6339859d4acb2536efb24feb6708e82f7d33b2ed7e036f2983fcced82/pandas-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:ed72cb3f45190874eb579c64fa92d9df74e98fd63e2be7f62bce5ace0ade61df", size = 9897372, upload-time = "2026-03-31T06:46:26.703Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/eb/781516b808a99ddf288143cec46b342b3016c3414d137da1fdc3290d8860/pandas-3.0.2-cp311-cp311-win_arm64.whl", hash = "sha256:f12b1a9e332c01e09510586f8ca9b108fd631fd656af82e452d7315ef6df5f9f", size = 9154922, upload-time = "2026-03-31T06:46:30.284Z" },
 ]
 
 [[package]]
@@ -871,6 +1205,56 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/43/85ef45e8b36c6a48546af7b266592dc32d7f67837a6514d111bced6d7d75/pooch-1.9.0.tar.gz", hash = "sha256:de46729579b9857ffd3e741987a2f6d5e0e03219892c167c6578c0091fb511ed", size = 61788, upload-time = "2026-01-30T19:15:09.649Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/2d/d4bf65e47cea8ff2c794a600c4fd1273a7902f268757c531e0ee9f18aa58/pooch-1.9.0-py3-none-any.whl", hash = "sha256:f265597baa9f760d25ceb29d0beb8186c243d6607b0f60b83ecf14078dbc703b", size = 67175, upload-time = "2026-01-30T19:15:08.36Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "4.25.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/8e/d08c41a8c004e1d437ef467e7c4f9c3295cd784eba48ed5d1d01f94b1dad/protobuf-4.25.9.tar.gz", hash = "sha256:b0dc7e7c68de8b1ce831dacb12fb407e838edbb8b6cc0dc3a2a6b4cbf6de9cff", size = 381040, upload-time = "2026-03-25T23:09:36.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/e9/59435bd04bdd46cb38c42a336b22f9843e8e586ff83c35a5423f8b14704e/protobuf-4.25.9-cp310-abi3-win32.whl", hash = "sha256:bde396f568b0b46fc8fbfe9f02facf25b6755b2578a3b8ac61e74b9d69499e03", size = 392879, upload-time = "2026-03-25T23:09:21.32Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/16/42a5c7f1001783d2b5bfcecde10127f09010f78982c86ae409122ce3ece6/protobuf-4.25.9-cp310-abi3-win_amd64.whl", hash = "sha256:3683c05154252206f7cb2d371626514b3708199d9bcf683b503dabf3a2e38e06", size = 413900, upload-time = "2026-03-25T23:09:23.589Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5b/0074a0a9eb01f3d1c4648ca5e81b22090c811b210b61df9018ac6d6c5cda/protobuf-4.25.9-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:9560813560e6ee72c11ca8873878bdb7ee003c96a57ebb013245fe84e2540904", size = 394826, upload-time = "2026-03-25T23:09:25.194Z" },
+    { url = "https://files.pythonhosted.org/packages/54/aa/b2dba856f64c36b2a06c67be1472de98cca07a2322d0f0cbf03279a40e5b/protobuf-4.25.9-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:999146ef02e7fa6a692477badd1528bcd7268df211852a3df2d834ba2b480791", size = 294191, upload-time = "2026-03-25T23:09:26.613Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5c/53f18822017b8bda6bd8bb4e02048e911fdc79a3dafdc83ab994fe922a84/protobuf-4.25.9-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:438c636de8fb706a0de94a12a268ef1ae8f5ba5ae655a7671fcda5968ba3c9be", size = 295178, upload-time = "2026-03-25T23:09:27.839Z" },
+    { url = "https://files.pythonhosted.org/packages/16/28/d5065b212685875d3924bcdb3201cbf467cb4d58a18aa19a8dfd99ea80a9/protobuf-4.25.9-py3-none-any.whl", hash = "sha256:d49b615e7c935194ac161f0965699ac84df6112c378e05ec53da65d2e4cbb6d4", size = 156822, upload-time = "2026-03-25T23:09:34.957Z" },
+]
+
+[[package]]
+name = "pumpp"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jams" },
+    { name = "librosa" },
+    { name = "mir-eval" },
+    { name = "scikit-learn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/f8/87684d69b15e46c62e38546cc63a8dc9968fbf71b779b694b423051ed98b/pumpp-0.6.0.tar.gz", hash = "sha256:dd78bd2e239d35f23bfa16d11417a909ca71dd9591446bead67bd02e39c87892", size = 35258, upload-time = "2022-04-14T19:12:28.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/a8/6361605db773aab683fae0824ef567f469143d51926edfd39aff3cd98298/pumpp-0.6.0-py3-none-any.whl", hash = "sha256:e2b3a896e2ff586656b970141e35af17f3a406ac954c251b9b92ee9e7e5aee23", size = 48307, upload-time = "2022-04-14T19:12:26.883Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -961,6 +1345,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -975,6 +1371,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
     { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
     { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
 ]
 
 [[package]]
@@ -1017,12 +1427,60 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
 name = "retrying"
 version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c8/5a/b17e1e257d3e6f2e7758930e1256832c9ddd576f8631781e6a072914befa/retrying-1.4.2.tar.gz", hash = "sha256:d102e75d53d8d30b88562d45361d6c6c934da06fab31bd81c0420acb97a8ba39", size = 11411, upload-time = "2025-08-03T03:35:25.189Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/67/f3/6cd296376653270ac1b423bb30bd70942d9916b6978c6f40472d6ac038e7/retrying-1.4.2-py3-none-any.whl", hash = "sha256:bbc004aeb542a74f3569aeddf42a2516efefcdaff90df0eb38fbfbf19f179f59", size = 10859, upload-time = "2025-08-03T03:35:23.829Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
+    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
+    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
 ]
 
 [[package]]
@@ -1052,7 +1510,7 @@ wheels = [
 
 [[package]]
 name = "scikit-learn"
-version = "1.8.0"
+version = "1.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
@@ -1060,14 +1518,13 @@ dependencies = [
     { name = "scipy" },
     { name = "threadpoolctl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/59/44985a2bdc95c74e34fef3d10cb5d93ce13b0e2a7baefffe1b53853b502d/scikit_learn-1.5.2.tar.gz", hash = "sha256:b4237ed7b3fdd0a4882792e68ef2545d5baa50aca3bb45aa7df468138ad8f94d", size = 7001680, upload-time = "2024-09-11T15:50:10.957Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/92/53ea2181da8ac6bf27170191028aee7251f8f841f8d3edbfdcaf2008fde9/scikit_learn-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:146b4d36f800c013d267b29168813f7a03a43ecd2895d04861f1240b564421da", size = 8595835, upload-time = "2025-12-10T07:07:39.385Z" },
-    { url = "https://files.pythonhosted.org/packages/01/18/d154dc1638803adf987910cdd07097d9c526663a55666a97c124d09fb96a/scikit_learn-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f984ca4b14914e6b4094c5d52a32ea16b49832c03bd17a110f004db3c223e8e1", size = 8080381, upload-time = "2025-12-10T07:07:41.93Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/44/226142fcb7b7101e64fdee5f49dbe6288d4c7af8abf593237b70fca080a4/scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e30adb87f0cc81c7690a84f7932dd66be5bac57cfe16b91cb9151683a4a2d3b", size = 8799632, upload-time = "2025-12-10T07:07:43.899Z" },
-    { url = "https://files.pythonhosted.org/packages/36/4d/4a67f30778a45d542bbea5db2dbfa1e9e100bf9ba64aefe34215ba9f11f6/scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ada8121bcb4dac28d930febc791a69f7cb1673c8495e5eee274190b73a4559c1", size = 9103788, upload-time = "2025-12-10T07:07:45.982Z" },
-    { url = "https://files.pythonhosted.org/packages/89/3c/45c352094cfa60050bcbb967b1faf246b22e93cb459f2f907b600f2ceda5/scikit_learn-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:c57b1b610bd1f40ba43970e11ce62821c2e6569e4d74023db19c6b26f246cb3b", size = 8081706, upload-time = "2025-12-10T07:07:48.111Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/46/5416595bb395757f754feb20c3d776553a386b661658fb21b7c814e89efe/scikit_learn-1.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:2838551e011a64e3053ad7618dda9310175f7515f1742fa2d756f7c874c05961", size = 7688451, upload-time = "2025-12-10T07:07:49.873Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/91/609961972f694cb9520c4c3d201e377a26583e1eb83bc5a334c893729214/scikit_learn-1.5.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:03b6158efa3faaf1feea3faa884c840ebd61b6484167c711548fce208ea09445", size = 12088580, upload-time = "2024-09-11T15:49:33.55Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7a/19fe32c810c5ceddafcfda16276d98df299c8649e24e84d4f00df4a91e01/scikit_learn-1.5.2-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:1ff45e26928d3b4eb767a8f14a9a6efbf1cbff7c05d1fb0f95f211a89fd4f5de", size = 10975994, upload-time = "2024-09-11T15:49:35.728Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/75/62e49f8a62bf3c60b0e64d0fce540578ee4f0e752765beb2e1dc7c6d6098/scikit_learn-1.5.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f763897fe92d0e903aa4847b0aec0e68cadfff77e8a0687cabd946c89d17e675", size = 12465782, upload-time = "2024-09-11T15:49:38.596Z" },
+    { url = "https://files.pythonhosted.org/packages/49/21/3723de321531c9745e40f1badafd821e029d346155b6c79704e0b7197552/scikit_learn-1.5.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8b0ccd4a902836493e026c03256e8b206656f91fbcc4fde28c57a5b752561f1", size = 13322034, upload-time = "2024-09-11T15:49:41.452Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1c/ccdd103cfcc9435a18819856fbbe0c20b8fa60bfc3343580de4be13f0668/scikit_learn-1.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:6c16d84a0d45e4894832b3c4d0bf73050939e21b99b01b6fd59cbb0cf39163b6", size = 11015224, upload-time = "2024-09-11T15:49:43.692Z" },
 ]
 
 [[package]]
@@ -1093,11 +1550,29 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "81.0.0"
+version = "80.10.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/95/faf61eb8363f26aa7e1d762267a8d602a1b26d4f3a1e758e92cb3cb8b054/setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70", size = 1200343, upload-time = "2026-01-25T22:38:17.252Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173", size = 1064234, upload-time = "2026-01-25T22:38:15.216Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]
@@ -1196,6 +1671,102 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tensorboard"
+version = "2.15.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "google-auth" },
+    { name = "google-auth-oauthlib" },
+    { name = "grpcio" },
+    { name = "markdown" },
+    { name = "numpy" },
+    { name = "protobuf" },
+    { name = "requests" },
+    { name = "setuptools" },
+    { name = "six" },
+    { name = "tensorboard-data-server" },
+    { name = "werkzeug" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/12/f6e9b9dcc310263cbd3948274e286538bd6800fd0c268850788f14a0c6d0/tensorboard-2.15.2-py3-none-any.whl", hash = "sha256:a6f6443728064d962caea6d34653e220e34ef8df764cb06a8212c17e1a8f0622", size = 5539713, upload-time = "2024-02-09T10:39:25.636Z" },
+]
+
+[[package]]
+name = "tensorboard-data-server"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/13/e503968fefabd4c6b2650af21e110aa8466fe21432cd7c43a84577a89438/tensorboard_data_server-0.7.2-py3-none-any.whl", hash = "sha256:7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb", size = 2356, upload-time = "2023-10-23T21:23:32.16Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/85/dabeaf902892922777492e1d253bb7e1264cadce3cea932f7ff599e53fea/tensorboard_data_server-0.7.2-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:9fe5d24221b29625dbc7328b0436ca7fc1c23de4acf4d272f1180856e32f9f60", size = 4823598, upload-time = "2023-10-23T21:23:33.714Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c6/825dab04195756cf8ff2e12698f22513b3db2f64925bdd41671bfb33aaa5/tensorboard_data_server-0.7.2-py3-none-manylinux_2_31_x86_64.whl", hash = "sha256:ef687163c24185ae9754ed5650eb5bc4d84ff257aabdc33f0cc6f74d8ba54530", size = 6590363, upload-time = "2023-10-23T21:23:35.583Z" },
+]
+
+[[package]]
+name = "tensorflow"
+version = "2.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "astunparse" },
+    { name = "flatbuffers" },
+    { name = "gast" },
+    { name = "google-pasta" },
+    { name = "grpcio" },
+    { name = "h5py" },
+    { name = "keras" },
+    { name = "libclang" },
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "opt-einsum" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "setuptools" },
+    { name = "six" },
+    { name = "tensorboard" },
+    { name = "tensorflow-estimator" },
+    { name = "tensorflow-io-gcs-filesystem" },
+    { name = "termcolor" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/72/2ede9c4b9b96650a8a7b909abf4733adf110c5907425ee252f8095385b11/tensorflow-2.15.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:6761efe511e6ee0f893f60738fefbcc51d6dc386eeaaafea59d21899ef369ffd", size = 236482723, upload-time = "2024-03-08T23:51:59.848Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/3191cd83da2f213a3c4af5e40597a98996e9c84b56666f9595dad8a6e780/tensorflow-2.15.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:aa926114d1e13ffe5b2ea59c3f195216f26646d7fe36e9e5207b291e4b7902ff", size = 205736374, upload-time = "2024-03-08T23:50:44.289Z" },
+    { url = "https://files.pythonhosted.org/packages/81/40/31b27ab3f46de305475ef5160acc8a2addb8fa9ea2179777c4e9bcc5baaf/tensorflow-2.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e73d43dbc68d8c711e70edecc4ac70472799a25ec4ec18a84d479ee18033d3c5", size = 2121, upload-time = "2024-03-08T23:56:06.384Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/2d/636471492d93b6c1bf5375b81be7105a313a8c91a07c37e43625b00ca5c3/tensorflow-2.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb0edd69103c154245c5f209f0507355cc68ba7e4de350084bc31edc562478e4", size = 475258663, upload-time = "2024-03-08T23:47:37.697Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c5/f5b31ee348459d6f6c54d762488aa0a8e42ff11a7395f4d158915ad43000/tensorflow-2.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:a49f8755c74a89553294a99ab25aa87ab1cddbfa40fe58387e09f64f0578cedc", size = 2096, upload-time = "2024-03-08T23:53:45.889Z" },
+]
+
+[[package]]
+name = "tensorflow-estimator"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/c8/2f823c8958d5342eafc6dd3e922f0cc4fcf8c2e0460284cc462dae3b60a0/tensorflow_estimator-2.15.0-py2.py3-none-any.whl", hash = "sha256:aedf21eec7fb2dc91150fc91a1ce12bc44dbb72278a08b58e79ff87c9e28f153", size = 441974, upload-time = "2023-11-07T01:10:10.812Z" },
+]
+
+[[package]]
+name = "tensorflow-io-gcs-filesystem"
+version = "0.37.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/9b/b2fb82d0da673b17a334f785fc19c23483165019ddc33b275ef25ca31173/tensorflow_io_gcs_filesystem-0.37.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:32c50ab4e29a23c1f91cd0f9ab8c381a0ab10f45ef5c5252e94965916041737c", size = 2470224, upload-time = "2024-07-01T23:44:23.039Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/cc/16634e76f3647fbec18187258da3ba11184a6232dcf9073dc44579076d36/tensorflow_io_gcs_filesystem-0.37.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:b02f9c5f94fd62773954a04f69b68c4d576d076fd0db4ca25d5479f0fbfcdbad", size = 3479613, upload-time = "2024-07-01T23:44:24.399Z" },
+    { url = "https://files.pythonhosted.org/packages/de/bf/ba597d3884c77d05a78050f3c178933d69e3f80200a261df6eaa920656cd/tensorflow_io_gcs_filesystem-0.37.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e1f2796b57e799a8ca1b75bf47c2aaa437c968408cc1a402a9862929e104cda", size = 4842079, upload-time = "2024-07-01T23:44:26.825Z" },
+    { url = "https://files.pythonhosted.org/packages/66/7f/e36ae148c2f03d61ca1bff24bc13a0fef6d6825c966abef73fc6f880a23b/tensorflow_io_gcs_filesystem-0.37.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ee7c8ee5fe2fd8cb6392669ef16e71841133041fee8a330eff519ad9b36e4556", size = 5085736, upload-time = "2024-07-01T23:44:28.618Z" },
+]
+
+[[package]]
+name = "termcolor"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
 ]
 
 [[package]]
@@ -1311,6 +1882,15 @@ dependencies = [
     { name = "uvicorn" },
 ]
 
+[package.optional-dependencies]
+advanced-chords = [
+    { name = "crema" },
+    { name = "keras" },
+    { name = "scikit-learn" },
+    { name = "setuptools" },
+    { name = "tensorflow" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "httpx" },
@@ -1322,16 +1902,22 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.14.1,<2.0.0" },
+    { name = "crema", marker = "extra == 'advanced-chords'", specifier = ">=0.2.0,<0.3.0" },
     { name = "demucs", specifier = ">=4.0.1,<5.0.0" },
     { name = "fastapi", specifier = ">=0.115.12,<1.0.0" },
+    { name = "keras", marker = "extra == 'advanced-chords'", specifier = ">=2.15,<2.16" },
     { name = "librosa", specifier = ">=0.10.2.post1,<1.0.0" },
     { name = "numpy", specifier = ">=1.26.4,<3.0.0" },
     { name = "openai-whisper", specifier = ">=20250625,<20260000" },
     { name = "pydantic", specifier = ">=2.11.3,<3.0.0" },
+    { name = "scikit-learn", marker = "extra == 'advanced-chords'", specifier = ">=1.3,<1.6" },
+    { name = "setuptools", marker = "extra == 'advanced-chords'", specifier = "<81" },
     { name = "soundfile", specifier = ">=0.13.1,<1.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.40,<3.0.0" },
+    { name = "tensorflow", marker = "extra == 'advanced-chords'", specifier = ">=2.15,<2.16" },
     { name = "uvicorn", specifier = ">=0.34.2,<1.0.0" },
 ]
+provides-extras = ["advanced-chords"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1363,6 +1949,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1382,4 +1977,44 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/da/6eee1ff8b6cbeed47eeb5229749168e81eb4b7b999a1a15a7176e51410c9/uvicorn-0.44.0.tar.gz", hash = "sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e", size = 86947, upload-time = "2026-04-06T09:23:22.826Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl", hash = "sha256:ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89", size = 69425, upload-time = "2026-04-06T09:23:21.524Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
+name = "wheel"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/62/75f18a0f03b4219c456652c7780e4d749b929eb605c098ce3a5b6b6bc081/wheel-0.47.0.tar.gz", hash = "sha256:cc72bd1009ba0cf63922e28f94d9d83b920aa2bb28f798a31d0691b02fa3c9b3", size = 63854, upload-time = "2026-04-22T15:51:27.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/1b/9e33c09813d65e248f7f773119148a612516a4bea93e9c6f545f78455b7c/wheel-0.47.0-py3-none-any.whl", hash = "sha256:212281cab4dff978f6cedd499cd893e1f620791ca6ff7107cf270781e587eced", size = 32218, upload-time = "2026-04-22T15:51:26.296Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "1.14.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/49/925324e2eaa0c83c45b7a1eb31004af4ad7b37fdc1d9e897ea7d551215da/wrapt-1.14.2.tar.gz", hash = "sha256:19d33781d891c99b5a35f810656d2fe01765b35ccfb6d395007d2edb1058d98f", size = 50701, upload-time = "2025-08-12T06:59:02.334Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/ea/7ab441022d98da4cd4ff6d2ec6cbd8e4bf69085f261bdf72971a43bd8a45/wrapt-1.14.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3913516545546d3ff82ffe5bb4a7eab29dc7f1c71cf7329a1494659dc2a60b7b", size = 35832, upload-time = "2025-08-12T06:58:22.674Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/26/953f79a4233603958234358820434d973bd859d3831b19fde23078e09771/wrapt-1.14.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:122015da6e0a1d09e1f9fbb8c756b9a8802e6cb01138f5256c121602bc7c7399", size = 77384, upload-time = "2025-08-12T06:58:41.195Z" },
+    { url = "https://files.pythonhosted.org/packages/53/7f/4057df32059ea4782cf34b7a9dc08c6b29c4e29ecccfa58b32a12eb77582/wrapt-1.14.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:257a53f69737f340d0ba6e4d5554b56a579ca884de6eada15a7126baae8dacc0", size = 78135, upload-time = "2025-08-12T06:58:31.259Z" },
+    { url = "https://files.pythonhosted.org/packages/37/80/d688dfde8c9d75b41c6f01a71e6f64a77861b6ad67e04d622d78060d638c/wrapt-1.14.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e60ca4aa80a85a0bc24cdf0f971d736f6d0957bdbc93874339027cfb0f286c99", size = 76933, upload-time = "2025-08-12T06:58:32.586Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b0/2b5f8b11c463f75acb6ca710a2ac2e40549f6b5d68bc85c135fc49a7ef19/wrapt-1.14.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f23bfecdc0e139f15b195ca3601e71a1388dc058bdbbd160ba9d0f4a17b4a12d", size = 76873, upload-time = "2025-08-12T06:58:42.64Z" },
+    { url = "https://files.pythonhosted.org/packages/28/d4/003f22d726ca8a0bc2170cad7651dad732f3d3a6e4f69d1f13d8244a93e9/wrapt-1.14.2-cp311-cp311-win32.whl", hash = "sha256:cb5aee915d67441bd07acbce9e4cab1d01a110b4e5f02932e80e5ef4c9411ae2", size = 33675, upload-time = "2025-08-12T06:58:54.885Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/61/8eb200c6cf899fedc677a7a01b2f189ad58f1d154d0ef84dab30800b9f01/wrapt-1.14.2-cp311-cp311-win_amd64.whl", hash = "sha256:e9773691347205f7d11e7c4395561633285c8d1d691ebfc73ffd64f9072aa22e", size = 35811, upload-time = "2025-08-12T06:58:53.921Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c7/7376998449689cf2adbdbeacad47084410d00f3ae04cf73e6127cf52b950/wrapt-1.14.2-py3-none-any.whl", hash = "sha256:82eea3b559f51f22aefc530b747b87406811ef00cb0c4734f48cb139c748db63", size = 21577, upload-time = "2025-08-12T06:59:01.408Z" },
 ]

--- a/apps/desktop/src-tauri/src/mobile_backend.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend.rs
@@ -86,6 +86,9 @@ pub struct JobSchema {
     status: String,
     progress: i64,
     source_artifact_id: Option<String>,
+    chord_backend: Option<String>,
+    chord_backend_fallback_from: Option<String>,
+    chord_source: Option<String>,
     error_message: Option<String>,
     runtime_device: Option<String>,
     started_at: Option<String>,
@@ -119,10 +122,15 @@ pub struct AnalysisResponse {
 #[serde(rename_all = "snake_case")]
 pub struct ChordResponse {
     project_id: String,
+    source_segments: Vec<Value>,
     timeline: Vec<Value>,
     backend: Option<String>,
     source_artifact_id: Option<String>,
+    has_user_edits: bool,
+    source_kind: String,
+    metadata: Value,
     created_at: Option<String>,
+    updated_at: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -368,6 +376,9 @@ mod android {
             status: row.get(3)?,
             progress: row.get(4)?,
             source_artifact_id: row.get(5)?,
+            chord_backend: None,
+            chord_backend_fallback_from: None,
+            chord_source: None,
             error_message: row.get(6)?,
             runtime_device: row.get(7)?,
             started_at: row.get(8)?,
@@ -407,6 +418,9 @@ mod android {
             status: "failed".to_string(),
             progress: 0,
             source_artifact_id: None,
+            chord_backend: None,
+            chord_backend_fallback_from: None,
+            chord_source: None,
             error_message: Some(message.to_string()),
             runtime_device: None,
             started_at: Some(timestamp.clone()),
@@ -720,10 +734,15 @@ mod android {
         let _ = get_project_schema(&connection, &project_id)?;
         Ok(ChordResponse {
             project_id,
+            source_segments: Vec::new(),
             timeline: Vec::new(),
             backend: None,
             source_artifact_id: None,
+            has_user_edits: false,
+            source_kind: "generated".to_string(),
+            metadata: serde_json::json!({}),
             created_at: None,
+            updated_at: None,
         })
     }
 

--- a/apps/desktop/src/App.project-analysis-mix.test.tsx
+++ b/apps/desktop/src/App.project-analysis-mix.test.tsx
@@ -10,9 +10,11 @@ import {
   mockCreateChords,
   mockCreateLyrics,
   mockCreatePreview,
+  mockCreateStems,
   mockUpdateLyrics,
   mockUpdateProject,
   renderApp,
+  setChordBackends,
   setProjectAnalysis,
   setProjectChords,
   setProjectLyrics,
@@ -85,10 +87,84 @@ describe("Desktop app project analysis mix", () => {
     await user.click(screen.getByRole("button", { name: "Refresh Chords" }));
 
     expect(mockCreateChords).toHaveBeenCalledWith("proj_123", {
-      backend: "default",
+      backend: "tuneforge-fast",
       force: true,
       overwrite_user_edits: false,
     });
+  });
+
+  it("uses the selected default chord backend for chord and stem jobs", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({ defaultChordBackend: "crema-advanced", defaultSourcesRailCollapsed: false }),
+    );
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Refresh Chords" }));
+    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+
+    expect(mockCreateChords).toHaveBeenCalledWith("proj_123", {
+      backend: "crema-advanced",
+      force: true,
+      overwrite_user_edits: false,
+    });
+    expect(mockCreateStems).toHaveBeenCalledWith(
+      "proj_123",
+      expect.objectContaining({ chord_backend: "crema-advanced" }),
+    );
+  });
+
+  it("falls back to built-in chords when the saved advanced backend is unavailable", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({ defaultChordBackend: "crema-advanced", defaultSourcesRailCollapsed: false }),
+    );
+    setChordBackends([
+      {
+        availability: "available",
+        available: true,
+        capabilities: {},
+        desktopOnly: false,
+        experimental: false,
+        id: "tuneforge-fast",
+        label: "Built-in Chords",
+        unavailable_reason: null,
+      },
+      {
+        availability: "unavailable",
+        available: false,
+        capabilities: {},
+        desktopOnly: true,
+        experimental: true,
+        id: "crema-advanced",
+        label: "Advanced Chords",
+        unavailable_reason: "crema is not installed",
+      },
+    ]);
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Refresh Chords" }));
+    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+
+    expect(mockCreateChords).toHaveBeenCalledWith("proj_123", {
+      backend: "tuneforge-fast",
+      backend_fallback_from: "crema-advanced",
+      force: true,
+      overwrite_user_edits: false,
+    });
+    expect(mockCreateStems).toHaveBeenCalledWith(
+      "proj_123",
+      expect.objectContaining({
+        chord_backend: "tuneforge-fast",
+        chord_backend_fallback_from: "crema-advanced",
+      }),
+    );
   });
 
   it("generates lyrics when transcript is empty", async () => {

--- a/apps/desktop/src/App.settings-theme.test.tsx
+++ b/apps/desktop/src/App.settings-theme.test.tsx
@@ -11,6 +11,7 @@ import {
   mockSave,
   queryByAriaKeyLabel,
   renderApp,
+  setChordBackends,
   setProjectAnalysis,
   setProjectChords,
 } from "./test/appTestHarness";
@@ -93,6 +94,7 @@ describe("Desktop app settings theme", () => {
     expect(screen.getByRole("button", { name: /^Collapse sources rail by default/ })).toHaveAttribute("aria-pressed", "false");
     expect(screen.getByRole("button", { name: /^Project first/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^AutoUse lyrics \+ chords/ })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: /^Built-in Chords/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^Enable lyrics follow by default/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^Enable chords follow by default/ })).toHaveAttribute("aria-pressed", "true");
     expect(window.localStorage.getItem("tuneforge.theme-preference")).toBe("system");
@@ -103,6 +105,7 @@ describe("Desktop app settings theme", () => {
       defaultSourcesRailCollapsed: false,
       defaultProjectWorkspace: "project",
       defaultPlaybackDisplayMode: "auto",
+      defaultChordBackend: "tuneforge-fast",
       defaultLyricsFollowEnabled: true,
       defaultChordsFollowEnabled: true,
     });
@@ -121,6 +124,7 @@ describe("Desktop app settings theme", () => {
     await user.click(screen.getByRole("button", { name: /^Collapse sources rail by default/ }));
     await user.click(screen.getByRole("button", { name: /^Playback first/ }));
     await user.click(screen.getByRole("button", { name: /^Lyrics \+ chords/ }));
+    await user.click(screen.getByRole("button", { name: /^Advanced Chords/ }));
     await user.click(screen.getByText("Show diagnostics"));
     expect(await screen.findByText("/tmp/tuneforge")).toBeInTheDocument();
 
@@ -136,6 +140,7 @@ describe("Desktop app settings theme", () => {
         defaultSourcesRailCollapsed: true,
         defaultProjectWorkspace: "playback",
         defaultPlaybackDisplayMode: "combined",
+        defaultChordBackend: "crema-advanced",
         defaultLyricsFollowEnabled: true,
         defaultChordsFollowEnabled: true,
       }),
@@ -166,6 +171,38 @@ describe("Desktop app settings theme", () => {
     });
   });
 
+  it("shows unavailable advanced chord backend without allowing selection", async () => {
+    setChordBackends([
+      {
+        availability: "available",
+        available: true,
+        capabilities: {},
+        desktopOnly: false,
+        experimental: false,
+        id: "tuneforge-fast",
+        label: "Built-in Chords",
+        unavailable_reason: null,
+      },
+      {
+        availability: "unavailable",
+        available: false,
+        capabilities: {},
+        desktopOnly: true,
+        experimental: true,
+        id: "crema-advanced",
+        label: "Advanced Chords",
+        unavailable_reason: "crema is not installed",
+      },
+    ]);
+
+    renderApp(["/settings"]);
+
+    expect(await screen.findByRole("heading", { name: "Control Room" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Built-in Chords/ })).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: /^Advanced Chords/ })).toBeDisabled();
+    expect(await screen.findByText("crema is not installed")).toBeInTheDocument();
+  });
+
   it("resets appearance, visibility, and all settings independently", async () => {
     const user = userEvent.setup();
     renderApp(["/settings"]);
@@ -175,6 +212,7 @@ describe("Desktop app settings theme", () => {
     await user.click(screen.getByRole("button", { name: /^Light/ }));
     await user.click(screen.getByRole("button", { name: /^Detailed/ }));
     await user.click(screen.getByRole("button", { name: /^Prefer sharps/ }));
+    await user.click(screen.getByRole("button", { name: /^Advanced Chords/ }));
     await user.click(screen.getByRole("button", { name: /^Open inspector by default/ }));
     await user.click(screen.getByRole("button", { name: /^Collapse sources rail by default/ }));
 
@@ -188,6 +226,9 @@ describe("Desktop app settings theme", () => {
     await user.click(screen.getByRole("button", { name: "Reset Notation" }));
     expect(screen.getByRole("button", { name: /^Auto by key/ })).toHaveAttribute("aria-pressed", "true");
 
+    await user.click(screen.getByRole("button", { name: "Reset Analysis Defaults" }));
+    expect(screen.getByRole("button", { name: /^Built-in Chords/ })).toHaveAttribute("aria-pressed", "true");
+
     await user.click(screen.getByRole("button", { name: "Reset Playback Defaults" }));
     expect(screen.getByRole("button", { name: /^Open inspector by default/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^Collapse sources rail by default/ })).toHaveAttribute("aria-pressed", "false");
@@ -198,6 +239,7 @@ describe("Desktop app settings theme", () => {
 
     await user.click(screen.getByRole("button", { name: /^Dark/ }));
     await user.click(screen.getByRole("button", { name: /^Dual labels/ }));
+    await user.click(screen.getByRole("button", { name: /^Advanced Chords/ }));
     await user.click(screen.getByRole("button", { name: /^Open inspector by default/ }));
     await user.click(screen.getByRole("button", { name: "Reset All Settings" }));
 
@@ -208,6 +250,7 @@ describe("Desktop app settings theme", () => {
     expect(screen.getByRole("button", { name: /^Collapse sources rail by default/ })).toHaveAttribute("aria-pressed", "false");
     expect(screen.getByRole("button", { name: /^Project first/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^AutoUse lyrics \+ chords/ })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: /^Built-in Chords/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^Enable lyrics follow by default/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^Enable chords follow by default/ })).toHaveAttribute("aria-pressed", "true");
   });
@@ -325,6 +368,7 @@ describe("Desktop app settings theme", () => {
     await user.click(screen.getByRole("button", { name: /Collapse sources rail by default/i }));
     await user.click(screen.getByRole("button", { name: /^Playback first/i }));
     await user.click(screen.getByRole("button", { name: /^Lyrics \+ chords/i }));
+    await user.click(screen.getByRole("button", { name: /^Advanced Chords/i }));
     await user.click(screen.getByRole("link", { name: "Open Theme Studio" }));
 
     expect(await screen.findByRole("heading", { name: "Metal / Heat Studio" })).toBeInTheDocument();
@@ -364,6 +408,7 @@ describe("Desktop app settings theme", () => {
     expect(screen.getByText("Collapsed")).toBeInTheDocument();
     expect(screen.getAllByText("Playback first").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Lyrics + chords").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Advanced Chords").length).toBeGreaterThan(0);
     expect(document.documentElement.style.getPropertyValue("--color-bg-app")).toBe("#123456");
   });
 });

--- a/apps/desktop/src/components/MusicalLabel.tsx
+++ b/apps/desktop/src/components/MusicalLabel.tsx
@@ -71,6 +71,7 @@ export function MusicalKeyLabel({
 
 export function MusicalChordLabel({
   activeKey,
+  bassPitchClass,
   fallbackLabel,
   mode,
   pitchClass,
@@ -78,6 +79,7 @@ export function MusicalChordLabel({
   variant,
 }: {
   activeKey?: MusicalKey | null;
+  bassPitchClass?: number | null;
   fallbackLabel: string;
   mode: EnharmonicDisplayMode;
   pitchClass?: number | null;
@@ -87,7 +89,7 @@ export function MusicalChordLabel({
   const isSupportedChord = typeof pitchClass === "number" && isSupportedChordQuality(quality);
   const options: PitchFormatOptions = { activeKey: activeKey ?? null, mode };
   const label = isSupportedChord
-    ? formatChordDisplay(pitchClass, quality, options)
+    ? formatChordDisplay(pitchClass, quality, options, bassPitchClass)
     : formatRawMusicalLabel(fallbackLabel);
 
   return <RenderMusicalLabel label={label} variant={variant} />;

--- a/apps/desktop/src/features/projects/components/PlaybackPracticeSurface.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackPracticeSurface.tsx
@@ -327,6 +327,7 @@ function ChordsPracticePanel() {
                 activeKey={activeEnharmonicKeyContext}
                 fallbackLabel={currentChord.label ?? "-"}
                 mode={enharmonicDisplayMode}
+                bassPitchClass={currentChord.bass_pitch_class}
                 pitchClass={currentChord.pitch_class}
                 quality={currentChord.quality}
                 variant="chord-card"
@@ -344,6 +345,7 @@ function ChordsPracticePanel() {
                 activeKey={activeEnharmonicKeyContext}
                 fallbackLabel={nextChord.label ?? "-"}
                 mode={enharmonicDisplayMode}
+                bassPitchClass={nextChord.bass_pitch_class}
                 pitchClass={nextChord.pitch_class}
                 quality={nextChord.quality}
                 variant="chord-card"
@@ -393,6 +395,7 @@ function ChordsPracticePanel() {
                     activeKey={activeEnharmonicKeyContext}
                     fallbackLabel={segment.label}
                     mode={enharmonicDisplayMode}
+                    bassPitchClass={segment.bass_pitch_class}
                     pitchClass={segment.pitch_class}
                     quality={segment.quality}
                     variant="chord-chip"
@@ -616,6 +619,7 @@ function LeadSheetChordButton({ chord }: { chord: LeadSheetChord }) {
         activeKey={activeEnharmonicKeyContext}
         fallbackLabel={chord.segment.label}
         mode={enharmonicDisplayMode}
+        bassPitchClass={chord.segment.bass_pitch_class}
         pitchClass={chord.segment.pitch_class}
         quality={chord.segment.quality}
         variant="chord-chip"

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
 import { confirm, save } from "@tauri-apps/plugin-dialog";
-import { api, type ArtifactSchema, type ProjectSchema } from "../../../lib/api";
+import { api, type ArtifactSchema, type ChordBackendsResponse, type ProjectSchema } from "../../../lib/api";
 import { usePreferences } from "../../../lib/preferences";
 import { usePlayback } from "../playback-context";
 import {
@@ -49,9 +49,13 @@ import {
   type SourceKeyOption,
   type TargetShiftOption,
 } from "../projectViewUtils";
-import type { DefaultPlaybackDisplayMode, PlaybackDisplayMode } from "../../../lib/preferences";
+import type { DefaultChordBackend, DefaultPlaybackDisplayMode, PlaybackDisplayMode } from "../../../lib/preferences";
 
 type PlaybackDisplayModeSource = "default" | "stored" | "user";
+type ChordBackendActionSelection = {
+  backend: DefaultChordBackend;
+  backend_fallback_from?: DefaultChordBackend;
+};
 
 function resolveDefaultPlaybackDisplayMode(
   defaultMode: DefaultPlaybackDisplayMode,
@@ -96,6 +100,7 @@ export function useProjectViewModel() {
     defaultLyricsFollowEnabled,
     defaultProjectWorkspace,
     defaultSourcesRailCollapsed,
+    defaultChordBackend,
     enharmonicDisplayMode,
     informationDensity,
   } = usePreferences();
@@ -173,6 +178,10 @@ export function useProjectViewModel() {
     queryKey: ["jobs"],
     queryFn: async () => (await api.listJobs()).jobs,
   });
+  const chordBackendsQuery = useQuery({
+    queryKey: ["chord-backends"],
+    queryFn: api.listChordBackends,
+  });
   const mobileCapabilitiesQuery = useQuery({
     queryKey: ["mobile-capabilities"],
     queryFn: async () => api.getMobileCapabilities(),
@@ -180,6 +189,33 @@ export function useProjectViewModel() {
   });
 
   useActiveJobPolling(projectId, jobsQuery.data);
+
+  async function chordBackendForAction(): Promise<ChordBackendActionSelection> {
+    if (defaultChordBackend === "tuneforge-fast") {
+      return { backend: "tuneforge-fast" };
+    }
+
+    let backendResponse: ChordBackendsResponse | undefined = chordBackendsQuery.data;
+    if (!backendResponse) {
+      try {
+        backendResponse = await queryClient.fetchQuery({
+          queryKey: ["chord-backends"],
+          queryFn: api.listChordBackends,
+        });
+      } catch {
+        return { backend: "tuneforge-fast", backend_fallback_from: defaultChordBackend };
+      }
+    }
+    if (!backendResponse) {
+      return { backend: "tuneforge-fast", backend_fallback_from: defaultChordBackend };
+    }
+
+    const selectedBackend = backendResponse.backends.find((backend) => backend.id === defaultChordBackend);
+    if (selectedBackend?.available) {
+      return { backend: defaultChordBackend };
+    }
+    return { backend: "tuneforge-fast", backend_fallback_from: defaultChordBackend };
+  }
 
   const analyzeMutation = useMutation({
     mutationFn: () => api.analyzeProject(projectId),
@@ -239,12 +275,14 @@ export function useProjectViewModel() {
   });
 
   const chordMutation = useMutation({
-    mutationFn: async (overwriteUserEdits: boolean) =>
-      api.createChords(projectId, {
-        backend: "default",
+    mutationFn: async (overwriteUserEdits: boolean) => {
+      const backendSelection = await chordBackendForAction();
+      return api.createChords(projectId, {
+        ...backendSelection,
         force: (chordsQuery.data?.timeline?.length ?? 0) > 0,
         overwrite_user_edits: overwriteUserEdits,
-      }),
+      });
+    },
     onSuccess: async () => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ["jobs"] }),
@@ -312,9 +350,12 @@ export function useProjectViewModel() {
       if (!selectedPrimaryArtifactId) {
         throw new Error("Select source audio or practice mix first.");
       }
+      const backendSelection = await chordBackendForAction();
       return api.createStems(projectId, {
         mode: "two_stem",
         output_format: "wav",
+        chord_backend: backendSelection.backend,
+        chord_backend_fallback_from: backendSelection.backend_fallback_from,
         force: hasVisibleStems,
         source_artifact_id: selectedPrimaryArtifactId,
         overwrite_chord_edits: overwriteChordEdits,

--- a/apps/desktop/src/features/projects/projectViewUtils.test.ts
+++ b/apps/desktop/src/features/projects/projectViewUtils.test.ts
@@ -99,11 +99,13 @@ describe("buildLeadSheetRows", () => {
 describe("transposeChordSegment", () => {
   it("transposes supported chord extensions", () => {
     const segment: ChordSegmentSchema = {
+      bass_pitch_class: 4,
       confidence: 0.9,
       end_seconds: 4,
-      label: "Cmaj7",
+      label: "Cmaj7/E",
       pitch_class: 0,
       quality: "maj7",
+      root_pitch_class: 0,
       start_seconds: 0,
     };
 
@@ -113,8 +115,10 @@ describe("transposeChordSegment", () => {
         mode: "auto",
       }),
     ).toMatchObject({
-      label: "Dmaj7",
+      bass_pitch_class: 6,
+      label: "Dmaj7/F#",
       pitch_class: 2,
+      root_pitch_class: 2,
       quality: "maj7",
     });
   });
@@ -141,6 +145,7 @@ describe("transposeChordSegment", () => {
 describe("formatJobStatusSummary", () => {
   it("includes chord detection source for chord jobs", () => {
     const job: JobSchema = {
+      chord_backend: "tuneforge-fast",
       chord_source: "source+stem",
       completed_at: "2026-04-18T13:16:14.000Z",
       created_at: "2026-04-18T13:16:00.000Z",
@@ -157,6 +162,28 @@ describe("formatJobStatusSummary", () => {
       updated_at: "2026-04-18T13:16:14.000Z",
     };
 
-    expect(formatJobStatusSummary(job)).toBe("completed / source+stem / 14 s");
+    expect(formatJobStatusSummary(job)).toBe("completed / built-in / source+stem / 14 s");
+  });
+
+  it("includes advanced chord backend for crema jobs", () => {
+    const job: JobSchema = {
+      chord_backend: "crema-advanced",
+      chord_source: "source",
+      completed_at: "2026-04-18T13:16:14.000Z",
+      created_at: "2026-04-18T13:16:00.000Z",
+      duration_seconds: 5.3,
+      error_message: null,
+      id: "job_chords_advanced",
+      progress: 100,
+      project_id: "proj_123",
+      runtime_device: null,
+      source_artifact_id: null,
+      started_at: "2026-04-18T13:16:09.000Z",
+      status: "completed",
+      type: "chords",
+      updated_at: "2026-04-18T13:16:14.000Z",
+    };
+
+    expect(formatJobStatusSummary(job)).toBe("completed / advanced / source / 5.3 s");
   });
 });

--- a/apps/desktop/src/features/projects/projectViewUtils.ts
+++ b/apps/desktop/src/features/projects/projectViewUtils.ts
@@ -99,12 +99,23 @@ export function formatJobDuration(durationSeconds: number | null | undefined) {
 export function formatJobStatusSummary(job: JobSchema) {
   return [
     job.status,
+    job.type === "chords" ? formatChordBackend(job.chord_backend) : null,
     job.type === "chords" ? job.chord_source : null,
     typeof job.runtime_device === "string" ? job.runtime_device.toUpperCase() : null,
     formatJobDuration(job.duration_seconds),
   ]
     .filter(Boolean)
     .join(" / ");
+}
+
+function formatChordBackend(backend: string | null | undefined) {
+  if (backend === "tuneforge-fast" || backend === "fast" || backend === "default") {
+    return "built-in";
+  }
+  if (backend === "crema-advanced" || backend === "advanced" || backend === "crema") {
+    return "advanced";
+  }
+  return backend ?? null;
 }
 
 export function formatPlaybackClock(totalSeconds: number) {
@@ -225,10 +236,16 @@ export function transposeChordSegment(
     return segment;
   }
   const pitchClass = transposePitchClass(segment.pitch_class, semitones);
+  const bassPitchClass =
+    typeof segment.bass_pitch_class === "number"
+      ? transposePitchClass(segment.bass_pitch_class, semitones)
+      : segment.bass_pitch_class;
   return {
     ...segment,
+    bass_pitch_class: bassPitchClass,
     pitch_class: pitchClass,
-    label: formatChordLabel(pitchClass, segment.quality, options),
+    root_pitch_class: typeof segment.root_pitch_class === "number" ? pitchClass : segment.root_pitch_class,
+    label: formatChordLabel(pitchClass, segment.quality, options, bassPitchClass),
   };
 }
 

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -2,9 +2,10 @@ import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { Link } from "react-router-dom";
-import { api } from "../../lib/api";
+import { api, type ChordBackendSchema } from "../../lib/api";
 import {
   usePreferences,
+  type DefaultChordBackend,
   type DefaultPlaybackDisplayMode,
   type EnharmonicDisplayMode,
   type InformationDensity,
@@ -23,8 +24,10 @@ import {
 } from "../../lib/theme";
 
 type ChoiceOption<T extends string> = {
+  disabled?: boolean;
   description: string;
   label: string;
+  status?: string;
   value: T;
 };
 
@@ -133,6 +136,21 @@ const playbackDisplayOptions: ChoiceOption<DefaultPlaybackDisplayMode>[] = [
   },
 ];
 
+const fallbackChordBackendOptions: ChoiceOption<DefaultChordBackend>[] = [
+  {
+    value: "tuneforge-fast",
+    label: "Built-in Chords",
+    description: "Default local detector with lightweight source and stem analysis.",
+  },
+  {
+    value: "crema-advanced",
+    label: "Advanced Chords",
+    description: "Experimental crema detector with sevenths and inversion labels.",
+    disabled: true,
+    status: "Unavailable",
+  },
+];
+
 function themePreferenceLabel(themePreference: ThemePreference) {
   if (themePreference === "system") {
     return "Follow system";
@@ -169,6 +187,31 @@ function playbackDisplayLabel(value: DefaultPlaybackDisplayMode) {
   return "Chords";
 }
 
+function chordBackendLabel(value: DefaultChordBackend) {
+  return value === "crema-advanced" ? "Advanced Chords" : "Built-in Chords";
+}
+
+function chordBackendOptions(backends: ChordBackendSchema[] | undefined): ChoiceOption<DefaultChordBackend>[] {
+  if (!backends?.length) {
+    return fallbackChordBackendOptions;
+  }
+
+  return fallbackChordBackendOptions.map((fallback) => {
+    const backend = backends.find((candidate) => candidate.id === fallback.value);
+    if (!backend) {
+      return fallback;
+    }
+    const unavailableReason = backend.available ? null : backend.unavailable_reason;
+    return {
+      value: fallback.value,
+      label: backend.label,
+      description: backend.description,
+      disabled: !backend.available,
+      status: unavailableReason ?? (backend.experimental ? "Experimental" : undefined),
+    };
+  });
+}
+
 function ChoiceGroup<T extends string>({
   description,
   legend,
@@ -191,12 +234,14 @@ function ChoiceGroup<T extends string>({
           <button
             key={option.value}
             aria-pressed={value === option.value}
+            disabled={option.disabled}
             className="settings-choice"
             onClick={() => onChange(option.value)}
             type="button"
           >
             <span className="settings-choice__label">{option.label}</span>
             <span className="settings-choice__copy">{option.description}</span>
+            {option.status ? <span className="settings-choice__copy">{option.status}</span> : null}
           </button>
         ))}
       </div>
@@ -247,6 +292,7 @@ export function SettingsView() {
     defaultSourcesRailCollapsed,
     defaultProjectWorkspace,
     defaultPlaybackDisplayMode,
+    defaultChordBackend,
     defaultLyricsFollowEnabled,
     defaultChordsFollowEnabled,
     setInformationDensity,
@@ -255,10 +301,12 @@ export function SettingsView() {
     setDefaultSourcesRailCollapsed,
     setDefaultProjectWorkspace,
     setDefaultPlaybackDisplayMode,
+    setDefaultChordBackend,
     setDefaultLyricsFollowEnabled,
     setDefaultChordsFollowEnabled,
     resetAppearancePreferences,
     resetNotationPreferences,
+    resetAnalysisPreferences,
     resetVisibilityPreferences,
     resetPreferences,
     replacePreferences,
@@ -269,7 +317,12 @@ export function SettingsView() {
     queryKey: ["health"],
     queryFn: api.getHealth,
   });
+  const chordBackendsQuery = useQuery({
+    queryKey: ["chord-backends"],
+    queryFn: api.listChordBackends,
+  });
   const savedThemeOverrideCount = themeOverrideCount(themeOverrides);
+  const chordBackendChoices = chordBackendOptions(chordBackendsQuery.data?.backends);
 
   function handleResetAppearance() {
     setThemePreference(DEFAULT_THEME_PREFERENCE);
@@ -283,6 +336,10 @@ export function SettingsView() {
 
   function handleResetNotation() {
     resetNotationPreferences();
+  }
+
+  function handleResetAnalysis() {
+    resetAnalysisPreferences();
   }
 
   function handleResetAllSettings() {
@@ -308,6 +365,7 @@ export function SettingsView() {
       const contents = serializeSettingsSnapshot({
         preferences: {
           defaultChordsFollowEnabled,
+          defaultChordBackend,
           defaultInspectorOpen,
           defaultPlaybackDisplayMode,
           defaultLyricsFollowEnabled,
@@ -384,6 +442,7 @@ export function SettingsView() {
             <span className="pill">Theme</span>
             <span className="pill">Density</span>
             <span className="pill">Musical notation</span>
+            <span className="pill">Chord backend</span>
             <span className="pill">Playback defaults</span>
           </div>
         </div>
@@ -420,6 +479,10 @@ export function SettingsView() {
           <div className="settings-overview__stat">
             <dt>Playback view</dt>
             <dd>{playbackDisplayLabel(defaultPlaybackDisplayMode)}</dd>
+          </div>
+          <div className="settings-overview__stat">
+            <dt>Chord backend</dt>
+            <dd>{chordBackendLabel(defaultChordBackend)}</dd>
           </div>
           <div className="settings-overview__stat">
             <dt>Playback follow</dt>
@@ -501,6 +564,29 @@ export function SettingsView() {
           <div className="button-row">
             <button className="button button--ghost button--small" onClick={handleResetNotation} type="button">
               Reset Notation
+            </button>
+          </div>
+        </div>
+
+        <div className="panel settings-panel">
+          <div className="panel-heading">
+            <div>
+              <h2>Analysis Defaults</h2>
+              <p className="subpanel__copy">Default engines for generated project analysis.</p>
+            </div>
+          </div>
+
+          <ChoiceGroup
+            description="Choose the backend used when generating or refreshing chords."
+            legend="Default chord backend"
+            onChange={setDefaultChordBackend}
+            options={chordBackendChoices}
+            value={defaultChordBackend}
+          />
+
+          <div className="button-row">
+            <button className="button button--ghost button--small" onClick={handleResetAnalysis} type="button">
+              Reset Analysis Defaults
             </button>
           </div>
         </div>

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -39,6 +39,8 @@ export type ExportRequest = components["schemas"]["ExportRequest"];
 export type ProjectUpdateRequest = components["schemas"]["ProjectUpdateRequest"];
 export type StemRequest = components["schemas"]["StemRequest"];
 export type ChordRequest = components["schemas"]["ChordRequest"];
+export type ChordBackendSchema = components["schemas"]["ChordBackendSchema"];
+export type ChordBackendsResponse = components["schemas"]["ChordBackendsResponse"];
 export type LyricsGenerateRequest = components["schemas"]["LyricsGenerateRequest"];
 export type LyricsUpdateRequest = components["schemas"]["LyricsUpdateRequest"];
 export type RuntimeCapabilities = MobileCapabilities | null;
@@ -53,6 +55,7 @@ export type TuneForgeClient = {
   deleteProject: (projectId: string) => Promise<components["schemas"]["DeleteResponse"]>;
   analyzeProject: (projectId: string) => Promise<components["schemas"]["JobResponse"]>;
   getAnalysis: (projectId: string) => Promise<AnalysisResponse>;
+  listChordBackends: () => Promise<ChordBackendsResponse>;
   createChords: (projectId: string, body: ChordRequest) => Promise<components["schemas"]["JobResponse"]>;
   getChords: (projectId: string) => Promise<ChordResponse>;
   createLyrics: (projectId: string, body: LyricsGenerateRequest) => Promise<components["schemas"]["JobResponse"]>;
@@ -73,6 +76,48 @@ export type TuneForgeClient = {
 
 let client = createClient<paths>({ baseUrl: apiBaseUrl });
 const mobileArtifactPaths = new Map<string, string>();
+const mobileChordBackendsResponse: ChordBackendsResponse = {
+  backends: [
+    {
+      availability: "available",
+      available: true,
+      capabilities: {
+        desktopOnly: false,
+        estimatedSpeed: "medium",
+        experimental: false,
+        supportsConfidence: true,
+        supportsInversions: false,
+        supportsNoChord: true,
+        supportsSevenths: true,
+      },
+      description: "TuneForge's built-in lightweight chord detector.",
+      desktopOnly: false,
+      experimental: false,
+      id: "tuneforge-fast",
+      label: "Built-in Chords",
+      unavailable_reason: null,
+    },
+    {
+      availability: "unavailable",
+      available: false,
+      capabilities: {
+        desktopOnly: true,
+        estimatedSpeed: "slow",
+        experimental: true,
+        supportsConfidence: true,
+        supportsInversions: true,
+        supportsNoChord: true,
+        supportsSevenths: true,
+      },
+      description: "Optional crema chord detector for desktop builds.",
+      desktopOnly: true,
+      experimental: true,
+      id: "crema-advanced",
+      label: "Advanced Chords",
+      unavailable_reason: "advanced chord backend is disabled on mobile",
+    },
+  ],
+};
 
 export class ApiError extends Error {
   code: string;
@@ -149,6 +194,7 @@ function createHttpTuneForgeClient(): TuneForgeClient {
       ),
     getAnalysis: (projectId: string) =>
       unwrap(client.GET("/api/v1/projects/{project_id}/analysis", { params: { path: { project_id: projectId } } })),
+    listChordBackends: () => unwrap(client.GET("/api/v1/chord-backends")),
     createChords: (projectId: string, body: ChordRequest) =>
       unwrap(client.POST("/api/v1/projects/{project_id}/chords", { params: { path: { project_id: projectId } }, body })),
     getChords: (projectId: string) =>
@@ -198,6 +244,7 @@ function createMobileTuneForgeClient(capabilities: MobileCapabilities): TuneForg
     deleteProject: (projectId: string) => invokeMobile("mobile_delete_project", { projectId }),
     analyzeProject: (projectId: string) => invokeMobile("mobile_submit_analyze", { projectId }),
     getAnalysis: (projectId: string) => invokeMobile("mobile_get_analysis", { projectId }),
+    listChordBackends: async () => mobileChordBackendsResponse,
     createChords: (projectId: string, body: ChordRequest) =>
       invokeMobile("mobile_submit_chords", { projectId, payload: body }),
     getChords: (projectId: string) => invokeMobile("mobile_get_chords", { projectId }),
@@ -283,6 +330,7 @@ export const api: TuneForgeClient = {
   deleteProject: (projectId: string) => activeClient.deleteProject(projectId),
   analyzeProject: (projectId: string) => activeClient.analyzeProject(projectId),
   getAnalysis: (projectId: string) => activeClient.getAnalysis(projectId),
+  listChordBackends: () => activeClient.listChordBackends(),
   createChords: (projectId: string, body: ChordRequest) => activeClient.createChords(projectId, body),
   getChords: (projectId: string) => activeClient.getChords(projectId),
   createLyrics: (projectId: string, body: LyricsGenerateRequest) => activeClient.createLyrics(projectId, body),

--- a/apps/desktop/src/lib/music.test.ts
+++ b/apps/desktop/src/lib/music.test.ts
@@ -68,5 +68,8 @@ describe("enharmonic formatting", () => {
       primary: { root: "C#", suffix: "sus2" },
       secondary: { root: "Db", suffix: "sus2" },
     });
+    expect(formatChordLabel(2, "major", { mode: "sharps" }, 6)).toBe("D/F#");
+    expect(formatChordLabel(0, "minor", { mode: "flats" }, 7)).toBe("Cm/G");
+    expect(formatChordLabel(0, "hdim7")).toBe("Cm7b5");
   });
 });

--- a/apps/desktop/src/lib/music.ts
+++ b/apps/desktop/src/lib/music.ts
@@ -1,5 +1,16 @@
 export type KeyMode = "major" | "minor";
-export type ChordQuality = "major" | "minor" | "7" | "maj7" | "m7" | "sus2" | "sus4" | "dim";
+export type ChordQuality =
+  | "major"
+  | "minor"
+  | "7"
+  | "maj7"
+  | "m7"
+  | "sus2"
+  | "sus4"
+  | "dim"
+  | "aug"
+  | "dim7"
+  | "hdim7";
 export type EnharmonicDisplayMode = "auto" | "sharps" | "flats" | "neutral" | "dual";
 
 export type MusicalKey = {
@@ -255,28 +266,34 @@ export function formatChordLabel(
   pitchClass: number,
   quality: ChordQuality,
   options: PitchFormatOptions = {},
+  bassPitchClass?: number | null,
 ): string {
   const suffix = chordQualitySuffix(quality);
   const noteName =
     options.mode === "dual"
-      ? formatDualPitchClass(pitchClass, suffix)
+      ? formatDualPitchClass(pitchClass, suffix, bassPitchClass)
       : formatChordRoot(pitchClass, options);
   if (options.mode === "dual") {
     return noteName;
   }
-  return `${noteName}${suffix}`;
+  const bassSuffix =
+    typeof bassPitchClass === "number" && bassPitchClass !== pitchClass
+      ? `/${formatPitchClass(bassPitchClass, options)}`
+      : "";
+  return `${noteName}${suffix}${bassSuffix}`;
 }
 
 export function formatChordDisplay(
   pitchClass: number,
   quality: ChordQuality,
   options: PitchFormatOptions = {},
+  bassPitchClass?: number | null,
 ): FormattedMusicalLabel {
   const { primaryLabel, secondaryLabel } =
     options.mode === "dual"
-      ? formatDualChordLabels(pitchClass, quality)
+      ? formatDualChordLabels(pitchClass, quality, bassPitchClass)
       : {
-          primaryLabel: formatChordLabel(pitchClass, quality, options),
+          primaryLabel: formatChordLabel(pitchClass, quality, options, bassPitchClass),
           secondaryLabel: null,
         };
 
@@ -309,12 +326,17 @@ export function formatAlternateChordLabel(
   pitchClass: number,
   quality: ChordQuality,
   options: PitchFormatOptions = {},
+  bassPitchClass?: number | null,
 ): string | null {
   const alternateRoot = formatAlternatePitchClass(pitchClass, options);
   if (!alternateRoot) {
     return null;
   }
-  return `${alternateRoot}${chordQualitySuffix(quality)}`;
+  const alternateBass =
+    typeof bassPitchClass === "number" && bassPitchClass !== pitchClass
+      ? formatAlternatePitchClass(bassPitchClass, options) ?? formatPitchClass(bassPitchClass, options)
+      : null;
+  return `${alternateRoot}${chordQualitySuffix(quality)}${alternateBass ? `/${alternateBass}` : ""}`;
 }
 
 export function isSupportedChordQuality(quality: string | null | undefined): quality is ChordQuality {
@@ -326,7 +348,10 @@ export function isSupportedChordQuality(quality: string | null | undefined): qua
     quality === "m7" ||
     quality === "sus2" ||
     quality === "sus4" ||
-    quality === "dim"
+    quality === "dim" ||
+    quality === "aug" ||
+    quality === "dim7" ||
+    quality === "hdim7"
   );
 }
 
@@ -387,12 +412,22 @@ function formatDualKeyLabels(key: MusicalKey): { primaryLabel: string; secondary
 function formatDualChordLabels(
   pitchClass: number,
   quality: ChordQuality,
+  bassPitchClass?: number | null,
 ): { primaryLabel: string; secondaryLabel: string | null } {
   const { primaryRoot, secondaryRoot } = getDualPitchClassParts(pitchClass);
+  const bassParts =
+    typeof bassPitchClass === "number" && bassPitchClass !== pitchClass
+      ? getDualPitchClassParts(bassPitchClass)
+      : null;
   const suffix = chordQualitySuffix(quality);
+  const primaryBass = bassParts ? `/${bassParts.primaryRoot}` : "";
+  const secondaryBass = bassParts ? `/${bassParts.secondaryRoot ?? bassParts.primaryRoot}` : "";
   return {
-    primaryLabel: `${primaryRoot}${suffix}`,
-    secondaryLabel: secondaryRoot ? `${secondaryRoot}${suffix}` : null,
+    primaryLabel: `${primaryRoot}${suffix}${primaryBass}`,
+    secondaryLabel:
+      secondaryRoot || bassParts?.secondaryRoot
+        ? `${secondaryRoot ?? primaryRoot}${suffix}${secondaryBass}`
+        : null,
   };
 }
 
@@ -406,14 +441,22 @@ function getDualPitchClassParts(pitchClass: number): { primaryRoot: string; seco
   };
 }
 
-function formatDualPitchClass(pitchClass: number, suffix = ""): string {
+function formatDualPitchClass(pitchClass: number, suffix = "", bassPitchClass?: number | null): string {
   const normalizedPitchClass = normalizePitchClass(pitchClass);
   const sharpLabel = SHARP_PITCH_CLASSES[normalizedPitchClass] ?? SHARP_PITCH_CLASSES[0];
   const flatLabel = FLAT_PITCH_CLASSES[normalizedPitchClass] ?? FLAT_PITCH_CLASSES[0];
+  const sharpBassSuffix =
+    typeof bassPitchClass === "number" && bassPitchClass !== pitchClass
+      ? `/${SHARP_PITCH_CLASSES[normalizePitchClass(bassPitchClass)] ?? SHARP_PITCH_CLASSES[0]}`
+      : "";
   if (sharpLabel === flatLabel) {
-    return `${sharpLabel}${suffix}`;
+    return `${sharpLabel}${suffix}${sharpBassSuffix}`;
   }
-  return `${sharpLabel}${suffix}/${flatLabel}${suffix}`;
+  const flatBassSuffix =
+    typeof bassPitchClass === "number" && bassPitchClass !== pitchClass
+      ? `/${FLAT_PITCH_CLASSES[normalizePitchClass(bassPitchClass)] ?? FLAT_PITCH_CLASSES[0]}`
+      : "";
+  return `${sharpLabel}${suffix}${sharpBassSuffix}/${flatLabel}${suffix}${flatBassSuffix}`;
 }
 
 function chordQualitySuffix(quality: ChordQuality): string {
@@ -434,5 +477,11 @@ function chordQualitySuffix(quality: ChordQuality): string {
       return "sus4";
     case "dim":
       return "dim";
+    case "aug":
+      return "aug";
+    case "dim7":
+      return "dim7";
+    case "hdim7":
+      return "m7b5";
   }
 }

--- a/apps/desktop/src/lib/preferences.tsx
+++ b/apps/desktop/src/lib/preferences.tsx
@@ -13,6 +13,7 @@ export type InformationDensity = "minimal" | "balanced" | "detailed";
 export type ProjectWorkspaceMode = "project" | "playback";
 export type PlaybackDisplayMode = "lyrics" | "chords" | "combined";
 export type DefaultPlaybackDisplayMode = "auto" | PlaybackDisplayMode;
+export type DefaultChordBackend = "tuneforge-fast" | "crema-advanced";
 export type { EnharmonicDisplayMode };
 
 export type UiPreferences = {
@@ -22,12 +23,14 @@ export type UiPreferences = {
   defaultSourcesRailCollapsed: boolean;
   defaultProjectWorkspace: ProjectWorkspaceMode;
   defaultPlaybackDisplayMode: DefaultPlaybackDisplayMode;
+  defaultChordBackend: DefaultChordBackend;
   defaultLyricsFollowEnabled: boolean;
   defaultChordsFollowEnabled: boolean;
 };
 
 export type AppearancePreferences = Pick<UiPreferences, "informationDensity">;
 export type NotationPreferences = Pick<UiPreferences, "enharmonicDisplayMode">;
+export type AnalysisPreferences = Pick<UiPreferences, "defaultChordBackend">;
 export type VisibilityPreferences = Pick<
   UiPreferences,
   | "defaultInspectorOpen"
@@ -45,11 +48,13 @@ type PreferencesContextValue = UiPreferences & {
   setDefaultSourcesRailCollapsed: (value: boolean) => void;
   setDefaultProjectWorkspace: (value: ProjectWorkspaceMode) => void;
   setDefaultPlaybackDisplayMode: (value: DefaultPlaybackDisplayMode) => void;
+  setDefaultChordBackend: (value: DefaultChordBackend) => void;
   setDefaultLyricsFollowEnabled: (value: boolean) => void;
   setDefaultChordsFollowEnabled: (value: boolean) => void;
   replacePreferences: (value: UiPreferences) => void;
   resetAppearancePreferences: () => void;
   resetNotationPreferences: () => void;
+  resetAnalysisPreferences: () => void;
   resetVisibilityPreferences: () => void;
   resetPreferences: () => void;
 };
@@ -64,6 +69,10 @@ export const DEFAULT_NOTATION_PREFERENCES: NotationPreferences = {
   enharmonicDisplayMode: "auto",
 };
 
+export const DEFAULT_ANALYSIS_PREFERENCES: AnalysisPreferences = {
+  defaultChordBackend: "tuneforge-fast",
+};
+
 export const DEFAULT_VISIBILITY_PREFERENCES: VisibilityPreferences = {
   defaultInspectorOpen: true,
   defaultSourcesRailCollapsed: false,
@@ -76,6 +85,7 @@ export const DEFAULT_VISIBILITY_PREFERENCES: VisibilityPreferences = {
 export const DEFAULT_PREFERENCES: UiPreferences = {
   ...DEFAULT_APPEARANCE_PREFERENCES,
   ...DEFAULT_NOTATION_PREFERENCES,
+  ...DEFAULT_ANALYSIS_PREFERENCES,
   ...DEFAULT_VISIBILITY_PREFERENCES,
 };
 
@@ -101,6 +111,10 @@ export function isDefaultPlaybackDisplayMode(
   value: unknown,
 ): value is DefaultPlaybackDisplayMode {
   return value === "auto" || isPlaybackDisplayMode(value);
+}
+
+export function isDefaultChordBackend(value: unknown): value is DefaultChordBackend {
+  return value === "tuneforge-fast" || value === "crema-advanced";
 }
 
 export function normalizePreferences(value: unknown): UiPreferences {
@@ -130,6 +144,9 @@ export function normalizePreferences(value: unknown): UiPreferences {
     defaultPlaybackDisplayMode: isDefaultPlaybackDisplayMode(candidate.defaultPlaybackDisplayMode)
       ? candidate.defaultPlaybackDisplayMode
       : DEFAULT_PREFERENCES.defaultPlaybackDisplayMode,
+    defaultChordBackend: isDefaultChordBackend(candidate.defaultChordBackend)
+      ? candidate.defaultChordBackend
+      : DEFAULT_PREFERENCES.defaultChordBackend,
     defaultLyricsFollowEnabled:
       typeof candidate.defaultLyricsFollowEnabled === "boolean"
         ? candidate.defaultLyricsFollowEnabled
@@ -199,6 +216,9 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
       setDefaultPlaybackDisplayMode: (defaultPlaybackDisplayMode) => {
         setPreferences((current) => mergePreferences(current, { defaultPlaybackDisplayMode }));
       },
+      setDefaultChordBackend: (defaultChordBackend) => {
+        setPreferences((current) => mergePreferences(current, { defaultChordBackend }));
+      },
       setDefaultLyricsFollowEnabled: (defaultLyricsFollowEnabled) => {
         setPreferences((current) => mergePreferences(current, { defaultLyricsFollowEnabled }));
       },
@@ -215,6 +235,9 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
       },
       resetNotationPreferences: () => {
         setPreferences((current) => mergePreferences(current, DEFAULT_NOTATION_PREFERENCES));
+      },
+      resetAnalysisPreferences: () => {
+        setPreferences((current) => mergePreferences(current, DEFAULT_ANALYSIS_PREFERENCES));
       },
       resetVisibilityPreferences: () => {
         setPreferences((current) => mergePreferences(current, DEFAULT_VISIBILITY_PREFERENCES));

--- a/apps/desktop/src/styles/settings-theme.css
+++ b/apps/desktop/src/styles/settings-theme.css
@@ -139,6 +139,12 @@
   transform: translateY(-1px);
 }
 
+.settings-choice:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+  transform: none;
+}
+
 .settings-choice:focus-visible,
 .settings-toggle:focus-visible,
 .settings-details summary:focus-visible {

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -10,6 +10,7 @@ const {
   setProjectAnalysis,
   setProjectChords,
   setProjectLyrics,
+  setChordBackends,
   setDeferredPreviewCompletion,
   flushPendingPreview,
   mockOpen,
@@ -22,6 +23,7 @@ const {
   mockGetAnalysis,
   mockGetChords,
   mockGetLyrics,
+  mockListChordBackends,
   mockListArtifacts,
   mockListJobs,
   mockCreateChords,
@@ -44,6 +46,7 @@ const {
     chordsByProject: Record<string, Record<string, unknown>>;
     lyricsByProject: Record<string, Record<string, unknown>>;
     artifactsByProject: Record<string, Array<Record<string, unknown>>>;
+    chordBackends: Array<Record<string, unknown>>;
     pendingPreviewArtifactsByProject: Record<string, Array<Record<string, unknown>>>;
     jobs: Array<Record<string, unknown>>;
     snapshotFiles: Record<string, string>;
@@ -146,6 +149,49 @@ const {
     };
   }
 
+  function makeChordBackends() {
+    return [
+      {
+        availability: "available",
+        available: true,
+        capabilities: {
+          desktopOnly: false,
+          estimatedSpeed: "medium",
+          experimental: false,
+          supportsConfidence: true,
+          supportsInversions: false,
+          supportsNoChord: true,
+          supportsSevenths: true,
+        },
+        description: "TuneForge's built-in lightweight chord detector.",
+        desktopOnly: false,
+        experimental: false,
+        id: "tuneforge-fast",
+        label: "Built-in Chords",
+        unavailable_reason: null,
+      },
+      {
+        availability: "available",
+        available: true,
+        capabilities: {
+          desktopOnly: true,
+          estimatedSpeed: "slow",
+          experimental: true,
+          supportsConfidence: true,
+          supportsInversions: true,
+          supportsNoChord: true,
+          supportsSevenths: true,
+        },
+        description: "Experimental crema chord detector.",
+        desktopOnly: true,
+        experimental: true,
+        id: "crema-advanced",
+        label: "Advanced Chords",
+        unavailable_reason: null,
+      },
+    ];
+  }
+
   function setProjects(projects: Array<Record<string, unknown>>) {
     state.projects = clone(projects);
   }
@@ -160,6 +206,10 @@ const {
 
   function setProjectLyrics(projectId: string, lyrics: Record<string, unknown>) {
     state.lyricsByProject[projectId] = clone(lyrics);
+  }
+
+  function setChordBackends(backends: Array<Record<string, unknown>>) {
+    state.chordBackends = clone(backends);
   }
 
   function setDeferredPreviewCompletion(value: boolean) {
@@ -230,6 +280,7 @@ const {
           },
         ],
       },
+      chordBackends: makeChordBackends(),
       pendingPreviewArtifactsByProject: {},
       jobs: [
         {
@@ -304,6 +355,7 @@ const {
     preview_format: "wav",
   }));
   const mockGetMobileCapabilities = vi.fn(async (): Promise<unknown> => null);
+  const mockListChordBackends = vi.fn(async () => ({ backends: clone(state.chordBackends) }));
   const mockListProjects = vi.fn(async (search?: string) => {
     const normalizedSearch = search?.trim().toLowerCase();
     const filteredProjects = normalizedSearch
@@ -381,6 +433,8 @@ const {
       type: "chords",
       status: "completed",
       progress: 100,
+      chord_backend: body?.backend === "crema-advanced" ? "crema-advanced" : "tuneforge-fast",
+      chord_backend_fallback_from: body?.backend_fallback_from ?? null,
       chord_source: body?.chord_source ?? "source",
       error_message: null,
       created_at: createdAt,
@@ -441,7 +495,7 @@ const {
   });
   const mockCreateStems = vi.fn(async (
     projectId: string,
-    body: { source_artifact_id?: string; force?: boolean; overwrite_chord_edits?: boolean },
+    body: { source_artifact_id?: string; force?: boolean; chord_backend?: string; overwrite_chord_edits?: boolean },
   ) => {
     const sourceArtifactId = body.source_artifact_id ?? "art_source";
     state.artifactsByProject[projectId] = (state.artifactsByProject[projectId] ?? []).filter((artifact) => {
@@ -611,6 +665,7 @@ const {
     setProjectAnalysis,
     setProjectChords,
     setProjectLyrics,
+    setChordBackends,
     setDeferredPreviewCompletion,
     flushPendingPreview,
     mockOpen,
@@ -623,6 +678,7 @@ const {
     mockGetAnalysis,
     mockGetChords,
     mockGetLyrics,
+    mockListChordBackends,
     mockListArtifacts,
     mockListJobs,
     mockCreateChords,
@@ -646,6 +702,7 @@ export {
   setProjectAnalysis,
   setProjectChords,
   setProjectLyrics,
+  setChordBackends,
   setDeferredPreviewCompletion,
   flushPendingPreview,
   mockOpen,
@@ -658,6 +715,7 @@ export {
   mockGetAnalysis,
   mockGetChords,
   mockGetLyrics,
+  mockListChordBackends,
   mockListArtifacts,
   mockListJobs,
   mockCreateChords,
@@ -698,6 +756,7 @@ vi.mock("../lib/api", async (importOriginal) => {
       getAnalysis: mockGetAnalysis,
       getChords: mockGetChords,
       getLyrics: mockGetLyrics,
+      listChordBackends: mockListChordBackends,
       listArtifacts: mockListArtifacts,
       listJobs: mockListJobs,
       createChords: mockCreateChords,

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "package:mac": "pnpm package:mac:app && pnpm package:mac:dmg",
     "package:mac:app": "pnpm --filter @tuneforge/desktop tauri build --bundles app",
     "package:mac:dmg": "node scripts/package-dmg.mjs",
+    "setup:dev": "bash scripts/setup-dev.sh",
     "sync:backend:default": "bash scripts/sync-backend-default.sh",
     "sync:backend:legacy-nvidia": "bash scripts/sync-backend-legacy-nvidia.sh",
     "test": "bash scripts/run-tests.sh",

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -21,6 +21,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/chord-backends": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Chord Backends */
+        get: operations["chord_backends_api_v1_chord_backends_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/projects/import": {
         parameters: {
             query?: never;
@@ -412,6 +429,48 @@ export interface components {
             /** Artifacts */
             artifacts: components["schemas"]["ArtifactSchema"][];
         };
+        /** ChordBackendCapabilitiesSchema */
+        ChordBackendCapabilitiesSchema: {
+            /** Supportssevenths */
+            supportsSevenths: boolean;
+            /** Supportsinversions */
+            supportsInversions: boolean;
+            /** Supportsconfidence */
+            supportsConfidence: boolean;
+            /** Supportsnochord */
+            supportsNoChord: boolean;
+            /** Estimatedspeed */
+            estimatedSpeed: string;
+            /** Desktoponly */
+            desktopOnly: boolean;
+            /** Experimental */
+            experimental: boolean;
+        };
+        /** ChordBackendSchema */
+        ChordBackendSchema: {
+            /** Id */
+            id: string;
+            /** Label */
+            label: string;
+            /** Description */
+            description: string;
+            /** Availability */
+            availability: string;
+            /** Available */
+            available: boolean;
+            /** Unavailable Reason */
+            unavailable_reason?: string | null;
+            capabilities: components["schemas"]["ChordBackendCapabilitiesSchema"];
+            /** Experimental */
+            experimental: boolean;
+            /** Desktoponly */
+            desktopOnly: boolean;
+        };
+        /** ChordBackendsResponse */
+        ChordBackendsResponse: {
+            /** Backends */
+            backends: components["schemas"]["ChordBackendSchema"][];
+        };
         /** ChordRequest */
         ChordRequest: {
             /**
@@ -419,6 +478,8 @@ export interface components {
              * @default default
              */
             backend: string;
+            /** Backend Fallback From */
+            backend_fallback_from?: string | null;
             /**
              * Force
              * @default false
@@ -447,6 +508,15 @@ export interface components {
              * @default false
              */
             has_user_edits: boolean;
+            /**
+             * Source Kind
+             * @default generated
+             */
+            source_kind: string;
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            };
             /** Created At */
             created_at?: string | null;
             /** Updated At */
@@ -460,12 +530,22 @@ export interface components {
             end_seconds: number;
             /** Label */
             label: string;
+            /** Display Label */
+            display_label?: string | null;
+            /** Raw Label */
+            raw_label?: string | null;
             /** Confidence */
             confidence?: number | null;
             /** Pitch Class */
             pitch_class?: number | null;
+            /** Root Pitch Class */
+            root_pitch_class?: number | null;
             /** Quality */
             quality?: string | null;
+            /** Bass Pitch Class */
+            bass_pitch_class?: number | null;
+            /** Bass Degree */
+            bass_degree?: string | null;
         };
         /** DeleteResponse */
         DeleteResponse: {
@@ -529,6 +609,10 @@ export interface components {
             progress: number;
             /** Source Artifact Id */
             source_artifact_id?: string | null;
+            /** Chord Backend */
+            chord_backend?: string | null;
+            /** Chord Backend Fallback From */
+            chord_backend_fallback_from?: string | null;
             /** Chord Source */
             chord_source?: string | null;
             /** Error Message */
@@ -745,6 +829,13 @@ export interface components {
             /** Source Artifact Id */
             source_artifact_id?: string | null;
             /**
+             * Chord Backend
+             * @default default
+             */
+            chord_backend: string;
+            /** Chord Backend Fallback From */
+            chord_backend_fallback_from?: string | null;
+            /**
              * Overwrite Chord Edits
              * @default false
              */
@@ -803,6 +894,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HealthResponse"];
+                };
+            };
+        };
+    };
+    chord_backends_api_v1_chord_backends_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChordBackendsResponse"];
                 };
             };
         };

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: pnpm setup:dev [options]
+
+Runs the standard developer setup:
+  pnpm install
+  uv sync --python 3.11 --all-groups
+  pnpm contracts:generate
+
+Options:
+  --advanced-chords, --crema  Install the optional crema/TensorFlow chord backend.
+  --legacy-nvidia             Use the Linux x86_64 legacy NVIDIA Torch profile.
+  --skip-pnpm-install         Skip workspace dependency installation.
+  --skip-contracts            Skip OpenAPI contract generation.
+  -h, --help                  Show this help.
+EOF
+}
+
+advanced_chords=0
+legacy_nvidia=0
+skip_pnpm_install=0
+skip_contracts=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --advanced-chords | --crema)
+      advanced_chords=1
+      ;;
+    --legacy-nvidia)
+      legacy_nvidia=1
+      ;;
+    --skip-pnpm-install)
+      skip_pnpm_install=1
+      ;;
+    --skip-contracts)
+      skip_contracts=1
+      ;;
+    --)
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+backend_dir="${repo_root}/apps/backend"
+marker_file="${backend_dir}/.venv/.tuneforge-legacy-nvidia"
+
+if [[ "${legacy_nvidia}" -eq 1 ]]; then
+  if [[ "$(uname -s)" != "Linux" ]]; then
+    echo "Legacy NVIDIA backend profile is only supported on Linux." >&2
+    exit 1
+  fi
+
+  if [[ "$(uname -m)" != "x86_64" ]]; then
+    echo "Legacy NVIDIA backend profile is only supported on Linux x86_64." >&2
+    exit 1
+  fi
+fi
+
+backend_sync_args=(sync --python 3.11 --all-groups)
+if [[ "${advanced_chords}" -eq 1 ]]; then
+  backend_sync_args+=(--extra advanced-chords)
+fi
+
+cd "${repo_root}"
+
+if [[ "${skip_pnpm_install}" -eq 0 ]]; then
+  echo "Installing workspace dependencies..."
+  pnpm install
+fi
+
+cd "${backend_dir}"
+
+if [[ "${legacy_nvidia}" -eq 1 ]]; then
+  echo "Recreating backend environment with legacy NVIDIA profile..."
+  rm -rf .venv
+elif [[ -f "${marker_file}" ]]; then
+  echo "Resetting backend environment from legacy NVIDIA profile..."
+  rm -rf .venv
+fi
+
+echo "Syncing backend dependencies..."
+uv "${backend_sync_args[@]}"
+
+if [[ "${legacy_nvidia}" -eq 1 ]]; then
+  echo "Installing legacy NVIDIA Torch wheels..."
+  uv pip install \
+    --python .venv/bin/python \
+    --torch-backend cu126 \
+    --reinstall-package torch \
+    --reinstall-package torchaudio \
+    "torch==2.6.0" \
+    "torchaudio==2.6.0"
+
+  touch "${marker_file}"
+else
+  rm -f "${marker_file}"
+fi
+
+if [[ "${skip_contracts}" -eq 0 ]]; then
+  cd "${repo_root}"
+  echo "Generating shared API contracts..."
+  pnpm contracts:generate
+fi
+
+echo "Setup complete."


### PR DESCRIPTION
## Summary
- Add optional Advanced Chords support through a crema-backed backend while keeping Built-in Chords as the default backend.
- Add backend capability/availability reporting, chord backend selection, generated timeline metadata, and fallback behavior when Advanced Chords is unavailable.
- Preserve richer chord labels, sevenths, no-chord segments, and inversion/slash-chord bass data from crema output.
- Add backend benchmark tooling and tests for backend registry, parser/normalizer, timeline conversion, fallback behavior, and API coverage.
- Add `pnpm setup:dev` for first-time setup, with flags for optional Advanced Chords and legacy NVIDIA profiles.

## Testing
- `pnpm contracts:generate`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `cd apps/backend && uv run --python 3.11 pytest`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop test --run`
- `cd apps/desktop/src-tauri && cargo check`
- `bash -n scripts/setup-dev.sh`
- `pnpm setup:dev --help`
- `git diff --check`
- `pnpm commitlint --edit`
