### PR TITLE
feat: paginate project job history

### DIFF
--- a/apps/desktop/src/App.project-playback-artifacts.test.tsx
+++ b/apps/desktop/src/App.project-playback-artifacts.test.tsx
@@ -25,6 +25,54 @@ import {
   selectFirstStemInAnalysis,
 } from "./test/projectTestActions";
 
+const PROJECT_JOB_HISTORY_PAGE_SIZE = 50;
+const TERMINAL_JOB_STATUSES = ["completed", "failed", "cancelled"] as const;
+
+function getJobsHistoryDetails() {
+  const jobHistory = screen.getByText("Show raw artifacts and processing history").closest("details");
+  expect(jobHistory).not.toBeNull();
+  return jobHistory as HTMLElement;
+}
+
+async function expectProjectJobsRequested(projectId: string) {
+  await waitFor(() =>
+    expect(mockListJobs.mock.calls.some(([params]) => params?.project_id === projectId)).toBe(true),
+  );
+}
+
+async function expectProjectTerminalJobsPageRequested(offset: number) {
+  await waitFor(() => {
+    const hasMatchingCall = mockListJobs.mock.calls.some(([params]) => {
+      const status = params?.status;
+      return (
+        params?.project_id === "proj_123" &&
+        params.limit === PROJECT_JOB_HISTORY_PAGE_SIZE &&
+        params.offset === offset &&
+        Array.isArray(status) &&
+        status.length === TERMINAL_JOB_STATUSES.length &&
+        TERMINAL_JOB_STATUSES.every((terminalStatus) => status.includes(terminalStatus))
+      );
+    });
+
+    expect(hasMatchingCall).toBe(true);
+  });
+}
+
+function terminalJob(index: number, overrides: Record<string, unknown> = {}) {
+  return {
+    id: `job_terminal_${index}`,
+    project_id: "proj_123",
+    type: "export",
+    status: "completed",
+    progress: 100,
+    source_artifact_id: null,
+    error_message: null,
+    created_at: `2026-04-18T13:${String(index % 60).padStart(2, "0")}:00.000Z`,
+    updated_at: `2026-04-18T13:${String(index % 60).padStart(2, "0")}:00.000Z`,
+    ...overrides,
+  };
+}
+
 describe("Desktop app project playback artifacts", () => {
   beforeEach(resetAppTestHarness);
 
@@ -143,9 +191,88 @@ describe("Desktop app project playback artifacts", () => {
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
-    await waitFor(() => expect(mockListJobs).toHaveBeenCalledWith({ project_id: "proj_123" }));
+    await expectProjectJobsRequested("proj_123");
     const stemError = await screen.findByRole("group", { name: "Stem error" });
     expect(within(stemError).getByText("Selected project stems failed.")).toBeInTheDocument();
+  });
+
+  it("loads later project terminal job pages with scoped filters", async () => {
+    const user = userEvent.setup();
+    setJobs([
+      ...Array.from({ length: PROJECT_JOB_HISTORY_PAGE_SIZE }, (_, index) =>
+        terminalJob(index, { id: `job_initial_terminal_${index}` }),
+      ),
+      terminalJob(PROJECT_JOB_HISTORY_PAGE_SIZE, {
+        id: "job_terminal_second_page",
+        status: "failed",
+        error_message: "Second terminal jobs page failed export.",
+      }),
+      {
+        id: "job_other_project_terminal",
+        project_id: "proj_other",
+        type: "export",
+        status: "failed",
+        progress: 100,
+        source_artifact_id: null,
+        error_message: "Other project failure must stay hidden.",
+        created_at: "2026-04-18T13:59:00.000Z",
+        updated_at: "2026-04-18T13:59:00.000Z",
+      },
+    ]);
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openAnalysisPanel(user);
+    await user.click(screen.getByText("Show raw artifacts and processing history"));
+
+    const jobHistory = getJobsHistoryDetails();
+    await expectProjectTerminalJobsPageRequested(0);
+    expect(within(jobHistory).queryByText("Second terminal jobs page failed export.")).not.toBeInTheDocument();
+
+    await user.click(within(jobHistory).getByRole("button", { name: /load more/i }));
+
+    await expectProjectTerminalJobsPageRequested(PROJECT_JOB_HISTORY_PAGE_SIZE);
+    expect(await within(jobHistory).findByText("Second terminal jobs page failed export.")).toBeInTheDocument();
+    expect(within(jobHistory).queryByText("Other project failure must stay hidden.")).not.toBeInTheDocument();
+  });
+
+  it("keeps loaded project job history visible when the next page fails", async () => {
+    const user = userEvent.setup();
+    setJobs([
+      terminalJob(0, {
+        id: "job_terminal_loaded_first",
+        status: "failed",
+        error_message: "Loaded terminal history stays visible.",
+      }),
+      ...Array.from({ length: PROJECT_JOB_HISTORY_PAGE_SIZE - 1 }, (_, index) =>
+        terminalJob(index + 1, { id: `job_terminal_loaded_${index + 1}` }),
+      ),
+      terminalJob(PROJECT_JOB_HISTORY_PAGE_SIZE, {
+        id: "job_terminal_unloaded_after_failure",
+        status: "failed",
+        error_message: "Unloaded terminal history stays hidden.",
+      }),
+    ]);
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openAnalysisPanel(user);
+    await user.click(screen.getByText("Show raw artifacts and processing history"));
+
+    const jobHistory = getJobsHistoryDetails();
+    await expectProjectTerminalJobsPageRequested(0);
+    expect(within(jobHistory).getByText("Loaded terminal history stays visible.")).toBeInTheDocument();
+
+    mockListJobs.mockClear();
+    mockListJobs.mockRejectedValueOnce(new Error("Project job history page failed."));
+    await user.click(within(jobHistory).getByRole("button", { name: /load more/i }));
+
+    await expectProjectTerminalJobsPageRequested(PROJECT_JOB_HISTORY_PAGE_SIZE);
+    expect(within(jobHistory).getByText("Loaded terminal history stays visible.")).toBeInTheDocument();
+    expect(within(jobHistory).queryByText("Unloaded terminal history stays hidden.")).not.toBeInTheDocument();
+    expect(await within(jobHistory).findByText("Could not load more history.")).toBeInTheDocument();
   });
 
   it("deletes a visible stem from the sources rail", async () => {

--- a/apps/desktop/src/features/projects/components/JobsHistory.tsx
+++ b/apps/desktop/src/features/projects/components/JobsHistory.tsx
@@ -4,63 +4,108 @@ import { artifactLabel, artifactSummary, formatArtifactTimestamp, formatJobStatu
 export function JobsHistory() {
   const {
     displayArtifacts,
+    hasNextProjectHistoryJobsPage,
     informationDensity,
+    isFetchNextProjectHistoryJobsPageError,
+    isFetchingNextProjectHistoryJobsPage,
+    isProjectJobsError,
+    isProjectJobsLoading,
+    loadNextProjectHistoryJobsPage,
     showSupportingCopy,
     visibleJobs,
   } = useProjectViewModelContext();
+  const hasJobs = visibleJobs.length > 0;
+  const showNoJobs = !isProjectJobsLoading && !isProjectJobsError && !hasJobs;
 
   return (
     <div className="panel jobs-history">
       <div className="panel-heading">
         <div>
-      <h2>Jobs and History</h2>
-      {showSupportingCopy ? (
-        <p className="subpanel__copy">
-          Raw artifacts and job logs stay available without crowding playback.
-        </p>
-      ) : null}
+          <h2>Jobs and History</h2>
+          {showSupportingCopy ? (
+            <p className="subpanel__copy">
+              Raw artifacts and job logs stay available without crowding playback.
+            </p>
+          ) : null}
         </div>
       </div>
 
       <details className="details-block details-block--flush">
         <summary>Show raw artifacts and processing history</summary>
         <div className="details-stack">
-      <ul className="artifact-list">
-        {displayArtifacts.length ? (
-          displayArtifacts.map((artifact) => (
-            <li key={artifact.id}>
-              <span>{artifactLabel(artifact)}</span>
-              <small>{artifact.format.toUpperCase()}</small>
-              <small>{formatArtifactTimestamp(artifact.created_at)}</small>
-              {informationDensity === "detailed" && artifactSummary(artifact) ? (
-                <small>{artifactSummary(artifact)}</small>
-              ) : null}
-            </li>
-          ))
-        ) : (
-          <li>No artifacts yet.</li>
-        )}
-      </ul>
+          <ul className="artifact-list">
+            {displayArtifacts.length ? (
+              displayArtifacts.map((artifact) => (
+                <li key={artifact.id}>
+                  <span>{artifactLabel(artifact)}</span>
+                  <small>{artifact.format.toUpperCase()}</small>
+                  <small>{formatArtifactTimestamp(artifact.created_at)}</small>
+                  {informationDensity === "detailed" && artifactSummary(artifact) ? (
+                    <small>{artifactSummary(artifact)}</small>
+                  ) : null}
+                </li>
+              ))
+            ) : (
+              <li>No artifacts yet.</li>
+            )}
+          </ul>
 
-      <ul className="job-list">
-        {visibleJobs.length ? (
-          visibleJobs.map((job) => (
-            <li key={job.id}>
-              <div>
-                <strong>{job.type}</strong>
-                <span>{formatJobStatusSummary(job)}</span>
-              </div>
-              <progress max={100} value={job.progress} />
-              <small>{formatArtifactTimestamp(job.completed_at ?? job.updated_at)}</small>
-              {job.error_message ? (
-                <small className="inline-error">{job.error_message}</small>
-              ) : null}
-            </li>
-          ))
-        ) : (
-          <li>No jobs yet.</li>
-        )}
-      </ul>
+          <div className="job-history-list">
+            {isProjectJobsLoading ? (
+              <p className="job-history-list__state" role="status">
+                Loading job history...
+              </p>
+            ) : null}
+
+            {isProjectJobsError ? (
+              <p className="job-history-list__state inline-error" role="alert">
+                Could not load job history.
+              </p>
+            ) : null}
+
+            <ul
+              aria-busy={isProjectJobsLoading || isFetchingNextProjectHistoryJobsPage}
+              aria-label="Project job history"
+              className="job-list"
+            >
+              {hasJobs
+                ? visibleJobs.map((job) => (
+                    <li key={job.id}>
+                      <div>
+                        <strong>{job.type}</strong>
+                        <span>{formatJobStatusSummary(job)}</span>
+                      </div>
+                      <progress max={100} value={job.progress} />
+                      <small>{formatArtifactTimestamp(job.completed_at ?? job.updated_at)}</small>
+                      {job.error_message ? (
+                        <small className="inline-error">{job.error_message}</small>
+                      ) : null}
+                    </li>
+                  ))
+                : null}
+            </ul>
+
+            {showNoJobs ? <p className="job-history-list__state">No jobs yet.</p> : null}
+
+            {isFetchNextProjectHistoryJobsPageError ? (
+              <p className="job-history-list__state inline-error" role="alert">
+                Could not load more history.
+              </p>
+            ) : null}
+
+            {hasNextProjectHistoryJobsPage ? (
+              <button
+                className="button button--ghost button--small job-history-list__load-more"
+                disabled={isFetchingNextProjectHistoryJobsPage}
+                onClick={() => {
+                  void loadNextProjectHistoryJobsPage();
+                }}
+                type="button"
+              >
+                {isFetchingNextProjectHistoryJobsPage ? "Loading history..." : "Load more history"}
+              </button>
+            ) : null}
+          </div>
         </div>
       </details>
     </div>

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -1,11 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
 import { confirm, save } from "@tauri-apps/plugin-dialog";
 import {
   api,
   getProjectSyncSummary,
   type ArtifactSchema,
+  type JobSchema,
   type ProjectSchema,
 } from "../../../lib/api";
 import { usePreferences } from "../../../lib/preferences";
@@ -82,12 +83,28 @@ import {
 } from "../playbackTempo";
 
 type PlaybackDisplayModeSource = "default" | "stored" | "user";
+const ACTIVE_PROJECT_JOB_STATUSES = ["running", "pending"] as const;
+const TERMINAL_PROJECT_JOB_STATUSES = ["completed", "failed", "cancelled"] as const;
+const ACTIVE_PROJECT_JOBS_LIMIT = 200;
+const PROJECT_HISTORY_JOBS_PAGE_SIZE = 50;
+const EMPTY_JOBS: JobSchema[] = [];
+
 type DeleteArtifactsRequest = {
   artifactIds: string[];
   nextSelectedArtifactId?: string | null;
   nextSelectedPrimaryArtifactId?: string | null;
   stemArtifactIds?: string[];
 };
+
+function getNextJobsPageOffset(lastPage: { has_more: boolean; offset: number; jobs: JobSchema[] }) {
+  return lastPage.has_more ? lastPage.offset + lastPage.jobs.length : undefined;
+}
+
+function uniqueJobsById(jobs: JobSchema[]) {
+  const jobsById = new Map<string, JobSchema>();
+  jobs.forEach((job) => jobsById.set(job.id, job));
+  return Array.from(jobsById.values());
+}
 
 function resolveDefaultPlaybackDisplayMode(
   defaultMode: DefaultPlaybackDisplayMode,
@@ -271,10 +288,31 @@ export function useProjectViewModel() {
     queryFn: async () => (await api.listArtifacts(projectId)).artifacts,
     enabled: Boolean(projectId),
   });
-  const jobsQuery = useQuery({
-    queryKey: ["jobs", { projectId }],
-    queryFn: async () => (await api.listJobs({ project_id: projectId })).jobs,
+  const activeProjectJobsQuery = useInfiniteQuery({
+    queryKey: ["jobs", { projectId, scope: "project", status: "active" }],
+    initialPageParam: 0,
+    queryFn: async ({ pageParam }) =>
+      api.listJobs({
+        project_id: projectId,
+        status: [...ACTIVE_PROJECT_JOB_STATUSES],
+        limit: ACTIVE_PROJECT_JOBS_LIMIT,
+        offset: pageParam,
+      }),
     enabled: Boolean(projectId),
+    getNextPageParam: getNextJobsPageOffset,
+  });
+  const terminalProjectJobsQuery = useInfiniteQuery({
+    queryKey: ["jobs", { projectId, scope: "project", status: "terminal" }],
+    initialPageParam: 0,
+    queryFn: async ({ pageParam }) =>
+      api.listJobs({
+        project_id: projectId,
+        status: [...TERMINAL_PROJECT_JOB_STATUSES],
+        limit: PROJECT_HISTORY_JOBS_PAGE_SIZE,
+        offset: pageParam,
+      }),
+    enabled: Boolean(projectId),
+    getNextPageParam: getNextJobsPageOffset,
   });
   const mobileCapabilitiesQuery = useQuery({
     queryKey: ["mobile-capabilities"],
@@ -293,8 +331,6 @@ export function useProjectViewModel() {
       throw new Error(projectSyncLockReason ?? "This project is locked for editing.");
     }
   }
-
-  useActiveJobPolling(projectId, jobsQuery.data);
 
   const analyzeMutation = useMutation({
     mutationFn: () => {
@@ -580,7 +616,26 @@ export function useProjectViewModel() {
     },
   });
 
-  const projectJobs = useMemo(() => jobsQuery.data ?? [], [jobsQuery.data]);
+  const activeProjectJobs = useMemo(
+    () => activeProjectJobsQuery.data?.pages.flatMap((page) => page.jobs) ?? EMPTY_JOBS,
+    [activeProjectJobsQuery.data],
+  );
+  const terminalProjectJobs = useMemo(
+    () => terminalProjectJobsQuery.data?.pages.flatMap((page) => page.jobs) ?? EMPTY_JOBS,
+    [terminalProjectJobsQuery.data],
+  );
+  const projectJobs = useMemo(
+    () => uniqueJobsById([...activeProjectJobs, ...terminalProjectJobs]),
+    [activeProjectJobs, terminalProjectJobs],
+  );
+  const isProjectJobsLoading =
+    activeProjectJobsQuery.isLoading || terminalProjectJobsQuery.isLoading;
+  const isProjectJobsError = activeProjectJobsQuery.isError || terminalProjectJobsQuery.isError;
+  const isProjectJobsLoaded =
+    activeProjectJobsQuery.isSuccess && terminalProjectJobsQuery.isSuccess;
+
+  useActiveJobPolling(projectId, projectJobs);
+
   const analyzeJob = projectJobs.find((job) => job.type === "analyze");
   const chordJob = projectJobs.find((job) => job.type === "chords");
   const lyricsJob = projectJobs.find((job) => job.type === "lyrics");
@@ -1748,7 +1803,7 @@ export function useProjectViewModel() {
   }, [visibleStemArtifacts]);
 
   useEffect(() => {
-    if (hydratedProjectId !== projectId || !jobsQuery.data) {
+    if (hydratedProjectId !== projectId || !isProjectJobsLoaded) {
       return;
     }
 
@@ -1757,7 +1812,7 @@ export function useProjectViewModel() {
       const next = current.filter((jobId) => activeStemJobIds.has(jobId));
       return next.length === current.length ? current : next;
     });
-  }, [hydratedProjectId, jobsQuery.data, projectId, stemJobs]);
+  }, [hydratedProjectId, isProjectJobsLoaded, projectId, stemJobs]);
 
   useEffect(() => {
     if (!loopStatusMessage || typeof window === "undefined") {
@@ -2164,6 +2219,7 @@ export function useProjectViewModel() {
     hasTimedLyricsTranscript,
     hasTransformChange,
     hasVisibleStems,
+    hasNextProjectHistoryJobsPage: terminalProjectJobsQuery.hasNextPage,
     higherCapoPreview,
     higherCapoShiftOptions,
     higherTargetPreview,
@@ -2178,6 +2234,10 @@ export function useProjectViewModel() {
     isLyricsRunning,
     isMobileRuntime,
     isPlaying,
+    isFetchingNextProjectHistoryJobsPage: terminalProjectJobsQuery.isFetchingNextPage,
+    isFetchNextProjectHistoryJobsPageError: terminalProjectJobsQuery.isFetchNextPageError,
+    isProjectJobsError,
+    isProjectJobsLoading,
     loopRange,
     loopAlignmentMode,
     loopAlignmentModeOverride,
@@ -2188,6 +2248,7 @@ export function useProjectViewModel() {
     isStemPlayback,
     isStemRunning,
     latestPreviewArtifact,
+    loadNextProjectHistoryJobsPage: terminalProjectJobsQuery.fetchNextPage,
     lowerCapoPreview,
     lowerCapoShiftOptions,
     lowerTargetPreview,

--- a/apps/desktop/src/styles/project-history.css
+++ b/apps/desktop/src/styles/project-history.css
@@ -35,6 +35,20 @@
   gap: 0.8rem;
 }
 
+.job-history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.job-history-list__state {
+  margin: 0;
+}
+
+.job-history-list__load-more {
+  align-self: flex-start;
+}
+
 .artifact-list li,
 .job-list li {
   display: flex;
@@ -55,4 +69,3 @@
   justify-content: space-between;
   gap: 1rem;
 }
-


### PR DESCRIPTION
## Summary

- Load project-scoped jobs through active and terminal paginated queries.
- Add project job history loading, page-error, and load-more UI while keeping artifacts unpaginated.
- Add regressions for terminal history pagination and next-page failures.
- Closes #150

## Testing

- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test --run src/App.project-playback-artifacts.test.tsx src/App.project-playback-stems.test.tsx src/App.activity.test.tsx`
- `pnpm --filter @tuneforge/desktop lint`
- `git diff --check`
- Reviewer: no findings.
- Contract guard: no issues; contract generation not needed.
