### PR TITLE
feat: add beat bar timing artifacts

### DIFF
--- a/apps/backend/alembic/versions/0013_analysis_timing.py
+++ b/apps/backend/alembic/versions/0013_analysis_timing.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0013_analysis_timing"
+down_revision = "0012_backend_hash_storage"
+branch_labels = None
+depends_on = None
+
+
+def _has_analysis_results_table() -> bool:
+    return sa.inspect(op.get_bind()).has_table("analysis_results")
+
+
+def upgrade() -> None:
+    if not _has_analysis_results_table():
+        return
+    with op.batch_alter_table("analysis_results") as batch_op:
+        batch_op.add_column(sa.Column("timing_json", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    if not _has_analysis_results_table():
+        return
+    with op.batch_alter_table("analysis_results") as batch_op:
+        batch_op.drop_column("timing_json")

--- a/apps/backend/app/engines/analysis.py
+++ b/apps/backend/app/engines/analysis.py
@@ -8,6 +8,8 @@ import numpy as np
 from app.engines.audio_features import HarmonicFeatures, active_chroma_mean, extract_harmonic_features
 from app.engines.chords import ChordSegment, detect_chords_from_features
 
+BEATS_PER_BAR = 4
+
 MAJOR_PROFILE = np.array(
     [6.35, 2.23, 3.48, 2.33, 4.38, 4.09, 2.52, 5.19, 2.39, 3.66, 2.29, 2.88],
     dtype=np.float32,
@@ -38,12 +40,33 @@ MINOR_DIATONIC_QUALITIES: dict[int, set[str]] = {
 }
 
 
+class AnalysisTimingBeatPayload(TypedDict):
+    index: int
+    seconds: float
+    bar_index: int
+    beat_in_bar: int
+
+
+class AnalysisTimingBarPayload(TypedDict):
+    index: int
+    start_seconds: float
+    end_seconds: float
+
+
+class AnalysisTimingPayload(TypedDict):
+    beats_per_bar: int
+    source: str
+    beats: list[AnalysisTimingBeatPayload]
+    bars: list[AnalysisTimingBarPayload]
+
+
 class AnalysisPayload(TypedDict):
     estimated_key: str | None
     key_confidence: float | None
     estimated_reference_hz: float | None
     tuning_offset_cents: float | None
     tempo_bpm: float | None
+    timing: AnalysisTimingPayload | None
 
 
 def analyze_track(source_path: Path) -> AnalysisPayload:
@@ -55,6 +78,7 @@ def analyze_track(source_path: Path) -> AnalysisPayload:
             "estimated_reference_hz": None,
             "tuning_offset_cents": None,
             "tempo_bpm": None,
+            "timing": None,
         }
 
     chord_timeline = detect_chords_from_features(features)
@@ -65,7 +89,101 @@ def analyze_track(source_path: Path) -> AnalysisPayload:
         "estimated_reference_hz": features.estimated_reference_hz,
         "tuning_offset_cents": features.tuning_offset_cents,
         "tempo_bpm": features.tempo_bpm,
+        "timing": _build_timing_payload(features),
     }
+
+
+def _build_timing_payload(features: HarmonicFeatures) -> AnalysisTimingPayload | None:
+    if features.duration_seconds <= 0.0:
+        return None
+
+    beat_times = _detected_beat_times(features)
+    source = "detected"
+    if beat_times.size < BEATS_PER_BAR:
+        beat_times = _fallback_beat_times(features.tempo_bpm, features.duration_seconds)
+        source = "tempo_fallback"
+    if beat_times.size < 2:
+        return None
+
+    beats: list[AnalysisTimingBeatPayload] = [
+        {
+            "index": index,
+            "seconds": round(float(seconds), 6),
+            "bar_index": index // BEATS_PER_BAR,
+            "beat_in_bar": (index % BEATS_PER_BAR) + 1,
+        }
+        for index, seconds in enumerate(beat_times.tolist())
+    ]
+    bars = _timing_bars(beats, features.duration_seconds)
+    if not bars:
+        return None
+    payload: AnalysisTimingPayload = {
+        "beats_per_bar": BEATS_PER_BAR,
+        "source": source,
+        "beats": beats,
+        "bars": bars,
+    }
+    return payload
+
+
+def _detected_beat_times(features: HarmonicFeatures) -> np.ndarray:
+    if features.beat_frames.size == 0 or features.times.size == 0:
+        return np.zeros(0, dtype=np.float64)
+    beat_frames = features.beat_frames[features.beat_frames < features.times.size]
+    if beat_frames.size == 0:
+        return np.zeros(0, dtype=np.float64)
+    beat_times = features.times[beat_frames].astype(np.float64)
+    return _clean_beat_times(beat_times, features.duration_seconds)
+
+
+def _fallback_beat_times(tempo_bpm: float | None, duration_seconds: float) -> np.ndarray:
+    if tempo_bpm is None or tempo_bpm <= 0.0 or duration_seconds <= 0.0:
+        return np.zeros(0, dtype=np.float64)
+    beat_seconds = 60.0 / tempo_bpm
+    if beat_seconds <= 0.0:
+        return np.zeros(0, dtype=np.float64)
+    beat_times = np.arange(0.0, duration_seconds + beat_seconds * 0.5, beat_seconds)
+    return _clean_beat_times(beat_times, duration_seconds)
+
+
+def _clean_beat_times(beat_times: np.ndarray, duration_seconds: float) -> np.ndarray:
+    finite_times = beat_times[np.isfinite(beat_times)]
+    bounded_times = finite_times[
+        (finite_times >= 0.0) & (finite_times <= duration_seconds + 1e-6)
+    ]
+    if bounded_times.size == 0:
+        return np.zeros(0, dtype=np.float64)
+    ordered_times = np.sort(bounded_times.astype(np.float64))
+    deduped: list[float] = []
+    for seconds in ordered_times.tolist():
+        if not deduped or seconds - deduped[-1] >= 0.05:
+            deduped.append(seconds)
+    return np.asarray(deduped, dtype=np.float64)
+
+
+def _timing_bars(
+    beats: list[AnalysisTimingBeatPayload],
+    duration_seconds: float,
+) -> list[AnalysisTimingBarPayload]:
+    bars: list[AnalysisTimingBarPayload] = []
+    for beat_index in range(0, len(beats), BEATS_PER_BAR):
+        start_seconds = beats[beat_index]["seconds"]
+        next_bar_index = beat_index + BEATS_PER_BAR
+        end_seconds = (
+            beats[next_bar_index]["seconds"]
+            if next_bar_index < len(beats)
+            else max(duration_seconds, start_seconds)
+        )
+        if end_seconds <= start_seconds:
+            continue
+        bars.append(
+            {
+                "index": beat_index // BEATS_PER_BAR,
+                "start_seconds": round(float(start_seconds), 6),
+                "end_seconds": round(float(end_seconds), 6),
+            }
+        )
+    return bars
 
 
 def _estimate_key(

--- a/apps/backend/app/models.py
+++ b/apps/backend/app/models.py
@@ -63,7 +63,8 @@ class AnalysisResult(Base):
     estimated_reference_hz: Mapped[float | None] = mapped_column(Float(), nullable=True)
     tuning_offset_cents: Mapped[float | None] = mapped_column(Float(), nullable=True)
     tempo_bpm: Mapped[float | None] = mapped_column(Float(), nullable=True)
-    analysis_version: Mapped[str] = mapped_column(String(32), default="v2")
+    timing_json: Mapped[dict[str, Any] | None] = mapped_column(JSON(), nullable=True)
+    analysis_version: Mapped[str] = mapped_column(String(32), default="v3")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
 
     project: Mapped[Project] = relationship(back_populates="analysis")

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -140,6 +140,26 @@ class AnalysisRequest(BaseModel):
     force: bool = False
 
 
+class AnalysisTimingBeatSchema(BaseModel):
+    index: int
+    seconds: float
+    bar_index: int
+    beat_in_bar: int
+
+
+class AnalysisTimingBarSchema(BaseModel):
+    index: int
+    start_seconds: float
+    end_seconds: float
+
+
+class AnalysisTimingSchema(BaseModel):
+    beats_per_bar: int
+    source: str
+    beats: list[AnalysisTimingBeatSchema] = Field(default_factory=list)
+    bars: list[AnalysisTimingBarSchema] = Field(default_factory=list)
+
+
 class AnalysisSchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -150,6 +170,7 @@ class AnalysisSchema(BaseModel):
     estimated_reference_hz: float | None
     tuning_offset_cents: float | None
     tempo_bpm: float | None
+    timing: AnalysisTimingSchema | None = Field(default=None, validation_alias="timing_json")
     analysis_version: str
     created_at: datetime
 

--- a/apps/backend/app/services/analysis.py
+++ b/apps/backend/app/services/analysis.py
@@ -25,24 +25,24 @@ def analyze_project(session: Session, project: Project) -> AnalysisResult:
     analysis.estimated_reference_hz = results["estimated_reference_hz"]  # type: ignore[assignment]
     analysis.tuning_offset_cents = results["tuning_offset_cents"]  # type: ignore[assignment]
     analysis.tempo_bpm = results["tempo_bpm"]  # type: ignore[assignment]
-    analysis.analysis_version = "v2"
+    analysis.timing_json = results["timing"]  # type: ignore[assignment]
+    analysis.analysis_version = "v3"
     session.flush()
 
+    analysis_payload = {
+        "project_id": project.id,
+        "source_artifact_id": analysis.source_artifact_id,
+        "estimated_key": analysis.estimated_key,
+        "key_confidence": analysis.key_confidence,
+        "estimated_reference_hz": analysis.estimated_reference_hz,
+        "tuning_offset_cents": analysis.tuning_offset_cents,
+        "tempo_bpm": analysis.tempo_bpm,
+        "timing": analysis.timing_json,
+        "analysis_version": analysis.analysis_version,
+    }
     analysis_path = project_analysis_dir(project.id) / "analysis.json"
     analysis_path.write_text(
-        json.dumps(
-            {
-                "project_id": project.id,
-                "source_artifact_id": analysis.source_artifact_id,
-                "estimated_key": analysis.estimated_key,
-                "key_confidence": analysis.key_confidence,
-                "estimated_reference_hz": analysis.estimated_reference_hz,
-                "tuning_offset_cents": analysis.tuning_offset_cents,
-                "tempo_bpm": analysis.tempo_bpm,
-                "analysis_version": analysis.analysis_version,
-            },
-            indent=2,
-        ),
+        json.dumps(analysis_payload, indent=2),
         encoding="utf-8",
     )
 

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -94,6 +94,26 @@ def sample_audio_file(tmp_path: Path) -> Path:
 
 
 @pytest.fixture()
+def sample_rhythmic_audio_file(tmp_path: Path) -> Path:
+    sample_rate = 44100
+    duration = 8.0
+    timeline = np.linspace(0, duration, int(sample_rate * duration), endpoint=False)
+    signal = (
+        0.28 * np.sin(2 * np.pi * 261.63 * timeline)
+        + 0.22 * np.sin(2 * np.pi * 329.63 * timeline)
+        + 0.18 * np.sin(2 * np.pi * 392.0 * timeline)
+    )
+    interval = 0.5
+    pulse = np.zeros_like(timeline)
+    for start in np.arange(0.0, duration, interval):
+        distance = np.abs(timeline - start)
+        pulse += 0.26 * np.exp(-((distance / 0.012) ** 2))
+    output_path = tmp_path / "fixture_rhythmic.wav"
+    sf.write(output_path, (signal + pulse).astype(np.float32), sample_rate)
+    return output_path
+
+
+@pytest.fixture()
 def sample_stereo_audio_file(tmp_path: Path) -> Path:
     sample_rate = 44100
     duration = 2.0

--- a/apps/backend/tests/test_analysis_flow.py
+++ b/apps/backend/tests/test_analysis_flow.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from .conftest import wait_for_job
 
 
-def test_analysis_job_persists_results(client, sample_audio_file: Path):
+def test_analysis_job_persists_results(client, sample_rhythmic_audio_file: Path):
     project = client.post(
         "/api/v1/projects/import",
-        json={"source_path": str(sample_audio_file), "copy_into_project": True},
+        json={"source_path": str(sample_rhythmic_audio_file), "copy_into_project": True},
     ).json()["project"]
 
     initial_jobs = client.get("/api/v1/jobs").json()["jobs"]
@@ -34,6 +35,10 @@ def test_analysis_job_persists_results(client, sample_audio_file: Path):
     assert analysis["estimated_reference_hz"] is not None
     assert analysis["tuning_offset_cents"] is not None
     assert analysis["estimated_key"] is not None
+    assert analysis["timing"] is not None
+    assert analysis["analysis_version"] == "v3"
+    assert analysis["timing"]["beats_per_bar"] == 4
+    assert analysis["timing"]["beats"][0]["beat_in_bar"] == 1
 
     artifacts = client.get(f"/api/v1/projects/{project['id']}/artifacts").json()["artifacts"]
     source_artifact = next(artifact for artifact in artifacts if artifact["type"] == "source_audio")
@@ -41,6 +46,8 @@ def test_analysis_job_persists_results(client, sample_audio_file: Path):
     assert len(analysis_artifacts) == 1
     assert analysis["source_artifact_id"] == source_artifact["id"]
     assert analysis_artifacts[0]["metadata"]["source_artifact_id"] == source_artifact["id"]
+    analysis_payload = json.loads(Path(analysis_artifacts[0]["path"]).read_text(encoding="utf-8"))
+    assert analysis_payload["timing"] == analysis["timing"]
 
     refresh_job = client.post(
         f"/api/v1/projects/{project['id']}/analyze",

--- a/apps/backend/tests/test_audio_analysis_engines.py
+++ b/apps/backend/tests/test_audio_analysis_engines.py
@@ -123,6 +123,7 @@ def test_chord_engine_handles_silence_and_short_audio(tmp_path: Path):
         "estimated_reference_hz": None,
         "tuning_offset_cents": None,
         "tempo_bpm": None,
+        "timing": None,
     }
 
     silence_path = tmp_path / "silence.wav"
@@ -172,6 +173,16 @@ def test_analysis_uses_harmonic_features_for_key_tuning_and_tempo(tmp_path: Path
     rhythmic = analyze_track(rhythmic_path)
     assert rhythmic["tempo_bpm"] is not None
     assert 100.0 <= rhythmic["tempo_bpm"] <= 140.0
+    assert rhythmic["timing"] is not None
+    assert rhythmic["timing"]["beats_per_bar"] == 4
+    assert rhythmic["timing"]["source"] in {"detected", "tempo_fallback"}
+    assert len(rhythmic["timing"]["beats"]) >= 4
+    assert len(rhythmic["timing"]["bars"]) >= 1
+    beat_seconds = [beat["seconds"] for beat in rhythmic["timing"]["beats"]]
+    assert beat_seconds == sorted(beat_seconds)
+    median_beat_seconds = float(np.median(np.diff(np.asarray(beat_seconds[:8]))))
+    assert 0.35 <= median_beat_seconds <= 0.65
+    assert rhythmic["timing"]["beats"][0]["beat_in_bar"] == 1
 
 
 def test_analysis_keeps_common_borrowed_chords_in_major_context(tmp_path: Path):

--- a/apps/desktop/src/App.project-precount.test.tsx
+++ b/apps/desktop/src/App.project-precount.test.tsx
@@ -21,6 +21,30 @@ const analysisWithTempo = {
   created_at: "2026-04-18T13:16:00.000Z",
 };
 
+const analysisWithTiming = {
+  ...analysisWithTempo,
+  timing: {
+    beats_per_bar: 4,
+    source: "detected",
+    beats: [
+      { index: 0, seconds: 0, bar_index: 0, beat_in_bar: 1 },
+      { index: 1, seconds: 0.48, bar_index: 0, beat_in_bar: 2 },
+      { index: 2, seconds: 1.01, bar_index: 0, beat_in_bar: 3 },
+      { index: 3, seconds: 1.5, bar_index: 0, beat_in_bar: 4 },
+      { index: 4, seconds: 2.04, bar_index: 1, beat_in_bar: 1 },
+      { index: 5, seconds: 2.52, bar_index: 1, beat_in_bar: 2 },
+      { index: 6, seconds: 3.02, bar_index: 1, beat_in_bar: 3 },
+      { index: 7, seconds: 3.51, bar_index: 1, beat_in_bar: 4 },
+      { index: 8, seconds: 4.04, bar_index: 2, beat_in_bar: 1 },
+    ],
+    bars: [
+      { index: 0, start_seconds: 0, end_seconds: 2.04 },
+      { index: 1, start_seconds: 2.04, end_seconds: 4.04 },
+      { index: 2, start_seconds: 4.04, end_seconds: 6 },
+    ],
+  },
+};
+
 function setupTempoAnalysis() {
   setProjectAnalysis("proj_123", analysisWithTempo);
 }
@@ -274,6 +298,110 @@ describe("Desktop app project playback pre-count", () => {
     );
     vi.useRealTimers();
   }, 15000);
+
+  it("uses timing-grid spacing for loop pre-counts when available", async () => {
+    const user = userEvent.setup();
+    setProjectAnalysis("proj_123", analysisWithTiming);
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    setPlaybackPosition("2.04");
+    await user.click(screen.getByRole("button", { name: "Set loop start" }));
+    setPlaybackPosition("4.04");
+    await user.click(screen.getByRole("button", { name: "Set loop end" }));
+
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    vi.useFakeTimers();
+
+    fireEvent.click(screen.getByLabelText("Enable loop pre-count"));
+    fireEvent.click(screen.getByRole("button", { name: "Play playback" }));
+    await flushMicrotasks();
+
+    const audioContext = getMockAudioContexts()[0];
+    expect(audioContext?.createdOscillators).toHaveLength(4);
+    const clickStartTimes = audioContext?.createdOscillators.map(
+      (oscillator) => oscillator.start.mock.calls[0]?.[0],
+    ) ?? [];
+    expect(Number(clickStartTimes[1]) - Number(clickStartTimes[0])).toBeCloseTo(0.48, 3);
+    expect(Number(clickStartTimes[2]) - Number(clickStartTimes[1])).toBeCloseTo(0.53, 3);
+    expect(Number(clickStartTimes[3]) - Number(clickStartTimes[2])).toBeCloseTo(0.49, 3);
+
+    act(() => {
+      vi.advanceTimersByTime(2075);
+    });
+    await flushMicrotasks();
+
+    expect(audioContext?.createdSources[0]?.start.mock.calls[0]?.[0]).toBeCloseTo(2.075, 3);
+    expect(audioContext?.createdSources[0]?.start.mock.calls[0]?.[1]).toBeCloseTo(2.04, 3);
+    vi.useRealTimers();
+  }, 15000);
+
+  it("snaps newly set loops by the project loop alignment mode", async () => {
+    const user = userEvent.setup();
+    setProjectAnalysis("proj_123", analysisWithTiming);
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+
+    await user.click(screen.getByRole("button", { name: "Beat" }));
+    setPlaybackPosition("1.9");
+    await user.click(screen.getByRole("button", { name: "Set loop start" }));
+    setPlaybackPosition("3.8");
+    await user.click(screen.getByRole("button", { name: "Set loop end" }));
+
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    await waitFor(() => expect(getMockAudioContexts()[0]?.createdSources).toHaveLength(1));
+    expect(getMockAudioContexts()[0]?.createdSources[0]?.start.mock.calls[0]?.[1]).toBeCloseTo(
+      2.04,
+      3,
+    );
+    const storedPlaybackState = JSON.parse(
+      window.localStorage.getItem("tuneforge.project-playback-state") ?? "{}",
+    );
+    expect(storedPlaybackState.proj_123.loopAlignmentMode).toBe("beat");
+  });
+
+  it("keeps project loop alignment override after resetting global settings", async () => {
+    const user = userEvent.setup();
+    const settingsRender = renderApp(["/settings"]);
+
+    expect(await screen.findByRole("heading", { name: "Control Room" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /^Bar/ }));
+    settingsRender.unmount();
+
+    setProjectAnalysis("proj_123", analysisWithTiming);
+    const projectRender = renderApp(["/projects/proj_123"]);
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    expect(screen.getByRole("button", { name: "Bar" })).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(screen.getByRole("button", { name: "Beat" }));
+    projectRender.unmount();
+
+    const resetRender = renderApp(["/settings"]);
+    expect(await screen.findByRole("heading", { name: "Control Room" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Reset All Settings" }));
+
+    expect(JSON.parse(window.localStorage.getItem("tuneforge.ui-preferences") ?? "{}")).toMatchObject({
+      defaultLoopAlignmentMode: "free",
+    });
+    const storedProjectPlaybackState = JSON.parse(
+      window.localStorage.getItem("tuneforge.project-playback-state") ?? "{}",
+    );
+    expect(storedProjectPlaybackState.proj_123.loopAlignmentMode).toBe("beat");
+    resetRender.unmount();
+
+    renderApp(["/projects/proj_123"]);
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    expect(screen.getByRole("button", { name: "Beat" })).toHaveAttribute("aria-pressed", "true");
+  });
 
   it("does not use song pre-count for a nonzero loop start", async () => {
     const user = userEvent.setup();

--- a/apps/desktop/src/App.settings-theme.test.tsx
+++ b/apps/desktop/src/App.settings-theme.test.tsx
@@ -160,6 +160,7 @@ describe("Desktop app settings theme", () => {
     await user.click(screen.getByRole("button", { name: /^Prefer sharps/ }));
     await user.click(screen.getByRole("button", { name: /^Playback first/ }));
     await user.click(screen.getByRole("button", { name: /^Lyrics \+ chords/ }));
+    await user.click(screen.getByRole("button", { name: /^Beat/ }));
     await user.click(screen.getByRole("button", { name: /^Advanced Chords/ }));
     await user.click(screen.getByText("Show diagnostics"));
     expect(await screen.findByText("/tmp/tuneforge")).toBeInTheDocument();
@@ -189,6 +190,7 @@ describe("Desktop app settings theme", () => {
         defaultSourcesRailCollapsed: false,
         defaultProjectWorkspace: "playback",
         defaultPlaybackDisplayMode: "combined",
+        defaultLoopAlignmentMode: "beat",
         defaultChordBackend: "crema-advanced",
         defaultLyricsFollowEnabled: true,
         defaultChordsFollowEnabled: true,

--- a/apps/desktop/src/App.tools-metronome.test.tsx
+++ b/apps/desktop/src/App.tools-metronome.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -14,6 +14,33 @@ import {
 function getMetronomeAudioContext() {
   return getMockAudioContexts().find((context) => context.createdOscillators.length > 0);
 }
+
+const timingAnalysis = {
+  project_id: "proj_123",
+  estimated_key: "G major",
+  key_confidence: 0.82,
+  estimated_reference_hz: 440,
+  tuning_offset_cents: 0,
+  tempo_bpm: 60,
+  analysis_version: "v3",
+  created_at: "2026-04-18T13:16:00.000Z",
+  timing: {
+    beats_per_bar: 4,
+    source: "detected",
+    beats: [
+      { index: 0, seconds: 0, bar_index: 0, beat_in_bar: 1 },
+      { index: 1, seconds: 0.12, bar_index: 0, beat_in_bar: 2 },
+      { index: 2, seconds: 0.24, bar_index: 0, beat_in_bar: 3 },
+      { index: 3, seconds: 0.36, bar_index: 0, beat_in_bar: 4 },
+      { index: 4, seconds: 0.48, bar_index: 1, beat_in_bar: 1 },
+      { index: 5, seconds: 0.62, bar_index: 1, beat_in_bar: 2 },
+    ],
+    bars: [
+      { index: 0, start_seconds: 0, end_seconds: 0.48 },
+      { index: 1, start_seconds: 0.48, end_seconds: 1 },
+    ],
+  },
+};
 
 describe("Desktop app tools metronome", () => {
   beforeEach(resetAppTestHarness);
@@ -152,6 +179,37 @@ describe("Desktop app tools metronome", () => {
     await waitFor(() =>
       expect(syncedContext?.createdOscillators.length).toBeGreaterThan(scheduledBeforePause),
     );
+  });
+
+  it("schedules followed clicks from analysis timing when available", async () => {
+    const user = userEvent.setup();
+    setProjectAnalysis("proj_123", timingAnalysis);
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    await user.click(screen.getByRole("tab", { name: "Playback" }));
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument(),
+    );
+    act(() => {
+      sourceAudio.currentTime = 0.45;
+      fireEvent.timeUpdate(sourceAudio);
+    });
+
+    await user.click(screen.getByRole("link", { name: "Tools" }));
+    await user.click(await screen.findByRole("tab", { name: "Metronome" }));
+    await user.click(screen.getByLabelText("Follow project playback"));
+
+    await waitFor(() => {
+      const frequencies =
+        getMetronomeAudioContext()?.createdOscillators.flatMap((oscillator) =>
+          oscillator.frequency.setValueAtTime.mock.calls.map((call) => call[0]),
+        ) ?? [];
+      expect(frequencies).toContain(1760);
+    });
   });
 
   it("keeps synced metronome armed when opening the playback project page", async () => {

--- a/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
@@ -1,5 +1,6 @@
 import { type KeyboardEvent, useEffect, useRef, useState } from "react";
 import { ArrowUpDown, AudioLines, Drumstick, Gauge, Layers } from "lucide-react";
+import { LOOP_ALIGNMENT_MODES, type LoopAlignmentMode } from "../../../lib/timingGrid";
 import {
   artifactLabel,
   artifactSummary,
@@ -21,6 +22,7 @@ export function PlaybackPracticeRail() {
     enharmonicDisplayMode,
     canUseTempo,
     handleSetPlaybackTempo,
+    handleSetLoopAlignmentMode,
     handleResetPlaybackTempo,
     handleSelectPrimaryArtifact,
     handleSelectStemArtifact,
@@ -33,6 +35,7 @@ export function PlaybackPracticeRail() {
     isStemPlayback,
     lowerCapoPreview,
     lowerCapoShiftOptions,
+    loopAlignmentMode,
     precountClickCount,
     precountDisabledReason,
     precountEnabled,
@@ -70,6 +73,11 @@ export function PlaybackPracticeRail() {
         ? `Original ${tempoOriginalBpm.toFixed(1)} BPM`
         : `${tempoTargetBpm.toFixed(0)} BPM (${tempoPlaybackRate.toFixed(3)}x)`
       : "Waiting for tempo analysis";
+  const loopAlignmentLabel = (mode: LoopAlignmentMode) => {
+    if (mode === "beat") return "Beat";
+    if (mode === "bar") return "Bar";
+    return "Exact";
+  };
   const [tempoDraftText, setTempoDraftText] = useState(() =>
     tempoDisplayBpm === null
       ? ""
@@ -301,6 +309,26 @@ export function PlaybackPracticeRail() {
             ? `${precountClickCount} clicks at ${precountTempoBpm.toFixed(1)} BPM`
             : precountDisabledReason}
         </p>
+      </section>
+
+      <section className="playback-loop-alignment-control" aria-labelledby="playback-loop-alignment-heading">
+        <div>
+          <p className="metric-label">Loop</p>
+          <h3 id="playback-loop-alignment-heading">Alignment</h3>
+        </div>
+        <div className="playback-loop-alignment-control__segments" role="group" aria-label="Loop alignment">
+          {LOOP_ALIGNMENT_MODES.map((mode) => (
+            <button
+              aria-pressed={loopAlignmentMode === mode}
+              className="button button--ghost button--small"
+              key={mode}
+              onClick={() => handleSetLoopAlignmentMode(mode)}
+              type="button"
+            >
+              {loopAlignmentLabel(mode)}
+            </button>
+          ))}
+        </div>
       </section>
 
       <section

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -4,6 +4,13 @@ import { useNavigate, useParams } from "react-router-dom";
 import { confirm, save } from "@tauri-apps/plugin-dialog";
 import { api, type ArtifactSchema, type ProjectSchema } from "../../../lib/api";
 import { usePreferences } from "../../../lib/preferences";
+import {
+  normalizeAnalysisTimingGrid,
+  normalizeLoopAlignmentMode,
+  snapLoopPointToTiming,
+  type AnalysisTimingGrid,
+  type LoopAlignmentMode,
+} from "../../../lib/timingGrid";
 import { usePlayback } from "../playback-context";
 import {
   DEFAULT_PRECOUNT_CLICK_COUNT,
@@ -106,9 +113,17 @@ function loopRangeFromPoints(
   firstPoint: number,
   secondPoint: number,
   durationSeconds: number,
+  loopAlignmentMode: LoopAlignmentMode = "free",
+  timingGrid: AnalysisTimingGrid | null = null,
 ): PlaybackLoopRange {
-  const boundedFirstPoint = clampPlaybackLoopPoint(firstPoint, durationSeconds);
-  const boundedSecondPoint = clampPlaybackLoopPoint(secondPoint, durationSeconds);
+  const boundedFirstPoint = clampPlaybackLoopPoint(
+    snapLoopPointToTiming(firstPoint, loopAlignmentMode, timingGrid),
+    durationSeconds,
+  );
+  const boundedSecondPoint = clampPlaybackLoopPoint(
+    snapLoopPointToTiming(secondPoint, loopAlignmentMode, timingGrid),
+    durationSeconds,
+  );
   let startSeconds = Math.min(boundedFirstPoint, boundedSecondPoint);
   let endSeconds = Math.max(boundedFirstPoint, boundedSecondPoint);
 
@@ -147,6 +162,7 @@ export function useProjectViewModel() {
     defaultPlaybackDisplayMode,
     defaultChordsFollowEnabled,
     defaultInspectorOpen,
+    defaultLoopAlignmentMode,
     defaultLyricsFollowEnabled,
     defaultProjectWorkspace,
     defaultSourcesRailCollapsed,
@@ -189,6 +205,8 @@ export function useProjectViewModel() {
   const [precountClickCount, setPrecountClickCount] = useState(DEFAULT_PRECOUNT_CLICK_COUNT);
   const [tempoTargetBpm, setTempoTargetBpm] = useState<number | null>(null);
   const [loopRange, setLoopRange] = useState<PlaybackLoopRange | null>(null);
+  const [loopAlignmentModeOverride, setLoopAlignmentModeOverride] =
+    useState<LoopAlignmentMode | null>(null);
   const [pendingLoopStartSeconds, setPendingLoopStartSeconds] = useState<number | null>(null);
   const [loopStatusMessage, setLoopStatusMessage] = useState<
     "Loop in" | "Loop set" | "Loop cleared" | null
@@ -625,7 +643,12 @@ export function useProjectViewModel() {
     ? artifactSummary(selectedPlaybackArtifact)
     : "";
 
+  const analysisTimingGrid = useMemo(
+    () => normalizeAnalysisTimingGrid(analysisQuery.data?.timing),
+    [analysisQuery.data?.timing],
+  );
   const detectedKey = parseKey(analysisQuery.data?.estimated_key);
+  const loopAlignmentMode = loopAlignmentModeOverride ?? defaultLoopAlignmentMode;
   const tempoOriginalBpm = normalizeTempoBpm(analysisQuery.data?.tempo_bpm);
   const tempoTargetBpmForPlayback = tempoOriginalBpm === null ? null : tempoTargetBpm;
   const tempoDisplayBpm = tempoTargetBpmForPlayback ?? tempoOriginalBpm;
@@ -1028,6 +1051,10 @@ export function useProjectViewModel() {
     setPrecountClickCount(normalizePrecountClickCount(value));
   }
 
+  function handleSetLoopAlignmentMode(value: LoopAlignmentMode) {
+    setLoopAlignmentModeOverride(normalizeLoopAlignmentMode(value));
+  }
+
   function handleDecreasePlaybackTempo() {
     if (!canUseTempo) {
       return;
@@ -1078,6 +1105,8 @@ export function useProjectViewModel() {
         pendingLoopStartSeconds,
         playbackTimeSeconds,
         playbackDurationSeconds || projectQuery.data?.duration_seconds || 0,
+        loopAlignmentMode,
+        analysisTimingGrid,
       );
       setLoopRange(nextLoopRange);
       setPendingLoopStartSeconds(null);
@@ -1493,6 +1522,7 @@ export function useProjectViewModel() {
     setPrecountClickCount(storedPlaybackState.precountClickCount);
     setTempoTargetBpm(storedPlaybackState.tempoTargetBpm);
     setLoopRange(storedPlaybackState.loopRange);
+    setLoopAlignmentModeOverride(storedPlaybackState.loopAlignmentMode);
     setPendingLoopStartSeconds(null);
     setLoopStatusMessage(null);
     setPlaybackDisplayModeSource(hasStoredPlayback ? "stored" : "default");
@@ -1653,6 +1683,7 @@ export function useProjectViewModel() {
       precountClickCount,
       tempoTargetBpm,
       loopRange,
+      loopAlignmentMode: loopAlignmentModeOverride,
       lyricsFollowEnabled,
       chordsFollowEnabled,
       stemControls,
@@ -1667,6 +1698,7 @@ export function useProjectViewModel() {
     hydratedProjectId,
     lyricsFollowEnabled,
     loopRange,
+    loopAlignmentModeOverride,
     playbackDisplayMode,
     precountClickCount,
     precountEnabled,
@@ -1906,9 +1938,11 @@ export function useProjectViewModel() {
       precountTempoBpm,
       tempoOriginalBpm,
       tempoTargetBpm: tempoTargetBpmForPlayback,
+      timingGrid: analysisTimingGrid,
       loopRange,
     });
   }, [
+    analysisTimingGrid,
     hydratedProjectId,
     isStemPlayback,
     projectId,
@@ -2001,6 +2035,7 @@ export function useProjectViewModel() {
     handleSetPrecountClickCount,
     handleSetPrecountEnabled,
     handleSetPrecountLoopEnabled,
+    handleSetLoopAlignmentMode,
     handleIncreasePlaybackTempo,
     handleSetPlaybackTempo,
     handleAcceptTabSuggestionGroup,
@@ -2036,6 +2071,8 @@ export function useProjectViewModel() {
     isMobileRuntime,
     isPlaying,
     loopRange,
+    loopAlignmentMode,
+    loopAlignmentModeOverride,
     loopStatusMessage,
     isDeleteArtifactsPending,
     isDeleteMixDisabled,

--- a/apps/desktop/src/features/projects/playback-context.ts
+++ b/apps/desktop/src/features/projects/playback-context.ts
@@ -1,4 +1,5 @@
 import { createContext, useContext } from "react";
+import type { AnalysisTimingGrid } from "../../lib/timingGrid";
 import type { PlaybackLoopRange, StemControlState } from "./projectPlaybackState";
 
 export type ProjectPlaybackSession = {
@@ -20,6 +21,7 @@ export type ProjectPlaybackSession = {
   precountTempoBpm: number | null;
   tempoOriginalBpm: number | null;
   tempoTargetBpm: number | null;
+  timingGrid: AnalysisTimingGrid | null;
   loopRange: PlaybackLoopRange | null;
 };
 

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -34,6 +34,7 @@ import {
   primeWebAudioContext,
 } from "../../lib/webAudio";
 import { useStableCallback } from "../../lib/useStableCallback";
+import { countInIntervalsForTiming } from "../../lib/timingGrid";
 import {
   PlaybackContext,
   type PlaybackContextValue,
@@ -1873,13 +1874,22 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     setPlaybackTimeSeconds(startTimeSeconds);
 
     const beatSeconds = 60 / tempoBpm;
+    const countInIntervals = countInIntervalsForTiming({
+      clickCount,
+      fallbackBeatSeconds: beatSeconds,
+      startTimeSeconds,
+      timingGrid: targetSession.timingGrid,
+    });
     const firstClickTimeSeconds = precountAudio.context.currentTime + PRECOUNT_START_DELAY_SECONDS;
-    const playbackStartTimeSeconds = firstClickTimeSeconds + clickCount * beatSeconds;
+    const playbackStartTimeSeconds =
+      firstClickTimeSeconds + countInIntervals.reduce((total, interval) => total + interval, 0);
+    let nextClickTimeSeconds = firstClickTimeSeconds;
     for (let index = 0; index < clickCount; index += 1) {
       schedulePrecountClaveClick({
         audioContext: precountAudio.context,
-        startTimeSeconds: firstClickTimeSeconds + index * beatSeconds,
+        startTimeSeconds: nextClickTimeSeconds,
       });
+      nextClickTimeSeconds += countInIntervals[index] ?? beatSeconds;
     }
 
     const timeoutId = window.setTimeout(() => {

--- a/apps/desktop/src/features/projects/projectPlaybackState.ts
+++ b/apps/desktop/src/features/projects/projectPlaybackState.ts
@@ -4,6 +4,10 @@ import {
   type PlaybackDisplayMode,
   type ProjectWorkspaceMode,
 } from "../../lib/preferences";
+import {
+  normalizeLoopAlignmentMode,
+  type LoopAlignmentMode,
+} from "../../lib/timingGrid";
 import { normalizeTempoTargetBpm } from "./playbackTempo";
 
 export type ProjectPanelMode = "studio" | "analysis";
@@ -36,6 +40,7 @@ export type StoredProjectPlaybackState = {
   precountClickCount: number;
   tempoTargetBpm: number | null;
   loopRange: PlaybackLoopRange | null;
+  loopAlignmentMode: LoopAlignmentMode | null;
   lyricsFollowEnabled: boolean;
   chordsFollowEnabled: boolean;
   stemControls: Record<string, StemControlState>;
@@ -57,6 +62,7 @@ const DEFAULT_STORED_PROJECT_PLAYBACK_STATE: StoredProjectPlaybackState = {
   precountClickCount: DEFAULT_PRECOUNT_CLICK_COUNT,
   tempoTargetBpm: null,
   loopRange: null,
+  loopAlignmentMode: null,
   lyricsFollowEnabled: true,
   chordsFollowEnabled: true,
   stemControls: {},
@@ -176,6 +182,10 @@ function normalizeStoredProjectPlaybackState(value: unknown): StoredProjectPlayb
     precountClickCount: normalizePrecountClickCount(candidate.precountClickCount),
     tempoTargetBpm: normalizeTempoTargetBpm(candidate.tempoTargetBpm),
     loopRange: normalizePlaybackLoopRange(candidate.loopRange),
+    loopAlignmentMode:
+      candidate.loopAlignmentMode === null || candidate.loopAlignmentMode === undefined
+        ? null
+        : normalizeLoopAlignmentMode(candidate.loopAlignmentMode),
     lyricsFollowEnabled:
       typeof candidate.lyricsFollowEnabled === "boolean"
         ? candidate.lyricsFollowEnabled

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -24,6 +24,7 @@ import {
   type DefaultStemModel,
   type EnharmonicDisplayMode,
   type InformationDensity,
+  type LoopAlignmentMode,
   type ProjectWorkspaceMode,
   type TunerVisualMode,
 } from "../../lib/preferences";
@@ -157,6 +158,24 @@ const playbackDisplayOptions: ChoiceOption<DefaultPlaybackDisplayMode>[] = [
   },
 ];
 
+const loopAlignmentOptions: ChoiceOption<LoopAlignmentMode>[] = [
+  {
+    value: "free",
+    label: "Exact",
+    description: "Keep loop points where they are set.",
+  },
+  {
+    value: "beat",
+    label: "Beat",
+    description: "Snap new loop points to detected beats.",
+  },
+  {
+    value: "bar",
+    label: "Bar",
+    description: "Snap new loop points to inferred bar starts.",
+  },
+];
+
 const fallbackChordBackendOptions: ChoiceOption<DefaultChordBackend>[] = [
   {
     value: "tuneforge-fast",
@@ -219,6 +238,12 @@ function playbackDisplayLabel(value: DefaultPlaybackDisplayMode) {
   if (value === "combined") return "Lyrics + chords";
   if (value === "lyrics") return "Lyrics";
   return "Chords";
+}
+
+function loopAlignmentLabel(value: LoopAlignmentMode) {
+  if (value === "beat") return "Beat";
+  if (value === "bar") return "Bar";
+  return "Exact";
 }
 
 function chordBackendLabel(value: DefaultChordBackend) {
@@ -427,6 +452,7 @@ export function SettingsView() {
     defaultSourcesRailCollapsed,
     defaultProjectWorkspace,
     defaultPlaybackDisplayMode,
+    defaultLoopAlignmentMode,
     defaultChordBackend,
     defaultStemModel,
     defaultLyricsFollowEnabled,
@@ -438,6 +464,7 @@ export function SettingsView() {
     setEnharmonicDisplayMode,
     setDefaultProjectWorkspace,
     setDefaultPlaybackDisplayMode,
+    setDefaultLoopAlignmentMode,
     setDefaultChordBackend,
     setDefaultStemModel,
     setDefaultLyricsFollowEnabled,
@@ -534,6 +561,7 @@ export function SettingsView() {
         preferences: {
           defaultChordsFollowEnabled,
           defaultChordBackend,
+          defaultLoopAlignmentMode,
           defaultStemModel,
           defaultInspectorOpen,
           defaultPlaybackDisplayMode,
@@ -645,6 +673,10 @@ export function SettingsView() {
           <div className="settings-overview__stat">
             <dt>Playback view</dt>
             <dd>{playbackDisplayLabel(defaultPlaybackDisplayMode)}</dd>
+          </div>
+          <div className="settings-overview__stat">
+            <dt>Loop alignment</dt>
+            <dd>{loopAlignmentLabel(defaultLoopAlignmentMode)}</dd>
           </div>
           <div className="settings-overview__stat">
             <dt>Chord backend</dt>
@@ -829,6 +861,14 @@ export function SettingsView() {
             onChange={setDefaultPlaybackDisplayMode}
             options={playbackDisplayOptions}
             value={defaultPlaybackDisplayMode}
+          />
+
+          <ChoiceGroup
+            description="Choose how new project loops align before that project stores its own mode."
+            legend="Default loop alignment"
+            onChange={setDefaultLoopAlignmentMode}
+            options={loopAlignmentOptions}
+            value={defaultLoopAlignmentMode}
           />
 
           <div className="settings-toggle-list">

--- a/apps/desktop/src/features/tools/metronome.tsx
+++ b/apps/desktop/src/features/tools/metronome.tsx
@@ -4,6 +4,7 @@ import {
   setNativeAudioClick,
 } from "../../lib/nativeAudio";
 import { useStableCallback } from "../../lib/useStableCallback";
+import { nextTimedBeatIndex, type AnalysisTimingBeat } from "../../lib/timingGrid";
 import {
   activateWebAudioContext,
   getWebAudioContextConstructor,
@@ -144,9 +145,13 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
     audioContext: AudioContext,
     beatIndex: number,
     startTimeSeconds: number,
+    timingBeat?: AnalysisTimingBeat,
   ) {
-    const beatNumber = beatNumberForIndex(beatIndex, beatsPerBarRef.current);
-    const accent = isAccentBeat(beatIndex, beatsPerBarRef.current, accentFirstBeatRef.current);
+    const beatNumber =
+      timingBeat?.beat_in_bar ?? beatNumberForIndex(beatIndex, beatsPerBarRef.current);
+    const accent = timingBeat
+      ? accentFirstBeatRef.current && timingBeat.beat_in_bar === 1
+      : isAccentBeat(beatIndex, beatsPerBarRef.current, accentFirstBeatRef.current);
     if (!(followPlaybackRef.current && nativeFollowClickActiveRef.current)) {
       scheduleMetronomeClick({
         accent,
@@ -191,10 +196,46 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
     );
   });
 
+  const scheduleTimed = useStableCallback(function scheduleTimed(
+    audioContext: AudioContext,
+    snapshot: PlaybackSnapshot,
+  ) {
+    const timingGrid = snapshot.session?.timingGrid;
+    if (!timingGrid || timingGrid.beats.length < 2) {
+      return;
+    }
+    const playbackTimeSeconds = Math.max(0, snapshot.playbackTimeSeconds);
+    let beatIndex = nextTimedBeatIndex({
+      lastPlaybackTimeSeconds: lastSyncedPlaybackTimeRef.current,
+      lastScheduledBeatIndex: lastSyncedScheduledBeatRef.current,
+      playbackTimeSeconds,
+      timingGrid,
+    });
+    const scheduleUntilPlaybackSeconds = playbackTimeSeconds + SCHEDULE_AHEAD_SECONDS;
+
+    while (
+      beatIndex < timingGrid.beats.length &&
+      timingGrid.beats[beatIndex].seconds <= scheduleUntilPlaybackSeconds
+    ) {
+      const beat = timingGrid.beats[beatIndex];
+      const startTimeSeconds =
+        audioContext.currentTime + Math.max(0, beat.seconds - playbackTimeSeconds);
+      scheduleBeat(audioContext, beat.index, startTimeSeconds, beat);
+      lastSyncedScheduledBeatRef.current = beatIndex;
+      beatIndex += 1;
+    }
+
+    lastSyncedPlaybackTimeRef.current = playbackTimeSeconds;
+  });
+
   const scheduleSynced = useStableCallback(function scheduleSynced(
     audioContext: AudioContext,
     snapshot: PlaybackSnapshot,
   ) {
+    if (snapshot.session?.timingGrid) {
+      scheduleTimed(audioContext, snapshot);
+      return;
+    }
     const beatSeconds = secondsPerBeat(bpmRef.current);
     const playbackTimeSeconds = Math.max(0, snapshot.playbackTimeSeconds);
     let beatIndex = nextSyncedBeatIndex({
@@ -371,7 +412,13 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
   ]);
 
   useEffect(() => {
-    if (!isTauriRuntime() || isWebAudioBackendForced() || !isRunning || !followPlayback) {
+    if (
+      !isTauriRuntime() ||
+      isWebAudioBackendForced() ||
+      !isRunning ||
+      !followPlayback ||
+      session?.timingGrid
+    ) {
       nativeFollowClickActiveRef.current = false;
       if (isTauriRuntime()) {
         void setNativeAudioClick({ enabled: false }).catch(() => undefined);
@@ -404,7 +451,7 @@ export function MetronomeProvider({ children }: { children: ReactNode }) {
     return () => {
       cancelled = true;
     };
-  }, [accentFirstBeat, beatsPerBar, bpm, followPlayback, isRunning, volume]);
+  }, [accentFirstBeat, beatsPerBar, bpm, followPlayback, isRunning, session?.timingGrid, volume]);
 
   const syncStatus = followPlayback
     ? session

--- a/apps/desktop/src/lib/preferences.tsx
+++ b/apps/desktop/src/lib/preferences.tsx
@@ -8,6 +8,11 @@ import {
   type ReactNode,
 } from "react";
 import type { EnharmonicDisplayMode } from "./music";
+import {
+  DEFAULT_LOOP_ALIGNMENT_MODE,
+  normalizeLoopAlignmentMode,
+  type LoopAlignmentMode,
+} from "./timingGrid";
 
 export type InformationDensity = "minimal" | "balanced" | "detailed";
 export type ProjectWorkspaceMode = "project" | "playback";
@@ -16,7 +21,7 @@ export type DefaultPlaybackDisplayMode = "auto" | PlaybackDisplayMode;
 export type DefaultChordBackend = "tuneforge-fast" | "crema-advanced";
 export type DefaultStemModel = "htdemucs_6s" | "htdemucs_ft";
 export type TunerVisualMode = "simple" | "wide-arc";
-export type { EnharmonicDisplayMode };
+export type { EnharmonicDisplayMode, LoopAlignmentMode };
 
 export const DEFAULT_TUNER_REFERENCE_HZ = 440;
 export const MIN_TUNER_REFERENCE_HZ = 400;
@@ -29,6 +34,7 @@ export type UiPreferences = {
   defaultSourcesRailCollapsed: boolean;
   defaultProjectWorkspace: ProjectWorkspaceMode;
   defaultPlaybackDisplayMode: DefaultPlaybackDisplayMode;
+  defaultLoopAlignmentMode: LoopAlignmentMode;
   defaultChordBackend: DefaultChordBackend;
   defaultStemModel: DefaultStemModel;
   defaultLyricsFollowEnabled: boolean;
@@ -51,6 +57,7 @@ export type VisibilityPreferences = Pick<
   | "defaultSourcesRailCollapsed"
   | "defaultProjectWorkspace"
   | "defaultPlaybackDisplayMode"
+  | "defaultLoopAlignmentMode"
   | "defaultLyricsFollowEnabled"
   | "defaultChordsFollowEnabled"
 >;
@@ -62,6 +69,7 @@ type PreferencesContextValue = UiPreferences & {
   setDefaultSourcesRailCollapsed: (value: boolean) => void;
   setDefaultProjectWorkspace: (value: ProjectWorkspaceMode) => void;
   setDefaultPlaybackDisplayMode: (value: DefaultPlaybackDisplayMode) => void;
+  setDefaultLoopAlignmentMode: (value: LoopAlignmentMode) => void;
   setDefaultChordBackend: (value: DefaultChordBackend) => void;
   setDefaultStemModel: (value: DefaultStemModel) => void;
   setDefaultLyricsFollowEnabled: (value: boolean) => void;
@@ -104,6 +112,7 @@ export const DEFAULT_VISIBILITY_PREFERENCES: VisibilityPreferences = {
   defaultSourcesRailCollapsed: false,
   defaultProjectWorkspace: "project",
   defaultPlaybackDisplayMode: "auto",
+  defaultLoopAlignmentMode: DEFAULT_LOOP_ALIGNMENT_MODE,
   defaultLyricsFollowEnabled: true,
   defaultChordsFollowEnabled: true,
 };
@@ -199,6 +208,10 @@ export function normalizePreferences(value: unknown): UiPreferences {
     defaultPlaybackDisplayMode: isDefaultPlaybackDisplayMode(candidate.defaultPlaybackDisplayMode)
       ? candidate.defaultPlaybackDisplayMode
       : DEFAULT_PREFERENCES.defaultPlaybackDisplayMode,
+    defaultLoopAlignmentMode: normalizeLoopAlignmentMode(
+      candidate.defaultLoopAlignmentMode,
+      DEFAULT_PREFERENCES.defaultLoopAlignmentMode,
+    ),
     defaultChordBackend: isDefaultChordBackend(candidate.defaultChordBackend)
       ? candidate.defaultChordBackend
       : DEFAULT_PREFERENCES.defaultChordBackend,
@@ -278,6 +291,9 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
       },
       setDefaultPlaybackDisplayMode: (defaultPlaybackDisplayMode) => {
         setPreferences((current) => mergePreferences(current, { defaultPlaybackDisplayMode }));
+      },
+      setDefaultLoopAlignmentMode: (defaultLoopAlignmentMode) => {
+        setPreferences((current) => mergePreferences(current, { defaultLoopAlignmentMode }));
       },
       setDefaultChordBackend: (defaultChordBackend) => {
         setPreferences((current) => mergePreferences(current, { defaultChordBackend }));

--- a/apps/desktop/src/lib/timingGrid.test.ts
+++ b/apps/desktop/src/lib/timingGrid.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  countInIntervalsForTiming,
+  nextTimedBeatIndex,
+  normalizeAnalysisTimingGrid,
+  normalizeLoopAlignmentMode,
+  snapLoopPointToTiming,
+  type AnalysisTimingGrid,
+} from "./timingGrid";
+
+const timingGrid: AnalysisTimingGrid = {
+  beats_per_bar: 4,
+  source: "detected",
+  beats: [
+    { index: 0, seconds: 0, bar_index: 0, beat_in_bar: 1 },
+    { index: 1, seconds: 0.48, bar_index: 0, beat_in_bar: 2 },
+    { index: 2, seconds: 1.01, bar_index: 0, beat_in_bar: 3 },
+    { index: 3, seconds: 1.5, bar_index: 0, beat_in_bar: 4 },
+    { index: 4, seconds: 2.04, bar_index: 1, beat_in_bar: 1 },
+  ],
+  bars: [
+    { index: 0, start_seconds: 0, end_seconds: 2.04 },
+    { index: 1, start_seconds: 2.04, end_seconds: 4 },
+  ],
+};
+
+describe("timing grid helpers", () => {
+  it("normalizes loop modes and timing payloads", () => {
+    expect(normalizeLoopAlignmentMode("beat")).toBe("beat");
+    expect(normalizeLoopAlignmentMode("bad")).toBe("free");
+    expect(normalizeAnalysisTimingGrid(timingGrid)?.beats).toHaveLength(5);
+    expect(normalizeAnalysisTimingGrid({ beats: [], bars: [] })).toBeNull();
+  });
+
+  it("snaps loop points to beats or bars when timing exists", () => {
+    expect(snapLoopPointToTiming(0.52, "free", timingGrid)).toBe(0.52);
+    expect(snapLoopPointToTiming(0.52, "beat", timingGrid)).toBe(0.48);
+    expect(snapLoopPointToTiming(1.8, "bar", timingGrid)).toBe(2.04);
+    expect(snapLoopPointToTiming(1.8, "bar", null)).toBe(1.8);
+  });
+
+  it("uses local beat intervals for count-in timing", () => {
+    const intervals = countInIntervalsForTiming({
+      clickCount: 4,
+      fallbackBeatSeconds: 0.5,
+      startTimeSeconds: 2.04,
+      timingGrid,
+    });
+    expect(intervals[0]).toBeCloseTo(0.48, 3);
+    expect(intervals[1]).toBeCloseTo(0.53, 3);
+    expect(intervals[2]).toBeCloseTo(0.49, 3);
+    expect(intervals[3]).toBeCloseTo(0.54, 3);
+  });
+
+  it("finds the next timed beat without rescheduling old beats", () => {
+    expect(
+      nextTimedBeatIndex({
+        lastPlaybackTimeSeconds: null,
+        lastScheduledBeatIndex: null,
+        playbackTimeSeconds: 0.5,
+        timingGrid,
+      }),
+    ).toBe(2);
+    expect(
+      nextTimedBeatIndex({
+        lastPlaybackTimeSeconds: 0.5,
+        lastScheduledBeatIndex: 2,
+        playbackTimeSeconds: 0.51,
+        timingGrid,
+      }),
+    ).toBe(3);
+  });
+});

--- a/apps/desktop/src/lib/timingGrid.ts
+++ b/apps/desktop/src/lib/timingGrid.ts
@@ -1,0 +1,250 @@
+export type LoopAlignmentMode = "free" | "beat" | "bar";
+
+export type AnalysisTimingBeat = {
+  index: number;
+  seconds: number;
+  bar_index: number;
+  beat_in_bar: number;
+};
+
+export type AnalysisTimingBar = {
+  index: number;
+  start_seconds: number;
+  end_seconds: number;
+};
+
+export type AnalysisTimingGrid = {
+  beats_per_bar: number;
+  source: string;
+  beats: AnalysisTimingBeat[];
+  bars: AnalysisTimingBar[];
+};
+
+export const DEFAULT_LOOP_ALIGNMENT_MODE: LoopAlignmentMode = "free";
+export const LOOP_ALIGNMENT_MODES: LoopAlignmentMode[] = ["free", "beat", "bar"];
+const TIMING_SNAP_EPSILON_SECONDS = 0.08;
+const TIMING_JUMP_TOLERANCE_SECONDS = 0.2;
+
+export function isLoopAlignmentMode(value: unknown): value is LoopAlignmentMode {
+  return value === "free" || value === "beat" || value === "bar";
+}
+
+export function normalizeLoopAlignmentMode(
+  value: unknown,
+  fallback: LoopAlignmentMode = DEFAULT_LOOP_ALIGNMENT_MODE,
+): LoopAlignmentMode {
+  return isLoopAlignmentMode(value) ? value : fallback;
+}
+
+export function normalizeAnalysisTimingGrid(value: unknown): AnalysisTimingGrid | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const candidate = value as Partial<AnalysisTimingGrid>;
+  const beatsPerBar =
+    typeof candidate.beats_per_bar === "number" &&
+    Number.isFinite(candidate.beats_per_bar) &&
+    candidate.beats_per_bar >= 1
+      ? Math.trunc(candidate.beats_per_bar)
+      : 4;
+  const beats = Array.isArray(candidate.beats)
+    ? candidate.beats
+        .map(normalizeTimingBeat)
+        .filter((beat): beat is AnalysisTimingBeat => beat !== null)
+        .sort((first, second) => first.seconds - second.seconds)
+    : [];
+  const bars = Array.isArray(candidate.bars)
+    ? candidate.bars
+        .map(normalizeTimingBar)
+        .filter((bar): bar is AnalysisTimingBar => bar !== null)
+        .sort((first, second) => first.start_seconds - second.start_seconds)
+    : [];
+
+  if (beats.length < 2 && bars.length === 0) {
+    return null;
+  }
+  return {
+    beats_per_bar: beatsPerBar,
+    source: typeof candidate.source === "string" ? candidate.source : "detected",
+    beats,
+    bars,
+  };
+}
+
+export function snapLoopPointToTiming(
+  value: number,
+  mode: LoopAlignmentMode,
+  timingGrid: AnalysisTimingGrid | null,
+) {
+  if (mode === "free" || !timingGrid) {
+    return value;
+  }
+
+  const candidates =
+    mode === "bar"
+      ? timingGrid.bars.map((bar) => bar.start_seconds)
+      : timingGrid.beats.map((beat) => beat.seconds);
+  if (!candidates.length) {
+    return value;
+  }
+  return nearestTime(value, candidates) ?? value;
+}
+
+export function countInIntervalsForTiming({
+  clickCount,
+  fallbackBeatSeconds,
+  startTimeSeconds,
+  timingGrid,
+}: {
+  clickCount: number;
+  fallbackBeatSeconds: number;
+  startTimeSeconds: number;
+  timingGrid: AnalysisTimingGrid | null;
+}) {
+  const fallbackIntervals = Array.from({ length: clickCount }, () => fallbackBeatSeconds);
+  if (!timingGrid || timingGrid.beats.length < 2 || clickCount <= 0) {
+    return fallbackIntervals;
+  }
+
+  const anchorIndex = timingAnchorBeatIndex(timingGrid.beats, startTimeSeconds);
+  if (anchorIndex === null) {
+    return fallbackIntervals;
+  }
+
+  const localFallback = localBeatSeconds(timingGrid.beats, anchorIndex) ?? fallbackBeatSeconds;
+  return fallbackIntervals.map((_interval, index) => {
+    const fromIndex = anchorIndex - clickCount + index;
+    const toIndex = fromIndex + 1;
+    if (
+      timingGrid.beats[fromIndex] &&
+      timingGrid.beats[toIndex] &&
+      timingGrid.beats[toIndex].seconds > timingGrid.beats[fromIndex].seconds
+    ) {
+      return timingGrid.beats[toIndex].seconds - timingGrid.beats[fromIndex].seconds;
+    }
+    return localFallback;
+  });
+}
+
+export function nextTimedBeatIndex({
+  lastPlaybackTimeSeconds,
+  lastScheduledBeatIndex,
+  playbackTimeSeconds,
+  timingGrid,
+}: {
+  lastPlaybackTimeSeconds: number | null;
+  lastScheduledBeatIndex: number | null;
+  playbackTimeSeconds: number;
+  timingGrid: AnalysisTimingGrid;
+}) {
+  const currentBeatIndex = firstBeatIndexAtOrAfter(timingGrid.beats, playbackTimeSeconds);
+  const jumped =
+    lastPlaybackTimeSeconds !== null &&
+    Math.abs(playbackTimeSeconds - lastPlaybackTimeSeconds) > TIMING_JUMP_TOLERANCE_SECONDS;
+
+  if (lastScheduledBeatIndex === null || jumped) {
+    return currentBeatIndex;
+  }
+  return Math.max(currentBeatIndex, lastScheduledBeatIndex + 1);
+}
+
+function normalizeTimingBeat(value: unknown): AnalysisTimingBeat | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const candidate = value as Partial<AnalysisTimingBeat>;
+  if (
+    typeof candidate.index !== "number" ||
+    typeof candidate.seconds !== "number" ||
+    typeof candidate.bar_index !== "number" ||
+    typeof candidate.beat_in_bar !== "number" ||
+    !Number.isFinite(candidate.seconds)
+  ) {
+    return null;
+  }
+  return {
+    index: Math.max(0, Math.trunc(candidate.index)),
+    seconds: Math.max(0, candidate.seconds),
+    bar_index: Math.max(0, Math.trunc(candidate.bar_index)),
+    beat_in_bar: Math.max(1, Math.trunc(candidate.beat_in_bar)),
+  };
+}
+
+function normalizeTimingBar(value: unknown): AnalysisTimingBar | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const candidate = value as Partial<AnalysisTimingBar>;
+  if (
+    typeof candidate.index !== "number" ||
+    typeof candidate.start_seconds !== "number" ||
+    typeof candidate.end_seconds !== "number" ||
+    !Number.isFinite(candidate.start_seconds) ||
+    !Number.isFinite(candidate.end_seconds)
+  ) {
+    return null;
+  }
+  const startSeconds = Math.max(0, candidate.start_seconds);
+  const endSeconds = Math.max(startSeconds, candidate.end_seconds);
+  return {
+    index: Math.max(0, Math.trunc(candidate.index)),
+    start_seconds: startSeconds,
+    end_seconds: endSeconds,
+  };
+}
+
+function nearestTime(value: number, candidates: number[]) {
+  let nearest: number | null = null;
+  let nearestDistance = Number.POSITIVE_INFINITY;
+  for (const candidate of candidates) {
+    const distance = Math.abs(candidate - value);
+    if (distance < nearestDistance) {
+      nearest = candidate;
+      nearestDistance = distance;
+    }
+  }
+  return nearest;
+}
+
+function timingAnchorBeatIndex(beats: AnalysisTimingBeat[], startTimeSeconds: number) {
+  const nearestIndex = nearestBeatIndex(beats, startTimeSeconds);
+  if (
+    nearestIndex !== null &&
+    Math.abs(beats[nearestIndex].seconds - startTimeSeconds) <= TIMING_SNAP_EPSILON_SECONDS
+  ) {
+    return nearestIndex;
+  }
+  return firstBeatIndexAtOrAfter(beats, startTimeSeconds);
+}
+
+function nearestBeatIndex(beats: AnalysisTimingBeat[], value: number) {
+  let nearestIndex: number | null = null;
+  let nearestDistance = Number.POSITIVE_INFINITY;
+  beats.forEach((beat, index) => {
+    const distance = Math.abs(beat.seconds - value);
+    if (distance < nearestDistance) {
+      nearestDistance = distance;
+      nearestIndex = index;
+    }
+  });
+  return nearestIndex;
+}
+
+function firstBeatIndexAtOrAfter(beats: AnalysisTimingBeat[], value: number) {
+  const index = beats.findIndex((beat) => beat.seconds >= value);
+  return index === -1 ? beats.length : index;
+}
+
+function localBeatSeconds(beats: AnalysisTimingBeat[], anchorIndex: number) {
+  const previous = beats[anchorIndex - 1];
+  const anchor = beats[anchorIndex];
+  if (previous && anchor && anchor.seconds > previous.seconds) {
+    return anchor.seconds - previous.seconds;
+  }
+  const next = beats[anchorIndex + 1];
+  if (anchor && next && next.seconds > anchor.seconds) {
+    return next.seconds - anchor.seconds;
+  }
+  return null;
+}

--- a/apps/desktop/src/styles/project-playback.css
+++ b/apps/desktop/src/styles/project-playback.css
@@ -914,6 +914,39 @@
   margin: 0;
 }
 
+.playback-loop-alignment-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  padding: 0.8rem;
+  border: 1px solid var(--divider);
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--surface-muted) 74%, transparent);
+}
+
+.playback-loop-alignment-control h3 {
+  margin: 0.15rem 0 0;
+  font-size: 1rem;
+}
+
+.playback-loop-alignment-control__segments {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.45rem;
+}
+
+.playback-loop-alignment-control__segments .button {
+  min-width: 0;
+  justify-content: center;
+  padding-inline: 0.4rem;
+}
+
+.playback-loop-alignment-control__segments .button[aria-pressed="true"] {
+  border-color: color-mix(in srgb, var(--playback-accent) 52%, var(--divider));
+  background: color-mix(in srgb, var(--surface-highlight) 20%, var(--panel-strong));
+  color: var(--text);
+}
+
 .playback-tempo-control {
   display: flex;
   flex-direction: column;

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -1667,6 +1667,9 @@ export function getMockAudioContexts() {
           setSamples: (samples: Float32Array | null) => void;
         }>;
         createdOscillators: Array<{
+          frequency: {
+            setValueAtTime: ReturnType<typeof vi.fn>;
+          };
           start: ReturnType<typeof vi.fn>;
           stop: ReturnType<typeof vi.fn>;
         }>;

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -471,6 +471,7 @@ export interface components {
             tuning_offset_cents: number | null;
             /** Tempo Bpm */
             tempo_bpm: number | null;
+            timing?: components["schemas"]["AnalysisTimingSchema"] | null;
             /** Analysis Version */
             analysis_version: string;
             /**
@@ -478,6 +479,37 @@ export interface components {
              * Format: date-time
              */
             created_at: string;
+        };
+        /** AnalysisTimingBarSchema */
+        AnalysisTimingBarSchema: {
+            /** Index */
+            index: number;
+            /** Start Seconds */
+            start_seconds: number;
+            /** End Seconds */
+            end_seconds: number;
+        };
+        /** AnalysisTimingBeatSchema */
+        AnalysisTimingBeatSchema: {
+            /** Index */
+            index: number;
+            /** Seconds */
+            seconds: number;
+            /** Bar Index */
+            bar_index: number;
+            /** Beat In Bar */
+            beat_in_bar: number;
+        };
+        /** AnalysisTimingSchema */
+        AnalysisTimingSchema: {
+            /** Beats Per Bar */
+            beats_per_bar: number;
+            /** Source */
+            source: string;
+            /** Beats */
+            beats?: components["schemas"]["AnalysisTimingBeatSchema"][];
+            /** Bars */
+            bars?: components["schemas"]["AnalysisTimingBarSchema"][];
         };
         /** ArtifactSchema */
         ArtifactSchema: {


### PR DESCRIPTION
## Summary

- Add durable beat/bar timing grids to backend analysis output and persistence.
- Wire loop alignment, pre-count, and followed metronome scheduling to use timing grids when available.
- Add global loop alignment defaults, per-project overrides, generated contracts, and focused tests.
- Refs #104, #105, #106, #107.

## Testing

- `pnpm contracts:generate`
- `cd apps/backend && uv run --python 3.11 pytest tests/test_audio_analysis_engines.py tests/test_analysis_flow.py`
- `pnpm --filter @tuneforge/desktop test -- App.project-precount.test.tsx App.tools-metronome.test.tsx timingGrid.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

