### PR TITLE
feat: define pagination API contract

### DIFF
--- a/apps/backend/app/api/pagination.py
+++ b/apps/backend/app/api/pagination.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Annotated, TypedDict
+
+from fastapi import Depends, Query
+
+DEFAULT_LIMIT = 50
+MAX_LIMIT = 200
+DEFAULT_OFFSET = 0
+
+
+@dataclass(frozen=True, slots=True)
+class PaginationParams:
+    limit: int
+    offset: int
+
+
+class PaginationMetadata(TypedDict):
+    total: int
+    limit: int
+    offset: int
+    has_more: bool
+
+
+def pagination_params(
+    limit: int = Query(
+        default=DEFAULT_LIMIT,
+        ge=1,
+        le=MAX_LIMIT,
+        description="Maximum number of items to return.",
+    ),
+    offset: int = Query(
+        default=DEFAULT_OFFSET,
+        ge=0,
+        description="Number of items to skip before returning results.",
+    ),
+) -> PaginationParams:
+    return PaginationParams(limit=limit, offset=offset)
+
+
+PaginationQuery = Annotated[PaginationParams, Depends(pagination_params)]
+
+
+def pagination_metadata(
+    *,
+    total: int,
+    limit: int,
+    offset: int,
+    number_of_returned_items: int,
+) -> PaginationMetadata:
+    return {
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+        "has_more": offset + number_of_returned_items < total,
+    }

--- a/apps/backend/tests/test_pagination.py
+++ b/apps/backend/tests/test_pagination.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.pagination import (
+    DEFAULT_LIMIT,
+    DEFAULT_OFFSET,
+    MAX_LIMIT,
+    PaginationQuery,
+    pagination_metadata,
+)
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    app = FastAPI()
+
+    @app.get("/items")
+    def items(pagination: PaginationQuery) -> dict[str, int]:
+        return {"limit": pagination.limit, "offset": pagination.offset}
+
+    return TestClient(app)
+
+
+def test_pagination_params_use_defaults(client: TestClient) -> None:
+    response = client.get("/items")
+
+    assert response.status_code == 200
+    assert response.json() == {"limit": DEFAULT_LIMIT, "offset": DEFAULT_OFFSET}
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ({"limit": "1", "offset": "0"}, {"limit": 1, "offset": 0}),
+        ({"limit": str(MAX_LIMIT), "offset": "25"}, {"limit": MAX_LIMIT, "offset": 25}),
+    ],
+)
+def test_pagination_params_accept_bounds(
+    client: TestClient,
+    query: dict[str, str],
+    expected: dict[str, int],
+) -> None:
+    response = client.get("/items", params=query)
+
+    assert response.status_code == 200
+    assert response.json() == expected
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        {"limit": "0"},
+        {"limit": str(MAX_LIMIT + 1)},
+        {"offset": "-1"},
+    ],
+)
+def test_pagination_params_reject_invalid_bounds(client: TestClient, query: dict[str, str]) -> None:
+    response = client.get("/items", params=query)
+
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize(
+    ("total", "limit", "offset", "number_of_returned_items", "has_more"),
+    [
+        (10, 5, 0, 5, True),
+        (10, 5, 5, 5, False),
+        (10, 5, 8, 2, False),
+        (3, 50, 0, 3, False),
+    ],
+)
+def test_pagination_metadata_sets_has_more(
+    total: int,
+    limit: int,
+    offset: int,
+    number_of_returned_items: int,
+    has_more: bool,
+) -> None:
+    assert pagination_metadata(
+        total=total,
+        limit=limit,
+        offset=offset,
+        number_of_returned_items=number_of_returned_items,
+    ) == {
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+        "has_more": has_more,
+    }

--- a/apps/backend/tests/test_pagination_contract.py
+++ b/apps/backend/tests/test_pagination_contract.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from app.main import app
+
+LIST_RESPONSE_CONTRACTS = {
+    ("/api/v1/chord-backends", "get"): ("ChordBackendsResponse", "backends", True),
+    ("/api/v1/stem-models", "get"): ("StemModelsResponse", "models", True),
+    ("/api/v1/projects", "get"): ("ProjectsResponse", "projects", True),
+    ("/api/v1/projects/{project_id}/sections", "get"): ("SongSectionsResponse", "sections", False),
+    ("/api/v1/projects/{project_id}/artifacts", "get"): ("ArtifactsResponse", "artifacts", True),
+    ("/api/v1/jobs", "get"): ("JobsResponse", "jobs", True),
+    ("/api/v1/sync/trusted-peers", "get"): ("SyncTrustedPeersResponse", "trusted_peers", True),
+}
+
+
+def test_list_routes_keep_concrete_openapi_response_refs() -> None:
+    openapi = app.openapi()
+
+    for (path, method), (schema_name, _list_field, _field_required) in LIST_RESPONSE_CONTRACTS.items():
+        response_schema = openapi["paths"][path][method]["responses"]["200"]["content"]["application/json"]["schema"]
+
+        assert response_schema == {"$ref": f"#/components/schemas/{schema_name}"}
+
+
+def test_existing_list_response_components_do_not_add_pagination_metadata() -> None:
+    openapi = app.openapi()
+    components = openapi["components"]["schemas"]
+    pagination_fields = {"total", "limit", "offset", "has_more"}
+
+    for schema_name, list_field, field_required in LIST_RESPONSE_CONTRACTS.values():
+        component_schema = components[schema_name]
+
+        assert set(component_schema["properties"]) == {list_field}
+        assert set(component_schema["properties"][list_field]) >= {"items", "type", "title"}
+        assert component_schema["properties"][list_field]["type"] == "array"
+        if field_required:
+            assert component_schema["required"] == [list_field]
+        else:
+            assert "required" not in component_schema
+        assert pagination_fields.isdisjoint(component_schema["properties"])

