### PR TITLE
feat: add sync delete tombstones

### DIFF
--- a/apps/backend/alembic/versions/0018_sync_delete_tombstones.py
+++ b/apps/backend/alembic/versions/0018_sync_delete_tombstones.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0018_sync_delete_tombstones"
+down_revision = "0017_sync_entity_revisions"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sync_delete_tombstones",
+        sa.Column("id", sa.String(length=64), nullable=False),
+        sa.Column("sync_group_id", sa.String(length=80), nullable=False),
+        sa.Column("project_id", sa.String(length=80), nullable=False),
+        sa.Column("target_type", sa.String(length=64), nullable=False),
+        sa.Column("target_id", sa.String(length=80), nullable=False),
+        sa.Column("author_device_id", sa.String(length=96), nullable=False),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("prior_metadata_json", sa.JSON(), nullable=False, server_default="{}"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_sync_delete_tombstones_group_target",
+        "sync_delete_tombstones",
+        ["sync_group_id", "target_type", "target_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_sync_delete_tombstones_project_id",
+        "sync_delete_tombstones",
+        ["project_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_sync_delete_tombstones_target",
+        "sync_delete_tombstones",
+        ["target_type", "target_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_sync_delete_tombstones_author_device_id",
+        "sync_delete_tombstones",
+        ["author_device_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_sync_delete_tombstones_deleted_at",
+        "sync_delete_tombstones",
+        ["deleted_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_sync_delete_tombstones_deleted_at", table_name="sync_delete_tombstones")
+    op.drop_index("ix_sync_delete_tombstones_author_device_id", table_name="sync_delete_tombstones")
+    op.drop_index("ix_sync_delete_tombstones_target", table_name="sync_delete_tombstones")
+    op.drop_index("ix_sync_delete_tombstones_project_id", table_name="sync_delete_tombstones")
+    op.drop_index("uq_sync_delete_tombstones_group_target", table_name="sync_delete_tombstones")
+    op.drop_table("sync_delete_tombstones")

--- a/apps/backend/app/models.py
+++ b/apps/backend/app/models.py
@@ -3,7 +3,18 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
-from sqlalchemy import JSON, Boolean, CheckConstraint, DateTime, Float, ForeignKey, Index, Integer, String, Text
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.db import Base
@@ -177,6 +188,36 @@ class SyncEntityRevision(Base):
     )
 
     project: Mapped[Project] = relationship(back_populates="sync_entity_revisions")
+
+
+class SyncDeleteTombstone(Base):
+    __tablename__ = "sync_delete_tombstones"
+    __table_args__ = (
+        Index(
+            "uq_sync_delete_tombstones_group_target",
+            "sync_group_id",
+            "target_type",
+            "target_id",
+            unique=True,
+        ),
+        Index("ix_sync_delete_tombstones_project_id", "project_id"),
+        Index("ix_sync_delete_tombstones_target", "target_type", "target_id"),
+        Index("ix_sync_delete_tombstones_author_device_id", "author_device_id"),
+        Index("ix_sync_delete_tombstones_deleted_at", "deleted_at"),
+    )
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    sync_group_id: Mapped[str] = mapped_column(String(80))
+    project_id: Mapped[str] = mapped_column(String(PROJECT_ID_LENGTH))
+    target_type: Mapped[str] = mapped_column(String(64))
+    target_id: Mapped[str] = mapped_column(String(80))
+    author_device_id: Mapped[str] = mapped_column(String(96))
+    deleted_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    prior_metadata_json: Mapped[dict[str, Any]] = mapped_column(JSON(), default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow, onupdate=utcnow
+    )
 
 
 class AnalysisResult(Base):

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -224,11 +224,30 @@ class SyncMetadataArtifactSchema(BaseModel):
     created_at: datetime
 
 
+class SyncDeleteTombstoneSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    tombstone_id: str = Field(validation_alias=AliasChoices("tombstone_id", "id"))
+    sync_group_id: str
+    project_id: str
+    target_type: str
+    target_id: str
+    author_device_id: str
+    deleted_at: datetime
+    prior_metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        validation_alias=AliasChoices("prior_metadata", "prior_metadata_json"),
+    )
+    created_at: datetime
+    updated_at: datetime
+
+
 class SyncMetadataResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     projects: list[SyncMetadataProjectSchema]
     artifacts: list[SyncMetadataArtifactSchema]
+    delete_tombstones: list[SyncDeleteTombstoneSchema] = Field(default_factory=list)
 
 
 class SyncProjectManifestProjectSchema(BaseModel):
@@ -290,6 +309,7 @@ class SyncProjectManifestSchema(BaseModel):
     project: SyncProjectManifestProjectSchema
     entity_revisions: list[SyncProjectManifestEntityRevisionSchema] = Field(default_factory=list)
     artifacts: list[SyncProjectManifestArtifactSchema]
+    delete_tombstones: list[SyncDeleteTombstoneSchema] = Field(default_factory=list)
 
 
 class SyncProjectManifestResponse(BaseModel):

--- a/apps/backend/app/services/artifacts.py
+++ b/apps/backend/app/services/artifacts.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 from app.errors import AppError
 from app.models import Artifact, Job
 from app.services.stem_models import STEM_ARTIFACT_TYPES
+from app.services.sync_tombstones import record_artifact_delete_tombstone
 from app.utils.hashing import file_sha256
 from app.utils.ids import new_id
 
@@ -141,6 +142,7 @@ def delete_project_artifact(session: Session, *, project_id: str, artifact_id: s
             status_code=409,
         )
     if artifact.type in STEM_ARTIFACT_TYPES:
+        record_artifact_delete_tombstone(session, artifact)
         _cleanup_artifact_path(Path(artifact.path))
         session.delete(artifact)
         return
@@ -158,8 +160,10 @@ def delete_project_artifact(session: Session, *, project_id: str, artifact_id: s
     ]
 
     for stem in related_stems:
+        record_artifact_delete_tombstone(session, stem)
         _cleanup_artifact_path(Path(stem.path))
         session.delete(stem)
 
+    record_artifact_delete_tombstone(session, artifact)
     _cleanup_artifact_path(Path(artifact.path))
     session.delete(artifact)

--- a/apps/backend/app/services/projects.py
+++ b/apps/backend/app/services/projects.py
@@ -10,12 +10,17 @@ from sqlalchemy.orm import Session
 
 from app.config import get_settings
 from app.errors import AppError
-from app.models import Project
+from app.models import Artifact, Project, SyncEntityRevision
 from app.services.artifacts import register_artifact
 from app.services.metadata import extract_audio_metadata, normalize_audio_to_wav
 from app.services.paths import ensure_project_dirs, project_root, project_source_dir
 from app.services.sync_identity import source_hash_to_project_id
 from app.services.sync_revisions import record_project_metadata_revision
+from app.services.sync_tombstones import (
+    record_artifact_delete_tombstone,
+    record_entity_revision_delete_tombstone,
+    record_project_delete_tombstone,
+)
 from app.utils.hashing import file_sha256
 
 
@@ -158,6 +163,13 @@ def import_project(
 def delete_project(session: Session, project_id: str) -> None:
     project = get_project(session, project_id)
     root = project_root(project.id)
+    record_project_delete_tombstone(session, project)
+    for artifact in list(session.scalars(select(Artifact).where(Artifact.project_id == project.id))):
+        record_artifact_delete_tombstone(session, artifact)
+    for revision in list(
+        session.scalars(select(SyncEntityRevision).where(SyncEntityRevision.project_id == project.id))
+    ):
+        record_entity_revision_delete_tombstone(session, revision)
     session.delete(project)
     session.flush()
     if root.exists():

--- a/apps/backend/app/services/stems.py
+++ b/apps/backend/app/services/stems.py
@@ -23,6 +23,7 @@ from app.services.stem_models import (
     model_output_artifact_type,
     resolve_stem_model,
 )
+from app.services.sync_tombstones import record_artifact_delete_tombstone
 from app.utils.ids import new_id
 
 
@@ -215,6 +216,7 @@ def _prune_extra_stem_artifacts(
         stem_model_id=stem_model_id,
     ):
         if artifact.id not in keep_ids:
+            record_artifact_delete_tombstone(session, artifact)
             _cleanup_artifact_path(Path(artifact.path))
             session.delete(artifact)
 

--- a/apps/backend/app/services/sync_manifest.py
+++ b/apps/backend/app/services/sync_manifest.py
@@ -17,7 +17,15 @@ from sqlalchemy.orm import Session
 
 from app.config import get_settings
 from app.errors import AppError
-from app.models import Artifact, ChordTimeline, LyricsTranscript, Project, SongSection, SyncEntityRevision
+from app.models import (
+    Artifact,
+    ChordTimeline,
+    LyricsTranscript,
+    Project,
+    SongSection,
+    SyncDeleteTombstone,
+    SyncEntityRevision,
+)
 from app.services.artifacts import register_artifact
 from app.services.paths import ensure_project_dirs, project_root
 from app.services.sync_identity import source_hash_to_project_id
@@ -27,6 +35,8 @@ from app.services.sync_revisions import (
     revision_payload_sha256,
     sanitize_revision_payload,
 )
+from app.services.sync_tombstones import apply_delete_tombstone
+from app.services.sync_trust import get_or_create_local_identity
 from app.utils.hashing import file_sha256
 
 SYNC_PROJECT_MANIFEST_SCHEMA_VERSION = "1"
@@ -68,6 +78,20 @@ class SyncEntityRevisionManifest:
 
 
 @dataclass(frozen=True)
+class SyncDeleteTombstoneManifest:
+    tombstone_id: str
+    sync_group_id: str
+    project_id: str
+    target_type: str
+    target_id: str
+    author_device_id: str
+    deleted_at: datetime
+    prior_metadata: dict[str, Any]
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
 class SyncProjectManifestProject:
     project_id: str
     display_name: str
@@ -87,6 +111,7 @@ class SyncProjectManifest:
     project: SyncProjectManifestProject
     entity_revisions: list[SyncEntityRevisionManifest]
     artifacts: list[SyncArtifactManifest]
+    delete_tombstones: list[SyncDeleteTombstoneManifest]
 
     @property
     def project_id(self) -> str:
@@ -149,6 +174,7 @@ def export_project_manifest(session: Session, project_id: str) -> SyncProjectMan
         )
     )
     entity_revisions = _list_project_entity_revisions(session, project_id=project.id)
+    delete_tombstones = _list_project_delete_tombstones(session, project_id=project.id)
 
     manifest = SyncProjectManifest(
         schema_version=SYNC_PROJECT_MANIFEST_SCHEMA_VERSION,
@@ -169,6 +195,10 @@ def export_project_manifest(session: Session, project_id: str) -> SyncProjectMan
             for revision in entity_revisions
         ],
         artifacts=[_export_artifact_manifest(artifact) for artifact in artifacts],
+        delete_tombstones=[
+            _export_delete_tombstone_manifest(tombstone)
+            for tombstone in delete_tombstones
+        ],
     )
     _validate_source_artifact_present(manifest)
     return manifest
@@ -198,7 +228,21 @@ def import_staged_project_manifest(
     _validate_project_manifest_schema_version(project_manifest)
     _validate_project_manifest_identity(project_manifest)
     source_artifact = _validate_staged_import_source_artifact(project_manifest)
-    _reject_duplicate_project_source(session, project_manifest)
+    local_sync_group_id = get_or_create_local_identity(session).sync_group_id
+    _validate_delete_tombstones(project_manifest, sync_group_id=local_sync_group_id)
+    _reject_locally_tombstoned_manifest_targets(
+        session,
+        project_manifest,
+        sync_group_id=local_sync_group_id,
+    )
+    existing_project = _find_existing_project_source(session, project_manifest)
+    if existing_project is not None:
+        if existing_project.id == project_manifest.project_id and project_manifest.delete_tombstones:
+            imported_tombstones = _import_delete_tombstones(session, project_manifest)
+            _apply_delete_tombstones(session, imported_tombstones)
+            return existing_project
+        raise _duplicate_project_source_error(existing_project.id, existing_project.display_name)
+    _reject_manifest_artifact_conflicts(session, project_manifest)
     root = project_root(project_manifest.project_id).resolve(strict=False)
     staged_root = (
         None if staging_root is None else Path(staging_root).expanduser().resolve(strict=False)
@@ -264,6 +308,8 @@ def import_staged_project_manifest(
                     details={"artifact_id": verified_artifact.manifest.artifact_id},
                 )
         _import_entity_revisions(session, project_manifest)
+        imported_tombstones = _import_delete_tombstones(session, project_manifest)
+        _apply_delete_tombstones(session, imported_tombstones)
         _hydrate_current_entity_revisions(session, project, project_manifest.entity_revisions)
     except OSError as exc:
         _cleanup_copied_artifacts(copied_paths, root)
@@ -302,6 +348,25 @@ def _list_project_entity_revisions(
                 SyncEntityRevision.entity_id.asc(),
                 SyncEntityRevision.created_at.asc(),
                 SyncEntityRevision.id.asc(),
+            )
+        )
+    )
+
+
+def _list_project_delete_tombstones(
+    session: Session,
+    *,
+    project_id: str,
+) -> list[SyncDeleteTombstone]:
+    return list(
+        session.scalars(
+            select(SyncDeleteTombstone)
+            .where(SyncDeleteTombstone.project_id == project_id)
+            .order_by(
+                SyncDeleteTombstone.target_type.asc(),
+                SyncDeleteTombstone.target_id.asc(),
+                SyncDeleteTombstone.deleted_at.asc(),
+                SyncDeleteTombstone.id.asc(),
             )
         )
     )
@@ -385,6 +450,24 @@ def _export_artifact_manifest(artifact: Artifact) -> SyncArtifactManifest:
     )
 
 
