### PR TITLE
fix: stabilize Linux native audio playback

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,8 @@ If unsure whether a feature fits, open a discussion or feature-request issue fir
 - Python 3.11
 - `ffmpeg` and `ffprobe` on your `PATH`
 - Rust toolchain (for the Tauri shell)
+- Linux desktop builds need Clang/libclang for native audio bindings (`sudo pacman -S clang` on
+  Arch, `sudo apt-get install clang libclang-dev` on Debian/Ubuntu).
 
 ## Setup
 
@@ -26,7 +28,8 @@ If unsure whether a feature fits, open a discussion or feature-request issue fir
 pnpm setup:dev
 ```
 
-This installs workspace dependencies, syncs the backend Python environment, and regenerates shared API contracts.
+This installs workspace dependencies, checks Tauri build prerequisites, syncs the backend Python
+environment, and regenerates shared API contracts.
 
 To install the optional experimental crema/TensorFlow Advanced Chords backend for local desktop development:
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Security reports follow the process in [SECURITY.md](./SECURITY.md). "There is n
 - `ffmpeg` and `ffprobe` available on `PATH` (install via `brew install ffmpeg`, `apt install ffmpeg`, etc.)
 - macOS system mic volume control uses the built-in CoreAudio API.
 - Linux system mic volume control uses `wpctl` or `pactl` for the active PipeWire/PulseAudio session.
+- Linux native tempo playback builds require Clang/libclang for `bindgen` (`sudo pacman -S clang`
+  on Arch, `sudo apt-get install clang libclang-dev` on Debian/Ubuntu).
 - Rust toolchain for Tauri
 
 ## Setup
@@ -61,7 +63,10 @@ Security reports follow the process in [SECURITY.md](./SECURITY.md). "There is n
 pnpm setup:dev
 ```
 
-That command installs workspace dependencies, syncs the backend Python environment, and regenerates shared API contracts. The first backend sync is heavy because it installs Demucs and Torch. The first stem-separation run will additionally download the Demucs model weights into the local Torch cache.
+That command installs workspace dependencies, checks Tauri build prerequisites, syncs the backend
+Python environment, and regenerates shared API contracts. The first backend sync is heavy because it
+installs Demucs and Torch. The first stem-separation run will additionally download the Demucs model
+weights into the local Torch cache.
 
 To install the optional experimental crema/TensorFlow Advanced Chords backend for local desktop development:
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
     "android:studio": "bash ../../scripts/android-arm64-env.sh tauri android dev --open",
     "dev": "vite",
     "lint": "eslint .",
-    "tauri": "tauri",
+    "tauri": "bash ../../scripts/run-tauri-command.sh",
     "test": "vitest",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/desktop/src-tauri/src/native_audio/mixer.rs
