### PR TITLE
feat: add playback media-control ownership

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4725,9 +4725,13 @@ name = "tuneforge"
 version = "0.1.0"
 dependencies = [
  "android_system_properties",
+ "block2",
  "chrono",
  "cpal",
+ "dbus",
  "ndk-sys",
+ "objc2",
+ "objc2-foundation",
  "rusqlite",
  "serde",
  "serde_json",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -29,7 +29,13 @@ signalsmith-stretch = "0.1.3"
 symphonia = { version = "0.5.5", default-features = false, features = ["all"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+dbus = "0.9.11"
 webkit2gtk = "2.0.2"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+block2 = "0.6.2"
+objc2 = "0.6.4"
+objc2-foundation = "0.3.2"
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_system_properties = "0.1.5"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ use tauri::{Manager, State};
 
 mod mobile_backend;
 mod native_audio;
+mod system_media;
 
 struct BackendRuntime {
     base_url: String,
@@ -336,6 +337,7 @@ pub fn run() {
             };
             app.manage(runtime);
             app.manage(native_audio::NativeAudioState::new());
+            app.manage(system_media::SystemMediaState::new(app.handle().clone()));
             #[cfg(target_os = "linux")]
             install_linux_media_permission_handler(app.handle())?;
             Ok(())
@@ -361,6 +363,9 @@ pub fn run() {
             native_audio::audio_start_input,
             native_audio::audio_stop_input,
             native_audio::audio_set_monitor,
+            system_media::system_media_update_state,
+            system_media::system_media_clear_state,
+            system_media::system_media_set_idle_inhibition,
             mobile_backend::mobile_capabilities,
             mobile_backend::mobile_get_health,
             mobile_backend::mobile_list_projects,

--- a/apps/desktop/src-tauri/src/system_media/mod.rs
+++ b/apps/desktop/src-tauri/src/system_media/mod.rs
@@ -1,0 +1,992 @@
+use serde::{Deserialize, Serialize};
+use std::sync::{Arc, Mutex};
+use tauri::{AppHandle, Emitter, State};
+
+pub const SYSTEM_MEDIA_CONTROL_EVENT: &str = "system-media://control";
+
+#[derive(Clone)]
+pub struct SystemMediaState {
+    app: AppHandle,
+    runtime: Arc<Mutex<SystemMediaRuntime>>,
+}
+
+impl SystemMediaState {
+    pub fn new(app: AppHandle) -> Self {
+        Self {
+            app,
+            runtime: Arc::new(Mutex::new(SystemMediaRuntime::default())),
+        }
+    }
+
+    fn update(&self, payload: SystemMediaPayload) -> Result<(), String> {
+        platform::update_media_state(&self.app, &payload)?;
+        let mut runtime = self
+            .runtime
+            .lock()
+            .map_err(|_| "System media state is unavailable.".to_string())?;
+        runtime.current = Some(payload);
+        Ok(())
+    }
+
+    fn clear(&self) -> Result<(), String> {
+        platform::clear_media_state(&self.app)?;
+        let mut runtime = self
+            .runtime
+            .lock()
+            .map_err(|_| "System media state is unavailable.".to_string())?;
+        runtime.current = None;
+        runtime.idle.set_active(false)?;
+        Ok(())
+    }
+
+    fn set_idle_inhibition(&self, active: bool) -> Result<(), String> {
+        let mut runtime = self
+            .runtime
+            .lock()
+            .map_err(|_| "System media state is unavailable.".to_string())?;
+        runtime.idle.set_active(active)
+    }
+}
+
+#[derive(Default)]
+struct SystemMediaRuntime {
+    current: Option<SystemMediaPayload>,
+    idle: platform::IdleInhibition,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SystemMediaPayload {
+    pub title: String,
+    pub artist: String,
+    pub album: Option<String>,
+    pub playback_state: SystemMediaPlaybackState,
+    pub duration_seconds: Option<f64>,
+    pub position_seconds: Option<f64>,
+    pub playback_rate: Option<f64>,
+    pub can_seek: bool,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SystemMediaPlaybackState {
+    None,
+    Playing,
+    Paused,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SystemMediaControlPayload {
+    pub action: SystemMediaControlAction,
+    pub position_seconds: Option<f64>,
+    pub seek_offset_seconds: Option<f64>,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SystemMediaControlAction {
+    Play,
+    Pause,
+    PlayPause,
+    Stop,
+    SeekBackward,
+    SeekForward,
+    SeekTo,
+}
+
+pub fn emit_control(
+    app: &AppHandle,
+    action: SystemMediaControlAction,
+    position_seconds: Option<f64>,
+    seek_offset_seconds: Option<f64>,
+) {
+    let _ = app.emit(
+        SYSTEM_MEDIA_CONTROL_EVENT,
+        SystemMediaControlPayload {
+            action,
+            position_seconds,
+            seek_offset_seconds,
+        },
+    );
+}
+
+#[tauri::command]
+pub fn system_media_update_state(
+    state: State<'_, SystemMediaState>,
+    payload: SystemMediaPayload,
+) -> Result<(), String> {
+    state.update(payload)
+}
+
+#[tauri::command]
+pub fn system_media_clear_state(state: State<'_, SystemMediaState>) -> Result<(), String> {
+    state.clear()
+}
+
+#[tauri::command]
+pub fn system_media_set_idle_inhibition(
+    state: State<'_, SystemMediaState>,
+    active: bool,
+) -> Result<(), String> {
+    state.set_idle_inhibition(active)
+}
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use super::{
+        emit_control, SystemMediaControlAction, SystemMediaPayload, SystemMediaPlaybackState,
+    };
+    use block2::RcBlock;
+    use objc2::runtime::AnyObject;
+    use objc2::{class, msg_send};
+    use objc2_foundation::{NSMutableDictionary, NSNumber, NSObject, NSString};
+    use std::ffi::{c_char, c_void, CString};
+    use std::sync::Once;
+    use tauri::AppHandle;
+
+    type CFAllocatorRef = *const c_void;
+    type CFStringRef = *const c_void;
+    type IOPMAssertionID = u32;
+    type IOReturn = i32;
+
+    const K_CF_STRING_ENCODING_UTF8: u32 = 0x0800_0100;
+    const K_IOPM_ASSERTION_LEVEL_ON: u32 = 255;
+    const K_IO_RETURN_SUCCESS: IOReturn = 0;
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
+        fn CFStringCreateWithCString(
+            alloc: CFAllocatorRef,
+            c_str: *const c_char,
+            encoding: u32,
+        ) -> CFStringRef;
+        fn CFRelease(cf: *const c_void);
+    }
+
+    #[link(name = "IOKit", kind = "framework")]
+    extern "C" {
+        fn IOPMAssertionCreateWithName(
+            assertion_type: CFStringRef,
+            level: u32,
+            assertion_name: CFStringRef,
+            assertion_id: *mut IOPMAssertionID,
+        ) -> IOReturn;
+        fn IOPMAssertionRelease(assertion_id: IOPMAssertionID) -> IOReturn;
+    }
+
+    #[link(name = "MediaPlayer", kind = "framework")]
+    extern "C" {}
+
+    static REGISTER_REMOTE_COMMANDS: Once = Once::new();
+
+    #[derive(Default)]
+    pub struct IdleInhibition {
+        assertion_id: Option<IOPMAssertionID>,
+    }
+
+    impl IdleInhibition {
+        pub fn set_active(&mut self, active: bool) -> Result<(), String> {
+            if active {
+                if self.assertion_id.is_some() {
+                    return Ok(());
+                }
+                let assertion_type = cf_string("NoDisplaySleepAssertion")?;
+                let assertion_name = cf_string("TuneForge playback")?;
+                let mut assertion_id = 0;
+                let result = unsafe {
+                    IOPMAssertionCreateWithName(
+                        assertion_type,
+                        K_IOPM_ASSERTION_LEVEL_ON,
+                        assertion_name,
+                        &mut assertion_id,
+                    )
+                };
+                unsafe {
+                    CFRelease(assertion_type);
+                    CFRelease(assertion_name);
+                }
+                if result != K_IO_RETURN_SUCCESS {
+                    return Err(format!("Could not inhibit macOS display sleep: {result}"));
+                }
+                self.assertion_id = Some(assertion_id);
+                return Ok(());
+            }
+
+            if let Some(assertion_id) = self.assertion_id.take() {
+                let result = unsafe { IOPMAssertionRelease(assertion_id) };
+                if result != K_IO_RETURN_SUCCESS {
+                    return Err(format!(
+                        "Could not release macOS display sleep assertion: {result}"
+                    ));
+                }
+            }
+            Ok(())
+        }
+    }
+
+    pub fn update_media_state(app: &AppHandle, payload: &SystemMediaPayload) -> Result<(), String> {
+        register_remote_commands(app);
+        unsafe {
+            set_remote_commands_enabled(true, payload.can_seek);
+            let center: *mut AnyObject = msg_send![class!(MPNowPlayingInfoCenter), defaultCenter];
+            if center.is_null() {
+                return Err("macOS Now Playing center is unavailable.".to_string());
+            }
+            let info = NSMutableDictionary::<NSString, NSObject>::new();
+            insert_string(&info, "title", &payload.title);
+            insert_string(&info, "artist", &payload.artist);
+            if let Some(album) = &payload.album {
+                insert_string(&info, "albumTitle", album);
+            }
+            if let Some(duration_seconds) = finite_non_negative(payload.duration_seconds) {
+                insert_number(&info, "playbackDuration", duration_seconds);
+            }
+            if let Some(position_seconds) = finite_non_negative(payload.position_seconds) {
+                insert_number(&info, "elapsedPlaybackTime", position_seconds);
+            }
+            let playback_rate = match payload.playback_state {
+                SystemMediaPlaybackState::Playing => payload.playback_rate.unwrap_or(1.0),
+                SystemMediaPlaybackState::Paused | SystemMediaPlaybackState::None => 0.0,
+            };
+            insert_number(&info, "playbackRate", playback_rate);
+            let _: () = msg_send![center, setNowPlayingInfo: &*info];
+            let playback_state = match payload.playback_state {
+                SystemMediaPlaybackState::None => 0isize,
+                SystemMediaPlaybackState::Playing => 1isize,
+                SystemMediaPlaybackState::Paused => 2isize,
+            };
+            let _: () = msg_send![center, setPlaybackState: playback_state];
+        }
+        Ok(())
+    }
+
+    pub fn clear_media_state(app: &AppHandle) -> Result<(), String> {
+        register_remote_commands(app);
+        unsafe {
+            set_remote_commands_enabled(false, false);
+            let center: *mut AnyObject = msg_send![class!(MPNowPlayingInfoCenter), defaultCenter];
+            if center.is_null() {
+                return Ok(());
+            }
+            let nil_info: *mut AnyObject = std::ptr::null_mut();
+            let _: () = msg_send![center, setNowPlayingInfo: nil_info];
+            let _: () = msg_send![center, setPlaybackState: 0isize];
+        }
+        Ok(())
+    }
+
+    fn cf_string(value: &str) -> Result<CFStringRef, String> {
+        let c_string = CString::new(value)
+            .map_err(|_| "System media string contained an interior null byte.".to_string())?;
+        let cf_string = unsafe {
+            CFStringCreateWithCString(
+                std::ptr::null(),
+                c_string.as_ptr(),
+                K_CF_STRING_ENCODING_UTF8,
+            )
+        };
+        if cf_string.is_null() {
+            return Err("Could not create macOS system media string.".to_string());
+        }
+        Ok(cf_string)
+    }
+
+    fn finite_non_negative(value: Option<f64>) -> Option<f64> {
+        value.filter(|next| next.is_finite() && *next >= 0.0)
+    }
+
+    unsafe fn insert_string(
+        info: &NSMutableDictionary<NSString, NSObject>,
+        key: &str,
+        value: &str,
+    ) {
+        let key = NSString::from_str(key);
+        let value = NSString::from_str(value).into_super();
+        info.insert(&*key, &*value);
+    }
+
+    unsafe fn insert_number(info: &NSMutableDictionary<NSString, NSObject>, key: &str, value: f64) {
+        let key = NSString::from_str(key);
+        let value = NSNumber::new_f64(value).into_super();
+        info.insert(&*key, &*value);
+    }
+
+    fn register_remote_commands(app: &AppHandle) {
+        let app = app.clone();
+        REGISTER_REMOTE_COMMANDS.call_once(move || unsafe {
+            let center: *mut AnyObject =
+                msg_send![class!(MPRemoteCommandCenter), sharedCommandCenter];
+            if center.is_null() {
+                return;
+            }
+
+            let play_command: *mut AnyObject = msg_send![center, playCommand];
+            add_command_handler(
+                play_command,
+                app.clone(),
+                SystemMediaControlAction::Play,
+                None,
+            );
+
+            let pause_command: *mut AnyObject = msg_send![center, pauseCommand];
+            add_command_handler(
+                pause_command,
+                app.clone(),
+                SystemMediaControlAction::Pause,
+                None,
+            );
+
+            let toggle_command: *mut AnyObject = msg_send![center, togglePlayPauseCommand];
+            add_command_handler(
+                toggle_command,
+                app.clone(),
+                SystemMediaControlAction::PlayPause,
+                None,
+            );
+
+            let stop_command: *mut AnyObject = msg_send![center, stopCommand];
+            add_command_handler(
+                stop_command,
+                app.clone(),
+                SystemMediaControlAction::Stop,
+                None,
+            );
+
+            let backward_command: *mut AnyObject = msg_send![center, seekBackwardCommand];
+            add_command_handler(
+                backward_command,
+                app.clone(),
+                SystemMediaControlAction::SeekBackward,
+                Some(10.0),
+            );
+
+            let forward_command: *mut AnyObject = msg_send![center, seekForwardCommand];
+            add_command_handler(
+                forward_command,
+                app.clone(),
+                SystemMediaControlAction::SeekForward,
+                Some(10.0),
+            );
+
+            let skip_backward_command: *mut AnyObject = msg_send![center, skipBackwardCommand];
+            add_skip_command_handler(
+                skip_backward_command,
+                app.clone(),
+                SystemMediaControlAction::SeekBackward,
+            );
+
+            let skip_forward_command: *mut AnyObject = msg_send![center, skipForwardCommand];
+            add_skip_command_handler(
+                skip_forward_command,
+                app.clone(),
+                SystemMediaControlAction::SeekForward,
+            );
+
+            let previous_command: *mut AnyObject = msg_send![center, previousTrackCommand];
+            add_command_handler(
+                previous_command,
+                app.clone(),
+                SystemMediaControlAction::SeekBackward,
+                Some(10.0),
+            );
+
+            let next_command: *mut AnyObject = msg_send![center, nextTrackCommand];
+            add_command_handler(
+                next_command,
+                app.clone(),
+                SystemMediaControlAction::SeekForward,
+                Some(10.0),
+            );
+
+            let position_command: *mut AnyObject = msg_send![center, changePlaybackPositionCommand];
+            if !position_command.is_null() {
+                let _: () = msg_send![position_command, setEnabled: true];
+                let block = RcBlock::new(move |event: *mut AnyObject| -> isize {
+                    if event.is_null() {
+                        return 0;
+                    }
+                    let position_seconds: f64 = msg_send![event, positionTime];
+                    emit_control(
+                        &app,
+                        SystemMediaControlAction::SeekTo,
+                        Some(position_seconds),
+                        None,
+                    );
+                    0
+                });
+                let block = RcBlock::into_raw(block);
+                let _: *mut AnyObject = msg_send![position_command, addTargetWithHandler: block];
+            }
+
+            set_remote_commands_enabled(false, false);
+        });
+    }
+
+    unsafe fn add_command_handler(
+        command: *mut AnyObject,
+        app: AppHandle,
+        action: SystemMediaControlAction,
+        seek_offset_seconds: Option<f64>,
+    ) {
+        if command.is_null() {
+            return;
+        }
+        let _: () = msg_send![command, setEnabled: true];
+        let block = RcBlock::new(move |_event: *mut AnyObject| -> isize {
+            emit_control(&app, action, None, seek_offset_seconds);
+            0
+        });
+        let block = RcBlock::into_raw(block);
+        let _: *mut AnyObject = msg_send![command, addTargetWithHandler: block];
+    }
+
+    unsafe fn add_skip_command_handler(
+        command: *mut AnyObject,
+        app: AppHandle,
+        action: SystemMediaControlAction,
+    ) {
+        if command.is_null() {
+            return;
+        }
+        let _: () = msg_send![command, setEnabled: true];
+        let interval = NSNumber::new_f64(10.0);
+        let intervals: *mut AnyObject = msg_send![class!(NSArray), arrayWithObject: &*interval];
+        let _: () = msg_send![command, setPreferredIntervals: intervals];
+        let block = RcBlock::new(move |event: *mut AnyObject| -> isize {
+            let interval = if event.is_null() {
+                10.0
+            } else {
+                let value: f64 = msg_send![event, interval];
+                if value.is_finite() && value > 0.0 {
+                    value
+                } else {
+                    10.0
+                }
+            };
+            emit_control(&app, action, None, Some(interval));
+            0
+        });
+        let block = RcBlock::into_raw(block);
+        let _: *mut AnyObject = msg_send![command, addTargetWithHandler: block];
+    }
+
+    unsafe fn set_remote_commands_enabled(enabled: bool, can_seek: bool) {
+        let center: *mut AnyObject = msg_send![class!(MPRemoteCommandCenter), sharedCommandCenter];
+        if center.is_null() {
+            return;
+        }
+        let play_command: *mut AnyObject = msg_send![center, playCommand];
+        set_command_enabled(play_command, enabled);
+        let pause_command: *mut AnyObject = msg_send![center, pauseCommand];
+        set_command_enabled(pause_command, enabled);
+        let toggle_command: *mut AnyObject = msg_send![center, togglePlayPauseCommand];
+        set_command_enabled(toggle_command, enabled);
+        let stop_command: *mut AnyObject = msg_send![center, stopCommand];
+        set_command_enabled(stop_command, enabled);
+        let backward_command: *mut AnyObject = msg_send![center, seekBackwardCommand];
+        set_command_enabled(backward_command, enabled && can_seek);
+        let forward_command: *mut AnyObject = msg_send![center, seekForwardCommand];
+        set_command_enabled(forward_command, enabled && can_seek);
+        let skip_backward_command: *mut AnyObject = msg_send![center, skipBackwardCommand];
+        set_command_enabled(skip_backward_command, enabled && can_seek);
+        let skip_forward_command: *mut AnyObject = msg_send![center, skipForwardCommand];
+        set_command_enabled(skip_forward_command, enabled && can_seek);
+        let previous_command: *mut AnyObject = msg_send![center, previousTrackCommand];
+        set_command_enabled(previous_command, enabled && can_seek);
+        let next_command: *mut AnyObject = msg_send![center, nextTrackCommand];
+        set_command_enabled(next_command, enabled && can_seek);
+        let position_command: *mut AnyObject = msg_send![center, changePlaybackPositionCommand];
+        set_command_enabled(position_command, enabled && can_seek);
+    }
+
+    unsafe fn set_command_enabled(command: *mut AnyObject, enabled: bool) {
+        if command.is_null() {
+            return;
+        }
+        let _: () = msg_send![command, setEnabled: enabled];
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod platform {
+    use super::{
+        emit_control, SystemMediaControlAction, SystemMediaPayload, SystemMediaPlaybackState,
+    };
+    use dbus::arg::{PropMap, RefArg, Variant};
+    use dbus::blocking::Connection;
+    use dbus::channel::{default_reply, MatchingReceiver, Sender};
+    use dbus::message::MatchRule;
+    use dbus::Message;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+    use std::time::Duration;
+    use tauri::AppHandle;
+
+    const MPRIS_BUS_NAME: &str = "org.mpris.MediaPlayer2.tuneforge";
+    const MPRIS_OBJECT_PATH: &str = "/org/mpris/MediaPlayer2";
+    const MPRIS_ROOT_INTERFACE: &str = "org.mpris.MediaPlayer2";
+    const MPRIS_PLAYER_INTERFACE: &str = "org.mpris.MediaPlayer2.Player";
+    const DBUS_PROPERTIES_INTERFACE: &str = "org.freedesktop.DBus.Properties";
+    const DBUS_INTROSPECTABLE_INTERFACE: &str = "org.freedesktop.DBus.Introspectable";
+    const SCREENSAVER_BUS_NAME: &str = "org.freedesktop.ScreenSaver";
+    const SCREENSAVER_OBJECT_PATH: &str = "/org/freedesktop/ScreenSaver";
+    const SCREENSAVER_INTERFACE: &str = "org.freedesktop.ScreenSaver";
+
+    static MPRIS_RUNTIME: Mutex<Option<Arc<MprisRuntime>>> = Mutex::new(None);
+
+    #[derive(Clone)]
+    struct MprisRuntime {
+        state: Arc<Mutex<Option<SystemMediaPayload>>>,
+        active: Arc<AtomicBool>,
+    }
+
+    #[derive(Default)]
+    pub struct IdleInhibition {
+        connection: Option<Connection>,
+        cookie: Option<u32>,
+    }
+
+    impl IdleInhibition {
+        pub fn set_active(&mut self, active: bool) -> Result<(), String> {
+            if active {
+                if self.cookie.is_some() {
+                    return Ok(());
+                }
+                let connection = Connection::new_session()
+                    .map_err(|error| format!("D-Bus unavailable: {error}"))?;
+                let proxy = connection.with_proxy(
+                    SCREENSAVER_BUS_NAME,
+                    SCREENSAVER_OBJECT_PATH,
+                    Duration::from_millis(500),
+                );
+                let (cookie,): (u32,) = proxy
+                    .method_call(
+                        SCREENSAVER_INTERFACE,
+                        "Inhibit",
+                        ("TuneForge", "Native playback active"),
+                    )
+                    .map_err(|error| format!("Could not inhibit desktop idle: {error}"))?;
+                self.connection = Some(connection);
+                self.cookie = Some(cookie);
+                return Ok(());
+            }
+
+            if let (Some(connection), Some(cookie)) = (self.connection.take(), self.cookie.take()) {
+                let proxy = connection.with_proxy(
+                    SCREENSAVER_BUS_NAME,
+                    SCREENSAVER_OBJECT_PATH,
+                    Duration::from_millis(500),
+                );
+                proxy
+                    .method_call::<(), _, _, _>(SCREENSAVER_INTERFACE, "UnInhibit", (cookie,))
+                    .map_err(|error| {
+                        format!("Could not release desktop idle inhibition: {error}")
+                    })?;
+            }
+            Ok(())
+        }
+    }
+
+    pub fn update_media_state(app: &AppHandle, payload: &SystemMediaPayload) -> Result<(), String> {
+        let runtime = ensure_mpris_runtime(app)?;
+        let mut state = runtime
+            .state
+            .lock()
+            .map_err(|_| "Linux MPRIS state is unavailable.".to_string())?;
+        *state = Some(payload.clone());
+        runtime.active.store(true, Ordering::Release);
+        Ok(())
+    }
+
+    pub fn clear_media_state(app: &AppHandle) -> Result<(), String> {
+        let runtime = ensure_mpris_runtime(app)?;
+        let mut state = runtime
+            .state
+            .lock()
+            .map_err(|_| "Linux MPRIS state is unavailable.".to_string())?;
+        *state = None;
+        runtime.active.store(false, Ordering::Release);
+        Ok(())
+    }
+
+    fn ensure_mpris_runtime(app: &AppHandle) -> Result<Arc<MprisRuntime>, String> {
+        let mut guard = MPRIS_RUNTIME
+            .lock()
+            .map_err(|_| "Linux MPRIS runtime is unavailable.".to_string())?;
+        if let Some(runtime) = guard.as_ref() {
+            return Ok(runtime.clone());
+        }
+
+        let runtime = Arc::new(MprisRuntime {
+            state: Arc::new(Mutex::new(None)),
+            active: Arc::new(AtomicBool::new(false)),
+        });
+        start_mpris_thread(app.clone(), runtime.clone())?;
+        *guard = Some(runtime.clone());
+        Ok(runtime)
+    }
+
+    fn start_mpris_thread(app: AppHandle, runtime: Arc<MprisRuntime>) -> Result<(), String> {
+        let connection =
+            Connection::new_session().map_err(|error| format!("D-Bus unavailable: {error}"))?;
+        connection
+            .request_name(MPRIS_BUS_NAME, false, true, false)
+            .map_err(|error| format!("Could not register MPRIS player: {error}"))?;
+
+        let state = runtime.state.clone();
+        let active = runtime.active.clone();
+        let mut rule = MatchRule::new_method_call();
+        rule.path = Some(MPRIS_OBJECT_PATH.into());
+        connection.start_receive(
+            rule,
+            Box::new(move |message, connection| {
+                if !handle_mpris_message(&app, &state, &active, &message, connection) {
+                    if let Some(reply) = default_reply(&message) {
+                        let _ = connection.send(reply);
+                    }
+                }
+                true
+            }),
+        );
+
+        thread::spawn(move || loop {
+            if connection.process(Duration::from_millis(1000)).is_err() {
+                break;
+            }
+        });
+
+        Ok(())
+    }
+
+    fn handle_mpris_message(
+        app: &AppHandle,
+        state: &Arc<Mutex<Option<SystemMediaPayload>>>,
+        active: &Arc<AtomicBool>,
+        message: &Message,
+        connection: &Connection,
+    ) -> bool {
+        let interface = message.interface().map(|value| value.to_string());
+        let member = message.member().map(|value| value.to_string());
+
+        match (interface.as_deref(), member.as_deref()) {
+            (Some(MPRIS_ROOT_INTERFACE), Some("Raise" | "Quit")) => {
+                send_reply(connection, message.method_return());
+                true
+            }
+            (Some(MPRIS_PLAYER_INTERFACE), Some(method)) => {
+                handle_player_method(app, active, message, connection, method);
+                true
+            }
+            (Some(DBUS_PROPERTIES_INTERFACE), Some("Get")) => {
+                handle_properties_get(state, active, message, connection);
+                true
+            }
+            (Some(DBUS_PROPERTIES_INTERFACE), Some("GetAll")) => {
+                handle_properties_get_all(state, active, message, connection);
+                true
+            }
+            (Some(DBUS_PROPERTIES_INTERFACE), Some("Set")) => {
+                send_reply(connection, message.method_return());
+                true
+            }
+            (Some(DBUS_INTROSPECTABLE_INTERFACE), Some("Introspect")) => {
+                send_reply(
+                    connection,
+                    message.method_return().append1(INTROSPECTION_XML),
+                );
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn handle_player_method(
+        app: &AppHandle,
+        active: &Arc<AtomicBool>,
+        message: &Message,
+        connection: &Connection,
+        method: &str,
+    ) {
+        if !active.load(Ordering::Acquire) {
+            send_reply(connection, message.method_return());
+            return;
+        }
+
+        match method {
+            "Play" => emit_control(app, SystemMediaControlAction::Play, None, None),
+            "Pause" => emit_control(app, SystemMediaControlAction::Pause, None, None),
+            "PlayPause" => emit_control(app, SystemMediaControlAction::PlayPause, None, None),
+            "Stop" => emit_control(app, SystemMediaControlAction::Stop, None, None),
+            "Seek" => {
+                if let Some(offset_microseconds) = message.get1::<i64>() {
+                    let offset_seconds = (offset_microseconds as f64) / 1_000_000.0;
+                    let action = if offset_seconds >= 0.0 {
+                        SystemMediaControlAction::SeekForward
+                    } else {
+                        SystemMediaControlAction::SeekBackward
+                    };
+                    emit_control(app, action, None, Some(offset_seconds.abs()));
+                }
+            }
+            "SetPosition" => {
+                let (_, position_microseconds): (Option<dbus::Path<'_>>, Option<i64>) =
+                    message.get2();
+                if let Some(position_microseconds) = position_microseconds {
+                    emit_control(
+                        app,
+                        SystemMediaControlAction::SeekTo,
+                        Some((position_microseconds as f64) / 1_000_000.0),
+                        None,
+                    );
+                }
+            }
+            "Next" => emit_control(app, SystemMediaControlAction::SeekForward, None, Some(10.0)),
+            "Previous" => emit_control(
+                app,
+                SystemMediaControlAction::SeekBackward,
+                None,
+                Some(10.0),
+            ),
+            "OpenUri" => {}
+            _ => {}
+        }
+        send_reply(connection, message.method_return());
+    }
+
+    fn handle_properties_get(
+        state: &Arc<Mutex<Option<SystemMediaPayload>>>,
+        active: &Arc<AtomicBool>,
+        message: &Message,
+        connection: &Connection,
+    ) {
+        let (interface, property): (Option<String>, Option<String>) = message.get2();
+        let state = snapshot_state(state);
+        let Some(value) = property_value(
+            interface.as_deref(),
+            property.as_deref(),
+            state.as_ref(),
+            active.load(Ordering::Acquire),
+        ) else {
+            send_reply(connection, message.method_return());
+            return;
+        };
+        send_reply(connection, message.method_return().append1(value));
+    }
+
+    fn handle_properties_get_all(
+        state: &Arc<Mutex<Option<SystemMediaPayload>>>,
+        active: &Arc<AtomicBool>,
+        message: &Message,
+        connection: &Connection,
+    ) {
+        let interface = message.get1::<String>();
+        let state = snapshot_state(state);
+        let props = properties_for_interface(
+            interface.as_deref(),
+            state.as_ref(),
+            active.load(Ordering::Acquire),
+        );
+        send_reply(connection, message.method_return().append1(props));
+    }
+
+    fn snapshot_state(
+        state: &Arc<Mutex<Option<SystemMediaPayload>>>,
+    ) -> Option<SystemMediaPayload> {
+        state.lock().ok().and_then(|guard| guard.clone())
+    }
+
+    fn properties_for_interface(
+        interface: Option<&str>,
+        state: Option<&SystemMediaPayload>,
+        active: bool,
+    ) -> PropMap {
+        match interface {
+            Some(MPRIS_ROOT_INTERFACE) => root_properties(),
+            Some(MPRIS_PLAYER_INTERFACE) => player_properties(state, active),
+            _ => PropMap::new(),
+        }
+    }
+
+    fn property_value(
+        interface: Option<&str>,
+        property: Option<&str>,
+        state: Option<&SystemMediaPayload>,
+        active: bool,
+    ) -> Option<Variant<Box<dyn RefArg>>> {
+        properties_for_interface(interface, state, active).remove(property?)
+    }
+
+    fn root_properties() -> PropMap {
+        let mut props = PropMap::new();
+        props.insert("CanQuit".into(), variant(false));
+        props.insert("CanRaise".into(), variant(false));
+        props.insert("HasTrackList".into(), variant(false));
+        props.insert("Identity".into(), variant("TuneForge".to_string()));
+        props.insert("DesktopEntry".into(), variant("tuneforge".to_string()));
+        props.insert("SupportedUriSchemes".into(), variant(Vec::<String>::new()));
+        props.insert("SupportedMimeTypes".into(), variant(Vec::<String>::new()));
+        props
+    }
+
+    fn player_properties(state: Option<&SystemMediaPayload>, active: bool) -> PropMap {
+        let mut props = PropMap::new();
+        let can_seek = active && state.is_some_and(|payload| payload.can_seek);
+        props.insert(
+            "PlaybackStatus".into(),
+            variant(playback_status(state, active).to_string()),
+        );
+        props.insert("Metadata".into(), variant(metadata(state)));
+        props.insert("Rate".into(), variant(1.0f64));
+        props.insert("MinimumRate".into(), variant(1.0f64));
+        props.insert("MaximumRate".into(), variant(1.0f64));
+        props.insert("CanGoNext".into(), variant(false));
+        props.insert("CanGoPrevious".into(), variant(false));
+        props.insert("CanPlay".into(), variant(active));
+        props.insert("CanPause".into(), variant(active));
+        props.insert("CanSeek".into(), variant(can_seek));
+        props.insert("CanControl".into(), variant(active));
+        props
+    }
+
+    fn metadata(state: Option<&SystemMediaPayload>) -> PropMap {
+        let mut metadata = PropMap::new();
+        metadata.insert(
+            "mpris:trackid".into(),
+            variant(dbus::Path::from(MPRIS_OBJECT_PATH)),
+        );
+        let Some(payload) = state else {
+            return metadata;
+        };
+        metadata.insert("xesam:title".into(), variant(payload.title.clone()));
+        metadata.insert("xesam:artist".into(), variant(vec![payload.artist.clone()]));
+        if let Some(album) = &payload.album {
+            metadata.insert("xesam:album".into(), variant(album.clone()));
+        }
+        if let Some(duration_seconds) = finite_non_negative(payload.duration_seconds) {
+            metadata.insert(
+                "mpris:length".into(),
+                variant((duration_seconds * 1_000_000.0) as i64),
+            );
+        }
+        metadata
+    }
+
+    fn playback_status(state: Option<&SystemMediaPayload>, active: bool) -> &'static str {
+        if !active {
+            return "Stopped";
+        }
+        match state.map(|payload| payload.playback_state) {
+            Some(SystemMediaPlaybackState::Playing) => "Playing",
+            Some(SystemMediaPlaybackState::Paused) => "Paused",
+            Some(SystemMediaPlaybackState::None) | None => "Stopped",
+        }
+    }
+
+    fn finite_non_negative(value: Option<f64>) -> Option<f64> {
+        value.filter(|next| next.is_finite() && *next >= 0.0)
+    }
+
+    fn variant<T: RefArg + 'static>(value: T) -> Variant<Box<dyn RefArg>> {
+        Variant(Box::new(value))
+    }
+
+    fn send_reply(connection: &Connection, message: Message) {
+        let _ = connection.send(message);
+    }
+
+    const INTROSPECTION_XML: &str = r#"
+<node>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg name="xml_data" type="s" direction="out"/>
+    </method>
+  </interface>
+  <interface name="org.freedesktop.DBus.Properties">
+    <method name="Get">
+      <arg name="interface_name" type="s" direction="in"/>
+      <arg name="property_name" type="s" direction="in"/>
+      <arg name="value" type="v" direction="out"/>
+    </method>
+    <method name="GetAll">
+      <arg name="interface_name" type="s" direction="in"/>
+      <arg name="properties" type="a{sv}" direction="out"/>
+    </method>
+    <method name="Set">
+      <arg name="interface_name" type="s" direction="in"/>
+      <arg name="property_name" type="s" direction="in"/>
+      <arg name="value" type="v" direction="in"/>
+    </method>
+  </interface>
+  <interface name="org.mpris.MediaPlayer2">
+    <method name="Raise"/>
+    <method name="Quit"/>
+    <property name="CanQuit" type="b" access="read"/>
+    <property name="CanRaise" type="b" access="read"/>
+    <property name="HasTrackList" type="b" access="read"/>
+    <property name="Identity" type="s" access="read"/>
+    <property name="DesktopEntry" type="s" access="read"/>
+    <property name="SupportedUriSchemes" type="as" access="read"/>
+    <property name="SupportedMimeTypes" type="as" access="read"/>
+  </interface>
+  <interface name="org.mpris.MediaPlayer2.Player">
+    <method name="Next"/>
+    <method name="Previous"/>
+    <method name="Pause"/>
+    <method name="PlayPause"/>
+    <method name="Stop"/>
+    <method name="Play"/>
+    <method name="Seek">
+      <arg name="Offset" type="x" direction="in"/>
+    </method>
+    <method name="SetPosition">
+      <arg name="TrackId" type="o" direction="in"/>
+      <arg name="Position" type="x" direction="in"/>
+    </method>
+    <method name="OpenUri">
+      <arg name="Uri" type="s" direction="in"/>
+    </method>
+    <property name="PlaybackStatus" type="s" access="read"/>
+    <property name="Metadata" type="a{sv}" access="read"/>
+    <property name="Rate" type="d" access="read"/>
+    <property name="MinimumRate" type="d" access="read"/>
+    <property name="MaximumRate" type="d" access="read"/>
+    <property name="CanGoNext" type="b" access="read"/>
+    <property name="CanGoPrevious" type="b" access="read"/>
+    <property name="CanPlay" type="b" access="read"/>
+    <property name="CanPause" type="b" access="read"/>
+    <property name="CanSeek" type="b" access="read"/>
+    <property name="CanControl" type="b" access="read"/>
+  </interface>
+</node>
+"#;
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+mod platform {
+    use super::SystemMediaPayload;
+    use tauri::AppHandle;
+
+    #[derive(Default)]
+    pub struct IdleInhibition {
+        active: bool,
+    }
+
+    impl IdleInhibition {
+        pub fn set_active(&mut self, active: bool) -> Result<(), String> {
+            self.active = active;
+            Ok(())
+        }
+    }
+
+    pub fn update_media_state(app: &AppHandle, payload: &SystemMediaPayload) -> Result<(), String> {
+        let _ = (app, payload);
+        Ok(())
+    }
+
+    pub fn clear_media_state(app: &AppHandle) -> Result<(), String> {
+        let _ = app;
+        Ok(())
+    }
+}

--- a/apps/desktop/src/App.project-media-controls.test.tsx
+++ b/apps/desktop/src/App.project-media-controls.test.tsx
@@ -1,0 +1,446 @@
+import { act, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  deferNextMockSystemMediaControlListen,
+  emitMockNativePlaybackError,
+  emitMockNativePlaybackPosition,
+  emitMockSystemMediaPlaybackControl,
+  findAudioByArtifactId,
+  getMockInvoke,
+  getMockMediaSession,
+  getMockWakeLock,
+  markAudioReady,
+  rejectMockSystemMediaCommand,
+  renderApp,
+  resetAppTestHarness,
+  resolveDeferredMockSystemMediaControlListen,
+  setMockNativeAudioState,
+} from "./test/appTestHarness";
+
+async function openPlaybackWorkspace(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("tab", { name: "Playback" }));
+}
+
+function mockTauriRuntime() {
+  Object.defineProperty(window, "__TAURI_INTERNALS__", {
+    configurable: true,
+    value: {},
+  });
+
+  return () => {
+    delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  };
+}
+
+function latestNativeSessionId() {
+  const prepareCall = [...getMockInvoke().mock.calls]
+    .reverse()
+    .find(([command]) => command === "audio_prepare_session");
+  const payload = (prepareCall?.[1] as { payload?: { sessionId?: string } } | undefined)?.payload;
+  if (!payload?.sessionId) {
+    throw new Error("Native audio session was not prepared.");
+  }
+  return payload.sessionId;
+}
+
+function invokeCalls(command: string) {
+  return getMockInvoke().mock.calls.filter(([name]) => name === command);
+}
+
+function hasSystemMediaPlaybackState(playbackState: "playing" | "paused") {
+  return invokeCalls("system_media_update_state").some(([, args]) => {
+    const payload = (args as { payload?: { playbackState?: string } } | undefined)?.payload;
+    return payload?.playbackState === playbackState;
+  });
+}
+
+function hasNativeIdleInhibition(active: boolean) {
+  return invokeCalls("system_media_set_idle_inhibition").some(([, args]) => {
+    return (args as { active?: boolean } | undefined)?.active === active;
+  });
+}
+
+function expectNoSystemMediaCommandCalls() {
+  expect(invokeCalls("system_media_update_state")).toHaveLength(0);
+  expect(invokeCalls("system_media_clear_state")).toHaveLength(0);
+  expect(invokeCalls("system_media_set_idle_inhibition")).toHaveLength(0);
+}
+
+function expectNoNativePlaybackCommandCalls() {
+  expect(invokeCalls("audio_prepare_session")).toHaveLength(0);
+  expect(invokeCalls("audio_play")).toHaveLength(0);
+  expect(invokeCalls("audio_pause")).toHaveLength(0);
+  expect(invokeCalls("audio_seek")).toHaveLength(0);
+  expect(invokeCalls("audio_stop")).toHaveLength(0);
+  expect(invokeCalls("audio_set_lanes")).toHaveLength(0);
+}
+
+function invokeCallIndexAfter(
+  startIndex: number,
+  command: string,
+  predicate: (args: unknown) => boolean = () => true,
+) {
+  return getMockInvoke().mock.calls.findIndex(
+    ([name, args], index) => index > startIndex && name === command && predicate(args),
+  );
+}
+
+async function waitForWebOwnerControls() {
+  await waitFor(() => {
+    expect(hasSystemMediaPlaybackState("playing")).toBe(true);
+  });
+  await waitFor(() => expect(getMockWakeLock().request).toHaveBeenCalledWith("screen"));
+}
+
+async function waitForNativeControls() {
+  await waitFor(() => expect(hasSystemMediaPlaybackState("playing")).toBe(true));
+  await waitFor(() => expect(hasNativeIdleInhibition(true)).toBe(true));
+}
+
+async function startForcedWebPlayback(user: ReturnType<typeof userEvent.setup>) {
+  vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
+  const restoreTauriRuntime = mockTauriRuntime();
+  setMockNativeAudioState({
+    capabilities: {
+      nativePlaybackSupported: true,
+      fallbackRequired: false,
+      fallbackReason: null,
+      backend: "desktop-cpal",
+    },
+  });
+  renderApp(["/projects/proj_123"]);
+  expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+  await openPlaybackWorkspace(user);
+  const sourceAudio = findAudioByArtifactId("art_source");
+  markAudioReady(sourceAudio);
+  await user.click(screen.getByRole("button", { name: "Play playback" }));
+  await waitFor(() => expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument());
+  return restoreTauriRuntime;
+}
+
+describe("Desktop app project media controls", () => {
+  beforeEach(resetAppTestHarness);
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  });
+
+  it("uses system media controls and browser wake lock when Web Audio is forced", async () => {
+    const user = userEvent.setup();
+    const restoreTauriRuntime = await startForcedWebPlayback(user);
+
+    await waitForWebOwnerControls();
+    expect(getMockMediaSession().actionHandlers.size).toBe(0);
+    expect(getMockMediaSession().setActionHandler).not.toHaveBeenCalled();
+    expect(hasNativeIdleInhibition(true)).toBe(false);
+    expectNoNativePlaybackCommandCalls();
+
+    act(() => {
+      emitMockSystemMediaPlaybackControl({ action: "pause" });
+    });
+    await waitFor(() => expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument());
+    await waitFor(() => expect(getMockWakeLock().sentinels[0]?.release).toHaveBeenCalled());
+    expectNoNativePlaybackCommandCalls();
+
+    act(() => {
+      emitMockSystemMediaPlaybackControl({ action: "play" });
+    });
+    await waitFor(() => expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument());
+    expectNoNativePlaybackCommandCalls();
+    restoreTauriRuntime();
+  });
+
+  it("routes system media controls to Web Audio when Web Audio owns playback", async () => {
+    const user = userEvent.setup();
+    const restoreTauriRuntime = await startForcedWebPlayback(user);
+    const sourceAudio = findAudioByArtifactId("art_source");
+
+    await waitForWebOwnerControls();
+    act(() => {
+      emitMockSystemMediaPlaybackControl({ action: "playPause" });
+    });
+    await waitFor(() => expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument());
+
+    act(() => {
+      emitMockSystemMediaPlaybackControl({ action: "playPause" });
+    });
+    await waitFor(() => expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument());
+
+    act(() => {
+      emitMockSystemMediaPlaybackControl({ action: "seekForward", seekOffsetSeconds: 10 });
+    });
+    await waitFor(() => {
+      expect(sourceAudio.currentTime).toBeGreaterThanOrEqual(10);
+      expect(sourceAudio.currentTime).toBeLessThan(11);
+    });
+    act(() => {
+      emitMockSystemMediaPlaybackControl({ action: "seekTo", positionSeconds: 22 });
+    });
+    await waitFor(() => {
+      expect(sourceAudio.currentTime).toBeCloseTo(22, 3);
+    });
+    expectNoNativePlaybackCommandCalls();
+    restoreTauriRuntime();
+  });
+
+  it("reacquires the browser wake lock after the sentinel is released", async () => {
+    const user = userEvent.setup();
+    const restoreTauriRuntime = await startForcedWebPlayback(user);
+
+    await waitForWebOwnerControls();
+    expect(getMockWakeLock().request).toHaveBeenCalledTimes(1);
+    getMockWakeLock().sentinels[0]?.dispatchRelease();
+    await waitFor(() => expect(getMockWakeLock().request).toHaveBeenCalledTimes(2));
+    expectNoNativePlaybackCommandCalls();
+    restoreTauriRuntime();
+  });
+
+  it("uses native controls and native idle inhibition after native playback starts", async () => {
+    const restoreTauriRuntime = mockTauriRuntime();
+    const user = userEvent.setup();
+    setMockNativeAudioState({
+      capabilities: {
+        nativePlaybackSupported: true,
+        fallbackRequired: false,
+        fallbackReason: null,
+        backend: "desktop-cpal",
+      },
+    });
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    await waitForNativeControls();
+    expect(getMockMediaSession().actionHandlers.size).toBe(0);
+    expect(getMockMediaSession().setActionHandler).not.toHaveBeenCalled();
+    expect(getMockWakeLock().request).not.toHaveBeenCalled();
+
+    emitMockSystemMediaPlaybackControl({ action: "pause" });
+    await waitFor(() => expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument());
+    await waitFor(() => expect(hasNativeIdleInhibition(false)).toBe(true));
+
+    restoreTauriRuntime();
+  });
+
+  it("routes native seek controls to the native transport", async () => {
+    const restoreTauriRuntime = mockTauriRuntime();
+    const user = userEvent.setup();
+    setMockNativeAudioState({
+      capabilities: {
+        nativePlaybackSupported: true,
+        fallbackRequired: false,
+        fallbackReason: null,
+        backend: "desktop-cpal",
+      },
+    });
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitForNativeControls();
+
+    emitMockSystemMediaPlaybackControl({ action: "seekForward", seekOffsetSeconds: 10 });
+    await waitFor(() => {
+      expect(
+        invokeCalls("audio_seek").some(([, args]) => {
+          const payload = (args as { payload?: { timeSeconds?: number } } | undefined)?.payload;
+          return payload?.timeSeconds === 10;
+        }),
+      ).toBe(true);
+    });
+
+    restoreTauriRuntime();
+  });
+
+  it("routes late system media listeners through the Web Audio owner after fallback", async () => {
+    deferNextMockSystemMediaControlListen();
+    const restoreTauriRuntime = mockTauriRuntime();
+    const user = userEvent.setup();
+    setMockNativeAudioState({
+      capabilities: {
+        nativePlaybackSupported: true,
+        fallbackRequired: false,
+        fallbackReason: null,
+        backend: "desktop-cpal",
+      },
+    });
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitForNativeControls();
+
+    const sessionId = latestNativeSessionId();
+    act(() => {
+      emitMockNativePlaybackPosition({
+        sessionId,
+        positionSeconds: 21,
+        durationSeconds: 182,
+        state: "playing",
+      });
+    });
+    act(() => {
+      emitMockNativePlaybackError({
+        sessionId,
+        message: "Native output failed.",
+      });
+    });
+
+    const sourceAudio = await waitFor(() => findAudioByArtifactId("art_source"));
+    markAudioReady(sourceAudio);
+    await waitForWebOwnerControls();
+
+    const nativePauseCount = invokeCalls("audio_pause").length;
+    act(() => {
+      emitMockSystemMediaPlaybackControl({ action: "pause" });
+    });
+    await waitFor(() => expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument());
+    expect(invokeCalls("audio_pause")).toHaveLength(nativePauseCount);
+
+    resolveDeferredMockSystemMediaControlListen();
+    await Promise.resolve();
+
+    act(() => {
+      emitMockSystemMediaPlaybackControl({ action: "play" });
+    });
+    await waitFor(() => expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument());
+    expect(invokeCalls("audio_pause")).toHaveLength(nativePauseCount);
+    restoreTauriRuntime();
+  });
+
+  it("activates Web Audio system controls only after native play falls back before start", async () => {
+    const restoreTauriRuntime = mockTauriRuntime();
+    const user = userEvent.setup();
+    setMockNativeAudioState({
+      capabilities: {
+        nativePlaybackSupported: true,
+        fallbackRequired: false,
+        fallbackReason: null,
+        backend: "desktop-cpal",
+      },
+      playFallbackReason: "Native playback could not start.",
+    });
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    await waitFor(() => expect(findAudioByArtifactId("art_source")).toBeInTheDocument());
+    expectNoSystemMediaCommandCalls();
+
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    await waitFor(() => expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument());
+    await waitForWebOwnerControls();
+    expect(hasNativeIdleInhibition(true)).toBe(false);
+    restoreTauriRuntime();
+  });
+
+  it("does not activate Web Audio controls when native release fails during runtime fallback", async () => {
+    const restoreTauriRuntime = mockTauriRuntime();
+    const user = userEvent.setup();
+    setMockNativeAudioState({
+      capabilities: {
+        nativePlaybackSupported: true,
+        fallbackRequired: false,
+        fallbackReason: null,
+        backend: "desktop-cpal",
+      },
+    });
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitForNativeControls();
+
+    rejectMockSystemMediaCommand("system_media_clear_state", "Native controls did not clear.");
+    const sessionId = latestNativeSessionId();
+    act(() => {
+      emitMockNativePlaybackError({
+        sessionId,
+        message: "Native output failed.",
+      });
+    });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument());
+    await Promise.resolve();
+    expect(getMockMediaSession().actionHandlers.size).toBe(0);
+    expect(getMockWakeLock().request).not.toHaveBeenCalled();
+    restoreTauriRuntime();
+  });
+
+  it("clears native controls before activating Web Audio controls on runtime fallback", async () => {
+    const restoreTauriRuntime = mockTauriRuntime();
+    const user = userEvent.setup();
+    setMockNativeAudioState({
+      capabilities: {
+        nativePlaybackSupported: true,
+        fallbackRequired: false,
+        fallbackReason: null,
+        backend: "desktop-cpal",
+      },
+    });
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitForNativeControls();
+
+    const sessionId = latestNativeSessionId();
+    act(() => {
+      emitMockNativePlaybackPosition({
+        sessionId,
+        positionSeconds: 42,
+        durationSeconds: 182,
+        state: "playing",
+      });
+    });
+    await waitFor(() => expect(screen.getByLabelText("Playback position")).toHaveValue("42"));
+
+    act(() => {
+      emitMockNativePlaybackError({
+        sessionId,
+        message: "Native output failed.",
+      });
+    });
+
+    await waitFor(() => expect(hasNativeIdleInhibition(false)).toBe(true));
+    await waitFor(() => {
+      expect(invokeCalls("system_media_clear_state").length).toBeGreaterThan(0);
+    });
+
+    const sourceAudio = await waitFor(() => findAudioByArtifactId("art_source"));
+    markAudioReady(sourceAudio);
+    await waitFor(() => expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument());
+    await waitFor(() => expect(sourceAudio.currentTime).toBeCloseTo(42, 3));
+    await waitForWebOwnerControls();
+    const clearIndex = invokeCallIndexAfter(0, "system_media_clear_state");
+    expect(clearIndex).toBeGreaterThan(-1);
+    const webUpdateIndex = invokeCallIndexAfter(clearIndex, "system_media_update_state", (args) => {
+      const payload = (args as { payload?: { playbackState?: string } } | undefined)?.payload;
+      return payload?.playbackState === "playing";
+    });
+    expect(webUpdateIndex).toBeGreaterThan(clearIndex);
+    restoreTauriRuntime();
+  });
+
+  it("pause releases the Web Audio wake lock without touching native idle inhibition", async () => {
+    const user = userEvent.setup();
+    const restoreTauriRuntime = await startForcedWebPlayback(user);
+    await waitForWebOwnerControls();
+
+    await user.click(screen.getByRole("button", { name: "Pause playback" }));
+    await waitFor(() => expect(getMockWakeLock().sentinels[0]?.release).toHaveBeenCalled());
+    expect(hasNativeIdleInhibition(true)).toBe(false);
+
+    restoreTauriRuntime();
+  });
+});

--- a/apps/desktop/src/App.project-playback-stems.test.tsx
+++ b/apps/desktop/src/App.project-playback-stems.test.tsx
@@ -14,6 +14,7 @@ import {
   mockCreatePreview,
   mockCreateStems,
   mockDeleteArtifact,
+  mockListArtifacts,
   mockListJobs,
   mockSave,
   mockUpdateProject,
@@ -580,10 +581,12 @@ describe("Desktop app project playback stems", () => {
 
     await act(async () => {
       flushPendingPreview("proj_123");
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["jobs"] }),
-        queryClient.invalidateQueries({ queryKey: ["artifacts", "proj_123"] }),
+      const [{ artifacts }, { jobs }] = await Promise.all([
+        mockListArtifacts("proj_123"),
+        mockListJobs(),
       ]);
+      queryClient.setQueryData(["artifacts", "proj_123"], artifacts);
+      queryClient.setQueryData(["jobs"], jobs);
     });
 
     await waitFor(() =>

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -33,6 +33,7 @@ import {
   getWebAudioContextConstructor,
   primeWebAudioContext,
 } from "../../lib/webAudio";
+import { releaseSystemMediaControls } from "../../lib/systemMedia";
 import { useStableCallback } from "../../lib/useStableCallback";
 import { countInIntervalsForTiming } from "../../lib/timingGrid";
 import {
@@ -64,7 +65,12 @@ import {
   loadStemBuffer as loadStemPlaybackBuffer,
   loadStemBuffers,
 } from "./stemPlaybackBuffers";
-import { useMediaSessionControls, useSpacebarPlaybackShortcut } from "./playbackEffects";
+import {
+  useSpacebarPlaybackShortcut,
+  useSystemPlaybackMediaControls,
+  useWebPlaybackWakeLock,
+  type PlaybackControlBackend,
+} from "./playbackEffects";
 import { PRECOUNT_START_DELAY_SECONDS, schedulePrecountClaveClick } from "./precountSound";
 
 type ActivePrecount = {
@@ -291,6 +297,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   const [webMediaSourcesEnabled, setWebMediaSourcesEnabled] = useState(
     initialWebMediaSourcesEnabled,
   );
+  const [playbackControlBackend, setPlaybackControlBackend] =
+    useState<PlaybackControlBackend>("none");
 
   useEffect(() => {
     sessionRef.current = session;
@@ -307,6 +315,14 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     isPlayingRef.current = isPlaying;
   }, [isPlaying]);
+
+  const clearPlaybackControlBackend = useCallback(() => {
+    setPlaybackControlBackend("none");
+  }, []);
+
+  const markWebPlaybackStartResult = useCallback((started: boolean) => {
+    setPlaybackControlBackend(started ? "web" : "none");
+  }, []);
 
   function setPrimaryAudioRef(element: HTMLAudioElement | null) {
     primaryAudioRef.current = element;
@@ -555,6 +571,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       nativePlaybackRef.current.sessionSignature === sessionSignature;
     try {
       if (!(await ensureNativePlaybackSession(targetSession))) {
+        clearPlaybackControlBackend();
         return false;
       }
       const latestSession = sessionRef.current;
@@ -587,6 +604,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         );
         nativePlaybackRef.current.blockedSessionSignature = sessionSignature;
         markNativePlaybackInactive();
+        clearPlaybackControlBackend();
         void requestNativeStop();
         return false;
       }
@@ -597,12 +615,14 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       pauseRenderedMediaElements(latestSession);
       setPlaybackTimeSeconds(snapshot.positionSeconds);
       setPlaybackDurationSeconds(snapshot.durationSeconds || latestSession.durationHintSeconds || 0);
+      setPlaybackControlBackend("native");
       setIsPlaying(true);
       return true;
     } catch (error) {
       rememberNativePlaybackError(playbackErrorMessage(error));
       nativePlaybackRef.current.blockedSessionSignature = sessionSignature;
       markNativePlaybackInactive();
+      clearPlaybackControlBackend();
       return false;
     }
   });
@@ -796,6 +816,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     }
 
     setPlaybackTimeSeconds(0);
+    clearPlaybackControlBackend();
     setIsPlaying(false);
   });
 
@@ -999,6 +1020,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     } catch {
       stemClockBlockedRef.current = true;
       disposeStemPlaybackState();
+      markWebPlaybackStartResult(false);
       setIsPlaying(false);
       return false;
     }
@@ -1010,6 +1032,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       syncStemElementTimes(targetPlaybackState.artifactIds, targetPlaybackState.durationSeconds);
       setPlaybackTimeSeconds(targetPlaybackState.durationSeconds);
       setPlaybackDurationSeconds(targetPlaybackState.durationSeconds);
+      markWebPlaybackStartResult(false);
       setIsPlaying(false);
       return false;
     }
@@ -1067,18 +1090,21 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     } catch {
       stemClockBlockedRef.current = true;
       disposeStemPlaybackState();
+      markWebPlaybackStartResult(false);
       setIsPlaying(false);
       return false;
     }
     if (scheduledCount !== Object.keys(nextSources).length || scheduledCount === 0) {
       stemClockBlockedRef.current = true;
       disposeStemPlaybackState();
+      markWebPlaybackStartResult(false);
       setIsPlaying(false);
       return false;
     }
 
     setPlaybackTimeSeconds(nextTime);
     setPlaybackDurationSeconds(targetPlaybackState.durationSeconds);
+    markWebPlaybackStartResult(true);
     setIsPlaying(true);
     rememberPlaybackBackend({ backend: "web", detail: null });
     scheduleStemClock(targetPlaybackState);
@@ -1302,6 +1328,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           element.currentTime = loopRange.startSeconds;
         });
         setPlaybackTimeSeconds(loopRange.startSeconds);
+        clearPlaybackControlBackend();
         setIsPlaying(false);
         if (
           await startPrecountThenPlayback(targetSession, loopRange.startSeconds, {
@@ -1516,6 +1543,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
         if (!latestPendingTransition.shouldPlay) {
           stopStemSources(targetPlaybackState, false);
+          clearPlaybackControlBackend();
           setIsPlaying(false);
           return;
         }
@@ -1527,6 +1555,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           return;
         }
         if (stemClockBlockedRef.current) {
+          markWebPlaybackStartResult(false);
           setIsPlaying(false);
           return;
         }
@@ -1547,6 +1576,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         if (fallbackStarted) {
           rememberPlaybackBackend({ backend: "web", detail: null });
         }
+        markWebPlaybackStartResult(fallbackStarted);
         setIsPlaying(fallbackStarted);
         return;
       }
@@ -1641,6 +1671,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
       if (!pendingTransition.shouldPlay) {
         targetElements.forEach((element) => element.pause());
+        clearPlaybackControlBackend();
         setIsPlaying(false);
         return;
       }
@@ -1656,6 +1687,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       if (started) {
         rememberPlaybackBackend({ backend: "web", detail: null });
       }
+      markWebPlaybackStartResult(started);
       setIsPlaying(started);
     })();
   });
