### PR TITLE
fix: lower pre-count click sound

### DIFF
--- a/apps/desktop/src/features/projects/precountSound.test.ts
+++ b/apps/desktop/src/features/projects/precountSound.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PRECOUNT_GAIN, schedulePrecountClaveClick } from "./precountSound";
+
+type MockAudioParam = AudioParam & {
+  exponentialRampToValueAtTime: ReturnType<typeof vi.fn>;
+  setValueAtTime: ReturnType<typeof vi.fn>;
+};
+
+type MockGainNode = GainNode & {
+  connect: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  gain: MockAudioParam;
+};
+
+type MockOscillatorNode = OscillatorNode & {
+  connect: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  frequency: MockAudioParam;
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+};
+
+type MockAudioContext = AudioContext & {
+  createdOscillators: MockOscillatorNode[];
+  createGain: ReturnType<typeof vi.fn>;
+};
+
+function getMockAudioContexts() {
+  return (
+    globalThis as typeof globalThis & {
+      __mockAudioContexts: MockAudioContext[];
+    }
+  ).__mockAudioContexts;
+}
+
+describe("precount sound", () => {
+  beforeEach(() => {
+    getMockAudioContexts().length = 0;
+  });
+
+  it("schedules a fixed lower full-volume clave-style click", () => {
+    const audioContext = new AudioContext() as MockAudioContext;
+
+    schedulePrecountClaveClick({
+      audioContext,
+      startTimeSeconds: 1.25,
+    });
+
+    const oscillator = audioContext.createdOscillators[0];
+    const gainNode = audioContext.createGain.mock.results[0]?.value as MockGainNode | undefined;
+    if (!oscillator || !gainNode) {
+      throw new Error("Expected precount click nodes to be created.");
+    }
+
+    expect(oscillator.type).toBe("square");
+    const startFrequencyCall = oscillator.frequency.setValueAtTime.mock.calls[0];
+    const startFrequencyHz = Number(startFrequencyCall?.[0]);
+    const safeStartTimeSeconds = Number(startFrequencyCall?.[1]);
+    expect(startFrequencyHz).toBe(760);
+    expect(startFrequencyHz).toBeLessThan(1450);
+    expect(oscillator.frequency.exponentialRampToValueAtTime).not.toHaveBeenCalled();
+    expect(safeStartTimeSeconds).toBe(1.25);
+
+    expect(gainNode.gain.setValueAtTime).toHaveBeenCalledWith(0.0001, 1.25);
+    const peakGainCall = gainNode.gain.exponentialRampToValueAtTime.mock.calls[0];
+    const releaseGainCall = gainNode.gain.exponentialRampToValueAtTime.mock.calls[1];
+    expect(peakGainCall?.[0]).toBe(PRECOUNT_GAIN);
+    expect(PRECOUNT_GAIN).toBe(1);
+    expect(Number(peakGainCall?.[1]) - safeStartTimeSeconds).toBeCloseTo(0.002, 6);
+    expect(releaseGainCall?.[0]).toBe(0.0001);
+    const stopTimeSeconds = Number(releaseGainCall?.[1]);
+    expect(stopTimeSeconds - safeStartTimeSeconds).toBeCloseTo(0.045, 6);
+    expect(oscillator.connect).toHaveBeenCalledWith(gainNode);
+    expect(gainNode.connect).toHaveBeenCalledWith(audioContext.destination);
+
+    expect(oscillator.start).toHaveBeenCalledWith(1.25);
+    expect(Number(oscillator.stop.mock.calls[0]?.[0]) - stopTimeSeconds).toBeCloseTo(0.004, 6);
+  });
+});

--- a/apps/desktop/src/features/projects/precountSound.ts
+++ b/apps/desktop/src/features/projects/precountSound.ts
@@ -1,5 +1,9 @@
 export const PRECOUNT_START_DELAY_SECONDS = 0.035;
-export const PRECOUNT_GAIN = 0.36;
+export const PRECOUNT_GAIN = 1;
+const PRECOUNT_FREQUENCY_HZ = 760;
+const PRECOUNT_CLICK_ATTACK_SECONDS = 0.002;
+const PRECOUNT_CLICK_DURATION_SECONDS = 0.045;
+const PRECOUNT_STOP_TAIL_SECONDS = 0.004;
 
 export function schedulePrecountClaveClick({
   audioContext,
@@ -11,12 +15,11 @@ export function schedulePrecountClaveClick({
   const oscillator = audioContext.createOscillator();
   const gainNode = audioContext.createGain();
   const safeStartTimeSeconds = Math.max(audioContext.currentTime, startTimeSeconds);
-  const peakTimeSeconds = safeStartTimeSeconds + 0.003;
-  const stopTimeSeconds = safeStartTimeSeconds + 0.072;
+  const peakTimeSeconds = safeStartTimeSeconds + PRECOUNT_CLICK_ATTACK_SECONDS;
+  const stopTimeSeconds = safeStartTimeSeconds + PRECOUNT_CLICK_DURATION_SECONDS;
 
-  oscillator.type = "triangle";
-  oscillator.frequency.setValueAtTime(2100, safeStartTimeSeconds);
-  oscillator.frequency.exponentialRampToValueAtTime(1450, stopTimeSeconds);
+  oscillator.type = "square";
+  oscillator.frequency.setValueAtTime(PRECOUNT_FREQUENCY_HZ, safeStartTimeSeconds);
   gainNode.gain.setValueAtTime(0.0001, safeStartTimeSeconds);
   gainNode.gain.exponentialRampToValueAtTime(PRECOUNT_GAIN, peakTimeSeconds);
   gainNode.gain.exponentialRampToValueAtTime(0.0001, stopTimeSeconds);
@@ -28,5 +31,5 @@ export function schedulePrecountClaveClick({
     gainNode.disconnect();
   };
   oscillator.start(safeStartTimeSeconds);
-  oscillator.stop(stopTimeSeconds + 0.006);
+  oscillator.stop(stopTimeSeconds + PRECOUNT_STOP_TAIL_SECONDS);
 }


### PR DESCRIPTION
## Summary

- Replace the high swept pre-count click with a fixed lower generated click.
- Make the pre-count click full peak volume so it stays audible before playback starts.
- Add focused coverage for the generated pre-count sound envelope.

## Testing

- `pnpm --filter @tuneforge/desktop test --run src/features/projects/precountSound.test.ts --reporter=dot`
- `pnpm --filter @tuneforge/desktop test --run src/App.project-precount.test.tsx --reporter=dot`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `git diff --check`
