### PR TITLE
docs: document API child list exceptions

### DIFF
--- a/apps/backend/tests/test_pagination_contract.py
+++ b/apps/backend/tests/test_pagination_contract.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from typing import Any
+
 from app.main import app
 
+PAGINATION_FIELDS = {"total", "limit", "offset", "has_more"}
 LIST_RESPONSE_CONTRACTS = {
     ("/api/v1/chord-backends", "get"): ("ChordBackendsResponse", "backends", True),
     ("/api/v1/stem-models", "get"): ("StemModelsResponse", "models", True),
@@ -13,6 +16,53 @@ PAGINATED_LIST_RESPONSE_CONTRACTS = {
     ("/api/v1/projects", "get"): ("ProjectsResponse", "projects"),
     ("/api/v1/jobs", "get"): ("JobsResponse", "jobs"),
 }
+PROJECT_CHILD_DOCUMENT_RESPONSE_CONTRACTS = {
+    ("/api/v1/projects/{project_id}/analysis", "get"): "AnalysisResponse",
+    ("/api/v1/projects/{project_id}/chords", "get"): "ChordResponse",
+    ("/api/v1/projects/{project_id}/lyrics", "get"): "LyricsResponse",
+    ("/api/v1/projects/{project_id}/lyrics", "put"): "LyricsResponse",
+    ("/api/v1/projects/{project_id}/tabs/proposals", "post"): "TabImportResponse",
+    ("/api/v1/projects/{project_id}/tabs/{tab_import_id}", "get"): "TabImportResponse",
+    ("/api/v1/projects/{project_id}/tabs/{tab_import_id}/accept", "post"): "TabImportApplyResponse",
+}
+PROJECT_CHILD_DOCUMENT_ARRAY_FIELDS = {
+    "AnalysisTimingSchema": ("beats", "bars"),
+    "ChordResponse": ("source_segments", "timeline"),
+    "LyricsResponse": ("source_segments", "segments"),
+    "TabImportSchema": ("groups",),
+    "TabSuggestionGroupSchema": ("suggestions",),
+    "TabImportApplyResponse": ("sections", "accepted_suggestion_ids", "ignored_suggestion_ids"),
+}
+PROJECT_CHILD_DOCUMENT_REFS = {
+    "AnalysisResponse": {"analysis": "AnalysisSchema"},
+    "AnalysisSchema": {"timing": "AnalysisTimingSchema"},
+    "TabImportResponse": {"tab_import": "TabImportSchema"},
+    "TabImportApplyResponse": {
+        "tab_import": "TabImportSchema",
+        "lyrics": "LyricsResponse",
+        "chords": "ChordResponse",
+    },
+}
+UNPAGINATED_ROUTE_CONTRACTS = {
+    ("/api/v1/chord-backends", "get"),
+    ("/api/v1/stem-models", "get"),
+    ("/api/v1/projects/{project_id}/sections", "get"),
+    ("/api/v1/projects/{project_id}/artifacts", "get"),
+    *PROJECT_CHILD_DOCUMENT_RESPONSE_CONTRACTS.keys(),
+}
+
+
+def _property_refs(property_schema: dict[str, Any]) -> set[str]:
+    refs = {property_schema["$ref"]} if "$ref" in property_schema else set()
+    refs.update(entry["$ref"] for entry in property_schema.get("anyOf", []) if "$ref" in entry)
+    return refs
+
+
+def _operation_query_parameter_names(openapi: dict[str, Any], path: str, method: str) -> set[str]:
+    path_item = openapi["paths"][path]
+    parameters = [*path_item.get("parameters", []), *path_item[method].get("parameters", [])]
+
+    return {parameter["name"] for parameter in parameters if parameter["in"] == "query"}
 
 
 def test_list_routes_keep_concrete_openapi_response_refs() -> None:
@@ -24,9 +74,14 @@ def test_list_routes_keep_concrete_openapi_response_refs() -> None:
             route: (schema_name, list_field, True)
             for route, (schema_name, list_field) in PAGINATED_LIST_RESPONSE_CONTRACTS.items()
         },
+        **{
+            route: (schema_name, "", True)
+            for route, schema_name in PROJECT_CHILD_DOCUMENT_RESPONSE_CONTRACTS.items()
+        },
     }
     for (path, method), (schema_name, _list_field, _field_required) in response_contracts.items():
-        response_schema = openapi["paths"][path][method]["responses"]["200"]["content"]["application/json"]["schema"]
+        content = openapi["paths"][path][method]["responses"]["200"]["content"]
+        response_schema = content["application/json"]["schema"]
 
         assert response_schema == {"$ref": f"#/components/schemas/{schema_name}"}
 
