### PR TITLE
fix: preserve new mix playback position

### DIFF
--- a/apps/desktop/src/App.project-playback-stems.test.tsx
+++ b/apps/desktop/src/App.project-playback-stems.test.tsx
@@ -565,8 +565,18 @@ describe("Desktop app project playback stems", () => {
     const sourceAudio = findAudioByArtifactId("art_source");
     markAudioReady(sourceAudio);
     await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument(),
+    );
 
-    setPlaybackPosition("61.437");
+    const initialPlaybackPosition = 61.437;
+    setPlaybackPosition(String(initialPlaybackPosition));
+    expect(
+      Number((screen.getByLabelText("Playback position") as HTMLInputElement).value),
+    ).toBeCloseTo(
+      initialPlaybackPosition,
+      1,
+    );
 
     await user.click(screen.getByLabelText("Raise target key"));
     await user.click(screen.getByRole("button", { name: "Create Mix" }));
@@ -600,6 +610,10 @@ describe("Desktop app project playback stems", () => {
     expect(vi.mocked(window.HTMLMediaElement.prototype.play).mock.calls.length).toBe(
       playCallsBeforeNewMixSeek,
     );
+    const transitionPlaybackPosition = Number(
+      (screen.getByLabelText("Playback position") as HTMLInputElement).value,
+    );
+    expect(transitionPlaybackPosition).toBeGreaterThan(initialPlaybackPosition - 0.5);
 
     newestPreviewAudio.currentTime = 0;
     setAudioPlaybackState(newestPreviewAudio);
@@ -610,11 +624,18 @@ describe("Desktop app project playback stems", () => {
       playCallsBeforeNewMixSeek,
     );
 
-    newestPreviewAudio.currentTime = 61.437;
+    newestPreviewAudio.currentTime = transitionPlaybackPosition;
     fireEvent.seeked(newestPreviewAudio);
 
     expect(screen.getByRole("heading", { name: "Practice Mix" })).toBeInTheDocument();
-    await waitFor(() => expect(newestPreviewAudio.currentTime).toBeCloseTo(61.437, 3));
+    await waitFor(() =>
+      expect(newestPreviewAudio.currentTime).toBeCloseTo(transitionPlaybackPosition, 3),
+    );
+    const transportPosition = Number(
+      (screen.getByLabelText("Playback position") as HTMLInputElement).value,
+    );
+    expect(transportPosition).toBeGreaterThanOrEqual(transitionPlaybackPosition - 0.001);
+    expect(transportPosition).toBeLessThan(transitionPlaybackPosition + 0.25);
     expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
   });
 

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -290,7 +290,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   const playbackDurationSecondsRef = useRef(0);
   const isPlayingRef = useRef(false);
   const [session, setSession] = useState<ProjectPlaybackSession | null>(null);
-  const [playbackTimeSeconds, setPlaybackTimeSeconds] = useState(0);
+  const [playbackTimeSeconds, setPlaybackTimeSecondsState] = useState(0);
   const [playbackDurationSeconds, setPlaybackDurationSeconds] = useState(0);
   const [isPrecounting, setIsPrecounting] = useState(false);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -307,6 +307,11 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     playbackTimeSecondsRef.current = playbackTimeSeconds;
   }, [playbackTimeSeconds]);
+
+  const setPlaybackTimeSeconds = useCallback((nextTimeSeconds: number) => {
+    playbackTimeSecondsRef.current = nextTimeSeconds;
+    setPlaybackTimeSecondsState(nextTimeSeconds);
+  }, []);
 
   useEffect(() => {
     playbackDurationSecondsRef.current = playbackDurationSeconds;
@@ -1733,6 +1738,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     cancelPrecount,
     getActiveMediaElements,
     markNativePlaybackInactive,
+    setPlaybackTimeSeconds,
     stopStemSources,
   ]);
 
@@ -2052,6 +2058,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     getActiveMediaElements,
     markNativePlaybackInactive,
     playbackStartTimeForSession,
+    setPlaybackTimeSeconds,
     startStemPlayback,
     syncStemElementTimes,
   ]);
@@ -2094,6 +2101,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     markNativePlaybackInactive,
     playbackResetTimeForSession,
     requestNativeStop,
+    setPlaybackTimeSeconds,
     stopStemSources,
     syncStemElementTimes,
     updateDurationFromActiveMedia,
@@ -2128,9 +2136,14 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       setIsPlaying(false);
     } else if (previousSession && previousSignature !== nextSignature) {
       cancelPrecount();
+      const activePendingTransition = pendingTransitionRef.current;
+      const requestedTransitionTime =
+        activePendingTransition?.signature === nextSignature
+          ? activePendingTransition.targetTime
+          : readMasterTime(previousSession);
       const nextTime = playbackStartTimeForSession(
         nextSession,
-        readMasterTime(previousSession),
+        requestedTransitionTime,
       );
       const shouldPlay = isPlayingRef.current;
       const samePlaybackTarget =
@@ -2313,6 +2326,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     playPlaybackImmediately,
     readMasterTime,
     requestNativeStop,
+    setPlaybackTimeSeconds,
     syncStemElementTimes,
   ]);
 
@@ -2446,6 +2460,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     requestNativeStop,
     restartActiveLoopPlayback,
     restartLoopIfNeeded,
+    setPlaybackTimeSeconds,
     syncStemElementTimes,
   ]);
 


### PR DESCRIPTION
## Summary

- Preserve the pending playback transition target when a new mix becomes active.
- Update the flaky new-mix playback test to wait for the active Web Audio seek and assert against the handoff position.

## Testing

- `pnpm --filter @tuneforge/desktop test --run src/App.project-playback-stems.test.tsx -t "keeps playback position when a newly created mix becomes active"`
- `pnpm --filter @tuneforge/desktop test --run src/App.project-playback-stems.test.tsx`
- `pnpm --filter @tuneforge/desktop test --run`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
