### PR TITLE
fix: use playback key for capo selector

### DIFF
--- a/apps/desktop/src/App.project-playback-stems.test.tsx
+++ b/apps/desktop/src/App.project-playback-stems.test.tsx
@@ -74,7 +74,7 @@ describe("Desktop app project playback stems", () => {
     await user.click(within(stemList).getAllByRole("button", { name: /Vocals/i })[0] as HTMLElement);
 
     expect(await screen.findByRole("heading", { name: "Vocals" })).toBeInTheDocument();
-    expect(screen.getByText("Stem monitor")).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Playback stem list" })).toBeInTheDocument();
 
     const sourceList = screen.getByRole("group", { name: "Playback source and mix list" });
     await user.click(within(sourceList).getByRole("button", { name: /Source Track/i }));
@@ -114,7 +114,7 @@ describe("Desktop app project playback stems", () => {
     await user.click(reopenDemoLinks[reopenDemoLinks.length - 1] as HTMLElement);
 
     expect(await screen.findByRole("heading", { name: "Vocals" })).toBeInTheDocument();
-    expect(screen.getByText("Stem monitor")).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Playback stem list" })).toBeInTheDocument();
   });
 
   it("restores mix-owned stems after reopening the project", async () => {
@@ -196,7 +196,7 @@ describe("Desktop app project playback stems", () => {
     await user.click(reopenDemoLinks[reopenDemoLinks.length - 1] as HTMLElement);
 
     expect(await screen.findByRole("heading", { name: "Vocals" })).toBeInTheDocument();
-    expect(screen.getByText("Stem monitor")).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Playback stem list" })).toBeInTheDocument();
   });
 
   it("toggles playback with spacebar and preserves time when switching mixes", async () => {
@@ -373,6 +373,30 @@ describe("Desktop app project playback stems", () => {
     expect(screen.getByText("Shift -1 semitone / 1st fret")).toBeInTheDocument();
   });
 
+  it("bases the visual capo selector on the selected practice mix key", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({
+        defaultSourcesRailCollapsed: false,
+        enharmonicDisplayMode: "sharps",
+      }),
+    );
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const savedMixList = screen.getByRole("group", { name: "Saved mix list" });
+    await user.click(within(savedMixList).getByRole("button", { name: /Practice Mix/i }));
+
+    await openPlaybackWorkspace(user);
+    await switchToChordsOnly(user);
+    await user.click(screen.getByLabelText("Lower capo shift"));
+
+    expect(screen.getByText("Shift -1 semitone / 1st fret")).toBeInTheDocument();
+    expect(getByAriaKeyLabel(screen.getByRole("group", { name: "Current chord card" }), "G#")).toBeInTheDocument();
+    expect(getByAriaKeyLabel(screen.getByLabelText("Capo Shift"), "G#")).toBeInTheDocument();
+  });
+
   it("keeps playback header compact outside detailed information density", async () => {
     const user = userEvent.setup();
     renderApp(["/projects/proj_123"]);
@@ -387,6 +411,30 @@ describe("Desktop app project playback stems", () => {
     expect(within(rail).queryByText("Full playback")).not.toBeInTheDocument();
     expect(within(rail).queryAllByText("Original source file")).toHaveLength(1);
     expect(within(sourceList).getByText("Original source file")).toBeInTheDocument();
+
+    await user.click(within(sourceList).getByRole("button", { name: /Practice Mix/i }));
+    const header = rail.querySelector(".playback-practice-rail__header") as HTMLElement;
+    expect(await within(header).findByRole("heading", { name: "Practice Mix" })).toBeInTheDocument();
+    expect(within(header).queryByText("Full playback")).not.toBeInTheDocument();
+    expect(within(header).queryByText("Shift +2 semitones")).not.toBeInTheDocument();
+  });
+
+  it("keeps stem playback header compact outside detailed information density", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    await openPlaybackWorkspace(user);
+    const stemList = await screen.findByRole("group", { name: "Playback stem list" });
+    await user.click(within(stemList).getAllByRole("button", { name: /Vocals/i })[0] as HTMLElement);
+    const rail = document.querySelector(".playback-practice-rail") as HTMLElement;
+    const header = rail.querySelector(".playback-practice-rail__header") as HTMLElement;
+
+    expect(await within(header).findByRole("heading", { name: "Vocals" })).toBeInTheDocument();
+    expect(within(header).queryByText("Stem monitor")).not.toBeInTheDocument();
+    expect(within(header).queryByText("2 of 2 stems audible")).not.toBeInTheDocument();
   });
 
   it("shows playback header details at detailed information density", async () => {
@@ -542,7 +590,7 @@ describe("Desktop app project playback stems", () => {
     );
     expect(vocalAudio).toHaveAttribute("preload", "metadata");
     expect(instrumentalAudio).toHaveAttribute("preload", "metadata");
-    expect(screen.getByText("Full playback")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Source Track" })).toBeInTheDocument();
   });
 
   it("reuses the shared stem clock when returning to stems after pausing", async () => {
@@ -602,7 +650,7 @@ describe("Desktop app project playback stems", () => {
 
     expect(soloVocals).toHaveAttribute("aria-pressed", "true");
     expect(muteInstrumental).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByText("1 of 2 stems audible")).toBeInTheDocument();
+    expect(screen.queryByText("1 of 2 stems audible")).not.toBeInTheDocument();
   });
 
   it("shows failed stem jobs inline and in processing history", async () => {

--- a/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
@@ -15,15 +15,16 @@ export function PlaybackPracticeRail() {
     capoSelectorRef,
     capoSemitones,
     capoShiftSummary,
+    capoSourceKey,
     enharmonicDisplayMode,
     handleSelectPrimaryArtifact,
     handleSelectStemArtifact,
     higherCapoPreview,
-    higherTargetShiftOptions,
+    higherCapoShiftOptions,
     informationDensity,
     isStemPlayback,
     lowerCapoPreview,
-    lowerTargetShiftOptions,
+    lowerCapoShiftOptions,
     previewArtifacts,
     selectedArtifactId,
     selectedArtifactTimestamp,
@@ -32,7 +33,6 @@ export function PlaybackPracticeRail() {
     setCapoSelectorOpen,
     setCapoTransposeSemitones,
     sourceArtifact,
-    sourceKey,
     stageModeLabel,
     stageSummary,
     stageTitle,
@@ -41,8 +41,7 @@ export function PlaybackPracticeRail() {
     toggleStemControl,
     visibleStemArtifacts,
   } = useProjectViewModelContext();
-  const showHeaderDetails =
-    informationDensity === "detailed" || selectedPlaybackArtifact?.type !== "source_audio";
+  const showHeaderDetails = informationDensity === "detailed";
 
   return (
     <aside className="panel playback-practice-rail">
@@ -72,19 +71,19 @@ export function PlaybackPracticeRail() {
           headingLabel="Transpose / Capo"
           higherButtonLabel="Raise capo shift"
           higherPreview={higherCapoPreview}
-          higherTargetShiftOptions={higherTargetShiftOptions}
+          higherTargetShiftOptions={higherCapoShiftOptions}
           isOpen={capoSelectorOpen}
           listboxLabel="Capo shift options"
           lowerButtonLabel="Lower capo shift"
           lowerPreview={lowerCapoPreview}
-          lowerTargetShiftOptions={lowerTargetShiftOptions}
+          lowerTargetShiftOptions={lowerCapoShiftOptions}
           optionRefs={capoOptionRefs}
           selectorLabel="Capo Shift"
           selectorRef={capoSelectorRef}
           setIsOpen={setCapoSelectorOpen}
           setSemitones={setCapoTransposeSemitones}
           showCompactControls
-          sourceKey={sourceKey}
+          sourceKey={capoSourceKey}
           value={capoSemitones}
         />
         <p className="artifact-meta playback-capo-control__summary">{capoShiftSummary}</p>

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -537,7 +537,6 @@ export function useProjectViewModel() {
   const transposeSemitones = clampTargetTranspose(targetTransposeSemitones);
   const targetKey = transposeKey(sourceKey, transposeSemitones);
   const capoSemitones = clampTargetTranspose(capoTransposeSemitones);
-  const capoKey = transposeKey(sourceKey, capoSemitones);
   const hasTransformChange = retuneMode !== "off" || transposeSemitones !== 0;
   const isAnalysisRunning = Boolean(
     analyzeJob && ["pending", "running"].includes(analyzeJob.status),
@@ -576,6 +575,8 @@ export function useProjectViewModel() {
     selectedPlaybackArtifact,
     selectableArtifacts,
   );
+  const capoSourceKey = transposeKey(sourceKey, chordTransposeSemitones);
+  const capoKey = transposeKey(capoSourceKey, capoSemitones);
   const displayedChordSemitones =
     chordTransposeSemitones + correctedSourceChordSemitones + capoSemitones;
   const activeEnharmonicKeyContext = sourceKeyBasis
@@ -658,9 +659,9 @@ export function useProjectViewModel() {
       ? transposeKey(sourceKey, transposeSemitones + 1)
       : null;
   const lowerCapoPreview =
-    capoSemitones > MIN_TARGET_TRANSPOSE ? transposeKey(sourceKey, capoSemitones - 1) : null;
+    capoSemitones > MIN_TARGET_TRANSPOSE ? transposeKey(capoSourceKey, capoSemitones - 1) : null;
   const higherCapoPreview =
-    capoSemitones < MAX_TARGET_TRANSPOSE ? transposeKey(sourceKey, capoSemitones + 1) : null;
+    capoSemitones < MAX_TARGET_TRANSPOSE ? transposeKey(capoSourceKey, capoSemitones + 1) : null;
   const targetShiftOptions = useMemo<TargetShiftOption[]>(
     () =>
       Array.from(
@@ -675,6 +676,20 @@ export function useProjectViewModel() {
       }),
     [sourceKey],
   );
+  const capoShiftOptions = useMemo<TargetShiftOption[]>(
+    () =>
+      Array.from(
+        { length: MAX_TARGET_TRANSPOSE - MIN_TARGET_TRANSPOSE + 1 },
+        (_, index) => MIN_TARGET_TRANSPOSE + index,
+      ).map((semitones) => {
+        const key = transposeKey(capoSourceKey, semitones);
+        return {
+          semitones,
+          key,
+        };
+      }),
+    [capoSourceKey],
+  );
   const lowerTargetShiftOptions = useMemo(
     () => targetShiftOptions.filter((option) => option.semitones < 0).sort((a, b) => b.semitones - a.semitones),
     [targetShiftOptions],
@@ -682,6 +697,14 @@ export function useProjectViewModel() {
   const higherTargetShiftOptions = useMemo(
     () => targetShiftOptions.filter((option) => option.semitones > 0).sort((a, b) => b.semitones - a.semitones),
     [targetShiftOptions],
+  );
+  const lowerCapoShiftOptions = useMemo(
+    () => capoShiftOptions.filter((option) => option.semitones < 0).sort((a, b) => b.semitones - a.semitones),
+    [capoShiftOptions],
+  );
+  const higherCapoShiftOptions = useMemo(
+    () => capoShiftOptions.filter((option) => option.semitones > 0).sort((a, b) => b.semitones - a.semitones),
+    [capoShiftOptions],
   );
   const sourceKeyOptions = useMemo<SourceKeyOption[]>(
     () => [
@@ -1450,6 +1473,7 @@ export function useProjectViewModel() {
     capoSelectorRef,
     capoSemitones,
     capoShiftSummary,
+    capoSourceKey,
     chordContextCopy,
     chordJob,
     chordMutation,
@@ -1492,6 +1516,7 @@ export function useProjectViewModel() {
     hasTransformChange,
     hasVisibleStems,
     higherCapoPreview,
+    higherCapoShiftOptions,
     higherTargetPreview,
     higherTargetShiftOptions,
     informationDensity,
@@ -1507,6 +1532,7 @@ export function useProjectViewModel() {
     isStemRunning,
     latestPreviewArtifact,
     lowerCapoPreview,
+    lowerCapoShiftOptions,
     lowerTargetPreview,
     lowerTargetShiftOptions,
     mobileCapabilities,


### PR DESCRIPTION
## Summary

- Base the playback Transpose / Capo selector on the selected source or practice mix key.
- Keep displayed chords and the capo selector aligned when switching to transposed practice mixes.
- Hide playback rail detail lines unless detailed information density is active.

## Testing

- `pnpm --filter @tuneforge/desktop test --run src/App.project-playback-stems.test.tsx`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