+def _export_delete_tombstone_manifest(tombstone: object) -> SyncDeleteTombstoneManifest:
+    prior_metadata = _tombstone_prior_metadata(tombstone)
+    if not isinstance(prior_metadata, dict):
+        prior_metadata = {}
+    return SyncDeleteTombstoneManifest(
+        tombstone_id=_tombstone_id(tombstone),
+        sync_group_id=_attr(tombstone, "sync_group_id"),
+        project_id=_attr(tombstone, "project_id"),
+        target_type=_normalize_tombstone_target_type(_attr(tombstone, "target_type")),
+        target_id=_attr(tombstone, "target_id"),
+        author_device_id=_attr(tombstone, "author_device_id"),
+        deleted_at=_attr(tombstone, "deleted_at"),
+        prior_metadata=cast(dict[str, Any], sanitize_sync_metadata(prior_metadata)),
+        created_at=_attr(tombstone, "created_at"),
+        updated_at=_attr(tombstone, "updated_at"),
+    )
+
+
 def _export_entity_revision_manifest(revision: SyncEntityRevision) -> SyncEntityRevisionManifest:
     metadata = sanitize_revision_payload(revision.metadata_json or {})
     payload = sanitize_revision_payload(revision.payload_json or {})
@@ -464,6 +547,59 @@ def _import_entity_revisions(session: Session, manifest: SyncProjectManifest) ->
         session.add(row)
 
     session.flush()
