### PR TITLE
feat: add jobs API sorting

### DIFF
--- a/apps/backend/app/api/routes/jobs.py
+++ b/apps/backend/app/api/routes/jobs.py
@@ -8,6 +8,7 @@ from app.dependencies import get_db, get_job_runner
 from app.errors import AppError
 from app.models import Job
 from app.schemas import JobResponse, JobSchema, JobsResponse
+from app.services.jobs import JobSortBy, JobSortOrder
 from app.services.jobs import list_jobs as list_jobs_service
 
 router = APIRouter(prefix="/jobs", tags=["jobs"])
@@ -19,6 +20,8 @@ def list_jobs(
     status: list[str] | None = Query(default=None, description="Filter jobs by status. May be repeated."),
     project_id: str | None = Query(default=None, description="Filter jobs by project ID."),
     search: str | None = Query(default=None, description="Filter jobs by project display name."),
+    sort_by: JobSortBy = Query(default="activity", description="Sort jobs by activity, timestamp, or status."),
+    sort_order: JobSortOrder | None = Query(default=None, description="Sort direction. Not valid with activity sort."),
     session: Session = Depends(get_db),
 ) -> JobsResponse:
     listed_jobs = list_jobs_service(
@@ -28,6 +31,8 @@ def list_jobs(
         statuses=status,
         project_id=project_id,
         search=search,
+        sort_by=sort_by,
+        sort_order=sort_order,
     )
     jobs = [JobSchema.model_validate(job) for job in listed_jobs.jobs]
     metadata = pagination_metadata(

--- a/apps/backend/app/services/jobs.py
+++ b/apps/backend/app/services/jobs.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from subprocess import Popen
-from typing import Any
+from typing import Any, Literal
 
 from sqlalchemy import case, func, select
 from sqlalchemy.orm import Session, sessionmaker
@@ -41,17 +41,14 @@ class ListedJobs:
 
 
 JobHandler = Callable[["JobExecutionContext", Session, Job], JobExecutionResult]
+JobSortBy = Literal["activity", "created_at", "started_at", "updated_at", "status"]
+JobSortOrder = Literal["asc", "desc"]
+JobTimestampSortBy = Literal["created_at", "started_at", "updated_at"]
 
 _TERMINAL_JOB_STATUSES = ("completed", "cancelled", "failed")
 
 
-def _job_ordering() -> tuple[Any, ...]:
-    status_rank = case(
-        (Job.status == "running", 0),
-        (Job.status == "pending", 1),
-        (Job.status.in_(_TERMINAL_JOB_STATUSES), 2),
-        else_=3,
-    )
+def _job_activity_tie_breakers() -> tuple[Any, ...]:
     running_timestamp = case(
         (Job.status == "running", func.coalesce(Job.started_at, Job.created_at)),
         else_=None,
@@ -65,7 +62,6 @@ def _job_ordering() -> tuple[Any, ...]:
     )
     terminal_id = case((Job.status.in_(_TERMINAL_JOB_STATUSES), Job.id), else_=None)
     return (
-        status_rank.asc(),
         running_timestamp.asc(),
         running_id.asc(),
         pending_created_at.asc(),
@@ -77,6 +73,60 @@ def _job_ordering() -> tuple[Any, ...]:
     )
 
 
+def _job_ordering() -> tuple[Any, ...]:
+    status_rank = case(
+        (Job.status == "running", 0),
+        (Job.status == "pending", 1),
+        (Job.status.in_(_TERMINAL_JOB_STATUSES), 2),
+        else_=3,
+    )
+    return (status_rank.asc(), *_job_activity_tie_breakers())
+
+
+def _job_timestamp_ordering(sort_by: JobTimestampSortBy, sort_order: JobSortOrder | None) -> tuple[Any, ...]:
+    timestamp_column: Any
+    if sort_by == "created_at":
+        timestamp_column = Job.created_at
+    elif sort_by == "started_at":
+        timestamp_column = Job.started_at
+    else:
+        timestamp_column = Job.updated_at
+    direction = sort_order or "desc"
+    timestamp_ordering = timestamp_column.asc() if direction == "asc" else timestamp_column.desc()
+    return (timestamp_column.is_(None).asc(), timestamp_ordering, Job.id.asc())
+
+
+def _job_status_ordering(sort_order: JobSortOrder | None) -> tuple[Any, ...]:
+    status_rank = case(
+        (Job.status == "running", 0),
+        (Job.status == "pending", 1),
+        (Job.status == "completed", 2),
+        (Job.status == "cancelled", 3),
+        (Job.status == "failed", 4),
+        else_=5,
+    )
+    status_ordering = status_rank.desc() if sort_order == "desc" else status_rank.asc()
+    return (status_ordering, *_job_activity_tie_breakers())
+
+
+def _list_jobs_ordering(sort_by: JobSortBy, sort_order: JobSortOrder | None) -> tuple[Any, ...]:
+    if sort_by == "activity":
+        if sort_order is not None:
+            raise AppError(
+                "INVALID_REQUEST",
+                "sort_order is not valid when sort_by is activity.",
+                status_code=422,
+            )
+        return _job_ordering()
+    if sort_by == "status":
+        return _job_status_ordering(sort_order)
+    if sort_by == "created_at":
+        return _job_timestamp_ordering("created_at", sort_order)
+    if sort_by == "started_at":
+        return _job_timestamp_ordering("started_at", sort_order)
+    return _job_timestamp_ordering("updated_at", sort_order)
+
+
 def list_jobs(
     session: Session,
     *,
@@ -85,6 +135,8 @@ def list_jobs(
     statuses: Sequence[str] | None = None,
     project_id: str | None = None,
     search: str | None = None,
+    sort_by: JobSortBy = "activity",
+    sort_order: JobSortOrder | None = None,
 ) -> ListedJobs:
     filters: list[Any] = []
     status_filters = tuple(statuses or ())
@@ -107,7 +159,11 @@ def list_jobs(
         jobs_statement = jobs_statement.where(*filters)
 
     total = session.scalar(total_statement) or 0
-    jobs = list(session.scalars(jobs_statement.order_by(*_job_ordering()).limit(limit).offset(offset)))
+    jobs = list(
+        session.scalars(
+            jobs_statement.order_by(*_list_jobs_ordering(sort_by, sort_order)).limit(limit).offset(offset)
+        )
+    )
     return ListedJobs(jobs=jobs, total=total)
 
 

--- a/apps/backend/tests/test_jobs_api.py
+++ b/apps/backend/tests/test_jobs_api.py
@@ -113,6 +113,206 @@ def test_list_jobs_orders_active_before_terminal_then_unknown(client: TestClient
     ]
 
 
+@pytest.mark.parametrize(
+    ("sort_by", "field_name"),
+    [
+        ("created_at", "created_at"),
+        ("updated_at", "updated_at"),
+    ],
+)
+def test_list_jobs_sorts_timestamp_fields_descending_by_default(
+    client: TestClient,
+    sort_by: str,
+    field_name: str,
+) -> None:
+    with SessionLocal() as session:
+        _add_job(session, "job_old", "running", **{field_name: _timestamp(1)})
+        _add_job(session, "job_same_a", "pending", **{field_name: _timestamp(10)})
+        _add_job(session, "job_same_b", "completed", **{field_name: _timestamp(10)})
+        _add_job(session, "job_new", "failed", **{field_name: _timestamp(30)})
+        session.commit()
+
+    response = client.get("/api/v1/jobs", params={"sort_by": sort_by})
+
+    assert response.status_code == 200
+    assert [job["id"] for job in response.json()["jobs"]] == [
+        "job_new",
+        "job_same_a",
+        "job_same_b",
+        "job_old",
+    ]
+
+
+def test_list_jobs_sorts_started_at_with_nulls_last_and_stable_tiebreaker(client: TestClient) -> None:
+    with SessionLocal() as session:
+        _add_job(session, "job_unstarted", "pending", created_at=_timestamp(30))
+        _add_job(session, "job_started_a", "running", started_at=_timestamp(10))
+        _add_job(session, "job_started_b", "completed", started_at=_timestamp(10))
+        _add_job(session, "job_started_late", "failed", started_at=_timestamp(20))
+        session.commit()
+
+    descending_response = client.get("/api/v1/jobs", params={"sort_by": "started_at"})
+    ascending_response = client.get(
+        "/api/v1/jobs",
+        params={"sort_by": "started_at", "sort_order": "asc"},
+    )
+
+    assert descending_response.status_code == 200
+    assert [job["id"] for job in descending_response.json()["jobs"]] == [
+        "job_started_late",
+        "job_started_a",
+        "job_started_b",
+        "job_unstarted",
+    ]
+    assert ascending_response.status_code == 200
+    assert [job["id"] for job in ascending_response.json()["jobs"]] == [
+        "job_started_a",
+        "job_started_b",
+        "job_started_late",
+        "job_unstarted",
+    ]
+
+
+def test_list_jobs_sorts_status_groups_ascending_and_descending(client: TestClient) -> None:
+    with SessionLocal() as session:
+        _add_job(session, "job_running", "running", started_at=_timestamp(10))
+        _add_job(session, "job_pending", "pending", created_at=_timestamp(20))
+        _add_job(session, "job_completed", "completed", completed_at=_timestamp(30))
+        _add_job(session, "job_cancelled", "cancelled", completed_at=_timestamp(40))
+        _add_job(session, "job_failed", "failed", completed_at=_timestamp(50))
+        _add_job(session, "job_unknown", "paused", updated_at=_timestamp(60))
+        session.commit()
+
+    ascending_response = client.get("/api/v1/jobs", params={"sort_by": "status"})
+    descending_response = client.get(
+        "/api/v1/jobs",
+        params={"sort_by": "status", "sort_order": "desc"},
+    )
+
+    assert ascending_response.status_code == 200
+    assert [job["id"] for job in ascending_response.json()["jobs"]] == [
+        "job_running",
+        "job_pending",
+        "job_completed",
+        "job_cancelled",
+        "job_failed",
+        "job_unknown",
+    ]
+    assert descending_response.status_code == 200
+    assert [job["id"] for job in descending_response.json()["jobs"]] == [
+        "job_unknown",
+        "job_failed",
+        "job_cancelled",
+        "job_completed",
+        "job_pending",
+        "job_running",
+    ]
+
+
+def test_list_jobs_status_sort_uses_activity_tiebreakers_within_groups(client: TestClient) -> None:
+    with SessionLocal() as session:
+        _add_job(session, "job_pending_b", "pending", created_at=_timestamp(10))
+        _add_job(session, "job_pending_a", "pending", created_at=_timestamp(10))
+        _add_job(session, "job_running_late", "running", started_at=_timestamp(20))
+        _add_job(session, "job_running_early", "running", started_at=_timestamp(5))
+        session.commit()
+
+    response = client.get("/api/v1/jobs", params={"sort_by": "status"})
+
+    assert response.status_code == 200
+    assert [job["id"] for job in response.json()["jobs"]] == [
+        "job_running_early",
+        "job_running_late",
+        "job_pending_a",
+        "job_pending_b",
+    ]
+
+
+def test_list_jobs_sorting_composes_with_filters_search_and_pagination(client: TestClient) -> None:
+    with SessionLocal() as session:
+        _add_project(session, "project_a", display_name="Needle Song")
+        _add_project(session, "project_b", display_name="Needle Song")
+        _add_project(session, "project_c", display_name="Other Song")
+        _add_job(
+            session,
+            "job_match_old",
+            "completed",
+            project_id="project_a",
+            updated_at=_timestamp(10),
+        )
+        _add_job(
+            session,
+            "job_match_middle",
+            "completed",
+            project_id="project_a",
+            updated_at=_timestamp(20),
+        )
+        _add_job(
+            session,
+            "job_match_new",
+            "completed",
+            project_id="project_a",
+            updated_at=_timestamp(30),
+        )
+        _add_job(
+            session,
+            "job_status_excluded",
+            "pending",
+            project_id="project_a",
+            updated_at=_timestamp(40),
+        )
+        _add_job(
+            session,
+            "job_project_excluded",
+            "completed",
+            project_id="project_b",
+            updated_at=_timestamp(50),
+        )
+        _add_job(
+            session,
+            "job_search_excluded",
+            "completed",
+            project_id="project_c",
+            updated_at=_timestamp(60),
+        )
+        session.commit()
+
+    response = client.get(
+        "/api/v1/jobs",
+        params=[
+            ("search", "needle"),
+            ("status", "completed"),
+            ("project_id", "project_a"),
+            ("sort_by", "updated_at"),
+            ("limit", "2"),
+            ("offset", "1"),
+        ],
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [job["id"] for job in payload["jobs"]] == ["job_match_middle", "job_match_old"]
+    assert payload["total"] == 3
+    assert payload["has_more"] is False
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"sort_by": "activity", "sort_order": "asc"},
+        {"sort_order": "desc"},
+    ],
+)
+def test_list_jobs_rejects_sort_order_with_activity_sort(
+    client: TestClient,
+    params: dict[str, str],
+) -> None:
+    response = client.get("/api/v1/jobs", params=params)
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "INVALID_REQUEST"
+
+
 def test_list_jobs_accepts_repeatable_status_filter(client: TestClient) -> None:
     with SessionLocal() as session:
         _add_job(session, "job_pending", "pending", created_at=_timestamp(1))

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -128,11 +128,13 @@ describe("Desktop app activity", () => {
     await waitFor(() => expect(mockListJobs).toHaveBeenCalledTimes(2));
     expect(mockListJobs).toHaveBeenCalledWith({
       status: ["running", "pending"],
+      sort_by: "activity",
       limit: 200,
       offset: 0,
     });
     expect(mockListJobs).toHaveBeenCalledWith({
       status: ["completed", "failed", "cancelled"],
+      sort_by: "activity",
       limit: 50,
       offset: 0,
     });
@@ -186,6 +188,7 @@ describe("Desktop app activity", () => {
     await waitFor(() =>
       expect(mockListJobs).toHaveBeenCalledWith({
         status: ["running", "pending"],
+        sort_by: "activity",
         search: "choir",
         limit: 200,
         offset: 0,
@@ -193,6 +196,7 @@ describe("Desktop app activity", () => {
     );
     expect(mockListJobs).toHaveBeenCalledWith({
       status: ["completed", "failed", "cancelled"],
+      sort_by: "activity",
       search: "choir",
       limit: 50,
       offset: 0,
@@ -282,6 +286,7 @@ describe("Desktop app activity", () => {
     expect(await screen.findByRole("article", { name: "active_205 running job" })).toBeInTheDocument();
     expect(mockListJobs).toHaveBeenCalledWith({
       status: ["running", "pending"],
+      sort_by: "activity",
       limit: 200,
       offset: 200,
     });
@@ -1110,12 +1115,71 @@ describe("Desktop app activity", () => {
     expect(await screen.findByRole("article", { name: "history_055 completed job" })).toBeInTheDocument();
     expect(mockListJobs).toHaveBeenCalledWith({
       status: ["completed", "failed", "cancelled"],
+      sort_by: "activity",
       limit: 50,
       offset: 50,
     });
     await waitFor(() =>
       expect(screen.queryByRole("button", { name: "Load more history" })).not.toBeInTheDocument(),
     );
+  });
+
+  it("paginates terminal history after activity sorting", async () => {
+    const user = userEvent.setup();
+    setJobs([
+      ...Array.from({ length: 50 }, (_, index) => {
+        const jobNumber = index + 1;
+        const timestamp = `2026-04-18T12:${String(50 - jobNumber).padStart(2, "0")}:00.000Z`;
+        return job({
+          id: `job_history_old_${String(jobNumber).padStart(3, "0")}`,
+          type: `history_old_${String(jobNumber).padStart(3, "0")}`,
+          status: "completed",
+          progress: 100,
+          completed_at: timestamp,
+          created_at: "2026-04-18T12:00:00.000Z",
+          updated_at: timestamp,
+        });
+      }),
+      job({
+        id: "job_history_tie_a",
+        type: "history_tie_a",
+        status: "completed",
+        progress: 100,
+        completed_at: "2026-04-18T13:59:00.000Z",
+        created_at: "2026-04-18T13:00:00.000Z",
+        updated_at: "2026-04-18T13:59:00.000Z",
+      }),
+      job({
+        id: "job_history_tie_b",
+        type: "history_tie_b",
+        status: "completed",
+        progress: 100,
+        completed_at: "2026-04-18T13:59:00.000Z",
+        created_at: "2026-04-18T13:00:00.000Z",
+        updated_at: "2026-04-18T13:59:00.000Z",
+      }),
+    ]);
+
+    renderApp(["/activity"]);
+
+    expect(await screen.findByRole("article", { name: "history_tie_b completed job" })).toBeInTheDocument();
+    const queue = await screen.findByRole("list", { name: "Job queue" });
+    const rows = within(queue).getAllByRole("article");
+    expect(rows.slice(0, 2).map((row) => row.getAttribute("aria-label"))).toEqual([
+      "history_tie_b completed job",
+      "history_tie_a completed job",
+    ]);
+    expect(screen.queryByRole("article", { name: "history_old_050 completed job" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Load more history" }));
+
+    expect(await screen.findByRole("article", { name: "history_old_050 completed job" })).toBeInTheDocument();
+    expect(mockListJobs).toHaveBeenCalledWith({
+      status: ["completed", "failed", "cancelled"],
+      sort_by: "activity",
+      limit: 50,
+      offset: 50,
+    });
   });
 
   it("loads additional terminal history pages when the history sentinel intersects", async () => {
@@ -1133,6 +1197,7 @@ describe("Desktop app activity", () => {
     expect(await screen.findByRole("article", { name: "history_055 completed job" })).toBeInTheDocument();
     expect(mockListJobs).toHaveBeenCalledWith({
       status: ["completed", "failed", "cancelled"],
+      sort_by: "activity",
       limit: 50,
       offset: 50,
     });
@@ -1166,6 +1231,7 @@ describe("Desktop app activity", () => {
     expect(await screen.findByRole("article", { name: "history_055 completed job" })).toBeInTheDocument();
     expect(mockListJobs).toHaveBeenCalledWith({
       status: ["completed", "failed", "cancelled"],
+      sort_by: "activity",
       limit: 50,
       offset: 50,
     });

--- a/apps/desktop/src/App.project-playback-artifacts.test.tsx
+++ b/apps/desktop/src/App.project-playback-artifacts.test.tsx
@@ -59,6 +59,8 @@ async function expectProjectTerminalJobsPageRequested(offset: number) {
 }
 
 function terminalJob(index: number, overrides: Record<string, unknown> = {}) {
+  const minute = 59 - (index % 60);
+  const timestamp = `2026-04-18T13:${String(minute).padStart(2, "0")}:00.000Z`;
   return {
     id: `job_terminal_${index}`,
     project_id: "proj_123",
@@ -67,8 +69,9 @@ function terminalJob(index: number, overrides: Record<string, unknown> = {}) {
     progress: 100,
     source_artifact_id: null,
     error_message: null,
-    created_at: `2026-04-18T13:${String(index % 60).padStart(2, "0")}:00.000Z`,
-    updated_at: `2026-04-18T13:${String(index % 60).padStart(2, "0")}:00.000Z`,
+    completed_at: timestamp,
+    created_at: timestamp,
+    updated_at: timestamp,
     ...overrides,
   };
 }

--- a/apps/desktop/src/features/activity/ActivityView.tsx
+++ b/apps/desktop/src/features/activity/ActivityView.tsx
@@ -247,13 +247,17 @@ export function ActivityView() {
   const activeJobsQuery = useInfiniteQuery({
     queryKey: activeJobsQueryKey,
     initialPageParam: 0,
-    queryFn: async ({ pageParam }) =>
-      api.listJobs({
+    queryFn: async ({ pageParam }) => {
+      const params = {
         status: [...ACTIVE_JOB_STATUSES],
+        sort_by: "activity" as const,
         ...(deferredSearch ? { search: deferredSearch } : {}),
         limit: ACTIVE_JOBS_LIMIT,
         offset: pageParam,
-      }),
+      };
+
+      return api.listJobs(params);
+    },
     getNextPageParam: (lastPage) =>
       lastPage.has_more ? lastPage.offset + lastPage.jobs.length : undefined,
   });
@@ -269,13 +273,17 @@ export function ActivityView() {
   const terminalJobsQuery = useInfiniteQuery({
     queryKey: terminalJobsQueryKey,
     initialPageParam: 0,
-    queryFn: async ({ pageParam }) =>
-      api.listJobs({
+    queryFn: async ({ pageParam }) => {
+      const params = {
         status: [...TERMINAL_JOB_STATUS_VALUES],
+        sort_by: "activity" as const,
         ...(deferredSearch ? { search: deferredSearch } : {}),
         limit: TERMINAL_JOBS_PAGE_SIZE,
         offset: pageParam,
-      }),
+      };
+
+      return api.listJobs(params);
+    },
     getNextPageParam: (lastPage) =>
       lastPage.has_more ? lastPage.offset + lastPage.jobs.length : undefined,
   });

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -19,6 +19,14 @@ import type {
 const DEFAULT_PROJECTS_LIMIT = 50;
 const DEFAULT_JOBS_LIMIT = 50;
 
+type MockListJobsParams = ListJobsParams & {
+  sort_by?: string | null;
+  sort_order?: string | null;
+};
+type JobSortOrder = "asc" | "desc";
+type TimestampJobSortField = "created_at" | "started_at" | "updated_at";
+type MockJobSortBy = "activity" | "status" | TimestampJobSortField;
+
 const {
   resetMockApiState,
   setProjects,
@@ -430,6 +438,181 @@ const {
 
   function setJobs(jobs: Array<Record<string, unknown>>) {
     state.jobs = jobs.map((job, index) => normalizeMockJob(job, index));
+  }
+
+  function jobStringValue(job: Record<string, unknown>, field: string) {
+    const value = job[field];
+    return typeof value === "string" && value ? value : null;
+  }
+
+  function jobTimestampMs(job: Record<string, unknown>, field: string) {
+    const value = jobStringValue(job, field);
+    if (!value) return null;
+
+    const timestamp = Date.parse(value);
+    return Number.isNaN(timestamp) ? null : timestamp;
+  }
+
+  function firstJobTimestampMs(job: Record<string, unknown>, fields: string[]) {
+    for (const field of fields) {
+      const timestamp = jobTimestampMs(job, field);
+      if (timestamp !== null) {
+        return timestamp;
+      }
+    }
+
+    return null;
+  }
+
+  function compareJobIds(left: Record<string, unknown>, right: Record<string, unknown>) {
+    return (jobStringValue(left, "id") ?? "").localeCompare(jobStringValue(right, "id") ?? "");
+  }
+
+  function compareJobIdsDescending(left: Record<string, unknown>, right: Record<string, unknown>) {
+    return compareJobIds(right, left);
+  }
+
+  function compareTimestampMs(
+    leftTimestamp: number | null,
+    rightTimestamp: number | null,
+    sortOrder: JobSortOrder,
+  ) {
+    if (leftTimestamp === null && rightTimestamp === null) return 0;
+    if (leftTimestamp === null) return 1;
+    if (rightTimestamp === null) return -1;
+    if (leftTimestamp === rightTimestamp) return 0;
+
+    return sortOrder === "asc" ? leftTimestamp - rightTimestamp : rightTimestamp - leftTimestamp;
+  }
+
+  function compareJobTimestampField(
+    left: Record<string, unknown>,
+    right: Record<string, unknown>,
+    field: TimestampJobSortField,
+    sortOrder: JobSortOrder,
+  ) {
+    const timestampComparison = compareTimestampMs(
+      jobTimestampMs(left, field),
+      jobTimestampMs(right, field),
+      sortOrder,
+    );
+    return timestampComparison || compareJobIds(left, right);
+  }
+
+  function mockJobStatus(job: Record<string, unknown>) {
+    return jobStringValue(job, "status") ?? "unknown";
+  }
+
+  function mockActivitySortGroup(job: Record<string, unknown>) {
+    const status = mockJobStatus(job);
+    if (status === "running") return 0;
+    if (status === "pending") return 1;
+    if (isTerminalJobStatus(status)) return 2;
+    return 3;
+  }
+
+  function compareActivityJobs(left: Record<string, unknown>, right: Record<string, unknown>) {
+    const leftGroup = mockActivitySortGroup(left);
+    const rightGroup = mockActivitySortGroup(right);
+
+    if (leftGroup !== rightGroup) {
+      return leftGroup - rightGroup;
+    }
+
+    if (leftGroup === 0) {
+      const timestampComparison = compareTimestampMs(
+        firstJobTimestampMs(left, ["started_at", "created_at"]),
+        firstJobTimestampMs(right, ["started_at", "created_at"]),
+        "asc",
+      );
+      return timestampComparison || compareJobIds(left, right);
+    }
+
+    if (leftGroup === 1) {
+      return compareJobTimestampField(left, right, "created_at", "asc");
+    }
+
+    if (leftGroup === 2) {
+      const timestampComparison = compareTimestampMs(
+        firstJobTimestampMs(left, ["completed_at", "updated_at"]),
+        firstJobTimestampMs(right, ["completed_at", "updated_at"]),
+        "desc",
+      );
+      return timestampComparison || compareJobIdsDescending(left, right);
+    }
+
+    const timestampComparison = compareTimestampMs(
+      jobTimestampMs(left, "updated_at"),
+      jobTimestampMs(right, "updated_at"),
+      "desc",
+    );
+    return timestampComparison || compareJobIdsDescending(left, right);
+  }
+
+  function statusSortGroup(job: Record<string, unknown>) {
+    switch (mockJobStatus(job)) {
+      case "running":
+        return 0;
+      case "pending":
+        return 1;
+      case "completed":
+        return 2;
+      case "cancelled":
+        return 3;
+      case "failed":
+        return 4;
+      default:
+        return 5;
+    }
+  }
+
+  function compareStatusJobs(
+    left: Record<string, unknown>,
+    right: Record<string, unknown>,
+    sortOrder: JobSortOrder,
+  ) {
+    const leftGroup = statusSortGroup(left);
+    const rightGroup = statusSortGroup(right);
+
+    if (leftGroup !== rightGroup) {
+      return sortOrder === "desc" ? rightGroup - leftGroup : leftGroup - rightGroup;
+    }
+
+    return compareActivityJobs(left, right);
+  }
+
+  function isTimestampJobSortField(value: string): value is TimestampJobSortField {
+    return value === "created_at" || value === "started_at" || value === "updated_at";
+  }
+
+  function normalizeJobSortBy(value: string | null | undefined): MockJobSortBy {
+    if (value === "status" || value === "activity") {
+      return value;
+    }
+
+    if (value && isTimestampJobSortField(value)) {
+      return value;
+    }
+
+    return "activity";
+  }
+
+  function sortJobsForParams(jobs: Array<Record<string, unknown>>, params?: MockListJobsParams) {
+    const sortBy = normalizeJobSortBy(params?.sort_by);
+    const sortOrder: JobSortOrder = params?.sort_order === "asc" ? "asc" : "desc";
+
+    return [...jobs].sort((left, right) => {
+      if (sortBy === "activity") {
+        return compareActivityJobs(left, right);
+      }
+
+      if (sortBy === "status") {
+        const statusSortOrder: JobSortOrder = params?.sort_order === "desc" ? "desc" : "asc";
+        return compareStatusJobs(left, right, statusSortOrder);
+      }
+
+      return compareJobTimestampField(left, right, sortBy, sortOrder);
+    });
   }
 
   function setSyncTransportStatus(nextStatus: Record<string, unknown>) {
@@ -1197,7 +1380,7 @@ const {
     ),
   );
   const mockListArtifacts = vi.fn(async (projectId: string) => ({ artifacts: clone(state.artifactsByProject[projectId] ?? []) }));
-  const mockListJobs = vi.fn(async (params?: ListJobsParams) => {
+  const mockListJobs = vi.fn(async (params?: MockListJobsParams) => {
     const normalizedJobs = state.jobs.map((job, index) => normalizeMockJob(job, index));
     const statusFilters = Array.isArray(params?.status) ? params.status : [];
     const normalizedSearch = params?.search?.trim().toLowerCase();
@@ -1214,15 +1397,16 @@ const {
         : true;
       return statusMatches && projectMatches && searchMatches;
     });
+    const sortedJobs = sortJobsForParams(filteredJobs, params);
     const offset = params?.offset ?? 0;
     const limit = params?.limit ?? DEFAULT_JOBS_LIMIT;
-    const jobs = filteredJobs.slice(offset, offset + limit);
+    const jobs = sortedJobs.slice(offset, offset + limit);
     return {
       jobs: clone(jobs),
-      total: filteredJobs.length,
+      total: sortedJobs.length,
       limit,
       offset,
-      has_more: offset + jobs.length < filteredJobs.length,
+      has_more: offset + jobs.length < sortedJobs.length,
     };
   });
   const mockCancelJob = vi.fn(async (jobId: string) => {

--- a/docs/API.md
+++ b/docs/API.md
@@ -47,10 +47,11 @@ Example:
 }
 ```
 
-Paginated endpoints must document their default sort. Sorting must be deterministic across repeated requests:
-timestamp, status, search-rank, or other non-unique sort keys need a stable tie-breaker, normally the entity's
-immutable ID. For example, newest-first pages should sort by `updated_at DESC, id DESC` instead of timestamp alone.
-If a sort key can be `null`, the endpoint must also document where null values appear.
+Paginated endpoints must document their default sort and any supported client-selected sort keys. Sorting must be
+deterministic across repeated requests: timestamp, status, search-rank, or other non-unique sort keys need a stable
+tie-breaker, normally the entity's immutable ID. For example, newest-first pages should sort by
+`updated_at DESC, id DESC` instead of timestamp alone. If a sort key can be `null`, the endpoint must also document
+where null values appear.
 
 ### Pagination Endpoint Audit
 
@@ -59,7 +60,7 @@ describe current pagination behavior or explicit unpaginated exceptions.
 
 | Endpoint or payload | List field | Pagination decision |
 | --- | --- | --- |
-| `GET /api/v1/jobs` | `jobs` | Paginated growable list with `status`, `project_id`, and project-name `search` filters. Default ordering is active-first and deterministic. |
+| `GET /api/v1/jobs` | `jobs` | Paginated growable list with `status`, `project_id`, and project-name `search` filters plus `sort_by`/`sort_order`. Default ordering is active-first and deterministic. |
 | `GET /api/v1/projects` | `projects` | Paginated growable list. `search` filters the full matching collection before pagination. Default ordering is `updated_at DESC, id DESC`. Desktop Library consumers should lazy-load this list. |
 | `GET /api/v1/projects/{project_id}/artifacts` | `artifacts` | Explicit unpaginated bounded project inventory exception: source audio, generated stems, practice mixes, exports, and cache artifacts. Ordered by `created_at DESC`; no pagination. |
 | `GET /api/v1/projects/{project_id}/sections` | `sections` | Explicit unpaginated project document/song-structure exception. Sections are bounded by the song arrangement and must stay complete for editing and playback. |
@@ -725,13 +726,32 @@ Query parameters:
 - `project_id` - optional project ID filter.
 - `search` - optional project display name filter. Search is applied before pagination and composes with
   `status` and `project_id` filters.
+- `sort_by` - optional sort key. Supported values are `activity` (default), `created_at`, `started_at`,
+  `updated_at`, and `status`.
+- `sort_order` - optional `asc` or `desc` direction for non-activity sorts. Omit this when `sort_by` is
+  `activity` or omitted; `sort_order` with activity sorting returns `422 INVALID_REQUEST`.
 
-Default ordering:
+Filters and search are applied before sorting, `total`, and pagination. Pagination is applied after sorting.
+
+Default activity ordering:
 
 - running jobs first, ordered by `started_at` when present, otherwise `created_at`, ascending, then `id` ascending.
 - pending jobs next, ordered by `created_at` ascending, then `id` ascending.
 - terminal jobs (`completed`, `cancelled`, `failed`) next, ordered by `completed_at` when present, otherwise `updated_at`, descending, then `id` descending.
 - unknown statuses last, ordered by `updated_at` descending, then `id` descending.
+
+Timestamp ordering:
+
+- `created_at`, `started_at`, and `updated_at` default to `desc`; use `sort_order=asc` for oldest-first.
+- `null` timestamp values are always last for both `asc` and `desc`.
+- Timestamp ties use `id` ascending as the deterministic tie-breaker.
+
+Status ordering:
+
+- `sort_by=status` defaults to `asc`.
+- `asc` groups jobs as `running`, `pending`, `completed`, `cancelled`, `failed`, then unknown statuses.
+- `desc` reverses those groups.
+- Jobs inside each status group use the same deterministic tie-breakers as activity ordering for that group.
 
 Response: `JobsResponse`.
 

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -3099,6 +3099,10 @@ export interface operations {
                 project_id?: string | null;
                 /** @description Filter jobs by project display name. */
                 search?: string | null;
+                /** @description Sort jobs by activity, timestamp, or status. */
+                sort_by?: "activity" | "created_at" | "started_at" | "updated_at" | "status";
+                /** @description Sort direction. Not valid with activity sort. */
+                sort_order?: ("asc" | "desc") | null;
                 /** @description Maximum number of items to return. */
                 limit?: number;
                 /** @description Number of items to skip before returning results. */


### PR DESCRIPTION
## Summary

- Add deterministic jobs API sorting by timestamps and status.
- Preserve Activity's active-first jobs ordering with explicit `sort_by=activity`.
- Update API docs, generated shared types, and focused backend/desktop coverage.
- Closes #153

## Testing

- `cd apps/backend && uv run --python 3.11 pytest tests/test_jobs_api.py tests/test_pagination_contract.py`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `pnpm contracts:generate`
- `pnpm --filter @tuneforge/desktop test --run src/App.activity.test.tsx`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
- `git diff --check`
- `pnpm test`
