### PR TITLE
fix: stabilize Linux dev and Crema runtime reporting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,13 @@ To combine the legacy NVIDIA profile with Advanced Chords:
 pnpm setup:dev -- --legacy-nvidia --advanced-chords
 ```
 
+If you later switch backend profiles directly, pass `--advanced-chords` / `--crema` to the sync helper too:
+
+```sh
+pnpm sync:backend:legacy-nvidia -- --advanced-chords
+pnpm sync:backend:default -- --advanced-chords
+```
+
 ## Development Loop
 
 Two terminals:

--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ To combine the legacy NVIDIA profile with Advanced Chords:
 pnpm setup:dev -- --legacy-nvidia --advanced-chords
 ```
 
+The standalone backend sync helpers also accept `--advanced-chords` / `--crema` when switching profiles:
+
+```sh
+pnpm sync:backend:legacy-nvidia -- --advanced-chords
+pnpm sync:backend:default -- --advanced-chords
+```
+
 Both backend sync helpers recreate `apps/backend/.venv` from scratch to avoid stale mixed CUDA stacks when switching profiles. `uv` still reuses its shared cache, so after the first install, switching is usually much faster than a cold download. It is intended for cards like the GTX 1050 Ti. macOS, CI, and the default Linux setup remain unchanged.
 
 ## Development

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -70,6 +70,12 @@ pnpm setup:dev -- --legacy-nvidia
 ```
 
 Use `pnpm setup:dev -- --legacy-nvidia --advanced-chords` to combine this profile with Advanced Chords.
+If you later switch profiles with the standalone helpers, pass the same optional extra there too:
+
+```sh
+pnpm sync:backend:legacy-nvidia -- --advanced-chords
+pnpm sync:backend:default -- --advanced-chords
+```
 
 This profile is an opt-in local override for Linux `x86_64`. The committed lockfile and the default macOS / Linux setup stay unchanged. When the override is active, use the repository commands (`pnpm dev:backend`, `pnpm test`, `pnpm lint`) so the backend keeps using the overridden `.venv` instead of asking `uv` to resync it.
 

--- a/apps/backend/app/engines/crema_chords.py
+++ b/apps/backend/app/engines/crema_chords.py
@@ -58,6 +58,14 @@ def detect_crema_chord_timeline(
     return segments
 
 
+def crema_runtime_device() -> str:
+    try:
+        import tensorflow as tf
+    except Exception:
+        return "cpu"
+    return "cuda" if tf.config.list_physical_devices("GPU") else "cpu"
+
+
 def crema_annotation_to_timeline(annotation: Any) -> list[dict[str, Any]]:
     segments: list[dict[str, Any]] = []
     for row in _annotation_rows(annotation):

--- a/apps/backend/app/services/chord_backends.py
+++ b/apps/backend/app/services/chord_backends.py
@@ -10,6 +10,7 @@ from app.engines.chords import detect_chord_timeline
 from app.engines.crema_chords import (
     crema_dependency_status,
     crema_model_metadata,
+    crema_runtime_device,
     detect_crema_chord_timeline,
 )
 from app.errors import AppError
@@ -43,6 +44,7 @@ class ChordDetectionResult:
     segments: list[dict[str, Any]]
     backend_id: str
     metadata: dict[str, Any]
+    runtime_device: str | None = None
 
 
 class ChordDetectionBackend(Protocol):
@@ -86,6 +88,7 @@ class FastChordBackend:
                 "engine": "librosa-chroma-template-viterbi",
                 "analysis_version": "v2",
             },
+            runtime_device="cpu",
         )
 
 
@@ -116,10 +119,15 @@ class CremaChordBackend:
                 availability.unavailable_reason or "Advanced chord backend is unavailable.",
                 status_code=409,
             )
+        segments = detect_crema_chord_timeline(source_path)
+        runtime_device = crema_runtime_device()
+        metadata = crema_model_metadata()
+        metadata["runtime_device"] = runtime_device
         return ChordDetectionResult(
-            segments=detect_crema_chord_timeline(source_path),
+            segments=segments,
             backend_id=self.id,
-            metadata=crema_model_metadata(),
+            metadata=metadata,
+            runtime_device=runtime_device,
         )
 
 

--- a/apps/backend/app/services/chords.py
+++ b/apps/backend/app/services/chords.py
@@ -46,6 +46,7 @@ def detect_project_chords(
     source_artifact = _source_audio_artifact(project)
     source_path = Path(source_artifact.path) if source_artifact is not None else Path(project.imported_path)
     source_result = _detect_timeline(source_path, selected_backend_id)
+    runtime_device = source_result.runtime_device
     source_timeline = source_result.segments
     augmented_timeline = (
         _augment_with_source_instrumental_stem(
@@ -75,6 +76,7 @@ def detect_project_chords(
         "backend_label": selected_backend.label,
         "backend_capabilities": selected_backend.capabilities.__dict__,
         "backend_fallback_from": backend_fallback_from,
+        "runtime_device": runtime_device,
         "detection": source_result.metadata,
     }
     existing.updated_at = updated_at

--- a/apps/backend/app/services/jobs.py
+++ b/apps/backend/app/services/jobs.py
@@ -291,7 +291,7 @@ class InProcessJobRunner:
         }
         session.flush()
         context.set_progress(20)
-        detect_project_chords(
+        chords = detect_project_chords(
             session,
             project,
             backend=backend,
@@ -302,7 +302,11 @@ class InProcessJobRunner:
             overwrite_user_edits=bool(job.payload_json.get("overwrite_user_edits", False)),
         )
         context.set_progress(90)
-        return JobExecutionResult(artifact_ids=[])
+        runtime_device = chords.metadata_json.get("runtime_device")
+        return JobExecutionResult(
+            artifact_ids=[],
+            runtime_device=runtime_device if isinstance(runtime_device, str) else None,
+        )
 
     def _handle_lyrics(self, context: JobExecutionContext, session: Session, job: Job) -> JobExecutionResult:
         project = get_project(session, job.project_id or "")

--- a/apps/backend/tests/test_chord_backends.py
+++ b/apps/backend/tests/test_chord_backends.py
@@ -107,6 +107,21 @@ def test_crema_detection_suppresses_known_runtime_noise(monkeypatch, capsys, rec
     assert timeline[0]["label"] == "C"
 
 
+def test_crema_backend_reports_tensorflow_runtime_device(monkeypatch):
+    monkeypatch.setattr("app.engines.crema_chords.importlib.util.find_spec", lambda _: object())
+    monkeypatch.setattr(
+        "app.services.chord_backends.detect_crema_chord_timeline",
+        lambda _: [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "C"}],
+    )
+    monkeypatch.setattr("app.services.chord_backends.crema_runtime_device", lambda: "cuda")
+
+    backend = resolve_chord_backend("crema-advanced", require_available=True)
+    result = backend.detect(Path("/tmp/source.wav"))
+
+    assert result.runtime_device == "cuda"
+    assert result.metadata["runtime_device"] == "cuda"
+
+
 def test_backend_registry_reports_fast_and_missing_crema(monkeypatch):
     def fake_find_spec(module_name: str):
         return None if module_name == "crema" else object()

--- a/apps/backend/tests/test_chord_flow.py
+++ b/apps/backend/tests/test_chord_flow.py
@@ -54,7 +54,7 @@ def test_chord_job_persists_timeline(client, sample_chord_audio_file: Path):
     final_job = wait_for_job(client, job["id"])
     assert final_job["status"] == "completed"
     assert final_job["chord_backend_fallback_from"] == "crema-advanced"
-    assert final_job["runtime_device"] is None
+    assert final_job["runtime_device"] == "cpu"
     assert final_job["duration_seconds"] is not None
 
     chords = client.get(f"/api/v1/projects/{project['id']}/chords").json()
@@ -64,6 +64,7 @@ def test_chord_job_persists_timeline(client, sample_chord_audio_file: Path):
     assert len(chords["source_segments"]) >= 3
     assert chords["has_user_edits"] is False
     assert chords["metadata"]["backend_fallback_from"] == "crema-advanced"
+    assert chords["metadata"]["runtime_device"] == "cpu"
     assert all(segment["end_seconds"] > segment["start_seconds"] for segment in chords["timeline"])
     assert all(segment["pitch_class"] is not None for segment in chords["timeline"])
     supported_qualities = {"major", "minor", "7", "maj7", "m7", "sus2", "sus4", "dim", None}

--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -1,4 +1,3 @@
 fn main() {
     tauri_build::build()
 }
-

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -253,18 +253,24 @@ fn development_backend() -> BackendRuntime {
 fn install_linux_media_permission_handler(
     app: &AppHandle,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    if let Some(webview) = app.get_webview("main") {
+    if let Some(webview) = app.get_webview_window("main") {
         webview.with_webview(|webview| {
-            use webkit2gtk::prelude::*;
+            use webkit2gtk::{glib::prelude::*, PermissionRequestExt, SettingsExt, WebViewExt};
+
+            if cfg!(debug_assertions) {
+                if let Some(settings) = webview.inner().settings() {
+                    settings.set_enable_write_console_messages_to_stdout(true);
+                }
+            }
 
             webview.inner().connect_permission_request(|_, request| {
                 let request_type = request.type_().name();
-                if request_type.as_str().contains("DeviceInfoPermissionRequest") {
+                if request_type.contains("DeviceInfoPermissionRequest") {
                     request.allow();
                     return true;
                 }
 
-                if request_type.as_str().contains("UserMediaPermissionRequest") {
+                if request_type.contains("UserMediaPermissionRequest") {
                     let is_audio = request.property::<bool>("is-for-audio-device");
                     let is_video = request.property::<bool>("is-for-video-device");
                     if is_audio && !is_video {

--- a/apps/desktop/src/BootScreen.tsx
+++ b/apps/desktop/src/BootScreen.tsx
@@ -1,0 +1,11 @@
+export function BootScreen({ message, title }: { message?: string; title: string }) {
+  return (
+    <main className="boot-screen">
+      <section className="boot-screen__panel" role="status">
+        <span className="boot-screen__eyebrow">Tuneforge</span>
+        <h1>{title}</h1>
+        {message ? <p>{message}</p> : null}
+      </section>
+    </main>
+  );
+}

--- a/apps/desktop/src/features/projects/projectViewUtils.test.ts
+++ b/apps/desktop/src/features/projects/projectViewUtils.test.ts
@@ -203,7 +203,7 @@ describe("formatJobStatusSummary", () => {
       id: "job_chords",
       progress: 100,
       project_id: "proj_123",
-      runtime_device: null,
+      runtime_device: "cpu",
       source_artifact_id: null,
       started_at: "2026-04-18T13:16:00.000Z",
       status: "completed",
@@ -211,7 +211,7 @@ describe("formatJobStatusSummary", () => {
       updated_at: "2026-04-18T13:16:14.000Z",
     };
 
-    expect(formatJobStatusSummary(job)).toBe("completed / built-in / source+stem / 14 s");
+    expect(formatJobStatusSummary(job)).toBe("completed / built-in / source+stem / CPU / 14 s");
   });
 
   it("includes advanced chord backend for crema jobs", () => {
@@ -225,7 +225,7 @@ describe("formatJobStatusSummary", () => {
       id: "job_chords_advanced",
       progress: 100,
       project_id: "proj_123",
-      runtime_device: null,
+      runtime_device: "cuda",
       source_artifact_id: null,
       started_at: "2026-04-18T13:16:09.000Z",
       status: "completed",
@@ -233,6 +233,6 @@ describe("formatJobStatusSummary", () => {
       updated_at: "2026-04-18T13:16:14.000Z",
     };
 
-    expect(formatJobStatusSummary(job)).toBe("completed / advanced / source / 5.3 s");
+    expect(formatJobStatusSummary(job)).toBe("completed / advanced / source / CUDA / 5.3 s");
   });
 });

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -3,22 +3,68 @@ import ReactDOM from "react-dom/client";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { HashRouter } from "react-router-dom";
 import App from "./App";
+import { BootScreen } from "./BootScreen";
 import { initializeApi } from "./lib/api";
 import { queryClient } from "./lib/query-client";
 import "./styles.css";
 
-async function bootstrap() {
-  await initializeApi();
+function formatBootError(error: unknown) {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  if (typeof error === "string" && error.trim()) {
+    return error;
+  }
+  return "The desktop shell started, but the frontend could not initialize.";
+}
 
-  ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-    <React.StrictMode>
-      <QueryClientProvider client={queryClient}>
-        <HashRouter>
-          <App />
-        </HashRouter>
-      </QueryClientProvider>
-    </React.StrictMode>,
-  );
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeoutId: ReturnType<typeof window.setTimeout> | null = null;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = window.setTimeout(() => {
+      reject(new Error("Timed out while initializing the desktop API bridge."));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timeoutId !== null) {
+      window.clearTimeout(timeoutId);
+    }
+  }
+}
+
+async function bootstrap() {
+  const rootElement = document.getElementById("root");
+  if (!rootElement) {
+    throw new Error("Root element was not found.");
+  }
+
+  const root = ReactDOM.createRoot(rootElement);
+  root.render(<BootScreen title="Starting Tuneforge" />);
+
+  try {
+    await withTimeout(initializeApi(), 8000);
+
+    root.render(
+      <React.StrictMode>
+        <QueryClientProvider client={queryClient}>
+          <HashRouter>
+            <App />
+          </HashRouter>
+        </QueryClientProvider>
+      </React.StrictMode>,
+    );
+  } catch (error) {
+    console.error("Tuneforge failed to initialize.", error);
+    root.render(
+      <BootScreen
+        title="Tuneforge could not start"
+        message={formatBootError(error)}
+      />,
+    );
+  }
 }
 
 void bootstrap();

--- a/apps/desktop/src/styles/base.css
+++ b/apps/desktop/src/styles/base.css
@@ -88,6 +88,44 @@ body {
   color: var(--text);
 }
 
+.boot-screen {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+  background: linear-gradient(145deg, #111827 0%, #1f2937 48%, #0f172a 100%);
+  color: #f8fafc;
+}
+
+.boot-screen__panel {
+  width: min(32rem, 100%);
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  border-radius: 8px;
+  padding: 1.5rem;
+  background: rgba(15, 23, 42, 0.82);
+  box-shadow: 0 1.4rem 3rem rgba(0, 0, 0, 0.28);
+}
+
+.boot-screen__eyebrow {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: #5eead4;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.boot-screen h1 {
+  margin: 0;
+  font-size: 1.45rem;
+  line-height: 1.2;
+}
+
+.boot-screen p {
+  margin: 0.75rem 0 0;
+  color: #cbd5e1;
+}
+
 button,
 input,
 select,
@@ -390,4 +428,3 @@ a {
 .panel--empty {
   text-align: center;
 }
-

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,8 +1,32 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+const reactRefreshPreamble = {
+  name: "tuneforge-react-refresh-preamble",
+  apply: "serve" as const,
+  transformIndexHtml: {
+    order: "pre" as const,
+    handler() {
+      return [
+        {
+          tag: "script",
+          attrs: { type: "module" },
+          children: [
+            'import { injectIntoGlobalHook } from "/@react-refresh";',
+            "if (!window.$RefreshSig$) {",
+            "  injectIntoGlobalHook(window);",
+            "  window.$RefreshReg$ = () => {};",
+            "  window.$RefreshSig$ = () => (type) => type;",
+            "}",
+          ].join("\n"),
+        },
+      ];
+    },
+  },
+};
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [reactRefreshPreamble, react()],
   server: {
     host: "127.0.0.1",
     port: 1420,

--- a/scripts/sync-backend-default.sh
+++ b/scripts/sync-backend-default.sh
@@ -1,11 +1,50 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+  cat <<'EOF'
+Usage: pnpm sync:backend:default [options]
+
+Recreates the backend environment with the default locked dependency set.
+
+Options:
+  --advanced-chords, --crema  Install the optional crema/TensorFlow chord backend.
+  -h, --help                  Show this help.
+EOF
+}
+
+advanced_chords=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --advanced-chords | --crema)
+      advanced_chords=1
+      ;;
+    --)
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
 repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 backend_dir="${repo_root}/apps/backend"
 marker_file="${backend_dir}/.venv/.tuneforge-legacy-nvidia"
 
 cd "${backend_dir}"
+backend_sync_args=(sync --python 3.11 --all-groups)
+if [[ "${advanced_chords}" -eq 1 ]]; then
+  backend_sync_args+=(--extra advanced-chords)
+fi
+
 rm -rf .venv
-uv sync --python 3.11 --all-groups
+uv "${backend_sync_args[@]}"
 rm -f "${marker_file}"

--- a/scripts/sync-backend-legacy-nvidia.sh
+++ b/scripts/sync-backend-legacy-nvidia.sh
@@ -1,6 +1,40 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+  cat <<'EOF'
+Usage: pnpm sync:backend:legacy-nvidia [options]
+
+Recreates the backend environment with the Linux x86_64 legacy NVIDIA Torch profile.
+
+Options:
+  --advanced-chords, --crema  Install the optional crema/TensorFlow chord backend.
+  -h, --help                  Show this help.
+EOF
+}
+
+advanced_chords=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --advanced-chords | --crema)
+      advanced_chords=1
+      ;;
+    --)
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
 repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 backend_dir="${repo_root}/apps/backend"
 marker_file="${backend_dir}/.venv/.tuneforge-legacy-nvidia"
@@ -19,8 +53,13 @@ cd "${backend_dir}"
 
 # Start from the standard locked backend environment, then locally override
 # torch/torchaudio with the older CUDA 12.6 wheels for legacy NVIDIA cards.
+backend_sync_args=(sync --python 3.11 --all-groups)
+if [[ "${advanced_chords}" -eq 1 ]]; then
+  backend_sync_args+=(--extra advanced-chords)
+fi
+
 rm -rf .venv
-uv sync --python 3.11 --all-groups
+uv "${backend_sync_args[@]}"
 uv pip install \
   --python .venv/bin/python \
   --torch-backend cu126 \


### PR DESCRIPTION
## Summary

- Stabilizes Linux desktop dev startup after the dependency updates and adds a visible boot failure surface instead of a black screen.
- Keeps Crema available across backend profile switches and records the resolved chord runtime device in job history.

## Testing

- `ruff check`
- `mypy app`
- `pnpm --filter @tuneforge/desktop test src/features/projects/projectViewUtils.test.ts --run`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop build`
- `cargo check`
- `cargo fmt --check`
- `pnpm test` (desktop: 14 files, 131 tests; backend: 60 tests)
