### PR TITLE
fix: stabilize native playback tempo handling

### DIFF
--- a/apps/desktop/src-tauri/src/native_audio/transport.rs
+++ b/apps/desktop/src-tauri/src/native_audio/transport.rs
@@ -31,7 +31,10 @@ use symphonia::core::{
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use tauri::Emitter;
 
-use super::{mixer::AudioLaneRequest, mixer::EffectiveAudioLane, AudioCapabilities};
+use super::{
+    mixer::{AudioLaneRequest, AudioLaneRole, EffectiveAudioLane},
+    AudioCapabilities,
+};
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use super::{
@@ -54,6 +57,15 @@ const CLICK_ACCENT_FREQUENCY_HZ: f64 = 1760.0;
 const STREAM_CHUNK_FRAMES: usize = 2048;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 const RING_BUFFER_SECONDS: usize = 8;
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+const PREBUFFER_TARGET_SECONDS: f64 = 0.12;
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+const PREBUFFER_TIMEOUT: Duration = Duration::from_millis(1500);
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+const PREBUFFER_POLL_INTERVAL: Duration = Duration::from_millis(5);
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+const SUSTAINED_UNDERRUN_ERROR_SECONDS: f64 = 0.5;
+const AUDIBLE_GAIN_FLOOR: f32 = 0.0001;
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -132,6 +144,20 @@ pub struct AudioSnapshot {
     pub native_playback_supported: bool,
     pub fallback_reason: Option<String>,
     pub lanes: Vec<EffectiveAudioLane>,
+    pub buffer_health: Vec<AudioBufferHealth>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioBufferHealth {
+    pub lane_id: String,
+    pub artifact_id: Option<String>,
+    pub role: AudioLaneRole,
+    pub ring_fill_samples: usize,
+    pub ring_capacity_samples: usize,
+    pub underrun_count: u64,
+    pub worker_error_count: u64,
+    pub last_worker_error: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -159,17 +185,23 @@ enum PlaybackLaneSource {
 #[derive(Clone)]
 struct PlaybackLane {
     id: String,
+    artifact_id: Option<String>,
+    role: AudioLaneRole,
     muted: bool,
     solo: bool,
     current_gain: f32,
     target_gain: f32,
     scratch: Vec<f32>,
     source: PlaybackLaneSource,
+    underrun_count: u64,
+    worker_error_count: u64,
+    last_worker_error: Option<String>,
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 struct StreamingLane {
     ring: Arc<Mutex<RingBuffer>>,
+    capacity_samples: usize,
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -191,13 +223,28 @@ impl RingBuffer {
         self.capacity_samples.saturating_sub(self.samples.len())
     }
 
+    fn fill_samples(&self) -> usize {
+        self.samples.len()
+    }
+
     fn clear(&mut self) {
         self.samples.clear();
     }
 
-    fn pop_into(&mut self, output: &mut [f32]) {
-        for sample in output {
+    fn pop_into(&mut self, output: &mut [f32]) -> RingReadStatus {
+        let available = self.samples.len().min(output.len());
+        for sample in &mut output[..available] {
             *sample = self.samples.pop_front().unwrap_or(0.0);
+        }
+        for sample in &mut output[available..] {
+            *sample = 0.0;
+        }
+        if available == output.len() {
+            RingReadStatus::Full
+        } else if available == 0 {
+            RingReadStatus::Empty
+        } else {
+            RingReadStatus::Partial
         }
     }
 
@@ -211,6 +258,22 @@ impl RingBuffer {
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RingReadStatus {
+    Full,
+    Empty,
+    Partial,
+    LockMiss,
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+impl RingReadStatus {
+    fn is_underrun(self) -> bool {
+        !matches!(self, Self::Full)
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 enum WorkerControl {
     SetPlaybackRate {
         playback_rate: f64,
@@ -218,6 +281,31 @@ enum WorkerControl {
     },
     Seek(f64),
     Stop,
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+struct WorkerError {
+    lane_id: String,
+    message: String,
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum NativePlaybackFallbackCause {
+    PrebufferTimeout,
+    SustainedUnderrun,
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+impl NativePlaybackFallbackCause {
+    fn message(self) -> &'static str {
+        match self {
+            Self::PrebufferTimeout => "Native playback prebuffer timed out.",
+            Self::SustainedUnderrun => {
+                "Native playback underrun persisted; falling back to Web Audio."
+            }
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -258,21 +346,81 @@ struct PlaybackShared {
     click: ClickState,
     ended_pending: bool,
     error_pending: Option<String>,
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    buffering: bool,
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    sustained_underrun_frames: usize,
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    underrun_error_pending: bool,
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    fallback_cause: Option<NativePlaybackFallbackCause>,
 }
 
 impl PlaybackShared {
     fn snapshot(&self) -> AudioSnapshot {
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        let fallback_reason = self
+            .fallback_reason
+            .clone()
+            .or_else(|| self.fallback_cause.map(|cause| cause.message().to_string()));
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        let fallback_reason = self.fallback_reason.clone();
+
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        let native_playback_supported =
+            self.native_playback_supported && self.fallback_cause.is_none();
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        let native_playback_supported = self.native_playback_supported;
+
         AudioSnapshot {
             session_id: self.session_id.clone(),
             state: self.status.as_str(),
             position_seconds: self.position_seconds,
             duration_seconds: self.duration_seconds,
             playback_rate: self.playback_rate,
-            native_playback_supported: self.native_playback_supported,
-            fallback_reason: self.fallback_reason.clone(),
+            native_playback_supported,
+            fallback_reason,
             lanes: self.snapshot_lanes.clone(),
+            buffer_health: runtime_buffer_health(&self.snapshot_lanes, &self.lanes),
         }
     }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    fn prebuffer_ready(&self) -> bool {
+        if self.duration_seconds > 0.0 && self.position_seconds >= self.duration_seconds {
+            return true;
+        }
+
+        let target_samples = prebuffer_target_samples(self.sample_rate, self.channels);
+        let mut has_audible_lane = false;
+        for lane in &self.lanes {
+            if !lane.is_audible() {
+                continue;
+            }
+            has_audible_lane = true;
+            match &lane.source {
+                PlaybackLaneSource::Stream(stream) => {
+                    let target = target_samples.min(stream.capacity_samples);
+                    let Ok(ring) = stream.ring.lock() else {
+                        return false;
+                    };
+                    if ring.fill_samples() < target {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        !has_audible_lane || self.fallback_cause.is_none()
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn prebuffer_target_samples(sample_rate: u32, channels: usize) -> usize {
+    let target_frames = (sample_rate as f64 * PREBUFFER_TARGET_SECONDS).ceil() as usize;
+    target_frames
+        .saturating_mul(channels)
+        .max(STREAM_CHUNK_FRAMES.saturating_mul(channels))
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -418,18 +566,37 @@ impl TransportState {
         }
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         if let Some(runtime) = &self.runtime {
+            let mut should_prebuffer = false;
             if let Ok(mut shared) = runtime.shared.lock() {
                 update_shared_lanes(&mut shared, &lanes);
                 if let Some(rate) = next_playback_rate {
                     let position_seconds = shared.position_seconds;
                     self.position_seconds = position_seconds;
                     shared.playback_rate = rate;
+                    shared.sustained_underrun_frames = 0;
+                    shared.underrun_error_pending = false;
+                    if shared.status == TransportStatus::Playing {
+                        shared.buffering = true;
+                        clear_lane_rings(&mut shared.lanes);
+                        should_prebuffer = true;
+                    }
                     for sender in &runtime.worker_control_senders {
                         let _ = sender.send(WorkerControl::SetPlaybackRate {
                             playback_rate: rate,
                             position_seconds,
                         });
                     }
+                }
+            }
+            if should_prebuffer {
+                match wait_for_runtime_prebuffer(runtime) {
+                    Ok(()) => {
+                        if let Ok(mut shared) = runtime.shared.lock() {
+                            shared.buffering = false;
+                            shared.sustained_underrun_frames = 0;
+                        }
+                    }
+                    Err(cause) => mark_runtime_fallback(runtime, cause),
                 }
             }
         }
@@ -465,14 +632,23 @@ impl TransportState {
             self.position_seconds = self.clamp_position(start_time_seconds);
         }
         let _ = request.scheduled_start_time_seconds;
-        self.status = TransportStatus::Playing;
-        self.started_at = Some(Instant::now());
-
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         if let Some(runtime) = &self.runtime {
             if should_seek_workers {
                 seek_runtime_workers(runtime, self.position_seconds);
             }
+            if let Ok(mut shared) = runtime.shared.lock() {
+                shared.position_seconds = self.position_seconds;
+                shared.ended_pending = false;
+            }
+            if let Err(cause) = wait_for_runtime_prebuffer(runtime) {
+                mark_runtime_fallback(runtime, cause);
+                self.status = TransportStatus::Paused;
+                self.started_at = None;
+                return Ok(self.snapshot());
+            }
+            self.status = TransportStatus::Playing;
+            self.started_at = Some(Instant::now());
             let mut shared = runtime
                 .shared
                 .lock()
@@ -480,7 +656,15 @@ impl TransportState {
             shared.position_seconds = self.position_seconds;
             shared.status = TransportStatus::Playing;
             shared.ended_pending = false;
+            shared.buffering = false;
+            shared.sustained_underrun_frames = 0;
+            shared.underrun_error_pending = false;
+            shared.fallback_cause = None;
+            return Ok(shared.snapshot());
         }
+
+        self.status = TransportStatus::Playing;
+        self.started_at = Some(Instant::now());
 
         Ok(self.snapshot())
     }
@@ -495,6 +679,8 @@ impl TransportState {
             if let Ok(mut shared) = runtime.shared.lock() {
                 self.position_seconds = shared.position_seconds;
                 shared.status = TransportStatus::Paused;
+                shared.buffering = false;
+                shared.sustained_underrun_frames = 0;
             }
         }
 
@@ -508,11 +694,18 @@ impl TransportState {
 
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         if let Some(runtime) = &self.runtime {
-            seek_runtime_workers(runtime, 0.0);
+            for sender in &runtime.worker_control_senders {
+                let _ = sender.send(WorkerControl::Seek(0.0));
+            }
             if let Ok(mut shared) = runtime.shared.lock() {
+                clear_lane_rings(&mut shared.lanes);
                 shared.position_seconds = 0.0;
                 shared.status = TransportStatus::Stopped;
                 shared.ended_pending = false;
+                shared.buffering = false;
+                shared.sustained_underrun_frames = 0;
+                shared.underrun_error_pending = false;
+                shared.fallback_cause = None;
             }
         }
 
@@ -527,7 +720,30 @@ impl TransportState {
 
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         if let Some(runtime) = &self.runtime {
+            let was_playing = self.status == TransportStatus::Playing;
+            if was_playing {
+                if let Ok(mut shared) = runtime.shared.lock() {
+                    shared.buffering = true;
+                    clear_lane_rings(&mut shared.lanes);
+                }
+            }
             seek_runtime_workers(runtime, self.position_seconds);
+            if let Ok(mut shared) = runtime.shared.lock() {
+                shared.position_seconds = self.position_seconds;
+                shared.ended_pending = false;
+            }
+            if was_playing {
+                match wait_for_runtime_prebuffer(runtime) {
+                    Ok(()) => {
+                        if let Ok(mut shared) = runtime.shared.lock() {
+                            shared.buffering = false;
+                            shared.sustained_underrun_frames = 0;
+                            shared.underrun_error_pending = false;
+                        }
+                    }
+                    Err(cause) => mark_runtime_fallback(runtime, cause),
+                }
+            }
             if let Ok(mut shared) = runtime.shared.lock() {
                 shared.position_seconds = self.position_seconds;
                 shared.ended_pending = false;
@@ -554,6 +770,7 @@ impl TransportState {
             native_playback_supported: self.native_playback_supported,
             fallback_reason: self.fallback_reason.clone(),
             lanes: self.lanes.clone(),
+            buffer_health: empty_buffer_health(&self.lanes),
         }
     }
 
@@ -596,8 +813,44 @@ impl TransportState {
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 fn seek_runtime_workers(runtime: &PlaybackRuntime, position_seconds: f64) {
+    if let Ok(mut shared) = runtime.shared.lock() {
+        clear_lane_rings(&mut shared.lanes);
+        shared.sustained_underrun_frames = 0;
+        shared.underrun_error_pending = false;
+    }
     for sender in &runtime.worker_control_senders {
         let _ = sender.send(WorkerControl::Seek(position_seconds));
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn wait_for_runtime_prebuffer(
+    runtime: &PlaybackRuntime,
+) -> Result<(), NativePlaybackFallbackCause> {
+    let started_at = Instant::now();
+    loop {
+        let ready = runtime
+            .shared
+            .lock()
+            .map(|shared| shared.prebuffer_ready())
+            .unwrap_or(false);
+        if ready {
+            return Ok(());
+        }
+        if started_at.elapsed() >= PREBUFFER_TIMEOUT {
+            return Err(NativePlaybackFallbackCause::PrebufferTimeout);
+        }
+        thread::sleep(PREBUFFER_POLL_INTERVAL);
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn mark_runtime_fallback(runtime: &PlaybackRuntime, cause: NativePlaybackFallbackCause) {
+    if let Ok(mut shared) = runtime.shared.lock() {
+        shared.status = TransportStatus::Paused;
+        shared.buffering = false;
+        shared.fallback_cause = Some(cause);
+        shared.underrun_error_pending = true;
     }
 }
 
@@ -640,6 +893,88 @@ fn update_shared_lanes(shared: &mut PlaybackShared, lanes: &[EffectiveAudioLane]
         if let Some(effective) = lanes.iter().find(|candidate| candidate.id == lane.id) {
             lane.muted = effective.muted;
             lane.solo = effective.solo;
+        }
+    }
+}
+
+fn empty_buffer_health(lanes: &[EffectiveAudioLane]) -> Vec<AudioBufferHealth> {
+    lanes
+        .iter()
+        .map(|lane| AudioBufferHealth {
+            lane_id: lane.id.clone(),
+            artifact_id: lane.artifact_id.clone(),
+            role: lane.role,
+            ring_fill_samples: 0,
+            ring_capacity_samples: 0,
+            underrun_count: 0,
+            worker_error_count: 0,
+            last_worker_error: None,
+        })
+        .collect()
+}
+
+fn runtime_buffer_health(
+    snapshot_lanes: &[EffectiveAudioLane],
+    playback_lanes: &[PlaybackLane],
+) -> Vec<AudioBufferHealth> {
+    if snapshot_lanes.is_empty() {
+        return playback_lanes
+            .iter()
+            .map(|lane| lane.buffer_health(None))
+            .collect();
+    }
+
+    snapshot_lanes
+        .iter()
+        .map(|snapshot_lane| {
+            playback_lanes
+                .iter()
+                .find(|lane| lane.id == snapshot_lane.id)
+                .map(|lane| lane.buffer_health(Some(snapshot_lane)))
+                .unwrap_or_else(|| AudioBufferHealth {
+                    lane_id: snapshot_lane.id.clone(),
+                    artifact_id: snapshot_lane.artifact_id.clone(),
+                    role: snapshot_lane.role,
+                    ring_fill_samples: 0,
+                    ring_capacity_samples: 0,
+                    underrun_count: 0,
+                    worker_error_count: 0,
+                    last_worker_error: None,
+                })
+        })
+        .collect()
+}
+
+impl PlaybackLane {
+    fn is_audible(&self) -> bool {
+        self.current_gain > AUDIBLE_GAIN_FLOOR || self.target_gain > AUDIBLE_GAIN_FLOOR
+    }
+
+    fn buffer_health(&self, metadata: Option<&EffectiveAudioLane>) -> AudioBufferHealth {
+        let (ring_fill_samples, ring_capacity_samples) = match &self.source {
+            PlaybackLaneSource::Stream(stream) => {
+                let fill = stream
+                    .ring
+                    .try_lock()
+                    .map(|ring| ring.fill_samples())
+                    .unwrap_or(0);
+                (fill, stream.capacity_samples)
+            }
+        };
+
+        AudioBufferHealth {
+            lane_id: metadata
+                .map(|lane| lane.id.clone())
+                .unwrap_or_else(|| self.id.clone()),
+            artifact_id: metadata
+                .map(|lane| lane.artifact_id.clone())
+                .unwrap_or_else(|| self.artifact_id.clone()),
+            role: metadata.map(|lane| lane.role).unwrap_or(self.role),
+            ring_fill_samples,
+            ring_capacity_samples,
+            underrun_count: self.underrun_count,
+            worker_error_count: self.worker_error_count,
+            last_worker_error: self.last_worker_error.clone(),
         }
     }
 }
@@ -702,7 +1037,9 @@ fn mix_shared_frame(shared: &mut PlaybackShared, channel: usize, sample_index: u
     sample.clamp(-1.0, 1.0)
 }
 
-fn prepare_lane_scratch(lanes: &mut [PlaybackLane], sample_count: usize) {
+fn prepare_lane_scratch(lanes: &mut [PlaybackLane], sample_count: usize) -> bool {
+    let mut audible_underrun = false;
+
     for lane in lanes {
         if lane.scratch.len() < sample_count {
             lane.scratch.resize(sample_count, 0.0);
@@ -710,10 +1047,55 @@ fn prepare_lane_scratch(lanes: &mut [PlaybackLane], sample_count: usize) {
             lane.scratch[..sample_count].fill(0.0);
         }
 
+        let is_audible = lane.is_audible();
+        let read_status = match &lane.source {
+            PlaybackLaneSource::Stream(stream) => match stream.ring.try_lock() {
+                Ok(mut ring) => ring.pop_into(&mut lane.scratch[..sample_count]),
+                Err(_) => RingReadStatus::LockMiss,
+            },
+        };
+
+        if read_status.is_underrun() {
+            lane.underrun_count = lane.underrun_count.saturating_add(1);
+            if is_audible {
+                audible_underrun = true;
+            }
+        }
+    }
+
+    audible_underrun
+}
+
+fn update_underrun_state(shared: &mut PlaybackShared, audible_underrun: bool, frame_count: usize) {
+    if shared.status != TransportStatus::Playing || shared.buffering {
+        shared.sustained_underrun_frames = 0;
+        return;
+    }
+
+    if !audible_underrun {
+        shared.sustained_underrun_frames = 0;
+        return;
+    }
+
+    shared.sustained_underrun_frames = shared
+        .sustained_underrun_frames
+        .saturating_add(frame_count.max(1));
+    let threshold_frames =
+        (shared.sample_rate as f64 * SUSTAINED_UNDERRUN_ERROR_SECONDS).ceil() as usize;
+    if shared.fallback_cause.is_none() && shared.sustained_underrun_frames >= threshold_frames {
+        shared.status = TransportStatus::Paused;
+        shared.buffering = false;
+        shared.fallback_cause = Some(NativePlaybackFallbackCause::SustainedUnderrun);
+        shared.underrun_error_pending = true;
+    }
+}
+
+fn clear_lane_rings(lanes: &mut [PlaybackLane]) {
+    for lane in lanes {
         match &lane.source {
             PlaybackLaneSource::Stream(stream) => {
-                if let Ok(mut ring) = stream.ring.try_lock() {
-                    ring.pop_into(&mut lane.scratch[..sample_count]);
+                if let Ok(mut ring) = stream.ring.lock() {
+                    ring.clear();
                 }
             }
         }
@@ -726,12 +1108,14 @@ fn render_shared_output(shared: &mut PlaybackShared, output: &mut [f32]) {
         output.fill(0.0);
         return;
     }
-    if shared.status == TransportStatus::Playing {
-        prepare_lane_scratch(&mut shared.lanes, output.len());
+    if shared.status == TransportStatus::Playing && !shared.buffering {
+        let frame_count = output.len() / shared.channels;
+        let audible_underrun = prepare_lane_scratch(&mut shared.lanes, output.len());
+        update_underrun_state(shared, audible_underrun, frame_count);
     }
 
     for (frame_index, frame) in output.chunks_mut(shared.channels).enumerate() {
-        if shared.status != TransportStatus::Playing {
+        if shared.status != TransportStatus::Playing || shared.buffering {
             frame.fill(0.0);
             continue;
         }
@@ -761,12 +1145,14 @@ where
         }
         return;
     }
-    if shared.status == TransportStatus::Playing {
-        prepare_lane_scratch(&mut shared.lanes, output.len());
+    if shared.status == TransportStatus::Playing && !shared.buffering {
+        let frame_count = output.len() / shared.channels;
+        let audible_underrun = prepare_lane_scratch(&mut shared.lanes, output.len());
+        update_underrun_state(shared, audible_underrun, frame_count);
     }
 
     for (frame_index, frame) in output.chunks_mut(shared.channels).enumerate() {
-        if shared.status != TransportStatus::Playing {
+        if shared.status != TransportStatus::Playing || shared.buffering {
             for sample in frame {
                 *sample = silent;
             }
@@ -836,6 +1222,10 @@ fn start_desktop_runtime(
         click: click.clone(),
         ended_pending: false,
         error_pending: None,
+        buffering: false,
+        sustained_underrun_frames: 0,
+        underrun_error_pending: false,
+        fallback_cause: None,
     }));
 
     drop(device);
@@ -877,10 +1267,19 @@ fn start_desktop_runtime(
             if reporter_stop_receiver.try_recv().is_ok() {
                 break;
             }
-            while let Ok(message) = worker_error_receiver.try_recv() {
+            while let Ok(worker_error) = worker_error_receiver.try_recv() {
                 if let Ok(mut shared) = shared.lock() {
-                    shared.error_pending = Some(message);
+                    if let Some(lane) = shared
+                        .lanes
+                        .iter_mut()
+                        .find(|lane| lane.id == worker_error.lane_id)
+                    {
+                        lane.worker_error_count = lane.worker_error_count.saturating_add(1);
+                        lane.last_worker_error = Some(worker_error.message.clone());
+                    }
+                    shared.error_pending = Some(worker_error.message);
                     shared.status = TransportStatus::Paused;
+                    shared.buffering = false;
                 }
             }
             emit_runtime_events(&app, &shared);
@@ -1012,7 +1411,15 @@ fn emit_runtime_events(app: &AppHandle, shared: &Arc<Mutex<PlaybackShared>>) {
         let snapshot = shared.snapshot();
         let ended = shared.ended_pending;
         shared.ended_pending = false;
-        let error = shared.error_pending.take();
+        let mut error = shared.error_pending.take();
+        if shared.underrun_error_pending {
+            shared.underrun_error_pending = false;
+            if error.is_none() {
+                error = shared
+                    .fallback_cause
+                    .map(|cause| cause.message().to_string());
+            }
+        }
         (snapshot, ended, error)
     };
 
@@ -1061,7 +1468,7 @@ fn load_playback_lanes(
     sample_rate: u32,
     channels: usize,
     playback_rate: f64,
-    worker_error_sender: mpsc::Sender<String>,
+    worker_error_sender: mpsc::Sender<WorkerError>,
 ) -> Result<LoadedPlaybackLanes, String> {
     let mut lanes = Vec::new();
     let mut worker_control_senders = Vec::new();
@@ -1086,6 +1493,7 @@ fn load_playback_lanes(
             );
         let ring = Arc::new(Mutex::new(RingBuffer::new(capacity_samples)));
         let (sender, worker_thread) = spawn_decoder_worker(
+            lane.id.clone(),
             path,
             ring.clone(),
             sample_rate,
@@ -1098,12 +1506,20 @@ fn load_playback_lanes(
         worker_threads.push(worker_thread);
         lanes.push(PlaybackLane {
             id: lane.id.clone(),
+            artifact_id: lane.artifact_id.clone(),
+            role: lane.role,
             muted: lane.muted,
             solo: lane.solo,
             current_gain: target_gain,
             target_gain,
             scratch: vec![0.0; sample_rate as usize * channels],
-            source: PlaybackLaneSource::Stream(Arc::new(StreamingLane { ring })),
+            source: PlaybackLaneSource::Stream(Arc::new(StreamingLane {
+                ring,
+                capacity_samples,
+            })),
+            underrun_count: 0,
+            worker_error_count: 0,
+            last_worker_error: None,
         });
     }
 
@@ -1116,12 +1532,13 @@ fn load_playback_lanes(
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 fn spawn_decoder_worker(
+    lane_id: String,
     path: PathBuf,
     ring: Arc<Mutex<RingBuffer>>,
     target_sample_rate: u32,
     target_channels: usize,
     playback_rate: f64,
-    error_sender: mpsc::Sender<String>,
+    error_sender: mpsc::Sender<WorkerError>,
 ) -> Result<(mpsc::Sender<WorkerControl>, JoinHandle<()>), String> {
     let mut playback_rate = normalize_playback_rate(Some(playback_rate));
     let mut decoder = StreamingDecoder::open(
@@ -1132,6 +1549,7 @@ fn spawn_decoder_worker(
         0.0,
     )?;
     let (sender, receiver) = mpsc::channel();
+    let mut pending_samples: Option<Vec<f32>> = None;
     let worker_thread = thread::spawn(move || loop {
         while let Ok(control) = receiver.try_recv() {
             match control {
@@ -1143,6 +1561,7 @@ fn spawn_decoder_worker(
                     if let Ok(mut guard) = ring.lock() {
                         guard.clear();
                     }
+                    pending_samples = None;
                     decoder.set_playback_rate(playback_rate);
                     if decoder.seek(position_seconds).is_err() {
                         match StreamingDecoder::open(
@@ -1156,7 +1575,10 @@ fn spawn_decoder_worker(
                                 decoder = reopened;
                             }
                             Err(error) => {
-                                let _ = error_sender.send(error);
+                                let _ = error_sender.send(WorkerError {
+                                    lane_id: lane_id.clone(),
+                                    message: error,
+                                });
                                 return;
                             }
                         }
@@ -1166,6 +1588,7 @@ fn spawn_decoder_worker(
                     if let Ok(mut guard) = ring.lock() {
                         guard.clear();
                     }
+                    pending_samples = None;
                     if decoder.seek(position_seconds).is_err() {
                         match StreamingDecoder::open(
                             path.clone(),
@@ -1178,13 +1601,27 @@ fn spawn_decoder_worker(
                                 decoder = reopened;
                             }
                             Err(error) => {
-                                let _ = error_sender.send(error);
+                                let _ = error_sender.send(WorkerError {
+                                    lane_id: lane_id.clone(),
+                                    message: error,
+                                });
                                 return;
                             }
                         }
                     }
                 }
                 WorkerControl::Stop => return,
+            }
+        }
+
+        if let Some(samples) = pending_samples.take() {
+            match push_or_defer_worker_samples(&ring, &mut pending_samples, samples) {
+                Ok(true) => continue,
+                Ok(false) => {
+                    thread::sleep(Duration::from_millis(5));
+                    continue;
+                }
+                Err(()) => return,
             }
         }
 
@@ -1204,26 +1641,41 @@ fn spawn_decoder_worker(
                     thread::sleep(Duration::from_millis(2));
                     continue;
                 }
-                if let Ok(mut guard) = ring.lock() {
-                    if !guard.push_samples(&samples) {
-                        drop(guard);
-                        thread::sleep(Duration::from_millis(5));
-                    }
-                } else {
-                    return;
+                match push_or_defer_worker_samples(&ring, &mut pending_samples, samples) {
+                    Ok(true) => {}
+                    Ok(false) => thread::sleep(Duration::from_millis(5)),
+                    Err(()) => return,
                 }
             }
             Ok(None) => {
                 thread::sleep(Duration::from_millis(20));
             }
             Err(error) => {
-                let _ = error_sender.send(error);
+                let _ = error_sender.send(WorkerError {
+                    lane_id: lane_id.clone(),
+                    message: error,
+                });
                 return;
             }
         }
     });
 
     Ok((sender, worker_thread))
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn push_or_defer_worker_samples(
+    ring: &Arc<Mutex<RingBuffer>>,
+    pending_samples: &mut Option<Vec<f32>>,
+    samples: Vec<f32>,
+) -> Result<bool, ()> {
+    let mut guard = ring.lock().map_err(|_| ())?;
+    if guard.push_samples(&samples) {
+        Ok(true)
+    } else {
+        *pending_samples = Some(samples);
+        Ok(false)
+    }
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -1727,6 +2179,61 @@ mod tests {
         }
     }
 
+    fn stream_lane(id: &str, ring: Arc<Mutex<RingBuffer>>, target_gain: f32) -> PlaybackLane {
+        PlaybackLane {
+            id: id.to_string(),
+            artifact_id: Some(format!("artifact-{id}")),
+            role: AudioLaneRole::Stem,
+            muted: false,
+            solo: false,
+            current_gain: target_gain,
+            target_gain,
+            scratch: vec![0.0; 1_000],
+            source: PlaybackLaneSource::Stream(Arc::new(StreamingLane {
+                ring,
+                capacity_samples: 1_000,
+            })),
+            underrun_count: 0,
+            worker_error_count: 0,
+            last_worker_error: None,
+        }
+    }
+
+    fn shared_with_lane(
+        ring: Arc<Mutex<RingBuffer>>,
+        sample_rate: u32,
+        channels: usize,
+        target_gain: f32,
+    ) -> PlaybackShared {
+        PlaybackShared {
+            session_id: Some("session".to_string()),
+            status: TransportStatus::Playing,
+            position_seconds: 0.0,
+            duration_seconds: 10.0,
+            playback_rate: 1.0,
+            native_playback_supported: true,
+            fallback_reason: None,
+            sample_rate,
+            channels,
+            lanes: vec![stream_lane("lane", ring, target_gain)],
+            snapshot_lanes: vec![EffectiveAudioLane {
+                id: "lane".to_string(),
+                artifact_id: Some("artifact-lane".to_string()),
+                role: AudioLaneRole::Stem,
+                effective_gain: target_gain,
+                muted: false,
+                solo: false,
+            }],
+            click: ClickState::default(),
+            ended_pending: false,
+            error_pending: None,
+            buffering: false,
+            sustained_underrun_frames: 0,
+            underrun_error_pending: false,
+            fallback_cause: None,
+        }
+    }
+
     #[test]
     fn seek_clamps_to_duration() {
         let mut state = TransportState::default();
@@ -1833,36 +2340,143 @@ mod tests {
         ring.lock()
             .expect("ring lock")
             .push_samples(&vec![0.5; 1_000]);
-        let mut shared = PlaybackShared {
-            session_id: Some("session".to_string()),
-            status: TransportStatus::Playing,
-            position_seconds: 0.0,
-            duration_seconds: 10.0,
-            playback_rate: 2.0,
-            native_playback_supported: true,
-            fallback_reason: None,
-            sample_rate: 1_000,
-            channels: 1,
-            lanes: vec![PlaybackLane {
-                id: "lane".to_string(),
-                muted: false,
-                solo: false,
-                current_gain: 1.0,
-                target_gain: 1.0,
-                scratch: vec![0.0; 1_000],
-                source: PlaybackLaneSource::Stream(Arc::new(StreamingLane { ring })),
-            }],
-            snapshot_lanes: Vec::new(),
-            click: ClickState::default(),
-            ended_pending: false,
-            error_pending: None,
-        };
+        let mut shared = shared_with_lane(ring, 1_000, 1, 1.0);
+        shared.playback_rate = 2.0;
         let mut output = vec![0.0; 10];
 
         render_shared_output(&mut shared, &mut output);
 
         assert_eq!(output[0], 0.5);
         assert!((shared.position_seconds - 0.02).abs() < 0.0001);
+    }
+
+    #[test]
+    fn snapshot_reports_buffer_health_for_stream_lane() {
+        let ring = Arc::new(Mutex::new(RingBuffer::new(1_000)));
+        ring.lock()
+            .expect("ring lock")
+            .push_samples(&vec![0.5; 128]);
+        let mut shared = shared_with_lane(ring, 1_000, 1, 1.0);
+        shared.lanes[0].underrun_count = 2;
+        shared.lanes[0].worker_error_count = 1;
+        shared.lanes[0].last_worker_error = Some("decode failed".to_string());
+
+        let snapshot = shared.snapshot();
+
+        assert_eq!(snapshot.buffer_health.len(), 1);
+        let health = &snapshot.buffer_health[0];
+        assert_eq!(health.lane_id, "lane");
+        assert_eq!(health.artifact_id.as_deref(), Some("artifact-lane"));
+        assert_eq!(health.role, AudioLaneRole::Stem);
+        assert_eq!(health.ring_fill_samples, 128);
+        assert_eq!(health.ring_capacity_samples, 1_000);
+        assert_eq!(health.underrun_count, 2);
+        assert_eq!(health.worker_error_count, 1);
+        assert_eq!(health.last_worker_error.as_deref(), Some("decode failed"));
+    }
+
+    #[test]
+    fn prepare_lane_scratch_counts_empty_partial_and_lock_miss_underruns() {
+        let empty_ring = Arc::new(Mutex::new(RingBuffer::new(1_000)));
+        let mut empty_lane = stream_lane("empty", empty_ring, 1.0);
+        assert!(prepare_lane_scratch(
+            std::slice::from_mut(&mut empty_lane),
+            10
+        ));
+        assert_eq!(empty_lane.underrun_count, 1);
+
+        let partial_ring = Arc::new(Mutex::new(RingBuffer::new(1_000)));
+        partial_ring
+            .lock()
+            .expect("ring lock")
+            .push_samples(&[0.25; 5]);
+        let mut partial_lane = stream_lane("partial", partial_ring, 1.0);
+        assert!(prepare_lane_scratch(
+            std::slice::from_mut(&mut partial_lane),
+            10
+        ));
+        assert_eq!(partial_lane.underrun_count, 1);
+        assert_eq!(partial_lane.scratch[0], 0.25);
+        assert_eq!(partial_lane.scratch[5], 0.0);
+
+        let locked_ring = Arc::new(Mutex::new(RingBuffer::new(1_000)));
+        let guard = locked_ring.lock().expect("ring lock");
+        let mut locked_lane = stream_lane("locked", locked_ring.clone(), 1.0);
+        assert!(prepare_lane_scratch(
+            std::slice::from_mut(&mut locked_lane),
+            10
+        ));
+        drop(guard);
+        assert_eq!(locked_lane.underrun_count, 1);
+    }
+
+    #[test]
+    fn sustained_underrun_marks_native_fallback_without_advancing() {
+        let ring = Arc::new(Mutex::new(RingBuffer::new(1_000)));
+        let mut shared = shared_with_lane(ring, 10, 1, 1.0);
+        let mut output = vec![0.0; 5];
+
+        render_shared_output(&mut shared, &mut output);
+        let snapshot = shared.snapshot();
+
+        assert_eq!(shared.status, TransportStatus::Paused);
+        assert_eq!(
+            shared.fallback_cause,
+            Some(NativePlaybackFallbackCause::SustainedUnderrun)
+        );
+        assert!(!snapshot.native_playback_supported);
+        assert_eq!(
+            snapshot.fallback_reason.as_deref(),
+            Some("Native playback underrun persisted; falling back to Web Audio.")
+        );
+        assert_eq!(shared.position_seconds, 0.0);
+    }
+
+    #[test]
+    fn render_shared_output_does_not_advance_while_buffering() {
+        let ring = Arc::new(Mutex::new(RingBuffer::new(1_000)));
+        ring.lock()
+            .expect("ring lock")
+            .push_samples(&vec![0.5; 1_000]);
+        let mut shared = shared_with_lane(ring, 1_000, 1, 1.0);
+        shared.buffering = true;
+        let mut output = vec![1.0; 10];
+
+        render_shared_output(&mut shared, &mut output);
+
+        assert!(output.iter().all(|sample| *sample == 0.0));
+        assert_eq!(shared.position_seconds, 0.0);
+        assert_eq!(shared.lanes[0].underrun_count, 0);
+    }
+
+    #[test]
+    fn worker_defers_stretched_tempo_chunks_instead_of_dropping_them() {
+        let ring = Arc::new(Mutex::new(RingBuffer::new(8)));
+        ring.lock()
+            .expect("ring lock")
+            .push_samples(&[0.1, 0.1, 0.1, 0.1, 0.1]);
+        let mut pending_samples = None;
+
+        let pushed =
+            push_or_defer_worker_samples(&ring, &mut pending_samples, vec![1.0, 2.0, 3.0, 4.0])
+                .expect("push samples");
+
+        assert!(!pushed);
+        assert_eq!(pending_samples.as_deref(), Some(&[1.0, 2.0, 3.0, 4.0][..]));
+        assert_eq!(ring.lock().expect("ring lock").fill_samples(), 5);
+
+        let mut drained = vec![0.0; 3];
+        ring.lock().expect("ring lock").pop_into(&mut drained);
+        let retry = pending_samples.take().expect("pending samples");
+
+        let pushed = push_or_defer_worker_samples(&ring, &mut pending_samples, retry)
+            .expect("retry pending samples");
+
+        assert!(pushed);
+        assert!(pending_samples.is_none());
+        let mut output = vec![0.0; 6];
+        ring.lock().expect("ring lock").pop_into(&mut output);
+        assert_eq!(output, vec![0.1, 0.1, 1.0, 2.0, 3.0, 4.0]);
     }
 
     #[test]

--- a/apps/desktop/src/App.project-tempo.test.tsx
+++ b/apps/desktop/src/App.project-tempo.test.tsx
@@ -2,9 +2,12 @@ import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  emitMockNativePlaybackError,
+  emitMockNativePlaybackPosition,
   findAudioByArtifactId,
   getMockAudioContexts,
   getMockInvoke,
+  mockListen,
   markAudioReady,
   mockCreateExport,
   mockCreatePreview,
@@ -51,6 +54,10 @@ function tempoControl() {
   return { group, section: section as HTMLElement };
 }
 
+async function waitForTempoSummary(text: string) {
+  await waitFor(() => expect(screen.getByText(text)).toBeInTheDocument());
+}
+
 function setPlaybackPosition(value: string) {
   fireEvent.change(screen.getByLabelText("Playback position"), { target: { value } });
 }
@@ -76,6 +83,17 @@ function mockTauriRuntime() {
   };
 }
 
+function latestNativeSessionId() {
+  const prepareCall = [...getMockInvoke().mock.calls]
+    .reverse()
+    .find(([command]) => command === "audio_prepare_session");
+  const payload = (prepareCall?.[1] as { payload?: { sessionId?: string } } | undefined)?.payload;
+  if (!payload?.sessionId) {
+    throw new Error("Native audio session was not prepared.");
+  }
+  return payload.sessionId;
+}
+
 describe("Desktop app project playback tempo", () => {
   beforeEach(resetAppTestHarness);
   afterEach(() => {
@@ -94,7 +112,7 @@ describe("Desktop app project playback tempo", () => {
     expect(within(section).getByText("Original 123.5 BPM")).toBeInTheDocument();
     await user.click(within(group).getByRole("button", { name: "Decrease playback tempo" }));
 
-    expect(within(section).getByText("123 BPM (0.996x)")).toBeInTheDocument();
+    await waitFor(() => expect(within(section).getByText("123 BPM (0.996x)")).toBeInTheDocument());
     expect(mockCreatePreview).not.toHaveBeenCalled();
     expect(mockCreateStems).not.toHaveBeenCalled();
     expect(mockCreateExport).not.toHaveBeenCalled();
@@ -108,6 +126,39 @@ describe("Desktop app project playback tempo", () => {
 
     await user.click(screen.getByRole("button", { name: "Reset" }));
     expect(screen.getByText("Original 123.5 BPM")).toBeInTheDocument();
+  });
+
+  it("flushes a pending tempo step before playback starts", async () => {
+    const user = userEvent.setup();
+    setupTempoAnalysis(120);
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+
+    await user.click(screen.getByRole("button", { name: "Decrease playback tempo" }));
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    await waitFor(() => expect(sourceAudio.playbackRate).toBeCloseTo(119 / 120, 4));
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+  });
+
+  it("commits direct BPM edits from the playback tempo selector", async () => {
+    const user = userEvent.setup();
+    setupTempoAnalysis(120);
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+
+    const bpmInput = screen.getByRole("spinbutton", { name: "Playback BPM" });
+    await user.clear(bpmInput);
+    await user.type(bpmInput, "96{Enter}");
+
+    expect(await screen.findByText("96 BPM (0.800x)")).toBeInTheDocument();
+    expect(bpmInput).toHaveValue(96);
   });
 
   it("does not open native playback while the project is idle", async () => {
@@ -138,6 +189,114 @@ describe("Desktop app project playback tempo", () => {
     restoreTauriRuntime();
   });
 
+  it("falls back to Web Audio when native play reports an underrun fallback", async () => {
+    const restoreTauriRuntime = mockTauriRuntime();
+    const user = userEvent.setup();
+    setupTempoAnalysis(120);
+    setMockNativeAudioState({
+      capabilities: {
+        nativePlaybackSupported: true,
+        fallbackRequired: false,
+        fallbackReason: null,
+        backend: "desktop-cpal",
+      },
+      playFallbackReason: "Native playback underrun persisted; falling back to Web Audio.",
+    });
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    await waitFor(() =>
+      expect(
+        getMockInvoke().mock.calls.some(([command]) => command === "audio_play"),
+      ).toBe(true),
+    );
+    await waitFor(() => {
+      expect(findAudioByArtifactId("art_source")).toBeInTheDocument();
+    });
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    await waitFor(() => expect(getMockAudioContexts()[0]?.createdSources).toHaveLength(1));
+    expect(window.localStorage.getItem("tuneforge.playback-native-error")).toBe(
+      "Native playback underrun persisted; falling back to Web Audio.",
+    );
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+    restoreTauriRuntime();
+  });
+
+  it("falls back to Web Audio at the current native time after a runtime underrun error", async () => {
+    const restoreTauriRuntime = mockTauriRuntime();
+    const user = userEvent.setup();
+    setupTempoAnalysis(120);
+    setMockNativeAudioState({
+      capabilities: {
+        nativePlaybackSupported: true,
+        fallbackRequired: false,
+        fallbackReason: null,
+        backend: "desktop-cpal",
+      },
+    });
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() =>
+      expect(
+        getMockInvoke().mock.calls.some(([command]) => command === "audio_play"),
+      ).toBe(true),
+    );
+    await waitFor(() =>
+      expect(mockListen.mock.calls.some(([eventName]) => eventName === "audio://error")).toBe(true),
+    );
+
+    const sessionId = latestNativeSessionId();
+    emitMockNativePlaybackPosition({
+      sessionId,
+      positionSeconds: 42.25,
+      durationSeconds: 182,
+      state: "playing",
+    });
+    await waitFor(() => expect(screen.getByLabelText("Playback position")).toHaveValue("42.25"));
+
+    emitMockNativePlaybackError({
+      sessionId: "stale-native-session",
+      message: "Stale native playback error.",
+    });
+    await waitFor(() => {
+      expect(
+        getMockInvoke().mock.calls.some(([command]) => command === "audio_stop"),
+      ).toBe(false);
+    });
+    expect(window.localStorage.getItem("tuneforge.playback-native-error")).toBeNull();
+
+    emitMockNativePlaybackError({
+      sessionId,
+      message: "Native playback underrun persisted; falling back to Web Audio.",
+    });
+
+    await waitFor(() => {
+      expect(findAudioByArtifactId("art_source")).toBeInTheDocument();
+    });
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    await waitFor(() => expect(getMockAudioContexts()[0]?.createdSources).toHaveLength(1));
+    expect(getMockAudioContexts()[0]?.createdSources[0]?.start.mock.calls[0]?.[1]).toBeCloseTo(
+      42.25,
+      3,
+    );
+    expect(window.localStorage.getItem("tuneforge.playback-native-error")).toBe(
+      "Native playback underrun persisted; falling back to Web Audio.",
+    );
+    expect(
+      getMockInvoke().mock.calls.some(([command]) => command === "audio_stop"),
+    ).toBe(true);
+    restoreTauriRuntime();
+  });
+
   it("keeps source and practice mix switching on the streamed media path when tempo is changed", async () => {
     const user = userEvent.setup();
     setupTempoAnalysis(120);
@@ -149,6 +308,7 @@ describe("Desktop app project playback tempo", () => {
     markAudioReady(sourceAudio);
 
     await user.click(screen.getByRole("button", { name: "Decrease playback tempo" }));
+    await waitForTempoSummary("119 BPM (0.992x)");
     await user.click(screen.getByRole("button", { name: "Play playback" }));
 
     expect(sourceAudio.playbackRate).toBeCloseTo(119 / 120, 4);
@@ -189,7 +349,9 @@ describe("Desktop app project playback tempo", () => {
 
     const playCallsBeforeTempoChange =
       vi.mocked(window.HTMLMediaElement.prototype.play).mock.calls.length;
-    await user.click(screen.getByRole("button", { name: "Decrease playback tempo" }));
+    const bpmInput = screen.getByRole("spinbutton", { name: "Playback BPM" });
+    await user.clear(bpmInput);
+    await user.type(bpmInput, "119{Enter}");
 
     await waitFor(() => {
       expect(sourceAudio.currentTime).toBeGreaterThanOrEqual(32.5);
@@ -218,6 +380,7 @@ describe("Desktop app project playback tempo", () => {
     markAudioReady(sourceAudio);
 
     await user.click(screen.getByRole("button", { name: "Decrease playback tempo" }));
+    await waitForTempoSummary("119 BPM (0.992x)");
     await user.click(screen.getByRole("button", { name: "Play playback" }));
     setPlaybackPosition("41.125");
 
@@ -277,6 +440,7 @@ describe("Desktop app project playback tempo", () => {
       ),
     );
     await user.click(screen.getByRole("button", { name: "Decrease playback tempo" }));
+    await waitForTempoSummary("119 BPM (0.992x)");
 
     const vocalAudio = findAudioByArtifactId("art_200");
     const instrumentalAudio = findAudioByArtifactId("art_201");
@@ -292,6 +456,7 @@ describe("Desktop app project playback tempo", () => {
     await user.click(screen.getByRole("button", { name: "Decrease playback tempo" }));
     await user.click(screen.getByRole("button", { name: "Decrease playback tempo" }));
     await user.click(screen.getByRole("button", { name: "Increase playback tempo" }));
+    await waitForTempoSummary("118 BPM (0.983x)");
 
     await waitFor(() => expect(vocalAudio.playbackRate).toBeCloseTo(118 / 120, 4));
     expect(instrumentalAudio.playbackRate).toBeCloseTo(118 / 120, 4);
@@ -320,6 +485,7 @@ describe("Desktop app project playback tempo", () => {
     const stemList = await screen.findByRole("group", { name: "Playback stem list" });
     await user.click(within(stemList).getAllByRole("button", { name: /Vocals/i })[0] as HTMLElement);
     await user.click(screen.getByRole("button", { name: "Decrease playback tempo" }));
+    await waitForTempoSummary("119 BPM (0.992x)");
 
     const vocalAudio = findAudioByArtifactId("art_200");
     const instrumentalAudio = findAudioByArtifactId("art_201");

--- a/apps/desktop/src/App.settings-theme.test.tsx
+++ b/apps/desktop/src/App.settings-theme.test.tsx
@@ -124,6 +124,21 @@ describe("Desktop app settings theme", () => {
         micCaptureSupported: true,
         nativePlaybackSupported: false,
       },
+      snapshot: {
+        fallbackReason: "buffer underrun on native lane vocals",
+        bufferHealth: [
+          {
+            laneId: "vocals",
+            artifactId: "art_vocals",
+            role: "stem",
+            ringFillSamples: 1200,
+            ringCapacitySamples: 4800,
+            underrunCount: 3,
+            workerErrorCount: 1,
+            lastWorkerError: "decoder stalled",
+          },
+        ],
+      },
     });
     window.localStorage.setItem(
       "tuneforge.tuner-input-capture-backend",
@@ -155,7 +170,10 @@ describe("Desktop app settings theme", () => {
     expect(screen.getByText(FRONTEND_VERSION_INFO.git_ref)).toBeInTheDocument();
     expect(screen.getAllByText("Native (desktop-cpal)")).toHaveLength(2);
     expect(screen.getByText("Native microphone failed.")).toBeInTheDocument();
-    expect(screen.getByText("Native output failed.")).toBeInTheDocument();
+    expect(screen.getAllByText("Native output failed.")).toHaveLength(2);
+    expect(screen.getByText("Latest Native Fallback Cause")).toBeInTheDocument();
+    expect(screen.getByText("Native Playback Buffer Health")).toBeInTheDocument();
+    expect(screen.getByText(/art_vocals: 25% buffer, 3 underruns, 1 worker errors/)).toBeInTheDocument();
     expect(screen.getAllByText("Web Audio")).toHaveLength(2);
 
     expect(document.documentElement).toHaveAttribute("data-theme", "light");

--- a/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
@@ -1,3 +1,4 @@
+import { type KeyboardEvent, useEffect, useRef, useState } from "react";
 import { ArrowUpDown, AudioLines, Drumstick, Gauge, Layers } from "lucide-react";
 import {
   artifactLabel,
@@ -19,8 +20,7 @@ export function PlaybackPracticeRail() {
     capoSourceKey,
     enharmonicDisplayMode,
     canUseTempo,
-    handleDecreasePlaybackTempo,
-    handleIncreasePlaybackTempo,
+    handleSetPlaybackTempo,
     handleResetPlaybackTempo,
     handleSelectPrimaryArtifact,
     handleSelectStemArtifact,
@@ -62,21 +62,121 @@ export function PlaybackPracticeRail() {
     visibleStemArtifacts,
   } = useProjectViewModelContext();
   const showHeaderDetails = informationDensity === "detailed";
-  const tempoDisplayLabel =
-    tempoDisplayBpm === null
-      ? "--"
-      : Number.isInteger(tempoDisplayBpm)
-        ? tempoDisplayBpm.toFixed(0)
-        : tempoDisplayBpm.toFixed(1);
   const tempoSummary =
     canUseTempo && tempoDisplayBpm !== null && tempoOriginalBpm !== null
       ? tempoTargetBpm === null
         ? `Original ${tempoOriginalBpm.toFixed(1)} BPM`
         : `${tempoTargetBpm.toFixed(0)} BPM (${tempoPlaybackRate.toFixed(3)}x)`
       : "Waiting for tempo analysis";
+  const [tempoDraftText, setTempoDraftText] = useState(() =>
+    tempoDisplayBpm === null
+      ? ""
+      : Number.isInteger(tempoDisplayBpm)
+        ? tempoDisplayBpm.toFixed(0)
+        : tempoDisplayBpm.toFixed(1),
+  );
+  const tempoCommitTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const skipNextTempoBlurCommit = useRef(false);
+
+  const clampTempoBpm = (value: number) =>
+    Math.max(tempoMinBpm, Math.min(tempoMaxBpm, Math.round(value)));
+
+  const formatTempoDraftText = (value: number | null) =>
+    value === null ? "" : Number.isInteger(value) ? value.toFixed(0) : value.toFixed(1);
+
+  useEffect(() => {
+    setTempoDraftText(
+      tempoDisplayBpm === null ? "" : formatTempoDraftText(tempoDisplayBpm),
+    );
+  }, [tempoDisplayBpm]);
+
+  useEffect(() => () => {
+    if (tempoCommitTimer.current !== null) {
+      clearTimeout(tempoCommitTimer.current);
+      tempoCommitTimer.current = null;
+    }
+  }, []);
+
+  const clearTempoCommitTimer = () => {
+    if (tempoCommitTimer.current !== null) {
+      clearTimeout(tempoCommitTimer.current);
+      tempoCommitTimer.current = null;
+    }
+  };
+
+  const restoreTempoDraft = () => {
+    setTempoDraftText(tempoDisplayBpm === null ? "" : formatTempoDraftText(tempoDisplayBpm));
+  };
+
+  const commitTempoFromInput = () => {
+    const trimmedDraft = tempoDraftText.trim();
+    const parsed = Number(trimmedDraft);
+    if (!Number.isFinite(parsed) || trimmedDraft === "") {
+      restoreTempoDraft();
+      return;
+    }
+    clearTempoCommitTimer();
+    const target = clampTempoBpm(parsed);
+    setTempoDraftText(formatTempoDraftText(target));
+    handleSetPlaybackTempo(target);
+  };
+
+  const scheduleTempoCommit = (value: number) => {
+    const target = clampTempoBpm(value);
+    setTempoDraftText(formatTempoDraftText(target));
+    clearTempoCommitTimer();
+    tempoCommitTimer.current = setTimeout(() => {
+      tempoCommitTimer.current = null;
+      handleSetPlaybackTempo(target);
+    }, 250);
+  };
+
+  const flushPendingTempoCommit = () => {
+    if (tempoCommitTimer.current === null) {
+      return;
+    }
+    commitTempoFromInput();
+  };
+
+  const handleTempoInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      commitTempoFromInput();
+      event.currentTarget.blur();
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      clearTempoCommitTimer();
+      restoreTempoDraft();
+      skipNextTempoBlurCommit.current = true;
+      event.currentTarget.blur();
+    }
+  };
+
+  const trimmedDraftTempoText = tempoDraftText.trim();
+  const draftTempoValue = Number(trimmedDraftTempoText);
+  const tempoDraftNumeric = trimmedDraftTempoText !== "" && Number.isFinite(draftTempoValue)
+    ? draftTempoValue
+    : tempoDisplayBpm ?? tempoMinBpm;
+  const canDecreaseTempo = canUseTempo && tempoDraftNumeric > tempoMinBpm;
+  const canIncreaseTempo = canUseTempo && tempoDraftNumeric < tempoMaxBpm;
+
+  const handleTempoReset = () => {
+    clearTempoCommitTimer();
+    handleResetPlaybackTempo();
+    setTempoDraftText(formatTempoDraftText(tempoOriginalBpm ?? tempoDisplayBpm ?? null));
+  };
 
   return (
-    <aside className="panel playback-practice-rail">
+    <aside
+      className="panel playback-practice-rail"
+      onBlur={(event) => {
+        const nextTarget = event.relatedTarget;
+        if (!(nextTarget instanceof Node) || !event.currentTarget.contains(nextTarget)) {
+          flushPendingTempoCommit();
+        }
+      }}
+    >
       <div
         aria-label="Playback rail shortcuts"
         className="playback-practice-rail__focus-icons"
@@ -205,7 +305,7 @@ export function PlaybackPracticeRail() {
           <button
             className="button button--ghost button--small"
             disabled={!canUseTempo || tempoTargetBpm === null}
-            onClick={handleResetPlaybackTempo}
+            onClick={handleTempoReset}
             type="button"
           >
             Reset
@@ -214,20 +314,39 @@ export function PlaybackPracticeRail() {
         <div className="playback-tempo-control__stepper" role="group" aria-label="Playback tempo BPM">
           <button
             aria-label="Decrease playback tempo"
-            disabled={!canUseTempo || tempoDisplayBpm === null || tempoDisplayBpm <= tempoMinBpm}
-            onClick={handleDecreasePlaybackTempo}
+            disabled={!canDecreaseTempo}
+            onClick={() => scheduleTempoCommit(tempoDraftNumeric - 1)}
             type="button"
           >
             -
           </button>
-          <strong aria-live="polite">
-            {tempoDisplayLabel}
+          <label aria-label="Playback BPM input" className="playback-tempo-control__input-wrap">
+            <input
+              aria-live="polite"
+              aria-label="Playback BPM"
+              className="playback-tempo-control__input"
+              disabled={!canUseTempo || tempoDisplayBpm === null}
+              max={tempoMaxBpm}
+              min={tempoMinBpm}
+              onBlur={() => {
+                if (skipNextTempoBlurCommit.current) {
+                  skipNextTempoBlurCommit.current = false;
+                  return;
+                }
+                commitTempoFromInput();
+              }}
+              onChange={(event) => setTempoDraftText(event.target.value)}
+              onKeyDown={handleTempoInputKeyDown}
+              step={1}
+              type="number"
+              value={tempoDraftText}
+            />
             <span>BPM</span>
-          </strong>
+          </label>
           <button
             aria-label="Increase playback tempo"
-            disabled={!canUseTempo || tempoDisplayBpm === null || tempoDisplayBpm >= tempoMaxBpm}
-            onClick={handleIncreasePlaybackTempo}
+            disabled={!canIncreaseTempo}
+            onClick={() => scheduleTempoCommit(tempoDraftNumeric + 1)}
             type="button"
           >
             +

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -61,6 +61,7 @@ import {
   MAX_PLAYBACK_TEMPO_BPM,
   MIN_PLAYBACK_TEMPO_BPM,
   normalizeTempoBpm,
+  normalizeTempoTargetBpm,
   tempoPlaybackRate,
   tempoTargetBpmFromStep,
 } from "../playbackTempo";
@@ -985,25 +986,39 @@ export function useProjectViewModel() {
     if (!canUseTempo) {
       return;
     }
-    setTempoTargetBpm((current) =>
-      tempoTargetBpmFromStep({
+    setTempoTargetBpm((current) => {
+      const next = tempoTargetBpmFromStep({
         currentTargetBpm: current,
         delta: -1,
         originalBpm: tempoOriginalBpm,
-      }),
-    );
+      });
+      return next === null ? null : Math.max(MIN_PLAYBACK_TEMPO_BPM, Math.min(MAX_PLAYBACK_TEMPO_BPM, next));
+    });
   }
 
   function handleIncreasePlaybackTempo() {
     if (!canUseTempo) {
       return;
     }
-    setTempoTargetBpm((current) =>
-      tempoTargetBpmFromStep({
+    setTempoTargetBpm((current) => {
+      const next = tempoTargetBpmFromStep({
         currentTargetBpm: current,
         delta: 1,
         originalBpm: tempoOriginalBpm,
-      }),
+      });
+      return next === null ? null : Math.max(MIN_PLAYBACK_TEMPO_BPM, Math.min(MAX_PLAYBACK_TEMPO_BPM, next));
+    });
+  }
+
+  function handleSetPlaybackTempo(targetBpm: number | null) {
+    if (!canUseTempo) {
+      return;
+    }
+    const normalizedTargetBpm = targetBpm === null ? null : normalizeTempoTargetBpm(targetBpm);
+    setTempoTargetBpm(() =>
+      normalizedTargetBpm === null
+        ? null
+        : Math.max(MIN_PLAYBACK_TEMPO_BPM, Math.min(MAX_PLAYBACK_TEMPO_BPM, normalizedTargetBpm)),
     );
   }
 
@@ -1891,6 +1906,7 @@ export function useProjectViewModel() {
     handleSetPrecountClickCount,
     handleSetPrecountEnabled,
     handleIncreasePlaybackTempo,
+    handleSetPlaybackTempo,
     handleAcceptTabSuggestionGroup,
     handleApplyTabSuggestions,
     handleCloseTabImport,

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -46,8 +46,10 @@ import {
 } from "./playbackPersistence";
 import { normalizePrecountClickCount } from "./projectPlaybackState";
 import {
+  MEDIA_PLAYBACK_RATE_RAMP_MS,
   PRIMARY_MEDIA_KEY,
   SEEK_TOLERANCE_SECONDS,
+  STEM_PLAYBACK_CROSSFADE_SECONDS,
   clampTime,
   playbackRateForSession,
   playbackSignature,
@@ -92,12 +94,91 @@ type NativePlaybackState = {
   playbackSignature: string | null;
 };
 
-function applyMediaElementPlaybackRate(element: HTMLAudioElement, playbackRate: number) {
+const mediaPlaybackRateRampFrames = new WeakMap<
+  HTMLAudioElement,
+  { frameId: number; targetPlaybackRate: number }
+>();
+
+function cancelMediaElementPlaybackRateRamp(element: HTMLAudioElement) {
+  const activeRamp = mediaPlaybackRateRampFrames.get(element);
+  if (!activeRamp || typeof window === "undefined") {
+    return;
+  }
+  window.cancelAnimationFrame(activeRamp.frameId);
+  mediaPlaybackRateRampFrames.delete(element);
+}
+
+function applyMediaElementPlaybackRate(
+  element: HTMLAudioElement,
+  playbackRate: number,
+  { ramp = false }: { ramp?: boolean } = {},
+) {
   const pitchPreservingElement = element as PitchPreservingAudioElement;
   pitchPreservingElement.preservesPitch = true;
   pitchPreservingElement.mozPreservesPitch = true;
   pitchPreservingElement.webkitPreservesPitch = true;
-  element.playbackRate = playbackRate;
+  if (!ramp || typeof window === "undefined") {
+    const activeRamp = mediaPlaybackRateRampFrames.get(element);
+    if (
+      activeRamp &&
+      Math.abs(activeRamp.targetPlaybackRate - playbackRate) <= 0.0001
+    ) {
+      return;
+    }
+    cancelMediaElementPlaybackRateRamp(element);
+    element.playbackRate = playbackRate;
+    return;
+  }
+
+  cancelMediaElementPlaybackRateRamp(element);
+  const initialPlaybackRate = element.playbackRate;
+  if (Math.abs(initialPlaybackRate - playbackRate) <= 0.0001) {
+    element.playbackRate = playbackRate;
+    return;
+  }
+
+  let startTimestamp: number | null = null;
+  const scheduleStep = () => {
+    const frameId = window.requestAnimationFrame((timestamp) => {
+      startTimestamp ??= timestamp;
+      const progress = Math.min(
+        1,
+        (timestamp - startTimestamp) / MEDIA_PLAYBACK_RATE_RAMP_MS,
+      );
+      element.playbackRate =
+        initialPlaybackRate + (playbackRate - initialPlaybackRate) * progress;
+      if (progress < 1) {
+        scheduleStep();
+        return;
+      }
+      mediaPlaybackRateRampFrames.delete(element);
+      element.playbackRate = playbackRate;
+    });
+    mediaPlaybackRateRampFrames.set(element, { frameId, targetPlaybackRate: playbackRate });
+  };
+  scheduleStep();
+}
+
+function setGainValue(gainNode: GainNode, value: number) {
+  gainNode.gain.value = value;
+}
+
+function rampGainValue(
+  gainNode: GainNode,
+  context: AudioContext,
+  value: number,
+  durationSeconds: number,
+) {
+  const gainParam = gainNode.gain;
+  if (typeof gainParam.linearRampToValueAtTime !== "function") {
+    setGainValue(gainNode, value);
+    return;
+  }
+
+  const startTime = context.currentTime;
+  gainParam.cancelScheduledValues(startTime);
+  gainParam.setValueAtTime(gainParam.value, startTime);
+  gainParam.linearRampToValueAtTime(value, startTime + durationSeconds);
 }
 
 function isTauriRuntime() {
@@ -208,6 +289,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           shouldPlay: restoredPlaybackState.isPlaying,
           targetTime: restoredPlaybackState.playbackTimeSeconds,
           awaitSeekBeforePlay: true,
+          crossfadeStemPlayback: false,
           awaitingLoadKeys: [],
           awaitingSeekKeys: [],
           forceSeekKeys: [],
@@ -542,6 +624,9 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         rememberNativePlaybackError(
           snapshot.fallbackReason ?? "Native playback start fell back to Web Audio.",
         );
+        nativePlaybackRef.current.blockedSessionSignature = sessionSignature;
+        markNativePlaybackInactive();
+        void requestNativeStop();
         return false;
       }
       const capabilities = await getNativeAudioCapabilityState();
@@ -794,15 +879,70 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     });
   });
 
-  const disposeStemPlaybackState = useStableCallback(function disposeStemPlaybackState() {
+  const fadeOutStemPlaybackState = useStableCallback(function fadeOutStemPlaybackState(
+    targetPlaybackState: StemPlaybackState,
+  ) {
+    const nextTime = getStemPlaybackTime(targetPlaybackState);
+    clearStemClock(targetPlaybackState);
+    targetPlaybackState.offsetSeconds = nextTime;
+    targetPlaybackState.startedAtContextTime = targetPlaybackState.context.currentTime;
+    targetPlaybackState.isPlaying = false;
+    syncStemElementTimes(targetPlaybackState.artifactIds, nextTime);
+
+    if (typeof window === "undefined") {
+      stopStemSources(targetPlaybackState, true);
+      disconnectStemGains(targetPlaybackState);
+      return;
+    }
+
+    const sources = targetPlaybackState.sources;
+    targetPlaybackState.sources = {};
+    const stopTime =
+      targetPlaybackState.context.currentTime + STEM_PLAYBACK_CROSSFADE_SECONDS;
+    Object.values(targetPlaybackState.gains).forEach((gainNode) => {
+      rampGainValue(
+        gainNode,
+        targetPlaybackState.context,
+        0,
+        STEM_PLAYBACK_CROSSFADE_SECONDS,
+      );
+    });
+    Object.values(sources).forEach((source) => {
+      source.onended = null;
+      try {
+        source.stop(stopTime);
+      } catch {
+        return;
+      }
+    });
+    window.setTimeout(() => {
+      Object.values(sources).forEach((source) => {
+        try {
+          source.disconnect();
+        } catch {
+          return;
+        }
+      });
+      disconnectStemGains(targetPlaybackState);
+    }, STEM_PLAYBACK_CROSSFADE_SECONDS * 1000);
+  });
+
+  const disposeStemPlaybackState = useStableCallback(function disposeStemPlaybackState(
+    { crossfade = false }: { crossfade?: boolean } = {},
+  ) {
     const targetPlaybackState = stemPlaybackRef.current;
     if (!targetPlaybackState) {
       return;
     }
 
+    stemPlaybackRef.current = null;
+    if (crossfade && targetPlaybackState.isPlaying) {
+      fadeOutStemPlaybackState(targetPlaybackState);
+      return;
+    }
+
     stopStemSources(targetPlaybackState, true);
     disconnectStemGains(targetPlaybackState);
-    stemPlaybackRef.current = null;
   });
 
   const closePlaybackAudioContext = useStableCallback(function closePlaybackAudioContext() {
@@ -870,6 +1010,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     targetSession: ProjectPlaybackSession,
     timeSeconds: number,
     scheduledStartTimeSeconds?: number,
+    { fadeIn = false }: { fadeIn?: boolean } = {},
   ) {
     if (!canUseBufferedClock(targetSession)) {
       return false;
@@ -938,7 +1079,15 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     targetPlaybackState.startedAtContextTime = clockStartTimeSeconds;
     targetPlaybackState.isPlaying = true;
     syncStemElementTimes(targetPlaybackState.artifactIds, nextTime);
-    applyStemVolumes(targetSession);
+    if (fadeIn) {
+      targetPlaybackState.artifactIds.forEach((artifactId) => {
+        const gainNode = targetPlaybackState.gains[artifactId];
+        if (gainNode) {
+          setGainValue(gainNode, 0);
+        }
+      });
+    }
+    applyStemVolumes(targetSession, { rampGains: fadeIn });
 
     let scheduledCount = 0;
     try {
@@ -1016,15 +1165,17 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
   const applyMediaPlaybackRate = useStableCallback(function applyMediaPlaybackRate(
     targetSession: ProjectPlaybackSession | null = sessionRef.current,
+    { ramp = false }: { ramp?: boolean } = {},
   ) {
     const playbackRate = playbackRateForSession(targetSession);
     getRenderedMediaElements(targetSession).forEach((element) => {
-      applyMediaElementPlaybackRate(element, playbackRate);
+      applyMediaElementPlaybackRate(element, playbackRate, { ramp });
     });
   });
 
   const applyStemVolumes = useStableCallback(function applyStemVolumes(
     targetSession: ProjectPlaybackSession | null = sessionRef.current,
+    { rampGains = false }: { rampGains?: boolean } = {},
   ) {
     if (!targetSession) {
       return;
@@ -1062,7 +1213,16 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           : 1;
         const gainNode = targetPlaybackState.gains[artifactId];
         if (gainNode) {
-          gainNode.gain.value = volume;
+          if (rampGains) {
+            rampGainValue(
+              gainNode,
+              targetPlaybackState.context,
+              volume,
+              STEM_PLAYBACK_CROSSFADE_SECONDS,
+            );
+          } else {
+            setGainValue(gainNode, volume);
+          }
         }
       });
     }
@@ -1303,7 +1463,9 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           return;
         }
 
-        const started = await startStemPlayback(latestSession, nextTime);
+        const started = await startStemPlayback(latestSession, nextTime, undefined, {
+          fadeIn: latestPendingTransition.crossfadeStemPlayback,
+        });
         if (started) {
           return;
         }
@@ -1533,6 +1695,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         shouldPlay: true,
         targetTime: masterTime,
         awaitSeekBeforePlay: true,
+        crossfadeStemPlayback: false,
         awaitingLoadKeys: activeKeys,
         awaitingSeekKeys: activeKeys,
         forceSeekKeys: activeKeys,
@@ -1831,6 +1994,81 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       const carriesNativeSession =
         previousUsesNative &&
         nativeSessionSignature(previousSession) === nativeSessionSignature(nextSession);
+      const nextNativeSessionSignature = nativeSessionSignature(nextSession);
+      if (samePlaybackTarget && carriesNativeSession) {
+        clearPendingTransition();
+        nativePlaybackRef.current = {
+          ...nativePlaybackRef.current,
+          playbackSignature: nextSignature,
+        };
+        sessionRef.current = nextSession;
+        setSession(nextSession);
+        setPlaybackTimeSeconds(nextTime);
+        setPlaybackDurationSeconds(nextSession.durationHintSeconds || playbackDurationSecondsRef.current);
+
+        const fallbackFromNativeLaneUpdate = (message: string) => {
+          const latestSession = sessionRef.current;
+          if (
+            !latestSession ||
+            playbackSignature(latestSession) !== nextSignature ||
+            nativeSessionSignature(latestSession) !== nextNativeSessionSignature
+          ) {
+            return;
+          }
+
+          rememberNativePlaybackError(message);
+          nativePlaybackRef.current.blockedSessionSignature = nextNativeSessionSignature;
+          markNativePlaybackInactive();
+          const fallbackTime = clampTime(
+            playbackTimeSecondsRef.current,
+            playbackDurationSecondsRef.current || latestSession.durationHintSeconds || 0,
+          );
+          void requestNativeStop();
+          syncStemElementTimes(latestSession.visibleStemArtifactIds, fallbackTime);
+          getRenderedMediaElements(latestSession).forEach((element) => {
+            element.pause();
+            element.currentTime = fallbackTime;
+          });
+          setPlaybackTimeSeconds(fallbackTime);
+          setIsPlaying(false);
+          if (shouldPlay) {
+            void playPlaybackImmediately();
+          }
+        };
+
+        void setNativeAudioLanes(nativeLaneUpdateForSession(nextSession))
+          .then((snapshot) => {
+            const latestSession = sessionRef.current;
+            if (
+              !latestSession ||
+              playbackSignature(latestSession) !== nextSignature ||
+              nativeSessionSignature(latestSession) !== nextNativeSessionSignature
+            ) {
+              return;
+            }
+            if (!snapshot.nativePlaybackSupported) {
+              fallbackFromNativeLaneUpdate(
+                snapshot.fallbackReason ?? "Native playback lane update fell back to Web Audio.",
+              );
+              return;
+            }
+
+            nativePlaybackRef.current = {
+              ...nativePlaybackRef.current,
+              active: snapshot.state === "playing",
+              blockedSessionSignature: null,
+              playbackSignature: nextSignature,
+            };
+            clearRememberedNativePlaybackError();
+            setPlaybackTimeSeconds(snapshot.positionSeconds);
+            setPlaybackDurationSeconds(snapshot.durationSeconds || latestSession.durationHintSeconds || 0);
+            setIsPlaying(snapshot.state === "playing");
+          })
+          .catch((error) => {
+            fallbackFromNativeLaneUpdate(playbackErrorMessage(error));
+          });
+        return;
+      }
       if (previousUsesNative && !carriesNativeSession) {
         void requestNativeStop();
         markNativePlaybackInactive();
@@ -1851,7 +2089,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           pendingTransition.signature = nextSignature;
           pendingTransition.shouldPlay = pendingTransition.shouldPlay || shouldPlay;
         }
-        applyMediaPlaybackRate(nextSession);
+        applyMediaPlaybackRate(nextSession, { ramp: shouldPlay });
         sessionRef.current = nextSession;
         setSession(nextSession);
         return;
@@ -1864,19 +2102,25 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           ? [PRIMARY_MEDIA_KEY]
           : [];
       const forceSeekKeys = primarySwap ? [PRIMARY_MEDIA_KEY] : [];
+      const shouldCrossfadeStemPlayback = shouldPlay && previousUsesBufferedClock;
       if (
         shouldPlay &&
-        (!samePlaybackTarget || previousUsesBufferedClock || nextUsesBufferedClock)
+        !shouldCrossfadeStemPlayback &&
+        (previousUsesBufferedClock || nextUsesBufferedClock)
       ) {
         getActiveMediaElements(previousSession).forEach((element) => element.pause());
       }
-      disposeStemPlaybackState();
+      disposeStemPlaybackState({ crossfade: shouldCrossfadeStemPlayback });
       pendingTransitionRef.current = {
         id: ++transitionCounterRef.current,
         signature: nextSignature,
         shouldPlay,
         targetTime: nextTime,
         awaitSeekBeforePlay: !samePlaybackTarget,
+        crossfadeStemPlayback:
+          shouldPlay &&
+          nextUsesBufferedClock &&
+          (previousUsesBufferedClock || !samePlaybackTarget),
         awaitingLoadKeys,
         awaitingSeekKeys,
         forceSeekKeys,
@@ -1900,6 +2144,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     getActiveMediaElements,
     getRenderedMediaElements,
     markNativePlaybackInactive,
+    playPlaybackImmediately,
     readMasterTime,
     requestNativeStop,
     syncStemElementTimes,
@@ -1975,7 +2220,11 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       }),
       listenNativeAudioErrors((error) => {
         const activeSession = sessionRef.current;
-        if (!activeSession || !nativePlaybackRef.current.active) {
+        if (
+          !activeSession ||
+          !nativePlaybackRef.current.active ||
+          error.sessionId !== nativePlaybackRef.current.sessionSignature
+        ) {
           return;
         }
         rememberNativePlaybackError(error.message);

--- a/apps/desktop/src/features/projects/playbackUtils.ts
+++ b/apps/desktop/src/features/projects/playbackUtils.ts
@@ -10,11 +10,14 @@ export type PendingTransition = {
   shouldPlay: boolean;
   targetTime: number;
   awaitSeekBeforePlay: boolean;
+  crossfadeStemPlayback: boolean;
   awaitingLoadKeys: string[];
   awaitingSeekKeys: string[];
   forceSeekKeys: string[];
 };
 
+export const MEDIA_PLAYBACK_RATE_RAMP_MS = 64;
+export const STEM_PLAYBACK_CROSSFADE_SECONDS = 0.05;
 const SEEK_TOLERANCE_SECONDS = 0.001;
 const PRIMARY_MEDIA_KEY = "__primary__";
 

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -11,7 +11,9 @@ import {
 } from "../../lib/playbackDiagnostics";
 import {
   getNativeAudioCapabilities,
+  getNativeAudioSnapshot,
   isWebAudioBackendForced,
+  type NativeAudioBufferHealth,
   type NativeAudioCapabilities,
 } from "../../lib/nativeAudio";
 import { TunerPreferenceControls } from "../tools/TunerPreferenceControls";
@@ -274,6 +276,29 @@ function lastPlaybackBackendLabel(backend: PlaybackBackend | null) {
     : "Web Audio";
 }
 
+function nativePlaybackHealthLabel(
+  health: NativeAudioBufferHealth[] | undefined,
+  webAudioForced: boolean,
+) {
+  if (webAudioForced) {
+    return "Web Audio forced";
+  }
+  if (!health?.length) {
+    return "No active native lanes";
+  }
+  return health
+    .map((lane) => {
+      const label = lane.artifactId ?? lane.laneId;
+      const fillPercent =
+        lane.ringCapacitySamples > 0
+          ? Math.round((lane.ringFillSamples / lane.ringCapacitySamples) * 100)
+          : 0;
+      const error = lane.lastWorkerError ? `, last worker error: ${lane.lastWorkerError}` : "";
+      return `${label}: ${fillPercent}% buffer, ${lane.underrunCount} underruns, ${lane.workerErrorCount} worker errors${error}`;
+    })
+    .join(" / ");
+}
+
 function diagnosticVersionValue(value: string | undefined) {
   const normalized = value?.trim();
   return normalized ? normalized : "Unknown";
@@ -441,10 +466,17 @@ export function SettingsView() {
     queryFn: getNativeAudioCapabilities,
     enabled: !webAudioForced,
   });
+  const nativeAudioSnapshotQuery = useQuery({
+    queryKey: ["native-audio-snapshot", webAudioForced],
+    queryFn: getNativeAudioSnapshot,
+    enabled: !webAudioForced,
+  });
   const lastInputCaptureBackend = readRememberedTunerInputCaptureBackend();
   const lastNativeCaptureError = readRememberedTunerNativeCaptureError();
   const lastPlaybackBackend = readRememberedPlaybackBackend();
   const lastNativePlaybackError = readRememberedNativePlaybackError();
+  const latestNativeFallbackCause =
+    lastNativePlaybackError ?? nativeAudioSnapshotQuery.data?.fallbackReason ?? "None";
   const savedThemeOverrideCount = themeOverrideCount(themeOverrides);
   const chordBackendChoices = chordBackendOptions(chordBackendsQuery.data?.backends);
   const stemModelChoices = stemModelOptions(stemModelsQuery.data?.models);
@@ -882,6 +914,18 @@ export function SettingsView() {
             <div>
               <dt>Last Native Playback Error</dt>
               <dd>{lastNativePlaybackError ?? "None"}</dd>
+            </div>
+            <div>
+              <dt>Latest Native Fallback Cause</dt>
+              <dd>{latestNativeFallbackCause}</dd>
+            </div>
+            <div>
+              <dt>Native Playback Buffer Health</dt>
+              <dd>
+                {nativeAudioSnapshotQuery.isError
+                  ? "Unavailable"
+                  : nativePlaybackHealthLabel(nativeAudioSnapshotQuery.data?.bufferHealth, webAudioForced)}
+              </dd>
             </div>
           </dl>
         </details>

--- a/apps/desktop/src/lib/nativeAudio.test.ts
+++ b/apps/desktop/src/lib/nativeAudio.test.ts
@@ -68,6 +68,7 @@ const snapshot: NativeAudioSnapshot = {
   nativePlaybackSupported: false,
   fallbackReason: "Native audio playback is not wired yet; use existing WebView playback.",
   lanes: [],
+  bufferHealth: [],
 };
 
 const inputState: NativeAudioInputState = {

--- a/apps/desktop/src/lib/nativeAudio.ts
+++ b/apps/desktop/src/lib/nativeAudio.ts
@@ -85,6 +85,17 @@ export type NativeAudioLane = {
   solo: boolean;
 };
 
+export type NativeAudioBufferHealth = {
+  laneId: string;
+  artifactId: string | null;
+  role: NativeAudioLaneRole;
+  ringFillSamples: number;
+  ringCapacitySamples: number;
+  underrunCount: number;
+  workerErrorCount: number;
+  lastWorkerError: string | null;
+};
+
 export type NativeAudioSnapshot = {
   sessionId: string | null;
   state: "stopped" | "playing" | "paused";
@@ -94,6 +105,7 @@ export type NativeAudioSnapshot = {
   nativePlaybackSupported: boolean;
   fallbackReason: string | null;
   lanes: NativeAudioLane[];
+  bufferHealth: NativeAudioBufferHealth[];
 };
 
 export type NativeAudioClickRequest = {

--- a/apps/desktop/src/styles/project-playback.css
+++ b/apps/desktop/src/styles/project-playback.css
@@ -914,7 +914,7 @@
 }
 
 .playback-tempo-control__stepper button,
-.playback-tempo-control__stepper strong {
+.playback-tempo-control__input-wrap {
   display: inline-grid;
   min-height: 2.8rem;
   place-items: center;
@@ -934,16 +934,37 @@
   opacity: 0.56;
 }
 
-.playback-tempo-control__stepper strong {
+.playback-tempo-control__input-wrap {
   gap: 0.1rem;
   background: color-mix(in srgb, var(--panel-strong) 76%, transparent);
   font-size: 1.25rem;
 }
 
-.playback-tempo-control__stepper strong span {
+.playback-tempo-control__input-wrap span {
   color: var(--muted);
   font-size: 0.72rem;
   font-weight: 800;
+}
+
+.playback-tempo-control__input {
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  font-size: 1.25rem;
+  font: inherit;
+  width: 100%;
+  text-align: center;
+  -moz-appearance: textfield;
+}
+
+.playback-tempo-control__input::-webkit-outer-spin-button,
+.playback-tempo-control__input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.playback-tempo-control__input:disabled {
+  opacity: 0.56;
 }
 
 .playback-tempo-control__summary {

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -47,7 +47,9 @@ const {
   mockGetMobileCapabilities,
   setMockSystemInputVolume,
   setMockNativeAudio,
+  emitMockNativeAudioError,
   emitMockNativeAudioInputFrame,
+  emitMockNativeAudioPosition,
   mockListen,
 } = vi.hoisted(() => {
   const createdAt = "2026-04-18T13:16:00.000Z";
@@ -63,11 +65,34 @@ const {
     id: number;
     payload: NativeAudioInputFrame;
   };
+  type NativeAudioPositionPayload = {
+    sessionId: string | null;
+    positionSeconds: number;
+    durationSeconds: number;
+    state: "stopped" | "playing" | "paused";
+  };
+  type NativeAudioErrorPayload = {
+    sessionId: string | null;
+    message: string;
+  };
+  type NativeAudioRuntimeEvent = {
+    event: "audio://position" | "audio://ended" | "audio://error";
+    id: number;
+    payload: Record<string, unknown>;
+  };
   const nativeInputFrameListeners = new Map<
     number,
     (event: NativeAudioInputFrameEvent) => void
   >();
+  const nativeRuntimeListeners = new Map<
+    number,
+    {
+      eventName: NativeAudioRuntimeEvent["event"];
+      handler: (event: NativeAudioRuntimeEvent) => void;
+    }
+  >();
   let nextNativeInputFrameListenerId = 1;
+  let nextNativeRuntimeListenerId = 1;
   let state: {
     projects: Array<Record<string, unknown>>;
     analysisByProject: Record<string, Record<string, unknown> | null>;
@@ -98,7 +123,9 @@ const {
       inputLevel: number;
       sampleRate: number | null;
     };
+    nativeAudioSnapshot: Record<string, unknown>;
     nativeAudioStartError: string | null;
+    nativeAudioPlayFallbackReason: string | null;
     nextProjectId: number;
     nextArtifactId: number;
     nextJobId: number;
@@ -427,7 +454,19 @@ const {
         inputLevel: 0,
         sampleRate: null,
       },
+      nativeAudioSnapshot: {
+        sessionId: null,
+        state: "stopped",
+        positionSeconds: 0,
+        durationSeconds: 0,
+        playbackRate: 1,
+        nativePlaybackSupported: false,
+        fallbackReason: "Native audio playback is not wired yet; use existing WebView playback.",
+        lanes: [],
+        bufferHealth: [],
+      },
       nativeAudioStartError: null,
+      nativeAudioPlayFallbackReason: null,
       nextProjectId: 200,
       nextArtifactId: 200,
       nextJobId: 200,
@@ -436,7 +475,9 @@ const {
       deferPreviewCompletion: false,
     };
     nativeInputFrameListeners.clear();
+    nativeRuntimeListeners.clear();
     nextNativeInputFrameListenerId = 1;
+    nextNativeRuntimeListenerId = 1;
   }
 
   resetMockApiState();
@@ -464,7 +505,9 @@ const {
     capabilities?: Record<string, unknown>;
     inputDevices?: Record<string, unknown>;
     inputState?: Partial<typeof state.nativeAudioInputState>;
+    snapshot?: Record<string, unknown>;
     startError?: string | null;
+    playFallbackReason?: string | null;
   }) {
     state.nativeAudioCapabilities = {
       ...state.nativeAudioCapabilities,
@@ -478,9 +521,39 @@ const {
       ...state.nativeAudioInputState,
       ...nextState.inputState,
     };
+    state.nativeAudioSnapshot = {
+      ...state.nativeAudioSnapshot,
+      ...nextState.snapshot,
+    };
     if ("startError" in nextState) {
       state.nativeAudioStartError = nextState.startError ?? null;
     }
+    if ("playFallbackReason" in nextState) {
+      state.nativeAudioPlayFallbackReason = nextState.playFallbackReason ?? null;
+    }
+  }
+  function effectiveNativeAudioLanes(
+    lanes: Array<{
+      id: string;
+      artifactId?: string | null;
+      role: string;
+      gain: number;
+      muted: boolean;
+      solo: boolean;
+    }>,
+  ) {
+    const hasSolo = lanes.some((lane) => lane.solo);
+    return lanes.map((lane) => {
+      const active = hasSolo ? lane.solo : !lane.muted;
+      return {
+        id: lane.id,
+        artifactId: lane.artifactId ?? null,
+        role: lane.role,
+        effectiveGain: active ? Math.max(0, Math.min(1, lane.gain)) : 0,
+        muted: lane.muted,
+        solo: lane.solo,
+      };
+    });
   }
   function emitMockNativeAudioInputFrame(frame: NativeAudioInputFrame) {
     nativeInputFrameListeners.forEach((listener, id) => {
@@ -491,24 +564,54 @@ const {
       });
     });
   }
+  function emitMockNativeAudioPosition(position: NativeAudioPositionPayload) {
+    emitMockNativeRuntimeEvent("audio://position", position);
+  }
+  function emitMockNativeAudioError(error: NativeAudioErrorPayload) {
+    emitMockNativeRuntimeEvent("audio://error", error);
+  }
+  function emitMockNativeRuntimeEvent(
+    eventName: NativeAudioRuntimeEvent["event"],
+    payload: Record<string, unknown>,
+  ) {
+    nativeRuntimeListeners.forEach((listener, id) => {
+      if (listener.eventName !== eventName) {
+        return;
+      }
+      listener.handler({
+        event: eventName,
+        id,
+        payload: clone(payload),
+      });
+    });
+  }
   const mockListen = vi.fn(
     async (
       eventName: string,
-      handler: (event: NativeAudioInputFrameEvent) => void,
+      handler: (event: NativeAudioInputFrameEvent | NativeAudioRuntimeEvent) => void,
     ) => {
       if (
         eventName === "audio://position" ||
         eventName === "audio://ended" ||
         eventName === "audio://error"
       ) {
-        return () => undefined;
+        const listenerId = nextNativeRuntimeListenerId;
+        nextNativeRuntimeListenerId += 1;
+        nativeRuntimeListeners.set(listenerId, {
+          eventName,
+          handler: handler as (event: NativeAudioRuntimeEvent) => void,
+        });
+        return () => nativeRuntimeListeners.delete(listenerId);
       }
       if (eventName !== "audio://input-frame") {
         throw new Error(`Unexpected listen event: ${eventName}`);
       }
       const listenerId = nextNativeInputFrameListenerId;
       nextNativeInputFrameListenerId += 1;
-      nativeInputFrameListeners.set(listenerId, handler);
+      nativeInputFrameListeners.set(
+        listenerId,
+        handler as (event: NativeAudioInputFrameEvent) => void,
+      );
       return () => nativeInputFrameListeners.delete(listenerId);
     },
   );
@@ -558,6 +661,136 @@ const {
 
     if (command === "audio_get_input_state") {
       return clone(state.nativeAudioInputState);
+    }
+
+    if (command === "audio_prepare_session") {
+      const payload = (args?.payload ?? {}) as {
+        sessionId?: string;
+        durationSeconds?: number | null;
+        playbackRate?: number | null;
+        lanes?: Array<{
+          id: string;
+          artifactId?: string | null;
+          role: string;
+          gain: number;
+          muted: boolean;
+          solo: boolean;
+        }>;
+      };
+      const nativePlaybackSupported = state.nativeAudioCapabilities.nativePlaybackSupported === true;
+      const fallbackReason =
+        nativePlaybackSupported
+          ? null
+          : String(state.nativeAudioCapabilities.fallbackReason ?? "Native audio playback is unavailable.");
+      const lanes = effectiveNativeAudioLanes(payload.lanes ?? []);
+      state.nativeAudioSnapshot = {
+        ...state.nativeAudioSnapshot,
+        sessionId: payload.sessionId ?? null,
+        state: "stopped",
+        positionSeconds: 0,
+        durationSeconds: payload.durationSeconds ?? 0,
+        playbackRate: payload.playbackRate ?? 1,
+        nativePlaybackSupported,
+        fallbackReason,
+        lanes,
+        bufferHealth: (payload.lanes ?? []).map((lane) => ({
+          laneId: lane.id,
+          artifactId: lane.artifactId ?? null,
+          role: lane.role,
+          ringFillSamples: 0,
+          ringCapacitySamples: 0,
+          underrunCount: 0,
+          workerErrorCount: 0,
+          lastWorkerError: null,
+        })),
+      };
+      return {
+        id: payload.sessionId ?? "session",
+        nativePlaybackSupported,
+        fallbackReason,
+        laneCount: lanes.length,
+      };
+    }
+
+    if (command === "audio_play") {
+      const payload = (args?.payload ?? {}) as { startTimeSeconds?: number | null };
+      if (state.nativeAudioPlayFallbackReason) {
+        state.nativeAudioSnapshot = {
+          ...state.nativeAudioSnapshot,
+          state: "paused",
+          nativePlaybackSupported: false,
+          fallbackReason: state.nativeAudioPlayFallbackReason,
+          positionSeconds: payload.startTimeSeconds ?? Number(state.nativeAudioSnapshot.positionSeconds ?? 0),
+        };
+        return clone(state.nativeAudioSnapshot);
+      }
+      state.nativeAudioSnapshot = {
+        ...state.nativeAudioSnapshot,
+        state: "playing",
+        positionSeconds: payload.startTimeSeconds ?? Number(state.nativeAudioSnapshot.positionSeconds ?? 0),
+      };
+      return clone(state.nativeAudioSnapshot);
+    }
+
+    if (command === "audio_pause") {
+      state.nativeAudioSnapshot = {
+        ...state.nativeAudioSnapshot,
+        state: "paused",
+      };
+      return clone(state.nativeAudioSnapshot);
+    }
+
+    if (command === "audio_stop") {
+      state.nativeAudioSnapshot = {
+        ...state.nativeAudioSnapshot,
+        state: "stopped",
+        positionSeconds: 0,
+      };
+      return clone(state.nativeAudioSnapshot);
+    }
+
+    if (command === "audio_seek") {
+      const payload = (args?.payload ?? {}) as { timeSeconds?: number };
+      state.nativeAudioSnapshot = {
+        ...state.nativeAudioSnapshot,
+        positionSeconds: payload.timeSeconds ?? 0,
+      };
+      return clone(state.nativeAudioSnapshot);
+    }
+
+    if (command === "audio_set_lanes") {
+      const payload = (args?.payload ?? {}) as {
+        playbackRate?: number | null;
+        lanes?: Array<{
+          id: string;
+          artifactId?: string | null;
+          role: string;
+          gain: number;
+          muted: boolean;
+          solo: boolean;
+        }>;
+      };
+      const lanes = effectiveNativeAudioLanes(payload.lanes ?? []);
+      state.nativeAudioSnapshot = {
+        ...state.nativeAudioSnapshot,
+        playbackRate: payload.playbackRate ?? Number(state.nativeAudioSnapshot.playbackRate ?? 1),
+        lanes,
+        bufferHealth: (payload.lanes ?? []).map((lane) => ({
+          laneId: lane.id,
+          artifactId: lane.artifactId ?? null,
+          role: lane.role,
+          ringFillSamples: 0,
+          ringCapacitySamples: 0,
+          underrunCount: 0,
+          workerErrorCount: 0,
+          lastWorkerError: null,
+        })),
+      };
+      return clone(state.nativeAudioSnapshot);
+    }
+
+    if (command === "audio_set_click" || command === "audio_get_snapshot") {
+      return clone(state.nativeAudioSnapshot);
     }
 
     if (command === "audio_start_input") {
@@ -1217,7 +1450,9 @@ const {
     mockGetMobileCapabilities,
     setMockSystemInputVolume,
     setMockNativeAudio,
+    emitMockNativeAudioError,
     emitMockNativeAudioInputFrame,
+    emitMockNativeAudioPosition,
     mockListen,
   };
 });
@@ -1489,6 +1724,18 @@ export function emitMockNativeInputFrame(
   frame: Parameters<typeof emitMockNativeAudioInputFrame>[0],
 ) {
   emitMockNativeAudioInputFrame(frame);
+}
+
+export function emitMockNativePlaybackPosition(
+  position: Parameters<typeof emitMockNativeAudioPosition>[0],
+) {
+  emitMockNativeAudioPosition(position);
+}
+
+export function emitMockNativePlaybackError(
+  error: Parameters<typeof emitMockNativeAudioError>[0],
+) {
+  emitMockNativeAudioError(error);
 }
 
 export function getMockMediaDevices() {

--- a/docs/NATIVE_AUDIO.md
+++ b/docs/NATIVE_AUDIO.md
@@ -69,6 +69,9 @@ Settings -> Local Data -> Show diagnostics reports:
 - playback backend
 - last playback backend
 - last native playback error
+- latest native fallback cause
+- native playback buffer health per lane, including fill level, underrun count, worker errors, and
+  the last worker error when present
 
 When `VITE_TUNEFORGE_FORCE_WEB_AUDIO=1` is active, diagnostics report `Web Audio (forced)`.
 


### PR DESCRIPTION
## Summary

- Fix native playback stem desync by tracking native lane buffer health and falling back to Web Audio on underruns.
- Stabilize native tempo changes, including preserving stretched samples when ring buffers are temporarily full.
- Add direct BPM entry with debounced tempo step handling.
- Expand regression coverage for native fallback, native tempo handling, and settings diagnostics.
- Document updated native playback diagnostics.

Closes #91.
Closes #78.
Closes #77.
Closes #76.

## Testing

- `./node_modules/.bin/vitest run`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `./node_modules/.bin/eslint .`
- `cd apps/desktop/src-tauri && cargo test --lib`
- `cd apps/desktop/src-tauri && cargo check`
- `git diff --check`