@@ -1740,6 +1772,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       }
       if (stemClockBlockedRef.current) {
         markNativePlaybackInactive();
+        markWebPlaybackStartResult(false);
         setIsPlaying(false);
         return;
       }
@@ -1783,6 +1816,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     if (started) {
       rememberPlaybackBackend({ backend: "web", detail: null });
     }
+    markWebPlaybackStartResult(started);
     setIsPlaying(started);
   });
 
@@ -1982,7 +2016,10 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     if (nativePlaybackRef.current.active) {
       void seekNativeAudio({ timeSeconds: nextTime })
         .then((snapshot) => setPlaybackTimeSeconds(snapshot.positionSeconds))
-        .catch(() => markNativePlaybackInactive());
+        .catch(() => {
+          markNativePlaybackInactive();
+          clearPlaybackControlBackend();
+        });
       setPlaybackTimeSeconds(nextTime);
       return;
     }
@@ -2011,6 +2048,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   }, [
     canUseBufferedClock,
     cancelPrecount,
+    clearPlaybackControlBackend,
     getActiveMediaElements,
     markNativePlaybackInactive,
     playbackStartTimeForSession,
@@ -2045,10 +2083,12 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       element.currentTime = resetTime;
     });
     setPlaybackTimeSeconds(resetTime);
