### PR TITLE
feat: paginate project list API

### DIFF
--- a/apps/backend/app/api/routes/projects.py
+++ b/apps/backend/app/api/routes/projects.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.api.pagination import PaginationQuery, pagination_metadata
 from app.dependencies import get_db, get_job_runner
 from app.errors import AppError
 from app.models import AnalysisResult, Artifact, ChordTimeline, LyricsTranscript
@@ -157,11 +158,24 @@ def create_project(
 
 @router.get("", response_model=ProjectsResponse)
 def projects(
+    pagination: PaginationQuery,
     search: str | None = Query(default=None, description="Filter projects by display name or path."),
     session: Session = Depends(get_db),
 ) -> ProjectsResponse:
-    projects_payload = [ProjectSchema.model_validate(project) for project in list_projects(session, search=search)]
-    return ProjectsResponse(projects=projects_payload)
+    listed_projects = list_projects(
+        session,
+        limit=pagination.limit,
+        offset=pagination.offset,
+        search=search,
+    )
+    projects_payload = [ProjectSchema.model_validate(project) for project in listed_projects.projects]
+    metadata = pagination_metadata(
+        total=listed_projects.total,
+        limit=pagination.limit,
+        offset=pagination.offset,
+        number_of_returned_items=len(projects_payload),
+    )
+    return ProjectsResponse(projects=projects_payload, **metadata)
 
 
 @router.get("/{project_id}", response_model=ProjectResponse)

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -147,6 +147,10 @@ class ProjectResponse(BaseModel):
 
 class ProjectsResponse(BaseModel):
     projects: list[ProjectSchema]
+    total: int
+    limit: int
+    offset: int
+    has_more: bool
 
 
 class DeleteResponse(BaseModel):

--- a/apps/backend/app/services/projects.py
+++ b/apps/backend/app/services/projects.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from fastapi import status
 from sqlalchemy import func, or_, select
@@ -25,6 +27,12 @@ from app.services.sync_tombstones import (
 from app.utils.hashing import file_sha256
 
 
+@dataclass(frozen=True, slots=True)
+class ListedProjects:
+    projects: list[Project]
+    total: int
+
+
 def ensure_project_mutable(project: Project) -> None:
     require_project_sync_editable(project)
 
@@ -40,12 +48,18 @@ def _validate_import_path(source_path: Path) -> None:
         )
 
 
-def list_projects(session: Session, *, search: str | None = None) -> list[Project]:
-    stmt = select(Project).where(Project.sync_status != "deleted")
+def list_projects(
+    session: Session,
+    *,
+    limit: int,
+    offset: int,
+    search: str | None = None,
+) -> ListedProjects:
+    filters: list[Any] = [Project.sync_status != "deleted"]
     normalized_search = (search or "").strip().lower()
     if normalized_search:
         like_term = f"%{normalized_search}%"
-        stmt = stmt.where(
+        filters.append(
             or_(
                 func.lower(Project.display_name).like(like_term),
                 func.lower(Project.source_path).like(like_term),
@@ -53,8 +67,17 @@ def list_projects(session: Session, *, search: str | None = None) -> list[Projec
             )
         )
 
-    stmt = stmt.order_by(Project.updated_at.desc())
-    return list(session.scalars(stmt))
+    total_statement = select(func.count()).select_from(Project).where(*filters)
+    projects_statement = (
+        select(Project)
+        .where(*filters)
+        .order_by(Project.updated_at.desc(), Project.id.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    total = session.scalar(total_statement) or 0
+    projects = list(session.scalars(projects_statement))
+    return ListedProjects(projects=projects, total=total)
 
 
 def get_project(session: Session, project_id: str) -> Project:

--- a/apps/backend/tests/test_pagination_contract.py
+++ b/apps/backend/tests/test_pagination_contract.py
@@ -5,12 +5,12 @@ from app.main import app
 LIST_RESPONSE_CONTRACTS = {
     ("/api/v1/chord-backends", "get"): ("ChordBackendsResponse", "backends", True),
     ("/api/v1/stem-models", "get"): ("StemModelsResponse", "models", True),
-    ("/api/v1/projects", "get"): ("ProjectsResponse", "projects", True),
     ("/api/v1/projects/{project_id}/sections", "get"): ("SongSectionsResponse", "sections", False),
     ("/api/v1/projects/{project_id}/artifacts", "get"): ("ArtifactsResponse", "artifacts", True),
     ("/api/v1/sync/trusted-peers", "get"): ("SyncTrustedPeersResponse", "trusted_peers", True),
 }
 PAGINATED_LIST_RESPONSE_CONTRACTS = {
+    ("/api/v1/projects", "get"): ("ProjectsResponse", "projects"),
     ("/api/v1/jobs", "get"): ("JobsResponse", "jobs"),
 }
 

--- a/apps/backend/tests/test_projects.py
+++ b/apps/backend/tests/test_projects.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -46,6 +46,28 @@ def _wait_for_project_job(client, project_id: str, predicate, *, timeout: float 
                 return job
         time.sleep(0.1)
     raise AssertionError(f"Timed out waiting for matching job in project {project_id}")
+
+
+def _insert_project_rows(
+    tmp_path: Path,
+    rows: list[tuple[str, str, datetime, str]],
+) -> None:
+    with SessionLocal() as session:
+        for index, row in enumerate(rows, start=1):
+            project_id, display_name, updated_at, sync_status = row
+            session.add(
+                Project(
+                    id=project_id,
+                    display_name=display_name,
+                    source_sha256=f"{index:064x}",
+                    source_path=str(tmp_path / f"{project_id}-source.wav"),
+                    imported_path=str(tmp_path / f"{project_id}-imported.wav"),
+                    sync_status=sync_status,
+                    created_at=updated_at,
+                    updated_at=updated_at,
+                )
+            )
+        session.commit()
 
 
 def test_import_project_persists_metadata_and_source_artifact(client, sample_audio_file: Path):
@@ -572,9 +594,157 @@ def test_project_list_can_filter_by_search_term(
     response = client.get("/api/v1/projects", params={"search": "choir"})
 
     assert response.status_code == 200
-    projects = response.json()["projects"]
+    payload = response.json()
+    projects = payload["projects"]
     assert len(projects) == 1
     assert projects[0]["display_name"] == "Choir Warmup"
+    assert payload["total"] == 1
+    assert payload["limit"] == 50
+    assert payload["offset"] == 0
+    assert payload["has_more"] is False
+
+
+def test_project_list_returns_empty_pagination_metadata(client):
+    response = client.get("/api/v1/projects")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["projects"] == []
+    assert payload["total"] == 0
+    assert payload["limit"] == 50
+    assert payload["offset"] == 0
+    assert payload["has_more"] is False
+
+
+def test_project_list_returns_empty_search_pagination_metadata(client, tmp_path: Path):
+    _insert_project_rows(
+        tmp_path,
+        [
+            ("proj_search_empty", "Visible Song", datetime(2026, 1, 1, tzinfo=UTC), "local"),
+        ],
+    )
+
+    response = client.get("/api/v1/projects", params={"search": "missing"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["projects"] == []
+    assert payload["total"] == 0
+    assert payload["limit"] == 50
+    assert payload["offset"] == 0
+    assert payload["has_more"] is False
+
+
+def test_project_list_exact_page_size_has_no_more_results(client, tmp_path: Path):
+    base_time = datetime(2026, 1, 1, tzinfo=UTC)
+    _insert_project_rows(
+        tmp_path,
+        [
+            (f"proj_exact_{index}", f"Exact Song {index}", base_time + timedelta(minutes=index), "local")
+            for index in range(3)
+        ],
+    )
+
+    response = client.get("/api/v1/projects", params={"limit": 3})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [project["id"] for project in payload["projects"]] == [
+        "proj_exact_2",
+        "proj_exact_1",
+        "proj_exact_0",
+    ]
+    assert payload["total"] == 3
+    assert payload["limit"] == 3
+    assert payload["offset"] == 0
+    assert payload["has_more"] is False
+
+
+def test_project_list_returns_pagination_metadata_and_page_boundaries(client, tmp_path: Path):
+    base_time = datetime(2026, 1, 1, tzinfo=UTC)
+    _insert_project_rows(
+        tmp_path,
+        [
+            (f"proj_page_{index}", f"Page Song {index}", base_time + timedelta(minutes=index), "local")
+            for index in range(5)
+        ],
+    )
+
+    middle_page = client.get("/api/v1/projects", params={"limit": 2, "offset": 2})
+
+    assert middle_page.status_code == 200
+    middle_payload = middle_page.json()
+    assert [project["id"] for project in middle_payload["projects"]] == ["proj_page_2", "proj_page_1"]
+    assert middle_payload["total"] == 5
+    assert middle_payload["limit"] == 2
+    assert middle_payload["offset"] == 2
+    assert middle_payload["has_more"] is True
+
+    last_page = client.get("/api/v1/projects", params={"limit": 2, "offset": 4})
+
+    assert last_page.status_code == 200
+    last_payload = last_page.json()
+    assert [project["id"] for project in last_payload["projects"]] == ["proj_page_0"]
+    assert last_payload["total"] == 5
+    assert last_payload["limit"] == 2
+    assert last_payload["offset"] == 4
+    assert last_payload["has_more"] is False
+
+
+def test_project_list_search_applies_before_pagination(client, tmp_path: Path):
+    base_time = datetime(2026, 1, 1, tzinfo=UTC)
+    _insert_project_rows(
+        tmp_path,
+        [
+            ("proj_recent_2", "Recent Song 2", base_time + timedelta(minutes=4), "local"),
+            ("proj_recent_1", "Recent Song 1", base_time + timedelta(minutes=3), "local"),
+            ("proj_recent_0", "Recent Song 0", base_time + timedelta(minutes=2), "local"),
+            ("proj_needle", "Deep Needle Match", base_time + timedelta(minutes=1), "local"),
+        ],
+    )
+
+    response = client.get("/api/v1/projects", params={"search": "needle", "limit": 1, "offset": 0})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [project["id"] for project in payload["projects"]] == ["proj_needle"]
+    assert payload["total"] == 1
+    assert payload["has_more"] is False
+
+
+def test_project_list_uses_project_id_as_updated_at_tie_breaker(client, tmp_path: Path):
+    tied_time = datetime(2026, 1, 1, tzinfo=UTC)
+    _insert_project_rows(
+        tmp_path,
+        [
+            ("proj_tie_a", "Tie A", tied_time, "local"),
+            ("proj_tie_c", "Tie C", tied_time, "local"),
+            ("proj_tie_b", "Tie B", tied_time, "local"),
+        ],
+    )
+
+    response = client.get("/api/v1/projects", params={"limit": 3})
+
+    assert response.status_code == 200
+    assert [project["id"] for project in response.json()["projects"]] == [
+        "proj_tie_c",
+        "proj_tie_b",
+        "proj_tie_a",
+    ]
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"limit": 0},
+        {"limit": 201},
+        {"offset": -1},
+    ],
+)
+def test_project_list_rejects_invalid_pagination_params(client, params: dict[str, int]):
+    response = client.get("/api/v1/projects", params=params)
+
+    assert response.status_code == 422
 
 
 def test_project_list_hides_deleted_sync_placeholders(client, tmp_path: Path):
@@ -605,8 +775,11 @@ def test_project_list_hides_deleted_sync_placeholders(client, tmp_path: Path):
     response = client.get("/api/v1/projects")
 
     assert response.status_code == 200
-    projects = response.json()["projects"]
+    payload = response.json()
+    projects = payload["projects"]
     assert [project["id"] for project in projects] == ["proj_visible_local"]
+    assert payload["total"] == 1
+    assert payload["has_more"] is False
 
 
 def test_import_project_replaces_deleted_sync_placeholder(

--- a/apps/desktop/src-tauri/src/mobile_backend.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend.rs
@@ -73,6 +73,19 @@ pub struct ProjectResponse {
 #[derive(Serialize)]
 pub struct ProjectsResponse {
     projects: Vec<ProjectSchema>,
+    total: usize,
+    limit: usize,
+    offset: usize,
+    has_more: bool,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+pub struct ListProjectsParams {
+    search: Option<String>,
+    limit: Option<i64>,
+    offset: Option<i64>,
 }
 
 #[derive(Clone, Serialize)]
@@ -225,7 +238,7 @@ macro_rules! mobile_stub {
 #[cfg(not(target_os = "android"))]
 mobile_stub!(mobile_get_health, HealthResponse, app: AppHandle);
 #[cfg(not(target_os = "android"))]
-mobile_stub!(mobile_list_projects, ProjectsResponse, app: AppHandle, search: Option<String>);
+mobile_stub!(mobile_list_projects, ProjectsResponse, app: AppHandle, params: Option<ListProjectsParams>);
 #[cfg(not(target_os = "android"))]
 mobile_stub!(mobile_import_project, ProjectResponse, app: AppHandle, payload: ProjectImportRequest);
 #[cfg(not(target_os = "android"))]
@@ -297,6 +310,8 @@ mod android {
     const WHISPER_MODEL_DIR: &str = "models/whisper";
     const WHISPER_MODEL_MISSING: &str =
         "Side-load a Whisper ggml model into app storage at models/whisper/ggml-base.bin or models/whisper/ggml-tiny.bin to enable local lyrics.";
+    const DEFAULT_PROJECTS_LIMIT: usize = 50;
+    const MAX_PROJECTS_LIMIT: usize = 200;
     const DEFAULT_JOBS_LIMIT: usize = 50;
     const MAX_JOBS_LIMIT: usize = 200;
 
@@ -393,6 +408,27 @@ mod android {
 
     fn now_iso() -> String {
         Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+    }
+
+    fn normalized_projects_limit(value: Option<i64>) -> Result<usize, String> {
+        let limit = value.unwrap_or(DEFAULT_PROJECTS_LIMIT as i64);
+        if limit < 1 {
+            return Err("Project list limit must be at least 1.".to_string());
+        }
+        if limit > MAX_PROJECTS_LIMIT as i64 {
+            return Err(format!(
+                "Project list limit must be less than or equal to {MAX_PROJECTS_LIMIT}."
+            ));
+        }
+        Ok(limit as usize)
+    }
+
+    fn normalized_projects_offset(value: Option<i64>) -> Result<usize, String> {
+        let offset = value.unwrap_or(0);
+        if offset < 0 {
+            return Err("Project list offset must be at least 0.".to_string());
+        }
+        Ok(offset as usize)
     }
 
     fn normalized_jobs_limit(value: Option<i64>) -> Result<usize, String> {
@@ -1701,28 +1737,71 @@ mod android {
     #[tauri::command]
     pub fn mobile_list_projects(
         app: AppHandle,
-        search: Option<String>,
+        params: Option<ListProjectsParams>,
     ) -> Result<ProjectsResponse, String> {
+        let params = params.unwrap_or_default();
+        let limit = normalized_projects_limit(params.limit)?;
+        let offset = normalized_projects_offset(params.offset)?;
         let connection = db(&app)?;
-        let mut statement = connection
-            .prepare("SELECT id, display_name, source_key_override, source_path, imported_path, duration_seconds, sample_rate, channels, created_at, updated_at FROM projects ORDER BY updated_at DESC")
-            .map_err(|error| error.to_string())?;
-        let needle = search.unwrap_or_default().to_ascii_lowercase();
-        let rows = statement
-            .query_map([], row_project)
-            .map_err(|error| error.to_string())?;
-        let mut projects = Vec::new();
-        for row in rows {
-            let project = row.map_err(|error| error.to_string())?;
-            if needle.is_empty()
-                || project.display_name.to_ascii_lowercase().contains(&needle)
-                || project.source_path.to_ascii_lowercase().contains(&needle)
-                || project.imported_path.to_ascii_lowercase().contains(&needle)
-            {
-                projects.push(project);
+        let needle = params
+            .search
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase();
+        let limit = limit as i64;
+        let offset = offset as i64;
+        let (projects, total) = if needle.is_empty() {
+            let total = connection
+                .query_row("SELECT COUNT(*) FROM projects", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .map_err(|error| error.to_string())?;
+            let mut statement = connection
+                .prepare(
+                    "SELECT id, display_name, source_key_override, source_path, imported_path, duration_seconds, sample_rate, channels, created_at, updated_at FROM projects ORDER BY updated_at DESC, id DESC LIMIT ?1 OFFSET ?2",
+                )
+                .map_err(|error| error.to_string())?;
+            let rows = statement
+                .query_map(params![limit, offset], row_project)
+                .map_err(|error| error.to_string())?;
+            let mut projects = Vec::new();
+            for row in rows {
+                projects.push(row.map_err(|error| error.to_string())?);
             }
-        }
-        Ok(ProjectsResponse { projects })
+            (projects, total as usize)
+        } else {
+            let like_term = format!("%{needle}%");
+            let total = connection
+                .query_row(
+                    "SELECT COUNT(*) FROM projects WHERE lower(display_name) LIKE ?1 OR lower(source_path) LIKE ?1 OR lower(imported_path) LIKE ?1",
+                    params![&like_term],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map_err(|error| error.to_string())?;
+            let mut statement = connection
+                .prepare(
+                    "SELECT id, display_name, source_key_override, source_path, imported_path, duration_seconds, sample_rate, channels, created_at, updated_at FROM projects WHERE lower(display_name) LIKE ?1 OR lower(source_path) LIKE ?1 OR lower(imported_path) LIKE ?1 ORDER BY updated_at DESC, id DESC LIMIT ?2 OFFSET ?3",
+                )
+                .map_err(|error| error.to_string())?;
+            let rows = statement
+                .query_map(params![&like_term, limit, offset], row_project)
+                .map_err(|error| error.to_string())?;
+            let mut projects = Vec::new();
+            for row in rows {
+                projects.push(row.map_err(|error| error.to_string())?);
+            }
+            (projects, total as usize)
+        };
+        let limit = limit as usize;
+        let offset = offset as usize;
+        let has_more = offset.saturating_add(projects.len()) < total;
+        Ok(ProjectsResponse {
+            projects,
+            total,
+            limit,
+            offset,
+            has_more,
+        })
     }
 
     #[tauri::command]

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { normalizeSyncTransportStatus, type JobSchema, type ProjectSchema } from "./lib/api";
 import {
   mockCancelJob,
+  mockGetProject,
   mockGetSyncIdentity,
   mockGetSyncTransportStatus,
   mockAnswerSyncPairingOffer,
@@ -100,7 +101,7 @@ describe("Desktop app activity", () => {
     expect(await screen.findByRole("heading", { level: 1, name: "Activity" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Jobs" })).toHaveAttribute("aria-selected", "true");
     expect(mockListJobs).toHaveBeenCalled();
-    expect(mockListProjects).toHaveBeenCalled();
+    await waitFor(() => expect(mockGetProject).toHaveBeenCalledWith("proj_123"));
   });
 
   it("requests active and terminal job pages separately", async () => {
@@ -120,6 +121,62 @@ describe("Desktop app activity", () => {
       offset: 0,
     });
     expect(mockListJobs.mock.calls.some(([params]) => params === undefined)).toBe(false);
+  });
+
+  it("resolves job project names from project details outside the first project page", async () => {
+    const deepProjectId = "proj_055";
+    setProjects(
+      Array.from({ length: 55 }, (_, index) => {
+        const projectNumber = index + 1;
+        const projectId = `proj_${String(projectNumber).padStart(3, "0")}`;
+        return project({
+          id: projectId,
+          display_name: projectId === deepProjectId ? "Deep Catalog Song" : `Catalog Song ${projectNumber}`,
+        });
+      }),
+    );
+    setJobs([
+      job({
+        id: "job_deep_project",
+        project_id: deepProjectId,
+        type: "lyrics",
+        status: "completed",
+        progress: 100,
+      }),
+    ]);
+
+    renderApp(["/activity"]);
+
+    const row = await screen.findByRole("article", { name: "lyrics completed job" });
+    expect(within(row).getByRole("link", { name: "Open Deep Catalog Song project" })).toHaveAttribute(
+      "href",
+      `/projects/${deepProjectId}`,
+    );
+    await waitFor(() => expect(mockGetProject).toHaveBeenCalledWith(deepProjectId));
+    expect(mockListProjects).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the project ID when a job project no longer exists", async () => {
+    setProjects([project({ id: "proj_123", display_name: "Demo Song" })]);
+    setJobs([
+      job({
+        id: "job_deleted_project",
+        project_id: "proj_deleted",
+        type: "preview",
+        status: "completed",
+        progress: 100,
+      }),
+    ]);
+
+    renderApp(["/activity"]);
+
+    const row = await screen.findByRole("article", { name: "preview completed job" });
+    expect(within(row).getByRole("link", { name: "Open proj_deleted project" })).toHaveAttribute(
+      "href",
+      "/projects/proj_deleted",
+    );
+    await waitFor(() => expect(mockGetProject).toHaveBeenCalledWith("proj_deleted"));
+    expect(mockListProjects).not.toHaveBeenCalled();
   });
 
   it("automatically loads additional active job pages", async () => {
@@ -993,6 +1050,63 @@ describe("Desktop app activity", () => {
     );
   });
 
+  it("keeps loaded history visible while new project details are loading", async () => {
+    const user = userEvent.setup();
+    let resolveSlowProject: () => void = () => {
+      throw new Error("Slow project lookup did not start.");
+    };
+    const defaultGetProjectImplementation = mockGetProject.getMockImplementation();
+    mockGetProject.mockImplementation(
+      async (projectId: string) =>
+        new Promise((resolve) => {
+          if (projectId === "proj_slow_history") {
+            resolveSlowProject = () =>
+              resolve({ project: project({ id: projectId, display_name: "Slow History Project" }) as ProjectSchema });
+            return;
+          }
+          resolve({ project: project({ id: projectId }) as ProjectSchema });
+        }),
+    );
+    try {
+      setJobs(
+        Array.from({ length: 51 }, (_, index) => {
+          const jobNumber = index + 1;
+          return job({
+            id: `job_history_${String(jobNumber).padStart(3, "0")}`,
+            project_id: jobNumber === 51 ? "proj_slow_history" : null,
+            type: `history_${String(jobNumber).padStart(3, "0")}`,
+            status: "completed",
+            progress: 100,
+            completed_at: `2026-04-18T13:${String(59 - index).padStart(2, "0")}:00.000Z`,
+            created_at: "2026-04-18T13:00:00.000Z",
+            updated_at: `2026-04-18T13:${String(59 - index).padStart(2, "0")}:00.000Z`,
+          });
+        }),
+      );
+
+      renderApp(["/activity"]);
+
+      expect(await screen.findByRole("article", { name: "history_001 completed job" })).toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: "Load more history" }));
+
+      const loadedRow = await screen.findByRole("article", { name: "history_051 completed job" });
+      expect(within(loadedRow).getByRole("link", { name: "Open proj_slow_history project" })).toHaveAttribute(
+        "href",
+        "/projects/proj_slow_history",
+      );
+      expect(screen.queryByText("Loading jobs...")).not.toBeInTheDocument();
+
+      resolveSlowProject();
+      expect(
+        await within(loadedRow).findByRole("link", { name: "Open Slow History Project project" }),
+      ).toHaveAttribute("href", "/projects/proj_slow_history");
+    } finally {
+      if (defaultGetProjectImplementation) {
+        mockGetProject.mockImplementation(defaultGetProjectImplementation);
+      }
+    }
+  });
+
   it("cancels pending jobs and refreshes the queue", async () => {
     const user = userEvent.setup();
     setJobs([
@@ -1059,8 +1173,18 @@ describe("Desktop app activity", () => {
       renderApp(["/activity"]);
 
       expect(await screen.findByRole("article", { name: "stems running job" })).toBeInTheDocument();
+      await waitFor(() => expect(mockGetProject).toHaveBeenCalledWith("proj_123"));
       expect(intervalHandlers).toHaveLength(1);
       const initialListJobsCalls = mockListJobs.mock.calls.length;
+      const initialGetProjectCalls = mockGetProject.mock.calls.length;
+
+      await act(async () => {
+        await intervalHandlers[0]?.();
+      });
+
+      await waitFor(() => expect(mockListJobs.mock.calls.length).toBeGreaterThan(initialListJobsCalls));
+      expect(mockGetProject).toHaveBeenCalledTimes(initialGetProjectCalls);
+      const listJobsCallsAfterActivePoll = mockListJobs.mock.calls.length;
 
       setJobs([
         job({
@@ -1080,9 +1204,10 @@ describe("Desktop app activity", () => {
         await intervalHandlers[0]?.();
       });
 
-      await waitFor(() => expect(mockListJobs.mock.calls.length).toBeGreaterThan(initialListJobsCalls));
+      await waitFor(() => expect(mockListJobs.mock.calls.length).toBeGreaterThan(listJobsCallsAfterActivePoll));
       const completedRow = await screen.findByRole("article", { name: "stems completed job" });
       expect(within(completedRow).queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument();
+      expect(mockGetProject).toHaveBeenCalledTimes(initialGetProjectCalls);
       expect(clearIntervalSpy).toHaveBeenCalledWith(1500);
     } finally {
       setIntervalSpy.mockRestore();

--- a/apps/desktop/src/App.library.test.tsx
+++ b/apps/desktop/src/App.library.test.tsx
@@ -48,9 +48,45 @@ describe("Desktop app library", () => {
     expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
     await user.type(screen.getByLabelText("Search projects"), "choir");
 
-    await waitFor(() => expect(mockListProjects).toHaveBeenLastCalledWith("choir"));
+    await waitFor(() =>
+      expect(mockListProjects).toHaveBeenLastCalledWith({ search: "choir", limit: 50, offset: 0 }),
+    );
     expect(screen.getByText("Choir Warmup")).toBeInTheDocument();
     expect(screen.queryByText("Bass Drill")).not.toBeInTheDocument();
+  });
+
+  it("loads additional project pages on request", async () => {
+    const user = userEvent.setup();
+    setProjects(
+      Array.from({ length: 55 }, (_, index) => {
+        const projectNumber = index + 1;
+        return {
+          id: `proj_${String(projectNumber).padStart(3, "0")}`,
+          display_name: `Project ${projectNumber}`,
+          source_path: `/tmp/project-${projectNumber}.wav`,
+          imported_path: `/tmp/projects/project-${projectNumber}.wav`,
+          duration_seconds: 120,
+          sample_rate: 44100,
+          channels: 2,
+          created_at: "2026-04-18T13:16:00.000Z",
+          updated_at: "2026-04-18T13:16:00.000Z",
+        };
+      }),
+    );
+
+    renderApp(["/"]);
+
+    expect(await screen.findByText("50 of 55 projects loaded")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Project 1", level: 2 })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Project 55", level: 2 })).not.toBeInTheDocument();
+    expect(mockListProjects).toHaveBeenCalledWith({ limit: 50, offset: 0 });
+
+    await user.click(screen.getByRole("button", { name: "Load more projects" }));
+
+    expect(await screen.findByRole("heading", { name: "Project 55", level: 2 })).toBeInTheDocument();
+    expect(screen.getByText("55 projects ready")).toBeInTheDocument();
+    expect(mockListProjects).toHaveBeenCalledWith({ limit: 50, offset: 50 });
+    expect(screen.queryByRole("button", { name: "Load more projects" })).not.toBeInTheDocument();
   });
 
   it("renders project cards with local timestamps and without filename subtitles", async () => {

--- a/apps/desktop/src/features/activity/ActivityView.tsx
+++ b/apps/desktop/src/features/activity/ActivityView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useInfiniteQuery, useMutation, useQueries, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import { api, type JobSchema, type ProjectSchema } from "../../lib/api";
 import { formatLocalDateTime, normalizeApiDateTime, parseApiDateTime } from "../../lib/datetime";
@@ -15,6 +15,8 @@ const TERMINAL_JOBS_PAGE_SIZE = 50;
 const ACTIVE_JOB_REFETCH_MS = 1500;
 const ACTIVE_JOBS_QUERY_KEY = ["jobs", "activity", "active"] as const;
 const TERMINAL_JOBS_QUERY_KEY = ["jobs", "activity", "terminal"] as const;
+const ACTIVITY_PROJECTS_QUERY_KEY = ["projects", "activity"] as const;
+const ACTIVITY_PROJECT_STALE_MS = 5 * 60 * 1000;
 const ACTIVITY_TABS = [
   { id: "jobs", label: "Jobs" },
   { id: "sync", label: "Sync" },
@@ -103,10 +105,6 @@ function formatJobDetails(job: JobSchema) {
 
 function progressValue(job: JobSchema) {
   return Math.max(0, Math.min(100, Math.round(job.progress)));
-}
-
-function projectById(projects: ProjectSchema[] | undefined) {
-  return new Map((projects ?? []).map((project) => [project.id, project]));
 }
 
 function hasActiveJob(jobs: JobSchema[] | undefined) {
@@ -268,18 +266,6 @@ export function ActivityView() {
     getNextPageParam: (lastPage) =>
       lastPage.has_more ? lastPage.offset + lastPage.jobs.length : undefined,
   });
-  const projectsQuery = useQuery({
-    queryKey: ["projects", "activity"],
-    queryFn: async () => (await api.listProjects()).projects,
-  });
-  const cancelJobMutation = useMutation({
-    mutationFn: (jobId: string) => api.cancelJob(jobId),
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["jobs"] });
-    },
-  });
-
-  const projectsById = useMemo(() => projectById(projectsQuery.data), [projectsQuery.data]);
   const activeJobs = useMemo(
     () => activeJobsData?.pages.flatMap((page) => page.jobs) ?? EMPTY_JOBS,
     [activeJobsData],
@@ -289,11 +275,47 @@ export function ActivityView() {
     [terminalJobsQuery.data],
   );
   const jobs = useMemo(() => uniqueJobs([...activeJobs, ...terminalJobs]), [activeJobs, terminalJobs]);
+  const jobProjectIds = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          jobs
+            .map((job) => job.project_id)
+            .filter((projectId): projectId is string => Boolean(projectId)),
+        ),
+      ).sort(),
+    [jobs],
+  );
+  const projectQueries = useQueries({
+    queries: jobProjectIds.map((projectId) => ({
+      queryKey: [...ACTIVITY_PROJECTS_QUERY_KEY, "detail", projectId],
+      staleTime: ACTIVITY_PROJECT_STALE_MS,
+      queryFn: async () => {
+        try {
+          const response = await api.getProject(projectId);
+          return response.project;
+        } catch {
+          return null;
+        }
+      },
+    })),
+  });
+  const cancelJobMutation = useMutation({
+    mutationFn: (jobId: string) => api.cancelJob(jobId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["jobs"] });
+    },
+  });
+
+  const projectsById = useMemo(
+    () => new Map(jobProjectIds.map((projectId, index) => [projectId, projectQueries[index]?.data ?? null])),
+    [jobProjectIds, projectQueries],
+  );
   const displayJobs = useMemo(() => orderJobsForQueue(jobs), [jobs]);
   const activeJobCount = displayJobs.filter(({ job }) => CANCELABLE_JOB_STATUSES.has(job.status)).length;
   const shouldPollJobs = hasActiveJob(activeJobs);
-  const isLoading = isActiveJobsLoading || terminalJobsQuery.isLoading || projectsQuery.isLoading;
-  const isError = isActiveJobsError || terminalJobsQuery.isError || projectsQuery.isError;
+  const isLoading = isActiveJobsLoading || terminalJobsQuery.isLoading;
+  const isError = isActiveJobsError || terminalJobsQuery.isError;
   const showJobList = !isLoading && !isError && displayJobs.length > 0;
   const showEmptyState = !isLoading && !isError && displayJobs.length === 0;
 
@@ -301,10 +323,7 @@ export function ActivityView() {
     if (!shouldPollJobs) return;
 
     const interval = window.setInterval(async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ACTIVE_JOBS_QUERY_KEY }),
-        queryClient.invalidateQueries({ queryKey: ["projects", "activity"] }),
-      ]);
+      await queryClient.invalidateQueries({ queryKey: ACTIVE_JOBS_QUERY_KEY });
     }, ACTIVE_JOB_REFETCH_MS);
 
     return () => window.clearInterval(interval);

--- a/apps/desktop/src/features/projects/LibraryView.tsx
+++ b/apps/desktop/src/features/projects/LibraryView.tsx
@@ -1,5 +1,5 @@
 import { startTransition, useDeferredValue, useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { open } from "@tauri-apps/plugin-dialog";
 import { Music2, Upload } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
@@ -9,6 +9,7 @@ import { usePreferences } from "../../lib/preferences";
 import { useChordBackendActionSelection } from "./hooks/useChordBackendActionSelection";
 
 const MAX_IMPORT_SELECTION = 25;
+const LIBRARY_PROJECTS_PAGE_SIZE = 50;
 
 function formatDuration(durationSeconds: number | null | undefined) {
   if (!durationSeconds) return "Unknown length";
@@ -247,9 +248,17 @@ export function LibraryView() {
   const deferredSearch = useDeferredValue(searchDraft.trim());
   const showSubtitle = informationDensity !== "minimal";
 
-  const projectsQuery = useQuery({
+  const projectsQuery = useInfiniteQuery({
     queryKey: ["projects", deferredSearch],
-    queryFn: async () => (await api.listProjects(deferredSearch || undefined)).projects,
+    initialPageParam: 0,
+    queryFn: ({ pageParam }) =>
+      api.listProjects({
+        ...(deferredSearch ? { search: deferredSearch } : {}),
+        limit: LIBRARY_PROJECTS_PAGE_SIZE,
+        offset: pageParam,
+      }),
+    getNextPageParam: (lastPage) =>
+      lastPage.has_more ? lastPage.offset + lastPage.projects.length : undefined,
   });
 
   const importMutation = useMutation({
@@ -353,7 +362,11 @@ export function LibraryView() {
     },
   });
 
-  const resultCount = projectsQuery.data?.length ?? 0;
+  const projectPages = projectsQuery.data?.pages ?? [];
+  const projects = projectPages.flatMap((page) => page.projects);
+  const loadedProjectCount = projects.length;
+  const totalProjectCount = projectPages[0]?.total ?? 0;
+  const hasLoadedAllProjects = loadedProjectCount >= totalProjectCount;
 
   return (
     <section className="screen">
@@ -410,16 +423,21 @@ export function LibraryView() {
         </label>
         <div className="library-toolbar__summary" aria-live="polite">
           {deferredSearch ? (
-            resultCount ? (
+            totalProjectCount ? (
               <span>
-                {resultCount} match{resultCount === 1 ? "" : "es"} for "{deferredSearch}"
+                {hasLoadedAllProjects
+                  ? `${totalProjectCount} match${totalProjectCount === 1 ? "" : "es"}`
+                  : `${loadedProjectCount} of ${totalProjectCount} matches loaded`}{" "}
+                for "{deferredSearch}"
               </span>
             ) : (
               <span>No matches for "{deferredSearch}"</span>
             )
           ) : (
             <span>
-              {resultCount} project{resultCount === 1 ? "" : "s"} ready
+              {hasLoadedAllProjects
+                ? `${totalProjectCount} project${totalProjectCount === 1 ? "" : "s"} ready`
+                : `${loadedProjectCount} of ${totalProjectCount} projects loaded`}
             </span>
           )}
         </div>
@@ -431,7 +449,7 @@ export function LibraryView() {
       ) : null}
 
       <div className="project-grid project-library-table">
-        {projectsQuery.data?.length ? (
+        {projects.length ? (
           <>
             <div className="project-library-table__header" aria-hidden="true">
               <span />
@@ -439,9 +457,9 @@ export function LibraryView() {
               <span>Updated</span>
               <span>Format / Duration</span>
             </div>
-            {projectsQuery.data.map((project) => <ProjectCard key={project.id} project={project} />)}
+            {projects.map((project) => <ProjectCard key={project.id} project={project} />)}
           </>
-        ) : (
+        ) : !projectsQuery.isLoading && !projectsQuery.isError ? (
           <div className="panel panel--empty">
             <h2>{deferredSearch ? "No matching projects" : "No projects yet"}</h2>
             <p>
@@ -450,8 +468,20 @@ export function LibraryView() {
                 : "Import a track to create the first playback-ready project."}
             </p>
           </div>
-        )}
+        ) : null}
       </div>
+      {projectsQuery.hasNextPage ? (
+        <div className="library-load-more">
+          <button
+            className="button button--ghost"
+            disabled={projectsQuery.isFetchingNextPage}
+            onClick={() => projectsQuery.fetchNextPage()}
+            type="button"
+          >
+            {projectsQuery.isFetchingNextPage ? "Loading projects..." : "Load more projects"}
+          </button>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -35,6 +35,7 @@ export type LyricsWordSchema = components["schemas"]["LyricsWordSchema"];
 export type ArtifactSchema = components["schemas"]["ArtifactSchema"];
 export type JobSchema = components["schemas"]["JobSchema"];
 export type JobsResponse = components["schemas"]["JobsResponse"];
+export type ListProjectsParams = NonNullable<paths["/api/v1/projects"]["get"]["parameters"]["query"]>;
 export type ListJobsParams = NonNullable<paths["/api/v1/jobs"]["get"]["parameters"]["query"]>;
 export type PreviewRequest = components["schemas"]["PreviewRequest"];
 export type RetuneRequest = components["schemas"]["RetuneRequest"];
@@ -1112,7 +1113,7 @@ async function createNativeSyncPairingOffer(body: SyncPairingOfferRequest): Prom
 export type TuneForgeClient = {
   getMobileCapabilities: () => Promise<RuntimeCapabilities>;
   getHealth: () => Promise<HealthResponse>;
-  listProjects: (search?: string) => Promise<components["schemas"]["ProjectsResponse"]>;
+  listProjects: (params?: ListProjectsParams) => Promise<components["schemas"]["ProjectsResponse"]>;
   importProject: (body: components["schemas"]["ProjectImportRequest"]) => Promise<components["schemas"]["ProjectResponse"]>;
   getProject: (projectId: string) => Promise<components["schemas"]["ProjectResponse"]>;
   updateProject: (projectId: string, body: ProjectUpdateRequest) => Promise<components["schemas"]["ProjectResponse"]>;
@@ -1285,12 +1286,8 @@ function createHttpTuneForgeClient(): TuneForgeClient {
   return {
     getMobileCapabilities: async () => null,
     getHealth: () => unwrap(client.GET("/api/v1/health")),
-    listProjects: (search?: string) =>
-      unwrap(
-        client.GET("/api/v1/projects", {
-          params: search ? ({ query: { search } } as never) : undefined,
-        }),
-      ),
+    listProjects: (params?: ListProjectsParams) =>
+      unwrap(client.GET("/api/v1/projects", params ? { params: { query: params } } : undefined)),
     importProject: (body: components["schemas"]["ProjectImportRequest"]) =>
       unwrap(client.POST("/api/v1/projects/import", { body })),
     getProject: (projectId: string) => unwrap(client.GET("/api/v1/projects/{project_id}", { params: { path: { project_id: projectId } } })),
@@ -1387,7 +1384,8 @@ function createMobileTuneForgeClient(capabilities: MobileCapabilities): TuneForg
   return {
     getMobileCapabilities: async () => capabilities,
     getHealth: () => invokeMobile("mobile_get_health"),
-    listProjects: (search?: string) => invokeMobile("mobile_list_projects", { search }),
+    listProjects: (params?: ListProjectsParams) =>
+      invokeMobile("mobile_list_projects", { params: params ?? null }),
     importProject: (body: components["schemas"]["ProjectImportRequest"]) =>
       invokeMobile("mobile_import_project", { payload: body }),
     getProject: (projectId: string) => invokeMobile("mobile_get_project", { projectId }),
@@ -1528,7 +1526,7 @@ export function getApiBaseUrl() {
 export const api: TuneForgeClient = {
   getMobileCapabilities: () => activeClient.getMobileCapabilities(),
   getHealth: () => activeClient.getHealth(),
-  listProjects: (search?: string) => activeClient.listProjects(search),
+  listProjects: (params?: ListProjectsParams) => activeClient.listProjects(params),
   importProject: (body) => activeClient.importProject(body),
   getProject: (projectId: string) => activeClient.getProject(projectId),
   updateProject: (projectId: string, body: ProjectUpdateRequest) => activeClient.updateProject(projectId, body),

--- a/apps/desktop/src/styles/library.css
+++ b/apps/desktop/src/styles/library.css
@@ -41,6 +41,11 @@
   grid-template-columns: 1fr;
 }
 
+.library-load-more {
+  display: flex;
+  justify-content: center;
+}
+
 .project-library-table__header,
 .project-card__link {
   display: grid;

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -5,6 +5,7 @@ import { vi } from "vitest";
 import App from "../App";
 import type {
   ListJobsParams,
+  ListProjectsParams,
   SyncPairingAnswerRequest,
   SyncPairingAnswerResponse,
   SyncPairingOfferRequest,
@@ -15,6 +16,7 @@ import type {
   SyncTrustedPeerResponse,
 } from "../lib/api";
 
+const DEFAULT_PROJECTS_LIMIT = 50;
 const DEFAULT_JOBS_LIMIT = 50;
 
 const {
@@ -1055,8 +1057,8 @@ const {
   const mockGetMobileCapabilities = vi.fn(async (): Promise<unknown> => null);
   const mockListChordBackends = vi.fn(async () => ({ backends: clone(state.chordBackends) }));
   const mockListStemModels = vi.fn(async () => ({ models: clone(state.stemModels) }));
-  const mockListProjects = vi.fn(async (search?: string) => {
-    const normalizedSearch = search?.trim().toLowerCase();
+  const mockListProjects = vi.fn(async (params?: ListProjectsParams) => {
+    const normalizedSearch = params?.search?.trim().toLowerCase();
     const filteredProjects = normalizedSearch
       ? state.projects.filter((project) => {
           const displayName = String(project.display_name ?? "").toLowerCase();
@@ -1069,7 +1071,16 @@ const {
           );
         })
       : state.projects;
-    return { projects: clone(filteredProjects) };
+    const offset = params?.offset ?? 0;
+    const limit = params?.limit ?? DEFAULT_PROJECTS_LIMIT;
+    const projects = filteredProjects.slice(offset, offset + limit);
+    return {
+      projects: clone(projects),
+      total: filteredProjects.length,
+      limit,
+      offset,
+      has_more: offset + projects.length < filteredProjects.length,
+    };
   });
   const mockImportProject = vi.fn(async (body: {
     source_path: string;

--- a/docs/API.md
+++ b/docs/API.md
@@ -60,7 +60,7 @@ describe current pagination behavior, pending pagination decisions, or explicit 
 | Endpoint or payload | List field | Pagination decision |
 | --- | --- | --- |
 | `GET /api/v1/jobs` | `jobs` | Paginated growable list with `status` and `project_id` filters. Default ordering is active-first and deterministic. |
-| `GET /api/v1/projects` | `projects` | Planned paginated growable list while preserving global `search`. Desktop Library consumers should lazy-load this list. |
+| `GET /api/v1/projects` | `projects` | Paginated growable list. `search` filters the full matching collection before pagination. Default ordering is `updated_at DESC, id DESC`. Desktop Library consumers should lazy-load this list. |
 | `GET /api/v1/projects/{project_id}/artifacts` | `artifacts` | Planned paginated project child list with project-scoped totals and stable newest-first ordering. Desktop project views should lazy-load this list. |
 | `GET /api/v1/projects/{project_id}/sections` | `sections` | Review with project child lists. Paginate if sections are treated as growable; otherwise document the bounded song-structure exception. |
 | `GET /api/v1/sync/trusted-peers` | `trusted_peers` | Review as either a paginated user-managed sync collection or an explicit bounded exception. |
@@ -461,9 +461,13 @@ If the same source track has already been imported, the endpoint returns HTTP `4
 
 Optional query:
 
-- `search`
+- `search` - filters projects by display name or path before pagination.
+- `limit` - page size, default `50`, minimum `1`, maximum `200`.
+- `offset` - zero-based row offset, default `0`, minimum `0`.
 
-Response: `ProjectsResponse`.
+Default ordering is deterministic newest-first: `updated_at DESC, id DESC`.
+
+Response: `ProjectsResponse` with `projects`, `total`, `limit`, `offset`, and `has_more`.
 
 ### Get project
 

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -1222,6 +1222,14 @@ export interface components {
         ProjectsResponse: {
             /** Projects */
             projects: components["schemas"]["ProjectSchema"][];
+            /** Total */
+            total: number;
+            /** Limit */
+            limit: number;
+            /** Offset */
+            offset: number;
+            /** Has More */
+            has_more: boolean;
         };
         /** RetuneRequest */
         RetuneRequest: {
@@ -2349,6 +2357,10 @@ export interface operations {
             query?: {
                 /** @description Filter projects by display name or path. */
                 search?: string | null;
+                /** @description Maximum number of items to return. */
+                limit?: number;
+                /** @description Number of items to skip before returning results. */
+                offset?: number;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
## Summary

- Paginate `GET /api/v1/projects` with shared `limit`/`offset` metadata while preserving global search and deterministic ordering.
- Update generated desktop contracts, mobile project listing, and API docs for the new project-list response shape.
- Add Library load-more pagination and keep Activity job project names resolved without loading the full project list.
- Closes #146

## Testing

- `cd apps/backend && uv run --python 3.11 pytest tests/test_projects.py tests/test_pagination_contract.py`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `pnpm contracts:generate`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test --run src/App.library.test.tsx src/App.activity.test.tsx`
- `pnpm --filter @tuneforge/desktop lint`
- `cd apps/desktop/src-tauri && cargo check`
- `git diff --check`