### PR TITLE
feat: revamp responsive desktop UI

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -69,7 +69,7 @@ This document is an engineering notice and distribution checklist, not legal adv
 - **Source:** <https://github.com/rusqlite/rusqlite> and <https://sqlite.org/>
 - **Notes:** Used by the embedded Android backend. Desktop persistence remains in the Python backend.
 
-### React, Vite, TanStack Query, openapi-fetch, openapi-typescript
+### React, Vite, TanStack Query, openapi-fetch, openapi-typescript, lucide-react
 
 - See each project's own license. The installed JavaScript tree is primarily permissive, with some non-copyleft notice/data licenses such as MPL-2.0 (`lightningcss`), BlueOak-1.0.0 (`lru-cache` / `minimatch`), CC-BY-4.0 (`caniuse-lite` browser data), and CC0-1.0 (`mdn-data`).
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -19,6 +19,7 @@
     "@tauri-apps/api": "^2.4.0",
     "@tauri-apps/plugin-dialog": "^2.2.1",
     "@tuneforge/shared-types": "workspace:*",
+    "lucide-react": "^1.14.0",
     "openapi-fetch": "^0.17.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/apps/desktop/src/App.library.test.tsx
+++ b/apps/desktop/src/App.library.test.tsx
@@ -190,6 +190,7 @@ describe("Desktop app library", () => {
     if (showInspectorButton) {
       await user.click(showInspectorButton);
     }
+    await user.click(screen.getByRole("tab", { name: "Analysis" }));
     await user.click(screen.getByRole("button", { name: "Delete Project" }));
 
     expect(mockDeleteProject).toHaveBeenCalledWith("proj_123");

--- a/apps/desktop/src/App.mobile.test.tsx
+++ b/apps/desktop/src/App.mobile.test.tsx
@@ -23,6 +23,7 @@ describe("Desktop app mobile capability gates", () => {
 
     renderApp(["/projects/proj_123"]);
 
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
     expect(await screen.findByRole("heading", { name: "Processing" })).toBeInTheDocument();
     expect(
       await screen.findByText("Local generation requires GPU acceleration on this device."),

--- a/apps/desktop/src/App.project-analysis-mix.test.tsx
+++ b/apps/desktop/src/App.project-analysis-mix.test.tsx
@@ -31,6 +31,21 @@ describe("Desktop app project analysis mix", () => {
     await user.click(screen.getByRole("tab", { name: "Playback" }));
   }
 
+  async function openProjectPanel(user: ReturnType<typeof userEvent.setup>, name: "Studio" | "Analysis") {
+    const tab = screen.getByRole("tab", { name });
+    if (tab.getAttribute("aria-selected") !== "true") {
+      await user.click(tab);
+    }
+  }
+
+  async function openStudioPanel(user: ReturnType<typeof userEvent.setup>) {
+    await openProjectPanel(user, "Studio");
+  }
+
+  async function openAnalysisPanel(user: ReturnType<typeof userEvent.setup>) {
+    await openProjectPanel(user, "Analysis");
+  }
+
   async function switchToLyricsOnly(user: ReturnType<typeof userEvent.setup>) {
     const lyricsToggle = screen.getByRole("button", { name: "Lyrics" });
     const chordsToggle = screen.getByRole("button", { name: "Chords" });
@@ -105,12 +120,14 @@ describe("Desktop app project analysis mix", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openStudioPanel(user);
     await user.click(screen.getByRole("button", { name: "Analyze Track" }));
 
     expect(mockAnalyzeProject).toHaveBeenCalledWith("proj_123");
   });
 
   it("surfaces detected tempo in the analysis panel", async () => {
+    const user = userEvent.setup();
     setProjectAnalysis("proj_123", {
       project_id: "proj_123",
       estimated_key: "G major",
@@ -125,6 +142,7 @@ describe("Desktop app project analysis mix", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openAnalysisPanel(user);
     expect(screen.getByText("121.5")).toBeInTheDocument();
     expect(screen.getByText("BPM")).toBeInTheDocument();
   });
@@ -134,6 +152,7 @@ describe("Desktop app project analysis mix", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openStudioPanel(user);
     await user.click(screen.getByRole("button", { name: "Refresh Chords" }));
 
     expect(mockCreateChords).toHaveBeenCalledWith("proj_123", {
@@ -153,6 +172,7 @@ describe("Desktop app project analysis mix", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openStudioPanel(user);
     await user.click(screen.getByRole("button", { name: "Refresh Chords" }));
     await user.click(screen.getByRole("button", { name: "Generate Stems" }));
 
@@ -199,6 +219,7 @@ describe("Desktop app project analysis mix", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openStudioPanel(user);
     await user.click(screen.getByRole("button", { name: "Refresh Chords" }));
     await user.click(screen.getByRole("button", { name: "Generate Stems" }));
 
@@ -234,6 +255,7 @@ describe("Desktop app project analysis mix", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openStudioPanel(user);
     await user.click(screen.getByRole("button", { name: "Generate Lyrics" }));
 
     expect(mockCreateLyrics).toHaveBeenCalledWith("proj_123", { force: false });
@@ -574,6 +596,7 @@ describe("Desktop app project analysis mix", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openStudioPanel(user);
     await user.click(screen.getByRole("button", { name: "Refresh Lyrics" }));
 
     expect(mockConfirm).toHaveBeenCalledWith(
@@ -605,6 +628,7 @@ describe("Desktop app project analysis mix", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openStudioPanel(user);
     await user.click(screen.getByRole("button", { name: "Refresh Chords" }));
 
     expect(mockConfirm).toHaveBeenCalledWith(
@@ -654,6 +678,7 @@ describe("Desktop app project analysis mix", () => {
     expect(screen.queryByText("A#/Bb")).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("tab", { name: "Project" }));
+    await openStudioPanel(user);
     await ensureInspectorVisible(user);
     expect(
       getByAriaKeyLabel(screen.getByText("Source Key", { selector: "span" }).closest("div") as HTMLElement, "Ebm"),
@@ -701,12 +726,15 @@ describe("Desktop app project analysis mix", () => {
     expect(getByAriaKeyLabel(screen.getByRole("group", { name: "Current chord card" }), "D#m / Ebm")).toBeInTheDocument();
 
     await user.click(screen.getByRole("tab", { name: "Project" }));
+    await openStudioPanel(user);
     await ensureInspectorVisible(user);
     const sourceKeyCard = screen.getByText("Source Key", { selector: "span" }).closest("div") as HTMLElement;
     expect(getByAriaKeyLabel(sourceKeyCard, "D#m / Ebm")).toBeInTheDocument();
+    await openAnalysisPanel(user);
     const estimatedKeyCard = screen.getByText("Estimated Key", { selector: "span" }).closest("div") as HTMLElement;
     expect(getByAriaKeyLabel(estimatedKeyCard, "D#m / Ebm")).toBeInTheDocument();
 
+    await openStudioPanel(user);
     await user.click(screen.getByLabelText("Target Key"));
     const targetKeyList = screen.getByRole("listbox", { name: "Target key options" });
     expect(getAllByAriaKeyLabel(targetKeyList as HTMLElement, "D#m / Ebm").length).toBeGreaterThan(0);
@@ -730,14 +758,19 @@ describe("Desktop app project analysis mix", () => {
     const targetKeyCard = screen.getAllByText("Target Key", { selector: "span" })[0]?.closest("div") as HTMLElement;
     expect(within(targetKeyCard).getByText("G#")).toBeInTheDocument();
 
+    await openAnalysisPanel(user);
     await user.click(screen.getByText("Correct source key for this project"));
     await user.click(screen.getByLabelText("Project Source Key"));
     await user.click(screen.getByRole("option", { name: "G#" }));
 
+    await openStudioPanel(user);
     const sourceKeyCard = screen.getByText("Source Key", { selector: "span" }).closest("div") as HTMLElement;
+    const updatedTargetKeyCard = screen
+      .getAllByText("Target Key", { selector: "span" })[0]
+      ?.closest("div") as HTMLElement;
     expect(mockUpdateProject).toHaveBeenCalledWith("proj_123", { source_key_override: "8:major" });
     expect(within(sourceKeyCard).getByText("G#")).toBeInTheDocument();
-    expect(within(targetKeyCard).getByText("A")).toBeInTheDocument();
+    expect(within(updatedTargetKeyCard).getByText("A")).toBeInTheDocument();
   });
 
   it("creates a new mix from the project source key override and target controls", async () => {
@@ -748,9 +781,11 @@ describe("Desktop app project analysis mix", () => {
     await ensureInspectorVisible(user);
     const sourceList = screen.getByRole("group", { name: "Source and mix list" });
     await user.click(within(sourceList).getByRole("button", { name: /Source Track/i }));
+    await openAnalysisPanel(user);
     await user.click(screen.getByText("Correct source key for this project"));
     await user.click(screen.getByLabelText("Project Source Key"));
     await user.click(screen.getByRole("option", { name: "A" }));
+    await openStudioPanel(user);
     await user.click(screen.getByLabelText("Raise target key"));
     await user.click(screen.getByRole("button", { name: "Create Mix" }));
 
@@ -796,6 +831,7 @@ describe("Desktop app project analysis mix", () => {
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
     await ensureInspectorVisible(user);
+    await openAnalysisPanel(user);
     await user.click(screen.getByText("Correct source key for this project"));
     await user.click(screen.getByLabelText("Project Source Key"));
     await user.click(screen.getByRole("option", { name: "A" }));
@@ -805,6 +841,7 @@ describe("Desktop app project analysis mix", () => {
     expect(getByAriaKeyLabel(screen.getByRole("group", { name: "Current chord card" }), "A")).toBeInTheDocument();
 
     await user.click(screen.getByRole("tab", { name: "Project" }));
+    await openStudioPanel(user);
     const savedMixList = screen.getByRole("group", { name: "Saved mix list" });
     await user.click(within(savedMixList).getByRole("button", { name: /Practice Mix/i }));
 
@@ -977,6 +1014,7 @@ describe("Desktop app project analysis mix", () => {
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
     await ensureInspectorVisible(user);
+    await openAnalysisPanel(user);
     await user.click(screen.getByText("Correct source key for this project"));
     await user.click(screen.getByLabelText("Project Source Key"));
 
@@ -1037,7 +1075,9 @@ describe("Desktop app project analysis mix", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openStudioPanel(user);
     await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    await openAnalysisPanel(user);
     await user.click(screen.getByText("Show raw artifacts and processing history"));
 
     const jobHistory = screen.getByText("Show raw artifacts and processing history").closest("details");

--- a/apps/desktop/src/App.project-playback-stems.test.tsx
+++ b/apps/desktop/src/App.project-playback-stems.test.tsx
@@ -56,12 +56,32 @@ describe("Desktop app project playback stems", () => {
     }
   }
 
+  async function openProjectPanel(user: ReturnType<typeof userEvent.setup>, name: "Studio" | "Analysis") {
+    const tab = screen.getByRole("tab", { name });
+    if (tab.getAttribute("aria-selected") !== "true") {
+      await user.click(tab);
+    }
+  }
+
+  async function openStudioPanel(user: ReturnType<typeof userEvent.setup>) {
+    await openProjectPanel(user, "Studio");
+  }
+
+  async function openAnalysisPanel(user: ReturnType<typeof userEvent.setup>) {
+    await openProjectPanel(user, "Analysis");
+  }
+
+  async function generateStems(user: ReturnType<typeof userEvent.setup>) {
+    await openStudioPanel(user);
+    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+  }
+
   it("switches between source playback and stems", async () => {
     const user = userEvent.setup();
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    await generateStems(user);
 
     expect(mockCreateStems).toHaveBeenCalledWith(
       "proj_123",
@@ -92,7 +112,7 @@ describe("Desktop app project playback stems", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    await generateStems(user);
 
     await openPlaybackWorkspace(user);
     const stemList = await screen.findByRole("group", { name: "Playback stem list" });
@@ -151,11 +171,12 @@ describe("Desktop app project playback stems", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    await generateStems(user);
 
+    await openStudioPanel(user);
     const savedMixList = screen.getByRole("group", { name: "Saved mix list" });
     await user.click(within(savedMixList).getByRole("button", { name: /Practice Mix/i }));
-    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    await generateStems(user);
 
     expect(mockCreateStems).toHaveBeenLastCalledWith(
       "proj_123",
@@ -426,7 +447,7 @@ describe("Desktop app project playback stems", () => {
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    await generateStems(user);
     await openPlaybackWorkspace(user);
     const stemList = await screen.findByRole("group", { name: "Playback stem list" });
     await user.click(within(stemList).getAllByRole("button", { name: /Vocals/i })[0] as HTMLElement);
@@ -512,7 +533,7 @@ describe("Desktop app project playback stems", () => {
 
     setPlaybackPosition("32.481");
 
-    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    await generateStems(user);
     await openPlaybackWorkspace(user);
     const stemList = await screen.findByRole("group", { name: "Playback stem list" });
     const firstStemSourceIndex = getMockAudioContexts()[0]?.createdSources.length ?? 0;
@@ -553,7 +574,7 @@ describe("Desktop app project playback stems", () => {
 
     setPlaybackPosition("41.662");
 
-    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    await generateStems(user);
     await openPlaybackWorkspace(user);
     const stemList = await screen.findByRole("group", { name: "Playback stem list" });
     await user.click(within(stemList).getAllByRole("button", { name: /Vocals/i })[0] as HTMLElement);
@@ -580,7 +601,7 @@ describe("Desktop app project playback stems", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    await generateStems(user);
     const vocalAudio = findAudioByArtifactId("art_200");
     const instrumentalAudio = findAudioByArtifactId("art_201");
     await waitFor(() =>
@@ -594,6 +615,7 @@ describe("Desktop app project playback stems", () => {
     );
     expect(vocalAudio).toHaveAttribute("preload", "metadata");
     expect(instrumentalAudio).toHaveAttribute("preload", "metadata");
+    await openStudioPanel(user);
     expect(screen.getByRole("heading", { name: "Source Track" })).toBeInTheDocument();
   });
 
@@ -608,7 +630,7 @@ describe("Desktop app project playback stems", () => {
 
     setPlaybackPosition("18.789");
 
-    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    await generateStems(user);
     await openPlaybackWorkspace(user);
     const stemList = await screen.findByRole("group", { name: "Playback stem list" });
     const firstStemSourceIndex = getMockAudioContexts()[0]?.createdSources.length ?? 0;
@@ -641,7 +663,7 @@ describe("Desktop app project playback stems", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    await generateStems(user);
 
     await openPlaybackWorkspace(user);
     const stemList = await screen.findByRole("group", { name: "Playback stem list" });
@@ -682,6 +704,7 @@ describe("Desktop app project playback stems", () => {
     const stemError = await screen.findByRole("group", { name: "Stem error" });
     expect(within(stemError).getByText("Demucs failed to separate the track.")).toBeInTheDocument();
 
+    await openAnalysisPanel(user);
     await user.click(screen.getByText("Show raw artifacts and processing history"));
     const jobHistory = screen.getByText("Show raw artifacts and processing history").closest("details");
     expect(jobHistory).not.toBeNull();
@@ -747,6 +770,7 @@ describe("Desktop app project playback stems", () => {
     await ensureInspectorVisible(user);
     const sourceList = screen.getByRole("group", { name: "Source and mix list" });
     await user.click(within(sourceList).getByRole("button", { name: /Source Track/i }));
+    await openAnalysisPanel(user);
     await user.click(screen.getByRole("button", { name: "Export Selected Audio" }));
 
     expect(mockSave).toHaveBeenCalled();
@@ -780,12 +804,14 @@ describe("Desktop app project playback stems", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    await generateStems(user);
 
+    await openStudioPanel(user);
     const savedMixList = screen.getByRole("group", { name: "Saved mix list" });
     await user.click(within(savedMixList).getByRole("button", { name: /Practice Mix/i }));
-    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    await generateStems(user);
 
+    await openStudioPanel(user);
     await user.click(screen.getByRole("button", { name: "Collapse sources rail" }));
 
     const stemSummaryChip = screen.getByText("Stem").closest(".rail-summary-chip");
@@ -799,7 +825,7 @@ describe("Desktop app project playback stems", () => {
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    await generateStems(user);
     expect(mockCreateStems).toHaveBeenCalledTimes(1);
 
     await user.click(screen.getByRole("button", { name: "Rebuild Stems" }));
@@ -840,7 +866,7 @@ describe("Desktop app project playback stems", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    await generateStems(user);
 
     expect(mockConfirm).toHaveBeenCalledWith(
       expect.stringContaining("Existing chord edits will be replaced"),
@@ -880,7 +906,7 @@ describe("Desktop app project playback stems", () => {
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
     const savedMixList = screen.getByRole("group", { name: "Saved mix list" });
     await user.click(within(savedMixList).getByRole("button", { name: /Practice Mix/i }));
-    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    await generateStems(user);
 
     expect(mockConfirm).not.toHaveBeenCalled();
     expect(mockCreateStems).toHaveBeenCalledWith(

--- a/apps/desktop/src/App.project-precount.test.tsx
+++ b/apps/desktop/src/App.project-precount.test.tsx
@@ -29,6 +29,10 @@ async function openPlaybackWorkspace(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole("tab", { name: "Playback" }));
 }
 
+async function openStudioPanel(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("tab", { name: "Studio" }));
+}
+
 function setPlaybackPosition(value: string) {
   fireEvent.change(screen.getByLabelText("Playback position"), { target: { value } });
 }
@@ -187,6 +191,7 @@ describe("Desktop app project playback pre-count", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openStudioPanel(user);
     await user.click(screen.getByRole("button", { name: "Generate Stems" }));
     await openPlaybackWorkspace(user);
 

--- a/apps/desktop/src/App.responsive-ui.test.tsx
+++ b/apps/desktop/src/App.responsive-ui.test.tsx
@@ -1,0 +1,91 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  findAudioByArtifactId,
+  markAudioReady,
+  renderApp,
+  resetAppTestHarness,
+} from "./test/appTestHarness";
+
+describe("Desktop app responsive UI revamp", () => {
+  beforeEach(resetAppTestHarness);
+
+  it("keeps library navigation expanded and uses dense project rows", async () => {
+    renderApp(["/"]);
+
+    expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
+    expect(document.querySelector(".app-shell")).not.toHaveClass("app-shell--compact");
+    expect(screen.getAllByRole("link", { name: "Library" }).length).toBeGreaterThan(0);
+    await screen.findByRole("link", { name: "Open Demo Song project" });
+    expect(document.querySelector(".project-library-table__header")).toBeInTheDocument();
+    expect(document.querySelectorAll(".project-library-row").length).toBeGreaterThan(0);
+  });
+
+  it("uses compact app chrome on project routes while preserving accessible navigation", async () => {
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    expect(document.querySelector(".app-shell")).toHaveClass("app-shell--compact");
+    expect(screen.getAllByRole("link", { name: "Library" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: "Tools" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: "Settings" }).length).toBeGreaterThan(0);
+  });
+
+  it("splits project work into Studio and Analysis panels", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Studio" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("group", { name: "Source and mix list" })).toBeInTheDocument();
+    const createMixButton = screen.getByRole("button", { name: "Create Mix" });
+    expect(createMixButton.closest(".mix-builder__footer")).not.toBeNull();
+    expect(screen.getByRole("heading", { name: "Processing" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Analyze Track" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Hide Inspector" }));
+    expect(screen.getByRole("button", { name: "Show Inspector" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Create Mix" })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Show Inspector" }));
+
+    await user.click(screen.getByRole("tab", { name: "Analysis" }));
+
+    expect(screen.getByRole("heading", { name: "Project Analysis" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Processing" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Analyze Track" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: "Source and mix list" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Hide Inspector" })).not.toBeInTheDocument();
+  });
+
+  it("keeps playback transport at the bottom of the fixed practice frame", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "Playback" }));
+
+    const workspace = document.querySelector(".playback-workspace--practice");
+    const transportDock = document.querySelector(".playback-transport-dock");
+    expect(workspace).not.toBeNull();
+    expect(transportDock).not.toBeNull();
+    expect(workspace).toContainElement(transportDock as HTMLElement);
+    expect((transportDock as HTMLElement).parentElement).toBe(workspace);
+    expect(within(transportDock as HTMLElement).getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+  });
+
+  it("collapses practice chrome while playback is active and restores it on pause", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    markAudioReady(findAudioByArtifactId("art_source"));
+    await user.click(screen.getByRole("tab", { name: "Playback" }));
+
+    const workspace = document.querySelector(".playback-workspace") as HTMLElement;
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(workspace).toHaveClass("playback-workspace--focus"));
+
+    await user.click(screen.getByRole("button", { name: "Pause playback" }));
+    await waitFor(() => expect(workspace).not.toHaveClass("playback-workspace--focus"));
+  });
+});

--- a/apps/desktop/src/App.settings-theme.test.tsx
+++ b/apps/desktop/src/App.settings-theme.test.tsx
@@ -83,15 +83,15 @@ describe("Desktop app settings theme", () => {
     expect(queryByAriaKeyLabel(targetKeyList as HTMLElement, "Ebm")).not.toBeInTheDocument();
   });
 
-  it("uses new default appearance and visibility settings", async () => {
+  it("uses new default appearance and playback settings", async () => {
     renderApp(["/settings"]);
 
     expect(await screen.findByRole("heading", { name: "Control Room" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^Follow system/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^Minimal/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^Auto by key/ })).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByRole("button", { name: /^Open inspector by default/ })).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByRole("button", { name: /^Collapse sources rail by default/ })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.queryByRole("button", { name: /^Open inspector by default/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^Collapse sources rail by default/ })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^Project first/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^AutoUse lyrics \+ chords/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^Built-in Chords/ })).toHaveAttribute("aria-pressed", "true");
@@ -113,7 +113,7 @@ describe("Desktop app settings theme", () => {
     });
   });
 
-  it("persists theme and UI visibility preferences", async () => {
+  it("persists theme and visible UI preferences", async () => {
     const user = userEvent.setup();
     renderApp(["/settings"]);
 
@@ -122,8 +122,6 @@ describe("Desktop app settings theme", () => {
     await user.click(screen.getByRole("button", { name: /^Light/ }));
     await user.click(screen.getByRole("button", { name: /^Detailed/ }));
     await user.click(screen.getByRole("button", { name: /^Prefer sharps/ }));
-    await user.click(screen.getByRole("button", { name: /^Open inspector by default/ }));
-    await user.click(screen.getByRole("button", { name: /^Collapse sources rail by default/ }));
     await user.click(screen.getByRole("button", { name: /^Playback first/ }));
     await user.click(screen.getByRole("button", { name: /^Lyrics \+ chords/ }));
     await user.click(screen.getByRole("button", { name: /^Advanced Chords/ }));
@@ -138,8 +136,8 @@ describe("Desktop app settings theme", () => {
       expect(JSON.parse(window.localStorage.getItem("tuneforge.ui-preferences") ?? "{}")).toMatchObject({
         informationDensity: "detailed",
         enharmonicDisplayMode: "sharps",
-        defaultInspectorOpen: false,
-        defaultSourcesRailCollapsed: true,
+        defaultInspectorOpen: true,
+        defaultSourcesRailCollapsed: false,
         defaultProjectWorkspace: "playback",
         defaultPlaybackDisplayMode: "combined",
         defaultChordBackend: "crema-advanced",
@@ -205,7 +203,7 @@ describe("Desktop app settings theme", () => {
     expect(await screen.findByText("crema is not installed")).toBeInTheDocument();
   });
 
-  it("resets appearance, visibility, and all settings independently", async () => {
+  it("resets appearance, playback, and all settings independently", async () => {
     const user = userEvent.setup();
     renderApp(["/settings"]);
 
@@ -215,15 +213,11 @@ describe("Desktop app settings theme", () => {
     await user.click(screen.getByRole("button", { name: /^Detailed/ }));
     await user.click(screen.getByRole("button", { name: /^Prefer sharps/ }));
     await user.click(screen.getByRole("button", { name: /^Advanced Chords/ }));
-    await user.click(screen.getByRole("button", { name: /^Open inspector by default/ }));
-    await user.click(screen.getByRole("button", { name: /^Collapse sources rail by default/ }));
 
     await user.click(screen.getByRole("button", { name: "Reset Appearance" }));
     expect(screen.getByRole("button", { name: /^Follow system/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^Minimal/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^Prefer sharps/ })).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByRole("button", { name: /^Open inspector by default/ })).toHaveAttribute("aria-pressed", "false");
-    expect(screen.getByRole("button", { name: /^Collapse sources rail by default/ })).toHaveAttribute("aria-pressed", "true");
 
     await user.click(screen.getByRole("button", { name: "Reset Notation" }));
     expect(screen.getByRole("button", { name: /^Auto by key/ })).toHaveAttribute("aria-pressed", "true");
@@ -232,8 +226,6 @@ describe("Desktop app settings theme", () => {
     expect(screen.getByRole("button", { name: /^Built-in Chords/ })).toHaveAttribute("aria-pressed", "true");
 
     await user.click(screen.getByRole("button", { name: "Reset Playback Defaults" }));
-    expect(screen.getByRole("button", { name: /^Open inspector by default/ })).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByRole("button", { name: /^Collapse sources rail by default/ })).toHaveAttribute("aria-pressed", "false");
     expect(screen.getByRole("button", { name: /^Project first/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^AutoUse lyrics \+ chords/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^Enable lyrics follow by default/ })).toHaveAttribute("aria-pressed", "true");
@@ -242,14 +234,11 @@ describe("Desktop app settings theme", () => {
     await user.click(screen.getByRole("button", { name: /^Dark/ }));
     await user.click(screen.getByRole("button", { name: /^Dual labels/ }));
     await user.click(screen.getByRole("button", { name: /^Advanced Chords/ }));
-    await user.click(screen.getByRole("button", { name: /^Open inspector by default/ }));
     await user.click(screen.getByRole("button", { name: "Reset All Settings" }));
 
     expect(screen.getByRole("button", { name: /^Follow system/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^Minimal/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^Auto by key/ })).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByRole("button", { name: /^Open inspector by default/ })).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByRole("button", { name: /^Collapse sources rail by default/ })).toHaveAttribute("aria-pressed", "false");
     expect(screen.getByRole("button", { name: /^Project first/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^AutoUse lyrics \+ chords/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^Built-in Chords/ })).toHaveAttribute("aria-pressed", "true");
@@ -366,8 +355,6 @@ describe("Desktop app settings theme", () => {
     await user.click(screen.getByRole("button", { name: /^Dark/i }));
     await user.click(screen.getByRole("button", { name: /^Detailed/i }));
     await user.click(screen.getByRole("button", { name: /^Prefer sharps/i }));
-    await user.click(screen.getByRole("button", { name: /Open inspector by default/i }));
-    await user.click(screen.getByRole("button", { name: /Collapse sources rail by default/i }));
     await user.click(screen.getByRole("button", { name: /^Playback first/i }));
     await user.click(screen.getByRole("button", { name: /^Lyrics \+ chords/i }));
     await user.click(screen.getByRole("button", { name: /^Advanced Chords/i }));
@@ -406,8 +393,6 @@ describe("Desktop app settings theme", () => {
     expect(screen.getByText("Settings imported.")).toBeInTheDocument();
     expect(screen.getAllByText("Detailed").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Prefer sharps")).toHaveLength(2);
-    expect(screen.getByText("Closed on load")).toBeInTheDocument();
-    expect(screen.getByText("Collapsed")).toBeInTheDocument();
     expect(screen.getAllByText("Playback first").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Lyrics + chords").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Advanced Chords").length).toBeGreaterThan(0);

--- a/apps/desktop/src/App.tools-metronome.test.tsx
+++ b/apps/desktop/src/App.tools-metronome.test.tsx
@@ -109,6 +109,7 @@ describe("Desktop app tools metronome", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "Analysis" }));
     await user.click(screen.getByRole("link", { name: "Follow on metronome at 121.5 BPM" }));
 
     expect(await screen.findByRole("heading", { name: "Metronome" })).toBeInTheDocument();
@@ -237,6 +238,7 @@ describe("Desktop app tools metronome", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "Analysis" }));
     await user.click(screen.getByRole("link", { name: "Follow on metronome at 121.5 BPM" }));
     expect(await screen.findByRole("heading", { name: "Metronome" })).toBeInTheDocument();
     expect(screen.getByLabelText("Tempo BPM")).toHaveValue(121.5);

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId } from "react";
+import { Library, Music2, Settings, Wrench } from "lucide-react";
 import { Link, NavLink, Route, Routes, matchPath, useLocation } from "react-router-dom";
 import { LibraryView } from "./features/projects/LibraryView";
 import { ProjectView } from "./features/projects/ProjectView";
@@ -147,6 +148,7 @@ function AppChrome() {
   const { dismissSession, session } = usePlayback();
   const routeProjectId =
     matchPath("/projects/:projectId", location.pathname)?.params.projectId ?? null;
+  const compactChrome = Boolean(routeProjectId);
 
   useEffect(() => {
     if (!routeProjectId || !session || routeProjectId === session.projectId) {
@@ -157,19 +159,47 @@ function AppChrome() {
   }, [dismissSession, routeProjectId, session]);
 
   return (
-    <div className="app-shell">
+    <div className={`app-shell${compactChrome ? " app-shell--compact" : ""}`}>
       <aside className="sidebar">
-        <div className="brand">
-          <span className="brand__eyebrow">Tuneforge</span>
-          <strong>Local Practice Rig</strong>
-        </div>
+        <Link aria-label="Tuneforge library" className="brand" title="Tuneforge" to="/">
+          <span className="brand__mark" aria-hidden="true">
+            <Music2 className="brand__icon" />
+          </span>
+          <span className="brand__copy">
+            <span className="brand__eyebrow">Tuneforge</span>
+            <strong>Local Practice Rig</strong>
+          </span>
+        </Link>
         <BackgroundPlaybackCard />
         <nav className="nav">
-          <NavLink to="/" end>
-            Library
+          <NavLink
+            aria-label="Library"
+            className={({ isActive }) => (isActive ? "active" : undefined)}
+            title="Library"
+            to="/"
+            end
+          >
+            <Library aria-hidden="true" className="nav__icon" />
+            <span className="nav__label">Library</span>
           </NavLink>
-          <NavLink to="/tools">Tools</NavLink>
-          <NavLink to="/settings">Settings</NavLink>
+          <NavLink
+            aria-label="Tools"
+            className={({ isActive }) => (isActive ? "active" : undefined)}
+            title="Tools"
+            to="/tools"
+          >
+            <Wrench aria-hidden="true" className="nav__icon" />
+            <span className="nav__label">Tools</span>
+          </NavLink>
+          <NavLink
+            aria-label="Settings"
+            className={({ isActive }) => (isActive ? "active" : undefined)}
+            title="Settings"
+            to="/settings"
+          >
+            <Settings aria-hidden="true" className="nav__icon" />
+            <span className="nav__label">Settings</span>
+          </NavLink>
         </nav>
       </aside>
       <main className="main-content">

--- a/apps/desktop/src/features/projects/LibraryView.tsx
+++ b/apps/desktop/src/features/projects/LibraryView.tsx
@@ -1,6 +1,7 @@
 import { startTransition, useDeferredValue, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { open } from "@tauri-apps/plugin-dialog";
+import { Music2, Upload } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import { api, type ProjectSchema } from "../../lib/api";
 import { formatLocalDateTime, normalizeApiDateTime } from "../../lib/datetime";
@@ -29,27 +30,33 @@ function ProjectCard({ project }: { project: ProjectSchema }) {
   const { informationDensity } = usePreferences();
   const updatedAtLabel = formatUpdatedAt(project.updated_at);
   const normalizedUpdatedAt = normalizeApiDateTime(project.updated_at);
+  const fileType = project.source_path.split(".").pop()?.toUpperCase() ?? "Audio";
 
   return (
-    <article className="project-card">
+    <article className="project-card project-library-row">
       <Link
         aria-label={`Open ${project.display_name} project`}
         className="project-card__link"
         to={`/projects/${project.id}`}
       >
-        <div className="project-card__meta-row">
-          <span className="pill">
-            <time dateTime={normalizedUpdatedAt}>{updatedAtLabel}</time>
-          </span>
-        </div>
+        <span className="project-library-row__icon" aria-hidden="true">
+          <Music2 />
+        </span>
 
         <div className="project-card__title-block">
           <h2>{project.display_name}</h2>
+          {informationDensity === "detailed" ? (
+            <span className="artifact-meta">{project.source_path}</span>
+          ) : null}
+        </div>
+
+        <div className="project-library-row__cell project-library-row__cell--date">
+          <time dateTime={normalizedUpdatedAt}>{updatedAtLabel}</time>
         </div>
 
         <div className="project-card__stats" role="list" aria-label={`${project.display_name} summary`}>
           <span className="stat-chip" role="listitem">
-            {project.source_path.split(".").pop()?.toUpperCase() ?? "Audio"}
+            {fileType}
           </span>
           <span className="stat-chip" role="listitem">
             {formatDuration(project.duration_seconds)}
@@ -152,6 +159,7 @@ export function LibraryView() {
           disabled={importMutation.isPending}
         >
           {importMutation.isPending ? "Importing..." : "Import Track"}
+          <Upload aria-hidden="true" className="button__icon" />
         </button>
       </div>
 
@@ -194,9 +202,17 @@ export function LibraryView() {
         <div className="panel panel--error">Could not load projects.</div>
       ) : null}
 
-      <div className="project-grid">
+      <div className="project-grid project-library-table">
         {projectsQuery.data?.length ? (
-          projectsQuery.data.map((project) => <ProjectCard key={project.id} project={project} />)
+          <>
+            <div className="project-library-table__header" aria-hidden="true">
+              <span />
+              <span>Title</span>
+              <span>Updated</span>
+              <span>Format / Duration</span>
+            </div>
+            {projectsQuery.data.map((project) => <ProjectCard key={project.id} project={project} />)}
+          </>
         ) : (
           <div className="panel panel--empty">
             <h2>{deferredSearch ? "No matching projects" : "No projects yet"}</h2>

--- a/apps/desktop/src/features/projects/components/InspectorPanel.tsx
+++ b/apps/desktop/src/features/projects/components/InspectorPanel.tsx
@@ -1,11 +1,12 @@
 import { Link } from "react-router-dom";
+import { PanelRightClose } from "lucide-react";
 import { MusicalKeyLabel } from "../../../components/MusicalLabel";
 import { formatKey } from "../../../lib/music";
 import { useMetronome } from "../../tools/metronome-context";
 import { TargetKeySelector } from "./TargetKeySelector";
 import { useProjectViewModelContext } from "./useProjectViewModelContext";
 
-export function InspectorPanel() {
+export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysis" }) {
   const {
     analysisQuery,
     canDeleteSelectedMix,
@@ -18,6 +19,7 @@ export function InspectorPanel() {
     exportMutation,
     handleDeleteMix,
     handleDeleteProject,
+    hasTransformChange,
     higherTargetPreview,
     higherTargetShiftOptions,
     isAnalysisRunning,
@@ -28,6 +30,7 @@ export function InspectorPanel() {
     referenceHz,
     retuneMode,
     setCentsOffset,
+    setInspectorOpen,
     setReferenceHz,
     setRetuneMode,
     setSourceKeySelectorOpen,
@@ -67,24 +70,35 @@ export function InspectorPanel() {
   }
 
   return (
-    <aside className="stack">
+    <aside className={`stack inspector-stack inspector-stack--${mode}`}>
       <div className="panel inspector-panel">
-        <div className="panel-heading">
-      <div>
-        <h2>Inspector</h2>
-        {showSupportingCopy ? (
-          <p className="subpanel__copy">
-            Mix decisions stay compact and close to playback.
-          </p>
-        ) : null}
-      </div>
+        <div className="panel-heading inspector-panel__heading">
+          <div>
+            <h2>{mode === "studio" ? "Mix Builder" : "Project Analysis"}</h2>
+            {showSupportingCopy ? (
+              <p className="subpanel__copy">
+                {mode === "studio"
+                  ? "Mix decisions stay compact and close to playback."
+                  : "Analysis, jobs, and project details stay out of the practice flow."}
+              </p>
+            ) : null}
+          </div>
+          {mode === "studio" ? (
+            <button
+              aria-label="Hide Inspector"
+              className="button button--ghost button--small rail-panel__toggle inspector-panel__toggle"
+              onClick={() => setInspectorOpen(false)}
+              type="button"
+            >
+              <PanelRightClose aria-hidden="true" className="project-inspector-toggle__icon" />
+              <span>Hide</span>
+            </button>
+          ) : null}
         </div>
 
         <div className="section-stack">
+      {mode === "studio" ? (
       <div className="subpanel">
-        <div className="subpanel__header">
-          <h3>Mix Builder</h3>
-        </div>
         <div className="mix-builder">
           <div className="mix-builder__retune">
             <div className="mix-builder__section-head">
@@ -216,9 +230,22 @@ export function InspectorPanel() {
               : "Could not create preview."}
           </p>
         ) : null}
+        <div className="mix-builder__footer">
+          <button
+            className="button button--primary"
+            onClick={() => previewMutation.mutate()}
+            disabled={previewMutation.isPending || !hasTransformChange}
+            type="button"
+          >
+            {previewMutation.isPending ? "Queueing..." : "Create Mix"}
+          </button>
+        </div>
       </div>
+      ) : null}
 
-      <div className="subpanel">
+      {mode === "analysis" ? (
+        <>
+      <div className="subpanel analysis-summary-panel">
         <div className="panel-heading panel-heading--compact">
           <div>
             <h3>Analysis</h3>
@@ -388,7 +415,7 @@ export function InspectorPanel() {
         </details>
       </div>
 
-      <div className="subpanel subpanel--compact">
+      <div className="subpanel subpanel--compact analysis-export-panel">
         <div className="subpanel__header">
           <h3>Export</h3>
           {showSupportingCopy ? (
@@ -407,7 +434,7 @@ export function InspectorPanel() {
         </button>
       </div>
 
-      <div className="subpanel">
+      <div className="subpanel analysis-details-panel">
         <div className="subpanel__header">
           <h3>Project Details</h3>
         </div>
@@ -455,7 +482,7 @@ export function InspectorPanel() {
         </details>
       </div>
 
-      <div className="subpanel subpanel--compact subpanel--danger">
+      <div className="subpanel subpanel--compact subpanel--danger analysis-danger-panel">
         <div className="subpanel__header">
           <h3>Danger Zone</h3>
         </div>
@@ -480,6 +507,8 @@ export function InspectorPanel() {
           </button>
         </div>
       </div>
+        </>
+      ) : null}
         </div>
       </div>
     </aside>

--- a/apps/desktop/src/features/projects/components/JobsHistory.tsx
+++ b/apps/desktop/src/features/projects/components/JobsHistory.tsx
@@ -10,7 +10,7 @@ export function JobsHistory() {
   } = useProjectViewModelContext();
 
   return (
-    <div className="panel">
+    <div className="panel jobs-history">
       <div className="panel-heading">
         <div>
       <h2>Jobs and History</h2>

--- a/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
@@ -1,3 +1,4 @@
+import { ArrowUpDown, AudioLines, Drumstick, Layers } from "lucide-react";
 import {
   artifactLabel,
   artifactSummary,
@@ -54,6 +55,25 @@ export function PlaybackPracticeRail() {
 
   return (
     <aside className="panel playback-practice-rail">
+      <div
+        aria-label="Playback rail shortcuts"
+        className="playback-practice-rail__focus-icons"
+        tabIndex={0}
+      >
+        <span title="Transpose / Capo">
+          <ArrowUpDown aria-hidden="true" />
+        </span>
+        <span title="Pre-count">
+          <Drumstick aria-hidden="true" />
+        </span>
+        <span title="Source and Mixes">
+          <Layers aria-hidden="true" />
+        </span>
+        <span title="Stem Practice">
+          <AudioLines aria-hidden="true" />
+        </span>
+      </div>
+      <div className="playback-practice-rail__content">
       <div className="playback-practice-rail__header">
         <p className="metric-label">Playback</p>
         <h2>{stageTitle}</h2>
@@ -255,6 +275,7 @@ export function PlaybackPracticeRail() {
           </p>
         )}
       </section>
+      </div>
     </aside>
   );
 }

--- a/apps/desktop/src/features/projects/components/PlaybackPracticeSurface.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackPracticeSurface.tsx
@@ -74,85 +74,87 @@ function PlaybackModeHeader() {
   const chordsSelected = playbackDisplayMode === "chords" || playbackDisplayMode === "combined";
 
   return (
-    <div className="playback-practice-surface__header">
-      <div>
-        <p className="metric-label">Practice View</p>
-        <h2>
-          {playbackDisplayMode === "combined"
-            ? "Lyrics + chords"
-            : playbackDisplayMode === "lyrics"
-              ? "Lyrics"
-              : "Chords"}
-        </h2>
-      </div>
-
-      <div className="playback-practice-surface__controls">
-        <div className="playback-mode-toggle" role="group" aria-label="Playback display mode">
-          <button
-            aria-pressed={lyricsSelected}
-            className={lyricsSelected ? "playback-mode-toggle__button playback-mode-toggle__button--active" : "playback-mode-toggle__button"}
-            onClick={() => handleTogglePlaybackDisplayLane("lyrics")}
-            type="button"
-          >
-            Lyrics
-          </button>
-          <button
-            aria-pressed={chordsSelected}
-            className={chordsSelected ? "playback-mode-toggle__button playback-mode-toggle__button--active" : "playback-mode-toggle__button"}
-            onClick={() => handleTogglePlaybackDisplayLane("chords")}
-            type="button"
-          >
-            Chords
-          </button>
+    <>
+      <div className="playback-practice-surface__header">
+        <div>
+          <p className="metric-label">Practice View</p>
+          <h2>
+            {playbackDisplayMode === "combined"
+              ? "Lyrics + chords"
+              : playbackDisplayMode === "lyrics"
+                ? "Lyrics"
+                : "Chords"}
+          </h2>
         </div>
 
-        <div className="button-row playback-practice-actions">
-          {lyricsSelected && hasLyricsTranscript && !isEditingLyrics ? (
+        <div className="playback-practice-surface__controls">
+          <div className="playback-mode-toggle" role="group" aria-label="Playback display mode">
+            <button
+              aria-pressed={lyricsSelected}
+              className={lyricsSelected ? "playback-mode-toggle__button playback-mode-toggle__button--active" : "playback-mode-toggle__button"}
+              onClick={() => handleTogglePlaybackDisplayLane("lyrics")}
+              type="button"
+            >
+              Lyrics
+            </button>
+            <button
+              aria-pressed={chordsSelected}
+              className={chordsSelected ? "playback-mode-toggle__button playback-mode-toggle__button--active" : "playback-mode-toggle__button"}
+              onClick={() => handleTogglePlaybackDisplayLane("chords")}
+              type="button"
+            >
+              Chords
+            </button>
+          </div>
+
+          <div className="button-row playback-practice-actions">
+            {lyricsSelected && hasLyricsTranscript && !isEditingLyrics ? (
+              <button
+                className="button button--ghost button--small"
+                type="button"
+                onClick={() => {
+                  setLyricsDraft(displayedLyrics.map((segment) => segment.text));
+                  setIsEditingLyrics(true);
+                }}
+                disabled={lyricsMutation.isPending || isLyricsRunning}
+              >
+                Edit Lyrics
+              </button>
+            ) : null}
             <button
               className="button button--ghost button--small"
               type="button"
-              onClick={() => {
-                setLyricsDraft(displayedLyrics.map((segment) => segment.text));
-                setIsEditingLyrics(true);
-              }}
-              disabled={lyricsMutation.isPending || isLyricsRunning}
+              onClick={handleOpenTabImport}
             >
-              Edit Lyrics
+              Import Tab
             </button>
-          ) : null}
-          <button
-            className="button button--ghost button--small"
-            type="button"
-            onClick={handleOpenTabImport}
-          >
-            Import Tab
-          </button>
-          {lyricsSelected ? (
-            <>
-              <button
-                aria-pressed={lyricsFollowEnabled}
-                className={`chip playback-follow-chip${lyricsFollowEnabled ? " chip--active" : ""}`}
-                onClick={() => handleSetLyricsFollowEnabled(!lyricsFollowEnabled)}
-                type="button"
-              >
-                Lyrics Follow
-              </button>
-            </>
-          ) : null}
-          {chordsSelected ? (
-            <>
-              {playbackDisplayMode === "chords" ? (
+            {lyricsSelected ? (
+              <>
                 <button
-                  aria-pressed={chordsFollowEnabled}
-                  className={`chip playback-follow-chip${chordsFollowEnabled ? " chip--active" : ""}`}
-                  onClick={() => handleSetChordsFollowEnabled(!chordsFollowEnabled)}
+                  aria-pressed={lyricsFollowEnabled}
+                  className={`chip playback-follow-chip${lyricsFollowEnabled ? " chip--active" : ""}`}
+                  onClick={() => handleSetLyricsFollowEnabled(!lyricsFollowEnabled)}
                   type="button"
                 >
-                  Chords Follow
+                  Lyrics Follow
                 </button>
-              ) : null}
-            </>
-          ) : null}
+              </>
+            ) : null}
+            {chordsSelected ? (
+              <>
+                {playbackDisplayMode === "chords" ? (
+                  <button
+                    aria-pressed={chordsFollowEnabled}
+                    className={`chip playback-follow-chip${chordsFollowEnabled ? " chip--active" : ""}`}
+                    onClick={() => handleSetChordsFollowEnabled(!chordsFollowEnabled)}
+                    type="button"
+                  >
+                    Chords Follow
+                  </button>
+                ) : null}
+              </>
+            ) : null}
+          </div>
         </div>
       </div>
       {isTabImportOpen ? (
@@ -171,7 +173,7 @@ function PlaybackModeHeader() {
           selectedSuggestionId={selectedTabSuggestionId}
         />
       ) : null}
-    </div>
+    </>
   );
 }
 
@@ -213,7 +215,6 @@ function TabImportDialog({
     <div className="tab-import-overlay" role="presentation">
       <section
         aria-label="Import tab suggestions"
-        aria-modal="true"
         className="tab-import-drawer"
         role="dialog"
       >

--- a/apps/desktop/src/features/projects/components/PlaybackWorkspace.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackWorkspace.tsx
@@ -19,7 +19,7 @@ export function PlaybackWorkspace() {
   const maxSeconds = playbackDurationSeconds || projectQuery.data?.duration_seconds || 0;
 
   return (
-    <div className="playback-workspace playback-workspace--practice">
+    <div className={`playback-workspace playback-workspace--practice${isPlaying ? " playback-workspace--focus" : ""}`}>
       <PlaybackPracticeRail />
       <PlaybackPracticeSurface />
       <div className="panel playback-transport-dock" ref={playbackTransportRef}>

--- a/apps/desktop/src/features/projects/components/ProjectHeader.tsx
+++ b/apps/desktop/src/features/projects/components/ProjectHeader.tsx
@@ -5,91 +5,72 @@ export function ProjectHeader() {
   const {
     activeWorkspace,
     draftName,
-    hasTransformChange,
-    inspectorOpen,
     isRenaming,
-    previewMutation,
     projectQuery,
     renameMutation,
     setDraftName,
-    setInspectorOpen,
     setIsRenaming,
     showSupportingCopy,
   } = useProjectViewModelContext();
 
   return (
-    <div className={`screen__header${activeWorkspace === "playback" ? " screen__header--compact" : ""}`}>
+    <div
+      className={`screen__header screen__header--project${
+        activeWorkspace === "playback" ? " screen__header--compact" : ""
+      }`}
+    >
       <div className="screen__title-block">
-    <p className="eyebrow">
-      <Link to="/">Library</Link> / Project
-    </p>
-    {isRenaming ? (
-      <div className="title-edit">
-        <input
-      aria-label="Project name"
-      className="title-input"
-      value={draftName}
-      onChange={(event) => setDraftName(event.target.value)}
-        />
-        <div className="button-row">
-      <button
-        className="button button--primary button--small"
-        type="button"
-        onClick={() => renameMutation.mutate()}
-        disabled={renameMutation.isPending || !draftName.trim()}
-      >
-        {renameMutation.isPending ? "Saving..." : "Save"}
-      </button>
-      <button
-        className="button button--ghost button--small"
-        type="button"
-        onClick={() => {
-          setIsRenaming(false);
-          setDraftName(projectQuery.data?.display_name ?? "");
-        }}
-        disabled={renameMutation.isPending}
-      >
-        Cancel
-      </button>
-        </div>
+        <p className="eyebrow">
+          <Link to="/">Library</Link> / Project
+        </p>
+        {isRenaming ? (
+          <div className="title-edit">
+            <input
+              aria-label="Project name"
+              className="title-input"
+              value={draftName}
+              onChange={(event) => setDraftName(event.target.value)}
+            />
+            <div className="button-row">
+              <button
+                className="button button--primary button--small"
+                type="button"
+                onClick={() => renameMutation.mutate()}
+                disabled={renameMutation.isPending || !draftName.trim()}
+              >
+                {renameMutation.isPending ? "Saving..." : "Save"}
+              </button>
+              <button
+                className="button button--ghost button--small"
+                type="button"
+                onClick={() => {
+                  setIsRenaming(false);
+                  setDraftName(projectQuery.data?.display_name ?? "");
+                }}
+                disabled={renameMutation.isPending}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="title-row">
+            <h1>{projectQuery.data?.display_name ?? "Project"}</h1>
+            <button
+              className="button button--ghost button--small"
+              type="button"
+              onClick={() => setIsRenaming(true)}
+            >
+              Rename
+            </button>
+          </div>
+        )}
+        {showSupportingCopy && activeWorkspace === "project" ? (
+          <p className="screen__subtitle">
+            Move between project tools and playback workspace without losing transport context.
+          </p>
+        ) : null}
       </div>
-    ) : (
-      <div className="title-row">
-        <h1>{projectQuery.data?.display_name ?? "Project"}</h1>
-        <button
-      className="button button--ghost button--small"
-      type="button"
-      onClick={() => setIsRenaming(true)}
-        >
-      Rename
-        </button>
-      </div>
-    )}
-    {showSupportingCopy && activeWorkspace === "project" ? (
-      <p className="screen__subtitle">
-        Move between project tools and playback workspace without losing transport context.
-      </p>
-    ) : null}
-      </div>
-
-      {activeWorkspace === "project" ? (
-        <div className="button-row">
-          <button
-            className="button button--primary"
-            onClick={() => previewMutation.mutate()}
-            disabled={previewMutation.isPending || !hasTransformChange}
-          >
-            {previewMutation.isPending ? "Queueing..." : "Create Mix"}
-          </button>
-          <button
-            className="button button--ghost"
-            type="button"
-            onClick={() => setInspectorOpen((current) => !current)}
-          >
-            {inspectorOpen ? "Hide Inspector" : "Show Inspector"}
-          </button>
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/features/projects/components/ProjectShell.tsx
+++ b/apps/desktop/src/features/projects/components/ProjectShell.tsx
@@ -7,7 +7,7 @@ export function ProjectShell() {
   const { activeWorkspace, handleSelectWorkspace } = useProjectViewModelContext();
 
   return (
-    <section className="screen">
+    <section className={`screen project-screen project-screen--${activeWorkspace}`}>
       <ProjectHeader />
 
       <div className="project-workspace-tabs" role="tablist" aria-label="Project workspace">

--- a/apps/desktop/src/features/projects/components/ProjectWorkspace.tsx
+++ b/apps/desktop/src/features/projects/components/ProjectWorkspace.tsx
@@ -1,3 +1,4 @@
+import { Activity, PanelRightOpen, SlidersHorizontal } from "lucide-react";
 import { useProjectViewModelContext } from "./useProjectViewModelContext";
 import { InspectorPanel } from "./InspectorPanel";
 import { JobsHistory } from "./JobsHistory";
@@ -6,21 +7,77 @@ import { ProjectPlaybackSummary } from "./ProjectPlaybackSummary";
 import { SourcesRail } from "./SourcesRail";
 
 export function ProjectWorkspace() {
-  const { inspectorOpen, sourcesRailCollapsed } = useProjectViewModelContext();
+  const {
+    activeProjectPanel,
+    handleSelectProjectPanel,
+    inspectorOpen,
+    setInspectorOpen,
+    sourcesRailCollapsed,
+  } = useProjectViewModelContext();
 
   return (
-    <div
-      className={`project-workbench${inspectorOpen ? "" : " project-workbench--wide"}${
-        sourcesRailCollapsed ? " project-workbench--sources-collapsed" : ""
-      }`}
-    >
-      <SourcesRail />
-      <div className="stack">
-        <ProjectPlaybackSummary />
-        <ProcessingPanel />
-        <JobsHistory />
+    <div className="project-workspace">
+      <div className="project-panel-toolbar">
+        <div className="project-panel-tabs" role="tablist" aria-label="Project sections">
+          <button
+            aria-selected={activeProjectPanel === "studio"}
+            className={`project-panel-tabs__button${
+              activeProjectPanel === "studio" ? " project-panel-tabs__button--active" : ""
+            }`}
+            onClick={() => handleSelectProjectPanel("studio")}
+            role="tab"
+            type="button"
+          >
+            <SlidersHorizontal aria-hidden="true" className="project-panel-tabs__icon" />
+            <span>Studio</span>
+          </button>
+          <button
+            aria-selected={activeProjectPanel === "analysis"}
+            className={`project-panel-tabs__button${
+              activeProjectPanel === "analysis" ? " project-panel-tabs__button--active" : ""
+            }`}
+            onClick={() => handleSelectProjectPanel("analysis")}
+            role="tab"
+            type="button"
+          >
+            <Activity aria-hidden="true" className="project-panel-tabs__icon" />
+            <span>Analysis</span>
+          </button>
+        </div>
       </div>
-      {inspectorOpen ? <InspectorPanel /> : null}
+
+      {activeProjectPanel === "studio" ? (
+        <div
+          className={`project-workbench project-workbench--studio${
+            inspectorOpen ? "" : " project-workbench--inspector-collapsed"
+          }${sourcesRailCollapsed ? " project-workbench--sources-collapsed" : ""}`}
+        >
+          <SourcesRail />
+          <div className="stack project-studio-main">
+            <ProjectPlaybackSummary />
+            <ProcessingPanel />
+          </div>
+          {inspectorOpen ? (
+            <InspectorPanel mode="studio" />
+          ) : (
+            <button
+              aria-label="Show Inspector"
+              className="panel inspector-collapsed"
+              onClick={() => setInspectorOpen(true)}
+              title="Show Inspector"
+              type="button"
+            >
+              <PanelRightOpen aria-hidden="true" className="project-inspector-toggle__icon" />
+              <span>Mix Builder</span>
+            </button>
+          )}
+        </div>
+      ) : (
+        <div className="project-analysis-workspace">
+          <InspectorPanel mode="analysis" />
+          <JobsHistory />
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/features/projects/components/TargetKeySelector.tsx
+++ b/apps/desktop/src/features/projects/components/TargetKeySelector.tsx
@@ -117,7 +117,12 @@ export function TargetKeySelector({
                     variant="selector-current"
                   />
                 </span>
-                <span className="target-selector__current-meta">{currentMeta}</span>
+                <span className="target-selector__current-meta">
+                  <span className="target-selector__current-meta-icon" aria-hidden="true">
+                    •
+                  </span>
+                  <span className="target-selector__current-meta-text">{currentMeta}</span>
+                </span>
               </span>
               <span
                 className={`target-selector__preview target-selector__preview--higher${
@@ -139,7 +144,12 @@ export function TargetKeySelector({
 
             {isOpen ? (
               <div className="target-selector__menu" role="listbox" aria-label={listboxLabel}>
-                <div className="target-selector__group-label">Higher pitch</div>
+                <div className="target-selector__group-label target-selector__group-label--higher">
+                  <span className="target-selector__group-icon" aria-hidden="true">
+                    ↑
+                  </span>
+                  <span className="target-selector__group-text">Higher pitch</span>
+                </div>
                 {higherTargetShiftOptions.map((option) => (
                   <button
                     key={option.semitones}
@@ -171,7 +181,12 @@ export function TargetKeySelector({
                     </span>
                   </button>
                 ))}
-                <div className="target-selector__group-label">Original</div>
+                <div className="target-selector__group-label target-selector__group-label--original">
+                  <span className="target-selector__group-icon" aria-hidden="true">
+                    •
+                  </span>
+                  <span className="target-selector__group-text">Original</span>
+                </div>
                 <button
                   ref={(node) => {
                     optionRefs.current[0] = node;
@@ -200,7 +215,12 @@ export function TargetKeySelector({
                     </span>
                   </span>
                 </button>
-                <div className="target-selector__group-label">Lower pitch</div>
+                <div className="target-selector__group-label target-selector__group-label--lower">
+                  <span className="target-selector__group-icon" aria-hidden="true">
+                    ↓
+                  </span>
+                  <span className="target-selector__group-text">Lower pitch</span>
+                </div>
                 {lowerTargetShiftOptions.map((option) => (
                   <button
                     key={option.semitones}

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -14,6 +14,7 @@ import {
   normalizePrecountClickCount,
   readProjectPlaybackState,
   writeProjectPlaybackState,
+  type ProjectPanelMode,
   type StemControlState,
 } from "../projectPlaybackState";
 import {
@@ -146,6 +147,7 @@ export function useProjectViewModel() {
   const [inspectorOpen, setInspectorOpen] = useState(defaultInspectorOpen);
   const [sourcesRailCollapsed, setSourcesRailCollapsed] = useState(defaultSourcesRailCollapsed);
   const [activeWorkspace, setActiveWorkspace] = useState(defaultProjectWorkspace);
+  const [activeProjectPanel, setActiveProjectPanel] = useState<ProjectPanelMode>("studio");
   const [playbackDisplayMode, setPlaybackDisplayMode] = useState<PlaybackDisplayMode>("combined");
   const [playbackDisplayModeSource, setPlaybackDisplayModeSource] =
     useState<PlaybackDisplayModeSource>("default");
@@ -1142,6 +1144,7 @@ export function useProjectViewModel() {
     setActiveWorkspace(
       hasStoredPlayback ? storedPlaybackState.activeWorkspace : defaultProjectWorkspace,
     );
+    setActiveProjectPanel(storedPlaybackState.activeProjectPanel);
     setPlaybackDisplayMode(
       hasStoredPlayback
         ? storedPlaybackState.playbackDisplayMode
@@ -1287,6 +1290,7 @@ export function useProjectViewModel() {
       selectedPrimaryArtifactId,
       selectedStemSourceArtifactId,
       activeWorkspace,
+      activeProjectPanel,
       playbackDisplayMode,
       capoTransposeSemitones: capoSemitones,
       precountEnabled,
@@ -1297,6 +1301,7 @@ export function useProjectViewModel() {
       dismissedStemJobIds,
     });
   }, [
+    activeProjectPanel,
     activeWorkspace,
     capoSemitones,
     chordsFollowEnabled,
@@ -1547,6 +1552,7 @@ export function useProjectViewModel() {
 
   return {
     activeWorkspace,
+    activeProjectPanel,
     activeChordIndex,
     activeEnharmonicKeyContext,
     activeLyricsIndex,
@@ -1598,6 +1604,7 @@ export function useProjectViewModel() {
     handleSelectPrimaryArtifact,
     handleSelectStemArtifact,
     handleSelectWorkspace,
+    handleSelectProjectPanel: setActiveProjectPanel,
     handleSetChordsFollowEnabled,
     handleSetLyricsFollowEnabled,
     handleSetPrecountClickCount,

--- a/apps/desktop/src/features/projects/projectPlaybackState.ts
+++ b/apps/desktop/src/features/projects/projectPlaybackState.ts
@@ -5,6 +5,8 @@ import {
   type ProjectWorkspaceMode,
 } from "../../lib/preferences";
 
+export type ProjectPanelMode = "studio" | "analysis";
+
 export type StemControlState = {
   muted: boolean;
   solo: boolean;
@@ -19,6 +21,7 @@ export type StoredProjectPlaybackState = {
   selectedPrimaryArtifactId: string | null;
   selectedStemSourceArtifactId: string | null;
   activeWorkspace: ProjectWorkspaceMode;
+  activeProjectPanel: ProjectPanelMode;
   playbackDisplayMode: PlaybackDisplayMode;
   capoTransposeSemitones: number;
   precountEnabled: boolean;
@@ -36,6 +39,7 @@ const DEFAULT_STORED_PROJECT_PLAYBACK_STATE: StoredProjectPlaybackState = {
   selectedPrimaryArtifactId: null,
   selectedStemSourceArtifactId: null,
   activeWorkspace: "project",
+  activeProjectPanel: "studio",
   playbackDisplayMode: "combined",
   capoTransposeSemitones: 0,
   precountEnabled: false,
@@ -75,6 +79,10 @@ function normalizeStemControlState(value: unknown): StemControlState {
   };
 }
 
+function isProjectPanelMode(value: unknown): value is ProjectPanelMode {
+  return value === "studio" || value === "analysis";
+}
+
 function normalizeStoredProjectPlaybackState(value: unknown): StoredProjectPlaybackState {
   if (!value || typeof value !== "object") {
     return DEFAULT_STORED_PROJECT_PLAYBACK_STATE;
@@ -109,6 +117,9 @@ function normalizeStoredProjectPlaybackState(value: unknown): StoredProjectPlayb
     activeWorkspace: isProjectWorkspaceMode(candidate.activeWorkspace)
       ? candidate.activeWorkspace
       : DEFAULT_STORED_PROJECT_PLAYBACK_STATE.activeWorkspace,
+    activeProjectPanel: isProjectPanelMode(candidate.activeProjectPanel)
+      ? candidate.activeProjectPanel
+      : DEFAULT_STORED_PROJECT_PLAYBACK_STATE.activeProjectPanel,
     playbackDisplayMode: isPlaybackDisplayMode(candidate.playbackDisplayMode)
       ? candidate.playbackDisplayMode
       : DEFAULT_STORED_PROJECT_PLAYBACK_STATE.playbackDisplayMode,

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -304,8 +304,6 @@ export function SettingsView() {
     defaultTunerReferenceHz,
     setInformationDensity,
     setEnharmonicDisplayMode,
-    setDefaultInspectorOpen,
-    setDefaultSourcesRailCollapsed,
     setDefaultProjectWorkspace,
     setDefaultPlaybackDisplayMode,
     setDefaultChordBackend,
@@ -482,14 +480,6 @@ export function SettingsView() {
             <dd>{enharmonicDisplayLabel(enharmonicDisplayMode)}</dd>
           </div>
           <div className="settings-overview__stat">
-            <dt>Inspector</dt>
-            <dd>{defaultInspectorOpen ? "Open on load" : "Closed on load"}</dd>
-          </div>
-          <div className="settings-overview__stat">
-            <dt>Sources rail</dt>
-            <dd>{defaultSourcesRailCollapsed ? "Collapsed" : "Expanded"}</dd>
-          </div>
-          <div className="settings-overview__stat">
             <dt>First project workspace</dt>
             <dd>{projectWorkspaceLabel(defaultProjectWorkspace)}</dd>
           </div>
@@ -663,18 +653,6 @@ export function SettingsView() {
           />
 
           <div className="settings-toggle-list">
-            <PreferenceToggle
-              description="Keep transform, export, and analysis controls visible on first load."
-              label="Open inspector by default"
-              onChange={setDefaultInspectorOpen}
-              value={defaultInspectorOpen}
-            />
-            <PreferenceToggle
-              description="Start with more playback space when you reopen dense projects."
-              label="Collapse sources rail by default"
-              onChange={setDefaultSourcesRailCollapsed}
-              value={defaultSourcesRailCollapsed}
-            />
             <PreferenceToggle
               description="Start each project with lyrics follow enabled until that project stores its own setting."
               label="Enable lyrics follow by default"

--- a/apps/desktop/src/styles/base.css
+++ b/apps/desktop/src/styles/base.css
@@ -79,6 +79,7 @@
 html,
 body,
 #root {
+  height: 100vh;
   min-height: 100vh;
 }
 
@@ -140,23 +141,80 @@ a {
 
 .app-shell {
   display: grid;
-  grid-template-columns: 240px minmax(0, 1fr);
-  min-height: 100vh;
+  grid-template-columns: var(--app-sidebar-width, 15rem) minmax(0, 1fr);
+  height: 100vh;
+  min-height: 0;
+  overflow: hidden;
+  transition: grid-template-columns 180ms ease;
+}
+
+.app-shell--compact {
+  --app-sidebar-width: 4.5rem;
+  --screen-padding: 1.15rem;
+  --screen-gap: 0.85rem;
 }
 
 .sidebar {
-  padding: 1.5rem;
+  min-width: 0;
+  padding: 1.2rem 0.9rem;
   background: var(--sidebar-bg);
   color: var(--sidebar-text);
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.2rem;
+  overflow: hidden auto;
 }
 
 .brand {
   display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+  border-radius: 18px;
+  color: var(--sidebar-text);
+}
+
+.brand__mark {
+  display: inline-grid;
+  flex: 0 0 2.45rem;
+  inline-size: 2.45rem;
+  block-size: 2.45rem;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--divider) 72%, transparent);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--panel-strong) 72%, var(--sidebar-bg) 28%);
+}
+
+.brand__icon,
+.nav__icon,
+.button__icon {
+  inline-size: 1.1rem;
+  block-size: 1.1rem;
+  flex: 0 0 auto;
+}
+
+.brand__copy,
+.nav__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.brand__copy {
+  display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.2rem;
+}
+
+.app-shell--compact .brand {
+  justify-content: center;
+}
+
+.app-shell--compact .brand__copy,
+.app-shell--compact .nav__label,
+.app-shell--compact .background-playback {
+  display: none;
 }
 
 .background-playback {
@@ -268,9 +326,18 @@ a {
 }
 
 .nav a {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
   padding: 0.8rem 0.95rem;
   border-radius: 999px;
   color: var(--sidebar-muted);
+}
+
+.app-shell--compact .nav a {
+  justify-content: center;
+  padding-inline: 0;
+  min-height: 2.7rem;
 }
 
 .nav a.active {
@@ -279,6 +346,8 @@ a {
 }
 
 .main-content {
+  min-height: 0;
+  overflow: auto;
   padding: var(--screen-padding, 2rem);
 }
 
@@ -300,6 +369,10 @@ a {
   font-size: clamp(2.2rem, 4vw, 3.4rem);
   margin: 0;
   line-height: 1.04;
+}
+
+.screen__header--project h1 {
+  font-size: clamp(1.7rem, 3vw, 2.55rem);
 }
 
 .screen__header--library {
@@ -393,6 +466,10 @@ a {
 
 .button--small {
   padding: 0.56rem 0.9rem;
+}
+
+.button__icon {
+  margin-left: 0.45rem;
 }
 
 .panel {

--- a/apps/desktop/src/styles/library.css
+++ b/apps/desktop/src/styles/library.css
@@ -6,6 +6,9 @@
 }
 
 .library-toolbar__summary {
+  display: flex;
+  min-height: 3.1rem;
+  align-items: center;
   color: var(--muted);
   white-space: nowrap;
 }
@@ -23,21 +26,58 @@
 
 .project-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 1rem;
+  gap: 0.55rem;
+}
+
+.project-library-table {
+  grid-template-columns: 1fr;
+}
+
+.project-library-table__header,
+.project-card__link {
+  display: grid;
+  grid-template-columns: 3rem minmax(14rem, 1.35fr) minmax(9rem, 0.6fr) minmax(12rem, 0.8fr);
+  gap: 0.9rem;
+  align-items: center;
+}
+
+.project-library-table__header {
+  padding: 0.1rem 0.72rem 0.15rem;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 700;
 }
 
 .project-card {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  padding: 1.25rem;
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.6rem 0.72rem;
   background: var(--project-card-bg);
   color: var(--project-card-text);
-  border-radius: 26px;
+  border-radius: 16px;
   border: 1px solid var(--panel-border);
-  box-shadow: 0 18px 36px var(--project-card-shadow);
-  min-height: 260px;
+  box-shadow: 0 10px 26px color-mix(in srgb, var(--project-card-shadow) 66%, transparent);
+  min-height: 0;
+}
+
+.project-library-row__icon {
+  display: inline-grid;
+  inline-size: 3rem;
+  block-size: 3rem;
+  place-items: center;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--surface-muted) 78%, transparent);
+  color: var(--playback-accent);
+}
+
+.project-library-row__icon svg {
+  inline-size: 1.18rem;
+  block-size: 1.18rem;
+}
+
+.project-library-row__cell {
+  color: var(--muted);
+  font-size: 0.9rem;
 }
 
 .project-card__meta-row,
@@ -57,26 +97,19 @@
   font-size: 0.83rem;
 }
 
-.project-card__link {
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  gap: 1rem;
-  color: inherit;
-}
-
 .project-card__title-block {
   min-width: 0;
 }
 
 .project-card__title-block h2 {
   margin: 0;
-  font-size: 1.55rem;
-  line-height: 1.12;
+  font-size: 1rem;
+  line-height: 1.15;
 }
 
 .card-details {
-  margin-top: auto;
+  display: none;
+  margin-top: 0;
   border-top: 1px solid color-mix(in srgb, var(--card-muted) 18%, transparent);
   padding-top: 0.85rem;
 }
@@ -101,4 +134,3 @@
 .path {
   word-break: break-word;
 }
-

--- a/apps/desktop/src/styles/project-inspector.css
+++ b/apps/desktop/src/styles/project-inspector.css
@@ -10,6 +10,52 @@
   gap: 1rem;
 }
 
+.inspector-panel {
+  --panel-padding: 0.86rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.inspector-panel__heading {
+  align-items: center;
+}
+
+.inspector-panel__heading h2 {
+  font-size: 1.28rem;
+  line-height: 1;
+}
+
+.inspector-panel__toggle {
+  flex-shrink: 0;
+}
+
+.inspector-stack--analysis .section-stack {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(18rem, 0.75fr);
+  grid-template-areas:
+    "summary details"
+    "summary export"
+    "danger danger";
+  align-items: start;
+}
+
+.analysis-summary-panel {
+  grid-area: summary;
+}
+
+.analysis-export-panel {
+  grid-area: export;
+}
+
+.analysis-details-panel {
+  grid-area: details;
+}
+
+.analysis-danger-panel {
+  grid-area: danger;
+}
+
 .mix-builder__retune {
   display: flex;
   flex-direction: column;
@@ -60,6 +106,18 @@
   color: var(--input-text);
 }
 
+.mix-builder__footer {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 0.85rem;
+  border-top: 1px solid var(--divider);
+}
+
+.mix-builder__footer .button {
+  min-width: min(100%, 11rem);
+  justify-content: center;
+}
+
 .key-shift__header {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -86,4 +144,3 @@
   line-height: 0.95;
   min-width: 0;
 }
-

--- a/apps/desktop/src/styles/project-layout.css
+++ b/apps/desktop/src/styles/project-layout.css
@@ -1,16 +1,82 @@
+.project-screen {
+  min-height: 0;
+}
+
+.project-screen--playback {
+  height: 100%;
+  overflow: hidden;
+}
+
+.project-workspace {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.project-panel-toolbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.project-panel-tabs {
+  display: inline-flex;
+  gap: 0.3rem;
+  padding: 0.24rem;
+  border: 1px solid var(--divider);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--panel-strong) 74%, transparent);
+}
+
+.project-panel-tabs__button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-weight: 750;
+  padding: 0.45rem 0.8rem;
+}
+
+.project-panel-tabs__button--active {
+  color: var(--text);
+  border-color: color-mix(in srgb, var(--playback-accent) 30%, transparent);
+  background: color-mix(in srgb, var(--panel) 82%, transparent);
+}
+
+.project-panel-tabs__icon,
+.project-inspector-toggle__icon {
+  inline-size: 1rem;
+  block-size: 1rem;
+}
+
+.project-inspector-toggle {
+  gap: 0.45rem;
+}
+
+.project-inspector-toggle--active {
+  border-color: color-mix(in srgb, var(--playback-accent) 34%, var(--button-border));
+}
+
 .project-workbench {
   display: grid;
-  grid-template-columns: minmax(182px, 0.56fr) minmax(0, 1.86fr) minmax(320px, 0.95fr);
-  gap: 1rem;
+  grid-template-columns: minmax(12rem, 0.58fr) minmax(0, 1fr) minmax(20rem, 0.95fr);
+  gap: 0.85rem;
   align-items: start;
+  min-height: 0;
 }
 
 .project-workspace-tabs {
   display: inline-flex;
   gap: 0.45rem;
   flex-wrap: wrap;
-  margin-bottom: 1rem;
-  padding: 0.35rem;
+  margin-bottom: 0.15rem;
+  padding: 0.28rem;
   border: 1px solid var(--divider);
   border-radius: 999px;
   background: color-mix(in srgb, var(--panel-strong) 74%, transparent);
@@ -22,7 +88,7 @@
   background: transparent;
   color: var(--muted);
   font-weight: 700;
-  padding: 0.58rem 1rem;
+  padding: 0.48rem 0.9rem;
   cursor: pointer;
 }
 
@@ -34,15 +100,41 @@
 }
 
 .project-workbench--wide {
-  grid-template-columns: minmax(182px, 0.6fr) minmax(0, 2.12fr);
+  grid-template-columns: minmax(12rem, 0.58fr) minmax(0, 1fr);
+}
+
+.project-workbench--inspector-collapsed {
+  grid-template-columns: minmax(12rem, 0.58fr) minmax(0, 1fr) 4.75rem;
 }
 
 .project-workbench--sources-collapsed {
-  grid-template-columns: 82px minmax(0, 1.98fr) minmax(320px, 0.95fr);
+  grid-template-columns: 4.75rem minmax(0, 1fr) minmax(20rem, 0.95fr);
 }
 
 .project-workbench--sources-collapsed.project-workbench--wide {
-  grid-template-columns: 82px minmax(0, 2.22fr);
+  grid-template-columns: 4.75rem minmax(0, 1fr);
+}
+
+.project-workbench--sources-collapsed.project-workbench--inspector-collapsed {
+  grid-template-columns: 4.75rem minmax(0, 1fr) 4.75rem;
+}
+
+.project-analysis-workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-areas:
+    "analysis"
+    "jobs";
+  gap: 0.85rem;
+  align-items: start;
+}
+
+.project-analysis-workspace .inspector-stack--analysis {
+  grid-area: analysis;
+}
+
+.project-analysis-workspace .jobs-history {
+  grid-area: jobs;
 }
 
 .processing-panel {
@@ -164,6 +256,22 @@
 
 .rail-summary-chip strong {
   font-size: 0.94rem;
+}
+
+.inspector-collapsed {
+  display: flex;
+  min-height: 100%;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 0.72rem 0.48rem;
+  color: var(--text);
+  cursor: pointer;
+  writing-mode: vertical-rl;
+}
+
+.inspector-collapsed:hover {
+  border-color: var(--button-hover-border);
 }
 
 .rail-section {
@@ -389,4 +497,36 @@
   color: var(--muted);
   font-size: 0.88rem;
   line-height: 1.05;
+}
+
+@media (max-width: 1200px) {
+  .project-analysis-workspace {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "analysis"
+      "jobs";
+  }
+
+  .inspector-stack--analysis .section-stack {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "summary"
+      "details"
+      "export"
+      "danger";
+  }
+}
+
+@media (max-width: 1024px) {
+  .project-workbench,
+  .project-workbench--sources-collapsed,
+  .project-workbench--inspector-collapsed,
+  .project-workbench--sources-collapsed.project-workbench--inspector-collapsed {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .inspector-collapsed {
+    min-height: 3.75rem;
+    writing-mode: horizontal-tb;
+  }
 }

--- a/apps/desktop/src/styles/project-playback.css
+++ b/apps/desktop/src/styles/project-playback.css
@@ -509,8 +509,13 @@
 
 .lyrics-editor {
   display: flex;
+  flex: 1;
   flex-direction: column;
   gap: 0.75rem;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0.35rem 0.5rem 0.75rem;
+  scrollbar-gutter: stable;
 }
 
 .lyrics-theater {
@@ -661,29 +666,63 @@
 
 .screen__header--compact {
   align-items: center;
-  margin-bottom: -0.2rem;
+  margin-bottom: -0.35rem;
 }
 
 .screen__header--compact .screen__title-block h1 {
-  font-size: clamp(1.85rem, 3vw, 2.6rem);
+  font-size: clamp(1.35rem, 2vw, 1.9rem);
+}
+
+.screen__header--compact .screen__title-block {
+  gap: 0.2rem;
+}
+
+.screen__header--compact .eyebrow {
+  margin-bottom: 0;
+  font-size: 0.66rem;
+  letter-spacing: 0.14em;
 }
 
 .playback-workspace--practice {
   display: grid;
+  flex: 1 1 0;
   grid-template-columns: minmax(16rem, 20rem) minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr) auto;
   grid-template-areas:
     "rail surface"
     "transport transport";
   align-items: start;
-  gap: 1rem;
+  gap: 0.75rem;
+  min-height: 0;
+  overflow: hidden;
+  transition: grid-template-columns 180ms ease;
 }
 
 .playback-practice-rail {
+  --panel-padding: 1rem;
   grid-area: rail;
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
-  position: static;
+  align-self: stretch;
+  min-height: 0;
+  max-height: 100%;
+  overflow: hidden;
+  position: relative;
+  transition:
+    opacity 160ms ease,
+    transform 160ms ease;
+}
+
+.playback-practice-rail__content {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+  flex-direction: column;
+  gap: 0.68rem;
+  overflow: auto;
+  transition:
+    opacity 160ms ease,
+    visibility 160ms ease;
 }
 
 .playback-practice-rail__header {
@@ -821,9 +860,11 @@
   grid-area: surface;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
   min-width: 0;
-  min-height: min(48rem, calc(100vh - 13rem));
+  min-height: 0;
+  height: 100%;
+  overflow: hidden;
 }
 
 .playback-practice-surface__header {
@@ -831,6 +872,10 @@
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 1rem;
   align-items: start;
+  transition:
+    opacity 160ms ease,
+    max-height 160ms ease,
+    transform 160ms ease;
 }
 
 .playback-practice-surface__header h2 {
@@ -886,13 +931,95 @@
   gap: 0.8rem;
 }
 
+.playback-workspace--focus {
+  grid-template-columns: 3.75rem minmax(0, 1fr);
+}
+
+.playback-workspace--focus .playback-practice-rail {
+  --panel-padding: 0.5rem;
+  overflow: hidden;
+  opacity: 1;
+  pointer-events: auto;
+  transform: none;
+}
+
+.playback-workspace--focus:has(.playback-practice-rail:hover),
+.playback-workspace--focus:has(.playback-practice-rail:focus-within) {
+  grid-template-columns: minmax(16rem, 20rem) minmax(0, 1fr);
+}
+
+.playback-practice-rail__focus-icons {
+  display: none;
+}
+
+.playback-workspace--focus .playback-practice-rail__focus-icons {
+  display: grid;
+  position: absolute;
+  z-index: 2;
+  inset-block-start: 0.5rem;
+  inset-inline: 0.5rem;
+  gap: 0.55rem;
+  outline: none;
+}
+
+.playback-practice-rail__focus-icons span {
+  display: inline-grid;
+  inline-size: 2.25rem;
+  block-size: 2.25rem;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--divider) 82%, transparent);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--panel-strong) 76%, transparent);
+  color: var(--muted);
+}
+
+.playback-practice-rail__focus-icons svg {
+  inline-size: 1.08rem;
+  block-size: 1.08rem;
+}
+
+.playback-workspace--focus .playback-practice-rail__content {
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+}
+
+.playback-workspace--focus:has(.playback-practice-rail:hover) .playback-practice-rail,
+.playback-workspace--focus:has(.playback-practice-rail:focus-within) .playback-practice-rail {
+  --panel-padding: 1rem;
+}
+
+.playback-workspace--focus:has(.playback-practice-rail:hover) .playback-practice-rail__focus-icons,
+.playback-workspace--focus:has(.playback-practice-rail:focus-within) .playback-practice-rail__focus-icons {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.playback-workspace--focus:has(.playback-practice-rail:hover) .playback-practice-rail__content,
+.playback-workspace--focus:has(.playback-practice-rail:focus-within) .playback-practice-rail__content {
+  overflow: auto;
+  opacity: 1;
+  pointer-events: auto;
+  visibility: visible;
+}
+
+.playback-workspace--focus .playback-practice-surface__header {
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  pointer-events: none;
+  transform: translateY(-0.4rem);
+}
+
 .playback-practice-body--chords {
   justify-content: flex-start;
 }
 
 .lyrics-theater--practice {
-  min-height: min(42rem, calc(100vh - 20rem));
-  max-height: min(42rem, calc(100vh - 20rem));
+  min-height: 0;
+  max-height: none;
+  flex: 1;
 }
 
 .chord-preview-grid--hero {
@@ -916,8 +1043,8 @@
   flex: 1;
   flex-direction: column;
   gap: 0.85rem;
-  min-height: min(42rem, calc(100vh - 20rem));
-  max-height: min(42rem, calc(100vh - 20rem));
+  min-height: 0;
+  max-height: none;
   overflow-y: auto;
   padding: 0.5rem 0.65rem;
   scrollbar-gutter: stable;
@@ -1048,7 +1175,8 @@
   z-index: 40;
   display: flex;
   justify-content: flex-end;
-  background: color-mix(in srgb, black 36%, transparent);
+  pointer-events: none;
+  background: transparent;
 }
 
 .tab-import-drawer {
@@ -1056,12 +1184,16 @@
   width: min(46rem, 100%);
   height: 100%;
   min-width: 0;
+  max-height: none;
   flex-direction: column;
   gap: 1rem;
   overflow-y: auto;
-  border-left: 1px solid var(--divider);
+  border: 1px solid var(--divider);
+  border-right: 0;
+  border-radius: 20px 0 0 20px;
   background: var(--panel);
   padding: 1rem;
+  pointer-events: auto;
   box-shadow: -18px 0 44px color-mix(in srgb, black 24%, transparent);
 }
 
@@ -1270,16 +1402,30 @@
   cursor: pointer;
 }
 
-@media (max-width: 980px) {
+@media (max-width: 1100px) {
   .playback-workspace--practice {
     grid-template-columns: 1fr;
+    grid-template-rows: minmax(0, 7rem) minmax(0, 1fr) auto;
     grid-template-areas:
       "rail"
       "surface"
       "transport";
   }
 
+  .playback-workspace--focus {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(0, 1fr) auto;
+    grid-template-areas:
+      "surface"
+      "transport";
+  }
+
+  .playback-workspace--focus .playback-practice-rail {
+    display: none;
+  }
+
   .playback-practice-rail {
+    max-height: 7rem;
     position: static;
   }
 
@@ -1301,6 +1447,49 @@
 
   .tab-import-detail {
     position: static;
+  }
+}
+
+@media (max-width: 720px) {
+  .playback-workspace--practice {
+    grid-template-rows: minmax(0, 2.75rem) minmax(0, 1fr) auto;
+  }
+
+  .playback-practice-rail {
+    max-height: 2.75rem;
+  }
+
+  .playback-practice-surface__header {
+    max-height: 4.25rem;
+    overflow: auto;
+  }
+
+  .playback-practice-surface__header h2 {
+    font-size: 1.28rem;
+  }
+
+  .playback-practice-surface__controls {
+    align-items: flex-start;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: 0.15rem;
+  }
+
+  .playback-mode-toggle,
+  .playback-practice-actions {
+    flex: 0 0 auto;
+  }
+
+  .playback-mode-toggle__button,
+  .playback-practice-actions .button,
+  .playback-follow-chip {
+    padding: 0.38rem 0.6rem;
+    font-size: 0.78rem;
+  }
+
+  .transport--compact {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/apps/desktop/src/styles/target-selector.css
+++ b/apps/desktop/src/styles/target-selector.css
@@ -86,12 +86,12 @@
 
 .target-selector__preview--lower {
   border-right: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
-  justify-content: flex-start;
+  justify-content: center;
 }
 
 .target-selector__preview--higher {
   border-left: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
-  justify-content: flex-end;
+  justify-content: center;
 }
 
 .target-selector__preview--disabled {
@@ -185,10 +185,19 @@
   text-transform: uppercase;
 }
 
+.target-selector__current-meta-icon {
+  display: none;
+}
+
 .target-selector__chevron {
   position: absolute;
   left: 50%;
   bottom: 0;
+  display: inline-flex;
+  width: 1rem;
+  height: 1rem;
+  align-items: center;
+  justify-content: center;
   transform: translateX(-50%);
   color: color-mix(in srgb, var(--chip-active-border) 82%, var(--text));
   font-size: 1.08rem;
@@ -226,12 +235,19 @@
 }
 
 .target-selector__group-label {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
   padding: 0.5rem 0.72rem 0.28rem;
   color: var(--muted);
   font-size: 0.68rem;
   font-weight: 700;
   letter-spacing: 0.14em;
   text-transform: uppercase;
+}
+
+.target-selector__group-icon {
+  display: none;
 }
 
 .target-selector__option {
@@ -376,4 +392,3 @@
 .target-selector__trigger[aria-expanded="true"] .target-selector__chevron {
   color: color-mix(in srgb, var(--playback-accent) 68%, var(--text));
 }
-

--- a/apps/desktop/src/styles/utilities-responsive.css
+++ b/apps/desktop/src/styles/utilities-responsive.css
@@ -17,7 +17,8 @@
 
 @media (max-width: 1200px) {
   .project-workbench,
-  .project-workbench--wide {
+  .project-workbench--wide,
+  .project-analysis-workspace {
     grid-template-columns: 1fr;
   }
 
@@ -41,6 +42,7 @@
 @media (max-width: 1000px) {
   .app-shell {
     grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(0, 1fr);
   }
 
   .sidebar {
@@ -52,6 +54,41 @@
 
   .nav {
     flex-direction: row;
+  }
+
+  .app-shell--compact .brand__copy {
+    display: flex;
+  }
+
+  .app-shell--compact .nav__label {
+    display: inline;
+  }
+
+  .app-shell--compact .nav a {
+    justify-content: flex-start;
+    padding-inline: 0.85rem;
+  }
+
+  .main-content {
+    --screen-padding: 1rem;
+  }
+
+  .project-panel-toolbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .project-library-table__header {
+    display: none;
+  }
+
+  .project-card__link {
+    grid-template-columns: 2.75rem minmax(0, 1fr);
+  }
+
+  .project-library-row__cell,
+  .project-card__stats {
+    grid-column: 2;
   }
 
   .screen__header,
@@ -109,6 +146,47 @@
 
   .theme-studio-preview__selector-showcase {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .sidebar {
+    gap: 0.75rem;
+    padding: 0.75rem;
+  }
+
+  .brand__copy,
+  .app-shell--compact .brand__copy {
+    display: none;
+  }
+
+  .nav {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .nav a {
+    flex: 1;
+    justify-content: center;
+  }
+
+  .nav__label,
+  .app-shell--compact .nav__label {
+    display: none;
+  }
+
+  .project-panel-tabs {
+    width: 100%;
+  }
+
+  .project-panel-tabs__button {
+    flex: 1;
+    justify-content: center;
+  }
+
+  .project-inspector-toggle {
+    width: 100%;
+    justify-content: center;
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@tuneforge/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types
+      lucide-react:
+        specifier: ^1.14.0
+        version: 1.14.0(react@19.2.5)
       openapi-fetch:
         specifier: ^0.17.0
         version: 0.17.0
@@ -1396,6 +1399,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@1.14.0:
+    resolution: {integrity: sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -3140,6 +3148,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@1.14.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   lz-string@1.5.0: {}
 


### PR DESCRIPTION
## Summary
- Revamp the desktop shell around adaptive navigation, denser library/project layouts, and responsive project panels.
- Rework Playback into a practice-first frame with a bottom transport, collapsible rail behavior, and internal lyrics/chords scrolling.
- Split Project into Studio and Analysis flows, move processing back under Now Playing, and keep Mix Builder focused on retune/create-mix controls.
- Add layout coverage for responsive navigation, project tabs, playback focus mode, and updated control placement.

## Testing
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop exec vitest run`
- `git diff --check`
