### PR TITLE
feat: normalize imports to internal WAV

### DIFF
--- a/apps/backend/app/services/metadata.py
+++ b/apps/backend/app/services/metadata.py
@@ -60,14 +60,18 @@ def extract_audio_metadata(source_path: Path) -> dict[str, Any]:
     }
 
 
-def normalize_media_to_wav(source_path: Path, destination_path: Path) -> None:
+def normalize_audio_to_wav(source_path: Path, destination_path: Path) -> None:
     destination_path.parent.mkdir(parents=True, exist_ok=True)
     command = [
         get_settings().ffmpeg_path,
         "-y",
         "-i",
         str(source_path),
+        "-map",
+        "0:a:0",
         "-vn",
+        "-c:a",
+        "pcm_s16le",
         str(destination_path),
     ]
     try:
@@ -75,13 +79,13 @@ def normalize_media_to_wav(source_path: Path, destination_path: Path) -> None:
     except FileNotFoundError as exc:
         raise AppError(
             "DEPENDENCY_MISSING",
-            "ffmpeg is required to import mp4 and webm sources.",
+            "ffmpeg is required to normalize imported audio.",
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         ) from exc
     except subprocess.CalledProcessError as exc:
         raise AppError(
             "PROCESSING_FAILED",
-            "Could not extract audio from the imported media file.",
+            "Could not normalize imported audio to WAV.",
             status_code=status.HTTP_400_BAD_REQUEST,
             details={"stderr": exc.stderr.strip()},
         ) from exc

--- a/apps/backend/app/services/projects.py
+++ b/apps/backend/app/services/projects.py
@@ -12,13 +12,11 @@ from app.config import get_settings
 from app.errors import AppError
 from app.models import Project
 from app.services.artifacts import register_artifact
-from app.services.metadata import extract_audio_metadata, normalize_media_to_wav
+from app.services.metadata import extract_audio_metadata, normalize_audio_to_wav
 from app.services.paths import ensure_project_dirs, project_root, project_source_dir
 from app.services.sync_identity import source_hash_to_project_id
 from app.services.sync_revisions import record_project_metadata_revision
 from app.utils.hashing import file_sha256
-
-NORMALIZED_IMPORT_FORMATS = {"mp4", "webm"}
 
 
 def _validate_import_path(source_path: Path) -> None:
@@ -90,7 +88,7 @@ def import_project(
 ) -> Project:
     resolved_source = Path(source_path).expanduser().resolve()
     _validate_import_path(resolved_source)