+
+
+def _import_delete_tombstones(
+    session: Session,
+    manifest: SyncProjectManifest,
+) -> list[SyncDeleteTombstone]:
+    if not manifest.delete_tombstones:
+        return []
+
+    imported: list[SyncDeleteTombstone] = []
+    for tombstone in manifest.delete_tombstones:
+        existing = session.scalar(
+            select(SyncDeleteTombstone).where(
+                SyncDeleteTombstone.sync_group_id == tombstone.sync_group_id,
+                SyncDeleteTombstone.target_type == tombstone.target_type,
+                SyncDeleteTombstone.target_id == tombstone.target_id,
+            )
+        )
+        if existing is not None:
+            imported.append(existing)
+            continue
+        if session.get(SyncDeleteTombstone, tombstone.tombstone_id) is not None:
+            raise AppError(
+                "SYNC_MANIFEST_TOMBSTONE_CONFLICT",
+                "A synced delete tombstone conflicts with an existing local tombstone.",
+                status_code=status.HTTP_409_CONFLICT,
+                details={"tombstone_id": tombstone.tombstone_id},
+            )
+        row = SyncDeleteTombstone(
+            id=tombstone.tombstone_id,
+            sync_group_id=tombstone.sync_group_id,
+            project_id=tombstone.project_id,
+            target_type=tombstone.target_type,
+            target_id=tombstone.target_id,
+            author_device_id=tombstone.author_device_id,
+            deleted_at=tombstone.deleted_at,
+            prior_metadata_json=deepcopy(tombstone.prior_metadata),
+            created_at=tombstone.created_at,
+            updated_at=tombstone.updated_at,
+        )
+        session.add(row)
+        imported.append(row)
+
+    session.flush()
+    return imported
+
+
+def _apply_delete_tombstones(
+    session: Session,
+    tombstones: list[SyncDeleteTombstone],
+) -> None:
+    for tombstone in tombstones:
+        apply_delete_tombstone(session, tombstone)
 
 
 def _validate_entity_revision_base_reference(
@@ -984,6 +1120,137 @@ def _source_artifact_not_wav_error(
     )
 
 
+def _validate_delete_tombstones(
+    manifest: SyncProjectManifest,
+    *,
+    sync_group_id: str,
+) -> None:
+    seen_tombstone_ids: set[str] = set()
+    seen_targets: set[tuple[str, str, str]] = set()
+    live_targets = _manifest_live_targets(manifest)
+    for tombstone in manifest.delete_tombstones:
+        if tombstone.project_id != manifest.project_id:
+            raise AppError(
+                "SYNC_MANIFEST_TOMBSTONE_PROJECT_MISMATCH",
+                "Delete tombstone manifest belongs to a different project.",
+                details={
+                    "tombstone_id": tombstone.tombstone_id,
+                    "project_id": tombstone.project_id,
+                },
+            )
+        if tombstone.sync_group_id != sync_group_id:
+            raise AppError(
+                "SYNC_MANIFEST_TOMBSTONE_SYNC_GROUP_MISMATCH",
+                "Delete tombstone manifest belongs to a different sync group.",
+                details={
+                    "tombstone_id": tombstone.tombstone_id,
+                    "sync_group_id": tombstone.sync_group_id,
+                },
+            )
+        if tombstone.target_type == "project" and tombstone.target_id != manifest.project_id:
+            raise AppError(
+                "SYNC_MANIFEST_TOMBSTONE_PROJECT_TARGET_MISMATCH",
+                "Project delete tombstone target_id must match the manifest project.",
+                details={
+                    "tombstone_id": tombstone.tombstone_id,
+                    "target_id": tombstone.target_id,
+                    "project_id": manifest.project_id,
+                },
+            )
+        if tombstone.tombstone_id in seen_tombstone_ids:
+            raise AppError(
+                "SYNC_MANIFEST_DUPLICATE_TOMBSTONE",
+                "Project manifest contains duplicate delete tombstone IDs.",
+                details={"tombstone_id": tombstone.tombstone_id},
+            )
+        seen_tombstone_ids.add(tombstone.tombstone_id)
+        tombstone_target = (tombstone.sync_group_id, tombstone.target_type, tombstone.target_id)
+        if tombstone_target in seen_targets:
+            raise AppError(
+                "SYNC_MANIFEST_DUPLICATE_TOMBSTONE_TARGET",
+                "Project manifest contains duplicate delete tombstones for the same target.",
+                details={
+                    "sync_group_id": tombstone.sync_group_id,
+                    "target_type": tombstone.target_type,
+                    "target_id": tombstone.target_id,
+                },
+            )
+        seen_targets.add(tombstone_target)
+        if (tombstone.target_type, tombstone.target_id) in live_targets:
+            raise AppError(
+                "SYNC_MANIFEST_TOMBSTONE_LIVE_TARGET",
+                "Project manifest contains a delete tombstone for a live sync target.",
+                details={
+                    "tombstone_id": tombstone.tombstone_id,
+                    "target_type": tombstone.target_type,
+                    "target_id": tombstone.target_id,
+                },
+            )
+
+
+def _reject_locally_tombstoned_manifest_targets(
+    session: Session,
+    manifest: SyncProjectManifest,
+    *,
+    sync_group_id: str,
+) -> None:
+    conflicts = _local_tombstone_conflicts(session, manifest, sync_group_id=sync_group_id)
+    if not conflicts:
+        return
+
+    tombstone = conflicts[0]
+    raise AppError(
+        "SYNC_MANIFEST_LOCAL_TOMBSTONE_CONFLICT",
+        "Project manifest would resurrect a locally tombstoned sync target.",
+        status_code=status.HTTP_409_CONFLICT,
+        details={
+            "tombstone_id": tombstone.tombstone_id,
+            "project_id": tombstone.project_id,
+            "target_type": tombstone.target_type,
+            "target_id": tombstone.target_id,
+        },
+    )
+
+
+def _local_tombstone_conflicts(
+    session: Session,
+    manifest: SyncProjectManifest,
+    *,
+    sync_group_id: str,
+) -> list[SyncDeleteTombstoneManifest]:
+    tombstones = _list_project_delete_tombstones(session, project_id=manifest.project_id)
+    if not tombstones:
+        return []
+
+    live_targets = _manifest_live_targets(manifest)
+    conflicts: list[SyncDeleteTombstoneManifest] = []
+    for row in tombstones:
+        tombstone = _export_delete_tombstone_manifest(row)
+        if tombstone.sync_group_id != sync_group_id:
+            continue
+        target = (_normalize_tombstone_target_type(tombstone.target_type), tombstone.target_id)
+        if target in live_targets:
+            conflicts.append(tombstone)
+    return conflicts
+
+
+def _manifest_live_targets(manifest: SyncProjectManifest) -> set[tuple[str, str]]:
+    targets = {("project", manifest.project_id)}
+    targets.update(("artifact", artifact.artifact_id) for artifact in manifest.artifacts)
+    targets.update(
+        ("entity_revision", revision.revision_id)
+        for revision in manifest.entity_revisions
+    )
+    return targets
+
+
+def _normalize_tombstone_target_type(target_type: str) -> str:
+    normalized = target_type.strip().lower()
+    if normalized in {"revision", "sync_entity_revision"}:
+        return "entity_revision"
+    return normalized
+
+
 def _required_source_sha256(project: Project) -> str:
     if project.source_sha256 is None:
         raise AppError(
@@ -1030,7 +1297,10 @@ def _validate_project_manifest_schema_version(manifest: SyncProjectManifest) -> 
         )
 
 
-def _reject_duplicate_project_source(session: Session, manifest: SyncProjectManifest) -> None:
+def _find_existing_project_source(
+    session: Session,
+    manifest: SyncProjectManifest,
+) -> Project | None:
     existing_project = session.get(Project, manifest.project_id)
     if existing_project is None:
         existing_project = session.scalar(
@@ -1038,9 +1308,18 @@ def _reject_duplicate_project_source(session: Session, manifest: SyncProjectMani
             .where(Project.source_sha256 == manifest.source_sha256)
             .order_by(Project.created_at.asc(), Project.id.asc())
         )
+    return existing_project
+
+
+def _reject_duplicate_project_source(session: Session, manifest: SyncProjectManifest) -> None:
+    existing_project = _find_existing_project_source(session, manifest)
     if existing_project is not None:
         raise _duplicate_project_source_error(existing_project.id, existing_project.display_name)
 
+    _reject_manifest_artifact_conflicts(session, manifest)
+
+
+def _reject_manifest_artifact_conflicts(session: Session, manifest: SyncProjectManifest) -> None:
     for artifact in manifest.artifacts:
         if session.get(Artifact, artifact.artifact_id) is not None:
             raise AppError(
@@ -1090,6 +1369,9 @@ def _coerce_project_manifest(manifest: SyncProjectManifest | Mapping[str, Any] |
     raw_entity_revisions = _field(manifest, "entity_revisions", default=[])
     if not isinstance(raw_entity_revisions, list):
         raise _invalid_manifest("Project manifest entity_revisions must be a list.")
+    raw_delete_tombstones = _field(manifest, "delete_tombstones", default=[])
+    if not isinstance(raw_delete_tombstones, list):
+        raise _invalid_manifest("Project manifest delete_tombstones must be a list.")
 
     project_id = _required_str(project_fields, "project_id")
     source_sha256 = _required_str(project_fields, "source_sha256").strip().lower()
@@ -1113,6 +1395,10 @@ def _coerce_project_manifest(manifest: SyncProjectManifest | Mapping[str, Any] |
             for revision in raw_entity_revisions
         ],
         artifacts=[_coerce_artifact_manifest(artifact) for artifact in raw_artifacts],
+        delete_tombstones=[
+            _coerce_delete_tombstone_manifest(tombstone)
+            for tombstone in raw_delete_tombstones
+        ],
     )
     _validate_project_manifest_identity(project_manifest)
     return project_manifest
@@ -1180,6 +1466,32 @@ def _coerce_entity_revision_manifest(manifest: Mapping[str, Any] | object) -> Sy
         state=_normalize_revision_state(_required_str(manifest, "state")),
         metadata=safe_metadata,
         payload=safe_payload,
+        created_at=_required_datetime(manifest, "created_at"),
+        updated_at=_required_datetime(manifest, "updated_at"),
+    )
+
+
+def _coerce_delete_tombstone_manifest(manifest: Mapping[str, Any] | object) -> SyncDeleteTombstoneManifest:
+    prior_metadata = _field(manifest, "prior_metadata", default={})
+    if not isinstance(prior_metadata, dict):
+        raise _invalid_manifest("Delete tombstone manifest prior_metadata must be an object.")
+    safe_prior_metadata = sanitize_sync_metadata(prior_metadata)
+    if safe_prior_metadata != prior_metadata:
+        raise _invalid_manifest("Delete tombstone manifest prior_metadata must be sync-safe.")
+
+    target_type = _normalize_tombstone_target_type(_required_str(manifest, "target_type"))
+    if target_type not in {"project", "artifact", "entity_revision"}:
+        raise _invalid_manifest("Delete tombstone manifest target_type is unsupported.")
+
+    return SyncDeleteTombstoneManifest(
+        tombstone_id=_required_tombstone_id(manifest),
+        sync_group_id=_required_str(manifest, "sync_group_id"),
+        project_id=_required_str(manifest, "project_id"),
+        target_type=target_type,
+        target_id=_required_str(manifest, "target_id"),
+        author_device_id=_required_str(manifest, "author_device_id"),
+        deleted_at=_required_datetime(manifest, "deleted_at"),
+        prior_metadata=cast(dict[str, Any], safe_prior_metadata),
         created_at=_required_datetime(manifest, "created_at"),
         updated_at=_required_datetime(manifest, "updated_at"),
     )
@@ -1270,6 +1582,15 @@ def _required_str(source: Mapping[str, Any] | object, name: str) -> str:
     value = _field(source, name)
     if not isinstance(value, str) or not value:
         raise _invalid_manifest(f"Project manifest field must be a non-empty string: {name}.")
+    return value
+
+
+def _required_tombstone_id(source: Mapping[str, Any] | object) -> str:
+    value = _field(source, "tombstone_id", default=None)
+    if value is None:
+        value = _field(source, "id")
+    if not isinstance(value, str) or not value:
+        raise _invalid_manifest("Project manifest field must be a non-empty string: tombstone_id.")
     return value
 
 
@@ -1410,3 +1731,23 @@ def _file_size(path: Path) -> int | None:
 
 def _invalid_manifest(message: str) -> AppError:
     return AppError("SYNC_MANIFEST_INVALID", message)
+
+
+def _tombstone_id(tombstone: object) -> str:
+    value = _attr(tombstone, "tombstone_id", default=None)
+    if isinstance(value, str):
+        return value
+    return _attr(tombstone, "id")
+
+
+def _tombstone_prior_metadata(tombstone: object) -> Any:
+    value = _attr(tombstone, "prior_metadata", default=None)
+    if value is not None:
+        return value
+    return _attr(tombstone, "prior_metadata_json", default=None)
+
+
+def _attr(source: object, name: str, *, default: Any = ...) -> Any:
+    if default is ...:
+        return getattr(source, name)
+    return getattr(source, name, default)

--- a/apps/backend/app/services/sync_metadata.py
+++ b/apps/backend/app/services/sync_metadata.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.models import Artifact, Project
+from app.models import Artifact, Project, SyncDeleteTombstone
 from app.services.paths import project_root
 
 LOCAL_METADATA_PATH_KEYS = {
@@ -51,9 +51,24 @@ class SyncMetadataArtifact:
 
 
 @dataclass(frozen=True)
+class SyncMetadataDeleteTombstone:
+    tombstone_id: str
+    sync_group_id: str
+    project_id: str
+    target_type: str
+    target_id: str
+    author_device_id: str
+    deleted_at: datetime
+    prior_metadata: dict[str, Any]
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
 class SyncMetadataResult:
     projects: list[SyncMetadataProject]
     artifacts: list[SyncMetadataArtifact]
+    delete_tombstones: list[SyncMetadataDeleteTombstone]
 
 
 def get_sync_metadata(session: Session) -> SyncMetadataResult:
@@ -67,10 +82,15 @@ def get_sync_metadata(session: Session) -> SyncMetadataResult:
             )
         )
     )
