### PR TITLE
feat: add multi-track import activity queue

### DIFF
--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -1,0 +1,236 @@
+import { act, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { JobSchema, ProjectSchema } from "./lib/api";
+import {
+  mockCancelJob,
+  mockListJobs,
+  mockListProjects,
+  renderApp,
+  resetAppTestHarness,
+  setJobs,
+  setProjects,
+} from "./test/appTestHarness";
+
+function project(overrides: Partial<ProjectSchema>): Record<string, unknown> {
+  return {
+    id: "proj_123",
+    display_name: "Demo Song",
+    source_key_override: null,
+    source_path: "/tmp/demo.wav",
+    imported_path: "/tmp/projects/demo.wav",
+    duration_seconds: 182,
+    sample_rate: 44100,
+    channels: 2,
+    created_at: "2026-04-18T13:16:00.000Z",
+    updated_at: "2026-04-18T13:16:00.000Z",
+    ...overrides,
+  };
+}
+
+function job(overrides: Partial<JobSchema>): Record<string, unknown> {
+  return {
+    id: "job_1",
+    project_id: "proj_123",
+    type: "preview",
+    status: "completed",
+    progress: 100,
+    error_message: null,
+    created_at: "2026-04-18T13:16:00.000Z",
+    updated_at: "2026-04-18T13:16:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("Desktop app activity", () => {
+  beforeEach(() => {
+    resetAppTestHarness();
+  });
+
+  it("opens Activity from the sidebar with Jobs selected", async () => {
+    const user = userEvent.setup();
+    renderApp(["/"]);
+
+    expect(await screen.findByRole("heading", { level: 1, name: "Practice Projects" })).toBeInTheDocument();
+    await user.click(screen.getByRole("link", { name: "Activity" }));
+
+    expect(await screen.findByRole("heading", { level: 1, name: "Activity" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Jobs" })).toHaveAttribute("aria-selected", "true");
+    expect(mockListJobs).toHaveBeenCalled();
+    expect(mockListProjects).toHaveBeenCalled();
+  });
+
+  it("shows project links and pending queue positions in queue order", async () => {
+    setProjects([
+      project({ id: "proj_1", display_name: "Ambient Wash" }),
+      project({ id: "proj_2", display_name: "Bass Drill" }),
+    ]);
+    setJobs([
+      job({
+        id: "job_done",
+        project_id: "proj_1",
+        type: "lyrics",
+        status: "completed",
+        progress: 100,
+        completed_at: "2026-04-18T13:25:00.000Z",
+        created_at: "2026-04-18T13:05:00.000Z",
+        updated_at: "2026-04-18T13:25:00.000Z",
+      }),
+      job({
+        id: "job_pending_2",
+        project_id: null,
+        type: "export",
+        status: "pending",
+        progress: 0,
+        created_at: "2026-04-18T13:20:00.000Z",
+        updated_at: "2026-04-18T13:20:00.000Z",
+      }),
+      job({
+        id: "job_running",
+        project_id: "proj_2",
+        type: "stems",
+        status: "running",
+        progress: 42,
+        stem_model: "htdemucs_6s",
+        stem_model_label: "Default (6 stems model)",
+        runtime_device: "mps",
+        started_at: "2026-04-18T13:22:00.000Z",
+        created_at: "2026-04-18T13:22:00.000Z",
+        updated_at: "2026-04-18T13:23:00.000Z",
+      }),
+      job({
+        id: "job_pending_1",
+        project_id: "proj_1",
+        type: "chords",
+        status: "pending",
+        progress: 0,
+        chord_backend: "tuneforge-fast",
+        chord_source: "source",
+        created_at: "2026-04-18T13:10:00.000Z",
+        updated_at: "2026-04-18T13:10:00.000Z",
+      }),
+    ]);
+
+    renderApp(["/activity"]);
+
+    const queue = await screen.findByRole("list", { name: "Job queue" });
+    const rows = within(queue).getAllByRole("article");
+
+    expect(rows.map((row) => row.getAttribute("aria-label"))).toEqual([
+      "stems running job",
+      "chords pending job",
+      "export pending job",
+      "lyrics completed job",
+    ]);
+    expect(within(rows[0]).getByRole("link", { name: "Open Bass Drill project" })).toHaveAttribute(
+      "href",
+      "/projects/proj_2",
+    );
+    expect(within(rows[0]).getByText("Default (6 stems model) / MPS")).toBeInTheDocument();
+    expect(within(rows[1]).getByRole("link", { name: "Open Ambient Wash project" })).toHaveAttribute(
+      "href",
+      "/projects/proj_1",
+    );
+    expect(within(rows[1]).getByText("Queue #1")).toBeInTheDocument();
+    expect(within(rows[1]).getByText("built-in / source")).toBeInTheDocument();
+    expect(within(rows[2]).getByText("Queue #2")).toBeInTheDocument();
+    expect(within(rows[2]).getByText("No project")).toBeInTheDocument();
+  });
+
+  it("cancels pending jobs and refreshes the queue", async () => {
+    const user = userEvent.setup();
+    setJobs([
+      job({
+        id: "job_pending",
+        type: "analyze",
+        status: "pending",
+        progress: 0,
+        created_at: "2026-04-18T13:10:00.000Z",
+        updated_at: "2026-04-18T13:10:00.000Z",
+      }),
+      job({
+        id: "job_completed",
+        type: "preview",
+        status: "completed",
+        progress: 100,
+        completed_at: "2026-04-18T13:20:00.000Z",
+        created_at: "2026-04-18T13:05:00.000Z",
+        updated_at: "2026-04-18T13:20:00.000Z",
+      }),
+    ]);
+
+    renderApp(["/activity"]);
+
+    const pendingRow = await screen.findByRole("article", { name: "analyze pending job" });
+    const completedRow = await screen.findByRole("article", { name: "preview completed job" });
+    expect(within(completedRow).queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument();
+    const initialListJobsCalls = mockListJobs.mock.calls.length;
+
+    await user.click(within(pendingRow).getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => expect(mockCancelJob).toHaveBeenCalledWith("job_pending"));
+    await waitFor(() => expect(mockListJobs.mock.calls.length).toBeGreaterThan(initialListJobsCalls));
+    expect(await screen.findByRole("article", { name: "analyze cancelled job" })).toBeInTheDocument();
+  });
+
+  it("refreshes active jobs until they reach a terminal status", async () => {
+    const intervalHandlers: Array<() => void | Promise<void>> = [];
+    const setIntervalSpy = vi
+      .spyOn(window, "setInterval")
+      .mockImplementation((handler: TimerHandler, timeout?: number) => {
+        if (timeout === 1500 && typeof handler === "function") {
+          intervalHandlers.push(handler as () => void | Promise<void>);
+          return 1500;
+        }
+        return 1;
+      });
+    const clearIntervalSpy = vi.spyOn(window, "clearInterval").mockImplementation(() => undefined);
+
+    try {
+      setJobs([
+        job({
+          id: "job_running",
+          project_id: "proj_123",
+          type: "stems",
+          status: "running",
+          progress: 25,
+          created_at: "2026-04-18T13:10:00.000Z",
+          started_at: "2026-04-18T13:10:30.000Z",
+          updated_at: "2026-04-18T13:11:00.000Z",
+        }),
+      ]);
+
+      renderApp(["/activity"]);
+
+      expect(await screen.findByRole("article", { name: "stems running job" })).toBeInTheDocument();
+      expect(intervalHandlers).toHaveLength(1);
+      const initialListJobsCalls = mockListJobs.mock.calls.length;
+
+      setJobs([
+        job({
+          id: "job_running",
+          project_id: "proj_123",
+          type: "stems",
+          status: "completed",
+          progress: 100,
+          completed_at: "2026-04-18T13:12:00.000Z",
+          created_at: "2026-04-18T13:10:00.000Z",
+          started_at: "2026-04-18T13:10:30.000Z",
+          updated_at: "2026-04-18T13:12:00.000Z",
+        }),
+      ]);
+
+      await act(async () => {
+        await intervalHandlers[0]?.();
+      });
+
+      await waitFor(() => expect(mockListJobs.mock.calls.length).toBeGreaterThan(initialListJobsCalls));
+      const completedRow = await screen.findByRole("article", { name: "stems completed job" });
+      expect(within(completedRow).queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument();
+      expect(clearIntervalSpy).toHaveBeenCalledWith(1500);
+    } finally {
+      setIntervalSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
+    }
+  });
+});

--- a/apps/desktop/src/App.library.test.tsx
+++ b/apps/desktop/src/App.library.test.tsx
@@ -104,7 +104,7 @@ describe("Desktop app library", () => {
     renderApp(["/"]);
 
     expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Import Track" }));
+    await user.click(screen.getByRole("button", { name: "Import Track(s)" }));
 
     expect(mockImportProject).toHaveBeenCalledWith({
       source_path: "/tmp/new-song.mp4",
@@ -112,11 +112,157 @@ describe("Desktop app library", () => {
       chord_backend: "tuneforge-fast",
       stem_model: "htdemucs_6s",
     });
+    expect(mockOpen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        multiple: true,
+      }),
+    );
     await waitFor(() =>
       expect(mockGetProject).toHaveBeenCalledWith(expect.stringMatching(/^proj_/)),
     );
     expect(await screen.findByRole("heading", { name: "New Song" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Hide Inspector" })).toBeInTheDocument();
+  });
+
+  it("imports multiple tracks in order and stays on the library", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({
+        defaultChordBackend: "crema-advanced",
+        defaultSourcesRailCollapsed: false,
+        defaultStemModel: "htdemucs_ft",
+      }),
+    );
+    mockOpen.mockResolvedValue(["/tmp/first-song.mp4", "/tmp/second-song.wav"]);
+
+    renderApp(["/"]);
+
+    expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Import Track(s)" }));
+
+    await waitFor(() => expect(mockImportProject).toHaveBeenCalledTimes(2));
+    expect(mockImportProject.mock.calls.map(([payload]) => payload.source_path)).toEqual([
+      "/tmp/first-song.mp4",
+      "/tmp/second-song.wav",
+    ]);
+    for (const [payload] of mockImportProject.mock.calls) {
+      expect(payload).toEqual(
+        expect.objectContaining({
+          copy_into_project: true,
+          chord_backend: "crema-advanced",
+          stem_model: "htdemucs_ft",
+        }),
+      );
+    }
+
+    const summary = await screen.findByRole("status");
+    expect(within(summary).getByText("2 tracks imported, 0 duplicates skipped, 0 failed.")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
+    expect(mockGetProject).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates selected import paths before importing", async () => {
+    const user = userEvent.setup();
+    mockOpen.mockResolvedValue([
+      "/tmp/first-song.mp4",
+      "/tmp/first-song.mp4",
+      "/tmp/second-song.wav",
+      "/tmp/first-song.mp4",
+    ]);
+
+    renderApp(["/"]);
+
+    expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Import Track(s)" }));
+
+    await waitFor(() => expect(mockImportProject).toHaveBeenCalledTimes(2));
+    expect(mockImportProject.mock.calls.map(([payload]) => payload.source_path)).toEqual([
+      "/tmp/first-song.mp4",
+      "/tmp/second-song.wav",
+    ]);
+
+    const summary = await screen.findByRole("status");
+    expect(within(summary).getByText("2 tracks imported, 2 duplicates skipped, 0 failed.")).toBeInTheDocument();
+    expect(mockGetProject).not.toHaveBeenCalled();
+  });
+
+  it("does not import when more than twenty-five files are selected", async () => {
+    const user = userEvent.setup();
+    mockOpen.mockResolvedValue(Array.from({ length: 26 }, (_, index) => `/tmp/song-${index + 1}.wav`));
+
+    renderApp(["/"]);
+
+    expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Import Track(s)" }));
+
+    const warning = await screen.findByRole("status");
+    expect(within(warning).getByText("Select up to 25 tracks at a time.")).toBeInTheDocument();
+    expect(mockImportProject).not.toHaveBeenCalled();
+    expect(mockGetProject).not.toHaveBeenCalled();
+  });
+
+  it("applies the import cap after deduplicating selected paths", async () => {
+    const user = userEvent.setup();
+    const uniquePaths = Array.from({ length: 25 }, (_, index) => `/tmp/song-${index + 1}.wav`);
+    mockOpen.mockResolvedValue([...uniquePaths, uniquePaths[0]]);
+
+    renderApp(["/"]);
+
+    expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Import Track(s)" }));
+
+    await waitFor(() => expect(mockImportProject).toHaveBeenCalledTimes(25));
+    expect(mockImportProject.mock.calls.map(([payload]) => payload.source_path)).toEqual(uniquePaths);
+
+    const summary = await screen.findByRole("status");
+    expect(within(summary).getByText("25 tracks imported, 1 duplicate skipped, 0 failed.")).toBeInTheDocument();
+    expect(mockGetProject).not.toHaveBeenCalled();
+  });
+
+  it("summarizes duplicate-content imports as skipped during a batch", async () => {
+    const user = userEvent.setup();
+    mockOpen.mockResolvedValue(["/tmp/demo.wav", "/tmp/new-song.wav"]);
+    mockImportProject.mockRejectedValueOnce(
+      Object.assign(new Error('This project is already imported with name "Demo Song".'), {
+        code: "DUPLICATE_PROJECT_SOURCE",
+        details: {
+          project_id: "proj_123",
+          project_name: "Demo Song",
+        },
+      }),
+    );
+
+    renderApp(["/"]);
+
+    expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Import Track(s)" }));
+
+    await waitFor(() => expect(mockImportProject).toHaveBeenCalledTimes(2));
+    const summary = await screen.findByRole("status");
+    expect(within(summary).getByText("1 track imported, 1 duplicate skipped, 0 failed.")).toBeInTheDocument();
+    expect(within(summary).queryByRole("link", { name: "Open project" })).not.toBeInTheDocument();
+    expect(mockGetProject).not.toHaveBeenCalled();
+  });
+
+  it("summarizes failed batch imports with file and error details", async () => {
+    const user = userEvent.setup();
+    mockOpen.mockResolvedValue(["/tmp/broken.wav", "/tmp/new-song.wav"]);
+    mockImportProject.mockRejectedValueOnce(new Error("Unsupported codec."));
+
+    renderApp(["/"]);
+
+    expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Import Track(s)" }));
+
+    await waitFor(() => expect(mockImportProject).toHaveBeenCalledTimes(2));
+    const summary = await screen.findByRole("status");
+    expect(
+      within(summary).getByText(
+        "1 track imported, 0 duplicates skipped, 1 failed. Failed: /tmp/broken.wav: Unsupported codec.",
+      ),
+    ).toBeInTheDocument();
+    expect(mockGetProject).not.toHaveBeenCalled();
   });
 
   it("shows duplicate import warning with a link to the existing project", async () => {
@@ -136,7 +282,7 @@ describe("Desktop app library", () => {
     renderApp(["/"]);
 
     expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Import Track" }));
+    await user.click(screen.getByRole("button", { name: "Import Track(s)" }));
 
     const warning = await screen.findByRole("status");
     expect(within(warning).getByText(duplicateMessage)).toBeInTheDocument();
@@ -175,14 +321,14 @@ describe("Desktop app library", () => {
     renderApp(["/"]);
 
     expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Import Track" }));
+    await user.click(screen.getByRole("button", { name: "Import Track(s)" }));
 
     const alert = await screen.findByRole("alert");
     expect(within(alert).getByText(genericMessage)).toBeInTheDocument();
     expect(within(alert).queryByRole("link", { name: "Open project" })).not.toBeInTheDocument();
 
     mockImportProject.mockImplementationOnce(async () => importPromise);
-    await user.click(screen.getByRole("button", { name: "Import Track" }));
+    await user.click(screen.getByRole("button", { name: "Import Track(s)" }));
 
     await waitFor(() => expect(screen.queryByText(genericMessage)).not.toBeInTheDocument());
     resolveImport({ project: existingProject });
@@ -206,7 +352,7 @@ describe("Desktop app library", () => {
     renderApp(["/"]);
 
     expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Import Track" }));
+    await user.click(screen.getByRole("button", { name: "Import Track(s)" }));
 
     expect(mockImportProject).toHaveBeenCalledWith({
       source_path: "/tmp/new-song.mp4",
@@ -249,7 +395,7 @@ describe("Desktop app library", () => {
     renderApp(["/"]);
 
     expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Import Track" }));
+    await user.click(screen.getByRole("button", { name: "Import Track(s)" }));
 
     expect(mockImportProject).toHaveBeenCalledWith({
       source_path: "/tmp/new-song.mp4",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId } from "react";
-import { Library, Music2, Settings, Wrench } from "lucide-react";
+import { Activity, Library, Music2, Settings, Wrench } from "lucide-react";
 import { Link, NavLink, Route, Routes, matchPath, useLocation } from "react-router-dom";
+import { ActivityView } from "./features/activity/ActivityView";
 import { LibraryView } from "./features/projects/LibraryView";
 import { ProjectView } from "./features/projects/ProjectView";
 import { usePlayback } from "./features/projects/playback-context";
@@ -192,6 +193,15 @@ function AppChrome() {
             <span className="nav__label">Tools</span>
           </NavLink>
           <NavLink
+            aria-label="Activity"
+            className={({ isActive }) => (isActive ? "active" : undefined)}
+            title="Activity"
+            to="/activity"
+          >
+            <Activity aria-hidden="true" className="nav__icon" />
+            <span className="nav__label">Activity</span>
+          </NavLink>
+          <NavLink
             aria-label="Settings"
             className={({ isActive }) => (isActive ? "active" : undefined)}
             title="Settings"
@@ -207,6 +217,7 @@ function AppChrome() {
           <Route path="/" element={<LibraryView />} />
           <Route path="/projects/:projectId" element={<ProjectView />} />
           <Route path="/tools" element={<ToolsView />} />
+          <Route path="/activity" element={<ActivityView />} />
           <Route path="/settings" element={<SettingsView />} />
           <Route path="/settings/theme-studio" element={<ThemeStudioView />} />
           <Route path="/settings/theme-preview" element={<ThemeStudioView />} />

--- a/apps/desktop/src/features/activity/ActivityView.tsx
+++ b/apps/desktop/src/features/activity/ActivityView.tsx
@@ -1,0 +1,325 @@
+import { useEffect, useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { api, type JobSchema, type ProjectSchema } from "../../lib/api";
+import { formatLocalDateTime, normalizeApiDateTime, parseApiDateTime } from "../../lib/datetime";
+import { formatJobStatusSummary } from "../projects/projectViewUtils";
+
+const CANCELABLE_JOB_STATUSES = new Set(["pending", "running"]);
+const TERMINAL_JOB_STATUSES = new Set(["completed", "failed", "cancelled"]);
+const ACTIVE_JOB_REFETCH_MS = 1500;
+
+type DisplayJob = {
+  job: JobSchema;
+  queuePosition: number | null;
+};
+
+function timestampMs(value: string | null | undefined) {
+  if (!value) return 0;
+  const parsed = parseApiDateTime(value);
+  const timestamp = parsed.getTime();
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+function compareCreatedAtAscending(left: JobSchema, right: JobSchema) {
+  return timestampMs(left.created_at) - timestampMs(right.created_at);
+}
+
+function recentJobTimestamp(job: JobSchema) {
+  return timestampMs(job.completed_at ?? job.updated_at ?? job.created_at);
+}
+
+function getJobSortGroup(job: JobSchema) {
+  if (job.status === "running") return 0;
+  if (job.status === "pending") return 1;
+  if (TERMINAL_JOB_STATUSES.has(job.status)) return 2;
+  return 3;
+}
+
+function orderJobsForQueue(jobs: JobSchema[]): DisplayJob[] {
+  const pendingJobs = jobs.filter((job) => job.status === "pending").sort(compareCreatedAtAscending);
+  const queuePositionById = new Map(
+    pendingJobs.map((job, index) => [job.id, index + 1]),
+  );
+
+  return [...jobs]
+    .sort((left, right) => {
+      const leftGroup = getJobSortGroup(left);
+      const rightGroup = getJobSortGroup(right);
+
+      if (leftGroup !== rightGroup) {
+        return leftGroup - rightGroup;
+      }
+
+      if (leftGroup === 0) {
+        return timestampMs(left.started_at ?? left.created_at) - timestampMs(right.started_at ?? right.created_at);
+      }
+
+      if (leftGroup === 1) {
+        return compareCreatedAtAscending(left, right);
+      }
+
+      return recentJobTimestamp(right) - recentJobTimestamp(left);
+    })
+    .map((job) => ({
+      job,
+      queuePosition: queuePositionById.get(job.id) ?? null,
+    }));
+}
+
+function formatTimestamp(value: string) {
+  return formatLocalDateTime(value, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatJobDetails(job: JobSchema) {
+  const summary = formatJobStatusSummary(job);
+  if (!summary || summary === job.status) {
+    return null;
+  }
+
+  const statusPrefix = `${job.status} / `;
+  return summary.startsWith(statusPrefix) ? summary.slice(statusPrefix.length) : summary;
+}
+
+function progressValue(job: JobSchema) {
+  return Math.max(0, Math.min(100, Math.round(job.progress)));
+}
+
+function projectById(projects: ProjectSchema[] | undefined) {
+  return new Map((projects ?? []).map((project) => [project.id, project]));
+}
+
+function hasActiveJob(jobs: JobSchema[] | undefined) {
+  return jobs?.some((job) => CANCELABLE_JOB_STATUSES.has(job.status)) ?? false;
+}
+
+function JobProjectLink({
+  project,
+  projectId,
+}: {
+  project: ProjectSchema | null;
+  projectId: string | null;
+}) {
+  if (!projectId) {
+    return <span>No project</span>;
+  }
+
+  const label = project?.display_name ?? projectId;
+  return (
+    <Link aria-label={`Open ${label} project`} className="activity-job-row__project-link" to={`/projects/${projectId}`}>
+      {label}
+    </Link>
+  );
+}
+
+function JobTimestamps({ job }: { job: JobSchema }) {
+  const timestamps = [
+    { label: "Created", value: job.created_at },
+    { label: "Started", value: job.started_at },
+    { label: "Updated", value: job.updated_at },
+    { label: "Completed", value: job.completed_at },
+  ].filter((item): item is { label: string; value: string } => Boolean(item.value));
+
+  return (
+    <dl className="activity-job-row__timestamps">
+      {timestamps.map((item) => (
+        <div key={item.label}>
+          <dt>{item.label}</dt>
+          <dd>
+            <time dateTime={normalizeApiDateTime(item.value)}>{formatTimestamp(item.value)}</time>
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function JobRow({
+  displayJob,
+  isCancelling,
+  onCancel,
+  project,
+}: {
+  displayJob: DisplayJob;
+  isCancelling: boolean;
+  onCancel: (jobId: string) => void;
+  project: ProjectSchema | null;
+}) {
+  const { job, queuePosition } = displayJob;
+  const details = formatJobDetails(job);
+  const progress = progressValue(job);
+  const canCancel = CANCELABLE_JOB_STATUSES.has(job.status);
+
+  return (
+    <li className="activity-job-row">
+      <article aria-label={`${job.type} ${job.status} job`} className="activity-job-row__article">
+        <div className="activity-job-row__main">
+          <div className="activity-job-row__identity">
+            <div className="activity-job-row__title-line">
+              <strong className="activity-job-row__type">{job.type}</strong>
+              <span className={`activity-job-row__status activity-job-row__status--${job.status}`}>
+                {job.status}
+              </span>
+              {queuePosition ? (
+                <span className="activity-job-row__queue-position">Queue #{queuePosition}</span>
+              ) : null}
+            </div>
+            <div className="activity-job-row__project">
+              <span className="metric-label">Project</span>
+              <JobProjectLink project={project} projectId={job.project_id} />
+            </div>
+            {details ? <p className="activity-job-row__details">{details}</p> : null}
+          </div>
+
+          <div className="activity-job-row__progress">
+            <span>{progress}%</span>
+            <progress aria-label={`${job.type} job progress`} max={100} value={progress} />
+          </div>
+
+          {canCancel ? (
+            <button
+              className="button button--ghost button--small activity-job-row__cancel"
+              disabled={isCancelling}
+              onClick={() => onCancel(job.id)}
+              type="button"
+            >
+              {isCancelling ? "Cancelling..." : "Cancel"}
+            </button>
+          ) : null}
+        </div>
+
+        <JobTimestamps job={job} />
+
+        {job.error_message ? (
+          <p className="activity-job-row__error" role="alert">
+            {job.error_message}
+          </p>
+        ) : null}
+      </article>
+    </li>
+  );
+}
+
+export function ActivityView() {
+  const queryClient = useQueryClient();
+  const jobsQuery = useQuery({
+    queryKey: ["jobs"],
+    queryFn: async () => (await api.listJobs()).jobs,
+  });
+  const projectsQuery = useQuery({
+    queryKey: ["projects", "activity"],
+    queryFn: async () => (await api.listProjects()).projects,
+  });
+  const cancelJobMutation = useMutation({
+    mutationFn: (jobId: string) => api.cancelJob(jobId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["jobs"] });
+    },
+  });
+
+  const projectsById = useMemo(() => projectById(projectsQuery.data), [projectsQuery.data]);
+  const displayJobs = useMemo(() => orderJobsForQueue(jobsQuery.data ?? []), [jobsQuery.data]);
+  const activeJobCount = displayJobs.filter(({ job }) => CANCELABLE_JOB_STATUSES.has(job.status)).length;
+  const shouldPollJobs = hasActiveJob(jobsQuery.data);
+  const isLoading = jobsQuery.isLoading || projectsQuery.isLoading;
+  const isError = jobsQuery.isError || projectsQuery.isError;
+  const showJobList = !isLoading && !isError && displayJobs.length > 0;
+  const showEmptyState = !isLoading && !isError && displayJobs.length === 0;
+
+  useEffect(() => {
+    if (!shouldPollJobs) return;
+
+    const interval = window.setInterval(async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["jobs"] }),
+        queryClient.invalidateQueries({ queryKey: ["projects", "activity"] }),
+      ]);
+    }, ACTIVE_JOB_REFETCH_MS);
+
+    return () => window.clearInterval(interval);
+  }, [queryClient, shouldPollJobs]);
+
+  return (
+    <section className="screen activity-screen">
+      <div className="screen__header">
+        <div className="screen__title-block">
+          <p className="eyebrow">Activity</p>
+          <h1>Activity</h1>
+          <p className="screen__subtitle">Review the local processing queue across every project.</p>
+        </div>
+      </div>
+
+      <div className="project-workspace-tabs" role="tablist" aria-label="Activity">
+        <button
+          aria-selected="true"
+          className="project-workspace-tabs__button project-workspace-tabs__button--active"
+          role="tab"
+          type="button"
+        >
+          Jobs
+        </button>
+      </div>
+
+      <section aria-labelledby="activity-jobs-heading" className="panel activity-jobs-panel">
+        <div className="panel-heading activity-jobs-panel__heading">
+          <div>
+            <h2 id="activity-jobs-heading">Jobs</h2>
+            <p className="subpanel__copy">
+              {activeJobCount
+                ? `${activeJobCount} active job${activeJobCount === 1 ? "" : "s"} in the queue.`
+                : "No pending or running jobs."}
+            </p>
+          </div>
+        </div>
+
+        {isLoading ? (
+          <div className="activity-jobs-panel__state" role="status">
+            Loading jobs...
+          </div>
+        ) : null}
+
+        {isError ? (
+          <div className="activity-jobs-panel__state activity-jobs-panel__state--error" role="alert">
+            Could not load the activity queue.
+          </div>
+        ) : null}
+
+        {cancelJobMutation.isError ? (
+          <div className="activity-jobs-panel__state activity-jobs-panel__state--error" role="alert">
+            Could not cancel the job.
+          </div>
+        ) : null}
+
+        {showJobList ? (
+          <ul aria-label="Job queue" className="activity-job-list">
+            {displayJobs.map((displayJob) => (
+              <JobRow
+                key={displayJob.job.id}
+                displayJob={displayJob}
+                isCancelling={
+                  cancelJobMutation.isPending && cancelJobMutation.variables === displayJob.job.id
+                }
+                onCancel={(jobId) => cancelJobMutation.mutate(jobId)}
+                project={
+                  displayJob.job.project_id ? projectsById.get(displayJob.job.project_id) ?? null : null
+                }
+              />
+            ))}
+          </ul>
+        ) : null}
+
+        {showEmptyState ? (
+          <div className="activity-jobs-panel__empty">
+            <h3>No jobs yet</h3>
+            <p>Import or process a track to populate the queue.</p>
+          </div>
+        ) : null}
+      </section>
+    </section>
+  );
+}

--- a/apps/desktop/src/features/projects/LibraryView.tsx
+++ b/apps/desktop/src/features/projects/LibraryView.tsx
@@ -8,6 +8,8 @@ import { formatLocalDateTime, normalizeApiDateTime } from "../../lib/datetime";
 import { usePreferences } from "../../lib/preferences";
 import { useChordBackendActionSelection } from "./hooks/useChordBackendActionSelection";
 
+const MAX_IMPORT_SELECTION = 25;
+
 function formatDuration(durationSeconds: number | null | undefined) {
   if (!durationSeconds) return "Unknown length";
   const minutes = Math.floor(durationSeconds / 60);
@@ -94,14 +96,89 @@ function ProjectCard({ project }: { project: ProjectSchema }) {
 
 type ImportNotice =
   | { kind: "duplicate"; message: string; projectId: string }
+  | { kind: "summary"; message: string }
+  | { kind: "warning"; message: string }
   | { kind: "error"; message: string };
+
+type BatchImportSummary = {
+  failures: Array<{ message: string; sourcePath: string }>;
+  importedCount: number;
+  skippedCount: number;
+  failedCount: number;
+};
+
+type ImportMutationResult =
+  | { kind: "none" }
+  | { kind: "selectionLimit" }
+  | { kind: "single"; project: ProjectSchema }
+  | { kind: "batch"; summary: BatchImportSummary };
+
+function normalizeImportSelection(selection: string | string[] | null): string[] {
+  if (!selection) {
+    return [];
+  }
+  return Array.isArray(selection) ? selection : [selection];
+}
+
+function getUniqueImportPaths(paths: string[]) {
+  const seen = new Set<string>();
+  const uniquePaths: string[] = [];
+  let duplicateCount = 0;
+
+  for (const path of paths) {
+    if (seen.has(path)) {
+      duplicateCount += 1;
+      continue;
+    }
+    seen.add(path);
+    uniquePaths.push(path);
+  }
+
+  return { duplicateCount, uniquePaths };
+}
+
+function pluralize(count: number, singular: string, plural = `${singular}s`) {
+  return count === 1 ? singular : plural;
+}
+
+function formatBatchImportSummary({ importedCount, skippedCount, failedCount }: BatchImportSummary) {
+  return `${importedCount} ${pluralize(importedCount, "track")} imported, ${skippedCount} ${pluralize(
+    skippedCount,
+    "duplicate",
+  )} skipped, ${failedCount} failed.`;
+}
+
+function formatBatchFailureSummary(failures: BatchImportSummary["failures"]) {
+  if (!failures.length) {
+    return "";
+  }
+
+  const visibleFailures = failures.slice(0, 3);
+  const hiddenFailureCount = failures.length - visibleFailures.length;
+  const failureSummary = visibleFailures
+    .map((failure) => `${failure.sourcePath}: ${trimTrailingPeriod(failure.message)}`)
+    .join("; ");
+  return ` Failed: ${failureSummary}${hiddenFailureCount ? `; and ${hiddenFailureCount} more` : ""}.`;
+}
+
+function trimTrailingPeriod(value: string) {
+  return value.replace(/[.]+$/, "");
+}
+
+function formatBatchImportNotice(summary: BatchImportSummary) {
+  return `${formatBatchImportSummary(summary)}${formatBatchFailureSummary(summary.failures)}`;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+function isDuplicateProjectSourceError(error: unknown): error is Record<string, unknown> {
+  return isRecord(error) && error.code === "DUPLICATE_PROJECT_SOURCE";
+}
+
 function getDuplicateImportNotice(error: unknown): ImportNotice | null {
-  if (!isRecord(error) || error.code !== "DUPLICATE_PROJECT_SOURCE" || !isRecord(error.details)) {
+  if (!isDuplicateProjectSourceError(error) || !isRecord(error.details)) {
     return null;
   }
 
@@ -124,8 +201,27 @@ function getImportErrorNotice(error: unknown): ImportNotice {
     return duplicateNotice;
   }
 
-  const message = error instanceof Error && error.message.trim() ? error.message.trim() : "The request failed.";
+  const message = getImportErrorMessage(error);
   return { kind: "error", message: `Could not import track. ${message}` };
+}
+
+function getImportErrorMessage(error: unknown) {
+  const message = error instanceof Error && error.message.trim() ? error.message.trim() : "The request failed.";
+  return message;
+}
+
+function getImportNoticeClassName(importNotice: ImportNotice) {
+  if (importNotice.kind === "error") {
+    return "panel library-import-notice panel--error";
+  }
+  if (importNotice.kind === "duplicate" || importNotice.kind === "warning") {
+    return "panel library-import-notice panel--warning";
+  }
+  return "panel library-import-notice";
+}
+
+function getImportNoticeRole(importNotice: ImportNotice) {
+  return importNotice.kind === "error" ? "alert" : "status";
 }
 
 export function LibraryView() {
@@ -147,7 +243,7 @@ export function LibraryView() {
     mutationFn: async () => {
       const selection = await open({
         directory: false,
-        multiple: false,
+        multiple: true,
         filters: [
           {
             name: "Audio / Video",
@@ -155,29 +251,89 @@ export function LibraryView() {
           },
         ],
       });
-      if (!selection || Array.isArray(selection)) {
-        return null;
+      const selectedPaths = normalizeImportSelection(selection);
+      if (!selectedPaths.length) {
+        return { kind: "none" } satisfies ImportMutationResult;
+      }
+      const { duplicateCount, uniquePaths } = getUniqueImportPaths(selectedPaths);
+      if (uniquePaths.length > MAX_IMPORT_SELECTION) {
+        return { kind: "selectionLimit" } satisfies ImportMutationResult;
       }
       const backendSelection = await chordBackendForAction();
-      const response = await api.importProject({
-        source_path: selection,
+      const importPayload = {
         copy_into_project: true,
         chord_backend: backendSelection.backend,
         stem_model: defaultStemModel,
         ...(backendSelection.backend_fallback_from
           ? { chord_backend_fallback_from: backendSelection.backend_fallback_from }
           : {}),
-      });
-      return response.project;
+      };
+
+      if (selectedPaths.length === 1) {
+        const sourcePath = uniquePaths[0];
+        if (!sourcePath) {
+          return { kind: "none" } satisfies ImportMutationResult;
+        }
+        const response = await api.importProject({
+          source_path: sourcePath,
+          ...importPayload,
+        });
+        return { kind: "single", project: response.project } satisfies ImportMutationResult;
+      }
+
+      let importedCount = 0;
+      let skippedCount = duplicateCount;
+      let failedCount = 0;
+      const failures: BatchImportSummary["failures"] = [];
+
+      for (const sourcePath of uniquePaths) {
+        try {
+          await api.importProject({
+            source_path: sourcePath,
+            ...importPayload,
+          });
+          importedCount += 1;
+        } catch (error) {
+          if (isDuplicateProjectSourceError(error)) {
+            skippedCount += 1;
+          } else {
+            failedCount += 1;
+            failures.push({ sourcePath, message: getImportErrorMessage(error) });
+          }
+        }
+      }
+
+      return {
+        kind: "batch",
+        summary: { failures, importedCount, skippedCount, failedCount },
+      } satisfies ImportMutationResult;
     },
     onMutate: () => {
       setImportNotice(null);
     },
-    onSuccess: async (project) => {
-      setImportNotice(null);
-      if (!project) return;
-      await queryClient.invalidateQueries({ queryKey: ["projects"] });
-      navigate(`/projects/${project.id}`);
+    onSuccess: async (result) => {
+      if (result.kind === "none") {
+        return;
+      }
+      if (result.kind === "selectionLimit") {
+        setImportNotice({ kind: "warning", message: "Select up to 25 tracks at a time." });
+        return;
+      }
+      if (result.kind === "single") {
+        setImportNotice(null);
+        await queryClient.invalidateQueries({ queryKey: ["projects"] });
+        navigate(`/projects/${result.project.id}`);
+        return;
+      }
+
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["projects"] }),
+        queryClient.invalidateQueries({ queryKey: ["jobs"] }),
+      ]);
+      setImportNotice({
+        kind: result.summary.failedCount ? "warning" : "summary",
+        message: formatBatchImportNotice(result.summary),
+      });
     },
     onError: (error) => {
       setImportNotice(getImportErrorNotice(error));
@@ -203,17 +359,15 @@ export function LibraryView() {
           onClick={() => importMutation.mutate()}
           disabled={importMutation.isPending}
         >
-          {importMutation.isPending ? "Importing..." : "Import Track"}
+          {importMutation.isPending ? "Importing..." : "Import Track(s)"}
           <Upload aria-hidden="true" className="button__icon" />
         </button>
       </div>
 
       {importNotice ? (
         <div
-          className={`panel library-import-notice ${
-            importNotice.kind === "duplicate" ? "panel--warning" : "panel--error"
-          }`}
-          role={importNotice.kind === "duplicate" ? "status" : "alert"}
+          className={getImportNoticeClassName(importNotice)}
+          role={getImportNoticeRole(importNotice)}
         >
           <span>{importNotice.message}</span>
           {importNotice.kind === "duplicate" ? (

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -6,6 +6,7 @@
 @import "./styles/project-history.css";
 @import "./styles/project-inspector.css";
 @import "./styles/tools.css";
+@import "./styles/activity.css";
 @import "./styles/musical-labels.css";
 @import "./styles/source-key-selector.css";
 @import "./styles/target-selector.css";

--- a/apps/desktop/src/styles/activity.css
+++ b/apps/desktop/src/styles/activity.css
@@ -1,0 +1,198 @@
+.activity-screen {
+  max-width: 1180px;
+}
+
+.activity-jobs-panel {
+  display: grid;
+  gap: 1rem;
+}
+
+.activity-jobs-panel__heading {
+  align-items: center;
+}
+
+.activity-jobs-panel__state,
+.activity-jobs-panel__empty {
+  border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+  border-radius: 18px;
+  padding: 1rem;
+  background: color-mix(in srgb, var(--surface-muted) 62%, transparent);
+}
+
+.activity-jobs-panel__state--error {
+  border-color: color-mix(in srgb, var(--danger) 44%, transparent);
+  color: var(--danger);
+}
+
+.activity-jobs-panel__empty {
+  text-align: center;
+}
+
+.activity-jobs-panel__empty h3,
+.activity-jobs-panel__empty p {
+  margin: 0;
+}
+
+.activity-jobs-panel__empty p {
+  margin-top: 0.35rem;
+  color: var(--muted);
+}
+
+.activity-job-list {
+  display: grid;
+  gap: 0.8rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.activity-job-row__article {
+  display: grid;
+  gap: 0.8rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 80%, transparent);
+  border-radius: 18px;
+  padding: 0.95rem;
+  background: color-mix(in srgb, var(--panel-strong) 76%, transparent);
+}
+
+.activity-job-row__main {
+  display: grid;
+  grid-template-columns: minmax(16rem, 1fr) minmax(10rem, 14rem) auto;
+  gap: 1rem;
+  align-items: center;
+}
+
+.activity-job-row__identity {
+  display: grid;
+  min-width: 0;
+  gap: 0.42rem;
+}
+
+.activity-job-row__title-line,
+.activity-job-row__project,
+.activity-job-row__progress {
+  display: flex;
+  min-width: 0;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.activity-job-row__type {
+  font-size: 1rem;
+}
+
+.activity-job-row__status,
+.activity-job-row__queue-position {
+  border: 1px solid color-mix(in srgb, var(--chip-border) 82%, transparent);
+  border-radius: 999px;
+  padding: 0.22rem 0.55rem;
+  background: color-mix(in srgb, var(--chip-bg) 76%, transparent);
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.activity-job-row__status--running {
+  border-color: color-mix(in srgb, var(--playback-accent) 38%, var(--chip-border));
+  color: var(--text);
+}
+
+.activity-job-row__status--failed {
+  border-color: color-mix(in srgb, var(--danger) 46%, var(--chip-border));
+  color: var(--danger);
+}
+
+.activity-job-row__queue-position {
+  color: var(--text);
+}
+
+.activity-job-row__project {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.activity-job-row__project-link {
+  color: var(--text);
+  font-weight: 760;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--playback-accent) 42%, transparent);
+  text-underline-offset: 0.18rem;
+}
+
+.activity-job-row__project-link:focus-visible {
+  border-radius: 6px;
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 3px;
+}
+
+.activity-job-row__details,
+.activity-job-row__error {
+  margin: 0;
+}
+
+.activity-job-row__details {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.activity-job-row__progress {
+  justify-content: flex-end;
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 800;
+}
+
+.activity-job-row__progress progress {
+  width: min(100%, 9rem);
+  accent-color: var(--playback-accent);
+}
+
+.activity-job-row__cancel {
+  justify-self: end;
+  white-space: nowrap;
+}
+
+.activity-job-row__timestamps {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+  gap: 0.7rem;
+  margin: 0;
+}
+
+.activity-job-row__timestamps div {
+  min-width: 0;
+}
+
+.activity-job-row__timestamps dt {
+  color: var(--muted);
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.activity-job-row__timestamps dd {
+  margin: 0.18rem 0 0;
+  color: var(--text);
+}
+
+.activity-job-row__error {
+  border-left: 3px solid var(--danger);
+  padding-left: 0.7rem;
+  color: var(--danger);
+  font-weight: 720;
+}
+
+@media (max-width: 920px) {
+  .activity-job-row__main {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .activity-job-row__progress {
+    justify-content: flex-start;
+  }
+
+  .activity-job-row__cancel {
+    justify-self: start;
+  }
+}

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -29,6 +29,7 @@ const {
   mockListStemModels,
   mockListArtifacts,
   mockListJobs,
+  mockCancelJob,
   mockCreateChords,
   mockCreateLyrics,
   mockCreateTabImport,
@@ -349,8 +350,50 @@ const {
     state.stemModels = clone(models);
   }
 
+  function isTerminalJobStatus(status: string) {
+    return ["completed", "failed", "cancelled"].includes(status);
+  }
+
+  function completedAtForJobStatus(status: string) {
+    return isTerminalJobStatus(status) ? createdAt : null;
+  }
+
+  function normalizeMockJob(job: Record<string, unknown>, index = 0): Record<string, unknown> {
+    const clonedJob = clone(job) as Record<string, unknown>;
+    const status = typeof clonedJob.status === "string" ? clonedJob.status : "pending";
+    const type = typeof clonedJob.type === "string" && clonedJob.type ? clonedJob.type : "activity";
+    const progress =
+      typeof clonedJob.progress === "number"
+        ? clonedJob.progress
+        : status === "completed"
+          ? 100
+          : 0;
+
+    return {
+      ...clonedJob,
+      id: typeof clonedJob.id === "string" && clonedJob.id ? clonedJob.id : `job_${index + 1}`,
+      project_id: "project_id" in clonedJob ? clonedJob.project_id : null,
+      type,
+      status,
+      progress,
+      error_message: "error_message" in clonedJob ? clonedJob.error_message : null,
+      completed_at: "completed_at" in clonedJob
+        ? clonedJob.completed_at
+        : completedAtForJobStatus(status),
+      created_at: typeof clonedJob.created_at === "string" ? clonedJob.created_at : createdAt,
+      updated_at: typeof clonedJob.updated_at === "string" ? clonedJob.updated_at : createdAt,
+    };
+  }
+
+  function makeMockJob(job: Record<string, unknown>) {
+    return normalizeMockJob({
+      id: `job_${state.nextJobId++}`,
+      ...job,
+    });
+  }
+
   function setJobs(jobs: Array<Record<string, unknown>>) {
-    state.jobs = clone(jobs);
+    state.jobs = jobs.map((job, index) => normalizeMockJob(job, index));
   }
 
   function setDeferredPreviewCompletion(value: boolean) {
@@ -367,9 +410,18 @@ const {
       ...(state.artifactsByProject[projectId] ?? []),
     ];
     state.pendingPreviewArtifactsByProject[projectId] = [];
-    state.jobs = state.jobs.map((job) =>
+    state.jobs = state.jobs.map((job, index) =>
       job.project_id === projectId && job.type === "preview" && job.status !== "completed"
-        ? { ...job, status: "completed", progress: 100, updated_at: createdAt }
+        ? normalizeMockJob(
+            {
+              ...job,
+              status: "completed",
+              progress: 100,
+              completed_at: job.completed_at ?? createdAt,
+              updated_at: createdAt,
+            },
+            index,
+          )
         : job,
     );
   }
@@ -957,16 +1009,46 @@ const {
       : state.projects;
     return { projects: clone(filteredProjects) };
   });
-  const mockImportProject = vi.fn(async ({ source_path }: { source_path: string; stem_model?: string }) => {
+  const mockImportProject = vi.fn(async (body: {
+    source_path: string;
+    display_name?: string | null;
+    chord_backend?: string | null;
+    chord_backend_fallback_from?: string | null;
+    stem_model?: string | null;
+  }) => {
+    const { source_path } = body;
     const id = `proj_${state.nextProjectId++}`;
     const baseName = source_path.split("/").pop() ?? "Imported Track";
-    const displayName = titleize(baseName);
+    const displayName = body.display_name?.trim() || titleize(baseName);
     const project = makeProject(id, displayName, source_path);
+    const sourceArtifactId = `art_${state.nextArtifactId++}`;
     state.projects.unshift(project);
     state.analysisByProject[id] = null;
+    state.chordsByProject[id] = {
+      project_id: id,
+      backend: null,
+      source_artifact_id: null,
+      source_segments: [],
+      created_at: null,
+      has_user_edits: false,
+      updated_at: null,
+      timeline: [],
+    };
+    state.lyricsByProject[id] = {
+      project_id: id,
+      backend: null,
+      source_artifact_id: null,
+      source_kind: null,
+      source_segments: [],
+      segments: [],
+      has_user_edits: false,
+      created_at: null,
+      updated_at: null,
+    };
+    state.sectionsByProject[id] = [];
     state.artifactsByProject[id] = [
       {
-        id: `art_${state.nextArtifactId++}`,
+        id: sourceArtifactId,
         project_id: id,
         type: "source_audio",
         format: "wav",
@@ -975,6 +1057,39 @@ const {
         created_at: createdAt,
       },
     ];
+    const selectedStemModel = body.stem_model === "htdemucs_ft" ? "htdemucs_ft" : "htdemucs_6s";
+    state.jobs.unshift(
+      makeMockJob({
+        project_id: id,
+        type: "stems",
+        status: "pending",
+        progress: 0,
+        source_artifact_id: sourceArtifactId,
+        stem_model: selectedStemModel,
+        stem_model_label: selectedStemModel === "htdemucs_ft" ? "2 stems model" : "Default (6 stems model)",
+      }),
+      makeMockJob({
+        project_id: id,
+        type: "lyrics",
+        status: "pending",
+        progress: 0,
+      }),
+      makeMockJob({
+        project_id: id,
+        type: "chords",
+        status: "pending",
+        progress: 0,
+        chord_backend: body.chord_backend === "crema-advanced" ? "crema-advanced" : "tuneforge-fast",
+        chord_backend_fallback_from: body.chord_backend_fallback_from ?? null,
+        chord_source: "source",
+      }),
+      makeMockJob({
+        project_id: id,
+        type: "analyze",
+        status: "pending",
+        progress: 0,
+      }),
+    );
     return { project: clone(project) };
   });
   const mockGetProject = vi.fn(async (projectId: string) => ({ project: clone(getProjectOrThrow(projectId)) }));
@@ -1009,11 +1124,31 @@ const {
     ),
   );
   const mockListArtifacts = vi.fn(async (projectId: string) => ({ artifacts: clone(state.artifactsByProject[projectId] ?? []) }));
-  const mockListJobs = vi.fn(async () => ({ jobs: clone(state.jobs) }));
+  const mockListJobs = vi.fn(async () => ({
+    jobs: clone(state.jobs.map((job, index) => normalizeMockJob(job, index))),
+  }));
+  const mockCancelJob = vi.fn(async (jobId: string) => {
+    const jobIndex = state.jobs.findIndex((job) => job.id === jobId);
+    if (jobIndex === -1) {
+      throw new Error(`Unknown job ${jobId}`);
+    }
+    const cancelledJob = normalizeMockJob(
+      {
+        ...state.jobs[jobIndex],
+        status: "cancelled",
+        progress: 0,
+        error_message: null,
+        completed_at: state.jobs[jobIndex]?.completed_at ?? createdAt,
+        updated_at: createdAt,
+      },
+      jobIndex,
+    );
+    state.jobs = state.jobs.map((job, index) => (index === jobIndex ? cancelledJob : job));
+    return { job: clone(cancelledJob) };
+  });
   const mockCreateChords = vi.fn(async (projectId: string, body?: Record<string, unknown>) => {
     state.chordsByProject[projectId] = makeChordTimeline(projectId);
-    const job = {
-      id: `job_${state.nextJobId++}`,
+    const job = makeMockJob({
       project_id: projectId,
       type: "chords",
       status: "completed",
@@ -1024,15 +1159,14 @@ const {
       error_message: null,
       created_at: createdAt,
       updated_at: createdAt,
-    };
+    });
     state.jobs.unshift(job);
     return { job: clone(job) };
   });
   const mockCreateLyrics = vi.fn(async (projectId: string, body?: { force?: boolean }) => {
     void body;
     state.lyricsByProject[projectId] = makeLyricsTranscript(projectId);
-    const job = {
-      id: `job_${state.nextJobId++}`,
+    const job = makeMockJob({
       project_id: projectId,
       type: "lyrics",
       status: "completed",
@@ -1040,7 +1174,7 @@ const {
       error_message: null,
       created_at: createdAt,
       updated_at: createdAt,
-    };
+    });
     state.jobs.unshift(job);
     return { job: clone(job) };
   });
@@ -1528,6 +1662,7 @@ const {
     mockListStemModels,
     mockListArtifacts,
     mockListJobs,
+    mockCancelJob,
     mockCreateChords,
     mockCreateLyrics,
     mockCreateTabImport,
@@ -1582,6 +1717,7 @@ export {
   mockListStemModels,
   mockListArtifacts,
   mockListJobs,
+  mockCancelJob,
   mockCreateChords,
   mockCreateLyrics,
   mockCreateTabImport,
@@ -1633,6 +1769,7 @@ vi.mock("../lib/api", async (importOriginal) => {
       listStemModels: mockListStemModels,
       listArtifacts: mockListArtifacts,
       listJobs: mockListJobs,
+      cancelJob: mockCancelJob,
       createChords: mockCreateChords,
       createLyrics: mockCreateLyrics,
       createTabImport: mockCreateTabImport,
@@ -1937,6 +2074,7 @@ export function resetAppTestHarness() {
   mockGetLyrics.mockClear();
   mockListArtifacts.mockClear();
   mockListJobs.mockClear();
+  mockCancelJob.mockClear();
   mockCreateChords.mockClear();
   mockCreateLyrics.mockClear();
   mockCreateTabImport.mockClear();


### PR DESCRIPTION
## Summary

- Add multi-track Library import with exact path dedupe, a 25-track cap, and batch summaries.
- Add Activity -> Jobs with project links, queue positions, active polling, and cancel actions.
- Update desktop tests and harness support for batch imports, global jobs, and job cancellation.

## Testing

- `pnpm --filter @tuneforge/desktop test --run src/App.library.test.tsx src/App.activity.test.tsx src/App.project-playback-artifacts.test.tsx`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`