### PR TITLE
feat: add Linux/macOS sync batch import

### DIFF
--- a/apps/backend/app/services/sync_manifest.py
+++ b/apps/backend/app/services/sync_manifest.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import Session
 from app.config import get_settings
 from app.errors import AppError
 from app.models import (
+    AnalysisResult,
     Artifact,
     ChordTimeline,
     LyricsTranscript,
@@ -326,6 +327,7 @@ def import_staged_project_manifest(
         imported_tombstones = _import_delete_tombstones(session, project_manifest)
         _apply_delete_tombstones(session, imported_tombstones)
         _hydrate_current_entity_revisions(session, project, project_manifest.entity_revisions)
+        hydrate_project_analysis_result_from_artifact(session, project.id)
         if upgrading_placeholder:
             mark_project_sync_local(session, project)
     except OSError as exc:
@@ -845,6 +847,54 @@ def _hydrate_section_revision(
     section.metadata_json = _payload_mapping(payload, ("metadata", "metadata_json"))
     section.created_at = _payload_datetime(payload, "created_at") or revision.created_at
     section.updated_at = _payload_datetime(payload, "updated_at") or revision.updated_at
+
+
+def _hydrate_analysis_result_from_artifact(session: Session, project: Project) -> None:
+    analysis_artifact = session.scalar(
+        select(Artifact)
+        .where(Artifact.project_id == project.id, Artifact.type == "analysis_json")
+        .order_by(Artifact.created_at.desc(), Artifact.id.desc())
+    )
+    if analysis_artifact is None:
+        return
+
+    payload = _read_analysis_artifact_payload(analysis_artifact)
+    payload_project_id = _analysis_optional_str(payload, "project_id")
+    if payload_project_id is not None and payload_project_id != project.id:
+        raise _invalid_manifest("Analysis artifact project_id must match the manifest project.")
+
+    source_artifact_id = _analysis_optional_str(payload, "source_artifact_id")
+    if source_artifact_id is not None:
+        source_artifact = session.get(Artifact, source_artifact_id)
+        if source_artifact is None or source_artifact.project_id != project.id:
+            raise _invalid_manifest("Analysis artifact source_artifact_id must belong to the manifest project.")
+
+    analysis = session.get(AnalysisResult, project.id)
+    if analysis is None:
+        analysis = AnalysisResult(project_id=project.id)
+        session.add(analysis)
+
+    artifact_metadata = analysis_artifact.metadata_json or {}
+    analysis.source_artifact_id = source_artifact_id
+    analysis.estimated_key = _analysis_optional_str(payload, "estimated_key")
+    analysis.key_confidence = _analysis_optional_float(payload, "key_confidence")
+    analysis.estimated_reference_hz = _analysis_optional_float(payload, "estimated_reference_hz")
+    analysis.tuning_offset_cents = _analysis_optional_float(payload, "tuning_offset_cents")
+    analysis.tempo_bpm = _analysis_optional_float(payload, "tempo_bpm")
+    analysis.timing_json = _analysis_optional_mapping(payload, "timing")
+    analysis.analysis_version = (
+        _analysis_optional_str(payload, "analysis_version")
+        or _analysis_optional_str(artifact_metadata, "analysis_version")
+        or "v3"
+    )
+    session.flush()
+
+
+def hydrate_project_analysis_result_from_artifact(session: Session, project_id: str) -> None:
+    project = session.get(Project, project_id)
+    if project is None:
+        return
+    _hydrate_analysis_result_from_artifact(session, project)
 
 
 def _verify_staged_artifacts(
@@ -1490,8 +1540,8 @@ def _coerce_artifact_manifest(manifest: Mapping[str, Any] | object) -> SyncArtif
 
 
 def _coerce_entity_revision_manifest(manifest: Mapping[str, Any] | object) -> SyncEntityRevisionManifest:
-    content_sha256 = _required_str(manifest, "content_sha256").strip().lower()
-    if not _is_sha256(content_sha256):
+    declared_content_sha256 = _required_str(manifest, "content_sha256").strip().lower()
+    if not _is_sha256(declared_content_sha256):
         raise _invalid_manifest("Entity revision manifest content_sha256 must be a full SHA-256 hex digest.")
 
     metadata = _field(manifest, "metadata", default={})
@@ -1506,8 +1556,7 @@ def _coerce_entity_revision_manifest(manifest: Mapping[str, Any] | object) -> Sy
         raise _invalid_manifest(
             "Entity revision manifest metadata and payload must be sync-safe."
         )
-    if content_sha256 != revision_payload_sha256(safe_payload):
-        raise _invalid_manifest("Entity revision manifest content_sha256 must match payload.")
+    content_sha256 = revision_payload_sha256(safe_payload)
 
     return SyncEntityRevisionManifest(
         revision_id=_required_str(manifest, "revision_id"),
@@ -1614,6 +1663,43 @@ def _payload_datetime(payload: Mapping[str, Any], name: str) -> datetime | None:
         except ValueError as exc:
             raise _invalid_manifest(f"Entity revision payload field must be an ISO datetime: {name}.") from exc
     raise _invalid_manifest(f"Entity revision payload field must be a datetime or null: {name}.")
+
+
+def _read_analysis_artifact_payload(artifact: Artifact) -> Mapping[str, Any]:
+    try:
+        payload = json.loads(Path(artifact.path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise _invalid_manifest("Analysis artifact payload must be readable JSON.") from exc
+    if not isinstance(payload, Mapping):
+        raise _invalid_manifest("Analysis artifact payload must be an object.")
+    return payload
+
+
+def _analysis_optional_str(payload: Mapping[str, Any], name: str) -> str | None:
+    value = payload.get(name)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise _invalid_manifest(f"Analysis artifact field must be a string or null: {name}.")
+    return value
+
+
+def _analysis_optional_float(payload: Mapping[str, Any], name: str) -> float | None:
+    value = payload.get(name)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise _invalid_manifest(f"Analysis artifact field must be numeric or null: {name}.")
+    return float(value)
+
+
+def _analysis_optional_mapping(payload: Mapping[str, Any], name: str) -> dict[str, Any] | None:
+    value = payload.get(name)
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise _invalid_manifest(f"Analysis artifact field must be an object or null: {name}.")
+    return cast(dict[str, Any], deepcopy(value))
 
 
 def _payload_first(payload: Mapping[str, Any], names: tuple[str, ...], *, default: Any) -> Any:

--- a/apps/backend/app/services/sync_reconciliation.py
+++ b/apps/backend/app/services/sync_reconciliation.py
@@ -274,8 +274,8 @@ def plan_sync_reconciliation(
         planned_project_ids = _planned_project_ids(actions)
         if (
             artifact.project_id in remote.project_manifests_by_id
-            and not _has_imported_local_project(local, artifact.project_id)
             and artifact.artifact_id in remote.manifest_artifact_ids_by_project.get(artifact.project_id, frozenset())
+            and not _is_deleted(ITEM_ARTIFACT, artifact.artifact_id, artifact.project_id, effective_tombstones)
         ):
             continue
         _plan_artifact(
@@ -294,8 +294,13 @@ def plan_sync_reconciliation(
     for revision in _sorted_remote_entity_revisions(remote.entity_revisions.values()):
         if (
             revision.project_id in remote.project_manifests_by_id
-            and not _has_imported_local_project(local, revision.project_id)
             and revision.revision_id in remote.manifest_revision_ids_by_project.get(revision.project_id, frozenset())
+            and not _is_deleted(
+                ITEM_ENTITY_REVISION,
+                revision.revision_id,
+                revision.project_id,
+                effective_tombstones,
+            )
         ):
             continue
         if _plan_entity_revision(
@@ -1312,7 +1317,8 @@ def _plan_entity_revision(
 
     local_revision = local.entity_revisions.get(revision.revision_id)
     if local_revision is not None:
-        if _normalize_sha256(local_revision.content_sha256) == revision.content_sha256:
+        local_content_sha256 = _local_revision_content_sha256(local_revision)
+        if local_content_sha256 == revision.content_sha256:
             _upsert_item(
                 items_by_key,
                 SyncReconciliationItem(
@@ -1336,7 +1342,8 @@ def _plan_entity_revision(
             content_sha256=revision.content_sha256,
             reason="Local and remote entity revisions share an ID but have different content hashes.",
             details={
-                "local_content_sha256": local_revision.content_sha256,
+                "local_content_sha256": local_content_sha256,
+                "stored_local_content_sha256": local_revision.content_sha256,
                 "remote_content_sha256": revision.content_sha256,
             },
         )
@@ -1420,7 +1427,8 @@ def _plan_entity_revision(
             details={
                 "base_revision_id": revision.base_revision_id,
                 "local_revision_id": divergent_revision.id,
-                "local_content_sha256": divergent_revision.content_sha256,
+                "local_content_sha256": _local_revision_content_sha256(divergent_revision),
+                "stored_local_content_sha256": divergent_revision.content_sha256,
                 "remote_content_sha256": revision.content_sha256,
             },
         )
@@ -2214,10 +2222,17 @@ def _divergent_local_revision(
             continue
         if local_revision.base_revision_id != remote_revision.base_revision_id:
             continue
-        if _normalize_sha256(local_revision.content_sha256) == remote_revision.content_sha256:
+        if _local_revision_content_sha256(local_revision) == remote_revision.content_sha256:
             continue
         return local_revision
     return None
+
+
+def _local_revision_content_sha256(revision: SyncEntityRevision) -> str | None:
+    payload = revision.payload_json
+    if isinstance(payload, Mapping):
+        return revision_payload_sha256(sanitize_revision_payload(payload))
+    return _normalize_sha256(revision.content_sha256)
 
 
 def _upsert_item(

--- a/apps/backend/app/services/sync_reconciliation_apply.py
+++ b/apps/backend/app/services/sync_reconciliation_apply.py
@@ -9,7 +9,10 @@ from sqlalchemy.orm import Session
 
 from app.errors import AppError
 from app.models import Project, SyncDeleteTombstone
-from app.services.sync_manifest import import_staged_project_manifest
+from app.services.sync_manifest import (
+    hydrate_project_analysis_result_from_artifact,
+    import_staged_project_manifest,
+)
 from app.services.sync_project_status import update_project_sync_status
 from app.services.sync_reconciliation import (
     ACTION_APPLY_DELETE_TOMBSTONE,
@@ -21,11 +24,12 @@ from app.services.sync_reconciliation import (
     ACTION_RECORD_CONFLICT,
     ACTION_UPSERT_PROJECT_STATUS,
     ITEM_ENTITY_REVISION,
+    ITEM_PROJECT,
     SyncReconciliationAction,
     SyncReconciliationPlan,
     plan_sync_reconciliation,
 )
-from app.services.sync_staging import require_staged_artifact
+from app.services.sync_staging import cleanup_staged_artifacts, require_staged_artifact
 from app.services.sync_tombstones import apply_delete_tombstone
 
 APPLY_STATUS_APPLIED = "applied"
@@ -73,9 +77,16 @@ def apply_sync_reconciliation(
     session: Session,
     request: object | Mapping[str, Any],
 ) -> SyncReconciliationApplyResult:
-    plan = plan_sync_reconciliation(session, request)
     context = _apply_context(request)
+    plan = _with_staged_manifest_import_actions(
+        session,
+        plan_sync_reconciliation(session, request),
+        context,
+    )
     results = [_apply_action_in_savepoint(session, action, context) for action in plan.actions]
+    results.extend(_hydrate_imported_project_analysis(session, context, results))
+    if context.use_content_addressed_staging:
+        _cleanup_imported_content_addressed_staging(session, context)
     return SyncReconciliationApplyResult(
         summary=_summarize_apply_results(plan, results),
         plan=plan,
@@ -96,7 +107,7 @@ def _apply_action_in_savepoint(
             action=action,
             status=APPLY_STATUS_FAILED,
             reason=exc.message,
-            details={"error_code": exc.code, "error_details": exc.details},
+            details=_error_details(action, exc),
         )
 
 
@@ -317,6 +328,117 @@ def _missing_content_addressed_artifacts(
     return missing
 
 
+def _cleanup_imported_content_addressed_staging(
+    session: Session,
+    context: _ApplyContext,
+) -> None:
+    imported_hashes: set[str] = set()
+    pending_hashes: set[str] = set()
+    imported_references: list[dict[str, Any]] = []
+    for project_id, manifest in context.project_manifests_by_id.items():
+        artifact_hashes = _manifest_artifact_hashes(manifest)
+        if _project_is_imported(session, project_id):
+            imported_hashes.update(artifact_hashes)
+            imported_references.extend(_manifest_artifact_references(manifest))
+        else:
+            pending_hashes.update(artifact_hashes)
+
+    cleanup_hashes = imported_hashes - pending_hashes
+    cleanup_references = [
+        reference
+        for reference in imported_references
+        if reference["content_sha256"] in cleanup_hashes
+    ]
+    if cleanup_hashes or cleanup_references:
+        cleanup_staged_artifacts(
+            session,
+            content_sha256s=cleanup_hashes,
+            references=cleanup_references,
+        )
+
+
+def _hydrate_imported_project_analysis(
+    session: Session,
+    context: _ApplyContext,
+    results: list[SyncReconciliationApplyActionResult],
+) -> list[SyncReconciliationApplyActionResult]:
+    repair_results: list[SyncReconciliationApplyActionResult] = []
+    imported_project_ids = {
+        result.action.project_id or result.action.item_id
+        for result in results
+        if result.action.action_type == ACTION_IMPORT_PROJECT_MANIFEST
+        and result.status == APPLY_STATUS_APPLIED
+    }
+    for project_id, manifest in context.project_manifests_by_id.items():
+        if project_id in imported_project_ids:
+            continue
+        if not _project_is_imported(session, project_id) or not _manifest_has_analysis_artifact(manifest):
+            continue
+        action = SyncReconciliationAction(
+            action_type=ACTION_NOOP,
+            item_type=ITEM_PROJECT,
+            item_id=project_id,
+            project_id=project_id,
+            content_sha256=_manifest_source_sha256(manifest),
+            reason="Repair imported project analysis from a synced analysis artifact.",
+            priority=30,
+            details={"source": "analysis_json", "repair": "analysis_result"},
+        )
+        try:
+            with session.begin_nested():
+                hydrate_project_analysis_result_from_artifact(session, project_id)
+            repair_results.append(
+                _result(
+                    action,
+                    APPLY_STATUS_SATISFIED,
+                    "Project analysis result is hydrated from the synced analysis artifact.",
+                )
+            )
+        except AppError as exc:
+            repair_results.append(
+                SyncReconciliationApplyActionResult(
+                    action=action,
+                    status=APPLY_STATUS_FAILED,
+                    reason=exc.message,
+                    details=_error_details(action, exc),
+                )
+            )
+    return repair_results
+
+
+def _manifest_has_analysis_artifact(manifest: object) -> bool:
+    return any(
+        _string_field(artifact, "type") == "analysis_json"
+        for artifact in _list_field(manifest, "artifacts")
+    )
+
+
+def _manifest_artifact_hashes(manifest: object) -> set[str]:
+    return {
+        content_sha256
+        for artifact in _list_field(manifest, "artifacts")
+        if (content_sha256 := _string_field(artifact, "content_sha256")) is not None
+    }
+
+
+def _manifest_artifact_references(manifest: object) -> list[dict[str, Any]]:
+    references: list[dict[str, Any]] = []
+    for artifact in _list_field(manifest, "artifacts"):
+        content_sha256 = _string_field(artifact, "content_sha256")
+        project_id = _string_field(artifact, "project_id")
+        artifact_id = _string_field(artifact, "artifact_id", "id")
+        if content_sha256 is None or project_id is None or artifact_id is None:
+            continue
+        references.append(
+            {
+                "content_sha256": content_sha256,
+                "project_id": project_id,
+                "artifact_id": artifact_id,
+            }
+        )
+    return references
+
+
 def _tombstone_for_action(
     session: Session,
     action: SyncReconciliationAction,
@@ -412,6 +534,112 @@ def _apply_context(request: object | Mapping[str, Any]) -> _ApplyContext:
     )
 
 
+def _with_staged_manifest_import_actions(
+    session: Session,
+    plan: SyncReconciliationPlan,
+    context: _ApplyContext,
+) -> SyncReconciliationPlan:
+    staged_import_actions = _staged_manifest_import_actions(session, plan, context)
+    if not staged_import_actions:
+        return plan
+
+    actions = [*plan.actions, *staged_import_actions]
+    summary = type(plan.summary)(
+        status_counts=plan.summary.status_counts,
+        total_items=plan.summary.total_items,
+        total_actions=len(actions),
+        total_conflicts=plan.summary.total_conflicts,
+    )
+    return SyncReconciliationPlan(summary=summary, items=plan.items, actions=actions)
+
+
+def _staged_manifest_import_actions(
+    session: Session,
+    plan: SyncReconciliationPlan,
+    context: _ApplyContext,
+) -> list[SyncReconciliationAction]:
+    planned_import_project_ids = {
+        action.project_id or action.item_id
+        for action in plan.actions
+        if action.action_type == ACTION_IMPORT_PROJECT_MANIFEST and action.item_type == ITEM_PROJECT
+    }
+    priority = _project_manifest_import_priority(plan)
+    actions: list[SyncReconciliationAction] = []
+    for project_id in sorted(context.project_manifests_by_id):
+        if project_id in planned_import_project_ids:
+            continue
+        if _project_has_blocking_apply_action(plan, project_id):
+            continue
+        if _project_is_imported(session, project_id):
+            continue
+        manifest = context.project_manifests_by_id[project_id]
+        actions.append(
+            SyncReconciliationAction(
+                action_type=ACTION_IMPORT_PROJECT_MANIFEST,
+                item_type=ITEM_PROJECT,
+                item_id=project_id,
+                project_id=project_id,
+                content_sha256=_manifest_source_sha256(manifest),
+                provider_device_id=None,
+                reason="Import project manifest using artifact content that is already staged locally.",
+                priority=priority,
+                details={
+                    "source": "sync_staged_artifacts",
+                    "staged_content_required": True,
+                },
+            )
+        )
+    return actions
+
+
+def _project_has_blocking_apply_action(plan: SyncReconciliationPlan, project_id: str) -> bool:
+    for action in plan.actions:
+        if action.project_id != project_id and action.item_id != project_id:
+            continue
+        if action.action_type == ACTION_RECORD_CONFLICT:
+            return True
+        if action.action_type == ACTION_APPLY_DELETE_TOMBSTONE and action.item_type == ITEM_PROJECT:
+            return True
+        if (
+            action.action_type == ACTION_UPSERT_PROJECT_STATUS
+            and _string_from_mapping(action.details, "project_status") in {"conflicted", "deleted"}
+        ):
+            return True
+    return False
+
+
+def _project_is_imported(session: Session, project_id: str) -> bool:
+    project = session.get(Project, project_id)
+    if project is None:
+        return False
+    source_path = (project.source_path or "").strip()
+    imported_path = (project.imported_path or "").strip()
+    return bool(
+        source_path
+        and imported_path
+        and not source_path.startswith("sync-placeholder:")
+        and not imported_path.startswith("sync-placeholder:")
+    )
+
+
+def _project_manifest_import_priority(plan: SyncReconciliationPlan) -> int:
+    for action in plan.actions:
+        if action.action_type == ACTION_IMPORT_PROJECT_MANIFEST:
+            return action.priority
+    return 30
+
+
+def _manifest_source_sha256(manifest: object) -> str | None:
+    project = _field(manifest, "project", default=manifest)
+    project_source_sha256 = _string_field(project, "source_sha256")
+    if project_source_sha256 is not None:
+        return project_source_sha256
+    for artifact in _list_field(manifest, "artifacts"):
+        if _string_field(artifact, "type") == "source_audio":
+            return _string_field(artifact, "content_sha256")
+    return None
+
+
 def _project_id_from_manifest(manifest: object) -> str | None:
     project = _field(manifest, "project", default=manifest)
     return _string_field(project, "project_id", "id")
@@ -442,6 +670,17 @@ def _result(
         reason=reason,
         details=details or {},
     )
+
+
+def _error_details(action: SyncReconciliationAction, exc: AppError) -> dict[str, Any]:
+    return {
+        "action_type": action.action_type,
+        "item_type": action.item_type,
+        "item_id": action.item_id,
+        "project_id": action.project_id,
+        "error_code": exc.code,
+        "error_details": exc.details,
+    }
 
 
 def _field(source: object, name: str, *, default: object = _MISSING) -> Any:

--- a/apps/backend/app/services/sync_staging.py
+++ b/apps/backend/app/services/sync_staging.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import shutil
 import tempfile
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path, PurePosixPath
@@ -17,6 +18,7 @@ from app.models import SyncStagedArtifact, utcnow
 from app.utils.hashing import file_sha256
 
 HEX_DIGITS = frozenset("0123456789abcdef")
+STAGING_REFERENCES_METADATA_KEY = "_sync_staging_references"
 
 
 @dataclass(frozen=True)
@@ -51,28 +53,47 @@ def stage_sync_artifact(
     if not _staged_path_matches(destination_path, content_sha256=normalized_sha256, size_bytes=size_bytes):
         _copy_verified_source(source, destination_path)
 
+    public_metadata = dict(metadata) if metadata is not None else None
+    next_reference = _reference_from_metadata(public_metadata, provider_device_id)
     now = utcnow()
     record = session.get(SyncStagedArtifact, normalized_sha256)
     if record is None:
+        metadata_json: dict[str, Any] = public_metadata or {}
+        if next_reference is not None:
+            metadata_json[STAGING_REFERENCES_METADATA_KEY] = [next_reference]
         record = SyncStagedArtifact(
             content_sha256=normalized_sha256,
             size_bytes=size_bytes,
             relative_path=relative_path,
             provider_device_id=provider_device_id,
-            metadata_json=dict(metadata) if metadata is not None else {},
+            metadata_json=metadata_json,
             verified_at=now,
             created_at=now,
             updated_at=now,
         )
         session.add(record)
     else:
+        existing_metadata = record.metadata_json if isinstance(record.metadata_json, dict) else {}
+        references = _staging_references(existing_metadata)
+        if next_reference is not None:
+            references = _merge_staging_references(references, next_reference)
         record.size_bytes = size_bytes
         record.relative_path = relative_path
         record.provider_device_id = provider_device_id
         if metadata is not None:
-            record.metadata_json = dict(metadata)
+            metadata_json = public_metadata or {}
+            if references:
+                metadata_json[STAGING_REFERENCES_METADATA_KEY] = references
+            record.metadata_json = metadata_json
         elif record.metadata_json is None:
-            record.metadata_json = {}
+            metadata_json = {}
+            if references:
+                metadata_json[STAGING_REFERENCES_METADATA_KEY] = references
+            record.metadata_json = metadata_json
+        elif next_reference is not None:
+            metadata_json = dict(existing_metadata)
+            metadata_json[STAGING_REFERENCES_METADATA_KEY] = references
+            record.metadata_json = metadata_json
         record.verified_at = now
         record.updated_at = now
 
@@ -82,6 +103,67 @@ def stage_sync_artifact(
 
 def get_staged_artifact_path(session: Session, *, content_sha256: str) -> Path:
     return require_staged_artifact(session, content_sha256=content_sha256).resolved_path
+
+
+def cleanup_staged_artifacts(
+    session: Session,
+    *,
+    content_sha256s: Iterable[str] = (),
+    references: Iterable[Mapping[str, Any]] = (),
+) -> int:
+    removed = 0
+    staging_root = _staging_root().resolve(strict=False)
+    normalized_hashes: set[str] = set()
+    for content_sha256 in content_sha256s:
+        try:
+            normalized_hashes.add(_normalize_content_sha256(content_sha256))
+        except AppError:
+            continue
+    references_by_hash: dict[str, list[dict[str, str]]] = {}
+    for reference in references:
+        raw_content_sha256 = reference.get("content_sha256")
+        if not isinstance(raw_content_sha256, str):
+            continue
+        try:
+            normalized_sha256 = _normalize_content_sha256(raw_content_sha256)
+        except AppError:
+            continue
+        cleanup_reference = _cleanup_reference_from_mapping(reference)
+        if cleanup_reference is not None:
+            references_by_hash.setdefault(normalized_sha256, []).append(cleanup_reference)
+        normalized_hashes.add(normalized_sha256)
+
+    for content_sha256 in sorted(normalized_hashes):
+        record = session.get(SyncStagedArtifact, content_sha256)
+        if record is None:
+            continue
+        metadata = record.metadata_json if isinstance(record.metadata_json, dict) else {}
+        remaining_references = _remove_staging_references(
+            _staging_references(metadata),
+            references_by_hash.get(content_sha256, []),
+        )
+        if remaining_references:
+            metadata_json = dict(metadata)
+            metadata_json[STAGING_REFERENCES_METADATA_KEY] = remaining_references
+            record.metadata_json = metadata_json
+            record.updated_at = utcnow()
+            continue
+        if STAGING_REFERENCES_METADATA_KEY in metadata and content_sha256 not in references_by_hash:
+            continue
+        try:
+            resolved_path = _resolve_staged_relative_path(record.relative_path)
+        except AppError:
+            continue
+        try:
+            resolved_path.unlink(missing_ok=True)
+        except OSError:
+            continue
+        session.delete(record)
+        removed += 1
+        _remove_empty_staging_dirs(resolved_path.parent, staging_root)
+
+    session.flush()
+    return removed
 
 
 def require_staged_artifact(
@@ -282,6 +364,100 @@ def _file_size(path: Path) -> int | None:
         return None
 
 
+def _reference_from_metadata(
+    metadata: Mapping[str, Any] | None,
+    provider_device_id: str | None,
+) -> dict[str, str] | None:
+    if metadata is None:
+        return None
+    project_id = metadata.get("project_id")
+    artifact_id = metadata.get("artifact_id")
+    if not isinstance(project_id, str) or not project_id:
+        return None
+    if not isinstance(artifact_id, str) or not artifact_id:
+        return None
+    reference = {"project_id": project_id, "artifact_id": artifact_id}
+    if isinstance(provider_device_id, str) and provider_device_id:
+        reference["provider_device_id"] = provider_device_id
+    return reference
+
+
+def _cleanup_reference_from_mapping(reference: Mapping[str, Any]) -> dict[str, str] | None:
+    project_id = reference.get("project_id")
+    artifact_id = reference.get("artifact_id")
+    if not isinstance(project_id, str) or not project_id:
+        return None
+    if not isinstance(artifact_id, str) or not artifact_id:
+        return None
+    cleanup_reference = {"project_id": project_id, "artifact_id": artifact_id}
+    provider_device_id = reference.get("provider_device_id")
+    if isinstance(provider_device_id, str) and provider_device_id:
+        cleanup_reference["provider_device_id"] = provider_device_id
+    return cleanup_reference
+
+
+def _staging_references(metadata: Mapping[str, Any]) -> list[dict[str, str]]:
+    raw_references = metadata.get(STAGING_REFERENCES_METADATA_KEY)
+    if not isinstance(raw_references, list):
+        return []
+    references: list[dict[str, str]] = []
+    for raw_reference in raw_references:
+        if isinstance(raw_reference, Mapping):
+            reference = _cleanup_reference_from_mapping(raw_reference)
+            if reference is not None:
+                references.append(reference)
+    return references
+
+
+def _merge_staging_references(
+    references: list[dict[str, str]],
+    next_reference: dict[str, str],
+) -> list[dict[str, str]]:
+    if any(_same_reference(reference, next_reference) for reference in references):
+        return references
+    return [*references, next_reference]
+
+
+def _remove_staging_references(
+    references: list[dict[str, str]],
+    cleanup_references: list[dict[str, str]],
+) -> list[dict[str, str]]:
+    if not cleanup_references:
+        return references
+    return [
+        reference
+        for reference in references
+        if not any(_same_reference(reference, cleanup_reference) for cleanup_reference in cleanup_references)
+    ]
+
+
+def _same_reference(left: Mapping[str, str], right: Mapping[str, str]) -> bool:
+    return (
+        left.get("project_id") == right.get("project_id")
+        and left.get("artifact_id") == right.get("artifact_id")
+        and (
+            "provider_device_id" not in left
+            or "provider_device_id" not in right
+            or left.get("provider_device_id") == right.get("provider_device_id")
+        )
+    )
+
+
+def _remove_empty_staging_dirs(path: Path, staging_root: Path) -> None:
+    current = path.resolve(strict=False)
+    while current != staging_root:
+        try:
+            current.relative_to(staging_root)
+        except ValueError:
+            return
+        with suppress(OSError):
+            current.rmdir()
+        parent = current.parent
+        if parent == current:
+            return
+        current = parent
+
+
 def _raise_source_unreadable(source_path: Path) -> None:
     try:
         exists = source_path.exists()
@@ -303,12 +479,14 @@ def _raise_source_unreadable(source_path: Path) -> None:
 
 def _to_dto(record: SyncStagedArtifact, resolved_path: Path) -> SyncStagedArtifactDTO:
     metadata = record.metadata_json if isinstance(record.metadata_json, dict) else {}
+    public_metadata = dict(metadata)
+    public_metadata.pop(STAGING_REFERENCES_METADATA_KEY, None)
     return SyncStagedArtifactDTO(
         content_sha256=record.content_sha256,
         size_bytes=record.size_bytes,
         relative_path=record.relative_path,
         provider_device_id=record.provider_device_id,
-        metadata=dict(metadata),
+        metadata=public_metadata,
         verified_at=record.verified_at,
         created_at=record.created_at,
         updated_at=record.updated_at,

--- a/apps/backend/tests/test_sync_reconciliation.py
+++ b/apps/backend/tests/test_sync_reconciliation.py
@@ -39,7 +39,7 @@ from app.services.sync_reconciliation import (
     SyncReconciliationPlan,
     plan_sync_reconciliation,
 )
-from app.services.sync_revisions import revision_payload_sha256
+from app.services.sync_revisions import revision_payload_sha256, sanitize_revision_payload
 
 
 @pytest.fixture()
@@ -323,6 +323,96 @@ def test_entity_revision_ancestry_imports_descendants_and_conflicts_siblings(
         "rev_a_remote_grandchild"
     )
     assert _action(plan, ACTION_RECORD_CONFLICT, ITEM_ENTITY_REVISION, "rev_remote_sibling") is not None
+
+
+def test_existing_project_manifest_scoped_revision_does_not_create_standalone_conflict(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash, source_size = _write_file(tmp_path / "legacy-hash-source.wav", b"source")
+    project_id = source_hash_to_project_id(source_hash)
+    _add_project(db_session, project_id, source_sha256=source_hash)
+    _add_artifact(
+        db_session,
+        artifact_id=f"art_source_{project_id}",
+        project_id=project_id,
+        path=tmp_path / "legacy-hash-source.wav",
+        content_sha256=source_hash,
+        size_bytes=source_size,
+        artifact_type="source_audio",
+    )
+    dirty_payload = {
+        "revision_id": "rev_legacy_hash",
+        "timeline": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "C"}],
+        "source_path": str(tmp_path / "local-only.wav"),
+    }
+    safe_payload = sanitize_revision_payload(dirty_payload)
+    legacy_hash = revision_payload_sha256(dirty_payload)
+    canonical_hash = revision_payload_sha256(safe_payload)
+    now = datetime.now(UTC)
+    db_session.add(
+        SyncEntityRevision(
+            id="rev_legacy_hash",
+            project_id=project_id,
+            entity_type="chords",
+            entity_id=project_id,
+            revision_type="manual",
+            base_revision_id=None,
+            source_artifact_id=f"art_source_{project_id}",
+            content_sha256=legacy_hash,
+            author_device_id="dev-local",
+            state="current",
+            metadata_json={},
+            payload_json=dirty_payload,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    db_session.commit()
+
+    manifest = _project_manifest(
+        project_id,
+        source_hash,
+        source_size_bytes=source_size,
+        extra_revisions=[
+            {
+                "revision_id": "rev_legacy_hash",
+                "project_id": project_id,
+                "entity_type": "chords",
+                "entity_id": project_id,
+                "revision_type": "manual",
+                "base_revision_id": None,
+                "author_device_id": "peer-a",
+                "source_artifact_id": f"art_source_{project_id}",
+                "content_sha256": canonical_hash,
+                "state": "current",
+                "metadata": {},
+                "payload": safe_payload,
+                "created_at": now,
+                "updated_at": now,
+            }
+        ],
+    )
+
+    plan = plan_sync_reconciliation(
+        db_session,
+        {
+            "remote_library": {},
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {"device_id": "peer-a", "available_content_hashes": [source_hash]}
+            ],
+        },
+    )
+
+    assert all(
+        item.item_id != "rev_legacy_hash"
+        for item in plan.items
+        if item.item_type == ITEM_ENTITY_REVISION
+    )
+    assert plan.summary.total_conflicts == 0
+    assert _action(plan, ACTION_RECORD_CONFLICT, ITEM_ENTITY_REVISION, "rev_legacy_hash") is None
 
 
 @pytest.mark.parametrize(
@@ -983,7 +1073,6 @@ def test_missing_project_manifest_rejects_invalid_embedded_entity_revisions(
 @pytest.mark.parametrize(
     ("case", "expected_reason"),
     [
-        ("payload_hash_mismatch", "Entity revision manifest content_sha256 must match payload."),
         ("unsafe_metadata", "Entity revision manifest metadata and payload must be sync-safe."),
         ("unsafe_payload", "Entity revision manifest metadata and payload must be sync-safe."),
     ],

--- a/apps/backend/tests/test_sync_reconciliation_apply_api.py
+++ b/apps/backend/tests/test_sync_reconciliation_apply_api.py
@@ -9,10 +9,12 @@ from fastapi.testclient import TestClient
 
 from app.db import SessionLocal
 from app.models import Artifact, Project, SyncDeleteTombstone, SyncEntityRevision, SyncTrustedPeer
+from app.services.paths import project_root
 from app.services.sync_identity import source_hash_to_project_id
 from app.services.sync_revisions import revision_payload_sha256
 from app.services.sync_staging import stage_sync_artifact
 from app.services.sync_trust import get_or_create_local_identity
+from app.utils.hashing import file_sha256
 
 
 def test_reconciliation_apply_imports_staged_project_manifest(
@@ -62,6 +64,171 @@ def test_reconciliation_apply_imports_staged_project_manifest(
         assert imported_revision is not None
         assert imported_revision.author_device_id == "peer-apply-a"
         assert session.get(SyncTrustedPeer, "peer-apply-a").sync_group_id == identity.sync_group_id
+
+
+def test_reconciliation_apply_imports_batched_staged_project_manifests(
+    client: TestClient,
+    sample_audio_file: Path,
+    sample_rhythmic_audio_file: Path,
+) -> None:
+    peer_device_id = "peer-apply-batch"
+    _ensure_identity_and_peer(peer_device_id)
+    fixtures = [
+        ("a", sample_audio_file, sample_rhythmic_audio_file),
+        ("b", sample_rhythmic_audio_file, sample_audio_file),
+    ]
+    manifests: list[dict[str, Any]] = []
+    remote_projects: list[dict[str, Any]] = []
+    available_hashes: set[str] = set()
+    expected_artifacts: dict[str, dict[str, tuple[str, str]]] = {}
+
+    for suffix, source_path, stem_path in fixtures:
+        source_sha256 = hashlib.sha256(source_path.read_bytes()).hexdigest()
+        stem_sha256 = hashlib.sha256(stem_path.read_bytes()).hexdigest()
+        project_id = source_hash_to_project_id(source_sha256)
+        stem_artifact_id = f"art_stem_{project_id}"
+        stem_relative_path = f"stems/{suffix}.wav"
+        manifests.append(
+            _project_manifest(
+                project_id,
+                source_sha256,
+                source_path.stat().st_size,
+                display_name=f"Batched Project {suffix.upper()}",
+                peer_device_id=peer_device_id,
+                revision_id=f"rev_apply_batch_{suffix}",
+                extra_artifacts=[
+                    _artifact_manifest(
+                        artifact_id=stem_artifact_id,
+                        project_id=project_id,
+                        artifact_type="stem",
+                        relative_path=stem_relative_path,
+                        content_sha256=stem_sha256,
+                        size_bytes=stem_path.stat().st_size,
+                    )
+                ],
+            )
+        )
+        remote_projects.append(
+            _remote_project(
+                project_id,
+                source_sha256,
+                display_name=f"Batched Project {suffix.upper()}",
+            )
+        )
+        _stage_artifact(source_path, content_sha256=source_sha256, provider_device_id=peer_device_id)
+        _stage_artifact(stem_path, content_sha256=stem_sha256, provider_device_id=peer_device_id)
+        available_hashes.update({source_sha256, stem_sha256})
+        expected_artifacts[project_id] = {
+            f"art_source_{project_id}": ("source/input.wav", source_sha256),
+            stem_artifact_id: (stem_relative_path, stem_sha256),
+        }
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": {
+                "projects": remote_projects,
+                "artifacts": [],
+                "entity_revisions": [],
+                "delete_tombstones": [],
+            },
+            "project_manifests": manifests,
+            "peer_inventory": [
+                {
+                    "device_id": peer_device_id,
+                    "available_content_sha256": sorted(available_hashes),
+                    "metadata": {"display_name": "Peer Apply Batch"},
+                }
+            ],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 0
+    assert payload["summary"]["skipped_actions"] == 0
+    imported_project_ids = {
+        result["action"]["project_id"]
+        for result in payload["results"]
+        if result["action"]["action_type"] == "import_project_manifest"
+        and result["status"] == "applied"
+    }
+    assert imported_project_ids == set(expected_artifacts)
+
+    with SessionLocal() as session:
+        for project_id, artifact_expectations in expected_artifacts.items():
+            project = session.get(Project, project_id)
+            assert project is not None
+            assert project.sync_status == "local"
+            assert project.sync_status_reason is None
+
+            root = project_root(project_id)
+            source_path = root / "source/input.wav"
+            assert Path(project.source_path) == source_path
+            assert Path(project.imported_path) == source_path
+            assert source_path.exists()
+
+            for artifact_id, (relative_path, content_sha256) in artifact_expectations.items():
+                artifact = session.get(Artifact, artifact_id)
+                assert artifact is not None
+                expected_path = root / relative_path
+                assert Path(artifact.path) == expected_path
+                assert expected_path.exists()
+                assert artifact.content_sha256 == content_sha256
+                assert file_sha256(expected_path) == content_sha256
+
+
+def test_reconciliation_apply_imports_manifest_when_bytes_are_already_staged(
+    client: TestClient,
+    sample_audio_file: Path,
+) -> None:
+    peer_device_id = "peer-apply-staged"
+    _ensure_identity_and_peer(peer_device_id)
+    content_sha256 = hashlib.sha256(sample_audio_file.read_bytes()).hexdigest()
+    project_id = source_hash_to_project_id(content_sha256)
+    manifest = _project_manifest(
+        project_id,
+        content_sha256,
+        sample_audio_file.stat().st_size,
+        peer_device_id=peer_device_id,
+        revision_id="rev_apply_already_staged",
+    )
+    _stage_source_audio(sample_audio_file, content_sha256=content_sha256, provider_device_id=peer_device_id)
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": {
+                "projects": [_remote_project(project_id, content_sha256)],
+                "artifacts": [],
+                "entity_revisions": [],
+                "delete_tombstones": [],
+            },
+            "project_manifests": [manifest],
+            "peer_inventory": [],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 0
+    assert payload["summary"]["skipped_actions"] == 0
+    assert any(
+        result["action"]["action_type"] == "import_project_manifest"
+        and result["action"]["project_id"] == project_id
+        and result["status"] == "applied"
+        for result in payload["results"]
+    )
+
+    with SessionLocal() as session:
+        project = session.get(Project, project_id)
+        assert project is not None
+        assert project.sync_status == "local"
+        artifact = session.get(Artifact, f"art_source_{project_id}")
+        assert artifact is not None
+        assert Path(artifact.path).exists()
 
 
 def test_reconciliation_apply_applies_trusted_delete_tombstone(
@@ -147,6 +314,15 @@ def _stage_source_audio(
     content_sha256: str,
     provider_device_id: str,
 ) -> None:
+    _stage_artifact(source_path, content_sha256=content_sha256, provider_device_id=provider_device_id)
+
+
+def _stage_artifact(
+    source_path: Path,
+    *,
+    content_sha256: str,
+    provider_device_id: str,
+) -> None:
     with SessionLocal() as session:
         stage_sync_artifact(
             session,
@@ -188,11 +364,16 @@ def _add_project_artifact(project_id: str, artifact_path: Path, content_sha256: 
         session.commit()
 
 
-def _remote_project(project_id: str, source_sha256: str) -> dict[str, Any]:
+def _remote_project(
+    project_id: str,
+    source_sha256: str,
+    *,
+    display_name: str = "Applied Remote Project",
+) -> dict[str, Any]:
     now = datetime.now(UTC).isoformat()
     return {
         "project_id": project_id,
-        "display_name": "Applied Remote Project",
+        "display_name": display_name,
         "source_key_override": None,
         "source_sha256": source_sha256,
         "duration_seconds": None,
@@ -203,39 +384,41 @@ def _remote_project(project_id: str, source_sha256: str) -> dict[str, Any]:
     }
 
 
-def _project_manifest(project_id: str, source_sha256: str, size_bytes: int) -> dict[str, Any]:
+def _project_manifest(
+    project_id: str,
+    source_sha256: str,
+    size_bytes: int,
+    *,
+    display_name: str = "Applied Remote Project",
+    peer_device_id: str = "peer-apply-a",
+    revision_id: str = "rev_apply_chords",
+    extra_artifacts: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     now = datetime.now(UTC).isoformat()
     revision_payload = {"timeline": []}
+    source_artifact = _artifact_manifest(
+        artifact_id=f"art_source_{project_id}",
+        project_id=project_id,
+        artifact_type="source_audio",
+        relative_path="source/input.wav",
+        content_sha256=source_sha256,
+        size_bytes=size_bytes,
+        created_at=now,
+    )
     return {
         "schema_version": "1",
         "exported_at": now,
-        "project": _remote_project(project_id, source_sha256),
-        "artifacts": [
-            {
-                "artifact_id": f"art_source_{project_id}",
-                "project_id": project_id,
-                "type": "source_audio",
-                "format": "wav",
-                "relative_path": "source/input.wav",
-                "content_sha256": source_sha256,
-                "size_bytes": size_bytes,
-                "generated_by": "sync",
-                "can_delete": False,
-                "can_regenerate": False,
-                "cache_key": None,
-                "metadata": {},
-                "created_at": now,
-            }
-        ],
+        "project": _remote_project(project_id, source_sha256, display_name=display_name),
+        "artifacts": [source_artifact, *(extra_artifacts or [])],
         "entity_revisions": [
             {
-                "revision_id": "rev_apply_chords",
+                "revision_id": revision_id,
                 "project_id": project_id,
                 "entity_type": "chords",
                 "entity_id": project_id,
                 "revision_type": "manual",
                 "base_revision_id": None,
-                "author_device_id": "peer-apply-a",
+                "author_device_id": peer_device_id,
                 "source_artifact_id": None,
                 "content_sha256": revision_payload_sha256(revision_payload),
                 "state": "current",
@@ -246,4 +429,31 @@ def _project_manifest(project_id: str, source_sha256: str, size_bytes: int) -> d
             }
         ],
         "delete_tombstones": [],
+    }
+
+
+def _artifact_manifest(
+    *,
+    artifact_id: str,
+    project_id: str,
+    artifact_type: str,
+    relative_path: str,
+    content_sha256: str,
+    size_bytes: int,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "artifact_id": artifact_id,
+        "project_id": project_id,
+        "type": artifact_type,
+        "format": "wav",
+        "relative_path": relative_path,
+        "content_sha256": content_sha256,
+        "size_bytes": size_bytes,
+        "generated_by": "sync",
+        "can_delete": artifact_type != "source_audio",
+        "can_regenerate": artifact_type != "source_audio",
+        "cache_key": None,
+        "metadata": {},
+        "created_at": created_at or datetime.now(UTC).isoformat(),
     }

--- a/apps/backend/tests/test_sync_reconciliation_apply_batch_import.py
+++ b/apps/backend/tests/test_sync_reconciliation_apply_batch_import.py
@@ -1,0 +1,1128 @@
+from __future__ import annotations
+
+import io
+import json
+import shutil
+import wave
+from dataclasses import asdict, dataclass, is_dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from fastapi.testclient import TestClient
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.config import get_settings
+from app.db import SessionLocal
+from app.models import (
+    AnalysisResult,
+    Artifact,
+    ChordTimeline,
+    Project,
+    SyncDeleteTombstone,
+    SyncEntityRevision,
+    SyncStagedArtifact,
+    SyncTrustedPeer,
+)
+from app.services.paths import project_root
+from app.services.sync_identity import source_hash_to_project_id
+from app.services.sync_manifest import export_project_manifest, import_staged_project_manifest
+from app.services.sync_revisions import CURRENT_REVISION_STATE, revision_payload_sha256, sanitize_revision_payload
+from app.services.sync_staging import stage_sync_artifact
+from app.services.sync_trust import get_or_create_local_identity
+from app.utils.hashing import file_sha256
+
+
+@dataclass(frozen=True)
+class Issue119ProjectFixture:
+    project_id: str
+    root: Path
+    source_relative_path: str
+    stem_relative_path: str
+    source_artifact_id: str
+    stem_artifact_id: str
+    artifact_hashes: dict[str, str]
+    artifact_sizes: dict[str, int]
+    artifact_bytes: dict[str, bytes]
+
+
+def test_issue119_apply_imports_fresh_multi_project_receiver(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _ensure_identity_and_peers("peer-issue119-a")
+
+    with SessionLocal() as session:
+        fixtures = [
+            _create_project_with_artifacts(session, tmp_path, slug="alpha", source_frames=64),
+            _create_project_with_artifacts(session, tmp_path, slug="beta", source_frames=96),
+        ]
+        manifests = [
+            _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+            for fixture in fixtures
+        ]
+        all_hashes = _manifest_content_hashes(manifests)
+        for manifest, fixture in zip(manifests, fixtures, strict=True):
+            _stage_manifest_content(
+                session,
+                manifest,
+                tmp_path=tmp_path,
+                artifact_bytes=fixture.artifact_bytes,
+                provider_device_id="peer-issue119-a",
+            )
+            _delete_live_project(session, fixture)
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": manifests,
+            "peer_inventory": [
+                {
+                    "device_id": "peer-issue119-a",
+                    "available_content_sha256": all_hashes,
+                }
+            ],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    summary = payload["summary"]
+    assert summary["failed_actions"] == 0
+    assert summary["skipped_actions"] == 0
+    assert summary["applied_actions"] >= len(fixtures)
+    assert summary["satisfied_actions"] >= len(all_hashes)
+
+    with SessionLocal() as session:
+        assert session.scalar(select(func.count()).select_from(SyncStagedArtifact)) == 0
+        staging_root = get_settings().data_root / "sync" / "staging"
+        for content_hash in all_hashes:
+            assert not (staging_root / "sha256" / content_hash[:2] / content_hash).exists()
+
+        for fixture in fixtures:
+            project = session.get(Project, fixture.project_id)
+            assert project is not None
+            assert project.sync_status == "local"
+            assert project.sync_status_reason is None
+            assert project.sync_required_artifact_ids == []
+            assert project.sync_provider_device_ids == []
+            assert project.sync_conflict_count == 0
+
+            imported_artifacts = {
+                artifact.id: artifact
+                for artifact in session.scalars(
+                    select(Artifact).where(Artifact.project_id == fixture.project_id)
+                )
+            }
+            assert set(imported_artifacts) == {
+                fixture.source_artifact_id,
+                fixture.stem_artifact_id,
+            }
+            expected_paths = {
+                fixture.source_artifact_id: fixture.source_relative_path,
+                fixture.stem_artifact_id: fixture.stem_relative_path,
+            }
+            for artifact_id, relative_path in expected_paths.items():
+                artifact = imported_artifacts[artifact_id]
+                copied_path = project_root(fixture.project_id) / relative_path
+                assert Path(artifact.path) == copied_path
+                assert copied_path.exists()
+                assert file_sha256(copied_path) == fixture.artifact_hashes[artifact_id]
+                assert artifact.content_sha256 == fixture.artifact_hashes[artifact_id]
+                assert artifact.size_bytes == fixture.artifact_sizes[artifact_id]
+
+
+def test_issue119_apply_hydrates_analysis_from_synced_analysis_artifact(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _ensure_identity_and_peers("peer-issue119-analysis")
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path, slug="analysis", source_frames=72)
+        _add_analysis_artifact(session, fixture)
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        _stage_manifest_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=fixture.artifact_bytes,
+            provider_device_id="peer-issue119-analysis",
+        )
+        _delete_live_project(session, fixture)
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": "peer-issue119-analysis",
+                    "available_content_sha256": _manifest_content_hashes([manifest]),
+                }
+            ],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["summary"]["failed_actions"] == 0
+
+    with SessionLocal() as session:
+        analysis = session.get(AnalysisResult, fixture.project_id)
+        assert analysis is not None
+        assert analysis.source_artifact_id == fixture.source_artifact_id
+        assert analysis.estimated_key == "F major"
+        assert analysis.key_confidence == 0.82
+        assert analysis.estimated_reference_hz == 441.25
+        assert analysis.tuning_offset_cents == 4.91
+        assert analysis.tempo_bpm == 118.5
+        assert analysis.timing_json == {
+            "beats_per_bar": 4,
+            "source": "detected",
+            "beats": [{"time_seconds": 0.0, "beat_in_bar": 1}],
+            "bars": [{"index": 1, "start_seconds": 0.0, "end_seconds": 2.0}],
+        }
+        assert analysis.analysis_version == "v3"
+        session.delete(analysis)
+        session.commit()
+
+    repair_response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": "peer-issue119-analysis",
+                    "available_content_sha256": _manifest_content_hashes([manifest]),
+                }
+            ],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert repair_response.status_code == 200
+    assert repair_response.json()["summary"]["failed_actions"] == 0
+
+    with SessionLocal() as session:
+        repaired_analysis = session.get(AnalysisResult, fixture.project_id)
+        assert repaired_analysis is not None
+        assert repaired_analysis.tempo_bpm == 118.5
+        assert repaired_analysis.estimated_key == "F major"
+
+
+def test_issue119_apply_reports_analysis_repair_failure_without_rolling_back_import(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _ensure_identity_and_peers("peer-issue119-analysis-failure")
+
+    with SessionLocal() as session:
+        fresh_fixture = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="fresh-analysis",
+            source_frames=74,
+        )
+        imported_fixture = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="bad-analysis",
+            source_frames=76,
+        )
+        _add_analysis_artifact(session, imported_fixture)
+        fresh_manifest = _jsonable_manifest(
+            export_project_manifest(session, project_id=fresh_fixture.project_id)
+        )
+        imported_manifest = _jsonable_manifest(
+            export_project_manifest(session, project_id=imported_fixture.project_id)
+        )
+        _stage_manifest_content(
+            session,
+            fresh_manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=fresh_fixture.artifact_bytes,
+            provider_device_id="peer-issue119-analysis-failure",
+        )
+        _delete_live_project(session, fresh_fixture)
+        analysis = session.get(AnalysisResult, imported_fixture.project_id)
+        assert analysis is not None
+        session.delete(analysis)
+        bad_analysis_artifact = session.get(Artifact, "art_issue119_analysis_json")
+        assert bad_analysis_artifact is not None
+        Path(bad_analysis_artifact.path).write_text("{not json", encoding="utf-8")
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [fresh_manifest, imported_manifest],
+            "peer_inventory": [
+                {
+                    "device_id": "peer-issue119-analysis-failure",
+                    "available_content_sha256": _manifest_content_hashes([fresh_manifest]),
+                }
+            ],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 1
+    failed_results = [
+        result for result in payload["results"] if result["status"] == "failed"
+    ]
+    assert len(failed_results) == 1
+    assert failed_results[0]["action"]["project_id"] == imported_fixture.project_id
+    assert failed_results[0]["reason"] == "Analysis artifact payload must be readable JSON."
+
+    with SessionLocal() as session:
+        fresh_project = session.get(Project, fresh_fixture.project_id)
+        assert fresh_project is not None
+        assert fresh_project.sync_status == "local"
+        assert session.get(AnalysisResult, imported_fixture.project_id) is None
+
+
+def test_issue119_staging_cleanup_keeps_shared_hash_until_all_references_import(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _ensure_identity_and_peers("peer-issue119-shared-hash")
+    shared_stem_bytes = b"shared issue119 stem bytes"
+
+    with SessionLocal() as session:
+        first = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="shared-one",
+            source_frames=78,
+            stem_bytes=shared_stem_bytes,
+        )
+        second = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="shared-two",
+            source_frames=82,
+            stem_bytes=shared_stem_bytes,
+        )
+        first_manifest = _jsonable_manifest(export_project_manifest(session, project_id=first.project_id))
+        second_manifest = _jsonable_manifest(export_project_manifest(session, project_id=second.project_id))
+        _stage_manifest_content(
+            session,
+            first_manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=first.artifact_bytes,
+            provider_device_id="peer-issue119-shared-hash",
+        )
+        _stage_manifest_content(
+            session,
+            second_manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=second.artifact_bytes,
+            provider_device_id="peer-issue119-shared-hash",
+        )
+        _delete_live_project(session, first)
+        _delete_live_project(session, second)
+        session.commit()
+
+    shared_hash = first.artifact_hashes[first.stem_artifact_id]
+    assert shared_hash == second.artifact_hashes[second.stem_artifact_id]
+
+    first_response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [first_manifest],
+            "peer_inventory": [
+                {
+                    "device_id": "peer-issue119-shared-hash",
+                    "available_content_sha256": _manifest_content_hashes([first_manifest]),
+                }
+            ],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert first_response.status_code == 200
+    assert first_response.json()["summary"]["failed_actions"] == 0
+    staging_root = get_settings().data_root / "sync" / "staging"
+    with SessionLocal() as session:
+        assert session.get(SyncStagedArtifact, first.artifact_hashes[first.source_artifact_id]) is None
+        assert session.get(SyncStagedArtifact, shared_hash) is not None
+        assert (staging_root / "sha256" / shared_hash[:2] / shared_hash).exists()
+
+    second_response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [second_manifest],
+            "peer_inventory": [
+                {
+                    "device_id": "peer-issue119-shared-hash",
+                    "available_content_sha256": _manifest_content_hashes([second_manifest]),
+                }
+            ],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert second_response.status_code == 200
+    assert second_response.json()["summary"]["failed_actions"] == 0
+    with SessionLocal() as session:
+        assert session.scalar(select(func.count()).select_from(SyncStagedArtifact)) == 0
+        assert not (staging_root / "sha256" / shared_hash[:2] / shared_hash).exists()
+
+
+def test_issue119_revision_manifest_hash_matches_sanitized_payload_and_round_trips(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _ = client
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path, slug="hash", source_frames=80)
+        local_path = str(tmp_path / "local-only" / "take.wav")
+        dirty_payload = {
+            "project_id": fixture.project_id,
+            "backend": "tuneforge-fast",
+            "source_kind": "user-edited",
+            "has_user_edits": True,
+            "source_artifact_id": fixture.source_artifact_id,
+            "timeline": [
+                {
+                    "start_seconds": 0.0,
+                    "end_seconds": 1.0,
+                    "label": "C",
+                    "source_path": local_path,
+                }
+            ],
+            "segments": [
+                {
+                    "start_seconds": 0.0,
+                    "end_seconds": 1.0,
+                    "label": "Am",
+                    "path": local_path,
+                }
+            ],
+            "metadata": {"reviewed": True, "render_path": local_path},
+        }
+        dirty_metadata = {"reason": "manual-edit", "local_path": local_path}
+        dirty_hash = revision_payload_sha256(dirty_payload)
+        session.add(
+            SyncEntityRevision(
+                id="rev_issue119_hash_chords",
+                project_id=fixture.project_id,
+                entity_type="chords",
+                entity_id=fixture.project_id,
+                revision_type="manual",
+                base_revision_id=None,
+                author_device_id="peer-issue119-source",
+                source_artifact_id=fixture.source_artifact_id,
+                content_sha256=dirty_hash,
+                state=CURRENT_REVISION_STATE,
+                metadata_json=dirty_metadata,
+                payload_json=dirty_payload,
+                created_at=datetime(2026, 1, 1, tzinfo=UTC),
+                updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+        )
+        session.commit()
+
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        exported_revision = _revision_by_id(manifest, "rev_issue119_hash_chords")
+        sanitized_payload = sanitize_revision_payload(dirty_payload)
+        sanitized_metadata = sanitize_revision_payload(dirty_metadata)
+        assert exported_revision["payload"] == sanitized_payload
+        assert exported_revision["metadata"] == sanitized_metadata
+        assert exported_revision["content_sha256"] == revision_payload_sha256(sanitized_payload)
+        assert exported_revision["content_sha256"] != dirty_hash
+
+        _stage_manifest_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=fixture.artifact_bytes,
+            provider_device_id="peer-issue119-source",
+        )
+        _delete_live_project(session, fixture)
+
+        import_staged_project_manifest(
+            session,
+            manifest=manifest,
+            use_content_addressed_staging=True,
+        )
+        session.commit()
+
+        imported_revision = session.get(SyncEntityRevision, "rev_issue119_hash_chords")
+        assert imported_revision is not None
+        assert imported_revision.content_sha256 == exported_revision["content_sha256"]
+        assert imported_revision.payload_json == sanitized_payload
+        assert imported_revision.metadata_json == sanitized_metadata
+
+        chords = session.get(ChordTimeline, fixture.project_id)
+        assert chords is not None
+        assert chords.has_user_edits is True
+        assert chords.source_kind == "user-edited"
+        assert chords.segments_json == [
+            {"start_seconds": 0.0, "end_seconds": 1.0, "label": "Am"}
+        ]
+
+
+def test_issue119_project_manifest_import_canonicalizes_revision_payload_hash(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _ensure_identity_and_peers("peer-issue119-hash-mismatch")
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="hash-mismatch",
+            source_frames=84,
+        )
+        session.add(
+            SyncEntityRevision(
+                id="rev_issue119_hash_mismatch",
+                project_id=fixture.project_id,
+                entity_type="chords",
+                entity_id=fixture.project_id,
+                revision_type="analysis",
+                base_revision_id=None,
+                author_device_id="peer-issue119-hash-mismatch",
+                source_artifact_id=fixture.source_artifact_id,
+                content_sha256=revision_payload_sha256({"timeline": [{"label": "C"}]}),
+                state=CURRENT_REVISION_STATE,
+                metadata_json={},
+                payload_json={"timeline": [{"label": "C"}]},
+                created_at=datetime(2026, 1, 1, tzinfo=UTC),
+                updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+        )
+        session.commit()
+
+        manifest = _jsonable_manifest(
+            export_project_manifest(session, project_id=fixture.project_id)
+        )
+        exported_revision = _revision_by_id(manifest, "rev_issue119_hash_mismatch")
+        canonical_hash = revision_payload_sha256(
+            sanitize_revision_payload(exported_revision["payload"])
+        )
+        assert exported_revision["content_sha256"] == canonical_hash
+        exported_revision["content_sha256"] = "0" * 64
+
+        _stage_manifest_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=fixture.artifact_bytes,
+            provider_device_id="peer-issue119-hash-mismatch",
+        )
+        _delete_live_project(session, fixture)
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": "peer-issue119-hash-mismatch",
+                    "available_content_sha256": _manifest_content_hashes([manifest]),
+                }
+            ],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 0
+    assert payload["plan"]["summary"]["total_conflicts"] == 0
+
+    with SessionLocal() as session:
+        project = session.get(Project, fixture.project_id)
+        assert project is not None
+        assert project.sync_status == "local"
+        assert project.sync_status_reason is None
+        imported_revision = session.get(SyncEntityRevision, "rev_issue119_hash_mismatch")
+        assert imported_revision is not None
+        assert imported_revision.content_sha256 == canonical_hash
+        assert imported_revision.content_sha256 != "0" * 64
+
+
+def test_issue119_reconnect_stale_manifest_does_not_resurrect_tombstoned_targets(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    identity = _ensure_identity_and_peers("peer-issue119-reconnect")
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path, slug="reconnect", source_frames=88)
+        deleted_path = fixture.root / "previews" / "deleted-mix.wav"
+        deleted_hash, deleted_size = _write_bytes(deleted_path, b"deleted mix")
+        session.add(
+            Artifact(
+                id="art_issue119_deleted_mix",
+                project_id=fixture.project_id,
+                type="preview_mix",
+                format="wav",
+                path=str(deleted_path),
+                content_sha256=deleted_hash,
+                size_bytes=deleted_size,
+                generated_by="preview",
+                can_delete=True,
+                can_regenerate=True,
+                metadata_json={"source_artifact_id": fixture.source_artifact_id},
+            )
+        )
+        session.add(
+            SyncEntityRevision(
+                id="rev_issue119_deleted_chords",
+                project_id=fixture.project_id,
+                entity_type="chords",
+                entity_id=fixture.project_id,
+                revision_type="manual",
+                base_revision_id=None,
+                author_device_id="peer-issue119-reconnect",
+                source_artifact_id=None,
+                content_sha256=revision_payload_sha256({"timeline": []}),
+                state=CURRENT_REVISION_STATE,
+                metadata_json={},
+                payload_json={"timeline": []},
+                created_at=datetime(2026, 1, 1, tzinfo=UTC),
+                updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+        )
+        session.commit()
+        stale_manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+
+        session.delete(session.get(Artifact, "art_issue119_deleted_mix"))
+        session.delete(session.get(SyncEntityRevision, "rev_issue119_deleted_chords"))
+        deleted_path.unlink()
+        now = datetime(2026, 1, 2, tzinfo=UTC)
+        session.add_all(
+            [
+                SyncDeleteTombstone(
+                    id="tomb_issue119_deleted_mix",
+                    sync_group_id=identity["sync_group_id"],
+                    project_id=fixture.project_id,
+                    target_type="artifact",
+                    target_id="art_issue119_deleted_mix",
+                    author_device_id=identity["device_id"],
+                    deleted_at=now,
+                    prior_metadata_json={"type": "preview_mix"},
+                    created_at=now,
+                    updated_at=now,
+                ),
+                SyncDeleteTombstone(
+                    id="tomb_issue119_deleted_chords",
+                    sync_group_id=identity["sync_group_id"],
+                    project_id=fixture.project_id,
+                    target_type="entity_revision",
+                    target_id="rev_issue119_deleted_chords",
+                    author_device_id=identity["device_id"],
+                    deleted_at=now,
+                    prior_metadata_json={"entity_type": "chords"},
+                    created_at=now,
+                    updated_at=now,
+                ),
+            ]
+        )
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [stale_manifest],
+            "peer_inventory": [
+                {
+                    "device_id": "peer-issue119-reconnect",
+                    "available_content_sha256": _manifest_content_hashes([stale_manifest]),
+                }
+            ],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    plan_items = response.json()["plan"]["items"]
+    assert _plan_item(plan_items, "artifact", "art_issue119_deleted_mix")["status"] == "deleted"
+    assert (
+        _plan_item(plan_items, "entity_revision", "rev_issue119_deleted_chords")["status"]
+        == "deleted"
+    )
+
+    with SessionLocal() as session:
+        project = session.get(Project, fixture.project_id)
+        assert project is not None
+        assert project.sync_status == "local"
+        assert session.get(Artifact, "art_issue119_deleted_mix") is None
+        assert session.get(SyncEntityRevision, "rev_issue119_deleted_chords") is None
+        assert not deleted_path.exists()
+        assert session.get(SyncDeleteTombstone, "tomb_issue119_deleted_mix") is not None
+        assert session.get(SyncDeleteTombstone, "tomb_issue119_deleted_chords") is not None
+
+
+def test_issue119_duplicate_source_from_second_peer_is_noop_and_remains_editable(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _ensure_identity_and_peers("peer-issue119-first", "peer-issue119-second")
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path, slug="duplicate", source_frames=104)
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        _stage_manifest_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=fixture.artifact_bytes,
+            provider_device_id="peer-issue119-first",
+        )
+        _delete_live_project(session, fixture)
+        session.commit()
+
+    first_response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": "peer-issue119-first",
+                    "available_content_sha256": _manifest_content_hashes([manifest]),
+                }
+            ],
+            "use_content_addressed_staging": True,
+        },
+    )
+    assert first_response.status_code == 200
+    assert first_response.json()["summary"]["failed_actions"] == 0
+
+    second_response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": "peer-issue119-second",
+                    "available_content_sha256": _manifest_content_hashes([manifest]),
+                }
+            ],
+            "use_content_addressed_staging": True,
+        },
+    )
+    assert second_response.status_code == 200
+    assert second_response.json()["summary"]["failed_actions"] == 0
+    assert second_response.json()["summary"]["applied_actions"] == 0
+    assert second_response.json()["plan"]["summary"]["total_conflicts"] == 0
+
+    with SessionLocal() as session:
+        project_count = session.scalar(
+            select(func.count())
+            .select_from(Project)
+            .where(Project.source_sha256 == manifest["project"]["source_sha256"])
+        )
+        assert project_count == 1
+        project = session.get(Project, fixture.project_id)
+        assert project is not None
+        assert project.sync_status == "local"
+
+    patch_response = client.patch(
+        f"/api/v1/projects/{fixture.project_id}",
+        json={"display_name": "Duplicate Source Editable"},
+    )
+    assert patch_response.status_code == 200
+    assert patch_response.json()["project"]["display_name"] == "Duplicate Source Editable"
+
+
+def test_issue119_remote_placeholder_stays_locked_until_cross_peer_bytes_import(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _ensure_identity_and_peers("peer-issue119-lock-a", "peer-issue119-lock-b")
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path, slug="lock", source_frames=112)
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        _delete_live_project(session, fixture)
+        session.commit()
+
+    first_response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": "peer-issue119-lock-a",
+                    "available_content_sha256": _manifest_content_hashes([manifest]),
+                }
+            ],
+            "use_content_addressed_staging": True,
+        },
+    )
+    assert first_response.status_code == 200
+    assert first_response.json()["summary"]["failed_actions"] == 0
+    assert first_response.json()["summary"]["applied_actions"] > 0
+
+    locked_response = client.patch(
+        f"/api/v1/projects/{fixture.project_id}",
+        json={"display_name": "Should Stay Locked"},
+    )
+    assert locked_response.status_code == 409
+    assert locked_response.json()["error"]["code"] == "PROJECT_SYNC_LOCKED"
+    assert locked_response.json()["error"]["details"]["sync_status"] == "remote_available"
+    assert locked_response.json()["error"]["details"]["sync_provider_device_ids"] == [
+        "peer-issue119-lock-a"
+    ]
+
+    with SessionLocal() as session:
+        _stage_manifest_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=fixture.artifact_bytes,
+            provider_device_id="peer-issue119-lock-b",
+        )
+        session.commit()
+
+    second_response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": "peer-issue119-lock-b",
+                    "available_content_sha256": _manifest_content_hashes([manifest]),
+                }
+            ],
+            "use_content_addressed_staging": True,
+        },
+    )
+    assert second_response.status_code == 200
+    assert second_response.json()["summary"]["failed_actions"] == 0
+    assert second_response.json()["summary"]["applied_actions"] > 0
+
+    unlocked_response = client.patch(
+        f"/api/v1/projects/{fixture.project_id}",
+        json={"display_name": "Unlocked After Import"},
+    )
+    assert unlocked_response.status_code == 200
+    assert unlocked_response.json()["project"]["display_name"] == "Unlocked After Import"
+
+    with SessionLocal() as session:
+        project = session.get(Project, fixture.project_id)
+        assert project is not None
+        assert project.sync_status == "local"
+        assert project.sync_provider_device_ids == []
+        assert project.sync_required_artifact_ids == []
+
+
+def _ensure_identity_and_peers(*peer_device_ids: str) -> dict[str, str]:
+    now = datetime.now(UTC)
+    with SessionLocal() as session:
+        identity = get_or_create_local_identity(session)
+        for peer_device_id in peer_device_ids:
+            if session.get(SyncTrustedPeer, peer_device_id) is not None:
+                continue
+            session.add(
+                SyncTrustedPeer(
+                    device_id=peer_device_id,
+                    sync_group_id=identity.sync_group_id,
+                    display_name=peer_device_id,
+                    public_key=f"pub-{peer_device_id}",
+                    endpoint_hints_json=[],
+                    trusted_at=now,
+                    revoked_at=None,
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+        session.commit()
+        return {"device_id": identity.device_id, "sync_group_id": identity.sync_group_id}
+
+
+def _create_project_with_artifacts(
+    session: Session,
+    tmp_path: Path,
+    *,
+    slug: str,
+    source_frames: int,
+    stem_bytes: bytes | None = None,
+) -> Issue119ProjectFixture:
+    source_bytes = _wav_bytes(frame_count=source_frames)
+    stem_bytes = stem_bytes if stem_bytes is not None else f"issue119 stem {slug}".encode()
+    external_source_path = tmp_path / "library" / f"{slug}.wav"
+    source_sha256, _ = _write_bytes(external_source_path, source_bytes)
+    project_id = source_hash_to_project_id(source_sha256)
+    root = project_root(project_id)
+    source_relative_path = f"source/{slug}.wav"
+    stem_relative_path = f"stems/{slug}-vocals.wav"
+    source_path = root / source_relative_path
+    stem_path = root / stem_relative_path
+    source_hash, source_size = _write_bytes(source_path, source_bytes)
+    stem_hash, stem_size = _write_bytes(stem_path, stem_bytes)
+    source_artifact_id = f"art_issue119_{slug}_source"
+    stem_artifact_id = f"art_issue119_{slug}_vocals"
+    timestamp = datetime(2026, 1, 1, tzinfo=UTC)
+
+    session.add(
+        Project(
+            id=project_id,
+            display_name=f"Issue 119 {slug.title()}",
+            source_key_override="1:major",
+            source_sha256=source_sha256,
+            source_path=str(external_source_path),
+            imported_path=str(source_path),
+            duration_seconds=1.0,
+            sample_rate=44100,
+            channels=1,
+            created_at=timestamp,
+            updated_at=timestamp,
+        )
+    )
+    session.flush()
+    session.add_all(
+        [
+            Artifact(
+                id=source_artifact_id,
+                project_id=project_id,
+                type="source_audio",
+                format="wav",
+                path=str(source_path),
+                content_sha256=source_hash,
+                size_bytes=source_size,
+                generated_by="import",
+                can_delete=False,
+                can_regenerate=False,
+                metadata_json={"source_label": slug},
+                created_at=timestamp,
+            ),
+            Artifact(
+                id=stem_artifact_id,
+                project_id=project_id,
+                type="vocals",
+                format="wav",
+                path=str(stem_path),
+                content_sha256=stem_hash,
+                size_bytes=stem_size,
+                generated_by="stems",
+                can_delete=True,
+                can_regenerate=True,
+                cache_key=f"stem:{project_id}:vocals",
+                metadata_json={"source_artifact_id": source_artifact_id},
+                created_at=timestamp,
+            ),
+        ]
+    )
+    session.commit()
+    return Issue119ProjectFixture(
+        project_id=project_id,
+        root=root,
+        source_relative_path=source_relative_path,
+        stem_relative_path=stem_relative_path,
+        source_artifact_id=source_artifact_id,
+        stem_artifact_id=stem_artifact_id,
+        artifact_hashes={
+            source_artifact_id: source_hash,
+            stem_artifact_id: stem_hash,
+        },
+        artifact_sizes={
+            source_artifact_id: source_size,
+            stem_artifact_id: stem_size,
+        },
+        artifact_bytes={
+            source_artifact_id: source_bytes,
+            stem_artifact_id: stem_bytes,
+        },
+    )
+
+
+def _add_analysis_artifact(session: Session, fixture: Issue119ProjectFixture) -> None:
+    analysis_payload = {
+        "project_id": fixture.project_id,
+        "source_artifact_id": fixture.source_artifact_id,
+        "estimated_key": "F major",
+        "key_confidence": 0.82,
+        "estimated_reference_hz": 441.25,
+        "tuning_offset_cents": 4.91,
+        "tempo_bpm": 118.5,
+        "timing": {
+            "beats_per_bar": 4,
+            "source": "detected",
+            "beats": [{"time_seconds": 0.0, "beat_in_bar": 1}],
+            "bars": [{"index": 1, "start_seconds": 0.0, "end_seconds": 2.0}],
+        },
+        "analysis_version": "v3",
+    }
+    contents = json.dumps(
+        analysis_payload,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    artifact_id = "art_issue119_analysis_json"
+    analysis_path = fixture.root / "analysis" / "analysis.json"
+    analysis_hash, analysis_size = _write_bytes(analysis_path, contents)
+    session.add(
+        AnalysisResult(
+            project_id=fixture.project_id,
+            source_artifact_id=fixture.source_artifact_id,
+            estimated_key="F major",
+            key_confidence=0.82,
+            estimated_reference_hz=441.25,
+            tuning_offset_cents=4.91,
+            tempo_bpm=118.5,
+            timing_json=analysis_payload["timing"],
+            analysis_version="v3",
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+    )
+    session.add(
+        Artifact(
+            id=artifact_id,
+            project_id=fixture.project_id,
+            type="analysis_json",
+            format="json",
+            path=str(analysis_path),
+            content_sha256=analysis_hash,
+            size_bytes=analysis_size,
+            generated_by="analysis",
+            can_delete=True,
+            can_regenerate=True,
+            metadata_json={
+                "analysis_version": "v3",
+                "source_artifact_id": fixture.source_artifact_id,
+            },
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+    )
+    session.commit()
+    fixture.artifact_hashes[artifact_id] = analysis_hash
+    fixture.artifact_sizes[artifact_id] = analysis_size
+    fixture.artifact_bytes[artifact_id] = contents
+
+
+def _jsonable_manifest(value: Any) -> dict[str, Any]:
+    manifest = _to_plain(value)
+    assert isinstance(manifest, dict)
+    if "project_manifest" in manifest:
+        manifest = manifest["project_manifest"]
+        assert isinstance(manifest, dict)
+    return manifest
+
+
+def _to_plain(value: Any) -> Any:
+    if hasattr(value, "model_dump"):
+        return _to_plain(value.model_dump(mode="json"))
+    if is_dataclass(value):
+        return _to_plain(asdict(value))
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {key: _to_plain(child) for key, child in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_plain(child) for child in value]
+    return value
+
+
+def _stage_manifest_content(
+    session: Session,
+    manifest: dict[str, Any],
+    *,
+    tmp_path: Path,
+    artifact_bytes: dict[str, bytes],
+    provider_device_id: str,
+) -> None:
+    for artifact in manifest["artifacts"]:
+        artifact_id = artifact["artifact_id"]
+        source_path = tmp_path / "issue119-stage" / provider_device_id / artifact_id
+        content = artifact_bytes[artifact_id]
+        _write_bytes(source_path, content)
+        stage_sync_artifact(
+            session,
+            source_path=source_path,
+            content_sha256=artifact["content_sha256"],
+            size_bytes=artifact["size_bytes"],
+            provider_device_id=provider_device_id,
+            metadata={"artifact_id": artifact_id, "project_id": artifact["project_id"]},
+        )
+
+
+def _delete_live_project(session: Session, fixture: Issue119ProjectFixture) -> None:
+    for revision in session.scalars(
+        select(SyncEntityRevision).where(SyncEntityRevision.project_id == fixture.project_id)
+    ):
+        session.delete(revision)
+    for artifact in session.scalars(select(Artifact).where(Artifact.project_id == fixture.project_id)):
+        session.delete(artifact)
+    project = session.get(Project, fixture.project_id)
+    if project is not None:
+        session.delete(project)
+    session.flush()
+    shutil.rmtree(fixture.root, ignore_errors=True)
+
+
+def _manifest_content_hashes(manifests: list[dict[str, Any]]) -> list[str]:
+    return sorted(
+        {
+            artifact["content_sha256"]
+            for manifest in manifests
+            for artifact in manifest["artifacts"]
+        }
+    )
+
+
+def _empty_remote_library() -> dict[str, list[Any]]:
+    return {
+        "projects": [],
+        "artifacts": [],
+        "entity_revisions": [],
+        "delete_tombstones": [],
+    }
+
+
+def _revision_by_id(manifest: dict[str, Any], revision_id: str) -> dict[str, Any]:
+    for revision in manifest["entity_revisions"]:
+        if revision["revision_id"] == revision_id:
+            return revision
+    raise AssertionError(f"Missing revision in manifest: {revision_id}")
+
+
+def _plan_item(items: list[dict[str, Any]], item_type: str, item_id: str) -> dict[str, Any]:
+    for item in items:
+        if item["item_type"] == item_type and item["item_id"] == item_id:
+            return item
+    raise AssertionError(f"Missing plan item: {item_type}:{item_id}")
+
+
+def _write_bytes(path: Path, contents: bytes) -> tuple[str, int]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(contents)
+    content_hash = file_sha256(path)
+    assert content_hash is not None
+    return content_hash, path.stat().st_size
+
+
+def _wav_bytes(*, frame_count: int, sample_rate: int = 44100) -> bytes:
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(b"\0\0" * frame_count)
+    return buffer.getvalue()

--- a/apps/desktop/src-tauri/src/sync_transport.rs
+++ b/apps/desktop/src-tauri/src/sync_transport.rs
@@ -43,6 +43,7 @@ pub struct SyncTransportStatus {
     pub failed_sessions: u64,
     pub last_status: Option<String>,
     pub last_error: Option<String>,
+    pub last_sync: Option<SyncTransportSyncResult>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -75,7 +76,12 @@ pub struct SyncTransportProjectResult {
 pub struct SyncTransportSyncResult {
     pub peer_device_id: String,
     pub remote_device_id: String,
+    pub status: String,
+    pub message: String,
     pub imported_projects: Vec<SyncTransportProjectResult>,
+    pub imported_project_count: usize,
+    pub skipped_project_count: usize,
+    pub failed_project_count: usize,
     pub received_artifacts: Vec<SyncTransportTransferResult>,
     pub served_artifact_requests: u64,
     pub remote_manifest_count: usize,
@@ -109,7 +115,7 @@ mod desktop {
     use sha2::{Digest, Sha256};
     use snow::{params::NoiseParams, Builder};
     use std::{
-        collections::HashMap,
+        collections::{HashMap, HashSet},
         env,
         fs::{self, File},
         io::{self, BufRead, BufReader, Read, Write},
@@ -126,6 +132,7 @@ mod desktop {
     use tauri::State;
 
     const DEFAULT_BIND_HOST: &str = "0.0.0.0";
+    const DEFAULT_LISTENER_PORT: u16 = 47619;
     const ENDPOINT_SCHEME: &str = "tuneforge-sync+tcp://";
     const PAIRING_PROTOCOL_VERSION: &str = "tuneforge-sync-v1";
     const TRANSPORT_PROTOCOL_VERSION: &str = "tuneforge-sync-transport-v1";
@@ -182,9 +189,10 @@ mod desktop {
                 .filter(|value| !value.is_empty())
                 .unwrap_or(DEFAULT_BIND_HOST)
                 .to_string();
-            let port = payload.port.unwrap_or(0);
-            let listener = TcpListener::bind((bind_host.as_str(), port))
-                .map_err(|error| format!("Could not bind sync transport listener: {error}"))?;
+            let port = payload.port.unwrap_or(DEFAULT_LISTENER_PORT);
+            let listener = TcpListener::bind((bind_host.as_str(), port)).map_err(|error| {
+                format!("Could not bind sync transport listener on {bind_host}:{port}: {error}")
+            })?;
             listener
                 .set_nonblocking(true)
                 .map_err(|error| format!("Could not configure sync transport listener: {error}"))?;
@@ -216,6 +224,7 @@ mod desktop {
             update_status(&self.shared_status, |status| {
                 status.last_status = Some("Sync transport listener started.".to_string());
                 status.last_error = None;
+                status.last_sync = None;
             });
 
             Ok(self.status())
@@ -271,6 +280,7 @@ mod desktop {
                 failed_sessions: shared.failed_sessions,
                 last_status: shared.last_status,
                 last_error: shared.last_error,
+                last_sync: shared.last_sync,
             }
         }
 
@@ -297,6 +307,24 @@ mod desktop {
         }
 
         fn sync_now(
+            &self,
+            payload: SyncTransportSyncNowRequest,
+        ) -> Result<SyncTransportSyncResult, String> {
+            let result = self.run_sync_now(payload);
+            update_status(&self.shared_status, |status| match &result {
+                Ok(sync_result) => {
+                    status.last_status = Some(sync_result.message.clone());
+                    status.last_sync = Some(sync_result.clone());
+                    status.last_error = None;
+                }
+                Err(error) => {
+                    status.last_error = Some(error.clone());
+                }
+            });
+            result
+        }
+
+        fn run_sync_now(
             &self,
             payload: SyncTransportSyncNowRequest,
         ) -> Result<SyncTransportSyncResult, String> {
@@ -366,6 +394,7 @@ mod desktop {
                 imported_projects = imported.imported_projects;
                 received_artifacts = imported.received_artifacts;
             }
+            let import_counts = import_outcome_counts(&imported_projects);
             connection.send_message(&ProtocolMessage::PhaseDone {
                 phase: "initiator_import".to_string(),
             })?;
@@ -374,16 +403,28 @@ mod desktop {
                 &mut connection,
                 &local_offer.project_manifests,
             )?;
+            let manifest_errors =
+                sync_manifest_errors(&local_offer.manifest_errors, &remote_offer.manifest_errors);
 
             Ok(SyncTransportSyncResult {
                 peer_device_id: payload.peer_device_id,
                 remote_device_id: session.remote_device_id,
+                status: sync_result_status(&manifest_errors, import_counts.failed),
+                message: sync_result_message(
+                    local_manifest_count,
+                    remote_offer.project_manifests.len(),
+                    received_artifacts.len(),
+                    import_counts,
+                ),
                 imported_projects,
+                imported_project_count: import_counts.imported,
+                skipped_project_count: import_counts.skipped,
+                failed_project_count: import_counts.failed,
                 received_artifacts,
                 served_artifact_requests,
                 remote_manifest_count: remote_offer.project_manifests.len(),
                 local_manifest_count,
-                manifest_errors: remote_offer.manifest_errors,
+                manifest_errors,
             })
         }
     }
@@ -432,6 +473,11 @@ mod desktop {
         thread: Option<JoinHandle<()>>,
     }
 
+    struct IncomingSessionResult {
+        message: String,
+        sync_result: SyncTransportSyncResult,
+    }
+
     #[derive(Clone, Default)]
     struct SharedStatus {
         active_sessions: usize,
@@ -439,6 +485,7 @@ mod desktop {
         failed_sessions: u64,
         last_status: Option<String>,
         last_error: Option<String>,
+        last_sync: Option<SyncTransportSyncResult>,
     }
 
     fn accept_loop(
@@ -457,6 +504,7 @@ mod desktop {
                         status.last_status =
                             Some(format!("Accepted sync peer session from {address}."));
                         status.last_error = None;
+                        status.last_sync = None;
                     });
                     thread::spawn(move || {
                         handle_incoming_session(base_url, stream, shared_status);
@@ -489,8 +537,9 @@ mod desktop {
         update_status(&shared_status, |status| {
             status.active_sessions = status.active_sessions.saturating_sub(1);
             match result {
-                Ok(summary) => {
-                    status.last_status = Some(summary);
+                Ok(result) => {
+                    status.last_status = Some(result.message);
+                    status.last_sync = Some(result.sync_result);
                     status.last_error = None;
                 }
                 Err(error) => {
@@ -501,7 +550,10 @@ mod desktop {
         });
     }
 
-    fn serve_incoming_session(base_url: String, stream: TcpStream) -> Result<String, String> {
+    fn serve_incoming_session(
+        base_url: String,
+        stream: TcpStream,
+    ) -> Result<IncomingSessionResult, String> {
         configure_stream(&stream)?;
         let client = BackendClient::new(&base_url)?;
         let mut connection = SecurePeerConnection::connect_responder(stream)?;
@@ -534,17 +586,47 @@ mod desktop {
             &remote_offer.metadata,
             &remote_offer.project_manifests,
         );
+        let import_counts = import_outcome_counts(&imported.imported_projects);
         connection.send_message(&ProtocolMessage::PhaseDone {
             phase: "responder_import".to_string(),
         })?;
 
-        Ok(format!(
-            "Sync session with {} completed: served {} artifact request(s), imported {} project manifest(s), offered {} local manifest(s).",
+        let message = format!(
+            "Sync session with {} completed: served {} artifact request(s), imported {} project(s), skipped {} project(s), failed {} project(s), offered {} local manifest(s).",
             session.remote_device_id,
             served_artifact_requests,
-            imported.imported_projects.len(),
+            import_counts.imported,
+            import_counts.skipped,
+            import_counts.failed,
             local_manifest_count
-        ))
+        );
+        let manifest_errors =
+            sync_manifest_errors(&local_offer.manifest_errors, &remote_offer.manifest_errors);
+        let sync_result = SyncTransportSyncResult {
+            peer_device_id: session.remote_device_id.clone(),
+            remote_device_id: session.remote_device_id,
+            status: sync_result_status(&manifest_errors, import_counts.failed),
+            message: sync_result_message(
+                local_manifest_count,
+                remote_offer.project_manifests.len(),
+                imported.received_artifacts.len(),
+                import_counts,
+            ),
+            imported_projects: imported.imported_projects,
+            imported_project_count: import_counts.imported,
+            skipped_project_count: import_counts.skipped,
+            failed_project_count: import_counts.failed,
+            received_artifacts: imported.received_artifacts,
+            served_artifact_requests,
+            remote_manifest_count: remote_offer.project_manifests.len(),
+            local_manifest_count,
+            manifest_errors,
+        };
+
+        Ok(IncomingSessionResult {
+            message,
+            sync_result,
+        })
     }
 
     fn update_status(
@@ -830,6 +912,9 @@ mod desktop {
     }
 
     fn configure_stream(stream: &TcpStream) -> Result<(), String> {
+        stream.set_nonblocking(false).map_err(|error| {
+            format!("Could not configure sync transport blocking mode: {error}")
+        })?;
         stream
             .set_read_timeout(Some(READ_TIMEOUT))
             .map_err(|error| format!("Could not set sync transport read timeout: {error}"))?;
@@ -1162,6 +1247,13 @@ mod desktop {
         received_artifacts: Vec<SyncTransportTransferResult>,
     }
 
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+    struct ImportOutcomeCounts {
+        imported: usize,
+        skipped: usize,
+        failed: usize,
+    }
+
     fn import_remote_manifests(
         client: &BackendClient,
         connection: &mut SecurePeerConnection,
@@ -1169,47 +1261,46 @@ mod desktop {
         remote_metadata: &Value,
         manifests: &[Value],
     ) -> ImportRemoteResult {
-        let mut imported_projects = Vec::new();
         let mut received_artifacts = Vec::new();
+        let mut transfer_failures = HashMap::new();
 
-        for manifest in manifests {
-            let project_id = manifest_project_id(manifest);
-            let artifacts = manifest_artifacts(manifest);
-            let mut project_failed = None;
-            for artifact in &artifacts {
-                match request_and_stage_artifact(client, connection, peer_device_id, artifact) {
-                    Ok(result) => received_artifacts.push(result),
-                    Err(error) => {
-                        project_failed = Some(error);
-                        break;
-                    }
+        let plan =
+            match plan_remote_manifest_batch(client, peer_device_id, remote_metadata, manifests) {
+                Ok(plan) => plan,
+                Err(error) => {
+                    return ImportRemoteResult {
+                        imported_projects: apply_failure_results(
+                            manifests,
+                            &transfer_failures,
+                            &format!("Could not plan remote sync reconciliation batch: {error}"),
+                        ),
+                        received_artifacts,
+                    };
+                }
+            };
+
+        for entry in planned_fetch_artifact_entries(&plan, manifests) {
+            match request_and_stage_artifact(client, connection, peer_device_id, &entry.artifact) {
+                Ok(result) => received_artifacts.push(result),
+                Err(error) => {
+                    transfer_failures
+                        .entry(entry.manifest_project_id)
+                        .or_insert(error);
                 }
             }
-
-            if let Some(error) = project_failed {
-                imported_projects.push(SyncTransportProjectResult {
-                    project_id,
-                    status: "failed".to_string(),
-                    message: Some(error),
-                });
-                continue;
-            }
-
-            match apply_remote_manifest(
-                client,
-                peer_device_id,
-                remote_metadata,
-                manifest,
-                &artifacts,
-            ) {
-                Ok(result) => imported_projects.push(result),
-                Err(error) => imported_projects.push(SyncTransportProjectResult {
-                    project_id,
-                    status: "failed".to_string(),
-                    message: Some(error.to_string()),
-                }),
-            }
         }
+
+        let available_content_sha256 = available_content_sha256(&received_artifacts);
+        let imported_projects = match apply_remote_manifest_batch(
+            client,
+            peer_device_id,
+            remote_metadata,
+            manifests,
+            &available_content_sha256,
+        ) {
+            Ok(results) => merge_transfer_failures(results, &transfer_failures),
+            Err(error) => apply_failure_results(manifests, &transfer_failures, &error.to_string()),
+        };
 
         ImportRemoteResult {
             imported_projects,
@@ -1217,60 +1308,387 @@ mod desktop {
         }
     }
 
-    fn apply_remote_manifest(
+    fn plan_remote_manifest_batch(
         client: &BackendClient,
         peer_device_id: &str,
         remote_metadata: &Value,
-        manifest: &Value,
-        artifacts: &[RemoteArtifact],
-    ) -> Result<SyncTransportProjectResult, BackendError> {
-        let project_id = manifest_project_id(manifest);
-        let available_content_sha256: Vec<String> = artifacts
-            .iter()
-            .map(|artifact| artifact.content_sha256.clone())
-            .collect();
-        let body = json!({
+        manifests: &[Value],
+    ) -> Result<Value, BackendError> {
+        let advertised_content_sha256 = manifest_content_sha256(manifests);
+        let body = reconciliation_plan_body(
+            peer_device_id,
+            remote_metadata,
+            manifests,
+            &advertised_content_sha256,
+        );
+        client.post_json_value("/api/v1/sync/reconciliation/plan", &body)
+    }
+
+    fn apply_remote_manifest_batch(
+        client: &BackendClient,
+        peer_device_id: &str,
+        remote_metadata: &Value,
+        manifests: &[Value],
+        available_content_sha256: &[String],
+    ) -> Result<Vec<SyncTransportProjectResult>, BackendError> {
+        let body = reconciliation_apply_body(
+            peer_device_id,
+            remote_metadata,
+            manifests,
+            available_content_sha256,
+        );
+        let response = client.post_json_value("/api/v1/sync/reconciliation/apply", &body)?;
+        Ok(map_batch_apply_response(manifests, &response))
+    }
+
+    fn reconciliation_plan_body(
+        peer_device_id: &str,
+        remote_metadata: &Value,
+        manifests: &[Value],
+        available_content_sha256: &[String],
+    ) -> Value {
+        json!({
             "remote_library": remote_metadata,
-            "project_manifests": [manifest],
+            "project_manifests": manifests,
+            "peer_inventory": [{
+                "device_id": peer_device_id,
+                "available_content_sha256": available_content_sha256,
+                "metadata": { "transport": "tuneforge-sync+tcp" },
+            }],
+        })
+    }
+
+    fn reconciliation_apply_body(
+        peer_device_id: &str,
+        remote_metadata: &Value,
+        manifests: &[Value],
+        available_content_sha256: &[String],
+    ) -> Value {
+        json!({
+            "remote_library": remote_metadata,
+            "project_manifests": manifests,
             "peer_inventory": [{
                 "device_id": peer_device_id,
                 "available_content_sha256": available_content_sha256,
                 "metadata": { "transport": "tuneforge-sync+tcp" },
             }],
             "use_content_addressed_staging": true,
-        });
-        let response = client.post_json_value("/api/v1/sync/reconciliation/apply", &body)?;
-        let summary = response.get("summary").unwrap_or(&Value::Null);
-        let failed_actions = summary
-            .get("failed_actions")
-            .and_then(Value::as_u64)
-            .unwrap_or(0);
-        let applied_actions = summary
-            .get("applied_actions")
-            .and_then(Value::as_u64)
-            .unwrap_or(0);
-        let satisfied_actions = summary
-            .get("satisfied_actions")
-            .and_then(Value::as_u64)
-            .unwrap_or(0);
-        let skipped_actions = summary
-            .get("skipped_actions")
-            .and_then(Value::as_u64)
-            .unwrap_or(0);
-        let status = if failed_actions > 0 {
-            "failed"
-        } else if applied_actions > 0 || satisfied_actions > 0 {
-            "applied"
-        } else {
-            "skipped"
-        };
-        Ok(SyncTransportProjectResult {
-            project_id,
-            status: status.to_string(),
-            message: Some(format!(
-                "Reconciliation apply: {applied_actions} applied, {satisfied_actions} satisfied, {skipped_actions} skipped, {failed_actions} failed."
-            )),
         })
+    }
+
+    #[derive(Clone, Debug, Default)]
+    struct ProjectApplyOutcome {
+        applied_actions: u64,
+        satisfied_actions: u64,
+        skipped_actions: u64,
+        failed_actions: u64,
+        conflicted_actions: u64,
+        imported_project_manifest: bool,
+        first_reason: Option<String>,
+    }
+
+    impl ProjectApplyOutcome {
+        fn record(&mut self, status: &str, action: &Value, reason: Option<&str>) {
+            let action_type = action.get("action_type").and_then(Value::as_str);
+            if action_type == Some("record_conflict")
+                || action_project_status(action) == Some("conflicted")
+            {
+                self.conflicted_actions = self.conflicted_actions.saturating_add(1);
+            }
+            match status {
+                "applied" => {
+                    self.applied_actions = self.applied_actions.saturating_add(1);
+                    if action_type == Some("import_project_manifest") {
+                        self.imported_project_manifest = true;
+                    }
+                }
+                "satisfied" => self.satisfied_actions = self.satisfied_actions.saturating_add(1),
+                "skipped" => self.skipped_actions = self.skipped_actions.saturating_add(1),
+                "failed" => self.failed_actions = self.failed_actions.saturating_add(1),
+                _ => self.skipped_actions = self.skipped_actions.saturating_add(1),
+            }
+            if self.first_reason.is_none() {
+                self.first_reason = reason.map(str::to_string);
+            }
+        }
+
+        fn status(&self) -> &'static str {
+            if self.failed_actions > 0 {
+                "failed"
+            } else if self.conflicted_actions > 0 {
+                "conflicted"
+            } else if self.imported_project_manifest {
+                "imported"
+            } else {
+                "skipped"
+            }
+        }
+
+        fn message(&self) -> String {
+            let mut message = format!(
+                "Reconciliation apply: {} applied, {} satisfied, {} skipped, {} failed, {} conflicted action(s).",
+                self.applied_actions,
+                self.satisfied_actions,
+                self.skipped_actions,
+                self.failed_actions,
+                self.conflicted_actions,
+            );
+            if let Some(reason) = &self.first_reason {
+                message.push(' ');
+                message.push_str(reason);
+            }
+            message
+        }
+    }
+
+    fn map_batch_apply_response(
+        manifests: &[Value],
+        response: &Value,
+    ) -> Vec<SyncTransportProjectResult> {
+        let mut outcomes: HashMap<String, ProjectApplyOutcome> = manifests
+            .iter()
+            .map(|manifest| {
+                (
+                    manifest_project_id(manifest),
+                    ProjectApplyOutcome::default(),
+                )
+            })
+            .collect();
+
+        for result in response
+            .get("results")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            let action = result.get("action").unwrap_or(&Value::Null);
+            let Some(project_id) = apply_result_project_id(action) else {
+                continue;
+            };
+            let Some(outcome) = outcomes.get_mut(project_id) else {
+                continue;
+            };
+            let status = result
+                .get("status")
+                .and_then(Value::as_str)
+                .unwrap_or("skipped");
+            let reason = result
+                .get("reason")
+                .and_then(Value::as_str)
+                .or_else(|| action.get("reason").and_then(Value::as_str));
+            let reason =
+                if action.get("action_type").and_then(Value::as_str) == Some("record_conflict") {
+                    action.get("reason").and_then(Value::as_str).or(reason)
+                } else {
+                    reason
+                };
+            outcome.record(status, action, reason);
+        }
+
+        manifests
+            .iter()
+            .map(|manifest| {
+                let project_id = manifest_project_id(manifest);
+                let outcome = outcomes.remove(&project_id).unwrap_or_default();
+                let message = if outcome.applied_actions == 0
+                    && outcome.satisfied_actions == 0
+                    && outcome.skipped_actions == 0
+                    && outcome.failed_actions == 0
+                    && outcome.conflicted_actions == 0
+                {
+                    "Reconciliation apply: no import actions were needed for this project."
+                        .to_string()
+                } else {
+                    outcome.message()
+                };
+                SyncTransportProjectResult {
+                    project_id,
+                    status: outcome.status().to_string(),
+                    message: Some(message),
+                }
+            })
+            .collect()
+    }
+
+    fn apply_result_project_id(action: &Value) -> Option<&str> {
+        action
+            .get("project_id")
+            .and_then(Value::as_str)
+            .or_else(|| match action.get("item_type").and_then(Value::as_str) {
+                Some("project") => action.get("item_id").and_then(Value::as_str),
+                _ => None,
+            })
+    }
+
+    fn action_project_status(action: &Value) -> Option<&str> {
+        action
+            .get("details")
+            .and_then(|details| details.get("project_status"))
+            .and_then(Value::as_str)
+    }
+
+    fn merge_transfer_failures(
+        mut results: Vec<SyncTransportProjectResult>,
+        transfer_failures: &HashMap<String, String>,
+    ) -> Vec<SyncTransportProjectResult> {
+        for result in &mut results {
+            if let Some(error) = transfer_failures.get(&result.project_id) {
+                result.status = "failed".to_string();
+                result.message = Some(format!(
+                    "Could not stage all remote artifact content before import: {error}"
+                ));
+            }
+        }
+        results
+    }
+
+    fn apply_failure_results(
+        manifests: &[Value],
+        transfer_failures: &HashMap<String, String>,
+        apply_error: &str,
+    ) -> Vec<SyncTransportProjectResult> {
+        manifests
+            .iter()
+            .map(|manifest| {
+                let project_id = manifest_project_id(manifest);
+                let message = transfer_failures.get(&project_id).map_or_else(
+                    || format!("Could not apply remote sync reconciliation batch: {apply_error}"),
+                    |error| {
+                        format!(
+                            "Could not stage all remote artifact content before import: {error}"
+                        )
+                    },
+                );
+                SyncTransportProjectResult {
+                    project_id,
+                    status: "failed".to_string(),
+                    message: Some(message),
+                }
+            })
+            .collect()
+    }
+
+    fn available_content_sha256(received_artifacts: &[SyncTransportTransferResult]) -> Vec<String> {
+        let mut seen = HashSet::new();
+        let mut values: Vec<String> = received_artifacts
+            .iter()
+            .filter_map(|artifact| {
+                if seen.insert(artifact.content_sha256.clone()) {
+                    Some(artifact.content_sha256.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        values.sort();
+        values
+    }
+
+    fn manifest_content_sha256(manifests: &[Value]) -> Vec<String> {
+        let mut seen = HashSet::new();
+        let mut values: Vec<String> = manifest_artifact_entries(manifests)
+            .into_iter()
+            .filter_map(|entry| {
+                if seen.insert(entry.artifact.content_sha256.clone()) {
+                    Some(entry.artifact.content_sha256)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        values.sort();
+        values
+    }
+
+    fn planned_fetch_artifact_entries(
+        plan: &Value,
+        manifests: &[Value],
+    ) -> Vec<ManifestArtifactEntry> {
+        let requested = planned_fetch_keys(plan);
+        manifest_artifact_entries(manifests)
+            .into_iter()
+            .filter(|entry| {
+                requested.contains(&(
+                    entry.artifact.artifact_id.clone(),
+                    entry.artifact.project_id.clone(),
+                    entry.artifact.content_sha256.clone(),
+                ))
+            })
+            .collect()
+    }
+
+    fn planned_fetch_keys(plan: &Value) -> HashSet<(String, String, String)> {
+        plan.get("actions")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter(|action| {
+                action.get("action_type").and_then(Value::as_str) == Some("fetch_artifact_content")
+            })
+            .filter_map(|action| {
+                Some((
+                    action.get("item_id")?.as_str()?.to_string(),
+                    action.get("project_id")?.as_str()?.to_string(),
+                    action.get("content_sha256")?.as_str()?.to_string(),
+                ))
+            })
+            .collect()
+    }
+
+    fn import_outcome_counts(results: &[SyncTransportProjectResult]) -> ImportOutcomeCounts {
+        let mut counts = ImportOutcomeCounts::default();
+        for result in results {
+            match result.status.as_str() {
+                "imported" => counts.imported += 1,
+                "failed" | "conflicted" => counts.failed += 1,
+                _ => counts.skipped += 1,
+            }
+        }
+        counts
+    }
+
+    fn sync_result_status(
+        manifest_errors: &[SyncTransportManifestError],
+        failed_project_count: usize,
+    ) -> String {
+        if failed_project_count > 0 || !manifest_errors.is_empty() {
+            "completed_with_errors"
+        } else {
+            "completed"
+        }
+        .to_string()
+    }
+
+    fn sync_manifest_errors(
+        local_errors: &[SyncTransportManifestError],
+        remote_errors: &[SyncTransportManifestError],
+    ) -> Vec<SyncTransportManifestError> {
+        let mut errors = Vec::with_capacity(local_errors.len() + remote_errors.len());
+        errors.extend(local_errors.iter().map(|error| SyncTransportManifestError {
+            project_id: error.project_id.clone(),
+            message: format!("Local manifest export failed: {}", error.message),
+        }));
+        errors.extend(
+            remote_errors
+                .iter()
+                .map(|error| SyncTransportManifestError {
+                    project_id: error.project_id.clone(),
+                    message: format!("Peer manifest export failed: {}", error.message),
+                }),
+        );
+        errors
+    }
+
+    fn sync_result_message(
+        local_manifest_count: usize,
+        remote_manifest_count: usize,
+        received_artifact_count: usize,
+        import_counts: ImportOutcomeCounts,
+    ) -> String {
+        format!(
+            "Exchanged {local_manifest_count} local and {remote_manifest_count} remote manifest(s); imported {} project(s), skipped {} project(s), failed {} project(s), received {received_artifact_count} artifact(s).",
+            import_counts.imported, import_counts.skipped, import_counts.failed
+        )
     }
 
     #[derive(Clone, Debug)]
@@ -1279,6 +1697,12 @@ mod desktop {
         project_id: String,
         content_sha256: String,
         size_bytes: u64,
+    }
+
+    #[derive(Clone, Debug)]
+    struct ManifestArtifactEntry {
+        manifest_project_id: String,
+        artifact: RemoteArtifact,
     }
 
     fn manifest_project_id(manifest: &Value) -> String {
@@ -1314,26 +1738,27 @@ mod desktop {
             .unwrap_or_default()
     }
 
+    fn manifest_artifact_entries(manifests: &[Value]) -> Vec<ManifestArtifactEntry> {
+        manifests
+            .iter()
+            .flat_map(|manifest| {
+                let manifest_project_id = manifest_project_id(manifest);
+                manifest_artifacts(manifest)
+                    .into_iter()
+                    .map(move |artifact| ManifestArtifactEntry {
+                        manifest_project_id: manifest_project_id.clone(),
+                        artifact,
+                    })
+            })
+            .collect()
+    }
+
     fn request_and_stage_artifact(
         client: &BackendClient,
         connection: &mut SecurePeerConnection,
         peer_device_id: &str,
         artifact: &RemoteArtifact,
     ) -> Result<SyncTransportTransferResult, String> {
-        let staging_path = format!(
-            "/api/v1/sync/artifacts/staging/{}",
-            percent_encode_path_segment(&artifact.content_sha256)
-        );
-        if client.get_json_value(&staging_path).is_ok() {
-            return Ok(SyncTransportTransferResult {
-                artifact_id: artifact.artifact_id.clone(),
-                content_sha256: artifact.content_sha256.clone(),
-                size_bytes: artifact.size_bytes,
-                status: "already_staged".to_string(),
-                message: None,
-            });
-        }
-
         connection.send_message(&ProtocolMessage::ArtifactRequest {
             artifact_id: artifact.artifact_id.clone(),
             content_sha256: artifact.content_sha256.clone(),
@@ -1451,7 +1876,11 @@ mod desktop {
     fn temp_artifact_path(content_sha256: &str) -> PathBuf {
         env::temp_dir()
             .join("tuneforge-sync-transport")
-            .join(format!("{}-{content_sha256}", process::id()))
+            .join(format!(
+                "{}-{}-{content_sha256}",
+                process::id(),
+                random_nonce()
+            ))
     }
 
     fn serve_artifact_requests_until_done(
@@ -2060,6 +2489,337 @@ mod desktop {
         }
 
         #[test]
+        fn reconciliation_apply_body_batches_every_manifest_with_one_peer_inventory() {
+            let manifests = vec![
+                json!({ "project": { "project_id": "proj_one" }, "artifacts": [] }),
+                json!({ "project": { "project_id": "proj_two" }, "artifacts": [] }),
+            ];
+            let remote_metadata = json!({ "projects": [] });
+            let available = vec!["hash_a".to_string(), "hash_b".to_string()];
+
+            let body =
+                reconciliation_apply_body("dev_peer", &remote_metadata, &manifests, &available);
+
+            assert_eq!(
+                body.get("project_manifests")
+                    .and_then(Value::as_array)
+                    .map(Vec::len),
+                Some(2)
+            );
+            assert_eq!(
+                body.get("peer_inventory")
+                    .and_then(Value::as_array)
+                    .and_then(|entries| entries.first())
+                    .and_then(|entry| entry.get("device_id"))
+                    .and_then(Value::as_str),
+                Some("dev_peer")
+            );
+            assert_eq!(
+                body.get("peer_inventory")
+                    .and_then(Value::as_array)
+                    .and_then(|entries| entries.first())
+                    .and_then(|entry| entry.get("available_content_sha256")),
+                Some(&json!(["hash_a", "hash_b"]))
+            );
+        }
+
+        #[test]
+        fn reconciliation_plan_body_advertises_manifest_artifact_hashes() {
+            let manifests = vec![
+                json!({
+                    "project": { "project_id": "proj_one" },
+                    "artifacts": [{
+                        "artifact_id": "art_one",
+                        "project_id": "proj_one",
+                        "content_sha256": "hash_b",
+                        "size_bytes": 20
+                    }]
+                }),
+                json!({
+                    "project": { "project_id": "proj_two" },
+                    "artifacts": [{
+                        "artifact_id": "art_two",
+                        "project_id": "proj_two",
+                        "content_sha256": "hash_a",
+                        "size_bytes": 10
+                    }, {
+                        "artifact_id": "art_two_duplicate_hash",
+                        "project_id": "proj_two",
+                        "content_sha256": "hash_b",
+                        "size_bytes": 20
+                    }]
+                }),
+            ];
+            let remote_metadata = json!({ "projects": [] });
+            let available = manifest_content_sha256(&manifests);
+
+            let body =
+                reconciliation_plan_body("dev_peer", &remote_metadata, &manifests, &available);
+
+            assert_eq!(
+                body.get("peer_inventory")
+                    .and_then(Value::as_array)
+                    .and_then(|entries| entries.first())
+                    .and_then(|entry| entry.get("available_content_sha256")),
+                Some(&json!(["hash_a", "hash_b"]))
+            );
+            assert!(body.get("use_content_addressed_staging").is_none());
+        }
+
+        #[test]
+        fn planned_fetch_artifact_entries_uses_backend_fetch_actions() {
+            let manifests = vec![
+                json!({
+                    "project": { "project_id": "proj_one" },
+                    "artifacts": [{
+                        "artifact_id": "art_one",
+                        "project_id": "proj_one",
+                        "content_sha256": "hash_a",
+                        "size_bytes": 10
+                    }]
+                }),
+                json!({
+                    "project": { "project_id": "proj_two" },
+                    "artifacts": [{
+                        "artifact_id": "art_two",
+                        "project_id": "proj_two",
+                        "content_sha256": "hash_b",
+                        "size_bytes": 20
+                    }]
+                }),
+            ];
+            let plan = json!({
+                "actions": [{
+                    "action_type": "fetch_artifact_content",
+                    "item_type": "artifact",
+                    "item_id": "art_two",
+                    "project_id": "proj_two",
+                    "content_sha256": "hash_b",
+                    "provider_device_id": "dev_peer",
+                    "priority": 20
+                }, {
+                    "action_type": "import_project_manifest",
+                    "item_type": "project",
+                    "item_id": "proj_one",
+                    "project_id": "proj_one",
+                    "priority": 30
+                }]
+            });
+
+            let entries = planned_fetch_artifact_entries(&plan, &manifests);
+
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0].artifact.artifact_id, "art_two");
+            assert_eq!(entries[0].manifest_project_id, "proj_two");
+        }
+
+        #[test]
+        fn planned_fetch_artifact_entries_is_empty_when_plan_needs_no_content() {
+            let manifests = vec![json!({
+                "project": { "project_id": "proj_one" },
+                "artifacts": [{
+                    "artifact_id": "art_one",
+                    "project_id": "proj_one",
+                    "content_sha256": "hash_a",
+                    "size_bytes": 10
+                }]
+            })];
+            let plan = json!({
+                "actions": [{
+                    "action_type": "noop",
+                    "item_type": "artifact",
+                    "item_id": "art_one",
+                    "project_id": "proj_one",
+                    "content_sha256": "hash_a",
+                    "priority": 10
+                }]
+            });
+
+            assert!(planned_fetch_artifact_entries(&plan, &manifests).is_empty());
+        }
+
+        #[test]
+        fn batch_apply_response_maps_projects_to_imported_skipped_and_failed() {
+            let manifests = vec![
+                json!({ "project": { "project_id": "proj_imported" }, "artifacts": [] }),
+                json!({ "project": { "project_id": "proj_skipped" }, "artifacts": [] }),
+                json!({ "project": { "project_id": "proj_conflicted" }, "artifacts": [] }),
+                json!({ "project": { "project_id": "proj_failed" }, "artifacts": [] }),
+            ];
+            let response = json!({
+                "results": [
+                    {
+                        "action": {
+                            "action_type": "fetch_artifact_content",
+                            "item_type": "artifact",
+                            "item_id": "art_imported",
+                            "project_id": "proj_imported"
+                        },
+                        "status": "satisfied",
+                        "reason": "Required artifact content is staged."
+                    },
+                    {
+                        "action": {
+                            "action_type": "import_project_manifest",
+                            "item_type": "project",
+                            "item_id": "proj_imported",
+                            "project_id": "proj_imported"
+                        },
+                        "status": "applied",
+                        "reason": "Project manifest was imported."
+                    },
+                    {
+                        "action": {
+                            "action_type": "record_conflict",
+                            "item_type": "project",
+                            "item_id": "proj_conflicted",
+                            "project_id": "proj_conflicted",
+                            "reason": "Local and remote project data diverged."
+                        },
+                        "status": "skipped",
+                        "reason": "Conflict persistence is not available through existing sync services."
+                    },
+                    {
+                        "action": {
+                            "action_type": "upsert_project_status",
+                            "item_type": "project",
+                            "item_id": "proj_conflicted",
+                            "project_id": "proj_conflicted",
+                            "details": {
+                                "project_status": "conflicted"
+                            }
+                        },
+                        "status": "applied",
+                        "reason": "Marked project conflicted."
+                    },
+                    {
+                        "action": {
+                            "action_type": "import_project_manifest",
+                            "item_type": "project",
+                            "item_id": "proj_failed",
+                            "project_id": "proj_failed"
+                        },
+                        "status": "failed",
+                        "reason": "Project manifest import failed."
+                    }
+                ]
+            });
+
+            let results = map_batch_apply_response(&manifests, &response);
+
+            assert_eq!(results.len(), 4);
+            assert_eq!(results[0].project_id, "proj_imported");
+            assert_eq!(results[0].status, "imported");
+            assert_eq!(results[1].project_id, "proj_skipped");
+            assert_eq!(results[1].status, "skipped");
+            assert_eq!(results[2].project_id, "proj_conflicted");
+            assert_eq!(results[2].status, "conflicted");
+            assert_eq!(
+                results[2].message.as_deref(),
+                Some(
+                    "Reconciliation apply: 1 applied, 0 satisfied, 1 skipped, 0 failed, 2 conflicted action(s). Local and remote project data diverged."
+                )
+            );
+            assert_eq!(results[3].project_id, "proj_failed");
+            assert_eq!(results[3].status, "failed");
+
+            let counts = import_outcome_counts(&results);
+            assert_eq!(
+                counts,
+                ImportOutcomeCounts {
+                    imported: 1,
+                    skipped: 1,
+                    failed: 2,
+                }
+            );
+        }
+
+        #[test]
+        fn sync_result_summary_distinguishes_import_skips_and_failures() {
+            let counts = ImportOutcomeCounts {
+                imported: 2,
+                skipped: 1,
+                failed: 1,
+            };
+
+            assert_eq!(
+                sync_result_status(&[], counts.failed),
+                "completed_with_errors"
+            );
+            assert_eq!(
+                sync_result_message(4, 5, 6, counts),
+                "Exchanged 4 local and 5 remote manifest(s); imported 2 project(s), skipped 1 project(s), failed 1 project(s), received 6 artifact(s)."
+            );
+        }
+
+        #[test]
+        fn sync_manifest_errors_include_local_and_peer_export_failures() {
+            let local_errors = vec![SyncTransportManifestError {
+                project_id: "proj_local".to_string(),
+                message: "local failure".to_string(),
+            }];
+            let remote_errors = vec![SyncTransportManifestError {
+                project_id: "proj_peer".to_string(),
+                message: "peer failure".to_string(),
+            }];
+
+            let errors = sync_manifest_errors(&local_errors, &remote_errors);
+
+            assert_eq!(errors.len(), 2);
+            assert_eq!(errors[0].project_id, "proj_local");
+            assert_eq!(
+                errors[0].message,
+                "Local manifest export failed: local failure"
+            );
+            assert_eq!(errors[1].project_id, "proj_peer");
+            assert_eq!(
+                errors[1].message,
+                "Peer manifest export failed: peer failure"
+            );
+            assert_eq!(sync_result_status(&errors, 0), "completed_with_errors");
+        }
+
+        #[test]
+        fn temp_artifact_path_is_unique_per_transfer() {
+            let first = temp_artifact_path("hash_same");
+            let second = temp_artifact_path("hash_same");
+
+            assert_ne!(first, second);
+        }
+
+        #[test]
+        fn available_content_sha256_deduplicates_received_and_already_staged_artifacts() {
+            let received_artifacts = vec![
+                SyncTransportTransferResult {
+                    artifact_id: "art_one".to_string(),
+                    content_sha256: "hash_b".to_string(),
+                    size_bytes: 10,
+                    status: "received".to_string(),
+                    message: None,
+                },
+                SyncTransportTransferResult {
+                    artifact_id: "art_two".to_string(),
+                    content_sha256: "hash_a".to_string(),
+                    size_bytes: 20,
+                    status: "already_staged".to_string(),
+                    message: None,
+                },
+                SyncTransportTransferResult {
+                    artifact_id: "art_three".to_string(),
+                    content_sha256: "hash_b".to_string(),
+                    size_bytes: 10,
+                    status: "already_staged".to_string(),
+                    message: None,
+                },
+            ];
+
+            assert_eq!(
+                available_content_sha256(&received_artifacts),
+                vec!["hash_a".to_string(), "hash_b".to_string()]
+            );
+        }
+
+        #[test]
         fn percent_decode_preserves_plain_base64url_device_ids() {
             assert_eq!(
                 percent_decode("dev_ed25519_abc-DEF_123"),
@@ -2147,6 +2907,7 @@ mod android_stub {
             failed_sessions: 0,
             last_status: None,
             last_error: Some("Sync transport is only available on desktop.".to_string()),
+            last_sync: None,
         }
     }
 

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -18,6 +18,7 @@ import {
   resetAppTestHarness,
   setJobs,
   setProjects,
+  setSyncTransportStatus,
   setSyncTrustedPeers,
 } from "./test/appTestHarness";
 
@@ -194,7 +195,144 @@ describe("Desktop app activity", () => {
     await user.click(within(peerRow as HTMLElement).getByRole("button", { name: "Sync Now" }));
 
     await waitFor(() => expect(mockSyncTrustedPeerNow).toHaveBeenCalledWith("device_peer_1"));
-    expect(await screen.findAllByText("Manifest exchange completed.")).not.toHaveLength(0);
+    expect(await screen.findAllByText("Manifest exchange completed with 4 project results.")).not.toHaveLength(0);
+
+    const projectResults = await screen.findByRole("list", { name: "Last sync project results" });
+    const resultRows = within(projectResults).getAllByRole("listitem");
+    expect(resultRows).toHaveLength(4);
+    expect(within(resultRows[0]).getByText("Applied")).toBeInTheDocument();
+    expect(within(resultRows[0]).getByText("proj_imported")).toBeInTheDocument();
+    expect(within(resultRows[0]).getByText("Reconciliation apply: 3 applied, 1 satisfied, 0 skipped, 0 failed.")).toBeInTheDocument();
+    expect(within(resultRows[1]).getByText("Skipped")).toBeInTheDocument();
+    expect(within(resultRows[1]).getByText("proj_up_to_date")).toBeInTheDocument();
+    expect(within(resultRows[2]).getByText("Conflicted")).toBeInTheDocument();
+    expect(within(resultRows[2]).getByText("Local lyrics conflict with the trusted peer revision.")).toBeInTheDocument();
+    expect(within(resultRows[3]).getByText("Failed")).toBeInTheDocument();
+    expect(within(resultRows[3]).getByText("proj_missing_audio")).toBeInTheDocument();
+    expect(within(resultRows[3]).getByText("Peer did not provide the required source audio.")).toBeInTheDocument();
+  });
+
+  it("shows listener-side sync project results from native status", async () => {
+    const user = userEvent.setup();
+    setSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: ["tcp://192.168.1.57:48625"],
+      last_status: "Sync session completed without structured details.",
+      last_sync: {
+        peer_device_id: "device_peer_1",
+        remote_device_id: "device_peer_1",
+        status: "completed_with_errors",
+        message:
+          "Exchanged 0 local and 2 remote manifest(s); imported 0 project(s), skipped 0 project(s), failed 2 project(s), received 16 artifact(s).",
+        project_results: [
+          {
+            project_id: "proj_conflicted",
+            status: "conflicted",
+            message: "Entity revision manifest content_sha256 must match payload.",
+          },
+        ],
+        manifest_errors: [],
+        received_artifacts: [],
+        served_artifact_requests: 0,
+        local_manifest_count: 0,
+        remote_manifest_count: 2,
+      },
+    });
+
+    await openSyncTab(user);
+
+    expect(
+      await screen.findByText(
+        "Exchanged 0 local and 2 remote manifest(s); imported 0 project(s), skipped 0 project(s), failed 2 project(s), received 16 artifact(s).",
+      ),
+    ).toBeInTheDocument();
+    const projectResults = await screen.findByRole("list", { name: "Last sync project results" });
+    const resultRows = within(projectResults).getAllByRole("listitem");
+    expect(resultRows).toHaveLength(1);
+    expect(within(resultRows[0]).getByText("Conflicted")).toBeInTheDocument();
+    expect(within(resultRows[0]).getByText("proj_conflicted")).toBeInTheDocument();
+    expect(
+      within(resultRows[0]).getByText("Entity revision manifest content_sha256 must match payload."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows newer listener sync results after a prior sync now result", async () => {
+    const user = userEvent.setup();
+    setSyncTrustedPeers([
+      {
+        device_id: "device_peer_1",
+        sync_group_id: "sync_group_local",
+        display_name: "Laptop Rig",
+        public_key: "pub_peer_1",
+        endpoint_hints: ["tcp://192.168.1.57:48625"],
+        trusted_at: "2026-04-18T13:16:00.000Z",
+      },
+    ]);
+    setSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: ["tcp://192.168.1.57:48625"],
+      last_sync: {
+        peer_device_id: "device_peer_1",
+        remote_device_id: "device_peer_1",
+        status: "completed",
+        message: "Listener import completed before sync now.",
+        project_results: [
+          {
+            project_id: "proj_listener_old",
+            status: "imported",
+            message: "Old listener result.",
+          },
+        ],
+        manifest_errors: [],
+        received_artifacts: [],
+        served_artifact_requests: 0,
+        local_manifest_count: 0,
+        remote_manifest_count: 1,
+      },
+    });
+    await openSyncTab(user);
+
+    const peers = await screen.findByRole("list", { name: "Trusted sync peers" });
+    const peerRow = within(peers).getByText("Laptop Rig").closest("li");
+    expect(peerRow).not.toBeNull();
+    await user.click(within(peerRow as HTMLElement).getByRole("button", { name: "Sync Now" }));
+
+    expect(await screen.findAllByText("Manifest exchange completed with 4 project results.")).not.toHaveLength(0);
+    expect(screen.getByText("proj_imported")).toBeInTheDocument();
+
+    setSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: ["tcp://192.168.1.57:48625"],
+      last_sync: {
+        peer_device_id: "device_peer_1",
+        remote_device_id: "device_peer_1",
+        status: "completed",
+        message: "Listener import completed after sync now.",
+        project_results: [
+          {
+            project_id: "proj_listener_new",
+            status: "imported",
+            message: "New listener result.",
+          },
+        ],
+        manifest_errors: [],
+        received_artifacts: [],
+        served_artifact_requests: 0,
+        local_manifest_count: 0,
+        remote_manifest_count: 1,
+      },
+    });
+    fireEvent.change(screen.getByLabelText("Peer offer or response payload"), {
+      target: { value: JSON.stringify(pairingPayload({ device_id: "device_peer_2" })) },
+    });
+    await user.click(screen.getByRole("button", { name: "Answer Offer" }));
+
+    expect(await screen.findByText("Listener import completed after sync now.")).toBeInTheDocument();
+    expect(screen.getByText("proj_listener_new")).toBeInTheDocument();
+    expect(screen.queryByText("proj_imported")).not.toBeInTheDocument();
   });
 
   it("shows project links and pending queue positions in queue order", async () => {

--- a/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
+++ b/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   api,
   type SyncPairingPayloadSchema,
+  type SyncTransportProjectResult,
   type SyncTransportRunStatus,
   type SyncTrustedPeerSchema,
 } from "../../lib/api";
@@ -135,6 +136,51 @@ function syncStatusText(status: SyncTransportRunStatus | null | undefined, peers
   return status.message ?? `${statusLabel(status.status)} for ${peerName}.`;
 }
 
+function syncResultKey(status: SyncTransportRunStatus | null | undefined) {
+  if (!status) {
+    return null;
+  }
+  return JSON.stringify({
+    peer: status.peer_device_id,
+    remote: status.remote_device_id,
+    status: status.status,
+    message: status.message,
+    projects: status.project_results.map((result) => [
+      result.project_id,
+      result.status,
+      result.message ?? null,
+    ]),
+    receivedArtifacts: status.received_artifacts.length,
+    remoteManifests: status.remote_manifest_count,
+    localManifests: status.local_manifest_count,
+  });
+}
+
+function syncProjectResultText(result: SyncTransportProjectResult) {
+  return result.message?.trim() || `${statusLabel(result.status)}.`;
+}
+
+function syncProjectResultList(status: SyncTransportRunStatus | null | undefined) {
+  const results = status?.project_results ?? [];
+  if (!results.length) {
+    return null;
+  }
+  return (
+    <ul className="activity-sync-project-results" aria-label="Last sync project results">
+      {results.map((result, index) => (
+        <li
+          className={`activity-sync-project-result activity-sync-project-result--${statusClassName(result.status)}`}
+          key={`${result.project_id}-${result.status}-${index}`}
+        >
+          <span className="activity-sync-project-result__status">{statusLabel(result.status)}</span>
+          <span className="activity-sync-project-result__project">{result.project_id}</span>
+          <span className="activity-sync-project-result__message">{syncProjectResultText(result)}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 function endpointList(endpointHints: string[]) {
   if (!endpointHints.length) {
     return <span>No listener endpoints announced.</span>;
@@ -157,6 +203,8 @@ export function ActivitySyncPanel() {
   const [pairingMessage, setPairingMessage] = useState<string | null>(null);
   const [pairingError, setPairingError] = useState<string | null>(null);
   const [lastSyncMessage, setLastSyncMessage] = useState<string | null>(null);
+  const [lastSyncResult, setLastSyncResult] = useState<SyncTransportRunStatus | null>(null);
+  const [hiddenListenerSyncKey, setHiddenListenerSyncKey] = useState<string | null>(null);
 
   const identityQuery = useQuery({
     queryKey: ["sync", "identity"],
@@ -178,7 +226,16 @@ export function ActivitySyncPanel() {
   const endpointHints = listenerQuery.data?.endpoint_hints ?? [];
   const listenerActive = listenerQuery.data?.active ?? false;
   const listenerStatus = listenerQuery.isError ? "unavailable" : listenerQuery.data?.status ?? "checking";
-  const lastSyncStatus = listenerQuery.data?.last_status ?? syncStatusText(listenerQuery.data?.last_sync, peersById);
+  const listenerSyncResult = listenerQuery.data?.last_sync ?? null;
+  const listenerSyncKey = useMemo(() => syncResultKey(listenerSyncResult), [listenerSyncResult]);
+  const showListenerSyncResult = listenerSyncResult !== null && listenerSyncKey !== hiddenListenerSyncKey;
+  const lastSyncStatus = listenerSyncResult
+    ? syncStatusText(listenerSyncResult, peersById)
+    : listenerQuery.data?.last_status ?? syncStatusText(listenerSyncResult, peersById);
+  const visibleSyncResult = showListenerSyncResult ? listenerSyncResult : lastSyncResult ?? listenerSyncResult;
+  const displayedLastSyncMessage = !showListenerSyncResult
+    ? lastSyncMessage ?? lastSyncStatus
+    : lastSyncStatus;
 
   const refreshSyncQueries = async () => {
     await Promise.all([
@@ -191,6 +248,8 @@ export function ActivitySyncPanel() {
     mutationFn: () => api.startSyncListener(),
     onSuccess: async () => {
       setLastSyncMessage("Sync listener started.");
+      setLastSyncResult(null);
+      setHiddenListenerSyncKey(null);
       await refreshSyncQueries();
     },
   });
@@ -198,6 +257,8 @@ export function ActivitySyncPanel() {
     mutationFn: () => api.stopSyncListener(),
     onSuccess: async () => {
       setLastSyncMessage("Sync listener stopped.");
+      setLastSyncResult(null);
+      setHiddenListenerSyncKey(null);
       await refreshSyncQueries();
     },
   });
@@ -271,6 +332,8 @@ export function ActivitySyncPanel() {
     mutationFn: (deviceId: string) => api.revokeSyncTrustedPeer(deviceId),
     onSuccess: async (response) => {
       setLastSyncMessage(`Revoked ${peerLabel(response.trusted_peer)}.`);
+      setLastSyncResult(null);
+      setHiddenListenerSyncKey(null);
       await refreshSyncQueries();
     },
   });
@@ -278,10 +341,14 @@ export function ActivitySyncPanel() {
     mutationFn: (deviceId: string) => api.syncTrustedPeerNow(deviceId),
     onSuccess: async (status) => {
       setLastSyncMessage(syncStatusText(status, peersById));
+      setLastSyncResult(status);
+      setHiddenListenerSyncKey(listenerSyncKey);
       await refreshSyncQueries();
     },
     onError: () => {
       setLastSyncMessage("Sync now failed.");
+      setLastSyncResult(null);
+      setHiddenListenerSyncKey(null);
     },
   });
 
@@ -362,7 +429,10 @@ export function ActivitySyncPanel() {
             </div>
             <div>
               <dt>Last Sync</dt>
-              <dd>{lastSyncMessage ?? lastSyncStatus}</dd>
+              <dd className="activity-sync-last-sync">
+                <span>{displayedLastSyncMessage}</span>
+                {syncProjectResultList(visibleSyncResult)}
+              </dd>
             </div>
             {lastListenerUpdatedAt ? (
               <div>

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -75,11 +75,34 @@ export type ProjectSyncSummary = {
 };
 export type SyncTransportRunStatus = {
   peer_device_id?: string | null;
+  remote_device_id?: string | null;
   status: string;
   message?: string | null;
   started_at?: string | null;
   completed_at?: string | null;
   error?: string | null;
+  project_results: SyncTransportProjectResult[];
+  manifest_errors: SyncTransportManifestError[];
+  received_artifacts: SyncTransportTransferResult[];
+  served_artifact_requests?: number | null;
+  local_manifest_count?: number | null;
+  remote_manifest_count?: number | null;
+};
+export type SyncTransportProjectResult = {
+  project_id: string;
+  status: string;
+  message?: string | null;
+};
+export type SyncTransportManifestError = {
+  project_id: string;
+  message: string;
+};
+export type SyncTransportTransferResult = {
+  artifact_id: string;
+  content_sha256?: string | null;
+  size_bytes?: number | null;
+  status: string;
+  message?: string | null;
 };
 export type SyncTransportStatus = {
   active: boolean;
@@ -172,6 +195,21 @@ function numberField(record: Record<string, unknown> | null, keys: string[]) {
     }
   }
   return null;
+}
+
+function recordArrayField(record: Record<string, unknown> | null, keys: string[]) {
+  if (!record) {
+    return [];
+  }
+  for (const key of keys) {
+    const value = record[key];
+    if (Array.isArray(value)) {
+      return value
+        .map((item) => asRecord(item))
+        .filter((item): item is Record<string, unknown> => item !== null);
+    }
+  }
+  return [];
 }
 
 function normalizeProjectSyncState(value: string | null) {
@@ -269,41 +307,106 @@ async function invokeDesktopNative<T>(command: string, args?: Record<string, unk
   return invoke<T>(command, args);
 }
 
+function normalizeTransportStatusToken(value: string) {
+  return value.trim().toLowerCase().replace(/[\s-]+/g, "_");
+}
+
+function normalizeSyncProjectResult(
+  value: unknown,
+  fallbackStatus = "failed",
+  fallbackMessage: string | null = null,
+): SyncTransportProjectResult | null {
+  const record = asRecord(value);
+  if (!record) {
+    return null;
+  }
+  return {
+    project_id: firstStringField([record], ["project_id", "projectId", "id"]) ?? "unknown",
+    status: normalizeTransportStatusToken(
+      firstStringField([record], ["status", "state", "result"]) ?? fallbackStatus,
+    ),
+    message: firstStringField([record], ["message", "error", "reason"]) ?? fallbackMessage,
+  };
+}
+
+function normalizeSyncManifestError(value: unknown): SyncTransportManifestError | null {
+  const record = asRecord(value);
+  if (!record) {
+    return null;
+  }
+  const message = firstStringField([record], ["message", "error", "reason"]);
+  if (!message) {
+    return null;
+  }
+  return {
+    project_id: firstStringField([record], ["project_id", "projectId", "id"]) ?? "unknown",
+    message,
+  };
+}
+
+function normalizeSyncTransferResult(value: unknown): SyncTransportTransferResult | null {
+  const record = asRecord(value);
+  if (!record) {
+    return null;
+  }
+  return {
+    artifact_id: firstStringField([record], ["artifact_id", "artifactId", "id"]) ?? "unknown",
+    content_sha256: firstStringField([record], ["content_sha256", "contentSha256"]),
+    size_bytes: numberField(record, ["size_bytes", "sizeBytes"]),
+    status: normalizeTransportStatusToken(
+      firstStringField([record], ["status", "state", "result"]) ?? "completed",
+    ),
+    message: firstStringField([record], ["message", "error", "reason"]),
+  };
+}
+
+const SYNC_PROJECT_RESULT_PROBLEM_STATES = new Set(["completed_with_errors", "conflicted", "error", "failed"]);
+
 function normalizeSyncRunStatus(value: unknown): SyncTransportRunStatus | null {
   const record = asRecord(value);
   if (!record) {
     return null;
   }
-  const manifestErrorCount = Array.isArray(record.manifest_errors)
-    ? record.manifest_errors.length
-    : Array.isArray(record.manifestErrors)
-      ? record.manifestErrors.length
-      : 0;
-  const importedProjectCount = Array.isArray(record.imported_projects)
-    ? record.imported_projects.length
-    : Array.isArray(record.importedProjects)
-      ? record.importedProjects.length
-      : 0;
-  const receivedArtifactCount = Array.isArray(record.received_artifacts)
-    ? record.received_artifacts.length
-    : Array.isArray(record.receivedArtifacts)
-      ? record.receivedArtifacts.length
-      : 0;
+  const manifestErrors = recordArrayField(record, ["manifest_errors", "manifestErrors"])
+    .map((item) => normalizeSyncManifestError(item))
+    .filter((item): item is SyncTransportManifestError => item !== null);
+  const importedProjectResults = recordArrayField(record, ["project_results", "projectResults", "imported_projects", "importedProjects"])
+    .map((item) => normalizeSyncProjectResult(item))
+    .filter((item): item is SyncTransportProjectResult => item !== null);
+  const manifestErrorProjectResults = manifestErrors.map((error) => ({
+    project_id: error.project_id,
+    status: "failed",
+    message: error.message,
+  }));
+  const projectResults = [...importedProjectResults, ...manifestErrorProjectResults];
+  const receivedArtifacts = recordArrayField(record, ["received_artifacts", "receivedArtifacts", "artifacts"])
+    .map((item) => normalizeSyncTransferResult(item))
+    .filter((item): item is SyncTransportTransferResult => item !== null);
   const localManifestCount = numberField(record, ["local_manifest_count", "localManifestCount"]);
   const remoteManifestCount = numberField(record, ["remote_manifest_count", "remoteManifestCount"]);
+  const hasProjectProblems = projectResults.some((result) =>
+    SYNC_PROJECT_RESULT_PROBLEM_STATES.has(result.status),
+  );
   const status = firstStringField([record], ["status", "state"]) ??
-    (manifestErrorCount > 0 ? "completed_with_errors" : "completed");
+    (manifestErrors.length > 0 || hasProjectProblems ? "completed_with_errors" : "completed");
   const summary =
     localManifestCount !== null || remoteManifestCount !== null
-      ? `Exchanged ${localManifestCount ?? 0} local and ${remoteManifestCount ?? 0} remote manifest(s); imported ${importedProjectCount} project(s), received ${receivedArtifactCount} artifact(s).`
+      ? `Exchanged ${localManifestCount ?? 0} local and ${remoteManifestCount ?? 0} remote manifest(s); processed ${projectResults.length} project(s), received ${receivedArtifacts.length} artifact(s).`
       : null;
   return {
     peer_device_id: firstStringField([record], ["peer_device_id", "peerDeviceId", "device_id", "deviceId"]),
+    remote_device_id: firstStringField([record], ["remote_device_id", "remoteDeviceId"]),
     status,
     message: firstStringField([record], ["message", "status_message", "statusMessage"]) ?? summary,
     started_at: firstStringField([record], ["started_at", "startedAt"]),
     completed_at: firstStringField([record], ["completed_at", "completedAt"]),
     error: firstStringField([record], ["error", "last_error", "lastError"]),
+    project_results: projectResults,
+    manifest_errors: manifestErrors,
+    received_artifacts: receivedArtifacts,
+    served_artifact_requests: numberField(record, ["served_artifact_requests", "servedArtifactRequests"]),
+    local_manifest_count: localManifestCount,
+    remote_manifest_count: remoteManifestCount,
   };
 }
 

--- a/apps/desktop/src/styles/activity.css
+++ b/apps/desktop/src/styles/activity.css
@@ -273,6 +273,70 @@
   padding-left: 1.1rem;
 }
 
+.activity-sync-last-sync {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.activity-sync-project-results {
+  display: grid;
+  gap: 0.35rem;
+  margin: 0.1rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.activity-sync-project-result {
+  display: grid;
+  grid-template-columns: auto minmax(6rem, 0.32fr) minmax(0, 1fr);
+  gap: 0.45rem;
+  align-items: start;
+  border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+  border-radius: 8px;
+  padding: 0.35rem 0.45rem;
+  background: color-mix(in srgb, var(--surface-muted) 54%, transparent);
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+.activity-sync-project-result__status {
+  display: inline-flex;
+  width: fit-content;
+  border: 1px solid color-mix(in srgb, var(--chip-border) 82%, transparent);
+  border-radius: 999px;
+  padding: 0.12rem 0.4rem;
+  background: color-mix(in srgb, var(--chip-bg) 78%, transparent);
+  color: var(--text);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.activity-sync-project-result__project {
+  color: var(--text);
+  font-weight: 760;
+  overflow-wrap: anywhere;
+}
+
+.activity-sync-project-result__message {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.activity-sync-project-result--conflicted,
+.activity-sync-project-result--failed {
+  border-color: color-mix(in srgb, var(--danger) 34%, var(--divider));
+}
+
+.activity-sync-project-result--conflicted .activity-sync-project-result__status,
+.activity-sync-project-result--failed .activity-sync-project-result__status {
+  border-color: color-mix(in srgb, var(--danger) 42%, var(--chip-border));
+  color: var(--danger);
+}
+
+.activity-sync-project-result--skipped .activity-sync-project-result__status {
+  color: var(--muted);
+}
+
 .activity-sync-field {
   display: grid;
   gap: 0.45rem;
@@ -374,6 +438,10 @@
 
   .activity-sync-grid,
   .activity-sync-peer-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .activity-sync-project-result {
     grid-template-columns: minmax(0, 1fr);
   }
 

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -8,6 +8,7 @@ import type {
   SyncPairingAnswerResponse,
   SyncPairingOfferRequest,
   SyncPairingOfferResponse,
+  SyncTransportRunStatus,
   SyncTrustedPeerSchema,
   SyncTrustedPeerCreateRequest,
   SyncTrustedPeerResponse,
@@ -1323,21 +1324,63 @@ const {
       }),
     };
   });
-  const mockSyncTrustedPeerNow = vi.fn(async (deviceId: string) => {
+  const mockSyncTrustedPeerNow = vi.fn(async (deviceId: string): Promise<SyncTransportRunStatus> => {
+    const syncResult: SyncTransportRunStatus = {
+      peer_device_id: deviceId,
+      remote_device_id: deviceId,
+      status: "completed_with_errors",
+      message: "Manifest exchange completed with 4 project results.",
+      started_at: createdAt,
+      completed_at: createdAt,
+      error: null,
+      project_results: [
+        {
+          project_id: "proj_imported",
+          status: "applied",
+          message: "Reconciliation apply: 3 applied, 1 satisfied, 0 skipped, 0 failed.",
+        },
+        {
+          project_id: "proj_up_to_date",
+          status: "skipped",
+          message: "Reconciliation apply: 0 applied, 0 satisfied, 2 skipped, 0 failed.",
+        },
+        {
+          project_id: "proj_conflict",
+          status: "conflicted",
+          message: "Local lyrics conflict with the trusted peer revision.",
+        },
+        {
+          project_id: "proj_missing_audio",
+          status: "failed",
+          message: "Peer did not provide the required source audio.",
+        },
+      ],
+      manifest_errors: [
+        {
+          project_id: "proj_missing_audio",
+          message: "Peer did not provide the required source audio.",
+        },
+      ],
+      received_artifacts: [
+        {
+          artifact_id: "art_imported_source",
+          content_sha256: "sha256-imported-source",
+          size_bytes: 4096,
+          status: "received",
+          message: "Received source audio.",
+        },
+      ],
+      served_artifact_requests: 1,
+      local_manifest_count: 2,
+      remote_manifest_count: 4,
+    };
     state.syncTransportStatus = {
       ...state.syncTransportStatus,
-      last_sync: {
-        peer_device_id: deviceId,
-        status: "completed",
-        message: "Manifest exchange completed.",
-        started_at: createdAt,
-        completed_at: createdAt,
-        error: null,
-      },
+      last_sync: syncResult,
       last_error: null,
       updated_at: createdAt,
     };
-    return clone(state.syncTransportStatus.last_sync);
+    return clone(syncResult);
   });
   const mockCreateChords = vi.fn(async (projectId: string, body?: Record<string, unknown>) => {
     state.chordsByProject[projectId] = makeChordTimeline(projectId);


### PR DESCRIPTION
## Summary
- Batch native sync imports so all remote artifacts are staged before one reconciliation apply.
- Add Linux/macOS LAN sync reporting for imported, skipped, failed, and conflicted projects.
- Preserve synced project files, artifact rows, analysis hydration, duplicate-source handling, tombstones, and edit-lock metadata.
- Stabilize the listener port across app restarts so trusted peers can reconnect without re-pairing when addresses remain valid.

Closes #119

## Testing
- `cd apps/backend && uv run --python 3.11 pytest tests/test_sync_reconciliation.py tests/test_sync_reconciliation_apply_api.py tests/test_sync_reconciliation_apply_batch_import.py tests/test_sync_staging.py`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `pnpm --filter @tuneforge/desktop test --run src/App.activity.test.tsx`
- `pnpm --filter @tuneforge/desktop typecheck`
- `cd apps/desktop/src-tauri && cargo test sync_transport`
- `cd apps/desktop/src-tauri && cargo check`
- `git diff --check`
- Manual macOS/Linux sync smoke: clean mac-to-linux import, linux-to-mac import, restart without re-pairing on stable port, pull after restart, and duplicate-source sync.