### PR TITLE
feat: use wide arc as default tuner

### DIFF
--- a/apps/desktop/src/App.settings-theme.test.tsx
+++ b/apps/desktop/src/App.settings-theme.test.tsx
@@ -113,6 +113,7 @@ describe("Desktop app settings theme", () => {
       defaultChordsFollowEnabled: true,
       defaultTunerInputDeviceId: null,
       defaultTunerReferenceHz: 440,
+      defaultTunerVisualMode: "wide-arc",
     });
   });
 
@@ -299,9 +300,14 @@ describe("Desktop app settings theme", () => {
     expect(screen.getByRole("button", { name: /^Enable lyrics follow by default/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^Enable chords follow by default/ })).toHaveAttribute("aria-pressed", "true");
 
+    await user.selectOptions(screen.getByLabelText("Default tuner"), "simple");
+    await user.click(screen.getByRole("button", { name: "Reset Tuner Defaults" }));
+    expect(screen.getByLabelText("Default tuner")).toHaveValue("wide-arc");
+
     await user.click(screen.getByRole("button", { name: /^Dark/ }));
     await user.click(screen.getByRole("button", { name: /^Dual labels/ }));
     await user.click(screen.getByRole("button", { name: /^Advanced Chords/ }));
+    await user.selectOptions(screen.getByLabelText("Default tuner"), "simple");
     await user.click(screen.getByRole("button", { name: "Reset All Settings" }));
 
     expect(screen.getByRole("button", { name: /^Follow system/ })).toHaveAttribute("aria-pressed", "true");
@@ -312,6 +318,7 @@ describe("Desktop app settings theme", () => {
     expect(screen.getByRole("button", { name: /^Built-in Chords/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^Enable lyrics follow by default/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^Enable chords follow by default/ })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByLabelText("Default tuner")).toHaveValue("wide-arc");
   });
 
   it("keeps project playback preferences when resetting all settings", async () => {

--- a/apps/desktop/src/App.tools-tuner.test.tsx
+++ b/apps/desktop/src/App.tools-tuner.test.tsx
@@ -27,24 +27,30 @@ describe("Desktop app tools tuner", () => {
     expect(screen.getByRole("button", { name: "Start" })).toBeEnabled();
     expect(screen.getByLabelText("Microphone source")).toHaveValue("");
     expect(screen.getByLabelText("A4 reference tuning")).toHaveValue(440);
-    expect(screen.getByLabelText("Tuner visual mode")).toHaveValue("simple");
+    expect(screen.getByLabelText("Tuner visual mode")).toHaveValue("wide-arc");
     expect(screen.getByRole("option", { name: "Wide Arc" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Simple Meter" })).toBeInTheDocument();
     expect(screen.queryByRole("option", { name: "Microphone 1" })).not.toBeInTheDocument();
     expect(screen.queryByRole("option", { name: "USB Interface" })).not.toBeInTheDocument();
+    expect(screen.getByTestId("wide-arc-tuner-meter")).toBeInTheDocument();
     expect(screen.getByRole("meter", { name: "Tuning offset" })).toBeInTheDocument();
     expect(screen.getByRole("meter", { name: "Input signal level" })).toBeInTheDocument();
     expect(getMockMediaDevices().getUserMedia).not.toHaveBeenCalled();
   });
 
-  it("keeps the wide arc visual mode available", async () => {
+  it("keeps the simple visual mode available and persists it", async () => {
     const user = userEvent.setup();
     renderApp(["/tools"]);
 
     expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
-    await user.selectOptions(screen.getByLabelText("Tuner visual mode"), "wide-arc");
+    await user.selectOptions(screen.getByLabelText("Tuner visual mode"), "simple");
 
-    expect(screen.getByLabelText("Tuner visual mode")).toHaveValue("wide-arc");
+    expect(screen.getByLabelText("Tuner visual mode")).toHaveValue("simple");
+    expect(screen.getByTestId("simple-tuner-meter")).toBeInTheDocument();
     expect(screen.getByRole("meter", { name: "Tuning offset" })).toBeInTheDocument();
+    expect(window.localStorage.getItem("tuneforge.ui-preferences")).toContain(
+      '"defaultTunerVisualMode":"simple"',
+    );
   });
 
   it("keeps tuner preferences synced between tools and settings", async () => {
@@ -66,22 +72,26 @@ describe("Desktop app tools tuner", () => {
     expect(await screen.findByRole("option", { name: "USB Interface" })).toBeInTheDocument();
     await user.selectOptions(screen.getByLabelText("Microphone source"), "cpal:1:usb");
     changeReferenceInput("442.5");
+    await user.selectOptions(screen.getByLabelText("Tuner visual mode"), "simple");
 
     await user.click(screen.getByRole("link", { name: "Settings" }));
 
     expect(await screen.findByRole("heading", { name: "Control Room" })).toBeInTheDocument();
     expect(screen.getByLabelText("Microphone source")).toHaveValue("cpal:1:usb");
     expect(screen.getByLabelText("A4 reference tuning")).toHaveValue(442.5);
+    expect(screen.getByLabelText("Default tuner")).toHaveValue("simple");
     expect(screen.getByText("Saved microphone")).toBeInTheDocument();
     expect(screen.getByText("442.5 Hz")).toBeInTheDocument();
 
     await user.selectOptions(screen.getByLabelText("Microphone source"), "");
     changeReferenceInput("441");
+    await user.selectOptions(screen.getByLabelText("Default tuner"), "wide-arc");
     await user.click(screen.getByRole("link", { name: "Tools" }));
 
     expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
     expect(screen.getByLabelText("Microphone source")).toHaveValue("");
     expect(screen.getByLabelText("A4 reference tuning")).toHaveValue(441);
+    expect(screen.getByLabelText("Tuner visual mode")).toHaveValue("wide-arc");
   });
 
   it("applies valid reference tuning edits before the field blurs", async () => {
@@ -183,6 +193,7 @@ describe("Desktop app tools tuner", () => {
       JSON.stringify({
         defaultTunerInputDeviceId: "",
         defaultTunerReferenceHz: 999,
+        defaultTunerVisualMode: "needle",
       }),
     );
 
@@ -191,6 +202,7 @@ describe("Desktop app tools tuner", () => {
     expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
     expect(screen.getByLabelText("Microphone source")).toHaveValue("");
     expect(screen.getByLabelText("A4 reference tuning")).toHaveValue(440);
+    expect(screen.getByLabelText("Tuner visual mode")).toHaveValue("wide-arc");
   });
 
   it("starts Web Audio capture with the system default source and stops cleanly", async () => {
@@ -267,7 +279,7 @@ describe("Desktop app tools tuner", () => {
         "50",
       ),
     );
-    expect(screen.getByTestId("simple-tuner-meter")).not.toHaveAttribute(
+    expect(screen.getByTestId("wide-arc-tuner-meter")).not.toHaveAttribute(
       "data-tuning-state",
       "no-pitch",
     );

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -25,6 +25,7 @@ import {
   type EnharmonicDisplayMode,
   type InformationDensity,
   type ProjectWorkspaceMode,
+  type TunerVisualMode,
 } from "../../lib/preferences";
 import {
   parseSettingsSnapshot,
@@ -232,6 +233,10 @@ function tunerInputDeviceLabel(value: string | null) {
   return value ? "Saved microphone" : "System Default";
 }
 
+function tunerVisualModeLabel(value: TunerVisualMode) {
+  return value === "simple" ? "Simple Meter" : "Wide Arc";
+}
+
 function inputCaptureBackendLabel(
   capabilities: NativeAudioCapabilities | undefined,
   webAudioForced: boolean,
@@ -428,6 +433,7 @@ export function SettingsView() {
     defaultChordsFollowEnabled,
     defaultTunerInputDeviceId,
     defaultTunerReferenceHz,
+    defaultTunerVisualMode,
     setInformationDensity,
     setEnharmonicDisplayMode,
     setDefaultProjectWorkspace,
@@ -438,6 +444,7 @@ export function SettingsView() {
     setDefaultChordsFollowEnabled,
     setDefaultTunerInputDeviceId,
     setDefaultTunerReferenceHz,
+    setDefaultTunerVisualMode,
     resetAppearancePreferences,
     resetNotationPreferences,
     resetAnalysisPreferences,
@@ -532,6 +539,7 @@ export function SettingsView() {
           defaultPlaybackDisplayMode,
           defaultTunerInputDeviceId,
           defaultTunerReferenceHz,
+          defaultTunerVisualMode,
           defaultLyricsFollowEnabled,
           defaultProjectWorkspace,
           defaultSourcesRailCollapsed,
@@ -655,6 +663,10 @@ export function SettingsView() {
             <dd>{defaultTunerReferenceHz.toFixed(1)} Hz</dd>
           </div>
           <div className="settings-overview__stat">
+            <dt>Default tuner</dt>
+            <dd>{tunerVisualModeLabel(defaultTunerVisualMode)}</dd>
+          </div>
+          <div className="settings-overview__stat">
             <dt>Playback follow</dt>
             <dd>
               {defaultLyricsFollowEnabled && defaultChordsFollowEnabled
@@ -719,7 +731,7 @@ export function SettingsView() {
           <div className="panel-heading">
             <div>
               <h2>Tuner Defaults</h2>
-              <p className="subpanel__copy">Default microphone source and A4 reference.</p>
+              <p className="subpanel__copy">Default microphone source, A4 reference, and tuner view.</p>
             </div>
           </div>
 
@@ -728,8 +740,10 @@ export function SettingsView() {
             nativeCaptureDisabled={webAudioForced}
             onInputDeviceChange={setDefaultTunerInputDeviceId}
             onReferenceHzChange={setDefaultTunerReferenceHz}
+            onVisualModeChange={setDefaultTunerVisualMode}
             referenceHz={defaultTunerReferenceHz}
             systemDefaultOnly={webAudioForced}
+            visualMode={defaultTunerVisualMode}
           />
 
           <div className="button-row">

--- a/apps/desktop/src/features/tools/ToolsView.tsx
+++ b/apps/desktop/src/features/tools/ToolsView.tsx
@@ -10,7 +10,7 @@ import {
   type NativeAudioInputFrame,
 } from "../../lib/nativeAudio";
 import { useStableCallback } from "../../lib/useStableCallback";
-import { usePreferences } from "../../lib/preferences";
+import { usePreferences, type TunerVisualMode } from "../../lib/preferences";
 import {
   activateWebAudioContext,
   getWebAudioContextConstructor,
@@ -25,7 +25,6 @@ import {
 import { TunerPreferenceControls } from "./TunerPreferenceControls";
 import {
   SimpleTunerMeter,
-  type TunerVisualMode,
   WideArcTunerMeter,
 } from "./TunerMeters";
 import { getTunerStatusLabel } from "./tunerMeterState";
@@ -114,8 +113,10 @@ function ChromaticTunerPage() {
   const {
     defaultTunerInputDeviceId,
     defaultTunerReferenceHz,
+    defaultTunerVisualMode,
     setDefaultTunerInputDeviceId,
     setDefaultTunerReferenceHz,
+    setDefaultTunerVisualMode,
   } = usePreferences();
   const [status, setStatus] = useState<TunerStatus>(() =>
     canUseTunerCapture(null) ? "idle" : "unsupported",
@@ -129,7 +130,6 @@ function ChromaticTunerPage() {
   const [reading, setReading] = useState<TunerPitchReading | null>(null);
   const [deviceRefreshToken, setDeviceRefreshToken] = useState(0);
   const [systemInputVolumeRefreshToken, setSystemInputVolumeRefreshToken] = useState(0);
-  const [visualMode, setVisualMode] = useState<TunerVisualMode>("simple");
   const analyserRef = useRef<AnalyserNode | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
   const frameIdRef = useRef<number | null>(null);
@@ -461,6 +461,12 @@ function ChromaticTunerPage() {
     setDefaultTunerReferenceHz(value);
   });
 
+  const handleVisualModeChange = useStableCallback(function handleVisualModeChange(
+    value: TunerVisualMode,
+  ) {
+    setDefaultTunerVisualMode(value);
+  });
+
   const isBusy = status === "starting";
   const isListening = status === "listening";
   const canStart =
@@ -495,22 +501,14 @@ function ChromaticTunerPage() {
           nativeCaptureDisabled={webAudioForced}
           onInputDeviceChange={handleInputDeviceChange}
           onReferenceHzChange={handleReferenceHzChange}
+          onVisualModeChange={handleVisualModeChange}
           referenceHz={defaultTunerReferenceHz}
           refreshToken={deviceRefreshToken}
           systemDefaultOnly={systemDefaultInputOnly}
-        >
-          <label className="tuner-field">
-            <span>Visual mode</span>
-            <select
-              aria-label="Tuner visual mode"
-              onChange={(event) => setVisualMode(event.target.value as TunerVisualMode)}
-              value={visualMode}
-            >
-              <option value="simple">Simple Meter</option>
-              <option value="wide-arc">Wide Arc</option>
-            </select>
-          </label>
-        </TunerPreferenceControls>
+          visualMode={defaultTunerVisualMode}
+          visualModeAriaLabel="Tuner visual mode"
+          visualModeLabel="Visual mode"
+        />
 
         <SystemInputVolumeControl
           deviceId={inputVolumeDeviceId}
@@ -519,7 +517,7 @@ function ChromaticTunerPage() {
 
         {errorMessage ? <p className="inline-error">{errorMessage}</p> : null}
 
-        {visualMode === "simple" ? (
+        {defaultTunerVisualMode === "simple" ? (
           <SimpleTunerMeter
             inputLevel={inputLevel}
             reading={reading}

--- a/apps/desktop/src/features/tools/TunerMeters.test.tsx
+++ b/apps/desktop/src/features/tools/TunerMeters.test.tsx
@@ -30,7 +30,7 @@ describe("tuner visual meters", () => {
     expect(screen.getAllByText("In tune")).toHaveLength(2);
     expect(screen.getByText("+2 cents")).toBeInTheDocument();
     expect(screen.getByTestId("simple-tuner-meter")).toHaveAttribute("data-tuning-state", "in-tune");
-    expect(screen.getByTestId("simple-tuner-meter")).toHaveStyle("--tuner-marker-position: 52%");
+    expect(screen.getByTestId("simple-tuner-meter")).toHaveStyle("--tuner-marker-position: 50%");
   });
 
   it("uses a less twitchy in-tune tolerance", () => {
@@ -38,6 +38,7 @@ describe("tuner visual meters", () => {
 
     expect(screen.getAllByText("In tune")).toHaveLength(2);
     expect(screen.getByText("+5 cents")).toBeInTheDocument();
+    expect(screen.getByTestId("simple-tuner-meter")).toHaveStyle("--tuner-marker-position: 50%");
   });
 
   it("renders flat readings to the left of center", () => {

--- a/apps/desktop/src/features/tools/TunerMeters.tsx
+++ b/apps/desktop/src/features/tools/TunerMeters.tsx
@@ -2,8 +2,6 @@ import { type CSSProperties } from "react";
 import { getTunerDisplay } from "./tunerMeterState";
 import { type TunerPitchReading } from "./tunerPitch";
 
-export type TunerVisualMode = "simple" | "wide-arc";
-
 type TunerMeterProps = {
   inputLevel: number;
   reading: TunerPitchReading | null;
@@ -12,8 +10,10 @@ type TunerMeterProps = {
 
 export function SimpleTunerMeter({ inputLevel, reading, referenceHz }: TunerMeterProps) {
   const display = getTunerDisplay(reading, referenceHz);
+  const markerPositionPercent =
+    display.toneState === "in-tune" ? 50 : display.markerPositionPercent;
   const style = {
-    "--tuner-marker-position": `${display.markerPositionPercent}%`,
+    "--tuner-marker-position": `${markerPositionPercent}%`,
   } as CSSProperties;
   const centerDirectionLabel = display.hasPitch ? "In tune" : "Center";
 

--- a/apps/desktop/src/features/tools/TunerPreferenceControls.tsx
+++ b/apps/desktop/src/features/tools/TunerPreferenceControls.tsx
@@ -7,6 +7,7 @@ import {
   MAX_TUNER_REFERENCE_HZ,
   MIN_TUNER_REFERENCE_HZ,
   normalizeTunerReferenceHz,
+  type TunerVisualMode,
 } from "../../lib/preferences";
 import {
   forgetTunerMicrophoneAccessGranted,
@@ -23,9 +24,13 @@ type TunerPreferenceControlsProps = {
   nativeCaptureDisabled?: boolean;
   onInputDeviceChange: (value: string | null) => void;
   onReferenceHzChange: (value: number) => void;
+  onVisualModeChange?: (value: TunerVisualMode) => void;
   referenceHz: number;
   refreshToken?: number;
   systemDefaultOnly?: boolean;
+  visualMode?: TunerVisualMode;
+  visualModeAriaLabel?: string;
+  visualModeLabel?: string;
 };
 
 export function TunerPreferenceControls({
@@ -35,9 +40,13 @@ export function TunerPreferenceControls({
   nativeCaptureDisabled = false,
   onInputDeviceChange,
   onReferenceHzChange,
+  onVisualModeChange,
   referenceHz,
   refreshToken = 0,
   systemDefaultOnly = false,
+  visualMode,
+  visualModeAriaLabel = "Default tuner",
+  visualModeLabel = "Default tuner",
 }: TunerPreferenceControlsProps) {
   const [devices, setDevices] = useState<TunerMicrophoneDevice[]>([]);
   const [deviceError, setDeviceError] = useState<string | null>(null);
@@ -164,6 +173,20 @@ export function TunerPreferenceControls({
           value={referenceDraft}
         />
       </label>
+
+      {visualMode && onVisualModeChange ? (
+        <label className="tuner-field">
+          <span>{visualModeLabel}</span>
+          <select
+            aria-label={visualModeAriaLabel}
+            onChange={(event) => onVisualModeChange(event.target.value as TunerVisualMode)}
+            value={visualMode}
+          >
+            <option value="wide-arc">Wide Arc</option>
+            <option value="simple">Simple Meter</option>
+          </select>
+        </label>
+      ) : null}
 
       {children}
 

--- a/apps/desktop/src/lib/preferences.tsx
+++ b/apps/desktop/src/lib/preferences.tsx
@@ -15,6 +15,7 @@ export type PlaybackDisplayMode = "lyrics" | "chords" | "combined";
 export type DefaultPlaybackDisplayMode = "auto" | PlaybackDisplayMode;
 export type DefaultChordBackend = "tuneforge-fast" | "crema-advanced";
 export type DefaultStemModel = "htdemucs_6s" | "htdemucs_ft";
+export type TunerVisualMode = "simple" | "wide-arc";
 export type { EnharmonicDisplayMode };
 
 export const DEFAULT_TUNER_REFERENCE_HZ = 440;
@@ -34,6 +35,7 @@ export type UiPreferences = {
   defaultChordsFollowEnabled: boolean;
   defaultTunerInputDeviceId: string | null;
   defaultTunerReferenceHz: number;
+  defaultTunerVisualMode: TunerVisualMode;
 };
 
 export type AppearancePreferences = Pick<UiPreferences, "informationDensity">;
@@ -41,7 +43,7 @@ export type NotationPreferences = Pick<UiPreferences, "enharmonicDisplayMode">;
 export type AnalysisPreferences = Pick<UiPreferences, "defaultChordBackend" | "defaultStemModel">;
 export type TunerPreferences = Pick<
   UiPreferences,
-  "defaultTunerInputDeviceId" | "defaultTunerReferenceHz"
+  "defaultTunerInputDeviceId" | "defaultTunerReferenceHz" | "defaultTunerVisualMode"
 >;
 export type VisibilityPreferences = Pick<
   UiPreferences,
@@ -66,6 +68,7 @@ type PreferencesContextValue = UiPreferences & {
   setDefaultChordsFollowEnabled: (value: boolean) => void;
   setDefaultTunerInputDeviceId: (value: string | null) => void;
   setDefaultTunerReferenceHz: (value: number) => void;
+  setDefaultTunerVisualMode: (value: TunerVisualMode) => void;
   replacePreferences: (value: UiPreferences) => void;
   resetAppearancePreferences: () => void;
   resetNotationPreferences: () => void;
@@ -93,6 +96,7 @@ export const DEFAULT_ANALYSIS_PREFERENCES: AnalysisPreferences = {
 export const DEFAULT_TUNER_PREFERENCES: TunerPreferences = {
   defaultTunerInputDeviceId: null,
   defaultTunerReferenceHz: DEFAULT_TUNER_REFERENCE_HZ,
+  defaultTunerVisualMode: "wide-arc",
 };
 
 export const DEFAULT_VISIBILITY_PREFERENCES: VisibilityPreferences = {
@@ -142,6 +146,10 @@ export function isDefaultChordBackend(value: unknown): value is DefaultChordBack
 
 export function isDefaultStemModel(value: unknown): value is DefaultStemModel {
   return value === "htdemucs_6s" || value === "htdemucs_ft";
+}
+
+function isTunerVisualMode(value: unknown): value is TunerVisualMode {
+  return value === "simple" || value === "wide-arc";
 }
 
 function normalizeTunerInputDeviceId(value: unknown): string | null {
@@ -199,6 +207,9 @@ export function normalizePreferences(value: unknown): UiPreferences {
       : DEFAULT_PREFERENCES.defaultStemModel,
     defaultTunerInputDeviceId: normalizeTunerInputDeviceId(candidate.defaultTunerInputDeviceId),
     defaultTunerReferenceHz: normalizeTunerReferenceHz(candidate.defaultTunerReferenceHz),
+    defaultTunerVisualMode: isTunerVisualMode(candidate.defaultTunerVisualMode)
+      ? candidate.defaultTunerVisualMode
+      : DEFAULT_PREFERENCES.defaultTunerVisualMode,
     defaultLyricsFollowEnabled:
       typeof candidate.defaultLyricsFollowEnabled === "boolean"
         ? candidate.defaultLyricsFollowEnabled
@@ -293,6 +304,9 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
             defaultTunerReferenceHz: normalizeTunerReferenceHz(defaultTunerReferenceHz),
           }),
         );
+      },
+      setDefaultTunerVisualMode: (defaultTunerVisualMode) => {
+        setPreferences((current) => mergePreferences(current, { defaultTunerVisualMode }));
       },
       replacePreferences: (value) => {
         const normalized = normalizePreferences(value);

--- a/apps/desktop/src/styles/tools.css
+++ b/apps/desktop/src/styles/tools.css
@@ -44,7 +44,7 @@
 
 .tuner-preferences {
   display: grid;
-  grid-template-columns: minmax(18rem, 1fr) minmax(12rem, 16rem);
+  grid-template-columns: minmax(16rem, 1fr) minmax(10rem, 12rem) minmax(10rem, 12rem);
   gap: 0.75rem;
   align-items: start;
 }
@@ -413,7 +413,9 @@
   background: var(--playback-accent);
   box-shadow: 0 0 0 0.32rem color-mix(in srgb, var(--playback-accent) 18%, transparent);
   transform: translate(-50%, -50%);
-  transition: opacity 90ms ease-out;
+  transition:
+    left 140ms ease-out,
+    opacity 90ms ease-out;
 }
 
 .simple-tuner-meter[data-tuning-state="no-pitch"] .simple-tuner-meter__marker {


### PR DESCRIPTION
## Summary

- Default the chromatic tuner to Wide Arc and persist the selected tuner view.
- Add the default tuner selector to Settings beside microphone source and A4 reference.
- Center the simple tuner marker while in tune and ease marker movement.

## Testing

- `pnpm --filter @tuneforge/desktop test -- App.tools-tuner.test.tsx App.settings-theme.test.tsx TunerMeters.test.tsx`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
- `git diff --check`