+    clearPlaybackControlBackend();
     setIsPlaying(false);
     updateDurationFromActiveMedia();
   }, [
     cancelPrecount,
+    clearPlaybackControlBackend,
     clearPendingTransition,
     getRenderedMediaElements,
     markNativePlaybackInactive,
@@ -2084,6 +2124,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       });
       setPlaybackTimeSeconds(resetTime);
       setPlaybackDurationSeconds(nextSession.durationHintSeconds || 0);
+      clearPlaybackControlBackend();
       setIsPlaying(false);
     } else if (previousSession && previousSignature !== nextSignature) {
       cancelPrecount();
@@ -2136,10 +2177,19 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
             element.currentTime = fallbackTime;
           });
           setPlaybackTimeSeconds(fallbackTime);
+          clearPlaybackControlBackend();
           setIsPlaying(false);
           if (shouldPlay) {
-            void playPlaybackImmediately();
+            void releaseSystemMediaControls()
+              .then(() => {
+                void playPlaybackImmediately();
+              })
+              .catch((error) => rememberNativePlaybackError(playbackErrorMessage(error)));
+            return;
           }
+          void releaseSystemMediaControls().catch((error) =>
+            rememberNativePlaybackError(playbackErrorMessage(error)),
+          );
         };
 
         void setNativeAudioLanes(nativeLaneUpdateForSession(nextSession))
