### PR TITLE
feat: add playback pre-count

### DIFF
--- a/apps/desktop/src/App.project-precount.test.tsx
+++ b/apps/desktop/src/App.project-precount.test.tsx
@@ -1,0 +1,218 @@
+import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  findAudioByArtifactId,
+  getMockAudioContexts,
+  markAudioReady,
+  resetAppTestHarness,
+  renderApp,
+  setProjectAnalysis,
+} from "./test/appTestHarness";
+
+const analysisWithTempo = {
+  project_id: "proj_123",
+  estimated_key: "G major",
+  key_confidence: 0.82,
+  estimated_reference_hz: 440,
+  tuning_offset_cents: 0,
+  tempo_bpm: 120,
+  analysis_version: "v1",
+  created_at: "2026-04-18T13:16:00.000Z",
+};
+
+function setupTempoAnalysis() {
+  setProjectAnalysis("proj_123", analysisWithTempo);
+}
+
+async function openPlaybackWorkspace(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("tab", { name: "Playback" }));
+}
+
+function setPlaybackPosition(value: string) {
+  fireEvent.change(screen.getByLabelText("Playback position"), { target: { value } });
+}
+
+async function flushMicrotasks(count = 6) {
+  for (let index = 0; index < count; index += 1) {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+}
+
+describe("Desktop app project playback pre-count", () => {
+  beforeEach(resetAppTestHarness);
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("shows pre-count disabled until analysis provides BPM", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+
+    expect(screen.getByLabelText("Enable pre-count")).toBeDisabled();
+    expect(screen.getByRole("group", { name: "Pre-count clicks" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Decrease pre-count clicks" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Increase pre-count clicks" })).toBeDisabled();
+    expect(screen.getByText("Waiting for BPM analysis")).toBeInTheDocument();
+  });
+
+  it("persists enabled pre-count and click count once BPM is known", async () => {
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    const firstRender = renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+
+    await user.click(screen.getByLabelText("Enable pre-count"));
+    await user.click(screen.getByRole("button", { name: "Increase pre-count clicks" }));
+
+    expect(screen.getByLabelText("Enable pre-count")).toBeChecked();
+    expect(screen.getByText("5 clicks at 120.0 BPM")).toBeInTheDocument();
+
+    firstRender.unmount();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    expect(screen.getByLabelText("Enable pre-count")).toBeChecked();
+    expect(screen.getByText("5 clicks at 120.0 BPM")).toBeInTheDocument();
+  });
+
+  it("runs pre-count before source playback and starts from zero", async () => {
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    sourceAudio.currentTime = 0;
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByLabelText("Enable pre-count"));
+    fireEvent.click(screen.getByRole("button", { name: "Play playback" }));
+    await flushMicrotasks();
+
+    const playSpy = vi.mocked(window.HTMLMediaElement.prototype.play);
+    expect(playSpy).not.toHaveBeenCalled();
+    const audioContext = getMockAudioContexts()[0];
+    expect(audioContext?.createdOscillators).toHaveLength(4);
+    expect(audioContext?.createdSources).toHaveLength(0);
+    const clickStartTimes = audioContext?.createdOscillators.map(
+      (oscillator) => oscillator.start.mock.calls[0]?.[0],
+    ) ?? [];
+    expect(Number(clickStartTimes[1]) - Number(clickStartTimes[0])).toBeCloseTo(0.5, 3);
+    expect(Number(clickStartTimes[3]) - Number(clickStartTimes[2])).toBeCloseTo(0.5, 3);
+
+    act(() => {
+      vi.advanceTimersByTime(2034);
+    });
+    expect(playSpy).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+    await flushMicrotasks();
+    expect(playSpy).not.toHaveBeenCalled();
+    expect(audioContext?.createdSources).toHaveLength(1);
+    expect(audioContext?.createdSources[0]?.start.mock.calls[0]?.[0]).toBeCloseTo(2.035, 3);
+    expect(audioContext?.createdSources[0]?.start.mock.calls[0]?.[1]).toBe(0);
+    expect(sourceAudio.currentTime).toBe(0);
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+  });
+
+  it("cancels pre-count without starting playback", async () => {
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByLabelText("Enable pre-count"));
+    fireEvent.click(screen.getByRole("button", { name: "Play playback" }));
+    await flushMicrotasks();
+    const audioContext = getMockAudioContexts()[0];
+    fireEvent.click(screen.getByRole("button", { name: "Stop playback" }));
+
+    act(() => {
+      vi.advanceTimersByTime(2500);
+    });
+
+    expect(vi.mocked(window.HTMLMediaElement.prototype.play)).not.toHaveBeenCalled();
+    expect(audioContext?.createdSources).toHaveLength(0);
+    expect(sourceAudio.currentTime).toBe(0);
+    expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+  });
+
+  it("does not pre-count when resuming mid-song", async () => {
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    setPlaybackPosition("12.5");
+
+    await user.click(screen.getByLabelText("Enable pre-count"));
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    await waitFor(() => expect(getMockAudioContexts()[0]?.createdSources).toHaveLength(1));
+    expect(vi.mocked(window.HTMLMediaElement.prototype.play)).not.toHaveBeenCalled();
+    expect(getMockAudioContexts()[0]?.createdOscillators).toHaveLength(0);
+    expect(getMockAudioContexts()[0]?.createdSources[0]?.start.mock.calls[0]?.[1]).toBeCloseTo(
+      12.5,
+      3,
+    );
+    expect(sourceAudio.currentTime).toBeCloseTo(12.5, 3);
+  });
+
+  it("schedules stem playback on the pre-count clock after the last click", async () => {
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    await openPlaybackWorkspace(user);
+
+    const stemList = await screen.findByRole("group", { name: "Playback stem list" });
+    await user.click(within(stemList).getAllByRole("button", { name: /Vocals/i })[0] as HTMLElement);
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByLabelText("Enable pre-count"));
+    fireEvent.click(screen.getByRole("button", { name: "Play playback" }));
+    await flushMicrotasks();
+
+    const stemAudioContext = getMockAudioContexts()[0];
+    expect(stemAudioContext?.createdOscillators).toHaveLength(4);
+    expect(stemAudioContext?.createdSources).toHaveLength(0);
+
+    await act(async () => {
+      vi.advanceTimersByTime(2035);
+    });
+    await flushMicrotasks();
+
+    expect(stemAudioContext.createdSources.length).toBeGreaterThan(0);
+    const startCalls = stemAudioContext.createdSources.map(
+      (source) => source.start.mock.calls[0],
+    );
+    startCalls.forEach((call) => {
+      expect(call?.[0]).toBeCloseTo(2.035, 3);
+      expect(call?.[1]).toBe(0);
+    });
+  });
+});

