### PR TITLE
feat: lazy load activity history

### DIFF
--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -22,6 +22,7 @@ import {
   setProjects,
   setSyncTransportStatus,
   setSyncTrustedPeers,
+  triggerMockIntersectionObserver,
 } from "./test/appTestHarness";
 
 const irohTransportId = "tuneforge-sync+iroh";
@@ -59,6 +60,21 @@ function job(overrides: Partial<JobSchema>): Record<string, unknown> {
     updated_at: "2026-04-18T13:16:00.000Z",
     ...overrides,
   };
+}
+
+function terminalHistoryJobs(count: number) {
+  return Array.from({ length: count }, (_, index) => {
+    const jobNumber = index + 1;
+    return job({
+      id: `job_history_${String(jobNumber).padStart(3, "0")}`,
+      type: `history_${String(jobNumber).padStart(3, "0")}`,
+      status: "completed",
+      progress: 100,
+      completed_at: `2026-04-18T13:${String(59 - index).padStart(2, "0")}:00.000Z`,
+      created_at: "2026-04-18T13:00:00.000Z",
+      updated_at: `2026-04-18T13:${String(59 - index).padStart(2, "0")}:00.000Z`,
+    });
+  });
 }
 
 function pairingPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
@@ -1017,20 +1033,7 @@ describe("Desktop app activity", () => {
 
   it("loads additional terminal history pages on request", async () => {
     const user = userEvent.setup();
-    setJobs(
-      Array.from({ length: 55 }, (_, index) => {
-        const jobNumber = index + 1;
-        return job({
-          id: `job_history_${String(jobNumber).padStart(3, "0")}`,
-          type: `history_${String(jobNumber).padStart(3, "0")}`,
-          status: "completed",
-          progress: 100,
-          completed_at: `2026-04-18T13:${String(59 - index).padStart(2, "0")}:00.000Z`,
-          created_at: "2026-04-18T13:00:00.000Z",
-          updated_at: `2026-04-18T13:${String(59 - index).padStart(2, "0")}:00.000Z`,
-        });
-      }),
-    );
+    setJobs(terminalHistoryJobs(55));
 
     renderApp(["/activity"]);
 
@@ -1048,6 +1051,171 @@ describe("Desktop app activity", () => {
     await waitFor(() =>
       expect(screen.queryByRole("button", { name: "Load more history" })).not.toBeInTheDocument(),
     );
+  });
+
+  it("loads additional terminal history pages when the history sentinel intersects", async () => {
+    setJobs(terminalHistoryJobs(55));
+
+    renderApp(["/activity"]);
+
+    expect(await screen.findByRole("article", { name: "history_001 completed job" })).toBeInTheDocument();
+    expect(screen.queryByRole("article", { name: "history_055 completed job" })).not.toBeInTheDocument();
+
+    act(() => {
+      triggerMockIntersectionObserver();
+    });
+
+    expect(await screen.findByRole("article", { name: "history_055 completed job" })).toBeInTheDocument();
+    expect(mockListJobs).toHaveBeenCalledWith({
+      status: ["completed", "failed", "cancelled"],
+      limit: 50,
+      offset: 50,
+    });
+  });
+
+  it("rebinds the history sentinel after returning to the Jobs tab", async () => {
+    const user = userEvent.setup();
+    setJobs(terminalHistoryJobs(55));
+
+    renderApp(["/activity"]);
+
+    expect(await screen.findByRole("article", { name: "history_001 completed job" })).toBeInTheDocument();
+    expect(screen.queryByRole("article", { name: "history_055 completed job" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Sync" }));
+    expect(await screen.findByRole("heading", { level: 2, name: "Sync" })).toBeInTheDocument();
+
+    act(() => {
+      triggerMockIntersectionObserver();
+    });
+
+    expect(mockListJobs.mock.calls.filter(([params]) => params?.offset === 50)).toHaveLength(0);
+
+    await user.click(screen.getByRole("tab", { name: "Jobs" }));
+    expect(await screen.findByRole("heading", { level: 2, name: "Jobs" })).toBeInTheDocument();
+
+    act(() => {
+      triggerMockIntersectionObserver();
+    });
+
+    expect(await screen.findByRole("article", { name: "history_055 completed job" })).toBeInTheDocument();
+    expect(mockListJobs).toHaveBeenCalledWith({
+      status: ["completed", "failed", "cancelled"],
+      limit: 50,
+      offset: 50,
+    });
+  });
+
+  it("keeps failed terminal history page loads on manual retry only", async () => {
+    const user = userEvent.setup();
+    const defaultListJobsImplementation = mockListJobs.getMockImplementation();
+    if (!defaultListJobsImplementation) {
+      throw new Error("Expected list jobs mock implementation.");
+    }
+    let rejectNextHistoryPage = true;
+    const getHistoryPageRequestCount = () =>
+      mockListJobs.mock.calls.filter(([params]) => params?.offset === 50).length;
+    mockListJobs.mockImplementation(async (params) => {
+      if (params?.offset === 50 && rejectNextHistoryPage) {
+        rejectNextHistoryPage = false;
+        throw new Error("History page failed.");
+      }
+
+      return defaultListJobsImplementation(params);
+    });
+    setJobs(terminalHistoryJobs(55));
+
+    renderApp(["/activity"]);
+
+    expect(await screen.findByRole("article", { name: "history_001 completed job" })).toBeInTheDocument();
+    expect(screen.queryByRole("article", { name: "history_055 completed job" })).not.toBeInTheDocument();
+
+    act(() => {
+      triggerMockIntersectionObserver();
+    });
+
+    await waitFor(() => expect(getHistoryPageRequestCount()).toBe(1));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Load more history" })).toBeEnabled(),
+    );
+
+    act(() => {
+      triggerMockIntersectionObserver();
+      triggerMockIntersectionObserver();
+    });
+
+    expect(getHistoryPageRequestCount()).toBe(1);
+
+    await user.click(screen.getByRole("button", { name: "Load more history" }));
+
+    expect(await screen.findByRole("article", { name: "history_055 completed job" })).toBeInTheDocument();
+    expect(getHistoryPageRequestCount()).toBe(2);
+  });
+
+  it("waits for terminal history refetch to settle before sentinel page loads", async () => {
+    const defaultListJobsImplementation = mockListJobs.getMockImplementation();
+    if (!defaultListJobsImplementation) {
+      throw new Error("Expected list jobs mock implementation.");
+    }
+    let terminalFirstPageRequests = 0;
+    let resolveTerminalRefetch: () => void = () => {
+      throw new Error("Terminal history refetch did not start.");
+    };
+    const getHistoryPageRequestCount = () =>
+      mockListJobs.mock.calls.filter(([params]) => params?.offset === 50).length;
+    mockListJobs.mockImplementation(async (params) => {
+      const isTerminalFirstPage =
+        params?.offset === 0 &&
+        Array.isArray(params.status) &&
+        params.status.includes("completed") &&
+        params.status.includes("failed") &&
+        params.status.includes("cancelled");
+      if (isTerminalFirstPage) {
+        terminalFirstPageRequests += 1;
+      }
+
+      if (isTerminalFirstPage && terminalFirstPageRequests === 2) {
+        return new Promise((resolve) => {
+          resolveTerminalRefetch = () => {
+            resolve(defaultListJobsImplementation(params));
+          };
+        });
+      }
+
+      return defaultListJobsImplementation(params);
+    });
+    setJobs(terminalHistoryJobs(55));
+
+    const { queryClient } = renderApp(["/activity"]);
+
+    expect(await screen.findByRole("article", { name: "history_001 completed job" })).toBeInTheDocument();
+    expect(screen.queryByRole("article", { name: "history_055 completed job" })).not.toBeInTheDocument();
+
+    act(() => {
+      void queryClient.invalidateQueries({ queryKey: ["jobs", "activity", "terminal"] });
+    });
+
+    await waitFor(() => expect(terminalFirstPageRequests).toBe(2));
+
+    act(() => {
+      triggerMockIntersectionObserver();
+    });
+
+    expect(getHistoryPageRequestCount()).toBe(0);
+
+    await act(async () => {
+      resolveTerminalRefetch();
+    });
+    await waitFor(() =>
+      expect(queryClient.isFetching({ queryKey: ["jobs", "activity", "terminal"] })).toBe(0),
+    );
+
+    act(() => {
+      triggerMockIntersectionObserver();
+    });
+
+    expect(await screen.findByRole("article", { name: "history_055 completed job" })).toBeInTheDocument();
+    expect(getHistoryPageRequestCount()).toBe(1);
   });
 
   it("keeps loaded history visible while new project details are loading", async () => {

--- a/apps/desktop/src/features/activity/ActivityView.tsx
+++ b/apps/desktop/src/features/activity/ActivityView.tsx
@@ -3,6 +3,7 @@ import { useInfiniteQuery, useMutation, useQueries, useQueryClient } from "@tans
 import { Link } from "react-router-dom";
 import { api, type JobSchema, type ProjectSchema } from "../../lib/api";
 import { formatLocalDateTime, normalizeApiDateTime, parseApiDateTime } from "../../lib/datetime";
+import { useLazyLoadSentinel } from "../../lib/useLazyLoadSentinel";
 import { formatJobStatusSummary } from "../projects/projectViewUtils";
 import { ActivitySyncPanel } from "./ActivitySyncPanel";
 
@@ -266,13 +267,23 @@ export function ActivityView() {
     getNextPageParam: (lastPage) =>
       lastPage.has_more ? lastPage.offset + lastPage.jobs.length : undefined,
   });
+  const {
+    data: terminalJobsData,
+    fetchNextPage: fetchNextTerminalJobsPage,
+    hasNextPage: hasNextTerminalJobsPage,
+    isError: isTerminalJobsError,
+    isFetchNextPageError: isFetchNextTerminalJobsPageError,
+    isFetching: isFetchingTerminalJobs,
+    isFetchingNextPage: isFetchingNextTerminalJobsPage,
+    isLoading: isTerminalJobsLoading,
+  } = terminalJobsQuery;
   const activeJobs = useMemo(
     () => activeJobsData?.pages.flatMap((page) => page.jobs) ?? EMPTY_JOBS,
     [activeJobsData],
   );
   const terminalJobs = useMemo(
-    () => terminalJobsQuery.data?.pages.flatMap((page) => page.jobs) ?? [],
-    [terminalJobsQuery.data],
+    () => terminalJobsData?.pages.flatMap((page) => page.jobs) ?? EMPTY_JOBS,
+    [terminalJobsData],
   );
   const jobs = useMemo(() => uniqueJobs([...activeJobs, ...terminalJobs]), [activeJobs, terminalJobs]);
   const jobProjectIds = useMemo(
@@ -314,10 +325,22 @@ export function ActivityView() {
   const displayJobs = useMemo(() => orderJobsForQueue(jobs), [jobs]);
   const activeJobCount = displayJobs.filter(({ job }) => CANCELABLE_JOB_STATUSES.has(job.status)).length;
   const shouldPollJobs = hasActiveJob(activeJobs);
-  const isLoading = isActiveJobsLoading || terminalJobsQuery.isLoading;
-  const isError = isActiveJobsError || terminalJobsQuery.isError;
+  const isLoading = isActiveJobsLoading || isTerminalJobsLoading;
+  const isError = isActiveJobsError || isTerminalJobsError;
   const showJobList = !isLoading && !isError && displayJobs.length > 0;
   const showEmptyState = !isLoading && !isError && displayJobs.length === 0;
+  const { loadNextPage: loadNextTerminalJobsPage, sentinelRef: terminalHistorySentinelRef } =
+    useLazyLoadSentinel({
+      enabled:
+        activeTab === "jobs" &&
+        !isFetchingTerminalJobs &&
+        !isTerminalJobsError &&
+        !isFetchNextTerminalJobsPageError,
+      fetchNextPage: fetchNextTerminalJobsPage,
+      hasNextPage: hasNextTerminalJobsPage,
+      isFetchingNextPage: isFetchingNextTerminalJobsPage,
+      rootMargin: "160px 0px",
+    });
 
   useEffect(() => {
     if (!shouldPollJobs) return;
@@ -432,15 +455,15 @@ export function ActivityView() {
             </ul>
           ) : null}
 
-          {terminalJobsQuery.hasNextPage ? (
-            <div className="activity-jobs-panel__load-more">
+          {hasNextTerminalJobsPage ? (
+            <div className="activity-jobs-panel__load-more" ref={terminalHistorySentinelRef}>
               <button
                 className="button button--ghost"
-                disabled={terminalJobsQuery.isFetchingNextPage}
-                onClick={() => terminalJobsQuery.fetchNextPage()}
+                disabled={isFetchingNextTerminalJobsPage}
+                onClick={loadNextTerminalJobsPage}
                 type="button"
               >
-                {terminalJobsQuery.isFetchingNextPage ? "Loading history..." : "Load more history"}
+                {isFetchingNextTerminalJobsPage ? "Loading history..." : "Load more history"}
               </button>
             </div>
           ) : null}

--- a/apps/desktop/src/features/projects/LibraryView.tsx
+++ b/apps/desktop/src/features/projects/LibraryView.tsx
@@ -1,4 +1,4 @@
-import { startTransition, useCallback, useDeferredValue, useEffect, useRef, useState } from "react";
+import { startTransition, useDeferredValue, useState } from "react";
 import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { open } from "@tauri-apps/plugin-dialog";
 import { Music2, Upload } from "lucide-react";
@@ -6,6 +6,7 @@ import { Link, useNavigate } from "react-router-dom";
 import { api, getProjectSyncSummary, type ProjectSchema } from "../../lib/api";
 import { formatLocalDateTime, normalizeApiDateTime } from "../../lib/datetime";
 import { usePreferences } from "../../lib/preferences";
+import { useLazyLoadSentinel } from "../../lib/useLazyLoadSentinel";
 import { useChordBackendActionSelection } from "./hooks/useChordBackendActionSelection";
 
 const MAX_IMPORT_SELECTION = 25;
@@ -245,8 +246,6 @@ export function LibraryView() {
   const { chordBackendForAction } = useChordBackendActionSelection();
   const [searchDraft, setSearchDraft] = useState("");
   const [importNotice, setImportNotice] = useState<ImportNotice | null>(null);
-  const loadMoreSentinelRef = useRef<HTMLDivElement | null>(null);
-  const fetchNextPageInFlightRef = useRef(false);
   const deferredSearch = useDeferredValue(searchDraft.trim());
   const showSubtitle = informationDensity !== "minimal";
 
@@ -386,52 +385,14 @@ export function LibraryView() {
   const showEmptyState = !showInitialLoading && !isProjectsError && !projects.length;
   const showPaginationStatus = showList && !showInitialLoading && !showInitialError;
   const showRefetchError = isRefetchError && !isFetchNextPageError && projects.length > 0;
-
-  const fetchNextProjectPage = useCallback(() => {
-    if (fetchNextPageInFlightRef.current || isFetchingNextPage || !hasNextPage) {
-      return;
-    }
-
-    fetchNextPageInFlightRef.current = true;
-    void fetchNextPage({ cancelRefetch: false }).finally(() => {
-      fetchNextPageInFlightRef.current = false;
+  const { loadNextPage: fetchNextProjectPage, sentinelRef: loadMoreSentinelRef } =
+    useLazyLoadSentinel({
+      enabled: showPaginationStatus && !isFetching && !isProjectsError,
+      fetchNextPage,
+      hasNextPage,
+      isFetchingNextPage,
+      rootMargin: "320px 0px",
     });
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
-
-  useEffect(() => {
-    const sentinel = loadMoreSentinelRef.current;
-    if (
-      !sentinel ||
-      !hasNextPage ||
-      isFetching ||
-      isFetchingNextPage ||
-      isProjectsError ||
-      typeof IntersectionObserver === "undefined"
-    ) {
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const [entry] = entries;
-        if (!entry?.isIntersecting || isFetching || isFetchingNextPage) {
-          return;
-        }
-
-        fetchNextProjectPage();
-      },
-      { rootMargin: "320px 0px" },
-    );
-
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [
-    fetchNextProjectPage,
-    hasNextPage,
-    isFetching,
-    isFetchingNextPage,
-    isProjectsError,
-  ]);
 
   return (
     <section className="screen">

--- a/apps/desktop/src/lib/useLazyLoadSentinel.ts
+++ b/apps/desktop/src/lib/useLazyLoadSentinel.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useRef } from "react";
+
+type FetchNextPage = (options: { cancelRefetch: false }) => Promise<unknown>;
+
+type UseLazyLoadSentinelOptions = {
+  enabled: boolean;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: FetchNextPage;
+  rootMargin?: string;
+};
+
+export function useLazyLoadSentinel<TElement extends Element = HTMLDivElement>({
+  enabled,
+  fetchNextPage,
+  hasNextPage,
+  isFetchingNextPage,
+  rootMargin = "320px 0px",
+}: UseLazyLoadSentinelOptions) {
+  const sentinelRef = useRef<TElement | null>(null);
+  const fetchNextPageInFlightRef = useRef(false);
+
+  const loadNextPage = useCallback(() => {
+    if (fetchNextPageInFlightRef.current || isFetchingNextPage || !hasNextPage) {
+      return;
+    }
+
+    fetchNextPageInFlightRef.current = true;
+    void fetchNextPage({ cancelRefetch: false })
+      .finally(() => {
+        fetchNextPageInFlightRef.current = false;
+      })
+      .catch(() => undefined);
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  useEffect(() => {
+    fetchNextPageInFlightRef.current = isFetchingNextPage;
+  }, [isFetchingNextPage]);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (
+      !enabled ||
+      !sentinel ||
+      !hasNextPage ||
+      isFetchingNextPage ||
+      typeof IntersectionObserver === "undefined"
+    ) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const [entry] = entries;
+        if (!entry?.isIntersecting || fetchNextPageInFlightRef.current) {
+          return;
+        }
+
+        loadNextPage();
+      },
+      { rootMargin },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [enabled, hasNextPage, isFetchingNextPage, loadNextPage, rootMargin]);
+
+  return { sentinelRef, loadNextPage };
+}


### PR DESCRIPTION
## Summary

- Extract shared lazy-load sentinel handling for desktop paginated lists.
- Use the shared hook for Activity Jobs history auto-loading and manual load-more retries.
- Keep history auto-load disabled during terminal history refetches to avoid dropped page requests.

Closes #149

## Testing

- `pnpm --filter @tuneforge/desktop test --run src/App.activity.test.tsx src/App.library.test.tsx`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
- `git diff --check`
