### PR TITLE
feat: expand Android mobile app experiment

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -69,6 +69,24 @@ This document is an engineering notice and distribution checklist, not legal adv
 - **Source:** <https://github.com/rusqlite/rusqlite> and <https://sqlite.org/>
 - **Notes:** Used by the embedded Android backend. Desktop persistence remains in the Python backend.
 
+### android_system_properties
+
+- **License:** Apache-2.0 / MIT (dual)
+- **Source:** <https://github.com/nical/android_system_properties>
+- **Notes:** Used by the embedded Android backend to detect emulator runtimes for debug-only flow testing.
+
+### ndk-sys
+
+- **License:** Apache-2.0 / MIT (dual)
+- **Source:** <https://github.com/rust-mobile/ndk>
+- **Notes:** Used by the embedded Android backend to call Android NDK media decode APIs.
+
+### whisper-rs / whisper.cpp
+
+- **License:** Unlicense for whisper-rs; MIT for whisper.cpp
+- **Source:** <https://codeberg.org/tazz4843/whisper-rs> and <https://github.com/ggml-org/whisper.cpp>
+- **Notes:** Used by the embedded Android backend for side-loaded local lyrics transcription. Tuneforge does not redistribute Whisper model weights.
+
 ### React, Vite, TanStack Query, openapi-fetch, openapi-typescript, lucide-react
 
 - See each project's own license. The installed JavaScript tree is primarily permissive, with some non-copyleft notice/data licenses such as MPL-2.0 (`lightningcss`), BlueOak-1.0.0 (`lru-cache` / `minimatch`), CC-BY-4.0 (`caniuse-lite` browser data), and CC0-1.0 (`mdn-data`).

--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Tuneforge</title>
   </head>
   <body>
@@ -10,4 +10,3 @@
     <script type="module" src="/src/main.tsx"></script>
   </body>
   </html>
