### PR TITLE
feat: expose build refs in diagnostics

### DIFF
--- a/apps/backend/app/__init__.py
+++ b/apps/backend/app/__init__.py
@@ -1,4 +1,5 @@
+from app.version import package_version
+
 __all__ = ["__version__"]
 
-__version__ = "0.1.0"
-
+__version__ = package_version()

--- a/apps/backend/app/api/routes/health.py
+++ b/apps/backend/app/api/routes/health.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
-from app import __version__
 from app.config import get_settings
-from app.schemas import HealthResponse
+from app.schemas import HealthResponse, VersionInfo
+from app.version import get_build_versions
 
 router = APIRouter(tags=["health"])
 
@@ -12,13 +12,21 @@ router = APIRouter(tags=["health"])
 @router.get("/health", response_model=HealthResponse)
 def health() -> HealthResponse:
     settings = get_settings()
+    versions = get_build_versions()
     return HealthResponse(
         name=settings.app_name,
-        version=__version__,
+        version=versions.backend.git_ref,
+        backend_version=VersionInfo(
+            package_version=versions.backend.package_version,
+            git_ref=versions.backend.git_ref,
+        ),
+        frontend_version=VersionInfo(
+            package_version=versions.frontend.package_version,
+            git_ref=versions.frontend.git_ref,
+        ),
         status="ok",
         api_base_url=f"{settings.base_url}{settings.api_prefix}",
         data_root=str(settings.data_root),
         default_export_format=settings.default_export_format,
         preview_format=settings.preview_format,
     )
-

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -25,9 +25,16 @@ class ErrorResponse(BaseModel):
     error: ErrorInfo
 
 
+class VersionInfo(BaseModel):
+    package_version: str
+    git_ref: str
+
+
 class HealthResponse(BaseModel):
     name: str
     version: str
+    backend_version: VersionInfo
+    frontend_version: VersionInfo
     status: str
     api_base_url: str
     data_root: str