+    delete_tombstones = _list_delete_tombstones(session)
 
     return SyncMetadataResult(
         projects=[_project_metadata(project) for project in projects],
         artifacts=[_artifact_metadata(artifact) for artifact in artifacts],
+        delete_tombstones=[
+            _delete_tombstone_metadata(tombstone)
+            for tombstone in delete_tombstones
+        ],
     )
 
 
@@ -106,12 +126,47 @@ def _artifact_metadata(artifact: Artifact) -> SyncMetadataArtifact:
     )
 
 
+def _delete_tombstone_metadata(tombstone: SyncDeleteTombstone) -> SyncMetadataDeleteTombstone:
+    return SyncMetadataDeleteTombstone(
+        tombstone_id=tombstone.id,
+        sync_group_id=tombstone.sync_group_id,
+        project_id=tombstone.project_id,
+        target_type=tombstone.target_type,
+        target_id=tombstone.target_id,
+        author_device_id=tombstone.author_device_id,
+        deleted_at=tombstone.deleted_at,
+        prior_metadata=cast_metadata(tombstone.prior_metadata_json),
+        created_at=tombstone.created_at,
+        updated_at=tombstone.updated_at,
+    )
+
+
 def project_relative_artifact_path(artifact: Artifact) -> str | None:
     return _project_relative_artifact_path(artifact)
 
 
 def sanitize_sync_metadata(value: Any) -> Any:
     return _sanitize_metadata(value)
