### PR TITLE
docs(agents): add scoped AGENTS guidance for repo subtrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,12 @@ Guidance for AI coding agents (Claude Code, Cursor, Copilot, Aider, Codex, etc.)
 
 This file is the agent-facing companion to [CONTRIBUTING.md](./CONTRIBUTING.md). Humans should read CONTRIBUTING.md; agents should read both, but this file takes precedence on conventions specific to automated work.
 
+## How to Read AGENTS Files in This Repo
+
+- This root file applies to the whole repository unless a deeper `AGENTS.md` exists.
+- Always look for a more-specific `AGENTS.md` in the directory tree you are editing.
+- If rules conflict, prefer the most deeply nested file for that path.
+
 ## Project Snapshot
 
 Tuneforge is a local-first desktop app for musicians learning songs: stem separation, chord/key/tempo detection, pitch shift, retune, export. No cloud, no account.
@@ -46,6 +52,7 @@ apps/
     src-tauri/            Rust shell (cargo)
 packages/
   shared-types/           generated TS contracts
+docs/                     product + architecture docs
 scripts/                  packaging helpers
 ```
 
@@ -110,6 +117,12 @@ When asked to implement a change:
 - Frontend uses Vitest + Testing Library. Test user-visible behavior, not implementation details.
 - Don't commit copyrighted audio under any circumstances.
 
+## Documentation Conventions
+
+- Keep docs aligned with behavior; if user-visible behavior changed, update docs in the same PR.
+- Prefer updating existing docs under `docs/` instead of adding near-duplicate pages.
+- Link docs with relative paths and keep section anchors stable where practical.
+
 ## Generated Artifacts
 
 The following files are generated. **Do not edit by hand.**
@@ -138,6 +151,17 @@ The following files are generated. **Do not edit by hand.**
 - Fill in the PR template. Be honest in the test plan — list the commands you actually ran.
 - Mark a PR as draft if any required gate fails locally.
 - Never use `--no-verify` and never `force-push` to `main` or to someone else's branch.
+
+## Recommended Scoped AGENTS.md Files
+
+To reduce ambiguity and keep this root file shorter over time, maintain additional scoped `AGENTS.md` files in:
+
+- `apps/backend/` for backend-only conventions and test commands.
+- `apps/desktop/` for frontend + Tauri guidance.
+- `packages/shared-types/` for generated-contract rules.
+- `docs/` for documentation structure and style.
+
+These scoped files should only include rules that are specific to that subtree; keep global policy in this root file.
 
 ## When to Stop and Ask
 

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md (Backend)
+
+Scope: applies to `apps/backend/**`.
+
+Use the root `AGENTS.md` for global rules. This file adds backend-specific guidance only.
+
+## Backend boundaries
+
+- Keep route handlers thin in `app/api/routes`.
+- Put orchestration and persistence logic in `app/services`.
+- Put compute/audio/ML logic in `app/engines`.
+- Do not call engines directly from routes.
+
+## Python and tooling
+
+- Run Python commands with `uv run --python 3.11 ...`.
+- Required checks when backend code changes:
+  - `uv run --python 3.11 ruff check .`
+  - `uv run --python 3.11 mypy app`
+  - `uv run --python 3.11 pytest`
+
+## API/schema changes
+
+- If request/response models or routes change, regenerate shared contracts from repo root:
+  - `pnpm contracts:generate`
+- Never hand-edit generated files.
+
+## Migrations
+
+- Database schema changes require a new Alembic revision in `alembic/versions/`.
+- Avoid destructive migrations unless explicitly approved by a human.

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md (Desktop)
+
+Scope: applies to `apps/desktop/**`.
+
+Use the root `AGENTS.md` for global rules. This file adds desktop-specific guidance only.
+
+## Frontend conventions
+
+- Keep TypeScript strict; avoid `any` except narrow boundary cases with justification.
+- Use generated contracts from `@tuneforge/shared-types` for backend-facing types.
+- Prefer user-visible behavior tests (Vitest + Testing Library), not implementation details.
+
+## Tauri conventions
+
+- Keep `src-tauri/src/main.rs` minimal; backend business logic stays in Python.
+- Do not add capabilities unless necessary; update `src-tauri/capabilities/default.json` only with clear need.
+
+## Checks
+
+- If frontend code changed: run from repo root `pnpm lint && pnpm typecheck && pnpm test`.
+- If `src-tauri/**` changed: run `cd src-tauri && cargo check`.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md (Docs)
+
+Scope: applies to `docs/**`.
+
+Use the root `AGENTS.md` for global product/safety constraints. This file adds docs-only guidance.
+
+## Documentation expectations
+
+- Keep docs synchronized with current behavior and architecture.
+- Prefer editing existing files over creating new overlapping docs.
+- Use concise headings and stable anchor-friendly section titles.
+- Use relative links for references within the repository.
+
+## Current docs map
+
+- `ARCHITECTURE.md`: architecture and component boundaries.
+- `SPEC.md`: product behavior/spec details.
+- `API.md`: API behavior and contracts.
+- `ROADMAP.md`: planned work and sequencing.
+- `MOBILE.md`: mobile-specific notes/constraints.
+- `REFERENCES.md`: external references and supporting material.

--- a/packages/shared-types/AGENTS.md
+++ b/packages/shared-types/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md (Shared Types)
+
+Scope: applies to `packages/shared-types/**`.
+
+This package is generated-contract focused.
+
+- Source of truth is backend OpenAPI output, not manual edits.
+- Do not hand-edit:
+  - `openapi.json`
+  - `src/generated/openapi.ts`
+- After backend API changes, regenerate from repo root:
+  - `pnpm contracts:generate`
+- If generated output changes, commit it in the same PR as backend API changes.


### PR DESCRIPTION
### Motivation

- Clarify agent-facing guidance after the docs were restructured and make it easier for automated agents to find subtree-specific rules. 
- Reduce ambiguity by making precedence explicit so deeper `AGENTS.md` files override root guidance for their subtree.

### Description

- Updated the root `AGENTS.md` to add a “How to Read AGENTS Files in This Repo” section and to include documentation conventions and an explicit recommendation to keep scoped `AGENTS.md` files for subtrees. 
- Added `apps/backend/AGENTS.md` containing backend-specific rules including `routes` → `services` → `engines` boundaries, Python tooling commands (use `uv run --python 3.11 ...`), contract regeneration (`pnpm contracts:generate`), and Alembic migration guidance. 
- Added `apps/desktop/AGENTS.md` containing frontend and Tauri guidance including strict TypeScript rules, use of `@tuneforge/shared-types`, and checks such as `pnpm lint && pnpm typecheck && pnpm test` and `cargo check` for `src-tauri`. 
- Added `packages/shared-types/AGENTS.md` enforcing that generated artifacts (`openapi.json`, `src/generated/openapi.ts`) are not hand-edited and that `pnpm contracts:generate` is used after API changes. 
- Added `docs/AGENTS.md` describing documentation expectations and a current docs map to help keep docs synchronized with behavior.

### Testing

- No automated tests were run because these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22dd578ac8326bdd6c437764cdbd9)