+++ b/apps/desktop/src-tauri/src/native_audio/mixer.rs
@@ -25,6 +25,7 @@ pub enum AudioLaneRole {
 #[serde(rename_all = "camelCase")]
 pub struct AudioLaneUpdate {
     pub lanes: Vec<AudioLaneRequest>,
+    pub playback_rate: Option<f64>,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/apps/desktop/src-tauri/src/native_audio/mod.rs
+++ b/apps/desktop/src-tauri/src/native_audio/mod.rs
@@ -172,6 +172,7 @@ pub fn audio_set_lanes(
     payload: mixer::AudioLaneUpdate,
 ) -> Result<transport::AudioSnapshot, String> {
     let raw_lanes = payload.lanes;
+    let playback_rate = payload.playback_rate;
     let effective_lanes = {
         let mut mixer = state
             .mixer
@@ -184,7 +185,7 @@ pub fn audio_set_lanes(
         .transport
         .lock()
         .map_err(|_| "Native audio transport state is unavailable.".to_string())?;
-    transport.set_lanes(raw_lanes, effective_lanes);
+    transport.set_lanes(raw_lanes, effective_lanes, playback_rate);
     Ok(transport.snapshot())
 }
 

--- a/apps/desktop/src-tauri/src/native_audio/transport.rs
+++ b/apps/desktop/src-tauri/src/native_audio/transport.rs
@@ -212,6 +212,10 @@ impl RingBuffer {
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 enum WorkerControl {
+    SetPlaybackRate {
+        playback_rate: f64,
+        position_seconds: f64,
+    },
     Seek(f64),
     Stop,
 }
@@ -337,6 +341,8 @@ impl TransportState {
         let mut fallback_reason = capabilities.fallback_reason.map(str::to_string);
         let mut next_runtime = None;
 
+        self.stop_runtime();
+
         if native_playback_supported {
             #[cfg(any(target_os = "linux", target_os = "macos"))]
             if let Some(app) = app {
@@ -367,7 +373,6 @@ impl TransportState {
             }
         }
 
-        self.stop_runtime();
         self.session_id = Some(request.session_id.clone());
         self.status = TransportStatus::Stopped;
         self.started_at = None;
@@ -391,13 +396,41 @@ impl TransportState {
         }
     }
 
-    pub fn set_lanes(&mut self, raw_lanes: Vec<AudioLaneRequest>, lanes: Vec<EffectiveAudioLane>) {
+    pub fn set_lanes(
+        &mut self,
+        raw_lanes: Vec<AudioLaneRequest>,
+        lanes: Vec<EffectiveAudioLane>,
+        playback_rate: Option<f64>,
+    ) {
         self.raw_lanes = raw_lanes;
         self.lanes = lanes.clone();
+        let mut next_playback_rate = None;
+        if playback_rate.is_some() {
+            let rate = normalize_playback_rate(playback_rate);
+            if (rate - self.playback_rate).abs() > RATE_TOLERANCE {
+                self.position_seconds = self.current_position();
+                self.playback_rate = rate;
+                if self.status == TransportStatus::Playing {
+                    self.started_at = Some(Instant::now());
+                }
+                next_playback_rate = Some(rate);
+            }
+        }
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         if let Some(runtime) = &self.runtime {
             if let Ok(mut shared) = runtime.shared.lock() {
                 update_shared_lanes(&mut shared, &lanes);
+                if let Some(rate) = next_playback_rate {
+                    let position_seconds = shared.position_seconds;
+                    self.position_seconds = position_seconds;
+                    shared.playback_rate = rate;
+                    for sender in &runtime.worker_control_senders {
+                        let _ = sender.send(WorkerControl::SetPlaybackRate {
+                            playback_rate: rate,
+                            position_seconds,
+                        });
+                    }
+                }
             }
         }
     }
@@ -1090,6 +1123,7 @@ fn spawn_decoder_worker(
     playback_rate: f64,
     error_sender: mpsc::Sender<String>,
 ) -> Result<(mpsc::Sender<WorkerControl>, JoinHandle<()>), String> {
+    let mut playback_rate = normalize_playback_rate(Some(playback_rate));
     let mut decoder = StreamingDecoder::open(
         path.clone(),
         target_sample_rate,
@@ -1101,6 +1135,33 @@ fn spawn_decoder_worker(
     let worker_thread = thread::spawn(move || loop {
         while let Ok(control) = receiver.try_recv() {
             match control {
+                WorkerControl::SetPlaybackRate {
+                    playback_rate: next_playback_rate,
+                    position_seconds,
+                } => {
+                    playback_rate = normalize_playback_rate(Some(next_playback_rate));
+                    if let Ok(mut guard) = ring.lock() {
+                        guard.clear();
+                    }
+                    decoder.set_playback_rate(playback_rate);
+                    if decoder.seek(position_seconds).is_err() {
+                        match StreamingDecoder::open(
+                            path.clone(),
+                            target_sample_rate,
+                            target_channels,
+                            playback_rate,
+                            position_seconds,
+                        ) {
+                            Ok(reopened) => {
+                                decoder = reopened;
+                            }
+                            Err(error) => {
+                                let _ = error_sender.send(error);
+                                return;
+                            }
+                        }
+                    }
+                }
                 WorkerControl::Seek(position_seconds) => {
                     if let Ok(mut guard) = ring.lock() {
                         guard.clear();
@@ -1233,6 +1294,13 @@ impl StreamingDecoder {
         match self {
             Self::Wav(decoder) => decoder.seek(position_seconds),
             Self::Symphonia(decoder) => decoder.seek(position_seconds),
+        }
+    }
+
+    fn set_playback_rate(&mut self, playback_rate: f64) {
+        match self {
+            Self::Wav(decoder) => decoder.set_playback_rate(playback_rate),
+            Self::Symphonia(decoder) => decoder.set_playback_rate(playback_rate),
         }
     }
 }
@@ -1426,6 +1494,11 @@ impl WavStreamDecoder {
         self.stretch.reset();
         Ok(())
     }
+
+    fn set_playback_rate(&mut self, playback_rate: f64) {
+        self.playback_rate = normalize_playback_rate(Some(playback_rate));
+        self.stretch.reset();
+    }
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -1593,6 +1666,11 @@ impl SymphoniaStreamDecoder {
             }
         }
     }
+
+    fn set_playback_rate(&mut self, playback_rate: f64) {
+        self.playback_rate = normalize_playback_rate(Some(playback_rate));
+        self.stretch.reset();
+    }
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -1708,6 +1786,28 @@ mod tests {
 
         assert!(session.native_playback_supported);
         assert_eq!(session.fallback_reason.as_deref(), None);
+    }
+
+    #[test]
+    fn lane_update_can_change_playback_rate_without_reprepare() {
+        let mut state = TransportState::default();
+        state.prepare(
+            None,
+            AudioSessionRequest {
+                session_id: "session".to_string(),
+                duration_seconds: Some(30.0),
+                playback_rate: Some(1.0),
+                lanes: Vec::new(),
+            },
+            Vec::new(),
+            capabilities(),
+        );
+
+        state.set_lanes(Vec::new(), Vec::new(), Some(1.5));
+        let snapshot = state.snapshot();
+
+        assert_eq!(snapshot.session_id.as_deref(), Some("session"));
+        assert!((snapshot.playback_rate - 1.5).abs() < RATE_TOLERANCE);
     }
 
     #[test]

--- a/apps/desktop/src/App.project-tempo.test.tsx
+++ b/apps/desktop/src/App.project-tempo.test.tsx
@@ -1,9 +1,10 @@
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   findAudioByArtifactId,
   getMockAudioContexts,
+  getMockInvoke,
   markAudioReady,
   mockCreateExport,
   mockCreatePreview,
@@ -11,6 +12,7 @@ import {
   renderApp,
   resetAppTestHarness,
   setAudioPlaybackState,
+  setMockNativeAudioState,
   setProjectAnalysis,
 } from "./test/appTestHarness";
 
@@ -53,8 +55,22 @@ function setPlaybackPosition(value: string) {
   fireEvent.change(screen.getByLabelText("Playback position"), { target: { value } });
 }
 
+function mockTauriRuntime() {
+  Object.defineProperty(window, "__TAURI_INTERNALS__", {
+    configurable: true,
+    value: {},
+  });
+
+  return () => {
+    delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  };
+}
+
 describe("Desktop app project playback tempo", () => {
   beforeEach(resetAppTestHarness);
+  afterEach(() => {
+    delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  });
 
   it("persists whole-BPM tempo changes and reset without creating audio files", async () => {
     const user = userEvent.setup();
@@ -82,6 +98,34 @@ describe("Desktop app project playback tempo", () => {
 
     await user.click(screen.getByRole("button", { name: "Reset" }));
     expect(screen.getByText("Original 123.5 BPM")).toBeInTheDocument();
+  });
+
+  it("does not open native playback while the project is idle", async () => {
+    const restoreTauriRuntime = mockTauriRuntime();
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    setMockNativeAudioState({
+      capabilities: {
+        nativePlaybackSupported: true,
+        fallbackRequired: false,
+        fallbackReason: null,
+        backend: "desktop-cpal",
+      },
+    });
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+
+    expect(
+      Array.from(document.querySelectorAll("audio")).every(
+        (element) => !element.getAttribute("src"),
+      ),
+    ).toBe(true);
+    expect(
+      getMockInvoke().mock.calls.some(([command]) => command === "audio_prepare_session"),
+    ).toBe(false);
+    restoreTauriRuntime();
   });
 
   it("keeps source and practice mix switching on the streamed media path when tempo is changed", async () => {

--- a/apps/desktop/src/App.tools-tuner.test.tsx
+++ b/apps/desktop/src/App.tools-tuner.test.tsx
@@ -14,7 +14,10 @@ import {
 
 describe("Desktop app tools tuner", () => {
   beforeEach(resetAppTestHarness);
-  afterEach(() => vi.unstubAllEnvs());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
 
   it("renders the tools route with chromatic tuner defaults", async () => {
     renderApp(["/tools"]);
@@ -272,6 +275,29 @@ describe("Desktop app tools tuner", () => {
     await user.click(screen.getByRole("button", { name: "Stop" }));
 
     expect(getMockInvoke()).toHaveBeenCalledWith("audio_stop_input");
+  });
+
+  it("does not poll native microphone devices while the tuner is idle", async () => {
+    const setIntervalSpy = vi.spyOn(window, "setInterval");
+    setMockNativeAudioState({
+      capabilities: {
+        micCaptureSupported: true,
+        backend: "desktop-cpal",
+      },
+      inputDevices: {
+        supported: true,
+        devices: [{ id: "cpal:1:usb", label: "USB Interface", isDefault: false }],
+        error: null,
+      },
+    });
+
+    renderApp(["/tools"]);
+
+    expect(await screen.findByRole("option", { name: "USB Interface" })).toBeInTheDocument();
+    expect(
+      getMockInvoke().mock.calls.filter(([command]) => command === "audio_list_input_devices"),
+    ).toHaveLength(1);
+    expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 5000);
   });
 
   it("can force Web Audio capture when native capture is available", async () => {

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -103,11 +103,10 @@ function nativeSessionSignature(session: ProjectPlaybackSession | null) {
   if (!session) {
     return "none";
   }
-  const playbackRate = playbackRateForSession(session).toFixed(6);
   const artifactIds = nativeActiveArtifactIds(session)
     .sort()
     .join(",");
-  return `${session.projectId}:native:${artifactIds}:rate:${playbackRate}`;
+  return `${session.projectId}:native:${artifactIds}`;
 }
 
 function nativeActiveArtifactIds(session: ProjectPlaybackSession) {
@@ -166,7 +165,15 @@ function nativeLaneRequestsForSession(session: ProjectPlaybackSession): NativeAu
   });
 }
 
+function nativeLaneUpdateForSession(session: ProjectPlaybackSession) {
+  return {
+    lanes: nativeLaneRequestsForSession(session),
+    playbackRate: playbackRateForSession(session),
+  };
+}
+
 export function PlaybackProvider({ children }: { children: ReactNode }) {
+  const initialWebMediaSourcesEnabled = isWebAudioBackendForced() || !isTauriRuntime();
   const restoredPlaybackState = useRef(readPersistedPlaybackState()).current;
   const primaryAudioRef = useRef<HTMLAudioElement | null>(null);
   const activePrecountRef = useRef<ActivePrecount | null>(null);
@@ -185,7 +192,9 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     sessionSignature: null,
     playbackSignature: null,
   });
+  const nativeStopPromiseRef = useRef<Promise<void> | null>(null);
   const nativeCapabilitiesPromiseRef = useRef<ReturnType<typeof getNativeAudioCapabilities> | null>(null);
+  const webMediaSourcesEnabledRef = useRef(initialWebMediaSourcesEnabled);
   const pendingTransitionRef = useRef<PendingTransition | null>(
     restoredPlaybackState
         ? {
@@ -218,6 +227,9 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   );
   const [isPrecounting, setIsPrecounting] = useState(false);
   const [isPlaying, setIsPlaying] = useState(restoredPlaybackState?.isPlaying ?? false);
+  const [webMediaSourcesEnabled, setWebMediaSourcesEnabled] = useState(
+    initialWebMediaSourcesEnabled,
+  );
 
   useEffect(() => {
     sessionRef.current = session;
@@ -293,7 +305,12 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
   const canUseBufferedClock = useCallback(
     (targetSession: ProjectPlaybackSession | null) => {
-      if (!targetSession || !canUseStemClock() || !usesDefaultPlaybackRate(targetSession)) {
+      if (
+        !webMediaSourcesEnabledRef.current ||
+        !targetSession ||
+        !canUseStemClock() ||
+        !usesDefaultPlaybackRate(targetSession)
+      ) {
         return false;
       }
 
@@ -309,6 +326,14 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     },
     [canUseStemClock],
   );
+
+  const enableWebMediaSources = useStableCallback(function enableWebMediaSources() {
+    if (webMediaSourcesEnabledRef.current) {
+      return;
+    }
+    webMediaSourcesEnabledRef.current = true;
+    setWebMediaSourcesEnabled(true);
+  });
 
   const getNativeAudioCapabilityState = useStableCallback(async function getNativeAudioCapabilityState() {
     if (isWebAudioBackendForced() || !isTauriRuntime()) {
@@ -354,6 +379,19 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     };
   });
 
+  const requestNativeStop = useStableCallback(function requestNativeStop() {
+    const stopPromise = stopNativeAudio()
+      .catch(() => undefined)
+      .then(() => undefined)
+      .finally(() => {
+        if (nativeStopPromiseRef.current === stopPromise) {
+          nativeStopPromiseRef.current = null;
+        }
+      });
+    nativeStopPromiseRef.current = stopPromise;
+    return stopPromise;
+  });
+
   const pauseRenderedMediaElements = useStableCallback(function pauseRenderedMediaElements(
     targetSession: ProjectPlaybackSession | null = sessionRef.current,
   ) {
@@ -369,7 +407,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     const sessionSignature = nativeSessionSignature(targetSession);
     const lanes = nativeLaneRequestsForSession(targetSession);
     if (nativePlaybackRef.current.sessionSignature === sessionSignature) {
-      await setNativeAudioLanes({ lanes });
+      await setNativeAudioLanes(nativeLaneUpdateForSession(targetSession));
       return true;
     }
 
@@ -380,9 +418,13 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     ) {
       const prepared = await pendingPrepare.preparePromise;
       if (prepared && nativePlaybackRef.current.sessionSignature === sessionSignature) {
-        await setNativeAudioLanes({ lanes });
+        await setNativeAudioLanes(nativeLaneUpdateForSession(targetSession));
       }
       return prepared;
+    }
+
+    if (nativeStopPromiseRef.current) {
+      await nativeStopPromiseRef.current;
     }
 
     const preparePromise = (async () => {
@@ -408,7 +450,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       }
       if (nativePlaybackRef.current.blockedSessionSignature === sessionSignature) {
         if (nativePlaybackRef.current.prepareSignature === sessionSignature) {
-          void stopNativeAudio().catch(() => undefined);
+          void requestNativeStop();
           nativePlaybackRef.current = {
             ...nativePlaybackRef.current,
             preparePromise: null,
@@ -420,7 +462,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       const currentNative = nativePlaybackRef.current;
       if (currentNative.prepareSignature !== sessionSignature) {
         if (!currentNative.active && !currentNative.prepareSignature) {
-          void stopNativeAudio().catch(() => undefined);
+          void requestNativeStop();
         }
         return false;
       }
@@ -446,7 +488,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     try {
       const prepared = await preparePromise;
       if (prepared && nativePlaybackRef.current.sessionSignature === sessionSignature) {
-        await setNativeAudioLanes({ lanes });
+        await setNativeAudioLanes(nativeLaneUpdateForSession(targetSession));
       }
       return prepared;
     } catch (error) {
@@ -471,6 +513,9 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     timeSeconds: number,
   ) {
     const sessionSignature = nativeSessionSignature(targetSession);
+    const wasNativeActive =
+      nativePlaybackRef.current.active &&
+      nativePlaybackRef.current.sessionSignature === sessionSignature;
     try {
       if (!(await ensureNativePlaybackSession(targetSession))) {
         return false;
@@ -486,14 +531,14 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           !nativePlaybackRef.current.active
         ) {
           markNativePlaybackInactive();
-          void stopNativeAudio().catch(() => undefined);
+          void requestNativeStop();
         }
         return false;
       }
-      await setNativeAudioLanes({ lanes: nativeLaneRequestsForSession(latestSession) });
+      await setNativeAudioLanes(nativeLaneUpdateForSession(latestSession));
       const snapshot = await playNativeAudio({
         startTimeSeconds:
-          timeSeconds <= SEEK_TOLERANCE_SECONDS
+          wasNativeActive || timeSeconds <= SEEK_TOLERANCE_SECONDS
             ? null
             : clampTime(timeSeconds, latestSession.durationHintSeconds || 0),
       });
@@ -1007,7 +1052,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       nativePlaybackRef.current.active &&
       nativePlaybackRef.current.sessionSignature === nativeSessionSignature(targetSession)
     ) {
-      void setNativeAudioLanes({ lanes: nativeLaneRequestsForSession(targetSession) }).catch(
+      void setNativeAudioLanes(nativeLaneUpdateForSession(targetSession)).catch(
         (error) => {
           rememberNativePlaybackError(playbackErrorMessage(error));
         },
@@ -1254,6 +1299,11 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         return;
       }
 
+      if (!webMediaSourcesEnabledRef.current) {
+        enableWebMediaSources();
+        return;
+      }
+
       const targetElements = getActiveMediaElements(targetSession);
       const targetKeys = getActiveMediaKeys(targetSession);
       if (!targetElements.length) {
@@ -1435,6 +1485,25 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         markNativePlaybackInactive();
         return;
       }
+    }
+
+    if (!webMediaSourcesEnabledRef.current) {
+      const activeKeys = getActiveMediaKeys(targetSession);
+      if (!activeKeys.length) {
+        return;
+      }
+      pendingTransitionRef.current = {
+        id: ++transitionCounterRef.current,
+        signature: playbackSignature(targetSession),
+        shouldPlay: true,
+        targetTime: masterTime,
+        awaitSeekBeforePlay: true,
+        awaitingLoadKeys: activeKeys,
+        awaitingSeekKeys: activeKeys,
+        forceSeekKeys: activeKeys,
+      };
+      enableWebMediaSources();
+      return;
     }
 
     const activeElements = getActiveMediaElements(targetSession);
@@ -1679,7 +1748,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     cancelPrecount();
     clearPendingTransition();
     if (nativePlaybackRef.current.active) {
-      void stopNativeAudio().catch(() => undefined);
+      void requestNativeStop();
       markNativePlaybackInactive();
     }
     if (stemPlaybackRef.current) {
@@ -1699,6 +1768,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     clearPendingTransition,
     getRenderedMediaElements,
     markNativePlaybackInactive,
+    requestNativeStop,
     stopStemSources,
     syncStemElementTimes,
     updateDurationFromActiveMedia,
@@ -1737,8 +1807,11 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       const previousUsesNative =
         nativePlaybackRef.current.active &&
         nativePlaybackRef.current.playbackSignature === previousSignature;
-      if (previousUsesNative) {
-        void stopNativeAudio().catch(() => undefined);
+      const carriesNativeSession =
+        previousUsesNative &&
+        nativeSessionSignature(previousSession) === nativeSessionSignature(nextSession);
+      if (previousUsesNative && !carriesNativeSession) {
+        void requestNativeStop();
         markNativePlaybackInactive();
         getActiveMediaElements(previousSession).forEach((element) => {
           element.pause();
@@ -1807,6 +1880,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     getRenderedMediaElements,
     markNativePlaybackInactive,
     readMasterTime,
+    requestNativeStop,
     syncStemElementTimes,
   ]);
 
@@ -1824,34 +1898,18 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   ]);
 
   useEffect(() => {
-    if (!session || !usesDefaultPlaybackRate(session)) {
-      if (nativePlaybackRef.current.preparePromise) {
-        nativePlaybackRef.current = {
-          ...nativePlaybackRef.current,
-          preparePromise: null,
-          prepareSignature: null,
-        };
-      }
-      return;
-    }
-    if (isPlayingRef.current) {
-      return;
-    }
-
-    void ensureNativePlaybackSession(session).catch((error) => {
-      rememberNativePlaybackError(playbackErrorMessage(error));
-    });
-  }, [ensureNativePlaybackSession, session]);
-
-  useEffect(() => {
-    if (!session?.visibleStemArtifactIds.length || !canUseStemClock()) {
+    if (
+      !webMediaSourcesEnabled ||
+      !session?.visibleStemArtifactIds.length ||
+      !canUseStemClock()
+    ) {
       return;
     }
 
     void Promise.allSettled(
       session.visibleStemArtifactIds.map((artifactId) => loadStemBuffer(artifactId)),
     );
-  }, [canUseStemClock, loadStemBuffer, session]);
+  }, [canUseStemClock, loadStemBuffer, session, webMediaSourcesEnabled]);
 
   useEffect(
     () => () => {
@@ -1885,7 +1943,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           return;
         }
         markNativePlaybackInactive();
-        void stopNativeAudio().catch(() => undefined);
+        void requestNativeStop();
         setPlaybackTimeSeconds(0);
         setIsPlaying(false);
         syncStemElementTimes(sessionRef.current?.visibleStemArtifactIds ?? [], 0);
@@ -1907,7 +1965,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         nativePlaybackRef.current.blockedSessionSignature = nativeSessionSignature(activeSession);
         markNativePlaybackInactive();
         setIsPlaying(false);
-        void stopNativeAudio().catch(() => undefined);
+        void requestNativeStop();
         syncStemElementTimes(activeSession.visibleStemArtifactIds, fallbackTime);
         getRenderedMediaElements(activeSession).forEach((element) => {
           element.pause();
@@ -1927,6 +1985,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     getRenderedMediaElements,
     markNativePlaybackInactive,
     playPlaybackImmediately,
+    requestNativeStop,
     syncStemElementTimes,
   ]);
 
@@ -1991,11 +2050,14 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         }
         ref={setPrimaryAudioRef}
         src={
-          session && !session.isStemPlayback && session.selectedPlaybackArtifactId
+          webMediaSourcesEnabled &&
+          session &&
+          !session.isStemPlayback &&
+          session.selectedPlaybackArtifactId
             ? api.streamArtifactUrl(session.selectedPlaybackArtifactId)
             : undefined
         }
-        preload="metadata"
+        preload={webMediaSourcesEnabled ? "metadata" : "none"}
         className="player player--hidden"
         onTimeUpdate={(event) => {
           if (!sessionRef.current || sessionRef.current.isStemPlayback) {
@@ -2034,8 +2096,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         <audio
           key={artifactId}
           ref={(element) => setStemAudioRef(artifactId, element)}
-          src={api.streamArtifactUrl(artifactId)}
-          preload="metadata"
+          src={webMediaSourcesEnabled ? api.streamArtifactUrl(artifactId) : undefined}
+          preload={webMediaSourcesEnabled ? "metadata" : "none"}
           className="player player--hidden"
           onTimeUpdate={(event) => {
             if (!sessionRef.current || !sessionRef.current.isStemPlayback) {

--- a/apps/desktop/src/features/tools/TunerPreferenceControls.tsx
+++ b/apps/desktop/src/features/tools/TunerPreferenceControls.tsx
@@ -28,8 +28,6 @@ type TunerPreferenceControlsProps = {
   systemDefaultOnly?: boolean;
 };
 
-const NATIVE_DEVICE_REFRESH_INTERVAL_MS = 5000;
-
 export function TunerPreferenceControls({
   children,
   className,
@@ -76,17 +74,12 @@ export function TunerPreferenceControls({
     }
 
     void refreshDevices();
-    const refreshIntervalId = window.setInterval(
-      refreshDevices,
-      NATIVE_DEVICE_REFRESH_INTERVAL_MS,
-    );
     if (canEnumerateDevices) {
       navigator.mediaDevices?.addEventListener?.("devicechange", refreshDevices);
     }
 
     return () => {
       active = false;
-      window.clearInterval(refreshIntervalId);
       if (canEnumerateDevices) {
         navigator.mediaDevices?.removeEventListener?.("devicechange", refreshDevices);
       }

--- a/apps/desktop/src/lib/nativeAudio.ts
+++ b/apps/desktop/src/lib/nativeAudio.ts
@@ -50,6 +50,7 @@ export type NativeAudioLaneRequest = {
 
 export type NativeAudioLaneUpdate = {
   lanes: NativeAudioLaneRequest[];
+  playbackRate?: number | null;
 };
 
 export type NativeAudioSessionRequest = {

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -456,6 +456,13 @@ const {
       eventName: string,
       handler: (event: NativeAudioInputFrameEvent) => void,
     ) => {
+      if (
+        eventName === "audio://position" ||
+        eventName === "audio://ended" ||
+        eventName === "audio://error"
+      ) {
+        return () => undefined;
+      }
       if (eventName !== "audio://input-frame") {
         throw new Error(`Unexpected listen event: ${eventName}`);
       }

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,5 +1,18 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { existsSync, realpathSync } from "node:fs";
+import { resolve } from "node:path";
+
+const workspaceRoot = resolve(import.meta.dirname, "../..");
+const fsAllow = Array.from(
+  new Set(
+    [
+      workspaceRoot,
+      realpathIfPresent(workspaceRoot),
+      realpathIfPresent(resolve(workspaceRoot, "node_modules")),
+    ].filter((path): path is string => Boolean(path)),
+  ),
+);
 
 const reactRefreshPreamble = {
   name: "tuneforge-react-refresh-preamble",
@@ -31,6 +44,9 @@ export default defineConfig({
     host: "127.0.0.1",
     port: 1420,
     strictPort: true,
+    fs: {
+      allow: fsAllow,
+    },
   },
   test: {
     environment: "jsdom",
@@ -41,3 +57,7 @@ export default defineConfig({
     setupFiles: "./src/setupTests.ts",
   },
 });
+
+function realpathIfPresent(path: string) {
+  return existsSync(path) ? realpathSync(path) : null;
+}

--- a/docs/NATIVE_AUDIO.md
+++ b/docs/NATIVE_AUDIO.md
@@ -15,11 +15,32 @@ added feature by feature behind the Tauri native audio boundary.
 - Native tempo changes use `signalsmith-stretch` for pitch-preserving playback.
 - If native setup, decode, seek, or output startup fails, playback falls back to Web Audio at the
   same transport position.
+- Linux native capture and playback currently use `cpal`'s ALSA host. On PipeWire/PulseAudio
+  desktops this usually routes through the host ALSA compatibility layer, but device labels may
+  still look like ALSA PCM names.
 
 ## Backend Selection
 
 The frontend prefers native audio when a feature is supported and falls back to Web Audio when
 native support is unavailable or startup fails.
+
+## Linux Build Prerequisites
+
+Native tempo playback uses `signalsmith-stretch`, which runs Rust `bindgen` during the Tauri build.
+Linux developers need Clang/libclang development files available to Cargo:
+
+```sh
+# Arch
+sudo pacman -S clang
+
+# Debian/Ubuntu
+sudo apt-get install clang libclang-dev
+```
+
+`pnpm setup:dev` checks these prerequisites. `pnpm --filter @tuneforge/desktop tauri ...` runs
+through a wrapper that sets `LIBCLANG_PATH` from a system install or from the backend `.venv` when
+the optional TensorFlow stack already installed the Python `libclang` wheel. Direct `cargo check` /
+`cargo test` commands still require the same system toolchain or equivalent `LIBCLANG_PATH`.
 
 For development comparisons, force Web Audio for native-audio-backed features:
 

--- a/scripts/configure-tauri-build-env.sh
+++ b/scripts/configure-tauri-build-env.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+configure_tauri_repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  if [[ -z "${LIBCLANG_PATH:-}" ]]; then
+    shopt -s nullglob
+    configure_tauri_libclang_candidates=(
+      "${configure_tauri_repo_root}"/apps/backend/.venv/lib/python*/site-packages/clang/native/libclang.so
+      /usr/lib/libclang.so
+      /usr/lib/libclang-*.so
+      /usr/lib/libclang.so.*
+      /usr/lib/llvm*/lib/libclang.so
+      /usr/lib/llvm*/lib/libclang-*.so
+      /usr/lib*/llvm*/lib/libclang.so
+      /usr/lib*/llvm*/lib/libclang-*.so
+      /usr/lib64/libclang.so
+      /usr/lib64/libclang-*.so
+      /usr/local/lib/libclang.so
+      /usr/local/lib/libclang-*.so
+    )
+    shopt -u nullglob
+
+    for configure_tauri_libclang_path in "${configure_tauri_libclang_candidates[@]}"; do
+      if [[ -f "${configure_tauri_libclang_path}" ]]; then
+        export LIBCLANG_PATH
+        LIBCLANG_PATH="$(dirname -- "${configure_tauri_libclang_path}")"
+        break
+      fi
+    done
+  fi
+
+  if [[ -z "${LIBCLANG_PATH:-}" ]]; then
+    cat >&2 <<'EOF'
+Tuneforge native tempo playback uses signalsmith-stretch, which runs bindgen during the Tauri build.
+bindgen requires libclang. Install Clang/libclang development files, then rerun this command.
+
+Arch:
+  sudo pacman -S clang
+
+Debian/Ubuntu:
+  sudo apt-get install -y clang libclang-dev
+EOF
+    return 1 2>/dev/null || exit 1
+  fi
+
+  if command -v cc >/dev/null 2>&1; then
+    configure_tauri_cc_include_dir="$(cc -print-file-name=include 2>/dev/null || true)"
+    if [[ -d "${configure_tauri_cc_include_dir}" ]]; then
+      case " ${BINDGEN_EXTRA_CLANG_ARGS:-} " in
+        *" -I${configure_tauri_cc_include_dir} "*) ;;
+        *)
+          export BINDGEN_EXTRA_CLANG_ARGS
+          BINDGEN_EXTRA_CLANG_ARGS="${BINDGEN_EXTRA_CLANG_ARGS:+${BINDGEN_EXTRA_CLANG_ARGS} }-I${configure_tauri_cc_include_dir}"
+          ;;
+      esac
+    fi
+  fi
+fi

--- a/scripts/run-tauri-command.sh
+++ b/scripts/run-tauri-command.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+desktop_dir="${repo_root}/apps/desktop"
+
+source "${repo_root}/scripts/configure-tauri-build-env.sh"
+
+cd "${desktop_dir}"
+exec pnpm exec tauri "$@"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -18,6 +18,7 @@ printf '\n[tests] Starting Tauri shell tests\n\n'
 tauri_start=${SECONDS}
 (
   cd "${repo_root}/apps/desktop/src-tauri"
+  source "${repo_root}/scripts/configure-tauri-build-env.sh"
   cargo test
 )
 tauri_elapsed=$((SECONDS - tauri_start))

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -81,6 +81,9 @@ if [[ "${skip_pnpm_install}" -eq 0 ]]; then
   pnpm install
 fi
 
+echo "Checking Tauri build dependencies..."
+source "${repo_root}/scripts/configure-tauri-build-env.sh"
+
 cd "${backend_dir}"
 
 if [[ "${legacy_nvidia}" -eq 1 ]]; then


### PR DESCRIPTION
## Summary
- Fixes #79.
- Avoid WebKit media preloads while native playback is selected, reducing idle Linux streams.
- Keep native tempo updates in place so active sessions do not spawn extra output streams.
- Add Tauri build env setup for libclang/bindgen and document Linux native-audio setup.
- Related follow-up issues: #76, #77, and #78 cover remaining Linux Web Audio/backend work.

## Testing
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test --run src/App.project-tempo.test.tsx src/App.tools-tuner.test.tsx src/lib/nativeAudio.test.ts`
- `cd apps/desktop/src-tauri && cargo test native_audio::transport`
- `cd apps/desktop/src-tauri && cargo fmt --check`
- `pnpm --filter @tuneforge/desktop tauri build --debug --no-bundle`
- Not run: macOS runtime validation.