+
+
+def cast_metadata(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    return cast(dict[str, Any], _sanitize_metadata(value))
+
+
+def _list_delete_tombstones(session: Session) -> list[SyncDeleteTombstone]:
+    return list(
+        session.scalars(
+            select(SyncDeleteTombstone).order_by(
+                SyncDeleteTombstone.project_id.asc(),
+                SyncDeleteTombstone.target_type.asc(),
+                SyncDeleteTombstone.target_id.asc(),
+                SyncDeleteTombstone.deleted_at.asc(),
+                SyncDeleteTombstone.id.asc(),
+            )
+        )
+    )
 
 
 def _project_relative_artifact_path(artifact: Artifact) -> str | None:
@@ -139,4 +194,6 @@ def _is_local_path_key(key: object) -> bool:
     if not isinstance(key, str):
         return False
     normalized = key.lower()
+    if normalized == "relative_path":
+        return False
     return normalized in LOCAL_METADATA_PATH_KEYS or normalized.endswith("_path")

--- a/apps/backend/app/services/sync_tombstones.py
+++ b/apps/backend/app/services/sync_tombstones.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import shutil
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models import Artifact, Project, SyncDeleteTombstone, SyncEntityRevision, utcnow
+from app.services.paths import project_root
+from app.services.sync_revisions import sanitize_revision_payload
+from app.services.sync_trust import get_or_create_local_identity
+from app.utils.ids import new_id
+
+PROJECT_TARGET_TYPE = "project"
+ARTIFACT_TARGET_TYPE = "artifact"
+ENTITY_REVISION_TARGET_TYPE = "entity_revision"
+
+
+def record_project_delete_tombstone(session: Session, project: Project) -> SyncDeleteTombstone:
+    return _record_delete_tombstone(
+        session,
+        project_id=project.id,
+        target_type=PROJECT_TARGET_TYPE,
+        target_id=project.id,
+        prior_metadata={
+            "project_id": project.id,
+            "display_name": project.display_name,
+            "source_sha256": project.source_sha256,
+            "duration_seconds": project.duration_seconds,
+            "sample_rate": project.sample_rate,
+            "channels": project.channels,
+            "created_at": project.created_at,
+            "updated_at": project.updated_at,
+        },
+    )
+
+
+def record_artifact_delete_tombstone(session: Session, artifact: Artifact) -> SyncDeleteTombstone:
+    return _record_delete_tombstone(
+        session,
+        project_id=artifact.project_id,
+        target_type=ARTIFACT_TARGET_TYPE,
+        target_id=artifact.id,
+        prior_metadata={
+            "artifact_id": artifact.id,
+            "project_id": artifact.project_id,
+            "type": artifact.type,
+            "format": artifact.format,
+            "content_sha256": artifact.content_sha256,
+            "size_bytes": artifact.size_bytes,
+            "generated_by": artifact.generated_by,
+            "can_delete": artifact.can_delete,
+            "can_regenerate": artifact.can_regenerate,
+            "metadata": artifact.metadata_json or {},
+            "cache_key": artifact.cache_key,
+            "created_at": artifact.created_at,
+        },
+    )
+
+
+def record_entity_revision_delete_tombstone(
+    session: Session,
+    revision: SyncEntityRevision,
+) -> SyncDeleteTombstone:
+    return _record_delete_tombstone(
+        session,
+        project_id=revision.project_id,
+        target_type=ENTITY_REVISION_TARGET_TYPE,
+        target_id=revision.id,
+        prior_metadata={
+            "revision_id": revision.id,
+            "project_id": revision.project_id,
+            "entity_type": revision.entity_type,
+            "entity_id": revision.entity_id,
+            "revision_type": revision.revision_type,
+            "base_revision_id": revision.base_revision_id,
+            "source_artifact_id": revision.source_artifact_id,
+            "content_sha256": revision.content_sha256,
+            "author_device_id": revision.author_device_id,
+            "state": revision.state,
+            "metadata": revision.metadata_json or {},
+            "payload": revision.payload_json or {},
+            "created_at": revision.created_at,
+            "updated_at": revision.updated_at,
+        },
+    )
+
+
+def apply_delete_tombstone(session: Session, tombstone: SyncDeleteTombstone) -> None:
+    if tombstone.target_type == PROJECT_TARGET_TYPE:
+        project = session.get(Project, tombstone.target_id)
+        if project is None or project.id != tombstone.project_id:
+            return
+        root = project_root(project.id)
+        session.delete(project)
+        session.flush()
+        if root.exists():
+            shutil.rmtree(root, ignore_errors=True)
+        return
+
+    if tombstone.target_type == ARTIFACT_TARGET_TYPE:
+        artifact = session.get(Artifact, tombstone.target_id)
+        if artifact is None or artifact.project_id != tombstone.project_id:
+            return
+        artifact_path = Path(artifact.path)
+        session.delete(artifact)
+        _cleanup_artifact_path(artifact_path)
+        session.flush()
+        return
+
+    if tombstone.target_type == ENTITY_REVISION_TARGET_TYPE:
+        revision = session.get(SyncEntityRevision, tombstone.target_id)
+        if revision is None or revision.project_id != tombstone.project_id:
+            return
+        session.delete(revision)
+        session.flush()
+
+
+def _record_delete_tombstone(
+    session: Session,
+    *,
+    project_id: str,
+    target_type: str,
+    target_id: str,
+    prior_metadata: Mapping[str, Any],
+) -> SyncDeleteTombstone:
+    identity = get_or_create_local_identity(session)
+    existing = session.scalar(
+        select(SyncDeleteTombstone).where(
+            SyncDeleteTombstone.sync_group_id == identity.sync_group_id,
+            SyncDeleteTombstone.target_type == target_type,
+            SyncDeleteTombstone.target_id == target_id,
+        )
+    )
+    now = utcnow()
+    sanitized_metadata = sanitize_revision_payload(prior_metadata)
+    if existing is not None:
+        existing.project_id = project_id
+        existing.author_device_id = identity.device_id
+        existing.prior_metadata_json = sanitized_metadata
+        existing.updated_at = now
+        session.flush()
+        return existing
+
+    tombstone = SyncDeleteTombstone(
+        id=new_id("del"),
+        sync_group_id=identity.sync_group_id,
+        project_id=project_id,
+        target_type=target_type,
+        target_id=target_id,
+        author_device_id=identity.device_id,
+        deleted_at=now,
+        prior_metadata_json=sanitized_metadata,
+        created_at=now,
+        updated_at=now,
+    )
+    session.add(tombstone)
+    session.flush()
+    return tombstone
+
+
+def _cleanup_artifact_path(path: Path) -> None:
+    if path.exists():
+        path.unlink(missing_ok=True)
+    try:
+        path.parent.rmdir()
+    except OSError:
+        pass

--- a/apps/backend/tests/test_db_migrations.py
+++ b/apps/backend/tests/test_db_migrations.py
@@ -148,6 +148,58 @@ def test_sync_entity_revisions_migration_creates_table_columns_and_indexes() -> 
     assert project_entity_index_columns == ["project_id", "entity_type", "entity_id"]
 
 
+def test_sync_delete_tombstones_migration_creates_table_columns_and_indexes() -> None:
+    settings = get_settings()
+    ensure_data_dirs(settings)
+
+    reconfigure_engine(settings)
+    run_migrations(settings)
+
+    with sqlite3.connect(settings.database_path) as connection:
+        tables = {
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+        columns = {
+            row[1]
+            for row in connection.execute("PRAGMA table_info('sync_delete_tombstones')")
+        }
+        indexes = {
+            row[1]
+            for row in connection.execute("PRAGMA index_list('sync_delete_tombstones')")
+        }
+        group_target_index_columns = [
+            row[2]
+            for row in connection.execute(
+                "PRAGMA index_info('uq_sync_delete_tombstones_group_target')"
+            )
+        ]
+
+    assert "sync_delete_tombstones" in tables
+    assert {
+        "id",
+        "sync_group_id",
+        "project_id",
+        "target_type",
+        "target_id",
+        "author_device_id",
+        "deleted_at",
+        "prior_metadata_json",
+        "created_at",
+        "updated_at",
+    } <= columns
+    assert {
+        "uq_sync_delete_tombstones_group_target",
+        "ix_sync_delete_tombstones_project_id",
+        "ix_sync_delete_tombstones_target",
+        "ix_sync_delete_tombstones_author_device_id",
+        "ix_sync_delete_tombstones_deleted_at",
+    } <= indexes
+    assert group_target_index_columns == ["sync_group_id", "target_type", "target_id"]
+
+
 def test_hash_storage_migration_backfills_existing_files(tmp_path: Path) -> None:
     settings = get_settings()
     ensure_data_dirs(settings)

--- a/apps/backend/tests/test_projects.py
+++ b/apps/backend/tests/test_projects.py
@@ -3,18 +3,35 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
-from app.config import get_settings
-from app.db import SessionLocal
+from app.config import ensure_data_dirs, get_settings
+from app.db import SessionLocal, reconfigure_engine, run_migrations
 from app.errors import AppError
-from app.models import Artifact, Project
+from app.models import Artifact, Project, SyncDeleteTombstone, SyncEntityRevision
 from app.services.analysis import analyze_project
+from app.services.artifacts import delete_project_artifact, register_artifact
 from app.services.paths import project_root
-from app.services.projects import import_project
+from app.services.projects import delete_project, import_project
+from app.services.stems import _prune_extra_stem_artifacts
 from app.services.sync_identity import source_hash_to_project_id, source_hash_to_project_storage_key
+from app.services.sync_tombstones import (
+    ARTIFACT_TARGET_TYPE,
+    ENTITY_REVISION_TARGET_TYPE,
+    PROJECT_TARGET_TYPE,
+)
+from app.services.sync_trust import get_or_create_local_identity
 from app.utils.hashing import file_sha256
+from app.utils.ids import new_id
 from tests.conftest import wait_for_job
+
+
+def _prepare_database() -> None:
+    settings = get_settings()
+    ensure_data_dirs(settings)
+    reconfigure_engine(settings)
+    run_migrations(settings)
 
 
 def test_import_project_persists_metadata_and_source_artifact(client, sample_audio_file: Path):
@@ -196,6 +213,199 @@ def test_import_project_translates_duplicate_project_id_race(
     assert exc.value.message == 'This project is already imported with name "race-fixture".'
     assert exc.value.details == {"project_id": project_id, "project_name": "race-fixture"}
     assert not project_root(project_id).exists()
+
+
+def test_delete_project_records_tombstones_for_cascaded_sync_rows(tmp_path: Path) -> None:
+    _prepare_database()
+    artifact_path = tmp_path / "source.wav"
+    artifact_path.write_bytes(b"source")
+    project_id = "proj_delete_tombstones"
+    revision_id = new_id("rev")
+
+    with SessionLocal() as session:
+        project = Project(
+            id=project_id,
+            display_name="Delete Me",
+            source_sha256="a" * 64,
+            source_path=str(tmp_path / "leaky-source.wav"),
+            imported_path=str(artifact_path),
+        )
+        session.add(project)
+        artifact = register_artifact(
+            session,
+            project_id=project_id,
+            artifact_id="art_delete_source",
+            artifact_type="source_audio",
+            artifact_format="wav",
+            path=artifact_path,
+            metadata={"render_path": str(tmp_path / "render.wav"), "safe": "kept"},
+            generated_by="import",
+            can_delete=False,
+            can_regenerate=False,
+        )
+        identity = get_or_create_local_identity(session)
+        session.add(
+            SyncEntityRevision(
+                id=revision_id,
+                project_id=project_id,
+                entity_type="project_metadata",
+                entity_id=project_id,
+                revision_type="metadata_change",
+                base_revision_id=None,
+                source_artifact_id=None,
+                content_sha256="b" * 64,
+                author_device_id=identity.device_id,
+                state="active",
+                metadata_json={"local_path": str(tmp_path / "metadata.wav"), "safe": "metadata"},
+                payload_json={"display_name": "Delete Me"},
+            )
+        )
+        session.flush()
+
+        delete_project(session, project_id)
+        session.commit()
+
+        tombstones = list(session.query(SyncDeleteTombstone).order_by(SyncDeleteTombstone.target_type))
+        tombstone_keys = {(tombstone.target_type, tombstone.target_id) for tombstone in tombstones}
+
+        assert session.get(Project, project_id) is None
+        assert session.get(Artifact, artifact.id) is None
+        assert session.get(SyncEntityRevision, revision_id) is None
+        assert tombstone_keys == {
+            (PROJECT_TARGET_TYPE, project_id),
+            (ARTIFACT_TARGET_TYPE, artifact.id),
+            (ENTITY_REVISION_TARGET_TYPE, revision_id),
+        }
+        artifact_tombstone = next(
+            tombstone for tombstone in tombstones if tombstone.target_type == ARTIFACT_TARGET_TYPE
+        )
+        assert artifact_tombstone.sync_group_id == identity.sync_group_id
+        assert artifact_tombstone.author_device_id == identity.device_id
+        assert artifact_tombstone.prior_metadata_json["metadata"] == {"safe": "kept"}
+        assert "path" not in artifact_tombstone.prior_metadata_json
+
+
+def test_delete_preview_mix_records_tombstones_for_related_stems(tmp_path: Path) -> None:
+    _prepare_database()
+    mix_path = tmp_path / "mix.wav"
+    related_stem_path = tmp_path / "mix-vocals.wav"
+    source_stem_path = tmp_path / "source-vocals.wav"
+    for path in (mix_path, related_stem_path, source_stem_path):
+        path.write_bytes(path.name.encode("utf-8"))
+
+    with SessionLocal() as session:
+        project = Project(
+            id="proj_mix_tombstones",
+            display_name="Mix Delete",
+            source_sha256="c" * 64,
+            source_path=str(tmp_path / "source.wav"),
+            imported_path=str(tmp_path / "source.wav"),
+        )
+        session.add(project)
+        mix = register_artifact(
+            session,
+            project_id=project.id,
+            artifact_id="art_mix_delete",
+            artifact_type="preview_mix",
+            artifact_format="wav",
+            path=mix_path,
+            metadata={"transpose": {"semitones": 1}},
+        )
+        related_stem = register_artifact(
+            session,
+            project_id=project.id,
+            artifact_id="art_mix_vocal_stem",
+            artifact_type="vocal_stem",
+            artifact_format="wav",
+            path=related_stem_path,
+            metadata={"source_artifact_id": mix.id, "source_artifact_type": "preview_mix"},
+        )
+        source_stem = register_artifact(
+            session,
+            project_id=project.id,
+            artifact_id="art_source_vocal_stem",
+            artifact_type="vocal_stem",
+            artifact_format="wav",
+            path=source_stem_path,
+            metadata={"source_artifact_id": "art_source", "source_artifact_type": "source_audio"},
+        )
+
+        delete_project_artifact(session, project_id=project.id, artifact_id=mix.id)
+        session.commit()
+
+        tombstone_ids = {
+            tombstone.target_id
+            for tombstone in session.query(SyncDeleteTombstone).filter_by(
+                project_id=project.id,
+                target_type=ARTIFACT_TARGET_TYPE,
+            )
+        }
+
+        assert session.get(Artifact, mix.id) is None
+        assert session.get(Artifact, related_stem.id) is None
+        assert session.get(Artifact, source_stem.id) is not None
+        assert tombstone_ids == {mix.id, related_stem.id}
+
+
+def test_pruning_stem_artifacts_records_tombstones(tmp_path: Path) -> None:
+    _prepare_database()
+    kept_path = tmp_path / "kept-vocals.wav"
+    pruned_path = tmp_path / "pruned-drums.wav"
+    source_path = tmp_path / "source.wav"
+    for path in (kept_path, pruned_path, source_path):
+        path.write_bytes(path.name.encode("utf-8"))
+
+    with SessionLocal() as session:
+        project = Project(
+            id="proj_prune_stem_tombstones",
+            display_name="Stem Prune",
+            source_sha256="d" * 64,
+            source_path=str(source_path),
+            imported_path=str(source_path),
+        )
+        session.add(project)
+        kept = register_artifact(
+            session,
+            project_id=project.id,
+            artifact_id="art_kept_vocals",
+            artifact_type="vocal_stem",
+            artifact_format="wav",
+            path=kept_path,
+            metadata={"source_artifact_id": "art_source", "stem_model": "htdemucs_6s"},
+        )
+        pruned = register_artifact(
+            session,
+            project_id=project.id,
+            artifact_id="art_pruned_drums",
+            artifact_type="drums_stem",
+            artifact_format="wav",
+            path=pruned_path,
+            metadata={"source_artifact_id": "art_source", "stem_model": "htdemucs_6s"},
+        )
+
+        _prune_extra_stem_artifacts(
+            session,
+            project_id=project.id,
+            source_artifact_id="art_source",
+            stem_model_id="htdemucs_6s",
+            keep_ids={kept.id},
+        )
+        session.commit()
+
+        tombstone = session.scalar(
+            select(SyncDeleteTombstone).where(
+                SyncDeleteTombstone.target_type == ARTIFACT_TARGET_TYPE,
+                SyncDeleteTombstone.target_id == pruned.id,
+            )
+        )
+        assert session.get(Artifact, kept.id) is not None
+        assert session.get(Artifact, pruned.id) is None
+        assert tombstone is not None
+        assert tombstone.project_id == project.id
+        assert tombstone.prior_metadata_json["metadata"] == {
+            "source_artifact_id": "art_source",
+            "stem_model": "htdemucs_6s",
+        }
 
 
 def test_import_project_enqueues_analysis_and_chords(client, sample_chord_audio_file: Path):

--- a/apps/backend/tests/test_sync_manifest.py
+++ b/apps/backend/tests/test_sync_manifest.py
@@ -24,11 +24,13 @@ from app.models import (
     LyricsTranscript,
     Project,
     SongSection,
+    SyncDeleteTombstone,
     SyncEntityRevision,
 )
 from app.services.paths import project_root
 from app.services.sync_identity import source_hash_to_project_id
 from app.services.sync_revisions import CURRENT_REVISION_STATE
+from app.services.sync_trust import get_or_create_local_identity
 from app.utils.hashing import file_sha256
 
 ManifestService = Callable[..., Any]
@@ -55,6 +57,20 @@ class ManifestProjectFixture:
     artifact_hashes: dict[str, str]
     artifact_sizes: dict[str, int]
     external_source_path: Path
+
+
+@dataclass(frozen=True)
+class FakeSyncDeleteTombstone:
+    id: str
+    sync_group_id: str
+    project_id: str
+    target_type: str
+    target_id: str
+    author_device_id: str
+    deleted_at: datetime
+    prior_metadata: dict[str, Any]
+    created_at: datetime
+    updated_at: datetime
 
 
 def _sync_manifest_services() -> tuple[ManifestService, ManifestService]:
@@ -102,22 +118,26 @@ def _plain_manifest(value: Any) -> dict[str, Any]:
         project = manifest["project"]
         artifacts = manifest.get("artifacts")
         entity_revisions = manifest.get("entity_revisions", [])
+        delete_tombstones = manifest.get("delete_tombstones", [])
     else:
         project = {
             key: child
             for key, child in manifest.items()
-            if key not in {"artifacts", "entity_revisions"}
+            if key not in {"artifacts", "entity_revisions", "delete_tombstones"}
         }
         artifacts = manifest.get("artifacts")
         entity_revisions = manifest.get("entity_revisions", [])
+        delete_tombstones = manifest.get("delete_tombstones", [])
 
     assert isinstance(project, dict)
     assert isinstance(artifacts, list)
     assert isinstance(entity_revisions, list)
+    assert isinstance(delete_tombstones, list)
     result: dict[str, Any] = {
         "project": project,
         "artifacts": artifacts,
         "entity_revisions": entity_revisions,
+        "delete_tombstones": delete_tombstones,
     }
     if "schema_version" in manifest:
         result["schema_version"] = manifest["schema_version"]
@@ -330,6 +350,30 @@ def _add_entity_revision(
             created_at=timestamp,
             updated_at=updated_at or timestamp,
         )
+    )
+
+
+def _fake_delete_tombstone(
+    *,
+    tombstone_id: str,
+    project_id: str,
+    target_type: str,
+    target_id: str,
+    sync_group_id: str = "sync_group_alpha",
+    prior_metadata: dict[str, Any] | None = None,
+) -> FakeSyncDeleteTombstone:
+    timestamp = datetime(2026, 1, 2, tzinfo=UTC)
+    return FakeSyncDeleteTombstone(
+        id=tombstone_id,
+        sync_group_id=sync_group_id,
+        project_id=project_id,
+        target_type=target_type,
+        target_id=target_id,
+        author_device_id="device_alpha",
+        deleted_at=timestamp,
+        prior_metadata=prior_metadata or {},
+        created_at=timestamp,
+        updated_at=timestamp,
     )
 
 
@@ -654,6 +698,63 @@ def test_export_project_manifest_includes_entity_revisions_without_local_paths(
         {"start_seconds": 0.0, "end_seconds": 1.0, "label": "Am"}
     ]
     assert chord_revision["payload"]["metadata"] == {"reviewed": True}
+
+
+def test_export_project_manifest_includes_delete_tombstones_without_local_paths(
+    client: object,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    module = importlib.import_module("app.services.sync_manifest")
+    export_manifest, _ = _sync_manifest_services()
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path)
+        tombstones = [
+            _fake_delete_tombstone(
+                tombstone_id="tomb_art_deleted",
+                project_id=fixture.project_id,
+                target_type="artifact",
+                target_id="art_deleted",
+                prior_metadata={
+                    "type": "preview_mix",
+                    "path": str(tmp_path / "local-preview.wav"),
+                    "relative_path": "previews/mix.wav",
+                },
+            ),
+            _fake_delete_tombstone(
+                tombstone_id="tomb_revision_deleted",
+                project_id=fixture.project_id,
+                target_type="entity_revision",
+                target_id="rev_deleted",
+                prior_metadata={"entity_type": "section", "source_path": str(tmp_path / "tab.txt")},
+            ),
+        ]
+        monkeypatch.setattr(module, "_list_project_delete_tombstones", lambda *args, **kwargs: tombstones)
+
+        manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+
+    _assert_no_absolute_local_paths(manifest, (tmp_path, fixture.root))
+    _assert_no_local_path_keys(manifest)
+
+    delete_tombstones = manifest["delete_tombstones"]
+    assert [tombstone["tombstone_id"] for tombstone in delete_tombstones] == [
+        "tomb_art_deleted",
+        "tomb_revision_deleted",
+    ]
+    artifact_tombstone = delete_tombstones[0]
+    assert artifact_tombstone["sync_group_id"] == "sync_group_alpha"
+    assert artifact_tombstone["project_id"] == fixture.project_id
+    assert artifact_tombstone["target_type"] == "artifact"
+    assert artifact_tombstone["target_id"] == "art_deleted"
+    assert artifact_tombstone["author_device_id"] == "device_alpha"
+    assert artifact_tombstone["prior_metadata"] == {
+        "type": "preview_mix",
+        "relative_path": "previews/mix.wav",
+    }
+    assert "deleted_at" in artifact_tombstone
+    assert "created_at" in artifact_tombstone
+    assert "updated_at" in artifact_tombstone
 
 
 @pytest.mark.parametrize("unportable_path", ["outside_project_root", "project_root_directory"])
@@ -1005,6 +1106,198 @@ def test_import_staged_project_manifest_rejects_non_sync_safe_revision_payload(
 
     assert exc.value.code == "SYNC_MANIFEST_INVALID"
     assert "sync-safe" in exc.value.message
+
+
+@pytest.mark.parametrize(
+    ("target_type", "target_id_key"),
+    [
+        ("project", "project"),
+        ("artifact", "artifact"),
+        ("entity_revision", "entity_revision"),
+    ],
+)
+def test_import_staged_project_manifest_rejects_locally_tombstoned_targets(
+    client: object,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    target_type: str,
+    target_id_key: str,
+) -> None:
+    module = importlib.import_module("app.services.sync_manifest")
+    export_manifest, import_manifest = _sync_manifest_services()
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path)
+        _add_project_entity_revisions(session, fixture)
+        sync_group_id = get_or_create_local_identity(session).sync_group_id
+        manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+        target_ids = {
+            "project": fixture.project_id,
+            "artifact": "art_vocals",
+            "entity_revision": "rev_chords_current",
+        }
+        tombstone = _fake_delete_tombstone(
+            tombstone_id=f"tomb_{target_type}",
+            project_id=fixture.project_id,
+            target_type=target_type,
+            target_id=target_ids[target_id_key],
+            sync_group_id=sync_group_id,
+        )
+        monkeypatch.setattr(
+            module,
+            "_list_project_delete_tombstones",
+            lambda *args, **kwargs: [tombstone],
+        )
+        _delete_live_project(session, fixture)
+
+        with pytest.raises(AppError) as exc:
+            import_manifest(session, manifest=manifest, staging_root=tmp_path / "unused-staging")
+
+    assert exc.value.code == "SYNC_MANIFEST_LOCAL_TOMBSTONE_CONFLICT"
+    assert exc.value.status_code == 409
+    assert exc.value.details == {
+        "tombstone_id": f"tomb_{target_type}",
+        "project_id": fixture.project_id,
+        "target_type": target_type,
+        "target_id": target_ids[target_id_key],
+    }
+
+
+def test_import_staged_project_manifest_persists_delete_tombstones(
+    client: object,
+    tmp_path: Path,
+) -> None:
+    export_manifest, import_manifest = _sync_manifest_services()
+    staging_root = tmp_path / "staging"
+    timestamp = "2026-01-02T00:00:00+00:00"
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path)
+        sync_group_id = get_or_create_local_identity(session).sync_group_id
+        manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+        manifest["delete_tombstones"] = [
+            {
+                "tombstone_id": "tomb_deleted_mix",
+                "sync_group_id": sync_group_id,
+                "project_id": fixture.project_id,
+                "target_type": "artifact",
+                "target_id": "art_deleted_mix",
+                "author_device_id": "device_alpha",
+                "deleted_at": timestamp,
+                "prior_metadata": {
+                    "type": "preview_mix",
+                    "relative_path": "previews/deleted-mix.wav",
+                },
+                "created_at": timestamp,
+                "updated_at": timestamp,
+            }
+        ]
+        _stage_manifest_files(manifest, staging_root=staging_root, source_root=fixture.root)
+        _delete_live_project(session, fixture)
+
+        import_manifest(session, manifest=manifest, staging_root=staging_root)
+        session.commit()
+
+        tombstone = session.get(SyncDeleteTombstone, "tomb_deleted_mix")
+        assert tombstone is not None
+        assert tombstone.sync_group_id == sync_group_id
+        assert tombstone.project_id == fixture.project_id
+        assert tombstone.target_type == "artifact"
+        assert tombstone.target_id == "art_deleted_mix"
+        assert tombstone.author_device_id == "device_alpha"
+        assert tombstone.prior_metadata_json == {
+            "type": "preview_mix",
+            "relative_path": "previews/deleted-mix.wav",
+        }
+
+
+def test_import_staged_project_manifest_rejects_out_of_group_delete_tombstones(
+    client: object,
+    tmp_path: Path,
+) -> None:
+    export_manifest, import_manifest = _sync_manifest_services()
+    timestamp = "2026-01-02T00:00:00+00:00"
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path)
+        get_or_create_local_identity(session)
+        manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+        manifest["delete_tombstones"] = [
+            {
+                "tombstone_id": "tomb_wrong_group",
+                "sync_group_id": "sync_group_other",
+                "project_id": fixture.project_id,
+                "target_type": "artifact",
+                "target_id": "art_deleted_mix",
+                "author_device_id": "device_alpha",
+                "deleted_at": timestamp,
+                "prior_metadata": {},
+                "created_at": timestamp,
+                "updated_at": timestamp,
+            }
+        ]
+
+        with pytest.raises(AppError) as exc:
+            import_manifest(session, manifest=manifest, staging_root=None)
+
+    assert exc.value.code == "SYNC_MANIFEST_TOMBSTONE_SYNC_GROUP_MISMATCH"
+    assert exc.value.details == {
+        "tombstone_id": "tomb_wrong_group",
+        "sync_group_id": "sync_group_other",
+    }
+
+
+def test_import_staged_project_manifest_applies_delete_tombstones_to_existing_project(
+    client: object,
+    tmp_path: Path,
+) -> None:
+    export_manifest, import_manifest = _sync_manifest_services()
+    timestamp = "2026-01-02T00:00:00+00:00"
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path)
+        sync_group_id = get_or_create_local_identity(session).sync_group_id
+        manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+        deleted_path = fixture.root / "previews" / "deleted-mix.wav"
+        deleted_hash, deleted_size = _write_bytes(deleted_path, b"deleted mix")
+        session.add(
+            Artifact(
+                id="art_deleted_mix",
+                project_id=fixture.project_id,
+                type="preview_mix",
+                format="wav",
+                path=str(deleted_path),
+                content_sha256=deleted_hash,
+                size_bytes=deleted_size,
+                generated_by="preview",
+                can_delete=True,
+                can_regenerate=True,
+                metadata_json={"source_artifact_id": "art_source_audio"},
+            )
+        )
+        session.flush()
+        manifest["delete_tombstones"] = [
+            {
+                "tombstone_id": "tomb_existing_deleted_mix",
+                "sync_group_id": sync_group_id,
+                "project_id": fixture.project_id,
+                "target_type": "artifact",
+                "target_id": "art_deleted_mix",
+                "author_device_id": "device_alpha",
+                "deleted_at": timestamp,
+                "prior_metadata": {"type": "preview_mix"},
+                "created_at": timestamp,
+                "updated_at": timestamp,
+            }
+        ]
+
+        imported_project = import_manifest(session, manifest=manifest, staging_root=None)
+        session.commit()
+
+        assert imported_project.id == fixture.project_id
+        assert session.get(Artifact, "art_deleted_mix") is None
+        assert not deleted_path.exists()
+        assert session.get(SyncDeleteTombstone, "tomb_existing_deleted_mix") is not None
 
 
 def test_import_staged_project_manifest_imports_content_addressed_staging(

--- a/docs/API.md
+++ b/docs/API.md
@@ -286,6 +286,19 @@ Artifact fields:
 - `metadata`
 - `created_at`
 
+Delete tombstone fields:
+
+- `tombstone_id`
+- `sync_group_id`
+- `project_id`
+- `target_type`
+- `target_id`
+- `author_device_id`
+- `deleted_at`
+- `prior_metadata`
+- `created_at`
+- `updated_at`
+
 `relative_path` is project-root relative when the artifact is stored under the backend-managed project root; otherwise it is `null`. Operational `source_audio` artifacts are app-managed WAV files under the project root. Artifact metadata is sanitized recursively before returning and removes local path-bearing keys such as `source_path`, `original_copy_path`, `playback_path`, `imported_path`, and any metadata key ending in `_path`. Non-path metadata such as retune/transpose settings, `stem_model`, and `source_artifact_id` is preserved. Job internals such as `result_artifact_ids_json` are not exposed.
 
 ### Export project sync manifest
@@ -297,9 +310,15 @@ Returns a single project manifest for manifest-only sync export. The response is
 - `schema_version`
 - `exported_at`
 - `project`
+- `entity_revisions`
 - `artifacts`
+- `delete_tombstones`
 
 Manifest paths are project-root relative and use portable path separators. The response does not expose absolute local source, project, artifact, or app data paths. The project entry's `source_sha256` is the identity hash of the original imported source bytes. Artifact entries' `content_sha256` values hash the bytes for those specific staged artifact files, including the `source_audio` artifact. These hashes are separate on purpose: an app-managed normalized WAV source artifact may have different bytes from the original import identity hash. `sync_entity_revisions.content_sha256` is also per-entity revision payload content, not project source identity. Projects whose `source_audio` artifact is not an app-managed readable PCM WAV must be reimported or repaired before manifest export. Receiving peers must verify staged files against the artifact SHA-256 values and must preserve the project `source_sha256` as identity metadata before accepting the import. The endpoint exports metadata only. File transfer and LAN peer discovery belong to the native sync layer, not the loopback FastAPI API.
+
+`entity_revisions` carries durable sync records for project metadata, chords, lyrics, sections, regeneration events, and other editable or generated project entities. Each revision records `revision_id`, `project_id`, `entity_type`, `entity_id`, `revision_type`, optional `base_revision_id`, `author_device_id`, optional `source_artifact_id`, `content_sha256`, `state`, `metadata`, `payload`, `created_at`, and `updated_at`.
+
+`delete_tombstones` carries durable group-delete records for project, artifact, and entity revision targets so offline peers do not resurrect deleted records when they reconnect. Each tombstone records the author device, delete timestamp, target type, target ID, sync group/project context, and prior metadata needed for diagnostics.
 
 ### Import staged project sync manifest
 
@@ -318,7 +337,7 @@ If the local library already contains the same canonical project or source SHA-2
 
 - `project`
 
-Staged import does not enqueue analysis, chord, lyrics, stem, or other generation jobs. Synced projects should import the durable state that was actually exported; future rebuilds are explicit user actions. This endpoint also does not expose FastAPI on the LAN. Peer communication should keep using the separate native sync layer while FastAPI remains bound to loopback.
+Staged import does not enqueue analysis, chord, lyrics, stem, or other generation jobs. Synced projects should import the durable state that was actually exported; future rebuilds are explicit user actions. Imports must reject older manifests that would recreate a project, artifact, or entity revision covered by an accepted delete tombstone. This endpoint also does not expose FastAPI on the LAN. Peer communication should keep using the separate native sync layer while FastAPI remains bound to loopback.
 
 ## Projects
 

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -1234,6 +1234,40 @@ export interface components {
                 [key: string]: unknown;
             };
         };
