### PR TITLE
fix: Treat source paths as provenance

### DIFF
--- a/apps/backend/alembic/versions/0012_backend_hash_storage.py
+++ b/apps/backend/alembic/versions/0012_backend_hash_storage.py
@@ -34,12 +34,6 @@ def upgrade() -> None:
     op.create_index("ix_artifacts_content_sha256", "artifacts", ["content_sha256"], unique=False)
 
     connection = op.get_bind()
-    for row in connection.execute(text("SELECT id, source_path FROM projects")):
-        connection.execute(
-            text("UPDATE projects SET source_sha256 = :sha WHERE id = :id"),
-            {"id": row.id, "sha": _file_sha256(row.source_path)},
-        )
-
     for row in connection.execute(text("SELECT id, path FROM artifacts")):
         connection.execute(
             text("UPDATE artifacts SET content_sha256 = :sha WHERE id = :id"),

--- a/apps/backend/alembic/versions/0014_sync_project_identity.py
+++ b/apps/backend/alembic/versions/0014_sync_project_identity.py
@@ -320,28 +320,45 @@ def _resolve_source_hash(
     source_artifact: dict[str, Any] | None,
 ) -> str | None:
     stored_hash = _normalize_source_hash(project.get("source_sha256"))
-    if stored_hash is not None:
+    if stored_hash is not None and _stored_source_hash_is_trusted(project, source_artifact, stored_hash):
         return stored_hash
 
     original_copy_path = _original_copy_path(source_artifact)
-    original_copy_hash = _file_sha256(original_copy_path)
+    original_copy_hash = _file_sha256(original_copy_path) if _is_app_managed_path(original_copy_path) else None
     if original_copy_hash is not None:
         return original_copy_hash
 
+    candidate_paths = [project.get("source_path")]
     if not _uses_normalized_source_proxy(project, source_artifact):
-        artifact_hash = _file_sha256(source_artifact.get("path") if source_artifact is not None else None)
-        if artifact_hash is not None:
-            return artifact_hash
+        candidate_paths.extend(
+            [
+                source_artifact.get("path") if source_artifact is not None else None,
+                project.get("imported_path"),
+            ]
+        )
+    return _first_app_managed_file_hash(candidate_paths)
 
-        imported_path_hash = _file_sha256(project.get("imported_path"))
-        if imported_path_hash is not None:
-            return imported_path_hash
 
-    source_path_hash = _file_sha256(project.get("source_path"))
-    if source_path_hash is not None:
-        return source_path_hash
-
-    return None
+def _stored_source_hash_is_trusted(
+    project: dict[str, Any],
+    source_artifact: dict[str, Any] | None,
+    stored_hash: str,
+) -> bool:
+    candidate_paths = [
+        _original_copy_path(source_artifact),
+        project.get("source_path"),
+    ]
+    if not _uses_normalized_source_proxy(project, source_artifact):
+        candidate_paths.extend(
+            [
+                source_artifact.get("path") if source_artifact is not None else None,
+                project.get("imported_path"),
+            ]
+        )
+    return any(
+        _is_app_managed_path(candidate_path) and _file_sha256(candidate_path) == stored_hash
+        for candidate_path in candidate_paths
+    )
 
 
 def _normalize_source_hash(value: Any) -> str | None:
@@ -372,6 +389,22 @@ def _original_copy_path(source_artifact: dict[str, Any] | None) -> str | None:
         return None
     value = _metadata_dict(source_artifact.get("metadata_json")).get("original_copy_path")
     return value if isinstance(value, str) else None
+
+
+def _is_app_managed_path(raw_path: Any) -> bool:
+    if not isinstance(raw_path, str) or not raw_path:
+        return False
+    return _project_root_for_path(raw_path, _projects_root()) is not None
+
+
+def _first_app_managed_file_hash(raw_paths: list[Any]) -> str | None:
+    for raw_path in raw_paths:
+        if not _is_app_managed_path(raw_path):
+            continue
+        file_hash = _file_sha256(raw_path)
+        if file_hash is not None:
+            return file_hash
+    return None
 
 
 def _uses_normalized_source_proxy(

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -144,10 +144,7 @@ SyncPreflightProjectStatus = Literal[
 ]
 SyncPreflightSourceHashSource = Literal[
     "database",
-    "source_path",
     "original_copy_path",
-    "source_artifact_path",
-    "imported_path",
 ]
 
 

--- a/apps/backend/app/services/projects.py
+++ b/apps/backend/app/services/projects.py
@@ -123,8 +123,6 @@ def import_project(
         imported_path = source_dir / f"{resolved_source.stem}.wav"
         artifact_format = "wav"
         artifact_metadata["original_format"] = resolved_source.suffix.lower().lstrip(".")
-    elif not copy_into_project:
-        imported_path = resolved_source
 
     project = Project(
         id=project_id,
@@ -158,7 +156,7 @@ def import_project(
             shutil.copy2(resolved_source, original_copy_path)
             working_source = original_copy_path
         normalize_media_to_wav(working_source, imported_path)
-    elif copy_into_project:
+    else:
         shutil.copy2(resolved_source, imported_path)
 
     register_artifact(

--- a/apps/backend/app/services/sync_identity.py
+++ b/apps/backend/app/services/sync_identity.py
@@ -8,13 +8,13 @@ from typing import Literal
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.config import get_settings
 from app.models import Artifact, Project
 from app.utils.hashing import file_sha256
 
 PROJECT_ID_PREFIX = "proj_sha256_"
 PROJECT_STORAGE_KEY_PREFIX = "proj_"
 PROJECT_STORAGE_HASH_LENGTH = 24
-NORMALIZED_IMPORT_SOURCE_FORMATS = {"mp4", "webm"}
 HEX_DIGITS = frozenset("0123456789abcdef")
 
 SyncPreflightProjectStatus = Literal[
@@ -26,10 +26,7 @@ SyncPreflightProjectStatus = Literal[
 ]
 SyncPreflightSourceHashSource = Literal[
     "database",
-    "source_path",
     "original_copy_path",
-    "source_artifact_path",
-    "imported_path",
 ]
 
 
@@ -184,7 +181,7 @@ def _project_preflight(project: Project, source_artifact: Artifact | None) -> Sy
             expected_project_id=None,
             expected_storage_key=None,
             source_hash_source=None,
-            reason="No readable canonical source file is available for this project.",
+            reason="No readable original-byte source copy is available for this project.",
         )
     source_sha256, source = resolved
     return _project_preflight_with_hash(project, source_sha256, source)
@@ -229,23 +226,10 @@ def _resolve_missing_source_hash(
     project: Project,
     source_artifact: Artifact | None,
 ) -> tuple[str, SyncPreflightSourceHashSource] | None:
-    original_copy_path = _original_copy_path(source_artifact)
+    original_copy_path = _original_copy_path(project, source_artifact)
     original_copy_hash = _path_hash(original_copy_path)
     if original_copy_hash is not None:
         return original_copy_hash, "original_copy_path"
-
-    if not _uses_normalized_source_proxy(project, source_artifact):
-        artifact_hash = _path_hash(source_artifact.path if source_artifact is not None else None)
-        if artifact_hash is not None:
-            return artifact_hash, "source_artifact_path"
-
-        imported_path_hash = _path_hash(project.imported_path)
-        if imported_path_hash is not None:
-            return imported_path_hash, "imported_path"
-
-    source_path_hash = _path_hash(project.source_path)
-    if source_path_hash is not None:
-        return source_path_hash, "source_path"
 
     return None
 
@@ -256,20 +240,23 @@ def _path_hash(raw_path: str | None) -> str | None:
     return file_sha256(Path(raw_path))
 
 
-def _original_copy_path(source_artifact: Artifact | None) -> str | None:
+def _original_copy_path(project: Project, source_artifact: Artifact | None) -> str | None:
     if source_artifact is None:
         return None
     value = source_artifact.metadata_json.get("original_copy_path")
-    return value if isinstance(value, str) else None
+    if not isinstance(value, str):
+        return None
+    root = _project_root(project.id).resolve(strict=False)
+    candidate = Path(value).expanduser().resolve(strict=False)
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None
+    return str(candidate)
 
 
-def _uses_normalized_source_proxy(project: Project, source_artifact: Artifact | None) -> bool:
-    original_format = source_artifact.metadata_json.get("original_format") if source_artifact else None
-    if isinstance(original_format, str) and original_format.lower() in NORMALIZED_IMPORT_SOURCE_FORMATS:
-        return True
-    source_format = Path(project.source_path).suffix.lower().lstrip(".")
-    imported_format = Path(project.imported_path).suffix.lower().lstrip(".")
-    return source_format in NORMALIZED_IMPORT_SOURCE_FORMATS and imported_format == "wav"
+def _project_root(project_id: str) -> Path:
+    return get_settings().projects_root / project_id_to_storage_key(project_id)
 
 
 def _with_duplicate_status(project: SyncPreflightProject) -> SyncPreflightProject:

--- a/apps/backend/app/services/sync_manifest.py
+++ b/apps/backend/app/services/sync_manifest.py
@@ -167,7 +167,7 @@ def export_project_manifest(session: Session, project_id: str) -> SyncProjectMan
         ],
         artifacts=[_export_artifact_manifest(artifact) for artifact in artifacts],
     )
-    _validate_source_artifact_matches_project_source(manifest)
+    _validate_source_artifact_present(manifest)
     return manifest
 
 
@@ -194,7 +194,7 @@ def import_staged_project_manifest(
     project_manifest = _coerce_project_manifest(manifest)
     _validate_project_manifest_schema_version(project_manifest)
     _validate_project_manifest_identity(project_manifest)
-    _validate_source_artifact_matches_project_source(project_manifest)
+    _validate_source_artifact_present(project_manifest)
     _reject_duplicate_project_source(session, project_manifest)
     root = project_root(project_manifest.project_id).resolve(strict=False)
     staged_root = (
@@ -831,19 +831,8 @@ def _source_artifact_manifest(manifest: SyncProjectManifest) -> SyncArtifactMani
     return source_artifacts[0]
 
 
-def _validate_source_artifact_matches_project_source(manifest: SyncProjectManifest) -> None:
-    source_artifact = _source_artifact_manifest(manifest)
-    if source_artifact.content_sha256 != manifest.source_sha256:
-        raise AppError(
-            "SYNC_MANIFEST_SOURCE_ARTIFACT_HASH_MISMATCH",
-            "Project manifest source artifact SHA-256 must match project source_sha256.",
-            details={
-                "project_id": manifest.project_id,
-                "artifact_id": source_artifact.artifact_id,
-                "source_sha256": manifest.source_sha256,
-                "artifact_content_sha256": source_artifact.content_sha256,
-            },
-        )
+def _validate_source_artifact_present(manifest: SyncProjectManifest) -> None:
+    _source_artifact_manifest(manifest)
 
 
 def _required_source_sha256(project: Project) -> str:

--- a/apps/backend/tests/test_db_migrations.py
+++ b/apps/backend/tests/test_db_migrations.py
@@ -165,7 +165,6 @@ def test_hash_storage_migration_backfills_existing_files(tmp_path: Path) -> None
     expected_project_hash = file_sha256(source_path)
     expected_project_id = source_hash_to_project_id(expected_project_hash)
     expected_storage_key = source_hash_to_project_storage_key(expected_project_hash)
-    duplicate_hash = file_sha256(duplicate_source_path)
 
     with sqlite3.connect(settings.database_path) as connection:
         connection.execute("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)")
@@ -317,14 +316,14 @@ def test_hash_storage_migration_backfills_existing_files(tmp_path: Path) -> None
         (
             "proj_duplicate_1",
             "Duplicate Song 1",
-            duplicate_hash,
+            None,
             str(duplicate_source_path),
             str(duplicate_source_path),
         ),
         (
             "proj_duplicate_2",
             "Duplicate Song 2",
-            duplicate_hash,
+            None,
             str(duplicate_source_path),
             str(duplicate_source_path),
         ),
@@ -455,13 +454,14 @@ def test_sync_identity_migration_prefers_imported_copy_when_hash_missing(tmp_pat
     assert source_artifact == (expected_project_id, str(expected_imported_path))
 
 
-def test_sync_identity_migration_recovers_already_moved_project_root(tmp_path: Path) -> None:
+def test_sync_identity_migration_does_not_recover_moved_root_from_external_source_hash(
+    tmp_path: Path,
+) -> None:
     settings = get_settings()
     ensure_data_dirs(settings)
     source_path = tmp_path / "source.wav"
     source_path.write_bytes(b"source")
     expected_project_hash = file_sha256(source_path)
-    expected_project_id = source_hash_to_project_id(expected_project_hash)
     expected_storage_key = source_hash_to_project_storage_key(expected_project_hash)
 
     old_project_root = settings.projects_root / "proj_interrupted"
@@ -554,8 +554,8 @@ def test_sync_identity_migration_recovers_already_moved_project_root(tmp_path: P
             "SELECT project_id, path FROM artifacts WHERE id = 'source_interrupted'"
         ).fetchone()
 
-    assert project == (expected_project_id, str(recovered_imported_path))
-    assert artifact == (expected_project_id, str(recovered_imported_path))
+    assert project == ("proj_interrupted", str(old_imported_path))
+    assert artifact == ("proj_interrupted", str(old_imported_path))
     assert recovered_imported_path.exists()
 
 

--- a/apps/backend/tests/test_projects.py
+++ b/apps/backend/tests/test_projects.py
@@ -9,6 +9,7 @@ from app.config import get_settings
 from app.db import SessionLocal
 from app.errors import AppError
 from app.models import Artifact, Project
+from app.services.analysis import analyze_project
 from app.services.paths import project_root
 from app.services.projects import import_project
 from app.services.sync_identity import source_hash_to_project_id, source_hash_to_project_storage_key
@@ -85,6 +86,75 @@ def test_import_project_rejects_duplicate_source_hash(client, sample_audio_file:
         "message": 'This project is already imported with name "Existing Song".',
         "details": {"project_id": project_id, "project_name": "Existing Song"},
     }
+
+
+def test_import_project_with_deprecated_external_reference_copies_source_under_project_root(
+    sample_audio_file: Path,
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "deprecated-external.wav"
+    source_path.write_bytes(sample_audio_file.read_bytes() + b"deprecated-external")
+    expected_hash = file_sha256(source_path)
+    assert expected_hash is not None
+    original_path = source_path.resolve()
+
+    with SessionLocal() as session:
+        project = import_project(
+            session,
+            source_path=str(source_path),
+            copy_into_project=False,
+            display_name=None,
+        )
+        session.commit()
+        session.refresh(project)
+
+        imported_path = Path(project.imported_path)
+        assert project.source_sha256 == expected_hash
+        assert project.source_path == str(original_path)
+        assert imported_path.exists()
+        assert imported_path.is_relative_to(project_root(project.id))
+        assert imported_path != original_path
+
+        source_artifact = next(artifact for artifact in project.artifacts if artifact.type == "source_audio")
+        assert Path(source_artifact.path) == imported_path
+        assert source_artifact.content_sha256 == expected_hash
+
+        source_path.unlink()
+        analysis = analyze_project(session, project)
+
+        assert analysis.project_id == project.id
+        assert imported_path.exists()
+
+
+def test_import_project_with_deprecated_external_reference_still_rejects_duplicate_source_hash(
+    sample_audio_file: Path,
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "deprecated-original.wav"
+    source_path.write_bytes(sample_audio_file.read_bytes() + b"deprecated-duplicate")
+    duplicate_source = tmp_path / "same-audio-different-path.wav"
+    duplicate_source.write_bytes(source_path.read_bytes())
+
+    with SessionLocal() as session:
+        project = import_project(
+            session,
+            source_path=str(source_path),
+            copy_into_project=False,
+            display_name="Original",
+        )
+        session.commit()
+
+    with SessionLocal() as session:
+        with pytest.raises(AppError) as exc:
+            import_project(
+                session,
+                source_path=str(duplicate_source),
+                copy_into_project=False,
+                display_name="Duplicate",
+            )
+
+    assert exc.value.code == "DUPLICATE_PROJECT_SOURCE"
+    assert exc.value.details == {"project_id": project.id, "project_name": "Original"}
 
 
 def test_import_project_translates_duplicate_project_id_race(

--- a/apps/backend/tests/test_sync_identity.py
+++ b/apps/backend/tests/test_sync_identity.py
@@ -77,6 +77,41 @@ def test_sync_preflight_reports_ready_projects(client, sample_audio_file: Path) 
     ]
 
 
+def test_sync_preflight_uses_stored_source_hash_before_original_copy(client, tmp_path: Path) -> None:
+    original_copy = tmp_path / "copy.wav"
+    original_copy.write_bytes(b"copy bytes")
+    stored_hash = "a" * 64
+    project_id = source_hash_to_project_id(stored_hash)
+    with SessionLocal() as session:
+        project = Project(
+            id=project_id,
+            display_name="Stored",
+            source_sha256=stored_hash,
+            source_path=str(tmp_path / "source.wav"),
+            imported_path=str(tmp_path / "imported.wav"),
+        )
+        session.add(project)
+        session.add(
+            Artifact(
+                id="art_stored_source",
+                project_id=project.id,
+                type="source_audio",
+                format="wav",
+                path=str(tmp_path / "proxy.wav"),
+                metadata_json={"original_copy_path": str(original_copy)},
+            )
+        )
+        session.commit()
+
+    response = client.get("/api/v1/sync/preflight")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["projects"][0]["source_sha256"] == stored_hash
+    assert payload["projects"][0]["source_hash_source"] == "database"
+
+
 def test_sync_metadata_exposes_sync_safe_project_and_artifact_metadata(
     client,
     sample_audio_file: Path,
@@ -211,7 +246,10 @@ def test_sync_metadata_exposes_sync_safe_project_and_artifact_metadata(
     assert external_artifact["metadata"] == {"transpose": {"semitones": -1}}
 
 
-def test_sync_preflight_resolves_missing_hash_from_source_path(client, sample_audio_file: Path) -> None:
+def test_sync_preflight_does_not_recover_missing_hash_from_source_path(
+    client,
+    sample_audio_file: Path,
+) -> None:
     expected_hash = file_sha256(sample_audio_file)
     assert expected_hash is not None
     with SessionLocal() as session:
@@ -229,14 +267,18 @@ def test_sync_preflight_resolves_missing_hash_from_source_path(client, sample_au
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["ok"] is True
-    assert payload["projects"][0]["status"] == "ready"
-    assert payload["projects"][0]["source_sha256"] == expected_hash
-    assert payload["projects"][0]["expected_project_id"] == source_hash_to_project_id(expected_hash)
-    assert payload["projects"][0]["source_hash_source"] == "source_path"
+    assert payload["ok"] is False
+    assert payload["missing_source_hash_projects"] == 1
+    assert payload["projects"][0]["status"] == "missing_source_hash"
+    assert payload["projects"][0]["source_sha256"] is None
+    assert payload["projects"][0]["expected_project_id"] is None
+    assert payload["projects"][0]["source_hash_source"] is None
 
 
-def test_sync_preflight_prefers_imported_copy_over_changed_source_path(client, tmp_path: Path) -> None:
+def test_sync_preflight_does_not_recover_missing_hash_from_runtime_artifacts(
+    client,
+    tmp_path: Path,
+) -> None:
     external_source = tmp_path / "external.wav"
     imported_copy = tmp_path / "project-source.wav"
     external_source.write_bytes(b"changed external bytes")
@@ -270,9 +312,9 @@ def test_sync_preflight_prefers_imported_copy_over_changed_source_path(client, t
 
     assert response.status_code == 200
     project = response.json()["projects"][0]
-    assert project["status"] == "ready"
-    assert project["source_sha256"] == expected_hash
-    assert project["source_hash_source"] == "source_artifact_path"
+    assert project["status"] == "missing_source_hash"
+    assert project["source_sha256"] is None
+    assert project["source_hash_source"] is None
 
 
 def test_sync_preflight_reports_missing_source_hash(client, tmp_path: Path) -> None:
@@ -300,6 +342,7 @@ def test_sync_preflight_reports_missing_source_hash(client, tmp_path: Path) -> N
     ]
     assert payload["projects"][0]["status"] == "missing_source_hash"
     assert payload["projects"][0]["expected_project_id"] is None
+    assert payload["projects"][0]["reason"] == "No readable original-byte source copy is available for this project."
 
 
 def test_sync_preflight_reports_invalid_source_hash(client, sample_audio_file: Path) -> None:
@@ -404,12 +447,16 @@ def test_sync_preflight_reports_noncanonical_project_id(client, sample_audio_fil
 def test_sync_preflight_uses_original_copy_before_normalized_proxy(client, sample_audio_file: Path) -> None:
     expected_hash = file_sha256(sample_audio_file)
     assert expected_hash is not None
-    original_copy = sample_audio_file
-    normalized_proxy = sample_audio_file.parent / "proxy.wav"
+    project_id = source_hash_to_project_id(expected_hash)
+    root = project_root(project_id)
+    original_copy = root / "source" / "original.webm"
+    original_copy.parent.mkdir(parents=True, exist_ok=True)
+    original_copy.write_bytes(sample_audio_file.read_bytes())
+    normalized_proxy = root / "source" / "proxy.wav"
     normalized_proxy.write_bytes(b"normalized proxy bytes")
     with SessionLocal() as session:
         project = Project(
-            id=source_hash_to_project_id(expected_hash),
+            id=project_id,
             display_name="Normalized",
             source_sha256=None,
             source_path=str(sample_audio_file.parent / "missing.webm"),
@@ -438,3 +485,43 @@ def test_sync_preflight_uses_original_copy_before_normalized_proxy(client, sampl
     assert project["status"] == "ready"
     assert project["source_sha256"] == expected_hash
     assert project["source_hash_source"] == "original_copy_path"
+
+
+def test_sync_preflight_ignores_external_original_copy_path(client, tmp_path: Path) -> None:
+    external_copy = tmp_path / "external-copy.wav"
+    external_copy.write_bytes(b"external original bytes")
+    external_hash = file_sha256(external_copy)
+    assert external_hash is not None
+    project_id = source_hash_to_project_id(external_hash)
+    runtime_path = project_root(project_id) / "source" / "runtime.wav"
+    runtime_path.parent.mkdir(parents=True, exist_ok=True)
+    runtime_path.write_bytes(b"runtime bytes")
+
+    with SessionLocal() as session:
+        project = Project(
+            id=project_id,
+            display_name="External Copy",
+            source_sha256=None,
+            source_path=str(tmp_path / "missing.wav"),
+            imported_path=str(runtime_path),
+        )
+        session.add(project)
+        session.add(
+            Artifact(
+                id="art_external_copy",
+                project_id=project.id,
+                type="source_audio",
+                format="wav",
+                path=str(runtime_path),
+                metadata_json={"original_copy_path": str(external_copy)},
+            )
+        )
+        session.commit()
+
+    response = client.get("/api/v1/sync/preflight")
+
+    assert response.status_code == 200
+    project = response.json()["projects"][0]
+    assert project["status"] == "missing_source_hash"
+    assert project["source_sha256"] is None
+    assert project["source_hash_source"] is None

--- a/apps/backend/tests/test_sync_manifest.py
+++ b/apps/backend/tests/test_sync_manifest.py
@@ -686,7 +686,7 @@ def test_export_project_manifest_rejects_unportable_artifact_paths(
     assert exc.value.details["artifact_id"] == f"art_bad_{unportable_path}"
 
 
-def test_export_project_manifest_requires_source_artifact_to_match_project_source_hash(
+def test_export_project_manifest_allows_source_artifact_hash_to_differ_from_project_source_hash(
     client: object,
     tmp_path: Path,
 ) -> None:
@@ -700,15 +700,12 @@ def test_export_project_manifest_requires_source_artifact_to_match_project_sourc
         source_artifact.content_sha256 = proxy_hash
         source_artifact.size_bytes = proxy_size
 
-        with pytest.raises(AppError) as exc:
-            export_manifest(session, project_id=fixture.project_id)
+        manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
 
-    assert exc.value.code == "SYNC_MANIFEST_SOURCE_ARTIFACT_HASH_MISMATCH"
-    assert exc.value.status_code == 400
-    assert exc.value.details["project_id"] == fixture.project_id
-    assert exc.value.details["artifact_id"] == "art_source_audio"
-    assert exc.value.details["source_sha256"] == fixture.source_sha256
-    assert exc.value.details["artifact_content_sha256"] == proxy_hash
+    source_artifact_manifest = _artifacts_by_id(manifest)["art_source_audio"]
+    assert manifest["project"]["source_sha256"] == fixture.source_sha256
+    assert source_artifact_manifest["content_sha256"] == proxy_hash
+    assert source_artifact_manifest["content_sha256"] != fixture.source_sha256
 
 
 def test_export_project_manifest_rejects_multiple_source_artifacts(
@@ -1143,7 +1140,7 @@ def test_import_staged_project_manifest_rejects_unsupported_schema_version(
     }
 
 
-def test_import_staged_project_manifest_rejects_source_artifact_hash_mismatch(
+def test_import_staged_project_manifest_preserves_independent_source_artifact_hash(
     client: object,
     tmp_path: Path,
 ) -> None:
@@ -1151,20 +1148,29 @@ def test_import_staged_project_manifest_rejects_source_artifact_hash_mismatch(
 
     with SessionLocal() as session:
         fixture = _create_project_with_artifacts(session, tmp_path)
+        source_path = fixture.root / fixture.source_relative_path
+        proxy_hash, proxy_size = _write_bytes(source_path, b"normalized proxy bytes")
+        source_artifact = session.get(Artifact, "art_source_audio")
+        assert source_artifact is not None
+        source_artifact.content_sha256 = proxy_hash
+        source_artifact.size_bytes = proxy_size
+
         manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
         artifacts = _artifacts_by_id(manifest)
-        artifacts["art_source_audio"]["content_sha256"] = fixture.artifact_hashes["art_vocals"]
+        assert artifacts["art_source_audio"]["content_sha256"] == proxy_hash
+        assert artifacts["art_source_audio"]["content_sha256"] != fixture.source_sha256
+
+        staging_root = tmp_path / "staging"
+        _stage_manifest_files(manifest, staging_root=staging_root, source_root=fixture.root)
         _delete_live_project(session, fixture)
 
-        with pytest.raises(AppError) as exc:
-            import_manifest(session, manifest=manifest, staging_root=tmp_path / "unused-staging")
+        imported_project = import_manifest(session, manifest=manifest, staging_root=staging_root)
+        imported_source_artifact = session.get(Artifact, "art_source_audio")
 
-    assert exc.value.code == "SYNC_MANIFEST_SOURCE_ARTIFACT_HASH_MISMATCH"
-    assert exc.value.status_code == 400
-    assert exc.value.details["project_id"] == fixture.project_id
-    assert exc.value.details["artifact_id"] == "art_source_audio"
-    assert exc.value.details["source_sha256"] == fixture.source_sha256
-    assert exc.value.details["artifact_content_sha256"] == fixture.artifact_hashes["art_vocals"]
+    assert imported_project.source_sha256 == fixture.source_sha256
+    assert imported_source_artifact is not None
+    assert imported_source_artifact.content_sha256 == proxy_hash
+    assert imported_source_artifact.content_sha256 != imported_project.source_sha256
 
 
 def test_import_staged_project_manifest_rejects_multiple_source_artifacts(

--- a/docs/API.md
+++ b/docs/API.md
@@ -250,7 +250,7 @@ The response includes:
 - duplicate source-hash groups
 - manual cleanup guidance
 
-Project status values are `ready`, `missing_source_hash`, `invalid_source_hash`, `duplicate_source_hash`, and `noncanonical_project_id`. Canonical project IDs use `proj_sha256_<full_source_sha256>`, while project storage directories use a shorter derived key such as `proj_<first_24_sha256_hex>`. This endpoint is sync-specific; general project responses do not expose source hashes.
+Project status values are `ready`, `missing_source_hash`, `invalid_source_hash`, `duplicate_source_hash`, and `noncanonical_project_id`. Canonical project IDs use `proj_sha256_<full_source_sha256>`, while project storage directories use a shorter derived key such as `proj_<first_24_sha256_hex>`. Preflight uses a stored `projects.source_sha256` when present. If that field is missing, preflight only recovers it from an explicit app-managed original-byte copy and otherwise reports `missing_source_hash`; `source_path` is provenance only and is not hashed during recovery. This endpoint is sync-specific; general project responses do not expose source hashes.
 
 ### Get sync metadata
 
@@ -299,7 +299,7 @@ Returns a single project manifest for manifest-only sync export. The response is
 - `project`
 - `artifacts`
 
-Manifest paths are project-root relative and use portable path separators. The response does not expose absolute local source, project, artifact, or app data paths. Artifact entries include `content_sha256`, and the project entry includes `source_sha256`; receiving peers must verify staged bytes against these SHA-256 values before accepting the import. For this v1 manifest spike, a portable manifest must contain exactly one `source_audio` artifact, and that artifact must match the project `source_sha256`; normalized proxy-only source imports are not portable until original-source artifacts are modeled explicitly. The endpoint exports metadata only. File transfer and LAN peer discovery belong to the native sync layer, not the loopback FastAPI API.
+Manifest paths are project-root relative and use portable path separators. The response does not expose absolute local source, project, artifact, or app data paths. The project entry's `source_sha256` is the identity hash of the original imported source bytes. Artifact entries' `content_sha256` values hash the bytes for those specific staged artifact files, which may include backend-managed runtime files such as normalized WAV proxies. `sync_entity_revisions.content_sha256` is also per-entity revision payload content, not project source identity. Receiving peers must verify staged files against the artifact SHA-256 values and must preserve the project `source_sha256` as identity metadata before accepting the import. The endpoint exports metadata only. File transfer and LAN peer discovery belong to the native sync layer, not the loopback FastAPI API.
 
 ### Import staged project sync manifest
 
@@ -335,6 +335,8 @@ Request fields:
 - `display_name`
 
 Response: `ProjectResponse`.
+
+`source_path` records where the user imported the file from on this install. Sync treats it as local provenance, not a durable source of original bytes. `copy_into_project=false` is accepted for compatibility, but new imports still create an app-managed operational source file under the project root.
 
 If the same source track has already been imported, the endpoint returns HTTP `409` with code `DUPLICATE_PROJECT_SOURCE`, message `This project is already imported with name "{name}".`, and details containing:
 

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -1411,7 +1411,7 @@ export interface components {
             /** Expected Storage Key */
             expected_storage_key: string | null;
             /** Source Hash Source */
-            source_hash_source: ("database" | "source_path" | "original_copy_path" | "source_artifact_path" | "imported_path") | null;
+            source_hash_source: ("database" | "original_copy_path") | null;
             /** Reason */
             reason?: string | null;
         };


### PR DESCRIPTION
## Summary

- Fixes #137.
- Keeps external source paths as local provenance after import.
- Ensures new imports use app-managed operational source files and narrows sync hash recovery to stored hashes or app-managed original-byte copies.
- Separates project source identity hashes from artifact content hashes in sync manifest validation and docs.

## Testing

- `pnpm contracts:generate`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `cd apps/backend && uv run --python 3.11 pytest tests/test_db_migrations.py tests/test_projects.py tests/test_sync_identity.py tests/test_sync_manifest.py`
- `pnpm --filter @tuneforge/desktop typecheck`
