### PR TITLE
feat: Queue full import processing

### DIFF
--- a/apps/backend/app/api/routes/projects.py
+++ b/apps/backend/app/api/routes/projects.py
@@ -115,10 +115,42 @@ def create_project(
             "chord_source": "source",
         },
     )
+    lyrics_job = runner.create_job(
+        session,
+        project_id=project.id,
+        job_type="lyrics",
+        payload=LyricsGenerateRequest(force=False).model_dump(),
+    )
+    source_artifact = resolve_stem_source_artifact(
+        session,
+        project=project,
+        source_artifact_id=None,
+    )
+    selected_stem_model = resolve_stem_model(payload.stem_model, require_available=False)
+    stem_job = runner.create_job(
+        session,
+        project_id=project.id,
+        job_type="stems",
+        payload={
+            **StemRequest(
+                mode="stems",
+                stem_model=selected_stem_model.id,
+                output_format="wav",
+                force=False,
+                source_artifact_id=source_artifact.id,
+                chord_backend=selected_chord_backend.id,
+                chord_backend_fallback_from=chord_backend_fallback_from,
+                overwrite_chord_edits=False,
+            ).model_dump(),
+            "stem_model_label": selected_stem_model.label,
+        },
+    )
     session.commit()
     session.refresh(project)
     runner.enqueue(analyze_job.id)
     runner.enqueue(chords_job.id)
+    runner.enqueue(lyrics_job.id)
+    runner.enqueue(stem_job.id)
     return ProjectResponse(project=ProjectSchema.model_validate(project))
 
 

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -75,10 +75,13 @@ class ProjectImportRequest(BaseModel):
     display_name: str | None = None
     chord_backend: str | None = None
     chord_backend_fallback_from: str | None = None
+    stem_model: str | None = None
 
     @model_validator(mode="after")
-    def validate_chord_backend(self) -> ProjectImportRequest:
+    def validate_import_request(self) -> ProjectImportRequest:
         _validate_chord_backend_fields(self.chord_backend, self.chord_backend_fallback_from)
+        if self.stem_model is not None and self.stem_model not in SUPPORTED_STEM_MODELS:
+            raise ValueError("Unsupported stem model.")
         return self
 
 

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -69,6 +69,29 @@ def isolated_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     get_settings.cache_clear()
 
 
+@pytest.fixture(autouse=True)
+def fast_lyrics_engine(isolated_data_dir, monkeypatch: pytest.MonkeyPatch):
+    from app.engines.lyrics import LyricsTranscription
+
+    def fake_transcription(*_args, **_kwargs):
+        return LyricsTranscription(
+            backend="openai-whisper",
+            requested_device="cpu",
+            device="cpu",
+            model="turbo",
+            language="en",
+            segments=[
+                {
+                    "start_seconds": 0.0,
+                    "end_seconds": 1.0,
+                    "text": "Test lyric",
+                }
+            ],
+        )
+
+    monkeypatch.setattr("app.services.lyrics.transcribe_project_lyrics", fake_transcription)
+
+
 @pytest.fixture()
 def client() -> TestClient:
     from app.main import app

--- a/apps/backend/tests/test_lyrics_flow.py
+++ b/apps/backend/tests/test_lyrics_flow.py
@@ -13,16 +13,20 @@ def _first_source_artifact_id(client, project_id: str) -> str:
     return next(artifact["id"] for artifact in artifacts if artifact["type"] == "source_audio")
 
 
-def test_get_lyrics_returns_empty_payload_until_generated(client, sample_audio_file: Path):
+def test_import_queues_lyrics_generation(client, sample_audio_file: Path):
     project = client.post(
         "/api/v1/projects/import",
         json={"source_path": str(sample_audio_file), "copy_into_project": True},
     ).json()["project"]
 
+    jobs = client.get("/api/v1/jobs").json()["jobs"]
+    lyrics_job = next(job for job in jobs if job["project_id"] == project["id"] and job["type"] == "lyrics")
+    assert wait_for_job(client, lyrics_job["id"])["status"] == "completed"
+
     payload = client.get(f"/api/v1/projects/{project['id']}/lyrics").json()
     assert payload["project_id"] == project["id"]
-    assert payload["segments"] == []
-    assert payload["source_segments"] == []
+    assert payload["segments"][0]["text"] == "Test lyric"
+    assert payload["source_segments"][0]["text"] == "Test lyric"
     assert payload["has_user_edits"] is False
 
 