--- a/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
@@ -21,10 +21,19 @@ export function PlaybackPracticeRail() {
     handleSelectStemArtifact,
     higherCapoPreview,
     higherCapoShiftOptions,
+    handleSetPrecountClickCount,
+    handleSetPrecountEnabled,
     informationDensity,
     isStemPlayback,
     lowerCapoPreview,
     lowerCapoShiftOptions,
+    precountClickCount,
+    precountDisabledReason,
+    precountEnabled,
+    precountMaxClickCount,
+    precountMinClickCount,
+    precountTempoBpm,
+    canUsePrecount,
     previewArtifacts,
     selectedArtifactId,
     selectedArtifactTimestamp,
@@ -87,6 +96,54 @@ export function PlaybackPracticeRail() {
           value={capoSemitones}
         />
         <p className="artifact-meta playback-capo-control__summary">{capoShiftSummary}</p>
+      </section>
+
+      <section
+        className={`playback-precount-control${
+          canUsePrecount ? "" : " playback-precount-control--disabled"
+        }`}
+        aria-labelledby="playback-precount-heading"
+      >
+        <div className="playback-precount-control__header">
+          <div>
+            <p className="metric-label">Pre-count</p>
+            <h3 id="playback-precount-heading">Count-in</h3>
+          </div>
+          <label className="playback-precount-control__toggle">
+            <input
+              aria-label="Enable pre-count"
+              checked={precountEnabled}
+              disabled={!canUsePrecount}
+              onChange={(event) => handleSetPrecountEnabled(event.target.checked)}
+              type="checkbox"
+            />
+            <span>{precountEnabled ? "On" : "Off"}</span>
+          </label>
+        </div>
+        <div className="playback-precount-control__stepper" role="group" aria-label="Pre-count clicks">
+          <button
+            aria-label="Decrease pre-count clicks"
+            disabled={!canUsePrecount || precountClickCount <= precountMinClickCount}
+            onClick={() => handleSetPrecountClickCount(precountClickCount - 1)}
+            type="button"
+          >
+            -
+          </button>
+          <strong aria-live="polite">{precountClickCount}</strong>
+          <button
+            aria-label="Increase pre-count clicks"
+            disabled={!canUsePrecount || precountClickCount >= precountMaxClickCount}
+            onClick={() => handleSetPrecountClickCount(precountClickCount + 1)}
+            type="button"
+          >
+            +
+          </button>
+        </div>
+        <p className="artifact-meta playback-precount-control__summary">
+          {canUsePrecount && precountTempoBpm !== null
+            ? `${precountClickCount} clicks at ${precountTempoBpm.toFixed(1)} BPM`
+            : precountDisabledReason}
+        </p>
       </section>
 
       <section className="playback-picker-group playback-picker-group--compact">

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -6,8 +6,12 @@ import { api, type ArtifactSchema, type ProjectSchema } from "../../../lib/api";
 import { usePreferences } from "../../../lib/preferences";
 import { usePlayback } from "../playback-context";
 import {
+  DEFAULT_PRECOUNT_CLICK_COUNT,
+  MAX_PRECOUNT_CLICK_COUNT,
+  MIN_PRECOUNT_CLICK_COUNT,
   clearProjectPlaybackState,
   hasProjectPlaybackState,
+  normalizePrecountClickCount,
   readProjectPlaybackState,
   writeProjectPlaybackState,
   type StemControlState,
@@ -131,6 +135,8 @@ export function useProjectViewModel() {
   const [targetSelectorOpen, setTargetSelectorOpen] = useState(false);
   const [capoTransposeSemitones, setCapoTransposeSemitones] = useState(0);
   const [capoSelectorOpen, setCapoSelectorOpen] = useState(false);
+  const [precountEnabled, setPrecountEnabled] = useState(false);
+  const [precountClickCount, setPrecountClickCount] = useState(DEFAULT_PRECOUNT_CLICK_COUNT);
   const [sourceKeySelectorOpen, setSourceKeySelectorOpen] = useState(false);
   const [selectedArtifactId, setSelectedArtifactId] = useState<string | null>(null);
   const [selectedPrimaryArtifactId, setSelectedPrimaryArtifactId] = useState<string | null>(null);
@@ -541,6 +547,13 @@ export function useProjectViewModel() {
     : "";
 
   const detectedKey = parseKey(analysisQuery.data?.estimated_key);
+  const analyzedTempoBpm = analysisQuery.data?.tempo_bpm;
+  const precountTempoBpm =
+    typeof analyzedTempoBpm === "number" && Number.isFinite(analyzedTempoBpm) && analyzedTempoBpm > 0
+      ? analyzedTempoBpm
+      : null;
+  const canUsePrecount = precountTempoBpm !== null;
+  const precountDisabledReason = canUsePrecount ? null : "Waiting for BPM analysis";
   const sourceKeyOverride = parseStoredKey(projectQuery.data?.source_key_override);
   const sourceKeyBasis = sourceKeyOverride ?? detectedKey ?? null;
   const sourceKey = sourceKeyBasis ?? DEFAULT_KEY;
@@ -861,6 +874,17 @@ export function useProjectViewModel() {
     await togglePlayback();
   }
 
+  function handleSetPrecountEnabled(enabled: boolean) {
+    if (enabled && !canUsePrecount) {
+      return;
+    }
+    setPrecountEnabled(enabled);
+  }
+
+  function handleSetPrecountClickCount(value: number) {
+    setPrecountClickCount(normalizePrecountClickCount(value));
+  }
+
   function handleSeekTo(timeSeconds: number) {
     seekTo(timeSeconds);
   }
@@ -1124,6 +1148,8 @@ export function useProjectViewModel() {
         : resolveDefaultPlaybackDisplayMode(defaultPlaybackDisplayMode, false, false),
     );
     setCapoTransposeSemitones(storedPlaybackState.capoTransposeSemitones);
+    setPrecountEnabled(storedPlaybackState.precountEnabled);
+    setPrecountClickCount(storedPlaybackState.precountClickCount);
     setPlaybackDisplayModeSource(hasStoredPlayback ? "stored" : "default");
     setLyricsFollowEnabled(
       hasStoredPlayback
@@ -1263,6 +1289,8 @@ export function useProjectViewModel() {
       activeWorkspace,
       playbackDisplayMode,
       capoTransposeSemitones: capoSemitones,
+      precountEnabled,
+      precountClickCount,
       lyricsFollowEnabled,
       chordsFollowEnabled,
       stemControls,
@@ -1276,6 +1304,8 @@ export function useProjectViewModel() {
     hydratedProjectId,
     lyricsFollowEnabled,
     playbackDisplayMode,
+    precountClickCount,
+    precountEnabled,
     projectId,
     selectedArtifactId,
     selectedPrimaryArtifactId,
@@ -1493,6 +1523,9 @@ export function useProjectViewModel() {
       visibleStemArtifactIds: visibleStemArtifacts.map((artifact) => artifact.id),
       stemControls,
       durationHintSeconds: projectQuery.data?.duration_seconds ?? 0,
+      precountEnabled,
+      precountClickCount,
+      precountTempoBpm,
     });
   }, [
     hydratedProjectId,
@@ -1500,6 +1533,9 @@ export function useProjectViewModel() {
     projectId,
     projectQuery.data?.display_name,
     projectQuery.data?.duration_seconds,
+    precountClickCount,
+    precountEnabled,
+    precountTempoBpm,
     registerProjectSession,
     selectedPlaybackArtifact,
     stageSummary,
@@ -1564,6 +1600,8 @@ export function useProjectViewModel() {
     handleSelectWorkspace,
     handleSetChordsFollowEnabled,
     handleSetLyricsFollowEnabled,
+    handleSetPrecountClickCount,
+    handleSetPrecountEnabled,
     handleAcceptTabSuggestionGroup,
     handleApplyTabSuggestions,
     handleCloseTabImport,
@@ -1615,6 +1653,13 @@ export function useProjectViewModel() {
     playbackDurationSeconds,
     playbackTransportRef,
     playbackTimeSeconds,
+    precountClickCount,
+    precountDisabledReason,
+    precountEnabled,
+    precountMaxClickCount: MAX_PRECOUNT_CLICK_COUNT,
+    precountMinClickCount: MIN_PRECOUNT_CLICK_COUNT,
+    precountTempoBpm,
+    canUsePrecount,
     previewArtifacts,
     previewMutation,
     projectQuery,

--- a/apps/desktop/src/features/projects/playback-context.ts
+++ b/apps/desktop/src/features/projects/playback-context.ts
@@ -11,12 +11,16 @@ export type ProjectPlaybackSession = {
   visibleStemArtifactIds: string[];
   stemControls: Record<string, StemControlState>;
   durationHintSeconds: number;
+  precountEnabled: boolean;
+  precountClickCount: number;
+  precountTempoBpm: number | null;
 };
 
 export type PlaybackSnapshot = {
   session: ProjectPlaybackSession | null;
   playbackTimeSeconds: number;
   playbackDurationSeconds: number;
+  isPrecounting: boolean;
   isPlaying: boolean;
 };
 
@@ -24,6 +28,7 @@ export type PlaybackContextValue = {
   session: ProjectPlaybackSession | null;
   playbackTimeSeconds: number;
   playbackDurationSeconds: number;
+  isPrecounting: boolean;
   isPlaying: boolean;
   activateStemPlayback: () => Promise<void>;
   getPlaybackSnapshot: () => PlaybackSnapshot;

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -18,6 +18,7 @@ import {
   readPersistedPlaybackState,
   writePersistedPlaybackState,
 } from "./playbackPersistence";
+import { normalizePrecountClickCount } from "./projectPlaybackState";
 import {
   PRIMARY_MEDIA_KEY,
   SEEK_TOLERANCE_SECONDS,
@@ -37,10 +38,22 @@ import {
   loadStemBuffers,
 } from "./stemPlaybackBuffers";
 import { useMediaSessionControls, useSpacebarPlaybackShortcut } from "./playbackEffects";
+import { PRECOUNT_START_DELAY_SECONDS, schedulePrecountClaveClick } from "./precountSound";
+
+type ActivePrecount = {
+  context: AudioContext;
+  ownsContext: boolean;
+  sequence: number;
+  signature: string;
+  timeoutId: number;
+};
 
 export function PlaybackProvider({ children }: { children: ReactNode }) {
   const restoredPlaybackState = useRef(readPersistedPlaybackState()).current;
   const primaryAudioRef = useRef<HTMLAudioElement | null>(null);
+  const activePrecountRef = useRef<ActivePrecount | null>(null);
+  const precountAudioContextRef = useRef<AudioContext | null>(null);
+  const precountSequenceRef = useRef(0);
   const stemAudioRefs = useRef<Record<string, HTMLAudioElement | null>>({});
   const stemAudioContextRef = useRef<AudioContext | null>(null);
   const stemClockBlockedRef = useRef(false);
@@ -75,6 +88,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   const [playbackDurationSeconds, setPlaybackDurationSeconds] = useState(
     restoredPlaybackState?.session.durationHintSeconds ?? 0,
   );
+  const [isPrecounting, setIsPrecounting] = useState(false);
   const [isPlaying, setIsPlaying] = useState(restoredPlaybackState?.isPlaying ?? false);
 
   useEffect(() => {
@@ -197,6 +211,63 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     stemAudioContextRef.current = context;
     return context;
   }, [getAudioContextConstructor]);
+
+  const cancelPrecount = useStableCallback(function cancelPrecount() {
+    const activePrecount = activePrecountRef.current;
+    activePrecountRef.current = null;
+    precountSequenceRef.current += 1;
+    setIsPrecounting(false);
+
+    if (!activePrecount) {
+      return;
+    }
+
+    window.clearTimeout(activePrecount.timeoutId);
+    if (!activePrecount.ownsContext) {
+      return;
+    }
+
+    if (precountAudioContextRef.current === activePrecount.context) {
+      precountAudioContextRef.current = null;
+    }
+    if (activePrecount.context.state !== "closed") {
+      void activePrecount.context.close().catch(() => undefined);
+    }
+  });
+
+  const closeOwnedPrecountContext = useStableCallback(function closeOwnedPrecountContext(
+    activePrecount: ActivePrecount,
+  ) {
+    if (!activePrecount.ownsContext) {
+      return;
+    }
+    if (precountAudioContextRef.current === activePrecount.context) {
+      precountAudioContextRef.current = null;
+    }
+    if (activePrecount.context.state !== "closed") {
+      void activePrecount.context.close().catch(() => undefined);
+    }
+  });
+
+  const getPrecountAudioContext = useStableCallback(function getPrecountAudioContext() {
+    if (canUseStemClock()) {
+      const playbackContext = getStemAudioContext();
+      return playbackContext ? { context: playbackContext, ownsContext: false } : null;
+    }
+
+    if (precountAudioContextRef.current && precountAudioContextRef.current.state !== "closed") {
+      return { context: precountAudioContextRef.current, ownsContext: true };
+    }
+
+    const AudioContextConstructor = getAudioContextConstructor();
+    if (!AudioContextConstructor) {
+      return null;
+    }
+
+    const context = new AudioContextConstructor();
+    precountAudioContextRef.current = context;
+    return { context, ownsContext: true };
+  });
 
   const activateStemPlayback = useCallback(async () => {
     if (!canUseStemClock()) {
@@ -382,7 +453,11 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     return nextPlaybackState;
   });
 
-  const startStemPlayback = useStableCallback(async function startStemPlayback(targetSession: ProjectPlaybackSession, timeSeconds: number) {
+  const startStemPlayback = useStableCallback(async function startStemPlayback(
+    targetSession: ProjectPlaybackSession,
+    timeSeconds: number,
+    scheduledStartTimeSeconds?: number,
+  ) {
     if (!canUseStemClock()) {
       return false;
     }
@@ -444,13 +519,23 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     );
 
     targetPlaybackState.sources = nextSources;
+    const sourceStartTimeSeconds =
+      scheduledStartTimeSeconds === undefined
+        ? 0
+        : Math.max(targetPlaybackState.context.currentTime, scheduledStartTimeSeconds);
+    const clockStartTimeSeconds =
+      scheduledStartTimeSeconds === undefined
+        ? targetPlaybackState.context.currentTime
+        : sourceStartTimeSeconds;
     targetPlaybackState.offsetSeconds = nextTime;
-    targetPlaybackState.startedAtContextTime = targetPlaybackState.context.currentTime;
+    targetPlaybackState.startedAtContextTime = clockStartTimeSeconds;
     targetPlaybackState.isPlaying = true;
     syncStemElementTimes(targetPlaybackState.artifactIds, nextTime);
     applyStemVolumes(targetSession);
 
-    Object.values(nextSources).forEach((sourceNode) => sourceNode.start(0, nextTime));
+    Object.values(nextSources).forEach((sourceNode) =>
+      sourceNode.start(sourceStartTimeSeconds, nextTime),
+    );
 
     setPlaybackTimeSeconds(nextTime);
     setPlaybackDurationSeconds(targetPlaybackState.durationSeconds);
@@ -580,6 +665,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       session: activeSession,
       playbackTimeSeconds: readMasterTime(activeSession),
       playbackDurationSeconds: playbackDurationSecondsRef.current,
+      isPrecounting: Boolean(activePrecountRef.current),
       isPlaying: isPlayingRef.current,
     };
   });
@@ -867,6 +953,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   });
 
   const pausePlayback = useCallback(() => {
+    cancelPrecount();
     const pendingTransition = pendingTransitionRef.current;
     if (pendingTransition) {
       pendingTransition.shouldPlay = false;
@@ -890,11 +977,20 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     setIsPlaying(false);
   }, [
     canUseStemClock,
+    cancelPrecount,
     getActiveMediaElements,
     stopStemSources,
   ]);
 
-  const playPlayback = useCallback(async () => {
+  const playPlaybackImmediately = useStableCallback(async function playPlaybackImmediately(
+    {
+      forceStartAtZero = false,
+      scheduledStemStartTimeSeconds,
+    }: {
+      forceStartAtZero?: boolean;
+      scheduledStemStartTimeSeconds?: number;
+    } = {},
+  ) {
     const targetSession = sessionRef.current;
     if (!targetSession) {
       return;
@@ -902,9 +998,13 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
     tryCompletePendingTransition();
 
+    const masterTime = forceStartAtZero ? 0 : readMasterTime(targetSession);
     if (canUseStemClock()) {
-      const masterTime = readMasterTime(targetSession);
-      const started = await startStemPlayback(targetSession, masterTime);
+      const started = await startStemPlayback(
+        targetSession,
+        masterTime,
+        scheduledStemStartTimeSeconds,
+      );
       if (started) {
         return;
       }
@@ -915,7 +1015,6 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       return;
     }
 
-    const masterTime = readMasterTime(targetSession);
     activeElements.forEach((element) => {
       if (Math.abs(element.currentTime - masterTime) > SEEK_TOLERANCE_SECONDS) {
         element.currentTime = masterTime;
@@ -927,24 +1026,170 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       activeElements.map((element) => Promise.resolve(element.play())),
     );
     setIsPlaying(results.some((result) => result.status === "fulfilled"));
+  });
+
+  const startPrecountThenPlayback = useStableCallback(async function startPrecountThenPlayback(
+    targetSession: ProjectPlaybackSession,
+    startTimeSeconds: number,
+  ) {
+    const tempoBpm = targetSession.precountTempoBpm;
+    if (!targetSession.precountEnabled || typeof tempoBpm !== "number" || !Number.isFinite(tempoBpm) || tempoBpm <= 0) {
+      return false;
+    }
+    if (startTimeSeconds > SEEK_TOLERANCE_SECONDS) {
+      return false;
+    }
+
+    const clickCount = normalizePrecountClickCount(targetSession.precountClickCount);
+    const signature = playbackSignature(targetSession);
+    cancelPrecount();
+    const sequence = ++precountSequenceRef.current;
+
+    let preparedStemPlaybackState: StemPlaybackState | null = null;
+    const willUsePlaybackAudioContext = canUseStemClock();
+    if (willUsePlaybackAudioContext) {
+      preparedStemPlaybackState = await prepareStemPlaybackState(targetSession);
+      if (!preparedStemPlaybackState) {
+        return false;
+      }
+      if (precountSequenceRef.current !== sequence || playbackSignature(sessionRef.current) !== signature) {
+        return true;
+      }
+    }
+
+    const precountAudio = getPrecountAudioContext();
+    if (!precountAudio) {
+      return false;
+    }
+
+    try {
+      if (precountAudio.context.state === "suspended") {
+        await precountAudio.context.resume();
+      }
+    } catch {
+      if (precountAudio.ownsContext && precountAudioContextRef.current === precountAudio.context) {
+        precountAudioContextRef.current = null;
+      }
+      if (precountAudio.ownsContext) {
+        void precountAudio.context.close().catch(() => undefined);
+      }
+      return false;
+    }
+
+    if (precountAudio.context.state !== "running") {
+      if (precountAudio.ownsContext && precountAudioContextRef.current === precountAudio.context) {
+        precountAudioContextRef.current = null;
+      }
+      if (precountAudio.ownsContext) {
+        void precountAudio.context.close().catch(() => undefined);
+      }
+      return false;
+    }
+
+    if (precountSequenceRef.current !== sequence || playbackSignature(sessionRef.current) !== signature) {
+      if (precountAudio.ownsContext && precountAudioContextRef.current === precountAudio.context) {
+        precountAudioContextRef.current = null;
+      }
+      if (precountAudio.ownsContext) {
+        void precountAudio.context.close().catch(() => undefined);
+      }
+      return true;
+    }
+
+    getActiveMediaElements(targetSession).forEach((element) => {
+      if (Math.abs(element.currentTime) > SEEK_TOLERANCE_SECONDS) {
+        element.currentTime = 0;
+      }
+    });
+    if (preparedStemPlaybackState) {
+      preparedStemPlaybackState.offsetSeconds = 0;
+      syncStemElementTimes(preparedStemPlaybackState.artifactIds, 0);
+      setPlaybackDurationSeconds(preparedStemPlaybackState.durationSeconds);
+    }
+    setPlaybackTimeSeconds(0);
+
+    const beatSeconds = 60 / tempoBpm;
+    const firstClickTimeSeconds = precountAudio.context.currentTime + PRECOUNT_START_DELAY_SECONDS;
+    const playbackStartTimeSeconds = firstClickTimeSeconds + clickCount * beatSeconds;
+    for (let index = 0; index < clickCount; index += 1) {
+      schedulePrecountClaveClick({
+        audioContext: precountAudio.context,
+        startTimeSeconds: firstClickTimeSeconds + index * beatSeconds,
+      });
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      const activePrecount = activePrecountRef.current;
+      if (!activePrecount || activePrecount.sequence !== sequence || activePrecount.signature !== signature) {
+        return;
+      }
+
+      activePrecountRef.current = null;
+      setIsPrecounting(false);
+      closeOwnedPrecountContext(activePrecount);
+
+      if (playbackSignature(sessionRef.current) !== signature) {
+        return;
+      }
+
+      void playPlaybackImmediately({
+        forceStartAtZero: true,
+        scheduledStemStartTimeSeconds: willUsePlaybackAudioContext
+          ? playbackStartTimeSeconds
+          : undefined,
+      });
+    }, Math.max(0, (playbackStartTimeSeconds - precountAudio.context.currentTime) * 1000));
+
+    activePrecountRef.current = {
+      context: precountAudio.context,
+      ownsContext: precountAudio.ownsContext,
+      sequence,
+      signature,
+      timeoutId,
+    };
+    setIsPrecounting(true);
+    return true;
+  });
+
+  const playPlayback = useCallback(async () => {
+    if (activePrecountRef.current) {
+      return;
+    }
+
+    const targetSession = sessionRef.current;
+    if (!targetSession) {
+      return;
+    }
+
+    tryCompletePendingTransition();
+
+    const masterTime = readMasterTime(targetSession);
+    if (await startPrecountThenPlayback(targetSession, masterTime)) {
+      return;
+    }
+
+    await playPlaybackImmediately();
   }, [
-    applyStemVolumes,
-    canUseStemClock,
-    getActiveMediaElements,
+    playPlaybackImmediately,
     readMasterTime,
-    startStemPlayback,
+    startPrecountThenPlayback,
     tryCompletePendingTransition,
   ]);
 
   const togglePlayback = useCallback(async () => {
+    if (activePrecountRef.current) {
+      cancelPrecount();
+      return;
+    }
     if (isPlayingRef.current) {
       pausePlayback();
       return;
     }
     await playPlayback();
-  }, [pausePlayback, playPlayback]);
+  }, [cancelPrecount, pausePlayback, playPlayback]);
 
   const seekTo = useCallback((timeSeconds: number) => {
+    cancelPrecount();
     const nextTime = clampTime(timeSeconds, playbackDurationSecondsRef.current);
     const pendingTransition = pendingTransitionRef.current;
     if (pendingTransition) {
@@ -973,7 +1218,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       element.currentTime = nextTime;
     });
     setPlaybackTimeSeconds(nextTime);
-  }, [canUseStemClock, getActiveMediaElements, startStemPlayback]);
+  }, [canUseStemClock, cancelPrecount, getActiveMediaElements, startStemPlayback]);
 
   const seekBy = useCallback(
     (secondsDelta: number) => {
@@ -983,6 +1228,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   );
 
   const stopPlayback = useCallback(() => {
+    cancelPrecount();
     clearPendingTransition();
     if (stemPlaybackRef.current) {
       stopStemSources(stemPlaybackRef.current, false);
@@ -997,6 +1243,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     setIsPlaying(false);
     updateDurationFromActiveMedia();
   }, [
+    cancelPrecount,
     clearPendingTransition,
     getRenderedMediaElements,
     stopStemSources,
@@ -1017,6 +1264,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     const nextSignature = playbackSignature(nextSession);
 
     if (previousSession && previousSession.projectId !== nextSession.projectId) {
+      cancelPrecount();
       clearPendingTransition();
       closePlaybackAudioContext();
       getRenderedMediaElements(previousSession).forEach((element) => {
@@ -1027,6 +1275,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       setPlaybackDurationSeconds(nextSession.durationHintSeconds || 0);
       setIsPlaying(false);
     } else if (previousSession && previousSignature !== nextSignature) {
+      cancelPrecount();
       const nextTime = readMasterTime(previousSession);
       const shouldPlay = isPlayingRef.current;
       const primarySwap =
@@ -1060,6 +1309,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     sessionRef.current = nextSession;
     setSession(nextSession);
   }, [
+    cancelPrecount,
     clearPendingTransition,
     closePlaybackAudioContext,
     disposeStemPlaybackState,
@@ -1086,9 +1336,10 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
   useEffect(
     () => () => {
+      cancelPrecount();
       closePlaybackAudioContext();
     },
-    [closePlaybackAudioContext],
+    [cancelPrecount, closePlaybackAudioContext],
   );
 
   useMediaSessionControls({
@@ -1108,6 +1359,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       session,
       playbackTimeSeconds,
       playbackDurationSeconds,
+      isPrecounting,
       isPlaying,
       activateStemPlayback,
       getPlaybackSnapshot,
@@ -1124,6 +1376,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       dismissSession,
       activateStemPlayback,
       getPlaybackSnapshot,
+      isPrecounting,
       isPlaying,
       pausePlayback,
       playbackDurationSeconds,

--- a/apps/desktop/src/features/projects/playbackPersistence.ts
+++ b/apps/desktop/src/features/projects/playbackPersistence.ts
@@ -1,7 +1,7 @@
 import type {
   ProjectPlaybackSession,
 } from "./playback-context";
-import type { StemControlState } from "./projectPlaybackState";
+import { normalizePrecountClickCount, type StemControlState } from "./projectPlaybackState";
 
 export type PersistedPlaybackState = {
   session: ProjectPlaybackSession;
@@ -71,6 +71,14 @@ function normalizeProjectPlaybackSession(value: unknown): ProjectPlaybackSession
       candidate.durationHintSeconds >= 0
         ? candidate.durationHintSeconds
         : 0,
+    precountEnabled: Boolean(candidate.precountEnabled),
+    precountClickCount: normalizePrecountClickCount(candidate.precountClickCount),
+    precountTempoBpm:
+      typeof candidate.precountTempoBpm === "number" &&
+      Number.isFinite(candidate.precountTempoBpm) &&
+      candidate.precountTempoBpm > 0
+        ? candidate.precountTempoBpm
+        : null,
   };
 }
 

--- a/apps/desktop/src/features/projects/precountSound.ts
+++ b/apps/desktop/src/features/projects/precountSound.ts
@@ -1,0 +1,32 @@
+export const PRECOUNT_START_DELAY_SECONDS = 0.035;
+export const PRECOUNT_GAIN = 0.36;
+
+export function schedulePrecountClaveClick({
+  audioContext,
+  startTimeSeconds,
+}: {
+  audioContext: AudioContext;
+  startTimeSeconds: number;
+}) {
+  const oscillator = audioContext.createOscillator();
+  const gainNode = audioContext.createGain();
+  const safeStartTimeSeconds = Math.max(audioContext.currentTime, startTimeSeconds);
+  const peakTimeSeconds = safeStartTimeSeconds + 0.003;
+  const stopTimeSeconds = safeStartTimeSeconds + 0.072;
+
+  oscillator.type = "triangle";
+  oscillator.frequency.setValueAtTime(2100, safeStartTimeSeconds);
+  oscillator.frequency.exponentialRampToValueAtTime(1450, stopTimeSeconds);
+  gainNode.gain.setValueAtTime(0.0001, safeStartTimeSeconds);
+  gainNode.gain.exponentialRampToValueAtTime(PRECOUNT_GAIN, peakTimeSeconds);
+  gainNode.gain.exponentialRampToValueAtTime(0.0001, stopTimeSeconds);
+
+  oscillator.connect(gainNode);
+  gainNode.connect(audioContext.destination);
+  oscillator.onended = () => {
+    oscillator.disconnect();
+    gainNode.disconnect();
+  };
+  oscillator.start(safeStartTimeSeconds);
+  oscillator.stop(stopTimeSeconds + 0.006);
+}

--- a/apps/desktop/src/features/projects/projectPlaybackState.ts
+++ b/apps/desktop/src/features/projects/projectPlaybackState.ts
@@ -10,6 +10,10 @@ export type StemControlState = {
   solo: boolean;
 };
 
+export const DEFAULT_PRECOUNT_CLICK_COUNT = 4;
+export const MIN_PRECOUNT_CLICK_COUNT = 1;
+export const MAX_PRECOUNT_CLICK_COUNT = 8;
+
 export type StoredProjectPlaybackState = {
   selectedArtifactId: string | null;
   selectedPrimaryArtifactId: string | null;
@@ -17,6 +21,8 @@ export type StoredProjectPlaybackState = {
   activeWorkspace: ProjectWorkspaceMode;
   playbackDisplayMode: PlaybackDisplayMode;
   capoTransposeSemitones: number;
+  precountEnabled: boolean;
+  precountClickCount: number;
   lyricsFollowEnabled: boolean;
   chordsFollowEnabled: boolean;
   stemControls: Record<string, StemControlState>;
@@ -32,6 +38,8 @@ const DEFAULT_STORED_PROJECT_PLAYBACK_STATE: StoredProjectPlaybackState = {
   activeWorkspace: "project",
   playbackDisplayMode: "combined",
   capoTransposeSemitones: 0,
+  precountEnabled: false,
+  precountClickCount: DEFAULT_PRECOUNT_CLICK_COUNT,
   lyricsFollowEnabled: true,
   chordsFollowEnabled: true,
   stemControls: {},
@@ -43,6 +51,16 @@ function normalizeTransposeSemitones(value: unknown) {
     return 0;
   }
   return Math.min(12, Math.max(-12, Math.trunc(value)));
+}
+
+export function normalizePrecountClickCount(value: unknown) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_PRECOUNT_CLICK_COUNT;
+  }
+  return Math.min(
+    MAX_PRECOUNT_CLICK_COUNT,
+    Math.max(MIN_PRECOUNT_CLICK_COUNT, Math.trunc(value)),
+  );
 }
 
 function normalizeStemControlState(value: unknown): StemControlState {
@@ -95,6 +113,11 @@ function normalizeStoredProjectPlaybackState(value: unknown): StoredProjectPlayb
       ? candidate.playbackDisplayMode
       : DEFAULT_STORED_PROJECT_PLAYBACK_STATE.playbackDisplayMode,
     capoTransposeSemitones: normalizeTransposeSemitones(candidate.capoTransposeSemitones),
+    precountEnabled:
+      typeof candidate.precountEnabled === "boolean"
+        ? candidate.precountEnabled
+        : DEFAULT_STORED_PROJECT_PLAYBACK_STATE.precountEnabled,
+    precountClickCount: normalizePrecountClickCount(candidate.precountClickCount),
     lyricsFollowEnabled:
       typeof candidate.lyricsFollowEnabled === "boolean"
         ? candidate.lyricsFollowEnabled

--- a/apps/desktop/src/styles/project-playback.css
+++ b/apps/desktop/src/styles/project-playback.css
@@ -720,6 +720,89 @@
   margin: 0;
 }
 
+.playback-precount-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  padding: 0.8rem;
+  border: 1px solid var(--divider);
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--surface-muted) 74%, transparent);
+}
+
+.playback-precount-control--disabled {
+  opacity: 0.72;
+}
+
+.playback-precount-control__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.playback-precount-control__header h3 {
+  margin: 0.15rem 0 0;
+  font-size: 1rem;
+}
+
+.playback-precount-control__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-height: 2.2rem;
+  padding: 0.4rem 0.62rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--panel) 72%, var(--panel-strong) 28%);
+  color: var(--text);
+  font-size: 0.84rem;
+  font-weight: 800;
+}
+
+.playback-precount-control__toggle input {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--playback-accent);
+}
+
+.playback-precount-control__stepper {
+  display: grid;
+  grid-template-columns: 2.6rem minmax(0, 1fr) 2.6rem;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.playback-precount-control__stepper button,
+.playback-precount-control__stepper strong {
+  display: inline-grid;
+  place-items: center;
+  min-height: 2.8rem;
+  border-radius: 12px;
+}
+
+.playback-precount-control__stepper button {
+  border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+  background: color-mix(in srgb, var(--panel) 68%, var(--panel-strong) 32%);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 1.35rem;
+}
+
+.playback-precount-control__stepper button:disabled {
+  cursor: not-allowed;
+  opacity: 0.56;
+}
+
+.playback-precount-control__stepper strong {
+  background: color-mix(in srgb, var(--panel-strong) 76%, transparent);
+  font-size: 1.25rem;
+}
+
+.playback-precount-control__summary {
+  margin: 0;
+}
+
 .playback-picker-group--compact {
   padding: 0.85rem;
   border-radius: 18px;


### PR DESCRIPTION
## Summary

- Add a BPM-gated pre-count control to the playback rail.
- Schedule generated clave-style count-in clicks on the shared playback clock.
- Preserve zero-offset starts for source, mix, and stem playback after the count-in.

## Testing

- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop exec vitest run`
