### PR TITLE
fix: stabilize diagnostics version provenance

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "identifier": "com.tuneforge.desktop",
   "build": {
     "beforeDevCommand": "pnpm --filter @tuneforge/desktop dev",
-    "beforeBuildCommand": "pnpm -w bundle:prepare && pnpm --filter @tuneforge/desktop build",
+    "beforeBuildCommand": "pnpm -w bundle:prepare && pnpm -w build:packaged-frontend",
     "devUrl": "http://127.0.0.1:1420",
     "frontendDist": "../dist"
   },

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -5,11 +5,6 @@ import { resolve } from "node:path";
 import { resolveBuildInfo } from "../../scripts/build-info.mjs";
 
 const workspaceRoot = resolve(import.meta.dirname, "../..");
-const tauriRoot = resolve(workspaceRoot, "apps/desktop/src-tauri");
-const packagedVersionInfoPath = resolve(tauriRoot, "resources/backend/version.json");
-const versionFilePath =
-  process.env.TUNEFORGE_VERSION_FILE ?? (existsSync(packagedVersionInfoPath) ? packagedVersionInfoPath : undefined);
-const buildInfo = resolveBuildInfo({ workspaceRoot, versionFilePath });
 const fsAllow = Array.from(
   new Set(
     [
@@ -44,28 +39,33 @@ const reactRefreshPreamble = {
   },
 };
 
-export default defineConfig({
-  plugins: [reactRefreshPreamble, react()],
-  define: {
-    __TUNEFORGE_FRONTEND_GIT_REF__: JSON.stringify(buildInfo.frontend.git_ref),
-    __TUNEFORGE_FRONTEND_PACKAGE_VERSION__: JSON.stringify(buildInfo.frontend.package_version),
-  },
-  server: {
-    host: "127.0.0.1",
-    port: 1420,
-    strictPort: true,
-    fs: {
-      allow: fsAllow,
+export default defineConfig(() => {
+  const versionFilePath = process.env.TUNEFORGE_VERSION_FILE;
+  const buildInfo = resolveBuildInfo({ workspaceRoot, versionFilePath });
+
+  return {
+    plugins: [reactRefreshPreamble, react()],
+    define: {
+      __TUNEFORGE_FRONTEND_GIT_REF__: JSON.stringify(buildInfo.frontend.git_ref),
+      __TUNEFORGE_FRONTEND_PACKAGE_VERSION__: JSON.stringify(buildInfo.frontend.package_version),
     },
-  },
-  test: {
-    environment: "jsdom",
-    env: {
-      NODE_ENV: "test",
+    server: {
+      host: "127.0.0.1",
+      port: 1420,
+      strictPort: true,
+      fs: {
+        allow: fsAllow,
+      },
     },
-    globals: true,
-    setupFiles: "./src/setupTests.ts",
-  },
+    test: {
+      environment: "jsdom",
+      env: {
+        NODE_ENV: "test",
+      },
+      globals: true,
+      setupFiles: "./src/setupTests.ts",
+    },
+  };
 });
 
 function realpathIfPresent(path: string) {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {
+    "build:packaged-frontend": "node scripts/build-packaged-frontend.mjs",
     "bundle:prepare": "node scripts/prepare-bundle.mjs",
     "contracts:generate": "pnpm --filter @tuneforge/shared-types generate",
     "dev": "concurrently -n backend,desktop -c blue,green \"pnpm dev:backend\" \"pnpm dev:desktop\"",

--- a/scripts/build-info.mjs
+++ b/scripts/build-info.mjs
@@ -38,6 +38,11 @@ export function resolveBuildInfo({
 
 export function writeBuildInfoFile(outputPath, options = {}) {
   const buildInfo = resolveBuildInfo({ ...options, versionFilePath: null });
+  writeResolvedBuildInfoFile(outputPath, buildInfo);
+  return buildInfo;
+}
+
+export function writeResolvedBuildInfoFile(outputPath, buildInfo) {
   writeFileSync(outputPath, `${JSON.stringify(buildInfo, null, 2)}\n`);
   return buildInfo;
 }

--- a/scripts/build-packaged-frontend.mjs
+++ b/scripts/build-packaged-frontend.mjs
@@ -1,0 +1,37 @@
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const scriptDir = path.dirname(__filename);
+const workspaceRoot = path.resolve(scriptDir, "..");
+const versionFilePath = path.join(
+  workspaceRoot,
+  "apps",
+  "desktop",
+  "src-tauri",
+  "resources",
+  "backend",
+  "version.json",
+);
+
+if (!existsSync(versionFilePath)) {
+  throw new Error(`Packaged version file not found at ${versionFilePath}. Run pnpm -w bundle:prepare first.`);
+}
+
+const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+const result = spawnSync(pnpm, ["--filter", "@tuneforge/desktop", "build"], {
+  cwd: workspaceRoot,
+  stdio: "inherit",
+  env: {
+    ...process.env,
+    TUNEFORGE_VERSION_FILE: versionFilePath,
+  },
+});
+
+if (result.error) {
+  throw result.error;
+}
+
+process.exit(result.status ?? 1);

--- a/scripts/prepare-bundle.mjs
+++ b/scripts/prepare-bundle.mjs
@@ -8,7 +8,7 @@ import {
 } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { writeBuildInfoFile } from "./build-info.mjs";
+import { resolveBuildInfo, writeResolvedBuildInfoFile } from "./build-info.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const scriptDir = path.dirname(__filename);
@@ -74,6 +74,7 @@ function main() {
   requirePath(venvConfigPath, "Backend virtualenv config");
   requirePath(sitePackagesRoot, "Backend site-packages");
   sitePackagesRootForFilter = sitePackagesRoot;
+  const buildInfo = resolveBuildInfo({ workspaceRoot, versionFilePath: null });
 
   const pythonHomeBin = parsePythonHome(venvConfigPath);
   const pythonInstallRoot = path.resolve(pythonHomeBin, "..");
@@ -89,7 +90,7 @@ function main() {
   copyInto(path.join(backendRoot, "pyproject.toml"), path.join(stagedBackendSourceRoot, "pyproject.toml"));
   copyInto(pythonInstallRoot, stagedPythonRoot, { dereference: true });
   copyInto(sitePackagesRoot, stagedSitePackagesRoot, { filter: shouldIncludeBundledSitePackage });
-  writeBuildInfoFile(path.join(stagedBackendRoot, "version.json"), { workspaceRoot });
+  writeResolvedBuildInfoFile(path.join(stagedBackendRoot, "version.json"), buildInfo);
 
   writeFileSync(
     path.join(stagedBackendRoot, "manifest.json"),


### PR DESCRIPTION
## Summary

- Capture packaged build metadata before staged Tauri resources dirty the tree.
- Route packaged frontend builds through an explicit version-file wrapper.
- Keep normal Vite dev/build provenance based on current git state unless an env override is set.

## Testing

- `node --check scripts/build-info.mjs`
- `node --check scripts/prepare-bundle.mjs`
- `node --check scripts/build-packaged-frontend.mjs`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop build`
- `node scripts/prepare-bundle.mjs`
- `pnpm -w build:packaged-frontend`
- `git diff --check`
- Manual: `pnpm dev` and `pnpm package:mac` user-confirmed.
