### PR TITLE
fix: allow packaged tempo playback streams

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -15,7 +15,7 @@
         "enable": true,
         "scope": ["$APPDATA/**"]
       },
-      "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:*; img-src 'self' data: blob: asset: http://asset.localhost; media-src 'self' blob: asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; script-src 'self'"
+      "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:*; img-src 'self' data: blob: asset: http://asset.localhost; media-src 'self' blob: asset: http://asset.localhost http://127.0.0.1:*; style-src 'self' 'unsafe-inline'; script-src 'self'"
     },
     "windows": [
       {


### PR DESCRIPTION
## Summary

- Allow packaged Tauri media CSP to stream tempo-adjusted playback from the loopback backend.
- Fix packaged-app tempo changes falling back to blocked media element playback.

## Testing

- `pnpm package:mac:app`
- Rebuilt packaged app, set project tempo to 113 BPM, and verified play toggles to pause with position advancing via Computer Use.
- `pnpm --filter @tuneforge/desktop lint`