--- a/apps/backend/app/version.py
+++ b/apps/backend/app/version.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import logging
+import os
+import subprocess
+import tomllib
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+UNKNOWN_VERSION = "unknown"
+
+logger = logging.getLogger("tuneforge.version")
+
+
+@dataclass(frozen=True)
+class VersionInfo:
+    package_version: str
+    git_ref: str
+
+
+@dataclass(frozen=True)
+class BuildVersions:
+    backend: VersionInfo
+    frontend: VersionInfo
+
+
+def package_version() -> str:
+    return _backend_package_version()
+
+
+@lru_cache(maxsize=1)
+def get_build_versions() -> BuildVersions:
+    version_file = _version_file_path()
+    if version_file is not None:
+        versions = _read_build_versions(version_file)
+        if versions is not None:
+            return versions
+
+    workspace_root = _workspace_root()
+    git_ref = _git_ref(workspace_root)
+    return BuildVersions(
+        backend=VersionInfo(
+            package_version=_env_value("TUNEFORGE_BACKEND_PACKAGE_VERSION") or _backend_package_version(),
+            git_ref=git_ref,
+        ),
+        frontend=VersionInfo(
+            package_version=_env_value("TUNEFORGE_FRONTEND_PACKAGE_VERSION")
+            or _frontend_package_version(workspace_root),
+            git_ref=git_ref,
+        ),
+    )
+
+
+def _env_value(name: str) -> str | None:
+    value = os.environ.get(name, "").strip()
+    return value or None
+
+
+def _version_file_path() -> Path | None:
+    configured = _env_value("TUNEFORGE_VERSION_FILE")
+    if configured is None:
+        return None
+    return Path(configured).expanduser().resolve()
+
+
+def _backend_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _workspace_root() -> Path | None:
+    backend_root = _backend_root()
+    if backend_root.name == "backend" and backend_root.parent.name == "apps":
+        return backend_root.parent.parent
+    return None
+
+
+def _backend_package_version() -> str:
+    try:
+        return importlib.metadata.version("tuneforge-backend")
+    except importlib.metadata.PackageNotFoundError:
+        return _read_package_version(_backend_root() / "pyproject.toml") or UNKNOWN_VERSION
+
+
+def _frontend_package_version(workspace_root: Path | None) -> str:
+    if workspace_root is None:
+        return UNKNOWN_VERSION
+    return _read_package_version(workspace_root / "apps" / "desktop" / "package.json") or UNKNOWN_VERSION
+
+
+def _read_package_version(package_path: Path) -> str | None:
+    if not package_path.exists():
+        return None
+    try:
+        if package_path.suffix == ".json":
+            parsed = json.loads(package_path.read_text(encoding="utf-8"))
+            version = parsed.get("version")
+            return version if isinstance(version, str) and version.strip() else None
+
+        parsed_toml = tomllib.loads(package_path.read_text(encoding="utf-8"))
+        version = parsed_toml.get("project", {}).get("version")
+        return version if isinstance(version, str) and version.strip() else None
+    except (OSError, json.JSONDecodeError, tomllib.TOMLDecodeError) as error:
+        logger.warning("Could not read package version from %s: %s", package_path, error)
+        return None
+
+
+def _git_ref(workspace_root: Path | None) -> str:
+    env_git_ref = _env_value("TUNEFORGE_GIT_REF")
+    if env_git_ref is not None:
+        return env_git_ref
+    if workspace_root is None:
+        return UNKNOWN_VERSION
+    try:
+        return subprocess.run(
+            ["git", "describe", "--tags", "--long", "--dirty", "--always"],
+            cwd=workspace_root,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
+        logger.warning("Could not resolve git ref: %s", error)
+        return UNKNOWN_VERSION
+
+
+def _read_build_versions(version_file: Path) -> BuildVersions | None:
+    try:
+        parsed = json.loads(version_file.read_text(encoding="utf-8"))
+        backend = _parse_version_info(parsed.get("backend"))
+        frontend = _parse_version_info(parsed.get("frontend"))
+    except (OSError, json.JSONDecodeError) as error:
+        logger.warning("Could not read build version file %s: %s", version_file, error)
+        return None
+
+    if backend is None or frontend is None:
+        logger.warning("Build version file %s did not contain backend and frontend versions.", version_file)
+        return None
+    return BuildVersions(backend=backend, frontend=frontend)
+
+
+def _parse_version_info(value: Any) -> VersionInfo | None:
+    if not isinstance(value, dict):
+        return None
+    package_version_value = value.get("package_version")
+    git_ref_value = value.get("git_ref")
+    if not isinstance(package_version_value, str) or not isinstance(git_ref_value, str):
+        return None
+    package_version_value = package_version_value.strip()
+    git_ref_value = git_ref_value.strip()
+    if not package_version_value or not git_ref_value:
+        return None
+    return VersionInfo(package_version=package_version_value, git_ref=git_ref_value)

--- a/apps/backend/tests/test_health.py
+++ b/apps/backend/tests/test_health.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+
+def test_health_reports_versions_from_version_file(tmp_path: Path, monkeypatch) -> None:
+    version_file = tmp_path / "version.json"
+    version_file.write_text(
+        json.dumps(
+            {
+                "backend": {"package_version": "9.8.7", "git_ref": "backend-ref"},
+                "frontend": {"package_version": "6.5.4", "git_ref": "frontend-ref"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TUNEFORGE_VERSION_FILE", str(version_file))
+
+    from app.main import app
+    from app.version import get_build_versions
+
+    get_build_versions.cache_clear()
+    with TestClient(app) as client:
+        payload = client.get("/api/v1/health").json()
+    get_build_versions.cache_clear()
+
+    assert payload["version"] == "backend-ref"
+    assert payload["backend_version"] == {"package_version": "9.8.7", "git_ref": "backend-ref"}
+    assert payload["frontend_version"] == {"package_version": "6.5.4", "git_ref": "frontend-ref"}
+
+
+def test_health_reports_env_git_ref_without_version_file(monkeypatch) -> None:
+    monkeypatch.delenv("TUNEFORGE_VERSION_FILE", raising=False)
+    monkeypatch.setenv("TUNEFORGE_GIT_REF", "dev-ref")
+    monkeypatch.setenv("TUNEFORGE_BACKEND_PACKAGE_VERSION", "1.2.3")
+    monkeypatch.setenv("TUNEFORGE_FRONTEND_PACKAGE_VERSION", "4.5.6")
+
+    from app.main import app
+    from app.version import get_build_versions
+
+    get_build_versions.cache_clear()
+    with TestClient(app) as client:
+        payload = client.get("/api/v1/health").json()
+    get_build_versions.cache_clear()
+
+    assert payload["version"] == "dev-ref"
+    assert payload["backend_version"] == {"package_version": "1.2.3", "git_ref": "dev-ref"}
+    assert payload["frontend_version"] == {"package_version": "4.5.6", "git_ref": "dev-ref"}

--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -1,3 +1,23 @@
 fn main() {
+    println!("cargo:rerun-if-env-changed=TUNEFORGE_GIT_REF");
+    if let Some(git_ref) = git_ref() {
+        println!("cargo:rustc-env=TUNEFORGE_GIT_REF={git_ref}");
+    }
     tauri_build::build()
+}
+
+fn git_ref() -> Option<String> {
+    std::env::var("TUNEFORGE_GIT_REF")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            std::process::Command::new("git")
+                .args(["describe", "--tags", "--long", "--dirty", "--always"])
+                .output()
+                .ok()
+                .filter(|output| output.status.success())
+                .and_then(|output| String::from_utf8(output.stdout).ok())
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -243,6 +243,10 @@ fn spawn_packaged_backend(app: &AppHandle) -> Result<BackendRuntime, Box<dyn std
         .env("PYTORCH_ENABLE_MPS_FALLBACK", "1")
         .env("TUNEFORGE_HOST", "127.0.0.1")
         .env("TUNEFORGE_PORT", port.to_string())
+        .env(
+            "TUNEFORGE_VERSION_FILE",
+            bundled_backend_root.join("version.json"),
+        )
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());

--- a/apps/desktop/src-tauri/src/mobile_backend.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend.rs
@@ -31,9 +31,18 @@ pub struct MobileCapabilities {
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "snake_case")]
+pub struct VersionInfo {
+    package_version: String,
+    git_ref: String,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub struct HealthResponse {
     name: String,
     version: String,
+    backend_version: VersionInfo,
+    frontend_version: VersionInfo,
     status: String,
     api_base_url: String,
     data_root: String,
@@ -1631,9 +1640,19 @@ mod android {
     #[tauri::command]
     pub fn mobile_get_health(app: AppHandle) -> Result<HealthResponse, String> {
         let root = app_data_root(&app)?;
+        let package_version = env!("CARGO_PKG_VERSION").to_string();
+        let git_ref = option_env!("TUNEFORGE_GIT_REF")
+            .unwrap_or("unknown")
+            .to_string();
+        let version_info = VersionInfo {
+            package_version,
+            git_ref: git_ref.clone(),
+        };
         Ok(HealthResponse {
             name: "Tuneforge Mobile".to_string(),
-            version: env!("CARGO_PKG_VERSION").to_string(),
+            version: git_ref,
+            backend_version: version_info.clone(),
+            frontend_version: version_info,
             status: "ok".to_string(),
             api_base_url: "mobile://embedded".to_string(),
             data_root: root.to_string_lossy().into_owned(),

--- a/apps/desktop/src/App.settings-theme.test.tsx
+++ b/apps/desktop/src/App.settings-theme.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FRONTEND_VERSION_INFO } from "./lib/buildInfo";
 import {
   resetAppTestHarness,
   getAllByAriaKeyLabel,
@@ -146,6 +147,12 @@ describe("Desktop app settings theme", () => {
     await user.click(screen.getByRole("button", { name: /^Advanced Chords/ }));
     await user.click(screen.getByText("Show diagnostics"));
     expect(await screen.findByText("/tmp/tuneforge")).toBeInTheDocument();
+    expect(screen.getByText("Backend Package Version")).toBeInTheDocument();
+    expect(screen.getByText("Backend Git Ref")).toBeInTheDocument();
+    expect(screen.getByText("backend-test-ref")).toBeInTheDocument();
+    expect(screen.getByText("Frontend Package Version")).toBeInTheDocument();
+    expect(screen.getByText("Frontend Git Ref")).toBeInTheDocument();
+    expect(screen.getByText(FRONTEND_VERSION_INFO.git_ref)).toBeInTheDocument();
     expect(screen.getAllByText("Native (desktop-cpal)")).toHaveLength(2);
     expect(screen.getByText("Native microphone failed.")).toBeInTheDocument();
     expect(screen.getByText("Native output failed.")).toBeInTheDocument();

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { Link } from "react-router-dom";
 import { api, type ChordBackendSchema } from "../../lib/api";
+import { FRONTEND_VERSION_INFO } from "../../lib/buildInfo";
 import {
   readRememberedNativePlaybackError,
   readRememberedPlaybackBackend,
@@ -253,6 +254,11 @@ function lastPlaybackBackendLabel(backend: PlaybackBackend | null) {
   return backend.backend === "native"
     ? `Native (${backend.detail ?? "unknown"})`
     : "Web Audio";
+}
+
+function diagnosticVersionValue(value: string | undefined) {
+  const normalized = value?.trim();
+  return normalized ? normalized : "Unknown";
 }
 
 function chordBackendOptions(backends: ChordBackendSchema[] | undefined): ChoiceOption<DefaultChordBackend>[] {
@@ -762,6 +768,24 @@ export function SettingsView() {
             <div>
               <dt>Status</dt>
               <dd>{healthQuery.data?.status ?? "Unknown"}</dd>
+            </div>
+            <div>
+              <dt>Backend Package Version</dt>
+              <dd>{diagnosticVersionValue(healthQuery.data?.backend_version?.package_version)}</dd>
+            </div>
+            <div>
+              <dt>Backend Git Ref</dt>
+              <dd className="path">
+                {diagnosticVersionValue(healthQuery.data?.backend_version?.git_ref ?? healthQuery.data?.version)}
+              </dd>
+            </div>
+            <div>
+              <dt>Frontend Package Version</dt>
+              <dd>{diagnosticVersionValue(FRONTEND_VERSION_INFO.package_version)}</dd>
+            </div>
+            <div>
+              <dt>Frontend Git Ref</dt>
+              <dd className="path">{diagnosticVersionValue(FRONTEND_VERSION_INFO.git_ref)}</dd>
             </div>
             <div>
               <dt>API Base URL</dt>

--- a/apps/desktop/src/lib/buildInfo.ts
+++ b/apps/desktop/src/lib/buildInfo.ts
@@ -1,0 +1,17 @@
+declare const __TUNEFORGE_FRONTEND_GIT_REF__: string | undefined;
+declare const __TUNEFORGE_FRONTEND_PACKAGE_VERSION__: string | undefined;
+
+export type VersionInfo = {
+  package_version: string;
+  git_ref: string;
+};
+
+export const FRONTEND_VERSION_INFO: VersionInfo = {
+  package_version: normalizeVersionValue(__TUNEFORGE_FRONTEND_PACKAGE_VERSION__),
+  git_ref: normalizeVersionValue(__TUNEFORGE_FRONTEND_GIT_REF__),
+};
+
+function normalizeVersionValue(value: string | undefined) {
+  const normalized = value?.trim();
+  return normalized ? normalized : "unknown";
+}

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -553,6 +553,16 @@ const {
     throw new Error(`Unexpected invoke command: ${command}`);
   });
   const mockGetHealth = vi.fn(async () => ({
+    name: "Tuneforge",
+    version: "backend-test-ref",
+    backend_version: {
+      package_version: "0.1.0",
+      git_ref: "backend-test-ref",
+    },
+    frontend_version: {
+      package_version: "0.1.0",
+      git_ref: "frontend-test-ref",
+    },
     status: "ok",
     api_base_url: "http://127.0.0.1:8765/api/v1",
     data_root: "/tmp/tuneforge",

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -2,8 +2,14 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { existsSync, realpathSync } from "node:fs";
 import { resolve } from "node:path";
+import { resolveBuildInfo } from "../../scripts/build-info.mjs";
 
 const workspaceRoot = resolve(import.meta.dirname, "../..");
+const tauriRoot = resolve(workspaceRoot, "apps/desktop/src-tauri");
+const packagedVersionInfoPath = resolve(tauriRoot, "resources/backend/version.json");
+const versionFilePath =
+  process.env.TUNEFORGE_VERSION_FILE ?? (existsSync(packagedVersionInfoPath) ? packagedVersionInfoPath : undefined);
+const buildInfo = resolveBuildInfo({ workspaceRoot, versionFilePath });
 const fsAllow = Array.from(
   new Set(
     [
@@ -40,6 +46,10 @@ const reactRefreshPreamble = {
 
 export default defineConfig({
   plugins: [reactRefreshPreamble, react()],
+  define: {
+    __TUNEFORGE_FRONTEND_GIT_REF__: JSON.stringify(buildInfo.frontend.git_ref),
+    __TUNEFORGE_FRONTEND_PACKAGE_VERSION__: JSON.stringify(buildInfo.frontend.package_version),
+  },
   server: {
     host: "127.0.0.1",
     port: 1420,

--- a/docs/API.md
+++ b/docs/API.md
@@ -71,7 +71,9 @@ Important fields:
 
 `GET /api/v1/health`
 
-Returns backend name, version, status, API base URL, data root, default export format, and preview format.
+Returns backend name, legacy backend git ref in `version`, backend/frontend package versions and git refs, status,
+API base URL, data root, default export format, and preview format. Build git refs use the packaged build
+metadata when available, otherwise local development resolves them with `git describe --tags --long --dirty --always`.
 
 ## Chord Backends
 

--- a/docs/NATIVE_AUDIO.md
+++ b/docs/NATIVE_AUDIO.md
@@ -61,6 +61,8 @@ project playback so Web Audio remains the comparison path for both.
 
 Settings -> Local Data -> Show diagnostics reports:
 
+- backend package version and git ref
+- frontend package version and git ref
 - input capture availability
 - last tuner capture backend
 - last native capture error

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -648,6 +648,8 @@ export interface components {
             name: string;
             /** Version */
             version: string;
+            backend_version: components["schemas"]["VersionInfo"];
+            frontend_version: components["schemas"]["VersionInfo"];
             /** Status */
             status: string;
             /** Api Base Url */
@@ -1071,6 +1073,13 @@ export interface components {
             input?: unknown;
             /** Context */
             ctx?: Record<string, never>;
+        };
+        /** VersionInfo */
+        VersionInfo: {
+            /** Package Version */
+            package_version: string;
+            /** Git Ref */
+            git_ref: string;
         };
     };
     responses: never;

--- a/packaging/flatpak/com.tuneforge.desktop.yml
+++ b/packaging/flatpak/com.tuneforge.desktop.yml
@@ -156,6 +156,7 @@ modules:
         LD_LIBRARY_PATH: /app/lib/tuneforge/backend/python/lib
         PYTHONPATH: /app/lib/tuneforge/backend/site-packages
         TUNEFORGE_BUNDLED_BACKEND_ROOT: /app/lib/tuneforge/backend
+        TUNEFORGE_VERSION_FILE: /run/build/tuneforge/version.json
     sources:
       - type: file
         path: ../../package.json
@@ -238,6 +239,8 @@ modules:
         path: com.tuneforge.desktop.desktop
       - type: file
         path: com.tuneforge.desktop.metainfo.xml
+      - type: file
+        path: generated/version.json
     build-commands:
       - install -Dm755 ffmpeg /app/bin/ffmpeg
       - install -Dm755 ffprobe /app/bin/ffprobe
@@ -251,6 +254,7 @@ modules:
       - rm -rf /app/share/tuneforge/node-sources /app/lib/pnpm /app/bin/pnpm /app/bin/pnpx
       - cargo build --release --locked --features custom-protocol --manifest-path apps/desktop/src-tauri/Cargo.toml
       - install -Dm755 apps/desktop/src-tauri/target/release/tuneforge /app/bin/tuneforge
+      - install -Dm644 version.json /app/lib/tuneforge/backend/version.json
       - install -dm755 /app/lib/tuneforge/backend/src
       - cp -a apps/backend/app /app/lib/tuneforge/backend/src/app
       - cp -a apps/backend/alembic /app/lib/tuneforge/backend/src/alembic

--- a/scripts/build-info.mjs
+++ b/scripts/build-info.mjs
@@ -1,0 +1,113 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const scriptDir = path.dirname(__filename);
+const defaultWorkspaceRoot = path.resolve(scriptDir, "..");
+const unknownVersion = "unknown";
+
+export function resolveBuildInfo({
+  workspaceRoot = defaultWorkspaceRoot,
+  versionFilePath = process.env.TUNEFORGE_VERSION_FILE,
+} = {}) {
+  const fileInfo = readBuildInfoFile(versionFilePath);
+  if (fileInfo) {
+    return fileInfo;
+  }
+
+  const gitRef = resolveGitRef(workspaceRoot);
+  return {
+    backend: {
+      package_version:
+        normalizedEnvValue("TUNEFORGE_BACKEND_PACKAGE_VERSION") ??
+        readPackageVersion(path.join(workspaceRoot, "apps", "backend", "pyproject.toml")) ??
+        unknownVersion,
+      git_ref: gitRef,
+    },
+    frontend: {
+      package_version:
+        normalizedEnvValue("TUNEFORGE_FRONTEND_PACKAGE_VERSION") ??
+        readPackageVersion(path.join(workspaceRoot, "apps", "desktop", "package.json")) ??
+        unknownVersion,
+      git_ref: gitRef,
+    },
+  };
+}
+
+export function writeBuildInfoFile(outputPath, options = {}) {
+  const buildInfo = resolveBuildInfo({ ...options, versionFilePath: null });
+  writeFileSync(outputPath, `${JSON.stringify(buildInfo, null, 2)}\n`);
+  return buildInfo;
+}
+
+function normalizedEnvValue(name) {
+  const value = process.env[name]?.trim();
+  return value ? value : null;
+}
+
+function resolveGitRef(workspaceRoot) {
+  const envGitRef = normalizedEnvValue("TUNEFORGE_GIT_REF");
+  if (envGitRef) {
+    return envGitRef;
+  }
+
+  try {
+    return execFileSync("git", ["describe", "--tags", "--long", "--dirty", "--always"], {
+      cwd: workspaceRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return unknownVersion;
+  }
+}
+
+function readBuildInfoFile(versionFilePath) {
+  if (!versionFilePath || !existsSync(versionFilePath)) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(versionFilePath, "utf8"));
+    const backend = normalizeVersionInfo(parsed.backend);
+    const frontend = normalizeVersionInfo(parsed.frontend);
+    if (!backend || !frontend) {
+      return null;
+    }
+    return { backend, frontend };
+  } catch {
+    return null;
+  }
+}
+
+function normalizeVersionInfo(value) {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const packageVersion = typeof value.package_version === "string" ? value.package_version.trim() : "";
+  const gitRef = typeof value.git_ref === "string" ? value.git_ref.trim() : "";
+  if (!packageVersion || !gitRef) {
+    return null;
+  }
+  return {
+    package_version: packageVersion,
+    git_ref: gitRef,
+  };
+}
+
+function readPackageVersion(packagePath) {
+  if (!existsSync(packagePath)) {
+    return null;
+  }
+
+  const contents = readFileSync(packagePath, "utf8");
+  if (packagePath.endsWith(".json")) {
+    const parsed = JSON.parse(contents);
+    return typeof parsed.version === "string" ? parsed.version : null;
+  }
+
+  const match = contents.match(/^version = "([^"]+)"$/m);
+  return match?.[1] ?? null;
+}

--- a/scripts/package-flatpak.mjs
+++ b/scripts/package-flatpak.mjs
@@ -2,12 +2,14 @@ import { existsSync, lstatSync, readdirSync, readFileSync, writeFileSync } from 
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { writeBuildInfoFile } from "./build-info.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const scriptDir = path.dirname(__filename);
 const workspaceRoot = path.resolve(scriptDir, "..");
 const flatpakRoot = path.join(workspaceRoot, "packaging", "flatpak");
 const baseManifestPath = path.join(flatpakRoot, "com.tuneforge.desktop.yml");
+const flatpakVersionInfoPath = path.join(flatpakRoot, "generated", "version.json");
 const appId = "com.tuneforge.desktop";
 const skipBundle = process.argv.includes("--no-bundle") || process.env.FLATPAK_NO_BUNDLE === "1";
 const profile = readProfileArg();
@@ -148,6 +150,7 @@ function main() {
   }
 
   run(process.execPath, [path.join("scripts", "generate-flatpak-sources.mjs"), "--profile", profile]);
+  writeBuildInfoFile(flatpakVersionInfoPath, { workspaceRoot });
   const manifestPath = manifestPathForProfile();
 
   checkCommand(

--- a/scripts/prepare-bundle.mjs
+++ b/scripts/prepare-bundle.mjs
@@ -8,6 +8,7 @@ import {
 } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { writeBuildInfoFile } from "./build-info.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const scriptDir = path.dirname(__filename);
@@ -88,6 +89,7 @@ function main() {
   copyInto(path.join(backendRoot, "pyproject.toml"), path.join(stagedBackendSourceRoot, "pyproject.toml"));
   copyInto(pythonInstallRoot, stagedPythonRoot, { dereference: true });
   copyInto(sitePackagesRoot, stagedSitePackagesRoot, { filter: shouldIncludeBundledSitePackage });
+  writeBuildInfoFile(path.join(stagedBackendRoot, "version.json"), { workspaceRoot });
 
   writeFileSync(
     path.join(stagedBackendRoot, "manifest.json"),
@@ -97,6 +99,7 @@ function main() {
         python_root: path.relative(resourcesRoot, stagedPythonRoot),
         site_packages: path.relative(resourcesRoot, stagedSitePackagesRoot),
         backend_source: path.relative(resourcesRoot, stagedBackendSourceRoot),
+        version_info: path.relative(resourcesRoot, path.join(stagedBackendRoot, "version.json")),
       },
       null,
       2,


### PR DESCRIPTION
## Summary

- Report backend and frontend package versions plus git refs in health and diagnostics.
- Generate package version metadata for macOS and Flatpak builds so runtime packages do not need Git.
- Regenerate shared health contracts and document the diagnostics fields.

## Testing

- `pnpm contracts:generate`
- `cd apps/backend && uv run --python 3.11 pytest tests/test_health.py tests/test_db_migrations.py`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `pnpm --filter @tuneforge/desktop test -- App.settings-theme.test.tsx`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
- `cd apps/desktop/src-tauri && cargo fmt --check`
- `cd apps/desktop/src-tauri && cargo check`
- `git diff --check`
