### PR TITLE
ci: tighten commitlint rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-        run: echo "$PR_TITLE" | pnpm exec commitlint
+        run: echo "$PR_TITLE" | pnpm exec commitlint --config commitlint.pr-title.config.cjs
 
   backend:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,7 +144,7 @@ The following files are generated. **Do not edit by hand.**
 
 ## Commit and PR Hygiene
 
-- **Conventional Commits required.** Format: `<type>(<optional scope>): <subject>`. Allowed types: `feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `build`, `ci`, `chore`, `revert`. Subject is imperative (`add ...`, not `Added`/`Adds`). Header ≤ 100 chars. The `commit-msg` Husky hook and a CI job (`commitlint`) enforce this on every commit and on the PR title.
+- **Conventional Commits required.** Format: `<type>(<optional scope>): <subject>`, followed by a blank line and at least one body line describing the change. Allowed types: `feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `build`, `ci`, `chore`, `revert`. Subject is imperative (`add ...`, not `Added`/`Adds`). Header, body, and footer lines must be ≤ 100 chars. The `commit-msg` Husky hook and a CI job (`commitlint`) enforce this on every commit; CI also checks the single-line PR title with the body requirement disabled.
 - Reference issues with `Fixes #123` / `Refs #123` in the body or footer.
 - One concern per commit and per PR. If a refactor and a feature are tangled, split them into separate PRs.
 - **Prefer one commit per PR.** A repository ruleset enforces squash merges and linear history on `main`, so any extra commits in a PR get folded into one at merge time anyway. The PR title becomes the squash commit message, so it must also pass commitlint. Recommended workflow: amend the existing commit and push with `git push --force-with-lease` rather than stacking fix-up commits.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,8 @@ Format:
 
 ```
 <type>(<optional scope>): <subject>
+
+One or more lines describing what changed.
 ```
 
 Allowed types: `feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `build`, `ci`, `chore`, `revert`.
@@ -114,9 +116,20 @@ Examples:
 
 ```
 feat(backend): add chord smoothing window
+
+Add a configurable smoothing pass to reduce noisy chord transitions.
+
 fix(desktop): keep playback position on tab switch
+
+Keep the shared playback clock mounted while navigating project views.
+
 ci: pin commitlint action to v6.2.1
+
+Use the same action version across branch and pull request checks.
+
 docs: clarify ffmpeg prerequisite
+
+Explain that FFmpeg is host-installed instead of bundled with Tuneforge.
 ```
 
 Rules:
@@ -124,6 +137,8 @@ Rules:
 - Use a concise, imperative subject (`add ...`, not `added ...` / `adds ...`).
 - Subject must not start with a capitalised word, PascalCase, or all-caps.
 - Header (full first line) must be ≤ 100 characters.
+- Include at least one body line describing the change.
+- Body and footer lines must be ≤ 100 characters.
 - Reference issues in the body or footer with `Fixes #123` / `Refs #123`.
 - Keep unrelated changes in separate PRs.
 

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -3,10 +3,11 @@
 /**
  * Commitlint configuration.
  *
- * Enforces Conventional Commits on every commit and on PR titles
- * (since `main` uses squash merges, the PR title becomes the squash
- * commit message). Keep types in sync with what auto-labelling and
- * any future semantic-release config expect.
+ * Enforces Conventional Commits on every commit. PR titles use
+ * `commitlint.pr-title.config.cjs` because they intentionally stay
+ * single-line while commit messages require a descriptive body.
+ * Keep types in sync with what auto-labelling and any future
+ * semantic-release config expect.
  *
  * Allowed types:
  *   feat      new user-facing feature
@@ -48,6 +49,7 @@ module.exports = {
       ["start-case", "pascal-case", "upper-case"],
     ],
     "header-max-length": [2, "always", 100],
-    "body-max-line-length": [1, "always", 100],
+    "body-empty": [2, "never"],
+    "body-max-line-length": [2, "always", 100],
   },
 };

--- a/commitlint.pr-title.config.cjs
+++ b/commitlint.pr-title.config.cjs
@@ -1,0 +1,16 @@
+// @ts-check
+
+/**
+ * Commitlint configuration for PR titles.
+ *
+ * PR titles become the squash commit subject on `main`, so they should
+ * follow the same Conventional Commit subject rules as normal commits.
+ * They are intentionally single-line, so the commit-body requirement is
+ * disabled here.
+ */
+module.exports = {
+  extends: ["./commitlint.config.cjs"],
+  rules: {
+    "body-empty": [0, "never"],
+  },
+};


### PR DESCRIPTION
## Summary
- Require commit messages to include a body and enforce 100-character body line limits as errors.
- Keep PR title lint single-line by using a separate commitlint config for title checks.
- Update contributor and agent docs with the stricter commit message format.

## Testing
- `node_modules/.bin/commitlint --last --config commitlint.config.cjs`
- `printf '%s\n' 'ci: tighten commitlint rules' | node_modules/.bin/commitlint --config commitlint.pr-title.config.cjs`
- Targeted commitlint cases: subject-only, body-present, long body, footer-only, PR title, long header
- `git diff --cached --check`
