### PR TITLE
feat(sync): add entity revisions

### DIFF
--- a/apps/backend/alembic/versions/0017_sync_entity_revisions.py
+++ b/apps/backend/alembic/versions/0017_sync_entity_revisions.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0017_sync_entity_revisions"
+down_revision = "0016_sync_artifact_staging"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sync_entity_revisions",
+        sa.Column("id", sa.String(length=64), nullable=False),
+        sa.Column("project_id", sa.String(length=80), nullable=False),
+        sa.Column("entity_type", sa.String(length=64), nullable=False),
+        sa.Column("entity_id", sa.String(length=80), nullable=False),
+        sa.Column("revision_type", sa.String(length=32), nullable=False),
+        sa.Column("base_revision_id", sa.String(length=64), nullable=True),
+        sa.Column("source_artifact_id", sa.String(length=32), nullable=True),
+        sa.Column("content_sha256", sa.String(length=64), nullable=False),
+        sa.Column("author_device_id", sa.String(length=96), nullable=False),
+        sa.Column("state", sa.String(length=32), nullable=False, server_default="active"),
+        sa.Column("metadata_json", sa.JSON(), nullable=False, server_default="{}"),
+        sa.Column("payload_json", sa.JSON(), nullable=False, server_default="{}"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "length(content_sha256) = 64",
+            name="ck_sync_entity_revisions_sha256_len",
+        ),
+        sa.ForeignKeyConstraint(["base_revision_id"], ["sync_entity_revisions.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["source_artifact_id"], ["artifacts.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_sync_entity_revisions_project_entity",
+        "sync_entity_revisions",
+        ["project_id", "entity_type", "entity_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_sync_entity_revisions_base_revision_id",
+        "sync_entity_revisions",
+        ["base_revision_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_sync_entity_revisions_author_device_id",
+        "sync_entity_revisions",
+        ["author_device_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_sync_entity_revisions_state",
+        "sync_entity_revisions",
+        ["state"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_sync_entity_revisions_state", table_name="sync_entity_revisions")
+    op.drop_index("ix_sync_entity_revisions_author_device_id", table_name="sync_entity_revisions")
+    op.drop_index("ix_sync_entity_revisions_base_revision_id", table_name="sync_entity_revisions")
+    op.drop_index("ix_sync_entity_revisions_project_entity", table_name="sync_entity_revisions")
+    op.drop_table("sync_entity_revisions")

--- a/apps/backend/app/models.py
+++ b/apps/backend/app/models.py
@@ -50,6 +50,9 @@ class Project(Base):
     artifacts: Mapped[list[Artifact]] = relationship(
         back_populates="project", cascade="all, delete-orphan"
     )
+    sync_entity_revisions: Mapped[list[SyncEntityRevision]] = relationship(
+        back_populates="project", cascade="all, delete-orphan"
+    )
     jobs: Mapped[list[Job]] = relationship(back_populates="project", cascade="all, delete-orphan")
 
 
@@ -130,6 +133,50 @@ class SyncStagedArtifact(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=utcnow, onupdate=utcnow
     )
+
+
+class SyncEntityRevision(Base):
+    __tablename__ = "sync_entity_revisions"
+    __table_args__ = (
+        CheckConstraint(
+            "length(content_sha256) = 64",
+            name="ck_sync_entity_revisions_sha256_len",
+        ),
+        Index(
+            "ix_sync_entity_revisions_project_entity",
+            "project_id",
+            "entity_type",
+            "entity_id",
+        ),
+        Index("ix_sync_entity_revisions_base_revision_id", "base_revision_id"),
+        Index("ix_sync_entity_revisions_author_device_id", "author_device_id"),
+        Index("ix_sync_entity_revisions_state", "state"),
+    )
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    project_id: Mapped[str] = mapped_column(
+        String(PROJECT_ID_LENGTH), ForeignKey("projects.id", ondelete="CASCADE")
+    )
+    entity_type: Mapped[str] = mapped_column(String(64))
+    entity_id: Mapped[str] = mapped_column(String(PROJECT_ID_LENGTH))
+    revision_type: Mapped[str] = mapped_column(String(32))
+    base_revision_id: Mapped[str | None] = mapped_column(
+        String(64), ForeignKey("sync_entity_revisions.id", ondelete="SET NULL"), nullable=True
+    )
+    source_artifact_id: Mapped[str | None] = mapped_column(
+        String(32), ForeignKey("artifacts.id", ondelete="SET NULL"), nullable=True
+    )
+    content_sha256: Mapped[str] = mapped_column(String(64))
+    author_device_id: Mapped[str] = mapped_column(String(96))
+    state: Mapped[str] = mapped_column(String(32), default="active")
+    metadata_json: Mapped[dict[str, Any]] = mapped_column(JSON(), default=dict)
+    payload_json: Mapped[dict[str, Any]] = mapped_column(JSON(), default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow, onupdate=utcnow
+    )
+
+    project: Mapped[Project] = relationship(back_populates="sync_entity_revisions")
 
 
 class AnalysisResult(Base):

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -266,12 +266,32 @@ class SyncProjectManifestArtifactSchema(BaseModel):
     created_at: datetime
 
 
+class SyncProjectManifestEntityRevisionSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    revision_id: str
+    project_id: str
+    entity_type: str
+    entity_id: str
+    revision_type: str
+    base_revision_id: str | None
+    author_device_id: str
+    source_artifact_id: str | None
+    content_sha256: str
+    state: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    payload: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime
+    updated_at: datetime
+
+
 class SyncProjectManifestSchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     schema_version: str
     exported_at: datetime
     project: SyncProjectManifestProjectSchema
+    entity_revisions: list[SyncProjectManifestEntityRevisionSchema] = Field(default_factory=list)
     artifacts: list[SyncProjectManifestArtifactSchema]
 
 

--- a/apps/backend/app/services/chords.py
+++ b/apps/backend/app/services/chords.py
@@ -20,6 +20,7 @@ from app.services.chord_backends import (
 )
 from app.services.paths import project_analysis_dir
 from app.services.stem_models import NON_VOCAL_SIX_STEM_SOURCES, model_output_artifact_type
+from app.services.sync_revisions import record_chord_revision
 from app.services.tab_state import clear_project_tab_state
 
 
@@ -87,6 +88,7 @@ def detect_project_chords(
     existing.updated_at = updated_at
     session.flush()
     session.refresh(existing)
+    record_chord_revision(session, chords=existing, revision_type="generated")
 
     chord_path = project_analysis_dir(project.id) / "chords.json"
     chord_path.write_text(

--- a/apps/backend/app/services/lyrics.py
+++ b/apps/backend/app/services/lyrics.py
@@ -16,6 +16,7 @@ from app.errors import AppError
 from app.models import Artifact, LyricsTranscript, Project
 from app.schemas import LyricsEditSegmentSchema
 from app.services.paths import project_analysis_dir
+from app.services.sync_revisions import record_lyrics_revision
 from app.services.tab_state import clear_project_tab_state
 
 WORD_RE = re.compile(r"\S+")
@@ -82,6 +83,7 @@ def generate_project_lyrics(session: Session, *, project: Project, force: bool =
     existing.has_user_edits = False
     session.flush()
     session.refresh(existing)
+    record_lyrics_revision(session, lyrics=existing, revision_type="generated")
 
     _write_lyrics_snapshot(project_id=project.id, lyrics=existing)
     return existing
@@ -129,6 +131,8 @@ def update_project_lyrics(
     lyrics.has_user_edits = updated_segments != source_segments
     session.flush()
     session.refresh(lyrics)
+    if updated_segments != current_segments:
+        record_lyrics_revision(session, lyrics=lyrics, revision_type="user_edit")
     _write_lyrics_snapshot(project_id=project.id, lyrics=lyrics)
     return lyrics
 
@@ -143,10 +147,13 @@ def persist_project_lyrics_segments(
     if lyrics is None:
         raise AppError("LYRICS_NOT_FOUND", "Lyrics have not been generated for this project.", status_code=404)
 
+    current_segments = lyrics.segments_json
     lyrics.segments_json = cast(list[dict[str, Any]], deepcopy(segments))
     lyrics.has_user_edits = lyrics.segments_json != lyrics.source_segments_json
     session.flush()
     session.refresh(lyrics)
+    if lyrics.segments_json != current_segments:
+        record_lyrics_revision(session, lyrics=lyrics, revision_type="user_edit")
     _write_lyrics_snapshot(project_id=project_id, lyrics=lyrics)
     return lyrics
 

--- a/apps/backend/app/services/projects.py
+++ b/apps/backend/app/services/projects.py
@@ -15,6 +15,7 @@ from app.services.artifacts import register_artifact
 from app.services.metadata import extract_audio_metadata, normalize_media_to_wav
 from app.services.paths import ensure_project_dirs, project_root, project_source_dir
 from app.services.sync_identity import source_hash_to_project_id
+from app.services.sync_revisions import record_project_metadata_revision
 from app.utils.hashing import file_sha256
 
 NORMALIZED_IMPORT_FORMATS = {"mp4", "webm"}
@@ -186,12 +187,23 @@ def delete_project(session: Session, project_id: str) -> None:
 
 def update_project(session: Session, project_id: str, *, updates: dict[str, str | None]) -> Project:
     project = get_project(session, project_id)
+    metadata_changed = False
     if "display_name" in updates:
         display_name = updates["display_name"]
         if display_name is not None:
-            project.display_name = display_name.strip()
+            normalized_display_name = display_name.strip()
+            if project.display_name != normalized_display_name:
+                project.display_name = normalized_display_name
+                metadata_changed = True
     if "source_key_override" in updates:
         source_key_override = updates["source_key_override"]
-        project.source_key_override = source_key_override.strip() if isinstance(source_key_override, str) else None
+        normalized_source_key_override = (
+            source_key_override.strip() if isinstance(source_key_override, str) else None
+        )
+        if project.source_key_override != normalized_source_key_override:
+            project.source_key_override = normalized_source_key_override
+            metadata_changed = True
     session.flush()
+    if metadata_changed:
+        record_project_metadata_revision(session, project=project, revision_type="metadata_change")
     return project

--- a/apps/backend/app/services/sync_manifest.py
+++ b/apps/backend/app/services/sync_manifest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import shutil
 from collections.abc import Mapping
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
@@ -13,11 +14,16 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.errors import AppError
-from app.models import Artifact, Project
+from app.models import Artifact, ChordTimeline, LyricsTranscript, Project, SongSection, SyncEntityRevision
 from app.services.artifacts import register_artifact
 from app.services.paths import ensure_project_dirs, project_root
 from app.services.sync_identity import source_hash_to_project_id
 from app.services.sync_metadata import project_relative_artifact_path, sanitize_sync_metadata
+from app.services.sync_revisions import (
+    CURRENT_REVISION_STATE,
+    revision_payload_sha256,
+    sanitize_revision_payload,
+)
 from app.utils.hashing import file_sha256
 
 SYNC_PROJECT_MANIFEST_SCHEMA_VERSION = "1"
@@ -41,6 +47,24 @@ class SyncArtifactManifest:
 
 
 @dataclass(frozen=True)
+class SyncEntityRevisionManifest:
+    revision_id: str
+    project_id: str
+    entity_type: str
+    entity_id: str
+    revision_type: str
+    base_revision_id: str | None
+    author_device_id: str
+    source_artifact_id: str | None
+    content_sha256: str
+    state: str
+    metadata: dict[str, Any]
+    payload: dict[str, Any]
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
 class SyncProjectManifestProject:
     project_id: str
     display_name: str
@@ -58,6 +82,7 @@ class SyncProjectManifest:
     schema_version: str
     exported_at: datetime
     project: SyncProjectManifestProject
+    entity_revisions: list[SyncEntityRevisionManifest]
     artifacts: list[SyncArtifactManifest]
 
     @property
@@ -120,6 +145,7 @@ def export_project_manifest(session: Session, project_id: str) -> SyncProjectMan
             .order_by(Artifact.created_at.asc(), Artifact.id.asc())
         )
     )
+    entity_revisions = _list_project_entity_revisions(session, project_id=project.id)
 
     manifest = SyncProjectManifest(
         schema_version=SYNC_PROJECT_MANIFEST_SCHEMA_VERSION,
@@ -135,6 +161,10 @@ def export_project_manifest(session: Session, project_id: str) -> SyncProjectMan
             created_at=project.created_at,
             updated_at=project.updated_at,
         ),
+        entity_revisions=[
+            _export_entity_revision_manifest(revision)
+            for revision in entity_revisions
+        ],
         artifacts=[_export_artifact_manifest(artifact) for artifact in artifacts],
     )
     _validate_source_artifact_matches_project_source(manifest)
@@ -231,6 +261,8 @@ def import_staged_project_manifest(
                     "A copied artifact file does not match its manifest.",
                     details={"artifact_id": verified_artifact.manifest.artifact_id},
                 )
+        _import_entity_revisions(session, project_manifest)
+        _hydrate_current_entity_revisions(session, project, project_manifest.entity_revisions)
     except OSError as exc:
         _cleanup_copied_artifacts(copied_paths, root)
         raise AppError(
@@ -252,6 +284,25 @@ def import_staged_project_manifest(
         raise
 
     return project
+
+
+def _list_project_entity_revisions(
+    session: Session,
+    *,
+    project_id: str,
+) -> list[SyncEntityRevision]:
+    return list(
+        session.scalars(
+            select(SyncEntityRevision)
+            .where(SyncEntityRevision.project_id == project_id)
+            .order_by(
+                SyncEntityRevision.entity_type.asc(),
+                SyncEntityRevision.entity_id.asc(),
+                SyncEntityRevision.created_at.asc(),
+                SyncEntityRevision.id.asc(),
+            )
+        )
+    )
 
 
 def _export_artifact_manifest(artifact: Artifact) -> SyncArtifactManifest:
@@ -323,6 +374,315 @@ def _export_artifact_manifest(artifact: Artifact) -> SyncArtifactManifest:
         metadata=cast(dict[str, Any], sanitize_sync_metadata(artifact.metadata_json or {})),
         created_at=artifact.created_at,
     )
+
+
+def _export_entity_revision_manifest(revision: SyncEntityRevision) -> SyncEntityRevisionManifest:
+    metadata = sanitize_revision_payload(revision.metadata_json or {})
+    payload = sanitize_revision_payload(revision.payload_json or {})
+    return SyncEntityRevisionManifest(
+        revision_id=revision.id,
+        project_id=revision.project_id,
+        entity_type=revision.entity_type,
+        entity_id=revision.entity_id,
+        revision_type=revision.revision_type,
+        base_revision_id=revision.base_revision_id,
+        author_device_id=revision.author_device_id,
+        source_artifact_id=revision.source_artifact_id,
+        content_sha256=revision_payload_sha256(payload),
+        state=revision.state,
+        metadata=metadata,
+        payload=payload,
+        created_at=revision.created_at,
+        updated_at=revision.updated_at,
+    )
+
+
+def _import_entity_revisions(session: Session, manifest: SyncProjectManifest) -> None:
+    if not manifest.entity_revisions:
+        return
+
+    seen_revision_ids: set[str] = set()
+    manifest_revisions_by_id = {
+        revision.revision_id: revision for revision in manifest.entity_revisions
+    }
+    for revision in manifest.entity_revisions:
+        if revision.project_id != manifest.project_id:
+            raise AppError(
+                "SYNC_MANIFEST_ENTITY_REVISION_PROJECT_MISMATCH",
+                "Entity revision manifest belongs to a different project.",
+                details={
+                    "revision_id": revision.revision_id,
+                    "project_id": revision.project_id,
+                },
+            )
+        if revision.revision_id in seen_revision_ids:
+            raise AppError(
+                "SYNC_MANIFEST_DUPLICATE_ENTITY_REVISION",
+                "Project manifest contains duplicate entity revision IDs.",
+                details={"revision_id": revision.revision_id},
+            )
+        seen_revision_ids.add(revision.revision_id)
+
+        _validate_entity_revision_base_reference(session, manifest.project_id, revision, manifest_revisions_by_id)
+        _validate_entity_revision_source_artifact_reference(session, manifest.project_id, revision)
+
+
+        if session.get(SyncEntityRevision, revision.revision_id) is not None:
+            raise AppError(
+                "SYNC_MANIFEST_ENTITY_REVISION_CONFLICT",
+                "A synced entity revision conflicts with an existing local revision.",
+                status_code=status.HTTP_409_CONFLICT,
+                details={"revision_id": revision.revision_id},
+            )
+
+    for revision in _entity_revisions_in_dependency_order(manifest.entity_revisions):
+        row = SyncEntityRevision(
+            id=revision.revision_id,
+            project_id=revision.project_id,
+            entity_type=revision.entity_type,
+            entity_id=revision.entity_id,
+            revision_type=revision.revision_type,
+            base_revision_id=revision.base_revision_id,
+            author_device_id=revision.author_device_id,
+            source_artifact_id=revision.source_artifact_id,
+            content_sha256=revision.content_sha256,
+            state=_normalize_revision_state(revision.state),
+            metadata_json=deepcopy(revision.metadata),
+            payload_json=deepcopy(revision.payload),
+            created_at=revision.created_at,
+            updated_at=revision.updated_at,
+        )
+        session.add(row)
+
+    session.flush()
+
+
+def _validate_entity_revision_base_reference(
+    session: Session,
+    project_id: str,
+    revision: SyncEntityRevisionManifest,
+    manifest_revisions_by_id: dict[str, SyncEntityRevisionManifest],
+) -> None:
+    if revision.base_revision_id is None:
+        return
+
+    manifest_base = manifest_revisions_by_id.get(revision.base_revision_id)
+    if manifest_base is not None:
+        if (
+            manifest_base.project_id != project_id
+            or manifest_base.entity_type != revision.entity_type
+            or manifest_base.entity_id != revision.entity_id
+        ):
+            raise _invalid_manifest(
+                "Entity revision base_revision_id must reference the same project entity."
+            )
+        return
+
+    existing_base = session.get(SyncEntityRevision, revision.base_revision_id)
+    if existing_base is None:
+        raise _invalid_manifest("Entity revision base_revision_id does not exist in the manifest.")
+    if (
+        existing_base.project_id != project_id
+        or existing_base.entity_type != revision.entity_type
+        or existing_base.entity_id != revision.entity_id
+    ):
+        raise _invalid_manifest("Entity revision base_revision_id must reference the same project entity.")
+
+
+def _validate_entity_revision_source_artifact_reference(
+    session: Session,
+    project_id: str,
+    revision: SyncEntityRevisionManifest,
+) -> None:
+    if revision.source_artifact_id is None:
+        return
+    artifact = session.get(Artifact, revision.source_artifact_id)
+    if artifact is None:
+        raise _invalid_manifest("Entity revision source_artifact_id does not exist in the manifest.")
+    if artifact.project_id != project_id:
+        raise _invalid_manifest("Entity revision source_artifact_id must belong to the manifest project.")
+
+
+def _entity_revisions_in_dependency_order(
+    revisions: list[SyncEntityRevisionManifest],
+) -> list[SyncEntityRevisionManifest]:
+    pending = {revision.revision_id: revision for revision in revisions}
+    ordered: list[SyncEntityRevisionManifest] = []
+    while pending:
+        ready = sorted(
+            (
+                revision
+                for revision in pending.values()
+                if revision.base_revision_id not in pending
+            ),
+            key=_entity_revision_sort_key,
+        )
+        if not ready:
+            raise _invalid_manifest("Entity revision base_revision_id contains a cycle.")
+        for revision in ready:
+            ordered.append(revision)
+            del pending[revision.revision_id]
+    return ordered
+
+
+def _entity_revision_sort_key(revision: SyncEntityRevisionManifest) -> tuple[str, str, datetime, str]:
+    return (
+        revision.entity_type,
+        revision.entity_id,
+        revision.created_at,
+        revision.revision_id,
+    )
+
+
+def _hydrate_current_entity_revisions(
+    session: Session,
+    project: Project,
+    revisions: list[SyncEntityRevisionManifest],
+) -> None:
+    current_revisions = [
+        revision for revision in revisions if _is_current_revision_state(revision.state)
+    ]
+    singleton_current: set[str] = set()
+    section_ids: set[str] = set()
+    for revision in current_revisions:
+        if revision.entity_type in {"project_metadata", "chords", "lyrics"}:
+            if revision.entity_type in singleton_current:
+                raise _invalid_manifest(
+                    f"Project manifest contains multiple current {revision.entity_type} revisions."
+                )
+            singleton_current.add(revision.entity_type)
+        elif revision.entity_type == "section":
+            if revision.entity_id in section_ids:
+                raise _invalid_manifest(
+                    "Project manifest contains multiple current section revisions for the same entity."
+                )
+            section_ids.add(revision.entity_id)
+
+    for revision in current_revisions:
+        if revision.entity_type == "project_metadata":
+            _hydrate_project_metadata_revision(project, revision)
+        elif revision.entity_type == "chords":
+            _hydrate_chord_revision(session, project, revision)
+        elif revision.entity_type == "lyrics":
+            _hydrate_lyrics_revision(session, project, revision)
+        elif revision.entity_type == "section":
+            _hydrate_section_revision(session, project, revision)
+
+    session.flush()
+
+
+def _is_current_revision_state(state: str) -> bool:
+    return _normalize_revision_state(state) == CURRENT_REVISION_STATE
+
+
+def _normalize_revision_state(state: str) -> str:
+    normalized = state.strip().lower()
+    if normalized == "current":
+        return CURRENT_REVISION_STATE
+    return normalized
+
+
+def _hydrate_project_metadata_revision(
+    project: Project,
+    revision: SyncEntityRevisionManifest,
+) -> None:
+    payload = revision.payload
+    if "display_name" in payload:
+        display_name = payload["display_name"]
+        if not isinstance(display_name, str) or not display_name.strip():
+            raise _invalid_manifest("Project metadata revision display_name must be a non-empty string.")
+        project.display_name = display_name.strip()
+    if "source_key_override" in payload:
+        source_key_override = payload["source_key_override"]
+        if source_key_override is not None and not isinstance(source_key_override, str):
+            raise _invalid_manifest("Project metadata revision source_key_override must be a string or null.")
+        project.source_key_override = source_key_override
+    project.updated_at = revision.updated_at
+
+
+def _hydrate_chord_revision(
+    session: Session,
+    project: Project,
+    revision: SyncEntityRevisionManifest,
+) -> None:
+    payload = revision.payload
+    chords = session.get(ChordTimeline, project.id)
+    if chords is None:
+        chords = ChordTimeline(project_id=project.id, created_at=revision.created_at)
+        session.add(chords)
+
+    segments = _payload_list(payload, ("segments", "segments_json", "timeline"))
+    timeline = _payload_list(payload, ("timeline", "timeline_json"), default=segments)
+    chords.backend = _payload_optional_str(payload, "backend") or "default"
+    chords.source_artifact_id = _payload_optional_str(payload, "source_artifact_id") or revision.source_artifact_id
+    chords.source_segments_json = _payload_list(payload, ("source_segments", "source_segments_json"))
+    chords.segments_json = segments
+    chords.timeline_json = timeline
+    chords.source_kind = _payload_optional_str(payload, "source_kind") or "generated"
+    chords.has_user_edits = _payload_bool(payload, "has_user_edits", default=False)
+    chords.metadata_json = _payload_mapping(
+        payload,
+        ("metadata", "metadata_json"),
+        default=revision.metadata,
+    )
+    chords.created_at = _payload_datetime(payload, "created_at") or revision.created_at
+    chords.updated_at = _payload_datetime(payload, "updated_at") or revision.updated_at
+
+
+def _hydrate_lyrics_revision(
+    session: Session,
+    project: Project,
+    revision: SyncEntityRevisionManifest,
+) -> None:
+    payload = revision.payload
+    lyrics = session.get(LyricsTranscript, project.id)
+    if lyrics is None:
+        lyrics = LyricsTranscript(project_id=project.id, created_at=revision.created_at)
+        session.add(lyrics)
+
+    lyrics.backend = _payload_optional_str(payload, "backend") or "openai-whisper"
+    lyrics.source_artifact_id = _payload_optional_str(payload, "source_artifact_id") or revision.source_artifact_id
+    lyrics.source_kind = _payload_optional_str(payload, "source_kind") or "ai"
+    lyrics.requested_device = _payload_optional_str(payload, "requested_device")
+    lyrics.device = _payload_optional_str(payload, "device")
+    lyrics.model_name = _payload_optional_str(payload, "model_name")
+    lyrics.language = _payload_optional_str(payload, "language")
+    lyrics.source_segments_json = _payload_list(payload, ("source_segments", "source_segments_json"))
+    lyrics.segments_json = _payload_list(payload, ("segments", "segments_json"))
+    lyrics.has_user_edits = _payload_bool(payload, "has_user_edits", default=False)
+    lyrics.created_at = _payload_datetime(payload, "created_at") or revision.created_at
+    lyrics.updated_at = _payload_datetime(payload, "updated_at") or revision.updated_at
+
+
+def _hydrate_section_revision(
+    session: Session,
+    project: Project,
+    revision: SyncEntityRevisionManifest,
+) -> None:
+    payload = revision.payload
+    section_id = _payload_optional_str(payload, "id") or revision.entity_id
+    if section_id != revision.entity_id:
+        raise _invalid_manifest("Section revision payload id must match entity_id.")
+    label = _payload_optional_str(payload, "label")
+    if label is None or not label.strip():
+        raise _invalid_manifest("Section revision label must be a non-empty string.")
+
+    section = session.get(SongSection, section_id)
+    if section is not None and section.project_id != project.id:
+        raise _invalid_manifest("Section revision conflicts with another project.")
+    if section is None:
+        section = SongSection(id=section_id, project_id=project.id, created_at=revision.created_at)
+        session.add(section)
+
+    section.project_id = project.id
+    section.tab_import_id = _payload_optional_str(payload, "tab_import_id")
+    section.label = label.strip()
+    section.start_seconds = _payload_optional_float(payload, "start_seconds")
+    section.end_seconds = _payload_optional_float(payload, "end_seconds")
+    section.source = _payload_optional_str(payload, "source") or "sync"
+    section.metadata_json = _payload_mapping(payload, ("metadata", "metadata_json"))
+    section.created_at = _payload_datetime(payload, "created_at") or revision.created_at
+    section.updated_at = _payload_datetime(payload, "updated_at") or revision.updated_at
 
 
 def _verify_staged_artifacts(
@@ -589,6 +949,9 @@ def _coerce_project_manifest(manifest: SyncProjectManifest | Mapping[str, Any] |
     raw_artifacts = _field(manifest, "artifacts")
     if not isinstance(raw_artifacts, list):
         raise _invalid_manifest("Project manifest artifacts must be a list.")
+    raw_entity_revisions = _field(manifest, "entity_revisions", default=[])
+    if not isinstance(raw_entity_revisions, list):
+        raise _invalid_manifest("Project manifest entity_revisions must be a list.")
 
     project_id = _required_str(project_fields, "project_id")
     source_sha256 = _required_str(project_fields, "source_sha256").strip().lower()
@@ -607,6 +970,10 @@ def _coerce_project_manifest(manifest: SyncProjectManifest | Mapping[str, Any] |
             created_at=_required_datetime(project_fields, "created_at"),
             updated_at=_required_datetime(project_fields, "updated_at"),
         ),
+        entity_revisions=[
+            _coerce_entity_revision_manifest(revision)
+            for revision in raw_entity_revisions
+        ],
         artifacts=[_coerce_artifact_manifest(artifact) for artifact in raw_artifacts],
     )
     _validate_project_manifest_identity(project_manifest)
@@ -640,6 +1007,114 @@ def _coerce_artifact_manifest(manifest: Mapping[str, Any] | object) -> SyncArtif
         metadata=metadata,
         created_at=_required_datetime(manifest, "created_at"),
     )
+
+
+def _coerce_entity_revision_manifest(manifest: Mapping[str, Any] | object) -> SyncEntityRevisionManifest:
+    content_sha256 = _required_str(manifest, "content_sha256").strip().lower()
+    if not _is_sha256(content_sha256):
+        raise _invalid_manifest("Entity revision manifest content_sha256 must be a full SHA-256 hex digest.")
+
+    metadata = _field(manifest, "metadata", default={})
+    if not isinstance(metadata, dict):
+        raise _invalid_manifest("Entity revision manifest metadata must be an object.")
+    payload = _field(manifest, "payload", default={})
+    if not isinstance(payload, dict):
+        raise _invalid_manifest("Entity revision manifest payload must be an object.")
+    safe_metadata = sanitize_revision_payload(metadata)
+    safe_payload = sanitize_revision_payload(payload)
+    if safe_metadata != metadata or safe_payload != payload:
+        raise _invalid_manifest(
+            "Entity revision manifest metadata and payload must be sync-safe."
+        )
+    if content_sha256 != revision_payload_sha256(safe_payload):
+        raise _invalid_manifest("Entity revision manifest content_sha256 must match payload.")
+
+    return SyncEntityRevisionManifest(
+        revision_id=_required_str(manifest, "revision_id"),
+        project_id=_required_str(manifest, "project_id"),
+        entity_type=_required_str(manifest, "entity_type"),
+        entity_id=_required_str(manifest, "entity_id"),
+        revision_type=_required_str(manifest, "revision_type"),
+        base_revision_id=_optional_str(manifest, "base_revision_id"),
+        author_device_id=_required_str(manifest, "author_device_id"),
+        source_artifact_id=_optional_str(manifest, "source_artifact_id"),
+        content_sha256=content_sha256,
+        state=_normalize_revision_state(_required_str(manifest, "state")),
+        metadata=safe_metadata,
+        payload=safe_payload,
+        created_at=_required_datetime(manifest, "created_at"),
+        updated_at=_required_datetime(manifest, "updated_at"),
+    )
+
+
+def _payload_optional_str(payload: Mapping[str, Any], name: str) -> str | None:
+    value = payload.get(name)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise _invalid_manifest(f"Entity revision payload field must be a string or null: {name}.")
+    return value
+
+
+def _payload_bool(payload: Mapping[str, Any], name: str, *, default: bool) -> bool:
+    value = payload.get(name, default)
+    if not isinstance(value, bool):
+        raise _invalid_manifest(f"Entity revision payload field must be a boolean: {name}.")
+    return value
+
+
+def _payload_optional_float(payload: Mapping[str, Any], name: str) -> float | None:
+    value = payload.get(name)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise _invalid_manifest(f"Entity revision payload field must be numeric or null: {name}.")
+    return float(value)
+
+
+def _payload_list(
+    payload: Mapping[str, Any],
+    names: tuple[str, ...],
+    *,
+    default: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    value = _payload_first(payload, names, default=[] if default is None else default)
+    if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+        raise _invalid_manifest(f"Entity revision payload field must be a list of objects: {names[0]}.")
+    return cast(list[dict[str, Any]], deepcopy(value))
+
+
+def _payload_mapping(
+    payload: Mapping[str, Any],
+    names: tuple[str, ...],
+    *,
+    default: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    value = _payload_first(payload, names, default={} if default is None else default)
+    if not isinstance(value, dict):
+        raise _invalid_manifest(f"Entity revision payload field must be an object: {names[0]}.")
+    return cast(dict[str, Any], deepcopy(value))
+
+
+def _payload_datetime(payload: Mapping[str, Any], name: str) -> datetime | None:
+    value = payload.get(name)
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise _invalid_manifest(f"Entity revision payload field must be an ISO datetime: {name}.") from exc
+    raise _invalid_manifest(f"Entity revision payload field must be a datetime or null: {name}.")
+
+
+def _payload_first(payload: Mapping[str, Any], names: tuple[str, ...], *, default: Any) -> Any:
+    for name in names:
+        if name in payload:
+            return payload[name]
+    return default
 
 
 def _field(source: Mapping[str, Any] | object, name: str, *, default: Any = ...) -> Any:

--- a/apps/backend/app/services/sync_revisions.py
+++ b/apps/backend/app/services/sync_revisions.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import PurePosixPath
+from typing import Any, TypeAlias, cast
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models import ChordTimeline, LyricsTranscript, Project, SongSection, SyncEntityRevision, utcnow
+from app.services.sync_metadata import sanitize_sync_metadata
+from app.services.sync_trust import get_or_create_local_identity
+from app.utils.ids import new_id
+
+RevisionPayload: TypeAlias = dict[str, Any]
+
+CURRENT_REVISION_STATE = "active"
+SUPERSEDED_REVISION_STATE = "superseded"
+PROJECT_METADATA_ENTITY_TYPE = "project_metadata"
+CHORDS_ENTITY_TYPE = "chords"
+LYRICS_ENTITY_TYPE = "lyrics"
+SECTION_ENTITY_TYPE = "section"
+REGENERATION_ENTITY_TYPE = "regeneration"
+
+_WINDOWS_ABSOLUTE_PATH_PATTERN = re.compile(r"^[A-Za-z]:[\\/]")
+_UNC_PATH_PATTERN = re.compile(r"^\\\\")
+_DROP = object()
+
+
+def record_project_metadata_revision(
+    session: Session,
+    project: Project,
+    revision_type: str = "metadata_change",
+    base_revision_id: str | None = None,
+) -> SyncEntityRevision:
+    payload = sanitize_revision_payload(
+        {
+            "project_id": project.id,
+            "display_name": project.display_name,
+            "source_key_override": project.source_key_override,
+            "source_sha256": project.source_sha256,
+            "duration_seconds": project.duration_seconds,
+            "sample_rate": project.sample_rate,
+            "channels": project.channels,
+        }
+    )
+    return _record_entity_revision(
+        session,
+        project_id=project.id,
+        entity_type=PROJECT_METADATA_ENTITY_TYPE,
+        entity_id=project.id,
+        revision_type=revision_type,
+        payload=payload,
+        metadata={},
+        source_artifact_id=None,
+        base_revision_id=base_revision_id,
+    )
+
+
+def record_chord_revision(
+    session: Session,
+    chords: ChordTimeline,
+    revision_type: str = "generated",
+    base_revision_id: str | None = None,
+) -> SyncEntityRevision:
+    payload = sanitize_revision_payload(
+        {
+            "project_id": chords.project_id,
+            "backend": chords.backend,
+            "source_kind": chords.source_kind,
+            "has_user_edits": chords.has_user_edits,
+            "source_segments": chords.source_segments_json or [],
+            "segments": chords.segments_json or [],
+            "timeline": chords.timeline_json or [],
+        }
+    )
+    metadata = sanitize_revision_payload(chords.metadata_json or {})
+    return _record_entity_revision(
+        session,
+        project_id=chords.project_id,
+        entity_type=CHORDS_ENTITY_TYPE,
+        entity_id=chords.project_id,
+        revision_type=revision_type,
+        payload=payload,
+        metadata=metadata,
+        source_artifact_id=chords.source_artifact_id,
+        base_revision_id=base_revision_id,
+    )
+
+
+def record_lyrics_revision(
+    session: Session,
+    lyrics: LyricsTranscript,
+    revision_type: str = "generated",
+    base_revision_id: str | None = None,
+) -> SyncEntityRevision:
+    payload = sanitize_revision_payload(
+        {
+            "project_id": lyrics.project_id,
+            "backend": lyrics.backend,
+            "source_kind": lyrics.source_kind,
+            "requested_device": lyrics.requested_device,
+            "device": lyrics.device,
+            "model_name": lyrics.model_name,
+            "language": lyrics.language,
+            "has_user_edits": lyrics.has_user_edits,
+            "source_segments": lyrics.source_segments_json or [],
+            "segments": lyrics.segments_json or [],
+        }
+    )
+    return _record_entity_revision(
+        session,
+        project_id=lyrics.project_id,
+        entity_type=LYRICS_ENTITY_TYPE,
+        entity_id=lyrics.project_id,
+        revision_type=revision_type,
+        payload=payload,
+        metadata={},
+        source_artifact_id=lyrics.source_artifact_id,
+        base_revision_id=base_revision_id,
+    )
+
+
+def record_section_revision(
+    session: Session,
+    section: SongSection,
+    revision_type: str = "user_edit",
+    base_revision_id: str | None = None,
+) -> SyncEntityRevision:
+    payload = sanitize_revision_payload(
+        {
+            "project_id": section.project_id,
+            "section_id": section.id,
+            "label": section.label,
+            "start_seconds": section.start_seconds,
+            "end_seconds": section.end_seconds,
+            "source": section.source,
+            "metadata": section.metadata_json or {},
+        }
+    )
+    return _record_entity_revision(
+        session,
+        project_id=section.project_id,
+        entity_type=SECTION_ENTITY_TYPE,
+        entity_id=section.id,
+        revision_type=revision_type,
+        payload=payload,
+        metadata={},
+        source_artifact_id=None,
+        base_revision_id=base_revision_id,
+    )
+
+
+def record_regeneration_revision(
+    session: Session,
+    *,
+    project_id: str,
+    entity_id: str,
+    revision_type: str = "regenerated",
+    base_revision_id: str | None = None,
+    source_artifact_id: str | None = None,
+    payload: Mapping[str, Any] | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> SyncEntityRevision:
+    revision_payload = sanitize_revision_payload(
+        {
+            "project_id": project_id,
+            "entity_id": entity_id,
+            "payload": dict(payload) if payload is not None else {},
+        }
+    )
+    revision_metadata = sanitize_revision_payload(dict(metadata) if metadata is not None else {})
+    return _record_entity_revision(
+        session,
+        project_id=project_id,
+        entity_type=REGENERATION_ENTITY_TYPE,
+        entity_id=entity_id,
+        revision_type=revision_type,
+        payload=revision_payload,
+        metadata=revision_metadata,
+        source_artifact_id=source_artifact_id,
+        base_revision_id=base_revision_id,
+    )
+
+
+def list_project_entity_revisions(session: Session, project_id: str) -> list[SyncEntityRevision]:
+    revisions = list(
+        session.scalars(
+            select(SyncEntityRevision)
+            .where(SyncEntityRevision.project_id == project_id)
+            .order_by(
+                SyncEntityRevision.entity_type.asc(),
+                SyncEntityRevision.entity_id.asc(),
+                SyncEntityRevision.created_at.desc(),
+                SyncEntityRevision.id.desc(),
+            )
+        )
+    )
+    current_by_entity: dict[tuple[str, str], SyncEntityRevision] = {}
+    for revision in revisions:
+        key = (revision.entity_type, revision.entity_id)
+        existing = current_by_entity.get(key)
+        if existing is None or _revision_precedes_existing(revision, existing):
+            current_by_entity[key] = revision
+
+    return sorted(
+        current_by_entity.values(),
+        key=lambda revision: (revision.entity_type, revision.entity_id),
+    )
+
+
+def current_entity_revision(
+    session: Session,
+    project_id: str,
+    entity_type: str,
+    entity_id: str,
+) -> SyncEntityRevision | None:
+    revisions = list(
+        session.scalars(
+            select(SyncEntityRevision)
+            .where(
+                SyncEntityRevision.project_id == project_id,
+                SyncEntityRevision.entity_type == entity_type,
+                SyncEntityRevision.entity_id == entity_id,
+            )
+            .order_by(SyncEntityRevision.created_at.desc(), SyncEntityRevision.id.desc())
+        )
+    )
+    current_revision: SyncEntityRevision | None = None
+    for revision in revisions:
+        if current_revision is None or _revision_precedes_existing(revision, current_revision):
+            current_revision = revision
+    return current_revision
+
+
+def _record_entity_revision(
+    session: Session,
+    *,
+    project_id: str,
+    entity_type: str,
+    entity_id: str,
+    revision_type: str,
+    payload: RevisionPayload,
+    metadata: RevisionPayload,
+    source_artifact_id: str | None,
+    base_revision_id: str | None,
+) -> SyncEntityRevision:
+    current_revision = current_entity_revision(session, project_id, entity_type, entity_id)
+    resolved_base_revision_id = (
+        base_revision_id
+        if base_revision_id is not None
+        else current_revision.id if current_revision is not None else None
+    )
+    _supersede_current_entity_revisions(session, project_id, entity_type, entity_id)
+
+    now = utcnow()
+    revision = SyncEntityRevision(
+        id=new_id("rev"),
+        project_id=project_id,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        revision_type=revision_type,
+        base_revision_id=resolved_base_revision_id,
+        author_device_id=get_or_create_local_identity(session).device_id,
+        source_artifact_id=source_artifact_id,
+        content_sha256=revision_payload_sha256(payload),
+        state=CURRENT_REVISION_STATE,
+        metadata_json=metadata,
+        payload_json=payload,
+        created_at=now,
+        updated_at=now,
+    )
+    session.add(revision)
+    session.flush()
+    return revision
+
+
+def _supersede_current_entity_revisions(
+    session: Session,
+    project_id: str,
+    entity_type: str,
+    entity_id: str,
+) -> None:
+    now = utcnow()
+    revisions = session.scalars(
+        select(SyncEntityRevision).where(
+            SyncEntityRevision.project_id == project_id,
+            SyncEntityRevision.entity_type == entity_type,
+            SyncEntityRevision.entity_id == entity_id,
+            SyncEntityRevision.state.in_((CURRENT_REVISION_STATE, "current")),
+        )
+    )
+    for revision in revisions:
+        revision.state = SUPERSEDED_REVISION_STATE
+        revision.updated_at = now
+
+
+def sanitize_revision_payload(value: Mapping[str, Any]) -> RevisionPayload:
+    sanitized = _sanitize_sync_safe_value(sanitize_sync_metadata(dict(value)))
+    if not isinstance(sanitized, dict):
+        return {}
+    return cast(RevisionPayload, sanitized)
+
+
+def _sanitize_sync_safe_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        sanitized: dict[str, Any] = {}
+        for key, child in value.items():
+            if not isinstance(key, str) or _is_path_like_key(key):
+                continue
+            sanitized_child = _sanitize_sync_safe_value(child)
+            if sanitized_child is not _DROP:
+                sanitized[key] = sanitized_child
+        return sanitized
+    if isinstance(value, list):
+        sanitized_items = [_sanitize_sync_safe_value(child) for child in value]
+        return [child for child in sanitized_items if child is not _DROP]
+    if isinstance(value, tuple):
+        sanitized_items = [_sanitize_sync_safe_value(child) for child in value]
+        return [child for child in sanitized_items if child is not _DROP]
+    if isinstance(value, datetime):
+        return _as_utc(value).isoformat()
+    if isinstance(value, str) and _looks_like_local_absolute_path(value):
+        return _DROP
+    return value
+
+
+def revision_payload_sha256(payload: RevisionPayload) -> str:
+    return hashlib.sha256(_canonical_json_bytes(payload)).hexdigest()
+
+
+def _canonical_json_bytes(payload: RevisionPayload) -> bytes:
+    return json.dumps(
+        payload,
+        allow_nan=False,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _revision_precedes_existing(
+    candidate: SyncEntityRevision,
+    existing: SyncEntityRevision,
+) -> bool:
+    candidate_rank = _revision_state_rank(candidate.state)
+    existing_rank = _revision_state_rank(existing.state)
+    if candidate_rank != existing_rank:
+        return candidate_rank < existing_rank
+    if candidate.created_at != existing.created_at:
+        return candidate.created_at > existing.created_at
+    if candidate.updated_at != existing.updated_at:
+        return candidate.updated_at > existing.updated_at
+    return candidate.id > existing.id
+
+
+def _revision_state_rank(state: str) -> int:
+    if state in {CURRENT_REVISION_STATE, "current"}:
+        return 0
+    if state == "conflict":
+        return 1
+    if state == SUPERSEDED_REVISION_STATE:
+        return 2
+    return 3
+
+
+def _is_path_like_key(key: str) -> bool:
+    normalized = key.strip().lower().replace("-", "_")
+    compact = normalized.replace("_", "")
+    return normalized == "path" or normalized.endswith("_path") or compact.endswith("path") or compact in {
+        "absolute_path",
+        "local_path",
+        "absolutepath",
+        "localpath",
+    }
+
+
+def _looks_like_local_absolute_path(value: str) -> bool:
+    if value.startswith("~/") or _WINDOWS_ABSOLUTE_PATH_PATTERN.match(value) is not None:
+        return True
+    if _UNC_PATH_PATTERN.match(value) is not None:
+        return True
+    try:
+        return PurePosixPath(value).is_absolute()
+    except ValueError:
+        return False
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)

--- a/apps/backend/app/services/tabs.py
+++ b/apps/backend/app/services/tabs.py
@@ -13,6 +13,11 @@ from app.engines.chord_labels import chord_label_to_segment, parse_chord_label
 from app.errors import AppError
 from app.models import ChordTimeline, LyricsTranscript, Project, SongSection, TabImport, utcnow
 from app.services.lyrics import persist_project_lyrics_segments, retime_lyrics_segment_text
+from app.services.sync_revisions import (
+    record_chord_revision,
+    record_project_metadata_revision,
+    record_section_revision,
+)
 from app.utils.ids import new_id
 
 PARSER_VERSION = "v1"
@@ -132,13 +137,15 @@ def apply_tab_suggestions(
     lyrics = _apply_lyric_suggestions(session, project, accepted_suggestions)
     chords = _apply_chord_suggestions(session, project, accepted_suggestions)
     sections = _apply_section_suggestions(session, project, tab_import, accepted_suggestions)
-    _apply_key_suggestions(project, accepted_suggestions)
+    project_metadata_changed = _apply_key_suggestions(project, accepted_suggestions)
 
     now = utcnow()
     tab_import.status = "applied" if accepted_ids else "reviewed"
     tab_import.updated_at = now
     tab_import.proposal_json = _mark_suggestions(tab_import.proposal_json, set(accepted_ids))
     session.flush()
+    if project_metadata_changed:
+        record_project_metadata_revision(session, project=project, revision_type="metadata_change")
     session.refresh(tab_import)
     if lyrics is not None:
         session.refresh(lyrics)
@@ -788,6 +795,7 @@ def _apply_chord_suggestions(
     chords.has_user_edits = True
     chords.source_kind = "user-edited"
     session.flush()
+    record_chord_revision(session, chords=chords, revision_type="user_edit")
     return chords
 
 
@@ -817,15 +825,21 @@ def _apply_section_suggestions(
         session.add(section)
         created.append(section)
     session.flush()
+    for section in created:
+        record_section_revision(session, section=section, revision_type="user_edit")
     return created
 
 
-def _apply_key_suggestions(project: Project, suggestions: list[dict[str, Any]]) -> None:
+def _apply_key_suggestions(project: Project, suggestions: list[dict[str, Any]]) -> bool:
+    metadata_changed = False
     for suggestion in suggestions:
         payload = suggestion.get("payload", {})
         source_key_override = payload.get("source_key_override")
         if suggestion["kind"] == "key" and isinstance(source_key_override, str):
-            project.source_key_override = source_key_override
+            if project.source_key_override != source_key_override:
+                project.source_key_override = source_key_override
+                metadata_changed = True
+    return metadata_changed
 
 
 def _overlay_chord_segments(

--- a/apps/backend/tests/test_db_migrations.py
+++ b/apps/backend/tests/test_db_migrations.py
@@ -93,6 +93,61 @@ def test_sync_artifact_staging_migration_creates_table_and_indexes() -> None:
     } <= indexes
 
 
+def test_sync_entity_revisions_migration_creates_table_columns_and_indexes() -> None:
+    settings = get_settings()
+    ensure_data_dirs(settings)
+
+    reconfigure_engine(settings)
+    run_migrations(settings)
+
+    with sqlite3.connect(settings.database_path) as connection:
+        tables = {
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+        columns = {
+            row[1]
+            for row in connection.execute("PRAGMA table_info('sync_entity_revisions')")
+        }
+        indexes = {
+            row[1]
+            for row in connection.execute("PRAGMA index_list('sync_entity_revisions')")
+        }
+        project_entity_index_columns = [
+            row[2]
+            for row in connection.execute(
+                "PRAGMA index_info('ix_sync_entity_revisions_project_entity')"
+            )
+        ]
+
+    assert "sync_entity_revisions" in tables
+    assert {
+        "id",
+        "project_id",
+        "entity_type",
+        "entity_id",
+        "revision_type",
+        "base_revision_id",
+        "source_artifact_id",
+        "content_sha256",
+        "author_device_id",
+        "state",
+        "metadata_json",
+        "payload_json",
+        "created_at",
+        "updated_at",
+    } <= columns
+    assert {
+        "ix_sync_entity_revisions_project_entity",
+        "ix_sync_entity_revisions_base_revision_id",
+        "ix_sync_entity_revisions_author_device_id",
+        "ix_sync_entity_revisions_state",
+    } <= indexes
+    assert project_entity_index_columns == ["project_id", "entity_type", "entity_id"]
+
+
 def test_hash_storage_migration_backfills_existing_files(tmp_path: Path) -> None:
     settings = get_settings()
     ensure_data_dirs(settings)

--- a/apps/backend/tests/test_sync_manifest.py
+++ b/apps/backend/tests/test_sync_manifest.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import hashlib
 import importlib
+import json
 import shutil
 from collections.abc import Callable, Iterable, Iterator
 from dataclasses import asdict, dataclass, is_dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -12,9 +15,18 @@ from sqlalchemy import select
 
 from app.db import SessionLocal
 from app.errors import AppError
-from app.models import Artifact, Job, Project
+from app.models import (
+    Artifact,
+    ChordTimeline,
+    Job,
+    LyricsTranscript,
+    Project,
+    SongSection,
+    SyncEntityRevision,
+)
 from app.services.paths import project_root
 from app.services.sync_identity import source_hash_to_project_id
+from app.services.sync_revisions import CURRENT_REVISION_STATE
 from app.utils.hashing import file_sha256
 
 ManifestService = Callable[..., Any]
@@ -87,13 +99,29 @@ def _plain_manifest(value: Any) -> dict[str, Any]:
     if "project" in manifest:
         project = manifest["project"]
         artifacts = manifest.get("artifacts")
+        entity_revisions = manifest.get("entity_revisions", [])
     else:
-        project = {key: child for key, child in manifest.items() if key != "artifacts"}
+        project = {
+            key: child
+            for key, child in manifest.items()
+            if key not in {"artifacts", "entity_revisions"}
+        }
         artifacts = manifest.get("artifacts")
+        entity_revisions = manifest.get("entity_revisions", [])
 
     assert isinstance(project, dict)
     assert isinstance(artifacts, list)
-    return {"project": project, "artifacts": artifacts}
+    assert isinstance(entity_revisions, list)
+    result: dict[str, Any] = {
+        "project": project,
+        "artifacts": artifacts,
+        "entity_revisions": entity_revisions,
+    }
+    if "schema_version" in manifest:
+        result["schema_version"] = manifest["schema_version"]
+    if "exported_at" in manifest:
+        result["exported_at"] = manifest["exported_at"]
+    return result
 
 
 def _iter_strings(value: Any) -> Iterator[str]:
@@ -137,6 +165,11 @@ def _assert_no_local_path_keys(payload: dict[str, Any]) -> None:
 def _artifacts_by_id(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
     artifacts = manifest["artifacts"]
     return {artifact["artifact_id"]: artifact for artifact in artifacts}
+
+
+def _entity_revisions_by_id(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    revisions = manifest["entity_revisions"]
+    return {revision["revision_id"]: revision for revision in revisions}
 
 
 def _write_bytes(path: Path, contents: bytes) -> tuple[str, int]:
@@ -237,6 +270,163 @@ def _create_project_with_artifacts(
     )
 
 
+def _revision_content_hash(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            payload,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _add_entity_revision(
+    session: Any,
+    *,
+    revision_id: str,
+    project_id: str,
+    entity_type: str,
+    entity_id: str,
+    payload: dict[str, Any],
+    revision_type: str = "edit",
+    base_revision_id: str | None = None,
+    source_artifact_id: str | None = None,
+    state: str = CURRENT_REVISION_STATE,
+    metadata: dict[str, Any] | None = None,
+    created_at: datetime | None = None,
+    updated_at: datetime | None = None,
+) -> None:
+    timestamp = created_at or datetime(2026, 1, 1, tzinfo=UTC)
+    session.add(
+        SyncEntityRevision(
+            id=revision_id,
+            project_id=project_id,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            revision_type=revision_type,
+            base_revision_id=base_revision_id,
+            author_device_id="device_alpha",
+            source_artifact_id=source_artifact_id,
+            content_sha256=_revision_content_hash(payload),
+            state=state,
+            metadata_json=metadata or {},
+            payload_json=payload,
+            created_at=timestamp,
+            updated_at=updated_at or timestamp,
+        )
+    )
+
+
+def _add_project_entity_revisions(session: Any, fixture: ManifestProjectFixture) -> None:
+    local_path = str(fixture.external_source_path)
+    _add_entity_revision(
+        session,
+        revision_id="rev_project_metadata_current",
+        project_id=fixture.project_id,
+        entity_type="project_metadata",
+        entity_id=fixture.project_id,
+        payload={
+            "display_name": "Synced Fixture",
+            "source_key_override": "2:major",
+            "source_path": local_path,
+        },
+        metadata={"source_path": local_path, "reason": "rename"},
+    )
+    _add_entity_revision(
+        session,
+        revision_id="rev_chords_previous",
+        project_id=fixture.project_id,
+        entity_type="chords",
+        entity_id="chords",
+        state="superseded",
+        payload={
+            "backend": "tuneforge-fast",
+            "timeline": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "G"}],
+        },
+    )
+    _add_entity_revision(
+        session,
+        revision_id="rev_chords_current",
+        project_id=fixture.project_id,
+        entity_type="chords",
+        entity_id="chords",
+        base_revision_id="rev_chords_previous",
+        source_artifact_id="art_source_audio",
+        payload={
+            "backend": "tuneforge-fast",
+            "source_artifact_id": "art_source_audio",
+            "source_segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "C"}],
+            "timeline": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "Am"}],
+            "has_user_edits": True,
+            "source_kind": "user-edited",
+            "metadata": {"reviewed": True, "source_path": local_path},
+        },
+    )
+    _add_entity_revision(
+        session,
+        revision_id="rev_lyrics_current",
+        project_id=fixture.project_id,
+        entity_type="lyrics",
+        entity_id="lyrics",
+        source_artifact_id="art_source_audio",
+        payload={
+            "backend": "whisper.cpp",
+            "source_artifact_id": "art_source_audio",
+            "source_kind": "user-edited",
+            "language": "en",
+            "source_segments": [
+                {"start_seconds": 0.0, "end_seconds": 1.0, "text": "hello", "words": []}
+            ],
+            "segments": [
+                {"start_seconds": 0.0, "end_seconds": 1.0, "text": "hello sync", "words": []}
+            ],
+            "has_user_edits": True,
+        },
+    )
+    _add_entity_revision(
+        session,
+        revision_id="rev_section_intro",
+        project_id=fixture.project_id,
+        entity_type="section",
+        entity_id="sec_intro",
+        payload={
+            "id": "sec_intro",
+            "label": "Intro",
+            "start_seconds": 0.0,
+            "end_seconds": 4.0,
+            "source": "tab",
+            "metadata": {"color": "blue", "source_path": local_path},
+        },
+    )
+    _add_entity_revision(
+        session,
+        revision_id="rev_section_verse",
+        project_id=fixture.project_id,
+        entity_type="section",
+        entity_id="sec_verse",
+        payload={
+            "id": "sec_verse",
+            "label": "Verse",
+            "start_seconds": 4.0,
+            "end_seconds": 12.0,
+            "source": "tab",
+            "metadata": {"color": "green"},
+        },
+    )
+    _add_entity_revision(
+        session,
+        revision_id="rev_unknown_marker",
+        project_id=fixture.project_id,
+        entity_type="marker",
+        entity_id="marker_one",
+        revision_type="generated",
+        payload={"label": "Marker", "source_path": local_path},
+    )
+    session.commit()
+
+
 def _stage_manifest_files(
     manifest: dict[str, Any],
     *,
@@ -274,11 +464,55 @@ def _stage_manifest_content_addressed_files(
 
 
 def _delete_live_project(session: Any, fixture: ManifestProjectFixture) -> None:
+    revisions = list(
+        session.scalars(
+            select(SyncEntityRevision).where(SyncEntityRevision.project_id == fixture.project_id)
+        )
+    )
+    for revision in revisions:
+        session.delete(revision)
     project = session.get(Project, fixture.project_id)
     assert project is not None
     session.delete(project)
     session.commit()
     shutil.rmtree(fixture.root, ignore_errors=True)
+
+
+def _create_foreign_source_artifact(session: Any, tmp_path: Path) -> str:
+    source_sha256 = "b" * 64
+    project_id = source_hash_to_project_id(source_sha256)
+    foreign_path = tmp_path / "foreign" / "source.wav"
+    content_sha256, size_bytes = _write_bytes(foreign_path, b"foreign source")
+    project = Project(
+        id=project_id,
+        display_name="Foreign Sync Fixture",
+        source_key_override=None,
+        source_sha256=source_sha256,
+        source_path=str(foreign_path),
+        imported_path=str(foreign_path),
+        duration_seconds=1.0,
+        sample_rate=44100,
+        channels=1,
+    )
+    session.add(project)
+    session.flush()
+    artifact_id = "art_foreign_source"
+    session.add(
+        Artifact(
+            id=artifact_id,
+            project_id=project_id,
+            type="source_audio",
+            format="wav",
+            path=str(foreign_path),
+            content_sha256=content_sha256,
+            size_bytes=size_bytes,
+            generated_by="import",
+            can_delete=False,
+            can_regenerate=False,
+        )
+    )
+    session.commit()
+    return artifact_id
 
 
 def test_export_project_manifest_omits_local_paths_and_includes_sync_safe_fields(
@@ -336,6 +570,76 @@ def test_export_project_manifest_omits_local_paths_and_includes_sync_safe_fields
         "stem_model": "htdemucs_6s",
         "source_artifact_id": "art_source_audio",
     }
+
+
+def test_export_project_manifest_includes_entity_revisions_without_local_paths(
+    client: object,
+    tmp_path: Path,
+) -> None:
+    export_manifest, _ = _sync_manifest_services()
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path)
+        _add_project_entity_revisions(session, fixture)
+        manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+
+    _assert_no_absolute_local_paths(manifest, (tmp_path, fixture.root))
+    _assert_no_local_path_keys(manifest)
+
+    revisions = manifest["entity_revisions"]
+    assert [
+        (
+            revision["entity_type"],
+            revision["entity_id"],
+            revision["created_at"],
+            revision["revision_id"],
+        )
+        for revision in revisions
+    ] == sorted(
+        (
+            revision["entity_type"],
+            revision["entity_id"],
+            revision["created_at"],
+            revision["revision_id"],
+        )
+        for revision in revisions
+    )
+
+    by_id = _entity_revisions_by_id(manifest)
+    assert set(by_id) == {
+        "rev_chords_current",
+        "rev_chords_previous",
+        "rev_lyrics_current",
+        "rev_project_metadata_current",
+        "rev_section_intro",
+        "rev_section_verse",
+        "rev_unknown_marker",
+    }
+
+    project_revision = by_id["rev_project_metadata_current"]
+    assert project_revision["project_id"] == fixture.project_id
+    assert project_revision["entity_type"] == "project_metadata"
+    assert project_revision["entity_id"] == fixture.project_id
+    assert project_revision["revision_type"] == "edit"
+    assert project_revision["base_revision_id"] is None
+    assert project_revision["author_device_id"] == "device_alpha"
+    assert project_revision["source_artifact_id"] is None
+    assert project_revision["state"] == CURRENT_REVISION_STATE
+    assert project_revision["payload"] == {
+        "display_name": "Synced Fixture",
+        "source_key_override": "2:major",
+    }
+    assert project_revision["metadata"] == {"reason": "rename"}
+    assert len(project_revision["content_sha256"]) == 64
+    assert "created_at" in project_revision
+    assert "updated_at" in project_revision
+
+    chord_revision = by_id["rev_chords_current"]
+    assert chord_revision["source_artifact_id"] == "art_source_audio"
+    assert chord_revision["base_revision_id"] == "rev_chords_previous"
+    assert chord_revision["payload"]["timeline"] == [
+        {"start_seconds": 0.0, "end_seconds": 1.0, "label": "Am"}
+    ]
+    assert chord_revision["payload"]["metadata"] == {"reviewed": True}
 
 
 @pytest.mark.parametrize("unportable_path", ["outside_project_root", "project_root_directory"])
@@ -499,6 +803,174 @@ def test_import_staged_project_manifest_rewrites_paths_preserves_hashes_and_skip
             session.scalars(select(Job.type).where(Job.project_id == fixture.project_id))
         )
         assert not job_types.intersection({"analyze", "chords"})
+
+
+def test_import_staged_project_manifest_hydrates_current_entity_revisions_and_skips_jobs(
+    client: object,
+    tmp_path: Path,
+) -> None:
+    export_manifest, import_manifest = _sync_manifest_services()
+    staging_root = tmp_path / "staging"
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path)
+        _add_project_entity_revisions(session, fixture)
+        manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+        _stage_manifest_files(manifest, staging_root=staging_root, source_root=fixture.root)
+        _delete_live_project(session, fixture)
+
+        import_manifest(session, manifest=manifest, staging_root=staging_root)
+        session.commit()
+
+        project = session.get(Project, fixture.project_id)
+        assert project is not None
+        assert project.display_name == "Synced Fixture"
+        assert project.source_key_override == "2:major"
+
+        chords = session.get(ChordTimeline, fixture.project_id)
+        assert chords is not None
+        assert chords.backend == "tuneforge-fast"
+        assert chords.source_artifact_id == "art_source_audio"
+        assert chords.source_segments_json == [
+            {"start_seconds": 0.0, "end_seconds": 1.0, "label": "C"}
+        ]
+        assert chords.segments_json == [
+            {"start_seconds": 0.0, "end_seconds": 1.0, "label": "Am"}
+        ]
+        assert chords.timeline_json == chords.segments_json
+        assert chords.has_user_edits is True
+        assert chords.source_kind == "user-edited"
+        assert chords.metadata_json == {"reviewed": True}
+
+        lyrics = session.get(LyricsTranscript, fixture.project_id)
+        assert lyrics is not None
+        assert lyrics.backend == "whisper.cpp"
+        assert lyrics.source_artifact_id == "art_source_audio"
+        assert lyrics.source_kind == "user-edited"
+        assert lyrics.language == "en"
+        assert lyrics.source_segments_json == [
+            {"start_seconds": 0.0, "end_seconds": 1.0, "text": "hello", "words": []}
+        ]
+        assert lyrics.segments_json == [
+            {"start_seconds": 0.0, "end_seconds": 1.0, "text": "hello sync", "words": []}
+        ]
+        assert lyrics.has_user_edits is True
+
+        sections = list(
+            session.scalars(
+                select(SongSection)
+                .where(SongSection.project_id == fixture.project_id)
+                .order_by(SongSection.start_seconds.asc(), SongSection.id.asc())
+            )
+        )
+        assert [section.id for section in sections] == ["sec_intro", "sec_verse"]
+        assert [section.label for section in sections] == ["Intro", "Verse"]
+        assert [section.start_seconds for section in sections] == [0.0, 4.0]
+        assert [section.end_seconds for section in sections] == [4.0, 12.0]
+        assert [section.source for section in sections] == ["tab", "tab"]
+        assert sections[0].metadata_json == {"color": "blue"}
+        assert sections[1].metadata_json == {"color": "green"}
+
+        revision_ids = set(
+            session.scalars(
+                select(SyncEntityRevision.id)
+                .where(SyncEntityRevision.project_id == fixture.project_id)
+            )
+        )
+        assert revision_ids == set(_entity_revisions_by_id(manifest))
+
+        job_types = set(session.scalars(select(Job.type).where(Job.project_id == fixture.project_id)))
+        assert job_types == set()
+
+
+def test_import_staged_project_manifest_rejects_foreign_revision_base(
+    client: object,
+    tmp_path: Path,
+) -> None:
+    export_manifest, import_manifest = _sync_manifest_services()
+    staging_root = tmp_path / "staging"
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path)
+        _add_project_entity_revisions(session, fixture)
+        manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+        _stage_manifest_files(manifest, staging_root=staging_root, source_root=fixture.root)
+        foreign_project_id = source_hash_to_project_id("c" * 64)
+        foreign_source = tmp_path / "foreign-source.wav"
+        session.add(
+            Project(
+                id=foreign_project_id,
+                display_name="Foreign Revision Project",
+                source_key_override=None,
+                source_sha256="c" * 64,
+                source_path=str(foreign_source),
+                imported_path=str(foreign_source),
+            )
+        )
+        _add_entity_revision(
+            session,
+            revision_id="rev_foreign_base",
+            project_id=foreign_project_id,
+            entity_type="chords",
+            entity_id="chords",
+            payload={"timeline": []},
+        )
+        session.commit()
+        _entity_revisions_by_id(manifest)["rev_chords_current"]["base_revision_id"] = "rev_foreign_base"
+        _delete_live_project(session, fixture)
+
+        with pytest.raises(AppError) as exc:
+            import_manifest(session, manifest=manifest, staging_root=staging_root)
+
+    assert exc.value.code == "SYNC_MANIFEST_INVALID"
+    assert "base_revision_id" in exc.value.message
+
+
+def test_import_staged_project_manifest_rejects_foreign_revision_source_artifact(
+    client: object,
+    tmp_path: Path,
+) -> None:
+    export_manifest, import_manifest = _sync_manifest_services()
+    staging_root = tmp_path / "staging"
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path)
+        _add_project_entity_revisions(session, fixture)
+        manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+        _stage_manifest_files(manifest, staging_root=staging_root, source_root=fixture.root)
+        foreign_artifact_id = _create_foreign_source_artifact(session, tmp_path)
+        _entity_revisions_by_id(manifest)["rev_chords_current"]["source_artifact_id"] = foreign_artifact_id
+        _delete_live_project(session, fixture)
+
+        with pytest.raises(AppError) as exc:
+            import_manifest(session, manifest=manifest, staging_root=staging_root)
+
+    assert exc.value.code == "SYNC_MANIFEST_INVALID"
+    assert "source_artifact_id" in exc.value.message
+
+
+def test_import_staged_project_manifest_rejects_non_sync_safe_revision_payload(
+    client: object,
+    tmp_path: Path,
+) -> None:
+    export_manifest, import_manifest = _sync_manifest_services()
+    staging_root = tmp_path / "staging"
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path)
+        _add_project_entity_revisions(session, fixture)
+        manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+        _stage_manifest_files(manifest, staging_root=staging_root, source_root=fixture.root)
+        revision = _entity_revisions_by_id(manifest)["rev_project_metadata_current"]
+        revision["payload"]["source_path"] = str(tmp_path / "peer-local.wav")
+        revision["content_sha256"] = _revision_content_hash(revision["payload"])
+        _delete_live_project(session, fixture)
+
+        with pytest.raises(AppError) as exc:
+            import_manifest(session, manifest=manifest, staging_root=staging_root)
+
+    assert exc.value.code == "SYNC_MANIFEST_INVALID"
+    assert "sync-safe" in exc.value.message
 
 
 def test_import_staged_project_manifest_imports_content_addressed_staging(

--- a/apps/backend/tests/test_sync_revisions.py
+++ b/apps/backend/tests/test_sync_revisions.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.config import ensure_data_dirs, get_settings
+from app.db import SessionLocal, reconfigure_engine, run_migrations
+from app.models import ChordTimeline, LyricsTranscript, Project, SongSection, SyncEntityRevision
+from app.services.sync_identity import source_hash_to_project_id
+from app.services.sync_revisions import (
+    CHORDS_ENTITY_TYPE,
+    CURRENT_REVISION_STATE,
+    LYRICS_ENTITY_TYPE,
+    PROJECT_METADATA_ENTITY_TYPE,
+    SECTION_ENTITY_TYPE,
+    SUPERSEDED_REVISION_STATE,
+    current_entity_revision,
+    list_project_entity_revisions,
+    record_chord_revision,
+    record_lyrics_revision,
+    record_project_metadata_revision,
+    record_section_revision,
+)
+from app.services.sync_trust import get_or_create_local_identity
+
+LOCAL_PATH_KEYS = {
+    "absolute_path",
+    "imported_path",
+    "local_path",
+    "original_copy_path",
+    "path",
+    "playback_path",
+    "render_path",
+    "source_path",
+}
+
+
+@pytest.fixture()
+def db_session() -> Iterator[Session]:
+    settings = get_settings()
+    ensure_data_dirs(settings)
+    reconfigure_engine(settings)
+    run_migrations(settings)
+
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def test_project_metadata_revision_uses_local_identity_and_stable_content_hash(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    project = _create_project(db_session, tmp_path)
+    first_revision = record_project_metadata_revision(db_session, project)
+    db_session.commit()
+    db_session.refresh(first_revision)
+    identity = get_or_create_local_identity(db_session)
+
+    second_revision = record_project_metadata_revision(db_session, project)
+    db_session.commit()
+    db_session.refresh(first_revision)
+    db_session.refresh(second_revision)
+
+    assert first_revision.author_device_id == identity.device_id
+    assert second_revision.author_device_id == identity.device_id
+    assert first_revision.content_sha256 == second_revision.content_sha256
+    assert first_revision.content_sha256 == _canonical_payload_hash(first_revision.payload_json)
+    assert first_revision.state == SUPERSEDED_REVISION_STATE
+    assert second_revision.state == CURRENT_REVISION_STATE
+    assert second_revision.base_revision_id == first_revision.id
+    assert current_entity_revision(
+        db_session,
+        project.id,
+        PROJECT_METADATA_ENTITY_TYPE,
+        project.id,
+    ).id == second_revision.id
+
+
+def test_chord_revision_sanitizes_payload_and_metadata(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    project = _create_project(db_session, tmp_path)
+    chords = ChordTimeline(
+        project_id=project.id,
+        backend="tuneforge-fast",
+        source_artifact_id="art_source",
+        timeline_json=[
+            {
+                "start": 0.0,
+                "end": 1.0,
+                "label": "C",
+                "source_path": str(tmp_path / "timeline-leak.wav"),
+            }
+        ],
+        source_segments_json=[
+            {
+                "start": 0.0,
+                "end": 1.0,
+                "label": "C",
+                "path": str(tmp_path / "source-leak.wav"),
+            }
+        ],
+        segments_json=[
+            {
+                "start": 0.0,
+                "end": 1.0,
+                "label": "C",
+                "note": str(tmp_path / "absolute-string-leak.wav"),
+            }
+        ],
+        source_kind="generated",
+        metadata_json={
+            "model": "tuneforge-fast",
+            "render_path": str(tmp_path / "render.wav"),
+            "nested": {"playback_path": str(tmp_path / "playback.wav"), "confidence": 0.9},
+        },
+    )
+    db_session.add(chords)
+    db_session.flush()
+
+    revision = record_chord_revision(db_session, chords)
+    db_session.commit()
+    db_session.refresh(revision)
+
+    payload = revision.payload_json
+    metadata = revision.metadata_json
+    assert revision.entity_type == CHORDS_ENTITY_TYPE
+    assert revision.entity_id == project.id
+    assert revision.source_artifact_id == "art_source"
+    assert payload["timeline"] == [{"start": 0.0, "end": 1.0, "label": "C"}]
+    assert payload["source_segments"] == [{"start": 0.0, "end": 1.0, "label": "C"}]
+    assert payload["segments"] == [{"start": 0.0, "end": 1.0, "label": "C"}]
+    assert metadata == {"model": "tuneforge-fast", "nested": {"confidence": 0.9}}
+    _assert_sync_safe(payload, tmp_path)
+    _assert_sync_safe(metadata, tmp_path)
+
+
+def test_lyrics_and_section_revisions_are_listed_as_current_project_entities(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    project = _create_project(db_session, tmp_path)
+    lyrics = LyricsTranscript(
+        project_id=project.id,
+        backend="whisper",
+        source_artifact_id="art_source",
+        source_kind="ai",
+        requested_device="cpu",
+        device="cpu",
+        model_name="base",
+        language="en",
+        source_segments_json=[{"start": 0.0, "end": 1.0, "text": "hello"}],
+        segments_json=[{"start": 0.0, "end": 1.0, "text": "hello edit"}],
+        has_user_edits=True,
+    )
+    section = SongSection(
+        id="section_intro",
+        project_id=project.id,
+        label="Intro",
+        start_seconds=0.0,
+        end_seconds=12.0,
+        source="user",
+        metadata_json={"source_path": str(tmp_path / "section-leak.txt"), "color": "blue"},
+    )
+    db_session.add_all([lyrics, section])
+    db_session.flush()
+
+    lyrics_revision = record_lyrics_revision(db_session, lyrics, revision_type="user_edit")
+    section_revision = record_section_revision(db_session, section)
+    db_session.commit()
+    db_session.refresh(lyrics_revision)
+    db_session.refresh(section_revision)
+
+    revisions = list_project_entity_revisions(db_session, project.id)
+    revision_ids = {revision.id for revision in revisions}
+
+    assert revision_ids == {lyrics_revision.id, section_revision.id}
+    assert lyrics_revision.entity_type == LYRICS_ENTITY_TYPE
+    assert lyrics_revision.revision_type == "user_edit"
+    assert lyrics_revision.payload_json["has_user_edits"] is True
+    assert section_revision.entity_type == SECTION_ENTITY_TYPE
+    assert section_revision.payload_json["metadata"] == {"color": "blue"}
+    _assert_sync_safe(section_revision.payload_json, tmp_path)
+
+
+def test_current_revision_lookup_prefers_current_state_then_latest_created_at(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    project = _create_project(db_session, tmp_path)
+    old_time = datetime.now(UTC) - timedelta(minutes=5)
+    new_time = datetime.now(UTC)
+    older_current = _manual_revision(
+        project_id=project.id,
+        revision_id="rev_manual_current",
+        entity_type=CHORDS_ENTITY_TYPE,
+        entity_id=project.id,
+        state=CURRENT_REVISION_STATE,
+        created_at=old_time,
+    )
+    newer_superseded = _manual_revision(
+        project_id=project.id,
+        revision_id="rev_manual_superseded",
+        entity_type=CHORDS_ENTITY_TYPE,
+        entity_id=project.id,
+        state=SUPERSEDED_REVISION_STATE,
+        created_at=new_time,
+    )
+    db_session.add_all([older_current, newer_superseded])
+    db_session.commit()
+
+    assert current_entity_revision(
+        db_session,
+        project.id,
+        CHORDS_ENTITY_TYPE,
+        project.id,
+    ).id == older_current.id
+
+    older_current.state = SUPERSEDED_REVISION_STATE
+    db_session.commit()
+
+    assert current_entity_revision(
+        db_session,
+        project.id,
+        CHORDS_ENTITY_TYPE,
+        project.id,
+    ).id == newer_superseded.id
+
+
+def test_record_revision_supersedes_imported_current_alias(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    project = _create_project(db_session, tmp_path)
+    imported_current = _manual_revision(
+        project_id=project.id,
+        revision_id="rev_imported_current",
+        entity_type=PROJECT_METADATA_ENTITY_TYPE,
+        entity_id=project.id,
+        state="current",
+        created_at=datetime.now(UTC),
+    )
+    db_session.add(imported_current)
+    db_session.commit()
+
+    next_revision = record_project_metadata_revision(db_session, project)
+    db_session.commit()
+    db_session.refresh(imported_current)
+    db_session.refresh(next_revision)
+
+    assert imported_current.state == SUPERSEDED_REVISION_STATE
+    assert next_revision.base_revision_id == imported_current.id
+    assert next_revision.state == CURRENT_REVISION_STATE
+
+
+def _create_project(session: Session, tmp_path: Path) -> Project:
+    source_hash = "a" * 64
+    project_id = source_hash_to_project_id(source_hash)
+    source_path = tmp_path / "library" / "source.wav"
+    imported_path = tmp_path / "app-data" / "source.wav"
+    project = Project(
+        id=project_id,
+        display_name="Sync Revision Fixture",
+        source_key_override="3:major",
+        source_sha256=source_hash,
+        source_path=str(source_path),
+        imported_path=str(imported_path),
+        duration_seconds=10.5,
+        sample_rate=44100,
+        channels=2,
+    )
+    session.add(project)
+    session.flush()
+    return project
+
+
+def _manual_revision(
+    *,
+    project_id: str,
+    revision_id: str,
+    entity_type: str,
+    entity_id: str,
+    state: str,
+    created_at: datetime,
+) -> SyncEntityRevision:
+    payload = {"value": revision_id}
+    return SyncEntityRevision(
+        id=revision_id,
+        project_id=project_id,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        revision_type="manual",
+        base_revision_id=None,
+        author_device_id="dev_manual",
+        source_artifact_id=None,
+        content_sha256=_canonical_payload_hash(payload),
+        state=state,
+        metadata_json={},
+        payload_json=payload,
+        created_at=created_at,
+        updated_at=created_at,
+    )
+
+
+def _canonical_payload_hash(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            payload,
+            allow_nan=False,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _assert_sync_safe(payload: dict[str, Any], local_root: Path) -> None:
+    encoded = json.dumps(payload, sort_keys=True)
+    assert str(local_root) not in encoded
+    leaked_keys = [
+        key
+        for key in _iter_keys(payload)
+        if key in LOCAL_PATH_KEYS or key.endswith("_path")
+    ]
+    assert leaked_keys == []
+    absolute_values = [
+        value
+        for value in _iter_strings(payload)
+        if _looks_like_local_absolute_path(value)
+    ]
+    assert absolute_values == []
+
+
+def _iter_keys(value: Any) -> Iterator[str]:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if isinstance(key, str):
+                yield key
+            yield from _iter_keys(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _iter_keys(child)
+
+
+def _iter_strings(value: Any) -> Iterator[str]:
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for child in value.values():
+            yield from _iter_strings(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _iter_strings(child)
+
+
+def _looks_like_local_absolute_path(value: str) -> bool:
+    return value.startswith("~/") or PurePosixPath(value).is_absolute()

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -1478,6 +1478,47 @@ export interface components {
              */
             created_at: string;
         };
+        /** SyncProjectManifestEntityRevisionSchema */
+        SyncProjectManifestEntityRevisionSchema: {
+            /** Revision Id */
+            revision_id: string;
+            /** Project Id */
+            project_id: string;
+            /** Entity Type */
+            entity_type: string;
+            /** Entity Id */
+            entity_id: string;
+            /** Revision Type */
+            revision_type: string;
+            /** Base Revision Id */
+            base_revision_id: string | null;
+            /** Author Device Id */
+            author_device_id: string;
+            /** Source Artifact Id */
+            source_artifact_id: string | null;
+            /** Content Sha256 */
+            content_sha256: string;
+            /** State */
+            state: string;
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            };
+            /** Payload */
+            payload?: {
+                [key: string]: unknown;
+            };
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+        };
         /** SyncProjectManifestProjectSchema */
         SyncProjectManifestProjectSchema: {
             /** Project Id */
@@ -1519,6 +1560,8 @@ export interface components {
              */
             exported_at: string;
             project: components["schemas"]["SyncProjectManifestProjectSchema"];
+            /** Entity Revisions */
+            entity_revisions?: components["schemas"]["SyncProjectManifestEntityRevisionSchema"][];
             /** Artifacts */
             artifacts: components["schemas"]["SyncProjectManifestArtifactSchema"][];
         };


### PR DESCRIPTION
## Summary

- Add sync entity revision storage, service helpers, and mutation wiring for project metadata, chords, lyrics, sections, and regeneration state.
- Include entity revisions in sync project manifests and hydrate current synced metadata/entities on staged import without creating jobs.
- Regenerate shared TypeScript contracts for the updated sync manifest schema.

Closes #115

## Testing

- `pnpm contracts:generate`
- `uv run --python 3.11 ruff check .`
- `uv run --python 3.11 mypy app`
- `uv run --python 3.11 pytest tests/test_projects.py tests/test_chord_flow.py tests/test_lyrics_flow.py tests/test_tab_import_flow.py tests/test_sync_revisions.py tests/test_sync_manifest.py tests/test_db_migrations.py`
- `pnpm --filter @tuneforge/desktop typecheck`