-    metadata = extract_audio_metadata(resolved_source)
+    original_format = resolved_source.suffix.lower().lstrip(".")
     source_sha256 = file_sha256(resolved_source)
     if source_sha256 is None:
         raise AppError(
@@ -108,21 +106,12 @@ def import_project(
     if existing_project is not None:
         raise _duplicate_project_source_error(existing_project.id, existing_project.display_name)
 
-    destination_name = resolved_source.name
+    metadata = extract_audio_metadata(resolved_source)
     source_dir = project_source_dir(project_id)
-    imported_path = source_dir / destination_name
-    artifact_format = resolved_source.suffix.lower().lstrip(".")
-    artifact_metadata = {"source_path": str(resolved_source)}
-    needs_normalization = artifact_format in NORMALIZED_IMPORT_FORMATS
+    imported_path = source_dir / f"{resolved_source.stem}.wav"
+    artifact_metadata = {"source_path": str(resolved_source), "original_format": original_format}
     fallback_project_name = display_name or resolved_source.stem
-
-    if needs_normalization:
-        if copy_into_project:
-            original_copy_path = source_dir / destination_name
-            artifact_metadata["original_copy_path"] = str(original_copy_path)
-        imported_path = source_dir / f"{resolved_source.stem}.wav"
-        artifact_format = "wav"
-        artifact_metadata["original_format"] = resolved_source.suffix.lower().lstrip(".")
+    _ = copy_into_project  # Historical API flag; imports always materialize an internal WAV.
 
     project = Project(
         id=project_id,
@@ -149,21 +138,13 @@ def import_project(
         raise _duplicate_project_source_error(project_id, fallback_project_name) from exc
 
     ensure_project_dirs(project_id)
-    if needs_normalization:
-        working_source = resolved_source
-        if copy_into_project:
-            original_copy_path = source_dir / destination_name
-            shutil.copy2(resolved_source, original_copy_path)
-            working_source = original_copy_path
-        normalize_media_to_wav(working_source, imported_path)
-    else:
-        shutil.copy2(resolved_source, imported_path)
+    normalize_audio_to_wav(resolved_source, imported_path)
 
     register_artifact(
         session,
         project_id=project.id,
         artifact_type="source_audio",
-        artifact_format=artifact_format,
+        artifact_format="wav",
         path=Path(project.imported_path),
         metadata=artifact_metadata,
         generated_by="import",

--- a/apps/backend/app/services/sync_manifest.py
+++ b/apps/backend/app/services/sync_manifest.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 import shutil
+import subprocess
 from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass
@@ -13,6 +15,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.config import get_settings
 from app.errors import AppError
 from app.models import Artifact, ChordTimeline, LyricsTranscript, Project, SongSection, SyncEntityRevision
 from app.services.artifacts import register_artifact
@@ -194,7 +197,7 @@ def import_staged_project_manifest(
     project_manifest = _coerce_project_manifest(manifest)
     _validate_project_manifest_schema_version(project_manifest)
     _validate_project_manifest_identity(project_manifest)
-    _validate_source_artifact_present(project_manifest)
+    source_artifact = _validate_staged_import_source_artifact(project_manifest)
     _reject_duplicate_project_source(session, project_manifest)
     root = project_root(project_manifest.project_id).resolve(strict=False)
     staged_root = (
@@ -207,7 +210,6 @@ def import_staged_project_manifest(
         project_root_path=root,
         use_content_addressed_staging=use_content_addressed_staging,
     )
-    source_artifact = _source_artifact_manifest(project_manifest)
     source_path = root / _safe_relative_path(source_artifact.relative_path)
 
     project = Project(
@@ -357,6 +359,13 @@ def _export_artifact_manifest(artifact: Artifact) -> SyncArtifactManifest:
                 "expected_sha256": artifact.content_sha256,
                 "actual_sha256": actual_sha256,
             },
+        )
+
+    if artifact.type == "source_audio":
+        _validate_export_source_artifact(
+            artifact=artifact,
+            relative_path=relative_path,
+            artifact_path=artifact_path,
         )
 
     return SyncArtifactManifest(
@@ -743,6 +752,13 @@ def _verify_staged_artifacts(
             staged_path = (staging_root / relative_path).resolve(strict=False)
             _ensure_child_path(staging_root, staged_path, "staged artifact")
             _verify_staged_file(artifact, staged_path)
+        if artifact.type == "source_audio":
+            _validate_wav_source_file(
+                artifact_id=artifact.artifact_id,
+                project_id=artifact.project_id,
+                relative_path=artifact.relative_path,
+                path=staged_path,
+            )
 
         verified.append(
             _VerifiedStagedArtifact(
@@ -832,7 +848,140 @@ def _source_artifact_manifest(manifest: SyncProjectManifest) -> SyncArtifactMani
 
 
 def _validate_source_artifact_present(manifest: SyncProjectManifest) -> None:
-    _source_artifact_manifest(manifest)
+    _validate_staged_import_source_artifact(manifest)
+
+
+def _validate_staged_import_source_artifact(manifest: SyncProjectManifest) -> SyncArtifactManifest:
+    source_artifact = _source_artifact_manifest(manifest)
+    if source_artifact.format != "wav":
+        raise _invalid_manifest("Project manifest source_audio artifact format must be 'wav'.")
+
+    relative_path = _safe_relative_path(source_artifact.relative_path)
+    if relative_path.suffix.lower() != ".wav":
+        raise _invalid_manifest("Project manifest source_audio artifact relative_path must end with .wav.")
+    return source_artifact
+
+
+def _validate_export_source_artifact(
+    *,
+    artifact: Artifact,
+    relative_path: str,
+    artifact_path: Path,
+) -> None:
+    if artifact.format != "wav":
+        raise AppError(
+            "SYNC_MANIFEST_SOURCE_ARTIFACT_UNSUPPORTED",
+            "Project source audio artifact must be an app-managed WAV before sync export.",
+            details={"artifact_id": artifact.id, "project_id": artifact.project_id, "format": artifact.format},
+        )
+    if PurePosixPath(relative_path).suffix.lower() != ".wav":
+        raise AppError(
+            "SYNC_MANIFEST_SOURCE_ARTIFACT_UNSUPPORTED",
+            "Project source audio artifact must use a .wav relative path before sync export.",
+            details={
+                "artifact_id": artifact.id,
+                "project_id": artifact.project_id,
+                "relative_path": relative_path,
+            },
+        )
+    _validate_wav_source_file(
+        artifact_id=artifact.id,
+        project_id=artifact.project_id,
+        relative_path=relative_path,
+        path=artifact_path,
+    )
+
+
+def _validate_wav_source_file(
+    *,
+    artifact_id: str,
+    project_id: str,
+    relative_path: str,
+    path: Path,
+) -> None:
+    command = [
+        get_settings().ffprobe_path,
+        "-v",
+        "error",
+        "-select_streams",
+        "a:0",
+        "-show_entries",
+        "stream=codec_name,channels,sample_rate",
+        "-show_entries",
+        "format=format_name",
+        "-of",
+        "json",
+        str(path),
+    ]
+    try:
+        result = subprocess.run(command, check=True, capture_output=True, text=True)
+        payload = json.loads(result.stdout or "{}")
+    except FileNotFoundError as exc:
+        raise AppError(
+            "DEPENDENCY_MISSING",
+            "ffprobe is required to validate source audio artifacts for sync.",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        ) from exc
+    except (json.JSONDecodeError, subprocess.CalledProcessError) as exc:
+        raise _source_artifact_not_wav_error(
+            artifact_id=artifact_id,
+            project_id=project_id,
+            relative_path=relative_path,
+        ) from exc
+
+    if not _is_wav_pcm_probe(payload):
+        raise _source_artifact_not_wav_error(
+            artifact_id=artifact_id,
+            project_id=project_id,
+            relative_path=relative_path,
+        )
+
+
+def _is_wav_pcm_probe(payload: Any) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    fmt = payload.get("format")
+    streams = payload.get("streams")
+    if not isinstance(fmt, dict) or not isinstance(streams, list) or not streams:
+        return False
+    stream = streams[0]
+    if not isinstance(stream, dict):
+        return False
+    format_name = fmt.get("format_name")
+    codec_name = stream.get("codec_name")
+    if not isinstance(format_name, str) or not isinstance(codec_name, str):
+        return False
+    format_names = {name.strip().lower() for name in format_name.split(",")}
+    return (
+        "wav" in format_names
+        and codec_name.startswith("pcm_")
+        and _positive_int(stream.get("channels"))
+        and _positive_int(stream.get("sample_rate"))
+    )
+
+
+def _positive_int(value: Any) -> bool:
+    try:
+        return int(value) > 0
+    except (TypeError, ValueError):
+        return False
+
+
+def _source_artifact_not_wav_error(
+    *,
+    artifact_id: str,
+    project_id: str,
+    relative_path: str,
+) -> AppError:
+    return AppError(
+        "SYNC_MANIFEST_SOURCE_ARTIFACT_NOT_WAV",
+        "Project source audio artifact file must be a readable PCM WAV.",
+        details={
+            "artifact_id": artifact_id,
+            "project_id": project_id,
+            "relative_path": relative_path,
+        },
+    )
 
 
 def _required_source_sha256(project: Project) -> str:

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -170,6 +170,31 @@ def _transcode_fixture(source_path: Path, destination_path: Path, codec: str) ->
 
 
 @pytest.fixture()
+def sample_mp3_file(tmp_path: Path, sample_audio_file: Path) -> Path:
+    return _transcode_fixture(sample_audio_file, tmp_path / "fixture.mp3", "libmp3lame")
+
+
+@pytest.fixture()
+def sample_flac_file(tmp_path: Path, sample_audio_file: Path) -> Path:
+    return _transcode_fixture(sample_audio_file, tmp_path / "fixture.flac", "flac")
+
+
+@pytest.fixture()
+def sample_m4a_file(tmp_path: Path, sample_audio_file: Path) -> Path:
+    return _transcode_fixture(sample_audio_file, tmp_path / "fixture.m4a", "aac")
+
+
+@pytest.fixture()
+def sample_aac_file(tmp_path: Path, sample_audio_file: Path) -> Path:
+    return _transcode_fixture(sample_audio_file, tmp_path / "fixture.aac", "aac")
+
+
+@pytest.fixture()
+def sample_ogg_file(tmp_path: Path, sample_audio_file: Path) -> Path:
+    return _transcode_fixture(sample_audio_file, tmp_path / "fixture.ogg", "libopus")
+
+
+@pytest.fixture()
 def sample_mp4_file(tmp_path: Path, sample_audio_file: Path) -> Path:
     return _transcode_fixture(sample_audio_file, tmp_path / "fixture.mp4", "aac")
 

--- a/apps/backend/tests/test_projects.py
+++ b/apps/backend/tests/test_projects.py
@@ -37,16 +37,21 @@ def test_import_project_persists_metadata_and_source_artifact(client, sample_aud
     data_root = get_settings().data_root
     imported_path = Path(project["imported_path"])
     assert imported_path.exists()
+    assert imported_path.suffix == ".wav"
     assert str(imported_path).startswith(
         str(data_root / "projects" / source_hash_to_project_storage_key(expected_hash))
     )
 
     artifacts = client.get(f"/api/v1/projects/{project['id']}/artifacts").json()["artifacts"]
     source_artifact = next(artifact for artifact in artifacts if artifact["type"] == "source_audio")
+    assert source_artifact["format"] == "wav"
     assert source_artifact["size_bytes"] > 0
     assert source_artifact["generated_by"] == "import"
     assert source_artifact["can_delete"] is False
     assert source_artifact["can_regenerate"] is False
+    assert source_artifact["metadata"]["source_path"] == str(sample_audio_file.resolve())
+    assert source_artifact["metadata"]["original_format"] == "wav"
+    assert "original_copy_path" not in source_artifact["metadata"]
     assert "content_sha256" not in source_artifact
     assert "source_sha256" not in project
 
@@ -88,12 +93,10 @@ def test_import_project_rejects_duplicate_source_hash(client, sample_audio_file:
     }
 
 
-def test_import_project_with_deprecated_external_reference_copies_source_under_project_root(
-    sample_audio_file: Path,
-    tmp_path: Path,
+def test_import_project_without_copy_still_materializes_internal_wav(
+    sample_mp3_file: Path,
 ) -> None:
-    source_path = tmp_path / "deprecated-external.wav"
-    source_path.write_bytes(sample_audio_file.read_bytes() + b"deprecated-external")
+    source_path = sample_mp3_file
     expected_hash = file_sha256(source_path)
     assert expected_hash is not None
     original_path = source_path.resolve()
@@ -112,12 +115,19 @@ def test_import_project_with_deprecated_external_reference_copies_source_under_p
         assert project.source_sha256 == expected_hash
         assert project.source_path == str(original_path)
         assert imported_path.exists()
+        assert imported_path.suffix == ".wav"
         assert imported_path.is_relative_to(project_root(project.id))
         assert imported_path != original_path
+        assert not (imported_path.parent / source_path.name).exists()
 
         source_artifact = next(artifact for artifact in project.artifacts if artifact.type == "source_audio")
         assert Path(source_artifact.path) == imported_path
-        assert source_artifact.content_sha256 == expected_hash
+        assert source_artifact.format == "wav"
+        assert source_artifact.metadata_json["source_path"] == str(original_path)
+        assert source_artifact.metadata_json["original_format"] == "mp3"
+        assert "original_copy_path" not in source_artifact.metadata_json
+        assert source_artifact.content_sha256 == file_sha256(imported_path)
+        assert source_artifact.content_sha256 != expected_hash
 
         source_path.unlink()
         analysis = analyze_project(session, project)
@@ -297,9 +307,29 @@ def test_retune_request_rejects_invalid_payload(client, sample_audio_file: Path)
     assert response.json()["error"]["code"] == "INVALID_REQUEST"
 
 
-@pytest.mark.parametrize("fixture_name", ["sample_mp4_file", "sample_webm_file"])
-def test_container_imports_are_normalized_and_analyzable(client, request, fixture_name: str):
+@pytest.mark.parametrize(
+    ("fixture_name", "original_format"),
+    [
+        ("sample_audio_file", "wav"),
+        ("sample_mp3_file", "mp3"),
+        ("sample_flac_file", "flac"),
+        ("sample_m4a_file", "m4a"),
+        ("sample_aac_file", "aac"),
+        ("sample_ogg_file", "ogg"),
+        ("sample_mp4_file", "mp4"),
+        ("sample_webm_file", "webm"),
+    ],
+)
+def test_supported_imports_are_normalized_to_internal_wav(
+    client,
+    request,
+    fixture_name: str,
+    original_format: str,
+):
     source_path = request.getfixturevalue(fixture_name)
+    source_hash = file_sha256(source_path)
+    assert source_hash is not None
+
     response = client.post(
         "/api/v1/projects/import",
         json={"source_path": str(source_path), "copy_into_project": True},
@@ -307,15 +337,26 @@ def test_container_imports_are_normalized_and_analyzable(client, request, fixtur
 
     assert response.status_code == 200
     project = response.json()["project"]
-    assert project["imported_path"].endswith(".wav")
+    imported_path = Path(project["imported_path"])
+    assert imported_path.exists()
+    assert imported_path.name == f"{source_path.stem}.wav"
+    assert project["id"] == source_hash_to_project_id(source_hash)
 
     artifacts = client.get(f"/api/v1/projects/{project['id']}/artifacts").json()["artifacts"]
     source_artifact = next(artifact for artifact in artifacts if artifact["type"] == "source_audio")
     assert source_artifact["format"] == "wav"
-    assert source_artifact["metadata"]["original_format"] in {"mp4", "webm"}
+    assert source_artifact["metadata"]["source_path"] == str(source_path.resolve())
+    assert source_artifact["metadata"]["original_format"] == original_format
+    assert "original_copy_path" not in source_artifact["metadata"]
+    if original_format != "wav":
+        assert not (imported_path.parent / source_path.name).exists()
 
-    analyze_job = client.post(
-        f"/api/v1/projects/{project['id']}/analyze",
-        json={"include_tempo": False, "force": False},
-    ).json()["job"]
-    assert wait_for_job(client, analyze_job["id"])["status"] == "completed"
+    with SessionLocal() as session:
+        project_row = session.get(Project, project["id"])
+        artifact_row = session.get(Artifact, source_artifact["id"])
+        assert project_row is not None
+        assert artifact_row is not None
+        assert project_row.source_sha256 == source_hash
+        assert artifact_row.content_sha256 == file_sha256(imported_path)
+        if original_format != "wav":
+            assert artifact_row.content_sha256 != source_hash

--- a/apps/backend/tests/test_sync_manifest.py
+++ b/apps/backend/tests/test_sync_manifest.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import hashlib
 import importlib
+import io
 import json
 import shutil
+import wave
 from collections.abc import Callable, Iterable, Iterator
 from dataclasses import asdict, dataclass, is_dataclass
 from datetime import UTC, datetime
@@ -180,13 +182,25 @@ def _write_bytes(path: Path, contents: bytes) -> tuple[str, int]:
     return content_hash, path.stat().st_size
 
 
+def _wav_bytes(*, frame_count: int = 64, sample_rate: int = 44100) -> bytes:
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(b"\0\0" * frame_count)
+    return buffer.getvalue()
+
+
 def _create_project_with_artifacts(
     session: Any,
     tmp_path: Path,
     *,
-    source_bytes: bytes = b"sync source audio",
+    source_bytes: bytes | None = None,
     stem_bytes: bytes = b"sync vocal stem",
 ) -> ManifestProjectFixture:
+    if source_bytes is None:
+        source_bytes = _wav_bytes()
     external_source = tmp_path / "user-library" / "fixture.wav"
     source_sha256, _ = _write_bytes(external_source, source_bytes)
     project_id = source_hash_to_project_id(source_sha256)
@@ -694,7 +708,7 @@ def test_export_project_manifest_allows_source_artifact_hash_to_differ_from_proj
     with SessionLocal() as session:
         fixture = _create_project_with_artifacts(session, tmp_path)
         source_path = fixture.root / fixture.source_relative_path
-        proxy_hash, proxy_size = _write_bytes(source_path, b"normalized proxy bytes")
+        proxy_hash, proxy_size = _write_bytes(source_path, _wav_bytes(frame_count=128))
         source_artifact = session.get(Artifact, "art_source_audio")
         assert source_artifact is not None
         source_artifact.content_sha256 = proxy_hash
@@ -708,6 +722,26 @@ def test_export_project_manifest_allows_source_artifact_hash_to_differ_from_proj
     assert source_artifact_manifest["content_sha256"] != fixture.source_sha256
 
 
+def test_export_project_manifest_rejects_non_wav_source_audio_artifact(
+    client: object,
+    tmp_path: Path,
+) -> None:
+    export_manifest, _ = _sync_manifest_services()
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path)
+        source_artifact = session.get(Artifact, "art_source_audio")
+        assert source_artifact is not None
+        source_artifact.format = "mp3"
+
+        with pytest.raises(AppError) as exc:
+            export_manifest(session, project_id=fixture.project_id)
+
+    assert exc.value.code == "SYNC_MANIFEST_SOURCE_ARTIFACT_UNSUPPORTED"
+    assert exc.value.status_code == 400
+    assert exc.value.details["artifact_id"] == "art_source_audio"
+    assert exc.value.details["format"] == "mp3"
+
+
 def test_export_project_manifest_rejects_multiple_source_artifacts(
     client: object,
     tmp_path: Path,
@@ -716,7 +750,10 @@ def test_export_project_manifest_rejects_multiple_source_artifacts(
     with SessionLocal() as session:
         fixture = _create_project_with_artifacts(session, tmp_path)
         duplicate_source_path = fixture.root / "source" / "duplicate.wav"
-        duplicate_hash, duplicate_size = _write_bytes(duplicate_source_path, b"duplicate source")
+        duplicate_hash, duplicate_size = _write_bytes(
+            duplicate_source_path,
+            _wav_bytes(frame_count=96),
+        )
         session.add(
             Artifact(
                 id="art_source_audio_duplicate",
@@ -1149,7 +1186,7 @@ def test_import_staged_project_manifest_preserves_independent_source_artifact_ha
     with SessionLocal() as session:
         fixture = _create_project_with_artifacts(session, tmp_path)
         source_path = fixture.root / fixture.source_relative_path
-        proxy_hash, proxy_size = _write_bytes(source_path, b"normalized proxy bytes")
+        proxy_hash, proxy_size = _write_bytes(source_path, _wav_bytes(frame_count=128))
         source_artifact = session.get(Artifact, "art_source_audio")
         assert source_artifact is not None
         source_artifact.content_sha256 = proxy_hash
@@ -1157,6 +1194,8 @@ def test_import_staged_project_manifest_preserves_independent_source_artifact_ha
 
         manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
         artifacts = _artifacts_by_id(manifest)
+        assert artifacts["art_source_audio"]["format"] == "wav"
+        assert artifacts["art_source_audio"]["relative_path"] == fixture.source_relative_path
         assert artifacts["art_source_audio"]["content_sha256"] == proxy_hash
         assert artifacts["art_source_audio"]["content_sha256"] != fixture.source_sha256
 
@@ -1169,8 +1208,83 @@ def test_import_staged_project_manifest_preserves_independent_source_artifact_ha
 
     assert imported_project.source_sha256 == fixture.source_sha256
     assert imported_source_artifact is not None
+    assert imported_source_artifact.format == "wav"
+    assert Path(imported_source_artifact.path).suffix == ".wav"
     assert imported_source_artifact.content_sha256 == proxy_hash
     assert imported_source_artifact.content_sha256 != imported_project.source_sha256
+
+
+@pytest.mark.parametrize(
+    ("artifact_field", "artifact_value", "message_fragment"),
+    [
+        ("format", "mp3", "format"),
+        ("relative_path", "source/fixture.mp3", "relative_path"),
+    ],
+)
+def test_import_staged_project_manifest_rejects_non_wav_source_audio_artifact(
+    client: object,
+    tmp_path: Path,
+    artifact_field: str,
+    artifact_value: str,
+    message_fragment: str,
+) -> None:
+    export_manifest, import_manifest = _sync_manifest_services()
+    staging_root = tmp_path / "staging"
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path)
+        manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+        _stage_manifest_files(manifest, staging_root=staging_root, source_root=fixture.root)
+
+        if artifact_field == "relative_path":
+            staged_source_path = staging_root / fixture.source_relative_path
+            staged_non_wav_path = staging_root / artifact_value
+            staged_non_wav_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(staged_source_path, staged_non_wav_path)
+
+        _artifacts_by_id(manifest)["art_source_audio"][artifact_field] = artifact_value
+        _delete_live_project(session, fixture)
+
+        with pytest.raises(AppError) as exc:
+            import_manifest(session, manifest=manifest, staging_root=staging_root)
+        session.rollback()
+
+        assert session.get(Project, fixture.project_id) is None
+
+    assert exc.value.code == "SYNC_MANIFEST_INVALID"
+    assert exc.value.status_code == 400
+    assert message_fragment in exc.value.message
+
+
+def test_import_staged_project_manifest_rejects_non_wav_source_audio_bytes(
+    client: object,
+    tmp_path: Path,
+) -> None:
+    export_manifest, import_manifest = _sync_manifest_services()
+    staging_root = tmp_path / "staging"
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path)
+        manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+        _stage_manifest_files(manifest, staging_root=staging_root, source_root=fixture.root)
+
+        staged_source_path = staging_root / fixture.source_relative_path
+        invalid_hash, invalid_size = _write_bytes(staged_source_path, b"not a wav file")
+        source_artifact = _artifacts_by_id(manifest)["art_source_audio"]
+        source_artifact["content_sha256"] = invalid_hash
+        source_artifact["size_bytes"] = invalid_size
+        _delete_live_project(session, fixture)
+
+        with pytest.raises(AppError) as exc:
+            import_manifest(session, manifest=manifest, staging_root=staging_root)
+        session.rollback()
+
+        assert session.get(Project, fixture.project_id) is None
+
+    assert exc.value.code == "SYNC_MANIFEST_SOURCE_ARTIFACT_NOT_WAV"
+    assert exc.value.status_code == 400
+    assert exc.value.details["artifact_id"] == "art_source_audio"
+    assert exc.value.details["relative_path"] == fixture.source_relative_path
 
 
 def test_import_staged_project_manifest_rejects_multiple_source_artifacts(

--- a/docs/API.md
+++ b/docs/API.md
@@ -286,7 +286,7 @@ Artifact fields:
 - `metadata`
 - `created_at`
 
-`relative_path` is project-root relative when the artifact is stored under the backend-managed project root; otherwise it is `null`. Artifact metadata is sanitized recursively before returning and removes local path-bearing keys such as `source_path`, `original_copy_path`, `playback_path`, `imported_path`, and any metadata key ending in `_path`. Non-path metadata such as retune/transpose settings, `stem_model`, and `source_artifact_id` is preserved. Job internals such as `result_artifact_ids_json` are not exposed.
+`relative_path` is project-root relative when the artifact is stored under the backend-managed project root; otherwise it is `null`. Operational `source_audio` artifacts are app-managed WAV files under the project root. Artifact metadata is sanitized recursively before returning and removes local path-bearing keys such as `source_path`, `original_copy_path`, `playback_path`, `imported_path`, and any metadata key ending in `_path`. Non-path metadata such as retune/transpose settings, `stem_model`, and `source_artifact_id` is preserved. Job internals such as `result_artifact_ids_json` are not exposed.
 
 ### Export project sync manifest
 
@@ -299,7 +299,7 @@ Returns a single project manifest for manifest-only sync export. The response is
 - `project`
 - `artifacts`
 
-Manifest paths are project-root relative and use portable path separators. The response does not expose absolute local source, project, artifact, or app data paths. The project entry's `source_sha256` is the identity hash of the original imported source bytes. Artifact entries' `content_sha256` values hash the bytes for those specific staged artifact files, which may include backend-managed runtime files such as normalized WAV proxies. `sync_entity_revisions.content_sha256` is also per-entity revision payload content, not project source identity. Receiving peers must verify staged files against the artifact SHA-256 values and must preserve the project `source_sha256` as identity metadata before accepting the import. The endpoint exports metadata only. File transfer and LAN peer discovery belong to the native sync layer, not the loopback FastAPI API.
+Manifest paths are project-root relative and use portable path separators. The response does not expose absolute local source, project, artifact, or app data paths. The project entry's `source_sha256` is the identity hash of the original imported source bytes. Artifact entries' `content_sha256` values hash the bytes for those specific staged artifact files, including the `source_audio` artifact. These hashes are separate on purpose: an app-managed normalized WAV source artifact may have different bytes from the original import identity hash. `sync_entity_revisions.content_sha256` is also per-entity revision payload content, not project source identity. Projects whose `source_audio` artifact is not an app-managed readable PCM WAV must be reimported or repaired before manifest export. Receiving peers must verify staged files against the artifact SHA-256 values and must preserve the project `source_sha256` as identity metadata before accepting the import. The endpoint exports metadata only. File transfer and LAN peer discovery belong to the native sync layer, not the loopback FastAPI API.
 
 ### Import staged project sync manifest
 
@@ -312,7 +312,7 @@ Request fields:
 - `manifest`
 - `staging_root`
 
-`staging_root` is a local directory containing the staged project files at the relative paths declared in the manifest. During import, the backend verifies source and artifact bytes with SHA-256, rewrites accepted paths into this install's backend-managed project root, and persists the project through backend services instead of copying database rows from another device.
+`staging_root` is a local directory containing the staged project files at the relative paths declared in the manifest. During import, the backend requires exactly one `source_audio` artifact, and that artifact must use `format="wav"` with a `.wav` relative path. The backend verifies source and artifact bytes with SHA-256, rewrites accepted paths into this install's backend-managed project root, and persists the project through backend services instead of copying database rows from another device. Original absolute import paths are local provenance only and are not sync-operational inputs.
 
 If the local library already contains the same canonical project or source SHA-256, staged import rejects the duplicate with HTTP `409` instead of creating a second project. The response uses the normal project wrapper shape:
 
@@ -336,7 +336,7 @@ Request fields:
 
 Response: `ProjectResponse`.
 
-`source_path` records where the user imported the file from on this install. Sync treats it as local provenance, not a durable source of original bytes. `copy_into_project=false` is accepted for compatibility, but new imports still create an app-managed operational source file under the project root.
+`source_path` records where the user imported the file from on this install. Sync treats it as local provenance, not a durable source of original bytes or an operational sync input. `copy_into_project=false` is accepted for compatibility, but new imports still create an app-managed operational WAV source artifact under the project root.
 
 If the same source track has already been imported, the endpoint returns HTTP `409` with code `DUPLICATE_PROJECT_SOURCE`, message `This project is already imported with name "{name}".`, and details containing:
 


### PR DESCRIPTION
## Summary

- Normalize every supported project import into an app-managed WAV source artifact.
- Keep `source_sha256` tied to original import bytes while artifact hashes track stored files.
- Enforce WAV/PCM `source_audio` artifacts for sync manifest export and staged import.
- Closes #138

## Testing

- `cd apps/backend && uv run --python 3.11 pytest tests/test_projects.py tests/test_sync_identity.py tests/test_sync_manifest.py`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `pnpm contracts:generate` not run; backend request/response schemas did not change.
