### PR TITLE
feat: add native audio adapter boundary

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -347,6 +347,7 @@ pub fn run() {
             native_audio::audio_set_lanes,
             native_audio::audio_get_snapshot,
             native_audio::audio_list_input_devices,
+            native_audio::audio_list_output_devices,
             native_audio::audio_start_input,
             native_audio::audio_stop_input,
             native_audio::audio_set_monitor,

--- a/apps/desktop/src-tauri/src/native_audio/capture.rs
+++ b/apps/desktop/src-tauri/src/native_audio/capture.rs
@@ -18,6 +18,22 @@ pub struct AudioInputDevices {
     pub error: Option<String>,
 }
 
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioOutputDevice {
+    pub id: String,
+    pub label: String,
+    pub is_default: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioOutputDevices {
+    pub supported: bool,
+    pub devices: Vec<AudioOutputDevice>,
+    pub error: Option<String>,
+}
+
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AudioInputRequest {
@@ -69,6 +85,22 @@ impl CaptureState {
         }
     }
 
+    pub fn list_output_devices(&self, capabilities: AudioCapabilities) -> AudioOutputDevices {
+        if !capabilities.native_playback_supported {
+            return AudioOutputDevices {
+                supported: false,
+                devices: Vec::new(),
+                error: Some("Native audio output device discovery is not wired yet.".to_string()),
+            };
+        }
+
+        AudioOutputDevices {
+            supported: true,
+            devices: Vec::new(),
+            error: None,
+        }
+    }
+
     pub fn start(&mut self, request: AudioInputRequest) -> Result<AudioInputState, String> {
         self.active = true;
         self.device_id = request.device_id;
@@ -103,4 +135,65 @@ impl CaptureState {
 
 fn normalize_gain(value: Option<f32>) -> f32 {
     value.unwrap_or(0.0).clamp(0.0, 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn capabilities(
+        native_playback_supported: bool,
+        mic_capture_supported: bool,
+    ) -> AudioCapabilities {
+        AudioCapabilities {
+            platform: "test",
+            backend: "test",
+            native_playback_supported,
+            mic_capture_supported,
+            mic_monitoring_supported: false,
+            system_input_volume_supported: false,
+            emits_events: Vec::new(),
+            fallback_required: !native_playback_supported,
+            fallback_reason: None,
+        }
+    }
+
+    #[test]
+    fn list_input_devices_reports_unsupported_when_capture_not_wired() {
+        let state = CaptureState::default();
+
+        let devices = state.list_devices(capabilities(false, false));
+
+        assert!(!devices.supported);
+        assert!(devices.devices.is_empty());
+        assert_eq!(
+            devices.error,
+            Some("Native microphone capture is not wired yet.".to_string())
+        );
+    }
+
+    #[test]
+    fn list_output_devices_reports_unsupported_when_playback_not_wired() {
+        let state = CaptureState::default();
+
+        let devices = state.list_output_devices(capabilities(false, false));
+
+        assert!(!devices.supported);
+        assert!(devices.devices.is_empty());
+        assert_eq!(
+            devices.error,
+            Some("Native audio output device discovery is not wired yet.".to_string())
+        );
+    }
+
+    #[test]
+    fn list_output_devices_returns_empty_supported_skeleton_when_playback_wired() {
+        let state = CaptureState::default();
+
+        let devices = state.list_output_devices(capabilities(true, false));
+
+        assert!(devices.supported);
+        assert!(devices.devices.is_empty());
+        assert_eq!(devices.error, None);
+    }
 }

--- a/apps/desktop/src-tauri/src/native_audio/mod.rs
+++ b/apps/desktop/src-tauri/src/native_audio/mod.rs
@@ -201,6 +201,17 @@ pub fn audio_list_input_devices(
 }
 
 #[tauri::command]
+pub fn audio_list_output_devices(
+    state: State<'_, NativeAudioState>,
+) -> Result<capture::AudioOutputDevices, String> {
+    let capture = state
+        .capture
+        .lock()
+        .map_err(|_| "Native audio capture state is unavailable.".to_string())?;
+    Ok(capture.list_output_devices(state.capabilities()))
+}
+
+#[tauri::command]
 pub fn audio_start_input(
     state: State<'_, NativeAudioState>,
     payload: capture::AudioInputRequest,

--- a/apps/desktop/src/lib/nativeAudio.test.ts
+++ b/apps/desktop/src/lib/nativeAudio.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  NativeAudioCapabilities,
+  NativeAudioDevices,
+  NativeAudioInputState,
+  NativeAudioSnapshot,
+} from "./nativeAudio";
+
+const { mockInvoke } = vi.hoisted(() => ({
+  mockInvoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mockInvoke,
+}));
+
+import {
+  getNativeAudioCapabilities,
+  getNativeAudioSnapshot,
+  listNativeAudioInputDevices,
+  listNativeAudioOutputDevices,
+  pauseNativeAudio,
+  playNativeAudio,
+  prepareNativeAudioSession,
+  seekNativeAudio,
+  setNativeAudioLanes,
+  setNativeAudioMonitor,
+  startNativeAudioInput,
+  stopNativeAudio,
+  stopNativeAudioInput,
+} from "./nativeAudio";
+
+const capabilities: NativeAudioCapabilities = {
+  platform: "macos",
+  backend: "desktop-null",
+  nativePlaybackSupported: false,
+  micCaptureSupported: false,
+  micMonitoringSupported: false,
+  systemInputVolumeSupported: true,
+  emitsEvents: ["audio://state", "audio://devices-changed"],
+  fallbackRequired: true,
+  fallbackReason: "Native audio playback is not wired yet; use existing WebView playback.",
+};
+
+const devices: NativeAudioDevices = {
+  supported: false,
+  devices: [],
+  error: "Native audio output device discovery is not wired yet.",
+};
+
+const snapshot: NativeAudioSnapshot = {
+  sessionId: "session-1",
+  state: "paused",
+  positionSeconds: 12,
+  durationSeconds: 180,
+  playbackRate: 1,
+  nativePlaybackSupported: false,
+  fallbackReason: "Native audio playback is not wired yet; use existing WebView playback.",
+  lanes: [],
+};
+
+const inputState: NativeAudioInputState = {
+  active: true,
+  deviceId: "built-in",
+  monitorEnabled: true,
+  monitorGain: 0.5,
+  inputLevel: 0,
+};
+
+describe("native audio adapter", () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+  });
+
+  it("wraps capability and device discovery commands", async () => {
+    mockInvoke
+      .mockResolvedValueOnce(capabilities)
+      .mockResolvedValueOnce(devices)
+      .mockResolvedValueOnce(devices);
+
+    await expect(getNativeAudioCapabilities()).resolves.toEqual(capabilities);
+    await expect(listNativeAudioInputDevices()).resolves.toEqual(devices);
+    await expect(listNativeAudioOutputDevices()).resolves.toEqual(devices);
+
+    expect(mockInvoke).toHaveBeenNthCalledWith(1, "audio_get_capabilities");
+    expect(mockInvoke).toHaveBeenNthCalledWith(2, "audio_list_input_devices");
+    expect(mockInvoke).toHaveBeenNthCalledWith(3, "audio_list_output_devices");
+  });
+
+  it("sends camelCase session and transport payloads", async () => {
+    const sessionRequest = {
+      sessionId: "session-1",
+      durationSeconds: 180,
+      playbackRate: 1,
+      lanes: [
+        {
+          id: "vocals",
+          artifactId: "artifact-vocals",
+          sourcePath: "/tmp/vocals.wav",
+          role: "stem" as const,
+          gain: 0.75,
+          muted: false,
+          solo: true,
+        },
+      ],
+    };
+    const laneUpdate = { lanes: sessionRequest.lanes };
+    mockInvoke.mockResolvedValue(snapshot);
+
+    await prepareNativeAudioSession(sessionRequest);
+    await playNativeAudio({ startTimeSeconds: 4, scheduledStartTimeSeconds: 10 });
+    await seekNativeAudio({ timeSeconds: 24 });
+    await setNativeAudioLanes(laneUpdate);
+
+    expect(mockInvoke).toHaveBeenNthCalledWith(1, "audio_prepare_session", {
+      payload: sessionRequest,
+    });
+    expect(mockInvoke).toHaveBeenNthCalledWith(2, "audio_play", {
+      payload: { startTimeSeconds: 4, scheduledStartTimeSeconds: 10 },
+    });
+    expect(mockInvoke).toHaveBeenNthCalledWith(3, "audio_seek", {
+      payload: { timeSeconds: 24 },
+    });
+    expect(mockInvoke).toHaveBeenNthCalledWith(4, "audio_set_lanes", {
+      payload: laneUpdate,
+    });
+  });
+
+  it("wraps snapshot and stop-state commands without payloads", async () => {
+    mockInvoke.mockResolvedValue(snapshot);
+
+    await pauseNativeAudio();
+    await stopNativeAudio();
+    await getNativeAudioSnapshot();
+
+    expect(mockInvoke).toHaveBeenNthCalledWith(1, "audio_pause");
+    expect(mockInvoke).toHaveBeenNthCalledWith(2, "audio_stop");
+    expect(mockInvoke).toHaveBeenNthCalledWith(3, "audio_get_snapshot");
+  });
+
+  it("wraps native input and monitor payloads", async () => {
+    mockInvoke.mockResolvedValue(inputState);
+
+    await startNativeAudioInput({
+      deviceId: "built-in",
+      monitorEnabled: true,
+      monitorGain: 0.5,
+    });
+    await setNativeAudioMonitor({ enabled: false, gain: 0 });
+    await stopNativeAudioInput();
+
+    expect(mockInvoke).toHaveBeenNthCalledWith(1, "audio_start_input", {
+      payload: { deviceId: "built-in", monitorEnabled: true, monitorGain: 0.5 },
+    });
+    expect(mockInvoke).toHaveBeenNthCalledWith(2, "audio_set_monitor", {
+      payload: { enabled: false, gain: 0 },
+    });
+    expect(mockInvoke).toHaveBeenNthCalledWith(3, "audio_stop_input");
+  });
+
+  it("leaves invoke errors visible to callers", async () => {
+    mockInvoke.mockRejectedValueOnce(new Error("Native audio unavailable."));
+
+    await expect(listNativeAudioOutputDevices()).rejects.toThrow("Native audio unavailable.");
+  });
+});

--- a/apps/desktop/src/lib/nativeAudio.ts
+++ b/apps/desktop/src/lib/nativeAudio.ts
@@ -1,0 +1,163 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type NativeAudioEventName =
+  | "audio://state"
+  | "audio://position"
+  | "audio://ended"
+  | "audio://error"
+  | "audio://input-level"
+  | "audio://devices-changed";
+
+export type NativeAudioCapabilities = {
+  platform: string;
+  backend: string;
+  nativePlaybackSupported: boolean;
+  micCaptureSupported: boolean;
+  micMonitoringSupported: boolean;
+  systemInputVolumeSupported: boolean;
+  emitsEvents: NativeAudioEventName[];
+  fallbackRequired: boolean;
+  fallbackReason: string | null;
+};
+
+export type NativeAudioDevice = {
+  id: string;
+  label: string;
+  isDefault: boolean;
+};
+
+export type NativeAudioDevices = {
+  supported: boolean;
+  devices: NativeAudioDevice[];
+  error: string | null;
+};
+
+export type NativeAudioLaneRole = "primary" | "stem" | "click" | "mic_monitor";
+
+export type NativeAudioLaneRequest = {
+  id: string;
+  artifactId?: string | null;
+  sourcePath?: string | null;
+  role: NativeAudioLaneRole;
+  gain: number;
+  muted: boolean;
+  solo: boolean;
+};
+
+export type NativeAudioLaneUpdate = {
+  lanes: NativeAudioLaneRequest[];
+};
+
+export type NativeAudioSessionRequest = {
+  sessionId: string;
+  durationSeconds?: number | null;
+  playbackRate?: number | null;
+  lanes: NativeAudioLaneRequest[];
+};
+
+export type NativeAudioSession = {
+  id: string;
+  nativePlaybackSupported: boolean;
+  fallbackReason: string | null;
+  laneCount: number;
+};
+
+export type NativeAudioPlayRequest = {
+  startTimeSeconds?: number | null;
+  scheduledStartTimeSeconds?: number | null;
+};
+
+export type NativeAudioSeekRequest = {
+  timeSeconds: number;
+};
+
+export type NativeAudioLane = {
+  id: string;
+  artifactId: string | null;
+  role: NativeAudioLaneRole;
+  effectiveGain: number;
+  muted: boolean;
+  solo: boolean;
+};
+
+export type NativeAudioSnapshot = {
+  sessionId: string | null;
+  state: "stopped" | "playing" | "paused";
+  positionSeconds: number;
+  durationSeconds: number;
+  playbackRate: number;
+  nativePlaybackSupported: boolean;
+  fallbackReason: string | null;
+  lanes: NativeAudioLane[];
+};
+
+export type NativeAudioInputRequest = {
+  deviceId?: string | null;
+  monitorEnabled?: boolean | null;
+  monitorGain?: number | null;
+};
+
+export type NativeAudioMonitorRequest = {
+  enabled: boolean;
+  gain?: number | null;
+};
+
+export type NativeAudioInputState = {
+  active: boolean;
+  deviceId: string | null;
+  monitorEnabled: boolean;
+  monitorGain: number;
+  inputLevel: number;
+};
+
+export function getNativeAudioCapabilities() {
+  return invoke<NativeAudioCapabilities>("audio_get_capabilities");
+}
+
+export function listNativeAudioInputDevices() {
+  return invoke<NativeAudioDevices>("audio_list_input_devices");
+}
+
+export function listNativeAudioOutputDevices() {
+  return invoke<NativeAudioDevices>("audio_list_output_devices");
+}
+
+export function prepareNativeAudioSession(payload: NativeAudioSessionRequest) {
+  return invoke<NativeAudioSession>("audio_prepare_session", { payload });
+}
+
+export function playNativeAudio(payload: NativeAudioPlayRequest = {}) {
+  return invoke<NativeAudioSnapshot>("audio_play", { payload });
+}
+
+export function pauseNativeAudio() {
+  return invoke<NativeAudioSnapshot>("audio_pause");
+}
+
+export function stopNativeAudio() {
+  return invoke<NativeAudioSnapshot>("audio_stop");
+}
+
+export function seekNativeAudio(payload: NativeAudioSeekRequest) {
+  return invoke<NativeAudioSnapshot>("audio_seek", { payload });
+}
+
+export function setNativeAudioLanes(payload: NativeAudioLaneUpdate) {
+  return invoke<NativeAudioSnapshot>("audio_set_lanes", { payload });
+}
+
+export function getNativeAudioSnapshot() {
+  return invoke<NativeAudioSnapshot>("audio_get_snapshot");
+}
+
+export function startNativeAudioInput(payload: NativeAudioInputRequest = {}) {
+  return invoke<NativeAudioInputState>("audio_start_input", { payload });
+}
+
+export function stopNativeAudioInput() {
+  return invoke<NativeAudioInputState>("audio_stop_input");
+}
+
+export function setNativeAudioMonitor(payload: NativeAudioMonitorRequest) {
+  return invoke<NativeAudioInputState>("audio_set_monitor", { payload });
+}


### PR DESCRIPTION
## Summary

- Add output device discovery skeleton wiring to the native audio Tauri command surface.
- Add typed frontend native audio adapter wrappers without replacing current playback.
- Cover the Rust skeleton and TypeScript adapter boundary with focused tests.

## Testing

- User verified `pnpm dev`
- `pnpm --filter @tuneforge/desktop test --run src/lib/nativeAudio.test.ts`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
- `cd apps/desktop/src-tauri && cargo test`
- `cd apps/desktop/src-tauri && cargo check`
- `cd apps/desktop/src-tauri && cargo fmt --check`
- `git diff --check`
