### PR TITLE
feat: add chromatic tuner tool

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3974,6 +3974,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
+ "webkit2gtk",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -18,5 +18,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4.44", features = ["serde"] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+webkit2gtk = "2.0.2"
+
 [target.'cfg(target_os = "android")'.dependencies]
 rusqlite = { version = "0.32.1", features = ["bundled"] }

--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Tuneforge uses the microphone for the chromatic tuner.</string>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -249,6 +249,40 @@ fn development_backend() -> BackendRuntime {
     BackendRuntime::new(base_url, None)
 }
 
+#[cfg(target_os = "linux")]
+fn install_linux_media_permission_handler(
+    app: &AppHandle,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(webview) = app.get_webview("main") {
+        webview.with_webview(|webview| {
+            use webkit2gtk::prelude::*;
+
+            webview.inner().connect_permission_request(|_, request| {
+                let request_type = request.type_().name();
+                if request_type.as_str().contains("DeviceInfoPermissionRequest") {
+                    request.allow();
+                    return true;
+                }
+
+                if request_type.as_str().contains("UserMediaPermissionRequest") {
+                    let is_audio = request.property::<bool>("is-for-audio-device");
+                    let is_video = request.property::<bool>("is-for-video-device");
+                    if is_audio && !is_video {
+                        request.allow();
+                    } else {
+                        request.deny();
+                    }
+                    return true;
+                }
+
+                false
+            });
+        })?;
+    }
+
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let app = tauri::Builder::default()
@@ -264,6 +298,8 @@ pub fn run() {
                 spawn_packaged_backend(app.handle())?
             };
             app.manage(runtime);
+            #[cfg(target_os = "linux")]
+            install_linux_media_permission_handler(app.handle())?;
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/apps/desktop/src/App.settings-theme.test.tsx
+++ b/apps/desktop/src/App.settings-theme.test.tsx
@@ -108,6 +108,8 @@ describe("Desktop app settings theme", () => {
       defaultChordBackend: "tuneforge-fast",
       defaultLyricsFollowEnabled: true,
       defaultChordsFollowEnabled: true,
+      defaultTunerInputDeviceId: null,
+      defaultTunerReferenceHz: 440,
     });
   });
 

--- a/apps/desktop/src/App.tools-tuner.test.tsx
+++ b/apps/desktop/src/App.tools-tuner.test.tsx
@@ -1,0 +1,173 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getMockAudioContexts,
+  getMockMediaDevices,
+  resetAppTestHarness,
+  renderApp,
+} from "./test/appTestHarness";
+
+describe("Desktop app tools tuner", () => {
+  beforeEach(resetAppTestHarness);
+
+  it("renders the tools route with chromatic tuner defaults", async () => {
+    renderApp(["/tools"]);
+
+    expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Chromatic Tuner" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("button", { name: "Start" })).toBeEnabled();
+    expect(screen.getByLabelText("Microphone source")).toHaveValue("");
+    expect(screen.getByLabelText("A4 reference tuning")).toHaveValue(440);
+    expect(screen.getByLabelText("Tuner visual mode")).toHaveValue("simple");
+    expect(screen.getByRole("option", { name: "Wide Arc" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Microphone 1" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "USB Interface" })).not.toBeInTheDocument();
+    expect(screen.getByRole("meter", { name: "Tuning offset" })).toBeInTheDocument();
+    expect(screen.getByRole("meter", { name: "Input signal level" })).toBeInTheDocument();
+    expect(getMockMediaDevices().getUserMedia).not.toHaveBeenCalled();
+  });
+
+  it("keeps the wide arc visual mode available", async () => {
+    const user = userEvent.setup();
+    renderApp(["/tools"]);
+
+    expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText("Tuner visual mode"), "wide-arc");
+
+    expect(screen.getByLabelText("Tuner visual mode")).toHaveValue("wide-arc");
+    expect(screen.getByRole("meter", { name: "Tuning offset" })).toBeInTheDocument();
+  });
+
+  it("keeps tuner preferences synced between tools and settings", async () => {
+    const user = userEvent.setup();
+    getMockMediaDevices().revealLabels();
+    renderApp(["/tools"]);
+
+    expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    expect(await screen.findByRole("option", { name: "USB Interface" })).toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText("Microphone source"), "usb");
+    changeReferenceInput("442.5");
+
+    await user.click(screen.getByRole("link", { name: "Settings" }));
+
+    expect(await screen.findByRole("heading", { name: "Control Room" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Microphone source")).toHaveValue("usb");
+    expect(screen.getByLabelText("A4 reference tuning")).toHaveValue(442.5);
+    expect(screen.getByText("Saved microphone")).toBeInTheDocument();
+    expect(screen.getByText("442.5 Hz")).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText("Microphone source"), "");
+    changeReferenceInput("441");
+    await user.click(screen.getByRole("link", { name: "Tools" }));
+
+    expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Microphone source")).toHaveValue("");
+    expect(screen.getByLabelText("A4 reference tuning")).toHaveValue(441);
+  });
+
+  it("applies valid reference tuning edits before the field blurs", async () => {
+    renderApp(["/tools"]);
+
+    expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("A4 reference tuning"), { target: { value: "442" } });
+
+    expect(window.localStorage.getItem("tuneforge.ui-preferences")).toContain(
+      '"defaultTunerReferenceHz":442',
+    );
+  });
+
+  it("normalizes invalid stored tuner preferences", async () => {
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({
+        defaultTunerInputDeviceId: "",
+        defaultTunerReferenceHz: 999,
+      }),
+    );
+
+    renderApp(["/tools"]);
+
+    expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Microphone source")).toHaveValue("");
+    expect(screen.getByLabelText("A4 reference tuning")).toHaveValue(440);
+  });
+
+  it("starts microphone capture with the selected source and stops cleanly", async () => {
+    const user = userEvent.setup();
+    getMockMediaDevices().revealLabels();
+    renderApp(["/tools"]);
+
+    expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    expect(await screen.findByRole("option", { name: "USB Interface" })).toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText("Microphone source"), "usb");
+    await user.click(screen.getByRole("button", { name: "Start" }));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument());
+    expect(getMockMediaDevices().getUserMedia).toHaveBeenCalledWith({
+      audio: {
+        autoGainControl: false,
+        deviceId: { exact: "usb" },
+        echoCancellation: false,
+        noiseSuppression: false,
+      },
+      video: false,
+    });
+    expect(getMockAudioContexts()).toHaveLength(1);
+    expect(getMockAudioContexts()[0]?.createdMediaStreamSources[0]?.connect).toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Stop" }));
+    expect(screen.getByRole("button", { name: "Start" })).toBeEnabled();
+  });
+
+  it("uses cached device labels before start without opening capture", async () => {
+    window.localStorage.setItem(
+      "tuneforge.tuner-microphone-devices",
+      JSON.stringify([{ deviceId: "usb", label: "USB Interface" }]),
+    );
+
+    renderApp(["/tools"]);
+
+    expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    expect(await screen.findByRole("option", { name: "USB Interface" })).toBeInTheDocument();
+    expect(getMockMediaDevices().getUserMedia).not.toHaveBeenCalled();
+  });
+
+  it("does not open capture when settings renders tuner defaults", async () => {
+    renderApp(["/settings"]);
+
+    expect(await screen.findByRole("heading", { name: "Control Room" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Microphone source")).toHaveValue("");
+    expect(getMockMediaDevices().getUserMedia).not.toHaveBeenCalled();
+  });
+
+  it("caches device labels after real tuner capture starts", async () => {
+    const user = userEvent.setup();
+    renderApp(["/tools"]);
+
+    expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "USB Interface" })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Start" }));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument());
+    expect(window.localStorage.getItem("tuneforge.tuner-microphone-devices")).toContain("USB Interface");
+  });
+
+  it("shows microphone permission failures as recoverable state", async () => {
+    const user = userEvent.setup();
+    getMockMediaDevices().rejectGetUserMedia(new DOMException("Denied", "NotAllowedError"));
+    renderApp(["/tools"]);
+
+    expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Start" }));
+
+    expect(await screen.findByText("Microphone permission was denied.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Start" })).toBeEnabled();
+  });
+});
+
+function changeReferenceInput(value: string) {
+  const input = screen.getByLabelText("A4 reference tuning");
+  fireEvent.change(input, { target: { value } });
+  fireEvent.blur(input);
+}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -6,6 +6,7 @@ import { usePlayback } from "./features/projects/playback-context";
 import { PlaybackProvider } from "./features/projects/playback";
 import { SettingsView } from "./features/settings/SettingsView";
 import { ThemeStudioView } from "./features/settings/ThemeStudioView";
+import { ToolsView } from "./features/tools/ToolsView";
 import { PreferencesProvider } from "./lib/preferences";
 import { ThemeProvider } from "./lib/theme";
 
