### PR TITLE
feat: Add native tuner mic capture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
+            libasound2-dev \
             libwebkit2gtk-4.1-dev \
             libgtk-3-dev \
             libayatana-appindicator3-dev \

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ pnpm dev
 
 The backend serves the local API on `http://127.0.0.1:8765/api/v1`.
 
+Native audio notes and the Web Audio fallback override are in [docs/NATIVE_AUDIO.md](docs/NATIVE_AUDIO.md).
+
 ## Configuration
 
 Backend behavior is environment-driven. Full table is in [apps/backend/README.md](apps/backend/README.md#configuration). The most relevant variables:

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -70,6 +70,12 @@ This document is an engineering notice and distribution checklist, not legal adv
 - **Source:** <https://github.com/tauri-apps/tauri>
 - **Notes:** The Rust crate inventory is primarily MIT / Apache-2.0 / BSD / ISC / Zlib family. It also includes MPL-2.0 and Unicode-3.0 notice obligations. Crates with LGPL-2.1-or-later as one license option, such as `r-efi`, also provide MIT or Apache-2.0 alternatives in the resolved metadata.
 
+### cpal
+
+- **License:** Apache-2.0 / MIT (dual)
+- **Source:** <https://github.com/RustAudio/cpal>
+- **Notes:** Used by the desktop shell for local microphone device enumeration and tuner input capture.
+
 ### rusqlite / SQLite
 
 - **License:** MIT for rusqlite; SQLite is public domain

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -33,6 +33,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.11.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +306,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -430,6 +454,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation-sys",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-sys"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
+name = "cpal"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+dependencies = [
+ "alsa",
+ "core-foundation-sys",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk 0.8.0",
+ "ndk-context",
+ "oboe",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.54.0",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +628,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "dbus"
@@ -1757,6 +1830,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1926,6 +2009,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2038,6 +2130,20 @@ dependencies = [
 
 [[package]]
 name = "ndk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+dependencies = [
+ "bitflags 2.11.1",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
@@ -2045,10 +2151,25 @@ dependencies = [
  "bitflags 2.11.1",
  "jni-sys 0.3.1",
  "log",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -2087,6 +2208,17 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-traits"
@@ -2313,6 +2445,29 @@ dependencies = [
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "oboe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+dependencies = [
+ "jni",
+ "ndk 0.8.0",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3362,7 +3517,7 @@ checksum = "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3"
 dependencies = [
  "bytemuck",
  "js-sys",
- "ndk",
+ "ndk 0.9.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -3562,8 +3717,8 @@ dependencies = [
  "jni",
  "libc",
  "log",
- "ndk",
- "ndk-sys",
+ "ndk 0.9.0",
+ "ndk-sys 0.6.0+11769913",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
@@ -3575,7 +3730,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -3647,7 +3802,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3793,7 +3948,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3818,7 +3973,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -3855,7 +4010,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -4220,7 +4375,8 @@ version = "0.1.0"
 dependencies = [
  "android_system_properties",
  "chrono",
- "ndk-sys",
+ "cpal",
+ "ndk-sys 0.6.0+11769913",
  "rusqlite",
  "serde",
  "serde_json",
@@ -4615,7 +4771,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -4639,7 +4795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -4713,6 +4869,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -4731,6 +4897,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4812,6 +4988,15 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5244,7 +5429,7 @@ dependencies = [
  "javascriptcore-rs",
  "jni",
  "libc",
- "ndk",
+ "ndk 0.9.0",
  "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
@@ -5262,7 +5447,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -23,6 +23,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4.44", features = ["serde"] }
 
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+cpal = "0.15.3"
+
 [target.'cfg(target_os = "linux")'.dependencies]
 webkit2gtk = "2.0.2"
 

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -3,5 +3,11 @@
   "identifier": "default",
   "description": "Default desktop capabilities for Tuneforge.",
   "windows": ["main"],
-  "permissions": ["dialog:allow-open", "dialog:allow-save", "dialog:allow-message"]
+  "permissions": [
+    "core:event:allow-listen",
+    "core:event:allow-unlisten",
+    "dialog:allow-open",
+    "dialog:allow-save",
+    "dialog:allow-message"
+  ]
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -348,6 +348,7 @@ pub fn run() {
             native_audio::audio_get_snapshot,
             native_audio::audio_list_input_devices,
             native_audio::audio_list_output_devices,
+            native_audio::audio_get_input_state,
             native_audio::audio_start_input,
             native_audio::audio_stop_input,
             native_audio::audio_set_monitor,

--- a/apps/desktop/src-tauri/src/native_audio/capture.rs
+++ b/apps/desktop/src-tauri/src/native_audio/capture.rs
@@ -1,6 +1,20 @@
 use serde::{Deserialize, Serialize};
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tauri::AppHandle;
 
-use super::AudioCapabilities;
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use tauri::Emitter;
+
+use super::{AudioCapabilities, AUDIO_EVENT_INPUT_FRAME};
+
+const DEFAULT_INPUT_DEVICE_ID: &str = "default";
+const INPUT_FRAME_SAMPLES: usize = 2048;
+const INPUT_FRAME_HOP_SAMPLES: usize = 1024;
+const INPUT_FRAME_EVENT_INTERVAL: Duration = Duration::from_millis(30);
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -57,15 +71,71 @@ pub struct AudioInputState {
     pub monitor_enabled: bool,
     pub monitor_gain: f32,
     pub input_level: f32,
+    pub sample_rate: Option<u32>,
 }
 
-#[derive(Default)]
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioInputFrame {
+    pub device_id: Option<String>,
+    pub sample_rate: u32,
+    pub input_level: f32,
+    pub samples: Vec<f32>,
+    pub timestamp_ms: u64,
+}
+
 pub struct CaptureState {
     active: bool,
     device_id: Option<String>,
     monitor_enabled: bool,
     monitor_gain: f32,
     input_level: f32,
+    sample_rate: Option<u32>,
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    runtime: Option<CaptureRuntime>,
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+struct CaptureRuntime {
+    stop_sender: mpsc::Sender<CaptureControl>,
+    shared: Arc<Mutex<CaptureSharedState>>,
+    worker_thread: Option<JoinHandle<()>>,
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+struct CaptureRuntime;
+
+#[derive(Default)]
+struct CaptureSharedState {
+    input_level: f32,
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+enum CaptureControl {
+    Stop,
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+struct CaptureStreamStartup {
+    effective_device_id: String,
+    sample_rate: u32,
+    stream: cpal::Stream,
+    frame_receiver: mpsc::Receiver<AudioInputFrame>,
+}
+
+impl Default for CaptureState {
+    fn default() -> Self {
+        Self {
+            active: false,
+            device_id: None,
+            monitor_enabled: false,
+            monitor_gain: 0.0,
+            input_level: 0.0,
+            sample_rate: None,
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            runtime: None,
+        }
+    }
 }
 
 impl CaptureState {
@@ -78,10 +148,17 @@ impl CaptureState {
             };
         }
 
-        AudioInputDevices {
-            supported: true,
-            devices: Vec::new(),
-            error: None,
+        match list_desktop_input_devices() {
+            Ok(devices) => AudioInputDevices {
+                supported: true,
+                devices,
+                error: None,
+            },
+            Err(error) => AudioInputDevices {
+                supported: false,
+                devices: Vec::new(),
+                error: Some(error),
+            },
         }
     }
 
@@ -101,18 +178,32 @@ impl CaptureState {
         }
     }
 
-    pub fn start(&mut self, request: AudioInputRequest) -> Result<AudioInputState, String> {
-        self.active = true;
-        self.device_id = request.device_id;
+    pub fn start(
+        &mut self,
+        app: AppHandle,
+        request: AudioInputRequest,
+    ) -> Result<AudioInputState, String> {
+        self.stop_runtime();
         self.monitor_enabled = request.monitor_enabled.unwrap_or(false);
         self.monitor_gain = normalize_gain(request.monitor_gain);
         self.input_level = 0.0;
+
+        let (device_id, sample_rate, runtime) = start_desktop_input(app, request.device_id)?;
+        self.active = true;
+        self.device_id = Some(device_id);
+        self.sample_rate = Some(sample_rate);
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        {
+            self.runtime = Some(runtime);
+        }
         Ok(self.state())
     }
 
     pub fn stop(&mut self) -> AudioInputState {
+        self.stop_runtime();
         self.active = false;
         self.input_level = 0.0;
+        self.sample_rate = None;
         self.state()
     }
 
@@ -122,19 +213,515 @@ impl CaptureState {
         self.state()
     }
 
-    fn state(&self) -> AudioInputState {
+    pub fn state(&self) -> AudioInputState {
         AudioInputState {
             active: self.active,
             device_id: self.device_id.clone(),
             monitor_enabled: self.monitor_enabled,
             monitor_gain: self.monitor_gain,
-            input_level: self.input_level,
+            input_level: self.current_input_level(),
+            sample_rate: self.sample_rate,
         }
+    }
+
+    fn current_input_level(&self) -> f32 {
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        if let Some(runtime) = &self.runtime {
+            if let Ok(shared) = runtime.shared.lock() {
+                return shared.input_level;
+            }
+        }
+
+        self.input_level
+    }
+
+    fn stop_runtime(&mut self) {
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        if let Some(mut runtime) = self.runtime.take() {
+            let _ = runtime.stop_sender.send(CaptureControl::Stop);
+            if let Some(worker_thread) = runtime.worker_thread.take() {
+                let _ = worker_thread.join();
+            }
+        }
+    }
+}
+
+impl Drop for CaptureState {
+    fn drop(&mut self) {
+        self.stop_runtime();
     }
 }
 
 fn normalize_gain(value: Option<f32>) -> f32 {
     value.unwrap_or(0.0).clamp(0.0, 1.0)
+}
+
+fn calculate_input_level(samples: &[f32]) -> f32 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let sum_squares = samples.iter().map(|sample| sample * sample).sum::<f32>();
+    (sum_squares / samples.len() as f32).sqrt().clamp(0.0, 1.0)
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn list_desktop_input_devices() -> Result<Vec<AudioInputDevice>, String> {
+    let host = cpal::default_host();
+    let default_name = host
+        .default_input_device()
+        .and_then(|device| device.name().ok());
+    let devices = host
+        .input_devices()
+        .map_err(|error| format!("Could not list native input devices: {error}"))?;
+    let mut marked_default = false;
+
+    Ok(devices
+        .enumerate()
+        .map(|(index, device)| {
+            let label = device
+                .name()
+                .unwrap_or_else(|_| format!("Input Device {}", index + 1));
+            let is_default = !marked_default && default_name.as_deref() == Some(label.as_str());
+            if is_default {
+                marked_default = true;
+            }
+            AudioInputDevice {
+                id: native_input_device_id(index, &label),
+                label,
+                is_default,
+            }
+        })
+        .collect())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn list_desktop_input_devices() -> Result<Vec<AudioInputDevice>, String> {
+    Err("Native microphone capture is only available on macOS and Linux.".to_string())
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn start_desktop_input(
+    app: AppHandle,
+    requested_device_id: Option<String>,
+) -> Result<(String, u32, CaptureRuntime), String> {
+    let (ready_sender, ready_receiver) = mpsc::sync_channel(1);
+    let (stop_sender, stop_receiver) = mpsc::channel();
+    let shared = Arc::new(Mutex::new(CaptureSharedState::default()));
+    let worker_shared = Arc::clone(&shared);
+    let worker_thread = thread::spawn(move || {
+        run_capture_worker(
+            app,
+            requested_device_id,
+            ready_sender,
+            stop_receiver,
+            worker_shared,
+        );
+    });
+
+    match ready_receiver
+        .recv()
+        .map_err(|_| "Native input worker stopped before startup completed.".to_string())?
+    {
+        Ok((effective_device_id, sample_rate)) => Ok((
+            effective_device_id,
+            sample_rate,
+            CaptureRuntime {
+                stop_sender,
+                shared,
+                worker_thread: Some(worker_thread),
+            },
+        )),
+        Err(error) => {
+            let _ = worker_thread.join();
+            Err(error)
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn run_capture_worker(
+    app: AppHandle,
+    requested_device_id: Option<String>,
+    ready_sender: mpsc::SyncSender<Result<(String, u32), String>>,
+    stop_receiver: mpsc::Receiver<CaptureControl>,
+    shared: Arc<Mutex<CaptureSharedState>>,
+) {
+    let startup = start_capture_stream(requested_device_id, shared);
+    match startup {
+        Ok(startup) => {
+            let _ = ready_sender.send(Ok((startup.effective_device_id, startup.sample_rate)));
+            emit_input_frames(app, startup.frame_receiver, stop_receiver, startup.stream);
+        }
+        Err(error) => {
+            let _ = ready_sender.send(Err(error));
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn start_capture_stream(
+    requested_device_id: Option<String>,
+    shared: Arc<Mutex<CaptureSharedState>>,
+) -> Result<CaptureStreamStartup, String> {
+    let host = cpal::default_host();
+    let (device, effective_device_id) = select_input_device(&host, requested_device_id.as_deref())?;
+    let supported_config = device
+        .default_input_config()
+        .map_err(|error| format!("Could not open native input configuration: {error}"))?;
+    let sample_format = supported_config.sample_format();
+    let config: cpal::StreamConfig = supported_config.into();
+    let sample_rate = config.sample_rate.0;
+    let channels = usize::from(config.channels.max(1));
+    let (sender, receiver) = mpsc::sync_channel::<AudioInputFrame>(2);
+    let device_id = Some(effective_device_id.clone());
+
+    let stream = match sample_format {
+        cpal::SampleFormat::I8 => build_input_stream(
+            &device,
+            &config,
+            channels,
+            sample_rate,
+            device_id.clone(),
+            sender.clone(),
+            Arc::clone(&shared),
+            convert_i8_sample,
+        ),
+        cpal::SampleFormat::F32 => build_input_stream(
+            &device,
+            &config,
+            channels,
+            sample_rate,
+            device_id.clone(),
+            sender.clone(),
+            Arc::clone(&shared),
+            convert_f32_sample,
+        ),
+        cpal::SampleFormat::I16 => build_input_stream(
+            &device,
+            &config,
+            channels,
+            sample_rate,
+            device_id.clone(),
+            sender.clone(),
+            Arc::clone(&shared),
+            convert_i16_sample,
+        ),
+        cpal::SampleFormat::I32 => build_input_stream(
+            &device,
+            &config,
+            channels,
+            sample_rate,
+            device_id.clone(),
+            sender.clone(),
+            Arc::clone(&shared),
+            convert_i32_sample,
+        ),
+        cpal::SampleFormat::I64 => build_input_stream(
+            &device,
+            &config,
+            channels,
+            sample_rate,
+            device_id.clone(),
+            sender.clone(),
+            Arc::clone(&shared),
+            convert_i64_sample,
+        ),
+        cpal::SampleFormat::U8 => build_input_stream(
+            &device,
+            &config,
+            channels,
+            sample_rate,
+            device_id.clone(),
+            sender.clone(),
+            Arc::clone(&shared),
+            convert_u8_sample,
+        ),
+        cpal::SampleFormat::U16 => build_input_stream(
+            &device,
+            &config,
+            channels,
+            sample_rate,
+            device_id,
+            sender,
+            Arc::clone(&shared),
+            convert_u16_sample,
+        ),
+        cpal::SampleFormat::U32 => build_input_stream(
+            &device,
+            &config,
+            channels,
+            sample_rate,
+            device_id.clone(),
+            sender.clone(),
+            Arc::clone(&shared),
+            convert_u32_sample,
+        ),
+        cpal::SampleFormat::U64 => build_input_stream(
+            &device,
+            &config,
+            channels,
+            sample_rate,
+            device_id.clone(),
+            sender.clone(),
+            Arc::clone(&shared),
+            convert_u64_sample,
+        ),
+        cpal::SampleFormat::F64 => build_input_stream(
+            &device,
+            &config,
+            channels,
+            sample_rate,
+            device_id,
+            sender,
+            Arc::clone(&shared),
+            convert_f64_sample,
+        ),
+        unsupported => Err(format!(
+            "Unsupported native input sample format: {unsupported:?}."
+        )),
+    }?;
+
+    stream
+        .play()
+        .map_err(|error| format!("Could not start native input stream: {error}"))?;
+
+    Ok(CaptureStreamStartup {
+        effective_device_id,
+        sample_rate,
+        stream,
+        frame_receiver: receiver,
+    })
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn start_desktop_input(
+    _app: AppHandle,
+    _requested_device_id: Option<String>,
+) -> Result<(String, u32, CaptureRuntime), String> {
+    Err("Native microphone capture is only available on macOS and Linux.".to_string())
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn select_input_device(
+    host: &cpal::Host,
+    requested_device_id: Option<&str>,
+) -> Result<(cpal::Device, String), String> {
+    let requested_device_id = requested_device_id.filter(|device_id| !device_id.is_empty());
+    if requested_device_id.is_none() || requested_device_id == Some(DEFAULT_INPUT_DEVICE_ID) {
+        let device = host
+            .default_input_device()
+            .ok_or_else(|| "No default native input device is available.".to_string())?;
+        return Ok((device, DEFAULT_INPUT_DEVICE_ID.to_string()));
+    }
+
+    let requested_device_id = requested_device_id.unwrap_or(DEFAULT_INPUT_DEVICE_ID);
+    let requested_hash = native_input_device_hash(requested_device_id);
+    let devices = host
+        .input_devices()
+        .map_err(|error| format!("Could not list native input devices: {error}"))?;
+    let mut hash_match: Option<(cpal::Device, String)> = None;
+
+    for (index, device) in devices.enumerate() {
+        let label = device
+            .name()
+            .unwrap_or_else(|_| format!("Input Device {}", index + 1));
+        let candidate_id = native_input_device_id(index, &label);
+        if candidate_id == requested_device_id {
+            return Ok((device, candidate_id));
+        }
+        if requested_hash == Some(stable_name_hash(&label)) && hash_match.is_none() {
+            hash_match = Some((device, candidate_id));
+        }
+    }
+
+    hash_match.ok_or_else(|| "Selected native input device was not found.".to_string())
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn build_input_stream<T, F>(
+    device: &cpal::Device,
+    config: &cpal::StreamConfig,
+    channels: usize,
+    sample_rate: u32,
+    device_id: Option<String>,
+    sender: mpsc::SyncSender<AudioInputFrame>,
+    shared: Arc<Mutex<CaptureSharedState>>,
+    convert_sample: F,
+) -> Result<cpal::Stream, String>
+where
+    T: cpal::SizedSample + Copy + Send + 'static,
+    F: Fn(T) -> f32 + Copy + Send + 'static,
+{
+    let mut pending_samples = Vec::with_capacity(INPUT_FRAME_SAMPLES + INPUT_FRAME_HOP_SAMPLES);
+    device
+        .build_input_stream(
+            config,
+            move |data: &[T], _| {
+                process_interleaved_input(
+                    data,
+                    channels,
+                    sample_rate,
+                    device_id.clone(),
+                    &sender,
+                    &shared,
+                    convert_sample,
+                    &mut pending_samples,
+                );
+            },
+            |error| eprintln!("Native microphone input stream error: {error}"),
+            None,
+        )
+        .map_err(|error| format!("Could not build native input stream: {error}"))
+}
+
+fn process_interleaved_input<T, F>(
+    data: &[T],
+    channels: usize,
+    sample_rate: u32,
+    device_id: Option<String>,
+    sender: &mpsc::SyncSender<AudioInputFrame>,
+    shared: &Arc<Mutex<CaptureSharedState>>,
+    convert_sample: F,
+    pending_samples: &mut Vec<f32>,
+) where
+    T: Copy,
+    F: Fn(T) -> f32,
+{
+    append_mono_samples(data, channels, convert_sample, pending_samples);
+
+    while pending_samples.len() >= INPUT_FRAME_SAMPLES {
+        let samples = pending_samples[..INPUT_FRAME_SAMPLES].to_vec();
+        let input_level = calculate_input_level(&samples);
+        if let Ok(mut shared) = shared.lock() {
+            shared.input_level = input_level;
+        }
+        let _ = sender.try_send(AudioInputFrame {
+            device_id: device_id.clone(),
+            sample_rate,
+            input_level,
+            samples,
+            timestamp_ms: current_timestamp_ms(),
+        });
+        pending_samples.drain(..INPUT_FRAME_HOP_SAMPLES.min(pending_samples.len()));
+    }
+}
+
+fn append_mono_samples<T, F>(
+    data: &[T],
+    channels: usize,
+    convert_sample: F,
+    pending_samples: &mut Vec<f32>,
+) where
+    T: Copy,
+    F: Fn(T) -> f32,
+{
+    if channels == 0 {
+        return;
+    }
+
+    for frame in data.chunks(channels) {
+        let sum = frame
+            .iter()
+            .map(|sample| convert_sample(*sample))
+            .sum::<f32>();
+        pending_samples.push((sum / frame.len() as f32).clamp(-1.0, 1.0));
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn emit_input_frames(
+    app: AppHandle,
+    receiver: mpsc::Receiver<AudioInputFrame>,
+    stop_receiver: mpsc::Receiver<CaptureControl>,
+    _stream: cpal::Stream,
+) {
+    let mut last_emit_at = Instant::now() - INPUT_FRAME_EVENT_INTERVAL;
+    loop {
+        if stop_receiver.try_recv().is_ok() {
+            break;
+        }
+        match receiver.recv_timeout(INPUT_FRAME_EVENT_INTERVAL) {
+            Ok(frame) => {
+                if last_emit_at.elapsed() < INPUT_FRAME_EVENT_INTERVAL {
+                    continue;
+                }
+                last_emit_at = Instant::now();
+                let _ = app.emit(AUDIO_EVENT_INPUT_FRAME, frame);
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+}
+
+fn convert_f32_sample(sample: f32) -> f32 {
+    sample.clamp(-1.0, 1.0)
+}
+
+fn convert_f64_sample(sample: f64) -> f32 {
+    sample.clamp(-1.0, 1.0) as f32
+}
+
+fn convert_i8_sample(sample: i8) -> f32 {
+    (sample as f32 / i8::MAX as f32).clamp(-1.0, 1.0)
+}
+
+fn convert_i16_sample(sample: i16) -> f32 {
+    (sample as f32 / i16::MAX as f32).clamp(-1.0, 1.0)
+}
+
+fn convert_i32_sample(sample: i32) -> f32 {
+    (sample as f32 / i32::MAX as f32).clamp(-1.0, 1.0)
+}
+
+fn convert_i64_sample(sample: i64) -> f32 {
+    (sample as f64 / i64::MAX as f64).clamp(-1.0, 1.0) as f32
+}
+
+fn convert_u8_sample(sample: u8) -> f32 {
+    ((sample as f32 - 128.0) / 128.0).clamp(-1.0, 1.0)
+}
+
+fn convert_u16_sample(sample: u16) -> f32 {
+    ((sample as f32 - 32768.0) / 32768.0).clamp(-1.0, 1.0)
+}
+
+fn convert_u32_sample(sample: u32) -> f32 {
+    ((sample as f64 - 2_147_483_648.0) / 2_147_483_648.0).clamp(-1.0, 1.0) as f32
+}
+
+fn convert_u64_sample(sample: u64) -> f32 {
+    ((sample as f64 - 9_223_372_036_854_775_808.0) / 9_223_372_036_854_775_808.0).clamp(-1.0, 1.0)
+        as f32
+}
+
+fn native_input_device_id(index: usize, label: &str) -> String {
+    format!("cpal:{index}:{:016x}", stable_name_hash(label))
+}
+
+fn native_input_device_hash(device_id: &str) -> Option<u64> {
+    let mut parts = device_id.split(':');
+    if parts.next()? != "cpal" {
+        return None;
+    }
+    let _index = parts.next()?;
+    u64::from_str_radix(parts.next()?, 16).ok()
+}
+
+fn stable_name_hash(value: &str) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325u64;
+    for byte in value.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+fn current_timestamp_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
+        .unwrap_or(0)
 }
 
 #[cfg(test)]
@@ -195,5 +782,88 @@ mod tests {
         assert!(devices.supported);
         assert!(devices.devices.is_empty());
         assert_eq!(devices.error, None);
+    }
+
+    #[test]
+    fn gain_normalization_clamps_monitor_values() {
+        assert_eq!(normalize_gain(Some(-0.1)), 0.0);
+        assert_eq!(normalize_gain(Some(0.5)), 0.5);
+        assert_eq!(normalize_gain(Some(2.0)), 1.0);
+        assert_eq!(normalize_gain(None), 0.0);
+    }
+
+    #[test]
+    fn sample_conversion_normalizes_common_formats() {
+        assert_eq!(convert_f32_sample(2.0), 1.0);
+        assert_eq!(convert_f64_sample(-2.0), -1.0);
+        assert_eq!(convert_i8_sample(i8::MAX), 1.0);
+        assert_eq!(convert_i8_sample(i8::MIN), -1.0);
+        assert_eq!(convert_i16_sample(i16::MAX), 1.0);
+        assert_eq!(convert_i16_sample(i16::MIN), -1.0);
+        assert_eq!(convert_i32_sample(i32::MAX), 1.0);
+        assert_eq!(convert_i32_sample(i32::MIN), -1.0);
+        assert_eq!(convert_i64_sample(i64::MAX), 1.0);
+        assert_eq!(convert_i64_sample(i64::MIN), -1.0);
+        assert_eq!(convert_u8_sample(255), 0.9921875);
+        assert_eq!(convert_u8_sample(0), -1.0);
+        assert_eq!(convert_u16_sample(65535), 0.9999695);
+        assert_eq!(convert_u16_sample(0), -1.0);
+        assert!((convert_u32_sample(u32::MAX) - 1.0).abs() < 0.000001);
+        assert_eq!(convert_u32_sample(0), -1.0);
+        assert!((convert_u64_sample(u64::MAX) - 1.0).abs() < 0.000001);
+        assert_eq!(convert_u64_sample(0), -1.0);
+    }
+
+    #[test]
+    fn input_level_uses_rms() {
+        let level = calculate_input_level(&[0.0, 0.5, -0.5, 0.0]);
+
+        assert!((level - 0.35355338).abs() < 0.000001);
+    }
+
+    #[test]
+    fn interleaved_samples_are_mixed_to_mono_frames() {
+        let mut pending_samples = Vec::new();
+
+        append_mono_samples(
+            &[1.0_f32, -1.0, 0.5, 0.25],
+            2,
+            convert_f32_sample,
+            &mut pending_samples,
+        );
+
+        assert_eq!(pending_samples, vec![0.0, 0.375]);
+    }
+
+    #[test]
+    fn native_device_ids_match_reordered_same_name() {
+        let original = native_input_device_id(0, "USB Interface");
+        let reordered = native_input_device_id(2, "USB Interface");
+
+        assert_eq!(
+            native_input_device_hash(&original),
+            native_input_device_hash(&reordered)
+        );
+        assert_ne!(original, reordered);
+    }
+
+    #[test]
+    fn stop_clears_active_status_and_level() {
+        let mut state = CaptureState {
+            active: true,
+            device_id: Some("cpal:0:test".to_string()),
+            monitor_enabled: false,
+            monitor_gain: 0.0,
+            input_level: 0.42,
+            sample_rate: Some(48_000),
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            runtime: None,
+        };
+
+        let stopped = state.stop();
+
+        assert!(!stopped.active);
+        assert_eq!(stopped.input_level, 0.0);
+        assert_eq!(stopped.sample_rate, None);
     }
 }

--- a/apps/desktop/src-tauri/src/native_audio/mod.rs
+++ b/apps/desktop/src-tauri/src/native_audio/mod.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 use std::sync::Mutex;
-use tauri::State;
+use tauri::{AppHandle, State};
 
 pub mod android_media;
 pub mod capture;
@@ -15,6 +15,7 @@ pub const AUDIO_EVENT_POSITION: &str = "audio://position";
 pub const AUDIO_EVENT_ENDED: &str = "audio://ended";
 pub const AUDIO_EVENT_ERROR: &str = "audio://error";
 pub const AUDIO_EVENT_INPUT_LEVEL: &str = "audio://input-level";
+pub const AUDIO_EVENT_INPUT_FRAME: &str = "audio://input-frame";
 pub const AUDIO_EVENT_DEVICES_CHANGED: &str = "audio://devices-changed";
 
 pub struct NativeAudioState {
@@ -75,6 +76,7 @@ impl AudioCapabilities {
                 AUDIO_EVENT_ENDED,
                 AUDIO_EVENT_ERROR,
                 AUDIO_EVENT_INPUT_LEVEL,
+                AUDIO_EVENT_INPUT_FRAME,
                 AUDIO_EVENT_DEVICES_CHANGED,
             ],
             fallback_required: !platform.native_playback_supported,
@@ -212,7 +214,19 @@ pub fn audio_list_output_devices(
 }
 
 #[tauri::command]
+pub fn audio_get_input_state(
+    state: State<'_, NativeAudioState>,
+) -> Result<capture::AudioInputState, String> {
+    let capture = state
+        .capture
+        .lock()
+        .map_err(|_| "Native audio capture state is unavailable.".to_string())?;
+    Ok(capture.state())
+}
+
+#[tauri::command]
 pub fn audio_start_input(
+    app: AppHandle,
     state: State<'_, NativeAudioState>,
     payload: capture::AudioInputRequest,
 ) -> Result<capture::AudioInputState, String> {
@@ -227,7 +241,7 @@ pub fn audio_start_input(
         .capture
         .lock()
         .map_err(|_| "Native audio capture state is unavailable.".to_string())?;
-    capture.start(payload)
+    capture.start(app, payload)
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/native_audio/platform/desktop.rs
+++ b/apps/desktop/src-tauri/src/native_audio/platform/desktop.rs
@@ -7,9 +7,9 @@ pub fn current_platform() -> AudioPlatform {
         } else {
             "linux"
         },
-        backend: "desktop-null",
+        backend: "desktop-cpal",
         native_playback_supported: false,
-        mic_capture_supported: false,
+        mic_capture_supported: true,
         mic_monitoring_supported: false,
         system_input_volume_supported: true,
     }

--- a/apps/desktop/src-tauri/src/native_audio/system_input.rs
+++ b/apps/desktop/src-tauri/src/native_audio/system_input.rs
@@ -37,13 +37,19 @@ impl SystemDefaultInputVolume {
 }
 
 #[tauri::command]
-pub fn get_system_default_input_volume() -> SystemDefaultInputVolume {
-    read_system_default_input_volume()
+pub fn get_system_default_input_volume(device_id: Option<String>) -> SystemDefaultInputVolume {
+    read_system_input_volume(device_id.as_deref())
 }
 
 #[tauri::command]
-pub fn set_system_default_input_volume(volume_percent: i32) -> SystemDefaultInputVolume {
-    write_system_default_input_volume(clamp_input_volume_percent(volume_percent))
+pub fn set_system_default_input_volume(
+    volume_percent: i32,
+    device_id: Option<String>,
+) -> SystemDefaultInputVolume {
+    write_system_input_volume(
+        clamp_input_volume_percent(volume_percent),
+        device_id.as_deref(),
+    )
 }
 
 #[cfg(target_os = "linux")]
@@ -76,6 +82,31 @@ fn parse_percent(value: &str) -> Option<u8> {
 
 fn clamp_input_volume_percent(value: i32) -> u8 {
     value.clamp(0, 100) as u8
+}
+
+fn is_default_input_device_id(device_id: Option<&str>) -> bool {
+    device_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && *value != "default")
+        .is_none()
+}
+
+fn native_input_device_hash(device_id: &str) -> Option<u64> {
+    let mut parts = device_id.split(':');
+    if parts.next()? != "cpal" {
+        return None;
+    }
+    let _index = parts.next()?;
+    u64::from_str_radix(parts.next()?, 16).ok()
+}
+
+fn stable_name_hash(value: &str) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325u64;
+    for byte in value.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
 }
 
 #[cfg(any(target_os = "linux", test))]
@@ -111,9 +142,119 @@ fn parse_pactl_mute(output: &str) -> Option<bool> {
     None
 }
 
+#[cfg(any(target_os = "linux", test))]
+#[derive(Debug, PartialEq, Eq)]
+struct PactlSource {
+    name: String,
+    description: String,
+    volume_percent: Option<u8>,
+    muted: Option<bool>,
+}
+
+#[cfg(any(target_os = "linux", test))]
+#[derive(Debug, PartialEq, Eq)]
+struct WpctlSource {
+    id: String,
+    label: String,
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn parse_pactl_sources(output: &str) -> Vec<PactlSource> {
+    let mut sources = Vec::new();
+    let mut current: Option<PactlSource> = None;
+
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("Source #") {
+            if let Some(source) = current.take() {
+                sources.push(source);
+            }
+            current = Some(PactlSource {
+                name: String::new(),
+                description: String::new(),
+                volume_percent: None,
+                muted: None,
+            });
+            continue;
+        }
+
+        let Some(source) = current.as_mut() else {
+            continue;
+        };
+
+        if let Some(name) = trimmed.strip_prefix("Name:") {
+            source.name = name.trim().to_string();
+        } else if let Some(description) = trimmed.strip_prefix("Description:") {
+            source.description = description.trim().to_string();
+        } else if let Some(mute) = trimmed.strip_prefix("Mute:") {
+            source.muted = parse_pactl_mute(mute);
+        } else if let Some(volume) = trimmed.strip_prefix("Volume:") {
+            source.volume_percent = parse_first_percent(volume);
+        }
+    }
+
+    if let Some(source) = current {
+        sources.push(source);
+    }
+
+    sources
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn parse_wpctl_sources(output: &str) -> Vec<WpctlSource> {
+    let mut sources = Vec::new();
+    let mut in_sources = false;
+
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.ends_with("Sources:") {
+            in_sources = true;
+            continue;
+        }
+        if in_sources && trimmed.ends_with(':') && !trimmed.ends_with("Sources:") {
+            break;
+        }
+        if !in_sources {
+            continue;
+        }
+
+        let normalized = trimmed
+            .trim_start_matches('│')
+            .trim()
+            .trim_start_matches('*')
+            .trim();
+        let Some((id, rest)) = normalized.split_once('.') else {
+            continue;
+        };
+        let id = id.trim();
+        if id.is_empty() || !id.chars().all(|character| character.is_ascii_digit()) {
+            continue;
+        }
+        let label = rest.split(" [").next().unwrap_or(rest).trim().to_string();
+        if !label.is_empty() {
+            sources.push(WpctlSource {
+                id: id.to_string(),
+                label,
+            });
+        }
+    }
+
+    sources
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn label_matches_native_device_id(label: &str, device_id: &str) -> bool {
+    native_input_device_hash(device_id) == Some(stable_name_hash(label))
+}
+
 #[cfg(target_os = "macos")]
 mod macos_system_audio {
-    use super::SystemDefaultInputVolume;
+    use super::{
+        is_default_input_device_id, native_input_device_hash, stable_name_hash,
+        SystemDefaultInputVolume,
+    };
+    use std::ffi::CStr;
+    use std::os::raw::c_char;
     use std::{ffi::c_void, mem, ptr};
 
     type AudioObjectID = u32;
@@ -121,6 +262,7 @@ mod macos_system_audio {
     type AudioObjectPropertyScope = u32;
     type AudioObjectPropertyElement = u32;
     type OSStatus = i32;
+    type CFStringRef = *const c_void;
 
     #[allow(non_snake_case)]
     #[derive(Clone, Copy)]
@@ -137,12 +279,33 @@ mod macos_system_audio {
 
     const NO_ERR: OSStatus = 0;
     const K_AUDIO_OBJECT_SYSTEM_OBJECT: AudioObjectID = 1;
+    const K_AUDIO_HARDWARE_PROPERTY_DEVICES: u32 = fourcc(b"dev#");
     const K_AUDIO_HARDWARE_PROPERTY_DEFAULT_INPUT_DEVICE: u32 = fourcc(b"dIn ");
+    const K_AUDIO_DEVICE_PROPERTY_DEVICE_NAME_CF_STRING: u32 = fourcc(b"lnam");
+    const K_AUDIO_DEVICE_PROPERTY_STREAM_CONFIGURATION: u32 = fourcc(b"slay");
     const K_AUDIO_DEVICE_PROPERTY_VOLUME_SCALAR: u32 = fourcc(b"volm");
     const K_AUDIO_DEVICE_PROPERTY_MUTE: u32 = fourcc(b"mute");
+    const K_AUDIO_DEVICE_PROPERTY_SCOPE_OUTPUT: u32 = fourcc(b"outp");
     const K_AUDIO_OBJECT_PROPERTY_SCOPE_GLOBAL: u32 = fourcc(b"glob");
     const K_AUDIO_OBJECT_PROPERTY_SCOPE_INPUT: u32 = fourcc(b"inpt");
     const K_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN: u32 = 0;
+    const K_CF_STRING_ENCODING_UTF8: u32 = 0x0800_0100;
+
+    #[allow(non_snake_case)]
+    #[derive(Clone, Copy)]
+    #[repr(C)]
+    struct AudioBuffer {
+        mNumberChannels: u32,
+        mDataByteSize: u32,
+        mData: *mut c_void,
+    }
+
+    #[allow(non_snake_case)]
+    #[repr(C)]
+    struct AudioBufferList {
+        mNumberBuffers: u32,
+        mBuffers: [AudioBuffer; 1],
+    }
 
     #[link(name = "CoreAudio", kind = "framework")]
     extern "C" {
@@ -171,45 +334,68 @@ mod macos_system_audio {
             in_data_size: u32,
             in_data: *const c_void,
         ) -> OSStatus;
+        fn AudioObjectGetPropertyDataSize(
+            in_object_id: AudioObjectID,
+            in_address: *const AudioObjectPropertyAddress,
+            in_qualifier_data_size: u32,
+            in_qualifier_data: *const c_void,
+            out_data_size: *mut u32,
+        ) -> OSStatus;
     }
 
-    pub(super) fn read() -> SystemDefaultInputVolume {
-        match read_default_input_device_volume() {
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
+        fn CFStringGetCStringPtr(the_string: CFStringRef, encoding: u32) -> *const c_char;
+        fn CFStringGetCString(
+            the_string: CFStringRef,
+            buffer: *mut c_char,
+            buffer_size: isize,
+            encoding: u32,
+        ) -> u8;
+    }
+
+    pub(super) fn read(device_id: Option<&str>) -> SystemDefaultInputVolume {
+        match read_target_input_device_volume(device_id) {
             Ok((volume_percent, muted)) => {
                 SystemDefaultInputVolume::supported(volume_percent, muted, "macos-coreaudio")
             }
             Err(error) => SystemDefaultInputVolume::unsupported(format!(
-                "Could not read macOS default input volume with CoreAudio: {error}"
+                "Could not read macOS input volume with CoreAudio: {error}"
             )),
         }
     }
 
-    pub(super) fn write(volume_percent: u8) -> SystemDefaultInputVolume {
-        match set_default_input_device_volume(volume_percent) {
-            Ok(()) => read(),
+    pub(super) fn write(volume_percent: u8, device_id: Option<&str>) -> SystemDefaultInputVolume {
+        match set_target_input_device_volume(volume_percent, device_id) {
+            Ok(()) => read(device_id),
             Err(error) => SystemDefaultInputVolume::unsupported(format!(
-                "Could not set macOS default input volume with CoreAudio: {error}"
+                "Could not set macOS input volume with CoreAudio: {error}"
             )),
         }
     }
 
-    fn read_default_input_device_volume() -> Result<(u8, Option<bool>), String> {
-        let device_id = default_input_device()?;
-        let volume = read_input_volume_percent(device_id)?;
-        let muted = read_input_mute(device_id);
+    fn read_target_input_device_volume(
+        device_id: Option<&str>,
+    ) -> Result<(u8, Option<bool>), String> {
+        let target = target_input_device(device_id)?;
+        let volume = read_input_volume_percent(target)?;
+        let muted = read_input_mute(target);
         Ok((volume, muted))
     }
 
-    fn set_default_input_device_volume(volume_percent: u8) -> Result<(), String> {
-        let device_id = default_input_device()?;
+    fn set_target_input_device_volume(
+        volume_percent: u8,
+        device_id: Option<&str>,
+    ) -> Result<(), String> {
+        let target = target_input_device(device_id)?;
         let scalar = f32::from(volume_percent) / 100.0;
         let mut wrote_volume = false;
 
         for address in volume_addresses() {
-            if !is_property_settable(device_id, &address) {
+            if !is_property_settable(target, &address) {
                 continue;
             }
-            set_property_data(device_id, &address, &scalar).map_err(|status| {
+            set_property_data(target, &address, &scalar).map_err(|status| {
                 format!(
                     "CoreAudio returned status {status} while setting input volume element {}.",
                     address.mElement
@@ -219,19 +405,42 @@ mod macos_system_audio {
         }
 
         if !wrote_volume {
-            return Err("default input device does not expose a settable volume.".to_string());
+            return Err("input device does not expose a settable volume.".to_string());
         }
 
         if volume_percent > 0 {
             let unmuted: u32 = 0;
             for address in mute_addresses() {
-                if is_property_settable(device_id, &address) {
-                    let _ = set_property_data(device_id, &address, &unmuted);
+                if is_property_settable(target, &address) {
+                    let _ = set_property_data(target, &address, &unmuted);
                 }
             }
         }
 
         Ok(())
+    }
+
+    fn target_input_device(device_id: Option<&str>) -> Result<AudioObjectID, String> {
+        if is_default_input_device_id(device_id) {
+            return default_input_device();
+        }
+
+        let requested_device_id = device_id.unwrap_or_default();
+        let requested_hash = native_input_device_hash(requested_device_id)
+            .ok_or_else(|| "selected input device is not a native cpal device.".to_string())?;
+        let mut hash_match = None;
+
+        for (index, audio_device_id, label) in input_devices()? {
+            let candidate_id = native_input_device_id(index, &label);
+            if candidate_id == requested_device_id {
+                return Ok(audio_device_id);
+            }
+            if hash_match.is_none() && stable_name_hash(&label) == requested_hash {
+                hash_match = Some(audio_device_id);
+            }
+        }
+
+        hash_match.ok_or_else(|| "selected input device was not found.".to_string())
     }
 
     fn default_input_device() -> Result<AudioObjectID, String> {
@@ -250,6 +459,117 @@ mod macos_system_audio {
         Ok(device_id)
     }
 
+    fn input_devices() -> Result<Vec<(usize, AudioObjectID, String)>, String> {
+        let devices = all_audio_devices()?;
+        let mut input_devices = Vec::new();
+
+        for device_id in devices {
+            if !device_has_input_channels(device_id) {
+                continue;
+            }
+            let label = device_name(device_id).unwrap_or_else(|_| "Input Device".to_string());
+            let index = input_devices.len();
+            input_devices.push((index, device_id, label));
+        }
+
+        Ok(input_devices)
+    }
+
+    fn all_audio_devices() -> Result<Vec<AudioObjectID>, String> {
+        let address = property_address(
+            K_AUDIO_HARDWARE_PROPERTY_DEVICES,
+            K_AUDIO_OBJECT_PROPERTY_SCOPE_GLOBAL,
+            K_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN,
+        );
+        let data_size =
+            get_property_data_size(K_AUDIO_OBJECT_SYSTEM_OBJECT, &address).map_err(|status| {
+                format!("CoreAudio returned status {status} while listing devices.")
+            })?;
+        let device_count = data_size as usize / mem::size_of::<AudioObjectID>();
+        if device_count == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut devices = vec![0u32; device_count];
+        get_property_data_into(K_AUDIO_OBJECT_SYSTEM_OBJECT, &address, &mut devices).map_err(
+            |status| format!("CoreAudio returned status {status} while reading devices."),
+        )?;
+        Ok(devices)
+    }
+
+    fn device_name(device_id: AudioObjectID) -> Result<String, String> {
+        let address = property_address(
+            K_AUDIO_DEVICE_PROPERTY_DEVICE_NAME_CF_STRING,
+            K_AUDIO_DEVICE_PROPERTY_SCOPE_OUTPUT,
+            K_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN,
+        );
+        let device_name =
+            get_property_data::<CFStringRef>(device_id, &address).map_err(|status| {
+                format!("CoreAudio returned status {status} while reading device name.")
+            })?;
+        if device_name.is_null() {
+            return Err("CoreAudio returned an empty device name.".to_string());
+        }
+
+        let c_string = unsafe { CFStringGetCStringPtr(device_name, K_CF_STRING_ENCODING_UTF8) };
+        if !c_string.is_null() {
+            return Ok(unsafe { CStr::from_ptr(c_string) }
+                .to_string_lossy()
+                .into_owned());
+        }
+
+        let mut buffer = [0 as c_char; 255];
+        let copied = unsafe {
+            CFStringGetCString(
+                device_name,
+                buffer.as_mut_ptr(),
+                buffer.len() as isize,
+                K_CF_STRING_ENCODING_UTF8,
+            )
+        };
+        if copied == 0 {
+            return Err("CoreFoundation could not copy the device name.".to_string());
+        }
+
+        Ok(unsafe { CStr::from_ptr(buffer.as_ptr()) }
+            .to_string_lossy()
+            .into_owned())
+    }
+
+    fn device_has_input_channels(device_id: AudioObjectID) -> bool {
+        let address = property_address(
+            K_AUDIO_DEVICE_PROPERTY_STREAM_CONFIGURATION,
+            K_AUDIO_OBJECT_PROPERTY_SCOPE_INPUT,
+            K_AUDIO_OBJECT_PROPERTY_ELEMENT_MAIN,
+        );
+        if !has_property(device_id, &address) {
+            return false;
+        }
+        let Ok(data_size) = get_property_data_size(device_id, &address) else {
+            return false;
+        };
+        if data_size as usize <= mem::size_of::<u32>() {
+            return false;
+        }
+
+        let mut data = vec![0u8; data_size as usize];
+        if get_property_bytes(device_id, &address, &mut data).is_err() {
+            return false;
+        }
+
+        let buffers = data.as_ptr().cast::<AudioBufferList>();
+        let number_buffers = unsafe { (*buffers).mNumberBuffers as usize };
+        let first_buffer = unsafe { ptr::addr_of!((*buffers).mBuffers).cast::<AudioBuffer>() };
+        for index in 0..number_buffers {
+            let buffer = unsafe { *first_buffer.add(index) };
+            if buffer.mNumberChannels > 0 {
+                return true;
+            }
+        }
+
+        false
+    }
+
     fn read_input_volume_percent(device_id: AudioObjectID) -> Result<u8, String> {
         for address in volume_addresses() {
             if !has_property(device_id, &address) {
@@ -262,7 +582,7 @@ mod macos_system_audio {
             }
         }
 
-        Err("default input device does not expose a readable volume.".to_string())
+        Err("input device does not expose a readable volume.".to_string())
     }
 
     fn read_input_mute(device_id: AudioObjectID) -> Option<bool> {
@@ -318,6 +638,10 @@ mod macos_system_audio {
         }
     }
 
+    fn native_input_device_id(index: usize, label: &str) -> String {
+        format!("cpal:{index}:{:016x}", stable_name_hash(label))
+    }
+
     fn has_property(object_id: AudioObjectID, address: &AudioObjectPropertyAddress) -> bool {
         unsafe { AudioObjectHasProperty(object_id, address) != 0 }
     }
@@ -361,6 +685,67 @@ mod macos_system_audio {
         Ok(unsafe { value.assume_init() })
     }
 
+    fn get_property_data_into<T: Copy>(
+        object_id: AudioObjectID,
+        address: &AudioObjectPropertyAddress,
+        values: &mut [T],
+    ) -> Result<(), OSStatus> {
+        let mut data_size = mem::size_of_val(values) as u32;
+        let status = unsafe {
+            AudioObjectGetPropertyData(
+                object_id,
+                address,
+                0,
+                ptr::null(),
+                &mut data_size,
+                values.as_mut_ptr().cast::<c_void>(),
+            )
+        };
+        if status == NO_ERR {
+            Ok(())
+        } else {
+            Err(status)
+        }
+    }
+
+    fn get_property_bytes(
+        object_id: AudioObjectID,
+        address: &AudioObjectPropertyAddress,
+        values: &mut [u8],
+    ) -> Result<(), OSStatus> {
+        let mut data_size = values.len() as u32;
+        let status = unsafe {
+            AudioObjectGetPropertyData(
+                object_id,
+                address,
+                0,
+                ptr::null(),
+                &mut data_size,
+                values.as_mut_ptr().cast::<c_void>(),
+            )
+        };
+        if status == NO_ERR {
+            Ok(())
+        } else {
+            Err(status)
+        }
+    }
+
+    fn get_property_data_size(
+        object_id: AudioObjectID,
+        address: &AudioObjectPropertyAddress,
+    ) -> Result<u32, OSStatus> {
+        let mut data_size = 0u32;
+        let status = unsafe {
+            AudioObjectGetPropertyDataSize(object_id, address, 0, ptr::null(), &mut data_size)
+        };
+        if status == NO_ERR {
+            Ok(data_size)
+        } else {
+            Err(status)
+        }
+    }
+
     fn set_property_data<T>(
         object_id: AudioObjectID,
         address: &AudioObjectPropertyAddress,
@@ -396,13 +781,16 @@ mod macos_system_audio {
 }
 
 #[cfg(target_os = "macos")]
-fn read_system_default_input_volume() -> SystemDefaultInputVolume {
-    macos_system_audio::read()
+fn read_system_input_volume(device_id: Option<&str>) -> SystemDefaultInputVolume {
+    macos_system_audio::read(device_id)
 }
 
 #[cfg(target_os = "macos")]
-fn write_system_default_input_volume(volume_percent: u8) -> SystemDefaultInputVolume {
-    macos_system_audio::write(volume_percent)
+fn write_system_input_volume(
+    volume_percent: u8,
+    device_id: Option<&str>,
+) -> SystemDefaultInputVolume {
+    macos_system_audio::write(volume_percent, device_id)
 }
 
 #[cfg(target_os = "linux")]
@@ -434,7 +822,11 @@ fn read_pactl_default_input_volume() -> Result<SystemDefaultInputVolume, String>
 }
 
 #[cfg(target_os = "linux")]
-fn read_system_default_input_volume() -> SystemDefaultInputVolume {
+fn read_system_input_volume(device_id: Option<&str>) -> SystemDefaultInputVolume {
+    if !is_default_input_device_id(device_id) {
+        return read_linux_input_device_volume(device_id.unwrap_or_default());
+    }
+
     read_wpctl_default_input_volume()
         .or_else(|wpctl_error| {
             read_pactl_default_input_volume().map_err(|pactl_error| {
@@ -444,6 +836,75 @@ fn read_system_default_input_volume() -> SystemDefaultInputVolume {
             })
         })
         .unwrap_or_else(SystemDefaultInputVolume::unsupported)
+}
+
+#[cfg(target_os = "linux")]
+fn read_linux_input_device_volume(device_id: &str) -> SystemDefaultInputVolume {
+    read_pactl_input_device_volume(device_id)
+        .or_else(|pactl_error| {
+            read_wpctl_input_device_volume(device_id).map_err(|wpctl_error| {
+                format!(
+                    "Could not read selected input volume with pactl ({pactl_error}) or wpctl ({wpctl_error})."
+                )
+            })
+        })
+        .unwrap_or_else(SystemDefaultInputVolume::unsupported)
+}
+
+#[cfg(target_os = "linux")]
+fn pactl_source_name_for_device(device_id: &str) -> Result<String, String> {
+    let output = run_host_audio_command("pactl", &["list", "sources"])?;
+    parse_pactl_sources(&output)
+        .into_iter()
+        .find(|source| {
+            let label = if source.description.is_empty() {
+                source.name.as_str()
+            } else {
+                source.description.as_str()
+            };
+            !label.starts_with("Monitor of") && label_matches_native_device_id(label, device_id)
+        })
+        .map(|source| source.name)
+        .ok_or_else(|| "selected input source was not found in pactl.".to_string())
+}
+
+#[cfg(target_os = "linux")]
+fn wpctl_source_id_for_device(device_id: &str) -> Result<String, String> {
+    let output = run_host_audio_command("wpctl", &["status"])?;
+    parse_wpctl_sources(&output)
+        .into_iter()
+        .find(|source| label_matches_native_device_id(&source.label, device_id))
+        .map(|source| source.id)
+        .ok_or_else(|| "selected input source was not found in wpctl.".to_string())
+}
+
+#[cfg(target_os = "linux")]
+fn read_pactl_input_device_volume(device_id: &str) -> Result<SystemDefaultInputVolume, String> {
+    let source_name = pactl_source_name_for_device(device_id)?;
+    let volume_output = run_host_audio_command("pactl", &["get-source-volume", &source_name])?;
+    let volume_percent = parse_first_percent(&volume_output)
+        .ok_or_else(|| "Could not parse pactl selected source volume.".to_string())?;
+    let muted = run_host_audio_command("pactl", &["get-source-mute", &source_name])
+        .ok()
+        .and_then(|output| parse_pactl_mute(&output));
+    Ok(SystemDefaultInputVolume::supported(
+        volume_percent,
+        muted,
+        "linux-pactl-device",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn read_wpctl_input_device_volume(device_id: &str) -> Result<SystemDefaultInputVolume, String> {
+    let source_id = wpctl_source_id_for_device(device_id)?;
+    let output = run_host_audio_command("wpctl", &["get-volume", &source_id])?;
+    let (volume_percent, muted) = parse_wpctl_volume(&output)
+        .ok_or_else(|| "Could not parse wpctl selected input volume.".to_string())?;
+    Ok(SystemDefaultInputVolume::supported(
+        volume_percent,
+        Some(muted),
+        "linux-wpctl-device",
+    ))
 }
 
 #[cfg(target_os = "linux")]
@@ -467,7 +928,14 @@ fn write_pactl_default_input_volume(
 }
 
 #[cfg(target_os = "linux")]
-fn write_system_default_input_volume(volume_percent: u8) -> SystemDefaultInputVolume {
+fn write_system_input_volume(
+    volume_percent: u8,
+    device_id: Option<&str>,
+) -> SystemDefaultInputVolume {
+    if !is_default_input_device_id(device_id) {
+        return write_linux_input_device_volume(volume_percent, device_id.unwrap_or_default());
+    }
+
     write_wpctl_default_input_volume(volume_percent)
         .or_else(|wpctl_error| {
             write_pactl_default_input_volume(volume_percent).map_err(|pactl_error| {
@@ -479,16 +947,59 @@ fn write_system_default_input_volume(volume_percent: u8) -> SystemDefaultInputVo
         .unwrap_or_else(SystemDefaultInputVolume::unsupported)
 }
 
+#[cfg(target_os = "linux")]
+fn write_linux_input_device_volume(
+    volume_percent: u8,
+    device_id: &str,
+) -> SystemDefaultInputVolume {
+    write_pactl_input_device_volume(volume_percent, device_id)
+        .or_else(|pactl_error| {
+            write_wpctl_input_device_volume(volume_percent, device_id).map_err(|wpctl_error| {
+                format!(
+                    "Could not set selected input volume with pactl ({pactl_error}) or wpctl ({wpctl_error})."
+                )
+            })
+        })
+        .unwrap_or_else(SystemDefaultInputVolume::unsupported)
+}
+
+#[cfg(target_os = "linux")]
+fn write_pactl_input_device_volume(
+    volume_percent: u8,
+    device_id: &str,
+) -> Result<SystemDefaultInputVolume, String> {
+    let source_name = pactl_source_name_for_device(device_id)?;
+    let volume = format!("{volume_percent}%");
+    run_host_audio_command("pactl", &["set-source-mute", &source_name, "0"])?;
+    run_host_audio_command("pactl", &["set-source-volume", &source_name, &volume])?;
+    read_pactl_input_device_volume(device_id)
+}
+
+#[cfg(target_os = "linux")]
+fn write_wpctl_input_device_volume(
+    volume_percent: u8,
+    device_id: &str,
+) -> Result<SystemDefaultInputVolume, String> {
+    let source_id = wpctl_source_id_for_device(device_id)?;
+    let volume = format!("{volume_percent}%");
+    run_host_audio_command("wpctl", &["set-mute", &source_id, "0"])?;
+    run_host_audio_command("wpctl", &["set-volume", &source_id, &volume])?;
+    read_wpctl_input_device_volume(device_id)
+}
+
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-fn read_system_default_input_volume() -> SystemDefaultInputVolume {
+fn read_system_input_volume(_device_id: Option<&str>) -> SystemDefaultInputVolume {
     SystemDefaultInputVolume::unsupported(
         "System input volume control is only available on macOS and Linux.",
     )
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-fn write_system_default_input_volume(_volume_percent: u8) -> SystemDefaultInputVolume {
-    read_system_default_input_volume()
+fn write_system_input_volume(
+    _volume_percent: u8,
+    device_id: Option<&str>,
+) -> SystemDefaultInputVolume {
+    read_system_input_volume(device_id)
 }
 
 #[cfg(test)]
@@ -518,5 +1029,69 @@ mod tests {
         );
         assert_eq!(parse_pactl_mute("Mute: yes"), Some(true));
         assert_eq!(parse_pactl_mute("Mute: no"), Some(false));
+    }
+
+    #[test]
+    fn parses_pactl_sources_for_device_matching() {
+        let sources = parse_pactl_sources(
+            r#"
+Source #42
+	State: RUNNING
+	Name: alsa_input.pci-0000_00_1f.3.analog-stereo
+	Description: Built-in Microphone
+	Mute: no
+	Volume: front-left: 49152 / 75% / -7.50 dB
+
+Source #43
+	Name: alsa_output.pci.monitor
+	Description: Monitor of Speakers
+	Mute: yes
+	Volume: front-left: 32768 / 50% / -18.00 dB
+"#,
+        );
+
+        assert_eq!(sources.len(), 2);
+        assert_eq!(sources[0].name, "alsa_input.pci-0000_00_1f.3.analog-stereo");
+        assert_eq!(sources[0].description, "Built-in Microphone");
+        assert_eq!(sources[0].volume_percent, Some(75));
+        assert_eq!(sources[0].muted, Some(false));
+    }
+
+    #[test]
+    fn parses_wpctl_sources_for_device_matching() {
+        let sources = parse_wpctl_sources(
+            r#"
+Audio
+ ├─ Sources:
+ │  *   54. Built-in Microphone               [vol: 0.75]
+ │      55. USB Interface                     [vol: 1.00]
+ ├─ Filters:
+"#,
+        );
+
+        assert_eq!(
+            sources,
+            vec![
+                WpctlSource {
+                    id: "54".to_string(),
+                    label: "Built-in Microphone".to_string(),
+                },
+                WpctlSource {
+                    id: "55".to_string(),
+                    label: "USB Interface".to_string(),
+                },
+            ],
+        );
+    }
+
+    #[test]
+    fn matches_native_device_hashes_from_cpal_ids() {
+        let device_id = format!("cpal:3:{:016x}", stable_name_hash("Built-in Microphone"));
+
+        assert!(label_matches_native_device_id(
+            "Built-in Microphone",
+            &device_id
+        ));
+        assert!(!label_matches_native_device_id("USB Interface", &device_id));
     }
 }

--- a/apps/desktop/src/App.settings-theme.test.tsx
+++ b/apps/desktop/src/App.settings-theme.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   resetAppTestHarness,
   getAllByAriaKeyLabel,
@@ -12,12 +12,14 @@ import {
   queryByAriaKeyLabel,
   renderApp,
   setChordBackends,
+  setMockNativeAudioState,
   setProjectAnalysis,
   setProjectChords,
 } from "./test/appTestHarness";
 
 describe("Desktop app settings theme", () => {
   beforeEach(resetAppTestHarness);
+  afterEach(() => vi.unstubAllEnvs());
 
   async function openPlaybackWorkspace(user: ReturnType<typeof userEvent.setup>) {
     await user.click(screen.getByRole("tab", { name: "Playback" }));
@@ -115,6 +117,18 @@ describe("Desktop app settings theme", () => {
 
   it("persists theme and visible UI preferences", async () => {
     const user = userEvent.setup();
+    setMockNativeAudioState({
+      capabilities: {
+        backend: "desktop-cpal",
+        micCaptureSupported: true,
+        nativePlaybackSupported: false,
+      },
+    });
+    window.localStorage.setItem(
+      "tuneforge.tuner-input-capture-backend",
+      JSON.stringify({ backend: "native", detail: "desktop-cpal" }),
+    );
+    window.localStorage.setItem("tuneforge.tuner-native-capture-error", "Native microphone failed.");
     renderApp(["/settings"]);
 
     expect(await screen.findByRole("heading", { name: "Control Room" })).toBeInTheDocument();
@@ -127,6 +141,9 @@ describe("Desktop app settings theme", () => {
     await user.click(screen.getByRole("button", { name: /^Advanced Chords/ }));
     await user.click(screen.getByText("Show diagnostics"));
     expect(await screen.findByText("/tmp/tuneforge")).toBeInTheDocument();
+    expect(screen.getAllByText("Native (desktop-cpal)")).toHaveLength(2);
+    expect(screen.getByText("Native microphone failed.")).toBeInTheDocument();
+    expect(screen.getByText("Web Audio")).toBeInTheDocument();
 
     expect(document.documentElement).toHaveAttribute("data-theme", "light");
     expect(window.localStorage.getItem("tuneforge.theme-preference")).toBe("light");
@@ -145,6 +162,26 @@ describe("Desktop app settings theme", () => {
         defaultChordsFollowEnabled: true,
       }),
     );
+  });
+
+  it("shows forced Web Audio diagnostics", async () => {
+    const user = userEvent.setup();
+    vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
+    setMockNativeAudioState({
+      capabilities: {
+        backend: "desktop-cpal",
+        micCaptureSupported: true,
+        nativePlaybackSupported: true,
+      },
+    });
+    renderApp(["/settings"]);
+
+    expect(await screen.findByRole("heading", { name: "Control Room" })).toBeInTheDocument();
+    await user.click(screen.getByText("Show diagnostics"));
+
+    expect(await screen.findByText("/tmp/tuneforge")).toBeInTheDocument();
+    expect(screen.getAllByText("Web Audio (forced)")).toHaveLength(2);
+    expect(mockInvoke).not.toHaveBeenCalledWith("audio_get_capabilities");
   });
 
   it("persists playback follow defaults", async () => {

--- a/apps/desktop/src/App.tools-tuner.test.tsx
+++ b/apps/desktop/src/App.tools-tuner.test.tsx
@@ -1,17 +1,20 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  emitMockNativeInputFrame,
   getMockAudioContexts,
   getMockInvoke,
   getMockMediaDevices,
   resetAppTestHarness,
   renderApp,
+  setMockNativeAudioState,
   setMockSystemInputVolumeState,
 } from "./test/appTestHarness";
 
 describe("Desktop app tools tuner", () => {
   beforeEach(resetAppTestHarness);
+  afterEach(() => vi.unstubAllEnvs());
 
   it("renders the tools route with chromatic tuner defaults", async () => {
     renderApp(["/tools"]);
@@ -43,18 +46,28 @@ describe("Desktop app tools tuner", () => {
 
   it("keeps tuner preferences synced between tools and settings", async () => {
     const user = userEvent.setup();
-    getMockMediaDevices().revealLabels();
+    setMockNativeAudioState({
+      capabilities: {
+        micCaptureSupported: true,
+        backend: "desktop-cpal",
+      },
+      inputDevices: {
+        supported: true,
+        devices: [{ id: "cpal:1:usb", label: "USB Interface", isDefault: false }],
+        error: null,
+      },
+    });
     renderApp(["/tools"]);
 
     expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
     expect(await screen.findByRole("option", { name: "USB Interface" })).toBeInTheDocument();
-    await user.selectOptions(screen.getByLabelText("Microphone source"), "usb");
+    await user.selectOptions(screen.getByLabelText("Microphone source"), "cpal:1:usb");
     changeReferenceInput("442.5");
 
     await user.click(screen.getByRole("link", { name: "Settings" }));
 
     expect(await screen.findByRole("heading", { name: "Control Room" })).toBeInTheDocument();
-    expect(screen.getByLabelText("Microphone source")).toHaveValue("usb");
+    expect(screen.getByLabelText("Microphone source")).toHaveValue("cpal:1:usb");
     expect(screen.getByLabelText("A4 reference tuning")).toHaveValue(442.5);
     expect(screen.getByText("Saved microphone")).toBeInTheDocument();
     expect(screen.getByText("442.5 Hz")).toBeInTheDocument();
@@ -93,18 +106,57 @@ describe("Desktop app tools tuner", () => {
     expect(systemInputVolume).toBeEnabled();
     expect(systemInputVolume).toHaveValue("87");
     expect(getMockInvoke()).not.toHaveBeenCalledWith("set_system_default_input_volume", {
+      deviceId: null,
       volumePercent: 83,
     });
     fireEvent.pointerUp(systemInputVolume);
 
     await waitFor(() =>
       expect(getMockInvoke()).toHaveBeenCalledWith("set_system_default_input_volume", {
+        deviceId: null,
         volumePercent: 87,
       }),
     );
     expect(getMockInvoke()).not.toHaveBeenCalledWith("set_system_default_input_volume", {
+      deviceId: null,
       volumePercent: 84,
     });
+  });
+
+  it("controls the selected native microphone volume", async () => {
+    const user = userEvent.setup();
+    setMockNativeAudioState({
+      capabilities: {
+        micCaptureSupported: true,
+        backend: "desktop-cpal",
+      },
+      inputDevices: {
+        supported: true,
+        devices: [{ id: "cpal:0:built-in", label: "Built-in Microphone", isDefault: false }],
+        error: null,
+      },
+    });
+    renderApp(["/tools"]);
+
+    expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText("Microphone source"), "cpal:0:built-in");
+
+    const selectedInputVolume = await screen.findByLabelText("Selected input volume");
+    fireEvent.change(selectedInputVolume, { target: { value: "72" } });
+    fireEvent.pointerUp(selectedInputVolume);
+
+    await waitFor(() =>
+      expect(getMockInvoke()).toHaveBeenCalledWith("get_system_default_input_volume", {
+        deviceId: "cpal:0:built-in",
+      }),
+    );
+    await waitFor(() =>
+      expect(getMockInvoke()).toHaveBeenCalledWith("set_system_default_input_volume", {
+        deviceId: "cpal:0:built-in",
+        volumePercent: 72,
+      }),
+    );
+    expect(await screen.findByText("Controls the selected microphone.")).toBeInTheDocument();
   });
 
   it("shows unsupported system microphone volume state", async () => {
@@ -138,21 +190,21 @@ describe("Desktop app tools tuner", () => {
     expect(screen.getByLabelText("A4 reference tuning")).toHaveValue(440);
   });
 
-  it("starts microphone capture with the selected source and stops cleanly", async () => {
+  it("starts Web Audio capture with the system default source and stops cleanly", async () => {
     const user = userEvent.setup();
     getMockMediaDevices().revealLabels();
     renderApp(["/tools"]);
 
     expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
-    expect(await screen.findByRole("option", { name: "USB Interface" })).toBeInTheDocument();
-    await user.selectOptions(screen.getByLabelText("Microphone source"), "usb");
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: "USB Interface" })).toBeDisabled(),
+    );
     await user.click(screen.getByRole("button", { name: "Start" }));
 
     await waitFor(() => expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument());
     expect(getMockMediaDevices().getUserMedia).toHaveBeenCalledWith({
       audio: {
         autoGainControl: false,
-        deviceId: { exact: "usb" },
         echoCancellation: false,
         noiseSuppression: false,
       },
@@ -165,6 +217,187 @@ describe("Desktop app tools tuner", () => {
     expect(screen.getByRole("button", { name: "Start" })).toBeEnabled();
   });
 
+  it("uses native microphone capture when available", async () => {
+    const user = userEvent.setup();
+    setMockNativeAudioState({
+      capabilities: {
+        micCaptureSupported: true,
+        backend: "desktop-cpal",
+      },
+      inputDevices: {
+        supported: true,
+        devices: [
+          { id: "cpal:0:built-in", label: "Built-in Microphone", isDefault: true },
+          { id: "cpal:1:usb", label: "USB Interface", isDefault: false },
+        ],
+        error: null,
+      },
+    });
+    renderApp(["/tools"]);
+
+    expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    expect(await screen.findByRole("option", { name: "USB Interface" })).toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText("Microphone source"), "cpal:1:usb");
+    await user.click(screen.getByRole("button", { name: "Start" }));
+
+    await waitFor(() =>
+      expect(getMockInvoke()).toHaveBeenCalledWith("audio_start_input", {
+        payload: { deviceId: "cpal:1:usb" },
+      }),
+    );
+    expect(window.localStorage.getItem("tuneforge.tuner-input-capture-backend")).toContain(
+      "desktop-cpal",
+    );
+    expect(getMockMediaDevices().getUserMedia).not.toHaveBeenCalled();
+
+    emitMockNativeInputFrame({
+      deviceId: "cpal:1:usb",
+      sampleRate: 48000,
+      inputLevel: 0.25,
+      samples: makeSineSamples(440, 48000, 2048),
+      timestampMs: 1000,
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole("meter", { name: "Input signal level" })).toHaveAttribute(
+        "aria-valuenow",
+        "50",
+      ),
+    );
+    expect(screen.getByTestId("simple-tuner-meter")).not.toHaveAttribute(
+      "data-tuning-state",
+      "no-pitch",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Stop" }));
+
+    expect(getMockInvoke()).toHaveBeenCalledWith("audio_stop_input");
+  });
+
+  it("can force Web Audio capture when native capture is available", async () => {
+    const user = userEvent.setup();
+    vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
+    getMockMediaDevices().revealLabels();
+    setMockNativeAudioState({
+      capabilities: {
+        micCaptureSupported: true,
+        backend: "desktop-cpal",
+      },
+      inputDevices: {
+        supported: true,
+        devices: [{ id: "cpal:1:usb", label: "Native USB Interface", isDefault: false }],
+        error: null,
+      },
+    });
+    renderApp(["/tools"]);
+
+    expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: "USB Interface" })).toBeDisabled(),
+    );
+    expect(screen.queryByRole("option", { name: "Native USB Interface" })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Start" }));
+
+    await waitFor(() =>
+      expect(getMockMediaDevices().getUserMedia).toHaveBeenCalledWith({
+        audio: {
+          autoGainControl: false,
+          echoCancellation: false,
+          noiseSuppression: false,
+        },
+        video: false,
+      }),
+    );
+    expect(getMockInvoke()).not.toHaveBeenCalledWith("audio_get_capabilities");
+    expect(getMockInvoke()).not.toHaveBeenCalledWith("audio_list_input_devices");
+    expect(getMockInvoke()).not.toHaveBeenCalledWith("audio_start_input", expect.anything());
+    expect(window.localStorage.getItem("tuneforge.tuner-input-capture-backend")).toContain(
+      '"web"',
+    );
+  });
+
+  it("falls back to Web Audio when native capture fails", async () => {
+    const user = userEvent.setup();
+    getMockMediaDevices().revealLabels();
+    setMockNativeAudioState({
+      capabilities: {
+        micCaptureSupported: true,
+        backend: "desktop-cpal",
+      },
+      inputDevices: {
+        supported: true,
+        devices: [{ id: "cpal:1:usb", label: "USB Interface", isDefault: false }],
+        error: null,
+      },
+      startError: "Native microphone failed.",
+    });
+    renderApp(["/tools"]);
+
+    expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Start" }));
+
+    await waitFor(() =>
+      expect(getMockMediaDevices().getUserMedia).toHaveBeenCalledWith({
+        audio: {
+          autoGainControl: false,
+          echoCancellation: false,
+          noiseSuppression: false,
+        },
+        video: false,
+      }),
+    );
+    expect(screen.queryByText("Native microphone failed.")).not.toBeInTheDocument();
+    expect(window.localStorage.getItem("tuneforge.tuner-native-capture-error")).toBe(
+      "Native microphone failed.",
+    );
+    expect(window.localStorage.getItem("tuneforge.tuner-input-capture-backend")).toContain(
+      '"web"',
+    );
+    expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
+  });
+
+  it("falls back to system-default Web Audio when a native microphone selection fails", async () => {
+    const user = userEvent.setup();
+    getMockMediaDevices().revealLabels();
+    setMockNativeAudioState({
+      capabilities: {
+        micCaptureSupported: true,
+        backend: "desktop-cpal",
+      },
+      inputDevices: {
+        supported: true,
+        devices: [{ id: "cpal:0:built-in", label: "Built-in Microphone", isDefault: false }],
+        error: null,
+      },
+      startError: "Native microphone failed.",
+    });
+    renderApp(["/tools"]);
+
+    expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    expect(await screen.findByRole("option", { name: "Built-in Microphone" })).toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText("Microphone source"), "cpal:0:built-in");
+    await user.click(screen.getByRole("button", { name: "Start" }));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument());
+    expect(screen.queryByText("Native microphone failed.")).not.toBeInTheDocument();
+    expect(getMockMediaDevices().getUserMedia).toHaveBeenCalledWith({
+      audio: {
+        autoGainControl: false,
+        echoCancellation: false,
+        noiseSuppression: false,
+      },
+      video: false,
+    });
+    expect(screen.getByLabelText("Microphone source")).toHaveValue("");
+    expect(screen.getByRole("option", { name: "Built-in Microphone" })).toBeDisabled();
+    expect(window.localStorage.getItem("tuneforge.tuner-native-capture-error")).toBe(
+      "Native microphone failed.",
+    );
+    expect(window.localStorage.getItem("tuneforge.tuner-input-capture-backend")).toContain(
+      '"web"',
+    );
+  });
+
   it("uses cached device labels before start without opening capture", async () => {
     window.localStorage.setItem(
       "tuneforge.tuner-microphone-devices",
@@ -174,7 +407,7 @@ describe("Desktop app tools tuner", () => {
     renderApp(["/tools"]);
 
     expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
-    expect(await screen.findByRole("option", { name: "USB Interface" })).toBeInTheDocument();
+    expect(await screen.findByRole("option", { name: "USB Interface" })).toBeDisabled();
     expect(getMockMediaDevices().getUserMedia).not.toHaveBeenCalled();
   });
 
@@ -215,4 +448,10 @@ function changeReferenceInput(value: string) {
   const input = screen.getByLabelText("A4 reference tuning");
   fireEvent.change(input, { target: { value } });
   fireEvent.blur(input);
+}
+
+function makeSineSamples(frequencyHz: number, sampleRate: number, sampleCount: number) {
+  return Array.from({ length: sampleCount }, (_, index) =>
+    Math.sin((2 * Math.PI * frequencyHz * index) / sampleRate) * 0.5,
+  );
 }

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -3,6 +3,11 @@ import { useQuery } from "@tanstack/react-query";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { Link } from "react-router-dom";
 import { api, type ChordBackendSchema } from "../../lib/api";
+import {
+  getNativeAudioCapabilities,
+  isWebAudioBackendForced,
+  type NativeAudioCapabilities,
+} from "../../lib/nativeAudio";
 import { TunerPreferenceControls } from "../tools/TunerPreferenceControls";
 import {
   usePreferences,
@@ -23,6 +28,11 @@ import {
   useTheme,
   type ThemePreference,
 } from "../../lib/theme";
+import {
+  readRememberedTunerInputCaptureBackend,
+  readRememberedTunerNativeCaptureError,
+  type TunerInputCaptureBackend,
+} from "../tools/tunerMicrophoneAccess";
 
 type ChoiceOption<T extends string> = {
   disabled?: boolean;
@@ -196,6 +206,41 @@ function tunerInputDeviceLabel(value: string | null) {
   return value ? "Saved microphone" : "System Default";
 }
 
+function inputCaptureBackendLabel(
+  capabilities: NativeAudioCapabilities | undefined,
+  webAudioForced: boolean,
+) {
+  if (webAudioForced) {
+    return "Web Audio (forced)";
+  }
+  if (!capabilities) {
+    return "Unknown";
+  }
+  return capabilities.micCaptureSupported ? `Native (${capabilities.backend})` : "Web Audio";
+}
+
+function playbackBackendLabel(
+  capabilities: NativeAudioCapabilities | undefined,
+  webAudioForced: boolean,
+) {
+  if (webAudioForced) {
+    return "Web Audio (forced)";
+  }
+  if (!capabilities) {
+    return "Unknown";
+  }
+  return capabilities.nativePlaybackSupported ? `Native (${capabilities.backend})` : "Web Audio";
+}
+
+function lastInputCaptureBackendLabel(backend: TunerInputCaptureBackend | null) {
+  if (!backend) {
+    return "Not started";
+  }
+  return backend.backend === "native"
+    ? `Native (${backend.detail ?? "unknown"})`
+    : "Web Audio";
+}
+
 function chordBackendOptions(backends: ChordBackendSchema[] | undefined): ChoiceOption<DefaultChordBackend>[] {
   if (!backends?.length) {
     return fallbackChordBackendOptions;
@@ -321,6 +366,7 @@ export function SettingsView() {
   } = usePreferences();
   const [isSnapshotBusy, setIsSnapshotBusy] = useState(false);
   const [snapshotStatus, setSnapshotStatus] = useState<SnapshotStatus | null>(null);
+  const webAudioForced = isWebAudioBackendForced();
   const healthQuery = useQuery({
     queryKey: ["health"],
     queryFn: api.getHealth,
@@ -329,6 +375,13 @@ export function SettingsView() {
     queryKey: ["chord-backends"],
     queryFn: api.listChordBackends,
   });
+  const nativeAudioQuery = useQuery({
+    queryKey: ["native-audio-capabilities", webAudioForced],
+    queryFn: getNativeAudioCapabilities,
+    enabled: !webAudioForced,
+  });
+  const lastInputCaptureBackend = readRememberedTunerInputCaptureBackend();
+  const lastNativeCaptureError = readRememberedTunerNativeCaptureError();
   const savedThemeOverrideCount = themeOverrideCount(themeOverrides);
   const chordBackendChoices = chordBackendOptions(chordBackendsQuery.data?.backends);
 
@@ -570,9 +623,11 @@ export function SettingsView() {
 
           <TunerPreferenceControls
             inputDeviceId={defaultTunerInputDeviceId}
+            nativeCaptureDisabled={webAudioForced}
             onInputDeviceChange={setDefaultTunerInputDeviceId}
             onReferenceHzChange={setDefaultTunerReferenceHz}
             referenceHz={defaultTunerReferenceHz}
+            systemDefaultOnly={webAudioForced}
           />
 
           <div className="button-row">
@@ -707,6 +762,22 @@ export function SettingsView() {
             <div>
               <dt>Default Export Format</dt>
               <dd>{healthQuery.data?.default_export_format ?? "wav"}</dd>
+            </div>
+            <div>
+              <dt>Input Capture Available</dt>
+              <dd>{inputCaptureBackendLabel(nativeAudioQuery.data, webAudioForced)}</dd>
+            </div>
+            <div>
+              <dt>Last Tuner Capture</dt>
+              <dd>{lastInputCaptureBackendLabel(lastInputCaptureBackend)}</dd>
+            </div>
+            <div>
+              <dt>Last Native Capture Error</dt>
+              <dd>{lastNativeCaptureError ?? "None"}</dd>
+            </div>
+            <div>
+              <dt>Playback Backend</dt>
+              <dd>{playbackBackendLabel(nativeAudioQuery.data, webAudioForced)}</dd>
             </div>
           </dl>
         </details>

--- a/apps/desktop/src/features/tools/ToolsView.tsx
+++ b/apps/desktop/src/features/tools/ToolsView.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
+import {
+  getNativeAudioCapabilities,
+  isWebAudioBackendForced,
+  listenNativeAudioInputFrames,
+  startNativeAudioInput,
+  stopNativeAudioInput,
+  type NativeAudioCapabilities,
+  type NativeAudioInputFrame,
+} from "../../lib/nativeAudio";
 import { useStableCallback } from "../../lib/useStableCallback";
 import { usePreferences } from "../../lib/preferences";
 import { MetronomePage } from "./MetronomePage";
@@ -21,9 +30,12 @@ import {
   updateStabilizedTunerReading,
 } from "./tunerReadingSmoothing";
 import {
+  clearRememberedTunerNativeCaptureError,
   forgetTunerMicrophoneAccessGranted,
+  rememberTunerInputCaptureBackend,
   rememberTunerMicrophoneDevices,
   rememberTunerMicrophoneAccessGranted,
+  rememberTunerNativeCaptureError,
   toVisibleTunerMicrophoneDevices,
 } from "./tunerMicrophoneAccess";
 import {
@@ -36,6 +48,7 @@ const SYSTEM_INPUT_VOLUME_COMMIT_DELAY_MS = 180;
 
 type TunerStatus = "idle" | "starting" | "listening" | "unsupported" | "error";
 type ToolId = "tuner" | "metronome";
+type CaptureBackend = "native" | "web";
 
 type AudioContextConstructor = typeof AudioContext;
 
@@ -103,10 +116,14 @@ function ChromaticTunerPage() {
     setDefaultTunerReferenceHz,
   } = usePreferences();
   const [status, setStatus] = useState<TunerStatus>(() =>
-    canUseTunerCapture() ? "idle" : "unsupported",
+    canUseTunerCapture(null) ? "idle" : "unsupported",
   );
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [inputLevel, setInputLevel] = useState(0);
+  const [activeCaptureBackend, setActiveCaptureBackend] = useState<CaptureBackend | null>(null);
+  const [nativeAudioCapabilities, setNativeAudioCapabilities] =
+    useState<NativeAudioCapabilities | null>(null);
+  const webAudioForced = isWebAudioBackendForced();
   const [reading, setReading] = useState<TunerPitchReading | null>(null);
   const [deviceRefreshToken, setDeviceRefreshToken] = useState(0);
   const [systemInputVolumeRefreshToken, setSystemInputVolumeRefreshToken] = useState(0);
@@ -116,6 +133,8 @@ function ChromaticTunerPage() {
   const frameIdRef = useRef<number | null>(null);
   const inputDeviceIdRef = useRef(defaultTunerInputDeviceId);
   const mediaSourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
+  const nativeCaptureActiveRef = useRef(false);
+  const nativeInputUnlistenRef = useRef<(() => void) | null>(null);
   const referenceHzRef = useRef(defaultTunerReferenceHz);
   const requestIdRef = useRef(0);
   const readingStabilizerRef = useRef(createStabilizedTunerReadingState());
@@ -135,10 +154,54 @@ function ChromaticTunerPage() {
     statusRef.current = status;
   }, [status]);
 
+  useEffect(() => {
+    let active = true;
+
+    async function refreshNativeAudioCapabilities() {
+      if (webAudioForced) {
+        setNativeAudioCapabilities(null);
+        if (statusRef.current === "unsupported" && canUseTunerCapture(null)) {
+          setStatus("idle");
+          setErrorMessage(null);
+        }
+        return;
+      }
+
+      try {
+        const capabilities = await getNativeAudioCapabilities();
+        if (!active) {
+          return;
+        }
+        setNativeAudioCapabilities(capabilities);
+        if (capabilities.micCaptureSupported && statusRef.current === "unsupported") {
+          setStatus("idle");
+          setErrorMessage(null);
+        }
+      } catch {
+        if (active) {
+          setNativeAudioCapabilities(null);
+        }
+      }
+    }
+
+    void refreshNativeAudioCapabilities();
+    return () => {
+      active = false;
+    };
+  }, [webAudioForced]);
+
   const releaseCapture = useStableCallback(function releaseCapture() {
     if (frameIdRef.current !== null) {
       window.cancelAnimationFrame(frameIdRef.current);
       frameIdRef.current = null;
+    }
+    setActiveCaptureBackend(null);
+
+    nativeInputUnlistenRef.current?.();
+    nativeInputUnlistenRef.current = null;
+    if (nativeCaptureActiveRef.current) {
+      nativeCaptureActiveRef.current = false;
+      void stopNativeAudioInput().catch(() => undefined);
     }
 
     try {
@@ -167,6 +230,23 @@ function ChromaticTunerPage() {
     setReading(null);
   });
 
+  const processTunerSamples = useStableCallback(function processTunerSamples(
+    samples: Float32Array<ArrayBufferLike>,
+    sampleRate: number,
+    inputLevel: number,
+    timestampMs: number,
+  ) {
+    setInputLevel(inputLevel);
+    const rawReading = analyzeTunerBuffer(samples, sampleRate, referenceHzRef.current);
+    const stabilizedState = updateStabilizedTunerReading(
+      readingStabilizerRef.current,
+      rawReading,
+      timestampMs,
+    );
+    readingStabilizerRef.current = stabilizedState;
+    setReading(stabilizedState.displayedReading);
+  });
+
   const readTunerFrame = useStableCallback(function readTunerFrame(timestampMs?: number) {
     const analyser = analyserRef.current;
     const audioContext = audioContextRef.current;
@@ -179,31 +259,126 @@ function ChromaticTunerPage() {
     }
 
     analyser.getFloatTimeDomainData(timeDomainDataRef.current);
-    setInputLevel(calculateTunerInputLevel(timeDomainDataRef.current));
-    const rawReading = analyzeTunerBuffer(
+    processTunerSamples(
       timeDomainDataRef.current,
       audioContext.sampleRate,
-      referenceHzRef.current,
-    );
-    const stabilizedState = updateStabilizedTunerReading(
-      readingStabilizerRef.current,
-      rawReading,
+      calculateTunerInputLevel(timeDomainDataRef.current),
       timestampMs ?? getCurrentTunerTimeMs(),
     );
-    readingStabilizerRef.current = stabilizedState;
-    setReading(stabilizedState.displayedReading);
     frameIdRef.current = window.requestAnimationFrame(readTunerFrame);
   });
 
-  const startTuner = useStableCallback(async function startTuner(nextDeviceId?: string | null) {
+  const resolveNativeAudioCapabilities = useStableCallback(async function resolveNativeAudioCapabilities() {
+    if (webAudioForced) {
+      setNativeAudioCapabilities(null);
+      return null;
+    }
+    if (nativeAudioCapabilities) {
+      return nativeAudioCapabilities;
+    }
+    try {
+      const capabilities = await getNativeAudioCapabilities();
+      setNativeAudioCapabilities(capabilities);
+      return capabilities;
+    } catch {
+      setNativeAudioCapabilities(null);
+      return null;
+    }
+  });
+
+  const handleNativeInputFrame = useStableCallback(function handleNativeInputFrame(
+    frame: NativeAudioInputFrame,
+  ) {
+    if (!nativeCaptureActiveRef.current || frame.sampleRate <= 0 || frame.samples.length === 0) {
+      return;
+    }
+    processTunerSamples(
+      new Float32Array(frame.samples),
+      frame.sampleRate,
+      frame.inputLevel,
+      frame.timestampMs,
+    );
+  });
+
+  const startNativeTuner = useStableCallback(async function startNativeTuner(
+    deviceId: string | null,
+    requestId: number,
+    backend: string | null,
+  ) {
+    const unlisten = await listenNativeAudioInputFrames(handleNativeInputFrame);
+    if (requestIdRef.current !== requestId) {
+      unlisten();
+      return;
+    }
+    nativeInputUnlistenRef.current = unlisten;
+    const inputState = await startNativeAudioInput({ deviceId });
+    nativeCaptureActiveRef.current = inputState.active;
+    if (requestIdRef.current !== requestId) {
+      releaseCapture();
+      return;
+    }
+    if (inputState.deviceId) {
+      inputDeviceIdRef.current = deviceId;
+    }
+    rememberTunerMicrophoneAccessGranted();
+    rememberTunerInputCaptureBackend({
+      backend: "native",
+      detail: backend,
+    });
+    clearRememberedTunerNativeCaptureError();
+    setActiveCaptureBackend("native");
+    setDeviceRefreshToken(Date.now());
+    setStatus("listening");
+  });
+
+  const startWebTuner = useStableCallback(async function startWebTuner(
+    _nextDeviceId: string | null,
+    requestId: number,
+  ) {
     const AudioContextCtor = getAudioContextConstructor();
     const mediaDevices = getMediaDevices();
     if (!AudioContextCtor || !mediaDevices) {
-      setStatus("unsupported");
-      setErrorMessage("Microphone capture is unavailable.");
+      throw new Error("Microphone capture is unavailable.");
+    }
+
+    const stream = await mediaDevices.getUserMedia(createAudioConstraints());
+    if (requestIdRef.current !== requestId) {
+      stream.getTracks().forEach((track) => track.stop());
       return;
     }
 
+    const audioContext = new AudioContextCtor();
+    const analyser = audioContext.createAnalyser();
+    analyser.fftSize = 2048;
+    analyser.smoothingTimeConstant = 0.12;
+
+    const mediaSource = audioContext.createMediaStreamSource(stream);
+    mediaSource.connect(analyser);
+
+    streamRef.current = stream;
+    audioContextRef.current = audioContext;
+    analyserRef.current = analyser;
+    mediaSourceRef.current = mediaSource;
+
+    if (audioContext.state === "suspended") {
+      await audioContext.resume();
+    }
+
+    if (requestIdRef.current !== requestId) {
+      releaseCapture();
+      return;
+    }
+
+    rememberTunerMicrophoneAccessGranted();
+    rememberTunerInputCaptureBackend({ backend: "web", detail: null });
+    await rememberVisibleAudioInputDevices(mediaDevices);
+    setActiveCaptureBackend("web");
+    setDeviceRefreshToken(Date.now());
+    setStatus("listening");
+    readTunerFrame();
+  });
+
+  const startTuner = useStableCallback(async function startTuner(nextDeviceId?: string | null) {
     releaseCapture();
     setErrorMessage(null);
     resetTunerDisplay();
@@ -212,43 +387,29 @@ function ChromaticTunerPage() {
 
     const requestId = requestIdRef.current + 1;
     requestIdRef.current = requestId;
+    const selectedDeviceId = nextDeviceId ?? inputDeviceIdRef.current;
+    const selectedNativeDevice = isNativeAudioInputDeviceId(selectedDeviceId);
+    const nativeCapabilities = await resolveNativeAudioCapabilities();
+
+    if (!webAudioForced && nativeCapabilities?.micCaptureSupported) {
+      try {
+        await startNativeTuner(selectedDeviceId, requestId, nativeCapabilities.backend);
+        return;
+      } catch (error) {
+        rememberTunerNativeCaptureError(captureErrorMessage(error));
+        if (requestIdRef.current !== requestId) {
+          return;
+        }
+        releaseCapture();
+      }
+    } else if (!webAudioForced && selectedNativeDevice) {
+      rememberTunerNativeCaptureError(
+        "Selected microphone requires native input capture, but native capture is unavailable.",
+      );
+    }
 
     try {
-      const stream = await mediaDevices.getUserMedia(
-        createAudioConstraints(nextDeviceId ?? inputDeviceIdRef.current),
-      );
-      if (requestIdRef.current !== requestId) {
-        stream.getTracks().forEach((track) => track.stop());
-        return;
-      }
-
-      const audioContext = new AudioContextCtor();
-      const analyser = audioContext.createAnalyser();
-      analyser.fftSize = 2048;
-      analyser.smoothingTimeConstant = 0.12;
-
-      const mediaSource = audioContext.createMediaStreamSource(stream);
-      mediaSource.connect(analyser);
-
-      streamRef.current = stream;
-      audioContextRef.current = audioContext;
-      analyserRef.current = analyser;
-      mediaSourceRef.current = mediaSource;
-
-      if (audioContext.state === "suspended") {
-        await audioContext.resume();
-      }
-
-      if (requestIdRef.current !== requestId) {
-        releaseCapture();
-        return;
-      }
-
-      rememberTunerMicrophoneAccessGranted();
-      await rememberVisibleAudioInputDevices(mediaDevices);
-      setDeviceRefreshToken(Date.now());
-      setStatus("listening");
-      readTunerFrame();
+      await startWebTuner(selectedDeviceId, requestId);
     } catch (error) {
       if (requestIdRef.current !== requestId) {
         return;
@@ -267,7 +428,11 @@ function ChromaticTunerPage() {
     releaseCapture();
     setErrorMessage(null);
     resetTunerDisplay();
-    setStatus(canUseTunerCapture() ? "idle" : "unsupported");
+    setStatus(
+      canUseTunerCapture(webAudioForced ? null : nativeAudioCapabilities)
+        ? "idle"
+        : "unsupported",
+    );
   });
 
   useEffect(
@@ -298,8 +463,19 @@ function ChromaticTunerPage() {
 
   const isBusy = status === "starting";
   const isListening = status === "listening";
-  const canStart = canUseTunerCapture() && !isBusy && !isListening;
+  const canStart =
+    canUseTunerCapture(webAudioForced ? null : nativeAudioCapabilities) && !isBusy && !isListening;
   const statusText = headerStatusLabel(status, reading);
+  const systemDefaultInputOnly =
+    webAudioForced ||
+    activeCaptureBackend === "web" ||
+    nativeAudioCapabilities?.micCaptureSupported === false;
+  const inputVolumeDeviceId =
+    webAudioForced ||
+    activeCaptureBackend === "web" ||
+    !isNativeAudioInputDeviceId(defaultTunerInputDeviceId)
+      ? null
+      : defaultTunerInputDeviceId;
 
   return (
     <div className="tuner-shell">
@@ -316,10 +492,12 @@ function ChromaticTunerPage() {
         <TunerPreferenceControls
           className="tuner-preferences--with-mode"
           inputDeviceId={defaultTunerInputDeviceId}
+          nativeCaptureDisabled={webAudioForced}
           onInputDeviceChange={handleInputDeviceChange}
           onReferenceHzChange={handleReferenceHzChange}
           referenceHz={defaultTunerReferenceHz}
           refreshToken={deviceRefreshToken}
+          systemDefaultOnly={systemDefaultInputOnly}
         >
           <label className="tuner-field">
             <span>Visual mode</span>
@@ -334,7 +512,10 @@ function ChromaticTunerPage() {
           </label>
         </TunerPreferenceControls>
 
-        <SystemInputVolumeControl refreshToken={systemInputVolumeRefreshToken} />
+        <SystemInputVolumeControl
+          deviceId={inputVolumeDeviceId}
+          refreshToken={systemInputVolumeRefreshToken}
+        />
 
         {errorMessage ? <p className="inline-error">{errorMessage}</p> : null}
 
@@ -397,7 +578,13 @@ function TunerHeader({
   );
 }
 
-function SystemInputVolumeControl({ refreshToken }: { refreshToken: number }) {
+function SystemInputVolumeControl({
+  deviceId,
+  refreshToken,
+}: {
+  deviceId: string | null;
+  refreshToken: number;
+}) {
   const [volumeState, setVolumeState] = useState<SystemDefaultInputVolume | null>(null);
   const [draftVolume, setDraftVolume] = useState(0);
   const [isSetting, setIsSetting] = useState(false);
@@ -407,7 +594,7 @@ function SystemInputVolumeControl({ refreshToken }: { refreshToken: number }) {
 
   const refreshVolume = useStableCallback(async function refreshVolume() {
     try {
-      const nextState = await getSystemDefaultInputVolume();
+      const nextState = await getSystemDefaultInputVolume(deviceId);
       setVolumeState(nextState);
       if (typeof nextState.volumePercent === "number") {
         setDraftVolume(nextState.volumePercent);
@@ -425,8 +612,13 @@ function SystemInputVolumeControl({ refreshToken }: { refreshToken: number }) {
   });
 
   useEffect(() => {
+    volumeSetRequestIdRef.current += 1;
+    if (volumeCommitTimeoutRef.current !== null) {
+      window.clearTimeout(volumeCommitTimeoutRef.current);
+      volumeCommitTimeoutRef.current = null;
+    }
     void refreshVolume();
-  }, [refreshToken, refreshVolume]);
+  }, [deviceId, refreshToken, refreshVolume]);
 
   useEffect(() => {
     return () => {
@@ -450,14 +642,15 @@ function SystemInputVolumeControl({ refreshToken }: { refreshToken: number }) {
   }, [refreshVolume]);
 
   const supported = Boolean(volumeState?.supported && typeof volumeState.volumePercent === "number");
-  const statusText = systemInputVolumeStatus(volumeState, isSetting);
+  const hasDeviceTarget = Boolean(deviceId);
+  const statusText = systemInputVolumeStatus(volumeState, isSetting, hasDeviceTarget);
 
   const commitVolume = useStableCallback(async function commitVolume(volume: number) {
     const requestId = volumeSetRequestIdRef.current + 1;
     volumeSetRequestIdRef.current = requestId;
     setIsSetting(true);
     try {
-      const nextState = await setSystemDefaultInputVolume(volume);
+      const nextState = await setSystemDefaultInputVolume(volume, deviceId);
       if (volumeSetRequestIdRef.current !== requestId) {
         return;
       }
@@ -513,12 +706,12 @@ function SystemInputVolumeControl({ refreshToken }: { refreshToken: number }) {
   return (
     <div className="tuner-system-volume">
       <label className="tuner-field">
-        <span className="tuner-field__label-row">
-          <span>System input volume</span>
+          <span className="tuner-field__label-row">
+          <span>{hasDeviceTarget ? "Selected input volume" : "System input volume"}</span>
           {supported ? <strong>{draftVolume}%</strong> : null}
         </span>
         <input
-          aria-label="System input volume"
+          aria-label={hasDeviceTarget ? "Selected input volume" : "System input volume"}
           disabled={!supported}
           max={100}
           min={0}
@@ -539,20 +732,28 @@ function SystemInputVolumeControl({ refreshToken }: { refreshToken: number }) {
 function systemInputVolumeStatus(
   volumeState: SystemDefaultInputVolume | null,
   isSetting: boolean,
+  hasDeviceTarget: boolean,
 ) {
   if (isSetting) {
-    return "Updating system input volume.";
+    return hasDeviceTarget ? "Updating selected input volume." : "Updating system input volume.";
   }
   if (!volumeState) {
-    return "Checking system input volume.";
+    return hasDeviceTarget ? "Checking selected input volume." : "Checking system input volume.";
   }
   if (!volumeState.supported) {
-    return volumeState.error ?? "System input volume control is unavailable.";
+    return (
+      volumeState.error ??
+      (hasDeviceTarget
+        ? "Selected input volume control is unavailable."
+        : "System input volume control is unavailable.")
+    );
   }
   if (volumeState.muted) {
-    return "Default microphone is muted.";
+    return hasDeviceTarget ? "Selected microphone is muted." : "Default microphone is muted.";
   }
-  return "Controls the operating system default microphone.";
+  return hasDeviceTarget
+    ? "Controls the selected microphone."
+    : "Controls the operating system default microphone.";
 }
 
 function getAudioContextConstructor(): AudioContextConstructor | null {
@@ -577,8 +778,8 @@ function getMediaDevices() {
   return navigator.mediaDevices;
 }
 
-function canUseTunerCapture() {
-  return Boolean(getAudioContextConstructor() && getMediaDevices());
+function canUseTunerCapture(nativeAudioCapabilities: NativeAudioCapabilities | null) {
+  return Boolean(nativeAudioCapabilities?.micCaptureSupported || (getAudioContextConstructor() && getMediaDevices()));
 }
 
 async function rememberVisibleAudioInputDevices(mediaDevices: MediaDevices) {
@@ -593,19 +794,23 @@ async function rememberVisibleAudioInputDevices(mediaDevices: MediaDevices) {
   }
 }
 
-function createAudioConstraints(inputDeviceId: string | null): MediaStreamConstraints {
+function createAudioConstraints(): MediaStreamConstraints {
   const audio: MediaTrackConstraints = {
     autoGainControl: false,
     echoCancellation: false,
     noiseSuppression: false,
   };
-  if (inputDeviceId) {
-    audio.deviceId = { exact: inputDeviceId };
-  }
   return { audio, video: false };
 }
 
+function isNativeAudioInputDeviceId(inputDeviceId: string | null) {
+  return inputDeviceId?.startsWith("cpal:") ?? false;
+}
+
 function captureErrorMessage(error: unknown) {
+  if (typeof error === "string" && error.trim()) {
+    return error;
+  }
   if (error instanceof DOMException) {
     if (isMicrophonePermissionError(error)) {
       return "Microphone permission was denied.";

--- a/apps/desktop/src/features/tools/TunerPreferenceControls.tsx
+++ b/apps/desktop/src/features/tools/TunerPreferenceControls.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import {
+  getNativeAudioCapabilities,
+  listNativeAudioInputDevices,
+} from "../../lib/nativeAudio";
+import {
   MAX_TUNER_REFERENCE_HZ,
   MIN_TUNER_REFERENCE_HZ,
   normalizeTunerReferenceHz,
@@ -16,20 +20,26 @@ type TunerPreferenceControlsProps = {
   children?: ReactNode;
   className?: string;
   inputDeviceId: string | null;
+  nativeCaptureDisabled?: boolean;
   onInputDeviceChange: (value: string | null) => void;
   onReferenceHzChange: (value: number) => void;
   referenceHz: number;
   refreshToken?: number;
+  systemDefaultOnly?: boolean;
 };
+
+const NATIVE_DEVICE_REFRESH_INTERVAL_MS = 5000;
 
 export function TunerPreferenceControls({
   children,
   className,
   inputDeviceId,
+  nativeCaptureDisabled = false,
   onInputDeviceChange,
   onReferenceHzChange,
   referenceHz,
   refreshToken = 0,
+  systemDefaultOnly = false,
 }: TunerPreferenceControlsProps) {
   const [devices, setDevices] = useState<TunerMicrophoneDevice[]>([]);
   const [deviceError, setDeviceError] = useState<string | null>(null);
@@ -45,17 +55,13 @@ export function TunerPreferenceControls({
   }, [isReferenceFocused, referenceHz]);
 
   useEffect(() => {
-    if (!canEnumerateDevices) {
-      setDevices([]);
-      setDeviceError("Microphone list unavailable.");
-      return undefined;
-    }
-
     let active = true;
 
     async function refreshDevices() {
       try {
-        const availableDevices = await enumerateAudioInputDevices();
+        const availableDevices = await enumerateTunerInputDevices({
+          includeNativeDevices: !nativeCaptureDisabled,
+        });
         if (!active) {
           return;
         }
@@ -70,18 +76,33 @@ export function TunerPreferenceControls({
     }
 
     void refreshDevices();
-    navigator.mediaDevices.addEventListener?.("devicechange", refreshDevices);
+    const refreshIntervalId = window.setInterval(
+      refreshDevices,
+      NATIVE_DEVICE_REFRESH_INTERVAL_MS,
+    );
+    if (canEnumerateDevices) {
+      navigator.mediaDevices?.addEventListener?.("devicechange", refreshDevices);
+    }
 
     return () => {
       active = false;
-      navigator.mediaDevices.removeEventListener?.("devicechange", refreshDevices);
+      window.clearInterval(refreshIntervalId);
+      if (canEnumerateDevices) {
+        navigator.mediaDevices?.removeEventListener?.("devicechange", refreshDevices);
+      }
     };
-  }, [canEnumerateDevices, refreshToken]);
+  }, [canEnumerateDevices, nativeCaptureDisabled, refreshToken]);
 
   const selectedDeviceMissing = useMemo(
-    () => Boolean(inputDeviceId && !devices.some((device) => device.deviceId === inputDeviceId)),
-    [devices, inputDeviceId],
+    () =>
+      Boolean(
+        !systemDefaultOnly &&
+          inputDeviceId &&
+          !devices.some((device) => device.deviceId === inputDeviceId),
+      ),
+    [devices, inputDeviceId, systemDefaultOnly],
   );
+  const selectedInputDeviceId = systemDefaultOnly ? "" : inputDeviceId ?? "";
 
   function commitReferenceDraft() {
     const normalizedReferenceHz = normalizeTunerReferenceHz(referenceDraft);
@@ -103,13 +124,23 @@ export function TunerPreferenceControls({
         <span>Microphone source</span>
         <select
           aria-label="Microphone source"
-          onChange={(event) => onInputDeviceChange(event.target.value || null)}
-          value={inputDeviceId ?? ""}
+          onChange={(event) => {
+            const nextValue = event.target.value || null;
+            if (systemDefaultOnly && nextValue) {
+              return;
+            }
+            onInputDeviceChange(nextValue);
+          }}
+          value={selectedInputDeviceId}
         >
           <option value="">System Default</option>
           {selectedDeviceMissing ? <option value={inputDeviceId ?? ""}>Saved microphone</option> : null}
           {devices.map((device) => (
-            <option key={device.deviceId || device.label} value={device.deviceId}>
+            <option
+              disabled={systemDefaultOnly}
+              key={device.deviceId || device.label}
+              value={device.deviceId}
+            >
               {device.label}
             </option>
           ))}
@@ -152,7 +183,47 @@ function canUseMediaDeviceEnumeration() {
   return typeof navigator !== "undefined" && typeof navigator.mediaDevices?.enumerateDevices === "function";
 }
 
+async function enumerateTunerInputDevices({
+  includeNativeDevices,
+}: {
+  includeNativeDevices: boolean;
+}) {
+  if (includeNativeDevices) {
+    const nativeDevices = await enumerateNativeAudioInputDevices();
+    if (nativeDevices.length > 0) {
+      rememberTunerMicrophoneDevices(nativeDevices);
+      return nativeDevices;
+    }
+  }
+  return enumerateAudioInputDevices();
+}
+
+async function enumerateNativeAudioInputDevices() {
+  try {
+    const capabilities = await getNativeAudioCapabilities();
+    if (!capabilities.micCaptureSupported) {
+      return [];
+    }
+    const deviceState = await listNativeAudioInputDevices();
+    if (!deviceState.supported) {
+      return [];
+    }
+    return deviceState.devices
+      .map((device) => ({
+        deviceId: device.id,
+        label: device.isDefault ? `${device.label} (Default)` : device.label,
+      }))
+      .filter((device) => device.label.trim());
+  } catch {
+    return [];
+  }
+}
+
 async function enumerateAudioInputDevices() {
+  if (!canUseMediaDeviceEnumeration()) {
+    return readRememberedTunerMicrophoneDevices();
+  }
+
   const devices = await navigator.mediaDevices.enumerateDevices();
   const visibleDevices = toVisibleTunerMicrophoneDevices(devices);
   if (visibleDevices.length > 0) {

--- a/apps/desktop/src/features/tools/systemInputVolume.ts
+++ b/apps/desktop/src/features/tools/systemInputVolume.ts
@@ -8,12 +8,18 @@ export type SystemDefaultInputVolume = {
   error: string | null;
 };
 
-export async function getSystemDefaultInputVolume() {
-  return invoke<SystemDefaultInputVolume>("get_system_default_input_volume");
+export async function getSystemDefaultInputVolume(deviceId?: string | null) {
+  return invoke<SystemDefaultInputVolume>("get_system_default_input_volume", {
+    deviceId: deviceId ?? null,
+  });
 }
 
-export async function setSystemDefaultInputVolume(volumePercent: number) {
+export async function setSystemDefaultInputVolume(
+  volumePercent: number,
+  deviceId?: string | null,
+) {
   return invoke<SystemDefaultInputVolume>("set_system_default_input_volume", {
+    deviceId: deviceId ?? null,
     volumePercent: clampSystemInputVolume(volumePercent),
   });
 }

--- a/apps/desktop/src/features/tools/tunerMicrophoneAccess.ts
+++ b/apps/desktop/src/features/tools/tunerMicrophoneAccess.ts
@@ -1,9 +1,16 @@
 const TUNER_MICROPHONE_ACCESS_KEY = "tuneforge.tuner-microphone-access-granted";
+const TUNER_INPUT_CAPTURE_BACKEND_KEY = "tuneforge.tuner-input-capture-backend";
 const TUNER_MICROPHONE_DEVICES_KEY = "tuneforge.tuner-microphone-devices";
+const TUNER_NATIVE_CAPTURE_ERROR_KEY = "tuneforge.tuner-native-capture-error";
 
 export type TunerMicrophoneDevice = {
   deviceId: string;
   label: string;
+};
+
+export type TunerInputCaptureBackend = {
+  backend: "native" | "web";
+  detail: string | null;
 };
 
 export function rememberTunerMicrophoneAccessGranted() {
@@ -11,6 +18,58 @@ export function rememberTunerMicrophoneAccessGranted() {
     return;
   }
   window.localStorage.setItem(TUNER_MICROPHONE_ACCESS_KEY, "true");
+}
+
+export function rememberTunerInputCaptureBackend(backend: TunerInputCaptureBackend) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.localStorage.setItem(
+    TUNER_INPUT_CAPTURE_BACKEND_KEY,
+    JSON.stringify({
+      backend: backend.backend,
+      detail: backend.detail,
+    }),
+  );
+}
+
+export function readRememberedTunerInputCaptureBackend(): TunerInputCaptureBackend | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    const rawBackend = JSON.parse(window.localStorage.getItem(TUNER_INPUT_CAPTURE_BACKEND_KEY) ?? "null");
+    if (!isTunerInputCaptureBackend(rawBackend)) {
+      return null;
+    }
+    return {
+      backend: rawBackend.backend,
+      detail: rawBackend.detail,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function rememberTunerNativeCaptureError(error: string) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.localStorage.setItem(TUNER_NATIVE_CAPTURE_ERROR_KEY, error);
+}
+
+export function readRememberedTunerNativeCaptureError() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return window.localStorage.getItem(TUNER_NATIVE_CAPTURE_ERROR_KEY);
+}
+
+export function clearRememberedTunerNativeCaptureError() {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.localStorage.removeItem(TUNER_NATIVE_CAPTURE_ERROR_KEY);
 }
 
 export function forgetTunerMicrophoneAccessGranted() {
@@ -96,5 +155,16 @@ function isTunerMicrophoneDevice(device: unknown): device is TunerMicrophoneDevi
     "label" in device &&
     typeof device.deviceId === "string" &&
     typeof device.label === "string"
+  );
+}
+
+function isTunerInputCaptureBackend(device: unknown): device is TunerInputCaptureBackend {
+  return (
+    typeof device === "object" &&
+    device !== null &&
+    "backend" in device &&
+    "detail" in device &&
+    (device.backend === "native" || device.backend === "web") &&
+    (device.detail === null || typeof device.detail === "string")
   );
 }

--- a/apps/desktop/src/lib/nativeAudio.test.ts
+++ b/apps/desktop/src/lib/nativeAudio.test.ts
@@ -1,24 +1,33 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   NativeAudioCapabilities,
   NativeAudioDevices,
+  NativeAudioInputFrame,
   NativeAudioInputState,
   NativeAudioSnapshot,
 } from "./nativeAudio";
 
-const { mockInvoke } = vi.hoisted(() => ({
+const { mockInvoke, mockListen } = vi.hoisted(() => ({
   mockInvoke: vi.fn(),
+  mockListen: vi.fn(),
 }));
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: mockInvoke,
 }));
 
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: mockListen,
+}));
+
 import {
   getNativeAudioCapabilities,
+  getNativeAudioInputState,
   getNativeAudioSnapshot,
+  isWebAudioBackendForced,
   listNativeAudioInputDevices,
   listNativeAudioOutputDevices,
+  listenNativeAudioInputFrames,
   pauseNativeAudio,
   playNativeAudio,
   prepareNativeAudioSession,
@@ -37,7 +46,7 @@ const capabilities: NativeAudioCapabilities = {
   micCaptureSupported: false,
   micMonitoringSupported: false,
   systemInputVolumeSupported: true,
-  emitsEvents: ["audio://state", "audio://devices-changed"],
+  emitsEvents: ["audio://state", "audio://input-frame", "audio://devices-changed"],
   fallbackRequired: true,
   fallbackReason: "Native audio playback is not wired yet; use existing WebView playback.",
 };
@@ -65,11 +74,25 @@ const inputState: NativeAudioInputState = {
   monitorEnabled: true,
   monitorGain: 0.5,
   inputLevel: 0,
+  sampleRate: 48000,
 };
 
 describe("native audio adapter", () => {
   beforeEach(() => {
+    vi.unstubAllEnvs();
     mockInvoke.mockReset();
+    mockListen.mockReset();
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("detects the Web Audio backend override from env", () => {
+    expect(isWebAudioBackendForced()).toBe(false);
+
+    vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "true");
+    expect(isWebAudioBackendForced()).toBe(true);
+
+    vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "0");
+    expect(isWebAudioBackendForced()).toBe(false);
   });
 
   it("wraps capability and device discovery commands", async () => {
@@ -141,6 +164,7 @@ describe("native audio adapter", () => {
   it("wraps native input and monitor payloads", async () => {
     mockInvoke.mockResolvedValue(inputState);
 
+    await getNativeAudioInputState();
     await startNativeAudioInput({
       deviceId: "built-in",
       monitorEnabled: true,
@@ -149,13 +173,37 @@ describe("native audio adapter", () => {
     await setNativeAudioMonitor({ enabled: false, gain: 0 });
     await stopNativeAudioInput();
 
-    expect(mockInvoke).toHaveBeenNthCalledWith(1, "audio_start_input", {
+    expect(mockInvoke).toHaveBeenNthCalledWith(1, "audio_get_input_state");
+    expect(mockInvoke).toHaveBeenNthCalledWith(2, "audio_start_input", {
       payload: { deviceId: "built-in", monitorEnabled: true, monitorGain: 0.5 },
     });
-    expect(mockInvoke).toHaveBeenNthCalledWith(2, "audio_set_monitor", {
+    expect(mockInvoke).toHaveBeenNthCalledWith(3, "audio_set_monitor", {
       payload: { enabled: false, gain: 0 },
     });
-    expect(mockInvoke).toHaveBeenNthCalledWith(3, "audio_stop_input");
+    expect(mockInvoke).toHaveBeenNthCalledWith(4, "audio_stop_input");
+  });
+
+  it("wraps native input frame events", async () => {
+    const unlisten = vi.fn();
+    const frame: NativeAudioInputFrame = {
+      deviceId: "built-in",
+      sampleRate: 48000,
+      inputLevel: 0.25,
+      samples: [0, 0.5, -0.5],
+      timestampMs: 1234,
+    };
+    mockListen.mockImplementation(async (_eventName, callback) => {
+      callback({ event: "audio://input-frame", id: 1, payload: frame });
+      return unlisten;
+    });
+    const handler = vi.fn();
+
+    const stopListening = await listenNativeAudioInputFrames(handler);
+
+    expect(mockListen).toHaveBeenCalledWith("audio://input-frame", expect.any(Function));
+    expect(handler).toHaveBeenCalledWith(frame);
+    stopListening();
+    expect(unlisten).toHaveBeenCalled();
   });
 
   it("leaves invoke errors visible to callers", async () => {

--- a/apps/desktop/src/lib/nativeAudio.ts
+++ b/apps/desktop/src/lib/nativeAudio.ts
@@ -1,4 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+
+const FORCE_WEB_AUDIO_VALUES = new Set(["1", "true", "yes", "on"]);
 
 export type NativeAudioEventName =
   | "audio://state"
@@ -6,6 +9,7 @@ export type NativeAudioEventName =
   | "audio://ended"
   | "audio://error"
   | "audio://input-level"
+  | "audio://input-frame"
   | "audio://devices-changed";
 
 export type NativeAudioCapabilities = {
@@ -108,7 +112,24 @@ export type NativeAudioInputState = {
   monitorEnabled: boolean;
   monitorGain: number;
   inputLevel: number;
+  sampleRate: number | null;
 };
+
+export type NativeAudioInputFrame = {
+  deviceId: string | null;
+  sampleRate: number;
+  inputLevel: number;
+  samples: number[];
+  timestampMs: number;
+};
+
+export function isWebAudioBackendForced() {
+  const configuredValue = import.meta.env.VITE_TUNEFORGE_FORCE_WEB_AUDIO;
+  return (
+    typeof configuredValue === "string" &&
+    FORCE_WEB_AUDIO_VALUES.has(configuredValue.trim().toLowerCase())
+  );
+}
 
 export function getNativeAudioCapabilities() {
   return invoke<NativeAudioCapabilities>("audio_get_capabilities");
@@ -150,6 +171,10 @@ export function getNativeAudioSnapshot() {
   return invoke<NativeAudioSnapshot>("audio_get_snapshot");
 }
 
+export function getNativeAudioInputState() {
+  return invoke<NativeAudioInputState>("audio_get_input_state");
+}
+
 export function startNativeAudioInput(payload: NativeAudioInputRequest = {}) {
   return invoke<NativeAudioInputState>("audio_start_input", { payload });
 }
@@ -160,4 +185,12 @@ export function stopNativeAudioInput() {
 
 export function setNativeAudioMonitor(payload: NativeAudioMonitorRequest) {
   return invoke<NativeAudioInputState>("audio_set_monitor", { payload });
+}
+
+export function listenNativeAudioInputFrames(
+  handler: (frame: NativeAudioInputFrame) => void,
+) {
+  return listen<NativeAudioInputFrame>("audio://input-frame", (event) => {
+    handler(event.payload);
+  });
 }

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -43,8 +43,28 @@ const {
   mockGetHealth,
   mockGetMobileCapabilities,
   setMockSystemInputVolume,
+  setMockNativeAudio,
+  emitMockNativeAudioInputFrame,
+  mockListen,
 } = vi.hoisted(() => {
   const createdAt = "2026-04-18T13:16:00.000Z";
+  type NativeAudioInputFrame = {
+    deviceId: string | null;
+    sampleRate: number;
+    inputLevel: number;
+    samples: number[];
+    timestampMs: number;
+  };
+  type NativeAudioInputFrameEvent = {
+    event: "audio://input-frame";
+    id: number;
+    payload: NativeAudioInputFrame;
+  };
+  const nativeInputFrameListeners = new Map<
+    number,
+    (event: NativeAudioInputFrameEvent) => void
+  >();
+  let nextNativeInputFrameListenerId = 1;
   let state: {
     projects: Array<Record<string, unknown>>;
     analysisByProject: Record<string, Record<string, unknown> | null>;
@@ -64,6 +84,17 @@ const {
       backend: string | null;
       error: string | null;
     };
+    nativeAudioCapabilities: Record<string, unknown>;
+    nativeAudioInputDevices: Record<string, unknown>;
+    nativeAudioInputState: {
+      active: boolean;
+      deviceId: string | null;
+      monitorEnabled: boolean;
+      monitorGain: number;
+      inputLevel: number;
+      sampleRate: number | null;
+    };
+    nativeAudioStartError: string | null;
     nextProjectId: number;
     nextArtifactId: number;
     nextJobId: number;
@@ -332,6 +363,31 @@ const {
         backend: "test",
         error: null,
       },
+      nativeAudioCapabilities: {
+        platform: "test",
+        backend: "test",
+        nativePlaybackSupported: false,
+        micCaptureSupported: false,
+        micMonitoringSupported: false,
+        systemInputVolumeSupported: true,
+        emitsEvents: ["audio://input-frame", "audio://devices-changed"],
+        fallbackRequired: true,
+        fallbackReason: "Native audio playback is not wired yet; use existing WebView playback.",
+      },
+      nativeAudioInputDevices: {
+        supported: true,
+        devices: [],
+        error: null,
+      },
+      nativeAudioInputState: {
+        active: false,
+        deviceId: null,
+        monitorEnabled: false,
+        monitorGain: 0,
+        inputLevel: 0,
+        sampleRate: null,
+      },
+      nativeAudioStartError: null,
       nextProjectId: 200,
       nextArtifactId: 200,
       nextJobId: 200,
@@ -339,6 +395,8 @@ const {
       nextSectionId: 200,
       deferPreviewCompletion: false,
     };
+    nativeInputFrameListeners.clear();
+    nextNativeInputFrameListenerId = 1;
   }
 
   resetMockApiState();
@@ -362,6 +420,51 @@ const {
       ...nextState,
     };
   }
+  function setMockNativeAudio(nextState: {
+    capabilities?: Record<string, unknown>;
+    inputDevices?: Record<string, unknown>;
+    inputState?: Partial<typeof state.nativeAudioInputState>;
+    startError?: string | null;
+  }) {
+    state.nativeAudioCapabilities = {
+      ...state.nativeAudioCapabilities,
+      ...nextState.capabilities,
+    };
+    state.nativeAudioInputDevices = {
+      ...state.nativeAudioInputDevices,
+      ...nextState.inputDevices,
+    };
+    state.nativeAudioInputState = {
+      ...state.nativeAudioInputState,
+      ...nextState.inputState,
+    };
+    if ("startError" in nextState) {
+      state.nativeAudioStartError = nextState.startError ?? null;
+    }
+  }
+  function emitMockNativeAudioInputFrame(frame: NativeAudioInputFrame) {
+    nativeInputFrameListeners.forEach((listener, id) => {
+      listener({
+        event: "audio://input-frame",
+        id,
+        payload: clone(frame),
+      });
+    });
+  }
+  const mockListen = vi.fn(
+    async (
+      eventName: string,
+      handler: (event: NativeAudioInputFrameEvent) => void,
+    ) => {
+      if (eventName !== "audio://input-frame") {
+        throw new Error(`Unexpected listen event: ${eventName}`);
+      }
+      const listenerId = nextNativeInputFrameListenerId;
+      nextNativeInputFrameListenerId += 1;
+      nativeInputFrameListeners.set(listenerId, handler);
+      return () => nativeInputFrameListeners.delete(listenerId);
+    },
+  );
   const mockInvoke = vi.fn(async (command: string, args?: Record<string, unknown>) => {
     if (command === "backend_base_url") {
       return "http://127.0.0.1:8765";
@@ -396,6 +499,48 @@ const {
         error: null,
       };
       return clone(state.systemInputVolume);
+    }
+
+    if (command === "audio_get_capabilities") {
+      return clone(state.nativeAudioCapabilities);
+    }
+
+    if (command === "audio_list_input_devices") {
+      return clone(state.nativeAudioInputDevices);
+    }
+
+    if (command === "audio_get_input_state") {
+      return clone(state.nativeAudioInputState);
+    }
+
+    if (command === "audio_start_input") {
+      if (state.nativeAudioStartError) {
+        throw new Error(state.nativeAudioStartError);
+      }
+      const payload = (args?.payload ?? {}) as {
+        deviceId?: string | null;
+        monitorEnabled?: boolean | null;
+        monitorGain?: number | null;
+      };
+      state.nativeAudioInputState = {
+        active: true,
+        deviceId: payload.deviceId ?? null,
+        monitorEnabled: payload.monitorEnabled ?? false,
+        monitorGain: payload.monitorGain ?? 0,
+        inputLevel: 0,
+        sampleRate: 48000,
+      };
+      return clone(state.nativeAudioInputState);
+    }
+
+    if (command === "audio_stop_input") {
+      state.nativeAudioInputState = {
+        ...state.nativeAudioInputState,
+        active: false,
+        inputLevel: 0,
+        sampleRate: null,
+      };
+      return clone(state.nativeAudioInputState);
     }
 
     throw new Error(`Unexpected invoke command: ${command}`);
@@ -988,6 +1133,9 @@ const {
     mockGetHealth,
     mockGetMobileCapabilities,
     setMockSystemInputVolume,
+    setMockNativeAudio,
+    emitMockNativeAudioInputFrame,
+    mockListen,
   };
 });
 
@@ -1029,6 +1177,7 @@ export {
   mockDeleteProject,
   mockGetHealth,
   mockGetMobileCapabilities,
+  mockListen,
 };
 
 vi.mock("@tauri-apps/plugin-dialog", () => ({
@@ -1040,6 +1189,10 @@ vi.mock("@tauri-apps/plugin-dialog", () => ({
 vi.mock("@tauri-apps/api/core", () => ({
   convertFileSrc: (path: string) => path,
   invoke: mockInvoke,
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: mockListen,
 }));
 
 vi.mock("../lib/api", async (importOriginal) => {
@@ -1222,6 +1375,18 @@ export function setMockSystemInputVolumeState(
   setMockSystemInputVolume(nextState);
 }
 
+export function setMockNativeAudioState(
+  nextState: Parameters<typeof setMockNativeAudio>[0],
+) {
+  setMockNativeAudio(nextState);
+}
+
+export function emitMockNativeInputFrame(
+  frame: Parameters<typeof emitMockNativeAudioInputFrame>[0],
+) {
+  emitMockNativeAudioInputFrame(frame);
+}
+
 export function getMockMediaDevices() {
   return (
     globalThis as typeof globalThis & {
@@ -1249,6 +1414,7 @@ export function resetAppTestHarness() {
   mockSave.mockReset();
   mockConfirm.mockReset();
   mockInvoke.mockClear();
+  mockListen.mockClear();
   mockConfirm.mockResolvedValue(true);
   mockListProjects.mockClear();
   mockImportProject.mockClear();

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -199,6 +199,8 @@ Validation failures return `INVALID_REQUEST` with serialized validation details.
 ## Packaging Constraints
 
 - FFmpeg is a host dependency and is not bundled.
+- Desktop tuner microphone capture uses `cpal` locally and falls back to Web Audio when native capture is unavailable.
+- Native audio development notes live in [NATIVE_AUDIO.md](NATIVE_AUDIO.md).
 - Desktop system microphone volume control uses CoreAudio on macOS, or host `wpctl`/`pactl` tools on Linux with an active PipeWire/PulseAudio session.
 - Advanced Chords dependencies are currently optional. If they become a default desktop backend, packaged builds must treat crema, its bundled chord model files, TensorFlow/Keras, h5py/HDF5, gRPC/Protobuf, and TensorBoard as default-runtime notice scope.
 - Demucs and lyrics models follow first-use local download/cache behavior.

--- a/docs/NATIVE_AUDIO.md
+++ b/docs/NATIVE_AUDIO.md
@@ -1,0 +1,50 @@
+# Native Audio
+
+TuneForge keeps Web Audio as the fallback implementation for desktop audio paths. Native audio is
+added feature by feature behind the Tauri native audio boundary.
+
+## Current Scope
+
+- Tuner microphone capture uses native `cpal` on supported desktop builds.
+- Tuner device listing uses native input enumeration first, then cached/browser labels as fallback.
+- Source, stem, and project playback still use Web Audio.
+- Native playback is intentionally not implemented yet.
+
+## Backend Selection
+
+The frontend prefers native audio when a feature is supported and falls back to Web Audio when
+native support is unavailable or startup fails.
+
+For development comparisons, force Web Audio for native-audio-backed features:
+
+```sh
+VITE_TUNEFORGE_FORCE_WEB_AUDIO=1 pnpm dev
+```
+
+If the backend is already running separately:
+
+```sh
+VITE_TUNEFORGE_FORCE_WEB_AUDIO=1 pnpm dev:desktop
+```
+
+This is a global native audio override, not a per-feature setting. It currently affects tuner
+capture. Future native playback work should use the same override so Web Audio can remain the
+comparison path for both capture and playback.
+
+## Diagnostics
+
+Settings -> Local Data -> Show diagnostics reports:
+
+- input capture availability
+- last tuner capture backend
+- last native capture error
+- playback backend
+
+When `VITE_TUNEFORGE_FORCE_WEB_AUDIO=1` is active, diagnostics report `Web Audio (forced)`.
+
+## Device And Volume Behavior
+
+Native tuner capture can use a selected input device without changing the system default microphone.
+Native selected-device volume uses host controls where available. Web Audio capture remains limited
+to the browser/system default input path, so non-default microphone choices are disabled while Web
+Audio is active.


### PR DESCRIPTION
## Summary
- Add real desktop tuner microphone capture through the native cpal backend.
- Use native input device enumeration and selected-device volume control, with Web Audio fallback preserved.
- Add diagnostics for native capture state/errors and document the global Web Audio override for native audio comparisons.
- Install ALSA development headers in desktop CI so Linux cpal dependencies compile.

## Testing
- pnpm --filter @tuneforge/desktop typecheck
- pnpm --filter @tuneforge/desktop lint
- pnpm --filter @tuneforge/desktop test -- App.tools-tuner.test.tsx App.settings-theme.test.tsx nativeAudio.test.ts
- cd apps/desktop/src-tauri && cargo check && cargo test
- cargo fmt --check
- git diff --check
