### PR TITLE
feat: add system mic volume and shared playback audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Security reports follow the process in [SECURITY.md](./SECURITY.md). "There is n
 - [`uv`](https://docs.astral.sh/uv/)
 - Python 3.11
 - `ffmpeg` and `ffprobe` available on `PATH` (install via `brew install ffmpeg`, `apt install ffmpeg`, etc.)
+- macOS system mic volume control uses the built-in CoreAudio API.
+- Linux system mic volume control uses `wpctl` or `pactl` for the active PipeWire/PulseAudio session.
 - Rust toolchain for Tauri
 
 ## Setup
@@ -163,7 +165,7 @@ The generated artifacts are written under `apps/desktop/src-tauri/target/release
 - `macos/Tuneforge.app`
 - `dmg/Tuneforge_0.1.0_aarch64.dmg` on Apple Silicon
 
-Run packaging from a normal macOS shell so `hdiutil` can create the disk image. Packaged builds require `ffmpeg`/`ffprobe` to be installed on the host system; Tuneforge does not bundle them (see [THIRD_PARTY_NOTICES.md](./THIRD_PARTY_NOTICES.md)). The macOS app checks the inherited `PATH` plus common Homebrew and MacPorts install locations when launching the bundled backend.
+Run packaging from a normal macOS shell so `hdiutil` can create the disk image. Packaged builds require `ffmpeg`/`ffprobe` to be installed on the host system; Tuneforge does not bundle them (see [THIRD_PARTY_NOTICES.md](./THIRD_PARTY_NOTICES.md)). System microphone volume control uses CoreAudio on macOS and depends on `wpctl` or `pactl` on Linux. The macOS app checks the inherited `PATH` plus common Homebrew and MacPorts install locations when launching the bundled backend.
 
 ## CI
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+use serde::Serialize;
 use std::{fs, process::Child, sync::Mutex};
 
 #[cfg(not(target_os = "android"))]
@@ -21,6 +22,38 @@ mod mobile_backend;
 struct BackendRuntime {
     base_url: String,
     child: Mutex<Option<Child>>,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SystemDefaultInputVolume {
+    supported: bool,
+    volume_percent: Option<u8>,
+    muted: Option<bool>,
+    backend: Option<&'static str>,
+    error: Option<String>,
+}
+
+impl SystemDefaultInputVolume {
+    fn supported(volume_percent: u8, muted: Option<bool>, backend: &'static str) -> Self {
+        Self {
+            supported: true,
+            volume_percent: Some(volume_percent.min(100)),
+            muted,
+            backend: Some(backend),
+            error: None,
+        }
+    }
+
+    fn unsupported(error: impl Into<String>) -> Self {
+        Self {
+            supported: false,
+            volume_percent: None,
+            muted: None,
+            backend: None,
+            error: Some(error.into()),
+        }
+    }
 }
 
 impl BackendRuntime {
@@ -55,6 +88,445 @@ fn read_settings_snapshot_file(path: String) -> Result<String, String> {
 #[tauri::command]
 fn write_settings_snapshot_file(path: String, contents: String) -> Result<(), String> {
     fs::write(&path, contents).map_err(|error| format!("Could not write settings file: {error}"))
+}
+
+#[tauri::command]
+fn get_system_default_input_volume() -> SystemDefaultInputVolume {
+    read_system_default_input_volume()
+}
+
+#[tauri::command]
+fn set_system_default_input_volume(volume_percent: i32) -> SystemDefaultInputVolume {
+    write_system_default_input_volume(clamp_input_volume_percent(volume_percent))
+}
+
+#[cfg(target_os = "linux")]
+fn run_host_audio_command(binary: &str, args: &[&str]) -> Result<String, String> {
+    let output = Command::new(binary)
+        .args(args)
+        .output()
+        .map_err(|error| format!("{binary} is unavailable: {error}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(if stderr.is_empty() {
+            format!("{binary} exited with status {}", output.status)
+        } else {
+            stderr
+        });
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn parse_percent(value: &str) -> Option<u8> {
+    let parsed = value.trim().parse::<f32>().ok()?;
+    if !parsed.is_finite() {
+        return None;
+    }
+    Some(parsed.round().clamp(0.0, 100.0) as u8)
+}
+
+fn clamp_input_volume_percent(value: i32) -> u8 {
+    value.clamp(0, 100) as u8
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn parse_wpctl_volume(output: &str) -> Option<(u8, bool)> {
+    let muted = output.contains("[MUTED]");
+    let raw_volume = output.split("Volume:").nth(1)?.split_whitespace().next()?;
+    let parsed = raw_volume.parse::<f32>().ok()?;
+    if !parsed.is_finite() {
+        return None;
+    }
+    Some(((parsed * 100.0).round().clamp(0.0, 100.0) as u8, muted))
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn parse_first_percent(output: &str) -> Option<u8> {
+    let percent_index = output.find('%')?;
+    let prefix = &output[..percent_index];
+    let digits_start = prefix
+        .rfind(|character: char| !character.is_ascii_digit())
+        .map_or(0, |index| index + 1);
+    parse_percent(&prefix[digits_start..])
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn parse_pactl_mute(output: &str) -> Option<bool> {
+    let normalized = output.trim().to_ascii_lowercase();
+    if normalized.ends_with("yes") {
+        return Some(true);
+    }
+    if normalized.ends_with("no") {
+        return Some(false);
+    }
+    None
+}
+
+#[cfg(target_os = "macos")]
+mod macos_system_audio {
+    use super::SystemDefaultInputVolume;
+    use std::{ffi::c_void, mem, ptr};
+
+    type AudioObjectID = u32;
+    type AudioObjectPropertySelector = u32;
+    type AudioObjectPropertyScope = u32;
+    type AudioObjectPropertyElement = u32;
+    type OSStatus = i32;
+
+    #[allow(non_snake_case)]
+    #[derive(Clone, Copy)]
+    #[repr(C)]
+    struct AudioObjectPropertyAddress {
+        mSelector: AudioObjectPropertySelector,
+        mScope: AudioObjectPropertyScope,
+        mElement: AudioObjectPropertyElement,
+    }
+
+    pub(super) const fn fourcc(bytes: &[u8; 4]) -> u32 {
+        u32::from_be_bytes(*bytes)
+    }
+
+    const NO_ERR: OSStatus = 0;
+    const K_AUDIO_OBJECT_SYSTEM_OBJECT: AudioObjectID = 1;
+    const K_AUDIO_HARDWARE_PROPERTY_DEFAULT_INPUT_DEVICE: u32 = fourcc(b"dIn ");
+    const K_AUDIO_DEVICE_PROPERTY_VOLUME_SCALAR: u32 = fourcc(b"volm");
+    const K_AUDIO_DEVICE_PROPERTY_MUTE: u32 = fourcc(b"mute");
+    const K_AUDIO_OBJECT_PROPERTY_SCOPE_GLOBAL: u32 = fourcc(b"glob");
+    const K_AUDIO_OBJECT_PROPERTY_SCOPE_INPUT: u32 = fourcc(b"inpt");
+    const K_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN: u32 = 0;
+
+    #[link(name = "CoreAudio", kind = "framework")]
+    extern "C" {
+        fn AudioObjectHasProperty(
+            in_object_id: AudioObjectID,
+            in_address: *const AudioObjectPropertyAddress,
+        ) -> u8;
+        fn AudioObjectIsPropertySettable(
+            in_object_id: AudioObjectID,
+            in_address: *const AudioObjectPropertyAddress,
+            out_is_settable: *mut u8,
+        ) -> OSStatus;
+        fn AudioObjectGetPropertyData(
+            in_object_id: AudioObjectID,
+            in_address: *const AudioObjectPropertyAddress,
+            in_qualifier_data_size: u32,
+            in_qualifier_data: *const c_void,
+            io_data_size: *mut u32,
+            out_data: *mut c_void,
+        ) -> OSStatus;
+        fn AudioObjectSetPropertyData(
+            in_object_id: AudioObjectID,
+            in_address: *const AudioObjectPropertyAddress,
+            in_qualifier_data_size: u32,
+            in_qualifier_data: *const c_void,
+            in_data_size: u32,
+            in_data: *const c_void,
+        ) -> OSStatus;
+    }
+
+    pub(super) fn read() -> SystemDefaultInputVolume {
+        match read_default_input_device_volume() {
+            Ok((volume_percent, muted)) => {
+                SystemDefaultInputVolume::supported(volume_percent, muted, "macos-coreaudio")
+            }
+            Err(error) => SystemDefaultInputVolume::unsupported(format!(
+                "Could not read macOS default input volume with CoreAudio: {error}"
+            )),
+        }
+    }
+
+    pub(super) fn write(volume_percent: u8) -> SystemDefaultInputVolume {
+        match set_default_input_device_volume(volume_percent) {
+            Ok(()) => read(),
+            Err(error) => SystemDefaultInputVolume::unsupported(format!(
+                "Could not set macOS default input volume with CoreAudio: {error}"
+            )),
+        }
+    }
+
+    fn read_default_input_device_volume() -> Result<(u8, Option<bool>), String> {
+        let device_id = default_input_device()?;
+        let volume = read_input_volume_percent(device_id)?;
+        let muted = read_input_mute(device_id);
+        Ok((volume, muted))
+    }
+
+    fn set_default_input_device_volume(volume_percent: u8) -> Result<(), String> {
+        let device_id = default_input_device()?;
+        let scalar = f32::from(volume_percent) / 100.0;
+        let mut wrote_volume = false;
+
+        for address in volume_addresses() {
+            if !is_property_settable(device_id, &address) {
+                continue;
+            }
+            set_property_data(device_id, &address, &scalar).map_err(|status| {
+                format!(
+                    "CoreAudio returned status {status} while setting input volume element {}.",
+                    address.mElement
+                )
+            })?;
+            wrote_volume = true;
+        }
+
+        if !wrote_volume {
+            return Err("default input device does not expose a settable volume.".to_string());
+        }
+
+        if volume_percent > 0 {
+            let unmuted: u32 = 0;
+            for address in mute_addresses() {
+                if is_property_settable(device_id, &address) {
+                    let _ = set_property_data(device_id, &address, &unmuted);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn default_input_device() -> Result<AudioObjectID, String> {
+        let address = property_address(
+            K_AUDIO_HARDWARE_PROPERTY_DEFAULT_INPUT_DEVICE,
+            K_AUDIO_OBJECT_PROPERTY_SCOPE_GLOBAL,
+            K_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN,
+        );
+        let device_id = get_property_data::<AudioObjectID>(K_AUDIO_OBJECT_SYSTEM_OBJECT, &address)
+            .map_err(|status| {
+                format!("CoreAudio returned status {status} for the default input device.")
+            })?;
+        if device_id == 0 {
+            return Err("no default input device is available.".to_string());
+        }
+        Ok(device_id)
+    }
+
+    fn read_input_volume_percent(device_id: AudioObjectID) -> Result<u8, String> {
+        for address in volume_addresses() {
+            if !has_property(device_id, &address) {
+                continue;
+            }
+            if let Ok(volume) = get_property_data::<f32>(device_id, &address) {
+                if volume.is_finite() {
+                    return Ok((volume * 100.0).round().clamp(0.0, 100.0) as u8);
+                }
+            }
+        }
+
+        Err("default input device does not expose a readable volume.".to_string())
+    }
+
+    fn read_input_mute(device_id: AudioObjectID) -> Option<bool> {
+        for address in mute_addresses() {
+            if !has_property(device_id, &address) {
+                continue;
+            }
+            if let Ok(muted) = get_property_data::<u32>(device_id, &address) {
+                return Some(muted != 0);
+            }
+        }
+
+        None
+    }
+
+    fn volume_addresses() -> [AudioObjectPropertyAddress; 9] {
+        input_channel_addresses(K_AUDIO_DEVICE_PROPERTY_VOLUME_SCALAR)
+    }
+
+    fn mute_addresses() -> [AudioObjectPropertyAddress; 9] {
+        input_channel_addresses(K_AUDIO_DEVICE_PROPERTY_MUTE)
+    }
+
+    fn input_channel_addresses(
+        selector: AudioObjectPropertySelector,
+    ) -> [AudioObjectPropertyAddress; 9] {
+        [
+            property_address(
+                selector,
+                K_AUDIO_OBJECT_PROPERTY_SCOPE_INPUT,
+                K_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN,
+            ),
+            property_address(selector, K_AUDIO_OBJECT_PROPERTY_SCOPE_INPUT, 1),
+            property_address(selector, K_AUDIO_OBJECT_PROPERTY_SCOPE_INPUT, 2),
+            property_address(selector, K_AUDIO_OBJECT_PROPERTY_SCOPE_INPUT, 3),
+            property_address(selector, K_AUDIO_OBJECT_PROPERTY_SCOPE_INPUT, 4),
+            property_address(selector, K_AUDIO_OBJECT_PROPERTY_SCOPE_INPUT, 5),
+            property_address(selector, K_AUDIO_OBJECT_PROPERTY_SCOPE_INPUT, 6),
+            property_address(selector, K_AUDIO_OBJECT_PROPERTY_SCOPE_INPUT, 7),
+            property_address(selector, K_AUDIO_OBJECT_PROPERTY_SCOPE_INPUT, 8),
+        ]
+    }
+
+    fn property_address(
+        selector: AudioObjectPropertySelector,
+        scope: AudioObjectPropertyScope,
+        element: AudioObjectPropertyElement,
+    ) -> AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress {
+            mSelector: selector,
+            mScope: scope,
+            mElement: element,
+        }
+    }
+
+    fn has_property(object_id: AudioObjectID, address: &AudioObjectPropertyAddress) -> bool {
+        unsafe { AudioObjectHasProperty(object_id, address) != 0 }
+    }
+
+    fn is_property_settable(
+        object_id: AudioObjectID,
+        address: &AudioObjectPropertyAddress,
+    ) -> bool {
+        if !has_property(object_id, address) {
+            return false;
+        }
+
+        let mut settable = 0u8;
+        let status = unsafe { AudioObjectIsPropertySettable(object_id, address, &mut settable) };
+        status == NO_ERR && settable != 0
+    }
+
+    fn get_property_data<T: Copy>(
+        object_id: AudioObjectID,
+        address: &AudioObjectPropertyAddress,
+    ) -> Result<T, OSStatus> {
+        let mut value = mem::MaybeUninit::<T>::uninit();
+        let mut data_size = mem::size_of::<T>() as u32;
+        let status = unsafe {
+            AudioObjectGetPropertyData(
+                object_id,
+                address,
+                0,
+                ptr::null(),
+                &mut data_size,
+                value.as_mut_ptr().cast::<c_void>(),
+            )
+        };
+        if status != NO_ERR {
+            return Err(status);
+        }
+        if data_size < mem::size_of::<T>() as u32 {
+            return Err(-1);
+        }
+
+        Ok(unsafe { value.assume_init() })
+    }
+
+    fn set_property_data<T>(
+        object_id: AudioObjectID,
+        address: &AudioObjectPropertyAddress,
+        value: &T,
+    ) -> Result<(), OSStatus> {
+        let status = unsafe {
+            AudioObjectSetPropertyData(
+                object_id,
+                address,
+                0,
+                ptr::null(),
+                mem::size_of::<T>() as u32,
+                (value as *const T).cast::<c_void>(),
+            )
+        };
+        if status == NO_ERR {
+            Ok(())
+        } else {
+            Err(status)
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn read_system_default_input_volume() -> SystemDefaultInputVolume {
+    macos_system_audio::read()
+}
+
+#[cfg(target_os = "macos")]
+fn write_system_default_input_volume(volume_percent: u8) -> SystemDefaultInputVolume {
+    macos_system_audio::write(volume_percent)
+}
+
+#[cfg(target_os = "linux")]
+fn read_wpctl_default_input_volume() -> Result<SystemDefaultInputVolume, String> {
+    let output = run_host_audio_command("wpctl", &["get-volume", "@DEFAULT_AUDIO_SOURCE@"])?;
+    let (volume_percent, muted) = parse_wpctl_volume(&output)
+        .ok_or_else(|| "Could not parse wpctl default input volume.".to_string())?;
+    Ok(SystemDefaultInputVolume::supported(
+        volume_percent,
+        Some(muted),
+        "linux-wpctl",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn read_pactl_default_input_volume() -> Result<SystemDefaultInputVolume, String> {
+    let volume_output = run_host_audio_command("pactl", &["get-source-volume", "@DEFAULT_SOURCE@"])?;
+    let volume_percent = parse_first_percent(&volume_output)
+        .ok_or_else(|| "Could not parse pactl default source volume.".to_string())?;
+    let muted = run_host_audio_command("pactl", &["get-source-mute", "@DEFAULT_SOURCE@"])
+        .ok()
+        .and_then(|output| parse_pactl_mute(&output));
+    Ok(SystemDefaultInputVolume::supported(
+        volume_percent,
+        muted,
+        "linux-pactl",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn read_system_default_input_volume() -> SystemDefaultInputVolume {
+    read_wpctl_default_input_volume()
+        .or_else(|wpctl_error| {
+            read_pactl_default_input_volume().map_err(|pactl_error| {
+                format!(
+                    "Could not read default input volume with wpctl ({wpctl_error}) or pactl ({pactl_error})."
+                )
+            })
+        })
+        .unwrap_or_else(SystemDefaultInputVolume::unsupported)
+}
+
+#[cfg(target_os = "linux")]
+fn write_wpctl_default_input_volume(volume_percent: u8) -> Result<SystemDefaultInputVolume, String> {
+    let volume = format!("{volume_percent}%");
+    run_host_audio_command("wpctl", &["set-mute", "@DEFAULT_AUDIO_SOURCE@", "0"])?;
+    run_host_audio_command("wpctl", &["set-volume", "@DEFAULT_AUDIO_SOURCE@", &volume])?;
+    read_wpctl_default_input_volume()
+}
+
+#[cfg(target_os = "linux")]
+fn write_pactl_default_input_volume(volume_percent: u8) -> Result<SystemDefaultInputVolume, String> {
+    let volume = format!("{volume_percent}%");
+    run_host_audio_command("pactl", &["set-source-mute", "@DEFAULT_SOURCE@", "0"])?;
+    run_host_audio_command("pactl", &["set-source-volume", "@DEFAULT_SOURCE@", &volume])?;
+    read_pactl_default_input_volume()
+}
+
+#[cfg(target_os = "linux")]
+fn write_system_default_input_volume(volume_percent: u8) -> SystemDefaultInputVolume {
+    write_wpctl_default_input_volume(volume_percent)
+        .or_else(|wpctl_error| {
+            write_pactl_default_input_volume(volume_percent).map_err(|pactl_error| {
+                format!(
+                    "Could not set default input volume with wpctl ({wpctl_error}) or pactl ({pactl_error})."
+                )
+            })
+        })
+        .unwrap_or_else(SystemDefaultInputVolume::unsupported)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn read_system_default_input_volume() -> SystemDefaultInputVolume {
+    SystemDefaultInputVolume::unsupported(
+        "System input volume control is only available on macOS and Linux.",
+    )
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn write_system_default_input_volume(_volume_percent: u8) -> SystemDefaultInputVolume {
+    read_system_default_input_volume()
 }
 
 #[cfg(not(target_os = "android"))]
@@ -312,6 +784,8 @@ pub fn run() {
             backend_base_url,
             read_settings_snapshot_file,
             write_settings_snapshot_file,
+            get_system_default_input_volume,
+            set_system_default_input_volume,
             mobile_backend::mobile_capabilities,
             mobile_backend::mobile_get_health,
             mobile_backend::mobile_list_projects,
@@ -388,5 +862,37 @@ mod tests {
 
         fs::remove_dir_all(root).expect("remove temp dirs");
         assert_eq!(resolved, Some(first_binary));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_fourcc_constants_use_core_audio_byte_order() {
+        assert_eq!(macos_system_audio::fourcc(b"dIn "), 0x6449_6e20);
+        assert_eq!(macos_system_audio::fourcc(b"volm"), 0x766f_6c6d);
+    }
+
+    #[test]
+    fn clamps_input_volume_command_values() {
+        assert_eq!(clamp_input_volume_percent(-20), 0);
+        assert_eq!(clamp_input_volume_percent(87), 87);
+        assert_eq!(clamp_input_volume_percent(160), 100);
+    }
+
+    #[test]
+    fn parses_wpctl_volume_and_mute_state() {
+        assert_eq!(parse_wpctl_volume("Volume: 0.37"), Some((37, false)));
+        assert_eq!(parse_wpctl_volume("Volume: 0.82 [MUTED]"), Some((82, true)));
+    }
+
+    #[test]
+    fn parses_pactl_volume_and_mute_state() {
+        assert_eq!(
+            parse_first_percent(
+                "Volume: front-left: 49152 / 75% / -7.50 dB, front-right: 49152 / 75% / -7.50 dB",
+            ),
+            Some(75),
+        );
+        assert_eq!(parse_pactl_mute("Mute: yes"), Some(true));
+        assert_eq!(parse_pactl_mute("Mute: no"), Some(false));
     }
 }

--- a/apps/desktop/src/App.project-playback-stems.test.tsx
+++ b/apps/desktop/src/App.project-playback-stems.test.tsx
@@ -23,6 +23,10 @@ import {
   setProjects,
 } from "./test/appTestHarness";
 
+function setPlaybackPosition(value: string) {
+  fireEvent.change(screen.getByLabelText("Playback position"), { target: { value } });
+}
+
 describe("Desktop app project playback stems", () => {
   beforeEach(resetAppTestHarness);
 
@@ -213,8 +217,7 @@ describe("Desktop app project playback stems", () => {
       expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument(),
     );
 
-    sourceAudio.currentTime = 47.253;
-    fireEvent.timeUpdate(sourceAudio);
+    setPlaybackPosition("47.253");
 
     const savedMixList = screen.getByRole("group", { name: "Saved mix list" });
     const playCallsBeforeMixSwitch = vi.mocked(window.HTMLMediaElement.prototype.play).mock.calls.length;
@@ -252,8 +255,7 @@ describe("Desktop app project playback stems", () => {
 
     await user.click(screen.getByRole("button", { name: "Play playback" }));
 
-    sourceAudio.currentTime = 32.417;
-    fireEvent.timeUpdate(sourceAudio);
+    setPlaybackPosition("32.417");
 
     expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
     expect(screen.getByLabelText("Playback position")).toHaveValue("32.417");
@@ -280,8 +282,7 @@ describe("Desktop app project playback stems", () => {
     markAudioReady(sourceAudio);
     await user.click(screen.getByRole("button", { name: "Play playback" }));
 
-    sourceAudio.currentTime = 61.437;
-    fireEvent.timeUpdate(sourceAudio);
+    setPlaybackPosition("61.437");
 
     await user.click(screen.getByLabelText("Raise target key"));
     await user.click(screen.getByRole("button", { name: "Create Mix" }));
@@ -465,8 +466,7 @@ describe("Desktop app project playback stems", () => {
     markAudioReady(sourceAudio);
     await user.click(screen.getByRole("button", { name: "Play playback" }));
 
-    sourceAudio.currentTime = 73.125;
-    fireEvent.timeUpdate(sourceAudio);
+    setPlaybackPosition("73.125");
 
     await waitFor(() =>
       expect(
@@ -481,7 +481,6 @@ describe("Desktop app project playback stems", () => {
       }),
     );
 
-    const playCallsBeforeReload = vi.mocked(window.HTMLMediaElement.prototype.play).mock.calls.length;
     firstRender.unmount();
 
     renderApp(["/projects/proj_123"]);
@@ -491,11 +490,14 @@ describe("Desktop app project playback stems", () => {
     markAudioReady(reloadedAudio);
 
     await waitFor(() => expect(reloadedAudio.currentTime).toBeCloseTo(73.125, 3));
-    await waitFor(() =>
-      expect(vi.mocked(window.HTMLMediaElement.prototype.play).mock.calls.length).toBeGreaterThan(
-        playCallsBeforeReload,
-      ),
-    );
+    await waitFor(() => {
+      const audioContexts = getMockAudioContexts();
+      const latestAudioContext = audioContexts[audioContexts.length - 1];
+      expect(latestAudioContext?.createdSources[0]?.start.mock.calls[0]?.[1]).toBeCloseTo(
+        73.125,
+        3,
+      );
+    });
     expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
   });
 
@@ -508,12 +510,12 @@ describe("Desktop app project playback stems", () => {
     markAudioReady(sourceAudio);
     await user.click(screen.getByRole("button", { name: "Play playback" }));
 
-    sourceAudio.currentTime = 32.481;
-    fireEvent.timeUpdate(sourceAudio);
+    setPlaybackPosition("32.481");
 
     await user.click(screen.getByRole("button", { name: "Generate Stems" }));
     await openPlaybackWorkspace(user);
     const stemList = await screen.findByRole("group", { name: "Playback stem list" });
+    const firstStemSourceIndex = getMockAudioContexts()[0]?.createdSources.length ?? 0;
     await user.click(within(stemList).getAllByRole("button", { name: /Vocals/i })[0] as HTMLElement);
 
     const vocalAudio = findAudioByArtifactId("art_200");
@@ -521,19 +523,22 @@ describe("Desktop app project playback stems", () => {
 
     await waitFor(() => expect(getMockAudioContexts()).toHaveLength(1));
     await waitFor(() =>
-      expect(getMockAudioContexts()[0]?.createdSources.length).toBe(2),
+      expect(getMockAudioContexts()[0]?.createdSources.length).toBe(firstStemSourceIndex + 2),
     );
 
-    const startCalls = getMockAudioContexts()[0].createdSources.map(
+    const startCalls = getMockAudioContexts()[0].createdSources.slice(firstStemSourceIndex).map(
       (source) => source.start.mock.calls[0],
     );
     expect(startCalls).toHaveLength(2);
+    const stemStartOffset = startCalls[0]?.[1] ?? 0;
     startCalls.forEach((startCall) => {
       expect(startCall?.[0]).toBe(0);
-      expect(startCall?.[1]).toBeCloseTo(32.481, 3);
+      expect(startCall?.[1]).toBeCloseTo(stemStartOffset, 3);
     });
-    await waitFor(() => expect(vocalAudio.currentTime).toBeCloseTo(32.481, 3));
-    await waitFor(() => expect(instrumentalAudio.currentTime).toBeCloseTo(32.481, 3));
+    expect(stemStartOffset).toBeGreaterThanOrEqual(32.481);
+    expect(stemStartOffset).toBeLessThan(33);
+    await waitFor(() => expect(vocalAudio.currentTime).toBeCloseTo(stemStartOffset, 1));
+    await waitFor(() => expect(instrumentalAudio.currentTime).toBeCloseTo(stemStartOffset, 1));
     expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
   });
 
@@ -546,8 +551,7 @@ describe("Desktop app project playback stems", () => {
     markAudioReady(sourceAudio);
     await user.click(screen.getByRole("button", { name: "Play playback" }));
 
-    sourceAudio.currentTime = 41.662;
-    fireEvent.timeUpdate(sourceAudio);
+    setPlaybackPosition("41.662");
 
     await user.click(screen.getByRole("button", { name: "Generate Stems" }));
     await openPlaybackWorkspace(user);
@@ -566,7 +570,7 @@ describe("Desktop app project playback stems", () => {
     markAudioReady(resumedSourceAudio);
 
     await waitFor(() =>
-      expect(resumedSourceAudio.currentTime).toBeCloseTo(transitionPlaybackPosition, 3),
+      expect(resumedSourceAudio.currentTime).toBeCloseTo(transitionPlaybackPosition, 1),
     );
     expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
   });
@@ -602,16 +606,16 @@ describe("Desktop app project playback stems", () => {
     markAudioReady(sourceAudio);
     await user.click(screen.getByRole("button", { name: "Play playback" }));
 
-    sourceAudio.currentTime = 18.789;
-    fireEvent.timeUpdate(sourceAudio);
+    setPlaybackPosition("18.789");
 
     await user.click(screen.getByRole("button", { name: "Generate Stems" }));
     await openPlaybackWorkspace(user);
     const stemList = await screen.findByRole("group", { name: "Playback stem list" });
+    const firstStemSourceIndex = getMockAudioContexts()[0]?.createdSources.length ?? 0;
     await user.click(within(stemList).getAllByRole("button", { name: /Vocals/i })[0] as HTMLElement);
 
     await waitFor(() =>
-      expect(getMockAudioContexts()[0]?.createdSources.length).toBe(2),
+      expect(getMockAudioContexts()[0]?.createdSources.length).toBe(firstStemSourceIndex + 2),
     );
 
     const initialStemStarts = getMockAudioContexts()[0].createdSources.length;

--- a/apps/desktop/src/App.tools-metronome.test.tsx
+++ b/apps/desktop/src/App.tools-metronome.test.tsx
@@ -11,6 +11,10 @@ import {
   setProjects,
 } from "./test/appTestHarness";
 
+function getMetronomeAudioContext() {
+  return getMockAudioContexts().find((context) => context.createdOscillators.length > 0);
+}
+
 describe("Desktop app tools metronome", () => {
   beforeEach(resetAppTestHarness);
 
@@ -132,9 +136,9 @@ describe("Desktop app tools metronome", () => {
     await user.click(screen.getByLabelText("Follow project playback"));
 
     await waitFor(() =>
-      expect(getMockAudioContexts()[0]?.createdOscillators.length).toBeGreaterThan(0),
+      expect(getMetronomeAudioContext()?.createdOscillators.length).toBeGreaterThan(0),
     );
-    const syncedContext = getMockAudioContexts()[0];
+    const syncedContext = getMetronomeAudioContext();
     const scheduledBeforePause = syncedContext?.createdOscillators.length ?? 0;
 
     await user.click(screen.getByRole("button", { name: "Pause background playback" }));
@@ -166,9 +170,9 @@ describe("Desktop app tools metronome", () => {
     await user.click(await screen.findByRole("tab", { name: "Metronome" }));
     await user.click(screen.getByLabelText("Follow project playback"));
     await waitFor(() =>
-      expect(getMockAudioContexts()[0]?.createdOscillators.length).toBeGreaterThan(0),
+      expect(getMetronomeAudioContext()?.createdOscillators.length).toBeGreaterThan(0),
     );
-    const syncedContext = getMockAudioContexts()[0];
+    const syncedContext = getMetronomeAudioContext();
 
     await user.click(screen.getByRole("link", { name: "Open Demo Song project" }));
 

--- a/apps/desktop/src/App.tools-tuner.test.tsx
+++ b/apps/desktop/src/App.tools-tuner.test.tsx
@@ -3,9 +3,11 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   getMockAudioContexts,
+  getMockInvoke,
   getMockMediaDevices,
   resetAppTestHarness,
   renderApp,
+  setMockSystemInputVolumeState,
 } from "./test/appTestHarness";
 
 describe("Desktop app tools tuner", () => {
@@ -75,6 +77,49 @@ describe("Desktop app tools tuner", () => {
     expect(window.localStorage.getItem("tuneforge.ui-preferences")).toContain(
       '"defaultTunerReferenceHz":442',
     );
+  });
+
+  it("controls the system default microphone volume", async () => {
+    renderApp(["/tools"]);
+
+    expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    const systemInputVolume = await screen.findByLabelText("System input volume");
+
+    expect(systemInputVolume).toHaveValue("64");
+    fireEvent.change(systemInputVolume, { target: { value: "83" } });
+    fireEvent.change(systemInputVolume, { target: { value: "84" } });
+    fireEvent.change(systemInputVolume, { target: { value: "87" } });
+
+    expect(systemInputVolume).toBeEnabled();
+    expect(systemInputVolume).toHaveValue("87");
+    expect(getMockInvoke()).not.toHaveBeenCalledWith("set_system_default_input_volume", {
+      volumePercent: 83,
+    });
+    fireEvent.pointerUp(systemInputVolume);
+
+    await waitFor(() =>
+      expect(getMockInvoke()).toHaveBeenCalledWith("set_system_default_input_volume", {
+        volumePercent: 87,
+      }),
+    );
+    expect(getMockInvoke()).not.toHaveBeenCalledWith("set_system_default_input_volume", {
+      volumePercent: 84,
+    });
+  });
+
+  it("shows unsupported system microphone volume state", async () => {
+    setMockSystemInputVolumeState({
+      supported: false,
+      volumePercent: null,
+      muted: null,
+      backend: null,
+      error: "System input volume control is unavailable.",
+    });
+    renderApp(["/tools"]);
+
+    expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    expect(await screen.findByText("System input volume control is unavailable.")).toBeInTheDocument();
+    expect(screen.getByLabelText("System input volume")).toBeDisabled();
   });
 
   it("normalizes invalid stored tuner preferences", async () => {

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -120,6 +120,18 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       .filter(Boolean) as HTMLAudioElement[];
   }
 
+  function getPlaybackArtifactIds(targetSession: ProjectPlaybackSession | null) {
+    if (!targetSession) {
+      return [] as string[];
+    }
+    if (targetSession.isStemPlayback) {
+      return targetSession.visibleStemArtifactIds;
+    }
+    return targetSession.selectedPlaybackArtifactId
+      ? [targetSession.selectedPlaybackArtifactId]
+      : [];
+  }
+
   const getAudioContextConstructor = useCallback(() => {
     if (typeof window === "undefined") {
       return null;
@@ -143,6 +155,19 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
   function syncStemElementTimes(artifactIds: string[], nextTime: number) {
     artifactIds.forEach((artifactId) => {
+      if (
+        sessionRef.current?.selectedPlaybackArtifactId === artifactId &&
+        primaryAudioRef.current
+      ) {
+        try {
+          if (Math.abs(primaryAudioRef.current.currentTime - nextTime) > SEEK_TOLERANCE_SECONDS) {
+            primaryAudioRef.current.currentTime = nextTime;
+          }
+        } catch {
+          return;
+        }
+      }
+
       const element = stemAudioRefs.current[artifactId];
       if (!element) {
         return;
@@ -230,7 +255,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     targetPlaybackState.offsetSeconds = targetPlaybackState.durationSeconds;
     targetPlaybackState.startedAtContextTime = targetPlaybackState.context.currentTime;
     targetPlaybackState.sources = {};
-    syncStemElementTimes(Object.keys(targetPlaybackState.gains), targetPlaybackState.durationSeconds);
+    syncStemElementTimes(targetPlaybackState.artifactIds, targetPlaybackState.durationSeconds);
 
     if (stemPlaybackRef.current !== targetPlaybackState) {
       return;
@@ -296,6 +321,18 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     stemPlaybackRef.current = null;
   });
 
+  const closePlaybackAudioContext = useStableCallback(function closePlaybackAudioContext() {
+    disposeStemPlaybackState();
+    stemBufferCacheRef.current.clear();
+
+    const audioContext = stemAudioContextRef.current;
+    stemAudioContextRef.current = null;
+    stemClockBlockedRef.current = false;
+    if (audioContext && audioContext.state !== "closed") {
+      void audioContext.close().catch(() => undefined);
+    }
+  });
+
   const prepareStemPlaybackState = useStableCallback(async function prepareStemPlaybackState(targetSession: ProjectPlaybackSession) {
     const signature = playbackSignature(targetSession);
     const existingPlaybackState = stemPlaybackRef.current;
@@ -310,13 +347,18 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       return null;
     }
 
-    const buffers = await getStemBuffers(targetSession.visibleStemArtifactIds);
+    const artifactIds = getPlaybackArtifactIds(targetSession);
+    if (!artifactIds.length) {
+      return null;
+    }
+
+    const buffers = await getStemBuffers(artifactIds);
     const durationSeconds = Math.max(
       targetSession.durationHintSeconds || 0,
       ...Object.values(buffers).map((buffer) => buffer.duration || 0),
     );
     const gains = Object.fromEntries(
-      targetSession.visibleStemArtifactIds.map((artifactId) => {
+      artifactIds.map((artifactId) => {
         const gainNode = context.createGain();
         gainNode.connect(context.destination);
         return [artifactId, gainNode] as const;
@@ -324,6 +366,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     );
     const nextPlaybackState: StemPlaybackState = {
       signature,
+      artifactIds,
       context,
       durationSeconds,
       startedAtContextTime: context.currentTime,
@@ -335,7 +378,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       clockFrameId: null,
     };
     stemPlaybackRef.current = nextPlaybackState;
-    syncStemElementTimes(targetSession.visibleStemArtifactIds, nextPlaybackState.offsetSeconds);
+    syncStemElementTimes(artifactIds, nextPlaybackState.offsetSeconds);
     return nextPlaybackState;
   });
 
@@ -372,7 +415,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     const nextTime = clampTime(timeSeconds, targetPlaybackState.durationSeconds);
     if (nextTime >= targetPlaybackState.durationSeconds) {
       targetPlaybackState.offsetSeconds = targetPlaybackState.durationSeconds;
-      syncStemElementTimes(targetSession.visibleStemArtifactIds, targetPlaybackState.durationSeconds);
+      syncStemElementTimes(targetPlaybackState.artifactIds, targetPlaybackState.durationSeconds);
       setPlaybackTimeSeconds(targetPlaybackState.durationSeconds);
       setPlaybackDurationSeconds(targetPlaybackState.durationSeconds);
       setIsPlaying(false);
@@ -380,7 +423,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     }
 
     const nextSources = Object.fromEntries(
-      targetSession.visibleStemArtifactIds.map((artifactId) => {
+      targetPlaybackState.artifactIds.map((artifactId) => {
         const sourceNode = targetPlaybackState.context.createBufferSource();
         sourceNode.buffer = targetPlaybackState.buffers[artifactId] ?? null;
         sourceNode.connect(targetPlaybackState.gains[artifactId]);
@@ -404,7 +447,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     targetPlaybackState.offsetSeconds = nextTime;
     targetPlaybackState.startedAtContextTime = targetPlaybackState.context.currentTime;
     targetPlaybackState.isPlaying = true;
-    syncStemElementTimes(targetSession.visibleStemArtifactIds, nextTime);
+    syncStemElementTimes(targetPlaybackState.artifactIds, nextTime);
     applyStemVolumes(targetSession);
 
     Object.values(nextSources).forEach((sourceNode) => sourceNode.start(0, nextTime));
@@ -474,6 +517,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       (artifactId) => targetSession.stemControls[artifactId]?.solo,
     );
     const hasSolo = soloedStemIds.length > 0;
+    const targetPlaybackState = stemPlaybackRef.current;
     targetSession.visibleStemArtifactIds.forEach((artifactId) => {
       const element = stemAudioRefs.current[artifactId];
       const state = targetSession.stemControls[artifactId] ?? {
@@ -485,18 +529,26 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       if (element) {
         element.volume = volume;
       }
+    });
 
-      const targetPlaybackState = stemPlaybackRef.current;
-      if (
-        targetPlaybackState &&
-        targetPlaybackState.signature === playbackSignature(targetSession)
-      ) {
+    if (
+      targetPlaybackState &&
+      targetPlaybackState.signature === playbackSignature(targetSession)
+    ) {
+      targetPlaybackState.artifactIds.forEach((artifactId) => {
+        const state = targetSession.stemControls[artifactId] ?? {
+          muted: false,
+          solo: false,
+        };
+        const volume = targetSession.isStemPlayback
+          ? (hasSolo ? (state.solo ? 1 : 0) : state.muted ? 0 : 1)
+          : 1;
         const gainNode = targetPlaybackState.gains[artifactId];
         if (gainNode) {
           gainNode.gain.value = volume;
         }
-      }
-    });
+      });
+    }
   });
 
   const readMasterTime = useStableCallback(function readMasterTime(
@@ -510,14 +562,13 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       return pendingTransition.targetTime;
     }
 
-    if (targetSession?.isStemPlayback) {
-      const targetPlaybackState = stemPlaybackRef.current;
-      if (
-        targetPlaybackState &&
-        targetPlaybackState.signature === playbackSignature(targetSession)
-      ) {
-        return getStemPlaybackTime(targetPlaybackState);
-      }
+    const targetPlaybackState = stemPlaybackRef.current;
+    if (
+      targetSession &&
+      targetPlaybackState &&
+      targetPlaybackState.signature === playbackSignature(targetSession)
+    ) {
+      return getStemPlaybackTime(targetPlaybackState);
     }
 
     return getActiveMediaElements(targetSession)[0]?.currentTime ?? playbackTimeSecondsRef.current;
@@ -572,16 +623,17 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   const updateDurationFromActiveMedia = useStableCallback(function updateDurationFromActiveMedia(
     targetSession: ProjectPlaybackSession | null = sessionRef.current,
   ) {
-    if (targetSession?.isStemPlayback) {
-      const targetPlaybackState = stemPlaybackRef.current;
-      if (
-        targetPlaybackState &&
-        targetPlaybackState.signature === playbackSignature(targetSession)
-      ) {
-        setPlaybackDurationSeconds(targetPlaybackState.durationSeconds);
-        return;
-      }
+    const targetPlaybackState = stemPlaybackRef.current;
+    if (
+      targetSession &&
+      targetPlaybackState &&
+      targetPlaybackState.signature === playbackSignature(targetSession)
+    ) {
+      setPlaybackDurationSeconds(targetPlaybackState.durationSeconds);
+      return;
+    }
 
+    if (targetSession?.isStemPlayback) {
       const renderedStemDuration = getStemElements(targetSession.visibleStemArtifactIds).reduce(
         (maxDuration, element) =>
           Number.isFinite(element.duration) ? Math.max(maxDuration, element.duration) : maxDuration,
@@ -639,7 +691,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       return;
     }
 
-    if (targetSession.isStemPlayback && canUseStemClock()) {
+    if (canUseStemClock()) {
       void (async () => {
         const activePendingTransition = pendingTransitionRef.current;
         const activeSession = sessionRef.current;
@@ -676,7 +728,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         latestPendingTransition.awaitingSeekKeys = [];
         latestPendingTransition.forceSeekKeys = [];
         targetPlaybackState.offsetSeconds = nextTime;
-        syncStemElementTimes(latestSession.visibleStemArtifactIds, nextTime);
+        syncStemElementTimes(targetPlaybackState.artifactIds, nextTime);
         applyStemVolumes(latestSession);
         setPlaybackTimeSeconds(nextTime);
         setPlaybackDurationSeconds(targetPlaybackState.durationSeconds);
@@ -820,12 +872,16 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       pendingTransition.shouldPlay = false;
     }
 
-    if (sessionRef.current?.isStemPlayback && canUseStemClock()) {
-      const targetPlaybackState = stemPlaybackRef.current;
-      if (targetPlaybackState) {
-        const nextTime = stopStemSources(targetPlaybackState, true);
-        setPlaybackTimeSeconds(nextTime);
-      }
+    const targetSession = sessionRef.current;
+    const targetPlaybackState = stemPlaybackRef.current;
+    if (
+      targetSession &&
+      canUseStemClock() &&
+      targetPlaybackState &&
+      targetPlaybackState.signature === playbackSignature(targetSession)
+    ) {
+      const nextTime = stopStemSources(targetPlaybackState, true);
+      setPlaybackTimeSeconds(nextTime);
       setIsPlaying(false);
       return;
     }
@@ -846,7 +902,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
     tryCompletePendingTransition();
 
-    if (targetSession.isStemPlayback && canUseStemClock()) {
+    if (canUseStemClock()) {
       const masterTime = readMasterTime(targetSession);
       const started = await startStemPlayback(targetSession, masterTime);
       if (started) {
@@ -895,15 +951,19 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       pendingTransition.targetTime = nextTime;
     }
 
-    if (sessionRef.current?.isStemPlayback && canUseStemClock()) {
-      syncStemElementTimes(sessionRef.current.visibleStemArtifactIds, nextTime);
-      const targetPlaybackState = stemPlaybackRef.current;
-      if (targetPlaybackState) {
-        targetPlaybackState.offsetSeconds = clampTime(nextTime, targetPlaybackState.durationSeconds);
-        targetPlaybackState.startedAtContextTime = targetPlaybackState.context.currentTime;
-        if (targetPlaybackState.isPlaying) {
-          void startStemPlayback(sessionRef.current, nextTime);
-        }
+    const targetSession = sessionRef.current;
+    const targetPlaybackState = stemPlaybackRef.current;
+    if (
+      targetSession &&
+      canUseStemClock() &&
+      targetPlaybackState &&
+      targetPlaybackState.signature === playbackSignature(targetSession)
+    ) {
+      syncStemElementTimes(targetPlaybackState.artifactIds, nextTime);
+      targetPlaybackState.offsetSeconds = clampTime(nextTime, targetPlaybackState.durationSeconds);
+      targetPlaybackState.startedAtContextTime = targetPlaybackState.context.currentTime;
+      if (targetPlaybackState.isPlaying) {
+        void startStemPlayback(targetSession, nextTime);
       }
       setPlaybackTimeSeconds(nextTime);
       return;
@@ -927,7 +987,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     if (stemPlaybackRef.current) {
       stopStemSources(stemPlaybackRef.current, false);
       stemPlaybackRef.current.offsetSeconds = 0;
-      syncStemElementTimes(Object.keys(stemPlaybackRef.current.gains), 0);
+      syncStemElementTimes(stemPlaybackRef.current.artifactIds, 0);
     }
     getRenderedMediaElements().forEach((element) => {
       element.pause();
@@ -945,10 +1005,11 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
   const dismissSession = useCallback(() => {
     stopPlayback();
+    closePlaybackAudioContext();
     setSession(null);
     sessionRef.current = null;
     setPlaybackDurationSeconds(0);
-  }, [stopPlayback]);
+  }, [closePlaybackAudioContext, stopPlayback]);
 
   const registerProjectSession = useCallback((nextSession: ProjectPlaybackSession) => {
     const previousSession = sessionRef.current;
@@ -957,7 +1018,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
     if (previousSession && previousSession.projectId !== nextSession.projectId) {
       clearPendingTransition();
-      disposeStemPlaybackState();
+      closePlaybackAudioContext();
       getRenderedMediaElements(previousSession).forEach((element) => {
         element.pause();
         element.currentTime = 0;
@@ -966,12 +1027,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       setPlaybackDurationSeconds(nextSession.durationHintSeconds || 0);
       setIsPlaying(false);
     } else if (previousSession && previousSignature !== nextSignature) {
-      const nextTime = previousSession.isStemPlayback
-        ? readMasterTime(previousSession)
-        : Math.max(
-            playbackTimeSecondsRef.current,
-            primaryAudioRef.current?.currentTime ?? 0,
-          );
+      const nextTime = readMasterTime(previousSession);
       const shouldPlay = isPlayingRef.current;
       const primarySwap =
         !previousSession.isStemPlayback && !nextSession.isStemPlayback;
@@ -984,9 +1040,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       if (shouldPlay) {
         getActiveMediaElements(previousSession).forEach((element) => element.pause());
       }
-      if (previousSession.isStemPlayback) {
-        disposeStemPlaybackState();
-      }
+      disposeStemPlaybackState();
       pendingTransitionRef.current = {
         id: ++transitionCounterRef.current,
         signature: nextSignature,
@@ -1007,6 +1061,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     setSession(nextSession);
   }, [
     clearPendingTransition,
+    closePlaybackAudioContext,
     disposeStemPlaybackState,
     getActiveMediaElements,
     getRenderedMediaElements,
@@ -1031,14 +1086,9 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
   useEffect(
     () => () => {
-      disposeStemPlaybackState();
-      const audioContext = stemAudioContextRef.current;
-      stemAudioContextRef.current = null;
-      if (audioContext) {
-        void audioContext.close().catch(() => undefined);
-      }
+      closePlaybackAudioContext();
     },
-    [disposeStemPlaybackState],
+    [closePlaybackAudioContext],
   );
 
   useMediaSessionControls({

--- a/apps/desktop/src/features/projects/playbackUtils.ts
+++ b/apps/desktop/src/features/projects/playbackUtils.ts
@@ -15,6 +15,7 @@ const PRIMARY_MEDIA_KEY = "__primary__";
 
 export type StemPlaybackState = {
   signature: string;
+  artifactIds: string[];
   context: AudioContext;
   durationSeconds: number;
   startedAtContextTime: number;

--- a/apps/desktop/src/features/projects/stemPlaybackClock.ts
+++ b/apps/desktop/src/features/projects/stemPlaybackClock.ts
@@ -64,7 +64,7 @@ export function stopStemSources(
   targetPlaybackState.isPlaying = false;
   targetPlaybackState.offsetSeconds = clampTime(nextTime, targetPlaybackState.durationSeconds);
   targetPlaybackState.startedAtContextTime = targetPlaybackState.context.currentTime;
-  syncStemElementTimes(Object.keys(targetPlaybackState.gains), targetPlaybackState.offsetSeconds);
+  syncStemElementTimes(targetPlaybackState.artifactIds, targetPlaybackState.offsetSeconds);
   return targetPlaybackState.offsetSeconds;
 }
 

--- a/apps/desktop/src/features/tools/ToolsView.tsx
+++ b/apps/desktop/src/features/tools/ToolsView.tsx
@@ -3,6 +3,12 @@ import { useSearchParams } from "react-router-dom";
 import { useStableCallback } from "../../lib/useStableCallback";
 import { usePreferences } from "../../lib/preferences";
 import { MetronomePage } from "./MetronomePage";
+import {
+  clampSystemInputVolume,
+  getSystemDefaultInputVolume,
+  setSystemDefaultInputVolume,
+  type SystemDefaultInputVolume,
+} from "./systemInputVolume";
 import { TunerPreferenceControls } from "./TunerPreferenceControls";
 import {
   SimpleTunerMeter,
@@ -25,6 +31,8 @@ import {
   calculateTunerInputLevel,
   type TunerPitchReading,
 } from "./tunerPitch";
+
+const SYSTEM_INPUT_VOLUME_COMMIT_DELAY_MS = 180;
 
 type TunerStatus = "idle" | "starting" | "listening" | "unsupported" | "error";
 type ToolId = "tuner" | "metronome";
@@ -101,6 +109,7 @@ function ChromaticTunerPage() {
   const [inputLevel, setInputLevel] = useState(0);
   const [reading, setReading] = useState<TunerPitchReading | null>(null);
   const [deviceRefreshToken, setDeviceRefreshToken] = useState(0);
+  const [systemInputVolumeRefreshToken, setSystemInputVolumeRefreshToken] = useState(0);
   const [visualMode, setVisualMode] = useState<TunerVisualMode>("simple");
   const analyserRef = useRef<AnalyserNode | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
@@ -198,6 +207,7 @@ function ChromaticTunerPage() {
     releaseCapture();
     setErrorMessage(null);
     resetTunerDisplay();
+    setSystemInputVolumeRefreshToken(Date.now());
     setStatus("starting");
 
     const requestId = requestIdRef.current + 1;
@@ -324,6 +334,8 @@ function ChromaticTunerPage() {
           </label>
         </TunerPreferenceControls>
 
+        <SystemInputVolumeControl refreshToken={systemInputVolumeRefreshToken} />
+
         {errorMessage ? <p className="inline-error">{errorMessage}</p> : null}
 
         {visualMode === "simple" ? (
@@ -383,6 +395,164 @@ function TunerHeader({
       </div>
     </div>
   );
+}
+
+function SystemInputVolumeControl({ refreshToken }: { refreshToken: number }) {
+  const [volumeState, setVolumeState] = useState<SystemDefaultInputVolume | null>(null);
+  const [draftVolume, setDraftVolume] = useState(0);
+  const [isSetting, setIsSetting] = useState(false);
+  const volumeSetRequestIdRef = useRef(0);
+  const volumeCommitTimeoutRef = useRef<number | null>(null);
+  const latestDraftVolumeRef = useRef(0);
+
+  const refreshVolume = useStableCallback(async function refreshVolume() {
+    try {
+      const nextState = await getSystemDefaultInputVolume();
+      setVolumeState(nextState);
+      if (typeof nextState.volumePercent === "number") {
+        setDraftVolume(nextState.volumePercent);
+        latestDraftVolumeRef.current = nextState.volumePercent;
+      }
+    } catch (error) {
+      setVolumeState({
+        supported: false,
+        volumePercent: null,
+        muted: null,
+        backend: null,
+        error: error instanceof Error ? error.message : "System input volume unavailable.",
+      });
+    }
+  });
+
+  useEffect(() => {
+    void refreshVolume();
+  }, [refreshToken, refreshVolume]);
+
+  useEffect(() => {
+    return () => {
+      if (volumeCommitTimeoutRef.current !== null) {
+        window.clearTimeout(volumeCommitTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    function refreshOnFocus() {
+      void refreshVolume();
+    }
+
+    window.addEventListener("focus", refreshOnFocus);
+    return () => window.removeEventListener("focus", refreshOnFocus);
+  }, [refreshVolume]);
+
+  const supported = Boolean(volumeState?.supported && typeof volumeState.volumePercent === "number");
+  const statusText = systemInputVolumeStatus(volumeState, isSetting);
+
+  const commitVolume = useStableCallback(async function commitVolume(volume: number) {
+    const requestId = volumeSetRequestIdRef.current + 1;
+    volumeSetRequestIdRef.current = requestId;
+    setIsSetting(true);
+    try {
+      const nextState = await setSystemDefaultInputVolume(volume);
+      if (volumeSetRequestIdRef.current !== requestId) {
+        return;
+      }
+      setVolumeState(nextState);
+    } catch (error) {
+      if (volumeSetRequestIdRef.current !== requestId) {
+        return;
+      }
+      setVolumeState({
+        supported: false,
+        volumePercent: null,
+        muted: null,
+        backend: null,
+        error: error instanceof Error ? error.message : "System input volume unavailable.",
+      });
+    } finally {
+      if (volumeSetRequestIdRef.current === requestId) {
+        setIsSetting(false);
+      }
+    }
+  });
+
+  function clearScheduledVolumeCommit() {
+    if (volumeCommitTimeoutRef.current !== null) {
+      window.clearTimeout(volumeCommitTimeoutRef.current);
+      volumeCommitTimeoutRef.current = null;
+    }
+  }
+
+  function scheduleVolumeCommit(volume: number) {
+    clearScheduledVolumeCommit();
+    volumeCommitTimeoutRef.current = window.setTimeout(() => {
+      volumeCommitTimeoutRef.current = null;
+      void commitVolume(volume);
+    }, SYSTEM_INPUT_VOLUME_COMMIT_DELAY_MS);
+  }
+
+  function flushVolumeCommit() {
+    if (!supported) {
+      return;
+    }
+    clearScheduledVolumeCommit();
+    void commitVolume(latestDraftVolumeRef.current);
+  }
+
+  function handleVolumeChange(value: string) {
+    const nextVolume = clampSystemInputVolume(Number(value));
+    latestDraftVolumeRef.current = nextVolume;
+    setDraftVolume(nextVolume);
+    scheduleVolumeCommit(nextVolume);
+  }
+
+  return (
+    <div className="tuner-system-volume">
+      <label className="tuner-field">
+        <span className="tuner-field__label-row">
+          <span>System input volume</span>
+          {supported ? <strong>{draftVolume}%</strong> : null}
+        </span>
+        <input
+          aria-label="System input volume"
+          disabled={!supported}
+          max={100}
+          min={0}
+          onChange={(event) => void handleVolumeChange(event.target.value)}
+          onBlur={flushVolumeCommit}
+          onKeyUp={flushVolumeCommit}
+          onPointerUp={flushVolumeCommit}
+          step={1}
+          type="range"
+          value={draftVolume}
+        />
+      </label>
+      <p className="tuner-preferences__status">{statusText}</p>
+    </div>
+  );
+}
+
+function systemInputVolumeStatus(
+  volumeState: SystemDefaultInputVolume | null,
+  isSetting: boolean,
+) {
+  if (isSetting) {
+    return "Updating system input volume.";
+  }
+  if (!volumeState) {
+    return "Checking system input volume.";
+  }
+  if (!volumeState.supported) {
+    return volumeState.error ?? "System input volume control is unavailable.";
+  }
+  if (volumeState.muted) {
+    return "Default microphone is muted.";
+  }
+  return "Controls the operating system default microphone.";
 }
 
 function getAudioContextConstructor(): AudioContextConstructor | null {

--- a/apps/desktop/src/features/tools/systemInputVolume.ts
+++ b/apps/desktop/src/features/tools/systemInputVolume.ts
@@ -1,0 +1,26 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type SystemDefaultInputVolume = {
+  supported: boolean;
+  volumePercent: number | null;
+  muted: boolean | null;
+  backend: string | null;
+  error: string | null;
+};
+
+export async function getSystemDefaultInputVolume() {
+  return invoke<SystemDefaultInputVolume>("get_system_default_input_volume");
+}
+
+export async function setSystemDefaultInputVolume(volumePercent: number) {
+  return invoke<SystemDefaultInputVolume>("set_system_default_input_volume", {
+    volumePercent: clampSystemInputVolume(volumePercent),
+  });
+}
+
+export function clampSystemInputVolume(volumePercent: number) {
+  if (!Number.isFinite(volumePercent)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(100, Math.round(volumePercent)));
+}

--- a/apps/desktop/src/styles/tools.css
+++ b/apps/desktop/src/styles/tools.css
@@ -61,6 +61,13 @@
   font-weight: 700;
 }
 
+.tuner-field__label-row {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
 .tuner-field input,
 .tuner-field select {
   width: 100%;
@@ -73,10 +80,20 @@
   box-shadow: inset 0 1px 0 color-mix(in srgb, white 8%, transparent);
 }
 
+.tuner-field input[type="range"] {
+  padding-inline: 0;
+  accent-color: var(--playback-accent);
+}
+
 .tuner-field input:focus-visible,
 .tuner-field select:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
+}
+
+.tuner-system-volume {
+  display: grid;
+  gap: 0.35rem;
 }
 
 .metronome-grid {

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -42,6 +42,7 @@ const {
   mockDeleteProject,
   mockGetHealth,
   mockGetMobileCapabilities,
+  setMockSystemInputVolume,
 } = vi.hoisted(() => {
   const createdAt = "2026-04-18T13:16:00.000Z";
   let state: {
@@ -56,6 +57,13 @@ const {
     pendingPreviewArtifactsByProject: Record<string, Array<Record<string, unknown>>>;
     jobs: Array<Record<string, unknown>>;
     snapshotFiles: Record<string, string>;
+    systemInputVolume: {
+      supported: boolean;
+      volumePercent: number | null;
+      muted: boolean | null;
+      backend: string | null;
+      error: string | null;
+    };
     nextProjectId: number;
     nextArtifactId: number;
     nextJobId: number;
@@ -317,6 +325,13 @@ const {
         },
       ],
       snapshotFiles: {},
+      systemInputVolume: {
+        supported: true,
+        volumePercent: 64,
+        muted: false,
+        backend: "test",
+        error: null,
+      },
       nextProjectId: 200,
       nextArtifactId: 200,
       nextJobId: 200,
@@ -339,6 +354,14 @@ const {
   const mockOpen = vi.fn(async (): Promise<string | string[] | null> => null);
   const mockSave = vi.fn(async (): Promise<string | null> => null);
   const mockConfirm = vi.fn(async (): Promise<boolean> => true);
+  function setMockSystemInputVolume(
+    nextState: Partial<typeof state.systemInputVolume>,
+  ) {
+    state.systemInputVolume = {
+      ...state.systemInputVolume,
+      ...nextState,
+    };
+  }
   const mockInvoke = vi.fn(async (command: string, args?: Record<string, unknown>) => {
     if (command === "backend_base_url") {
       return "http://127.0.0.1:8765";
@@ -357,6 +380,22 @@ const {
         throw new Error(`Missing snapshot file: ${path}`);
       }
       return contents;
+    }
+
+    if (command === "get_system_default_input_volume") {
+      return clone(state.systemInputVolume);
+    }
+
+    if (command === "set_system_default_input_volume") {
+      const nextVolume = Math.max(0, Math.min(100, Math.round(Number(args?.volumePercent ?? 0))));
+      state.systemInputVolume = {
+        supported: true,
+        volumePercent: nextVolume,
+        muted: false,
+        backend: "test",
+        error: null,
+      };
+      return clone(state.systemInputVolume);
     }
 
     throw new Error(`Unexpected invoke command: ${command}`);
@@ -948,6 +987,7 @@ const {
     mockDeleteProject,
     mockGetHealth,
     mockGetMobileCapabilities,
+    setMockSystemInputVolume,
   };
 });
 
@@ -1169,6 +1209,16 @@ export function getMockAudioContexts() {
 
 export function getMockFetch() {
   return globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+}
+
+export function getMockInvoke() {
+  return mockInvoke;
+}
+
+export function setMockSystemInputVolumeState(
+  nextState: Parameters<typeof setMockSystemInputVolume>[0],
+) {
+  setMockSystemInputVolume(nextState);
 }
 
 export function getMockMediaDevices() {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -199,6 +199,7 @@ Validation failures return `INVALID_REQUEST` with serialized validation details.
 ## Packaging Constraints
 
 - FFmpeg is a host dependency and is not bundled.
+- Desktop system microphone volume control uses CoreAudio on macOS, or host `wpctl`/`pactl` tools on Linux with an active PipeWire/PulseAudio session.
 - Advanced Chords dependencies are currently optional. If they become a default desktop backend, packaged builds must treat crema, its bundled chord model files, TensorFlow/Keras, h5py/HDF5, gRPC/Protobuf, and TensorBoard as default-runtime notice scope.
 - Demucs and lyrics models follow first-use local download/cache behavior.
 - The Linux legacy NVIDIA profile is an opt-in local backend environment override; it does not change the default lockfile, CI setup, or packaged dependency baseline.


### PR DESCRIPTION
## Summary

- Add live system default input volume control to the tuner.
- Use CoreAudio on macOS and `wpctl`/`pactl` on Linux for host mic volume.
- Route project playback through shared Web Audio transport for mixes and stems.
- Document desktop host audio integration requirements.

## Testing

- `cd apps/desktop/src-tauri && cargo check`
- `cd apps/desktop/src-tauri && cargo test`
- `pnpm --filter @tuneforge/desktop test -- App.tools-tuner.test.tsx`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
- Manual macOS and Linux smoke tests for system mic volume control.
