### PR TITLE
feat: paginate jobs API and activity history

### DIFF
--- a/apps/backend/app/api/routes/jobs.py
+++ b/apps/backend/app/api/routes/jobs.py
@@ -1,22 +1,40 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
-from sqlalchemy import select
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
+from app.api.pagination import PaginationQuery, pagination_metadata
 from app.dependencies import get_db, get_job_runner
 from app.errors import AppError
 from app.models import Job
 from app.schemas import JobResponse, JobSchema, JobsResponse
+from app.services.jobs import list_jobs as list_jobs_service
 
 router = APIRouter(prefix="/jobs", tags=["jobs"])
 
 
 @router.get("", response_model=JobsResponse)
-def list_jobs(session: Session = Depends(get_db)) -> JobsResponse:
-    stmt = select(Job).order_by(Job.updated_at.desc())
-    jobs = [JobSchema.model_validate(job) for job in session.scalars(stmt)]
-    return JobsResponse(jobs=jobs)
+def list_jobs(
+    pagination: PaginationQuery,
+    status: list[str] | None = Query(default=None, description="Filter jobs by status. May be repeated."),
+    project_id: str | None = Query(default=None, description="Filter jobs by project ID."),
+    session: Session = Depends(get_db),
+) -> JobsResponse:
+    listed_jobs = list_jobs_service(
+        session,
+        limit=pagination.limit,
+        offset=pagination.offset,
+        statuses=status,
+        project_id=project_id,
+    )
+    jobs = [JobSchema.model_validate(job) for job in listed_jobs.jobs]
+    metadata = pagination_metadata(
+        total=listed_jobs.total,
+        limit=pagination.limit,
+        offset=pagination.offset,
+        number_of_returned_items=len(jobs),
+    )
+    return JobsResponse(jobs=jobs, **metadata)
 
 
 @router.get("/{job_id}", response_model=JobResponse)

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -1073,6 +1073,10 @@ class JobResponse(BaseModel):
 
 class JobsResponse(BaseModel):
     jobs: list[JobSchema]
+    total: int
+    limit: int
+    offset: int
+    has_more: bool
 
 
 class ArtifactSchema(BaseModel):

--- a/apps/backend/app/services/jobs.py
+++ b/apps/backend/app/services/jobs.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import queue
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from subprocess import Popen
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import case, func, select
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.errors import AppError, JobCancelledError
@@ -34,7 +34,73 @@ class JobExecutionResult:
     runtime_device: str | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class ListedJobs:
+    jobs: list[Job]
+    total: int
+
+
 JobHandler = Callable[["JobExecutionContext", Session, Job], JobExecutionResult]
+
+_TERMINAL_JOB_STATUSES = ("completed", "cancelled", "failed")
+
+
+def _job_ordering() -> tuple[Any, ...]:
+    status_rank = case(
+        (Job.status == "running", 0),
+        (Job.status == "pending", 1),
+        (Job.status.in_(_TERMINAL_JOB_STATUSES), 2),
+        else_=3,
+    )
+    running_timestamp = case(
+        (Job.status == "running", func.coalesce(Job.started_at, Job.created_at)),
+        else_=None,
+    )
+    running_id = case((Job.status == "running", Job.id), else_=None)
+    pending_created_at = case((Job.status == "pending", Job.created_at), else_=None)
+    pending_id = case((Job.status == "pending", Job.id), else_=None)
+    terminal_timestamp = case(
+        (Job.status.in_(_TERMINAL_JOB_STATUSES), func.coalesce(Job.completed_at, Job.updated_at)),
+        else_=None,
+    )
+    terminal_id = case((Job.status.in_(_TERMINAL_JOB_STATUSES), Job.id), else_=None)
+    return (
+        status_rank.asc(),
+        running_timestamp.asc(),
+        running_id.asc(),
+        pending_created_at.asc(),
+        pending_id.asc(),
+        terminal_timestamp.desc(),
+        terminal_id.desc(),
+        Job.updated_at.desc(),
+        Job.id.desc(),
+    )
+
+
+def list_jobs(
+    session: Session,
+    *,
+    limit: int,
+    offset: int,
+    statuses: Sequence[str] | None = None,
+    project_id: str | None = None,
+) -> ListedJobs:
+    filters: list[Any] = []
+    status_filters = tuple(statuses or ())
+    if status_filters:
+        filters.append(Job.status.in_(status_filters))
+    if project_id is not None:
+        filters.append(Job.project_id == project_id)
+
+    total_statement = select(func.count()).select_from(Job)
+    jobs_statement = select(Job)
+    if filters:
+        total_statement = total_statement.where(*filters)
+        jobs_statement = jobs_statement.where(*filters)
+
+    total = session.scalar(total_statement) or 0
+    jobs = list(session.scalars(jobs_statement.order_by(*_job_ordering()).limit(limit).offset(offset)))
+    return ListedJobs(jobs=jobs, total=total)
 
 
 def _as_utc_datetime(value: datetime) -> datetime:

