### PR TITLE
fix: improve migration mismatch diagnostics

### DIFF
--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -28,4 +28,8 @@ Use the root `AGENTS.md` for global rules. This file adds backend-specific guida
 ## Migrations
 
 - Database schema changes require a new Alembic revision in `alembic/versions/`.
+- Before adding a new model or migration, check whether the default dev database is already stamped with
+  migrations from another branch. If it is, inspect the other branch's migration, evaluate whether it can be
+  imported into the current branch without breaking current work, and ask the user before importing it. Do not
+  switch branches to resolve this; the other branch can contain unrelated work that conflicts with current work.
 - Avoid destructive migrations unless explicitly approved by a human.

--- a/apps/backend/app/db.py
+++ b/apps/backend/app/db.py
@@ -4,6 +4,10 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 
 from alembic.config import Config
+from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
+from alembic.script.revision import ResolutionError
+from alembic.util.exc import CommandError
 from sqlalchemy import create_engine
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
@@ -22,6 +26,10 @@ def _engine_for(settings: Settings):
 _engine = _engine_for(get_settings())
 SessionLocal = sessionmaker(autoflush=False, expire_on_commit=False, class_=Session)
 SessionLocal.configure(bind=_engine)
+
+
+class UnknownDatabaseRevisionError(RuntimeError):
+    pass
 
 
 def reconfigure_engine(settings: Settings) -> None:
@@ -51,7 +59,40 @@ def session_scope() -> Iterator[Session]:
 def run_migrations(settings: Settings | None = None) -> None:
     current = settings or get_settings()
     ensure_data_dirs(current)
-    config = Config(str(current.backend_root / "alembic.ini"))
-    config.set_main_option("sqlalchemy.url", current.database_url)
-    config.set_main_option("script_location", str(current.backend_root / "alembic"))
+    config = _migration_config(current)
+    _ensure_database_revision_is_known(current, config)
     command.upgrade(config, "head")
+
+
+def _migration_config(settings: Settings) -> Config:
+    config = Config(str(settings.backend_root / "alembic.ini"))
+    config.set_main_option("sqlalchemy.url", settings.database_url)
+    config.set_main_option("script_location", str(settings.backend_root / "alembic"))
+    return config
+
+
+def _ensure_database_revision_is_known(settings: Settings, config: Config) -> None:
+    script = ScriptDirectory.from_config(config)
+    with _engine.connect() as connection:
+        migration_context = MigrationContext.configure(connection)
+        current_revisions = migration_context.get_current_heads()
+
+    unknown_revisions: list[str] = []
+    for revision in current_revisions:
+        try:
+            script.get_revision(revision)
+        except (CommandError, ResolutionError):
+            unknown_revisions.append(revision)
+
+    if unknown_revisions:
+        known_heads = ", ".join(script.get_heads()) or "base"
+        unknown = ", ".join(unknown_revisions)
+        raise UnknownDatabaseRevisionError(
+            "Database migration history references revision(s) that this checkout does not know: "
+            f"{unknown}.\n"
+            f"Database: {settings.database_path}\n"
+            f"Known migration head(s) in this checkout: {known_heads}\n"
+            "This usually happens after running a branch with newer migrations, then switching to a branch "
+            "without those migration files. Switch to a branch containing the missing migration, merge or rebase "
+            "the migration into this checkout, or run this branch with a separate TUNEFORGE_DATA_DIR."
+        )

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
@@ -15,10 +16,12 @@ from app.api.routes.health import router as health_router
 from app.api.routes.jobs import router as jobs_router
 from app.api.routes.projects import router as projects_router
 from app.config import ensure_data_dirs, get_settings
-from app.db import SessionLocal, reconfigure_engine, run_migrations
+from app.db import SessionLocal, UnknownDatabaseRevisionError, reconfigure_engine, run_migrations
 from app.errors import AppError
 from app.schemas import ErrorInfo, ErrorResponse
 from app.services.jobs import InProcessJobRunner
+
+logger = logging.getLogger("tuneforge.startup")
 
 
 @asynccontextmanager
@@ -26,7 +29,11 @@ async def lifespan(app: FastAPI):
     settings = get_settings()
     ensure_data_dirs(settings)
     reconfigure_engine(settings)
-    run_migrations(settings)
+    try:
+        run_migrations(settings)
+    except UnknownDatabaseRevisionError as error:
+        logger.error("%s", error)
+        raise
     runner = InProcessJobRunner(SessionLocal, max_workers=settings.max_workers)
     runner.recover_running_jobs()
     runner.start()

--- a/apps/backend/tests/test_db_migrations.py
+++ b/apps/backend/tests/test_db_migrations.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from app.config import ensure_data_dirs, get_settings
+from app.db import UnknownDatabaseRevisionError, reconfigure_engine, run_migrations
+
+
+def test_run_migrations_reports_unknown_database_revision() -> None:
+    settings = get_settings()
+    ensure_data_dirs(settings)
+    with sqlite3.connect(settings.database_path) as connection:
+        connection.execute("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)")
+        connection.execute("INSERT INTO alembic_version (version_num) VALUES (?)", ("9999_future_branch",))
+
+    reconfigure_engine(settings)
+
+    with pytest.raises(UnknownDatabaseRevisionError) as exc:
+        run_migrations(settings)
+
+    message = str(exc.value)
+    assert "9999_future_branch" in message
+    assert str(settings.database_path) in message
+    assert "branch with newer migrations" in message
+    assert "TUNEFORGE_DATA_DIR" in message


### PR DESCRIPTION
## Summary

- Detect databases stamped with Alembic revisions missing from the current checkout before upgrade.
- Log an actionable startup message with the missing revision, known checkout head, and recovery options.
- Add backend AGENTS guidance for checking/importing branch migrations safely.

## Testing

- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `cd apps/backend && uv run --python 3.11 pytest`
- Manual: `pnpm dev:backend` with a DB stamped at an unknown revision prints migration mismatch guidance.
