### PR TITLE
feat: Add incremental sync result reporting

### DIFF
--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -505,11 +505,29 @@ class SyncReconciliationPlanResponse(BaseModel):
 
 
 SyncReconciliationApplyActionStatus = Literal["applied", "satisfied", "skipped", "failed"]
+SyncReconciliationTimingPhase = Literal["plan", "apply", "action", "staging_cleanup"]
 
 
 class SyncReconciliationApplyRequest(SyncReconciliationPlanRequest):
     staging_root: str | None = Field(default=None, min_length=1)
     use_content_addressed_staging: bool = True
+    project_ids: list[str] = Field(default_factory=list)
+    include_timing_evidence: bool = False
+
+    @field_validator("project_ids")
+    @classmethod
+    def validate_project_ids(cls, value: list[str]) -> list[str]:
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for project_id in value:
+            cleaned = project_id.strip()
+            if not cleaned:
+                raise ValueError("Project IDs cannot contain empty values.")
+            if cleaned in seen:
+                continue
+            normalized.append(cleaned)
+            seen.add(cleaned)
+        return normalized
 
 
 class SyncReconciliationApplySummarySchema(BaseModel):
@@ -531,12 +549,26 @@ class SyncReconciliationApplyActionResultSchema(BaseModel):
     details: dict[str, Any] = Field(default_factory=dict)
 
 
+class SyncReconciliationTimingEvidenceSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    phase: SyncReconciliationTimingPhase
+    duration_ms: float = Field(ge=0)
+    action_type: SyncReconciliationActionType | None = None
+    item_type: str | None = None
+    item_id: str | None = None
+    project_id: str | None = None
+    status: SyncReconciliationApplyActionStatus | None = None
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
 class SyncReconciliationApplyResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     summary: SyncReconciliationApplySummarySchema
     plan: SyncReconciliationPlanResponse
     results: list[SyncReconciliationApplyActionResultSchema]
+    timing_evidence: list[SyncReconciliationTimingEvidenceSchema] = Field(default_factory=list)
 
 
 class SyncTransportHandshakeChallengeSchema(BaseModel):

--- a/apps/backend/app/services/projects.py
+++ b/apps/backend/app/services/projects.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 
 from app.config import get_settings
 from app.errors import AppError
-from app.models import Artifact, Project, SyncDeleteTombstone, SyncEntityRevision
+from app.models import Artifact, Project, SyncDeleteTombstone, SyncEntityRevision, utcnow
 from app.services.artifacts import register_artifact
 from app.services.metadata import extract_audio_metadata, normalize_audio_to_wav
 from app.services.paths import ensure_project_dirs, project_root, project_source_dir
@@ -18,7 +18,6 @@ from app.services.sync_identity import source_hash_to_project_id
 from app.services.sync_project_status import require_project_sync_editable
 from app.services.sync_revisions import record_project_metadata_revision
 from app.services.sync_tombstones import (
-    PROJECT_TARGET_TYPE,
     record_artifact_delete_tombstone,
     record_entity_revision_delete_tombstone,
     record_project_delete_tombstone,
@@ -125,8 +124,7 @@ def _clear_project_delete_tombstones_for_reimport(session: Session, *, project_i
     tombstones = list(
         session.scalars(
             select(SyncDeleteTombstone).where(
-                SyncDeleteTombstone.target_type == PROJECT_TARGET_TYPE,
-                SyncDeleteTombstone.target_id == project_id,
+                SyncDeleteTombstone.project_id == project_id,
             )
         )
     )
@@ -223,13 +221,14 @@ def import_project(
 def delete_project(session: Session, project_id: str) -> None:
     project = get_mutable_project(session, project_id)
     root = project_root(project.id)
-    record_project_delete_tombstone(session, project)
+    deleted_at = utcnow()
+    record_project_delete_tombstone(session, project, deleted_at=deleted_at)
     for artifact in list(session.scalars(select(Artifact).where(Artifact.project_id == project.id))):
-        record_artifact_delete_tombstone(session, artifact)
+        record_artifact_delete_tombstone(session, artifact, deleted_at=deleted_at)
     for revision in list(
         session.scalars(select(SyncEntityRevision).where(SyncEntityRevision.project_id == project.id))
     ):
-        record_entity_revision_delete_tombstone(session, revision)
+        record_entity_revision_delete_tombstone(session, revision, deleted_at=deleted_at)
     session.delete(project)
     session.flush()
     if root.exists():

--- a/apps/backend/app/services/sync_manifest.py
+++ b/apps/backend/app/services/sync_manifest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from copy import deepcopy
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
@@ -177,6 +177,16 @@ def export_project_manifest(session: Session, project_id: str) -> SyncProjectMan
     )
     entity_revisions = _list_project_entity_revisions(session, project_id=project.id)
     delete_tombstones = _list_project_delete_tombstones(session, project_id=project.id)
+    live_targets = _live_target_updated_at(project, artifacts, entity_revisions)
+    exported_tombstones = [
+        _export_delete_tombstone_manifest(tombstone)
+        for tombstone in delete_tombstones
+    ]
+    project_resurrection_window = _project_resurrection_window_for_live_targets(
+        project_updated_at=project.updated_at,
+        tombstones=exported_tombstones,
+        project_id=project.id,
+    )
 
     manifest = SyncProjectManifest(
         schema_version=SYNC_PROJECT_MANIFEST_SCHEMA_VERSION,
@@ -198,8 +208,13 @@ def export_project_manifest(session: Session, project_id: str) -> SyncProjectMan
         ],
         artifacts=[_export_artifact_manifest(artifact) for artifact in artifacts],
         delete_tombstones=[
-            _export_delete_tombstone_manifest(tombstone)
-            for tombstone in delete_tombstones
+            tombstone
+            for tombstone in exported_tombstones
+            if not _live_target_supersedes_tombstone(
+                tombstone,
+                live_targets,
+                project_resurrection_window=project_resurrection_window,
+            )
         ],
     )
     _validate_source_artifact_present(manifest)
@@ -335,6 +350,11 @@ def import_staged_project_manifest(
         _import_entity_revisions(session, project_manifest)
         imported_tombstones = _import_delete_tombstones(session, project_manifest)
         _apply_delete_tombstones(session, imported_tombstones)
+        _retire_manifest_superseded_local_tombstones(
+            session,
+            project_manifest,
+            sync_group_id=local_sync_group_id,
+        )
         _hydrate_current_entity_revisions(session, project, project_manifest.entity_revisions)
         hydrate_project_analysis_result_from_artifact(session, project.id)
         if upgrading_placeholder:
@@ -435,6 +455,11 @@ def _merge_staged_project_manifest(
         _import_entity_revisions(session, merge_manifest)
         imported_tombstones = _import_delete_tombstones(session, manifest)
         _apply_delete_tombstones(session, imported_tombstones)
+        _retire_manifest_superseded_local_tombstones(
+            session,
+            manifest,
+            sync_group_id=get_or_create_local_identity(session).sync_group_id,
+        )
         _hydrate_current_entity_revisions(session, project, missing_revisions)
         hydrate_project_analysis_result_from_artifact(session, project.id)
     except OSError as exc:
@@ -500,7 +525,7 @@ def _reject_existing_manifest_item_conflicts(
             continue
         if (
             existing_revision.project_id != manifest.project_id
-            or revision_payload_sha256(existing_revision.payload_json or {}) != revision.content_sha256
+            or _local_revision_content_sha256(existing_revision) != revision.content_sha256
         ):
             raise AppError(
                 "SYNC_MANIFEST_ENTITY_REVISION_CONFLICT",
@@ -546,6 +571,44 @@ def _list_project_delete_tombstones(
             )
         )
     )
+
+
+def _live_target_updated_at(
+    project: Project,
+    artifacts: Iterable[Artifact],
+    entity_revisions: Iterable[SyncEntityRevision],
+) -> dict[tuple[str, str], datetime]:
+    targets = {("project", project.id): project.updated_at}
+    targets.update({("artifact", artifact.id): artifact.created_at for artifact in artifacts})
+    targets.update({
+        ("entity_revision", revision.id): revision.updated_at for revision in entity_revisions
+    })
+    return targets
+
+
+def _live_target_supersedes_tombstone(
+    tombstone: SyncDeleteTombstoneManifest,
+    live_targets: dict[tuple[str, str], datetime],
+    *,
+    project_resurrection_window: tuple[datetime, datetime] | None = None,
+) -> bool:
+    target_updated_at = live_targets.get((tombstone.target_type, tombstone.target_id))
+    if target_updated_at is None:
+        return False
+    tombstone_deleted_at = _as_utc(tombstone.deleted_at)
+    if _as_utc(target_updated_at) > tombstone_deleted_at:
+        return True
+    return _tombstone_is_inside_project_resurrection_window(
+        tombstone_deleted_at,
+        project_resurrection_window,
+    )
+
+
+def _local_revision_content_sha256(revision: SyncEntityRevision) -> str | None:
+    payload = revision.payload_json
+    if isinstance(payload, Mapping):
+        return revision_payload_sha256(sanitize_revision_payload(payload))
+    return None
 
 
 def _export_artifact_manifest(artifact: Artifact) -> SyncArtifactManifest:
@@ -1445,17 +1508,144 @@ def _local_tombstone_conflicts(
     tombstones = _list_project_delete_tombstones(session, project_id=manifest.project_id)
     if not tombstones:
         return []
+    exported_tombstones = [_export_delete_tombstone_manifest(row) for row in tombstones]
+    project_resurrection_window = _project_resurrection_window_for_live_targets(
+        project_updated_at=manifest.updated_at,
+        tombstones=exported_tombstones,
+        project_id=manifest.project_id,
+    )
 
     live_targets = _manifest_live_targets(manifest)
     conflicts: list[SyncDeleteTombstoneManifest] = []
-    for row in tombstones:
-        tombstone = _export_delete_tombstone_manifest(row)
+    for tombstone in exported_tombstones:
         if tombstone.sync_group_id != sync_group_id:
             continue
         target = (_normalize_tombstone_target_type(tombstone.target_type), tombstone.target_id)
         if target in live_targets:
+            if _manifest_target_supersedes_tombstone(
+                manifest,
+                tombstone,
+                project_resurrection_window=project_resurrection_window,
+            ):
+                continue
             conflicts.append(tombstone)
     return conflicts
+
+
+def _retire_manifest_superseded_local_tombstones(
+    session: Session,
+    manifest: SyncProjectManifest,
+    *,
+    sync_group_id: str,
+) -> None:
+    tombstones = _list_project_delete_tombstones(session, project_id=manifest.project_id)
+    exported_tombstones = {
+        row.id: _export_delete_tombstone_manifest(row)
+        for row in tombstones
+    }
+    project_resurrection_window = _project_resurrection_window_for_live_targets(
+        project_updated_at=manifest.updated_at,
+        tombstones=exported_tombstones.values(),
+        project_id=manifest.project_id,
+    )
+    for row in tombstones:
+        tombstone = exported_tombstones[row.id]
+        if tombstone.sync_group_id != sync_group_id:
+            continue
+        if _manifest_target_supersedes_tombstone(
+            manifest,
+            tombstone,
+            project_resurrection_window=project_resurrection_window,
+        ):
+            session.delete(row)
+    session.flush()
+
+
+def _manifest_target_supersedes_tombstone(
+    manifest: SyncProjectManifest,
+    tombstone: SyncDeleteTombstoneManifest,
+    *,
+    project_resurrection_window: tuple[datetime, datetime] | None = None,
+) -> bool:
+    target_type = _normalize_tombstone_target_type(tombstone.target_type)
+    target_updated_at = _manifest_target_updated_at(
+        manifest,
+        target_type=target_type,
+        target_id=tombstone.target_id,
+    )
+    if target_updated_at is None:
+        return False
+    tombstone_deleted_at = _as_utc(tombstone.deleted_at)
+    if _as_utc(target_updated_at) > tombstone_deleted_at:
+        return True
+    return _tombstone_is_inside_project_resurrection_window(
+        tombstone_deleted_at,
+        project_resurrection_window,
+    )
+
+
+def _manifest_target_updated_at(
+    manifest: SyncProjectManifest,
+    *,
+    target_type: str,
+    target_id: str,
+) -> datetime | None:
+    if target_type == "project" and target_id == manifest.project_id:
+        return manifest.updated_at
+    if target_type == "artifact":
+        return next(
+            (
+                artifact.created_at
+                for artifact in manifest.artifacts
+                if artifact.artifact_id == target_id
+            ),
+            None,
+        )
+    if target_type == "entity_revision":
+        return next(
+            (
+                revision.updated_at
+                for revision in manifest.entity_revisions
+                if revision.revision_id == target_id
+            ),
+            None,
+        )
+    return None
+
+
+def _project_resurrection_window_for_live_targets(
+    *,
+    project_updated_at: datetime,
+    tombstones: Iterable[SyncDeleteTombstoneManifest],
+    project_id: str,
+) -> tuple[datetime, datetime] | None:
+    project_updated = _as_utc(project_updated_at)
+    superseded_project_deletes = [
+        _as_utc(tombstone.deleted_at)
+        for tombstone in tombstones
+        if _normalize_tombstone_target_type(tombstone.target_type) == "project"
+        and tombstone.target_id == project_id
+        and project_updated > _as_utc(tombstone.deleted_at)
+    ]
+    if not superseded_project_deletes:
+        return None
+    return max(superseded_project_deletes), project_updated
+
+
+def _tombstone_is_inside_project_resurrection_window(
+    tombstone_deleted_at: datetime,
+    project_resurrection_window: tuple[datetime, datetime] | None,
+) -> bool:
+    if project_resurrection_window is None:
+        return False
+    project_deleted_at, project_updated_at = project_resurrection_window
+    return project_deleted_at <= tombstone_deleted_at < project_updated_at
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
 
 
 def _manifest_live_targets(manifest: SyncProjectManifest) -> set[tuple[str, str]]:

--- a/apps/backend/app/services/sync_metadata.py
+++ b/apps/backend/app/services/sync_metadata.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.models import Artifact, Project, SyncDeleteTombstone
+from app.models import Artifact, Project, SyncDeleteTombstone, SyncEntityRevision
 from app.services.paths import project_root
 
 LOCAL_METADATA_PATH_KEYS = {
@@ -88,7 +88,30 @@ def get_sync_metadata(session: Session) -> SyncMetadataResult:
             )
         )
     )
-    delete_tombstones = _list_delete_tombstones(session)
+    entity_revisions = list(
+        session.scalars(
+            select(SyncEntityRevision).order_by(
+                SyncEntityRevision.project_id.asc(),
+                SyncEntityRevision.updated_at.asc(),
+                SyncEntityRevision.id.asc(),
+            )
+        )
+    )
+    live_targets = _live_target_updated_at(projects, artifacts, entity_revisions)
+    all_delete_tombstones = _list_delete_tombstones(session)
+    project_resurrection_windows = _project_resurrection_windows_for_live_targets(
+        projects,
+        all_delete_tombstones,
+    )
+    delete_tombstones = [
+        tombstone
+        for tombstone in all_delete_tombstones
+        if not _live_target_supersedes_tombstone(
+            tombstone,
+            live_targets,
+            project_resurrection_windows=project_resurrection_windows,
+        )
+    ]
 
     return SyncMetadataResult(
         projects=[_project_metadata(project) for project in projects],
@@ -173,6 +196,74 @@ def _list_delete_tombstones(session: Session) -> list[SyncDeleteTombstone]:
             )
         )
     )
+
+
+def _live_target_updated_at(
+    projects: list[Project],
+    artifacts: list[Artifact],
+    entity_revisions: list[SyncEntityRevision],
+) -> dict[tuple[str, str], datetime]:
+    targets = {("project", project.id): project.updated_at for project in projects}
+    targets.update({("artifact", artifact.id): artifact.created_at for artifact in artifacts})
+    targets.update({
+        ("entity_revision", revision.id): revision.updated_at for revision in entity_revisions
+    })
+    return targets
+
+
+def _live_target_supersedes_tombstone(
+    tombstone: SyncDeleteTombstone,
+    live_targets: dict[tuple[str, str], datetime],
+    *,
+    project_resurrection_windows: dict[str, tuple[datetime, datetime]],
+) -> bool:
+    target_updated_at = live_targets.get((tombstone.target_type, tombstone.target_id))
+    if target_updated_at is None:
+        return False
+    tombstone_deleted_at = _as_utc(tombstone.deleted_at)
+    if _as_utc(target_updated_at) > tombstone_deleted_at:
+        return True
+    return _tombstone_is_inside_project_resurrection_window(
+        tombstone_deleted_at,
+        project_resurrection_windows.get(tombstone.project_id),
+    )
+
+
+def _project_resurrection_windows_for_live_targets(
+    projects: list[Project],
+    tombstones: list[SyncDeleteTombstone],
+) -> dict[str, tuple[datetime, datetime]]:
+    project_updated_at = {project.id: _as_utc(project.updated_at) for project in projects}
+    windows: dict[str, tuple[datetime, datetime]] = {}
+    for tombstone in tombstones:
+        if tombstone.target_type != "project" or tombstone.target_id != tombstone.project_id:
+            continue
+        live_updated_at = project_updated_at.get(tombstone.project_id)
+        if live_updated_at is None:
+            continue
+        tombstone_deleted_at = _as_utc(tombstone.deleted_at)
+        if live_updated_at <= tombstone_deleted_at:
+            continue
+        existing = windows.get(tombstone.project_id)
+        if existing is None or tombstone_deleted_at > existing[0]:
+            windows[tombstone.project_id] = (tombstone_deleted_at, live_updated_at)
+    return windows
+
+
+def _tombstone_is_inside_project_resurrection_window(
+    tombstone_deleted_at: datetime,
+    project_resurrection_window: tuple[datetime, datetime] | None,
+) -> bool:
+    if project_resurrection_window is None:
+        return False
+    project_deleted_at, project_updated_at = project_resurrection_window
+    return project_deleted_at <= tombstone_deleted_at < project_updated_at
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
 
 
 def _project_relative_artifact_path(artifact: Artifact) -> str | None:

