### PR TITLE
feat: add sync reconciliation planner

### DIFF
--- a/apps/backend/app/api/routes/sync.py
+++ b/apps/backend/app/api/routes/sync.py
@@ -21,6 +21,8 @@ from app.schemas import (
     SyncProjectImportResponse,
     SyncProjectManifestResponse,
     SyncProjectStagedImportRequest,
+    SyncReconciliationPlanRequest,
+    SyncReconciliationPlanResponse,
     SyncStagedArtifactSchema,
     SyncTrustedPeerCreateRequest,
     SyncTrustedPeerResponse,
@@ -72,6 +74,12 @@ def _require_staged_artifact(
     return require_staged_artifact(session, content_sha256=content_sha256)
 
 
+def plan_sync_reconciliation(session: Session, payload: SyncReconciliationPlanRequest) -> Any:
+    from app.services.sync_reconciliation import plan_sync_reconciliation as service_plan_sync_reconciliation
+
+    return service_plan_sync_reconciliation(session, payload)
+
+
 @router.get("/preflight", response_model=SyncPreflightResponse)
 def sync_preflight(session: Session = Depends(get_db)) -> SyncPreflightResponse:
     return SyncPreflightResponse.model_validate(run_sync_preflight(session))
@@ -80,6 +88,15 @@ def sync_preflight(session: Session = Depends(get_db)) -> SyncPreflightResponse:
 @router.get("/metadata", response_model=SyncMetadataResponse)
 def sync_metadata(session: Session = Depends(get_db)) -> SyncMetadataResponse:
     return SyncMetadataResponse.model_validate(get_sync_metadata(session))
+
+
+@router.post("/reconciliation/plan", response_model=SyncReconciliationPlanResponse)
+def sync_reconciliation_plan(
+    payload: SyncReconciliationPlanRequest,
+    session: Session = Depends(get_db),
+) -> SyncReconciliationPlanResponse:
+    plan = plan_sync_reconciliation(session, payload)
+    return SyncReconciliationPlanResponse.model_validate(plan)
 
 
 @router.get("/identity", response_model=SyncLocalIdentityResponse)

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -350,6 +350,92 @@ class SyncProjectImportResponse(BaseModel):
     project: ProjectSchema
 
 
+SyncReconciliationStatus = Literal[
+    "noop",
+    "identical_content",
+    "missing_local_bytes",
+    "remote_available",
+    "missing_provider",
+    "deleted",
+    "conflicted",
+]
+SyncReconciliationActionType = Literal[
+    "apply_delete_tombstone",
+    "import_project_manifest",
+    "import_entity_revision",
+    "fetch_artifact_content",
+    "import_artifact_manifest",
+    "record_conflict",
+    "noop",
+]
+
+
+class SyncPeerInventoryEntrySchema(BaseModel):
+    device_id: str
+    available_content_sha256: list[str]
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class SyncReconciliationRemoteLibrarySchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    projects: list[SyncMetadataProjectSchema]
+    artifacts: list[SyncMetadataArtifactSchema]
+    entity_revisions: list[SyncProjectManifestEntityRevisionSchema] = Field(default_factory=list)
+    delete_tombstones: list[SyncDeleteTombstoneSchema] = Field(default_factory=list)
+
+
+class SyncReconciliationPlanRequest(BaseModel):
+    remote_library: SyncReconciliationRemoteLibrarySchema
+    project_manifests: list[SyncProjectManifestSchema] = Field(default_factory=list)
+    peer_inventory: list[SyncPeerInventoryEntrySchema]
+
+
+class SyncReconciliationSummarySchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    total_items: int
+    total_actions: int
+    total_conflicts: int
+    status_counts: dict[SyncReconciliationStatus, int] = Field(default_factory=dict)
+
+
+class SyncReconciliationItemSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    item_type: str
+    item_id: str
+    project_id: str | None = None
+    status: SyncReconciliationStatus
+    action_type: SyncReconciliationActionType | None = None
+    content_sha256: str | None = None
+    chosen_provider_device_id: str | None = None
+    reason: str | None = None
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class SyncReconciliationActionSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    action_type: SyncReconciliationActionType
+    item_type: str
+    item_id: str
+    project_id: str | None = None
+    content_sha256: str | None = None
+    provider_device_id: str | None = None
+    reason: str | None = None
+    priority: int
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class SyncReconciliationPlanResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    summary: SyncReconciliationSummarySchema
+    items: list[SyncReconciliationItemSchema]
+    actions: list[SyncReconciliationActionSchema]
+
+
 class SyncLocalIdentitySchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/apps/backend/app/services/sync_reconciliation.py
+++ b/apps/backend/app/services/sync_reconciliation.py
@@ -1,0 +1,2224 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.errors import AppError
+from app.models import (
+    Artifact,
+    Project,
+    SyncDeleteTombstone,
+    SyncEntityRevision,
+    SyncLocalIdentity,
+    SyncTrustedPeer,
+)
+from app.services.sync_identity import source_hash_to_project_id
+from app.services.sync_manifest import _coerce_project_manifest
+from app.services.sync_revisions import revision_payload_sha256, sanitize_revision_payload
+from app.services.sync_trust import LOCAL_IDENTITY_ID
+from app.utils.hashing import file_sha256
+
+SYNC_RECONCILIATION_STATUSES = (
+    "noop",
+    "identical_content",
+    "missing_local_bytes",
+    "remote_available",
+    "missing_provider",
+    "deleted",
+    "conflicted",
+)
+
+ACTION_APPLY_DELETE_TOMBSTONE = "apply_delete_tombstone"
+ACTION_IMPORT_PROJECT_MANIFEST = "import_project_manifest"
+ACTION_IMPORT_ENTITY_REVISION = "import_entity_revision"
+ACTION_FETCH_ARTIFACT_CONTENT = "fetch_artifact_content"
+ACTION_IMPORT_ARTIFACT_MANIFEST = "import_artifact_manifest"
+ACTION_RECORD_CONFLICT = "record_conflict"
+ACTION_NOOP = "noop"
+
+ITEM_PROJECT = "project"
+ITEM_ARTIFACT = "artifact"
+ITEM_ENTITY_REVISION = "entity_revision"
+ITEM_DELETE_TOMBSTONE = "delete_tombstone"
+
+_STATUS_PRECEDENCE = {
+    "noop": 0,
+    "identical_content": 10,
+    "remote_available": 20,
+    "missing_local_bytes": 30,
+    "missing_provider": 40,
+    "conflicted": 50,
+    "deleted": 60,
+}
+
+_ACTION_PRIORITY = {
+    ACTION_APPLY_DELETE_TOMBSTONE: 0,
+    ACTION_RECORD_CONFLICT: 10,
+    ACTION_FETCH_ARTIFACT_CONTENT: 20,
+    ACTION_IMPORT_PROJECT_MANIFEST: 30,
+    ACTION_IMPORT_ARTIFACT_MANIFEST: 40,
+    ACTION_IMPORT_ENTITY_REVISION: 50,
+    ACTION_NOOP: 100,
+}
+
+_MISSING = object()
+
+
+@dataclass(frozen=True)
+class SyncReconciliationSummary:
+    status_counts: dict[str, int]
+    total_items: int
+    total_actions: int
+    total_conflicts: int
+
+
+@dataclass(frozen=True)
+class SyncReconciliationItem:
+    item_type: str
+    item_id: str
+    project_id: str | None
+    status: str
+    action_type: str | None = None
+    content_sha256: str | None = None
+    chosen_provider_device_id: str | None = None
+    reason: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SyncReconciliationAction:
+    action_type: str
+    item_type: str
+    item_id: str
+    priority: int
+    project_id: str | None = None
+    content_sha256: str | None = None
+    provider_device_id: str | None = None
+    reason: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SyncReconciliationPlan:
+    summary: SyncReconciliationSummary
+    items: list[SyncReconciliationItem]
+    actions: list[SyncReconciliationAction]
+
+
+@dataclass(frozen=True)
+class _RemoteProject:
+    project_id: str
+    source_sha256: str | None
+    raw: Any
+
+
+@dataclass(frozen=True)
+class _RemoteArtifact:
+    artifact_id: str
+    project_id: str
+    content_sha256: str | None
+    size_bytes: int | None
+    type: str | None
+    format: str | None
+    relative_path: str | None
+    raw: Any
+
+
+@dataclass(frozen=True)
+class _RemoteEntityRevision:
+    revision_id: str
+    project_id: str
+    entity_type: str
+    entity_id: str
+    base_revision_id: str | None
+    source_artifact_id: str | None
+    content_sha256: str | None
+    raw: Any
+
+
+@dataclass(frozen=True)
+class _RemoteTombstone:
+    tombstone_id: str
+    sync_group_id: str | None
+    project_id: str
+    target_type: str
+    target_id: str
+    author_device_id: str | None
+    deleted_at: Any
+    raw: Any
+
+
+@dataclass(frozen=True)
+class _RemoteRequest:
+    projects: dict[str, _RemoteProject]
+    artifacts: dict[str, _RemoteArtifact]
+    entity_revisions: dict[str, _RemoteEntityRevision]
+    tombstones: list[_RemoteTombstone]
+    project_manifests_by_id: dict[str, Any]
+    manifest_artifact_ids_by_project: dict[str, frozenset[str]]
+    manifest_revision_ids_by_project: dict[str, frozenset[str]]
+    provider_device_ids_by_content_sha256: dict[str, tuple[str, ...]]
+
+
+@dataclass(frozen=True)
+class _LocalState:
+    identity: SyncLocalIdentity | None
+    trusted_device_ids: frozenset[str]
+    projects: dict[str, Project]
+    artifacts: dict[str, Artifact]
+    artifacts_by_content_sha256: dict[str, tuple[Artifact, ...]]
+    entity_revisions: dict[str, SyncEntityRevision]
+    entity_revisions_by_entity: dict[tuple[str, str, str], tuple[SyncEntityRevision, ...]]
+    tombstones: tuple[SyncDeleteTombstone, ...]
+
+
+def plan_sync_reconciliation(
+    session: Session,
+    request: object | Mapping[str, Any],
+) -> SyncReconciliationPlan:
+    """Build a deterministic, read-only sync reconciliation plan."""
+
+    local = _load_local_state(session)
+    remote = _coerce_remote_request(request, trusted_device_ids=local.trusted_device_ids)
+
+    items_by_key: dict[tuple[str, str], SyncReconciliationItem] = {}
+    actions: list[SyncReconciliationAction] = []
+
+    valid_remote_tombstones: list[_RemoteTombstone] = []
+    ignored_remote_tombstones: list[tuple[_RemoteTombstone, str]] = []
+    for tombstone in remote.tombstones:
+        valid, reason = _validate_remote_tombstone(tombstone, local)
+        if valid:
+            valid_remote_tombstones.append(tombstone)
+        else:
+            ignored_remote_tombstones.append((tombstone, reason))
+
+    effective_tombstones = _effective_tombstone_targets(local.tombstones, valid_remote_tombstones)
+
+    for tombstone, reason in sorted(ignored_remote_tombstones, key=lambda item: _remote_tombstone_sort_key(item[0])):
+        _upsert_item(
+            items_by_key,
+            SyncReconciliationItem(
+                item_type=ITEM_DELETE_TOMBSTONE,
+                item_id=tombstone.tombstone_id,
+                project_id=tombstone.project_id,
+                status="noop",
+                action_type=ACTION_NOOP,
+                reason=reason,
+                details=_tombstone_details(tombstone),
+            ),
+        )
+
+    for tombstone in sorted(valid_remote_tombstones, key=_remote_tombstone_sort_key):
+        _upsert_item(
+            items_by_key,
+            SyncReconciliationItem(
+                item_type=tombstone.target_type,
+                item_id=tombstone.target_id,
+                project_id=tombstone.project_id,
+                status="deleted",
+                action_type=ACTION_APPLY_DELETE_TOMBSTONE,
+                reason="A valid delete tombstone wins over remote manifests.",
+                details=_tombstone_details(tombstone),
+            ),
+        )
+        actions.append(
+            _action(
+                ACTION_APPLY_DELETE_TOMBSTONE,
+                item_type=tombstone.target_type,
+                item_id=tombstone.target_id,
+                project_id=tombstone.project_id,
+                reason="Apply valid sync delete tombstone before imports or fetches.",
+                details=_tombstone_details(tombstone),
+            )
+        )
+
+    for project in sorted(remote.projects.values(), key=lambda project: project.project_id):
+        _plan_project(
+            project,
+            remote=remote,
+            local=local,
+            effective_tombstones=effective_tombstones,
+            items_by_key=items_by_key,
+            actions=actions,
+        )
+
+    for artifact in sorted(remote.artifacts.values(), key=lambda artifact: (artifact.project_id, artifact.artifact_id)):
+        planned_project_ids = _planned_project_ids(actions)
+        if (
+            artifact.project_id in remote.project_manifests_by_id
+            and artifact.project_id not in local.projects
+            and artifact.artifact_id in remote.manifest_artifact_ids_by_project.get(artifact.project_id, frozenset())
+        ):
+            continue
+        _plan_artifact(
+            artifact,
+            remote=remote,
+            local=local,
+            effective_tombstones=effective_tombstones,
+            planned_project_ids=planned_project_ids,
+            items_by_key=items_by_key,
+            actions=actions,
+        )
+
+    planned_artifact_project_ids = _planned_artifact_project_ids(actions)
+    planned_revision_ids = set(local.entity_revisions)
+    planned_remote_revisions_by_id: dict[str, _RemoteEntityRevision] = {}
+    for revision in _sorted_remote_entity_revisions(remote.entity_revisions.values()):
+        if (
+            revision.project_id in remote.project_manifests_by_id
+            and revision.project_id not in local.projects
+            and revision.revision_id in remote.manifest_revision_ids_by_project.get(revision.project_id, frozenset())
+        ):
+            continue
+        if _plan_entity_revision(
+            revision,
+            local=local,
+            effective_tombstones=effective_tombstones,
+            planned_revision_ids=frozenset(planned_revision_ids),
+            planned_remote_revisions_by_id=planned_remote_revisions_by_id,
+            planned_artifact_project_ids=planned_artifact_project_ids,
+            items_by_key=items_by_key,
+            actions=actions,
+        ):
+            planned_revision_ids.add(revision.revision_id)
+            if revision.revision_id not in local.entity_revisions:
+                planned_remote_revisions_by_id[revision.revision_id] = revision
+
+    items = sorted(items_by_key.values(), key=_item_sort_key)
+    deduped_actions = _dedupe_actions(actions)
+    summary = _summarize(items, deduped_actions)
+    return SyncReconciliationPlan(summary=summary, items=items, actions=deduped_actions)
+
+
+def _load_local_state(session: Session) -> _LocalState:
+    identity = session.get(SyncLocalIdentity, LOCAL_IDENTITY_ID)
+    trusted_device_ids: frozenset[str]
+    if identity is None:
+        trusted_device_ids = frozenset()
+    else:
+        trusted_device_ids = frozenset(
+            peer.device_id
+            for peer in session.scalars(
+                select(SyncTrustedPeer)
+                .where(SyncTrustedPeer.revoked_at.is_(None))
+                .where(SyncTrustedPeer.sync_group_id == identity.sync_group_id)
+                .order_by(SyncTrustedPeer.device_id.asc())
+            )
+        )
+
+    projects = {
+        project.id: project
+        for project in session.scalars(select(Project).order_by(Project.id.asc()))
+    }
+    artifacts = {
+        artifact.id: artifact
+        for artifact in session.scalars(select(Artifact).order_by(Artifact.project_id.asc(), Artifact.id.asc()))
+    }
+    artifacts_by_hash: dict[str, list[Artifact]] = {}
+    for artifact in artifacts.values():
+        content_hash = _normalize_sha256(artifact.content_sha256)
+        if content_hash is not None:
+            artifacts_by_hash.setdefault(content_hash, []).append(artifact)
+
+    revisions = {
+        revision.id: revision
+        for revision in session.scalars(
+            select(SyncEntityRevision).order_by(
+                SyncEntityRevision.project_id.asc(),
+                SyncEntityRevision.entity_type.asc(),
+                SyncEntityRevision.entity_id.asc(),
+                SyncEntityRevision.id.asc(),
+            )
+        )
+    }
+    revisions_by_entity: dict[tuple[str, str, str], list[SyncEntityRevision]] = {}
+    for revision in revisions.values():
+        key = (revision.project_id, revision.entity_type, revision.entity_id)
+        revisions_by_entity.setdefault(key, []).append(revision)
+
+    tombstones = tuple(
+        session.scalars(
+            select(SyncDeleteTombstone).order_by(
+                SyncDeleteTombstone.project_id.asc(),
+                SyncDeleteTombstone.target_type.asc(),
+                SyncDeleteTombstone.target_id.asc(),
+                SyncDeleteTombstone.deleted_at.asc(),
+                SyncDeleteTombstone.id.asc(),
+            )
+        )
+    )
+
+    return _LocalState(
+        identity=identity,
+        trusted_device_ids=trusted_device_ids,
+        projects=projects,
+        artifacts=artifacts,
+        artifacts_by_content_sha256={
+            content_hash: tuple(sorted(rows, key=lambda artifact: (artifact.project_id, artifact.id)))
+            for content_hash, rows in artifacts_by_hash.items()
+        },
+        entity_revisions=revisions,
+        entity_revisions_by_entity={
+            key: tuple(sorted(rows, key=lambda revision: revision.id))
+            for key, rows in revisions_by_entity.items()
+        },
+        tombstones=tombstones,
+    )
+
+
+def _coerce_remote_request(
+    request: object | Mapping[str, Any],
+    *,
+    trusted_device_ids: frozenset[str],
+) -> _RemoteRequest:
+    library = _first_field(
+        request,
+        "remote_library",
+        "remote_library_manifest",
+        "library_manifest",
+        "library",
+        default=request,
+    )
+
+    project_manifests = _collect_project_manifests(request, library)
+    projects = _remote_projects(library, project_manifests)
+    artifacts = _remote_artifacts(library, project_manifests)
+    revisions = _remote_entity_revisions(library, project_manifests)
+    tombstones = _remote_tombstones(library, project_manifests)
+    inventory_source = _first_field(
+        request,
+        "peer_inventory",
+        "peer_inventories",
+        "inventory",
+        default=_first_field(library, "peer_inventory", "peer_inventories", "inventory", default=[]),
+    )
+
+    return _RemoteRequest(
+        projects=projects,
+        artifacts=artifacts,
+        entity_revisions=revisions,
+        tombstones=tombstones,
+        project_manifests_by_id={
+            project_id: manifest
+            for project_id, manifest in (
+                (_project_id_from_manifest(manifest), manifest)
+                for manifest in project_manifests
+            )
+            if project_id is not None
+        },
+        manifest_artifact_ids_by_project=_manifest_artifact_ids_by_project(project_manifests),
+        manifest_revision_ids_by_project=_manifest_revision_ids_by_project(project_manifests),
+        provider_device_ids_by_content_sha256=_provider_inventory(
+            inventory_source,
+            trusted_device_ids=trusted_device_ids,
+        ),
+    )
+
+
+def _manifest_artifact_ids_by_project(project_manifests: Iterable[Any]) -> dict[str, frozenset[str]]:
+    artifact_ids_by_project: dict[str, set[str]] = {}
+    for manifest in project_manifests:
+        project_id = _project_id_from_manifest(manifest)
+        if project_id is None:
+            continue
+        artifact_ids = {
+            artifact.artifact_id
+            for artifact in _manifest_artifacts(manifest)
+        }
+        if artifact_ids:
+            artifact_ids_by_project[project_id] = artifact_ids
+    return {
+        project_id: frozenset(artifact_ids)
+        for project_id, artifact_ids in artifact_ids_by_project.items()
+    }
+
+
+def _manifest_revision_ids_by_project(project_manifests: Iterable[Any]) -> dict[str, frozenset[str]]:
+    revision_ids_by_project: dict[str, set[str]] = {}
+    for manifest in project_manifests:
+        project_id = _project_id_from_manifest(manifest)
+        if project_id is None:
+            continue
+        revision_ids = {
+            revision.revision_id
+            for revision in _manifest_entity_revisions(manifest)
+        }
+        if revision_ids:
+            revision_ids_by_project[project_id] = revision_ids
+    return {
+        project_id: frozenset(revision_ids)
+        for project_id, revision_ids in revision_ids_by_project.items()
+    }
+
+
+def _collect_project_manifests(request: object, library: object) -> list[Any]:
+    manifests: list[Any] = []
+    for source in (request, library):
+        for name in ("project_manifest", "project_manifests", "manifests"):
+            manifests.extend(_list_field(source, name))
+
+        for project in _list_field(source, "projects"):
+            nested_manifest = _first_field(project, "manifest", "project_manifest", default=None)
+            if nested_manifest is not None:
+                manifests.append(nested_manifest)
+
+    by_project_id: dict[str, Any] = {}
+    fallback: list[Any] = []
+    for manifest in manifests:
+        project_id = _project_id_from_manifest(manifest)
+        if project_id is None:
+            fallback.append(manifest)
+            continue
+        by_project_id[project_id] = manifest
+    return [by_project_id[key] for key in sorted(by_project_id)] + fallback
+
+
+def _remote_projects(library: object, project_manifests: Iterable[Any]) -> dict[str, _RemoteProject]:
+    projects: dict[str, _RemoteProject] = {}
+    for raw_project in _list_field(library, "projects"):
+        project = _coerce_remote_project(raw_project)
+        if project is not None:
+            projects[project.project_id] = project
+
+    for manifest in project_manifests:
+        project = _coerce_remote_project(_first_field(manifest, "project", default=manifest))
+        if project is not None:
+            projects[project.project_id] = project
+
+    return projects
+
+
+def _remote_artifacts(library: object, project_manifests: Iterable[Any]) -> dict[str, _RemoteArtifact]:
+    artifacts: dict[str, _RemoteArtifact] = {}
+    for raw_artifact in _list_field(library, "artifacts"):
+        artifact = _coerce_remote_artifact(raw_artifact)
+        if artifact is not None:
+            artifacts[artifact.artifact_id] = artifact
+
+    for manifest in project_manifests:
+        for raw_artifact in _list_field(manifest, "artifacts"):
+            artifact = _coerce_remote_artifact(raw_artifact)
+            if artifact is not None:
+                artifacts[artifact.artifact_id] = artifact
+
+    return artifacts
+
+
+def _remote_entity_revisions(
+    library: object,
+    project_manifests: Iterable[Any],
+) -> dict[str, _RemoteEntityRevision]:
+    revisions: dict[str, _RemoteEntityRevision] = {}
+    for raw_revision in _list_field(library, "entity_revisions", "revisions"):
+        revision = _coerce_remote_revision(raw_revision)
+        if revision is not None:
+            revisions[revision.revision_id] = revision
+
+    for manifest in project_manifests:
+        for raw_revision in _list_field(manifest, "entity_revisions", "revisions"):
+            revision = _coerce_remote_revision(raw_revision)
+            if revision is not None:
+                revisions[revision.revision_id] = revision
+
+    return revisions
+
+
+def _remote_tombstones(library: object, project_manifests: Iterable[Any]) -> list[_RemoteTombstone]:
+    tombstones_by_key: dict[tuple[str, str, str, str], _RemoteTombstone] = {}
+    for source in (library, *project_manifests):
+        for raw_tombstone in _list_field(source, "delete_tombstones", "tombstones"):
+            tombstone = _coerce_remote_tombstone(raw_tombstone)
+            if tombstone is None:
+                continue
+            key = (
+                tombstone.tombstone_id,
+                tombstone.sync_group_id or "",
+                tombstone.target_type,
+                tombstone.target_id,
+            )
+            tombstones_by_key[key] = tombstone
+
+    return [tombstones_by_key[key] for key in sorted(tombstones_by_key)]
+
+
+def _provider_inventory(
+    inventory: object,
+    *,
+    trusted_device_ids: frozenset[str],
+) -> dict[str, tuple[str, ...]]:
+    providers_by_hash: dict[str, set[str]] = {}
+    for device_id, content_hash in _iter_inventory_availability(inventory):
+        if device_id not in trusted_device_ids:
+            continue
+        normalized_hash = _normalize_sha256(content_hash)
+        if normalized_hash is None:
+            continue
+        providers_by_hash.setdefault(normalized_hash, set()).add(device_id)
+
+    return {
+        content_hash: tuple(sorted(device_ids))
+        for content_hash, device_ids in sorted(providers_by_hash.items())
+    }
+
+
+def _iter_inventory_availability(inventory: object) -> Iterable[tuple[str, str]]:
+    if isinstance(inventory, Mapping):
+        device_id = _str_field(inventory, "device_id", "provider_device_id", "peer_device_id")
+        if device_id is not None:
+            yield from _iter_peer_inventory(device_id, inventory)
+            return
+        for key, value in inventory.items():
+            if isinstance(key, str) and not _looks_like_inventory_field_name(key):
+                yield from _iter_peer_inventory(key, value)
+            else:
+                yield from _iter_inventory_availability(value)
+        return
+
+    if isinstance(inventory, str) or not isinstance(inventory, (list, tuple)):
+        return
+
+    for entry in _as_list(inventory):
+        device_id = _str_field(entry, "device_id", "provider_device_id", "peer_device_id")
+        if device_id is not None:
+            yield from _iter_peer_inventory(device_id, entry)
+        elif isinstance(entry, (list, tuple, Mapping)):
+            yield from _iter_inventory_availability(entry)
+
+
+def _iter_peer_inventory(device_id: str, entry: object) -> Iterable[tuple[str, str]]:
+    if isinstance(entry, str):
+        yield device_id, entry
+        return
+    if isinstance(entry, (list, tuple)):
+        for value in entry:
+            if isinstance(value, str):
+                yield device_id, value
+                continue
+            content_hash = _str_field(value, "content_sha256", "sha256", "content_hash")
+            if content_hash is not None and _inventory_entry_is_available(value):
+                yield device_id, content_hash
+        return
+
+    direct_hash = _str_field(entry, "content_sha256", "sha256", "content_hash")
+    if direct_hash is not None and _inventory_entry_is_available(entry):
+        yield device_id, direct_hash
+
+    for name in (
+        "content_sha256s",
+        "content_hashes",
+        "available_content_sha256",
+        "available_content_sha256s",
+        "available_content_hashes",
+        "available_content",
+        "available_artifacts",
+        "artifacts",
+    ):
+        for value in _list_field(entry, name):
+            if isinstance(value, str):
+                yield device_id, value
+                continue
+            content_hash = _str_field(value, "content_sha256", "sha256", "content_hash")
+            if content_hash is not None and _inventory_entry_is_available(value):
+                yield device_id, content_hash
+
+
+def _inventory_entry_is_available(entry: object) -> bool:
+    status = _str_field(entry, "status", "availability", default=None)
+    if status is None:
+        available = _first_field(entry, "available", default=None)
+        return not isinstance(available, bool) or available
+    return status in {"available", "local", "ready", "present"}
+
+
+def _looks_like_inventory_field_name(key: str) -> bool:
+    return key in {
+        "peer_inventory",
+        "peer_inventories",
+        "inventory",
+        "providers",
+        "available_content",
+    }
+
+
+def _plan_project(
+    project: _RemoteProject,
+    *,
+    remote: _RemoteRequest,
+    local: _LocalState,
+    effective_tombstones: frozenset[tuple[str, str]],
+    items_by_key: dict[tuple[str, str], SyncReconciliationItem],
+    actions: list[SyncReconciliationAction],
+) -> None:
+    if _is_deleted(ITEM_PROJECT, project.project_id, project.project_id, effective_tombstones):
+        _upsert_item(
+            items_by_key,
+            SyncReconciliationItem(
+                item_type=ITEM_PROJECT,
+                item_id=project.project_id,
+                project_id=project.project_id,
+                status="deleted",
+                action_type=ACTION_APPLY_DELETE_TOMBSTONE,
+                reason="Project is covered by a sync delete tombstone.",
+            ),
+        )
+        return
+
+    local_project = local.projects.get(project.project_id)
+    if local_project is not None:
+        if (
+            project.source_sha256 is not None
+            and local_project.source_sha256 is not None
+            and _normalize_sha256(local_project.source_sha256) != project.source_sha256
+        ):
+            _record_conflict(
+                items_by_key,
+                actions,
+                item_type=ITEM_PROJECT,
+                item_id=project.project_id,
+                project_id=project.project_id,
+                content_sha256=project.source_sha256,
+                reason="Remote project has the same ID with a different source SHA-256.",
+                details={
+                    "local_source_sha256": local_project.source_sha256,
+                    "remote_source_sha256": project.source_sha256,
+                },
+            )
+            return
+        _upsert_item(
+            items_by_key,
+            SyncReconciliationItem(
+                item_type=ITEM_PROJECT,
+                item_id=project.project_id,
+                project_id=project.project_id,
+                status="noop",
+                action_type=ACTION_NOOP,
+                content_sha256=project.source_sha256,
+                reason="Project already exists locally.",
+            ),
+        )
+        return
+
+    manifest = remote.project_manifests_by_id.get(project.project_id)
+    if manifest is None:
+        _upsert_item(
+            items_by_key,
+            SyncReconciliationItem(
+                item_type=ITEM_PROJECT,
+                item_id=project.project_id,
+                project_id=project.project_id,
+                status="missing_provider",
+                content_sha256=project.source_sha256,
+                reason="Project manifest is required before import.",
+            ),
+        )
+        return
+
+    manifest_artifacts = _manifest_artifacts(manifest)
+    source_artifact, source_error, source_details = _importable_source_artifact_for_manifest(manifest_artifacts)
+    if source_error is not None:
+        _record_conflict(
+            items_by_key,
+            actions,
+            item_type=ITEM_PROJECT,
+            item_id=project.project_id,
+            project_id=project.project_id,
+            content_sha256=project.source_sha256,
+            reason=source_error,
+            details=source_details,
+        )
+        return
+
+    assert source_artifact is not None
+    source_hash = source_artifact.content_sha256
+    if source_hash is None:
+        _upsert_item(
+            items_by_key,
+            SyncReconciliationItem(
+                item_type=ITEM_PROJECT,
+                item_id=project.project_id,
+                project_id=project.project_id,
+                status="missing_provider",
+                reason="Project manifest does not identify required source content.",
+            ),
+        )
+        return
+    if project.source_sha256 is None:
+        _upsert_item(
+            items_by_key,
+            SyncReconciliationItem(
+                item_type=ITEM_PROJECT,
+                item_id=project.project_id,
+                project_id=project.project_id,
+                status="missing_provider",
+                reason="Project manifest does not include source SHA-256 identity metadata.",
+            ),
+        )
+        return
+    try:
+        expected_project_id = source_hash_to_project_id(project.source_sha256)
+    except ValueError:
+        _record_conflict(
+            items_by_key,
+            actions,
+            item_type=ITEM_PROJECT,
+            item_id=project.project_id,
+            project_id=project.project_id,
+            content_sha256=project.source_sha256,
+            reason="Project manifest source_sha256 must be a full SHA-256 hex digest.",
+            details={"source_sha256": project.source_sha256},
+        )
+        return
+    if project.project_id != expected_project_id:
+        _record_conflict(
+            items_by_key,
+            actions,
+            item_type=ITEM_PROJECT,
+            item_id=project.project_id,
+            project_id=project.project_id,
+            content_sha256=project.source_sha256,
+            reason="Project manifest project_id must be derived from source_sha256.",
+            details={
+                "expected_project_id": expected_project_id,
+                "source_sha256": project.source_sha256,
+            },
+        )
+        return
+
+    manifest_revisions = _manifest_entity_revisions(manifest)
+    manifest_error = _project_manifest_import_error(
+        project=project,
+        manifest=manifest,
+        artifacts=manifest_artifacts,
+        revisions=manifest_revisions,
+        local=local,
+        effective_tombstones=effective_tombstones,
+    )
+    if manifest_error is not None:
+        reason, details = manifest_error
+        _record_conflict(
+            items_by_key,
+            actions,
+            item_type=ITEM_PROJECT,
+            item_id=project.project_id,
+            project_id=project.project_id,
+            content_sha256=project.source_sha256,
+            reason=reason,
+            details=details,
+        )
+        return
+
+    missing_hash_artifact_ids = [
+        artifact.artifact_id
+        for artifact in manifest_artifacts
+        if artifact.content_sha256 is None
+    ]
+    if missing_hash_artifact_ids:
+        _upsert_item(
+            items_by_key,
+            SyncReconciliationItem(
+                item_type=ITEM_PROJECT,
+                item_id=project.project_id,
+                project_id=project.project_id,
+                status="missing_provider",
+                content_sha256=source_hash,
+                reason="Project manifest contains artifacts without content SHA-256 metadata.",
+                details={"artifact_ids": sorted(missing_hash_artifact_ids)},
+            ),
+        )
+        return
+
+    available_artifacts = _manifest_artifact_availability(manifest_artifacts, remote=remote, local=local)
+    missing_provider_artifacts = [
+        artifact.artifact_id
+        for artifact, local_artifact, provider_device_id in available_artifacts
+        if local_artifact is None and provider_device_id is None
+    ]
+    if missing_provider_artifacts:
+        _upsert_item(
+            items_by_key,
+            SyncReconciliationItem(
+                item_type=ITEM_PROJECT,
+                item_id=project.project_id,
+                project_id=project.project_id,
+                status="missing_provider",
+                content_sha256=source_hash,
+                reason="No local bytes or trusted provider are available for every project manifest artifact.",
+                details={"artifact_ids": sorted(missing_provider_artifacts)},
+            ),
+        )
+        return
+
+    artifact_providers = {
+        artifact.artifact_id: provider_device_id
+        for artifact, local_artifact, provider_device_id in available_artifacts
+        if local_artifact is None and provider_device_id is not None
+    }
+    local_artifact_ids = {
+        artifact.artifact_id: local_artifact.id
+        for artifact, local_artifact, _provider_device_id in available_artifacts
+        if local_artifact is not None
+    }
+    if not artifact_providers:
+        _upsert_item(
+            items_by_key,
+            SyncReconciliationItem(
+                item_type=ITEM_PROJECT,
+                item_id=project.project_id,
+                project_id=project.project_id,
+                status="identical_content",
+                action_type=ACTION_IMPORT_PROJECT_MANIFEST,
+                content_sha256=source_hash,
+                reason="All project manifest artifact bytes are already verified locally.",
+                details={
+                    "local_artifact_ids": local_artifact_ids,
+                    "manifest_artifact_count": len(manifest_artifacts),
+                },
+            ),
+        )
+        actions.append(
+            _action(
+                ACTION_IMPORT_PROJECT_MANIFEST,
+                item_type=ITEM_PROJECT,
+                item_id=project.project_id,
+                project_id=project.project_id,
+                content_sha256=source_hash,
+                reason="Import project manifest using locally verified artifact content.",
+                details={
+                    "source_artifact_id": source_artifact.artifact_id if source_artifact else None,
+                    "manifest_artifact_count": len(manifest_artifacts),
+                },
+            )
+        )
+        return
+
+    chosen_provider_device_id = sorted(artifact_providers.values())[0]
+    _upsert_item(
+        items_by_key,
+        SyncReconciliationItem(
+            item_type=ITEM_PROJECT,
+            item_id=project.project_id,
+            project_id=project.project_id,
+            status="remote_available",
+            action_type=ACTION_IMPORT_PROJECT_MANIFEST,
+            content_sha256=source_hash,
+            chosen_provider_device_id=chosen_provider_device_id,
+            reason="Every project manifest artifact is local or advertised by a trusted peer.",
+            details={
+                "artifact_providers": artifact_providers,
+                "manifest_artifact_count": len(manifest_artifacts),
+            },
+        ),
+    )
+    for artifact, local_artifact, provider_device_id in available_artifacts:
+        if local_artifact is not None or provider_device_id is None or artifact.content_sha256 is None:
+            continue
+        actions.append(
+            _action(
+                ACTION_FETCH_ARTIFACT_CONTENT,
+                item_type=ITEM_ARTIFACT,
+                item_id=artifact.artifact_id,
+                project_id=project.project_id,
+                content_sha256=artifact.content_sha256,
+                provider_device_id=provider_device_id,
+                reason="Fetch project manifest artifact bytes before importing the project.",
+            )
+        )
+    actions.append(
+        _action(
+            ACTION_IMPORT_PROJECT_MANIFEST,
+            item_type=ITEM_PROJECT,
+            item_id=project.project_id,
+            project_id=project.project_id,
+            content_sha256=source_hash,
+            provider_device_id=chosen_provider_device_id,
+            reason="Import project manifest after every required artifact is available.",
+            details={
+                "source_artifact_id": source_artifact.artifact_id if source_artifact else None,
+                "manifest_artifact_count": len(manifest_artifacts),
+            },
+        )
+    )
+
+
+def _plan_artifact(
+    artifact: _RemoteArtifact,
+    *,
+    remote: _RemoteRequest,
+    local: _LocalState,
+    effective_tombstones: frozenset[tuple[str, str]],
+    planned_project_ids: frozenset[str],
+    items_by_key: dict[tuple[str, str], SyncReconciliationItem],
+    actions: list[SyncReconciliationAction],
+) -> None:
+    if _is_deleted(ITEM_ARTIFACT, artifact.artifact_id, artifact.project_id, effective_tombstones):
+        _upsert_item(
+            items_by_key,
+            SyncReconciliationItem(
+                item_type=ITEM_ARTIFACT,
+                item_id=artifact.artifact_id,
+                project_id=artifact.project_id,
+                status="deleted",
+                action_type=ACTION_APPLY_DELETE_TOMBSTONE,
+                content_sha256=artifact.content_sha256,
+                reason="Artifact is covered by a sync delete tombstone.",
+            ),
+        )
+        return
+
+    if artifact.content_sha256 is None:
+        _upsert_item(
+            items_by_key,
+            SyncReconciliationItem(
+                item_type=ITEM_ARTIFACT,
+                item_id=artifact.artifact_id,
+                project_id=artifact.project_id,
+                status="missing_provider",
+                reason="Remote artifact does not include a content SHA-256.",
+            ),
+        )
+        return
+
+    if artifact.project_id not in local.projects and artifact.project_id not in planned_project_ids:
+        _upsert_item(
+            items_by_key,
+            SyncReconciliationItem(
+                item_type=ITEM_ARTIFACT,
+                item_id=artifact.artifact_id,
+                project_id=artifact.project_id,
+                status="missing_provider",
+                content_sha256=artifact.content_sha256,
+                reason=(
+                    "Project must exist locally or have an importable project manifest before importing "
+                    "an artifact."
+                ),
+            ),
+        )
+        return
+
+    local_artifact = local.artifacts.get(artifact.artifact_id)
+    if local_artifact is not None:
+        local_hash = _normalize_sha256(local_artifact.content_sha256)
+        if local_hash != artifact.content_sha256:
+            _record_conflict(
+                items_by_key,
+                actions,
+                item_type=ITEM_ARTIFACT,
+                item_id=artifact.artifact_id,
+                project_id=artifact.project_id,
+                content_sha256=artifact.content_sha256,
+                reason="Local and remote artifacts share an ID but have different content hashes.",
+                details={
+                    "local_content_sha256": local_hash,
+                    "remote_content_sha256": artifact.content_sha256,
+                },
+            )
+            return
+
+        if _artifact_has_verified_content(local_artifact, artifact.content_sha256, artifact.size_bytes):
+            _upsert_item(
+                items_by_key,
+                SyncReconciliationItem(
+                    item_type=ITEM_ARTIFACT,
+                    item_id=artifact.artifact_id,
+                    project_id=artifact.project_id,
+                    status="identical_content",
+                    action_type=ACTION_NOOP,
+                    content_sha256=artifact.content_sha256,
+                    reason="Artifact bytes are already verified locally.",
+                ),
+            )
+            return
+
+        provider_device_id = _choose_provider(remote, artifact.content_sha256)
+        _upsert_item(
+            items_by_key,
+            SyncReconciliationItem(
+                item_type=ITEM_ARTIFACT,
+                item_id=artifact.artifact_id,
+                project_id=artifact.project_id,
+                status="missing_local_bytes",
+                action_type=ACTION_FETCH_ARTIFACT_CONTENT if provider_device_id is not None else None,
+                content_sha256=artifact.content_sha256,
+                chosen_provider_device_id=provider_device_id,
+                reason="Local artifact metadata exists, but verified bytes are missing.",
+            ),
+        )
+        if provider_device_id is not None:
+            actions.append(
+                _action(
+                    ACTION_FETCH_ARTIFACT_CONTENT,
+                    item_type=ITEM_ARTIFACT,
+                    item_id=artifact.artifact_id,
+                    project_id=artifact.project_id,
+                    content_sha256=artifact.content_sha256,
+                    provider_device_id=provider_device_id,
+                    reason="Fetch artifact bytes from the selected trusted provider.",
+                )
+            )
+        return
+
+    duplicate = _verified_artifact_for_hash(local, artifact.content_sha256)
+    if duplicate is not None:
+        _upsert_item(
+            items_by_key,
+            SyncReconciliationItem(
+                item_type=ITEM_ARTIFACT,
+                item_id=artifact.artifact_id,
+                project_id=artifact.project_id,
+                status="identical_content",
+                action_type=ACTION_IMPORT_ARTIFACT_MANIFEST,
+                content_sha256=artifact.content_sha256,
+                reason="Content hash is already verified under another local artifact ID.",
+                details={"local_artifact_id": duplicate.id},
+            ),
+        )
+        actions.append(
+            _action(
+                ACTION_IMPORT_ARTIFACT_MANIFEST,
+                item_type=ITEM_ARTIFACT,
+                item_id=artifact.artifact_id,
+                project_id=artifact.project_id,
+                content_sha256=artifact.content_sha256,
+                reason="Import artifact manifest without fetching duplicate bytes.",
+                details={"local_artifact_id": duplicate.id},
+            )
+        )
+        return
+
+    provider_device_id = _choose_provider(remote, artifact.content_sha256)
+    if provider_device_id is not None:
+        _upsert_item(
+            items_by_key,
+            SyncReconciliationItem(
+                item_type=ITEM_ARTIFACT,
+                item_id=artifact.artifact_id,
+                project_id=artifact.project_id,
+                status="remote_available",
+                action_type=ACTION_FETCH_ARTIFACT_CONTENT,
+                content_sha256=artifact.content_sha256,
+                chosen_provider_device_id=provider_device_id,
+                reason="Artifact content is advertised by a trusted peer.",
+            ),
+        )
+        actions.append(
+            _action(
+                ACTION_FETCH_ARTIFACT_CONTENT,
+                item_type=ITEM_ARTIFACT,
+                item_id=artifact.artifact_id,
+                project_id=artifact.project_id,
+                content_sha256=artifact.content_sha256,
+                provider_device_id=provider_device_id,
+                reason="Fetch artifact bytes from the selected trusted provider.",
+            )
+        )
+        actions.append(
+            _action(
+                ACTION_IMPORT_ARTIFACT_MANIFEST,
+                item_type=ITEM_ARTIFACT,
+                item_id=artifact.artifact_id,
+                project_id=artifact.project_id,
+                content_sha256=artifact.content_sha256,
+                provider_device_id=provider_device_id,
+                reason="Import artifact manifest after content is available.",
+            )
+        )
+        return
+
+    _upsert_item(
+        items_by_key,
+        SyncReconciliationItem(
+            item_type=ITEM_ARTIFACT,
+            item_id=artifact.artifact_id,
+            project_id=artifact.project_id,
+            status="missing_provider",
+            content_sha256=artifact.content_sha256,
+            reason="No local bytes or trusted provider are available for artifact content.",
+        ),
+    )
+
+
+def _plan_entity_revision(
+    revision: _RemoteEntityRevision,
+    *,
+    local: _LocalState,
+    effective_tombstones: frozenset[tuple[str, str]],
+    planned_revision_ids: frozenset[str],
+    planned_remote_revisions_by_id: Mapping[str, _RemoteEntityRevision],
+    planned_artifact_project_ids: Mapping[str, str],
+    items_by_key: dict[tuple[str, str], SyncReconciliationItem],
+    actions: list[SyncReconciliationAction],
+) -> bool:
+    if _is_deleted(ITEM_ENTITY_REVISION, revision.revision_id, revision.project_id, effective_tombstones):
+        _upsert_item(
+            items_by_key,
+            SyncReconciliationItem(
+                item_type=ITEM_ENTITY_REVISION,
+                item_id=revision.revision_id,
+                project_id=revision.project_id,
+                status="deleted",
+                action_type=ACTION_APPLY_DELETE_TOMBSTONE,
+                content_sha256=revision.content_sha256,
+                reason="Entity revision is covered by a sync delete tombstone.",
+            ),
+        )
+        return False
+
+    local_revision = local.entity_revisions.get(revision.revision_id)
+    if local_revision is not None:
+        if _normalize_sha256(local_revision.content_sha256) == revision.content_sha256:
+            _upsert_item(
+                items_by_key,
+                SyncReconciliationItem(
+                    item_type=ITEM_ENTITY_REVISION,
+                    item_id=revision.revision_id,
+                    project_id=revision.project_id,
+                    status="identical_content",
+                    action_type=ACTION_NOOP,
+                    content_sha256=revision.content_sha256,
+                    reason="Entity revision already exists locally with the same content hash.",
+                ),
+            )
+            return True
+
+        _record_conflict(
+            items_by_key,
+            actions,
+            item_type=ITEM_ENTITY_REVISION,
+            item_id=revision.revision_id,
+            project_id=revision.project_id,
+            content_sha256=revision.content_sha256,
+            reason="Local and remote entity revisions share an ID but have different content hashes.",
+            details={
+                "local_content_sha256": local_revision.content_sha256,
+                "remote_content_sha256": revision.content_sha256,
+            },
+        )
+        return False
+
+    if revision.project_id not in local.projects:
+        _upsert_item(
+            items_by_key,
+            SyncReconciliationItem(
+                item_type=ITEM_ENTITY_REVISION,
+                item_id=revision.revision_id,
+                project_id=revision.project_id,
+                status="missing_provider",
+                content_sha256=revision.content_sha256,
+                reason="Project must exist locally before importing a standalone entity revision.",
+                details={"base_revision_id": revision.base_revision_id},
+            ),
+        )
+        return False
+
+    if revision.base_revision_id is not None and revision.base_revision_id not in planned_revision_ids:
+        _upsert_item(
+            items_by_key,
+            SyncReconciliationItem(
+                item_type=ITEM_ENTITY_REVISION,
+                item_id=revision.revision_id,
+                project_id=revision.project_id,
+                status="missing_provider",
+                content_sha256=revision.content_sha256,
+                reason="Base revision must exist locally or be planned before importing this entity revision.",
+                details={"base_revision_id": revision.base_revision_id},
+            ),
+        )
+        return False
+
+    reference_error = _standalone_entity_revision_reference_error(
+        revision,
+        local=local,
+        planned_remote_revisions_by_id=planned_remote_revisions_by_id,
+        planned_artifact_project_ids=planned_artifact_project_ids,
+    )
+    if reference_error is not None:
+        reason, details = reference_error
+        _record_conflict(
+            items_by_key,
+            actions,
+            item_type=ITEM_ENTITY_REVISION,
+            item_id=revision.revision_id,
+            project_id=revision.project_id,
+            content_sha256=revision.content_sha256,
+            reason=reason,
+            details=details,
+        )
+        return False
+
+    revision_manifest_error = _entity_revision_manifest_contract_error(revision)
+    if revision_manifest_error is not None:
+        reason, details = revision_manifest_error
+        _record_conflict(
+            items_by_key,
+            actions,
+            item_type=ITEM_ENTITY_REVISION,
+            item_id=revision.revision_id,
+            project_id=revision.project_id,
+            content_sha256=revision.content_sha256,
+            reason=reason,
+            details=details,
+        )
+        return False
+
+    divergent_revision = _divergent_local_revision(revision, local)
+    if divergent_revision is not None:
+        _record_conflict(
+            items_by_key,
+            actions,
+            item_type=ITEM_ENTITY_REVISION,
+            item_id=revision.revision_id,
+            project_id=revision.project_id,
+            content_sha256=revision.content_sha256,
+            reason="Remote entity revision diverges from a local revision with the same base.",
+            details={
+                "base_revision_id": revision.base_revision_id,
+                "local_revision_id": divergent_revision.id,
+                "local_content_sha256": divergent_revision.content_sha256,
+                "remote_content_sha256": revision.content_sha256,
+            },
+        )
+        return False
+
+    _upsert_item(
+        items_by_key,
+        SyncReconciliationItem(
+            item_type=ITEM_ENTITY_REVISION,
+            item_id=revision.revision_id,
+            project_id=revision.project_id,
+            status="remote_available",
+            action_type=ACTION_IMPORT_ENTITY_REVISION,
+            content_sha256=revision.content_sha256,
+            reason="Remote entity revision can be imported.",
+            details={"base_revision_id": revision.base_revision_id},
+        ),
+    )
+    actions.append(
+        _action(
+            ACTION_IMPORT_ENTITY_REVISION,
+            item_type=ITEM_ENTITY_REVISION,
+            item_id=revision.revision_id,
+            project_id=revision.project_id,
+            content_sha256=revision.content_sha256,
+            reason="Import remote entity revision metadata.",
+            details={"base_revision_id": revision.base_revision_id},
+        )
+    )
+    return True
+
+
+def _validate_remote_tombstone(tombstone: _RemoteTombstone, local: _LocalState) -> tuple[bool, str]:
+    if local.identity is None:
+        return False, "Ignored remote tombstone because the local sync identity is missing."
+    if tombstone.sync_group_id != local.identity.sync_group_id:
+        return False, "Ignored remote tombstone from a different sync group."
+    if tombstone.author_device_id == local.identity.device_id:
+        return True, ""
+    if tombstone.author_device_id in local.trusted_device_ids:
+        return True, ""
+    return False, "Ignored remote tombstone from an untrusted or revoked author device."
+
+
+def _project_manifest_import_error(
+    *,
+    project: _RemoteProject,
+    manifest: object,
+    artifacts: Iterable[_RemoteArtifact],
+    revisions: Iterable[_RemoteEntityRevision],
+    local: _LocalState,
+    effective_tombstones: frozenset[tuple[str, str]],
+) -> tuple[str, dict[str, Any]] | None:
+    manifest_artifacts = list(artifacts)
+    manifest_revisions = list(revisions)
+    tombstoned_artifacts = [
+        artifact.artifact_id
+        for artifact in manifest_artifacts
+        if _is_deleted(ITEM_ARTIFACT, artifact.artifact_id, project.project_id, effective_tombstones)
+    ]
+    tombstoned_revisions = [
+        revision.revision_id
+        for revision in manifest_revisions
+        if _is_deleted(ITEM_ENTITY_REVISION, revision.revision_id, project.project_id, effective_tombstones)
+    ]
+    if tombstoned_artifacts or tombstoned_revisions:
+        return (
+            "Project manifest contains live targets covered by sync delete tombstones.",
+            {
+                "artifact_ids": sorted(tombstoned_artifacts),
+                "revision_ids": sorted(tombstoned_revisions),
+            },
+        )
+
+    artifact_error = _artifact_manifest_import_error(
+        project=project,
+        artifacts=manifest_artifacts,
+    )
+    if artifact_error is not None:
+        return artifact_error
+
+    try:
+        _coerce_project_manifest(manifest)
+    except AppError as exc:
+        return exc.message, dict(exc.details)
+
+    artifact_conflicts = [
+        artifact.artifact_id
+        for artifact in manifest_artifacts
+        if artifact.artifact_id in local.artifacts
+    ]
+    if artifact_conflicts:
+        return (
+            "A synced artifact conflicts with an existing local artifact.",
+            {"artifact_ids": sorted(artifact_conflicts)},
+        )
+
+    revision_ids = [revision.revision_id for revision in manifest_revisions]
+    duplicate_revision_ids = _duplicates(revision_ids)
+    if duplicate_revision_ids:
+        return (
+            "Project manifest contains duplicate entity revision IDs.",
+            {"revision_ids": duplicate_revision_ids},
+        )
+
+    revision_conflicts = [
+        revision.revision_id
+        for revision in manifest_revisions
+        if revision.revision_id in local.entity_revisions
+    ]
+    if revision_conflicts:
+        return (
+            "A synced entity revision conflicts with an existing local revision.",
+            {"revision_ids": sorted(revision_conflicts)},
+        )
+
+    manifest_revisions_by_id = {
+        revision.revision_id: revision
+        for revision in manifest_revisions
+    }
+    manifest_artifacts_by_id = {
+        artifact.artifact_id: artifact
+        for artifact in manifest_artifacts
+    }
+    for revision in manifest_revisions:
+        if revision.project_id != project.project_id:
+            return (
+                "Entity revision manifest belongs to a different project.",
+                {"revision_id": revision.revision_id, "project_id": revision.project_id},
+            )
+        base_error = _entity_revision_base_reference_error(
+            revision,
+            project_id=project.project_id,
+            local=local,
+            manifest_revisions_by_id=manifest_revisions_by_id,
+        )
+        if base_error is not None:
+            reason, details = base_error
+            return reason, {"revision_id": revision.revision_id, **details}
+        source_error = _entity_revision_source_artifact_reference_error(
+            revision,
+            project_id=project.project_id,
+            manifest_artifacts_by_id=manifest_artifacts_by_id,
+        )
+        if source_error is not None:
+            reason, details = source_error
+            return reason, {"revision_id": revision.revision_id, **details}
+
+    cycle_revision_ids = _cycle_revision_ids(manifest_revisions)
+    if cycle_revision_ids:
+        return (
+            "Entity revision base_revision_id contains a cycle.",
+            {"revision_ids": cycle_revision_ids},
+        )
+
+    return None
+
+
+def _artifact_manifest_import_error(
+    *,
+    project: _RemoteProject,
+    artifacts: Iterable[_RemoteArtifact],
+) -> tuple[str, dict[str, Any]] | None:
+    manifest_artifacts = list(artifacts)
+    duplicate_artifact_ids = _duplicates(artifact.artifact_id for artifact in manifest_artifacts)
+    if duplicate_artifact_ids:
+        return (
+            "Project manifest contains duplicate artifact IDs.",
+            {"artifact_ids": duplicate_artifact_ids},
+        )
+
+    relative_paths: set[str] = set()
+    for artifact in manifest_artifacts:
+        if artifact.project_id != project.project_id:
+            return (
+                "Artifact manifest belongs to a different project.",
+                {"artifact_id": artifact.artifact_id, "project_id": artifact.project_id},
+            )
+        if artifact.content_sha256 is None or not _is_sha256(artifact.content_sha256):
+            return (
+                "Artifact manifest content_sha256 must be a full SHA-256 hex digest.",
+                {"artifact_id": artifact.artifact_id},
+            )
+        if artifact.size_bytes is None or artifact.size_bytes < 0:
+            return (
+                "Artifact manifest size_bytes must be non-negative.",
+                {"artifact_id": artifact.artifact_id, "size_bytes": artifact.size_bytes},
+            )
+        metadata = _first_field(artifact.raw, "metadata", default={})
+        if not isinstance(metadata, Mapping):
+            return (
+                "Artifact manifest metadata must be an object.",
+                {"artifact_id": artifact.artifact_id},
+            )
+        path_error = _manifest_relative_path_error(artifact.relative_path)
+        if path_error is not None:
+            return (
+                path_error,
+                {
+                    "artifact_id": artifact.artifact_id,
+                    "relative_path": artifact.relative_path,
+                },
+            )
+
+        assert artifact.relative_path is not None
+        normalized_path = PurePosixPath(artifact.relative_path).as_posix()
+        if normalized_path in relative_paths:
+            return (
+                "Project manifest contains duplicate artifact relative paths.",
+                {"relative_path": normalized_path},
+            )
+        relative_paths.add(normalized_path)
+
+    return None
+
+
+def _entity_revision_base_reference_error(
+    revision: _RemoteEntityRevision,
+    *,
+    project_id: str,
+    local: _LocalState,
+    manifest_revisions_by_id: Mapping[str, _RemoteEntityRevision],
+) -> tuple[str, dict[str, Any]] | None:
+    if revision.base_revision_id is None:
+        return None
+
+    manifest_base = manifest_revisions_by_id.get(revision.base_revision_id)
+    if manifest_base is not None:
+        if (
+            manifest_base.project_id != project_id
+            or manifest_base.entity_type != revision.entity_type
+            or manifest_base.entity_id != revision.entity_id
+        ):
+            return (
+                "Entity revision base_revision_id must reference the same project entity.",
+                {"base_revision_id": revision.base_revision_id},
+            )
+        return None
+
+    existing_base = local.entity_revisions.get(revision.base_revision_id)
+    if existing_base is None:
+        return (
+            "Entity revision base_revision_id does not exist in the manifest.",
+            {"base_revision_id": revision.base_revision_id},
+        )
+    if (
+        existing_base.project_id != project_id
+        or existing_base.entity_type != revision.entity_type
+        or existing_base.entity_id != revision.entity_id
+    ):
+        return (
+            "Entity revision base_revision_id must reference the same project entity.",
+            {"base_revision_id": revision.base_revision_id},
+        )
+    return None
+
+
+def _entity_revision_source_artifact_reference_error(
+    revision: _RemoteEntityRevision,
+    *,
+    project_id: str,
+    manifest_artifacts_by_id: Mapping[str, _RemoteArtifact],
+) -> tuple[str, dict[str, Any]] | None:
+    if revision.source_artifact_id is None:
+        return None
+    artifact = manifest_artifacts_by_id.get(revision.source_artifact_id)
+    if artifact is None:
+        return (
+            "Entity revision source_artifact_id does not exist in the manifest.",
+            {"source_artifact_id": revision.source_artifact_id},
+        )
+    if artifact.project_id != project_id:
+        return (
+            "Entity revision source_artifact_id must belong to the manifest project.",
+            {"source_artifact_id": revision.source_artifact_id},
+        )
+    return None
+
+
+def _standalone_entity_revision_reference_error(
+    revision: _RemoteEntityRevision,
+    *,
+    local: _LocalState,
+    planned_remote_revisions_by_id: Mapping[str, _RemoteEntityRevision],
+    planned_artifact_project_ids: Mapping[str, str],
+) -> tuple[str, dict[str, Any]] | None:
+    base_error = _entity_revision_base_reference_error(
+        revision,
+        project_id=revision.project_id,
+        local=local,
+        manifest_revisions_by_id=planned_remote_revisions_by_id,
+    )
+    if base_error is not None:
+        reason, details = base_error
+        return reason, {"revision_id": revision.revision_id, **details}
+
+    source_error = _standalone_entity_revision_source_artifact_reference_error(
+        revision,
+        local=local,
+        planned_artifact_project_ids=planned_artifact_project_ids,
+    )
+    if source_error is not None:
+        reason, details = source_error
+        return reason, {"revision_id": revision.revision_id, **details}
+    return None
+
+
+def _standalone_entity_revision_source_artifact_reference_error(
+    revision: _RemoteEntityRevision,
+    *,
+    local: _LocalState,
+    planned_artifact_project_ids: Mapping[str, str],
+) -> tuple[str, dict[str, Any]] | None:
+    if revision.source_artifact_id is None:
+        return None
+
+    local_artifact = local.artifacts.get(revision.source_artifact_id)
+    if local_artifact is not None:
+        if local_artifact.project_id != revision.project_id:
+            return (
+                "Entity revision source_artifact_id must belong to the manifest project.",
+                {"source_artifact_id": revision.source_artifact_id},
+            )
+        return None
+
+    planned_project_id = planned_artifact_project_ids.get(revision.source_artifact_id)
+    if planned_project_id is None:
+        return (
+            "Entity revision source_artifact_id does not exist in the manifest.",
+            {"source_artifact_id": revision.source_artifact_id},
+        )
+    if planned_project_id != revision.project_id:
+        return (
+            "Entity revision source_artifact_id must belong to the manifest project.",
+            {"source_artifact_id": revision.source_artifact_id},
+        )
+    return None
+
+
+def _entity_revision_manifest_contract_error(
+    revision: _RemoteEntityRevision,
+) -> tuple[str, dict[str, Any]] | None:
+    if revision.content_sha256 is None or not _is_sha256(revision.content_sha256):
+        return (
+            "Entity revision manifest content_sha256 must be a full SHA-256 hex digest.",
+            {"revision_id": revision.revision_id},
+        )
+
+    metadata = _first_field(revision.raw, "metadata", default={})
+    if not isinstance(metadata, Mapping):
+        return (
+            "Entity revision manifest metadata must be an object.",
+            {"revision_id": revision.revision_id},
+        )
+    payload = _first_field(revision.raw, "payload", default={})
+    if not isinstance(payload, Mapping):
+        return (
+            "Entity revision manifest payload must be an object.",
+            {"revision_id": revision.revision_id},
+        )
+
+    safe_metadata = sanitize_revision_payload(metadata)
+    safe_payload = sanitize_revision_payload(payload)
+    if safe_metadata != metadata or safe_payload != payload:
+        return (
+            "Entity revision manifest metadata and payload must be sync-safe.",
+            {"revision_id": revision.revision_id},
+        )
+    if revision.content_sha256 != revision_payload_sha256(safe_payload):
+        return (
+            "Entity revision manifest content_sha256 must match payload.",
+            {"revision_id": revision.revision_id},
+        )
+    return None
+
+
+def _cycle_revision_ids(revisions: Iterable[_RemoteEntityRevision]) -> list[str]:
+    pending = {revision.revision_id: revision for revision in revisions}
+    while pending:
+        ready = [
+            revision_id
+            for revision_id, revision in pending.items()
+            if revision.base_revision_id not in pending
+        ]
+        if not ready:
+            return sorted(pending)
+        for revision_id in ready:
+            del pending[revision_id]
+    return []
+
+
+def _duplicates(values: Iterable[str]) -> list[str]:
+    counts = Counter(values)
+    return sorted(value for value, count in counts.items() if count > 1)
+
+
+def _effective_tombstone_targets(
+    local_tombstones: Iterable[SyncDeleteTombstone],
+    remote_tombstones: Iterable[_RemoteTombstone],
+) -> frozenset[tuple[str, str]]:
+    targets: set[tuple[str, str]] = set()
+    for local_tombstone in local_tombstones:
+        target_type = _normalize_target_type(local_tombstone.target_type)
+        targets.add((target_type, local_tombstone.target_id))
+        if target_type == ITEM_PROJECT:
+            targets.add((ITEM_PROJECT, local_tombstone.project_id))
+    for remote_tombstone in remote_tombstones:
+        targets.add((remote_tombstone.target_type, remote_tombstone.target_id))
+        if remote_tombstone.target_type == ITEM_PROJECT:
+            targets.add((ITEM_PROJECT, remote_tombstone.project_id))
+    return frozenset(targets)
+
+
+def _is_deleted(
+    item_type: str,
+    item_id: str,
+    project_id: str,
+    effective_tombstones: frozenset[tuple[str, str]],
+) -> bool:
+    if (ITEM_PROJECT, project_id) in effective_tombstones:
+        return True
+    return (item_type, item_id) in effective_tombstones
+
+
+def _record_conflict(
+    items_by_key: dict[tuple[str, str], SyncReconciliationItem],
+    actions: list[SyncReconciliationAction],
+    *,
+    item_type: str,
+    item_id: str,
+    project_id: str,
+    content_sha256: str | None,
+    reason: str,
+    details: dict[str, Any],
+) -> None:
+    _upsert_item(
+        items_by_key,
+        SyncReconciliationItem(
+            item_type=item_type,
+            item_id=item_id,
+            project_id=project_id,
+            status="conflicted",
+            action_type=ACTION_RECORD_CONFLICT,
+            content_sha256=content_sha256,
+            reason=reason,
+            details=details,
+        ),
+    )
+    actions.append(
+        _action(
+            ACTION_RECORD_CONFLICT,
+            item_type=item_type,
+            item_id=item_id,
+            project_id=project_id,
+            content_sha256=content_sha256,
+            reason=reason,
+            details=details,
+        )
+    )
+
+
+def _coerce_remote_project(raw: object) -> _RemoteProject | None:
+    project_id = _str_field(raw, "project_id", "id")
+    if project_id is None:
+        return None
+    return _RemoteProject(
+        project_id=project_id,
+        source_sha256=_normalize_sha256(_str_field(raw, "source_sha256")),
+        raw=raw,
+    )
+
+
+def _coerce_remote_artifact(raw: object) -> _RemoteArtifact | None:
+    artifact_id = _str_field(raw, "artifact_id", "id")
+    project_id = _str_field(raw, "project_id")
+    if artifact_id is None or project_id is None:
+        return None
+    return _RemoteArtifact(
+        artifact_id=artifact_id,
+        project_id=project_id,
+        content_sha256=_normalize_sha256(_str_field(raw, "content_sha256")),
+        size_bytes=_int_field(raw, "size_bytes"),
+        type=_str_field(raw, "type", "artifact_type"),
+        format=_str_field(raw, "format"),
+        relative_path=_str_field(raw, "relative_path"),
+        raw=raw,
+    )
+
+
+def _coerce_remote_revision(raw: object) -> _RemoteEntityRevision | None:
+    revision_id = _str_field(raw, "revision_id", "id")
+    project_id = _str_field(raw, "project_id")
+    entity_type = _str_field(raw, "entity_type")
+    entity_id = _str_field(raw, "entity_id")
+    if revision_id is None or project_id is None or entity_type is None or entity_id is None:
+        return None
+    return _RemoteEntityRevision(
+        revision_id=revision_id,
+        project_id=project_id,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        base_revision_id=_str_field(raw, "base_revision_id"),
+        source_artifact_id=_str_field(raw, "source_artifact_id"),
+        content_sha256=_normalize_sha256(_str_field(raw, "content_sha256")),
+        raw=raw,
+    )
+
+
+def _sorted_remote_entity_revisions(
+    revisions: Iterable[_RemoteEntityRevision],
+) -> list[_RemoteEntityRevision]:
+    revisions_by_id = {revision.revision_id: revision for revision in revisions}
+    visiting: set[str] = set()
+    visited: set[str] = set()
+    ordered: list[_RemoteEntityRevision] = []
+
+    def visit(revision: _RemoteEntityRevision) -> None:
+        if revision.revision_id in visited:
+            return
+        if revision.revision_id in visiting:
+            visited.add(revision.revision_id)
+            ordered.append(revision)
+            return
+        visiting.add(revision.revision_id)
+        if revision.base_revision_id is not None:
+            base_revision = revisions_by_id.get(revision.base_revision_id)
+            if base_revision is not None:
+                visit(base_revision)
+        visiting.remove(revision.revision_id)
+        visited.add(revision.revision_id)
+        ordered.append(revision)
+
+    for revision in sorted(
+        revisions_by_id.values(),
+        key=lambda value: (
+            value.project_id,
+            value.entity_type,
+            value.entity_id,
+            value.base_revision_id or "",
+            value.revision_id,
+        ),
+    ):
+        visit(revision)
+    return ordered
+
+
+def _coerce_remote_tombstone(raw: object) -> _RemoteTombstone | None:
+    tombstone_id = _str_field(raw, "tombstone_id", "id")
+    project_id = _str_field(raw, "project_id")
+    target_type = _str_field(raw, "target_type")
+    target_id = _str_field(raw, "target_id")
+    if tombstone_id is None or project_id is None or target_type is None or target_id is None:
+        return None
+    return _RemoteTombstone(
+        tombstone_id=tombstone_id,
+        sync_group_id=_str_field(raw, "sync_group_id"),
+        project_id=project_id,
+        target_type=_normalize_target_type(target_type),
+        target_id=target_id,
+        author_device_id=_str_field(raw, "author_device_id"),
+        deleted_at=_first_field(raw, "deleted_at", default=None),
+        raw=raw,
+    )
+
+
+def _source_artifact_for_manifest(manifest: object) -> _RemoteArtifact | None:
+    source_artifacts = [
+        artifact
+        for artifact in _manifest_artifacts(manifest)
+        if artifact.type == "source_audio"
+    ]
+    if not source_artifacts:
+        return None
+    return sorted(source_artifacts, key=lambda artifact: artifact.artifact_id)[0]
+
+
+def _importable_source_artifact_for_manifest(
+    artifacts: Iterable[_RemoteArtifact],
+) -> tuple[_RemoteArtifact | None, str | None, dict[str, Any]]:
+    source_artifacts = [
+        artifact
+        for artifact in artifacts
+        if artifact.type == "source_audio"
+    ]
+    if len(source_artifacts) != 1:
+        return (
+            None,
+            "Project manifest must contain exactly one source_audio artifact.",
+            {"source_artifact_count": len(source_artifacts)},
+        )
+
+    source_artifact = source_artifacts[0]
+    if source_artifact.format != "wav":
+        return (
+            None,
+            "Project manifest source_audio artifact format must be 'wav'.",
+            {"artifact_id": source_artifact.artifact_id, "format": source_artifact.format},
+        )
+    path_error = _manifest_relative_path_error(source_artifact.relative_path)
+    if path_error is not None:
+        return (
+            None,
+            path_error,
+            {
+                "artifact_id": source_artifact.artifact_id,
+                "relative_path": source_artifact.relative_path,
+            },
+        )
+    assert source_artifact.relative_path is not None
+    if PurePosixPath(source_artifact.relative_path).suffix.lower() != ".wav":
+        return (
+            None,
+            "Project manifest source_audio artifact relative_path must end with .wav.",
+            {
+                "artifact_id": source_artifact.artifact_id,
+                "relative_path": source_artifact.relative_path,
+            },
+        )
+    return source_artifact, None, {}
+
+
+def _manifest_relative_path_error(relative_path: str | None) -> str | None:
+    if relative_path is None or "\x00" in relative_path or "\\" in relative_path:
+        return "Sync manifest artifact relative path is invalid."
+    path = PurePosixPath(relative_path)
+    if path.is_absolute() or not path.parts:
+        return "Sync manifest artifact relative path is invalid."
+    if any(part in {"", ".", ".."} for part in path.parts):
+        return "Sync manifest artifact relative path is invalid."
+    return None
+
+
+def _manifest_artifacts(manifest: object) -> list[_RemoteArtifact]:
+    return [
+        artifact
+        for artifact in (_coerce_remote_artifact(raw) for raw in _list_field(manifest, "artifacts"))
+        if artifact is not None
+    ]
+
+
+def _manifest_entity_revisions(manifest: object) -> list[_RemoteEntityRevision]:
+    return [
+        revision
+        for revision in (_coerce_remote_revision(raw) for raw in _list_field(manifest, "entity_revisions", "revisions"))
+        if revision is not None
+    ]
+
+
+def _manifest_artifact_availability(
+    artifacts: Iterable[_RemoteArtifact],
+    *,
+    remote: _RemoteRequest,
+    local: _LocalState,
+) -> list[tuple[_RemoteArtifact, Artifact | None, str | None]]:
+    availability: list[tuple[_RemoteArtifact, Artifact | None, str | None]] = []
+    for artifact in sorted(artifacts, key=lambda value: value.artifact_id):
+        if artifact.content_sha256 is None:
+            availability.append((artifact, None, None))
+            continue
+        local_artifact = _verified_artifact_for_hash(
+            local,
+            artifact.content_sha256,
+            size_bytes=artifact.size_bytes,
+        )
+        provider_device_id = None if local_artifact is not None else _choose_provider(remote, artifact.content_sha256)
+        availability.append((artifact, local_artifact, provider_device_id))
+    return availability
+
+
+def _project_id_from_manifest(manifest: object) -> str | None:
+    project = _first_field(manifest, "project", default=manifest)
+    return _str_field(project, "project_id", "id")
+
+
+def _choose_provider(remote: _RemoteRequest, content_sha256: str) -> str | None:
+    providers = remote.provider_device_ids_by_content_sha256.get(content_sha256, ())
+    return providers[0] if providers else None
+
+
+def _planned_project_ids(actions: Iterable[SyncReconciliationAction]) -> frozenset[str]:
+    return frozenset(
+        action.item_id
+        for action in actions
+        if action.action_type == ACTION_IMPORT_PROJECT_MANIFEST and action.item_type == ITEM_PROJECT
+    )
+
+
+def _planned_artifact_project_ids(actions: Iterable[SyncReconciliationAction]) -> dict[str, str]:
+    return {
+        action.item_id: action.project_id
+        for action in actions
+        if action.action_type == ACTION_IMPORT_ARTIFACT_MANIFEST
+        and action.item_type == ITEM_ARTIFACT
+        and action.project_id is not None
+    }
+
+
+def _verified_artifact_for_hash(
+    local: _LocalState,
+    content_sha256: str,
+    *,
+    exclude_artifact_id: str | None = None,
+    size_bytes: int | None = None,
+) -> Artifact | None:
+    for artifact in local.artifacts_by_content_sha256.get(content_sha256, ()):
+        if artifact.id == exclude_artifact_id:
+            continue
+        if _artifact_has_verified_content(artifact, content_sha256, size_bytes):
+            return artifact
+    return None
+
+
+def _artifact_has_verified_content(
+    artifact: Artifact,
+    content_sha256: str,
+    size_bytes: int | None,
+) -> bool:
+    if _normalize_sha256(artifact.content_sha256) != content_sha256:
+        return False
+    artifact_path = Path(artifact.path).expanduser()
+    if size_bytes is not None:
+        try:
+            if artifact_path.stat().st_size != size_bytes:
+                return False
+        except OSError:
+            return False
+    return file_sha256(artifact_path) == content_sha256
+
+
+def _divergent_local_revision(
+    remote_revision: _RemoteEntityRevision,
+    local: _LocalState,
+) -> SyncEntityRevision | None:
+    key = (
+        remote_revision.project_id,
+        remote_revision.entity_type,
+        remote_revision.entity_id,
+    )
+    for local_revision in local.entity_revisions_by_entity.get(key, ()):
+        if local_revision.id == remote_revision.revision_id:
+            continue
+        if local_revision.base_revision_id != remote_revision.base_revision_id:
+            continue
+        if _normalize_sha256(local_revision.content_sha256) == remote_revision.content_sha256:
+            continue
+        return local_revision
+    return None
+
+
+def _upsert_item(
+    items_by_key: dict[tuple[str, str], SyncReconciliationItem],
+    item: SyncReconciliationItem,
+) -> None:
+    existing = items_by_key.get((item.item_type, item.item_id))
+    if existing is None or _STATUS_PRECEDENCE[item.status] > _STATUS_PRECEDENCE[existing.status]:
+        items_by_key[(item.item_type, item.item_id)] = item
+
+
+def _action(
+    action_type: str,
+    *,
+    item_type: str,
+    item_id: str,
+    project_id: str | None,
+    content_sha256: str | None = None,
+    provider_device_id: str | None = None,
+    reason: str | None = None,
+    details: dict[str, Any] | None = None,
+) -> SyncReconciliationAction:
+    return SyncReconciliationAction(
+        action_type=action_type,
+        item_type=item_type,
+        item_id=item_id,
+        project_id=project_id,
+        content_sha256=content_sha256,
+        provider_device_id=provider_device_id,
+        reason=reason,
+        priority=_ACTION_PRIORITY[action_type],
+        details=details or {},
+    )
+
+
+def _dedupe_actions(actions: Iterable[SyncReconciliationAction]) -> list[SyncReconciliationAction]:
+    seen: set[tuple[Any, ...]] = set()
+    deduped: list[SyncReconciliationAction] = []
+    for action in actions:
+        key = _action_key(action)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(action)
+    return sorted(deduped, key=lambda action: action.priority)
+
+
+def _action_key(action: SyncReconciliationAction) -> tuple[Any, ...]:
+    return (
+        action.priority,
+        action.action_type,
+        action.project_id or "",
+        action.item_type,
+        action.item_id,
+        action.content_sha256 or "",
+        action.provider_device_id or "",
+        _stable_json(action.details or {}),
+    )
+
+
+def _item_sort_key(item: SyncReconciliationItem) -> tuple[int, str, str, str, str]:
+    item_type_order = {
+        ITEM_DELETE_TOMBSTONE: 0,
+        ITEM_PROJECT: 1,
+        ITEM_ARTIFACT: 2,
+        ITEM_ENTITY_REVISION: 3,
+    }.get(item.item_type, 99)
+    return (
+        item_type_order,
+        item.project_id or "",
+        item.item_type,
+        item.item_id,
+        item.status,
+    )
+
+
+def _summarize(
+    items: list[SyncReconciliationItem],
+    actions: list[SyncReconciliationAction],
+) -> SyncReconciliationSummary:
+    counts = Counter(item.status for item in items)
+    status_counts = {status: int(counts.get(status, 0)) for status in SYNC_RECONCILIATION_STATUSES}
+    return SyncReconciliationSummary(
+        status_counts=status_counts,
+        total_items=len(items),
+        total_actions=len(actions),
+        total_conflicts=status_counts["conflicted"],
+    )
+
+
+def _remote_tombstone_sort_key(tombstone: _RemoteTombstone) -> tuple[str, str, str, str, str]:
+    return (
+        tombstone.project_id,
+        tombstone.target_type,
+        tombstone.target_id,
+        _sortable_datetime(tombstone.deleted_at),
+        tombstone.tombstone_id,
+    )
+
+
+def _tombstone_details(tombstone: _RemoteTombstone) -> dict[str, Any]:
+    return {
+        "tombstone_id": tombstone.tombstone_id,
+        "sync_group_id": tombstone.sync_group_id,
+        "author_device_id": tombstone.author_device_id,
+        "target_type": tombstone.target_type,
+        "target_id": tombstone.target_id,
+        "deleted_at": _sortable_datetime(tombstone.deleted_at),
+    }
+
+
+def _normalize_target_type(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized in {"revision", "entity"}:
+        return ITEM_ENTITY_REVISION
+    return normalized
+
+
+def _normalize_sha256(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    return normalized or None
+
+
+def _is_sha256(value: str) -> bool:
+    if len(value) != 64:
+        return False
+    try:
+        int(value, 16)
+    except ValueError:
+        return False
+    return True
+
+
+def _first_field(source: object, *names: str, default: object = _MISSING) -> Any:
+    for name in names:
+        if isinstance(source, Mapping) and name in source:
+            return source[name]
+        if hasattr(source, name):
+            return getattr(source, name)
+    if default is _MISSING:
+        return None
+    return default
+
+
+def _list_field(source: object, *names: str) -> list[Any]:
+    value = _first_field(source, *names, default=[])
+    return _as_list(value)
+
+
+def _as_list(value: object) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, Mapping):
+        return list(value.values())
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return [value]
+
+
+def _str_field(source: object, *names: str, default: str | None = None) -> str | None:
+    value = _first_field(source, *names, default=default)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        value = str(value)
+    value = value.strip()
+    return value or None
+
+
+def _int_field(source: object, *names: str) -> int | None:
+    value = _first_field(source, *names, default=None)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdecimal():
+        return int(value)
+    return None
+
+
+def _sortable_datetime(value: object) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _stable_json(value: Mapping[str, Any]) -> str:
+    return json.dumps(value, default=str, ensure_ascii=True, separators=(",", ":"), sort_keys=True)

--- a/apps/backend/tests/test_sync_reconciliation.py
+++ b/apps/backend/tests/test_sync_reconciliation.py
@@ -1,0 +1,1280 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import asdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.config import ensure_data_dirs, get_settings
+from app.db import SessionLocal, reconfigure_engine, run_migrations
+from app.models import (
+    Artifact,
+    Project,
+    SyncDeleteTombstone,
+    SyncEntityRevision,
+    SyncLocalIdentity,
+    SyncTrustedPeer,
+)
+from app.services.sync_identity import source_hash_to_project_id
+from app.services.sync_reconciliation import (
+    ACTION_APPLY_DELETE_TOMBSTONE,
+    ACTION_FETCH_ARTIFACT_CONTENT,
+    ACTION_IMPORT_ARTIFACT_MANIFEST,
+    ACTION_IMPORT_ENTITY_REVISION,
+    ACTION_IMPORT_PROJECT_MANIFEST,
+    ACTION_NOOP,
+    ACTION_RECORD_CONFLICT,
+    ITEM_ARTIFACT,
+    ITEM_DELETE_TOMBSTONE,
+    ITEM_ENTITY_REVISION,
+    ITEM_PROJECT,
+    SyncReconciliationAction,
+    SyncReconciliationItem,
+    SyncReconciliationPlan,
+    plan_sync_reconciliation,
+)
+from app.services.sync_revisions import revision_payload_sha256
+
+
+@pytest.fixture()
+def db_session() -> Any:
+    settings = get_settings()
+    ensure_data_dirs(settings)
+    reconfigure_engine(settings)
+    run_migrations(settings)
+
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def test_artifact_classification_uses_verified_bytes_and_trusted_provider_choice(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    _add_identity_and_peers(db_session)
+    project = _add_project(db_session, "proj_local", source_sha256=_sha("source"))
+    identical_hash, identical_size = _write_file(tmp_path / "identical.wav", b"same bytes")
+    local_conflict_hash, _ = _write_file(tmp_path / "conflict.wav", b"local conflict")
+    missing_local_hash = _sha("missing local")
+    remote_hash = _sha("remote")
+    untrusted_hash = _sha("untrusted")
+    missing_provider_hash = _sha("missing provider")
+
+    _add_artifact(
+        db_session,
+        artifact_id="art_identical",
+        project_id=project.id,
+        path=tmp_path / "identical.wav",
+        content_sha256=identical_hash,
+        size_bytes=identical_size,
+    )
+    _add_artifact(
+        db_session,
+        artifact_id="art_missing_local_bytes",
+        project_id=project.id,
+        path=tmp_path / "missing.wav",
+        content_sha256=missing_local_hash,
+        size_bytes=32,
+    )
+    _add_artifact(
+        db_session,
+        artifact_id="art_conflict",
+        project_id=project.id,
+        path=tmp_path / "conflict.wav",
+        content_sha256=local_conflict_hash,
+        size_bytes=(tmp_path / "conflict.wav").stat().st_size,
+    )
+    db_session.commit()
+
+    request = {
+        "remote_library": {
+            "projects": [
+                {
+                    "project_id": project.id,
+                    "display_name": project.display_name,
+                    "source_sha256": project.source_sha256,
+                }
+            ],
+            "artifacts": [
+                _artifact_manifest(project.id, "art_identical", identical_hash, identical_size),
+                _artifact_manifest(project.id, "art_missing_local_bytes", missing_local_hash, 32),
+                _artifact_manifest(project.id, "art_remote_available", remote_hash, 64),
+                _artifact_manifest(project.id, "art_missing_provider", missing_provider_hash, 64),
+                _artifact_manifest(project.id, "art_conflict", _sha("remote conflict"), 64),
+                _artifact_manifest(project.id, "art_duplicate_content", identical_hash, identical_size),
+                _artifact_manifest(project.id, "art_untrusted_only", untrusted_hash, 64),
+            ],
+        },
+        "peer_inventory": [
+            {
+                "device_id": "peer-b",
+                "available_content_hashes": [missing_local_hash, remote_hash],
+            },
+            {
+                "device_id": "peer-a",
+                "available_content_hashes": [missing_local_hash, remote_hash],
+            },
+            {"device_id": "peer-revoked", "available_content_hashes": [untrusted_hash]},
+            {"device_id": "peer-untrusted", "available_content_hashes": [untrusted_hash]},
+        ],
+    }
+
+    plan = plan_sync_reconciliation(db_session, request)
+
+    assert _item(plan, ITEM_PROJECT, project.id).status == "noop"
+    assert _item(plan, ITEM_ARTIFACT, "art_identical").status == "identical_content"
+    missing_local = _item(plan, ITEM_ARTIFACT, "art_missing_local_bytes")
+    assert missing_local.status == "missing_local_bytes"
+    assert missing_local.chosen_provider_device_id == "peer-a"
+    remote_available = _item(plan, ITEM_ARTIFACT, "art_remote_available")
+    assert remote_available.status == "remote_available"
+    assert remote_available.chosen_provider_device_id == "peer-a"
+    assert _item(plan, ITEM_ARTIFACT, "art_missing_provider").status == "missing_provider"
+    assert _item(plan, ITEM_ARTIFACT, "art_untrusted_only").status == "missing_provider"
+    assert _item(plan, ITEM_ARTIFACT, "art_conflict").status == "conflicted"
+    duplicate = _item(plan, ITEM_ARTIFACT, "art_duplicate_content")
+    assert duplicate.status == "identical_content"
+    assert duplicate.action_type == ACTION_IMPORT_ARTIFACT_MANIFEST
+
+    fetch_actions = {
+        action.item_id: action
+        for action in plan.actions
+        if action.action_type == ACTION_FETCH_ARTIFACT_CONTENT
+    }
+    assert fetch_actions["art_missing_local_bytes"].provider_device_id == "peer-a"
+    assert fetch_actions["art_remote_available"].provider_device_id == "peer-a"
+    assert _action(plan, ACTION_RECORD_CONFLICT, ITEM_ARTIFACT, "art_conflict") is not None
+    assert _action(plan, ACTION_IMPORT_ARTIFACT_MANIFEST, ITEM_ARTIFACT, "art_duplicate_content") is not None
+
+
+def test_valid_tombstones_apply_first_and_untrusted_tombstones_are_noop(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    _add_identity_and_peers(db_session)
+    project = _add_project(db_session, "proj_tombstones", source_sha256=_sha("source"))
+    artifact_hash, artifact_size = _write_file(tmp_path / "deleted.wav", b"deleted bytes")
+    import_hash = _sha("import")
+    deleted_project_source = _sha("deleted project")
+    _add_artifact(
+        db_session,
+        artifact_id="art_deleted",
+        project_id=project.id,
+        path=tmp_path / "deleted.wav",
+        content_sha256=artifact_hash,
+        size_bytes=artifact_size,
+    )
+    db_session.commit()
+
+    valid_tombstone = _tombstone(
+        tombstone_id="tomb_art_deleted",
+        project_id=project.id,
+        target_type=ITEM_ARTIFACT,
+        target_id="art_deleted",
+        author_device_id="peer-a",
+    )
+    deleted_project_tombstone = _tombstone(
+        tombstone_id="tomb_project_deleted",
+        project_id="proj_deleted_remote",
+        target_type=ITEM_PROJECT,
+        target_id="proj_deleted_remote",
+        author_device_id="dev-local",
+    )
+    wrong_group_tombstone = _tombstone(
+        tombstone_id="tomb_wrong_group",
+        project_id=project.id,
+        target_type=ITEM_ARTIFACT,
+        target_id="art_wrong_group",
+        author_device_id="peer-a",
+        sync_group_id="other-group",
+    )
+    revoked_tombstone = _tombstone(
+        tombstone_id="tomb_revoked",
+        project_id=project.id,
+        target_type=ITEM_ARTIFACT,
+        target_id="art_revoked",
+        author_device_id="peer-revoked",
+    )
+    request = {
+        "remote_library": {
+            "projects": [
+                {"project_id": project.id, "source_sha256": project.source_sha256},
+                {"project_id": "proj_deleted_remote", "source_sha256": deleted_project_source},
+            ],
+            "artifacts": [
+                _artifact_manifest(project.id, "art_deleted", _sha("remote update"), artifact_size),
+                _artifact_manifest(project.id, "art_import", import_hash, 64),
+            ],
+            "delete_tombstones": [
+                valid_tombstone,
+                wrong_group_tombstone,
+                revoked_tombstone,
+                deleted_project_tombstone,
+            ],
+        },
+        "project_manifests": [
+            _project_manifest("proj_deleted_remote", deleted_project_source),
+        ],
+        "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [import_hash]}],
+    }
+
+    plan = plan_sync_reconciliation(db_session, request)
+
+    assert _item(plan, ITEM_ARTIFACT, "art_deleted").status == "deleted"
+    assert _item(plan, ITEM_PROJECT, "proj_deleted_remote").status == "deleted"
+    assert _item(plan, ITEM_DELETE_TOMBSTONE, "tomb_wrong_group").status == "noop"
+    assert _item(plan, ITEM_DELETE_TOMBSTONE, "tomb_wrong_group").action_type == ACTION_NOOP
+    assert _item(plan, ITEM_DELETE_TOMBSTONE, "tomb_revoked").status == "noop"
+    assert _action(plan, ACTION_IMPORT_PROJECT_MANIFEST, ITEM_PROJECT, "proj_deleted_remote") is None
+    assert all(
+        action.action_type == ACTION_APPLY_DELETE_TOMBSTONE
+        for action in plan.actions[:2]
+    )
+    assert _action(plan, ACTION_APPLY_DELETE_TOMBSTONE, ITEM_ARTIFACT, "art_wrong_group") is None
+    assert _action(plan, ACTION_APPLY_DELETE_TOMBSTONE, ITEM_ARTIFACT, "art_revoked") is None
+
+
+def test_entity_revision_ancestry_imports_descendants_and_conflicts_siblings(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    del tmp_path
+    _add_identity_and_peers(db_session)
+    project = _add_project(db_session, "proj_revisions", source_sha256=_sha("source"))
+    _add_revision(
+        db_session,
+        project_id=project.id,
+        revision_id="rev_base",
+        content_sha256=_sha("base"),
+        base_revision_id=None,
+    )
+    _add_revision(
+        db_session,
+        project_id=project.id,
+        revision_id="rev_existing",
+        content_sha256=_revision_payload_sha("rev_existing"),
+        base_revision_id="rev_base",
+    )
+    db_session.commit()
+
+    request = {
+        "remote_library": {
+            "projects": [{"project_id": project.id, "source_sha256": project.source_sha256}],
+            "entity_revisions": [
+                _revision_manifest(
+                    project.id,
+                    revision_id="rev_existing",
+                    content_sha256=_revision_payload_sha("rev_existing"),
+                    base_revision_id="rev_base",
+                ),
+                _revision_manifest(
+                    project.id,
+                    revision_id="rev_a_remote_grandchild",
+                    content_sha256=_revision_payload_sha("rev_a_remote_grandchild"),
+                    base_revision_id="rev_z_remote_descendant",
+                ),
+                _revision_manifest(
+                    project.id,
+                    revision_id="rev_z_remote_descendant",
+                    content_sha256=_revision_payload_sha("rev_z_remote_descendant"),
+                    base_revision_id="rev_existing",
+                ),
+                _revision_manifest(
+                    project.id,
+                    revision_id="rev_remote_sibling",
+                    content_sha256=_revision_payload_sha("rev_remote_sibling"),
+                    base_revision_id="rev_base",
+                ),
+            ],
+        }
+    }
+
+    plan = plan_sync_reconciliation(db_session, request)
+
+    assert _item(plan, ITEM_ENTITY_REVISION, "rev_existing").status == "identical_content"
+    descendant = _item(plan, ITEM_ENTITY_REVISION, "rev_z_remote_descendant")
+    assert descendant.status == "remote_available"
+    assert descendant.action_type == ACTION_IMPORT_ENTITY_REVISION
+    grandchild = _item(plan, ITEM_ENTITY_REVISION, "rev_a_remote_grandchild")
+    assert grandchild.status == "remote_available"
+    assert grandchild.action_type == ACTION_IMPORT_ENTITY_REVISION
+    sibling = _item(plan, ITEM_ENTITY_REVISION, "rev_remote_sibling")
+    assert sibling.status == "conflicted"
+    assert sibling.action_type == ACTION_RECORD_CONFLICT
+    import_revision_action_ids = [
+        action.item_id
+        for action in plan.actions
+        if action.action_type == ACTION_IMPORT_ENTITY_REVISION
+    ]
+    assert import_revision_action_ids.index("rev_z_remote_descendant") < import_revision_action_ids.index(
+        "rev_a_remote_grandchild"
+    )
+    assert _action(plan, ACTION_RECORD_CONFLICT, ITEM_ENTITY_REVISION, "rev_remote_sibling") is not None
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_reason"),
+    [
+        ("payload_hash_mismatch", "Entity revision manifest content_sha256 must match payload."),
+        ("unsafe_metadata", "Entity revision manifest metadata and payload must be sync-safe."),
+        ("unsafe_payload", "Entity revision manifest metadata and payload must be sync-safe."),
+    ],
+)
+def test_library_entity_revisions_reject_invalid_payload_contract(
+    db_session: Session,
+    case: str,
+    expected_reason: str,
+) -> None:
+    _add_identity_and_peers(db_session)
+    project = _add_project(db_session, "proj_library_revision_contract", source_sha256=_sha("library revisions"))
+    _add_revision(
+        db_session,
+        project_id=project.id,
+        revision_id="rev_base_library_contract",
+        content_sha256=_sha("library base"),
+        base_revision_id=None,
+    )
+    db_session.commit()
+    revision_id = f"rev_library_{case}"
+    revision = _revision_manifest(
+        project.id,
+        revision_id=revision_id,
+        content_sha256=_revision_payload_sha(revision_id),
+        base_revision_id="rev_base_library_contract",
+    )
+    if case == "payload_hash_mismatch":
+        revision["content_sha256"] = _sha("wrong library revision payload")
+    elif case == "unsafe_metadata":
+        revision["metadata"] = {"local_path": "/tmp/private.wav"}
+    elif case == "unsafe_payload":
+        revision["payload"] = {"revision_id": revision_id, "absolute_path": "/tmp/private.wav"}
+
+    request = {
+        "remote_library": {
+            "projects": [{"project_id": project.id, "source_sha256": project.source_sha256}],
+            "entity_revisions": [revision],
+        }
+    }
+
+    plan = plan_sync_reconciliation(db_session, request)
+
+    item = _item(plan, ITEM_ENTITY_REVISION, revision_id)
+    assert item.status == "conflicted"
+    assert item.reason == expected_reason
+    assert _action(plan, ACTION_IMPORT_ENTITY_REVISION, ITEM_ENTITY_REVISION, revision_id) is None
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_reason"),
+    [
+        ("wrong_base_entity", "Entity revision base_revision_id must reference the same project entity."),
+        ("missing_source_artifact", "Entity revision source_artifact_id does not exist in the manifest."),
+        ("foreign_source_artifact", "Entity revision source_artifact_id must belong to the manifest project."),
+    ],
+)
+def test_library_entity_revisions_reject_invalid_reference_contract(
+    db_session: Session,
+    tmp_path: Path,
+    case: str,
+    expected_reason: str,
+) -> None:
+    _add_identity_and_peers(db_session)
+    project = _add_project(db_session, "proj_library_reference_contract", source_sha256=_sha("library references"))
+    if case == "wrong_base_entity":
+        _add_revision(
+            db_session,
+            project_id=project.id,
+            revision_id="rev_wrong_base_library_contract",
+            content_sha256=_sha("library wrong base"),
+            base_revision_id=None,
+            entity_id="other_entity",
+        )
+    elif case == "foreign_source_artifact":
+        other_project = _add_project(
+            db_session,
+            "proj_library_reference_other",
+            source_sha256=_sha("library references other"),
+        )
+        artifact_hash, artifact_size = _write_file(tmp_path / "foreign-source.wav", b"foreign source")
+        _add_artifact(
+            db_session,
+            artifact_id="art_foreign_source",
+            project_id=other_project.id,
+            path=tmp_path / "foreign-source.wav",
+            content_sha256=artifact_hash,
+            size_bytes=artifact_size,
+            artifact_type="source_audio",
+        )
+    db_session.commit()
+
+    revision_id = f"rev_library_{case}"
+    revision = _revision_manifest(
+        project.id,
+        revision_id=revision_id,
+        content_sha256=_revision_payload_sha(revision_id),
+        base_revision_id="rev_wrong_base_library_contract" if case == "wrong_base_entity" else None,
+    )
+    if case == "missing_source_artifact":
+        revision["source_artifact_id"] = "art_missing_source"
+    elif case == "foreign_source_artifact":
+        revision["source_artifact_id"] = "art_foreign_source"
+
+    request = {
+        "remote_library": {
+            "projects": [{"project_id": project.id, "source_sha256": project.source_sha256}],
+            "entity_revisions": [revision],
+        }
+    }
+
+    plan = plan_sync_reconciliation(db_session, request)
+
+    item = _item(plan, ITEM_ENTITY_REVISION, revision_id)
+    assert item.status == "conflicted"
+    assert item.reason == expected_reason
+    assert _action(plan, ACTION_IMPORT_ENTITY_REVISION, ITEM_ENTITY_REVISION, revision_id) is None
+
+
+def test_missing_project_import_requires_manifest_and_source_availability(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    _add_identity_and_peers(db_session)
+    existing_project = _add_project(db_session, "proj_existing", source_sha256=_sha("existing source"))
+    duplicate_hash, duplicate_size = _write_file(tmp_path / "duplicate-source.wav", b"duplicate source")
+    remote_provider_hash = _sha("provider source")
+    missing_hash = _sha("missing source")
+    no_manifest_hash = _sha("no manifest")
+    no_manifest_artifact_hash = _sha("no manifest artifact")
+    duplicate_project_id = source_hash_to_project_id(duplicate_hash)
+    remote_provider_project_id = source_hash_to_project_id(remote_provider_hash)
+    missing_project_id = source_hash_to_project_id(missing_hash)
+    no_manifest_project_id = source_hash_to_project_id(no_manifest_hash)
+    _add_artifact(
+        db_session,
+        artifact_id="art_existing_source",
+        project_id=existing_project.id,
+        path=tmp_path / "duplicate-source.wav",
+        content_sha256=duplicate_hash,
+        size_bytes=duplicate_size,
+        artifact_type="source_audio",
+    )
+    db_session.commit()
+
+    request = {
+        "remote_library": {
+            "projects": [
+                {"project_id": duplicate_project_id, "source_sha256": duplicate_hash},
+                {"project_id": remote_provider_project_id, "source_sha256": remote_provider_hash},
+                {"project_id": missing_project_id, "source_sha256": missing_hash},
+                {"project_id": no_manifest_project_id, "source_sha256": no_manifest_hash},
+            ],
+            "artifacts": [
+                _artifact_manifest(no_manifest_project_id, "art_no_manifest", no_manifest_artifact_hash, 64),
+            ],
+        },
+        "project_manifests": [
+            _project_manifest(duplicate_project_id, duplicate_hash, source_size_bytes=duplicate_size),
+            _project_manifest(remote_provider_project_id, remote_provider_hash),
+            _project_manifest(missing_project_id, missing_hash),
+        ],
+        "peer_inventory": [
+            {"device_id": "peer-a", "available_content_hashes": [remote_provider_hash, no_manifest_artifact_hash]},
+        ],
+    }
+
+    plan = plan_sync_reconciliation(db_session, request)
+
+    duplicate_project = _item(plan, ITEM_PROJECT, duplicate_project_id)
+    assert duplicate_project.status == "identical_content"
+    assert duplicate_project.action_type == ACTION_IMPORT_PROJECT_MANIFEST
+    provider_project = _item(plan, ITEM_PROJECT, remote_provider_project_id)
+    assert provider_project.status == "remote_available"
+    assert provider_project.chosen_provider_device_id == "peer-a"
+    assert _item(plan, ITEM_PROJECT, missing_project_id).status == "missing_provider"
+    assert _item(plan, ITEM_PROJECT, no_manifest_project_id).status == "missing_provider"
+    assert _item(plan, ITEM_ARTIFACT, "art_no_manifest").status == "missing_provider"
+    assert _action(plan, ACTION_IMPORT_PROJECT_MANIFEST, ITEM_PROJECT, duplicate_project_id) is not None
+    assert (
+        _action(plan, ACTION_FETCH_ARTIFACT_CONTENT, ITEM_ARTIFACT, f"art_source_{remote_provider_project_id}")
+        is not None
+    )
+    assert _action(plan, ACTION_IMPORT_PROJECT_MANIFEST, ITEM_PROJECT, remote_provider_project_id) is not None
+    assert _action(plan, ACTION_FETCH_ARTIFACT_CONTENT, ITEM_ARTIFACT, "art_no_manifest") is None
+    assert _action(plan, ACTION_IMPORT_ARTIFACT_MANIFEST, ITEM_ARTIFACT, "art_no_manifest") is None
+
+
+def test_missing_project_import_requires_every_manifest_artifact_available(
+    db_session: Session,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash = _sha("atomic source")
+    stem_hash = _sha("atomic stem")
+    blocked_source_hash = _sha("blocked source")
+    blocked_stem_hash = _sha("blocked stem")
+    available_project_id = source_hash_to_project_id(source_hash)
+    blocked_project_id = source_hash_to_project_id(blocked_source_hash)
+
+    request = {
+        "remote_library": {
+            "projects": [
+                {"project_id": available_project_id, "source_sha256": source_hash},
+                {"project_id": blocked_project_id, "source_sha256": blocked_source_hash},
+            ]
+        },
+        "project_manifests": [
+            _project_manifest(
+                available_project_id,
+                source_hash,
+                extra_artifacts=[
+                    _artifact_manifest(available_project_id, "art_stem_available", stem_hash, 64),
+                ],
+                extra_revisions=[
+                    _revision_manifest(
+                        available_project_id,
+                        revision_id="rev_manifest_imported_with_project",
+                        content_sha256=_revision_payload_sha("rev_manifest_imported_with_project"),
+                        base_revision_id=None,
+                    ),
+                ],
+            ),
+            _project_manifest(
+                blocked_project_id,
+                blocked_source_hash,
+                extra_artifacts=[
+                    _artifact_manifest(blocked_project_id, "art_stem_blocked", blocked_stem_hash, 64),
+                ],
+            ),
+        ],
+        "peer_inventory": [
+            {
+                "device_id": "peer-a",
+                "available_content_hashes": [source_hash, stem_hash, blocked_source_hash],
+            },
+        ],
+    }
+
+    plan = plan_sync_reconciliation(db_session, request)
+
+    available_project = _item(plan, ITEM_PROJECT, available_project_id)
+    assert available_project.status == "remote_available"
+    assert _action(plan, ACTION_FETCH_ARTIFACT_CONTENT, ITEM_ARTIFACT, f"art_source_{available_project_id}") is not None
+    assert _action(plan, ACTION_FETCH_ARTIFACT_CONTENT, ITEM_ARTIFACT, "art_stem_available") is not None
+    assert _action(plan, ACTION_IMPORT_PROJECT_MANIFEST, ITEM_PROJECT, available_project_id) is not None
+    assert _action(plan, ACTION_IMPORT_ARTIFACT_MANIFEST, ITEM_ARTIFACT, "art_stem_available") is None
+    assert _action(
+        plan,
+        ACTION_IMPORT_ENTITY_REVISION,
+        ITEM_ENTITY_REVISION,
+        "rev_manifest_imported_with_project",
+    ) is None
+
+    blocked_project = _item(plan, ITEM_PROJECT, blocked_project_id)
+    assert blocked_project.status == "missing_provider"
+    assert blocked_project.details == {"artifact_ids": ["art_stem_blocked"]}
+    assert _action(plan, ACTION_IMPORT_PROJECT_MANIFEST, ITEM_PROJECT, blocked_project_id) is None
+    assert _action(plan, ACTION_FETCH_ARTIFACT_CONTENT, ITEM_ARTIFACT, f"art_source_{blocked_project_id}") is None
+    assert _action(plan, ACTION_IMPORT_ARTIFACT_MANIFEST, ITEM_ARTIFACT, "art_stem_blocked") is None
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_reason"),
+    [
+        ("missing_source", "Project manifest must contain exactly one source_audio artifact."),
+        ("ambiguous_source", "Project manifest must contain exactly one source_audio artifact."),
+        ("wrong_type", "Project manifest must contain exactly one source_audio artifact."),
+        ("non_wav_format", "Project manifest source_audio artifact format must be 'wav'."),
+        ("non_wav_relative_path", "Project manifest source_audio artifact relative_path must end with .wav."),
+        ("unsafe_relative_path", "Sync manifest artifact relative path is invalid."),
+        ("noncanonical_project_id", "Project manifest project_id must be derived from source_sha256."),
+    ],
+)
+def test_missing_project_manifest_source_artifact_must_match_import_contract(
+    db_session: Session,
+    case: str,
+    expected_reason: str,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash = _sha(f"{case} source")
+    project_id = "proj_noncanonical" if case == "noncanonical_project_id" else source_hash_to_project_id(source_hash)
+    manifest = _project_manifest(project_id, source_hash)
+    if case == "missing_source":
+        manifest["artifacts"] = []
+    elif case == "ambiguous_source":
+        manifest["artifacts"].append(
+            _artifact_manifest(
+                f"proj_{case}",
+                f"art_source_extra_{case}",
+                _sha(f"{case} extra"),
+                64,
+                artifact_type="source_audio",
+            )
+        )
+    elif case == "wrong_type":
+        manifest["artifacts"][0]["type"] = "source"
+    elif case == "non_wav_format":
+        manifest["artifacts"][0]["format"] = "mp3"
+    elif case == "non_wav_relative_path":
+        manifest["artifacts"][0]["relative_path"] = "source/input.mp3"
+    elif case == "unsafe_relative_path":
+        manifest["artifacts"][0]["relative_path"] = "../source/input.wav"
+
+    request = {
+        "remote_library": {
+            "projects": [{"project_id": project_id, "source_sha256": source_hash}],
+        },
+        "project_manifests": [manifest],
+        "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [source_hash]}],
+    }
+
+    plan = plan_sync_reconciliation(db_session, request)
+
+    item = _item(plan, ITEM_PROJECT, project_id)
+    assert item.status == "conflicted"
+    assert item.action_type == ACTION_RECORD_CONFLICT
+    assert item.reason == expected_reason
+    assert _action(plan, ACTION_IMPORT_PROJECT_MANIFEST, ITEM_PROJECT, project_id) is None
+    assert _action(plan, ACTION_RECORD_CONFLICT, ITEM_PROJECT, project_id) is not None
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_reason"),
+    [
+        ("project_mismatch", "Artifact manifest belongs to a different project."),
+        ("duplicate_id", "Project manifest contains duplicate artifact IDs."),
+        ("duplicate_path", "Project manifest contains duplicate artifact relative paths."),
+        ("unsafe_relative_path", "Sync manifest artifact relative path is invalid."),
+        ("invalid_content_sha256", "Artifact manifest content_sha256 must be a full SHA-256 hex digest."),
+        ("negative_size", "Artifact manifest size_bytes must be non-negative."),
+        ("non_object_metadata", "Artifact manifest metadata must be an object."),
+    ],
+)
+def test_missing_project_manifest_rejects_invalid_non_source_artifacts(
+    db_session: Session,
+    case: str,
+    expected_reason: str,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash = _sha(f"{case} non-source source")
+    stem_hash = _sha(f"{case} non-source stem")
+    project_id = source_hash_to_project_id(source_hash)
+    stem = _artifact_manifest(project_id, "art_invalid_non_source", stem_hash, 64)
+    manifest = _project_manifest(project_id, source_hash, extra_artifacts=[stem])
+    if case == "project_mismatch":
+        stem["project_id"] = "proj_other"
+    elif case == "duplicate_id":
+        stem["artifact_id"] = f"art_source_{project_id}"
+    elif case == "duplicate_path":
+        stem["relative_path"] = manifest["artifacts"][0]["relative_path"]
+    elif case == "unsafe_relative_path":
+        stem["relative_path"] = "../stems/unsafe.wav"
+    elif case == "invalid_content_sha256":
+        stem["content_sha256"] = "not-a-sha"
+    elif case == "negative_size":
+        stem["size_bytes"] = -1
+    elif case == "non_object_metadata":
+        stem["metadata"] = []
+
+    request = {
+        "remote_library": {
+            "projects": [{"project_id": project_id, "source_sha256": source_hash}],
+        },
+        "project_manifests": [manifest],
+        "peer_inventory": [
+            {"device_id": "peer-a", "available_content_hashes": [source_hash, stem_hash]},
+        ],
+    }
+
+    plan = plan_sync_reconciliation(db_session, request)
+
+    item = _item(plan, ITEM_PROJECT, project_id)
+    assert item.status == "conflicted"
+    assert item.reason == expected_reason
+    assert _action(plan, ACTION_IMPORT_PROJECT_MANIFEST, ITEM_PROJECT, project_id) is None
+    assert _action(plan, ACTION_FETCH_ARTIFACT_CONTENT, ITEM_ARTIFACT, "art_invalid_non_source") is None
+
+
+def test_missing_project_manifest_rejects_tombstoned_contained_targets(
+    db_session: Session,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash = _sha("tombstoned contained target source")
+    project_id = source_hash_to_project_id(source_hash)
+    db_session.add(
+        SyncDeleteTombstone(
+            id="tomb_contained_artifact",
+            sync_group_id="group-a",
+            project_id=project_id,
+            target_type=ITEM_ARTIFACT,
+            target_id=f"art_source_{project_id}",
+            author_device_id="dev-local",
+            deleted_at=datetime.now(UTC),
+            prior_metadata_json={},
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+    )
+    db_session.commit()
+
+    request = {
+        "remote_library": {
+            "projects": [{"project_id": project_id, "source_sha256": source_hash}],
+        },
+        "project_manifests": [_project_manifest(project_id, source_hash)],
+        "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [source_hash]}],
+    }
+
+    plan = plan_sync_reconciliation(db_session, request)
+
+    item = _item(plan, ITEM_PROJECT, project_id)
+    assert item.status == "conflicted"
+    assert item.reason == "Project manifest contains live targets covered by sync delete tombstones."
+    assert item.details == {"artifact_ids": [f"art_source_{project_id}"], "revision_ids": []}
+    assert _action(plan, ACTION_IMPORT_PROJECT_MANIFEST, ITEM_PROJECT, project_id) is None
+
+
+def test_missing_project_manifest_rejects_local_artifact_and_revision_id_conflicts(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    _add_identity_and_peers(db_session)
+    existing_project = _add_project(db_session, "proj_existing_conflict", source_sha256=_sha("existing"))
+    conflict_hash, conflict_size = _write_file(tmp_path / "conflict.wav", b"conflict artifact")
+    _add_artifact(
+        db_session,
+        artifact_id="art_conflicting_id",
+        project_id=existing_project.id,
+        path=tmp_path / "conflict.wav",
+        content_sha256=conflict_hash,
+        size_bytes=conflict_size,
+        artifact_type="source_audio",
+    )
+    _add_revision(
+        db_session,
+        project_id=existing_project.id,
+        revision_id="rev_conflicting_id",
+        content_sha256=_sha("existing revision"),
+        base_revision_id=None,
+    )
+    db_session.commit()
+
+    artifact_source_hash = _sha("artifact conflict source")
+    artifact_project_id = source_hash_to_project_id(artifact_source_hash)
+    artifact_conflict_manifest = _project_manifest(artifact_project_id, artifact_source_hash)
+    artifact_conflict_manifest["artifacts"][0]["artifact_id"] = "art_conflicting_id"
+    revision_source_hash = _sha("revision conflict source")
+    revision_project_id = source_hash_to_project_id(revision_source_hash)
+    revision_conflict_manifest = _project_manifest(
+        revision_project_id,
+        revision_source_hash,
+        extra_revisions=[
+            _revision_manifest(
+                revision_project_id,
+                revision_id="rev_conflicting_id",
+                content_sha256=_revision_payload_sha("rev_conflicting_id"),
+                base_revision_id=None,
+            ),
+        ],
+    )
+    request = {
+        "remote_library": {
+            "projects": [
+                {"project_id": artifact_project_id, "source_sha256": artifact_source_hash},
+                {"project_id": revision_project_id, "source_sha256": revision_source_hash},
+            ],
+        },
+        "project_manifests": [artifact_conflict_manifest, revision_conflict_manifest],
+        "peer_inventory": [
+            {
+                "device_id": "peer-a",
+                "available_content_hashes": [artifact_source_hash, revision_source_hash],
+            }
+        ],
+    }
+
+    plan = plan_sync_reconciliation(db_session, request)
+
+    artifact_item = _item(plan, ITEM_PROJECT, artifact_project_id)
+    assert artifact_item.status == "conflicted"
+    assert artifact_item.reason == "A synced artifact conflicts with an existing local artifact."
+    assert artifact_item.details == {"artifact_ids": ["art_conflicting_id"]}
+    revision_item = _item(plan, ITEM_PROJECT, revision_project_id)
+    assert revision_item.status == "conflicted"
+    assert revision_item.reason == "A synced entity revision conflicts with an existing local revision."
+    assert revision_item.details == {"revision_ids": ["rev_conflicting_id"]}
+    assert _action(plan, ACTION_IMPORT_PROJECT_MANIFEST, ITEM_PROJECT, artifact_project_id) is None
+    assert _action(plan, ACTION_IMPORT_PROJECT_MANIFEST, ITEM_PROJECT, revision_project_id) is None
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_reason"),
+    [
+        ("missing_base", "Entity revision base_revision_id does not exist in the manifest."),
+        ("wrong_base_entity", "Entity revision base_revision_id must reference the same project entity."),
+        ("missing_source_artifact", "Entity revision source_artifact_id does not exist in the manifest."),
+        ("cycle", "Entity revision base_revision_id contains a cycle."),
+    ],
+)
+def test_missing_project_manifest_rejects_invalid_embedded_entity_revisions(
+    db_session: Session,
+    case: str,
+    expected_reason: str,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash = _sha(f"{case} revision source")
+    project_id = source_hash_to_project_id(source_hash)
+    if case == "missing_base":
+        revisions = [
+            _revision_manifest(
+                project_id,
+                revision_id="rev_missing_base",
+                content_sha256=_revision_payload_sha("rev_missing_base"),
+                base_revision_id="rev_does_not_exist",
+            )
+        ]
+    elif case == "wrong_base_entity":
+        revisions = [
+            _revision_manifest(
+                project_id,
+                revision_id="rev_wrong_base",
+                content_sha256=_revision_payload_sha("rev_wrong_base"),
+                base_revision_id=None,
+            ),
+            {
+                **_revision_manifest(
+                    project_id,
+                    revision_id="rev_wrong_child",
+                    content_sha256=_revision_payload_sha("rev_wrong_child"),
+                    base_revision_id="rev_wrong_base",
+                ),
+                "entity_id": "other_entity",
+            },
+        ]
+    elif case == "missing_source_artifact":
+        revisions = [
+            {
+                **_revision_manifest(
+                    project_id,
+                    revision_id="rev_missing_source_artifact",
+                    content_sha256=_revision_payload_sha("rev_missing_source_artifact"),
+                    base_revision_id=None,
+                ),
+                "source_artifact_id": "art_missing",
+            }
+        ]
+    else:
+        revisions = [
+            _revision_manifest(
+                project_id,
+                revision_id="rev_cycle_a",
+                content_sha256=_revision_payload_sha("rev_cycle_a"),
+                base_revision_id="rev_cycle_b",
+            ),
+            _revision_manifest(
+                project_id,
+                revision_id="rev_cycle_b",
+                content_sha256=_revision_payload_sha("rev_cycle_b"),
+                base_revision_id="rev_cycle_a",
+            ),
+        ]
+    request = {
+        "remote_library": {
+            "projects": [{"project_id": project_id, "source_sha256": source_hash}],
+        },
+        "project_manifests": [
+            _project_manifest(project_id, source_hash, extra_revisions=revisions),
+        ],
+        "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [source_hash]}],
+    }
+
+    plan = plan_sync_reconciliation(db_session, request)
+
+    item = _item(plan, ITEM_PROJECT, project_id)
+    assert item.status == "conflicted"
+    assert item.reason == expected_reason
+    assert _action(plan, ACTION_IMPORT_PROJECT_MANIFEST, ITEM_PROJECT, project_id) is None
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_reason"),
+    [
+        ("payload_hash_mismatch", "Entity revision manifest content_sha256 must match payload."),
+        ("unsafe_metadata", "Entity revision manifest metadata and payload must be sync-safe."),
+        ("unsafe_payload", "Entity revision manifest metadata and payload must be sync-safe."),
+    ],
+)
+def test_missing_project_manifest_rejects_invalid_revision_payload_contract(
+    db_session: Session,
+    case: str,
+    expected_reason: str,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash = _sha(f"{case} source")
+    project_id = source_hash_to_project_id(source_hash)
+    revision_id = f"rev_{case}"
+    revision = _revision_manifest(
+        project_id,
+        revision_id=revision_id,
+        content_sha256=_revision_payload_sha(revision_id),
+        base_revision_id=None,
+    )
+    if case == "payload_hash_mismatch":
+        revision["content_sha256"] = _sha("wrong revision payload")
+    elif case == "unsafe_metadata":
+        revision["metadata"] = {"local_path": "/tmp/private.wav"}
+    elif case == "unsafe_payload":
+        revision["payload"] = {"revision_id": revision_id, "absolute_path": "/tmp/private.wav"}
+
+    request = {
+        "remote_library": {
+            "projects": [{"project_id": project_id, "source_sha256": source_hash}],
+        },
+        "project_manifests": [
+            _project_manifest(project_id, source_hash, extra_revisions=[revision]),
+        ],
+        "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [source_hash]}],
+    }
+
+    plan = plan_sync_reconciliation(db_session, request)
+
+    item = _item(plan, ITEM_PROJECT, project_id)
+    assert item.status == "conflicted"
+    assert item.reason == expected_reason
+    assert _action(plan, ACTION_IMPORT_PROJECT_MANIFEST, ITEM_PROJECT, project_id) is None
+
+
+def test_repeated_planning_is_idempotent_and_does_not_write_identity_or_rows(
+    db_session: Session,
+) -> None:
+    before_counts = _table_counts(db_session)
+    request = {
+        "remote_library": {
+            "delete_tombstones": [
+                _tombstone(
+                    tombstone_id="tomb_without_identity",
+                    project_id="proj_missing",
+                    target_type=ITEM_PROJECT,
+                    target_id="proj_missing",
+                    author_device_id="peer-a",
+                )
+            ]
+        }
+    }
+
+    first = plan_sync_reconciliation(db_session, request)
+    second = plan_sync_reconciliation(db_session, request)
+
+    assert asdict(first) == asdict(second)
+    assert _item(first, ITEM_DELETE_TOMBSTONE, "tomb_without_identity").status == "noop"
+    assert _table_counts(db_session) == before_counts
+    assert db_session.scalar(select(func.count()).select_from(SyncLocalIdentity)) == 0
+    assert list(db_session.new) == []
+    assert list(db_session.dirty) == []
+    assert list(db_session.deleted) == []
+
+
+def _add_identity_and_peers(session: Session) -> None:
+    now = datetime.now(UTC)
+    session.add(
+        SyncLocalIdentity(
+            id="local",
+            sync_group_id="group-a",
+            device_id="dev-local",
+            display_name="Local",
+            public_key="pub-local",
+            private_key="priv-local",
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    session.add_all(
+        [
+            SyncTrustedPeer(
+                device_id="peer-b",
+                sync_group_id="group-a",
+                display_name="Peer B",
+                public_key="pub-peer-b",
+                endpoint_hints_json=[],
+                trusted_at=now,
+                revoked_at=None,
+                created_at=now,
+                updated_at=now,
+            ),
+            SyncTrustedPeer(
+                device_id="peer-a",
+                sync_group_id="group-a",
+                display_name="Peer A",
+                public_key="pub-peer-a",
+                endpoint_hints_json=[],
+                trusted_at=now,
+                revoked_at=None,
+                created_at=now,
+                updated_at=now,
+            ),
+            SyncTrustedPeer(
+                device_id="peer-revoked",
+                sync_group_id="group-a",
+                display_name="Peer Revoked",
+                public_key="pub-peer-revoked",
+                endpoint_hints_json=[],
+                trusted_at=now,
+                revoked_at=now,
+                created_at=now,
+                updated_at=now,
+            ),
+            SyncTrustedPeer(
+                device_id="peer-other-group",
+                sync_group_id="other-group",
+                display_name="Peer Other",
+                public_key="pub-peer-other",
+                endpoint_hints_json=[],
+                trusted_at=now,
+                revoked_at=None,
+                created_at=now,
+                updated_at=now,
+            ),
+        ]
+    )
+    session.flush()
+
+
+def _add_project(session: Session, project_id: str, *, source_sha256: str) -> Project:
+    project = Project(
+        id=project_id,
+        display_name=project_id,
+        source_sha256=source_sha256,
+        source_path=f"/tmp/{project_id}.wav",
+        imported_path=f"/tmp/{project_id}.wav",
+    )
+    session.add(project)
+    session.flush()
+    return project
+
+
+def _add_artifact(
+    session: Session,
+    *,
+    artifact_id: str,
+    project_id: str,
+    path: Path,
+    content_sha256: str,
+    size_bytes: int,
+    artifact_type: str = "stem",
+) -> Artifact:
+    artifact = Artifact(
+        id=artifact_id,
+        project_id=project_id,
+        type=artifact_type,
+        format="wav",
+        path=str(path),
+        content_sha256=content_sha256,
+        size_bytes=size_bytes,
+        generated_by="test",
+        can_delete=True,
+        can_regenerate=False,
+        metadata_json={},
+    )
+    session.add(artifact)
+    session.flush()
+    return artifact
+
+
+def _add_revision(
+    session: Session,
+    *,
+    project_id: str,
+    revision_id: str,
+    content_sha256: str,
+    base_revision_id: str | None,
+    entity_id: str | None = None,
+    source_artifact_id: str | None = None,
+) -> SyncEntityRevision:
+    now = datetime.now(UTC)
+    revision = SyncEntityRevision(
+        id=revision_id,
+        project_id=project_id,
+        entity_type="chords",
+        entity_id=entity_id or project_id,
+        revision_type="manual",
+        base_revision_id=base_revision_id,
+        source_artifact_id=source_artifact_id,
+        content_sha256=content_sha256,
+        author_device_id="dev-local",
+        state="current",
+        metadata_json={},
+        payload_json={"revision_id": revision_id},
+        created_at=now,
+        updated_at=now,
+    )
+    session.add(revision)
+    session.flush()
+    return revision
+
+
+def _artifact_manifest(
+    project_id: str,
+    artifact_id: str,
+    content_sha256: str,
+    size_bytes: int,
+    *,
+    artifact_type: str = "stem",
+) -> dict[str, Any]:
+    return {
+        "artifact_id": artifact_id,
+        "project_id": project_id,
+        "type": artifact_type,
+        "format": "wav",
+        "relative_path": f"stems/{artifact_id}.wav",
+        "content_sha256": content_sha256,
+        "size_bytes": size_bytes,
+        "generated_by": "test",
+        "can_delete": True,
+        "can_regenerate": False,
+        "cache_key": None,
+        "metadata": {},
+        "created_at": datetime.now(UTC),
+    }
+
+
+def _project_manifest(
+    project_id: str,
+    source_sha256: str,
+    *,
+    source_size_bytes: int = 64,
+    extra_artifacts: list[dict[str, Any]] | None = None,
+    extra_revisions: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    now = datetime.now(UTC)
+    source_artifact_id = f"art_source_{project_id}"
+    return {
+        "schema_version": "1",
+        "exported_at": now,
+        "project": {
+            "project_id": project_id,
+            "display_name": project_id,
+            "source_key_override": None,
+            "source_sha256": source_sha256,
+            "duration_seconds": None,
+            "sample_rate": None,
+            "channels": None,
+            "created_at": now,
+            "updated_at": now,
+        },
+        "artifacts": [
+            _artifact_manifest(
+                project_id,
+                source_artifact_id,
+                source_sha256,
+                source_size_bytes,
+                artifact_type="source_audio",
+            )
+        ]
+        + (extra_artifacts or []),
+        "entity_revisions": extra_revisions or [],
+        "delete_tombstones": [],
+    }
+
+
+def _revision_manifest(
+    project_id: str,
+    *,
+    revision_id: str,
+    content_sha256: str,
+    base_revision_id: str | None,
+) -> dict[str, Any]:
+    now = datetime.now(UTC)
+    return {
+        "revision_id": revision_id,
+        "project_id": project_id,
+        "entity_type": "chords",
+        "entity_id": project_id,
+        "revision_type": "manual",
+        "base_revision_id": base_revision_id,
+        "author_device_id": "peer-a",
+        "source_artifact_id": None,
+        "content_sha256": content_sha256,
+        "state": "current",
+        "metadata": {},
+        "payload": {"revision_id": revision_id},
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
+def _tombstone(
+    *,
+    tombstone_id: str,
+    project_id: str,
+    target_type: str,
+    target_id: str,
+    author_device_id: str,
+    sync_group_id: str = "group-a",
+) -> dict[str, Any]:
+    now = datetime.now(UTC)
+    return {
+        "tombstone_id": tombstone_id,
+        "sync_group_id": sync_group_id,
+        "project_id": project_id,
+        "target_type": target_type,
+        "target_id": target_id,
+        "author_device_id": author_device_id,
+        "deleted_at": now,
+        "prior_metadata": {},
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
+def _write_file(path: Path, contents: bytes) -> tuple[str, int]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(contents)
+    return hashlib.sha256(contents).hexdigest(), len(contents)
+
+
+def _sha(seed: str) -> str:
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()
+
+
+def _revision_payload_sha(revision_id: str) -> str:
+    return revision_payload_sha256({"revision_id": revision_id})
+
+
+def _item(plan: SyncReconciliationPlan, item_type: str, item_id: str) -> SyncReconciliationItem:
+    for item in plan.items:
+        if item.item_type == item_type and item.item_id == item_id:
+            return item
+    raise AssertionError(f"Missing reconciliation item: {item_type}:{item_id}")
+
+
+def _action(
+    plan: SyncReconciliationPlan,
+    action_type: str,
+    item_type: str,
+    item_id: str,
+) -> SyncReconciliationAction | None:
+    for action in plan.actions:
+        if action.action_type == action_type and action.item_type == item_type and action.item_id == item_id:
+            return action
+    return None
+
+
+def _table_counts(session: Session) -> dict[str, int]:
+    models = (
+        Artifact,
+        Project,
+        SyncDeleteTombstone,
+        SyncEntityRevision,
+        SyncLocalIdentity,
+        SyncTrustedPeer,
+    )
+    return {
+        model.__tablename__: int(session.scalar(select(func.count()).select_from(model)) or 0)
+        for model in models
+    }

--- a/apps/backend/tests/test_sync_reconciliation_api.py
+++ b/apps/backend/tests/test_sync_reconciliation_api.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.routes import sync as sync_routes
+from app.db import SessionLocal
+from app.models import Project
+from app.services.sync_revisions import revision_payload_sha256
+
+
+def test_sync_reconciliation_plan_api_returns_service_plan(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    content_sha256 = "a" * 64
+    captured: dict[str, Any] = {}
+
+    def fake_plan_sync_reconciliation(session: Any, payload: Any) -> dict[str, Any]:
+        captured["session"] = session
+        captured["payload"] = payload
+        return {
+            "summary": {
+                "total_items": 2,
+                "total_actions": 2,
+                "total_conflicts": 1,
+                "status_counts": {
+                    "remote_available": 1,
+                    "conflicted": 1,
+                },
+            },
+            "items": [
+                {
+                    "item_type": "project",
+                    "item_id": "proj_remote",
+                    "project_id": "proj_remote",
+                    "status": "remote_available",
+                    "action_type": "import_project_manifest",
+                    "content_sha256": content_sha256,
+                    "chosen_provider_device_id": "device-peer",
+                    "reason": "Remote project is not present locally.",
+                    "details": {"manifest_index": 0},
+                },
+                {
+                    "item_type": "entity_revision",
+                    "item_id": "rev_conflict",
+                    "project_id": "proj_remote",
+                    "status": "conflicted",
+                    "action_type": "record_conflict",
+                    "content_sha256": "b" * 64,
+                    "chosen_provider_device_id": None,
+                    "reason": "Both peers edited the same entity.",
+                    "details": {"local_revision_id": "rev_local"},
+                },
+            ],
+            "actions": [
+                {
+                    "action_type": "import_project_manifest",
+                    "item_type": "project",
+                    "item_id": "proj_remote",
+                    "project_id": "proj_remote",
+                    "content_sha256": content_sha256,
+                    "provider_device_id": "device-peer",
+                    "reason": "Import the remote project manifest.",
+                    "priority": 10,
+                    "details": {"manifest_index": 0},
+                },
+                {
+                    "action_type": "record_conflict",
+                    "item_type": "entity_revision",
+                    "item_id": "rev_conflict",
+                    "project_id": "proj_remote",
+                    "content_sha256": "b" * 64,
+                    "provider_device_id": None,
+                    "reason": "Surface a user-resolvable conflict.",
+                    "priority": 20,
+                    "details": {"local_revision_id": "rev_local"},
+                },
+            ],
+        }
+
+    monkeypatch.setattr(sync_routes, "plan_sync_reconciliation", fake_plan_sync_reconciliation)
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/plan",
+        json={
+            "remote_library": _metadata_payload(content_sha256),
+            "project_manifests": [_project_manifest_payload(content_sha256)],
+            "peer_inventory": [
+                {
+                    "device_id": "device-peer",
+                    "available_content_sha256": [content_sha256],
+                    "metadata": {"display_name": "Studio Laptop"},
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"] == {
+        "total_items": 2,
+        "total_actions": 2,
+        "total_conflicts": 1,
+        "status_counts": {
+            "remote_available": 1,
+            "conflicted": 1,
+        },
+    }
+    assert payload["items"][0] == {
+        "item_type": "project",
+        "item_id": "proj_remote",
+        "project_id": "proj_remote",
+        "status": "remote_available",
+        "action_type": "import_project_manifest",
+        "content_sha256": content_sha256,
+        "chosen_provider_device_id": "device-peer",
+        "reason": "Remote project is not present locally.",
+        "details": {"manifest_index": 0},
+    }
+    assert payload["actions"][0] == {
+        "action_type": "import_project_manifest",
+        "item_type": "project",
+        "item_id": "proj_remote",
+        "project_id": "proj_remote",
+        "content_sha256": content_sha256,
+        "provider_device_id": "device-peer",
+        "reason": "Import the remote project manifest.",
+        "priority": 10,
+        "details": {"manifest_index": 0},
+    }
+
+    captured_payload = captured["payload"]
+    assert captured["session"] is not None
+    assert captured_payload.remote_library.projects[0].project_id == "proj_remote"
+    assert captured_payload.remote_library.delete_tombstones == []
+    assert captured_payload.project_manifests[0].project.project_id == "proj_remote"
+    assert captured_payload.peer_inventory[0].device_id == "device-peer"
+    assert captured_payload.peer_inventory[0].available_content_sha256 == [content_sha256]
+    assert captured_payload.peer_inventory[0].metadata == {"display_name": "Studio Laptop"}
+
+
+def test_sync_reconciliation_plan_request_defaults_project_manifests_and_peer_metadata(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_plan_sync_reconciliation(session: Any, payload: Any) -> dict[str, Any]:
+        captured["payload"] = payload
+        return _empty_plan()
+
+    monkeypatch.setattr(sync_routes, "plan_sync_reconciliation", fake_plan_sync_reconciliation)
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/plan",
+        json={
+            "remote_library": {
+                "projects": [],
+                "artifacts": [],
+            },
+            "peer_inventory": [
+                {
+                    "device_id": "device-empty",
+                    "available_content_sha256": [],
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == _empty_plan()
+    captured_payload = captured["payload"]
+    assert captured_payload.remote_library.delete_tombstones == []
+    assert captured_payload.project_manifests == []
+    assert captured_payload.peer_inventory[0].metadata == {}
+
+
+def test_sync_reconciliation_plan_requires_peer_inventory_content_list(
+    client: TestClient,
+) -> None:
+    response = client.post(
+        "/api/v1/sync/reconciliation/plan",
+        json={
+            "remote_library": {
+                "projects": [],
+                "artifacts": [],
+            },
+            "peer_inventory": [
+                {
+                    "device_id": "device-missing-content-list",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_sync_reconciliation_plan_api_accepts_library_entity_revisions(
+    client: TestClient,
+) -> None:
+    with SessionLocal() as session:
+        session.add(
+            Project(
+                id="proj_api",
+                display_name="API Project",
+                source_sha256="d" * 64,
+                source_path="/tmp/proj_api.wav",
+                imported_path="/tmp/proj_api.wav",
+            )
+        )
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/plan",
+        json={
+            "remote_library": {
+                "projects": [],
+                "artifacts": [],
+                "entity_revisions": [_revision_payload("rev_api_remote")],
+            },
+            "peer_inventory": [],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["items"] == [
+        {
+            "item_type": "entity_revision",
+            "item_id": "rev_api_remote",
+            "project_id": "proj_api",
+            "status": "remote_available",
+            "action_type": "import_entity_revision",
+            "content_sha256": revision_payload_sha256({"timeline": []}),
+            "chosen_provider_device_id": None,
+            "reason": "Remote entity revision can be imported.",
+            "details": {"base_revision_id": None},
+        }
+    ]
+    assert payload["actions"][0]["action_type"] == "import_entity_revision"
+    assert payload["actions"][0]["item_id"] == "rev_api_remote"
+
+
+def _empty_plan() -> dict[str, Any]:
+    return {
+        "summary": {
+            "total_items": 0,
+            "total_actions": 0,
+            "total_conflicts": 0,
+            "status_counts": {},
+        },
+        "items": [],
+        "actions": [],
+    }
+
+
+def _revision_payload(revision_id: str) -> dict[str, Any]:
+    timestamp = _timestamp()
+    return {
+        "revision_id": revision_id,
+        "project_id": "proj_api",
+        "entity_type": "chords",
+        "entity_id": "proj_api",
+        "revision_type": "manual",
+        "base_revision_id": None,
+        "author_device_id": "device-peer",
+        "source_artifact_id": None,
+        "content_sha256": revision_payload_sha256({"timeline": []}),
+        "state": "active",
+        "metadata": {},
+        "payload": {"timeline": []},
+        "created_at": timestamp,
+        "updated_at": timestamp,
+    }
+
+
+def _metadata_payload(content_sha256: str) -> dict[str, Any]:
+    timestamp = _timestamp()
+    return {
+        "projects": [
+            {
+                "project_id": "proj_remote",
+                "display_name": "Remote Project",
+                "source_key_override": None,
+                "source_sha256": content_sha256,
+                "duration_seconds": 1.0,
+                "sample_rate": 44100,
+                "channels": 2,
+                "created_at": timestamp,
+                "updated_at": timestamp,
+            }
+        ],
+        "artifacts": [
+            {
+                "artifact_id": "art_source",
+                "project_id": "proj_remote",
+                "type": "source",
+                "format": "wav",
+                "relative_path": "source/input.wav",
+                "content_sha256": content_sha256,
+                "size_bytes": 12,
+                "generated_by": "import",
+                "can_delete": False,
+                "can_regenerate": False,
+                "cache_key": None,
+                "metadata": {},
+                "created_at": timestamp,
+            }
+        ],
+    }
+
+
+def _project_manifest_payload(content_sha256: str) -> dict[str, Any]:
+    timestamp = _timestamp()
+    return {
+        "schema_version": "1",
+        "exported_at": timestamp,
+        "project": {
+            "project_id": "proj_remote",
+            "display_name": "Remote Project",
+            "source_key_override": None,
+            "source_sha256": content_sha256,
+            "duration_seconds": 1.0,
+            "sample_rate": 44100,
+            "channels": 2,
+            "created_at": timestamp,
+            "updated_at": timestamp,
+        },
+        "artifacts": [
+            {
+                "artifact_id": "art_source",
+                "project_id": "proj_remote",
+                "type": "source",
+                "format": "wav",
+                "relative_path": "source/input.wav",
+                "content_sha256": content_sha256,
+                "size_bytes": 12,
+                "generated_by": "import",
+                "can_delete": False,
+                "can_regenerate": False,
+                "cache_key": None,
+                "metadata": {},
+                "created_at": timestamp,
+            }
+        ],
+    }
+
+
+def _timestamp() -> str:
+    return datetime(2026, 5, 18, 12, 0, tzinfo=UTC).isoformat()

--- a/docs/API.md
+++ b/docs/API.md
@@ -301,6 +301,36 @@ Delete tombstone fields:
 
 `relative_path` is project-root relative when the artifact is stored under the backend-managed project root; otherwise it is `null`. Operational `source_audio` artifacts are app-managed WAV files under the project root. Artifact metadata is sanitized recursively before returning and removes local path-bearing keys such as `source_path`, `original_copy_path`, `playback_path`, `imported_path`, and any metadata key ending in `_path`. Non-path metadata such as retune/transpose settings, `stem_model`, and `source_artifact_id` is preserved. Job internals such as `result_artifact_ids_json` are not exposed.
 
+### Plan sync reconciliation
+
+`POST /api/v1/sync/reconciliation/plan`
+
+Returns a stateless sync plan comparing the local library with metadata supplied by the native sync layer. The
+endpoint reads local state but does not write projects, artifacts, revisions, tombstones, staged files, jobs, or
+conflict records. Clients execute returned actions through the existing import, staging, and future sync flows.
+
+Request fields:
+
+- `remote_library` - sync metadata in the same shape returned by `GET /api/v1/sync/metadata`, plus optional
+  `entity_revisions`: `projects`, `artifacts`, `entity_revisions`, and optional `delete_tombstones`.
+- `project_manifests` - optional list of exported project manifests, default `[]`.
+- `peer_inventory` - peer entries with `device_id`, `available_content_sha256`, and optional small `metadata`.
+
+Response fields:
+
+- `summary` - `total_items`, `total_actions`, `total_conflicts`, and `status_counts`.
+- `items` - per-project, artifact, revision, or tombstone decisions with `item_type`, `item_id`, optional
+  `project_id`, `status`, optional `action_type`, optional `content_sha256`, optional
+  `chosen_provider_device_id`, optional `reason`, and `details`.
+- `actions` - ordered operations with `action_type`, `item_type`, `item_id`, optional `project_id`, optional
+  `content_sha256`, optional `provider_device_id`, optional `reason`, `priority`, and `details`.
+
+Planner statuses are `noop`, `identical_content`, `missing_local_bytes`, `remote_available`,
+`missing_provider`, `deleted`, and `conflicted`.
+
+Action types are `apply_delete_tombstone`, `import_project_manifest`, `import_entity_revision`,
+`fetch_artifact_content`, `import_artifact_manifest`, `record_conflict`, and `noop`.
+
 ### Export project sync manifest
 
 `GET /api/v1/sync/projects/{project_id}/manifest`

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -468,6 +468,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/sync/reconciliation/plan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Sync Reconciliation Plan */
+        post: operations["sync_reconciliation_plan_api_v1_sync_reconciliation_plan_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/sync/identity": {
         parameters: {
             query?: never;
@@ -1415,6 +1432,17 @@ export interface components {
             /** Signature */
             signature: string;
         };
+        /** SyncPeerInventoryEntrySchema */
+        SyncPeerInventoryEntrySchema: {
+            /** Device Id */
+            device_id: string;
+            /** Available Content Sha256 */
+            available_content_sha256: string[];
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            };
+        };
         /** SyncPreflightDuplicateGroupSchema */
         SyncPreflightDuplicateGroupSchema: {
             /** Source Sha256 */
@@ -1612,6 +1640,98 @@ export interface components {
             staging_root?: string | null;
             /** Use Content Addressed Staging */
             use_content_addressed_staging?: boolean | null;
+        };
+        /** SyncReconciliationActionSchema */
+        SyncReconciliationActionSchema: {
+            /**
+             * Action Type
+             * @enum {string}
+             */
+            action_type: "apply_delete_tombstone" | "import_project_manifest" | "import_entity_revision" | "fetch_artifact_content" | "import_artifact_manifest" | "record_conflict" | "noop";
+            /** Item Type */
+            item_type: string;
+            /** Item Id */
+            item_id: string;
+            /** Project Id */
+            project_id?: string | null;
+            /** Content Sha256 */
+            content_sha256?: string | null;
+            /** Provider Device Id */
+            provider_device_id?: string | null;
+            /** Reason */
+            reason?: string | null;
+            /** Priority */
+            priority: number;
+            /** Details */
+            details?: {
+                [key: string]: unknown;
+            };
+        };
+        /** SyncReconciliationItemSchema */
+        SyncReconciliationItemSchema: {
+            /** Item Type */
+            item_type: string;
+            /** Item Id */
+            item_id: string;
+            /** Project Id */
+            project_id?: string | null;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "noop" | "identical_content" | "missing_local_bytes" | "remote_available" | "missing_provider" | "deleted" | "conflicted";
+            /** Action Type */
+            action_type?: ("apply_delete_tombstone" | "import_project_manifest" | "import_entity_revision" | "fetch_artifact_content" | "import_artifact_manifest" | "record_conflict" | "noop") | null;
+            /** Content Sha256 */
+            content_sha256?: string | null;
+            /** Chosen Provider Device Id */
+            chosen_provider_device_id?: string | null;
+            /** Reason */
+            reason?: string | null;
+            /** Details */
+            details?: {
+                [key: string]: unknown;
+            };
+        };
+        /** SyncReconciliationPlanRequest */
+        SyncReconciliationPlanRequest: {
+            remote_library: components["schemas"]["SyncReconciliationRemoteLibrarySchema"];
+            /** Project Manifests */
+            project_manifests?: components["schemas"]["SyncProjectManifestSchema"][];
+            /** Peer Inventory */
+            peer_inventory: components["schemas"]["SyncPeerInventoryEntrySchema"][];
+        };
+        /** SyncReconciliationPlanResponse */
+        SyncReconciliationPlanResponse: {
+            summary: components["schemas"]["SyncReconciliationSummarySchema"];
+            /** Items */
+            items: components["schemas"]["SyncReconciliationItemSchema"][];
+            /** Actions */
+            actions: components["schemas"]["SyncReconciliationActionSchema"][];
+        };
+        /** SyncReconciliationRemoteLibrarySchema */
+        SyncReconciliationRemoteLibrarySchema: {
+            /** Projects */
+            projects: components["schemas"]["SyncMetadataProjectSchema"][];
+            /** Artifacts */
+            artifacts: components["schemas"]["SyncMetadataArtifactSchema"][];
+            /** Entity Revisions */
+            entity_revisions?: components["schemas"]["SyncProjectManifestEntityRevisionSchema"][];
+            /** Delete Tombstones */
+            delete_tombstones?: components["schemas"]["SyncDeleteTombstoneSchema"][];
+        };
+        /** SyncReconciliationSummarySchema */
+        SyncReconciliationSummarySchema: {
+            /** Total Items */
+            total_items: number;
+            /** Total Actions */
+            total_actions: number;
+            /** Total Conflicts */
+            total_conflicts: number;
+            /** Status Counts */
+            status_counts?: {
+                [key: string]: number;
+            };
         };
         /** SyncStagedArtifactSchema */
         SyncStagedArtifactSchema: {
@@ -2807,6 +2927,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SyncMetadataResponse"];
+                };
+            };
+        };
+    };
+    sync_reconciliation_plan_api_v1_sync_reconciliation_plan_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SyncReconciliationPlanRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncReconciliationPlanResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };


### PR DESCRIPTION
## Summary

- Add a stateless backend sync reconciliation planner with no DB migration or write-side effects.
- Add `POST /api/v1/sync/reconciliation/plan`, request/response schemas, docs, and generated shared types.
- Cover trusted provider choice, tombstone precedence, stale inventory, duplicate content, revision conflicts, and importer-aligned manifest validation.

Closes #125

## Testing

- `uv run --python 3.11 pytest tests/test_sync_reconciliation.py tests/test_sync_reconciliation_api.py`
- `uv run --python 3.11 pytest`
- `uv run --python 3.11 ruff check .`
- `uv run --python 3.11 mypy app`
- `pnpm contracts:generate`
- `pnpm --filter @tuneforge/desktop typecheck`