### PR TITLE
feat: lazy load library projects

### DIFF
--- a/apps/desktop/src/App.library.test.tsx
+++ b/apps/desktop/src/App.library.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
@@ -11,7 +11,30 @@ import {
   renderApp,
   setChordBackends,
   setProjects,
+  triggerMockIntersectionObserver,
 } from "./test/appTestHarness";
+
+function makeLibraryProject(projectNumber: number) {
+  return {
+    id: `proj_${String(projectNumber).padStart(3, "0")}`,
+    display_name: `Project ${projectNumber}`,
+    source_path: `/tmp/project-${projectNumber}.wav`,
+    imported_path: `/tmp/projects/project-${projectNumber}.wav`,
+    duration_seconds: 120,
+    sample_rate: 44100,
+    channels: 2,
+    created_at: "2026-04-18T13:16:00.000Z",
+    updated_at: "2026-04-18T13:16:00.000Z",
+  };
+}
+
+function setLibraryProjects(count: number) {
+  setProjects(Array.from({ length: count }, (_, index) => makeLibraryProject(index + 1)));
+}
+
+function getProjectHeadingCount(name: string) {
+  return screen.queryAllByRole("heading", { name, level: 2 }).length;
+}
 
 describe("Desktop app library", () => {
   beforeEach(resetAppTestHarness);
@@ -55,24 +78,8 @@ describe("Desktop app library", () => {
     expect(screen.queryByText("Bass Drill")).not.toBeInTheDocument();
   });
 
-  it("loads additional project pages on request", async () => {
-    const user = userEvent.setup();
-    setProjects(
-      Array.from({ length: 55 }, (_, index) => {
-        const projectNumber = index + 1;
-        return {
-          id: `proj_${String(projectNumber).padStart(3, "0")}`,
-          display_name: `Project ${projectNumber}`,
-          source_path: `/tmp/project-${projectNumber}.wav`,
-          imported_path: `/tmp/projects/project-${projectNumber}.wav`,
-          duration_seconds: 120,
-          sample_rate: 44100,
-          channels: 2,
-          created_at: "2026-04-18T13:16:00.000Z",
-          updated_at: "2026-04-18T13:16:00.000Z",
-        };
-      }),
-    );
+  it("loads additional project pages when the scroll sentinel enters view", async () => {
+    setLibraryProjects(55);
 
     renderApp(["/"]);
 
@@ -80,13 +87,165 @@ describe("Desktop app library", () => {
     expect(screen.getByRole("heading", { name: "Project 1", level: 2 })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Project 55", level: 2 })).not.toBeInTheDocument();
     expect(mockListProjects).toHaveBeenCalledWith({ limit: 50, offset: 0 });
+    expect(screen.getByText("More projects load as you scroll.")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Load more projects" }));
+    act(() => {
+      triggerMockIntersectionObserver();
+    });
 
     expect(await screen.findByRole("heading", { name: "Project 55", level: 2 })).toBeInTheDocument();
     expect(screen.getByText("55 projects ready")).toBeInTheDocument();
+    expect(screen.getByText("All projects loaded.")).toBeInTheDocument();
     expect(mockListProjects).toHaveBeenCalledWith({ limit: 50, offset: 50 });
     expect(screen.queryByRole("button", { name: "Load more projects" })).not.toBeInTheDocument();
+  });
+
+  it("ignores repeated next-page triggers while a page request is already in flight", async () => {
+    let resolveNextPage!: () => void;
+    mockListProjects
+      .mockImplementationOnce(async (params) => ({
+        projects: Array.from({ length: 50 }, (_, index) => makeLibraryProject(index + 1)),
+        total: 55,
+        limit: params?.limit ?? 50,
+        offset: params?.offset ?? 0,
+        has_more: true,
+      }))
+      .mockImplementationOnce(
+        async (params) =>
+          new Promise((resolve) => {
+            resolveNextPage = () =>
+              resolve({
+                projects: Array.from({ length: 5 }, (_, index) => makeLibraryProject(51 + index)),
+                total: 55,
+                limit: params?.limit ?? 50,
+                offset: params?.offset ?? 0,
+                has_more: false,
+              });
+          }),
+      );
+
+    renderApp(["/"]);
+
+    expect(await screen.findByText("50 of 55 projects loaded")).toBeInTheDocument();
+    const loadMoreButton = screen.getByRole("button", { name: "Load more projects" });
+
+    act(() => {
+      triggerMockIntersectionObserver();
+      triggerMockIntersectionObserver();
+      fireEvent.click(loadMoreButton);
+    });
+
+    await waitFor(() =>
+      expect(mockListProjects.mock.calls.filter(([params]) => params?.offset === 50)).toHaveLength(1),
+    );
+
+    act(() => {
+      resolveNextPage();
+    });
+
+    expect(await screen.findByRole("heading", { name: "Project 55", level: 2 })).toBeInTheDocument();
+  });
+
+  it("searches across all projects after multiple pages have been loaded", async () => {
+    const user = userEvent.setup();
+    setLibraryProjects(55);
+
+    renderApp(["/"]);
+
+    expect(await screen.findByText("50 of 55 projects loaded")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Load more projects" }));
+    expect(await screen.findByRole("heading", { name: "Project 55", level: 2 })).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("Search projects"), "project 55");
+
+    await waitFor(() =>
+      expect(mockListProjects).toHaveBeenLastCalledWith({
+        search: "project 55",
+        limit: 50,
+        offset: 0,
+      }),
+    );
+    expect(await screen.findByText('1 match for "project 55"')).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Project 55", level: 2 })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Project 1", level: 2 })).not.toBeInTheDocument();
+  });
+
+  it("refreshes loaded library pages after batch import without duplicate rows", async () => {
+    const user = userEvent.setup();
+    setLibraryProjects(55);
+    mockOpen.mockResolvedValue(["/tmp/new-alpha.wav", "/tmp/new-beta.wav"]);
+
+    renderApp(["/"]);
+
+    expect(await screen.findByText("50 of 55 projects loaded")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Load more projects" }));
+    expect(await screen.findByRole("heading", { name: "Project 55", level: 2 })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Import Track(s)" }));
+
+    expect(await screen.findByText("57 projects ready")).toBeInTheDocument();
+    const summary = screen.getByRole("status");
+    expect(within(summary).getByText("2 tracks imported, 0 duplicates skipped, 0 failed.")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "New Alpha", level: 2 })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "New Beta", level: 2 })).toBeInTheDocument();
+    expect(getProjectHeadingCount("Project 49")).toBe(1);
+    expect(getProjectHeadingCount("Project 50")).toBe(1);
+    expect(getProjectHeadingCount("Project 55")).toBe(1);
+  });
+
+  it("shows a refetch error after import invalidation fails while keeping loaded rows visible", async () => {
+    const user = userEvent.setup();
+    setLibraryProjects(1);
+    mockOpen.mockResolvedValue(["/tmp/new-alpha.wav", "/tmp/new-beta.wav"]);
+    mockListProjects.mockImplementationOnce(async (params) => ({
+      projects: [makeLibraryProject(1)],
+      total: 1,
+      limit: params?.limit ?? 50,
+      offset: params?.offset ?? 0,
+      has_more: false,
+    }));
+    mockListProjects.mockRejectedValueOnce(new Error("Refresh failed"));
+
+    renderApp(["/"]);
+
+    expect(await screen.findByRole("heading", { name: "Project 1", level: 2 })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Import Track(s)" }));
+
+    const refetchError = await screen.findByText("Could not refresh projects. Showing saved results.");
+    expect(refetchError.closest('[role="alert"]')).not.toBeNull();
+    expect(screen.getByRole("heading", { name: "Project 1", level: 2 })).toBeInTheDocument();
+  });
+
+  it("shows library loading, empty, failure, and final-page states", async () => {
+    let resolveProjects!: () => void;
+    mockListProjects.mockImplementationOnce(
+      async (params) =>
+        new Promise((resolve) => {
+          resolveProjects = () =>
+            resolve({
+              projects: [],
+              total: 0,
+              limit: params?.limit ?? 50,
+              offset: params?.offset ?? 0,
+              has_more: false,
+            });
+        }),
+    );
+
+    const { unmount } = renderApp(["/"]);
+
+    expect(await screen.findByText("Loading projects...")).toBeInTheDocument();
+    resolveProjects();
+    expect(await screen.findByRole("heading", { name: "No projects yet" })).toBeInTheDocument();
+    expect(screen.getByText("0 projects ready")).toBeInTheDocument();
+
+    unmount();
+    mockListProjects.mockRejectedValueOnce(new Error("Library unavailable"));
+    renderApp(["/"]);
+
+    const alert = await screen.findByRole("alert");
+    expect(within(alert).getByText("Could not load projects.")).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "No projects yet" })).not.toBeInTheDocument();
   });
 
   it("renders project cards with local timestamps and without filename subtitles", async () => {

--- a/apps/desktop/src/features/projects/LibraryView.tsx
+++ b/apps/desktop/src/features/projects/LibraryView.tsx
@@ -1,4 +1,4 @@
-import { startTransition, useDeferredValue, useState } from "react";
+import { startTransition, useCallback, useDeferredValue, useEffect, useRef, useState } from "react";
 import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { open } from "@tauri-apps/plugin-dialog";
 import { Music2, Upload } from "lucide-react";
@@ -245,6 +245,8 @@ export function LibraryView() {
   const { chordBackendForAction } = useChordBackendActionSelection();
   const [searchDraft, setSearchDraft] = useState("");
   const [importNotice, setImportNotice] = useState<ImportNotice | null>(null);
+  const loadMoreSentinelRef = useRef<HTMLDivElement | null>(null);
+  const fetchNextPageInFlightRef = useRef(false);
   const deferredSearch = useDeferredValue(searchDraft.trim());
   const showSubtitle = informationDensity !== "minimal";
 
@@ -260,6 +262,17 @@ export function LibraryView() {
     getNextPageParam: (lastPage) =>
       lastPage.has_more ? lastPage.offset + lastPage.projects.length : undefined,
   });
+  const {
+    data: projectsData,
+    fetchNextPage,
+    hasNextPage,
+    isError: isProjectsError,
+    isFetchNextPageError,
+    isFetching,
+    isFetchingNextPage,
+    isLoading: isProjectsLoading,
+    isRefetchError,
+  } = projectsQuery;
 
   const importMutation = useMutation({
     mutationFn: async () => {
@@ -362,11 +375,63 @@ export function LibraryView() {
     },
   });
 
-  const projectPages = projectsQuery.data?.pages ?? [];
+  const projectPages = projectsData?.pages ?? [];
   const projects = projectPages.flatMap((page) => page.projects);
   const loadedProjectCount = projects.length;
   const totalProjectCount = projectPages[0]?.total ?? 0;
   const hasLoadedAllProjects = loadedProjectCount >= totalProjectCount;
+  const showInitialLoading = isProjectsLoading;
+  const showInitialError = isProjectsError && !projects.length;
+  const showList = projects.length > 0;
+  const showEmptyState = !showInitialLoading && !isProjectsError && !projects.length;
+  const showPaginationStatus = showList && !showInitialLoading && !showInitialError;
+  const showRefetchError = isRefetchError && !isFetchNextPageError && projects.length > 0;
+
+  const fetchNextProjectPage = useCallback(() => {
+    if (fetchNextPageInFlightRef.current || isFetchingNextPage || !hasNextPage) {
+      return;
+    }
+
+    fetchNextPageInFlightRef.current = true;
+    void fetchNextPage({ cancelRefetch: false }).finally(() => {
+      fetchNextPageInFlightRef.current = false;
+    });
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  useEffect(() => {
+    const sentinel = loadMoreSentinelRef.current;
+    if (
+      !sentinel ||
+      !hasNextPage ||
+      isFetching ||
+      isFetchingNextPage ||
+      isProjectsError ||
+      typeof IntersectionObserver === "undefined"
+    ) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const [entry] = entries;
+        if (!entry?.isIntersecting || isFetching || isFetchingNextPage) {
+          return;
+        }
+
+        fetchNextProjectPage();
+      },
+      { rootMargin: "320px 0px" },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [
+    fetchNextProjectPage,
+    hasNextPage,
+    isFetching,
+    isFetchingNextPage,
+    isProjectsError,
+  ]);
 
   return (
     <section className="screen">
@@ -443,13 +508,24 @@ export function LibraryView() {
         </div>
       </div>
 
-      {projectsQuery.isLoading ? <div className="panel">Loading projects...</div> : null}
-      {projectsQuery.isError ? (
-        <div className="panel panel--error">Could not load projects.</div>
+      {showInitialLoading ? (
+        <div className="panel" role="status">
+          Loading projects...
+        </div>
+      ) : null}
+      {showInitialError ? (
+        <div className="panel panel--error" role="alert">
+          Could not load projects.
+        </div>
+      ) : null}
+      {showRefetchError ? (
+        <div className="panel panel--error" role="alert">
+          Could not refresh projects. Showing saved results.
+        </div>
       ) : null}
 
       <div className="project-grid project-library-table">
-        {projects.length ? (
+        {showList ? (
           <>
             <div className="project-library-table__header" aria-hidden="true">
               <span />
@@ -459,7 +535,7 @@ export function LibraryView() {
             </div>
             {projects.map((project) => <ProjectCard key={project.id} project={project} />)}
           </>
-        ) : !projectsQuery.isLoading && !projectsQuery.isError ? (
+        ) : showEmptyState ? (
           <div className="panel panel--empty">
             <h2>{deferredSearch ? "No matching projects" : "No projects yet"}</h2>
             <p>
@@ -470,16 +546,42 @@ export function LibraryView() {
           </div>
         ) : null}
       </div>
-      {projectsQuery.hasNextPage ? (
-        <div className="library-load-more">
-          <button
-            className="button button--ghost"
-            disabled={projectsQuery.isFetchingNextPage}
-            onClick={() => projectsQuery.fetchNextPage()}
-            type="button"
-          >
-            {projectsQuery.isFetchingNextPage ? "Loading projects..." : "Load more projects"}
-          </button>
+
+      {showPaginationStatus ? (
+        <div
+          aria-live="polite"
+          className="library-load-more"
+          ref={loadMoreSentinelRef}
+        >
+          {isFetchNextPageError ? (
+            <>
+              <span role="alert">Could not load more projects.</span>
+              <button
+                className="button button--ghost"
+                disabled={isFetchingNextPage}
+                onClick={fetchNextProjectPage}
+                type="button"
+              >
+                Try again
+              </button>
+            </>
+          ) : isFetchingNextPage ? (
+            <span>Loading more projects...</span>
+          ) : hasNextPage ? (
+            <>
+              <span>More projects load as you scroll.</span>
+              <button
+                className="button button--ghost"
+                disabled={isFetchingNextPage}
+                onClick={fetchNextProjectPage}
+                type="button"
+              >
+                Load more projects
+              </button>
+            </>
+          ) : (
+            <span>All projects loaded.</span>
+          )}
         </div>
       ) : null}
     </section>

--- a/apps/desktop/src/styles/library.css
+++ b/apps/desktop/src/styles/library.css
@@ -43,7 +43,12 @@
 
 .library-load-more {
   display: flex;
+  min-height: 3rem;
+  align-items: center;
   justify-content: center;
+  gap: 0.75rem;
+  color: var(--muted);
+  font-size: 0.9rem;
 }
 
 .project-library-table__header,

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -2141,6 +2141,80 @@ export function queryByAriaKeyLabel(container: HTMLElement, label: string) {
   return within(container).queryByText((_, element) => hasAriaKeyLabel(element, label));
 }
 
+type MockIntersectionObserverCallback = (
+  entries: IntersectionObserverEntry[],
+  observer: IntersectionObserver,
+) => void;
+
+const mockIntersectionObservers: MockIntersectionObserver[] = [];
+
+function normalizeMockRootMargin(rootMargin: string | undefined) {
+  const value = rootMargin?.trim() || "0px";
+  const parts = value.split(/\s+/);
+  if (parts.length > 4 || parts.some((part) => !/^-?(?:\d+|\d*\.\d+)(px|%)$/.test(part))) {
+    throw new SyntaxError("Failed to construct 'IntersectionObserver': rootMargin must be specified in pixels or percent.");
+  }
+  return value;
+}
+
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root: Element | Document | null = null;
+  readonly rootMargin: string;
+  readonly scrollMargin = "";
+  readonly thresholds: ReadonlyArray<number> = [];
+  readonly observedElements = new Set<Element>();
+
+  constructor(
+    private readonly callback: MockIntersectionObserverCallback,
+    options?: IntersectionObserverInit,
+  ) {
+    this.rootMargin = normalizeMockRootMargin(options?.rootMargin);
+    mockIntersectionObservers.push(this);
+  }
+
+  disconnect() {
+    this.observedElements.clear();
+  }
+
+  observe(target: Element) {
+    this.observedElements.add(target);
+  }
+
+  takeRecords() {
+    return [];
+  }
+
+  unobserve(target: Element) {
+    this.observedElements.delete(target);
+  }
+
+  trigger(isIntersecting = true) {
+    const entries = Array.from(this.observedElements, (target) => ({
+      boundingClientRect: {} as DOMRectReadOnly,
+      intersectionRatio: isIntersecting ? 1 : 0,
+      intersectionRect: {} as DOMRectReadOnly,
+      isIntersecting,
+      rootBounds: null,
+      target,
+      time: 0,
+    }));
+    if (entries.length) {
+      this.callback(entries as IntersectionObserverEntry[], this);
+    }
+  }
+}
+
+function installMockIntersectionObserver() {
+  mockIntersectionObservers.length = 0;
+  vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+}
+
+export function triggerMockIntersectionObserver(isIntersecting = true) {
+  for (const observer of mockIntersectionObservers) {
+    observer.trigger(isIntersecting);
+  }
+}
+
 export function installMatchMediaMock(initialMatches = false) {
   const listeners = new Set<(event: MediaQueryListEvent) => void>();
   let matches = initialMatches;
@@ -2419,4 +2493,5 @@ export function resetAppTestHarness() {
   setMockAudioSourceStartError(null);
   getMockMediaDevices().reset();
   installMatchMediaMock(false);
+  installMockIntersectionObserver();
 }


### PR DESCRIPTION
## Summary

- Add scroll-sentinel lazy loading for Library project pages with a manual fallback.
- Preserve project search and import refresh behavior across paginated results.
- Expand desktop coverage for scroll loading, duplicate fetch guards, refetch failures, and UI states.

## Testing

- `pnpm --filter @tuneforge/desktop test --run App.library.test.tsx`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
- `git diff --check`

Closes #148
