### PR TITLE
feat: add streaming native playback

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -74,7 +74,19 @@ This document is an engineering notice and distribution checklist, not legal adv
 
 - **License:** Apache-2.0 / MIT (dual)
 - **Source:** <https://github.com/RustAudio/cpal>
-- **Notes:** Used by the desktop shell for local microphone device enumeration and tuner input capture.
+- **Notes:** Used by the desktop shell for local microphone device enumeration, tuner input capture, and native desktop playback.
+
+### signalsmith-stretch
+
+- **License:** MIT
+- **Source:** <https://github.com/colinmarc/signalsmith-stretch-rs>
+- **Notes:** Used by the native desktop playback engine for tempo changes with pitch preservation. Its resolved Rust transitive stack is permissively licensed.
+
+### Symphonia
+
+- **License:** MPL-2.0
+- **Source:** <https://github.com/pdeljanov/Symphonia>
+- **Notes:** Used only by the native desktop playback engine for streaming demux/decode of local playback files. FFmpeg remains the host dependency for transform/export work.
 
 ### rusqlite / SQLite
 

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -70,6 +70,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +124,26 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.11.1",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -131,7 +157,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "shlex",
  "syn 2.0.117",
 ]
@@ -470,7 +496,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
 dependencies = [
- "bindgen",
+ "bindgen 0.72.1",
 ]
 
 [[package]]
@@ -630,10 +656,123 @@ dependencies = [
 ]
 
 [[package]]
