### PR TITLE
fix: restore Web Audio output on Linux

### DIFF
--- a/apps/backend/app/api/routes/artifacts.py
+++ b/apps/backend/app/api/routes/artifacts.py
@@ -12,6 +12,18 @@ from app.models import Artifact
 
 router = APIRouter(prefix="/artifacts", tags=["artifacts"])
 
+AUDIO_MEDIA_TYPES = {
+    "aac": "audio/aac",
+    "flac": "audio/flac",
+    "m4a": "audio/mp4",
+    "mka": "audio/x-matroska",
+    "mkv": "video/x-matroska",
+    "mp3": "audio/mpeg",
+    "ogg": "audio/ogg",
+    "wav": "audio/wav",
+    "webm": "audio/webm",
+}
+
 
 @router.get("/{artifact_id}/stream")
 def stream_artifact(artifact_id: str, session: Session = Depends(get_db)) -> FileResponse:
@@ -21,5 +33,5 @@ def stream_artifact(artifact_id: str, session: Session = Depends(get_db)) -> Fil
     path = Path(artifact.path)
     if not path.exists():
         raise AppError("ARTIFACT_NOT_FOUND", "Artifact file no longer exists.", status_code=404)
-    return FileResponse(path=path, media_type=f"audio/{artifact.format}", filename=path.name)
-
+    media_type = AUDIO_MEDIA_TYPES.get(artifact.format.lower(), f"audio/{artifact.format}")
+    return FileResponse(path=path, media_type=media_type, filename=path.name)

--- a/apps/desktop/src/App.project-playback-stems.test.tsx
+++ b/apps/desktop/src/App.project-playback-stems.test.tsx
@@ -20,6 +20,8 @@ import {
   setProjectChords,
   setAudioPlaybackState,
   setDeferredPreviewCompletion,
+  setMockAudioContextInitialState,
+  setMockAudioSourceStartError,
   setProjects,
 } from "./test/appTestHarness";
 
@@ -322,6 +324,44 @@ describe("Desktop app project playback stems", () => {
     const restartedSource = getMockAudioContexts()[0].createdSources[sourceCountAfterEnd];
     expect(restartedSource?.start.mock.calls[0]?.[1]).toBe(0);
     expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+  });