--- a/apps/backend/tests/test_projects.py
+++ b/apps/backend/tests/test_projects.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import pytest
+import soundfile as sf
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
@@ -32,6 +34,17 @@ def _prepare_database() -> None:
     ensure_data_dirs(settings)
     reconfigure_engine(settings)
     run_migrations(settings)
+
+
+def _wait_for_project_job(client, project_id: str, predicate, *, timeout: float = 5.0) -> dict:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        jobs = client.get("/api/v1/jobs").json()["jobs"]
+        for job in jobs:
+            if job["project_id"] == project_id and predicate(job):
+                return job
+        time.sleep(0.1)
+    raise AssertionError(f"Timed out waiting for matching job in project {project_id}")
 
 
 def test_import_project_persists_metadata_and_source_artifact(client, sample_audio_file: Path):
@@ -408,30 +421,91 @@ def test_pruning_stem_artifacts_records_tombstones(tmp_path: Path) -> None:
         }
 
 
-def test_import_project_enqueues_analysis_and_chords(client, sample_chord_audio_file: Path):
+def test_import_project_enqueues_full_source_processing(
+    client,
+    sample_chord_audio_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def fake_separate_two_stems(
+        source_path: Path,
+        vocal_path: Path,
+        instrumental_path: Path,
+        *,
+        model: str,
+        device: str,
+        model_repo=None,
+        on_progress=None,
+        should_cancel=None,
+        register_process=None,
+        unregister_process=None,
+    ):
+        signal, sample_rate = sf.read(source_path, always_2d=True)
+        vocal_path.parent.mkdir(parents=True, exist_ok=True)
+        instrumental_path.parent.mkdir(parents=True, exist_ok=True)
+        sf.write(vocal_path, signal * 0.7, sample_rate)
+        sf.write(instrumental_path, signal * 0.3, sample_rate)
+        if on_progress:
+            on_progress(98)
+        return {"engine": "demucs", "model": model, "requested_device": device, "device": "cpu"}
+
+    monkeypatch.setattr("app.services.stems.separate_two_stems", fake_separate_two_stems)
+
     response = client.post(
         "/api/v1/projects/import",
-        json={"source_path": str(sample_chord_audio_file), "copy_into_project": True},
+        json={
+            "source_path": str(sample_chord_audio_file),
+            "copy_into_project": True,
+            "stem_model": "htdemucs_ft",
+        },
     )
 
     assert response.status_code == 200
     project = response.json()["project"]
+    source_artifact = next(
+        artifact
+        for artifact in client.get(f"/api/v1/projects/{project['id']}/artifacts").json()["artifacts"]
+        if artifact["type"] == "source_audio"
+    )
 
     jobs = client.get("/api/v1/jobs").json()["jobs"]
     analyze_job = next(job for job in jobs if job["project_id"] == project["id"] and job["type"] == "analyze")
-    chord_job = next(job for job in jobs if job["project_id"] == project["id"] and job["type"] == "chords")
+    chord_job = next(
+        job
+        for job in jobs
+        if job["project_id"] == project["id"] and job["type"] == "chords" and job["chord_source"] == "source"
+    )
+    lyrics_job = next(job for job in jobs if job["project_id"] == project["id"] and job["type"] == "lyrics")
+    stem_job = next(job for job in jobs if job["project_id"] == project["id"] and job["type"] == "stems")
 
-    assert wait_for_job(client, analyze_job["id"])["status"] == "completed"
-    completed_chord_job = wait_for_job(client, chord_job["id"])
+    assert wait_for_job(client, analyze_job["id"], timeout=90.0)["status"] == "completed"
+    completed_chord_job = wait_for_job(client, chord_job["id"], timeout=90.0)
     assert completed_chord_job["status"] == "completed"
     assert completed_chord_job["chord_backend"] == "tuneforge-fast"
     assert completed_chord_job["chord_source"] == "source"
+    assert wait_for_job(client, lyrics_job["id"])["status"] == "completed"
+    completed_stem_job = wait_for_job(client, stem_job["id"])
+    assert completed_stem_job["status"] == "completed"
+    assert completed_stem_job["source_artifact_id"] == source_artifact["id"]
+    assert completed_stem_job["stem_model"] == "htdemucs_ft"
+    assert completed_stem_job["stem_model_label"] == "2 stems model"
+
+    chord_refresh_job = _wait_for_project_job(
+        client,
+        project["id"],
+        lambda job: job["type"] == "chords" and job["id"] != chord_job["id"],
+    )
+    completed_chord_refresh_job = wait_for_job(client, chord_refresh_job["id"])
+    assert completed_chord_refresh_job["status"] == "completed"
+    assert completed_chord_refresh_job["chord_backend"] == "tuneforge-fast"
+    assert completed_chord_refresh_job["chord_source"] == "source+stem"
 
     analysis = client.get(f"/api/v1/projects/{project['id']}/analysis").json()["analysis"]
     chords = client.get(f"/api/v1/projects/{project['id']}/chords").json()
+    lyrics = client.get(f"/api/v1/projects/{project['id']}/lyrics").json()
 
     assert analysis is not None
     assert len(chords["timeline"]) >= 3
+    assert lyrics["segments"][0]["text"] == "Test lyric"
 
 
 def test_project_can_be_renamed(client, sample_audio_file: Path):

--- a/apps/backend/tests/test_transform_flow.py
+++ b/apps/backend/tests/test_transform_flow.py
@@ -2,7 +2,30 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import soundfile as sf
+
 from .conftest import wait_for_job
+
+
+def _fake_separate_sources(
+    source_path: Path,
+    output_paths: dict[str, Path],
+    *,
+    model: str,
+    device: str,
+    model_repo=None,
+    on_progress=None,
+    should_cancel=None,
+    register_process=None,
+    unregister_process=None,
+):
+    signal, sample_rate = sf.read(source_path, always_2d=True)
+    for index, output_path in enumerate(output_paths.values(), start=1):
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        sf.write(output_path, signal * (index / 10), sample_rate)
+    if on_progress:
+        on_progress(98)
+    return {"engine": "demucs", "model": model, "requested_device": device, "device": "cpu"}
 
 
 def test_preview_generation_cache_and_export(client, sample_audio_file: Path):
@@ -71,3 +94,39 @@ def test_preview_generation_cache_and_export(client, sample_audio_file: Path):
     exported = [artifact for artifact in export_artifacts if artifact["type"] == "export_mix"]
     assert exported
     assert any(Path(artifact["path"]).suffix == ".mp3" for artifact in exported)
+
+
+def test_preview_mix_creation_does_not_auto_queue_stems(
+    client,
+    sample_audio_file: Path,
+    monkeypatch,
+):
+    monkeypatch.setattr("app.services.stems.separate_sources", _fake_separate_sources)
+
+    project = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_audio_file), "copy_into_project": True},
+    ).json()["project"]
+    import_stem_job = next(
+        job
+        for job in client.get("/api/v1/jobs").json()["jobs"]
+        if job["project_id"] == project["id"] and job["type"] == "stems"
+    )
+    assert wait_for_job(client, import_stem_job["id"])["status"] == "completed"
+
+    preview_job = client.post(
+        f"/api/v1/projects/{project['id']}/preview",
+        json={"transpose": {"semitones": 1}, "output_format": "wav"},
+    ).json()["job"]
+    assert wait_for_job(client, preview_job["id"])["status"] == "completed"
+
+    artifacts = client.get(f"/api/v1/projects/{project['id']}/artifacts").json()["artifacts"]
+    preview_artifact = next(artifact for artifact in artifacts if artifact["type"] == "preview_mix")
+    jobs = client.get("/api/v1/jobs").json()["jobs"]
+    assert not [
+        job
+        for job in jobs
+        if job["project_id"] == project["id"]
+        and job["type"] == "stems"
+        and job["source_artifact_id"] == preview_artifact["id"]
+    ]

