### PR TITLE
fix: improve playback start and loop behavior

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint .",
     "tauri": "bash ../../scripts/run-tauri-command.sh",
     "test": "vitest",
+    "test:e2e": "node ../../scripts/playback-smoke.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -41,6 +42,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "jsdom": "^29.1.1",
+    "playwright": "^1.59.1",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.59.2",
     "vite": "^8.0.10",

--- a/apps/desktop/src-tauri/src/native_audio/transport.rs
+++ b/apps/desktop/src-tauri/src/native_audio/transport.rs
@@ -2255,6 +2255,49 @@ mod tests {
     }
 
     #[test]
+    fn seek_clamps_to_zero() {
+        let mut state = TransportState::default();
+        state.prepare(
+            None,
+            AudioSessionRequest {
+                session_id: "session".to_string(),
+                duration_seconds: Some(30.0),
+                playback_rate: Some(1.0),
+                lanes: Vec::new(),
+            },
+            Vec::new(),
+            capabilities(),
+        );
+
+        let snapshot = state.seek(AudioSeekRequest { time_seconds: -10.0 });
+
+        assert_eq!(snapshot.position_seconds, 0.0);
+    }
+
+    #[test]
+    fn stop_resets_transport_position() {
+        let mut state = TransportState::default();
+        state.prepare(
+            None,
+            AudioSessionRequest {
+                session_id: "session".to_string(),
+                duration_seconds: Some(30.0),
+                playback_rate: Some(1.0),
+                lanes: Vec::new(),
+            },
+            Vec::new(),
+            capabilities(),
+        );
+        state.position_seconds = 12.0;
+
+        let snapshot = state.stop();
+
+        assert_eq!(snapshot.position_seconds, 0.0);
+        assert_eq!(snapshot.state, "stopped");
+        assert_eq!(snapshot.playback_rate, 1.0);
+    }
+
+    #[test]
     fn pause_preserves_current_position() {
         let mut state = TransportState::default();
         state.prepare(

--- a/apps/desktop/src/App.project-analysis-mix.test.tsx
+++ b/apps/desktop/src/App.project-analysis-mix.test.tsx
@@ -6,6 +6,7 @@ import {
   findAudioByArtifactId,
   getAllByAriaKeyLabel,
   getByAriaKeyLabel,
+  getMockAudioContexts,
   markAudioReady,
   mockAnalyzeProject,
   mockConfirm,
@@ -1009,6 +1010,56 @@ describe("Desktop app project analysis mix", () => {
 
     expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
     expect(sourceAudio.currentTime).toBeCloseTo(8, 3);
+  });
+
+  it("starts transport playback from a stopped lyric selection", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    await openPlaybackWorkspace(user);
+    await switchToLyricsOnly(user);
+
+    const lyricsTranscript = screen.getByRole("group", { name: "Lyrics transcript" });
+    const secondLyric = within(lyricsTranscript).getByRole("button", { name: /0:08/i });
+    await user.click(secondLyric);
+    sourceAudio.currentTime = 0;
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    await waitFor(() => expect(getMockAudioContexts()[0]?.createdSources).toHaveLength(1));
+    expect(getMockAudioContexts()[0]?.createdSources[0]?.start.mock.calls[0]?.[1]).toBeCloseTo(
+      8,
+      3,
+    );
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+  });
+
+  it("starts transport playback from a stopped chord selection", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    await openPlaybackWorkspace(user);
+    await switchToChordsOnly(user);
+
+    const chordTimeline = screen.getByRole("group", { name: "Chord timeline" });
+    const secondChord = within(chordTimeline).getByRole("button", { name: /D\s*0:16/ });
+    await user.click(secondChord);
+    sourceAudio.currentTime = 0;
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    await waitFor(() => expect(getMockAudioContexts()[0]?.createdSources).toHaveLength(1));
+    expect(getMockAudioContexts()[0]?.createdSources[0]?.start.mock.calls[0]?.[1]).toBeCloseTo(
+      16,
+      3,
+    );
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
   });
 
   it("does not duplicate the detected key inside the project source key selector", async () => {

--- a/apps/desktop/src/App.project-playback-stems.test.tsx
+++ b/apps/desktop/src/App.project-playback-stems.test.tsx
@@ -322,6 +322,27 @@ describe("Desktop app project playback stems", () => {
     expect(screen.getByLabelText("Playback position")).toHaveValue("0");
   });
 
+  it("starts source playback from a stopped scrubber selection", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+
+    setPlaybackPosition("32.417");
+    sourceAudio.currentTime = 0;
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    await waitFor(() => expect(getMockAudioContexts()[0]?.createdSources).toHaveLength(1));
+    expect(getMockAudioContexts()[0]?.createdSources[0]?.start.mock.calls[0]?.[1]).toBeCloseTo(
+      32.417,
+      3,
+    );
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+  });
+
   it("cycles the source loop control and only persists a complete loop", async () => {
     const user = userEvent.setup();
     renderApp(["/projects/proj_123"]);

--- a/apps/desktop/src/App.project-precount.test.tsx
+++ b/apps/desktop/src/App.project-precount.test.tsx
@@ -61,6 +61,7 @@ describe("Desktop app project playback pre-count", () => {
     await openPlaybackWorkspace(user);
 
     expect(screen.getByLabelText("Enable pre-count")).toBeDisabled();
+    expect(screen.getByLabelText("Enable loop pre-count")).toBeDisabled();
     expect(screen.getByRole("group", { name: "Pre-count clicks" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Decrease pre-count clicks" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Increase pre-count clicks" })).toBeDisabled();
@@ -76,9 +77,11 @@ describe("Desktop app project playback pre-count", () => {
     await openPlaybackWorkspace(user);
 
     await user.click(screen.getByLabelText("Enable pre-count"));
+    await user.click(screen.getByLabelText("Enable loop pre-count"));
     await user.click(screen.getByRole("button", { name: "Increase pre-count clicks" }));
 
     expect(screen.getByLabelText("Enable pre-count")).toBeChecked();
+    expect(screen.getByLabelText("Enable loop pre-count")).toBeChecked();
     expect(screen.getByText("5 clicks at 120.0 BPM")).toBeInTheDocument();
 
     firstRender.unmount();
@@ -87,6 +90,7 @@ describe("Desktop app project playback pre-count", () => {
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
     await openPlaybackWorkspace(user);
     expect(screen.getByLabelText("Enable pre-count")).toBeChecked();
+    expect(screen.getByLabelText("Enable loop pre-count")).toBeChecked();
     expect(screen.getByText("5 clicks at 120.0 BPM")).toBeInTheDocument();
   });
 
@@ -183,6 +187,117 @@ describe("Desktop app project playback pre-count", () => {
       3,
     );
     expect(sourceAudio.currentTime).toBeCloseTo(12.5, 3);
+  });
+
+  it("does not pre-count when resuming after pause", async () => {
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByLabelText("Enable pre-count"));
+    fireEvent.click(screen.getByRole("button", { name: "Play playback" }));
+    await flushMicrotasks();
+
+    const audioContext = getMockAudioContexts()[0];
+    expect(audioContext?.createdOscillators).toHaveLength(4);
+
+    act(() => {
+      vi.advanceTimersByTime(2035);
+    });
+    await flushMicrotasks();
+    const sourceStartCount = audioContext?.createdSources.length ?? 0;
+    const oscillatorCount = audioContext?.createdOscillators.length ?? 0;
+    expect(sourceStartCount).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole("button", { name: "Pause playback" }));
+    fireEvent.click(screen.getByRole("button", { name: "Play playback" }));
+    await flushMicrotasks();
+
+    expect(audioContext?.createdSources.length).toBeGreaterThanOrEqual(sourceStartCount);
+    expect(audioContext?.createdOscillators).toHaveLength(oscillatorCount);
+    vi.useRealTimers();
+  }, 15000);
+
+  it("loop pre-counts from loop start on fresh playback and each loop wrap", async () => {
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    setPlaybackPosition("12.25");
+    await user.click(screen.getByRole("button", { name: "Set loop start" }));
+    setPlaybackPosition("24.5");
+    await user.click(screen.getByRole("button", { name: "Set loop end" }));
+
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    vi.useFakeTimers();
+
+    fireEvent.click(screen.getByLabelText("Enable loop pre-count"));
+    fireEvent.click(screen.getByRole("button", { name: "Play playback" }));
+    await flushMicrotasks();
+
+    const audioContext = getMockAudioContexts()[0];
+    expect(audioContext?.createdSources).toHaveLength(0);
+    expect(audioContext?.createdOscillators).toHaveLength(4);
+    act(() => {
+      vi.advanceTimersByTime(2035);
+    });
+    await flushMicrotasks();
+    expect(audioContext?.createdSources).toHaveLength(1);
+    expect(audioContext?.createdSources[0]?.start.mock.calls[0]?.[1]).toBeCloseTo(12.25, 3);
+    expect(sourceAudio.currentTime).toBeCloseTo(12.25, 3);
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+
+    act(() => {
+      sourceAudio.currentTime = 24.5;
+      fireEvent.timeUpdate(sourceAudio);
+    });
+    await flushMicrotasks();
+    expect(audioContext?.createdOscillators).toHaveLength(8);
+    const sourceCountBeforeRollover = audioContext?.createdSources.length ?? 0;
+    act(() => {
+      vi.advanceTimersByTime(2035);
+    });
+    await flushMicrotasks();
+    expect(audioContext?.createdSources).toHaveLength(sourceCountBeforeRollover + 1);
+    expect(audioContext?.createdSources[sourceCountBeforeRollover]?.start.mock.calls[0]?.[1]).toBeCloseTo(
+      12.25,
+      3,
+    );
+    vi.useRealTimers();
+  }, 15000);
+
+  it("does not use song pre-count for a nonzero loop start", async () => {
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    setPlaybackPosition("12.25");
+    await user.click(screen.getByRole("button", { name: "Set loop start" }));
+    setPlaybackPosition("24.5");
+    await user.click(screen.getByRole("button", { name: "Set loop end" }));
+
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    await user.click(screen.getByLabelText("Enable pre-count"));
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    await waitFor(() => expect(getMockAudioContexts()[0]?.createdSources).toHaveLength(1));
+    expect(getMockAudioContexts()[0]?.createdOscillators).toHaveLength(0);
+    expect(getMockAudioContexts()[0]?.createdSources[0]?.start.mock.calls[0]?.[1]).toBeCloseTo(
+      12.25,
+      3,
+    );
   });
 
   it("schedules stem playback on the pre-count clock after the last click", async () => {

--- a/apps/desktop/src/App.project-tempo.test.tsx
+++ b/apps/desktop/src/App.project-tempo.test.tsx
@@ -128,6 +128,33 @@ describe("Desktop app project playback tempo", () => {
     expect(screen.getByText("Original 123.5 BPM")).toBeInTheDocument();
   });
 
+  it("keeps tempo-correct playback when seeking is loop-bounded", async () => {
+    const user = userEvent.setup();
+    setupTempoAnalysis(120);
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    setPlaybackPosition("12.25");
+    await user.click(screen.getByRole("button", { name: "Set loop start" }));
+    setPlaybackPosition("24.5");
+    await user.click(screen.getByRole("button", { name: "Set loop end" }));
+
+    setPlaybackPosition("99");
+    expect(screen.getByLabelText("Playback position")).toHaveValue("12.25");
+
+    await user.click(screen.getByRole("button", { name: "Decrease playback tempo" }));
+    await waitForTempoSummary("119 BPM (0.992x)");
+
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    await waitFor(() => expect(sourceAudio.currentTime).toBeCloseTo(12.25, 3));
+    await waitFor(() => expect(sourceAudio.playbackRate).toBeCloseTo(119 / 120, 4));
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+  });
+
   it("flushes a pending tempo step before playback starts", async () => {
     const user = userEvent.setup();
     setupTempoAnalysis(120);

--- a/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
@@ -28,6 +28,7 @@ export function PlaybackPracticeRail() {
     higherCapoShiftOptions,
     handleSetPrecountClickCount,
     handleSetPrecountEnabled,
+    handleSetPrecountLoopEnabled,
     informationDensity,
     isStemPlayback,
     lowerCapoPreview,
@@ -35,6 +36,7 @@ export function PlaybackPracticeRail() {
     precountClickCount,
     precountDisabledReason,
     precountEnabled,
+    precountLoopEnabled,
     precountMaxClickCount,
     precountMinClickCount,
     precountTempoBpm,
@@ -265,6 +267,16 @@ export function PlaybackPracticeRail() {
             <span>{precountEnabled ? "On" : "Off"}</span>
           </label>
         </div>
+        <label className="playback-precount-control__toggle">
+          <input
+            aria-label="Enable loop pre-count"
+            checked={precountLoopEnabled}
+            disabled={!canUsePrecount}
+            onChange={(event) => handleSetPrecountLoopEnabled(event.target.checked)}
+            type="checkbox"
+          />
+          <span>{precountLoopEnabled ? "Loop on" : "Loop off"}</span>
+        </label>
         <div className="playback-precount-control__stepper" role="group" aria-label="Pre-count clicks">
           <button
             aria-label="Decrease pre-count clicks"

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -185,6 +185,7 @@ export function useProjectViewModel() {
   const [capoTransposeSemitones, setCapoTransposeSemitones] = useState(0);
   const [capoSelectorOpen, setCapoSelectorOpen] = useState(false);
   const [precountEnabled, setPrecountEnabled] = useState(false);
+  const [precountLoopEnabled, setPrecountLoopEnabled] = useState(false);
   const [precountClickCount, setPrecountClickCount] = useState(DEFAULT_PRECOUNT_CLICK_COUNT);
   const [tempoTargetBpm, setTempoTargetBpm] = useState<number | null>(null);
   const [loopRange, setLoopRange] = useState<PlaybackLoopRange | null>(null);
@@ -1016,6 +1017,13 @@ export function useProjectViewModel() {
     setPrecountEnabled(enabled);
   }
 
+  function handleSetPrecountLoopEnabled(enabled: boolean) {
+    if (enabled && !canUsePrecount) {
+      return;
+    }
+    setPrecountLoopEnabled(enabled);
+  }
+
   function handleSetPrecountClickCount(value: number) {
     setPrecountClickCount(normalizePrecountClickCount(value));
   }
@@ -1481,6 +1489,7 @@ export function useProjectViewModel() {
     );
     setCapoTransposeSemitones(storedPlaybackState.capoTransposeSemitones);
     setPrecountEnabled(storedPlaybackState.precountEnabled);
+    setPrecountLoopEnabled(storedPlaybackState.precountLoopEnabled);
     setPrecountClickCount(storedPlaybackState.precountClickCount);
     setTempoTargetBpm(storedPlaybackState.tempoTargetBpm);
     setLoopRange(storedPlaybackState.loopRange);
@@ -1640,6 +1649,7 @@ export function useProjectViewModel() {
       playbackDisplayMode,
       capoTransposeSemitones: capoSemitones,
       precountEnabled,
+      precountLoopEnabled,
       precountClickCount,
       tempoTargetBpm,
       loopRange,
@@ -1660,6 +1670,7 @@ export function useProjectViewModel() {
     playbackDisplayMode,
     precountClickCount,
     precountEnabled,
+    precountLoopEnabled,
     projectId,
     selectedArtifactId,
     selectedPrimaryArtifactId,
@@ -1890,6 +1901,7 @@ export function useProjectViewModel() {
       stemControls,
       durationHintSeconds: projectQuery.data?.duration_seconds ?? 0,
       precountEnabled,
+      precountLoopEnabled,
       precountClickCount,
       precountTempoBpm,
       tempoOriginalBpm,
@@ -1904,6 +1916,7 @@ export function useProjectViewModel() {
     projectQuery.data?.duration_seconds,
     precountClickCount,
     precountEnabled,
+    precountLoopEnabled,
     precountTempoBpm,
     registerProjectSession,
     loopRange,
@@ -1987,6 +2000,7 @@ export function useProjectViewModel() {
     handleSetLyricsFollowEnabled,
     handleSetPrecountClickCount,
     handleSetPrecountEnabled,
+    handleSetPrecountLoopEnabled,
     handleIncreasePlaybackTempo,
     handleSetPlaybackTempo,
     handleAcceptTabSuggestionGroup,
@@ -2051,6 +2065,7 @@ export function useProjectViewModel() {
     precountClickCount,
     precountDisabledReason,
     precountEnabled,
+    precountLoopEnabled,
     precountMaxClickCount: MAX_PRECOUNT_CLICK_COUNT,
     precountMinClickCount: MIN_PRECOUNT_CLICK_COUNT,
     precountTempoBpm,

--- a/apps/desktop/src/features/projects/playback-context.ts
+++ b/apps/desktop/src/features/projects/playback-context.ts
@@ -15,6 +15,7 @@ export type ProjectPlaybackSession = {
   stemControls: Record<string, StemControlState>;
   durationHintSeconds: number;
   precountEnabled: boolean;
+  precountLoopEnabled: boolean;
   precountClickCount: number;
   precountTempoBpm: number | null;
   tempoOriginalBpm: number | null;

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -277,6 +277,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   const webMediaSourcesEnabledRef = useRef(initialWebMediaSourcesEnabled);
   const pendingTransitionRef = useRef<PendingTransition | null>(null);
   const transitionCounterRef = useRef(0);
+  const allowFreshPlaybackRef = useRef(true);
   const sessionRef = useRef<ProjectPlaybackSession | null>(null);
   const playbackTimeSecondsRef = useRef(0);
   const playbackDurationSecondsRef = useRef(0);
@@ -1239,7 +1240,11 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   ) {
     const loopRange = getPlayableLoopRange(targetSession);
     if (!loopRange) {
-      return requestedTimeSeconds;
+      const durationSeconds =
+        sessionRef.current?.projectId === targetSession.projectId
+          ? playbackDurationSecondsRef.current || targetSession.durationHintSeconds || 0
+          : targetSession.durationHintSeconds || 0;
+      return clampTime(requestedTimeSeconds, durationSeconds);
     }
 
     const durationSeconds = playbackDurationSecondsRef.current || targetSession.durationHintSeconds || 0;
@@ -1262,7 +1267,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       return false;
     }
 
-    seekTo(loopRange.startSeconds);
+    void restartActiveLoopPlayback(targetSession);
     return true;
   });
 
@@ -1274,14 +1279,51 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       return false;
     }
 
-    seekTo(loopRange.startSeconds);
-    const bufferedClockIsActive =
-      targetSession &&
-      canUseBufferedClock(targetSession) &&
-      stemPlaybackRef.current?.signature === playbackSignature(targetSession);
-    if (isPlayingRef.current && !bufferedClockIsActive) {
-      void playPlaybackImmediately({ forceStartAtZero: true });
-    }
+    void (async () => {
+      if (
+        targetSession &&
+        targetSession.precountLoopEnabled &&
+        typeof targetSession.precountTempoBpm === "number" &&
+        Number.isFinite(targetSession.precountTempoBpm) &&
+        targetSession.precountTempoBpm > 0
+      ) {
+        if (nativePlaybackRef.current.active) {
+          void requestNativeStop();
+          markNativePlaybackInactive();
+        }
+        if (stemPlaybackRef.current) {
+          stopStemSources(stemPlaybackRef.current, false);
+          stemPlaybackRef.current.offsetSeconds = loopRange.startSeconds;
+          syncStemElementTimes(stemPlaybackRef.current.artifactIds, loopRange.startSeconds);
+        }
+        getRenderedMediaElements(targetSession).forEach((element) => {
+          element.pause();
+          element.currentTime = loopRange.startSeconds;
+        });
+        setPlaybackTimeSeconds(loopRange.startSeconds);
+        setIsPlaying(false);
+        if (
+          await startPrecountThenPlayback(targetSession, loopRange.startSeconds, {
+            loopWrap: true,
+          })
+        ) {
+          return;
+        }
+      }
+      seekTo(loopRange.startSeconds);
+      if (
+        targetSession &&
+        isPlayingRef.current &&
+        playbackSignature(sessionRef.current) === playbackSignature(targetSession)
+      ) {
+        const bufferedClockIsActive =
+          canUseBufferedClock(targetSession) &&
+          stemPlaybackRef.current?.signature === playbackSignature(targetSession);
+        if (!bufferedClockIsActive) {
+          void playPlaybackImmediately({ forceStartAtZero: true });
+        }
+      }
+    })();
     return true;
   });
 
@@ -1301,6 +1343,10 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       nativePlaybackRef.current.active &&
       nativePlaybackRef.current.playbackSignature === playbackSignature(targetSession)
     ) {
+      return playbackTimeSecondsRef.current;
+    }
+
+    if (!isPlayingRef.current) {
       return playbackTimeSecondsRef.current;
     }
 
@@ -1614,6 +1660,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   });
 
   const pausePlayback = useCallback(() => {
+    allowFreshPlaybackRef.current = false;
     cancelPrecount();
     const pendingTransition = pendingTransitionRef.current;
     if (pendingTransition) {
@@ -1741,14 +1788,33 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   const startPrecountThenPlayback = useStableCallback(async function startPrecountThenPlayback(
     targetSession: ProjectPlaybackSession,
     startTimeSeconds: number,
+    options: { loopWrap?: boolean } = {},
   ) {
+    if (options.loopWrap !== true && !allowFreshPlaybackRef.current) {
+      return false;
+    }
     const tempoBpm = targetSession.precountTempoBpm;
-    if (!targetSession.precountEnabled || typeof tempoBpm !== "number" || !Number.isFinite(tempoBpm) || tempoBpm <= 0) {
+    if (typeof tempoBpm !== "number" || !Number.isFinite(tempoBpm) || tempoBpm <= 0) {
       return false;
     }
-    if (startTimeSeconds > SEEK_TOLERANCE_SECONDS) {
+
+    const loopRange = getPlayableLoopRange(targetSession);
+    const isSongStart = Math.abs(startTimeSeconds) <= SEEK_TOLERANCE_SECONDS;
+    const isLoopStart = Boolean(
+      loopRange &&
+        Math.abs(startTimeSeconds - loopRange.startSeconds) <= SEEK_TOLERANCE_SECONDS,
+    );
+    const shouldUseLoopPrecount =
+      targetSession.precountLoopEnabled && Boolean(isLoopStart);
+    const shouldUseSongPrecount =
+      options.loopWrap !== true && targetSession.precountEnabled && isSongStart;
+    if (!shouldUseLoopPrecount && !shouldUseSongPrecount) {
       return false;
     }
+    if (!isSongStart && !isLoopStart) {
+      return false;
+    }
+    allowFreshPlaybackRef.current = false;
 
     const clickCount = normalizePrecountClickCount(targetSession.precountClickCount);
     const signature = playbackSignature(targetSession);
@@ -1795,16 +1861,16 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     }
 
     getActiveMediaElements(targetSession).forEach((element) => {
-      if (Math.abs(element.currentTime) > SEEK_TOLERANCE_SECONDS) {
-        element.currentTime = 0;
+      if (Math.abs(element.currentTime - startTimeSeconds) > SEEK_TOLERANCE_SECONDS) {
+        element.currentTime = startTimeSeconds;
       }
     });
     if (preparedStemPlaybackState) {
-      preparedStemPlaybackState.offsetSeconds = 0;
-      syncStemElementTimes(preparedStemPlaybackState.artifactIds, 0);
+      preparedStemPlaybackState.offsetSeconds = startTimeSeconds;
+      syncStemElementTimes(preparedStemPlaybackState.artifactIds, startTimeSeconds);
       setPlaybackDurationSeconds(preparedStemPlaybackState.durationSeconds);
     }
-    setPlaybackTimeSeconds(0);
+    setPlaybackTimeSeconds(startTimeSeconds);
 
     const beatSeconds = 60 / tempoBpm;
     const firstClickTimeSeconds = precountAudio.context.currentTime + PRECOUNT_START_DELAY_SECONDS;
@@ -1869,6 +1935,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       return;
     }
 
+    allowFreshPlaybackRef.current = false;
     await playPlaybackImmediately();
   }, [
     playPlaybackImmediately,
@@ -1893,13 +1960,15 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
   const seekTo = useCallback((timeSeconds: number) => {
     cancelPrecount();
-    const nextTime = clampTime(timeSeconds, playbackDurationSecondsRef.current);
+    const targetSession = sessionRef.current;
+    const nextTime = targetSession
+      ? playbackStartTimeForSession(targetSession, timeSeconds)
+      : clampTime(timeSeconds, playbackDurationSecondsRef.current);
     const pendingTransition = pendingTransitionRef.current;
     if (pendingTransition) {
       pendingTransition.targetTime = nextTime;
     }
 
-    const targetSession = sessionRef.current;
     if (nativePlaybackRef.current.active) {
       void seekNativeAudio({ timeSeconds: nextTime })
         .then((snapshot) => setPlaybackTimeSeconds(snapshot.positionSeconds))
@@ -1934,6 +2003,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     cancelPrecount,
     getActiveMediaElements,
     markNativePlaybackInactive,
+    playbackStartTimeForSession,
     startStemPlayback,
     syncStemElementTimes,
   ]);
@@ -1946,6 +2016,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   );
 
   const stopPlayback = useCallback(() => {
+    allowFreshPlaybackRef.current = true;
     cancelPrecount();
     clearPendingTransition();
     const targetSession = sessionRef.current;
@@ -1996,6 +2067,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       cancelPrecount();
       clearPendingTransition();
       closePlaybackAudioContext();
+      allowFreshPlaybackRef.current = true;
       getRenderedMediaElements(previousSession).forEach((element) => {
         element.pause();
         element.currentTime = 0;

--- a/apps/desktop/src/features/projects/projectPlaybackState.ts
+++ b/apps/desktop/src/features/projects/projectPlaybackState.ts
@@ -32,6 +32,7 @@ export type StoredProjectPlaybackState = {
   playbackDisplayMode: PlaybackDisplayMode;
   capoTransposeSemitones: number;
   precountEnabled: boolean;
+  precountLoopEnabled: boolean;
   precountClickCount: number;
   tempoTargetBpm: number | null;
   loopRange: PlaybackLoopRange | null;
@@ -52,6 +53,7 @@ const DEFAULT_STORED_PROJECT_PLAYBACK_STATE: StoredProjectPlaybackState = {
   playbackDisplayMode: "combined",
   capoTransposeSemitones: 0,
   precountEnabled: false,
+  precountLoopEnabled: false,
   precountClickCount: DEFAULT_PRECOUNT_CLICK_COUNT,
   tempoTargetBpm: null,
   loopRange: null,
@@ -167,6 +169,10 @@ function normalizeStoredProjectPlaybackState(value: unknown): StoredProjectPlayb
       typeof candidate.precountEnabled === "boolean"
         ? candidate.precountEnabled
         : DEFAULT_STORED_PROJECT_PLAYBACK_STATE.precountEnabled,
+    precountLoopEnabled:
+      typeof candidate.precountLoopEnabled === "boolean"
+        ? candidate.precountLoopEnabled
+        : DEFAULT_STORED_PROJECT_PLAYBACK_STATE.precountLoopEnabled,
     precountClickCount: normalizePrecountClickCount(candidate.precountClickCount),
     tempoTargetBpm: normalizeTempoTargetBpm(candidate.tempoTargetBpm),
     loopRange: normalizePlaybackLoopRange(candidate.loopRange),

--- a/docs/NATIVE_AUDIO.md
+++ b/docs/NATIVE_AUDIO.md
@@ -81,3 +81,51 @@ Native tuner capture can use a selected input device without changing the system
 Native selected-device volume uses host controls where available. Web Audio capture remains limited
 to the browser/system default input path, so non-default microphone choices are disabled while Web
 Audio is active.
+
+## Playback QA Matrix
+
+Use this matrix for local regressions against source, practice-mix, and stems.
+Run once with native playback selected per platform, then rerun with forced Web Audio.
+
+| Check | Native macOS | Native Linux | Forced Web Audio (`VITE_TUNEFORGE_FORCE_WEB_AUDIO=1`) |
+| --- | --- | --- | --- |
+| Source playback | start/seek/pause/resume/stop works | start/seek/pause/resume/stop works | start/seek/pause/resume/stop works |
+| Practice mix playback | start/seek/pause/resume/stop works | start/seek/pause/resume/stop works | start/seek/pause/resume/stop works |
+| Stem playback | start/seek/pause/resume/stop works | start/seek/pause/resume/stop works | start/seek/pause/resume/stop works |
+| Mute/Solo behavior | lane mute and solo are independent and audible | lane mute and solo are independent and audible | lane mute and solo are independent and audible |
+| Seek accuracy | scrub reflects transport position and lane audio resumes at target | same | same |
+| Stop semantics | returns transport to expected idle state | same | same |
+| Pause/Resume | no drift on resume at least for short cycle | no drift on resume at least for short cycle | no drift on resume at least for short cycle |
+| Loop | loop boundaries and loop duration stable | stable | stable |
+| Song count-in | only runs from absolute song start | same | same |
+| Loop count-in | runs at loop start and on loop wrap, never on pause/resume | same | same |
+| Tempo control | tempo change applies and stays stable | tempo change applies and stays stable | tempo change applies and stays stable |
+| Metronome follow | follows active track tempo while BPM changes | follows active track tempo while BPM changes | follows active track tempo while BPM changes |
+| Fallback + no output device | falls back (or errors and recovers) without crash when no native output exists | same | same |
+
+## Local-only Playwright Smoke Harness
+
+Scaffold file: `scripts/playback-smoke.mjs` (local only, not wired to CI). This is a
+browser-based smoke check for the frontend/Web Audio transport path; native output still needs the
+manual matrix above. `pnpm setup:dev` installs the Playwright Chromium browser needed by this
+smoke check; use `pnpm setup:dev -- --skip-playwright-browsers` to skip that download.
+
+Check that the local smoke scaffold is available:
+
+```sh
+pnpm --filter @tuneforge/desktop test:e2e
+```
+
+Start the dev app first with `pnpm dev`, or `pnpm dev:desktop` when the backend is already
+running. Then execute the smoke pass with the visible project name from the library:
+
+```sh
+pnpm --filter @tuneforge/desktop test:e2e -- --run --project-name="Demo Song"
+```
+
+For full coverage, use a fixture project with timed lyrics or chords. The smoke pass always checks
+stopped scrubber start, and it also checks stopped lyrics/chords start when a timed practice target
+is available.
+
+If you already know the project ID, `--project-id=<id>` opens the project route directly.
+Set `TUNEFORGE_SMOKE_APP_URL` if the desktop frontend is not on `http://127.0.0.1:1420`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
+      playwright:
+        specifier: ^1.59.1
+        version: 1.59.1
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -1132,6 +1135,11 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1492,6 +1500,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -2921,6 +2939,9 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -3223,6 +3244,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@8.0.0: {}
 

--- a/scripts/playback-smoke.mjs
+++ b/scripts/playback-smoke.mjs
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+
+import process from "node:process";
+import { createRequire } from "node:module";
+
+const desktopRequire = createRequire(new URL("../apps/desktop/package.json", import.meta.url));
+
+const appUrl = process.env.TUNEFORGE_SMOKE_APP_URL || "http://127.0.0.1:1420";
+const projectId = readOption("project-id") || process.env.TUNEFORGE_SMOKE_PROJECT_ID || "";
+const projectName = readOption("project-name") || process.env.TUNEFORGE_SMOKE_PROJECT_NAME || "";
+const run = process.argv.includes("--run");
+const headed = process.argv.includes("--headed");
+
+if (!run) {
+  console.log("[playback-smoke] Local smoke scaffold is available.");
+  console.log("Start the desktop dev frontend, then run:");
+  console.log(
+    '  pnpm --filter @tuneforge/desktop test:e2e -- --run --project-name="Demo Song"',
+  );
+  process.exit(0);
+}
+
+if (!projectId && !projectName) {
+  console.error(
+    "[playback-smoke] Missing --project-name/--project-id or TUNEFORGE_SMOKE_PROJECT_NAME/TUNEFORGE_SMOKE_PROJECT_ID.",
+  );
+  process.exit(1);
+}
+
+let chromium;
+try {
+  ({ chromium } = desktopRequire("playwright"));
+} catch {
+  console.error("[playback-smoke] Playwright is not installed locally.");
+  console.error("  pnpm setup:dev");
+  console.error("or:");
+  console.error("  pnpm install");
+  console.error("  pnpm --filter @tuneforge/desktop exec playwright install chromium");
+  process.exit(1);
+}
+
+const browser = await chromium.launch({ headless: !headed });
+
+try {
+  const page = await browser.newPage();
+  logStep(
+    `Running ${headed ? "headed" : "headless"} smoke against ${appUrl} (${projectId ? `project ${projectId}` : `project "${projectName}"`}).`,
+  );
+  await openProject(page, { appUrl, projectId, projectName });
+  await page.getByRole("heading", { name: /.+/ }).first().waitFor();
+  logStep("Project opened.");
+  await openPlayback(page);
+  await resetSmokePlaybackState(page);
+
+  const durationSeconds = await readPlaybackDuration(page);
+  logStep(`Playback tab ready. Duration: ${formatSeconds(durationSeconds)}.`);
+  const scrubberStartSeconds = stoppedStartProbeTime(durationSeconds);
+  await seekTo(page, scrubberStartSeconds);
+  await expectPosition(page, scrubberStartSeconds, "after stopped scrubber seek");
+  await verifyPlayStartsFromSelection(page, scrubberStartSeconds, "stopped scrubber selection");
+  logStep(`Stopped scrubber selection started at ${formatSeconds(scrubberStartSeconds)}.`);
+
+  const practiceStartSeconds = await chooseStoppedPracticeSelection(page);
+  if (practiceStartSeconds === null) {
+    logStep("Skipped stopped lyrics/chords selection; no timed practice target was available.");
+  } else {
+    await verifyPlayStartsFromSelection(page, practiceStartSeconds, "stopped lyrics/chords selection");
+    logStep(`Stopped lyrics/chords selection started at ${formatSeconds(practiceStartSeconds)}.`);
+  }
+
+  const loopStartSeconds = Math.min(12.25, Math.max(0.25, durationSeconds * 0.25));
+  let loopEndSeconds = Math.min(24.5, Math.max(loopStartSeconds + 0.5, durationSeconds * 0.5));
+  loopEndSeconds = Math.min(durationSeconds, loopEndSeconds);
+  if (loopEndSeconds - loopStartSeconds < 0.25) {
+    throw new Error(
+      `Project is too short for smoke loop coverage. Duration: ${durationSeconds.toFixed(3)}s.`,
+    );
+  }
+  const outsideLoopSeconds = Math.min(
+    durationSeconds,
+    Math.max(loopEndSeconds + 0.5, durationSeconds * 0.9),
+  );
+
+  await seekTo(page, loopStartSeconds);
+  await expectPosition(page, loopStartSeconds, "after seeking to loop start");
+  await page.getByRole("button", { name: "Set loop start" }).click();
+  await seekTo(page, loopEndSeconds);
+  await expectPosition(page, loopEndSeconds, "after seeking to loop end");
+  await page.getByRole("button", { name: "Set loop end" }).click();
+  await expectPosition(page, loopStartSeconds, "after setting loop end");
+  logStep(`Loop set: ${formatSeconds(loopStartSeconds)} to ${formatSeconds(loopEndSeconds)}.`);
+
+  await seekTo(page, outsideLoopSeconds);
+  await expectPosition(page, loopStartSeconds, "after seeking outside the loop");
+  logStep("Seek outside loop snapped back to loop start.");
+
+  await page.getByLabel("Enable pre-count").check();
+  await page.getByLabel("Enable loop pre-count").check();
+  const playbackBpmInput = page.getByRole("spinbutton", { name: "Playback BPM" });
+  await playbackBpmInput.fill("128");
+  await playbackBpmInput.press("Enter");
+  logStep("Song and loop pre-count enabled; tempo set to 128 BPM.");
+
+  await page.getByRole("button", { name: "Play playback" }).click();
+  await page.getByRole("button", { name: "Pause playback" }).waitFor();
+  await page.getByRole("button", { name: "Pause playback" }).click();
+  await page.getByRole("button", { name: "Play playback" }).click();
+  await page.getByRole("button", { name: "Pause playback" }).waitFor();
+  await page.getByRole("button", { name: "Stop playback" }).click();
+  await expectPosition(page, loopStartSeconds, "after stop with active loop");
+  logStep("Play, pause, resume, and stop passed.");
+  logStep("Passed.");
+} catch (error) {
+  console.error(`[playback-smoke] ${errorMessage(error)}`);
+  process.exitCode = 1;
+} finally {
+  await browser.close();
+}
+
+function readOption(name) {
+  const prefix = `--${name}=`;
+  return process.argv.find((arg) => arg.startsWith(prefix))?.slice(prefix.length) ?? "";
+}
+
+function logStep(message) {
+  console.log(`[playback-smoke] ${message}`);
+}
+
+function formatSeconds(value) {
+  return `${value.toFixed(3)}s`;
+}
+
+async function openProject(page, { appUrl, projectId, projectName }) {
+  const baseUrl = appUrl.replace(/\/$/, "");
+  if (projectId) {
+    await gotoApp(page, `${baseUrl}/projects/${projectId}`);
+    return;
+  }
+
+  await gotoApp(page, baseUrl);
+  try {
+    await page.getByRole("link", { name: `Open ${projectName} project` }).click();
+  } catch (error) {
+    throw new Error(
+      `Could not find a library project named "${projectName}". Use the visible library name or pass --project-id=<id>.\n${errorMessage(error)}`,
+    );
+  }
+}
+
+async function gotoApp(page, url) {
+  try {
+    await page.goto(url, { waitUntil: "domcontentloaded" });
+  } catch (error) {
+    const message = errorMessage(error);
+    if (message.includes("ERR_CONNECTION_REFUSED")) {
+      throw new Error(
+        [
+          `Could not reach TuneForge at ${url}.`,
+          "Start the dev app first, for example:",
+          "  pnpm dev",
+          "or, if the backend is already running:",
+          "  pnpm dev:desktop",
+          "Set TUNEFORGE_SMOKE_APP_URL if the frontend is on a different URL.",
+        ].join("\n"),
+      );
+    }
+    throw error;
+  }
+}
+
+async function openPlayback(page) {
+  const playbackTab = page.getByRole("tab", { name: "Playback" });
+  if ((await playbackTab.getAttribute("aria-selected")) !== "true") {
+    await playbackTab.click();
+  }
+}
+
+async function resetSmokePlaybackState(page) {
+  await page.getByRole("button", { name: "Stop playback" }).click();
+  const clearLoopButton = page.getByRole("button", { name: "Clear loop" });
+  if (await clearLoopButton.isVisible().catch(() => false)) {
+    await clearLoopButton.click();
+  }
+  await setCheckbox(page, "Enable pre-count", false);
+  await setCheckbox(page, "Enable loop pre-count", false);
+  await seekTo(page, 0);
+  await expectPosition(page, 0, "after resetting smoke playback state");
+}
+
+async function setCheckbox(page, label, checked) {
+  const checkbox = page.getByLabel(label);
+  if (await checkbox.isEnabled().catch(() => false)) {
+    await checkbox.setChecked(checked);
+  }
+}
+
+async function seekTo(page, value) {
+  await page.getByLabel("Playback position").evaluate((element, nextValue) => {
+    if (!(element instanceof HTMLInputElement)) {
+      throw new Error("Playback position control is not an input element.");
+    }
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    valueSetter?.call(element, String(nextValue));
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+  }, value);
+}
+
+function stoppedStartProbeTime(durationSeconds) {
+  return Math.min(Math.max(8, durationSeconds * 0.2), Math.max(0, durationSeconds - 2));
+}
+
+async function verifyPlayStartsFromSelection(page, startSeconds, label) {
+  await page.getByRole("button", { name: "Play playback" }).click();
+  await page.getByRole("button", { name: "Pause playback" }).waitFor({ timeout: 5000 });
+  await expectPositionAtLeast(page, startSeconds - 0.05, label, { timeout: 3500 });
+  await page.getByRole("button", { name: "Stop playback" }).click();
+  await expectPosition(page, 0, `after stopping ${label}`);
+}
+
+async function chooseStoppedPracticeSelection(page) {
+  const selectors = [
+    '[role="group"][aria-label="Lyrics and chords lead sheet"] [role="button"]',
+    '[role="group"][aria-label="Lyrics transcript"] [role="button"]',
+    '[role="group"][aria-label="Chord timeline"] button',
+  ];
+
+  for (const selector of selectors) {
+    const candidates = page.locator(selector);
+    const candidateCount = Math.min(await candidates.count(), 24);
+    for (let index = 0; index < candidateCount; index += 1) {
+      const candidate = candidates.nth(index);
+      if (!(await candidate.isVisible().catch(() => false))) {
+        continue;
+      }
+      await candidate.click();
+      const selectedSeconds = await readPlaybackPosition(page);
+      if (selectedSeconds > 3) {
+        return selectedSeconds;
+      }
+    }
+  }
+
+  return null;
+}
+
+async function readPlaybackDuration(page) {
+  const rawMax = await page.getByLabel("Playback position").evaluate((element) => {
+    const input = element;
+    return input instanceof HTMLInputElement ? input.max : "";
+  });
+  const durationSeconds = Number(rawMax);
+  if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) {
+    throw new Error(`Playback duration is unavailable for smoke test. Range max: ${rawMax}`);
+  }
+  return durationSeconds;
+}
+
+async function readPlaybackPosition(page) {
+  const rawValue = await page.getByLabel("Playback position").evaluate((element) => {
+    const input = element;
+    return input instanceof HTMLInputElement ? input.value : "";
+  });
+  const positionSeconds = Number(rawValue);
+  return Number.isFinite(positionSeconds) ? positionSeconds : 0;
+}
+
+async function expectPosition(page, value, label) {
+  try {
+    await page.waitForFunction(
+      ({ expected }) => {
+        const input = document.querySelector('input[aria-label="Playback position"]');
+        if (!(input instanceof HTMLInputElement)) {
+          return false;
+        }
+        const actual = Number(input.value);
+        return Number.isFinite(actual) && Math.abs(actual - expected) <= 0.05;
+      },
+      { expected: value },
+    );
+  } catch (error) {
+    const actual = await page
+      .locator('input[aria-label="Playback position"]')
+      .evaluate((input) => (input instanceof HTMLInputElement ? input.value : "missing"))
+      .catch(() => "missing");
+    throw new Error(
+      `Expected playback position near ${value.toFixed(3)} ${label}, but saw ${actual}.\n${errorMessage(error)}`,
+    );
+  }
+}
+
+async function expectPositionAtLeast(page, value, label, options = {}) {
+  try {
+    await page.waitForFunction(
+      ({ minimum }) => {
+        const input = document.querySelector('input[aria-label="Playback position"]');
+        if (!(input instanceof HTMLInputElement)) {
+          return false;
+        }
+        const actual = Number(input.value);
+        return Number.isFinite(actual) && actual >= minimum;
+      },
+      { minimum: value },
+      options,
+    );
+  } catch (error) {
+    const actual = await readPlaybackPosition(page).catch(() => "missing");
+    throw new Error(
+      `Expected playback position at or after ${value.toFixed(3)} for ${label}, but saw ${actual}.\n${errorMessage(error)}`,
+    );
+  }
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -7,6 +7,7 @@ Usage: pnpm setup:dev [options]
 
 Runs the standard developer setup:
   pnpm install
+  pnpm --filter @tuneforge/desktop exec playwright install chromium
   uv sync --python 3.11 --all-groups
   pnpm contracts:generate
   pnpm models:demucs:prepare
@@ -15,6 +16,7 @@ Options:
   --advanced-chords, --crema  Install the optional crema/TensorFlow chord backend.
   --legacy-nvidia             Use the Linux x86_64 legacy NVIDIA Torch profile.
   --skip-demucs-models        Skip preparing the local pinned Demucs model repo.
+  --skip-playwright-browsers  Skip installing Playwright's Chromium browser.
   --skip-pnpm-install         Skip workspace dependency installation.
   --skip-contracts            Skip OpenAPI contract generation.
   -h, --help                  Show this help.
@@ -24,6 +26,7 @@ EOF
 advanced_chords=0
 legacy_nvidia=0
 skip_demucs_models=0
+skip_playwright_browsers=0
 skip_pnpm_install=0
 skip_contracts=0
 
@@ -37,6 +40,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     --skip-demucs-models)
       skip_demucs_models=1
+      ;;
+    --skip-playwright-browsers)
+      skip_playwright_browsers=1
       ;;
     --skip-pnpm-install)
       skip_pnpm_install=1
@@ -85,6 +91,11 @@ cd "${repo_root}"
 if [[ "${skip_pnpm_install}" -eq 0 ]]; then
   echo "Installing workspace dependencies..."
   pnpm install
+fi
+
+if [[ "${skip_playwright_browsers}" -eq 0 ]]; then
+  echo "Installing Playwright Chromium browser..."
+  pnpm --filter @tuneforge/desktop exec playwright install chromium
 fi
 
 echo "Checking Tauri build dependencies..."


### PR DESCRIPTION
## Summary

- Add independent loop pre-count playback behavior and UI state.
- Make loop seek/stop behavior snap to the active loop start where appropriate.
- Fix stopped playback starts from scrubber, lyrics, and chord selections.
- Add playback regression tests and local Playwright smoke coverage for frontend/Web Audio behavior.
- Document the playback QA matrix and local smoke workflow.

Closes #81

## Testing

- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test -- --run src/App.project-playback-stems.test.tsx src/App.project-analysis-mix.test.tsx src/App.project-precount.test.tsx src/App.project-tempo.test.tsx`
- `cd apps/desktop/src-tauri && cargo check`
- `cd apps/desktop/src-tauri && cargo test seek_clamps_to_ -- --nocapture`
- `cd apps/desktop/src-tauri && cargo test stop_resets_transport_position -- --nocapture`
- `node --check scripts/playback-smoke.mjs`
- `pnpm --filter @tuneforge/desktop test:e2e`
- `pnpm --filter @tuneforge/desktop test:e2e -- --run --project-name="Natural"`
