### PR TITLE
feat(sync): add artifact staging model

### DIFF
--- a/apps/backend/alembic/versions/0016_sync_artifact_staging.py
+++ b/apps/backend/alembic/versions/0016_sync_artifact_staging.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0016_sync_artifact_staging"
+down_revision = "0015_sync_trust_identity"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sync_staged_artifacts",
+        sa.Column("content_sha256", sa.String(length=64), nullable=False),
+        sa.Column("size_bytes", sa.Integer(), nullable=False),
+        sa.Column("relative_path", sa.String(length=2048), nullable=False),
+        sa.Column("provider_device_id", sa.String(length=96), nullable=True),
+        sa.Column("metadata_json", sa.JSON(), nullable=False, server_default="{}"),
+        sa.Column("verified_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "length(content_sha256) = 64",
+            name="ck_sync_staged_artifacts_sha256_len",
+        ),
+        sa.CheckConstraint(
+            "size_bytes >= 0",
+            name="ck_sync_staged_artifacts_size_nonnegative",
+        ),
+        sa.PrimaryKeyConstraint("content_sha256"),
+    )
+    op.create_index(
+        "ix_sync_staged_artifacts_provider_device_id",
+        "sync_staged_artifacts",
+        ["provider_device_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_sync_staged_artifacts_verified_at",
+        "sync_staged_artifacts",
+        ["verified_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_sync_staged_artifacts_verified_at",
+        table_name="sync_staged_artifacts",
+    )
+    op.drop_index(
+        "ix_sync_staged_artifacts_provider_device_id",
+        table_name="sync_staged_artifacts",
+    )
+    op.drop_table("sync_staged_artifacts")

--- a/apps/backend/app/api/routes/sync.py
+++ b/apps/backend/app/api/routes/sync.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
@@ -7,6 +9,7 @@ from app.dependencies import get_db
 from app.schemas import (
     ErrorResponse,
     ProjectSchema,
+    SyncArtifactStagingRequest,
     SyncLocalIdentityResponse,
     SyncLocalIdentitySchema,
     SyncLocalIdentityUpdateRequest,
@@ -18,6 +21,7 @@ from app.schemas import (
     SyncProjectImportResponse,
     SyncProjectManifestResponse,
     SyncProjectStagedImportRequest,
+    SyncStagedArtifactSchema,
     SyncTrustedPeerCreateRequest,
     SyncTrustedPeerResponse,
     SyncTrustedPeerSchema,
@@ -35,6 +39,37 @@ from app.services.sync_trust import (
 )
 
 router = APIRouter(prefix="/sync", tags=["sync"])
+
+
+def _stage_sync_artifact(
+    session: Session,
+    *,
+    source_path: str,
+    content_sha256: str,
+    size_bytes: int,
+    provider_device_id: str | None,
+    metadata: dict[str, Any],
+) -> Any:
+    from app.services.sync_staging import stage_sync_artifact
+
+    return stage_sync_artifact(
+        session,
+        source_path=source_path,
+        content_sha256=content_sha256,
+        size_bytes=size_bytes,
+        provider_device_id=provider_device_id,
+        metadata=metadata,
+    )
+
+
+def _require_staged_artifact(
+    session: Session,
+    *,
+    content_sha256: str,
+) -> Any:
+    from app.services.sync_staging import require_staged_artifact
+
+    return require_staged_artifact(session, content_sha256=content_sha256)
 
 
 @router.get("/preflight", response_model=SyncPreflightResponse)
@@ -122,6 +157,31 @@ def sync_project_manifest(
     return SyncProjectManifestResponse.model_validate({"project_manifest": project_manifest})
 
 
+@router.post("/artifacts/staging", response_model=SyncStagedArtifactSchema)
+def sync_artifact_stage(
+    payload: SyncArtifactStagingRequest,
+    session: Session = Depends(get_db),
+) -> SyncStagedArtifactSchema:
+    staged_artifact = _stage_sync_artifact(
+        session,
+        source_path=payload.source_path,
+        content_sha256=payload.content_sha256,
+        size_bytes=payload.size_bytes,
+        provider_device_id=payload.provider_device_id,
+        metadata=payload.metadata,
+    )
+    return SyncStagedArtifactSchema.model_validate(staged_artifact)
+
+
+@router.get("/artifacts/staging/{content_sha256}", response_model=SyncStagedArtifactSchema)
+def sync_artifact_staging_detail(
+    content_sha256: str,
+    session: Session = Depends(get_db),
+) -> SyncStagedArtifactSchema:
+    staged_artifact = _require_staged_artifact(session, content_sha256=content_sha256)
+    return SyncStagedArtifactSchema.model_validate(staged_artifact)
+
+
 @router.post(
     "/projects/import",
     response_model=SyncProjectImportResponse,
@@ -133,11 +193,13 @@ def sync_project_import(
 ) -> SyncProjectImportResponse:
     from app.services.sync_manifest import import_staged_project_manifest
 
-    project = import_staged_project_manifest(
-        session,
-        manifest=payload.manifest.model_dump(mode="python"),
-        staging_root=payload.staging_root,
-    )
+    import_kwargs: dict[str, Any] = {
+        "manifest": payload.manifest.model_dump(mode="python"),
+        "staging_root": payload.staging_root,
+        "use_content_addressed_staging": payload.use_content_addressed_staging is True,
+    }
+
+    project = import_staged_project_manifest(session, **import_kwargs)
     session.commit()
     session.refresh(project)
     return SyncProjectImportResponse(project=ProjectSchema.model_validate(project))

--- a/apps/backend/app/models.py
+++ b/apps/backend/app/models.py
@@ -111,6 +111,27 @@ class SyncPairingOffer(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
 
 
+class SyncStagedArtifact(Base):
+    __tablename__ = "sync_staged_artifacts"
+    __table_args__ = (
+        CheckConstraint("length(content_sha256) = 64", name="ck_sync_staged_artifacts_sha256_len"),
+        CheckConstraint("size_bytes >= 0", name="ck_sync_staged_artifacts_size_nonnegative"),
+        Index("ix_sync_staged_artifacts_provider_device_id", "provider_device_id"),
+        Index("ix_sync_staged_artifacts_verified_at", "verified_at"),
+    )
+
+    content_sha256: Mapped[str] = mapped_column(String(64), primary_key=True)
+    size_bytes: Mapped[int] = mapped_column(Integer())
+    relative_path: Mapped[str] = mapped_column(String(2048))
+    provider_device_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    metadata_json: Mapped[dict[str, Any]] = mapped_column(JSON(), default=dict)
+    verified_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow, onupdate=utcnow
+    )
+
+
 class AnalysisResult(Base):
     __tablename__ = "analysis_results"
 

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -279,9 +279,31 @@ class SyncProjectManifestResponse(BaseModel):
     project_manifest: SyncProjectManifestSchema
 
 
+class SyncArtifactStagingRequest(BaseModel):
+    source_path: str = Field(min_length=1)
+    content_sha256: str = Field(min_length=64, max_length=64)
+    size_bytes: int = Field(ge=0)
+    provider_device_id: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class SyncStagedArtifactSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    content_sha256: str
+    size_bytes: int
+    relative_path: str
+    provider_device_id: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    verified_at: datetime
+    created_at: datetime
+    updated_at: datetime
+
+
 class SyncProjectStagedImportRequest(BaseModel):
     manifest: SyncProjectManifestSchema
-    staging_root: str = Field(min_length=1)
+    staging_root: str | None = Field(default=None, min_length=1)
+    use_content_addressed_staging: bool | None = None
 
 
 class SyncProjectImportResponse(BaseModel):

--- a/apps/backend/app/services/sync_manifest.py
+++ b/apps/backend/app/services/sync_manifest.py
@@ -145,16 +145,38 @@ def import_staged_project_manifest(
     session: Session,
     *,
     manifest: SyncProjectManifest | Mapping[str, Any] | object,
-    staging_root: Path | str,
+    staging_root: Path | str | None = None,
+    use_content_addressed_staging: bool = False,
+    staged_content_addressed: bool | None = None,
 ) -> Project:
+    if staged_content_addressed is not None:
+        flags_conflict = (
+            use_content_addressed_staging is not False
+            and use_content_addressed_staging != staged_content_addressed
+        )
+        if flags_conflict:
+            raise AppError(
+                "SYNC_MANIFEST_STAGING_MODE_CONFLICT",
+                "Sync manifest import received conflicting staging mode flags.",
+            )
+        use_content_addressed_staging = staged_content_addressed
+
     project_manifest = _coerce_project_manifest(manifest)
     _validate_project_manifest_schema_version(project_manifest)
     _validate_project_manifest_identity(project_manifest)
     _validate_source_artifact_matches_project_source(project_manifest)
     _reject_duplicate_project_source(session, project_manifest)
     root = project_root(project_manifest.project_id).resolve(strict=False)
-    staged_root = Path(staging_root).expanduser().resolve(strict=False)
-    verified_artifacts = _verify_staged_artifacts(project_manifest, staging_root=staged_root, project_root_path=root)
+    staged_root = (
+        None if staging_root is None else Path(staging_root).expanduser().resolve(strict=False)
+    )
+    verified_artifacts = _verify_staged_artifacts(
+        session,
+        project_manifest,
+        staging_root=staged_root,
+        project_root_path=root,
+        use_content_addressed_staging=use_content_addressed_staging,
+    )
     source_artifact = _source_artifact_manifest(project_manifest)
     source_path = root / _safe_relative_path(source_artifact.relative_path)
 
@@ -304,14 +326,22 @@ def _export_artifact_manifest(artifact: Artifact) -> SyncArtifactManifest:
 
 
 def _verify_staged_artifacts(
+    session: Session,
     manifest: SyncProjectManifest,
     *,
-    staging_root: Path,
+    staging_root: Path | None,
     project_root_path: Path,
+    use_content_addressed_staging: bool,
 ) -> list[_VerifiedStagedArtifact]:
     verified: list[_VerifiedStagedArtifact] = []
     destination_paths: set[Path] = set()
     artifact_ids: set[str] = set()
+
+    if not use_content_addressed_staging and staging_root is None:
+        raise AppError(
+            "SYNC_MANIFEST_STAGING_ROOT_REQUIRED",
+            "A staging root is required for relative staged artifact import.",
+        )
 
     for artifact in manifest.artifacts:
         if artifact.project_id != manifest.project_id:
@@ -329,9 +359,7 @@ def _verify_staged_artifacts(
         artifact_ids.add(artifact.artifact_id)
 
         relative_path = _safe_relative_path(artifact.relative_path)
-        staged_path = (staging_root / relative_path).resolve(strict=False)
         destination_path = (project_root_path / relative_path).resolve(strict=False)
-        _ensure_child_path(staging_root, staged_path, "staged artifact")
         _ensure_child_path(project_root_path, destination_path, "destination artifact")
         if destination_path in destination_paths:
             raise AppError(
@@ -348,7 +376,14 @@ def _verify_staged_artifacts(
                 details={"relative_path": artifact.relative_path},
             )
 
-        _verify_staged_file(artifact, staged_path)
+        if use_content_addressed_staging:
+            staged_path = _content_addressed_staged_path(session, artifact)
+        else:
+            assert staging_root is not None
+            staged_path = (staging_root / relative_path).resolve(strict=False)
+            _ensure_child_path(staging_root, staged_path, "staged artifact")
+            _verify_staged_file(artifact, staged_path)
+
         verified.append(
             _VerifiedStagedArtifact(
                 manifest=artifact,
@@ -358,6 +393,32 @@ def _verify_staged_artifacts(
         )
 
     return verified
+
+
+def _content_addressed_staged_path(session: Session, artifact: SyncArtifactManifest) -> Path:
+    try:
+        from app.services.sync_staging import require_staged_artifact
+    except ModuleNotFoundError as exc:
+        if exc.name == "app.services.sync_staging":
+            raise AppError(
+                "SYNC_STAGING_SERVICE_UNAVAILABLE",
+                "Content-addressed sync staging is not available.",
+            ) from exc
+        raise
+
+    staged_artifact = require_staged_artifact(
+        session,
+        content_sha256=artifact.content_sha256,
+        size_bytes=artifact.size_bytes,
+    )
+    resolved_path = getattr(staged_artifact, "resolved_path", None)
+    if not isinstance(resolved_path, Path):
+        raise AppError(
+            "SYNC_STAGING_ARTIFACT_PATH_INVALID",
+            "A staged sync artifact resolved to an invalid local path.",
+            details={"artifact_id": artifact.artifact_id},
+        )
+    return resolved_path
 
 
 def _verify_staged_file(artifact: SyncArtifactManifest, staged_path: Path) -> None:

--- a/apps/backend/app/services/sync_staging.py
+++ b/apps/backend/app/services/sync_staging.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import shutil
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from fastapi import status
+from sqlalchemy.orm import Session
+
+from app.config import get_settings
+from app.errors import AppError
+from app.models import SyncStagedArtifact, utcnow
+from app.utils.hashing import file_sha256
+
+HEX_DIGITS = frozenset("0123456789abcdef")
+
+
+@dataclass(frozen=True)
+class SyncStagedArtifactDTO:
+    content_sha256: str
+    size_bytes: int
+    relative_path: str
+    provider_device_id: str | None
+    metadata: dict[str, Any]
+    verified_at: datetime
+    created_at: datetime
+    updated_at: datetime
+    resolved_path: Path
+
+
+def stage_sync_artifact(
+    session: Session,
+    *,
+    source_path: Path | str,
+    content_sha256: str,
+    size_bytes: int,
+    provider_device_id: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> SyncStagedArtifactDTO:
+    normalized_sha256 = _normalize_content_sha256(content_sha256)
+    _validate_size_bytes(size_bytes)
+    source = Path(source_path).expanduser().resolve(strict=False)
+    _verify_source_file(source, content_sha256=normalized_sha256, size_bytes=size_bytes)
+
+    relative_path = _relative_path_for_hash(normalized_sha256)
+    destination_path = _staging_root() / Path(relative_path)
+    if not _staged_path_matches(destination_path, content_sha256=normalized_sha256, size_bytes=size_bytes):
+        _copy_verified_source(source, destination_path)
+
+    now = utcnow()
+    record = session.get(SyncStagedArtifact, normalized_sha256)
+    if record is None:
+        record = SyncStagedArtifact(
+            content_sha256=normalized_sha256,
+            size_bytes=size_bytes,
+            relative_path=relative_path,
+            provider_device_id=provider_device_id,
+            metadata_json=dict(metadata) if metadata is not None else {},
+            verified_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+        session.add(record)
+    else:
+        record.size_bytes = size_bytes
+        record.relative_path = relative_path
+        record.provider_device_id = provider_device_id
+        if metadata is not None:
+            record.metadata_json = dict(metadata)
+        elif record.metadata_json is None:
+            record.metadata_json = {}
+        record.verified_at = now
+        record.updated_at = now
+
+    session.flush()
+    return _verify_staged_record(record, expected_size_bytes=size_bytes)
+
+
+def get_staged_artifact_path(session: Session, *, content_sha256: str) -> Path:
+    return require_staged_artifact(session, content_sha256=content_sha256).resolved_path
+
+
+def require_staged_artifact(
+    session: Session,
+    *,
+    content_sha256: str,
+    size_bytes: int | None = None,
+) -> SyncStagedArtifactDTO:
+    normalized_sha256 = _normalize_content_sha256(content_sha256)
+    if size_bytes is not None:
+        _validate_size_bytes(size_bytes)
+    record = session.get(SyncStagedArtifact, normalized_sha256)
+    if record is None:
+        raise AppError(
+            "SYNC_STAGING_ARTIFACT_NOT_FOUND",
+            "Sync artifact has not been staged locally.",
+            status_code=status.HTTP_404_NOT_FOUND,
+            details={"content_sha256": normalized_sha256},
+        )
+    return _verify_staged_record(record, expected_size_bytes=size_bytes)
+
+
+def _normalize_content_sha256(content_sha256: str) -> str:
+    normalized = content_sha256.strip().lower()
+    if len(normalized) != 64 or any(character not in HEX_DIGITS for character in normalized):
+        raise AppError(
+            "SYNC_STAGING_HASH_INVALID",
+            "Sync staged artifact content_sha256 must be a full SHA-256 hex digest.",
+            details={"content_sha256": content_sha256},
+        )
+    return normalized
+
+
+def _validate_size_bytes(size_bytes: int) -> None:
+    if size_bytes < 0:
+        raise AppError(
+            "SYNC_STAGING_SIZE_INVALID",
+            "Sync staged artifact size_bytes must be non-negative.",
+            details={"size_bytes": size_bytes},
+        )
+
+
+def _verify_source_file(source_path: Path, *, content_sha256: str, size_bytes: int) -> None:
+    actual_size = _file_size(source_path)
+    if actual_size is None:
+        _raise_source_unreadable(source_path)
+    if actual_size != size_bytes:
+        raise AppError(
+            "SYNC_STAGING_SOURCE_SIZE_MISMATCH",
+            "Source artifact size does not match the requested staged artifact size.",
+            status_code=status.HTTP_409_CONFLICT,
+            details={
+                "source_path": str(source_path),
+                "expected_size_bytes": size_bytes,
+                "actual_size_bytes": actual_size,
+            },
+        )
+
+    actual_sha256 = file_sha256(source_path)
+    if actual_sha256 is None:
+        _raise_source_unreadable(source_path)
+    if actual_sha256 != content_sha256:
+        raise AppError(
+            "SYNC_STAGING_SOURCE_HASH_MISMATCH",
+            "Source artifact SHA-256 does not match the requested staged artifact hash.",
+            status_code=status.HTTP_409_CONFLICT,
+            details={
+                "source_path": str(source_path),
+                "expected_sha256": content_sha256,
+                "actual_sha256": actual_sha256,
+            },
+        )
+
+
+def _verify_staged_record(
+    record: SyncStagedArtifact,
+    *,
+    expected_size_bytes: int | None,
+) -> SyncStagedArtifactDTO:
+    resolved_path = _resolve_staged_relative_path(record.relative_path)
+    if expected_size_bytes is not None and record.size_bytes != expected_size_bytes:
+        raise AppError(
+            "SYNC_STAGING_RECORD_SIZE_MISMATCH",
+            "Staged artifact record size does not match the requested size.",
+            status_code=status.HTTP_409_CONFLICT,
+            details={
+                "content_sha256": record.content_sha256,
+                "expected_size_bytes": expected_size_bytes,
+                "actual_size_bytes": record.size_bytes,
+            },
+        )
+
+    actual_size = _file_size(resolved_path)
+    if actual_size is None:
+        raise AppError(
+            "SYNC_STAGING_FILE_MISSING",
+            "Staged sync artifact file is missing or unreadable.",
+            status_code=status.HTTP_404_NOT_FOUND,
+            details={"content_sha256": record.content_sha256, "relative_path": record.relative_path},
+        )
+    if actual_size != record.size_bytes:
+        raise AppError(
+            "SYNC_STAGING_FILE_SIZE_MISMATCH",
+            "Staged sync artifact file size does not match its database record.",
+            status_code=status.HTTP_409_CONFLICT,
+            details={
+                "content_sha256": record.content_sha256,
+                "relative_path": record.relative_path,
+                "expected_size_bytes": record.size_bytes,
+                "actual_size_bytes": actual_size,
+            },
+        )
+
+    actual_sha256 = file_sha256(resolved_path)
+    if actual_sha256 != record.content_sha256:
+        raise AppError(
+            "SYNC_STAGING_FILE_HASH_MISMATCH",
+            "Staged sync artifact file SHA-256 does not match its database record.",
+            status_code=status.HTTP_409_CONFLICT,
+            details={
+                "content_sha256": record.content_sha256,
+                "relative_path": record.relative_path,
+                "expected_sha256": record.content_sha256,
+                "actual_sha256": actual_sha256,
+            },
+        )
+
+    return _to_dto(record, resolved_path)
+
+
+def _copy_verified_source(source_path: Path, destination_path: Path) -> None:
+    temp_path: Path | None = None
+    try:
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            prefix=f".{destination_path.name}.",
+            suffix=".tmp",
+            dir=destination_path.parent,
+            delete=False,
+        ) as temp_file:
+            temp_path = Path(temp_file.name)
+        shutil.copy2(source_path, temp_path)
+        temp_path.replace(destination_path)
+    except OSError as exc:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
+        raise AppError(
+            "SYNC_STAGING_COPY_FAILED",
+            "Source artifact could not be copied into sync staging.",
+            details={"source_path": str(source_path), "destination_path": str(destination_path)},
+        ) from exc
+
+
+def _relative_path_for_hash(content_sha256: str) -> str:
+    return str(PurePosixPath("sha256", content_sha256[:2], content_sha256))
+
+
+def _staging_root() -> Path:
+    return get_settings().data_root / "sync" / "staging"
+
+
+def _resolve_staged_relative_path(relative_path: str) -> Path:
+    relative = PurePosixPath(relative_path)
+    if relative.is_absolute() or any(part in {"", ".", ".."} for part in relative.parts):
+        raise AppError(
+            "SYNC_STAGING_RELATIVE_PATH_INVALID",
+            "Staged sync artifact record contains an invalid relative path.",
+            status_code=status.HTTP_409_CONFLICT,
+            details={"relative_path": relative_path},
+        )
+    root = _staging_root().resolve(strict=False)
+    resolved = (root / Path(relative_path)).resolve(strict=False)
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise AppError(
+            "SYNC_STAGING_RELATIVE_PATH_INVALID",
+            "Staged sync artifact record points outside the sync staging root.",
+            status_code=status.HTTP_409_CONFLICT,
+            details={"relative_path": relative_path},
+        ) from exc
+    return resolved
+
+
+def _staged_path_matches(destination_path: Path, *, content_sha256: str, size_bytes: int) -> bool:
+    actual_size = _file_size(destination_path)
+    if actual_size != size_bytes:
+        return False
+    return file_sha256(destination_path) == content_sha256
+
+
+def _file_size(path: Path) -> int | None:
+    try:
+        if not path.is_file():
+            return None
+        return path.stat().st_size
+    except OSError:
+        return None
+
+
+def _raise_source_unreadable(source_path: Path) -> None:
+    try:
+        exists = source_path.exists()
+    except OSError:
+        exists = False
+    if not exists:
+        raise AppError(
+            "SYNC_STAGING_SOURCE_FILE_MISSING",
+            "Source artifact file does not exist.",
+            status_code=status.HTTP_404_NOT_FOUND,
+            details={"source_path": str(source_path)},
+        )
+    raise AppError(
+        "SYNC_STAGING_SOURCE_FILE_UNREADABLE",
+        "Source artifact file is not readable.",
+        details={"source_path": str(source_path)},
+    )
+
+
+def _to_dto(record: SyncStagedArtifact, resolved_path: Path) -> SyncStagedArtifactDTO:
+    metadata = record.metadata_json if isinstance(record.metadata_json, dict) else {}
+    return SyncStagedArtifactDTO(
+        content_sha256=record.content_sha256,
+        size_bytes=record.size_bytes,
+        relative_path=record.relative_path,
+        provider_device_id=record.provider_device_id,
+        metadata=dict(metadata),
+        verified_at=record.verified_at,
+        created_at=record.created_at,
+        updated_at=record.updated_at,
+        resolved_path=resolved_path,
+    )

--- a/apps/backend/tests/test_db_migrations.py
+++ b/apps/backend/tests/test_db_migrations.py
@@ -53,6 +53,46 @@ def test_sync_trust_identity_migration_creates_identity_and_trust_tables() -> No
     } <= tables
 
 
+def test_sync_artifact_staging_migration_creates_table_and_indexes() -> None:
+    settings = get_settings()
+    ensure_data_dirs(settings)
+
+    reconfigure_engine(settings)
+    run_migrations(settings)
+
+    with sqlite3.connect(settings.database_path) as connection:
+        tables = {
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+        columns = {
+            row[1]
+            for row in connection.execute("PRAGMA table_info('sync_staged_artifacts')")
+        }
+        indexes = {
+            row[1]
+            for row in connection.execute("PRAGMA index_list('sync_staged_artifacts')")
+        }
+
+    assert "sync_staged_artifacts" in tables
+    assert {
+        "content_sha256",
+        "size_bytes",
+        "relative_path",
+        "provider_device_id",
+        "metadata_json",
+        "verified_at",
+        "created_at",
+        "updated_at",
+    } <= columns
+    assert {
+        "ix_sync_staged_artifacts_provider_device_id",
+        "ix_sync_staged_artifacts_verified_at",
+    } <= indexes
+
+
 def test_hash_storage_migration_backfills_existing_files(tmp_path: Path) -> None:
     settings = get_settings()
     ensure_data_dirs(settings)

--- a/apps/backend/tests/test_sync_manifest.py
+++ b/apps/backend/tests/test_sync_manifest.py
@@ -251,6 +251,28 @@ def _stage_manifest_files(
         shutil.copy2(source_path, staged_path)
 
 
+def _stage_manifest_content_addressed_files(
+    session: Any,
+    manifest: dict[str, Any],
+    *,
+    source_root: Path,
+) -> dict[str, Path]:
+    from app.services.sync_staging import stage_sync_artifact
+
+    staged_paths: dict[str, Path] = {}
+    for artifact in manifest["artifacts"]:
+        relative_path = artifact["relative_path"]
+        source_path = source_root / relative_path
+        staged = stage_sync_artifact(
+            session,
+            source_path=source_path,
+            content_sha256=artifact["content_sha256"],
+            size_bytes=artifact["size_bytes"],
+        )
+        staged_paths[artifact["content_sha256"]] = staged.resolved_path
+    return staged_paths
+
+
 def _delete_live_project(session: Any, fixture: ManifestProjectFixture) -> None:
     project = session.get(Project, fixture.project_id)
     assert project is not None
@@ -477,6 +499,125 @@ def test_import_staged_project_manifest_rewrites_paths_preserves_hashes_and_skip
             session.scalars(select(Job.type).where(Job.project_id == fixture.project_id))
         )
         assert not job_types.intersection({"analyze", "chords"})
+
+
+def test_import_staged_project_manifest_imports_content_addressed_staging(
+    client: object,
+    tmp_path: Path,
+) -> None:
+    export_manifest, import_manifest = _sync_manifest_services()
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path)
+        manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+        staged_paths = _stage_manifest_content_addressed_files(
+            session,
+            manifest,
+            source_root=fixture.root,
+        )
+        _delete_live_project(session, fixture)
+
+        import_manifest(
+            session,
+            manifest=manifest,
+            use_content_addressed_staging=True,
+        )
+        session.commit()
+
+        receiving_root = project_root(fixture.project_id)
+        project = session.get(Project, fixture.project_id)
+        assert project is not None
+        expected_source_path = receiving_root / fixture.source_relative_path
+        assert Path(project.source_path) == expected_source_path
+        assert Path(project.imported_path) == expected_source_path
+
+        artifacts = {
+            artifact.id: artifact
+            for artifact in session.scalars(
+                select(Artifact).where(Artifact.project_id == fixture.project_id)
+            )
+        }
+        assert set(artifacts) == {"art_source_audio", "art_vocals"}
+        for artifact_id, relative_path in {
+            "art_source_audio": fixture.source_relative_path,
+            "art_vocals": fixture.stem_relative_path,
+        }.items():
+            imported_path = receiving_root / relative_path
+            assert Path(artifacts[artifact_id].path) == imported_path
+            assert imported_path.exists()
+            assert imported_path not in staged_paths.values()
+            assert file_sha256(imported_path) == fixture.artifact_hashes[artifact_id]
+
+
+def test_import_staged_project_manifest_rejects_missing_content_addressed_staging_before_writes(
+    client: object,
+    tmp_path: Path,
+) -> None:
+    export_manifest, import_manifest = _sync_manifest_services()
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path)
+        manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+        staged_paths = _stage_manifest_content_addressed_files(
+            session,
+            manifest,
+            source_root=fixture.root,
+        )
+        missing_path = staged_paths[fixture.artifact_hashes["art_source_audio"]]
+        _delete_live_project(session, fixture)
+        missing_path.unlink()
+
+        with pytest.raises(AppError) as exc:
+            import_manifest(
+                session,
+                manifest=manifest,
+                use_content_addressed_staging=True,
+            )
+        session.rollback()
+
+        receiving_root = project_root(fixture.project_id)
+        assert session.get(Project, fixture.project_id) is None
+        assert not (receiving_root / fixture.source_relative_path).exists()
+        assert not (receiving_root / fixture.stem_relative_path).exists()
+
+    assert exc.value.code == "SYNC_STAGING_FILE_MISSING"
+    assert exc.value.details["content_sha256"] == fixture.artifact_hashes["art_source_audio"]
+
+
+def test_import_staged_project_manifest_rejects_corrupt_content_addressed_staging(
+    client: object,
+    tmp_path: Path,
+) -> None:
+    export_manifest, import_manifest = _sync_manifest_services()
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path)
+        manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+        staged_paths = _stage_manifest_content_addressed_files(
+            session,
+            manifest,
+            source_root=fixture.root,
+        )
+        corrupt_path = staged_paths[fixture.artifact_hashes["art_vocals"]]
+        _delete_live_project(session, fixture)
+        corrupt_path.write_bytes(b"corrupt stem!!!")
+
+        with pytest.raises(AppError) as exc:
+            import_manifest(
+                session,
+                manifest=manifest,
+                use_content_addressed_staging=True,
+            )
+        session.rollback()
+
+        receiving_root = project_root(fixture.project_id)
+        assert session.get(Project, fixture.project_id) is None
+        assert not (receiving_root / fixture.source_relative_path).exists()
+        assert not (receiving_root / fixture.stem_relative_path).exists()
+
+    assert exc.value.code == "SYNC_STAGING_FILE_HASH_MISMATCH"
+    assert exc.value.details["content_sha256"] == fixture.artifact_hashes["art_vocals"]
+    assert exc.value.details["actual_sha256"] != fixture.artifact_hashes["art_vocals"]
 
 
 def test_import_staged_project_manifest_rejects_hash_mismatch(

--- a/apps/backend/tests/test_sync_staging.py
+++ b/apps/backend/tests/test_sync_staging.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.db import SessionLocal
+from app.errors import AppError
+from app.models import SyncStagedArtifact
+from app.services.sync_staging import (
+    get_staged_artifact_path,
+    require_staged_artifact,
+    stage_sync_artifact,
+)
+from app.utils.hashing import file_sha256
+
+
+def test_stage_sync_artifact_stores_verified_bytes_under_content_addressed_path(
+    client: object,
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "source.bin"
+    source_path.write_bytes(b"sync artifact bytes")
+    content_sha256 = file_sha256(source_path)
+    assert content_sha256 is not None
+
+    with SessionLocal() as session:
+        staged = stage_sync_artifact(
+            session,
+            source_path=source_path,
+            content_sha256=content_sha256.upper(),
+            size_bytes=source_path.stat().st_size,
+            provider_device_id="device-a",
+            metadata={"kind": "source_audio"},
+        )
+        staged_path = get_staged_artifact_path(session, content_sha256=content_sha256)
+        record = session.get(SyncStagedArtifact, content_sha256)
+
+    assert staged.content_sha256 == content_sha256
+    assert staged.size_bytes == source_path.stat().st_size
+    assert staged.relative_path == f"sha256/{content_sha256[:2]}/{content_sha256}"
+    assert staged.provider_device_id == "device-a"
+    assert staged.metadata == {"kind": "source_audio"}
+    assert staged.resolved_path == staged_path
+    assert staged.resolved_path.read_bytes() == b"sync artifact bytes"
+    assert not Path(staged.relative_path).is_absolute()
+    assert record is not None
+    assert record.relative_path == staged.relative_path
+
+
+def test_stage_sync_artifact_is_idempotent_and_repairs_missing_staged_file(
+    client: object,
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "source.bin"
+    source_path.write_bytes(b"idempotent bytes")
+    content_sha256 = file_sha256(source_path)
+    assert content_sha256 is not None
+
+    with SessionLocal() as session:
+        first = stage_sync_artifact(
+            session,
+            source_path=source_path,
+            content_sha256=content_sha256,
+            size_bytes=source_path.stat().st_size,
+        )
+        first.resolved_path.unlink()
+
+        second = stage_sync_artifact(
+            session,
+            source_path=source_path,
+            content_sha256=content_sha256,
+            size_bytes=source_path.stat().st_size,
+            provider_device_id="device-b",
+            metadata={"restaged": True},
+        )
+        records = session.query(SyncStagedArtifact).all()
+
+    assert second.content_sha256 == first.content_sha256
+    assert second.resolved_path == first.resolved_path
+    assert second.resolved_path.read_bytes() == b"idempotent bytes"
+    assert second.provider_device_id == "device-b"
+    assert second.metadata == {"restaged": True}
+    assert len(records) == 1
+
+
+def test_stage_sync_artifact_rejects_hash_mismatch(client: object, tmp_path: Path) -> None:
+    source_path = tmp_path / "source.bin"
+    source_path.write_bytes(b"actual bytes")
+    expected_sha256 = file_sha256(tmp_path / "missing.bin") or "0" * 64
+
+    with SessionLocal() as session:
+        with pytest.raises(AppError) as exc:
+            stage_sync_artifact(
+                session,
+                source_path=source_path,
+                content_sha256=expected_sha256,
+                size_bytes=source_path.stat().st_size,
+            )
+
+    assert exc.value.code == "SYNC_STAGING_SOURCE_HASH_MISMATCH"
+    assert exc.value.status_code == 409
+
+
+def test_stage_sync_artifact_rejects_size_mismatch(client: object, tmp_path: Path) -> None:
+    source_path = tmp_path / "source.bin"
+    source_path.write_bytes(b"actual bytes")
+    content_sha256 = file_sha256(source_path)
+    assert content_sha256 is not None
+
+    with SessionLocal() as session:
+        with pytest.raises(AppError) as exc:
+            stage_sync_artifact(
+                session,
+                source_path=source_path,
+                content_sha256=content_sha256,
+                size_bytes=source_path.stat().st_size + 1,
+            )
+
+    assert exc.value.code == "SYNC_STAGING_SOURCE_SIZE_MISMATCH"
+    assert exc.value.status_code == 409
+
+
+def test_require_staged_artifact_rejects_missing_staged_content(
+    client: object,
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "source.bin"
+    source_path.write_bytes(b"missing staged bytes")
+    content_sha256 = file_sha256(source_path)
+    assert content_sha256 is not None
+
+    with SessionLocal() as session:
+        staged = stage_sync_artifact(
+            session,
+            source_path=source_path,
+            content_sha256=content_sha256,
+            size_bytes=source_path.stat().st_size,
+        )
+        staged.resolved_path.unlink()
+
+        with pytest.raises(AppError) as exc:
+            require_staged_artifact(session, content_sha256=content_sha256)
+
+    assert exc.value.code == "SYNC_STAGING_FILE_MISSING"
+    assert exc.value.status_code == 404

--- a/apps/backend/tests/test_sync_staging_api.py
+++ b/apps/backend/tests/test_sync_staging_api.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from app.api.routes import sync as sync_routes
+from app.models import Project
+
+
+@dataclass(frozen=True)
+class StagedArtifactFixture:
+    content_sha256: str
+    size_bytes: int
+    relative_path: str
+    provider_device_id: str | None
+    metadata: dict[str, Any]
+    verified_at: datetime
+    created_at: datetime
+    updated_at: datetime
+    resolved_path: str
+
+
+def _staged_artifact(
+    *,
+    content_sha256: str,
+    size_bytes: int,
+    relative_path: str = "sync-artifacts/ab/cd/artifact.bin",
+    provider_device_id: str | None = "device-local",
+    metadata: dict[str, Any] | None = None,
+    resolved_path: Path | None = None,
+) -> StagedArtifactFixture:
+    timestamp = datetime(2026, 5, 15, 12, 0, tzinfo=UTC)
+    return StagedArtifactFixture(
+        content_sha256=content_sha256,
+        size_bytes=size_bytes,
+        relative_path=relative_path,
+        provider_device_id=provider_device_id,
+        metadata=metadata or {},
+        verified_at=timestamp,
+        created_at=timestamp,
+        updated_at=timestamp,
+        resolved_path=str(resolved_path or Path("/tmp/tuneforge-private/artifact.bin")),
+    )
+
+
+def _manifest_payload(content_sha256: str, *, project_id: str = "proj_sync_api_import") -> dict[str, Any]:
+    timestamp = datetime(2026, 5, 15, 12, 0, tzinfo=UTC).isoformat()
+    return {
+        "schema_version": "1",
+        "exported_at": timestamp,
+        "project": {
+            "project_id": project_id,
+            "display_name": "Staged API Import",
+            "source_key_override": None,
+            "source_sha256": content_sha256,
+            "duration_seconds": 1.0,
+            "sample_rate": 44100,
+            "channels": 2,
+            "created_at": timestamp,
+            "updated_at": timestamp,
+        },
+        "artifacts": [
+            {
+                "artifact_id": "art_source",
+                "project_id": project_id,
+                "type": "source",
+                "format": "wav",
+                "relative_path": "source/input.wav",
+                "content_sha256": content_sha256,
+                "size_bytes": 12,
+                "generated_by": "import",
+                "can_delete": False,
+                "can_regenerate": False,
+                "cache_key": None,
+                "metadata": {},
+                "created_at": timestamp,
+            }
+        ],
+    }
+
+
+def test_stage_sync_artifact_api_returns_record_without_absolute_path(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    source_path = tmp_path / "source.wav"
+    source_path.write_bytes(b"staged artifact")
+    content_sha256 = hashlib.sha256(source_path.read_bytes()).hexdigest()
+    captured: dict[str, Any] = {}
+
+    def fake_stage_sync_artifact(
+        session: Any,
+        *,
+        source_path: str,
+        content_sha256: str,
+        size_bytes: int,
+        provider_device_id: str | None,
+        metadata: dict[str, Any],
+    ) -> StagedArtifactFixture:
+        captured.update(
+            {
+                "source_path": source_path,
+                "content_sha256": content_sha256,
+                "size_bytes": size_bytes,
+                "provider_device_id": provider_device_id,
+                "metadata": metadata,
+            }
+        )
+        return _staged_artifact(
+            content_sha256=content_sha256,
+            size_bytes=size_bytes,
+            provider_device_id=provider_device_id,
+            metadata=metadata,
+            resolved_path=tmp_path / "data" / "sync-artifacts" / content_sha256,
+        )
+
+    monkeypatch.setattr(sync_routes, "_stage_sync_artifact", fake_stage_sync_artifact)
+
+    response = client.post(
+        "/api/v1/sync/artifacts/staging",
+        json={
+            "source_path": str(source_path),
+            "content_sha256": content_sha256,
+            "size_bytes": source_path.stat().st_size,
+            "provider_device_id": "device-a",
+            "metadata": {"role": "source"},
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert set(payload) == {
+        "content_sha256",
+        "size_bytes",
+        "relative_path",
+        "provider_device_id",
+        "metadata",
+        "verified_at",
+        "created_at",
+        "updated_at",
+    }
+    assert payload["content_sha256"] == content_sha256
+    assert payload["size_bytes"] == source_path.stat().st_size
+    assert payload["provider_device_id"] == "device-a"
+    assert payload["metadata"] == {"role": "source"}
+    assert payload["relative_path"] == "sync-artifacts/ab/cd/artifact.bin"
+    assert str(source_path) not in json.dumps(payload)
+    assert str(tmp_path) not in json.dumps(payload)
+    assert "resolved_path" not in payload
+    assert captured == {
+        "source_path": str(source_path),
+        "content_sha256": content_sha256,
+        "size_bytes": source_path.stat().st_size,
+        "provider_device_id": "device-a",
+        "metadata": {"role": "source"},
+    }
+
+
+def test_get_sync_staged_artifact_api_returns_staged_metadata(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    content_sha256 = hashlib.sha256(b"existing staged artifact").hexdigest()
+    captured: dict[str, Any] = {}
+
+    def fake_require_staged_artifact(
+        session: Any,
+        *,
+        content_sha256: str,
+    ) -> StagedArtifactFixture:
+        captured["content_sha256"] = content_sha256
+        return _staged_artifact(
+            content_sha256=content_sha256,
+            size_bytes=24,
+            provider_device_id="device-b",
+            metadata={"format": "wav", "verified_by": "api-test"},
+            resolved_path=tmp_path / "hidden" / content_sha256,
+        )
+
+    monkeypatch.setattr(sync_routes, "_require_staged_artifact", fake_require_staged_artifact)
+
+    response = client.get(f"/api/v1/sync/artifacts/staging/{content_sha256}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["content_sha256"] == content_sha256
+    assert payload["size_bytes"] == 24
+    assert payload["provider_device_id"] == "device-b"
+    assert payload["metadata"] == {"format": "wav", "verified_by": "api-test"}
+    assert str(tmp_path) not in json.dumps(payload)
+    assert "resolved_path" not in payload
+    assert captured == {"content_sha256": content_sha256}
+
+
+def test_sync_project_import_api_accepts_legacy_staging_root_payload(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    from app.services import sync_manifest as sync_manifest_service
+
+    content_sha256 = hashlib.sha256(b"legacy staging root").hexdigest()
+    staging_root = tmp_path / "staging"
+    captured: dict[str, Any] = {}
+
+    def fake_import_staged_project_manifest(
+        session: Any,
+        *,
+        manifest: dict[str, Any],
+        staging_root: str,
+        use_content_addressed_staging: bool | None = None,
+    ) -> Project:
+        captured.update(
+            {
+                "manifest": manifest,
+                "staging_root": staging_root,
+                "use_content_addressed_staging": use_content_addressed_staging,
+            }
+        )
+        project = Project(
+            id=manifest["project"]["project_id"],
+            display_name=manifest["project"]["display_name"],
+            source_key_override=manifest["project"]["source_key_override"],
+            source_sha256=manifest["project"]["source_sha256"],
+            source_path=str(tmp_path / "imported.wav"),
+            imported_path=str(tmp_path / "imported.wav"),
+            duration_seconds=manifest["project"]["duration_seconds"],
+            sample_rate=manifest["project"]["sample_rate"],
+            channels=manifest["project"]["channels"],
+        )
+        session.add(project)
+        session.flush()
+        return project
+
+    monkeypatch.setattr(
+        sync_manifest_service,
+        "import_staged_project_manifest",
+        fake_import_staged_project_manifest,
+    )
+
+    response = client.post(
+        "/api/v1/sync/projects/import",
+        json={"manifest": _manifest_payload(content_sha256), "staging_root": str(staging_root)},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["project"]["id"] == "proj_sync_api_import"
+    assert captured["manifest"]["project"]["source_sha256"] == content_sha256
+    assert captured["staging_root"] == str(staging_root)
+    assert captured["use_content_addressed_staging"] is False
+
+
+def test_sync_project_import_api_allows_content_addressed_payload_without_staging_root(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    from app.services import sync_manifest as sync_manifest_service
+
+    content_sha256 = hashlib.sha256(b"content addressed staging").hexdigest()
+    project_id = f"proj_sha256_{content_sha256}"
+    captured: dict[str, Any] = {}
+
+    def fake_import_staged_project_manifest(
+        session: Any,
+        *,
+        manifest: dict[str, Any],
+        staging_root: str | None,
+        use_content_addressed_staging: bool,
+    ) -> Project:
+        captured.update(
+            {
+                "manifest": manifest,
+                "staging_root": staging_root,
+                "use_content_addressed_staging": use_content_addressed_staging,
+            }
+        )
+        project = Project(
+            id=manifest["project"]["project_id"],
+            display_name=manifest["project"]["display_name"],
+            source_key_override=manifest["project"]["source_key_override"],
+            source_sha256=manifest["project"]["source_sha256"],
+            source_path=str(tmp_path / "imported.wav"),
+            imported_path=str(tmp_path / "imported.wav"),
+            duration_seconds=manifest["project"]["duration_seconds"],
+            sample_rate=manifest["project"]["sample_rate"],
+            channels=manifest["project"]["channels"],
+        )
+        session.add(project)
+        session.flush()
+        return project
+
+    monkeypatch.setattr(
+        sync_manifest_service,
+        "import_staged_project_manifest",
+        fake_import_staged_project_manifest,
+    )
+
+    response = client.post(
+        "/api/v1/sync/projects/import",
+        json={
+            "manifest": _manifest_payload(content_sha256, project_id=project_id),
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["project"]["id"] == project_id
+    assert captured["manifest"]["project"]["source_sha256"] == content_sha256
+    assert captured["staging_root"] is None
+    assert captured["use_content_addressed_staging"] is True

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -555,6 +555,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/sync/artifacts/staging": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Sync Artifact Stage */
+        post: operations["sync_artifact_stage_api_v1_sync_artifacts_staging_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/sync/artifacts/staging/{content_sha256}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Sync Artifact Staging Detail */
+        get: operations["sync_artifact_staging_detail_api_v1_sync_artifacts_staging__content_sha256__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/sync/projects/import": {
         parameters: {
             query?: never;
@@ -1185,6 +1219,21 @@ export interface components {
              */
             overwrite_chord_edits: boolean;
         };
+        /** SyncArtifactStagingRequest */
+        SyncArtifactStagingRequest: {
+            /** Source Path */
+            source_path: string;
+            /** Content Sha256 */
+            content_sha256: string;
+            /** Size Bytes */
+            size_bytes: number;
+            /** Provider Device Id */
+            provider_device_id?: string | null;
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            };
+        };
         /** SyncLocalIdentityResponse */
         SyncLocalIdentityResponse: {
             identity: components["schemas"]["SyncLocalIdentitySchema"];
@@ -1477,7 +1526,39 @@ export interface components {
         SyncProjectStagedImportRequest: {
             manifest: components["schemas"]["SyncProjectManifestSchema"];
             /** Staging Root */
-            staging_root: string;
+            staging_root?: string | null;
+            /** Use Content Addressed Staging */
+            use_content_addressed_staging?: boolean | null;
+        };
+        /** SyncStagedArtifactSchema */
+        SyncStagedArtifactSchema: {
+            /** Content Sha256 */
+            content_sha256: string;
+            /** Size Bytes */
+            size_bytes: number;
+            /** Relative Path */
+            relative_path: string;
+            /** Provider Device Id */
+            provider_device_id?: string | null;
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            };
+            /**
+             * Verified At
+             * Format: date-time
+             */
+            verified_at: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
         };
         /** SyncTrustedPeerCreateRequest */
         SyncTrustedPeerCreateRequest: {
@@ -2835,6 +2916,70 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SyncProjectManifestResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    sync_artifact_stage_api_v1_sync_artifacts_staging_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SyncArtifactStagingRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncStagedArtifactSchema"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    sync_artifact_staging_detail_api_v1_sync_artifacts_staging__content_sha256__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                content_sha256: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncStagedArtifactSchema"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary
- Add content-addressed sync artifact staging storage with SHA-256 verification and database metadata.
- Expose loopback staging upload/lookup endpoints and regenerated shared contracts.
- Let manifest imports consume staged artifact bytes without trusting caller-shaped filesystem paths.
- Closes #114

## Testing
- `cd apps/backend && uv run --python 3.11 pytest tests/test_sync_staging.py tests/test_sync_staging_api.py tests/test_sync_manifest.py tests/test_db_migrations.py::test_sync_artifact_staging_migration_creates_table_and_indexes`
- `cd apps/backend && uv run --python 3.11 pytest tests/test_sync_identity.py tests/test_sync_trust.py`
- `cd apps/backend && uv run --python 3.11 ruff check app/api/routes/sync.py app/models.py app/schemas.py app/services/sync_manifest.py app/services/sync_staging.py tests/test_db_migrations.py tests/test_sync_manifest.py tests/test_sync_staging.py tests/test_sync_staging_api.py`
- `cd apps/backend && uv run --python 3.11 mypy app/api/routes/sync.py app/models.py app/schemas.py app/services/sync_manifest.py app/services/sync_staging.py`
- `pnpm contracts:generate`
- `pnpm --filter @tuneforge/desktop typecheck`
- `git diff --check`