--- a/apps/desktop/src/App.library.test.tsx
+++ b/apps/desktop/src/App.library.test.tsx
@@ -110,6 +110,7 @@ describe("Desktop app library", () => {
       source_path: "/tmp/new-song.mp4",
       copy_into_project: true,
       chord_backend: "tuneforge-fast",
+      stem_model: "htdemucs_6s",
     });
     await waitFor(() =>
       expect(mockGetProject).toHaveBeenCalledWith(expect.stringMatching(/^proj_/)),
@@ -190,11 +191,15 @@ describe("Desktop app library", () => {
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
   });
 
-  it("uses the selected default chord backend when importing a track", async () => {
+  it("uses the selected default chord backend and stem model when importing a track", async () => {
     const user = userEvent.setup();
     window.localStorage.setItem(
       "tuneforge.ui-preferences",
-      JSON.stringify({ defaultChordBackend: "crema-advanced", defaultSourcesRailCollapsed: false }),
+      JSON.stringify({
+        defaultChordBackend: "crema-advanced",
+        defaultSourcesRailCollapsed: false,
+        defaultStemModel: "htdemucs_ft",
+      }),
     );
     mockOpen.mockResolvedValue("/tmp/new-song.mp4");
 
@@ -207,6 +212,7 @@ describe("Desktop app library", () => {
       source_path: "/tmp/new-song.mp4",
       copy_into_project: true,
       chord_backend: "crema-advanced",
+      stem_model: "htdemucs_ft",
     });
   });
 
@@ -249,6 +255,7 @@ describe("Desktop app library", () => {
       source_path: "/tmp/new-song.mp4",
       copy_into_project: true,
       chord_backend: "tuneforge-fast",
+      stem_model: "htdemucs_6s",
       chord_backend_fallback_from: "crema-advanced",
     });
   });

--- a/apps/desktop/src/features/projects/LibraryView.tsx
+++ b/apps/desktop/src/features/projects/LibraryView.tsx
@@ -131,7 +131,7 @@ function getImportErrorNotice(error: unknown): ImportNotice {
 export function LibraryView() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { informationDensity } = usePreferences();
+  const { defaultStemModel, informationDensity } = usePreferences();
   const { chordBackendForAction } = useChordBackendActionSelection();
   const [searchDraft, setSearchDraft] = useState("");
   const [importNotice, setImportNotice] = useState<ImportNotice | null>(null);
@@ -163,6 +163,7 @@ export function LibraryView() {
         source_path: selection,
         copy_into_project: true,
         chord_backend: backendSelection.backend,
+        stem_model: defaultStemModel,
         ...(backendSelection.backend_fallback_from
           ? { chord_backend_fallback_from: backendSelection.backend_fallback_from }
           : {}),

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -957,7 +957,7 @@ const {
       : state.projects;
     return { projects: clone(filteredProjects) };
   });
-  const mockImportProject = vi.fn(async ({ source_path }: { source_path: string }) => {
+  const mockImportProject = vi.fn(async ({ source_path }: { source_path: string; stem_model?: string }) => {
     const id = `proj_${state.nextProjectId++}`;
     const baseName = source_path.split("/").pop() ?? "Imported Track";
     const displayName = titleize(baseName);

--- a/docs/API.md
+++ b/docs/API.md
@@ -345,15 +345,19 @@ Staged import does not enqueue analysis, chord, lyrics, stem, or other generatio
 
 `POST /api/v1/projects/import`
 
-Creates a project from a source path and queues initial analysis and chord jobs.
+Creates a project from a source path and queues initial analysis, chord, lyrics, and source stem jobs.
 
 Request fields:
 
 - `source_path`
 - `copy_into_project`
 - `display_name`
+- `stem_model`
 
 Response: `ProjectResponse`.
+
+`stem_model` is optional. Desktop imports send the user's default stem model so automatic source stems match
+manual stem generation preferences; if omitted, the backend stem model default is used.
 
 `source_path` records where the user imported the file from on this install. Sync treats it as local provenance, not a durable source of original bytes or an operational sync input. `copy_into_project=false` is accepted for compatibility, but new imports still create an app-managed operational WAV source artifact under the project root.
 

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -1060,6 +1060,8 @@ export interface components {
             chord_backend?: string | null;
             /** Chord Backend Fallback From */
             chord_backend_fallback_from?: string | null;
+            /** Stem Model */
+            stem_model?: string | null;
         };
         /** ProjectResponse */
         ProjectResponse: {


### PR DESCRIPTION
## Summary
- Queue analysis, chords, lyrics, and source stem jobs from normal project import.
- Send the desktop default stem model during import so automatic stems match user preferences.
- Keep practice mix stem generation explicit and document the import behavior.

## Testing
- `cd apps/backend && uv run --python 3.11 pytest tests/test_projects.py tests/test_stem_flow.py tests/test_analysis_flow.py tests/test_lyrics_flow.py tests/test_transform_flow.py`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `pnpm contracts:generate`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test --run src/App.library.test.tsx`
- `pnpm --filter @tuneforge/desktop lint`