### PR TITLE
feat: add sync project locks

### DIFF
--- a/apps/backend/alembic/versions/0019_sync_project_state.py
+++ b/apps/backend/alembic/versions/0019_sync_project_state.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0019_sync_project_state"
+down_revision = "0018_sync_delete_tombstones"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("projects") as batch_op:
+        batch_op.add_column(
+            sa.Column("sync_status", sa.String(length=32), nullable=False, server_default="local")
+        )
+        batch_op.add_column(sa.Column("sync_status_reason", sa.Text(), nullable=True))
+        batch_op.add_column(
+            sa.Column("sync_required_artifact_ids_json", sa.JSON(), nullable=False, server_default="[]")
+        )
+        batch_op.add_column(
+            sa.Column("sync_provider_device_ids_json", sa.JSON(), nullable=False, server_default="[]")
+        )
+        batch_op.add_column(
+            sa.Column("sync_conflict_count", sa.Integer(), nullable=False, server_default="0")
+        )
+        batch_op.add_column(
+            sa.Column(
+                "sync_status_updated_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            )
+        )
+        batch_op.create_check_constraint(
+            "ck_projects_sync_status",
+            "sync_status IN ("
+            "'local', "
+            "'syncing', "
+            "'remote_available', "
+            "'downloading', "
+            "'missing', "
+            "'deleted', "
+            "'conflicted'"
+            ")",
+        )
+        batch_op.create_check_constraint(
+            "ck_projects_sync_conflict_count_nonnegative",
+            "sync_conflict_count >= 0",
+        )
+        batch_op.create_index("ix_projects_sync_status", ["sync_status"], unique=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("projects") as batch_op:
+        batch_op.drop_index("ix_projects_sync_status")
+        batch_op.drop_constraint("ck_projects_sync_conflict_count_nonnegative", type_="check")
+        batch_op.drop_constraint("ck_projects_sync_status", type_="check")
+        batch_op.drop_column("sync_status_updated_at")
+        batch_op.drop_column("sync_conflict_count")
+        batch_op.drop_column("sync_provider_device_ids_json")
+        batch_op.drop_column("sync_required_artifact_ids_json")
+        batch_op.drop_column("sync_status_reason")
+        batch_op.drop_column("sync_status")

--- a/apps/backend/app/api/routes/projects.py
+++ b/apps/backend/app/api/routes/projects.py
@@ -46,6 +46,7 @@ from app.services.chords import project_chord_detection_source
 from app.services.lyrics import update_project_lyrics
 from app.services.projects import (
     delete_project,
+    get_mutable_project,
     get_project,
     import_project,
     list_projects,
@@ -195,7 +196,7 @@ def project_analyze(
     session: Session = Depends(get_db),
     runner=Depends(get_job_runner),
 ) -> JobResponse:
-    get_project(session, project_id)
+    get_mutable_project(session, project_id)
     job = runner.create_job(
         session,
         project_id=project_id,
@@ -222,7 +223,7 @@ def project_chords(
     session: Session = Depends(get_db),
     runner=Depends(get_job_runner),
 ) -> JobResponse:
-    project = get_project(session, project_id)
+    project = get_mutable_project(session, project_id)
     selected_backend = resolve_chord_backend(payload.backend, require_available=True)
     job_payload = payload.model_dump()
     job_payload["chord_backend"] = selected_backend.id
@@ -255,7 +256,7 @@ def project_lyrics(
     session: Session = Depends(get_db),
     runner=Depends(get_job_runner),
 ) -> JobResponse:
-    get_project(session, project_id)
+    get_mutable_project(session, project_id)
     job = runner.create_job(
         session,
         project_id=project_id,
@@ -293,7 +294,7 @@ def project_lyrics_update(
     payload: LyricsUpdateRequest,
     session: Session = Depends(get_db),
 ) -> LyricsResponse:
-    project = get_project(session, project_id)
+    project = get_mutable_project(session, project_id)
     lyrics = update_project_lyrics(session, project=project, edits=payload.segments)
     return LyricsResponse.model_validate(lyrics)
 
@@ -304,7 +305,7 @@ def project_tab_import_create(
     payload: TabImportCreateRequest,
     session: Session = Depends(get_db),
 ) -> TabImportResponse:
-    project = get_project(session, project_id)
+    project = get_mutable_project(session, project_id)
     tab_import = create_tab_import(session, project=project, raw_text=payload.raw_text)
     return TabImportResponse(tab_import=TabImportSchema.model_validate(tab_import))
 
@@ -327,7 +328,7 @@ def project_tab_import_accept(
     payload: TabImportApplyRequest,
     session: Session = Depends(get_db),
 ) -> TabImportApplyResponse:
-    project = get_project(session, project_id)
+    project = get_mutable_project(session, project_id)
     tab_import = get_tab_import(session, project_id=project_id, tab_import_id=tab_import_id)
     result = apply_tab_suggestions(
         session,
@@ -360,7 +361,7 @@ def project_retune(
     session: Session = Depends(get_db),
     runner=Depends(get_job_runner),
 ) -> JobResponse:
-    get_project(session, project_id)
+    get_mutable_project(session, project_id)
     job = runner.create_job(
         session,
         project_id=project_id,
@@ -380,7 +381,7 @@ def project_transpose(
     session: Session = Depends(get_db),
     runner=Depends(get_job_runner),
 ) -> JobResponse:
-    get_project(session, project_id)
+    get_mutable_project(session, project_id)
     job = runner.create_job(
         session,
         project_id=project_id,
@@ -400,7 +401,7 @@ def project_preview(
     session: Session = Depends(get_db),
     runner=Depends(get_job_runner),
 ) -> JobResponse:
-    get_project(session, project_id)
+    get_mutable_project(session, project_id)
     job = runner.create_job(
         session,
         project_id=project_id,
@@ -420,7 +421,7 @@ def project_stems(
     session: Session = Depends(get_db),
     runner=Depends(get_job_runner),
 ) -> JobResponse:
-    project = get_project(session, project_id)
+    project = get_mutable_project(session, project_id)
     source_artifact = resolve_stem_source_artifact(
         session,
         project=project,
@@ -458,7 +459,7 @@ def project_artifacts(project_id: str, session: Session = Depends(get_db)) -> Ar
 
 @router.delete("/{project_id}/artifacts/{artifact_id}", response_model=DeleteResponse)
 def project_artifact_delete(project_id: str, artifact_id: str, session: Session = Depends(get_db)) -> DeleteResponse:
-    get_project(session, project_id)
+    get_mutable_project(session, project_id)
     delete_project_artifact(session, project_id=project_id, artifact_id=artifact_id)
     session.commit()
     return DeleteResponse(deleted=True)
@@ -471,7 +472,7 @@ def project_export(
     session: Session = Depends(get_db),
     runner=Depends(get_job_runner),
 ) -> JobResponse:
-    project = get_project(session, project_id)
+    project = get_mutable_project(session, project_id)
     for artifact_id in payload.artifact_ids:
         artifact = session.get(Artifact, artifact_id)
         if artifact is None or artifact.project_id != project.id:

--- a/apps/backend/app/api/routes/sync.py
+++ b/apps/backend/app/api/routes/sync.py
@@ -21,6 +21,8 @@ from app.schemas import (
     SyncProjectImportResponse,
     SyncProjectManifestResponse,
     SyncProjectStagedImportRequest,
+    SyncProjectStatusUpdateRequest,
+    SyncProjectStatusUpdateResponse,
     SyncReconciliationPlanRequest,
     SyncReconciliationPlanResponse,
     SyncStagedArtifactSchema,
@@ -31,6 +33,7 @@ from app.schemas import (
 )
 from app.services.sync_identity import run_sync_preflight
 from app.services.sync_metadata import get_sync_metadata
+from app.services.sync_project_status import update_project_sync_status
 from app.services.sync_trust import (
     create_pairing_offer,
     get_or_create_local_identity,
@@ -172,6 +175,32 @@ def sync_project_manifest(
 
     project_manifest = export_project_manifest(session, project_id=project_id)
     return SyncProjectManifestResponse.model_validate({"project_manifest": project_manifest})
+
+
+@router.patch("/projects/{project_id}/status", response_model=SyncProjectStatusUpdateResponse)
+def sync_project_status_update(
+    project_id: str,
+    payload: SyncProjectStatusUpdateRequest,
+    session: Session = Depends(get_db),
+) -> SyncProjectStatusUpdateResponse:
+    placeholder_metadata: dict[str, Any] | None = None
+    if payload.manifest is not None:
+        placeholder_metadata = payload.manifest.model_dump(mode="python")
+    elif payload.project is not None:
+        placeholder_metadata = payload.project.model_dump(mode="python")
+    project = update_project_sync_status(
+        session,
+        project_id=project_id,
+        sync_status=payload.sync_status,
+        sync_status_reason=payload.sync_status_reason,
+        sync_required_artifact_ids=payload.sync_required_artifact_ids,
+        sync_provider_device_ids=payload.sync_provider_device_ids,
+        sync_conflict_count=payload.sync_conflict_count,
+        manifest=placeholder_metadata,
+    )
+    session.commit()
+    session.refresh(project)
+    return SyncProjectStatusUpdateResponse(project=ProjectSchema.model_validate(project))
 
 
 @router.post("/artifacts/staging", response_model=SyncStagedArtifactSchema)

--- a/apps/backend/app/models.py
+++ b/apps/backend/app/models.py
@@ -26,8 +26,32 @@ def utcnow() -> datetime:
     return datetime.now(UTC)
 
 
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
 class Project(Base):
     __tablename__ = "projects"
+    __table_args__ = (
+        CheckConstraint(
+            "sync_status IN ("
+            "'local', "
+            "'syncing', "
+            "'remote_available', "
+            "'downloading', "
+            "'missing', "
+            "'deleted', "
+            "'conflicted'"
+            ")",
+            name="ck_projects_sync_status",
+        ),
+        CheckConstraint(
+            "sync_conflict_count >= 0",
+            name="ck_projects_sync_conflict_count_nonnegative",
+        ),
+    )
 
     id: Mapped[str] = mapped_column(String(PROJECT_ID_LENGTH), primary_key=True)
     display_name: Mapped[str] = mapped_column(String(255))
@@ -41,6 +65,14 @@ class Project(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=utcnow, onupdate=utcnow
+    )
+    sync_status: Mapped[str] = mapped_column(String(32), default="local")
+    sync_status_reason: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    sync_required_artifact_ids_json: Mapped[list[str]] = mapped_column(JSON(), default=list)
+    sync_provider_device_ids_json: Mapped[list[str]] = mapped_column(JSON(), default=list)
+    sync_conflict_count: Mapped[int] = mapped_column(Integer(), default=0)
+    sync_status_updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow
     )
 
     analysis: Mapped[AnalysisResult | None] = relationship(
@@ -65,6 +97,18 @@ class Project(Base):
         back_populates="project", cascade="all, delete-orphan"
     )
     jobs: Mapped[list[Job]] = relationship(back_populates="project", cascade="all, delete-orphan")
+
+    @property
+    def sync_editable(self) -> bool:
+        return self.sync_status == "local"
+
+    @property
+    def sync_required_artifact_ids(self) -> list[str]:
+        return _string_list(self.sync_required_artifact_ids_json)
+
+    @property
+    def sync_provider_device_ids(self) -> list[str]:
+        return _string_list(self.sync_provider_device_ids_json)
 
 
 class SyncLocalIdentity(Base):

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -18,6 +18,15 @@ SUPPORTED_STEM_MODELS = {
 }
 SIX_STEM_MODEL_ALIASES = {"6_stems", "six_stems", "htdemucs_6s"}
 TWO_STEM_MODEL_ALIASES = {"2_stems", "two_stems", "two_stem", "htdemucs_ft"}
+SyncProjectStatus = Literal[
+    "local",
+    "syncing",
+    "remote_available",
+    "downloading",
+    "missing",
+    "deleted",
+    "conflicted",
+]
 
 
 def _validate_chord_backend_fields(backend: str | None, backend_fallback_from: str | None) -> None:
@@ -65,6 +74,12 @@ class ProjectSchema(BaseModel):
     duration_seconds: float | None
     sample_rate: int | None
     channels: int | None
+    sync_status: SyncProjectStatus = "local"
+    sync_status_reason: str | None = None
+    sync_editable: bool = True
+    sync_required_artifact_ids: list[str] = Field(default_factory=list)
+    sync_provider_device_ids: list[str] = Field(default_factory=list)
+    sync_conflict_count: int = 0
     created_at: datetime
     updated_at: datetime
 
@@ -319,6 +334,58 @@ class SyncProjectManifestResponse(BaseModel):
     project_manifest: SyncProjectManifestSchema
 
 
+class SyncProjectStatusProjectMetadataSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    project_id: str
+    display_name: str
+    source_key_override: str | None = None
+    source_sha256: str | None = None
+    duration_seconds: float | None = None
+    sample_rate: int | None = None
+    channels: int | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class SyncProjectStatusUpdateRequest(BaseModel):
+    sync_status: SyncProjectStatus
+    sync_status_reason: str | None = None
+    sync_required_artifact_ids: list[str] | None = None
+    sync_provider_device_ids: list[str] | None = None
+    sync_conflict_count: int | None = Field(default=None, ge=0)
+    manifest: SyncProjectManifestSchema | None = None
+    project: SyncProjectStatusProjectMetadataSchema | None = None
+
+    @field_validator("sync_status_reason")
+    @classmethod
+    def validate_sync_status_reason(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        return normalized or None
+
+    @field_validator("sync_required_artifact_ids", "sync_provider_device_ids")
+    @classmethod
+    def validate_sync_id_list(cls, value: list[str] | None) -> list[str] | None:
+        if value is None:
+            return None
+        normalized = [item.strip() for item in value]
+        if any(not item for item in normalized):
+            raise ValueError("Sync ID lists cannot contain empty values.")
+        return normalized
+
+    @model_validator(mode="after")
+    def validate_status_metadata(self) -> SyncProjectStatusUpdateRequest:
+        if self.manifest is not None and self.project is not None:
+            raise ValueError("Provide either manifest or project metadata, not both.")
+        return self
+
+
+class SyncProjectStatusUpdateResponse(BaseModel):
+    project: ProjectSchema
+
+
 class SyncArtifactStagingRequest(BaseModel):
     source_path: str = Field(min_length=1)
     content_sha256: str = Field(min_length=64, max_length=64)
@@ -365,6 +432,7 @@ SyncReconciliationActionType = Literal[
     "import_entity_revision",
     "fetch_artifact_content",
     "import_artifact_manifest",
+    "upsert_project_status",
     "record_conflict",
     "noop",
 ]

--- a/apps/backend/app/services/artifacts.py
+++ b/apps/backend/app/services/artifacts.py
@@ -124,6 +124,9 @@ def _has_pending_audio_job(session: Session, *, project_id: str) -> bool:
 
 
 def delete_project_artifact(session: Session, *, project_id: str, artifact_id: str) -> None:
+    from app.services.projects import get_mutable_project
+
+    get_mutable_project(session, project_id)
     artifact = session.get(Artifact, artifact_id)
     if artifact is None or artifact.project_id != project_id:
         raise AppError("ARTIFACT_NOT_FOUND", "Artifact does not belong to this project.", status_code=404)

--- a/apps/backend/app/services/jobs.py
+++ b/apps/backend/app/services/jobs.py
@@ -17,7 +17,7 @@ from app.services.analysis import analyze_project
 from app.services.chord_backends import resolve_chord_backend
 from app.services.chords import detect_project_chords, project_chord_detection_source
 from app.services.lyrics import generate_project_lyrics
-from app.services.projects import get_project
+from app.services.projects import get_mutable_project, get_project
 from app.services.stems import generate_stems
 from app.services.transformations import (
     build_preview_plan,
@@ -108,6 +108,8 @@ class InProcessJobRunner:
         self._queue.put(job_id)
 
     def create_job(self, session: Session, *, project_id: str | None, job_type: str, payload: dict[str, Any]) -> Job:
+        if project_id is not None:
+            get_mutable_project(session, project_id)
         job = Job(
             id=new_id("job"),
             project_id=project_id,
@@ -234,6 +236,8 @@ class InProcessJobRunner:
                 handler = self._handlers.get(job.type)
                 if handler is None:
                     raise AppError("PROCESSING_FAILED", f"Unsupported job type: {job.type}")
+                if job.project_id is not None:
+                    get_mutable_project(session, job.project_id)
                 result = handler(context, session, job)
                 job.status = "completed"
                 job.progress = 100

--- a/apps/backend/app/services/projects.py
+++ b/apps/backend/app/services/projects.py
@@ -15,6 +15,7 @@ from app.services.artifacts import register_artifact
 from app.services.metadata import extract_audio_metadata, normalize_audio_to_wav
 from app.services.paths import ensure_project_dirs, project_root, project_source_dir
 from app.services.sync_identity import source_hash_to_project_id
+from app.services.sync_project_status import require_project_sync_editable
 from app.services.sync_revisions import record_project_metadata_revision
 from app.services.sync_tombstones import (
     record_artifact_delete_tombstone,
@@ -22,6 +23,10 @@ from app.services.sync_tombstones import (
     record_project_delete_tombstone,
 )
 from app.utils.hashing import file_sha256
+
+
+def ensure_project_mutable(project: Project) -> None:
+    require_project_sync_editable(project)
 
 
 def _validate_import_path(source_path: Path) -> None:
@@ -56,6 +61,12 @@ def get_project(session: Session, project_id: str) -> Project:
     project = session.get(Project, project_id)
     if not project:
         raise AppError("PROJECT_NOT_FOUND", "Project not found.", status_code=status.HTTP_404_NOT_FOUND)
+    return project
+
+
+def get_mutable_project(session: Session, project_id: str) -> Project:
+    project = get_project(session, project_id)
+    ensure_project_mutable(project)
     return project
 
 
@@ -161,7 +172,7 @@ def import_project(
 
 
 def delete_project(session: Session, project_id: str) -> None:
-    project = get_project(session, project_id)
+    project = get_mutable_project(session, project_id)
     root = project_root(project.id)
     record_project_delete_tombstone(session, project)
     for artifact in list(session.scalars(select(Artifact).where(Artifact.project_id == project.id))):
@@ -177,7 +188,7 @@ def delete_project(session: Session, project_id: str) -> None:
 
 
 def update_project(session: Session, project_id: str, *, updates: dict[str, str | None]) -> Project:
-    project = get_project(session, project_id)
+    project = get_mutable_project(session, project_id)
     metadata_changed = False
     if "display_name" in updates:
         display_name = updates["display_name"]

--- a/apps/backend/app/services/sync_manifest.py
+++ b/apps/backend/app/services/sync_manifest.py
@@ -30,6 +30,7 @@ from app.services.artifacts import register_artifact
 from app.services.paths import ensure_project_dirs, project_root
 from app.services.sync_identity import source_hash_to_project_id
 from app.services.sync_metadata import project_relative_artifact_path, sanitize_sync_metadata
+from app.services.sync_project_status import mark_project_sync_local
 from app.services.sync_revisions import (
     CURRENT_REVISION_STATE,
     revision_payload_sha256,
@@ -236,12 +237,18 @@ def import_staged_project_manifest(
         sync_group_id=local_sync_group_id,
     )
     existing_project = _find_existing_project_source(session, project_manifest)
+    project: Project | None = None
+    upgrading_placeholder = False
     if existing_project is not None:
         if existing_project.id == project_manifest.project_id and project_manifest.delete_tombstones:
             imported_tombstones = _import_delete_tombstones(session, project_manifest)
             _apply_delete_tombstones(session, imported_tombstones)
             return existing_project
-        raise _duplicate_project_source_error(existing_project.id, existing_project.display_name)
+        if _can_upgrade_project_placeholder(existing_project, project_manifest):
+            project = existing_project
+            upgrading_placeholder = True
+        else:
+            raise _duplicate_project_source_error(existing_project.id, existing_project.display_name)
     _reject_manifest_artifact_conflicts(session, project_manifest)
     root = project_root(project_manifest.project_id).resolve(strict=False)
     staged_root = (
@@ -256,25 +263,33 @@ def import_staged_project_manifest(
     )
     source_path = root / _safe_relative_path(source_artifact.relative_path)
 
-    project = Project(
-        id=project_manifest.project_id,
-        display_name=project_manifest.display_name,
-        source_key_override=project_manifest.source_key_override,
-        source_sha256=project_manifest.source_sha256,
-        source_path=str(source_path),
-        imported_path=str(source_path),
-        duration_seconds=project_manifest.duration_seconds,
-        sample_rate=project_manifest.sample_rate,
-        channels=project_manifest.channels,
-        created_at=project_manifest.created_at,
-        updated_at=project_manifest.updated_at,
-    )
-    session.add(project)
-    try:
+    if project is None:
+        project = Project(
+            id=project_manifest.project_id,
+            display_name=project_manifest.display_name,
+            source_key_override=project_manifest.source_key_override,
+            source_sha256=project_manifest.source_sha256,
+            source_path=str(source_path),
+            imported_path=str(source_path),
+            duration_seconds=project_manifest.duration_seconds,
+            sample_rate=project_manifest.sample_rate,
+            channels=project_manifest.channels,
+            created_at=project_manifest.created_at,
+            updated_at=project_manifest.updated_at,
+        )
+        session.add(project)
+        try:
+            session.flush()
+        except IntegrityError as exc:
+            session.rollback()
+            _raise_duplicate_project_source(session, project_manifest.project_id, project_manifest.source_sha256, exc)
+    else:
+        _upgrade_project_placeholder_from_manifest(
+            project,
+            project_manifest,
+            source_path=source_path,
+        )
         session.flush()
-    except IntegrityError as exc:
-        session.rollback()
-        _raise_duplicate_project_source(session, project_manifest.project_id, project_manifest.source_sha256, exc)
 
     ensure_project_dirs(project.id)
     copied_paths: list[Path] = []
@@ -311,6 +326,8 @@ def import_staged_project_manifest(
         imported_tombstones = _import_delete_tombstones(session, project_manifest)
         _apply_delete_tombstones(session, imported_tombstones)
         _hydrate_current_entity_revisions(session, project, project_manifest.entity_revisions)
+        if upgrading_placeholder:
+            mark_project_sync_local(session, project)
     except OSError as exc:
         _cleanup_copied_artifacts(copied_paths, root)
         raise AppError(
@@ -1309,6 +1326,45 @@ def _find_existing_project_source(
             .order_by(Project.created_at.asc(), Project.id.asc())
         )
     return existing_project
+
+
+def _can_upgrade_project_placeholder(project: Project, manifest: SyncProjectManifest) -> bool:
+    if project.id != manifest.project_id:
+        return False
+    if project.source_sha256 is not None and project.source_sha256 != manifest.source_sha256:
+        return False
+    return _is_project_placeholder(project)
+
+
+def _is_project_placeholder(project: Project) -> bool:
+    for field_name in ("sync_status", "sync_state"):
+        value = getattr(project, field_name, None)
+        if isinstance(value, str) and value.strip().lower() != "local":
+            return True
+
+    source_path = project.source_path.strip()
+    imported_path = project.imported_path.strip()
+    if not source_path and not imported_path:
+        return True
+    return source_path.startswith("sync-placeholder:") and imported_path.startswith("sync-placeholder:")
+
+
+def _upgrade_project_placeholder_from_manifest(
+    project: Project,
+    manifest: SyncProjectManifest,
+    *,
+    source_path: Path,
+) -> None:
+    project.display_name = manifest.display_name
+    project.source_key_override = manifest.source_key_override
+    project.source_sha256 = manifest.source_sha256
+    project.source_path = str(source_path)
+    project.imported_path = str(source_path)
+    project.duration_seconds = manifest.duration_seconds
+    project.sample_rate = manifest.sample_rate
+    project.channels = manifest.channels
+    project.created_at = manifest.created_at
+    project.updated_at = manifest.updated_at
 
 
 def _reject_duplicate_project_source(session: Session, manifest: SyncProjectManifest) -> None:

--- a/apps/backend/app/services/sync_project_status.py
+++ b/apps/backend/app/services/sync_project_status.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from fastapi import status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.errors import AppError
+from app.models import Artifact, Project, utcnow
+from app.utils.hashing import file_sha256
+
+SYNC_PROJECT_STATUSES = {
+    "local",
+    "syncing",
+    "remote_available",
+    "downloading",
+    "missing",
+    "deleted",
+    "conflicted",
+}
+LOCAL_SYNC_STATUS = "local"
+SyncProjectStatus = Literal[
+    "local",
+    "syncing",
+    "remote_available",
+    "downloading",
+    "missing",
+    "deleted",
+    "conflicted",
+]
+
+
+def sync_editable_for_status(sync_status: str | None) -> bool:
+    return (sync_status or LOCAL_SYNC_STATUS) == LOCAL_SYNC_STATUS
+
+
+def project_sync_editable(project: Project) -> bool:
+    return sync_editable_for_status(project.sync_status)
+
+
+def require_project_sync_editable(project: Project) -> None:
+    if project_sync_editable(project):
+        return
+    raise AppError(
+        "PROJECT_SYNC_LOCKED",
+        "Project is still syncing and cannot be edited.",
+        status_code=status.HTTP_409_CONFLICT,
+        details=project_sync_lock_details(project),
+    )
+
+
+def project_sync_lock_details(project: Project) -> dict[str, Any]:
+    return {
+        "project_id": project.id,
+        "sync_status": project.sync_status,
+        "sync_status_reason": project.sync_status_reason,
+        "sync_required_artifact_ids": project.sync_required_artifact_ids,
+        "sync_provider_device_ids": project.sync_provider_device_ids,
+        "sync_conflict_count": project.sync_conflict_count,
+    }
+
+
+def update_project_sync_status(
+    session: Session,
+    *,
+    project_id: str,
+    sync_status: str,
+    sync_status_reason: str | None = None,
+    sync_required_artifact_ids: Sequence[str] | None = None,
+    sync_provider_device_ids: Sequence[str] | None = None,
+    sync_conflict_count: int | None = None,
+    manifest: object | Mapping[str, Any] | None = None,
+) -> Project:
+    normalized_status = _normalize_sync_status(sync_status)
+    project = session.get(Project, project_id)
+    if project is None:
+        if manifest is None:
+            raise AppError(
+                "SYNC_PROJECT_STATUS_MANIFEST_REQUIRED",
+                "A project manifest is required to create a sync project placeholder.",
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+        project = _project_placeholder_from_manifest(project_id=project_id, manifest=manifest)
+        session.add(project)
+        session.flush()
+
+    required_artifact_ids = _normalize_string_list(sync_required_artifact_ids)
+    provider_device_ids = _normalize_string_list(sync_provider_device_ids)
+    conflict_count = 0 if sync_conflict_count is None else max(sync_conflict_count, 0)
+
+    if normalized_status == LOCAL_SYNC_STATUS:
+        _require_local_project_bytes_verified(
+            session,
+            project=project,
+            required_artifact_ids=required_artifact_ids or project.sync_required_artifact_ids,
+        )
+        _set_project_sync_fields(
+            project,
+            sync_status=LOCAL_SYNC_STATUS,
+            sync_status_reason=None,
+            sync_required_artifact_ids=[],
+            sync_provider_device_ids=[],
+            sync_conflict_count=0,
+        )
+    else:
+        _set_project_sync_fields(
+            project,
+            sync_status=normalized_status,
+            sync_status_reason=_normalize_reason(sync_status_reason),
+            sync_required_artifact_ids=required_artifact_ids,
+            sync_provider_device_ids=provider_device_ids,
+            sync_conflict_count=conflict_count,
+        )
+
+    session.flush()
+    return project
+
+
+def mark_project_sync_local(session: Session, project: Project) -> Project:
+    _require_local_project_bytes_verified(
+        session,
+        project=project,
+        required_artifact_ids=project.sync_required_artifact_ids,
+    )
+    _set_project_sync_fields(
+        project,
+        sync_status=LOCAL_SYNC_STATUS,
+        sync_status_reason=None,
+        sync_required_artifact_ids=[],
+        sync_provider_device_ids=[],
+        sync_conflict_count=0,
+    )
+    session.flush()
+    return project
+
+
+def _set_project_sync_fields(
+    project: Project,
+    *,
+    sync_status: str,
+    sync_status_reason: str | None,
+    sync_required_artifact_ids: list[str],
+    sync_provider_device_ids: list[str],
+    sync_conflict_count: int,
+) -> None:
+    project.sync_status = sync_status
+    project.sync_status_reason = sync_status_reason
+    project.sync_required_artifact_ids_json = sync_required_artifact_ids
+    project.sync_provider_device_ids_json = sync_provider_device_ids
+    project.sync_conflict_count = sync_conflict_count
+    project.sync_status_updated_at = utcnow()
+
+
+def _normalize_sync_status(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized not in SYNC_PROJECT_STATUSES:
+        raise AppError(
+            "SYNC_PROJECT_STATUS_INVALID",
+            "Project sync status is not supported.",
+            status_code=status.HTTP_400_BAD_REQUEST,
+            details={"sync_status": value, "supported_statuses": sorted(SYNC_PROJECT_STATUSES)},
+        )
+    return normalized
+
+
+def _normalize_string_list(values: Sequence[str] | None) -> list[str]:
+    if values is None:
+        return []
+    normalized = []
+    seen = set()
+    for value in values:
+        cleaned = value.strip()
+        if not cleaned or cleaned in seen:
+            continue
+        normalized.append(cleaned)
+        seen.add(cleaned)
+    return normalized
+
+
+def _normalize_reason(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _project_placeholder_from_manifest(
+    *,
+    project_id: str,
+    manifest: object | Mapping[str, Any],
+) -> Project:
+    project_payload = _field(manifest, "project", default=manifest)
+    manifest_project_id = _required_string(project_payload, "project_id")
+    if manifest_project_id != project_id:
+        raise AppError(
+            "SYNC_PROJECT_STATUS_MANIFEST_MISMATCH",
+            "Project manifest does not match the requested project.",
+            status_code=status.HTTP_409_CONFLICT,
+            details={"project_id": project_id, "manifest_project_id": manifest_project_id},
+        )
+
+    now = utcnow()
+    created_at = _datetime_field(project_payload, "created_at") or now
+    updated_at = _datetime_field(project_payload, "updated_at") or now
+    return Project(
+        id=project_id,
+        display_name=_required_string(project_payload, "display_name"),
+        source_key_override=_string_field(project_payload, "source_key_override"),
+        source_sha256=_string_field(project_payload, "source_sha256"),
+        source_path="",
+        imported_path="",
+        duration_seconds=_float_or_none(_field(project_payload, "duration_seconds")),
+        sample_rate=_int_or_none(_field(project_payload, "sample_rate")),
+        channels=_int_or_none(_field(project_payload, "channels")),
+        created_at=created_at,
+        updated_at=updated_at,
+    )
+
+
+def _require_local_project_bytes_verified(
+    session: Session,
+    *,
+    project: Project,
+    required_artifact_ids: Sequence[str],
+) -> None:
+    artifact_ids = _normalize_string_list(required_artifact_ids)
+    if not artifact_ids:
+        source_artifact = session.scalar(
+            select(Artifact)
+            .where(Artifact.project_id == project.id)
+            .where(Artifact.type == "source_audio")
+            .order_by(Artifact.created_at.asc(), Artifact.id.asc())
+        )
+        if source_artifact is None:
+            raise _local_bytes_error(project.id, ["source_audio"])
+        _verify_artifact_file(source_artifact)
+        return
+
+    missing: list[str] = []
+    for artifact_id in artifact_ids:
+        artifact = session.get(Artifact, artifact_id)
+        if artifact is None or artifact.project_id != project.id:
+            missing.append(artifact_id)
+            continue
+        try:
+            _verify_artifact_file(artifact)
+        except AppError:
+            missing.append(artifact_id)
+    if missing:
+        raise _local_bytes_error(project.id, missing)
+
+
+def _verify_artifact_file(artifact: Artifact) -> None:
+    path = Path(artifact.path).expanduser().resolve(strict=False)
+    if not path.exists():
+        raise _local_bytes_error(artifact.project_id, [artifact.id])
+    if artifact.size_bytes != path.stat().st_size:
+        raise _local_bytes_error(artifact.project_id, [artifact.id])
+    if artifact.content_sha256:
+        actual_sha256 = file_sha256(path)
+        if actual_sha256 != artifact.content_sha256:
+            raise _local_bytes_error(artifact.project_id, [artifact.id])
+
+
+def _local_bytes_error(project_id: str, missing_artifact_ids: Sequence[str]) -> AppError:
+    return AppError(
+        "SYNC_PROJECT_STATUS_LOCAL_BYTES_UNVERIFIED",
+        "Project cannot be marked local until required artifact bytes are verified.",
+        status_code=status.HTTP_409_CONFLICT,
+        details={"project_id": project_id, "required_artifact_ids": list(missing_artifact_ids)},
+    )
+
+
+def _field(source: object, name: str, *, default: Any = None) -> Any:
+    if isinstance(source, Mapping):
+        return source.get(name, default)
+    return getattr(source, name, default)
+
+
+def _required_string(source: object, name: str) -> str:
+    value = _string_field(source, name)
+    if value is None:
+        raise AppError(
+            "SYNC_PROJECT_STATUS_MANIFEST_INVALID",
+            "Project manifest is missing required placeholder metadata.",
+            status_code=status.HTTP_400_BAD_REQUEST,
+            details={"field": name},
+        )
+    return value
+
+
+def _string_field(source: object, name: str) -> str | None:
+    value = _field(source, name)
+    return value if isinstance(value, str) else None
+
+
+def _datetime_field(source: object, name: str) -> datetime | None:
+    value = _field(source, name)
+    return value if isinstance(value, datetime) else None
+
+
+def _float_or_none(value: object) -> float | None:
+    if isinstance(value, int | float):
+        return float(value)
+    return None
+
+
+def _int_or_none(value: object) -> int | None:
+    if isinstance(value, int):
+        return value
+    return None

--- a/apps/backend/app/services/sync_reconciliation.py
+++ b/apps/backend/app/services/sync_reconciliation.py
@@ -41,6 +41,7 @@ ACTION_IMPORT_PROJECT_MANIFEST = "import_project_manifest"
 ACTION_IMPORT_ENTITY_REVISION = "import_entity_revision"
 ACTION_FETCH_ARTIFACT_CONTENT = "fetch_artifact_content"
 ACTION_IMPORT_ARTIFACT_MANIFEST = "import_artifact_manifest"
+ACTION_UPSERT_PROJECT_STATUS = "upsert_project_status"
 ACTION_RECORD_CONFLICT = "record_conflict"
 ACTION_NOOP = "noop"
 
@@ -48,6 +49,23 @@ ITEM_PROJECT = "project"
 ITEM_ARTIFACT = "artifact"
 ITEM_ENTITY_REVISION = "entity_revision"
 ITEM_DELETE_TOMBSTONE = "delete_tombstone"
+
+PROJECT_SYNC_STATUS_LOCAL = "local"
+PROJECT_SYNC_STATUS_SYNCING = "syncing"
+PROJECT_SYNC_STATUS_REMOTE_AVAILABLE = "remote_available"
+PROJECT_SYNC_STATUS_DOWNLOADING = "downloading"
+PROJECT_SYNC_STATUS_MISSING = "missing"
+PROJECT_SYNC_STATUS_DELETED = "deleted"
+PROJECT_SYNC_STATUS_CONFLICTED = "conflicted"
+PROJECT_SYNC_STATUSES = (
+    PROJECT_SYNC_STATUS_LOCAL,
+    PROJECT_SYNC_STATUS_SYNCING,
+    PROJECT_SYNC_STATUS_REMOTE_AVAILABLE,
+    PROJECT_SYNC_STATUS_DOWNLOADING,
+    PROJECT_SYNC_STATUS_MISSING,
+    PROJECT_SYNC_STATUS_DELETED,
+    PROJECT_SYNC_STATUS_CONFLICTED,
+)
 
 _STATUS_PRECEDENCE = {
     "noop": 0,
@@ -62,6 +80,7 @@ _STATUS_PRECEDENCE = {
 _ACTION_PRIORITY = {
     ACTION_APPLY_DELETE_TOMBSTONE: 0,
     ACTION_RECORD_CONFLICT: 10,
+    ACTION_UPSERT_PROJECT_STATUS: 15,
     ACTION_FETCH_ARTIFACT_CONTENT: 20,
     ACTION_IMPORT_PROJECT_MANIFEST: 30,
     ACTION_IMPORT_ARTIFACT_MANIFEST: 40,
@@ -255,7 +274,7 @@ def plan_sync_reconciliation(
         planned_project_ids = _planned_project_ids(actions)
         if (
             artifact.project_id in remote.project_manifests_by_id
-            and artifact.project_id not in local.projects
+            and not _has_imported_local_project(local, artifact.project_id)
             and artifact.artifact_id in remote.manifest_artifact_ids_by_project.get(artifact.project_id, frozenset())
         ):
             continue
@@ -275,7 +294,7 @@ def plan_sync_reconciliation(
     for revision in _sorted_remote_entity_revisions(remote.entity_revisions.values()):
         if (
             revision.project_id in remote.project_manifests_by_id
-            and revision.project_id not in local.projects
+            and not _has_imported_local_project(local, revision.project_id)
             and revision.revision_id in remote.manifest_revision_ids_by_project.get(revision.project_id, frozenset())
         ):
             continue
@@ -372,6 +391,22 @@ def _load_local_state(session: Session) -> _LocalState:
             for key, rows in revisions_by_entity.items()
         },
         tombstones=tombstones,
+    )
+
+
+def _has_imported_local_project(local: _LocalState, project_id: str) -> bool:
+    project = local.projects.get(project_id)
+    return project is not None and not _is_sync_project_placeholder(project)
+
+
+def _is_sync_project_placeholder(project: Project) -> bool:
+    source_path = (project.source_path or "").strip()
+    imported_path = (project.imported_path or "").strip()
+    return (
+        not source_path
+        or not imported_path
+        or source_path.startswith("sync-placeholder:")
+        or imported_path.startswith("sync-placeholder:")
     )
 
 
@@ -659,6 +694,7 @@ def _plan_project(
     actions: list[SyncReconciliationAction],
 ) -> None:
     if _is_deleted(ITEM_PROJECT, project.project_id, project.project_id, effective_tombstones):
+        reason = "Project is covered by a sync delete tombstone."
         _upsert_item(
             items_by_key,
             SyncReconciliationItem(
@@ -667,8 +703,15 @@ def _plan_project(
                 project_id=project.project_id,
                 status="deleted",
                 action_type=ACTION_APPLY_DELETE_TOMBSTONE,
-                reason="Project is covered by a sync delete tombstone.",
+                reason=reason,
             ),
+        )
+        _append_project_status_action(
+            actions,
+            project,
+            project_status=PROJECT_SYNC_STATUS_DELETED,
+            reason=reason,
+            content_sha256=project.source_sha256,
         )
         return
 
@@ -693,22 +736,24 @@ def _plan_project(
                 },
             )
             return
-        _upsert_item(
-            items_by_key,
-            SyncReconciliationItem(
-                item_type=ITEM_PROJECT,
-                item_id=project.project_id,
-                project_id=project.project_id,
-                status="noop",
-                action_type=ACTION_NOOP,
-                content_sha256=project.source_sha256,
-                reason="Project already exists locally.",
-            ),
-        )
-        return
+        if not _is_sync_project_placeholder(local_project):
+            _upsert_item(
+                items_by_key,
+                SyncReconciliationItem(
+                    item_type=ITEM_PROJECT,
+                    item_id=project.project_id,
+                    project_id=project.project_id,
+                    status="noop",
+                    action_type=ACTION_NOOP,
+                    content_sha256=project.source_sha256,
+                    reason="Project already exists locally.",
+                ),
+            )
+            return
 
     manifest = remote.project_manifests_by_id.get(project.project_id)
     if manifest is None:
+        reason = "Project manifest is required before import."
         _upsert_item(
             items_by_key,
             SyncReconciliationItem(
@@ -717,8 +762,15 @@ def _plan_project(
                 project_id=project.project_id,
                 status="missing_provider",
                 content_sha256=project.source_sha256,
-                reason="Project manifest is required before import.",
+                reason=reason,
             ),
+        )
+        _append_project_status_action(
+            actions,
+            project,
+            project_status=PROJECT_SYNC_STATUS_MISSING,
+            reason=reason,
+            content_sha256=project.source_sha256,
         )
         return
 
@@ -735,11 +787,20 @@ def _plan_project(
             reason=source_error,
             details=source_details,
         )
+        _append_project_status_action(
+            actions,
+            project,
+            project_status=PROJECT_SYNC_STATUS_CONFLICTED,
+            reason=source_error,
+            content_sha256=project.source_sha256,
+            status_details=source_details,
+        )
         return
 
     assert source_artifact is not None
     source_hash = source_artifact.content_sha256
     if source_hash is None:
+        reason = "Project manifest does not identify required source content."
         _upsert_item(
             items_by_key,
             SyncReconciliationItem(
@@ -747,11 +808,19 @@ def _plan_project(
                 item_id=project.project_id,
                 project_id=project.project_id,
                 status="missing_provider",
-                reason="Project manifest does not identify required source content.",
+                reason=reason,
             ),
+        )
+        _append_project_status_action(
+            actions,
+            project,
+            project_status=PROJECT_SYNC_STATUS_MISSING,
+            reason=reason,
+            content_sha256=project.source_sha256,
         )
         return
     if project.source_sha256 is None:
+        reason = "Project manifest does not include source SHA-256 identity metadata."
         _upsert_item(
             items_by_key,
             SyncReconciliationItem(
@@ -759,13 +828,22 @@ def _plan_project(
                 item_id=project.project_id,
                 project_id=project.project_id,
                 status="missing_provider",
-                reason="Project manifest does not include source SHA-256 identity metadata.",
+                reason=reason,
             ),
+        )
+        _append_project_status_action(
+            actions,
+            project,
+            project_status=PROJECT_SYNC_STATUS_MISSING,
+            reason=reason,
+            content_sha256=source_hash,
         )
         return
     try:
         expected_project_id = source_hash_to_project_id(project.source_sha256)
     except ValueError:
+        details: dict[str, Any] = {"source_sha256": project.source_sha256}
+        reason = "Project manifest source_sha256 must be a full SHA-256 hex digest."
         _record_conflict(
             items_by_key,
             actions,
@@ -773,11 +851,24 @@ def _plan_project(
             item_id=project.project_id,
             project_id=project.project_id,
             content_sha256=project.source_sha256,
-            reason="Project manifest source_sha256 must be a full SHA-256 hex digest.",
-            details={"source_sha256": project.source_sha256},
+            reason=reason,
+            details=details,
+        )
+        _append_project_status_action(
+            actions,
+            project,
+            project_status=PROJECT_SYNC_STATUS_CONFLICTED,
+            reason=reason,
+            content_sha256=project.source_sha256,
+            status_details=details,
         )
         return
     if project.project_id != expected_project_id:
+        details = {
+            "expected_project_id": expected_project_id,
+            "source_sha256": project.source_sha256,
+        }
+        reason = "Project manifest project_id must be derived from source_sha256."
         _record_conflict(
             items_by_key,
             actions,
@@ -785,11 +876,16 @@ def _plan_project(
             item_id=project.project_id,
             project_id=project.project_id,
             content_sha256=project.source_sha256,
-            reason="Project manifest project_id must be derived from source_sha256.",
-            details={
-                "expected_project_id": expected_project_id,
-                "source_sha256": project.source_sha256,
-            },
+            reason=reason,
+            details=details,
+        )
+        _append_project_status_action(
+            actions,
+            project,
+            project_status=PROJECT_SYNC_STATUS_CONFLICTED,
+            reason=reason,
+            content_sha256=project.source_sha256,
+            status_details=details,
         )
         return
 
@@ -814,6 +910,14 @@ def _plan_project(
             reason=reason,
             details=details,
         )
+        _append_project_status_action(
+            actions,
+            project,
+            project_status=PROJECT_SYNC_STATUS_CONFLICTED,
+            reason=reason,
+            content_sha256=project.source_sha256,
+            status_details=details,
+        )
         return
 
     missing_hash_artifact_ids = [
@@ -822,6 +926,8 @@ def _plan_project(
         if artifact.content_sha256 is None
     ]
     if missing_hash_artifact_ids:
+        reason = "Project manifest contains artifacts without content SHA-256 metadata."
+        details = {"artifact_ids": sorted(missing_hash_artifact_ids)}
         _upsert_item(
             items_by_key,
             SyncReconciliationItem(
@@ -830,9 +936,17 @@ def _plan_project(
                 project_id=project.project_id,
                 status="missing_provider",
                 content_sha256=source_hash,
-                reason="Project manifest contains artifacts without content SHA-256 metadata.",
-                details={"artifact_ids": sorted(missing_hash_artifact_ids)},
+                reason=reason,
+                details=details,
             ),
+        )
+        _append_project_status_action(
+            actions,
+            project,
+            project_status=PROJECT_SYNC_STATUS_MISSING,
+            reason=reason,
+            content_sha256=source_hash,
+            status_details=details,
         )
         return
 
@@ -843,6 +957,8 @@ def _plan_project(
         if local_artifact is None and provider_device_id is None
     ]
     if missing_provider_artifacts:
+        reason = "No local bytes or trusted provider are available for every project manifest artifact."
+        details = {"artifact_ids": sorted(missing_provider_artifacts)}
         _upsert_item(
             items_by_key,
             SyncReconciliationItem(
@@ -851,9 +967,17 @@ def _plan_project(
                 project_id=project.project_id,
                 status="missing_provider",
                 content_sha256=source_hash,
-                reason="No local bytes or trusted provider are available for every project manifest artifact.",
-                details={"artifact_ids": sorted(missing_provider_artifacts)},
+                reason=reason,
+                details=details,
             ),
+        )
+        _append_project_status_action(
+            actions,
+            project,
+            project_status=PROJECT_SYNC_STATUS_MISSING,
+            reason=reason,
+            content_sha256=source_hash,
+            status_details=details,
         )
         return
 
@@ -901,6 +1025,11 @@ def _plan_project(
         return
 
     chosen_provider_device_id = sorted(artifact_providers.values())[0]
+    reason = "Every project manifest artifact is local or advertised by a trusted peer."
+    details = {
+        "artifact_providers": artifact_providers,
+        "manifest_artifact_count": len(manifest_artifacts),
+    }
     _upsert_item(
         items_by_key,
         SyncReconciliationItem(
@@ -911,12 +1040,18 @@ def _plan_project(
             action_type=ACTION_IMPORT_PROJECT_MANIFEST,
             content_sha256=source_hash,
             chosen_provider_device_id=chosen_provider_device_id,
-            reason="Every project manifest artifact is local or advertised by a trusted peer.",
-            details={
-                "artifact_providers": artifact_providers,
-                "manifest_artifact_count": len(manifest_artifacts),
-            },
+            reason=reason,
+            details=details,
         ),
+    )
+    _append_project_status_action(
+        actions,
+        project,
+        project_status=PROJECT_SYNC_STATUS_REMOTE_AVAILABLE,
+        reason=reason,
+        content_sha256=source_hash,
+        provider_device_id=chosen_provider_device_id,
+        status_details=details,
     )
     for artifact, local_artifact, provider_device_id in available_artifacts:
         if local_artifact is not None or provider_device_id is None or artifact.content_sha256 is None:
@@ -987,7 +1122,10 @@ def _plan_artifact(
         )
         return
 
-    if artifact.project_id not in local.projects and artifact.project_id not in planned_project_ids:
+    if (
+        not _has_imported_local_project(local, artifact.project_id)
+        and artifact.project_id not in planned_project_ids
+    ):
         _upsert_item(
             items_by_key,
             SyncReconciliationItem(
@@ -1204,7 +1342,7 @@ def _plan_entity_revision(
         )
         return False
 
-    if revision.project_id not in local.projects:
+    if not _has_imported_local_project(local, revision.project_id):
         _upsert_item(
             items_by_key,
             SyncReconciliationItem(
@@ -1742,6 +1880,56 @@ def _record_conflict(
             details=details,
         )
     )
+
+
+def _append_project_status_action(
+    actions: list[SyncReconciliationAction],
+    project: _RemoteProject,
+    *,
+    project_status: str,
+    reason: str,
+    content_sha256: str | None,
+    provider_device_id: str | None = None,
+    status_details: dict[str, Any] | None = None,
+) -> None:
+    actions.append(
+        _action(
+            ACTION_UPSERT_PROJECT_STATUS,
+            item_type=ITEM_PROJECT,
+            item_id=project.project_id,
+            project_id=project.project_id,
+            content_sha256=content_sha256,
+            provider_device_id=provider_device_id,
+            reason=reason,
+            details={
+                "project_status": project_status,
+                "edit_locked": project_status != PROJECT_SYNC_STATUS_LOCAL,
+                "create_placeholder": project_status != PROJECT_SYNC_STATUS_DELETED,
+                "lock_reason": reason,
+                "remote_metadata": _remote_project_metadata(project),
+                "status_details": status_details or {},
+            },
+        )
+    )
+
+
+def _remote_project_metadata(project: _RemoteProject) -> dict[str, Any]:
+    metadata: dict[str, Any] = {"project_id": project.project_id}
+    for name in (
+        "display_name",
+        "source_key_override",
+        "duration_seconds",
+        "sample_rate",
+        "channels",
+        "created_at",
+        "updated_at",
+    ):
+        value = _first_field(project.raw, name, default=None)
+        if value is not None:
+            metadata[name] = value
+    if project.source_sha256 is not None:
+        metadata["source_sha256"] = project.source_sha256
+    return metadata
 
 
 def _coerce_remote_project(raw: object) -> _RemoteProject | None:

--- a/apps/backend/tests/test_sync_manifest.py
+++ b/apps/backend/tests/test_sync_manifest.py
@@ -940,6 +940,61 @@ def test_import_staged_project_manifest_rewrites_paths_preserves_hashes_and_skip
         assert not job_types.intersection({"analyze", "chords"})
 
 
+def test_import_staged_project_manifest_upgrades_placeholder_and_clears_sync_lock(
+    client: object,
+    tmp_path: Path,
+) -> None:
+    export_manifest, import_manifest = _sync_manifest_services()
+    staging_root = tmp_path / "staging"
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path)
+        manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+        _stage_manifest_files(manifest, staging_root=staging_root, source_root=fixture.root)
+        _delete_live_project(session, fixture)
+
+        placeholder = Project(
+            id=fixture.project_id,
+            display_name="Remote Placeholder",
+            source_key_override=None,
+            source_sha256=fixture.source_sha256,
+            source_path="",
+            imported_path="",
+            duration_seconds=None,
+            sample_rate=None,
+            channels=None,
+        )
+        placeholder.sync_status = "remote_available"
+        placeholder.sync_status_reason = "Waiting for source audio."
+        placeholder.sync_required_artifact_ids_json = ["art_source_audio"]
+        placeholder.sync_provider_device_ids_json = ["peer-a"]
+        placeholder.sync_conflict_count = 2
+        session.add(placeholder)
+        session.flush()
+
+        imported_project = import_manifest(session, manifest=manifest, staging_root=staging_root)
+        session.commit()
+
+        assert imported_project.id == fixture.project_id
+        project = session.get(Project, fixture.project_id)
+        assert project is not None
+        receiving_root = project_root(fixture.project_id)
+        expected_source_path = receiving_root / fixture.source_relative_path
+        assert Path(project.source_path) == expected_source_path
+        assert Path(project.imported_path) == expected_source_path
+        assert project.display_name == "Sync Fixture"
+        assert project.sync_status == "local"
+        assert project.sync_status_reason is None
+        assert project.sync_required_artifact_ids_json == []
+        assert project.sync_provider_device_ids_json == []
+        assert project.sync_conflict_count == 0
+
+        artifact_ids = set(
+            session.scalars(select(Artifact.id).where(Artifact.project_id == fixture.project_id))
+        )
+        assert artifact_ids == {"art_source_audio", "art_vocals"}
+
+
 def test_import_staged_project_manifest_hydrates_current_entity_revisions_and_skips_jobs(
     client: object,
     tmp_path: Path,

--- a/apps/backend/tests/test_sync_project_edit_lock.py
+++ b/apps/backend/tests/test_sync_project_edit_lock.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.db import SessionLocal
+from app.errors import AppError
+from app.models import Job, Project
+from app.services.artifacts import delete_project_artifact, register_artifact
+from app.services.jobs import InProcessJobRunner, JobExecutionContext, JobExecutionResult
+
+
+def _create_project_with_artifacts(tmp_path: Path) -> tuple[str, str, str]:
+    source_path = tmp_path / "locked-source.wav"
+    source_path.write_bytes(b"source")
+    preview_path = tmp_path / "locked-preview.wav"
+    preview_path.write_bytes(b"preview")
+
+    with SessionLocal() as session:
+        project = Project(
+            id="proj_sync_locked",
+            display_name="Locked Project",
+            source_sha256="a" * 64,
+            source_path=str(source_path),
+            imported_path=str(source_path),
+            duration_seconds=1.0,
+            sample_rate=44100,
+            channels=2,
+        )
+        session.add(project)
+        source_artifact = register_artifact(
+            session,
+            project_id=project.id,
+            artifact_id="art_locked_source",
+            artifact_type="source_audio",
+            artifact_format="wav",
+            path=source_path,
+            generated_by="import",
+            can_delete=False,
+            can_regenerate=False,
+        )
+        preview_artifact = register_artifact(
+            session,
+            project_id=project.id,
+            artifact_id="art_locked_preview",
+            artifact_type="preview_mix",
+            artifact_format="wav",
+            path=preview_path,
+            generated_by="test",
+            can_delete=True,
+            can_regenerate=True,
+        )
+        session.commit()
+        return project.id, source_artifact.id, preview_artifact.id
+
+
+def _lock_project(locked_project_id: str) -> None:
+    with SessionLocal() as session:
+        project = session.get(Project, locked_project_id)
+        assert project is not None
+        project.sync_status = "remote_available"
+        project.sync_status_reason = "Available from peer."
+        project.sync_required_artifact_ids_json = ["art_locked_source"]
+        project.sync_provider_device_ids_json = ["peer-a"]
+        project.sync_conflict_count = 1
+        session.commit()
+
+
+def _assert_sync_locked(response, project_id: str) -> None:
+    assert response.status_code == 409
+    assert response.json()["error"] == {
+        "code": "PROJECT_SYNC_LOCKED",
+        "message": "Project is still syncing and cannot be edited.",
+        "details": {
+            "project_id": project_id,
+            "sync_status": "remote_available",
+            "sync_status_reason": "Available from peer.",
+            "sync_required_artifact_ids": ["art_locked_source"],
+            "sync_provider_device_ids": ["peer-a"],
+            "sync_conflict_count": 1,
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("method", "path_template", "payload"),
+    [
+        ("PATCH", "/api/v1/projects/{project_id}", {"display_name": "Renamed"}),
+        ("PATCH", "/api/v1/projects/{project_id}", {"source_key_override": "8:major"}),
+        ("DELETE", "/api/v1/projects/{project_id}", None),
+        ("POST", "/api/v1/projects/{project_id}/analyze", {"include_tempo": False, "force": False}),
+        ("POST", "/api/v1/projects/{project_id}/chords", {"backend": "default", "force": False}),
+        ("POST", "/api/v1/projects/{project_id}/lyrics", {"force": False}),
+        ("PUT", "/api/v1/projects/{project_id}/lyrics", {"segments": [{"text": "edited lyric"}]}),
+        ("POST", "/api/v1/projects/{project_id}/tabs/proposals", {"raw_text": "[Verse]\nC"}),
+        ("POST", "/api/v1/projects/{project_id}/tabs/tab_missing/accept", {"accepted_suggestion_ids": []}),
+        ("POST", "/api/v1/projects/{project_id}/retune", {"target_reference_hz": 441.0}),
+        ("POST", "/api/v1/projects/{project_id}/transpose", {"semitones": 1}),
+        ("POST", "/api/v1/projects/{project_id}/preview", {"transpose": {"semitones": 1}}),
+        (
+            "POST",
+            "/api/v1/projects/{project_id}/stems",
+            {"mode": "stems", "output_format": "wav", "force": False},
+        ),
+        (
+            "POST",
+            "/api/v1/projects/{project_id}/export",
+            {"artifact_ids": ["{source_artifact_id}"], "mixdown_mode": "copy", "output_format": "wav"},
+        ),
+        ("DELETE", "/api/v1/projects/{project_id}/artifacts/{preview_artifact_id}", None),
+    ],
+)
+def test_locked_project_mutations_return_conflict(
+    client,
+    tmp_path: Path,
+    method: str,
+    path_template: str,
+    payload: dict[str, Any] | None,
+) -> None:
+    project_id, source_artifact_id, preview_artifact_id = _create_project_with_artifacts(tmp_path)
+    _lock_project(project_id)
+
+    path = path_template.format(
+        project_id=project_id,
+        source_artifact_id=source_artifact_id,
+        preview_artifact_id=preview_artifact_id,
+    )
+    request_payload = (
+        None
+        if payload is None
+        else {
+            key: (
+                [source_artifact_id]
+                if key == "artifact_ids" and value == ["{source_artifact_id}"]
+                else value
+            )
+            for key, value in payload.items()
+        }
+    )
+
+    response = (
+        client.request(method, path)
+        if request_payload is None
+        else client.request(method, path, json=request_payload)
+    )
+
+    _assert_sync_locked(response, project_id)
+    with SessionLocal() as session:
+        assert session.get(Project, project_id) is not None
+        job_count = session.scalar(select(func.count()).select_from(Job))
+        assert job_count == 0
+
+
+def test_locked_project_artifact_delete_service_returns_conflict(
+    client,
+    tmp_path: Path,
+) -> None:
+    _ = client
+    project_id, _, preview_artifact_id = _create_project_with_artifacts(tmp_path)
+    _lock_project(project_id)
+
+    with SessionLocal() as session:
+        with pytest.raises(AppError) as exc:
+            delete_project_artifact(
+                session,
+                project_id=project_id,
+                artifact_id=preview_artifact_id,
+            )
+
+    assert exc.value.code == "PROJECT_SYNC_LOCKED"
+    assert exc.value.status_code == 409
+    assert exc.value.details == {
+        "project_id": project_id,
+        "sync_status": "remote_available",
+        "sync_status_reason": "Available from peer.",
+        "sync_required_artifact_ids": ["art_locked_source"],
+        "sync_provider_device_ids": ["peer-a"],
+        "sync_conflict_count": 1,
+    }
+
+
+def test_locked_project_job_creation_service_returns_conflict(
+    client,
+    tmp_path: Path,
+) -> None:
+    _ = client
+    project_id, _, _ = _create_project_with_artifacts(tmp_path)
+    _lock_project(project_id)
+    runner = InProcessJobRunner(SessionLocal)
+
+    with SessionLocal() as session:
+        with pytest.raises(AppError) as exc:
+            runner.create_job(
+                session,
+                project_id=project_id,
+                job_type="analyze",
+                payload={"include_tempo": False, "force": False},
+            )
+
+    assert exc.value.code == "PROJECT_SYNC_LOCKED"
+
+
+def test_pending_project_job_fails_if_project_locks_before_execution(
+    client,
+    tmp_path: Path,
+) -> None:
+    _ = client
+    project_id, _, _ = _create_project_with_artifacts(tmp_path)
+    runner = InProcessJobRunner(SessionLocal)
+    with SessionLocal() as session:
+        job = runner.create_job(
+            session,
+            project_id=project_id,
+            job_type="test_mutation",
+            payload={},
+        )
+        session.commit()
+        job_id = job.id
+
+    _lock_project(project_id)
+    handler_called = False
+
+    def handler(
+        _context: JobExecutionContext,
+        _session: Session,
+        _job: Job,
+    ) -> JobExecutionResult:
+        nonlocal handler_called
+        handler_called = True
+        return JobExecutionResult(artifact_ids=[])
+
+    runner._handlers["test_mutation"] = handler
+    runner._execute_job(job_id)
+
+    assert handler_called is False
+    with SessionLocal() as session:
+        job = session.get(Job, job_id)
+        assert job is not None
+        assert job.status == "failed"
+        assert job.error_message == "Project is still syncing and cannot be edited."
+        assert job.result_artifact_ids_json == []
+
+
+def test_locked_project_read_routes_remain_open(
+    client,
+    tmp_path: Path,
+) -> None:
+    project_id, _, _ = _create_project_with_artifacts(tmp_path)
+    _lock_project(project_id)
+
+    projects_response = client.get("/api/v1/projects")
+    assert projects_response.status_code == 200
+    assert [project["id"] for project in projects_response.json()["projects"]] == [project_id]
+
+    detail_response = client.get(f"/api/v1/projects/{project_id}")
+    assert detail_response.status_code == 200
+    assert detail_response.json()["project"]["id"] == project_id
+
+    artifacts_response = client.get(f"/api/v1/projects/{project_id}/artifacts")
+    assert artifacts_response.status_code == 200
+    assert {artifact["id"] for artifact in artifacts_response.json()["artifacts"]} == {
+        "art_locked_preview",
+        "art_locked_source",
+    }
+
+    assert client.get(f"/api/v1/projects/{project_id}/analysis").status_code == 200
+    assert client.get(f"/api/v1/projects/{project_id}/chords").status_code == 200
+    assert client.get(f"/api/v1/projects/{project_id}/lyrics").status_code == 200
+    assert client.get(f"/api/v1/projects/{project_id}/sections").status_code == 200
+
+    tab_response = client.get(f"/api/v1/projects/{project_id}/tabs/tab_missing")
+    assert tab_response.status_code == 404
+    assert tab_response.json()["error"]["code"] == "TAB_IMPORT_NOT_FOUND"

--- a/apps/backend/tests/test_sync_project_status_api.py
+++ b/apps/backend/tests/test_sync_project_status_api.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.services.sync_identity import source_hash_to_project_id
+
+
+def _create_project(tmp_path: Path, *, project_id: str) -> str:
+    from app.db import SessionLocal
+    from app.models import Project
+
+    source_path = tmp_path / f"{project_id}.wav"
+    source_path.write_bytes(b"sync status fixture")
+    with SessionLocal() as session:
+        session.add(
+            Project(
+                id=project_id,
+                display_name="Sync Status Fixture",
+                source_sha256="a" * 64,
+                source_path=str(source_path),
+                imported_path=str(source_path),
+                duration_seconds=1.0,
+                sample_rate=44100,
+                channels=2,
+            )
+        )
+        session.commit()
+    return project_id
+
+
+def test_project_schema_exposes_default_sync_status(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    project_id = _create_project(tmp_path, project_id="proj_sync_status_default")
+
+    response = client.get(f"/api/v1/projects/{project_id}")
+
+    assert response.status_code == 200
+    project = response.json()["project"]
+    assert project["sync_status"] == "local"
+    assert project["sync_status_reason"] is None
+    assert project["sync_editable"] is True
+    assert project["sync_required_artifact_ids"] == []
+    assert project["sync_provider_device_ids"] == []
+    assert project["sync_conflict_count"] == 0
+
+
+def test_sync_project_status_update_persists_status_fields(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    project_id = _create_project(tmp_path, project_id="proj_sync_status_update")
+
+    response = client.patch(
+        f"/api/v1/sync/projects/{project_id}/status",
+        json={
+            "sync_status": "remote_available",
+            "sync_status_reason": " Available from Studio Laptop ",
+            "sync_required_artifact_ids": [" art_source ", "art_stems"],
+            "sync_provider_device_ids": [" laptop-a "],
+            "sync_conflict_count": 2,
+        },
+    )
+
+    assert response.status_code == 200
+    project = response.json()["project"]
+    assert project["sync_status"] == "remote_available"
+    assert project["sync_status_reason"] == "Available from Studio Laptop"
+    assert project["sync_editable"] is False
+    assert project["sync_required_artifact_ids"] == ["art_source", "art_stems"]
+    assert project["sync_provider_device_ids"] == ["laptop-a"]
+    assert project["sync_conflict_count"] == 2
+
+    detail_response = client.get(f"/api/v1/projects/{project_id}")
+    assert detail_response.status_code == 200
+    persisted_project = detail_response.json()["project"]
+    assert persisted_project["sync_status"] == "remote_available"
+    assert persisted_project["sync_editable"] is False
+    assert persisted_project["sync_required_artifact_ids"] == ["art_source", "art_stems"]
+
+
+def test_sync_project_status_update_rejects_unsupported_status(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    project_id = _create_project(tmp_path, project_id="proj_sync_status_invalid")
+
+    response = client.patch(
+        f"/api/v1/sync/projects/{project_id}/status",
+        json={"sync_status": "paused"},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "INVALID_REQUEST"
+
+
+def test_sync_project_status_update_creates_placeholder_from_project_metadata(
+    client: TestClient,
+) -> None:
+    source_sha256 = "b" * 64
+    project_id = source_hash_to_project_id(source_sha256)
+
+    response = client.patch(
+        f"/api/v1/sync/projects/{project_id}/status",
+        json={
+            "sync_status": "remote_available",
+            "sync_status_reason": "Available from peer.",
+            "sync_required_artifact_ids": ["art_source_audio"],
+            "sync_provider_device_ids": ["peer-a"],
+            "project": {
+                "project_id": project_id,
+                "display_name": "Remote Placeholder",
+                "source_sha256": source_sha256,
+                "duration_seconds": 12.5,
+                "sample_rate": 44100,
+                "channels": 2,
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    project = response.json()["project"]
+    assert project["id"] == project_id
+    assert project["display_name"] == "Remote Placeholder"
+    assert project["source_path"] == ""
+    assert project["imported_path"] == ""
+    assert project["sync_status"] == "remote_available"
+    assert project["sync_editable"] is False
+    assert project["sync_status_reason"] == "Available from peer."
+    assert project["sync_required_artifact_ids"] == ["art_source_audio"]
+    assert project["sync_provider_device_ids"] == ["peer-a"]
+
+
+def test_sync_project_status_update_requires_metadata_for_missing_project(
+    client: TestClient,
+) -> None:
+    response = client.patch(
+        "/api/v1/sync/projects/proj_missing/status",
+        json={"sync_status": "missing"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "SYNC_PROJECT_STATUS_MANIFEST_REQUIRED"

--- a/apps/backend/tests/test_sync_reconciliation.py
+++ b/apps/backend/tests/test_sync_reconciliation.py
@@ -29,6 +29,7 @@ from app.services.sync_reconciliation import (
     ACTION_IMPORT_PROJECT_MANIFEST,
     ACTION_NOOP,
     ACTION_RECORD_CONFLICT,
+    ACTION_UPSERT_PROJECT_STATUS,
     ITEM_ARTIFACT,
     ITEM_DELETE_TOMBSTONE,
     ITEM_ENTITY_REVISION,
@@ -234,6 +235,10 @@ def test_valid_tombstones_apply_first_and_untrusted_tombstones_are_noop(
     assert _item(plan, ITEM_DELETE_TOMBSTONE, "tomb_wrong_group").action_type == ACTION_NOOP
     assert _item(plan, ITEM_DELETE_TOMBSTONE, "tomb_revoked").status == "noop"
     assert _action(plan, ACTION_IMPORT_PROJECT_MANIFEST, ITEM_PROJECT, "proj_deleted_remote") is None
+    deleted_status = _action(plan, ACTION_UPSERT_PROJECT_STATUS, ITEM_PROJECT, "proj_deleted_remote")
+    assert deleted_status is not None
+    assert deleted_status.details["project_status"] == "deleted"
+    assert deleted_status.details["create_placeholder"] is False
     assert all(
         action.action_type == ACTION_APPLY_DELETE_TOMBSTONE
         for action in plan.actions[:2]
@@ -501,6 +506,24 @@ def test_missing_project_import_requires_manifest_and_source_availability(
     assert _item(plan, ITEM_PROJECT, missing_project_id).status == "missing_provider"
     assert _item(plan, ITEM_PROJECT, no_manifest_project_id).status == "missing_provider"
     assert _item(plan, ITEM_ARTIFACT, "art_no_manifest").status == "missing_provider"
+    provider_status = _action(
+        plan,
+        ACTION_UPSERT_PROJECT_STATUS,
+        ITEM_PROJECT,
+        remote_provider_project_id,
+    )
+    assert provider_status is not None
+    assert provider_status.provider_device_id == "peer-a"
+    assert provider_status.details["project_status"] == "remote_available"
+    assert provider_status.details["edit_locked"] is True
+    assert provider_status.details["remote_metadata"]["source_sha256"] == remote_provider_hash
+    missing_status = _action(plan, ACTION_UPSERT_PROJECT_STATUS, ITEM_PROJECT, missing_project_id)
+    assert missing_status is not None
+    assert missing_status.details["project_status"] == "missing"
+    no_manifest_status = _action(plan, ACTION_UPSERT_PROJECT_STATUS, ITEM_PROJECT, no_manifest_project_id)
+    assert no_manifest_status is not None
+    assert no_manifest_status.details["project_status"] == "missing"
+    assert _action(plan, ACTION_UPSERT_PROJECT_STATUS, ITEM_PROJECT, duplicate_project_id) is None
     assert _action(plan, ACTION_IMPORT_PROJECT_MANIFEST, ITEM_PROJECT, duplicate_project_id) is not None
     assert (
         _action(plan, ACTION_FETCH_ARTIFACT_CONTENT, ITEM_ARTIFACT, f"art_source_{remote_provider_project_id}")
@@ -509,6 +532,46 @@ def test_missing_project_import_requires_manifest_and_source_availability(
     assert _action(plan, ACTION_IMPORT_PROJECT_MANIFEST, ITEM_PROJECT, remote_provider_project_id) is not None
     assert _action(plan, ACTION_FETCH_ARTIFACT_CONTENT, ITEM_ARTIFACT, "art_no_manifest") is None
     assert _action(plan, ACTION_IMPORT_ARTIFACT_MANIFEST, ITEM_ARTIFACT, "art_no_manifest") is None
+
+
+def test_existing_sync_placeholder_still_plans_manifest_import(
+    db_session: Session,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash = _sha("placeholder source")
+    project_id = source_hash_to_project_id(source_hash)
+    placeholder = Project(
+        id=project_id,
+        display_name="Remote Placeholder",
+        source_sha256=source_hash,
+        source_path="",
+        imported_path="",
+    )
+    placeholder.sync_status = "remote_available"
+    placeholder.sync_required_artifact_ids_json = [f"art_source_{project_id}"]
+    placeholder.sync_provider_device_ids_json = ["peer-a"]
+    db_session.add(placeholder)
+    db_session.commit()
+
+    request = {
+        "remote_library": {
+            "projects": [{"project_id": project_id, "source_sha256": source_hash}],
+        },
+        "project_manifests": [_project_manifest(project_id, source_hash)],
+        "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [source_hash]}],
+    }
+
+    plan = plan_sync_reconciliation(db_session, request)
+
+    placeholder_item = _item(plan, ITEM_PROJECT, project_id)
+    assert placeholder_item.status == "remote_available"
+    assert placeholder_item.action_type == ACTION_IMPORT_PROJECT_MANIFEST
+    status_action = _action(plan, ACTION_UPSERT_PROJECT_STATUS, ITEM_PROJECT, project_id)
+    assert status_action is not None
+    assert status_action.details["project_status"] == "remote_available"
+    assert _action(plan, ACTION_FETCH_ARTIFACT_CONTENT, ITEM_ARTIFACT, f"art_source_{project_id}") is not None
+    assert _action(plan, ACTION_IMPORT_PROJECT_MANIFEST, ITEM_PROJECT, project_id) is not None
+    assert _action(plan, ACTION_IMPORT_ARTIFACT_MANIFEST, ITEM_ARTIFACT, f"art_source_{project_id}") is None
 
 
 def test_missing_project_import_requires_every_manifest_artifact_available(
@@ -565,6 +628,13 @@ def test_missing_project_import_requires_every_manifest_artifact_available(
 
     available_project = _item(plan, ITEM_PROJECT, available_project_id)
     assert available_project.status == "remote_available"
+    available_status = _action(plan, ACTION_UPSERT_PROJECT_STATUS, ITEM_PROJECT, available_project_id)
+    assert available_status is not None
+    assert available_status.details["project_status"] == "remote_available"
+    assert available_status.details["status_details"]["artifact_providers"] == {
+        f"art_source_{available_project_id}": "peer-a",
+        "art_stem_available": "peer-a",
+    }
     assert _action(plan, ACTION_FETCH_ARTIFACT_CONTENT, ITEM_ARTIFACT, f"art_source_{available_project_id}") is not None
     assert _action(plan, ACTION_FETCH_ARTIFACT_CONTENT, ITEM_ARTIFACT, "art_stem_available") is not None
     assert _action(plan, ACTION_IMPORT_PROJECT_MANIFEST, ITEM_PROJECT, available_project_id) is not None
@@ -579,6 +649,10 @@ def test_missing_project_import_requires_every_manifest_artifact_available(
     blocked_project = _item(plan, ITEM_PROJECT, blocked_project_id)
     assert blocked_project.status == "missing_provider"
     assert blocked_project.details == {"artifact_ids": ["art_stem_blocked"]}
+    blocked_status = _action(plan, ACTION_UPSERT_PROJECT_STATUS, ITEM_PROJECT, blocked_project_id)
+    assert blocked_status is not None
+    assert blocked_status.details["project_status"] == "missing"
+    assert blocked_status.details["status_details"] == {"artifact_ids": ["art_stem_blocked"]}
     assert _action(plan, ACTION_IMPORT_PROJECT_MANIFEST, ITEM_PROJECT, blocked_project_id) is None
     assert _action(plan, ACTION_FETCH_ARTIFACT_CONTENT, ITEM_ARTIFACT, f"art_source_{blocked_project_id}") is None
     assert _action(plan, ACTION_IMPORT_ARTIFACT_MANIFEST, ITEM_ARTIFACT, "art_stem_blocked") is None
@@ -640,6 +714,10 @@ def test_missing_project_manifest_source_artifact_must_match_import_contract(
     assert item.status == "conflicted"
     assert item.action_type == ACTION_RECORD_CONFLICT
     assert item.reason == expected_reason
+    status_action = _action(plan, ACTION_UPSERT_PROJECT_STATUS, ITEM_PROJECT, project_id)
+    assert status_action is not None
+    assert status_action.details["project_status"] == "conflicted"
+    assert status_action.details["lock_reason"] == expected_reason
     assert _action(plan, ACTION_IMPORT_PROJECT_MANIFEST, ITEM_PROJECT, project_id) is None
     assert _action(plan, ACTION_RECORD_CONFLICT, ITEM_PROJECT, project_id) is not None
 

--- a/apps/desktop/src/App.library.test.tsx
+++ b/apps/desktop/src/App.library.test.tsx
@@ -97,6 +97,55 @@ describe("Desktop app library", () => {
     expect(within(openLink).queryByText(/\[Sa-dxgZt4rY\]\.webm/i)).not.toBeInTheDocument();
   });
 
+  it("shows non-local sync status on library rows and treats missing sync fields as local", async () => {
+    const updatedAt = "2026-04-21T02:59:00.000000";
+
+    setProjects([
+      {
+        id: "proj_remote",
+        display_name: "Remote Demo",
+        source_path: "/tmp/remote-demo.wav",
+        imported_path: "/tmp/projects/remote-demo.wav",
+        duration_seconds: 219,
+        sample_rate: 44100,
+        channels: 2,
+        created_at: updatedAt,
+        updated_at: updatedAt,
+        sync_status: "remote_available",
+        sync_editable: false,
+        sync_status_reason: "Download source audio before editing.",
+      },
+      {
+        id: "proj_local",
+        display_name: "Legacy Local",
+        source_path: "/tmp/legacy-local.wav",
+        imported_path: "/tmp/projects/legacy-local.wav",
+        duration_seconds: 95,
+        sample_rate: 44100,
+        channels: 2,
+        created_at: updatedAt,
+        updated_at: updatedAt,
+      },
+    ]);
+
+    renderApp(["/"]);
+
+    const remoteCard = (await screen.findByRole("heading", { name: "Remote Demo", level: 2 })).closest(
+      "article",
+    );
+    const localCard = screen.getByRole("heading", { name: "Legacy Local", level: 2 }).closest("article");
+    expect(remoteCard).not.toBeNull();
+    expect(localCard).not.toBeNull();
+
+    expect(within(remoteCard as HTMLElement).getByText("Remote Available")).toBeInTheDocument();
+    expect(
+      within(remoteCard as HTMLElement).getByLabelText(
+        "Sync status: Remote Available. Download source audio before editing.",
+      ),
+    ).toBeInTheDocument();
+    expect(within(localCard as HTMLElement).queryByText("Local")).not.toBeInTheDocument();
+  });
+
   it("imports track from library and opens project", async () => {
     const user = userEvent.setup();
     mockOpen.mockResolvedValue("/tmp/new-song.mp4");

--- a/apps/desktop/src/App.project-analysis-mix.test.tsx
+++ b/apps/desktop/src/App.project-analysis-mix.test.tsx
@@ -16,6 +16,8 @@ import {
   mockCreatePreview,
   mockCreateStems,
   mockCreateTabImport,
+  mockDeleteProject,
+  mockCreateExport,
   mockUpdateLyrics,
   mockUpdateProject,
   renderApp,
@@ -23,6 +25,7 @@ import {
   setProjectAnalysis,
   setProjectChords,
   setProjectLyrics,
+  setProjects,
 } from "./test/appTestHarness";
 
 describe("Desktop app project analysis mix", () => {
@@ -125,6 +128,73 @@ describe("Desktop app project analysis mix", () => {
     await user.click(screen.getByRole("button", { name: "Analyze Track" }));
 
     expect(mockAnalyzeProject).toHaveBeenCalledWith("proj_123");
+  });
+
+  it("shows sync lock reason and disables project mutation controls for locked projects", async () => {
+    const user = userEvent.setup();
+    setProjects([
+      {
+        id: "proj_123",
+        display_name: "Demo Song",
+        source_key_override: null,
+        source_path: "/tmp/demo.wav",
+        imported_path: "/tmp/app/demo-song.wav",
+        duration_seconds: 182,
+        sample_rate: 44100,
+        channels: 2,
+        created_at: "2026-04-18T13:16:00.000Z",
+        updated_at: "2026-04-18T13:16:00.000Z",
+        sync_status: "remote_available",
+        sync_editable: false,
+        sync_status_reason: "Download source audio before editing.",
+      },
+    ]);
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    expect(screen.getByText("Remote Available")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Download source audio before editing.");
+
+    const renameButton = screen.getByRole("button", { name: "Rename" });
+    expect(renameButton).toBeDisabled();
+    fireEvent.click(renameButton);
+    expect(mockUpdateProject).not.toHaveBeenCalled();
+
+    await openStudioPanel(user);
+    const analyzeButton = screen.getByRole("button", { name: "Analyze Track" });
+    expect(analyzeButton).toBeDisabled();
+    fireEvent.click(analyzeButton);
+    expect(mockAnalyzeProject).not.toHaveBeenCalled();
+
+    expect(screen.getByRole("button", { name: "Refresh Chords" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Refresh Lyrics" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Generate Stems" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Create Mix" })).toBeDisabled();
+
+    await openAnalysisPanel(user);
+    const sourceKeyButton = screen.getByRole("button", { name: "Project Source Key" });
+    expect(sourceKeyButton).toBeDisabled();
+    fireEvent.click(sourceKeyButton);
+    expect(screen.queryByRole("listbox", { name: "Project Source Key options" })).not.toBeInTheDocument();
+
+    const exportButton = screen.getByRole("button", { name: "Export Selected Audio" });
+    expect(exportButton).toBeDisabled();
+    fireEvent.click(exportButton);
+    expect(mockCreateExport).not.toHaveBeenCalled();
+
+    const deleteProjectButton = screen.getByRole("button", { name: "Delete Project" });
+    expect(deleteProjectButton).toBeDisabled();
+    fireEvent.click(deleteProjectButton);
+    expect(mockDeleteProject).not.toHaveBeenCalled();
+
+    await openPlaybackWorkspace(user);
+    expect(screen.getByRole("button", { name: "Edit Lyrics" })).toBeDisabled();
+    const importTabButton = screen.getByRole("button", { name: "Import Tab" });
+    expect(importTabButton).toBeDisabled();
+    fireEvent.click(importTabButton);
+    expect(mockCreateTabImport).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog", { name: "Import tab suggestions" })).not.toBeInTheDocument();
   });
 
   it("surfaces detected tempo in the analysis panel", async () => {

--- a/apps/desktop/src/features/projects/LibraryView.tsx
+++ b/apps/desktop/src/features/projects/LibraryView.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { open } from "@tauri-apps/plugin-dialog";
 import { Music2, Upload } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
-import { api, type ProjectSchema } from "../../lib/api";
+import { api, getProjectSyncSummary, type ProjectSchema } from "../../lib/api";
 import { formatLocalDateTime, normalizeApiDateTime } from "../../lib/datetime";
 import { usePreferences } from "../../lib/preferences";
 import { useChordBackendActionSelection } from "./hooks/useChordBackendActionSelection";
@@ -33,6 +33,8 @@ function ProjectCard({ project }: { project: ProjectSchema }) {
   const updatedAtLabel = formatUpdatedAt(project.updated_at);
   const normalizedUpdatedAt = normalizeApiDateTime(project.updated_at);
   const fileType = project.source_path.split(".").pop()?.toUpperCase() ?? "Audio";
+  const syncSummary = getProjectSyncSummary(project);
+  const syncReason = syncSummary.lockReason ? ` ${syncSummary.lockReason}` : "";
 
   return (
     <article className="project-card project-library-row">
@@ -46,7 +48,18 @@ function ProjectCard({ project }: { project: ProjectSchema }) {
         </span>
 
         <div className="project-card__title-block">
-          <h2>{project.display_name}</h2>
+          <div className="project-card__title-row">
+            <h2>{project.display_name}</h2>
+            {!syncSummary.isLocal || syncSummary.isLocked ? (
+              <span
+                aria-label={`Sync status: ${syncSummary.label}.${syncReason}`}
+                className={`sync-status-badge sync-status-badge--${syncSummary.state}`}
+                title={syncSummary.lockReason ?? undefined}
+              >
+                {syncSummary.label}
+              </span>
+            ) : null}
+          </div>
           {informationDensity === "detailed" ? (
             <span className="artifact-meta">{project.source_path}</span>
           ) : null}

--- a/apps/desktop/src/features/projects/components/InspectorPanel.tsx
+++ b/apps/desktop/src/features/projects/components/InspectorPanel.tsx
@@ -32,7 +32,9 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
     lowerTargetPreview,
     lowerTargetShiftOptions,
     previewMutation,
+    projectEditLocked,
     projectQuery,
+    projectSyncLockReason,
     referenceHz,
     retuneMode,
     selectedPrimaryStemArtifacts,
@@ -65,6 +67,7 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
     tuningSummary,
   } = useProjectViewModelContext();
   const { launchMetronome } = useMetronome();
+  const editLockTitle = projectSyncLockReason ?? undefined;
   const tempoBpm = analysisQuery.data?.tempo_bpm;
   const canOpenMetronome = typeof tempoBpm === "number" && Number.isFinite(tempoBpm);
   const estimatedReferenceHz = analysisQuery.data?.estimated_reference_hz;
@@ -135,9 +138,11 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
                   key={modeOption.value}
                   className="button button--small mix-builder__mode-button"
                   aria-pressed={retuneMode === modeOption.value}
+                  disabled={projectEditLocked}
                   onClick={() =>
                     setRetuneMode(modeOption.value as "off" | "reference" | "cents")
                   }
+                  title={editLockTitle}
                   type="button"
                 >
                   {modeOption.label}
@@ -150,6 +155,7 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
                 <span>Target Reference Hz</span>
                 <input
                   aria-label="Target Reference Hz"
+                  disabled={projectEditLocked}
                   value={referenceHz}
                   onChange={(event) => setReferenceHz(event.target.value)}
                   type="number"
@@ -163,6 +169,7 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
                 <span>Cents Offset</span>
                 <input
                   aria-label="Cents Offset"
+                  disabled={projectEditLocked}
                   value={centsOffset}
                   onChange={(event) => setCentsOffset(event.target.value)}
                   type="number"
@@ -215,6 +222,7 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
             <TargetKeySelector
               currentKey={targetKey}
               currentMeta={targetSelectionSummary}
+              disabled={projectEditLocked}
               enharmonicDisplayMode={enharmonicDisplayMode}
               headingLabel="Target Selection"
               higherButtonLabel="Raise target key"
@@ -252,7 +260,8 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
           <button
             className="button button--primary"
             onClick={() => previewMutation.mutate()}
-            disabled={previewMutation.isPending || !hasTransformChange}
+            disabled={projectEditLocked || previewMutation.isPending || !hasTransformChange}
+            title={editLockTitle}
             type="button"
           >
             {previewMutation.isPending ? "Queueing..." : "Create Mix"}
@@ -352,11 +361,15 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
                   aria-label="Project Source Key"
                   aria-expanded={sourceKeySelectorOpen}
                   aria-haspopup="listbox"
-                  disabled={sourceKeyOverrideMutation.isPending}
+                  disabled={projectEditLocked || sourceKeyOverrideMutation.isPending}
                   onClick={() => {
+                    if (projectEditLocked) {
+                      return;
+                    }
                     setTargetSelectorOpen(false);
                     setSourceKeySelectorOpen((current) => !current);
                   }}
+                  title={editLockTitle}
                   type="button"
                 >
                   <span className="source-key-selector__current">
@@ -397,8 +410,11 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
                           className={`source-key-selector__option${
                             isSelected ? " source-key-selector__option--selected" : ""
                           }`}
-                          disabled={sourceKeyOverrideMutation.isPending}
+                          disabled={projectEditLocked || sourceKeyOverrideMutation.isPending}
                           onClick={() => {
+                            if (projectEditLocked) {
+                              return;
+                            }
                             sourceKeyOverrideMutation.mutate(
                               option.value === "auto" ? null : option.value,
                             );
@@ -445,7 +461,8 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
         <button
           className="button"
           onClick={() => exportMutation.mutate()}
-          disabled={exportMutation.isPending}
+          disabled={projectEditLocked || exportMutation.isPending}
+          title={editLockTitle}
           type="button"
         >
           {exportMutation.isPending ? "Queueing..." : "Export Selected Audio"}
@@ -508,7 +525,8 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
           <button
             className="button button--ghost button--small"
             onClick={handleDeleteProject}
-            disabled={deleteMutation.isPending}
+            disabled={projectEditLocked || deleteMutation.isPending}
+            title={editLockTitle}
             type="button"
           >
             Delete Project
@@ -517,6 +535,7 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
             className="button button--ghost button--small"
             onClick={handleDeleteAllMixes}
             disabled={!canDeleteAnyMixes || isDeleteMixDisabled}
+            title={editLockTitle}
             type="button"
           >
             {isDeleteArtifactsPending ? "Deleting..." : "Delete All Mixes"}
@@ -525,6 +544,7 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
             className="button button--ghost button--small"
             onClick={handleDeleteAllStems}
             disabled={!canDeleteAnyStems || isDeleteStemDisabled}
+            title={editLockTitle}
             type="button"
           >
             {deleteStemMutation.isPending ? "Deleting..." : "Delete All Stems"}
@@ -534,6 +554,7 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
               className="button button--ghost button--small"
               onClick={handleDeleteSelectedPrimaryStems}
               disabled={!selectedPrimaryStemArtifacts.length || isDeleteStemDisabled}
+              title={editLockTitle}
               type="button"
             >
               {deleteStemMutation.isPending ? "Deleting..." : selectedPrimaryStemDeleteLabel}

--- a/apps/desktop/src/features/projects/components/PlaybackPracticeSurface.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackPracticeSurface.tsx
@@ -61,6 +61,8 @@ function PlaybackModeHeader() {
     lyricsFollowEnabled,
     lyricsMutation,
     playbackDisplayMode,
+    projectEditLocked,
+    projectSyncLockReason,
     selectedTabSuggestionId,
     setIsEditingLyrics,
     setLyricsDraft,
@@ -113,10 +115,14 @@ function PlaybackModeHeader() {
                 className="button button--ghost button--small"
                 type="button"
                 onClick={() => {
+                  if (projectEditLocked) {
+                    return;
+                  }
                   setLyricsDraft(displayedLyrics.map((segment) => segment.text));
                   setIsEditingLyrics(true);
                 }}
-                disabled={lyricsMutation.isPending || isLyricsRunning}
+                disabled={projectEditLocked || lyricsMutation.isPending || isLyricsRunning}
+                title={projectSyncLockReason ?? undefined}
               >
                 Edit Lyrics
               </button>
@@ -125,6 +131,8 @@ function PlaybackModeHeader() {
               className="button button--ghost button--small"
               type="button"
               onClick={handleOpenTabImport}
+              disabled={projectEditLocked}
+              title={projectSyncLockReason ?? undefined}
             >
               Import Tab
             </button>
@@ -163,6 +171,8 @@ function PlaybackModeHeader() {
           applyMutation={tabImportApplyMutation}
           draft={tabImportDraft}
           importMutation={tabImportMutation}
+          isProjectLocked={projectEditLocked}
+          lockReason={projectSyncLockReason}
           onAcceptGroup={handleAcceptTabSuggestionGroup}
           onApply={handleApplyTabSuggestions}
           onClose={handleCloseTabImport}
@@ -182,6 +192,8 @@ function TabImportDialog({
   applyMutation,
   draft,
   importMutation,
+  isProjectLocked,
+  lockReason,
   onAcceptGroup,
   onApply,
   onClose,
@@ -195,6 +207,8 @@ function TabImportDialog({
   applyMutation: ReturnType<typeof useProjectViewModelContext>["tabImportApplyMutation"];
   draft: string;
   importMutation: ReturnType<typeof useProjectViewModelContext>["tabImportMutation"];
+  isProjectLocked: boolean;
+  lockReason: string | null;
   onAcceptGroup: (suggestionIds: string[]) => void;
   onApply: () => void;
   onClose: () => void;
@@ -239,22 +253,29 @@ function TabImportDialog({
             value={draft}
             onChange={(event) => onSetDraft(event.currentTarget.value)}
             placeholder={"[Verse]\nG       D\nHello from the first line"}
+            disabled={isProjectLocked}
           />
         </label>
 
         <div className="button-row tab-import-actions">
           <button
             className="button button--primary button--small"
-            disabled={!draft.trim() || importMutation.isPending || applyMutation.isPending}
+            disabled={
+              isProjectLocked || !draft.trim() || importMutation.isPending || applyMutation.isPending
+            }
             onClick={onCreateProposal}
+            title={lockReason ?? undefined}
             type="button"
           >
             {importMutation.isPending ? "Reading..." : "Create Suggestions"}
           </button>
           <button
             className="button button--ghost button--small"
-            disabled={acceptedCount === 0 || importMutation.isPending || applyMutation.isPending}
+            disabled={
+              isProjectLocked || acceptedCount === 0 || importMutation.isPending || applyMutation.isPending
+            }
             onClick={onApply}
+            title={lockReason ?? undefined}
             type="button"
           >
             {applyMutation.isPending ? "Applying..." : `Apply Accepted (${acceptedCount})`}
@@ -271,7 +292,9 @@ function TabImportDialog({
                 <TabSuggestionGroup
                   acceptedSuggestionIds={acceptedSuggestionIds}
                   group={group}
+                  isProjectLocked={isProjectLocked}
                   key={group.kind}
+                  lockReason={lockReason}
                   onAcceptGroup={onAcceptGroup}
                   onRejectGroup={onRejectGroup}
                   onSelectSuggestion={onSelectSuggestion}
@@ -292,6 +315,8 @@ function TabImportDialog({
 function TabSuggestionGroup({
   acceptedSuggestionIds,
   group,
+  isProjectLocked,
+  lockReason,
   onAcceptGroup,
   onRejectGroup,
   onSelectSuggestion,
@@ -300,6 +325,8 @@ function TabSuggestionGroup({
 }: {
   acceptedSuggestionIds: string[];
   group: TabSuggestionGroupSchema;
+  isProjectLocked: boolean;
+  lockReason: string | null;
   onAcceptGroup: (suggestionIds: string[]) => void;
   onRejectGroup: (suggestionIds: string[]) => void;
   onSelectSuggestion: (suggestionId: string | null) => void;
@@ -319,16 +346,18 @@ function TabSuggestionGroup({
         <div className="button-row">
           <button
             className="button button--ghost button--small"
-            disabled={!suggestionIds.length}
+            disabled={isProjectLocked || !suggestionIds.length}
             onClick={() => onAcceptGroup(suggestionIds)}
+            title={lockReason ?? undefined}
             type="button"
           >
             Accept Group
           </button>
           <button
             className="button button--ghost button--small"
-            disabled={!suggestionIds.length}
+            disabled={isProjectLocked || !suggestionIds.length}
             onClick={() => onRejectGroup(suggestionIds)}
+            title={lockReason ?? undefined}
             type="button"
           >
             Reject Group
@@ -348,6 +377,7 @@ function TabSuggestionGroup({
               <input
                 aria-label={`Accept ${suggestion.title}`}
                 checked={accepted}
+                disabled={isProjectLocked}
                 onChange={() => onToggleSuggestion(suggestion.id)}
                 type="checkbox"
               />
@@ -511,6 +541,8 @@ function LyricsEditor() {
     displayedLyrics,
     lyricsDraft,
     lyricsSaveMutation,
+    projectEditLocked,
+    projectSyncLockReason,
     setIsEditingLyrics,
     setLyricsDraft,
   } = useProjectViewModelContext();
@@ -525,6 +557,7 @@ function LyricsEditor() {
           <textarea
             aria-label={`Lyric segment ${index + 1}`}
             className="lyrics-editor__input"
+            disabled={projectEditLocked}
             value={lyricsDraft[index] ?? ""}
             onChange={(event) => {
               const nextValue = event.currentTarget.value;
@@ -544,7 +577,8 @@ function LyricsEditor() {
           className="button button--primary button--small"
           type="button"
           onClick={() => lyricsSaveMutation.mutate()}
-          disabled={lyricsSaveMutation.isPending}
+          disabled={projectEditLocked || lyricsSaveMutation.isPending}
+          title={projectSyncLockReason ?? undefined}
         >
           {lyricsSaveMutation.isPending ? "Saving..." : "Save Lyrics"}
         </button>

--- a/apps/desktop/src/features/projects/components/ProcessingPanel.tsx
+++ b/apps/desktop/src/features/projects/components/ProcessingPanel.tsx
@@ -8,6 +8,7 @@ export function ProcessingPanel() {
     canGenerateLyrics,
     canGenerateStems,
     chordMutation,
+    handleAnalyzeAction,
     handleChordAction,
     handleLyricsAction,
     handleStemAction,
@@ -21,16 +22,23 @@ export function ProcessingPanel() {
     isStemRunning,
     lyricsMutation,
     mobileGenerationMessage,
+    projectEditLocked,
+    projectSyncLockReason,
     selectedPrimaryArtifactId,
     showSupportingCopy,
     stemMutation,
   } = useProjectViewModelContext();
 
-  const analyzeDisabled = analyzeMutation.isPending || isAnalysisRunning || !canAnalyze;
+  const analyzeDisabled = projectEditLocked || analyzeMutation.isPending || isAnalysisRunning || !canAnalyze;
   const lyricsDisabled = lyricsMutation.isPending || isLyricsRunning || !canGenerateLyrics;
   const chordsDisabled = chordMutation.isPending || isChordRunning || !canGenerateChords;
   const stemsDisabled =
-    stemMutation.isPending || isStemRunning || !selectedPrimaryArtifactId || !canGenerateStems;
+    projectEditLocked ||
+    stemMutation.isPending ||
+    isStemRunning ||
+    !selectedPrimaryArtifactId ||
+    !canGenerateStems;
+  const editLockTitle = projectSyncLockReason ?? undefined;
 
   return (
     <div className="panel processing-panel">
@@ -51,7 +59,8 @@ export function ProcessingPanel() {
         <button
           className="button button--small"
           disabled={analyzeDisabled}
-          onClick={() => analyzeMutation.mutate()}
+          onClick={handleAnalyzeAction}
+          title={editLockTitle}
           type="button"
         >
           {analyzeMutation.isPending || isAnalysisRunning ? "Analyzing..." : "Analyze Track"}
@@ -60,6 +69,7 @@ export function ProcessingPanel() {
           className="button button--small"
           disabled={chordsDisabled}
           onClick={() => void handleChordAction()}
+          title={editLockTitle}
           type="button"
         >
           {chordMutation.isPending || isChordRunning
@@ -72,6 +82,7 @@ export function ProcessingPanel() {
           className="button button--small"
           disabled={lyricsDisabled}
           onClick={() => void handleLyricsAction()}
+          title={editLockTitle}
           type="button"
         >
           {lyricsMutation.isPending || isLyricsRunning
@@ -84,6 +95,7 @@ export function ProcessingPanel() {
           className="button button--small"
           disabled={stemsDisabled}
           onClick={() => void handleStemAction()}
+          title={editLockTitle}
           type="button"
         >
           {stemMutation.isPending || isStemRunning

--- a/apps/desktop/src/features/projects/components/ProjectHeader.tsx
+++ b/apps/desktop/src/features/projects/components/ProjectHeader.tsx
@@ -6,12 +6,17 @@ export function ProjectHeader() {
     activeWorkspace,
     draftName,
     isRenaming,
+    projectEditLocked,
     projectQuery,
+    projectSyncLockReason,
+    projectSyncSummary,
     renameMutation,
     setDraftName,
     setIsRenaming,
     showSupportingCopy,
   } = useProjectViewModelContext();
+  const showSyncStatus = !projectSyncSummary.isLocal || projectSyncSummary.isLocked;
+  const syncReason = projectSyncLockReason ? ` ${projectSyncLockReason}` : "";
 
   return (
     <div
@@ -28,6 +33,7 @@ export function ProjectHeader() {
             <input
               aria-label="Project name"
               className="title-input"
+              disabled={projectEditLocked || renameMutation.isPending}
               value={draftName}
               onChange={(event) => setDraftName(event.target.value)}
             />
@@ -36,7 +42,7 @@ export function ProjectHeader() {
                 className="button button--primary button--small"
                 type="button"
                 onClick={() => renameMutation.mutate()}
-                disabled={renameMutation.isPending || !draftName.trim()}
+                disabled={projectEditLocked || renameMutation.isPending || !draftName.trim()}
               >
                 {renameMutation.isPending ? "Saving..." : "Save"}
               </button>
@@ -56,15 +62,30 @@ export function ProjectHeader() {
         ) : (
           <div className="title-row">
             <h1>{projectQuery.data?.display_name ?? "Project"}</h1>
+            {showSyncStatus ? (
+              <span
+                aria-label={`Sync status: ${projectSyncSummary.label}.${syncReason}`}
+                className={`sync-status-badge sync-status-badge--${projectSyncSummary.state}`}
+                title={projectSyncLockReason ?? undefined}
+              >
+                {projectSyncSummary.label}
+              </span>
+            ) : null}
             <button
               className="button button--ghost button--small"
               type="button"
               onClick={() => setIsRenaming(true)}
+              disabled={projectEditLocked}
             >
               Rename
             </button>
           </div>
         )}
+        {projectSyncLockReason ? (
+          <p className="project-sync-lock-reason" role="status">
+            {projectSyncLockReason}
+          </p>
+        ) : null}
         {showSupportingCopy && activeWorkspace === "project" ? (
           <p className="screen__subtitle">
             Move between project tools and playback workspace without losing transport context.

--- a/apps/desktop/src/features/projects/components/SourcesRail.tsx
+++ b/apps/desktop/src/features/projects/components/SourcesRail.tsx
@@ -12,6 +12,7 @@ export function SourcesRail() {
     isDeleteMixDisabled,
     isDeleteStemDisabled,
     previewArtifacts,
+    projectSyncLockReason,
     selectedArtifactId,
     selectedPrimaryArtifactId,
     setDismissedStemJobIds,
@@ -25,6 +26,7 @@ export function SourcesRail() {
     stemOutputLabel,
     visibleStemArtifacts,
   } = useProjectViewModelContext();
+  const editLockTitle = projectSyncLockReason ?? undefined;
 
   return (
     <aside className={`stack sources-rail${sourcesRailCollapsed ? " sources-rail--collapsed" : ""}`}>
@@ -133,7 +135,7 @@ export function SourcesRail() {
                         className="button button--ghost button--small artifact-action-row__delete"
                         disabled={isDeleteMixDisabled || artifact.can_delete === false}
                         onClick={() => void handleDeleteMix(artifact)}
-                        title="Delete saved mix"
+                        title={editLockTitle ?? "Delete saved mix"}
                         type="button"
                       >
                         <Trash2 aria-hidden="true" className="artifact-action-row__delete-icon" />
@@ -181,7 +183,7 @@ export function SourcesRail() {
                         className="button button--ghost button--small artifact-action-row__delete"
                         disabled={isDeleteStemDisabled || artifact.can_delete === false}
                         onClick={() => void handleDeleteStem(artifact)}
-                        title="Delete stem track"
+                        title={editLockTitle ?? "Delete stem track"}
                         type="button"
                       >
                         <Trash2 aria-hidden="true" className="artifact-action-row__delete-icon" />

--- a/apps/desktop/src/features/projects/components/TargetKeySelector.tsx
+++ b/apps/desktop/src/features/projects/components/TargetKeySelector.tsx
@@ -11,6 +11,7 @@ import {
 type TargetKeySelectorProps = {
   currentKey: MusicalKey;
   currentMeta: string;
+  disabled?: boolean;
   enharmonicDisplayMode: EnharmonicDisplayMode;
   headingLabel: string;
   higherButtonLabel: string;
@@ -35,6 +36,7 @@ type TargetKeySelectorProps = {
 export function TargetKeySelector({
   currentKey,
   currentMeta,
+  disabled = false,
   enharmonicDisplayMode,
   headingLabel,
   higherButtonLabel,
@@ -67,7 +69,7 @@ export function TargetKeySelector({
         <button
           className="button"
           aria-label={lowerButtonLabel}
-          disabled={value <= MIN_TARGET_TRANSPOSE}
+          disabled={disabled || value <= MIN_TARGET_TRANSPOSE}
           onClick={() => {
             setIsOpen(false);
             setSemitones((current) => clampTargetTranspose(current - 1));
@@ -85,6 +87,7 @@ export function TargetKeySelector({
               aria-label={selectorLabel}
               aria-expanded={isOpen}
               aria-haspopup="listbox"
+              disabled={disabled}
               onClick={() => setIsOpen((current) => !current)}
               type="button"
             >
@@ -161,6 +164,7 @@ export function TargetKeySelector({
                     }`}
                     role="option"
                     aria-selected={option.semitones === value}
+                    disabled={disabled}
                     onClick={() => {
                       setSemitones(option.semitones);
                       setIsOpen(false);
@@ -196,6 +200,7 @@ export function TargetKeySelector({
                   }`}
                   role="option"
                   aria-selected={value === 0}
+                  disabled={disabled}
                   onClick={() => {
                     setSemitones(0);
                     setIsOpen(false);
@@ -232,6 +237,7 @@ export function TargetKeySelector({
                     }`}
                     role="option"
                     aria-selected={option.semitones === value}
+                    disabled={disabled}
                     onClick={() => {
                       setSemitones(option.semitones);
                       setIsOpen(false);
@@ -259,7 +265,7 @@ export function TargetKeySelector({
         <button
           className="button"
           aria-label={higherButtonLabel}
-          disabled={value >= MAX_TARGET_TRANSPOSE}
+          disabled={disabled || value >= MAX_TARGET_TRANSPOSE}
           onClick={() => {
             setIsOpen(false);
             setSemitones((current) => clampTargetTranspose(current + 1));

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -2,7 +2,12 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
 import { confirm, save } from "@tauri-apps/plugin-dialog";
-import { api, type ArtifactSchema, type ProjectSchema } from "../../../lib/api";
+import {
+  api,
+  getProjectSyncSummary,
+  type ArtifactSchema,
+  type ProjectSchema,
+} from "../../../lib/api";
 import { usePreferences } from "../../../lib/preferences";
 import {
   normalizeAnalysisTimingGrid,
@@ -275,11 +280,26 @@ export function useProjectViewModel() {
     queryFn: async () => api.getMobileCapabilities(),
     staleTime: Infinity,
   });
+  const projectSyncSummary = useMemo(
+    () => getProjectSyncSummary(projectQuery.data),
+    [projectQuery.data],
+  );
+  const projectEditLocked = projectSyncSummary.isLocked;
+  const projectSyncLockReason = projectSyncSummary.lockReason;
+
+  function assertProjectEditable() {
+    if (projectEditLocked) {
+      throw new Error(projectSyncLockReason ?? "This project is locked for editing.");
+    }
+  }
 
   useActiveJobPolling(projectId, jobsQuery.data);
 
   const analyzeMutation = useMutation({
-    mutationFn: () => api.analyzeProject(projectId),
+    mutationFn: () => {
+      assertProjectEditable();
+      return api.analyzeProject(projectId);
+    },
     onSuccess: async () => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ["jobs"] }),
@@ -292,7 +312,10 @@ export function useProjectViewModel() {
   });
 
   const renameMutation = useMutation({
-    mutationFn: async () => api.updateProject(projectId, { display_name: draftName }),
+    mutationFn: async () => {
+      assertProjectEditable();
+      return api.updateProject(projectId, { display_name: draftName });
+    },
     onSuccess: async () => {
       setIsRenaming(false);
       await Promise.all([
@@ -303,8 +326,10 @@ export function useProjectViewModel() {
   });
 
   const sourceKeyOverrideMutation = useMutation({
-    mutationFn: async (sourceKeyOverride: string | null) =>
-      api.updateProject(projectId, { source_key_override: sourceKeyOverride }),
+    mutationFn: async (sourceKeyOverride: string | null) => {
+      assertProjectEditable();
+      return api.updateProject(projectId, { source_key_override: sourceKeyOverride });
+    },
     onMutate: async (sourceKeyOverride) => {
       await Promise.all([
         queryClient.cancelQueries({ queryKey: ["project", projectId] }),
@@ -343,6 +368,7 @@ export function useProjectViewModel() {
 
   const chordMutation = useMutation({
     mutationFn: async (overwriteUserEdits: boolean) => {
+      assertProjectEditable();
       const backendSelection = await chordBackendForAction();
       return api.createChords(projectId, {
         ...backendSelection,
@@ -359,7 +385,10 @@ export function useProjectViewModel() {
   });
 
   const lyricsMutation = useMutation({
-    mutationFn: async (force: boolean) => api.createLyrics(projectId, { force }),
+    mutationFn: async (force: boolean) => {
+      assertProjectEditable();
+      return api.createLyrics(projectId, { force });
+    },
     onSuccess: async () => {
       setIsEditingLyrics(false);
       await Promise.all([
@@ -370,10 +399,12 @@ export function useProjectViewModel() {
   });
 
   const lyricsSaveMutation = useMutation({
-    mutationFn: async () =>
-      api.updateLyrics(projectId, {
+    mutationFn: async () => {
+      assertProjectEditable();
+      return api.updateLyrics(projectId, {
         segments: lyricsDraft.map((text) => ({ text })),
-      }),
+      });
+    },
     onSuccess: async () => {
       setIsEditingLyrics(false);
       await queryClient.invalidateQueries({ queryKey: ["lyrics", projectId] });
@@ -381,7 +412,10 @@ export function useProjectViewModel() {
   });
 
   const tabImportMutation = useMutation({
-    mutationFn: async (rawText: string) => api.createTabImport(projectId, { raw_text: rawText }),
+    mutationFn: async (rawText: string) => {
+      assertProjectEditable();
+      return api.createTabImport(projectId, { raw_text: rawText });
+    },
     onSuccess: (response) => {
       const firstSuggestion =
         response.tab_import.groups?.flatMap((group) => group.suggestions ?? [])[0] ?? null;
@@ -392,6 +426,7 @@ export function useProjectViewModel() {
 
   const tabImportApplyMutation = useMutation({
     mutationFn: async () => {
+      assertProjectEditable();
       const tabImportId = tabImportMutation.data?.tab_import.id;
       if (!tabImportId) {
         throw new Error("Create tab suggestions first.");
@@ -417,6 +452,7 @@ export function useProjectViewModel() {
 
   const previewMutation = useMutation({
     mutationFn: async () => {
+      assertProjectEditable();
       if (retuneMode === "off" && transposeSemitones === 0) {
         throw new Error("Choose a tuning or key change first.");
       }
@@ -449,6 +485,7 @@ export function useProjectViewModel() {
 
   const stemMutation = useMutation({
     mutationFn: async (overwriteChordEdits: boolean) => {
+      assertProjectEditable();
       if (!selectedPrimaryArtifactId) {
         throw new Error("Select source audio or practice mix first.");
       }
@@ -474,6 +511,7 @@ export function useProjectViewModel() {
 
   const exportMutation = useMutation({
     mutationFn: async () => {
+      assertProjectEditable();
       const exportArtifact =
         selectedArtifact ??
         primaryArtifacts.find((artifact) => artifact.type === "preview_mix") ??
@@ -503,7 +541,10 @@ export function useProjectViewModel() {
   });
 
   const deleteMutation = useMutation({
-    mutationFn: () => api.deleteProject(projectId),
+    mutationFn: () => {
+      assertProjectEditable();
+      return api.deleteProject(projectId);
+    },
     onSuccess: async () => {
       dismissSession();
       clearProjectPlaybackState(projectId);
@@ -514,6 +555,7 @@ export function useProjectViewModel() {
 
   const deleteArtifactsMutation = useMutation({
     mutationFn: async (request: DeleteArtifactsRequest) => {
+      assertProjectEditable();
       for (const artifactId of Array.from(new Set(request.artifactIds))) {
         await api.deleteArtifact(projectId, artifactId);
       }
@@ -694,14 +736,18 @@ export function useProjectViewModel() {
         ? "Emulator lyrics actions are enabled for flow testing; stem generation is unavailable on this device."
         : "Side-load a Whisper model to enable local lyrics. Stem generation is unavailable on this device."
     : null;
-  const canAnalyze = !isMobileRuntime || mobileCapabilities?.analysisAvailable === true;
+  const canAnalyze =
+    !projectEditLocked && (!isMobileRuntime || mobileCapabilities?.analysisAvailable === true);
   const canGenerateLyrics =
-    !isMobileRuntime ||
-    mobileCapabilities?.whisperAvailable === true ||
-    mobileGenerationTestingAvailable;
+    !projectEditLocked &&
+    (!isMobileRuntime ||
+      mobileCapabilities?.whisperAvailable === true ||
+      mobileGenerationTestingAvailable);
   const canGenerateStems =
-    !isMobileRuntime || mobileCapabilities?.stemSeparationAvailable === true;
-  const canGenerateChords = !isMobileRuntime || mobileCapabilities?.basicChordsAvailable === true;
+    !projectEditLocked &&
+    (!isMobileRuntime || mobileCapabilities?.stemSeparationAvailable === true);
+  const canGenerateChords =
+    !projectEditLocked && (!isMobileRuntime || mobileCapabilities?.basicChordsAvailable === true);
   const currentKeyValue = sourceKeyOverride ? serializeKey(sourceKeyOverride) : "auto";
   const hasVisibleStems = visibleStemArtifacts.length > 0;
   const stemErrorMessage =
@@ -714,12 +760,14 @@ export function useProjectViewModel() {
   const canDeleteSelectedStem = isStemArtifact(selectedArtifact);
   const isDeleteArtifactsPending = deleteArtifactsMutation.isPending;
   const isDeleteStemDisabled =
+    projectEditLocked ||
     isDeleteArtifactsPending ||
     isPlaying ||
     isChordRunning ||
     isAnyStemJobRunning ||
     isAnyExportJobRunning;
   const isDeleteMixDisabled =
+    projectEditLocked ||
     isDeleteArtifactsPending ||
     isPlaying ||
     isChordRunning ||
@@ -951,7 +999,17 @@ export function useProjectViewModel() {
     handleSetPlaybackDisplayMode("combined");
   }
 
+  function handleAnalyzeAction() {
+    if (projectEditLocked) {
+      return;
+    }
+    analyzeMutation.mutate();
+  }
+
   async function handleChordAction() {
+    if (projectEditLocked) {
+      return;
+    }
     if (!canGenerateChords) {
       return;
     }
@@ -983,6 +1041,9 @@ export function useProjectViewModel() {
   }
 
   function handleOpenTabImport() {
+    if (projectEditLocked) {
+      return;
+    }
     setIsTabImportOpen(true);
   }
 
@@ -994,6 +1055,9 @@ export function useProjectViewModel() {
   }
 
   function handleCreateTabImportProposal() {
+    if (projectEditLocked) {
+      return;
+    }
     if (!tabImportDraft.trim()) {
       return;
     }
@@ -1001,6 +1065,9 @@ export function useProjectViewModel() {
   }
 
   function handleToggleTabSuggestion(suggestionId: string) {
+    if (projectEditLocked) {
+      return;
+    }
     setAcceptedTabSuggestionIds((current) =>
       current.includes(suggestionId)
         ? current.filter((id) => id !== suggestionId)
@@ -1010,11 +1077,17 @@ export function useProjectViewModel() {
   }
 
   function handleAcceptTabSuggestionGroup(suggestionIds: string[]) {
+    if (projectEditLocked) {
+      return;
+    }
     setAcceptedTabSuggestionIds((current) => Array.from(new Set([...current, ...suggestionIds])));
     setSelectedTabSuggestionId(suggestionIds[0] ?? null);
   }
 
   function handleRejectTabSuggestionGroup(suggestionIds: string[]) {
+    if (projectEditLocked) {
+      return;
+    }
     const ids = new Set(suggestionIds);
     setAcceptedTabSuggestionIds((current) => current.filter((id) => !ids.has(id)));
     if (selectedTabSuggestionId && ids.has(selectedTabSuggestionId)) {
@@ -1023,6 +1096,9 @@ export function useProjectViewModel() {
   }
 
   function handleApplyTabSuggestions() {
+    if (projectEditLocked) {
+      return;
+    }
     if (!acceptedTabSuggestionIds.length) {
       return;
     }
@@ -1139,6 +1215,9 @@ export function useProjectViewModel() {
   }
 
   async function handleLyricsAction() {
+    if (projectEditLocked) {
+      return;
+    }
     if (!canGenerateLyrics) {
       return;
     }
@@ -1164,6 +1243,9 @@ export function useProjectViewModel() {
   }
 
   async function handleStemAction() {
+    if (projectEditLocked) {
+      return;
+    }
     if (!selectedPrimaryArtifactId) {
       return;
     }
@@ -1252,6 +1334,9 @@ export function useProjectViewModel() {
   }
 
   async function handleDeleteProject() {
+    if (projectEditLocked) {
+      return;
+    }
     const approved = await confirm(
       "Delete this project and all of its mixes, stems, and exports?",
       {
@@ -1269,6 +1354,7 @@ export function useProjectViewModel() {
 
   async function handleDeleteMix(artifact = selectedArtifact) {
     if (
+      projectEditLocked ||
       !artifact ||
       artifact.type !== "preview_mix" ||
       artifact.can_delete === false ||
@@ -1306,7 +1392,13 @@ export function useProjectViewModel() {
   }
 
   async function handleDeleteStem(artifact = selectedArtifact) {
-    if (!artifact || !isStemArtifact(artifact) || artifact.can_delete === false || isDeleteStemDisabled) {
+    if (
+      projectEditLocked ||
+      !artifact ||
+      !isStemArtifact(artifact) ||
+      artifact.can_delete === false ||
+      isDeleteStemDisabled
+    ) {
       return;
     }
     const approved = await confirm(
@@ -1331,7 +1423,7 @@ export function useProjectViewModel() {
   }
 
   async function handleDeleteAllMixes() {
-    if (!canDeleteAnyMixes || isDeleteMixDisabled) {
+    if (projectEditLocked || !canDeleteAnyMixes || isDeleteMixDisabled) {
       return;
     }
     const approved = await confirm(
@@ -1367,7 +1459,7 @@ export function useProjectViewModel() {
   }
 
   async function handleDeleteAllStems() {
-    if (!canDeleteAnyStems || isDeleteStemDisabled) {
+    if (projectEditLocked || !canDeleteAnyStems || isDeleteStemDisabled) {
       return;
     }
     const approved = await confirm(
@@ -1392,7 +1484,12 @@ export function useProjectViewModel() {
   }
 
   async function handleDeleteSelectedPrimaryStems() {
-    if (!selectedPrimaryStemDeleteLabel || !selectedPrimaryStemArtifacts.length || isDeleteStemDisabled) {
+    if (
+      projectEditLocked ||
+      !selectedPrimaryStemDeleteLabel ||
+      !selectedPrimaryStemArtifacts.length ||
+      isDeleteStemDisabled
+    ) {
       return;
     }
     const approved = await confirm(
@@ -1421,6 +1518,18 @@ export function useProjectViewModel() {
       setDraftName(projectQuery.data?.display_name ?? "");
     }
   }, [isRenaming, projectQuery.data?.display_name]);
+
+  useEffect(() => {
+    if (!projectEditLocked) {
+      return;
+    }
+
+    setIsRenaming(false);
+    setIsEditingLyrics(false);
+    setIsTabImportOpen(false);
+    setSourceKeySelectorOpen(false);
+    setTargetSelectorOpen(false);
+  }, [projectEditLocked]);
 
   useEffect(() => {
     if (!isEditingLyrics) {
@@ -2015,6 +2124,7 @@ export function useProjectViewModel() {
     enharmonicDisplayMode,
     exportMutation,
     acceptedTabSuggestionIds,
+    handleAnalyzeAction,
     handleDeleteMix,
     handleDeleteStem,
     handleDeleteAllMixes,
@@ -2109,7 +2219,10 @@ export function useProjectViewModel() {
     canUsePrecount,
     previewArtifacts,
     previewMutation,
+    projectEditLocked,
     projectQuery,
+    projectSyncLockReason,
+    projectSyncSummary,
     referenceHz,
     renameMutation,
     retuneMode,

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -55,6 +55,150 @@ export type TabImportSchema = components["schemas"]["TabImportSchema"];
 export type TabSuggestionGroupSchema = components["schemas"]["TabSuggestionGroupSchema"];
 export type TabSuggestionSchema = components["schemas"]["TabSuggestionSchema"];
 export type RuntimeCapabilities = MobileCapabilities | null;
+export type ProjectSyncSummary = {
+  state: string;
+  label: string;
+  isLocal: boolean;
+  isLocked: boolean;
+  lockReason: string | null;
+};
+
+const LOCAL_SYNC_STATES = new Set(["local", "noop", "identical_content"]);
+const PROJECT_SYNC_STATE_LABELS: Record<string, string> = {
+  conflicted: "Conflicted",
+  deleted: "Deleted",
+  downloading: "Downloading",
+  local: "Local",
+  missing: "Missing",
+  missing_local_bytes: "Missing Bytes",
+  missing_provider: "Missing Provider",
+  remote_available: "Remote Available",
+  syncing: "Syncing",
+};
+const PROJECT_SYNC_LOCK_REASONS: Record<string, string> = {
+  conflicted: "Resolve sync conflicts before editing this project.",
+  deleted: "This project was deleted in the sync group and cannot be edited.",
+  downloading: "This project is downloading required local data before edits are enabled.",
+  missing: "Required project data is missing on this device.",
+  missing_local_bytes: "Required project audio is missing on this device.",
+  missing_provider: "No trusted synced device can provide the required project data.",
+  remote_available: "Required project data is available from another synced device and must be downloaded before editing.",
+  syncing: "This project is still syncing required local data before edits are enabled.",
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null ? value as Record<string, unknown> : null;
+}
+
+function firstStringField(records: Array<Record<string, unknown> | null>, keys: string[]) {
+  for (const record of records) {
+    if (!record) {
+      continue;
+    }
+    for (const key of keys) {
+      const value = record[key];
+      if (typeof value === "string" && value.trim()) {
+        return value.trim();
+      }
+    }
+  }
+  return null;
+}
+
+function firstBooleanField(records: Array<Record<string, unknown> | null>, keys: string[]) {
+  for (const record of records) {
+    if (!record) {
+      continue;
+    }
+    for (const key of keys) {
+      const value = record[key];
+      if (typeof value === "boolean") {
+        return value;
+      }
+    }
+  }
+  return null;
+}
+
+function normalizeProjectSyncState(value: string | null) {
+  return value?.toLowerCase().replace(/[\s-]+/g, "_") ?? "local";
+}
+
+function labelFromSyncState(state: string) {
+  return PROJECT_SYNC_STATE_LABELS[state] ??
+    state
+      .split("_")
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ");
+}
+
+function defaultProjectLockReason(state: string, isLocal: boolean) {
+  if (PROJECT_SYNC_LOCK_REASONS[state]) {
+    return PROJECT_SYNC_LOCK_REASONS[state];
+  }
+  return isLocal
+    ? "This project is locked until sync makes it editable."
+    : "This project is not ready for local edits yet.";
+}
+
+export function getProjectSyncSummary(project: ProjectSchema | null | undefined): ProjectSyncSummary {
+  if (!project) {
+    return {
+      state: "local",
+      label: PROJECT_SYNC_STATE_LABELS.local,
+      isLocal: true,
+      isLocked: false,
+      lockReason: null,
+    };
+  }
+
+  const projectRecord = project as ProjectSchema & Record<string, unknown>;
+  const syncRecord =
+    asRecord(projectRecord.sync) ??
+    asRecord(projectRecord.sync_status) ??
+    asRecord(projectRecord.sync_state);
+  const state = normalizeProjectSyncState(
+    firstStringField([projectRecord], ["sync_state", "sync_status", "syncState", "syncStatus"]) ??
+      firstStringField(
+        [syncRecord],
+        ["sync_state", "sync_status", "syncState", "syncStatus", "state", "status"],
+      ),
+  );
+  const isLocal = LOCAL_SYNC_STATES.has(state);
+  const explicitLocked = firstBooleanField(
+    [projectRecord, syncRecord],
+    ["edit_locked", "is_edit_locked", "locked", "read_only", "readOnly"],
+  );
+  const explicitEditable = firstBooleanField(
+    [projectRecord, syncRecord],
+    ["sync_editable", "syncEditable", "can_edit", "editable", "is_editable", "canEdit"],
+  );
+  const isLocked = explicitLocked ?? (explicitEditable === null ? !isLocal : !explicitEditable);
+  const lockReason = isLocked
+    ? firstStringField(
+        [projectRecord, syncRecord],
+        [
+          "edit_lock_reason",
+          "lock_reason",
+          "sync_status_reason",
+          "syncStatusReason",
+          "sync_lock_reason",
+          "unavailable_reason",
+          "reason",
+          "message",
+        ],
+      ) ?? defaultProjectLockReason(state, isLocal)
+    : null;
+
+  return {
+    state,
+    label: labelFromSyncState(state),
+    isLocal,
+    isLocked,
+    lockReason,
+  };
+}
 
 export type TuneForgeClient = {
   getMobileCapabilities: () => Promise<RuntimeCapabilities>;

--- a/apps/desktop/src/styles/base.css
+++ b/apps/desktop/src/styles/base.css
@@ -407,6 +407,41 @@ a {
   flex-wrap: wrap;
 }
 
+.sync-status-badge {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  border: 1px solid color-mix(in srgb, var(--chip-active-border) 34%, var(--chip-border));
+  border-radius: 999px;
+  padding: 0.22rem 0.5rem;
+  background: color-mix(in srgb, var(--chip-active-bg) 78%, transparent);
+  color: color-mix(in srgb, var(--chip-active-border) 78%, var(--text));
+  font-size: 0.68rem;
+  font-weight: 800;
+  line-height: 1;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.sync-status-badge--conflicted,
+.sync-status-badge--missing,
+.sync-status-badge--missing_local_bytes,
+.sync-status-badge--missing_provider {
+  border-color: color-mix(in srgb, var(--color-state-warning) 54%, var(--chip-border));
+  color: color-mix(in srgb, var(--color-state-warning) 72%, var(--text));
+}
+
+.sync-status-badge--deleted {
+  border-color: color-mix(in srgb, var(--danger) 54%, var(--chip-border));
+  color: color-mix(in srgb, var(--danger) 76%, var(--text));
+}
+
+.project-sync-lock-reason {
+  margin: 0;
+  max-width: 48rem;
+  color: var(--muted);
+}
+
 .title-input,
 .search-field__input,
 .controls input,

--- a/apps/desktop/src/styles/library.css
+++ b/apps/desktop/src/styles/library.css
@@ -109,6 +109,13 @@
   min-width: 0;
 }
 
+.project-card__title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
 .project-card__title-block h2 {
   margin: 0;
   font-size: 1rem;

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -572,6 +572,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/sync/projects/{project_id}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Sync Project Status Update */
+        patch: operations["sync_project_status_update_api_v1_sync_projects__project_id__status_patch"];
+        trace?: never;
+    };
     "/api/v1/sync/artifacts/staging": {
         parameters: {
             query?: never;
@@ -1102,6 +1119,28 @@ export interface components {
             sample_rate: number | null;
             /** Channels */
             channels: number | null;
+            /**
+             * Sync Status
+             * @default local
+             * @enum {string}
+             */
+            sync_status: "local" | "syncing" | "remote_available" | "downloading" | "missing" | "deleted" | "conflicted";
+            /** Sync Status Reason */
+            sync_status_reason?: string | null;
+            /**
+             * Sync Editable
+             * @default true
+             */
+            sync_editable: boolean;
+            /** Sync Required Artifact Ids */
+            sync_required_artifact_ids?: string[];
+            /** Sync Provider Device Ids */
+            sync_provider_device_ids?: string[];
+            /**
+             * Sync Conflict Count
+             * @default 0
+             */
+            sync_conflict_count: number;
             /**
              * Created At
              * Format: date-time
@@ -1641,13 +1680,56 @@ export interface components {
             /** Use Content Addressed Staging */
             use_content_addressed_staging?: boolean | null;
         };
+        /** SyncProjectStatusProjectMetadataSchema */
+        SyncProjectStatusProjectMetadataSchema: {
+            /** Project Id */
+            project_id: string;
+            /** Display Name */
+            display_name: string;
+            /** Source Key Override */
+            source_key_override?: string | null;
+            /** Source Sha256 */
+            source_sha256?: string | null;
+            /** Duration Seconds */
+            duration_seconds?: number | null;
+            /** Sample Rate */
+            sample_rate?: number | null;
+            /** Channels */
+            channels?: number | null;
+            /** Created At */
+            created_at?: string | null;
+            /** Updated At */
+            updated_at?: string | null;
+        };
+        /** SyncProjectStatusUpdateRequest */
+        SyncProjectStatusUpdateRequest: {
+            /**
+             * Sync Status
+             * @enum {string}
+             */
+            sync_status: "local" | "syncing" | "remote_available" | "downloading" | "missing" | "deleted" | "conflicted";
+            /** Sync Status Reason */
+            sync_status_reason?: string | null;
+            /** Sync Required Artifact Ids */
+            sync_required_artifact_ids?: string[] | null;
+            /** Sync Provider Device Ids */
+            sync_provider_device_ids?: string[] | null;
+            /** Sync Conflict Count */
+            sync_conflict_count?: number | null;
+            manifest?: components["schemas"]["SyncProjectManifestSchema"] | null;
+            project?: components["schemas"]["SyncProjectStatusProjectMetadataSchema"] | null;
+        };
+        /** SyncProjectStatusUpdateResponse */
+        SyncProjectStatusUpdateResponse: {
+            project: components["schemas"]["ProjectSchema"];
+        };
         /** SyncReconciliationActionSchema */
         SyncReconciliationActionSchema: {
             /**
              * Action Type
              * @enum {string}
              */
-            action_type: "apply_delete_tombstone" | "import_project_manifest" | "import_entity_revision" | "fetch_artifact_content" | "import_artifact_manifest" | "record_conflict" | "noop";
+            action_type: "apply_delete_tombstone" | "import_project_manifest" | "import_entity_revision" | "fetch_artifact_content" | "import_artifact_manifest" | "upsert_project_status" | "record_conflict" | "noop";
             /** Item Type */
             item_type: string;
             /** Item Id */
@@ -1681,7 +1763,7 @@ export interface components {
              */
             status: "noop" | "identical_content" | "missing_local_bytes" | "remote_available" | "missing_provider" | "deleted" | "conflicted";
             /** Action Type */
-            action_type?: ("apply_delete_tombstone" | "import_project_manifest" | "import_entity_revision" | "fetch_artifact_content" | "import_artifact_manifest" | "record_conflict" | "noop") | null;
+            action_type?: ("apply_delete_tombstone" | "import_project_manifest" | "import_entity_revision" | "fetch_artifact_content" | "import_artifact_manifest" | "upsert_project_status" | "record_conflict" | "noop") | null;
             /** Content Sha256 */
             content_sha256?: string | null;
             /** Chosen Provider Device Id */
@@ -3152,6 +3234,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SyncProjectManifestResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    sync_project_status_update_api_v1_sync_projects__project_id__status_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SyncProjectStatusUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncProjectStatusUpdateResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary
- Add persisted sync status and edit-lock metadata for metadata-first synced projects.
- Enforce sync locks across project mutations, artifact deletion, route job creation, and delayed jobs.
- Add reconciliation status actions, placeholder import upgrade, desktop locked-project UX, and regenerated contracts.

## Testing
- `pnpm contracts:generate`
- `uv run --python 3.11 pytest -q`
- `uv run --python 3.11 ruff check .`
- `uv run --python 3.11 mypy app`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop test --run App.library.test.tsx App.project-analysis-mix.test.tsx`

Closes #117