### PR TITLE
chore: add test action to Codex environments

### DIFF
--- a/.codex/environments/development.toml
+++ b/.codex/environments/development.toml
@@ -28,3 +28,8 @@ name = "Package Mac"
 icon = "tool"
 command = "pnpm package:mac"
 platform = "darwin"
+
+[[actions]]
+name = "Run Tests"
+icon = "test"
+command = "pnpm test"

--- a/.codex/environments/legacy-nvidia.toml
+++ b/.codex/environments/legacy-nvidia.toml
@@ -34,3 +34,8 @@ name = "Default Backend"
 icon = "tool"
 command = "pnpm sync:backend:default"
 platform = "linux"
+
+[[actions]]
+name = "Run Tests"
+icon = "test"
+command = "pnpm test"


### PR DESCRIPTION
## Summary
- Add a Run Tests action to the development Codex environment.
- Add the same test action to the legacy NVIDIA Codex environment.
- Point both actions at `pnpm test` so Codex environments run the full workspace suite.

## Testing
- `python3 -c "import pathlib,tomllib; [tomllib.loads(p.read_text()) for p in [pathlib.Path('.codex/environments/development.toml'), pathlib.Path('.codex/environments/legacy-nvidia.toml')]]; print('toml ok')"`
- `git diff --cached --check`