--- a/docs/API.md
+++ b/docs/API.md
@@ -14,6 +14,65 @@ This document summarizes the current route surface. The generated OpenAPI schema
 - Timestamps: ISO 8601 strings in API responses.
 - Errors use a structured `error` object with `code`, `message`, and `details`.
 
+### Pagination Contract
+
+Endpoints that expose growable collections use offset pagination. Endpoint-specific follow-ups should add this
+contract without renaming the existing list field, so generated OpenAPI clients keep a predictable response shape.
+
+Request query parameters:
+
+- `limit` - page size, default `50`, minimum `1`, maximum `200`.
+- `offset` - zero-based row offset, default `0`, minimum `0`.
+
+Existing search and filter parameters apply to the full matching collection before `total`, `limit`, and `offset`
+are applied.
+
+Response fields:
+
+- the existing list field, such as `projects`, `jobs`, or `artifacts`.
+- `total` - count after search and filters, before pagination.
+- `limit` - the effective limit used for this response.
+- `offset` - the effective offset used for this response.
+- `has_more` - `true` when `offset + <returned count> < total`.
+
+Example:
+
+```json
+{
+  "projects": [],
+  "total": 125,
+  "limit": 50,
+  "offset": 0,
+  "has_more": true
+}
+```
+
+Paginated endpoints must document their default sort. Sorting must be deterministic across repeated requests:
+timestamp, status, search-rank, or other non-unique sort keys need a stable tie-breaker, normally the entity's
+immutable ID. For example, newest-first pages should sort by `updated_at DESC, id DESC` instead of timestamp alone.
+If a sort key can be `null`, the endpoint must also document where null values appear.
+
+### Pagination Endpoint Audit
+
+This audit captures the current list-like API surface. Until endpoint-specific pagination lands, the individual
+endpoint sections later in this document describe the current unpaginated behavior.
+
+| Endpoint or payload | List field | Pagination decision |
+| --- | --- | --- |
+| `GET /api/v1/jobs` | `jobs` | Planned paginated growable list. It also needs project-name search and explicit sort controls. Desktop Activity and project job-history consumers should lazy-load this list. |
+| `GET /api/v1/projects` | `projects` | Planned paginated growable list while preserving global `search`. Desktop Library consumers should lazy-load this list. |
+| `GET /api/v1/projects/{project_id}/artifacts` | `artifacts` | Planned paginated project child list with project-scoped totals and stable newest-first ordering. Desktop project views should lazy-load this list. |
+| `GET /api/v1/projects/{project_id}/sections` | `sections` | Review with project child lists. Paginate if sections are treated as growable; otherwise document the bounded song-structure exception. |
+| `GET /api/v1/sync/trusted-peers` | `trusted_peers` | Review as either a paginated user-managed sync collection or an explicit bounded exception. |
+| `GET /api/v1/chord-backends` | `backends` | Explicit unpaginated exception: small static capability list, bounded by bundled/local backend implementations. |
+| `GET /api/v1/stem-models` | `models` | Explicit unpaginated exception: small static capability list, bounded by supported local stem models. |
+| `GET /api/v1/sync/metadata` | `projects`, `artifacts`, `delete_tombstones` | Explicit unpaginated sync snapshot exception. The payload is a complete sync inventory used by native sync and reconciliation, not an interactive scroll list. If scale requires chunking, it should be a sync protocol change rather than this generic pagination contract. |
+| `GET /api/v1/sync/preflight` | `projects`, `duplicate_groups`, `manual_cleanup_guidance` | Explicit unpaginated diagnostic exception. The response is a complete local-library health report. |
+| `GET /api/v1/sync/projects/{project_id}/manifest` | `entity_revisions`, `artifacts`, `delete_tombstones` | Explicit unpaginated manifest exception. The response is an atomic project export unit. |
+| `POST /api/v1/sync/reconciliation/plan` | `items`, `actions` | Explicit unpaginated planning exception. The response is a complete computed plan for the supplied sync inventory. |
+| `POST /api/v1/sync/reconciliation/apply` | `plan.items`, `plan.actions`, `results`, `timing_evidence` | Explicit unpaginated apply exception. Partial pages would make apply summaries and results incomplete. |
+| Project document payloads, including analysis timing, chords, lyrics, tab imports, and tab apply results | nested content arrays | Explicit unpaginated document exceptions unless a future endpoint exposes them as standalone growable collections. These arrays are part of a single project document or edit result, not top-level list browsing. |
+
 Example error response:
 
 ```json


### PR DESCRIPTION
## Summary

- Define the shared list pagination contract for API performance follow-ups.
- Add backend pagination query and metadata helpers without changing route responses.
- Document current list endpoint decisions and exceptions.

Closes #144

## Testing

- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `cd apps/backend && uv run --python 3.11 pytest`