@@ -34,7 +89,6 @@ def test_list_routes_keep_concrete_openapi_response_refs() -> None:
 def test_existing_list_response_components_do_not_add_pagination_metadata() -> None:
     openapi = app.openapi()
     components = openapi["components"]["schemas"]
-    pagination_fields = {"total", "limit", "offset", "has_more"}
 
     for schema_name, list_field, field_required in LIST_RESPONSE_CONTRACTS.values():
         component_schema = components[schema_name]
@@ -46,17 +100,50 @@ def test_existing_list_response_components_do_not_add_pagination_metadata() -> N
             assert component_schema["required"] == [list_field]
         else:
             assert "required" not in component_schema
-        assert pagination_fields.isdisjoint(component_schema["properties"])
+        assert PAGINATION_FIELDS.isdisjoint(component_schema["properties"])
 
 
 def test_paginated_list_response_components_include_pagination_metadata() -> None:
     openapi = app.openapi()
     components = openapi["components"]["schemas"]
-    pagination_fields = {"total", "limit", "offset", "has_more"}
 
     for schema_name, list_field in PAGINATED_LIST_RESPONSE_CONTRACTS.values():
         component_schema = components[schema_name]
 
-        assert set(component_schema["properties"]) == {list_field, *pagination_fields}
+        assert set(component_schema["properties"]) == {list_field, *PAGINATION_FIELDS}
         assert component_schema["properties"][list_field]["type"] == "array"
-        assert set(component_schema["required"]) == {list_field, *pagination_fields}
+        assert set(component_schema["required"]) == {list_field, *PAGINATION_FIELDS}
+
+
+def test_unpaginated_exception_routes_do_not_expose_pagination_query_params() -> None:
+    openapi = app.openapi()
+
+    for path, method in UNPAGINATED_ROUTE_CONTRACTS:
+        query_parameter_names = _operation_query_parameter_names(openapi, path, method)
+
+        assert {"limit", "offset"}.isdisjoint(query_parameter_names)
+
+
+def test_project_child_document_arrays_remain_unpaginated_document_content() -> None:
+    openapi = app.openapi()
+    components = openapi["components"]["schemas"]
+
+    for schema_name in set(PROJECT_CHILD_DOCUMENT_RESPONSE_CONTRACTS.values()):
+        component_schema = components[schema_name]
+
+        assert PAGINATION_FIELDS.isdisjoint(component_schema["properties"])
+
+    for schema_name, array_fields in PROJECT_CHILD_DOCUMENT_ARRAY_FIELDS.items():
+        component_schema = components[schema_name]
+
+        assert PAGINATION_FIELDS.isdisjoint(component_schema["properties"])
+        for array_field in array_fields:
+            assert component_schema["properties"][array_field]["type"] == "array"
+
+    for schema_name, field_refs in PROJECT_CHILD_DOCUMENT_REFS.items():
+        component_schema = components[schema_name]
+
+        for field_name, ref_schema_name in field_refs.items():
+            assert f"#/components/schemas/{ref_schema_name}" in _property_refs(
+                component_schema["properties"][field_name]
+            )

--- a/docs/API.md
+++ b/docs/API.md
@@ -29,7 +29,7 @@ are applied.
 
 Response fields:
 
-- the existing list field, such as `projects`, `jobs`, or `artifacts`.
+- the existing list field, such as `projects` or `jobs`.
 - `total` - count after search and filters, before pagination.
 - `limit` - the effective limit used for this response.
 - `offset` - the effective offset used for this response.
@@ -61,8 +61,8 @@ describe current pagination behavior, pending pagination decisions, or explicit 
 | --- | --- | --- |
 | `GET /api/v1/jobs` | `jobs` | Paginated growable list with `status` and `project_id` filters. Default ordering is active-first and deterministic. |
 | `GET /api/v1/projects` | `projects` | Paginated growable list. `search` filters the full matching collection before pagination. Default ordering is `updated_at DESC, id DESC`. Desktop Library consumers should lazy-load this list. |
-| `GET /api/v1/projects/{project_id}/artifacts` | `artifacts` | Planned paginated project child list with project-scoped totals and stable newest-first ordering. Desktop project views should lazy-load this list. |
-| `GET /api/v1/projects/{project_id}/sections` | `sections` | Review with project child lists. Paginate if sections are treated as growable; otherwise document the bounded song-structure exception. |
+| `GET /api/v1/projects/{project_id}/artifacts` | `artifacts` | Explicit unpaginated bounded project inventory exception: source audio, generated stems, practice mixes, exports, and cache artifacts. Ordered by `created_at DESC`; no pagination. |
+| `GET /api/v1/projects/{project_id}/sections` | `sections` | Explicit unpaginated project document/song-structure exception. Sections are bounded by the song arrangement and must stay complete for editing and playback. |
 | `GET /api/v1/sync/trusted-peers` | `trusted_peers` | Review as either a paginated user-managed sync collection or an explicit bounded exception. |
 | `GET /api/v1/chord-backends` | `backends` | Explicit unpaginated exception: small static capability list, bounded by bundled/local backend implementations. |
 | `GET /api/v1/stem-models` | `models` | Explicit unpaginated exception: small static capability list, bounded by supported local stem models. |
