### PR TITLE
feat: add baseline LAN sync transport

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -76,6 +76,12 @@ This document is an engineering notice and distribution checklist, not legal adv
 - **Source:** <https://github.com/tauri-apps/tauri>
 - **Notes:** The Rust crate inventory is primarily MIT / Apache-2.0 / BSD / ISC / Zlib family. It also includes MPL-2.0 and Unicode-3.0 notice obligations. Crates with LGPL-2.1-or-later as one license option, such as `r-efi`, also provide MIT or Apache-2.0 alternatives in the resolved metadata.
 
+### TuneForge LAN sync transport Rust crates
+
+- **License:** Apache-2.0 / MIT for `snow`, `base64`, `rand`, `sha2`, and the RustCrypto AEAD/hash stack; BSD-3-Clause for `ed25519-dalek` and `curve25519-dalek`; MIT / BSD-3-Clause for `if-addrs`.
+- **Source:** <https://github.com/mcginty/snow>, <https://github.com/dalek-cryptography/curve25519-dalek>, <https://github.com/RustCrypto>, <https://github.com/rust-random/rand>, <https://github.com/marshallpierce/rust-base64>, and <https://github.com/messense/if-addrs>.
+- **Notes:** Used by the desktop-only same-LAN sync transport for Noise encrypted sessions, trusted Ed25519 peer identity verification, SHA-256 artifact verification, random session nonces, and local interface endpoint hints. The FastAPI backend remains loopback-only.
+
 ### cpal
 
 - **License:** Apache-2.0 / MIT (dual)

