### PR TITLE
feat: add playback tempo control

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Pre-1.0. The desktop dev flow (`pnpm dev`) is the fastest way to iterate. Local 
 - Pitch transpose (semitones) and retune (target reference Hz).
 - Stem separation via a local Demucs backend (`htdemucs_ft` by default).
 - Preview rendering (cached) and export to `wav`, `mp3`, or `flac`.
-- Per-project playback session with persistence across navigation.
+- Per-project playback session with persistence, count-in, and playback-level tempo changes.
 
 ## Threat Model and Scope
 

--- a/apps/desktop/src/App.project-tempo.test.tsx
+++ b/apps/desktop/src/App.project-tempo.test.tsx
@@ -1,0 +1,292 @@
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  findAudioByArtifactId,
+  getMockAudioContexts,
+  markAudioReady,
+  mockCreateExport,
+  mockCreatePreview,
+  mockCreateStems,
+  renderApp,
+  resetAppTestHarness,
+  setAudioPlaybackState,
+  setProjectAnalysis,
+} from "./test/appTestHarness";
+
+const tempoAnalysis = {
+  project_id: "proj_123",
+  estimated_key: "G major",
+  key_confidence: 0.82,
+  estimated_reference_hz: 440,
+  tuning_offset_cents: 0,
+  tempo_bpm: 123.5,
+  analysis_version: "v1",
+  created_at: "2026-04-18T13:16:00.000Z",
+};
+
+function setupTempoAnalysis(tempoBpm = 123.5) {
+  setProjectAnalysis("proj_123", {
+    ...tempoAnalysis,
+    tempo_bpm: tempoBpm,
+  });
+}
+
+async function openPlaybackWorkspace(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("tab", { name: "Playback" }));
+}
+
+async function openStudioPanel(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("tab", { name: "Studio" }));
+}
+
+function tempoControl() {
+  const group = screen.getByRole("group", { name: "Playback tempo BPM" });
+  const section = group.closest("section");
+  if (!section) {
+    throw new Error("Tempo control not found.");
+  }
+  return { group, section: section as HTMLElement };
+}
+
+function setPlaybackPosition(value: string) {
+  fireEvent.change(screen.getByLabelText("Playback position"), { target: { value } });
+}
+
+describe("Desktop app project playback tempo", () => {
+  beforeEach(resetAppTestHarness);
+
+  it("persists whole-BPM tempo changes and reset without creating audio files", async () => {
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    const firstRender = renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    const { group, section } = tempoControl();
+
+    expect(within(section).getByText("Original 123.5 BPM")).toBeInTheDocument();
+    await user.click(within(group).getByRole("button", { name: "Decrease playback tempo" }));
+
+    expect(within(section).getByText("123 BPM (0.996x)")).toBeInTheDocument();
+    expect(mockCreatePreview).not.toHaveBeenCalled();
+    expect(mockCreateStems).not.toHaveBeenCalled();
+    expect(mockCreateExport).not.toHaveBeenCalled();
+
+    firstRender.unmount();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    expect(screen.getByText("123 BPM (0.996x)")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Reset" }));
+    expect(screen.getByText("Original 123.5 BPM")).toBeInTheDocument();
+  });
+
+  it("keeps source and practice mix switching on the streamed media path when tempo is changed", async () => {
+    const user = userEvent.setup();
+    setupTempoAnalysis(120);
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+
+    await user.click(screen.getByRole("button", { name: "Decrease playback tempo" }));
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    expect(sourceAudio.playbackRate).toBeCloseTo(119 / 120, 4);
+    expect((sourceAudio as HTMLAudioElement & { preservesPitch?: boolean }).preservesPitch).toBe(true);
+    expect(vi.mocked(window.HTMLMediaElement.prototype.play)).toHaveBeenCalled();
+    expect(getMockAudioContexts()[0]?.createdSources ?? []).toHaveLength(0);
+
+    setPlaybackPosition("47.253");
+    const sourceList = screen.getByRole("group", { name: "Playback source and mix list" });
+    await user.click(within(sourceList).getByRole("button", { name: /Practice Mix/i }));
+
+    const previewAudio = findAudioByArtifactId("art_preview");
+    previewAudio.currentTime = 0;
+    setAudioPlaybackState(previewAudio);
+    fireEvent.loadedMetadata(previewAudio);
+    fireEvent.canPlay(previewAudio);
+    previewAudio.currentTime = 47.253;
+    fireEvent.seeked(previewAudio);
+
+    await waitFor(() => expect(previewAudio.currentTime).toBeCloseTo(47.253, 3));
+    expect(previewAudio.playbackRate).toBeCloseTo(119 / 120, 4);
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+  });
+
+  it("preserves time when changing tempo during active buffered playback", async () => {
+    const user = userEvent.setup();
+    setupTempoAnalysis(120);
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(getMockAudioContexts()[0]?.createdSources).toHaveLength(1));
+    setPlaybackPosition("32.5");
+    await openPlaybackWorkspace(user);
+
+    const playCallsBeforeTempoChange =
+      vi.mocked(window.HTMLMediaElement.prototype.play).mock.calls.length;
+    await user.click(screen.getByRole("button", { name: "Decrease playback tempo" }));
+
+    await waitFor(() => {
+      expect(sourceAudio.currentTime).toBeGreaterThanOrEqual(32.5);
+      expect(sourceAudio.currentTime).toBeLessThan(32.7);
+    });
+    await waitFor(() =>
+      expect(vi.mocked(window.HTMLMediaElement.prototype.play).mock.calls.length).toBeGreaterThan(
+        playCallsBeforeTempoChange,
+      ),
+    );
+    expect(sourceAudio.playbackRate).toBeCloseTo(119 / 120, 4);
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+  });
+
+  it("starts tempo-adjusted stems from metadata without requiring a pause toggle", async () => {
+    const user = userEvent.setup();
+    setupTempoAnalysis(120);
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openStudioPanel(user);
+    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    await openPlaybackWorkspace(user);
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+
+    await user.click(screen.getByRole("button", { name: "Decrease playback tempo" }));
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    setPlaybackPosition("41.125");
+
+    const playCallsBeforeStemSwitch =
+      vi.mocked(window.HTMLMediaElement.prototype.play).mock.calls.length;
+    const stemList = await screen.findByRole("group", { name: "Playback stem list" });
+    await user.click(within(stemList).getAllByRole("button", { name: /Vocals/i })[0] as HTMLElement);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Full Mix" })).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      ),
+    );
+
+    const vocalAudio = findAudioByArtifactId("art_200");
+    const instrumentalAudio = findAudioByArtifactId("art_201");
+    setAudioPlaybackState(vocalAudio, {
+      readyState: HTMLMediaElement.HAVE_METADATA,
+    });
+    setAudioPlaybackState(instrumentalAudio, {
+      readyState: HTMLMediaElement.HAVE_METADATA,
+    });
+    fireEvent.loadedMetadata(vocalAudio);
+    fireEvent.loadedMetadata(instrumentalAudio);
+    fireEvent.seeked(vocalAudio);
+    fireEvent.seeked(instrumentalAudio);
+
+    await waitFor(() =>
+      expect(vi.mocked(window.HTMLMediaElement.prototype.play).mock.calls.length).toBeGreaterThan(
+        playCallsBeforeStemSwitch,
+      ),
+    );
+    expect(vocalAudio.currentTime).toBeCloseTo(41.125, 3);
+    expect(instrumentalAudio.currentTime).toBeCloseTo(41.125, 3);
+    expect(vocalAudio.playbackRate).toBeCloseTo(119 / 120, 4);
+    expect(instrumentalAudio.playbackRate).toBeCloseTo(119 / 120, 4);
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+  });
+
+  it("updates tempo-adjusted stem rate in place without replaying or seeking", async () => {
+    const user = userEvent.setup();
+    setupTempoAnalysis(120);
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openStudioPanel(user);
+    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    await openPlaybackWorkspace(user);
+
+    const stemList = await screen.findByRole("group", { name: "Playback stem list" });
+    await user.click(within(stemList).getAllByRole("button", { name: /Vocals/i })[0] as HTMLElement);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Full Mix" })).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      ),
+    );
+    await user.click(screen.getByRole("button", { name: "Decrease playback tempo" }));
+
+    const vocalAudio = findAudioByArtifactId("art_200");
+    const instrumentalAudio = findAudioByArtifactId("art_201");
+    markAudioReady(vocalAudio);
+    markAudioReady(instrumentalAudio);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    setPlaybackPosition("52.25");
+
+    const playCallsBeforeTempoChanges =
+      vi.mocked(window.HTMLMediaElement.prototype.play).mock.calls.length;
+    const pauseCallsBeforeTempoChanges =
+      vi.mocked(window.HTMLMediaElement.prototype.pause).mock.calls.length;
+    await user.click(screen.getByRole("button", { name: "Decrease playback tempo" }));
+    await user.click(screen.getByRole("button", { name: "Decrease playback tempo" }));
+    await user.click(screen.getByRole("button", { name: "Increase playback tempo" }));
+
+    await waitFor(() => expect(vocalAudio.playbackRate).toBeCloseTo(118 / 120, 4));
+    expect(instrumentalAudio.playbackRate).toBeCloseTo(118 / 120, 4);
+    expect(vocalAudio.currentTime).toBeCloseTo(52.25, 3);
+    expect(instrumentalAudio.currentTime).toBeCloseTo(52.25, 3);
+    expect(vi.mocked(window.HTMLMediaElement.prototype.play).mock.calls).toHaveLength(
+      playCallsBeforeTempoChanges,
+    );
+    expect(vi.mocked(window.HTMLMediaElement.prototype.pause).mock.calls).toHaveLength(
+      pauseCallsBeforeTempoChanges,
+    );
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+  });
+
+  it("keeps tempo-adjusted stem playback synced with mute, solo, and full-mix handoff", async () => {
+    const user = userEvent.setup();
+    setupTempoAnalysis(120);
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openStudioPanel(user);
+    await user.click(screen.getByRole("button", { name: "Generate Stems" }));
+    await openPlaybackWorkspace(user);
+
+    const stemList = await screen.findByRole("group", { name: "Playback stem list" });
+    await user.click(within(stemList).getAllByRole("button", { name: /Vocals/i })[0] as HTMLElement);
+    await user.click(screen.getByRole("button", { name: "Decrease playback tempo" }));
+
+    const vocalAudio = findAudioByArtifactId("art_200");
+    const instrumentalAudio = findAudioByArtifactId("art_201");
+    markAudioReady(vocalAudio);
+    markAudioReady(instrumentalAudio);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    expect(vocalAudio.playbackRate).toBeCloseTo(119 / 120, 4);
+    expect(instrumentalAudio.playbackRate).toBeCloseTo(119 / 120, 4);
+    await user.click(screen.getByRole("button", { name: "Solo Vocals" }));
+    expect(vocalAudio.volume).toBe(1);
+    expect(instrumentalAudio.volume).toBe(0);
+
+    setPlaybackPosition("28.25");
+    await user.click(screen.getByRole("button", { name: "Full Mix" }));
+    const sourceAudio = findAudioByArtifactId("art_source");
+    setAudioPlaybackState(sourceAudio);
+    fireEvent.loadedMetadata(sourceAudio);
+    fireEvent.canPlay(sourceAudio);
+    sourceAudio.currentTime = 28.25;
+    fireEvent.seeked(sourceAudio);
+
+    await waitFor(() => expect(sourceAudio.currentTime).toBeCloseTo(28.25, 3));
+    expect(sourceAudio.playbackRate).toBeCloseTo(119 / 120, 4);
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpDown, AudioLines, Drumstick, Layers } from "lucide-react";
+import { ArrowUpDown, AudioLines, Drumstick, Gauge, Layers } from "lucide-react";
 import {
   artifactLabel,
   artifactSummary,
@@ -18,6 +18,10 @@ export function PlaybackPracticeRail() {
     capoShiftSummary,
     capoSourceKey,
     enharmonicDisplayMode,
+    canUseTempo,
+    handleDecreasePlaybackTempo,
+    handleIncreasePlaybackTempo,
+    handleResetPlaybackTempo,
     handleSelectPrimaryArtifact,
     handleSelectStemArtifact,
     higherCapoPreview,
@@ -48,10 +52,28 @@ export function PlaybackPracticeRail() {
     stageTitle,
     stemControls,
     stemOutputLabel,
+    tempoDisplayBpm,
+    tempoMaxBpm,
+    tempoMinBpm,
+    tempoOriginalBpm,
+    tempoPlaybackRate,
+    tempoTargetBpm,
     toggleStemControl,
     visibleStemArtifacts,
   } = useProjectViewModelContext();
   const showHeaderDetails = informationDensity === "detailed";
+  const tempoDisplayLabel =
+    tempoDisplayBpm === null
+      ? "--"
+      : Number.isInteger(tempoDisplayBpm)
+        ? tempoDisplayBpm.toFixed(0)
+        : tempoDisplayBpm.toFixed(1);
+  const tempoSummary =
+    canUseTempo && tempoDisplayBpm !== null && tempoOriginalBpm !== null
+      ? tempoTargetBpm === null
+        ? `Original ${tempoOriginalBpm.toFixed(1)} BPM`
+        : `${tempoTargetBpm.toFixed(0)} BPM (${tempoPlaybackRate.toFixed(3)}x)`
+      : "Waiting for tempo analysis";
 
   return (
     <aside className="panel playback-practice-rail">
@@ -65,6 +87,9 @@ export function PlaybackPracticeRail() {
         </span>
         <span title="Pre-count">
           <Drumstick aria-hidden="true" />
+        </span>
+        <span title="Tempo">
+          <Gauge aria-hidden="true" />
         </span>
         <span title="Source and Mixes">
           <Layers aria-hidden="true" />
@@ -164,6 +189,51 @@ export function PlaybackPracticeRail() {
             ? `${precountClickCount} clicks at ${precountTempoBpm.toFixed(1)} BPM`
             : precountDisabledReason}
         </p>
+      </section>
+
+      <section
+        className={`playback-tempo-control${
+          canUseTempo ? "" : " playback-tempo-control--disabled"
+        }`}
+        aria-labelledby="playback-tempo-heading"
+      >
+        <div className="playback-tempo-control__header">
+          <div>
+            <p className="metric-label">Tempo</p>
+            <h3 id="playback-tempo-heading">Playback BPM</h3>
+          </div>
+          <button
+            className="button button--ghost button--small"
+            disabled={!canUseTempo || tempoTargetBpm === null}
+            onClick={handleResetPlaybackTempo}
+            type="button"
+          >
+            Reset
+          </button>
+        </div>
+        <div className="playback-tempo-control__stepper" role="group" aria-label="Playback tempo BPM">
+          <button
+            aria-label="Decrease playback tempo"
+            disabled={!canUseTempo || tempoDisplayBpm === null || tempoDisplayBpm <= tempoMinBpm}
+            onClick={handleDecreasePlaybackTempo}
+            type="button"
+          >
+            -
+          </button>
+          <strong aria-live="polite">
+            {tempoDisplayLabel}
+            <span>BPM</span>
+          </strong>
+          <button
+            aria-label="Increase playback tempo"
+            disabled={!canUseTempo || tempoDisplayBpm === null || tempoDisplayBpm >= tempoMaxBpm}
+            onClick={handleIncreasePlaybackTempo}
+            type="button"
+          >
+            +
+          </button>
+        </div>
+        <p className="artifact-meta playback-tempo-control__summary">{tempoSummary}</p>
       </section>
 
       <section className="playback-picker-group playback-picker-group--compact">

--- a/apps/desktop/src/features/projects/components/PlaybackTransport.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackTransport.tsx
@@ -1,3 +1,4 @@
+import { RotateCcw } from "lucide-react";
 import { PlayPauseGlyph, SeekGlyph, StopGlyph } from "./TransportGlyphs";
 import { formatPlaybackClock } from "../projectViewUtils";
 
@@ -7,8 +8,11 @@ export function PlaybackTransport({
   maxSeconds,
   playbackTimeSeconds,
   seekAnimationRevision,
+  tempoDisplayBpm,
+  tempoTargetBpm,
   onSeek,
   onSeekTo,
+  onResetTempo,
   onStop,
   onTogglePlayback,
 }: {
@@ -17,11 +21,21 @@ export function PlaybackTransport({
   maxSeconds: number;
   playbackTimeSeconds: number;
   seekAnimationRevision: Record<"backward" | "forward", number>;
+  tempoDisplayBpm: number | null;
+  tempoTargetBpm: number | null;
   onSeek: (secondsDelta: number) => void;
   onSeekTo: (timeSeconds: number) => void;
+  onResetTempo: () => void;
   onStop: () => void;
   onTogglePlayback: () => Promise<void>;
 }) {
+  const tempoLabel =
+    tempoDisplayBpm === null
+      ? "--"
+      : Number.isInteger(tempoDisplayBpm)
+        ? tempoDisplayBpm.toFixed(0)
+        : tempoDisplayBpm.toFixed(1);
+
   return (
     <div className={`transport${compact ? " transport--compact" : ""}`}>
       <div className="transport__controls">
@@ -67,6 +81,18 @@ export function PlaybackTransport({
           />
         </button>
       </div>
+
+      <button
+        aria-label={tempoTargetBpm === null ? "Tempo at original" : "Reset tempo"}
+        className={`transport__tempo${tempoTargetBpm === null ? "" : " transport__tempo--active"}`}
+        disabled={tempoDisplayBpm === null || tempoTargetBpm === null}
+        onClick={onResetTempo}
+        type="button"
+      >
+        <span>Tempo</span>
+        <strong>{tempoLabel} BPM</strong>
+        {tempoTargetBpm !== null ? <RotateCcw aria-hidden="true" size={14} /> : null}
+      </button>
 
       <label className="transport__scrubber">
         <span className="metric-label">Playback position</span>

--- a/apps/desktop/src/features/projects/components/PlaybackWorkspace.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackWorkspace.tsx
@@ -7,6 +7,7 @@ export function PlaybackWorkspace() {
   const {
     handleSeek,
     handleSeekTo,
+    handleResetPlaybackTempo,
     isPlaying,
     playbackDurationSeconds,
     playbackTransportRef,
@@ -14,6 +15,8 @@ export function PlaybackWorkspace() {
     projectQuery,
     seekAnimationRevision,
     stopPlayback,
+    tempoDisplayBpm,
+    tempoTargetBpm,
     togglePlayback,
   } = useProjectViewModelContext();
   const maxSeconds = playbackDurationSeconds || projectQuery.data?.duration_seconds || 0;
@@ -29,8 +32,11 @@ export function PlaybackWorkspace() {
           maxSeconds={maxSeconds}
           playbackTimeSeconds={playbackTimeSeconds}
           seekAnimationRevision={seekAnimationRevision}
+          tempoDisplayBpm={tempoDisplayBpm}
+          tempoTargetBpm={tempoTargetBpm}
           onSeek={handleSeek}
           onSeekTo={handleSeekTo}
+          onResetTempo={handleResetPlaybackTempo}
           onStop={stopPlayback}
           onTogglePlayback={togglePlayback}
         />

--- a/apps/desktop/src/features/projects/components/ProjectPlaybackSummary.tsx
+++ b/apps/desktop/src/features/projects/components/ProjectPlaybackSummary.tsx
@@ -5,6 +5,7 @@ export function ProjectPlaybackSummary() {
   const {
     handleSeek,
     handleSeekTo,
+    handleResetPlaybackTempo,
     handleSelectWorkspace,
     isPlaying,
     playbackDurationSeconds,
@@ -17,6 +18,8 @@ export function ProjectPlaybackSummary() {
     stageSummary,
     stageTitle,
     stopPlayback,
+    tempoDisplayBpm,
+    tempoTargetBpm,
     togglePlayback,
   } = useProjectViewModelContext();
   const maxSeconds = playbackDurationSeconds || projectQuery.data?.duration_seconds || 0;
@@ -49,8 +52,11 @@ export function ProjectPlaybackSummary() {
           maxSeconds={maxSeconds}
           playbackTimeSeconds={playbackTimeSeconds}
           seekAnimationRevision={seekAnimationRevision}
+          tempoDisplayBpm={tempoDisplayBpm}
+          tempoTargetBpm={tempoTargetBpm}
           onSeek={handleSeek}
           onSeekTo={handleSeekTo}
+          onResetTempo={handleResetPlaybackTempo}
           onStop={stopPlayback}
           onTogglePlayback={togglePlayback}
         />

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -57,6 +57,13 @@ import {
 } from "../projectViewUtils";
 import type { DefaultPlaybackDisplayMode, PlaybackDisplayMode } from "../../../lib/preferences";
 import { useChordBackendActionSelection } from "./useChordBackendActionSelection";
+import {
+  MAX_PLAYBACK_TEMPO_BPM,
+  MIN_PLAYBACK_TEMPO_BPM,
+  normalizeTempoBpm,
+  tempoPlaybackRate,
+  tempoTargetBpmFromStep,
+} from "../playbackTempo";
 
 type PlaybackDisplayModeSource = "default" | "stored" | "user";
 
@@ -138,6 +145,7 @@ export function useProjectViewModel() {
   const [capoSelectorOpen, setCapoSelectorOpen] = useState(false);
   const [precountEnabled, setPrecountEnabled] = useState(false);
   const [precountClickCount, setPrecountClickCount] = useState(DEFAULT_PRECOUNT_CLICK_COUNT);
+  const [tempoTargetBpm, setTempoTargetBpm] = useState<number | null>(null);
   const [sourceKeySelectorOpen, setSourceKeySelectorOpen] = useState(false);
   const [selectedArtifactId, setSelectedArtifactId] = useState<string | null>(null);
   const [selectedPrimaryArtifactId, setSelectedPrimaryArtifactId] = useState<string | null>(null);
@@ -555,12 +563,16 @@ export function useProjectViewModel() {
     : "";
 
   const detectedKey = parseKey(analysisQuery.data?.estimated_key);
-  const analyzedTempoBpm = analysisQuery.data?.tempo_bpm;
-  const precountTempoBpm =
-    typeof analyzedTempoBpm === "number" && Number.isFinite(analyzedTempoBpm) && analyzedTempoBpm > 0
-      ? analyzedTempoBpm
-      : null;
-  const canUsePrecount = precountTempoBpm !== null;
+  const tempoOriginalBpm = normalizeTempoBpm(analysisQuery.data?.tempo_bpm);
+  const tempoTargetBpmForPlayback = tempoOriginalBpm === null ? null : tempoTargetBpm;
+  const tempoDisplayBpm = tempoTargetBpmForPlayback ?? tempoOriginalBpm;
+  const tempoPlaybackRateValue = tempoPlaybackRate({
+    originalBpm: tempoOriginalBpm,
+    targetBpm: tempoTargetBpmForPlayback,
+  });
+  const precountTempoBpm = tempoDisplayBpm;
+  const canUsePrecount = tempoOriginalBpm !== null;
+  const canUseTempo = tempoOriginalBpm !== null;
   const precountDisabledReason = canUsePrecount ? null : "Waiting for BPM analysis";
   const sourceKeyOverride = parseStoredKey(projectQuery.data?.source_key_override);
   const sourceKeyBasis = sourceKeyOverride ?? detectedKey ?? null;
@@ -905,6 +917,36 @@ export function useProjectViewModel() {
     setPrecountClickCount(normalizePrecountClickCount(value));
   }
 
+  function handleDecreasePlaybackTempo() {
+    if (!canUseTempo) {
+      return;
+    }
+    setTempoTargetBpm((current) =>
+      tempoTargetBpmFromStep({
+        currentTargetBpm: current,
+        delta: -1,
+        originalBpm: tempoOriginalBpm,
+      }),
+    );
+  }
+
+  function handleIncreasePlaybackTempo() {
+    if (!canUseTempo) {
+      return;
+    }
+    setTempoTargetBpm((current) =>
+      tempoTargetBpmFromStep({
+        currentTargetBpm: current,
+        delta: 1,
+        originalBpm: tempoOriginalBpm,
+      }),
+    );
+  }
+
+  function handleResetPlaybackTempo() {
+    setTempoTargetBpm(null);
+  }
+
   function handleSeekTo(timeSeconds: number) {
     seekTo(timeSeconds);
   }
@@ -1171,6 +1213,7 @@ export function useProjectViewModel() {
     setCapoTransposeSemitones(storedPlaybackState.capoTransposeSemitones);
     setPrecountEnabled(storedPlaybackState.precountEnabled);
     setPrecountClickCount(storedPlaybackState.precountClickCount);
+    setTempoTargetBpm(storedPlaybackState.tempoTargetBpm);
     setPlaybackDisplayModeSource(hasStoredPlayback ? "stored" : "default");
     setLyricsFollowEnabled(
       hasStoredPlayback
@@ -1313,6 +1356,7 @@ export function useProjectViewModel() {
       capoTransposeSemitones: capoSemitones,
       precountEnabled,
       precountClickCount,
+      tempoTargetBpm,
       lyricsFollowEnabled,
       chordsFollowEnabled,
       stemControls,
@@ -1334,6 +1378,7 @@ export function useProjectViewModel() {
     selectedPrimaryArtifactId,
     selectedStemSourceArtifactId,
     stemControls,
+    tempoTargetBpm,
   ]);
 
   useEffect(() => {
@@ -1549,6 +1594,8 @@ export function useProjectViewModel() {
       precountEnabled,
       precountClickCount,
       precountTempoBpm,
+      tempoOriginalBpm,
+      tempoTargetBpm: tempoTargetBpmForPlayback,
     });
   }, [
     hydratedProjectId,
@@ -1564,6 +1611,8 @@ export function useProjectViewModel() {
     stageSummary,
     stageTitle,
     stemControls,
+    tempoOriginalBpm,
+    tempoTargetBpmForPlayback,
     visibleStemArtifacts,
   ]);
 
@@ -1583,6 +1632,7 @@ export function useProjectViewModel() {
     canGenerateChords,
     canGenerateLyrics,
     canGenerateStems,
+    canUseTempo,
     capoKey,
     capoOptionRefs,
     capoSelectionSummary,
@@ -1616,6 +1666,7 @@ export function useProjectViewModel() {
     handleDeleteMix,
     handleDeleteProject,
     handleChordAction,
+    handleDecreasePlaybackTempo,
     handleLyricsAction,
     handleSeek,
     handleSeekTo,
@@ -1627,12 +1678,14 @@ export function useProjectViewModel() {
     handleSetLyricsFollowEnabled,
     handleSetPrecountClickCount,
     handleSetPrecountEnabled,
+    handleIncreasePlaybackTempo,
     handleAcceptTabSuggestionGroup,
     handleApplyTabSuggestions,
     handleCloseTabImport,
     handleCreateTabImportProposal,
     handleOpenTabImport,
     handleRejectTabSuggestionGroup,
+    handleResetPlaybackTempo,
     handleSetPlaybackDisplayMode,
     handleStemAction,
     handleTogglePlaybackDisplayLane,
@@ -1749,6 +1802,12 @@ export function useProjectViewModel() {
     targetSelectorOpen,
     targetSelectorRef,
     targetShiftSummary,
+    tempoDisplayBpm,
+    tempoMaxBpm: MAX_PLAYBACK_TEMPO_BPM,
+    tempoMinBpm: MIN_PLAYBACK_TEMPO_BPM,
+    tempoOriginalBpm,
+    tempoPlaybackRate: tempoPlaybackRateValue,
+    tempoTargetBpm: tempoTargetBpmForPlayback,
     togglePlayback: handleTogglePlayback,
     toggleStemControl,
     transposeSemitones,

--- a/apps/desktop/src/features/projects/playback-context.ts
+++ b/apps/desktop/src/features/projects/playback-context.ts
@@ -14,6 +14,8 @@ export type ProjectPlaybackSession = {
   precountEnabled: boolean;
   precountClickCount: number;
   precountTempoBpm: number | null;
+  tempoOriginalBpm: number | null;
+  tempoTargetBpm: number | null;
 };
 
 export type PlaybackSnapshot = {

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -23,9 +23,12 @@ import {
   PRIMARY_MEDIA_KEY,
   SEEK_TOLERANCE_SECONDS,
   clampTime,
+  playbackRateForSession,
   playbackSignature,
+  playbackTargetSignature,
   type PendingTransition,
   type StemPlaybackState,
+  usesDefaultPlaybackRate,
 } from "./playbackUtils";
 import {
   clearStemClock as clearStemClockFrame,
@@ -48,6 +51,20 @@ type ActivePrecount = {
   timeoutId: number;
 };
 
+type PitchPreservingAudioElement = HTMLAudioElement & {
+  mozPreservesPitch?: boolean;
+  preservesPitch?: boolean;
+  webkitPreservesPitch?: boolean;
+};
+
+function applyMediaElementPlaybackRate(element: HTMLAudioElement, playbackRate: number) {
+  const pitchPreservingElement = element as PitchPreservingAudioElement;
+  pitchPreservingElement.preservesPitch = true;
+  pitchPreservingElement.mozPreservesPitch = true;
+  pitchPreservingElement.webkitPreservesPitch = true;
+  element.playbackRate = playbackRate;
+}
+
 export function PlaybackProvider({ children }: { children: ReactNode }) {
   const restoredPlaybackState = useRef(readPersistedPlaybackState()).current;
   const primaryAudioRef = useRef<HTMLAudioElement | null>(null);
@@ -66,6 +83,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           signature: playbackSignature(restoredPlaybackState.session),
           shouldPlay: restoredPlaybackState.isPlaying,
           targetTime: restoredPlaybackState.playbackTimeSeconds,
+          awaitSeekBeforePlay: true,
           awaitingLoadKeys: [],
           awaitingSeekKeys: [],
           forceSeekKeys: [],
@@ -120,9 +138,17 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     });
   }, [isPlaying, playbackTimeSeconds, session]);
 
+  function setPrimaryAudioRef(element: HTMLAudioElement | null) {
+    primaryAudioRef.current = element;
+    if (element) {
+      applyMediaElementPlaybackRate(element, playbackRateForSession(sessionRef.current));
+    }
+  }
+
   function setStemAudioRef(artifactId: string, element: HTMLAudioElement | null) {
     if (element) {
       stemAudioRefs.current[artifactId] = element;
+      applyMediaElementPlaybackRate(element, playbackRateForSession(sessionRef.current));
       return;
     }
     delete stemAudioRefs.current[artifactId];
@@ -169,7 +195,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
   const canUseBufferedClock = useCallback(
     (targetSession: ProjectPlaybackSession | null) => {
-      if (!targetSession || !canUseStemClock()) {
+      if (!targetSession || !canUseStemClock() || !usesDefaultPlaybackRate(targetSession)) {
         return false;
       }
 
@@ -610,6 +636,15 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       : [];
   });
 
+  const applyMediaPlaybackRate = useStableCallback(function applyMediaPlaybackRate(
+    targetSession: ProjectPlaybackSession | null = sessionRef.current,
+  ) {
+    const playbackRate = playbackRateForSession(targetSession);
+    getRenderedMediaElements(targetSession).forEach((element) => {
+      applyMediaElementPlaybackRate(element, playbackRate);
+    });
+  });
+
   const applyStemVolumes = useStableCallback(function applyStemVolumes(
     targetSession: ProjectPlaybackSession | null = sessionRef.current,
   ) {
@@ -861,6 +896,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
             element.currentTime = nextTime;
           }
         });
+        applyMediaPlaybackRate(latestSession);
 
         const results = await Promise.allSettled(
           fallbackElements.map((element) => Promise.resolve(element.play())),
@@ -876,10 +912,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       return;
     }
 
-    const minimumReadyState =
-      pendingTransition.shouldPlay && targetSession.isStemPlayback
-        ? HTMLMediaElement.HAVE_FUTURE_DATA
-        : HTMLMediaElement.HAVE_METADATA;
+    const minimumReadyState = HTMLMediaElement.HAVE_METADATA;
     const ready = targetElements.every((element) => {
       if (element.readyState >= minimumReadyState) {
         return true;
@@ -920,19 +953,23 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       const shouldForceSeek = forceSeekKeys.includes(mediaKey);
       if (shouldForceSeek) {
         element.currentTime = nextTime;
-        if (!awaitingSeekKeys.includes(mediaKey)) {
+        if (pendingTransition.awaitSeekBeforePlay && !awaitingSeekKeys.includes(mediaKey)) {
           awaitingSeekKeys.push(mediaKey);
         }
         return;
       }
       if (Math.abs(element.currentTime - nextTime) > SEEK_TOLERANCE_SECONDS) {
         element.currentTime = nextTime;
-        if (!awaitingSeekKeys.includes(mediaKey)) {
+        if (pendingTransition.awaitSeekBeforePlay && !awaitingSeekKeys.includes(mediaKey)) {
           awaitingSeekKeys.push(mediaKey);
         }
         return;
       }
-      if (element.seeking && !awaitingSeekKeys.includes(mediaKey)) {
+      if (
+        pendingTransition.awaitSeekBeforePlay &&
+        element.seeking &&
+        !awaitingSeekKeys.includes(mediaKey)
+      ) {
         awaitingSeekKeys.push(mediaKey);
       }
     });
@@ -958,6 +995,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       return;
     }
 
+    applyMediaPlaybackRate(targetSession);
     void Promise.allSettled(
       targetElements.map((element) => Promise.resolve(element.play())),
     ).then((results) => {
@@ -1040,6 +1078,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       }
     });
     applyStemVolumes(targetSession);
+    applyMediaPlaybackRate(targetSession);
 
     const results = await Promise.allSettled(
       activeElements.map((element) => Promise.resolve(element.play())),
@@ -1297,15 +1336,36 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       cancelPrecount();
       const nextTime = readMasterTime(previousSession);
       const shouldPlay = isPlayingRef.current;
+      const samePlaybackTarget =
+        playbackTargetSignature(previousSession) === playbackTargetSignature(nextSession);
+      const previousUsesBufferedClock = canUseBufferedClock(previousSession);
+      const nextUsesBufferedClock = canUseBufferedClock(nextSession);
+      if (samePlaybackTarget && !previousUsesBufferedClock && !nextUsesBufferedClock) {
+        const pendingTransition = pendingTransitionRef.current;
+        if (
+          pendingTransition &&
+          playbackTargetSignature(previousSession) === playbackTargetSignature(nextSession)
+        ) {
+          pendingTransition.signature = nextSignature;
+          pendingTransition.shouldPlay = pendingTransition.shouldPlay || shouldPlay;
+        }
+        applyMediaPlaybackRate(nextSession);
+        sessionRef.current = nextSession;
+        setSession(nextSession);
+        return;
+      }
       const primarySwap =
-        !previousSession.isStemPlayback && !nextSession.isStemPlayback;
+        !samePlaybackTarget && !previousSession.isStemPlayback && !nextSession.isStemPlayback;
       const awaitingLoadKeys = primarySwap ? [PRIMARY_MEDIA_KEY] : [];
       const awaitingSeekKeys =
         primarySwap
           ? [PRIMARY_MEDIA_KEY]
           : [];
       const forceSeekKeys = primarySwap ? [PRIMARY_MEDIA_KEY] : [];
-      if (shouldPlay) {
+      if (
+        shouldPlay &&
+        (!samePlaybackTarget || previousUsesBufferedClock || nextUsesBufferedClock)
+      ) {
         getActiveMediaElements(previousSession).forEach((element) => element.pause());
       }
       disposeStemPlaybackState();
@@ -1314,6 +1374,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         signature: nextSignature,
         shouldPlay,
         targetTime: nextTime,
+        awaitSeekBeforePlay: !samePlaybackTarget,
         awaitingLoadKeys,
         awaitingSeekKeys,
         forceSeekKeys,
@@ -1329,6 +1390,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     setSession(nextSession);
   }, [
     cancelPrecount,
+    applyMediaPlaybackRate,
+    canUseBufferedClock,
     clearPendingTransition,
     closePlaybackAudioContext,
     disposeStemPlaybackState,
@@ -1338,10 +1401,17 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   ]);
 
   useEffect(() => {
+    applyMediaPlaybackRate(session);
     applyStemVolumes(session);
     tryCompletePendingTransition();
     updateDurationFromActiveMedia(session);
-  }, [applyStemVolumes, session, tryCompletePendingTransition, updateDurationFromActiveMedia]);
+  }, [
+    applyMediaPlaybackRate,
+    applyStemVolumes,
+    session,
+    tryCompletePendingTransition,
+    updateDurationFromActiveMedia,
+  ]);
 
   useEffect(() => {
     if (!session?.visibleStemArtifactIds.length || !canUseStemClock()) {
@@ -1365,6 +1435,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     isPlaying,
     pausePlayback,
     playbackDurationSeconds,
+    playbackRate: playbackRateForSession(session),
     playbackTimeSeconds,
     playPlayback,
     seekBy,
@@ -1419,7 +1490,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
             ? session.selectedPlaybackArtifactId ?? "__none__"
             : "__none__"
         }
-        ref={primaryAudioRef}
+        ref={setPrimaryAudioRef}
         src={
           session && !session.isStemPlayback && session.selectedPlaybackArtifactId
             ? api.streamArtifactUrl(session.selectedPlaybackArtifactId)
@@ -1434,6 +1505,12 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           setPlaybackTimeSeconds(event.currentTarget.currentTime);
         }}
         onLoadedMetadata={() => {
+          if (primaryAudioRef.current) {
+            applyMediaElementPlaybackRate(
+              primaryAudioRef.current,
+              playbackRateForSession(sessionRef.current),
+            );
+          }
           markPendingLoadComplete(PRIMARY_MEDIA_KEY);
           updateDurationFromActiveMedia();
           tryCompletePendingTransition();
@@ -1471,6 +1548,13 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
             setPlaybackTimeSeconds(event.currentTarget.currentTime);
           }}
           onLoadedMetadata={() => {
+            const element = stemAudioRefs.current[artifactId];
+            if (element) {
+              applyMediaElementPlaybackRate(
+                element,
+                playbackRateForSession(sessionRef.current),
+              );
+            }
             if (sessionRef.current?.visibleStemArtifactIds[0] === artifactId) {
               updateDurationFromActiveMedia();
             }

--- a/apps/desktop/src/features/projects/playbackEffects.ts
+++ b/apps/desktop/src/features/projects/playbackEffects.ts
@@ -6,6 +6,7 @@ type MediaSessionControls = {
   isPlaying: boolean;
   pausePlayback: () => void;
   playbackDurationSeconds: number;
+  playbackRate: number;
   playbackTimeSeconds: number;
   playPlayback: () => Promise<void>;
   seekBy: (secondsDelta: number) => void;
@@ -17,6 +18,7 @@ export function useMediaSessionControls({
   isPlaying,
   pausePlayback,
   playbackDurationSeconds,
+  playbackRate,
   playbackTimeSeconds,
   playPlayback,
   seekBy,
@@ -77,7 +79,7 @@ export function useMediaSessionControls({
       ) {
         navigator.mediaSession.setPositionState({
           duration: playbackDurationSeconds,
-          playbackRate: 1,
+          playbackRate,
           position: clampTime(playbackTimeSeconds, playbackDurationSeconds),
         });
       }
@@ -102,6 +104,7 @@ export function useMediaSessionControls({
     isPlaying,
     pausePlayback,
     playbackDurationSeconds,
+    playbackRate,
     playbackTimeSeconds,
     playPlayback,
     seekBy,

--- a/apps/desktop/src/features/projects/playbackPersistence.ts
+++ b/apps/desktop/src/features/projects/playbackPersistence.ts
@@ -1,6 +1,7 @@
 import type {
   ProjectPlaybackSession,
 } from "./playback-context";
+import { normalizeTempoBpm, normalizeTempoTargetBpm } from "./playbackTempo";
 import { normalizePrecountClickCount, type StemControlState } from "./projectPlaybackState";
 
 export type PersistedPlaybackState = {
@@ -79,6 +80,8 @@ function normalizeProjectPlaybackSession(value: unknown): ProjectPlaybackSession
       candidate.precountTempoBpm > 0
         ? candidate.precountTempoBpm
         : null,
+    tempoOriginalBpm: normalizeTempoBpm(candidate.tempoOriginalBpm),
+    tempoTargetBpm: normalizeTempoTargetBpm(candidate.tempoTargetBpm),
   };
 }
 

--- a/apps/desktop/src/features/projects/playbackTempo.ts
+++ b/apps/desktop/src/features/projects/playbackTempo.ts
@@ -1,0 +1,54 @@
+export const MIN_PLAYBACK_TEMPO_BPM = 30;
+export const MAX_PLAYBACK_TEMPO_BPM = 240;
+export const DEFAULT_PLAYBACK_RATE = 1;
+export const PLAYBACK_RATE_TOLERANCE = 0.0001;
+
+export function normalizeTempoBpm(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+  return value;
+}
+
+export function normalizeTempoTargetBpm(value: unknown): number | null {
+  const normalizedValue = normalizeTempoBpm(value);
+  return normalizedValue === null ? null : Math.round(normalizedValue);
+}
+
+export function tempoTargetBpmFromStep({
+  currentTargetBpm,
+  delta,
+  originalBpm,
+}: {
+  currentTargetBpm: number | null;
+  delta: -1 | 1;
+  originalBpm: number | null;
+}) {
+  if (currentTargetBpm !== null) {
+    return normalizeTempoTargetBpm(currentTargetBpm + delta);
+  }
+  if (originalBpm === null) {
+    return null;
+  }
+  if (Number.isInteger(originalBpm)) {
+    return normalizeTempoTargetBpm(originalBpm + delta);
+  }
+  return normalizeTempoTargetBpm(delta > 0 ? Math.ceil(originalBpm) : Math.floor(originalBpm));
+}
+
+export function tempoPlaybackRate({
+  originalBpm,
+  targetBpm,
+}: {
+  originalBpm: number | null;
+  targetBpm: number | null;
+}) {
+  if (originalBpm === null || targetBpm === null) {
+    return DEFAULT_PLAYBACK_RATE;
+  }
+  return targetBpm / originalBpm;
+}
+
+export function isDefaultPlaybackRate(playbackRate: number) {
+  return Math.abs(playbackRate - DEFAULT_PLAYBACK_RATE) <= PLAYBACK_RATE_TOLERANCE;
+}

--- a/apps/desktop/src/features/projects/playbackUtils.ts
+++ b/apps/desktop/src/features/projects/playbackUtils.ts
@@ -1,10 +1,15 @@
 import type { ProjectPlaybackSession } from "./playback-context";
+import {
+  isDefaultPlaybackRate,
+  tempoPlaybackRate,
+} from "./playbackTempo";
 
 export type PendingTransition = {
   id: number;
   signature: string;
   shouldPlay: boolean;
   targetTime: number;
+  awaitSeekBeforePlay: boolean;
   awaitingLoadKeys: string[];
   awaitingSeekKeys: string[];
   forceSeekKeys: string[];
@@ -32,10 +37,33 @@ export function playbackSignature(session: ProjectPlaybackSession | null) {
     return "none";
   }
 
+  const playbackRate = playbackRateForSession(session).toFixed(6);
+  return `${playbackTargetSignature(session)}:rate:${playbackRate}`;
+}
+
+export function playbackTargetSignature(session: ProjectPlaybackSession | null) {
+  if (!session) {
+    return "none";
+  }
+
   const activeSignature = session.isStemPlayback
     ? `stems:${session.visibleStemArtifactIds.join(",")}`
     : `primary:${session.selectedPlaybackArtifactId ?? "none"}`;
   return `${session.projectId}:${activeSignature}`;
+}
+
+export function playbackRateForSession(session: ProjectPlaybackSession | null) {
+  if (!session) {
+    return 1;
+  }
+  return tempoPlaybackRate({
+    originalBpm: session.tempoOriginalBpm,
+    targetBpm: session.tempoTargetBpm,
+  });
+}
+
+export function usesDefaultPlaybackRate(session: ProjectPlaybackSession | null) {
+  return isDefaultPlaybackRate(playbackRateForSession(session));
 }
 
 export function isInteractiveTarget(target: EventTarget | null) {

--- a/apps/desktop/src/features/projects/projectPlaybackState.ts
+++ b/apps/desktop/src/features/projects/projectPlaybackState.ts
@@ -4,6 +4,7 @@ import {
   type PlaybackDisplayMode,
   type ProjectWorkspaceMode,
 } from "../../lib/preferences";
+import { normalizeTempoTargetBpm } from "./playbackTempo";
 
 export type ProjectPanelMode = "studio" | "analysis";
 
@@ -26,6 +27,7 @@ export type StoredProjectPlaybackState = {
   capoTransposeSemitones: number;
   precountEnabled: boolean;
   precountClickCount: number;
+  tempoTargetBpm: number | null;
   lyricsFollowEnabled: boolean;
   chordsFollowEnabled: boolean;
   stemControls: Record<string, StemControlState>;
@@ -44,6 +46,7 @@ const DEFAULT_STORED_PROJECT_PLAYBACK_STATE: StoredProjectPlaybackState = {
   capoTransposeSemitones: 0,
   precountEnabled: false,
   precountClickCount: DEFAULT_PRECOUNT_CLICK_COUNT,
+  tempoTargetBpm: null,
   lyricsFollowEnabled: true,
   chordsFollowEnabled: true,
   stemControls: {},
@@ -129,6 +132,7 @@ function normalizeStoredProjectPlaybackState(value: unknown): StoredProjectPlayb
         ? candidate.precountEnabled
         : DEFAULT_STORED_PROJECT_PLAYBACK_STATE.precountEnabled,
     precountClickCount: normalizePrecountClickCount(candidate.precountClickCount),
+    tempoTargetBpm: normalizeTempoTargetBpm(candidate.tempoTargetBpm),
     lyricsFollowEnabled:
       typeof candidate.lyricsFollowEnabled === "boolean"
         ? candidate.lyricsFollowEnabled

--- a/apps/desktop/src/styles/project-playback.css
+++ b/apps/desktop/src/styles/project-playback.css
@@ -135,7 +135,7 @@
 
 .transport {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-columns: auto auto minmax(0, 1fr);
   gap: 1rem;
   align-items: end;
 }
@@ -308,6 +308,44 @@
 
 .transport__button--stop:active .transport__stop-block {
   transform: scale(0.84);
+}
+
+.transport__tempo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  min-width: 7.3rem;
+  min-height: 3rem;
+  padding: 0.45rem 0.7rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--panel-strong) 74%, transparent);
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.transport__tempo span {
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.transport__tempo strong {
+  color: var(--text);
+  font-size: 0.88rem;
+  white-space: nowrap;
+}
+
+.transport__tempo--active {
+  border-color: color-mix(in srgb, var(--playback-accent) 50%, var(--divider));
+  background: color-mix(in srgb, var(--playback-accent) 14%, var(--panel-strong));
+  color: var(--playback-accent);
+}
+
+.transport__tempo:disabled {
+  cursor: default;
+  opacity: 0.72;
 }
 
 .transport__scrubber {
@@ -839,6 +877,76 @@
 }
 
 .playback-precount-control__summary {
+  margin: 0;
+}
+
+.playback-tempo-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  padding: 0.8rem;
+  border: 1px solid var(--divider);
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--surface-muted) 74%, transparent);
+}
+
+.playback-tempo-control--disabled {
+  opacity: 0.72;
+}
+
+.playback-tempo-control__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.playback-tempo-control__header h3 {
+  margin: 0.15rem 0 0;
+  font-size: 1rem;
+}
+
+.playback-tempo-control__stepper {
+  display: grid;
+  grid-template-columns: 2.6rem minmax(0, 1fr) 2.6rem;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.playback-tempo-control__stepper button,
+.playback-tempo-control__stepper strong {
+  display: inline-grid;
+  min-height: 2.8rem;
+  place-items: center;
+  border-radius: 12px;
+}
+
+.playback-tempo-control__stepper button {
+  border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+  background: color-mix(in srgb, var(--panel) 68%, var(--panel-strong) 32%);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 1.35rem;
+}
+
+.playback-tempo-control__stepper button:disabled {
+  cursor: not-allowed;
+  opacity: 0.56;
+}
+
+.playback-tempo-control__stepper strong {
+  gap: 0.1rem;
+  background: color-mix(in srgb, var(--panel-strong) 76%, transparent);
+  font-size: 1.25rem;
+}
+
+.playback-tempo-control__stepper strong span {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.playback-tempo-control__summary {
   margin: 0;
 }
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -118,6 +118,7 @@ Capo-relative display is a harmonic presentation feature. It should not alter au
 
 - Persist per-project playback session state.
 - Support source playback, saved mixes, and stem playback.
+- Support playback-level tempo changes by BPM without rendering new audio files.
 - Support lyrics-only, chords-only, and combined practice displays.
 - Future practice work should build from beat/bar artifacts: current bar/beat highlight, count-in, loop-by-bars, and section practice.
 


### PR DESCRIPTION
## Summary

- Add BPM-step playback tempo controls with reset to original analyzed tempo.
- Keep original tempo on the buffered Web Audio path and apply adjusted rates on existing media streams.
- Preserve source, practice mix, and stem switching while active tempo changes update in place.

## Testing

- `pnpm --filter @tuneforge/desktop test`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
- `git diff --check`