@@ -2168,6 +2218,11 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
             clearRememberedNativePlaybackError();
             setPlaybackTimeSeconds(snapshot.positionSeconds);
             setPlaybackDurationSeconds(snapshot.durationSeconds || latestSession.durationHintSeconds || 0);
+            if (snapshot.state === "stopped") {
+              clearPlaybackControlBackend();
+            } else {
+              setPlaybackControlBackend("native");
+            }
             setIsPlaying(snapshot.state === "playing");
           })
           .catch((error) => {
@@ -2178,6 +2233,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       if (previousUsesNative && !carriesNativeSession) {
         void requestNativeStop();
         markNativePlaybackInactive();
+        clearPlaybackControlBackend();
         getActiveMediaElements(previousSession).forEach((element) => {
           element.pause();
           element.currentTime = nextTime;
@@ -2235,6 +2291,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     } else if (!previousSession) {
       setPlaybackTimeSeconds(playbackResetTimeForSession(nextSession));
       setPlaybackDurationSeconds(nextSession.durationHintSeconds || 0);
+      clearPlaybackControlBackend();
       setIsPlaying(false);
     }
 
@@ -2244,6 +2301,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     cancelPrecount,
     applyMediaPlaybackRate,
     canUseBufferedClock,
+    clearPlaybackControlBackend,
     clearPendingTransition,
     closePlaybackAudioContext,
     disposeStemPlaybackState,
@@ -2314,6 +2372,9 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         }
         setPlaybackTimeSeconds(position.positionSeconds);
         setPlaybackDurationSeconds(position.durationSeconds || activeSession.durationHintSeconds || 0);
+        if (position.state === "stopped") {
+          clearPlaybackControlBackend();
+        }
         setIsPlaying(position.state === "playing");
       }),
       listenNativeAudioEnded((snapshot: NativeAudioSnapshot) => {
@@ -2328,6 +2389,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         }
         const resetTime = playbackResetTimeForSession(activeSession);
         setPlaybackTimeSeconds(resetTime);
+        clearPlaybackControlBackend();
         setIsPlaying(false);
         syncStemElementTimes(activeSession?.visibleStemArtifactIds ?? [], resetTime);
         getRenderedMediaElements().forEach((element) => {
@@ -2351,6 +2413,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         );
         nativePlaybackRef.current.blockedSessionSignature = nativeSessionSignature(activeSession);
         markNativePlaybackInactive();
+        clearPlaybackControlBackend();
         setIsPlaying(false);
         void requestNativeStop();
         syncStemElementTimes(activeSession.visibleStemArtifactIds, fallbackTime);
@@ -2359,7 +2422,13 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           element.currentTime = fallbackTime;
         });
         setPlaybackTimeSeconds(fallbackTime);
-        void playPlaybackImmediately();
+        void releaseSystemMediaControls()
+          .then(() => {
+            void playPlaybackImmediately();
+          })
+          .catch((releaseError) =>
+            rememberNativePlaybackError(playbackErrorMessage(releaseError)),
+          );
       }),
     ]);
 