+
+  it("primes Web Audio from the playback gesture before artifact buffers finish loading", async () => {
+    const user = userEvent.setup();
+    setMockAudioContextInitialState("suspended");
+    getMockFetch().mockImplementationOnce(
+      () => new Promise<Response>(() => undefined),
+    );
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    await waitFor(() => expect(getMockAudioContexts()).toHaveLength(1));
+    expect(getMockAudioContexts()[0]?.resume).toHaveBeenCalled();
+    expect(getMockAudioContexts()[0]?.createdSources).toHaveLength(0);
+  });
+
+  it("keeps playback stopped when Web Audio sources cannot start", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(getMockAudioContexts()[0]?.createdSources).toHaveLength(1));
+    setMockAudioSourceStartError(new Error("start failed"));
+
+    await user.click(screen.getByRole("button", { name: "Pause playback" }));
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
   });
 
   it("keeps playback position when a newly created mix becomes active", async () => {

--- a/apps/desktop/src/features/projects/playback-context.ts
+++ b/apps/desktop/src/features/projects/playback-context.ts
@@ -36,6 +36,7 @@ export type PlaybackContextValue = {
   isPrecounting: boolean;
   isPlaying: boolean;
   activateStemPlayback: () => Promise<void>;
+  primeWebAudioForGesture: () => Promise<void>;
   getPlaybackSnapshot: () => PlaybackSnapshot;
   registerProjectSession: (session: ProjectPlaybackSession) => void;
   togglePlayback: () => Promise<void>;

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -28,6 +28,11 @@ import {
   rememberNativePlaybackError,
   rememberPlaybackBackend,
 } from "../../lib/playbackDiagnostics";
+import {
+  activateWebAudioContext,
+  getWebAudioContextConstructor,
+  primeWebAudioContext,
+} from "../../lib/webAudio";
 import { useStableCallback } from "../../lib/useStableCallback";
 import {
   PlaybackContext,
@@ -282,18 +287,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       .filter(Boolean) as HTMLAudioElement[];
   }
 
-  const getAudioContextConstructor = useCallback(() => {
-    if (typeof window === "undefined") {
-      return null;
-    }
-
-    return (
-      window.AudioContext ??
-      (window as Window & typeof globalThis & { webkitAudioContext?: typeof AudioContext })
-        .webkitAudioContext ??
-      null
-    );
-  }, []);
+  const getAudioContextConstructor = useCallback(() => getWebAudioContextConstructor(), []);
 
   const canUseStemClock = useCallback(
     () =>
@@ -615,6 +609,30 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     return context;
   }, [getAudioContextConstructor]);
 
+  const activatePlaybackAudioContext = useStableCallback(async function activatePlaybackAudioContext(
+    context: AudioContext,
+  ) {
+    await activateWebAudioContext(context);
+  });
+
+  const primeWebAudioForGesture = useStableCallback(async function primeWebAudioForGesture() {
+    if (!canUseStemClock()) {
+      return;
+    }
+
+    const context = getStemAudioContext();
+    if (!context) {
+      return;
+    }
+
+    primeWebAudioContext(context);
+    try {
+      await activatePlaybackAudioContext(context);
+    } catch {
+      stemClockBlockedRef.current = true;
+    }
+  });
+
   const cancelPrecount = useStableCallback(function cancelPrecount() {
     const activePrecount = activePrecountRef.current;
     activePrecountRef.current = null;
@@ -682,20 +700,12 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       return;
     }
 
-    // WebKit on Linux is stricter about user-gesture timing for AudioContext resume.
     try {
-      await context.resume();
+      await activatePlaybackAudioContext(context);
     } catch {
       stemClockBlockedRef.current = true;
-      return;
     }
-
-    const contextState = (context as AudioContext).state;
-    if (contextState !== "running") {
-      stemClockBlockedRef.current = true;
-      return;
-    }
-  }, [canUseStemClock, getStemAudioContext]);
+  }, [activatePlaybackAudioContext, canUseStemClock, getStemAudioContext]);
 
   const loadStemBuffer = useStableCallback(async function loadStemBuffer(artifactId: string) {
     return loadStemPlaybackBuffer(artifactId, {
@@ -875,14 +885,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     }
 
     try {
-      await targetPlaybackState.context.resume();
+      await activatePlaybackAudioContext(targetPlaybackState.context);
     } catch {
-      stemClockBlockedRef.current = true;
-      disposeStemPlaybackState();
-      setIsPlaying(false);
-      return false;
-    }
-    if (targetPlaybackState.context.state !== "running") {
       stemClockBlockedRef.current = true;
       disposeStemPlaybackState();
       setIsPlaying(false);
@@ -936,9 +940,24 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     syncStemElementTimes(targetPlaybackState.artifactIds, nextTime);
     applyStemVolumes(targetSession);
 
-    Object.values(nextSources).forEach((sourceNode) =>
-      sourceNode.start(sourceStartTimeSeconds, nextTime),
-    );
+    let scheduledCount = 0;
+    try {
+      Object.values(nextSources).forEach((sourceNode) => {
+        sourceNode.start(sourceStartTimeSeconds, nextTime);
+        scheduledCount += 1;
+      });
+    } catch {
+      stemClockBlockedRef.current = true;
+      disposeStemPlaybackState();
+      setIsPlaying(false);
+      return false;
+    }
+    if (scheduledCount !== Object.keys(nextSources).length || scheduledCount === 0) {
+      stemClockBlockedRef.current = true;
+      disposeStemPlaybackState();
+      setIsPlaying(false);
+      return false;
+    }
 
     setPlaybackTimeSeconds(nextTime);
     setPlaybackDurationSeconds(targetPlaybackState.durationSeconds);
@@ -1171,6 +1190,19 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     }
   });
 
+  const playWebMediaElements = useStableCallback(async function playWebMediaElements(
+    elements: HTMLAudioElement[],
+  ) {
+    if (!elements.length) {
+      return false;
+    }
+
+    const results = await Promise.allSettled(
+      elements.map((element) => Promise.resolve(element.play())),
+    );
+    return results.some((result) => result.status === "fulfilled");
+  });
+
   const clearPendingTransition = useStableCallback(function clearPendingTransition() {
     pendingTransitionRef.current = null;
   });
@@ -1275,6 +1307,10 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         if (started) {
           return;
         }
+        if (stemClockBlockedRef.current) {
+          setIsPlaying(false);
+          return;
+        }
 
         const fallbackElements = getActiveMediaElements(latestSession);
         if (!fallbackElements.length) {
@@ -1288,10 +1324,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         });
         applyMediaPlaybackRate(latestSession);
 
