### PR TITLE
chore: ignore local pnpm store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ apps/backend/.ruff_cache/
 
 # JavaScript / build output
 node_modules/
+/.pnpm-store/
 dist/
 build/
 .coverage


### PR DESCRIPTION
## Summary
- Ignore the workspace-local `.pnpm-store/` directory created by direct pnpm test runs.

## Testing
- `pnpm --filter @tuneforge/desktop test --run`