@@ -166,6 +167,7 @@ function AppChrome() {
           <NavLink to="/" end>
             Library
           </NavLink>
+          <NavLink to="/tools">Tools</NavLink>
           <NavLink to="/settings">Settings</NavLink>
         </nav>
       </aside>
@@ -173,6 +175,7 @@ function AppChrome() {
         <Routes>
           <Route path="/" element={<LibraryView />} />
           <Route path="/projects/:projectId" element={<ProjectView />} />
+          <Route path="/tools" element={<ToolsView />} />
           <Route path="/settings" element={<SettingsView />} />
           <Route path="/settings/theme-studio" element={<ThemeStudioView />} />
           <Route path="/settings/theme-preview" element={<ThemeStudioView />} />

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { Link } from "react-router-dom";
 import { api, type ChordBackendSchema } from "../../lib/api";
+import { TunerPreferenceControls } from "../tools/TunerPreferenceControls";
 import {
   usePreferences,
   type DefaultChordBackend,
@@ -191,6 +192,10 @@ function chordBackendLabel(value: DefaultChordBackend) {
   return value === "crema-advanced" ? "Advanced Chords" : "Built-in Chords";
 }
 
+function tunerInputDeviceLabel(value: string | null) {
+  return value ? "Saved microphone" : "System Default";
+}
+
 function chordBackendOptions(backends: ChordBackendSchema[] | undefined): ChoiceOption<DefaultChordBackend>[] {
   if (!backends?.length) {
     return fallbackChordBackendOptions;
@@ -295,6 +300,8 @@ export function SettingsView() {
     defaultChordBackend,
     defaultLyricsFollowEnabled,
     defaultChordsFollowEnabled,
+    defaultTunerInputDeviceId,
+    defaultTunerReferenceHz,
     setInformationDensity,
     setEnharmonicDisplayMode,
     setDefaultInspectorOpen,
@@ -304,9 +311,12 @@ export function SettingsView() {
     setDefaultChordBackend,
     setDefaultLyricsFollowEnabled,
     setDefaultChordsFollowEnabled,
+    setDefaultTunerInputDeviceId,
+    setDefaultTunerReferenceHz,
     resetAppearancePreferences,
     resetNotationPreferences,
     resetAnalysisPreferences,
+    resetTunerPreferences,
     resetVisibilityPreferences,
     resetPreferences,
     replacePreferences,
@@ -342,6 +352,10 @@ export function SettingsView() {
     resetAnalysisPreferences();
   }
 
+  function handleResetTunerDefaults() {
+    resetTunerPreferences();
+  }
+
   function handleResetAllSettings() {
     setThemePreference(DEFAULT_THEME_PREFERENCE);
     resetThemeOverrides();
@@ -368,6 +382,8 @@ export function SettingsView() {
           defaultChordBackend,
           defaultInspectorOpen,
           defaultPlaybackDisplayMode,
+          defaultTunerInputDeviceId,
+          defaultTunerReferenceHz,
           defaultLyricsFollowEnabled,
           defaultProjectWorkspace,
           defaultSourcesRailCollapsed,
@@ -442,6 +458,7 @@ export function SettingsView() {
             <span className="pill">Theme</span>
             <span className="pill">Density</span>
             <span className="pill">Musical notation</span>
+            <span className="pill">Tuner</span>
             <span className="pill">Chord backend</span>
             <span className="pill">Playback defaults</span>
           </div>
@@ -483,6 +500,14 @@ export function SettingsView() {
           <div className="settings-overview__stat">
             <dt>Chord backend</dt>
             <dd>{chordBackendLabel(defaultChordBackend)}</dd>
+          </div>
+          <div className="settings-overview__stat">
+            <dt>Tuner mic</dt>
+            <dd>{tunerInputDeviceLabel(defaultTunerInputDeviceId)}</dd>
+          </div>
+          <div className="settings-overview__stat">
+            <dt>A4 reference</dt>
+            <dd>{defaultTunerReferenceHz.toFixed(1)} Hz</dd>
           </div>
           <div className="settings-overview__stat">
             <dt>Playback follow</dt>
@@ -541,6 +566,28 @@ export function SettingsView() {
           <div className="button-row">
             <button className="button button--ghost button--small" onClick={handleResetAppearance} type="button">
               Reset Appearance
+            </button>
+          </div>
+        </div>
+
+        <div className="panel settings-panel">
+          <div className="panel-heading">
+            <div>
+              <h2>Tuner Defaults</h2>
+              <p className="subpanel__copy">Default microphone source and A4 reference.</p>
+            </div>
+          </div>
+
+          <TunerPreferenceControls
+            inputDeviceId={defaultTunerInputDeviceId}
+            onInputDeviceChange={setDefaultTunerInputDeviceId}
+            onReferenceHzChange={setDefaultTunerReferenceHz}
+            referenceHz={defaultTunerReferenceHz}
+          />
+
+          <div className="button-row">
+            <button className="button button--ghost button--small" onClick={handleResetTunerDefaults} type="button">
+              Reset Tuner Defaults
             </button>
           </div>
         </div>

--- a/apps/desktop/src/features/tools/ToolsView.tsx
+++ b/apps/desktop/src/features/tools/ToolsView.tsx
@@ -1,0 +1,431 @@
+import { useEffect, useRef, useState } from "react";
+import { useStableCallback } from "../../lib/useStableCallback";
+import { usePreferences } from "../../lib/preferences";
+import { TunerPreferenceControls } from "./TunerPreferenceControls";
+import {
+  SimpleTunerMeter,
+  type TunerVisualMode,
+  WideArcTunerMeter,
+} from "./TunerMeters";
+import { getTunerStatusLabel } from "./tunerMeterState";
+import {
+  createStabilizedTunerReadingState,
+  updateStabilizedTunerReading,
+} from "./tunerReadingSmoothing";
+import {
+  forgetTunerMicrophoneAccessGranted,
+  rememberTunerMicrophoneDevices,
+  rememberTunerMicrophoneAccessGranted,
+  toVisibleTunerMicrophoneDevices,
+} from "./tunerMicrophoneAccess";
+import {
+  analyzeTunerBuffer,
+  calculateTunerInputLevel,
+  type TunerPitchReading,
+} from "./tunerPitch";
+
+type TunerStatus = "idle" | "starting" | "listening" | "unsupported" | "error";
+
+type AudioContextConstructor = typeof AudioContext;
+
+export function ToolsView() {
+  return (
+    <section className="screen">
+      <div className="screen__header">
+        <div className="screen__title-block">
+          <p className="eyebrow">Tools</p>
+          <h1>Tools</h1>
+          <p className="screen__subtitle">Local musician utilities.</p>
+        </div>
+      </div>
+
+      <div className="project-workspace-tabs" role="tablist" aria-label="Tools">
+        <button
+          aria-selected="true"
+          className="project-workspace-tabs__button project-workspace-tabs__button--active"
+          role="tab"
+          type="button"
+        >
+          Chromatic Tuner
+        </button>
+      </div>
+
+      <ChromaticTunerPage />
+    </section>
+  );
+}
+
+function ChromaticTunerPage() {
+  const {
+    defaultTunerInputDeviceId,
+    defaultTunerReferenceHz,
+    setDefaultTunerInputDeviceId,
+    setDefaultTunerReferenceHz,
+  } = usePreferences();
+  const [status, setStatus] = useState<TunerStatus>(() =>
+    canUseTunerCapture() ? "idle" : "unsupported",
+  );
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [inputLevel, setInputLevel] = useState(0);
+  const [reading, setReading] = useState<TunerPitchReading | null>(null);
+  const [deviceRefreshToken, setDeviceRefreshToken] = useState(0);
+  const [visualMode, setVisualMode] = useState<TunerVisualMode>("simple");
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const frameIdRef = useRef<number | null>(null);
+  const inputDeviceIdRef = useRef(defaultTunerInputDeviceId);
+  const mediaSourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
+  const referenceHzRef = useRef(defaultTunerReferenceHz);
+  const requestIdRef = useRef(0);
+  const readingStabilizerRef = useRef(createStabilizedTunerReadingState());
+  const statusRef = useRef(status);
+  const streamRef = useRef<MediaStream | null>(null);
+  const timeDomainDataRef = useRef<Float32Array<ArrayBuffer> | null>(null);
+
+  useEffect(() => {
+    inputDeviceIdRef.current = defaultTunerInputDeviceId;
+  }, [defaultTunerInputDeviceId]);
+
+  useEffect(() => {
+    referenceHzRef.current = defaultTunerReferenceHz;
+  }, [defaultTunerReferenceHz]);
+
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
+
+  const releaseCapture = useStableCallback(function releaseCapture() {
+    if (frameIdRef.current !== null) {
+      window.cancelAnimationFrame(frameIdRef.current);
+      frameIdRef.current = null;
+    }
+
+    try {
+      mediaSourceRef.current?.disconnect();
+      analyserRef.current?.disconnect();
+    } catch {
+      // Audio nodes can already be disconnected during rapid source switches.
+    }
+    mediaSourceRef.current = null;
+    analyserRef.current = null;
+    timeDomainDataRef.current = null;
+
+    streamRef.current?.getTracks().forEach((track) => track.stop());
+    streamRef.current = null;
+
+    const audioContext = audioContextRef.current;
+    audioContextRef.current = null;
+    if (audioContext && audioContext.state !== "closed") {
+      void audioContext.close().catch(() => undefined);
+    }
+  });
+
+  const resetTunerDisplay = useStableCallback(function resetTunerDisplay() {
+    readingStabilizerRef.current = createStabilizedTunerReadingState();
+    setInputLevel(0);
+    setReading(null);
+  });
+
+  const readTunerFrame = useStableCallback(function readTunerFrame(timestampMs?: number) {
+    const analyser = analyserRef.current;
+    const audioContext = audioContextRef.current;
+    if (!analyser || !audioContext) {
+      return;
+    }
+
+    if (!timeDomainDataRef.current || timeDomainDataRef.current.length !== analyser.fftSize) {
+      timeDomainDataRef.current = new Float32Array(analyser.fftSize);
+    }
+
+    analyser.getFloatTimeDomainData(timeDomainDataRef.current);
+    setInputLevel(calculateTunerInputLevel(timeDomainDataRef.current));
+    const rawReading = analyzeTunerBuffer(
+      timeDomainDataRef.current,
+      audioContext.sampleRate,
+      referenceHzRef.current,
+    );
+    const stabilizedState = updateStabilizedTunerReading(
+      readingStabilizerRef.current,
+      rawReading,
+      timestampMs ?? getCurrentTunerTimeMs(),
+    );
+    readingStabilizerRef.current = stabilizedState;
+    setReading(stabilizedState.displayedReading);
+    frameIdRef.current = window.requestAnimationFrame(readTunerFrame);
+  });
+
+  const startTuner = useStableCallback(async function startTuner(nextDeviceId?: string | null) {
+    const AudioContextCtor = getAudioContextConstructor();
+    const mediaDevices = getMediaDevices();
+    if (!AudioContextCtor || !mediaDevices) {
+      setStatus("unsupported");
+      setErrorMessage("Microphone capture is unavailable.");
+      return;
+    }
+
+    releaseCapture();
+    setErrorMessage(null);
+    resetTunerDisplay();
+    setStatus("starting");
+
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+
+    try {
+      const stream = await mediaDevices.getUserMedia(
+        createAudioConstraints(nextDeviceId ?? inputDeviceIdRef.current),
+      );
+      if (requestIdRef.current !== requestId) {
+        stream.getTracks().forEach((track) => track.stop());
+        return;
+      }
+
+      const audioContext = new AudioContextCtor();
+      const analyser = audioContext.createAnalyser();
+      analyser.fftSize = 2048;
+      analyser.smoothingTimeConstant = 0.12;
+
+      const mediaSource = audioContext.createMediaStreamSource(stream);
+      mediaSource.connect(analyser);
+
+      streamRef.current = stream;
+      audioContextRef.current = audioContext;
+      analyserRef.current = analyser;
+      mediaSourceRef.current = mediaSource;
+
+      if (audioContext.state === "suspended") {
+        await audioContext.resume();
+      }
+
+      if (requestIdRef.current !== requestId) {
+        releaseCapture();
+        return;
+      }
+
+      rememberTunerMicrophoneAccessGranted();
+      await rememberVisibleAudioInputDevices(mediaDevices);
+      setDeviceRefreshToken(Date.now());
+      setStatus("listening");
+      readTunerFrame();
+    } catch (error) {
+      if (requestIdRef.current !== requestId) {
+        return;
+      }
+      releaseCapture();
+      if (isMicrophonePermissionError(error)) {
+        forgetTunerMicrophoneAccessGranted();
+      }
+      setStatus("error");
+      setErrorMessage(captureErrorMessage(error));
+    }
+  });
+
+  const stopTuner = useStableCallback(function stopTuner() {
+    requestIdRef.current += 1;
+    releaseCapture();
+    setErrorMessage(null);
+    resetTunerDisplay();
+    setStatus(canUseTunerCapture() ? "idle" : "unsupported");
+  });
+
+  useEffect(
+    () => () => {
+      requestIdRef.current += 1;
+      releaseCapture();
+    },
+    [releaseCapture],
+  );
+
+  const handleInputDeviceChange = useStableCallback(function handleInputDeviceChange(
+    value: string | null,
+  ) {
+    inputDeviceIdRef.current = value;
+    setDefaultTunerInputDeviceId(value);
+    if (statusRef.current === "listening") {
+      void startTuner(value);
+    }
+  });
+
+  const handleReferenceHzChange = useStableCallback(function handleReferenceHzChange(
+    value: number,
+  ) {
+    referenceHzRef.current = value;
+    resetTunerDisplay();
+    setDefaultTunerReferenceHz(value);
+  });
+
+  const isBusy = status === "starting";
+  const isListening = status === "listening";
+  const canStart = canUseTunerCapture() && !isBusy && !isListening;
+  const statusText = headerStatusLabel(status, reading);
+
+  return (
+    <div className="tuner-shell">
+      <div className="panel tuner-panel">
+        <TunerHeader
+          canStart={canStart}
+          isBusy={isBusy}
+          isListening={isListening}
+          onStart={() => void startTuner()}
+          onStop={stopTuner}
+          statusText={statusText}
+        />
+
+        <TunerPreferenceControls
+          className="tuner-preferences--with-mode"
+          inputDeviceId={defaultTunerInputDeviceId}
+          onInputDeviceChange={handleInputDeviceChange}
+          onReferenceHzChange={handleReferenceHzChange}
+          referenceHz={defaultTunerReferenceHz}
+          refreshToken={deviceRefreshToken}
+        >
+          <label className="tuner-field">
+            <span>Visual mode</span>
+            <select
+              aria-label="Tuner visual mode"
+              onChange={(event) => setVisualMode(event.target.value as TunerVisualMode)}
+              value={visualMode}
+            >
+              <option value="simple">Simple Meter</option>
+              <option value="wide-arc">Wide Arc</option>
+            </select>
+          </label>
+        </TunerPreferenceControls>
+
+        {errorMessage ? <p className="inline-error">{errorMessage}</p> : null}
+
+        {visualMode === "simple" ? (
+          <SimpleTunerMeter
+            inputLevel={inputLevel}
+            reading={reading}
+            referenceHz={defaultTunerReferenceHz}
+          />
+        ) : (
+          <WideArcTunerMeter
+            inputLevel={inputLevel}
+            reading={reading}
+            referenceHz={defaultTunerReferenceHz}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TunerHeader({
+  canStart,
+  isBusy,
+  isListening,
+  onStart,
+  onStop,
+  statusText,
+}: {
+  canStart: boolean;
+  isBusy: boolean;
+  isListening: boolean;
+  onStart: () => void;
+  onStop: () => void;
+  statusText: string;
+}) {
+  return (
+    <div className="tuner-header">
+      <div>
+        <h2>Chromatic Tuner</h2>
+        <p className="subpanel__copy">{statusText}</p>
+      </div>
+      <div className="button-row">
+        {isListening || isBusy ? (
+          <button className="button button--ghost" onClick={onStop} type="button">
+            Stop
+          </button>
+        ) : (
+          <button
+            className="button button--primary"
+            disabled={!canStart}
+            onClick={onStart}
+            type="button"
+          >
+            Start
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function getAudioContextConstructor(): AudioContextConstructor | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return (
+    window.AudioContext ??
+    (window as Window & typeof globalThis & { webkitAudioContext?: AudioContextConstructor })
+      .webkitAudioContext ??
+    null
+  );
+}
+
+function getMediaDevices() {
+  if (
+    typeof navigator === "undefined" ||
+    typeof navigator.mediaDevices?.getUserMedia !== "function"
+  ) {
+    return null;
+  }
+  return navigator.mediaDevices;
+}
+
+function canUseTunerCapture() {
+  return Boolean(getAudioContextConstructor() && getMediaDevices());
+}
+
+async function rememberVisibleAudioInputDevices(mediaDevices: MediaDevices) {
+  if (typeof mediaDevices.enumerateDevices !== "function") {
+    return;
+  }
+  try {
+    const devices = await mediaDevices.enumerateDevices();
+    rememberTunerMicrophoneDevices(toVisibleTunerMicrophoneDevices(devices));
+  } catch {
+    // Device labels are a convenience cache; tuner capture should continue without them.
+  }
+}
+
+function createAudioConstraints(inputDeviceId: string | null): MediaStreamConstraints {
+  const audio: MediaTrackConstraints = {
+    autoGainControl: false,
+    echoCancellation: false,
+    noiseSuppression: false,
+  };
+  if (inputDeviceId) {
+    audio.deviceId = { exact: inputDeviceId };
+  }
+  return { audio, video: false };
+}
+
+function captureErrorMessage(error: unknown) {
+  if (error instanceof DOMException) {
+    if (isMicrophonePermissionError(error)) {
+      return "Microphone permission was denied.";
+    }
+    if (error.name === "NotFoundError" || error.name === "OverconstrainedError") {
+      return "Selected microphone was not found.";
+    }
+  }
+  return error instanceof Error ? error.message : "Could not start microphone capture.";
+}
+
+function isMicrophonePermissionError(error: unknown) {
+  return error instanceof DOMException && (error.name === "NotAllowedError" || error.name === "SecurityError");
+}
+
+function getCurrentTunerTimeMs() {
+  return typeof performance !== "undefined" ? performance.now() : Date.now();
+}
+
+function headerStatusLabel(status: TunerStatus, reading: TunerPitchReading | null) {
+  if (status === "error" || status === "unsupported") return "Error";
+  if (status === "starting") return "Listening";
+  if (status === "listening") return getTunerStatusLabel(reading);
+  return "Ready";
+}

--- a/apps/desktop/src/features/tools/TunerMeters.test.tsx
+++ b/apps/desktop/src/features/tools/TunerMeters.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  InputLevelMeter,
+  SimpleTunerMeter,
+  WideArcTunerMeter,
+} from "./TunerMeters";
+import { type TunerPitchReading } from "./tunerPitch";
+
+describe("tuner visual meters", () => {
+  afterEach(() => {
+    delete document.documentElement.dataset.theme;
+  });
+
+  it("renders no pitch without an active centered marker and keeps input level visible", () => {
+    render(<SimpleTunerMeter inputLevel={0.42} reading={null} referenceHz={440} />);
+
+    expect(screen.getByText("--")).toBeInTheDocument();
+    expect(screen.getAllByText("No pitch")).toHaveLength(1);
+    expect(screen.getByText("Center")).toBeInTheDocument();
+    expect(screen.queryByText("In tune")).not.toBeInTheDocument();
+    expect(screen.getByTestId("simple-tuner-meter")).toHaveAttribute("data-tuning-state", "no-pitch");
+    expect(screen.getByTestId("simple-tuner-marker")).toHaveAttribute("aria-hidden", "true");
+    expect(screen.getByRole("meter", { name: "Input signal level" })).toHaveAttribute("aria-valuenow", "65");
+  });
+
+  it("renders in tune readings with the restrained center state", () => {
+    render(<SimpleTunerMeter inputLevel={0.5} reading={makeReading(2)} referenceHz={440} />);
+
+    expect(screen.getAllByText("In tune")).toHaveLength(2);
+    expect(screen.getByText("+2 cents")).toBeInTheDocument();
+    expect(screen.getByTestId("simple-tuner-meter")).toHaveAttribute("data-tuning-state", "in-tune");
+    expect(screen.getByTestId("simple-tuner-meter")).toHaveStyle("--tuner-marker-position: 52%");
+  });
+
+  it("uses a less twitchy in-tune tolerance", () => {
+    render(<SimpleTunerMeter inputLevel={0.5} reading={makeReading(5)} referenceHz={440} />);
+
+    expect(screen.getAllByText("In tune")).toHaveLength(2);
+    expect(screen.getByText("+5 cents")).toBeInTheDocument();
+  });
+
+  it("renders flat readings to the left of center", () => {
+    render(<SimpleTunerMeter inputLevel={0.5} reading={makeReading(-12)} referenceHz={440} />);
+
+    expect(screen.getAllByText("Flat")).toHaveLength(2);
+    expect(screen.getByText("-12 cents")).toBeInTheDocument();
+    expect(screen.getByTestId("simple-tuner-meter")).toHaveAttribute("data-tuning-state", "flat");
+    expect(screen.getByTestId("simple-tuner-meter")).toHaveStyle("--tuner-marker-position: 38%");
+  });
+
+  it("renders sharp readings to the right of center", () => {
+    render(<SimpleTunerMeter inputLevel={0.5} reading={makeReading(18)} referenceHz={440} />);
+
+    expect(screen.getAllByText("Sharp")).toHaveLength(2);
+    expect(screen.getByText("+18 cents")).toBeInTheDocument();
+    expect(screen.getByTestId("simple-tuner-meter")).toHaveAttribute("data-tuning-state", "sharp");
+    expect(screen.getByTestId("simple-tuner-meter")).toHaveStyle("--tuner-marker-position: 68%");
+  });
+
+  it("clamps marker position while preserving actual cents text", () => {
+    const { rerender } = render(
+      <SimpleTunerMeter inputLevel={0.5} reading={makeReading(63)} referenceHz={440} />,
+    );
+
+    expect(screen.getByText("+63 cents")).toBeInTheDocument();
+    expect(screen.getByTestId("simple-tuner-meter")).toHaveStyle("--tuner-marker-position: 100%");
+
+    rerender(<SimpleTunerMeter inputLevel={0.5} reading={makeReading(-63)} referenceHz={440} />);
+
+    expect(screen.getByText("-63 cents")).toBeInTheDocument();
+    expect(screen.getByTestId("simple-tuner-meter")).toHaveStyle("--tuner-marker-position: 0%");
+  });
+
+  it("renders input level as a subtle meter", () => {
+    render(<InputLevelMeter inputLevel={0.37} />);
+
+    expect(screen.getByRole("meter", { name: "Input signal level" })).toHaveAttribute("aria-valuenow", "61");
+  });
+
+  it("keeps wide arc no-pitch state neutral", () => {
+    render(<WideArcTunerMeter inputLevel={0.2} reading={null} referenceHz={440} />);
+
+    expect(screen.getByTestId("wide-arc-tuner-meter")).toHaveAttribute("data-tuning-state", "no-pitch");
+  });
+
+  it.each(["light", "dark"] as const)("renders readable meter surfaces in %s theme", (theme) => {
+    document.documentElement.dataset.theme = theme;
+
+    render(
+      <>
+        <SimpleTunerMeter inputLevel={0.5} reading={makeReading(0)} referenceHz={440} />
+        <WideArcTunerMeter inputLevel={0.5} reading={makeReading(0)} referenceHz={440} />
+      </>,
+    );
+
+    expect(screen.getAllByRole("meter", { name: "Tuning offset" })).toHaveLength(2);
+    expect(screen.getAllByText("A")).toHaveLength(2);
+  });
+});
+
+function makeReading(cents: number): TunerPitchReading {
+  const targetFrequencyHz = 440;
+  const frequencyHz = targetFrequencyHz * 2 ** (cents / 1200);
+  return {
+    cents,
+    confidence: 0.95,
+    frequencyHz,
+    inputLevel: 0.5,
+    noteName: "A",
+    pitchClass: 9,
+    targetFrequencyHz,
+  };
+}

--- a/apps/desktop/src/features/tools/TunerMeters.tsx
+++ b/apps/desktop/src/features/tools/TunerMeters.tsx
@@ -1,0 +1,145 @@
+import { type CSSProperties } from "react";
+import { getTunerDisplay } from "./tunerMeterState";
+import { type TunerPitchReading } from "./tunerPitch";
+
+export type TunerVisualMode = "simple" | "wide-arc";
+
+type TunerMeterProps = {
+  inputLevel: number;
+  reading: TunerPitchReading | null;
+  referenceHz: number;
+};
+
+export function SimpleTunerMeter({ inputLevel, reading, referenceHz }: TunerMeterProps) {
+  const display = getTunerDisplay(reading, referenceHz);
+  const style = {
+    "--tuner-marker-position": `${display.markerPositionPercent}%`,
+  } as CSSProperties;
+  const centerDirectionLabel = display.hasPitch ? "In tune" : "Center";
+
+  return (
+    <div
+      className="simple-tuner-meter"
+      data-testid="simple-tuner-meter"
+      data-tuning-state={display.toneState}
+      style={style}
+    >
+      <div className="simple-tuner-meter__readout" aria-live="polite">
+        <span className="simple-tuner-meter__note">{display.noteName}</span>
+        <span className="simple-tuner-meter__status">{display.statusLabel}</span>
+        {display.hasPitch ? (
+          <span className="simple-tuner-meter__cents">{display.centsLabel}</span>
+        ) : null}
+        <span className="simple-tuner-meter__meta">{display.metaLabel}</span>
+      </div>
+
+      <div
+        aria-label="Tuning offset"
+        aria-valuemax={50}
+        aria-valuemin={-50}
+        aria-valuenow={display.hasPitch ? Math.round(display.clampedCents) : undefined}
+        className="simple-tuner-meter__bar"
+        role="meter"
+      >
+        <div className="simple-tuner-meter__scale" aria-hidden="true">
+          <span>-50</span>
+          <span>-25</span>
+          <span>0</span>
+          <span>+25</span>
+          <span>+50</span>
+        </div>
+        <div className="simple-tuner-meter__track">
+          <span className="simple-tuner-meter__center" />
+          <span
+            aria-hidden={!display.hasPitch}
+            className="simple-tuner-meter__marker"
+            data-testid="simple-tuner-marker"
+          />
+        </div>
+        <div className="simple-tuner-meter__directions" aria-hidden="true">
+          <span>Flat</span>
+          <span>{centerDirectionLabel}</span>
+          <span>Sharp</span>
+        </div>
+      </div>
+
+      <InputLevelMeter inputLevel={inputLevel} />
+    </div>
+  );
+}
+
+export function WideArcTunerMeter({ inputLevel, reading, referenceHz }: TunerMeterProps) {
+  const display = getTunerDisplay(reading, referenceHz);
+  const style = {
+    "--tuner-needle-rotation": `${display.clampedCents * 0.9}deg`,
+  } as CSSProperties;
+
+  return (
+    <div
+      className="wide-arc-tuner-meter"
+      data-testid="wide-arc-tuner-meter"
+      data-tuning-state={display.toneState}
+      style={style}
+    >
+      <div
+        aria-label="Tuning offset"
+        aria-valuemax={50}
+        aria-valuemin={-50}
+        aria-valuenow={display.hasPitch ? Math.round(display.clampedCents) : undefined}
+        className="tuner-gauge"
+        role="meter"
+      >
+        <div className="tuner-gauge__scale" aria-hidden="true">
+          <span>-50</span>
+          <span>-25</span>
+          <span>0</span>
+          <span>+25</span>
+          <span>+50</span>
+        </div>
+        <div className="tuner-gauge__arc" aria-hidden="true">
+          <span className="tuner-gauge__tick tuner-gauge__tick--left" />
+          <span className="tuner-gauge__tick tuner-gauge__tick--center" />
+          <span className="tuner-gauge__tick tuner-gauge__tick--right" />
+          <span className="tuner-gauge__needle" />
+        </div>
+      </div>
+
+      <div className="tuner-readout" aria-live="polite">
+        <span className="tuner-readout__note">{display.noteName}</span>
+        <span className="tuner-readout__cents">{display.centsLabel}</span>
+        <span className="tuner-readout__meta">{display.metaLabel}</span>
+      </div>
+
+      <InputLevelMeter inputLevel={inputLevel} />
+    </div>
+  );
+}
+
+export function InputLevelMeter({ inputLevel }: { inputLevel: number }) {
+  const clampedLevel = clamp(inputLevel, 0, 1);
+  const levelPercent = Math.round(Math.sqrt(clampedLevel) * 100);
+  const style = {
+    "--tuner-level": `${levelPercent}%`,
+  } as CSSProperties;
+
+  return (
+    <div
+      aria-label="Input signal level"
+      aria-valuemax={100}
+      aria-valuemin={0}
+      aria-valuenow={levelPercent}
+      className="tuner-level"
+      role="meter"
+      style={style}
+    >
+      <span>Signal</span>
+      <div className="tuner-level__track">
+        <span className="tuner-level__bar" />
+      </div>
+    </div>
+  );
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}

--- a/apps/desktop/src/features/tools/TunerPreferenceControls.tsx
+++ b/apps/desktop/src/features/tools/TunerPreferenceControls.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  MAX_TUNER_REFERENCE_HZ,
+  MIN_TUNER_REFERENCE_HZ,
+  normalizeTunerReferenceHz,
+} from "../../lib/preferences";
+import {
+  forgetTunerMicrophoneAccessGranted,
+  readRememberedTunerMicrophoneDevices,
+  rememberTunerMicrophoneDevices,
+  toVisibleTunerMicrophoneDevices,
+  type TunerMicrophoneDevice,
+} from "./tunerMicrophoneAccess";
+
+type TunerPreferenceControlsProps = {
+  children?: ReactNode;
+  className?: string;
+  inputDeviceId: string | null;
+  onInputDeviceChange: (value: string | null) => void;
+  onReferenceHzChange: (value: number) => void;
+  referenceHz: number;
+  refreshToken?: number;
+};
+
+export function TunerPreferenceControls({
+  children,
+  className,
+  inputDeviceId,
+  onInputDeviceChange,
+  onReferenceHzChange,
+  referenceHz,
+  refreshToken = 0,
+}: TunerPreferenceControlsProps) {
+  const [devices, setDevices] = useState<TunerMicrophoneDevice[]>([]);
+  const [deviceError, setDeviceError] = useState<string | null>(null);
+  const [isReferenceFocused, setIsReferenceFocused] = useState(false);
+  const [referenceDraft, setReferenceDraft] = useState(formatReferenceValue(referenceHz));
+  const canEnumerateDevices = canUseMediaDeviceEnumeration();
+
+  useEffect(() => {
+    if (isReferenceFocused) {
+      return;
+    }
+    setReferenceDraft(formatReferenceValue(referenceHz));
+  }, [isReferenceFocused, referenceHz]);
+
+  useEffect(() => {
+    if (!canEnumerateDevices) {
+      setDevices([]);
+      setDeviceError("Microphone list unavailable.");
+      return undefined;
+    }
+
+    let active = true;
+
+    async function refreshDevices() {
+      try {
+        const availableDevices = await enumerateAudioInputDevices();
+        if (!active) {
+          return;
+        }
+        setDevices(availableDevices);
+        setDeviceError(null);
+      } catch {
+        if (active) {
+          setDevices([]);
+          setDeviceError("Microphone list unavailable.");
+        }
+      }
+    }
+
+    void refreshDevices();
+    navigator.mediaDevices.addEventListener?.("devicechange", refreshDevices);
+
+    return () => {
+      active = false;
+      navigator.mediaDevices.removeEventListener?.("devicechange", refreshDevices);
+    };
+  }, [canEnumerateDevices, refreshToken]);
+
+  const selectedDeviceMissing = useMemo(
+    () => Boolean(inputDeviceId && !devices.some((device) => device.deviceId === inputDeviceId)),
+    [devices, inputDeviceId],
+  );
+
+  function commitReferenceDraft() {
+    const normalizedReferenceHz = normalizeTunerReferenceHz(referenceDraft);
+    setReferenceDraft(formatReferenceValue(normalizedReferenceHz));
+    onReferenceHzChange(normalizedReferenceHz);
+  }
+
+  function handleReferenceDraftChange(value: string) {
+    setReferenceDraft(value);
+    const parsedReferenceHz = parseValidReferenceHz(value);
+    if (parsedReferenceHz !== null) {
+      onReferenceHzChange(parsedReferenceHz);
+    }
+  }
+
+  return (
+    <div className={["tuner-preferences", className].filter(Boolean).join(" ")}>
+      <label className="tuner-field">
+        <span>Microphone source</span>
+        <select
+          aria-label="Microphone source"
+          onChange={(event) => onInputDeviceChange(event.target.value || null)}
+          value={inputDeviceId ?? ""}
+        >
+          <option value="">System Default</option>
+          {selectedDeviceMissing ? <option value={inputDeviceId ?? ""}>Saved microphone</option> : null}
+          {devices.map((device) => (
+            <option key={device.deviceId || device.label} value={device.deviceId}>
+              {device.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="tuner-field">
+        <span>A4 reference tuning</span>
+        <input
+          aria-label="A4 reference tuning"
+          inputMode="decimal"
+          max={MAX_TUNER_REFERENCE_HZ}
+          min={MIN_TUNER_REFERENCE_HZ}
+          onBlur={() => {
+            setIsReferenceFocused(false);
+            commitReferenceDraft();
+          }}
+          onChange={(event) => handleReferenceDraftChange(event.target.value)}
+          onFocus={() => setIsReferenceFocused(true)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              commitReferenceDraft();
+              event.currentTarget.blur();
+            }
+          }}
+          step="0.1"
+          type="number"
+          value={referenceDraft}
+        />
+      </label>
+
+      {children}
+
+      {deviceError ? <p className="tuner-preferences__status">{deviceError}</p> : null}
+    </div>
+  );
+}
+
+function canUseMediaDeviceEnumeration() {
+  return typeof navigator !== "undefined" && typeof navigator.mediaDevices?.enumerateDevices === "function";
+}
+
+async function enumerateAudioInputDevices() {
+  const devices = await navigator.mediaDevices.enumerateDevices();
+  const visibleDevices = toVisibleTunerMicrophoneDevices(devices);
+  if (visibleDevices.length > 0) {
+    rememberTunerMicrophoneDevices(visibleDevices);
+    return visibleDevices;
+  }
+
+  if ((await getMicrophonePermissionState()) === "denied") {
+    forgetTunerMicrophoneAccessGranted();
+    return [];
+  }
+
+  return readRememberedTunerMicrophoneDevices();
+}
+
+async function getMicrophonePermissionState() {
+  if (typeof navigator === "undefined" || typeof navigator.permissions?.query !== "function") {
+    return null;
+  }
+
+  try {
+    const status = await navigator.permissions.query({ name: "microphone" as PermissionName });
+    return status.state;
+  } catch {
+    return null;
+  }
+}
+
+function formatReferenceValue(referenceHz: number) {
+  return Number.isInteger(referenceHz) ? referenceHz.toFixed(0) : referenceHz.toFixed(1);
+}
+
+function parseValidReferenceHz(value: string) {
+  const numericValue = Number(value);
+  if (
+    !Number.isFinite(numericValue) ||
+    numericValue < MIN_TUNER_REFERENCE_HZ ||
+    numericValue > MAX_TUNER_REFERENCE_HZ
+  ) {
+    return null;
+  }
+  return normalizeTunerReferenceHz(numericValue);
+}

--- a/apps/desktop/src/features/tools/tunerMeterState.ts
+++ b/apps/desktop/src/features/tools/tunerMeterState.ts
@@ -1,0 +1,44 @@
+import { formatCents, type TunerPitchReading } from "./tunerPitch";
+
+export type TunerToneState = "no-pitch" | "in-tune" | "flat" | "sharp";
+
+export const TUNER_IN_TUNE_CENTS = 5;
+
+export function getTunerToneState(reading: TunerPitchReading | null): TunerToneState {
+  if (!reading) {
+    return "no-pitch";
+  }
+  if (Math.abs(reading.cents) <= TUNER_IN_TUNE_CENTS) {
+    return "in-tune";
+  }
+  return reading.cents < 0 ? "flat" : "sharp";
+}
+
+export function getTunerStatusLabel(reading: TunerPitchReading | null) {
+  const toneState = getTunerToneState(reading);
+  if (toneState === "no-pitch") return "No pitch";
+  if (toneState === "in-tune") return "In tune";
+  if (toneState === "flat") return "Flat";
+  return "Sharp";
+}
+
+export function getTunerDisplay(reading: TunerPitchReading | null, referenceHz: number) {
+  const toneState = getTunerToneState(reading);
+  const clampedCents = clamp(reading?.cents ?? 0, -50, 50);
+  return {
+    centsLabel: reading ? `${formatCents(reading.cents)} cents` : "No pitch",
+    clampedCents,
+    hasPitch: Boolean(reading),
+    markerPositionPercent: ((clampedCents + 50) / 100) * 100,
+    metaLabel: reading
+      ? `${reading.frequencyHz.toFixed(2)} Hz -> target ${reading.targetFrequencyHz.toFixed(2)} Hz`
+      : `Reference ${referenceHz.toFixed(1)} Hz`,
+    noteName: reading?.noteName ?? "--",
+    statusLabel: getTunerStatusLabel(reading),
+    toneState,
+  };
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}

--- a/apps/desktop/src/features/tools/tunerMicrophoneAccess.ts
+++ b/apps/desktop/src/features/tools/tunerMicrophoneAccess.ts
@@ -1,0 +1,100 @@
+const TUNER_MICROPHONE_ACCESS_KEY = "tuneforge.tuner-microphone-access-granted";
+const TUNER_MICROPHONE_DEVICES_KEY = "tuneforge.tuner-microphone-devices";
+
+export type TunerMicrophoneDevice = {
+  deviceId: string;
+  label: string;
+};
+
+export function rememberTunerMicrophoneAccessGranted() {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.localStorage.setItem(TUNER_MICROPHONE_ACCESS_KEY, "true");
+}
+
+export function forgetTunerMicrophoneAccessGranted() {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.localStorage.removeItem(TUNER_MICROPHONE_ACCESS_KEY);
+  window.localStorage.removeItem(TUNER_MICROPHONE_DEVICES_KEY);
+}
+
+export function hasRememberedTunerMicrophoneAccess() {
+  return (
+    typeof window !== "undefined" &&
+    window.localStorage.getItem(TUNER_MICROPHONE_ACCESS_KEY) === "true"
+  );
+}
+
+export function rememberTunerMicrophoneDevices(devices: TunerMicrophoneDevice[]) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const visibleDevices = normalizeTunerMicrophoneDevices(devices);
+  if (visibleDevices.length === 0) {
+    window.localStorage.removeItem(TUNER_MICROPHONE_DEVICES_KEY);
+    return;
+  }
+  window.localStorage.setItem(TUNER_MICROPHONE_DEVICES_KEY, JSON.stringify(visibleDevices));
+}
+
+export function readRememberedTunerMicrophoneDevices() {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const rawDevices = JSON.parse(window.localStorage.getItem(TUNER_MICROPHONE_DEVICES_KEY) ?? "[]");
+    if (!Array.isArray(rawDevices)) {
+      return [];
+    }
+    return normalizeTunerMicrophoneDevices(rawDevices);
+  } catch {
+    return [];
+  }
+}
+
+export function toVisibleTunerMicrophoneDevices(devices: MediaDeviceInfo[]) {
+  return normalizeTunerMicrophoneDevices(
+    devices
+      .filter((device) => device.kind === "audioinput")
+      .map((device) => ({
+        deviceId: device.deviceId,
+        label: device.label,
+      })),
+  );
+}
+
+function normalizeTunerMicrophoneDevices(devices: unknown[]) {
+  const visibleDevices: TunerMicrophoneDevice[] = [];
+  const seenDeviceIds = new Set<string>();
+
+  for (const device of devices) {
+    if (!isTunerMicrophoneDevice(device)) {
+      continue;
+    }
+    const label = device.label.trim();
+    const deviceId = device.deviceId.trim();
+    if (!label || seenDeviceIds.has(deviceId)) {
+      continue;
+    }
+    seenDeviceIds.add(deviceId);
+    visibleDevices.push({ deviceId, label });
+  }
+
+  return visibleDevices;
+}
+
+function isTunerMicrophoneDevice(device: unknown): device is TunerMicrophoneDevice {
+  return (
+    typeof device === "object" &&
+    device !== null &&
+    "deviceId" in device &&
+    "label" in device &&
+    typeof device.deviceId === "string" &&
+    typeof device.label === "string"
+  );
+}

--- a/apps/desktop/src/features/tools/tunerPitch.test.ts
+++ b/apps/desktop/src/features/tools/tunerPitch.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  analyzeTunerBuffer,
+  calculateTunerInputLevel,
+  formatCents,
+  frequencyToTunerReading,
+} from "./tunerPitch";
+
+describe("chromatic tuner pitch helpers", () => {
+  it("maps frequencies to notes and cents from the selected reference", () => {
+    expect(frequencyToTunerReading(440, 440)?.noteName).toBe("A");
+    expect(frequencyToTunerReading(440, 440)?.cents).toBeCloseTo(0, 5);
+    expect(frequencyToTunerReading(432, 432)?.noteName).toBe("A");
+
+    const sharpReading = frequencyToTunerReading(466.16, 440);
+    expect(sharpReading?.noteName).toBe("A#");
+    expect(sharpReading?.cents).toBeCloseTo(0, 1);
+  });
+
+  it("detects the dominant pitch from a sine buffer", () => {
+    const reading = analyzeTunerBuffer(makeSineWave(440), 44100, 440);
+
+    expect(reading?.noteName).toBe("A");
+    expect(reading?.frequencyHz).toBeCloseTo(440, 0);
+    expect(reading?.cents).toBeCloseTo(0, 0);
+    expect(reading?.confidence).toBeGreaterThan(0.9);
+  });
+
+  it("ignores silence and formats signed cents", () => {
+    expect(analyzeTunerBuffer(new Float32Array(4096), 44100, 440)).toBeNull();
+    expect(calculateTunerInputLevel(new Float32Array([0, 0.5, -0.5, 0]))).toBeCloseTo(0.3535, 3);
+    expect(formatCents(3.2)).toBe("+3");
+    expect(formatCents(-2.6)).toBe("-3");
+  });
+});
+
+function makeSineWave(frequencyHz: number, sampleRate = 44100) {
+  const samples = new Float32Array(4096);
+  for (let index = 0; index < samples.length; index += 1) {
+    samples[index] = Math.sin((2 * Math.PI * frequencyHz * index) / sampleRate) * 0.72;
+  }
+  return samples;
+}

--- a/apps/desktop/src/features/tools/tunerPitch.ts
+++ b/apps/desktop/src/features/tools/tunerPitch.ts
@@ -1,0 +1,161 @@
+export type TunerPitchReading = {
+  cents: number;
+  confidence: number;
+  frequencyHz: number;
+  inputLevel: number;
+  noteName: string;
+  pitchClass: number;
+  targetFrequencyHz: number;
+};
+
+const NOTE_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"] as const;
+const MIN_TUNER_FREQUENCY_HZ = 50;
+const MAX_TUNER_FREQUENCY_HZ = 2000;
+const MIN_SIGNAL_RMS = 0.008;
+const MIN_CORRELATION = 0.62;
+
+export function frequencyToTunerReading(
+  frequencyHz: number,
+  referenceHz: number,
+  inputLevel = 0,
+  confidence = 1,
+): TunerPitchReading | null {
+  if (!Number.isFinite(frequencyHz) || frequencyHz <= 0 || !Number.isFinite(referenceHz) || referenceHz <= 0) {
+    return null;
+  }
+
+  const exactMidiNote = 69 + 12 * Math.log2(frequencyHz / referenceHz);
+  const nearestMidiNote = Math.round(exactMidiNote);
+  const pitchClass = ((nearestMidiNote % 12) + 12) % 12;
+  const targetFrequencyHz = referenceHz * 2 ** ((nearestMidiNote - 69) / 12);
+  const cents = 1200 * Math.log2(frequencyHz / targetFrequencyHz);
+
+  return {
+    cents,
+    confidence: clamp(confidence, 0, 1),
+    frequencyHz,
+    inputLevel: clamp(inputLevel, 0, 1),
+    noteName: NOTE_NAMES[pitchClass] ?? NOTE_NAMES[0],
+    pitchClass,
+    targetFrequencyHz,
+  };
+}
+
+export function analyzeTunerBuffer(
+  samples: Float32Array<ArrayBufferLike>,
+  sampleRate: number,
+  referenceHz: number,
+): TunerPitchReading | null {
+  if (samples.length === 0 || sampleRate <= 0) {
+    return null;
+  }
+
+  const inputLevel = calculateRms(samples);
+  if (inputLevel < MIN_SIGNAL_RMS) {
+    return null;
+  }
+
+  const minLag = Math.max(1, Math.floor(sampleRate / MAX_TUNER_FREQUENCY_HZ));
+  const maxLag = Math.min(samples.length - 2, Math.floor(sampleRate / MIN_TUNER_FREQUENCY_HZ));
+  if (maxLag <= minLag) {
+    return null;
+  }
+
+  const correlations = new Float32Array(maxLag + 1);
+
+  for (let lag = minLag; lag <= maxLag; lag += 1) {
+    correlations[lag] = normalizedCorrelation(samples, lag);
+  }
+
+  const { lag: bestLag, correlation: bestCorrelation } = findFirstConfidentPeak(
+    correlations,
+    minLag,
+    maxLag,
+  );
+
+  if (bestLag === 0 || bestCorrelation < MIN_CORRELATION) {
+    return null;
+  }
+
+  const lag = interpolateLag(correlations, bestLag);
+  return frequencyToTunerReading(sampleRate / lag, referenceHz, inputLevel, bestCorrelation);
+}
+
+export function formatCents(cents: number) {
+  const roundedCents = Math.round(cents);
+  if (roundedCents > 0) {
+    return `+${roundedCents}`;
+  }
+  return `${roundedCents}`;
+}
+
+export function calculateTunerInputLevel(samples: Float32Array<ArrayBufferLike>) {
+  let sumSquares = 0;
+  for (const sample of samples) {
+    sumSquares += sample * sample;
+  }
+  return Math.sqrt(sumSquares / samples.length);
+}
+
+function calculateRms(samples: Float32Array<ArrayBufferLike>) {
+  return calculateTunerInputLevel(samples);
+}
+
+function normalizedCorrelation(samples: Float32Array<ArrayBufferLike>, lag: number) {
+  let sum = 0;
+  let firstEnergy = 0;
+  let secondEnergy = 0;
+  const sampleCount = samples.length - lag;
+
+  for (let index = 0; index < sampleCount; index += 1) {
+    const first = samples[index] ?? 0;
+    const second = samples[index + lag] ?? 0;
+    sum += first * second;
+    firstEnergy += first * first;
+    secondEnergy += second * second;
+  }
+
+  const denominator = Math.sqrt(firstEnergy * secondEnergy);
+  return denominator > 0 ? sum / denominator : 0;
+}
+
+function interpolateLag(correlations: Float32Array, lag: number) {
+  const previous = correlations[lag - 1] ?? correlations[lag] ?? 0;
+  const current = correlations[lag] ?? 0;
+  const next = correlations[lag + 1] ?? current;
+  const denominator = previous - 2 * current + next;
+  if (Math.abs(denominator) < 0.000001) {
+    return lag;
+  }
+  return lag + (previous - next) / (2 * denominator);
+}
+
+function findFirstConfidentPeak(
+  correlations: Float32Array,
+  minLag: number,
+  maxLag: number,
+) {
+  let fallbackLag = 0;
+  let fallbackCorrelation = 0;
+
+  for (let lag = minLag + 1; lag < maxLag; lag += 1) {
+    const previous = correlations[lag - 1] ?? 0;
+    const current = correlations[lag] ?? 0;
+    const next = correlations[lag + 1] ?? 0;
+
+    if (current > fallbackCorrelation) {
+      fallbackCorrelation = current;
+      fallbackLag = lag;
+    }
+
+    if (current >= MIN_CORRELATION && current >= previous && current > next) {
+      return { lag, correlation: current };
+    }
+  }
+
+  return { lag: fallbackLag, correlation: fallbackCorrelation };
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}

--- a/apps/desktop/src/features/tools/tunerReadingSmoothing.test.ts
+++ b/apps/desktop/src/features/tools/tunerReadingSmoothing.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  createStabilizedTunerReadingState,
+  updateStabilizedTunerReading,
+} from "./tunerReadingSmoothing";
+import { type TunerPitchReading } from "./tunerPitch";
+
+describe("tuner reading smoothing", () => {
+  it("holds the last pitch through short no-pitch gaps", () => {
+    let state = createStabilizedTunerReadingState();
+    state = updateStabilizedTunerReading(state, makeReading("A", 9, 4), 0);
+    state = updateStabilizedTunerReading(state, null, 180);
+
+    expect(state.displayedReading?.noteName).toBe("A");
+
+    state = updateStabilizedTunerReading(state, null, 260);
+
+    expect(state.displayedReading).toBeNull();
+  });
+
+  it("smooths same-note cents changes", () => {
+    let state = createStabilizedTunerReadingState();
+    state = updateStabilizedTunerReading(state, makeReading("A", 9, 18), 0);
+    state = updateStabilizedTunerReading(state, makeReading("A", 9, -2), 16);
+
+    expect(state.displayedReading?.cents).toBeGreaterThan(-2);
+    expect(state.displayedReading?.cents).toBeLessThan(18);
+  });
+
+  it("debounces single-frame note changes", () => {
+    let state = createStabilizedTunerReadingState();
+    state = updateStabilizedTunerReading(state, makeReading("A", 9, 8), 0);
+    state = updateStabilizedTunerReading(state, makeReading("G#", 8, 2), 32);
+
+    expect(state.displayedReading?.noteName).toBe("A");
+
+    state = updateStabilizedTunerReading(state, makeReading("G#", 8, 1), 130);
+
+    expect(state.displayedReading?.noteName).toBe("G#");
+  });
+});
+
+function makeReading(noteName: string, pitchClass: number, cents: number): TunerPitchReading {
+  const targetFrequencyHz = 440;
+  const frequencyHz = targetFrequencyHz * 2 ** (cents / 1200);
+  return {
+    cents,
+    confidence: 0.95,
+    frequencyHz,
+    inputLevel: 0.5,
+    noteName,
+    pitchClass,
+    targetFrequencyHz,
+  };
+}

--- a/apps/desktop/src/features/tools/tunerReadingSmoothing.ts
+++ b/apps/desktop/src/features/tools/tunerReadingSmoothing.ts
@@ -1,0 +1,103 @@
+import { type TunerPitchReading } from "./tunerPitch";
+
+export type StabilizedTunerReadingState = {
+  displayedReading: TunerPitchReading | null;
+  lastPitchTimeMs: number | null;
+  pendingReading: TunerPitchReading | null;
+  pendingSinceMs: number | null;
+};
+
+const CENTS_SMOOTHING = 0.34;
+const FREQUENCY_SMOOTHING = 0.34;
+const NOTE_CHANGE_CONFIRM_MS = 90;
+const PITCH_HOLD_MS = 240;
+
+export function createStabilizedTunerReadingState(): StabilizedTunerReadingState {
+  return {
+    displayedReading: null,
+    lastPitchTimeMs: null,
+    pendingReading: null,
+    pendingSinceMs: null,
+  };
+}
+
+export function updateStabilizedTunerReading(
+  previousState: StabilizedTunerReadingState,
+  rawReading: TunerPitchReading | null,
+  nowMs: number,
+): StabilizedTunerReadingState {
+  if (!rawReading) {
+    if (
+      previousState.displayedReading &&
+      previousState.lastPitchTimeMs !== null &&
+      nowMs - previousState.lastPitchTimeMs <= PITCH_HOLD_MS
+    ) {
+      return {
+        ...previousState,
+        pendingReading: null,
+        pendingSinceMs: null,
+      };
+    }
+    return createStabilizedTunerReadingState();
+  }
+
+  if (!previousState.displayedReading) {
+    return {
+      displayedReading: rawReading,
+      lastPitchTimeMs: nowMs,
+      pendingReading: null,
+      pendingSinceMs: null,
+    };
+  }
+
+  if (rawReading.pitchClass !== previousState.displayedReading.pitchClass) {
+    const pendingSinceMs =
+      previousState.pendingReading?.pitchClass === rawReading.pitchClass
+        ? previousState.pendingSinceMs
+        : nowMs;
+
+    if (pendingSinceMs !== null && nowMs - pendingSinceMs >= NOTE_CHANGE_CONFIRM_MS) {
+      return {
+        displayedReading: rawReading,
+        lastPitchTimeMs: nowMs,
+        pendingReading: null,
+        pendingSinceMs: null,
+      };
+    }
+
+    return {
+      ...previousState,
+      lastPitchTimeMs: nowMs,
+      pendingReading: rawReading,
+      pendingSinceMs,
+    };
+  }
+
+  const displayedReading = smoothMatchingReading(previousState.displayedReading, rawReading);
+  return {
+    displayedReading,
+    lastPitchTimeMs: nowMs,
+    pendingReading: null,
+    pendingSinceMs: null,
+  };
+}
+
+function smoothMatchingReading(
+  previousReading: TunerPitchReading,
+  rawReading: TunerPitchReading,
+): TunerPitchReading {
+  if (Math.abs(previousReading.targetFrequencyHz - rawReading.targetFrequencyHz) > 0.001) {
+    return rawReading;
+  }
+
+  const cents = blend(previousReading.cents, rawReading.cents, CENTS_SMOOTHING);
+  return {
+    ...rawReading,
+    cents,
+    frequencyHz: blend(previousReading.frequencyHz, rawReading.frequencyHz, FREQUENCY_SMOOTHING),
+  };
+}
+
+function blend(previousValue: number, nextValue: number, amount: number) {
+  return previousValue + (nextValue - previousValue) * amount;
+}

--- a/apps/desktop/src/lib/preferences.tsx
+++ b/apps/desktop/src/lib/preferences.tsx
@@ -16,6 +16,10 @@ export type DefaultPlaybackDisplayMode = "auto" | PlaybackDisplayMode;
 export type DefaultChordBackend = "tuneforge-fast" | "crema-advanced";
 export type { EnharmonicDisplayMode };
 
+export const DEFAULT_TUNER_REFERENCE_HZ = 440;
+export const MIN_TUNER_REFERENCE_HZ = 400;
+export const MAX_TUNER_REFERENCE_HZ = 480;
+
 export type UiPreferences = {
   informationDensity: InformationDensity;
   enharmonicDisplayMode: EnharmonicDisplayMode;
@@ -26,11 +30,17 @@ export type UiPreferences = {
   defaultChordBackend: DefaultChordBackend;
   defaultLyricsFollowEnabled: boolean;
   defaultChordsFollowEnabled: boolean;
+  defaultTunerInputDeviceId: string | null;
+  defaultTunerReferenceHz: number;
 };
 
 export type AppearancePreferences = Pick<UiPreferences, "informationDensity">;
 export type NotationPreferences = Pick<UiPreferences, "enharmonicDisplayMode">;
 export type AnalysisPreferences = Pick<UiPreferences, "defaultChordBackend">;
+export type TunerPreferences = Pick<
+  UiPreferences,
+  "defaultTunerInputDeviceId" | "defaultTunerReferenceHz"
+>;
 export type VisibilityPreferences = Pick<
   UiPreferences,
   | "defaultInspectorOpen"
@@ -51,10 +61,13 @@ type PreferencesContextValue = UiPreferences & {
   setDefaultChordBackend: (value: DefaultChordBackend) => void;
   setDefaultLyricsFollowEnabled: (value: boolean) => void;
   setDefaultChordsFollowEnabled: (value: boolean) => void;
+  setDefaultTunerInputDeviceId: (value: string | null) => void;
+  setDefaultTunerReferenceHz: (value: number) => void;
   replacePreferences: (value: UiPreferences) => void;
   resetAppearancePreferences: () => void;
   resetNotationPreferences: () => void;
   resetAnalysisPreferences: () => void;
+  resetTunerPreferences: () => void;
   resetVisibilityPreferences: () => void;
   resetPreferences: () => void;
 };
@@ -73,6 +86,11 @@ export const DEFAULT_ANALYSIS_PREFERENCES: AnalysisPreferences = {
   defaultChordBackend: "tuneforge-fast",
 };
 
+export const DEFAULT_TUNER_PREFERENCES: TunerPreferences = {
+  defaultTunerInputDeviceId: null,
+  defaultTunerReferenceHz: DEFAULT_TUNER_REFERENCE_HZ,
+};
+
 export const DEFAULT_VISIBILITY_PREFERENCES: VisibilityPreferences = {
   defaultInspectorOpen: true,
   defaultSourcesRailCollapsed: false,
@@ -86,6 +104,7 @@ export const DEFAULT_PREFERENCES: UiPreferences = {
   ...DEFAULT_APPEARANCE_PREFERENCES,
   ...DEFAULT_NOTATION_PREFERENCES,
   ...DEFAULT_ANALYSIS_PREFERENCES,
+  ...DEFAULT_TUNER_PREFERENCES,
   ...DEFAULT_VISIBILITY_PREFERENCES,
 };
 
@@ -115,6 +134,26 @@ export function isDefaultPlaybackDisplayMode(
 
 export function isDefaultChordBackend(value: unknown): value is DefaultChordBackend {
   return value === "tuneforge-fast" || value === "crema-advanced";
+}
+
+function normalizeTunerInputDeviceId(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmedValue = value.trim();
+  return trimmedValue.length > 0 ? trimmedValue : null;
+}
+
+export function normalizeTunerReferenceHz(value: unknown): number {
+  const numericValue = typeof value === "number" ? value : Number(value);
+  if (
+    !Number.isFinite(numericValue) ||
+    numericValue < MIN_TUNER_REFERENCE_HZ ||
+    numericValue > MAX_TUNER_REFERENCE_HZ
+  ) {
+    return DEFAULT_TUNER_REFERENCE_HZ;
+  }
+  return Math.round(numericValue * 10) / 10;
 }
 
 export function normalizePreferences(value: unknown): UiPreferences {
@@ -147,6 +186,8 @@ export function normalizePreferences(value: unknown): UiPreferences {
     defaultChordBackend: isDefaultChordBackend(candidate.defaultChordBackend)
       ? candidate.defaultChordBackend
       : DEFAULT_PREFERENCES.defaultChordBackend,
+    defaultTunerInputDeviceId: normalizeTunerInputDeviceId(candidate.defaultTunerInputDeviceId),
+    defaultTunerReferenceHz: normalizeTunerReferenceHz(candidate.defaultTunerReferenceHz),
     defaultLyricsFollowEnabled:
       typeof candidate.defaultLyricsFollowEnabled === "boolean"
         ? candidate.defaultLyricsFollowEnabled
@@ -225,6 +266,20 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
       setDefaultChordsFollowEnabled: (defaultChordsFollowEnabled) => {
         setPreferences((current) => mergePreferences(current, { defaultChordsFollowEnabled }));
       },
+      setDefaultTunerInputDeviceId: (defaultTunerInputDeviceId) => {
+        setPreferences((current) =>
+          mergePreferences(current, {
+            defaultTunerInputDeviceId: normalizeTunerInputDeviceId(defaultTunerInputDeviceId),
+          }),
+        );
+      },
+      setDefaultTunerReferenceHz: (defaultTunerReferenceHz) => {
+        setPreferences((current) =>
+          mergePreferences(current, {
+            defaultTunerReferenceHz: normalizeTunerReferenceHz(defaultTunerReferenceHz),
+          }),
+        );
+      },
       replacePreferences: (value) => {
         const normalized = normalizePreferences(value);
         persistPreferences(normalized);
@@ -238,6 +293,9 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
       },
       resetAnalysisPreferences: () => {
         setPreferences((current) => mergePreferences(current, DEFAULT_ANALYSIS_PREFERENCES));
+      },
+      resetTunerPreferences: () => {
+        setPreferences((current) => mergePreferences(current, DEFAULT_TUNER_PREFERENCES));
       },
       resetVisibilityPreferences: () => {
         setPreferences((current) => mergePreferences(current, DEFAULT_VISIBILITY_PREFERENCES));

--- a/apps/desktop/src/setupTests.ts
+++ b/apps/desktop/src/setupTests.ts
@@ -13,15 +13,39 @@ type MockGainNode = GainNode & {
   disconnect: ReturnType<typeof vi.fn>;
 };
 
+type MockAnalyserNode = AnalyserNode & {
+  getFloatTimeDomainData: ReturnType<typeof vi.fn>;
+  setSamples: (samples: Float32Array | null) => void;
+};
+
+type MockMediaStreamAudioSourceNode = MediaStreamAudioSourceNode & {
+  connect: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+};
+
 type MockAudioContextInstance = AudioContext & {
   advanceTime: (seconds: number) => void;
+  createdAnalysers: MockAnalyserNode[];
+  createdMediaStreamSources: MockMediaStreamAudioSourceNode[];
   createdSources: MockAudioBufferSourceNode[];
+  createAnalyser: ReturnType<typeof vi.fn>;
   createBufferSource: ReturnType<typeof vi.fn>;
   createGain: ReturnType<typeof vi.fn>;
+  createMediaStreamSource: ReturnType<typeof vi.fn>;
   decodeAudioData: ReturnType<typeof vi.fn>;
   resume: ReturnType<typeof vi.fn>;
   suspend: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
+};
+
+type MockMediaDevicesController = {
+  clearGetUserMediaError: () => void;
+  enumerateDevices: ReturnType<typeof vi.fn>;
+  getUserMedia: ReturnType<typeof vi.fn>;
+  revealLabels: () => void;
+  rejectGetUserMedia: (error: Error | DOMException) => void;
+  reset: () => void;
+  setDevices: (devices: MediaDeviceInfo[]) => void;
 };
 
 function createStorageMock(): Storage {
@@ -57,6 +81,85 @@ Object.defineProperty(window, "localStorage", {
 Object.defineProperty(window, "sessionStorage", {
   writable: true,
   value: createStorageMock(),
+});
+
+function makeMediaDevice(deviceId: string, label: string): MediaDeviceInfo {
+  return {
+    deviceId,
+    groupId: `group-${deviceId}`,
+    kind: "audioinput",
+    label,
+    toJSON: () => ({}),
+  } as MediaDeviceInfo;
+}
+
+function makeMediaStream(): MediaStream {
+  const track = {
+    kind: "audio",
+    stop: vi.fn(),
+  } as unknown as MediaStreamTrack;
+
+  return {
+    getAudioTracks: vi.fn(() => [track]),
+    getTracks: vi.fn(() => [track]),
+  } as unknown as MediaStream;
+}
+
+const defaultMediaDevices = [
+  makeMediaDevice("built-in", "Built-in Microphone"),
+  makeMediaDevice("usb", "USB Interface"),
+];
+let mediaDevices = [...defaultMediaDevices];
+let mediaDeviceLabelsVisible = false;
+let getUserMediaError: Error | DOMException | null = null;
+
+const mockMediaDevices = {
+  addEventListener: vi.fn(),
+  enumerateDevices: vi.fn(async () =>
+    mediaDevices.map((device) => ({
+      ...device,
+      label: mediaDeviceLabelsVisible ? device.label : "",
+    })),
+  ),
+  getUserMedia: vi.fn(async () => {
+    if (getUserMediaError) {
+      throw getUserMediaError;
+    }
+    mediaDeviceLabelsVisible = true;
+    return makeMediaStream();
+  }),
+  removeEventListener: vi.fn(),
+};
+
+const mockMediaDevicesController: MockMediaDevicesController = {
+  clearGetUserMediaError() {
+    getUserMediaError = null;
+  },
+  enumerateDevices: mockMediaDevices.enumerateDevices,
+  getUserMedia: mockMediaDevices.getUserMedia,
+  revealLabels() {
+    mediaDeviceLabelsVisible = true;
+  },
+  rejectGetUserMedia(error) {
+    getUserMediaError = error;
+  },
+  reset() {
+    mediaDevices = [...defaultMediaDevices];
+    mediaDeviceLabelsVisible = false;
+    getUserMediaError = null;
+    mockMediaDevices.addEventListener.mockClear();
+    mockMediaDevices.enumerateDevices.mockClear();
+    mockMediaDevices.getUserMedia.mockClear();
+    mockMediaDevices.removeEventListener.mockClear();
+  },
+  setDevices(devices) {
+    mediaDevices = devices;
+  },
+};
+
+Object.defineProperty(navigator, "mediaDevices", {
+  configurable: true,
+  value: mockMediaDevices,
 });
 
 Object.defineProperty(window, "matchMedia", {
@@ -130,6 +233,8 @@ Object.defineProperty(window, "cancelAnimationFrame", {
 class MockAudioContext {
   destination = {} as AudioDestinationNode;
   state: AudioContextState = "running";
+  createdAnalysers: MockAnalyserNode[] = [];
+  createdMediaStreamSources: MockMediaStreamAudioSourceNode[] = [];
   createdSources: MockAudioBufferSourceNode[] = [];
   private currentTimeSeconds = 0;
 
@@ -187,6 +292,40 @@ class MockAudioContext {
     connect: vi.fn(),
     disconnect: vi.fn(),
   }) as unknown as MockGainNode);
+
+  createAnalyser = vi.fn(() => {
+    let samples: Float32Array | null = null;
+    const analyser = {
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      fftSize: 2048,
+      frequencyBinCount: 1024,
+      getFloatTimeDomainData: vi.fn((target: Float32Array) => {
+        if (!samples) {
+          target.fill(0);
+          return;
+        }
+        for (let index = 0; index < target.length; index += 1) {
+          target[index] = samples[index % samples.length] ?? 0;
+        }
+      }),
+      smoothingTimeConstant: 0,
+      setSamples(nextSamples: Float32Array | null) {
+        samples = nextSamples;
+      },
+    } as unknown as MockAnalyserNode;
+    this.createdAnalysers.push(analyser);
+    return analyser;
+  });
+
+  createMediaStreamSource = vi.fn(() => {
+    const source = {
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    } as unknown as MockMediaStreamAudioSourceNode;
+    this.createdMediaStreamSources.push(source);
+    return source;
+  });
 }
 
 const mockFetch = vi.fn(async () => {
@@ -216,4 +355,9 @@ Object.defineProperty(window, "webkitAudioContext", {
 Object.defineProperty(globalThis, "__mockAudioContexts", {
   writable: true,
   value: mockAudioContexts,
+});
+
+Object.defineProperty(globalThis, "__mockMediaDevices", {
+  writable: true,
+  value: mockMediaDevicesController,
 });

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -5,6 +5,7 @@
 @import "./styles/project-playback.css";
 @import "./styles/project-history.css";
 @import "./styles/project-inspector.css";
+@import "./styles/tools.css";
 @import "./styles/musical-labels.css";
 @import "./styles/source-key-selector.css";
 @import "./styles/target-selector.css";

--- a/apps/desktop/src/styles/tools.css
+++ b/apps/desktop/src/styles/tools.css
@@ -1,0 +1,392 @@
+.tuner-shell {
+  max-width: 920px;
+}
+
+.tuner-panel {
+  display: grid;
+  gap: 1.1rem;
+  border-color: color-mix(in srgb, var(--chip-active-border) 24%, var(--panel-border));
+  background: color-mix(in srgb, var(--panel-strong) 88%, var(--panel));
+}
+
+.tuner-header {
+  display: flex;
+  gap: 1rem;
+  align-items: start;
+  justify-content: space-between;
+}
+
+.tuner-header h2 {
+  margin: 0;
+}
+
+.tuner-preferences {
+  display: grid;
+  grid-template-columns: minmax(18rem, 1fr) minmax(12rem, 16rem);
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.tuner-preferences--with-mode {
+  grid-template-columns: minmax(16rem, 1fr) minmax(10rem, 12rem) minmax(10rem, 12rem);
+}
+
+.tuner-field {
+  display: grid;
+  gap: 0.36rem;
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+.tuner-field input,
+.tuner-field select {
+  width: 100%;
+  height: 2.9rem;
+  border: 1px solid var(--input-border);
+  border-radius: 12px;
+  padding: 0.68rem 0.8rem;
+  background: color-mix(in srgb, var(--input-bg) 92%, var(--panel-strong));
+  color: var(--input-text);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 8%, transparent);
+}
+
+.tuner-field input:focus-visible,
+.tuner-field select:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.tuner-preferences__status {
+  grid-column: 1 / -1;
+  margin: 0;
+  color: var(--muted);
+}
+
+.simple-tuner-meter,
+.wide-arc-tuner-meter {
+  display: grid;
+  gap: 1.1rem;
+}
+
+.simple-tuner-meter {
+  padding: 1.1rem;
+  border: 1px solid color-mix(in srgb, var(--chip-active-border) 18%, var(--divider));
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--surface-muted) 64%, transparent);
+}
+
+.simple-tuner-meter__readout {
+  display: grid;
+  justify-items: center;
+  gap: 0.12rem;
+  min-height: 9.8rem;
+  text-align: center;
+}
+
+.simple-tuner-meter__note {
+  min-width: 6rem;
+  padding: 0.08rem 0.95rem 0.34rem;
+  border: 1px solid color-mix(in srgb, var(--chip-active-border) 38%, var(--divider));
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--panel-strong) 88%, var(--surface-muted));
+  color: var(--text);
+  font-size: clamp(4.2rem, 13vw, 7.5rem);
+  font-weight: 900;
+  line-height: 0.95;
+}
+
+.simple-tuner-meter[data-tuning-state="in-tune"] .simple-tuner-meter__note {
+  border-color: color-mix(in srgb, var(--playback-accent) 58%, var(--chip-active-border));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--playback-accent) 14%, transparent);
+}
+
+.simple-tuner-meter[data-tuning-state="no-pitch"] .simple-tuner-meter__note {
+  color: var(--muted);
+}
+
+.simple-tuner-meter__status {
+  color: var(--muted);
+  font-size: 0.9rem;
+  font-weight: 800;
+}
+
+.simple-tuner-meter[data-tuning-state="in-tune"] .simple-tuner-meter__status {
+  color: color-mix(in srgb, var(--playback-accent) 68%, var(--text));
+}
+
+.simple-tuner-meter__cents {
+  color: var(--text);
+  font-size: 1.05rem;
+  font-weight: 850;
+}
+
+.simple-tuner-meter__meta {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.simple-tuner-meter__bar {
+  display: grid;
+  gap: 0.35rem;
+  width: min(100%, 48rem);
+  justify-self: center;
+}
+
+.simple-tuner-meter__scale,
+.simple-tuner-meter__directions {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 800;
+  text-align: center;
+}
+
+.simple-tuner-meter__directions {
+  grid-template-columns: repeat(3, 1fr);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+}
+
+.simple-tuner-meter__track {
+  position: relative;
+  height: 1.1rem;
+  border: 1px solid color-mix(in srgb, var(--chip-active-border) 28%, var(--divider));
+  border-radius: 999px;
+  background:
+    linear-gradient(90deg, transparent 0 49.5%, color-mix(in srgb, var(--chip-active-border) 18%, transparent) 49.5% 50.5%, transparent 50.5%),
+    color-mix(in srgb, var(--panel-strong) 84%, var(--surface-muted));
+}
+
+.simple-tuner-meter[data-tuning-state="in-tune"] .simple-tuner-meter__track {
+  background:
+    linear-gradient(90deg, transparent 0 49.5%, color-mix(in srgb, var(--playback-accent) 26%, transparent) 49.5% 50.5%, transparent 50.5%),
+    color-mix(in srgb, var(--panel-strong) 84%, var(--surface-muted));
+}
+
+.simple-tuner-meter[data-tuning-state="no-pitch"] .simple-tuner-meter__track {
+  opacity: 0.68;
+}
+
+.simple-tuner-meter__center {
+  position: absolute;
+  inset-block: -0.38rem;
+  left: 50%;
+  width: 2px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--chip-active-border) 62%, var(--divider));
+  transform: translateX(-50%);
+}
+
+.simple-tuner-meter[data-tuning-state="in-tune"] .simple-tuner-meter__center {
+  background: color-mix(in srgb, var(--playback-accent) 62%, var(--chip-active-border));
+}
+
+.simple-tuner-meter[data-tuning-state="no-pitch"] .simple-tuner-meter__center {
+  background: color-mix(in srgb, var(--divider) 82%, transparent);
+  opacity: 0.72;
+}
+
+.simple-tuner-meter__marker {
+  position: absolute;
+  top: 50%;
+  left: var(--tuner-marker-position, 50%);
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid color-mix(in srgb, white 38%, var(--playback-accent));
+  border-radius: 999px;
+  background: var(--playback-accent);
+  box-shadow: 0 0 0 0.32rem color-mix(in srgb, var(--playback-accent) 18%, transparent);
+  transform: translate(-50%, -50%);
+  transition: opacity 90ms ease-out;
+}
+
+.simple-tuner-meter[data-tuning-state="no-pitch"] .simple-tuner-meter__marker {
+  opacity: 0;
+}
+
+.simple-tuner-meter[data-tuning-state="flat"] .simple-tuner-meter__marker,
+.simple-tuner-meter[data-tuning-state="sharp"] .simple-tuner-meter__marker {
+  background: color-mix(in srgb, var(--playback-accent) 70%, var(--chip-active-border));
+}
+
+.tuner-gauge {
+  display: grid;
+  gap: 0.65rem;
+  min-height: 12rem;
+  padding: 0.6rem 0.5rem 0;
+}
+
+.tuner-gauge__scale {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 800;
+  text-align: center;
+}
+
+.tuner-gauge__arc {
+  position: relative;
+  width: min(100%, 34rem);
+  aspect-ratio: 2.25;
+  justify-self: center;
+  overflow: hidden;
+  border-bottom: 1px solid color-mix(in srgb, var(--divider) 82%, transparent);
+}
+
+.tuner-gauge__arc::before {
+  content: "";
+  position: absolute;
+  inset: 8% 4% -90%;
+  border: 2px solid color-mix(in srgb, var(--focus-ring) 44%, var(--divider));
+  border-bottom: 0;
+  border-radius: 50% 50% 0 0;
+  background:
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--chip-active-border) 16%, transparent) 0 34%,
+      color-mix(in srgb, var(--chip-active-border) 12%, transparent) 43% 57%,
+      color-mix(in srgb, var(--chip-active-border) 16%, transparent) 66% 100%
+    ),
+    color-mix(in srgb, var(--surface-muted) 56%, transparent);
+}
+
+.wide-arc-tuner-meter[data-tuning-state="in-tune"] .tuner-gauge__arc::before {
+  background:
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--chip-active-border) 16%, transparent) 0 34%,
+      color-mix(in srgb, var(--playback-accent) 22%, transparent) 43% 57%,
+      color-mix(in srgb, var(--chip-active-border) 16%, transparent) 66% 100%
+    ),
+    color-mix(in srgb, var(--surface-muted) 56%, transparent);
+}
+
+.tuner-gauge__tick,
+.tuner-gauge__needle {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  transform-origin: 50% 100%;
+}
+
+.tuner-gauge__tick {
+  width: 2px;
+  height: 70%;
+  background: color-mix(in srgb, var(--divider) 72%, transparent);
+}
+
+.tuner-gauge__tick--left {
+  transform: rotate(-32deg);
+}
+
+.tuner-gauge__tick--center {
+  height: 82%;
+  background: color-mix(in srgb, var(--chip-active-border) 70%, var(--divider));
+  transform: rotate(0deg);
+}
+
+.wide-arc-tuner-meter[data-tuning-state="in-tune"] .tuner-gauge__tick--center {
+  background: color-mix(in srgb, var(--playback-accent) 72%, var(--divider));
+}
+
+.tuner-gauge__tick--right {
+  transform: rotate(32deg);
+}
+
+.tuner-gauge__needle {
+  width: 4px;
+  height: 88%;
+  border-radius: 999px;
+  background: var(--playback-accent);
+  box-shadow: 0 0 18px color-mix(in srgb, var(--playback-accent) 32%, transparent);
+  transform: rotate(var(--tuner-needle-rotation, 0deg));
+  transition: opacity 90ms ease-out;
+}
+
+.wide-arc-tuner-meter[data-tuning-state="no-pitch"] .tuner-gauge__needle {
+  opacity: 0;
+}
+
+.wide-arc-tuner-meter[data-tuning-state="no-pitch"] .tuner-gauge__arc {
+  opacity: 0.68;
+}
+
+.tuner-readout {
+  display: grid;
+  justify-items: center;
+  gap: 0.18rem;
+  text-align: center;
+}
+
+.tuner-readout__note {
+  min-width: 5.3rem;
+  padding: 0.12rem 0.76rem 0.28rem;
+  border: 1px solid color-mix(in srgb, var(--chip-active-border) 48%, transparent);
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--panel-strong) 90%, var(--surface-muted));
+  font-size: clamp(4rem, 12vw, 7rem);
+  font-weight: 900;
+  line-height: 0.95;
+}
+
+.wide-arc-tuner-meter[data-tuning-state="no-pitch"] .tuner-readout__note {
+  color: var(--muted);
+}
+
+.tuner-readout__cents {
+  color: var(--text);
+  font-size: 1.1rem;
+  font-weight: 800;
+}
+
+.tuner-readout__meta {
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.tuner-level {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.8rem;
+  align-items: center;
+  color: var(--muted);
+  font-weight: 800;
+}
+
+.tuner-level__track {
+  height: 0.95rem;
+  overflow: hidden;
+  border: 1px solid var(--divider);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface-muted) 80%, transparent);
+}
+
+.tuner-level__bar {
+  display: block;
+  width: var(--tuner-level, 0%);
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--focus-ring), var(--playback-accent));
+  transition: width 90ms ease-out;
+}
+
+@media (max-width: 860px) {
+  .tuner-preferences,
+  .tuner-preferences--with-mode {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .tuner-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .tuner-gauge {
+    min-height: 10.5rem;
+  }
+}

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -885,6 +885,12 @@ export function getMockAudioContexts() {
   return (
     globalThis as typeof globalThis & {
       __mockAudioContexts: Array<{
+        createdAnalysers: Array<{
+          setSamples: (samples: Float32Array | null) => void;
+        }>;
+        createdMediaStreamSources: Array<{
+          connect: ReturnType<typeof vi.fn>;
+        }>;
         createdSources: Array<{
           start: ReturnType<typeof vi.fn>;
         }>;
@@ -895,6 +901,22 @@ export function getMockAudioContexts() {
 
 export function getMockFetch() {
   return globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+}
+
+export function getMockMediaDevices() {
+  return (
+    globalThis as typeof globalThis & {
+      __mockMediaDevices: {
+        clearGetUserMediaError: () => void;
+        enumerateDevices: ReturnType<typeof vi.fn>;
+        getUserMedia: ReturnType<typeof vi.fn>;
+        revealLabels: () => void;
+        rejectGetUserMedia: (error: Error | DOMException) => void;
+        reset: () => void;
+        setDevices: (devices: MediaDeviceInfo[]) => void;
+      };
+    }
+  ).__mockMediaDevices;
 }
 
 
@@ -933,5 +955,6 @@ export function resetAppTestHarness() {
   vi.mocked(window.HTMLMediaElement.prototype.pause).mockClear();
   getMockFetch().mockClear();
   getMockAudioContexts().length = 0;
+  getMockMediaDevices().reset();
   installMatchMediaMock(false);
 }


### PR DESCRIPTION
## Summary

- Add the desktop Tools route with a tabbed Chromatic Tuner.
- Add shared tuner preferences for microphone source and A4 reference tuning, surfaced in both Tools and Settings.
- Implement Simple Meter as the default tuner visualization, keep Wide Arc as an alternate mode, and stabilize the tuner display for practice use.
- Add desktop microphone permission handling, cached microphone labels, and tests for tuner math, controls, preferences, and visual states.

## Testing

- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop test --run`
- `cd apps/desktop/src-tauri && cargo check`
