### PR TITLE
test: report backend pytest durations

### DIFF
--- a/apps/backend/alembic/versions/0007_artifact_storage_metadata.py
+++ b/apps/backend/alembic/versions/0007_artifact_storage_metadata.py
@@ -13,6 +13,7 @@ depends_on = None
 
 
 def upgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS uq_artifacts_stem_per_source")
     with op.batch_alter_table("artifacts") as batch_op:
         batch_op.add_column(sa.Column("size_bytes", sa.Integer(), nullable=False, server_default="0"))
         batch_op.add_column(

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -43,6 +43,7 @@ select = ["E", "F", "I", "UP", "B"]
 ignore = ["B008"]
 
 [tool.pytest.ini_options]
+addopts = ["--durations=10"]
 pythonpath = ["."]
 testpaths = ["tests"]
 


### PR DESCRIPTION
## Summary

- Add backend pytest slowest-duration reporting by default.
- Drop the existing stem expression index before the `0007` batch migration reflection, then let the migration recreate it.
- Closes #87.

## Testing

- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `cd apps/backend && uv run --python 3.11 pytest`
- `cd apps/backend && uv run --python 3.11 pytest tests/test_projects.py::test_import_project_persists_metadata_and_source_artifact -q -o filterwarnings=error::sqlalchemy.exc.SAWarning`
- `cd apps/backend && uv run --python 3.11 pytest tests/test_db_migrations.py -q -o filterwarnings=error::sqlalchemy.exc.SAWarning`
- `git diff --check`
