### PR TITLE
fix: respect chord backend preference on import

### DIFF
--- a/apps/backend/app/api/routes/projects.py
+++ b/apps/backend/app/api/routes/projects.py
@@ -40,7 +40,7 @@ from app.schemas import (
     TransposeRequest,
 )
 from app.services.artifacts import delete_project_artifact
-from app.services.chord_backends import FAST_CHORD_BACKEND_ID, resolve_chord_backend
+from app.services.chord_backends import FAST_CHORD_BACKEND_ID, ChordDetectionBackend, resolve_chord_backend
 from app.services.chords import project_chord_detection_source
 from app.services.lyrics import update_project_lyrics
 from app.services.projects import (
@@ -61,6 +61,18 @@ from app.services.tabs import (
 router = APIRouter(prefix="/projects", tags=["projects"])
 
 
+def _resolve_import_chord_backend(
+    requested_backend: str | None,
+    backend_fallback_from: str | None,
+) -> tuple[ChordDetectionBackend, str | None]:
+    selected_backend = resolve_chord_backend(requested_backend, require_available=False)
+    availability = selected_backend.availability()
+    if availability.available:
+        return selected_backend, backend_fallback_from
+    fallback_backend = resolve_chord_backend(FAST_CHORD_BACKEND_ID, require_available=True)
+    return fallback_backend, backend_fallback_from or selected_backend.id
+
+
 @router.post("/import", response_model=ProjectResponse)
 def create_project(
     payload: ProjectImportRequest,
@@ -79,13 +91,21 @@ def create_project(
         job_type="analyze",
         payload=AnalysisRequest(include_tempo=False, force=False).model_dump(),
     )
+    selected_chord_backend, chord_backend_fallback_from = _resolve_import_chord_backend(
+        payload.chord_backend,
+        payload.chord_backend_fallback_from,
+    )
     chords_job = runner.create_job(
         session,
         project_id=project.id,
         job_type="chords",
         payload={
-            **ChordRequest(backend="default", force=False).model_dump(),
-            "chord_backend": FAST_CHORD_BACKEND_ID,
+            **ChordRequest(
+                backend=selected_chord_backend.id,
+                backend_fallback_from=chord_backend_fallback_from,
+                force=False,
+            ).model_dump(),
+            "chord_backend": selected_chord_backend.id,
             "chord_source": "source",
         },
     )

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -5,6 +5,15 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+SUPPORTED_CHORD_BACKENDS = {"default", "fast", "tuneforge-fast", "librosa", "advanced", "crema", "crema-advanced"}
+
+
+def _validate_chord_backend_fields(backend: str | None, backend_fallback_from: str | None) -> None:
+    if backend is not None and backend not in SUPPORTED_CHORD_BACKENDS:
+        raise ValueError("Unsupported chord backend.")
+    if backend_fallback_from is not None and backend_fallback_from not in SUPPORTED_CHORD_BACKENDS:
+        raise ValueError("Unsupported chord backend.")
+
 
 class ErrorInfo(BaseModel):
     code: str
@@ -45,6 +54,13 @@ class ProjectImportRequest(BaseModel):
     source_path: str
     copy_into_project: bool = True
     display_name: str | None = None
+    chord_backend: str | None = None
+    chord_backend_fallback_from: str | None = None
+
+    @model_validator(mode="after")
+    def validate_chord_backend(self) -> ProjectImportRequest:
+        _validate_chord_backend_fields(self.chord_backend, self.chord_backend_fallback_from)
+        return self
 
 
 class ProjectUpdateRequest(BaseModel):
@@ -131,11 +147,7 @@ class ChordRequest(BaseModel):
 
     @model_validator(mode="after")
     def validate_backend(self) -> ChordRequest:
-        supported = {"default", "fast", "tuneforge-fast", "librosa", "advanced", "crema", "crema-advanced"}
-        if self.backend not in supported or (
-            self.backend_fallback_from is not None and self.backend_fallback_from not in supported
-        ):
-            raise ValueError("Unsupported chord backend.")
+        _validate_chord_backend_fields(self.backend, self.backend_fallback_from)
         return self
 
 
@@ -441,11 +453,7 @@ class StemRequest(BaseModel):
             raise ValueError("Only two_stem mode is supported in v1.")
         if self.output_format != "wav":
             raise ValueError("Stem output must be wav in v1.")
-        supported = {"default", "fast", "tuneforge-fast", "librosa", "advanced", "crema", "crema-advanced"}
-        if self.chord_backend not in supported or (
-            self.chord_backend_fallback_from is not None and self.chord_backend_fallback_from not in supported
-        ):
-            raise ValueError("Unsupported chord backend.")
+        _validate_chord_backend_fields(self.chord_backend, self.chord_backend_fallback_from)
         return self
 
 

--- a/apps/backend/tests/test_chord_flow.py
+++ b/apps/backend/tests/test_chord_flow.py
@@ -37,7 +37,7 @@ def test_chord_job_persists_timeline(client, sample_chord_audio_file: Path):
     initial_chord_job = next(
         job for job in initial_jobs if job["project_id"] == project["id"] and job["type"] == "chords"
     )
-    assert wait_for_job(client, initial_chord_job["id"])["status"] == "completed"
+    assert wait_for_job(client, initial_chord_job["id"], timeout=90.0)["status"] == "completed"
 
     initial = client.get(f"/api/v1/projects/{project['id']}/chords").json()
     assert initial["project_id"] == project["id"]
@@ -78,6 +78,85 @@ def test_chord_job_persists_timeline(client, sample_chord_audio_file: Path):
     assert any(label == "G" for label in labels)
     assert any(label == "Am" for label in labels)
     assert any(label == "F" for label in labels)
+
+
+def test_import_chord_job_uses_requested_advanced_backend_when_available(
+    client,
+    sample_chord_audio_file: Path,
+    monkeypatch,
+):
+    monkeypatch.setattr("app.services.chord_backends.crema_dependency_status", lambda **_kwargs: (True, None))
+    monkeypatch.setattr("app.services.chord_backends.crema_runtime_device", lambda: "cpu")
+    monkeypatch.setattr(
+        "app.services.chord_backends.crema_model_metadata",
+        lambda: {"backend_id": "crema-advanced", "engine": "crema-test"},
+    )
+    monkeypatch.setattr(
+        "app.services.chord_backends.detect_crema_chord_timeline",
+        lambda _: [_segment("D/F#", confidence=0.91, pitch_class=2, quality="major")],
+    )
+
+    project = client.post(
+        "/api/v1/projects/import",
+        json={
+            "source_path": str(sample_chord_audio_file),
+            "copy_into_project": True,
+            "chord_backend": "crema-advanced",
+        },
+    ).json()["project"]
+
+    initial_jobs = client.get("/api/v1/jobs").json()["jobs"]
+    initial_chord_job = next(
+        job for job in initial_jobs if job["project_id"] == project["id"] and job["type"] == "chords"
+    )
+    assert initial_chord_job["chord_backend"] == "crema-advanced"
+
+    final_job = wait_for_job(client, initial_chord_job["id"], timeout=90.0)
+    assert final_job["status"] == "completed"
+    assert final_job["chord_backend"] == "crema-advanced"
+    assert final_job["chord_backend_fallback_from"] is None
+
+    chords = client.get(f"/api/v1/projects/{project['id']}/chords").json()
+    assert chords["backend"] == "crema-advanced"
+    assert chords["metadata"]["backend_fallback_from"] is None
+    assert chords["metadata"]["runtime_device"] == "cpu"
+    assert [segment["label"] for segment in chords["timeline"]] == ["D/F#"]
+
+
+def test_import_chord_job_falls_back_when_requested_advanced_backend_is_unavailable(
+    client,
+    sample_chord_audio_file: Path,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "app.services.chord_backends.crema_dependency_status",
+        lambda **_kwargs: (False, "crema is not installed"),
+    )
+
+    project = client.post(
+        "/api/v1/projects/import",
+        json={
+            "source_path": str(sample_chord_audio_file),
+            "copy_into_project": True,
+            "chord_backend": "crema-advanced",
+        },
+    ).json()["project"]
+
+    initial_jobs = client.get("/api/v1/jobs").json()["jobs"]
+    initial_chord_job = next(
+        job for job in initial_jobs if job["project_id"] == project["id"] and job["type"] == "chords"
+    )
+    assert initial_chord_job["chord_backend"] == "tuneforge-fast"
+    assert initial_chord_job["chord_backend_fallback_from"] == "crema-advanced"
+
+    final_job = wait_for_job(client, initial_chord_job["id"], timeout=90.0)
+    assert final_job["status"] == "completed"
+    assert final_job["chord_backend"] == "tuneforge-fast"
+    assert final_job["chord_backend_fallback_from"] == "crema-advanced"
+
+    chords = client.get(f"/api/v1/projects/{project['id']}/chords").json()
+    assert chords["backend"] == "tuneforge-fast"
+    assert chords["metadata"]["backend_fallback_from"] == "crema-advanced"
 
 
 @pytest.mark.parametrize("backend_id", ["tuneforge-fast", "crema-advanced"])

--- a/apps/desktop/src/App.library.test.tsx
+++ b/apps/desktop/src/App.library.test.tsx
@@ -9,6 +9,7 @@ import {
   mockListProjects,
   mockOpen,
   renderApp,
+  setChordBackends,
   setProjects,
 } from "./test/appTestHarness";
 
@@ -108,12 +109,76 @@ describe("Desktop app library", () => {
     expect(mockImportProject).toHaveBeenCalledWith({
       source_path: "/tmp/new-song.mp4",
       copy_into_project: true,
+      chord_backend: "tuneforge-fast",
     });
     await waitFor(() =>
       expect(mockGetProject).toHaveBeenCalledWith(expect.stringMatching(/^proj_/)),
     );
     expect(await screen.findByRole("heading", { name: "New Song" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Hide Inspector" })).toBeInTheDocument();
+  });
+
+  it("uses the selected default chord backend when importing a track", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({ defaultChordBackend: "crema-advanced", defaultSourcesRailCollapsed: false }),
+    );
+    mockOpen.mockResolvedValue("/tmp/new-song.mp4");
+
+    renderApp(["/"]);
+
+    expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Import Track" }));
+
+    expect(mockImportProject).toHaveBeenCalledWith({
+      source_path: "/tmp/new-song.mp4",
+      copy_into_project: true,
+      chord_backend: "crema-advanced",
+    });
+  });
+
+  it("falls back to built-in chords when importing with unavailable advanced chords", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({ defaultChordBackend: "crema-advanced", defaultSourcesRailCollapsed: false }),
+    );
+    setChordBackends([
+      {
+        availability: "available",
+        available: true,
+        capabilities: {},
+        desktopOnly: false,
+        experimental: false,
+        id: "tuneforge-fast",
+        label: "Built-in Chords",
+        unavailable_reason: null,
+      },
+      {
+        availability: "unavailable",
+        available: false,
+        capabilities: {},
+        desktopOnly: true,
+        experimental: true,
+        id: "crema-advanced",
+        label: "Advanced Chords",
+        unavailable_reason: "crema is not installed",
+      },
+    ]);
+    mockOpen.mockResolvedValue("/tmp/new-song.mp4");
+
+    renderApp(["/"]);
+
+    expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Import Track" }));
+
+    expect(mockImportProject).toHaveBeenCalledWith({
+      source_path: "/tmp/new-song.mp4",
+      copy_into_project: true,
+      chord_backend: "tuneforge-fast",
+      chord_backend_fallback_from: "crema-advanced",
+    });
   });
 
   it("deletes project after confirmation and returns to library", async () => {

--- a/apps/desktop/src/features/projects/LibraryView.tsx
+++ b/apps/desktop/src/features/projects/LibraryView.tsx
@@ -5,6 +5,7 @@ import { Link, useNavigate } from "react-router-dom";
 import { api, type ProjectSchema } from "../../lib/api";
 import { formatLocalDateTime, normalizeApiDateTime } from "../../lib/datetime";
 import { usePreferences } from "../../lib/preferences";
+import { useChordBackendActionSelection } from "./hooks/useChordBackendActionSelection";
 
 function formatDuration(durationSeconds: number | null | undefined) {
   if (!durationSeconds) return "Unknown length";
@@ -88,6 +89,7 @@ export function LibraryView() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { informationDensity } = usePreferences();
+  const { chordBackendForAction } = useChordBackendActionSelection();
   const [searchDraft, setSearchDraft] = useState("");
   const deferredSearch = useDeferredValue(searchDraft.trim());
   const showSubtitle = informationDensity !== "minimal";
@@ -112,9 +114,14 @@ export function LibraryView() {
       if (!selection || Array.isArray(selection)) {
         return null;
       }
+      const backendSelection = await chordBackendForAction();
       const response = await api.importProject({
         source_path: selection,
         copy_into_project: true,
+        chord_backend: backendSelection.backend,
+        ...(backendSelection.backend_fallback_from
+          ? { chord_backend_fallback_from: backendSelection.backend_fallback_from }
+          : {}),
       });
       return response.project;
     },

--- a/apps/desktop/src/features/projects/hooks/useChordBackendActionSelection.ts
+++ b/apps/desktop/src/features/projects/hooks/useChordBackendActionSelection.ts
@@ -1,0 +1,47 @@
+import { useCallback } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { api, type ChordBackendsResponse } from "../../../lib/api";
+import { usePreferences, type DefaultChordBackend } from "../../../lib/preferences";
+
+export type ChordBackendActionSelection = {
+  backend: DefaultChordBackend;
+  backend_fallback_from?: DefaultChordBackend;
+};
+
+export function useChordBackendActionSelection() {
+  const queryClient = useQueryClient();
+  const { defaultChordBackend } = usePreferences();
+  const chordBackendsQuery = useQuery({
+    queryKey: ["chord-backends"],
+    queryFn: api.listChordBackends,
+  });
+
+  const chordBackendForAction = useCallback(async (): Promise<ChordBackendActionSelection> => {
+    if (defaultChordBackend === "tuneforge-fast") {
+      return { backend: "tuneforge-fast" };
+    }
+
+    let backendResponse: ChordBackendsResponse | undefined = chordBackendsQuery.data;
+    if (!backendResponse) {
+      try {
+        backendResponse = await queryClient.fetchQuery({
+          queryKey: ["chord-backends"],
+          queryFn: api.listChordBackends,
+        });
+      } catch {
+        return { backend: "tuneforge-fast", backend_fallback_from: defaultChordBackend };
+      }
+    }
+    if (!backendResponse) {
+      return { backend: "tuneforge-fast", backend_fallback_from: defaultChordBackend };
+    }
+
+    const selectedBackend = backendResponse.backends.find((backend) => backend.id === defaultChordBackend);
+    if (selectedBackend?.available) {
+      return { backend: defaultChordBackend };
+    }
+    return { backend: "tuneforge-fast", backend_fallback_from: defaultChordBackend };
+  }, [chordBackendsQuery.data, defaultChordBackend, queryClient]);
+
+  return { chordBackendForAction, chordBackendsQuery };
+}

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
 import { confirm, save } from "@tauri-apps/plugin-dialog";
-import { api, type ArtifactSchema, type ChordBackendsResponse, type ProjectSchema } from "../../../lib/api";
+import { api, type ArtifactSchema, type ProjectSchema } from "../../../lib/api";
 import { usePreferences } from "../../../lib/preferences";
 import { usePlayback } from "../playback-context";
 import {
@@ -50,13 +50,10 @@ import {
   type SourceKeyOption,
   type TargetShiftOption,
 } from "../projectViewUtils";
-import type { DefaultChordBackend, DefaultPlaybackDisplayMode, PlaybackDisplayMode } from "../../../lib/preferences";
+import type { DefaultPlaybackDisplayMode, PlaybackDisplayMode } from "../../../lib/preferences";
+import { useChordBackendActionSelection } from "./useChordBackendActionSelection";
 
 type PlaybackDisplayModeSource = "default" | "stored" | "user";
-type ChordBackendActionSelection = {
-  backend: DefaultChordBackend;
-  backend_fallback_from?: DefaultChordBackend;
-};
 
 function resolveDefaultPlaybackDisplayMode(
   defaultMode: DefaultPlaybackDisplayMode,
@@ -101,10 +98,10 @@ export function useProjectViewModel() {
     defaultLyricsFollowEnabled,
     defaultProjectWorkspace,
     defaultSourcesRailCollapsed,
-    defaultChordBackend,
     enharmonicDisplayMode,
     informationDensity,
   } = usePreferences();
+  const { chordBackendForAction } = useChordBackendActionSelection();
   const chordSegmentRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const chordTimelineRef = useRef<HTMLDivElement | null>(null);
   const combinedLeadSheetRef = useRef<HTMLDivElement | null>(null);
@@ -192,10 +189,6 @@ export function useProjectViewModel() {
     queryKey: ["jobs"],
     queryFn: async () => (await api.listJobs()).jobs,
   });
-  const chordBackendsQuery = useQuery({
-    queryKey: ["chord-backends"],
-    queryFn: api.listChordBackends,
-  });
   const mobileCapabilitiesQuery = useQuery({
     queryKey: ["mobile-capabilities"],
     queryFn: async () => api.getMobileCapabilities(),
@@ -203,33 +196,6 @@ export function useProjectViewModel() {
   });
 
   useActiveJobPolling(projectId, jobsQuery.data);
-
-  async function chordBackendForAction(): Promise<ChordBackendActionSelection> {
-    if (defaultChordBackend === "tuneforge-fast") {
-      return { backend: "tuneforge-fast" };
-    }
-
-    let backendResponse: ChordBackendsResponse | undefined = chordBackendsQuery.data;
-    if (!backendResponse) {
-      try {
-        backendResponse = await queryClient.fetchQuery({
-          queryKey: ["chord-backends"],
-          queryFn: api.listChordBackends,
-        });
-      } catch {
-        return { backend: "tuneforge-fast", backend_fallback_from: defaultChordBackend };
-      }
-    }
-    if (!backendResponse) {
-      return { backend: "tuneforge-fast", backend_fallback_from: defaultChordBackend };
-    }
-
-    const selectedBackend = backendResponse.backends.find((backend) => backend.id === defaultChordBackend);
-    if (selectedBackend?.available) {
-      return { backend: defaultChordBackend };
-    }
-    return { backend: "tuneforge-fast", backend_fallback_from: defaultChordBackend };
-  }
 
   const analyzeMutation = useMutation({
     mutationFn: () => api.analyzeProject(projectId),

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -814,6 +814,10 @@ export interface components {
             copy_into_project: boolean;
             /** Display Name */
             display_name?: string | null;
+            /** Chord Backend */
+            chord_backend?: string | null;
+            /** Chord Backend Fallback From */
+            chord_backend_fallback_from?: string | null;
         };
         /** ProjectResponse */
         ProjectResponse: {


### PR DESCRIPTION
## Summary

- Pass the selected chord backend through project import so initial chord jobs respect the desktop preference.
- Fall back to built-in chords during import when Advanced Chords is unavailable and preserve fallback metadata.
- Share chord backend selection logic between library import, chord refresh, and stem generation.

## Testing

- `pnpm contracts:generate`
- `uv run --python 3.11 pytest tests/test_chord_flow.py`
- `pnpm --filter @tuneforge/desktop test -- App.library.test.tsx App.project-analysis-mix.test.tsx`
- `pnpm lint`
- `pnpm typecheck`