-

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,8 +5,10 @@
   "type": "module",
   "scripts": {
     "build": "tsc && vite build",
-    "android:build": "bash ../../scripts/android-arm64-env.sh tauri android build --target aarch64 --apk",
-    "android:build:debug": "bash ../../scripts/android-arm64-env.sh tauri android build --debug --target aarch64 --apk",
+    "android:prepare": "bash ../../scripts/android-prepare-generated.sh",
+    "android:icons": "tauri icon --output src-tauri/target/android-icons src-tauri/icons/icon.png",
+    "android:build": "pnpm android:prepare && pnpm android:icons && bash ../../scripts/android-arm64-env.sh tauri android build --target aarch64 --apk",
+    "android:build:debug": "pnpm android:prepare && pnpm android:icons && bash ../../scripts/android-arm64-env.sh tauri android build --debug --target aarch64 --apk",
     "android:studio": "bash ../../scripts/android-arm64-env.sh tauri android dev --open",
     "dev": "vite",
     "lint": "eslint .",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -95,6 +95,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.1",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +294,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfb"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +341,26 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -680,6 +729,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +877,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futf"
@@ -1330,6 +1391,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1576,6 +1643,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,7 +1807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -1749,6 +1825,16 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1862,6 +1948,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1944,6 +2036,16 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "num-conv"
@@ -3391,6 +3493,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni",
  "libc",
  "log",
@@ -3977,7 +4080,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 name = "tuneforge"
 version = "0.1.0"
 dependencies = [
+ "android_system_properties",
  "chrono",
+ "ndk-sys",
  "rusqlite",
  "serde",
  "serde_json",
@@ -3986,6 +4091,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "webkit2gtk",
+ "whisper-rs",
 ]
 
 [[package]]
@@ -4397,6 +4503,28 @@ dependencies = [
  "thiserror 2.0.18",
  "windows",
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "whisper-rs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2088172d00f936c348d6a72f488dc2660ab3f507263a195df308a3c2383229f6"
+dependencies = [
+ "whisper-rs-sys",
+]
+
+[[package]]
+name = "whisper-rs-sys"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f"
+dependencies = [
+ "bindgen",
+ "cfg-if",
+ "cmake",
+ "fs_extra",
+ "semver",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ default = []
 custom-protocol = ["tauri/custom-protocol"]
 
 [dependencies]
-tauri = { version = "2.5.0", features = [] }
+tauri = { version = "2.5.0", features = ["protocol-asset"] }
 tauri-plugin-dialog = "2.2.1"
 tauri-plugin-fs = "2.5.0"
 serde = { version = "1", features = ["derive"] }
@@ -27,4 +27,7 @@ chrono = { version = "0.4.44", features = ["serde"] }
 webkit2gtk = "2.0.2"
 
 [target.'cfg(target_os = "android")'.dependencies]
+android_system_properties = "0.1.5"
+ndk-sys = { version = "0.6.0", features = ["media"] }
 rusqlite = { version = "0.39.0", features = ["bundled"] }
+whisper-rs = "0.16.0"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -35,6 +35,7 @@ struct SystemDefaultInputVolume {
 }
 
 impl SystemDefaultInputVolume {
+    #[cfg(not(target_os = "android"))]
     fn supported(volume_percent: u8, muted: Option<bool>, backend: &'static str) -> Self {
         Self {
             supported: true,

--- a/apps/desktop/src-tauri/src/mobile_backend.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend.rs
@@ -6,15 +6,25 @@ use tauri::AppHandle;
 const MOBILE_UNAVAILABLE: &str = "Mobile embedded backend is only available in Android builds.";
 #[cfg(target_os = "android")]
 const GPU_REQUIRED: &str = "Local generation requires GPU acceleration on this device.";
+#[cfg(target_os = "android")]
+const LYRICS_NOT_WIRED: &str =
+    "Mobile lyrics transcription is not wired yet; emulator mode only tests the submit flow.";
+#[cfg(target_os = "android")]
+const STEMS_NOT_WIRED: &str =
+    "Mobile stem separation is not wired yet; emulator mode only tests the submit flow.";
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MobileCapabilities {
     platform: &'static str,
     media_backend: &'static str,
+    is_emulator: bool,
     gpu_backend: Option<&'static str>,
+    analysis_available: bool,
+    basic_chords_available: bool,
     whisper_available: bool,
     stem_separation_available: bool,
+    generation_testing_available: bool,
     max_recommended_model: Option<&'static str>,
     cpu_fallback_allowed: bool,
 }
@@ -239,28 +249,127 @@ mobile_stub!(mobile_cancel_job, JobResponse, app: AppHandle, job_id: String);
 #[cfg(target_os = "android")]
 mod android {
     use super::*;
+    use android_system_properties::AndroidSystemProperties;
     use chrono::{SecondsFormat, Utc};
     use rusqlite::{params, Connection, OptionalExtension, Row};
     use serde_json::json;
     use std::{
-        fs, io,
+        ffi::{CStr, CString},
+        fs, io, mem,
+        os::{fd::AsRawFd, raw::c_char},
         path::{Path, PathBuf},
+        ptr, slice,
         str::FromStr,
+        thread,
+        time::Instant,
     };
     use tauri::Manager;
     use tauri_plugin_fs::{FilePath, FsExt, OpenOptions};
+    use whisper_rs::{
+        install_logging_hooks, FullParams, SamplingStrategy, WhisperContext,
+        WhisperContextParameters,
+    };
+
+    const WHISPER_SAMPLE_RATE: u32 = 16_000;
+    const WHISPER_MODEL_DIR: &str = "models/whisper";
+    const WHISPER_MODEL_MISSING: &str =
+        "Side-load a Whisper ggml model into app storage at models/whisper/ggml-base.bin or models/whisper/ggml-tiny.bin to enable local lyrics.";
+
+    #[derive(Clone)]
+    struct WhisperModel {
+        path: PathBuf,
+        name: &'static str,
+        max_recommended_model: &'static str,
+    }
+
+    struct DecodedAudio {
+        samples: Vec<f32>,
+        sample_rate: u32,
+        channels: u32,
+    }
+
+    struct MobileLyricsTranscription {
+        backend: &'static str,
+        requested_device: &'static str,
+        device: &'static str,
+        model_name: String,
+        language: Option<String>,
+        segments: Vec<Value>,
+    }
 
     #[tauri::command]
-    pub fn mobile_capabilities() -> Result<MobileCapabilities, String> {
+    pub fn mobile_capabilities(app: AppHandle) -> Result<MobileCapabilities, String> {
+        let root = app_data_root(&app)?;
+        let whisper_model = find_whisper_model(&root);
+        let is_emulator = is_android_emulator();
         Ok(MobileCapabilities {
             platform: "android",
             media_backend: "android_media_codec",
+            is_emulator,
             gpu_backend: None,
-            whisper_available: false,
+            analysis_available: true,
+            basic_chords_available: true,
+            whisper_available: whisper_model.is_some(),
             stem_separation_available: false,
-            max_recommended_model: None,
+            generation_testing_available: generation_testing_available(is_emulator),
+            max_recommended_model: whisper_model
+                .as_ref()
+                .map(|model| model.max_recommended_model),
             cpu_fallback_allowed: false,
         })
+    }
+
+    fn generation_testing_available(is_emulator: bool) -> bool {
+        cfg!(debug_assertions) && is_emulator
+    }
+
+    fn is_android_emulator() -> bool {
+        let properties = AndroidSystemProperties::new();
+        if property_is(&properties, "ro.kernel.qemu", "1")
+            || property_is(&properties, "ro.boot.qemu", "1")
+        {
+            return true;
+        }
+
+        [
+            ("ro.hardware", &["goldfish", "ranchu"][..]),
+            ("ro.product.board", &["goldfish", "ranchu"]),
+            ("ro.product.device", &["generic", "emulator", "sdk_gphone"]),
+            ("ro.product.model", &["sdk", "emulator"]),
+            ("ro.product.name", &["sdk", "emulator"]),
+        ]
+        .iter()
+        .any(|(name, needles)| property_contains_any(&properties, name, needles))
+    }
+
+    fn property_is(properties: &AndroidSystemProperties, name: &str, expected: &str) -> bool {
+        properties
+            .get(name)
+            .is_some_and(|value| value.trim().eq_ignore_ascii_case(expected))
+    }
+
+    fn property_contains_any(
+        properties: &AndroidSystemProperties,
+        name: &str,
+        needles: &[&str],
+    ) -> bool {
+        properties.get(name).is_some_and(|value| {
+            let normalized = value.to_ascii_lowercase();
+            needles.iter().any(|needle| normalized.contains(needle))
+        })
+    }
+
+    fn generation_unavailable_message(job_type: &str) -> &'static str {
+        let is_emulator = is_android_emulator();
+        if generation_testing_available(is_emulator) {
+            match job_type {
+                "lyrics" => LYRICS_NOT_WIRED,
+                "stems" => STEMS_NOT_WIRED,
+                _ => GPU_REQUIRED,
+            }
+        } else {
+            GPU_REQUIRED
+        }
     }
 
     fn now_iso() -> String {
@@ -285,6 +394,11 @@ mod android {
 
     fn db(app: &AppHandle) -> Result<Connection, String> {
         let root = app_data_root(app)?;
+        db_at_root(&root)
+    }
+
+    fn db_at_root(root: &Path) -> Result<Connection, String> {
+        fs::create_dir_all(root).map_err(|error| error.to_string())?;
         let connection =
             Connection::open(root.join("mobile.sqlite3")).map_err(|error| error.to_string())?;
         connection
@@ -327,6 +441,42 @@ mod android {
                     started_at TEXT,
                     completed_at TEXT,
                     duration_seconds REAL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS analysis_results (
+                    project_id TEXT PRIMARY KEY,
+                    source_artifact_id TEXT,
+                    estimated_key TEXT,
+                    key_confidence REAL,
+                    estimated_reference_hz REAL,
+                    tuning_offset_cents REAL,
+                    tempo_bpm REAL,
+                    analysis_version TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS chord_timelines (
+                    project_id TEXT PRIMARY KEY,
+                    source_segments_json TEXT NOT NULL,
+                    timeline_json TEXT NOT NULL,
+                    backend TEXT,
+                    source_artifact_id TEXT,
+                    has_user_edits INTEGER NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS lyrics_transcripts (
+                    project_id TEXT PRIMARY KEY,
+                    backend TEXT NOT NULL,
+                    source_artifact_id TEXT,
+                    source_kind TEXT NOT NULL,
+                    requested_device TEXT,
+                    device TEXT,
+                    model_name TEXT,
+                    language TEXT,
+                    source_segments_json TEXT NOT NULL,
+                    segments_json TEXT NOT NULL,
+                    has_user_edits INTEGER NOT NULL,
                     created_at TEXT NOT NULL,
                     updated_at TEXT NOT NULL
                 );
@@ -453,6 +603,1682 @@ mod android {
         Ok(job)
     }
 
+    fn create_completed_job(
+        connection: &Connection,
+        project_id: &str,
+        job_type: &str,
+        source_artifact_id: Option<String>,
+    ) -> Result<JobSchema, String> {
+        let timestamp = now_iso();
+        let job = JobSchema {
+            id: new_id("job"),
+            project_id: Some(project_id.to_string()),
+            r#type: job_type.to_string(),
+            status: "completed".to_string(),
+            progress: 100,
+            source_artifact_id,
+            chord_backend: None,
+            chord_backend_fallback_from: None,
+            chord_source: None,
+            error_message: None,
+            runtime_device: Some("cpu".to_string()),
+            started_at: Some(timestamp.clone()),
+            completed_at: Some(timestamp.clone()),
+            duration_seconds: Some(0.0),
+            created_at: timestamp.clone(),
+            updated_at: timestamp,
+        };
+        connection
+            .execute(
+                "INSERT INTO jobs (id, project_id, type, status, progress, source_artifact_id, error_message, runtime_device, started_at, completed_at, duration_seconds, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+                params![
+                    job.id,
+                    job.project_id,
+                    job.r#type,
+                    job.status,
+                    job.progress,
+                    job.source_artifact_id,
+                    job.error_message,
+                    job.runtime_device,
+                    job.started_at,
+                    job.completed_at,
+                    job.duration_seconds,
+                    job.created_at,
+                    job.updated_at,
+                ],
+            )
+            .map_err(|error| error.to_string())?;
+        Ok(job)
+    }
+
+    fn create_running_job(
+        connection: &Connection,
+        project_id: &str,
+        job_type: &str,
+        source_artifact_id: Option<String>,
+    ) -> Result<JobSchema, String> {
+        let timestamp = now_iso();
+        let job = JobSchema {
+            id: new_id("job"),
+            project_id: Some(project_id.to_string()),
+            r#type: job_type.to_string(),
+            status: "running".to_string(),
+            progress: 5,
+            source_artifact_id,
+            chord_backend: None,
+            chord_backend_fallback_from: None,
+            chord_source: None,
+            error_message: None,
+            runtime_device: Some("cpu".to_string()),
+            started_at: Some(timestamp.clone()),
+            completed_at: None,
+            duration_seconds: None,
+            created_at: timestamp.clone(),
+            updated_at: timestamp,
+        };
+        connection
+            .execute(
+                "INSERT INTO jobs (id, project_id, type, status, progress, source_artifact_id, error_message, runtime_device, started_at, completed_at, duration_seconds, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+                params![
+                    job.id,
+                    job.project_id,
+                    job.r#type,
+                    job.status,
+                    job.progress,
+                    job.source_artifact_id,
+                    job.error_message,
+                    job.runtime_device,
+                    job.started_at,
+                    job.completed_at,
+                    job.duration_seconds,
+                    job.created_at,
+                    job.updated_at,
+                ],
+            )
+            .map_err(|error| error.to_string())?;
+        Ok(job)
+    }
+
+    fn update_job_progress(
+        connection: &Connection,
+        job_id: &str,
+        progress: i64,
+    ) -> Result<(), String> {
+        connection
+            .execute(
+                "UPDATE jobs SET progress = ?1, updated_at = ?2 WHERE id = ?3 AND status IN ('pending', 'running')",
+                params![progress, now_iso(), job_id],
+            )
+            .map_err(|error| error.to_string())?;
+        Ok(())
+    }
+
+    fn complete_running_job(
+        connection: &Connection,
+        job_id: &str,
+        duration_seconds: f64,
+    ) -> Result<(), String> {
+        let timestamp = now_iso();
+        connection
+            .execute(
+                "UPDATE jobs SET status = 'completed', progress = 100, error_message = NULL, runtime_device = 'cpu', completed_at = ?1, duration_seconds = ?2, updated_at = ?1 WHERE id = ?3 AND status IN ('pending', 'running')",
+                params![timestamp, duration_seconds, job_id],
+            )
+            .map_err(|error| error.to_string())?;
+        Ok(())
+    }
+
+    fn fail_running_job(
+        connection: &Connection,
+        job_id: &str,
+        message: &str,
+        duration_seconds: f64,
+    ) -> Result<(), String> {
+        let timestamp = now_iso();
+        connection
+            .execute(
+                "UPDATE jobs SET status = 'failed', progress = 0, error_message = ?1, completed_at = ?2, duration_seconds = ?3, updated_at = ?2 WHERE id = ?4 AND status IN ('pending', 'running')",
+                params![message, timestamp, duration_seconds, job_id],
+            )
+            .map_err(|error| error.to_string())?;
+        Ok(())
+    }
+
+    fn get_source_artifact(
+        connection: &Connection,
+        project_id: &str,
+    ) -> Result<ArtifactSchema, String> {
+        connection
+            .query_row(
+                "SELECT id, project_id, type, format, path, size_bytes, generated_by, can_delete, can_regenerate, metadata_json, created_at FROM artifacts WHERE project_id = ?1 AND type = 'source_audio' ORDER BY created_at DESC LIMIT 1",
+                params![project_id],
+                row_artifact,
+            )
+            .optional()
+            .map_err(|error| error.to_string())?
+            .ok_or_else(|| "Source audio is missing.".to_string())
+    }
+
+    struct MobileAudioFeatures {
+        duration_seconds: f64,
+        sample_rate: i64,
+        channels: i64,
+        pitch_classes: [f64; 12],
+    }
+
+    fn read_mobile_audio(path: &Path) -> Result<DecodedAudio, String> {
+        match read_wav_audio(path) {
+            Ok(audio) => Ok(audio),
+            Err(wav_error) => read_android_media_audio(path).map_err(|media_error| {
+                format!(
+                    "Mobile audio decode supports PCM WAV files and formats Android MediaCodec can decode. WAV decode failed: {wav_error}. Android MediaCodec decode failed: {media_error}"
+                )
+            }),
+        }
+    }
+
+    fn read_audio_features(path: &Path) -> Result<MobileAudioFeatures, String> {
+        const MAX_ANALYSIS_SECONDS: usize = 30;
+        let audio = read_mobile_audio(path)?;
+        if audio.sample_rate == 0 || audio.channels == 0 {
+            return Err("Decoded audio contained invalid stream metadata.".to_string());
+        }
+        if audio.samples.is_empty() {
+            return Err("Decoded audio contained no samples.".to_string());
+        }
+
+        let max_samples = audio
+            .samples
+            .len()
+            .min(audio.sample_rate as usize * MAX_ANALYSIS_SECONDS);
+        let samples = audio.samples[..max_samples]
+            .iter()
+            .map(|sample| *sample as f64)
+            .collect::<Vec<_>>();
+
+        Ok(MobileAudioFeatures {
+            duration_seconds: audio.samples.len() as f64 / audio.sample_rate as f64,
+            sample_rate: audio.sample_rate as i64,
+            channels: audio.channels as i64,
+            pitch_classes: pitch_class_energy(&samples, audio.sample_rate as f64),
+        })
+    }
+
+    fn create_playback_proxy_if_needed(project_root: &Path, source_path: &Path) -> Option<PathBuf> {
+        let format = source_format(source_path);
+        if !matches!(format.as_str(), "webm" | "mkv" | "mka") {
+            return None;
+        }
+
+        let audio = read_mobile_audio(source_path).ok()?;
+        if audio.samples.is_empty() || audio.sample_rate == 0 {
+            return None;
+        }
+
+        let playback_dir = project_root.join("playback");
+        fs::create_dir_all(&playback_dir).ok()?;
+        let playback_path = playback_dir.join("source-playback.wav");
+        write_mono_pcm_wav(&playback_path, &audio).ok()?;
+        Some(playback_path)
+    }
+
+    fn existing_playback_proxy_path(project_root: &Path) -> Option<PathBuf> {
+        let playback_path = project_root.join("playback").join("source-playback.wav");
+        playback_path.is_file().then_some(playback_path)
+    }
+
+    fn spawn_playback_proxy_generation(
+        root: PathBuf,
+        project_root: PathBuf,
+        source_path: PathBuf,
+        artifact_id: String,
+    ) {
+        if !matches!(source_format(&source_path).as_str(), "webm" | "mkv" | "mka") {
+            return;
+        }
+
+        thread::spawn(move || {
+            let Some(playback_path) = create_playback_proxy_if_needed(&project_root, &source_path)
+            else {
+                return;
+            };
+            let Ok(connection) = db_at_root(&root) else {
+                return;
+            };
+            let _ = attach_playback_proxy_metadata(&connection, &artifact_id, &playback_path);
+        });
+    }
+
+    fn attach_playback_proxy_metadata(
+        connection: &Connection,
+        artifact_id: &str,
+        playback_path: &Path,
+    ) -> Result<(), String> {
+        let metadata_json: String = connection
+            .query_row(
+                "SELECT metadata_json FROM artifacts WHERE id = ?1",
+                params![artifact_id],
+                |row| row.get(0),
+            )
+            .map_err(|error| error.to_string())?;
+        let mut metadata =
+            serde_json::from_str::<Value>(&metadata_json).unwrap_or_else(|_| json!({}));
+        metadata["playback_path"] = json!(playback_path.to_string_lossy().into_owned());
+        metadata["playback_format"] = json!("wav");
+        metadata["playback_generated_by"] = json!("android-mediacodec");
+        connection
+            .execute(
+                "UPDATE artifacts SET metadata_json = ?1 WHERE id = ?2",
+                params![metadata.to_string(), artifact_id],
+            )
+            .map_err(|error| error.to_string())?;
+        Ok(())
+    }
+
+    fn ensure_source_playback_proxy_metadata(
+        connection: &Connection,
+        root: &Path,
+        project_id: &str,
+    ) -> Result<(), String> {
+        let project = get_project_schema(connection, project_id)?;
+        let source_artifact = get_source_artifact(connection, project_id)?;
+        if source_artifact
+            .metadata
+            .get("playback_path")
+            .and_then(Value::as_str)
+            .is_some_and(|path| Path::new(path).is_file())
+        {
+            return Ok(());
+        }
+
+        let project_root = root.join("projects").join(project_id);
+        let playback_path = existing_playback_proxy_path(&project_root).or_else(|| {
+            create_playback_proxy_if_needed(&project_root, Path::new(&project.imported_path))
+        });
+        if let Some(playback_path) = playback_path {
+            attach_playback_proxy_metadata(connection, &source_artifact.id, &playback_path)?;
+        }
+        Ok(())
+    }
+
+    fn write_mono_pcm_wav(path: &Path, audio: &DecodedAudio) -> Result<(), String> {
+        if audio.sample_rate == 0 {
+            return Err("Decoded audio contained invalid stream metadata.".to_string());
+        }
+        let data_bytes = audio
+            .samples
+            .len()
+            .checked_mul(2)
+            .ok_or_else(|| "Decoded audio is too large for a playback proxy.".to_string())?;
+        let riff_size = 36usize
+            .checked_add(data_bytes)
+            .ok_or_else(|| "Decoded audio is too large for a playback proxy.".to_string())?;
+        let data_bytes = u32::try_from(data_bytes)
+            .map_err(|_| "Decoded audio is too large for a playback proxy.".to_string())?;
+        let riff_size = u32::try_from(riff_size)
+            .map_err(|_| "Decoded audio is too large for a playback proxy.".to_string())?;
+        let byte_rate = audio
+            .sample_rate
+            .checked_mul(2)
+            .ok_or_else(|| "Decoded audio sample rate is invalid.".to_string())?;
+
+        let mut bytes = Vec::with_capacity(44 + data_bytes as usize);
+        bytes.extend_from_slice(b"RIFF");
+        bytes.extend_from_slice(&riff_size.to_le_bytes());
+        bytes.extend_from_slice(b"WAVE");
+        bytes.extend_from_slice(b"fmt ");
+        bytes.extend_from_slice(&16u32.to_le_bytes());
+        bytes.extend_from_slice(&1u16.to_le_bytes());
+        bytes.extend_from_slice(&1u16.to_le_bytes());
+        bytes.extend_from_slice(&audio.sample_rate.to_le_bytes());
+        bytes.extend_from_slice(&byte_rate.to_le_bytes());
+        bytes.extend_from_slice(&2u16.to_le_bytes());
+        bytes.extend_from_slice(&16u16.to_le_bytes());
+        bytes.extend_from_slice(b"data");
+        bytes.extend_from_slice(&data_bytes.to_le_bytes());
+
+        for sample in &audio.samples {
+            let scaled = (sample.clamp(-1.0, 1.0) * i16::MAX as f32).round() as i16;
+            bytes.extend_from_slice(&scaled.to_le_bytes());
+        }
+
+        fs::write(path, bytes).map_err(|error| error.to_string())
+    }
+
+    fn read_wav_audio(path: &Path) -> Result<DecodedAudio, String> {
+        let bytes = fs::read(path).map_err(|error| error.to_string())?;
+        if bytes.len() < 12 || &bytes[0..4] != b"RIFF" || &bytes[8..12] != b"WAVE" {
+            return Err("Not a PCM WAV file.".to_string());
+        }
+
+        let mut audio_format = 0u16;
+        let mut channels = 0u16;
+        let mut sample_rate = 0u32;
+        let mut block_align = 0u16;
+        let mut bits_per_sample = 0u16;
+        let mut data_range: Option<(usize, usize)> = None;
+        let mut offset = 12usize;
+        while offset + 8 <= bytes.len() {
+            let chunk_id = &bytes[offset..offset + 4];
+            let chunk_size = read_u32_le(&bytes, offset + 4)
+                .ok_or_else(|| "Invalid WAV chunk header.".to_string())?
+                as usize;
+            let chunk_start = offset + 8;
+            let chunk_end = chunk_start.saturating_add(chunk_size);
+            if chunk_end > bytes.len() {
+                return Err("Invalid WAV chunk size.".to_string());
+            }
+            if chunk_id == b"fmt " {
+                if chunk_size < 16 {
+                    return Err("Invalid WAV fmt chunk.".to_string());
+                }
+                audio_format = read_u16_le(&bytes, chunk_start)
+                    .ok_or_else(|| "Invalid WAV audio format.".to_string())?;
+                channels = read_u16_le(&bytes, chunk_start + 2)
+                    .ok_or_else(|| "Invalid WAV channel count.".to_string())?;
+                sample_rate = read_u32_le(&bytes, chunk_start + 4)
+                    .ok_or_else(|| "Invalid WAV sample rate.".to_string())?;
+                block_align = read_u16_le(&bytes, chunk_start + 12)
+                    .ok_or_else(|| "Invalid WAV block alignment.".to_string())?;
+                bits_per_sample = read_u16_le(&bytes, chunk_start + 14)
+                    .ok_or_else(|| "Invalid WAV bit depth.".to_string())?;
+            } else if chunk_id == b"data" {
+                data_range = Some((chunk_start, chunk_end));
+            }
+            offset = chunk_end + (chunk_size % 2);
+        }
+
+        if audio_format != 1 && audio_format != 3 {
+            return Err("Lyrics WAV decode supports PCM and 32-bit float WAV files.".to_string());
+        }
+        if channels == 0 || sample_rate == 0 || block_align == 0 || bits_per_sample == 0 {
+            return Err("Invalid WAV stream metadata.".to_string());
+        }
+        let (data_start, data_end) =
+            data_range.ok_or_else(|| "WAV data chunk is missing.".to_string())?;
+        let frame_count = (data_end - data_start) / block_align as usize;
+        let bytes_per_sample = (bits_per_sample / 8) as usize;
+        if bytes_per_sample == 0 {
+            return Err("Invalid WAV bit depth.".to_string());
+        }
+
+        let mut samples = Vec::with_capacity(frame_count);
+        for frame_index in 0..frame_count {
+            let frame_start = data_start + frame_index * block_align as usize;
+            let mut sum = 0.0;
+            for channel_index in 0..channels as usize {
+                let sample_offset = frame_start + channel_index * bytes_per_sample;
+                sum += decode_wav_sample(&bytes, sample_offset, audio_format, bits_per_sample)?;
+            }
+            samples.push((sum / channels as f64).clamp(-1.0, 1.0) as f32);
+        }
+
+        Ok(DecodedAudio {
+            samples,
+            sample_rate,
+            channels: channels as u32,
+        })
+    }
+
+    struct MediaExtractorHandle {
+        ptr: *mut ndk_sys::AMediaExtractor,
+        data_source_file: Option<fs::File>,
+    }
+
+    impl MediaExtractorHandle {
+        fn new() -> Result<Self, String> {
+            let ptr = unsafe { ndk_sys::AMediaExtractor_new() };
+            if ptr.is_null() {
+                return Err("Android MediaExtractor could not be created.".to_string());
+            }
+            Ok(Self {
+                ptr,
+                data_source_file: None,
+            })
+        }
+
+        fn set_data_source(&mut self, path: &Path) -> Result<(), String> {
+            let file = fs::File::open(path).map_err(|error| {
+                format!("Android MediaExtractor could not open the imported audio: {error}")
+            })?;
+            let length: ndk_sys::off64_t = file
+                .metadata()
+                .map_err(|error| {
+                    format!("Android MediaExtractor could not inspect the imported audio: {error}")
+                })?
+                .len()
+                .try_into()
+                .map_err(|_| {
+                    "Imported audio is too large for Android MediaExtractor.".to_string()
+                })?;
+            let fd_status = unsafe {
+                ndk_sys::AMediaExtractor_setDataSourceFd(self.ptr, file.as_raw_fd(), 0, length)
+            };
+            if fd_status == ndk_sys::media_status_t::AMEDIA_OK {
+                self.data_source_file = Some(file);
+                return Ok(());
+            }
+
+            let path = CString::new(path.to_string_lossy().as_bytes())
+                .map_err(|_| "Audio path contains an invalid null byte.".to_string())?;
+            let status = unsafe { ndk_sys::AMediaExtractor_setDataSource(self.ptr, path.as_ptr()) };
+            if status != ndk_sys::media_status_t::AMEDIA_OK {
+                return Err("Android MediaExtractor could not open the imported audio.".to_string());
+            }
+            Ok(())
+        }
+    }
+
+    impl Drop for MediaExtractorHandle {
+        fn drop(&mut self) {
+            unsafe {
+                let _ = ndk_sys::AMediaExtractor_delete(self.ptr);
+            }
+        }
+    }
+
+    struct MediaFormatHandle(*mut ndk_sys::AMediaFormat);
+
+    impl MediaFormatHandle {
+        fn from_track(extractor: &MediaExtractorHandle, index: usize) -> Result<Self, String> {
+            let ptr = unsafe { ndk_sys::AMediaExtractor_getTrackFormat(extractor.ptr, index) };
+            if ptr.is_null() {
+                return Err("Android MediaExtractor returned an invalid track format.".to_string());
+            }
+            Ok(Self(ptr))
+        }
+    }
+
+    impl Drop for MediaFormatHandle {
+        fn drop(&mut self) {
+            unsafe {
+                let _ = ndk_sys::AMediaFormat_delete(self.0);
+            }
+        }
+    }
+
+    struct MediaCodecHandle {
+        ptr: *mut ndk_sys::AMediaCodec,
+        started: bool,
+    }
+
+    impl MediaCodecHandle {
+        fn new(mime: &str) -> Result<Self, String> {
+            let mime = CString::new(mime)
+                .map_err(|_| "Audio MIME type contains a null byte.".to_string())?;
+            let ptr = unsafe { ndk_sys::AMediaCodec_createDecoderByType(mime.as_ptr()) };
+            if ptr.is_null() {
+                return Err("Android MediaCodec has no decoder for this audio format.".to_string());
+            }
+            Ok(Self {
+                ptr,
+                started: false,
+            })
+        }
+
+        fn configure(&self, format: &MediaFormatHandle) -> Result<(), String> {
+            let status = unsafe {
+                ndk_sys::AMediaCodec_configure(
+                    self.ptr,
+                    format.0,
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    0,
+                )
+            };
+            if status != ndk_sys::media_status_t::AMEDIA_OK {
+                return Err("Android MediaCodec could not configure the audio decoder.".to_string());
+            }
+            Ok(())
+        }
+
+        fn start(&mut self) -> Result<(), String> {
+            let status = unsafe { ndk_sys::AMediaCodec_start(self.ptr) };
+            if status != ndk_sys::media_status_t::AMEDIA_OK {
+                return Err("Android MediaCodec could not start the audio decoder.".to_string());
+            }
+            self.started = true;
+            Ok(())
+        }
+    }
+
+    impl Drop for MediaCodecHandle {
+        fn drop(&mut self) {
+            unsafe {
+                if self.started {
+                    let _ = ndk_sys::AMediaCodec_stop(self.ptr);
+                }
+                let _ = ndk_sys::AMediaCodec_delete(self.ptr);
+            }
+        }
+    }
+
+    fn media_format_string(
+        format: &MediaFormatHandle,
+        key: *const c_char,
+    ) -> Result<Option<String>, String> {
+        let mut value: *const c_char = ptr::null();
+        let found = unsafe { ndk_sys::AMediaFormat_getString(format.0, key, &mut value) };
+        if !found || value.is_null() {
+            return Ok(None);
+        }
+        let value = unsafe { CStr::from_ptr(value) }
+            .to_str()
+            .map_err(|_| "Android media format contained invalid UTF-8.".to_string())?
+            .to_string();
+        Ok(Some(value))
+    }
+
+    fn media_format_i32(format: *mut ndk_sys::AMediaFormat, key: *const c_char) -> Option<i32> {
+        let mut value = 0i32;
+        let found = unsafe { ndk_sys::AMediaFormat_getInt32(format, key, &mut value) };
+        found.then_some(value)
+    }
+
+    fn media_format_handle_i32(format: &MediaFormatHandle, key: *const c_char) -> Option<i32> {
+        media_format_i32(format.0, key)
+    }
+
+    fn read_android_media_audio(path: &Path) -> Result<DecodedAudio, String> {
+        const TIMEOUT_US: i64 = 10_000;
+        const PCM_ENCODING_16BIT: i32 = 2;
+        const PCM_ENCODING_FLOAT: i32 = 4;
+
+        let mut extractor = MediaExtractorHandle::new()?;
+        extractor.set_data_source(path)?;
+
+        let track_count = unsafe { ndk_sys::AMediaExtractor_getTrackCount(extractor.ptr) };
+        let mut selected_track = None;
+        let mut selected_format = None;
+        let mut selected_mime = None;
+        for track_index in 0..track_count {
+            let format = MediaFormatHandle::from_track(&extractor, track_index)?;
+            let mime = media_format_string(&format, unsafe { ndk_sys::AMEDIAFORMAT_KEY_MIME })?;
+            if mime
+                .as_deref()
+                .is_some_and(|value| value.starts_with("audio/"))
+            {
+                selected_track = Some(track_index);
+                selected_mime = mime;
+                selected_format = Some(format);
+                break;
+            }
+        }
+
+        let track_index = selected_track.ok_or_else(|| {
+            "Android MediaExtractor did not find an audio track in the imported file.".to_string()
+        })?;
+        let format = selected_format
+            .ok_or_else(|| "Android MediaExtractor lost the selected audio format.".to_string())?;
+        let mime = selected_mime.ok_or_else(|| {
+            "Android MediaExtractor did not report an audio MIME type.".to_string()
+        })?;
+
+        let sample_rate =
+            media_format_handle_i32(&format, unsafe { ndk_sys::AMEDIAFORMAT_KEY_SAMPLE_RATE })
+                .ok_or_else(|| {
+                    "Android MediaExtractor did not report an audio sample rate.".to_string()
+                })?;
+        let channels =
+            media_format_handle_i32(&format, unsafe { ndk_sys::AMEDIAFORMAT_KEY_CHANNEL_COUNT })
+                .ok_or_else(|| {
+                    "Android MediaExtractor did not report an audio channel count.".to_string()
+                })?;
+        if sample_rate <= 0 || channels <= 0 {
+            return Err("Android MediaExtractor reported invalid audio metadata.".to_string());
+        }
+
+        let status = unsafe { ndk_sys::AMediaExtractor_selectTrack(extractor.ptr, track_index) };
+        if status != ndk_sys::media_status_t::AMEDIA_OK {
+            return Err("Android MediaExtractor could not select the audio track.".to_string());
+        }
+
+        let mut codec = MediaCodecHandle::new(&mime)?;
+        codec.configure(&format)?;
+        codec.start()?;
+
+        let mut output_sample_rate = sample_rate;
+        let mut output_channels = channels;
+        let mut output_encoding = PCM_ENCODING_16BIT;
+        let mut decoded = Vec::new();
+        let mut input_eos = false;
+        let mut output_eos = false;
+        let mut idle_iterations = 0usize;
+
+        while !output_eos {
+            let mut made_progress = false;
+            if !input_eos {
+                let input_index =
+                    unsafe { ndk_sys::AMediaCodec_dequeueInputBuffer(codec.ptr, TIMEOUT_US) };
+                if input_index >= 0 {
+                    let mut input_capacity = 0usize;
+                    let input_buffer = unsafe {
+                        ndk_sys::AMediaCodec_getInputBuffer(
+                            codec.ptr,
+                            input_index as usize,
+                            &mut input_capacity,
+                        )
+                    };
+                    if input_buffer.is_null() {
+                        return Err(
+                            "Android MediaCodec returned an invalid input buffer.".to_string()
+                        );
+                    }
+                    let sample_size = unsafe {
+                        ndk_sys::AMediaExtractor_readSampleData(
+                            extractor.ptr,
+                            input_buffer,
+                            input_capacity,
+                        )
+                    };
+                    if sample_size < 0 {
+                        let status = unsafe {
+                            ndk_sys::AMediaCodec_queueInputBuffer(
+                                codec.ptr,
+                                input_index as usize,
+                                0,
+                                0,
+                                0,
+                                ndk_sys::AMEDIACODEC_BUFFER_FLAG_END_OF_STREAM,
+                            )
+                        };
+                        if status != ndk_sys::media_status_t::AMEDIA_OK {
+                            return Err("Android MediaCodec could not queue audio end-of-stream."
+                                .to_string());
+                        }
+                        input_eos = true;
+                    } else {
+                        let sample_time =
+                            unsafe { ndk_sys::AMediaExtractor_getSampleTime(extractor.ptr) };
+                        let sample_flags =
+                            unsafe { ndk_sys::AMediaExtractor_getSampleFlags(extractor.ptr) };
+                        let status = unsafe {
+                            ndk_sys::AMediaCodec_queueInputBuffer(
+                                codec.ptr,
+                                input_index as usize,
+                                0,
+                                sample_size as usize,
+                                sample_time.max(0) as u64,
+                                sample_flags,
+                            )
+                        };
+                        if status != ndk_sys::media_status_t::AMEDIA_OK {
+                            return Err(
+                                "Android MediaCodec could not queue compressed audio.".to_string()
+                            );
+                        }
+                        unsafe {
+                            ndk_sys::AMediaExtractor_advance(extractor.ptr);
+                        }
+                    }
+                    made_progress = true;
+                }
+            }
+
+            let mut info: ndk_sys::AMediaCodecBufferInfo = unsafe { mem::zeroed() };
+            let output_index = unsafe {
+                ndk_sys::AMediaCodec_dequeueOutputBuffer(codec.ptr, &mut info, TIMEOUT_US)
+            };
+            if output_index >= 0 {
+                let mut output_capacity = 0usize;
+                let output_buffer = unsafe {
+                    ndk_sys::AMediaCodec_getOutputBuffer(
+                        codec.ptr,
+                        output_index as usize,
+                        &mut output_capacity,
+                    )
+                };
+                if output_buffer.is_null() {
+                    return Err("Android MediaCodec returned an invalid output buffer.".to_string());
+                }
+                let offset = info.offset.max(0) as usize;
+                let size = info.size.max(0) as usize;
+                if size > 0 {
+                    let end = offset.saturating_add(size);
+                    if end > output_capacity {
+                        return Err(
+                            "Android MediaCodec returned an invalid output range.".to_string()
+                        );
+                    }
+                    let output = unsafe { slice::from_raw_parts(output_buffer.add(offset), size) };
+                    decoded.extend_from_slice(output);
+                }
+                if info.flags & ndk_sys::AMEDIACODEC_BUFFER_FLAG_END_OF_STREAM != 0 {
+                    output_eos = true;
+                }
+                unsafe {
+                    ndk_sys::AMediaCodec_releaseOutputBuffer(
+                        codec.ptr,
+                        output_index as usize,
+                        false,
+                    );
+                }
+                made_progress = true;
+            } else if output_index == ndk_sys::AMEDIACODEC_INFO_OUTPUT_FORMAT_CHANGED as isize {
+                let output_format = unsafe { ndk_sys::AMediaCodec_getOutputFormat(codec.ptr) };
+                if !output_format.is_null() {
+                    output_sample_rate = media_format_i32(output_format, unsafe {
+                        ndk_sys::AMEDIAFORMAT_KEY_SAMPLE_RATE
+                    })
+                    .unwrap_or(output_sample_rate);
+                    output_channels = media_format_i32(output_format, unsafe {
+                        ndk_sys::AMEDIAFORMAT_KEY_CHANNEL_COUNT
+                    })
+                    .unwrap_or(output_channels);
+                    output_encoding = media_format_i32(output_format, unsafe {
+                        ndk_sys::AMEDIAFORMAT_KEY_PCM_ENCODING
+                    })
+                    .unwrap_or(PCM_ENCODING_16BIT);
+                    unsafe {
+                        let _ = ndk_sys::AMediaFormat_delete(output_format);
+                    }
+                }
+                made_progress = true;
+            } else if output_index != ndk_sys::AMEDIACODEC_INFO_TRY_AGAIN_LATER as isize {
+                return Err("Android MediaCodec failed while decoding audio.".to_string());
+            }
+
+            if made_progress {
+                idle_iterations = 0;
+            } else {
+                idle_iterations += 1;
+                if idle_iterations > 2_000 {
+                    return Err("Android MediaCodec timed out while decoding audio.".to_string());
+                }
+            }
+        }
+
+        match output_encoding {
+            PCM_ENCODING_16BIT => {
+                pcm_i16_bytes_to_mono(&decoded, output_sample_rate, output_channels)
+            }
+            PCM_ENCODING_FLOAT => {
+                pcm_f32_bytes_to_mono(&decoded, output_sample_rate, output_channels)
+            }
+            _ => Err("Android MediaCodec returned an unsupported PCM output encoding.".to_string()),
+        }
+    }
+
+    fn pcm_i16_bytes_to_mono(
+        bytes: &[u8],
+        sample_rate: i32,
+        channels: i32,
+    ) -> Result<DecodedAudio, String> {
+        if sample_rate <= 0 || channels <= 0 {
+            return Err("Android MediaCodec returned invalid PCM metadata.".to_string());
+        }
+        let channel_count = channels as usize;
+        let frame_bytes = channel_count
+            .checked_mul(2)
+            .ok_or_else(|| "Android MediaCodec returned invalid channel metadata.".to_string())?;
+        if frame_bytes == 0 {
+            return Err("Android MediaCodec returned invalid channel metadata.".to_string());
+        }
+        let frame_count = bytes.len() / frame_bytes;
+        let mut samples = Vec::with_capacity(frame_count);
+        for frame_index in 0..frame_count {
+            let frame_start = frame_index * frame_bytes;
+            let mut sum = 0.0f32;
+            for channel_index in 0..channel_count {
+                let sample_start = frame_start + channel_index * 2;
+                let raw = i16::from_le_bytes(
+                    bytes
+                        .get(sample_start..sample_start + 2)
+                        .ok_or_else(|| {
+                            "Android MediaCodec returned truncated PCM data.".to_string()
+                        })?
+                        .try_into()
+                        .map_err(|_| "Android MediaCodec returned invalid PCM data.".to_string())?,
+                );
+                sum += raw as f32 / i16::MAX as f32;
+            }
+            samples.push((sum / channel_count as f32).clamp(-1.0, 1.0));
+        }
+        Ok(DecodedAudio {
+            samples,
+            sample_rate: sample_rate as u32,
+            channels: channels as u32,
+        })
+    }
+
+    fn pcm_f32_bytes_to_mono(
+        bytes: &[u8],
+        sample_rate: i32,
+        channels: i32,
+    ) -> Result<DecodedAudio, String> {
+        if sample_rate <= 0 || channels <= 0 {
+            return Err("Android MediaCodec returned invalid PCM metadata.".to_string());
+        }
+        let channel_count = channels as usize;
+        let frame_bytes = channel_count
+            .checked_mul(4)
+            .ok_or_else(|| "Android MediaCodec returned invalid channel metadata.".to_string())?;
+        if frame_bytes == 0 {
+            return Err("Android MediaCodec returned invalid channel metadata.".to_string());
+        }
+        let frame_count = bytes.len() / frame_bytes;
+        let mut samples = Vec::with_capacity(frame_count);
+        for frame_index in 0..frame_count {
+            let frame_start = frame_index * frame_bytes;
+            let mut sum = 0.0f32;
+            for channel_index in 0..channel_count {
+                let sample_start = frame_start + channel_index * 4;
+                let raw = f32::from_le_bytes(
+                    bytes
+                        .get(sample_start..sample_start + 4)
+                        .ok_or_else(|| {
+                            "Android MediaCodec returned truncated PCM data.".to_string()
+                        })?
+                        .try_into()
+                        .map_err(|_| "Android MediaCodec returned invalid PCM data.".to_string())?,
+                );
+                sum += raw;
+            }
+            samples.push((sum / channel_count as f32).clamp(-1.0, 1.0));
+        }
+        Ok(DecodedAudio {
+            samples,
+            sample_rate: sample_rate as u32,
+            channels: channels as u32,
+        })
+    }
+
+    fn read_lyrics_audio(path: &Path) -> Result<DecodedAudio, String> {
+        let decoded = read_mobile_audio(path)?;
+        Ok(DecodedAudio {
+            samples: resample_mono(&decoded.samples, decoded.sample_rate, WHISPER_SAMPLE_RATE),
+            sample_rate: WHISPER_SAMPLE_RATE,
+            channels: 1,
+        })
+    }
+
+    fn resample_mono(
+        samples: &[f32],
+        source_sample_rate: u32,
+        target_sample_rate: u32,
+    ) -> Vec<f32> {
+        if samples.is_empty() || source_sample_rate == 0 || source_sample_rate == target_sample_rate
+        {
+            return samples.to_vec();
+        }
+
+        let output_len = ((samples.len() as f64) * target_sample_rate as f64
+            / source_sample_rate as f64)
+            .ceil()
+            .max(1.0) as usize;
+        let ratio = source_sample_rate as f64 / target_sample_rate as f64;
+        let mut output = Vec::with_capacity(output_len);
+        for index in 0..output_len {
+            let source_position = index as f64 * ratio;
+            let left_index = source_position.floor() as usize;
+            let right_index = (left_index + 1).min(samples.len().saturating_sub(1));
+            let fraction = (source_position - left_index as f64) as f32;
+            let left = samples[left_index];
+            let right = samples[right_index];
+            output.push(left + (right - left) * fraction);
+        }
+        output
+    }
+
+    fn read_u16_le(bytes: &[u8], offset: usize) -> Option<u16> {
+        Some(u16::from_le_bytes(
+            bytes.get(offset..offset + 2)?.try_into().ok()?,
+        ))
+    }
+
+    fn read_u32_le(bytes: &[u8], offset: usize) -> Option<u32> {
+        Some(u32::from_le_bytes(
+            bytes.get(offset..offset + 4)?.try_into().ok()?,
+        ))
+    }
+
+    fn decode_wav_sample(
+        bytes: &[u8],
+        offset: usize,
+        audio_format: u16,
+        bits_per_sample: u16,
+    ) -> Result<f64, String> {
+        match (audio_format, bits_per_sample) {
+            (1, 8) => Ok((bytes
+                .get(offset)
+                .copied()
+                .ok_or_else(|| "Invalid WAV sample data.".to_string())?
+                as f64
+                - 128.0)
+                / 128.0),
+            (1, 16) => {
+                let raw = i16::from_le_bytes(
+                    bytes
+                        .get(offset..offset + 2)
+                        .ok_or_else(|| "Invalid WAV sample data.".to_string())?
+                        .try_into()
+                        .map_err(|_| "Invalid WAV sample data.".to_string())?,
+                );
+                Ok(raw as f64 / i16::MAX as f64)
+            }
+            (1, 24) => {
+                let sample = bytes
+                    .get(offset..offset + 3)
+                    .ok_or_else(|| "Invalid WAV sample data.".to_string())?;
+                let raw =
+                    (sample[0] as i32) | ((sample[1] as i32) << 8) | ((sample[2] as i32) << 16);
+                let signed = if raw & 0x800000 != 0 {
+                    raw | !0x00ff_ffff
+                } else {
+                    raw
+                };
+                Ok(signed as f64 / 8_388_608.0)
+            }
+            (1, 32) => {
+                let raw = i32::from_le_bytes(
+                    bytes
+                        .get(offset..offset + 4)
+                        .ok_or_else(|| "Invalid WAV sample data.".to_string())?
+                        .try_into()
+                        .map_err(|_| "Invalid WAV sample data.".to_string())?,
+                );
+                Ok(raw as f64 / i32::MAX as f64)
+            }
+            (3, 32) => {
+                let raw = f32::from_le_bytes(
+                    bytes
+                        .get(offset..offset + 4)
+                        .ok_or_else(|| "Invalid WAV sample data.".to_string())?
+                        .try_into()
+                        .map_err(|_| "Invalid WAV sample data.".to_string())?,
+                );
+                Ok(raw as f64)
+            }
+            _ => Err(
+                "Mobile CPU analysis currently supports 8/16/24/32-bit PCM WAV files.".to_string(),
+            ),
+        }
+    }
+
+    fn pitch_class_energy(samples: &[f64], sample_rate: f64) -> [f64; 12] {
+        let mut energies = [0.0; 12];
+        if samples.is_empty() || sample_rate <= 0.0 {
+            return energies;
+        }
+
+        for midi_note in 36..85 {
+            let frequency = 440.0 * 2.0_f64.powf((midi_note as f64 - 69.0) / 12.0);
+            let normalized = frequency / sample_rate;
+            if normalized >= 0.5 {
+                continue;
+            }
+            let coeff = 2.0 * (2.0 * std::f64::consts::PI * normalized).cos();
+            let mut q1 = 0.0;
+            let mut q2 = 0.0;
+            for sample in samples {
+                let q0 = coeff * q1 - q2 + sample;
+                q2 = q1;
+                q1 = q0;
+            }
+            let power = q1 * q1 + q2 * q2 - coeff * q1 * q2;
+            energies[(midi_note % 12) as usize] += power.max(0.0);
+        }
+
+        let total: f64 = energies.iter().sum();
+        if total > 0.0 {
+            for energy in &mut energies {
+                *energy /= total;
+            }
+        }
+        energies
+    }
+
+    fn estimate_key(pitch_classes: &[f64; 12]) -> (Option<String>, Option<f64>) {
+        const MAJOR_PROFILE: [f64; 12] = [
+            6.35, 2.23, 3.48, 2.33, 4.38, 4.09, 2.52, 5.19, 2.39, 3.66, 2.29, 2.88,
+        ];
+        const MINOR_PROFILE: [f64; 12] = [
+            6.33, 2.68, 3.52, 5.38, 2.60, 3.53, 2.54, 4.75, 3.98, 2.69, 3.34, 3.17,
+        ];
+        let total: f64 = pitch_classes.iter().sum();
+        if total <= 0.0 {
+            return (None, None);
+        }
+
+        let mut scored_keys = Vec::with_capacity(24);
+        for pitch_class in 0..12 {
+            scored_keys.push((
+                key_label(pitch_class, "major"),
+                profile_score(pitch_classes, &MAJOR_PROFILE, pitch_class),
+            ));
+            scored_keys.push((
+                key_label(pitch_class, "minor"),
+                profile_score(pitch_classes, &MINOR_PROFILE, pitch_class),
+            ));
+        }
+        scored_keys.sort_by(|left, right| right.1.total_cmp(&left.1));
+        let best = scored_keys.first().cloned();
+        let second = scored_keys.get(1).map(|(_, score)| *score).unwrap_or(0.0);
+        if let Some((label, score)) = best {
+            let confidence = ((score - second).abs() / (score.abs() + 1.0)).clamp(0.0, 1.0);
+            return (Some(label), Some(confidence));
+        }
+        (None, None)
+    }
+
+    fn profile_score(pitch_classes: &[f64; 12], profile: &[f64; 12], root: usize) -> f64 {
+        let mut score = 0.0;
+        for pitch_class in 0..12 {
+            score += pitch_classes[pitch_class] * profile[(pitch_class + 12 - root) % 12];
+        }
+        score
+    }
+
+    fn detect_basic_chord(features: &MobileAudioFeatures) -> Value {
+        let mut best: Option<(usize, &'static str, f64)> = None;
+        for pitch_class in 0..12 {
+            let major = chord_score(&features.pitch_classes, pitch_class, &[0, 4, 7]);
+            let minor = chord_score(&features.pitch_classes, pitch_class, &[0, 3, 7]);
+            for (quality, score) in [("major", major), ("minor", minor)] {
+                if best
+                    .map(|(_, _, best_score)| score > best_score)
+                    .unwrap_or(true)
+                {
+                    best = Some((pitch_class, quality, score));
+                }
+            }
+        }
+
+        let end_seconds = features.duration_seconds.max(0.1);
+        if let Some((pitch_class, quality, score)) = best {
+            if score > 0.0 {
+                return json!({
+                    "start_seconds": 0.0,
+                    "end_seconds": end_seconds,
+                    "label": chord_label(pitch_class, quality),
+                    "confidence": score.clamp(0.0, 1.0),
+                    "pitch_class": pitch_class,
+                    "quality": quality,
+                });
+            }
+        }
+
+        json!({
+            "start_seconds": 0.0,
+            "end_seconds": end_seconds,
+            "label": "N.C.",
+            "confidence": 0.0,
+            "pitch_class": Value::Null,
+            "quality": Value::Null,
+        })
+    }
+
+    fn chord_score(pitch_classes: &[f64; 12], root: usize, intervals: &[usize; 3]) -> f64 {
+        let chord_energy: f64 = intervals
+            .iter()
+            .map(|interval| pitch_classes[(root + interval) % 12])
+            .sum();
+        let root_energy = pitch_classes[root];
+        (root_energy * 0.5 + chord_energy) / 1.5
+    }
+
+    fn key_label(pitch_class: usize, mode: &str) -> String {
+        format!("{} {mode}", pitch_name(pitch_class))
+    }
+
+    fn chord_label(pitch_class: usize, quality: &str) -> String {
+        if quality == "minor" {
+            format!("{}m", pitch_name(pitch_class))
+        } else {
+            pitch_name(pitch_class).to_string()
+        }
+    }
+
+    fn pitch_name(pitch_class: usize) -> &'static str {
+        const NAMES: [&str; 12] = [
+            "C", "C#", "D", "Eb", "E", "F", "F#", "G", "Ab", "A", "Bb", "B",
+        ];
+        NAMES[pitch_class % 12]
+    }
+
+    fn store_analysis_result(
+        connection: &Connection,
+        root: &Path,
+        project: &ProjectSchema,
+        source_artifact: &ArtifactSchema,
+        features: &MobileAudioFeatures,
+    ) -> Result<Value, String> {
+        let timestamp = now_iso();
+        let (estimated_key, key_confidence) = estimate_key(&features.pitch_classes);
+        let analysis_version = "mobile-cpu-v1";
+        let analysis = json!({
+            "project_id": project.id,
+            "source_artifact_id": source_artifact.id,
+            "estimated_key": estimated_key,
+            "key_confidence": key_confidence,
+            "estimated_reference_hz": Value::Null,
+            "tuning_offset_cents": Value::Null,
+            "tempo_bpm": Value::Null,
+            "analysis_version": analysis_version,
+            "created_at": timestamp,
+        });
+
+        connection
+            .execute(
+                "UPDATE projects SET duration_seconds = ?1, sample_rate = ?2, channels = ?3, updated_at = ?4 WHERE id = ?5",
+                params![
+                    features.duration_seconds,
+                    features.sample_rate,
+                    features.channels,
+                    timestamp,
+                    project.id,
+                ],
+            )
+            .map_err(|error| error.to_string())?;
+        connection
+            .execute(
+                "INSERT INTO analysis_results (project_id, source_artifact_id, estimated_key, key_confidence, estimated_reference_hz, tuning_offset_cents, tempo_bpm, analysis_version, created_at)
+                 VALUES (?1, ?2, ?3, ?4, NULL, NULL, NULL, ?5, ?6)
+                 ON CONFLICT(project_id) DO UPDATE SET source_artifact_id = excluded.source_artifact_id, estimated_key = excluded.estimated_key, key_confidence = excluded.key_confidence, estimated_reference_hz = excluded.estimated_reference_hz, tuning_offset_cents = excluded.tuning_offset_cents, tempo_bpm = excluded.tempo_bpm, analysis_version = excluded.analysis_version, created_at = excluded.created_at",
+                params![
+                    project.id,
+                    source_artifact.id,
+                    estimated_key,
+                    key_confidence,
+                    analysis_version,
+                    timestamp,
+                ],
+            )
+            .map_err(|error| error.to_string())?;
+
+        let analysis_dir = root.join("projects").join(&project.id).join("analysis");
+        fs::create_dir_all(&analysis_dir).map_err(|error| error.to_string())?;
+        let analysis_path = analysis_dir.join("analysis.json");
+        fs::write(
+            &analysis_path,
+            serde_json::to_vec_pretty(&analysis).map_err(|error| error.to_string())?,
+        )
+        .map_err(|error| error.to_string())?;
+        let size_bytes = fs::metadata(&analysis_path)
+            .map(|metadata| metadata.len() as i64)
+            .unwrap_or(0);
+        connection
+            .execute(
+                "DELETE FROM artifacts WHERE project_id = ?1 AND type = 'analysis_json'",
+                params![project.id],
+            )
+            .map_err(|error| error.to_string())?;
+        connection
+            .execute(
+                "INSERT INTO artifacts (id, project_id, type, format, path, size_bytes, generated_by, can_delete, can_regenerate, metadata_json, created_at)
+                 VALUES (?1, ?2, 'analysis_json', 'json', ?3, ?4, 'analysis', 0, 1, ?5, ?6)",
+                params![
+                    new_id("art"),
+                    project.id,
+                    analysis_path.to_string_lossy().into_owned(),
+                    size_bytes,
+                    json!({
+                        "analysis_version": analysis_version,
+                        "source_artifact_id": source_artifact.id,
+                    })
+                    .to_string(),
+                    timestamp,
+                ],
+            )
+            .map_err(|error| error.to_string())?;
+
+        Ok(analysis)
+    }
+
+    fn get_analysis_value(
+        connection: &Connection,
+        project_id: &str,
+    ) -> Result<Option<Value>, String> {
+        connection
+            .query_row(
+                "SELECT project_id, source_artifact_id, estimated_key, key_confidence, estimated_reference_hz, tuning_offset_cents, tempo_bpm, analysis_version, created_at FROM analysis_results WHERE project_id = ?1",
+                params![project_id],
+                |row| {
+                    Ok(json!({
+                        "project_id": row.get::<_, String>(0)?,
+                        "source_artifact_id": row.get::<_, Option<String>>(1)?,
+                        "estimated_key": row.get::<_, Option<String>>(2)?,
+                        "key_confidence": row.get::<_, Option<f64>>(3)?,
+                        "estimated_reference_hz": row.get::<_, Option<f64>>(4)?,
+                        "tuning_offset_cents": row.get::<_, Option<f64>>(5)?,
+                        "tempo_bpm": row.get::<_, Option<f64>>(6)?,
+                        "analysis_version": row.get::<_, String>(7)?,
+                        "created_at": row.get::<_, String>(8)?,
+                    }))
+                },
+            )
+            .optional()
+            .map_err(|error| error.to_string())
+    }
+
+    fn store_chord_timeline(
+        connection: &Connection,
+        root: &Path,
+        project: &ProjectSchema,
+        source_artifact: &ArtifactSchema,
+        features: &MobileAudioFeatures,
+    ) -> Result<ChordResponse, String> {
+        let timestamp = now_iso();
+        let timeline = vec![detect_basic_chord(features)];
+        let timeline_json = serde_json::to_string(&timeline).map_err(|error| error.to_string())?;
+        connection
+            .execute(
+                "INSERT INTO chord_timelines (project_id, source_segments_json, timeline_json, backend, source_artifact_id, has_user_edits, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, 'mobile-cpu-basic', ?4, 0, ?5, ?5)
+                 ON CONFLICT(project_id) DO UPDATE SET source_segments_json = excluded.source_segments_json, timeline_json = excluded.timeline_json, backend = excluded.backend, source_artifact_id = excluded.source_artifact_id, has_user_edits = excluded.has_user_edits, updated_at = excluded.updated_at",
+                params![
+                    project.id,
+                    timeline_json,
+                    timeline_json,
+                    source_artifact.id,
+                    timestamp,
+                ],
+            )
+            .map_err(|error| error.to_string())?;
+
+        let chord_path = root
+            .join("projects")
+            .join(&project.id)
+            .join("analysis")
+            .join("chords.json");
+        if let Some(parent) = chord_path.parent() {
+            fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+        }
+        let response = ChordResponse {
+            project_id: project.id.clone(),
+            source_segments: timeline.clone(),
+            timeline,
+            backend: Some("mobile-cpu-basic".to_string()),
+            source_artifact_id: Some(source_artifact.id.clone()),
+            has_user_edits: false,
+            source_kind: "generated".to_string(),
+            metadata: json!({}),
+            created_at: Some(timestamp.clone()),
+            updated_at: Some(timestamp),
+        };
+        fs::write(
+            chord_path,
+            serde_json::to_vec_pretty(&response).map_err(|error| error.to_string())?,
+        )
+        .map_err(|error| error.to_string())?;
+        Ok(response)
+    }
+
+    fn get_chord_response(
+        connection: &Connection,
+        project_id: String,
+    ) -> Result<ChordResponse, String> {
+        connection
+            .query_row(
+                "SELECT project_id, source_segments_json, timeline_json, backend, source_artifact_id, has_user_edits, created_at, updated_at FROM chord_timelines WHERE project_id = ?1",
+                params![project_id],
+                |row| {
+                    let source_segments_raw: String = row.get(1)?;
+                    let timeline_raw: String = row.get(2)?;
+                    let source_segments = serde_json::from_str(&source_segments_raw).unwrap_or_default();
+                    let timeline = serde_json::from_str(&timeline_raw).unwrap_or_default();
+                    Ok(ChordResponse {
+                        project_id: row.get(0)?,
+                        source_segments,
+                        timeline,
+                        backend: row.get(3)?,
+                        source_artifact_id: row.get(4)?,
+                        has_user_edits: row.get::<_, i64>(5)? != 0,
+                        source_kind: "generated".to_string(),
+                        metadata: json!({}),
+                        created_at: row.get(6)?,
+                        updated_at: row.get(7)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(|error| error.to_string())?
+            .map(Ok)
+            .unwrap_or_else(|| Ok(empty_chords(project_id)))
+    }
+
+    fn empty_chords(project_id: String) -> ChordResponse {
+        ChordResponse {
+            project_id,
+            source_segments: Vec::new(),
+            timeline: Vec::new(),
+            backend: None,
+            source_artifact_id: None,
+            has_user_edits: false,
+            source_kind: "generated".to_string(),
+            metadata: json!({}),
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    fn find_whisper_model(root: &Path) -> Option<WhisperModel> {
+        [
+            ("ggml-base.bin", "base", "base"),
+            ("ggml-base.en.bin", "base.en", "base"),
+            ("ggml-tiny.bin", "tiny", "tiny"),
+            ("ggml-tiny.en.bin", "tiny.en", "tiny"),
+        ]
+        .into_iter()
+        .find_map(|(file_name, name, max_recommended_model)| {
+            let path = root.join(WHISPER_MODEL_DIR).join(file_name);
+            path.is_file().then_some(WhisperModel {
+                path,
+                name,
+                max_recommended_model,
+            })
+        })
+    }
+
+    fn payload_force(payload: &Value) -> bool {
+        payload
+            .get("force")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    }
+
+    fn get_lyrics_response(
+        connection: &Connection,
+        project_id: String,
+    ) -> Result<LyricsResponse, String> {
+        connection
+            .query_row(
+                "SELECT project_id, backend, source_artifact_id, source_kind, requested_device, device, model_name, language, source_segments_json, segments_json, has_user_edits, created_at, updated_at FROM lyrics_transcripts WHERE project_id = ?1",
+                params![project_id],
+                |row| {
+                    let source_segments_raw: String = row.get(8)?;
+                    let segments_raw: String = row.get(9)?;
+                    let source_segments =
+                        serde_json::from_str(&source_segments_raw).unwrap_or_default();
+                    let segments = serde_json::from_str(&segments_raw).unwrap_or_default();
+                    Ok(LyricsResponse {
+                        project_id: row.get(0)?,
+                        backend: row.get(1)?,
+                        source_artifact_id: row.get(2)?,
+                        source_kind: row.get(3)?,
+                        requested_device: row.get(4)?,
+                        device: row.get(5)?,
+                        model_name: row.get(6)?,
+                        language: row.get(7)?,
+                        source_segments,
+                        segments,
+                        has_user_edits: row.get::<_, i64>(10)? != 0,
+                        created_at: row.get(11)?,
+                        updated_at: row.get(12)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(|error| error.to_string())?
+            .map(Ok)
+            .unwrap_or_else(|| Ok(empty_lyrics(project_id)))
+    }
+
+    fn write_lyrics_snapshot(root: &Path, lyrics: &LyricsResponse) -> Result<(), String> {
+        let lyrics_path = root
+            .join("projects")
+            .join(&lyrics.project_id)
+            .join("analysis")
+            .join("lyrics.json");
+        if let Some(parent) = lyrics_path.parent() {
+            fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+        }
+        fs::write(
+            lyrics_path,
+            serde_json::to_vec_pretty(lyrics).map_err(|error| error.to_string())?,
+        )
+        .map_err(|error| error.to_string())?;
+        Ok(())
+    }
+
+    fn store_lyrics_transcript(
+        connection: &Connection,
+        root: &Path,
+        project: &ProjectSchema,
+        source_artifact: &ArtifactSchema,
+        transcription: MobileLyricsTranscription,
+    ) -> Result<LyricsResponse, String> {
+        let timestamp = now_iso();
+        let source_segments_json =
+            serde_json::to_string(&transcription.segments).map_err(|error| error.to_string())?;
+        let segments_json = source_segments_json.clone();
+        connection
+            .execute(
+                "INSERT INTO lyrics_transcripts (project_id, backend, source_artifact_id, source_kind, requested_device, device, model_name, language, source_segments_json, segments_json, has_user_edits, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, 'ai', ?4, ?5, ?6, ?7, ?8, ?9, 0, ?10, ?10)
+                 ON CONFLICT(project_id) DO UPDATE SET backend = excluded.backend, source_artifact_id = excluded.source_artifact_id, source_kind = excluded.source_kind, requested_device = excluded.requested_device, device = excluded.device, model_name = excluded.model_name, language = excluded.language, source_segments_json = excluded.source_segments_json, segments_json = excluded.segments_json, has_user_edits = excluded.has_user_edits, updated_at = excluded.updated_at",
+                params![
+                    project.id,
+                    transcription.backend,
+                    source_artifact.id,
+                    transcription.requested_device,
+                    transcription.device,
+                    transcription.model_name,
+                    transcription.language,
+                    source_segments_json,
+                    segments_json,
+                    timestamp,
+                ],
+            )
+            .map_err(|error| error.to_string())?;
+        let response = get_lyrics_response(connection, project.id.clone())?;
+        write_lyrics_snapshot(root, &response)?;
+        Ok(response)
+    }
+
+    fn payload_lyrics_edits(payload: &Value) -> Result<Vec<String>, String> {
+        let segments = payload
+            .get("segments")
+            .and_then(Value::as_array)
+            .ok_or_else(|| "Lyrics edits must include a segments array.".to_string())?;
+        Ok(segments
+            .iter()
+            .map(|segment| {
+                segment
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string()
+            })
+            .collect())
+    }
+
+    fn update_lyrics_transcript(
+        connection: &Connection,
+        root: &Path,
+        project_id: String,
+        payload: &Value,
+    ) -> Result<LyricsResponse, String> {
+        let edits = payload_lyrics_edits(payload)?;
+        let (source_segments, current_segments): (Vec<Value>, Vec<Value>) = connection
+            .query_row(
+                "SELECT source_segments_json, segments_json FROM lyrics_transcripts WHERE project_id = ?1",
+                params![project_id],
+                |row| {
+                    let source_segments_raw: String = row.get(0)?;
+                    let current_segments_raw: String = row.get(1)?;
+                    Ok((
+                        serde_json::from_str(&source_segments_raw).unwrap_or_default(),
+                        serde_json::from_str(&current_segments_raw).unwrap_or_default(),
+                    ))
+                },
+            )
+            .optional()
+            .map_err(|error| error.to_string())?
+            .ok_or_else(|| "Lyrics have not been generated for this project.".to_string())?;
+
+        if edits.len() != current_segments.len() {
+            return Err("Lyrics edits must preserve the existing segment count in v1.".to_string());
+        }
+
+        let mut updated_segments = Vec::with_capacity(current_segments.len());
+        for (index, text) in edits.into_iter().enumerate() {
+            let current_segment = &current_segments[index];
+            let source_segment = source_segments.get(index);
+            let mut updated = current_segment
+                .as_object()
+                .cloned()
+                .unwrap_or_else(serde_json::Map::new);
+
+            updated.insert("text".to_string(), Value::String(text.clone()));
+            updated.insert(
+                "start_seconds".to_string(),
+                current_segment
+                    .get("start_seconds")
+                    .cloned()
+                    .unwrap_or(Value::Null),
+            );
+            updated.insert(
+                "end_seconds".to_string(),
+                current_segment
+                    .get("end_seconds")
+                    .cloned()
+                    .unwrap_or(Value::Null),
+            );
+
+            let source_text = source_segment
+                .and_then(Value::as_object)
+                .and_then(|segment| segment.get("text"))
+                .and_then(Value::as_str);
+            let current_text = current_segment.get("text").and_then(Value::as_str);
+            if Some(text.as_str()) == source_text {
+                if let Some(words) = source_segment.and_then(|segment| segment.get("words")) {
+                    updated.insert("words".to_string(), words.clone());
+                } else {
+                    updated.remove("words");
+                }
+            } else if Some(text.as_str()) != current_text {
+                updated.remove("words");
+            }
+
+            updated_segments.push(Value::Object(updated));
+        }
+
+        let has_user_edits = updated_segments != source_segments;
+        let updated_segments_json =
+            serde_json::to_string(&updated_segments).map_err(|error| error.to_string())?;
+        connection
+            .execute(
+                "UPDATE lyrics_transcripts SET segments_json = ?1, has_user_edits = ?2, updated_at = ?3 WHERE project_id = ?4",
+                params![
+                    updated_segments_json,
+                    if has_user_edits { 1_i64 } else { 0_i64 },
+                    now_iso(),
+                    project_id,
+                ],
+            )
+            .map_err(|error| error.to_string())?;
+        let response = get_lyrics_response(connection, project_id)?;
+        write_lyrics_snapshot(root, &response)?;
+        Ok(response)
+    }
+
+    fn transcribe_project_lyrics(
+        source_path: &Path,
+        model: &WhisperModel,
+    ) -> Result<MobileLyricsTranscription, String> {
+        let audio = read_lyrics_audio(source_path)?;
+        if audio.samples.is_empty() {
+            return Err(
+                "Imported audio did not contain samples for lyrics transcription.".to_string(),
+            );
+        }
+
+        install_logging_hooks();
+        let context =
+            WhisperContext::new_with_params(&model.path, WhisperContextParameters::default())
+                .map_err(|error| format!("Whisper model could not be loaded: {error}"))?;
+        let mut state = context
+            .create_state()
+            .map_err(|error| format!("Whisper state could not be created: {error}"))?;
+        let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+        let thread_count = thread::available_parallelism()
+            .map(|count| count.get().clamp(1, 4) as i32)
+            .unwrap_or(2);
+        params.set_n_threads(thread_count);
+        params.set_translate(false);
+        params.set_language(None);
+        params.set_no_context(true);
+        params.set_token_timestamps(false);
+        params.set_print_special(false);
+        params.set_print_progress(false);
+        params.set_print_realtime(false);
+        params.set_print_timestamps(false);
+        params.set_temperature(0.0);
+
+        state
+            .full(params, &audio.samples)
+            .map_err(|error| format!("Whisper transcription failed: {error}"))?;
+
+        let mut segments = Vec::new();
+        for segment in state.as_iter() {
+            let text = segment
+                .to_str_lossy()
+                .map_err(|error| format!("Whisper returned invalid transcript text: {error}"))?
+                .trim()
+                .to_string();
+            if text.is_empty() {
+                continue;
+            }
+            segments.push(json!({
+                "start_seconds": segment.start_timestamp() as f64 / 100.0,
+                "end_seconds": segment.end_timestamp() as f64 / 100.0,
+                "text": text,
+            }));
+        }
+
+        Ok(MobileLyricsTranscription {
+            backend: "whisper.cpp",
+            requested_device: "cpu",
+            device: "cpu",
+            model_name: model.name.to_string(),
+            language: whisper_rs::get_lang_str(state.full_lang_id_from_state())
+                .map(ToString::to_string),
+            segments,
+        })
+    }
+
+    fn run_lyrics_job(
+        root: PathBuf,
+        job_id: String,
+        project: ProjectSchema,
+        source_artifact: ArtifactSchema,
+        model: WhisperModel,
+    ) {
+        let started = Instant::now();
+        let connection = match db_at_root(&root) {
+            Ok(connection) => connection,
+            Err(_) => return,
+        };
+
+        let result = (|| {
+            update_job_progress(&connection, &job_id, 15)?;
+            let transcription =
+                transcribe_project_lyrics(Path::new(&project.imported_path), &model)?;
+            update_job_progress(&connection, &job_id, 90)?;
+            store_lyrics_transcript(
+                &connection,
+                &root,
+                &project,
+                &source_artifact,
+                transcription,
+            )?;
+            Ok::<(), String>(())
+        })();
+
+        let duration_seconds = started.elapsed().as_secs_f64();
+        match result {
+            Ok(()) => {
+                let _ = complete_running_job(&connection, &job_id, duration_seconds);
+            }
+            Err(message) => {
+                let _ = fail_running_job(&connection, &job_id, &message, duration_seconds);
+            }
+        }
+    }
+
     fn is_android_file_uri(source_path: &str) -> bool {
         source_path.starts_with("content://") || source_path.starts_with("file://")
     }
@@ -568,7 +2394,8 @@ mod android {
         }
 
         let project_id = new_id("proj");
-        let source_dir = root.join("projects").join(&project_id).join("source");
+        let project_root = root.join("projects").join(&project_id);
+        let source_dir = project_root.join("source");
         fs::create_dir_all(&source_dir).map_err(|error| error.to_string())?;
         let source_file_name = source_filename(&app, &payload.source_path);
         let imported_path = if payload.copy_into_project || source_is_uri {
@@ -617,21 +2444,26 @@ mod android {
         let size_bytes = fs::metadata(&imported_path)
             .map(|metadata| metadata.len() as i64)
             .unwrap_or(0);
+        let source_artifact_id = new_id("art");
+        let artifact_metadata = json!({ "source_path": payload.source_path });
+
         connection
             .execute(
                 "INSERT INTO artifacts (id, project_id, type, format, path, size_bytes, generated_by, can_delete, can_regenerate, metadata_json, created_at)
                  VALUES (?1, ?2, 'source_audio', ?3, ?4, ?5, 'import', 0, 0, ?6, ?7)",
                 params![
-                    new_id("art"),
-                    project_id,
+                    &source_artifact_id,
+                    &project_id,
                     source_format(&imported_path),
                     imported_path.to_string_lossy().into_owned(),
                     size_bytes,
-                    json!({ "source_path": payload.source_path }).to_string(),
+                    artifact_metadata.to_string(),
                     timestamp,
                 ],
             )
             .map_err(|error| error.to_string())?;
+
+        spawn_playback_proxy_generation(root, project_root, imported_path, source_artifact_id);
 
         Ok(ProjectResponse { project })
     }
@@ -685,6 +2517,12 @@ mod android {
             )
             .map_err(|error| error.to_string())?;
         connection
+            .execute(
+                "DELETE FROM lyrics_transcripts WHERE project_id = ?1",
+                params![project_id],
+            )
+            .map_err(|error| error.to_string())?;
+        connection
             .execute("DELETE FROM projects WHERE id = ?1", params![project_id])
             .map_err(|error| error.to_string())?;
         let root = app_data_root(&app)?.join("projects").join(project_id);
@@ -700,8 +2538,25 @@ mod android {
         project_id: String,
     ) -> Result<JobResponse, String> {
         let connection = db(&app)?;
+        let root = app_data_root(&app)?;
+        let project = get_project_schema(&connection, &project_id)?;
+        let source_artifact = get_source_artifact(&connection, &project_id)?;
+        let features = match read_audio_features(Path::new(&project.imported_path)) {
+            Ok(features) => features,
+            Err(message) => {
+                return Ok(JobResponse {
+                    job: create_failed_job(&connection, &project_id, "analyze", &message)?,
+                });
+            }
+        };
+        store_analysis_result(&connection, &root, &project, &source_artifact, &features)?;
         Ok(JobResponse {
-            job: create_failed_job(&connection, &project_id, "analyze", GPU_REQUIRED)?,
+            job: create_completed_job(
+                &connection,
+                &project_id,
+                "analyze",
+                Some(source_artifact.id),
+            )?,
         })
     }
 
@@ -712,7 +2567,9 @@ mod android {
     ) -> Result<AnalysisResponse, String> {
         let connection = db(&app)?;
         let _ = get_project_schema(&connection, &project_id)?;
-        Ok(AnalysisResponse { analysis: None })
+        Ok(AnalysisResponse {
+            analysis: get_analysis_value(&connection, &project_id)?,
+        })
     }
 
     #[tauri::command]
@@ -723,8 +2580,25 @@ mod android {
     ) -> Result<JobResponse, String> {
         let _ = payload;
         let connection = db(&app)?;
+        let root = app_data_root(&app)?;
+        let project = get_project_schema(&connection, &project_id)?;
+        let source_artifact = get_source_artifact(&connection, &project_id)?;
+        let features = match read_audio_features(Path::new(&project.imported_path)) {
+            Ok(features) => features,
+            Err(message) => {
+                return Ok(JobResponse {
+                    job: create_failed_job(&connection, &project_id, "chords", &message)?,
+                });
+            }
+        };
+        store_chord_timeline(&connection, &root, &project, &source_artifact, &features)?;
         Ok(JobResponse {
-            job: create_failed_job(&connection, &project_id, "chords", GPU_REQUIRED)?,
+            job: create_completed_job(
+                &connection,
+                &project_id,
+                "chords",
+                Some(source_artifact.id),
+            )?,
         })
     }
 
@@ -732,18 +2606,7 @@ mod android {
     pub fn mobile_get_chords(app: AppHandle, project_id: String) -> Result<ChordResponse, String> {
         let connection = db(&app)?;
         let _ = get_project_schema(&connection, &project_id)?;
-        Ok(ChordResponse {
-            project_id,
-            source_segments: Vec::new(),
-            timeline: Vec::new(),
-            backend: None,
-            source_artifact_id: None,
-            has_user_edits: false,
-            source_kind: "generated".to_string(),
-            metadata: serde_json::json!({}),
-            created_at: None,
-            updated_at: None,
-        })
+        get_chord_response(&connection, project_id)
     }
 
     #[tauri::command]
@@ -752,18 +2615,58 @@ mod android {
         project_id: String,
         payload: Value,
     ) -> Result<JobResponse, String> {
-        let _ = payload;
         let connection = db(&app)?;
-        Ok(JobResponse {
-            job: create_failed_job(&connection, &project_id, "lyrics", GPU_REQUIRED)?,
-        })
+        let root = app_data_root(&app)?;
+        let project = get_project_schema(&connection, &project_id)?;
+        let force = payload_force(&payload);
+        let existing = get_lyrics_response(&connection, project_id.clone())?;
+        if !force && !existing.segments.is_empty() {
+            return Ok(JobResponse {
+                job: create_completed_job(
+                    &connection,
+                    &project_id,
+                    "lyrics",
+                    existing.source_artifact_id,
+                )?,
+            });
+        }
+        let source_artifact = match get_source_artifact(&connection, &project_id) {
+            Ok(artifact) => artifact,
+            Err(message) => {
+                return Ok(JobResponse {
+                    job: create_failed_job(&connection, &project_id, "lyrics", &message)?,
+                });
+            }
+        };
+        let model = match find_whisper_model(&root) {
+            Some(model) => model,
+            None => {
+                return Ok(JobResponse {
+                    job: create_failed_job(
+                        &connection,
+                        &project_id,
+                        "lyrics",
+                        WHISPER_MODEL_MISSING,
+                    )?,
+                });
+            }
+        };
+        let job = create_running_job(
+            &connection,
+            &project_id,
+            "lyrics",
+            Some(source_artifact.id.clone()),
+        )?;
+        let job_id = job.id.clone();
+        thread::spawn(move || run_lyrics_job(root, job_id, project, source_artifact, model));
+        Ok(JobResponse { job })
     }
 
     #[tauri::command]
     pub fn mobile_get_lyrics(app: AppHandle, project_id: String) -> Result<LyricsResponse, String> {
         let connection = db(&app)?;
         let _ = get_project_schema(&connection, &project_id)?;
-        Ok(empty_lyrics(project_id))
+        get_lyrics_response(&connection, project_id)
     }
 
     #[tauri::command]
@@ -772,10 +2675,10 @@ mod android {
         project_id: String,
         payload: Value,
     ) -> Result<LyricsResponse, String> {
-        let _ = payload;
         let connection = db(&app)?;
+        let root = app_data_root(&app)?;
         let _ = get_project_schema(&connection, &project_id)?;
-        Ok(empty_lyrics(project_id))
+        update_lyrics_transcript(&connection, &root, project_id, &payload)
     }
 
     fn empty_lyrics(project_id: String) -> LyricsResponse {
@@ -823,7 +2726,12 @@ mod android {
         let _ = payload;
         let connection = db(&app)?;
         Ok(JobResponse {
-            job: create_failed_job(&connection, &project_id, "stems", GPU_REQUIRED)?,
+            job: create_failed_job(
+                &connection,
+                &project_id,
+                "stems",
+                generation_unavailable_message("stems"),
+            )?,
         })
     }
 
@@ -869,7 +2777,9 @@ mod android {
         project_id: String,
     ) -> Result<ArtifactsResponse, String> {
         let connection = db(&app)?;
+        let root = app_data_root(&app)?;
         let _ = get_project_schema(&connection, &project_id)?;
+        ensure_source_playback_proxy_metadata(&connection, &root, &project_id)?;
         let mut statement = connection
             .prepare("SELECT id, project_id, type, format, path, size_bytes, generated_by, can_delete, can_regenerate, metadata_json, created_at FROM artifacts WHERE project_id = ?1 ORDER BY created_at DESC")
             .map_err(|error| error.to_string())?;

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -10,6 +10,13 @@
     "frontendDist": "../dist"
   },
   "app": {
+    "security": {
+      "assetProtocol": {
+        "enable": true,
+        "scope": ["$APPDATA/**"]
+      },
+      "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:*; img-src 'self' data: blob: asset: http://asset.localhost; media-src 'self' blob: asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; script-src 'self'"
+    },
     "windows": [
       {
         "title": "Tuneforge",

--- a/apps/desktop/src/App.mobile.test.tsx
+++ b/apps/desktop/src/App.mobile.test.tsx
@@ -14,9 +14,13 @@ describe("Desktop app mobile capability gates", () => {
     mockGetMobileCapabilities.mockResolvedValue({
       platform: "android",
       mediaBackend: "android_media_codec",
+      isEmulator: false,
       gpuBackend: null,
+      analysisAvailable: true,
+      basicChordsAvailable: true,
       whisperAvailable: false,
       stemSeparationAvailable: false,
+      generationTestingAvailable: false,
       maxRecommendedModel: null,
       cpuFallbackAllowed: false,
     });
@@ -26,11 +30,63 @@ describe("Desktop app mobile capability gates", () => {
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
     expect(await screen.findByRole("heading", { name: "Processing" })).toBeInTheDocument();
     expect(
-      await screen.findByText("Local generation requires GPU acceleration on this device."),
+      await screen.findByText(
+        "Side-load a Whisper model to enable local lyrics. Stem generation is unavailable on this device.",
+      ),
     ).toBeInTheDocument();
-    expect(await screen.findByRole("button", { name: "Analyze Track" })).toBeDisabled();
-    expect(await screen.findByRole("button", { name: "Refresh Chords" })).toBeDisabled();
+    expect(await screen.findByRole("button", { name: "Analyze Track" })).toBeEnabled();
+    expect(await screen.findByRole("button", { name: "Refresh Chords" })).toBeEnabled();
     expect(await screen.findByRole("button", { name: "Refresh Lyrics" })).toBeDisabled();
+    expect(await screen.findByRole("button", { name: "Generate Stems" })).toBeDisabled();
+  });
+
+  it("allows emulator lyrics flow testing while keeping stems disabled", async () => {
+    mockGetMobileCapabilities.mockResolvedValue({
+      platform: "android",
+      mediaBackend: "android_media_codec",
+      isEmulator: true,
+      gpuBackend: null,
+      analysisAvailable: true,
+      basicChordsAvailable: true,
+      whisperAvailable: false,
+      stemSeparationAvailable: false,
+      generationTestingAvailable: true,
+      maxRecommendedModel: null,
+      cpuFallbackAllowed: false,
+    });
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(
+      await screen.findByText(
+        "Emulator lyrics actions are enabled for flow testing; stem generation is unavailable on this device.",
+      ),
+    ).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Refresh Lyrics" })).toBeEnabled();
+    expect(await screen.findByRole("button", { name: "Generate Stems" })).toBeDisabled();
+  });
+
+  it("enables local lyrics when a side-loaded Whisper model is available", async () => {
+    mockGetMobileCapabilities.mockResolvedValue({
+      platform: "android",
+      mediaBackend: "android_media_codec",
+      isEmulator: false,
+      gpuBackend: null,
+      analysisAvailable: true,
+      basicChordsAvailable: true,
+      whisperAvailable: true,
+      stemSeparationAvailable: false,
+      generationTestingAvailable: false,
+      maxRecommendedModel: "base",
+      cpuFallbackAllowed: false,
+    });
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(
+      await screen.findByText("Local lyrics are available. Stem generation is unavailable on this device."),
+    ).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Refresh Lyrics" })).toBeEnabled();
     expect(await screen.findByRole("button", { name: "Generate Stems" })).toBeDisabled();
   });
 

--- a/apps/desktop/src/App.project-analysis-mix.test.tsx
+++ b/apps/desktop/src/App.project-analysis-mix.test.tsx
@@ -147,6 +147,27 @@ describe("Desktop app project analysis mix", () => {
     expect(screen.getByText("BPM")).toBeInTheDocument();
   });
 
+  it("does not leave tuning pending when mobile analysis omits reference pitch", async () => {
+    const user = userEvent.setup();
+    setProjectAnalysis("proj_123", {
+      project_id: "proj_123",
+      estimated_key: "E minor",
+      key_confidence: 0.06,
+      estimated_reference_hz: null,
+      tuning_offset_cents: null,
+      tempo_bpm: null,
+      analysis_version: "mobile-cpu-v1",
+      created_at: "2026-05-04T17:43:00.000Z",
+    });
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openAnalysisPanel(user);
+    expect(screen.getByText("Not detected")).toBeInTheDocument();
+    expect(screen.queryByText("Pending")).not.toBeInTheDocument();
+  });
+
   it("refreshes existing chords with force enabled", async () => {
     const user = userEvent.setup();
     renderApp(["/projects/proj_123"]);

--- a/apps/desktop/src/features/projects/components/InspectorPanel.tsx
+++ b/apps/desktop/src/features/projects/components/InspectorPanel.tsx
@@ -59,6 +59,16 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
   const { launchMetronome } = useMetronome();
   const tempoBpm = analysisQuery.data?.tempo_bpm;
   const canOpenMetronome = typeof tempoBpm === "number" && Number.isFinite(tempoBpm);
+  const estimatedReferenceHz = analysisQuery.data?.estimated_reference_hz;
+  const hasEstimatedReferenceHz =
+    typeof estimatedReferenceHz === "number" && Number.isFinite(estimatedReferenceHz);
+  const tuningValue = hasEstimatedReferenceHz
+    ? estimatedReferenceHz.toFixed(2)
+    : analysisQuery.data
+      ? "Not detected"
+      : isAnalysisRunning
+        ? "Analyzing..."
+        : "Pending";
   const metronomeSearchParams = new URLSearchParams();
   if (canOpenMetronome) {
     metronomeSearchParams.set("tool", "metronome");
@@ -256,9 +266,9 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
             <span className="metric-label">Detected Tuning</span>
             <strong>
               <span className="analysis-stat__value">
-                {analysisQuery.data?.estimated_reference_hz?.toFixed(2) ?? "Pending"}
+                {tuningValue}
               </span>
-              <span className="analysis-stat__unit">Hz</span>
+              {hasEstimatedReferenceHz ? <span className="analysis-stat__unit">Hz</span> : null}
             </strong>
           </div>
           <div className="analysis-stat">

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -208,7 +208,13 @@ export function useProjectViewModel() {
   const analyzeMutation = useMutation({
     mutationFn: () => api.analyzeProject(projectId),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["jobs"] });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["jobs"] }),
+        queryClient.invalidateQueries({ queryKey: ["analysis", projectId] }),
+        queryClient.invalidateQueries({ queryKey: ["artifacts", projectId] }),
+        queryClient.invalidateQueries({ queryKey: ["project", projectId] }),
+        queryClient.invalidateQueries({ queryKey: ["projects"] }),
+      ]);
     },
   });
 
@@ -575,13 +581,25 @@ export function useProjectViewModel() {
   const isStemRunning = Boolean(stemJob && ["pending", "running"].includes(stemJob.status));
   const mobileCapabilities = mobileCapabilitiesQuery.data ?? null;
   const isMobileRuntime = mobileCapabilities !== null;
+  const mobileGenerationTestingAvailable =
+    mobileCapabilities?.generationTestingAvailable === true;
   const mobileGenerationMessage = isMobileRuntime
-    ? "Local generation requires GPU acceleration on this device."
+    ? mobileCapabilities?.whisperAvailable === true
+      ? mobileCapabilities.stemSeparationAvailable === true
+        ? null
+        : "Local lyrics are available. Stem generation is unavailable on this device."
+      : mobileGenerationTestingAvailable
+        ? "Emulator lyrics actions are enabled for flow testing; stem generation is unavailable on this device."
+        : "Side-load a Whisper model to enable local lyrics. Stem generation is unavailable on this device."
     : null;
-  const canAnalyze = !isMobileRuntime || mobileCapabilities?.gpuBackend != null;
-  const canGenerateLyrics = !isMobileRuntime || mobileCapabilities?.whisperAvailable === true;
-  const canGenerateStems = !isMobileRuntime || mobileCapabilities?.stemSeparationAvailable === true;
-  const canGenerateChords = !isMobileRuntime || mobileCapabilities?.gpuBackend != null;
+  const canAnalyze = !isMobileRuntime || mobileCapabilities?.analysisAvailable === true;
+  const canGenerateLyrics =
+    !isMobileRuntime ||
+    mobileCapabilities?.whisperAvailable === true ||
+    mobileGenerationTestingAvailable;
+  const canGenerateStems =
+    !isMobileRuntime || mobileCapabilities?.stemSeparationAvailable === true;
+  const canGenerateChords = !isMobileRuntime || mobileCapabilities?.basicChordsAvailable === true;
   const currentKeyValue = sourceKeyOverride ? serializeKey(sourceKeyOverride) : "auto";
   const hasVisibleStems = visibleStemArtifacts.length > 0;
   const stemErrorMessage =

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -167,6 +167,25 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     [getAudioContextConstructor],
   );
 
+  const canUseBufferedClock = useCallback(
+    (targetSession: ProjectPlaybackSession | null) => {
+      if (!targetSession || !canUseStemClock()) {
+        return false;
+      }
+
+      const artifactIds = getPlaybackArtifactIds(targetSession);
+      if (!artifactIds.length) {
+        return false;
+      }
+
+      return artifactIds.every((artifactId) => {
+        const streamUrl = api.streamArtifactUrl(artifactId);
+        return Boolean(streamUrl) && !/^https?:\/\/asset\.localhost(?:\/|$)/.test(streamUrl);
+      });
+    },
+    [canUseStemClock],
+  );
+
   function syncStemElementTimes(artifactIds: string[], nextTime: number) {
     artifactIds.forEach((artifactId) => {
       if (
@@ -458,7 +477,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     timeSeconds: number,
     scheduledStartTimeSeconds?: number,
   ) {
-    if (!canUseStemClock()) {
+    if (!canUseBufferedClock(targetSession)) {
       return false;
     }
 
@@ -777,7 +796,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       return;
     }
 
-    if (canUseStemClock()) {
+    if (canUseBufferedClock(targetSession)) {
       void (async () => {
         const activePendingTransition = pendingTransitionRef.current;
         const activeSession = sessionRef.current;
@@ -963,7 +982,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     const targetPlaybackState = stemPlaybackRef.current;
     if (
       targetSession &&
-      canUseStemClock() &&
+      canUseBufferedClock(targetSession) &&
       targetPlaybackState &&
       targetPlaybackState.signature === playbackSignature(targetSession)
     ) {
@@ -976,7 +995,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     getActiveMediaElements().forEach((element) => element.pause());
     setIsPlaying(false);
   }, [
-    canUseStemClock,
+    canUseBufferedClock,
     cancelPrecount,
     getActiveMediaElements,
     stopStemSources,
@@ -999,7 +1018,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     tryCompletePendingTransition();
 
     const masterTime = forceStartAtZero ? 0 : readMasterTime(targetSession);
-    if (canUseStemClock()) {
+    if (canUseBufferedClock(targetSession)) {
       const started = await startStemPlayback(
         targetSession,
         masterTime,
@@ -1046,7 +1065,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     const sequence = ++precountSequenceRef.current;
 
     let preparedStemPlaybackState: StemPlaybackState | null = null;
-    const willUsePlaybackAudioContext = canUseStemClock();
+    const willUsePlaybackAudioContext = canUseBufferedClock(targetSession);
     if (willUsePlaybackAudioContext) {
       preparedStemPlaybackState = await prepareStemPlaybackState(targetSession);
       if (!preparedStemPlaybackState) {
@@ -1200,7 +1219,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     const targetPlaybackState = stemPlaybackRef.current;
     if (
       targetSession &&
-      canUseStemClock() &&
+      canUseBufferedClock(targetSession) &&
       targetPlaybackState &&
       targetPlaybackState.signature === playbackSignature(targetSession)
     ) {
@@ -1218,7 +1237,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       element.currentTime = nextTime;
     });
     setPlaybackTimeSeconds(nextTime);
-  }, [canUseStemClock, cancelPrecount, getActiveMediaElements, startStemPlayback]);
+  }, [canUseBufferedClock, cancelPrecount, getActiveMediaElements, startStemPlayback]);
 
   const seekBy = useCallback(
     (secondsDelta: number) => {

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -181,7 +181,11 @@ async function invokeMobile<T>(command: string, args?: Record<string, unknown>) 
 
 function rememberArtifactPaths(artifacts: ArtifactSchema[]) {
   artifacts.forEach((artifact) => {
-    mobileArtifactPaths.set(artifact.id, artifact.path);
+    const playbackPath =
+      typeof artifact.metadata.playback_path === "string"
+        ? artifact.metadata.playback_path
+        : artifact.path;
+    mobileArtifactPaths.set(artifact.id, playbackPath);
   });
 }
 

--- a/apps/desktop/src/styles/base.css
+++ b/apps/desktop/src/styles/base.css
@@ -3,6 +3,10 @@
   font-family: "Avenir Next", "Segoe UI", sans-serif;
   line-height: 1.5;
   font-weight: 400;
+  --safe-area-top: env(safe-area-inset-top, 0px);
+  --safe-area-right: env(safe-area-inset-right, 0px);
+  --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-area-left: env(safe-area-inset-left, 0px);
   --text: var(--color-text-primary);
   --text-secondary: var(--color-text-secondary);
   --muted: var(--color-text-muted);
@@ -79,8 +83,8 @@
 html,
 body,
 #root {
-  height: 100vh;
-  min-height: 100vh;
+  height: 100dvh;
+  min-height: 100dvh;
 }
 
 body {
@@ -142,7 +146,7 @@ a {
 .app-shell {
   display: grid;
   grid-template-columns: var(--app-sidebar-width, 15rem) minmax(0, 1fr);
-  height: 100vh;
+  height: 100dvh;
   min-height: 0;
   overflow: hidden;
   transition: grid-template-columns 180ms ease;
@@ -348,7 +352,10 @@ a {
 .main-content {
   min-height: 0;
   overflow: auto;
-  padding: var(--screen-padding, 2rem);
+  padding-block-start: calc(var(--screen-padding, 2rem) + var(--safe-area-top));
+  padding-block-end: calc(var(--screen-padding, 2rem) + var(--safe-area-bottom));
+  padding-inline-start: calc(var(--screen-padding, 2rem) + var(--safe-area-left));
+  padding-inline-end: calc(var(--screen-padding, 2rem) + var(--safe-area-right));
 }
 
 .screen {

--- a/apps/desktop/src/styles/project-inspector.css
+++ b/apps/desktop/src/styles/project-inspector.css
@@ -56,6 +56,17 @@
   grid-area: danger;
 }
 
+@media (max-width: 1200px) {
+  .inspector-stack--analysis .section-stack {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "summary"
+      "details"
+      "export"
+      "danger";
+  }
+}
+
 .mix-builder__retune {
   display: flex;
   flex-direction: column;

--- a/apps/desktop/src/styles/utilities-responsive.css
+++ b/apps/desktop/src/styles/utilities-responsive.css
@@ -5,8 +5,8 @@
 
 .player--hidden {
   position: absolute;
-  width: 0;
-  height: 0;
+  width: 1px;
+  height: 1px;
   opacity: 0;
   pointer-events: none;
 }

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -13,40 +13,60 @@ The frontend talks through a `TuneForgeClient` boundary. Desktop uses the existi
 
 ## Android Embedded Backend
 
-Rust owns mobile project persistence, artifact records, job records, and app data paths. Kotlin/Android is the intended bridge for platform-only work:
+Rust owns mobile project persistence, artifact records, job records, and app data paths. Kotlin/Android or Rust NDK bindings are the intended bridge for platform-only work:
 
 - `content://` import resolution and permissions
 - Android media decode/encode through `MediaExtractor`, `MediaCodec`, `MediaMuxer`, and Media3 Transformer
 - GPU/NPU capability probes
-- future native ML runtime integration
+- native ML runtime integration
 
-The current Rust command surface is present even when generation is unavailable. Generation commands must fail closed if accelerated local inference is not available.
+The current Rust command surface is present even when generation is unavailable. Generation commands must fail closed if required local inference assets are unavailable.
 
-## GPU-Only Generation
+## Mobile Processing Gates
 
-Mobile ML generation has no CPU fallback. Capability detection returns:
+Analyze and basic chord detection may run on CPU. Lyrics transcription may also run locally on CPU when a side-loaded `whisper.cpp` ggml model is present in app-private storage. Stem separation and other heavier generation paths stay unavailable until a native local runtime is wired. Capability detection returns:
 
 - `gpuBackend`: `vulkan`, `nnapi`, `qnn`, `coreml`, or `null`
+- `isEmulator`
+- `analysisAvailable`
+- `basicChordsAvailable`
 - `whisperAvailable`
 - `stemSeparationAvailable`
+- `generationTestingAvailable`
 - `maxRecommendedModel`
 - `cpuFallbackAllowed: false`
 
-If required acceleration is unavailable, the UI disables generation and shows:
+If the local Whisper model is missing, the UI disables lyrics generation and shows:
 
 ```text
-Local generation requires GPU acceleration on this device.
+Side-load a Whisper model to enable local lyrics. Stem generation is unavailable on this device.
 ```
+
+Debug Android emulator builds may set `generationTestingAvailable` so the lyrics action can submit jobs during UI flow testing. This does not report Whisper or stem separation as available. Once a Whisper model is side-loaded, lyrics use the real local transcription path; stems stay disabled and still fail closed if invoked directly.
+
+For local lyrics testing, side-load one of these files before launching the app:
+
+```sh
+adb push ggml-base.bin /data/local/tmp/ggml-base.bin
+adb shell run-as com.tuneforge.desktop mkdir -p models/whisper
+adb shell run-as com.tuneforge.desktop cp /data/local/tmp/ggml-base.bin models/whisper/ggml-base.bin
+```
+
+The supported lookup priority is `ggml-base.bin`, `ggml-base.en.bin`, `ggml-tiny.bin`, then
+`ggml-tiny.en.bin`.
 
 ## FFmpeg Policy
 
 Mobile does not bundle FFmpeg. Android uses platform media APIs instead.
 
 - Import keeps the original file inside app storage.
-- Decode for waveform/ML uses Android media decode APIs.
+- WAV/PCM can be read directly for CPU analysis and basic chord detection.
+- Compressed audio should decode through Android media APIs before waveform or ML processing.
 - Mobile internal generated audio should prefer `m4a`/AAC first.
-- Desktop keeps WAV intermediates and `wav`/`mp3`/`flac` exports through host-installed FFmpeg.
+- Desktop currently keeps WAV intermediates and `wav`/`mp3`/`flac` exports through host-installed FFmpeg.
 - Unsupported mobile export formats stay unavailable until a native encoder path exists.
+
+Future desktop refinement: consider matching the mobile storage model by keeping the original import as the canonical source and creating normalized PCM/WAV files only as disposable derived cache. Analysis, chords, and feature data should stay cached separately so repeated desktop workflows do not require persistent full-size WAV copies.
 
 ## Android Setup
 
@@ -64,8 +84,22 @@ Android commands. Tauri cannot initialize or build the Android target without an
 Android builds are arm64-only by default for this experiment. Use `pnpm package:android` or
 `pnpm package:android:debug`; both pass `--target aarch64` and avoid building `armv7`, `i686`, or
 `x86_64`.
+Android package scripts run `tauri icon --output src-tauri/target/android-icons src-tauri/icons/icon.png`
+before building so ignored desktop icon outputs stay under `target/` while the generated Android
+launcher resources under `apps/desktop/src-tauri/gen/android/app/src/main/res/` are refreshed from
+the tracked TuneForge icon instead of Tauri's default icon.
 The Android scripts run through `scripts/android-arm64-env.sh` so Cargo uses the rustup toolchain and
 the Android NDK `aarch64-linux-android24-clang` compiler.
+
+## Stem Separation Spike
+
+Stem separation remains unavailable on mobile in this experiment. The lowest-risk next spike is an
+ONNX/Open-Unmix path because it has existing Android-oriented ONNX exports and a smaller integration
+surface than a full Demucs port, but it still needs native STFT/iSTFT, chunking, memory budgeting,
+and model-file policy work. ExecuTorch/Demucs is the more future-proof PyTorch-native direction, but
+it is higher risk for this branch because it requires model export validation, Android runtime
+integration, and careful device/backend selection. Full runtime integration should wait until the
+basic mobile project, analysis, chords, lyrics, playback, and packaging path is stable.
 
 For Android Studio repo-root import, run `pnpm android:studio:shim` after Android init. The script
 writes ignored root Gradle files that point Studio at `apps/desktop/src-tauri/gen/android`, set the

--- a/packages/shared-types/src/mobile.ts
+++ b/packages/shared-types/src/mobile.ts
@@ -1,9 +1,13 @@
 export type MobileCapabilities = {
   platform: "android" | "ios";
   mediaBackend: "android_media_codec" | "avfoundation";
+  isEmulator: boolean;
   gpuBackend: "vulkan" | "nnapi" | "qnn" | "coreml" | null;
+  analysisAvailable: boolean;
+  basicChordsAvailable: boolean;
   whisperAvailable: boolean;
   stemSeparationAvailable: boolean;
+  generationTestingAvailable: boolean;
   maxRecommendedModel: "tiny" | "base" | "small" | null;
-  cpuFallbackAllowed: false;
+  cpuFallbackAllowed: boolean;
 };

--- a/scripts/android-arm64-env.sh
+++ b/scripts/android-arm64-env.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ANDROID_HOME="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-$HOME/Library/Android/sdk}}"
 NDK_ROOT="${ANDROID_NDK_HOME:-${ANDROID_NDK_ROOT:-}}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [[ -z "$NDK_ROOT" ]]; then
   if [[ ! -d "$ANDROID_HOME/ndk" ]]; then
@@ -27,19 +28,50 @@ esac
 
 toolchain="$NDK_ROOT/toolchains/llvm/prebuilt/$prebuilt/bin"
 cc="$toolchain/aarch64-linux-android24-clang"
+cxx="$toolchain/aarch64-linux-android24-clang++"
 ar="$toolchain/llvm-ar"
 
 if [[ ! -x "$cc" ]]; then
   echo "Android arm64 compiler not found: $cc" >&2
   exit 1
 fi
+if [[ ! -x "$cxx" ]]; then
+  echo "Android arm64 C++ compiler not found: $cxx" >&2
+  exit 1
+fi
 
 cargo_bin="$(dirname "$(rustup which cargo)")"
 
 export PATH="$cargo_bin:$toolchain:$PATH"
+export ANDROID_HOME="$ANDROID_HOME"
+export ANDROID_SDK_ROOT="$ANDROID_HOME"
+export ANDROID_NDK_HOME="$NDK_ROOT"
+export ANDROID_NDK_ROOT="$NDK_ROOT"
 export CC_aarch64_linux_android="$cc"
+export CXX_aarch64_linux_android="$cxx"
 export AR_aarch64_linux_android="$ar"
 export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER="$cc"
 export CARGO_TARGET_AARCH64_LINUX_ANDROID_AR="$ar"
+export CMAKE_TOOLCHAIN_FILE="$SCRIPT_DIR/android-arm64.toolchain.cmake"
+export ANDROID_ABI="arm64-v8a"
+export ANDROID_PLATFORM="android-24"
+export CMAKE_ANDROID_ARCH_ABI="arm64-v8a"
+export CMAKE_SYSTEM_PROCESSOR="aarch64"
+export CMAKE_SYSTEM_VERSION="24"
+
+if command -v make >/dev/null 2>&1; then
+  export CMAKE_MAKE_PROGRAM="$(command -v make)"
+fi
+
+# whisper-rs-sys checks the macOS build-script host instead of the Android target
+# and asks rustc to link ggml-blas even when the Android CMake build disables it.
+# Provide an empty archive so the unused static-lib request does not break
+# Android packaging on macOS.
+shim_dir="${TMPDIR:-/tmp}/tuneforge-android-link-shims"
+mkdir -p "$shim_dir"
+if [[ ! -f "$shim_dir/libggml-blas.a" ]]; then
+  "$ar" crs "$shim_dir/libggml-blas.a"
+fi
+export RUSTFLAGS="${RUSTFLAGS:-} -L native=$shim_dir"
 
 exec "$@"

--- a/scripts/android-arm64.toolchain.cmake
+++ b/scripts/android-arm64.toolchain.cmake
@@ -1,0 +1,16 @@
+set(ANDROID_ABI arm64-v8a)
+set(CMAKE_ANDROID_ARCH_ABI arm64-v8a)
+set(ANDROID_PLATFORM android-24)
+set(CMAKE_SYSTEM_VERSION 24)
+set(ANDROID_USE_LEGACY_TOOLCHAIN_FILE OFF)
+set(ANDROID_ABI arm64-v8a CACHE STRING "Android ABI" FORCE)
+set(CMAKE_ANDROID_ARCH_ABI arm64-v8a CACHE STRING "Android ABI" FORCE)
+set(ANDROID_PLATFORM android-24 CACHE STRING "Android platform" FORCE)
+set(CMAKE_SYSTEM_VERSION 24 CACHE STRING "Android API level" FORCE)
+set(ANDROID_USE_LEGACY_TOOLCHAIN_FILE OFF CACHE BOOL "Use modern Android NDK CMake toolchain" FORCE)
+
+if(NOT DEFINED ENV{ANDROID_NDK_HOME})
+  message(FATAL_ERROR "ANDROID_NDK_HOME is required for the TuneForge Android arm64 toolchain.")
+endif()
+
+include("$ENV{ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake")

--- a/scripts/android-prepare-generated.sh
+++ b/scripts/android-prepare-generated.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ANDROID_MAIN="$ROOT_DIR/apps/desktop/src-tauri/gen/android/app/src/main"
+MANIFEST="$ANDROID_MAIN/AndroidManifest.xml"
+MAIN_ACTIVITY="$ANDROID_MAIN/java/com/tuneforge/desktop/MainActivity.kt"
+
+if [[ ! -f "$MANIFEST" || ! -f "$MAIN_ACTIVITY" ]]; then
+  echo "Android project is not initialized. Run pnpm --filter @tuneforge/desktop tauri android init first." >&2
+  exit 1
+fi
+
+ensure_permission() {
+  local permission="$1"
+  if grep -q "$permission" "$MANIFEST"; then
+    return
+  fi
+
+  local temp_file
+  temp_file="$(mktemp)"
+  awk -v permission="$permission" '
+    { print }
+    /android.permission.INTERNET/ {
+      print "    <uses-permission android:name=\"" permission "\" />"
+    }
+  ' "$MANIFEST" > "$temp_file"
+  mv "$temp_file" "$MANIFEST"
+}
+
+ensure_permission "android.permission.RECORD_AUDIO"
+ensure_permission "android.permission.MODIFY_AUDIO_SETTINGS"
+
+cat > "$MAIN_ACTIVITY" <<'KOTLIN'
+package com.tuneforge.desktop
+
+import android.os.Build
+import android.os.Bundle
+import android.view.View
+import android.view.WindowInsets
+import android.view.WindowInsetsController
+
+class MainActivity : TauriActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    scheduleHideNavigationBar()
+  }
+
+  override fun onWindowFocusChanged(hasFocus: Boolean) {
+    super.onWindowFocusChanged(hasFocus)
+    if (hasFocus) {
+      scheduleHideNavigationBar()
+    }
+  }
+
+  @Suppress("DEPRECATION")
+  private fun scheduleHideNavigationBar() {
+    window.decorView.post {
+      hideNavigationBar()
+    }
+  }
+
+  @Suppress("DEPRECATION")
+  private fun hideNavigationBar() {
+    val decorView = window.decorView
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      window.setDecorFitsSystemWindows(true)
+      decorView.windowInsetsController?.let { controller ->
+        controller.hide(WindowInsets.Type.navigationBars())
+        controller.systemBarsBehavior =
+          WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+      }
+      return
+    }
+
+    decorView.systemUiVisibility =
+      View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or
+        View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY or
+        View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+  }
+}
+KOTLIN


### PR DESCRIPTION
## Summary
- Rebase the Android-first Tauri mobile experiment onto current main under the broader `feat/mobile-app-android` branch.
- Enable mobile embedded analysis, built-in chords, local Whisper lyrics gates, and explicit mobile capability reporting.
- Add Android packaging/icon preparation, safe-area/playback fixes, docs updates, and stem-separation spike notes.

## Testing
- `pnpm --filter @tuneforge/desktop test --run App.project-playback-stems.test.tsx App.project-analysis-mix.test.tsx App.mobile.test.tsx`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
- `cd apps/desktop/src-tauri && cargo check`
- `bash scripts/android-arm64-env.sh cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml --target aarch64-linux-android`
- `pnpm package:android:debug`
- Emulator smoke test: launched final APK headless, verified analysis display and playback advance, and checked logcat for crashes.
