### PR TITLE
feat: add metronome tool

### DIFF
--- a/apps/desktop/src/App.tools-metronome.test.tsx
+++ b/apps/desktop/src/App.tools-metronome.test.tsx
@@ -1,0 +1,252 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  findAudioByArtifactId,
+  getMockAudioContexts,
+  markAudioReady,
+  resetAppTestHarness,
+  renderApp,
+  setProjectAnalysis,
+  setProjects,
+} from "./test/appTestHarness";
+
+describe("Desktop app tools metronome", () => {
+  beforeEach(resetAppTestHarness);
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("opens the metronome tab from query params with seeded BPM", async () => {
+    renderApp(["/tools?tool=metronome&bpm=121.5&projectId=proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Metronome" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("heading", { name: "Metronome" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Tempo BPM")).toHaveValue(121.5);
+    expect(screen.getByText("Seeded from project analysis.")).toBeInTheDocument();
+    expect(screen.getByLabelText("Beats per bar")).toHaveValue(4);
+    expect(screen.getByLabelText("Accent first beat")).toBeChecked();
+    expect(screen.getByLabelText("Follow project playback")).not.toBeChecked();
+  });
+
+  it("arms follow mode from query params", async () => {
+    renderApp(["/tools?tool=metronome&bpm=121.5&projectId=proj_123&followPlayback=1"]);
+
+    expect(await screen.findByRole("heading", { name: "Metronome" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Tempo BPM")).toHaveValue(121.5);
+    expect(screen.getByLabelText("Follow project playback")).toBeChecked();
+    expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
+    expect(screen.getByText("No project playback active")).toBeInTheDocument();
+  });
+
+  it("updates tempo from the tap pad", async () => {
+    const nowSpy = vi.spyOn(performance, "now");
+    renderApp(["/tools?tool=metronome&bpm=90"]);
+
+    expect(await screen.findByRole("heading", { name: "Metronome" })).toBeInTheDocument();
+    const tapPad = screen.getByRole("button", { name: /Tap Tempo/i });
+    nowSpy.mockReturnValue(0);
+    fireEvent.click(tapPad);
+    nowSpy.mockReturnValue(500);
+    fireEvent.click(tapPad);
+
+    expect(screen.getByLabelText("Tempo BPM")).toHaveValue(120);
+    expect(screen.getByText("120.0 BPM")).toBeInTheDocument();
+  });
+
+  it("starts and stops generated click playback", async () => {
+    const user = userEvent.setup();
+    renderApp(["/tools?tool=metronome"]);
+
+    expect(await screen.findByRole("heading", { name: "Metronome" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Tempo BPM")).toHaveValue(100);
+    await user.click(screen.getByRole("button", { name: "Start" }));
+
+    await waitFor(() =>
+      expect(getMockAudioContexts()[0]?.createdOscillators.length).toBeGreaterThan(0),
+    );
+    expect(getMockAudioContexts()[0]?.createdOscillators[0]?.start).toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Stop" }));
+    expect(getMockAudioContexts()[0]?.close).toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Start" })).toBeInTheDocument();
+  });
+
+  it("shows volume percentage and double-click resets volume to 80 percent", async () => {
+    const user = userEvent.setup();
+    renderApp(["/tools?tool=metronome"]);
+
+    expect(await screen.findByRole("heading", { name: "Metronome" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Metronome volume 80%" })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Metronome volume"), { target: { value: "0.42" } });
+
+    expect(screen.getByRole("button", { name: "Metronome volume 42%" })).toBeInTheDocument();
+    await user.dblClick(screen.getByRole("button", { name: "Metronome volume 42%" }));
+
+    expect(screen.getByLabelText("Metronome volume")).toHaveValue("0.8");
+    expect(screen.getByRole("button", { name: "Metronome volume 80%" })).toBeInTheDocument();
+  });
+
+  it("opens from the project analysis tempo action", async () => {
+    const user = userEvent.setup();
+    setProjectAnalysis("proj_123", {
+      project_id: "proj_123",
+      estimated_key: "G major",
+      key_confidence: 0.82,
+      estimated_reference_hz: 440,
+      tuning_offset_cents: 0,
+      tempo_bpm: 121.48,
+      analysis_version: "v1",
+      created_at: "2026-04-18T13:16:00.000Z",
+    });
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("link", { name: "Follow on metronome at 121.5 BPM" }));
+
+    expect(await screen.findByRole("heading", { name: "Metronome" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Metronome" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByLabelText("Tempo BPM")).toHaveValue(121.5);
+    expect(screen.getByLabelText("Follow project playback")).toBeChecked();
+    expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
+  });
+
+  it("follows active project playback when sync is enabled", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    await user.click(screen.getByRole("tab", { name: "Playback" }));
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument(),
+    );
+
+    await user.click(screen.getByRole("link", { name: "Tools" }));
+    await user.click(await screen.findByRole("tab", { name: "Metronome" }));
+    await user.click(screen.getByLabelText("Follow project playback"));
+
+    await waitFor(() =>
+      expect(getMockAudioContexts()[0]?.createdOscillators.length).toBeGreaterThan(0),
+    );
+    const syncedContext = getMockAudioContexts()[0];
+    const scheduledBeforePause = syncedContext?.createdOscillators.length ?? 0;
+
+    await user.click(screen.getByRole("button", { name: "Pause background playback" }));
+    await waitFor(() =>
+      expect(screen.getAllByText("Waiting for Demo Song playback").length).toBeGreaterThan(0),
+    );
+    expect(syncedContext?.close).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Play background playback" }));
+    await waitFor(() =>
+      expect(syncedContext?.createdOscillators.length).toBeGreaterThan(scheduledBeforePause),
+    );
+  });
+
+  it("keeps synced metronome armed when opening the playback project page", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    await user.click(screen.getByRole("tab", { name: "Playback" }));
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument(),
+    );
+
+    await user.click(screen.getByRole("link", { name: "Tools" }));
+    await user.click(await screen.findByRole("tab", { name: "Metronome" }));
+    await user.click(screen.getByLabelText("Follow project playback"));
+    await waitFor(() =>
+      expect(getMockAudioContexts()[0]?.createdOscillators.length).toBeGreaterThan(0),
+    );
+    const syncedContext = getMockAudioContexts()[0];
+
+    await user.click(screen.getByRole("link", { name: "Open Demo Song project" }));
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Metronome" })).not.toBeInTheDocument();
+    expect(syncedContext?.close).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("link", { name: "Tools" }));
+    await user.click(await screen.findByRole("tab", { name: "Metronome" }));
+
+    expect(screen.getByLabelText("Follow project playback")).toBeChecked();
+    expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
+    expect(syncedContext?.close).not.toHaveBeenCalled();
+  });
+
+  it("updates followed metronome BPM from the next opened project analysis", async () => {
+    const user = userEvent.setup();
+    setProjects([
+      {
+        id: "proj_123",
+        display_name: "Demo Song",
+        source_path: "/tmp/demo.wav",
+        imported_path: "/tmp/projects/demo.wav",
+        duration_seconds: 182,
+        sample_rate: 44100,
+        channels: 2,
+        created_at: "2026-04-18T13:16:00.000Z",
+        updated_at: "2026-04-18T13:16:00.000Z",
+      },
+      {
+        id: "proj_456",
+        display_name: "Bass Drill",
+        source_path: "/tmp/bass-drill.wav",
+        imported_path: "/tmp/projects/bass-drill.wav",
+        duration_seconds: 120,
+        sample_rate: 48000,
+        channels: 2,
+        created_at: "2026-04-18T13:16:00.000Z",
+        updated_at: "2026-04-18T13:16:00.000Z",
+      },
+    ]);
+    setProjectAnalysis("proj_123", {
+      project_id: "proj_123",
+      estimated_key: "G major",
+      key_confidence: 0.82,
+      estimated_reference_hz: 440,
+      tuning_offset_cents: 0,
+      tempo_bpm: 121.48,
+      analysis_version: "v1",
+      created_at: "2026-04-18T13:16:00.000Z",
+    });
+    setProjectAnalysis("proj_456", {
+      project_id: "proj_456",
+      estimated_key: "A minor",
+      key_confidence: 0.74,
+      estimated_reference_hz: 440,
+      tuning_offset_cents: 0,
+      tempo_bpm: 88.76,
+      analysis_version: "v1",
+      created_at: "2026-04-18T13:16:00.000Z",
+    });
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("link", { name: "Follow on metronome at 121.5 BPM" }));
+    expect(await screen.findByRole("heading", { name: "Metronome" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Tempo BPM")).toHaveValue(121.5);
+    expect(screen.getByLabelText("Follow project playback")).toBeChecked();
+
+    await user.click(screen.getByRole("link", { name: "Library" }));
+    await user.click(await screen.findByRole("link", { name: "Open Bass Drill project" }));
+
+    expect(await screen.findByRole("heading", { name: "Bass Drill" })).toBeInTheDocument();
+    await user.click(screen.getByRole("link", { name: "Tools" }));
+    await user.click(await screen.findByRole("tab", { name: "Metronome" }));
+
+    await waitFor(() => expect(screen.getByLabelText("Tempo BPM")).toHaveValue(88.8));
+    expect(screen.getByLabelText("Follow project playback")).toBeChecked();
+    expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -6,6 +6,7 @@ import { usePlayback } from "./features/projects/playback-context";
 import { PlaybackProvider } from "./features/projects/playback";
 import { SettingsView } from "./features/settings/SettingsView";
 import { ThemeStudioView } from "./features/settings/ThemeStudioView";
+import { MetronomeProvider } from "./features/tools/metronome";
 import { ToolsView } from "./features/tools/ToolsView";
 import { PreferencesProvider } from "./lib/preferences";
 import { ThemeProvider } from "./lib/theme";
@@ -190,7 +191,9 @@ export default function App() {
     <ThemeProvider>
       <PreferencesProvider>
         <PlaybackProvider>
-          <AppChrome />
+          <MetronomeProvider>
+            <AppChrome />
+          </MetronomeProvider>
         </PlaybackProvider>
       </PreferencesProvider>
     </ThemeProvider>

--- a/apps/desktop/src/features/projects/ProjectView.tsx
+++ b/apps/desktop/src/features/projects/ProjectView.tsx
@@ -1,9 +1,21 @@
+import { useEffect } from "react";
 import { ProjectShell } from "./components/ProjectShell";
 import { ProjectViewModelProvider } from "./components/ProjectViewModelContext";
 import { useProjectViewModel } from "./hooks/useProjectViewModel";
+import { useMetronome } from "../tools/metronome-context";
 
 export function ProjectView() {
   const model = useProjectViewModel();
+  const { followPlayback, seedBpm } = useMetronome();
+  const tempoBpm = model.analysisQuery.data?.tempo_bpm;
+
+  useEffect(() => {
+    if (!followPlayback || typeof tempoBpm !== "number" || !Number.isFinite(tempoBpm)) {
+      return;
+    }
+
+    seedBpm(tempoBpm);
+  }, [followPlayback, seedBpm, tempoBpm]);
 
   return (
     <ProjectViewModelProvider model={model}>

--- a/apps/desktop/src/features/projects/components/InspectorPanel.tsx
+++ b/apps/desktop/src/features/projects/components/InspectorPanel.tsx
@@ -1,5 +1,7 @@
+import { Link } from "react-router-dom";
 import { MusicalKeyLabel } from "../../../components/MusicalLabel";
 import { formatKey } from "../../../lib/music";
+import { useMetronome } from "../../tools/metronome-context";
 import { TargetKeySelector } from "./TargetKeySelector";
 import { useProjectViewModelContext } from "./useProjectViewModelContext";
 
@@ -51,6 +53,18 @@ export function InspectorPanel() {
     transposeSemitones,
     tuningSummary,
   } = useProjectViewModelContext();
+  const { launchMetronome } = useMetronome();
+  const tempoBpm = analysisQuery.data?.tempo_bpm;
+  const canOpenMetronome = typeof tempoBpm === "number" && Number.isFinite(tempoBpm);
+  const metronomeSearchParams = new URLSearchParams();
+  if (canOpenMetronome) {
+    metronomeSearchParams.set("tool", "metronome");
+    metronomeSearchParams.set("bpm", tempoBpm.toFixed(1));
+    metronomeSearchParams.set("followPlayback", "1");
+    if (projectQuery.data?.id) {
+      metronomeSearchParams.set("projectId", projectQuery.data.id);
+    }
+  }
 
   return (
     <aside className="stack">
@@ -249,7 +263,7 @@ export function InspectorPanel() {
             <span className="metric-label">Tempo</span>
             <strong>
               <span className="analysis-stat__value">
-                {analysisQuery.data?.tempo_bpm?.toFixed(1) ?? "-"}
+                {canOpenMetronome ? tempoBpm.toFixed(1) : "-"}
               </span>
               <span className="analysis-stat__unit">BPM</span>
             </strong>
@@ -263,6 +277,18 @@ export function InspectorPanel() {
             </strong>
           </div>
         </div>
+        {canOpenMetronome ? (
+          <div className="analysis-action-row">
+            <Link
+              aria-label={`Follow on metronome at ${tempoBpm.toFixed(1)} BPM`}
+              className="button button--small analysis-stat__action"
+              onClick={() => void launchMetronome({ bpm: tempoBpm, followPlayback: true })}
+              to={`/tools?${metronomeSearchParams.toString()}`}
+            >
+              Follow on Metronome
+            </Link>
+          </div>
+        ) : null}
         <details className="details-block details-block--inset">
           <summary>Correct source key for this project</summary>
           <p className="artifact-meta">

--- a/apps/desktop/src/features/projects/playback-context.ts
+++ b/apps/desktop/src/features/projects/playback-context.ts
@@ -13,12 +13,20 @@ export type ProjectPlaybackSession = {
   durationHintSeconds: number;
 };
 
+export type PlaybackSnapshot = {
+  session: ProjectPlaybackSession | null;
+  playbackTimeSeconds: number;
+  playbackDurationSeconds: number;
+  isPlaying: boolean;
+};
+
 export type PlaybackContextValue = {
   session: ProjectPlaybackSession | null;
   playbackTimeSeconds: number;
   playbackDurationSeconds: number;
   isPlaying: boolean;
   activateStemPlayback: () => Promise<void>;
+  getPlaybackSnapshot: () => PlaybackSnapshot;
   registerProjectSession: (session: ProjectPlaybackSession) => void;
   togglePlayback: () => Promise<void>;
   playPlayback: () => Promise<void>;

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -523,6 +523,16 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     return getActiveMediaElements(targetSession)[0]?.currentTime ?? playbackTimeSecondsRef.current;
   });
 
+  const getPlaybackSnapshot = useStableCallback(function getPlaybackSnapshot() {
+    const activeSession = sessionRef.current;
+    return {
+      session: activeSession,
+      playbackTimeSeconds: readMasterTime(activeSession),
+      playbackDurationSeconds: playbackDurationSecondsRef.current,
+      isPlaying: isPlayingRef.current,
+    };
+  });
+
   useEffect(() => {
     if (typeof window === "undefined") {
       return;
@@ -1050,6 +1060,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       playbackDurationSeconds,
       isPlaying,
       activateStemPlayback,
+      getPlaybackSnapshot,
       registerProjectSession,
       togglePlayback,
       playPlayback,
@@ -1062,6 +1073,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     [
       dismissSession,
       activateStemPlayback,
+      getPlaybackSnapshot,
       isPlaying,
       pausePlayback,
       playbackDurationSeconds,

--- a/apps/desktop/src/features/tools/MetronomePage.tsx
+++ b/apps/desktop/src/features/tools/MetronomePage.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useRef } from "react";
+import { useSearchParams } from "react-router-dom";
+import { useMetronome } from "./metronome-context";
+import {
+  MAX_BEATS_PER_BAR,
+  MAX_METRONOME_BPM,
+  MIN_BEATS_PER_BAR,
+  MIN_METRONOME_BPM,
+} from "./metronomeUtils";
+
+export function MetronomePage() {
+  const [searchParams] = useSearchParams();
+  const {
+    accentFirstBeat,
+    activeBeat,
+    beatsPerBar,
+    bpm,
+    bpmDraft,
+    commitBpmDraft,
+    errorMessage,
+    followPlayback,
+    handleTapTempo,
+    isRunning,
+    launchMetronome,
+    resetVolume,
+    seedBpm,
+    setAccentFirstBeat,
+    setBeatsPerBarValue,
+    setBpmDraftValue,
+    setFollowPlaybackEnabled,
+    setVolume,
+    startMetronome,
+    stopMetronome,
+    syncStatus,
+    tapBpm,
+    volume,
+  } = useMetronome();
+  const queryBpm = searchParams.get("bpm");
+  const queryProjectId = searchParams.get("projectId");
+  const queryFollowPlayback = searchParams.get("followPlayback");
+  const lastQueryKeyRef = useRef<string | null>(null);
+  const seededFromAnalysis = queryBpm !== null && queryProjectId !== null;
+  const volumePercent = Math.round(volume * 100);
+
+  useEffect(() => {
+    const queryKey = `${queryBpm ?? ""}|${queryProjectId ?? ""}|${queryFollowPlayback ?? ""}`;
+    if (lastQueryKeyRef.current === queryKey) {
+      return;
+    }
+    lastQueryKeyRef.current = queryKey;
+
+    if (queryFollowPlayback === "1") {
+      void launchMetronome({ bpm: queryBpm, followPlayback: true });
+      return;
+    }
+
+    if (queryBpm !== null) {
+      seedBpm(queryBpm);
+    }
+  }, [launchMetronome, queryBpm, queryFollowPlayback, queryProjectId, seedBpm]);
+
+  return (
+    <div className="metronome-shell">
+      <div className="panel metronome-panel">
+        <div className="metronome-header">
+          <div>
+            <h2>Metronome</h2>
+            <p className="subpanel__copy">
+              {seededFromAnalysis ? "Seeded from project analysis." : syncStatus}
+            </p>
+          </div>
+          <div className="button-row">
+            {isRunning ? (
+              <button className="button button--ghost" onClick={stopMetronome} type="button">
+                Stop
+              </button>
+            ) : (
+              <button
+                className="button button--primary"
+                onClick={() => void startMetronome()}
+                type="button"
+              >
+                Start
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div className="metronome-grid">
+          <label className="metronome-field metronome-field--tempo">
+            <span>Tempo BPM</span>
+            <input
+              aria-label="Tempo BPM"
+              max={MAX_METRONOME_BPM}
+              min={MIN_METRONOME_BPM}
+              onBlur={commitBpmDraft}
+              onChange={(event) => setBpmDraftValue(event.target.value)}
+              step="0.1"
+              type="number"
+              value={bpmDraft}
+            />
+          </label>
+          <label className="metronome-field">
+            <span>Beats per bar</span>
+            <input
+              aria-label="Beats per bar"
+              max={MAX_BEATS_PER_BAR}
+              min={MIN_BEATS_PER_BAR}
+              onChange={(event) => setBeatsPerBarValue(event.target.value)}
+              step="1"
+              type="number"
+              value={beatsPerBar}
+            />
+          </label>
+          <div className="metronome-field">
+            <div className="metronome-field__label-row">
+              <span>Metronome volume</span>
+              <button
+                aria-label={`Metronome volume ${volumePercent}%`}
+                className="metronome-volume-value"
+                onDoubleClick={resetVolume}
+                type="button"
+              >
+                {volumePercent}%
+              </button>
+            </div>
+            <input
+              aria-label="Metronome volume"
+              max="1"
+              min="0"
+              onChange={(event) => setVolume(Number(event.target.value))}
+              step="0.01"
+              type="range"
+              value={volume}
+            />
+          </div>
+        </div>
+
+        <div className="metronome-switches">
+          <label className="metronome-toggle">
+            <input
+              checked={accentFirstBeat}
+              onChange={(event) => setAccentFirstBeat(event.target.checked)}
+              type="checkbox"
+            />
+            <span>Accent first beat</span>
+          </label>
+          <label className="metronome-toggle">
+            <input
+              checked={followPlayback}
+              onChange={(event) => void setFollowPlaybackEnabled(event.target.checked)}
+              type="checkbox"
+            />
+            <span>Follow project playback</span>
+          </label>
+        </div>
+
+        <div className="metronome-readout" aria-live="polite">
+          <div className="metronome-readout__tempo">
+            <strong>{bpm.toFixed(1)}</strong>
+            <span>BPM</span>
+          </div>
+          <div className="metronome-beats" aria-label="Beat position">
+            {Array.from({ length: beatsPerBar }, (_, index) => index + 1).map((beatNumber) => (
+              <span
+                key={beatNumber}
+                className={`metronome-beats__dot${
+                  activeBeat === beatNumber ? " metronome-beats__dot--active" : ""
+                }${beatNumber === 1 && accentFirstBeat ? " metronome-beats__dot--accent" : ""}`}
+              >
+                {beatNumber}
+              </span>
+            ))}
+          </div>
+          <p className="artifact-meta">{syncStatus}</p>
+        </div>
+
+        <button className="metronome-tap-pad" onClick={handleTapTempo} type="button">
+          <span>Tap Tempo</span>
+          <strong>{tapBpm === null ? "Tap here" : `${tapBpm.toFixed(1)} BPM`}</strong>
+        </button>
+
+        {errorMessage ? <p className="inline-error">{errorMessage}</p> : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/tools/ToolsView.tsx
+++ b/apps/desktop/src/features/tools/ToolsView.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { useStableCallback } from "../../lib/useStableCallback";
 import { usePreferences } from "../../lib/preferences";
+import { MetronomePage } from "./MetronomePage";
 import { TunerPreferenceControls } from "./TunerPreferenceControls";
 import {
   SimpleTunerMeter,
@@ -25,10 +27,27 @@ import {
 } from "./tunerPitch";
 
 type TunerStatus = "idle" | "starting" | "listening" | "unsupported" | "error";
+type ToolId = "tuner" | "metronome";
 
 type AudioContextConstructor = typeof AudioContext;
 
 export function ToolsView() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTool = readToolId(searchParams);
+
+  function handleSelectTool(tool: ToolId) {
+    const nextSearchParams = new URLSearchParams(searchParams);
+    if (tool === "tuner") {
+      nextSearchParams.delete("tool");
+      nextSearchParams.delete("bpm");
+      nextSearchParams.delete("followPlayback");
+      nextSearchParams.delete("projectId");
+    } else {
+      nextSearchParams.set("tool", "metronome");
+    }
+    setSearchParams(nextSearchParams);
+  }
+
   return (
     <section className="screen">
       <div className="screen__header">
@@ -40,19 +59,32 @@ export function ToolsView() {
       </div>
 
       <div className="project-workspace-tabs" role="tablist" aria-label="Tools">
-        <button
-          aria-selected="true"
-          className="project-workspace-tabs__button project-workspace-tabs__button--active"
-          role="tab"
-          type="button"
-        >
-          Chromatic Tuner
-        </button>
+        {[
+          { id: "tuner", label: "Chromatic Tuner" },
+          { id: "metronome", label: "Metronome" },
+        ].map((tool) => (
+          <button
+            key={tool.id}
+            aria-selected={activeTool === tool.id}
+            className={`project-workspace-tabs__button${
+              activeTool === tool.id ? " project-workspace-tabs__button--active" : ""
+            }`}
+            onClick={() => handleSelectTool(tool.id as ToolId)}
+            role="tab"
+            type="button"
+          >
+            {tool.label}
+          </button>
+        ))}
       </div>
 
-      <ChromaticTunerPage />
+      {activeTool === "tuner" ? <ChromaticTunerPage /> : <MetronomePage />}
     </section>
   );
+}
+
+function readToolId(searchParams: URLSearchParams): ToolId {
+  return searchParams.get("tool") === "metronome" ? "metronome" : "tuner";
 }
 
 function ChromaticTunerPage() {

--- a/apps/desktop/src/features/tools/metronome-context.ts
+++ b/apps/desktop/src/features/tools/metronome-context.ts
@@ -1,0 +1,42 @@
+import { createContext, useContext } from "react";
+
+export type MetronomeLaunchOptions = {
+  bpm?: unknown;
+  followPlayback?: boolean;
+};
+
+export type MetronomeContextValue = {
+  accentFirstBeat: boolean;
+  activeBeat: number | null;
+  beatsPerBar: number;
+  bpm: number;
+  bpmDraft: string;
+  errorMessage: string | null;
+  followPlayback: boolean;
+  isRunning: boolean;
+  syncStatus: string;
+  tapBpm: number | null;
+  volume: number;
+  commitBpmDraft: () => void;
+  handleTapTempo: () => void;
+  launchMetronome: (options?: MetronomeLaunchOptions) => Promise<void>;
+  resetVolume: () => void;
+  seedBpm: (value: unknown) => void;
+  setAccentFirstBeat: (enabled: boolean) => void;
+  setBeatsPerBarValue: (value: string) => void;
+  setBpmDraftValue: (value: string) => void;
+  setFollowPlaybackEnabled: (enabled: boolean) => Promise<void>;
+  setVolume: (volume: number) => void;
+  startMetronome: () => Promise<void>;
+  stopMetronome: () => void;
+};
+
+export const MetronomeContext = createContext<MetronomeContextValue | null>(null);
+
+export function useMetronome() {
+  const context = useContext(MetronomeContext);
+  if (!context) {
+    throw new Error("useMetronome must be used within a MetronomeProvider.");
+  }
+  return context;
+}

--- a/apps/desktop/src/features/tools/metronome.tsx
+++ b/apps/desktop/src/features/tools/metronome.tsx
@@ -1,0 +1,452 @@
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useStableCallback } from "../../lib/useStableCallback";
+import { usePlayback, type PlaybackSnapshot } from "../projects/playback-context";
+import { MetronomeContext, type MetronomeLaunchOptions } from "./metronome-context";
+import { DEFAULT_METRONOME_SOUND, scheduleMetronomeClick } from "./metronomeSound";
+import {
+  DEFAULT_BEATS_PER_BAR,
+  DEFAULT_METRONOME_VOLUME,
+  beatNumberForIndex,
+  createTapTempoState,
+  isAccentBeat,
+  nextSyncedBeatIndex,
+  normalizeBeatsPerBar,
+  normalizeMetronomeBpm,
+  secondsPerBeat,
+  updateTapTempo,
+  type TapTempoState,
+} from "./metronomeUtils";
+
+const SCHEDULE_AHEAD_SECONDS = 0.12;
+const SCHEDULER_INTERVAL_MS = 25;
+const START_DELAY_SECONDS = 0.035;
+
+type AudioContextConstructor = typeof AudioContext;
+
+export function MetronomeProvider({ children }: { children: ReactNode }) {
+  const { getPlaybackSnapshot, isPlaying, session } = usePlayback();
+  const [bpm, setBpm] = useState(() => normalizeMetronomeBpm(null));
+  const [bpmDraft, setBpmDraft] = useState(() => normalizeMetronomeBpm(null).toString());
+  const [beatsPerBar, setBeatsPerBar] = useState(DEFAULT_BEATS_PER_BAR);
+  const [accentFirstBeat, setAccentFirstBeat] = useState(true);
+  const [followPlayback, setFollowPlayback] = useState(false);
+  const [volume, setVolumeState] = useState(DEFAULT_METRONOME_VOLUME);
+  const [isRunning, setIsRunning] = useState(false);
+  const [activeBeat, setActiveBeat] = useState<number | null>(null);
+  const [tapBpm, setTapBpm] = useState<number | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const accentFirstBeatRef = useRef(accentFirstBeat);
+  const activeBeatTimeoutsRef = useRef<number[]>([]);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const beatsPerBarRef = useRef(beatsPerBar);
+  const bpmRef = useRef(bpm);
+  const followPlaybackRef = useRef(followPlayback);
+  const freeRunOriginRef = useRef(0);
+  const isRunningRef = useRef(isRunning);
+  const lastSyncedPlaybackTimeRef = useRef<number | null>(null);
+  const lastSyncedScheduledBeatRef = useRef<number | null>(null);
+  const nextFreeRunBeatIndexRef = useRef(0);
+  const schedulerIntervalRef = useRef<number | null>(null);
+  const tapTempoStateRef = useRef<TapTempoState>(createTapTempoState());
+  const volumeRef = useRef(volume);
+
+  useEffect(() => {
+    bpmRef.current = bpm;
+  }, [bpm]);
+
+  useEffect(() => {
+    beatsPerBarRef.current = beatsPerBar;
+  }, [beatsPerBar]);
+
+  useEffect(() => {
+    accentFirstBeatRef.current = accentFirstBeat;
+  }, [accentFirstBeat]);
+
+  useEffect(() => {
+    followPlaybackRef.current = followPlayback;
+  }, [followPlayback]);
+
+  useEffect(() => {
+    volumeRef.current = volume;
+  }, [volume]);
+
+  useEffect(() => {
+    isRunningRef.current = isRunning;
+  }, [isRunning]);
+
+  const clearBeatTimeouts = useStableCallback(function clearBeatTimeouts() {
+    activeBeatTimeoutsRef.current.forEach((timeoutId) => window.clearTimeout(timeoutId));
+    activeBeatTimeoutsRef.current = [];
+  });
+
+  const clearScheduler = useStableCallback(function clearScheduler() {
+    if (schedulerIntervalRef.current !== null) {
+      window.clearInterval(schedulerIntervalRef.current);
+      schedulerIntervalRef.current = null;
+    }
+    clearBeatTimeouts();
+    setActiveBeat(null);
+  });
+
+  const stopAudioClock = useStableCallback(function stopAudioClock() {
+    clearScheduler();
+    lastSyncedPlaybackTimeRef.current = null;
+    lastSyncedScheduledBeatRef.current = null;
+    const audioContext = audioContextRef.current;
+    audioContextRef.current = null;
+    if (audioContext && audioContext.state !== "closed") {
+      void audioContext.close().catch(() => undefined);
+    }
+  });
+
+  const pauseSyncedClock = useStableCallback(function pauseSyncedClock() {
+    clearScheduler();
+    lastSyncedPlaybackTimeRef.current = null;
+    lastSyncedScheduledBeatRef.current = null;
+  });
+
+  const ensureAudioContext = useStableCallback(function ensureAudioContext() {
+    if (audioContextRef.current && audioContextRef.current.state !== "closed") {
+      return audioContextRef.current;
+    }
+    const AudioContextCtor = getAudioContextConstructor();
+    if (!AudioContextCtor) {
+      setErrorMessage("Audio playback is unavailable.");
+      return null;
+    }
+    const audioContext = new AudioContextCtor();
+    audioContextRef.current = audioContext;
+    return audioContext;
+  });
+
+  const activateAudioContext = useStableCallback(async function activateAudioContext() {
+    const audioContext = ensureAudioContext();
+    if (!audioContext) {
+      return null;
+    }
+    try {
+      if (audioContext.state === "suspended") {
+        await audioContext.resume();
+      }
+    } catch {
+      setErrorMessage("Could not start metronome audio.");
+      return null;
+    }
+    return audioContext;
+  });
+
+  const scheduleBeat = useStableCallback(function scheduleBeat(
+    audioContext: AudioContext,
+    beatIndex: number,
+    startTimeSeconds: number,
+  ) {
+    const beatNumber = beatNumberForIndex(beatIndex, beatsPerBarRef.current);
+    const accent = isAccentBeat(beatIndex, beatsPerBarRef.current, accentFirstBeatRef.current);
+    scheduleMetronomeClick({
+      accent,
+      audioContext,
+      sound: DEFAULT_METRONOME_SOUND,
+      startTimeSeconds,
+      volume: volumeRef.current,
+    });
+
+    const timeoutId = window.setTimeout(
+      () => setActiveBeat(beatNumber),
+      Math.max(0, (startTimeSeconds - audioContext.currentTime) * 1000),
+    );
+    activeBeatTimeoutsRef.current.push(timeoutId);
+  });
+
+  const scheduleFreeRun = useStableCallback(function scheduleFreeRun(audioContext: AudioContext) {
+    const beatSeconds = secondsPerBeat(bpmRef.current);
+    let nextBeatIndex = nextFreeRunBeatIndexRef.current;
+    const scheduleUntilSeconds = audioContext.currentTime + SCHEDULE_AHEAD_SECONDS;
+
+    while (freeRunOriginRef.current + nextBeatIndex * beatSeconds <= scheduleUntilSeconds) {
+      const beatTimeSeconds = freeRunOriginRef.current + nextBeatIndex * beatSeconds;
+      if (beatTimeSeconds >= audioContext.currentTime - 0.005) {
+        scheduleBeat(audioContext, nextBeatIndex, beatTimeSeconds);
+      }
+      nextBeatIndex += 1;
+    }
+
+    nextFreeRunBeatIndexRef.current = nextBeatIndex;
+  });
+
+  const startFreeRunClock = useStableCallback(function startFreeRunClock(audioContext: AudioContext) {
+    clearScheduler();
+    freeRunOriginRef.current = audioContext.currentTime + START_DELAY_SECONDS;
+    nextFreeRunBeatIndexRef.current = 0;
+    scheduleFreeRun(audioContext);
+    schedulerIntervalRef.current = window.setInterval(
+      () => scheduleFreeRun(audioContext),
+      SCHEDULER_INTERVAL_MS,
+    );
+  });
+
+  const scheduleSynced = useStableCallback(function scheduleSynced(
+    audioContext: AudioContext,
+    snapshot: PlaybackSnapshot,
+  ) {
+    const beatSeconds = secondsPerBeat(bpmRef.current);
+    const playbackTimeSeconds = Math.max(0, snapshot.playbackTimeSeconds);
+    let beatIndex = nextSyncedBeatIndex({
+      bpm: bpmRef.current,
+      lastPlaybackTimeSeconds: lastSyncedPlaybackTimeRef.current,
+      lastScheduledBeatIndex: lastSyncedScheduledBeatRef.current,
+      playbackTimeSeconds,
+    });
+    const scheduleUntilPlaybackSeconds = playbackTimeSeconds + SCHEDULE_AHEAD_SECONDS;
+
+    while (beatIndex * beatSeconds <= scheduleUntilPlaybackSeconds) {
+      const beatPlaybackTimeSeconds = beatIndex * beatSeconds;
+      const startTimeSeconds =
+        audioContext.currentTime + Math.max(0, beatPlaybackTimeSeconds - playbackTimeSeconds);
+      scheduleBeat(audioContext, beatIndex, startTimeSeconds);
+      lastSyncedScheduledBeatRef.current = beatIndex;
+      beatIndex += 1;
+    }
+
+    lastSyncedPlaybackTimeRef.current = playbackTimeSeconds;
+  });
+
+  const seedBpm = useStableCallback(function seedBpm(value: unknown) {
+    const nextBpm = normalizeMetronomeBpm(value);
+    setBpm(nextBpm);
+    setBpmDraft(nextBpm.toString());
+  });
+
+  const startMetronome = useStableCallback(async function startMetronome() {
+    setErrorMessage(null);
+    const audioContext = await activateAudioContext();
+    if (!audioContext) {
+      return;
+    }
+    setIsRunning(true);
+  });
+
+  const stopMetronome = useStableCallback(function stopMetronome() {
+    stopAudioClock();
+    setIsRunning(false);
+  });
+
+  const setFollowPlaybackEnabled = useStableCallback(async function setFollowPlaybackEnabled(
+    enabled: boolean,
+  ) {
+    setFollowPlayback(enabled);
+    if (!enabled) {
+      return;
+    }
+    await startMetronome();
+  });
+
+  const launchMetronome = useStableCallback(async function launchMetronome(
+    options: MetronomeLaunchOptions = {},
+  ) {
+    if (options.bpm !== undefined) {
+      seedBpm(options.bpm);
+    }
+    if (typeof options.followPlayback === "boolean") {
+      setFollowPlayback(options.followPlayback);
+    }
+    await startMetronome();
+  });
+
+  const setBpmDraftValue = useStableCallback(function setBpmDraftValue(value: string) {
+    setBpmDraft(value);
+    const numericValue = Number(value);
+    if (!Number.isFinite(numericValue)) {
+      return;
+    }
+    setBpm(normalizeMetronomeBpm(numericValue));
+  });
+
+  const commitBpmDraft = useStableCallback(function commitBpmDraft() {
+    const nextBpm = normalizeMetronomeBpm(bpmDraft, bpm);
+    setBpm(nextBpm);
+    setBpmDraft(nextBpm.toString());
+  });
+
+  const setBeatsPerBarValue = useStableCallback(function setBeatsPerBarValue(value: string) {
+    setBeatsPerBar(normalizeBeatsPerBar(value, beatsPerBar));
+  });
+
+  const setVolume = useStableCallback(function setVolume(value: number) {
+    setVolumeState(normalizeVolume(value));
+  });
+
+  const resetVolume = useStableCallback(function resetVolume() {
+    setVolumeState(DEFAULT_METRONOME_VOLUME);
+  });
+
+  const handleTapTempo = useStableCallback(function handleTapTempo() {
+    const result = updateTapTempo(tapTempoStateRef.current, getCurrentMetronomeTimeMs());
+    tapTempoStateRef.current = result.state;
+    setTapBpm(result.bpm);
+    if (result.bpm !== null) {
+      setBpm(result.bpm);
+      setBpmDraft(result.bpm.toString());
+    }
+  });
+
+  useEffect(
+    () => () => {
+      stopAudioClock();
+    },
+    [stopAudioClock],
+  );
+
+  useEffect(() => {
+    if (!isRunning) {
+      return;
+    }
+    if (!followPlayback) {
+      const audioContext = audioContextRef.current;
+      if (audioContext && audioContext.state !== "closed") {
+        startFreeRunClock(audioContext);
+        return;
+      }
+      void activateAudioContext().then((nextAudioContext) => {
+        if (nextAudioContext && isRunningRef.current && !followPlaybackRef.current) {
+          startFreeRunClock(nextAudioContext);
+        }
+      });
+      return;
+    }
+
+    clearScheduler();
+    lastSyncedPlaybackTimeRef.current = null;
+    lastSyncedScheduledBeatRef.current = null;
+  }, [
+    accentFirstBeat,
+    activateAudioContext,
+    beatsPerBar,
+    bpm,
+    clearScheduler,
+    followPlayback,
+    isRunning,
+    startFreeRunClock,
+  ]);
+
+  useEffect(() => {
+    if (!isRunning || !followPlayback) {
+      return;
+    }
+
+    let frameId: number | null = null;
+    function tick() {
+      const snapshot = getPlaybackSnapshot();
+      if (!snapshot.session || !snapshot.isPlaying) {
+        pauseSyncedClock();
+      } else {
+        const audioContext = ensureAudioContext();
+        if (audioContext) {
+          if (audioContext.state === "suspended") {
+            void audioContext.resume().catch(() => undefined);
+          }
+          scheduleSynced(audioContext, snapshot);
+        }
+      }
+      frameId = window.requestAnimationFrame(tick);
+    }
+
+    frameId = window.requestAnimationFrame(tick);
+    return () => {
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId);
+      }
+    };
+  }, [
+    ensureAudioContext,
+    followPlayback,
+    getPlaybackSnapshot,
+    isRunning,
+    pauseSyncedClock,
+    scheduleSynced,
+  ]);
+
+  const syncStatus = followPlayback
+    ? session
+      ? isPlaying
+        ? `Following ${session.projectName}`
+        : `Waiting for ${session.projectName} playback`
+      : "No project playback active"
+    : "Standalone clock";
+
+  const value = useMemo(
+    () => ({
+      accentFirstBeat,
+      activeBeat,
+      beatsPerBar,
+      bpm,
+      bpmDraft,
+      commitBpmDraft,
+      errorMessage,
+      followPlayback,
+      handleTapTempo,
+      isRunning,
+      launchMetronome,
+      resetVolume,
+      seedBpm,
+      setAccentFirstBeat,
+      setBeatsPerBarValue,
+      setBpmDraftValue,
+      setFollowPlaybackEnabled,
+      setVolume,
+      startMetronome,
+      stopMetronome,
+      syncStatus,
+      tapBpm,
+      volume,
+    }),
+    [
+      accentFirstBeat,
+      activeBeat,
+      beatsPerBar,
+      bpm,
+      bpmDraft,
+      commitBpmDraft,
+      errorMessage,
+      followPlayback,
+      handleTapTempo,
+      isRunning,
+      launchMetronome,
+      resetVolume,
+      seedBpm,
+      setBeatsPerBarValue,
+      setBpmDraftValue,
+      setFollowPlaybackEnabled,
+      setVolume,
+      startMetronome,
+      stopMetronome,
+      syncStatus,
+      tapBpm,
+      volume,
+    ],
+  );
+
+  return <MetronomeContext.Provider value={value}>{children}</MetronomeContext.Provider>;
+}
+
+function getAudioContextConstructor(): AudioContextConstructor | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return (
+    window.AudioContext ??
+    (window as Window & typeof globalThis & { webkitAudioContext?: AudioContextConstructor })
+      .webkitAudioContext ??
+    null
+  );
+}
+
+function getCurrentMetronomeTimeMs() {
+  return typeof performance !== "undefined" ? performance.now() : Date.now();
+}
+
+function normalizeVolume(value: number) {
+  if (!Number.isFinite(value)) {
+    return DEFAULT_METRONOME_VOLUME;
+  }
+  return Math.max(0, Math.min(1, value));
+}

--- a/apps/desktop/src/features/tools/metronomeSound.ts
+++ b/apps/desktop/src/features/tools/metronomeSound.ts
@@ -1,0 +1,65 @@
+export type GeneratedMetronomeSound = {
+  accentDurationSeconds: number;
+  accentFrequencyHz: number;
+  durationSeconds: number;
+  frequencyHz: number;
+  id: "generated-click";
+  kind: "generated";
+  label: string;
+};
+
+export type MetronomeSound = GeneratedMetronomeSound;
+
+export const METRONOME_SOUNDS: MetronomeSound[] = [
+  {
+    accentDurationSeconds: 0.045,
+    accentFrequencyHz: 1760,
+    durationSeconds: 0.032,
+    frequencyHz: 1175,
+    id: "generated-click",
+    kind: "generated",
+    label: "Generated Click",
+  },
+];
+
+export const DEFAULT_METRONOME_SOUND = METRONOME_SOUNDS[0];
+
+export function scheduleMetronomeClick({
+  accent,
+  audioContext,
+  sound = DEFAULT_METRONOME_SOUND,
+  startTimeSeconds,
+  volume,
+}: {
+  accent: boolean;
+  audioContext: AudioContext;
+  sound?: MetronomeSound;
+  startTimeSeconds: number;
+  volume: number;
+}) {
+  const oscillator = audioContext.createOscillator();
+  const gainNode = audioContext.createGain();
+  const durationSeconds = accent ? sound.accentDurationSeconds : sound.durationSeconds;
+  const frequencyHz = accent ? sound.accentFrequencyHz : sound.frequencyHz;
+  const peakGain = Math.min(1, Math.max(0, volume)) * (accent ? 0.42 : 0.32);
+  const safeStartTimeSeconds = Math.max(audioContext.currentTime, startTimeSeconds);
+  const stopTimeSeconds = safeStartTimeSeconds + durationSeconds;
+
+  oscillator.type = "square";
+  oscillator.frequency.setValueAtTime(frequencyHz, safeStartTimeSeconds);
+  gainNode.gain.setValueAtTime(0.0001, safeStartTimeSeconds);
+  gainNode.gain.exponentialRampToValueAtTime(
+    Math.max(0.0001, peakGain),
+    safeStartTimeSeconds + 0.004,
+  );
+  gainNode.gain.exponentialRampToValueAtTime(0.0001, stopTimeSeconds);
+
+  oscillator.connect(gainNode);
+  gainNode.connect(audioContext.destination);
+  oscillator.onended = () => {
+    oscillator.disconnect();
+    gainNode.disconnect();
+  };
+  oscillator.start(safeStartTimeSeconds);
+  oscillator.stop(stopTimeSeconds + 0.004);
+}

--- a/apps/desktop/src/features/tools/metronomeUtils.test.ts
+++ b/apps/desktop/src/features/tools/metronomeUtils.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_METRONOME_BPM,
+  MIN_METRONOME_BPM,
+  createTapTempoState,
+  nextSyncedBeatIndex,
+  normalizeBeatsPerBar,
+  normalizeMetronomeBpm,
+  updateTapTempo,
+} from "./metronomeUtils";
+
+describe("metronome utils", () => {
+  it("normalizes tempo and meter inputs", () => {
+    expect(normalizeMetronomeBpm(12)).toBe(MIN_METRONOME_BPM);
+    expect(normalizeMetronomeBpm(260)).toBe(MAX_METRONOME_BPM);
+    expect(normalizeMetronomeBpm("121.48")).toBe(121.5);
+    expect(normalizeMetronomeBpm("nope", 132)).toBe(132);
+    expect(normalizeBeatsPerBar(0)).toBe(1);
+    expect(normalizeBeatsPerBar(14)).toBe(12);
+    expect(normalizeBeatsPerBar("7.9")).toBe(7);
+  });
+
+  it("calculates tap tempo from recent valid taps", () => {
+    let state = createTapTempoState();
+    let result = updateTapTempo(state, 0);
+    expect(result.bpm).toBeNull();
+
+    state = result.state;
+    result = updateTapTempo(state, 500);
+    expect(result.bpm).toBe(120);
+
+    state = result.state;
+    result = updateTapTempo(state, 1000);
+    expect(result.bpm).toBe(120);
+  });
+
+  it("ignores accidental double taps and resets after idle gaps", () => {
+    let state = createTapTempoState();
+    state = updateTapTempo(state, 0).state;
+
+    const ignored = updateTapTempo(state, 120);
+    expect(ignored.bpm).toBeNull();
+    expect(ignored.state).toBe(state);
+
+    const reset = updateTapTempo(state, 3200);
+    expect(reset.bpm).toBeNull();
+    expect(reset.state.tapTimesMs).toEqual([3200]);
+  });
+
+  it("realigns synced beats after playback jumps", () => {
+    expect(
+      nextSyncedBeatIndex({
+        bpm: 120,
+        lastPlaybackTimeSeconds: null,
+        lastScheduledBeatIndex: null,
+        playbackTimeSeconds: 0,
+      }),
+    ).toBe(0);
+    expect(
+      nextSyncedBeatIndex({
+        bpm: 120,
+        lastPlaybackTimeSeconds: 0.1,
+        lastScheduledBeatIndex: 1,
+        playbackTimeSeconds: 0.11,
+      }),
+    ).toBe(2);
+    expect(
+      nextSyncedBeatIndex({
+        bpm: 120,
+        lastPlaybackTimeSeconds: 12,
+        lastScheduledBeatIndex: 30,
+        playbackTimeSeconds: 4,
+      }),
+    ).toBe(8);
+  });
+});

--- a/apps/desktop/src/features/tools/metronomeUtils.ts
+++ b/apps/desktop/src/features/tools/metronomeUtils.ts
@@ -1,0 +1,140 @@
+export const DEFAULT_METRONOME_BPM = 100;
+export const MIN_METRONOME_BPM = 30;
+export const MAX_METRONOME_BPM = 240;
+export const DEFAULT_BEATS_PER_BAR = 4;
+export const DEFAULT_METRONOME_VOLUME = 0.8;
+export const MIN_BEATS_PER_BAR = 1;
+export const MAX_BEATS_PER_BAR = 12;
+export const TAP_MIN_INTERVAL_MS = 250;
+export const TAP_MAX_INTERVAL_MS = 2000;
+export const TAP_RESET_INTERVAL_MS = 2500;
+export const TAP_HISTORY_LIMIT = 6;
+export const SYNC_BEAT_EPSILON_SECONDS = 0.015;
+export const SYNC_PLAYBACK_JUMP_TOLERANCE_SECONDS = 0.2;
+
+export type TapTempoState = {
+  tapTimesMs: number[];
+};
+
+export type TapTempoUpdate = {
+  bpm: number | null;
+  state: TapTempoState;
+};
+
+export function createTapTempoState(): TapTempoState {
+  return { tapTimesMs: [] };
+}
+
+export function normalizeMetronomeBpm(
+  value: unknown,
+  fallback: number = DEFAULT_METRONOME_BPM,
+) {
+  if (value === null || value === undefined || value === "") {
+    return clampBpm(fallback);
+  }
+  const numericValue = typeof value === "number" ? value : Number(value);
+  const fallbackValue = Number.isFinite(fallback) ? fallback : DEFAULT_METRONOME_BPM;
+  if (!Number.isFinite(numericValue)) {
+    return clampBpm(fallbackValue);
+  }
+  return clampBpm(numericValue);
+}
+
+export function normalizeBeatsPerBar(
+  value: unknown,
+  fallback: number = DEFAULT_BEATS_PER_BAR,
+) {
+  if (value === null || value === undefined || value === "") {
+    return clampBeatsPerBar(fallback);
+  }
+  const numericValue = typeof value === "number" ? value : Number(value);
+  const fallbackValue = Number.isFinite(fallback) ? fallback : DEFAULT_BEATS_PER_BAR;
+  if (!Number.isFinite(numericValue)) {
+    return clampBeatsPerBar(fallbackValue);
+  }
+  return clampBeatsPerBar(Math.trunc(numericValue));
+}
+
+export function secondsPerBeat(bpm: number) {
+  return 60 / normalizeMetronomeBpm(bpm);
+}
+
+export function beatNumberForIndex(beatIndex: number, beatsPerBar: number) {
+  return (Math.max(0, beatIndex) % normalizeBeatsPerBar(beatsPerBar)) + 1;
+}
+
+export function isAccentBeat(beatIndex: number, beatsPerBar: number, accentFirstBeat: boolean) {
+  return accentFirstBeat && beatNumberForIndex(beatIndex, beatsPerBar) === 1;
+}
+
+export function updateTapTempo(
+  state: TapTempoState,
+  timestampMs: number,
+): TapTempoUpdate {
+  const tapTimesMs = state.tapTimesMs;
+  const previousTapMs = tapTimesMs[tapTimesMs.length - 1];
+  if (previousTapMs === undefined || timestampMs - previousTapMs > TAP_RESET_INTERVAL_MS) {
+    return { bpm: null, state: { tapTimesMs: [timestampMs] } };
+  }
+
+  const intervalMs = timestampMs - previousTapMs;
+  if (intervalMs < TAP_MIN_INTERVAL_MS) {
+    return { bpm: null, state };
+  }
+  if (intervalMs > TAP_MAX_INTERVAL_MS) {
+    return { bpm: null, state: { tapTimesMs: [timestampMs] } };
+  }
+
+  const nextTapTimesMs = [...tapTimesMs, timestampMs].slice(-TAP_HISTORY_LIMIT);
+  const intervals = nextTapTimesMs
+    .slice(1)
+    .map((tapMs, index) => tapMs - nextTapTimesMs[index])
+    .filter((nextIntervalMs) =>
+      nextIntervalMs >= TAP_MIN_INTERVAL_MS && nextIntervalMs <= TAP_MAX_INTERVAL_MS,
+    );
+  if (intervals.length === 0) {
+    return { bpm: null, state: { tapTimesMs: nextTapTimesMs } };
+  }
+
+  const averageIntervalMs =
+    intervals.reduce((total, nextIntervalMs) => total + nextIntervalMs, 0) / intervals.length;
+  return {
+    bpm: normalizeMetronomeBpm(60000 / averageIntervalMs),
+    state: { tapTimesMs: nextTapTimesMs },
+  };
+}
+
+export function nextSyncedBeatIndex({
+  bpm,
+  lastPlaybackTimeSeconds,
+  lastScheduledBeatIndex,
+  playbackTimeSeconds,
+}: {
+  bpm: number;
+  lastPlaybackTimeSeconds: number | null;
+  lastScheduledBeatIndex: number | null;
+  playbackTimeSeconds: number;
+}) {
+  const beatSeconds = secondsPerBeat(bpm);
+  const currentBeatIndex = Math.max(
+    0,
+    Math.ceil((playbackTimeSeconds - SYNC_BEAT_EPSILON_SECONDS) / beatSeconds),
+  );
+  const jumped =
+    lastPlaybackTimeSeconds !== null &&
+    Math.abs(playbackTimeSeconds - lastPlaybackTimeSeconds) >
+      SYNC_PLAYBACK_JUMP_TOLERANCE_SECONDS;
+
+  if (lastScheduledBeatIndex === null || jumped) {
+    return currentBeatIndex;
+  }
+  return Math.max(currentBeatIndex, lastScheduledBeatIndex + 1);
+}
+
+function clampBpm(value: number) {
+  return Math.round(Math.min(MAX_METRONOME_BPM, Math.max(MIN_METRONOME_BPM, value)) * 10) / 10;
+}
+
+function clampBeatsPerBar(value: number) {
+  return Math.min(MAX_BEATS_PER_BAR, Math.max(MIN_BEATS_PER_BAR, value));
+}

--- a/apps/desktop/src/setupTests.ts
+++ b/apps/desktop/src/setupTests.ts
@@ -8,9 +8,23 @@ type MockAudioBufferSourceNode = AudioBufferSourceNode & {
   disconnect: ReturnType<typeof vi.fn>;
 };
 
+type MockAudioParam = AudioParam & {
+  exponentialRampToValueAtTime: ReturnType<typeof vi.fn>;
+  setValueAtTime: ReturnType<typeof vi.fn>;
+};
+
 type MockGainNode = GainNode & {
+  gain: MockAudioParam;
   connect: ReturnType<typeof vi.fn>;
   disconnect: ReturnType<typeof vi.fn>;
+};
+
+type MockOscillatorNode = OscillatorNode & {
+  connect: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  frequency: MockAudioParam;
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
 };
 
 type MockAnalyserNode = AnalyserNode & {
@@ -26,11 +40,13 @@ type MockMediaStreamAudioSourceNode = MediaStreamAudioSourceNode & {
 type MockAudioContextInstance = AudioContext & {
   advanceTime: (seconds: number) => void;
   createdAnalysers: MockAnalyserNode[];
+  createdOscillators: MockOscillatorNode[];
   createdMediaStreamSources: MockMediaStreamAudioSourceNode[];
   createdSources: MockAudioBufferSourceNode[];
   createAnalyser: ReturnType<typeof vi.fn>;
   createBufferSource: ReturnType<typeof vi.fn>;
   createGain: ReturnType<typeof vi.fn>;
+  createOscillator: ReturnType<typeof vi.fn>;
   createMediaStreamSource: ReturnType<typeof vi.fn>;
   decodeAudioData: ReturnType<typeof vi.fn>;
   resume: ReturnType<typeof vi.fn>;
@@ -234,6 +250,7 @@ class MockAudioContext {
   destination = {} as AudioDestinationNode;
   state: AudioContextState = "running";
   createdAnalysers: MockAnalyserNode[] = [];
+  createdOscillators: MockOscillatorNode[] = [];
   createdMediaStreamSources: MockMediaStreamAudioSourceNode[] = [];
   createdSources: MockAudioBufferSourceNode[] = [];
   private currentTimeSeconds = 0;
@@ -288,10 +305,32 @@ class MockAudioContext {
   });
 
   createGain = vi.fn(() => ({
-    gain: { value: 1 },
+    gain: {
+      value: 1,
+      exponentialRampToValueAtTime: vi.fn(),
+      setValueAtTime: vi.fn(),
+    },
     connect: vi.fn(),
     disconnect: vi.fn(),
   }) as unknown as MockGainNode);
+
+  createOscillator = vi.fn(() => {
+    const oscillator = {
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      frequency: {
+        value: 440,
+        exponentialRampToValueAtTime: vi.fn(),
+        setValueAtTime: vi.fn(),
+      },
+      onended: null,
+      start: vi.fn(),
+      stop: vi.fn(),
+      type: "sine",
+    } as unknown as MockOscillatorNode;
+    this.createdOscillators.push(oscillator);
+    return oscillator;
+  });
 
   createAnalyser = vi.fn(() => {
     let samples: Float32Array | null = null;

--- a/apps/desktop/src/styles/project-layout.css
+++ b/apps/desktop/src/styles/project-layout.css
@@ -283,6 +283,16 @@
   font-weight: 600;
 }
 
+.analysis-action-row {
+  display: flex;
+  margin-top: 0.85rem;
+}
+
+.analysis-stat__action {
+  justify-content: center;
+  width: 100%;
+}
+
 .meta-stat {
   border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
   border-radius: 16px;

--- a/apps/desktop/src/styles/tools.css
+++ b/apps/desktop/src/styles/tools.css
@@ -2,10 +2,21 @@
   max-width: 920px;
 }
 
+.metronome-shell {
+  max-width: 920px;
+}
+
 .tuner-panel {
   display: grid;
   gap: 1.1rem;
   border-color: color-mix(in srgb, var(--chip-active-border) 24%, var(--panel-border));
+  background: color-mix(in srgb, var(--panel-strong) 88%, var(--panel));
+}
+
+.metronome-panel {
+  display: grid;
+  gap: 1.1rem;
+  border-color: color-mix(in srgb, var(--playback-accent) 24%, var(--panel-border));
   background: color-mix(in srgb, var(--panel-strong) 88%, var(--panel));
 }
 
@@ -16,7 +27,18 @@
   justify-content: space-between;
 }
 
+.metronome-header {
+  display: flex;
+  gap: 1rem;
+  align-items: start;
+  justify-content: space-between;
+}
+
 .tuner-header h2 {
+  margin: 0;
+}
+
+.metronome-header h2 {
   margin: 0;
 }
 
@@ -55,6 +77,181 @@
 .tuner-field select:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
+}
+
+.metronome-grid {
+  display: grid;
+  grid-template-columns: minmax(12rem, 1fr) minmax(10rem, 12rem) minmax(12rem, 1fr);
+  gap: 0.75rem;
+  align-items: end;
+}
+
+.metronome-field {
+  display: grid;
+  gap: 0.36rem;
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+.metronome-field__label-row {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.metronome-field input {
+  width: 100%;
+  height: 2.9rem;
+  border: 1px solid var(--input-border);
+  border-radius: 12px;
+  padding: 0.68rem 0.8rem;
+  background: color-mix(in srgb, var(--input-bg) 92%, var(--panel-strong));
+  color: var(--input-text);
+}
+
+.metronome-field input[type="range"] {
+  padding-inline: 0;
+  accent-color: var(--playback-accent);
+}
+
+.metronome-field input:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.metronome-volume-value {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 850;
+}
+
+.metronome-volume-value:focus-visible {
+  border-radius: 6px;
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 3px;
+}
+
+.metronome-switches {
+  display: flex;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+
+.metronome-toggle {
+  display: inline-flex;
+  gap: 0.5rem;
+  align-items: center;
+  min-height: 2.5rem;
+  padding: 0.5rem 0.72rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--panel) 72%, var(--panel-strong) 28%);
+  color: var(--text);
+  font-size: 0.88rem;
+  font-weight: 800;
+}
+
+.metronome-toggle input {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--playback-accent);
+}
+
+.metronome-readout {
+  display: grid;
+  justify-items: center;
+  gap: 0.75rem;
+  padding: 1.1rem;
+  border: 1px solid color-mix(in srgb, var(--chip-active-border) 18%, var(--divider));
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--surface-muted) 64%, transparent);
+  text-align: center;
+}
+
+.metronome-readout__tempo {
+  display: flex;
+  gap: 0.45rem;
+  align-items: baseline;
+}
+
+.metronome-readout__tempo strong {
+  color: var(--text);
+  font-size: clamp(3.2rem, 10vw, 5.2rem);
+  font-weight: 900;
+  line-height: 0.95;
+}
+
+.metronome-readout__tempo span {
+  color: var(--muted);
+  font-size: 1rem;
+  font-weight: 850;
+}
+
+.metronome-beats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(2.25rem, 1fr));
+  width: min(100%, 32rem);
+  gap: 0.45rem;
+}
+
+.metronome-beats__dot {
+  display: grid;
+  place-items: center;
+  min-width: 0;
+  aspect-ratio: 1;
+  border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--panel-strong) 72%, var(--surface-muted));
+  color: var(--muted);
+  font-weight: 900;
+  transition:
+    background 90ms ease-out,
+    color 90ms ease-out,
+    transform 90ms ease-out;
+}
+
+.metronome-beats__dot--accent {
+  border-color: color-mix(in srgb, var(--playback-accent) 36%, var(--divider));
+}
+
+.metronome-beats__dot--active {
+  background: var(--playback-accent);
+  color: var(--panel);
+  transform: scale(1.06);
+}
+
+.metronome-tap-pad {
+  display: grid;
+  justify-items: center;
+  gap: 0.24rem;
+  min-height: 7rem;
+  border: 1px dashed color-mix(in srgb, var(--playback-accent) 52%, var(--divider));
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--panel) 72%, var(--surface-muted));
+  color: var(--text);
+  cursor: pointer;
+}
+
+.metronome-tap-pad:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.metronome-tap-pad span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.metronome-tap-pad strong {
+  font-size: 1.35rem;
 }
 
 .tuner-preferences__status {
@@ -375,13 +572,15 @@
 
 @media (max-width: 860px) {
   .tuner-preferences,
-  .tuner-preferences--with-mode {
+  .tuner-preferences--with-mode,
+  .metronome-grid {
     grid-template-columns: 1fr;
   }
 }
 
 @media (max-width: 720px) {
-  .tuner-header {
+  .tuner-header,
+  .metronome-header {
     align-items: stretch;
     flex-direction: column;
   }

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -888,12 +888,17 @@ export function getMockAudioContexts() {
         createdAnalysers: Array<{
           setSamples: (samples: Float32Array | null) => void;
         }>;
+        createdOscillators: Array<{
+          start: ReturnType<typeof vi.fn>;
+          stop: ReturnType<typeof vi.fn>;
+        }>;
         createdMediaStreamSources: Array<{
           connect: ReturnType<typeof vi.fn>;
         }>;
         createdSources: Array<{
           start: ReturnType<typeof vi.fn>;
         }>;
+        close: ReturnType<typeof vi.fn>;
       }>;
     }
   ).__mockAudioContexts;


### PR DESCRIPTION
## Summary

- Add a Metronome tab under Tools with generated Web Audio clicks, tap tempo, BPM controls, beat count, accent toggle, and 80% default volume.
- Add Follow on Metronome from project analysis tempo, seeding the BPM and arming playback-follow mode.
- Move metronome clock state into a global provider so follow mode survives route changes and updates BPM when a followed project changes.

## Testing

- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test --run`
- `pnpm --filter @tuneforge/desktop lint`
