### PR TITLE
feat: Polish playback practice follow behavior

### DIFF
--- a/apps/desktop/src/App.project-analysis-mix.test.tsx
+++ b/apps/desktop/src/App.project-analysis-mix.test.tsx
@@ -1,10 +1,12 @@
-import { screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   resetAppTestHarness,
+  findAudioByArtifactId,
   getAllByAriaKeyLabel,
   getByAriaKeyLabel,
+  markAudioReady,
   mockAnalyzeProject,
   mockConfirm,
   mockCreateChords,
@@ -28,15 +30,31 @@ describe("Desktop app project analysis mix", () => {
   }
 
   async function switchToLyricsOnly(user: ReturnType<typeof userEvent.setup>) {
+    const lyricsToggle = screen.getByRole("button", { name: "Lyrics" });
     const chordsToggle = screen.getByRole("button", { name: "Chords" });
-    if (chordsToggle.getAttribute("aria-pressed") === "true") {
+    const lyricsPressed = lyricsToggle.getAttribute("aria-pressed") === "true";
+    const chordsPressed = chordsToggle.getAttribute("aria-pressed") === "true";
+    if (!lyricsPressed && chordsPressed) {
+      await user.click(lyricsToggle);
+      await user.click(chordsToggle);
+      return;
+    }
+    if (lyricsPressed && chordsPressed) {
       await user.click(chordsToggle);
     }
   }
 
   async function switchToChordsOnly(user: ReturnType<typeof userEvent.setup>) {
     const lyricsToggle = screen.getByRole("button", { name: "Lyrics" });
-    if (lyricsToggle.getAttribute("aria-pressed") === "true") {
+    const chordsToggle = screen.getByRole("button", { name: "Chords" });
+    const lyricsPressed = lyricsToggle.getAttribute("aria-pressed") === "true";
+    const chordsPressed = chordsToggle.getAttribute("aria-pressed") === "true";
+    if (lyricsPressed && !chordsPressed) {
+      await user.click(chordsToggle);
+      await user.click(lyricsToggle);
+      return;
+    }
+    if (lyricsPressed && chordsPressed) {
       await user.click(lyricsToggle);
     }
   }
@@ -46,6 +64,36 @@ describe("Desktop app project analysis mix", () => {
     if (showInspectorButton) {
       await user.click(showInspectorButton);
     }
+  }
+
+  function installScrollMock(element: HTMLElement, axis: "vertical" | "horizontal" = "vertical") {
+    const scrollTo = vi.fn();
+    Object.defineProperty(element, "scrollTo", {
+      configurable: true,
+      value: scrollTo,
+    });
+    if (axis === "vertical") {
+      Object.defineProperty(element, "clientHeight", {
+        configurable: true,
+        value: 100,
+      });
+      Object.defineProperty(element, "scrollHeight", {
+        configurable: true,
+        value: 500,
+      });
+      element.scrollTop = 200;
+    } else {
+      Object.defineProperty(element, "clientWidth", {
+        configurable: true,
+        value: 100,
+      });
+      Object.defineProperty(element, "scrollWidth", {
+        configurable: true,
+        value: 500,
+      });
+      element.scrollLeft = 200;
+    }
+    return scrollTo;
   }
 
   it("analyzes track from processing panel", async () => {
@@ -198,7 +246,9 @@ describe("Desktop app project analysis mix", () => {
     await switchToLyricsOnly(user);
     const lyricsTranscript = screen.getByRole("group", { name: "Lyrics transcript" });
     const activeLyric = within(lyricsTranscript).getByRole("button", { name: /0:00/i });
-    expect(activeLyric.className).toContain("lyrics-theater__segment--active");
+    expect(lyricsTranscript.className).toContain("lead-sheet");
+    expect(activeLyric.className).toContain("lead-sheet__row--lyrics");
+    expect(activeLyric.className).toContain("lead-sheet__row--active");
 
     await user.click(screen.getByRole("button", { name: "Edit Lyrics" }));
     const firstTextarea = screen.getByLabelText("Lyric segment 1");
@@ -213,6 +263,151 @@ describe("Desktop app project analysis mix", () => {
       ],
     });
     expect(await screen.findByText("Edited lyric line")).toBeInTheDocument();
+  });
+
+  it("hard follows lyrics during playback after manual scroll", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    await openPlaybackWorkspace(user);
+    await switchToLyricsOnly(user);
+
+    const lyricsTranscript = screen.getByRole("group", { name: "Lyrics transcript" });
+    const scrollTo = installScrollMock(lyricsTranscript);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument(),
+    );
+    scrollTo.mockClear();
+
+    fireEvent.wheel(lyricsTranscript, { deltaY: 320 });
+    await user.click(within(lyricsTranscript).getByRole("button", { name: /0:08/i }));
+
+    await waitFor(() => expect(scrollTo).toHaveBeenCalled());
+    expect(within(lyricsTranscript).getByRole("button", { name: /0:08/i }).className).toContain(
+      "lead-sheet__row--active",
+    );
+  });
+
+  it("lets users browse follow views while playback is stopped", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+
+    const leadSheet = screen.getByRole("group", { name: "Lyrics and chords lead sheet" });
+    const leadSheetScrollTo = installScrollMock(leadSheet);
+    const secondLeadSheetRow = Array.from(
+      leadSheet.querySelectorAll<HTMLElement>(".lead-sheet__row--lyrics"),
+    ).find((row) => row.textContent?.includes("Second") && row.textContent.includes("steady"));
+    expect(secondLeadSheetRow).not.toBeNull();
+    fireEvent.wheel(leadSheet, { deltaY: 320 });
+    await user.click(secondLeadSheetRow as HTMLElement);
+    await waitFor(() =>
+      expect((secondLeadSheetRow as HTMLElement).className).toContain("lead-sheet__row--active"),
+    );
+    expect(leadSheetScrollTo).not.toHaveBeenCalled();
+
+    await switchToLyricsOnly(user);
+    const lyricsTranscript = screen.getByRole("group", { name: "Lyrics transcript" });
+    const lyricsScrollTo = installScrollMock(lyricsTranscript);
+    const firstLyric = within(lyricsTranscript).getByRole("button", { name: /0:00/i });
+    fireEvent.wheel(lyricsTranscript, { deltaY: -320 });
+    await user.click(firstLyric);
+    await waitFor(() =>
+      expect(firstLyric.className).toContain("lead-sheet__row--active"),
+    );
+    expect(lyricsScrollTo).not.toHaveBeenCalled();
+
+    await switchToChordsOnly(user);
+    const chordTimeline = screen.getByRole("group", { name: "Chord timeline" });
+    const chordScrollTo = installScrollMock(chordTimeline, "horizontal");
+    const secondChord = within(chordTimeline).getByRole("button", { name: /D\s*0:16/ });
+    fireEvent.wheel(chordTimeline, { deltaX: 320 });
+    await user.click(secondChord);
+    await waitFor(() => expect(secondChord).toHaveAttribute("aria-pressed", "true"));
+    expect(chordScrollTo).not.toHaveBeenCalled();
+  });
+
+  it("keeps lyric highlights current when lyrics follow is off", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    await switchToLyricsOnly(user);
+    await user.click(screen.getByRole("button", { name: "Lyrics Follow" }));
+
+    const lyricsTranscript = screen.getByRole("group", { name: "Lyrics transcript" });
+    const scrollTo = installScrollMock(lyricsTranscript);
+    const secondLyric = within(lyricsTranscript).getByRole("button", { name: /0:08/i });
+
+    fireEvent.wheel(lyricsTranscript, { deltaY: 320 });
+    await user.click(secondLyric);
+
+    await waitFor(() =>
+      expect(secondLyric.className).toContain("lead-sheet__row--active"),
+    );
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("activates clicked lyric rows when transcript segment timings overlap", async () => {
+    const user = userEvent.setup();
+    const segments = [
+      {
+        start_seconds: 0,
+        end_seconds: 12,
+        text: "First overlapping phrase",
+        words: [],
+      },
+      {
+        start_seconds: 8,
+        end_seconds: 16,
+        text: "Second overlapping phrase",
+        words: [],
+      },
+    ];
+    setProjectLyrics("proj_123", {
+      project_id: "proj_123",
+      backend: "openai-whisper",
+      source_artifact_id: "art_source",
+      source_kind: "ai",
+      source_segments: segments,
+      segments,
+      has_user_edits: false,
+      created_at: "2026-04-18T13:16:00.000Z",
+      updated_at: "2026-04-18T13:16:00.000Z",
+    });
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+
+    const leadSheet = screen.getByRole("group", { name: "Lyrics and chords lead sheet" });
+    const combinedSecond = within(leadSheet).getByRole("button", {
+      name: /Second overlapping phrase/i,
+    });
+    await user.click(combinedSecond);
+    await waitFor(() => expect(combinedSecond.className).toContain("lead-sheet__row--active"));
+
+    await switchToLyricsOnly(user);
+    const lyricsTranscript = screen.getByRole("group", { name: "Lyrics transcript" });
+    const lyricsFirst = within(lyricsTranscript).getByRole("button", {
+      name: /First overlapping phrase/i,
+    });
+    const lyricsSecond = within(lyricsTranscript).getByRole("button", {
+      name: /Second overlapping phrase/i,
+    });
+    await user.click(lyricsFirst);
+    await waitFor(() => expect(lyricsFirst.className).toContain("lead-sheet__row--active"));
+
+    await user.click(lyricsSecond);
+    await waitFor(() => expect(lyricsSecond.className).toContain("lead-sheet__row--active"));
   });
 
   it("renders a combined lead sheet with lyric chords and instrumental rows", async () => {
@@ -238,6 +433,60 @@ describe("Desktop app project analysis mix", () => {
     expect(getByAriaKeyLabel(leadSheet, "G")).toBeInTheDocument();
     expect(within(leadSheet).getByText("Instrumental")).toBeInTheDocument();
     expect(getByAriaKeyLabel(leadSheet, "D")).toBeInTheDocument();
+  });
+
+  it("hard follows combined lead sheet during playback after manual scroll", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    await openPlaybackWorkspace(user);
+
+    const leadSheet = screen.getByRole("group", { name: "Lyrics and chords lead sheet" });
+    const scrollTo = installScrollMock(leadSheet);
+    const secondLyricRow = Array.from(
+      leadSheet.querySelectorAll<HTMLElement>(".lead-sheet__row--lyrics"),
+    ).find((row) => row.textContent?.includes("Second") && row.textContent.includes("steady"));
+    expect(secondLyricRow).not.toBeNull();
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument(),
+    );
+    scrollTo.mockClear();
+
+    fireEvent.wheel(leadSheet, { deltaY: 320 });
+    await user.click(secondLyricRow as HTMLElement);
+
+    await waitFor(() => expect(scrollTo).toHaveBeenCalled());
+    expect((secondLyricRow as HTMLElement).className).toContain("lead-sheet__row--active");
+  });
+
+  it("hard follows chords during playback after manual timeline scroll", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    await openPlaybackWorkspace(user);
+    await switchToChordsOnly(user);
+
+    const chordTimeline = screen.getByRole("group", { name: "Chord timeline" });
+    const scrollTo = installScrollMock(chordTimeline, "horizontal");
+    const secondChord = within(chordTimeline).getByRole("button", { name: /D\s*0:16/ });
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument(),
+    );
+    scrollTo.mockClear();
+
+    fireEvent.wheel(chordTimeline, { deltaX: 320 });
+    await user.click(secondChord);
+
+    await waitFor(() => expect(scrollTo).toHaveBeenCalled());
+    expect(secondChord).toHaveAttribute("aria-pressed", "true");
   });
 
   it("refreshes edited lyrics with confirmation", async () => {
@@ -594,6 +843,60 @@ describe("Desktop app project analysis mix", () => {
     expect(await screen.findByRole("button", { name: "Lyrics Follow" })).toHaveAttribute("aria-pressed", "false");
     await switchToChordsOnly(user);
     expect(screen.getByRole("button", { name: "Chords Follow" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("scrolls the page to transport when playback starts from the playback workspace", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    await switchToLyricsOnly(user);
+
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    const scrollIntoView = vi.mocked(window.HTMLElement.prototype.scrollIntoView);
+    scrollIntoView.mockClear();
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    await waitFor(() =>
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        behavior: "smooth",
+        block: "end",
+      }),
+    );
+  });
+
+  it("plays from the focused lyric when space starts playback", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    await openPlaybackWorkspace(user);
+    await switchToLyricsOnly(user);
+
+    const lyricsTranscript = screen.getByRole("group", { name: "Lyrics transcript" });
+    const secondLyric = within(lyricsTranscript).getByRole("button", { name: /0:08/i });
+    await user.click(secondLyric);
+
+    expect(sourceAudio.currentTime).toBeCloseTo(8, 3);
+    expect(secondLyric).toHaveFocus();
+    fireEvent.keyDown(secondLyric, { code: "Space", key: " " });
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument(),
+    );
+    expect(sourceAudio.currentTime).toBeCloseTo(8, 3);
+
+    sourceAudio.currentTime = 12.5;
+    fireEvent.timeUpdate(sourceAudio);
+    fireEvent.keyDown(secondLyric, { code: "Space", key: " " });
+
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+    expect(sourceAudio.currentTime).toBeCloseTo(8, 3);
   });
 
   it("does not duplicate the detected key inside the project source key selector", async () => {

--- a/apps/desktop/src/features/projects/components/PlaybackPracticeSurface.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackPracticeSurface.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from "react";
+import type { CSSProperties, KeyboardEvent } from "react";
 import { MusicalChordLabel } from "../../../components/MusicalLabel";
 import type { LeadSheetChord, LeadSheetLyricsRow, LeadSheetRow } from "../projectViewUtils";
 import {
@@ -18,6 +18,25 @@ export function PlaybackPracticeSurface() {
       {playbackDisplayMode === "combined" ? <CombinedLeadSheetPanel /> : null}
     </main>
   );
+}
+
+function usePracticeTargetSpacePlayback() {
+  const { handleSeekTo, isPlaying, togglePlayback } = useProjectViewModelContext();
+
+  return function handlePracticeTargetSpacePlayback(
+    event: KeyboardEvent<HTMLElement>,
+    timeSeconds: number,
+  ) {
+    if (event.code !== "Space" && event.key !== " ") {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    handleSeekTo(timeSeconds);
+    if (!isPlaying) {
+      void togglePlayback();
+    }
+  };
 }
 
 function PlaybackModeHeader() {
@@ -123,7 +142,6 @@ function LyricsPracticePanel() {
     activeLyricsIndex,
     activeLyricsWordIndex,
     displayedLyrics,
-    handleSeekTo,
     hasLyricsTranscript,
     hasTimedLyricsTranscript,
     isEditingLyrics,
@@ -131,7 +149,6 @@ function LyricsPracticePanel() {
     lyricsSaveMutation,
     lyricsSegmentRefs,
     lyricsTheaterRef,
-    pauseLyricsFollow,
     showSupportingCopy,
   } = useProjectViewModelContext();
 
@@ -143,75 +160,34 @@ function LyricsPracticePanel() {
     <div className="playback-practice-body">
       {hasLyricsTranscript ? (
         <div
-          className="lyrics-theater lyrics-theater--practice"
+          className="lead-sheet lead-sheet--lyrics-only"
           role="group"
           aria-label="Lyrics transcript"
           ref={lyricsTheaterRef}
-          onPointerDownCapture={pauseLyricsFollow}
-          onTouchMove={pauseLyricsFollow}
-          onWheel={pauseLyricsFollow}
         >
-          <div aria-hidden="true" className="lyrics-theater__edge" />
+          <div aria-hidden="true" className="lead-sheet__edge" />
           {displayedLyrics.map((segment, index) => {
-            const isActive = index === activeLyricsIndex;
-            const referenceIndex = activeLyricsIndex >= 0 ? activeLyricsIndex : -999;
-            const distance = Math.abs(index - referenceIndex);
             const segmentKey = `${segment.start_seconds}-${segment.end_seconds}-${index}`;
-            const canSeek = hasTimedLyrics(segment);
-            const content =
-              isActive && (segment.words?.length ?? 0) > 0 ? (
-                <span className="lyrics-segment__words">
-                  {(segment.words ?? []).map((word, wordIndex) => (
-                    <span
-                      key={`${segmentKey}-${wordIndex}-${word.start_seconds}`}
-                      className={`lyrics-word${
-                        wordIndex === activeLyricsWordIndex ? " lyrics-word--active" : ""
-                      }`}
-                    >
-                      {word.text}
-                    </span>
-                  ))}
-                </span>
-              ) : (
-                <span className="lyrics-segment__text">{segment.text}</span>
-              );
-            const distanceClass =
-              distance === 0
-                ? " lyrics-theater__segment--active"
-                : distance === 1
-                  ? " lyrics-theater__segment--near"
-                  : distance === 2
-                    ? " lyrics-theater__segment--far"
-                    : " lyrics-theater__segment--distant";
-
-            if (canSeek) {
-              return (
-                <button
-                  key={segmentKey}
-                  className={`lyrics-segment lyrics-theater__segment${distanceClass}`}
-                  type="button"
-                  ref={(element) => {
-                    lyricsSegmentRefs.current[segmentKey] = element;
-                  }}
-                  onClick={() => handleSeekTo(segment.start_seconds ?? 0)}
-                >
-                  <small>{formatPlaybackClock(segment.start_seconds ?? 0)}</small>
-                  {content}
-                </button>
-              );
-            }
-
+            const row: LeadSheetLyricsRow = {
+              activeWordIndex: index === activeLyricsIndex ? activeLyricsWordIndex : -1,
+              chords: [],
+              id: `lyrics-only-${segmentKey}`,
+              isActive: index === activeLyricsIndex,
+              lyricIndex: index,
+              segment,
+              type: "lyrics",
+            };
             return (
-              <div
+              <LeadSheetLyricsRowView
                 key={segmentKey}
-                className={`lyrics-segment lyrics-segment--static lyrics-theater__segment${distanceClass}`}
-              >
-                <small>Static</small>
-                {content}
-              </div>
+                row={row}
+                setRowRef={(element) => {
+                  lyricsSegmentRefs.current[segmentKey] = element;
+                }}
+              />
             );
           })}
-          <div aria-hidden="true" className="lyrics-theater__edge" />
+          <div aria-hidden="true" className="lead-sheet__edge" />
         </div>
       ) : (
         <EmptyPracticeState copy="Generate a lyrics pass to keep transcription and playback together while you practice." />
@@ -224,7 +200,7 @@ function LyricsPracticePanel() {
       ) : null}
       {hasTimedLyricsTranscript && showSupportingCopy ? (
         <div className="chord-context">
-          <span className="artifact-meta">Scroll inside lyrics to pause follow. Seek or play resumes it.</span>
+          <span className="artifact-meta">Follow keeps the active lyric in view while playback moves.</span>
         </div>
       ) : null}
       {lyricsSaveMutation.error ? (
@@ -312,9 +288,9 @@ function ChordsPracticePanel() {
     handleSeekTo,
     hasChordTimeline,
     nextChord,
-    pauseChordsFollow,
     showSupportingCopy,
   } = useProjectViewModelContext();
+  const handlePracticeTargetSpacePlayback = usePracticeTargetSpacePlayback();
 
   return (
     <div className="playback-practice-body playback-practice-body--chords">
@@ -369,8 +345,6 @@ function ChordsPracticePanel() {
           role="group"
           aria-label="Chord timeline"
           ref={chordTimelineRef}
-          onPointerDownCapture={pauseChordsFollow}
-          onWheel={pauseChordsFollow}
         >
           <div aria-hidden="true" className="chord-timeline__edge" />
           {displayedChords.map((segment, index) => {
@@ -389,6 +363,9 @@ function ChordsPracticePanel() {
                   ] = element;
                 }}
                 onClick={() => handleSeekTo(segment.start_seconds)}
+                onKeyDown={(event) =>
+                  handlePracticeTargetSpacePlayback(event, segment.start_seconds)
+                }
               >
                 <span>
                   <MusicalChordLabel
@@ -412,7 +389,7 @@ function ChordsPracticePanel() {
       )}
       {hasChordTimeline && showSupportingCopy ? (
         <div className="chord-context">
-          <span className="artifact-meta">Scroll inside chords to pause follow. Seek or play resumes it.</span>
+          <span className="artifact-meta">Follow keeps the active chord in view while playback moves.</span>
         </div>
       ) : null}
       {chordJob?.error_message ? <p className="inline-error">{chordJob.error_message}</p> : null}
@@ -432,7 +409,6 @@ function CombinedLeadSheetPanel() {
     isEditingLyrics,
     lyricsJob,
     lyricsSaveMutation,
-    pauseLyricsFollow,
     showSupportingCopy,
   } = useProjectViewModelContext();
 
@@ -448,9 +424,6 @@ function CombinedLeadSheetPanel() {
           role="group"
           aria-label="Lyrics and chords lead sheet"
           ref={combinedLeadSheetRef}
-          onPointerDownCapture={pauseLyricsFollow}
-          onTouchMove={pauseLyricsFollow}
-          onWheel={pauseLyricsFollow}
         >
           <div aria-hidden="true" className="lead-sheet__edge" />
           {combinedLeadSheetRows.map((row) => (
@@ -531,6 +504,7 @@ function LeadSheetLyricsRowView({
   setRowRef: (element: HTMLElement | null) => void;
 }) {
   const { handleSeekTo } = useProjectViewModelContext();
+  const handlePracticeTargetSpacePlayback = usePracticeTargetSpacePlayback();
   const canSeek = hasTimedLyrics(row.segment);
   const wordAnchoredChords = row.chords.filter((chord) => chord.anchor.type === "word");
   const percentAnchoredChords = row.chords.filter((chord) => chord.anchor.type === "percent");
@@ -554,10 +528,12 @@ function LeadSheetLyricsRowView({
       onKeyDown={
         canSeek
           ? (event) => {
-              if (event.key === "Enter" || event.key === " ") {
+              if (event.key === "Enter") {
                 event.preventDefault();
                 handleSeekTo(row.segment.start_seconds ?? 0);
+                return;
               }
+              handlePracticeTargetSpacePlayback(event, row.segment.start_seconds ?? 0);
             }
           : undefined
       }
@@ -600,6 +576,7 @@ function LeadSheetChordButton({ chord }: { chord: LeadSheetChord }) {
     enharmonicDisplayMode,
     handleSeekTo,
   } = useProjectViewModelContext();
+  const handlePracticeTargetSpacePlayback = usePracticeTargetSpacePlayback();
   const style =
     chord.anchor.type === "percent"
       ? ({ "--lead-sheet-chord-left": `${chord.anchor.percent}%` } as CSSProperties)
@@ -614,6 +591,9 @@ function LeadSheetChordButton({ chord }: { chord: LeadSheetChord }) {
         event.stopPropagation();
         handleSeekTo(chord.segment.start_seconds);
       }}
+      onKeyDown={(event) =>
+        handlePracticeTargetSpacePlayback(event, chord.segment.start_seconds)
+      }
     >
       <MusicalChordLabel
         activeKey={activeEnharmonicKeyContext}

--- a/apps/desktop/src/features/projects/components/PlaybackWorkspace.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackWorkspace.tsx
@@ -9,6 +9,7 @@ export function PlaybackWorkspace() {
     handleSeekTo,
     isPlaying,
     playbackDurationSeconds,
+    playbackTransportRef,
     playbackTimeSeconds,
     projectQuery,
     seekAnimationRevision,
@@ -21,7 +22,7 @@ export function PlaybackWorkspace() {
     <div className="playback-workspace playback-workspace--practice">
       <PlaybackPracticeRail />
       <PlaybackPracticeSurface />
-      <div className="panel playback-transport-dock">
+      <div className="panel playback-transport-dock" ref={playbackTransportRef}>
         <PlaybackTransport
           compact
           isPlaying={isPlaying}

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -108,12 +108,14 @@ export function useProjectViewModel() {
   const chordTimelineRef = useRef<HTMLDivElement | null>(null);
   const combinedLeadSheetRef = useRef<HTMLDivElement | null>(null);
   const combinedLeadSheetRowRefs = useRef<Record<string, HTMLElement | null>>({});
-  const lyricsSegmentRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const lyricsSegmentRefs = useRef<Record<string, HTMLElement | null>>({});
   const lyricsTheaterRef = useRef<HTMLDivElement | null>(null);
+  const playbackTransportRef = useRef<HTMLDivElement | null>(null);
   const pendingPreviewSelection = useRef<{ previousLatestPreviewArtifactId: string | null } | null>(
     null,
   );
   const persistedStemSourceArtifactId = useRef<string | null>(null);
+  const wasPlayingRef = useRef(isPlaying);
   const targetSelectorRef = useRef<HTMLDivElement | null>(null);
   const targetOptionRefs = useRef<Record<number, HTMLButtonElement | null>>({});
   const sourceKeySelectorRef = useRef<HTMLDivElement | null>(null);
@@ -145,8 +147,6 @@ export function useProjectViewModel() {
   const [lyricsDraft, setLyricsDraft] = useState<string[]>([]);
   const [lyricsFollowEnabled, setLyricsFollowEnabled] = useState(defaultLyricsFollowEnabled);
   const [chordsFollowEnabled, setChordsFollowEnabled] = useState(defaultChordsFollowEnabled);
-  const [lyricsFollowPaused, setLyricsFollowPaused] = useState(false);
-  const [chordsFollowPaused, setChordsFollowPaused] = useState(false);
   const showSupportingCopy = informationDensity !== "minimal";
 
   const projectQuery = useQuery({
@@ -706,11 +706,6 @@ export function useProjectViewModel() {
     setSelectedArtifactId(artifact.id);
   }
 
-  function resumePlaybackFollow() {
-    setLyricsFollowPaused(false);
-    setChordsFollowPaused(false);
-  }
-
   function handleSelectWorkspace(workspace: "project" | "playback") {
     setActiveWorkspace(workspace);
   }
@@ -718,7 +713,6 @@ export function useProjectViewModel() {
   function handleSetPlaybackDisplayMode(displayMode: PlaybackDisplayMode) {
     setPlaybackDisplayMode(displayMode);
     setPlaybackDisplayModeSource("user");
-    resumePlaybackFollow();
   }
 
   function handleTogglePlaybackDisplayLane(lane: "lyrics" | "chords") {
@@ -757,37 +751,17 @@ export function useProjectViewModel() {
 
   function handleSetLyricsFollowEnabled(enabled: boolean) {
     setLyricsFollowEnabled(enabled);
-    setLyricsFollowPaused(false);
   }
 
   function handleSetChordsFollowEnabled(enabled: boolean) {
     setChordsFollowEnabled(enabled);
-    setChordsFollowPaused(false);
-  }
-
-  function pauseLyricsFollow() {
-    if (!lyricsFollowEnabled) {
-      return;
-    }
-    setLyricsFollowPaused(true);
-  }
-
-  function pauseChordsFollow() {
-    if (!chordsFollowEnabled) {
-      return;
-    }
-    setChordsFollowPaused(true);
   }
 
   async function handleTogglePlayback() {
-    if (!isPlaying) {
-      resumePlaybackFollow();
-    }
     await togglePlayback();
   }
 
   function handleSeekTo(timeSeconds: number) {
-    resumePlaybackFollow();
     seekTo(timeSeconds);
   }
 
@@ -797,7 +771,6 @@ export function useProjectViewModel() {
       ...current,
       [direction]: current[direction] + 1,
     }));
-    resumePlaybackFollow();
     seekBy(secondsDelta);
   }
 
@@ -1047,8 +1020,6 @@ export function useProjectViewModel() {
         ? storedPlaybackState.chordsFollowEnabled
         : defaultChordsFollowEnabled,
     );
-    setLyricsFollowPaused(false);
-    setChordsFollowPaused(false);
     setStemControls(storedPlaybackState.stemControls);
     setDismissedStemJobIds(storedPlaybackState.dismissedStemJobIds);
     setHydratedProjectId(projectId);
@@ -1200,7 +1171,7 @@ export function useProjectViewModel() {
       activeWorkspace !== "playback" ||
       playbackDisplayMode !== "chords" ||
       !chordsFollowEnabled ||
-      chordsFollowPaused ||
+      !isPlaying ||
       activeChordIndex < 0
     ) {
       return;
@@ -1244,7 +1215,6 @@ export function useProjectViewModel() {
     activeChordIndex,
     activeWorkspace,
     chordsFollowEnabled,
-    chordsFollowPaused,
     displayedChords,
     isPlaying,
     playbackDisplayMode,
@@ -1255,7 +1225,7 @@ export function useProjectViewModel() {
       activeWorkspace !== "playback" ||
       playbackDisplayMode !== "lyrics" ||
       !lyricsFollowEnabled ||
-      lyricsFollowPaused ||
+      !isPlaying ||
       isEditingLyrics ||
       activeLyricsIndex < 0
     ) {
@@ -1298,12 +1268,12 @@ export function useProjectViewModel() {
     lyricsContainer.scrollTop = targetScrollTop;
   }, [
     activeLyricsIndex,
+    activeLyricsWordIndex,
     activeWorkspace,
     displayedLyrics,
     isEditingLyrics,
     isPlaying,
     lyricsFollowEnabled,
-    lyricsFollowPaused,
     playbackDisplayMode,
   ]);
 
@@ -1312,7 +1282,7 @@ export function useProjectViewModel() {
       activeWorkspace !== "playback" ||
       playbackDisplayMode !== "combined" ||
       !lyricsFollowEnabled ||
-      lyricsFollowPaused ||
+      !isPlaying ||
       isEditingLyrics
     ) {
       return;
@@ -1355,17 +1325,20 @@ export function useProjectViewModel() {
     isEditingLyrics,
     isPlaying,
     lyricsFollowEnabled,
-    lyricsFollowPaused,
     playbackDisplayMode,
   ]);
 
   useEffect(() => {
-    if (!isPlaying) {
+    const wasPlaying = wasPlayingRef.current;
+    wasPlayingRef.current = isPlaying;
+    if (wasPlaying || !isPlaying || activeWorkspace !== "playback") {
       return;
     }
-    setLyricsFollowPaused(false);
-    setChordsFollowPaused(false);
-  }, [isPlaying]);
+    playbackTransportRef.current?.scrollIntoView?.({
+      behavior: "smooth",
+      block: "end",
+    });
+  }, [activeWorkspace, isPlaying]);
 
   const currentSourceSummary = selectedPrimaryArtifact
     ? artifactSummary(selectedPrimaryArtifact) ||
@@ -1499,11 +1472,10 @@ export function useProjectViewModel() {
     lyricsSaveMutation,
     lyricsSegmentRefs,
     lyricsTheaterRef,
-    pauseChordsFollow,
-    pauseLyricsFollow,
     nextChord,
     playbackDisplayMode,
     playbackDurationSeconds,
+    playbackTransportRef,
     playbackTimeSeconds,
     previewArtifacts,
     previewMutation,

--- a/apps/desktop/src/features/projects/projectViewUtils.test.ts
+++ b/apps/desktop/src/features/projects/projectViewUtils.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { ChordSegmentSchema, JobSchema, LyricsSegmentSchema } from "../../lib/api";
-import { buildLeadSheetRows, formatJobStatusSummary, transposeChordSegment } from "./projectViewUtils";
+import {
+  buildLeadSheetRows,
+  findActiveLyricsIndex,
+  formatJobStatusSummary,
+  transposeChordSegment,
+} from "./projectViewUtils";
 
 function chord(startSeconds: number, endSeconds: number, label: string): ChordSegmentSchema {
   return {
@@ -93,6 +98,50 @@ describe("buildLeadSheetRows", () => {
 
     expect(rows.map((row) => row.type)).toEqual(["chords", "lyrics", "chords"]);
     expect(rows[2]?.isActive).toBe(true);
+  });
+});
+
+describe("findActiveLyricsIndex", () => {
+  it("prefers the next phrase once overlapping lyric segments start", () => {
+    const lyrics: LyricsSegmentSchema[] = [
+      {
+        end_seconds: 12,
+        start_seconds: 0,
+        text: "First overlapping phrase",
+        words: [],
+      },
+      {
+        end_seconds: 16,
+        start_seconds: 8,
+        text: "Second overlapping phrase",
+        words: [],
+      },
+    ];
+
+    expect(findActiveLyricsIndex(lyrics, 7.99)).toBe(0);
+    expect(findActiveLyricsIndex(lyrics, 7.9995)).toBe(1);
+    expect(findActiveLyricsIndex(lyrics, 8)).toBe(1);
+  });
+
+  it("keeps lyric gaps inactive outside seek precision tolerance", () => {
+    const lyrics: LyricsSegmentSchema[] = [
+      {
+        end_seconds: 4,
+        start_seconds: 0,
+        text: "Before the gap",
+        words: [],
+      },
+      {
+        end_seconds: 12,
+        start_seconds: 8,
+        text: "After the gap",
+        words: [],
+      },
+    ];
+
+    expect(findActiveLyricsIndex(lyrics, 5)).toBe(-1);
+    expect(findActiveLyricsIndex(lyrics, 7.99)).toBe(-1);
+    expect(findActiveLyricsIndex(lyrics, 7.9995)).toBe(1);
   });
 });
 

--- a/apps/desktop/src/features/projects/projectViewUtils.ts
+++ b/apps/desktop/src/features/projects/projectViewUtils.ts
@@ -265,15 +265,35 @@ export function hasTimedLyrics(
   return typeof segment.start_seconds === "number" && typeof segment.end_seconds === "number";
 }
 
+const ACTIVE_LYRIC_BOUNDARY_EPSILON_SECONDS = 0.005;
+
 export function findActiveLyricsIndex(timeline: LyricsSegmentSchema[], playbackTimeSeconds: number) {
+  for (let index = timeline.length - 1; index >= 0; index -= 1) {
+    const segment = timeline[index];
+    if (
+      segment &&
+      hasTimedLyrics(segment) &&
+      Math.abs(playbackTimeSeconds - segment.start_seconds) <= ACTIVE_LYRIC_BOUNDARY_EPSILON_SECONDS
+    ) {
+      return index;
+    }
+  }
+
   return timeline.findIndex((segment, index) => {
     if (!hasTimedLyrics(segment)) {
       return false;
     }
     const isLast = index === timeline.length - 1;
+    const nextTimedSegmentStart = timeline
+      .slice(index + 1)
+      .find((candidate) => typeof candidate.start_seconds === "number")?.start_seconds;
+    const effectiveEndSeconds =
+      !isLast && typeof nextTimedSegmentStart === "number"
+        ? Math.min(segment.end_seconds, nextTimedSegmentStart)
+        : segment.end_seconds;
     return (
       playbackTimeSeconds >= segment.start_seconds &&
-      (playbackTimeSeconds < segment.end_seconds || isLast)
+      (playbackTimeSeconds < effectiveEndSeconds || isLast)
     );
   });
 }

--- a/apps/desktop/src/styles/project-playback.css
+++ b/apps/desktop/src/styles/project-playback.css
@@ -520,12 +520,12 @@
   max-height: 33rem;
   min-height: 33rem;
   overflow-y: auto;
-  padding: 0.4rem 0.35rem 0.4rem 0;
+  padding: 0.5rem 0.65rem;
   scrollbar-gutter: stable;
 }
 
 .lyrics-theater__edge {
-  flex: 0 0 clamp(7rem, 18vh, 10rem);
+  flex: 0 0 clamp(1rem, 4vh, 2.5rem);
 }
 
 .lyrics-segment {
@@ -683,8 +683,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.85rem;
-  position: sticky;
-  top: 1rem;
+  position: static;
 }
 
 .playback-practice-rail__header {
@@ -787,7 +786,7 @@
 }
 
 .playback-practice-body--chords {
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 .lyrics-theater--practice {
@@ -796,7 +795,7 @@
 }
 
 .chord-preview-grid--hero {
-  margin: auto 0 1rem;
+  margin: 0 0 1rem;
 }
 
 .chord-preview-grid--hero .chord-card {
@@ -819,12 +818,12 @@
   min-height: min(42rem, calc(100vh - 20rem));
   max-height: min(42rem, calc(100vh - 20rem));
   overflow-y: auto;
-  padding: 0.45rem 0.45rem 0.45rem 0;
+  padding: 0.5rem 0.65rem;
   scrollbar-gutter: stable;
 }
 
 .lead-sheet__edge {
-  flex: 0 0 clamp(7rem, 18vh, 10rem);
+  flex: 0 0 clamp(1rem, 4vh, 2.5rem);
 }
 
 .lead-sheet__row {


### PR DESCRIPTION
## Summary
- Make playback follow toggles literal while playback is active, without pausing follow after manual scroll.
- Keep phrase, word, and chord highlighting independent of follow state.
- Reduce playback layout gaps, align lyrics-only with the combined lead sheet, and scroll to the transport when playback starts.
- Preserve phrase/chord seeking and Space playback behavior for practice workflows.
- Resolve active lyric phrases by the next segment start and tolerate near-boundary media seek precision.

## Testing
- `pnpm --filter @tuneforge/desktop test --run App.project-analysis-mix.test.tsx`
- `pnpm --filter @tuneforge/desktop test --run App.project-analysis-mix.test.tsx projectViewUtils.test.ts`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
