### PR TITLE
fix: preserve legacy NVIDIA setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ pnpm sync:backend:default -- --advanced-chords
 
 Both backend sync helpers recreate `apps/backend/.venv` from scratch to avoid stale mixed CUDA stacks when switching profiles. `uv` still reuses its shared cache, so after the first install, switching is usually much faster than a cold download. It is intended for cards like the GTX 1050 Ti. macOS, CI, and the default Linux setup remain unchanged.
 
+When the legacy marker is active, use the root `pnpm` scripts for backend work. They preserve the local Torch
+override; running raw `uv run` inside `apps/backend` can resync the default Torch stack and leave CUDA libraries mixed.
+
 ## Development
 
 Two terminals:

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -77,7 +77,10 @@ pnpm sync:backend:legacy-nvidia -- --advanced-chords
 pnpm sync:backend:default -- --advanced-chords
 ```
 
-This profile is an opt-in local override for Linux `x86_64`. The committed lockfile and the default macOS / Linux setup stay unchanged. When the override is active, use the repository commands (`pnpm dev:backend`, `pnpm test`, `pnpm lint`) so the backend keeps using the overridden `.venv` instead of asking `uv` to resync it.
+This profile is an opt-in local override for Linux `x86_64`. The committed lockfile and the default macOS / Linux
+setup stay unchanged. When the override is active, use the repository commands (`pnpm dev:backend`, `pnpm test`,
+`pnpm lint`, `pnpm contracts:generate`) so the backend keeps using the overridden `.venv` instead of asking `uv` to
+resync it.
 
 Both backend sync helpers recreate `.venv` from scratch before installing packages. That avoids stale mixed CUDA stacks after switching between the default and legacy NVIDIA profiles, while still letting `uv` reuse its shared cache for faster reinstalls.
 

--- a/packages/shared-types/scripts/generate.mjs
+++ b/packages/shared-types/scripts/generate.mjs
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
@@ -6,28 +7,48 @@ const __filename = fileURLToPath(import.meta.url);
 const packageRoot = path.resolve(path.dirname(__filename), "..");
 const workspaceRoot = path.resolve(packageRoot, "..", "..");
 const backendRoot = path.resolve(workspaceRoot, "apps", "backend");
+const legacyNvidiaMarker = path.resolve(backendRoot, ".venv", ".tuneforge-legacy-nvidia");
 const openApiJson = path.resolve(packageRoot, "openapi.json");
 const generatedPath = path.resolve(packageRoot, "src", "generated", "openapi.ts");
 
-execFileSync(
-  "uv",
-  [
-    "run",
-    "--project",
-    backendRoot,
-    "--python",
-    "3.11",
-    "python",
-    "-m",
-    "app.export_openapi",
-    openApiJson,
-  ],
-  { stdio: "inherit", cwd: workspaceRoot },
-);
+function backendVenvPython() {
+  return path.resolve(backendRoot, ".venv", process.platform === "win32" ? "Scripts/python.exe" : "bin/python");
+}
+
+if (existsSync(legacyNvidiaMarker)) {
+  const python = backendVenvPython();
+  if (!existsSync(python)) {
+    throw new Error("Legacy NVIDIA backend marker is present, but apps/backend/.venv is missing.");
+  }
+
+  execFileSync(python, ["-m", "app.export_openapi", openApiJson], {
+    stdio: "inherit",
+    cwd: backendRoot,
+    env: {
+      ...process.env,
+      PYTORCH_ENABLE_MPS_FALLBACK: process.env.PYTORCH_ENABLE_MPS_FALLBACK ?? "1",
+    },
+  });
+} else {
+  execFileSync(
+    "uv",
+    [
+      "run",
+      "--project",
+      backendRoot,
+      "--python",
+      "3.11",
+      "python",
+      "-m",
+      "app.export_openapi",
+      openApiJson,
+    ],
+    { stdio: "inherit", cwd: workspaceRoot },
+  );
+}
 
 execFileSync(
   "pnpm",
   ["exec", "openapi-typescript", openApiJson, "-o", generatedPath],
   { stdio: "inherit", cwd: packageRoot },
 );
-

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -124,6 +124,20 @@ if [[ "${legacy_nvidia}" -eq 1 ]]; then
     "torch==2.6.0" \
     "torchaudio==2.6.0"
 
+  .venv/bin/python - <<'PY'
+import sys
+
+import torch
+
+if not torch.__version__.startswith("2.6.0"):
+    raise SystemExit(f"Expected torch 2.6.0 for the legacy NVIDIA profile, found {torch.__version__}.")
+
+if torch.version.cuda != "12.6":
+    raise SystemExit(f"Expected CUDA 12.6 for the legacy NVIDIA profile, found {torch.version.cuda}.")
+
+sys.stdout.write(f"Verified legacy NVIDIA Torch profile: torch {torch.__version__}, CUDA {torch.version.cuda}\n")
+PY
+
   touch "${marker_file}"
 else
   rm -f "${marker_file}"

--- a/scripts/sync-backend-legacy-nvidia.sh
+++ b/scripts/sync-backend-legacy-nvidia.sh
@@ -68,4 +68,18 @@ uv pip install \
   "torch==2.6.0" \
   "torchaudio==2.6.0"
 
+.venv/bin/python - <<'PY'
+import sys
+
+import torch
+
+if not torch.__version__.startswith("2.6.0"):
+    raise SystemExit(f"Expected torch 2.6.0 for the legacy NVIDIA profile, found {torch.__version__}.")
+
+if torch.version.cuda != "12.6":
+    raise SystemExit(f"Expected CUDA 12.6 for the legacy NVIDIA profile, found {torch.version.cuda}.")
+
+sys.stdout.write(f"Verified legacy NVIDIA Torch profile: torch {torch.__version__}, CUDA {torch.version.cuda}\n")
+PY
+
 touch "${marker_file}"


### PR DESCRIPTION
## Summary
- Preserve the legacy NVIDIA backend venv during contract generation by using the marker-aware local Python.
- Verify `torch 2.6.0` and CUDA `12.6` before writing the legacy NVIDIA marker.
- Document that raw `uv run` can resync the backend venv away from the legacy override.

## Testing
- `pnpm contracts:generate`
- `node --check packages/shared-types/scripts/generate.mjs`
- `bash -n scripts/setup-dev.sh scripts/sync-backend-legacy-nvidia.sh scripts/run-backend-module.sh`
- `git diff --check`
- Not run: full `pnpm test` because the current local `.venv` is already in the mixed Torch/CUDA state and needs `pnpm sync:backend:legacy-nvidia -- --crema` before Torch can import successfully.