### PR TITLE
perf: Defer input device discovery

### DIFF
--- a/apps/desktop/src-tauri/src/native_audio/capture.rs
+++ b/apps/desktop/src-tauri/src/native_audio/capture.rs
@@ -265,11 +265,19 @@ fn calculate_input_level(samples: &[f32]) -> f32 {
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
+struct DesktopInputDeviceDescriptor {
+    exposed_id: String,
+    stable_hash: u64,
+    label: String,
+    cpal_id: Option<cpal::DeviceId>,
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn list_desktop_input_devices() -> Result<Vec<AudioInputDevice>, String> {
     let host = cpal::default_host();
-    let default_name = host
+    let default_device_id = host
         .default_input_device()
-        .and_then(|device| device.name().ok());
+        .and_then(|device| device.id().ok());
     let devices = host
         .input_devices()
         .map_err(|error| format!("Could not list native input devices: {error}"))?;
@@ -278,16 +286,15 @@ fn list_desktop_input_devices() -> Result<Vec<AudioInputDevice>, String> {
     Ok(devices
         .enumerate()
         .map(|(index, device)| {
-            let label = device
-                .name()
-                .unwrap_or_else(|_| format!("Input Device {}", index + 1));
-            let is_default = !marked_default && default_name.as_deref() == Some(label.as_str());
+            let descriptor = describe_desktop_input_device(index, &device);
+            let is_default =
+                !marked_default && descriptor.cpal_id.as_ref() == default_device_id.as_ref();
             if is_default {
                 marked_default = true;
             }
             AudioInputDevice {
-                id: native_input_device_id(index, &label),
-                label,
+                id: descriptor.exposed_id,
+                label: descriptor.label,
                 is_default,
             }
         })
@@ -522,15 +529,12 @@ fn select_input_device(
     let mut hash_match: Option<(cpal::Device, String)> = None;
 
     for (index, device) in devices.enumerate() {
-        let label = device
-            .name()
-            .unwrap_or_else(|_| format!("Input Device {}", index + 1));
-        let candidate_id = native_input_device_id(index, &label);
-        if candidate_id == requested_device_id {
-            return Ok((device, candidate_id));
+        let descriptor = describe_desktop_input_device(index, &device);
+        if descriptor.exposed_id == requested_device_id {
+            return Ok((device, descriptor.exposed_id));
         }
-        if requested_hash == Some(stable_name_hash(&label)) && hash_match.is_none() {
-            hash_match = Some((device, candidate_id));
+        if requested_hash == Some(descriptor.stable_hash) && hash_match.is_none() {
+            hash_match = Some((device, descriptor.exposed_id));
         }
     }
 
@@ -695,8 +699,63 @@ fn convert_u64_sample(sample: u64) -> f32 {
         as f32
 }
 
+#[cfg(test)]
 fn native_input_device_id(index: usize, label: &str) -> String {
-    format!("cpal:{index}:{:016x}", stable_name_hash(label))
+    native_input_device_id_from_hash(index, stable_name_hash(label))
+}
+
+fn native_input_device_id_from_hash(index: usize, hash: u64) -> String {
+    format!("cpal:{index}:{hash:016x}")
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn describe_desktop_input_device(
+    index: usize,
+    device: &cpal::Device,
+) -> DesktopInputDeviceDescriptor {
+    let label = device
+        .description()
+        .map(|description| description.name().trim().to_string())
+        .ok()
+        .filter(|label| !label.is_empty())
+        .unwrap_or_else(|| format!("Input Device {}", index + 1));
+
+    let cpal_id = device.id().ok();
+    let stable_hash = stable_name_hash(native_input_device_hash_source(&label, cpal_id.as_ref()));
+
+    DesktopInputDeviceDescriptor {
+        exposed_id: native_input_device_id_from_hash(index, stable_hash),
+        stable_hash,
+        label,
+        cpal_id,
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn native_input_device_hash_source<'a>(
+    label: &'a str,
+    cpal_id: Option<&'a cpal::DeviceId>,
+) -> &'a str {
+    native_input_device_hash_source_for_platform(
+        label,
+        cpal_id.map(|device_id| device_id.1.as_str()),
+        cfg!(target_os = "linux"),
+    )
+}
+
+fn native_input_device_hash_source_for_platform<'a>(
+    label: &'a str,
+    backend_device_id: Option<&'a str>,
+    prefer_backend_device_id: bool,
+) -> &'a str {
+    if prefer_backend_device_id {
+        if let Some(backend_device_id) =
+            backend_device_id.filter(|device_id| !device_id.trim().is_empty())
+        {
+            return backend_device_id;
+        }
+    }
+    label
 }
 
 fn native_input_device_hash(device_id: &str) -> Option<u64> {
@@ -845,6 +904,44 @@ mod tests {
             native_input_device_hash(&reordered)
         );
         assert_ne!(original, reordered);
+    }
+
+    #[test]
+    fn native_device_hash_source_can_preserve_linux_backend_ids() {
+        let display_label = "USB Audio Interface";
+        let legacy_backend_id = "alsa_input.usb-interface";
+        let hash_source = native_input_device_hash_source_for_platform(
+            display_label,
+            Some(legacy_backend_id),
+            true,
+        );
+
+        assert_eq!(hash_source, legacy_backend_id);
+        assert_eq!(
+            native_input_device_hash(&native_input_device_id_from_hash(
+                0,
+                stable_name_hash(hash_source),
+            )),
+            native_input_device_hash(&native_input_device_id(0, legacy_backend_id)),
+        );
+        assert_ne!(
+            stable_name_hash(display_label),
+            stable_name_hash(hash_source)
+        );
+    }
+
+    #[test]
+    fn native_device_hash_source_keeps_display_label_when_backend_id_is_not_preferred() {
+        let display_label = "USB Audio Interface";
+
+        assert_eq!(
+            native_input_device_hash_source_for_platform(
+                display_label,
+                Some("coreaudio-device-uid"),
+                false,
+            ),
+            display_label,
+        );
     }
 
     #[test]

--- a/apps/desktop/src/App.tools-tuner.test.tsx
+++ b/apps/desktop/src/App.tools-tuner.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -35,6 +35,7 @@ describe("Desktop app tools tuner", () => {
     expect(screen.getByTestId("wide-arc-tuner-meter")).toBeInTheDocument();
     expect(screen.getByRole("meter", { name: "Tuning offset" })).toBeInTheDocument();
     expect(screen.getByRole("meter", { name: "Input signal level" })).toBeInTheDocument();
+    expect(getMockInvoke()).not.toHaveBeenCalledWith("audio_list_input_devices");
     expect(getMockMediaDevices().getUserMedia).not.toHaveBeenCalled();
   });
 
@@ -69,7 +70,7 @@ describe("Desktop app tools tuner", () => {
     renderApp(["/tools"]);
 
     expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
-    expect(await screen.findByRole("option", { name: "USB Interface" })).toBeInTheDocument();
+    await refreshMicrophoneOptions("USB Interface");
     await user.selectOptions(screen.getByLabelText("Microphone source"), "cpal:1:usb");
     changeReferenceInput("442.5");
     await user.selectOptions(screen.getByLabelText("Tuner visual mode"), "simple");
@@ -80,7 +81,7 @@ describe("Desktop app tools tuner", () => {
     expect(screen.getByLabelText("Microphone source")).toHaveValue("cpal:1:usb");
     expect(screen.getByLabelText("A4 reference tuning")).toHaveValue(442.5);
     expect(screen.getByLabelText("Default tuner")).toHaveValue("simple");
-    expect(screen.getByText("Saved microphone")).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "USB Interface" })).toBeInTheDocument();
     expect(screen.getByText("442.5 Hz")).toBeInTheDocument();
 
     await user.selectOptions(screen.getByLabelText("Microphone source"), "");
@@ -152,6 +153,7 @@ describe("Desktop app tools tuner", () => {
     renderApp(["/tools"]);
 
     expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    await refreshMicrophoneOptions("Built-in Microphone");
     await user.selectOptions(screen.getByLabelText("Microphone source"), "cpal:0:built-in");
 
     const selectedInputVolume = await screen.findByLabelText("Selected input volume");
@@ -211,9 +213,7 @@ describe("Desktop app tools tuner", () => {
     renderApp(["/tools"]);
 
     expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
-    await waitFor(() =>
-      expect(screen.getByRole("option", { name: "USB Interface" })).toBeDisabled(),
-    );
+    expect(screen.queryByRole("option", { name: "USB Interface" })).not.toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Start" }));
 
     await waitFor(() => expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument());
@@ -251,7 +251,7 @@ describe("Desktop app tools tuner", () => {
     renderApp(["/tools"]);
 
     expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
-    expect(await screen.findByRole("option", { name: "USB Interface" })).toBeInTheDocument();
+    await refreshMicrophoneOptions("USB Interface");
     await user.selectOptions(screen.getByLabelText("Microphone source"), "cpal:1:usb");
     await user.click(screen.getByRole("button", { name: "Start" }));
 
@@ -265,12 +265,14 @@ describe("Desktop app tools tuner", () => {
     );
     expect(getMockMediaDevices().getUserMedia).not.toHaveBeenCalled();
 
-    emitMockNativeInputFrame({
-      deviceId: "cpal:1:usb",
-      sampleRate: 48000,
-      inputLevel: 0.25,
-      samples: makeSineSamples(440, 48000, 2048),
-      timestampMs: 1000,
+    act(() => {
+      emitMockNativeInputFrame({
+        deviceId: "cpal:1:usb",
+        sampleRate: 48000,
+        inputLevel: 0.25,
+        samples: makeSineSamples(440, 48000, 2048),
+        timestampMs: 1000,
+      });
     });
 
     await waitFor(() =>
@@ -289,7 +291,7 @@ describe("Desktop app tools tuner", () => {
     expect(getMockInvoke()).toHaveBeenCalledWith("audio_stop_input");
   });
 
-  it("does not poll native microphone devices while the tuner is idle", async () => {
+  it("does not query native microphone devices while the tuner is idle until the picker is opened", async () => {
     const setIntervalSpy = vi.spyOn(window, "setInterval");
     setMockNativeAudioState({
       capabilities: {
@@ -305,11 +307,80 @@ describe("Desktop app tools tuner", () => {
 
     renderApp(["/tools"]);
 
-    expect(await screen.findByRole("option", { name: "USB Interface" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "USB Interface" })).not.toBeInTheDocument();
+    expect(
+      getMockInvoke().mock.calls.filter(([command]) => command === "audio_list_input_devices"),
+    ).toHaveLength(0);
+
+    await refreshMicrophoneOptions("USB Interface");
+
     expect(
       getMockInvoke().mock.calls.filter(([command]) => command === "audio_list_input_devices"),
     ).toHaveLength(1);
     expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 5000);
+  });
+
+  it("runs a follow-up refresh when devices change during active native discovery", async () => {
+    setMockNativeAudioState({
+      capabilities: {
+        micCaptureSupported: true,
+        backend: "desktop-cpal",
+      },
+    });
+    const mockInvoke = getMockInvoke();
+    const originalInvoke = mockInvoke.getMockImplementation();
+    if (!originalInvoke) {
+      throw new Error("Missing invoke mock implementation.");
+    }
+    type NativeInputDevicesResponse = {
+      supported: boolean;
+      devices: Array<{ id: string; label: string; isDefault: boolean }>;
+      error: string | null;
+    };
+    let resolveFirstInputDevices: (value: NativeInputDevicesResponse) => void = () => undefined;
+    const firstInputDevices = new Promise<NativeInputDevicesResponse>((resolve) => {
+      resolveFirstInputDevices = resolve;
+    });
+    let inputDeviceCalls = 0;
+    mockInvoke.mockImplementation(async (command, args) => {
+      if (command === "audio_list_input_devices") {
+        inputDeviceCalls += 1;
+        if (inputDeviceCalls === 1) {
+          return firstInputDevices;
+        }
+        return {
+          supported: true,
+          devices: [{ id: "cpal:2:new", label: "New Interface", isDefault: false }],
+          error: null,
+        };
+      }
+      return originalInvoke(command, args);
+    });
+
+    try {
+      renderApp(["/tools"]);
+
+      expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+      fireEvent.focus(screen.getByLabelText("Microphone source"));
+      await waitFor(() => expect(inputDeviceCalls).toBe(1));
+
+      emitMockMediaDeviceChange();
+      await act(async () => {
+        resolveFirstInputDevices({
+          supported: true,
+          devices: [{ id: "cpal:1:old", label: "Old Interface", isDefault: false }],
+          error: null,
+        });
+        await firstInputDevices;
+      });
+
+      expect(await screen.findByRole("option", { name: "New Interface" })).toBeInTheDocument();
+      expect(screen.queryByRole("option", { name: "Old Interface" })).not.toBeInTheDocument();
+      expect(inputDeviceCalls).toBe(2);
+    } finally {
+      mockInvoke.mockImplementation(originalInvoke);
+    }
   });
 
   it("can force Web Audio capture when native capture is available", async () => {
@@ -330,9 +401,6 @@ describe("Desktop app tools tuner", () => {
     renderApp(["/tools"]);
 
     expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
-    await waitFor(() =>
-      expect(screen.getByRole("option", { name: "USB Interface" })).toBeDisabled(),
-    );
     expect(screen.queryByRole("option", { name: "Native USB Interface" })).not.toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Start" }));
 
@@ -412,7 +480,7 @@ describe("Desktop app tools tuner", () => {
     renderApp(["/tools"]);
 
     expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
-    expect(await screen.findByRole("option", { name: "Built-in Microphone" })).toBeInTheDocument();
+    await refreshMicrophoneOptions("Built-in Microphone");
     await user.selectOptions(screen.getByLabelText("Microphone source"), "cpal:0:built-in");
     await user.click(screen.getByRole("button", { name: "Start" }));
 
@@ -454,6 +522,7 @@ describe("Desktop app tools tuner", () => {
 
     expect(await screen.findByRole("heading", { name: "Control Room" })).toBeInTheDocument();
     expect(screen.getByLabelText("Microphone source")).toHaveValue("");
+    expect(getMockInvoke()).not.toHaveBeenCalledWith("audio_list_input_devices");
     expect(getMockMediaDevices().getUserMedia).not.toHaveBeenCalled();
   });
 
@@ -486,6 +555,29 @@ function changeReferenceInput(value: string) {
   const input = screen.getByLabelText("A4 reference tuning");
   fireEvent.change(input, { target: { value } });
   fireEvent.blur(input);
+}
+
+async function refreshMicrophoneOptions(optionName: string) {
+  const inputSource = screen.getByLabelText("Microphone source");
+  fireEvent.pointerDown(inputSource);
+  fireEvent.focus(inputSource);
+  return screen.findByRole("option", { name: optionName });
+}
+
+function emitMockMediaDeviceChange() {
+  const addEventListener = vi.mocked(navigator.mediaDevices.addEventListener);
+  const listener = addEventListener.mock.calls.find(
+    ([eventName]) => eventName === "devicechange",
+  )?.[1];
+  if (!listener) {
+    throw new Error("Missing media devicechange listener.");
+  }
+  const event = new Event("devicechange");
+  if (typeof listener === "function") {
+    act(() => listener(event));
+    return;
+  }
+  act(() => listener.handleEvent(event));
 }
 
 function makeSineSamples(frequencyHz: number, sampleRate: number, sampleCount: number) {

--- a/apps/desktop/src/features/tools/TunerPreferenceControls.tsx
+++ b/apps/desktop/src/features/tools/TunerPreferenceControls.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
   getNativeAudioCapabilities,
   listNativeAudioInputDevices,
@@ -48,11 +48,18 @@ export function TunerPreferenceControls({
   visualModeAriaLabel = "Default tuner",
   visualModeLabel = "Default tuner",
 }: TunerPreferenceControlsProps) {
-  const [devices, setDevices] = useState<TunerMicrophoneDevice[]>([]);
+  const [devices, setDevices] = useState<TunerMicrophoneDevice[]>(() =>
+    readRememberedTunerMicrophoneDevices(),
+  );
   const [deviceError, setDeviceError] = useState<string | null>(null);
   const [isReferenceFocused, setIsReferenceFocused] = useState(false);
   const [referenceDraft, setReferenceDraft] = useState(formatReferenceValue(referenceHz));
   const canEnumerateDevices = canUseMediaDeviceEnumeration();
+  const isMountedRef = useRef(true);
+  const lastRefreshTokenRef = useRef(refreshToken);
+  const pendingRefreshRef = useRef(false);
+  const refreshPromiseRef = useRef<Promise<void> | null>(null);
+  const refreshRequestIdRef = useRef(0);
 
   useEffect(() => {
     if (isReferenceFocused) {
@@ -62,38 +69,88 @@ export function TunerPreferenceControls({
   }, [isReferenceFocused, referenceHz]);
 
   useEffect(() => {
-    let active = true;
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      refreshRequestIdRef.current += 1;
+    };
+  }, []);
 
-    async function refreshDevices() {
-      try {
-        const availableDevices = await enumerateTunerInputDevices({
-          includeNativeDevices: !nativeCaptureDisabled,
-        });
-        if (!active) {
-          return;
-        }
-        setDevices(availableDevices);
-        setDeviceError(null);
-      } catch {
-        if (active) {
-          setDevices([]);
-          setDeviceError("Microphone list unavailable.");
-        }
+  useEffect(() => {
+    pendingRefreshRef.current = false;
+    refreshPromiseRef.current = null;
+    refreshRequestIdRef.current += 1;
+    setDevices(readRememberedTunerMicrophoneDevices());
+    setDeviceError(null);
+  }, [nativeCaptureDisabled]);
+
+  const refreshDevices = useCallback(({ queueIfBusy = false } = {}) => {
+    if (refreshPromiseRef.current) {
+      if (queueIfBusy) {
+        pendingRefreshRef.current = true;
       }
+      return refreshPromiseRef.current;
     }
 
-    void refreshDevices();
+    const refreshPromise = (async () => {
+      while (isMountedRef.current) {
+        pendingRefreshRef.current = false;
+        const requestId = refreshRequestIdRef.current + 1;
+        refreshRequestIdRef.current = requestId;
+
+        try {
+          const availableDevices = await enumerateTunerInputDevices({
+            includeNativeDevices: !nativeCaptureDisabled,
+          });
+          if (!isMountedRef.current || refreshRequestIdRef.current !== requestId) {
+            return;
+          }
+          setDevices(availableDevices);
+          setDeviceError(null);
+        } catch {
+          if (isMountedRef.current && refreshRequestIdRef.current === requestId) {
+            setDevices([]);
+            setDeviceError("Microphone list unavailable.");
+          }
+        }
+
+        if (!pendingRefreshRef.current) {
+          return;
+        }
+      }
+    })();
+
+    refreshPromiseRef.current = refreshPromise;
+    void refreshPromise.finally(() => {
+      if (refreshPromiseRef.current === refreshPromise) {
+        refreshPromiseRef.current = null;
+      }
+    });
+    return refreshPromise;
+  }, [nativeCaptureDisabled]);
+
+  useEffect(() => {
+    if (lastRefreshTokenRef.current === refreshToken) {
+      return;
+    }
+    lastRefreshTokenRef.current = refreshToken;
+    void refreshDevices({ queueIfBusy: true });
+  }, [refreshDevices, refreshToken]);
+
+  useEffect(() => {
+    function refreshOnDeviceChange() {
+      void refreshDevices({ queueIfBusy: true });
+    }
     if (canEnumerateDevices) {
-      navigator.mediaDevices?.addEventListener?.("devicechange", refreshDevices);
+      navigator.mediaDevices?.addEventListener?.("devicechange", refreshOnDeviceChange);
     }
 
     return () => {
-      active = false;
       if (canEnumerateDevices) {
-        navigator.mediaDevices?.removeEventListener?.("devicechange", refreshDevices);
+        navigator.mediaDevices?.removeEventListener?.("devicechange", refreshOnDeviceChange);
       }
     };
-  }, [canEnumerateDevices, nativeCaptureDisabled, refreshToken]);
+  }, [canEnumerateDevices, refreshDevices]);
 
   const selectedDeviceMissing = useMemo(
     () =>
@@ -120,12 +177,19 @@ export function TunerPreferenceControls({
     }
   }
 
+  function handleInputDeviceRefreshRequest() {
+    if (!systemDefaultOnly) {
+      void refreshDevices();
+    }
+  }
+
   return (
     <div className={["tuner-preferences", className].filter(Boolean).join(" ")}>
       <label className="tuner-field">
         <span>Microphone source</span>
         <select
           aria-label="Microphone source"
+          onFocus={handleInputDeviceRefreshRequest}
           onChange={(event) => {
             const nextValue = event.target.value || null;
             if (systemDefaultOnly && nextValue) {
@@ -133,6 +197,12 @@ export function TunerPreferenceControls({
             }
             onInputDeviceChange(nextValue);
           }}
+          onKeyDown={(event) => {
+            if (event.key === " " || event.key === "ArrowDown" || event.key === "Enter") {
+              handleInputDeviceRefreshRequest();
+            }
+          }}
+          onPointerDown={handleInputDeviceRefreshRequest}
           value={selectedInputDeviceId}
         >
           <option value="">System Default</option>


### PR DESCRIPTION
## Summary

- Lazy-load tuner microphone devices from Tools and Settings instead of querying on route mount.
- Keep native input-device discovery on CPAL descriptions while preserving saved `cpal:` ID hash compatibility.
- Queue a follow-up device refresh when `devicechange` or tuner start fires during active discovery.

## Testing

- `cd apps/desktop && ./node_modules/.bin/tsc --noEmit`
- `cd apps/desktop && ./node_modules/.bin/eslint .`
- `cd apps/desktop && ./node_modules/.bin/vitest run src/App.tools-tuner.test.tsx --reporter=verbose`
- `cd apps/desktop/src-tauri && cargo check`
- `cd apps/desktop/src-tauri && cargo test native_audio::capture`
- `git diff --check`