### PR TITLE
feat: add job project search

### DIFF
--- a/apps/backend/app/api/routes/jobs.py
+++ b/apps/backend/app/api/routes/jobs.py
@@ -18,6 +18,7 @@ def list_jobs(
     pagination: PaginationQuery,
     status: list[str] | None = Query(default=None, description="Filter jobs by status. May be repeated."),
     project_id: str | None = Query(default=None, description="Filter jobs by project ID."),
+    search: str | None = Query(default=None, description="Filter jobs by project display name."),
     session: Session = Depends(get_db),
 ) -> JobsResponse:
     listed_jobs = list_jobs_service(
@@ -26,6 +27,7 @@ def list_jobs(
         offset=pagination.offset,
         statuses=status,
         project_id=project_id,
+        search=search,
     )
     jobs = [JobSchema.model_validate(job) for job in listed_jobs.jobs]
     metadata = pagination_metadata(

--- a/apps/backend/app/services/jobs.py
+++ b/apps/backend/app/services/jobs.py
@@ -12,7 +12,7 @@ from sqlalchemy import case, func, select
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.errors import AppError, JobCancelledError
-from app.models import Artifact, ChordTimeline, Job, utcnow
+from app.models import Artifact, ChordTimeline, Job, Project, utcnow
 from app.services.analysis import analyze_project
 from app.services.chord_backends import resolve_chord_backend
 from app.services.chords import detect_project_chords, project_chord_detection_source
@@ -84,6 +84,7 @@ def list_jobs(
     offset: int,
     statuses: Sequence[str] | None = None,
     project_id: str | None = None,
+    search: str | None = None,
 ) -> ListedJobs:
     filters: list[Any] = []
     status_filters = tuple(statuses or ())
@@ -91,9 +92,16 @@ def list_jobs(
         filters.append(Job.status.in_(status_filters))
     if project_id is not None:
         filters.append(Job.project_id == project_id)
+    normalized_search = (search or "").strip().lower()
+    search_projects = bool(normalized_search)
+    if search_projects:
+        filters.append(func.lower(Project.display_name).contains(normalized_search, autoescape=True))
 
     total_statement = select(func.count()).select_from(Job)
     jobs_statement = select(Job)
+    if search_projects:
+        total_statement = total_statement.join(Project, Project.id == Job.project_id)
+        jobs_statement = jobs_statement.join(Project, Project.id == Job.project_id)
     if filters:
         total_statement = total_statement.where(*filters)
         jobs_statement = jobs_statement.where(*filters)

--- a/apps/backend/tests/test_jobs_api.py
+++ b/apps/backend/tests/test_jobs_api.py
@@ -16,11 +16,11 @@ def _timestamp(minutes: int) -> datetime:
     return _BASE_TIME + timedelta(minutes=minutes)
 
 
-def _add_project(session: Session, project_id: str) -> None:
+def _add_project(session: Session, project_id: str, *, display_name: str | None = None) -> None:
     session.add(
         Project(
             id=project_id,
-            display_name=project_id,
+            display_name=display_name or project_id,
             source_path=f"/tmp/{project_id}.wav",
             imported_path=f"/tmp/tuneforge/{project_id}.wav",
         )
@@ -147,6 +147,126 @@ def test_list_jobs_filters_by_project_id(client: TestClient) -> None:
     payload = response.json()
     assert [job["id"] for job in payload["jobs"]] == ["job_project_a_1", "job_project_a_2"]
     assert payload["total"] == 2
+
+
+def test_list_jobs_search_applies_before_pagination(client: TestClient) -> None:
+    with SessionLocal() as session:
+        _add_project(session, "project_early", display_name="Earlier Song")
+        _add_project(session, "project_target", display_name="Deep Needle Match")
+        _add_job(session, "job_early_1", "pending", project_id="project_early", created_at=_timestamp(1))
+        _add_job(session, "job_early_2", "pending", project_id="project_early", created_at=_timestamp(2))
+        _add_job(session, "job_target", "pending", project_id="project_target", created_at=_timestamp(3))
+        session.commit()
+
+    response = client.get("/api/v1/jobs", params={"search": "  NEEDLE  ", "limit": "1"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [job["id"] for job in payload["jobs"]] == ["job_target"]
+    assert payload["total"] == 1
+    assert payload["has_more"] is False
+
+
+def test_list_jobs_search_combines_with_status_and_project_filters(client: TestClient) -> None:
+    with SessionLocal() as session:
+        _add_project(session, "project_a", display_name="Practice Alpha")
+        _add_project(session, "project_b", display_name="Practice Alpha")
+        _add_job(session, "job_a_pending", "pending", project_id="project_a", created_at=_timestamp(1))
+        _add_job(
+            session,
+            "job_a_completed",
+            "completed",
+            project_id="project_a",
+            completed_at=_timestamp(2),
+        )
+        _add_job(
+            session,
+            "job_b_completed",
+            "completed",
+            project_id="project_b",
+            completed_at=_timestamp(3),
+        )
+        session.commit()
+
+    response = client.get(
+        "/api/v1/jobs",
+        params=[("search", "alpha"), ("status", "completed"), ("project_id", "project_a")],
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [job["id"] for job in payload["jobs"]] == ["job_a_completed"]
+    assert payload["total"] == 1
+
+
+def test_list_jobs_search_excludes_no_project_jobs(client: TestClient) -> None:
+    with SessionLocal() as session:
+        _add_project(session, "project_match", display_name="Global Match")
+        _add_job(session, "job_project", "pending", project_id="project_match", created_at=_timestamp(1))
+        _add_job(session, "job_no_project", "pending", project_id=None, created_at=_timestamp(2))
+        session.commit()
+
+    search_response = client.get("/api/v1/jobs", params={"search": "match"})
+    no_search_response = client.get("/api/v1/jobs")
+
+    assert search_response.status_code == 200
+    assert [job["id"] for job in search_response.json()["jobs"]] == ["job_project"]
+    assert search_response.json()["total"] == 1
+    assert no_search_response.status_code == 200
+    assert [job["id"] for job in no_search_response.json()["jobs"]] == ["job_project", "job_no_project"]
+    assert no_search_response.json()["total"] == 2
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_job_id"),
+    [
+        ("%", "job_percent"),
+        ("_", "job_underscore"),
+    ],
+)
+def test_list_jobs_search_treats_like_metacharacters_as_literals(
+    client: TestClient,
+    query: str,
+    expected_job_id: str,
+) -> None:
+    with SessionLocal() as session:
+        _add_project(session, "project_percent", display_name="Mix 100%")
+        _add_project(session, "project_underscore", display_name="rough_mix")
+        _add_project(session, "project_plain", display_name="Plain Song")
+        _add_job(session, "job_percent", "pending", project_id="project_percent", created_at=_timestamp(1))
+        _add_job(
+            session,
+            "job_underscore",
+            "pending",
+            project_id="project_underscore",
+            created_at=_timestamp(2),
+        )
+        _add_job(session, "job_plain", "pending", project_id="project_plain", created_at=_timestamp(3))
+        _add_job(session, "job_no_project", "pending", project_id=None, created_at=_timestamp(4))
+        session.commit()
+
+    response = client.get("/api/v1/jobs", params={"search": query})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [job["id"] for job in payload["jobs"]] == [expected_job_id]
+    assert payload["total"] == 1
+
+
+def test_list_jobs_empty_search_preserves_existing_behavior(client: TestClient) -> None:
+    with SessionLocal() as session:
+        _add_project(session, "project_a", display_name="Project A")
+        _add_job(session, "job_project", "pending", project_id="project_a", created_at=_timestamp(1))
+        _add_job(session, "job_no_project", "pending", project_id=None, created_at=_timestamp(2))
+        session.commit()
+
+    no_search_payload = client.get("/api/v1/jobs").json()
+    empty_search_payload = client.get("/api/v1/jobs", params={"search": "   "}).json()
+
+    assert [job["id"] for job in empty_search_payload["jobs"]] == [
+        job["id"] for job in no_search_payload["jobs"]
+    ]
+    assert empty_search_payload["total"] == no_search_payload["total"]
 
 
 def test_list_jobs_keeps_terminal_pages_stable(client: TestClient) -> None:

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -139,6 +139,71 @@ describe("Desktop app activity", () => {
     expect(mockListJobs.mock.calls.some(([params]) => params === undefined)).toBe(false);
   });
 
+  it("searches activity jobs by project name", async () => {
+    setProjects([
+      project({ id: "proj_choir", display_name: "Choir Practice" }),
+      project({ id: "proj_drums", display_name: "Drum Study" }),
+    ]);
+    setJobs([
+      job({
+        id: "job_choir_active",
+        project_id: "proj_choir",
+        type: "stems",
+        status: "running",
+        progress: 50,
+      }),
+      job({
+        id: "job_choir_history",
+        project_id: "proj_choir",
+        type: "lyrics",
+        status: "completed",
+        progress: 100,
+      }),
+      job({
+        id: "job_drums",
+        project_id: "proj_drums",
+        type: "analyze",
+        status: "completed",
+        progress: 100,
+      }),
+      job({
+        id: "job_no_project",
+        project_id: null,
+        type: "export",
+        status: "completed",
+        progress: 100,
+      }),
+    ]);
+
+    renderApp(["/activity"]);
+
+    expect(await screen.findByRole("article", { name: "stems running job" })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Search jobs by project"), {
+      target: { value: " choir " },
+    });
+
+    await waitFor(() =>
+      expect(mockListJobs).toHaveBeenCalledWith({
+        status: ["running", "pending"],
+        search: "choir",
+        limit: 200,
+        offset: 0,
+      }),
+    );
+    expect(mockListJobs).toHaveBeenCalledWith({
+      status: ["completed", "failed", "cancelled"],
+      search: "choir",
+      limit: 50,
+      offset: 0,
+    });
+    expect(await screen.findByRole("article", { name: "lyrics completed job" })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByRole("article", { name: "analyze completed job" })).not.toBeInTheDocument(),
+    );
+    expect(screen.queryByRole("article", { name: "export completed job" })).not.toBeInTheDocument();
+  });
+
   it("resolves job project names from project details outside the first project page", async () => {
     const deepProjectId = "proj_055";
     setProjects(

--- a/apps/desktop/src/features/activity/ActivityView.tsx
+++ b/apps/desktop/src/features/activity/ActivityView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { useInfiniteQuery, useMutation, useQueries, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import { api, type JobSchema, type ProjectSchema } from "../../lib/api";
@@ -232,14 +232,25 @@ function JobRow({
 
 export function ActivityView() {
   const [activeTab, setActiveTab] = useState<ActivityTab>("jobs");
+  const [searchDraft, setSearchDraft] = useState("");
+  const deferredSearch = useDeferredValue(searchDraft.trim());
   const previousActiveJobIds = useRef<Set<string>>(new Set());
   const queryClient = useQueryClient();
+  const activeJobsQueryKey = useMemo(
+    () => [...ACTIVE_JOBS_QUERY_KEY, deferredSearch] as const,
+    [deferredSearch],
+  );
+  const terminalJobsQueryKey = useMemo(
+    () => [...TERMINAL_JOBS_QUERY_KEY, deferredSearch] as const,
+    [deferredSearch],
+  );
   const activeJobsQuery = useInfiniteQuery({
-    queryKey: ACTIVE_JOBS_QUERY_KEY,
+    queryKey: activeJobsQueryKey,
     initialPageParam: 0,
     queryFn: async ({ pageParam }) =>
       api.listJobs({
         status: [...ACTIVE_JOB_STATUSES],
+        ...(deferredSearch ? { search: deferredSearch } : {}),
         limit: ACTIVE_JOBS_LIMIT,
         offset: pageParam,
       }),
@@ -256,11 +267,12 @@ export function ActivityView() {
     isSuccess: isActiveJobsSuccess,
   } = activeJobsQuery;
   const terminalJobsQuery = useInfiniteQuery({
-    queryKey: TERMINAL_JOBS_QUERY_KEY,
+    queryKey: terminalJobsQueryKey,
     initialPageParam: 0,
     queryFn: async ({ pageParam }) =>
       api.listJobs({
         status: [...TERMINAL_JOB_STATUS_VALUES],
+        ...(deferredSearch ? { search: deferredSearch } : {}),
         limit: TERMINAL_JOBS_PAGE_SIZE,
         offset: pageParam,
       }),
@@ -346,11 +358,11 @@ export function ActivityView() {
     if (!shouldPollJobs) return;
 
     const interval = window.setInterval(async () => {
-      await queryClient.invalidateQueries({ queryKey: ACTIVE_JOBS_QUERY_KEY });
+      await queryClient.invalidateQueries({ queryKey: activeJobsQueryKey });
     }, ACTIVE_JOB_REFETCH_MS);
 
     return () => window.clearInterval(interval);
-  }, [queryClient, shouldPollJobs]);
+  }, [activeJobsQueryKey, queryClient, shouldPollJobs]);
 
   useEffect(() => {
     if (!hasNextActiveJobsPage || isFetchingNextActiveJobsPage) return;
@@ -368,9 +380,9 @@ export function ActivityView() {
     previousActiveJobIds.current = currentActiveJobIds;
 
     if (activeJobLeftQueue) {
-      queryClient.invalidateQueries({ queryKey: TERMINAL_JOBS_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: terminalJobsQueryKey });
     }
-  }, [activeJobs, isActiveJobsSuccess, queryClient]);
+  }, [activeJobs, isActiveJobsSuccess, queryClient, terminalJobsQueryKey]);
 
   return (
     <section className="screen activity-screen">
@@ -417,6 +429,17 @@ export function ActivityView() {
                   : "No pending or running jobs."}
               </p>
             </div>
+            <label className="search-field">
+              <span className="search-field__label">Search jobs</span>
+              <input
+                aria-label="Search jobs by project"
+                className="search-field__input"
+                placeholder="Search project names"
+                type="search"
+                value={searchDraft}
+                onChange={(event) => setSearchDraft(event.target.value)}
+              />
+            </label>
           </div>
 
           {isLoading ? (
@@ -470,8 +493,12 @@ export function ActivityView() {
 
           {showEmptyState ? (
             <div className="activity-jobs-panel__empty">
-              <h3>No jobs yet</h3>
-              <p>Import or process a track to populate the queue.</p>
+              <h3>{deferredSearch ? "No matching jobs" : "No jobs yet"}</h3>
+              <p>
+                {deferredSearch
+                  ? "Try a different project name or clear the search."
+                  : "Import or process a track to populate the queue."}
+              </p>
             </div>
           ) : null}
         </section>

--- a/apps/desktop/src/styles/activity.css
+++ b/apps/desktop/src/styles/activity.css
@@ -11,6 +11,14 @@
   align-items: center;
 }
 
+.activity-jobs-panel__heading .search-field {
+  width: min(20rem, 100%);
+}
+
+.activity-jobs-panel__heading .search-field__input {
+  min-height: 3.2rem;
+}
+
 .activity-jobs-panel__state,
 .activity-jobs-panel__empty {
   border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -1200,12 +1200,19 @@ const {
   const mockListJobs = vi.fn(async (params?: ListJobsParams) => {
     const normalizedJobs = state.jobs.map((job, index) => normalizeMockJob(job, index));
     const statusFilters = Array.isArray(params?.status) ? params.status : [];
+    const normalizedSearch = params?.search?.trim().toLowerCase();
     const filteredJobs = normalizedJobs.filter((job) => {
       const statusMatches =
         statusFilters.length === 0 || statusFilters.includes(String(job.status));
       const projectMatches =
         params?.project_id == null || job.project_id === params.project_id;
-      return statusMatches && projectMatches;
+      const searchMatches = normalizedSearch
+        ? state.projects.some((project) => {
+            const displayName = String(project.display_name ?? "").toLowerCase();
+            return project.id === job.project_id && displayName.includes(normalizedSearch);
+          })
+        : true;
+      return statusMatches && projectMatches && searchMatches;
     });
     const offset = params?.offset ?? 0;
     const limit = params?.limit ?? DEFAULT_JOBS_LIMIT;

--- a/docs/API.md
+++ b/docs/API.md
@@ -59,7 +59,7 @@ describe current pagination behavior or explicit unpaginated exceptions.
 
 | Endpoint or payload | List field | Pagination decision |
 | --- | --- | --- |
-| `GET /api/v1/jobs` | `jobs` | Paginated growable list with `status` and `project_id` filters. Default ordering is active-first and deterministic. |
+| `GET /api/v1/jobs` | `jobs` | Paginated growable list with `status`, `project_id`, and project-name `search` filters. Default ordering is active-first and deterministic. |
 | `GET /api/v1/projects` | `projects` | Paginated growable list. `search` filters the full matching collection before pagination. Default ordering is `updated_at DESC, id DESC`. Desktop Library consumers should lazy-load this list. |
 | `GET /api/v1/projects/{project_id}/artifacts` | `artifacts` | Explicit unpaginated bounded project inventory exception: source audio, generated stems, practice mixes, exports, and cache artifacts. Ordered by `created_at DESC`; no pagination. |
 | `GET /api/v1/projects/{project_id}/sections` | `sections` | Explicit unpaginated project document/song-structure exception. Sections are bounded by the song arrangement and must stay complete for editing and playback. |
@@ -723,6 +723,8 @@ Query parameters:
 - `offset` - zero-based row offset, default `0`, minimum `0`.
 - `status` - optional repeatable status filter, for example `?status=pending&status=running`.
 - `project_id` - optional project ID filter.
+- `search` - optional project display name filter. Search is applied before pagination and composes with
+  `status` and `project_id` filters.
 
 Default ordering:
 

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -3097,6 +3097,8 @@ export interface operations {
                 status?: string[] | null;
                 /** @description Filter jobs by project ID. */
                 project_id?: string | null;
+                /** @description Filter jobs by project display name. */
+                search?: string | null;
                 /** @description Maximum number of items to return. */
                 limit?: number;
                 /** @description Number of items to skip before returning results. */


### PR DESCRIPTION
## Summary

- Add project-name `search` support to `GET /api/v1/jobs`.
- Wire Activity Jobs search to the new API parameter while keeping active and terminal pagination.
- Update generated shared types, docs, backend tests, and desktop harness coverage.

Closes #152

## Testing

- `cd apps/backend && uv run --python 3.11 pytest tests/test_jobs_api.py`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `pnpm contracts:generate`
- `pnpm --filter @tuneforge/desktop test --run src/App.activity.test.tsx`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm test`