--- a/apps/backend/app/services/sync_reconciliation.py
+++ b/apps/backend/app/services/sync_reconciliation.py
@@ -221,16 +221,27 @@ def plan_sync_reconciliation(
             ignored_remote_tombstones.append((tombstone, reason))
 
     fresh_remote_tombstones: list[_RemoteTombstone] = []
+    remote_project_resurrection_windows = _project_resurrection_windows_for_tombstones(
+        valid_remote_tombstones,
+        local=local,
+        remote=remote,
+        include_remote=False,
+    )
     for tombstone in valid_remote_tombstones:
-        if _project_tombstone_is_older_than_live_project(
-            target_type=tombstone.target_type,
-            project_id=tombstone.project_id,
-            deleted_at=tombstone.deleted_at,
-            local_projects=local.projects,
-            remote_projects=remote.projects,
+        if _tombstone_is_older_than_live_target(
+            tombstone,
+            local=local,
+            remote=remote,
+            include_remote=False,
+            project_resurrection_window=remote_project_resurrection_windows.get(tombstone.project_id),
         ):
+            reason = (
+                "Project delete tombstone is older than a live project."
+                if tombstone.target_type == ITEM_PROJECT
+                else "Delete tombstone is older than a live sync target."
+            )
             ignored_remote_tombstones.append(
-                (tombstone, "Project delete tombstone is older than a live project manifest.")
+                (tombstone, reason)
             )
         else:
             fresh_remote_tombstones.append(tombstone)
@@ -239,8 +250,8 @@ def plan_sync_reconciliation(
     effective_tombstones = _effective_tombstone_targets(
         local.tombstones,
         valid_remote_tombstones,
-        local_projects=local.projects,
-        remote_projects=remote.projects,
+        local=local,
+        remote=remote,
     )
 
     for tombstone, reason in sorted(ignored_remote_tombstones, key=lambda item: _remote_tombstone_sort_key(item[0])):
@@ -324,6 +335,19 @@ def plan_sync_reconciliation(
             and local_revision is not None
             and local_revision.project_id == revision.project_id
             and _local_revision_content_sha256(local_revision) == revision.content_sha256
+        ):
+            continue
+        if (
+            revision.project_id in remote.project_manifests_by_id
+            and revision.revision_id in remote.manifest_revision_ids_by_project.get(revision.project_id, frozenset())
+            and revision.project_id not in planned_project_ids
+            and _has_imported_local_project(local, revision.project_id)
+            and not _is_deleted(
+                ITEM_ENTITY_REVISION,
+                revision.revision_id,
+                revision.project_id,
+                effective_tombstones,
+            )
         ):
             continue
         if (
@@ -443,6 +467,8 @@ def _has_imported_local_project(local: _LocalState, project_id: str) -> bool:
 
 
 def _is_sync_project_placeholder(project: Project) -> bool:
+    if project.sync_status != PROJECT_SYNC_STATUS_LOCAL:
+        return True
     source_path = (project.source_path or "").strip()
     imported_path = (project.imported_path or "").strip()
     return (
@@ -1893,30 +1919,50 @@ def _effective_tombstone_targets(
     local_tombstones: Iterable[SyncDeleteTombstone],
     remote_tombstones: Iterable[_RemoteTombstone],
     *,
-    local_projects: Mapping[str, Project],
-    remote_projects: Mapping[str, _RemoteProject],
+    local: _LocalState,
+    remote: _RemoteRequest,
 ) -> frozenset[tuple[str, str]]:
     targets: set[tuple[str, str]] = set()
+    local_tombstones = tuple(local_tombstones)
+    remote_tombstones = tuple(remote_tombstones)
+    local_project_resurrection_windows = _project_resurrection_windows_for_tombstones(
+        local_tombstones,
+        local=local,
+        remote=remote,
+        include_remote=True,
+    )
+    remote_project_resurrection_windows = _project_resurrection_windows_for_tombstones(
+        remote_tombstones,
+        local=local,
+        remote=remote,
+        include_remote=False,
+    )
     for local_tombstone in local_tombstones:
         target_type = _normalize_target_type(local_tombstone.target_type)
-        if _project_tombstone_is_older_than_live_project(
+        if _tombstone_fields_are_older_than_live_target(
             target_type=target_type,
+            target_id=local_tombstone.target_id,
             project_id=local_tombstone.project_id,
             deleted_at=local_tombstone.deleted_at,
-            local_projects=local_projects,
-            remote_projects=remote_projects,
+            local=local,
+            remote=remote,
+            include_remote=True,
+            project_resurrection_window=local_project_resurrection_windows.get(local_tombstone.project_id),
         ):
             continue
         targets.add((target_type, local_tombstone.target_id))
         if target_type == ITEM_PROJECT:
             targets.add((ITEM_PROJECT, local_tombstone.project_id))
     for remote_tombstone in remote_tombstones:
-        if _project_tombstone_is_older_than_live_project(
+        if _tombstone_fields_are_older_than_live_target(
             target_type=remote_tombstone.target_type,
+            target_id=remote_tombstone.target_id,
             project_id=remote_tombstone.project_id,
             deleted_at=remote_tombstone.deleted_at,
-            local_projects=local_projects,
-            remote_projects=remote_projects,
+            local=local,
+            remote=remote,
+            include_remote=False,
+            project_resurrection_window=remote_project_resurrection_windows.get(remote_tombstone.project_id),
         ):
             continue
         targets.add((remote_tombstone.target_type, remote_tombstone.target_id))
@@ -1925,37 +1971,201 @@ def _effective_tombstone_targets(
     return frozenset(targets)
 
 
-def _project_tombstone_is_older_than_live_project(
+def _tombstone_is_older_than_live_target(
+    tombstone: object,
+    *,
+    local: _LocalState,
+    remote: _RemoteRequest,
+    include_remote: bool,
+    project_resurrection_window: tuple[datetime, datetime] | None = None,
+) -> bool:
+    target_type = _normalize_target_type(_str_field(tombstone, "target_type", default="") or "")
+    target_id = _str_field(tombstone, "target_id")
+    project_id = _str_field(tombstone, "project_id")
+    if target_id is None or project_id is None:
+        return False
+    return _tombstone_fields_are_older_than_live_target(
+        target_type=target_type,
+        target_id=target_id,
+        project_id=project_id,
+        deleted_at=_first_field(tombstone, "deleted_at", default=None),
+        local=local,
+        remote=remote,
+        include_remote=include_remote,
+        project_resurrection_window=project_resurrection_window,
+    )
+
+
+def _tombstone_fields_are_older_than_live_target(
     *,
     target_type: str,
+    target_id: str,
     project_id: str,
     deleted_at: object,
-    local_projects: Mapping[str, Project],
-    remote_projects: Mapping[str, _RemoteProject],
+    local: _LocalState,
+    remote: _RemoteRequest,
+    include_remote: bool,
+    project_resurrection_window: tuple[datetime, datetime] | None = None,
 ) -> bool:
-    if target_type != ITEM_PROJECT:
-        return False
-
     tombstone_deleted_at = _coerce_datetime(deleted_at)
     if tombstone_deleted_at is None:
         return False
 
-    local_project = local_projects.get(project_id)
+    live_updated_at = _local_live_target_updated_at(
+        local,
+        target_type=target_type,
+        target_id=target_id,
+        project_id=project_id,
+    )
+    if live_updated_at is not None and live_updated_at > tombstone_deleted_at:
+        return True
+    if live_updated_at is not None and _tombstone_is_inside_project_resurrection_window(
+        tombstone_deleted_at,
+        project_resurrection_window,
+    ):
+        return True
+
+    if include_remote:
+        remote_updated_at = _remote_live_target_updated_at(
+            remote,
+            target_type=target_type,
+            target_id=target_id,
+            project_id=project_id,
+        )
+        if remote_updated_at is not None and remote_updated_at > tombstone_deleted_at:
+            return True
+        return remote_updated_at is not None and _tombstone_is_inside_project_resurrection_window(
+            tombstone_deleted_at,
+            project_resurrection_window,
+        )
+    return False
+
+
+def _local_live_target_updated_at(
+    local: _LocalState,
+    *,
+    target_type: str,
+    target_id: str,
+    project_id: str,
+) -> datetime | None:
+    if target_type == ITEM_PROJECT:
+        local_project = local.projects.get(project_id)
+        if target_id != project_id:
+            return None
+        if local_project is None or local_project.sync_status == PROJECT_SYNC_STATUS_DELETED:
+            return None
+        return _coerce_datetime(local_project.updated_at)
+    if target_type == ITEM_ARTIFACT:
+        local_artifact = local.artifacts.get(target_id)
+        if local_artifact is None or local_artifact.project_id != project_id:
+            return None
+        return _coerce_datetime(local_artifact.created_at)
+    if target_type == ITEM_ENTITY_REVISION:
+        local_revision = local.entity_revisions.get(target_id)
+        if local_revision is None or local_revision.project_id != project_id:
+            return None
+        return _coerce_datetime(local_revision.updated_at)
+    return None
+
+
+def _remote_live_target_updated_at(
+    remote: _RemoteRequest,
+    *,
+    target_type: str,
+    target_id: str,
+    project_id: str,
+) -> datetime | None:
+    if target_type == ITEM_PROJECT:
+        if target_id != project_id:
+            return None
+        remote_project = remote.projects.get(project_id)
+        if remote_project is None:
+            return None
+        remote_status = _str_field(remote_project.raw, "sync_status", "sync_state")
+        if remote_status == PROJECT_SYNC_STATUS_DELETED:
+            return None
+        return _coerce_datetime(
+            _first_field(remote_project.raw, "updated_at", "created_at", default=None)
+        )
+    if target_type == ITEM_ARTIFACT:
+        remote_artifact = remote.artifacts.get(target_id)
+        if remote_artifact is None or remote_artifact.project_id != project_id:
+            return None
+        return _coerce_datetime(_first_field(remote_artifact.raw, "created_at", default=None))
+    if target_type == ITEM_ENTITY_REVISION:
+        remote_revision = remote.entity_revisions.get(target_id)
+        if remote_revision is None or remote_revision.project_id != project_id:
+            return None
+        return _coerce_datetime(
+            _first_field(remote_revision.raw, "updated_at", "created_at", default=None)
+        )
+    return None
+
+
+def _project_resurrection_windows_for_tombstones(
+    tombstones: Iterable[object],
+    *,
+    local: _LocalState,
+    remote: _RemoteRequest,
+    include_remote: bool,
+) -> dict[str, tuple[datetime, datetime]]:
+    windows: dict[str, tuple[datetime, datetime]] = {}
+    for tombstone in tombstones:
+        target_type = _normalize_target_type(_str_field(tombstone, "target_type", default="") or "")
+        project_id = _str_field(tombstone, "project_id")
+        target_id = _str_field(tombstone, "target_id")
+        if target_type != ITEM_PROJECT or project_id is None or target_id != project_id:
+            continue
+        tombstone_deleted_at = _coerce_datetime(_first_field(tombstone, "deleted_at", default=None))
+        if tombstone_deleted_at is None:
+            continue
+        live_project_updated_at = _live_project_updated_at(
+            project_id,
+            local=local,
+            remote=remote,
+            include_remote=include_remote,
+        )
+        if live_project_updated_at is None or live_project_updated_at <= tombstone_deleted_at:
+            continue
+        existing = windows.get(project_id)
+        if existing is None or tombstone_deleted_at > existing[0]:
+            windows[project_id] = (tombstone_deleted_at, live_project_updated_at)
+    return windows
+
+
+def _live_project_updated_at(
+    project_id: str,
+    *,
+    local: _LocalState,
+    remote: _RemoteRequest,
+    include_remote: bool,
+) -> datetime | None:
+    candidates: list[datetime] = []
+    local_project = local.projects.get(project_id)
     if local_project is not None and local_project.sync_status != PROJECT_SYNC_STATUS_DELETED:
         local_updated_at = _coerce_datetime(local_project.updated_at)
-        if local_updated_at is not None and local_updated_at > tombstone_deleted_at:
-            return True
+        if local_updated_at is not None:
+            candidates.append(local_updated_at)
+    if include_remote:
+        remote_updated_at = _remote_live_target_updated_at(
+            remote,
+            target_type=ITEM_PROJECT,
+            target_id=project_id,
+            project_id=project_id,
+        )
+        if remote_updated_at is not None:
+            candidates.append(remote_updated_at)
+    return max(candidates) if candidates else None
 
-    remote_project = remote_projects.get(project_id)
-    if remote_project is None:
+
+def _tombstone_is_inside_project_resurrection_window(
+    tombstone_deleted_at: datetime,
+    project_resurrection_window: tuple[datetime, datetime] | None,
+) -> bool:
+    if project_resurrection_window is None:
         return False
-    remote_status = _str_field(remote_project.raw, "sync_status", "sync_state")
-    if remote_status == PROJECT_SYNC_STATUS_DELETED:
-        return False
-    remote_updated_at = _coerce_datetime(
-        _first_field(remote_project.raw, "updated_at", "created_at", default=None)
-    )
-    return remote_updated_at is not None and remote_updated_at > tombstone_deleted_at
+    project_deleted_at, project_updated_at = project_resurrection_window
+    return project_deleted_at <= tombstone_deleted_at < project_updated_at
 
 
 def _is_deleted(
@@ -2348,7 +2558,7 @@ def _local_revision_content_sha256(revision: SyncEntityRevision) -> str | None:
     payload = revision.payload_json
     if isinstance(payload, Mapping):
         return revision_payload_sha256(sanitize_revision_payload(payload))
-    return _normalize_sha256(revision.content_sha256)
+    return None
 
 
 def _upsert_item(

--- a/apps/backend/app/services/sync_reconciliation_apply.py
+++ b/apps/backend/app/services/sync_reconciliation_apply.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from time import perf_counter
 from typing import Any
 
 from sqlalchemy.orm import Session
@@ -38,7 +39,7 @@ from app.services.sync_reconciliation import (
     SyncReconciliationPlan,
     plan_sync_reconciliation,
 )
-from app.services.sync_revisions import revision_payload_sha256
+from app.services.sync_revisions import revision_payload_sha256, sanitize_revision_payload
 from app.services.sync_staging import cleanup_staged_artifacts, require_staged_artifact
 from app.services.sync_tombstones import apply_delete_tombstone
 from app.utils.hashing import file_sha256
@@ -47,6 +48,11 @@ APPLY_STATUS_APPLIED = "applied"
 APPLY_STATUS_SATISFIED = "satisfied"
 APPLY_STATUS_SKIPPED = "skipped"
 APPLY_STATUS_FAILED = "failed"
+
+TIMING_PHASE_PLAN = "plan"
+TIMING_PHASE_APPLY = "apply"
+TIMING_PHASE_ACTION = "action"
+TIMING_PHASE_STAGING_CLEANUP = "staging_cleanup"
 
 _MISSING = object()
 
@@ -69,10 +75,23 @@ class SyncReconciliationApplyActionResult:
 
 
 @dataclass(frozen=True)
+class SyncReconciliationTimingEvidence:
+    phase: str
+    duration_ms: float
+    action_type: str | None = None
+    item_type: str | None = None
+    item_id: str | None = None
+    project_id: str | None = None
+    status: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
 class SyncReconciliationApplyResult:
     summary: SyncReconciliationApplySummary
     plan: SyncReconciliationPlan
     results: list[SyncReconciliationApplyActionResult]
+    timing_evidence: list[SyncReconciliationTimingEvidence] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -80,8 +99,10 @@ class _ApplyContext:
     project_manifests_by_id: dict[str, object]
     tombstones_by_id: dict[str, object]
     tombstones_by_target: dict[tuple[str, str], object]
+    scoped_project_ids: frozenset[str]
     staging_root: str | None
     use_content_addressed_staging: bool
+    include_timing_evidence: bool
 
 
 def apply_sync_reconciliation(
@@ -89,19 +110,62 @@ def apply_sync_reconciliation(
     request: object | Mapping[str, Any],
 ) -> SyncReconciliationApplyResult:
     context = _apply_context(request)
+    timing_evidence: list[SyncReconciliationTimingEvidence] = []
+
+    plan_started_at = _timing_start(context)
+    plan_request = _scoped_plan_request(request, context)
     plan = _with_staged_manifest_import_actions(
         session,
-        plan_sync_reconciliation(session, request),
+        plan_sync_reconciliation(session, plan_request),
         context,
     )
-    results = [_apply_action_in_savepoint(session, action, context) for action in plan.actions]
+    _record_timing(
+        timing_evidence,
+        phase=TIMING_PHASE_PLAN,
+        started_at=plan_started_at,
+        details={
+            "planned_actions": len(plan.actions),
+            "scoped_project_count": len(context.scoped_project_ids),
+        },
+    )
+
+    apply_started_at = _timing_start(context)
+    results: list[SyncReconciliationApplyActionResult] = []
+    for action in plan.actions:
+        action_started_at = _timing_start(context)
+        result = _apply_action_in_savepoint(session, action, context)
+        results.append(result)
+        _record_action_timing(timing_evidence, action, result, action_started_at)
+
     results.extend(_hydrate_imported_project_analysis(session, context, results))
     if context.use_content_addressed_staging:
-        _cleanup_imported_content_addressed_staging(session, context)
+        cleanup_started_at = _timing_start(context)
+        cleanup_details = _cleanup_imported_content_addressed_staging(session, context)
+        _record_timing(
+            timing_evidence,
+            phase=TIMING_PHASE_STAGING_CLEANUP,
+            started_at=cleanup_started_at,
+            details=cleanup_details,
+        )
+    summary = _summarize_apply_results(plan, results)
+    _record_timing(
+        timing_evidence,
+        phase=TIMING_PHASE_APPLY,
+        started_at=apply_started_at,
+        details={
+            "planned_actions": summary.planned_actions,
+            "applied_actions": summary.applied_actions,
+            "satisfied_actions": summary.satisfied_actions,
+            "skipped_actions": summary.skipped_actions,
+            "failed_actions": summary.failed_actions,
+            "result_count": len(results),
+        },
+    )
     return SyncReconciliationApplyResult(
-        summary=_summarize_apply_results(plan, results),
+        summary=summary,
         plan=plan,
         results=results,
+        timing_evidence=timing_evidence,
     )
 
 
@@ -350,7 +414,7 @@ def _import_entity_revision(
         return _result(action, APPLY_STATUS_SKIPPED, "Entity revision is not present in the project manifest.")
     existing_revision = session.get(SyncEntityRevision, revision.revision_id)
     if existing_revision is not None:
-        if revision_payload_sha256(existing_revision.payload_json or {}) == revision.content_sha256:
+        if _local_revision_content_sha256(existing_revision) == revision.content_sha256:
             return _result(action, APPLY_STATUS_SATISFIED, "Entity revision is already imported locally.")
         return _result(action, APPLY_STATUS_FAILED, "Entity revision conflicts with a local revision.")
 
@@ -503,7 +567,7 @@ def _missing_content_addressed_artifacts(
 def _cleanup_imported_content_addressed_staging(
     session: Session,
     context: _ApplyContext,
-) -> None:
+) -> dict[str, Any]:
     imported_hashes: set[str] = set()
     pending_hashes: set[str] = set()
     imported_references: list[dict[str, Any]] = []
@@ -527,6 +591,12 @@ def _cleanup_imported_content_addressed_staging(
             content_sha256s=cleanup_hashes,
             references=cleanup_references,
         )
+    return {
+        "imported_content_sha256_count": len(imported_hashes),
+        "pending_content_sha256_count": len(pending_hashes),
+        "cleaned_content_sha256_count": len(cleanup_hashes),
+        "cleaned_reference_count": len(cleanup_references),
+    }
 
 
 def _hydrate_imported_project_analysis(
@@ -680,6 +750,12 @@ def _apply_context(request: object | Mapping[str, Any]) -> _ApplyContext:
         )
         if project_id is not None
     }
+    explicit_project_ids = _normalized_string_set(_list_field(request, "project_ids"))
+    scoped_project_ids = (
+        frozenset(explicit_project_ids)
+        if explicit_project_ids
+        else frozenset(project_manifests_by_id)
+    )
 
     remote_library = _field(request, "remote_library", default={})
     tombstones = [
@@ -689,6 +765,9 @@ def _apply_context(request: object | Mapping[str, Any]) -> _ApplyContext:
     tombstones_by_id: dict[str, object] = {}
     tombstones_by_target: dict[tuple[str, str], object] = {}
     for tombstone in tombstones:
+        tombstone_project_id = _string_field(tombstone, "project_id")
+        if scoped_project_ids and tombstone_project_id not in scoped_project_ids:
+            continue
         tombstone_id = _string_field(tombstone, "tombstone_id", "id")
         target_type = _normalize_target_type(_string_field(tombstone, "target_type") or "")
         target_id = _string_field(tombstone, "target_id")
@@ -701,9 +780,62 @@ def _apply_context(request: object | Mapping[str, Any]) -> _ApplyContext:
         project_manifests_by_id=project_manifests_by_id,
         tombstones_by_id=tombstones_by_id,
         tombstones_by_target=tombstones_by_target,
+        scoped_project_ids=scoped_project_ids,
         staging_root=_string_field(request, "staging_root"),
         use_content_addressed_staging=_bool_field(request, "use_content_addressed_staging", default=True),
+        include_timing_evidence=_bool_field(request, "include_timing_evidence", default=False),
     )
+
+
+def _scoped_plan_request(
+    request: object | Mapping[str, Any],
+    context: _ApplyContext,
+) -> object | Mapping[str, Any]:
+    if not context.scoped_project_ids:
+        return request
+
+    payload = _object_mapping(request)
+    payload["project_manifests"] = [
+        manifest
+        for manifest in _list_field(request, "project_manifests")
+        if _project_id_from_manifest(manifest) in context.scoped_project_ids
+    ]
+    payload["remote_library"] = _scoped_remote_library(
+        _field(request, "remote_library", default={}),
+        context.scoped_project_ids,
+    )
+    return payload
+
+
+def _scoped_remote_library(
+    remote_library: object,
+    scoped_project_ids: frozenset[str],
+) -> dict[str, Any]:
+    scoped = _object_mapping(remote_library)
+    scoped["projects"] = [
+        project
+        for project in _list_field(remote_library, "projects")
+        if _string_field(project, "project_id", "id") in scoped_project_ids
+    ]
+    scoped["artifacts"] = [
+        artifact
+        for artifact in _list_field(remote_library, "artifacts")
+        if _string_field(artifact, "project_id") in scoped_project_ids
+    ]
+    scoped["entity_revisions"] = [
+        revision
+        for revision in _list_field(remote_library, "entity_revisions", "revisions")
+        if _string_field(revision, "project_id") in scoped_project_ids
+    ]
+    scoped_tombstones = [
+        tombstone
+        for tombstone in _list_field(remote_library, "delete_tombstones", "tombstones")
+        if _string_field(tombstone, "project_id") in scoped_project_ids
+    ]
+    scoped["delete_tombstones"] = scoped_tombstones
+    if "tombstones" in scoped:
+        scoped["tombstones"] = scoped_tombstones
+    return scoped
 
 
 def _with_staged_manifest_import_actions(
@@ -844,6 +976,56 @@ def _result(
     )
 
 
+def _timing_start(context: _ApplyContext) -> float | None:
+    return perf_counter() if context.include_timing_evidence else None
+
+
+def _record_action_timing(
+    timing_evidence: list[SyncReconciliationTimingEvidence],
+    action: SyncReconciliationAction,
+    result: SyncReconciliationApplyActionResult,
+    started_at: float | None,
+) -> None:
+    _record_timing(
+        timing_evidence,
+        phase=TIMING_PHASE_ACTION,
+        started_at=started_at,
+        action_type=action.action_type,
+        item_type=action.item_type,
+        item_id=action.item_id,
+        project_id=action.project_id,
+        status=result.status,
+    )
+
+
+def _record_timing(
+    timing_evidence: list[SyncReconciliationTimingEvidence],
+    *,
+    phase: str,
+    started_at: float | None,
+    action_type: str | None = None,
+    item_type: str | None = None,
+    item_id: str | None = None,
+    project_id: str | None = None,
+    status: str | None = None,
+    details: dict[str, Any] | None = None,
+) -> None:
+    if started_at is None:
+        return
+    timing_evidence.append(
+        SyncReconciliationTimingEvidence(
+            phase=phase,
+            duration_ms=round((perf_counter() - started_at) * 1000, 3),
+            action_type=action_type,
+            item_type=item_type,
+            item_id=item_id,
+            project_id=project_id,
+            status=status,
+            details=details or {},
+        )
+    )
+
+
 def _error_details(action: SyncReconciliationAction, exc: AppError) -> dict[str, Any]:
     return {
         "action_type": action.action_type,
@@ -870,6 +1052,16 @@ def _field(source: object, name: str, *, default: object = _MISSING) -> Any:
     return value
 
 
+def _object_mapping(source: object) -> dict[str, Any]:
+    if isinstance(source, Mapping):
+        return dict(source)
+    model_dump = getattr(source, "model_dump", None)
+    if callable(model_dump):
+        dumped = model_dump(mode="python")
+        return dict(dumped) if isinstance(dumped, Mapping) else {}
+    return {}
+
+
 def _list_field(source: object, *names: str) -> list[Any]:
     for name in names:
         value = _field(source, name, default=None)
@@ -891,6 +1083,14 @@ def _string_field(source: object, *names: str) -> str | None:
             if normalized:
                 return normalized
     return None
+
+
+def _normalized_string_set(values: list[Any]) -> set[str]:
+    return {
+        normalized
+        for value in values
+        if isinstance(value, str) and (normalized := value.strip())
+    }
 
 
 def _required_string(source: object, *names: str) -> str:
@@ -956,6 +1156,13 @@ def _normalize_target_type(value: str) -> str:
     if normalized in {"revision", "entity", "sync_entity_revision"}:
         return ITEM_ENTITY_REVISION
     return normalized
+
+
+def _local_revision_content_sha256(revision: SyncEntityRevision) -> str | None:
+    payload = revision.payload_json
+    if isinstance(payload, Mapping):
+        return revision_payload_sha256(sanitize_revision_payload(payload))
+    return None
 
 
 def _utcnow() -> datetime:

--- a/apps/backend/app/services/sync_tombstones.py
+++ b/apps/backend/app/services/sync_tombstones.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import shutil
 from collections.abc import Mapping
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -19,12 +20,18 @@ ARTIFACT_TARGET_TYPE = "artifact"
 ENTITY_REVISION_TARGET_TYPE = "entity_revision"
 
 
-def record_project_delete_tombstone(session: Session, project: Project) -> SyncDeleteTombstone:
+def record_project_delete_tombstone(
+    session: Session,
+    project: Project,
+    *,
+    deleted_at: datetime | None = None,
+) -> SyncDeleteTombstone:
     return _record_delete_tombstone(
         session,
         project_id=project.id,
         target_type=PROJECT_TARGET_TYPE,
         target_id=project.id,
+        deleted_at=deleted_at,
         prior_metadata={
             "project_id": project.id,
             "display_name": project.display_name,
@@ -38,12 +45,18 @@ def record_project_delete_tombstone(session: Session, project: Project) -> SyncD
     )
 
 
-def record_artifact_delete_tombstone(session: Session, artifact: Artifact) -> SyncDeleteTombstone:
+def record_artifact_delete_tombstone(
+    session: Session,
+    artifact: Artifact,
+    *,
+    deleted_at: datetime | None = None,
+) -> SyncDeleteTombstone:
     return _record_delete_tombstone(
         session,
         project_id=artifact.project_id,
         target_type=ARTIFACT_TARGET_TYPE,
         target_id=artifact.id,
+        deleted_at=deleted_at,
         prior_metadata={
             "artifact_id": artifact.id,
             "project_id": artifact.project_id,
@@ -64,12 +77,15 @@ def record_artifact_delete_tombstone(session: Session, artifact: Artifact) -> Sy
 def record_entity_revision_delete_tombstone(
     session: Session,
     revision: SyncEntityRevision,
+    *,
+    deleted_at: datetime | None = None,
 ) -> SyncDeleteTombstone:
     return _record_delete_tombstone(
         session,
         project_id=revision.project_id,
         target_type=ENTITY_REVISION_TARGET_TYPE,
         target_id=revision.id,
+        deleted_at=deleted_at,
         prior_metadata={
             "revision_id": revision.id,
             "project_id": revision.project_id,
@@ -125,6 +141,7 @@ def _record_delete_tombstone(
     project_id: str,
     target_type: str,
     target_id: str,
+    deleted_at: datetime | None = None,
     prior_metadata: Mapping[str, Any],
 ) -> SyncDeleteTombstone:
     identity = get_or_create_local_identity(session)
@@ -135,11 +152,12 @@ def _record_delete_tombstone(
             SyncDeleteTombstone.target_id == target_id,
         )
     )
-    now = utcnow()
+    now = deleted_at or utcnow()
     sanitized_metadata = sanitize_revision_payload(prior_metadata)
     if existing is not None:
         existing.project_id = project_id
         existing.author_device_id = identity.device_id
+        existing.deleted_at = now
         existing.prior_metadata_json = sanitized_metadata
         existing.updated_at = now
         session.flush()

--- a/apps/backend/tests/test_projects.py
+++ b/apps/backend/tests/test_projects.py
@@ -641,6 +641,18 @@ def test_import_project_replaces_deleted_sync_placeholder(
                 prior_metadata_json={"display_name": "Deleted Placeholder"},
             )
         )
+        session.add(
+            SyncDeleteTombstone(
+                id="tomb_reimport_artifact",
+                sync_group_id="group-a",
+                project_id=project_id,
+                target_type=ARTIFACT_TARGET_TYPE,
+                target_id="art_reimport_artifact",
+                author_device_id="peer-a",
+                deleted_at=datetime(2026, 1, 1, tzinfo=UTC),
+                prior_metadata_json={"type": "source_audio"},
+            )
+        )
         session.commit()
 
     response = client.post(
@@ -660,6 +672,7 @@ def test_import_project_replaces_deleted_sync_placeholder(
 
     with SessionLocal() as session:
         assert session.get(SyncDeleteTombstone, "tomb_reimport_project") is None
+        assert session.get(SyncDeleteTombstone, "tomb_reimport_artifact") is None
         persisted_project = session.get(Project, project_id)
         assert persisted_project is not None
         assert persisted_project.sync_status == "local"

--- a/apps/backend/tests/test_sync_identity.py
+++ b/apps/backend/tests/test_sync_identity.py
@@ -289,6 +289,87 @@ def test_sync_metadata_omits_deleted_projects_but_keeps_tombstones(
     ]
 
 
+def test_sync_metadata_omits_tombstones_superseded_by_live_targets(
+    client,
+    sample_audio_file: Path,
+) -> None:
+    source_hash = file_sha256(sample_audio_file)
+    assert source_hash is not None
+    project_id = source_hash_to_project_id(source_hash)
+    deleted_at = datetime(2026, 1, 1, tzinfo=UTC)
+    live_at = datetime(2026, 1, 2, tzinfo=UTC)
+
+    with SessionLocal() as session:
+        project = Project(
+            id=project_id,
+            display_name="Reimported Sync Fixture",
+            source_sha256=source_hash,
+            source_path=str(sample_audio_file),
+            imported_path=str(sample_audio_file),
+            created_at=live_at,
+            updated_at=live_at,
+        )
+        session.add(project)
+        session.add(
+            Artifact(
+                id="art_live_source",
+                project_id=project_id,
+                type="source_audio",
+                format="wav",
+                path=str(sample_audio_file),
+                content_sha256=source_hash,
+                size_bytes=sample_audio_file.stat().st_size,
+                generated_by="import",
+                can_delete=False,
+                can_regenerate=False,
+                created_at=live_at,
+            )
+        )
+        session.add_all(
+            [
+                SyncDeleteTombstone(
+                    id="tomb_superseded_project",
+                    sync_group_id="group-a",
+                    project_id=project_id,
+                    target_type="project",
+                    target_id=project_id,
+                    author_device_id="peer-a",
+                    deleted_at=deleted_at,
+                    prior_metadata_json={"display_name": "Deleted Sync Fixture"},
+                ),
+                SyncDeleteTombstone(
+                    id="tomb_superseded_artifact",
+                    sync_group_id="group-a",
+                    project_id=project_id,
+                    target_type="artifact",
+                    target_id="art_live_source",
+                    author_device_id="peer-a",
+                    deleted_at=deleted_at,
+                    prior_metadata_json={"type": "source_audio"},
+                ),
+                SyncDeleteTombstone(
+                    id="tomb_deleted_artifact",
+                    sync_group_id="group-a",
+                    project_id=project_id,
+                    target_type="artifact",
+                    target_id="art_deleted",
+                    author_device_id="peer-a",
+                    deleted_at=deleted_at,
+                    prior_metadata_json={"type": "preview_mix"},
+                ),
+            ]
+        )
+        session.commit()
+
+    response = client.get("/api/v1/sync/metadata")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [tombstone["tombstone_id"] for tombstone in payload["delete_tombstones"]] == [
+        "tomb_deleted_artifact"
+    ]
+
+
 def test_sync_preflight_does_not_recover_missing_hash_from_source_path(
     client,
     sample_audio_file: Path,

--- a/apps/backend/tests/test_sync_manifest.py
+++ b/apps/backend/tests/test_sync_manifest.py
@@ -8,7 +8,7 @@ import shutil
 import wave
 from collections.abc import Callable, Iterable, Iterator
 from dataclasses import asdict, dataclass, is_dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -361,8 +361,9 @@ def _fake_delete_tombstone(
     target_id: str,
     sync_group_id: str = "sync_group_alpha",
     prior_metadata: dict[str, Any] | None = None,
+    deleted_at: datetime | None = None,
 ) -> FakeSyncDeleteTombstone:
-    timestamp = datetime(2026, 1, 2, tzinfo=UTC)
+    timestamp = deleted_at or datetime(2026, 1, 2, tzinfo=UTC)
     return FakeSyncDeleteTombstone(
         id=tombstone_id,
         sync_group_id=sync_group_id,
@@ -711,6 +712,14 @@ def test_export_project_manifest_includes_delete_tombstones_without_local_paths(
     with SessionLocal() as session:
         fixture = _create_project_with_artifacts(session, tmp_path)
         tombstones = [
+            _fake_delete_tombstone(
+                tombstone_id="tomb_art_live_source",
+                project_id=fixture.project_id,
+                target_type="artifact",
+                target_id="art_source_audio",
+                prior_metadata={"type": "source_audio"},
+                deleted_at=datetime(2020, 1, 1, tzinfo=UTC),
+            ),
             _fake_delete_tombstone(
                 tombstone_id="tomb_art_deleted",
                 project_id=fixture.project_id,
@@ -1197,6 +1206,7 @@ def test_import_staged_project_manifest_rejects_locally_tombstoned_targets(
             target_type=target_type,
             target_id=target_ids[target_id_key],
             sync_group_id=sync_group_id,
+            deleted_at=manifest["project"]["updated_at"] + timedelta(seconds=1),
         )
         monkeypatch.setattr(
             module,

--- a/apps/backend/tests/test_sync_reconciliation.py
+++ b/apps/backend/tests/test_sync_reconciliation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import asdict
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -1088,6 +1088,8 @@ def test_missing_project_manifest_rejects_tombstoned_contained_targets(
     _add_identity_and_peers(db_session)
     source_hash = _sha("tombstoned contained target source")
     project_id = source_hash_to_project_id(source_hash)
+    stale_manifest = _project_manifest(project_id, source_hash)
+    tombstone_time = datetime.now(UTC) + timedelta(seconds=1)
     db_session.add(
         SyncDeleteTombstone(
             id="tomb_contained_artifact",
@@ -1096,10 +1098,10 @@ def test_missing_project_manifest_rejects_tombstoned_contained_targets(
             target_type=ITEM_ARTIFACT,
             target_id=f"art_source_{project_id}",
             author_device_id="dev-local",
-            deleted_at=datetime.now(UTC),
+            deleted_at=tombstone_time,
             prior_metadata_json={},
-            created_at=datetime.now(UTC),
-            updated_at=datetime.now(UTC),
+            created_at=tombstone_time,
+            updated_at=tombstone_time,
         )
     )
     db_session.commit()
@@ -1108,7 +1110,7 @@ def test_missing_project_manifest_rejects_tombstoned_contained_targets(
         "remote_library": {
             "projects": [{"project_id": project_id, "source_sha256": source_hash}],
         },
-        "project_manifests": [_project_manifest(project_id, source_hash)],
+        "project_manifests": [stale_manifest],
         "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [source_hash]}],
     }
 

--- a/apps/backend/tests/test_sync_reconciliation_apply_batch_import.py
+++ b/apps/backend/tests/test_sync_reconciliation_apply_batch_import.py
@@ -5,7 +5,7 @@ import json
 import shutil
 import wave
 from dataclasses import asdict, dataclass, is_dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +26,7 @@ from app.models import (
     SyncTrustedPeer,
 )
 from app.services.paths import project_root
+from app.services.projects import delete_project
 from app.services.sync_identity import source_hash_to_project_id
 from app.services.sync_manifest import export_project_manifest, import_staged_project_manifest
 from app.services.sync_revisions import CURRENT_REVISION_STATE, revision_payload_sha256, sanitize_revision_payload
@@ -134,6 +135,112 @@ def test_issue119_apply_imports_fresh_multi_project_receiver(
                 assert file_sha256(copied_path) == fixture.artifact_hashes[artifact_id]
                 assert artifact.content_sha256 == fixture.artifact_hashes[artifact_id]
                 assert artifact.size_bytes == fixture.artifact_sizes[artifact_id]
+
+
+def test_issue163_project_scoped_apply_ignores_unselected_remote_projects_and_reports_timing(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _ensure_identity_and_peers("peer-issue163-scoped")
+
+    with SessionLocal() as session:
+        selected = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="scoped-selected",
+            source_frames=80,
+        )
+        unselected = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="scoped-unselected",
+            source_frames=112,
+        )
+        selected_manifest = _jsonable_manifest(
+            export_project_manifest(session, project_id=selected.project_id)
+        )
+        unselected_manifest = _jsonable_manifest(
+            export_project_manifest(session, project_id=unselected.project_id)
+        )
+        _stage_manifest_content(
+            session,
+            selected_manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=selected.artifact_bytes,
+            provider_device_id="peer-issue163-scoped",
+        )
+        _delete_live_project(session, selected)
+        _delete_live_project(session, unselected)
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": {
+                "projects": [
+                    selected_manifest["project"],
+                    unselected_manifest["project"],
+                ],
+                "artifacts": [],
+                "entity_revisions": [],
+                "delete_tombstones": [],
+            },
+            "project_manifests": [selected_manifest],
+            "peer_inventory": [
+                {
+                    "device_id": "peer-issue163-scoped",
+                    "available_content_sha256": _manifest_content_hashes([selected_manifest]),
+                }
+            ],
+            "project_ids": [selected.project_id],
+            "use_content_addressed_staging": True,
+            "include_timing_evidence": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    summary = payload["summary"]
+    assert summary["failed_actions"] == 0
+    assert summary["skipped_actions"] == 0
+    assert summary["applied_actions"] >= 1
+
+    planned_project_ids = {
+        item["project_id"]
+        for item in payload["plan"]["items"]
+        if item["project_id"] is not None
+    }
+    result_project_ids = {
+        result["action"]["project_id"] or result["action"]["item_id"]
+        for result in payload["results"]
+    }
+    assert selected.project_id in planned_project_ids
+    assert selected.project_id in result_project_ids
+    assert unselected.project_id not in planned_project_ids
+    assert unselected.project_id not in result_project_ids
+
+    timing_evidence = payload["timing_evidence"]
+    phases = {entry["phase"] for entry in timing_evidence}
+    assert {"plan", "apply", "action", "staging_cleanup"} <= phases
+    assert all(entry["duration_ms"] >= 0 for entry in timing_evidence)
+    assert sum(1 for entry in timing_evidence if entry["phase"] == "action") == summary["planned_actions"]
+    assert any(
+        entry["phase"] == "action"
+        and entry["action_type"] == "import_project_manifest"
+        and entry["project_id"] == selected.project_id
+        and entry["status"] == "applied"
+        for entry in timing_evidence
+    )
+
+    with SessionLocal() as session:
+        project = session.get(Project, selected.project_id)
+        assert project is not None
+        assert project.sync_status == "local"
+        assert project.sync_status_reason is None
+        assert project.sync_required_artifact_ids == []
+        assert project.sync_provider_device_ids == []
+        assert project.sync_conflict_count == 0
+        assert session.get(Project, unselected.project_id) is None
 
 
 def test_issue119_apply_hydrates_analysis_from_synced_analysis_artifact(
@@ -476,6 +583,310 @@ def test_issue119_revision_manifest_hash_matches_sanitized_payload_and_round_tri
         ]
 
 
+def test_issue163_retry_merges_missing_artifacts_with_existing_canonical_revision(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _ensure_identity_and_peers("peer-issue163-retry")
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path, slug="retry", source_frames=72)
+        dirty_payload = {
+            "project_id": fixture.project_id,
+            "timeline": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "C"}],
+            "source_path": str(tmp_path / "local-only.wav"),
+        }
+        session.add(
+            SyncEntityRevision(
+                id="rev_issue163_retry_chords",
+                project_id=fixture.project_id,
+                entity_type="chords",
+                entity_id=fixture.project_id,
+                revision_type="generated",
+                base_revision_id=None,
+                author_device_id="peer-issue163-retry",
+                source_artifact_id=fixture.source_artifact_id,
+                content_sha256=revision_payload_sha256(dirty_payload),
+                state=CURRENT_REVISION_STATE,
+                metadata_json={},
+                payload_json=dirty_payload,
+                created_at=datetime(2026, 1, 1, tzinfo=UTC),
+                updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+        )
+        session.commit()
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        exported_revision = _revision_by_id(manifest, "rev_issue163_retry_chords")
+        assert exported_revision["payload"] == sanitize_revision_payload(dirty_payload)
+        assert exported_revision["content_sha256"] != revision_payload_sha256(dirty_payload)
+
+        _stage_manifest_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=fixture.artifact_bytes,
+            provider_device_id="peer-issue163-retry",
+        )
+        stem = session.get(Artifact, fixture.stem_artifact_id)
+        assert stem is not None
+        Path(stem.path).unlink()
+        session.delete(stem)
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": "peer-issue163-retry",
+                    "available_content_sha256": _manifest_content_hashes([manifest]),
+                }
+            ],
+            "project_ids": [fixture.project_id],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 0
+    assert payload["summary"]["applied_actions"] >= 1
+    assert all(
+        result["action"]["action_type"] != "record_conflict"
+        for result in payload["results"]
+    )
+    with SessionLocal() as session:
+        assert session.get(Artifact, fixture.stem_artifact_id) is not None
+        revision = session.get(SyncEntityRevision, "rev_issue163_retry_chords")
+        assert revision is not None
+        assert revision.content_sha256 == revision_payload_sha256(dirty_payload)
+
+
+def test_issue163_retry_rejects_existing_revision_without_canonical_payload(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _ensure_identity_and_peers("peer-issue163-bad-payload")
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path, slug="bad-payload", source_frames=74)
+        payload = {
+            "project_id": fixture.project_id,
+            "timeline": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "C"}],
+        }
+        content_sha256 = revision_payload_sha256(payload)
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        remote_revision = {
+            "revision_id": "rev_issue163_bad_payload_chords",
+            "project_id": fixture.project_id,
+            "entity_type": "chords",
+            "entity_id": fixture.project_id,
+            "revision_type": "generated",
+            "base_revision_id": None,
+            "author_device_id": "peer-issue163-bad-payload",
+            "source_artifact_id": fixture.source_artifact_id,
+            "content_sha256": content_sha256,
+            "state": CURRENT_REVISION_STATE,
+            "metadata": {},
+            "payload": payload,
+            "created_at": datetime(2026, 1, 1, tzinfo=UTC).isoformat(),
+            "updated_at": datetime(2026, 1, 1, tzinfo=UTC).isoformat(),
+        }
+        session.add(
+            SyncEntityRevision(
+                id="rev_issue163_bad_payload_chords",
+                project_id=fixture.project_id,
+                entity_type="chords",
+                entity_id=fixture.project_id,
+                revision_type="generated",
+                base_revision_id=None,
+                author_device_id="peer-issue163-bad-payload",
+                source_artifact_id=fixture.source_artifact_id,
+                content_sha256=content_sha256,
+                state=CURRENT_REVISION_STATE,
+                metadata_json={},
+                payload_json=None,
+                created_at=datetime(2026, 1, 1, tzinfo=UTC),
+                updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+        )
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": {
+                **_empty_remote_library(),
+                "projects": [manifest["project"]],
+                "entity_revisions": [remote_revision],
+            },
+            "project_manifests": [],
+            "peer_inventory": [],
+            "project_ids": [fixture.project_id],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    revision_item = _plan_item(
+        payload["plan"]["items"],
+        "entity_revision",
+        "rev_issue163_bad_payload_chords",
+    )
+    assert revision_item["status"] == "conflicted"
+    assert revision_item["reason"] == "Local and remote entity revisions share an ID but have different content hashes."
+    assert revision_item["details"]["remote_content_sha256"] == content_sha256
+    assert revision_item["details"]["local_content_sha256"] is None
+
+
+def test_issue163_existing_project_embedded_revision_drift_is_not_reported_as_conflict(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _ensure_identity_and_peers("peer-issue163-existing")
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path, slug="existing", source_frames=76)
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        local_payload = {"project_id": fixture.project_id, "timeline": [{"label": "C"}]}
+        remote_payload = {"project_id": fixture.project_id, "timeline": [{"label": "G"}]}
+        session.add(
+            SyncEntityRevision(
+                id="rev_issue163_existing_drift",
+                project_id=fixture.project_id,
+                entity_type="chords",
+                entity_id=fixture.project_id,
+                revision_type="generated",
+                base_revision_id=None,
+                author_device_id="peer-issue163-existing",
+                source_artifact_id=fixture.source_artifact_id,
+                content_sha256=revision_payload_sha256(local_payload),
+                state=CURRENT_REVISION_STATE,
+                metadata_json={},
+                payload_json=local_payload,
+                created_at=datetime(2026, 1, 1, tzinfo=UTC),
+                updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+        )
+        session.commit()
+        manifest["entity_revisions"].append(
+            {
+                "revision_id": "rev_issue163_existing_drift",
+                "project_id": fixture.project_id,
+                "entity_type": "chords",
+                "entity_id": fixture.project_id,
+                "revision_type": "generated",
+                "base_revision_id": None,
+                "author_device_id": "peer-issue163-existing",
+                "source_artifact_id": fixture.source_artifact_id,
+                "content_sha256": revision_payload_sha256(remote_payload),
+                "state": CURRENT_REVISION_STATE,
+                "metadata": {},
+                "payload": remote_payload,
+                "created_at": datetime(2026, 1, 1, tzinfo=UTC).isoformat(),
+                "updated_at": datetime(2026, 1, 1, tzinfo=UTC).isoformat(),
+            }
+        )
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": "peer-issue163-existing",
+                    "available_content_sha256": _manifest_content_hashes([manifest]),
+                }
+            ],
+            "project_ids": [fixture.project_id],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 0
+    assert payload["plan"]["summary"]["total_conflicts"] == 0
+    assert all(
+        item["item_type"] != "entity_revision"
+        or item["item_id"] != "rev_issue163_existing_drift"
+        for item in payload["plan"]["items"]
+    )
+    assert all(
+        result["action"]["action_type"] != "record_conflict"
+        for result in payload["results"]
+    )
+
+
+def test_issue163_newer_manifest_reimports_project_after_local_project_tombstone(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _ensure_identity_and_peers("peer-issue163-reimport")
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path, slug="reimport", source_frames=78)
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        delete_project(session, fixture.project_id)
+        tombstone = session.scalar(
+            select(SyncDeleteTombstone).where(
+                SyncDeleteTombstone.project_id == fixture.project_id,
+                SyncDeleteTombstone.target_type == "project",
+            )
+        )
+        assert tombstone is not None
+        resurrected_at = tombstone.deleted_at.replace(microsecond=0) + timedelta(seconds=1)
+        manifest["project"]["created_at"] = resurrected_at.isoformat()
+        manifest["project"]["updated_at"] = resurrected_at.isoformat()
+        _stage_manifest_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=fixture.artifact_bytes,
+            provider_device_id="peer-issue163-reimport",
+        )
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": "peer-issue163-reimport",
+                    "available_content_sha256": _manifest_content_hashes([manifest]),
+                }
+            ],
+            "project_ids": [fixture.project_id],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 0
+    assert payload["summary"]["applied_actions"] >= 1
+    project_item = _plan_item(payload["plan"]["items"], "project", fixture.project_id)
+    assert project_item["status"] == "remote_available"
+    with SessionLocal() as session:
+        project = session.get(Project, fixture.project_id)
+        assert project is not None
+        assert project.sync_status == "local"
+        assert session.get(Artifact, fixture.source_artifact_id) is not None
+        assert session.get(Artifact, fixture.stem_artifact_id) is not None
+        assert (
+            session.scalar(
+                select(func.count())
+                .select_from(SyncDeleteTombstone)
+                .where(SyncDeleteTombstone.project_id == fixture.project_id)
+            )
+            == 0
+        )
+        exported_manifest = export_project_manifest(session, project_id=fixture.project_id)
+        assert exported_manifest.delete_tombstones == []
+
+
 def test_issue119_project_manifest_import_canonicalizes_revision_payload_hash(
     client: TestClient,
     tmp_path: Path,
@@ -609,7 +1020,7 @@ def test_issue119_reconnect_stale_manifest_does_not_resurrect_tombstoned_targets
         session.delete(session.get(Artifact, "art_issue119_deleted_mix"))
         session.delete(session.get(SyncEntityRevision, "rev_issue119_deleted_chords"))
         deleted_path.unlink()
-        now = datetime(2026, 1, 2, tzinfo=UTC)
+        now = datetime.now(UTC) + timedelta(seconds=1)
         session.add_all(
             [
                 SyncDeleteTombstone(

--- a/apps/desktop/src-tauri/src/sync_transport.rs
+++ b/apps/desktop/src-tauri/src/sync_transport.rs
@@ -63,6 +63,28 @@ pub struct SyncTransportTransferResult {
     pub message: Option<String>,
 }
 
+#[derive(Clone, Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncTransportTransferCounts {
+    pub requested: usize,
+    pub received: usize,
+    pub already_staged: usize,
+    pub failed: usize,
+    pub received_bytes: u64,
+    pub already_staged_bytes: u64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncTransportTimingEvidence {
+    pub phase: String,
+    pub project_id: Option<String>,
+    pub artifact_id: Option<String>,
+    pub started_at: String,
+    pub completed_at: String,
+    pub duration_ms: u64,
+}
+
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SyncTransportProjectResult {
@@ -74,19 +96,26 @@ pub struct SyncTransportProjectResult {
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SyncTransportSyncResult {
+    pub run_id: String,
     pub peer_device_id: String,
     pub remote_device_id: String,
     pub status: String,
     pub message: String,
+    pub started_at: String,
+    pub completed_at: String,
+    pub duration_ms: u64,
+    pub project_results: Vec<SyncTransportProjectResult>,
     pub imported_projects: Vec<SyncTransportProjectResult>,
     pub imported_project_count: usize,
     pub skipped_project_count: usize,
     pub failed_project_count: usize,
     pub received_artifacts: Vec<SyncTransportTransferResult>,
+    pub transfer_counts: SyncTransportTransferCounts,
     pub served_artifact_requests: u64,
     pub remote_manifest_count: usize,
     pub local_manifest_count: usize,
     pub manifest_errors: Vec<SyncTransportManifestError>,
+    pub timings: Vec<SyncTransportTimingEvidence>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -101,7 +130,8 @@ mod desktop {
     use super::{
         SyncTransportManifestError, SyncTransportPairingOffer, SyncTransportPairingOfferRequest,
         SyncTransportProjectResult, SyncTransportStartListenerRequest, SyncTransportStatus,
-        SyncTransportSyncNowRequest, SyncTransportSyncResult, SyncTransportTransferResult,
+        SyncTransportSyncNowRequest, SyncTransportSyncResult, SyncTransportTimingEvidence,
+        SyncTransportTransferCounts, SyncTransportTransferResult,
     };
     use base64::{
         engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
@@ -127,7 +157,7 @@ mod desktop {
             Arc, Mutex,
         },
         thread::{self, JoinHandle},
-        time::Duration,
+        time::{Duration, Instant},
     };
     use tauri::State;
 
@@ -328,6 +358,10 @@ mod desktop {
             &self,
             payload: SyncTransportSyncNowRequest,
         ) -> Result<SyncTransportSyncResult, String> {
+            let run_id = sync_run_id();
+            let run_started_at = Utc::now();
+            let run_started_instant = Instant::now();
+            let mut timings = Vec::new();
             let client = BackendClient::new(&self.base_url)?;
             let peer = client
                 .trusted_peer(&payload.peer_device_id)
@@ -349,24 +383,31 @@ mod desktop {
                     )
                 })?;
             let endpoint = parse_endpoint_hint(&endpoint_hint, Some(&payload.peer_device_id))?;
+            let timer = SyncPhaseTimer::start("peer_connect");
             let stream = TcpStream::connect_timeout(&endpoint, Duration::from_secs(10)).map_err(
                 |error| format!("Could not connect to sync peer at {endpoint}: {error}"),
             )?;
             configure_stream(&stream)?;
+            timings.push(timer.finish());
 
+            let timer = SyncPhaseTimer::start("peer_authentication");
             let mut connection = SecurePeerConnection::connect_initiator(stream)?;
             let session = authenticate_session(
                 &mut connection,
                 &client,
                 Some(payload.peer_device_id.clone()),
             )?;
+            timings.push(timer.finish());
 
+            let timer = SyncPhaseTimer::start("local_manifest_export");
             let local_offer = load_local_manifest_offer(
                 &client,
                 payload.project_ids.as_deref(),
                 payload.export_local,
             );
+            timings.push(timer.finish());
             let local_manifest_count = local_offer.project_manifests.len();
+            let timer = SyncPhaseTimer::start("manifest_exchange");
             connection.send_message(&ProtocolMessage::ManifestOffer(local_offer.clone()))?;
             let remote_offer = match connection.read_message()? {
                 ProtocolMessage::ManifestOffer(offer) => offer,
@@ -380,6 +421,7 @@ mod desktop {
                     ));
                 }
             };
+            timings.push(timer.finish());
 
             let mut imported_projects = Vec::new();
             let mut received_artifacts = Vec::new();
@@ -390,6 +432,7 @@ mod desktop {
                     &session.remote_device_id,
                     &remote_offer.metadata,
                     &remote_offer.project_manifests,
+                    &mut timings,
                 );
                 imported_projects = imported.imported_projects;
                 received_artifacts = imported.received_artifacts;
@@ -398,33 +441,46 @@ mod desktop {
             connection.send_message(&ProtocolMessage::PhaseDone {
                 phase: "initiator_import".to_string(),
             })?;
+            let timer = SyncPhaseTimer::start("serve_artifact_requests");
             let served_artifact_requests = serve_artifact_requests_until_done(
                 &client,
                 &mut connection,
                 &local_offer.project_manifests,
             )?;
+            timings.push(timer.finish());
             let manifest_errors =
                 sync_manifest_errors(&local_offer.manifest_errors, &remote_offer.manifest_errors);
+            let completed_at = Utc::now();
+            let duration_ms = duration_millis(run_started_instant.elapsed());
+            let transfer_counts = transfer_counts(&received_artifacts);
+            let project_results = imported_projects.clone();
 
             Ok(SyncTransportSyncResult {
+                run_id,
                 peer_device_id: payload.peer_device_id,
                 remote_device_id: session.remote_device_id,
                 status: sync_result_status(&manifest_errors, import_counts.failed),
                 message: sync_result_message(
                     local_manifest_count,
                     remote_offer.project_manifests.len(),
-                    received_artifacts.len(),
+                    &transfer_counts,
                     import_counts,
                 ),
+                started_at: run_started_at.to_rfc3339(),
+                completed_at: completed_at.to_rfc3339(),
+                duration_ms,
+                project_results,
                 imported_projects,
                 imported_project_count: import_counts.imported,
                 skipped_project_count: import_counts.skipped,
                 failed_project_count: import_counts.failed,
                 received_artifacts,
+                transfer_counts,
                 served_artifact_requests,
                 remote_manifest_count: remote_offer.project_manifests.len(),
                 local_manifest_count,
                 manifest_errors,
+                timings,
             })
         }
     }
@@ -554,10 +610,17 @@ mod desktop {
         base_url: String,
         stream: TcpStream,
     ) -> Result<IncomingSessionResult, String> {
+        let run_id = sync_run_id();
+        let run_started_at = Utc::now();
+        let run_started_instant = Instant::now();
+        let mut timings = Vec::new();
         configure_stream(&stream)?;
         let client = BackendClient::new(&base_url)?;
+        let timer = SyncPhaseTimer::start("peer_authentication");
         let mut connection = SecurePeerConnection::connect_responder(stream)?;
         let session = authenticate_session(&mut connection, &client, None)?;
+        timings.push(timer.finish());
+        let timer = SyncPhaseTimer::start("manifest_exchange");
         let remote_offer = match connection.read_message()? {
             ProtocolMessage::ManifestOffer(offer) => offer,
             ProtocolMessage::Error(error) => {
@@ -570,21 +633,27 @@ mod desktop {
                 ));
             }
         };
+        timings.push(timer.finish());
+        let timer = SyncPhaseTimer::start("local_manifest_export");
         let local_offer = load_local_manifest_offer(&client, None, true);
+        timings.push(timer.finish());
         let local_manifest_count = local_offer.project_manifests.len();
         connection.send_message(&ProtocolMessage::ManifestOffer(local_offer.clone()))?;
 
+        let timer = SyncPhaseTimer::start("serve_artifact_requests");
         let served_artifact_requests = serve_artifact_requests_until_done(
             &client,
             &mut connection,
             &local_offer.project_manifests,
         )?;
+        timings.push(timer.finish());
         let imported = import_remote_manifests(
             &client,
             &mut connection,
             &session.remote_device_id,
             &remote_offer.metadata,
             &remote_offer.project_manifests,
+            &mut timings,
         );
         let import_counts = import_outcome_counts(&imported.imported_projects);
         connection.send_message(&ProtocolMessage::PhaseDone {
@@ -602,25 +671,36 @@ mod desktop {
         );
         let manifest_errors =
             sync_manifest_errors(&local_offer.manifest_errors, &remote_offer.manifest_errors);
+        let completed_at = Utc::now();
+        let duration_ms = duration_millis(run_started_instant.elapsed());
+        let transfer_counts = transfer_counts(&imported.received_artifacts);
+        let project_results = imported.imported_projects.clone();
         let sync_result = SyncTransportSyncResult {
+            run_id,
             peer_device_id: session.remote_device_id.clone(),
             remote_device_id: session.remote_device_id,
             status: sync_result_status(&manifest_errors, import_counts.failed),
             message: sync_result_message(
                 local_manifest_count,
                 remote_offer.project_manifests.len(),
-                imported.received_artifacts.len(),
+                &transfer_counts,
                 import_counts,
             ),
+            started_at: run_started_at.to_rfc3339(),
+            completed_at: completed_at.to_rfc3339(),
+            duration_ms,
+            project_results,
             imported_projects: imported.imported_projects,
             imported_project_count: import_counts.imported,
             skipped_project_count: import_counts.skipped,
             failed_project_count: import_counts.failed,
             received_artifacts: imported.received_artifacts,
+            transfer_counts,
             served_artifact_requests,
             remote_manifest_count: remote_offer.project_manifests.len(),
             local_manifest_count,
             manifest_errors,
+            timings,
         };
 
         Ok(IncomingSessionResult {
@@ -636,6 +716,62 @@ mod desktop {
         if let Ok(mut status) = shared_status.lock() {
             update(&mut status);
         }
+    }
+
+    struct SyncPhaseTimer {
+        phase: String,
+        project_id: Option<String>,
+        artifact_id: Option<String>,
+        started_at: DateTime<Utc>,
+        started_instant: Instant,
+    }
+
+    impl SyncPhaseTimer {
+        fn start(phase: impl Into<String>) -> Self {
+            Self::start_scoped(phase, None, None)
+        }
+
+        fn start_project(phase: impl Into<String>, project_id: &str) -> Self {
+            Self::start_scoped(phase, Some(project_id.to_string()), None)
+        }
+
+        fn start_artifact(phase: impl Into<String>, artifact: &RemoteArtifact) -> Self {
+            Self::start_scoped(
+                phase,
+                Some(artifact.project_id.clone()),
+                Some(artifact.artifact_id.clone()),
+            )
+        }
+
+        fn start_scoped(
+            phase: impl Into<String>,
+            project_id: Option<String>,
+            artifact_id: Option<String>,
+        ) -> Self {
+            Self {
+                phase: phase.into(),
+                project_id,
+                artifact_id,
+                started_at: Utc::now(),
+                started_instant: Instant::now(),
+            }
+        }
+
+        fn finish(self) -> SyncTransportTimingEvidence {
+            let completed_at = Utc::now();
+            SyncTransportTimingEvidence {
+                phase: self.phase,
+                project_id: self.project_id,
+                artifact_id: self.artifact_id,
+                started_at: self.started_at.to_rfc3339(),
+                completed_at: completed_at.to_rfc3339(),
+                duration_ms: duration_millis(self.started_instant.elapsed()),
+            }
+        }
+    }
+
+    fn duration_millis(duration: Duration) -> u64 {
+        duration.as_millis().min(u128::from(u64::MAX)) as u64
     }
 
     #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -1182,6 +1318,10 @@ mod desktop {
         URL_SAFE_NO_PAD.encode(bytes)
     }
 
+    fn sync_run_id() -> String {
+        format!("sync_{}", random_nonce())
+    }
+
     fn load_local_manifest_offer(
         client: &BackendClient,
         project_ids: Option<&[String]>,
@@ -1260,18 +1400,23 @@ mod desktop {
         peer_device_id: &str,
         remote_metadata: &Value,
         manifests: &[Value],
+        timings: &mut Vec<SyncTransportTimingEvidence>,
     ) -> ImportRemoteResult {
         let mut received_artifacts = Vec::new();
-        let mut transfer_failures = HashMap::new();
 
+        let timer = SyncPhaseTimer::start("reconciliation_plan");
         let plan =
             match plan_remote_manifest_batch(client, peer_device_id, remote_metadata, manifests) {
-                Ok(plan) => plan,
+                Ok(plan) => {
+                    timings.push(timer.finish());
+                    plan
+                }
                 Err(error) => {
+                    timings.push(timer.finish());
                     return ImportRemoteResult {
                         imported_projects: apply_failure_results(
                             manifests,
-                            &transfer_failures,
+                            &HashMap::new(),
                             &format!("Could not plan remote sync reconciliation batch: {error}"),
                         ),
                         received_artifacts,
@@ -1279,32 +1424,147 @@ mod desktop {
                 }
             };
 
-        for entry in planned_fetch_artifact_entries(&plan, manifests, peer_device_id) {
-            match request_and_stage_artifact(client, connection, peer_device_id, &entry.artifact) {
-                Ok(result) => received_artifacts.push(result),
-                Err(error) => {
-                    transfer_failures
-                        .entry(entry.manifest_project_id)
-                        .or_insert(error);
-                }
-            }
+        let mut imported_projects = Vec::with_capacity(manifests.len());
+        let manifest_project_ids: HashSet<String> =
+            manifests.iter().map(manifest_project_id).collect();
+        for manifest in manifests {
+            let project_result = import_remote_manifest_project(
+                client,
+                connection,
+                peer_device_id,
+                remote_metadata,
+                manifest,
+                &plan,
+                &mut received_artifacts,
+                timings,
+            );
+            imported_projects.push(project_result);
         }
-
-        let available_content_sha256 = available_content_sha256(&received_artifacts);
-        let imported_projects = match apply_remote_manifest_batch(
-            client,
-            peer_device_id,
-            remote_metadata,
-            manifests,
-            &available_content_sha256,
-        ) {
-            Ok(results) => merge_transfer_failures(results, &transfer_failures),
-            Err(error) => apply_failure_results(manifests, &transfer_failures, &error.to_string()),
-        };
+        for project_id in planned_delete_project_ids(&plan)
+            .into_iter()
+            .filter(|project_id| !manifest_project_ids.contains(project_id))
+        {
+            imported_projects.push(apply_remote_tombstone_project(
+                client,
+                peer_device_id,
+                remote_metadata,
+                &project_id,
+                timings,
+            ));
+        }
 
         ImportRemoteResult {
             imported_projects,
             received_artifacts,
+        }
+    }
+
+    fn apply_remote_tombstone_project(
+        client: &BackendClient,
+        peer_device_id: &str,
+        remote_metadata: &Value,
+        project_id: &str,
+        timings: &mut Vec<SyncTransportTimingEvidence>,
+    ) -> SyncTransportProjectResult {
+        let remote_metadata = remote_metadata_for_project(remote_metadata, project_id);
+        let body = reconciliation_apply_body_with_project_ids(
+            peer_device_id,
+            &remote_metadata,
+            &[],
+            &[],
+            &[project_id.to_string()],
+        );
+        let timer = SyncPhaseTimer::start_project("reconciliation_apply", project_id);
+        let response = client.post_json_value("/api/v1/sync/reconciliation/apply", &body);
+        timings.push(timer.finish());
+        match response {
+            Ok(response) => map_project_apply_response(&[project_id.to_string()], &response)
+                .pop()
+                .unwrap_or_else(|| {
+                    failed_project_result(
+                        project_id,
+                        "Backend apply response did not include this project.",
+                    )
+                }),
+            Err(error) => failed_project_result(project_id, &error.to_string()),
+        }
+    }
+
+    fn import_remote_manifest_project(
+        client: &BackendClient,
+        connection: &mut SecurePeerConnection,
+        peer_device_id: &str,
+        remote_metadata: &Value,
+        manifest: &Value,
+        plan: &Value,
+        received_artifacts: &mut Vec<SyncTransportTransferResult>,
+        timings: &mut Vec<SyncTransportTimingEvidence>,
+    ) -> SyncTransportProjectResult {
+        let project_id = manifest_project_id(manifest);
+        let mut project_transfers = Vec::new();
+        let mut transfer_failure = None;
+
+        for entry in
+            planned_fetch_artifact_entries(plan, std::slice::from_ref(manifest), peer_device_id)
+        {
+            match request_or_use_staged_artifact(
+                client,
+                connection,
+                peer_device_id,
+                &entry.artifact,
+                timings,
+            ) {
+                Ok(result) => {
+                    project_transfers.push(result.clone());
+                    received_artifacts.push(result);
+                }
+                Err(error) => {
+                    let failed = failed_transfer_result(&entry.artifact, &error);
+                    project_transfers.push(failed.clone());
+                    received_artifacts.push(failed);
+                    transfer_failure.get_or_insert((entry.manifest_project_id, error));
+                }
+            }
+        }
+
+        let transfer_failures = transfer_failure
+            .as_ref()
+            .map(|(project_id, error)| HashMap::from([(project_id.clone(), error.clone())]))
+            .unwrap_or_default();
+        if !transfer_failures.is_empty() {
+            return apply_failure_results(
+                std::slice::from_ref(manifest),
+                &transfer_failures,
+                "Could not stage all remote artifact content before import.",
+            )
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| {
+                failed_project_result(
+                    &project_id,
+                    "Could not stage all remote artifact content before import.",
+                )
+            });
+        }
+
+        let available_content_sha256 = available_content_sha256(&project_transfers);
+        match apply_remote_manifest_project(
+            client,
+            peer_device_id,
+            remote_metadata,
+            manifest,
+            &available_content_sha256,
+            timings,
+        ) {
+            Ok(result) => result,
+            Err(error) => apply_failure_results(
+                std::slice::from_ref(manifest),
+                &HashMap::new(),
+                &error.to_string(),
+            )
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| failed_project_result(&project_id, &error.to_string())),
         }
     }
 
@@ -1324,21 +1584,34 @@ mod desktop {
         client.post_json_value("/api/v1/sync/reconciliation/plan", &body)
     }
 
-    fn apply_remote_manifest_batch(
+    fn apply_remote_manifest_project(
         client: &BackendClient,
         peer_device_id: &str,
         remote_metadata: &Value,
-        manifests: &[Value],
+        manifest: &Value,
         available_content_sha256: &[String],
-    ) -> Result<Vec<SyncTransportProjectResult>, BackendError> {
+        timings: &mut Vec<SyncTransportTimingEvidence>,
+    ) -> Result<SyncTransportProjectResult, BackendError> {
+        let project_id = manifest_project_id(manifest);
+        let manifests = vec![manifest.clone()];
+        let remote_metadata = remote_metadata_for_project(remote_metadata, &project_id);
         let body = reconciliation_apply_body(
             peer_device_id,
-            remote_metadata,
-            manifests,
+            &remote_metadata,
+            &manifests,
             available_content_sha256,
         );
-        let response = client.post_json_value("/api/v1/sync/reconciliation/apply", &body)?;
-        Ok(map_batch_apply_response(manifests, &response))
+        let timer = SyncPhaseTimer::start_project("reconciliation_apply", &project_id);
+        let response = client.post_json_value("/api/v1/sync/reconciliation/apply", &body);
+        timings.push(timer.finish());
+        let response = response?;
+        let mut results = map_batch_apply_response(&manifests, &response);
+        Ok(results.pop().unwrap_or_else(|| {
+            failed_project_result(
+                &project_id,
+                "Backend apply response did not include this project.",
+            )
+        }))
     }
 
     fn reconciliation_plan_body(
@@ -1364,6 +1637,23 @@ mod desktop {
         manifests: &[Value],
         available_content_sha256: &[String],
     ) -> Value {
+        let project_ids: Vec<String> = manifests.iter().map(manifest_project_id).collect();
+        reconciliation_apply_body_with_project_ids(
+            peer_device_id,
+            remote_metadata,
+            manifests,
+            available_content_sha256,
+            &project_ids,
+        )
+    }
+
+    fn reconciliation_apply_body_with_project_ids(
+        peer_device_id: &str,
+        remote_metadata: &Value,
+        manifests: &[Value],
+        available_content_sha256: &[String],
+        project_ids: &[String],
+    ) -> Value {
         json!({
             "remote_library": remote_metadata,
             "project_manifests": manifests,
@@ -1372,8 +1662,85 @@ mod desktop {
                 "available_content_sha256": available_content_sha256,
                 "metadata": { "transport": "tuneforge-sync+tcp" },
             }],
+            "project_ids": project_ids,
             "use_content_addressed_staging": true,
+            "include_timing_evidence": true,
         })
+    }
+
+    fn remote_metadata_for_project(remote_metadata: &Value, project_id: &str) -> Value {
+        let mut metadata = remote_metadata
+            .as_object()
+            .cloned()
+            .unwrap_or_else(serde_json::Map::new);
+        metadata.insert(
+            "projects".to_string(),
+            filtered_project_array(remote_metadata, "projects", project_id),
+        );
+        metadata.insert(
+            "artifacts".to_string(),
+            filtered_project_array(remote_metadata, "artifacts", project_id),
+        );
+        metadata.insert(
+            "entity_revisions".to_string(),
+            filtered_project_array(remote_metadata, "entity_revisions", project_id),
+        );
+        metadata.insert(
+            "delete_tombstones".to_string(),
+            filtered_project_array(remote_metadata, "delete_tombstones", project_id),
+        );
+        Value::Object(metadata)
+    }
+
+    fn filtered_project_array(metadata: &Value, key: &str, project_id: &str) -> Value {
+        let values = metadata
+            .get(key)
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter(|item| value_project_id(item) == Some(project_id))
+                    .cloned()
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        Value::Array(values)
+    }
+
+    fn value_project_id(value: &Value) -> Option<&str> {
+        value
+            .get("project_id")
+            .and_then(Value::as_str)
+            .or_else(|| value.get("projectId").and_then(Value::as_str))
+            .or_else(|| {
+                value
+                    .get("project")
+                    .and_then(|project| project.get("project_id"))
+                    .and_then(Value::as_str)
+            })
+    }
+
+    fn planned_delete_project_ids(plan: &Value) -> Vec<String> {
+        let mut seen = HashSet::new();
+        let mut project_ids: Vec<String> = plan
+            .get("actions")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter(|action| {
+                action.get("action_type").and_then(Value::as_str) == Some("apply_delete_tombstone")
+            })
+            .filter_map(|action| {
+                action
+                    .get("project_id")
+                    .and_then(Value::as_str)
+                    .or_else(|| action.get("item_id").and_then(Value::as_str))
+                    .map(str::to_string)
+            })
+            .filter(|project_id| seen.insert(project_id.clone()))
+            .collect();
+        project_ids.sort();
+        project_ids
     }
 
     #[derive(Clone, Debug, Default)]
@@ -1384,7 +1751,9 @@ mod desktop {
         failed_actions: u64,
         conflicted_actions: u64,
         imported_project_manifest: bool,
-        first_reason: Option<String>,
+        applied_delete_tombstone: bool,
+        selected_reason: Option<String>,
+        selected_reason_priority: u8,
     }
 
     impl ProjectApplyOutcome {
@@ -1401,14 +1770,21 @@ mod desktop {
                     if action_type == Some("import_project_manifest") {
                         self.imported_project_manifest = true;
                     }
+                    if action_type == Some("apply_delete_tombstone") {
+                        self.applied_delete_tombstone = true;
+                    }
                 }
                 "satisfied" => self.satisfied_actions = self.satisfied_actions.saturating_add(1),
                 "skipped" => self.skipped_actions = self.skipped_actions.saturating_add(1),
                 "failed" => self.failed_actions = self.failed_actions.saturating_add(1),
                 _ => self.skipped_actions = self.skipped_actions.saturating_add(1),
             }
-            if self.first_reason.is_none() {
-                self.first_reason = reason.map(str::to_string);
+            if let Some(reason) = reason {
+                let priority = action_reason_priority(status, action);
+                if self.selected_reason.is_none() || priority >= self.selected_reason_priority {
+                    self.selected_reason = Some(reason.to_string());
+                    self.selected_reason_priority = priority;
+                }
             }
         }
 
@@ -1417,6 +1793,8 @@ mod desktop {
                 "failed"
             } else if self.conflicted_actions > 0 {
                 "conflicted"
+            } else if self.applied_delete_tombstone {
+                "deleted"
             } else if self.imported_project_manifest {
                 "imported"
             } else {
@@ -1433,11 +1811,30 @@ mod desktop {
                 self.failed_actions,
                 self.conflicted_actions,
             );
-            if let Some(reason) = &self.first_reason {
+            if let Some(reason) = &self.selected_reason {
                 message.push(' ');
                 message.push_str(reason);
             }
             message
+        }
+    }
+
+    fn action_reason_priority(status: &str, action: &Value) -> u8 {
+        let action_type = action.get("action_type").and_then(Value::as_str);
+        if status == "failed" {
+            return 50;
+        }
+        if action_type == Some("record_conflict") {
+            return 45;
+        }
+        if action_project_status(action) == Some("conflicted") {
+            return 40;
+        }
+        match status {
+            "applied" => 30,
+            "satisfied" => 20,
+            "skipped" => 10,
+            _ => 0,
         }
     }
 
@@ -1487,27 +1884,82 @@ mod desktop {
 
         manifests
             .iter()
-            .map(|manifest| {
-                let project_id = manifest_project_id(manifest);
-                let outcome = outcomes.remove(&project_id).unwrap_or_default();
-                let message = if outcome.applied_actions == 0
-                    && outcome.satisfied_actions == 0
-                    && outcome.skipped_actions == 0
-                    && outcome.failed_actions == 0
-                    && outcome.conflicted_actions == 0
-                {
-                    "Reconciliation apply: no import actions were needed for this project."
-                        .to_string()
-                } else {
-                    outcome.message()
-                };
-                SyncTransportProjectResult {
-                    project_id,
-                    status: outcome.status().to_string(),
-                    message: Some(message),
-                }
+            .map(|manifest| manifest_project_id(manifest))
+            .map(|project_id| {
+                let outcome = outcomes.remove(&project_id);
+                outcome_to_project_result(project_id, outcome)
             })
             .collect()
+    }
+
+    fn map_project_apply_response(
+        project_ids: &[String],
+        response: &Value,
+    ) -> Vec<SyncTransportProjectResult> {
+        let mut outcomes: HashMap<String, ProjectApplyOutcome> = project_ids
+            .iter()
+            .map(|project_id| (project_id.clone(), ProjectApplyOutcome::default()))
+            .collect();
+
+        for result in response
+            .get("results")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            let action = result.get("action").unwrap_or(&Value::Null);
+            let Some(project_id) = apply_result_project_id(action) else {
+                continue;
+            };
+            let Some(outcome) = outcomes.get_mut(project_id) else {
+                continue;
+            };
+            let status = result
+                .get("status")
+                .and_then(Value::as_str)
+                .unwrap_or("skipped");
+            let reason = result
+                .get("reason")
+                .and_then(Value::as_str)
+                .or_else(|| action.get("reason").and_then(Value::as_str));
+            let reason =
+                if action.get("action_type").and_then(Value::as_str) == Some("record_conflict") {
+                    action.get("reason").and_then(Value::as_str).or(reason)
+                } else {
+                    reason
+                };
+            outcome.record(status, action, reason);
+        }
+
+        project_ids
+            .iter()
+            .map(|project_id| {
+                let outcome = outcomes.remove(project_id);
+                outcome_to_project_result(project_id.clone(), outcome)
+            })
+            .collect()
+    }
+
+    fn outcome_to_project_result(
+        project_id: String,
+        outcome: Option<ProjectApplyOutcome>,
+    ) -> SyncTransportProjectResult {
+        let outcome = outcome.unwrap_or_default();
+        let message = if outcome.applied_actions == 0
+            && outcome.satisfied_actions == 0
+            && outcome.skipped_actions == 0
+            && outcome.failed_actions == 0
+            && outcome.conflicted_actions == 0
+        {
+            "Reconciliation apply: no import actions were needed for this project.".to_string()
+        } else {
+            outcome.message()
+        };
+        SyncTransportProjectResult {
+            project_id,
+            status: outcome.status().to_string(),
+            message: Some(message),
+        }
     }
 
     fn apply_result_project_id(action: &Value) -> Option<&str> {
@@ -1525,21 +1977,6 @@ mod desktop {
             .get("details")
             .and_then(|details| details.get("project_status"))
             .and_then(Value::as_str)
-    }
-
-    fn merge_transfer_failures(
-        mut results: Vec<SyncTransportProjectResult>,
-        transfer_failures: &HashMap<String, String>,
-    ) -> Vec<SyncTransportProjectResult> {
-        for result in &mut results {
-            if let Some(error) = transfer_failures.get(&result.project_id) {
-                result.status = "failed".to_string();
-                result.message = Some(format!(
-                    "Could not stage all remote artifact content before import: {error}"
-                ));
-            }
-        }
-        results
     }
 
     fn apply_failure_results(
@@ -1568,10 +2005,19 @@ mod desktop {
             .collect()
     }
 
+    fn failed_project_result(project_id: &str, message: &str) -> SyncTransportProjectResult {
+        SyncTransportProjectResult {
+            project_id: project_id.to_string(),
+            status: "failed".to_string(),
+            message: Some(message.to_string()),
+        }
+    }
+
     fn available_content_sha256(received_artifacts: &[SyncTransportTransferResult]) -> Vec<String> {
         let mut seen = HashSet::new();
         let mut values: Vec<String> = received_artifacts
             .iter()
+            .filter(|artifact| matches!(artifact.status.as_str(), "received" | "already_staged"))
             .filter_map(|artifact| {
                 if seen.insert(artifact.content_sha256.clone()) {
                     Some(artifact.content_sha256.clone())
@@ -1582,6 +2028,32 @@ mod desktop {
             .collect();
         values.sort();
         values
+    }
+
+    fn transfer_counts(
+        transfer_results: &[SyncTransportTransferResult],
+    ) -> SyncTransportTransferCounts {
+        let mut counts = SyncTransportTransferCounts {
+            requested: transfer_results.len(),
+            ..SyncTransportTransferCounts::default()
+        };
+        for result in transfer_results {
+            match result.status.as_str() {
+                "received" => {
+                    counts.received = counts.received.saturating_add(1);
+                    counts.received_bytes = counts.received_bytes.saturating_add(result.size_bytes);
+                }
+                "already_staged" => {
+                    counts.already_staged = counts.already_staged.saturating_add(1);
+                    counts.already_staged_bytes = counts
+                        .already_staged_bytes
+                        .saturating_add(result.size_bytes);
+                }
+                "failed" => counts.failed = counts.failed.saturating_add(1),
+                _ => {}
+            }
+        }
+        counts
     }
 
     fn manifest_content_sha256(manifests: &[Value]) -> Vec<String> {
@@ -1688,12 +2160,17 @@ mod desktop {
     fn sync_result_message(
         local_manifest_count: usize,
         remote_manifest_count: usize,
-        received_artifact_count: usize,
+        transfer_counts: &SyncTransportTransferCounts,
         import_counts: ImportOutcomeCounts,
     ) -> String {
         format!(
-            "Exchanged {local_manifest_count} local and {remote_manifest_count} remote manifest(s); imported {} project(s), skipped {} project(s), failed {} project(s), received {received_artifact_count} artifact(s).",
-            import_counts.imported, import_counts.skipped, import_counts.failed
+            "Exchanged {local_manifest_count} local and {remote_manifest_count} remote manifest(s); imported {} project(s), skipped {} project(s), failed {} project(s), received {} artifact(s), reused {} staged artifact(s), failed {} transfer(s).",
+            import_counts.imported,
+            import_counts.skipped,
+            import_counts.failed,
+            transfer_counts.received,
+            transfer_counts.already_staged,
+            transfer_counts.failed
         )
     }
 
@@ -1759,12 +2236,65 @@ mod desktop {
             .collect()
     }
 
+    fn request_or_use_staged_artifact(
+        client: &BackendClient,
+        connection: &mut SecurePeerConnection,
+        peer_device_id: &str,
+        artifact: &RemoteArtifact,
+        timings: &mut Vec<SyncTransportTimingEvidence>,
+    ) -> Result<SyncTransportTransferResult, String> {
+        let timer = SyncPhaseTimer::start_artifact("artifact_staging_check", artifact);
+        let staged = already_staged_artifact_result(client, artifact);
+        timings.push(timer.finish());
+        if let Some(result) = staged? {
+            return Ok(result);
+        }
+        request_and_stage_artifact(client, connection, peer_device_id, artifact, timings)
+    }
+
+    fn already_staged_artifact_result(
+        client: &BackendClient,
+        artifact: &RemoteArtifact,
+    ) -> Result<Option<SyncTransportTransferResult>, String> {
+        let path = format!(
+            "/api/v1/sync/artifacts/staging/{}",
+            percent_encode_path_segment(&artifact.content_sha256)
+        );
+        match client.get_json_value(&path) {
+            Ok(staged) => {
+                let staged_size_bytes = staged.get("size_bytes").and_then(Value::as_u64);
+                if staged_size_bytes != Some(artifact.size_bytes) {
+                    return Err(
+                        "Existing staged sync artifact did not match the requested size."
+                            .to_string(),
+                    );
+                }
+                Ok(Some(SyncTransportTransferResult {
+                    artifact_id: artifact.artifact_id.clone(),
+                    content_sha256: artifact.content_sha256.clone(),
+                    size_bytes: artifact.size_bytes,
+                    status: "already_staged".to_string(),
+                    message: Some(
+                        "Artifact content was already staged and verified locally.".to_string(),
+                    ),
+                }))
+            }
+            Err(error) if error.status == Some(404) => Ok(None),
+            Err(error) => Err(format!(
+                "Could not inspect staged sync artifact {}: {error}",
+                artifact.content_sha256
+            )),
+        }
+    }
+
     fn request_and_stage_artifact(
         client: &BackendClient,
         connection: &mut SecurePeerConnection,
         peer_device_id: &str,
         artifact: &RemoteArtifact,
+        timings: &mut Vec<SyncTransportTimingEvidence>,
     ) -> Result<SyncTransportTransferResult, String> {
+        let timer = SyncPhaseTimer::start_artifact("artifact_transfer", artifact);
         connection.send_message(&ProtocolMessage::ArtifactRequest {
             artifact_id: artifact.artifact_id.clone(),
             content_sha256: artifact.content_sha256.clone(),
@@ -1849,9 +2379,12 @@ mod desktop {
                 }
             }
         };
+        timings.push(timer.finish());
 
         if let Err(error) = receive_result {
+            let cleanup_timer = SyncPhaseTimer::start_artifact("artifact_cleanup", artifact);
             let _ = fs::remove_file(&temp_path);
+            timings.push(cleanup_timer.finish());
             return Err(error);
         }
 
@@ -1866,8 +2399,12 @@ mod desktop {
                 "project_id": artifact.project_id,
             },
         });
+        let timer = SyncPhaseTimer::start_artifact("artifact_staging", artifact);
         let stage_result = client.post_json_value("/api/v1/sync/artifacts/staging", &body);
+        timings.push(timer.finish());
+        let cleanup_timer = SyncPhaseTimer::start_artifact("artifact_cleanup", artifact);
         let _ = fs::remove_file(&temp_path);
+        timings.push(cleanup_timer.finish());
         stage_result.map_err(|error| format!("Could not stage received sync artifact: {error}"))?;
 
         Ok(SyncTransportTransferResult {
@@ -1877,6 +2414,19 @@ mod desktop {
             status: "received".to_string(),
             message: None,
         })
+    }
+
+    fn failed_transfer_result(
+        artifact: &RemoteArtifact,
+        message: &str,
+    ) -> SyncTransportTransferResult {
+        SyncTransportTransferResult {
+            artifact_id: artifact.artifact_id.clone(),
+            content_sha256: artifact.content_sha256.clone(),
+            size_bytes: artifact.size_bytes,
+            status: "failed".to_string(),
+            message: Some(message.to_string()),
+        }
     }
 
     fn temp_artifact_path(content_sha256: &str) -> PathBuf {
@@ -2527,6 +3077,30 @@ mod desktop {
                     .and_then(|entry| entry.get("available_content_sha256")),
                 Some(&json!(["hash_a", "hash_b"]))
             );
+            assert_eq!(
+                body.get("project_ids"),
+                Some(&json!(["proj_one", "proj_two"]))
+            );
+            assert_eq!(body.get("include_timing_evidence"), Some(&json!(true)));
+        }
+
+        #[test]
+        fn reconciliation_apply_body_can_scope_delete_only_project_without_manifest() {
+            let body = reconciliation_apply_body_with_project_ids(
+                "dev_peer",
+                &json!({ "delete_tombstones": [{ "project_id": "proj_deleted" }] }),
+                &[],
+                &[],
+                &["proj_deleted".to_string()],
+            );
+
+            assert_eq!(
+                body.get("project_manifests")
+                    .and_then(Value::as_array)
+                    .map(Vec::len),
+                Some(0)
+            );
+            assert_eq!(body.get("project_ids"), Some(&json!(["proj_deleted"])));
         }
 
         #[test]
@@ -2790,14 +3364,22 @@ mod desktop {
                 skipped: 1,
                 failed: 1,
             };
+            let transfer_counts = SyncTransportTransferCounts {
+                requested: 8,
+                received: 6,
+                already_staged: 1,
+                failed: 1,
+                received_bytes: 120,
+                already_staged_bytes: 20,
+            };
 
             assert_eq!(
                 sync_result_status(&[], counts.failed),
                 "completed_with_errors"
             );
             assert_eq!(
-                sync_result_message(4, 5, 6, counts),
-                "Exchanged 4 local and 5 remote manifest(s); imported 2 project(s), skipped 1 project(s), failed 1 project(s), received 6 artifact(s)."
+                sync_result_message(4, 5, &transfer_counts, counts),
+                "Exchanged 4 local and 5 remote manifest(s); imported 2 project(s), skipped 1 project(s), failed 1 project(s), received 6 artifact(s), reused 1 staged artifact(s), failed 1 transfer(s)."
             );
         }
 
@@ -2860,11 +3442,205 @@ mod desktop {
                     status: "already_staged".to_string(),
                     message: None,
                 },
+                SyncTransportTransferResult {
+                    artifact_id: "art_failed".to_string(),
+                    content_sha256: "hash_c".to_string(),
+                    size_bytes: 30,
+                    status: "failed".to_string(),
+                    message: Some("transfer failed".to_string()),
+                },
             ];
 
             assert_eq!(
                 available_content_sha256(&received_artifacts),
                 vec!["hash_a".to_string(), "hash_b".to_string()]
+            );
+        }
+
+        #[test]
+        fn transfer_counts_summarizes_received_reused_and_failed_transfers() {
+            let counts = transfer_counts(&[
+                SyncTransportTransferResult {
+                    artifact_id: "art_one".to_string(),
+                    content_sha256: "hash_a".to_string(),
+                    size_bytes: 10,
+                    status: "received".to_string(),
+                    message: None,
+                },
+                SyncTransportTransferResult {
+                    artifact_id: "art_two".to_string(),
+                    content_sha256: "hash_b".to_string(),
+                    size_bytes: 20,
+                    status: "already_staged".to_string(),
+                    message: None,
+                },
+                SyncTransportTransferResult {
+                    artifact_id: "art_three".to_string(),
+                    content_sha256: "hash_c".to_string(),
+                    size_bytes: 30,
+                    status: "failed".to_string(),
+                    message: Some("transfer failed".to_string()),
+                },
+            ]);
+
+            assert_eq!(counts.requested, 3);
+            assert_eq!(counts.received, 1);
+            assert_eq!(counts.already_staged, 1);
+            assert_eq!(counts.failed, 1);
+            assert_eq!(counts.received_bytes, 10);
+            assert_eq!(counts.already_staged_bytes, 20);
+        }
+
+        #[test]
+        fn remote_metadata_for_project_filters_full_offer_to_one_project() {
+            let metadata = json!({
+                "projects": [
+                    { "project_id": "proj_one", "display_name": "One" },
+                    { "project_id": "proj_two", "display_name": "Two" }
+                ],
+                "artifacts": [
+                    { "artifact_id": "art_one", "project_id": "proj_one" },
+                    { "artifact_id": "art_two", "project_id": "proj_two" }
+                ],
+                "entity_revisions": [
+                    { "revision_id": "rev_one", "project_id": "proj_one" },
+                    { "revision_id": "rev_two", "project_id": "proj_two" }
+                ],
+                "delete_tombstones": [
+                    { "tombstone_id": "del_one", "project_id": "proj_one" },
+                    { "tombstone_id": "del_two", "project_id": "proj_two" }
+                ]
+            });
+            let filtered = remote_metadata_for_project(&metadata, "proj_two");
+
+            assert_eq!(
+                filtered
+                    .get("projects")
+                    .and_then(Value::as_array)
+                    .and_then(|projects| projects.first())
+                    .and_then(|project| project.get("project_id"))
+                    .and_then(Value::as_str),
+                Some("proj_two")
+            );
+            assert_eq!(
+                filtered
+                    .get("projects")
+                    .and_then(Value::as_array)
+                    .map(Vec::len),
+                Some(1)
+            );
+            assert_eq!(
+                filtered
+                    .get("artifacts")
+                    .and_then(Value::as_array)
+                    .map(Vec::len),
+                Some(1)
+            );
+            assert_eq!(
+                filtered
+                    .get("delete_tombstones")
+                    .and_then(Value::as_array)
+                    .map(Vec::len),
+                Some(1)
+            );
+        }
+
+        #[test]
+        fn planned_delete_project_ids_reads_tombstone_apply_actions() {
+            let plan = json!({
+                "actions": [
+                    {
+                        "action_type": "apply_delete_tombstone",
+                        "project_id": "proj_deleted",
+                        "item_id": "proj_deleted"
+                    },
+                    {
+                        "action_type": "apply_delete_tombstone",
+                        "project_id": "proj_deleted",
+                        "item_id": "art_deleted"
+                    },
+                    {
+                        "action_type": "import_project_manifest",
+                        "project_id": "proj_live",
+                        "item_id": "proj_live"
+                    }
+                ]
+            });
+
+            assert_eq!(
+                planned_delete_project_ids(&plan),
+                vec!["proj_deleted".to_string()]
+            );
+        }
+
+        #[test]
+        fn project_apply_response_maps_delete_tombstone_to_deleted_result() {
+            let results = map_project_apply_response(
+                &["proj_deleted".to_string()],
+                &json!({
+                    "results": [{
+                        "action": {
+                            "action_type": "apply_delete_tombstone",
+                            "item_type": "project",
+                            "item_id": "proj_deleted",
+                            "project_id": "proj_deleted"
+                        },
+                        "status": "applied",
+                        "reason": "Delete tombstone was applied through the sync tombstone service."
+                    }]
+                }),
+            );
+
+            assert_eq!(results.len(), 1);
+            assert_eq!(results[0].project_id, "proj_deleted");
+            assert_eq!(results[0].status, "deleted");
+            assert_eq!(
+                results[0].message.as_deref(),
+                Some(
+                    "Reconciliation apply: 1 applied, 0 satisfied, 0 skipped, 0 failed, 0 conflicted action(s). Delete tombstone was applied through the sync tombstone service."
+                )
+            );
+        }
+
+        #[test]
+        fn batch_apply_response_uses_final_failure_reason_over_earlier_skip() {
+            let manifests = vec![json!({
+                "project": { "project_id": "proj_failed" },
+                "artifacts": []
+            })];
+            let response = json!({
+                "results": [
+                    {
+                        "action": {
+                            "action_type": "fetch_artifact_content",
+                            "item_type": "artifact",
+                            "item_id": "art_missing",
+                            "project_id": "proj_failed"
+                        },
+                        "status": "skipped",
+                        "reason": "Required artifact content is not staged locally."
+                    },
+                    {
+                        "action": {
+                            "action_type": "import_project_manifest",
+                            "item_type": "project",
+                            "item_id": "proj_failed",
+                            "project_id": "proj_failed"
+                        },
+                        "status": "failed",
+                        "reason": "Project manifest import failed after staging completed."
+                    }
+                ]
+            });
+
+            let results = map_batch_apply_response(&manifests, &response);
+
+            assert_eq!(results[0].status, "failed");
+            assert_eq!(
+                results[0].message.as_deref(),
+                Some(
+                    "Reconciliation apply: 0 applied, 0 satisfied, 1 skipped, 1 failed, 0 conflicted action(s). Project manifest import failed after staging completed."
+                )
             );
         }
 

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { JobSchema, ProjectSchema } from "./lib/api";
+import { normalizeSyncTransportStatus, type JobSchema, type ProjectSchema } from "./lib/api";
 import {
   mockCancelJob,
   mockGetSyncIdentity,
@@ -255,6 +255,254 @@ describe("Desktop app activity", () => {
     expect(
       within(resultRows[0]).getByText("Entity revision manifest content_sha256 must match payload."),
     ).toBeInTheDocument();
+  });
+
+  it("normalizes sync run identity, timing, counters, and final project rows", () => {
+    const normalized = normalizeSyncTransportStatus({
+      running: true,
+      state: "listening",
+      endpointHints: ["tcp://192.168.1.57:48625"],
+      lastSync: {
+        runId: "sync_run_retry_2",
+        sessionId: "sync_session_retry_2",
+        peerDeviceId: "device_peer_1",
+        remoteDeviceId: "device_peer_1",
+        status: "completed_with_errors",
+        message: "Retry completed after staged bytes were reused.",
+        startedAt: "2026-04-18T13:16:00.000Z",
+        completedAt: "2026-04-18T13:16:01.250Z",
+        durationMs: 1250,
+        timing: {
+          planningMs: 10,
+          transferMs: 25,
+          applyMs: 30,
+        },
+        importedProjectCount: 1,
+        skippedProjectCount: 1,
+        failedProjectCount: 0,
+        projectResults: [
+          {
+            projectId: "proj_retry",
+            status: "failed",
+            message: "Old ffprobe failure.",
+            isFinal: true,
+            completedAt: "2026-04-18T13:15:00.000Z",
+            failedCount: 1,
+          },
+          {
+            projectId: "proj_retry",
+            status: "applied",
+            message: "Retry imported the project.",
+            isFinal: true,
+            completedAt: "2026-04-18T13:16:01.000Z",
+            appliedCount: 3,
+            satisfiedCount: 1,
+            skippedCount: 0,
+            failedCount: 0,
+          },
+          {
+            projectId: "proj_deleted",
+            status: "deleted",
+            message: "Delete tombstone caught up.",
+            isFinal: true,
+            deletedCount: 1,
+          },
+        ],
+        manifestErrors: [
+          {
+            projectId: "proj_retry",
+            message: "Local manifest export failed: Old ffprobe failure.",
+          },
+          {
+            projectId: "proj_deleted",
+            message: "Peer manifest export failed: stale tombstone warning.",
+          },
+        ],
+        receivedArtifacts: [],
+      },
+    });
+
+    expect(normalized.last_sync).toMatchObject({
+      run_id: "sync_run_retry_2",
+      session_id: "sync_session_retry_2",
+      status: "completed",
+      duration_ms: 1250,
+      imported_project_count: 1,
+      skipped_project_count: 1,
+      failed_project_count: 0,
+    });
+    expect(normalized.last_sync?.timing).toEqual({
+      planningMs: 10,
+      transferMs: 25,
+      applyMs: 30,
+    });
+    expect(normalized.last_sync?.project_results).toHaveLength(2);
+    expect(normalized.last_sync?.project_results[0]).toMatchObject({
+      project_id: "proj_retry",
+      status: "applied",
+      applied_count: 3,
+      satisfied_count: 1,
+      skipped_count: 0,
+      failed_count: 0,
+    });
+    expect(normalized.last_sync?.project_results[1]).toMatchObject({
+      project_id: "proj_deleted",
+      status: "deleted",
+      deleted_count: 1,
+    });
+  });
+
+  it("keeps newer successful sync rows when stale failures arrive later in the payload", () => {
+    const normalized = normalizeSyncTransportStatus({
+      active: true,
+      status: "listening",
+      last_sync: {
+        run_id: "sync_retry_latest",
+        peer_device_id: "device_peer_1",
+        remote_device_id: "device_peer_1",
+        completed_at: "2026-04-18T13:16:02.000Z",
+        project_results: [
+          {
+            project_id: "proj_retry",
+            status: "applied",
+            message: "Retry imported the project.",
+            is_final: true,
+            completed_at: "2026-04-18T13:16:01.000Z",
+          },
+          {
+            project_id: "proj_retry",
+            status: "failed",
+            message: "Old ffprobe failure.",
+            is_final: true,
+            run_id: "sync_retry_old",
+            completed_at: "2026-04-18T13:15:00.000Z",
+          },
+        ],
+        manifest_errors: [],
+        received_artifacts: [],
+      },
+    });
+
+    expect(normalized.last_sync?.project_results).toEqual([
+      expect.objectContaining({
+        project_id: "proj_retry",
+        status: "applied",
+        message: "Retry imported the project.",
+      }),
+    ]);
+  });
+
+  it("keeps manifest errors as project rows only when no final project result exists", () => {
+    const normalized = normalizeSyncTransportStatus({
+      active: true,
+      status: "listening",
+      last_sync: {
+        peer_device_id: "device_peer_1",
+        remote_device_id: "device_peer_1",
+        project_results: [
+          {
+            project_id: "proj_staging",
+            status: "staging",
+            message: "Receiving project artifacts.",
+            is_final: false,
+          },
+        ],
+        manifest_errors: [
+          {
+            project_id: "proj_staging",
+            message: "Peer manifest export failed before apply.",
+          },
+        ],
+        received_artifacts: [],
+      },
+    });
+
+    expect(normalized.last_sync?.status).toBe("completed_with_errors");
+    expect(normalized.last_sync?.project_results).toEqual([
+      expect.objectContaining({
+        project_id: "proj_staging",
+        status: "failed",
+        message: "Peer manifest export failed before apply.",
+      }),
+    ]);
+  });
+
+  it("shows final retry and delete catch-up rows without obsolete failures", async () => {
+    const user = userEvent.setup();
+    setSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: ["tcp://192.168.1.57:48625"],
+      last_sync: {
+        run_id: "sync_run_retry_2",
+        session_id: "sync_session_retry_2",
+        peer_device_id: "device_peer_1",
+        remote_device_id: "device_peer_1",
+        status: "completed",
+        message: "Retry completed after staged bytes were reused.",
+        started_at: "2026-04-18T13:16:00.000Z",
+        completed_at: "2026-04-18T13:16:01.400Z",
+        duration_ms: 1400,
+        imported_project_count: 1,
+        skipped_project_count: 1,
+        failed_project_count: 0,
+        project_results: [
+          {
+            project_id: "proj_retry",
+            status: "failed",
+            message: "Old ffprobe failure.",
+            is_final: true,
+          },
+          {
+            project_id: "proj_retry",
+            status: "applied",
+            message: "Retry imported the project.",
+            is_final: true,
+            applied_count: 3,
+            satisfied_count: 1,
+            skipped_count: 0,
+            failed_count: 0,
+          },
+          {
+            project_id: "proj_deleted",
+            status: "deleted",
+            message: "Delete tombstone caught up.",
+            is_final: true,
+            deleted_count: 1,
+          },
+        ],
+        manifest_errors: [
+          {
+            project_id: "proj_retry",
+            message: "Local manifest export failed: Old ffprobe failure.",
+          },
+          {
+            project_id: "proj_deleted",
+            message: "Peer manifest export failed: stale tombstone warning.",
+          },
+        ],
+        received_artifacts: [],
+      },
+    });
+
+    await openSyncTab(user);
+
+    expect(await screen.findByText("Retry completed after staged bytes were reused.")).toBeInTheDocument();
+    expect(screen.getByText(/Run sync_run_retry_2/)).toBeInTheDocument();
+    expect(screen.getByText(/Duration 1\.4 s/)).toBeInTheDocument();
+    expect(screen.getByText(/1 imported, 1 skipped, 0 failed/)).toBeInTheDocument();
+
+    const projectResults = await screen.findByRole("list", { name: "Last sync project results" });
+    const resultRows = within(projectResults).getAllByRole("listitem");
+    expect(resultRows).toHaveLength(2);
+    expect(within(resultRows[0]).getByText("Applied")).toBeInTheDocument();
+    expect(within(resultRows[0]).getByText("proj_retry")).toBeInTheDocument();
+    expect(within(resultRows[0]).getByText("Retry imported the project.")).toBeInTheDocument();
+    expect(within(resultRows[1]).getByText("Deleted")).toBeInTheDocument();
+    expect(within(resultRows[1]).getByText("proj_deleted")).toBeInTheDocument();
+    expect(within(resultRows[1]).getByText("Delete tombstone caught up.")).toBeInTheDocument();
+    expect(screen.queryByText("Old ffprobe failure.")).not.toBeInTheDocument();
+    expect(screen.queryByText(/stale tombstone warning/)).not.toBeInTheDocument();
   });
 
   it("shows newer listener sync results after a prior sync now result", async () => {

--- a/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
+++ b/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   api,
+  mergeSyncProjectResults,
   type SyncPairingPayloadSchema,
   type SyncTransportProjectResult,
   type SyncTransportRunStatus,
@@ -140,28 +141,161 @@ function syncResultKey(status: SyncTransportRunStatus | null | undefined) {
   if (!status) {
     return null;
   }
+  const projectResults = mergeSyncProjectResults(status.project_results, status.manifest_errors);
   return JSON.stringify({
+    run: status.run_id,
+    session: status.session_id,
     peer: status.peer_device_id,
     remote: status.remote_device_id,
+    started: status.started_at,
+    completed: status.completed_at,
+    durationSeconds: status.duration_seconds,
+    durationMs: status.duration_ms,
     status: status.status,
     message: status.message,
-    projects: status.project_results.map((result) => [
+    projects: projectResults.map((result) => [
       result.project_id,
       result.status,
       result.message ?? null,
+      result.completed_at ?? null,
+      result.is_final ?? null,
+      result.counters ?? null,
     ]),
     receivedArtifacts: status.received_artifacts.length,
     remoteManifests: status.remote_manifest_count,
     localManifests: status.local_manifest_count,
+    importedProjects: status.imported_project_count,
+    appliedProjects: status.applied_project_count,
+    deletedProjects: status.deleted_project_count,
+    skippedProjects: status.skipped_project_count,
+    failedProjects: status.failed_project_count,
   });
 }
 
+function formatSyncDuration(seconds: number | null | undefined) {
+  if (typeof seconds !== "number" || !Number.isFinite(seconds) || seconds < 0) {
+    return null;
+  }
+  if (seconds < 1) {
+    return `${Math.max(1, Math.round(seconds * 1000))} ms`;
+  }
+  if (seconds < 60) {
+    return `${seconds < 10 ? seconds.toFixed(1) : Math.round(seconds)} s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = Math.round(seconds % 60).toString().padStart(2, "0");
+  return `${minutes}:${remainingSeconds}`;
+}
+
+function syncRunDurationSeconds(status: SyncTransportRunStatus) {
+  if (typeof status.duration_seconds === "number") {
+    return status.duration_seconds;
+  }
+  if (typeof status.duration_ms === "number") {
+    return status.duration_ms / 1000;
+  }
+  if (status.started_at && status.completed_at) {
+    const startedAt = new Date(normalizeApiDateTime(status.started_at)).getTime();
+    const completedAt = new Date(normalizeApiDateTime(status.completed_at)).getTime();
+    if (Number.isFinite(startedAt) && Number.isFinite(completedAt) && completedAt >= startedAt) {
+      return (completedAt - startedAt) / 1000;
+    }
+  }
+  return null;
+}
+
+function syncRunProjectCounterText(status: SyncTransportRunStatus) {
+  const counters: string[] = [];
+  if (typeof status.imported_project_count === "number") {
+    counters.push(`${status.imported_project_count} imported`);
+  }
+  if (typeof status.applied_project_count === "number") {
+    counters.push(`${status.applied_project_count} applied`);
+  }
+  if (typeof status.deleted_project_count === "number") {
+    counters.push(`${status.deleted_project_count} deleted`);
+  }
+  if (typeof status.skipped_project_count === "number") {
+    counters.push(`${status.skipped_project_count} skipped`);
+  }
+  if (typeof status.failed_project_count === "number") {
+    counters.push(`${status.failed_project_count} failed`);
+  }
+  return counters.length ? counters.join(", ") : null;
+}
+
+function syncRunSummaryText(status: SyncTransportRunStatus | null | undefined) {
+  if (!status) {
+    return null;
+  }
+  const parts: string[] = [];
+  if (status.run_id) {
+    parts.push(`Run ${status.run_id}`);
+  } else if (status.session_id) {
+    parts.push(`Session ${status.session_id}`);
+  }
+  const completedAt = formatTimestamp(status.completed_at);
+  if (completedAt) {
+    parts.push(`Completed ${completedAt}`);
+  }
+  const duration = formatSyncDuration(syncRunDurationSeconds(status));
+  if (duration) {
+    parts.push(`Duration ${duration}`);
+  }
+  const counters = syncRunProjectCounterText(status);
+  if (counters) {
+    parts.push(counters);
+  }
+  return parts.length ? parts.join(" | ") : null;
+}
+
+function projectCounterValue(result: SyncTransportProjectResult, key: keyof SyncTransportProjectResult) {
+  const value = result[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function syncProjectCounterText(result: SyncTransportProjectResult) {
+  const directCounters: Array<[string, number | null]> = [
+    ["imported", projectCounterValue(result, "imported_count")],
+    ["applied", projectCounterValue(result, "applied_count")],
+    ["deleted", projectCounterValue(result, "deleted_count")],
+    ["satisfied", projectCounterValue(result, "satisfied_count")],
+    ["skipped", projectCounterValue(result, "skipped_count")],
+    ["failed", projectCounterValue(result, "failed_count")],
+    ["received", projectCounterValue(result, "received_artifact_count")],
+    ["reused", projectCounterValue(result, "reused_artifact_count")],
+  ];
+  const counters = directCounters.filter((entry): entry is [string, number] => entry[1] !== null);
+  if (!counters.length && result.counters) {
+    Object.entries(result.counters)
+      .filter(([key]) => key.endsWith("_count"))
+      .sort(([left], [right]) => left.localeCompare(right))
+      .forEach(([key, value]) => {
+        counters.push([key.replace(/_count$/, "").replace(/_/g, " "), value]);
+      });
+  }
+  return counters.length
+    ? `${counters.map(([label, value]) => `${value} ${label}`).join(", ")}.`
+    : null;
+}
+
 function syncProjectResultText(result: SyncTransportProjectResult) {
-  return result.message?.trim() || `${statusLabel(result.status)}.`;
+  return result.message?.trim() || syncProjectCounterText(result) || `${statusLabel(result.status)}.`;
+}
+
+function syncProjectIdLabel(projectId: string) {
+  const normalized = projectId.trim();
+  if (normalized.length <= 30) {
+    return normalized;
+  }
+  if (normalized.startsWith("proj_sha256_")) {
+    return `${normalized.slice(0, 19)}...${normalized.slice(-8)}`;
+  }
+  return `${normalized.slice(0, 18)}...${normalized.slice(-8)}`;
 }
 
 function syncProjectResultList(status: SyncTransportRunStatus | null | undefined) {
-  const results = status?.project_results ?? [];
+  const results = status ? mergeSyncProjectResults(status.project_results, status.manifest_errors) : [];
   if (!results.length) {
     return null;
   }
@@ -173,7 +307,9 @@ function syncProjectResultList(status: SyncTransportRunStatus | null | undefined
           key={`${result.project_id}-${result.status}-${index}`}
         >
           <span className="activity-sync-project-result__status">{statusLabel(result.status)}</span>
-          <span className="activity-sync-project-result__project">{result.project_id}</span>
+          <span className="activity-sync-project-result__project" title={result.project_id}>
+            {syncProjectIdLabel(result.project_id)}
+          </span>
           <span className="activity-sync-project-result__message">{syncProjectResultText(result)}</span>
         </li>
       ))}
@@ -236,6 +372,7 @@ export function ActivitySyncPanel() {
   const displayedLastSyncMessage = !showListenerSyncResult
     ? lastSyncMessage ?? lastSyncStatus
     : lastSyncStatus;
+  const visibleSyncSummary = syncRunSummaryText(visibleSyncResult);
 
   const refreshSyncQueries = async () => {
     await Promise.all([
@@ -431,6 +568,7 @@ export function ActivitySyncPanel() {
               <dt>Last Sync</dt>
               <dd className="activity-sync-last-sync">
                 <span>{displayedLastSyncMessage}</span>
+                {visibleSyncSummary ? <small>{visibleSyncSummary}</small> : null}
                 {syncProjectResultList(visibleSyncResult)}
               </dd>
             </div>

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -73,13 +73,22 @@ export type ProjectSyncSummary = {
   isLocked: boolean;
   lockReason: string | null;
 };
+export type SyncTransportMetricMap = Record<string, number>;
+export type SyncTransportTiming = Record<string, unknown> | Record<string, unknown>[];
 export type SyncTransportRunStatus = {
+  run_id?: string | null;
+  session_id?: string | null;
   peer_device_id?: string | null;
   remote_device_id?: string | null;
+  direction?: string | null;
   status: string;
   message?: string | null;
   started_at?: string | null;
   completed_at?: string | null;
+  duration_seconds?: number | null;
+  duration_ms?: number | null;
+  timing?: SyncTransportTiming | null;
+  transfer_counts?: SyncTransportMetricMap;
   error?: string | null;
   project_results: SyncTransportProjectResult[];
   manifest_errors: SyncTransportManifestError[];
@@ -87,11 +96,36 @@ export type SyncTransportRunStatus = {
   served_artifact_requests?: number | null;
   local_manifest_count?: number | null;
   remote_manifest_count?: number | null;
+  imported_project_count?: number | null;
+  applied_project_count?: number | null;
+  deleted_project_count?: number | null;
+  skipped_project_count?: number | null;
+  failed_project_count?: number | null;
+  total_project_count?: number | null;
 };
 export type SyncTransportProjectResult = {
   project_id: string;
+  run_id?: string | null;
+  session_id?: string | null;
   status: string;
+  phase?: string | null;
+  action?: string | null;
   message?: string | null;
+  is_final?: boolean | null;
+  started_at?: string | null;
+  completed_at?: string | null;
+  duration_seconds?: number | null;
+  duration_ms?: number | null;
+  timing?: SyncTransportTiming | null;
+  counters?: SyncTransportMetricMap;
+  imported_count?: number | null;
+  applied_count?: number | null;
+  deleted_count?: number | null;
+  satisfied_count?: number | null;
+  skipped_count?: number | null;
+  failed_count?: number | null;
+  received_artifact_count?: number | null;
+  reused_artifact_count?: number | null;
 };
 export type SyncTransportManifestError = {
   project_id: string;
@@ -197,6 +231,39 @@ function numberField(record: Record<string, unknown> | null, keys: string[]) {
   return null;
 }
 
+function recordField(record: Record<string, unknown> | null, keys: string[]) {
+  if (!record) {
+    return null;
+  }
+  for (const key of keys) {
+    const value = asRecord(record[key]);
+    if (value) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function recordOrRecordArrayField(record: Record<string, unknown> | null, keys: string[]) {
+  if (!record) {
+    return null;
+  }
+  for (const key of keys) {
+    const value = record[key];
+    const recordValue = asRecord(value);
+    if (recordValue) {
+      return recordValue;
+    }
+    if (Array.isArray(value)) {
+      const records = value.filter((item): item is Record<string, unknown> => asRecord(item) !== null);
+      if (records.length === value.length) {
+        return records;
+      }
+    }
+  }
+  return null;
+}
+
 function recordArrayField(record: Record<string, unknown> | null, keys: string[]) {
   if (!record) {
     return [];
@@ -210,6 +277,50 @@ function recordArrayField(record: Record<string, unknown> | null, keys: string[]
     }
   }
   return [];
+}
+
+function normalizeMetricKey(value: string) {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[\s-]+/g, "_")
+    .toLowerCase();
+}
+
+function numericMetricsFromRecord(record: Record<string, unknown> | null) {
+  const metrics: SyncTransportMetricMap = {};
+  if (!record) {
+    return metrics;
+  }
+  Object.entries(record).forEach(([key, value]) => {
+    const metricKey = normalizeMetricKey(key);
+    const looksLikeMetric =
+      /(?:_count|_bytes|_ms|_seconds)$/.test(metricKey) ||
+      metricKey.startsWith("count_");
+    if (looksLikeMetric && typeof value === "number" && Number.isFinite(value)) {
+      metrics[metricKey] = value;
+    }
+  });
+  return metrics;
+}
+
+function syncMetricMap(record: Record<string, unknown>) {
+  const explicitMetrics =
+    recordField(record, ["counters", "counts", "metrics", "project_counters", "projectCounters"]);
+  return {
+    ...numericMetricsFromRecord(explicitMetrics),
+    ...numericMetricsFromRecord(record),
+  };
+}
+
+function timingField(record: Record<string, unknown>) {
+  return recordOrRecordArrayField(record, [
+    "timing",
+    "timings",
+    "timing_metrics",
+    "timingMetrics",
+    "phase_timings",
+    "phaseTimings",
+  ]);
 }
 
 function normalizeProjectSyncState(value: string | null) {
@@ -311,6 +422,118 @@ function normalizeTransportStatusToken(value: string) {
   return value.trim().toLowerCase().replace(/[\s-]+/g, "_");
 }
 
+const SYNC_PROJECT_RESULT_PROGRESS_STATES = new Set([
+  "applying",
+  "downloading",
+  "exporting",
+  "importing",
+  "pending",
+  "planning",
+  "queued",
+  "receiving",
+  "running",
+  "staging",
+  "syncing",
+  "transferring",
+]);
+const SYNC_PROJECT_RESULT_PROBLEM_STATES = new Set([
+  "aborted",
+  "cancelled",
+  "canceled",
+  "completed_with_errors",
+  "conflicted",
+  "error",
+  "failed",
+]);
+
+function projectResultKey(result: SyncTransportProjectResult) {
+  return result.project_id.trim() || "unknown";
+}
+
+function isFinalSyncProjectResult(result: SyncTransportProjectResult) {
+  if (result.is_final !== null && result.is_final !== undefined) {
+    return result.is_final;
+  }
+  return !SYNC_PROJECT_RESULT_PROGRESS_STATES.has(result.status);
+}
+
+function syncResultTime(value: string | null | undefined) {
+  if (!value) {
+    return null;
+  }
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function syncProjectResultTime(result: SyncTransportProjectResult) {
+  return syncResultTime(result.completed_at) ?? syncResultTime(result.started_at);
+}
+
+function shouldReplaceSyncProjectResult(
+  current: SyncTransportProjectResult,
+  candidate: SyncTransportProjectResult,
+) {
+  const currentIsFinal = isFinalSyncProjectResult(current);
+  const candidateIsFinal = isFinalSyncProjectResult(candidate);
+  if (candidateIsFinal !== currentIsFinal) {
+    return candidateIsFinal;
+  }
+  const currentTime = syncProjectResultTime(current);
+  const candidateTime = syncProjectResultTime(candidate);
+  if (currentTime !== null || candidateTime !== null) {
+    if (currentTime === null) {
+      return true;
+    }
+    if (candidateTime === null) {
+      return false;
+    }
+    if (candidateTime !== currentTime) {
+      return candidateTime > currentTime;
+    }
+  }
+  return true;
+}
+
+export function mergeSyncProjectResults(
+  projectResults: SyncTransportProjectResult[],
+  manifestErrors: SyncTransportManifestError[] = [],
+) {
+  const merged = new Map<string, SyncTransportProjectResult>();
+  projectResults.forEach((result) => {
+    const key = projectResultKey(result);
+    const current = merged.get(key);
+    if (!current || shouldReplaceSyncProjectResult(current, result)) {
+      merged.delete(key);
+      merged.set(key, result);
+    }
+  });
+
+  const projectsWithFinalResults = new Set(
+    Array.from(merged.values())
+      .filter((result) => isFinalSyncProjectResult(result))
+      .map((result) => projectResultKey(result)),
+  );
+  manifestErrors.forEach((error) => {
+    const key = error.project_id.trim() || "unknown";
+    if (projectsWithFinalResults.has(key)) {
+      return;
+    }
+    const result: SyncTransportProjectResult = {
+      project_id: key,
+      status: "failed",
+      message: error.message,
+      is_final: true,
+    };
+    const current = merged.get(key);
+    if (!current || shouldReplaceSyncProjectResult(current, result)) {
+      merged.delete(key);
+      merged.set(key, result);
+    }
+  });
+
+  return Array.from(merged.values());
+}
+
 function normalizeSyncProjectResult(
   value: unknown,
   fallbackStatus = "failed",
@@ -320,12 +543,32 @@ function normalizeSyncProjectResult(
   if (!record) {
     return null;
   }
+  const counters = syncMetricMap(record);
   return {
     project_id: firstStringField([record], ["project_id", "projectId", "id"]) ?? "unknown",
+    run_id: firstStringField([record], ["run_id", "runId", "sync_run_id", "syncRunId"]),
+    session_id: firstStringField([record], ["session_id", "sessionId", "sync_session_id", "syncSessionId"]),
     status: normalizeTransportStatusToken(
       firstStringField([record], ["status", "state", "result"]) ?? fallbackStatus,
     ),
+    phase: firstStringField([record], ["phase", "stage"]),
+    action: firstStringField([record], ["action", "operation"]),
     message: firstStringField([record], ["message", "error", "reason"]) ?? fallbackMessage,
+    is_final: firstBooleanField([record], ["is_final", "isFinal", "final"]),
+    started_at: firstStringField([record], ["started_at", "startedAt"]),
+    completed_at: firstStringField([record], ["completed_at", "completedAt", "finished_at", "finishedAt"]),
+    duration_seconds: numberField(record, ["duration_seconds", "durationSeconds", "elapsed_seconds", "elapsedSeconds"]),
+    duration_ms: numberField(record, ["duration_ms", "durationMs", "elapsed_ms", "elapsedMs"]),
+    timing: timingField(record),
+    counters,
+    imported_count: numberField(record, ["imported_count", "importedCount"]),
+    applied_count: numberField(record, ["applied_count", "appliedCount"]),
+    deleted_count: numberField(record, ["deleted_count", "deletedCount"]),
+    satisfied_count: numberField(record, ["satisfied_count", "satisfiedCount"]),
+    skipped_count: numberField(record, ["skipped_count", "skippedCount"]),
+    failed_count: numberField(record, ["failed_count", "failedCount"]),
+    received_artifact_count: numberField(record, ["received_artifact_count", "receivedArtifactCount"]),
+    reused_artifact_count: numberField(record, ["reused_artifact_count", "reusedArtifactCount"]),
   };
 }
 
@@ -360,57 +603,112 @@ function normalizeSyncTransferResult(value: unknown): SyncTransportTransferResul
   };
 }
 
-const SYNC_PROJECT_RESULT_PROBLEM_STATES = new Set(["completed_with_errors", "conflicted", "error", "failed"]);
-
-function normalizeSyncRunStatus(value: unknown): SyncTransportRunStatus | null {
+export function normalizeSyncRunStatus(value: unknown): SyncTransportRunStatus | null {
   const record = asRecord(value);
   if (!record) {
     return null;
   }
+  const runId = firstStringField([record], ["run_id", "runId", "sync_run_id", "syncRunId", "id"]);
+  const sessionId = firstStringField([record], ["session_id", "sessionId", "sync_session_id", "syncSessionId"]);
+  const runStartedAt = firstStringField([record], ["started_at", "startedAt"]);
+  const runCompletedAt = firstStringField([record], ["completed_at", "completedAt", "finished_at", "finishedAt"]);
   const manifestErrors = recordArrayField(record, ["manifest_errors", "manifestErrors"])
     .map((item) => normalizeSyncManifestError(item))
     .filter((item): item is SyncTransportManifestError => item !== null);
-  const importedProjectResults = recordArrayField(record, ["project_results", "projectResults", "imported_projects", "importedProjects"])
+  const importedProjectResults = recordArrayField(record, [
+    "project_results",
+    "projectResults",
+    "imported_projects",
+    "importedProjects",
+    "projects",
+    "results",
+  ])
     .map((item) => normalizeSyncProjectResult(item))
-    .filter((item): item is SyncTransportProjectResult => item !== null);
-  const manifestErrorProjectResults = manifestErrors.map((error) => ({
-    project_id: error.project_id,
-    status: "failed",
-    message: error.message,
-  }));
-  const projectResults = [...importedProjectResults, ...manifestErrorProjectResults];
+    .filter((item): item is SyncTransportProjectResult => item !== null)
+    .map((result) => ({
+      ...result,
+      run_id: result.run_id ?? runId,
+      session_id: result.session_id ?? sessionId,
+      started_at: result.started_at ?? runStartedAt,
+      completed_at: result.completed_at ?? runCompletedAt,
+    }));
+  const finalProjectResultKeys = new Set(
+    importedProjectResults
+      .filter((result) => isFinalSyncProjectResult(result))
+      .map((result) => projectResultKey(result)),
+  );
+  const uncoveredManifestErrorCount = manifestErrors.filter(
+    (error) => !finalProjectResultKeys.has(error.project_id.trim() || "unknown"),
+  ).length;
+  const projectResults = mergeSyncProjectResults(importedProjectResults, manifestErrors);
   const receivedArtifacts = recordArrayField(record, ["received_artifacts", "receivedArtifacts", "artifacts"])
     .map((item) => normalizeSyncTransferResult(item))
     .filter((item): item is SyncTransportTransferResult => item !== null);
   const localManifestCount = numberField(record, ["local_manifest_count", "localManifestCount"]);
   const remoteManifestCount = numberField(record, ["remote_manifest_count", "remoteManifestCount"]);
+  const importedProjectCount = numberField(record, ["imported_project_count", "importedProjectCount"]);
+  const appliedProjectCount = numberField(record, ["applied_project_count", "appliedProjectCount"]);
+  const deletedProjectCount = numberField(record, ["deleted_project_count", "deletedProjectCount"]);
+  const skippedProjectCount = numberField(record, ["skipped_project_count", "skippedProjectCount"]);
+  const failedProjectCount = numberField(record, ["failed_project_count", "failedProjectCount"]);
+  const totalProjectCount = numberField(record, ["total_project_count", "totalProjectCount", "project_count", "projectCount"]);
+  const transferCounts = numericMetricsFromRecord(recordField(record, ["transfer_counts", "transferCounts"]));
   const hasProjectProblems = projectResults.some((result) =>
     SYNC_PROJECT_RESULT_PROBLEM_STATES.has(result.status),
   );
-  const status = firstStringField([record], ["status", "state"]) ??
-    (manifestErrors.length > 0 || hasProjectProblems ? "completed_with_errors" : "completed");
+  const explicitError = firstStringField([record], ["error", "last_error", "lastError"]);
+  const explicitStatus = firstStringField([record], ["status", "state"]);
+  let status = normalizeTransportStatusToken(
+    explicitStatus ??
+      (uncoveredManifestErrorCount > 0 || hasProjectProblems ? "completed_with_errors" : "completed"),
+  );
+  if (
+    status === "completed_with_errors" &&
+    !explicitError &&
+    !hasProjectProblems &&
+    uncoveredManifestErrorCount === 0
+  ) {
+    status = "completed";
+  }
   const summary =
-    localManifestCount !== null || remoteManifestCount !== null
-      ? `Exchanged ${localManifestCount ?? 0} local and ${remoteManifestCount ?? 0} remote manifest(s); processed ${projectResults.length} project(s), received ${receivedArtifacts.length} artifact(s).`
+    localManifestCount !== null ||
+    remoteManifestCount !== null ||
+    importedProjectCount !== null ||
+    skippedProjectCount !== null ||
+    failedProjectCount !== null
+      ? `Exchanged ${localManifestCount ?? 0} local and ${remoteManifestCount ?? 0} remote manifest(s); imported ${importedProjectCount ?? 0} project(s), skipped ${skippedProjectCount ?? 0} project(s), failed ${failedProjectCount ?? 0} project(s), received ${receivedArtifacts.length} artifact(s).`
       : null;
   return {
+    run_id: runId,
+    session_id: sessionId,
     peer_device_id: firstStringField([record], ["peer_device_id", "peerDeviceId", "device_id", "deviceId"]),
     remote_device_id: firstStringField([record], ["remote_device_id", "remoteDeviceId"]),
+    direction: firstStringField([record], ["direction", "role"]),
     status,
     message: firstStringField([record], ["message", "status_message", "statusMessage"]) ?? summary,
-    started_at: firstStringField([record], ["started_at", "startedAt"]),
-    completed_at: firstStringField([record], ["completed_at", "completedAt"]),
-    error: firstStringField([record], ["error", "last_error", "lastError"]),
+    started_at: runStartedAt,
+    completed_at: runCompletedAt,
+    duration_seconds: numberField(record, ["duration_seconds", "durationSeconds", "elapsed_seconds", "elapsedSeconds"]),
+    duration_ms: numberField(record, ["duration_ms", "durationMs", "elapsed_ms", "elapsedMs"]),
+    timing: timingField(record),
+    transfer_counts: transferCounts,
+    error: explicitError,
     project_results: projectResults,
     manifest_errors: manifestErrors,
     received_artifacts: receivedArtifacts,
     served_artifact_requests: numberField(record, ["served_artifact_requests", "servedArtifactRequests"]),
     local_manifest_count: localManifestCount,
     remote_manifest_count: remoteManifestCount,
+    imported_project_count: importedProjectCount,
+    applied_project_count: appliedProjectCount,
+    deleted_project_count: deletedProjectCount,
+    skipped_project_count: skippedProjectCount,
+    failed_project_count: failedProjectCount,
+    total_project_count: totalProjectCount,
   };
 }
 
-function normalizeSyncTransportStatus(value: unknown): SyncTransportStatus {
+export function normalizeSyncTransportStatus(value: unknown): SyncTransportStatus {
   const record = asRecord(value);
   if (!record) {
     return {

--- a/apps/desktop/src/styles/activity.css
+++ b/apps/desktop/src/styles/activity.css
@@ -288,7 +288,7 @@
 
 .activity-sync-project-result {
   display: grid;
-  grid-template-columns: auto minmax(6rem, 0.32fr) minmax(0, 1fr);
+  grid-template-columns: auto minmax(0, 1fr);
   gap: 0.45rem;
   align-items: start;
   border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
@@ -314,10 +314,12 @@
 .activity-sync-project-result__project {
   color: var(--text);
   font-weight: 760;
+  min-width: 0;
   overflow-wrap: anywhere;
 }
 
 .activity-sync-project-result__message {
+  grid-column: 1 / -1;
   min-width: 0;
   overflow-wrap: anywhere;
 }

--- a/packages/shared-types/scripts/generate.mjs
+++ b/packages/shared-types/scripts/generate.mjs
@@ -49,6 +49,6 @@ if (existsSync(legacyNvidiaMarker)) {
 
 execFileSync(
   "pnpm",
-  ["exec", "openapi-typescript", openApiJson, "-o", generatedPath],
+  ["exec", "openapi-typescript", openApiJson, "-o", generatedPath, "--default-non-nullable", "false"],
   { stdio: "inherit", cwd: packageRoot },
 );

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -701,12 +701,12 @@ export interface components {
              * Include Tempo
              * @default false
              */
-            include_tempo: boolean;
+            include_tempo?: boolean;
             /**
              * Force
              * @default false
              */
-            force: boolean;
+            force?: boolean;
         };
         /** AnalysisResponse */
         AnalysisResponse: {
@@ -851,19 +851,19 @@ export interface components {
              * Backend
              * @default default
              */
-            backend: string;
+            backend?: string;
             /** Backend Fallback From */
             backend_fallback_from?: string | null;
             /**
              * Force
              * @default false
              */
-            force: boolean;
+            force?: boolean;
             /**
              * Overwrite User Edits
              * @default false
              */
-            overwrite_user_edits: boolean;
+            overwrite_user_edits?: boolean;
         };
         /** ChordResponse */
         ChordResponse: {
@@ -881,12 +881,12 @@ export interface components {
              * Has User Edits
              * @default false
              */
-            has_user_edits: boolean;
+            has_user_edits?: boolean;
             /**
              * Source Kind
              * @default generated
              */
-            source_kind: string;
+            source_kind?: string;
             /** Metadata */
             metadata?: {
                 [key: string]: unknown;
@@ -949,12 +949,12 @@ export interface components {
              * Mixdown Mode
              * @default copy
              */
-            mixdown_mode: string;
+            mixdown_mode?: string;
             /**
              * Output Format
              * @default wav
              */
-            output_format: string;
+            output_format?: string;
             /** Destination Path */
             destination_path?: string | null;
         };
@@ -1047,7 +1047,7 @@ export interface components {
              * Force
              * @default false
              */
-            force: boolean;
+            force?: boolean;
         };
         /** LyricsResponse */
         LyricsResponse: {
@@ -1075,7 +1075,7 @@ export interface components {
              * Has User Edits
              * @default false
              */
-            has_user_edits: boolean;
+            has_user_edits?: boolean;
             /** Created At */
             created_at?: string | null;
             /** Updated At */
@@ -1116,7 +1116,7 @@ export interface components {
              * Output Format
              * @default wav
              */
-            output_format: string;
+            output_format?: string;
         };
         /** PreviewRetuneRequest */
         PreviewRetuneRequest: {
@@ -1138,7 +1138,7 @@ export interface components {
              * Copy Into Project
              * @default true
              */
-            copy_into_project: boolean;
+            copy_into_project?: boolean;
             /** Display Name */
             display_name?: string | null;
             /** Chord Backend */
@@ -1175,14 +1175,14 @@ export interface components {
              * @default local
              * @enum {string}
              */
-            sync_status: "local" | "syncing" | "remote_available" | "downloading" | "missing" | "deleted" | "conflicted";
+            sync_status?: "local" | "syncing" | "remote_available" | "downloading" | "missing" | "deleted" | "conflicted";
             /** Sync Status Reason */
             sync_status_reason?: string | null;
             /**
              * Sync Editable
              * @default true
              */
-            sync_editable: boolean;
+            sync_editable?: boolean;
             /** Sync Required Artifact Ids */
             sync_required_artifact_ids?: string[];
             /** Sync Provider Device Ids */
@@ -1191,7 +1191,7 @@ export interface components {
              * Sync Conflict Count
              * @default 0
              */
-            sync_conflict_count: number;
+            sync_conflict_count?: number;
             /**
              * Created At
              * Format: date-time
@@ -1225,12 +1225,12 @@ export interface components {
              * Preview Only
              * @default true
              */
-            preview_only: boolean;
+            preview_only?: boolean;
             /**
              * Output Format
              * @default wav
              */
-            output_format: string;
+            output_format?: string;
         };
         /** SongSectionSchema */
         SongSectionSchema: {
@@ -1300,33 +1300,33 @@ export interface components {
              * Mode
              * @default stems
              */
-            mode: string;
+            mode?: string;
             /** Stem Model */
             stem_model?: string | null;
             /**
              * Output Format
              * @default wav
              */
-            output_format: string;
+            output_format?: string;
             /**
              * Force
              * @default false
              */
-            force: boolean;
+            force?: boolean;
             /** Source Artifact Id */
             source_artifact_id?: string | null;
             /**
              * Chord Backend
              * @default default
              */
-            chord_backend: string;
+            chord_backend?: string;
             /** Chord Backend Fallback From */
             chord_backend_fallback_from?: string | null;
             /**
              * Overwrite Chord Edits
              * @default false
              */
-            overwrite_chord_edits: boolean;
+            overwrite_chord_edits?: boolean;
         };
         /** SyncArtifactStagingRequest */
         SyncArtifactStagingRequest: {
@@ -1480,7 +1480,7 @@ export interface components {
              * Adopt Sync Group
              * @default false
              */
-            adopt_sync_group: boolean;
+            adopt_sync_group?: boolean;
         };
         /** SyncPairingAnswerResponse */
         SyncPairingAnswerResponse: {
@@ -1495,7 +1495,7 @@ export interface components {
              * Ttl Seconds
              * @default 600
              */
-            ttl_seconds: number;
+            ttl_seconds?: number;
         };
         /** SyncPairingOfferResponse */
         SyncPairingOfferResponse: {
@@ -1844,7 +1844,14 @@ export interface components {
              * Use Content Addressed Staging
              * @default true
              */
-            use_content_addressed_staging: boolean;
+            use_content_addressed_staging?: boolean;
+            /** Project Ids */
+            project_ids?: string[];
+            /**
+             * Include Timing Evidence
+             * @default false
+             */
+            include_timing_evidence?: boolean;
         };
         /** SyncReconciliationApplyResponse */
         SyncReconciliationApplyResponse: {
@@ -1852,6 +1859,8 @@ export interface components {
             plan: components["schemas"]["SyncReconciliationPlanResponse"];
             /** Results */
             results: components["schemas"]["SyncReconciliationApplyActionResultSchema"][];
+            /** Timing Evidence */
+            timing_evidence?: components["schemas"]["SyncReconciliationTimingEvidenceSchema"][];
         };
         /** SyncReconciliationApplySummarySchema */
         SyncReconciliationApplySummarySchema: {
@@ -1930,6 +1939,30 @@ export interface components {
             /** Status Counts */
             status_counts?: {
                 [key: string]: number;
+            };
+        };
+        /** SyncReconciliationTimingEvidenceSchema */
+        SyncReconciliationTimingEvidenceSchema: {
+            /**
+             * Phase
+             * @enum {string}
+             */
+            phase: "plan" | "apply" | "action" | "staging_cleanup";
+            /** Duration Ms */
+            duration_ms: number;
+            /** Action Type */
+            action_type?: ("apply_delete_tombstone" | "import_project_manifest" | "import_entity_revision" | "fetch_artifact_content" | "import_artifact_manifest" | "upsert_project_status" | "record_conflict" | "noop") | null;
+            /** Item Type */
+            item_type?: string | null;
+            /** Item Id */
+            item_id?: string | null;
+            /** Project Id */
+            project_id?: string | null;
+            /** Status */
+            status?: ("applied" | "satisfied" | "skipped" | "failed") | null;
+            /** Details */
+            details?: {
+                [key: string]: unknown;
             };
         };
         /** SyncStagedArtifactSchema */
@@ -2029,7 +2062,7 @@ export interface components {
              * Adopt Sync Group
              * @default false
              */
-            adopt_sync_group: boolean;
+            adopt_sync_group?: boolean;
         };
         /** SyncTrustedPeerResponse */
         SyncTrustedPeerResponse: {
@@ -2137,7 +2170,7 @@ export interface components {
              * Status
              * @default pending
              */
-            status: string;
+            status?: string;
             /** Title */
             title: string;
             /** Current Text */
@@ -2165,12 +2198,12 @@ export interface components {
              * Preview Only
              * @default true
              */
-            preview_only: boolean;
+            preview_only?: boolean;
             /**
              * Output Format
              * @default wav
              */
-            output_format: string;
+            output_format?: string;
         };
         /** ValidationError */
         ValidationError: {


### PR DESCRIPTION
## Summary
- Make native desktop sync apply remote projects incrementally, reuse verified staged artifacts, and report fresh per-run project outcomes.
- Add backend scoped apply/timing evidence and cleanup for stale project/tombstone rows so retries and delete/resurrect flows converge.
- Normalize Activity sync results so stale rows are replaced and final project states are visible.

Closes #163
Closes #161

## Testing
- `cd apps/backend && uv run --python 3.11 pytest`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `pnpm contracts:generate`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test --run src/App.activity.test.tsx`
- `cd apps/desktop/src-tauri && cargo test sync_transport && cargo check`
- Manual 2-device LAN testing on May 20, 2026: empty library sync, multi-track incremental sync, interrupted sync resume, mid-job sync retry, delete/resurrect project sync, mix/stem round trips, and project/mix/stem deletion propagation.