+name = "dasp"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7381b67da416b639690ac77c73b86a7b5e64a29e31d1f75fb3b1102301ef355a"
+dependencies = [
+ "dasp_envelope",
+ "dasp_frame",
+ "dasp_interpolate",
+ "dasp_peak",
+ "dasp_ring_buffer",
+ "dasp_rms",
+ "dasp_sample",
+ "dasp_signal",
+ "dasp_slice",
+ "dasp_window",
+]
+
+[[package]]
+name = "dasp_envelope"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ec617ce7016f101a87fe85ed44180839744265fae73bb4aa43e7ece1b7668b6"
+dependencies = [
+ "dasp_frame",
+ "dasp_peak",
+ "dasp_ring_buffer",
+ "dasp_rms",
+ "dasp_sample",
+]
+
+[[package]]
+name = "dasp_frame"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a3937f5fe2135702897535c8d4a5553f8b116f76c1529088797f2eee7c5cd6"
+dependencies = [
+ "dasp_sample",
+]
+
+[[package]]
+name = "dasp_interpolate"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc975a6563bb7ca7ec0a6c784ead49983a21c24835b0bc96eea11ee407c7486"
+dependencies = [
+ "dasp_frame",
+ "dasp_ring_buffer",
+ "dasp_sample",
+]
+
+[[package]]
+name = "dasp_peak"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf88559d79c21f3d8523d91250c397f9a15b5fc72fbb3f87fdb0a37b79915bf"
+dependencies = [
+ "dasp_frame",
+ "dasp_sample",
+]
+
+[[package]]
+name = "dasp_ring_buffer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07d79e19b89618a543c4adec9c5a347fe378a19041699b3278e616e387511ea1"
+
+[[package]]
+name = "dasp_rms"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6c5dcb30b7e5014486e2822537ea2beae50b19722ffe2ed7549ab03774575aa"
+dependencies = [
+ "dasp_frame",
+ "dasp_ring_buffer",
+ "dasp_sample",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
+name = "dasp_signal"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa1ab7d01689c6ed4eae3d38fe1cea08cba761573fbd2d592528d55b421077e7"
+dependencies = [
+ "dasp_envelope",
+ "dasp_frame",
+ "dasp_interpolate",
+ "dasp_peak",
+ "dasp_ring_buffer",
+ "dasp_rms",
+ "dasp_sample",
+ "dasp_window",
+]
+
+[[package]]
+name = "dasp_slice"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e1c7335d58e7baedafa516cb361360ff38d6f4d3f9d9d5ee2a2fc8e27178fa1"
+dependencies = [
+ "dasp_frame",
+ "dasp_sample",
+]
+
+[[package]]
+name = "dasp_window"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99ded7b88821d2ce4e8b842c9f1c86ac911891ab89443cc1de750cae764c5076"
+dependencies = [
+ "dasp_sample",
+]
 
 [[package]]
 name = "dbus"
@@ -860,6 +999,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +1023,12 @@ dependencies = [
  "serde_core",
  "typeid",
 ]
+
+[[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
 name = "fallible-iterator"
@@ -1895,6 +2049,12 @@ dependencies = [
  "indexmap 2.14.0",
  "selectors 0.24.0",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -3153,6 +3313,12 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
@@ -3270,7 +3436,7 @@ dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
  "precomputed-hash",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "servo_arc 0.4.3",
  "smallvec",
 ]
@@ -3470,6 +3636,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signalsmith-stretch"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51dae6f10b5532510f65c309c4d868babe3aecf6ce0782678081338311f176fd"
+dependencies = [
+ "bindgen 0.70.1",
+ "cc",
+ "dasp",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3639,6 +3816,201 @@ dependencies = [
  "base64 0.21.7",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "symphonia"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-flac",
+ "symphonia-bundle-mp3",
+ "symphonia-codec-aac",
+ "symphonia-codec-adpcm",
+ "symphonia-codec-alac",
+ "symphonia-codec-pcm",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-caf",
+ "symphonia-format-isomp4",
+ "symphonia-format-mkv",
+ "symphonia-format-ogg",
+ "symphonia-format-riff",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-flac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-aac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-adpcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-alac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8413fa754942ac16a73634c9dfd1500ed5c61430956b33728567f667fdd393ab"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-pcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-vorbis"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-format-caf"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8faf379316b6b6e6bbc274d00e7a592e0d63ff1a7e182ce8ba25e24edd3d096"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-format-isomp4"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-mkv"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122d786d2c43a49beb6f397551b4a050d8229eaa54c7ddf9ee4b98899b8742d0"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-ogg"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
 ]
 
 [[package]]
@@ -4380,6 +4752,8 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "signalsmith-stretch",
+ "symphonia",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -4814,7 +5188,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f"
 dependencies = [
- "bindgen",
+ "bindgen 0.72.1",
  "cfg-if",
  "cmake",
  "fs_extra",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -25,6 +25,8 @@ chrono = { version = "0.4.44", features = ["serde"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 cpal = "0.15.3"
+signalsmith-stretch = "0.1.3"
+symphonia = { version = "0.5.5", default-features = false, features = ["all"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 webkit2gtk = "2.0.2"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -345,6 +345,7 @@ pub fn run() {
             native_audio::audio_stop,
             native_audio::audio_seek,
             native_audio::audio_set_lanes,
+            native_audio::audio_set_click,
             native_audio::audio_get_snapshot,
             native_audio::audio_list_input_devices,
             native_audio::audio_list_output_devices,

--- a/apps/desktop/src-tauri/src/native_audio/decode.rs
+++ b/apps/desktop/src-tauri/src/native_audio/decode.rs
@@ -11,6 +11,13 @@ pub struct DecodedAudio {
     pub channels: u32,
 }
 
+#[derive(Clone)]
+pub struct DecodedInterleavedAudio {
+    pub samples: Vec<f32>,
+    pub sample_rate: u32,
+    pub channels: u32,
+}
+
 pub fn read_mobile_audio(path: &Path) -> Result<DecodedAudio, String> {
     match read_wav_audio(path) {
         Ok(audio) => Ok(audio),
@@ -77,6 +84,23 @@ pub fn write_mono_pcm_wav(path: &Path, audio: &DecodedAudio) -> Result<(), Strin
 }
 
 pub fn read_wav_audio(path: &Path) -> Result<DecodedAudio, String> {
+    let decoded = read_wav_audio_interleaved(path)?;
+    let channels =
+        usize::try_from(decoded.channels).map_err(|_| "Invalid WAV channel count.".to_string())?;
+    let mut samples = Vec::with_capacity(decoded.samples.len() / channels);
+    for frame in decoded.samples.chunks_exact(channels) {
+        let sum = frame.iter().map(|sample| f64::from(*sample)).sum::<f64>();
+        samples.push((sum / decoded.channels as f64).clamp(-1.0, 1.0) as f32);
+    }
+
+    Ok(DecodedAudio {
+        samples,
+        sample_rate: decoded.sample_rate,
+        channels: decoded.channels,
+    })
+}
+
+pub fn read_wav_audio_interleaved(path: &Path) -> Result<DecodedInterleavedAudio, String> {
     let bytes = fs::read(path).map_err(|error| error.to_string())?;
     if bytes.len() < 12 || &bytes[0..4] != b"RIFF" || &bytes[8..12] != b"WAVE" {
         return Err("Not a PCM WAV file.".to_string());
@@ -133,18 +157,20 @@ pub fn read_wav_audio(path: &Path) -> Result<DecodedAudio, String> {
         return Err("Invalid WAV bit depth.".to_string());
     }
 
-    let mut samples = Vec::with_capacity(frame_count);
+    let channels_usize = channels as usize;
+    let mut samples = Vec::with_capacity(frame_count * channels_usize);
     for frame_index in 0..frame_count {
         let frame_start = data_start + frame_index * block_align as usize;
-        let mut sum = 0.0;
-        for channel_index in 0..channels as usize {
+        for channel_index in 0..channels_usize {
             let sample_offset = frame_start + channel_index * bytes_per_sample;
-            sum += decode_wav_sample(&bytes, sample_offset, audio_format, bits_per_sample)?;
+            samples.push(
+                decode_wav_sample(&bytes, sample_offset, audio_format, bits_per_sample)?
+                    .clamp(-1.0, 1.0) as f32,
+            );
         }
-        samples.push((sum / channels as f64).clamp(-1.0, 1.0) as f32);
     }
 
-    Ok(DecodedAudio {
+    Ok(DecodedInterleavedAudio {
         samples,
         sample_rate,
         channels: channels as u32,
@@ -178,19 +204,94 @@ pub fn resample_mono(
     output
 }
 
-fn read_u16_le(bytes: &[u8], offset: usize) -> Option<u16> {
+pub fn resample_interleaved(
+    samples: &[f32],
+    channels: u32,
+    source_sample_rate: u32,
+    target_sample_rate: u32,
+) -> Vec<f32> {
+    let channel_count = channels as usize;
+    if samples.is_empty()
+        || channel_count == 0
+        || source_sample_rate == 0
+        || source_sample_rate == target_sample_rate
+    {
+        return samples.to_vec();
+    }
+
+    let input_frames = samples.len() / channel_count;
+    if input_frames == 0 {
+        return Vec::new();
+    }
+
+    let output_frames = ((input_frames as f64) * target_sample_rate as f64
+        / source_sample_rate as f64)
+        .ceil()
+        .max(1.0) as usize;
+    let ratio = source_sample_rate as f64 / target_sample_rate as f64;
+    let mut output = Vec::with_capacity(output_frames * channel_count);
+    for output_frame in 0..output_frames {
+        let source_position = output_frame as f64 * ratio;
+        let left_frame = source_position.floor() as usize;
+        let right_frame = (left_frame + 1).min(input_frames.saturating_sub(1));
+        let fraction = (source_position - left_frame as f64) as f32;
+        for channel in 0..channel_count {
+            let left = samples[left_frame * channel_count + channel];
+            let right = samples[right_frame * channel_count + channel];
+            output.push(left + (right - left) * fraction);
+        }
+    }
+    output
+}
+
+pub fn convert_interleaved_channels(
+    samples: &[f32],
+    source_channels: u32,
+    target_channels: u32,
+) -> Vec<f32> {
+    let source_count = source_channels as usize;
+    let target_count = target_channels as usize;
+    if samples.is_empty() || source_count == 0 || target_count == 0 {
+        return Vec::new();
+    }
+    if source_count == target_count {
+        return samples.to_vec();
+    }
+
+    let frames = samples.len() / source_count;
+    let mut output = Vec::with_capacity(frames * target_count);
+    for frame in samples.chunks_exact(source_count) {
+        if target_count == 1 {
+            let sum = frame.iter().map(|sample| f64::from(*sample)).sum::<f64>();
+            output.push((sum / source_count as f64).clamp(-1.0, 1.0) as f32);
+            continue;
+        }
+
+        for channel in 0..target_count {
+            let source_channel = if source_count == 1 {
+                0
+            } else {
+                channel.min(source_count - 1)
+            };
+            output.push(frame[source_channel]);
+        }
+    }
+    output
+}
+
+pub(crate) fn read_u16_le(bytes: &[u8], offset: usize) -> Option<u16> {
     Some(u16::from_le_bytes(
         bytes.get(offset..offset + 2)?.try_into().ok()?,
     ))
 }
 
-fn read_u32_le(bytes: &[u8], offset: usize) -> Option<u32> {
+pub(crate) fn read_u32_le(bytes: &[u8], offset: usize) -> Option<u32> {
     Some(u32::from_le_bytes(
         bytes.get(offset..offset + 4)?.try_into().ok()?,
     ))
 }
 
-fn decode_wav_sample(
+pub(crate) fn decode_wav_sample(
     bytes: &[u8],
     offset: usize,
     audio_format: u16,
@@ -279,5 +380,46 @@ mod tests {
         assert_eq!(decoded.sample_rate, 48_000);
         assert_eq!(decoded.channels, 1);
         assert_eq!(decoded.samples.len(), 3);
+    }
+
+    #[test]
+    fn read_wav_audio_interleaved_preserves_stereo_channels() {
+        let path = std::env::temp_dir().join(format!(
+            "tuneforge-audio-stereo-decode-test-{}.wav",
+            std::process::id()
+        ));
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"RIFF");
+        bytes.extend_from_slice(&44u32.to_le_bytes());
+        bytes.extend_from_slice(b"WAVEfmt ");
+        bytes.extend_from_slice(&16u32.to_le_bytes());
+        bytes.extend_from_slice(&1u16.to_le_bytes());
+        bytes.extend_from_slice(&2u16.to_le_bytes());
+        bytes.extend_from_slice(&48_000u32.to_le_bytes());
+        bytes.extend_from_slice(&192_000u32.to_le_bytes());
+        bytes.extend_from_slice(&4u16.to_le_bytes());
+        bytes.extend_from_slice(&16u16.to_le_bytes());
+        bytes.extend_from_slice(b"data");
+        bytes.extend_from_slice(&8u32.to_le_bytes());
+        for sample in [i16::MAX, i16::MIN, 0, i16::MAX / 2] {
+            bytes.extend_from_slice(&sample.to_le_bytes());
+        }
+        fs::write(&path, bytes).expect("write wav");
+
+        let decoded = read_wav_audio_interleaved(&path).expect("read wav");
+        let _ = fs::remove_file(&path);
+
+        assert_eq!(decoded.sample_rate, 48_000);
+        assert_eq!(decoded.channels, 2);
+        assert_eq!(decoded.samples.len(), 4);
+        assert!(decoded.samples[0] > 0.99);
+        assert!(decoded.samples[1] < -0.99);
+    }
+
+    #[test]
+    fn convert_interleaved_channels_duplicates_mono_to_stereo() {
+        let converted = convert_interleaved_channels(&[0.25, -0.5], 1, 2);
+
+        assert_eq!(converted, vec![0.25, 0.25, -0.5, -0.5]);
     }
 }

--- a/apps/desktop/src-tauri/src/native_audio/mod.rs
+++ b/apps/desktop/src-tauri/src/native_audio/mod.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, State};
 
 pub mod android_media;
@@ -18,20 +18,21 @@ pub const AUDIO_EVENT_INPUT_LEVEL: &str = "audio://input-level";
 pub const AUDIO_EVENT_INPUT_FRAME: &str = "audio://input-frame";
 pub const AUDIO_EVENT_DEVICES_CHANGED: &str = "audio://devices-changed";
 
+#[derive(Clone)]
 pub struct NativeAudioState {
     capabilities: AudioCapabilities,
-    mixer: Mutex<mixer::MixerState>,
-    transport: Mutex<transport::TransportState>,
-    capture: Mutex<capture::CaptureState>,
+    mixer: Arc<Mutex<mixer::MixerState>>,
+    transport: Arc<Mutex<transport::TransportState>>,
+    capture: Arc<Mutex<capture::CaptureState>>,
 }
 
 impl NativeAudioState {
     pub fn new() -> Self {
         Self {
             capabilities: AudioCapabilities::detect(),
-            mixer: Mutex::new(mixer::MixerState::default()),
-            transport: Mutex::new(transport::TransportState::default()),
-            capture: Mutex::new(capture::CaptureState::default()),
+            mixer: Arc::new(Mutex::new(mixer::MixerState::default())),
+            transport: Arc::new(Mutex::new(transport::TransportState::default())),
+            capture: Arc::new(Mutex::new(capture::CaptureState::default())),
         }
     }
 
@@ -93,24 +94,30 @@ pub fn audio_get_capabilities(state: State<'_, NativeAudioState>) -> AudioCapabi
 }
 
 #[tauri::command]
-pub fn audio_prepare_session(
+pub async fn audio_prepare_session(
+    app: AppHandle,
     state: State<'_, NativeAudioState>,
     payload: transport::AudioSessionRequest,
 ) -> Result<transport::AudioSession, String> {
-    let effective_lanes = {
-        let mut mixer = state
-            .mixer
-            .lock()
-            .map_err(|_| "Native audio mixer state is unavailable.".to_string())?;
-        mixer.set_lanes(payload.lanes.clone());
-        mixer.effective_lanes()
-    };
+    let state = state.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        let effective_lanes = {
+            let mut mixer = state
+                .mixer
+                .lock()
+                .map_err(|_| "Native audio mixer state is unavailable.".to_string())?;
+            mixer.set_lanes(payload.lanes.clone());
+            mixer.effective_lanes()
+        };
 
-    let mut transport = state
-        .transport
-        .lock()
-        .map_err(|_| "Native audio transport state is unavailable.".to_string())?;
-    Ok(transport.prepare(payload, effective_lanes, state.capabilities()))
+        let mut transport = state
+            .transport
+            .lock()
+            .map_err(|_| "Native audio transport state is unavailable.".to_string())?;
+        Ok(transport.prepare(Some(app), payload, effective_lanes, state.capabilities()))
+    })
+    .await
+    .map_err(|error| format!("Native audio prepare task failed: {error}"))?
 }
 
 #[tauri::command]
@@ -164,20 +171,33 @@ pub fn audio_set_lanes(
     state: State<'_, NativeAudioState>,
     payload: mixer::AudioLaneUpdate,
 ) -> Result<transport::AudioSnapshot, String> {
+    let raw_lanes = payload.lanes;
     let effective_lanes = {
         let mut mixer = state
             .mixer
             .lock()
             .map_err(|_| "Native audio mixer state is unavailable.".to_string())?;
-        mixer.set_lanes(payload.lanes);
+        mixer.set_lanes(raw_lanes.clone());
         mixer.effective_lanes()
     };
     let mut transport = state
         .transport
         .lock()
         .map_err(|_| "Native audio transport state is unavailable.".to_string())?;
-    transport.set_effective_lanes(effective_lanes);
+    transport.set_lanes(raw_lanes, effective_lanes);
     Ok(transport.snapshot())
+}
+
+#[tauri::command]
+pub fn audio_set_click(
+    state: State<'_, NativeAudioState>,
+    payload: transport::AudioClickRequest,
+) -> Result<transport::AudioSnapshot, String> {
+    let mut transport = state
+        .transport
+        .lock()
+        .map_err(|_| "Native audio transport state is unavailable.".to_string())?;
+    Ok(transport.set_click(payload))
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/native_audio/platform/desktop.rs
+++ b/apps/desktop/src-tauri/src/native_audio/platform/desktop.rs
@@ -8,7 +8,7 @@ pub fn current_platform() -> AudioPlatform {
             "linux"
         },
         backend: "desktop-cpal",
-        native_playback_supported: false,
+        native_playback_supported: true,
         mic_capture_supported: true,
         mic_monitoring_supported: false,
         system_input_volume_supported: true,

--- a/apps/desktop/src-tauri/src/native_audio/transport.rs
+++ b/apps/desktop/src-tauri/src/native_audio/transport.rs
@@ -1,7 +1,59 @@
 use serde::{Deserialize, Serialize};
-use std::time::Instant;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tauri::AppHandle;
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use std::{
+    collections::VecDeque,
+    fs::File,
+    io::{Read, Seek, SeekFrom},
+    path::{Path, PathBuf},
+    sync::mpsc,
+    thread::{self, JoinHandle},
+};
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use cpal::{FromSample, Sample, SampleFormat, SizedSample};
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use symphonia::core::{
+    audio::SampleBuffer,
+    codecs::{Decoder, DecoderOptions, CODEC_TYPE_NULL},
+    errors::Error as SymphoniaError,
+    formats::{FormatOptions, FormatReader, SeekMode, SeekTo},
+    io::MediaSourceStream,
+    meta::MetadataOptions,
+    probe::Hint,
+    units::Time,
+};
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use tauri::Emitter;
 
 use super::{mixer::AudioLaneRequest, mixer::EffectiveAudioLane, AudioCapabilities};
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use super::{
+    decode::{
+        convert_interleaved_channels, decode_wav_sample, read_u16_le, read_u32_le,
+        resample_interleaved,
+    },
+    AUDIO_EVENT_ENDED, AUDIO_EVENT_ERROR, AUDIO_EVENT_POSITION, AUDIO_EVENT_STATE,
+};
+
+const DEFAULT_PLAYBACK_RATE: f64 = 1.0;
+const RATE_TOLERANCE: f64 = 0.0001;
+const GAIN_RAMP_SECONDS: f64 = 0.015;
+const POSITION_EVENT_INTERVAL: Duration = Duration::from_millis(40);
+const CLICK_DURATION_SECONDS: f64 = 0.032;
+const CLICK_ACCENT_DURATION_SECONDS: f64 = 0.045;
+const CLICK_FREQUENCY_HZ: f64 = 1175.0;
+const CLICK_ACCENT_FREQUENCY_HZ: f64 = 1760.0;
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+const STREAM_CHUNK_FRAMES: usize = 2048;
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+const RING_BUFFER_SECONDS: usize = 8;
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -34,6 +86,41 @@ pub struct AudioSeekRequest {
     pub time_seconds: f64,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioClickRequest {
+    pub enabled: bool,
+    pub bpm: Option<f64>,
+    pub beats_per_bar: Option<u32>,
+    pub accent_first_beat: Option<bool>,
+    pub gain: Option<f32>,
+    pub follow_transport: Option<bool>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioPositionEvent {
+    pub session_id: Option<String>,
+    pub position_seconds: f64,
+    pub duration_seconds: f64,
+    pub state: &'static str,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioStateEvent {
+    pub session_id: Option<String>,
+    pub state: &'static str,
+    pub position_seconds: f64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioErrorEvent {
+    pub session_id: Option<String>,
+    pub message: String,
+}
+
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AudioSnapshot {
@@ -64,6 +151,142 @@ impl TransportStatus {
     }
 }
 
+#[derive(Clone)]
+enum PlaybackLaneSource {
+    Stream(Arc<StreamingLane>),
+}
+
+#[derive(Clone)]
+struct PlaybackLane {
+    id: String,
+    muted: bool,
+    solo: bool,
+    current_gain: f32,
+    target_gain: f32,
+    scratch: Vec<f32>,
+    source: PlaybackLaneSource,
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+struct StreamingLane {
+    ring: Arc<Mutex<RingBuffer>>,
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+struct RingBuffer {
+    samples: VecDeque<f32>,
+    capacity_samples: usize,
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+impl RingBuffer {
+    fn new(capacity_samples: usize) -> Self {
+        Self {
+            samples: VecDeque::with_capacity(capacity_samples),
+            capacity_samples,
+        }
+    }
+
+    fn available_capacity(&self) -> usize {
+        self.capacity_samples.saturating_sub(self.samples.len())
+    }
+
+    fn clear(&mut self) {
+        self.samples.clear();
+    }
+
+    fn pop_into(&mut self, output: &mut [f32]) {
+        for sample in output {
+            *sample = self.samples.pop_front().unwrap_or(0.0);
+        }
+    }
+
+    fn push_samples(&mut self, samples: &[f32]) -> bool {
+        if samples.len() > self.available_capacity() {
+            return false;
+        }
+        self.samples.extend(samples.iter().copied());
+        true
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+enum WorkerControl {
+    Seek(f64),
+    Stop,
+}
+
+#[derive(Clone)]
+struct ClickState {
+    enabled: bool,
+    bpm: f64,
+    beats_per_bar: u32,
+    accent_first_beat: bool,
+    gain: f32,
+    follow_transport: bool,
+}
+
+impl Default for ClickState {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            bpm: 120.0,
+            beats_per_bar: 4,
+            accent_first_beat: true,
+            gain: 0.75,
+            follow_transport: true,
+        }
+    }
+}
+
+struct PlaybackShared {
+    session_id: Option<String>,
+    status: TransportStatus,
+    position_seconds: f64,
+    duration_seconds: f64,
+    playback_rate: f64,
+    native_playback_supported: bool,
+    fallback_reason: Option<String>,
+    sample_rate: u32,
+    channels: usize,
+    lanes: Vec<PlaybackLane>,
+    snapshot_lanes: Vec<EffectiveAudioLane>,
+    click: ClickState,
+    ended_pending: bool,
+    error_pending: Option<String>,
+}
+
+impl PlaybackShared {
+    fn snapshot(&self) -> AudioSnapshot {
+        AudioSnapshot {
+            session_id: self.session_id.clone(),
+            state: self.status.as_str(),
+            position_seconds: self.position_seconds,
+            duration_seconds: self.duration_seconds,
+            playback_rate: self.playback_rate,
+            native_playback_supported: self.native_playback_supported,
+            fallback_reason: self.fallback_reason.clone(),
+            lanes: self.snapshot_lanes.clone(),
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+struct PlaybackRuntime {
+    shared: Arc<Mutex<PlaybackShared>>,
+    audio_stop_sender: mpsc::Sender<RuntimeControl>,
+    reporter_stop_sender: mpsc::Sender<RuntimeControl>,
+    worker_control_senders: Vec<mpsc::Sender<WorkerControl>>,
+    audio_thread: Option<JoinHandle<()>>,
+    reporter_thread: Option<JoinHandle<()>>,
+    worker_threads: Vec<JoinHandle<()>>,
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+enum RuntimeControl {
+    Stop,
+}
+
 pub struct TransportState {
     session_id: Option<String>,
     status: TransportStatus,
@@ -73,7 +296,11 @@ pub struct TransportState {
     playback_rate: f64,
     native_playback_supported: bool,
     fallback_reason: Option<String>,
+    raw_lanes: Vec<AudioLaneRequest>,
     lanes: Vec<EffectiveAudioLane>,
+    click: ClickState,
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    runtime: Option<PlaybackRuntime>,
 }
 
 impl Default for TransportState {
@@ -84,10 +311,14 @@ impl Default for TransportState {
             started_at: None,
             position_seconds: 0.0,
             duration_seconds: 0.0,
-            playback_rate: 1.0,
+            playback_rate: DEFAULT_PLAYBACK_RATE,
             native_playback_supported: false,
             fallback_reason: None,
+            raw_lanes: Vec::new(),
             lanes: Vec::new(),
+            click: ClickState::default(),
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            runtime: None,
         }
     }
 }
@@ -95,25 +326,62 @@ impl Default for TransportState {
 impl TransportState {
     pub fn prepare(
         &mut self,
+        app: Option<AppHandle>,
         request: AudioSessionRequest,
         lanes: Vec<EffectiveAudioLane>,
         capabilities: AudioCapabilities,
     ) -> AudioSession {
+        let duration_seconds = request.duration_seconds.unwrap_or(0.0).max(0.0);
+        let playback_rate = normalize_playback_rate(request.playback_rate);
+        let mut native_playback_supported = capabilities.native_playback_supported;
+        let mut fallback_reason = capabilities.fallback_reason.map(str::to_string);
+        let mut next_runtime = None;
+
+        if native_playback_supported {
+            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            if let Some(app) = app {
+                match start_desktop_runtime(
+                    app,
+                    &request.session_id,
+                    duration_seconds,
+                    playback_rate,
+                    &request.lanes,
+                    &lanes,
+                    &self.click,
+                ) {
+                    Ok(runtime) => {
+                        next_runtime = Some(runtime);
+                    }
+                    Err(error) => {
+                        native_playback_supported = false;
+                        fallback_reason = Some(error);
+                    }
+                }
+            }
+
+            #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+            {
+                native_playback_supported = false;
+                fallback_reason =
+                    Some("Native playback is unsupported on this platform.".to_string());
+            }
+        }
+
+        self.stop_runtime();
         self.session_id = Some(request.session_id.clone());
         self.status = TransportStatus::Stopped;
         self.started_at = None;
         self.position_seconds = 0.0;
-        self.duration_seconds = request.duration_seconds.unwrap_or(0.0).max(0.0);
-        self.playback_rate = request.playback_rate.unwrap_or(1.0).max(0.0);
-        let default_rate_supported = (self.playback_rate - 1.0).abs() < f64::EPSILON;
-        self.native_playback_supported =
-            capabilities.native_playback_supported && default_rate_supported;
-        self.fallback_reason = if default_rate_supported {
-            capabilities.fallback_reason.map(str::to_string)
-        } else {
-            Some("Native audio playback only supports default-rate playback.".to_string())
-        };
-        self.lanes = lanes;
+        self.duration_seconds = duration_seconds;
+        self.playback_rate = playback_rate;
+        self.raw_lanes = request.lanes.clone();
+        self.lanes = lanes.clone();
+        self.native_playback_supported = native_playback_supported;
+        self.fallback_reason = fallback_reason;
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        {
+            self.runtime = next_runtime;
+        }
 
         AudioSession {
             id: request.session_id,
@@ -123,20 +391,64 @@ impl TransportState {
         }
     }
 
-    pub fn set_effective_lanes(&mut self, lanes: Vec<EffectiveAudioLane>) {
-        self.lanes = lanes;
+    pub fn set_lanes(&mut self, raw_lanes: Vec<AudioLaneRequest>, lanes: Vec<EffectiveAudioLane>) {
+        self.raw_lanes = raw_lanes;
+        self.lanes = lanes.clone();
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        if let Some(runtime) = &self.runtime {
+            if let Ok(mut shared) = runtime.shared.lock() {
+                update_shared_lanes(&mut shared, &lanes);
+            }
+        }
+    }
+
+    pub fn set_click(&mut self, request: AudioClickRequest) -> AudioSnapshot {
+        self.click = ClickState {
+            enabled: request.enabled,
+            bpm: request.bpm.unwrap_or(120.0).clamp(30.0, 300.0),
+            beats_per_bar: request.beats_per_bar.unwrap_or(4).clamp(1, 12),
+            accent_first_beat: request.accent_first_beat.unwrap_or(true),
+            gain: request.gain.unwrap_or(0.75).clamp(0.0, 1.0),
+            follow_transport: request.follow_transport.unwrap_or(true),
+        };
+
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        if let Some(runtime) = &self.runtime {
+            if let Ok(mut shared) = runtime.shared.lock() {
+                shared.click = self.click.clone();
+            }
+        }
+
+        self.snapshot()
     }
 
     pub fn play(&mut self, request: AudioPlayRequest) -> Result<AudioSnapshot, String> {
         if self.session_id.is_none() {
             return Err("Native audio session is not prepared.".to_string());
         }
+
+        let should_seek_workers = request.start_time_seconds.is_some();
         if let Some(start_time_seconds) = request.start_time_seconds {
             self.position_seconds = self.clamp_position(start_time_seconds);
         }
         let _ = request.scheduled_start_time_seconds;
         self.status = TransportStatus::Playing;
         self.started_at = Some(Instant::now());
+
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        if let Some(runtime) = &self.runtime {
+            if should_seek_workers {
+                seek_runtime_workers(runtime, self.position_seconds);
+            }
+            let mut shared = runtime
+                .shared
+                .lock()
+                .map_err(|_| "Native playback state is unavailable.".to_string())?;
+            shared.position_seconds = self.position_seconds;
+            shared.status = TransportStatus::Playing;
+            shared.ended_pending = false;
+        }
+
         Ok(self.snapshot())
     }
 
@@ -144,6 +456,15 @@ impl TransportState {
         self.position_seconds = self.current_position();
         self.status = TransportStatus::Paused;
         self.started_at = None;
+
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        if let Some(runtime) = &self.runtime {
+            if let Ok(mut shared) = runtime.shared.lock() {
+                self.position_seconds = shared.position_seconds;
+                shared.status = TransportStatus::Paused;
+            }
+        }
+
         self.snapshot()
     }
 
@@ -151,6 +472,17 @@ impl TransportState {
         self.position_seconds = 0.0;
         self.status = TransportStatus::Stopped;
         self.started_at = None;
+
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        if let Some(runtime) = &self.runtime {
+            seek_runtime_workers(runtime, 0.0);
+            if let Ok(mut shared) = runtime.shared.lock() {
+                shared.position_seconds = 0.0;
+                shared.status = TransportStatus::Stopped;
+                shared.ended_pending = false;
+            }
+        }
+
         self.snapshot()
     }
 
@@ -159,10 +491,27 @@ impl TransportState {
         if self.status == TransportStatus::Playing {
             self.started_at = Some(Instant::now());
         }
+
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        if let Some(runtime) = &self.runtime {
+            seek_runtime_workers(runtime, self.position_seconds);
+            if let Ok(mut shared) = runtime.shared.lock() {
+                shared.position_seconds = self.position_seconds;
+                shared.ended_pending = false;
+            }
+        }
+
         self.snapshot()
     }
 
     pub fn snapshot(&self) -> AudioSnapshot {
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        if let Some(runtime) = &self.runtime {
+            if let Ok(shared) = runtime.shared.lock() {
+                return shared.snapshot();
+            }
+        }
+
         AudioSnapshot {
             session_id: self.session_id.clone(),
             state: self.status.as_str(),
@@ -188,19 +537,1103 @@ impl TransportState {
     }
 
     fn clamp_position(&self, value: f64) -> f64 {
-        if !value.is_finite() {
-            return 0.0;
-        }
-        if self.duration_seconds <= 0.0 {
-            return value.max(0.0);
-        }
-        value.clamp(0.0, self.duration_seconds)
+        clamp_position(value, self.duration_seconds)
     }
+
+    fn stop_runtime(&mut self) {
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        if let Some(mut runtime) = self.runtime.take() {
+            for sender in &runtime.worker_control_senders {
+                let _ = sender.send(WorkerControl::Stop);
+            }
+            let _ = runtime.audio_stop_sender.send(RuntimeControl::Stop);
+            let _ = runtime.reporter_stop_sender.send(RuntimeControl::Stop);
+            if let Some(audio_thread) = runtime.audio_thread.take() {
+                let _ = audio_thread.join();
+            }
+            if let Some(reporter_thread) = runtime.reporter_thread.take() {
+                let _ = reporter_thread.join();
+            }
+            for worker_thread in runtime.worker_threads {
+                let _ = worker_thread.join();
+            }
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn seek_runtime_workers(runtime: &PlaybackRuntime, position_seconds: f64) {
+    for sender in &runtime.worker_control_senders {
+        let _ = sender.send(WorkerControl::Seek(position_seconds));
+    }
+}
+
+impl Drop for TransportState {
+    fn drop(&mut self) {
+        self.stop_runtime();
+    }
+}
+
+fn normalize_playback_rate(value: Option<f64>) -> f64 {
+    let rate = value.unwrap_or(DEFAULT_PLAYBACK_RATE);
+    if !rate.is_finite() || rate <= 0.0 {
+        return DEFAULT_PLAYBACK_RATE;
+    }
+    rate
+}
+
+fn clamp_position(value: f64, duration_seconds: f64) -> f64 {
+    if !value.is_finite() {
+        return 0.0;
+    }
+    if duration_seconds <= 0.0 {
+        return value.max(0.0);
+    }
+    value.clamp(0.0, duration_seconds)
+}
+
+fn effective_gain_for_lane(lanes: &[EffectiveAudioLane], id: &str) -> f32 {
+    lanes
+        .iter()
+        .find(|lane| lane.id == id)
+        .map(|lane| lane.effective_gain.clamp(0.0, 1.0))
+        .unwrap_or(0.0)
+}
+
+fn update_shared_lanes(shared: &mut PlaybackShared, lanes: &[EffectiveAudioLane]) {
+    shared.snapshot_lanes = lanes.to_vec();
+    for lane in &mut shared.lanes {
+        lane.target_gain = effective_gain_for_lane(lanes, &lane.id);
+        if let Some(effective) = lanes.iter().find(|candidate| candidate.id == lane.id) {
+            lane.muted = effective.muted;
+            lane.solo = effective.solo;
+        }
+    }
+}
+
+fn click_sample(click: &ClickState, position_seconds: f64, channel: usize) -> f32 {
+    if !click.enabled || click.bpm <= 0.0 || click.gain <= 0.0 {
+        return 0.0;
+    }
+
+    let beat_seconds = 60.0 / click.bpm;
+    if beat_seconds <= 0.0 {
+        return 0.0;
+    }
+    let beat_index = (position_seconds / beat_seconds).floor().max(0.0) as u64;
+    let beat_offset = position_seconds - beat_index as f64 * beat_seconds;
+    let accented = click.accent_first_beat && beat_index % u64::from(click.beats_per_bar) == 0;
+    let duration = if accented {
+        CLICK_ACCENT_DURATION_SECONDS
+    } else {
+        CLICK_DURATION_SECONDS
+    };
+    if !(0.0..=duration).contains(&beat_offset) {
+        return 0.0;
+    }
+
+    let frequency = if accented {
+        CLICK_ACCENT_FREQUENCY_HZ
+    } else {
+        CLICK_FREQUENCY_HZ
+    };
+    let phase = (beat_offset * frequency).fract();
+    let square = if phase < 0.5 { 1.0 } else { -1.0 };
+    let envelope = (1.0 - beat_offset / duration).max(0.0);
+    let pan = if channel == 0 { 1.0 } else { 0.92 };
+    (square * envelope * f64::from(click.gain) * pan * 0.35) as f32
+}
+
+fn mix_shared_frame(shared: &mut PlaybackShared, channel: usize, sample_index: usize) -> f32 {
+    let mut sample = 0.0;
+    let ramp_step = (1.0 / (shared.sample_rate as f64 * GAIN_RAMP_SECONDS)).max(0.0001) as f32;
+
+    for lane in &mut shared.lanes {
+        if lane.current_gain < lane.target_gain {
+            lane.current_gain = (lane.current_gain + ramp_step).min(lane.target_gain);
+        } else if lane.current_gain > lane.target_gain {
+            lane.current_gain = (lane.current_gain - ramp_step).max(lane.target_gain);
+        }
+
+        let lane_sample = lane.scratch.get(sample_index).copied().unwrap_or(0.0);
+
+        if lane.current_gain > 0.0001 {
+            sample += lane_sample * lane.current_gain;
+        }
+    }
+
+    if !shared.click.follow_transport || shared.status == TransportStatus::Playing {
+        sample += click_sample(&shared.click, shared.position_seconds, channel);
+    }
+
+    sample.clamp(-1.0, 1.0)
+}
+
+fn prepare_lane_scratch(lanes: &mut [PlaybackLane], sample_count: usize) {
+    for lane in lanes {
+        if lane.scratch.len() < sample_count {
+            lane.scratch.resize(sample_count, 0.0);
+        } else {
+            lane.scratch[..sample_count].fill(0.0);
+        }
+
+        match &lane.source {
+            PlaybackLaneSource::Stream(stream) => {
+                if let Ok(mut ring) = stream.ring.try_lock() {
+                    ring.pop_into(&mut lane.scratch[..sample_count]);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+fn render_shared_output(shared: &mut PlaybackShared, output: &mut [f32]) {
+    if shared.channels == 0 {
+        output.fill(0.0);
+        return;
+    }
+    if shared.status == TransportStatus::Playing {
+        prepare_lane_scratch(&mut shared.lanes, output.len());
+    }
+
+    for (frame_index, frame) in output.chunks_mut(shared.channels).enumerate() {
+        if shared.status != TransportStatus::Playing {
+            frame.fill(0.0);
+            continue;
+        }
+
+        for (channel, sample) in frame.iter_mut().enumerate() {
+            *sample = mix_shared_frame(shared, channel, frame_index * shared.channels + channel);
+        }
+
+        shared.position_seconds += shared.playback_rate / shared.sample_rate as f64;
+        if shared.duration_seconds > 0.0 && shared.position_seconds >= shared.duration_seconds {
+            shared.position_seconds = 0.0;
+            shared.status = TransportStatus::Stopped;
+            shared.ended_pending = true;
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn render_shared_output_typed<T>(shared: &mut PlaybackShared, output: &mut [T])
+where
+    T: Sample + FromSample<f32> + Copy,
+{
+    let silent = T::from_sample(0.0);
+    if shared.channels == 0 {
+        for sample in output {
+            *sample = silent;
+        }
+        return;
+    }
+    if shared.status == TransportStatus::Playing {
+        prepare_lane_scratch(&mut shared.lanes, output.len());
+    }
+
+    for (frame_index, frame) in output.chunks_mut(shared.channels).enumerate() {
+        if shared.status != TransportStatus::Playing {
+            for sample in frame {
+                *sample = silent;
+            }
+            continue;
+        }
+
+        for (channel, sample) in frame.iter_mut().enumerate() {
+            *sample = T::from_sample(mix_shared_frame(
+                shared,
+                channel,
+                frame_index * shared.channels + channel,
+            ));
+        }
+
+        shared.position_seconds += shared.playback_rate / shared.sample_rate as f64;
+        if shared.duration_seconds > 0.0 && shared.position_seconds >= shared.duration_seconds {
+            shared.position_seconds = 0.0;
+            shared.status = TransportStatus::Stopped;
+            shared.ended_pending = true;
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn start_desktop_runtime(
+    app: AppHandle,
+    session_id: &str,
+    duration_seconds: f64,
+    playback_rate: f64,
+    raw_lanes: &[AudioLaneRequest],
+    effective_lanes: &[EffectiveAudioLane],
+    click: &ClickState,
+) -> Result<PlaybackRuntime, String> {
+    let host = cpal::default_host();
+    let device = host
+        .default_output_device()
+        .ok_or_else(|| "Native audio output device is unavailable.".to_string())?;
+    let supported_config = device
+        .default_output_config()
+        .map_err(|error| format!("Native audio output config is unavailable: {error}"))?;
+    let sample_format = supported_config.sample_format();
+    let stream_config: cpal::StreamConfig = supported_config.into();
+    let sample_rate = stream_config.sample_rate.0;
+    let channels = usize::from(stream_config.channels).max(1);
+    let (worker_error_sender, worker_error_receiver) = mpsc::channel();
+    let loaded_lanes = load_playback_lanes(
+        raw_lanes,
+        effective_lanes,
+        sample_rate,
+        channels,
+        playback_rate,
+        worker_error_sender,
+    )?;
+    let snapshot_lanes = effective_lanes.to_vec();
+    let shared = Arc::new(Mutex::new(PlaybackShared {
+        session_id: Some(session_id.to_string()),
+        status: TransportStatus::Stopped,
+        position_seconds: 0.0,
+        duration_seconds,
+        playback_rate,
+        native_playback_supported: true,
+        fallback_reason: None,
+        sample_rate,
+        channels,
+        lanes: loaded_lanes.lanes,
+        snapshot_lanes,
+        click: click.clone(),
+        ended_pending: false,
+        error_pending: None,
+    }));
+
+    drop(device);
+
+    let (audio_stop_sender, audio_stop_receiver) = mpsc::channel();
+    let (ready_sender, ready_receiver) = mpsc::channel();
+    let audio_thread = thread::spawn({
+        let shared = shared.clone();
+        let app = app.clone();
+        move || {
+            start_output_stream_thread(
+                stream_config,
+                sample_format,
+                shared,
+                app,
+                audio_stop_receiver,
+                ready_sender,
+            );
+        }
+    });
+
+    match ready_receiver.recv_timeout(Duration::from_secs(5)) {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => {
+            let _ = audio_thread.join();
+            return Err(error);
+        }
+        Err(_) => {
+            let _ = audio_stop_sender.send(RuntimeControl::Stop);
+            let _ = audio_thread.join();
+            return Err("Native audio output stream did not start in time.".to_string());
+        }
+    }
+
+    let (reporter_stop_sender, reporter_stop_receiver) = mpsc::channel();
+    let reporter_thread = thread::spawn({
+        let shared = shared.clone();
+        move || loop {
+            if reporter_stop_receiver.try_recv().is_ok() {
+                break;
+            }
+            while let Ok(message) = worker_error_receiver.try_recv() {
+                if let Ok(mut shared) = shared.lock() {
+                    shared.error_pending = Some(message);
+                    shared.status = TransportStatus::Paused;
+                }
+            }
+            emit_runtime_events(&app, &shared);
+            thread::sleep(POSITION_EVENT_INTERVAL);
+        }
+    });
+
+    Ok(PlaybackRuntime {
+        shared,
+        audio_stop_sender,
+        reporter_stop_sender,
+        worker_control_senders: loaded_lanes.worker_control_senders,
+        audio_thread: Some(audio_thread),
+        reporter_thread: Some(reporter_thread),
+        worker_threads: loaded_lanes.worker_threads,
+    })
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn start_output_stream_thread(
+    config: cpal::StreamConfig,
+    sample_format: SampleFormat,
+    shared: Arc<Mutex<PlaybackShared>>,
+    app: AppHandle,
+    stop_receiver: mpsc::Receiver<RuntimeControl>,
+    ready_sender: mpsc::Sender<Result<(), String>>,
+) {
+    let host = cpal::default_host();
+    let result = (|| {
+        let device = host
+            .default_output_device()
+            .ok_or_else(|| "Native audio output device is unavailable.".to_string())?;
+        let stream = build_output_stream(&device, &config, sample_format, shared, app)?;
+        stream
+            .play()
+            .map_err(|error| format!("Native audio output stream could not start: {error}"))?;
+        Ok(stream)
+    })();
+    let stream = match result {
+        Ok(stream) => {
+            let _ = ready_sender.send(Ok(()));
+            stream
+        }
+        Err(error) => {
+            let _ = ready_sender.send(Err(error));
+            return;
+        }
+    };
+    loop {
+        if stop_receiver
+            .recv_timeout(Duration::from_millis(250))
+            .is_ok()
+        {
+            break;
+        }
+    }
+    drop(stream);
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn build_output_stream(
+    device: &cpal::Device,
+    config: &cpal::StreamConfig,
+    sample_format: SampleFormat,
+    shared: Arc<Mutex<PlaybackShared>>,
+    app: AppHandle,
+) -> Result<cpal::Stream, String> {
+    match sample_format {
+        SampleFormat::F32 => build_typed_output_stream::<f32>(device, config, shared, app),
+        SampleFormat::I16 => build_typed_output_stream::<i16>(device, config, shared, app),
+        SampleFormat::U16 => build_typed_output_stream::<u16>(device, config, shared, app),
+        other => Err(format!(
+            "Native audio sample format {other:?} is unsupported."
+        )),
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn build_typed_output_stream<T>(
+    device: &cpal::Device,
+    config: &cpal::StreamConfig,
+    shared: Arc<Mutex<PlaybackShared>>,
+    app: AppHandle,
+) -> Result<cpal::Stream, String>
+where
+    T: Sample + SizedSample + FromSample<f32>,
+{
+    let data_shared = shared.clone();
+    let error_shared = shared;
+    device
+        .build_output_stream(
+            config,
+            move |output: &mut [T], _| {
+                if let Ok(mut shared) = data_shared.lock() {
+                    render_shared_output_typed(&mut shared, output);
+                    return;
+                }
+                let silent = T::from_sample(0.0);
+                for sample in output {
+                    *sample = silent;
+                }
+            },
+            move |error| {
+                let message = format!("Native audio output stream error: {error}");
+                if let Ok(mut shared) = error_shared.lock() {
+                    shared.error_pending = Some(message.clone());
+                    shared.status = TransportStatus::Paused;
+                }
+                let _ = app.emit(
+                    AUDIO_EVENT_ERROR,
+                    AudioErrorEvent {
+                        session_id: None,
+                        message,
+                    },
+                );
+            },
+            None,
+        )
+        .map_err(|error| format!("Native audio output stream could not be built: {error}"))
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn emit_runtime_events(app: &AppHandle, shared: &Arc<Mutex<PlaybackShared>>) {
+    let (snapshot, ended, error) = {
+        let mut shared = match shared.lock() {
+            Ok(shared) => shared,
+            Err(_) => return,
+        };
+        let snapshot = shared.snapshot();
+        let ended = shared.ended_pending;
+        shared.ended_pending = false;
+        let error = shared.error_pending.take();
+        (snapshot, ended, error)
+    };
+
+    let _ = app.emit(
+        AUDIO_EVENT_POSITION,
+        AudioPositionEvent {
+            session_id: snapshot.session_id.clone(),
+            position_seconds: snapshot.position_seconds,
+            duration_seconds: snapshot.duration_seconds,
+            state: snapshot.state,
+        },
+    );
+    let _ = app.emit(
+        AUDIO_EVENT_STATE,
+        AudioStateEvent {
+            session_id: snapshot.session_id.clone(),
+            state: snapshot.state,
+            position_seconds: snapshot.position_seconds,
+        },
+    );
+    if ended {
+        let _ = app.emit(AUDIO_EVENT_ENDED, snapshot.clone());
+    }
+    if let Some(message) = error {
+        let _ = app.emit(
+            AUDIO_EVENT_ERROR,
+            AudioErrorEvent {
+                session_id: snapshot.session_id,
+                message,
+            },
+        );
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+struct LoadedPlaybackLanes {
+    lanes: Vec<PlaybackLane>,
+    worker_control_senders: Vec<mpsc::Sender<WorkerControl>>,
+    worker_threads: Vec<JoinHandle<()>>,
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn load_playback_lanes(
+    raw_lanes: &[AudioLaneRequest],
+    effective_lanes: &[EffectiveAudioLane],
+    sample_rate: u32,
+    channels: usize,
+    playback_rate: f64,
+    worker_error_sender: mpsc::Sender<String>,
+) -> Result<LoadedPlaybackLanes, String> {
+    let mut lanes = Vec::new();
+    let mut worker_control_senders = Vec::new();
+    let mut worker_threads = Vec::new();
+
+    for lane in raw_lanes {
+        let Some(source_path) = &lane.source_path else {
+            continue;
+        };
+        let path = PathBuf::from(source_path);
+        if !path.exists() {
+            return Err(format!("Native playback source is missing: {source_path}"));
+        }
+
+        let capacity_samples = (sample_rate as usize)
+            .saturating_mul(channels)
+            .saturating_mul(RING_BUFFER_SECONDS)
+            .max(
+                STREAM_CHUNK_FRAMES
+                    .saturating_mul(channels)
+                    .saturating_mul(2),
+            );
+        let ring = Arc::new(Mutex::new(RingBuffer::new(capacity_samples)));
+        let (sender, worker_thread) = spawn_decoder_worker(
+            path,
+            ring.clone(),
+            sample_rate,
+            channels,
+            playback_rate,
+            worker_error_sender.clone(),
+        )?;
+        let target_gain = effective_gain_for_lane(effective_lanes, &lane.id);
+        worker_control_senders.push(sender);
+        worker_threads.push(worker_thread);
+        lanes.push(PlaybackLane {
+            id: lane.id.clone(),
+            muted: lane.muted,
+            solo: lane.solo,
+            current_gain: target_gain,
+            target_gain,
+            scratch: vec![0.0; sample_rate as usize * channels],
+            source: PlaybackLaneSource::Stream(Arc::new(StreamingLane { ring })),
+        });
+    }
+
+    Ok(LoadedPlaybackLanes {
+        lanes,
+        worker_control_senders,
+        worker_threads,
+    })
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn spawn_decoder_worker(
+    path: PathBuf,
+    ring: Arc<Mutex<RingBuffer>>,
+    target_sample_rate: u32,
+    target_channels: usize,
+    playback_rate: f64,
+    error_sender: mpsc::Sender<String>,
+) -> Result<(mpsc::Sender<WorkerControl>, JoinHandle<()>), String> {
+    let mut decoder = StreamingDecoder::open(
+        path.clone(),
+        target_sample_rate,
+        target_channels,
+        playback_rate,
+        0.0,
+    )?;
+    let (sender, receiver) = mpsc::channel();
+    let worker_thread = thread::spawn(move || loop {
+        while let Ok(control) = receiver.try_recv() {
+            match control {
+                WorkerControl::Seek(position_seconds) => {
+                    if let Ok(mut guard) = ring.lock() {
+                        guard.clear();
+                    }
+                    if decoder.seek(position_seconds).is_err() {
+                        match StreamingDecoder::open(
+                            path.clone(),
+                            target_sample_rate,
+                            target_channels,
+                            playback_rate,
+                            position_seconds,
+                        ) {
+                            Ok(reopened) => {
+                                decoder = reopened;
+                            }
+                            Err(error) => {
+                                let _ = error_sender.send(error);
+                                return;
+                            }
+                        }
+                    }
+                }
+                WorkerControl::Stop => return,
+            }
+        }
+
+        let requested_samples = STREAM_CHUNK_FRAMES.saturating_mul(target_channels);
+        let has_capacity = ring
+            .lock()
+            .map(|guard| guard.available_capacity() >= requested_samples)
+            .unwrap_or(false);
+        if !has_capacity {
+            thread::sleep(Duration::from_millis(5));
+            continue;
+        }
+
+        match decoder.next_chunk() {
+            Ok(Some(samples)) => {
+                if samples.is_empty() {
+                    thread::sleep(Duration::from_millis(2));
+                    continue;
+                }
+                if let Ok(mut guard) = ring.lock() {
+                    if !guard.push_samples(&samples) {
+                        drop(guard);
+                        thread::sleep(Duration::from_millis(5));
+                    }
+                } else {
+                    return;
+                }
+            }
+            Ok(None) => {
+                thread::sleep(Duration::from_millis(20));
+            }
+            Err(error) => {
+                let _ = error_sender.send(error);
+                return;
+            }
+        }
+    });
+
+    Ok((sender, worker_thread))
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+enum StreamingDecoder {
+    Wav(WavStreamDecoder),
+    Symphonia(SymphoniaStreamDecoder),
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+impl StreamingDecoder {
+    fn open(
+        path: PathBuf,
+        target_sample_rate: u32,
+        target_channels: usize,
+        playback_rate: f64,
+        start_seconds: f64,
+    ) -> Result<Self, String> {
+        let is_wav = path
+            .extension()
+            .and_then(|value| value.to_str())
+            .map(|value| value.eq_ignore_ascii_case("wav"))
+            .unwrap_or(false);
+        if is_wav {
+            match WavStreamDecoder::open(
+                &path,
+                target_sample_rate,
+                target_channels,
+                playback_rate,
+                start_seconds,
+            ) {
+                Ok(decoder) => return Ok(Self::Wav(decoder)),
+                Err(wav_error) => {
+                    return SymphoniaStreamDecoder::open(
+                        path,
+                        target_sample_rate,
+                        target_channels,
+                        playback_rate,
+                        start_seconds,
+                    )
+                    .map(Self::Symphonia)
+                    .map_err(|symphonia_error| {
+                        format!(
+                            "Native playback could not decode WAV source. Fast path failed: {wav_error}. Symphonia failed: {symphonia_error}"
+                        )
+                    });
+                }
+            }
+        }
+
+        SymphoniaStreamDecoder::open(
+            path,
+            target_sample_rate,
+            target_channels,
+            playback_rate,
+            start_seconds,
+        )
+        .map(Self::Symphonia)
+    }
+
+    fn next_chunk(&mut self) -> Result<Option<Vec<f32>>, String> {
+        match self {
+            Self::Wav(decoder) => decoder.next_chunk(),
+            Self::Symphonia(decoder) => decoder.next_chunk(),
+        }
+    }
+
+    fn seek(&mut self, position_seconds: f64) -> Result<(), String> {
+        match self {
+            Self::Wav(decoder) => decoder.seek(position_seconds),
+            Self::Symphonia(decoder) => decoder.seek(position_seconds),
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+struct WavStreamDecoder {
+    file: File,
+    audio_format: u16,
+    channels: u16,
+    sample_rate: u32,
+    block_align: u16,
+    bits_per_sample: u16,
+    bytes_per_sample: usize,
+    data_start: u64,
+    data_end: u64,
+    target_sample_rate: u32,
+    target_channels: usize,
+    playback_rate: f64,
+    stretch: signalsmith_stretch::Stretch,
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+impl WavStreamDecoder {
+    fn open(
+        path: &Path,
+        target_sample_rate: u32,
+        target_channels: usize,
+        playback_rate: f64,
+        start_seconds: f64,
+    ) -> Result<Self, String> {
+        let mut file = File::open(path).map_err(|error| error.to_string())?;
+        let mut riff = [0u8; 12];
+        file.read_exact(&mut riff)
+            .map_err(|error| error.to_string())?;
+        if &riff[0..4] != b"RIFF" || &riff[8..12] != b"WAVE" {
+            return Err("Not a PCM WAV file.".to_string());
+        }
+
+        let mut audio_format = 0u16;
+        let mut channels = 0u16;
+        let mut sample_rate = 0u32;
+        let mut block_align = 0u16;
+        let mut bits_per_sample = 0u16;
+        let mut data_range: Option<(u64, u64)> = None;
+
+        loop {
+            let mut header = [0u8; 8];
+            match file.read_exact(&mut header) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                Err(error) => return Err(error.to_string()),
+            }
+
+            let chunk_size = read_u32_le(&header, 4)
+                .ok_or_else(|| "Invalid WAV chunk header.".to_string())?
+                as u64;
+            let chunk_start = file.stream_position().map_err(|error| error.to_string())?;
+            let chunk_end = chunk_start.saturating_add(chunk_size);
+
+            if &header[0..4] == b"fmt " {
+                if chunk_size < 16 {
+                    return Err("Invalid WAV fmt chunk.".to_string());
+                }
+                let mut fmt = vec![0u8; chunk_size as usize];
+                file.read_exact(&mut fmt)
+                    .map_err(|error| error.to_string())?;
+                audio_format =
+                    read_u16_le(&fmt, 0).ok_or_else(|| "Invalid WAV audio format.".to_string())?;
+                channels =
+                    read_u16_le(&fmt, 2).ok_or_else(|| "Invalid WAV channel count.".to_string())?;
+                sample_rate =
+                    read_u32_le(&fmt, 4).ok_or_else(|| "Invalid WAV sample rate.".to_string())?;
+                block_align = read_u16_le(&fmt, 12)
+                    .ok_or_else(|| "Invalid WAV block alignment.".to_string())?;
+                bits_per_sample =
+                    read_u16_le(&fmt, 14).ok_or_else(|| "Invalid WAV bit depth.".to_string())?;
+            } else if &header[0..4] == b"data" {
+                data_range = Some((chunk_start, chunk_end));
+                file.seek(SeekFrom::Start(chunk_end + (chunk_size % 2)))
+                    .map_err(|error| error.to_string())?;
+            } else {
+                file.seek(SeekFrom::Start(chunk_end + (chunk_size % 2)))
+                    .map_err(|error| error.to_string())?;
+            }
+        }
+
+        if audio_format != 1 && audio_format != 3 {
+            return Err("WAV decode supports PCM and 32-bit float WAV files.".to_string());
+        }
+        if channels == 0 || sample_rate == 0 || block_align == 0 || bits_per_sample == 0 {
+            return Err("Invalid WAV stream metadata.".to_string());
+        }
+        let bytes_per_sample = (bits_per_sample / 8) as usize;
+        if bytes_per_sample == 0 {
+            return Err("Invalid WAV bit depth.".to_string());
+        }
+        let (data_start, data_end) =
+            data_range.ok_or_else(|| "WAV data chunk is missing.".to_string())?;
+
+        let mut decoder = Self {
+            file,
+            audio_format,
+            channels,
+            sample_rate,
+            block_align,
+            bits_per_sample,
+            bytes_per_sample,
+            data_start,
+            data_end,
+            target_sample_rate,
+            target_channels,
+            playback_rate,
+            stretch: signalsmith_stretch::Stretch::preset_default(
+                target_channels as u32,
+                target_sample_rate,
+            ),
+        };
+        decoder.seek(start_seconds)?;
+        Ok(decoder)
+    }
+
+    fn next_chunk(&mut self) -> Result<Option<Vec<f32>>, String> {
+        let current = self
+            .file
+            .stream_position()
+            .map_err(|error| error.to_string())?;
+        if current >= self.data_end {
+            return Ok(None);
+        }
+
+        let source_frames = STREAM_CHUNK_FRAMES
+            .min(((self.data_end - current) / u64::from(self.block_align)) as usize);
+        if source_frames == 0 {
+            return Ok(None);
+        }
+
+        let byte_count = source_frames
+            .checked_mul(self.block_align as usize)
+            .ok_or_else(|| "WAV chunk is too large.".to_string())?;
+        let mut bytes = vec![0u8; byte_count];
+        let read_count = self
+            .file
+            .read(&mut bytes)
+            .map_err(|error| error.to_string())?;
+        bytes.truncate(read_count);
+        let frames_read = bytes.len() / self.block_align as usize;
+        if frames_read == 0 {
+            return Ok(None);
+        }
+
+        let source_channels = self.channels as usize;
+        let mut samples = Vec::with_capacity(frames_read.saturating_mul(source_channels));
+        for frame_index in 0..frames_read {
+            let frame_start = frame_index * self.block_align as usize;
+            for channel_index in 0..source_channels {
+                let sample_offset = frame_start + channel_index * self.bytes_per_sample;
+                samples.push(
+                    decode_wav_sample(
+                        &bytes,
+                        sample_offset,
+                        self.audio_format,
+                        self.bits_per_sample,
+                    )?
+                    .clamp(-1.0, 1.0) as f32,
+                );
+            }
+        }
+
+        prepare_stream_chunk(
+            &samples,
+            u32::from(self.channels),
+            self.sample_rate,
+            self.target_sample_rate,
+            self.target_channels,
+            self.playback_rate,
+            &mut self.stretch,
+        )
+        .map(Some)
+    }
+
+    fn seek(&mut self, position_seconds: f64) -> Result<(), String> {
+        let source_frame = (position_seconds.max(0.0) * self.sample_rate as f64).floor() as u64;
+        let source_offset = source_frame.saturating_mul(u64::from(self.block_align));
+        let bounded = self
+            .data_start
+            .saturating_add(source_offset)
+            .min(self.data_end);
+        self.file
+            .seek(SeekFrom::Start(bounded))
+            .map_err(|error| error.to_string())?;
+        self.stretch.reset();
+        Ok(())
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+struct SymphoniaStreamDecoder {
+    format: Box<dyn FormatReader>,
+    decoder: Box<dyn Decoder>,
+    track_id: u32,
+    sample_buffer: Option<SampleBuffer<f32>>,
+    sample_buffer_spec: Option<(u32, usize)>,
+    target_sample_rate: u32,
+    target_channels: usize,
+    playback_rate: f64,
+    stretch: signalsmith_stretch::Stretch,
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+impl SymphoniaStreamDecoder {
+    fn open(
+        path: PathBuf,
+        target_sample_rate: u32,
+        target_channels: usize,
+        playback_rate: f64,
+        start_seconds: f64,
+    ) -> Result<Self, String> {
+        let file = File::open(&path).map_err(|error| error.to_string())?;
+        let mss = MediaSourceStream::new(Box::new(file), Default::default());
+        let mut hint = Hint::new();
+        if let Some(extension) = path.extension().and_then(|value| value.to_str()) {
+            hint.with_extension(extension);
+        }
+        let probed = symphonia::default::get_probe()
+            .format(
+                &hint,
+                mss,
+                &FormatOptions::default(),
+                &MetadataOptions::default(),
+            )
+            .map_err(|error| format!("Native playback could not probe media: {error}"))?;
+        let format = probed.format;
+        let track = format
+            .default_track()
+            .or_else(|| {
+                format
+                    .tracks()
+                    .iter()
+                    .find(|track| track.codec_params.codec != CODEC_TYPE_NULL)
+            })
+            .ok_or_else(|| "Native playback source does not contain an audio track.".to_string())?;
+        let track_id = track.id;
+        let codec_params = track.codec_params.clone();
+        let decoder = symphonia::default::get_codecs()
+            .make(&codec_params, &DecoderOptions::default())
+            .map_err(|error| format!("Native playback codec is unsupported: {error}"))?;
+
+        let mut stream = Self {
+            format,
+            decoder,
+            track_id,
+            sample_buffer: None,
+            sample_buffer_spec: None,
+            target_sample_rate,
+            target_channels,
+            playback_rate,
+            stretch: signalsmith_stretch::Stretch::preset_default(
+                target_channels as u32,
+                target_sample_rate,
+            ),
+        };
+        if start_seconds > 0.0 {
+            stream.seek(start_seconds)?;
+        }
+        Ok(stream)
+    }
+
+    fn next_chunk(&mut self) -> Result<Option<Vec<f32>>, String> {
+        loop {
+            let packet = match self.format.next_packet() {
+                Ok(packet) => packet,
+                Err(SymphoniaError::IoError(error))
+                    if error.kind() == std::io::ErrorKind::UnexpectedEof =>
+                {
+                    return Ok(None)
+                }
+                Err(SymphoniaError::DecodeError(_)) => continue,
+                Err(SymphoniaError::ResetRequired) => {
+                    self.decoder.reset();
+                    continue;
+                }
+                Err(error) => {
+                    return Err(format!("Native playback demux failed: {error}"));
+                }
+            };
+
+            if packet.track_id() != self.track_id {
+                continue;
+            }
+
+            let decoded = match self.decoder.decode(&packet) {
+                Ok(decoded) => decoded,
+                Err(SymphoniaError::DecodeError(_)) => continue,
+                Err(SymphoniaError::IoError(error))
+                    if error.kind() == std::io::ErrorKind::UnexpectedEof =>
+                {
+                    return Ok(None)
+                }
+                Err(SymphoniaError::ResetRequired) => {
+                    self.decoder.reset();
+                    continue;
+                }
+                Err(error) => {
+                    return Err(format!("Native playback decode failed: {error}"));
+                }
+            };
+            let spec = *decoded.spec();
+            let duration = decoded.capacity() as u64;
+            let spec_key = (spec.rate, spec.channels.count());
+            let needs_buffer = self
+                .sample_buffer
+                .as_ref()
+                .map(|buffer| {
+                    self.sample_buffer_spec != Some(spec_key)
+                        || buffer.capacity() < duration as usize * spec.channels.count()
+                })
+                .unwrap_or(true);
+            if needs_buffer {
+                self.sample_buffer = Some(SampleBuffer::<f32>::new(duration, spec));
+                self.sample_buffer_spec = Some(spec_key);
+            }
+            let buffer = self
+                .sample_buffer
+                .as_mut()
+                .ok_or_else(|| "Native playback sample buffer is unavailable.".to_string())?;
+            buffer.copy_interleaved_ref(decoded);
+
+            return prepare_stream_chunk(
+                buffer.samples(),
+                spec.channels.count() as u32,
+                spec.rate,
+                self.target_sample_rate,
+                self.target_channels,
+                self.playback_rate,
+                &mut self.stretch,
+            )
+            .map(Some);
+        }
+    }
+
+    fn seek(&mut self, position_seconds: f64) -> Result<(), String> {
+        match self.format.seek(
+            SeekMode::Accurate,
+            SeekTo::Time {
+                time: Time::from(position_seconds.max(0.0)),
+                track_id: Some(self.track_id),
+            },
+        ) {
+            Ok(_) => {
+                self.decoder.reset();
+                self.stretch.reset();
+                self.sample_buffer = None;
+                self.sample_buffer_spec = None;
+                Ok(())
+            }
+            Err(_) => {
+                Err("Native playback source cannot seek to the requested position.".to_string())
+            }
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn prepare_stream_chunk(
+    samples: &[f32],
+    source_channels: u32,
+    source_sample_rate: u32,
+    target_sample_rate: u32,
+    target_channels: usize,
+    playback_rate: f64,
+    stretch: &mut signalsmith_stretch::Stretch,
+) -> Result<Vec<f32>, String> {
+    if samples.is_empty() || source_channels == 0 || target_channels == 0 {
+        return Ok(Vec::new());
+    }
+    let resampled = resample_interleaved(
+        samples,
+        source_channels,
+        source_sample_rate,
+        target_sample_rate,
+    );
+    let converted =
+        convert_interleaved_channels(&resampled, source_channels, target_channels as u32);
+    if (playback_rate - DEFAULT_PLAYBACK_RATE).abs() <= RATE_TOLERANCE {
+        return Ok(converted);
+    }
+    if playback_rate <= 0.0 {
+        return Ok(converted);
+    }
+
+    let input_frames = converted.len() / target_channels;
+    let output_frames = ((input_frames as f64) / playback_rate).ceil().max(1.0) as usize;
+    let mut output = vec![0.0; output_frames * target_channels];
+    stretch.process(&converted, &mut output);
+    Ok(output)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     fn capabilities() -> AudioCapabilities {
         AudioCapabilities {
@@ -220,6 +1653,7 @@ mod tests {
     fn seek_clamps_to_duration() {
         let mut state = TransportState::default();
         state.prepare(
+            None,
             AudioSessionRequest {
                 session_id: "session".to_string(),
                 duration_seconds: Some(30.0),
@@ -239,6 +1673,7 @@ mod tests {
     fn pause_preserves_current_position() {
         let mut state = TransportState::default();
         state.prepare(
+            None,
             AudioSessionRequest {
                 session_id: "session".to_string(),
                 duration_seconds: Some(30.0),
@@ -257,9 +1692,10 @@ mod tests {
     }
 
     #[test]
-    fn non_default_rate_requires_fallback() {
+    fn non_default_rate_is_native_supported_when_capability_allows_it() {
         let mut state = TransportState::default();
         let session = state.prepare(
+            None,
             AudioSessionRequest {
                 session_id: "session".to_string(),
                 duration_seconds: Some(30.0),
@@ -270,10 +1706,101 @@ mod tests {
             capabilities(),
         );
 
-        assert!(!session.native_playback_supported);
-        assert_eq!(
-            session.fallback_reason.as_deref(),
-            Some("Native audio playback only supports default-rate playback.")
-        );
+        assert!(session.native_playback_supported);
+        assert_eq!(session.fallback_reason.as_deref(), None);
+    }
+
+    #[test]
+    fn click_sample_accents_first_beat() {
+        let click = ClickState {
+            enabled: true,
+            bpm: 120.0,
+            beats_per_bar: 4,
+            accent_first_beat: true,
+            gain: 1.0,
+            follow_transport: true,
+        };
+
+        let accented = click_sample(&click, 0.001, 0).abs();
+        let unaccented = click_sample(&click, 0.501, 0).abs();
+
+        assert!(accented > unaccented);
+    }
+
+    #[test]
+    fn render_shared_output_advances_source_position_by_rate() {
+        let ring = Arc::new(Mutex::new(RingBuffer::new(1_000)));
+        ring.lock()
+            .expect("ring lock")
+            .push_samples(&vec![0.5; 1_000]);
+        let mut shared = PlaybackShared {
+            session_id: Some("session".to_string()),
+            status: TransportStatus::Playing,
+            position_seconds: 0.0,
+            duration_seconds: 10.0,
+            playback_rate: 2.0,
+            native_playback_supported: true,
+            fallback_reason: None,
+            sample_rate: 1_000,
+            channels: 1,
+            lanes: vec![PlaybackLane {
+                id: "lane".to_string(),
+                muted: false,
+                solo: false,
+                current_gain: 1.0,
+                target_gain: 1.0,
+                scratch: vec![0.0; 1_000],
+                source: PlaybackLaneSource::Stream(Arc::new(StreamingLane { ring })),
+            }],
+            snapshot_lanes: Vec::new(),
+            click: ClickState::default(),
+            ended_pending: false,
+            error_pending: None,
+        };
+        let mut output = vec![0.0; 10];
+
+        render_shared_output(&mut shared, &mut output);
+
+        assert_eq!(output[0], 0.5);
+        assert!((shared.position_seconds - 0.02).abs() < 0.0001);
+    }
+
+    #[test]
+    fn wav_stream_decoder_preserves_stereo_channels() {
+        let path = std::env::temp_dir().join(format!(
+            "tuneforge-transport-stereo-stream-test-{}.wav",
+            std::process::id()
+        ));
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"RIFF");
+        bytes.extend_from_slice(&44u32.to_le_bytes());
+        bytes.extend_from_slice(b"WAVEfmt ");
+        bytes.extend_from_slice(&16u32.to_le_bytes());
+        bytes.extend_from_slice(&1u16.to_le_bytes());
+        bytes.extend_from_slice(&2u16.to_le_bytes());
+        bytes.extend_from_slice(&48_000u32.to_le_bytes());
+        bytes.extend_from_slice(&192_000u32.to_le_bytes());
+        bytes.extend_from_slice(&4u16.to_le_bytes());
+        bytes.extend_from_slice(&16u16.to_le_bytes());
+        bytes.extend_from_slice(b"data");
+        bytes.extend_from_slice(&8u32.to_le_bytes());
+        for sample in [i16::MAX, i16::MIN, 0, i16::MAX / 2] {
+            bytes.extend_from_slice(&sample.to_le_bytes());
+        }
+        fs::write(&path, bytes).expect("write wav");
+
+        let mut decoder =
+            WavStreamDecoder::open(&path, 48_000, 2, 1.0, 0.0).expect("open stream decoder");
+        let decoded = decoder
+            .next_chunk()
+            .expect("decode stream chunk")
+            .expect("stream chunk");
+        let _ = fs::remove_file(&path);
+
+        assert_eq!(decoded.len(), 4);
+        assert!(decoded[0] > 0.99);
+        assert!(decoded[1] < -0.99);
+        assert_eq!(decoded[2], 0.0);
+        assert!(decoded[3] > 0.49);
     }
 }

--- a/apps/desktop/src/App.settings-theme.test.tsx
+++ b/apps/desktop/src/App.settings-theme.test.tsx
@@ -129,6 +129,11 @@ describe("Desktop app settings theme", () => {
       JSON.stringify({ backend: "native", detail: "desktop-cpal" }),
     );
     window.localStorage.setItem("tuneforge.tuner-native-capture-error", "Native microphone failed.");
+    window.localStorage.setItem(
+      "tuneforge.playback-backend",
+      JSON.stringify({ backend: "web", detail: null }),
+    );
+    window.localStorage.setItem("tuneforge.playback-native-error", "Native output failed.");
     renderApp(["/settings"]);
 
     expect(await screen.findByRole("heading", { name: "Control Room" })).toBeInTheDocument();
@@ -143,7 +148,8 @@ describe("Desktop app settings theme", () => {
     expect(await screen.findByText("/tmp/tuneforge")).toBeInTheDocument();
     expect(screen.getAllByText("Native (desktop-cpal)")).toHaveLength(2);
     expect(screen.getByText("Native microphone failed.")).toBeInTheDocument();
-    expect(screen.getByText("Web Audio")).toBeInTheDocument();
+    expect(screen.getByText("Native output failed.")).toBeInTheDocument();
+    expect(screen.getAllByText("Web Audio")).toHaveLength(2);
 
     expect(document.documentElement).toHaveAttribute("data-theme", "light");
     expect(window.localStorage.getItem("tuneforge.theme-preference")).toBe("light");

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -1575,6 +1575,10 @@ export function useProjectViewModel() {
     { label: "Mix", value: `${previewArtifacts.length}` },
     { label: "Stem", value: `${stemArtifacts.length}` },
   ];
+  const nativePlaybackArtifacts = useMemo(
+    () => [...primaryArtifacts, ...visibleStemArtifacts].filter((artifact) => isPlayableArtifact(artifact)),
+    [primaryArtifacts, visibleStemArtifacts],
+  );
 
   useEffect(() => {
     if (hydratedProjectId !== projectId || !projectId || !selectedPlaybackArtifact) {
@@ -1588,6 +1592,13 @@ export function useProjectViewModel() {
       stageSummary,
       selectedPlaybackArtifactId: selectedPlaybackArtifact.id,
       isStemPlayback,
+      playbackArtifactIds: nativePlaybackArtifacts.map((artifact) => artifact.id),
+      artifactPathsById: Object.fromEntries(
+        nativePlaybackArtifacts.map((artifact) => [artifact.id, artifact.path]),
+      ),
+      artifactFormatsById: Object.fromEntries(
+        nativePlaybackArtifacts.map((artifact) => [artifact.id, artifact.format]),
+      ),
       visibleStemArtifactIds: visibleStemArtifacts.map((artifact) => artifact.id),
       stemControls,
       durationHintSeconds: projectQuery.data?.duration_seconds ?? 0,
@@ -1607,6 +1618,7 @@ export function useProjectViewModel() {
     precountEnabled,
     precountTempoBpm,
     registerProjectSession,
+    nativePlaybackArtifacts,
     selectedPlaybackArtifact,
     stageSummary,
     stageTitle,

--- a/apps/desktop/src/features/projects/playback-context.ts
+++ b/apps/desktop/src/features/projects/playback-context.ts
@@ -8,6 +8,9 @@ export type ProjectPlaybackSession = {
   stageSummary: string;
   selectedPlaybackArtifactId: string | null;
   isStemPlayback: boolean;
+  playbackArtifactIds: string[];
+  artifactPathsById: Record<string, string>;
+  artifactFormatsById: Record<string, string>;
   visibleStemArtifactIds: string[];
   stemControls: Record<string, StemControlState>;
   durationHintSeconds: number;

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -7,6 +7,27 @@ import {
   type ReactNode,
 } from "react";
 import { api } from "../../lib/api";
+import {
+  getNativeAudioCapabilities,
+  isWebAudioBackendForced,
+  listenNativeAudioEnded,
+  listenNativeAudioErrors,
+  listenNativeAudioPositions,
+  pauseNativeAudio,
+  playNativeAudio,
+  prepareNativeAudioSession,
+  seekNativeAudio,
+  setNativeAudioLanes,
+  stopNativeAudio,
+  type NativeAudioLaneRequest,
+  type NativeAudioSnapshot,
+} from "../../lib/nativeAudio";
+import {
+  clearRememberedNativePlaybackError,
+  playbackErrorMessage,
+  rememberNativePlaybackError,
+  rememberPlaybackBackend,
+} from "../../lib/playbackDiagnostics";
 import { useStableCallback } from "../../lib/useStableCallback";
 import {
   PlaybackContext,
@@ -57,12 +78,92 @@ type PitchPreservingAudioElement = HTMLAudioElement & {
   webkitPreservesPitch?: boolean;
 };
 
+type NativePlaybackState = {
+  active: boolean;
+  blockedSessionSignature: string | null;
+  preparePromise: Promise<boolean> | null;
+  prepareSignature: string | null;
+  sessionSignature: string | null;
+  playbackSignature: string | null;
+};
+
 function applyMediaElementPlaybackRate(element: HTMLAudioElement, playbackRate: number) {
   const pitchPreservingElement = element as PitchPreservingAudioElement;
   pitchPreservingElement.preservesPitch = true;
   pitchPreservingElement.mozPreservesPitch = true;
   pitchPreservingElement.webkitPreservesPitch = true;
   element.playbackRate = playbackRate;
+}
+
+function isTauriRuntime() {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+function nativeSessionSignature(session: ProjectPlaybackSession | null) {
+  if (!session) {
+    return "none";
+  }
+  const playbackRate = playbackRateForSession(session).toFixed(6);
+  const artifactIds = nativeActiveArtifactIds(session)
+    .sort()
+    .join(",");
+  return `${session.projectId}:native:${artifactIds}:rate:${playbackRate}`;
+}
+
+function nativeActiveArtifactIds(session: ProjectPlaybackSession) {
+  return getSessionPlaybackArtifactIds(session).filter((artifactId) =>
+    Boolean(session.artifactPathsById[artifactId]),
+  );
+}
+
+function getSessionPlaybackArtifactIds(targetSession: ProjectPlaybackSession | null) {
+  if (!targetSession) {
+    return [] as string[];
+  }
+  if (targetSession.isStemPlayback) {
+    return targetSession.visibleStemArtifactIds;
+  }
+  return targetSession.selectedPlaybackArtifactId
+    ? [targetSession.selectedPlaybackArtifactId]
+    : [];
+}
+
+function nativeLaneRequestsForSession(session: ProjectPlaybackSession): NativeAudioLaneRequest[] {
+  const selectedId = session.selectedPlaybackArtifactId;
+  const hasSolo = session.visibleStemArtifactIds.some(
+    (artifactId) => session.stemControls[artifactId]?.solo,
+  );
+  const activeArtifactIds = new Set(nativeActiveArtifactIds(session));
+
+  return session.playbackArtifactIds.flatMap((artifactId) => {
+    if (!activeArtifactIds.has(artifactId)) {
+      return [];
+    }
+    const sourcePath = session.artifactPathsById[artifactId];
+    if (!sourcePath) {
+      return [];
+    }
+
+    const isStem = session.visibleStemArtifactIds.includes(artifactId);
+    const isActivePrimary = !session.isStemPlayback && artifactId === selectedId;
+    const stemState = session.stemControls[artifactId] ?? { muted: false, solo: false };
+    const stemAudible = session.isStemPlayback
+      ? hasSolo
+        ? stemState.solo
+        : !stemState.muted
+      : false;
+    return [
+      {
+        id: artifactId,
+        artifactId,
+        sourcePath,
+        role: isStem ? "stem" : "primary",
+        gain: 1,
+        muted: isStem ? !stemAudible : !isActivePrimary,
+        solo: isStem ? stemState.solo : false,
+      } satisfies NativeAudioLaneRequest,
+    ];
+  });
 }
 
 export function PlaybackProvider({ children }: { children: ReactNode }) {
@@ -76,6 +177,15 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   const stemClockBlockedRef = useRef(false);
   const stemBufferCacheRef = useRef(new Map<string, Promise<AudioBuffer>>());
   const stemPlaybackRef = useRef<StemPlaybackState | null>(null);
+  const nativePlaybackRef = useRef<NativePlaybackState>({
+    active: false,
+    blockedSessionSignature: null,
+    preparePromise: null,
+    prepareSignature: null,
+    sessionSignature: null,
+    playbackSignature: null,
+  });
+  const nativeCapabilitiesPromiseRef = useRef<ReturnType<typeof getNativeAudioCapabilities> | null>(null);
   const pendingTransitionRef = useRef<PendingTransition | null>(
     restoredPlaybackState
         ? {
@@ -160,18 +270,6 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       .filter(Boolean) as HTMLAudioElement[];
   }
 
-  function getPlaybackArtifactIds(targetSession: ProjectPlaybackSession | null) {
-    if (!targetSession) {
-      return [] as string[];
-    }
-    if (targetSession.isStemPlayback) {
-      return targetSession.visibleStemArtifactIds;
-    }
-    return targetSession.selectedPlaybackArtifactId
-      ? [targetSession.selectedPlaybackArtifactId]
-      : [];
-  }
-
   const getAudioContextConstructor = useCallback(() => {
     if (typeof window === "undefined") {
       return null;
@@ -199,7 +297,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         return false;
       }
 
-      const artifactIds = getPlaybackArtifactIds(targetSession);
+      const artifactIds = getSessionPlaybackArtifactIds(targetSession);
       if (!artifactIds.length) {
         return false;
       }
@@ -212,7 +310,222 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     [canUseStemClock],
   );
 
-  function syncStemElementTimes(artifactIds: string[], nextTime: number) {
+  const getNativeAudioCapabilityState = useStableCallback(async function getNativeAudioCapabilityState() {
+    if (isWebAudioBackendForced() || !isTauriRuntime()) {
+      return null;
+    }
+    if (!nativeCapabilitiesPromiseRef.current) {
+      nativeCapabilitiesPromiseRef.current = getNativeAudioCapabilities().catch((error) => {
+        nativeCapabilitiesPromiseRef.current = null;
+        throw error;
+      });
+    }
+    return nativeCapabilitiesPromiseRef.current;
+  });
+
+  const canUseNativePlayback = useStableCallback(async function canUseNativePlayback(
+    targetSession: ProjectPlaybackSession | null,
+  ) {
+    if (!targetSession) {
+      return false;
+    }
+    const sessionSignature = nativeSessionSignature(targetSession);
+    if (nativePlaybackRef.current.blockedSessionSignature === sessionSignature) {
+      return false;
+    }
+    const artifactIds = getSessionPlaybackArtifactIds(targetSession);
+    if (!artifactIds.length) {
+      return false;
+    }
+    const lanes = nativeLaneRequestsForSession(targetSession);
+    const laneArtifactIds = new Set(lanes.map((lane) => lane.artifactId));
+    if (!lanes.length || !artifactIds.every((artifactId) => laneArtifactIds.has(artifactId))) {
+      return false;
+    }
+    const capabilities = await getNativeAudioCapabilityState();
+    return Boolean(capabilities?.nativePlaybackSupported);
+  });
+
+  const markNativePlaybackInactive = useStableCallback(function markNativePlaybackInactive() {
+    nativePlaybackRef.current = {
+      ...nativePlaybackRef.current,
+      active: false,
+      playbackSignature: null,
+    };
+  });
+
+  const pauseRenderedMediaElements = useStableCallback(function pauseRenderedMediaElements(
+    targetSession: ProjectPlaybackSession | null = sessionRef.current,
+  ) {
+    getRenderedMediaElements(targetSession).forEach((element) => element.pause());
+  });
+
+  const ensureNativePlaybackSession = useStableCallback(async function ensureNativePlaybackSession(
+    targetSession: ProjectPlaybackSession,
+  ) {
+    if (!(await canUseNativePlayback(targetSession))) {
+      return false;
+    }
+    const sessionSignature = nativeSessionSignature(targetSession);
+    const lanes = nativeLaneRequestsForSession(targetSession);
+    if (nativePlaybackRef.current.sessionSignature === sessionSignature) {
+      await setNativeAudioLanes({ lanes });
+      return true;
+    }
+
+    const pendingPrepare = nativePlaybackRef.current;
+    if (
+      pendingPrepare.prepareSignature === sessionSignature &&
+      pendingPrepare.preparePromise
+    ) {
+      const prepared = await pendingPrepare.preparePromise;
+      if (prepared && nativePlaybackRef.current.sessionSignature === sessionSignature) {
+        await setNativeAudioLanes({ lanes });
+      }
+      return prepared;
+    }
+
+    const preparePromise = (async () => {
+      const preparedSession = await prepareNativeAudioSession({
+        sessionId: sessionSignature,
+        durationSeconds: targetSession.durationHintSeconds || null,
+        playbackRate: playbackRateForSession(targetSession),
+        lanes,
+      });
+      if (!preparedSession.nativePlaybackSupported) {
+        if (nativePlaybackRef.current.prepareSignature === sessionSignature) {
+          nativePlaybackRef.current = {
+            ...nativePlaybackRef.current,
+            blockedSessionSignature: sessionSignature,
+            preparePromise: null,
+            prepareSignature: null,
+          };
+        }
+        rememberNativePlaybackError(
+          preparedSession.fallbackReason ?? "Native playback prepare fell back to Web Audio.",
+        );
+        return false;
+      }
+      if (nativePlaybackRef.current.blockedSessionSignature === sessionSignature) {
+        if (nativePlaybackRef.current.prepareSignature === sessionSignature) {
+          void stopNativeAudio().catch(() => undefined);
+          nativePlaybackRef.current = {
+            ...nativePlaybackRef.current,
+            preparePromise: null,
+            prepareSignature: null,
+          };
+        }
+        return false;
+      }
+      const currentNative = nativePlaybackRef.current;
+      if (currentNative.prepareSignature !== sessionSignature) {
+        if (!currentNative.active && !currentNative.prepareSignature) {
+          void stopNativeAudio().catch(() => undefined);
+        }
+        return false;
+      }
+      nativePlaybackRef.current = {
+        ...currentNative,
+        active: false,
+        blockedSessionSignature: null,
+        preparePromise: null,
+        prepareSignature: null,
+        sessionSignature,
+        playbackSignature: null,
+      };
+      clearRememberedNativePlaybackError();
+      return true;
+    })();
+
+    nativePlaybackRef.current = {
+      ...nativePlaybackRef.current,
+      preparePromise,
+      prepareSignature: sessionSignature,
+    };
+
+    try {
+      const prepared = await preparePromise;
+      if (prepared && nativePlaybackRef.current.sessionSignature === sessionSignature) {
+        await setNativeAudioLanes({ lanes });
+      }
+      return prepared;
+    } catch (error) {
+      if (
+        nativePlaybackRef.current.prepareSignature === sessionSignature ||
+        nativePlaybackRef.current.sessionSignature === sessionSignature
+      ) {
+        nativePlaybackRef.current = {
+          ...nativePlaybackRef.current,
+          blockedSessionSignature: sessionSignature,
+          preparePromise: null,
+          prepareSignature: null,
+        };
+        rememberNativePlaybackError(playbackErrorMessage(error));
+      }
+      return false;
+    }
+  });
+
+  const tryStartNativePlayback = useStableCallback(async function tryStartNativePlayback(
+    targetSession: ProjectPlaybackSession,
+    timeSeconds: number,
+  ) {
+    const sessionSignature = nativeSessionSignature(targetSession);
+    try {
+      if (!(await ensureNativePlaybackSession(targetSession))) {
+        return false;
+      }
+      const latestSession = sessionRef.current;
+      if (
+        !latestSession ||
+        playbackSignature(latestSession) !== playbackSignature(targetSession) ||
+        nativeSessionSignature(latestSession) !== sessionSignature
+      ) {
+        if (
+          nativePlaybackRef.current.sessionSignature === sessionSignature &&
+          !nativePlaybackRef.current.active
+        ) {
+          markNativePlaybackInactive();
+          void stopNativeAudio().catch(() => undefined);
+        }
+        return false;
+      }
+      await setNativeAudioLanes({ lanes: nativeLaneRequestsForSession(latestSession) });
+      const snapshot = await playNativeAudio({
+        startTimeSeconds:
+          timeSeconds <= SEEK_TOLERANCE_SECONDS
+            ? null
+            : clampTime(timeSeconds, latestSession.durationHintSeconds || 0),
+      });
+      nativePlaybackRef.current.active = snapshot.nativePlaybackSupported;
+      nativePlaybackRef.current.playbackSignature = playbackSignature(latestSession);
+      if (!snapshot.nativePlaybackSupported) {
+        rememberNativePlaybackError(
+          snapshot.fallbackReason ?? "Native playback start fell back to Web Audio.",
+        );
+        return false;
+      }
+      const capabilities = await getNativeAudioCapabilityState();
+      rememberPlaybackBackend({ backend: "native", detail: capabilities?.backend ?? null });
+      clearRememberedNativePlaybackError();
+      disposeStemPlaybackState();
+      pauseRenderedMediaElements(latestSession);
+      setPlaybackTimeSeconds(snapshot.positionSeconds);
+      setPlaybackDurationSeconds(snapshot.durationSeconds || latestSession.durationHintSeconds || 0);
+      setIsPlaying(true);
+      return true;
+    } catch (error) {
+      rememberNativePlaybackError(playbackErrorMessage(error));
+      nativePlaybackRef.current.blockedSessionSignature = sessionSignature;
+      markNativePlaybackInactive();
+      return false;
+    }
+  });
+
+  const syncStemElementTimes = useStableCallback(function syncStemElementTimes(
+    artifactIds: string[],
+    nextTime: number,
+  ) {
     artifactIds.forEach((artifactId) => {
       if (
         sessionRef.current?.selectedPlaybackArtifactId === artifactId &&
@@ -240,7 +553,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         return;
       }
     });
-  }
+  });
 
   const getStemAudioContext = useCallback(() => {
     if (stemAudioContextRef.current) {
@@ -463,7 +776,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       return null;
     }
 
-    const artifactIds = getPlaybackArtifactIds(targetSession);
+    const artifactIds = getSessionPlaybackArtifactIds(targetSession);
     if (!artifactIds.length) {
       return null;
     }
@@ -585,6 +898,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     setPlaybackTimeSeconds(nextTime);
     setPlaybackDurationSeconds(targetPlaybackState.durationSeconds);
     setIsPlaying(true);
+    rememberPlaybackBackend({ backend: "web", detail: null });
     scheduleStemClock(targetPlaybackState);
     return true;
   });
@@ -688,6 +1002,17 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         }
       });
     }
+
+    if (
+      nativePlaybackRef.current.active &&
+      nativePlaybackRef.current.sessionSignature === nativeSessionSignature(targetSession)
+    ) {
+      void setNativeAudioLanes({ lanes: nativeLaneRequestsForSession(targetSession) }).catch(
+        (error) => {
+          rememberNativePlaybackError(playbackErrorMessage(error));
+        },
+      );
+    }
   });
 
   const readMasterTime = useStableCallback(function readMasterTime(
@@ -699,6 +1024,14 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       playbackSignature(targetSession) === pendingTransition.signature
     ) {
       return pendingTransition.targetTime;
+    }
+
+    if (
+      targetSession &&
+      nativePlaybackRef.current.active &&
+      nativePlaybackRef.current.playbackSignature === playbackSignature(targetSession)
+    ) {
+      return playbackTimeSecondsRef.current;
     }
 
     const targetPlaybackState = stemPlaybackRef.current;
@@ -825,26 +1158,38 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   });
 
   const tryCompletePendingTransition = useStableCallback(function tryCompletePendingTransition() {
-    const pendingTransition = pendingTransitionRef.current;
-    const targetSession = sessionRef.current;
-    if (!pendingTransition || !targetSession) {
-      return;
-    }
+    void (async () => {
+      let pendingTransition = pendingTransitionRef.current;
+      let targetSession = sessionRef.current;
+      if (!pendingTransition || !targetSession) {
+        return;
+      }
 
-    if (canUseBufferedClock(targetSession)) {
-      void (async () => {
-        const activePendingTransition = pendingTransitionRef.current;
-        const activeSession = sessionRef.current;
+      if (pendingTransition.shouldPlay) {
+        const started = await tryStartNativePlayback(
+          targetSession,
+          pendingTransition.targetTime,
+        );
+        const latestPendingTransition = pendingTransitionRef.current;
+        const latestSession = sessionRef.current;
         if (
-          !activePendingTransition ||
-          !activeSession ||
-          activePendingTransition.id !== pendingTransition.id ||
-          playbackSignature(activeSession) !== pendingTransition.signature
+          !latestPendingTransition ||
+          !latestSession ||
+          latestPendingTransition.id !== pendingTransition.id ||
+          playbackSignature(latestSession) !== pendingTransition.signature
         ) {
           return;
         }
+        if (started) {
+          clearPendingTransition();
+          return;
+        }
+        pendingTransition = latestPendingTransition;
+        targetSession = latestSession;
+      }
 
-        const targetPlaybackState = await prepareStemPlaybackState(activeSession);
+      if (canUseBufferedClock(targetSession)) {
+        const targetPlaybackState = await prepareStemPlaybackState(targetSession);
         if (!targetPlaybackState) {
           return;
         }
@@ -901,112 +1246,119 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         const results = await Promise.allSettled(
           fallbackElements.map((element) => Promise.resolve(element.play())),
         );
-        setIsPlaying(results.some((result) => result.status === "fulfilled"));
-      })();
-      return;
-    }
-
-    const targetElements = getActiveMediaElements(targetSession);
-    const targetKeys = getActiveMediaKeys(targetSession);
-    if (!targetElements.length) {
-      return;
-    }
-
-    const minimumReadyState = HTMLMediaElement.HAVE_METADATA;
-    const ready = targetElements.every((element) => {
-      if (element.readyState >= minimumReadyState) {
-        return true;
+        const fallbackStarted = results.some((result) => result.status === "fulfilled");
+        if (fallbackStarted) {
+          rememberPlaybackBackend({ backend: "web", detail: null });
+        }
+        setIsPlaying(fallbackStarted);
+        return;
       }
-      return (
-        !pendingTransition.shouldPlay &&
-        Number.isFinite(element.duration) &&
-        element.duration > 0
+
+      const targetElements = getActiveMediaElements(targetSession);
+      const targetKeys = getActiveMediaKeys(targetSession);
+      if (!targetElements.length) {
+        return;
+      }
+
+      const minimumReadyState = HTMLMediaElement.HAVE_METADATA;
+      const ready = targetElements.every((element) => {
+        if (element.readyState >= minimumReadyState) {
+          return true;
+        }
+        return (
+          !pendingTransition.shouldPlay &&
+          Number.isFinite(element.duration) &&
+          element.duration > 0
+        );
+      });
+      if (!ready) {
+        return;
+      }
+
+      const nextTime = clampTime(
+        pendingTransition.targetTime,
+        targetElements[0]?.duration ?? playbackDurationSecondsRef.current,
       );
-    });
-    if (!ready) {
-      return;
-    }
-
-    const nextTime = clampTime(
-      pendingTransition.targetTime,
-      targetElements[0]?.duration ?? playbackDurationSecondsRef.current,
-    );
-    const activeKeySet = new Set(targetKeys);
-    const awaitingLoadKeys = pendingTransition.awaitingLoadKeys.filter((key) =>
-      activeKeySet.has(key),
-    );
-    pendingTransition.awaitingLoadKeys = awaitingLoadKeys;
-    if (awaitingLoadKeys.length > 0) {
-      return;
-    }
-    const awaitingSeekKeys = pendingTransition.awaitingSeekKeys.filter((key) =>
-      activeKeySet.has(key),
-    );
-    const forceSeekKeys = pendingTransition.forceSeekKeys.filter((key) =>
-      activeKeySet.has(key),
-    );
-    targetElements.forEach((element, index) => {
-      const mediaKey = targetKeys[index];
-      if (!mediaKey) {
+      const activeKeySet = new Set(targetKeys);
+      const awaitingLoadKeys = pendingTransition.awaitingLoadKeys.filter((key) =>
+        activeKeySet.has(key),
+      );
+      pendingTransition.awaitingLoadKeys = awaitingLoadKeys;
+      if (awaitingLoadKeys.length > 0) {
         return;
       }
-      const shouldForceSeek = forceSeekKeys.includes(mediaKey);
-      if (shouldForceSeek) {
-        element.currentTime = nextTime;
-        if (pendingTransition.awaitSeekBeforePlay && !awaitingSeekKeys.includes(mediaKey)) {
+      const awaitingSeekKeys = pendingTransition.awaitingSeekKeys.filter((key) =>
+        activeKeySet.has(key),
+      );
+      const forceSeekKeys = pendingTransition.forceSeekKeys.filter((key) =>
+        activeKeySet.has(key),
+      );
+      targetElements.forEach((element, index) => {
+        const mediaKey = targetKeys[index];
+        if (!mediaKey) {
+          return;
+        }
+        const shouldForceSeek = forceSeekKeys.includes(mediaKey);
+        if (shouldForceSeek) {
+          element.currentTime = nextTime;
+          if (pendingTransition.awaitSeekBeforePlay && !awaitingSeekKeys.includes(mediaKey)) {
+            awaitingSeekKeys.push(mediaKey);
+          }
+          return;
+        }
+        if (Math.abs(element.currentTime - nextTime) > SEEK_TOLERANCE_SECONDS) {
+          element.currentTime = nextTime;
+          if (pendingTransition.awaitSeekBeforePlay && !awaitingSeekKeys.includes(mediaKey)) {
+            awaitingSeekKeys.push(mediaKey);
+          }
+          return;
+        }
+        if (
+          pendingTransition.awaitSeekBeforePlay &&
+          element.seeking &&
+          !awaitingSeekKeys.includes(mediaKey)
+        ) {
           awaitingSeekKeys.push(mediaKey);
         }
+      });
+      pendingTransition.awaitingSeekKeys = awaitingSeekKeys;
+      pendingTransition.forceSeekKeys = forceSeekKeys.filter(
+        (mediaKey) => !awaitingSeekKeys.includes(mediaKey),
+      );
+      applyStemVolumes(targetSession);
+      setPlaybackTimeSeconds(nextTime);
+      updateDurationFromActiveMedia(targetSession);
+
+      if (awaitingSeekKeys.length > 0) {
         return;
       }
-      if (Math.abs(element.currentTime - nextTime) > SEEK_TOLERANCE_SECONDS) {
-        element.currentTime = nextTime;
-        if (pendingTransition.awaitSeekBeforePlay && !awaitingSeekKeys.includes(mediaKey)) {
-          awaitingSeekKeys.push(mediaKey);
-        }
+
+      const transitionId = pendingTransition.id;
+      const transitionSignature = pendingTransition.signature;
+      clearPendingTransition();
+
+      if (!pendingTransition.shouldPlay) {
+        targetElements.forEach((element) => element.pause());
+        setIsPlaying(false);
         return;
       }
-      if (
-        pendingTransition.awaitSeekBeforePlay &&
-        element.seeking &&
-        !awaitingSeekKeys.includes(mediaKey)
-      ) {
-        awaitingSeekKeys.push(mediaKey);
-      }
-    });
-    pendingTransition.awaitingSeekKeys = awaitingSeekKeys;
-    pendingTransition.forceSeekKeys = forceSeekKeys.filter(
-      (mediaKey) => !awaitingSeekKeys.includes(mediaKey),
-    );
-    applyStemVolumes(targetSession);
-    setPlaybackTimeSeconds(nextTime);
-    updateDurationFromActiveMedia(targetSession);
 
-    if (awaitingSeekKeys.length > 0) {
-      return;
-    }
-
-    const transitionId = pendingTransition.id;
-    const transitionSignature = pendingTransition.signature;
-    clearPendingTransition();
-
-    if (!pendingTransition.shouldPlay) {
-      targetElements.forEach((element) => element.pause());
-      setIsPlaying(false);
-      return;
-    }
-
-    applyMediaPlaybackRate(targetSession);
-    void Promise.allSettled(
-      targetElements.map((element) => Promise.resolve(element.play())),
-    ).then((results) => {
+      applyMediaPlaybackRate(targetSession);
+      const results = await Promise.allSettled(
+        targetElements.map((element) => Promise.resolve(element.play())),
+      );
       if (pendingTransitionRef.current?.id === transitionId) {
         return;
       }
       if (playbackSignature(sessionRef.current) !== transitionSignature) {
         return;
       }
-      setIsPlaying(results.some((result) => result.status === "fulfilled"));
-    });
+      const started = results.some((result) => result.status === "fulfilled");
+      if (started) {
+        rememberPlaybackBackend({ backend: "web", detail: null });
+      }
+      setIsPlaying(started);
+    })();
   });
 
   const pausePlayback = useCallback(() => {
@@ -1017,6 +1369,18 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     }
 
     const targetSession = sessionRef.current;
+    if (nativePlaybackRef.current.active) {
+      void pauseNativeAudio()
+        .then((snapshot) => {
+          setPlaybackTimeSeconds(snapshot.positionSeconds);
+          setIsPlaying(false);
+        })
+        .catch(() => undefined);
+      markNativePlaybackInactive();
+      setIsPlaying(false);
+      return;
+    }
+
     const targetPlaybackState = stemPlaybackRef.current;
     if (
       targetSession &&
@@ -1036,6 +1400,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     canUseBufferedClock,
     cancelPrecount,
     getActiveMediaElements,
+    markNativePlaybackInactive,
     stopStemSources,
   ]);
 
@@ -1056,6 +1421,10 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     tryCompletePendingTransition();
 
     const masterTime = forceStartAtZero ? 0 : readMasterTime(targetSession);
+    if (await tryStartNativePlayback(targetSession, masterTime)) {
+      return;
+    }
+
     if (canUseBufferedClock(targetSession)) {
       const started = await startStemPlayback(
         targetSession,
@@ -1063,6 +1432,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         scheduledStemStartTimeSeconds,
       );
       if (started) {
+        markNativePlaybackInactive();
         return;
       }
     }
@@ -1083,7 +1453,12 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     const results = await Promise.allSettled(
       activeElements.map((element) => Promise.resolve(element.play())),
     );
-    setIsPlaying(results.some((result) => result.status === "fulfilled"));
+    markNativePlaybackInactive();
+    const started = results.some((result) => result.status === "fulfilled");
+    if (started) {
+      rememberPlaybackBackend({ backend: "web", detail: null });
+    }
+    setIsPlaying(started);
   });
 
   const startPrecountThenPlayback = useStableCallback(async function startPrecountThenPlayback(
@@ -1255,6 +1630,14 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     }
 
     const targetSession = sessionRef.current;
+    if (nativePlaybackRef.current.active) {
+      void seekNativeAudio({ timeSeconds: nextTime })
+        .then((snapshot) => setPlaybackTimeSeconds(snapshot.positionSeconds))
+        .catch(() => markNativePlaybackInactive());
+      setPlaybackTimeSeconds(nextTime);
+      return;
+    }
+
     const targetPlaybackState = stemPlaybackRef.current;
     if (
       targetSession &&
@@ -1276,7 +1659,14 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       element.currentTime = nextTime;
     });
     setPlaybackTimeSeconds(nextTime);
-  }, [canUseBufferedClock, cancelPrecount, getActiveMediaElements, startStemPlayback]);
+  }, [
+    canUseBufferedClock,
+    cancelPrecount,
+    getActiveMediaElements,
+    markNativePlaybackInactive,
+    startStemPlayback,
+    syncStemElementTimes,
+  ]);
 
   const seekBy = useCallback(
     (secondsDelta: number) => {
@@ -1288,6 +1678,10 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   const stopPlayback = useCallback(() => {
     cancelPrecount();
     clearPendingTransition();
+    if (nativePlaybackRef.current.active) {
+      void stopNativeAudio().catch(() => undefined);
+      markNativePlaybackInactive();
+    }
     if (stemPlaybackRef.current) {
       stopStemSources(stemPlaybackRef.current, false);
       stemPlaybackRef.current.offsetSeconds = 0;
@@ -1304,7 +1698,9 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     cancelPrecount,
     clearPendingTransition,
     getRenderedMediaElements,
+    markNativePlaybackInactive,
     stopStemSources,
+    syncStemElementTimes,
     updateDurationFromActiveMedia,
   ]);
 
@@ -1338,9 +1734,21 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       const shouldPlay = isPlayingRef.current;
       const samePlaybackTarget =
         playbackTargetSignature(previousSession) === playbackTargetSignature(nextSession);
+      const previousUsesNative =
+        nativePlaybackRef.current.active &&
+        nativePlaybackRef.current.playbackSignature === previousSignature;
+      if (previousUsesNative) {
+        void stopNativeAudio().catch(() => undefined);
+        markNativePlaybackInactive();
+        getActiveMediaElements(previousSession).forEach((element) => {
+          element.pause();
+          element.currentTime = nextTime;
+        });
+        syncStemElementTimes(previousSession.visibleStemArtifactIds, nextTime);
+      }
       const previousUsesBufferedClock = canUseBufferedClock(previousSession);
       const nextUsesBufferedClock = canUseBufferedClock(nextSession);
-      if (samePlaybackTarget && !previousUsesBufferedClock && !nextUsesBufferedClock) {
+      if (samePlaybackTarget && !previousUsesNative && !previousUsesBufferedClock && !nextUsesBufferedClock) {
         const pendingTransition = pendingTransitionRef.current;
         if (
           pendingTransition &&
@@ -1397,7 +1805,9 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     disposeStemPlaybackState,
     getActiveMediaElements,
     getRenderedMediaElements,
+    markNativePlaybackInactive,
     readMasterTime,
+    syncStemElementTimes,
   ]);
 
   useEffect(() => {
@@ -1412,6 +1822,26 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     tryCompletePendingTransition,
     updateDurationFromActiveMedia,
   ]);
+
+  useEffect(() => {
+    if (!session || !usesDefaultPlaybackRate(session)) {
+      if (nativePlaybackRef.current.preparePromise) {
+        nativePlaybackRef.current = {
+          ...nativePlaybackRef.current,
+          preparePromise: null,
+          prepareSignature: null,
+        };
+      }
+      return;
+    }
+    if (isPlayingRef.current) {
+      return;
+    }
+
+    void ensureNativePlaybackSession(session).catch((error) => {
+      rememberNativePlaybackError(playbackErrorMessage(error));
+    });
+  }, [ensureNativePlaybackSession, session]);
 
   useEffect(() => {
     if (!session?.visibleStemArtifactIds.length || !canUseStemClock()) {
@@ -1430,6 +1860,75 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     },
     [cancelPrecount, closePlaybackAudioContext],
   );
+
+  useEffect(() => {
+    if (!isTauriRuntime()) {
+      return;
+    }
+
+    const unlisteners = Promise.all([
+      listenNativeAudioPositions((position) => {
+        const activeSession = sessionRef.current;
+        if (
+          !activeSession ||
+          !nativePlaybackRef.current.active ||
+          position.sessionId !== nativePlaybackRef.current.sessionSignature
+        ) {
+          return;
+        }
+        setPlaybackTimeSeconds(position.positionSeconds);
+        setPlaybackDurationSeconds(position.durationSeconds || activeSession.durationHintSeconds || 0);
+        setIsPlaying(position.state === "playing");
+      }),
+      listenNativeAudioEnded((snapshot: NativeAudioSnapshot) => {
+        if (snapshot.sessionId !== nativePlaybackRef.current.sessionSignature) {
+          return;
+        }
+        markNativePlaybackInactive();
+        void stopNativeAudio().catch(() => undefined);
+        setPlaybackTimeSeconds(0);
+        setIsPlaying(false);
+        syncStemElementTimes(sessionRef.current?.visibleStemArtifactIds ?? [], 0);
+        getRenderedMediaElements().forEach((element) => {
+          element.pause();
+          element.currentTime = 0;
+        });
+      }),
+      listenNativeAudioErrors((error) => {
+        const activeSession = sessionRef.current;
+        if (!activeSession || !nativePlaybackRef.current.active) {
+          return;
+        }
+        rememberNativePlaybackError(error.message);
+        const fallbackTime = clampTime(
+          playbackTimeSecondsRef.current,
+          playbackDurationSecondsRef.current || activeSession.durationHintSeconds || 0,
+        );
+        nativePlaybackRef.current.blockedSessionSignature = nativeSessionSignature(activeSession);
+        markNativePlaybackInactive();
+        setIsPlaying(false);
+        void stopNativeAudio().catch(() => undefined);
+        syncStemElementTimes(activeSession.visibleStemArtifactIds, fallbackTime);
+        getRenderedMediaElements(activeSession).forEach((element) => {
+          element.pause();
+          element.currentTime = fallbackTime;
+        });
+        setPlaybackTimeSeconds(fallbackTime);
+        void playPlaybackImmediately();
+      }),
+    ]);
+
+    return () => {
+      void unlisteners.then((items) => {
+        items.forEach((unlisten) => unlisten());
+      });
+    };
+  }, [
+    getRenderedMediaElements,
+    markNativePlaybackInactive,
+    playPlaybackImmediately,
+    syncStemElementTimes,
+  ]);
 
   useMediaSessionControls({
     isPlaying,

--- a/apps/desktop/src/features/projects/playbackPersistence.ts
+++ b/apps/desktop/src/features/projects/playbackPersistence.ts
@@ -44,6 +44,29 @@ function normalizeProjectPlaybackSession(value: unknown): ProjectPlaybackSession
         (artifactId): artifactId is string => typeof artifactId === "string",
       )
     : [];
+  const playbackArtifactIds = Array.isArray(candidate.playbackArtifactIds)
+    ? candidate.playbackArtifactIds.filter(
+        (artifactId): artifactId is string => typeof artifactId === "string",
+      )
+    : [];
+  const artifactPathsById =
+    candidate.artifactPathsById && typeof candidate.artifactPathsById === "object"
+      ? Object.fromEntries(
+          Object.entries(candidate.artifactPathsById).filter(
+            (entry): entry is [string, string] =>
+              typeof entry[0] === "string" && typeof entry[1] === "string",
+          ),
+        )
+      : {};
+  const artifactFormatsById =
+    candidate.artifactFormatsById && typeof candidate.artifactFormatsById === "object"
+      ? Object.fromEntries(
+          Object.entries(candidate.artifactFormatsById).filter(
+            (entry): entry is [string, string] =>
+              typeof entry[0] === "string" && typeof entry[1] === "string",
+          ),
+        )
+      : {};
   const stemControlsInput =
     candidate.stemControls && typeof candidate.stemControls === "object"
       ? candidate.stemControls
@@ -59,6 +82,9 @@ function normalizeProjectPlaybackSession(value: unknown): ProjectPlaybackSession
         ? candidate.selectedPlaybackArtifactId
         : null,
     isStemPlayback: Boolean(candidate.isStemPlayback),
+    playbackArtifactIds,
+    artifactPathsById,
+    artifactFormatsById,
     visibleStemArtifactIds,
     stemControls: Object.fromEntries(
       Object.entries(stemControlsInput).map(([artifactId, controlState]) => [

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -4,6 +4,11 @@ import { open, save } from "@tauri-apps/plugin-dialog";
 import { Link } from "react-router-dom";
 import { api, type ChordBackendSchema } from "../../lib/api";
 import {
+  readRememberedNativePlaybackError,
+  readRememberedPlaybackBackend,
+  type PlaybackBackend,
+} from "../../lib/playbackDiagnostics";
+import {
   getNativeAudioCapabilities,
   isWebAudioBackendForced,
   type NativeAudioCapabilities,
@@ -241,6 +246,15 @@ function lastInputCaptureBackendLabel(backend: TunerInputCaptureBackend | null) 
     : "Web Audio";
 }
 
+function lastPlaybackBackendLabel(backend: PlaybackBackend | null) {
+  if (!backend) {
+    return "Not started";
+  }
+  return backend.backend === "native"
+    ? `Native (${backend.detail ?? "unknown"})`
+    : "Web Audio";
+}
+
 function chordBackendOptions(backends: ChordBackendSchema[] | undefined): ChoiceOption<DefaultChordBackend>[] {
   if (!backends?.length) {
     return fallbackChordBackendOptions;
@@ -382,6 +396,8 @@ export function SettingsView() {
   });
   const lastInputCaptureBackend = readRememberedTunerInputCaptureBackend();
   const lastNativeCaptureError = readRememberedTunerNativeCaptureError();
+  const lastPlaybackBackend = readRememberedPlaybackBackend();
+  const lastNativePlaybackError = readRememberedNativePlaybackError();
   const savedThemeOverrideCount = themeOverrideCount(themeOverrides);
   const chordBackendChoices = chordBackendOptions(chordBackendsQuery.data?.backends);
 
@@ -778,6 +794,14 @@ export function SettingsView() {
             <div>
               <dt>Playback Backend</dt>
               <dd>{playbackBackendLabel(nativeAudioQuery.data, webAudioForced)}</dd>
+            </div>
+            <div>
+              <dt>Last Playback Backend</dt>
+              <dd>{lastPlaybackBackendLabel(lastPlaybackBackend)}</dd>
+            </div>
+            <div>
+              <dt>Last Native Playback Error</dt>
+              <dd>{lastNativePlaybackError ?? "None"}</dd>
             </div>
           </dl>
         </details>

--- a/apps/desktop/src/features/tools/metronome.tsx
+++ b/apps/desktop/src/features/tools/metronome.tsx
@@ -1,4 +1,8 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  isWebAudioBackendForced,
+  setNativeAudioClick,
+} from "../../lib/nativeAudio";
 import { useStableCallback } from "../../lib/useStableCallback";
 import { usePlayback, type PlaybackSnapshot } from "../projects/playback-context";
 import { MetronomeContext, type MetronomeLaunchOptions } from "./metronome-context";
@@ -45,6 +49,7 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
   const isRunningRef = useRef(isRunning);
   const lastSyncedPlaybackTimeRef = useRef<number | null>(null);
   const lastSyncedScheduledBeatRef = useRef<number | null>(null);
+  const nativeFollowClickActiveRef = useRef(false);
   const nextFreeRunBeatIndexRef = useRef(0);
   const schedulerIntervalRef = useRef<number | null>(null);
   const tapTempoStateRef = useRef<TapTempoState>(createTapTempoState());
@@ -142,13 +147,15 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
   ) {
     const beatNumber = beatNumberForIndex(beatIndex, beatsPerBarRef.current);
     const accent = isAccentBeat(beatIndex, beatsPerBarRef.current, accentFirstBeatRef.current);
-    scheduleMetronomeClick({
-      accent,
-      audioContext,
-      sound: DEFAULT_METRONOME_SOUND,
-      startTimeSeconds,
-      volume: volumeRef.current,
-    });
+    if (!(followPlaybackRef.current && nativeFollowClickActiveRef.current)) {
+      scheduleMetronomeClick({
+        accent,
+        audioContext,
+        sound: DEFAULT_METRONOME_SOUND,
+        startTimeSeconds,
+        volume: volumeRef.current,
+      });
+    }
 
     const timeoutId = window.setTimeout(
       () => setActiveBeat(beatNumber),
@@ -365,6 +372,42 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
     scheduleSynced,
   ]);
 
+  useEffect(() => {
+    if (!isTauriRuntime() || isWebAudioBackendForced() || !isRunning || !followPlayback) {
+      nativeFollowClickActiveRef.current = false;
+      if (isTauriRuntime()) {
+        void setNativeAudioClick({ enabled: false }).catch(() => undefined);
+      }
+      return;
+    }
+
+    let cancelled = false;
+    void setNativeAudioClick({
+      enabled: true,
+      bpm,
+      beatsPerBar,
+      accentFirstBeat,
+      gain: volume,
+      followTransport: true,
+    })
+      .then((snapshot) => {
+        if (!cancelled) {
+          nativeFollowClickActiveRef.current = Boolean(
+            snapshot.nativePlaybackSupported && snapshot.sessionId,
+          );
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          nativeFollowClickActiveRef.current = false;
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [accentFirstBeat, beatsPerBar, bpm, followPlayback, isRunning, volume]);
+
   const syncStatus = followPlayback
     ? session
       ? isPlaying
@@ -438,6 +481,10 @@ function getAudioContextConstructor(): AudioContextConstructor | null {
       .webkitAudioContext ??
     null
   );
+}
+
+function isTauriRuntime() {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 }
 
 function getCurrentMetronomeTimeMs() {

--- a/apps/desktop/src/lib/nativeAudio.test.ts
+++ b/apps/desktop/src/lib/nativeAudio.test.ts
@@ -28,10 +28,12 @@ import {
   listNativeAudioInputDevices,
   listNativeAudioOutputDevices,
   listenNativeAudioInputFrames,
+  listenNativeAudioPositions,
   pauseNativeAudio,
   playNativeAudio,
   prepareNativeAudioSession,
   seekNativeAudio,
+  setNativeAudioClick,
   setNativeAudioLanes,
   setNativeAudioMonitor,
   startNativeAudioInput,
@@ -134,6 +136,14 @@ describe("native audio adapter", () => {
     await playNativeAudio({ startTimeSeconds: 4, scheduledStartTimeSeconds: 10 });
     await seekNativeAudio({ timeSeconds: 24 });
     await setNativeAudioLanes(laneUpdate);
+    await setNativeAudioClick({
+      enabled: true,
+      bpm: 120,
+      beatsPerBar: 4,
+      accentFirstBeat: true,
+      gain: 0.75,
+      followTransport: true,
+    });
 
     expect(mockInvoke).toHaveBeenNthCalledWith(1, "audio_prepare_session", {
       payload: sessionRequest,
@@ -146,6 +156,16 @@ describe("native audio adapter", () => {
     });
     expect(mockInvoke).toHaveBeenNthCalledWith(4, "audio_set_lanes", {
       payload: laneUpdate,
+    });
+    expect(mockInvoke).toHaveBeenNthCalledWith(5, "audio_set_click", {
+      payload: {
+        enabled: true,
+        bpm: 120,
+        beatsPerBar: 4,
+        accentFirstBeat: true,
+        gain: 0.75,
+        followTransport: true,
+      },
     });
   });
 
@@ -202,6 +222,28 @@ describe("native audio adapter", () => {
 
     expect(mockListen).toHaveBeenCalledWith("audio://input-frame", expect.any(Function));
     expect(handler).toHaveBeenCalledWith(frame);
+    stopListening();
+    expect(unlisten).toHaveBeenCalled();
+  });
+
+  it("wraps native position events", async () => {
+    const unlisten = vi.fn();
+    const position = {
+      sessionId: "session-1",
+      positionSeconds: 12,
+      durationSeconds: 180,
+      state: "playing" as const,
+    };
+    mockListen.mockImplementation(async (_eventName, callback) => {
+      callback({ event: "audio://position", id: 1, payload: position });
+      return unlisten;
+    });
+    const handler = vi.fn();
+
+    const stopListening = await listenNativeAudioPositions(handler);
+
+    expect(mockListen).toHaveBeenCalledWith("audio://position", expect.any(Function));
+    expect(handler).toHaveBeenCalledWith(position);
     stopListening();
     expect(unlisten).toHaveBeenCalled();
   });

--- a/apps/desktop/src/lib/nativeAudio.ts
+++ b/apps/desktop/src/lib/nativeAudio.ts
@@ -95,6 +95,27 @@ export type NativeAudioSnapshot = {
   lanes: NativeAudioLane[];
 };
 
+export type NativeAudioClickRequest = {
+  enabled: boolean;
+  bpm?: number | null;
+  beatsPerBar?: number | null;
+  accentFirstBeat?: boolean | null;
+  gain?: number | null;
+  followTransport?: boolean | null;
+};
+
+export type NativeAudioPositionEvent = {
+  sessionId: string | null;
+  positionSeconds: number;
+  durationSeconds: number;
+  state: "stopped" | "playing" | "paused";
+};
+
+export type NativeAudioErrorEvent = {
+  sessionId: string | null;
+  message: string;
+};
+
 export type NativeAudioInputRequest = {
   deviceId?: string | null;
   monitorEnabled?: boolean | null;
@@ -167,6 +188,10 @@ export function setNativeAudioLanes(payload: NativeAudioLaneUpdate) {
   return invoke<NativeAudioSnapshot>("audio_set_lanes", { payload });
 }
 
+export function setNativeAudioClick(payload: NativeAudioClickRequest) {
+  return invoke<NativeAudioSnapshot>("audio_set_click", { payload });
+}
+
 export function getNativeAudioSnapshot() {
   return invoke<NativeAudioSnapshot>("audio_get_snapshot");
 }
@@ -191,6 +216,26 @@ export function listenNativeAudioInputFrames(
   handler: (frame: NativeAudioInputFrame) => void,
 ) {
   return listen<NativeAudioInputFrame>("audio://input-frame", (event) => {
+    handler(event.payload);
+  });
+}
+
+export function listenNativeAudioPositions(
+  handler: (position: NativeAudioPositionEvent) => void,
+) {
+  return listen<NativeAudioPositionEvent>("audio://position", (event) => {
+    handler(event.payload);
+  });
+}
+
+export function listenNativeAudioEnded(handler: (snapshot: NativeAudioSnapshot) => void) {
+  return listen<NativeAudioSnapshot>("audio://ended", (event) => {
+    handler(event.payload);
+  });
+}
+
+export function listenNativeAudioErrors(handler: (error: NativeAudioErrorEvent) => void) {
+  return listen<NativeAudioErrorEvent>("audio://error", (event) => {
     handler(event.payload);
   });
 }

--- a/apps/desktop/src/lib/playbackDiagnostics.ts
+++ b/apps/desktop/src/lib/playbackDiagnostics.ts
@@ -1,0 +1,72 @@
+const NATIVE_PLAYBACK_ERROR_KEY = "tuneforge.playback-native-error";
+const PLAYBACK_BACKEND_KEY = "tuneforge.playback-backend";
+
+export type PlaybackBackend = {
+  backend: "native" | "web";
+  detail: string | null;
+};
+
+export function rememberPlaybackBackend(backend: PlaybackBackend) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.localStorage.setItem(
+    PLAYBACK_BACKEND_KEY,
+    JSON.stringify({
+      backend: backend.backend,
+      detail: backend.detail,
+    }),
+  );
+}
+
+export function readRememberedPlaybackBackend(): PlaybackBackend | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    const rawBackend = JSON.parse(window.localStorage.getItem(PLAYBACK_BACKEND_KEY) ?? "null");
+    if (
+      rawBackend?.backend !== "native" &&
+      rawBackend?.backend !== "web"
+    ) {
+      return null;
+    }
+    return {
+      backend: rawBackend.backend,
+      detail: typeof rawBackend.detail === "string" ? rawBackend.detail : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function rememberNativePlaybackError(error: string) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.localStorage.setItem(NATIVE_PLAYBACK_ERROR_KEY, error);
+}
+
+export function readRememberedNativePlaybackError() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return window.localStorage.getItem(NATIVE_PLAYBACK_ERROR_KEY);
+}
+
+export function clearRememberedNativePlaybackError() {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.localStorage.removeItem(NATIVE_PLAYBACK_ERROR_KEY);
+}
+
+export function playbackErrorMessage(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return "Native playback failed.";
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -199,7 +199,9 @@ Validation failures return `INVALID_REQUEST` with serialized validation details.
 ## Packaging Constraints
 
 - FFmpeg is a host dependency and is not bundled.
-- Desktop tuner microphone capture uses `cpal` locally and falls back to Web Audio when native capture is unavailable.
+- Desktop tuner microphone capture and project playback use `cpal` locally and fall back to Web Audio when native audio is unavailable.
+- Native desktop tempo playback uses `signalsmith-stretch` for pitch preservation.
+- Native desktop playback decodes local files through a WAV fast path or Symphonia. FFmpeg remains a host dependency for transform/export work.
 - Native audio development notes live in [NATIVE_AUDIO.md](NATIVE_AUDIO.md).
 - Desktop system microphone volume control uses CoreAudio on macOS, or host `wpctl`/`pactl` tools on Linux with an active PipeWire/PulseAudio session.
 - Advanced Chords dependencies are currently optional. If they become a default desktop backend, packaged builds must treat crema, its bundled chord model files, TensorFlow/Keras, h5py/HDF5, gRPC/Protobuf, and TensorBoard as default-runtime notice scope.

--- a/docs/NATIVE_AUDIO.md
+++ b/docs/NATIVE_AUDIO.md
@@ -7,8 +7,14 @@ added feature by feature behind the Tauri native audio boundary.
 
 - Tuner microphone capture uses native `cpal` on supported desktop builds.
 - Tuner device listing uses native input enumeration first, then cached/browser labels as fallback.
-- Source, stem, and project playback still use Web Audio.
-- Native playback is intentionally not implemented yet.
+- Source, practice-mix, and stem playback prefer native `cpal` on macOS/Linux when every active
+  artifact has a local path. WAV uses a fast streaming reader; other common formats decode through
+  Symphonia for playback only.
+- Native playback supports shared transport play/pause/seek, position events, mute/solo lane gains,
+  and generated metronome click lanes for follow-playback mode.
+- Native tempo changes use `signalsmith-stretch` for pitch-preserving playback.
+- If native setup, decode, seek, or output startup fails, playback falls back to Web Audio at the
+  same transport position.
 
 ## Backend Selection
 
@@ -27,9 +33,8 @@ If the backend is already running separately:
 VITE_TUNEFORGE_FORCE_WEB_AUDIO=1 pnpm dev:desktop
 ```
 
-This is a global native audio override, not a per-feature setting. It currently affects tuner
-capture. Future native playback work should use the same override so Web Audio can remain the
-comparison path for both capture and playback.
+This is a global native audio override, not a per-feature setting. It affects tuner capture and
+project playback so Web Audio remains the comparison path for both.
 
 ## Diagnostics
 
@@ -39,6 +44,8 @@ Settings -> Local Data -> Show diagnostics reports:
 - last tuner capture backend
 - last native capture error
 - playback backend
+- last playback backend
+- last native playback error
 
 When `VITE_TUNEFORGE_FORCE_WEB_AUDIO=1` is active, diagnostics report `Web Audio (forced)`.
 


### PR DESCRIPTION
## Summary

- Add streaming native desktop playback through the existing Tauri native-audio layer.
- Decode local playback lanes with WAV fast path or Symphonia workers, then mix through cpal output.
- Support source, practice mix, stems, mute/solo, metronome follow clicks, position events, diagnostics, and native tempo DSP.
- Keep Web Audio fallback and the force-Web-Audio development override.

## Testing

- `cargo fmt --check`
- `cargo check`
- `cargo test`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test -- App.project-tempo.test.tsx App.project-playback-stems.test.tsx App.settings-theme.test.tsx nativeAudio.test.ts`