### PR TITLE
feat: add playback transpose capo control

### DIFF
--- a/apps/desktop/src/App.project-playback-stems.test.tsx
+++ b/apps/desktop/src/App.project-playback-stems.test.tsx
@@ -5,6 +5,7 @@ import {
   resetAppTestHarness,
   flushPendingPreview,
   findAudioByArtifactId,
+  getByAriaKeyLabel,
   getMockAudioContexts,
   getMockFetch,
   markAudioReady,
@@ -27,6 +28,21 @@ describe("Desktop app project playback stems", () => {
 
   async function openPlaybackWorkspace(user: ReturnType<typeof userEvent.setup>) {
     await user.click(screen.getByRole("tab", { name: "Playback" }));
+  }
+
+  async function switchToChordsOnly(user: ReturnType<typeof userEvent.setup>) {
+    const lyricsToggle = screen.getByRole("button", { name: "Lyrics" });
+    const chordsToggle = screen.getByRole("button", { name: "Chords" });
+    const lyricsPressed = lyricsToggle.getAttribute("aria-pressed") === "true";
+    const chordsPressed = chordsToggle.getAttribute("aria-pressed") === "true";
+    if (lyricsPressed && !chordsPressed) {
+      await user.click(chordsToggle);
+      await user.click(lyricsToggle);
+      return;
+    }
+    if (lyricsPressed && chordsPressed) {
+      await user.click(lyricsToggle);
+    }
   }
 
   async function ensureInspectorVisible(user: ReturnType<typeof userEvent.setup>) {
@@ -64,7 +80,7 @@ describe("Desktop app project playback stems", () => {
     await user.click(within(sourceList).getByRole("button", { name: /Source Track/i }));
 
     expect(await screen.findByRole("heading", { name: "Source Track" })).toBeInTheDocument();
-    expect(screen.getByText("Full playback")).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Playback source and mix list" })).toBeInTheDocument();
   });
 
   it("persists selected stem playback state across project reopen", async () => {
@@ -313,6 +329,83 @@ describe("Desktop app project playback stems", () => {
     expect(screen.getByRole("heading", { name: "Practice Mix" })).toBeInTheDocument();
     await waitFor(() => expect(newestPreviewAudio.currentTime).toBeCloseTo(61.437, 3));
     expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+  });
+
+  it("applies and persists a visual capo shift without creating a mix", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({
+        defaultSourcesRailCollapsed: false,
+        enharmonicDisplayMode: "sharps",
+      }),
+    );
+
+    const { unmount } = renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    await switchToChordsOnly(user);
+    expect(getByAriaKeyLabel(screen.getByRole("group", { name: "Current chord card" }), "G")).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Lower capo shift"));
+
+    expect(screen.getByText("Shift -1 semitone / 1st fret")).toBeInTheDocument();
+    expect(getByAriaKeyLabel(screen.getByRole("group", { name: "Current chord card" }), "F#")).toBeInTheDocument();
+    expect(mockCreatePreview).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(
+        JSON.parse(window.localStorage.getItem("tuneforge.project-playback-state") ?? "{}"),
+      ).toMatchObject({
+        proj_123: {
+          activeWorkspace: "playback",
+          capoTransposeSemitones: -1,
+        },
+      }),
+    );
+
+    unmount();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await switchToChordsOnly(user);
+    expect(getByAriaKeyLabel(screen.getByRole("group", { name: "Current chord card" }), "F#")).toBeInTheDocument();
+    expect(screen.getByText("Shift -1 semitone / 1st fret")).toBeInTheDocument();
+  });
+
+  it("keeps playback header compact outside detailed information density", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+
+    const rail = document.querySelector(".playback-practice-rail") as HTMLElement;
+    const sourceList = within(rail).getByRole("group", {
+      name: "Playback source and mix list",
+    });
+    expect(within(rail).queryByText("Full playback")).not.toBeInTheDocument();
+    expect(within(rail).queryAllByText("Original source file")).toHaveLength(1);
+    expect(within(sourceList).getByText("Original source file")).toBeInTheDocument();
+  });
+
+  it("shows playback header details at detailed information density", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({
+        defaultSourcesRailCollapsed: false,
+        informationDensity: "detailed",
+      }),
+    );
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+
+    const rail = document.querySelector(".playback-practice-rail") as HTMLElement;
+    expect(within(rail).getByText("Full playback")).toBeInTheDocument();
+    expect(within(rail).queryAllByText("Original source file")).toHaveLength(3);
   });
 
   it("restores active playback after app reload", async () => {

--- a/apps/desktop/src/features/projects/components/InspectorPanel.tsx
+++ b/apps/desktop/src/features/projects/components/InspectorPanel.tsx
@@ -1,7 +1,7 @@
 import { MusicalKeyLabel } from "../../../components/MusicalLabel";
 import { formatKey } from "../../../lib/music";
+import { TargetKeySelector } from "./TargetKeySelector";
 import { useProjectViewModelContext } from "./useProjectViewModelContext";
-import { MAX_TARGET_TRANSPOSE, MIN_TARGET_TRANSPOSE, clampTargetTranspose } from "../projectViewUtils";
 
 export function InspectorPanel() {
   const {
@@ -166,210 +166,32 @@ export function InspectorPanel() {
               </div>
             </div>
 
-            <div className="key-stepper__heading">
-              <span className="metric-label">Target Selection</span>
-              {showSupportingCopy ? (
-                <span className="artifact-meta">
-                  Step through all shifts from 1 octave down to 1 octave up.
-                </span>
-              ) : null}
-            </div>
-            <div className="key-stepper">
-              <button
-                className="button"
-                aria-label="Lower target key"
-                disabled={transposeSemitones <= MIN_TARGET_TRANSPOSE}
-                onClick={() => {
-                  setTargetSelectorOpen(false);
-                  setTargetTransposeSemitones((current) => clampTargetTranspose(current - 1));
-                }}
-                type="button"
-              >
-                -
-              </button>
-              <div className="key-stepper__value">
-                <div className="target-selector" ref={targetSelectorRef}>
-                  <button
-                    className={`target-selector__trigger${
-                      enharmonicDisplayMode === "dual" ? " target-selector__trigger--dual" : ""
-                    }`}
-                    aria-label="Target Key"
-                    aria-expanded={targetSelectorOpen}
-                    aria-haspopup="listbox"
-                    onClick={() => setTargetSelectorOpen((current) => !current)}
-                    type="button"
-                  >
-                    <span
-                      className={`target-selector__preview target-selector__preview--lower${
-                        !lowerTargetPreview ? " target-selector__preview--disabled" : ""
-                      }`}
-                    >
-                      {lowerTargetPreview ? (
-                        <MusicalKeyLabel
-                          keyValue={lowerTargetPreview}
-                          mode={enharmonicDisplayMode}
-                          variant="selector-preview"
-                        />
-                      ) : null}
-                    </span>
-                    <span
-                      className={`target-selector__current${
-                        enharmonicDisplayMode === "dual" ? " target-selector__current--dual" : ""
-                      }`}
-                    >
-                      <span
-                        className={`target-selector__current-key${
-                          enharmonicDisplayMode === "dual" ? " target-selector__current-key--dual" : ""
-                        }`}
-                      >
-                        <MusicalKeyLabel
-                          keyValue={targetKey}
-                          mode={enharmonicDisplayMode}
-                          variant="selector-current"
-                        />
-                      </span>
-                      <span className="target-selector__current-meta">
-                        {targetSelectionSummary}
-                      </span>
-                    </span>
-                    <span
-                      className={`target-selector__preview target-selector__preview--higher${
-                        !higherTargetPreview ? " target-selector__preview--disabled" : ""
-                      }`}
-                    >
-                      {higherTargetPreview ? (
-                        <MusicalKeyLabel
-                          keyValue={higherTargetPreview}
-                          mode={enharmonicDisplayMode}
-                          variant="selector-preview"
-                        />
-                      ) : null}
-                    </span>
-                    <span className="target-selector__chevron" aria-hidden="true">
-                      ⌄
-                    </span>
-                  </button>
-
-                  {targetSelectorOpen ? (
-                    <div
-                      className="target-selector__menu"
-                      role="listbox"
-                      aria-label="Target key options"
-                    >
-                      <div className="target-selector__group-label">Higher pitch</div>
-                      {higherTargetShiftOptions.map((option) => (
-                        <button
-                          key={option.semitones}
-                          ref={(node) => {
-                            targetOptionRefs.current[option.semitones] = node;
-                          }}
-                          className={`target-selector__option${
-                            option.semitones === transposeSemitones
-                              ? " target-selector__option--selected"
-                              : ""
-                          }`}
-                          role="option"
-                          aria-selected={option.semitones === transposeSemitones}
-                          onClick={() => {
-                            setTargetTransposeSemitones(option.semitones);
-                            setTargetSelectorOpen(false);
-                          }}
-                          type="button"
-                        >
-                          <span className="target-selector__option-direction" aria-hidden="true">
-                            ↑
-                          </span>
-                          <span className="target-selector__option-content">
-                            <span className="target-selector__option-label">
-                              <MusicalKeyLabel
-                                keyValue={option.key}
-                                mode={enharmonicDisplayMode}
-                                variant="selector-option"
-                              />
-                            </span>
-                          </span>
-                        </button>
-                      ))}
-                      <div className="target-selector__group-label">Original</div>
-                      <button
-                        ref={(node) => {
-                          targetOptionRefs.current[0] = node;
-                        }}
-                        className={`target-selector__option${
-                          transposeSemitones === 0 ? " target-selector__option--selected" : ""
-                        }`}
-                        role="option"
-                        aria-selected={transposeSemitones === 0}
-                        onClick={() => {
-                          setTargetTransposeSemitones(0);
-                          setTargetSelectorOpen(false);
-                        }}
-                        type="button"
-                      >
-                        <span className="target-selector__option-direction" aria-hidden="true">
-                          •
-                        </span>
-                        <span className="target-selector__option-content">
-                          <span className="target-selector__option-label">
-                            <MusicalKeyLabel
-                              keyValue={sourceKey}
-                              mode={enharmonicDisplayMode}
-                              variant="selector-option"
-                            />
-                          </span>
-                        </span>
-                      </button>
-                      <div className="target-selector__group-label">Lower pitch</div>
-                      {lowerTargetShiftOptions.map((option) => (
-                        <button
-                          key={option.semitones}
-                          ref={(node) => {
-                            targetOptionRefs.current[option.semitones] = node;
-                          }}
-                          className={`target-selector__option${
-                            option.semitones === transposeSemitones
-                              ? " target-selector__option--selected"
-                              : ""
-                          }`}
-                          role="option"
-                          aria-selected={option.semitones === transposeSemitones}
-                          onClick={() => {
-                            setTargetTransposeSemitones(option.semitones);
-                            setTargetSelectorOpen(false);
-                          }}
-                          type="button"
-                        >
-                          <span className="target-selector__option-direction" aria-hidden="true">
-                            ↓
-                          </span>
-                          <span className="target-selector__option-content">
-                            <span className="target-selector__option-label">
-                              <MusicalKeyLabel
-                                keyValue={option.key}
-                                mode={enharmonicDisplayMode}
-                                variant="selector-option"
-                              />
-                            </span>
-                          </span>
-                        </button>
-                      ))}
-                    </div>
-                  ) : null}
-                </div>
-              </div>
-              <button
-                className="button"
-                aria-label="Raise target key"
-                disabled={transposeSemitones >= MAX_TARGET_TRANSPOSE}
-                onClick={() => {
-                  setTargetSelectorOpen(false);
-                  setTargetTransposeSemitones((current) => clampTargetTranspose(current + 1));
-                }}
-                type="button"
-              >
-                +
-              </button>
-            </div>
+            <TargetKeySelector
+              currentKey={targetKey}
+              currentMeta={targetSelectionSummary}
+              enharmonicDisplayMode={enharmonicDisplayMode}
+              headingLabel="Target Selection"
+              higherButtonLabel="Raise target key"
+              higherPreview={higherTargetPreview}
+              higherTargetShiftOptions={higherTargetShiftOptions}
+              isOpen={targetSelectorOpen}
+              listboxLabel="Target key options"
+              lowerButtonLabel="Lower target key"
+              lowerPreview={lowerTargetPreview}
+              lowerTargetShiftOptions={lowerTargetShiftOptions}
+              optionRefs={targetOptionRefs}
+              selectorLabel="Target Key"
+              selectorRef={targetSelectorRef}
+              setIsOpen={setTargetSelectorOpen}
+              setSemitones={setTargetTransposeSemitones}
+              sourceKey={sourceKey}
+              supportingCopy={
+                showSupportingCopy
+                  ? "Step through all shifts from 1 octave down to 1 octave up."
+                  : null
+              }
+              value={transposeSemitones}
+            />
           </div>
         </div>
 

--- a/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
@@ -3,19 +3,36 @@ import {
   artifactSummary,
   formatArtifactTimestamp,
 } from "../projectViewUtils";
+import { TargetKeySelector } from "./TargetKeySelector";
 import { useProjectViewModelContext } from "./useProjectViewModelContext";
 
 export function PlaybackPracticeRail() {
   const {
+    capoKey,
+    capoOptionRefs,
+    capoSelectionSummary,
+    capoSelectorOpen,
+    capoSelectorRef,
+    capoSemitones,
+    capoShiftSummary,
+    enharmonicDisplayMode,
     handleSelectPrimaryArtifact,
     handleSelectStemArtifact,
+    higherCapoPreview,
+    higherTargetShiftOptions,
+    informationDensity,
     isStemPlayback,
+    lowerCapoPreview,
+    lowerTargetShiftOptions,
     previewArtifacts,
     selectedArtifactId,
     selectedArtifactTimestamp,
     selectedPlaybackArtifact,
     selectedPrimaryArtifact,
+    setCapoSelectorOpen,
+    setCapoTransposeSemitones,
     sourceArtifact,
+    sourceKey,
     stageModeLabel,
     stageSummary,
     stageTitle,
@@ -24,24 +41,54 @@ export function PlaybackPracticeRail() {
     toggleStemControl,
     visibleStemArtifacts,
   } = useProjectViewModelContext();
+  const showHeaderDetails =
+    informationDensity === "detailed" || selectedPlaybackArtifact?.type !== "source_audio";
 
   return (
     <aside className="panel playback-practice-rail">
       <div className="playback-practice-rail__header">
         <p className="metric-label">Playback</p>
         <h2>{stageTitle}</h2>
-        <p className="artifact-meta">{stageSummary}</p>
-        <div className="playback-workspace__summary-meta playback-workspace__summary-meta--inline">
-          <span>{stageModeLabel}</span>
-          {selectedArtifactTimestamp ? <span>{selectedArtifactTimestamp}</span> : null}
-          {selectedPlaybackArtifact ? (
-            <span>
-              {artifactSummary(selectedPlaybackArtifact) ||
-                formatArtifactTimestamp(selectedPlaybackArtifact.created_at)}
-            </span>
-          ) : null}
-        </div>
+        {showHeaderDetails ? <p className="artifact-meta">{stageSummary}</p> : null}
+        {showHeaderDetails ? (
+          <div className="playback-workspace__summary-meta playback-workspace__summary-meta--inline">
+            <span>{stageModeLabel}</span>
+            {selectedArtifactTimestamp ? <span>{selectedArtifactTimestamp}</span> : null}
+            {selectedPlaybackArtifact ? (
+              <span>
+                {artifactSummary(selectedPlaybackArtifact) ||
+                  formatArtifactTimestamp(selectedPlaybackArtifact.created_at)}
+              </span>
+            ) : null}
+          </div>
+        ) : null}
       </div>
+
+      <section className="playback-capo-control">
+        <TargetKeySelector
+          currentKey={capoKey}
+          currentMeta={capoSelectionSummary}
+          enharmonicDisplayMode={enharmonicDisplayMode}
+          headingLabel="Transpose / Capo"
+          higherButtonLabel="Raise capo shift"
+          higherPreview={higherCapoPreview}
+          higherTargetShiftOptions={higherTargetShiftOptions}
+          isOpen={capoSelectorOpen}
+          listboxLabel="Capo shift options"
+          lowerButtonLabel="Lower capo shift"
+          lowerPreview={lowerCapoPreview}
+          lowerTargetShiftOptions={lowerTargetShiftOptions}
+          optionRefs={capoOptionRefs}
+          selectorLabel="Capo Shift"
+          selectorRef={capoSelectorRef}
+          setIsOpen={setCapoSelectorOpen}
+          setSemitones={setCapoTransposeSemitones}
+          showCompactControls
+          sourceKey={sourceKey}
+          value={capoSemitones}
+        />
+        <p className="artifact-meta playback-capo-control__summary">{capoShiftSummary}</p>
+      </section>
 
       <section className="playback-picker-group playback-picker-group--compact">
         <div className="playback-picker-group__header">

--- a/apps/desktop/src/features/projects/components/TargetKeySelector.tsx
+++ b/apps/desktop/src/features/projects/components/TargetKeySelector.tsx
@@ -1,0 +1,254 @@
+import type { Dispatch, MutableRefObject, RefObject, SetStateAction } from "react";
+import { MusicalKeyLabel } from "../../../components/MusicalLabel";
+import type { EnharmonicDisplayMode, MusicalKey } from "../../../lib/music";
+import {
+  MAX_TARGET_TRANSPOSE,
+  MIN_TARGET_TRANSPOSE,
+  clampTargetTranspose,
+  type TargetShiftOption,
+} from "../projectViewUtils";
+
+type TargetKeySelectorProps = {
+  currentKey: MusicalKey;
+  currentMeta: string;
+  enharmonicDisplayMode: EnharmonicDisplayMode;
+  headingLabel: string;
+  higherButtonLabel: string;
+  higherPreview: MusicalKey | null;
+  higherTargetShiftOptions: TargetShiftOption[];
+  isOpen: boolean;
+  listboxLabel: string;
+  lowerButtonLabel: string;
+  lowerPreview: MusicalKey | null;
+  lowerTargetShiftOptions: TargetShiftOption[];
+  optionRefs: MutableRefObject<Record<number, HTMLButtonElement | null>>;
+  selectorLabel: string;
+  selectorRef: RefObject<HTMLDivElement | null>;
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
+  setSemitones: Dispatch<SetStateAction<number>>;
+  showCompactControls?: boolean;
+  sourceKey: MusicalKey;
+  supportingCopy?: string | null;
+  value: number;
+};
+
+export function TargetKeySelector({
+  currentKey,
+  currentMeta,
+  enharmonicDisplayMode,
+  headingLabel,
+  higherButtonLabel,
+  higherPreview,
+  higherTargetShiftOptions,
+  isOpen,
+  listboxLabel,
+  lowerButtonLabel,
+  lowerPreview,
+  lowerTargetShiftOptions,
+  optionRefs,
+  selectorLabel,
+  selectorRef,
+  setIsOpen,
+  setSemitones,
+  showCompactControls = false,
+  sourceKey,
+  supportingCopy,
+  value,
+}: TargetKeySelectorProps) {
+  const compactClass = showCompactControls ? " key-stepper--small" : "";
+
+  return (
+    <>
+      <div className="key-stepper__heading">
+        <span className="metric-label">{headingLabel}</span>
+        {supportingCopy ? <span className="artifact-meta">{supportingCopy}</span> : null}
+      </div>
+      <div className={`key-stepper${compactClass}`}>
+        <button
+          className="button"
+          aria-label={lowerButtonLabel}
+          disabled={value <= MIN_TARGET_TRANSPOSE}
+          onClick={() => {
+            setIsOpen(false);
+            setSemitones((current) => clampTargetTranspose(current - 1));
+          }}
+          type="button"
+        >
+          -
+        </button>
+        <div className="key-stepper__value">
+          <div className="target-selector" ref={selectorRef}>
+            <button
+              className={`target-selector__trigger${
+                enharmonicDisplayMode === "dual" ? " target-selector__trigger--dual" : ""
+              }`}
+              aria-label={selectorLabel}
+              aria-expanded={isOpen}
+              aria-haspopup="listbox"
+              onClick={() => setIsOpen((current) => !current)}
+              type="button"
+            >
+              <span
+                className={`target-selector__preview target-selector__preview--lower${
+                  !lowerPreview ? " target-selector__preview--disabled" : ""
+                }`}
+              >
+                {lowerPreview ? (
+                  <MusicalKeyLabel
+                    keyValue={lowerPreview}
+                    mode={enharmonicDisplayMode}
+                    variant="selector-preview"
+                  />
+                ) : null}
+              </span>
+              <span
+                className={`target-selector__current${
+                  enharmonicDisplayMode === "dual" ? " target-selector__current--dual" : ""
+                }`}
+              >
+                <span
+                  className={`target-selector__current-key${
+                    enharmonicDisplayMode === "dual" ? " target-selector__current-key--dual" : ""
+                  }`}
+                >
+                  <MusicalKeyLabel
+                    keyValue={currentKey}
+                    mode={enharmonicDisplayMode}
+                    variant="selector-current"
+                  />
+                </span>
+                <span className="target-selector__current-meta">{currentMeta}</span>
+              </span>
+              <span
+                className={`target-selector__preview target-selector__preview--higher${
+                  !higherPreview ? " target-selector__preview--disabled" : ""
+                }`}
+              >
+                {higherPreview ? (
+                  <MusicalKeyLabel
+                    keyValue={higherPreview}
+                    mode={enharmonicDisplayMode}
+                    variant="selector-preview"
+                  />
+                ) : null}
+              </span>
+              <span className="target-selector__chevron" aria-hidden="true">
+                ⌄
+              </span>
+            </button>
+
+            {isOpen ? (
+              <div className="target-selector__menu" role="listbox" aria-label={listboxLabel}>
+                <div className="target-selector__group-label">Higher pitch</div>
+                {higherTargetShiftOptions.map((option) => (
+                  <button
+                    key={option.semitones}
+                    ref={(node) => {
+                      optionRefs.current[option.semitones] = node;
+                    }}
+                    className={`target-selector__option${
+                      option.semitones === value ? " target-selector__option--selected" : ""
+                    }`}
+                    role="option"
+                    aria-selected={option.semitones === value}
+                    onClick={() => {
+                      setSemitones(option.semitones);
+                      setIsOpen(false);
+                    }}
+                    type="button"
+                  >
+                    <span className="target-selector__option-direction" aria-hidden="true">
+                      ↑
+                    </span>
+                    <span className="target-selector__option-content">
+                      <span className="target-selector__option-label">
+                        <MusicalKeyLabel
+                          keyValue={option.key}
+                          mode={enharmonicDisplayMode}
+                          variant="selector-option"
+                        />
+                      </span>
+                    </span>
+                  </button>
+                ))}
+                <div className="target-selector__group-label">Original</div>
+                <button
+                  ref={(node) => {
+                    optionRefs.current[0] = node;
+                  }}
+                  className={`target-selector__option${
+                    value === 0 ? " target-selector__option--selected" : ""
+                  }`}
+                  role="option"
+                  aria-selected={value === 0}
+                  onClick={() => {
+                    setSemitones(0);
+                    setIsOpen(false);
+                  }}
+                  type="button"
+                >
+                  <span className="target-selector__option-direction" aria-hidden="true">
+                    •
+                  </span>
+                  <span className="target-selector__option-content">
+                    <span className="target-selector__option-label">
+                      <MusicalKeyLabel
+                        keyValue={sourceKey}
+                        mode={enharmonicDisplayMode}
+                        variant="selector-option"
+                      />
+                    </span>
+                  </span>
+                </button>
+                <div className="target-selector__group-label">Lower pitch</div>
+                {lowerTargetShiftOptions.map((option) => (
+                  <button
+                    key={option.semitones}
+                    ref={(node) => {
+                      optionRefs.current[option.semitones] = node;
+                    }}
+                    className={`target-selector__option${
+                      option.semitones === value ? " target-selector__option--selected" : ""
+                    }`}
+                    role="option"
+                    aria-selected={option.semitones === value}
+                    onClick={() => {
+                      setSemitones(option.semitones);
+                      setIsOpen(false);
+                    }}
+                    type="button"
+                  >
+                    <span className="target-selector__option-direction" aria-hidden="true">
+                      ↓
+                    </span>
+                    <span className="target-selector__option-content">
+                      <span className="target-selector__option-label">
+                        <MusicalKeyLabel
+                          keyValue={option.key}
+                          mode={enharmonicDisplayMode}
+                          variant="selector-option"
+                        />
+                      </span>
+                    </span>
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </div>
+        <button
+          className="button"
+          aria-label={higherButtonLabel}
+          disabled={value >= MAX_TARGET_TRANSPOSE}
+          onClick={() => {
+            setIsOpen(false);
+            setSemitones((current) => clampTargetTranspose(current + 1));
+          }}
+          type="button"
+        >
+          +
+        </button>
+      </div>
+    </>
+  );
+}

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -36,6 +36,7 @@ import {
   findActiveLyricsIndex,
   findActiveLyricsWordIndex,
   formatArtifactTimestamp,
+  formatCapoShiftSummary,
   formatRetuneSummary,
   formatSemitoneShift,
   formatTargetSelectionSummary,
@@ -118,6 +119,8 @@ export function useProjectViewModel() {
   const wasPlayingRef = useRef(isPlaying);
   const targetSelectorRef = useRef<HTMLDivElement | null>(null);
   const targetOptionRefs = useRef<Record<number, HTMLButtonElement | null>>({});
+  const capoSelectorRef = useRef<HTMLDivElement | null>(null);
+  const capoOptionRefs = useRef<Record<number, HTMLButtonElement | null>>({});
   const sourceKeySelectorRef = useRef<HTMLDivElement | null>(null);
   const sourceKeyOptionRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const [retuneMode, setRetuneMode] = useState<"off" | "reference" | "cents">("off");
@@ -129,6 +132,8 @@ export function useProjectViewModel() {
   });
   const [targetTransposeSemitones, setTargetTransposeSemitones] = useState(0);
   const [targetSelectorOpen, setTargetSelectorOpen] = useState(false);
+  const [capoTransposeSemitones, setCapoTransposeSemitones] = useState(0);
+  const [capoSelectorOpen, setCapoSelectorOpen] = useState(false);
   const [sourceKeySelectorOpen, setSourceKeySelectorOpen] = useState(false);
   const [selectedArtifactId, setSelectedArtifactId] = useState<string | null>(null);
   const [selectedPrimaryArtifactId, setSelectedPrimaryArtifactId] = useState<string | null>(null);
@@ -531,6 +536,8 @@ export function useProjectViewModel() {
   const sourceKey = sourceKeyBasis ?? DEFAULT_KEY;
   const transposeSemitones = clampTargetTranspose(targetTransposeSemitones);
   const targetKey = transposeKey(sourceKey, transposeSemitones);
+  const capoSemitones = clampTargetTranspose(capoTransposeSemitones);
+  const capoKey = transposeKey(sourceKey, capoSemitones);
   const hasTransformChange = retuneMode !== "off" || transposeSemitones !== 0;
   const isAnalysisRunning = Boolean(
     analyzeJob && ["pending", "running"].includes(analyzeJob.status),
@@ -569,9 +576,10 @@ export function useProjectViewModel() {
     selectedPlaybackArtifact,
     selectableArtifacts,
   );
-  const displayedChordSemitones = chordTransposeSemitones + correctedSourceChordSemitones;
+  const displayedChordSemitones =
+    chordTransposeSemitones + correctedSourceChordSemitones + capoSemitones;
   const activeEnharmonicKeyContext = sourceKeyBasis
-    ? transposeKey(sourceKeyBasis, chordTransposeSemitones)
+    ? transposeKey(sourceKeyBasis, chordTransposeSemitones + capoSemitones)
     : null;
   const displayedChords = useMemo(
     () =>
@@ -615,7 +623,7 @@ export function useProjectViewModel() {
       }),
     [activeChordIndex, activeLyricsIndex, activeLyricsWordIndex, displayedChords, displayedLyrics],
   );
-  const chordContextCopy =
+  const baseChordContextCopy =
     correctedSourceChordSemitones === 0 && chordTransposeSemitones === 0
       ? "Chord labels follow the original arrangement."
       : correctedSourceChordSemitones !== 0 && chordTransposeSemitones === 0
@@ -627,10 +635,18 @@ export function useProjectViewModel() {
           : `Chord labels follow corrected source key and selected playback (${formatSemitoneShift(
           chordTransposeSemitones,
         ).toLowerCase()}).`;
+  const chordContextCopy =
+    capoSemitones === 0
+      ? baseChordContextCopy
+      : `${baseChordContextCopy} Visual capo: ${formatCapoShiftSummary(
+          capoSemitones,
+        ).toLowerCase()}.`;
   const sourceKeyStatus = sourceKeyOverride ? "Corrected" : detectedKey ? "Detected" : "Default";
   const targetShiftSummary =
     transposeSemitones === 0 ? "Original key" : formatSemitoneShift(transposeSemitones);
   const targetSelectionSummary = formatTargetSelectionSummary(transposeSemitones);
+  const capoShiftSummary = formatCapoShiftSummary(capoSemitones);
+  const capoSelectionSummary = formatTargetSelectionSummary(capoSemitones);
   const sourceKeySelectorCurrentKey = sourceKeyOverride ?? detectedKey ?? sourceKey;
   const sourceKeySelectorCurrentBadge = sourceKeyOverride ? null : detectedKey ? "Original" : "No override";
   const lowerTargetPreview =
@@ -641,6 +657,10 @@ export function useProjectViewModel() {
     transposeSemitones < MAX_TARGET_TRANSPOSE
       ? transposeKey(sourceKey, transposeSemitones + 1)
       : null;
+  const lowerCapoPreview =
+    capoSemitones > MIN_TARGET_TRANSPOSE ? transposeKey(sourceKey, capoSemitones - 1) : null;
+  const higherCapoPreview =
+    capoSemitones < MAX_TARGET_TRANSPOSE ? transposeKey(sourceKey, capoSemitones + 1) : null;
   const targetShiftOptions = useMemo<TargetShiftOption[]>(
     () =>
       Array.from(
@@ -946,6 +966,15 @@ export function useProjectViewModel() {
   }, [targetSelectorOpen, transposeSemitones]);
 
   useEffect(() => {
+    if (!capoSelectorOpen) {
+      return;
+    }
+
+    const activeOption = capoOptionRefs.current[capoSemitones];
+    activeOption?.scrollIntoView?.({ block: "center" });
+  }, [capoSelectorOpen, capoSemitones]);
+
+  useEffect(() => {
     if (!sourceKeySelectorOpen) {
       return;
     }
@@ -955,18 +984,22 @@ export function useProjectViewModel() {
   }, [currentKeyValue, sourceKeySelectorOpen]);
 
   useEffect(() => {
-    if (!targetSelectorOpen && !sourceKeySelectorOpen) {
+    if (!targetSelectorOpen && !sourceKeySelectorOpen && !capoSelectorOpen) {
       return;
     }
 
     function handlePointerDown(event: PointerEvent) {
       const targetInside = targetSelectorRef.current?.contains(event.target as Node) ?? false;
       const sourceInside = sourceKeySelectorRef.current?.contains(event.target as Node) ?? false;
+      const capoInside = capoSelectorRef.current?.contains(event.target as Node) ?? false;
       if (!targetInside) {
         setTargetSelectorOpen(false);
       }
       if (!sourceInside) {
         setSourceKeySelectorOpen(false);
+      }
+      if (!capoInside) {
+        setCapoSelectorOpen(false);
       }
     }
 
@@ -974,6 +1007,7 @@ export function useProjectViewModel() {
       if (event.key === "Escape") {
         setTargetSelectorOpen(false);
         setSourceKeySelectorOpen(false);
+        setCapoSelectorOpen(false);
       }
     }
 
@@ -984,7 +1018,7 @@ export function useProjectViewModel() {
       window.removeEventListener("pointerdown", handlePointerDown);
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [sourceKeySelectorOpen, targetSelectorOpen]);
+  }, [capoSelectorOpen, sourceKeySelectorOpen, targetSelectorOpen]);
 
   useEffect(() => {
     setInspectorOpen(defaultInspectorOpen);
@@ -1009,6 +1043,7 @@ export function useProjectViewModel() {
         ? storedPlaybackState.playbackDisplayMode
         : resolveDefaultPlaybackDisplayMode(defaultPlaybackDisplayMode, false, false),
     );
+    setCapoTransposeSemitones(storedPlaybackState.capoTransposeSemitones);
     setPlaybackDisplayModeSource(hasStoredPlayback ? "stored" : "default");
     setLyricsFollowEnabled(
       hasStoredPlayback
@@ -1147,6 +1182,7 @@ export function useProjectViewModel() {
       selectedStemSourceArtifactId,
       activeWorkspace,
       playbackDisplayMode,
+      capoTransposeSemitones: capoSemitones,
       lyricsFollowEnabled,
       chordsFollowEnabled,
       stemControls,
@@ -1154,6 +1190,7 @@ export function useProjectViewModel() {
     });
   }, [
     activeWorkspace,
+    capoSemitones,
     chordsFollowEnabled,
     dismissedStemJobIds,
     hydratedProjectId,
@@ -1406,6 +1443,13 @@ export function useProjectViewModel() {
     canGenerateChords,
     canGenerateLyrics,
     canGenerateStems,
+    capoKey,
+    capoOptionRefs,
+    capoSelectionSummary,
+    capoSelectorOpen,
+    capoSelectorRef,
+    capoSemitones,
+    capoShiftSummary,
     chordContextCopy,
     chordJob,
     chordMutation,
@@ -1447,6 +1491,7 @@ export function useProjectViewModel() {
     hasTimedLyricsTranscript,
     hasTransformChange,
     hasVisibleStems,
+    higherCapoPreview,
     higherTargetPreview,
     higherTargetShiftOptions,
     informationDensity,
@@ -1461,6 +1506,7 @@ export function useProjectViewModel() {
     isStemPlayback,
     isStemRunning,
     latestPreviewArtifact,
+    lowerCapoPreview,
     lowerTargetPreview,
     lowerTargetShiftOptions,
     mobileCapabilities,
@@ -1490,6 +1536,8 @@ export function useProjectViewModel() {
     selectedPlaybackArtifact,
     selectedPrimaryArtifact,
     selectedPrimaryArtifactId,
+    setCapoSelectorOpen,
+    setCapoTransposeSemitones,
     setCentsOffset,
     setDismissedStemJobIds,
     setDraftName,

--- a/apps/desktop/src/features/projects/projectPlaybackState.ts
+++ b/apps/desktop/src/features/projects/projectPlaybackState.ts
@@ -16,6 +16,7 @@ export type StoredProjectPlaybackState = {
   selectedStemSourceArtifactId: string | null;
   activeWorkspace: ProjectWorkspaceMode;
   playbackDisplayMode: PlaybackDisplayMode;
+  capoTransposeSemitones: number;
   lyricsFollowEnabled: boolean;
   chordsFollowEnabled: boolean;
   stemControls: Record<string, StemControlState>;
@@ -30,11 +31,19 @@ const DEFAULT_STORED_PROJECT_PLAYBACK_STATE: StoredProjectPlaybackState = {
   selectedStemSourceArtifactId: null,
   activeWorkspace: "project",
   playbackDisplayMode: "combined",
+  capoTransposeSemitones: 0,
   lyricsFollowEnabled: true,
   chordsFollowEnabled: true,
   stemControls: {},
   dismissedStemJobIds: [],
 };
+
+function normalizeTransposeSemitones(value: unknown) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.min(12, Math.max(-12, Math.trunc(value)));
+}
 
 function normalizeStemControlState(value: unknown): StemControlState {
   if (!value || typeof value !== "object") {
@@ -85,6 +94,7 @@ function normalizeStoredProjectPlaybackState(value: unknown): StoredProjectPlayb
     playbackDisplayMode: isPlaybackDisplayMode(candidate.playbackDisplayMode)
       ? candidate.playbackDisplayMode
       : DEFAULT_STORED_PROJECT_PLAYBACK_STATE.playbackDisplayMode,
+    capoTransposeSemitones: normalizeTransposeSemitones(candidate.capoTransposeSemitones),
     lyricsFollowEnabled:
       typeof candidate.lyricsFollowEnabled === "boolean"
         ? candidate.lyricsFollowEnabled

--- a/apps/desktop/src/features/projects/projectViewUtils.ts
+++ b/apps/desktop/src/features/projects/projectViewUtils.ts
@@ -45,6 +45,31 @@ export function formatSemitoneShift(semitones: number) {
   return `Shift ${semitones > 0 ? "+" : ""}${semitones} semitone${Math.abs(semitones) === 1 ? "" : "s"}`;
 }
 
+function formatOrdinal(value: number) {
+  const lastTwoDigits = value % 100;
+  if (lastTwoDigits >= 11 && lastTwoDigits <= 13) {
+    return `${value}th`;
+  }
+  if (value % 10 === 1) {
+    return `${value}st`;
+  }
+  if (value % 10 === 2) {
+    return `${value}nd`;
+  }
+  if (value % 10 === 3) {
+    return `${value}rd`;
+  }
+  return `${value}th`;
+}
+
+export function formatCapoShiftSummary(semitones: number) {
+  const shiftSummary = formatSemitoneShift(semitones);
+  if (semitones >= 0) {
+    return shiftSummary;
+  }
+  return `${shiftSummary} / ${formatOrdinal(Math.abs(semitones))} fret`;
+}
+
 export const MIN_TARGET_TRANSPOSE = -12;
 export const MAX_TARGET_TRANSPOSE = 12;
 

--- a/apps/desktop/src/styles/musical-labels.css
+++ b/apps/desktop/src/styles/musical-labels.css
@@ -222,3 +222,55 @@
   min-width: 0;
 }
 
+.key-stepper--small {
+  gap: 0.45rem;
+  padding: 0.55rem;
+  border-radius: 16px;
+}
+
+.key-stepper--small > .button {
+  min-width: 3rem;
+  min-height: 3.55rem;
+  font-size: 1.35rem;
+  border-radius: 16px;
+}
+
+.key-stepper--small .target-selector__trigger {
+  min-height: 3.45rem;
+}
+
+.key-stepper--small .target-selector__preview {
+  min-height: 3rem;
+  padding: 0.28rem 0.22rem 0.62rem;
+  font-size: 0.78rem;
+}
+
+.key-stepper--small .target-selector__current {
+  min-height: 3rem;
+  margin-inline: 0.1rem;
+  padding: 0.38rem 0.48rem 0.68rem;
+}
+
+.key-stepper--small .target-selector__current-key {
+  font-size: 1.5rem;
+  letter-spacing: 0;
+}
+
+.key-stepper--small .target-selector__current-key--dual {
+  font-size: 1.2rem;
+}
+
+.key-stepper--small .target-selector__current-meta {
+  font-size: 0.58rem;
+  letter-spacing: 0.06em;
+}
+
+.key-stepper--small .target-selector__chevron {
+  font-size: 0.92rem;
+}
+
+.key-stepper--small .target-selector__menu {
+  width: min(100%, 17rem);
+  max-height: 15rem;
+  border-radius: 18px;
+}

--- a/apps/desktop/src/styles/project-playback.css
+++ b/apps/desktop/src/styles/project-playback.css
@@ -702,6 +702,24 @@
   margin-top: 0.2rem;
 }
 
+.playback-capo-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 0.8rem;
+  border: 1px solid var(--divider);
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--surface-muted) 76%, transparent);
+}
+
+.playback-capo-control .key-stepper__heading {
+  margin-bottom: 0;
+}
+
+.playback-capo-control__summary {
+  margin: 0;
+}
+
 .playback-picker-group--compact {
   padding: 0.85rem;
   border-radius: 18px;


### PR DESCRIPTION
## Summary

- Add a playback-side Transpose / Capo selector that visually shifts displayed chords only.
- Reuse the key selector UI across inspector and playback, with a compact playback variant.
- Persist the per-project visual capo shift and keep source-track header details behind detailed density.

## Testing

- `pnpm --filter @tuneforge/desktop test --run`
- `pnpm --filter @tuneforge/desktop test --run src/App.project-playback-stems.test.tsx`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
