### PR TITLE
feat: add sync identity preflight

### DIFF
--- a/apps/backend/alembic/versions/0014_sync_project_identity.py
+++ b/apps/backend/alembic/versions/0014_sync_project_identity.py
@@ -1,0 +1,597 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0014_sync_project_identity"
+down_revision = "0013_analysis_timing"
+branch_labels = None
+depends_on = None
+
+PROJECT_ID_LENGTH = 80
+PROJECT_ID_PREFIX = "proj_sha256_"
+PROJECT_STORAGE_KEY_PREFIX = "proj_"
+PROJECT_STORAGE_HASH_LENGTH = 24
+NORMALIZED_IMPORT_SOURCE_FORMATS = {"mp4", "webm"}
+HEX_DIGITS = frozenset("0123456789abcdef")
+PROJECT_REFERENCE_TABLES = (
+    "analysis_results",
+    "chord_timelines",
+    "lyrics_transcripts",
+    "tab_imports",
+    "song_sections",
+    "artifacts",
+    "jobs",
+)
+PROJECT_SNAPSHOT_FILENAMES = ("analysis.json", "chords.json", "lyrics.json")
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    _widen_project_id_columns(inspector)
+    _restore_artifact_expression_indexes(connection, inspector)
+    _migrate_existing_project_ids(connection, inspector)
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    _narrow_project_id_columns(inspector)
+
+
+def _widen_project_id_columns(inspector: sa.Inspector) -> None:
+    _alter_column_length(inspector, "projects", "id", length=PROJECT_ID_LENGTH)
+    for table_name in PROJECT_REFERENCE_TABLES:
+        _alter_column_length(inspector, table_name, "project_id", length=PROJECT_ID_LENGTH)
+
+
+def _narrow_project_id_columns(inspector: sa.Inspector) -> None:
+    _alter_column_length(inspector, "projects", "id", length=32)
+    for table_name in PROJECT_REFERENCE_TABLES:
+        _alter_column_length(inspector, table_name, "project_id", length=32)
+
+
+def _alter_column_length(
+    inspector: sa.Inspector,
+    table_name: str,
+    column_name: str,
+    *,
+    length: int,
+) -> None:
+    if not inspector.has_table(table_name):
+        return
+    columns = {column["name"]: column for column in inspector.get_columns(table_name)}
+    if column_name not in columns:
+        return
+    column = columns[column_name]
+    with op.batch_alter_table(table_name) as batch_op:
+        batch_op.alter_column(
+            column_name,
+            existing_type=sa.String(length=32),
+            type_=sa.String(length=length),
+            existing_nullable=bool(column["nullable"]),
+        )
+
+
+def _restore_artifact_expression_indexes(connection: sa.Connection, inspector: sa.Inspector) -> None:
+    if not inspector.has_table("artifacts"):
+        return
+    connection.execute(sa.text("DROP INDEX IF EXISTS uq_artifacts_analysis_json_project"))
+    connection.execute(sa.text("DROP INDEX IF EXISTS uq_artifacts_stem_per_source"))
+    connection.execute(
+        sa.text(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_artifacts_analysis_json_project
+            ON artifacts (project_id)
+            WHERE type = 'analysis_json'
+            """
+        )
+    )
+    connection.execute(
+        sa.text(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_artifacts_stem_per_source
+            ON artifacts (
+                project_id,
+                type,
+                json_extract(metadata_json, '$.source_artifact_id'),
+                coalesce(json_extract(metadata_json, '$.stem_model'), '')
+            )
+            WHERE type IN (
+                'vocal_stem',
+                'instrumental_stem',
+                'drums_stem',
+                'bass_stem',
+                'guitar_stem',
+                'piano_stem',
+                'other_stem'
+            )
+            """
+        )
+    )
+
+
+def _migrate_existing_project_ids(connection: sa.Connection, inspector: sa.Inspector) -> None:
+    if not inspector.has_table("projects"):
+        return
+
+    source_artifacts = _source_artifacts_by_project(connection, inspector)
+    project_rows = [
+        dict(row._mapping)
+        for row in connection.execute(
+            sa.text(
+                """
+                SELECT id, source_path, imported_path, source_sha256
+                FROM projects
+                ORDER BY id
+                """
+            )
+        )
+    ]
+    resolved_hashes = {
+        project["id"]: source_hash
+        for project in project_rows
+        if (source_hash := _resolve_source_hash(project, source_artifacts.get(project["id"]))) is not None
+    }
+    duplicate_hashes = {
+        source_hash
+        for source_hash, count in Counter(resolved_hashes.values()).items()
+        if count > 1
+    }
+
+    existing_project_ids = {project["id"] for project in project_rows}
+    project_artifacts = _artifacts_by_project(connection, inspector)
+    projects_root = _projects_root()
+
+    for project in project_rows:
+        old_id = project["id"]
+        source_hash = resolved_hashes.get(old_id)
+        if source_hash is None:
+            continue
+
+        connection.execute(
+            sa.text("UPDATE projects SET source_sha256 = :source_sha256 WHERE id = :project_id"),
+            {"project_id": old_id, "source_sha256": source_hash},
+        )
+
+        if source_hash in duplicate_hashes:
+            continue
+
+        new_root = projects_root / _source_hash_to_project_storage_key(source_hash)
+        new_id = _source_hash_to_project_id(source_hash)
+        artifacts = _project_artifacts(project_artifacts, old_id, new_id)
+        if old_id == new_id:
+            _recover_canonical_project_paths(
+                connection,
+                project=project,
+                artifacts=artifacts,
+                projects_root=projects_root,
+                new_root=new_root,
+                new_id=new_id,
+            )
+            continue
+        if new_id in existing_project_ids:
+            continue
+
+        old_root = projects_root / old_id
+        if not _storage_paths_can_move(project, artifacts, old_root, new_root):
+            continue
+
+        path_updates = _path_updates(project, artifacts, old_root, new_root)
+        if not _move_project_root(old_root, new_root):
+            continue
+
+        _rewrite_project_snapshots(new_root, old_id=old_id, new_id=new_id)
+        _update_project_references(connection, inspector, old_id=old_id, new_id=new_id)
+        _update_path_columns(connection, project=project, artifact_updates=path_updates)
+        connection.execute(
+            sa.text(
+                """
+                UPDATE projects
+                SET id = :new_id, source_sha256 = :source_sha256
+                WHERE id = :old_id
+                """
+            ),
+            {"old_id": old_id, "new_id": new_id, "source_sha256": source_hash},
+        )
+
+        existing_project_ids.remove(old_id)
+        existing_project_ids.add(new_id)
+
+
+def _source_artifacts_by_project(
+    connection: sa.Connection,
+    inspector: sa.Inspector,
+) -> dict[str, dict[str, Any]]:
+    if not inspector.has_table("artifacts"):
+        return {}
+    artifacts: dict[str, dict[str, Any]] = {}
+    for row in connection.execute(
+        sa.text(
+            """
+            SELECT id, project_id, path, metadata_json
+            FROM artifacts
+            WHERE type = 'source_audio'
+            ORDER BY project_id, created_at, id
+            """
+        )
+    ):
+        artifact = dict(row._mapping)
+        artifacts.setdefault(artifact["project_id"], artifact)
+    return artifacts
+
+
+def _artifacts_by_project(
+    connection: sa.Connection,
+    inspector: sa.Inspector,
+) -> dict[str, list[dict[str, Any]]]:
+    if not inspector.has_table("artifacts"):
+        return {}
+    artifacts: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in connection.execute(
+        sa.text(
+            """
+            SELECT id, project_id, path, metadata_json
+            FROM artifacts
+            ORDER BY project_id, id
+            """
+        )
+    ):
+        artifact = dict(row._mapping)
+        artifacts[artifact["project_id"]].append(artifact)
+    return artifacts
+
+
+def _project_artifacts(
+    project_artifacts: dict[str, list[dict[str, Any]]],
+    old_id: str,
+    new_id: str,
+) -> list[dict[str, Any]]:
+    artifacts: list[dict[str, Any]] = []
+    seen_artifact_ids: set[str] = set()
+    for project_id in (old_id, new_id):
+        for artifact in project_artifacts.get(project_id, []):
+            artifact_id = artifact["id"]
+            if artifact_id in seen_artifact_ids:
+                continue
+            seen_artifact_ids.add(artifact_id)
+            artifacts.append(artifact)
+    return artifacts
+
+
+def _recover_canonical_project_paths(
+    connection: sa.Connection,
+    *,
+    project: dict[str, Any],
+    artifacts: list[dict[str, Any]],
+    projects_root: Path,
+    new_root: Path,
+    new_id: str,
+) -> None:
+    for old_root in _candidate_project_roots(project, artifacts, projects_root, new_root):
+        if old_root.exists() and new_root.exists():
+            continue
+        path_updates = _path_updates(project, artifacts, old_root, new_root)
+        if not _move_project_root(old_root, new_root):
+            continue
+        _rewrite_project_snapshots(new_root, old_id=old_root.name, new_id=new_id)
+        _update_path_columns(connection, project=project, artifact_updates=path_updates)
+
+
+def _candidate_project_roots(
+    project: dict[str, Any],
+    artifacts: list[dict[str, Any]],
+    projects_root: Path,
+    new_root: Path,
+) -> list[Path]:
+    roots: list[Path] = []
+    for value in _owned_path_values(project, artifacts):
+        if not isinstance(value, str):
+            continue
+        root = _project_root_for_path(value, projects_root)
+        if root is None or root == new_root or root in roots:
+            continue
+        roots.append(root)
+    return roots
+
+
+def _project_root_for_path(value: str, projects_root: Path) -> Path | None:
+    root_text = str(projects_root)
+    prefix = f"{root_text}/"
+    if not value.startswith(prefix):
+        return None
+    remainder = value[len(prefix):]
+    project_root_name = remainder.split("/", 1)[0]
+    if not project_root_name:
+        return None
+    return projects_root / project_root_name
+
+
+def _resolve_source_hash(
+    project: dict[str, Any],
+    source_artifact: dict[str, Any] | None,
+) -> str | None:
+    stored_hash = _normalize_source_hash(project.get("source_sha256"))
+    if stored_hash is not None:
+        return stored_hash
+
+    original_copy_path = _original_copy_path(source_artifact)
+    original_copy_hash = _file_sha256(original_copy_path)
+    if original_copy_hash is not None:
+        return original_copy_hash
+
+    if not _uses_normalized_source_proxy(project, source_artifact):
+        artifact_hash = _file_sha256(source_artifact.get("path") if source_artifact is not None else None)
+        if artifact_hash is not None:
+            return artifact_hash
+
+        imported_path_hash = _file_sha256(project.get("imported_path"))
+        if imported_path_hash is not None:
+            return imported_path_hash
+
+    source_path_hash = _file_sha256(project.get("source_path"))
+    if source_path_hash is not None:
+        return source_path_hash
+
+    return None
+
+
+def _normalize_source_hash(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    if len(normalized) != 64 or any(character not in HEX_DIGITS for character in normalized):
+        return None
+    return normalized
+
+
+def _file_sha256(raw_path: Any) -> str | None:
+    if not isinstance(raw_path, str) or not raw_path:
+        return None
+    path = Path(raw_path)
+    hasher = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                hasher.update(chunk)
+    except OSError:
+        return None
+    return hasher.hexdigest()
+
+
+def _original_copy_path(source_artifact: dict[str, Any] | None) -> str | None:
+    if source_artifact is None:
+        return None
+    value = _metadata_dict(source_artifact.get("metadata_json")).get("original_copy_path")
+    return value if isinstance(value, str) else None
+
+
+def _uses_normalized_source_proxy(
+    project: dict[str, Any],
+    source_artifact: dict[str, Any] | None,
+) -> bool:
+    metadata = _metadata_dict(source_artifact.get("metadata_json")) if source_artifact else {}
+    original_format = metadata.get("original_format")
+    if isinstance(original_format, str) and original_format.lower() in NORMALIZED_IMPORT_SOURCE_FORMATS:
+        return True
+    source_format = Path(str(project.get("source_path", ""))).suffix.lower().lstrip(".")
+    imported_format = Path(str(project.get("imported_path", ""))).suffix.lower().lstrip(".")
+    return source_format in NORMALIZED_IMPORT_SOURCE_FORMATS and imported_format == "wav"
+
+
+def _source_hash_to_project_id(source_sha256: str) -> str:
+    return f"{PROJECT_ID_PREFIX}{source_sha256}"
+
+
+def _source_hash_to_project_storage_key(source_sha256: str) -> str:
+    return f"{PROJECT_STORAGE_KEY_PREFIX}{source_sha256[:PROJECT_STORAGE_HASH_LENGTH]}"
+
+
+def _projects_root() -> Path:
+    from app.config import get_settings
+
+    return get_settings().projects_root
+
+
+def _storage_paths_can_move(
+    project: dict[str, Any],
+    artifacts: list[dict[str, Any]],
+    old_root: Path,
+    new_root: Path,
+) -> bool:
+    if old_root.exists():
+        return not new_root.exists()
+    if new_root.exists():
+        # Recover interrupted prior runs where the folder move happened before DB updates fully completed.
+        return _has_owned_path(project, artifacts, old_root) or _has_owned_path(project, artifacts, new_root)
+    return not _has_owned_path(project, artifacts, old_root)
+
+
+def _has_owned_path(
+    project: dict[str, Any],
+    artifacts: list[dict[str, Any]],
+    old_root: Path,
+) -> bool:
+    return any(
+        isinstance(value, str) and _is_under_root(value, old_root)
+        for value in _owned_path_values(project, artifacts)
+    )
+
+
+def _owned_path_values(
+    project: dict[str, Any],
+    artifacts: list[dict[str, Any]],
+) -> list[Any]:
+    path_values = [project.get("source_path"), project.get("imported_path")]
+    for artifact in artifacts:
+        path_values.append(artifact.get("path"))
+        path_values.extend(_metadata_path_values(_metadata_dict(artifact.get("metadata_json"))))
+    return path_values
+
+
+def _is_under_root(value: str, root: Path) -> bool:
+    root_text = str(root)
+    return value == root_text or value.startswith(f"{root_text}/")
+
+
+def _metadata_path_values(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        paths: list[str] = []
+        for item in value:
+            paths.extend(_metadata_path_values(item))
+        return paths
+    if isinstance(value, dict):
+        paths = []
+        for item in value.values():
+            paths.extend(_metadata_path_values(item))
+        return paths
+    return []
+
+
+def _move_project_root(old_root: Path, new_root: Path) -> bool:
+    if not old_root.exists():
+        return True
+    try:
+        new_root.parent.mkdir(parents=True, exist_ok=True)
+        old_root.rename(new_root)
+    except OSError:
+        return False
+    return True
+
+
+def _path_updates(
+    project: dict[str, Any],
+    artifacts: list[dict[str, Any]],
+    old_root: Path,
+    new_root: Path,
+) -> list[tuple[str, str, str | None]]:
+    updates: list[tuple[str, str, str | None]] = []
+    project["source_path"] = _rewrite_path(str(project.get("source_path", "")), old_root, new_root)
+    project["imported_path"] = _rewrite_path(str(project.get("imported_path", "")), old_root, new_root)
+    for artifact in artifacts:
+        path = _rewrite_path(str(artifact.get("path", "")), old_root, new_root)
+        metadata = _rewrite_metadata_paths(artifact.get("metadata_json"), old_root, new_root)
+        updates.append((artifact["id"], path, metadata))
+    return updates
+
+
+def _rewrite_path(value: str, old_root: Path, new_root: Path) -> str:
+    old_text = str(old_root)
+    new_text = str(new_root)
+    if value == old_text:
+        return new_text
+    prefix = f"{old_text}/"
+    if value.startswith(prefix):
+        return f"{new_text}/{value[len(prefix):]}"
+    return value
+
+
+def _rewrite_metadata_paths(raw_metadata: Any, old_root: Path, new_root: Path) -> str | None:
+    metadata = _metadata_dict(raw_metadata)
+    rewritten = _rewrite_metadata_value(metadata, old_root, new_root)
+    if rewritten == metadata:
+        return None
+    return json.dumps(rewritten, separators=(",", ":"))
+
+
+def _rewrite_metadata_value(value: Any, old_root: Path, new_root: Path) -> Any:
+    if isinstance(value, str):
+        return _rewrite_path(value, old_root, new_root)
+    if isinstance(value, list):
+        return [_rewrite_metadata_value(item, old_root, new_root) for item in value]
+    if isinstance(value, dict):
+        return {key: _rewrite_metadata_value(item, old_root, new_root) for key, item in value.items()}
+    return value
+
+
+def _metadata_dict(raw_metadata: Any) -> dict[str, Any]:
+    if isinstance(raw_metadata, dict):
+        return raw_metadata
+    if isinstance(raw_metadata, str) and raw_metadata:
+        try:
+            parsed = json.loads(raw_metadata)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _rewrite_project_snapshots(project_root: Path, *, old_id: str, new_id: str) -> None:
+    analysis_root = project_root / "analysis"
+    for filename in PROJECT_SNAPSHOT_FILENAMES:
+        _rewrite_snapshot_project_id(analysis_root / filename, old_id=old_id, new_id=new_id)
+
+
+def _rewrite_snapshot_project_id(path: Path, *, old_id: str, new_id: str) -> None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return
+    if not isinstance(data, dict) or data.get("project_id") != old_id:
+        return
+    data["project_id"] = new_id
+    try:
+        path.write_text(json.dumps(data, separators=(",", ":")), encoding="utf-8")
+    except OSError:
+        return
+
+
+def _update_project_references(
+    connection: sa.Connection,
+    inspector: sa.Inspector,
+    *,
+    old_id: str,
+    new_id: str,
+) -> None:
+    for table_name in PROJECT_REFERENCE_TABLES:
+        if not inspector.has_table(table_name):
+            continue
+        columns = {column["name"] for column in inspector.get_columns(table_name)}
+        if "project_id" not in columns:
+            continue
+        connection.execute(
+            sa.text(f"UPDATE {table_name} SET project_id = :new_id WHERE project_id = :old_id"),
+            {"old_id": old_id, "new_id": new_id},
+        )
+
+
+def _update_path_columns(
+    connection: sa.Connection,
+    *,
+    project: dict[str, Any],
+    artifact_updates: list[tuple[str, str, str | None]],
+) -> None:
+    connection.execute(
+        sa.text(
+            """
+            UPDATE projects
+            SET source_path = :source_path, imported_path = :imported_path
+            WHERE id = :project_id
+            """
+        ),
+        {
+            "project_id": project["id"],
+            "source_path": project["source_path"],
+            "imported_path": project["imported_path"],
+        },
+    )
+    for artifact_id, path, metadata in artifact_updates:
+        connection.execute(
+            sa.text("UPDATE artifacts SET path = :path WHERE id = :artifact_id"),
+            {"artifact_id": artifact_id, "path": path},
+        )
+        if metadata is not None:
+            connection.execute(
+                sa.text("UPDATE artifacts SET metadata_json = :metadata WHERE id = :artifact_id"),
+                {"artifact_id": artifact_id, "metadata": metadata},
+            )

--- a/apps/backend/app/api/routes/sync.py
+++ b/apps/backend/app/api/routes/sync.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_db
+from app.schemas import SyncPreflightResponse
+from app.services.sync_identity import run_sync_preflight
+
+router = APIRouter(prefix="/sync", tags=["sync"])
+
+
+@router.get("/preflight", response_model=SyncPreflightResponse)
+def sync_preflight(session: Session = Depends(get_db)) -> SyncPreflightResponse:
+    return SyncPreflightResponse.model_validate(run_sync_preflight(session))

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -16,6 +16,7 @@ from app.api.routes.health import router as health_router
 from app.api.routes.jobs import router as jobs_router
 from app.api.routes.projects import router as projects_router
 from app.api.routes.stem_models import router as stem_models_router
+from app.api.routes.sync import router as sync_router
 from app.config import ensure_data_dirs, get_settings
 from app.db import SessionLocal, UnknownDatabaseRevisionError, reconfigure_engine, run_migrations
 from app.errors import AppError
@@ -84,3 +85,4 @@ app.include_router(stem_models_router, prefix=get_settings().api_prefix)
 app.include_router(projects_router, prefix=get_settings().api_prefix)
 app.include_router(jobs_router, prefix=get_settings().api_prefix)
 app.include_router(artifacts_router, prefix=get_settings().api_prefix)
+app.include_router(sync_router, prefix=get_settings().api_prefix)

--- a/apps/backend/app/models.py
+++ b/apps/backend/app/models.py
@@ -8,6 +8,8 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db import Base
 
+PROJECT_ID_LENGTH = 80
+
 
 def utcnow() -> datetime:
     return datetime.now(UTC)
@@ -16,7 +18,7 @@ def utcnow() -> datetime:
 class Project(Base):
     __tablename__ = "projects"
 
-    id: Mapped[str] = mapped_column(String(32), primary_key=True)
+    id: Mapped[str] = mapped_column(String(PROJECT_ID_LENGTH), primary_key=True)
     display_name: Mapped[str] = mapped_column(String(255))
     source_key_override: Mapped[str | None] = mapped_column(String(32), nullable=True)
     source_sha256: Mapped[str | None] = mapped_column(String(64), nullable=True)
@@ -55,7 +57,7 @@ class AnalysisResult(Base):
     __tablename__ = "analysis_results"
 
     project_id: Mapped[str] = mapped_column(
-        String(32), ForeignKey("projects.id", ondelete="CASCADE"), primary_key=True
+        String(PROJECT_ID_LENGTH), ForeignKey("projects.id", ondelete="CASCADE"), primary_key=True
     )
     source_artifact_id: Mapped[str | None] = mapped_column(String(32), nullable=True)
     estimated_key: Mapped[str | None] = mapped_column(String(64), nullable=True)
@@ -74,7 +76,7 @@ class ChordTimeline(Base):
     __tablename__ = "chord_timelines"
 
     project_id: Mapped[str] = mapped_column(
-        String(32), ForeignKey("projects.id", ondelete="CASCADE"), primary_key=True
+        String(PROJECT_ID_LENGTH), ForeignKey("projects.id", ondelete="CASCADE"), primary_key=True
     )
     backend: Mapped[str] = mapped_column(String(64), default="default")
     source_artifact_id: Mapped[str | None] = mapped_column(String(32), nullable=True)
@@ -96,7 +98,7 @@ class LyricsTranscript(Base):
     __tablename__ = "lyrics_transcripts"
 
     project_id: Mapped[str] = mapped_column(
-        String(32), ForeignKey("projects.id", ondelete="CASCADE"), primary_key=True
+        String(PROJECT_ID_LENGTH), ForeignKey("projects.id", ondelete="CASCADE"), primary_key=True
     )
     backend: Mapped[str] = mapped_column(String(64), default="openai-whisper")
     source_artifact_id: Mapped[str | None] = mapped_column(String(32), nullable=True)
@@ -120,7 +122,9 @@ class TabImport(Base):
     __tablename__ = "tab_imports"
 
     id: Mapped[str] = mapped_column(String(32), primary_key=True)
-    project_id: Mapped[str] = mapped_column(String(32), ForeignKey("projects.id", ondelete="CASCADE"))
+    project_id: Mapped[str] = mapped_column(
+        String(PROJECT_ID_LENGTH), ForeignKey("projects.id", ondelete="CASCADE")
+    )
     raw_text: Mapped[str] = mapped_column(Text())
     parser_version: Mapped[str] = mapped_column(String(32), default="v1")
     status: Mapped[str] = mapped_column(String(32), default="proposed")
@@ -144,7 +148,9 @@ class SongSection(Base):
     __tablename__ = "song_sections"
 
     id: Mapped[str] = mapped_column(String(32), primary_key=True)
-    project_id: Mapped[str] = mapped_column(String(32), ForeignKey("projects.id", ondelete="CASCADE"))
+    project_id: Mapped[str] = mapped_column(
+        String(PROJECT_ID_LENGTH), ForeignKey("projects.id", ondelete="CASCADE")
+    )
     tab_import_id: Mapped[str | None] = mapped_column(
         String(32), ForeignKey("tab_imports.id", ondelete="SET NULL"), nullable=True
     )
@@ -166,7 +172,9 @@ class Artifact(Base):
     __tablename__ = "artifacts"
 
     id: Mapped[str] = mapped_column(String(32), primary_key=True)
-    project_id: Mapped[str] = mapped_column(String(32), ForeignKey("projects.id", ondelete="CASCADE"))
+    project_id: Mapped[str] = mapped_column(
+        String(PROJECT_ID_LENGTH), ForeignKey("projects.id", ondelete="CASCADE")
+    )
     type: Mapped[str] = mapped_column(String(64))
     format: Mapped[str] = mapped_column(String(32))
     path: Mapped[str] = mapped_column(String(2048))
@@ -187,7 +195,7 @@ class Job(Base):
 
     id: Mapped[str] = mapped_column(String(32), primary_key=True)
     project_id: Mapped[str | None] = mapped_column(
-        String(32), ForeignKey("projects.id", ondelete="CASCADE"), nullable=True
+        String(PROJECT_ID_LENGTH), ForeignKey("projects.id", ondelete="CASCADE"), nullable=True
     )
     type: Mapped[str] = mapped_column(String(64))
     status: Mapped[str] = mapped_column(String(32), default="pending")

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -133,6 +133,66 @@ class ProjectsResponse(BaseModel):
 
 class DeleteResponse(BaseModel):
     deleted: bool
+
+
+SyncPreflightProjectStatus = Literal[
+    "ready",
+    "missing_source_hash",
+    "invalid_source_hash",
+    "duplicate_source_hash",
+    "noncanonical_project_id",
+]
+SyncPreflightSourceHashSource = Literal[
+    "database",
+    "source_path",
+    "original_copy_path",
+    "source_artifact_path",
+    "imported_path",
+]
+
+
+class SyncPreflightProjectSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    project_id: str
+    display_name: str
+    status: SyncPreflightProjectStatus
+    source_sha256: str | None
+    expected_project_id: str | None
+    expected_storage_key: str | None
+    source_hash_source: SyncPreflightSourceHashSource | None
+    reason: str | None = None
+
+
+class SyncPreflightDuplicateProjectSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    project_id: str
+    display_name: str
+
+
+class SyncPreflightDuplicateGroupSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    source_sha256: str
+    expected_project_id: str
+    projects: list[SyncPreflightDuplicateProjectSchema]
+
+
+class SyncPreflightResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    ok: bool
+    total_projects: int
+    ready_projects: int
+    missing_source_hash_projects: int
+    invalid_source_hash_projects: int
+    duplicate_source_hash_projects: int
+    noncanonical_project_id_projects: int
+    projects: list[SyncPreflightProjectSchema]
+    duplicate_groups: list[SyncPreflightDuplicateGroupSchema]
+    manual_cleanup_required: bool
+    manual_cleanup_guidance: list[str]
 
 
 class AnalysisRequest(BaseModel):

--- a/apps/backend/app/services/paths.py
+++ b/apps/backend/app/services/paths.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from pathlib import Path
 
 from app.config import get_settings
+from app.services.sync_identity import project_id_to_storage_key
 
 
 def project_root(project_id: str) -> Path:
-    return get_settings().projects_root / project_id
+    return get_settings().projects_root / project_id_to_storage_key(project_id)
 
 
 def project_source_dir(project_id: str) -> Path:

--- a/apps/backend/app/services/projects.py
+++ b/apps/backend/app/services/projects.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from fastapi import status
 from sqlalchemy import func, or_, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.config import get_settings
@@ -13,8 +14,8 @@ from app.models import Project
 from app.services.artifacts import register_artifact
 from app.services.metadata import extract_audio_metadata, normalize_media_to_wav
 from app.services.paths import ensure_project_dirs, project_root, project_source_dir
+from app.services.sync_identity import source_hash_to_project_id
 from app.utils.hashing import file_sha256
-from app.utils.ids import new_id
 
 NORMALIZED_IMPORT_FORMATS = {"mp4", "webm"}
 
@@ -54,6 +55,15 @@ def get_project(session: Session, project_id: str) -> Project:
     return project
 
 
+def _duplicate_project_source_error(project_id: str) -> AppError:
+    return AppError(
+        "DUPLICATE_PROJECT_SOURCE",
+        "This source track is already imported.",
+        status_code=status.HTTP_409_CONFLICT,
+        details={"project_id": project_id},
+    )
+
+
 def import_project(
     session: Session,
     *,
@@ -64,36 +74,42 @@ def import_project(
     resolved_source = Path(source_path).expanduser().resolve()
     _validate_import_path(resolved_source)
     metadata = extract_audio_metadata(resolved_source)
+    source_sha256 = file_sha256(resolved_source)
+    if source_sha256 is None:
+        raise AppError(
+            "SOURCE_HASH_UNAVAILABLE",
+            "Could not compute a source hash for this file.",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
 
-    project_id = new_id("proj")
-    ensure_project_dirs(project_id)
+    project_id = source_hash_to_project_id(source_sha256)
+    existing_project = session.get(Project, project_id)
+    if existing_project is None:
+        existing_project = session.scalar(select(Project).where(Project.source_sha256 == source_sha256))
+    if existing_project is not None:
+        raise _duplicate_project_source_error(existing_project.id)
+
     destination_name = resolved_source.name
     source_dir = project_source_dir(project_id)
     imported_path = source_dir / destination_name
     artifact_format = resolved_source.suffix.lower().lstrip(".")
     artifact_metadata = {"source_path": str(resolved_source)}
+    needs_normalization = artifact_format in NORMALIZED_IMPORT_FORMATS
 
-    if artifact_format in NORMALIZED_IMPORT_FORMATS:
-        working_source = resolved_source
+    if needs_normalization:
         if copy_into_project:
             original_copy_path = source_dir / destination_name
-            shutil.copy2(resolved_source, original_copy_path)
-            working_source = original_copy_path
             artifact_metadata["original_copy_path"] = str(original_copy_path)
         imported_path = source_dir / f"{resolved_source.stem}.wav"
-        normalize_media_to_wav(working_source, imported_path)
         artifact_format = "wav"
         artifact_metadata["original_format"] = resolved_source.suffix.lower().lstrip(".")
-    else:
-        if copy_into_project:
-            shutil.copy2(resolved_source, imported_path)
-        else:
-            imported_path = resolved_source
+    elif not copy_into_project:
+        imported_path = resolved_source
 
     project = Project(
         id=project_id,
         display_name=display_name or resolved_source.stem,
-        source_sha256=file_sha256(resolved_source),
+        source_sha256=source_sha256,
         source_path=str(resolved_source),
         imported_path=str(imported_path),
         duration_seconds=metadata["duration_seconds"],
@@ -101,7 +117,22 @@ def import_project(
         channels=metadata["channels"],
     )
     session.add(project)
-    session.flush()
+    try:
+        session.flush()
+    except IntegrityError as exc:
+        session.rollback()
+        raise _duplicate_project_source_error(project_id) from exc
+
+    ensure_project_dirs(project_id)
+    if needs_normalization:
+        working_source = resolved_source
+        if copy_into_project:
+            original_copy_path = source_dir / destination_name
+            shutil.copy2(resolved_source, original_copy_path)
+            working_source = original_copy_path
+        normalize_media_to_wav(working_source, imported_path)
+    elif copy_into_project:
+        shutil.copy2(resolved_source, imported_path)
 
     register_artifact(
         session,

--- a/apps/backend/app/services/sync_identity.py
+++ b/apps/backend/app/services/sync_identity.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models import Artifact, Project
+from app.utils.hashing import file_sha256
+
+PROJECT_ID_PREFIX = "proj_sha256_"
+PROJECT_STORAGE_KEY_PREFIX = "proj_"
+PROJECT_STORAGE_HASH_LENGTH = 24
+NORMALIZED_IMPORT_SOURCE_FORMATS = {"mp4", "webm"}
+HEX_DIGITS = frozenset("0123456789abcdef")
+
+SyncPreflightProjectStatus = Literal[
+    "ready",
+    "missing_source_hash",
+    "invalid_source_hash",
+    "duplicate_source_hash",
+    "noncanonical_project_id",
+]
+SyncPreflightSourceHashSource = Literal[
+    "database",
+    "source_path",
+    "original_copy_path",
+    "source_artifact_path",
+    "imported_path",
+]
+
+
+@dataclass(frozen=True)
+class SyncPreflightProject:
+    project_id: str
+    display_name: str
+    status: SyncPreflightProjectStatus
+    source_sha256: str | None
+    expected_project_id: str | None
+    expected_storage_key: str | None
+    source_hash_source: SyncPreflightSourceHashSource | None
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class SyncPreflightDuplicateProject:
+    project_id: str
+    display_name: str
+
+
+@dataclass(frozen=True)
+class SyncPreflightDuplicateGroup:
+    source_sha256: str
+    expected_project_id: str
+    projects: list[SyncPreflightDuplicateProject]
+
+
+@dataclass(frozen=True)
+class SyncPreflightResult:
+    ok: bool
+    total_projects: int
+    ready_projects: int
+    missing_source_hash_projects: int
+    invalid_source_hash_projects: int
+    duplicate_source_hash_projects: int
+    noncanonical_project_id_projects: int
+    projects: list[SyncPreflightProject]
+    duplicate_groups: list[SyncPreflightDuplicateGroup]
+    manual_cleanup_required: bool
+    manual_cleanup_guidance: list[str]
+
+
+def source_hash_to_project_id(source_sha256: str) -> str:
+    normalized = source_sha256.strip().lower()
+    if len(normalized) != 64 or any(character not in HEX_DIGITS for character in normalized):
+        raise ValueError("source_sha256 must be a full SHA-256 hex digest.")
+    return f"{PROJECT_ID_PREFIX}{normalized}"
+
+
+def source_hash_to_project_storage_key(source_sha256: str) -> str:
+    normalized = source_sha256.strip().lower()
+    source_hash_to_project_id(normalized)
+    return f"{PROJECT_STORAGE_KEY_PREFIX}{normalized[:PROJECT_STORAGE_HASH_LENGTH]}"
+
+
+def project_id_to_storage_key(project_id: str) -> str:
+    if not project_id.startswith(PROJECT_ID_PREFIX):
+        return project_id
+    source_sha256 = project_id.removeprefix(PROJECT_ID_PREFIX)
+    try:
+        return source_hash_to_project_storage_key(source_sha256)
+    except ValueError:
+        return project_id
+
+
+def run_sync_preflight(session: Session) -> SyncPreflightResult:
+    projects = list(session.scalars(select(Project).order_by(Project.created_at.asc(), Project.id.asc())))
+    source_artifacts = _source_artifacts_by_project(session)
+    preflight_projects = [
+        _project_preflight(project, source_artifacts.get(project.id))
+        for project in projects
+    ]
+    duplicate_hashes = {
+        source_sha256
+        for source_sha256, count in Counter(
+            project.source_sha256
+            for project in preflight_projects
+            if project.status in {"ready", "noncanonical_project_id"} and project.source_sha256 is not None
+        ).items()
+        if count > 1
+    }
+
+    final_projects = [
+        _with_duplicate_status(project) if project.source_sha256 in duplicate_hashes else project
+        for project in preflight_projects
+    ]
+    duplicate_groups = _duplicate_groups(final_projects, duplicate_hashes)
+    missing_count = sum(1 for project in final_projects if project.status == "missing_source_hash")
+    invalid_count = sum(1 for project in final_projects if project.status == "invalid_source_hash")
+    duplicate_count = sum(1 for project in final_projects if project.status == "duplicate_source_hash")
+    noncanonical_count = sum(1 for project in final_projects if project.status == "noncanonical_project_id")
+    ready_count = sum(1 for project in final_projects if project.status == "ready")
+    ok = missing_count == 0 and invalid_count == 0 and duplicate_count == 0 and noncanonical_count == 0
+
+    return SyncPreflightResult(
+        ok=ok,
+        total_projects=len(final_projects),
+        ready_projects=ready_count,
+        missing_source_hash_projects=missing_count,
+        invalid_source_hash_projects=invalid_count,
+        duplicate_source_hash_projects=duplicate_count,
+        noncanonical_project_id_projects=noncanonical_count,
+        projects=final_projects,
+        duplicate_groups=duplicate_groups,
+        manual_cleanup_required=not ok,
+        manual_cleanup_guidance=_manual_cleanup_guidance(
+            missing_count=missing_count,
+            invalid_count=invalid_count,
+            duplicate_count=duplicate_count,
+            noncanonical_count=noncanonical_count,
+        ),
+    )
+
+
+def _source_artifacts_by_project(session: Session) -> dict[str, Artifact]:
+    stmt = (
+        select(Artifact)
+        .where(Artifact.type == "source_audio")
+        .order_by(Artifact.project_id.asc(), Artifact.created_at.asc(), Artifact.id.asc())
+    )
+    artifacts: dict[str, Artifact] = {}
+    for artifact in session.scalars(stmt):
+        artifacts.setdefault(artifact.project_id, artifact)
+    return artifacts
+
+
+def _project_preflight(project: Project, source_artifact: Artifact | None) -> SyncPreflightProject:
+    if project.source_sha256:
+        try:
+            normalized_hash = _normalize_source_hash(project.source_sha256)
+        except ValueError:
+            return SyncPreflightProject(
+                project_id=project.id,
+                display_name=project.display_name,
+                status="invalid_source_hash",
+                source_sha256=project.source_sha256,
+                expected_project_id=None,
+                expected_storage_key=None,
+                source_hash_source="database",
+                reason="Stored source_sha256 is not a full SHA-256 hex digest.",
+            )
+        return _project_preflight_with_hash(project, normalized_hash, "database")
+
+    resolved = _resolve_missing_source_hash(project, source_artifact)
+    if resolved is None:
+        return SyncPreflightProject(
+            project_id=project.id,
+            display_name=project.display_name,
+            status="missing_source_hash",
+            source_sha256=None,
+            expected_project_id=None,
+            expected_storage_key=None,
+            source_hash_source=None,
+            reason="No readable canonical source file is available for this project.",
+        )
+    source_sha256, source = resolved
+    return _project_preflight_with_hash(project, source_sha256, source)
+
+
+def _project_preflight_with_hash(
+    project: Project,
+    source_sha256: str,
+    source_hash_source: SyncPreflightSourceHashSource,
+) -> SyncPreflightProject:
+    expected_project_id = source_hash_to_project_id(source_sha256)
+    expected_storage_key = source_hash_to_project_storage_key(source_sha256)
+    if project.id != expected_project_id:
+        return SyncPreflightProject(
+            project_id=project.id,
+            display_name=project.display_name,
+            status="noncanonical_project_id",
+            source_sha256=source_sha256,
+            expected_project_id=expected_project_id,
+            expected_storage_key=expected_storage_key,
+            source_hash_source=source_hash_source,
+            reason="Project ID is not derived from the source SHA-256.",
+        )
+    return SyncPreflightProject(
+        project_id=project.id,
+        display_name=project.display_name,
+        status="ready",
+        source_sha256=source_sha256,
+        expected_project_id=expected_project_id,
+        expected_storage_key=expected_storage_key,
+        source_hash_source=source_hash_source,
+    )
+
+
+def _normalize_source_hash(source_sha256: str) -> str:
+    normalized = source_sha256.strip().lower()
+    source_hash_to_project_id(normalized)
+    return normalized
+
+
+def _resolve_missing_source_hash(
+    project: Project,
+    source_artifact: Artifact | None,
+) -> tuple[str, SyncPreflightSourceHashSource] | None:
+    original_copy_path = _original_copy_path(source_artifact)
+    original_copy_hash = _path_hash(original_copy_path)
+    if original_copy_hash is not None:
+        return original_copy_hash, "original_copy_path"
+
+    if not _uses_normalized_source_proxy(project, source_artifact):
+        artifact_hash = _path_hash(source_artifact.path if source_artifact is not None else None)
+        if artifact_hash is not None:
+            return artifact_hash, "source_artifact_path"
+
+        imported_path_hash = _path_hash(project.imported_path)
+        if imported_path_hash is not None:
+            return imported_path_hash, "imported_path"
+
+    source_path_hash = _path_hash(project.source_path)
+    if source_path_hash is not None:
+        return source_path_hash, "source_path"
+
+    return None
+
+
+def _path_hash(raw_path: str | None) -> str | None:
+    if not raw_path:
+        return None
+    return file_sha256(Path(raw_path))
+
+
+def _original_copy_path(source_artifact: Artifact | None) -> str | None:
+    if source_artifact is None:
+        return None
+    value = source_artifact.metadata_json.get("original_copy_path")
+    return value if isinstance(value, str) else None
+
+
+def _uses_normalized_source_proxy(project: Project, source_artifact: Artifact | None) -> bool:
+    original_format = source_artifact.metadata_json.get("original_format") if source_artifact else None
+    if isinstance(original_format, str) and original_format.lower() in NORMALIZED_IMPORT_SOURCE_FORMATS:
+        return True
+    source_format = Path(project.source_path).suffix.lower().lstrip(".")
+    imported_format = Path(project.imported_path).suffix.lower().lstrip(".")
+    return source_format in NORMALIZED_IMPORT_SOURCE_FORMATS and imported_format == "wav"
+
+
+def _with_duplicate_status(project: SyncPreflightProject) -> SyncPreflightProject:
+    return SyncPreflightProject(
+        project_id=project.project_id,
+        display_name=project.display_name,
+        status="duplicate_source_hash",
+        source_sha256=project.source_sha256,
+        expected_project_id=project.expected_project_id,
+        expected_storage_key=project.expected_storage_key,
+        source_hash_source=project.source_hash_source,
+        reason="Another project has the same source SHA-256.",
+    )
+
+
+def _duplicate_groups(
+    projects: list[SyncPreflightProject],
+    duplicate_hashes: set[str],
+) -> list[SyncPreflightDuplicateGroup]:
+    grouped_projects: dict[str, list[SyncPreflightDuplicateProject]] = defaultdict(list)
+    for project in projects:
+        if project.source_sha256 in duplicate_hashes and project.source_sha256 is not None:
+            grouped_projects[project.source_sha256].append(
+                SyncPreflightDuplicateProject(project_id=project.project_id, display_name=project.display_name)
+            )
+
+    return [
+        SyncPreflightDuplicateGroup(
+            source_sha256=source_sha256,
+            expected_project_id=source_hash_to_project_id(source_sha256),
+            projects=grouped_projects[source_sha256],
+        )
+        for source_sha256 in sorted(grouped_projects)
+    ]
+
+
+def _manual_cleanup_guidance(
+    *,
+    missing_count: int,
+    invalid_count: int,
+    duplicate_count: int,
+    noncanonical_count: int,
+) -> list[str]:
+    guidance: list[str] = []
+    if missing_count:
+        guidance.append(
+            "Restore the original source file or re-import affected projects so TuneForge can compute source hashes."
+        )
+    if invalid_count:
+        guidance.append("Repair invalid project source hashes before enabling sync.")
+    if duplicate_count:
+        guidance.append(
+            "Delete duplicate same-source projects or keep one canonical project before enabling sync."
+        )
+    if noncanonical_count:
+        guidance.append("Re-import or migrate affected projects so project IDs use canonical source hashes.")
+    return guidance

--- a/apps/backend/tests/test_db_migrations.py
+++ b/apps/backend/tests/test_db_migrations.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
 
@@ -7,6 +8,7 @@ import pytest
 
 from app.config import ensure_data_dirs, get_settings
 from app.db import UnknownDatabaseRevisionError, reconfigure_engine, run_migrations
+from app.services.sync_identity import source_hash_to_project_id, source_hash_to_project_storage_key
 from app.utils.hashing import file_sha256
 
 
@@ -32,10 +34,21 @@ def test_run_migrations_reports_unknown_database_revision() -> None:
 def test_hash_storage_migration_backfills_existing_files(tmp_path: Path) -> None:
     settings = get_settings()
     ensure_data_dirs(settings)
-    source_path = tmp_path / "source.wav"
+    duplicate_source_path = tmp_path / "duplicate.wav"
     artifact_path = tmp_path / "artifact.wav"
+    old_project_root = settings.projects_root / "proj_legacy"
+    old_project_source_dir = old_project_root / "source"
+    old_project_source_dir.mkdir(parents=True)
+    source_path = old_project_source_dir / "source.wav"
+    imported_path = old_project_source_dir / "imported.wav"
     source_path.write_bytes(b"source")
+    imported_path.write_bytes(b"imported")
+    duplicate_source_path.write_bytes(b"duplicate")
     artifact_path.write_bytes(b"artifact")
+    expected_project_hash = file_sha256(source_path)
+    expected_project_id = source_hash_to_project_id(expected_project_hash)
+    expected_storage_key = source_hash_to_project_storage_key(expected_project_hash)
+    duplicate_hash = file_sha256(duplicate_source_path)
 
     with sqlite3.connect(settings.database_path) as connection:
         connection.execute("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)")
@@ -79,11 +92,57 @@ def test_hash_storage_migration_backfills_existing_files(tmp_path: Path) -> None
         )
         connection.execute(
             """
+            CREATE TABLE analysis_results (
+                project_id VARCHAR(32) PRIMARY KEY,
+                source_artifact_id VARCHAR(32),
+                estimated_key VARCHAR(64),
+                key_confidence FLOAT,
+                estimated_reference_hz FLOAT,
+                tuning_offset_cents FLOAT,
+                tempo_bpm FLOAT,
+                analysis_version VARCHAR(32) NOT NULL DEFAULT 'v3',
+                created_at DATETIME
+            )
+            """
+        )
+        connection.execute(
+            """
             INSERT INTO projects (
                 id, display_name, source_path, imported_path
             ) VALUES (?, ?, ?, ?)
             """,
-            ("proj_1", "Song", str(source_path), str(source_path)),
+            ("proj_legacy", "Song", str(source_path), str(imported_path)),
+        )
+        connection.execute(
+            """
+            INSERT INTO projects (
+                id, display_name, source_path, imported_path
+            ) VALUES (?, ?, ?, ?)
+            """,
+            ("proj_duplicate_1", "Duplicate Song 1", str(duplicate_source_path), str(duplicate_source_path)),
+        )
+        connection.execute(
+            """
+            INSERT INTO projects (
+                id, display_name, source_path, imported_path
+            ) VALUES (?, ?, ?, ?)
+            """,
+            ("proj_duplicate_2", "Duplicate Song 2", str(duplicate_source_path), str(duplicate_source_path)),
+        )
+        connection.execute(
+            """
+            INSERT INTO artifacts (
+                id, project_id, type, format, path, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "source_1",
+                "proj_legacy",
+                "source_audio",
+                "wav",
+                str(imported_path),
+                "{}",
+            ),
         )
         connection.execute(
             """
@@ -93,21 +152,38 @@ def test_hash_storage_migration_backfills_existing_files(tmp_path: Path) -> None
             """,
             (
                 "art_1",
-                "proj_1",
+                "proj_legacy",
                 "vocal_stem",
                 "wav",
                 str(artifact_path),
                 '{"source_artifact_id":"source_1"}',
             ),
         )
+        connection.execute(
+            """
+            INSERT INTO analysis_results (project_id, source_artifact_id)
+            VALUES (?, ?)
+            """,
+            ("proj_legacy", "source_1"),
+        )
 
     reconfigure_engine(settings)
     run_migrations(settings)
 
     with sqlite3.connect(settings.database_path) as connection:
-        project_hash = connection.execute(
-            "SELECT source_sha256 FROM projects WHERE id = 'proj_1'"
+        project_rows = connection.execute(
+            """
+            SELECT id, display_name, source_sha256, source_path, imported_path
+            FROM projects
+            ORDER BY display_name
+            """
+        ).fetchall()
+        analysis_project_id = connection.execute(
+            "SELECT project_id FROM analysis_results WHERE source_artifact_id = 'source_1'"
         ).fetchone()[0]
+        source_artifact = connection.execute(
+            "SELECT project_id, path, content_sha256 FROM artifacts WHERE id = 'source_1'"
+        ).fetchone()
         artifact_hash = connection.execute(
             "SELECT content_sha256 FROM artifacts WHERE id = 'art_1'"
         ).fetchone()[0]
@@ -115,8 +191,740 @@ def test_hash_storage_migration_backfills_existing_files(tmp_path: Path) -> None
             row[1]
             for row in connection.execute("PRAGMA index_list('artifacts')")
         }
+        project_columns = {
+            row[1]
+            for row in connection.execute("PRAGMA table_info('projects')")
+        }
 
-    assert project_hash == file_sha256(source_path)
+    assert project_rows == [
+        (
+            "proj_duplicate_1",
+            "Duplicate Song 1",
+            duplicate_hash,
+            str(duplicate_source_path),
+            str(duplicate_source_path),
+        ),
+        (
+            "proj_duplicate_2",
+            "Duplicate Song 2",
+            duplicate_hash,
+            str(duplicate_source_path),
+            str(duplicate_source_path),
+        ),
+        (
+            expected_project_id,
+            "Song",
+            expected_project_hash,
+            str(settings.projects_root / expected_storage_key / "source" / "source.wav"),
+            str(settings.projects_root / expected_storage_key / "source" / "imported.wav"),
+        ),
+    ]
+    assert analysis_project_id == expected_project_id
+    assert source_artifact == (
+        expected_project_id,
+        str(settings.projects_root / expected_storage_key / "source" / "imported.wav"),
+        file_sha256(settings.projects_root / expected_storage_key / "source" / "imported.wav"),
+    )
     assert artifact_hash == file_sha256(artifact_path)
     assert "ix_artifacts_content_sha256" in indexes
     assert "uq_artifacts_stem_per_source" in indexes
+    assert "sync_project_id" not in project_columns
+    assert not old_project_root.exists()
+    assert (settings.projects_root / expected_storage_key).exists()
+
+
+def test_sync_identity_migration_prefers_imported_copy_when_hash_missing(tmp_path: Path) -> None:
+    settings = get_settings()
+    ensure_data_dirs(settings)
+    external_source_path = tmp_path / "external.wav"
+    external_source_path.write_bytes(b"changed external bytes")
+    old_project_root = settings.projects_root / "proj_legacy"
+    old_imported_path = old_project_root / "source" / "imported.wav"
+    old_imported_path.parent.mkdir(parents=True)
+    old_imported_path.write_bytes(b"original imported bytes")
+    expected_project_hash = file_sha256(old_imported_path)
+    expected_project_id = source_hash_to_project_id(expected_project_hash)
+    expected_storage_key = source_hash_to_project_storage_key(expected_project_hash)
+    expected_imported_path = settings.projects_root / expected_storage_key / "source" / "imported.wav"
+
+    assert file_sha256(external_source_path) != expected_project_hash
+
+    with sqlite3.connect(settings.database_path) as connection:
+        connection.execute("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)")
+        connection.execute(
+            "INSERT INTO alembic_version (version_num) VALUES (?)",
+            ("0013_analysis_timing",),
+        )
+        connection.execute(
+            """
+            CREATE TABLE projects (
+                id VARCHAR(32) PRIMARY KEY,
+                display_name VARCHAR(255) NOT NULL,
+                source_key_override VARCHAR(32),
+                source_sha256 VARCHAR(64),
+                source_path VARCHAR(2048) NOT NULL,
+                imported_path VARCHAR(2048) NOT NULL,
+                duration_seconds FLOAT,
+                sample_rate INTEGER,
+                channels INTEGER,
+                created_at DATETIME,
+                updated_at DATETIME
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE artifacts (
+                id VARCHAR(32) PRIMARY KEY,
+                project_id VARCHAR(32) NOT NULL,
+                type VARCHAR(64) NOT NULL,
+                format VARCHAR(32) NOT NULL,
+                path VARCHAR(2048) NOT NULL,
+                content_sha256 VARCHAR(64),
+                size_bytes INTEGER NOT NULL DEFAULT 0,
+                generated_by VARCHAR(128) NOT NULL DEFAULT 'unknown',
+                can_delete BOOLEAN NOT NULL DEFAULT 1,
+                can_regenerate BOOLEAN NOT NULL DEFAULT 0,
+                metadata_json JSON NOT NULL DEFAULT '{}',
+                cache_key VARCHAR(128),
+                created_at DATETIME
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO projects (
+                id, display_name, source_sha256, source_path, imported_path
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                "proj_legacy",
+                "Song",
+                None,
+                str(external_source_path),
+                str(old_imported_path),
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO artifacts (
+                id, project_id, type, format, path, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            ("source_1", "proj_legacy", "source_audio", "wav", str(old_imported_path), "{}"),
+        )
+
+    reconfigure_engine(settings)
+    run_migrations(settings)
+
+    with sqlite3.connect(settings.database_path) as connection:
+        project = connection.execute(
+            """
+            SELECT id, source_sha256, source_path, imported_path
+            FROM projects
+            WHERE display_name = 'Song'
+            """
+        ).fetchone()
+        source_artifact = connection.execute(
+            "SELECT project_id, path FROM artifacts WHERE id = 'source_1'"
+        ).fetchone()
+
+    assert project == (
+        expected_project_id,
+        expected_project_hash,
+        str(external_source_path),
+        str(expected_imported_path),
+    )
+    assert source_artifact == (expected_project_id, str(expected_imported_path))
+
+
+def test_sync_identity_migration_recovers_already_moved_project_root(tmp_path: Path) -> None:
+    settings = get_settings()
+    ensure_data_dirs(settings)
+    source_path = tmp_path / "source.wav"
+    source_path.write_bytes(b"source")
+    expected_project_hash = file_sha256(source_path)
+    expected_project_id = source_hash_to_project_id(expected_project_hash)
+    expected_storage_key = source_hash_to_project_storage_key(expected_project_hash)
+
+    old_project_root = settings.projects_root / "proj_interrupted"
+    old_imported_path = old_project_root / "source" / "imported.wav"
+    recovered_project_root = settings.projects_root / expected_storage_key
+    recovered_imported_path = recovered_project_root / "source" / "imported.wav"
+    recovered_imported_path.parent.mkdir(parents=True)
+    recovered_imported_path.write_bytes(b"imported")
+
+    with sqlite3.connect(settings.database_path) as connection:
+        connection.execute("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)")
+        connection.execute(
+            "INSERT INTO alembic_version (version_num) VALUES (?)",
+            ("0013_analysis_timing",),
+        )
+        connection.execute(
+            """
+            CREATE TABLE projects (
+                id VARCHAR(32) PRIMARY KEY,
+                display_name VARCHAR(255) NOT NULL,
+                source_key_override VARCHAR(32),
+                source_sha256 VARCHAR(64),
+                source_path VARCHAR(2048) NOT NULL,
+                imported_path VARCHAR(2048) NOT NULL,
+                duration_seconds FLOAT,
+                sample_rate INTEGER,
+                channels INTEGER,
+                created_at DATETIME,
+                updated_at DATETIME
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE artifacts (
+                id VARCHAR(32) PRIMARY KEY,
+                project_id VARCHAR(32) NOT NULL,
+                type VARCHAR(64) NOT NULL,
+                format VARCHAR(32) NOT NULL,
+                path VARCHAR(2048) NOT NULL,
+                content_sha256 VARCHAR(64),
+                size_bytes INTEGER NOT NULL DEFAULT 0,
+                generated_by VARCHAR(128) NOT NULL DEFAULT 'unknown',
+                can_delete BOOLEAN NOT NULL DEFAULT 1,
+                can_regenerate BOOLEAN NOT NULL DEFAULT 0,
+                metadata_json JSON NOT NULL DEFAULT '{}',
+                cache_key VARCHAR(128),
+                created_at DATETIME
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO projects (
+                id, display_name, source_sha256, source_path, imported_path
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                "proj_interrupted",
+                "Interrupted",
+                expected_project_hash,
+                str(source_path),
+                str(old_imported_path),
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO artifacts (
+                id, project_id, type, format, path, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "source_interrupted",
+                "proj_interrupted",
+                "source_audio",
+                "wav",
+                str(old_imported_path),
+                "{}",
+            ),
+        )
+
+    reconfigure_engine(settings)
+    run_migrations(settings)
+
+    with sqlite3.connect(settings.database_path) as connection:
+        project = connection.execute(
+            "SELECT id, imported_path FROM projects WHERE display_name = 'Interrupted'"
+        ).fetchone()
+        artifact = connection.execute(
+            "SELECT project_id, path FROM artifacts WHERE id = 'source_interrupted'"
+        ).fetchone()
+
+    assert project == (expected_project_id, str(recovered_imported_path))
+    assert artifact == (expected_project_id, str(recovered_imported_path))
+    assert recovered_imported_path.exists()
+
+
+def test_sync_identity_migration_recovers_artifacts_already_referenced_by_new_project_id(tmp_path: Path) -> None:
+    settings = get_settings()
+    ensure_data_dirs(settings)
+    old_project_id = "proj_interrupted"
+    source_path = tmp_path / "source.wav"
+    source_path.write_bytes(b"source")
+    expected_project_hash = file_sha256(source_path)
+    expected_project_id = source_hash_to_project_id(expected_project_hash)
+    expected_storage_key = source_hash_to_project_storage_key(expected_project_hash)
+
+    old_project_root = settings.projects_root / old_project_id
+    old_source_path = old_project_root / "source" / "source.wav"
+    old_imported_path = old_project_root / "source" / "imported.wav"
+    old_stem_path = old_project_root / "stems" / "vocals.wav"
+    recovered_project_root = settings.projects_root / expected_storage_key
+    recovered_source_path = recovered_project_root / "source" / "source.wav"
+    recovered_imported_path = recovered_project_root / "source" / "imported.wav"
+    recovered_stem_path = recovered_project_root / "stems" / "vocals.wav"
+    recovered_source_path.parent.mkdir(parents=True)
+    recovered_source_path.write_bytes(source_path.read_bytes())
+    recovered_imported_path.write_bytes(b"imported")
+
+    with sqlite3.connect(settings.database_path) as connection:
+        connection.execute("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)")
+        connection.execute(
+            "INSERT INTO alembic_version (version_num) VALUES (?)",
+            ("0013_analysis_timing",),
+        )
+        connection.execute(
+            """
+            CREATE TABLE projects (
+                id VARCHAR(32) PRIMARY KEY,
+                display_name VARCHAR(255) NOT NULL,
+                source_key_override VARCHAR(32),
+                source_sha256 VARCHAR(64),
+                source_path VARCHAR(2048) NOT NULL,
+                imported_path VARCHAR(2048) NOT NULL,
+                duration_seconds FLOAT,
+                sample_rate INTEGER,
+                channels INTEGER,
+                created_at DATETIME,
+                updated_at DATETIME
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE artifacts (
+                id VARCHAR(32) PRIMARY KEY,
+                project_id VARCHAR(32) NOT NULL,
+                type VARCHAR(64) NOT NULL,
+                format VARCHAR(32) NOT NULL,
+                path VARCHAR(2048) NOT NULL,
+                content_sha256 VARCHAR(64),
+                size_bytes INTEGER NOT NULL DEFAULT 0,
+                generated_by VARCHAR(128) NOT NULL DEFAULT 'unknown',
+                can_delete BOOLEAN NOT NULL DEFAULT 1,
+                can_regenerate BOOLEAN NOT NULL DEFAULT 0,
+                metadata_json JSON NOT NULL DEFAULT '{}',
+                cache_key VARCHAR(128),
+                created_at DATETIME
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE analysis_results (
+                project_id VARCHAR(32) PRIMARY KEY,
+                source_artifact_id VARCHAR(32),
+                estimated_key VARCHAR(64),
+                key_confidence FLOAT,
+                estimated_reference_hz FLOAT,
+                tuning_offset_cents FLOAT,
+                tempo_bpm FLOAT,
+                analysis_version VARCHAR(32) NOT NULL DEFAULT 'v3',
+                created_at DATETIME
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO projects (
+                id, display_name, source_sha256, source_path, imported_path
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                old_project_id,
+                "Interrupted",
+                expected_project_hash,
+                str(recovered_source_path),
+                str(recovered_imported_path),
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO artifacts (
+                id, project_id, type, format, path, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "source_interrupted",
+                expected_project_id,
+                "source_audio",
+                "wav",
+                str(old_imported_path),
+                json.dumps({"original_copy_path": str(old_source_path)}),
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO artifacts (
+                id, project_id, type, format, path, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "stem_interrupted",
+                expected_project_id,
+                "vocal_stem",
+                "wav",
+                str(old_stem_path),
+                json.dumps(
+                    {
+                        "source_artifact_id": "source_interrupted",
+                        "source_path": str(old_imported_path),
+                        "copies": [str(old_stem_path)],
+                    }
+                ),
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO analysis_results (project_id, source_artifact_id)
+            VALUES (?, ?)
+            """,
+            (old_project_id, "source_interrupted"),
+        )
+
+    reconfigure_engine(settings)
+    run_migrations(settings)
+
+    with sqlite3.connect(settings.database_path) as connection:
+        project = connection.execute(
+            """
+            SELECT id, source_path, imported_path
+            FROM projects
+            WHERE display_name = 'Interrupted'
+            """
+        ).fetchone()
+        artifacts = {
+            row[0]: row[1:]
+            for row in connection.execute(
+                """
+                SELECT id, project_id, path, metadata_json
+                FROM artifacts
+                ORDER BY id
+                """
+            )
+        }
+        analysis_project_id = connection.execute(
+            "SELECT project_id FROM analysis_results WHERE source_artifact_id = 'source_interrupted'"
+        ).fetchone()[0]
+
+    assert project == (expected_project_id, str(recovered_source_path), str(recovered_imported_path))
+    assert artifacts["source_interrupted"] == (
+        expected_project_id,
+        str(recovered_imported_path),
+        json.dumps({"original_copy_path": str(recovered_source_path)}, separators=(",", ":")),
+    )
+    assert artifacts["stem_interrupted"] == (
+        expected_project_id,
+        str(recovered_stem_path),
+        json.dumps(
+            {
+                "source_artifact_id": "source_interrupted",
+                "source_path": str(recovered_imported_path),
+                "copies": [str(recovered_stem_path)],
+            },
+            separators=(",", ":"),
+        ),
+    )
+    assert analysis_project_id == expected_project_id
+
+
+def test_sync_identity_migration_recovers_canonical_project_with_legacy_paths() -> None:
+    settings = get_settings()
+    ensure_data_dirs(settings)
+    legacy_project_id = "proj_legacy_paths"
+    old_project_root = settings.projects_root / legacy_project_id
+    old_source_path = old_project_root / "source" / "source.wav"
+    old_imported_path = old_project_root / "source" / "imported.wav"
+    old_stem_path = old_project_root / "stems" / "vocals.wav"
+    old_analysis_path = old_project_root / "analysis" / "analysis.json"
+    old_source_path.parent.mkdir(parents=True)
+    old_stem_path.parent.mkdir(parents=True)
+    old_analysis_path.parent.mkdir(parents=True)
+    old_source_path.write_bytes(b"source")
+    old_imported_path.write_bytes(b"imported")
+    old_stem_path.write_bytes(b"stem")
+    old_analysis_path.write_text(json.dumps({"project_id": legacy_project_id, "tempo_bpm": 120}), encoding="utf-8")
+    expected_project_hash = file_sha256(old_source_path)
+    expected_project_id = source_hash_to_project_id(expected_project_hash)
+    expected_storage_key = source_hash_to_project_storage_key(expected_project_hash)
+    expected_project_root = settings.projects_root / expected_storage_key
+    expected_source_path = expected_project_root / "source" / "source.wav"
+    expected_imported_path = expected_project_root / "source" / "imported.wav"
+    expected_stem_path = expected_project_root / "stems" / "vocals.wav"
+    expected_analysis_path = expected_project_root / "analysis" / "analysis.json"
+
+    with sqlite3.connect(settings.database_path) as connection:
+        connection.execute("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)")
+        connection.execute(
+            "INSERT INTO alembic_version (version_num) VALUES (?)",
+            ("0013_analysis_timing",),
+        )
+        connection.execute(
+            """
+            CREATE TABLE projects (
+                id VARCHAR(80) PRIMARY KEY,
+                display_name VARCHAR(255) NOT NULL,
+                source_key_override VARCHAR(32),
+                source_sha256 VARCHAR(64),
+                source_path VARCHAR(2048) NOT NULL,
+                imported_path VARCHAR(2048) NOT NULL,
+                duration_seconds FLOAT,
+                sample_rate INTEGER,
+                channels INTEGER,
+                created_at DATETIME,
+                updated_at DATETIME
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE artifacts (
+                id VARCHAR(32) PRIMARY KEY,
+                project_id VARCHAR(80) NOT NULL,
+                type VARCHAR(64) NOT NULL,
+                format VARCHAR(32) NOT NULL,
+                path VARCHAR(2048) NOT NULL,
+                content_sha256 VARCHAR(64),
+                size_bytes INTEGER NOT NULL DEFAULT 0,
+                generated_by VARCHAR(128) NOT NULL DEFAULT 'unknown',
+                can_delete BOOLEAN NOT NULL DEFAULT 1,
+                can_regenerate BOOLEAN NOT NULL DEFAULT 0,
+                metadata_json JSON NOT NULL DEFAULT '{}',
+                cache_key VARCHAR(128),
+                created_at DATETIME
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO projects (
+                id, display_name, source_sha256, source_path, imported_path
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                expected_project_id,
+                "Canonical Interrupted",
+                expected_project_hash,
+                str(old_source_path),
+                str(old_imported_path),
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO artifacts (
+                id, project_id, type, format, path, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "source_canonical_interrupted",
+                expected_project_id,
+                "source_audio",
+                "wav",
+                str(old_imported_path),
+                json.dumps({"original_copy_path": str(old_source_path)}),
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO artifacts (
+                id, project_id, type, format, path, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "stem_canonical_interrupted",
+                expected_project_id,
+                "vocal_stem",
+                "wav",
+                str(old_stem_path),
+                json.dumps({"source_path": str(old_imported_path)}),
+            ),
+        )
+
+    reconfigure_engine(settings)
+    run_migrations(settings)
+
+    with sqlite3.connect(settings.database_path) as connection:
+        project = connection.execute(
+            """
+            SELECT id, source_path, imported_path
+            FROM projects
+            WHERE display_name = 'Canonical Interrupted'
+            """
+        ).fetchone()
+        artifacts = {
+            row[0]: row[1:]
+            for row in connection.execute(
+                """
+                SELECT id, project_id, path, metadata_json
+                FROM artifacts
+                ORDER BY id
+                """
+            )
+        }
+
+    assert project == (expected_project_id, str(expected_source_path), str(expected_imported_path))
+    assert artifacts["source_canonical_interrupted"] == (
+        expected_project_id,
+        str(expected_imported_path),
+        json.dumps({"original_copy_path": str(expected_source_path)}, separators=(",", ":")),
+    )
+    assert artifacts["stem_canonical_interrupted"] == (
+        expected_project_id,
+        str(expected_stem_path),
+        json.dumps({"source_path": str(expected_imported_path)}, separators=(",", ":")),
+    )
+    assert not old_project_root.exists()
+    assert expected_stem_path.exists()
+    snapshot = json.loads(expected_analysis_path.read_text(encoding="utf-8"))
+    assert snapshot == {"project_id": expected_project_id, "tempo_bpm": 120}
+
+
+def test_sync_identity_migration_recovers_already_rewritten_project_root_and_snapshots() -> None:
+    settings = get_settings()
+    ensure_data_dirs(settings)
+    old_project_id = "proj_interrupted"
+    recovered_project_root = settings.projects_root / "proj_placeholder"
+    recovered_source_path = recovered_project_root / "source" / "source.wav"
+    recovered_imported_path = recovered_project_root / "source" / "imported.wav"
+    recovered_source_path.parent.mkdir(parents=True)
+    recovered_source_path.write_bytes(b"source")
+    recovered_imported_path.write_bytes(b"imported")
+    expected_project_hash = file_sha256(recovered_source_path)
+    expected_project_id = source_hash_to_project_id(expected_project_hash)
+    expected_storage_key = source_hash_to_project_storage_key(expected_project_hash)
+    expected_project_root = settings.projects_root / expected_storage_key
+    recovered_project_root.rename(expected_project_root)
+    recovered_source_path = expected_project_root / "source" / "source.wav"
+    recovered_imported_path = expected_project_root / "source" / "imported.wav"
+    analysis_dir = expected_project_root / "analysis"
+    analysis_dir.mkdir()
+    snapshot_payloads = {
+        "analysis.json": {"project_id": old_project_id, "kind": "analysis", "nested": {"project_id": old_project_id}},
+        "chords.json": {"project_id": old_project_id, "timeline": [{"project_id": old_project_id, "chord": "C"}]},
+        "lyrics.json": {"project_id": old_project_id, "segments": [{"text": "hello"}]},
+    }
+    for filename, payload in snapshot_payloads.items():
+        (analysis_dir / filename).write_text(json.dumps(payload), encoding="utf-8")
+
+    with sqlite3.connect(settings.database_path) as connection:
+        connection.execute("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)")
+        connection.execute(
+            "INSERT INTO alembic_version (version_num) VALUES (?)",
+            ("0013_analysis_timing",),
+        )
+        connection.execute(
+            """
+            CREATE TABLE projects (
+                id VARCHAR(32) PRIMARY KEY,
+                display_name VARCHAR(255) NOT NULL,
+                source_key_override VARCHAR(32),
+                source_sha256 VARCHAR(64),
+                source_path VARCHAR(2048) NOT NULL,
+                imported_path VARCHAR(2048) NOT NULL,
+                duration_seconds FLOAT,
+                sample_rate INTEGER,
+                channels INTEGER,
+                created_at DATETIME,
+                updated_at DATETIME
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE artifacts (
+                id VARCHAR(32) PRIMARY KEY,
+                project_id VARCHAR(32) NOT NULL,
+                type VARCHAR(64) NOT NULL,
+                format VARCHAR(32) NOT NULL,
+                path VARCHAR(2048) NOT NULL,
+                content_sha256 VARCHAR(64),
+                size_bytes INTEGER NOT NULL DEFAULT 0,
+                generated_by VARCHAR(128) NOT NULL DEFAULT 'unknown',
+                can_delete BOOLEAN NOT NULL DEFAULT 1,
+                can_regenerate BOOLEAN NOT NULL DEFAULT 0,
+                metadata_json JSON NOT NULL DEFAULT '{}',
+                cache_key VARCHAR(128),
+                created_at DATETIME
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE analysis_results (
+                project_id VARCHAR(32) PRIMARY KEY,
+                source_artifact_id VARCHAR(32),
+                estimated_key VARCHAR(64),
+                key_confidence FLOAT,
+                estimated_reference_hz FLOAT,
+                tuning_offset_cents FLOAT,
+                tempo_bpm FLOAT,
+                analysis_version VARCHAR(32) NOT NULL DEFAULT 'v3',
+                created_at DATETIME
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO projects (
+                id, display_name, source_sha256, source_path, imported_path
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                old_project_id,
+                "Interrupted",
+                expected_project_hash,
+                str(recovered_source_path),
+                str(recovered_imported_path),
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO artifacts (
+                id, project_id, type, format, path, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "source_interrupted",
+                old_project_id,
+                "source_audio",
+                "wav",
+                str(recovered_imported_path),
+                json.dumps({"original_copy_path": str(recovered_source_path)}),
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO analysis_results (project_id, source_artifact_id)
+            VALUES (?, ?)
+            """,
+            (old_project_id, "source_interrupted"),
+        )
+
+    reconfigure_engine(settings)
+    run_migrations(settings)
+
+    with sqlite3.connect(settings.database_path) as connection:
+        project = connection.execute(
+            """
+            SELECT id, source_path, imported_path
+            FROM projects
+            WHERE display_name = 'Interrupted'
+            """
+        ).fetchone()
+        artifact = connection.execute(
+            "SELECT project_id, path, metadata_json FROM artifacts WHERE id = 'source_interrupted'"
+        ).fetchone()
+        analysis_project_id = connection.execute(
+            "SELECT project_id FROM analysis_results WHERE source_artifact_id = 'source_interrupted'"
+        ).fetchone()[0]
+
+    assert project == (expected_project_id, str(recovered_source_path), str(recovered_imported_path))
+    assert artifact == (
+        expected_project_id,
+        str(recovered_imported_path),
+        json.dumps({"original_copy_path": str(recovered_source_path)}),
+    )
+    assert analysis_project_id == expected_project_id
+    for filename, payload in snapshot_payloads.items():
+        snapshot = json.loads((analysis_dir / filename).read_text(encoding="utf-8"))
+        assert snapshot["project_id"] == expected_project_id
+        assert {key: value for key, value in snapshot.items() if key != "project_id"} == {
+            key: value for key, value in payload.items() if key != "project_id"
+        }

--- a/apps/backend/tests/test_projects.py
+++ b/apps/backend/tests/test_projects.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from app.config import get_settings
 from app.db import SessionLocal
+from app.errors import AppError
 from app.models import Artifact, Project
+from app.services.paths import project_root
+from app.services.projects import import_project
+from app.services.sync_identity import source_hash_to_project_id, source_hash_to_project_storage_key
 from app.utils.hashing import file_sha256
 from tests.conftest import wait_for_job
 
@@ -24,10 +29,16 @@ def test_import_project_persists_metadata_and_source_artifact(client, sample_aud
     assert project["sample_rate"] == 44100
     assert project["channels"] == 1
 
+    expected_hash = file_sha256(sample_audio_file)
+    assert expected_hash is not None
+    assert project["id"] == source_hash_to_project_id(expected_hash)
+
     data_root = get_settings().data_root
     imported_path = Path(project["imported_path"])
     assert imported_path.exists()
-    assert str(imported_path).startswith(str(data_root / "projects"))
+    assert str(imported_path).startswith(
+        str(data_root / "projects" / source_hash_to_project_storage_key(expected_hash))
+    )
 
     artifacts = client.get(f"/api/v1/projects/{project['id']}/artifacts").json()["artifacts"]
     source_artifact = next(artifact for artifact in artifacts if artifact["type"] == "source_audio")
@@ -43,8 +54,58 @@ def test_import_project_persists_metadata_and_source_artifact(client, sample_aud
         artifact_row = session.get(Artifact, source_artifact["id"])
         assert project_row is not None
         assert artifact_row is not None
-        assert project_row.source_sha256 == file_sha256(sample_audio_file)
+        assert project_row.source_sha256 == expected_hash
         assert artifact_row.content_sha256 == file_sha256(imported_path)
+
+
+def test_import_project_rejects_duplicate_source_hash(client, sample_audio_file: Path):
+    first = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_audio_file), "copy_into_project": True},
+    ).json()["project"]
+
+    response = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_audio_file), "copy_into_project": True},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["error"] == {
+        "code": "DUPLICATE_PROJECT_SOURCE",
+        "message": "This source track is already imported.",
+        "details": {"project_id": first["id"]},
+    }
+    for job in client.get("/api/v1/jobs").json()["jobs"]:
+        if job["project_id"] == first["id"]:
+            assert wait_for_job(client, job["id"])["status"] == "completed"
+
+
+def test_import_project_translates_duplicate_project_id_race(
+    monkeypatch: pytest.MonkeyPatch,
+    sample_audio_file: Path,
+) -> None:
+    source_hash = file_sha256(sample_audio_file)
+    assert source_hash is not None
+    project_id = source_hash_to_project_id(source_hash)
+
+    with SessionLocal() as session:
+        def raise_duplicate_project_id(*args, **kwargs):
+            raise IntegrityError("INSERT INTO projects", {}, Exception("duplicate project id"))
+
+        monkeypatch.setattr(session, "flush", raise_duplicate_project_id)
+
+        with pytest.raises(AppError) as exc:
+            import_project(
+                session,
+                source_path=str(sample_audio_file),
+                copy_into_project=True,
+                display_name=None,
+            )
+
+    assert exc.value.code == "DUPLICATE_PROJECT_SOURCE"
+    assert exc.value.status_code == 409
+    assert exc.value.details == {"project_id": project_id}
+    assert not project_root(project_id).exists()
 
 
 def test_import_project_enqueues_analysis_and_chords(client, sample_chord_audio_file: Path):
@@ -111,10 +172,11 @@ def test_project_source_key_override_can_be_updated_and_cleared(client, sample_a
     assert cleared_response.json()["project"]["source_key_override"] is None
 
 
-def test_project_list_can_filter_by_search_term(client, sample_audio_file: Path, tmp_path: Path):
-    second_source = tmp_path / "bass-riff.wav"
-    second_source.write_bytes(sample_audio_file.read_bytes())
-
+def test_project_list_can_filter_by_search_term(
+    client,
+    sample_audio_file: Path,
+    sample_stereo_audio_file: Path,
+):
     client.post(
         "/api/v1/projects/import",
         json={
@@ -126,7 +188,7 @@ def test_project_list_can_filter_by_search_term(client, sample_audio_file: Path,
     client.post(
         "/api/v1/projects/import",
         json={
-            "source_path": str(second_source),
+            "source_path": str(sample_stereo_audio_file),
             "copy_into_project": True,
             "display_name": "Bass Drill",
         },

--- a/apps/backend/tests/test_sync_identity.py
+++ b/apps/backend/tests/test_sync_identity.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.db import SessionLocal
+from app.models import Artifact, Project
+from app.services.sync_identity import (
+    project_id_to_storage_key,
+    source_hash_to_project_id,
+    source_hash_to_project_storage_key,
+)
+from app.utils.hashing import file_sha256
+
+
+def test_source_hash_to_project_id_normalizes_full_sha256() -> None:
+    source_hash = "A" * 64
+
+    assert source_hash_to_project_id(source_hash) == f"proj_sha256_{source_hash.lower()}"
+    assert source_hash_to_project_storage_key(source_hash) == f"proj_{source_hash.lower()[:24]}"
+
+
+@pytest.mark.parametrize("source_hash", ["", "abc", "g" * 64, "a" * 63, "a" * 65])
+def test_source_hash_to_project_id_rejects_invalid_hashes(source_hash: str) -> None:
+    with pytest.raises(ValueError, match="full SHA-256"):
+        source_hash_to_project_id(source_hash)
+
+
+def test_project_id_to_storage_key_maps_canonical_ids_and_preserves_legacy_ids() -> None:
+    source_hash = "b" * 64
+
+    assert project_id_to_storage_key(f"proj_sha256_{source_hash}") == f"proj_{source_hash[:24]}"
+    assert project_id_to_storage_key("proj_legacy") == "proj_legacy"
+
+
+def test_sync_preflight_reports_ready_projects(client, sample_audio_file: Path) -> None:
+    expected_hash = file_sha256(sample_audio_file)
+    assert expected_hash is not None
+    project_id = source_hash_to_project_id(expected_hash)
+    with SessionLocal() as session:
+        session.add(
+            Project(
+                id=project_id,
+                display_name="fixture",
+                source_sha256=expected_hash,
+                source_path=str(sample_audio_file),
+                imported_path=str(sample_audio_file),
+            )
+        )
+        session.commit()
+
+    response = client.get("/api/v1/sync/preflight")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["total_projects"] == 1
+    assert payload["ready_projects"] == 1
+    assert payload["missing_source_hash_projects"] == 0
+    assert payload["invalid_source_hash_projects"] == 0
+    assert payload["duplicate_source_hash_projects"] == 0
+    assert payload["noncanonical_project_id_projects"] == 0
+    assert payload["manual_cleanup_required"] is False
+    assert payload["projects"] == [
+        {
+            "project_id": project_id,
+            "display_name": "fixture",
+            "status": "ready",
+            "source_sha256": expected_hash,
+            "expected_project_id": source_hash_to_project_id(expected_hash),
+            "expected_storage_key": source_hash_to_project_storage_key(expected_hash),
+            "source_hash_source": "database",
+            "reason": None,
+        }
+    ]
+
+
+def test_sync_preflight_resolves_missing_hash_from_source_path(client, sample_audio_file: Path) -> None:
+    expected_hash = file_sha256(sample_audio_file)
+    assert expected_hash is not None
+    with SessionLocal() as session:
+        project = Project(
+            id=source_hash_to_project_id(expected_hash),
+            display_name="Readable",
+            source_sha256=None,
+            source_path=str(sample_audio_file),
+            imported_path=str(sample_audio_file.parent / "missing-imported.wav"),
+        )
+        session.add(project)
+        session.commit()
+
+    response = client.get("/api/v1/sync/preflight")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["projects"][0]["status"] == "ready"
+    assert payload["projects"][0]["source_sha256"] == expected_hash
+    assert payload["projects"][0]["expected_project_id"] == source_hash_to_project_id(expected_hash)
+    assert payload["projects"][0]["source_hash_source"] == "source_path"
+
+
+def test_sync_preflight_prefers_imported_copy_over_changed_source_path(client, tmp_path: Path) -> None:
+    external_source = tmp_path / "external.wav"
+    imported_copy = tmp_path / "project-source.wav"
+    external_source.write_bytes(b"changed external bytes")
+    imported_copy.write_bytes(b"original imported bytes")
+    expected_hash = file_sha256(imported_copy)
+    assert expected_hash is not None
+    assert file_sha256(external_source) != expected_hash
+
+    with SessionLocal() as session:
+        project = Project(
+            id=source_hash_to_project_id(expected_hash),
+            display_name="Copied",
+            source_sha256=None,
+            source_path=str(external_source),
+            imported_path=str(imported_copy),
+        )
+        session.add(project)
+        session.add(
+            Artifact(
+                id="art_copied",
+                project_id=project.id,
+                type="source_audio",
+                format="wav",
+                path=str(imported_copy),
+                metadata_json={"source_path": str(external_source)},
+            )
+        )
+        session.commit()
+
+    response = client.get("/api/v1/sync/preflight")
+
+    assert response.status_code == 200
+    project = response.json()["projects"][0]
+    assert project["status"] == "ready"
+    assert project["source_sha256"] == expected_hash
+    assert project["source_hash_source"] == "source_artifact_path"
+
+
+def test_sync_preflight_reports_missing_source_hash(client, tmp_path: Path) -> None:
+    missing_path = tmp_path / "missing.wav"
+    with SessionLocal() as session:
+        project = Project(
+            id="proj_missing",
+            display_name="Missing",
+            source_sha256=None,
+            source_path=str(missing_path),
+            imported_path=str(missing_path),
+        )
+        session.add(project)
+        session.commit()
+
+    response = client.get("/api/v1/sync/preflight")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is False
+    assert payload["missing_source_hash_projects"] == 1
+    assert payload["manual_cleanup_required"] is True
+    assert payload["manual_cleanup_guidance"] == [
+        "Restore the original source file or re-import affected projects so TuneForge can compute source hashes."
+    ]
+    assert payload["projects"][0]["status"] == "missing_source_hash"
+    assert payload["projects"][0]["expected_project_id"] is None
+
+
+def test_sync_preflight_reports_invalid_source_hash(client, sample_audio_file: Path) -> None:
+    with SessionLocal() as session:
+        project = Project(
+            id="proj_invalid",
+            display_name="Invalid",
+            source_sha256="not-a-hash",
+            source_path=str(sample_audio_file),
+            imported_path=str(sample_audio_file),
+        )
+        session.add(project)
+        session.commit()
+
+    response = client.get("/api/v1/sync/preflight")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is False
+    assert payload["invalid_source_hash_projects"] == 1
+    assert payload["projects"][0]["status"] == "invalid_source_hash"
+    assert payload["projects"][0]["source_hash_source"] == "database"
+
+
+def test_sync_preflight_reports_duplicate_source_hashes(client, sample_audio_file: Path) -> None:
+    source_hash = file_sha256(sample_audio_file)
+    assert source_hash is not None
+    with SessionLocal() as session:
+        session.add_all(
+            [
+                Project(
+                    id="proj_dup_1",
+                    display_name="First",
+                    source_sha256=source_hash,
+                    source_path=str(sample_audio_file),
+                    imported_path=str(sample_audio_file),
+                ),
+                Project(
+                    id="proj_dup_2",
+                    display_name="Second",
+                    source_sha256=source_hash,
+                    source_path=str(sample_audio_file),
+                    imported_path=str(sample_audio_file),
+                ),
+            ]
+        )
+        session.commit()
+
+    response = client.get("/api/v1/sync/preflight")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is False
+    assert payload["duplicate_source_hash_projects"] == 2
+    assert [project["status"] for project in payload["projects"]] == [
+        "duplicate_source_hash",
+        "duplicate_source_hash",
+    ]
+    assert payload["duplicate_groups"] == [
+        {
+            "source_sha256": source_hash,
+            "expected_project_id": source_hash_to_project_id(source_hash),
+            "projects": [
+                {"project_id": "proj_dup_1", "display_name": "First"},
+                {"project_id": "proj_dup_2", "display_name": "Second"},
+            ],
+        }
+    ]
+    assert payload["manual_cleanup_guidance"] == [
+        "Delete duplicate same-source projects or keep one canonical project before enabling sync."
+    ]
+
+
+def test_sync_preflight_reports_noncanonical_project_id(client, sample_audio_file: Path) -> None:
+    source_hash = file_sha256(sample_audio_file)
+    assert source_hash is not None
+    with SessionLocal() as session:
+        session.add(
+            Project(
+                id="proj_legacy",
+                display_name="Legacy",
+                source_sha256=source_hash,
+                source_path=str(sample_audio_file),
+                imported_path=str(sample_audio_file),
+            )
+        )
+        session.commit()
+
+    response = client.get("/api/v1/sync/preflight")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is False
+    assert payload["noncanonical_project_id_projects"] == 1
+    assert payload["projects"][0]["status"] == "noncanonical_project_id"
+    assert payload["projects"][0]["expected_project_id"] == source_hash_to_project_id(source_hash)
+    assert payload["manual_cleanup_guidance"] == [
+        "Re-import or migrate affected projects so project IDs use canonical source hashes."
+    ]
+
+
+def test_sync_preflight_uses_original_copy_before_normalized_proxy(client, sample_audio_file: Path) -> None:
+    expected_hash = file_sha256(sample_audio_file)
+    assert expected_hash is not None
+    original_copy = sample_audio_file
+    normalized_proxy = sample_audio_file.parent / "proxy.wav"
+    normalized_proxy.write_bytes(b"normalized proxy bytes")
+    with SessionLocal() as session:
+        project = Project(
+            id=source_hash_to_project_id(expected_hash),
+            display_name="Normalized",
+            source_sha256=None,
+            source_path=str(sample_audio_file.parent / "missing.webm"),
+            imported_path=str(normalized_proxy),
+        )
+        session.add(project)
+        session.add(
+            Artifact(
+                id="art_normalized",
+                project_id=project.id,
+                type="source_audio",
+                format="wav",
+                path=str(normalized_proxy),
+                metadata_json={
+                    "original_format": "webm",
+                    "original_copy_path": str(original_copy),
+                },
+            )
+        )
+        session.commit()
+
+    response = client.get("/api/v1/sync/preflight")
+
+    assert response.status_code == 200
+    project = response.json()["projects"][0]
+    assert project["status"] == "ready"
+    assert project["source_sha256"] == expected_hash
+    assert project["source_hash_source"] == "original_copy_path"

--- a/docs/API.md
+++ b/docs/API.md
@@ -91,6 +91,24 @@ Returns available chord backends and capability metadata. Built-in chords are al
 
 Returns supported stem models and availability metadata. Labels are `Default (6 stems model)` for `htdemucs_6s` and `2 stems model` for `htdemucs_ft`.
 
+## Sync
+
+### Run sync preflight
+
+`GET /api/v1/sync/preflight`
+
+Checks the local library before multi-device sync is enabled. The endpoint returns HTTP `200` for both passing and failing preflight results because failures are actionable diagnostics rather than request errors.
+
+The response includes:
+
+- `ok`
+- project status counts
+- per-project sync identity status
+- duplicate source-hash groups
+- manual cleanup guidance
+
+Project status values are `ready`, `missing_source_hash`, `invalid_source_hash`, `duplicate_source_hash`, and `noncanonical_project_id`. Canonical project IDs use `proj_sha256_<full_source_sha256>`, while project storage directories use a shorter derived key such as `proj_<first_24_sha256_hex>`. This endpoint is sync-specific; general project responses do not expose source hashes.
+
 ## Projects
 
 ### Import project

--- a/docs/MULTI_DEVICE_LIBRARY_SYNC_SPIKE.md
+++ b/docs/MULTI_DEVICE_LIBRARY_SYNC_SPIKE.md
@@ -60,7 +60,7 @@ Remote processing should not be part of v1 sync. If it is revisited later, it sh
 
 With backend parity assumed, the syncable library should include durable project data:
 
-- Project records: local project ID, sync project ID, display name, source key override, duration, sample rate, channels, timestamps, source hash, and project revision metadata.
+- Project records: canonical project ID, display name, source key override, duration, sample rate, channels, timestamps, source hash, and project revision metadata.
 - Source files: original imported source plus any normalized working source required by the receiving runtime.
 - Artifacts: source audio, stems, saved practice mixes, previews, exports, analysis JSON snapshots, and future timing artifacts.
 - Analysis: key, tuning, tempo, timing grids, source artifact link, analysis version, and timestamps.
@@ -82,20 +82,20 @@ In-progress jobs should not be synced as runnable jobs. A receiving device can d
 
 ## Identity, Existing Projects, And Migration
 
-The UI does not treat project IDs as user-facing library identity. That is useful for sync because the local project ID can remain an internal storage/API detail even though it may appear in routes, APIs, paths, or diagnostics. Existing libraries already contain projects with random IDs, so v1 sync needs a deliberate migration or compatibility plan before sync is enabled.
+The UI does not treat project IDs as user-facing library identity, but project IDs do appear in routes, APIs, paths, diagnostics, foreign keys, and manifests. Keeping a second project identity would make the sync model harder to reason about. V1 sync therefore makes the database/API `project_id` the canonical sync identity.
 
-The safest v1 direction is to introduce a canonical sync identity derived from the source track SHA-256 while keeping local database project IDs as internal IDs:
+Canonical project identity is derived from the source track SHA-256:
 
-- `project_id`: local database/API ID used by the current backend and project directory layout. Existing projects may keep their random IDs.
-- `sync_project_id`: deterministic sync identity derived from the full SHA-256 of the canonical imported source bytes, for example `proj_sha256_<full_hex_or_base32_sha256>`.
+- `project_id`: deterministic database/API identity derived from the full SHA-256 of the canonical imported source bytes, for example `proj_sha256_<full_sha256_hex>`.
+- `project_storage_key`: short storage directory key derived from the same hash, for example `proj_<first_24_sha256_hex>`.
 - `source_sha256`: full SHA-256 of the canonical imported source bytes.
-- `artifact_id`: stable artifact record identity. It can be deterministic where practical from sync project ID, artifact type, source artifact relation, generation parameters, and content hash, but replacement/regeneration semantics should be explicit.
+- `artifact_id`: stable artifact record identity. It can be deterministic where practical from project ID, artifact type, source artifact relation, generation parameters, and content hash, but replacement/regeneration semantics should be explicit.
 - `content_sha256`: full SHA-256 of the artifact bytes for verification and dedupe.
 - `entity_revision`: durable revision metadata for editable or regenerable entities such as project metadata, chords, lyrics, and sections.
 
-This keeps the sync contract deterministic without requiring an immediate risky rewrite of every local project directory and database foreign key. New sync-enabled imports may choose to set local `project_id` equal to `sync_project_id`, but the sync layer should not require that. The important rule is that sync manifests use `sync_project_id`, not a random local `project_id`.
+The full source hash remains in the database/API identity for collision detection and verification. The shorter storage key is only an implementation detail for local project folders and compact relative paths.
 
-A future storage cleanup migration could re-key local project IDs and project root directories to match the sync identity. Since project IDs are not exposed in the UI, that would not be a user-facing rename. It is still an internal data migration and should not be required for the first sync spike.
+Existing libraries may contain random project IDs. The migration is best-effort: TuneForge attempts to compute source hashes, re-key safe projects to canonical IDs, rewrite project foreign keys, and move project folders to the derived storage key. If the original source is missing, duplicate source hashes exist, or a path conflict makes re-keying unsafe, the project can remain on a legacy ID and sync preflight will require cleanup or re-import before sync is enabled.
 
 Expected migration flow before enabling sync:
 
@@ -103,15 +103,14 @@ Expected migration flow before enabling sync:
 2. Ensure every project has `source_sha256`; compute it from the canonical imported source bytes if missing.
 3. Detect duplicate `source_sha256` values in the local library.
 4. If duplicates exist, fail migration and require manual cleanup before enabling sync. The user can delete a duplicate project and import it again later if needed.
-5. Assign `sync_project_id = proj_sha256_<full_source_sha256>` for every migrated project.
-6. Add a uniqueness constraint or equivalent guard for `source_sha256` / `sync_project_id` in sync-enabled libraries.
-7. Keep a mapping from `sync_project_id` to local `project_id` for backend import/export, API calls, and path rewriting.
-8. Only enable sync after the migration has completed without unresolved duplicates.
+5. Re-key each safe project to `project_id = proj_sha256_<full_source_sha256>` and move its folder to `proj_<first_24_source_sha256_hex>`.
+6. Add a uniqueness constraint or equivalent guard for `source_sha256` in sync-enabled libraries.
+7. Only enable sync after the migration has completed without unresolved missing hashes, duplicates, or legacy project IDs.
 
 Import behavior should be strict:
 
 - If the local library already has the same `source_sha256`, import should fail hard with a message such as: `You already have project "<project name>" imported.`
-- If the sync group manifest already knows the same `sync_project_id`, import should fail or redirect to the existing synced project rather than creating a duplicate.
+- If the sync group manifest already knows the same canonical project ID, import should fail or redirect to the existing synced project rather than creating a duplicate.
 - V1 should not support intentional same-source duplicate projects or variants. If the user wants to reset a project, they can delete it from the library and import it again.
 - The project ID must be based on the original source bytes, not a platform-specific normalized WAV proxy, otherwise macOS, Linux, and mobile could derive different sync IDs for the same import.
 - Hash prefixes must not be the only stored identity. Prefixes are acceptable for display, logs, or compact filenames only if the implementation retains the full hash for collision detection and verification.
@@ -120,8 +119,15 @@ Tradeoffs:
 
 - Byte-identical source imports naturally converge to the same sync project.
 - The same song encoded in different containers or bitrates will not dedupe unless a future audio fingerprinting layer is added.
-- Existing random project IDs can remain as local compatibility details while sync identity is deterministic.
+- Existing random project IDs are allowed only as migration leftovers that must be cleaned up before sync is enabled.
 - The no-duplicates rule keeps v1 simple, but it rules out multiple independent arrangements from the exact same source until a future explicit variant model exists.
+
+Implementation decision for the first sync milestone:
+
+- Desktop backend imports now use canonical `project_id = proj_sha256_<full_source_sha256>`.
+- Project directories use the shorter derived storage key instead of the full project ID.
+- `GET /api/v1/sync/preflight` checks existing libraries for missing hashes, invalid hashes, duplicate source hashes, and noncanonical project IDs before sync is enabled.
+- Duplicate import rejection is enforced for backend imports because the canonical project ID makes same-source duplicates a primary-key conflict.
 
 ## Storage And Portability
 
@@ -132,8 +138,8 @@ The portable unit should be a sync group manifest plus project manifests and con
 - `sync_group_manifest`: sync group ID, schema version, known devices, known projects, group-level feature flags, delete tombstone summary, and high-water marks.
 - `device_manifest`: device ID, display name, platform, public identity, protocol versions, advertised capabilities, last-seen metadata, and trust state.
 - `library_manifest`: local device ID, schema version, known sync projects, available artifacts, group delete tombstones, and high-water marks.
-- `project_manifest`: sync project ID, local display/project metadata, analysis/chords/lyrics/sections records, artifact list, revision records, and dependency links.
-- `artifact_manifest`: artifact ID, sync project ID, type, format, relative project path, byte size, SHA-256, generated-by metadata, can-delete/can-regenerate flags, metadata, cache key when meaningful, source artifact relation, and replacement/supersession state.
+- `project_manifest`: canonical project ID, local display/project metadata, analysis/chords/lyrics/sections records, artifact list, revision records, and dependency links.
+- `artifact_manifest`: artifact ID, canonical project ID, type, format, relative project path, byte size, SHA-256, generated-by metadata, can-delete/can-regenerate flags, metadata, cache key when meaningful, source artifact relation, and replacement/supersession state.
 - `peer_inventory`: per-device advertisement of which content hashes and artifact bytes are currently available, transferring, or missing.
 - `entity_revision`: durable entity type, entity ID, revision ID, base revision ID, author device ID, logical counter or monotonic sequence, updated timestamp, generation metadata when relevant, and content hash.
 - `delete_tombstone`: durable record for group-level deletion of a project, artifact, or entity revision.
@@ -252,7 +258,7 @@ Benefits:
 
 - Best fit for project/artifact semantics.
 - Can exclude preferences and local app state by construction.
-- Can model generated artifacts, user edits, conflict branches, deterministic sync project IDs, and group delete tombstones explicitly.
+- Can model generated artifacts, user edits, conflict branches, canonical project IDs, and group delete tombstones explicitly.
 - Works across Linux, macOS, mobile, and future platforms without syncing raw database files.
 - Allows transport choices to change without changing the library contract.
 
@@ -406,7 +412,7 @@ The first real implementation milestone should be library sync between two deskt
 
 Recommended spike sequence:
 
-1. Existing-library migration preflight: compute missing source hashes, detect duplicate source hashes, assign `sync_project_id`, and fail hard if manual cleanup is required.
+1. Existing-library migration preflight: compute missing source hashes, detect duplicate source hashes, re-key safe projects to canonical IDs, and fail hard if manual cleanup is required.
 2. Manifest-only desktop project export/import with path rewriting and hash verification.
 3. Strict duplicate import behavior based on source SHA-256.
 4. Content-addressed artifact staging and idempotent import.
@@ -572,9 +578,9 @@ Notifications:
 
 For the eventual implementation spike, validate in this order:
 
-1. Existing-library migration tests for projects with random IDs, missing source hashes, duplicate source hashes, and successful `sync_project_id` assignment.
+1. Existing-library migration tests for projects with random IDs, missing source hashes, duplicate source hashes, and successful canonical project ID assignment.
 2. Manifest tests for desktop project export/import, path rewriting, hashes, and dedupe.
-3. Deterministic sync project ID tests from full source SHA-256.
+3. Deterministic canonical project ID tests from full source SHA-256.
 4. Duplicate import tests proving same-source imports fail hard and point to the existing project.
 5. Staged import tests proving that synced data is imported through backend services rather than raw database writes.
 6. Entity revision tests for chords, lyrics, sections, project renames, base revision tracking, rebuild events, and conflict branches.
@@ -607,8 +613,6 @@ For the eventual implementation spike, validate in this order:
 ## Open Questions
 
 - Should v1 sync job history at all, or only current durable outputs and metadata?
-- Should `sync_project_id` remain a separate canonical sync field permanently, or should local `project_id` eventually be migrated to match it?
-- What exact `sync_project_id` encoding should be used for source-hash-derived IDs?
 - How long should delete tombstones be retained?
 - Should TuneForge support undo for group deletes, and if so, how does that interact with offline peers?
 - Should source imports always copy into the project for syncable projects?

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -434,6 +434,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/sync/preflight": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Sync Preflight */
+        get: operations["sync_preflight_api_v1_sync_preflight_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1031,6 +1048,69 @@ export interface components {
              * @default false
              */
             overwrite_chord_edits: boolean;
+        };
+        /** SyncPreflightDuplicateGroupSchema */
+        SyncPreflightDuplicateGroupSchema: {
+            /** Source Sha256 */
+            source_sha256: string;
+            /** Expected Project Id */
+            expected_project_id: string;
+            /** Projects */
+            projects: components["schemas"]["SyncPreflightDuplicateProjectSchema"][];
+        };
+        /** SyncPreflightDuplicateProjectSchema */
+        SyncPreflightDuplicateProjectSchema: {
+            /** Project Id */
+            project_id: string;
+            /** Display Name */
+            display_name: string;
+        };
+        /** SyncPreflightProjectSchema */
+        SyncPreflightProjectSchema: {
+            /** Project Id */
+            project_id: string;
+            /** Display Name */
+            display_name: string;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "ready" | "missing_source_hash" | "invalid_source_hash" | "duplicate_source_hash" | "noncanonical_project_id";
+            /** Source Sha256 */
+            source_sha256: string | null;
+            /** Expected Project Id */
+            expected_project_id: string | null;
+            /** Expected Storage Key */
+            expected_storage_key: string | null;
+            /** Source Hash Source */
+            source_hash_source: ("database" | "source_path" | "original_copy_path" | "source_artifact_path" | "imported_path") | null;
+            /** Reason */
+            reason?: string | null;
+        };
+        /** SyncPreflightResponse */
+        SyncPreflightResponse: {
+            /** Ok */
+            ok: boolean;
+            /** Total Projects */
+            total_projects: number;
+            /** Ready Projects */
+            ready_projects: number;
+            /** Missing Source Hash Projects */
+            missing_source_hash_projects: number;
+            /** Invalid Source Hash Projects */
+            invalid_source_hash_projects: number;
+            /** Duplicate Source Hash Projects */
+            duplicate_source_hash_projects: number;
+            /** Noncanonical Project Id Projects */
+            noncanonical_project_id_projects: number;
+            /** Projects */
+            projects: components["schemas"]["SyncPreflightProjectSchema"][];
+            /** Duplicate Groups */
+            duplicate_groups: components["schemas"]["SyncPreflightDuplicateGroupSchema"][];
+            /** Manual Cleanup Required */
+            manual_cleanup_required: boolean;
+            /** Manual Cleanup Guidance */
+            manual_cleanup_guidance: string[];
         };
         /** TabImportApplyRequest */
         TabImportApplyRequest: {
@@ -2107,6 +2187,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    sync_preflight_api_v1_sync_preflight_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncPreflightResponse"];
                 };
             };
         };


### PR DESCRIPTION
## Summary

- Add deterministic sync project IDs backed by source SHA-256.
- Add a sync preflight endpoint for missing, invalid, and duplicate source-hash diagnostics.
- Document the first sync milestone decision and regenerate shared API types.

Closes #110.

## Testing

- `uv run --python 3.11 pytest tests/test_sync_identity.py tests/test_projects.py tests/test_db_migrations.py`
- `uv run --python 3.11 ruff check .`
- `uv run --python 3.11 mypy app`
- `pnpm contracts:generate`
- `pnpm --filter @tuneforge/desktop typecheck`
- Reviewer: `uv run --python 3.11 pytest` passed with 108 tests.
- Contract guard: targeted backend tests and desktop typecheck passed.