@@ -71,7 +71,7 @@ describe current pagination behavior, pending pagination decisions, or explicit 
 | `GET /api/v1/sync/projects/{project_id}/manifest` | `entity_revisions`, `artifacts`, `delete_tombstones` | Explicit unpaginated manifest exception. The response is an atomic project export unit. |
 | `POST /api/v1/sync/reconciliation/plan` | `items`, `actions` | Explicit unpaginated planning exception. The response is a complete computed plan for the supplied sync inventory. |
 | `POST /api/v1/sync/reconciliation/apply` | `plan.items`, `plan.actions`, `results`, `timing_evidence` | Explicit unpaginated apply exception. Partial pages would make apply summaries and results incomplete. |
-| Project document payloads, including analysis timing, chords, lyrics, tab imports, and tab apply results | nested content arrays | Explicit unpaginated document exceptions unless a future endpoint exposes them as standalone growable collections. These arrays are part of a single project document or edit result, not top-level list browsing. |
+| Project document payloads, including analysis timing, chords, lyrics, tab imports, and tab apply results | nested content arrays and result arrays | Explicit unpaginated document exceptions unless a future endpoint exposes them as standalone growable collections. These arrays are part of a single project document or edit result, not top-level list browsing. |
 
 Example error response:
 
@@ -517,6 +517,9 @@ Returns the stored analysis result, or `null` if no result exists.
 
 Analysis includes key, key confidence, reference tuning, tuning offset, tempo, analysis version, source artifact, and creation time.
 
+Analysis is an unpaginated project document payload. Its timing data is returned with the analysis document so playback
+and editing consumers do not need lazy-loaded fragments.
+
 ## Chords
 
 ### Generate chords
@@ -540,6 +543,9 @@ Response: `JobResponse`.
 
 Returns source segments, current timeline segments, backend, source artifact, source kind, user-edit state, metadata, and timestamps. If no chord timeline exists, the response contains an empty timeline.
 
+Chord timelines are unpaginated project document payloads. The source and current timelines stay complete so playback
+and editing consumers share one coherent chord document.
+
 ## Lyrics
 
 ### Generate lyrics
@@ -560,6 +566,9 @@ Response: `JobResponse`.
 
 Returns source transcript segments, current edited segments, backend, source artifact, model/device metadata, language, user-edit state, and timestamps. If no lyrics exist, the response contains empty segment lists.
 
+Lyrics segments are unpaginated project document payloads. Source and edited segments stay complete so lyric editing
+and playback highlighting do not depend on lazy-loaded fragments.
+
 ### Update lyrics
 
 `PUT /api/v1/projects/{project_id}/lyrics`
@@ -575,6 +584,19 @@ Each segment currently accepts:
 - `text`
 
 Response: `LyricsResponse`.
+
+## Sections
+
+### List project sections
+
+`GET /api/v1/projects/{project_id}/sections`
+
+Returns the complete song-structure section list for the project.
+
+Sections are an unpaginated project document payload. They are bounded by the arrangement and stay complete so editing,
+playback navigation, and tab-import apply results use one shared song-structure view.
+
+Response: `SongSectionsResponse`.
 
 ## Transforms and Previews
 
@@ -653,7 +675,10 @@ Response: `JobResponse`.
 
 `GET /api/v1/projects/{project_id}/artifacts`
 
-Returns artifacts for a project ordered by newest first.
+Returns the bounded project inventory for source audio, generated stems, practice mixes, exports, and cache artifacts.
+Results are ordered by `created_at DESC`.
+
+Project artifacts are not paginated. They are project-scoped inventory, not a library-level growable browsing list.
 
 Response: `ArtifactsResponse`.
 


### PR DESCRIPTION
## Summary

- Document project child artifacts and project document payloads as explicit unpaginated API exceptions.
- Add pagination contract tests that guard concrete response refs, unpaginated route query params, and nested document arrays.

Closes #147

## Testing

- `cd apps/backend && uv run --python 3.11 pytest tests/test_pagination_contract.py tests/test_projects.py`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `git diff --check`