-        const results = await Promise.allSettled(
-          fallbackElements.map((element) => Promise.resolve(element.play())),
-        );
-        const fallbackStarted = results.some((result) => result.status === "fulfilled");
+        const fallbackStarted = await playWebMediaElements(fallbackElements);
         if (fallbackStarted) {
           rememberPlaybackBackend({ backend: "web", detail: null });
         }
@@ -1394,16 +1427,13 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       }
 
       applyMediaPlaybackRate(targetSession);
-      const results = await Promise.allSettled(
-        targetElements.map((element) => Promise.resolve(element.play())),
-      );
+      const started = await playWebMediaElements(targetElements);
       if (pendingTransitionRef.current?.id === transitionId) {
         return;
       }
       if (playbackSignature(sessionRef.current) !== transitionSignature) {
         return;
       }
-      const started = results.some((result) => result.status === "fulfilled");
       if (started) {
         rememberPlaybackBackend({ backend: "web", detail: null });
       }
@@ -1485,6 +1515,11 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         markNativePlaybackInactive();
         return;
       }
+      if (stemClockBlockedRef.current) {
+        markNativePlaybackInactive();
+        setIsPlaying(false);
+        return;
+      }
     }
 
     if (!webMediaSourcesEnabledRef.current) {
@@ -1519,11 +1554,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     applyStemVolumes(targetSession);
     applyMediaPlaybackRate(targetSession);
 
-    const results = await Promise.allSettled(
-      activeElements.map((element) => Promise.resolve(element.play())),
-    );
     markNativePlaybackInactive();
-    const started = results.some((result) => result.status === "fulfilled");
+    const started = await playWebMediaElements(activeElements);
     if (started) {
       rememberPlaybackBackend({ backend: "web", detail: null });
     }
@@ -1565,20 +1597,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     }
 
     try {
-      if (precountAudio.context.state === "suspended") {
-        await precountAudio.context.resume();
-      }
+      await activatePlaybackAudioContext(precountAudio.context);
     } catch {
-      if (precountAudio.ownsContext && precountAudioContextRef.current === precountAudio.context) {
-        precountAudioContextRef.current = null;
-      }
-      if (precountAudio.ownsContext) {
-        void precountAudio.context.close().catch(() => undefined);
-      }
-      return false;
-    }
-
-    if (precountAudio.context.state !== "running") {
       if (precountAudio.ownsContext && precountAudioContextRef.current === precountAudio.context) {
         precountAudioContextRef.current = null;
       }
@@ -1687,8 +1707,9 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       pausePlayback();
       return;
     }
+    await primeWebAudioForGesture();
     await playPlayback();