+        /** SyncDeleteTombstoneSchema */
+        SyncDeleteTombstoneSchema: {
+            /** Tombstone Id */
+            tombstone_id: string;
+            /** Sync Group Id */
+            sync_group_id: string;
+            /** Project Id */
+            project_id: string;
+            /** Target Type */
+            target_type: string;
+            /** Target Id */
+            target_id: string;
+            /** Author Device Id */
+            author_device_id: string;
+            /**
+             * Deleted At
+             * Format: date-time
+             */
+            deleted_at: string;
+            /** Prior Metadata */
+            prior_metadata?: {
+                [key: string]: unknown;
+            };
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+        };
         /** SyncLocalIdentityResponse */
         SyncLocalIdentityResponse: {
             identity: components["schemas"]["SyncLocalIdentitySchema"];
@@ -1325,6 +1359,8 @@ export interface components {
             projects: components["schemas"]["SyncMetadataProjectSchema"][];
             /** Artifacts */
             artifacts: components["schemas"]["SyncMetadataArtifactSchema"][];
+            /** Delete Tombstones */
+            delete_tombstones?: components["schemas"]["SyncDeleteTombstoneSchema"][];
         };
         /** SyncPairingOfferRequest */
         SyncPairingOfferRequest: {
@@ -1564,6 +1600,8 @@ export interface components {
             entity_revisions?: components["schemas"]["SyncProjectManifestEntityRevisionSchema"][];
             /** Artifacts */
             artifacts: components["schemas"]["SyncProjectManifestArtifactSchema"][];
+            /** Delete Tombstones */
+            delete_tombstones?: components["schemas"]["SyncDeleteTombstoneSchema"][];
         };
         /** SyncProjectStagedImportRequest */
         SyncProjectStagedImportRequest: {


### PR DESCRIPTION
## Summary

- Add durable sync delete tombstones for project, artifact, and entity revision deletes.
- Include tombstones in sync metadata and project manifests so offline peers do not resurrect deleted records.
- Preserve the #137/#138 source hash split: project identity stays on original bytes, while source artifacts stay app-managed WAV files with their own content hashes.
- Closes #116

## Testing

- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `cd apps/backend && uv run --python 3.11 pytest tests/test_db_migrations.py tests/test_projects.py tests/test_sync_manifest.py tests/test_sync_revisions.py`
- `pnpm contracts:generate`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm exec commitlint --from origin/main --to HEAD --verbose`
