### PR TITLE
feat: add tab import augmentation

### DIFF
--- a/apps/backend/alembic/versions/0010_tab_imports_and_sections.py
+++ b/apps/backend/alembic/versions/0010_tab_imports_and_sections.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0010_tab_imports_and_sections"
+down_revision = "0009_chord_backend_metadata"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tab_imports",
+        sa.Column("id", sa.String(length=32), nullable=False),
+        sa.Column("project_id", sa.String(length=32), nullable=False),
+        sa.Column("raw_text", sa.Text(), nullable=False),
+        sa.Column("parser_version", sa.String(length=32), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("parsed_json", sa.JSON(), nullable=False),
+        sa.Column("proposal_json", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_tab_imports_project_id", "tab_imports", ["project_id"], unique=True)
+
+    op.create_table(
+        "song_sections",
+        sa.Column("id", sa.String(length=32), nullable=False),
+        sa.Column("project_id", sa.String(length=32), nullable=False),
+        sa.Column("tab_import_id", sa.String(length=32), nullable=True),
+        sa.Column("label", sa.String(length=128), nullable=False),
+        sa.Column("start_seconds", sa.Float(), nullable=True),
+        sa.Column("end_seconds", sa.Float(), nullable=True),
+        sa.Column("source", sa.String(length=32), nullable=False),
+        sa.Column("metadata_json", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["tab_import_id"], ["tab_imports.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_song_sections_project_id", "song_sections", ["project_id"])
+    op.create_index("ix_song_sections_tab_import_id", "song_sections", ["tab_import_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_song_sections_tab_import_id", table_name="song_sections")
+    op.drop_index("ix_song_sections_project_id", table_name="song_sections")
+    op.drop_table("song_sections")
+    op.drop_index("ix_tab_imports_project_id", table_name="tab_imports")
+    op.drop_table("tab_imports")

--- a/apps/backend/app/api/routes/projects.py
+++ b/apps/backend/app/api/routes/projects.py
@@ -29,7 +29,14 @@ from app.schemas import (
     ProjectsResponse,
     ProjectUpdateRequest,
     RetuneRequest,
+    SongSectionSchema,
+    SongSectionsResponse,
     StemRequest,
+    TabImportApplyRequest,
+    TabImportApplyResponse,
+    TabImportCreateRequest,
+    TabImportResponse,
+    TabImportSchema,
     TransposeRequest,
 )
 from app.services.artifacts import delete_project_artifact
@@ -44,6 +51,12 @@ from app.services.projects import (
     update_project,
 )
 from app.services.stems import resolve_stem_source_artifact
+from app.services.tabs import (
+    apply_tab_suggestions,
+    create_tab_import,
+    get_tab_import,
+    list_project_sections,
+)
 
 router = APIRouter(prefix="/projects", tags=["projects"])
 
@@ -225,6 +238,61 @@ def project_lyrics_update(
     project = get_project(session, project_id)
     lyrics = update_project_lyrics(session, project=project, edits=payload.segments)
     return LyricsResponse.model_validate(lyrics)
+
+
+@router.post("/{project_id}/tabs/proposals", response_model=TabImportResponse)
+def project_tab_import_create(
+    project_id: str,
+    payload: TabImportCreateRequest,
+    session: Session = Depends(get_db),
+) -> TabImportResponse:
+    project = get_project(session, project_id)
+    tab_import = create_tab_import(session, project=project, raw_text=payload.raw_text)
+    return TabImportResponse(tab_import=TabImportSchema.model_validate(tab_import))
+
+
+@router.get("/{project_id}/tabs/{tab_import_id}", response_model=TabImportResponse)
+def project_tab_import_detail(
+    project_id: str,
+    tab_import_id: str,
+    session: Session = Depends(get_db),
+) -> TabImportResponse:
+    get_project(session, project_id)
+    tab_import = get_tab_import(session, project_id=project_id, tab_import_id=tab_import_id)
+    return TabImportResponse(tab_import=TabImportSchema.model_validate(tab_import))
+
+
+@router.post("/{project_id}/tabs/{tab_import_id}/accept", response_model=TabImportApplyResponse)
+def project_tab_import_accept(
+    project_id: str,
+    tab_import_id: str,
+    payload: TabImportApplyRequest,
+    session: Session = Depends(get_db),
+) -> TabImportApplyResponse:
+    project = get_project(session, project_id)
+    tab_import = get_tab_import(session, project_id=project_id, tab_import_id=tab_import_id)
+    result = apply_tab_suggestions(
+        session,
+        project=project,
+        tab_import=tab_import,
+        accepted_suggestion_ids=payload.accepted_suggestion_ids,
+    )
+    return TabImportApplyResponse(
+        tab_import=TabImportSchema.model_validate(result["tab_import"]),
+        accepted_suggestion_ids=result["accepted_suggestion_ids"],
+        ignored_suggestion_ids=result["ignored_suggestion_ids"],
+        lyrics=LyricsResponse.model_validate(result["lyrics"]) if result["lyrics"] is not None else None,
+        chords=ChordResponse.model_validate(result["chords"]) if result["chords"] is not None else None,
+        sections=[SongSectionSchema.model_validate(section) for section in result["sections"]],
+        project=ProjectSchema.model_validate(result["project"]),
+    )
+
+
+@router.get("/{project_id}/sections", response_model=SongSectionsResponse)
+def project_sections(project_id: str, session: Session = Depends(get_db)) -> SongSectionsResponse:
+    get_project(session, project_id)
+    sections = list_project_sections(session, project_id=project_id)
+    return SongSectionsResponse(sections=[SongSectionSchema.model_validate(section) for section in sections])
 
 
 @router.post("/{project_id}/retune", response_model=JobResponse)

--- a/apps/backend/app/engines/chord_labels.py
+++ b/apps/backend/app/engines/chord_labels.py
@@ -45,6 +45,7 @@ QUALITY_ALIASES: dict[str, str] = {
     "augmented": "aug",
     "+": "aug",
     "sus2": "sus2",
+    "sus": "sus4",
     "sus4": "sus4",
     "7": "7",
     "dom7": "7",
@@ -99,6 +100,10 @@ DEGREE_TO_SEMITONE: dict[str, int] = {
 }
 
 HARTE_LABEL_RE = re.compile(r"^([A-Ga-g](?:#|b)?)(?::([^/]+))?(?:/(.+))?$")
+LEAD_SHEET_LABEL_RE = re.compile(
+    r"^([A-Ga-g](?:#|b)?)(maj7|major7|M7|min7|minor7|m7|min|minor|maj|major|m|"
+    r"dim7|dim|aug|sus2|sus4|sus|7|\+)?(?:/([A-Ga-g](?:#|b)?))?$"
+)
 
 
 @dataclass(frozen=True)
@@ -138,6 +143,17 @@ def parse_chord_label(raw_label: str) -> ParsedChordLabel:
         )
 
     match = HARTE_LABEL_RE.match(normalized)
+    lead_sheet_match = LEAD_SHEET_LABEL_RE.match(normalized)
+    if lead_sheet_match and (not match or match.group(2) is None and len(normalized) > len(lead_sheet_match.group(1))):
+        root_name, quality_raw, bass_raw = lead_sheet_match.groups()
+        return _parsed_chord_label_from_parts(
+            raw_label=raw_label,
+            normalized=normalized,
+            root_name=root_name,
+            quality_raw=quality_raw,
+            bass_raw=bass_raw,
+        )
+
     if not match:
         return ParsedChordLabel(
             raw_label=raw_label,
@@ -150,6 +166,23 @@ def parse_chord_label(raw_label: str) -> ParsedChordLabel:
         )
 
     root_name, quality_raw, bass_raw = match.groups()
+    return _parsed_chord_label_from_parts(
+        raw_label=raw_label,
+        normalized=normalized,
+        root_name=root_name,
+        quality_raw=quality_raw,
+        bass_raw=bass_raw,
+    )
+
+
+def _parsed_chord_label_from_parts(
+    *,
+    raw_label: str,
+    normalized: str,
+    root_name: str,
+    quality_raw: str | None,
+    bass_raw: str | None,
+) -> ParsedChordLabel:
     root_pitch_class = NOTE_TO_PITCH_CLASS.get(_normalize_note_name(root_name))
     if root_pitch_class is None:
         return ParsedChordLabel(

--- a/apps/backend/app/models.py
+++ b/apps/backend/app/models.py
@@ -38,6 +38,12 @@ class Project(Base):
     lyrics: Mapped[LyricsTranscript | None] = relationship(
         back_populates="project", uselist=False, cascade="all, delete-orphan"
     )
+    tab_import: Mapped[TabImport | None] = relationship(
+        back_populates="project", uselist=False, cascade="all, delete-orphan"
+    )
+    song_sections: Mapped[list[SongSection]] = relationship(
+        back_populates="project", cascade="all, delete-orphan"
+    )
     artifacts: Mapped[list[Artifact]] = relationship(
         back_populates="project", cascade="all, delete-orphan"
     )
@@ -106,6 +112,52 @@ class LyricsTranscript(Base):
     )
 
     project: Mapped[Project] = relationship(back_populates="lyrics")
+
+
+class TabImport(Base):
+    __tablename__ = "tab_imports"
+
+    id: Mapped[str] = mapped_column(String(32), primary_key=True)
+    project_id: Mapped[str] = mapped_column(String(32), ForeignKey("projects.id", ondelete="CASCADE"))
+    raw_text: Mapped[str] = mapped_column(Text())
+    parser_version: Mapped[str] = mapped_column(String(32), default="v1")
+    status: Mapped[str] = mapped_column(String(32), default="proposed")
+    parsed_json: Mapped[dict[str, Any]] = mapped_column(JSON(), default=dict)
+    proposal_json: Mapped[dict[str, Any]] = mapped_column(JSON(), default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow, onupdate=utcnow
+    )
+
+    project: Mapped[Project] = relationship(back_populates="tab_import")
+    song_sections: Mapped[list[SongSection]] = relationship(back_populates="tab_import")
+
+    @property
+    def groups(self) -> list[dict[str, Any]]:
+        groups = self.proposal_json.get("groups")
+        return groups if isinstance(groups, list) else []
+
+
+class SongSection(Base):
+    __tablename__ = "song_sections"
+
+    id: Mapped[str] = mapped_column(String(32), primary_key=True)
+    project_id: Mapped[str] = mapped_column(String(32), ForeignKey("projects.id", ondelete="CASCADE"))
+    tab_import_id: Mapped[str | None] = mapped_column(
+        String(32), ForeignKey("tab_imports.id", ondelete="SET NULL"), nullable=True
+    )
+    label: Mapped[str] = mapped_column(String(128))
+    start_seconds: Mapped[float | None] = mapped_column(Float(), nullable=True)
+    end_seconds: Mapped[float | None] = mapped_column(Float(), nullable=True)
+    source: Mapped[str] = mapped_column(String(32), default="tab")
+    metadata_json: Mapped[dict[str, Any]] = mapped_column(JSON(), default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow, onupdate=utcnow
+    )
+
+    project: Mapped[Project] = relationship(back_populates="song_sections")
+    tab_import: Mapped[TabImport | None] = relationship(back_populates="song_sections")
 
 
 class Artifact(Base):

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -247,6 +247,88 @@ class LyricsResponse(BaseModel):
     updated_at: datetime | None = None
 
 
+class SongSectionSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    project_id: str
+    tab_import_id: str | None = None
+    label: str
+    start_seconds: float | None = None
+    end_seconds: float | None = None
+    source: str
+    metadata: dict[str, Any] = Field(default_factory=dict, validation_alias="metadata_json")
+    created_at: datetime
+    updated_at: datetime
+
+
+class SongSectionsResponse(BaseModel):
+    sections: list[SongSectionSchema] = Field(default_factory=list)
+
+
+class TabImportCreateRequest(BaseModel):
+    raw_text: str
+
+    @field_validator("raw_text")
+    @classmethod
+    def validate_raw_text(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("Tab text cannot be empty.")
+        return value
+
+
+class TabSuggestionSchema(BaseModel):
+    id: str
+    kind: str
+    status: str = "pending"
+    title: str
+    current_text: str | None = None
+    suggested_text: str | None = None
+    start_seconds: float | None = None
+    end_seconds: float | None = None
+    segment_index: int | None = None
+    chord_index: int | None = None
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+class TabSuggestionGroupSchema(BaseModel):
+    kind: str
+    label: str
+    suggestions: list[TabSuggestionSchema] = Field(default_factory=list)
+
+
+class TabImportSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    project_id: str
+    raw_text: str
+    parser_version: str
+    status: str
+    parsed: dict[str, Any] = Field(default_factory=dict, validation_alias="parsed_json")
+    groups: list[TabSuggestionGroupSchema] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: datetime
+
+
+class TabImportResponse(BaseModel):
+    tab_import: TabImportSchema
+
+
+class TabImportApplyRequest(BaseModel):
+    accepted_suggestion_ids: list[str] = Field(default_factory=list)
+
+
+class TabImportApplyResponse(BaseModel):
+    tab_import: TabImportSchema
+    accepted_suggestion_ids: list[str] = Field(default_factory=list)
+    ignored_suggestion_ids: list[str] = Field(default_factory=list)
+    lyrics: LyricsResponse | None = None
+    chords: ChordResponse | None = None
+    sections: list[SongSectionSchema] = Field(default_factory=list)
+    project: ProjectSchema
+
+
 class JobSchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/apps/backend/app/services/chords.py
+++ b/apps/backend/app/services/chords.py
@@ -17,6 +17,7 @@ from app.services.chord_backends import (
     resolve_chord_backend_id,
 )
 from app.services.paths import project_analysis_dir
+from app.services.tab_state import clear_project_tab_state
 
 
 def detect_project_chords(
@@ -59,6 +60,7 @@ def detect_project_chords(
         else source_timeline
     )
     updated_at = utcnow()
+    clear_project_tab_state(session, project_id=project.id)
 
     if existing is None:
         existing = ChordTimeline(project_id=project.id, created_at=updated_at)

--- a/apps/backend/app/services/lyrics.py
+++ b/apps/backend/app/services/lyrics.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import re
 from copy import deepcopy
+from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, cast
 
@@ -14,6 +16,9 @@ from app.errors import AppError
 from app.models import Artifact, LyricsTranscript, Project
 from app.schemas import LyricsEditSegmentSchema
 from app.services.paths import project_analysis_dir
+from app.services.tab_state import clear_project_tab_state
+
+WORD_RE = re.compile(r"\S+")
 
 
 def _source_artifact(project: Project) -> Artifact | None:
@@ -58,6 +63,8 @@ def generate_project_lyrics(session: Session, *, project: Project, force: bool =
         download_root=get_settings().lyrics_cache_dir,
     )
     source_artifact = _source_artifact(project)
+    if force:
+        clear_project_tab_state(session, project_id=project.id)
 
     if existing is None:
         existing = LyricsTranscript(project_id=project.id)
@@ -114,7 +121,7 @@ def update_project_lyrics(
             else:
                 current_segment.pop("words", None)
         elif text != current_segments[index].get("text"):
-            current_segment.pop("words", None)
+            current_segment["words"] = retime_lyrics_words(current_segments[index], text)
 
         updated_segments.append(current_segment)
 
@@ -124,3 +131,130 @@ def update_project_lyrics(
     session.refresh(lyrics)
     _write_lyrics_snapshot(project_id=project.id, lyrics=lyrics)
     return lyrics
+
+
+def persist_project_lyrics_segments(
+    session: Session,
+    *,
+    project_id: str,
+    segments: list[dict[str, Any]],
+) -> LyricsTranscript:
+    lyrics = session.get(LyricsTranscript, project_id)
+    if lyrics is None:
+        raise AppError("LYRICS_NOT_FOUND", "Lyrics have not been generated for this project.", status_code=404)
+
+    lyrics.segments_json = cast(list[dict[str, Any]], deepcopy(segments))
+    lyrics.has_user_edits = lyrics.segments_json != lyrics.source_segments_json
+    session.flush()
+    session.refresh(lyrics)
+    _write_lyrics_snapshot(project_id=project_id, lyrics=lyrics)
+    return lyrics
+
+
+def retime_lyrics_segment_text(segment: dict[str, Any], text: str) -> dict[str, Any]:
+    updated = dict(segment)
+    updated["text"] = text
+    updated["start_seconds"] = segment.get("start_seconds")
+    updated["end_seconds"] = segment.get("end_seconds")
+    updated["words"] = retime_lyrics_words(segment, text)
+    return updated
+
+
+def retime_lyrics_words(segment: dict[str, Any], text: str) -> list[dict[str, Any]]:
+    new_tokens = [match.group(0) for match in WORD_RE.finditer(text)]
+    if not new_tokens:
+        return []
+
+    words = [word for word in segment.get("words", []) if isinstance(word, dict)]
+    timed_words = [
+        word
+        for word in words
+        if isinstance(word.get("start_seconds"), int | float)
+        and isinstance(word.get("end_seconds"), int | float)
+    ]
+    if not timed_words:
+        start_seconds = _number_or_none(segment.get("start_seconds"))
+        end_seconds = _number_or_none(segment.get("end_seconds"))
+        if start_seconds is None or end_seconds is None or end_seconds <= start_seconds:
+            return []
+        return _spread_words(new_tokens, start_seconds, end_seconds)
+
+    old_tokens = [str(word.get("text", "")) for word in timed_words]
+    old_normalized = [_normalize_word(token) for token in old_tokens]
+    new_normalized = [_normalize_word(token) for token in new_tokens]
+    matcher = SequenceMatcher(a=old_normalized, b=new_normalized, autojunk=False)
+    updated_words: list[dict[str, Any]] = []
+
+    for tag, old_start, old_end, new_start, new_end in matcher.get_opcodes():
+        replacement_tokens = new_tokens[new_start:new_end]
+        if not replacement_tokens:
+            continue
+        if tag == "equal":
+            for old_index, token in zip(range(old_start, old_end), replacement_tokens, strict=True):
+                updated_words.append(_word_with_text(timed_words[old_index], token))
+            continue
+
+        span_start, span_end = _timing_span_for_edit(timed_words, old_start, old_end, segment)
+        if tag == "replace" and old_end - old_start == new_end - new_start:
+            for old_index, token in zip(range(old_start, old_end), replacement_tokens, strict=True):
+                updated_words.append(_word_with_text(timed_words[old_index], token))
+            continue
+        updated_words.extend(_spread_words(replacement_tokens, span_start, span_end))
+
+    return updated_words
+
+
+def _normalize_word(value: str) -> str:
+    return re.sub(r"[^\w']+", "", value.lower())
+
+
+def _number_or_none(value: object) -> float | None:
+    return float(value) if isinstance(value, int | float) else None
+
+
+def _word_with_text(word: dict[str, Any], text: str) -> dict[str, Any]:
+    updated = dict(word)
+    updated["text"] = text
+    return updated
+
+
+def _timing_span_for_edit(
+    timed_words: list[dict[str, Any]],
+    old_start: int,
+    old_end: int,
+    segment: dict[str, Any],
+) -> tuple[float, float]:
+    segment_start = _number_or_none(segment.get("start_seconds"))
+    segment_end = _number_or_none(segment.get("end_seconds"))
+    if old_start < old_end:
+        first = timed_words[old_start]
+        last = timed_words[old_end - 1]
+        return float(first["start_seconds"]), float(last["end_seconds"])
+
+    if old_start > 0:
+        start = float(timed_words[old_start - 1]["end_seconds"])
+    else:
+        start = segment_start if segment_start is not None else float(timed_words[0]["start_seconds"])
+
+    if old_start < len(timed_words):
+        end = float(timed_words[old_start]["start_seconds"])
+    else:
+        end = segment_end if segment_end is not None else float(timed_words[-1]["end_seconds"])
+
+    if end <= start:
+        end = start + 0.05
+    return start, end
+
+
+def _spread_words(tokens: list[str], start_seconds: float, end_seconds: float) -> list[dict[str, Any]]:
+    duration = max(end_seconds - start_seconds, 0.05)
+    step = duration / len(tokens)
+    return [
+        {
+            "text": token,
+            "start_seconds": round(start_seconds + index * step, 3),
+            "end_seconds": round(start_seconds + (index + 1) * step, 3),
+            "confidence": None,
+        }
+        for index, token in enumerate(tokens)
+    ]

--- a/apps/backend/app/services/tab_state.py
+++ b/apps/backend/app/services/tab_state.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from sqlalchemy import delete
+from sqlalchemy.orm import Session
+
+from app.models import SongSection, TabImport
+
+
+def clear_project_tab_state(session: Session, *, project_id: str) -> None:
+    session.execute(delete(SongSection).where(SongSection.project_id == project_id, SongSection.source == "tab"))
+    session.execute(delete(TabImport).where(TabImport.project_id == project_id))
+    session.flush()

--- a/apps/backend/app/services/tabs.py
+++ b/apps/backend/app/services/tabs.py
@@ -1,0 +1,937 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+from copy import deepcopy
+from difflib import SequenceMatcher
+from typing import Any, cast
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.engines.chord_labels import chord_label_to_segment, parse_chord_label
+from app.errors import AppError
+from app.models import ChordTimeline, LyricsTranscript, Project, SongSection, TabImport, utcnow
+from app.services.lyrics import persist_project_lyrics_segments, retime_lyrics_segment_text
+from app.utils.ids import new_id
+
+PARSER_VERSION = "v1"
+SECTION_LABELS = {
+    "final",
+    "intro",
+    "verse",
+    "verso",
+    "parte",
+    "primeira parte",
+    "segunda parte",
+    "terceira parte",
+    "quarta parte",
+    "pre-chorus",
+    "pre chorus",
+    "pre-refrao",
+    "pre refrao",
+    "chorus",
+    "refrao",
+    "refrao final",
+    "refrain",
+    "bridge",
+    "solo",
+    "instrumental",
+    "interludio",
+    "outro",
+    "coda",
+}
+CHORDPRO_SECTION_ALIASES = {
+    "soc": "Chorus",
+    "start_of_chorus": "Chorus",
+    "sov": "Verse",
+    "start_of_verse": "Verse",
+    "sob": "Bridge",
+    "start_of_bridge": "Bridge",
+}
+DIRECTIVE_RE = re.compile(r"^\{\s*([^}:]+)\s*:?\s*([^}]*)\}\s*$")
+INLINE_CHORD_RE = re.compile(r"\[([^\]]+)\]")
+KEY_RE = re.compile(
+    r"\b(?:key|tom|tone|tonality)\s*[:=-]\s*([A-Ga-g](?:#|b)?\s*(?:m|min|minor|major)?)\b",
+    re.IGNORECASE,
+)
+WORD_RE = re.compile(r"\S+")
+TAB_STAFF_RE = re.compile(r"^\s*(?:[eEABGD]|[1-6])\|")
+PRINT_MARKER_RE = re.compile(r"^(?:page|pagina)\s+\d+\s*/\s*\d+$")
+PART_MARKER_RE = re.compile(r"^(?:part|parte)\s+\d+\s+(?:of|de)\s+\d+(?:\s*[-–]\s*\d+x)?$")
+METADATA_PREFIXES = {
+    "afinacao",
+    "artist",
+    "capo",
+    "capotraste",
+    "cifra",
+    "composition",
+    "composicao",
+    "guitar",
+    "song",
+    "title",
+    "tuning",
+    "violao",
+}
+FOOTER_PREFIXES = {
+    "composition by",
+    "composicao de",
+    "copyright",
+    "written by",
+}
+
+
+def create_tab_import(session: Session, *, project: Project, raw_text: str) -> TabImport:
+    parsed = parse_tab_text(raw_text)
+    proposal = build_tab_proposal(project, parsed)
+    tab_import = session.scalar(select(TabImport).where(TabImport.project_id == project.id))
+    if tab_import is None:
+        tab_import = TabImport(id=new_id("tab"), project_id=project.id)
+        session.add(tab_import)
+    tab_import.raw_text = raw_text
+    tab_import.parser_version = PARSER_VERSION
+    tab_import.status = "proposed"
+    tab_import.parsed_json = parsed
+    tab_import.proposal_json = proposal
+    tab_import.updated_at = utcnow()
+    session.flush()
+    session.refresh(tab_import)
+    return tab_import
+
+
+def get_tab_import(session: Session, *, project_id: str, tab_import_id: str) -> TabImport:
+    tab_import = session.get(TabImport, tab_import_id)
+    if tab_import is None or tab_import.project_id != project_id:
+        raise AppError("TAB_IMPORT_NOT_FOUND", "Tab import not found.", status_code=404)
+    return tab_import
+
+
+def list_project_sections(session: Session, *, project_id: str) -> list[SongSection]:
+    return list(
+        session.scalars(
+            select(SongSection)
+            .where(SongSection.project_id == project_id)
+            .order_by(SongSection.start_seconds.is_(None), SongSection.start_seconds, SongSection.created_at)
+        )
+    )
+
+
+def apply_tab_suggestions(
+    session: Session,
+    *,
+    project: Project,
+    tab_import: TabImport,
+    accepted_suggestion_ids: list[str],
+) -> dict[str, Any]:
+    accepted = set(accepted_suggestion_ids)
+    suggestions = _flatten_suggestions(tab_import.proposal_json)
+    accepted_suggestions = [suggestion for suggestion in suggestions if suggestion["id"] in accepted]
+    accepted_ids = [suggestion["id"] for suggestion in accepted_suggestions]
+    ignored_ids = sorted(accepted - set(accepted_ids))
+
+    lyrics = _apply_lyric_suggestions(session, project, accepted_suggestions)
+    chords = _apply_chord_suggestions(session, project, accepted_suggestions)
+    sections = _apply_section_suggestions(session, project, tab_import, accepted_suggestions)
+    _apply_key_suggestions(project, accepted_suggestions)
+
+    now = utcnow()
+    tab_import.status = "applied" if accepted_ids else "reviewed"
+    tab_import.updated_at = now
+    tab_import.proposal_json = _mark_suggestions(tab_import.proposal_json, set(accepted_ids))
+    session.flush()
+    session.refresh(tab_import)
+    if lyrics is not None:
+        session.refresh(lyrics)
+    if chords is not None:
+        session.refresh(chords)
+    for section in sections:
+        session.refresh(section)
+
+    return {
+        "tab_import": tab_import,
+        "accepted_suggestion_ids": accepted_ids,
+        "ignored_suggestion_ids": ignored_ids,
+        "lyrics": lyrics,
+        "chords": chords,
+        "sections": sections,
+        "project": project,
+    }
+
+
+def parse_tab_text(raw_text: str) -> dict[str, Any]:
+    parsed_lines: list[dict[str, Any]] = []
+    lines = raw_text.splitlines()
+    index = 0
+    while index < len(lines):
+        raw_line = lines[index].rstrip()
+        stripped = raw_line.strip()
+        if not stripped:
+            index += 1
+            continue
+
+        key = _parse_key(stripped)
+        if key is not None:
+            parsed_lines.append({"type": "key", "key": key, "line_number": index + 1, "raw": raw_line})
+            index += 1
+            continue
+
+        if _is_tab_marker(stripped):
+            parsed_lines.append(
+                {"type": "ignored", "reason": "tablature_marker", "line_number": index + 1, "raw": raw_line}
+            )
+            index += 1
+            continue
+
+        directive = _parse_directive(stripped)
+        if directive is not None:
+            parsed_lines.append({**directive, "line_number": index + 1, "raw": raw_line})
+            index += 1
+            continue
+
+        section = _parse_section(stripped)
+        if section is not None:
+            parsed_lines.append({"type": "section", "label": section, "line_number": index + 1, "raw": raw_line})
+            index += 1
+            continue
+
+        ignored_reason = _ignored_line_reason(stripped, line_index=index, lines=lines)
+        if ignored_reason is not None:
+            parsed_lines.append(
+                {"type": "ignored", "reason": ignored_reason, "line_number": index + 1, "raw": raw_line}
+            )
+            index += 1
+            continue
+
+        parenthetical_chords = _parse_parenthetical_chords(stripped)
+        if parenthetical_chords:
+            parsed_lines.append(
+                {
+                    "type": "chords",
+                    "chords": parenthetical_chords,
+                    "line_number": index + 1,
+                    "raw": raw_line,
+                }
+            )
+            index += 1
+            continue
+
+        inline = _parse_inline_chords(raw_line)
+        if inline is not None:
+            parsed_lines.append({**inline, "line_number": index + 1, "raw": raw_line})
+            index += 1
+            continue
+
+        chord_positions = _parse_chord_line(raw_line)
+        if chord_positions:
+            lyric_index = _next_line_index_for_chord_pair(lines, index + 1)
+            if lyric_index is not None:
+                lyric_line = lines[lyric_index].rstrip()
+                parsed_lines.append(
+                    {
+                        "type": "lyrics",
+                        "text": lyric_line.strip(),
+                        "line_number": lyric_index + 1,
+                        "raw": lyric_line,
+                        "chords": _anchor_chords_to_lyrics(chord_positions, lyric_line),
+                    }
+                )
+                index = lyric_index + 1
+                continue
+            parsed_lines.append(
+                {
+                    "type": "chords",
+                    "chords": chord_positions,
+                    "line_number": index + 1,
+                    "raw": raw_line,
+                }
+            )
+            index += 1
+            continue
+
+        if _looks_like_lyric_line(stripped):
+            parsed_lines.append(
+                {"type": "lyrics", "text": stripped, "line_number": index + 1, "raw": raw_line, "chords": []}
+            )
+        else:
+            parsed_lines.append({"type": "ignored", "reason": "noise", "line_number": index + 1, "raw": raw_line})
+        index += 1
+
+    return {
+        "version": PARSER_VERSION,
+        "lines": parsed_lines,
+        "lyrics": [line for line in parsed_lines if line["type"] == "lyrics"],
+        "sections": [line for line in parsed_lines if line["type"] == "section"],
+        "keys": [line for line in parsed_lines if line["type"] == "key"],
+    }
+
+
+def build_tab_proposal(project: Project, parsed: dict[str, Any]) -> dict[str, Any]:
+    lyrics_segments = _current_lyrics_segments(project)
+    lyric_matches = _match_tab_lyrics_to_segments(parsed.get("lyrics", []), lyrics_segments)
+    lyric_suggestions = _build_lyric_suggestions(parsed.get("lyrics", []), lyrics_segments, lyric_matches)
+    chord_suggestions = _build_chord_suggestions(
+        parsed.get("lyrics", []),
+        lyrics_segments,
+        lyric_matches,
+        project.chords,
+    )
+    section_suggestions = _build_section_suggestions(
+        parsed.get("sections", []),
+        parsed.get("lyrics", []),
+        lyrics_segments,
+        lyric_matches,
+    )
+    key_suggestions = _build_key_suggestions(parsed.get("keys", []), project)
+
+    groups = [
+        {"kind": "lyrics", "label": "Lyrics", "suggestions": lyric_suggestions},
+        {"kind": "chords", "label": "Chords", "suggestions": chord_suggestions},
+        {"kind": "sections", "label": "Sections", "suggestions": section_suggestions},
+        {"kind": "key", "label": "Key", "suggestions": key_suggestions},
+    ]
+    return {"groups": groups}
+
+
+def _ignored_line_reason(line: str, *, line_index: int, lines: list[str]) -> str | None:
+    folded = _fold_text(line).lower().strip()
+    if TAB_STAFF_RE.match(line):
+        return "tablature_staff"
+    if _is_tab_marker(line):
+        return "tablature_marker"
+    if PART_MARKER_RE.match(folded):
+        return "tablature_part_marker"
+    if PRINT_MARKER_RE.match(folded):
+        return "print_marker"
+    if _is_footer_line(folded):
+        return "footer"
+    if _is_metadata_line(folded):
+        return "metadata"
+    if _is_likely_preamble_line(line, line_index=line_index, lines=lines):
+        return "preamble"
+    return None
+
+
+def _is_tab_marker(line: str) -> bool:
+    folded = _fold_text(line).lower().strip()
+    return bool(
+        re.match(r"^\[\s*tab\b", folded)
+        or re.match(r"^tab\s*[-:]", folded)
+        or folded in {"tablature", "tablatura"}
+    )
+
+
+def _is_metadata_line(folded_line: str) -> bool:
+    prefix = re.split(r"\s*[:=-]\s*", folded_line, maxsplit=1)[0].strip()
+    if prefix in METADATA_PREFIXES:
+        return True
+    return any(folded_line.startswith(f"{metadata_prefix} ") for metadata_prefix in METADATA_PREFIXES)
+
+
+def _is_footer_line(folded_line: str) -> bool:
+    return any(folded_line.startswith(prefix) for prefix in FOOTER_PREFIXES) or "information is wrong" in folded_line
+
+
+def _is_likely_preamble_line(line: str, *, line_index: int, lines: list[str]) -> bool:
+    if line_index > 2 or not _looks_like_lyric_line(line):
+        return False
+    if _parse_key(line) is not None or _parse_section(line) is not None:
+        return False
+    if _parse_parenthetical_chords(line) or _parse_chord_line(line):
+        return False
+    upcoming = [candidate.strip() for candidate in lines[line_index + 1 : line_index + 8] if candidate.strip()]
+    return any(
+        _parse_key(candidate) is not None
+        or _parse_section(candidate) is not None
+        or _is_tab_marker(candidate)
+        or _parse_chord_line(candidate)
+        or _ignored_line_reason_without_preamble(candidate) is not None
+        for candidate in upcoming
+    )
+
+
+def _ignored_line_reason_without_preamble(line: str) -> str | None:
+    folded = _fold_text(line).lower().strip()
+    if TAB_STAFF_RE.match(line):
+        return "tablature_staff"
+    if _is_tab_marker(line):
+        return "tablature_marker"
+    if PART_MARKER_RE.match(folded):
+        return "tablature_part_marker"
+    if PRINT_MARKER_RE.match(folded):
+        return "print_marker"
+    if _is_footer_line(folded):
+        return "footer"
+    if _is_metadata_line(folded):
+        return "metadata"
+    return None
+
+
+def _next_line_index_for_chord_pair(lines: list[str], start_index: int) -> int | None:
+    index = start_index
+    while index < len(lines):
+        candidate = lines[index].rstrip()
+        stripped = candidate.strip()
+        if not stripped or PRINT_MARKER_RE.match(_fold_text(stripped).lower()):
+            index += 1
+            continue
+        if _ignored_line_reason_without_preamble(stripped) is not None:
+            return None
+        if _parse_key(stripped) is not None or _parse_section(stripped) is not None:
+            return None
+        if _parse_chord_line(candidate):
+            return None
+        return index if _looks_like_lyric_line(stripped) else None
+    return None
+
+
+def _looks_like_lyric_line(line: str) -> bool:
+    folded = _fold_text(line)
+    if not re.search(r"[A-Za-z]", folded):
+        return False
+    symbol_count = len(re.findall(r"[-|_/\\]", line))
+    return symbol_count <= max(3, len(line) // 3)
+
+
+def _parse_directive(line: str) -> dict[str, Any] | None:
+    match = DIRECTIVE_RE.match(line)
+    if not match:
+        return None
+    name = match.group(1).strip().lower()
+    value = match.group(2).strip()
+    if name in {"key", "meta-key"}:
+        key = _parse_key(value)
+        return {"type": "key", "key": key} if key is not None else None
+    if name in CHORDPRO_SECTION_ALIASES:
+        return {"type": "section", "label": CHORDPRO_SECTION_ALIASES[name]}
+    if name in {"start_of_tab", "end_of_tab", "eot", "end_of_chorus", "eoc", "end_of_verse", "eov"}:
+        return {"type": "directive", "name": name, "value": value}
+    return None
+
+
+def _parse_section(line: str) -> str | None:
+    section_match = re.match(r"^\[\s*([^\]]+?)\s*\](?:\s+.*)?$", line)
+    bracketed = section_match.group(1).strip() if section_match else line
+    normalized = _normalize_section_label(bracketed)
+    if normalized in SECTION_LABELS:
+        return bracketed.strip()
+    return None
+
+
+def _parse_inline_chords(line: str) -> dict[str, Any] | None:
+    chords: list[dict[str, Any]] = []
+    lyric_parts: list[str] = []
+    cursor = 0
+    lyric_cursor = 0
+    for match in INLINE_CHORD_RE.finditer(line):
+        raw_chord = match.group(1).strip()
+        if not _is_chord_token(raw_chord):
+            continue
+        before = line[cursor:match.start()]
+        lyric_parts.append(before)
+        lyric_cursor += len(before)
+        chords.append({"label": raw_chord, "column": lyric_cursor, "word_index": None})
+        cursor = match.end()
+
+    if not chords:
+        return None
+    lyric_parts.append(line[cursor:])
+    lyric_text = "".join(lyric_parts).strip()
+    if not lyric_text:
+        return None
+    return {
+        "type": "lyrics",
+        "text": lyric_text,
+        "chords": _anchor_chords_to_lyrics(chords, lyric_text),
+    }
+
+
+def _parse_chord_line(line: str) -> list[dict[str, Any]]:
+    tokens = list(re.finditer(r"\S+", line))
+    if not tokens:
+        return []
+    chord_tokens = [
+        {"label": token.group(0), "column": token.start(), "word_index": None}
+        for token in tokens
+        if _is_chord_token(token.group(0))
+    ]
+    if len(chord_tokens) != len(tokens):
+        return []
+    return chord_tokens if len(chord_tokens) >= 1 else []
+
+
+def _parse_parenthetical_chords(line: str) -> list[dict[str, Any]]:
+    if not line.startswith("(") or not line.endswith(")"):
+        return []
+    inner = line[1:-1].strip()
+    if not inner:
+        return []
+    chord_line = _parse_chord_line(inner)
+    if not chord_line:
+        return []
+    return [{**chord, "column": chord["column"] + 1} for chord in chord_line]
+
+
+def _anchor_chords_to_lyrics(chords: list[dict[str, Any]], lyric_line: str) -> list[dict[str, Any]]:
+    word_matches = list(WORD_RE.finditer(lyric_line))
+    anchored: list[dict[str, Any]] = []
+    for chord in chords:
+        column = int(chord.get("column", 0))
+        word_index = 0
+        for index, match in enumerate(word_matches):
+            if match.start() <= column:
+                word_index = index
+        anchored.append({**chord, "word_index": word_index})
+    return anchored
+
+
+def _is_chord_token(token: str) -> bool:
+    parsed = parse_chord_label(token)
+    return not parsed.is_unknown
+
+
+def _parse_key(value: str) -> dict[str, Any] | None:
+    key_value = value.strip()
+    key_match = KEY_RE.search(key_value)
+    if key_match:
+        key_value = key_match.group(1)
+    match = re.match(r"^([A-Ga-g](?:#|b)?)(?:\s*(m|min|minor|major))?$", key_value.strip())
+    if not match:
+        return None
+    root, mode_raw = match.groups()
+    parsed_root = parse_chord_label(root)
+    if parsed_root.root_pitch_class is None:
+        return None
+    mode = "minor" if mode_raw and mode_raw.lower() in {"m", "min", "minor"} else "major"
+    return {
+        "label": f"{root.strip()}{'m' if mode == 'minor' else ''}",
+        "source_key_override": f"{parsed_root.root_pitch_class}:{mode}",
+    }
+
+
+def _current_lyrics_segments(project: Project) -> list[dict[str, Any]]:
+    return deepcopy(project.lyrics.segments_json) if project.lyrics is not None else []
+
+
+def _match_tab_lyrics_to_segments(
+    tab_lyrics: list[dict[str, Any]],
+    lyrics_segments: list[dict[str, Any]],
+) -> dict[int, int]:
+    if not tab_lyrics or not lyrics_segments:
+        return {}
+
+    threshold = 0.55
+    scores = [
+        [
+            _text_similarity(str(tab_lyric.get("text", "")), str(lyrics_segment.get("text", "")))
+            for lyrics_segment in lyrics_segments
+        ]
+        for tab_lyric in tab_lyrics
+    ]
+    tab_count = len(tab_lyrics)
+    lyric_count = len(lyrics_segments)
+    dp = [[0.0 for _ in range(lyric_count + 1)] for _ in range(tab_count + 1)]
+    choice = [["" for _ in range(lyric_count + 1)] for _ in range(tab_count + 1)]
+
+    for tab_index in range(1, tab_count + 1):
+        for lyric_index in range(1, lyric_count + 1):
+            best = dp[tab_index - 1][lyric_index]
+            best_choice = "up"
+            if dp[tab_index][lyric_index - 1] > best:
+                best = dp[tab_index][lyric_index - 1]
+                best_choice = "left"
+
+            score = scores[tab_index - 1][lyric_index - 1]
+            diagonal = dp[tab_index - 1][lyric_index - 1] + score if score >= threshold else -1.0
+            if diagonal > best:
+                best = diagonal
+                best_choice = "diag"
+
+            dp[tab_index][lyric_index] = best
+            choice[tab_index][lyric_index] = best_choice
+
+    matches: dict[int, int] = {}
+    tab_index = tab_count
+    lyric_index = lyric_count
+    while tab_index > 0 and lyric_index > 0:
+        current_choice = choice[tab_index][lyric_index]
+        if current_choice == "diag":
+            matches[tab_index - 1] = lyric_index - 1
+            tab_index -= 1
+            lyric_index -= 1
+        elif current_choice == "left":
+            lyric_index -= 1
+        else:
+            tab_index -= 1
+    return dict(sorted(matches.items()))
+
+
+def _build_lyric_suggestions(
+    tab_lyrics: list[dict[str, Any]],
+    lyrics_segments: list[dict[str, Any]],
+    lyric_matches: dict[int, int],
+) -> list[dict[str, Any]]:
+    suggestions: list[dict[str, Any]] = []
+    for tab_index, lyric in enumerate(tab_lyrics):
+        suggested_text = str(lyric.get("text", "")).strip()
+        segment_index = lyric_matches.get(tab_index)
+        if segment_index is None:
+            suggestions.append(
+                _suggestion(
+                    suggestion_id=f"lyrics-extra-{tab_index}",
+                    kind="lyrics",
+                    title="Additional tab lyric line",
+                    current_text=None,
+                    suggested_text=suggested_text,
+                    payload={"action": "append_untimed_lyric", "text": suggested_text, "tab_line_index": tab_index},
+                )
+            )
+            continue
+        current = lyrics_segments[segment_index]
+        current_text = str(current.get("text", ""))
+        if _normalize_text(current_text) == _normalize_text(suggested_text):
+            continue
+        suggestions.append(
+            _suggestion(
+                suggestion_id=f"lyrics-{segment_index}-{tab_index}",
+                kind="lyrics",
+                title="Update lyric text",
+                current_text=current_text,
+                suggested_text=suggested_text,
+                start_seconds=_float_or_none(current.get("start_seconds")),
+                end_seconds=_float_or_none(current.get("end_seconds")),
+                segment_index=segment_index,
+                payload={"action": "replace_lyric_segment", "segment_index": segment_index, "text": suggested_text},
+            )
+        )
+    return suggestions
+
+
+def _build_chord_suggestions(
+    tab_lyrics: list[dict[str, Any]],
+    lyrics_segments: list[dict[str, Any]],
+    lyric_matches: dict[int, int],
+    chords: ChordTimeline | None,
+) -> list[dict[str, Any]]:
+    suggestions: list[dict[str, Any]] = []
+    current_timeline = chords.segments_json if chords is not None else []
+    for tab_index, lyric in enumerate(tab_lyrics):
+        segment_index = lyric_matches.get(tab_index)
+        if segment_index is None:
+            continue
+        segment = lyrics_segments[segment_index]
+        for chord_index, chord in enumerate(lyric.get("chords", [])):
+            chord_segment = _tab_chord_to_segment(chord, segment)
+            if chord_segment is None:
+                continue
+            current_label = _current_chord_label_at(current_timeline, chord_segment["start_seconds"])
+            if current_label == chord_segment["label"]:
+                continue
+            suggestions.append(
+                _suggestion(
+                    suggestion_id=f"chord-{segment_index}-{tab_index}-{chord_index}",
+                    kind="chords",
+                    title="Update chord marker",
+                    current_text=current_label,
+                    suggested_text=chord_segment["label"],
+                    start_seconds=chord_segment["start_seconds"],
+                    end_seconds=chord_segment["end_seconds"],
+                    segment_index=segment_index,
+                    chord_index=chord_index,
+                    payload={"action": "overlay_chord", "segment": chord_segment},
+                )
+            )
+    return suggestions
+
+
+def _build_section_suggestions(
+    sections: list[dict[str, Any]],
+    tab_lyrics: list[dict[str, Any]],
+    lyrics_segments: list[dict[str, Any]],
+    lyric_matches: dict[int, int],
+) -> list[dict[str, Any]]:
+    suggestions: list[dict[str, Any]] = []
+    matched_tab_indexes = sorted(lyric_matches)
+    for section_index, section in enumerate(sections):
+        label = str(section.get("label", "")).strip()
+        line_number = int(section.get("line_number", 0))
+        next_tab_index = next(
+            (
+                tab_index
+                for tab_index in matched_tab_indexes
+                if int(tab_lyrics[tab_index].get("line_number", 0)) > line_number
+            ),
+            None,
+        )
+        start_seconds = None
+        if next_tab_index is not None:
+            segment = lyrics_segments[lyric_matches[next_tab_index]]
+            start_seconds = _float_or_none(segment.get("start_seconds"))
+        suggestions.append(
+            _suggestion(
+                suggestion_id=f"section-{section_index}",
+                kind="sections",
+                title="Add song section",
+                current_text=None,
+                suggested_text=label,
+                start_seconds=start_seconds,
+                payload={"action": "add_section", "label": label, "start_seconds": start_seconds},
+            )
+        )
+    return suggestions
+
+
+def _build_key_suggestions(keys: list[dict[str, Any]], project: Project) -> list[dict[str, Any]]:
+    for key in keys:
+        parsed_key = key.get("key")
+        if not isinstance(parsed_key, dict):
+            continue
+        source_key_override = parsed_key.get("source_key_override")
+        if not isinstance(source_key_override, str) or source_key_override == project.source_key_override:
+            continue
+        return [
+            _suggestion(
+                suggestion_id="key-source",
+                kind="key",
+                title="Update source key",
+                current_text=project.source_key_override,
+                suggested_text=str(parsed_key.get("label", source_key_override)),
+                payload={"action": "update_source_key", "source_key_override": source_key_override},
+            )
+        ]
+    return []
+
+
+def _tab_chord_to_segment(chord: dict[str, Any], segment: dict[str, Any]) -> dict[str, Any] | None:
+    start_seconds = _time_for_word(segment, int(chord.get("word_index", 0)))
+    segment_end = _float_or_none(segment.get("end_seconds"))
+    if start_seconds is None or segment_end is None:
+        return None
+    end_seconds = min(segment_end, start_seconds + 2.0)
+    if end_seconds <= start_seconds:
+        end_seconds = start_seconds + 0.25
+    return chord_label_to_segment(
+        str(chord.get("label", "")),
+        start_seconds=start_seconds,
+        end_seconds=end_seconds,
+        confidence=None,
+    )
+
+
+def _time_for_word(segment: dict[str, Any], word_index: int) -> float | None:
+    words = [word for word in segment.get("words", []) if isinstance(word, dict)]
+    if words and 0 <= word_index < len(words):
+        start_seconds = _float_or_none(words[word_index].get("start_seconds"))
+        if start_seconds is not None:
+            return start_seconds
+    segment_start = _float_or_none(segment.get("start_seconds"))
+    segment_end = _float_or_none(segment.get("end_seconds"))
+    if segment_start is None or segment_end is None:
+        return None
+    return round(segment_start + max(0, word_index) * 0.5, 3)
+
+
+def _current_chord_label_at(timeline: list[dict[str, Any]], time_seconds: float) -> str | None:
+    for segment in timeline:
+        start = _float_or_none(segment.get("start_seconds"))
+        end = _float_or_none(segment.get("end_seconds"))
+        if start is not None and end is not None and start <= time_seconds < end:
+            label = segment.get("label")
+            return str(label) if label is not None else None
+    return None
+
+
+def _apply_lyric_suggestions(
+    session: Session,
+    project: Project,
+    suggestions: list[dict[str, Any]],
+) -> LyricsTranscript | None:
+    lyric_suggestions = [suggestion for suggestion in suggestions if suggestion["kind"] == "lyrics"]
+    if not lyric_suggestions:
+        return None
+    lyrics = session.get(LyricsTranscript, project.id)
+    if lyrics is None:
+        return None
+    segments = deepcopy(lyrics.segments_json)
+    for suggestion in lyric_suggestions:
+        payload = suggestion.get("payload", {})
+        if payload.get("action") == "replace_lyric_segment":
+            index = payload.get("segment_index")
+            text = payload.get("text")
+            if isinstance(index, int) and 0 <= index < len(segments) and isinstance(text, str):
+                segments[index] = retime_lyrics_segment_text(segments[index], text)
+        elif payload.get("action") == "append_untimed_lyric" and isinstance(payload.get("text"), str):
+            segments.append({"text": payload["text"], "start_seconds": None, "end_seconds": None, "words": []})
+    return persist_project_lyrics_segments(session, project_id=project.id, segments=segments)
+
+
+def _apply_chord_suggestions(
+    session: Session,
+    project: Project,
+    suggestions: list[dict[str, Any]],
+) -> ChordTimeline | None:
+    chord_segments = [
+        suggestion.get("payload", {}).get("segment")
+        for suggestion in suggestions
+        if suggestion["kind"] == "chords" and isinstance(suggestion.get("payload", {}).get("segment"), dict)
+    ]
+    if not chord_segments:
+        return None
+    chords = session.get(ChordTimeline, project.id)
+    if chords is None:
+        chords = ChordTimeline(project_id=project.id, backend="tab", source_kind="user-edited")
+        session.add(chords)
+    timeline = _overlay_chord_segments(chords.segments_json or [], cast(list[dict[str, Any]], chord_segments))
+    chords.segments_json = timeline
+    chords.timeline_json = deepcopy(timeline)
+    if not chords.source_segments_json:
+        chords.source_segments_json = deepcopy(timeline)
+    chords.has_user_edits = True
+    chords.source_kind = "user-edited"
+    session.flush()
+    return chords
+
+
+def _apply_section_suggestions(
+    session: Session,
+    project: Project,
+    tab_import: TabImport,
+    suggestions: list[dict[str, Any]],
+) -> list[SongSection]:
+    created: list[SongSection] = []
+    for suggestion in suggestions:
+        if suggestion["kind"] != "sections":
+            continue
+        payload = suggestion.get("payload", {})
+        if payload.get("action") != "add_section" or not isinstance(payload.get("label"), str):
+            continue
+        section = SongSection(
+            id=new_id("sec"),
+            project_id=project.id,
+            tab_import_id=tab_import.id,
+            label=payload["label"],
+            start_seconds=_float_or_none(payload.get("start_seconds")),
+            end_seconds=None,
+            source="tab",
+            metadata_json={"suggestion_id": suggestion["id"]},
+        )
+        session.add(section)
+        created.append(section)
+    session.flush()
+    return created
+
+
+def _apply_key_suggestions(project: Project, suggestions: list[dict[str, Any]]) -> None:
+    for suggestion in suggestions:
+        payload = suggestion.get("payload", {})
+        source_key_override = payload.get("source_key_override")
+        if suggestion["kind"] == "key" and isinstance(source_key_override, str):
+            project.source_key_override = source_key_override
+
+
+def _overlay_chord_segments(
+    current_timeline: list[dict[str, Any]],
+    accepted_segments: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    timeline = [dict(segment) for segment in current_timeline]
+    for accepted in sorted(accepted_segments, key=lambda segment: float(segment["start_seconds"])):
+        start = float(accepted["start_seconds"])
+        end = float(accepted["end_seconds"])
+        next_timeline: list[dict[str, Any]] = []
+        for segment in timeline:
+            segment_start = float(segment["start_seconds"])
+            segment_end = float(segment["end_seconds"])
+            if segment_end <= start or segment_start >= end:
+                next_timeline.append(segment)
+                continue
+            if segment_start < start:
+                next_timeline.append({**segment, "end_seconds": start})
+            if segment_end > end:
+                next_timeline.append({**segment, "start_seconds": end})
+        next_timeline.append(dict(accepted))
+        timeline = _merge_chord_segments(sorted(next_timeline, key=lambda segment: float(segment["start_seconds"])))
+    return timeline
+
+
+def _merge_chord_segments(timeline: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    merged: list[dict[str, Any]] = []
+    for segment in timeline:
+        if not merged or merged[-1].get("label") != segment.get("label"):
+            merged.append(dict(segment))
+            continue
+        merged[-1]["end_seconds"] = segment["end_seconds"]
+    return merged
+
+
+def _flatten_suggestions(proposal_json: dict[str, Any]) -> list[dict[str, Any]]:
+    suggestions: list[dict[str, Any]] = []
+    for group in proposal_json.get("groups", []):
+        if isinstance(group, dict):
+            suggestions.extend(
+                [suggestion for suggestion in group.get("suggestions", []) if isinstance(suggestion, dict)]
+            )
+    return suggestions
+
+
+def _mark_suggestions(proposal_json: dict[str, Any], accepted_ids: set[str]) -> dict[str, Any]:
+    proposal = deepcopy(proposal_json)
+    for group in proposal.get("groups", []):
+        if not isinstance(group, dict):
+            continue
+        for suggestion in group.get("suggestions", []):
+            if isinstance(suggestion, dict):
+                suggestion["status"] = "accepted" if suggestion.get("id") in accepted_ids else "rejected"
+    return proposal
+
+
+def _suggestion(
+    *,
+    suggestion_id: str,
+    kind: str,
+    title: str,
+    current_text: str | None = None,
+    suggested_text: str | None = None,
+    start_seconds: float | None = None,
+    end_seconds: float | None = None,
+    segment_index: int | None = None,
+    chord_index: int | None = None,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": suggestion_id,
+        "kind": kind,
+        "status": "pending",
+        "title": title,
+        "current_text": current_text,
+        "suggested_text": suggested_text,
+        "start_seconds": start_seconds,
+        "end_seconds": end_seconds,
+        "segment_index": segment_index,
+        "chord_index": chord_index,
+        "payload": payload or {},
+    }
+
+
+def _text_similarity(first: str, second: str) -> float:
+    return SequenceMatcher(a=_normalize_text(first), b=_normalize_text(second), autojunk=False).ratio()
+
+
+def _normalize_text(value: str) -> str:
+    return re.sub(r"\s+", " ", re.sub(r"[^\w'\s]+", "", value.lower())).strip()
+
+
+def _normalize_section_label(value: str) -> str:
+    folded = _fold_text(value).lower().strip()
+    folded = re.sub(r"\s+\d+$", "", folded)
+    folded = re.sub(r"\s*\(\d+x\)$", "", folded)
+    folded = folded.replace("_", " ")
+    folded = re.sub(r"\s*-\s*", "-", folded)
+    folded = re.sub(r"\s+", " ", folded)
+    return folded
+
+
+def _fold_text(value: str) -> str:
+    return unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode("ascii")
+
+
+def _float_or_none(value: object) -> float | None:
+    return float(value) if isinstance(value, int | float) else None

--- a/apps/backend/tests/test_chord_flow.py
+++ b/apps/backend/tests/test_chord_flow.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 
 from app.db import SessionLocal
+from app.models import SongSection, TabImport
 from app.services.artifacts import register_artifact
 from app.services.chord_backends import ChordDetectionResult
 from app.services.chords import detect_project_chords
@@ -223,3 +224,57 @@ def test_chord_refresh_preserves_user_edits_without_overwrite(
     assert calls
     assert chords.has_user_edits is False
     assert [segment["label"] for segment in chords.segments_json] == ["G"]
+
+
+def test_chord_refresh_clears_current_tab_state(client, sample_chord_audio_file: Path, monkeypatch):
+    project = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_chord_audio_file), "copy_into_project": True},
+    ).json()["project"]
+
+    initial_jobs = client.get("/api/v1/jobs").json()["jobs"]
+    initial_chord_job = next(
+        job for job in initial_jobs if job["project_id"] == project["id"] and job["type"] == "chords"
+    )
+    assert wait_for_job(client, initial_chord_job["id"])["status"] == "completed"
+
+    with SessionLocal() as session:
+        session.add(
+            TabImport(
+                id="tab_test",
+                project_id=project["id"],
+                raw_text="Key: D",
+                parser_version="test",
+                status="applied",
+                parsed_json={},
+                proposal_json={},
+            )
+        )
+        session.add(
+            SongSection(
+                id="sec_test",
+                project_id=project["id"],
+                tab_import_id="tab_test",
+                label="Verse",
+                source="tab",
+                metadata_json={},
+            )
+        )
+        session.commit()
+
+    def fake_detect_timeline(path: Path, backend_id: str) -> ChordDetectionResult:
+        del path
+        return ChordDetectionResult(
+            segments=[_segment("G", confidence=0.88, pitch_class=7, quality="major")],
+            backend_id=backend_id,
+            metadata={},
+        )
+
+    monkeypatch.setattr("app.services.chords._detect_timeline", fake_detect_timeline)
+
+    with SessionLocal() as session:
+        project_model = get_project(session, project["id"])
+        detect_project_chords(session, project_model, force=True)
+        assert session.get(TabImport, "tab_test") is None
+        assert session.get(SongSection, "sec_test") is None
+        session.commit()

--- a/apps/backend/tests/test_lyrics_flow.py
+++ b/apps/backend/tests/test_lyrics_flow.py
@@ -91,7 +91,9 @@ def test_lyrics_job_persists_transcript_and_update_preserves_timings(
     assert updated["segments"][0]["text"] == "Edited first line"
     assert updated["segments"][0]["start_seconds"] == 0.0
     assert updated["segments"][0]["end_seconds"] == 1.2
-    assert updated["segments"][0]["words"] == []
+    assert [word["text"] for word in updated["segments"][0]["words"]] == ["Edited", "first", "line"]
+    assert updated["segments"][0]["words"][0]["start_seconds"] == 0.0
+    assert updated["segments"][0]["words"][-1]["end_seconds"] == 1.2
     assert updated["source_segments"][0]["text"] == "First line"
     assert updated["has_user_edits"] is True
 

--- a/apps/backend/tests/test_tab_import_flow.py
+++ b/apps/backend/tests/test_tab_import_flow.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.engines.lyrics import LyricsTranscription
+from app.services.tabs import _match_tab_lyrics_to_segments
+
+from .conftest import wait_for_job
+
+
+def _install_lyrics_fixture(monkeypatch) -> None:
+    def fake_transcription(*_args, **_kwargs):
+        return LyricsTranscription(
+            backend="openai-whisper",
+            requested_device="cpu",
+            device="cpu",
+            model="turbo",
+            language="en",
+            segments=[
+                {
+                    "start_seconds": 0.0,
+                    "end_seconds": 8.0,
+                    "text": "Hello from the first line",
+                    "words": [
+                        {"text": "Hello", "start_seconds": 0.0, "end_seconds": 1.0, "confidence": 0.9},
+                        {"text": "from", "start_seconds": 1.0, "end_seconds": 2.0, "confidence": 0.9},
+                        {"text": "the", "start_seconds": 2.0, "end_seconds": 3.0, "confidence": 0.9},
+                        {"text": "first", "start_seconds": 3.0, "end_seconds": 4.5, "confidence": 0.9},
+                        {"text": "line", "start_seconds": 4.5, "end_seconds": 6.0, "confidence": 0.9},
+                    ],
+                },
+                {
+                    "start_seconds": 8.0,
+                    "end_seconds": 16.0,
+                    "text": "Second lyric line stays steady",
+                    "words": [
+                        {"text": "Second", "start_seconds": 8.0, "end_seconds": 9.4, "confidence": 0.9},
+                        {"text": "lyric", "start_seconds": 9.4, "end_seconds": 10.8, "confidence": 0.9},
+                        {"text": "line", "start_seconds": 10.8, "end_seconds": 12.0, "confidence": 0.9},
+                        {"text": "stays", "start_seconds": 12.0, "end_seconds": 13.4, "confidence": 0.9},
+                        {"text": "steady", "start_seconds": 13.4, "end_seconds": 15.2, "confidence": 0.9},
+                    ],
+                },
+            ],
+        )
+
+    monkeypatch.setattr("app.services.lyrics.transcribe_project_lyrics", fake_transcription)
+
+
+def _create_project_with_lyrics(client, monkeypatch, sample_audio_file: Path) -> dict:
+    _install_lyrics_fixture(monkeypatch)
+    project = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_audio_file), "copy_into_project": True},
+    ).json()["project"]
+    job = client.post(f"/api/v1/projects/{project['id']}/lyrics", json={"force": False}).json()["job"]
+    assert wait_for_job(client, job["id"])["status"] == "completed"
+    return project
+
+
+def _suggestions_by_kind(tab_import: dict) -> dict[str, list[dict]]:
+    return {group["kind"]: group["suggestions"] for group in tab_import["groups"]}
+
+
+def test_tab_import_creates_suggestions_without_mutating_project(client, monkeypatch, sample_audio_file: Path):
+    project = _create_project_with_lyrics(client, monkeypatch, sample_audio_file)
+    raw_tab = """{key: D}
+[Verse 1]
+F#       G#
+Hello from the fast line
+[Chorus]
+[A#m]Second lyric line stays steady
+[Chorus 2]
+Extra outro line
+"""
+
+    response = client.post(
+        f"/api/v1/projects/{project['id']}/tabs/proposals",
+        json={"raw_text": raw_tab},
+    )
+
+    assert response.status_code == 200
+    tab_import = response.json()["tab_import"]
+    assert tab_import["raw_text"] == raw_tab
+    groups = _suggestions_by_kind(tab_import)
+    assert groups["lyrics"][0]["suggested_text"] == "Hello from the fast line"
+    assert groups["lyrics"][-1]["suggested_text"] == "Extra outro line"
+    assert [suggestion["suggested_text"] for suggestion in groups["chords"]][:3] == ["F#", "G#", "A#m"]
+    assert [suggestion["suggested_text"] for suggestion in groups["sections"]] == [
+        "Verse 1",
+        "Chorus",
+        "Chorus 2",
+    ]
+    assert groups["key"][0]["payload"]["source_key_override"] == "2:major"
+
+    lyrics = client.get(f"/api/v1/projects/{project['id']}/lyrics").json()
+    assert lyrics["segments"][0]["text"] == "Hello from the first line"
+    assert client.get(f"/api/v1/projects/{project['id']}").json()["project"]["source_key_override"] is None
+
+
+def test_tab_lyric_alignment_prefers_tab_order_over_greedy_best_match():
+    tab_lyrics = [
+        {"text": "verse one hello brave world"},
+        {"text": "verse one hello brave world"},
+    ]
+    lyrics_segments = [
+        {"text": "verse one hello world"},
+        {"text": "verse one hello brave world"},
+    ]
+
+    assert _match_tab_lyrics_to_segments(tab_lyrics, lyrics_segments) == {0: 0, 1: 1}
+
+
+def test_tab_import_filters_rich_chord_sheet_noise_before_alignment(client, monkeypatch, sample_audio_file: Path):
+    project = _create_project_with_lyrics(client, monkeypatch, sample_audio_file)
+    raw_tab = """Synthetic Song
+Example Artist
+Chord sheet print view
+Tom: D (shape chords in C)
+Capo on 2nd fret
+Tuning: E A D G B E
+[Intro] Em
+
+[Tab - Intro]
+Part 1 of 2
+   Em          A
+E|----------------|
+B|----------------|
+G|----------------|
+D|--2-2-2---------|
+A|----------------|
+E|----------------|
+
+( A  G  D/F# )
+
+[Verse 1]
+F#       G#
+Hello from the fast line
+Page 1 / 2
+[Chorus]
+[A#m]Second lyric line stays steady
+
+Composition by Example Writer. Report wrong info.
+"""
+
+    response = client.post(
+        f"/api/v1/projects/{project['id']}/tabs/proposals",
+        json={"raw_text": raw_tab},
+    )
+
+    assert response.status_code == 200
+    tab_import = response.json()["tab_import"]
+    assert tab_import["raw_text"] == raw_tab
+    groups = _suggestions_by_kind(tab_import)
+    assert [suggestion["suggested_text"] for suggestion in groups["lyrics"]] == ["Hello from the fast line"]
+    assert {suggestion["suggested_text"] for suggestion in groups["chords"]} >= {"F#", "G#", "A#m"}
+    assert [suggestion["suggested_text"] for suggestion in groups["sections"]] == [
+        "Intro",
+        "Verse 1",
+        "Chorus",
+    ]
+    assert groups["key"][0]["payload"]["source_key_override"] == "2:major"
+    ignored_reasons = {line["reason"] for line in tab_import["parsed"]["lines"] if line["type"] == "ignored"}
+    assert ignored_reasons >= {"preamble", "metadata", "tablature_marker", "tablature_staff", "print_marker", "footer"}
+
+
+def test_tab_import_is_single_project_scoped_record(client, monkeypatch, sample_audio_file: Path):
+    project = _create_project_with_lyrics(client, monkeypatch, sample_audio_file)
+    first = client.post(
+        f"/api/v1/projects/{project['id']}/tabs/proposals",
+        json={"raw_text": "Key: D\n[Verse]\nHello from the fast line\n"},
+    ).json()["tab_import"]
+    second_raw = "Key: E\n[Chorus]\nSecond lyric line stays steady\n"
+    second = client.post(
+        f"/api/v1/projects/{project['id']}/tabs/proposals",
+        json={"raw_text": second_raw},
+    ).json()["tab_import"]
+
+    assert second["id"] == first["id"]
+    assert second["raw_text"] == second_raw
+    detail = client.get(f"/api/v1/projects/{project['id']}/tabs/{first['id']}").json()["tab_import"]
+    assert detail["raw_text"] == second_raw
+
+
+def test_tab_import_acceptance_applies_only_selected_suggestions(client, monkeypatch, sample_audio_file: Path):
+    project = _create_project_with_lyrics(client, monkeypatch, sample_audio_file)
+    raw_tab = """Key: D
+[Verse]
+F#      G#
+Hello from the fast line
+"""
+    tab_import = client.post(
+        f"/api/v1/projects/{project['id']}/tabs/proposals",
+        json={"raw_text": raw_tab},
+    ).json()["tab_import"]
+    groups = _suggestions_by_kind(tab_import)
+    accepted_ids = [
+        groups["lyrics"][0]["id"],
+        groups["chords"][0]["id"],
+        groups["sections"][0]["id"],
+    ]
+    accepted_chord_label = groups["chords"][0]["suggested_text"]
+
+    applied = client.post(
+        f"/api/v1/projects/{project['id']}/tabs/{tab_import['id']}/accept",
+        json={"accepted_suggestion_ids": accepted_ids},
+    ).json()
+
+    assert applied["accepted_suggestion_ids"] == accepted_ids
+    assert applied["project"]["source_key_override"] is None
+    lyrics = client.get(f"/api/v1/projects/{project['id']}/lyrics").json()
+    assert lyrics["segments"][0]["text"] == "Hello from the fast line"
+    assert [word["text"] for word in lyrics["segments"][0]["words"]] == ["Hello", "from", "the", "fast", "line"]
+    assert lyrics["segments"][0]["words"][3]["start_seconds"] == 3.0
+
+    chords = client.get(f"/api/v1/projects/{project['id']}/chords").json()
+    assert chords["has_user_edits"] is True
+    assert chords["source_kind"] == "user-edited"
+    assert accepted_chord_label in {segment["label"] for segment in chords["timeline"]}
+
+    sections = client.get(f"/api/v1/projects/{project['id']}/sections").json()["sections"]
+    assert sections[0]["label"] == "Verse"
+    assert sections[0]["start_seconds"] == 0.0
+
+
+def test_lyrics_refresh_clears_current_tab_state(client, monkeypatch, sample_audio_file: Path):
+    project = _create_project_with_lyrics(client, monkeypatch, sample_audio_file)
+    tab_import = client.post(
+        f"/api/v1/projects/{project['id']}/tabs/proposals",
+        json={"raw_text": "Key: D\n[Verse]\nF#\nHello from the fast line\n"},
+    ).json()["tab_import"]
+    groups = _suggestions_by_kind(tab_import)
+    client.post(
+        f"/api/v1/projects/{project['id']}/tabs/{tab_import['id']}/accept",
+        json={"accepted_suggestion_ids": [groups["sections"][0]["id"]]},
+    )
+    assert client.get(f"/api/v1/projects/{project['id']}/sections").json()["sections"]
+
+    job = client.post(f"/api/v1/projects/{project['id']}/lyrics", json={"force": True}).json()["job"]
+    assert wait_for_job(client, job["id"])["status"] == "completed"
+
+    assert client.get(f"/api/v1/projects/{project['id']}/tabs/{tab_import['id']}").status_code == 404
+    assert client.get(f"/api/v1/projects/{project['id']}/sections").json()["sections"] == []

--- a/apps/desktop/src/App.project-analysis-mix.test.tsx
+++ b/apps/desktop/src/App.project-analysis-mix.test.tsx
@@ -9,10 +9,12 @@ import {
   markAudioReady,
   mockAnalyzeProject,
   mockConfirm,
+  mockAcceptTabImport,
   mockCreateChords,
   mockCreateLyrics,
   mockCreatePreview,
   mockCreateStems,
+  mockCreateTabImport,
   mockUpdateLyrics,
   mockUpdateProject,
   renderApp,
@@ -262,7 +264,59 @@ describe("Desktop app project analysis mix", () => {
         { text: "Second lyric line stays steady" },
       ],
     });
-    expect(await screen.findByText("Edited lyric line")).toBeInTheDocument();
+    const editedWord = await screen.findByText("Edited");
+    expect(editedWord).toHaveClass("lyrics-word");
+  });
+
+  it("reviews pasted tab suggestions before applying accepted changes", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    expect(screen.getByRole("group", { name: "Lyrics and chords lead sheet" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Import Tab" }));
+    const dialog = await screen.findByRole("dialog", { name: "Import tab suggestions" });
+    fireEvent.change(within(dialog).getByLabelText("Tab text"), {
+      target: { value: "[Verse]\nF#\nHello from the fast line" },
+    });
+    await user.click(within(dialog).getByRole("button", { name: "Create Suggestions" }));
+
+    expect(mockCreateTabImport).toHaveBeenCalledWith("proj_123", {
+      raw_text: "[Verse]\nF#\nHello from the fast line",
+    });
+    expect(await within(dialog).findByRole("heading", { name: "Lyrics" })).toBeInTheDocument();
+    expect(within(dialog).getByRole("heading", { name: "Chords" })).toBeInTheDocument();
+    expect(within(dialog).getByRole("heading", { name: "Sections" })).toBeInTheDocument();
+    expect(within(dialog).getByRole("heading", { name: "Key" })).toBeInTheDocument();
+    expect(within(dialog).getByRole("button", { name: "Apply Accepted (0)" })).toBeDisabled();
+
+    const lyricCheckbox = within(dialog).getByLabelText("Accept Update lyric segment 1");
+    const lyricSuggestion = lyricCheckbox.closest(".tab-import-suggestion");
+    expect(lyricSuggestion).not.toBeNull();
+    expect(within(lyricSuggestion as HTMLElement).getByText("Hello from the first line")).toBeInTheDocument();
+    expect(within(lyricSuggestion as HTMLElement).getByText("Hello from the fast line")).toBeInTheDocument();
+    expect(lyricCheckbox).not.toBeChecked();
+    await user.click(lyricCheckbox);
+    const chordGroup = within(dialog).getByRole("heading", { name: "Chords" }).closest("section");
+    expect(chordGroup).not.toBeNull();
+    await user.click(within(chordGroup as HTMLElement).getByRole("button", { name: "Accept Group" }));
+    await user.click(within(dialog).getByRole("button", { name: "Apply Accepted (2)" }));
+
+    await waitFor(() =>
+      expect(mockAcceptTabImport).toHaveBeenCalledWith("proj_123", "tab_200", {
+        accepted_suggestion_ids: ["tab_200_lyrics_1", "tab_200_chord_1"],
+      }),
+    );
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "Import tab suggestions" })).not.toBeInTheDocument(),
+    );
+
+    const leadSheet = screen.getByRole("group", { name: "Lyrics and chords lead sheet" });
+    const fastWord = await within(leadSheet).findByText("fast");
+    expect(fastWord).toHaveClass("lyrics-word");
+    expect(getByAriaKeyLabel(leadSheet, "F#")).toBeInTheDocument();
   });
 
   it("hard follows lyrics during playback after manual scroll", async () => {
@@ -523,7 +577,7 @@ describe("Desktop app project analysis mix", () => {
     await user.click(screen.getByRole("button", { name: "Refresh Lyrics" }));
 
     expect(mockConfirm).toHaveBeenCalledWith(
-      "Refresh lyrics? This replaces the current transcript and discards your edits.",
+      "Refresh lyrics? This replaces the current transcript and discards your edits, including accepted tab suggestions.",
       expect.objectContaining({
         title: "Refresh lyrics",
         kind: "warning",
@@ -554,7 +608,7 @@ describe("Desktop app project analysis mix", () => {
     await user.click(screen.getByRole("button", { name: "Refresh Chords" }));
 
     expect(mockConfirm).toHaveBeenCalledWith(
-      "Refresh chords? This replaces the current chord timeline and discards your edits.",
+      "Refresh chords? This replaces the current chord timeline and discards your edits, including accepted tab suggestions.",
       expect.objectContaining({
         title: "Refresh chords",
         kind: "warning",

--- a/apps/desktop/src/features/projects/components/PlaybackPracticeSurface.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackPracticeSurface.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, KeyboardEvent } from "react";
 import { MusicalChordLabel } from "../../../components/MusicalLabel";
+import type { TabSuggestionGroupSchema, TabSuggestionSchema } from "../../../lib/api";
 import type { LeadSheetChord, LeadSheetLyricsRow, LeadSheetRow } from "../projectViewUtils";
 import {
   formatPlaybackClock,
@@ -41,19 +42,33 @@ function usePracticeTargetSpacePlayback() {
 
 function PlaybackModeHeader() {
   const {
+    acceptedTabSuggestionIds,
     chordsFollowEnabled,
     displayedLyrics,
+    handleAcceptTabSuggestionGroup,
+    handleApplyTabSuggestions,
+    handleCloseTabImport,
+    handleCreateTabImportProposal,
+    handleOpenTabImport,
+    handleRejectTabSuggestionGroup,
     handleSetChordsFollowEnabled,
     handleSetLyricsFollowEnabled,
     handleTogglePlaybackDisplayLane,
     hasLyricsTranscript,
     isEditingLyrics,
     isLyricsRunning,
+    isTabImportOpen,
     lyricsFollowEnabled,
-    setLyricsDraft,
     lyricsMutation,
     playbackDisplayMode,
+    selectedTabSuggestionId,
     setIsEditingLyrics,
+    setLyricsDraft,
+    setSelectedTabSuggestionId,
+    setTabImportDraft,
+    tabImportApplyMutation,
+    tabImportDraft,
+    tabImportMutation,
   } = useProjectViewModelContext();
   const lyricsSelected = playbackDisplayMode === "lyrics" || playbackDisplayMode === "combined";
   const chordsSelected = playbackDisplayMode === "chords" || playbackDisplayMode === "combined";
@@ -105,6 +120,13 @@ function PlaybackModeHeader() {
               Edit Lyrics
             </button>
           ) : null}
+          <button
+            className="button button--ghost button--small"
+            type="button"
+            onClick={handleOpenTabImport}
+          >
+            Import Tab
+          </button>
           {lyricsSelected ? (
             <>
               <button
@@ -133,8 +155,275 @@ function PlaybackModeHeader() {
           ) : null}
         </div>
       </div>
+      {isTabImportOpen ? (
+        <TabImportDialog
+          acceptedSuggestionIds={acceptedTabSuggestionIds}
+          applyMutation={tabImportApplyMutation}
+          draft={tabImportDraft}
+          importMutation={tabImportMutation}
+          onAcceptGroup={handleAcceptTabSuggestionGroup}
+          onApply={handleApplyTabSuggestions}
+          onClose={handleCloseTabImport}
+          onCreateProposal={handleCreateTabImportProposal}
+          onRejectGroup={handleRejectTabSuggestionGroup}
+          onSelectSuggestion={setSelectedTabSuggestionId}
+          onSetDraft={setTabImportDraft}
+          selectedSuggestionId={selectedTabSuggestionId}
+        />
+      ) : null}
     </div>
   );
+}
+
+function TabImportDialog({
+  acceptedSuggestionIds,
+  applyMutation,
+  draft,
+  importMutation,
+  onAcceptGroup,
+  onApply,
+  onClose,
+  onCreateProposal,
+  onRejectGroup,
+  onSelectSuggestion,
+  onSetDraft,
+  selectedSuggestionId,
+}: {
+  acceptedSuggestionIds: string[];
+  applyMutation: ReturnType<typeof useProjectViewModelContext>["tabImportApplyMutation"];
+  draft: string;
+  importMutation: ReturnType<typeof useProjectViewModelContext>["tabImportMutation"];
+  onAcceptGroup: (suggestionIds: string[]) => void;
+  onApply: () => void;
+  onClose: () => void;
+  onCreateProposal: () => void;
+  onRejectGroup: (suggestionIds: string[]) => void;
+  onSelectSuggestion: (suggestionId: string | null) => void;
+  onSetDraft: (value: string) => void;
+  selectedSuggestionId: string | null;
+}) {
+  const { handleToggleTabSuggestion } = useProjectViewModelContext();
+  const groups = importMutation.data?.tab_import.groups ?? [];
+  const suggestions = groups.flatMap((group) => group.suggestions ?? []);
+  const selectedSuggestion =
+    suggestions.find((suggestion) => suggestion.id === selectedSuggestionId) ?? suggestions[0] ?? null;
+  const acceptedCount = acceptedSuggestionIds.length;
+
+  return (
+    <div className="tab-import-overlay" role="presentation">
+      <section
+        aria-label="Import tab suggestions"
+        aria-modal="true"
+        className="tab-import-drawer"
+        role="dialog"
+      >
+        <div className="tab-import-drawer__header">
+          <div>
+            <p className="metric-label">Tab Import</p>
+            <h3>Review Suggestions</h3>
+          </div>
+          <button
+            className="button button--ghost button--small"
+            disabled={importMutation.isPending || applyMutation.isPending}
+            onClick={onClose}
+            type="button"
+          >
+            Close
+          </button>
+        </div>
+
+        <label className="tab-import-input">
+          <span>Tab text</span>
+          <textarea
+            value={draft}
+            onChange={(event) => onSetDraft(event.currentTarget.value)}
+            placeholder={"[Verse]\nG       D\nHello from the first line"}
+          />
+        </label>
+
+        <div className="button-row tab-import-actions">
+          <button
+            className="button button--primary button--small"
+            disabled={!draft.trim() || importMutation.isPending || applyMutation.isPending}
+            onClick={onCreateProposal}
+            type="button"
+          >
+            {importMutation.isPending ? "Reading..." : "Create Suggestions"}
+          </button>
+          <button
+            className="button button--ghost button--small"
+            disabled={acceptedCount === 0 || importMutation.isPending || applyMutation.isPending}
+            onClick={onApply}
+            type="button"
+          >
+            {applyMutation.isPending ? "Applying..." : `Apply Accepted (${acceptedCount})`}
+          </button>
+        </div>
+
+        {importMutation.error ? <p className="inline-error">{mutationErrorMessage(importMutation.error)}</p> : null}
+        {applyMutation.error ? <p className="inline-error">{mutationErrorMessage(applyMutation.error)}</p> : null}
+
+        {groups.length ? (
+          <div className="tab-import-review">
+            <div className="tab-import-groups">
+              {groups.map((group) => (
+                <TabSuggestionGroup
+                  acceptedSuggestionIds={acceptedSuggestionIds}
+                  group={group}
+                  key={group.kind}
+                  onAcceptGroup={onAcceptGroup}
+                  onRejectGroup={onRejectGroup}
+                  onSelectSuggestion={onSelectSuggestion}
+                  onToggleSuggestion={handleToggleTabSuggestion}
+                  selectedSuggestionId={selectedSuggestion?.id ?? null}
+                />
+              ))}
+            </div>
+
+            <TabSuggestionDetail suggestion={selectedSuggestion} />
+          </div>
+        ) : null}
+      </section>
+    </div>
+  );
+}
+
+function TabSuggestionGroup({
+  acceptedSuggestionIds,
+  group,
+  onAcceptGroup,
+  onRejectGroup,
+  onSelectSuggestion,
+  onToggleSuggestion,
+  selectedSuggestionId,
+}: {
+  acceptedSuggestionIds: string[];
+  group: TabSuggestionGroupSchema;
+  onAcceptGroup: (suggestionIds: string[]) => void;
+  onRejectGroup: (suggestionIds: string[]) => void;
+  onSelectSuggestion: (suggestionId: string | null) => void;
+  onToggleSuggestion: (suggestionId: string) => void;
+  selectedSuggestionId: string | null;
+}) {
+  const suggestions = group.suggestions ?? [];
+  const suggestionIds = suggestions.map((suggestion) => suggestion.id);
+
+  return (
+    <section className="tab-import-group">
+      <div className="tab-import-group__header">
+        <div>
+          <h4>{group.label}</h4>
+          <span className="artifact-meta">{suggestions.length} suggestions</span>
+        </div>
+        <div className="button-row">
+          <button
+            className="button button--ghost button--small"
+            disabled={!suggestionIds.length}
+            onClick={() => onAcceptGroup(suggestionIds)}
+            type="button"
+          >
+            Accept Group
+          </button>
+          <button
+            className="button button--ghost button--small"
+            disabled={!suggestionIds.length}
+            onClick={() => onRejectGroup(suggestionIds)}
+            type="button"
+          >
+            Reject Group
+          </button>
+        </div>
+      </div>
+
+      <div className="tab-import-suggestions">
+        {suggestions.map((suggestion) => {
+          const accepted = acceptedSuggestionIds.includes(suggestion.id);
+          const selected = suggestion.id === selectedSuggestionId;
+          return (
+            <div
+              className={`tab-import-suggestion${selected ? " tab-import-suggestion--selected" : ""}`}
+              key={suggestion.id}
+            >
+              <input
+                aria-label={`Accept ${suggestion.title}`}
+                checked={accepted}
+                onChange={() => onToggleSuggestion(suggestion.id)}
+                type="checkbox"
+              />
+              <button
+                className="tab-import-suggestion__summary"
+                onClick={(event) => {
+                  event.preventDefault();
+                  onSelectSuggestion(suggestion.id);
+                }}
+                type="button"
+              >
+                <span className="tab-import-suggestion__heading">
+                  <span>{suggestion.title}</span>
+                  <small>{suggestionTimeLabel(suggestion)}</small>
+                </span>
+                <span className="tab-import-suggestion__comparison">
+                  <span className="tab-import-suggestion__cell">
+                    <span className="metric-label">Current</span>
+                    <span>{suggestion.current_text ?? "-"}</span>
+                  </span>
+                  <span className="tab-import-suggestion__cell">
+                    <span className="metric-label">Tab</span>
+                    <span>{suggestion.suggested_text ?? "-"}</span>
+                  </span>
+                </span>
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function TabSuggestionDetail({ suggestion }: { suggestion: TabSuggestionSchema | null }) {
+  if (!suggestion) {
+    return (
+      <aside className="tab-import-detail">
+        <p className="artifact-meta">No suggestions yet.</p>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="tab-import-detail">
+      <div>
+        <p className="metric-label">{suggestion.kind}</p>
+        <h4>{suggestion.title}</h4>
+        <span className="artifact-meta">{suggestionTimeLabel(suggestion)}</span>
+      </div>
+      <div className="tab-import-diff">
+        <div>
+          <span className="metric-label">Current</span>
+          <p>{suggestion.current_text ?? "-"}</p>
+        </div>
+        <div>
+          <span className="metric-label">Tab</span>
+          <p>{suggestion.suggested_text ?? "-"}</p>
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+function suggestionTimeLabel(suggestion: TabSuggestionSchema) {
+  if (typeof suggestion.start_seconds !== "number") {
+    return "Untimed";
+  }
+  const start = formatPlaybackClock(suggestion.start_seconds);
+  if (typeof suggestion.end_seconds !== "number") {
+    return start;
+  }
+  return `${start} - ${formatPlaybackClock(suggestion.end_seconds)}`;
+}
+
+function mutationErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : "The request failed.";
 }
 
 function LyricsPracticePanel() {

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -150,6 +150,10 @@ export function useProjectViewModel() {
   const [dismissedStemJobIds, setDismissedStemJobIds] = useState<string[]>([]);
   const [isEditingLyrics, setIsEditingLyrics] = useState(false);
   const [lyricsDraft, setLyricsDraft] = useState<string[]>([]);
+  const [isTabImportOpen, setIsTabImportOpen] = useState(false);
+  const [tabImportDraft, setTabImportDraft] = useState("");
+  const [acceptedTabSuggestionIds, setAcceptedTabSuggestionIds] = useState<string[]>([]);
+  const [selectedTabSuggestionId, setSelectedTabSuggestionId] = useState<string | null>(null);
   const [lyricsFollowEnabled, setLyricsFollowEnabled] = useState(defaultLyricsFollowEnabled);
   const [chordsFollowEnabled, setChordsFollowEnabled] = useState(defaultChordsFollowEnabled);
   const showSupportingCopy = informationDensity !== "minimal";
@@ -172,6 +176,11 @@ export function useProjectViewModel() {
   const lyricsQuery = useQuery({
     queryKey: ["lyrics", projectId],
     queryFn: async () => api.getLyrics(projectId),
+    enabled: Boolean(projectId),
+  });
+  const sectionsQuery = useQuery({
+    queryKey: ["sections", projectId],
+    queryFn: async () => api.listSections(projectId),
     enabled: Boolean(projectId),
   });
   const artifactsQuery = useQuery({
@@ -315,6 +324,41 @@ export function useProjectViewModel() {
     onSuccess: async () => {
       setIsEditingLyrics(false);
       await queryClient.invalidateQueries({ queryKey: ["lyrics", projectId] });
+    },
+  });
+
+  const tabImportMutation = useMutation({
+    mutationFn: async (rawText: string) => api.createTabImport(projectId, { raw_text: rawText }),
+    onSuccess: (response) => {
+      const firstSuggestion =
+        response.tab_import.groups?.flatMap((group) => group.suggestions ?? [])[0] ?? null;
+      setAcceptedTabSuggestionIds([]);
+      setSelectedTabSuggestionId(firstSuggestion?.id ?? null);
+    },
+  });
+
+  const tabImportApplyMutation = useMutation({
+    mutationFn: async () => {
+      const tabImportId = tabImportMutation.data?.tab_import.id;
+      if (!tabImportId) {
+        throw new Error("Create tab suggestions first.");
+      }
+      return api.acceptTabImport(projectId, tabImportId, {
+        accepted_suggestion_ids: acceptedTabSuggestionIds,
+      });
+    },
+    onSuccess: async () => {
+      setIsTabImportOpen(false);
+      setAcceptedTabSuggestionIds([]);
+      setSelectedTabSuggestionId(null);
+      setTabImportDraft("");
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["project", projectId] }),
+        queryClient.invalidateQueries({ queryKey: ["projects"] }),
+        queryClient.invalidateQueries({ queryKey: ["lyrics", projectId] }),
+        queryClient.invalidateQueries({ queryKey: ["chords", projectId] }),
+        queryClient.invalidateQueries({ queryKey: ["sections", projectId] }),
+      ]);
     },
   });
 
@@ -777,7 +821,7 @@ export function useProjectViewModel() {
     const hasUserChordEdits = chordsQuery.data?.has_user_edits === true;
     if (hasExistingChords && hasUserChordEdits) {
       const approved = await confirm(
-        "Refresh chords? This replaces the current chord timeline and discards your edits.",
+        "Refresh chords? This replaces the current chord timeline and discards your edits, including accepted tab suggestions.",
         {
           title: "Refresh chords",
           kind: "warning",
@@ -798,6 +842,53 @@ export function useProjectViewModel() {
 
   function handleSetChordsFollowEnabled(enabled: boolean) {
     setChordsFollowEnabled(enabled);
+  }
+
+  function handleOpenTabImport() {
+    setIsTabImportOpen(true);
+  }
+
+  function handleCloseTabImport() {
+    if (tabImportMutation.isPending || tabImportApplyMutation.isPending) {
+      return;
+    }
+    setIsTabImportOpen(false);
+  }
+
+  function handleCreateTabImportProposal() {
+    if (!tabImportDraft.trim()) {
+      return;
+    }
+    tabImportMutation.mutate(tabImportDraft);
+  }
+
+  function handleToggleTabSuggestion(suggestionId: string) {
+    setAcceptedTabSuggestionIds((current) =>
+      current.includes(suggestionId)
+        ? current.filter((id) => id !== suggestionId)
+        : [...current, suggestionId],
+    );
+    setSelectedTabSuggestionId(suggestionId);
+  }
+
+  function handleAcceptTabSuggestionGroup(suggestionIds: string[]) {
+    setAcceptedTabSuggestionIds((current) => Array.from(new Set([...current, ...suggestionIds])));
+    setSelectedTabSuggestionId(suggestionIds[0] ?? null);
+  }
+
+  function handleRejectTabSuggestionGroup(suggestionIds: string[]) {
+    const ids = new Set(suggestionIds);
+    setAcceptedTabSuggestionIds((current) => current.filter((id) => !ids.has(id)));
+    if (selectedTabSuggestionId && ids.has(selectedTabSuggestionId)) {
+      setSelectedTabSuggestionId(null);
+    }
+  }
+
+  function handleApplyTabSuggestions() {
+    if (!acceptedTabSuggestionIds.length) {
+      return;
+    }
+    tabImportApplyMutation.mutate();
   }
 
   async function handleTogglePlayback() {
@@ -825,8 +916,8 @@ export function useProjectViewModel() {
     if (hasExistingLyrics) {
       const approved = await confirm(
         lyricsQuery.data?.has_user_edits
-          ? "Refresh lyrics? This replaces the current transcript and discards your edits."
-          : "Refresh lyrics? This replaces the current transcript with a new pass.",
+          ? "Refresh lyrics? This replaces the current transcript and discards your edits, including accepted tab suggestions."
+          : "Refresh lyrics? This replaces the current transcript with a new pass and clears the current tab import.",
         {
           title: "Refresh lyrics",
           kind: "warning",
@@ -1495,6 +1586,7 @@ export function useProjectViewModel() {
     draftName,
     enharmonicDisplayMode,
     exportMutation,
+    acceptedTabSuggestionIds,
     handleDeleteMix,
     handleDeleteProject,
     handleChordAction,
@@ -1506,9 +1598,16 @@ export function useProjectViewModel() {
     handleSelectWorkspace,
     handleSetChordsFollowEnabled,
     handleSetLyricsFollowEnabled,
+    handleAcceptTabSuggestionGroup,
+    handleApplyTabSuggestions,
+    handleCloseTabImport,
+    handleCreateTabImportProposal,
+    handleOpenTabImport,
+    handleRejectTabSuggestionGroup,
     handleSetPlaybackDisplayMode,
     handleStemAction,
     handleTogglePlaybackDisplayLane,
+    handleToggleTabSuggestion,
     hasChordTimeline,
     hasEditedLyrics: lyricsQuery.data?.has_user_edits ?? false,
     hasLyricsTranscript,
@@ -1525,6 +1624,7 @@ export function useProjectViewModel() {
     isAnalysisRunning,
     isChordRunning,
     isEditingLyrics,
+    isTabImportOpen,
     isLyricsRunning,
     isMobileRuntime,
     isPlaying,
@@ -1557,7 +1657,9 @@ export function useProjectViewModel() {
     retuneMode,
     seekAnimationRevision,
     seekTo,
+    sectionsQuery,
     selectedArtifactId,
+    selectedTabSuggestionId,
     selectedArtifactTimestamp,
     selectedPlaybackArtifact,
     selectedPrimaryArtifact,
@@ -1577,6 +1679,8 @@ export function useProjectViewModel() {
     setTargetSelectorOpen,
     setTargetTransposeSemitones,
     setLyricsDraft,
+    setSelectedTabSuggestionId,
+    setTabImportDraft,
     showSupportingCopy,
     sourceArtifact,
     sourceKey,
@@ -1600,6 +1704,9 @@ export function useProjectViewModel() {
     stemMutation,
     stemOutputLabel,
     stopPlayback,
+    tabImportApplyMutation,
+    tabImportDraft,
+    tabImportMutation,
     targetKey,
     targetOptionRefs,
     targetSelectionSummary,

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -43,6 +43,15 @@ export type ChordBackendSchema = components["schemas"]["ChordBackendSchema"];
 export type ChordBackendsResponse = components["schemas"]["ChordBackendsResponse"];
 export type LyricsGenerateRequest = components["schemas"]["LyricsGenerateRequest"];
 export type LyricsUpdateRequest = components["schemas"]["LyricsUpdateRequest"];
+export type SongSectionSchema = components["schemas"]["SongSectionSchema"];
+export type SongSectionsResponse = components["schemas"]["SongSectionsResponse"];
+export type TabImportApplyRequest = components["schemas"]["TabImportApplyRequest"];
+export type TabImportApplyResponse = components["schemas"]["TabImportApplyResponse"];
+export type TabImportCreateRequest = components["schemas"]["TabImportCreateRequest"];
+export type TabImportResponse = components["schemas"]["TabImportResponse"];
+export type TabImportSchema = components["schemas"]["TabImportSchema"];
+export type TabSuggestionGroupSchema = components["schemas"]["TabSuggestionGroupSchema"];
+export type TabSuggestionSchema = components["schemas"]["TabSuggestionSchema"];
 export type RuntimeCapabilities = MobileCapabilities | null;
 
 export type TuneForgeClient = {
@@ -61,6 +70,14 @@ export type TuneForgeClient = {
   createLyrics: (projectId: string, body: LyricsGenerateRequest) => Promise<components["schemas"]["JobResponse"]>;
   getLyrics: (projectId: string) => Promise<LyricsResponse>;
   updateLyrics: (projectId: string, body: LyricsUpdateRequest) => Promise<LyricsResponse>;
+  createTabImport: (projectId: string, body: TabImportCreateRequest) => Promise<TabImportResponse>;
+  getTabImport: (projectId: string, tabImportId: string) => Promise<TabImportResponse>;
+  acceptTabImport: (
+    projectId: string,
+    tabImportId: string,
+    body: TabImportApplyRequest,
+  ) => Promise<TabImportApplyResponse>;
+  listSections: (projectId: string) => Promise<SongSectionsResponse>;
   createPreview: (projectId: string, body: PreviewRequest) => Promise<components["schemas"]["JobResponse"]>;
   createStems: (projectId: string, body: StemRequest) => Promise<components["schemas"]["JobResponse"]>;
   createRetune: (projectId: string, body: RetuneRequest) => Promise<components["schemas"]["JobResponse"]>;
@@ -205,6 +222,23 @@ function createHttpTuneForgeClient(): TuneForgeClient {
       unwrap(client.GET("/api/v1/projects/{project_id}/lyrics", { params: { path: { project_id: projectId } } })),
     updateLyrics: (projectId: string, body: LyricsUpdateRequest) =>
       unwrap(client.PUT("/api/v1/projects/{project_id}/lyrics", { params: { path: { project_id: projectId } }, body })),
+    createTabImport: (projectId: string, body: TabImportCreateRequest) =>
+      unwrap(client.POST("/api/v1/projects/{project_id}/tabs/proposals", { params: { path: { project_id: projectId } }, body })),
+    getTabImport: (projectId: string, tabImportId: string) =>
+      unwrap(
+        client.GET("/api/v1/projects/{project_id}/tabs/{tab_import_id}", {
+          params: { path: { project_id: projectId, tab_import_id: tabImportId } },
+        }),
+      ),
+    acceptTabImport: (projectId: string, tabImportId: string, body: TabImportApplyRequest) =>
+      unwrap(
+        client.POST("/api/v1/projects/{project_id}/tabs/{tab_import_id}/accept", {
+          params: { path: { project_id: projectId, tab_import_id: tabImportId } },
+          body,
+        }),
+      ),
+    listSections: (projectId: string) =>
+      unwrap(client.GET("/api/v1/projects/{project_id}/sections", { params: { path: { project_id: projectId } } })),
     createPreview: (projectId: string, body: PreviewRequest) =>
       unwrap(client.POST("/api/v1/projects/{project_id}/preview", { params: { path: { project_id: projectId } }, body })),
     createStems: (projectId: string, body: StemRequest) =>
@@ -253,6 +287,28 @@ function createMobileTuneForgeClient(capabilities: MobileCapabilities): TuneForg
     getLyrics: (projectId: string) => invokeMobile("mobile_get_lyrics", { projectId }),
     updateLyrics: (projectId: string, body: LyricsUpdateRequest) =>
       invokeMobile("mobile_update_lyrics", { projectId, payload: body }),
+    createTabImport: async () => {
+      throw new ApiError({
+        code: "UNSUPPORTED_RUNTIME",
+        message: "Tab import is not available on mobile yet.",
+        details: {},
+      });
+    },
+    getTabImport: async () => {
+      throw new ApiError({
+        code: "UNSUPPORTED_RUNTIME",
+        message: "Tab import is not available on mobile yet.",
+        details: {},
+      });
+    },
+    acceptTabImport: async () => {
+      throw new ApiError({
+        code: "UNSUPPORTED_RUNTIME",
+        message: "Tab import is not available on mobile yet.",
+        details: {},
+      });
+    },
+    listSections: async () => ({ sections: [] }),
     createPreview: (projectId: string, body: PreviewRequest) =>
       invokeMobile("mobile_submit_preview", { projectId, payload: body }),
     createStems: (projectId: string, body: StemRequest) =>
@@ -336,6 +392,11 @@ export const api: TuneForgeClient = {
   createLyrics: (projectId: string, body: LyricsGenerateRequest) => activeClient.createLyrics(projectId, body),
   getLyrics: (projectId: string) => activeClient.getLyrics(projectId),
   updateLyrics: (projectId: string, body: LyricsUpdateRequest) => activeClient.updateLyrics(projectId, body),
+  createTabImport: (projectId: string, body: TabImportCreateRequest) => activeClient.createTabImport(projectId, body),
+  getTabImport: (projectId: string, tabImportId: string) => activeClient.getTabImport(projectId, tabImportId),
+  acceptTabImport: (projectId: string, tabImportId: string, body: TabImportApplyRequest) =>
+    activeClient.acceptTabImport(projectId, tabImportId, body),
+  listSections: (projectId: string) => activeClient.listSections(projectId),
   createPreview: (projectId: string, body: PreviewRequest) => activeClient.createPreview(projectId, body),
   createStems: (projectId: string, body: StemRequest) => activeClient.createStems(projectId, body),
   createRetune: (projectId: string, body: RetuneRequest) => activeClient.createRetune(projectId, body),

--- a/apps/desktop/src/styles/project-playback.css
+++ b/apps/desktop/src/styles/project-playback.css
@@ -959,6 +959,185 @@
   margin: auto 0;
 }
 
+.tab-import-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  justify-content: flex-end;
+  background: color-mix(in srgb, black 36%, transparent);
+}
+
+.tab-import-drawer {
+  display: flex;
+  width: min(46rem, 100%);
+  height: 100%;
+  min-width: 0;
+  flex-direction: column;
+  gap: 1rem;
+  overflow-y: auto;
+  border-left: 1px solid var(--divider);
+  background: var(--panel);
+  padding: 1rem;
+  box-shadow: -18px 0 44px color-mix(in srgb, black 24%, transparent);
+}
+
+.tab-import-drawer__header,
+.tab-import-group__header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.tab-import-drawer__header h3,
+.tab-import-detail h4,
+.tab-import-group h4 {
+  margin: 0.15rem 0 0;
+}
+
+.tab-import-input {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  color: var(--text);
+  font-weight: 700;
+}
+
+.tab-import-input textarea {
+  min-height: 10rem;
+  resize: vertical;
+  border: 1px solid var(--input-border);
+  border-radius: 12px;
+  background: var(--input-bg);
+  color: var(--text);
+  padding: 0.8rem 0.9rem;
+  font: inherit;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  line-height: 1.45;
+}
+
+.tab-import-actions {
+  justify-content: flex-start;
+}
+
+.tab-import-review {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(14rem, 0.85fr);
+  gap: 0.9rem;
+  align-items: start;
+}
+
+.tab-import-groups,
+.tab-import-suggestions,
+.tab-import-detail,
+.tab-import-diff {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.tab-import-group,
+.tab-import-detail {
+  border: 1px solid var(--divider);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--panel-strong) 72%, transparent);
+  padding: 0.85rem;
+}
+
+.tab-import-suggestion {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.65rem;
+  align-items: start;
+  border: 1px solid var(--divider);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--surface-muted) 68%, transparent);
+  padding: 0.55rem 0.65rem;
+}
+
+.tab-import-suggestion--selected {
+  border-color: color-mix(in srgb, var(--playback-accent) 58%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--playback-accent) 16%, transparent);
+}
+
+.tab-import-suggestion input {
+  width: 1rem;
+  height: 1rem;
+  margin-top: 0.2rem;
+}
+
+.tab-import-suggestion__summary {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.55rem;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  padding: 0;
+  text-align: left;
+}
+
+.tab-import-suggestion__heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.55rem;
+  align-items: baseline;
+}
+
+.tab-import-suggestion__comparison {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.tab-import-suggestion__cell {
+  min-width: 0;
+  border: 1px solid var(--divider);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel-strong) 64%, transparent);
+  padding: 0.45rem 0.5rem;
+}
+
+.tab-import-suggestion__cell > span:last-child {
+  display: block;
+  margin-top: 0.2rem;
+  white-space: pre-wrap;
+}
+
+.tab-import-suggestion__heading span,
+.tab-import-suggestion__cell > span:last-child,
+.tab-import-diff p {
+  overflow-wrap: anywhere;
+}
+
+.tab-import-suggestion__summary small {
+  color: var(--muted);
+}
+
+.tab-import-detail {
+  position: sticky;
+  top: 0;
+}
+
+.tab-import-diff {
+  gap: 0.55rem;
+}
+
+.tab-import-diff > div {
+  border: 1px solid var(--divider);
+  border-radius: 10px;
+  padding: 0.65rem;
+}
+
+.tab-import-diff p {
+  margin: 0.25rem 0 0;
+  white-space: pre-wrap;
+}
+
 .playback-workspace--practice .playback-transport-dock {
   grid-area: transport;
   position: static;
@@ -1031,6 +1210,14 @@
 
   .playback-practice-warning {
     text-align: left;
+  }
+
+  .tab-import-review {
+    grid-template-columns: 1fr;
+  }
+
+  .tab-import-detail {
+    position: static;
   }
 }
 

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -28,11 +28,15 @@ const {
   mockListJobs,
   mockCreateChords,
   mockCreateLyrics,
+  mockCreateTabImport,
   mockCreatePreview,
   mockCreateStems,
   mockAnalyzeProject,
   mockUpdateLyrics,
   mockUpdateProject,
+  mockGetTabImport,
+  mockAcceptTabImport,
+  mockListSections,
   mockCreateExport,
   mockDeleteArtifact,
   mockDeleteProject,
@@ -45,6 +49,8 @@ const {
     analysisByProject: Record<string, Record<string, unknown> | null>;
     chordsByProject: Record<string, Record<string, unknown>>;
     lyricsByProject: Record<string, Record<string, unknown>>;
+    tabImportsByProject: Record<string, Array<Record<string, unknown>>>;
+    sectionsByProject: Record<string, Array<Record<string, unknown>>>;
     artifactsByProject: Record<string, Array<Record<string, unknown>>>;
     chordBackends: Array<Record<string, unknown>>;
     pendingPreviewArtifactsByProject: Record<string, Array<Record<string, unknown>>>;
@@ -53,6 +59,8 @@ const {
     nextProjectId: number;
     nextArtifactId: number;
     nextJobId: number;
+    nextTabImportId: number;
+    nextSectionId: number;
     deferPreviewCompletion: boolean;
   };
 
@@ -255,6 +263,10 @@ const {
       lyricsByProject: {
         proj_123: makeLyricsTranscript("proj_123"),
       },
+      tabImportsByProject: {},
+      sectionsByProject: {
+        proj_123: [],
+      },
       artifactsByProject: {
         proj_123: [
           {
@@ -308,6 +320,8 @@ const {
       nextProjectId: 200,
       nextArtifactId: 200,
       nextJobId: 200,
+      nextTabImportId: 200,
+      nextSectionId: 200,
       deferPreviewCompletion: false,
     };
   }
@@ -583,6 +597,36 @@ const {
     project.updated_at = createdAt;
     return { project: clone(project) };
   });
+
+  function retimeWordsForText(segment: Record<string, unknown>, text: string) {
+    const words = text.trim().split(/\s+/).filter(Boolean);
+    const currentWords = Array.isArray(segment.words)
+      ? (segment.words as Array<Record<string, unknown>>)
+      : [];
+    if (!words.length || !currentWords.length) {
+      return undefined;
+    }
+    const segmentStart = Number(segment.start_seconds ?? currentWords[0]?.start_seconds ?? 0);
+    const segmentEnd = Number(
+      segment.end_seconds ?? currentWords[currentWords.length - 1]?.end_seconds ?? segmentStart + words.length,
+    );
+    const span = Math.max(segmentEnd - segmentStart, 0.001);
+    return words.map((word, index) => {
+      const matchedWord = currentWords[Math.min(index, currentWords.length - 1)] ?? {};
+      if (index < currentWords.length) {
+        return { ...matchedWord, text: word };
+      }
+      const startSeconds = segmentStart + (span * index) / words.length;
+      const endSeconds = segmentStart + (span * (index + 1)) / words.length;
+      return {
+        confidence: null,
+        end_seconds: endSeconds,
+        start_seconds: startSeconds,
+        text: word,
+      };
+    });
+  }
+
   const mockUpdateLyrics = vi.fn(async (projectId: string, body: { segments: Array<{ text: string }> }) => {
     const current = clone(
       state.lyricsByProject[projectId] ?? {
@@ -614,7 +658,10 @@ const {
         return clone(sourceSegment);
       }
       if (nextText !== segment.text) {
-        delete nextSegment.words;
+        const retimedWords = retimeWordsForText(segment, nextText);
+        if (retimedWords) {
+          nextSegment.words = retimedWords;
+        }
       }
       return nextSegment;
     });
@@ -624,6 +671,210 @@ const {
     state.lyricsByProject[projectId] = current;
     return clone(current);
   });
+  function buildTabImport(projectId: string, rawText: string, tabImportId = `tab_${state.nextTabImportId++}`) {
+    const lyrics = state.lyricsByProject[projectId];
+    const chords = state.chordsByProject[projectId];
+    const project = getProjectOrThrow(projectId);
+    const currentLyric = String(((lyrics?.segments as Array<Record<string, unknown>> | undefined)?.[0]?.text) ?? "");
+    const currentChord = String(((chords?.timeline as Array<Record<string, unknown>> | undefined)?.[0]?.label) ?? "");
+    return {
+      id: tabImportId,
+      project_id: projectId,
+      raw_text: rawText,
+      parser_version: "test",
+      status: "pending",
+      parsed: {
+        key: "D",
+        sections: [{ label: "Verse" }],
+      },
+      groups: [
+        {
+          kind: "lyrics",
+          label: "Lyrics",
+          suggestions: [
+            {
+              id: `${tabImportId}_lyrics_1`,
+              kind: "lyrics",
+              status: "pending",
+              title: "Update lyric segment 1",
+              current_text: currentLyric,
+              suggested_text: "Hello from the fast line",
+              start_seconds: 0,
+              end_seconds: 8,
+              segment_index: 0,
+              payload: { text: "Hello from the fast line" },
+            },
+          ],
+        },
+        {
+          kind: "chords",
+          label: "Chords",
+          suggestions: [
+            {
+              id: `${tabImportId}_chord_1`,
+              kind: "chords",
+              status: "pending",
+              title: "Use F# at 00:00",
+              current_text: currentChord,
+              suggested_text: "F#",
+              start_seconds: 0,
+              end_seconds: 8,
+              chord_index: 0,
+              payload: { label: "F#" },
+            },
+          ],
+        },
+        {
+          kind: "sections",
+          label: "Sections",
+          suggestions: [
+            {
+              id: `${tabImportId}_section_1`,
+              kind: "sections",
+              status: "pending",
+              title: "Add Verse section",
+              current_text: null,
+              suggested_text: "Verse",
+              start_seconds: 0,
+              end_seconds: null,
+              payload: { label: "Verse" },
+            },
+          ],
+        },
+        {
+          kind: "key",
+          label: "Key",
+          suggestions: [
+            {
+              id: `${tabImportId}_key_1`,
+              kind: "key",
+              status: "pending",
+              title: "Set source key to D",
+              current_text: String(project.source_key_override ?? "G major"),
+              suggested_text: "D",
+              start_seconds: null,
+              end_seconds: null,
+              payload: { source_key: "D" },
+            },
+          ],
+        },
+      ],
+      created_at: createdAt,
+      updated_at: createdAt,
+    };
+  }
+  const mockCreateTabImport = vi.fn(async (projectId: string, body: { raw_text: string }) => {
+    const existingTabImport = state.tabImportsByProject[projectId]?.[0] ?? null;
+    const existingId = typeof existingTabImport?.id === "string" ? existingTabImport.id : undefined;
+    const tabImport = buildTabImport(projectId, body.raw_text, existingId);
+    state.tabImportsByProject[projectId] = [tabImport];
+    return { tab_import: clone(tabImport) };
+  });
+  const mockGetTabImport = vi.fn(async (projectId: string, tabImportId: string) => {
+    const tabImport = (state.tabImportsByProject[projectId] ?? []).find((item) => item.id === tabImportId);
+    if (!tabImport) {
+      throw new Error(`Unknown tab import ${tabImportId}`);
+    }
+    return { tab_import: clone(tabImport) };
+  });
+  const mockAcceptTabImport = vi.fn(async (projectId: string, tabImportId: string, body: { accepted_suggestion_ids?: string[] }) => {
+    const tabImport = (state.tabImportsByProject[projectId] ?? []).find((item) => item.id === tabImportId);
+    if (!tabImport) {
+      throw new Error(`Unknown tab import ${tabImportId}`);
+    }
+    const acceptedIds = new Set(body.accepted_suggestion_ids ?? []);
+    const groups = (tabImport.groups as Array<Record<string, unknown>>).map((group) => ({
+      ...group,
+      suggestions: ((group.suggestions as Array<Record<string, unknown>>) ?? []).map((suggestion) => {
+        const suggestionId = String(suggestion.id);
+        const accepted = acceptedIds.has(suggestionId);
+        if (!accepted) {
+          return { ...suggestion, status: "ignored" };
+        }
+        if (suggestion.kind === "lyrics") {
+          const currentLyrics = state.lyricsByProject[projectId];
+          const segments = (currentLyrics.segments as Array<Record<string, unknown>>).map((segment, index) => {
+            if (index !== 0) {
+              return segment;
+            }
+            const suggestedText = String(suggestion.suggested_text ?? "");
+            return {
+              ...segment,
+              text: suggestedText,
+              words: retimeWordsForText(segment, suggestedText),
+            };
+          });
+          state.lyricsByProject[projectId] = {
+            ...currentLyrics,
+            has_user_edits: true,
+            segments,
+            updated_at: createdAt,
+          };
+        }
+        if (suggestion.kind === "chords") {
+          const currentChords = state.chordsByProject[projectId];
+          const timeline = (currentChords.timeline as Array<Record<string, unknown>>).map((segment, index) =>
+            index === 0
+              ? {
+                  ...segment,
+                  label: "F#",
+                  pitch_class: 6,
+                  quality: "major",
+                }
+              : segment,
+          );
+          state.chordsByProject[projectId] = {
+            ...currentChords,
+            has_user_edits: true,
+            timeline,
+            updated_at: createdAt,
+          };
+        }
+        if (suggestion.kind === "sections") {
+          const section = {
+            id: `section_${state.nextSectionId++}`,
+            project_id: projectId,
+            tab_import_id: tabImportId,
+            label: "Verse",
+            start_seconds: 0,
+            end_seconds: null,
+            source: "tab",
+            metadata: {},
+            created_at: createdAt,
+            updated_at: createdAt,
+          };
+          state.sectionsByProject[projectId] = [
+            ...(state.sectionsByProject[projectId] ?? []),
+            section,
+          ];
+        }
+        if (suggestion.kind === "key") {
+          const project = getProjectOrThrow(projectId);
+          project.source_key_override = "D";
+          project.updated_at = createdAt;
+        }
+        return { ...suggestion, status: "accepted" };
+      }),
+    }));
+    tabImport.groups = groups;
+    tabImport.status = "applied";
+    tabImport.updated_at = createdAt;
+    const allSuggestionIds = groups.flatMap((group) =>
+      ((group.suggestions as Array<Record<string, unknown>>) ?? []).map((suggestion) => String(suggestion.id)),
+    );
+    return {
+      tab_import: clone(tabImport),
+      accepted_suggestion_ids: Array.from(acceptedIds),
+      ignored_suggestion_ids: allSuggestionIds.filter((suggestionId) => !acceptedIds.has(suggestionId)),
+      lyrics: clone(state.lyricsByProject[projectId] ?? null),
+      chords: clone(state.chordsByProject[projectId] ?? null),
+      sections: clone(state.sectionsByProject[projectId] ?? []),
+      project: clone(getProjectOrThrow(projectId)),
+    };
+  });
+  const mockListSections = vi.fn(async (projectId: string) => ({
+    sections: clone(state.sectionsByProject[projectId] ?? []),
+  }));
   const mockCreateExport = vi.fn(async (projectId: string, body: Record<string, unknown>) => {
     const job = {
       id: `job_${state.nextJobId++}`,
@@ -683,11 +934,15 @@ const {
     mockListJobs,
     mockCreateChords,
     mockCreateLyrics,
+    mockCreateTabImport,
     mockCreatePreview,
     mockCreateStems,
     mockAnalyzeProject,
     mockUpdateLyrics,
     mockUpdateProject,
+    mockGetTabImport,
+    mockAcceptTabImport,
+    mockListSections,
     mockCreateExport,
     mockDeleteArtifact,
     mockDeleteProject,
@@ -720,11 +975,15 @@ export {
   mockListJobs,
   mockCreateChords,
   mockCreateLyrics,
+  mockCreateTabImport,
   mockCreatePreview,
   mockCreateStems,
   mockAnalyzeProject,
   mockUpdateLyrics,
   mockUpdateProject,
+  mockGetTabImport,
+  mockAcceptTabImport,
+  mockListSections,
   mockCreateExport,
   mockDeleteArtifact,
   mockDeleteProject,
@@ -761,6 +1020,10 @@ vi.mock("../lib/api", async (importOriginal) => {
       listJobs: mockListJobs,
       createChords: mockCreateChords,
       createLyrics: mockCreateLyrics,
+      createTabImport: mockCreateTabImport,
+      getTabImport: mockGetTabImport,
+      acceptTabImport: mockAcceptTabImport,
+      listSections: mockListSections,
       createPreview: mockCreatePreview,
       createStems: mockCreateStems,
       analyzeProject: mockAnalyzeProject,
@@ -946,6 +1209,10 @@ export function resetAppTestHarness() {
   mockListJobs.mockClear();
   mockCreateChords.mockClear();
   mockCreateLyrics.mockClear();
+  mockCreateTabImport.mockClear();
+  mockGetTabImport.mockClear();
+  mockAcceptTabImport.mockClear();
+  mockListSections.mockClear();
   mockCreatePreview.mockClear();
   mockCreateStems.mockClear();
   mockAnalyzeProject.mockClear();

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -47,6 +47,7 @@ Roadmap items are grouped by track so related work can move independently.
 - Improve editable lyrics timeline behavior for segment timing, text correction, and playback follow.
 - Add Android lyrics MVP using local Whisper or an equivalent local runtime behind the mobile capability model.
 - Support tab import for lyrics correction and chord/lyric alignment where useful.
+- Research local forced-alignment second passes, such as WhisperX- or Gentle-style alignment, after lyrics generation or accepted lyric/tab edits to refine word and phrase timing.
 - Keep generated lyrics positioned as editable draft output, not guaranteed transcription truth.
 
 ## Mobile

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -162,6 +162,74 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/projects/{project_id}/tabs/proposals": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Project Tab Import Create */
+        post: operations["project_tab_import_create_api_v1_projects__project_id__tabs_proposals_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/projects/{project_id}/tabs/{tab_import_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Project Tab Import Detail */
+        get: operations["project_tab_import_detail_api_v1_projects__project_id__tabs__tab_import_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/projects/{project_id}/tabs/{tab_import_id}/accept": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Project Tab Import Accept */
+        post: operations["project_tab_import_accept_api_v1_projects__project_id__tabs__tab_import_id__accept_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/projects/{project_id}/sections": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Project Sections */
+        get: operations["project_sections_api_v1_projects__project_id__sections_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/projects/{project_id}/retune": {
         parameters: {
             query?: never;
@@ -809,6 +877,42 @@ export interface components {
              */
             output_format: string;
         };
+        /** SongSectionSchema */
+        SongSectionSchema: {
+            /** Id */
+            id: string;
+            /** Project Id */
+            project_id: string;
+            /** Tab Import Id */
+            tab_import_id?: string | null;
+            /** Label */
+            label: string;
+            /** Start Seconds */
+            start_seconds?: number | null;
+            /** End Seconds */
+            end_seconds?: number | null;
+            /** Source */
+            source: string;
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            };
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+        };
+        /** SongSectionsResponse */
+        SongSectionsResponse: {
+            /** Sections */
+            sections?: components["schemas"]["SongSectionSchema"][];
+        };
         /** StemRequest */
         StemRequest: {
             /**
@@ -840,6 +944,101 @@ export interface components {
              * @default false
              */
             overwrite_chord_edits: boolean;
+        };
+        /** TabImportApplyRequest */
+        TabImportApplyRequest: {
+            /** Accepted Suggestion Ids */
+            accepted_suggestion_ids?: string[];
+        };
+        /** TabImportApplyResponse */
+        TabImportApplyResponse: {
+            tab_import: components["schemas"]["TabImportSchema"];
+            /** Accepted Suggestion Ids */
+            accepted_suggestion_ids?: string[];
+            /** Ignored Suggestion Ids */
+            ignored_suggestion_ids?: string[];
+            lyrics?: components["schemas"]["LyricsResponse"] | null;
+            chords?: components["schemas"]["ChordResponse"] | null;
+            /** Sections */
+            sections?: components["schemas"]["SongSectionSchema"][];
+            project: components["schemas"]["ProjectSchema"];
+        };
+        /** TabImportCreateRequest */
+        TabImportCreateRequest: {
+            /** Raw Text */
+            raw_text: string;
+        };
+        /** TabImportResponse */
+        TabImportResponse: {
+            tab_import: components["schemas"]["TabImportSchema"];
+        };
+        /** TabImportSchema */
+        TabImportSchema: {
+            /** Id */
+            id: string;
+            /** Project Id */
+            project_id: string;
+            /** Raw Text */
+            raw_text: string;
+            /** Parser Version */
+            parser_version: string;
+            /** Status */
+            status: string;
+            /** Parsed */
+            parsed?: {
+                [key: string]: unknown;
+            };
+            /** Groups */
+            groups?: components["schemas"]["TabSuggestionGroupSchema"][];
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+        };
+        /** TabSuggestionGroupSchema */
+        TabSuggestionGroupSchema: {
+            /** Kind */
+            kind: string;
+            /** Label */
+            label: string;
+            /** Suggestions */
+            suggestions?: components["schemas"]["TabSuggestionSchema"][];
+        };
+        /** TabSuggestionSchema */
+        TabSuggestionSchema: {
+            /** Id */
+            id: string;
+            /** Kind */
+            kind: string;
+            /**
+             * Status
+             * @default pending
+             */
+            status: string;
+            /** Title */
+            title: string;
+            /** Current Text */
+            current_text?: string | null;
+            /** Suggested Text */
+            suggested_text?: string | null;
+            /** Start Seconds */
+            start_seconds?: number | null;
+            /** End Seconds */
+            end_seconds?: number | null;
+            /** Segment Index */
+            segment_index?: number | null;
+            /** Chord Index */
+            chord_index?: number | null;
+            /** Payload */
+            payload?: {
+                [key: string]: unknown;
+            };
         };
         /** TransposeRequest */
         TransposeRequest: {
@@ -1300,6 +1499,140 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["JobResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    project_tab_import_create_api_v1_projects__project_id__tabs_proposals_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TabImportCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TabImportResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    project_tab_import_detail_api_v1_projects__project_id__tabs__tab_import_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                tab_import_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TabImportResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    project_tab_import_accept_api_v1_projects__project_id__tabs__tab_import_id__accept_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                tab_import_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TabImportApplyRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TabImportApplyResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    project_sections_api_v1_projects__project_id__sections_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SongSectionsResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary
- Add project-scoped tab import proposals for lyrics, chords, sections, and source key.
- Apply only accepted suggestions, preserving lyric word timing and marking accepted chord overlays as user edits.
- Store raw tab text and accepted tab sections, clear tab state on destructive lyrics/chords refreshes, and expose generated API types.
- Add an unobtrusive desktop Import Tab review drawer with grouped suggestions and current-vs-tab context.
- Record future local forced-alignment research in the roadmap.

## Testing
- `uv run --python 3.11 ruff check .`
- `uv run --python 3.11 mypy app`
- `uv run --python 3.11 pytest`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