--- a/apps/backend/app/api/routes/sync.py
+++ b/apps/backend/app/api/routes/sync.py
@@ -14,6 +14,8 @@ from app.schemas import (
     SyncLocalIdentitySchema,
     SyncLocalIdentityUpdateRequest,
     SyncMetadataResponse,
+    SyncPairingAnswerRequest,
+    SyncPairingAnswerResponse,
     SyncPairingOfferRequest,
     SyncPairingOfferResponse,
     SyncPairingOfferSchema,
@@ -23,9 +25,13 @@ from app.schemas import (
     SyncProjectStagedImportRequest,
     SyncProjectStatusUpdateRequest,
     SyncProjectStatusUpdateResponse,
+    SyncReconciliationApplyRequest,
+    SyncReconciliationApplyResponse,
     SyncReconciliationPlanRequest,
     SyncReconciliationPlanResponse,
     SyncStagedArtifactSchema,
+    SyncTransportHandshakeSignatureResponse,
+    SyncTransportHandshakeSignRequest,
     SyncTrustedPeerCreateRequest,
     SyncTrustedPeerResponse,
     SyncTrustedPeerSchema,
@@ -35,6 +41,7 @@ from app.services.sync_identity import run_sync_preflight
 from app.services.sync_metadata import get_sync_metadata
 from app.services.sync_project_status import update_project_sync_status
 from app.services.sync_trust import (
+    answer_pairing_offer,
     create_pairing_offer,
     get_or_create_local_identity,
     list_trusted_peers,
@@ -83,6 +90,18 @@ def plan_sync_reconciliation(session: Session, payload: SyncReconciliationPlanRe
     return service_plan_sync_reconciliation(session, payload)
 
 
+def apply_sync_reconciliation(session: Session, payload: SyncReconciliationApplyRequest) -> Any:
+    from app.services.sync_reconciliation_apply import apply_sync_reconciliation as service_apply_sync_reconciliation
+
+    return service_apply_sync_reconciliation(session, payload)
+
+
+def sign_transport_handshake_challenge(session: Session, payload: SyncTransportHandshakeSignRequest) -> Any:
+    from app.services.sync_transport import sign_transport_handshake_challenge as service_sign_challenge
+
+    return service_sign_challenge(session, payload)
+
+
 @router.get("/preflight", response_model=SyncPreflightResponse)
 def sync_preflight(session: Session = Depends(get_db)) -> SyncPreflightResponse:
     return SyncPreflightResponse.model_validate(run_sync_preflight(session))
@@ -100,6 +119,24 @@ def sync_reconciliation_plan(
 ) -> SyncReconciliationPlanResponse:
     plan = plan_sync_reconciliation(session, payload)
     return SyncReconciliationPlanResponse.model_validate(plan)
+
+
+@router.post("/reconciliation/apply", response_model=SyncReconciliationApplyResponse)
+def sync_reconciliation_apply(
+    payload: SyncReconciliationApplyRequest,
+    session: Session = Depends(get_db),
+) -> SyncReconciliationApplyResponse:
+    result = apply_sync_reconciliation(session, payload)
+    return SyncReconciliationApplyResponse.model_validate(result)
+
+
+@router.post("/transport/handshake/sign", response_model=SyncTransportHandshakeSignatureResponse)
+def sync_transport_handshake_sign(
+    payload: SyncTransportHandshakeSignRequest,
+    session: Session = Depends(get_db),
+) -> SyncTransportHandshakeSignatureResponse:
+    signature = sign_transport_handshake_challenge(session, payload)
+    return SyncTransportHandshakeSignatureResponse.model_validate(signature)
 
 
 @router.get("/identity", response_model=SyncLocalIdentityResponse)
@@ -135,6 +172,28 @@ def sync_pairing_offer_create(
                 "ttl_seconds": payload.ttl_seconds,
             }
         )
+    )
+
+
+@router.post("/pairing/responses", response_model=SyncPairingAnswerResponse)
+def sync_pairing_offer_answer(
+    payload: SyncPairingAnswerRequest,
+    session: Session = Depends(get_db),
+) -> SyncPairingAnswerResponse:
+    pairing_answer = answer_pairing_offer(
+        session,
+        offer=payload.offer.model_dump(mode="python"),
+        endpoint_hints=payload.endpoint_hints,
+        adopt_sync_group=payload.adopt_sync_group,
+    )
+    return SyncPairingAnswerResponse(
+        pairing_response=SyncPairingOfferSchema.model_validate(
+            {
+                "payload": pairing_answer.payload,
+                "expires_at": pairing_answer.payload["expires_at"],
+            }
+        ).payload,
+        trusted_peer=SyncTrustedPeerSchema.model_validate(pairing_answer.trusted_peer),
     )
 
 

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -504,6 +504,97 @@ class SyncReconciliationPlanResponse(BaseModel):
     actions: list[SyncReconciliationActionSchema]
 
 
+SyncReconciliationApplyActionStatus = Literal["applied", "satisfied", "skipped", "failed"]
+
+
+class SyncReconciliationApplyRequest(SyncReconciliationPlanRequest):
+    staging_root: str | None = Field(default=None, min_length=1)
+    use_content_addressed_staging: bool = True
+
+
+class SyncReconciliationApplySummarySchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    planned_actions: int
+    applied_actions: int
+    satisfied_actions: int
+    skipped_actions: int
+    failed_actions: int
+
+
+class SyncReconciliationApplyActionResultSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    action: SyncReconciliationActionSchema
+    status: SyncReconciliationApplyActionStatus
+    reason: str | None = None
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class SyncReconciliationApplyResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    summary: SyncReconciliationApplySummarySchema
+    plan: SyncReconciliationPlanResponse
+    results: list[SyncReconciliationApplyActionResultSchema]
+
+
+class SyncTransportHandshakeChallengeSchema(BaseModel):
+    protocol_version: str = Field(min_length=1)
+    challenge_type: Literal["transport_handshake"]
+    session_id: str = Field(min_length=16, max_length=128)
+    challenge_nonce: str = Field(min_length=16, max_length=512)
+    requester_device_id: str = Field(min_length=1, max_length=128)
+    responder_device_id: str = Field(min_length=1, max_length=128)
+    issued_at: datetime
+    expires_at: datetime
+
+    @field_validator(
+        "protocol_version",
+        "session_id",
+        "challenge_nonce",
+        "requester_device_id",
+        "responder_device_id",
+    )
+    @classmethod
+    def validate_canonical_string(cls, value: str) -> str:
+        if value != value.strip() or not value:
+            raise ValueError("Transport handshake challenge fields must be canonical strings.")
+        return value
+
+    @model_validator(mode="after")
+    def validate_time_window(self) -> SyncTransportHandshakeChallengeSchema:
+        if self.issued_at >= self.expires_at:
+            raise ValueError("Transport handshake issued_at must be before expires_at.")
+        return self
+
+
+class SyncTransportHandshakeSignRequest(BaseModel):
+    peer_device_id: str = Field(min_length=1, max_length=128)
+    challenge: SyncTransportHandshakeChallengeSchema
+
+    @field_validator("peer_device_id")
+    @classmethod
+    def validate_peer_device_id(cls, value: str) -> str:
+        if value != value.strip() or not value:
+            raise ValueError("peer_device_id must be canonical.")
+        return value
+
+
+class SyncTransportHandshakeSignatureResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    protocol_version: str
+    challenge_type: Literal["transport_handshake"]
+    local_device_id: str
+    peer_device_id: str
+    public_key: str
+    challenge: SyncTransportHandshakeChallengeSchema
+    canonical_challenge_json: str
+    signature: str
+    signed_at: datetime
+
+
 class SyncLocalIdentitySchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -590,6 +681,20 @@ class SyncPairingOfferResponse(BaseModel):
     pairing_offer: SyncPairingOfferSchema
 
 
+class SyncPairingAnswerRequest(BaseModel):
+    offer: SyncPairingPayloadSchema
+    endpoint_hints: list[str] = Field(default_factory=list)
+    adopt_sync_group: bool = False
+
+    @field_validator("endpoint_hints")
+    @classmethod
+    def validate_endpoint_hints(cls, value: list[str]) -> list[str]:
+        normalized = [hint.strip() for hint in value]
+        if any(not hint for hint in normalized):
+            raise ValueError("Endpoint hints cannot be empty.")
+        return normalized
+
+
 class SyncTrustedPeerSchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -631,6 +736,11 @@ class SyncTrustedPeerCreateRequest(BaseModel):
 
 
 class SyncTrustedPeerResponse(BaseModel):
+    trusted_peer: SyncTrustedPeerSchema
+
+
+class SyncPairingAnswerResponse(BaseModel):
+    pairing_response: SyncPairingPayloadSchema
     trusted_peer: SyncTrustedPeerSchema
 
 

--- a/apps/backend/app/services/sync_reconciliation_apply.py
+++ b/apps/backend/app/services/sync_reconciliation_apply.py
@@ -1,0 +1,551 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.errors import AppError
+from app.models import Project, SyncDeleteTombstone
+from app.services.sync_manifest import import_staged_project_manifest
+from app.services.sync_project_status import update_project_sync_status
+from app.services.sync_reconciliation import (
+    ACTION_APPLY_DELETE_TOMBSTONE,
+    ACTION_FETCH_ARTIFACT_CONTENT,
+    ACTION_IMPORT_ARTIFACT_MANIFEST,
+    ACTION_IMPORT_ENTITY_REVISION,
+    ACTION_IMPORT_PROJECT_MANIFEST,
+    ACTION_NOOP,
+    ACTION_RECORD_CONFLICT,
+    ACTION_UPSERT_PROJECT_STATUS,
+    ITEM_ENTITY_REVISION,
+    SyncReconciliationAction,
+    SyncReconciliationPlan,
+    plan_sync_reconciliation,
+)
+from app.services.sync_staging import require_staged_artifact
+from app.services.sync_tombstones import apply_delete_tombstone
+
+APPLY_STATUS_APPLIED = "applied"
+APPLY_STATUS_SATISFIED = "satisfied"
+APPLY_STATUS_SKIPPED = "skipped"
+APPLY_STATUS_FAILED = "failed"
+
+_MISSING = object()
+
+
+@dataclass(frozen=True)
+class SyncReconciliationApplySummary:
+    planned_actions: int
+    applied_actions: int
+    satisfied_actions: int
+    skipped_actions: int
+    failed_actions: int
+
+
+@dataclass(frozen=True)
+class SyncReconciliationApplyActionResult:
+    action: SyncReconciliationAction
+    status: str
+    reason: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SyncReconciliationApplyResult:
+    summary: SyncReconciliationApplySummary
+    plan: SyncReconciliationPlan
+    results: list[SyncReconciliationApplyActionResult]
+
+
+@dataclass(frozen=True)
+class _ApplyContext:
+    project_manifests_by_id: dict[str, object]
+    tombstones_by_id: dict[str, object]
+    tombstones_by_target: dict[tuple[str, str], object]
+    staging_root: str | None
+    use_content_addressed_staging: bool
+
+
+def apply_sync_reconciliation(
+    session: Session,
+    request: object | Mapping[str, Any],
+) -> SyncReconciliationApplyResult:
+    plan = plan_sync_reconciliation(session, request)
+    context = _apply_context(request)
+    results = [_apply_action_in_savepoint(session, action, context) for action in plan.actions]
+    return SyncReconciliationApplyResult(
+        summary=_summarize_apply_results(plan, results),
+        plan=plan,
+        results=results,
+    )
+
+
+def _apply_action_in_savepoint(
+    session: Session,
+    action: SyncReconciliationAction,
+    context: _ApplyContext,
+) -> SyncReconciliationApplyActionResult:
+    try:
+        with session.begin_nested():
+            return _apply_action(session, action, context)
+    except AppError as exc:
+        return SyncReconciliationApplyActionResult(
+            action=action,
+            status=APPLY_STATUS_FAILED,
+            reason=exc.message,
+            details={"error_code": exc.code, "error_details": exc.details},
+        )
+
+
+def _apply_action(
+    session: Session,
+    action: SyncReconciliationAction,
+    context: _ApplyContext,
+) -> SyncReconciliationApplyActionResult:
+    if action.action_type == ACTION_NOOP:
+        return _result(action, APPLY_STATUS_SATISFIED, "Action is already satisfied.")
+    if action.action_type == ACTION_FETCH_ARTIFACT_CONTENT:
+        return _verify_staged_artifact(session, action)
+    if action.action_type == ACTION_IMPORT_PROJECT_MANIFEST:
+        return _import_project_manifest(session, action, context)
+    if action.action_type == ACTION_APPLY_DELETE_TOMBSTONE:
+        return _apply_delete_tombstone_action(session, action, context)
+    if action.action_type == ACTION_UPSERT_PROJECT_STATUS:
+        return _upsert_project_status(session, action, context)
+    if action.action_type == ACTION_IMPORT_ARTIFACT_MANIFEST:
+        return _result(
+            action,
+            APPLY_STATUS_SKIPPED,
+            "Standalone artifact manifest import is not available through existing sync services.",
+        )
+    if action.action_type == ACTION_IMPORT_ENTITY_REVISION:
+        return _result(
+            action,
+            APPLY_STATUS_SKIPPED,
+            "Standalone entity revision import is not available through existing sync services.",
+            details={"supported_path": "Include the revision in a staged project manifest."},
+        )
+    if action.action_type == ACTION_RECORD_CONFLICT:
+        return _result(
+            action,
+            APPLY_STATUS_SKIPPED,
+            "Conflict persistence is not available through existing sync services.",
+        )
+    return _result(action, APPLY_STATUS_SKIPPED, "Reconciliation action type is not supported.")
+
+
+def _verify_staged_artifact(
+    session: Session,
+    action: SyncReconciliationAction,
+) -> SyncReconciliationApplyActionResult:
+    if action.content_sha256 is None:
+        return _result(
+            action,
+            APPLY_STATUS_SKIPPED,
+            "Fetch action does not identify content_sha256.",
+        )
+    try:
+        staged_artifact = require_staged_artifact(session, content_sha256=action.content_sha256)
+    except AppError as exc:
+        return _result(
+            action,
+            APPLY_STATUS_SKIPPED,
+            "Required artifact content is not staged locally.",
+            details={"error_code": exc.code, "error_details": exc.details},
+        )
+    return _result(
+        action,
+        APPLY_STATUS_SATISFIED,
+        "Required artifact content is staged and verified locally.",
+        details={
+            "content_sha256": staged_artifact.content_sha256,
+            "size_bytes": staged_artifact.size_bytes,
+            "provider_device_id": staged_artifact.provider_device_id,
+        },
+    )
+
+
+def _import_project_manifest(
+    session: Session,
+    action: SyncReconciliationAction,
+    context: _ApplyContext,
+) -> SyncReconciliationApplyActionResult:
+    project_id = action.project_id or action.item_id
+    manifest = context.project_manifests_by_id.get(project_id)
+    if manifest is None:
+        return _result(
+            action,
+            APPLY_STATUS_SKIPPED,
+            "Project manifest is not present in the apply request.",
+        )
+
+    if context.use_content_addressed_staging:
+        missing = _missing_content_addressed_artifacts(session, manifest)
+        if missing:
+            return _result(
+                action,
+                APPLY_STATUS_SKIPPED,
+                "Project manifest import is waiting for staged artifact content.",
+                details={"missing_artifacts": missing},
+            )
+
+    project = import_staged_project_manifest(
+        session,
+        manifest=manifest,
+        staging_root=context.staging_root,
+        use_content_addressed_staging=context.use_content_addressed_staging,
+    )
+    return _result(
+        action,
+        APPLY_STATUS_APPLIED,
+        "Project manifest was imported through the sync manifest service.",
+        details={"project_id": project.id},
+    )
+
+
+def _apply_delete_tombstone_action(
+    session: Session,
+    action: SyncReconciliationAction,
+    context: _ApplyContext,
+) -> SyncReconciliationApplyActionResult:
+    tombstone = _tombstone_for_action(session, action, context)
+    if tombstone is None:
+        return _result(
+            action,
+            APPLY_STATUS_SKIPPED,
+            "Delete tombstone is not present in the apply request.",
+        )
+
+    apply_delete_tombstone(session, tombstone)
+    return _result(
+        action,
+        APPLY_STATUS_APPLIED,
+        "Delete tombstone was applied through the sync tombstone service.",
+        details={
+            "tombstone_id": tombstone.id,
+            "target_type": tombstone.target_type,
+            "target_id": tombstone.target_id,
+            "project_id": tombstone.project_id,
+            "persisted_tombstone": tombstone in session,
+        },
+    )
+
+
+def _upsert_project_status(
+    session: Session,
+    action: SyncReconciliationAction,
+    context: _ApplyContext,
+) -> SyncReconciliationApplyActionResult:
+    project_id = action.project_id or action.item_id
+    project_status = _string_from_mapping(action.details, "project_status")
+    if project_status is None:
+        return _result(
+            action,
+            APPLY_STATUS_SKIPPED,
+            "Project status action does not include a project_status.",
+        )
+
+    manifest_or_metadata = context.project_manifests_by_id.get(project_id)
+    if manifest_or_metadata is None:
+        remote_metadata = _mapping_from_mapping(action.details, "remote_metadata")
+        if remote_metadata is not None and _string_from_mapping(remote_metadata, "display_name") is not None:
+            manifest_or_metadata = remote_metadata
+
+    if session.get(Project, project_id) is None and manifest_or_metadata is None:
+        return _result(
+            action,
+            APPLY_STATUS_SKIPPED,
+            "Project status placeholder requires project metadata.",
+        )
+
+    status_details = _mapping_from_mapping(action.details, "status_details") or {}
+    required_artifact_ids, provider_device_ids = _status_artifact_and_provider_ids(action, status_details)
+    project = update_project_sync_status(
+        session,
+        project_id=project_id,
+        sync_status=project_status,
+        sync_status_reason=action.reason,
+        sync_required_artifact_ids=required_artifact_ids,
+        sync_provider_device_ids=provider_device_ids,
+        sync_conflict_count=1 if project_status == "conflicted" else 0,
+        manifest=manifest_or_metadata,
+    )
+    return _result(
+        action,
+        APPLY_STATUS_APPLIED,
+        "Project sync status was updated through the sync status service.",
+        details={
+            "project_id": project.id,
+            "sync_status": project.sync_status,
+            "sync_required_artifact_ids": project.sync_required_artifact_ids,
+            "sync_provider_device_ids": project.sync_provider_device_ids,
+        },
+    )
+
+
+def _missing_content_addressed_artifacts(
+    session: Session,
+    manifest: object,
+) -> list[dict[str, Any]]:
+    missing: list[dict[str, Any]] = []
+    for artifact in _list_field(manifest, "artifacts"):
+        artifact_id = _string_field(artifact, "artifact_id", "id")
+        content_sha256 = _string_field(artifact, "content_sha256")
+        size_bytes = _int_field(artifact, "size_bytes")
+        if content_sha256 is None or size_bytes is None:
+            missing.append(
+                {
+                    "artifact_id": artifact_id,
+                    "content_sha256": content_sha256,
+                    "reason": "Artifact manifest does not include content_sha256 and size_bytes.",
+                }
+            )
+            continue
+        try:
+            require_staged_artifact(session, content_sha256=content_sha256, size_bytes=size_bytes)
+        except AppError as exc:
+            missing.append(
+                {
+                    "artifact_id": artifact_id,
+                    "content_sha256": content_sha256,
+                    "error_code": exc.code,
+                }
+            )
+    return missing
+
+
+def _tombstone_for_action(
+    session: Session,
+    action: SyncReconciliationAction,
+    context: _ApplyContext,
+) -> SyncDeleteTombstone | None:
+    tombstone_id = _string_from_mapping(action.details, "tombstone_id")
+    raw_tombstone = context.tombstones_by_id.get(tombstone_id) if tombstone_id is not None else None
+    if raw_tombstone is None:
+        raw_tombstone = context.tombstones_by_target.get((action.item_type, action.item_id))
+    if raw_tombstone is None:
+        return None
+
+    raw_tombstone_id = _required_string(raw_tombstone, "tombstone_id", "id")
+    persisted = session.get(SyncDeleteTombstone, raw_tombstone_id)
+    if persisted is not None:
+        return persisted
+
+    tombstone = SyncDeleteTombstone(
+        id=raw_tombstone_id,
+        sync_group_id=_required_string(raw_tombstone, "sync_group_id"),
+        project_id=_required_string(raw_tombstone, "project_id"),
+        target_type=_normalize_target_type(_required_string(raw_tombstone, "target_type")),
+        target_id=_required_string(raw_tombstone, "target_id"),
+        author_device_id=_required_string(raw_tombstone, "author_device_id"),
+        deleted_at=_datetime_field(raw_tombstone, "deleted_at") or _utcnow(),
+        prior_metadata_json=_mapping_field(raw_tombstone, "prior_metadata", "prior_metadata_json") or {},
+        created_at=_datetime_field(raw_tombstone, "created_at") or _utcnow(),
+        updated_at=_datetime_field(raw_tombstone, "updated_at") or _utcnow(),
+    )
+    session.add(tombstone)
+    session.flush()
+    return tombstone
+
+
+def _status_artifact_and_provider_ids(
+    action: SyncReconciliationAction,
+    status_details: Mapping[str, Any],
+) -> tuple[list[str], list[str]]:
+    artifact_ids: set[str] = set()
+    provider_ids: set[str] = set()
+
+    artifact_providers = status_details.get("artifact_providers")
+    if isinstance(artifact_providers, Mapping):
+        for artifact_id, provider_device_id in artifact_providers.items():
+            if isinstance(artifact_id, str) and artifact_id:
+                artifact_ids.add(artifact_id)
+            if isinstance(provider_device_id, str) and provider_device_id:
+                provider_ids.add(provider_device_id)
+
+    raw_artifact_ids = status_details.get("artifact_ids")
+    if isinstance(raw_artifact_ids, list):
+        artifact_ids.update(item for item in raw_artifact_ids if isinstance(item, str) and item)
+
+    if isinstance(action.provider_device_id, str) and action.provider_device_id:
+        provider_ids.add(action.provider_device_id)
+
+    return sorted(artifact_ids), sorted(provider_ids)
+
+
+def _apply_context(request: object | Mapping[str, Any]) -> _ApplyContext:
+    project_manifests = _list_field(request, "project_manifests")
+    project_manifests_by_id = {
+        project_id: manifest
+        for project_id, manifest in (
+            (_project_id_from_manifest(manifest), manifest)
+            for manifest in project_manifests
+        )
+        if project_id is not None
+    }
+
+    remote_library = _field(request, "remote_library", default={})
+    tombstones = [
+        *(_list_field(remote_library, "delete_tombstones", "tombstones")),
+        *(tombstone for manifest in project_manifests for tombstone in _list_field(manifest, "delete_tombstones")),
+    ]
+    tombstones_by_id: dict[str, object] = {}
+    tombstones_by_target: dict[tuple[str, str], object] = {}
+    for tombstone in tombstones:
+        tombstone_id = _string_field(tombstone, "tombstone_id", "id")
+        target_type = _normalize_target_type(_string_field(tombstone, "target_type") or "")
+        target_id = _string_field(tombstone, "target_id")
+        if tombstone_id is not None:
+            tombstones_by_id[tombstone_id] = tombstone
+        if target_type and target_id is not None:
+            tombstones_by_target[(target_type, target_id)] = tombstone
+
+    return _ApplyContext(
+        project_manifests_by_id=project_manifests_by_id,
+        tombstones_by_id=tombstones_by_id,
+        tombstones_by_target=tombstones_by_target,
+        staging_root=_string_field(request, "staging_root"),
+        use_content_addressed_staging=_bool_field(request, "use_content_addressed_staging", default=True),
+    )
+
+
+def _project_id_from_manifest(manifest: object) -> str | None:
+    project = _field(manifest, "project", default=manifest)
+    return _string_field(project, "project_id", "id")
+
+
+def _summarize_apply_results(
+    plan: SyncReconciliationPlan,
+    results: list[SyncReconciliationApplyActionResult],
+) -> SyncReconciliationApplySummary:
+    return SyncReconciliationApplySummary(
+        planned_actions=len(plan.actions),
+        applied_actions=sum(1 for result in results if result.status == APPLY_STATUS_APPLIED),
+        satisfied_actions=sum(1 for result in results if result.status == APPLY_STATUS_SATISFIED),
+        skipped_actions=sum(1 for result in results if result.status == APPLY_STATUS_SKIPPED),
+        failed_actions=sum(1 for result in results if result.status == APPLY_STATUS_FAILED),
+    )
+
+
+def _result(
+    action: SyncReconciliationAction,
+    status: str,
+    reason: str,
+    details: dict[str, Any] | None = None,
+) -> SyncReconciliationApplyActionResult:
+    return SyncReconciliationApplyActionResult(
+        action=action,
+        status=status,
+        reason=reason,
+        details=details or {},
+    )
+
+
+def _field(source: object, name: str, *, default: object = _MISSING) -> Any:
+    if isinstance(source, Mapping):
+        value = source.get(name, default)
+    else:
+        model_dump = getattr(source, "model_dump", None)
+        if callable(model_dump):
+            dumped = model_dump(mode="python")
+            value = dumped.get(name, default) if isinstance(dumped, Mapping) else default
+        else:
+            value = getattr(source, name, default)
+    if value is _MISSING:
+        raise KeyError(name)
+    return value
+
+
+def _list_field(source: object, *names: str) -> list[Any]:
+    for name in names:
+        value = _field(source, name, default=None)
+        if value is None:
+            continue
+        if isinstance(value, list):
+            return value
+        if isinstance(value, tuple):
+            return list(value)
+        return []
+    return []
+
+
+def _string_field(source: object, *names: str) -> str | None:
+    for name in names:
+        value = _field(source, name, default=None)
+        if isinstance(value, str):
+            normalized = value.strip()
+            if normalized:
+                return normalized
+    return None
+
+
+def _required_string(source: object, *names: str) -> str:
+    value = _string_field(source, *names)
+    if value is None:
+        expected = " or ".join(names)
+        raise KeyError(expected)
+    return value
+
+
+def _string_from_mapping(source: Mapping[str, Any], name: str) -> str | None:
+    value = source.get(name)
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _mapping_from_mapping(source: Mapping[str, Any], name: str) -> Mapping[str, Any] | None:
+    value = source.get(name)
+    return value if isinstance(value, Mapping) else None
+
+
+def _mapping_field(source: object, *names: str) -> dict[str, Any] | None:
+    for name in names:
+        value = _field(source, name, default=None)
+        if isinstance(value, Mapping):
+            return dict(value)
+    return None
+
+
+def _int_field(source: object, name: str) -> int | None:
+    value = _field(source, name, default=None)
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _bool_field(source: object, name: str, *, default: bool) -> bool:
+    value = _field(source, name, default=default)
+    return value if isinstance(value, bool) else default
+
+
+def _datetime_field(source: object, name: str) -> datetime | None:
+    value = _field(source, name, default=None)
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=UTC)
+        return parsed.astimezone(UTC)
+    return None
+
+
+def _normalize_target_type(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized in {"revision", "entity", "sync_entity_revision"}:
+        return ITEM_ENTITY_REVISION
+    return normalized
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)

--- a/apps/backend/app/services/sync_transport.py
+++ b/apps/backend/app/services/sync_transport.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from fastapi import status
+from sqlalchemy.orm import Session
+
+from app.errors import AppError
+from app.models import SyncLocalIdentity
+from app.services import sync_crypto
+from app.services.sync_trust import (
+    LOCAL_IDENTITY_ID,
+    SYNC_GROUP_MISMATCH,
+    SYNC_PAIRING_PROTOCOL_VERSION,
+    get_or_create_local_identity,
+    require_trusted_peer,
+)
+
+TRANSPORT_HANDSHAKE_CHALLENGE_TYPE = "transport_handshake"
+TRANSPORT_HANDSHAKE_MAX_TTL_SECONDS = 300
+TRANSPORT_HANDSHAKE_CLOCK_SKEW_SECONDS = 30
+SYNC_TRANSPORT_CHALLENGE_INVALID = "SYNC_TRANSPORT_CHALLENGE_INVALID"
+
+_MISSING = object()
+
+
+@dataclass(frozen=True)
+class SyncTransportHandshakeSignature:
+    protocol_version: str
+    challenge_type: str
+    local_device_id: str
+    peer_device_id: str
+    public_key: str
+    challenge: dict[str, Any]
+    canonical_challenge_json: str
+    signature: str
+    signed_at: datetime
+
+
+def sign_transport_handshake_challenge(
+    session: Session,
+    request: object | Mapping[str, Any],
+) -> SyncTransportHandshakeSignature:
+    identity = _get_or_create_local_identity_orm(session)
+    peer_device_id = _required_string(request, "peer_device_id")
+    trusted_peer = require_trusted_peer(session, peer_device_id)
+    if trusted_peer.sync_group_id != identity.sync_group_id:
+        raise AppError(
+            SYNC_GROUP_MISMATCH,
+            "Trusted peer belongs to a different sync group.",
+            status_code=status.HTTP_403_FORBIDDEN,
+            details={
+                "local_sync_group_id": identity.sync_group_id,
+                "peer_sync_group_id": trusted_peer.sync_group_id,
+            },
+        )
+
+    challenge = _field(request, "challenge")
+    canonical_challenge = _canonical_transport_handshake_challenge(
+        challenge,
+        local_device_id=identity.device_id,
+        peer_device_id=peer_device_id,
+    )
+    canonical_challenge_json = canonical_transport_handshake_challenge_json(canonical_challenge)
+    signature = sync_crypto.sign_payload(
+        sync_crypto.decode_key(identity.private_key),
+        canonical_challenge_json.encode("utf-8"),
+    )
+    return SyncTransportHandshakeSignature(
+        protocol_version=canonical_challenge["protocol_version"],
+        challenge_type=canonical_challenge["challenge_type"],
+        local_device_id=identity.device_id,
+        peer_device_id=peer_device_id,
+        public_key=identity.public_key,
+        challenge=canonical_challenge,
+        canonical_challenge_json=canonical_challenge_json,
+        signature=signature,
+        signed_at=_utcnow(),
+    )
+
+
+def canonical_transport_handshake_challenge_json(challenge: Mapping[str, Any]) -> str:
+    return json.dumps(challenge, sort_keys=True, separators=(",", ":"))
+
+
+def _get_or_create_local_identity_orm(session: Session) -> SyncLocalIdentity:
+    get_or_create_local_identity(session)
+    identity = session.get(SyncLocalIdentity, LOCAL_IDENTITY_ID)
+    if identity is None:
+        raise AppError(
+            "SYNC_IDENTITY_MISSING",
+            "Local sync identity could not be loaded.",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+    return identity
+
+
+def _canonical_transport_handshake_challenge(
+    challenge: object,
+    *,
+    local_device_id: str,
+    peer_device_id: str,
+) -> dict[str, Any]:
+    protocol_version = _required_string(challenge, "protocol_version")
+    if protocol_version != SYNC_PAIRING_PROTOCOL_VERSION:
+        raise _invalid_challenge(
+            "Transport handshake challenge uses an unsupported protocol version.",
+            {"protocol_version": protocol_version},
+        )
+
+    challenge_type = _required_string(challenge, "challenge_type")
+    if challenge_type != TRANSPORT_HANDSHAKE_CHALLENGE_TYPE:
+        raise _invalid_challenge(
+            "Transport handshake challenge_type is not supported.",
+            {"challenge_type": challenge_type},
+        )
+
+    requester_device_id = _required_string(challenge, "requester_device_id")
+    if requester_device_id != peer_device_id:
+        raise _invalid_challenge(
+            "Transport handshake requester_device_id must match the trusted peer.",
+            {
+                "peer_device_id": peer_device_id,
+                "requester_device_id": requester_device_id,
+            },
+        )
+
+    responder_device_id = _required_string(challenge, "responder_device_id")
+    if responder_device_id != local_device_id:
+        raise _invalid_challenge(
+            "Transport handshake responder_device_id must match the local device.",
+            {
+                "local_device_id": local_device_id,
+                "responder_device_id": responder_device_id,
+            },
+        )
+
+    session_id = _required_string(challenge, "session_id")
+    challenge_nonce = _required_string(challenge, "challenge_nonce")
+    issued_at = _required_datetime(challenge, "issued_at")
+    expires_at = _required_datetime(challenge, "expires_at")
+    _validate_challenge_window(issued_at=issued_at, expires_at=expires_at)
+
+    return {
+        "challenge_nonce": challenge_nonce,
+        "challenge_type": TRANSPORT_HANDSHAKE_CHALLENGE_TYPE,
+        "expires_at": expires_at.isoformat(),
+        "issued_at": issued_at.isoformat(),
+        "protocol_version": SYNC_PAIRING_PROTOCOL_VERSION,
+        "requester_device_id": requester_device_id,
+        "responder_device_id": responder_device_id,
+        "session_id": session_id,
+    }
+
+
+def _validate_challenge_window(*, issued_at: datetime, expires_at: datetime) -> None:
+    now = _utcnow()
+    if issued_at >= expires_at:
+        raise _invalid_challenge("Transport handshake issued_at must be before expires_at.")
+    if expires_at <= now:
+        raise _invalid_challenge("Transport handshake challenge has expired.")
+    if issued_at > now + timedelta(seconds=TRANSPORT_HANDSHAKE_CLOCK_SKEW_SECONDS):
+        raise _invalid_challenge("Transport handshake issued_at is too far in the future.")
+    if expires_at - issued_at > timedelta(seconds=TRANSPORT_HANDSHAKE_MAX_TTL_SECONDS):
+        raise _invalid_challenge(
+            "Transport handshake challenge lifetime is too long.",
+            {"max_ttl_seconds": TRANSPORT_HANDSHAKE_MAX_TTL_SECONDS},
+        )
+
+
+def _field(source: object, name: str, *, default: object = _MISSING) -> Any:
+    if isinstance(source, Mapping):
+        value = source.get(name, default)
+    else:
+        model_dump = getattr(source, "model_dump", None)
+        if callable(model_dump):
+            dumped = model_dump(mode="python")
+            value = dumped.get(name, default) if isinstance(dumped, Mapping) else default
+        else:
+            value = getattr(source, name, default)
+    if value is _MISSING:
+        raise _invalid_challenge(f"Transport handshake challenge is missing {name}.")
+    return value
+
+
+def _required_string(source: object, name: str) -> str:
+    value = _field(source, name)
+    if not isinstance(value, str):
+        raise _invalid_challenge(f"Transport handshake {name} must be a string.")
+    if value != value.strip() or not value:
+        raise _invalid_challenge(f"Transport handshake {name} must be canonical.")
+    return value
+
+
+def _required_datetime(source: object, name: str) -> datetime:
+    value = _field(source, name)
+    if not isinstance(value, datetime):
+        raise _invalid_challenge(f"Transport handshake {name} must be an ISO-8601 timestamp.")
+    if value.tzinfo is None:
+        raise _invalid_challenge(f"Transport handshake {name} must include a timezone.")
+    return value.astimezone(UTC)
+
+
+def _invalid_challenge(message: str, details: dict[str, Any] | None = None) -> AppError:
+    return AppError(
+        SYNC_TRANSPORT_CHALLENGE_INVALID,
+        message,
+        status_code=status.HTTP_400_BAD_REQUEST,
+        details=details,
+    )
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)

--- a/apps/backend/app/services/sync_trust.py
+++ b/apps/backend/app/services/sync_trust.py
@@ -59,6 +59,12 @@ class SyncPairingOfferRecord:
 
 
 @dataclass(frozen=True)
+class SyncPairingAnswerRecord:
+    payload: dict[str, Any]
+    trusted_peer: TrustedSyncPeer
+
+
+@dataclass(frozen=True)
 class TrustedSyncPeer:
     device_id: str
     sync_group_id: str
@@ -163,69 +169,55 @@ def trust_peer_from_pairing_payload(
     payload_values = _validate_pairing_payload(payload)
     local_identity = _get_or_create_local_identity_orm(session)
 
-    if payload_values.device_id == local_identity.device_id:
-        raise AppError(
-            SYNC_PAIRING_SELF,
-            "Cannot trust this device's own pairing payload.",
-            status_code=status.HTTP_409_CONFLICT,
-        )
-
-    if payload_values.sync_group_id != local_identity.sync_group_id:
-        if not adopt_sync_group or _active_trusted_peer_count(session) > 0:
-            raise AppError(
-                SYNC_GROUP_MISMATCH,
-                "Pairing payload belongs to a different sync group.",
-                status_code=status.HTTP_409_CONFLICT,
-                details={
-                    "local_sync_group_id": local_identity.sync_group_id,
-                    "payload_sync_group_id": payload_values.sync_group_id,
-                },
-            )
-        local_identity.sync_group_id = payload_values.sync_group_id
-        local_identity.updated_at = _utcnow()
-        session.flush()
+    _validate_pairing_peer_identity(
+        session,
+        local_identity=local_identity,
+        payload_values=payload_values,
+        adopt_sync_group=adopt_sync_group,
+    )
 
     local_offer = session.get(SyncPairingOffer, payload_values.pairing_offer_id)
     if local_offer is None:
         raise _pairing_invalid("Pairing offer is unknown.")
     _validate_local_pairing_offer(local_offer, payload_values)
 
-    existing_public_key_peer = session.scalars(
-        select(SyncTrustedPeer).where(SyncTrustedPeer.public_key == payload_values.public_key)
-    ).first()
-    if (
-        existing_public_key_peer is not None
-        and existing_public_key_peer.device_id != payload_values.device_id
-    ):
-        raise _pairing_invalid("Pairing payload public_key is already trusted for a different device.")
-
     now = _utcnow()
-    peer = session.get(SyncTrustedPeer, payload_values.device_id)
-    if peer is None:
-        peer = SyncTrustedPeer(
-            device_id=payload_values.device_id,
-            sync_group_id=payload_values.sync_group_id,
-            display_name=payload_values.display_name,
-            public_key=payload_values.public_key,
-            endpoint_hints_json=payload_values.endpoint_hints,
-            trusted_at=now,
-            revoked_at=None,
-            created_at=now,
-            updated_at=now,
-        )
-        session.add(peer)
-    else:
-        peer.sync_group_id = payload_values.sync_group_id
-        peer.display_name = payload_values.display_name
-        peer.public_key = payload_values.public_key
-        peer.endpoint_hints_json = payload_values.endpoint_hints
-        peer.trusted_at = now
-        peer.revoked_at = None
-        peer.updated_at = now
+    peer = _upsert_trusted_peer_from_pairing_values(session, payload_values=payload_values, now=now)
 
     local_offer.used_at = now
     session.flush()
     return _trusted_peer_from_orm(peer)
+
+
+def answer_pairing_offer(
+    session: Session,
+    offer: Mapping[str, Any] | object,
+    endpoint_hints: list[str] | None = None,
+    adopt_sync_group: bool = False,
+) -> SyncPairingAnswerRecord:
+    offer_values = _validate_pairing_payload(offer)
+    local_identity = _get_or_create_local_identity_orm(session)
+
+    _validate_pairing_peer_identity(
+        session,
+        local_identity=local_identity,
+        payload_values=offer_values,
+        adopt_sync_group=adopt_sync_group,
+    )
+
+    now = _utcnow()
+    peer = _upsert_trusted_peer_from_pairing_values(session, payload_values=offer_values, now=now)
+    response_payload = _local_pairing_response_payload(
+        local_identity,
+        offer_values=offer_values,
+        endpoint_hints=endpoint_hints,
+    )
+    session.flush()
+
+    return SyncPairingAnswerRecord(
+        payload=response_payload,
+        trusted_peer=_trusted_peer_from_orm(peer),
+    )
 
 
 def revoke_trusted_peer(session: Session, device_id: str) -> TrustedSyncPeer:
@@ -326,6 +318,101 @@ def _get_or_create_local_identity_orm(
 def _active_trusted_peer_count(session: Session) -> int:
     statement = select(func.count()).select_from(SyncTrustedPeer).where(SyncTrustedPeer.revoked_at.is_(None))
     return int(session.scalar(statement) or 0)
+
+
+def _validate_pairing_peer_identity(
+    session: Session,
+    *,
+    local_identity: SyncLocalIdentity,
+    payload_values: _PairingPayloadValues,
+    adopt_sync_group: bool,
+) -> None:
+    if payload_values.device_id == local_identity.device_id:
+        raise AppError(
+            SYNC_PAIRING_SELF,
+            "Cannot trust this device's own pairing payload.",
+            status_code=status.HTTP_409_CONFLICT,
+        )
+
+    if payload_values.sync_group_id != local_identity.sync_group_id:
+        if not adopt_sync_group or _active_trusted_peer_count(session) > 0:
+            raise AppError(
+                SYNC_GROUP_MISMATCH,
+                "Pairing payload belongs to a different sync group.",
+                status_code=status.HTTP_409_CONFLICT,
+                details={
+                    "local_sync_group_id": local_identity.sync_group_id,
+                    "payload_sync_group_id": payload_values.sync_group_id,
+                },
+            )
+        local_identity.sync_group_id = payload_values.sync_group_id
+        local_identity.updated_at = _utcnow()
+        session.flush()
+
+
+def _upsert_trusted_peer_from_pairing_values(
+    session: Session,
+    *,
+    payload_values: _PairingPayloadValues,
+    now: datetime,
+) -> SyncTrustedPeer:
+    existing_public_key_peer = session.scalars(
+        select(SyncTrustedPeer).where(SyncTrustedPeer.public_key == payload_values.public_key)
+    ).first()
+    if (
+        existing_public_key_peer is not None
+        and existing_public_key_peer.device_id != payload_values.device_id
+    ):
+        raise _pairing_invalid("Pairing payload public_key is already trusted for a different device.")
+
+    peer = session.get(SyncTrustedPeer, payload_values.device_id)
+    if peer is None:
+        peer = SyncTrustedPeer(
+            device_id=payload_values.device_id,
+            sync_group_id=payload_values.sync_group_id,
+            display_name=payload_values.display_name,
+            public_key=payload_values.public_key,
+            endpoint_hints_json=payload_values.endpoint_hints,
+            trusted_at=now,
+            revoked_at=None,
+            created_at=now,
+            updated_at=now,
+        )
+        session.add(peer)
+        return peer
+
+    peer.sync_group_id = payload_values.sync_group_id
+    peer.display_name = payload_values.display_name
+    peer.public_key = payload_values.public_key
+    peer.endpoint_hints_json = payload_values.endpoint_hints
+    peer.trusted_at = now
+    peer.revoked_at = None
+    peer.updated_at = now
+    return peer
+
+
+def _local_pairing_response_payload(
+    local_identity: SyncLocalIdentity,
+    *,
+    offer_values: _PairingPayloadValues,
+    endpoint_hints: list[str] | None,
+) -> dict[str, Any]:
+    response_payload: dict[str, Any] = {
+        "protocol_version": SYNC_PAIRING_PROTOCOL_VERSION,
+        "pairing_offer_id": offer_values.pairing_offer_id,
+        "sync_group_id": local_identity.sync_group_id,
+        "device_id": local_identity.device_id,
+        "display_name": local_identity.display_name,
+        "public_key": local_identity.public_key,
+        "endpoint_hints": _normalize_endpoint_hints(endpoint_hints),
+        "pairing_secret": offer_values.pairing_secret,
+        "expires_at": offer_values.expires_at.isoformat(),
+    }
+    response_payload["signature"] = sync_crypto.sign_payload(
+        sync_crypto.decode_key(local_identity.private_key),
+        _pairing_payload_signature_message(response_payload),
+    )
+    return response_payload
 
 
 def _local_identity_from_orm(identity: SyncLocalIdentity) -> LocalSyncIdentity:

--- a/apps/backend/tests/test_sync_reconciliation_apply_api.py
+++ b/apps/backend/tests/test_sync_reconciliation_apply_api.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from app.db import SessionLocal
+from app.models import Artifact, Project, SyncDeleteTombstone, SyncEntityRevision, SyncTrustedPeer
+from app.services.sync_identity import source_hash_to_project_id
+from app.services.sync_revisions import revision_payload_sha256
+from app.services.sync_staging import stage_sync_artifact
+from app.services.sync_trust import get_or_create_local_identity
+
+
+def test_reconciliation_apply_imports_staged_project_manifest(
+    client: TestClient,
+    sample_audio_file: Path,
+) -> None:
+    identity = _ensure_identity_and_peer("peer-apply-a")
+    content_sha256 = hashlib.sha256(sample_audio_file.read_bytes()).hexdigest()
+    project_id = source_hash_to_project_id(content_sha256)
+    manifest = _project_manifest(project_id, content_sha256, sample_audio_file.stat().st_size)
+    _stage_source_audio(sample_audio_file, content_sha256=content_sha256, provider_device_id="peer-apply-a")
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": {
+                "projects": [_remote_project(project_id, content_sha256)],
+                "artifacts": [],
+                "entity_revisions": [],
+                "delete_tombstones": [],
+            },
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": "peer-apply-a",
+                    "available_content_sha256": [content_sha256],
+                    "metadata": {"display_name": "Peer Apply"},
+                }
+            ],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 0
+    assert payload["summary"]["skipped_actions"] == 0
+    assert payload["summary"]["applied_actions"] >= 2
+    assert payload["summary"]["satisfied_actions"] >= 1
+
+    with SessionLocal() as session:
+        project = session.get(Project, project_id)
+        assert project is not None
+        assert project.sync_status == "local"
+        assert session.get(Artifact, f"art_source_{project_id}") is not None
+        imported_revision = session.get(SyncEntityRevision, "rev_apply_chords")
+        assert imported_revision is not None
+        assert imported_revision.author_device_id == "peer-apply-a"
+        assert session.get(SyncTrustedPeer, "peer-apply-a").sync_group_id == identity.sync_group_id
+
+
+def test_reconciliation_apply_applies_trusted_delete_tombstone(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    identity = _ensure_identity_and_peer("peer-apply-delete")
+    project_id = "proj_apply_tombstone"
+    artifact_path = tmp_path / "deleted.wav"
+    artifact_path.write_bytes(b"delete me")
+    content_sha256 = hashlib.sha256(artifact_path.read_bytes()).hexdigest()
+    _add_project_artifact(project_id, artifact_path, content_sha256)
+    now = datetime.now(UTC).isoformat()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": {
+                "projects": [],
+                "artifacts": [],
+                "entity_revisions": [],
+                "delete_tombstones": [
+                    {
+                        "tombstone_id": "tomb_apply_artifact",
+                        "sync_group_id": identity.sync_group_id,
+                        "project_id": project_id,
+                        "target_type": "artifact",
+                        "target_id": "art_apply_deleted",
+                        "author_device_id": "peer-apply-delete",
+                        "deleted_at": now,
+                        "prior_metadata": {},
+                        "created_at": now,
+                        "updated_at": now,
+                    }
+                ],
+            },
+            "project_manifests": [],
+            "peer_inventory": [],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 0
+    assert payload["summary"]["applied_actions"] == 1
+    assert payload["results"][0]["action"]["action_type"] == "apply_delete_tombstone"
+
+    with SessionLocal() as session:
+        assert session.get(Artifact, "art_apply_deleted") is None
+        assert session.get(Project, project_id) is not None
+        tombstone = session.get(SyncDeleteTombstone, "tomb_apply_artifact")
+        assert tombstone is not None
+        assert tombstone.target_type == "artifact"
+        assert tombstone.target_id == "art_apply_deleted"
+        assert tombstone.author_device_id == "peer-apply-delete"
+    assert not artifact_path.exists()
+
+
+def _ensure_identity_and_peer(peer_device_id: str) -> Any:
+    now = datetime.now(UTC)
+    with SessionLocal() as session:
+        identity = get_or_create_local_identity(session)
+        session.add(
+            SyncTrustedPeer(
+                device_id=peer_device_id,
+                sync_group_id=identity.sync_group_id,
+                display_name=peer_device_id,
+                public_key=f"pub-{peer_device_id}",
+                endpoint_hints_json=[],
+                trusted_at=now,
+                revoked_at=None,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        session.commit()
+        return identity
+
+
+def _stage_source_audio(
+    source_path: Path,
+    *,
+    content_sha256: str,
+    provider_device_id: str,
+) -> None:
+    with SessionLocal() as session:
+        stage_sync_artifact(
+            session,
+            source_path=source_path,
+            content_sha256=content_sha256,
+            size_bytes=source_path.stat().st_size,
+            provider_device_id=provider_device_id,
+            metadata={"role": "source_audio"},
+        )
+        session.commit()
+
+
+def _add_project_artifact(project_id: str, artifact_path: Path, content_sha256: str) -> None:
+    with SessionLocal() as session:
+        session.add(
+            Project(
+                id=project_id,
+                display_name="Apply Tombstone",
+                source_sha256="a" * 64,
+                source_path=str(artifact_path),
+                imported_path=str(artifact_path),
+            )
+        )
+        session.add(
+            Artifact(
+                id="art_apply_deleted",
+                project_id=project_id,
+                type="stem",
+                format="wav",
+                path=str(artifact_path),
+                content_sha256=content_sha256,
+                size_bytes=artifact_path.stat().st_size,
+                generated_by="test",
+                can_delete=True,
+                can_regenerate=False,
+                metadata_json={},
+            )
+        )
+        session.commit()
+
+
+def _remote_project(project_id: str, source_sha256: str) -> dict[str, Any]:
+    now = datetime.now(UTC).isoformat()
+    return {
+        "project_id": project_id,
+        "display_name": "Applied Remote Project",
+        "source_key_override": None,
+        "source_sha256": source_sha256,
+        "duration_seconds": None,
+        "sample_rate": None,
+        "channels": None,
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
+def _project_manifest(project_id: str, source_sha256: str, size_bytes: int) -> dict[str, Any]:
+    now = datetime.now(UTC).isoformat()
+    revision_payload = {"timeline": []}
+    return {
+        "schema_version": "1",
+        "exported_at": now,
+        "project": _remote_project(project_id, source_sha256),
+        "artifacts": [
+            {
+                "artifact_id": f"art_source_{project_id}",
+                "project_id": project_id,
+                "type": "source_audio",
+                "format": "wav",
+                "relative_path": "source/input.wav",
+                "content_sha256": source_sha256,
+                "size_bytes": size_bytes,
+                "generated_by": "sync",
+                "can_delete": False,
+                "can_regenerate": False,
+                "cache_key": None,
+                "metadata": {},
+                "created_at": now,
+            }
+        ],
+        "entity_revisions": [
+            {
+                "revision_id": "rev_apply_chords",
+                "project_id": project_id,
+                "entity_type": "chords",
+                "entity_id": project_id,
+                "revision_type": "manual",
+                "base_revision_id": None,
+                "author_device_id": "peer-apply-a",
+                "source_artifact_id": None,
+                "content_sha256": revision_payload_sha256(revision_payload),
+                "state": "current",
+                "metadata": {},
+                "payload": revision_payload,
+                "created_at": now,
+                "updated_at": now,
+            }
+        ],
+        "delete_tombstones": [],
+    }

--- a/apps/backend/tests/test_sync_transport_api.py
+++ b/apps/backend/tests/test_sync_transport_api.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from app.db import SessionLocal
+from app.models import SyncTrustedPeer
+from app.services import sync_crypto
+
+
+def test_transport_handshake_signs_canonical_challenge(client: TestClient) -> None:
+    identity = client.get("/api/v1/sync/identity").json()["identity"]
+    _add_trusted_peer(identity["sync_group_id"], device_id="peer-transport-a")
+
+    challenge = _challenge(
+        peer_device_id="peer-transport-a",
+        local_device_id=identity["device_id"],
+    )
+    response = client.post(
+        "/api/v1/sync/transport/handshake/sign",
+        json={"peer_device_id": "peer-transport-a", "challenge": challenge},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["local_device_id"] == identity["device_id"]
+    assert payload["peer_device_id"] == "peer-transport-a"
+    assert payload["public_key"] == identity["public_key"]
+    assert payload["challenge"]["challenge_type"] == "transport_handshake"
+    assert "private" not in json.dumps(payload)
+
+    sync_crypto.verify_payload_signature(
+        sync_crypto.decode_key(identity["public_key"]),
+        payload["canonical_challenge_json"].encode("utf-8"),
+        payload["signature"],
+    )
+
+
+def test_transport_handshake_rejects_noncanonical_responder(client: TestClient) -> None:
+    identity = client.get("/api/v1/sync/identity").json()["identity"]
+    _add_trusted_peer(identity["sync_group_id"], device_id="peer-transport-b")
+
+    challenge = _challenge(
+        peer_device_id="peer-transport-b",
+        local_device_id="dev_wrong_responder",
+    )
+    response = client.post(
+        "/api/v1/sync/transport/handshake/sign",
+        json={"peer_device_id": "peer-transport-b", "challenge": challenge},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "SYNC_TRANSPORT_CHALLENGE_INVALID"
+
+
+def test_transport_handshake_rejects_unknown_peer(client: TestClient) -> None:
+    identity = client.get("/api/v1/sync/identity").json()["identity"]
+    response = client.post(
+        "/api/v1/sync/transport/handshake/sign",
+        json={
+            "peer_device_id": "peer-transport-unknown",
+            "challenge": _challenge(
+                peer_device_id="peer-transport-unknown",
+                local_device_id=identity["device_id"],
+            ),
+        },
+    )
+
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "SYNC_PEER_UNTRUSTED"
+
+
+def _add_trusted_peer(sync_group_id: str, *, device_id: str) -> None:
+    now = datetime.now(UTC)
+    with SessionLocal() as session:
+        session.add(
+            SyncTrustedPeer(
+                device_id=device_id,
+                sync_group_id=sync_group_id,
+                display_name=device_id,
+                public_key=f"pub-{device_id}",
+                endpoint_hints_json=[],
+                trusted_at=now,
+                revoked_at=None,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        session.commit()
+
+
+def _challenge(*, peer_device_id: str, local_device_id: str) -> dict[str, Any]:
+    issued_at = datetime.now(UTC)
+    expires_at = issued_at + timedelta(seconds=60)
+    return {
+        "protocol_version": "tuneforge-sync-v1",
+        "challenge_type": "transport_handshake",
+        "session_id": "session-transport-0001",
+        "challenge_nonce": "nonce-transport-0000000000000001",
+        "requester_device_id": peer_device_id,
+        "responder_device_id": local_device_id,
+        "issued_at": issued_at.isoformat(),
+        "expires_at": expires_at.isoformat(),
+    }

--- a/apps/backend/tests/test_sync_trust.py
+++ b/apps/backend/tests/test_sync_trust.py
@@ -48,6 +48,7 @@ SIGNED_PAIRING_OFFER_FIELDS = (
 class SyncTrustServices:
     get_or_create_local_identity: SyncTrustService
     create_pairing_offer: SyncTrustService
+    answer_pairing_offer: SyncTrustService
     trust_peer: SyncTrustService
     list_trusted_peers: SyncTrustService
     revoke_trusted_peer: SyncTrustService
@@ -92,6 +93,7 @@ def sync_trust_services() -> SyncTrustServices:
             "get_or_create_local_sync_identity",
         ),
         create_pairing_offer=_require_callable(module, "create_pairing_offer"),
+        answer_pairing_offer=_require_callable(module, "answer_pairing_offer"),
         trust_peer=_require_callable(module, "trust_peer", "trust_peer_from_pairing_payload"),
         list_trusted_peers=_require_callable(module, "list_trusted_peers"),
         revoke_trusted_peer=_require_callable(module, "revoke_trusted_peer"),
@@ -161,6 +163,49 @@ def test_trusting_valid_peer_persists_pairwise_trust(
     assert trusted_peer.get("revoked_at") is None
     assert listed_peer["device_id"] == peer_offer["device_id"]
     assert listed_peer.get("revoked_at") is None
+
+
+def test_answer_pairing_offer_trusts_remote_and_returns_local_response(
+    db_session: Session,
+    sync_trust_services: SyncTrustServices,
+) -> None:
+    identity = _local_identity(sync_trust_services, db_session)
+    template_offer = _pairing_payload(_pairing_offer(sync_trust_services, db_session))
+    remote_offer = _remote_pairing_offer(
+        sync_trust_services,
+        sync_group_id=identity["sync_group_id"],
+        public_key_like=identity["public_key"],
+        template_offer=template_offer,
+        pairing_offer_id="pair_remote_offer_1",
+    )
+
+    answer = _plain_mapping(
+        sync_trust_services.answer_pairing_offer(
+            db_session,
+            remote_offer,
+            endpoint_hints=["tuneforge-sync+tcp://192.168.1.42:48625?device_id=device_local&v=1"],
+        )
+    )
+    response_payload = _unwrap_mapping(answer, "payload")
+    trusted_peer = _unwrap_mapping(answer, "trusted_peer")
+
+    assert trusted_peer["device_id"] == remote_offer["device_id"]
+    assert trusted_peer["public_key"] == remote_offer["public_key"]
+    assert response_payload["device_id"] == identity["device_id"]
+    assert response_payload["public_key"] == identity["public_key"]
+    assert response_payload["pairing_offer_id"] == remote_offer["pairing_offer_id"]
+    assert response_payload["pairing_secret"] == remote_offer["pairing_secret"]
+    assert response_payload["expires_at"] == remote_offer["expires_at"]
+    assert response_payload["endpoint_hints"] == [
+        "tuneforge-sync+tcp://192.168.1.42:48625?device_id=device_local&v=1"
+    ]
+    _verify_pairing_payload_signature(identity["public_key"], response_payload)
+
+    listed_peer = _peer_by_device_id(
+        _plain_list(sync_trust_services.list_trusted_peers(db_session)),
+        remote_offer["device_id"],
+    )
+    assert listed_peer["device_id"] == remote_offer["device_id"]
 
 
 def test_self_pairing_is_rejected(
@@ -363,6 +408,50 @@ def test_trusted_peer_routes_create_list_and_revoke(client, sync_trust_services:
     assert revoked_peer["revoked_at"] is not None
 
 
+def test_pairing_response_route_answers_remote_offer(client, sync_trust_services: SyncTrustServices) -> None:
+    identity = _unwrap_mapping(client.get("/api/v1/sync/identity").json(), "identity")
+    template_offer = _pairing_payload(
+        _unwrap_mapping(client.post("/api/v1/sync/pairing/offers", json={}).json(), "pairing_offer")
+    )
+    remote_offer = _remote_pairing_offer(
+        sync_trust_services,
+        sync_group_id=identity["sync_group_id"],
+        public_key_like=identity["public_key"],
+        template_offer=template_offer,
+        pairing_offer_id="pair_remote_route_offer",
+    )
+
+    response = client.post(
+        "/api/v1/sync/pairing/responses",
+        json={
+            "offer": remote_offer,
+            "endpoint_hints": ["tuneforge-sync+tcp://192.168.1.42:48625?device_id=device_local&v=1"],
+            "adopt_sync_group": False,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    pairing_response = _unwrap_mapping(payload, "pairing_response")
+    trusted_peer = _unwrap_mapping(payload, "trusted_peer")
+    assert trusted_peer["device_id"] == remote_offer["device_id"]
+    assert pairing_response["device_id"] == identity["device_id"]
+    assert pairing_response["pairing_offer_id"] == remote_offer["pairing_offer_id"]
+    assert pairing_response["pairing_secret"] == remote_offer["pairing_secret"]
+    assert pairing_response["endpoint_hints"] == [
+        "tuneforge-sync+tcp://192.168.1.42:48625?device_id=device_local&v=1"
+    ]
+    _verify_pairing_payload_signature(
+        identity["public_key"],
+        {**pairing_response, "expires_at": _parse_datetime(pairing_response["expires_at"]).isoformat()},
+    )
+
+    list_response = client.get("/api/v1/sync/trusted-peers")
+    assert list_response.status_code == 200
+    peers = _unwrap_list(list_response.json(), "trusted_peers")
+    assert _peer_by_device_id(peers, remote_offer["device_id"])["public_key"] == remote_offer["public_key"]
+
+
 def _require_callable(module: Any, *names: str) -> SyncTrustService:
     for name in names:
         value = getattr(module, name, None)
@@ -492,6 +581,13 @@ def _sign_pairing_payload(private_key_bytes: bytes, payload: dict[str, Any]) -> 
     signed_payload = {field_name: payload[field_name] for field_name in SIGNED_PAIRING_OFFER_FIELDS}
     message = json.dumps(signed_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return crypto.sign_payload(private_key_bytes, message)
+
+
+def _verify_pairing_payload_signature(public_key: str, payload: dict[str, Any]) -> None:
+    crypto = importlib.import_module("app.services.sync_crypto")
+    signed_payload = {field_name: payload[field_name] for field_name in SIGNED_PAIRING_OFFER_FIELDS}
+    message = json.dumps(signed_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    crypto.verify_payload_signature(crypto.decode_key(public_key), message, payload["signature"])
 
 
 def _b64encode(raw: bytes) -> str:

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bindgen"
 version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +231,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -378,6 +428,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +463,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -420,6 +505,12 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "convert_case"
@@ -561,6 +652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -619,6 +711,42 @@ name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "darling"
@@ -785,6 +913,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,6 +974,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -972,6 +1111,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +1218,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "field-offset"
@@ -1386,6 +1555,16 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1853,6 +2032,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,6 +2071,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2630,6 +2828,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2869,6 +3073,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2911,6 +3125,29 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -3626,6 +3863,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3654,6 +3900,22 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "snow"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "850948bee068e713b8ab860fe1adc4d109676ab4c3b621fd8147f06b261f2f85"
+dependencies = [
+ "aes-gcm",
+ "blake2",
+ "chacha20poly1305",
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "rustc_version",
+ "sha2",
+ "subtle",
+]
 
 [[package]]
 name = "socket2"
@@ -3711,6 +3973,16 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -3785,6 +4057,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -4725,17 +5003,23 @@ name = "tuneforge"
 version = "0.1.0"
 dependencies = [
  "android_system_properties",
+ "base64 0.22.1",
  "block2",
  "chrono",
  "cpal",
  "dbus",
+ "ed25519-dalek",
+ "if-addrs",
  "ndk-sys",
  "objc2",
  "objc2-foundation",
+ "rand 0.8.6",
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "signalsmith-stretch",
+ "snow",
  "symphonia",
  "tauri",
  "tauri-build",
@@ -4815,6 +5099,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "url"
@@ -5865,6 +6159,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -23,6 +23,14 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4.44", features = ["serde"] }
 
+[target.'cfg(not(target_os = "android"))'.dependencies]
+base64 = "0.22.1"
+ed25519-dalek = "2.2.0"
+if-addrs = "0.13.4"
+rand = "0.8.6"
+sha2 = "0.10.9"
+snow = "0.9.6"
+
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 cpal = "0.17.3"
 signalsmith-stretch = "0.1.3"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ use tauri::{Manager, State};
 
 mod mobile_backend;
 mod native_audio;
+mod sync_transport;
 mod system_media;
 
 struct BackendRuntime {
@@ -335,8 +336,10 @@ pub fn run() {
             } else {
                 spawn_packaged_backend(app.handle())?
             };
+            let sync_transport = sync_transport::SyncTransportState::new(runtime.base_url.clone());
             app.manage(runtime);
             app.manage(native_audio::NativeAudioState::new());
+            app.manage(sync_transport);
             app.manage(system_media::SystemMediaState::new(app.handle().clone()));
             #[cfg(target_os = "linux")]
             install_linux_media_permission_handler(app.handle())?;
@@ -366,6 +369,11 @@ pub fn run() {
             system_media::system_media_update_state,
             system_media::system_media_clear_state,
             system_media::system_media_set_idle_inhibition,
+            sync_transport::sync_transport_start_listener,
+            sync_transport::sync_transport_stop_listener,
+            sync_transport::sync_transport_status,
+            sync_transport::sync_transport_create_pairing_offer,
+            sync_transport::sync_transport_sync_now,
             mobile_backend::mobile_capabilities,
             mobile_backend::mobile_get_health,
             mobile_backend::mobile_list_projects,
@@ -396,6 +404,8 @@ pub fn run() {
 
     app.run(|app_handle, event| {
         if let tauri::RunEvent::Exit = event {
+            let sync_transport = app_handle.state::<sync_transport::SyncTransportState>();
+            sync_transport.shutdown();
             let runtime = app_handle.state::<BackendRuntime>();
             runtime.shutdown();
         }

--- a/apps/desktop/src-tauri/src/sync_transport.rs
+++ b/apps/desktop/src-tauri/src/sync_transport.rs
@@ -1,0 +1,2229 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncTransportStartListenerRequest {
+    pub bind_host: Option<String>,
+    pub port: Option<u16>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncTransportSyncNowRequest {
+    pub peer_device_id: String,
+    pub endpoint_hint: Option<String>,
+    pub project_ids: Option<Vec<String>>,
+    #[serde(default = "default_true")]
+    pub export_local: bool,
+    #[serde(default = "default_true")]
+    pub import_remote: bool,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncTransportPairingOfferRequest {
+    pub ttl_seconds: Option<u32>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncTransportStatus {
+    pub supported: bool,
+    pub running: bool,
+    pub bind_host: Option<String>,
+    pub port: Option<u16>,
+    pub endpoint_hints: Vec<String>,
+    pub active_sessions: usize,
+    pub accepted_sessions: u64,
+    pub failed_sessions: u64,
+    pub last_status: Option<String>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncTransportPairingOffer {
+    pub endpoint_hints: Vec<String>,
+    pub pairing_offer: Value,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncTransportTransferResult {
+    pub artifact_id: String,
+    pub content_sha256: String,
+    pub size_bytes: u64,
+    pub status: String,
+    pub message: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncTransportProjectResult {
+    pub project_id: String,
+    pub status: String,
+    pub message: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncTransportSyncResult {
+    pub peer_device_id: String,
+    pub remote_device_id: String,
+    pub imported_projects: Vec<SyncTransportProjectResult>,
+    pub received_artifacts: Vec<SyncTransportTransferResult>,
+    pub served_artifact_requests: u64,
+    pub remote_manifest_count: usize,
+    pub local_manifest_count: usize,
+    pub manifest_errors: Vec<SyncTransportManifestError>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncTransportManifestError {
+    pub project_id: String,
+    pub message: String,
+}
+
+#[cfg(not(target_os = "android"))]
+mod desktop {
+    use super::{
+        SyncTransportManifestError, SyncTransportPairingOffer, SyncTransportPairingOfferRequest,
+        SyncTransportProjectResult, SyncTransportStartListenerRequest, SyncTransportStatus,
+        SyncTransportSyncNowRequest, SyncTransportSyncResult, SyncTransportTransferResult,
+    };
+    use base64::{
+        engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+        Engine as _,
+    };
+    use chrono::{DateTime, Utc};
+    use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+    use rand::{rngs::OsRng, RngCore};
+    use serde::{Deserialize, Serialize};
+    use serde_json::{json, Value};
+    use sha2::{Digest, Sha256};
+    use snow::{params::NoiseParams, Builder};
+    use std::{
+        collections::HashMap,
+        env,
+        fs::{self, File},
+        io::{self, BufRead, BufReader, Read, Write},
+        net::{IpAddr, SocketAddr, TcpListener, TcpStream, ToSocketAddrs},
+        path::PathBuf,
+        process,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc, Mutex,
+        },
+        thread::{self, JoinHandle},
+        time::Duration,
+    };
+    use tauri::State;
+
+    const DEFAULT_BIND_HOST: &str = "0.0.0.0";
+    const ENDPOINT_SCHEME: &str = "tuneforge-sync+tcp://";
+    const PAIRING_PROTOCOL_VERSION: &str = "tuneforge-sync-v1";
+    const TRANSPORT_PROTOCOL_VERSION: &str = "tuneforge-sync-transport-v1";
+    const TRANSPORT_HANDSHAKE_CHALLENGE_TYPE: &str = "transport_handshake";
+    const NOISE_PATTERN: &str = "Noise_XX_25519_ChaChaPoly_BLAKE2s";
+    const READ_TIMEOUT: Duration = Duration::from_secs(45);
+    const WRITE_TIMEOUT: Duration = Duration::from_secs(45);
+    const ACCEPT_SLEEP: Duration = Duration::from_millis(100);
+    const MAX_RAW_FRAME: usize = 65_535;
+    const ENCRYPTED_PAYLOAD_CHUNK: usize = 32 * 1024;
+    const ARTIFACT_CHUNK_SIZE: usize = 24 * 1024;
+    const PAIRING_OFFER_TTL_SECONDS: u32 = 600;
+    const TRANSPORT_HANDSHAKE_TTL_SECONDS: i64 = 60;
+    const HTTP_TIMEOUT: Duration = Duration::from_secs(45);
+
+    #[derive(Clone)]
+    pub struct SyncTransportState {
+        base_url: String,
+        listener: Arc<Mutex<Option<ListenerHandle>>>,
+        shared_status: Arc<Mutex<SharedStatus>>,
+    }
+
+    impl SyncTransportState {
+        pub fn new(base_url: String) -> Self {
+            Self {
+                base_url,
+                listener: Arc::new(Mutex::new(None)),
+                shared_status: Arc::new(Mutex::new(SharedStatus::default())),
+            }
+        }
+
+        fn start_listener(
+            &self,
+            payload: SyncTransportStartListenerRequest,
+        ) -> Result<SyncTransportStatus, String> {
+            {
+                let guard = self
+                    .listener
+                    .lock()
+                    .map_err(|_| "Sync transport listener state is unavailable.".to_string())?;
+                if guard.is_some() {
+                    return Ok(self.status());
+                }
+            }
+
+            let client = BackendClient::new(&self.base_url)?;
+            let identity = client
+                .local_identity()
+                .map_err(|error| format!("Could not load local sync identity: {error}"))?;
+            let bind_host = payload
+                .bind_host
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .unwrap_or(DEFAULT_BIND_HOST)
+                .to_string();
+            let port = payload.port.unwrap_or(0);
+            let listener = TcpListener::bind((bind_host.as_str(), port))
+                .map_err(|error| format!("Could not bind sync transport listener: {error}"))?;
+            listener
+                .set_nonblocking(true)
+                .map_err(|error| format!("Could not configure sync transport listener: {error}"))?;
+            let bind_addr = listener
+                .local_addr()
+                .map_err(|error| format!("Could not inspect sync transport listener: {error}"))?;
+            let endpoint_hints = endpoint_hints_for_port(bind_addr.port(), &identity.device_id);
+            let stop = Arc::new(AtomicBool::new(false));
+            let thread_stop = Arc::clone(&stop);
+            let base_url = self.base_url.clone();
+            let shared_status = Arc::clone(&self.shared_status);
+            let thread = thread::spawn(move || {
+                accept_loop(listener, base_url, thread_stop, shared_status);
+            });
+
+            let handle = ListenerHandle {
+                bind_addr,
+                endpoint_hints,
+                stop,
+                thread: Some(thread),
+            };
+            {
+                let mut guard = self
+                    .listener
+                    .lock()
+                    .map_err(|_| "Sync transport listener state is unavailable.".to_string())?;
+                *guard = Some(handle);
+            }
+            update_status(&self.shared_status, |status| {
+                status.last_status = Some("Sync transport listener started.".to_string());
+                status.last_error = None;
+            });
+
+            Ok(self.status())
+        }
+
+        fn stop_listener(&self) -> Result<SyncTransportStatus, String> {
+            let listener = {
+                let mut guard = self
+                    .listener
+                    .lock()
+                    .map_err(|_| "Sync transport listener state is unavailable.".to_string())?;
+                guard.take()
+            };
+
+            if let Some(mut listener) = listener {
+                listener.stop.store(true, Ordering::SeqCst);
+                if let Some(thread) = listener.thread.take() {
+                    thread
+                        .join()
+                        .map_err(|_| "Sync transport listener thread panicked.".to_string())?;
+                }
+                update_status(&self.shared_status, |status| {
+                    status.last_status = Some("Sync transport listener stopped.".to_string());
+                });
+            }
+
+            Ok(self.status())
+        }
+
+        pub fn shutdown(&self) {
+            let _ = self.stop_listener();
+        }
+
+        fn status(&self) -> SyncTransportStatus {
+            let shared = self
+                .shared_status
+                .lock()
+                .map(|status| status.clone())
+                .unwrap_or_default();
+            let listener = self.listener.lock().ok();
+            let listener = listener.as_ref().and_then(|guard| guard.as_ref());
+
+            SyncTransportStatus {
+                supported: true,
+                running: listener.is_some(),
+                bind_host: listener.map(|handle| handle.bind_addr.ip().to_string()),
+                port: listener.map(|handle| handle.bind_addr.port()),
+                endpoint_hints: listener
+                    .map(|handle| handle.endpoint_hints.clone())
+                    .unwrap_or_default(),
+                active_sessions: shared.active_sessions,
+                accepted_sessions: shared.accepted_sessions,
+                failed_sessions: shared.failed_sessions,
+                last_status: shared.last_status,
+                last_error: shared.last_error,
+            }
+        }
+
+        fn create_pairing_offer(
+            &self,
+            payload: SyncTransportPairingOfferRequest,
+        ) -> Result<SyncTransportPairingOffer, String> {
+            let status = self.status();
+            if !status.running || status.endpoint_hints.is_empty() {
+                return Err(
+                    "Start the sync transport listener before creating a LAN pairing offer."
+                        .to_string(),
+                );
+            }
+            let ttl_seconds = payload.ttl_seconds.unwrap_or(PAIRING_OFFER_TTL_SECONDS);
+            let client = BackendClient::new(&self.base_url)?;
+            let pairing_offer = client
+                .create_pairing_offer(status.endpoint_hints.clone(), ttl_seconds)
+                .map_err(|error| format!("Could not create sync pairing offer: {error}"))?;
+            Ok(SyncTransportPairingOffer {
+                endpoint_hints: status.endpoint_hints,
+                pairing_offer,
+            })
+        }
+
+        fn sync_now(
+            &self,
+            payload: SyncTransportSyncNowRequest,
+        ) -> Result<SyncTransportSyncResult, String> {
+            let client = BackendClient::new(&self.base_url)?;
+            let peer = client
+                .trusted_peer(&payload.peer_device_id)
+                .map_err(|error| format!("Could not load trusted sync peer: {error}"))?
+                .ok_or_else(|| {
+                    format!(
+                        "Trusted sync peer {} is not known or has been revoked.",
+                        payload.peer_device_id
+                    )
+                })?;
+            let endpoint_hint = payload
+                .endpoint_hint
+                .clone()
+                .or_else(|| first_tcp_endpoint_hint(&peer.endpoint_hints))
+                .ok_or_else(|| {
+                    format!(
+                        "Trusted sync peer {} does not have a TuneForge TCP endpoint hint.",
+                        payload.peer_device_id
+                    )
+                })?;
+            let endpoint = parse_endpoint_hint(&endpoint_hint, Some(&payload.peer_device_id))?;
+            let stream = TcpStream::connect_timeout(&endpoint, Duration::from_secs(10)).map_err(
+                |error| format!("Could not connect to sync peer at {endpoint}: {error}"),
+            )?;
+            configure_stream(&stream)?;
+
+            let mut connection = SecurePeerConnection::connect_initiator(stream)?;
+            let session = authenticate_session(
+                &mut connection,
+                &client,
+                Some(payload.peer_device_id.clone()),
+            )?;
+
+            let local_offer = load_local_manifest_offer(
+                &client,
+                payload.project_ids.as_deref(),
+                payload.export_local,
+            );
+            let local_manifest_count = local_offer.project_manifests.len();
+            connection.send_message(&ProtocolMessage::ManifestOffer(local_offer.clone()))?;
+            let remote_offer = match connection.read_message()? {
+                ProtocolMessage::ManifestOffer(offer) => offer,
+                ProtocolMessage::Error(error) => {
+                    return Err(format!("Sync peer returned an error: {}", error.message));
+                }
+                other => {
+                    return Err(format!(
+                        "Sync peer sent unexpected message during manifest exchange: {}",
+                        other.kind()
+                    ));
+                }
+            };
+
+            let mut imported_projects = Vec::new();
+            let mut received_artifacts = Vec::new();
+            if payload.import_remote {
+                let imported = import_remote_manifests(
+                    &client,
+                    &mut connection,
+                    &session.remote_device_id,
+                    &remote_offer.metadata,
+                    &remote_offer.project_manifests,
+                );
+                imported_projects = imported.imported_projects;
+                received_artifacts = imported.received_artifacts;
+            }
+            connection.send_message(&ProtocolMessage::PhaseDone {
+                phase: "initiator_import".to_string(),
+            })?;
+            let served_artifact_requests = serve_artifact_requests_until_done(
+                &client,
+                &mut connection,
+                &local_offer.project_manifests,
+            )?;
+
+            Ok(SyncTransportSyncResult {
+                peer_device_id: payload.peer_device_id,
+                remote_device_id: session.remote_device_id,
+                imported_projects,
+                received_artifacts,
+                served_artifact_requests,
+                remote_manifest_count: remote_offer.project_manifests.len(),
+                local_manifest_count,
+                manifest_errors: remote_offer.manifest_errors,
+            })
+        }
+    }
+
+    pub fn sync_transport_start_listener(
+        state: State<'_, SyncTransportState>,
+        payload: SyncTransportStartListenerRequest,
+    ) -> Result<SyncTransportStatus, String> {
+        state.start_listener(payload)
+    }
+
+    pub fn sync_transport_stop_listener(
+        state: State<'_, SyncTransportState>,
+    ) -> Result<SyncTransportStatus, String> {
+        state.stop_listener()
+    }
+
+    pub fn sync_transport_status(state: State<'_, SyncTransportState>) -> SyncTransportStatus {
+        state.status()
+    }
+
+    pub async fn sync_transport_create_pairing_offer(
+        state: State<'_, SyncTransportState>,
+        payload: SyncTransportPairingOfferRequest,
+    ) -> Result<SyncTransportPairingOffer, String> {
+        let state = state.inner().clone();
+        tauri::async_runtime::spawn_blocking(move || state.create_pairing_offer(payload))
+            .await
+            .map_err(|error| format!("Sync transport pairing task failed: {error}"))?
+    }
+
+    pub async fn sync_transport_sync_now(
+        state: State<'_, SyncTransportState>,
+        payload: SyncTransportSyncNowRequest,
+    ) -> Result<SyncTransportSyncResult, String> {
+        let state = state.inner().clone();
+        tauri::async_runtime::spawn_blocking(move || state.sync_now(payload))
+            .await
+            .map_err(|error| format!("Sync transport task failed: {error}"))?
+    }
+
+    struct ListenerHandle {
+        bind_addr: SocketAddr,
+        endpoint_hints: Vec<String>,
+        stop: Arc<AtomicBool>,
+        thread: Option<JoinHandle<()>>,
+    }
+
+    #[derive(Clone, Default)]
+    struct SharedStatus {
+        active_sessions: usize,
+        accepted_sessions: u64,
+        failed_sessions: u64,
+        last_status: Option<String>,
+        last_error: Option<String>,
+    }
+
+    fn accept_loop(
+        listener: TcpListener,
+        base_url: String,
+        stop: Arc<AtomicBool>,
+        shared_status: Arc<Mutex<SharedStatus>>,
+    ) {
+        while !stop.load(Ordering::SeqCst) {
+            match listener.accept() {
+                Ok((stream, address)) => {
+                    let base_url = base_url.clone();
+                    let shared_status = Arc::clone(&shared_status);
+                    update_status(&shared_status, |status| {
+                        status.accepted_sessions += 1;
+                        status.last_status =
+                            Some(format!("Accepted sync peer session from {address}."));
+                        status.last_error = None;
+                    });
+                    thread::spawn(move || {
+                        handle_incoming_session(base_url, stream, shared_status);
+                    });
+                }
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    thread::sleep(ACCEPT_SLEEP);
+                }
+                Err(error) => {
+                    update_status(&shared_status, |status| {
+                        status.failed_sessions += 1;
+                        status.last_error =
+                            Some(format!("Sync transport listener accept failed: {error}"));
+                    });
+                    thread::sleep(ACCEPT_SLEEP);
+                }
+            }
+        }
+    }
+
+    fn handle_incoming_session(
+        base_url: String,
+        stream: TcpStream,
+        shared_status: Arc<Mutex<SharedStatus>>,
+    ) {
+        update_status(&shared_status, |status| {
+            status.active_sessions += 1;
+        });
+        let result = serve_incoming_session(base_url, stream);
+        update_status(&shared_status, |status| {
+            status.active_sessions = status.active_sessions.saturating_sub(1);
+            match result {
+                Ok(summary) => {
+                    status.last_status = Some(summary);
+                    status.last_error = None;
+                }
+                Err(error) => {
+                    status.failed_sessions += 1;
+                    status.last_error = Some(error);
+                }
+            }
+        });
+    }
+
+    fn serve_incoming_session(base_url: String, stream: TcpStream) -> Result<String, String> {
+        configure_stream(&stream)?;
+        let client = BackendClient::new(&base_url)?;
+        let mut connection = SecurePeerConnection::connect_responder(stream)?;
+        let session = authenticate_session(&mut connection, &client, None)?;
+        let remote_offer = match connection.read_message()? {
+            ProtocolMessage::ManifestOffer(offer) => offer,
+            ProtocolMessage::Error(error) => {
+                return Err(format!("Sync peer returned an error: {}", error.message));
+            }
+            other => {
+                return Err(format!(
+                    "Sync peer sent unexpected first sync message: {}",
+                    other.kind()
+                ));
+            }
+        };
+        let local_offer = load_local_manifest_offer(&client, None, true);
+        let local_manifest_count = local_offer.project_manifests.len();
+        connection.send_message(&ProtocolMessage::ManifestOffer(local_offer.clone()))?;
+
+        let served_artifact_requests = serve_artifact_requests_until_done(
+            &client,
+            &mut connection,
+            &local_offer.project_manifests,
+        )?;
+        let imported = import_remote_manifests(
+            &client,
+            &mut connection,
+            &session.remote_device_id,
+            &remote_offer.metadata,
+            &remote_offer.project_manifests,
+        );
+        connection.send_message(&ProtocolMessage::PhaseDone {
+            phase: "responder_import".to_string(),
+        })?;
+
+        Ok(format!(
+            "Sync session with {} completed: served {} artifact request(s), imported {} project manifest(s), offered {} local manifest(s).",
+            session.remote_device_id,
+            served_artifact_requests,
+            imported.imported_projects.len(),
+            local_manifest_count
+        ))
+    }
+
+    fn update_status(
+        shared_status: &Arc<Mutex<SharedStatus>>,
+        update: impl FnOnce(&mut SharedStatus),
+    ) {
+        if let Ok(mut status) = shared_status.lock() {
+            update(&mut status);
+        }
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct ManifestOffer {
+        metadata: Value,
+        project_manifests: Vec<Value>,
+        manifest_errors: Vec<SyncTransportManifestError>,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(tag = "type", rename_all = "snake_case")]
+    enum ProtocolMessage {
+        AuthChallenge {
+            protocol_version: String,
+            device_id: String,
+            session_nonce: String,
+        },
+        AuthProof {
+            handshake_signature: Value,
+        },
+        ManifestOffer(ManifestOffer),
+        ArtifactRequest {
+            artifact_id: String,
+            content_sha256: String,
+            size_bytes: u64,
+        },
+        ArtifactStart {
+            artifact_id: String,
+            content_sha256: String,
+            size_bytes: u64,
+        },
+        ArtifactChunk {
+            data: String,
+        },
+        ArtifactEnd {
+            content_sha256: String,
+            size_bytes: u64,
+        },
+        Status {
+            phase: String,
+            message: String,
+        },
+        PhaseDone {
+            phase: String,
+        },
+        Error(ProtocolError),
+    }
+
+    impl ProtocolMessage {
+        fn kind(&self) -> &'static str {
+            match self {
+                Self::AuthChallenge { .. } => "auth_challenge",
+                Self::AuthProof { .. } => "auth_proof",
+                Self::ManifestOffer(_) => "manifest_offer",
+                Self::ArtifactRequest { .. } => "artifact_request",
+                Self::ArtifactStart { .. } => "artifact_start",
+                Self::ArtifactChunk { .. } => "artifact_chunk",
+                Self::ArtifactEnd { .. } => "artifact_end",
+                Self::Status { .. } => "status",
+                Self::PhaseDone { .. } => "phase_done",
+                Self::Error(_) => "error",
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct ProtocolError {
+        code: String,
+        message: String,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct EncryptedChunk {
+        message_id: u64,
+        chunk_index: u32,
+        chunk_count: u32,
+        data: String,
+    }
+
+    struct SecurePeerConnection {
+        stream: TcpStream,
+        noise: snow::TransportState,
+        handshake_hash: String,
+        next_message_id: u64,
+    }
+
+    impl SecurePeerConnection {
+        fn connect_initiator(mut stream: TcpStream) -> Result<Self, String> {
+            let mut handshake = build_noise_handshake(true)?;
+            let mut buffer = vec![0_u8; MAX_RAW_FRAME];
+            let written = handshake
+                .write_message(&[], &mut buffer)
+                .map_err(|error| format!("Noise handshake write failed: {error}"))?;
+            write_raw_frame(&mut stream, &buffer[..written])?;
+
+            let message = read_raw_frame(&mut stream)?;
+            handshake
+                .read_message(&message, &mut buffer)
+                .map_err(|error| format!("Noise handshake read failed: {error}"))?;
+
+            let written = handshake
+                .write_message(&[], &mut buffer)
+                .map_err(|error| format!("Noise handshake write failed: {error}"))?;
+            write_raw_frame(&mut stream, &buffer[..written])?;
+            let handshake_hash = URL_SAFE_NO_PAD.encode(handshake.get_handshake_hash());
+            let noise = handshake
+                .into_transport_mode()
+                .map_err(|error| format!("Noise transport setup failed: {error}"))?;
+            Ok(Self {
+                stream,
+                noise,
+                handshake_hash,
+                next_message_id: 1,
+            })
+        }
+
+        fn connect_responder(mut stream: TcpStream) -> Result<Self, String> {
+            let mut handshake = build_noise_handshake(false)?;
+            let mut buffer = vec![0_u8; MAX_RAW_FRAME];
+
+            let message = read_raw_frame(&mut stream)?;
+            handshake
+                .read_message(&message, &mut buffer)
+                .map_err(|error| format!("Noise handshake read failed: {error}"))?;
+
+            let written = handshake
+                .write_message(&[], &mut buffer)
+                .map_err(|error| format!("Noise handshake write failed: {error}"))?;
+            write_raw_frame(&mut stream, &buffer[..written])?;
+
+            let message = read_raw_frame(&mut stream)?;
+            handshake
+                .read_message(&message, &mut buffer)
+                .map_err(|error| format!("Noise handshake read failed: {error}"))?;
+            let handshake_hash = URL_SAFE_NO_PAD.encode(handshake.get_handshake_hash());
+            let noise = handshake
+                .into_transport_mode()
+                .map_err(|error| format!("Noise transport setup failed: {error}"))?;
+            Ok(Self {
+                stream,
+                noise,
+                handshake_hash,
+                next_message_id: 1,
+            })
+        }
+
+        fn send_message(&mut self, message: &ProtocolMessage) -> Result<(), String> {
+            let payload = serde_json::to_vec(message)
+                .map_err(|error| format!("Could not encode sync transport message: {error}"))?;
+            let message_id = self.next_message_id;
+            self.next_message_id = self.next_message_id.saturating_add(1);
+            let chunk_count = payload.len().max(1).div_ceil(ENCRYPTED_PAYLOAD_CHUNK) as u32;
+            for (index, chunk) in payload.chunks(ENCRYPTED_PAYLOAD_CHUNK).enumerate() {
+                let envelope = EncryptedChunk {
+                    message_id,
+                    chunk_index: index as u32,
+                    chunk_count,
+                    data: STANDARD.encode(chunk),
+                };
+                self.send_encrypted_chunk(&envelope)?;
+            }
+            if payload.is_empty() {
+                let envelope = EncryptedChunk {
+                    message_id,
+                    chunk_index: 0,
+                    chunk_count: 1,
+                    data: String::new(),
+                };
+                self.send_encrypted_chunk(&envelope)?;
+            }
+            Ok(())
+        }
+
+        fn read_message(&mut self) -> Result<ProtocolMessage, String> {
+            let first = self.read_encrypted_chunk()?;
+            if first.chunk_count == 0 {
+                return Err("Encrypted sync transport message has no chunks.".to_string());
+            }
+            if first.chunk_index != 0 {
+                return Err("Encrypted sync transport chunks arrived out of order.".to_string());
+            }
+            let mut chunks = Vec::with_capacity(first.chunk_count as usize);
+            let message_id = first.message_id;
+            chunks.push(decode_standard_base64(&first.data)?);
+            for expected_index in 1..first.chunk_count {
+                let next = self.read_encrypted_chunk()?;
+                if next.message_id != message_id || next.chunk_index != expected_index {
+                    return Err("Encrypted sync transport chunks arrived out of order.".to_string());
+                }
+                if next.chunk_count != first.chunk_count {
+                    return Err("Encrypted sync transport chunk count changed.".to_string());
+                }
+                chunks.push(decode_standard_base64(&next.data)?);
+            }
+            let payload = chunks.concat();
+            serde_json::from_slice(&payload)
+                .map_err(|error| format!("Could not decode sync transport message: {error}"))
+        }
+
+        fn send_encrypted_chunk(&mut self, chunk: &EncryptedChunk) -> Result<(), String> {
+            let plaintext = serde_json::to_vec(chunk)
+                .map_err(|error| format!("Could not encode encrypted chunk: {error}"))?;
+            let mut ciphertext = vec![0_u8; plaintext.len() + 1024];
+            let written = self
+                .noise
+                .write_message(&plaintext, &mut ciphertext)
+                .map_err(|error| format!("Noise transport write failed: {error}"))?;
+            write_raw_frame(&mut self.stream, &ciphertext[..written])
+        }
+
+        fn read_encrypted_chunk(&mut self) -> Result<EncryptedChunk, String> {
+            let ciphertext = read_raw_frame(&mut self.stream)?;
+            let mut plaintext = vec![0_u8; MAX_RAW_FRAME];
+            let read = self
+                .noise
+                .read_message(&ciphertext, &mut plaintext)
+                .map_err(|error| format!("Noise transport read failed: {error}"))?;
+            serde_json::from_slice(&plaintext[..read])
+                .map_err(|error| format!("Could not decode encrypted chunk: {error}"))
+        }
+    }
+
+    fn build_noise_handshake(initiator: bool) -> Result<snow::HandshakeState, String> {
+        let params: NoiseParams = NOISE_PATTERN
+            .parse()
+            .map_err(|error| format!("Noise pattern is invalid: {error}"))?;
+        let builder = Builder::new(params);
+        let keypair = builder
+            .generate_keypair()
+            .map_err(|error| format!("Could not generate Noise static keypair: {error}"))?;
+        let params: NoiseParams = NOISE_PATTERN
+            .parse()
+            .map_err(|error| format!("Noise pattern is invalid: {error}"))?;
+        let builder = Builder::new(params).local_private_key(&keypair.private);
+        if initiator {
+            builder
+                .build_initiator()
+                .map_err(|error| format!("Could not create Noise initiator: {error}"))
+        } else {
+            builder
+                .build_responder()
+                .map_err(|error| format!("Could not create Noise responder: {error}"))
+        }
+    }
+
+    fn write_raw_frame(stream: &mut TcpStream, payload: &[u8]) -> Result<(), String> {
+        if payload.len() > MAX_RAW_FRAME {
+            return Err("Sync transport frame is too large.".to_string());
+        }
+        let length = (payload.len() as u32).to_be_bytes();
+        stream
+            .write_all(&length)
+            .and_then(|_| stream.write_all(payload))
+            .map_err(|error| format!("Could not write sync transport frame: {error}"))
+    }
+
+    fn read_raw_frame(stream: &mut TcpStream) -> Result<Vec<u8>, String> {
+        let mut length = [0_u8; 4];
+        stream
+            .read_exact(&mut length)
+            .map_err(|error| format!("Could not read sync transport frame length: {error}"))?;
+        let length = u32::from_be_bytes(length) as usize;
+        if length > MAX_RAW_FRAME {
+            return Err("Sync transport frame exceeds the maximum frame size.".to_string());
+        }
+        let mut payload = vec![0_u8; length];
+        stream
+            .read_exact(&mut payload)
+            .map_err(|error| format!("Could not read sync transport frame: {error}"))?;
+        Ok(payload)
+    }
+
+    fn configure_stream(stream: &TcpStream) -> Result<(), String> {
+        stream
+            .set_read_timeout(Some(READ_TIMEOUT))
+            .map_err(|error| format!("Could not set sync transport read timeout: {error}"))?;
+        stream
+            .set_write_timeout(Some(WRITE_TIMEOUT))
+            .map_err(|error| format!("Could not set sync transport write timeout: {error}"))?;
+        stream
+            .set_nodelay(true)
+            .map_err(|error| format!("Could not configure sync transport socket: {error}"))?;
+        Ok(())
+    }
+
+    #[derive(Debug)]
+    struct AuthenticatedSession {
+        remote_device_id: String,
+    }
+
+    fn authenticate_session(
+        connection: &mut SecurePeerConnection,
+        client: &BackendClient,
+        expected_peer_device_id: Option<String>,
+    ) -> Result<AuthenticatedSession, String> {
+        let identity = client
+            .local_identity()
+            .map_err(|error| format!("Could not load local sync identity: {error}"))?;
+        let local_nonce = random_nonce();
+        connection.send_message(&ProtocolMessage::AuthChallenge {
+            protocol_version: TRANSPORT_PROTOCOL_VERSION.to_string(),
+            device_id: identity.device_id.clone(),
+            session_nonce: local_nonce.clone(),
+        })?;
+        let (remote_device_id, remote_nonce) = match connection.read_message()? {
+            ProtocolMessage::AuthChallenge {
+                protocol_version,
+                device_id,
+                session_nonce,
+            } => {
+                if protocol_version != TRANSPORT_PROTOCOL_VERSION {
+                    return Err(format!(
+                        "Sync peer uses unsupported transport protocol version {protocol_version}."
+                    ));
+                }
+                (device_id, session_nonce)
+            }
+            ProtocolMessage::Error(error) => {
+                return Err(format!(
+                    "Sync peer returned an auth error: {}",
+                    error.message
+                ));
+            }
+            other => {
+                return Err(format!(
+                    "Sync peer sent unexpected auth message: {}",
+                    other.kind()
+                ));
+            }
+        };
+        if let Some(expected_peer_device_id) = expected_peer_device_id.as_deref() {
+            if remote_device_id != expected_peer_device_id {
+                return Err(format!(
+                    "Sync peer identity mismatch: expected {expected_peer_device_id}, got {remote_device_id}."
+                ));
+            }
+        }
+        let trusted_peer = client
+            .trusted_peer(&remote_device_id)
+            .map_err(|error| format!("Could not verify trusted sync peer: {error}"))?
+            .ok_or_else(|| format!("Sync peer {remote_device_id} is not trusted."))?;
+
+        let local_challenge = transport_handshake_challenge(
+            &remote_device_id,
+            &identity.device_id,
+            &remote_nonce,
+            &local_nonce,
+            &connection.handshake_hash,
+        );
+        let local_signature = client
+            .sign_transport_handshake(&remote_device_id, &local_challenge)
+            .map_err(|error| format!("Could not sign sync transport handshake: {error}"))?;
+        connection.send_message(&ProtocolMessage::AuthProof {
+            handshake_signature: local_signature,
+        })?;
+
+        let remote_signature = match connection.read_message()? {
+            ProtocolMessage::AuthProof {
+                handshake_signature,
+            } => handshake_signature,
+            ProtocolMessage::Error(error) => {
+                return Err(format!(
+                    "Sync peer returned an auth error: {}",
+                    error.message
+                ));
+            }
+            other => {
+                return Err(format!(
+                    "Sync peer sent unexpected auth proof message: {}",
+                    other.kind()
+                ));
+            }
+        };
+        verify_transport_handshake_signature(
+            &remote_signature,
+            &trusted_peer,
+            &identity.device_id,
+            &remote_device_id,
+            &local_nonce,
+            &remote_nonce,
+            &connection.handshake_hash,
+        )?;
+
+        Ok(AuthenticatedSession { remote_device_id })
+    }
+
+    fn transport_handshake_challenge(
+        requester_device_id: &str,
+        responder_device_id: &str,
+        session_id: &str,
+        challenge_nonce: &str,
+        handshake_hash: &str,
+    ) -> Value {
+        let issued_at = Utc::now();
+        let expires_at = issued_at + chrono::Duration::seconds(TRANSPORT_HANDSHAKE_TTL_SECONDS);
+        json!({
+            "protocol_version": PAIRING_PROTOCOL_VERSION,
+            "challenge_type": TRANSPORT_HANDSHAKE_CHALLENGE_TYPE,
+            "session_id": session_id,
+            "challenge_nonce": bound_noise_nonce(challenge_nonce, handshake_hash),
+            "requester_device_id": requester_device_id,
+            "responder_device_id": responder_device_id,
+            "issued_at": issued_at.to_rfc3339(),
+            "expires_at": expires_at.to_rfc3339(),
+        })
+    }
+
+    fn verify_transport_handshake_signature(
+        signature_value: &Value,
+        trusted_peer: &SyncTrustedPeer,
+        local_device_id: &str,
+        remote_device_id: &str,
+        local_nonce: &str,
+        remote_nonce: &str,
+        handshake_hash: &str,
+    ) -> Result<(), String> {
+        let proof: TransportHandshakeSignature = serde_json::from_value(signature_value.clone())
+            .map_err(|error| {
+                format!("Sync peer transport handshake proof is malformed: {error}")
+            })?;
+        if proof.protocol_version != PAIRING_PROTOCOL_VERSION {
+            return Err(format!(
+                "Sync peer transport proof uses unsupported pairing protocol version {}.",
+                proof.protocol_version
+            ));
+        }
+        if proof.challenge_type != TRANSPORT_HANDSHAKE_CHALLENGE_TYPE {
+            return Err("Sync peer transport proof has an unsupported challenge type.".to_string());
+        }
+        if proof.local_device_id != trusted_peer.device_id
+            || proof.local_device_id != remote_device_id
+            || proof.peer_device_id != local_device_id
+        {
+            return Err(
+                "Sync peer transport proof device IDs do not match this session.".to_string(),
+            );
+        }
+        if proof.public_key != trusted_peer.public_key {
+            return Err(
+                "Sync peer transport proof public key does not match trusted peer.".to_string(),
+            );
+        }
+        let expected_device_id = derive_device_id(&proof.public_key)?;
+        if expected_device_id != proof.local_device_id {
+            return Err(
+                "Sync peer transport proof device_id does not match its public key.".to_string(),
+            );
+        }
+        let signed_challenge: Value = serde_json::from_str(&proof.canonical_challenge_json)
+            .map_err(|error| format!("Sync peer transport proof challenge is invalid: {error}"))?;
+        validate_transport_challenge(
+            &signed_challenge,
+            local_device_id,
+            remote_device_id,
+            local_nonce,
+            remote_nonce,
+            handshake_hash,
+        )?;
+
+        let public_key_bytes = decode_public_key(&proof.public_key)?;
+        let verifying_key = VerifyingKey::from_bytes(&public_key_bytes)
+            .map_err(|error| format!("Sync peer public key is invalid: {error}"))?;
+        let signature_bytes = decode_urlsafe_key(&proof.signature)?;
+        let signature = Signature::from_slice(&signature_bytes)
+            .map_err(|error| format!("Sync peer transport proof signature is invalid: {error}"))?;
+        verifying_key
+            .verify(proof.canonical_challenge_json.as_bytes(), &signature)
+            .map_err(|_| "Sync peer transport proof signature verification failed.".to_string())
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    struct TransportHandshakeSignature {
+        protocol_version: String,
+        challenge_type: String,
+        local_device_id: String,
+        peer_device_id: String,
+        public_key: String,
+        #[allow(dead_code)]
+        challenge: Value,
+        canonical_challenge_json: String,
+        signature: String,
+        #[allow(dead_code)]
+        signed_at: String,
+    }
+
+    fn validate_transport_challenge(
+        challenge: &Value,
+        local_device_id: &str,
+        remote_device_id: &str,
+        local_nonce: &str,
+        remote_nonce: &str,
+        handshake_hash: &str,
+    ) -> Result<(), String> {
+        expect_json_string(challenge, "protocol_version", PAIRING_PROTOCOL_VERSION)?;
+        expect_json_string(
+            challenge,
+            "challenge_type",
+            TRANSPORT_HANDSHAKE_CHALLENGE_TYPE,
+        )?;
+        expect_json_string(challenge, "requester_device_id", local_device_id)?;
+        expect_json_string(challenge, "responder_device_id", remote_device_id)?;
+        expect_json_string(challenge, "session_id", local_nonce)?;
+        expect_json_string(
+            challenge,
+            "challenge_nonce",
+            &bound_noise_nonce(remote_nonce, handshake_hash),
+        )?;
+        let expires_at = json_string(challenge, "expires_at")
+            .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+            .map(|value| value.with_timezone(&Utc))
+            .ok_or_else(|| "Sync peer transport proof expiration is invalid.".to_string())?;
+        if expires_at <= Utc::now() {
+            return Err("Sync peer transport proof has expired.".to_string());
+        }
+        Ok(())
+    }
+
+    fn bound_noise_nonce(nonce: &str, handshake_hash: &str) -> String {
+        format!("{nonce}.{handshake_hash}")
+    }
+
+    fn expect_json_string(value: &Value, field: &str, expected: &str) -> Result<(), String> {
+        match json_string(value, field) {
+            Some(actual) if actual == expected => Ok(()),
+            _ => Err(format!(
+                "Sync transport challenge {field} did not match this session."
+            )),
+        }
+    }
+
+    fn json_string<'a>(value: &'a Value, field: &str) -> Option<&'a str> {
+        value.get(field).and_then(Value::as_str)
+    }
+
+    fn random_nonce() -> String {
+        let mut bytes = [0_u8; 24];
+        OsRng.fill_bytes(&mut bytes);
+        URL_SAFE_NO_PAD.encode(bytes)
+    }
+
+    fn load_local_manifest_offer(
+        client: &BackendClient,
+        project_ids: Option<&[String]>,
+        include_manifests: bool,
+    ) -> ManifestOffer {
+        let metadata = client
+            .get_json_value("/api/v1/sync/metadata")
+            .unwrap_or_else(|error| json!({ "error": error.to_string() }));
+        let mut project_manifests = Vec::new();
+        let mut manifest_errors = Vec::new();
+        if include_manifests {
+            let selected_project_ids = project_ids
+                .map(|values| values.to_vec())
+                .unwrap_or_else(|| project_ids_from_metadata(&metadata));
+            for project_id in selected_project_ids {
+                let path = format!(
+                    "/api/v1/sync/projects/{}/manifest",
+                    percent_encode_path_segment(&project_id)
+                );
+                match client.get_json_value(&path) {
+                    Ok(response) => {
+                        if let Some(manifest) = response.get("project_manifest") {
+                            project_manifests.push(manifest.clone());
+                        } else {
+                            manifest_errors.push(SyncTransportManifestError {
+                                project_id,
+                                message:
+                                    "Backend manifest response did not include project_manifest."
+                                        .to_string(),
+                            });
+                        }
+                    }
+                    Err(error) => manifest_errors.push(SyncTransportManifestError {
+                        project_id,
+                        message: error.to_string(),
+                    }),
+                }
+            }
+        }
+        ManifestOffer {
+            metadata,
+            project_manifests,
+            manifest_errors,
+        }
+    }
+
+    fn project_ids_from_metadata(metadata: &Value) -> Vec<String> {
+        metadata
+            .get("projects")
+            .and_then(Value::as_array)
+            .map(|projects| {
+                projects
+                    .iter()
+                    .filter_map(|project| project.get("project_id").and_then(Value::as_str))
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    struct ImportRemoteResult {
+        imported_projects: Vec<SyncTransportProjectResult>,
+        received_artifacts: Vec<SyncTransportTransferResult>,
+    }
+
+    fn import_remote_manifests(
+        client: &BackendClient,
+        connection: &mut SecurePeerConnection,
+        peer_device_id: &str,
+        remote_metadata: &Value,
+        manifests: &[Value],
+    ) -> ImportRemoteResult {
+        let mut imported_projects = Vec::new();
+        let mut received_artifacts = Vec::new();
+
+        for manifest in manifests {
+            let project_id = manifest_project_id(manifest);
+            let artifacts = manifest_artifacts(manifest);
+            let mut project_failed = None;
+            for artifact in &artifacts {
+                match request_and_stage_artifact(client, connection, peer_device_id, artifact) {
+                    Ok(result) => received_artifacts.push(result),
+                    Err(error) => {
+                        project_failed = Some(error);
+                        break;
+                    }
+                }
+            }
+
+            if let Some(error) = project_failed {
+                imported_projects.push(SyncTransportProjectResult {
+                    project_id,
+                    status: "failed".to_string(),
+                    message: Some(error),
+                });
+                continue;
+            }
+
+            match apply_remote_manifest(
+                client,
+                peer_device_id,
+                remote_metadata,
+                manifest,
+                &artifacts,
+            ) {
+                Ok(result) => imported_projects.push(result),
+                Err(error) => imported_projects.push(SyncTransportProjectResult {
+                    project_id,
+                    status: "failed".to_string(),
+                    message: Some(error.to_string()),
+                }),
+            }
+        }
+
+        ImportRemoteResult {
+            imported_projects,
+            received_artifacts,
+        }
+    }
+
+    fn apply_remote_manifest(
+        client: &BackendClient,
+        peer_device_id: &str,
+        remote_metadata: &Value,
+        manifest: &Value,
+        artifacts: &[RemoteArtifact],
+    ) -> Result<SyncTransportProjectResult, BackendError> {
+        let project_id = manifest_project_id(manifest);
+        let available_content_sha256: Vec<String> = artifacts
+            .iter()
+            .map(|artifact| artifact.content_sha256.clone())
+            .collect();
+        let body = json!({
+            "remote_library": remote_metadata,
+            "project_manifests": [manifest],
+            "peer_inventory": [{
+                "device_id": peer_device_id,
+                "available_content_sha256": available_content_sha256,
+                "metadata": { "transport": "tuneforge-sync+tcp" },
+            }],
+            "use_content_addressed_staging": true,
+        });
+        let response = client.post_json_value("/api/v1/sync/reconciliation/apply", &body)?;
+        let summary = response.get("summary").unwrap_or(&Value::Null);
+        let failed_actions = summary
+            .get("failed_actions")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let applied_actions = summary
+            .get("applied_actions")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let satisfied_actions = summary
+            .get("satisfied_actions")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let skipped_actions = summary
+            .get("skipped_actions")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let status = if failed_actions > 0 {
+            "failed"
+        } else if applied_actions > 0 || satisfied_actions > 0 {
+            "applied"
+        } else {
+            "skipped"
+        };
+        Ok(SyncTransportProjectResult {
+            project_id,
+            status: status.to_string(),
+            message: Some(format!(
+                "Reconciliation apply: {applied_actions} applied, {satisfied_actions} satisfied, {skipped_actions} skipped, {failed_actions} failed."
+            )),
+        })
+    }
+
+    #[derive(Clone, Debug)]
+    struct RemoteArtifact {
+        artifact_id: String,
+        project_id: String,
+        content_sha256: String,
+        size_bytes: u64,
+    }
+
+    fn manifest_project_id(manifest: &Value) -> String {
+        manifest
+            .get("project")
+            .and_then(|project| project.get("project_id"))
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string()
+    }
+
+    fn manifest_artifacts(manifest: &Value) -> Vec<RemoteArtifact> {
+        manifest
+            .get("artifacts")
+            .and_then(Value::as_array)
+            .map(|artifacts| {
+                artifacts
+                    .iter()
+                    .filter_map(|artifact| {
+                        let artifact_id = artifact.get("artifact_id")?.as_str()?.to_string();
+                        let project_id = artifact.get("project_id")?.as_str()?.to_string();
+                        let content_sha256 = artifact.get("content_sha256")?.as_str()?.to_string();
+                        let size_bytes = artifact.get("size_bytes")?.as_u64()?;
+                        Some(RemoteArtifact {
+                            artifact_id,
+                            project_id,
+                            content_sha256,
+                            size_bytes,
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn request_and_stage_artifact(
+        client: &BackendClient,
+        connection: &mut SecurePeerConnection,
+        peer_device_id: &str,
+        artifact: &RemoteArtifact,
+    ) -> Result<SyncTransportTransferResult, String> {
+        let staging_path = format!(
+            "/api/v1/sync/artifacts/staging/{}",
+            percent_encode_path_segment(&artifact.content_sha256)
+        );
+        if client.get_json_value(&staging_path).is_ok() {
+            return Ok(SyncTransportTransferResult {
+                artifact_id: artifact.artifact_id.clone(),
+                content_sha256: artifact.content_sha256.clone(),
+                size_bytes: artifact.size_bytes,
+                status: "already_staged".to_string(),
+                message: None,
+            });
+        }
+
+        connection.send_message(&ProtocolMessage::ArtifactRequest {
+            artifact_id: artifact.artifact_id.clone(),
+            content_sha256: artifact.content_sha256.clone(),
+            size_bytes: artifact.size_bytes,
+        })?;
+
+        match connection.read_message()? {
+            ProtocolMessage::ArtifactStart {
+                artifact_id,
+                content_sha256,
+                size_bytes,
+            } => {
+                if artifact_id != artifact.artifact_id
+                    || content_sha256 != artifact.content_sha256
+                    || size_bytes != artifact.size_bytes
+                {
+                    return Err(
+                        "Sync peer artifact response did not match the request.".to_string()
+                    );
+                }
+            }
+            ProtocolMessage::Error(error) => return Err(error.message),
+            other => {
+                return Err(format!(
+                    "Sync peer sent unexpected artifact response: {}",
+                    other.kind()
+                ));
+            }
+        }
+
+        let temp_path = temp_artifact_path(&artifact.content_sha256);
+        if let Some(parent) = temp_path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|error| format!("Could not create sync artifact temp dir: {error}"))?;
+        }
+        let mut file = File::create(&temp_path)
+            .map_err(|error| format!("Could not create sync artifact temp file: {error}"))?;
+        let mut hasher = Sha256::new();
+        let mut size_bytes = 0_u64;
+        let receive_result = loop {
+            match connection.read_message()? {
+                ProtocolMessage::ArtifactChunk { data } => {
+                    let chunk = decode_standard_base64(&data)?;
+                    let next_size_bytes = size_bytes.saturating_add(chunk.len() as u64);
+                    if next_size_bytes > artifact.size_bytes {
+                        break Err(
+                            "Received sync artifact exceeded the requested size.".to_string()
+                        );
+                    }
+                    size_bytes = next_size_bytes;
+                    hasher.update(&chunk);
+                    file.write_all(&chunk).map_err(|error| {
+                        format!("Could not write received sync artifact bytes: {error}")
+                    })?;
+                }
+                ProtocolMessage::ArtifactEnd {
+                    content_sha256,
+                    size_bytes: peer_size_bytes,
+                } => {
+                    file.flush().map_err(|error| {
+                        format!("Could not flush received sync artifact bytes: {error}")
+                    })?;
+                    let actual_sha256 = hex_digest(hasher.finalize().as_slice());
+                    if content_sha256 != artifact.content_sha256
+                        || actual_sha256 != artifact.content_sha256
+                        || peer_size_bytes != artifact.size_bytes
+                        || size_bytes != artifact.size_bytes
+                    {
+                        break Err(
+                            "Received sync artifact bytes failed SHA-256 or size verification."
+                                .to_string(),
+                        );
+                    }
+                    break Ok(());
+                }
+                ProtocolMessage::Error(error) => break Err(error.message),
+                other => {
+                    break Err(format!(
+                        "Sync peer sent unexpected artifact transfer message: {}",
+                        other.kind()
+                    ));
+                }
+            }
+        };
+
+        if let Err(error) = receive_result {
+            let _ = fs::remove_file(&temp_path);
+            return Err(error);
+        }
+
+        let body = json!({
+            "source_path": temp_path.to_string_lossy(),
+            "content_sha256": artifact.content_sha256,
+            "size_bytes": artifact.size_bytes,
+            "provider_device_id": peer_device_id,
+            "metadata": {
+                "source": "tuneforge-sync+tcp",
+                "artifact_id": artifact.artifact_id,
+                "project_id": artifact.project_id,
+            },
+        });
+        let stage_result = client.post_json_value("/api/v1/sync/artifacts/staging", &body);
+        let _ = fs::remove_file(&temp_path);
+        stage_result.map_err(|error| format!("Could not stage received sync artifact: {error}"))?;
+
+        Ok(SyncTransportTransferResult {
+            artifact_id: artifact.artifact_id.clone(),
+            content_sha256: artifact.content_sha256.clone(),
+            size_bytes: artifact.size_bytes,
+            status: "received".to_string(),
+            message: None,
+        })
+    }
+
+    fn temp_artifact_path(content_sha256: &str) -> PathBuf {
+        env::temp_dir()
+            .join("tuneforge-sync-transport")
+            .join(format!("{}-{content_sha256}", process::id()))
+    }
+
+    fn serve_artifact_requests_until_done(
+        client: &BackendClient,
+        connection: &mut SecurePeerConnection,
+        offered_manifests: &[Value],
+    ) -> Result<u64, String> {
+        let offered_artifacts = offered_artifacts_by_id(offered_manifests);
+        let mut served = 0_u64;
+        loop {
+            match connection.read_message()? {
+                ProtocolMessage::ArtifactRequest {
+                    artifact_id,
+                    content_sha256,
+                    size_bytes,
+                } => {
+                    let result = offered_artifacts
+                        .get(&artifact_id)
+                        .ok_or_else(|| {
+                            format!("Sync peer requested artifact {artifact_id} that was not offered.")
+                        })
+                        .and_then(|artifact| {
+                            if artifact.content_sha256 != content_sha256
+                                || artifact.size_bytes != size_bytes
+                            {
+                                return Err(format!(
+                                    "Sync peer request for artifact {artifact_id} does not match the offered manifest."
+                                ));
+                            }
+                            send_artifact_response(client, connection, artifact)
+                        });
+                    if let Err(error) = result {
+                        let _ = connection.send_message(&ProtocolMessage::Error(ProtocolError {
+                            code: "artifact_transfer_failed".to_string(),
+                            message: error.clone(),
+                        }));
+                        return Err(error);
+                    }
+                    served = served.saturating_add(1);
+                }
+                ProtocolMessage::PhaseDone { .. } => return Ok(served),
+                ProtocolMessage::Status { .. } => {}
+                ProtocolMessage::Error(error) => return Err(error.message),
+                other => {
+                    return Err(format!(
+                        "Sync peer sent unexpected message while serving artifacts: {}",
+                        other.kind()
+                    ));
+                }
+            }
+        }
+    }
+
+    fn send_artifact_response(
+        client: &BackendClient,
+        connection: &mut SecurePeerConnection,
+        artifact: &RemoteArtifact,
+    ) -> Result<(), String> {
+        let path = format!(
+            "/api/v1/artifacts/{}/stream",
+            percent_encode_path_segment(&artifact.artifact_id)
+        );
+        let mut body = client.get_body(&path).map_err(|error| {
+            format!(
+                "Could not read local artifact {}: {error}",
+                artifact.artifact_id
+            )
+        })?;
+        connection.send_message(&ProtocolMessage::ArtifactStart {
+            artifact_id: artifact.artifact_id.clone(),
+            content_sha256: artifact.content_sha256.clone(),
+            size_bytes: artifact.size_bytes,
+        })?;
+
+        let mut buffer = [0_u8; ARTIFACT_CHUNK_SIZE];
+        let mut hasher = Sha256::new();
+        let mut actual_size = 0_u64;
+        loop {
+            let read = body
+                .read(&mut buffer)
+                .map_err(|error| format!("Could not stream local artifact bytes: {error}"))?;
+            if read == 0 {
+                break;
+            }
+            actual_size = actual_size.saturating_add(read as u64);
+            hasher.update(&buffer[..read]);
+            connection.send_message(&ProtocolMessage::ArtifactChunk {
+                data: STANDARD.encode(&buffer[..read]),
+            })?;
+        }
+
+        let actual_sha256 = hex_digest(hasher.finalize().as_slice());
+        if actual_sha256 != artifact.content_sha256 || actual_size != artifact.size_bytes {
+            return Err(
+                "Local artifact bytes do not match the requested SHA-256 or size.".to_string(),
+            );
+        }
+        connection.send_message(&ProtocolMessage::ArtifactEnd {
+            content_sha256: actual_sha256,
+            size_bytes: actual_size,
+        })
+    }
+
+    fn offered_artifacts_by_id(manifests: &[Value]) -> HashMap<String, RemoteArtifact> {
+        manifests
+            .iter()
+            .flat_map(manifest_artifacts)
+            .map(|artifact| (artifact.artifact_id.clone(), artifact))
+            .collect()
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    struct SyncLocalIdentityResponse {
+        identity: SyncLocalIdentity,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    struct SyncLocalIdentity {
+        device_id: String,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    struct SyncTrustedPeersResponse {
+        trusted_peers: Vec<SyncTrustedPeer>,
+    }
+
+    #[derive(Clone, Debug, Deserialize)]
+    struct SyncTrustedPeer {
+        device_id: String,
+        public_key: String,
+        endpoint_hints: Vec<String>,
+        revoked_at: Option<String>,
+    }
+
+    #[derive(Debug)]
+    struct BackendClient {
+        host: String,
+        port: u16,
+    }
+
+    impl BackendClient {
+        fn new(base_url: &str) -> Result<Self, String> {
+            let without_scheme = base_url.strip_prefix("http://").ok_or_else(|| {
+                "Sync transport only supports loopback http:// backends.".to_string()
+            })?;
+            let authority = without_scheme.split('/').next().unwrap_or(without_scheme);
+            let (host, port) = match authority.rsplit_once(':') {
+                Some((host, port)) => {
+                    let port = port
+                        .parse::<u16>()
+                        .map_err(|_| format!("Backend base URL has an invalid port: {base_url}"))?;
+                    (host.to_string(), port)
+                }
+                None => (authority.to_string(), 80),
+            };
+            if host != "127.0.0.1" && host != "localhost" && host != "[::1]" && host != "::1" {
+                return Err(
+                    "Sync transport refuses to proxy a non-loopback backend over LAN.".to_string(),
+                );
+            }
+            Ok(Self { host, port })
+        }
+
+        fn local_identity(&self) -> Result<SyncLocalIdentity, BackendError> {
+            self.get_json::<SyncLocalIdentityResponse>("/api/v1/sync/identity")
+                .map(|response| response.identity)
+        }
+
+        fn trusted_peer(&self, device_id: &str) -> Result<Option<SyncTrustedPeer>, BackendError> {
+            let response =
+                self.get_json::<SyncTrustedPeersResponse>("/api/v1/sync/trusted-peers")?;
+            Ok(response
+                .trusted_peers
+                .into_iter()
+                .find(|peer| peer.device_id == device_id && peer.revoked_at.is_none()))
+        }
+
+        fn create_pairing_offer(
+            &self,
+            endpoint_hints: Vec<String>,
+            ttl_seconds: u32,
+        ) -> Result<Value, BackendError> {
+            let body = json!({
+                "endpoint_hints": endpoint_hints,
+                "ttl_seconds": ttl_seconds,
+            });
+            self.post_json_value("/api/v1/sync/pairing/offers", &body)
+        }
+
+        fn sign_transport_handshake(
+            &self,
+            peer_device_id: &str,
+            challenge: &Value,
+        ) -> Result<Value, BackendError> {
+            let body = json!({
+                "peer_device_id": peer_device_id,
+                "challenge": challenge,
+            });
+            self.post_json_value("/api/v1/sync/transport/handshake/sign", &body)
+        }
+
+        fn get_json<T: for<'de> Deserialize<'de>>(&self, path: &str) -> Result<T, BackendError> {
+            let value = self.request_json_value("GET", path, None)?;
+            serde_json::from_value(value).map_err(|error| BackendError::local(error.to_string()))
+        }
+
+        fn get_json_value(&self, path: &str) -> Result<Value, BackendError> {
+            self.request_json_value("GET", path, None)
+        }
+
+        fn post_json_value(&self, path: &str, body: &Value) -> Result<Value, BackendError> {
+            self.request_json_value("POST", path, Some(body))
+        }
+
+        fn request_json_value(
+            &self,
+            method: &str,
+            path: &str,
+            body: Option<&Value>,
+        ) -> Result<Value, BackendError> {
+            let mut response = self.request_body(method, path, body)?;
+            let mut bytes = Vec::new();
+            response
+                .read_to_end(&mut bytes)
+                .map_err(|error| BackendError::local(error.to_string()))?;
+            if bytes.is_empty() {
+                return Ok(Value::Null);
+            }
+            serde_json::from_slice(&bytes).map_err(|error| {
+                BackendError::local(format!("Could not decode backend JSON response: {error}"))
+            })
+        }
+
+        fn get_body(&self, path: &str) -> Result<BackendBody, BackendError> {
+            self.request_body("GET", path, None)
+        }
+
+        fn request_body(
+            &self,
+            method: &str,
+            path: &str,
+            body: Option<&Value>,
+        ) -> Result<BackendBody, BackendError> {
+            let mut stream = TcpStream::connect((self.host.as_str(), self.port))
+                .map_err(|error| BackendError::local(error.to_string()))?;
+            stream
+                .set_read_timeout(Some(HTTP_TIMEOUT))
+                .map_err(|error| BackendError::local(error.to_string()))?;
+            stream
+                .set_write_timeout(Some(HTTP_TIMEOUT))
+                .map_err(|error| BackendError::local(error.to_string()))?;
+
+            let body_bytes = match body {
+                Some(value) => serde_json::to_vec(value)
+                    .map_err(|error| BackendError::local(error.to_string()))?,
+                None => Vec::new(),
+            };
+            write!(
+                stream,
+                "{method} {path} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\nAccept: application/json\r\nContent-Length: {}\r\n",
+                self.host,
+                body_bytes.len()
+            )
+            .map_err(|error| BackendError::local(error.to_string()))?;
+            if body.is_some() {
+                stream
+                    .write_all(b"Content-Type: application/json\r\n")
+                    .map_err(|error| BackendError::local(error.to_string()))?;
+            }
+            stream
+                .write_all(b"\r\n")
+                .and_then(|_| stream.write_all(&body_bytes))
+                .map_err(|error| BackendError::local(error.to_string()))?;
+
+            let mut reader = BufReader::new(stream);
+            let mut status_line = String::new();
+            reader
+                .read_line(&mut status_line)
+                .map_err(|error| BackendError::local(error.to_string()))?;
+            let status = parse_status_code(&status_line)?;
+            let mut content_length = None;
+            loop {
+                let mut line = String::new();
+                reader
+                    .read_line(&mut line)
+                    .map_err(|error| BackendError::local(error.to_string()))?;
+                if line == "\r\n" || line == "\n" || line.is_empty() {
+                    break;
+                }
+                if let Some(value) = line
+                    .strip_prefix("Content-Length:")
+                    .or_else(|| line.strip_prefix("content-length:"))
+                {
+                    content_length = value.trim().parse::<u64>().ok();
+                }
+            }
+            if !(200..300).contains(&status) {
+                let mut error_body = String::new();
+                let _ = reader.read_to_string(&mut error_body);
+                return Err(BackendError {
+                    status: Some(status),
+                    message: backend_error_message(status, &error_body),
+                });
+            }
+            Ok(BackendBody {
+                reader,
+                remaining: content_length,
+            })
+        }
+    }
+
+    struct BackendBody {
+        reader: BufReader<TcpStream>,
+        remaining: Option<u64>,
+    }
+
+    impl Read for BackendBody {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if matches!(self.remaining, Some(0)) {
+                return Ok(0);
+            }
+            let max_read = self
+                .remaining
+                .map(|remaining| remaining.min(buf.len() as u64) as usize)
+                .unwrap_or(buf.len());
+            let read = self.reader.read(&mut buf[..max_read])?;
+            if let Some(remaining) = self.remaining.as_mut() {
+                *remaining = remaining.saturating_sub(read as u64);
+            }
+            Ok(read)
+        }
+    }
+
+    #[derive(Debug)]
+    struct BackendError {
+        status: Option<u16>,
+        message: String,
+    }
+
+    impl BackendError {
+        fn local(message: String) -> Self {
+            Self {
+                status: None,
+                message,
+            }
+        }
+    }
+
+    impl std::fmt::Display for BackendError {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self.status {
+                Some(status) => write!(formatter, "backend HTTP {status}: {}", self.message),
+                None => formatter.write_str(&self.message),
+            }
+        }
+    }
+
+    fn parse_status_code(status_line: &str) -> Result<u16, BackendError> {
+        status_line
+            .split_whitespace()
+            .nth(1)
+            .and_then(|value| value.parse::<u16>().ok())
+            .ok_or_else(|| {
+                BackendError::local(format!("Invalid backend HTTP status: {status_line}"))
+            })
+    }
+
+    fn backend_error_message(status: u16, body: &str) -> String {
+        serde_json::from_str::<Value>(body)
+            .ok()
+            .and_then(|value| {
+                value
+                    .get("message")
+                    .or_else(|| value.get("detail"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            })
+            .unwrap_or_else(|| {
+                let trimmed = body.trim();
+                if trimmed.is_empty() {
+                    format!("Backend returned HTTP {status}.")
+                } else {
+                    trimmed.to_string()
+                }
+            })
+    }
+
+    fn endpoint_hints_for_port(port: u16, device_id: &str) -> Vec<String> {
+        let mut hosts = Vec::new();
+        if let Ok(addresses) = if_addrs::get_if_addrs() {
+            for address in addresses {
+                match address.ip() {
+                    IpAddr::V4(ip) if !ip.is_loopback() && !ip.is_link_local() => {
+                        let host = ip.to_string();
+                        if !hosts.contains(&host) {
+                            hosts.push(host);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        if hosts.is_empty() {
+            hosts.push("127.0.0.1".to_string());
+        }
+        hosts
+            .into_iter()
+            .map(|host| {
+                format!(
+                    "{ENDPOINT_SCHEME}{host}:{port}?device_id={}&v=1",
+                    percent_encode_query_value(device_id)
+                )
+            })
+            .collect()
+    }
+
+    fn first_tcp_endpoint_hint(endpoint_hints: &[String]) -> Option<String> {
+        endpoint_hints
+            .iter()
+            .find(|hint| hint.starts_with(ENDPOINT_SCHEME))
+            .cloned()
+    }
+
+    fn parse_endpoint_hint(
+        endpoint_hint: &str,
+        expected_device_id: Option<&str>,
+    ) -> Result<SocketAddr, String> {
+        let rest = endpoint_hint
+            .strip_prefix(ENDPOINT_SCHEME)
+            .ok_or_else(|| "Endpoint hint is not a TuneForge TCP URI.".to_string())?;
+        let (authority, query) = rest.split_once('?').unwrap_or((rest, ""));
+        if let Some(expected_device_id) = expected_device_id {
+            if let Some(device_id) = query_parameter(query, "device_id") {
+                if device_id != expected_device_id {
+                    return Err(
+                        "Endpoint hint device_id does not match the trusted peer.".to_string()
+                    );
+                }
+            }
+        }
+        let socket_text = if authority.starts_with('[') {
+            authority.to_string()
+        } else {
+            authority.to_string()
+        };
+        let mut addresses = socket_text
+            .to_socket_addrs()
+            .map_err(|error| format!("Could not resolve sync endpoint hint: {error}"))?;
+        addresses
+            .next()
+            .ok_or_else(|| "Sync endpoint hint did not resolve to a socket address.".to_string())
+    }
+
+    fn query_parameter(query: &str, key: &str) -> Option<String> {
+        query.split('&').find_map(|part| {
+            let (part_key, value) = part.split_once('=')?;
+            (part_key == key).then(|| percent_decode(value))
+        })
+    }
+
+    fn decode_public_key(public_key: &str) -> Result<[u8; 32], String> {
+        let decoded =
+            decode_urlsafe_key(public_key.strip_prefix("ed25519:").unwrap_or(public_key))?;
+        decoded
+            .try_into()
+            .map_err(|_| "Ed25519 public key must be 32 bytes.".to_string())
+    }
+
+    fn derive_device_id(public_key: &str) -> Result<String, String> {
+        let public_key = decode_public_key(public_key)?;
+        let digest = Sha256::digest(public_key);
+        Ok(format!("dev_ed25519_{}", URL_SAFE_NO_PAD.encode(digest)))
+    }
+
+    fn decode_urlsafe_key(value: &str) -> Result<Vec<u8>, String> {
+        URL_SAFE_NO_PAD
+            .decode(value.trim().trim_end_matches('='))
+            .map_err(|error| format!("Value must be URL-safe base64: {error}"))
+    }
+
+    fn decode_standard_base64(value: &str) -> Result<Vec<u8>, String> {
+        STANDARD
+            .decode(value)
+            .map_err(|error| format!("Value must be base64: {error}"))
+    }
+
+    fn hex_digest(bytes: &[u8]) -> String {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut output = String::with_capacity(bytes.len() * 2);
+        for byte in bytes {
+            output.push(HEX[(byte >> 4) as usize] as char);
+            output.push(HEX[(byte & 0x0f) as usize] as char);
+        }
+        output
+    }
+
+    fn percent_encode_path_segment(value: &str) -> String {
+        percent_encode(value)
+    }
+
+    fn percent_encode_query_value(value: &str) -> String {
+        percent_encode(value)
+    }
+
+    fn percent_encode(value: &str) -> String {
+        let mut encoded = String::new();
+        for byte in value.bytes() {
+            if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~') {
+                encoded.push(byte as char);
+            } else {
+                encoded.push_str(&format!("%{byte:02X}"));
+            }
+        }
+        encoded
+    }
+
+    fn percent_decode(value: &str) -> String {
+        let mut bytes = Vec::with_capacity(value.len());
+        let raw = value.as_bytes();
+        let mut index = 0;
+        while index < raw.len() {
+            if raw[index] == b'%' && index + 2 < raw.len() {
+                if let Ok(hex) = std::str::from_utf8(&raw[index + 1..index + 3]) {
+                    if let Ok(byte) = u8::from_str_radix(hex, 16) {
+                        bytes.push(byte);
+                        index += 3;
+                        continue;
+                    }
+                }
+            }
+            bytes.push(raw[index]);
+            index += 1;
+        }
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn endpoint_hint_rejects_unexpected_device_id() {
+            let hint = format!("{ENDPOINT_SCHEME}127.0.0.1:3000?device_id=dev_one&v=1");
+            let error = parse_endpoint_hint(&hint, Some("dev_two")).expect_err("reject mismatch");
+
+            assert!(error.contains("device_id"));
+        }
+
+        #[test]
+        fn endpoint_hint_parses_ipv4_socket() {
+            let hint = format!("{ENDPOINT_SCHEME}127.0.0.1:3000?device_id=dev_one&v=1");
+            let socket = parse_endpoint_hint(&hint, Some("dev_one")).expect("parse hint");
+
+            assert_eq!(socket.port(), 3000);
+        }
+
+        #[test]
+        fn transport_handshake_challenge_binds_nonces_and_noise_hash() {
+            let challenge = transport_handshake_challenge(
+                "dev_requester",
+                "dev_responder",
+                "local",
+                "remote",
+                "noise_hash",
+            );
+
+            assert_eq!(
+                challenge.get("requester_device_id").and_then(Value::as_str),
+                Some("dev_requester")
+            );
+            assert_eq!(
+                challenge.get("responder_device_id").and_then(Value::as_str),
+                Some("dev_responder")
+            );
+            assert_eq!(
+                challenge.get("session_id").and_then(Value::as_str),
+                Some("local")
+            );
+            assert_eq!(
+                challenge.get("challenge_nonce").and_then(Value::as_str),
+                Some("remote.noise_hash")
+            );
+        }
+
+        #[test]
+        fn offered_artifacts_are_scoped_to_manifest_metadata() {
+            let manifests = vec![json!({
+                "artifacts": [{
+                    "artifact_id": "art_allowed",
+                    "project_id": "proj_allowed",
+                    "content_sha256": "abc123",
+                    "size_bytes": 42,
+                }]
+            })];
+
+            let offered = offered_artifacts_by_id(&manifests);
+
+            assert_eq!(offered.len(), 1);
+            assert_eq!(
+                offered
+                    .get("art_allowed")
+                    .map(|artifact| artifact.content_sha256.as_str()),
+                Some("abc123")
+            );
+            assert!(offered.get("art_unknown").is_none());
+        }
+
+        #[test]
+        fn percent_decode_preserves_plain_base64url_device_ids() {
+            assert_eq!(
+                percent_decode("dev_ed25519_abc-DEF_123"),
+                "dev_ed25519_abc-DEF_123"
+            );
+        }
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+pub use desktop::SyncTransportState;
+
+#[cfg(not(target_os = "android"))]
+#[tauri::command]
+pub fn sync_transport_start_listener(
+    state: tauri::State<'_, desktop::SyncTransportState>,
+    payload: SyncTransportStartListenerRequest,
+) -> Result<SyncTransportStatus, String> {
+    desktop::sync_transport_start_listener(state, payload)
+}
+
+#[cfg(not(target_os = "android"))]
+#[tauri::command]
+pub fn sync_transport_stop_listener(
+    state: tauri::State<'_, desktop::SyncTransportState>,
+) -> Result<SyncTransportStatus, String> {
+    desktop::sync_transport_stop_listener(state)
+}
+
+#[cfg(not(target_os = "android"))]
+#[tauri::command]
+pub fn sync_transport_status(
+    state: tauri::State<'_, desktop::SyncTransportState>,
+) -> SyncTransportStatus {
+    desktop::sync_transport_status(state)
+}
+
+#[cfg(not(target_os = "android"))]
+#[tauri::command]
+pub async fn sync_transport_create_pairing_offer(
+    state: tauri::State<'_, desktop::SyncTransportState>,
+    payload: SyncTransportPairingOfferRequest,
+) -> Result<SyncTransportPairingOffer, String> {
+    desktop::sync_transport_create_pairing_offer(state, payload).await
+}
+
+#[cfg(not(target_os = "android"))]
+#[tauri::command]
+pub async fn sync_transport_sync_now(
+    state: tauri::State<'_, desktop::SyncTransportState>,
+    payload: SyncTransportSyncNowRequest,
+) -> Result<SyncTransportSyncResult, String> {
+    desktop::sync_transport_sync_now(state, payload).await
+}
+
+#[cfg(target_os = "android")]
+mod android_stub {
+    use super::{
+        SyncTransportPairingOffer, SyncTransportPairingOfferRequest,
+        SyncTransportStartListenerRequest, SyncTransportStatus, SyncTransportSyncNowRequest,
+        SyncTransportSyncResult,
+    };
+    use tauri::State;
+
+    #[derive(Clone, Default)]
+    pub struct SyncTransportState;
+
+    impl SyncTransportState {
+        pub fn new(_base_url: String) -> Self {
+            Self
+        }
+
+        pub fn shutdown(&self) {}
+    }
+
+    fn unsupported_status() -> SyncTransportStatus {
+        SyncTransportStatus {
+            supported: false,
+            running: false,
+            bind_host: None,
+            port: None,
+            endpoint_hints: Vec::new(),
+            active_sessions: 0,
+            accepted_sessions: 0,
+            failed_sessions: 0,
+            last_status: None,
+            last_error: Some("Sync transport is only available on desktop.".to_string()),
+        }
+    }
+
+    pub fn sync_transport_start_listener(
+        _state: State<'_, SyncTransportState>,
+        _payload: SyncTransportStartListenerRequest,
+    ) -> Result<SyncTransportStatus, String> {
+        Err("Sync transport is only available on desktop.".to_string())
+    }
+
+    pub fn sync_transport_stop_listener(
+        _state: State<'_, SyncTransportState>,
+    ) -> Result<SyncTransportStatus, String> {
+        Err("Sync transport is only available on desktop.".to_string())
+    }
+
+    pub fn sync_transport_status(_state: State<'_, SyncTransportState>) -> SyncTransportStatus {
+        unsupported_status()
+    }
+
+    pub async fn sync_transport_create_pairing_offer(
+        _state: State<'_, SyncTransportState>,
+        _payload: SyncTransportPairingOfferRequest,
+    ) -> Result<SyncTransportPairingOffer, String> {
+        Err("Sync transport is only available on desktop.".to_string())
+    }
+
+    pub async fn sync_transport_sync_now(
+        _state: State<'_, SyncTransportState>,
+        _payload: SyncTransportSyncNowRequest,
+    ) -> Result<SyncTransportSyncResult, String> {
+        Err("Sync transport is only available on desktop.".to_string())
+    }
+}
+
+#[cfg(target_os = "android")]
+pub use android_stub::SyncTransportState;
+
+#[cfg(target_os = "android")]
+#[tauri::command]
+pub fn sync_transport_start_listener(
+    state: tauri::State<'_, android_stub::SyncTransportState>,
+    payload: SyncTransportStartListenerRequest,
+) -> Result<SyncTransportStatus, String> {
+    android_stub::sync_transport_start_listener(state, payload)
+}
+
+#[cfg(target_os = "android")]
+#[tauri::command]
+pub fn sync_transport_stop_listener(
+    state: tauri::State<'_, android_stub::SyncTransportState>,
+) -> Result<SyncTransportStatus, String> {
+    android_stub::sync_transport_stop_listener(state)
+}
+
+#[cfg(target_os = "android")]
+#[tauri::command]
+pub fn sync_transport_status(
+    state: tauri::State<'_, android_stub::SyncTransportState>,
+) -> SyncTransportStatus {
+    android_stub::sync_transport_status(state)
+}
+
+#[cfg(target_os = "android")]
+#[tauri::command]
+pub async fn sync_transport_create_pairing_offer(
+    state: tauri::State<'_, android_stub::SyncTransportState>,
+    payload: SyncTransportPairingOfferRequest,
+) -> Result<SyncTransportPairingOffer, String> {
+    android_stub::sync_transport_create_pairing_offer(state, payload).await
+}
+
+#[cfg(target_os = "android")]
+#[tauri::command]
+pub async fn sync_transport_sync_now(
+    state: tauri::State<'_, android_stub::SyncTransportState>,
+    payload: SyncTransportSyncNowRequest,
+) -> Result<SyncTransportSyncResult, String> {
+    android_stub::sync_transport_sync_now(state, payload).await
+}

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -1,15 +1,24 @@
-import { act, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { JobSchema, ProjectSchema } from "./lib/api";
 import {
   mockCancelJob,
+  mockGetSyncIdentity,
+  mockGetSyncTransportStatus,
+  mockAnswerSyncPairingOffer,
+  mockListSyncTrustedPeers,
+  mockStartSyncListener,
+  mockStopSyncListener,
+  mockSyncTrustedPeerNow,
+  mockTrustSyncPeer,
   mockListJobs,
   mockListProjects,
   renderApp,
   resetAppTestHarness,
   setJobs,
   setProjects,
+  setSyncTrustedPeers,
 } from "./test/appTestHarness";
 
 function project(overrides: Partial<ProjectSchema>): Record<string, unknown> {
@@ -42,6 +51,31 @@ function job(overrides: Partial<JobSchema>): Record<string, unknown> {
   };
 }
 
+function pairingPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    sync_group_id: "sync_group_local",
+    device_id: "device_peer_1",
+    display_name: "Laptop Rig",
+    public_key: "pub_peer_1",
+    endpoint_hints: ["tcp://192.168.1.57:48625"],
+    protocol_version: "tuneforge-sync-v1",
+    pairing_offer_id: "pair_offer_peer_1",
+    pairing_secret: "pair_secret_peer_1",
+    expires_at: "2026-04-18T13:26:00.000Z",
+    signature: "pair_signature_peer_1",
+    ...overrides,
+  };
+}
+
+async function openSyncTab(user: ReturnType<typeof userEvent.setup>) {
+  renderApp(["/activity"]);
+  expect(await screen.findByRole("heading", { level: 2, name: "Jobs" })).toBeInTheDocument();
+
+  await user.click(screen.getByRole("tab", { name: "Sync" }));
+
+  expect(await screen.findByRole("heading", { level: 2, name: "Sync" })).toBeInTheDocument();
+}
+
 describe("Desktop app activity", () => {
   beforeEach(() => {
     resetAppTestHarness();
@@ -58,6 +92,109 @@ describe("Desktop app activity", () => {
     expect(screen.getByRole("tab", { name: "Jobs" })).toHaveAttribute("aria-selected", "true");
     expect(mockListJobs).toHaveBeenCalled();
     expect(mockListProjects).toHaveBeenCalled();
+  });
+
+  it("switches between Activity Jobs and Sync tabs", async () => {
+    const user = userEvent.setup();
+    renderApp(["/activity"]);
+
+    expect(await screen.findByRole("heading", { level: 2, name: "Jobs" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Jobs" })).toHaveAttribute("aria-selected", "true");
+
+    await user.click(screen.getByRole("tab", { name: "Sync" }));
+
+    expect(await screen.findByRole("heading", { level: 2, name: "Sync" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Sync" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.queryByRole("list", { name: "Job queue" })).not.toBeInTheDocument();
+    expect(mockGetSyncIdentity).toHaveBeenCalled();
+    expect(mockGetSyncTransportStatus).toHaveBeenCalled();
+    expect(mockListSyncTrustedPeers).toHaveBeenCalled();
+  });
+
+  it("answers a peer pairing offer", async () => {
+    const user = userEvent.setup();
+    const payload = pairingPayload();
+    await openSyncTab(user);
+
+    fireEvent.change(screen.getByLabelText("Peer offer or response payload"), {
+      target: { value: JSON.stringify(payload) },
+    });
+    await user.click(screen.getByRole("button", { name: "Answer Offer" }));
+
+    await waitFor(() =>
+      expect(mockAnswerSyncPairingOffer).toHaveBeenCalledWith({
+        offer: expect.objectContaining({ device_id: "device_peer_1" }),
+        endpoint_hints: [],
+        adopt_sync_group: false,
+      }),
+    );
+    expect(await screen.findByText("Laptop Rig")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Trusted Laptop Rig\. Pairing response (ready|copied)\./),
+    ).toBeInTheDocument();
+    expect((screen.getByLabelText("Pairing response") as HTMLTextAreaElement).value).toContain(
+      '"device_id": "device_local"',
+    );
+  });
+
+  it("trusts a peer from a pasted pairing response", async () => {
+    const user = userEvent.setup();
+    const payload = pairingPayload();
+    await openSyncTab(user);
+
+    fireEvent.change(screen.getByLabelText("Peer offer or response payload"), {
+      target: { value: JSON.stringify(payload) },
+    });
+    await user.click(screen.getByRole("button", { name: "Trust Response" }));
+
+    await waitFor(() =>
+      expect(mockTrustSyncPeer).toHaveBeenCalledWith({
+        payload: expect.objectContaining({ device_id: "device_peer_1" }),
+        adopt_sync_group: false,
+      }),
+    );
+    expect(await screen.findByText("Laptop Rig")).toBeInTheDocument();
+    expect(screen.getByText("Trusted Laptop Rig.")).toBeInTheDocument();
+  });
+
+  it("starts and stops the native sync listener", async () => {
+    const user = userEvent.setup();
+    await openSyncTab(user);
+
+    expect(await screen.findByText("Stopped")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Start Listener" }));
+
+    await waitFor(() => expect(mockStartSyncListener).toHaveBeenCalled());
+    expect(await screen.findByText("Listening")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Stop Listener" }));
+
+    await waitFor(() => expect(mockStopSyncListener).toHaveBeenCalled());
+    expect(await screen.findByText("Stopped")).toBeInTheDocument();
+  });
+
+  it("runs sync now for a trusted peer", async () => {
+    const user = userEvent.setup();
+    setSyncTrustedPeers([
+      {
+        device_id: "device_peer_1",
+        sync_group_id: "sync_group_local",
+        display_name: "Laptop Rig",
+        public_key: "pub_peer_1",
+        endpoint_hints: ["tcp://192.168.1.57:48625"],
+        trusted_at: "2026-04-18T13:16:00.000Z",
+      },
+    ]);
+    await openSyncTab(user);
+
+    const peers = await screen.findByRole("list", { name: "Trusted sync peers" });
+    const peerRow = within(peers).getByText("Laptop Rig").closest("li");
+    expect(peerRow).not.toBeNull();
+
+    await user.click(within(peerRow as HTMLElement).getByRole("button", { name: "Sync Now" }));
+
+    await waitFor(() => expect(mockSyncTrustedPeerNow).toHaveBeenCalledWith("device_peer_1"));
+    expect(await screen.findAllByText("Manifest exchange completed.")).not.toHaveLength(0);
   });
 
   it("shows project links and pending queue positions in queue order", async () => {

--- a/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
+++ b/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
@@ -1,0 +1,554 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  api,
+  type SyncPairingPayloadSchema,
+  type SyncTransportRunStatus,
+  type SyncTrustedPeerSchema,
+} from "../../lib/api";
+import { formatLocalDateTime, normalizeApiDateTime } from "../../lib/datetime";
+
+const PAIRING_OFFER_TTL_SECONDS = 600;
+
+function statusLabel(value: string | null | undefined) {
+  const normalized = value?.trim();
+  if (!normalized) {
+    return "Unknown";
+  }
+  return normalized
+    .replace(/[_-]+/g, " ")
+    .split(" ")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function statusClassName(value: string | null | undefined) {
+  return (value?.trim().toLowerCase() || "unknown").replace(/[^a-z0-9_-]+/g, "_");
+}
+
+function formatTimestamp(value: string | null | undefined) {
+  if (!value) {
+    return null;
+  }
+  const normalized = normalizeApiDateTime(value);
+  if (Number.isNaN(new Date(normalized).getTime())) {
+    return null;
+  }
+  return formatLocalDateTime(value, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null ? value as Record<string, unknown> : null;
+}
+
+function requiredPairingString(
+  payloadRecord: Record<string, unknown>,
+  fieldName: keyof SyncPairingPayloadSchema,
+): string {
+  const value = payloadRecord[fieldName];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`Pairing payload is missing ${fieldName}.`);
+  }
+  return value;
+}
+
+function pairingEndpointHints(value: unknown): string[] {
+  if (value === undefined) {
+    return [];
+  }
+  if (
+    !Array.isArray(value) ||
+    !value.every((hint): hint is string => typeof hint === "string" && Boolean(hint.trim()))
+  ) {
+    throw new Error("Pairing payload endpoint_hints must be a list of strings.");
+  }
+  return value;
+}
+
+function parsePairingPayload(rawValue: string): SyncPairingPayloadSchema {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawValue);
+  } catch {
+    throw new Error("Pairing payload must be valid JSON.");
+  }
+
+  const parsedRecord = asRecord(parsed);
+  const payloadRecord = asRecord(parsedRecord?.payload) ?? parsedRecord;
+  if (!payloadRecord) {
+    throw new Error("Pairing payload must be a JSON object.");
+  }
+  const displayName = payloadRecord.display_name;
+  if (displayName !== undefined && displayName !== null && typeof displayName !== "string") {
+    throw new Error("Pairing payload display_name must be a string.");
+  }
+  const expiresAt = requiredPairingString(payloadRecord, "expires_at");
+  if (Number.isNaN(new Date(expiresAt).getTime())) {
+    throw new Error("Pairing payload expires_at must be a valid date.");
+  }
+
+  return {
+    sync_group_id: requiredPairingString(payloadRecord, "sync_group_id"),
+    device_id: requiredPairingString(payloadRecord, "device_id"),
+    display_name: displayName ?? null,
+    public_key: requiredPairingString(payloadRecord, "public_key"),
+    endpoint_hints: pairingEndpointHints(payloadRecord.endpoint_hints),
+    protocol_version: requiredPairingString(payloadRecord, "protocol_version"),
+    pairing_offer_id: requiredPairingString(payloadRecord, "pairing_offer_id"),
+    pairing_secret: requiredPairingString(payloadRecord, "pairing_secret"),
+    expires_at: expiresAt,
+    signature: requiredPairingString(payloadRecord, "signature"),
+  };
+}
+
+async function copyToClipboard(value: string) {
+  if (!navigator.clipboard?.writeText) {
+    return false;
+  }
+  await navigator.clipboard.writeText(value);
+  return true;
+}
+
+function peerLabel(peer: SyncTrustedPeerSchema) {
+  return peer.display_name?.trim() || peer.device_id;
+}
+
+function peerEndpointSummary(peer: SyncTrustedPeerSchema) {
+  return peer.endpoint_hints?.length ? peer.endpoint_hints.join(", ") : "No endpoint hints";
+}
+
+function syncStatusText(status: SyncTransportRunStatus | null | undefined, peersById: Map<string, SyncTrustedPeerSchema>) {
+  if (!status) {
+    return "No sync run yet.";
+  }
+  const peer = status.peer_device_id ? peersById.get(status.peer_device_id) : null;
+  const peerName = peer ? peerLabel(peer) : status.peer_device_id ?? "peer";
+  if (status.error) {
+    return `${statusLabel(status.status)} for ${peerName}: ${status.error}`;
+  }
+  return status.message ?? `${statusLabel(status.status)} for ${peerName}.`;
+}
+
+function endpointList(endpointHints: string[]) {
+  if (!endpointHints.length) {
+    return <span>No listener endpoints announced.</span>;
+  }
+  return (
+    <ul className="activity-sync-endpoints" aria-label="Listener endpoint hints">
+      {endpointHints.map((hint) => (
+        <li key={hint}>{hint}</li>
+      ))}
+    </ul>
+  );
+}
+
+export function ActivitySyncPanel() {
+  const queryClient = useQueryClient();
+  const [pairingPayloadDraft, setPairingPayloadDraft] = useState("");
+  const [pairingOfferText, setPairingOfferText] = useState("");
+  const [pairingOfferLabel, setPairingOfferLabel] = useState("Local pairing offer");
+  const [adoptSyncGroup, setAdoptSyncGroup] = useState(false);
+  const [pairingMessage, setPairingMessage] = useState<string | null>(null);
+  const [pairingError, setPairingError] = useState<string | null>(null);
+  const [lastSyncMessage, setLastSyncMessage] = useState<string | null>(null);
+
+  const identityQuery = useQuery({
+    queryKey: ["sync", "identity"],
+    queryFn: async () => (await api.getSyncIdentity()).identity,
+  });
+  const listenerQuery = useQuery({
+    queryKey: ["sync", "listener"],
+    queryFn: () => api.getSyncTransportStatus(),
+  });
+  const peersQuery = useQuery({
+    queryKey: ["sync", "trusted-peers"],
+    queryFn: async () => (await api.listSyncTrustedPeers()).trusted_peers,
+  });
+
+  const peersById = useMemo(
+    () => new Map((peersQuery.data ?? []).map((peer) => [peer.device_id, peer])),
+    [peersQuery.data],
+  );
+  const endpointHints = listenerQuery.data?.endpoint_hints ?? [];
+  const listenerActive = listenerQuery.data?.active ?? false;
+  const listenerStatus = listenerQuery.isError ? "unavailable" : listenerQuery.data?.status ?? "checking";
+  const lastSyncStatus = listenerQuery.data?.last_status ?? syncStatusText(listenerQuery.data?.last_sync, peersById);
+
+  const refreshSyncQueries = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ["sync", "listener"] }),
+      queryClient.invalidateQueries({ queryKey: ["sync", "trusted-peers"] }),
+    ]);
+  };
+
+  const startListenerMutation = useMutation({
+    mutationFn: () => api.startSyncListener(),
+    onSuccess: async () => {
+      setLastSyncMessage("Sync listener started.");
+      await refreshSyncQueries();
+    },
+  });
+  const stopListenerMutation = useMutation({
+    mutationFn: () => api.stopSyncListener(),
+    onSuccess: async () => {
+      setLastSyncMessage("Sync listener stopped.");
+      await refreshSyncQueries();
+    },
+  });
+  const createPairingOfferMutation = useMutation({
+    mutationFn: () =>
+      api.createSyncPairingOffer({
+        endpoint_hints: endpointHints,
+        ttl_seconds: PAIRING_OFFER_TTL_SECONDS,
+      }),
+    onSuccess: async (response) => {
+      const nextOfferText = JSON.stringify(response.pairing_offer.payload, null, 2);
+      const expiresAt = formatTimestamp(response.pairing_offer.expires_at);
+      setPairingOfferText(nextOfferText);
+      setPairingOfferLabel("Local pairing offer");
+      setPairingError(null);
+      try {
+        const copied = await copyToClipboard(nextOfferText);
+        setPairingMessage(
+          copied
+            ? `Pairing offer copied.${expiresAt ? ` Expires ${expiresAt}.` : ""}`
+            : `Pairing offer ready.${expiresAt ? ` Expires ${expiresAt}.` : ""}`,
+        );
+      } catch {
+        setPairingMessage(`Pairing offer ready.${expiresAt ? ` Expires ${expiresAt}.` : ""}`);
+      }
+    },
+  });
+  const answerPairingOfferMutation = useMutation({
+    mutationFn: (offer: SyncPairingPayloadSchema) =>
+      api.answerSyncPairingOffer({
+        offer,
+        endpoint_hints: endpointHints,
+        adopt_sync_group: adoptSyncGroup,
+      }),
+    onSuccess: async (response) => {
+      const nextResponseText = JSON.stringify(response.pairing_response, null, 2);
+      setPairingPayloadDraft("");
+      setPairingOfferText(nextResponseText);
+      setPairingOfferLabel("Pairing response");
+      setPairingError(null);
+      try {
+        const copied = await copyToClipboard(nextResponseText);
+        setPairingMessage(
+          copied
+            ? `Trusted ${peerLabel(response.trusted_peer)}. Pairing response copied.`
+            : `Trusted ${peerLabel(response.trusted_peer)}. Pairing response ready.`,
+        );
+      } catch {
+        setPairingMessage(`Trusted ${peerLabel(response.trusted_peer)}. Pairing response ready.`);
+      }
+      await refreshSyncQueries();
+    },
+    onError: () => {
+      setPairingError("Could not answer the pairing offer.");
+    },
+  });
+  const trustPeerMutation = useMutation({
+    mutationFn: (payload: SyncPairingPayloadSchema) =>
+      api.trustSyncPeer({ payload, adopt_sync_group: adoptSyncGroup }),
+    onSuccess: async (response) => {
+      setPairingPayloadDraft("");
+      setPairingError(null);
+      setPairingMessage(`Trusted ${peerLabel(response.trusted_peer)}.`);
+      await refreshSyncQueries();
+    },
+    onError: () => {
+      setPairingError("Could not trust the pairing payload.");
+    },
+  });
+  const revokePeerMutation = useMutation({
+    mutationFn: (deviceId: string) => api.revokeSyncTrustedPeer(deviceId),
+    onSuccess: async (response) => {
+      setLastSyncMessage(`Revoked ${peerLabel(response.trusted_peer)}.`);
+      await refreshSyncQueries();
+    },
+  });
+  const syncNowMutation = useMutation({
+    mutationFn: (deviceId: string) => api.syncTrustedPeerNow(deviceId),
+    onSuccess: async (status) => {
+      setLastSyncMessage(syncStatusText(status, peersById));
+      await refreshSyncQueries();
+    },
+    onError: () => {
+      setLastSyncMessage("Sync now failed.");
+    },
+  });
+
+  function handleTrustPeer() {
+    setPairingError(null);
+      setPairingMessage(null);
+    try {
+      trustPeerMutation.mutate(parsePairingPayload(pairingPayloadDraft));
+    } catch (error) {
+      setPairingError(error instanceof Error ? error.message : "Pairing payload is invalid.");
+    }
+  }
+
+  function handleAnswerPairingOffer() {
+    setPairingError(null);
+    setPairingMessage(null);
+    try {
+      answerPairingOfferMutation.mutate(parsePairingPayload(pairingPayloadDraft));
+    } catch (error) {
+      setPairingError(error instanceof Error ? error.message : "Pairing payload is invalid.");
+    }
+  }
+
+  function handleListenerToggle() {
+    if (listenerActive) {
+      stopListenerMutation.mutate();
+      return;
+    }
+    startListenerMutation.mutate();
+  }
+
+  const listenerMutationPending = startListenerMutation.isPending || stopListenerMutation.isPending;
+  const pairingPayloadPending = answerPairingOfferMutation.isPending || trustPeerMutation.isPending;
+  const trustedPeers = peersQuery.data ?? [];
+  const lastListenerUpdatedAt = formatTimestamp(listenerQuery.data?.updated_at);
+
+  return (
+    <section
+      aria-labelledby="activity-sync-heading"
+      className="panel activity-sync-panel"
+      id="activity-sync-panel"
+      role="tabpanel"
+    >
+      <div className="panel-heading activity-sync-panel__heading">
+        <div>
+          <h2 id="activity-sync-heading">Sync</h2>
+          <p className="subpanel__copy">Native LAN transport lab for trusted desktop peers.</p>
+        </div>
+        <button
+          className="button button--ghost button--small"
+          disabled={listenerMutationPending}
+          onClick={handleListenerToggle}
+          type="button"
+        >
+          {listenerMutationPending ? "Updating..." : listenerActive ? "Stop Listener" : "Start Listener"}
+        </button>
+      </div>
+
+      <div className="activity-sync-grid">
+        <section className="activity-sync-section" aria-labelledby="activity-sync-listener-heading">
+          <h3 id="activity-sync-listener-heading">Listener</h3>
+          <dl className="activity-sync-facts">
+            <div>
+              <dt>Status</dt>
+              <dd>
+                <span className={`activity-sync-status activity-sync-status--${statusClassName(listenerStatus)}`}>
+                  {statusLabel(listenerStatus)}
+                </span>
+              </dd>
+            </div>
+            <div>
+              <dt>Device</dt>
+              <dd>{identityQuery.data?.display_name || identityQuery.data?.device_id || "Checking identity"}</dd>
+            </div>
+            <div>
+              <dt>Endpoints</dt>
+              <dd>{endpointList(endpointHints)}</dd>
+            </div>
+            <div>
+              <dt>Last Sync</dt>
+              <dd>{lastSyncMessage ?? lastSyncStatus}</dd>
+            </div>
+            {lastListenerUpdatedAt ? (
+              <div>
+                <dt>Updated</dt>
+                <dd>
+                  <time dateTime={normalizeApiDateTime(listenerQuery.data?.updated_at ?? "")}>
+                    {lastListenerUpdatedAt}
+                  </time>
+                </dd>
+              </div>
+            ) : null}
+          </dl>
+
+          {listenerQuery.isError ? (
+            <p className="activity-sync-alert activity-sync-alert--error" role="alert">
+              Native sync transport is unavailable.
+            </p>
+          ) : null}
+          {listenerQuery.data?.last_error ? (
+            <p className="activity-sync-alert activity-sync-alert--error" role="alert">
+              {listenerQuery.data.last_error}
+            </p>
+          ) : null}
+          {startListenerMutation.isError || stopListenerMutation.isError ? (
+            <p className="activity-sync-alert activity-sync-alert--error" role="alert">
+              Could not update the sync listener.
+            </p>
+          ) : null}
+          {lastSyncMessage ? (
+            <p className="activity-sync-alert" role="status">
+              {lastSyncMessage}
+            </p>
+          ) : null}
+        </section>
+
+        <section className="activity-sync-section" aria-labelledby="activity-sync-pairing-heading">
+          <div className="activity-sync-section__header">
+            <h3 id="activity-sync-pairing-heading">Pairing</h3>
+            <button
+              className="button button--ghost button--small"
+              disabled={!listenerActive || createPairingOfferMutation.isPending}
+              onClick={() => createPairingOfferMutation.mutate()}
+              title={listenerActive ? undefined : "Start the listener before creating a pairing offer."}
+              type="button"
+            >
+              {createPairingOfferMutation.isPending ? "Creating..." : "Copy Pairing Offer"}
+            </button>
+          </div>
+
+          {pairingOfferText ? (
+            <label className="activity-sync-field">
+              <span>{pairingOfferLabel}</span>
+              <textarea readOnly value={pairingOfferText} />
+            </label>
+          ) : null}
+
+          <label className="activity-sync-field">
+            <span>Peer offer or response payload</span>
+            <textarea
+              onChange={(event) => setPairingPayloadDraft(event.currentTarget.value)}
+              placeholder='{"device_id":"...","pairing_offer_id":"..."}'
+              value={pairingPayloadDraft}
+            />
+          </label>
+          <label className="activity-sync-checkbox">
+            <input
+              checked={adoptSyncGroup}
+              onChange={(event) => setAdoptSyncGroup(event.currentTarget.checked)}
+              type="checkbox"
+            />
+            <span>Adopt peer sync group</span>
+          </label>
+          <div className="activity-sync-actions">
+            <button
+              className="button button--primary button--small"
+              disabled={!pairingPayloadDraft.trim() || pairingPayloadPending}
+              onClick={handleAnswerPairingOffer}
+              type="button"
+            >
+              {answerPairingOfferMutation.isPending ? "Answering..." : "Answer Offer"}
+            </button>
+            <button
+              className="button button--ghost button--small"
+              disabled={!pairingPayloadDraft.trim() || pairingPayloadPending}
+              onClick={handleTrustPeer}
+              type="button"
+            >
+              {trustPeerMutation.isPending ? "Trusting..." : "Trust Response"}
+            </button>
+          </div>
+          {pairingMessage ? (
+            <p className="activity-sync-alert" role="status">
+              {pairingMessage}
+            </p>
+          ) : null}
+          {pairingError || createPairingOfferMutation.isError ? (
+            <p className="activity-sync-alert activity-sync-alert--error" role="alert">
+              {pairingError ?? "Could not create a pairing offer."}
+            </p>
+          ) : null}
+        </section>
+      </div>
+
+      <section className="activity-sync-section activity-sync-section--peers" aria-labelledby="activity-sync-peers-heading">
+        <div className="activity-sync-section__header">
+          <h3 id="activity-sync-peers-heading">Trusted Peers</h3>
+          <span className="metric-label">{trustedPeers.length} trusted</span>
+        </div>
+
+        {peersQuery.isLoading ? (
+          <p className="activity-sync-alert" role="status">
+            Loading trusted peers...
+          </p>
+        ) : null}
+        {peersQuery.isError ? (
+          <p className="activity-sync-alert activity-sync-alert--error" role="alert">
+            Could not load trusted peers.
+          </p>
+        ) : null}
+        {!peersQuery.isLoading && !peersQuery.isError && trustedPeers.length === 0 ? (
+          <p className="activity-sync-empty">No trusted peers.</p>
+        ) : null}
+        {trustedPeers.length ? (
+          <ul className="activity-sync-peer-list" aria-label="Trusted sync peers">
+            {trustedPeers.map((peer) => {
+              const isRevoking = revokePeerMutation.isPending && revokePeerMutation.variables === peer.device_id;
+              const isSyncing = syncNowMutation.isPending && syncNowMutation.variables === peer.device_id;
+              const trustedAt = formatTimestamp(peer.trusted_at);
+
+              return (
+                <li className="activity-sync-peer-row" key={peer.device_id}>
+                  <div className="activity-sync-peer-row__main">
+                    <strong>{peerLabel(peer)}</strong>
+                    <dl>
+                      <div>
+                        <dt>Device</dt>
+                        <dd>{peer.device_id}</dd>
+                      </div>
+                      <div>
+                        <dt>Endpoints</dt>
+                        <dd>{peerEndpointSummary(peer)}</dd>
+                      </div>
+                      {trustedAt ? (
+                        <div>
+                          <dt>Trusted</dt>
+                          <dd>
+                            <time dateTime={normalizeApiDateTime(peer.trusted_at)}>{trustedAt}</time>
+                          </dd>
+                        </div>
+                      ) : null}
+                    </dl>
+                  </div>
+                  <div className="activity-sync-peer-row__actions">
+                    <button
+                      className="button button--ghost button--small"
+                      disabled={isSyncing}
+                      onClick={() => syncNowMutation.mutate(peer.device_id)}
+                      type="button"
+                    >
+                      {isSyncing ? "Syncing..." : "Sync Now"}
+                    </button>
+                    <button
+                      className="button button--ghost button--small"
+                      disabled={isRevoking}
+                      onClick={() => revokePeerMutation.mutate(peer.device_id)}
+                      type="button"
+                    >
+                      {isRevoking ? "Revoking..." : "Revoke"}
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        ) : null}
+        {revokePeerMutation.isError ? (
+          <p className="activity-sync-alert activity-sync-alert--error" role="alert">
+            Could not revoke the trusted peer.
+          </p>
+        ) : null}
+        {syncNowMutation.isError ? (
+          <p className="activity-sync-alert activity-sync-alert--error" role="alert">
+            Could not run sync now.
+          </p>
+        ) : null}
+      </section>
+    </section>
+  );
+}

--- a/apps/desktop/src/features/activity/ActivityView.tsx
+++ b/apps/desktop/src/features/activity/ActivityView.tsx
@@ -1,13 +1,20 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import { api, type JobSchema, type ProjectSchema } from "../../lib/api";
 import { formatLocalDateTime, normalizeApiDateTime, parseApiDateTime } from "../../lib/datetime";
 import { formatJobStatusSummary } from "../projects/projectViewUtils";
+import { ActivitySyncPanel } from "./ActivitySyncPanel";
 
 const CANCELABLE_JOB_STATUSES = new Set(["pending", "running"]);
 const TERMINAL_JOB_STATUSES = new Set(["completed", "failed", "cancelled"]);
 const ACTIVE_JOB_REFETCH_MS = 1500;
+const ACTIVITY_TABS = [
+  { id: "jobs", label: "Jobs" },
+  { id: "sync", label: "Sync" },
+] as const;
+
+type ActivityTab = (typeof ACTIVITY_TABS)[number]["id"];
 
 type DisplayJob = {
   job: JobSchema;
@@ -206,6 +213,7 @@ function JobRow({
 }
 
 export function ActivityView() {
+  const [activeTab, setActiveTab] = useState<ActivityTab>("jobs");
   const queryClient = useQueryClient();
   const jobsQuery = useQuery({
     queryKey: ["jobs"],
@@ -250,76 +258,93 @@ export function ActivityView() {
         <div className="screen__title-block">
           <p className="eyebrow">Activity</p>
           <h1>Activity</h1>
-          <p className="screen__subtitle">Review the local processing queue across every project.</p>
+          <p className="screen__subtitle">Review local processing and sync lab activity.</p>
         </div>
       </div>
 
       <div className="project-workspace-tabs" role="tablist" aria-label="Activity">
-        <button
-          aria-selected="true"
-          className="project-workspace-tabs__button project-workspace-tabs__button--active"
-          role="tab"
-          type="button"
-        >
-          Jobs
-        </button>
+        {ACTIVITY_TABS.map((tab) => (
+          <button
+            aria-controls={`activity-${tab.id}-panel`}
+            aria-selected={activeTab === tab.id}
+            className={`project-workspace-tabs__button${
+              activeTab === tab.id ? " project-workspace-tabs__button--active" : ""
+            }`}
+            id={`activity-tab-${tab.id}`}
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            role="tab"
+            type="button"
+          >
+            {tab.label}
+          </button>
+        ))}
       </div>
 
-      <section aria-labelledby="activity-jobs-heading" className="panel activity-jobs-panel">
-        <div className="panel-heading activity-jobs-panel__heading">
-          <div>
-            <h2 id="activity-jobs-heading">Jobs</h2>
-            <p className="subpanel__copy">
-              {activeJobCount
-                ? `${activeJobCount} active job${activeJobCount === 1 ? "" : "s"} in the queue.`
-                : "No pending or running jobs."}
-            </p>
+      {activeTab === "jobs" ? (
+        <section
+          aria-labelledby="activity-jobs-heading"
+          className="panel activity-jobs-panel"
+          id="activity-jobs-panel"
+          role="tabpanel"
+        >
+          <div className="panel-heading activity-jobs-panel__heading">
+            <div>
+              <h2 id="activity-jobs-heading">Jobs</h2>
+              <p className="subpanel__copy">
+                {activeJobCount
+                  ? `${activeJobCount} active job${activeJobCount === 1 ? "" : "s"} in the queue.`
+                  : "No pending or running jobs."}
+              </p>
+            </div>
           </div>
-        </div>
 
-        {isLoading ? (
-          <div className="activity-jobs-panel__state" role="status">
-            Loading jobs...
-          </div>
-        ) : null}
+          {isLoading ? (
+            <div className="activity-jobs-panel__state" role="status">
+              Loading jobs...
+            </div>
+          ) : null}
 
-        {isError ? (
-          <div className="activity-jobs-panel__state activity-jobs-panel__state--error" role="alert">
-            Could not load the activity queue.
-          </div>
-        ) : null}
+          {isError ? (
+            <div className="activity-jobs-panel__state activity-jobs-panel__state--error" role="alert">
+              Could not load the activity queue.
+            </div>
+          ) : null}
 
-        {cancelJobMutation.isError ? (
-          <div className="activity-jobs-panel__state activity-jobs-panel__state--error" role="alert">
-            Could not cancel the job.
-          </div>
-        ) : null}
+          {cancelJobMutation.isError ? (
+            <div className="activity-jobs-panel__state activity-jobs-panel__state--error" role="alert">
+              Could not cancel the job.
+            </div>
+          ) : null}
 
-        {showJobList ? (
-          <ul aria-label="Job queue" className="activity-job-list">
-            {displayJobs.map((displayJob) => (
-              <JobRow
-                key={displayJob.job.id}
-                displayJob={displayJob}
-                isCancelling={
-                  cancelJobMutation.isPending && cancelJobMutation.variables === displayJob.job.id
-                }
-                onCancel={(jobId) => cancelJobMutation.mutate(jobId)}
-                project={
-                  displayJob.job.project_id ? projectsById.get(displayJob.job.project_id) ?? null : null
-                }
-              />
-            ))}
-          </ul>
-        ) : null}
+          {showJobList ? (
+            <ul aria-label="Job queue" className="activity-job-list">
+              {displayJobs.map((displayJob) => (
+                <JobRow
+                  key={displayJob.job.id}
+                  displayJob={displayJob}
+                  isCancelling={
+                    cancelJobMutation.isPending && cancelJobMutation.variables === displayJob.job.id
+                  }
+                  onCancel={(jobId) => cancelJobMutation.mutate(jobId)}
+                  project={
+                    displayJob.job.project_id ? projectsById.get(displayJob.job.project_id) ?? null : null
+                  }
+                />
+              ))}
+            </ul>
+          ) : null}
 
-        {showEmptyState ? (
-          <div className="activity-jobs-panel__empty">
-            <h3>No jobs yet</h3>
-            <p>Import or process a track to populate the queue.</p>
-          </div>
-        ) : null}
-      </section>
+          {showEmptyState ? (
+            <div className="activity-jobs-panel__empty">
+              <h3>No jobs yet</h3>
+              <p>Import or process a track to populate the queue.</p>
+            </div>
+          ) : null}
+        </section>
+      ) : null}
+
+      {activeTab === "sync" ? <ActivitySyncPanel /> : null}
     </section>
   );
 }

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -54,6 +54,17 @@ export type TabImportResponse = components["schemas"]["TabImportResponse"];
 export type TabImportSchema = components["schemas"]["TabImportSchema"];
 export type TabSuggestionGroupSchema = components["schemas"]["TabSuggestionGroupSchema"];
 export type TabSuggestionSchema = components["schemas"]["TabSuggestionSchema"];
+export type SyncLocalIdentitySchema = components["schemas"]["SyncLocalIdentitySchema"];
+export type SyncLocalIdentityResponse = components["schemas"]["SyncLocalIdentityResponse"];
+export type SyncPairingOfferRequest = components["schemas"]["SyncPairingOfferRequest"];
+export type SyncPairingOfferResponse = components["schemas"]["SyncPairingOfferResponse"];
+export type SyncPairingPayloadSchema = components["schemas"]["SyncPairingPayloadSchema"];
+export type SyncPairingAnswerRequest = components["schemas"]["SyncPairingAnswerRequest"];
+export type SyncPairingAnswerResponse = components["schemas"]["SyncPairingAnswerResponse"];
+export type SyncTrustedPeerCreateRequest = components["schemas"]["SyncTrustedPeerCreateRequest"];
+export type SyncTrustedPeerResponse = components["schemas"]["SyncTrustedPeerResponse"];
+export type SyncTrustedPeerSchema = components["schemas"]["SyncTrustedPeerSchema"];
+export type SyncTrustedPeersResponse = components["schemas"]["SyncTrustedPeersResponse"];
 export type RuntimeCapabilities = MobileCapabilities | null;
 export type ProjectSyncSummary = {
   state: string;
@@ -61,6 +72,23 @@ export type ProjectSyncSummary = {
   isLocal: boolean;
   isLocked: boolean;
   lockReason: string | null;
+};
+export type SyncTransportRunStatus = {
+  peer_device_id?: string | null;
+  status: string;
+  message?: string | null;
+  started_at?: string | null;
+  completed_at?: string | null;
+  error?: string | null;
+};
+export type SyncTransportStatus = {
+  active: boolean;
+  status: string;
+  endpoint_hints: string[];
+  last_status?: string | null;
+  last_error?: string | null;
+  last_sync?: SyncTransportRunStatus | null;
+  updated_at?: string | null;
 };
 
 const LOCAL_SYNC_STATES = new Set(["local", "noop", "identical_content"]);
@@ -115,6 +143,32 @@ function firstBooleanField(records: Array<Record<string, unknown> | null>, keys:
       if (typeof value === "boolean") {
         return value;
       }
+    }
+  }
+  return null;
+}
+
+function stringArrayField(record: Record<string, unknown> | null, keys: string[]) {
+  if (!record) {
+    return [];
+  }
+  for (const key of keys) {
+    const value = record[key];
+    if (Array.isArray(value)) {
+      return value.filter((item): item is string => typeof item === "string" && Boolean(item.trim()));
+    }
+  }
+  return [];
+}
+
+function numberField(record: Record<string, unknown> | null, keys: string[]) {
+  if (!record) {
+    return null;
+  }
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
     }
   }
   return null;
@@ -200,6 +254,122 @@ export function getProjectSyncSummary(project: ProjectSchema | null | undefined)
   };
 }
 
+function unsupportedRuntimeError(feature: string) {
+  return new ApiError({
+    code: "UNSUPPORTED_RUNTIME",
+    message: `${feature} requires the desktop native runtime.`,
+    details: {},
+  });
+}
+
+async function invokeDesktopNative<T>(command: string, args?: Record<string, unknown>) {
+  if (!isTauriRuntime()) {
+    throw unsupportedRuntimeError("Native sync transport");
+  }
+  return invoke<T>(command, args);
+}
+
+function normalizeSyncRunStatus(value: unknown): SyncTransportRunStatus | null {
+  const record = asRecord(value);
+  if (!record) {
+    return null;
+  }
+  const manifestErrorCount = Array.isArray(record.manifest_errors)
+    ? record.manifest_errors.length
+    : Array.isArray(record.manifestErrors)
+      ? record.manifestErrors.length
+      : 0;
+  const importedProjectCount = Array.isArray(record.imported_projects)
+    ? record.imported_projects.length
+    : Array.isArray(record.importedProjects)
+      ? record.importedProjects.length
+      : 0;
+  const receivedArtifactCount = Array.isArray(record.received_artifacts)
+    ? record.received_artifacts.length
+    : Array.isArray(record.receivedArtifacts)
+      ? record.receivedArtifacts.length
+      : 0;
+  const localManifestCount = numberField(record, ["local_manifest_count", "localManifestCount"]);
+  const remoteManifestCount = numberField(record, ["remote_manifest_count", "remoteManifestCount"]);
+  const status = firstStringField([record], ["status", "state"]) ??
+    (manifestErrorCount > 0 ? "completed_with_errors" : "completed");
+  const summary =
+    localManifestCount !== null || remoteManifestCount !== null
+      ? `Exchanged ${localManifestCount ?? 0} local and ${remoteManifestCount ?? 0} remote manifest(s); imported ${importedProjectCount} project(s), received ${receivedArtifactCount} artifact(s).`
+      : null;
+  return {
+    peer_device_id: firstStringField([record], ["peer_device_id", "peerDeviceId", "device_id", "deviceId"]),
+    status,
+    message: firstStringField([record], ["message", "status_message", "statusMessage"]) ?? summary,
+    started_at: firstStringField([record], ["started_at", "startedAt"]),
+    completed_at: firstStringField([record], ["completed_at", "completedAt"]),
+    error: firstStringField([record], ["error", "last_error", "lastError"]),
+  };
+}
+
+function normalizeSyncTransportStatus(value: unknown): SyncTransportStatus {
+  const record = asRecord(value);
+  if (!record) {
+    return {
+      active: false,
+      status: "unavailable",
+      endpoint_hints: [],
+      last_error: "Native sync transport returned an invalid status.",
+    };
+  }
+
+  const active = firstBooleanField([record], ["active", "running", "listening", "is_listening", "isListening"]) ?? false;
+  const status = firstStringField([record], ["status", "state", "listener_status", "listenerStatus"]) ??
+    (active ? "listening" : "stopped");
+  return {
+    active,
+    status,
+    endpoint_hints: stringArrayField(record, ["endpoint_hints", "endpointHints", "endpoints"]),
+    last_status: firstStringField([record], ["last_status", "lastStatus"]),
+    last_error: firstStringField([record], ["last_error", "lastError", "error"]),
+    last_sync: normalizeSyncRunStatus(record.last_sync ?? record.lastSync ?? null),
+    updated_at: firstStringField([record], ["updated_at", "updatedAt"]),
+  };
+}
+
+async function getSyncTransportStatus() {
+  return normalizeSyncTransportStatus(await invokeDesktopNative<unknown>("sync_transport_status"));
+}
+
+async function startSyncListener() {
+  return normalizeSyncTransportStatus(await invokeDesktopNative<unknown>("sync_transport_start_listener", { payload: {} }));
+}
+
+async function stopSyncListener() {
+  return normalizeSyncTransportStatus(await invokeDesktopNative<unknown>("sync_transport_stop_listener"));
+}
+
+async function syncTrustedPeerNow(deviceId: string) {
+  const result = normalizeSyncRunStatus(
+    await invokeDesktopNative<unknown>("sync_transport_sync_now", { payload: { peerDeviceId: deviceId } }),
+  );
+  if (!result) {
+    throw new Error("Native sync transport returned an invalid sync result.");
+  }
+  return result;
+}
+
+async function createNativeSyncPairingOffer(body: SyncPairingOfferRequest): Promise<SyncPairingOfferResponse> {
+  const nativeResponse = asRecord(
+    await invokeDesktopNative<unknown>("sync_transport_create_pairing_offer", {
+      payload: { ttlSeconds: body.ttl_seconds },
+    }),
+  );
+  const pairingOffer = asRecord(nativeResponse?.pairingOffer) ?? asRecord(nativeResponse?.pairing_offer);
+  if (!pairingOffer) {
+    throw new Error("Native sync transport returned an invalid pairing offer.");
+  }
+  if (asRecord(pairingOffer.pairing_offer)) {
+    return pairingOffer as SyncPairingOfferResponse;
+  }
+  return { pairing_offer: pairingOffer as SyncPairingOfferResponse["pairing_offer"] };
+}
+
 export type TuneForgeClient = {
   getMobileCapabilities: () => Promise<RuntimeCapabilities>;
   getHealth: () => Promise<HealthResponse>;
@@ -235,6 +405,16 @@ export type TuneForgeClient = {
   listJobs: () => Promise<components["schemas"]["JobsResponse"]>;
   getJob: (jobId: string) => Promise<components["schemas"]["JobResponse"]>;
   cancelJob: (jobId: string) => Promise<components["schemas"]["JobResponse"]>;
+  getSyncIdentity: () => Promise<SyncLocalIdentityResponse>;
+  createSyncPairingOffer: (body: SyncPairingOfferRequest) => Promise<SyncPairingOfferResponse>;
+  answerSyncPairingOffer: (body: SyncPairingAnswerRequest) => Promise<SyncPairingAnswerResponse>;
+  listSyncTrustedPeers: () => Promise<SyncTrustedPeersResponse>;
+  trustSyncPeer: (body: SyncTrustedPeerCreateRequest) => Promise<SyncTrustedPeerResponse>;
+  revokeSyncTrustedPeer: (deviceId: string) => Promise<SyncTrustedPeerResponse>;
+  getSyncTransportStatus: () => Promise<SyncTransportStatus>;
+  startSyncListener: () => Promise<SyncTransportStatus>;
+  stopSyncListener: () => Promise<SyncTransportStatus>;
+  syncTrustedPeerNow: (deviceId: string) => Promise<SyncTransportRunStatus>;
   streamArtifactUrl: (artifactId: string) => string;
 };
 
@@ -439,6 +619,26 @@ function createHttpTuneForgeClient(): TuneForgeClient {
     getJob: (jobId: string) => unwrap(client.GET("/api/v1/jobs/{job_id}", { params: { path: { job_id: jobId } } })),
     cancelJob: (jobId: string) =>
       unwrap(client.POST("/api/v1/jobs/{job_id}/cancel", { params: { path: { job_id: jobId } } })),
+    getSyncIdentity: () => unwrap(client.GET("/api/v1/sync/identity")),
+    createSyncPairingOffer: (body: SyncPairingOfferRequest) =>
+      isTauriRuntime()
+        ? createNativeSyncPairingOffer(body)
+        : unwrap(client.POST("/api/v1/sync/pairing/offers", { body })),
+    answerSyncPairingOffer: (body: SyncPairingAnswerRequest) =>
+      unwrap(client.POST("/api/v1/sync/pairing/responses", { body })),
+    listSyncTrustedPeers: () => unwrap(client.GET("/api/v1/sync/trusted-peers")),
+    trustSyncPeer: (body: SyncTrustedPeerCreateRequest) =>
+      unwrap(client.POST("/api/v1/sync/trusted-peers", { body })),
+    revokeSyncTrustedPeer: (deviceId: string) =>
+      unwrap(
+        client.DELETE("/api/v1/sync/trusted-peers/{device_id}", {
+          params: { path: { device_id: deviceId } },
+        }),
+      ),
+    getSyncTransportStatus,
+    startSyncListener,
+    stopSyncListener,
+    syncTrustedPeerNow,
     streamArtifactUrl: (artifactId: string) => `${getApiBaseUrl()}/api/v1/artifacts/${artifactId}/stream`,
   };
 }
@@ -508,6 +708,36 @@ function createMobileTuneForgeClient(capabilities: MobileCapabilities): TuneForg
     listJobs: () => invokeMobile("mobile_list_jobs"),
     getJob: (jobId: string) => invokeMobile("mobile_get_job", { jobId }),
     cancelJob: (jobId: string) => invokeMobile("mobile_cancel_job", { jobId }),
+    getSyncIdentity: async () => {
+      throw unsupportedRuntimeError("Sync identity");
+    },
+    createSyncPairingOffer: async () => {
+      throw unsupportedRuntimeError("Sync pairing");
+    },
+    answerSyncPairingOffer: async () => {
+      throw unsupportedRuntimeError("Sync pairing");
+    },
+    listSyncTrustedPeers: async () => {
+      throw unsupportedRuntimeError("Trusted sync peers");
+    },
+    trustSyncPeer: async () => {
+      throw unsupportedRuntimeError("Sync pairing");
+    },
+    revokeSyncTrustedPeer: async () => {
+      throw unsupportedRuntimeError("Trusted sync peers");
+    },
+    getSyncTransportStatus: async () => {
+      throw unsupportedRuntimeError("Native sync transport");
+    },
+    startSyncListener: async () => {
+      throw unsupportedRuntimeError("Native sync transport");
+    },
+    stopSyncListener: async () => {
+      throw unsupportedRuntimeError("Native sync transport");
+    },
+    syncTrustedPeerNow: async () => {
+      throw unsupportedRuntimeError("Native sync transport");
+    },
     streamArtifactUrl: (artifactId: string) => {
       const artifactPath = mobileArtifactPaths.get(artifactId);
       return artifactPath ? convertFileSrc(artifactPath) : "";
@@ -587,5 +817,15 @@ export const api: TuneForgeClient = {
   listJobs: () => activeClient.listJobs(),
   getJob: (jobId: string) => activeClient.getJob(jobId),
   cancelJob: (jobId: string) => activeClient.cancelJob(jobId),
+  getSyncIdentity: () => activeClient.getSyncIdentity(),
+  createSyncPairingOffer: (body: SyncPairingOfferRequest) => activeClient.createSyncPairingOffer(body),
+  answerSyncPairingOffer: (body: SyncPairingAnswerRequest) => activeClient.answerSyncPairingOffer(body),
+  listSyncTrustedPeers: () => activeClient.listSyncTrustedPeers(),
+  trustSyncPeer: (body: SyncTrustedPeerCreateRequest) => activeClient.trustSyncPeer(body),
+  revokeSyncTrustedPeer: (deviceId: string) => activeClient.revokeSyncTrustedPeer(deviceId),
+  getSyncTransportStatus: () => activeClient.getSyncTransportStatus(),
+  startSyncListener: () => activeClient.startSyncListener(),
+  stopSyncListener: () => activeClient.stopSyncListener(),
+  syncTrustedPeerNow: (deviceId: string) => activeClient.syncTrustedPeerNow(deviceId),
   streamArtifactUrl: (artifactId: string) => activeClient.streamArtifactUrl(artifactId),
 };

--- a/apps/desktop/src/styles/activity.css
+++ b/apps/desktop/src/styles/activity.css
@@ -183,6 +183,182 @@
   font-weight: 720;
 }
 
+.activity-sync-panel {
+  display: grid;
+  gap: 1.1rem;
+}
+
+.activity-sync-panel__heading {
+  align-items: center;
+}
+
+.activity-sync-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(18rem, 1.1fr);
+  gap: 1.1rem;
+}
+
+.activity-sync-section {
+  display: grid;
+  align-content: start;
+  gap: 0.85rem;
+  min-width: 0;
+  padding-top: 1rem;
+  border-top: 1px solid color-mix(in srgb, var(--divider) 76%, transparent);
+}
+
+.activity-sync-section__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+
+.activity-sync-facts,
+.activity-sync-peer-row dl {
+  display: grid;
+  gap: 0.7rem;
+  margin: 0;
+}
+
+.activity-sync-facts div,
+.activity-sync-peer-row dl div {
+  display: grid;
+  gap: 0.18rem;
+  min-width: 0;
+}
+
+.activity-sync-facts dt,
+.activity-sync-peer-row dt {
+  color: var(--muted);
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.activity-sync-facts dd,
+.activity-sync-peer-row dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.activity-sync-status {
+  display: inline-flex;
+  width: fit-content;
+  border: 1px solid color-mix(in srgb, var(--chip-border) 82%, transparent);
+  border-radius: 999px;
+  padding: 0.22rem 0.55rem;
+  background: color-mix(in srgb, var(--chip-bg) 76%, transparent);
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.activity-sync-status--listening {
+  border-color: color-mix(in srgb, var(--playback-accent) 42%, var(--chip-border));
+}
+
+.activity-sync-status--error,
+.activity-sync-status--unavailable {
+  border-color: color-mix(in srgb, var(--danger) 48%, var(--chip-border));
+  color: var(--danger);
+}
+
+.activity-sync-endpoints {
+  display: grid;
+  gap: 0.3rem;
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.activity-sync-field {
+  display: grid;
+  gap: 0.45rem;
+  color: var(--text);
+  font-weight: 700;
+}
+
+.activity-sync-field textarea {
+  min-height: 8rem;
+  resize: vertical;
+  border: 1px solid var(--input-border);
+  border-radius: 12px;
+  background: var(--input-bg);
+  color: var(--text);
+  padding: 0.8rem 0.9rem;
+  font: inherit;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  line-height: 1.45;
+}
+
+.activity-sync-field textarea:focus-visible,
+.activity-sync-checkbox input:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.activity-sync-checkbox {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+  font-weight: 760;
+}
+
+.activity-sync-actions {
+  display: flex;
+  gap: 0.7rem;
+  flex-wrap: wrap;
+}
+
+.activity-sync-alert,
+.activity-sync-empty {
+  margin: 0;
+  color: var(--muted);
+}
+
+.activity-sync-alert--error {
+  color: var(--danger);
+  font-weight: 720;
+}
+
+.activity-sync-peer-list {
+  display: grid;
+  gap: 0.7rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.activity-sync-peer-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: start;
+  padding: 0.85rem 0;
+  border-top: 1px solid color-mix(in srgb, var(--divider) 72%, transparent);
+}
+
+.activity-sync-peer-row:first-child {
+  border-top: 0;
+}
+
+.activity-sync-peer-row__main {
+  display: grid;
+  gap: 0.55rem;
+  min-width: 0;
+}
+
+.activity-sync-peer-row__actions {
+  display: flex;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 @media (max-width: 920px) {
   .activity-job-row__main {
     grid-template-columns: minmax(0, 1fr);
@@ -194,5 +370,14 @@
 
   .activity-job-row__cancel {
     justify-self: start;
+  }
+
+  .activity-sync-grid,
+  .activity-sync-peer-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .activity-sync-peer-row__actions {
+    justify-content: flex-start;
   }
 }

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -3,6 +3,15 @@ import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { vi } from "vitest";
 import App from "../App";
+import type {
+  SyncPairingAnswerRequest,
+  SyncPairingAnswerResponse,
+  SyncPairingOfferRequest,
+  SyncPairingOfferResponse,
+  SyncTrustedPeerSchema,
+  SyncTrustedPeerCreateRequest,
+  SyncTrustedPeerResponse,
+} from "../lib/api";
 
 const {
   resetMockApiState,
@@ -13,6 +22,8 @@ const {
   setChordBackends,
   setStemModels,
   setJobs,
+  setSyncTransportStatus,
+  setSyncTrustedPeers,
   setDeferredPreviewCompletion,
   flushPendingPreview,
   mockOpen,
@@ -30,6 +41,16 @@ const {
   mockListArtifacts,
   mockListJobs,
   mockCancelJob,
+  mockGetSyncIdentity,
+  mockGetSyncTransportStatus,
+  mockStartSyncListener,
+  mockStopSyncListener,
+  mockCreateSyncPairingOffer,
+  mockAnswerSyncPairingOffer,
+  mockListSyncTrustedPeers,
+  mockTrustSyncPeer,
+  mockRevokeSyncTrustedPeer,
+  mockSyncTrustedPeerNow,
   mockCreateChords,
   mockCreateLyrics,
   mockCreateTabImport,
@@ -130,6 +151,9 @@ const {
     stemModels: Array<Record<string, unknown>>;
     pendingPreviewArtifactsByProject: Record<string, Array<Record<string, unknown>>>;
     jobs: Array<Record<string, unknown>>;
+    syncIdentity: Record<string, unknown>;
+    syncTransportStatus: Record<string, unknown>;
+    syncTrustedPeers: Array<Record<string, unknown>>;
     snapshotFiles: Record<string, string>;
     systemInputVolume: {
       supported: boolean;
@@ -396,6 +420,17 @@ const {
     state.jobs = jobs.map((job, index) => normalizeMockJob(job, index));
   }
 
+  function setSyncTransportStatus(nextStatus: Record<string, unknown>) {
+    state.syncTransportStatus = {
+      ...state.syncTransportStatus,
+      ...clone(nextStatus),
+    };
+  }
+
+  function setSyncTrustedPeers(peers: Array<Record<string, unknown>>) {
+    state.syncTrustedPeers = clone(peers);
+  }
+
   function setDeferredPreviewCompletion(value: boolean) {
     state.deferPreviewCompletion = value;
   }
@@ -502,6 +537,23 @@ const {
           updated_at: createdAt,
         },
       ],
+      syncIdentity: {
+        device_id: "device_local",
+        sync_group_id: "sync_group_local",
+        display_name: "Studio Mac",
+        public_key: "pub_local",
+        created_at: createdAt,
+        updated_at: createdAt,
+      },
+      syncTransportStatus: {
+        active: false,
+        status: "stopped",
+        endpoint_hints: [],
+        last_error: null,
+        last_sync: null,
+        updated_at: createdAt,
+      },
+      syncTrustedPeers: [],
       snapshotFiles: {},
       systemInputVolume: {
         supported: true,
@@ -1146,6 +1198,147 @@ const {
     state.jobs = state.jobs.map((job, index) => (index === jobIndex ? cancelledJob : job));
     return { job: clone(cancelledJob) };
   });
+  function normalizeSyncPeer(peer: Record<string, unknown>): SyncTrustedPeerSchema {
+    return {
+      device_id: String(peer.device_id ?? "device_peer"),
+      sync_group_id: String(peer.sync_group_id ?? "sync_group_local"),
+      display_name: typeof peer.display_name === "string" ? peer.display_name : null,
+      public_key: String(peer.public_key ?? "pub_peer"),
+      endpoint_hints: Array.isArray(peer.endpoint_hints)
+        ? peer.endpoint_hints.filter((hint): hint is string => typeof hint === "string")
+        : [],
+      trusted_at: typeof peer.trusted_at === "string" ? peer.trusted_at : createdAt,
+      revoked_at: typeof peer.revoked_at === "string" ? peer.revoked_at : null,
+      updated_at: typeof peer.updated_at === "string" ? peer.updated_at : createdAt,
+    };
+  }
+  const mockGetSyncIdentity = vi.fn(async () => ({ identity: clone(state.syncIdentity) }));
+  const mockGetSyncTransportStatus = vi.fn(async () => clone(state.syncTransportStatus));
+  const mockStartSyncListener = vi.fn(async () => {
+    state.syncTransportStatus = {
+      ...state.syncTransportStatus,
+      active: true,
+      status: "listening",
+      endpoint_hints: ["tcp://192.168.1.42:48625"],
+      last_error: null,
+      updated_at: createdAt,
+    };
+    return clone(state.syncTransportStatus);
+  });
+  const mockStopSyncListener = vi.fn(async () => {
+    state.syncTransportStatus = {
+      ...state.syncTransportStatus,
+      active: false,
+      status: "stopped",
+      endpoint_hints: [],
+      updated_at: createdAt,
+    };
+    return clone(state.syncTransportStatus);
+  });
+  const mockCreateSyncPairingOffer = vi.fn(async (
+    body: SyncPairingOfferRequest,
+  ): Promise<SyncPairingOfferResponse> => ({
+    pairing_offer: {
+      payload: {
+        sync_group_id: String(state.syncIdentity.sync_group_id),
+        device_id: String(state.syncIdentity.device_id),
+        display_name: typeof state.syncIdentity.display_name === "string" ? state.syncIdentity.display_name : null,
+        public_key: String(state.syncIdentity.public_key),
+        endpoint_hints: clone(body.endpoint_hints ?? []),
+        protocol_version: "tuneforge-sync-v1",
+        pairing_offer_id: "pair_offer_1",
+        pairing_secret: "pair_secret_1",
+        expires_at: "2026-04-18T13:26:00.000Z",
+        signature: "pair_signature_1",
+      },
+      expires_at: "2026-04-18T13:26:00.000Z",
+      ttl_seconds: body.ttl_seconds,
+    },
+  }));
+  const mockAnswerSyncPairingOffer = vi.fn(async (
+    body: SyncPairingAnswerRequest,
+  ): Promise<SyncPairingAnswerResponse> => {
+    const peer = normalizeSyncPeer({
+      device_id: body.offer.device_id,
+      sync_group_id: body.offer.sync_group_id,
+      display_name: body.offer.display_name,
+      public_key: body.offer.public_key,
+      endpoint_hints: body.offer.endpoint_hints,
+      trusted_at: createdAt,
+      updated_at: createdAt,
+    });
+    state.syncTrustedPeers = [
+      peer,
+      ...state.syncTrustedPeers.filter((existingPeer) => existingPeer.device_id !== peer.device_id),
+    ];
+    return {
+      pairing_response: {
+        sync_group_id: String(state.syncIdentity.sync_group_id),
+        device_id: String(state.syncIdentity.device_id),
+        display_name: typeof state.syncIdentity.display_name === "string" ? state.syncIdentity.display_name : null,
+        public_key: String(state.syncIdentity.public_key),
+        endpoint_hints: clone(body.endpoint_hints ?? []),
+        protocol_version: "tuneforge-sync-v1",
+        pairing_offer_id: body.offer.pairing_offer_id,
+        pairing_secret: body.offer.pairing_secret,
+        expires_at: body.offer.expires_at,
+        signature: "pair_response_signature_1",
+      },
+      trusted_peer: clone(peer),
+    };
+  });
+  const mockListSyncTrustedPeers = vi.fn(async () => ({
+    trusted_peers: clone(state.syncTrustedPeers.map((peer) => normalizeSyncPeer(peer))),
+  }));
+  const mockTrustSyncPeer = vi.fn(async (
+    body: SyncTrustedPeerCreateRequest,
+  ): Promise<SyncTrustedPeerResponse> => {
+    const peer = normalizeSyncPeer({
+      device_id: body.payload.device_id,
+      sync_group_id: body.payload.sync_group_id,
+      display_name: body.payload.display_name,
+      public_key: body.payload.public_key,
+      endpoint_hints: body.payload.endpoint_hints,
+      trusted_at: createdAt,
+      updated_at: createdAt,
+    });
+    state.syncTrustedPeers = [
+      peer,
+      ...state.syncTrustedPeers.filter((existingPeer) => existingPeer.device_id !== peer.device_id),
+    ];
+    return { trusted_peer: clone(peer) };
+  });
+  const mockRevokeSyncTrustedPeer = vi.fn(async (deviceId: string) => {
+    const peer = normalizeSyncPeer(
+      state.syncTrustedPeers.find((trustedPeer) => trustedPeer.device_id === deviceId) ?? {
+        device_id: deviceId,
+      },
+    );
+    state.syncTrustedPeers = state.syncTrustedPeers.filter((trustedPeer) => trustedPeer.device_id !== deviceId);
+    return {
+      trusted_peer: clone({
+        ...peer,
+        revoked_at: createdAt,
+        updated_at: createdAt,
+      }),
+    };
+  });
+  const mockSyncTrustedPeerNow = vi.fn(async (deviceId: string) => {
+    state.syncTransportStatus = {
+      ...state.syncTransportStatus,
+      last_sync: {
+        peer_device_id: deviceId,
+        status: "completed",
+        message: "Manifest exchange completed.",
+        started_at: createdAt,
+        completed_at: createdAt,
+        error: null,
+      },
+      last_error: null,
+      updated_at: createdAt,
+    };
+    return clone(state.syncTransportStatus.last_sync);
+  });
   const mockCreateChords = vi.fn(async (projectId: string, body?: Record<string, unknown>) => {
     state.chordsByProject[projectId] = makeChordTimeline(projectId);
     const job = makeMockJob({
@@ -1646,6 +1839,8 @@ const {
     setChordBackends,
     setStemModels,
     setJobs,
+    setSyncTransportStatus,
+    setSyncTrustedPeers,
     setDeferredPreviewCompletion,
     flushPendingPreview,
     mockOpen,
@@ -1663,6 +1858,16 @@ const {
     mockListArtifacts,
     mockListJobs,
     mockCancelJob,
+    mockGetSyncIdentity,
+    mockGetSyncTransportStatus,
+    mockStartSyncListener,
+    mockStopSyncListener,
+    mockCreateSyncPairingOffer,
+    mockAnswerSyncPairingOffer,
+    mockListSyncTrustedPeers,
+    mockTrustSyncPeer,
+    mockRevokeSyncTrustedPeer,
+    mockSyncTrustedPeerNow,
     mockCreateChords,
     mockCreateLyrics,
     mockCreateTabImport,
@@ -1701,6 +1906,8 @@ export {
   setChordBackends,
   setStemModels,
   setJobs,
+  setSyncTransportStatus,
+  setSyncTrustedPeers,
   setDeferredPreviewCompletion,
   flushPendingPreview,
   mockOpen,
@@ -1718,6 +1925,16 @@ export {
   mockListArtifacts,
   mockListJobs,
   mockCancelJob,
+  mockGetSyncIdentity,
+  mockGetSyncTransportStatus,
+  mockStartSyncListener,
+  mockStopSyncListener,
+  mockCreateSyncPairingOffer,
+  mockAnswerSyncPairingOffer,
+  mockListSyncTrustedPeers,
+  mockTrustSyncPeer,
+  mockRevokeSyncTrustedPeer,
+  mockSyncTrustedPeerNow,
   mockCreateChords,
   mockCreateLyrics,
   mockCreateTabImport,
@@ -1770,6 +1987,16 @@ vi.mock("../lib/api", async (importOriginal) => {
       listArtifacts: mockListArtifacts,
       listJobs: mockListJobs,
       cancelJob: mockCancelJob,
+      getSyncIdentity: mockGetSyncIdentity,
+      getSyncTransportStatus: mockGetSyncTransportStatus,
+      startSyncListener: mockStartSyncListener,
+      stopSyncListener: mockStopSyncListener,
+      createSyncPairingOffer: mockCreateSyncPairingOffer,
+      answerSyncPairingOffer: mockAnswerSyncPairingOffer,
+      listSyncTrustedPeers: mockListSyncTrustedPeers,
+      trustSyncPeer: mockTrustSyncPeer,
+      revokeSyncTrustedPeer: mockRevokeSyncTrustedPeer,
+      syncTrustedPeerNow: mockSyncTrustedPeerNow,
       createChords: mockCreateChords,
       createLyrics: mockCreateLyrics,
       createTabImport: mockCreateTabImport,
@@ -2075,6 +2302,16 @@ export function resetAppTestHarness() {
   mockListArtifacts.mockClear();
   mockListJobs.mockClear();
   mockCancelJob.mockClear();
+  mockGetSyncIdentity.mockClear();
+  mockGetSyncTransportStatus.mockClear();
+  mockStartSyncListener.mockClear();
+  mockStopSyncListener.mockClear();
+  mockCreateSyncPairingOffer.mockClear();
+  mockAnswerSyncPairingOffer.mockClear();
+  mockListSyncTrustedPeers.mockClear();
+  mockTrustSyncPeer.mockClear();
+  mockRevokeSyncTrustedPeer.mockClear();
+  mockSyncTrustedPeerNow.mockClear();
   mockCreateChords.mockClear();
   mockCreateLyrics.mockClear();
   mockCreateTabImport.mockClear();

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -485,6 +485,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/sync/reconciliation/apply": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Sync Reconciliation Apply */
+        post: operations["sync_reconciliation_apply_api_v1_sync_reconciliation_apply_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/sync/transport/handshake/sign": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Sync Transport Handshake Sign */
+        post: operations["sync_transport_handshake_sign_api_v1_sync_transport_handshake_sign_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/sync/identity": {
         parameters: {
             query?: never;
@@ -514,6 +548,23 @@ export interface paths {
         put?: never;
         /** Sync Pairing Offer Create */
         post: operations["sync_pairing_offer_create_api_v1_sync_pairing_offers_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/sync/pairing/responses": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Sync Pairing Offer Answer */
+        post: operations["sync_pairing_offer_answer_api_v1_sync_pairing_responses_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1420,6 +1471,22 @@ export interface components {
             /** Delete Tombstones */
             delete_tombstones?: components["schemas"]["SyncDeleteTombstoneSchema"][];
         };
+        /** SyncPairingAnswerRequest */
+        SyncPairingAnswerRequest: {
+            offer: components["schemas"]["SyncPairingPayloadSchema"];
+            /** Endpoint Hints */
+            endpoint_hints?: string[];
+            /**
+             * Adopt Sync Group
+             * @default false
+             */
+            adopt_sync_group: boolean;
+        };
+        /** SyncPairingAnswerResponse */
+        SyncPairingAnswerResponse: {
+            pairing_response: components["schemas"]["SyncPairingPayloadSchema"];
+            trusted_peer: components["schemas"]["SyncTrustedPeerSchema"];
+        };
         /** SyncPairingOfferRequest */
         SyncPairingOfferRequest: {
             /** Endpoint Hints */
@@ -1749,6 +1816,56 @@ export interface components {
                 [key: string]: unknown;
             };
         };
+        /** SyncReconciliationApplyActionResultSchema */
+        SyncReconciliationApplyActionResultSchema: {
+            action: components["schemas"]["SyncReconciliationActionSchema"];
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "applied" | "satisfied" | "skipped" | "failed";
+            /** Reason */
+            reason?: string | null;
+            /** Details */
+            details?: {
+                [key: string]: unknown;
+            };
+        };
+        /** SyncReconciliationApplyRequest */
+        SyncReconciliationApplyRequest: {
+            remote_library: components["schemas"]["SyncReconciliationRemoteLibrarySchema"];
+            /** Project Manifests */
+            project_manifests?: components["schemas"]["SyncProjectManifestSchema"][];
+            /** Peer Inventory */
+            peer_inventory: components["schemas"]["SyncPeerInventoryEntrySchema"][];
+            /** Staging Root */
+            staging_root?: string | null;
+            /**
+             * Use Content Addressed Staging
+             * @default true
+             */
+            use_content_addressed_staging: boolean;
+        };
+        /** SyncReconciliationApplyResponse */
+        SyncReconciliationApplyResponse: {
+            summary: components["schemas"]["SyncReconciliationApplySummarySchema"];
+            plan: components["schemas"]["SyncReconciliationPlanResponse"];
+            /** Results */
+            results: components["schemas"]["SyncReconciliationApplyActionResultSchema"][];
+        };
+        /** SyncReconciliationApplySummarySchema */
+        SyncReconciliationApplySummarySchema: {
+            /** Planned Actions */
+            planned_actions: number;
+            /** Applied Actions */
+            applied_actions: number;
+            /** Satisfied Actions */
+            satisfied_actions: number;
+            /** Skipped Actions */
+            skipped_actions: number;
+            /** Failed Actions */
+            failed_actions: number;
+        };
         /** SyncReconciliationItemSchema */
         SyncReconciliationItemSchema: {
             /** Item Type */
@@ -1844,6 +1961,66 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
+        };
+        /** SyncTransportHandshakeChallengeSchema */
+        SyncTransportHandshakeChallengeSchema: {
+            /** Protocol Version */
+            protocol_version: string;
+            /**
+             * Challenge Type
+             * @constant
+             */
+            challenge_type: "transport_handshake";
+            /** Session Id */
+            session_id: string;
+            /** Challenge Nonce */
+            challenge_nonce: string;
+            /** Requester Device Id */
+            requester_device_id: string;
+            /** Responder Device Id */
+            responder_device_id: string;
+            /**
+             * Issued At
+             * Format: date-time
+             */
+            issued_at: string;
+            /**
+             * Expires At
+             * Format: date-time
+             */
+            expires_at: string;
+        };
+        /** SyncTransportHandshakeSignRequest */
+        SyncTransportHandshakeSignRequest: {
+            /** Peer Device Id */
+            peer_device_id: string;
+            challenge: components["schemas"]["SyncTransportHandshakeChallengeSchema"];
+        };
+        /** SyncTransportHandshakeSignatureResponse */
+        SyncTransportHandshakeSignatureResponse: {
+            /** Protocol Version */
+            protocol_version: string;
+            /**
+             * Challenge Type
+             * @constant
+             */
+            challenge_type: "transport_handshake";
+            /** Local Device Id */
+            local_device_id: string;
+            /** Peer Device Id */
+            peer_device_id: string;
+            /** Public Key */
+            public_key: string;
+            challenge: components["schemas"]["SyncTransportHandshakeChallengeSchema"];
+            /** Canonical Challenge Json */
+            canonical_challenge_json: string;
+            /** Signature */
+            signature: string;
+            /**
+             * Signed At
+             * Format: date-time
+             */
+            signed_at: string;
         };
         /** SyncTrustedPeerCreateRequest */
         SyncTrustedPeerCreateRequest: {
@@ -3046,6 +3223,72 @@ export interface operations {
             };
         };
     };
+    sync_reconciliation_apply_api_v1_sync_reconciliation_apply_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SyncReconciliationApplyRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncReconciliationApplyResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    sync_transport_handshake_sign_api_v1_sync_transport_handshake_sign_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SyncTransportHandshakeSignRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncTransportHandshakeSignatureResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     sync_local_identity_api_v1_sync_identity_get: {
         parameters: {
             query?: never;
@@ -3119,6 +3362,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SyncPairingOfferResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    sync_pairing_offer_answer_api_v1_sync_pairing_responses_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SyncPairingAnswerRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncPairingAnswerResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary
- Add the baseline native TCP LAN sync transport with encrypted peer sessions, manual pairing, artifact transfer, and SHA-256 staging verification.
- Add backend transport signing and reconciliation apply endpoints, generated shared contracts, and Activity > Sync controls for starting listeners, pairing, trusted peers, and Sync Now.
- Keep FastAPI loopback-only; LAN exposure is limited to the native Tauri transport.
- Closes #126.

## Testing
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `cd apps/backend && uv run --python 3.11 pytest`
- `pnpm contracts:generate`
- `pnpm --filter @tuneforge/desktop test --run src/App.activity.test.tsx`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
- `cd apps/desktop/src-tauri && cargo test`
- `cd apps/desktop/src-tauri && cargo check`
- Manual Linux/macOS LAN validation: pairing and artifact byte transfer worked; import/apply follow-up findings are documented in #119.