@@ -2369,6 +2438,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       });
     };
   }, [
+    clearPlaybackControlBackend,
     getRenderedMediaElements,
     markNativePlaybackInactive,
     playbackResetTimeForSession,
@@ -2379,7 +2449,12 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     syncStemElementTimes,
   ]);
 
-  useMediaSessionControls({
+  useWebPlaybackWakeLock({
+    backend: playbackControlBackend,
+    isPlaying,
+  });
+  useSystemPlaybackMediaControls({
+    backend: playbackControlBackend,
     isPlaying,
     pausePlayback,
     playbackDurationSeconds,
@@ -2387,6 +2462,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     playbackTimeSeconds,
     playPlayback,
     seekBy,
+    seekTo,
     session,
     stopPlayback,
   });

--- a/apps/desktop/src/features/projects/playbackEffects.ts
+++ b/apps/desktop/src/features/projects/playbackEffects.ts
@@ -1,8 +1,18 @@
-import { useEffect, type RefObject } from "react";
+import { useEffect, useRef, type RefObject } from "react";
+import {
+  clearSystemMediaState,
+  listenSystemMediaControls,
+  setSystemMediaIdleInhibition,
+  updateSystemMediaState,
+  type SystemMediaControlEvent,
+} from "../../lib/systemMedia";
 import type { ProjectPlaybackSession } from "./playback-context";
-import { clampTime, isInteractiveTarget } from "./playbackUtils";
+import { isInteractiveTarget } from "./playbackUtils";
 
-type MediaSessionControls = {
+export type PlaybackControlBackend = "none" | "web" | "native";
+
+type PlaybackMediaControls = {
+  backend: PlaybackControlBackend;
   isPlaying: boolean;
   pausePlayback: () => void;
   playbackDurationSeconds: number;
@@ -10,11 +20,101 @@ type MediaSessionControls = {
   playbackTimeSeconds: number;
   playPlayback: () => Promise<void>;
   seekBy: (secondsDelta: number) => void;
+  seekTo: (timeSeconds: number) => void;
   session: ProjectPlaybackSession | null;
   stopPlayback: () => void;
 };
 
-export function useMediaSessionControls({
+type WakeLockSentinelLike = {
+  release: () => Promise<void>;
+  addEventListener?: (type: "release", listener: () => void) => void;
+  removeEventListener?: (type: "release", listener: () => void) => void;
+};
+
+type NavigatorWithWakeLock = Navigator & {
+  wakeLock?: {
+    request: (type: "screen") => Promise<WakeLockSentinelLike>;
+  };
+};
+
+function isTauriRuntime() {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+export function useWebPlaybackWakeLock({
+  backend,
+  isPlaying,
+}: Pick<PlaybackMediaControls, "backend" | "isPlaying">) {
+  useEffect(() => {
+    if (backend !== "web" || !isPlaying || typeof navigator === "undefined") {
+      return;
+    }
+
+    let sentinel: WakeLockSentinelLike | null = null;
+    let sentinelReleaseHandler: (() => void) | null = null;
+    let cancelled = false;
+    const wakeLock = (navigator as NavigatorWithWakeLock).wakeLock;
+    if (!wakeLock) {
+      return;
+    }
+
+    function clearSentinel() {
+      if (sentinel && sentinelReleaseHandler) {
+        sentinel.removeEventListener?.("release", sentinelReleaseHandler);
+      }
+      sentinel = null;
+      sentinelReleaseHandler = null;
+    }
+
+    async function acquireWakeLock() {
+      if (cancelled || sentinel || document.visibilityState === "hidden") {
+        return;
+      }
+      try {
+        const nextSentinel = await wakeLock?.request("screen") ?? null;
+        if (cancelled) {
+          void nextSentinel?.release().catch(() => undefined);
+          return;
+        }
+        sentinel = nextSentinel;
+        sentinelReleaseHandler = () => {
+          if (sentinel !== nextSentinel) {
+            return;
+          }
+          clearSentinel();
+          if (!cancelled && document.visibilityState === "visible") {
+            void acquireWakeLock();
+          }
+        };
+        sentinel?.addEventListener?.("release", sentinelReleaseHandler);
+      } catch {
+        clearSentinel();
+      }
+    }
+
+    function handleVisibilityChange() {
+      if (document.visibilityState === "visible" && !sentinel) {
+        void acquireWakeLock();
+      }
+    }
+
+    void acquireWakeLock();
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      const activeSentinel = sentinel;
+      clearSentinel();
+      if (activeSentinel) {
+        void activeSentinel.release().catch(() => undefined);
+      }
+    };
+  }, [backend, isPlaying]);
+}
+
+export function useSystemPlaybackMediaControls({
+  backend,
   isPlaying,
   pausePlayback,
   playbackDurationSeconds,
@@ -22,95 +122,149 @@ export function useMediaSessionControls({
   playbackTimeSeconds,
   playPlayback,
   seekBy,
+  seekTo,
   session,
   stopPlayback,
-}: MediaSessionControls) {
+}: PlaybackMediaControls) {
+  const ownsSystemControlsRef = useRef(false);
+
   useEffect(() => {
-    if (typeof navigator === "undefined" || !("mediaSession" in navigator)) {
+    if (backend === "none" || !isTauriRuntime()) {
+      if (ownsSystemControlsRef.current) {
+        void clearSystemMediaState().catch(() => undefined);
+        void setSystemMediaIdleInhibition(false).catch(() => undefined);
+        ownsSystemControlsRef.current = false;
+      }
       return;
     }
 
     if (!session) {
-      try {
-        navigator.mediaSession.metadata = null;
-        navigator.mediaSession.playbackState = "none";
-      } catch {
-        return;
+      if (ownsSystemControlsRef.current) {
+        void clearSystemMediaState().catch(() => undefined);
+        void setSystemMediaIdleInhibition(false).catch(() => undefined);
+        ownsSystemControlsRef.current = false;
       }
       return;
     }
 
-    try {
-      if (typeof MediaMetadata !== "undefined") {
-        navigator.mediaSession.metadata = new MediaMetadata({
-          title: session.stageTitle || session.projectName,
-          artist: session.projectName,
-          album: session.stageSummary,
-        });
-      }
-
-      navigator.mediaSession.playbackState = isPlaying ? "playing" : "paused";
-      navigator.mediaSession.setActionHandler("play", () => {
-        void playPlayback();
-      });
-      navigator.mediaSession.setActionHandler("pause", () => {
-        pausePlayback();
-      });
-      navigator.mediaSession.setActionHandler("stop", () => {
-        stopPlayback();
-      });
-      navigator.mediaSession.setActionHandler("seekbackward", () => {
-        seekBy(-10);
-      });
-      navigator.mediaSession.setActionHandler("seekforward", () => {
-        seekBy(10);
-      });
-      navigator.mediaSession.setActionHandler("previoustrack", () => {
-        seekBy(-10);
-      });
-      navigator.mediaSession.setActionHandler("nexttrack", () => {
-        seekBy(10);
-      });
-
-      if (
-        typeof navigator.mediaSession.setPositionState === "function" &&
-        Number.isFinite(playbackDurationSeconds) &&
-        playbackDurationSeconds > 0
-      ) {
-        navigator.mediaSession.setPositionState({
-          duration: playbackDurationSeconds,
-          playbackRate,
-          position: clampTime(playbackTimeSeconds, playbackDurationSeconds),
-        });
-      }
-    } catch {
-      return;
-    }
-
-    return () => {
-      try {
-        navigator.mediaSession.setActionHandler("play", null);
-        navigator.mediaSession.setActionHandler("pause", null);
-        navigator.mediaSession.setActionHandler("stop", null);
-        navigator.mediaSession.setActionHandler("seekbackward", null);
-        navigator.mediaSession.setActionHandler("seekforward", null);
-        navigator.mediaSession.setActionHandler("previoustrack", null);
-        navigator.mediaSession.setActionHandler("nexttrack", null);
-      } catch {
-        return;
-      }
-    };
+    ownsSystemControlsRef.current = true;
+    void updateSystemMediaState({
+      title: session.stageTitle || session.projectName,
+      artist: session.projectName,
+      album: session.stageSummary,
+      playbackState: isPlaying ? "playing" : "paused",
+      durationSeconds: Number.isFinite(playbackDurationSeconds)
+        ? playbackDurationSeconds
+        : session.durationHintSeconds,
+      positionSeconds: playbackTimeSeconds,
+      playbackRate,
+      canSeek: true,
+    }).catch(() => undefined);
   }, [
+    backend,
     isPlaying,
-    pausePlayback,
     playbackDurationSeconds,
     playbackRate,
     playbackTimeSeconds,
+    session,
+  ]);
+
+  useEffect(() => {
+    if (backend === "none" || !session || !isTauriRuntime()) {
+      return;
+    }
+
+    let cancelled = false;
+
+    function handleControl(event: SystemMediaControlEvent) {
+      if (cancelled) {
+        return;
+      }
+      if (event.action === "play") {
+        void playPlayback();
+        return;
+      }
+      if (event.action === "pause") {
+        pausePlayback();
+        return;
+      }
+      if (event.action === "playPause") {
+        if (isPlaying) {
+          pausePlayback();
+        } else {
+          void playPlayback();
+        }
+        return;
+      }
+      if (event.action === "stop") {
+        stopPlayback();
+        return;
+      }
+      if (event.action === "seekBackward") {
+        seekBy(-Math.abs(event.seekOffsetSeconds ?? 10));
+        return;
+      }
+      if (event.action === "seekForward") {
+        seekBy(Math.abs(event.seekOffsetSeconds ?? 10));
+        return;
+      }
+      if (event.action === "seekTo" && typeof event.positionSeconds === "number") {
+        seekTo(event.positionSeconds);
+      }
+    }
+
+    let unlisten: (() => void) | null = null;
+    void listenSystemMediaControls(handleControl)
+      .then((nextUnlisten) => {
+        if (cancelled) {
+          nextUnlisten();
+          return;
+        }
+        unlisten = nextUnlisten;
+      })
+      .catch(() => undefined);
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [
+    backend,
+    isPlaying,
+    pausePlayback,
     playPlayback,
     seekBy,
+    seekTo,
     session,
     stopPlayback,
   ]);
+
+  useEffect(() => {
+    if (!ownsSystemControlsRef.current) {
+      return;
+    }
+
+    if (backend !== "native" || !isPlaying) {
+      void setSystemMediaIdleInhibition(false).catch(() => undefined);
+      return;
+    }
+
+    void setSystemMediaIdleInhibition(true).catch(() => undefined);
+    return () => {
+      void setSystemMediaIdleInhibition(false).catch(() => undefined);
+    };
+  }, [backend, isPlaying]);
+
+  useEffect(
+    () => () => {
+      if (ownsSystemControlsRef.current) {
+        void clearSystemMediaState().catch(() => undefined);
+        void setSystemMediaIdleInhibition(false).catch(() => undefined);
+        ownsSystemControlsRef.current = false;
+      }
+    },
+    [],
+  );
 }
 
 export function useSpacebarPlaybackShortcut({

--- a/apps/desktop/src/lib/systemMedia.ts
+++ b/apps/desktop/src/lib/systemMedia.ts
@@ -1,0 +1,59 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+
+export const SYSTEM_MEDIA_CONTROL_EVENT = "system-media://control";
+
+export type SystemMediaPlaybackState = "none" | "playing" | "paused";
+
+export type SystemMediaState = {
+  title: string;
+  artist: string;
+  album?: string | null;
+  playbackState: SystemMediaPlaybackState;
+  durationSeconds?: number | null;
+  positionSeconds?: number | null;
+  playbackRate?: number | null;
+  canSeek: boolean;
+};
+
+export type SystemMediaControlAction =
+  | "play"
+  | "pause"
+  | "playPause"
+  | "stop"
+  | "seekBackward"
+  | "seekForward"
+  | "seekTo";
+
+export type SystemMediaControlEvent = {
+  action: SystemMediaControlAction;
+  positionSeconds?: number | null;
+  seekOffsetSeconds?: number | null;
+};
+
+export function updateSystemMediaState(payload: SystemMediaState) {
+  return invoke<void>("system_media_update_state", { payload });
+}
+
+export function clearSystemMediaState() {
+  return invoke<void>("system_media_clear_state");
+}
+
+export function setSystemMediaIdleInhibition(active: boolean) {
+  return invoke<void>("system_media_set_idle_inhibition", { active });
+}
+
+export async function releaseSystemMediaControls() {
+  await Promise.all([
+    clearSystemMediaState(),
+    setSystemMediaIdleInhibition(false),
+  ]);
+}
+
+export function listenSystemMediaControls(
+  handler: (event: SystemMediaControlEvent) => void,
+) {
+  return listen<SystemMediaControlEvent>(SYSTEM_MEDIA_CONTROL_EVENT, (event) => {
+    handler(event.payload);
+  });
+}

--- a/apps/desktop/src/setupTests.ts
+++ b/apps/desktop/src/setupTests.ts
@@ -65,6 +65,29 @@ type MockMediaDevicesController = {
   setDevices: (devices: MediaDeviceInfo[]) => void;
 };
 
+type MockMediaSessionActionHandler = (details?: MediaSessionActionDetails) => void;
+
+type MockMediaSessionController = MediaSession & {
+  actionHandlers: Map<string, MockMediaSessionActionHandler>;
+  dispatchAction: (action: string, details?: MediaSessionActionDetails) => void;
+  reset: () => void;
+  throwOnAction: (action: MediaSessionAction | "seekto") => void;
+};
+
+type MockWakeLockSentinel = {
+  released: boolean;
+  release: ReturnType<typeof vi.fn>;
+  addEventListener: ReturnType<typeof vi.fn>;
+  dispatchRelease: () => void;
+  removeEventListener: ReturnType<typeof vi.fn>;
+};
+
+type MockWakeLockController = {
+  request: ReturnType<typeof vi.fn>;
+  sentinels: MockWakeLockSentinel[];
+  reset: () => void;
+};
+
 function createStorageMock(): Storage {
   let storage = new Map<string, string>();
 
@@ -177,6 +200,110 @@ const mockMediaDevicesController: MockMediaDevicesController = {
 Object.defineProperty(navigator, "mediaDevices", {
   configurable: true,
   value: mockMediaDevices,
+});
+
+const mockMediaSessionActionHandlers = new Map<string, MockMediaSessionActionHandler>();
+const mockMediaSessionThrowingActions = new Set<MediaSessionAction | "seekto">();
+const mockSetMediaSessionActionHandler = vi.fn(
+  (action: MediaSessionAction | "seekto", handler: MockMediaSessionActionHandler | null) => {
+    if (mockMediaSessionThrowingActions.has(action)) {
+      throw new Error(`Unsupported media session action: ${action}`);
+    }
+    if (handler) {
+      mockMediaSessionActionHandlers.set(action, handler);
+      return;
+    }
+    mockMediaSessionActionHandlers.delete(action);
+  },
+);
+const mockSetMediaSessionPositionState = vi.fn();
+const mockMediaSession = {
+  metadata: null,
+  playbackState: "none",
+  setActionHandler: mockSetMediaSessionActionHandler,
+  setPositionState: mockSetMediaSessionPositionState,
+  actionHandlers: mockMediaSessionActionHandlers,
+  dispatchAction(action: string, details?: MediaSessionActionDetails) {
+    mockMediaSessionActionHandlers.get(action)?.(details);
+  },
+  reset: () => {
+    mockMediaSession.metadata = null;
+    mockMediaSession.playbackState = "none";
+    mockMediaSessionActionHandlers.clear();
+    mockMediaSessionThrowingActions.clear();
+    mockSetMediaSessionActionHandler.mockClear();
+    mockSetMediaSessionPositionState.mockClear();
+  },
+  throwOnAction: (action: MediaSessionAction | "seekto") => {
+    mockMediaSessionThrowingActions.add(action);
+  },
+} as unknown as MockMediaSessionController;
+
+class MockMediaMetadata {
+  album?: string;
+  artist?: string;
+  artwork?: MediaImage[];
+  title?: string;
+
+  constructor(init: MediaMetadataInit = {}) {
+    this.album = init.album;
+    this.artist = init.artist;
+    this.artwork = init.artwork;
+    this.title = init.title;
+  }
+}
+
+const mockWakeLock: MockWakeLockController = {
+  request: vi.fn(async () => {
+    const releaseListeners = new Set<() => void>();
+    const sentinel: MockWakeLockSentinel = {
+      released: false,
+      release: vi.fn(async () => {
+        sentinel.released = true;
+      }),
+      addEventListener: vi.fn((type: "release", listener: () => void) => {
+        if (type === "release") {
+          releaseListeners.add(listener);
+        }
+      }),
+      dispatchRelease() {
+        sentinel.released = true;
+        releaseListeners.forEach((listener) => listener());
+      },
+      removeEventListener: vi.fn((type: "release", listener: () => void) => {
+        if (type === "release") {
+          releaseListeners.delete(listener);
+        }
+      }),
+    };
+    mockWakeLock.sentinels.push(sentinel);
+    return sentinel;
+  }),
+  sentinels: [],
+  reset() {
+    this.request.mockClear();
+    this.sentinels.splice(0, this.sentinels.length);
+  },
+};
+
+Object.defineProperty(navigator, "mediaSession", {
+  configurable: true,
+  value: mockMediaSession,
+});
+
+Object.defineProperty(navigator, "wakeLock", {
+  configurable: true,
+  value: mockWakeLock,
+});
+
+Object.defineProperty(globalThis, "MediaMetadata", {
+  configurable: true,
+  value: MockMediaMetadata,
+});
+
+Object.defineProperty(window, "MediaMetadata", {
+  configurable: true,
+  value: MockMediaMetadata,
 });
 
 Object.defineProperty(window, "matchMedia", {
@@ -447,4 +574,14 @@ Object.defineProperty(globalThis, "__setMockAudioSourceStartError", {
 Object.defineProperty(globalThis, "__mockMediaDevices", {
   writable: true,
   value: mockMediaDevicesController,
+});
+
+Object.defineProperty(globalThis, "__mockMediaSession", {
+  writable: true,
+  value: mockMediaSession,
+});
+
+Object.defineProperty(globalThis, "__mockWakeLock", {
+  writable: true,
+  value: mockWakeLock,
 });

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -50,7 +50,11 @@ const {
   emitMockNativeAudioError,
   emitMockNativeAudioInputFrame,
   emitMockNativeAudioPosition,
+  emitMockSystemMediaControl,
+  deferNextSystemMediaControlListen,
   mockListen,
+  rejectSystemMediaCommand,
+  resolveDeferredSystemMediaControlListen,
 } = vi.hoisted(() => {
   const createdAt = "2026-04-18T13:16:00.000Z";
   type NativeAudioInputFrame = {
@@ -80,6 +84,20 @@ const {
     id: number;
     payload: Record<string, unknown>;
   };
+  type SystemMediaControlPayload = {
+    action: "play" | "pause" | "playPause" | "stop" | "seekBackward" | "seekForward" | "seekTo";
+    positionSeconds?: number | null;
+    seekOffsetSeconds?: number | null;
+  };
+  type SystemMediaControlEvent = {
+    event: "system-media://control";
+    id: number;
+    payload: SystemMediaControlPayload;
+  };
+  type SystemMediaCommand =
+    | "system_media_update_state"
+    | "system_media_clear_state"
+    | "system_media_set_idle_inhibition";
   const nativeInputFrameListeners = new Map<
     number,
     (event: NativeAudioInputFrameEvent) => void
@@ -91,8 +109,14 @@ const {
       handler: (event: NativeAudioRuntimeEvent) => void;
     }
   >();
+  const systemMediaControlListeners = new Map<
+    number,
+    (event: SystemMediaControlEvent) => void
+  >();
   let nextNativeInputFrameListenerId = 1;
   let nextNativeRuntimeListenerId = 1;
+  let nextSystemMediaControlListenerId = 1;
+  let deferredSystemMediaControlListenResolver: (() => void) | null = null;
   let state: {
     projects: Array<Record<string, unknown>>;
     analysisByProject: Record<string, Record<string, unknown> | null>;
@@ -126,6 +150,10 @@ const {
     nativeAudioSnapshot: Record<string, unknown>;
     nativeAudioStartError: string | null;
     nativeAudioPlayFallbackReason: string | null;
+    systemMediaState: Record<string, unknown> | null;
+    systemMediaIdleInhibited: boolean;
+    systemMediaCommandErrors: Partial<Record<SystemMediaCommand, string>>;
+    deferNextSystemMediaControlListen: boolean;
     nextProjectId: number;
     nextArtifactId: number;
     nextJobId: number;
@@ -467,6 +495,10 @@ const {
       },
       nativeAudioStartError: null,
       nativeAudioPlayFallbackReason: null,
+      systemMediaState: null,
+      systemMediaIdleInhibited: false,
+      systemMediaCommandErrors: {},
+      deferNextSystemMediaControlListen: false,
       nextProjectId: 200,
       nextArtifactId: 200,
       nextJobId: 200,
@@ -476,8 +508,11 @@ const {
     };
     nativeInputFrameListeners.clear();
     nativeRuntimeListeners.clear();
+    systemMediaControlListeners.clear();
     nextNativeInputFrameListenerId = 1;
     nextNativeRuntimeListenerId = 1;
+    nextSystemMediaControlListenerId = 1;
+    deferredSystemMediaControlListenResolver = null;
   }
 
   resetMockApiState();
@@ -570,6 +605,24 @@ const {
   function emitMockNativeAudioError(error: NativeAudioErrorPayload) {
     emitMockNativeRuntimeEvent("audio://error", error);
   }
+  function emitMockSystemMediaControl(payload: SystemMediaControlPayload) {
+    systemMediaControlListeners.forEach((listener, id) => {
+      listener({
+        event: "system-media://control",
+        id,
+        payload: clone(payload),
+      });
+    });
+  }
+  function deferNextSystemMediaControlListen() {
+    state.deferNextSystemMediaControlListen = true;
+  }
+  function resolveDeferredSystemMediaControlListen() {
+    deferredSystemMediaControlListenResolver?.();
+  }
+  function rejectSystemMediaCommand(command: SystemMediaCommand, message: string) {
+    state.systemMediaCommandErrors[command] = message;
+  }
   function emitMockNativeRuntimeEvent(
     eventName: NativeAudioRuntimeEvent["event"],
     payload: Record<string, unknown>,
@@ -588,8 +641,27 @@ const {
   const mockListen = vi.fn(
     async (
       eventName: string,
-      handler: (event: NativeAudioInputFrameEvent | NativeAudioRuntimeEvent) => void,
+      handler: (event: NativeAudioInputFrameEvent | NativeAudioRuntimeEvent | SystemMediaControlEvent) => void,
     ) => {
+      if (eventName === "system-media://control") {
+        const listenerId = nextSystemMediaControlListenerId;
+        nextSystemMediaControlListenerId += 1;
+        systemMediaControlListeners.set(
+          listenerId,
+          handler as (event: SystemMediaControlEvent) => void,
+        );
+        const unlisten = () => systemMediaControlListeners.delete(listenerId);
+        if (state.deferNextSystemMediaControlListen) {
+          state.deferNextSystemMediaControlListen = false;
+          await new Promise<void>((resolve) => {
+            deferredSystemMediaControlListenResolver = () => {
+              deferredSystemMediaControlListenResolver = null;
+              resolve();
+            };
+          });
+        }
+        return unlisten;
+      }
       if (
         eventName === "audio://position" ||
         eventName === "audio://ended" ||
@@ -649,6 +721,30 @@ const {
         error: null,
       };
       return clone(state.systemInputVolume);
+    }
+
+    if (command === "system_media_update_state") {
+      if (state.systemMediaCommandErrors.system_media_update_state) {
+        throw new Error(state.systemMediaCommandErrors.system_media_update_state);
+      }
+      state.systemMediaState = clone((args?.payload ?? {}) as Record<string, unknown>);
+      return null;
+    }
+
+    if (command === "system_media_clear_state") {
+      if (state.systemMediaCommandErrors.system_media_clear_state) {
+        throw new Error(state.systemMediaCommandErrors.system_media_clear_state);
+      }
+      state.systemMediaState = null;
+      return null;
+    }
+
+    if (command === "system_media_set_idle_inhibition") {
+      if (state.systemMediaCommandErrors.system_media_set_idle_inhibition) {
+        throw new Error(state.systemMediaCommandErrors.system_media_set_idle_inhibition);
+      }
+      state.systemMediaIdleInhibited = Boolean(args?.active);
+      return null;
     }
 
     if (command === "audio_get_capabilities") {
@@ -1453,7 +1549,11 @@ const {
     emitMockNativeAudioError,
     emitMockNativeAudioInputFrame,
     emitMockNativeAudioPosition,
+    emitMockSystemMediaControl,
+    deferNextSystemMediaControlListen,
     mockListen,
+    rejectSystemMediaCommand,
+    resolveDeferredSystemMediaControlListen,
   };
 });
 
@@ -1741,6 +1841,30 @@ export function emitMockNativePlaybackError(
   emitMockNativeAudioError(error);
 }
 
+export function emitMockSystemMediaPlaybackControl(
+  payload: Parameters<typeof emitMockSystemMediaControl>[0],
+) {
+  emitMockSystemMediaControl(payload);
+}
+
+export function deferNextMockSystemMediaControlListen() {
+  deferNextSystemMediaControlListen();
+}
+
+export function resolveDeferredMockSystemMediaControlListen() {
+  resolveDeferredSystemMediaControlListen();
+}
+
+export function rejectMockSystemMediaCommand(
+  command:
+    | "system_media_update_state"
+    | "system_media_clear_state"
+    | "system_media_set_idle_inhibition",
+  message: string,
+) {
+  rejectSystemMediaCommand(command, message);
+}
+
 export function getMockMediaDevices() {
   return (
     globalThis as typeof globalThis & {
@@ -1757,9 +1881,41 @@ export function getMockMediaDevices() {
   ).__mockMediaDevices;
 }
 
+export function getMockMediaSession() {
+  return (
+    globalThis as typeof globalThis & {
+      __mockMediaSession: MediaSession & {
+        actionHandlers: Map<string, (details?: MediaSessionActionDetails) => void>;
+        dispatchAction: (action: string, details?: MediaSessionActionDetails) => void;
+        reset: () => void;
+        setActionHandler: ReturnType<typeof vi.fn>;
+        setPositionState: ReturnType<typeof vi.fn>;
+        throwOnAction: (action: MediaSessionAction | "seekto") => void;
+      };
+    }
+  ).__mockMediaSession;
+}
+
+export function getMockWakeLock() {
+  return (
+    globalThis as typeof globalThis & {
+      __mockWakeLock: {
+        request: ReturnType<typeof vi.fn>;
+        reset: () => void;
+        sentinels: Array<{
+          dispatchRelease: () => void;
+          released: boolean;
+          release: ReturnType<typeof vi.fn>;
+        }>;
+      };
+    }
+  ).__mockWakeLock;
+}
+
 
 export function resetAppTestHarness() {
   resetMockApiState();
+  delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
   window.localStorage.clear();
   window.sessionStorage.clear();
   delete document.documentElement.dataset.theme;
@@ -1770,6 +1926,9 @@ export function resetAppTestHarness() {
   mockInvoke.mockClear();
   mockListen.mockClear();
   mockConfirm.mockResolvedValue(true);
+  getMockMediaSession().reset();
+  getMockWakeLock().reset();
+  getMockMediaDevices().reset();
   mockListProjects.mockClear();
   mockImportProject.mockClear();
   mockGetProject.mockClear();

--- a/docs/NATIVE_AUDIO.md
+++ b/docs/NATIVE_AUDIO.md
@@ -24,6 +24,22 @@ added feature by feature behind the Tauri native audio boundary.
 The frontend prefers native audio when a feature is supported and falls back to Web Audio when
 native support is unavailable or startup fails.
 
+Playback also owns media-key controls and wake prevention through the active backend only:
+
+- TuneForge registers one desktop system-media adapter with the OS for media keys and headset
+  controls. That adapter does not choose the audio engine; it routes play/pause/stop/seek events to
+  the current playback owner.
+- Native playback owns the transport only after native playback has successfully started, and uses
+  native idle/display inhibition while playing.
+- Web Audio/HTML media playback owns the transport when playback starts through browser media,
+  including `VITE_TUNEFORGE_FORCE_WEB_AUDIO=1` and native fallback. It uses the browser Screen Wake
+  Lock while playing.
+- Native fallback is an explicit ownership transfer. TuneForge clears system media state and native
+  idle inhibition, starts the Web Audio path at the fallback position, then re-registers system
+  media state for the Web Audio owner and acquires the browser wake lock. Diagnostics keep the
+  native fallback reason.
+- Failed native prepare/play attempts before audio starts never activate native transport ownership.
+
 ## Linux Build Prerequisites
 
 Native tempo playback uses `signalsmith-stretch`, which runs Rust `bindgen` during the Tauri build.
@@ -101,6 +117,9 @@ Run once with native playback selected per platform, then rerun with forced Web 
 | Loop count-in | runs at loop start and on loop wrap, never on pause/resume | same | same |
 | Tempo control | tempo change applies and stays stable | tempo change applies and stays stable | tempo change applies and stays stable |
 | Metronome follow | follows active track tempo while BPM changes | follows active track tempo while BPM changes | follows active track tempo while BPM changes |
+| Media keys / headset controls | system media controls play/pause/stop/seek native transport only | MPRIS controls play/pause/stop/seek native transport only | system media controls play/pause/stop/seek browser transport only |
+| Wake prevention | native display idle inhibition while playing; released on pause/stop/end/fallback | desktop idle inhibition while playing; released on pause/stop/end/fallback | Screen Wake Lock while playing; released on pause/stop/end |
+| Native runtime fallback ownership | system state/inhibition clear before Web Audio starts at fallback position, then system controls route to Web Audio | same | not applicable; web owns controls from start |
 | Fallback + no output device | falls back (or errors and recovers) without crash when no native output exists | same | same |
 
 ## Local-only Playwright Smoke Harness


### PR DESCRIPTION
## Summary

- Add backend-owned playback media-control routing for native and Web Audio playback.
- Register OS media controls through the Tauri adapter while routing commands to the active owner.
- Keep native idle inhibition for native playback and browser Screen Wake Lock for Web Audio.
- Document fallback ownership and media-key QA expectations.

## Testing

- `pnpm --filter @tuneforge/desktop exec vitest run src/App.project-media-controls.test.tsx`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test`
- `cd apps/desktop/src-tauri && cargo check`
- `git diff --check`

Linux MPRIS media-key behavior was not manually tested locally.
