### PR TITLE
feat: add sync transport bake-off evidence

### DIFF
--- a/apps/desktop/src-tauri/src/sync_transport.rs
+++ b/apps/desktop/src-tauri/src/sync_transport.rs
@@ -59,6 +59,10 @@ pub struct SyncTransportTransferResult {
     pub artifact_id: String,
     pub content_sha256: String,
     pub size_bytes: u64,
+    pub started_at: String,
+    pub completed_at: String,
+    pub duration_ms: u64,
+    pub throughput_bytes_per_second: f64,
     pub status: String,
     pub message: Option<String>,
 }
@@ -112,10 +116,14 @@ pub struct SyncTransportSyncResult {
     pub received_artifacts: Vec<SyncTransportTransferResult>,
     pub transfer_counts: SyncTransportTransferCounts,
     pub served_artifact_requests: u64,
+    pub total_received_bytes: u64,
+    pub total_served_bytes: u64,
+    pub time_to_first_artifact_ms: Option<u64>,
+    pub throughput_bytes_per_second: f64,
     pub remote_manifest_count: usize,
     pub local_manifest_count: usize,
     pub manifest_errors: Vec<SyncTransportManifestError>,
-    pub timings: Vec<SyncTransportTimingEvidence>,
+    pub phase_timings: Vec<SyncTransportTimingEvidence>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -165,7 +173,7 @@ mod desktop {
     const DEFAULT_LISTENER_PORT: u16 = 47619;
     const ENDPOINT_SCHEME: &str = "tuneforge-sync+tcp://";
     const PAIRING_PROTOCOL_VERSION: &str = "tuneforge-sync-v1";
-    const TRANSPORT_PROTOCOL_VERSION: &str = "tuneforge-sync-transport-v1";
+    const TRANSPORT_PROTOCOL_VERSION: &str = "tuneforge-sync-transport-v2";
     const TRANSPORT_HANDSHAKE_CHALLENGE_TYPE: &str = "transport_handshake";
     const NOISE_PATTERN: &str = "Noise_XX_25519_ChaChaPoly_BLAKE2s";
     const READ_TIMEOUT: Duration = Duration::from_secs(45);
@@ -173,7 +181,9 @@ mod desktop {
     const ACCEPT_SLEEP: Duration = Duration::from_millis(100);
     const MAX_RAW_FRAME: usize = 65_535;
     const ENCRYPTED_PAYLOAD_CHUNK: usize = 32 * 1024;
-    const ARTIFACT_CHUNK_SIZE: usize = 24 * 1024;
+    const ARTIFACT_CHUNK_SIZE: usize = 32 * 1024;
+    const ENCRYPTED_FRAME_MESSAGE_CHUNK: u8 = 1;
+    const ENCRYPTED_FRAME_ARTIFACT_CHUNK: u8 = 2;
     const PAIRING_OFFER_TTL_SECONDS: u32 = 600;
     const TRANSPORT_HANDSHAKE_TTL_SECONDS: i64 = 60;
     const HTTP_TIMEOUT: Duration = Duration::from_secs(45);
@@ -362,6 +372,7 @@ mod desktop {
             let run_started_at = Utc::now();
             let run_started_instant = Instant::now();
             let mut timings = Vec::new();
+            let mut metrics = SyncRunMetrics::start(run_started_instant);
             let client = BackendClient::new(&self.base_url)?;
             let peer = client
                 .trusted_peer(&payload.peer_device_id)
@@ -432,6 +443,7 @@ mod desktop {
                     &session.remote_device_id,
                     &remote_offer.metadata,
                     &remote_offer.project_manifests,
+                    &mut metrics,
                     &mut timings,
                 );
                 imported_projects = imported.imported_projects;
@@ -446,6 +458,7 @@ mod desktop {
                 &client,
                 &mut connection,
                 &local_offer.project_manifests,
+                &mut metrics,
             )?;
             timings.push(timer.finish());
             let manifest_errors =
@@ -477,10 +490,15 @@ mod desktop {
                 received_artifacts,
                 transfer_counts,
                 served_artifact_requests,
+                total_received_bytes: metrics.total_received_bytes,
+                total_served_bytes: metrics.total_served_bytes,
+                time_to_first_artifact_ms: metrics.time_to_first_artifact_ms(),
+                throughput_bytes_per_second: metrics
+                    .throughput_bytes_per_second(run_started_instant.elapsed()),
                 remote_manifest_count: remote_offer.project_manifests.len(),
                 local_manifest_count,
                 manifest_errors,
-                timings,
+                phase_timings: timings,
             })
         }
     }
@@ -614,6 +632,7 @@ mod desktop {
         let run_started_at = Utc::now();
         let run_started_instant = Instant::now();
         let mut timings = Vec::new();
+        let mut metrics = SyncRunMetrics::start(run_started_instant);
         configure_stream(&stream)?;
         let client = BackendClient::new(&base_url)?;
         let timer = SyncPhaseTimer::start("peer_authentication");
@@ -645,6 +664,7 @@ mod desktop {
             &client,
             &mut connection,
             &local_offer.project_manifests,
+            &mut metrics,
         )?;
         timings.push(timer.finish());
         let imported = import_remote_manifests(
@@ -653,6 +673,7 @@ mod desktop {
             &session.remote_device_id,
             &remote_offer.metadata,
             &remote_offer.project_manifests,
+            &mut metrics,
             &mut timings,
         );
         let import_counts = import_outcome_counts(&imported.imported_projects);
@@ -697,10 +718,15 @@ mod desktop {
             received_artifacts: imported.received_artifacts,
             transfer_counts,
             served_artifact_requests,
+            total_received_bytes: metrics.total_received_bytes,
+            total_served_bytes: metrics.total_served_bytes,
+            time_to_first_artifact_ms: metrics.time_to_first_artifact_ms(),
+            throughput_bytes_per_second: metrics
+                .throughput_bytes_per_second(run_started_instant.elapsed()),
             remote_manifest_count: remote_offer.project_manifests.len(),
             local_manifest_count,
             manifest_errors,
-            timings,
+            phase_timings: timings,
         };
 
         Ok(IncomingSessionResult {
@@ -774,6 +800,98 @@ mod desktop {
         duration.as_millis().min(u128::from(u64::MAX)) as u64
     }
 
+    fn throughput_bytes_per_second(bytes: u64, duration: Duration) -> f64 {
+        if bytes == 0 {
+            return 0.0;
+        }
+        let seconds = duration.as_secs_f64();
+        if seconds <= 0.0 {
+            0.0
+        } else {
+            bytes as f64 / seconds
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct SyncRunMetrics {
+        started_instant: Instant,
+        total_received_bytes: u64,
+        total_served_bytes: u64,
+        first_artifact_at: Option<Duration>,
+    }
+
+    impl SyncRunMetrics {
+        fn start(started_instant: Instant) -> Self {
+            Self {
+                started_instant,
+                total_received_bytes: 0,
+                total_served_bytes: 0,
+                first_artifact_at: None,
+            }
+        }
+
+        fn record_received_artifact_bytes(&mut self, bytes: u64) {
+            self.total_received_bytes = self.total_received_bytes.saturating_add(bytes);
+            self.record_first_artifact_bytes(bytes);
+        }
+
+        fn record_served_artifact_bytes(&mut self, bytes: u64) {
+            self.total_served_bytes = self.total_served_bytes.saturating_add(bytes);
+            self.record_first_artifact_bytes(bytes);
+        }
+
+        fn record_first_artifact_bytes(&mut self, bytes: u64) {
+            if bytes > 0 && self.first_artifact_at.is_none() {
+                self.first_artifact_at = Some(self.started_instant.elapsed());
+            }
+        }
+
+        fn time_to_first_artifact_ms(&self) -> Option<u64> {
+            self.first_artifact_at.map(duration_millis)
+        }
+
+        fn throughput_bytes_per_second(&self, duration: Duration) -> f64 {
+            throughput_bytes_per_second(
+                self.total_received_bytes
+                    .saturating_add(self.total_served_bytes),
+                duration,
+            )
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct TransferTiming {
+        started_at: String,
+        completed_at: String,
+        duration_ms: u64,
+        throughput_bytes_per_second: f64,
+    }
+
+    struct TransferTimer {
+        started_at: DateTime<Utc>,
+        started_instant: Instant,
+    }
+
+    impl TransferTimer {
+        fn start() -> Self {
+            Self {
+                started_at: Utc::now(),
+                started_instant: Instant::now(),
+            }
+        }
+
+        fn finish(self, bytes: u64) -> TransferTiming {
+            let completed_at = Utc::now();
+            let duration = self.started_instant.elapsed();
+            TransferTiming {
+                started_at: self.started_at.to_rfc3339(),
+                completed_at: completed_at.to_rfc3339(),
+                duration_ms: duration_millis(duration),
+                throughput_bytes_per_second: throughput_bytes_per_second(bytes, duration),
+            }
+        }
+    }
+
     #[derive(Clone, Debug, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
     struct ManifestOffer {
@@ -804,9 +922,6 @@ mod desktop {
             content_sha256: String,
             size_bytes: u64,
         },
-        ArtifactChunk {
-            data: String,
-        },
         ArtifactEnd {
             content_sha256: String,
             size_bytes: u64,
@@ -829,7 +944,6 @@ mod desktop {
                 Self::ManifestOffer(_) => "manifest_offer",
                 Self::ArtifactRequest { .. } => "artifact_request",
                 Self::ArtifactStart { .. } => "artifact_start",
-                Self::ArtifactChunk { .. } => "artifact_chunk",
                 Self::ArtifactEnd { .. } => "artifact_end",
                 Self::Status { .. } => "status",
                 Self::PhaseDone { .. } => "phase_done",
@@ -852,6 +966,16 @@ mod desktop {
         chunk_index: u32,
         chunk_count: u32,
         data: String,
+    }
+
+    enum EncryptedFrame {
+        MessageChunk(EncryptedChunk),
+        ArtifactChunk(Vec<u8>),
+    }
+
+    enum ArtifactTransferFrame {
+        Chunk(Vec<u8>),
+        Message(ProtocolMessage),
     }
 
     struct SecurePeerConnection {
@@ -949,7 +1073,36 @@ mod desktop {
         }
 
         fn read_message(&mut self) -> Result<ProtocolMessage, String> {
-            let first = self.read_encrypted_chunk()?;
+            let first = match self.read_encrypted_frame()? {
+                EncryptedFrame::MessageChunk(chunk) => chunk,
+                EncryptedFrame::ArtifactChunk(_) => {
+                    return Err(
+                        "Received artifact bytes while waiting for a sync transport message."
+                            .to_string(),
+                    );
+                }
+            };
+            self.read_message_from_first_chunk(first)
+        }
+
+        fn send_artifact_chunk(&mut self, chunk: &[u8]) -> Result<(), String> {
+            let plaintext = encode_artifact_chunk_frame(chunk);
+            self.send_encrypted_plaintext(&plaintext)
+        }
+
+        fn read_artifact_transfer_frame(&mut self) -> Result<ArtifactTransferFrame, String> {
+            match self.read_encrypted_frame()? {
+                EncryptedFrame::ArtifactChunk(chunk) => Ok(ArtifactTransferFrame::Chunk(chunk)),
+                EncryptedFrame::MessageChunk(chunk) => self
+                    .read_message_from_first_chunk(chunk)
+                    .map(ArtifactTransferFrame::Message),
+            }
+        }
+
+        fn read_message_from_first_chunk(
+            &mut self,
+            first: EncryptedChunk,
+        ) -> Result<ProtocolMessage, String> {
             if first.chunk_count == 0 {
                 return Err("Encrypted sync transport message has no chunks.".to_string());
             }
@@ -960,7 +1113,15 @@ mod desktop {
             let message_id = first.message_id;
             chunks.push(decode_standard_base64(&first.data)?);
             for expected_index in 1..first.chunk_count {
-                let next = self.read_encrypted_chunk()?;
+                let next = match self.read_encrypted_frame()? {
+                    EncryptedFrame::MessageChunk(chunk) => chunk,
+                    EncryptedFrame::ArtifactChunk(_) => {
+                        return Err(
+                            "Received artifact bytes inside a chunked sync transport message."
+                                .to_string(),
+                        );
+                    }
+                };
                 if next.message_id != message_id || next.chunk_index != expected_index {
                     return Err("Encrypted sync transport chunks arrived out of order.".to_string());
                 }
@@ -975,25 +1136,64 @@ mod desktop {
         }
 
         fn send_encrypted_chunk(&mut self, chunk: &EncryptedChunk) -> Result<(), String> {
-            let plaintext = serde_json::to_vec(chunk)
-                .map_err(|error| format!("Could not encode encrypted chunk: {error}"))?;
+            let plaintext = encode_message_chunk_frame(chunk)?;
+            self.send_encrypted_plaintext(&plaintext)
+        }
+
+        fn send_encrypted_plaintext(&mut self, plaintext: &[u8]) -> Result<(), String> {
             let mut ciphertext = vec![0_u8; plaintext.len() + 1024];
             let written = self
                 .noise
-                .write_message(&plaintext, &mut ciphertext)
+                .write_message(plaintext, &mut ciphertext)
                 .map_err(|error| format!("Noise transport write failed: {error}"))?;
             write_raw_frame(&mut self.stream, &ciphertext[..written])
         }
 
-        fn read_encrypted_chunk(&mut self) -> Result<EncryptedChunk, String> {
+        fn read_encrypted_frame(&mut self) -> Result<EncryptedFrame, String> {
             let ciphertext = read_raw_frame(&mut self.stream)?;
             let mut plaintext = vec![0_u8; MAX_RAW_FRAME];
             let read = self
                 .noise
                 .read_message(&ciphertext, &mut plaintext)
                 .map_err(|error| format!("Noise transport read failed: {error}"))?;
-            serde_json::from_slice(&plaintext[..read])
-                .map_err(|error| format!("Could not decode encrypted chunk: {error}"))
+            decode_encrypted_frame_plaintext(&plaintext[..read])
+        }
+    }
+
+    fn encode_message_chunk_frame(chunk: &EncryptedChunk) -> Result<Vec<u8>, String> {
+        let payload = serde_json::to_vec(chunk)
+            .map_err(|error| format!("Could not encode encrypted chunk: {error}"))?;
+        let mut plaintext = Vec::with_capacity(payload.len() + 1);
+        plaintext.push(ENCRYPTED_FRAME_MESSAGE_CHUNK);
+        plaintext.extend_from_slice(&payload);
+        Ok(plaintext)
+    }
+
+    fn encode_artifact_chunk_frame(chunk: &[u8]) -> Vec<u8> {
+        let mut plaintext = Vec::with_capacity(chunk.len() + 1);
+        plaintext.push(ENCRYPTED_FRAME_ARTIFACT_CHUNK);
+        plaintext.extend_from_slice(chunk);
+        plaintext
+    }
+
+    fn decode_encrypted_frame_plaintext(plaintext: &[u8]) -> Result<EncryptedFrame, String> {
+        let Some((&frame_type, payload)) = plaintext.split_first() else {
+            return Err("Encrypted sync transport frame is empty.".to_string());
+        };
+        match frame_type {
+            ENCRYPTED_FRAME_MESSAGE_CHUNK => {
+                let chunk = serde_json::from_slice(payload)
+                    .map_err(|error| format!("Could not decode encrypted chunk: {error}"))?;
+                Ok(EncryptedFrame::MessageChunk(chunk))
+            }
+            ENCRYPTED_FRAME_ARTIFACT_CHUNK => Ok(EncryptedFrame::ArtifactChunk(payload.to_vec())),
+            // v2 peers reject v1 during auth, but this keeps the error path readable.
+            b'{' => {
+                let chunk = serde_json::from_slice(plaintext)
+                    .map_err(|error| format!("Could not decode encrypted chunk: {error}"))?;
+                Ok(EncryptedFrame::MessageChunk(chunk))
+            }
+            _ => Err("Encrypted sync transport frame has an unsupported type.".to_string()),
         }
     }
 
@@ -1400,6 +1600,7 @@ mod desktop {
         peer_device_id: &str,
         remote_metadata: &Value,
         manifests: &[Value],
+        metrics: &mut SyncRunMetrics,
         timings: &mut Vec<SyncTransportTimingEvidence>,
     ) -> ImportRemoteResult {
         let mut received_artifacts = Vec::new();
@@ -1436,6 +1637,7 @@ mod desktop {
                 manifest,
                 &plan,
                 &mut received_artifacts,
+                metrics,
                 timings,
             );
             imported_projects.push(project_result);
@@ -1498,6 +1700,7 @@ mod desktop {
         manifest: &Value,
         plan: &Value,
         received_artifacts: &mut Vec<SyncTransportTransferResult>,
+        metrics: &mut SyncRunMetrics,
         timings: &mut Vec<SyncTransportTimingEvidence>,
     ) -> SyncTransportProjectResult {
         let project_id = manifest_project_id(manifest);
@@ -1512,6 +1715,7 @@ mod desktop {
                 connection,
                 peer_device_id,
                 &entry.artifact,
+                metrics,
                 timings,
             ) {
                 Ok(result) => {
@@ -1519,10 +1723,9 @@ mod desktop {
                     received_artifacts.push(result);
                 }
                 Err(error) => {
-                    let failed = failed_transfer_result(&entry.artifact, &error);
-                    project_transfers.push(failed.clone());
-                    received_artifacts.push(failed);
-                    transfer_failure.get_or_insert((entry.manifest_project_id, error));
+                    project_transfers.push(error.result.clone());
+                    received_artifacts.push(error.result);
+                    transfer_failure.get_or_insert((entry.manifest_project_id, error.message));
                 }
             }
         }
@@ -2241,21 +2444,42 @@ mod desktop {
         connection: &mut SecurePeerConnection,
         peer_device_id: &str,
         artifact: &RemoteArtifact,
+        metrics: &mut SyncRunMetrics,
         timings: &mut Vec<SyncTransportTimingEvidence>,
-    ) -> Result<SyncTransportTransferResult, String> {
+    ) -> Result<SyncTransportTransferResult, TransferFailure> {
+        let transfer_timer = TransferTimer::start();
         let timer = SyncPhaseTimer::start_artifact("artifact_staging_check", artifact);
         let staged = already_staged_artifact_result(client, artifact);
         timings.push(timer.finish());
-        if let Some(result) = staged? {
-            return Ok(result);
+        match staged {
+            Ok(true) => {
+                return Ok(transfer_result(
+                    artifact,
+                    "already_staged",
+                    Some("Artifact content was already staged and verified locally.".to_string()),
+                    transfer_timer.finish(0),
+                ));
+            }
+            Ok(false) => {}
+            Err(error) => {
+                return Err(transfer_failure(artifact, transfer_timer.finish(0), error));
+            }
         }
-        request_and_stage_artifact(client, connection, peer_device_id, artifact, timings)
+        request_and_stage_artifact(
+            client,
+            connection,
+            peer_device_id,
+            artifact,
+            transfer_timer,
+            metrics,
+            timings,
+        )
     }
 
     fn already_staged_artifact_result(
         client: &BackendClient,
         artifact: &RemoteArtifact,
-    ) -> Result<Option<SyncTransportTransferResult>, String> {
+    ) -> Result<bool, String> {
         let path = format!(
             "/api/v1/sync/artifacts/staging/{}",
             percent_encode_path_segment(&artifact.content_sha256)
@@ -2269,17 +2493,9 @@ mod desktop {
                             .to_string(),
                     );
                 }
-                Ok(Some(SyncTransportTransferResult {
-                    artifact_id: artifact.artifact_id.clone(),
-                    content_sha256: artifact.content_sha256.clone(),
-                    size_bytes: artifact.size_bytes,
-                    status: "already_staged".to_string(),
-                    message: Some(
-                        "Artifact content was already staged and verified locally.".to_string(),
-                    ),
-                }))
+                Ok(true)
             }
-            Err(error) if error.status == Some(404) => Ok(None),
+            Err(error) if error.status == Some(404) => Ok(false),
             Err(error) => Err(format!(
                 "Could not inspect staged sync artifact {}: {error}",
                 artifact.content_sha256
@@ -2292,52 +2508,90 @@ mod desktop {
         connection: &mut SecurePeerConnection,
         peer_device_id: &str,
         artifact: &RemoteArtifact,
+        transfer_timer: TransferTimer,
+        metrics: &mut SyncRunMetrics,
         timings: &mut Vec<SyncTransportTimingEvidence>,
-    ) -> Result<SyncTransportTransferResult, String> {
+    ) -> Result<SyncTransportTransferResult, TransferFailure> {
         let timer = SyncPhaseTimer::start_artifact("artifact_transfer", artifact);
-        connection.send_message(&ProtocolMessage::ArtifactRequest {
+        if let Err(error) = connection.send_message(&ProtocolMessage::ArtifactRequest {
             artifact_id: artifact.artifact_id.clone(),
             content_sha256: artifact.content_sha256.clone(),
             size_bytes: artifact.size_bytes,
-        })?;
+        }) {
+            timings.push(timer.finish());
+            return Err(transfer_failure(artifact, transfer_timer.finish(0), error));
+        }
 
-        match connection.read_message()? {
-            ProtocolMessage::ArtifactStart {
+        match connection.read_message() {
+            Ok(ProtocolMessage::ArtifactStart {
                 artifact_id,
                 content_sha256,
                 size_bytes,
-            } => {
+            }) => {
                 if artifact_id != artifact.artifact_id
                     || content_sha256 != artifact.content_sha256
                     || size_bytes != artifact.size_bytes
                 {
-                    return Err(
-                        "Sync peer artifact response did not match the request.".to_string()
-                    );
+                    timings.push(timer.finish());
+                    return Err(transfer_failure(
+                        artifact,
+                        transfer_timer.finish(0),
+                        "Sync peer artifact response did not match the request.".to_string(),
+                    ));
                 }
             }
-            ProtocolMessage::Error(error) => return Err(error.message),
-            other => {
-                return Err(format!(
-                    "Sync peer sent unexpected artifact response: {}",
-                    other.kind()
+            Ok(ProtocolMessage::Error(error)) => {
+                timings.push(timer.finish());
+                return Err(transfer_failure(
+                    artifact,
+                    transfer_timer.finish(0),
+                    error.message,
                 ));
+            }
+            Ok(other) => {
+                timings.push(timer.finish());
+                return Err(transfer_failure(
+                    artifact,
+                    transfer_timer.finish(0),
+                    format!(
+                        "Sync peer sent unexpected artifact response: {}",
+                        other.kind()
+                    ),
+                ));
+            }
+            Err(error) => {
+                timings.push(timer.finish());
+                return Err(transfer_failure(artifact, transfer_timer.finish(0), error));
             }
         }
 
         let temp_path = temp_artifact_path(&artifact.content_sha256);
         if let Some(parent) = temp_path.parent() {
-            fs::create_dir_all(parent)
-                .map_err(|error| format!("Could not create sync artifact temp dir: {error}"))?;
+            if let Err(error) = fs::create_dir_all(parent) {
+                timings.push(timer.finish());
+                return Err(transfer_failure(
+                    artifact,
+                    transfer_timer.finish(0),
+                    format!("Could not create sync artifact temp dir: {error}"),
+                ));
+            }
         }
-        let mut file = File::create(&temp_path)
-            .map_err(|error| format!("Could not create sync artifact temp file: {error}"))?;
+        let mut file = match File::create(&temp_path) {
+            Ok(file) => file,
+            Err(error) => {
+                timings.push(timer.finish());
+                return Err(transfer_failure(
+                    artifact,
+                    transfer_timer.finish(0),
+                    format!("Could not create sync artifact temp file: {error}"),
+                ));
+            }
+        };
         let mut hasher = Sha256::new();
         let mut size_bytes = 0_u64;
         let receive_result = loop {
-            match connection.read_message()? {
-                ProtocolMessage::ArtifactChunk { data } => {
-                    let chunk = decode_standard_base64(&data)?;
+            match connection.read_artifact_transfer_frame() {
+                Ok(ArtifactTransferFrame::Chunk(chunk)) => {
                     let next_size_bytes = size_bytes.saturating_add(chunk.len() as u64);
                     if next_size_bytes > artifact.size_bytes {
                         break Err(
@@ -2345,18 +2599,23 @@ mod desktop {
                         );
                     }
                     size_bytes = next_size_bytes;
+                    metrics.record_received_artifact_bytes(chunk.len() as u64);
                     hasher.update(&chunk);
-                    file.write_all(&chunk).map_err(|error| {
-                        format!("Could not write received sync artifact bytes: {error}")
-                    })?;
+                    if let Err(error) = file.write_all(&chunk) {
+                        break Err(format!(
+                            "Could not write received sync artifact bytes: {error}"
+                        ));
+                    }
                 }
-                ProtocolMessage::ArtifactEnd {
+                Ok(ArtifactTransferFrame::Message(ProtocolMessage::ArtifactEnd {
                     content_sha256,
                     size_bytes: peer_size_bytes,
-                } => {
-                    file.flush().map_err(|error| {
-                        format!("Could not flush received sync artifact bytes: {error}")
-                    })?;
+                })) => {
+                    if let Err(error) = file.flush() {
+                        break Err(format!(
+                            "Could not flush received sync artifact bytes: {error}"
+                        ));
+                    }
                     let actual_sha256 = hex_digest(hasher.finalize().as_slice());
                     if content_sha256 != artifact.content_sha256
                         || actual_sha256 != artifact.content_sha256
@@ -2370,22 +2629,26 @@ mod desktop {
                     }
                     break Ok(());
                 }
-                ProtocolMessage::Error(error) => break Err(error.message),
-                other => {
+                Ok(ArtifactTransferFrame::Message(ProtocolMessage::Error(error))) => {
+                    break Err(error.message);
+                }
+                Ok(ArtifactTransferFrame::Message(other)) => {
                     break Err(format!(
                         "Sync peer sent unexpected artifact transfer message: {}",
                         other.kind()
                     ));
                 }
+                Err(error) => break Err(error),
             }
         };
+        let transfer_timing = transfer_timer.finish(size_bytes);
         timings.push(timer.finish());
 
         if let Err(error) = receive_result {
             let cleanup_timer = SyncPhaseTimer::start_artifact("artifact_cleanup", artifact);
             let _ = fs::remove_file(&temp_path);
             timings.push(cleanup_timer.finish());
-            return Err(error);
+            return Err(transfer_failure(artifact, transfer_timing, error));
         }
 
         let body = json!({
@@ -2405,27 +2668,50 @@ mod desktop {
         let cleanup_timer = SyncPhaseTimer::start_artifact("artifact_cleanup", artifact);
         let _ = fs::remove_file(&temp_path);
         timings.push(cleanup_timer.finish());
-        stage_result.map_err(|error| format!("Could not stage received sync artifact: {error}"))?;
+        if let Err(error) = stage_result {
+            return Err(transfer_failure(
+                artifact,
+                transfer_timing,
+                format!("Could not stage received sync artifact: {error}"),
+            ));
+        }
 
-        Ok(SyncTransportTransferResult {
-            artifact_id: artifact.artifact_id.clone(),
-            content_sha256: artifact.content_sha256.clone(),
-            size_bytes: artifact.size_bytes,
-            status: "received".to_string(),
-            message: None,
-        })
+        Ok(transfer_result(artifact, "received", None, transfer_timing))
     }
 
-    fn failed_transfer_result(
+    #[derive(Clone, Debug)]
+    struct TransferFailure {
+        message: String,
+        result: SyncTransportTransferResult,
+    }
+
+    fn transfer_result(
         artifact: &RemoteArtifact,
-        message: &str,
+        status: &str,
+        message: Option<String>,
+        timing: TransferTiming,
     ) -> SyncTransportTransferResult {
         SyncTransportTransferResult {
             artifact_id: artifact.artifact_id.clone(),
             content_sha256: artifact.content_sha256.clone(),
             size_bytes: artifact.size_bytes,
-            status: "failed".to_string(),
-            message: Some(message.to_string()),
+            started_at: timing.started_at,
+            completed_at: timing.completed_at,
+            duration_ms: timing.duration_ms,
+            throughput_bytes_per_second: timing.throughput_bytes_per_second,
+            status: status.to_string(),
+            message,
+        }
+    }
+
+    fn transfer_failure(
+        artifact: &RemoteArtifact,
+        timing: TransferTiming,
+        message: String,
+    ) -> TransferFailure {
+        TransferFailure {
+            result: transfer_result(artifact, "failed", Some(message.clone()), timing),
+            message,
         }
     }
 
@@ -2443,6 +2729,7 @@ mod desktop {
         client: &BackendClient,
         connection: &mut SecurePeerConnection,
         offered_manifests: &[Value],
+        metrics: &mut SyncRunMetrics,
     ) -> Result<u64, String> {
         let offered_artifacts = offered_artifacts_by_id(offered_manifests);
         let mut served = 0_u64;
@@ -2466,7 +2753,7 @@ mod desktop {
                                     "Sync peer request for artifact {artifact_id} does not match the offered manifest."
                                 ));
                             }
-                            send_artifact_response(client, connection, artifact)
+                            send_artifact_response(client, connection, artifact, metrics)
                         });
                     if let Err(error) = result {
                         let _ = connection.send_message(&ProtocolMessage::Error(ProtocolError {
@@ -2494,6 +2781,7 @@ mod desktop {
         client: &BackendClient,
         connection: &mut SecurePeerConnection,
         artifact: &RemoteArtifact,
+        metrics: &mut SyncRunMetrics,
     ) -> Result<(), String> {
         let path = format!(
             "/api/v1/artifacts/{}/stream",
@@ -2523,9 +2811,8 @@ mod desktop {
             }
             actual_size = actual_size.saturating_add(read as u64);
             hasher.update(&buffer[..read]);
-            connection.send_message(&ProtocolMessage::ArtifactChunk {
-                data: STANDARD.encode(&buffer[..read]),
-            })?;
+            connection.send_artifact_chunk(&buffer[..read])?;
+            metrics.record_served_artifact_bytes(read as u64);
         }
 
         let actual_sha256 = hex_digest(hasher.finalize().as_slice());
@@ -2977,6 +3264,25 @@ mod desktop {
     mod tests {
         use super::*;
 
+        fn test_transfer_result(
+            artifact_id: &str,
+            content_sha256: &str,
+            size_bytes: u64,
+            status: &str,
+        ) -> SyncTransportTransferResult {
+            SyncTransportTransferResult {
+                artifact_id: artifact_id.to_string(),
+                content_sha256: content_sha256.to_string(),
+                size_bytes,
+                started_at: "2026-01-01T00:00:00Z".to_string(),
+                completed_at: "2026-01-01T00:00:01Z".to_string(),
+                duration_ms: 1_000,
+                throughput_bytes_per_second: size_bytes as f64,
+                status: status.to_string(),
+                message: None,
+            }
+        }
+
         #[test]
         fn endpoint_hint_rejects_unexpected_device_id() {
             let hint = format!("{ENDPOINT_SCHEME}127.0.0.1:3000?device_id=dev_one&v=1");
@@ -3019,6 +3325,21 @@ mod desktop {
                 challenge.get("challenge_nonce").and_then(Value::as_str),
                 Some("remote.noise_hash")
             );
+        }
+
+        #[test]
+        fn artifact_chunks_encode_as_binary_frames_without_json_base64_payloads() {
+            let frame = encode_artifact_chunk_frame(b"binary\0payload");
+
+            assert_eq!(frame.first().copied(), Some(ENCRYPTED_FRAME_ARTIFACT_CHUNK));
+            assert_eq!(&frame[1..], b"binary\0payload");
+            assert!(serde_json::from_slice::<Value>(&frame).is_err());
+            match decode_encrypted_frame_plaintext(&frame).expect("decode artifact frame") {
+                EncryptedFrame::ArtifactChunk(chunk) => {
+                    assert_eq!(chunk, b"binary\0payload");
+                }
+                EncryptedFrame::MessageChunk(_) => panic!("expected binary artifact frame"),
+            }
         }
 
         #[test]
@@ -3384,6 +3705,67 @@ mod desktop {
         }
 
         #[test]
+        fn sync_result_serializes_phase_timings_and_transport_metrics() {
+            let result = SyncTransportSyncResult {
+                run_id: "sync_test".to_string(),
+                peer_device_id: "dev_peer".to_string(),
+                remote_device_id: "dev_remote".to_string(),
+                status: "completed".to_string(),
+                message: "done".to_string(),
+                started_at: "2026-01-01T00:00:00Z".to_string(),
+                completed_at: "2026-01-01T00:00:02Z".to_string(),
+                duration_ms: 2_000,
+                project_results: Vec::new(),
+                imported_projects: Vec::new(),
+                imported_project_count: 0,
+                skipped_project_count: 0,
+                failed_project_count: 0,
+                received_artifacts: Vec::new(),
+                transfer_counts: SyncTransportTransferCounts::default(),
+                served_artifact_requests: 1,
+                total_received_bytes: 30,
+                total_served_bytes: 70,
+                time_to_first_artifact_ms: Some(250),
+                throughput_bytes_per_second: 50.0,
+                remote_manifest_count: 0,
+                local_manifest_count: 0,
+                manifest_errors: Vec::new(),
+                phase_timings: vec![SyncTransportTimingEvidence {
+                    phase: "artifact_transfer".to_string(),
+                    project_id: Some("proj_one".to_string()),
+                    artifact_id: Some("art_one".to_string()),
+                    started_at: "2026-01-01T00:00:00Z".to_string(),
+                    completed_at: "2026-01-01T00:00:01Z".to_string(),
+                    duration_ms: 1_000,
+                }],
+            };
+
+            let value = serde_json::to_value(result).expect("serialize sync result");
+
+            assert!(value.get("phaseTimings").is_some());
+            assert!(value.get("timings").is_none());
+            assert_eq!(value.get("totalReceivedBytes"), Some(&json!(30)));
+            assert_eq!(value.get("totalServedBytes"), Some(&json!(70)));
+            assert_eq!(value.get("timeToFirstArtifactMs"), Some(&json!(250)));
+            assert_eq!(value.get("throughputBytesPerSecond"), Some(&json!(50.0)));
+        }
+
+        #[test]
+        fn transfer_result_serializes_timing_and_throughput() {
+            let result = test_transfer_result("art_one", "hash_a", 10, "received");
+
+            let value = serde_json::to_value(result).expect("serialize transfer result");
+
+            assert_eq!(value.get("startedAt"), Some(&json!("2026-01-01T00:00:00Z")));
+            assert_eq!(
+                value.get("completedAt"),
+                Some(&json!("2026-01-01T00:00:01Z"))
+            );
+            assert_eq!(value.get("durationMs"), Some(&json!(1_000)));
+            assert_eq!(value.get("throughputBytesPerSecond"), Some(&json!(10.0)));
+        }
+
+        #[test]
         fn sync_manifest_errors_include_local_and_peer_export_failures() {
             let local_errors = vec![SyncTransportManifestError {
                 project_id: "proj_local".to_string(),
@@ -3421,33 +3803,12 @@ mod desktop {
         #[test]
         fn available_content_sha256_deduplicates_received_and_already_staged_artifacts() {
             let received_artifacts = vec![
+                test_transfer_result("art_one", "hash_b", 10, "received"),
+                test_transfer_result("art_two", "hash_a", 20, "already_staged"),
+                test_transfer_result("art_three", "hash_b", 10, "already_staged"),
                 SyncTransportTransferResult {
-                    artifact_id: "art_one".to_string(),
-                    content_sha256: "hash_b".to_string(),
-                    size_bytes: 10,
-                    status: "received".to_string(),
-                    message: None,
-                },
-                SyncTransportTransferResult {
-                    artifact_id: "art_two".to_string(),
-                    content_sha256: "hash_a".to_string(),
-                    size_bytes: 20,
-                    status: "already_staged".to_string(),
-                    message: None,
-                },
-                SyncTransportTransferResult {
-                    artifact_id: "art_three".to_string(),
-                    content_sha256: "hash_b".to_string(),
-                    size_bytes: 10,
-                    status: "already_staged".to_string(),
-                    message: None,
-                },
-                SyncTransportTransferResult {
-                    artifact_id: "art_failed".to_string(),
-                    content_sha256: "hash_c".to_string(),
-                    size_bytes: 30,
-                    status: "failed".to_string(),
                     message: Some("transfer failed".to_string()),
+                    ..test_transfer_result("art_failed", "hash_c", 30, "failed")
                 },
             ];
 
@@ -3460,26 +3821,11 @@ mod desktop {
         #[test]
         fn transfer_counts_summarizes_received_reused_and_failed_transfers() {
             let counts = transfer_counts(&[
+                test_transfer_result("art_one", "hash_a", 10, "received"),
+                test_transfer_result("art_two", "hash_b", 20, "already_staged"),
                 SyncTransportTransferResult {
-                    artifact_id: "art_one".to_string(),
-                    content_sha256: "hash_a".to_string(),
-                    size_bytes: 10,
-                    status: "received".to_string(),
-                    message: None,
-                },
-                SyncTransportTransferResult {
-                    artifact_id: "art_two".to_string(),
-                    content_sha256: "hash_b".to_string(),
-                    size_bytes: 20,
-                    status: "already_staged".to_string(),
-                    message: None,
-                },
-                SyncTransportTransferResult {
-                    artifact_id: "art_three".to_string(),
-                    content_sha256: "hash_c".to_string(),
-                    size_bytes: 30,
-                    status: "failed".to_string(),
                     message: Some("transfer failed".to_string()),
+                    ..test_transfer_result("art_three", "hash_c", 30, "failed")
                 },
             ]);
 

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -257,6 +257,57 @@ describe("Desktop app activity", () => {
     ).toBeInTheDocument();
   });
 
+  it("hides stale listener sync details after sync now fails", async () => {
+    const user = userEvent.setup();
+    setSyncTrustedPeers([
+      {
+        device_id: "device_peer_1",
+        sync_group_id: "sync_group_local",
+        display_name: "Laptop Rig",
+        public_key: "pub_peer_1",
+        endpoint_hints: ["tcp://192.168.1.57:48625"],
+        trusted_at: "2026-04-18T13:16:00.000Z",
+      },
+    ]);
+    setSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: ["tcp://192.168.1.57:48625"],
+      last_sync: {
+        peer_device_id: "device_peer_1",
+        remote_device_id: "device_peer_1",
+        status: "completed",
+        message: "Listener import completed before failed sync now.",
+        project_results: [
+          {
+            project_id: "proj_listener_previous",
+            status: "imported",
+            message: "Previous listener result.",
+          },
+        ],
+        manifest_errors: [],
+        received_artifacts: [],
+      },
+    });
+    mockSyncTrustedPeerNow.mockRejectedValueOnce(new Error("Peer unavailable."));
+
+    await openSyncTab(user);
+
+    expect(await screen.findByText("Listener import completed before failed sync now.")).toBeInTheDocument();
+    expect(screen.getByText("proj_listener_previous")).toBeInTheDocument();
+
+    const peers = await screen.findByRole("list", { name: "Trusted sync peers" });
+    const peerRow = within(peers).getByText("Laptop Rig").closest("li");
+    expect(peerRow).not.toBeNull();
+    await user.click(within(peerRow as HTMLElement).getByRole("button", { name: "Sync Now" }));
+
+    await waitFor(() => expect(mockSyncTrustedPeerNow).toHaveBeenCalledWith("device_peer_1"));
+    expect(await screen.findAllByText("Sync now failed.")).not.toHaveLength(0);
+    expect(screen.queryByText("Listener import completed before failed sync now.")).not.toBeInTheDocument();
+    expect(screen.queryByText("proj_listener_previous")).not.toBeInTheDocument();
+    expect(screen.queryByRole("list", { name: "Last sync project results" })).not.toBeInTheDocument();
+  });
+
   it("normalizes sync run identity, timing, counters, and final project rows", () => {
     const normalized = normalizeSyncTransportStatus({
       running: true,
@@ -269,7 +320,7 @@ describe("Desktop app activity", () => {
         remoteDeviceId: "device_peer_1",
         status: "completed_with_errors",
         message: "Retry completed after staged bytes were reused.",
-        startedAt: "2026-04-18T13:16:00.000Z",
+        startedAt: "2026-04-18 13:16:00",
         completedAt: "2026-04-18T13:16:01.250Z",
         durationMs: 1250,
         timing: {
@@ -277,6 +328,19 @@ describe("Desktop app activity", () => {
           transferMs: 25,
           applyMs: 30,
         },
+        phaseTimings: [
+          {
+            phase: "artifact_transfer",
+            artifactId: "art_retry_source",
+            startedAt: "2026-04-18T13:16:00.150Z",
+            completedAt: "2026-04-18T13:16:00.650Z",
+            durationMs: 500,
+          },
+        ],
+        totalReceivedBytes: 3_000_000,
+        totalServedBytes: 1_000_000,
+        timeToFirstArtifactMs: 650,
+        throughputBytesPerSecond: 3_200_000,
         importedProjectCount: 1,
         skippedProjectCount: 1,
         failedProjectCount: 0,
@@ -318,7 +382,18 @@ describe("Desktop app activity", () => {
             message: "Peer manifest export failed: stale tombstone warning.",
           },
         ],
-        receivedArtifacts: [],
+        receivedArtifacts: [
+          {
+            artifactId: "art_retry_source",
+            contentSha256: "sha256-retry-source",
+            sizeBytes: 1_000_000,
+            status: "received",
+            startedAt: "2026-04-18T13:16:00.150Z",
+            completedAt: "2026-04-18T13:16:00.650Z",
+            durationMs: 500,
+            throughputBytesPerSecond: 2_000_000,
+          },
+        ],
       },
     });
 
@@ -326,7 +401,12 @@ describe("Desktop app activity", () => {
       run_id: "sync_run_retry_2",
       session_id: "sync_session_retry_2",
       status: "completed",
+      started_at: "2026-04-18T13:16:00.000Z",
       duration_ms: 1250,
+      total_received_bytes: 3_000_000,
+      total_served_bytes: 1_000_000,
+      time_to_first_artifact_ms: 650,
+      throughput_bytes_per_second: 3_200_000,
       imported_project_count: 1,
       skipped_project_count: 1,
       failed_project_count: 0,
@@ -336,6 +416,22 @@ describe("Desktop app activity", () => {
       transferMs: 25,
       applyMs: 30,
     });
+    expect(normalized.last_sync?.phase_timings).toEqual([
+      expect.objectContaining({
+        phase: "artifact_transfer",
+        artifact_id: "art_retry_source",
+        duration_ms: 500,
+      }),
+    ]);
+    expect(normalized.last_sync?.received_artifacts).toEqual([
+      expect.objectContaining({
+        artifact_id: "art_retry_source",
+        started_at: "2026-04-18T13:16:00.150Z",
+        completed_at: "2026-04-18T13:16:00.650Z",
+        duration_ms: 500,
+        throughput_bytes_per_second: 2_000_000,
+      }),
+    ]);
     expect(normalized.last_sync?.project_results).toHaveLength(2);
     expect(normalized.last_sync?.project_results[0]).toMatchObject({
       project_id: "proj_retry",
@@ -350,6 +446,60 @@ describe("Desktop app activity", () => {
       status: "deleted",
       deleted_count: 1,
     });
+  });
+
+  it("infers sync TTFA only when native omits the metric", () => {
+    const explicitNull = normalizeSyncTransportStatus({
+      active: true,
+      status: "listening",
+      last_sync: {
+        started_at: "2026-04-18T13:16:00.000Z",
+        time_to_first_artifact_ms: null,
+        received_artifacts: [
+          {
+            artifact_id: "art_received_source",
+            status: "received",
+            completed_at: "2026-04-18T13:16:00.500Z",
+          },
+        ],
+      },
+    });
+
+    expect(explicitNull.last_sync?.time_to_first_artifact_ms).toBeNull();
+
+    const legacyPayload = normalizeSyncTransportStatus({
+      active: true,
+      status: "listening",
+      last_sync: {
+        started_at: "2026-04-18T13:16:00.000Z",
+        received_artifacts: [
+          {
+            artifact_id: "art_already_staged",
+            status: "already_staged",
+            completed_at: "2026-04-18T13:16:00.200Z",
+          },
+          {
+            artifact_id: "art_received_source",
+            status: "received",
+            completed_at: "2026-04-18T13:16:00.800Z",
+          },
+        ],
+        phase_timings: [
+          {
+            phase: "artifact_transfer",
+            artifact_id: "art_already_staged",
+            completed_at: "2026-04-18T13:16:00.200Z",
+          },
+          {
+            phase: "artifact_transfer",
+            artifact_id: "art_received_source",
+            completed_at: "2026-04-18T13:16:00.800Z",
+          },
+        ],
+      },
+    });
+
+    expect(legacyPayload.last_sync?.time_to_first_artifact_ms).toBe(800);
   });
 
   it("keeps newer successful sync rows when stale failures arrive later in the payload", () => {
@@ -443,6 +593,10 @@ describe("Desktop app activity", () => {
         started_at: "2026-04-18T13:16:00.000Z",
         completed_at: "2026-04-18T13:16:01.400Z",
         duration_ms: 1400,
+        time_to_first_artifact_ms: 450,
+        total_received_bytes: 3_000_000,
+        total_served_bytes: 1_000_000,
+        throughput_bytes_per_second: 2_500_000,
         imported_project_count: 1,
         skipped_project_count: 1,
         failed_project_count: 0,
@@ -481,7 +635,16 @@ describe("Desktop app activity", () => {
             message: "Peer manifest export failed: stale tombstone warning.",
           },
         ],
-        received_artifacts: [],
+        received_artifacts: [
+          {
+            artifact_id: "art_retry_source",
+            content_sha256: "sha256-retry-source",
+            size_bytes: 1_000_000,
+            status: "received",
+            duration_ms: 500,
+            throughput_bytes_per_second: 2_000_000,
+          },
+        ],
       },
     });
 
@@ -491,6 +654,9 @@ describe("Desktop app activity", () => {
     expect(screen.getByText(/Run sync_run_retry_2/)).toBeInTheDocument();
     expect(screen.getByText(/Duration 1\.4 s/)).toBeInTheDocument();
     expect(screen.getByText(/1 imported, 1 skipped, 0 failed/)).toBeInTheDocument();
+    expect(screen.getByText(/TTFA 450 ms/)).toBeInTheDocument();
+    expect(screen.getByText(/4\.0 MB total/)).toBeInTheDocument();
+    expect(screen.getByText(/2\.5 MB\/s/)).toBeInTheDocument();
 
     const projectResults = await screen.findByRole("list", { name: "Last sync project results" });
     const resultRows = within(projectResults).getAllByRole("listitem");
@@ -503,6 +669,12 @@ describe("Desktop app activity", () => {
     expect(within(resultRows[1]).getByText("Delete tombstone caught up.")).toBeInTheDocument();
     expect(screen.queryByText("Old ffprobe failure.")).not.toBeInTheDocument();
     expect(screen.queryByText(/stale tombstone warning/)).not.toBeInTheDocument();
+
+    const artifactTransfers = await screen.findByRole("list", { name: "Last sync artifact transfers" });
+    const transferRows = within(artifactTransfers).getAllByRole("listitem");
+    expect(transferRows).toHaveLength(1);
+    expect(within(transferRows[0]).getByText("art_retry_source")).toBeInTheDocument();
+    expect(within(transferRows[0]).getByText("500 ms / 2.0 MB/s")).toBeInTheDocument();
   });
 
   it("shows newer listener sync results after a prior sync now result", async () => {

--- a/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
+++ b/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
@@ -6,6 +6,7 @@ import {
   type SyncPairingPayloadSchema,
   type SyncTransportProjectResult,
   type SyncTransportRunStatus,
+  type SyncTransportTransferResult,
   type SyncTrustedPeerSchema,
 } from "../../lib/api";
 import { formatLocalDateTime, normalizeApiDateTime } from "../../lib/datetime";
@@ -151,6 +152,10 @@ function syncResultKey(status: SyncTransportRunStatus | null | undefined) {
     completed: status.completed_at,
     durationSeconds: status.duration_seconds,
     durationMs: status.duration_ms,
+    timeToFirstArtifactMs: status.time_to_first_artifact_ms,
+    totalReceivedBytes: status.total_received_bytes,
+    totalServedBytes: status.total_served_bytes,
+    throughputBytesPerSecond: status.throughput_bytes_per_second,
     status: status.status,
     message: status.message,
     projects: projectResults.map((result) => [
@@ -161,7 +166,15 @@ function syncResultKey(status: SyncTransportRunStatus | null | undefined) {
       result.is_final ?? null,
       result.counters ?? null,
     ]),
-    receivedArtifacts: status.received_artifacts.length,
+    receivedArtifacts: status.received_artifacts.map((artifact) => [
+      artifact.artifact_id,
+      artifact.status,
+      artifact.size_bytes ?? null,
+      artifact.started_at ?? null,
+      artifact.completed_at ?? null,
+      artifact.duration_ms ?? null,
+      artifact.throughput_bytes_per_second ?? null,
+    ]),
     remoteManifests: status.remote_manifest_count,
     localManifests: status.local_manifest_count,
     importedProjects: status.imported_project_count,
@@ -185,6 +198,36 @@ function formatSyncDuration(seconds: number | null | undefined) {
   const minutes = Math.floor(seconds / 60);
   const remainingSeconds = Math.round(seconds % 60).toString().padStart(2, "0");
   return `${minutes}:${remainingSeconds}`;
+}
+
+function formatDurationMs(milliseconds: number | null | undefined) {
+  if (typeof milliseconds !== "number" || !Number.isFinite(milliseconds) || milliseconds < 0) {
+    return null;
+  }
+  if (milliseconds < 1000) {
+    return `${Math.round(milliseconds)} ms`;
+  }
+  return formatSyncDuration(milliseconds / 1000);
+}
+
+function formatByteCount(bytes: number | null | undefined) {
+  if (typeof bytes !== "number" || !Number.isFinite(bytes) || bytes < 0) {
+    return null;
+  }
+  if (bytes < 1000) {
+    return `${Math.round(bytes)} B`;
+  }
+  if (bytes < 1_000_000) {
+    const kilobytes = bytes / 1000;
+    return `${kilobytes < 10 ? kilobytes.toFixed(1) : Math.round(kilobytes)} KB`;
+  }
+  const megabytes = bytes / 1_000_000;
+  return `${megabytes < 10 ? megabytes.toFixed(1) : Math.round(megabytes)} MB`;
+}
+
+function formatThroughput(bytesPerSecond: number | null | undefined) {
+  const formatted = formatByteCount(bytesPerSecond);
+  return formatted ? `${formatted}/s` : null;
 }
 
 function syncRunDurationSeconds(status: SyncTransportRunStatus) {
@@ -224,6 +267,15 @@ function syncRunProjectCounterText(status: SyncTransportRunStatus) {
   return counters.length ? counters.join(", ") : null;
 }
 
+function syncRunTotalTransferBytes(status: SyncTransportRunStatus) {
+  const receivedBytes = typeof status.total_received_bytes === "number" ? status.total_received_bytes : null;
+  const servedBytes = typeof status.total_served_bytes === "number" ? status.total_served_bytes : null;
+  if (receivedBytes === null && servedBytes === null) {
+    return null;
+  }
+  return (receivedBytes ?? 0) + (servedBytes ?? 0);
+}
+
 function syncRunSummaryText(status: SyncTransportRunStatus | null | undefined) {
   if (!status) {
     return null;
@@ -245,6 +297,18 @@ function syncRunSummaryText(status: SyncTransportRunStatus | null | undefined) {
   const counters = syncRunProjectCounterText(status);
   if (counters) {
     parts.push(counters);
+  }
+  const timeToFirstArtifact = formatDurationMs(status.time_to_first_artifact_ms);
+  if (timeToFirstArtifact) {
+    parts.push(`TTFA ${timeToFirstArtifact}`);
+  }
+  const totalTransferBytes = formatByteCount(syncRunTotalTransferBytes(status));
+  if (totalTransferBytes) {
+    parts.push(`${totalTransferBytes} total`);
+  }
+  const throughput = formatThroughput(status.throughput_bytes_per_second);
+  if (throughput) {
+    parts.push(throughput);
   }
   return parts.length ? parts.join(" | ") : null;
 }
@@ -294,6 +358,19 @@ function syncProjectIdLabel(projectId: string) {
   return `${normalized.slice(0, 18)}...${normalized.slice(-8)}`;
 }
 
+function syncTransferMetricText(artifact: SyncTransportTransferResult) {
+  const parts: string[] = [];
+  const duration = formatDurationMs(artifact.duration_ms);
+  if (duration) {
+    parts.push(duration);
+  }
+  const throughput = formatThroughput(artifact.throughput_bytes_per_second);
+  if (throughput) {
+    parts.push(throughput);
+  }
+  return parts.length ? parts.join(" / ") : null;
+}
+
 function syncProjectResultList(status: SyncTransportRunStatus | null | undefined) {
   const results = status ? mergeSyncProjectResults(status.project_results, status.manifest_errors) : [];
   if (!results.length) {
@@ -311,6 +388,27 @@ function syncProjectResultList(status: SyncTransportRunStatus | null | undefined
             {syncProjectIdLabel(result.project_id)}
           </span>
           <span className="activity-sync-project-result__message">{syncProjectResultText(result)}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function syncTransferResultList(status: SyncTransportRunStatus | null | undefined) {
+  const results = status?.received_artifacts
+    .map((artifact) => [artifact, syncTransferMetricText(artifact)] as const)
+    .filter((entry): entry is readonly [SyncTransportTransferResult, string] => entry[1] !== null) ?? [];
+  if (!results.length) {
+    return null;
+  }
+  return (
+    <ul className="activity-sync-transfer-results" aria-label="Last sync artifact transfers">
+      {results.map(([artifact, metrics], index) => (
+        <li className="activity-sync-transfer-result" key={`${artifact.artifact_id}-${index}`}>
+          <span className="activity-sync-transfer-result__artifact" title={artifact.artifact_id}>
+            {syncProjectIdLabel(artifact.artifact_id)}
+          </span>
+          <span className="activity-sync-transfer-result__metrics">{metrics}</span>
         </li>
       ))}
     </ul>
@@ -368,7 +466,7 @@ export function ActivitySyncPanel() {
   const lastSyncStatus = listenerSyncResult
     ? syncStatusText(listenerSyncResult, peersById)
     : listenerQuery.data?.last_status ?? syncStatusText(listenerSyncResult, peersById);
-  const visibleSyncResult = showListenerSyncResult ? listenerSyncResult : lastSyncResult ?? listenerSyncResult;
+  const visibleSyncResult = showListenerSyncResult ? listenerSyncResult : lastSyncResult;
   const displayedLastSyncMessage = !showListenerSyncResult
     ? lastSyncMessage ?? lastSyncStatus
     : lastSyncStatus;
@@ -485,7 +583,7 @@ export function ActivitySyncPanel() {
     onError: () => {
       setLastSyncMessage("Sync now failed.");
       setLastSyncResult(null);
-      setHiddenListenerSyncKey(null);
+      setHiddenListenerSyncKey(listenerSyncKey);
     },
   });
 
@@ -570,6 +668,7 @@ export function ActivitySyncPanel() {
                 <span>{displayedLastSyncMessage}</span>
                 {visibleSyncSummary ? <small>{visibleSyncSummary}</small> : null}
                 {syncProjectResultList(visibleSyncResult)}
+                {syncTransferResultList(visibleSyncResult)}
               </dd>
             </div>
             {lastListenerUpdatedAt ? (

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -1,6 +1,7 @@
 import createClient from "openapi-fetch";
 import { convertFileSrc, invoke } from "@tauri-apps/api/core";
 import type { components, MobileCapabilities, paths } from "@tuneforge/shared-types";
+import { normalizeApiDateTime } from "./datetime";
 
 const DEFAULT_API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://127.0.0.1:8765";
 let apiBaseUrl = DEFAULT_API_BASE_URL;
@@ -74,6 +75,15 @@ export type ProjectSyncSummary = {
   lockReason: string | null;
 };
 export type SyncTransportMetricMap = Record<string, number>;
+export type SyncTransportPhaseTiming = {
+  phase?: string | null;
+  project_id?: string | null;
+  artifact_id?: string | null;
+  started_at?: string | null;
+  completed_at?: string | null;
+  duration_ms?: number | null;
+  throughput_bytes_per_second?: number | null;
+};
 export type SyncTransportTiming = Record<string, unknown> | Record<string, unknown>[];
 export type SyncTransportRunStatus = {
   run_id?: string | null;
@@ -88,7 +98,12 @@ export type SyncTransportRunStatus = {
   duration_seconds?: number | null;
   duration_ms?: number | null;
   timing?: SyncTransportTiming | null;
+  phase_timings?: SyncTransportPhaseTiming[];
   transfer_counts?: SyncTransportMetricMap;
+  total_received_bytes?: number | null;
+  total_served_bytes?: number | null;
+  time_to_first_artifact_ms?: number | null;
+  throughput_bytes_per_second?: number | null;
   error?: string | null;
   project_results: SyncTransportProjectResult[];
   manifest_errors: SyncTransportManifestError[];
@@ -137,6 +152,10 @@ export type SyncTransportTransferResult = {
   size_bytes?: number | null;
   status: string;
   message?: string | null;
+  started_at?: string | null;
+  completed_at?: string | null;
+  duration_ms?: number | null;
+  throughput_bytes_per_second?: number | null;
 };
 export type SyncTransportStatus = {
   active: boolean;
@@ -231,6 +250,29 @@ function numberField(record: Record<string, unknown> | null, keys: string[]) {
   return null;
 }
 
+function nullableNumberField(record: Record<string, unknown> | null, keys: string[]) {
+  let present = false;
+  if (!record) {
+    return { present, value: null };
+  }
+  for (const key of keys) {
+    if (!Object.prototype.hasOwnProperty.call(record, key)) {
+      continue;
+    }
+    present = true;
+    const value = record[key];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return { present, value };
+    }
+  }
+  return { present, value: null };
+}
+
+function dateTimeField(record: Record<string, unknown> | null, keys: string[]) {
+  const value = firstStringField([record], keys);
+  return value ? normalizeApiDateTime(value) : null;
+}
+
 function recordField(record: Record<string, unknown> | null, keys: string[]) {
   if (!record) {
     return null;
@@ -264,6 +306,30 @@ function recordOrRecordArrayField(record: Record<string, unknown> | null, keys: 
   return null;
 }
 
+function recordArrayOrObjectValuesField(record: Record<string, unknown> | null, keys: string[]) {
+  if (!record) {
+    return [];
+  }
+  for (const key of keys) {
+    const value = record[key];
+    if (Array.isArray(value)) {
+      return value
+        .map((item) => asRecord(item))
+        .filter((item): item is Record<string, unknown> => item !== null);
+    }
+    const valueRecord = asRecord(value);
+    if (valueRecord) {
+      const records = Object.values(valueRecord)
+        .map((item) => asRecord(item))
+        .filter((item): item is Record<string, unknown> => item !== null);
+      if (records.length) {
+        return records;
+      }
+    }
+  }
+  return [];
+}
+
 function recordArrayField(record: Record<string, unknown> | null, keys: string[]) {
   if (!record) {
     return [];
@@ -295,6 +361,7 @@ function numericMetricsFromRecord(record: Record<string, unknown> | null) {
     const metricKey = normalizeMetricKey(key);
     const looksLikeMetric =
       /(?:_count|_bytes|_ms|_seconds)$/.test(metricKey) ||
+      /_per_second$/.test(metricKey) ||
       metricKey.startsWith("count_");
     if (looksLikeMetric && typeof value === "number" && Number.isFinite(value)) {
       metrics[metricKey] = value;
@@ -321,6 +388,80 @@ function timingField(record: Record<string, unknown>) {
     "phase_timings",
     "phaseTimings",
   ]);
+}
+
+function durationMsFromDateTimes(startedAt: string | null | undefined, completedAt: string | null | undefined) {
+  if (!startedAt || !completedAt) {
+    return null;
+  }
+  const startedTimestamp = Date.parse(normalizeApiDateTime(startedAt));
+  const completedTimestamp = Date.parse(normalizeApiDateTime(completedAt));
+  if (!Number.isFinite(startedTimestamp) || !Number.isFinite(completedTimestamp)) {
+    return null;
+  }
+  const durationMs = completedTimestamp - startedTimestamp;
+  return durationMs >= 0 ? durationMs : null;
+}
+
+function throughputFromBytesAndDuration(bytes: number | null | undefined, durationMs: number | null | undefined) {
+  if (
+    typeof bytes !== "number" ||
+    !Number.isFinite(bytes) ||
+    bytes < 0 ||
+    typeof durationMs !== "number" ||
+    !Number.isFinite(durationMs) ||
+    durationMs <= 0
+  ) {
+    return null;
+  }
+  return (bytes * 1000) / durationMs;
+}
+
+function normalizeSyncPhaseTiming(value: unknown): SyncTransportPhaseTiming | null {
+  const record = asRecord(value);
+  if (!record) {
+    return null;
+  }
+  const startedAt = dateTimeField(record, ["started_at", "startedAt", "start_time", "startTime"]);
+  const completedAt = dateTimeField(record, [
+    "completed_at",
+    "completedAt",
+    "finished_at",
+    "finishedAt",
+    "end_time",
+    "endTime",
+  ]);
+  const durationMs =
+    numberField(record, ["duration_ms", "durationMs", "elapsed_ms", "elapsedMs"]) ??
+    durationMsFromDateTimes(startedAt, completedAt);
+  const timing: SyncTransportPhaseTiming = {
+    phase: firstStringField([record], ["phase", "stage", "name"]),
+    project_id: firstStringField([record], ["project_id", "projectId"]),
+    artifact_id: firstStringField([record], ["artifact_id", "artifactId"]),
+    started_at: startedAt,
+    completed_at: completedAt,
+    duration_ms: durationMs,
+    throughput_bytes_per_second: numberField(record, [
+      "throughput_bytes_per_second",
+      "throughputBytesPerSecond",
+      "bytes_per_second",
+      "bytesPerSecond",
+    ]),
+  };
+  const hasTimingValue = Object.values(timing).some((item) => item !== null && item !== undefined);
+  return hasTimingValue ? timing : null;
+}
+
+function phaseTimingField(record: Record<string, unknown>) {
+  return recordArrayOrObjectValuesField(record, [
+    "phase_timings",
+    "phaseTimings",
+    "timings",
+    "timing_metrics",
+    "timingMetrics",
+  ])
+    .map((item) => normalizeSyncPhaseTiming(item))
+    .filter((item): item is SyncTransportPhaseTiming => item !== null);
 }
 
 function normalizeProjectSyncState(value: string | null) {
@@ -461,7 +602,7 @@ function syncResultTime(value: string | null | undefined) {
   if (!value) {
     return null;
   }
-  const timestamp = Date.parse(value);
+  const timestamp = Date.parse(normalizeApiDateTime(value));
   return Number.isFinite(timestamp) ? timestamp : null;
 }
 
@@ -555,8 +696,8 @@ function normalizeSyncProjectResult(
     action: firstStringField([record], ["action", "operation"]),
     message: firstStringField([record], ["message", "error", "reason"]) ?? fallbackMessage,
     is_final: firstBooleanField([record], ["is_final", "isFinal", "final"]),
-    started_at: firstStringField([record], ["started_at", "startedAt"]),
-    completed_at: firstStringField([record], ["completed_at", "completedAt", "finished_at", "finishedAt"]),
+    started_at: dateTimeField(record, ["started_at", "startedAt"]),
+    completed_at: dateTimeField(record, ["completed_at", "completedAt", "finished_at", "finishedAt"]),
     duration_seconds: numberField(record, ["duration_seconds", "durationSeconds", "elapsed_seconds", "elapsedSeconds"]),
     duration_ms: numberField(record, ["duration_ms", "durationMs", "elapsed_ms", "elapsedMs"]),
     timing: timingField(record),
@@ -592,6 +733,11 @@ function normalizeSyncTransferResult(value: unknown): SyncTransportTransferResul
   if (!record) {
     return null;
   }
+  const startedAt = dateTimeField(record, ["started_at", "startedAt"]);
+  const completedAt = dateTimeField(record, ["completed_at", "completedAt", "finished_at", "finishedAt"]);
+  const durationMs =
+    numberField(record, ["duration_ms", "durationMs", "elapsed_ms", "elapsedMs"]) ??
+    durationMsFromDateTimes(startedAt, completedAt);
   return {
     artifact_id: firstStringField([record], ["artifact_id", "artifactId", "id"]) ?? "unknown",
     content_sha256: firstStringField([record], ["content_sha256", "contentSha256"]),
@@ -600,7 +746,113 @@ function normalizeSyncTransferResult(value: unknown): SyncTransportTransferResul
       firstStringField([record], ["status", "state", "result"]) ?? "completed",
     ),
     message: firstStringField([record], ["message", "error", "reason"]),
+    started_at: startedAt,
+    completed_at: completedAt,
+    duration_ms: durationMs,
+    throughput_bytes_per_second: numberField(record, [
+      "throughput_bytes_per_second",
+      "throughputBytesPerSecond",
+      "bytes_per_second",
+      "bytesPerSecond",
+    ]) ?? throughputFromBytesAndDuration(numberField(record, ["size_bytes", "sizeBytes"]), durationMs),
   };
+}
+
+function normalizedPhaseName(value: string | null | undefined) {
+  return value?.trim().toLowerCase().replace(/[\s-]+/g, "_") ?? "";
+}
+
+function transferTimingForArtifact(
+  artifact: SyncTransportTransferResult,
+  phaseTimings: SyncTransportPhaseTiming[],
+) {
+  const artifactTimings = phaseTimings.filter((timing) => timing.artifact_id === artifact.artifact_id);
+  if (!artifactTimings.length) {
+    return null;
+  }
+  return artifactTimings.find((timing) => normalizedPhaseName(timing.phase).includes("transfer")) ??
+    artifactTimings.find((timing) => normalizedPhaseName(timing.phase).includes("staging_check")) ??
+    artifactTimings[0];
+}
+
+function enrichSyncTransferResult(
+  artifact: SyncTransportTransferResult,
+  phaseTimings: SyncTransportPhaseTiming[],
+) {
+  const timing = transferTimingForArtifact(artifact, phaseTimings);
+  if (!timing) {
+    return artifact;
+  }
+  const startedAt = artifact.started_at ?? timing.started_at ?? null;
+  const completedAt = artifact.completed_at ?? timing.completed_at ?? null;
+  const durationMs =
+    artifact.duration_ms ??
+    timing.duration_ms ??
+    durationMsFromDateTimes(startedAt, completedAt);
+  const timingIsTransfer = normalizedPhaseName(timing.phase).includes("transfer");
+  return {
+    ...artifact,
+    started_at: startedAt,
+    completed_at: completedAt,
+    duration_ms: durationMs,
+    throughput_bytes_per_second:
+      artifact.throughput_bytes_per_second ??
+      timing.throughput_bytes_per_second ??
+      (timingIsTransfer ? throughputFromBytesAndDuration(artifact.size_bytes, durationMs) : null),
+  };
+}
+
+function sumArtifactBytes(artifacts: SyncTransportTransferResult[]) {
+  let total = 0;
+  let hasBytes = false;
+  artifacts.forEach((artifact) => {
+    if (
+      artifact.status !== "failed" &&
+      typeof artifact.size_bytes === "number" &&
+      Number.isFinite(artifact.size_bytes) &&
+      artifact.size_bytes >= 0
+    ) {
+      total += artifact.size_bytes;
+      hasBytes = true;
+    }
+  });
+  return hasBytes ? total : null;
+}
+
+function firstArtifactCompletedOffsetMs(
+  runStartedAt: string | null,
+  artifacts: SyncTransportTransferResult[],
+  phaseTimings: SyncTransportPhaseTiming[],
+) {
+  if (!runStartedAt) {
+    return null;
+  }
+  const runStartedTimestamp = Date.parse(normalizeApiDateTime(runStartedAt));
+  if (!Number.isFinite(runStartedTimestamp)) {
+    return null;
+  }
+  const ignoredArtifactIds = new Set(
+    artifacts
+      .filter((artifact) => artifact.status === "failed" || artifact.status === "already_staged")
+      .map((artifact) => artifact.artifact_id),
+  );
+  const artifactCompletedTimestamps = [
+    ...artifacts
+      .filter((artifact) => !ignoredArtifactIds.has(artifact.artifact_id))
+      .map((artifact) => syncResultTime(artifact.completed_at)),
+    ...phaseTimings
+      .filter(
+        (timing) =>
+          timing.artifact_id &&
+          !ignoredArtifactIds.has(timing.artifact_id) &&
+          normalizedPhaseName(timing.phase).includes("transfer"),
+      )
+      .map((timing) => syncResultTime(timing.completed_at)),
+  ].filter((timestamp): timestamp is number => timestamp !== null && timestamp >= runStartedTimestamp);
+  if (!artifactCompletedTimestamps.length) {
+    return null;
+  }
+  return Math.min(...artifactCompletedTimestamps) - runStartedTimestamp;
 }
 
 export function normalizeSyncRunStatus(value: unknown): SyncTransportRunStatus | null {
@@ -610,8 +862,9 @@ export function normalizeSyncRunStatus(value: unknown): SyncTransportRunStatus |
   }
   const runId = firstStringField([record], ["run_id", "runId", "sync_run_id", "syncRunId", "id"]);
   const sessionId = firstStringField([record], ["session_id", "sessionId", "sync_session_id", "syncSessionId"]);
-  const runStartedAt = firstStringField([record], ["started_at", "startedAt"]);
-  const runCompletedAt = firstStringField([record], ["completed_at", "completedAt", "finished_at", "finishedAt"]);
+  const runStartedAt = dateTimeField(record, ["started_at", "startedAt"]);
+  const runCompletedAt = dateTimeField(record, ["completed_at", "completedAt", "finished_at", "finishedAt"]);
+  const phaseTimings = phaseTimingField(record);
   const manifestErrors = recordArrayField(record, ["manifest_errors", "manifestErrors"])
     .map((item) => normalizeSyncManifestError(item))
     .filter((item): item is SyncTransportManifestError => item !== null);
@@ -643,7 +896,8 @@ export function normalizeSyncRunStatus(value: unknown): SyncTransportRunStatus |
   const projectResults = mergeSyncProjectResults(importedProjectResults, manifestErrors);
   const receivedArtifacts = recordArrayField(record, ["received_artifacts", "receivedArtifacts", "artifacts"])
     .map((item) => normalizeSyncTransferResult(item))
-    .filter((item): item is SyncTransportTransferResult => item !== null);
+    .filter((item): item is SyncTransportTransferResult => item !== null)
+    .map((item) => enrichSyncTransferResult(item, phaseTimings));
   const localManifestCount = numberField(record, ["local_manifest_count", "localManifestCount"]);
   const remoteManifestCount = numberField(record, ["remote_manifest_count", "remoteManifestCount"]);
   const importedProjectCount = numberField(record, ["imported_project_count", "importedProjectCount"]);
@@ -652,7 +906,55 @@ export function normalizeSyncRunStatus(value: unknown): SyncTransportRunStatus |
   const skippedProjectCount = numberField(record, ["skipped_project_count", "skippedProjectCount"]);
   const failedProjectCount = numberField(record, ["failed_project_count", "failedProjectCount"]);
   const totalProjectCount = numberField(record, ["total_project_count", "totalProjectCount", "project_count", "projectCount"]);
-  const transferCounts = numericMetricsFromRecord(recordField(record, ["transfer_counts", "transferCounts"]));
+  const transferCountRecord = recordField(record, ["transfer_counts", "transferCounts"]);
+  const transferCounts = numericMetricsFromRecord(transferCountRecord);
+  const durationMs =
+    numberField(record, ["duration_ms", "durationMs", "elapsed_ms", "elapsedMs"]) ??
+    durationMsFromDateTimes(runStartedAt, runCompletedAt);
+  const durationSeconds =
+    numberField(record, ["duration_seconds", "durationSeconds", "elapsed_seconds", "elapsedSeconds"]) ??
+    (durationMs === null ? null : durationMs / 1000);
+  const totalReceivedBytes =
+    numberField(record, ["total_received_bytes", "totalReceivedBytes", "received_bytes", "receivedBytes"]) ??
+    numberField(transferCountRecord, ["total_received_bytes", "totalReceivedBytes", "received_bytes", "receivedBytes"]) ??
+    sumArtifactBytes(receivedArtifacts);
+  const totalServedBytes =
+    numberField(record, ["total_served_bytes", "totalServedBytes", "served_bytes", "servedBytes", "sent_bytes", "sentBytes"]) ??
+    numberField(transferCountRecord, [
+      "total_served_bytes",
+      "totalServedBytes",
+      "served_bytes",
+      "servedBytes",
+      "sent_bytes",
+      "sentBytes",
+    ]);
+  const totalTransferBytes =
+    totalReceivedBytes === null && totalServedBytes === null
+      ? null
+      : (totalReceivedBytes ?? 0) + (totalServedBytes ?? 0);
+  const throughputBytesPerSecond =
+    numberField(record, [
+      "throughput_bytes_per_second",
+      "throughputBytesPerSecond",
+      "bytes_per_second",
+      "bytesPerSecond",
+    ]) ??
+    numberField(transferCountRecord, [
+      "throughput_bytes_per_second",
+      "throughputBytesPerSecond",
+      "bytes_per_second",
+      "bytesPerSecond",
+    ]) ??
+    throughputFromBytesAndDuration(totalTransferBytes, durationMs);
+  const explicitTimeToFirstArtifactMs = nullableNumberField(record, [
+    "time_to_first_artifact_ms",
+    "timeToFirstArtifactMs",
+    "ttfa_ms",
+    "ttfaMs",
+  ]);
+  const timeToFirstArtifactMs = explicitTimeToFirstArtifactMs.present
+    ? explicitTimeToFirstArtifactMs.value
+    : firstArtifactCompletedOffsetMs(runStartedAt, receivedArtifacts, phaseTimings);
   const hasProjectProblems = projectResults.some((result) =>
     SYNC_PROJECT_RESULT_PROBLEM_STATES.has(result.status),
   );
@@ -688,10 +990,15 @@ export function normalizeSyncRunStatus(value: unknown): SyncTransportRunStatus |
     message: firstStringField([record], ["message", "status_message", "statusMessage"]) ?? summary,
     started_at: runStartedAt,
     completed_at: runCompletedAt,
-    duration_seconds: numberField(record, ["duration_seconds", "durationSeconds", "elapsed_seconds", "elapsedSeconds"]),
-    duration_ms: numberField(record, ["duration_ms", "durationMs", "elapsed_ms", "elapsedMs"]),
+    duration_seconds: durationSeconds,
+    duration_ms: durationMs,
     timing: timingField(record),
+    phase_timings: phaseTimings,
     transfer_counts: transferCounts,
+    total_received_bytes: totalReceivedBytes,
+    total_served_bytes: totalServedBytes,
+    time_to_first_artifact_ms: timeToFirstArtifactMs,
+    throughput_bytes_per_second: throughputBytesPerSecond,
     error: explicitError,
     project_results: projectResults,
     manifest_errors: manifestErrors,

--- a/apps/desktop/src/styles/activity.css
+++ b/apps/desktop/src/styles/activity.css
@@ -339,6 +339,36 @@
   color: var(--muted);
 }
 
+.activity-sync-transfer-results {
+  display: grid;
+  gap: 0.28rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.activity-sync-transfer-result {
+  display: flex;
+  gap: 0.45rem;
+  align-items: baseline;
+  justify-content: space-between;
+  min-width: 0;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.activity-sync-transfer-result__artifact {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.activity-sync-transfer-result__metrics {
+  flex: 0 0 auto;
+  color: var(--text);
+  font-weight: 760;
+  white-space: nowrap;
+}
+
 .activity-sync-field {
   display: grid;
   gap: 0.45rem;

--- a/docs/MULTI_DEVICE_LIBRARY_SYNC_SPIKE.md
+++ b/docs/MULTI_DEVICE_LIBRARY_SYNC_SPIKE.md
@@ -387,6 +387,58 @@ Costs:
 
 These mechanisms should be evaluated as discovery and pairing aids, not as the core product protocol.
 
+## Transport Bake-Off For #118
+
+#118 should compare candidate transport and blob layers without moving library truth out of TuneForge's semantic manifests. The transport can discover peers, authenticate sessions, move bytes, expose progress, resume work, and report evidence. It must not become the owner of projects, revisions, conflicts, tombstones, or app state. `project_manifest`, `artifact_manifest`, `entity_revision`, `delete_tombstone`, and SHA-256 verification remain the source of truth across all options.
+
+No exact measured bake-off numbers are present in this document yet. The current desktop custom baseline now records enough evidence to run manual before/after comparisons, but the table below should stay empty or `TBD` until someone captures real runs on named devices and datasets.
+
+The default recommendation is to keep the custom LAN baseline as the control and run an Iroh follow-up spike unless research finds a blocker. Current research did not show a blocker: Iroh is Rust-native, dual MIT/Apache-2.0 licensed, provides encrypted QUIC peer connections with direct and relay paths, and `iroh-blobs` provides content-addressed verified streaming, range requests, and resumable blob downloads. The main Iroh risk is integration work: Tauri desktop and Android lifecycle, storage, relay policy, and keeping Iroh BLAKE3 blob IDs separate from TuneForge's SHA-256 sync contract.
+
+Research notes as of 2026-05-20:
+
+- [Iroh documentation](https://docs.iroh.computer/what-is-iroh) describes Rust-native encrypted QUIC connections, peer discovery, NAT traversal, relay fallback, and composable protocols such as `iroh-blobs`; the [Iroh repository](https://github.com/n0-computer/iroh) is dual licensed MIT/Apache-2.0.
+- [`iroh-blobs`](https://docs.iroh.computer/protocols/blobs) is content-addressed with BLAKE3 and supports verified streaming, range requests, and resumable downloads. TuneForge can use those as transport internals only; SHA-256 remains the manifest contract.
+- [Ouisync developer docs](https://ouisync.net/developers/) describe a Rust peer-to-peer sync library with Kotlin and Dart/Flutter bindings and MPL-2.0 licensing. It is mobile-relevant, but it is a managed repository/file sync substrate rather than TuneForge semantics.
+- [Syncthing docs](https://docs.syncthing.net/v2.0.0/users/syncing.html) describe block exchange and file-conflict behavior, and its [specs](https://docs.syncthing.net/v2.0.0/specs/index.html) cover local/global discovery and relay protocols, but it is MPL-2.0, Go-based, folder-oriented, and the [official Syncthing Android app has been discontinued](https://forum.syncthing.net/t/discontinuing-syncthing-android/23002). A Syncthing-managed bundle is therefore a desktop comparison/reference, not the primary product boundary.
+
+### Baseline Evidence Fields
+
+The current custom desktop transport records run-level and phase-level evidence that should be copied into bake-off notes before testing another candidate against the same dataset:
+
+| Evidence area | Recorded fields | How to use it |
+| --- | --- | --- |
+| Run identity and before/after timing | `runId`, `peerDeviceId`, `remoteDeviceId`, `startedAt`, `completedAt`, `durationMs`, `status`, `message` | Tie every manual measurement to one sync run and compare start/end wall-clock duration across candidates. |
+| Manifest exchange | `localManifestCount`, `remoteManifestCount`, `manifestErrors` | Confirm each candidate compared the same manifest set and did not hide export/import errors. |
+| Project import outcome | `importedProjectCount`, `skippedProjectCount`, `failedProjectCount`, `projectResults`, `importedProjects` | Compare semantic results, not only transfer speed. A faster transport that imports fewer projects failed the bake-off. |
+| Artifact transfer outcome | `receivedArtifacts[]`, `transferCounts.requested`, `transferCounts.received`, `transferCounts.alreadyStaged`, `transferCounts.failed`, `transferCounts.receivedBytes`, `transferCounts.alreadyStagedBytes` | Separate cold transfers from reused staged content and quantify bytes moved versus bytes already present. |
+| Artifact-level verification | `receivedArtifacts[].artifactId`, `contentSha256`, `sizeBytes`, `status`, `message` | Prove received bytes match the semantic artifact SHA-256 before import. |
+| Transport phase timing evidence | `phaseTimings[]` / `phase_timings[]` entries with `phase`, `projectId`, `artifactId`, `startedAt`, `completedAt`, and `durationMs` | Compare discovery/handshake, manifest exchange, staging checks, transfers, staging, reconciliation, cleanup, and serving phases. |
+| Backend reconciliation timing | `include_timing_evidence=true` on apply requests; response `timing_evidence[]` with `phase`, `duration_ms`, `action_type`, `item_type`, `item_id`, `project_id`, `status`, and `details` | Separate transport time from backend plan/apply/action/staging-cleanup time. |
+| Resumability evidence | `alreadyStaged`, `alreadyStagedBytes`, artifact statuses `already_staged`, `received`, or `failed` | The custom baseline currently proves full verified staged-content reuse on rerun; it does not prove mid-artifact byte-range resume. |
+
+### Candidate Comparison
+
+| Candidate | Performance | Resumability | Lifecycle | Packaging | Licensing | Mobile feasibility | Semantic-manifest fit | Recommendation |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Custom LAN baseline | Measure with current `durationMs`, `transferCounts`, `receivedBytes`, and `phaseTimings` / `phase_timings`; same-LAN TCP/Noise is a useful lower-complexity control but not a WAN or relay benchmark. | Reuses fully verified content-addressed staging via `already_staged`; no proven mid-artifact byte-range resume. | Simple Tauri-owned listener/session lifecycle; easy to pause, stop, and surface in existing Activity UI. | Already in the Tauri/Rust desktop shell with limited dependency surface; desktop-only today. | Current Rust crates are already tracked in notices; no new managed sync runtime. | Android stubs exist, but mobile lifecycle, background networking, and permissions are not solved. | Excellent because it already exchanges TuneForge manifests, inventories, tombstones, and staged artifacts. | Keep as the control implementation for every bake-off run. |
+| Iroh | Needs measured runs, but QUIC, direct paths, relay fallback, and blob transfer are a strong match for large artifacts. | `iroh-blobs` supports verified streaming, range requests, and resumable downloads; spike must prove this against WAV stems and interrupted transfers. | Requires endpoint/router lifecycle, relay policy, local-only/offline behavior, and status integration inside Tauri. | Rust crates fit the shell; Android build, storage backend, and binary size need proof. | Dual MIT/Apache-2.0 is the cleanest candidate against project policy. | Iroh targets mobile, but TuneForge should integrate from Rust/Tauri rather than relying on immature non-Rust bindings. | Strong if Iroh blob IDs remain transport-local and TuneForge SHA-256 manifests stay authoritative. | Preferred follow-up spike unless lifecycle, package size, relay policy, or mobile build research finds a blocker. |
+| Ouisync | Needs measured runs; likely useful for repository sync comparison, but performance must be tested with manifest bundles and large WAV artifacts. | Managed repository sync may reduce custom resume work, but TuneForge must verify how partial content, conflicts, and retries surface to the app. | More substrate-owned lifecycle and access-control behavior to reconcile with TuneForge pairing and trust. | Rust library with mobile-relevant bindings, but repository storage and service shape add integration surface. | MPL-2.0 requires explicit policy and notice review before runtime adoption. | Stronger mobile story than Syncthing-managed bundle because Kotlin and Dart/Flutter bindings exist. | Medium: can carry a TuneForge sync bundle, but its repository/conflict model must not replace entity revisions or tombstones. | Spike only if Iroh has a blocker or if managed repository sync becomes the main risk to compare. |
+| Syncthing-managed sync bundle | Mature block exchange makes it a useful reference; measure only a sync-safe bundle, never the app data directory or SQLite. | Strong block-level reuse and temporary-file behavior, but semantics are file-level and conflict files are not TuneForge conflicts. | Harder: bundled or external daemon, REST/admin surface, background process supervision, upgrades, and user configuration. | Go binary/service packaging is heavier than Rust crates and may vary by desktop platform. | MPL-2.0 requires explicit policy and notice review before bundling. | Weak for primary mobile sync because the official Android wrapper was discontinued; forks or Termux are not a product baseline. | Medium-low: acceptable only if it transports manifests/blobs and TuneForge still imports through services. | Use as desktop-focused comparison and design reference, not the default implementation. |
+
+### Manual Measurement Template
+
+Fill this table with real evidence from the fields above. Do not enter estimated throughput or invented durations.
+
+| Date | Candidate | Scenario | Devices and network | Dataset | Before/control evidence | After/result evidence | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| TBD | Custom LAN baseline | Cold import | OS, CPU, storage, Wi-Fi/Ethernet, direct or relay path | Project count, artifact count, total bytes, largest artifact bytes, WAV/stem mix | `runId`, `startedAt`, local/remote manifest counts, staged bytes before run | `completedAt`, `durationMs`, transfer counts, import counts, manifest errors, `phaseTimings` / `phase_timings`, backend timing evidence | Control row for comparison. |
+| TBD | Iroh | Same scenario as control | Same device pair and network where possible | Same dataset | Same baseline fields plus Iroh transport/blob identifiers used internally | Same result fields; include range/resume evidence for interrupted transfer rerun | Prefer if it matches semantics and improves lifecycle or resumability without policy blockers. |
+| TBD | Ouisync | Same scenario as control | Same device pair and network where possible | Same dataset | Same baseline fields plus repository state before run | Same result fields; note repository conflicts, retries, and import verification | Use to test managed repository tradeoffs. |
+| TBD | Syncthing-managed bundle | Same scenario as control | Same device pair and network where possible | Same sync bundle only | Bundle index/block state and TuneForge manifest counts | TuneForge import result after bundle arrival, plus Syncthing status evidence | Desktop/reference only unless mobile packaging risk changes. |
+
+The interrupted lyrics-job convergence edge case tracked by #163 is a sync v2 follow-up and does not block #118. Completed lyrics revisions and artifacts should still sync as durable library state, but interrupted runnable jobs are not part of the v1 sync truth and should not determine the transport bake-off outcome.
+
 ## Recommended Direction
 
 Build a TuneForge-owned semantic sync layer with a swappable transport/blob layer. The sync layer should operate above backend persistence and below UI workflows. It should treat Linux desktop, macOS desktop, and mobile as peers in the same trusted sync group.
@@ -421,7 +473,7 @@ Recommended spike sequence:
 7. Edit-locking for syncing projects until minimum usable data is verified.
 8. Linux-to-macOS desktop sync on the same LAN.
 9. Three-peer desktop sync behavior.
-10. Transport bake-off: custom LAN baseline, Iroh, Ouisync, and possibly a Syncthing-managed sync bundle.
+10. Transport bake-off: keep the custom LAN baseline as the control, prefer an Iroh follow-up spike, and compare Ouisync plus a Syncthing-managed sync bundle if the evidence or blockers justify it.
 11. Mobile library sync and WAV playback/battery validation.
 
 ## Security Model


### PR DESCRIPTION
## Summary
- Add native sync transport v2 evidence for phase timing, byte counts, throughput, and TTFA.
- Stream artifact bytes as encrypted binary frames while keeping SHA-256 staging verification authoritative.
- Surface compact Activity sync transfer metrics and document the #118 transport bake-off comparison.

Closes #118

## Testing
- `cd apps/desktop/src-tauri && cargo test sync_transport`
- `cd apps/desktop/src-tauri && cargo check`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test --run src/App.activity.test.tsx`
- `git diff --check`