--- a/apps/backend/tests/test_jobs_api.py
+++ b/apps/backend/tests/test_jobs_api.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.db import SessionLocal
+from app.models import Job, Project
+
+_BASE_TIME = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _timestamp(minutes: int) -> datetime:
+    return _BASE_TIME + timedelta(minutes=minutes)
+
+
+def _add_project(session: Session, project_id: str) -> None:
+    session.add(
+        Project(
+            id=project_id,
+            display_name=project_id,
+            source_path=f"/tmp/{project_id}.wav",
+            imported_path=f"/tmp/tuneforge/{project_id}.wav",
+        )
+    )
+
+
+def _add_job(
+    session: Session,
+    job_id: str,
+    status: str,
+    *,
+    project_id: str | None = None,
+    created_at: datetime | None = None,
+    started_at: datetime | None = None,
+    completed_at: datetime | None = None,
+    updated_at: datetime | None = None,
+) -> None:
+    effective_created_at = created_at or _timestamp(0)
+    session.add(
+        Job(
+            id=job_id,
+            project_id=project_id,
+            type="test",
+            status=status,
+            progress=0,
+            error_message=None,
+            runtime_device=None,
+            payload_json={},
+            result_artifact_ids_json=[],
+            cancel_requested=False,
+            created_at=effective_created_at,
+            started_at=started_at,
+            completed_at=completed_at,
+            duration_seconds=None,
+            updated_at=updated_at or completed_at or started_at or effective_created_at,
+        )
+    )
+
+
+def test_list_jobs_returns_pagination_metadata(client: TestClient) -> None:
+    with SessionLocal() as session:
+        _add_job(session, "job_a", "pending", created_at=_timestamp(1))
+        _add_job(session, "job_b", "pending", created_at=_timestamp(2))
+        _add_job(session, "job_c", "pending", created_at=_timestamp(3))
+        session.commit()
+
+    response = client.get("/api/v1/jobs", params={"limit": "2"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [job["id"] for job in payload["jobs"]] == ["job_a", "job_b"]
+    assert payload["total"] == 3
+    assert payload["limit"] == 2
+    assert payload["offset"] == 0
+    assert payload["has_more"] is True
+
+
+def test_list_jobs_orders_active_before_terminal_then_unknown(client: TestClient) -> None:
+    with SessionLocal() as session:
+        _add_job(session, "job_pending", "pending", created_at=_timestamp(1))
+        _add_job(
+            session,
+            "job_running_started",
+            "running",
+            created_at=_timestamp(0),
+            started_at=_timestamp(10),
+            updated_at=_timestamp(10),
+        )
+        _add_job(session, "job_running_fallback", "running", created_at=_timestamp(5))
+        _add_job(
+            session,
+            "job_terminal",
+            "failed",
+            created_at=_timestamp(2),
+            completed_at=_timestamp(30),
+            updated_at=_timestamp(30),
+        )
+        _add_job(session, "job_unknown", "paused", created_at=_timestamp(4), updated_at=_timestamp(100))
+        session.commit()
+
+    response = client.get("/api/v1/jobs")
+
+    assert response.status_code == 200
+    assert [job["id"] for job in response.json()["jobs"]] == [
+        "job_running_fallback",
+        "job_running_started",
+        "job_pending",
+        "job_terminal",
+        "job_unknown",
+    ]
+
+
+def test_list_jobs_accepts_repeatable_status_filter(client: TestClient) -> None:
+    with SessionLocal() as session:
+        _add_job(session, "job_pending", "pending", created_at=_timestamp(1))
+        _add_job(session, "job_running", "running", started_at=_timestamp(2))
+        _add_job(session, "job_completed", "completed", completed_at=_timestamp(3))
+        session.commit()
+
+    response = client.get(
+        "/api/v1/jobs",
+        params=[("status", "pending"), ("status", "running")],
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [job["id"] for job in payload["jobs"]] == ["job_running", "job_pending"]
+    assert payload["total"] == 2
+
+
+def test_list_jobs_filters_by_project_id(client: TestClient) -> None:
+    with SessionLocal() as session:
+        _add_project(session, "project_a")
+        _add_project(session, "project_b")
+        _add_job(session, "job_project_a_1", "pending", project_id="project_a", created_at=_timestamp(1))
+        _add_job(session, "job_project_a_2", "pending", project_id="project_a", created_at=_timestamp(2))
+        _add_job(session, "job_project_b", "pending", project_id="project_b", created_at=_timestamp(3))
+        _add_job(session, "job_global", "pending", project_id=None, created_at=_timestamp(4))
+        session.commit()
+
+    response = client.get("/api/v1/jobs", params={"project_id": "project_a"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [job["id"] for job in payload["jobs"]] == ["job_project_a_1", "job_project_a_2"]
+    assert payload["total"] == 2
+
+
+def test_list_jobs_keeps_terminal_pages_stable(client: TestClient) -> None:
+    with SessionLocal() as session:
+        _add_job(
+            session,
+            "job_a",
+            "completed",
+            completed_at=_timestamp(10),
+            updated_at=_timestamp(99),
+        )
+        _add_job(
+            session,
+            "job_b",
+            "completed",
+            completed_at=None,
+            updated_at=_timestamp(30),
+        )
+        _add_job(
+            session,
+            "job_c",
+            "cancelled",
+            completed_at=_timestamp(30),
+            updated_at=_timestamp(30),
+        )
+        _add_job(
+            session,
+            "job_d",
+            "failed",
+            completed_at=_timestamp(30),
+            updated_at=_timestamp(30),
+        )
+        session.commit()
+
+    first_page = client.get("/api/v1/jobs", params={"limit": "2"}).json()
+    second_page = client.get("/api/v1/jobs", params={"limit": "2", "offset": "2"}).json()
+
+    assert [job["id"] for job in first_page["jobs"]] == ["job_d", "job_c"]
+    assert first_page["has_more"] is True
+    assert [job["id"] for job in second_page["jobs"]] == ["job_b", "job_a"]
+    assert second_page["has_more"] is False
+
+
+@pytest.mark.parametrize("params", [{"limit": "0"}, {"offset": "-1"}])
+def test_list_jobs_rejects_invalid_pagination_query(client: TestClient, params: dict[str, str]) -> None:
+    response = client.get("/api/v1/jobs", params=params)
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "INVALID_REQUEST"

--- a/apps/backend/tests/test_pagination_contract.py
+++ b/apps/backend/tests/test_pagination_contract.py
@@ -8,15 +8,24 @@ LIST_RESPONSE_CONTRACTS = {
     ("/api/v1/projects", "get"): ("ProjectsResponse", "projects", True),
     ("/api/v1/projects/{project_id}/sections", "get"): ("SongSectionsResponse", "sections", False),
     ("/api/v1/projects/{project_id}/artifacts", "get"): ("ArtifactsResponse", "artifacts", True),
-    ("/api/v1/jobs", "get"): ("JobsResponse", "jobs", True),
     ("/api/v1/sync/trusted-peers", "get"): ("SyncTrustedPeersResponse", "trusted_peers", True),
+}
+PAGINATED_LIST_RESPONSE_CONTRACTS = {
+    ("/api/v1/jobs", "get"): ("JobsResponse", "jobs"),
 }
 
 
 def test_list_routes_keep_concrete_openapi_response_refs() -> None:
     openapi = app.openapi()
 
-    for (path, method), (schema_name, _list_field, _field_required) in LIST_RESPONSE_CONTRACTS.items():
+    response_contracts = {
+        **LIST_RESPONSE_CONTRACTS,
+        **{
+            route: (schema_name, list_field, True)
+            for route, (schema_name, list_field) in PAGINATED_LIST_RESPONSE_CONTRACTS.items()
+        },
+    }
+    for (path, method), (schema_name, _list_field, _field_required) in response_contracts.items():
         response_schema = openapi["paths"][path][method]["responses"]["200"]["content"]["application/json"]["schema"]
 
         assert response_schema == {"$ref": f"#/components/schemas/{schema_name}"}
@@ -38,3 +47,16 @@ def test_existing_list_response_components_do_not_add_pagination_metadata() -> N
         else:
             assert "required" not in component_schema
         assert pagination_fields.isdisjoint(component_schema["properties"])
+
+
+def test_paginated_list_response_components_include_pagination_metadata() -> None:
+    openapi = app.openapi()
+    components = openapi["components"]["schemas"]
+    pagination_fields = {"total", "limit", "offset", "has_more"}
+
+    for schema_name, list_field in PAGINATED_LIST_RESPONSE_CONTRACTS.values():
+        component_schema = components[schema_name]
+
+        assert set(component_schema["properties"]) == {list_field, *pagination_fields}
+        assert component_schema["properties"][list_field]["type"] == "array"
+        assert set(component_schema["required"]) == {list_field, *pagination_fields}

--- a/apps/desktop/src-tauri/src/mobile_backend.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend.rs
@@ -125,6 +125,20 @@ pub struct JobResponse {
 #[derive(Serialize)]
 pub struct JobsResponse {
     jobs: Vec<JobSchema>,
+    total: usize,
+    limit: usize,
+    offset: usize,
+    has_more: bool,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+pub struct ListJobsParams {
+    status: Option<Vec<String>>,
+    project_id: Option<String>,
+    limit: Option<i64>,
+    offset: Option<i64>,
 }
 
 #[derive(Serialize)]
@@ -249,7 +263,7 @@ mobile_stub!(mobile_delete_artifact, DeleteResponse, app: AppHandle, project_id:
 #[cfg(not(target_os = "android"))]
 mobile_stub!(mobile_submit_export, JobResponse, app: AppHandle, project_id: String, payload: EmptyPayload);
 #[cfg(not(target_os = "android"))]
-mobile_stub!(mobile_list_jobs, JobsResponse, app: AppHandle);
+mobile_stub!(mobile_list_jobs, JobsResponse, app: AppHandle, params: Option<ListJobsParams>);
 #[cfg(not(target_os = "android"))]
 mobile_stub!(mobile_get_job, JobResponse, app: AppHandle, job_id: String);
 #[cfg(not(target_os = "android"))]
@@ -283,6 +297,8 @@ mod android {
     const WHISPER_MODEL_DIR: &str = "models/whisper";
     const WHISPER_MODEL_MISSING: &str =
         "Side-load a Whisper ggml model into app storage at models/whisper/ggml-base.bin or models/whisper/ggml-tiny.bin to enable local lyrics.";
+    const DEFAULT_JOBS_LIMIT: usize = 50;
+    const MAX_JOBS_LIMIT: usize = 200;
 
     #[derive(Clone)]
     struct WhisperModel {
@@ -377,6 +393,27 @@ mod android {
 
     fn now_iso() -> String {
         Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+    }
+
+    fn normalized_jobs_limit(value: Option<i64>) -> Result<usize, String> {
+        let limit = value.unwrap_or(DEFAULT_JOBS_LIMIT as i64);
+        if limit < 1 {
+            return Err("Job list limit must be at least 1.".to_string());
+        }
+        if limit > MAX_JOBS_LIMIT as i64 {
+            return Err(format!(
+                "Job list limit must be less than or equal to {MAX_JOBS_LIMIT}."
+            ));
+        }
+        Ok(limit as usize)
+    }
+
+    fn normalized_jobs_offset(value: Option<i64>) -> Result<usize, String> {
+        let offset = value.unwrap_or(0);
+        if offset < 0 {
+            return Err("Job list offset must be at least 0.".to_string());
+        }
+        Ok(offset as usize)
     }
 
     fn new_id(prefix: &str) -> String {
@@ -2148,19 +2185,67 @@ mod android {
     }
 
     #[tauri::command]
-    pub fn mobile_list_jobs(app: AppHandle) -> Result<JobsResponse, String> {
+    pub fn mobile_list_jobs(
+        app: AppHandle,
+        params: Option<ListJobsParams>,
+    ) -> Result<JobsResponse, String> {
+        let params = params.unwrap_or_default();
+        let limit = normalized_jobs_limit(params.limit)?;
+        let offset = normalized_jobs_offset(params.offset)?;
+        let status_filters = params.status.unwrap_or_default();
         let connection = db(&app)?;
         let mut statement = connection
-            .prepare("SELECT id, project_id, type, status, progress, source_artifact_id, error_message, runtime_device, started_at, completed_at, duration_seconds, created_at, updated_at FROM jobs ORDER BY created_at DESC")
+            .prepare(
+                r#"
+                SELECT id, project_id, type, status, progress, source_artifact_id, error_message, runtime_device, started_at, completed_at, duration_seconds, created_at, updated_at
+                FROM jobs
+                ORDER BY
+                    CASE
+                        WHEN status = 'running' THEN 0
+                        WHEN status = 'pending' THEN 1
+                        WHEN status IN ('completed', 'cancelled', 'failed') THEN 2
+                        ELSE 3
+                    END ASC,
+                    CASE WHEN status = 'running' THEN COALESCE(started_at, created_at) END ASC,
+                    CASE WHEN status = 'running' THEN id END ASC,
+                    CASE WHEN status = 'pending' THEN created_at END ASC,
+                    CASE WHEN status = 'pending' THEN id END ASC,
+                    CASE WHEN status IN ('completed', 'cancelled', 'failed') THEN COALESCE(completed_at, updated_at) END DESC,
+                    CASE WHEN status IN ('completed', 'cancelled', 'failed') THEN id END DESC,
+                    updated_at DESC,
+                    id DESC
+                "#,
+            )
             .map_err(|error| error.to_string())?;
         let rows = statement
             .query_map([], row_job)
             .map_err(|error| error.to_string())?;
         let mut jobs = Vec::new();
         for row in rows {
-            jobs.push(row.map_err(|error| error.to_string())?);
+            let job = row.map_err(|error| error.to_string())?;
+            let status_matches = status_filters.is_empty()
+                || status_filters.iter().any(|status| status == &job.status);
+            let project_matches = params.project_id.as_ref().map_or(true, |project_id| {
+                job.project_id.as_deref() == Some(project_id.as_str())
+            });
+            if status_matches && project_matches {
+                jobs.push(job);
+            }
         }
-        Ok(JobsResponse { jobs })
+        let total = jobs.len();
+        let jobs = jobs
+            .into_iter()
+            .skip(offset)
+            .take(limit)
+            .collect::<Vec<_>>();
+        let has_more = offset.saturating_add(jobs.len()) < total;
+        Ok(JobsResponse {
+            jobs,
+            total,
+            limit,
+            offset,
+            has_more,
+        })
     }
 
     #[tauri::command]

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -95,6 +95,52 @@ describe("Desktop app activity", () => {
     expect(mockListProjects).toHaveBeenCalled();
   });
 
+  it("requests active and terminal job pages separately", async () => {
+    renderApp(["/activity"]);
+
+    expect(await screen.findByRole("heading", { level: 2, name: "Jobs" })).toBeInTheDocument();
+
+    await waitFor(() => expect(mockListJobs).toHaveBeenCalledTimes(2));
+    expect(mockListJobs).toHaveBeenCalledWith({
+      status: ["running", "pending"],
+      limit: 200,
+      offset: 0,
+    });
+    expect(mockListJobs).toHaveBeenCalledWith({
+      status: ["completed", "failed", "cancelled"],
+      limit: 50,
+      offset: 0,
+    });
+    expect(mockListJobs.mock.calls.some(([params]) => params === undefined)).toBe(false);
+  });
+
+  it("automatically loads additional active job pages", async () => {
+    setJobs(
+      Array.from({ length: 205 }, (_, index) => {
+        const jobNumber = index + 1;
+        return job({
+          id: `job_active_${String(jobNumber).padStart(3, "0")}`,
+          type: `active_${String(jobNumber).padStart(3, "0")}`,
+          status: "running",
+          progress: 25,
+          started_at: `2026-04-18T13:${String(index % 60).padStart(2, "0")}:00.000Z`,
+          created_at: `2026-04-18T13:${String(index % 60).padStart(2, "0")}:00.000Z`,
+          updated_at: `2026-04-18T13:${String(index % 60).padStart(2, "0")}:00.000Z`,
+        });
+      }),
+    );
+
+    renderApp(["/activity"]);
+
+    expect(await screen.findByRole("article", { name: "active_001 running job" })).toBeInTheDocument();
+    expect(await screen.findByRole("article", { name: "active_205 running job" })).toBeInTheDocument();
+    expect(mockListJobs).toHaveBeenCalledWith({
+      status: ["running", "pending"],
+      limit: 200,
+      offset: 200,
+    });
+  });
+
   it("switches between Activity Jobs and Sync tabs", async () => {
     const user = userEvent.setup();
     renderApp(["/activity"]);
@@ -830,6 +876,41 @@ describe("Desktop app activity", () => {
     expect(within(rows[1]).getByText("built-in / source")).toBeInTheDocument();
     expect(within(rows[2]).getByText("Queue #2")).toBeInTheDocument();
     expect(within(rows[2]).getByText("No project")).toBeInTheDocument();
+  });
+
+  it("loads additional terminal history pages on request", async () => {
+    const user = userEvent.setup();
+    setJobs(
+      Array.from({ length: 55 }, (_, index) => {
+        const jobNumber = index + 1;
+        return job({
+          id: `job_history_${String(jobNumber).padStart(3, "0")}`,
+          type: `history_${String(jobNumber).padStart(3, "0")}`,
+          status: "completed",
+          progress: 100,
+          completed_at: `2026-04-18T13:${String(59 - index).padStart(2, "0")}:00.000Z`,
+          created_at: "2026-04-18T13:00:00.000Z",
+          updated_at: `2026-04-18T13:${String(59 - index).padStart(2, "0")}:00.000Z`,
+        });
+      }),
+    );
+
+    renderApp(["/activity"]);
+
+    expect(await screen.findByRole("article", { name: "history_001 completed job" })).toBeInTheDocument();
+    expect(screen.queryByRole("article", { name: "history_055 completed job" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Load more history" }));
+
+    expect(await screen.findByRole("article", { name: "history_055 completed job" })).toBeInTheDocument();
+    expect(mockListJobs).toHaveBeenCalledWith({
+      status: ["completed", "failed", "cancelled"],
+      limit: 50,
+      offset: 50,
+    });
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Load more history" })).not.toBeInTheDocument(),
+    );
   });
 
   it("cancels pending jobs and refreshes the queue", async () => {

--- a/apps/desktop/src/App.project-playback-artifacts.test.tsx
+++ b/apps/desktop/src/App.project-playback-artifacts.test.tsx
@@ -114,6 +114,40 @@ describe("Desktop app project playback artifacts", () => {
     },
   );
 
+  it("loads project-scoped jobs so global pagination cannot hide project failures", async () => {
+    setJobs([
+      ...Array.from({ length: 60 }, (_, index) => ({
+        id: `job_other_running_${index}`,
+        project_id: `proj_other_${index}`,
+        type: "stems",
+        status: "running",
+        progress: 50,
+        source_artifact_id: null,
+        error_message: null,
+        created_at: "2026-04-18T13:00:00.000Z",
+        updated_at: "2026-04-18T13:00:00.000Z",
+      })),
+      {
+        id: "job_selected_failed",
+        project_id: "proj_123",
+        type: "stems",
+        status: "failed",
+        progress: 15,
+        source_artifact_id: "art_source",
+        error_message: "Selected project stems failed.",
+        created_at: "2026-04-18T13:16:00.000Z",
+        updated_at: "2026-04-18T13:16:00.000Z",
+      },
+    ]);
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await waitFor(() => expect(mockListJobs).toHaveBeenCalledWith({ project_id: "proj_123" }));
+    const stemError = await screen.findByRole("group", { name: "Stem error" });
+    expect(within(stemError).getByText("Selected project stems failed.")).toBeInTheDocument();
+  });
+
   it("deletes a visible stem from the sources rail", async () => {
     const user = userEvent.setup();
     renderApp(["/projects/proj_123"]);
@@ -312,6 +346,10 @@ describe("Desktop app project playback artifacts", () => {
           updated_at: "2026-04-18T13:16:00.000Z",
         },
       ],
+      total: 1,
+      limit: 50,
+      offset: 0,
+      has_more: false,
     });
 
     renderApp(["/projects/proj_123"]);
@@ -349,6 +387,10 @@ describe("Desktop app project playback artifacts", () => {
           updated_at: "2026-04-18T13:16:00.000Z",
         },
       ],
+      total: 1,
+      limit: 50,
+      offset: 0,
+      has_more: false,
     });
 
     renderApp(["/projects/proj_123"]);

--- a/apps/desktop/src/App.project-playback-stems.test.tsx
+++ b/apps/desktop/src/App.project-playback-stems.test.tsx
@@ -534,10 +534,10 @@ describe("Desktop app project playback stems", () => {
       flushPendingPreview("proj_123");
       const [{ artifacts }, { jobs }] = await Promise.all([
         mockListArtifacts("proj_123"),
-        mockListJobs(),
+        mockListJobs({ project_id: "proj_123" }),
       ]);
       queryClient.setQueryData(["artifacts", "proj_123"], artifacts);
-      queryClient.setQueryData(["jobs"], jobs);
+      queryClient.setQueryData(["jobs", { projectId: "proj_123" }], jobs);
     });
 
     expect(await screen.findByRole("heading", { name: "Practice Mix" })).toBeInTheDocument();

--- a/apps/desktop/src/features/activity/ActivityView.tsx
+++ b/apps/desktop/src/features/activity/ActivityView.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import { api, type JobSchema, type ProjectSchema } from "../../lib/api";
 import { formatLocalDateTime, normalizeApiDateTime, parseApiDateTime } from "../../lib/datetime";
@@ -7,8 +7,14 @@ import { formatJobStatusSummary } from "../projects/projectViewUtils";
 import { ActivitySyncPanel } from "./ActivitySyncPanel";
 
 const CANCELABLE_JOB_STATUSES = new Set(["pending", "running"]);
-const TERMINAL_JOB_STATUSES = new Set(["completed", "failed", "cancelled"]);
+const ACTIVE_JOB_STATUSES = ["running", "pending"] as const;
+const TERMINAL_JOB_STATUS_VALUES = ["completed", "failed", "cancelled"] as const;
+const TERMINAL_JOB_STATUSES = new Set<string>(TERMINAL_JOB_STATUS_VALUES);
+const ACTIVE_JOBS_LIMIT = 200;
+const TERMINAL_JOBS_PAGE_SIZE = 50;
 const ACTIVE_JOB_REFETCH_MS = 1500;
+const ACTIVE_JOBS_QUERY_KEY = ["jobs", "activity", "active"] as const;
+const TERMINAL_JOBS_QUERY_KEY = ["jobs", "activity", "terminal"] as const;
 const ACTIVITY_TABS = [
   { id: "jobs", label: "Jobs" },
   { id: "sync", label: "Sync" },
@@ -20,6 +26,8 @@ type DisplayJob = {
   job: JobSchema;
   queuePosition: number | null;
 };
+
+const EMPTY_JOBS: JobSchema[] = [];
 
 function timestampMs(value: string | null | undefined) {
   if (!value) return 0;
@@ -103,6 +111,17 @@ function projectById(projects: ProjectSchema[] | undefined) {
 
 function hasActiveJob(jobs: JobSchema[] | undefined) {
   return jobs?.some((job) => CANCELABLE_JOB_STATUSES.has(job.status)) ?? false;
+}
+
+function uniqueJobs(jobs: JobSchema[]) {
+  const seen = new Set<string>();
+  return jobs.filter((job) => {
+    if (seen.has(job.id)) {
+      return false;
+    }
+    seen.add(job.id);
+    return true;
+  });
 }
 
 function JobProjectLink({
@@ -214,10 +233,40 @@ function JobRow({
 
 export function ActivityView() {
   const [activeTab, setActiveTab] = useState<ActivityTab>("jobs");
+  const previousActiveJobIds = useRef<Set<string>>(new Set());
   const queryClient = useQueryClient();
-  const jobsQuery = useQuery({
-    queryKey: ["jobs"],
-    queryFn: async () => (await api.listJobs()).jobs,
+  const activeJobsQuery = useInfiniteQuery({
+    queryKey: ACTIVE_JOBS_QUERY_KEY,
+    initialPageParam: 0,
+    queryFn: async ({ pageParam }) =>
+      api.listJobs({
+        status: [...ACTIVE_JOB_STATUSES],
+        limit: ACTIVE_JOBS_LIMIT,
+        offset: pageParam,
+      }),
+    getNextPageParam: (lastPage) =>
+      lastPage.has_more ? lastPage.offset + lastPage.jobs.length : undefined,
+  });
+  const {
+    data: activeJobsData,
+    fetchNextPage: fetchNextActiveJobsPage,
+    hasNextPage: hasNextActiveJobsPage,
+    isError: isActiveJobsError,
+    isFetchingNextPage: isFetchingNextActiveJobsPage,
+    isLoading: isActiveJobsLoading,
+    isSuccess: isActiveJobsSuccess,
+  } = activeJobsQuery;
+  const terminalJobsQuery = useInfiniteQuery({
+    queryKey: TERMINAL_JOBS_QUERY_KEY,
+    initialPageParam: 0,
+    queryFn: async ({ pageParam }) =>
+      api.listJobs({
+        status: [...TERMINAL_JOB_STATUS_VALUES],
+        limit: TERMINAL_JOBS_PAGE_SIZE,
+        offset: pageParam,
+      }),
+    getNextPageParam: (lastPage) =>
+      lastPage.has_more ? lastPage.offset + lastPage.jobs.length : undefined,
   });
   const projectsQuery = useQuery({
     queryKey: ["projects", "activity"],
@@ -231,11 +280,20 @@ export function ActivityView() {
   });
 
   const projectsById = useMemo(() => projectById(projectsQuery.data), [projectsQuery.data]);
-  const displayJobs = useMemo(() => orderJobsForQueue(jobsQuery.data ?? []), [jobsQuery.data]);
+  const activeJobs = useMemo(
+    () => activeJobsData?.pages.flatMap((page) => page.jobs) ?? EMPTY_JOBS,
+    [activeJobsData],
+  );
+  const terminalJobs = useMemo(
+    () => terminalJobsQuery.data?.pages.flatMap((page) => page.jobs) ?? [],
+    [terminalJobsQuery.data],
+  );
+  const jobs = useMemo(() => uniqueJobs([...activeJobs, ...terminalJobs]), [activeJobs, terminalJobs]);
+  const displayJobs = useMemo(() => orderJobsForQueue(jobs), [jobs]);
   const activeJobCount = displayJobs.filter(({ job }) => CANCELABLE_JOB_STATUSES.has(job.status)).length;
-  const shouldPollJobs = hasActiveJob(jobsQuery.data);
-  const isLoading = jobsQuery.isLoading || projectsQuery.isLoading;
-  const isError = jobsQuery.isError || projectsQuery.isError;
+  const shouldPollJobs = hasActiveJob(activeJobs);
+  const isLoading = isActiveJobsLoading || terminalJobsQuery.isLoading || projectsQuery.isLoading;
+  const isError = isActiveJobsError || terminalJobsQuery.isError || projectsQuery.isError;
   const showJobList = !isLoading && !isError && displayJobs.length > 0;
   const showEmptyState = !isLoading && !isError && displayJobs.length === 0;
 
@@ -244,13 +302,33 @@ export function ActivityView() {
 
     const interval = window.setInterval(async () => {
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["jobs"] }),
+        queryClient.invalidateQueries({ queryKey: ACTIVE_JOBS_QUERY_KEY }),
         queryClient.invalidateQueries({ queryKey: ["projects", "activity"] }),
       ]);
     }, ACTIVE_JOB_REFETCH_MS);
 
     return () => window.clearInterval(interval);
   }, [queryClient, shouldPollJobs]);
+
+  useEffect(() => {
+    if (!hasNextActiveJobsPage || isFetchingNextActiveJobsPage) return;
+
+    fetchNextActiveJobsPage();
+  }, [fetchNextActiveJobsPage, hasNextActiveJobsPage, isFetchingNextActiveJobsPage]);
+
+  useEffect(() => {
+    if (!isActiveJobsSuccess) return;
+
+    const currentActiveJobIds = new Set(activeJobs.map((job) => job.id));
+    const activeJobLeftQueue = [...previousActiveJobIds.current].some(
+      (jobId) => !currentActiveJobIds.has(jobId),
+    );
+    previousActiveJobIds.current = currentActiveJobIds;
+
+    if (activeJobLeftQueue) {
+      queryClient.invalidateQueries({ queryKey: TERMINAL_JOBS_QUERY_KEY });
+    }
+  }, [activeJobs, isActiveJobsSuccess, queryClient]);
 
   return (
     <section className="screen activity-screen">
@@ -333,6 +411,19 @@ export function ActivityView() {
                 />
               ))}
             </ul>
+          ) : null}
+
+          {terminalJobsQuery.hasNextPage ? (
+            <div className="activity-jobs-panel__load-more">
+              <button
+                className="button button--ghost"
+                disabled={terminalJobsQuery.isFetchingNextPage}
+                onClick={() => terminalJobsQuery.fetchNextPage()}
+                type="button"
+              >
+                {terminalJobsQuery.isFetchingNextPage ? "Loading history..." : "Load more history"}
+              </button>
+            </div>
           ) : null}
 
           {showEmptyState ? (

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -272,8 +272,9 @@ export function useProjectViewModel() {
     enabled: Boolean(projectId),
   });
   const jobsQuery = useQuery({
-    queryKey: ["jobs"],
-    queryFn: async () => (await api.listJobs()).jobs,
+    queryKey: ["jobs", { projectId }],
+    queryFn: async () => (await api.listJobs({ project_id: projectId })).jobs,
+    enabled: Boolean(projectId),
   });
   const mobileCapabilitiesQuery = useQuery({
     queryKey: ["mobile-capabilities"],
@@ -579,10 +580,7 @@ export function useProjectViewModel() {
     },
   });
 
-  const projectJobs = useMemo(
-    () => jobsQuery.data?.filter((job) => job.project_id === projectId) ?? [],
-    [jobsQuery.data, projectId],
-  );
+  const projectJobs = useMemo(() => jobsQuery.data ?? [], [jobsQuery.data]);
   const analyzeJob = projectJobs.find((job) => job.type === "analyze");
   const chordJob = projectJobs.find((job) => job.type === "chords");
   const lyricsJob = projectJobs.find((job) => job.type === "lyrics");

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -34,6 +34,8 @@ export type LyricsSegmentSchema = components["schemas"]["LyricsSegmentSchema"];
 export type LyricsWordSchema = components["schemas"]["LyricsWordSchema"];
 export type ArtifactSchema = components["schemas"]["ArtifactSchema"];
 export type JobSchema = components["schemas"]["JobSchema"];
+export type JobsResponse = components["schemas"]["JobsResponse"];
+export type ListJobsParams = NonNullable<paths["/api/v1/jobs"]["get"]["parameters"]["query"]>;
 export type PreviewRequest = components["schemas"]["PreviewRequest"];
 export type RetuneRequest = components["schemas"]["RetuneRequest"];
 export type ExportRequest = components["schemas"]["ExportRequest"];
@@ -1110,7 +1112,7 @@ export type TuneForgeClient = {
   listArtifacts: (projectId: string) => Promise<components["schemas"]["ArtifactsResponse"]>;
   deleteArtifact: (projectId: string, artifactId: string) => Promise<components["schemas"]["DeleteResponse"]>;
   createExport: (projectId: string, body: ExportRequest) => Promise<components["schemas"]["JobResponse"]>;
-  listJobs: () => Promise<components["schemas"]["JobsResponse"]>;
+  listJobs: (params?: ListJobsParams) => Promise<JobsResponse>;
   getJob: (jobId: string) => Promise<components["schemas"]["JobResponse"]>;
   cancelJob: (jobId: string) => Promise<components["schemas"]["JobResponse"]>;
   getSyncIdentity: () => Promise<SyncLocalIdentityResponse>;
@@ -1323,7 +1325,8 @@ function createHttpTuneForgeClient(): TuneForgeClient {
       ),
     createExport: (projectId: string, body: ExportRequest) =>
       unwrap(client.POST("/api/v1/projects/{project_id}/export", { params: { path: { project_id: projectId } }, body })),
-    listJobs: () => unwrap(client.GET("/api/v1/jobs")),
+    listJobs: (params?: ListJobsParams) =>
+      unwrap(client.GET("/api/v1/jobs", params ? { params: { query: params } } : undefined)),
     getJob: (jobId: string) => unwrap(client.GET("/api/v1/jobs/{job_id}", { params: { path: { job_id: jobId } } })),
     cancelJob: (jobId: string) =>
       unwrap(client.POST("/api/v1/jobs/{job_id}/cancel", { params: { path: { job_id: jobId } } })),
@@ -1413,7 +1416,7 @@ function createMobileTuneForgeClient(capabilities: MobileCapabilities): TuneForg
       invokeMobile("mobile_delete_artifact", { projectId, artifactId }),
     createExport: (projectId: string, body: ExportRequest) =>
       invokeMobile("mobile_submit_export", { projectId, payload: body }),
-    listJobs: () => invokeMobile("mobile_list_jobs"),
+    listJobs: (params?: ListJobsParams) => invokeMobile("mobile_list_jobs", { params: params ?? null }),
     getJob: (jobId: string) => invokeMobile("mobile_get_job", { jobId }),
     cancelJob: (jobId: string) => invokeMobile("mobile_cancel_job", { jobId }),
     getSyncIdentity: async () => {
@@ -1522,7 +1525,7 @@ export const api: TuneForgeClient = {
   listArtifacts: (projectId: string) => activeClient.listArtifacts(projectId),
   deleteArtifact: (projectId: string, artifactId: string) => activeClient.deleteArtifact(projectId, artifactId),
   createExport: (projectId: string, body: ExportRequest) => activeClient.createExport(projectId, body),
-  listJobs: () => activeClient.listJobs(),
+  listJobs: (params?: ListJobsParams) => activeClient.listJobs(params),
   getJob: (jobId: string) => activeClient.getJob(jobId),
   cancelJob: (jobId: string) => activeClient.cancelJob(jobId),
   getSyncIdentity: () => activeClient.getSyncIdentity(),

--- a/apps/desktop/src/styles/activity.css
+++ b/apps/desktop/src/styles/activity.css
@@ -46,6 +46,11 @@
   list-style: none;
 }
 
+.activity-jobs-panel__load-more {
+  display: flex;
+  justify-content: center;
+}
+
 .activity-job-row__article {
   display: grid;
   gap: 0.8rem;

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { vi } from "vitest";
 import App from "../App";
 import type {
+  ListJobsParams,
   SyncPairingAnswerRequest,
   SyncPairingAnswerResponse,
   SyncPairingOfferRequest,
@@ -13,6 +14,8 @@ import type {
   SyncTrustedPeerCreateRequest,
   SyncTrustedPeerResponse,
 } from "../lib/api";
+
+const DEFAULT_JOBS_LIMIT = 50;
 
 const {
   resetMockApiState,
@@ -1177,9 +1180,27 @@ const {
     ),
   );
   const mockListArtifacts = vi.fn(async (projectId: string) => ({ artifacts: clone(state.artifactsByProject[projectId] ?? []) }));
-  const mockListJobs = vi.fn(async () => ({
-    jobs: clone(state.jobs.map((job, index) => normalizeMockJob(job, index))),
-  }));
+  const mockListJobs = vi.fn(async (params?: ListJobsParams) => {
+    const normalizedJobs = state.jobs.map((job, index) => normalizeMockJob(job, index));
+    const statusFilters = Array.isArray(params?.status) ? params.status : [];
+    const filteredJobs = normalizedJobs.filter((job) => {
+      const statusMatches =
+        statusFilters.length === 0 || statusFilters.includes(String(job.status));
+      const projectMatches =
+        params?.project_id == null || job.project_id === params.project_id;
+      return statusMatches && projectMatches;
+    });
+    const offset = params?.offset ?? 0;
+    const limit = params?.limit ?? DEFAULT_JOBS_LIMIT;
+    const jobs = filteredJobs.slice(offset, offset + limit);
+    return {
+      jobs: clone(jobs),
+      total: filteredJobs.length,
+      limit,
+      offset,
+      has_more: offset + jobs.length < filteredJobs.length,
+    };
+  });
   const mockCancelJob = vi.fn(async (jobId: string) => {
     const jobIndex = state.jobs.findIndex((job) => job.id === jobId);
     if (jobIndex === -1) {

--- a/docs/API.md
+++ b/docs/API.md
@@ -54,12 +54,12 @@ If a sort key can be `null`, the endpoint must also document where null values a
 
 ### Pagination Endpoint Audit
 
-This audit captures the current list-like API surface. Until endpoint-specific pagination lands, the individual
-endpoint sections later in this document describe the current unpaginated behavior.
+This audit captures the current list-like API surface. Individual endpoint sections later in this document
+describe current pagination behavior, pending pagination decisions, or explicit unpaginated exceptions.
 
 | Endpoint or payload | List field | Pagination decision |
 | --- | --- | --- |
-| `GET /api/v1/jobs` | `jobs` | Planned paginated growable list. It also needs project-name search and explicit sort controls. Desktop Activity and project job-history consumers should lazy-load this list. |
+| `GET /api/v1/jobs` | `jobs` | Paginated growable list with `status` and `project_id` filters. Default ordering is active-first and deterministic. |
 | `GET /api/v1/projects` | `projects` | Planned paginated growable list while preserving global `search`. Desktop Library consumers should lazy-load this list. |
 | `GET /api/v1/projects/{project_id}/artifacts` | `artifacts` | Planned paginated project child list with project-scoped totals and stable newest-first ordering. Desktop project views should lazy-load this list. |
 | `GET /api/v1/projects/{project_id}/sections` | `sections` | Review with project child lists. Paginate if sections are treated as growable; otherwise document the bounded song-structure exception. |
@@ -686,7 +686,21 @@ Response: `JobResponse`.
 
 `GET /api/v1/jobs`
 
-Returns all jobs ordered by most recently updated.
+Returns a paginated list of jobs.
+
+Query parameters:
+
+- `limit` - page size, default `50`, minimum `1`, maximum `200`.
+- `offset` - zero-based row offset, default `0`, minimum `0`.
+- `status` - optional repeatable status filter, for example `?status=pending&status=running`.
+- `project_id` - optional project ID filter.
+
+Default ordering:
+
+- running jobs first, ordered by `started_at` when present, otherwise `created_at`, ascending, then `id` ascending.
+- pending jobs next, ordered by `created_at` ascending, then `id` ascending.
+- terminal jobs (`completed`, `cancelled`, `failed`) next, ordered by `completed_at` when present, otherwise `updated_at`, descending, then `id` descending.
+- unknown statuses last, ordered by `updated_at` descending, then `id` descending.
 
 Response: `JobsResponse`.
 

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -1035,6 +1035,14 @@ export interface components {
         JobsResponse: {
             /** Jobs */
             jobs: components["schemas"]["JobSchema"][];
+            /** Total */
+            total: number;
+            /** Limit */
+            limit: number;
+            /** Offset */
+            offset: number;
+            /** Has More */
+            has_more: boolean;
         };
         /** LyricsEditSegmentSchema */
         LyricsEditSegmentSchema: {
@@ -3072,7 +3080,16 @@ export interface operations {
     };
     list_jobs_api_v1_jobs_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Filter jobs by status. May be repeated. */
+                status?: string[] | null;
+                /** @description Filter jobs by project ID. */
+                project_id?: string | null;
+                /** @description Maximum number of items to return. */
+                limit?: number;
+                /** @description Number of items to skip before returning results. */
+                offset?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -3086,6 +3103,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["JobsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };


### PR DESCRIPTION
## Summary

- Closes #145.
- Add paginated jobs API filters, metadata, active-first ordering, and generated contracts.
- Update Activity Jobs to load all active jobs while paging terminal history, including mobile/Tauri compatibility.

## Testing

- `cd apps/backend && uv run --python 3.11 pytest tests/test_jobs_api.py tests/test_pagination_contract.py tests/test_pagination.py`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `cd apps/backend && uv run --python 3.11 pytest`
- `pnpm contracts:generate`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop test`
- `pnpm --filter @tuneforge/desktop test --run src/App.activity.test.tsx`
- `pnpm --filter @tuneforge/desktop test --run src/App.project-playback-artifacts.test.tsx`
- `pnpm --filter @tuneforge/desktop typecheck`
- `cd apps/desktop/src-tauri && cargo check`
