### PR TITLE
fix: validate three-peer sync

### DIFF
--- a/apps/backend/app/services/projects.py
+++ b/apps/backend/app/services/projects.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 
 from app.config import get_settings
 from app.errors import AppError
-from app.models import Artifact, Project, SyncEntityRevision
+from app.models import Artifact, Project, SyncDeleteTombstone, SyncEntityRevision
 from app.services.artifacts import register_artifact
 from app.services.metadata import extract_audio_metadata, normalize_audio_to_wav
 from app.services.paths import ensure_project_dirs, project_root, project_source_dir
@@ -18,6 +18,7 @@ from app.services.sync_identity import source_hash_to_project_id
 from app.services.sync_project_status import require_project_sync_editable
 from app.services.sync_revisions import record_project_metadata_revision
 from app.services.sync_tombstones import (
+    PROJECT_TARGET_TYPE,
     record_artifact_delete_tombstone,
     record_entity_revision_delete_tombstone,
     record_project_delete_tombstone,
@@ -41,7 +42,7 @@ def _validate_import_path(source_path: Path) -> None:
 
 
 def list_projects(session: Session, *, search: str | None = None) -> list[Project]:
-    stmt = select(Project)
+    stmt = select(Project).where(Project.sync_status != "deleted")
     normalized_search = (search or "").strip().lower()
     if normalized_search:
         like_term = f"%{normalized_search}%"
@@ -95,6 +96,48 @@ def _find_existing_source_project(
     )
 
 
+def _discard_deleted_project_placeholder(
+    session: Session,
+    *,
+    project_id: str,
+    source_sha256: str,
+) -> None:
+    placeholders = list(
+        session.scalars(
+            select(Project)
+            .where(Project.sync_status == "deleted")
+            .where(or_(Project.id == project_id, Project.source_sha256 == source_sha256))
+            .order_by(Project.created_at.asc(), Project.id.asc())
+        )
+    )
+    if not placeholders:
+        return
+
+    for project in placeholders:
+        root = project_root(project.id)
+        session.delete(project)
+        if root.exists():
+            shutil.rmtree(root, ignore_errors=True)
+    session.flush()
+
+
+def _clear_project_delete_tombstones_for_reimport(session: Session, *, project_id: str) -> None:
+    tombstones = list(
+        session.scalars(
+            select(SyncDeleteTombstone).where(
+                SyncDeleteTombstone.target_type == PROJECT_TARGET_TYPE,
+                SyncDeleteTombstone.target_id == project_id,
+            )
+        )
+    )
+    if not tombstones:
+        return
+
+    for tombstone in tombstones:
+        session.delete(tombstone)
+    session.flush()
+
+
 def import_project(
     session: Session,
     *,
@@ -114,6 +157,11 @@ def import_project(
         )
 
     project_id = source_hash_to_project_id(source_sha256)
+    _discard_deleted_project_placeholder(
+        session,
+        project_id=project_id,
+        source_sha256=source_sha256,
+    )
     existing_project = _find_existing_source_project(
         session,
         project_id=project_id,
@@ -121,6 +169,7 @@ def import_project(
     )
     if existing_project is not None:
         raise _duplicate_project_source_error(existing_project.id, existing_project.display_name)
+    _clear_project_delete_tombstones_for_reimport(session, project_id=project_id)
 
     metadata = extract_audio_metadata(resolved_source)
     source_dir = project_source_dir(project_id)

--- a/apps/backend/app/services/sync_manifest.py
+++ b/apps/backend/app/services/sync_manifest.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess
 from collections.abc import Mapping
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any, cast
@@ -241,13 +241,22 @@ def import_staged_project_manifest(
     project: Project | None = None
     upgrading_placeholder = False
     if existing_project is not None:
-        if existing_project.id == project_manifest.project_id and project_manifest.delete_tombstones:
-            imported_tombstones = _import_delete_tombstones(session, project_manifest)
-            _apply_delete_tombstones(session, imported_tombstones)
-            return existing_project
         if _can_upgrade_project_placeholder(existing_project, project_manifest):
             project = existing_project
             upgrading_placeholder = True
+        elif existing_project.id == project_manifest.project_id:
+            root = project_root(project_manifest.project_id).resolve(strict=False)
+            staged_root = (
+                None if staging_root is None else Path(staging_root).expanduser().resolve(strict=False)
+            )
+            return _merge_staged_project_manifest(
+                session,
+                project=existing_project,
+                manifest=project_manifest,
+                staging_root=staged_root,
+                project_root_path=root,
+                use_content_addressed_staging=use_content_addressed_staging,
+            )
         else:
             raise _duplicate_project_source_error(existing_project.id, existing_project.display_name)
     _reject_manifest_artifact_conflicts(session, project_manifest)
@@ -351,6 +360,154 @@ def import_staged_project_manifest(
         raise
 
     return project
+
+
+def _merge_staged_project_manifest(
+    session: Session,
+    *,
+    project: Project,
+    manifest: SyncProjectManifest,
+    staging_root: Path | None,
+    project_root_path: Path,
+    use_content_addressed_staging: bool,
+) -> Project:
+    _validate_existing_project_matches_manifest(project, manifest)
+    _reject_existing_manifest_item_conflicts(session, manifest)
+
+    missing_artifacts = [
+        artifact
+        for artifact in manifest.artifacts
+        if session.get(Artifact, artifact.artifact_id) is None
+    ]
+    missing_revisions = [
+        revision
+        for revision in manifest.entity_revisions
+        if session.get(SyncEntityRevision, revision.revision_id) is None
+    ]
+    merge_manifest = replace(
+        manifest,
+        artifacts=missing_artifacts,
+        entity_revisions=missing_revisions,
+    )
+    verified_artifacts = (
+        []
+        if not missing_artifacts
+        else _verify_staged_artifacts(
+            session,
+            merge_manifest,
+            staging_root=staging_root,
+            project_root_path=project_root_path,
+            use_content_addressed_staging=use_content_addressed_staging,
+        )
+    )
+
+    ensure_project_dirs(project.id)
+    copied_paths: list[Path] = []
+    try:
+        for verified_artifact in verified_artifacts:
+            verified_artifact.destination_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(verified_artifact.staged_path, verified_artifact.destination_path)
+            copied_paths.append(verified_artifact.destination_path)
+        for verified_artifact in verified_artifacts:
+            imported_artifact = register_artifact(
+                session,
+                project_id=project.id,
+                artifact_type=verified_artifact.manifest.type,
+                artifact_format=verified_artifact.manifest.format,
+                path=verified_artifact.destination_path,
+                artifact_id=verified_artifact.manifest.artifact_id,
+                metadata=verified_artifact.manifest.metadata,
+                cache_key=verified_artifact.manifest.cache_key,
+                generated_by=verified_artifact.manifest.generated_by,
+                can_delete=verified_artifact.manifest.can_delete,
+                can_regenerate=verified_artifact.manifest.can_regenerate,
+                created_at=verified_artifact.manifest.created_at,
+            )
+            if (
+                imported_artifact.content_sha256 != verified_artifact.manifest.content_sha256
+                or imported_artifact.size_bytes != verified_artifact.manifest.size_bytes
+            ):
+                raise AppError(
+                    "SYNC_MANIFEST_IMPORTED_FILE_MISMATCH",
+                    "A copied artifact file does not match its manifest.",
+                    details={"artifact_id": verified_artifact.manifest.artifact_id},
+                )
+        _import_entity_revisions(session, merge_manifest)
+        imported_tombstones = _import_delete_tombstones(session, manifest)
+        _apply_delete_tombstones(session, imported_tombstones)
+        _hydrate_current_entity_revisions(session, project, missing_revisions)
+        hydrate_project_analysis_result_from_artifact(session, project.id)
+    except OSError as exc:
+        _cleanup_copied_artifacts(copied_paths, project_root_path)
+        raise AppError(
+            "SYNC_MANIFEST_COPY_FAILED",
+            "A staged artifact could not be copied into the local project store.",
+        ) from exc
+    except AppError:
+        _cleanup_copied_artifacts(copied_paths, project_root_path)
+        raise
+    except IntegrityError as exc:
+        _cleanup_copied_artifacts(copied_paths, project_root_path)
+        raise AppError(
+            "SYNC_MANIFEST_ARTIFACT_CONFLICT",
+            "A synced artifact conflicts with an existing local artifact.",
+            status_code=status.HTTP_409_CONFLICT,
+        ) from exc
+    except Exception:
+        _cleanup_copied_artifacts(copied_paths, project_root_path)
+        raise
+
+    session.flush()
+    return project
+
+
+def _validate_existing_project_matches_manifest(
+    project: Project,
+    manifest: SyncProjectManifest,
+) -> None:
+    if project.id != manifest.project_id or project.source_sha256 != manifest.source_sha256:
+        raise AppError(
+            "SYNC_MANIFEST_PROJECT_CONFLICT",
+            "A synced project manifest conflicts with an existing local project.",
+            status_code=status.HTTP_409_CONFLICT,
+            details={"project_id": manifest.project_id},
+        )
+
+
+def _reject_existing_manifest_item_conflicts(
+    session: Session,
+    manifest: SyncProjectManifest,
+) -> None:
+    for artifact in manifest.artifacts:
+        existing_artifact = session.get(Artifact, artifact.artifact_id)
+        if existing_artifact is None:
+            continue
+        if (
+            existing_artifact.project_id != manifest.project_id
+            or existing_artifact.content_sha256 != artifact.content_sha256
+            or existing_artifact.size_bytes != artifact.size_bytes
+        ):
+            raise AppError(
+                "SYNC_MANIFEST_ARTIFACT_CONFLICT",
+                "A synced artifact conflicts with an existing local artifact.",
+                status_code=status.HTTP_409_CONFLICT,
+                details={"artifact_id": artifact.artifact_id},
+            )
+
+    for revision in manifest.entity_revisions:
+        existing_revision = session.get(SyncEntityRevision, revision.revision_id)
+        if existing_revision is None:
+            continue
+        if (
+            existing_revision.project_id != manifest.project_id
+            or revision_payload_sha256(existing_revision.payload_json or {}) != revision.content_sha256
+        ):
+            raise AppError(
+                "SYNC_MANIFEST_ENTITY_REVISION_CONFLICT",
+                "A synced entity revision conflicts with an existing local revision.",
+                status_code=status.HTTP_409_CONFLICT,
+                details={"revision_id": revision.revision_id},
+            )
 
 
 def _list_project_entity_revisions(

--- a/apps/backend/app/services/sync_metadata.py
+++ b/apps/backend/app/services/sync_metadata.py
@@ -72,7 +72,13 @@ class SyncMetadataResult:
 
 
 def get_sync_metadata(session: Session) -> SyncMetadataResult:
-    projects = list(session.scalars(select(Project).order_by(Project.created_at.asc(), Project.id.asc())))
+    projects = list(
+        session.scalars(
+            select(Project)
+            .where(Project.sync_status != "deleted")
+            .order_by(Project.created_at.asc(), Project.id.asc())
+        )
+    )
     artifacts = list(
         session.scalars(
             select(Artifact).order_by(

--- a/apps/backend/app/services/sync_reconciliation.py
+++ b/apps/backend/app/services/sync_reconciliation.py
@@ -4,7 +4,7 @@ import json
 from collections import Counter
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any
 
@@ -220,7 +220,28 @@ def plan_sync_reconciliation(
         else:
             ignored_remote_tombstones.append((tombstone, reason))
 
-    effective_tombstones = _effective_tombstone_targets(local.tombstones, valid_remote_tombstones)
+    fresh_remote_tombstones: list[_RemoteTombstone] = []
+    for tombstone in valid_remote_tombstones:
+        if _project_tombstone_is_older_than_live_project(
+            target_type=tombstone.target_type,
+            project_id=tombstone.project_id,
+            deleted_at=tombstone.deleted_at,
+            local_projects=local.projects,
+            remote_projects=remote.projects,
+        ):
+            ignored_remote_tombstones.append(
+                (tombstone, "Project delete tombstone is older than a live project manifest.")
+            )
+        else:
+            fresh_remote_tombstones.append(tombstone)
+    valid_remote_tombstones = fresh_remote_tombstones
+
+    effective_tombstones = _effective_tombstone_targets(
+        local.tombstones,
+        valid_remote_tombstones,
+        local_projects=local.projects,
+        remote_projects=remote.projects,
+    )
 
     for tombstone, reason in sorted(ignored_remote_tombstones, key=lambda item: _remote_tombstone_sort_key(item[0])):
         _upsert_item(
@@ -270,12 +291,16 @@ def plan_sync_reconciliation(
             actions=actions,
         )
 
+    planned_project_ids = _planned_project_ids(actions)
     for artifact in sorted(remote.artifacts.values(), key=lambda artifact: (artifact.project_id, artifact.artifact_id)):
-        planned_project_ids = _planned_project_ids(actions)
         if (
             artifact.project_id in remote.project_manifests_by_id
             and artifact.artifact_id in remote.manifest_artifact_ids_by_project.get(artifact.project_id, frozenset())
             and not _is_deleted(ITEM_ARTIFACT, artifact.artifact_id, artifact.project_id, effective_tombstones)
+            and (
+                artifact.project_id in planned_project_ids
+                or not _has_imported_local_project(local, artifact.project_id)
+            )
         ):
             continue
         _plan_artifact(
@@ -292,6 +317,15 @@ def plan_sync_reconciliation(
     planned_revision_ids = set(local.entity_revisions)
     planned_remote_revisions_by_id: dict[str, _RemoteEntityRevision] = {}
     for revision in _sorted_remote_entity_revisions(remote.entity_revisions.values()):
+        local_revision = local.entity_revisions.get(revision.revision_id)
+        if (
+            revision.project_id in remote.project_manifests_by_id
+            and revision.revision_id in remote.manifest_revision_ids_by_project.get(revision.project_id, frozenset())
+            and local_revision is not None
+            and local_revision.project_id == revision.project_id
+            and _local_revision_content_sha256(local_revision) == revision.content_sha256
+        ):
+            continue
         if (
             revision.project_id in remote.project_manifests_by_id
             and revision.revision_id in remote.manifest_revision_ids_by_project.get(revision.project_id, frozenset())
@@ -300,6 +334,10 @@ def plan_sync_reconciliation(
                 revision.revision_id,
                 revision.project_id,
                 effective_tombstones,
+            )
+            and (
+                revision.project_id in planned_project_ids
+                or not _has_imported_local_project(local, revision.project_id)
             )
         ):
             continue
@@ -721,6 +759,7 @@ def _plan_project(
         return
 
     local_project = local.projects.get(project.project_id)
+    manifest = remote.project_manifests_by_id.get(project.project_id)
     if local_project is not None:
         if (
             project.source_sha256 is not None
@@ -756,7 +795,6 @@ def _plan_project(
             )
             return
 
-    manifest = remote.project_manifests_by_id.get(project.project_id)
     if manifest is None:
         reason = "Project manifest is required before import."
         _upsert_item(
@@ -1318,6 +1356,21 @@ def _plan_entity_revision(
     local_revision = local.entity_revisions.get(revision.revision_id)
     if local_revision is not None:
         local_content_sha256 = _local_revision_content_sha256(local_revision)
+        if local_revision.project_id != revision.project_id:
+            _record_conflict(
+                items_by_key,
+                actions,
+                item_type=ITEM_ENTITY_REVISION,
+                item_id=revision.revision_id,
+                project_id=revision.project_id,
+                content_sha256=revision.content_sha256,
+                reason="Remote entity revision ID is already used by a different local project.",
+                details={
+                    "local_project_id": local_revision.project_id,
+                    "remote_project_id": revision.project_id,
+                },
+            )
+            return False
         if local_content_sha256 == revision.content_sha256:
             _upsert_item(
                 items_by_key,
@@ -1515,11 +1568,17 @@ def _project_manifest_import_error(
     except AppError as exc:
         return exc.message, dict(exc.details)
 
-    artifact_conflicts = [
-        artifact.artifact_id
-        for artifact in manifest_artifacts
-        if artifact.artifact_id in local.artifacts
-    ]
+    artifact_conflicts = []
+    for artifact in manifest_artifacts:
+        local_artifact = local.artifacts.get(artifact.artifact_id)
+        if local_artifact is None:
+            continue
+        if (
+            local_artifact.project_id != project.project_id
+            or artifact.content_sha256 is None
+            or _normalize_sha256(local_artifact.content_sha256) != artifact.content_sha256
+        ):
+            artifact_conflicts.append(artifact.artifact_id)
     if artifact_conflicts:
         return (
             "A synced artifact conflicts with an existing local artifact.",
@@ -1534,11 +1593,16 @@ def _project_manifest_import_error(
             {"revision_ids": duplicate_revision_ids},
         )
 
-    revision_conflicts = [
-        revision.revision_id
-        for revision in manifest_revisions
-        if revision.revision_id in local.entity_revisions
-    ]
+    revision_conflicts = []
+    for revision in manifest_revisions:
+        local_revision = local.entity_revisions.get(revision.revision_id)
+        if local_revision is None:
+            continue
+        if _local_revision_content_sha256(local_revision) != revision.content_sha256:
+            revision_conflicts.append(revision.revision_id)
+            continue
+        if local_revision.project_id != project.project_id:
+            revision_conflicts.append(revision.revision_id)
     if revision_conflicts:
         return (
             "A synced entity revision conflicts with an existing local revision.",
@@ -1828,18 +1892,70 @@ def _duplicates(values: Iterable[str]) -> list[str]:
 def _effective_tombstone_targets(
     local_tombstones: Iterable[SyncDeleteTombstone],
     remote_tombstones: Iterable[_RemoteTombstone],
+    *,
+    local_projects: Mapping[str, Project],
+    remote_projects: Mapping[str, _RemoteProject],
 ) -> frozenset[tuple[str, str]]:
     targets: set[tuple[str, str]] = set()
     for local_tombstone in local_tombstones:
         target_type = _normalize_target_type(local_tombstone.target_type)
+        if _project_tombstone_is_older_than_live_project(
+            target_type=target_type,
+            project_id=local_tombstone.project_id,
+            deleted_at=local_tombstone.deleted_at,
+            local_projects=local_projects,
+            remote_projects=remote_projects,
+        ):
+            continue
         targets.add((target_type, local_tombstone.target_id))
         if target_type == ITEM_PROJECT:
             targets.add((ITEM_PROJECT, local_tombstone.project_id))
     for remote_tombstone in remote_tombstones:
+        if _project_tombstone_is_older_than_live_project(
+            target_type=remote_tombstone.target_type,
+            project_id=remote_tombstone.project_id,
+            deleted_at=remote_tombstone.deleted_at,
+            local_projects=local_projects,
+            remote_projects=remote_projects,
+        ):
+            continue
         targets.add((remote_tombstone.target_type, remote_tombstone.target_id))
         if remote_tombstone.target_type == ITEM_PROJECT:
             targets.add((ITEM_PROJECT, remote_tombstone.project_id))
     return frozenset(targets)
+
+
+def _project_tombstone_is_older_than_live_project(
+    *,
+    target_type: str,
+    project_id: str,
+    deleted_at: object,
+    local_projects: Mapping[str, Project],
+    remote_projects: Mapping[str, _RemoteProject],
+) -> bool:
+    if target_type != ITEM_PROJECT:
+        return False
+
+    tombstone_deleted_at = _coerce_datetime(deleted_at)
+    if tombstone_deleted_at is None:
+        return False
+
+    local_project = local_projects.get(project_id)
+    if local_project is not None and local_project.sync_status != PROJECT_SYNC_STATUS_DELETED:
+        local_updated_at = _coerce_datetime(local_project.updated_at)
+        if local_updated_at is not None and local_updated_at > tombstone_deleted_at:
+            return True
+
+    remote_project = remote_projects.get(project_id)
+    if remote_project is None:
+        return False
+    remote_status = _str_field(remote_project.raw, "sync_status", "sync_state")
+    if remote_status == PROJECT_SYNC_STATUS_DELETED:
+        return False
+    remote_updated_at = _coerce_datetime(
+        _first_field(remote_project.raw, "updated_at", "created_at", default=None)
+    )
+    return remote_updated_at is not None and remote_updated_at > tombstone_deleted_at
 
 
 def _is_deleted(
@@ -2421,6 +2537,22 @@ def _sortable_datetime(value: object) -> str:
     if value is None:
         return ""
     return str(value)
+
+
+def _coerce_datetime(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    else:
+        return None
+
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
 
 
 def _stable_json(value: Mapping[str, Any]) -> str:

--- a/apps/backend/app/services/sync_reconciliation_apply.py
+++ b/apps/backend/app/services/sync_reconciliation_apply.py
@@ -1,15 +1,24 @@
 from __future__ import annotations
 
+import shutil
 from collections.abc import Mapping
+from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 from sqlalchemy.orm import Session
 
 from app.errors import AppError
-from app.models import Project, SyncDeleteTombstone
+from app.models import Artifact, Project, SyncDeleteTombstone, SyncEntityRevision
+from app.services.artifacts import register_artifact
+from app.services.paths import project_root
 from app.services.sync_manifest import (
+    _coerce_project_manifest,
+    _hydrate_current_entity_revisions,
+    _normalize_revision_state,
+    _safe_relative_path,
     hydrate_project_analysis_result_from_artifact,
     import_staged_project_manifest,
 )
@@ -29,8 +38,10 @@ from app.services.sync_reconciliation import (
     SyncReconciliationPlan,
     plan_sync_reconciliation,
 )
+from app.services.sync_revisions import revision_payload_sha256
 from app.services.sync_staging import cleanup_staged_artifacts, require_staged_artifact
 from app.services.sync_tombstones import apply_delete_tombstone
+from app.utils.hashing import file_sha256
 
 APPLY_STATUS_APPLIED = "applied"
 APPLY_STATUS_SATISFIED = "satisfied"
@@ -127,18 +138,9 @@ def _apply_action(
     if action.action_type == ACTION_UPSERT_PROJECT_STATUS:
         return _upsert_project_status(session, action, context)
     if action.action_type == ACTION_IMPORT_ARTIFACT_MANIFEST:
-        return _result(
-            action,
-            APPLY_STATUS_SKIPPED,
-            "Standalone artifact manifest import is not available through existing sync services.",
-        )
+        return _import_artifact_manifest(session, action, context)
     if action.action_type == ACTION_IMPORT_ENTITY_REVISION:
-        return _result(
-            action,
-            APPLY_STATUS_SKIPPED,
-            "Standalone entity revision import is not available through existing sync services.",
-            details={"supported_path": "Include the revision in a staged project manifest."},
-        )
+        return _import_entity_revision(session, action, context)
     if action.action_type == ACTION_RECORD_CONFLICT:
         return _result(
             action,
@@ -217,6 +219,168 @@ def _import_project_manifest(
     )
 
 
+def _import_artifact_manifest(
+    session: Session,
+    action: SyncReconciliationAction,
+    context: _ApplyContext,
+) -> SyncReconciliationApplyActionResult:
+    project_id = action.project_id
+    if project_id is None:
+        return _result(action, APPLY_STATUS_SKIPPED, "Artifact import action does not include a project_id.")
+    project = session.get(Project, project_id)
+    if project is None:
+        return _result(action, APPLY_STATUS_SKIPPED, "Project must exist before importing an artifact manifest.")
+    manifest = context.project_manifests_by_id.get(project_id)
+    if manifest is None:
+        return _result(action, APPLY_STATUS_SKIPPED, "Project manifest is not present in the apply request.")
+    project_manifest = _coerce_project_manifest(manifest)
+    artifact_manifest = next(
+        (
+            artifact
+            for artifact in project_manifest.artifacts
+            if artifact.artifact_id == action.item_id
+        ),
+        None,
+    )
+    if artifact_manifest is None:
+        return _result(action, APPLY_STATUS_SKIPPED, "Artifact manifest is not present in the project manifest.")
+    if artifact_manifest.project_id != project_id:
+        return _result(action, APPLY_STATUS_FAILED, "Artifact manifest belongs to a different project.")
+
+    existing_artifact = session.get(Artifact, artifact_manifest.artifact_id)
+    if existing_artifact is not None:
+        if (
+            existing_artifact.project_id != project_id
+            or existing_artifact.content_sha256 != artifact_manifest.content_sha256
+            or existing_artifact.size_bytes != artifact_manifest.size_bytes
+        ):
+            return _result(action, APPLY_STATUS_FAILED, "Artifact manifest conflicts with a local artifact.")
+        existing_path = Path(existing_artifact.path)
+        if (
+            existing_path.exists()
+            and existing_path.stat().st_size == artifact_manifest.size_bytes
+            and file_sha256(existing_path) == artifact_manifest.content_sha256
+        ):
+            return _result(action, APPLY_STATUS_SATISFIED, "Artifact manifest is already imported locally.")
+        destination_path = existing_path
+    else:
+        destination_path = project_root(project_id) / _safe_relative_path(artifact_manifest.relative_path)
+        if destination_path.exists():
+            return _result(action, APPLY_STATUS_FAILED, "Artifact destination already exists locally.")
+
+    try:
+        staged_artifact = require_staged_artifact(
+            session,
+            content_sha256=artifact_manifest.content_sha256,
+            size_bytes=artifact_manifest.size_bytes,
+        )
+    except AppError as exc:
+        return _result(
+            action,
+            APPLY_STATUS_SKIPPED,
+            "Artifact manifest import is waiting for staged artifact content.",
+            details={"error_code": exc.code, "error_details": exc.details},
+        )
+
+    destination_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(staged_artifact.resolved_path, destination_path)
+    if existing_artifact is None:
+        imported_artifact = register_artifact(
+            session,
+            project_id=project_id,
+            artifact_type=artifact_manifest.type,
+            artifact_format=artifact_manifest.format,
+            path=destination_path,
+            artifact_id=artifact_manifest.artifact_id,
+            metadata=artifact_manifest.metadata,
+            cache_key=artifact_manifest.cache_key,
+            generated_by=artifact_manifest.generated_by,
+            can_delete=artifact_manifest.can_delete,
+            can_regenerate=artifact_manifest.can_regenerate,
+            created_at=artifact_manifest.created_at,
+        )
+    else:
+        existing_artifact.path = str(destination_path)
+        existing_artifact.metadata_json = deepcopy(artifact_manifest.metadata)
+        existing_artifact.cache_key = artifact_manifest.cache_key
+        existing_artifact.generated_by = artifact_manifest.generated_by
+        existing_artifact.can_delete = artifact_manifest.can_delete
+        existing_artifact.can_regenerate = artifact_manifest.can_regenerate
+        imported_artifact = existing_artifact
+    if (
+        imported_artifact.content_sha256 != artifact_manifest.content_sha256
+        or imported_artifact.size_bytes != artifact_manifest.size_bytes
+    ):
+        return _result(action, APPLY_STATUS_FAILED, "Copied artifact bytes do not match the manifest.")
+    if artifact_manifest.type == "analysis_json":
+        hydrate_project_analysis_result_from_artifact(session, project_id)
+    session.flush()
+    return _result(
+        action,
+        APPLY_STATUS_APPLIED,
+        "Artifact manifest was imported into the existing project.",
+        details={"artifact_id": artifact_manifest.artifact_id, "project_id": project_id},
+    )
+
+
+def _import_entity_revision(
+    session: Session,
+    action: SyncReconciliationAction,
+    context: _ApplyContext,
+) -> SyncReconciliationApplyActionResult:
+    project_id = action.project_id
+    if project_id is None:
+        return _result(action, APPLY_STATUS_SKIPPED, "Entity revision action does not include a project_id.")
+    project = session.get(Project, project_id)
+    if project is None:
+        return _result(action, APPLY_STATUS_SKIPPED, "Project must exist before importing an entity revision.")
+    manifest = context.project_manifests_by_id.get(project_id)
+    if manifest is None:
+        return _result(action, APPLY_STATUS_SKIPPED, "Project manifest is not present in the apply request.")
+    project_manifest = _coerce_project_manifest(manifest)
+    revision = next(
+        (
+            candidate
+            for candidate in project_manifest.entity_revisions
+            if candidate.revision_id == action.item_id
+        ),
+        None,
+    )
+    if revision is None:
+        return _result(action, APPLY_STATUS_SKIPPED, "Entity revision is not present in the project manifest.")
+    existing_revision = session.get(SyncEntityRevision, revision.revision_id)
+    if existing_revision is not None:
+        if revision_payload_sha256(existing_revision.payload_json or {}) == revision.content_sha256:
+            return _result(action, APPLY_STATUS_SATISFIED, "Entity revision is already imported locally.")
+        return _result(action, APPLY_STATUS_FAILED, "Entity revision conflicts with a local revision.")
+
+    row = SyncEntityRevision(
+        id=revision.revision_id,
+        project_id=revision.project_id,
+        entity_type=revision.entity_type,
+        entity_id=revision.entity_id,
+        revision_type=revision.revision_type,
+        base_revision_id=revision.base_revision_id,
+        author_device_id=revision.author_device_id,
+        source_artifact_id=revision.source_artifact_id,
+        content_sha256=revision.content_sha256,
+        state=_normalize_revision_state(revision.state),
+        metadata_json=deepcopy(revision.metadata),
+        payload_json=deepcopy(revision.payload),
+        created_at=revision.created_at,
+        updated_at=revision.updated_at,
+    )
+    session.add(row)
+    _hydrate_current_entity_revisions(session, project, [revision])
+    session.flush()
+    return _result(
+        action,
+        APPLY_STATUS_APPLIED,
+        "Entity revision was imported into the existing project.",
+        details={"revision_id": revision.revision_id, "project_id": project_id},
+    )
+
+
 def _apply_delete_tombstone_action(
     session: Session,
     action: SyncReconciliationAction,
@@ -257,6 +421,14 @@ def _upsert_project_status(
             action,
             APPLY_STATUS_SKIPPED,
             "Project status action does not include a project_status.",
+        )
+
+    create_placeholder = _bool_field(action.details, "create_placeholder", default=True)
+    if session.get(Project, project_id) is None and not create_placeholder:
+        return _result(
+            action,
+            APPLY_STATUS_SKIPPED,
+            "Project status action does not create a deleted placeholder.",
         )
 
     manifest_or_metadata = context.project_manifests_by_id.get(project_id)

--- a/apps/backend/tests/test_projects.py
+++ b/apps/backend/tests/test_projects.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -574,6 +575,94 @@ def test_project_list_can_filter_by_search_term(
     projects = response.json()["projects"]
     assert len(projects) == 1
     assert projects[0]["display_name"] == "Choir Warmup"
+
+
+def test_project_list_hides_deleted_sync_placeholders(client, tmp_path: Path):
+    with SessionLocal() as session:
+        session.add_all(
+            [
+                Project(
+                    id="proj_visible_local",
+                    display_name="Visible Project",
+                    source_sha256="a" * 64,
+                    source_path=str(tmp_path / "visible-source.wav"),
+                    imported_path=str(tmp_path / "visible-imported.wav"),
+                    sync_status="local",
+                ),
+                Project(
+                    id="proj_hidden_deleted",
+                    display_name="Hidden Deleted Project",
+                    source_sha256="b" * 64,
+                    source_path="sync-placeholder:proj_hidden_deleted",
+                    imported_path="sync-placeholder:proj_hidden_deleted",
+                    sync_status="deleted",
+                    sync_status_reason="Project is covered by a sync delete tombstone.",
+                ),
+            ]
+        )
+        session.commit()
+
+    response = client.get("/api/v1/projects")
+
+    assert response.status_code == 200
+    projects = response.json()["projects"]
+    assert [project["id"] for project in projects] == ["proj_visible_local"]
+
+
+def test_import_project_replaces_deleted_sync_placeholder(
+    client,
+    sample_audio_file: Path,
+) -> None:
+    source_hash = file_sha256(sample_audio_file)
+    assert source_hash is not None
+    project_id = source_hash_to_project_id(source_hash)
+
+    with SessionLocal() as session:
+        session.add(
+            Project(
+                id=project_id,
+                display_name="Deleted Placeholder",
+                source_sha256=source_hash,
+                source_path=f"sync-placeholder:{project_id}",
+                imported_path=f"sync-placeholder:{project_id}",
+                sync_status="deleted",
+                sync_status_reason="Project is covered by a sync delete tombstone.",
+            )
+        )
+        session.add(
+            SyncDeleteTombstone(
+                id="tomb_reimport_project",
+                sync_group_id="group-a",
+                project_id=project_id,
+                target_type=PROJECT_TARGET_TYPE,
+                target_id=project_id,
+                author_device_id="peer-a",
+                deleted_at=datetime(2026, 1, 1, tzinfo=UTC),
+                prior_metadata_json={"display_name": "Deleted Placeholder"},
+            )
+        )
+        session.commit()
+
+    response = client.post(
+        "/api/v1/projects/import",
+        json={
+            "source_path": str(sample_audio_file),
+            "copy_into_project": True,
+            "display_name": "Reimported Project",
+        },
+    )
+
+    assert response.status_code == 200
+    project = response.json()["project"]
+    assert project["id"] == project_id
+    assert project["display_name"] == "Reimported Project"
+    assert project["sync_status"] == "local"
+
+    with SessionLocal() as session:
+        assert session.get(SyncDeleteTombstone, "tomb_reimport_project") is None
+        persisted_project = session.get(Project, project_id)
+        assert persisted_project is not None
+        assert persisted_project.sync_status == "local"
 
 
 def test_retune_request_rejects_invalid_payload(client, sample_audio_file: Path):

--- a/apps/backend/tests/test_sync_identity.py
+++ b/apps/backend/tests/test_sync_identity.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 
 from app.db import SessionLocal
-from app.models import Artifact, Project
+from app.models import Artifact, Project, SyncDeleteTombstone
 from app.services.paths import project_root
 from app.services.sync_identity import (
     project_id_to_storage_key,
@@ -244,6 +245,48 @@ def test_sync_metadata_exposes_sync_safe_project_and_artifact_metadata(
     external_artifact = artifacts["art_external"]
     assert external_artifact["relative_path"] is None
     assert external_artifact["metadata"] == {"transpose": {"semitones": -1}}
+
+
+def test_sync_metadata_omits_deleted_projects_but_keeps_tombstones(
+    client,
+    sample_audio_file: Path,
+) -> None:
+    source_hash = file_sha256(sample_audio_file)
+    assert source_hash is not None
+    project_id = source_hash_to_project_id(source_hash)
+
+    with SessionLocal() as session:
+        project = Project(
+            id=project_id,
+            display_name="Deleted Sync Fixture",
+            source_sha256=source_hash,
+            source_path=str(sample_audio_file),
+            imported_path=str(sample_audio_file),
+            sync_status="deleted",
+        )
+        session.add(project)
+        session.add(
+            SyncDeleteTombstone(
+                id="tomb_deleted_sync_project",
+                sync_group_id="group-a",
+                project_id=project_id,
+                target_type="project",
+                target_id=project_id,
+                author_device_id="peer-a",
+                deleted_at=datetime(2026, 1, 1, tzinfo=UTC),
+                prior_metadata_json={"display_name": "Deleted Sync Fixture"},
+            )
+        )
+        session.commit()
+
+    response = client.get("/api/v1/sync/metadata")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["projects"] == []
+    assert [tombstone["tombstone_id"] for tombstone in payload["delete_tombstones"]] == [
+        "tomb_deleted_sync_project"
+    ]
 
 
 def test_sync_preflight_does_not_recover_missing_hash_from_source_path(

--- a/apps/backend/tests/test_sync_reconciliation.py
+++ b/apps/backend/tests/test_sync_reconciliation.py
@@ -156,6 +156,127 @@ def test_artifact_classification_uses_verified_bytes_and_trusted_provider_choice
     assert _action(plan, ACTION_IMPORT_ARTIFACT_MANIFEST, ITEM_ARTIFACT, "art_duplicate_content") is not None
 
 
+def test_issue120_three_peer_group_uses_online_trusted_provider_deterministically(
+    db_session: Session,
+) -> None:
+    _add_identity_and_peers(db_session)
+    now = datetime.now(UTC)
+    db_session.add(
+        SyncTrustedPeer(
+            device_id="peer-c",
+            sync_group_id="group-a",
+            display_name="Peer C",
+            public_key="pub-peer-c",
+            endpoint_hints_json=[],
+            trusted_at=now,
+            revoked_at=None,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    project = _add_project(db_session, "proj_issue120_three_peer", source_sha256=_sha("issue120 source"))
+    online_hash = _sha("issue120 online artifact")
+    untrusted_only_hash = _sha("issue120 untrusted artifact")
+    db_session.commit()
+
+    base_request = {
+        "remote_library": {
+            "projects": [{"project_id": project.id, "source_sha256": project.source_sha256}],
+            "artifacts": [
+                _artifact_manifest(project.id, "art_issue120_online", online_hash, 64),
+                _artifact_manifest(project.id, "art_issue120_untrusted_only", untrusted_only_hash, 64),
+            ],
+        },
+    }
+
+    all_online_plan = plan_sync_reconciliation(
+        db_session,
+        {
+            **base_request,
+            "peer_inventory": [
+                {"device_id": "peer-c", "available_content_hashes": [online_hash]},
+                {"device_id": "peer-b", "available_content_hashes": [online_hash]},
+                {"device_id": "peer-a", "available_content_hashes": [online_hash]},
+                {"device_id": "peer-revoked", "available_content_hashes": [online_hash, untrusted_only_hash]},
+                {"device_id": "peer-untrusted", "available_content_hashes": [online_hash, untrusted_only_hash]},
+            ],
+        },
+    )
+
+    all_online_item = _item(all_online_plan, ITEM_ARTIFACT, "art_issue120_online")
+    assert all_online_item.status == "remote_available"
+    assert all_online_item.chosen_provider_device_id == "peer-a"
+    all_online_fetch = _action(
+        all_online_plan,
+        ACTION_FETCH_ARTIFACT_CONTENT,
+        ITEM_ARTIFACT,
+        "art_issue120_online",
+    )
+    assert all_online_fetch is not None
+    assert all_online_fetch.provider_device_id == "peer-a"
+    all_online_import = _action(
+        all_online_plan,
+        ACTION_IMPORT_ARTIFACT_MANIFEST,
+        ITEM_ARTIFACT,
+        "art_issue120_online",
+    )
+    assert all_online_import is not None
+    assert all_online_import.provider_device_id == "peer-a"
+
+    first_provider_absent_plan = plan_sync_reconciliation(
+        db_session,
+        {
+            **base_request,
+            "peer_inventory": [
+                {"device_id": "peer-c", "available_content_hashes": [online_hash]},
+                {"device_id": "peer-b", "available_content_hashes": [online_hash]},
+                {"device_id": "peer-revoked", "available_content_hashes": [online_hash, untrusted_only_hash]},
+                {"device_id": "peer-untrusted", "available_content_hashes": [online_hash, untrusted_only_hash]},
+            ],
+        },
+    )
+
+    switched_item = _item(first_provider_absent_plan, ITEM_ARTIFACT, "art_issue120_online")
+    assert switched_item.status == "remote_available"
+    assert switched_item.chosen_provider_device_id == "peer-b"
+    switched_fetch = _action(
+        first_provider_absent_plan,
+        ACTION_FETCH_ARTIFACT_CONTENT,
+        ITEM_ARTIFACT,
+        "art_issue120_online",
+    )
+    assert switched_fetch is not None
+    assert switched_fetch.provider_device_id == "peer-b"
+    switched_import = _action(
+        first_provider_absent_plan,
+        ACTION_IMPORT_ARTIFACT_MANIFEST,
+        ITEM_ARTIFACT,
+        "art_issue120_online",
+    )
+    assert switched_import is not None
+    assert switched_import.provider_device_id == "peer-b"
+    untrusted_only = _item(first_provider_absent_plan, ITEM_ARTIFACT, "art_issue120_untrusted_only")
+    assert untrusted_only.status == "missing_provider"
+    assert (
+        _action(
+            first_provider_absent_plan,
+            ACTION_FETCH_ARTIFACT_CONTENT,
+            ITEM_ARTIFACT,
+            "art_issue120_untrusted_only",
+        )
+        is None
+    )
+    assert (
+        _action(
+            first_provider_absent_plan,
+            ACTION_IMPORT_ARTIFACT_MANIFEST,
+            ITEM_ARTIFACT,
+            "art_issue120_untrusted_only",
+        )
+        is None
+    )
+
+
 def test_valid_tombstones_apply_first_and_untrusted_tombstones_are_noop(
     db_session: Session,
     tmp_path: Path,
@@ -204,6 +325,9 @@ def test_valid_tombstones_apply_first_and_untrusted_tombstones_are_noop(
         target_id="art_revoked",
         author_device_id="peer-revoked",
     )
+    stale_deleted_project_manifest = _project_manifest("proj_deleted_remote", deleted_project_source)
+    stale_deleted_project_manifest["project"]["created_at"] = datetime(2026, 1, 1, tzinfo=UTC)
+    stale_deleted_project_manifest["project"]["updated_at"] = datetime(2026, 1, 1, tzinfo=UTC)
     request = {
         "remote_library": {
             "projects": [
@@ -221,9 +345,7 @@ def test_valid_tombstones_apply_first_and_untrusted_tombstones_are_noop(
                 deleted_project_tombstone,
             ],
         },
-        "project_manifests": [
-            _project_manifest("proj_deleted_remote", deleted_project_source),
-        ],
+        "project_manifests": [stale_deleted_project_manifest],
         "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [import_hash]}],
     }
 
@@ -245,6 +367,97 @@ def test_valid_tombstones_apply_first_and_untrusted_tombstones_are_noop(
     )
     assert _action(plan, ACTION_APPLY_DELETE_TOMBSTONE, ITEM_ARTIFACT, "art_wrong_group") is None
     assert _action(plan, ACTION_APPLY_DELETE_TOMBSTONE, ITEM_ARTIFACT, "art_revoked") is None
+
+
+def test_newer_project_manifest_wins_over_older_local_project_tombstone(
+    db_session: Session,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash = _sha("reimported source")
+    project_id = source_hash_to_project_id(source_hash)
+    deleted_at = datetime(2026, 1, 1, tzinfo=UTC)
+    reimported_at = datetime(2026, 1, 2, tzinfo=UTC)
+    db_session.add(
+        SyncDeleteTombstone(
+            id="tomb_old_local_project",
+            sync_group_id="group-a",
+            project_id=project_id,
+            target_type=ITEM_PROJECT,
+            target_id=project_id,
+            author_device_id="peer-a",
+            deleted_at=deleted_at,
+            created_at=deleted_at,
+            updated_at=deleted_at,
+            prior_metadata_json={"display_name": "Old Project"},
+        )
+    )
+    db_session.flush()
+    manifest = _project_manifest(project_id, source_hash)
+    manifest["project"]["created_at"] = reimported_at
+    manifest["project"]["updated_at"] = reimported_at
+
+    plan = plan_sync_reconciliation(
+        db_session,
+        {
+            "remote_library": {
+                "projects": [],
+                "artifacts": [],
+                "entity_revisions": [],
+                "delete_tombstones": [],
+            },
+            "project_manifests": [manifest],
+            "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [source_hash]}],
+        },
+    )
+
+    project_item = _item(plan, ITEM_PROJECT, project_id)
+    assert project_item.status == "remote_available"
+    assert _action(plan, ACTION_APPLY_DELETE_TOMBSTONE, ITEM_PROJECT, project_id) is None
+    assert _action(plan, ACTION_IMPORT_PROJECT_MANIFEST, ITEM_PROJECT, project_id) is not None
+
+
+def test_older_remote_project_tombstone_does_not_delete_newer_local_project(
+    db_session: Session,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash = _sha("local reimported source")
+    project_id = source_hash_to_project_id(source_hash)
+    project = _add_project(db_session, project_id, source_sha256=source_hash)
+    project.updated_at = datetime(2026, 1, 2, tzinfo=UTC)
+    deleted_at = datetime(2026, 1, 1, tzinfo=UTC)
+    db_session.flush()
+
+    plan = plan_sync_reconciliation(
+        db_session,
+        {
+            "remote_library": {
+                "projects": [],
+                "artifacts": [],
+                "entity_revisions": [],
+                "delete_tombstones": [
+                    {
+                        "tombstone_id": "tomb_old_remote_project",
+                        "sync_group_id": "group-a",
+                        "project_id": project_id,
+                        "target_type": ITEM_PROJECT,
+                        "target_id": project_id,
+                        "author_device_id": "peer-a",
+                        "deleted_at": deleted_at,
+                        "prior_metadata": {},
+                        "created_at": deleted_at,
+                        "updated_at": deleted_at,
+                    }
+                ],
+            },
+            "project_manifests": [],
+            "peer_inventory": [],
+        },
+    )
+
+    tombstone_item = _item(plan, ITEM_DELETE_TOMBSTONE, "tomb_old_remote_project")
+    assert tombstone_item.status == "noop"
+    assert "older than a live project" in tombstone_item.reason
+    assert _action(plan, ACTION_APPLY_DELETE_TOMBSTONE, ITEM_PROJECT, project_id) is None
 
 
 def test_entity_revision_ancestry_imports_descendants_and_conflicts_siblings(

--- a/apps/backend/tests/test_sync_reconciliation_apply_api.py
+++ b/apps/backend/tests/test_sync_reconciliation_apply_api.py
@@ -287,6 +287,87 @@ def test_reconciliation_apply_applies_trusted_delete_tombstone(
     assert not artifact_path.exists()
 
 
+def test_reconciliation_apply_does_not_recreate_deleted_project_placeholder(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    identity = _ensure_identity_and_peer("peer-apply-project-delete")
+    project_id = "proj_apply_deleted_project"
+    source_path = tmp_path / "deleted-project.wav"
+    source_path.write_bytes(b"deleted project source")
+    content_sha256 = hashlib.sha256(source_path.read_bytes()).hexdigest()
+    _add_project_artifact(project_id, source_path, content_sha256)
+    stale_at = datetime(2026, 1, 1, tzinfo=UTC)
+    deleted_at = datetime(2026, 1, 2, tzinfo=UTC)
+    with SessionLocal() as session:
+        project = session.get(Project, project_id)
+        assert project is not None
+        project.created_at = stale_at
+        project.updated_at = stale_at
+        session.commit()
+    remote_project = _remote_project(project_id, content_sha256)
+    remote_project["created_at"] = stale_at.isoformat()
+    remote_project["updated_at"] = stale_at.isoformat()
+    stale_manifest = _project_manifest(
+        project_id,
+        content_sha256,
+        source_path.stat().st_size,
+        peer_device_id="peer-apply-project-delete",
+    )
+    stale_manifest["project"]["created_at"] = stale_at.isoformat()
+    stale_manifest["project"]["updated_at"] = stale_at.isoformat()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": {
+                "projects": [remote_project],
+                "artifacts": [],
+                "entity_revisions": [],
+                "delete_tombstones": [
+                    {
+                        "tombstone_id": "tomb_apply_project",
+                        "sync_group_id": identity.sync_group_id,
+                        "project_id": project_id,
+                        "target_type": "project",
+                        "target_id": project_id,
+                        "author_device_id": "peer-apply-project-delete",
+                        "deleted_at": deleted_at.isoformat(),
+                        "prior_metadata": {},
+                        "created_at": deleted_at.isoformat(),
+                        "updated_at": deleted_at.isoformat(),
+                    }
+                ],
+            },
+            "project_manifests": [stale_manifest],
+            "peer_inventory": [],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 0
+    assert any(
+        result["action"]["action_type"] == "apply_delete_tombstone"
+        and result["action"]["item_type"] == "project"
+        and result["status"] == "applied"
+        for result in payload["results"]
+    )
+    assert any(
+        result["action"]["action_type"] == "upsert_project_status"
+        and result["action"]["item_type"] == "project"
+        and result["status"] == "skipped"
+        for result in payload["results"]
+    )
+
+    with SessionLocal() as session:
+        assert session.get(Project, project_id) is None
+        tombstone = session.get(SyncDeleteTombstone, "tomb_apply_project")
+        assert tombstone is not None
+        assert tombstone.target_type == "project"
+        assert tombstone.target_id == project_id
+
+
 def _ensure_identity_and_peer(peer_device_id: str) -> Any:
     now = datetime.now(UTC)
     with SessionLocal() as session:

--- a/apps/backend/tests/test_sync_reconciliation_apply_batch_import.py
+++ b/apps/backend/tests/test_sync_reconciliation_apply_batch_import.py
@@ -832,6 +832,447 @@ def test_issue119_remote_placeholder_stays_locked_until_cross_peer_bytes_import(
         assert project.sync_required_artifact_ids == []
 
 
+def test_issue120_three_peer_import_uses_staged_bytes_from_non_advertising_peer(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _ensure_identity_and_peers(
+        "peer-issue120-manifest",
+        "peer-issue120-bytes",
+        "peer-issue120-offline",
+    )
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="issue120-three-peer",
+            source_frames=120,
+        )
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        _delete_live_project(session, fixture)
+        session.commit()
+
+    peer_inventory = [
+        {
+            "device_id": "peer-issue120-manifest",
+            "available_content_sha256": _manifest_content_hashes([manifest]),
+        }
+    ]
+    first_response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [manifest],
+            "peer_inventory": peer_inventory,
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert first_response.status_code == 200
+    first_payload = first_response.json()
+    assert first_payload["summary"]["failed_actions"] == 0
+    assert first_payload["summary"]["skipped_actions"] > 0
+    project_item = _plan_item(first_payload["plan"]["items"], "project", fixture.project_id)
+    assert project_item["status"] == "remote_available"
+    assert project_item["chosen_provider_device_id"] == "peer-issue120-manifest"
+    assert any(
+        result["action"]["action_type"] == "import_project_manifest"
+        and result["status"] == "skipped"
+        and result["details"]["missing_artifacts"]
+        for result in first_payload["results"]
+    )
+
+    with SessionLocal() as session:
+        placeholder = session.get(Project, fixture.project_id)
+        assert placeholder is not None
+        assert placeholder.sync_status == "remote_available"
+        assert placeholder.sync_provider_device_ids == ["peer-issue120-manifest"]
+        assert session.scalar(
+            select(func.count())
+            .select_from(Artifact)
+            .where(Artifact.project_id == fixture.project_id)
+        ) == 0
+
+    locked_response = client.patch(
+        f"/api/v1/projects/{fixture.project_id}",
+        json={"display_name": "Still Waiting For Bytes"},
+    )
+    assert locked_response.status_code == 409
+    assert locked_response.json()["error"]["code"] == "PROJECT_SYNC_LOCKED"
+
+    with SessionLocal() as session:
+        _stage_manifest_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=fixture.artifact_bytes,
+            provider_device_id="peer-issue120-bytes",
+        )
+        session.commit()
+
+    second_response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [manifest],
+            "peer_inventory": peer_inventory,
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert second_response.status_code == 200
+    second_payload = second_response.json()
+    assert second_payload["summary"]["failed_actions"] == 0
+    fetch_results = [
+        result
+        for result in second_payload["results"]
+        if result["action"]["action_type"] == "fetch_artifact_content"
+    ]
+    assert fetch_results
+    assert {result["status"] for result in fetch_results} == {"satisfied"}
+    assert {
+        result["action"]["provider_device_id"] for result in fetch_results
+    } == {"peer-issue120-manifest"}
+    assert {result["details"]["provider_device_id"] for result in fetch_results} == {
+        "peer-issue120-bytes"
+    }
+    assert any(
+        result["action"]["action_type"] == "import_project_manifest"
+        and result["status"] == "applied"
+        for result in second_payload["results"]
+    )
+
+    unlocked_response = client.patch(
+        f"/api/v1/projects/{fixture.project_id}",
+        json={"display_name": "Editable After Three Peer Import"},
+    )
+    assert unlocked_response.status_code == 200
+    assert unlocked_response.json()["project"]["display_name"] == (
+        "Editable After Three Peer Import"
+    )
+
+    with SessionLocal() as session:
+        project = session.get(Project, fixture.project_id)
+        assert project is not None
+        assert project.sync_status == "local"
+        assert project.sync_status_reason is None
+        assert project.sync_provider_device_ids == []
+        assert project.sync_required_artifact_ids == []
+        assert "peer-issue120-offline" not in project.sync_provider_device_ids
+
+        imported_artifacts = {
+            artifact.id: artifact
+            for artifact in session.scalars(
+                select(Artifact).where(Artifact.project_id == fixture.project_id)
+            )
+        }
+        assert set(imported_artifacts) == {
+            fixture.source_artifact_id,
+            fixture.stem_artifact_id,
+        }
+        for artifact_id, expected_hash in fixture.artifact_hashes.items():
+            artifact = imported_artifacts[artifact_id]
+            assert artifact.content_sha256 == expected_hash
+            assert Path(artifact.path).exists()
+            assert file_sha256(Path(artifact.path)) == expected_hash
+
+
+def test_issue120_stale_inventory_cannot_import_without_verified_staged_size(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _ensure_identity_and_peers(
+        "peer-issue120-stale-inventory",
+        "peer-issue120-size-provider",
+    )
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="issue120-stale-inventory",
+            source_frames=124,
+        )
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        stale_size_manifest = json.loads(json.dumps(manifest))
+        stale_source_artifact = _artifact_by_id(stale_size_manifest, fixture.source_artifact_id)
+        stale_source_artifact["size_bytes"] += 1
+        _delete_live_project(session, fixture)
+        session.commit()
+
+    stale_inventory = [
+        {
+            "device_id": "peer-issue120-stale-inventory",
+            "available_content_sha256": _manifest_content_hashes([stale_size_manifest]),
+        }
+    ]
+    missing_bytes_response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [stale_size_manifest],
+            "peer_inventory": stale_inventory,
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert missing_bytes_response.status_code == 200
+    missing_bytes_payload = missing_bytes_response.json()
+    assert missing_bytes_payload["summary"]["failed_actions"] == 0
+    assert any(
+        result["action"]["action_type"] == "import_project_manifest"
+        and result["status"] == "skipped"
+        and {
+            artifact["artifact_id"]
+            for artifact in result["details"]["missing_artifacts"]
+        }
+        == {fixture.source_artifact_id, fixture.stem_artifact_id}
+        for result in missing_bytes_payload["results"]
+    )
+
+    with SessionLocal() as session:
+        project = session.get(Project, fixture.project_id)
+        assert project is not None
+        assert project.sync_status == "remote_available"
+        assert session.scalar(
+            select(func.count())
+            .select_from(Artifact)
+            .where(Artifact.project_id == fixture.project_id)
+        ) == 0
+
+        _stage_manifest_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=fixture.artifact_bytes,
+            provider_device_id="peer-issue120-size-provider",
+        )
+        session.commit()
+
+    mismatched_size_response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [stale_size_manifest],
+            "peer_inventory": stale_inventory,
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert mismatched_size_response.status_code == 200
+    mismatched_size_payload = mismatched_size_response.json()
+    assert mismatched_size_payload["summary"]["failed_actions"] == 0
+    import_skips = [
+        result
+        for result in mismatched_size_payload["results"]
+        if result["action"]["action_type"] == "import_project_manifest"
+        and result["status"] == "skipped"
+    ]
+    assert len(import_skips) == 1
+    assert import_skips[0]["details"]["missing_artifacts"] == [
+        {
+            "artifact_id": fixture.source_artifact_id,
+            "content_sha256": fixture.artifact_hashes[fixture.source_artifact_id],
+            "error_code": "SYNC_STAGING_RECORD_SIZE_MISMATCH",
+        }
+    ]
+
+    with SessionLocal() as session:
+        project = session.get(Project, fixture.project_id)
+        assert project is not None
+        assert project.sync_status == "remote_available"
+        assert session.scalar(
+            select(func.count())
+            .select_from(Artifact)
+            .where(Artifact.project_id == fixture.project_id)
+        ) == 0
+
+    correct_manifest_response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [manifest],
+            "peer_inventory": stale_inventory,
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert correct_manifest_response.status_code == 200
+    assert correct_manifest_response.json()["summary"]["failed_actions"] == 0
+
+    with SessionLocal() as session:
+        project = session.get(Project, fixture.project_id)
+        assert project is not None
+        assert project.sync_status == "local"
+        assert project.sync_required_artifact_ids == []
+        assert project.sync_provider_device_ids == []
+        assert {
+            artifact.id
+            for artifact in session.scalars(
+                select(Artifact).where(Artifact.project_id == fixture.project_id)
+            )
+        } == {fixture.source_artifact_id, fixture.stem_artifact_id}
+
+
+def test_issue120_existing_project_imports_late_manifest_artifacts(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _ensure_identity_and_peers("peer-issue120-late-artifact")
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="issue120-late-artifact",
+            source_frames=128,
+        )
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        late_artifact_path = project_root(fixture.project_id) / fixture.stem_relative_path
+        late_artifact = session.get(Artifact, fixture.stem_artifact_id)
+        assert late_artifact is not None
+        session.delete(late_artifact)
+        late_artifact_path.unlink()
+        _stage_manifest_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=fixture.artifact_bytes,
+            provider_device_id="peer-issue120-late-artifact",
+        )
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": "peer-issue120-late-artifact",
+                    "available_content_sha256": _manifest_content_hashes([manifest]),
+                }
+            ],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 0
+    assert any(
+        result["action"]["action_type"] == "import_artifact_manifest"
+        and result["action"]["project_id"] == fixture.project_id
+        and result["action"]["item_id"] == fixture.stem_artifact_id
+        and result["status"] == "applied"
+        for result in payload["results"]
+    )
+
+    with SessionLocal() as session:
+        project = session.get(Project, fixture.project_id)
+        assert project is not None
+        assert project.sync_status == "local"
+        restored_artifact = session.get(Artifact, fixture.stem_artifact_id)
+        assert restored_artifact is not None
+        assert Path(restored_artifact.path).exists()
+        assert restored_artifact.content_sha256 == fixture.artifact_hashes[fixture.stem_artifact_id]
+
+
+def test_issue120_remote_tombstone_from_trusted_peer_wins_over_stale_manifest(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    identity = _ensure_identity_and_peers(
+        "peer-issue120-stale-manifest",
+        "peer-issue120-tombstone",
+    )
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="issue120-tombstone",
+            source_frames=128,
+        )
+        stale_manifest = _jsonable_manifest(
+            export_project_manifest(session, project_id=fixture.project_id)
+        )
+        deleted_artifact_path = project_root(fixture.project_id) / fixture.stem_relative_path
+        deleted_artifact = session.get(Artifact, fixture.stem_artifact_id)
+        assert deleted_artifact is not None
+        session.delete(deleted_artifact)
+        deleted_artifact_path.unlink()
+        session.commit()
+
+    tombstone_time = datetime(2026, 1, 2, tzinfo=UTC).isoformat()
+    tombstone = {
+        "tombstone_id": "tomb_issue120_remote_deleted_stem",
+        "sync_group_id": identity["sync_group_id"],
+        "project_id": fixture.project_id,
+        "target_type": "artifact",
+        "target_id": fixture.stem_artifact_id,
+        "author_device_id": "peer-issue120-tombstone",
+        "deleted_at": tombstone_time,
+        "prior_metadata": {"artifact_id": fixture.stem_artifact_id, "type": "vocals"},
+        "created_at": tombstone_time,
+        "updated_at": tombstone_time,
+    }
+    remote_library = _empty_remote_library()
+    remote_library["delete_tombstones"] = [tombstone]
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": remote_library,
+            "project_manifests": [stale_manifest],
+            "peer_inventory": [
+                {
+                    "device_id": "peer-issue120-stale-manifest",
+                    "available_content_sha256": _manifest_content_hashes([stale_manifest]),
+                }
+            ],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 0
+    assert (
+        _plan_item(payload["plan"]["items"], "artifact", fixture.stem_artifact_id)["status"]
+        == "deleted"
+    )
+    assert all(
+        result["action"]["action_type"] != "import_project_manifest"
+        for result in payload["results"]
+    )
+    assert any(
+        result["action"]["action_type"] == "apply_delete_tombstone"
+        and result["action"]["item_id"] == fixture.stem_artifact_id
+        and result["status"] == "applied"
+        for result in payload["results"]
+    )
+
+    editable_response = client.patch(
+        f"/api/v1/projects/{fixture.project_id}",
+        json={"display_name": "Tombstone Still Editable"},
+    )
+    assert editable_response.status_code == 200
+    assert editable_response.json()["project"]["display_name"] == "Tombstone Still Editable"
+
+    with SessionLocal() as session:
+        project = session.get(Project, fixture.project_id)
+        assert project is not None
+        assert project.sync_status == "local"
+        assert session.get(Artifact, fixture.source_artifact_id) is not None
+        assert session.get(Artifact, fixture.stem_artifact_id) is None
+        assert not deleted_artifact_path.exists()
+        persisted_tombstone = session.get(SyncDeleteTombstone, tombstone["tombstone_id"])
+        assert persisted_tombstone is not None
+        assert persisted_tombstone.author_device_id == "peer-issue120-tombstone"
+
+
 def _ensure_identity_and_peers(*peer_device_ids: str) -> dict[str, str]:
     now = datetime.now(UTC)
     with SessionLocal() as session:
@@ -1101,6 +1542,13 @@ def _revision_by_id(manifest: dict[str, Any], revision_id: str) -> dict[str, Any
         if revision["revision_id"] == revision_id:
             return revision
     raise AssertionError(f"Missing revision in manifest: {revision_id}")
+
+
+def _artifact_by_id(manifest: dict[str, Any], artifact_id: str) -> dict[str, Any]:
+    for artifact in manifest["artifacts"]:
+        if artifact["artifact_id"] == artifact_id:
+            return artifact
+    raise AssertionError(f"Missing artifact in manifest: {artifact_id}")
 
 
 def _plan_item(items: list[dict[str, Any]], item_type: str, item_id: str) -> dict[str, Any]:

--- a/apps/desktop/src-tauri/src/sync_transport.rs
+++ b/apps/desktop/src-tauri/src/sync_transport.rs
@@ -1279,7 +1279,7 @@ mod desktop {
                 }
             };
 
-        for entry in planned_fetch_artifact_entries(&plan, manifests) {
+        for entry in planned_fetch_artifact_entries(&plan, manifests, peer_device_id) {
             match request_and_stage_artifact(client, connection, peer_device_id, &entry.artifact) {
                 Ok(result) => received_artifacts.push(result),
                 Err(error) => {
@@ -1603,8 +1603,9 @@ mod desktop {
     fn planned_fetch_artifact_entries(
         plan: &Value,
         manifests: &[Value],
+        provider_device_id: &str,
     ) -> Vec<ManifestArtifactEntry> {
-        let requested = planned_fetch_keys(plan);
+        let requested = planned_fetch_keys(plan, provider_device_id);
         manifest_artifact_entries(manifests)
             .into_iter()
             .filter(|entry| {
@@ -1617,13 +1618,18 @@ mod desktop {
             .collect()
     }
 
-    fn planned_fetch_keys(plan: &Value) -> HashSet<(String, String, String)> {
+    fn planned_fetch_keys(
+        plan: &Value,
+        provider_device_id: &str,
+    ) -> HashSet<(String, String, String)> {
         plan.get("actions")
             .and_then(Value::as_array)
             .into_iter()
             .flatten()
             .filter(|action| {
                 action.get("action_type").and_then(Value::as_str) == Some("fetch_artifact_content")
+                    && action.get("provider_device_id").and_then(Value::as_str)
+                        == Some(provider_device_id)
             })
             .filter_map(|action| {
                 Some((
@@ -2606,11 +2612,54 @@ mod desktop {
                 }]
             });
 
-            let entries = planned_fetch_artifact_entries(&plan, &manifests);
+            let entries = planned_fetch_artifact_entries(&plan, &manifests, "dev_peer");
 
             assert_eq!(entries.len(), 1);
             assert_eq!(entries[0].artifact.artifact_id, "art_two");
             assert_eq!(entries[0].manifest_project_id, "proj_two");
+        }
+
+        #[test]
+        fn planned_fetch_artifact_entries_requires_matching_provider_device_id() {
+            let manifests = vec![json!({
+                "project": { "project_id": "proj_one" },
+                "artifacts": [{
+                    "artifact_id": "art_one",
+                    "project_id": "proj_one",
+                    "content_sha256": "hash_a",
+                    "size_bytes": 10
+                }, {
+                    "artifact_id": "art_two",
+                    "project_id": "proj_one",
+                    "content_sha256": "hash_b",
+                    "size_bytes": 20
+                }]
+            })];
+            let plan = json!({
+                "actions": [{
+                    "action_type": "fetch_artifact_content",
+                    "item_type": "artifact",
+                    "item_id": "art_one",
+                    "project_id": "proj_one",
+                    "content_sha256": "hash_a",
+                    "provider_device_id": "dev_other_peer",
+                    "priority": 20
+                }, {
+                    "action_type": "fetch_artifact_content",
+                    "item_type": "artifact",
+                    "item_id": "art_two",
+                    "project_id": "proj_one",
+                    "content_sha256": "hash_b",
+                    "provider_device_id": "dev_selected_peer",
+                    "priority": 20
+                }]
+            });
+
+            let entries = planned_fetch_artifact_entries(&plan, &manifests, "dev_selected_peer");
+
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0].artifact.artifact_id, "art_two");
+            assert_eq!(entries[0].artifact.content_sha256, "hash_b");
         }
 
         #[test]
@@ -2635,7 +2684,7 @@ mod desktop {
                 }]
             });
 
-            assert!(planned_fetch_artifact_entries(&plan, &manifests).is_empty());
+            assert!(planned_fetch_artifact_entries(&plan, &manifests, "dev_peer").is_empty());
         }
 
         #[test]


### PR DESCRIPTION
## Summary
- Add three-peer sync validation for trusted peers, stale inventory, provider choice, and apply convergence.
- Preserve delete tombstones while hiding deleted placeholders from the library and allowing same-source reimport.
- Merge late manifest artifacts and entity revisions into existing projects after partial sync.
- Closes #120

## Testing
- `cd apps/backend && uv run --python 3.11 pytest tests/test_sync_reconciliation.py tests/test_sync_reconciliation_apply_batch_import.py`
- `cd apps/backend && uv run --python 3.11 pytest tests/test_projects.py tests/test_sync_reconciliation.py tests/test_sync_reconciliation_apply_api.py tests/test_sync_identity.py tests/test_sync_reconciliation_apply_batch_import.py`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `cd apps/desktop/src-tauri && cargo test sync_transport`
- `cd apps/desktop/src-tauri && cargo check`