-  }, [cancelPrecount, pausePlayback, playPlayback]);
+  }, [cancelPrecount, pausePlayback, playPlayback, primeWebAudioForGesture]);
 
   const seekTo = useCallback((timeSeconds: number) => {
     cancelPrecount();
@@ -2010,6 +2031,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       isPrecounting,
       isPlaying,
       activateStemPlayback,
+      primeWebAudioForGesture,
       getPlaybackSnapshot,
       registerProjectSession,
       togglePlayback,
@@ -2023,6 +2045,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     [
       dismissSession,
       activateStemPlayback,
+      primeWebAudioForGesture,
       getPlaybackSnapshot,
       isPrecounting,
       isPlaying,

--- a/apps/desktop/src/features/tools/ToolsView.tsx
+++ b/apps/desktop/src/features/tools/ToolsView.tsx
@@ -11,6 +11,10 @@ import {
 } from "../../lib/nativeAudio";
 import { useStableCallback } from "../../lib/useStableCallback";
 import { usePreferences } from "../../lib/preferences";
+import {
+  activateWebAudioContext,
+  getWebAudioContextConstructor,
+} from "../../lib/webAudio";
 import { MetronomePage } from "./MetronomePage";
 import {
   clampSystemInputVolume,
@@ -49,8 +53,6 @@ const SYSTEM_INPUT_VOLUME_COMMIT_DELAY_MS = 180;
 type TunerStatus = "idle" | "starting" | "listening" | "unsupported" | "error";
 type ToolId = "tuner" | "metronome";
 type CaptureBackend = "native" | "web";
-
-type AudioContextConstructor = typeof AudioContext;
 
 export function ToolsView() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -335,7 +337,7 @@ function ChromaticTunerPage() {
     _nextDeviceId: string | null,
     requestId: number,
   ) {
-    const AudioContextCtor = getAudioContextConstructor();
+    const AudioContextCtor = getWebAudioContextConstructor();
     const mediaDevices = getMediaDevices();
     if (!AudioContextCtor || !mediaDevices) {
       throw new Error("Microphone capture is unavailable.");
@@ -360,9 +362,7 @@ function ChromaticTunerPage() {
     analyserRef.current = analyser;
     mediaSourceRef.current = mediaSource;
 
-    if (audioContext.state === "suspended") {
-      await audioContext.resume();
-    }
+    await activateWebAudioContext(audioContext);
 
     if (requestIdRef.current !== requestId) {
       releaseCapture();
@@ -756,18 +756,6 @@ function systemInputVolumeStatus(
     : "Controls the operating system default microphone.";
 }
 
-function getAudioContextConstructor(): AudioContextConstructor | null {
-  if (typeof window === "undefined") {
-    return null;
-  }
-  return (
-    window.AudioContext ??
-    (window as Window & typeof globalThis & { webkitAudioContext?: AudioContextConstructor })
-      .webkitAudioContext ??
-    null
-  );
-}
-
 function getMediaDevices() {
   if (
     typeof navigator === "undefined" ||
@@ -779,7 +767,7 @@ function getMediaDevices() {
 }
 
 function canUseTunerCapture(nativeAudioCapabilities: NativeAudioCapabilities | null) {
-  return Boolean(nativeAudioCapabilities?.micCaptureSupported || (getAudioContextConstructor() && getMediaDevices()));
+  return Boolean(nativeAudioCapabilities?.micCaptureSupported || (getWebAudioContextConstructor() && getMediaDevices()));
 }
 
 async function rememberVisibleAudioInputDevices(mediaDevices: MediaDevices) {

--- a/apps/desktop/src/features/tools/metronome.tsx
+++ b/apps/desktop/src/features/tools/metronome.tsx
@@ -4,6 +4,10 @@ import {
   setNativeAudioClick,
 } from "../../lib/nativeAudio";
 import { useStableCallback } from "../../lib/useStableCallback";
+import {
+  activateWebAudioContext,
+  getWebAudioContextConstructor,
+} from "../../lib/webAudio";
 import { usePlayback, type PlaybackSnapshot } from "../projects/playback-context";
 import { MetronomeContext, type MetronomeLaunchOptions } from "./metronome-context";
 import { DEFAULT_METRONOME_SOUND, scheduleMetronomeClick } from "./metronomeSound";
@@ -24,8 +28,6 @@ import {
 const SCHEDULE_AHEAD_SECONDS = 0.12;
 const SCHEDULER_INTERVAL_MS = 25;
 const START_DELAY_SECONDS = 0.035;
-
-type AudioContextConstructor = typeof AudioContext;
 
 export function MetronomeProvider({ children }: { children: ReactNode }) {
   const { getPlaybackSnapshot, isPlaying, session } = usePlayback();
@@ -114,7 +116,7 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
     if (audioContextRef.current && audioContextRef.current.state !== "closed") {
       return audioContextRef.current;
     }
-    const AudioContextCtor = getAudioContextConstructor();
+    const AudioContextCtor = getWebAudioContextConstructor();
     if (!AudioContextCtor) {
       setErrorMessage("Audio playback is unavailable.");
       return null;
@@ -130,9 +132,7 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
       return null;
     }
     try {
-      if (audioContext.state === "suspended") {
-        await audioContext.resume();
-      }
+      await activateWebAudioContext(audioContext);
     } catch {
       setErrorMessage("Could not start metronome audio.");
       return null;
@@ -348,9 +348,7 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
       } else {
         const audioContext = ensureAudioContext();
         if (audioContext) {
-          if (audioContext.state === "suspended") {
-            void audioContext.resume().catch(() => undefined);
-          }
+          void activateWebAudioContext(audioContext).catch(() => undefined);
           scheduleSynced(audioContext, snapshot);
         }
       }
@@ -469,18 +467,6 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
   );
 
   return <MetronomeContext.Provider value={value}>{children}</MetronomeContext.Provider>;
-}
-
-function getAudioContextConstructor(): AudioContextConstructor | null {
-  if (typeof window === "undefined") {
-    return null;
-  }
-  return (
-    window.AudioContext ??
-    (window as Window & typeof globalThis & { webkitAudioContext?: AudioContextConstructor })
-      .webkitAudioContext ??
-    null
-  );
 }
 
 function isTauriRuntime() {

--- a/apps/desktop/src/lib/webAudio.ts
+++ b/apps/desktop/src/lib/webAudio.ts
@@ -1,0 +1,48 @@
+export function getWebAudioContextConstructor() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return (
+    window.AudioContext ??
+    (window as Window & typeof globalThis & { webkitAudioContext?: typeof AudioContext })
+      .webkitAudioContext ??
+    null
+  );
+}
+
+export async function activateWebAudioContext(context: AudioContext) {
+  if (context.state === "suspended") {
+    await context.resume();
+  }
+
+  if (context.state !== "running") {
+    throw new Error(`Web Audio context is ${context.state}, not running.`);
+  }
+}
+
+export function primeWebAudioContext(context: AudioContext) {
+  const primedContext = context as AudioContext & { __tuneforgePriming?: boolean };
+  try {
+    primedContext.__tuneforgePriming = true;
+    const source = context.createBufferSource();
+    const gain = context.createGain();
+    source.buffer = context.createBuffer(1, 1, context.sampleRate);
+    gain.gain.value = 0;
+    source.connect(gain);
+    gain.connect(context.destination);
+    source.start(0);
+    window.setTimeout(() => {
+      try {
+        source.disconnect();
+        gain.disconnect();
+      } catch {
+        // Nodes can already be disconnected by the backend.
+      }
+    }, 0);
+  } catch {
+    // Priming is opportunistic. Activation still decides whether playback can continue.
+  } finally {
+    delete primedContext.__tuneforgePriming;
+  }
+}

--- a/apps/desktop/src/setupTests.ts
+++ b/apps/desktop/src/setupTests.ts
@@ -44,6 +44,7 @@ type MockAudioContextInstance = AudioContext & {
   createdMediaStreamSources: MockMediaStreamAudioSourceNode[];
   createdSources: MockAudioBufferSourceNode[];
   createAnalyser: ReturnType<typeof vi.fn>;
+  createBuffer: ReturnType<typeof vi.fn>;
   createBufferSource: ReturnType<typeof vi.fn>;
   createGain: ReturnType<typeof vi.fn>;
   createOscillator: ReturnType<typeof vi.fn>;
@@ -208,6 +209,8 @@ Object.defineProperty(window.HTMLMediaElement.prototype, "pause", {
 });
 
 const mockAudioContexts: MockAudioContextInstance[] = [];
+let mockAudioContextInitialState: AudioContextState = "running";
+let mockAudioSourceStartError: Error | null = null;
 const RAF_STEP_SECONDS = 1 / 60;
 let nextAnimationFrameId = 1;
 let mockAnimationTimeMs = 0;
@@ -248,7 +251,8 @@ Object.defineProperty(window, "cancelAnimationFrame", {
 
 class MockAudioContext {
   destination = {} as AudioDestinationNode;
-  state: AudioContextState = "running";
+  sampleRate = 48000;
+  state: AudioContextState = mockAudioContextInitialState;
   createdAnalysers: MockAnalyserNode[] = [];
   createdOscillators: MockOscillatorNode[] = [];
   createdMediaStreamSources: MockMediaStreamAudioSourceNode[] = [];
@@ -291,16 +295,37 @@ class MockAudioContext {
     return { duration } as AudioBuffer;
   });
 
+  createBuffer = vi.fn((numberOfChannels: number, length: number, sampleRate: number) => ({
+    duration: sampleRate > 0 ? length / sampleRate : 0,
+    length,
+    numberOfChannels,
+    sampleRate,
+  }) as AudioBuffer);
+
   createBufferSource = vi.fn(() => {
     const source = {
       buffer: null,
       onended: null,
       connect: vi.fn(),
       disconnect: vi.fn(),
-      start: vi.fn(),
+      start: vi.fn(() => {
+        if (
+          !(this as MockAudioContext & { __tuneforgePriming?: boolean }).__tuneforgePriming &&
+          mockAudioSourceStartError
+        ) {
+          const error = mockAudioSourceStartError;
+          mockAudioSourceStartError = null;
+          throw error;
+        }
+        this.createdAnalysers.forEach((analyser) => {
+          analyser.setSamples(new Float32Array([0.08, -0.08, 0.04, -0.04]));
+        });
+      }),
       stop: vi.fn(),
     } as unknown as MockAudioBufferSourceNode;
-    this.createdSources.push(source);
+    if (!(this as MockAudioContext & { __tuneforgePriming?: boolean }).__tuneforgePriming) {
+      this.createdSources.push(source);
+    }
     return source;
   });
 
@@ -324,7 +349,11 @@ class MockAudioContext {
         setValueAtTime: vi.fn(),
       },
       onended: null,
-      start: vi.fn(),
+      start: vi.fn(() => {
+        this.createdAnalysers.forEach((analyser) => {
+          analyser.setSamples(new Float32Array([0.08, -0.08, 0.04, -0.04]));
+        });
+      }),
       stop: vi.fn(),
       type: "sine",
     } as unknown as MockOscillatorNode;
@@ -359,7 +388,12 @@ class MockAudioContext {
 
   createMediaStreamSource = vi.fn(() => {
     const source = {
-      connect: vi.fn(),
+      connect: vi.fn((node: AudioNode) => {
+        const analyser = node as MockAnalyserNode;
+        if (typeof analyser.setSamples === "function") {
+          analyser.setSamples(new Float32Array([0.08, -0.08, 0.04, -0.04]));
+        }
+      }),
       disconnect: vi.fn(),
     } as unknown as MockMediaStreamAudioSourceNode;
     this.createdMediaStreamSources.push(source);
@@ -394,6 +428,20 @@ Object.defineProperty(window, "webkitAudioContext", {
 Object.defineProperty(globalThis, "__mockAudioContexts", {
   writable: true,
   value: mockAudioContexts,
+});
+
+Object.defineProperty(globalThis, "__setMockAudioContextInitialState", {
+  writable: true,
+  value: (state: AudioContextState) => {
+    mockAudioContextInitialState = state;
+  },
+});
+
+Object.defineProperty(globalThis, "__setMockAudioSourceStartError", {
+  writable: true,
+  value: (error: Error | null) => {
+    mockAudioSourceStartError = error;
+  },
 });
 
 Object.defineProperty(globalThis, "__mockMediaDevices", {

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -1363,9 +1363,26 @@ export function getMockAudioContexts() {
           start: ReturnType<typeof vi.fn>;
         }>;
         close: ReturnType<typeof vi.fn>;
+        resume: ReturnType<typeof vi.fn>;
       }>;
     }
   ).__mockAudioContexts;
+}
+
+export function setMockAudioContextInitialState(state: AudioContextState) {
+  (
+    globalThis as typeof globalThis & {
+      __setMockAudioContextInitialState: (state: AudioContextState) => void;
+    }
+  ).__setMockAudioContextInitialState(state);
+}
+
+export function setMockAudioSourceStartError(error: Error | null) {
+  (
+    globalThis as typeof globalThis & {
+      __setMockAudioSourceStartError: (error: Error | null) => void;
+    }
+  ).__setMockAudioSourceStartError(error);
 }
 
 export function getMockFetch() {
@@ -1451,6 +1468,8 @@ export function resetAppTestHarness() {
   vi.mocked(window.HTMLMediaElement.prototype.pause).mockClear();
   getMockFetch().mockClear();
   getMockAudioContexts().length = 0;
+  setMockAudioContextInitialState("running");
+  setMockAudioSourceStartError(null);
   getMockMediaDevices().reset();
   installMatchMediaMock(false);
 }


### PR DESCRIPTION
## Summary

- Prime Web Audio from playback gestures before fetch/decode or fallback transitions.
- Enforce running Web Audio contexts for playback, precount, metronome, and tuner paths.
- Keep failed Web Audio buffer starts from marking playback active.
- Improve artifact stream MIME mapping for common audio/container formats, including WebM and Matroska.

## Testing

- `pnpm --filter @tuneforge/desktop test -- --run apps/desktop/src/App.project-playback-stems.test.tsx apps/desktop/src/App.project-precount.test.tsx apps/desktop/src/App.tools-metronome.test.tsx apps/desktop/src/App.tools-tuner.test.tsx apps/desktop/src/App.settings-theme.test.tsx`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `cd apps/backend && uv run --python 3.11 python -c "from app.api.routes.artifacts import AUDIO_MEDIA_TYPES; assert AUDIO_MEDIA_TYPES['webm'] == 'audio/webm'; assert AUDIO_MEDIA_TYPES['mkv'] == 'video/x-matroska'; assert AUDIO_MEDIA_TYPES['mka'] == 'audio/x-matroska'; print('artifact MIME map ok')"`
- Manual: Linux native and `VITE_TUNEFORGE_FORCE_WEB_AUDIO=1` playback meters move in pavucontrol.
- Manual: macOS native and forced Web Audio playback paths work.
