### PR TITLE
feat: Add bulk activity job controls

### DIFF
--- a/apps/backend/app/api/routes/jobs.py
+++ b/apps/backend/app/api/routes/jobs.py
@@ -7,9 +7,22 @@ from app.api.pagination import PaginationQuery, pagination_metadata
 from app.dependencies import get_db, get_job_runner
 from app.errors import AppError
 from app.models import Job
-from app.schemas import JobResponse, JobSchema, JobsResponse
-from app.services.jobs import JobSortBy, JobSortOrder
-from app.services.jobs import list_jobs as list_jobs_service
+from app.schemas import (
+    BulkJobRequest,
+    BulkJobSkippedProjectSchema,
+    BulkJobsResponse,
+    JobResponse,
+    JobSchema,
+    JobsResponse,
+)
+from app.services.jobs import (
+    JobSortBy,
+    JobSortOrder,
+    create_bulk_activity_jobs,
+)
+from app.services.jobs import (
+    list_jobs as list_jobs_service,
+)
 
 router = APIRouter(prefix="/jobs", tags=["jobs"])
 
@@ -42,6 +55,27 @@ def list_jobs(
         number_of_returned_items=len(jobs),
     )
     return JobsResponse(jobs=jobs, **metadata)
+
+
+@router.post("/bulk", response_model=BulkJobsResponse)
+def create_bulk_jobs(
+    payload: BulkJobRequest,
+    session: Session = Depends(get_db),
+    runner=Depends(get_job_runner),
+) -> BulkJobsResponse:
+    result = create_bulk_activity_jobs(session, runner, payload=payload)
+    return BulkJobsResponse(
+        created_jobs=[JobSchema.model_validate(job) for job in result.jobs],
+        total_projects=result.total_projects,
+        skipped=[
+            BulkJobSkippedProjectSchema(
+                project_id=skipped.project_id,
+                project_name=skipped.project_name,
+                reason=skipped.reason,
+            )
+            for skipped in result.skipped
+        ],
+    )
 
 
 @router.get("/{job_id}", response_model=JobResponse)

--- a/apps/backend/app/api/routes/projects.py
+++ b/apps/backend/app/api/routes/projects.py
@@ -43,7 +43,7 @@ from app.schemas import (
 )
 from app.services.artifacts import delete_project_artifact
 from app.services.chord_backends import FAST_CHORD_BACKEND_ID, ChordDetectionBackend, resolve_chord_backend
-from app.services.chords import project_chord_detection_source
+from app.services.jobs import create_project_activity_job
 from app.services.lyrics import update_project_lyrics
 from app.services.projects import (
     delete_project,
@@ -53,7 +53,7 @@ from app.services.projects import (
     list_projects,
     update_project,
 )
-from app.services.stem_models import TWO_STEMS_MODEL_ID, resolve_stem_model
+from app.services.stem_models import resolve_stem_model
 from app.services.stems import resolve_stem_source_artifact
 from app.services.tabs import (
     apply_tab_suggestions,
@@ -210,16 +210,13 @@ def project_analyze(
     session: Session = Depends(get_db),
     runner=Depends(get_job_runner),
 ) -> JobResponse:
-    get_mutable_project(session, project_id)
-    job = runner.create_job(
+    job = create_project_activity_job(
         session,
+        runner,
         project_id=project_id,
         job_type="analyze",
-        payload=payload.model_dump(),
+        payload=payload,
     )
-    session.commit()
-    session.refresh(job)
-    runner.enqueue(job.id)
     return JobResponse(job=JobSchema.model_validate(job))
 
 
@@ -237,20 +234,13 @@ def project_chords(
     session: Session = Depends(get_db),
     runner=Depends(get_job_runner),
 ) -> JobResponse:
-    project = get_mutable_project(session, project_id)
-    selected_backend = resolve_chord_backend(payload.backend, require_available=True)
-    job_payload = payload.model_dump()
-    job_payload["chord_backend"] = selected_backend.id
-    job_payload["chord_source"] = project_chord_detection_source(project, backend=selected_backend.id)
-    job = runner.create_job(
+    job = create_project_activity_job(
         session,
+        runner,
         project_id=project_id,
         job_type="chords",
-        payload=job_payload,
+        payload=payload,
     )
-    session.commit()
-    session.refresh(job)
-    runner.enqueue(job.id)
     return JobResponse(job=JobSchema.model_validate(job))
 
 
@@ -270,16 +260,13 @@ def project_lyrics(
     session: Session = Depends(get_db),
     runner=Depends(get_job_runner),
 ) -> JobResponse:
-    get_mutable_project(session, project_id)
-    job = runner.create_job(
+    job = create_project_activity_job(
         session,
+        runner,
         project_id=project_id,
         job_type="lyrics",
-        payload=payload.model_dump(),
+        payload=payload,
     )
-    session.commit()
-    session.refresh(job)
-    runner.enqueue(job.id)
     return JobResponse(job=JobSchema.model_validate(job))
 
 
@@ -435,31 +422,13 @@ def project_stems(
     session: Session = Depends(get_db),
     runner=Depends(get_job_runner),
 ) -> JobResponse:
-    project = get_mutable_project(session, project_id)
-    source_artifact = resolve_stem_source_artifact(
+    job = create_project_activity_job(
         session,
-        project=project,
-        source_artifact_id=payload.source_artifact_id,
-    )
-    job_payload = payload.model_dump()
-    selected_chord_backend = resolve_chord_backend(payload.chord_backend, require_available=False)
-    requested_stem_model = payload.stem_model
-    if payload.mode == "two_stem" and requested_stem_model in {None, "default"}:
-        requested_stem_model = TWO_STEMS_MODEL_ID
-    selected_stem_model = resolve_stem_model(requested_stem_model, require_available=False)
-    job_payload["chord_backend"] = selected_chord_backend.id
-    job_payload["stem_model"] = selected_stem_model.id
-    job_payload["stem_model_label"] = selected_stem_model.label
-    job_payload["source_artifact_id"] = source_artifact.id
-    job = runner.create_job(
-        session,
+        runner,
         project_id=project_id,
         job_type="stems",
-        payload=job_payload,
+        payload=payload,
     )
-    session.commit()
-    session.refresh(job)
-    runner.enqueue(job.id)
     return JobResponse(job=JobSchema.model_validate(job))
 
 

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -1075,6 +1075,36 @@ class JobResponse(BaseModel):
     job: JobSchema
 
 
+BulkJobType = Literal["analyze", "chords", "lyrics", "stems"]
+BulkJobSkipReason = Literal["active_job", "locked", "creation_failed", "no_existing_stems"]
+
+
+class BulkJobRequest(BaseModel):
+    job_type: BulkJobType = Field(description="Project job type to enqueue for every project.")
+    chord_backend: str | None = None
+    chord_backend_fallback_from: str | None = None
+    stem_model: str | None = None
+
+    @model_validator(mode="after")
+    def validate_bulk_job_request(self) -> BulkJobRequest:
+        _validate_chord_backend_fields(self.chord_backend, self.chord_backend_fallback_from)
+        if self.stem_model is not None and self.stem_model not in SUPPORTED_STEM_MODELS:
+            raise ValueError("Unsupported stem model.")
+        return self
+
+
+class BulkJobSkippedProjectSchema(BaseModel):
+    project_id: str
+    project_name: str
+    reason: BulkJobSkipReason
+
+
+class BulkJobsResponse(BaseModel):
+    created_jobs: list[JobSchema]
+    total_projects: int
+    skipped: list[BulkJobSkippedProjectSchema]
+
+
 class JobsResponse(BaseModel):
     jobs: list[JobSchema]
     total: int

--- a/apps/backend/app/services/jobs.py
+++ b/apps/backend/app/services/jobs.py
@@ -6,19 +6,21 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from subprocess import Popen
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from sqlalchemy import case, func, select
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.errors import AppError, JobCancelledError
 from app.models import Artifact, ChordTimeline, Job, Project, utcnow
+from app.schemas import AnalysisRequest, BulkJobRequest, ChordRequest, LyricsGenerateRequest, StemRequest
 from app.services.analysis import analyze_project
 from app.services.chord_backends import resolve_chord_backend
 from app.services.chords import detect_project_chords, project_chord_detection_source
 from app.services.lyrics import generate_project_lyrics
 from app.services.projects import get_mutable_project, get_project
-from app.services.stems import generate_stems
+from app.services.stem_models import STEM_ARTIFACT_TYPES, TWO_STEMS_MODEL_ID, resolve_stem_model
+from app.services.stems import generate_stems, resolve_stem_source_artifact
 from app.services.transformations import (
     build_preview_plan,
     build_single_transform_plan,
@@ -44,8 +46,27 @@ JobHandler = Callable[["JobExecutionContext", Session, Job], JobExecutionResult]
 JobSortBy = Literal["activity", "created_at", "started_at", "updated_at", "status"]
 JobSortOrder = Literal["asc", "desc"]
 JobTimestampSortBy = Literal["created_at", "started_at", "updated_at"]
+BulkActivityJobType = Literal["analyze", "chords", "lyrics", "stems"]
+BulkActivityJobSkipReason = Literal["active_job", "locked", "creation_failed", "no_existing_stems"]
+ProjectActivityJobPayload = AnalysisRequest | ChordRequest | LyricsGenerateRequest | StemRequest
 
+_ACTIVE_JOB_STATUSES = ("pending", "running")
+_BULK_ACTIVITY_JOB_TYPES = frozenset({"analyze", "chords", "lyrics", "stems"})
 _TERMINAL_JOB_STATUSES = ("completed", "cancelled", "failed")
+
+
+@dataclass(frozen=True, slots=True)
+class BulkActivityJobSkippedProject:
+    project_id: str
+    project_name: str
+    reason: BulkActivityJobSkipReason
+
+
+@dataclass(frozen=True, slots=True)
+class BulkActivityJobCreationResult:
+    jobs: list[Job]
+    total_projects: int
+    skipped: list[BulkActivityJobSkippedProject]
 
 
 def _job_activity_tie_breakers() -> tuple[Any, ...]:
@@ -165,6 +186,250 @@ def list_jobs(
         )
     )
     return ListedJobs(jobs=jobs, total=total)
+
+
+def validate_bulk_activity_job_type(job_type: str) -> BulkActivityJobType:
+    if job_type not in _BULK_ACTIVITY_JOB_TYPES:
+        raise AppError(
+            "INVALID_REQUEST",
+            "Unsupported bulk job type.",
+            status_code=422,
+            details={"supported_job_types": sorted(_BULK_ACTIVITY_JOB_TYPES)},
+        )
+    return cast(BulkActivityJobType, job_type)
+
+
+def create_project_activity_job(
+    session: Session,
+    runner: InProcessJobRunner,
+    *,
+    project_id: str,
+    job_type: BulkActivityJobType,
+    payload: ProjectActivityJobPayload,
+) -> Job:
+    project = get_mutable_project(session, project_id)
+    job = _create_project_activity_job(session, runner, project=project, job_type=job_type, payload=payload)
+    session.commit()
+    session.refresh(job)
+    runner.enqueue(job.id)
+    return job
+
+
+def create_bulk_activity_jobs(
+    session: Session,
+    runner: InProcessJobRunner,
+    *,
+    payload: BulkJobRequest,
+) -> BulkActivityJobCreationResult:
+    validated_job_type = validate_bulk_activity_job_type(payload.job_type)
+    projects = list(
+        session.scalars(
+            select(Project)
+            .where(Project.sync_status != "deleted")
+            .order_by(Project.updated_at.desc(), Project.id.desc())
+        )
+    )
+    created_jobs: list[Job] = []
+    skipped: list[BulkActivityJobSkippedProject] = []
+    for project in projects:
+        if _has_active_project_job(session, project_id=project.id, job_type=validated_job_type):
+            skipped.append(
+                BulkActivityJobSkippedProject(
+                    project_id=project.id,
+                    project_name=project.display_name,
+                    reason="active_job",
+                )
+            )
+            continue
+        if not project.sync_editable:
+            skipped.append(
+                BulkActivityJobSkippedProject(
+                    project_id=project.id,
+                    project_name=project.display_name,
+                    reason="locked",
+                )
+            )
+            continue
+        try:
+            project_jobs: list[Job] = []
+            for job_payload in _bulk_activity_job_payloads(
+                session,
+                project=project,
+                request=payload,
+                job_type=validated_job_type,
+            ):
+                job = _create_project_activity_job(
+                    session,
+                    runner,
+                    project=project,
+                    job_type=validated_job_type,
+                    payload=job_payload,
+                )
+                session.flush()
+                project_jobs.append(job)
+            session.commit()
+            for job in project_jobs:
+                session.refresh(job)
+            created_jobs.extend(project_jobs)
+        except AppError as exc:
+            session.rollback()
+            if exc.code == "PROJECT_SYNC_LOCKED":
+                reason: BulkActivityJobSkipReason = "locked"
+            elif exc.code == "NO_EXISTING_STEMS":
+                reason = "no_existing_stems"
+            else:
+                reason = "creation_failed"
+            skipped.append(
+                BulkActivityJobSkippedProject(
+                    project_id=project.id,
+                    project_name=project.display_name,
+                    reason=reason,
+                )
+            )
+
+    for job in created_jobs:
+        runner.enqueue(job.id)
+
+    return BulkActivityJobCreationResult(
+        jobs=created_jobs,
+        total_projects=len(projects),
+        skipped=skipped,
+    )
+
+
+def _has_active_project_job(session: Session, *, project_id: str, job_type: BulkActivityJobType) -> bool:
+    return (
+        session.scalar(
+            select(Job.id)
+            .where(
+                Job.project_id == project_id,
+                Job.type == job_type,
+                Job.status.in_(_ACTIVE_JOB_STATUSES),
+            )
+            .limit(1)
+        )
+        is not None
+    )
+
+
+def _bulk_activity_job_payloads(
+    session: Session,
+    *,
+    project: Project,
+    request: BulkJobRequest,
+    job_type: BulkActivityJobType,
+) -> list[ProjectActivityJobPayload]:
+    if job_type == "stems":
+        source_artifact_ids = _existing_stem_source_artifact_ids(session, project_id=project.id)
+        if not source_artifact_ids:
+            raise AppError("NO_EXISTING_STEMS", "Project has no existing stems to refresh.")
+        return [
+            StemRequest(
+                mode="stems",
+                output_format="wav",
+                force=True,
+                source_artifact_id=source_artifact_id,
+                stem_model=request.stem_model,
+                chord_backend=request.chord_backend or "default",
+                chord_backend_fallback_from=request.chord_backend_fallback_from,
+                overwrite_chord_edits=False,
+            )
+            for source_artifact_id in source_artifact_ids
+        ]
+    return [_default_bulk_activity_job_payload(job_type, request=request)]
+
+
+def _default_bulk_activity_job_payload(
+    job_type: BulkActivityJobType,
+    *,
+    request: BulkJobRequest,
+) -> ProjectActivityJobPayload:
+    if job_type == "analyze":
+        return AnalysisRequest(include_tempo=False, force=True)
+    if job_type == "chords":
+        return ChordRequest(
+            backend=request.chord_backend or "default",
+            backend_fallback_from=request.chord_backend_fallback_from,
+            force=True,
+            overwrite_user_edits=True,
+        )
+    if job_type == "lyrics":
+        return LyricsGenerateRequest(force=True)
+    raise AppError("INVALID_REQUEST", "Job payload does not match job type.", status_code=422)
+
+
+def _existing_stem_source_artifact_ids(session: Session, *, project_id: str) -> list[str]:
+    seen: set[str] = set()
+    source_artifact_ids: list[str] = []
+    stmt = (
+        select(Artifact)
+        .where(
+            Artifact.project_id == project_id,
+            Artifact.type.in_(tuple(STEM_ARTIFACT_TYPES)),
+        )
+        .order_by(Artifact.created_at.asc(), Artifact.id.asc())
+    )
+    for artifact in session.scalars(stmt):
+        source_artifact_id = artifact.metadata_json.get("source_artifact_id")
+        if not isinstance(source_artifact_id, str) or source_artifact_id in seen:
+            continue
+        seen.add(source_artifact_id)
+        source_artifact_ids.append(source_artifact_id)
+    return source_artifact_ids
+
+
+def _create_project_activity_job(
+    session: Session,
+    runner: InProcessJobRunner,
+    *,
+    project: Project,
+    job_type: BulkActivityJobType,
+    payload: ProjectActivityJobPayload,
+) -> Job:
+    job_payload = _project_activity_job_payload(session, project=project, job_type=job_type, payload=payload)
+    return runner.create_job(
+        session,
+        project_id=project.id,
+        job_type=job_type,
+        payload=job_payload,
+    )
+
+
+def _project_activity_job_payload(
+    session: Session,
+    *,
+    project: Project,
+    job_type: BulkActivityJobType,
+    payload: ProjectActivityJobPayload,
+) -> dict[str, Any]:
+    if job_type == "analyze" and isinstance(payload, AnalysisRequest):
+        return payload.model_dump()
+    if job_type == "chords" and isinstance(payload, ChordRequest):
+        selected_backend = resolve_chord_backend(payload.backend, require_available=True)
+        job_payload = payload.model_dump()
+        job_payload["chord_backend"] = selected_backend.id
+        job_payload["chord_source"] = project_chord_detection_source(project, backend=selected_backend.id)
+        return job_payload
+    if job_type == "lyrics" and isinstance(payload, LyricsGenerateRequest):
+        return payload.model_dump()
+    if job_type == "stems" and isinstance(payload, StemRequest):
+        source_artifact = resolve_stem_source_artifact(
+            session,
+            project=project,
+            source_artifact_id=payload.source_artifact_id,
+        )
+        selected_chord_backend = resolve_chord_backend(payload.chord_backend, require_available=False)
+        requested_stem_model = payload.stem_model
+        if payload.mode == "two_stem" and requested_stem_model in {None, "default"}:
+            requested_stem_model = TWO_STEMS_MODEL_ID
+        selected_stem_model = resolve_stem_model(requested_stem_model, require_available=False)
+        job_payload = payload.model_dump()
+        job_payload["chord_backend"] = selected_chord_backend.id
+        job_payload["stem_model"] = selected_stem_model.id
+        job_payload["stem_model_label"] = selected_stem_model.label
+        job_payload["source_artifact_id"] = source_artifact.id
+        return job_payload
+    raise AppError("INVALID_REQUEST", "Job payload does not match job type.", status_code=422)
 
 
 def _as_utc_datetime(value: datetime) -> datetime:

--- a/apps/backend/tests/test_jobs_api.py
+++ b/apps/backend/tests/test_jobs_api.py
@@ -4,10 +4,11 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.db import SessionLocal
-from app.models import Job, Project
+from app.models import Artifact, Job, Project
 
 _BASE_TIME = datetime(2026, 1, 1, tzinfo=UTC)
 
@@ -16,13 +17,22 @@ def _timestamp(minutes: int) -> datetime:
     return _BASE_TIME + timedelta(minutes=minutes)
 
 
-def _add_project(session: Session, project_id: str, *, display_name: str | None = None) -> None:
+def _add_project(
+    session: Session,
+    project_id: str,
+    *,
+    display_name: str | None = None,
+    sync_status: str = "local",
+    sync_status_reason: str | None = None,
+) -> None:
     session.add(
         Project(
             id=project_id,
             display_name=display_name or project_id,
             source_path=f"/tmp/{project_id}.wav",
             imported_path=f"/tmp/tuneforge/{project_id}.wav",
+            sync_status=sync_status,
+            sync_status_reason=sync_status_reason,
         )
     )
 
@@ -33,6 +43,7 @@ def _add_job(
     status: str,
     *,
     project_id: str | None = None,
+    job_type: str = "test",
     created_at: datetime | None = None,
     started_at: datetime | None = None,
     completed_at: datetime | None = None,
@@ -43,7 +54,7 @@ def _add_job(
         Job(
             id=job_id,
             project_id=project_id,
-            type="test",
+            type=job_type,
             status=status,
             progress=0,
             error_message=None,
@@ -58,6 +69,209 @@ def _add_job(
             updated_at=updated_at or completed_at or started_at or effective_created_at,
         )
     )
+
+
+def _add_artifact(
+    session: Session,
+    artifact_id: str,
+    project_id: str,
+    artifact_type: str,
+    *,
+    metadata: dict[str, str] | None = None,
+) -> None:
+    session.add(
+        Artifact(
+            id=artifact_id,
+            project_id=project_id,
+            type=artifact_type,
+            format="wav",
+            path=f"/tmp/{artifact_id}.wav",
+            metadata_json=metadata or {},
+            generated_by="test",
+            can_delete=True,
+            can_regenerate=True,
+        )
+    )
+
+
+def _capture_enqueued_jobs(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    enqueued: list[str] = []
+    monkeypatch.setattr(client.app.state.job_runner, "enqueue", enqueued.append)
+    return enqueued
+
+
+def test_bulk_jobs_creates_jobs_for_editable_projects(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    enqueued = _capture_enqueued_jobs(client, monkeypatch)
+    with SessionLocal() as session:
+        _add_project(session, "project_a")
+        _add_project(session, "project_b")
+        session.commit()
+
+    response = client.post(
+        "/api/v1/jobs/bulk",
+        json={"job_type": "chords", "chord_backend": "tuneforge-fast"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    created_jobs = payload["created_jobs"]
+    assert payload["total_projects"] == 2
+    assert payload["skipped"] == []
+    assert {job["project_id"] for job in created_jobs} == {"project_a", "project_b"}
+    assert {job["type"] for job in created_jobs} == {"chords"}
+    assert {job["status"] for job in created_jobs} == {"pending"}
+    assert set(enqueued) == {job["id"] for job in created_jobs}
+
+    with SessionLocal() as session:
+        jobs = list(session.scalars(select(Job).where(Job.type == "chords")))
+        assert {job.project_id for job in jobs} == {"project_a", "project_b"}
+        assert all(job.payload_json["force"] is True for job in jobs)
+        assert all(job.payload_json["overwrite_user_edits"] is True for job in jobs)
+        assert all(job.payload_json["chord_backend"] == "tuneforge-fast" for job in jobs)
+
+
+def test_bulk_lyrics_refreshes_existing_transcripts(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    enqueued = _capture_enqueued_jobs(client, monkeypatch)
+    with SessionLocal() as session:
+        _add_project(session, "project_a")
+        session.commit()
+
+    response = client.post("/api/v1/jobs/bulk", json={"job_type": "lyrics"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [job["project_id"] for job in payload["created_jobs"]] == ["project_a"]
+    assert set(enqueued) == {payload["created_jobs"][0]["id"]}
+    with SessionLocal() as session:
+        job = session.scalar(select(Job).where(Job.type == "lyrics"))
+        assert job is not None
+        assert job.payload_json["force"] is True
+
+
+def test_bulk_stems_refreshes_only_sources_with_existing_stems(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    enqueued = _capture_enqueued_jobs(client, monkeypatch)
+    with SessionLocal() as session:
+        _add_project(session, "project_with_stems")
+        _add_project(session, "project_without_stems", display_name="No Stems Song")
+        _add_artifact(session, "source_existing", "project_with_stems", "source_audio")
+        _add_artifact(session, "mix_existing", "project_with_stems", "preview_mix")
+        _add_artifact(session, "mix_without_stems", "project_with_stems", "preview_mix")
+        _add_artifact(session, "source_without", "project_without_stems", "source_audio")
+        _add_artifact(
+            session,
+            "stem_source_existing",
+            "project_with_stems",
+            "vocal_stem",
+            metadata={"source_artifact_id": "source_existing", "stem_model": "htdemucs_6s"},
+        )
+        _add_artifact(
+            session,
+            "stem_mix_existing",
+            "project_with_stems",
+            "vocal_stem",
+            metadata={"source_artifact_id": "mix_existing", "stem_model": "htdemucs_6s"},
+        )
+        session.commit()
+
+    response = client.post(
+        "/api/v1/jobs/bulk",
+        json={
+            "job_type": "stems",
+            "chord_backend": "tuneforge-fast",
+            "chord_backend_fallback_from": "crema-advanced",
+            "stem_model": "htdemucs_ft",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total_projects"] == 2
+    assert payload["skipped"] == [
+        {
+            "project_id": "project_without_stems",
+            "project_name": "No Stems Song",
+            "reason": "no_existing_stems",
+        }
+    ]
+    assert [job["project_id"] for job in payload["created_jobs"]] == [
+        "project_with_stems",
+        "project_with_stems",
+    ]
+    assert set(enqueued) == {job["id"] for job in payload["created_jobs"]}
+    with SessionLocal() as session:
+        jobs = list(session.scalars(select(Job).where(Job.type == "stems").order_by(Job.created_at.asc())))
+        assert {job.payload_json["source_artifact_id"] for job in jobs} == {"source_existing", "mix_existing"}
+        assert all(job.payload_json["force"] is True for job in jobs)
+        assert all(job.payload_json["chord_backend"] == "tuneforge-fast" for job in jobs)
+        assert all(job.payload_json["chord_backend_fallback_from"] == "crema-advanced" for job in jobs)
+        assert all(job.payload_json["stem_model"] == "htdemucs_ft" for job in jobs)
+
+
+def test_bulk_jobs_skips_active_duplicate_project_type(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    enqueued = _capture_enqueued_jobs(client, monkeypatch)
+    with SessionLocal() as session:
+        _add_project(session, "project_a", display_name="Active Song")
+        _add_project(session, "project_b")
+        _add_job(session, "job_existing", "pending", project_id="project_a", job_type="lyrics")
+        session.commit()
+
+    response = client.post("/api/v1/jobs/bulk", json={"job_type": "lyrics"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total_projects"] == 2
+    assert payload["skipped"] == [
+        {"project_id": "project_a", "project_name": "Active Song", "reason": "active_job"}
+    ]
+    assert [job["project_id"] for job in payload["created_jobs"]] == ["project_b"]
+    assert set(enqueued) == {payload["created_jobs"][0]["id"]}
+
+
+def test_bulk_jobs_skips_locked_project(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    enqueued = _capture_enqueued_jobs(client, monkeypatch)
+    with SessionLocal() as session:
+        _add_project(session, "project_editable")
+        _add_project(
+            session,
+            "project_locked",
+            display_name="Locked Song",
+            sync_status="remote_available",
+            sync_status_reason="Available from peer.",
+        )
+        session.commit()
+
+    response = client.post("/api/v1/jobs/bulk", json={"job_type": "analyze"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total_projects"] == 2
+    assert payload["skipped"] == [
+        {"project_id": "project_locked", "project_name": "Locked Song", "reason": "locked"}
+    ]
+    assert [job["project_id"] for job in payload["created_jobs"]] == ["project_editable"]
+    assert set(enqueued) == {payload["created_jobs"][0]["id"]}
+
+
+def test_bulk_jobs_rejects_unsupported_job_type(client: TestClient) -> None:
+    response = client.post("/api/v1/jobs/bulk", json={"job_type": "preview"})
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "INVALID_REQUEST"
 
 
 def test_list_jobs_returns_pagination_metadata(client: TestClient) -> None:

--- a/apps/backend/tests/test_pagination_contract.py
+++ b/apps/backend/tests/test_pagination_contract.py
@@ -31,6 +31,9 @@ SYNC_DOCUMENT_RESPONSE_CONTRACTS = {
     ("/api/v1/sync/reconciliation/plan", "post"): "SyncReconciliationPlanResponse",
     ("/api/v1/sync/reconciliation/apply", "post"): "SyncReconciliationApplyResponse",
 }
+JOB_ACTION_DOCUMENT_RESPONSE_CONTRACTS = {
+    ("/api/v1/jobs/bulk", "post"): "BulkJobsResponse",
+}
 PROJECT_CHILD_DOCUMENT_ARRAY_FIELDS = {
     "AnalysisTimingSchema": ("beats", "bars"),
     "ChordResponse": ("source_segments", "timeline"),
@@ -60,6 +63,7 @@ EXPLICIT_UNPAGINATED_RESPONSE_CONTRACTS = {
     },
     **PROJECT_CHILD_DOCUMENT_RESPONSE_CONTRACTS,
     **SYNC_DOCUMENT_RESPONSE_CONTRACTS,
+    **JOB_ACTION_DOCUMENT_RESPONSE_CONTRACTS,
 }
 CLASSIFIED_ARRAY_RESPONSE_ROUTE_KEYS = {
     *PAGINATED_RESPONSE_CONTRACTS,

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { normalizeSyncTransportStatus, type JobSchema, type ProjectSchema } from "./lib/api";
 import {
   mockCancelJob,
+  mockConfirm,
   mockGetProject,
   mockGetSyncIdentity,
   mockGetSyncTransportStatus,
@@ -15,10 +16,12 @@ import {
   mockSyncTrustedPeerNow,
   mockTrustSyncPeer,
   mockListJobs,
+  mockBulkJobs,
   mockListProjects,
   renderApp,
   resetAppTestHarness,
   setJobs,
+  setChordBackends,
   setProjects,
   setSyncTransportStatus,
   setSyncTrustedPeers,
@@ -1440,6 +1443,218 @@ describe("Desktop app activity", () => {
     await waitFor(() => expect(mockCancelJob).toHaveBeenCalledWith("job_pending"));
     await waitFor(() => expect(mockListJobs.mock.calls.length).toBeGreaterThan(initialListJobsCalls));
     expect(await screen.findByRole("article", { name: "analyze cancelled job" })).toBeInTheDocument();
+  });
+
+  it("requires confirmation before starting a bulk job action", async () => {
+    const user = userEvent.setup();
+    let approveConfirm: ((value: boolean) => void) | null = null;
+    mockConfirm.mockImplementationOnce(
+      () =>
+        new Promise<boolean>((resolve) => {
+          approveConfirm = resolve;
+        }),
+    );
+
+    renderApp(["/activity"]);
+
+    expect(await screen.findByRole("heading", { level: 2, name: "Jobs" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Analyze all projects" }));
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.stringContaining("may use CPU/GPU heavily"),
+      expect.objectContaining({
+        title: "Analyze all projects",
+        okLabel: "Analyze all",
+        cancelLabel: "Cancel",
+      }),
+    );
+    expect(mockBulkJobs).not.toHaveBeenCalled();
+
+    await act(async () => {
+      approveConfirm?.(true);
+    });
+
+    await waitFor(() => expect(mockBulkJobs).toHaveBeenCalledWith({ job_type: "analyze" }));
+  });
+
+  it("does not enqueue a bulk job action when confirmation is cancelled", async () => {
+    const user = userEvent.setup();
+    mockConfirm.mockResolvedValueOnce(false);
+
+    renderApp(["/activity"]);
+
+    expect(await screen.findByRole("heading", { level: 2, name: "Jobs" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Refresh chords for all projects" }));
+
+    await waitFor(() => expect(mockConfirm).toHaveBeenCalled());
+    expect(mockBulkJobs).not.toHaveBeenCalled();
+  });
+
+  it("shows a bulk job success summary and refreshes jobs", async () => {
+    const user = userEvent.setup();
+    setProjects([
+      project({ id: "proj_bulk_1", display_name: "Bulk Song 1" }),
+      project({ id: "proj_bulk_2", display_name: "Bulk Song 2" }),
+      project({ id: "proj_bulk_3", display_name: "Bulk Song 3" }),
+    ]);
+    setJobs([]);
+
+    renderApp(["/activity"]);
+
+    expect(await screen.findByRole("heading", { level: 2, name: "Jobs" })).toBeInTheDocument();
+    await waitFor(() => expect(mockListJobs).toHaveBeenCalledTimes(2));
+    const initialListJobsCalls = mockListJobs.mock.calls.length;
+
+    await user.click(screen.getByRole("button", { name: "Refresh lyrics for all projects" }));
+
+    await waitFor(() => expect(mockBulkJobs).toHaveBeenCalledWith({ job_type: "lyrics" }));
+    expect(await screen.findByText("Lyrics jobs: 3 queued, 0 skipped.")).toBeInTheDocument();
+    await waitFor(() => expect(mockListJobs.mock.calls.length).toBeGreaterThan(initialListJobsCalls));
+  });
+
+  it("shows grouped skip details for partial bulk job success", async () => {
+    const user = userEvent.setup();
+    setProjects([
+      project({ id: "proj_bulk_skip", display_name: "Busy Song" }),
+      project({ id: "proj_bulk_queue", display_name: "Queued Song" }),
+    ]);
+    setJobs([
+      job({
+        id: "job_active_bulk_lyrics",
+        project_id: "proj_bulk_skip",
+        type: "lyrics",
+        status: "running",
+        progress: 40,
+      }),
+    ]);
+
+    renderApp(["/activity"]);
+
+    expect(await screen.findByRole("heading", { level: 2, name: "Jobs" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Refresh lyrics for all projects" }));
+
+    expect(await screen.findByText("Lyrics jobs: 1 queued, 1 skipped.")).toBeInTheDocument();
+    const skippedProjects = screen.getByLabelText("Skipped projects");
+    expect(within(skippedProjects).getByText("Already active:")).toBeInTheDocument();
+    expect(within(skippedProjects).getByText("Busy Song (proj_bulk_skip)")).toBeInTheDocument();
+  });
+
+  it("shows skip details when every bulk job project is skipped", async () => {
+    const user = userEvent.setup();
+    setProjects([
+      project({ id: "proj_bulk_skip_a", display_name: "Busy Song A" }),
+      project({ id: "proj_bulk_skip_b", display_name: "Busy Song B" }),
+    ]);
+    setJobs([
+      job({
+        id: "job_active_bulk_lyrics_a",
+        project_id: "proj_bulk_skip_a",
+        type: "lyrics",
+        status: "pending",
+        progress: 0,
+      }),
+      job({
+        id: "job_active_bulk_lyrics_b",
+        project_id: "proj_bulk_skip_b",
+        type: "lyrics",
+        status: "running",
+        progress: 30,
+      }),
+    ]);
+
+    renderApp(["/activity"]);
+
+    expect(await screen.findByRole("heading", { level: 2, name: "Jobs" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Refresh lyrics for all projects" }));
+
+    expect(await screen.findByText("Lyrics jobs: 0 queued, 2 skipped.")).toBeInTheDocument();
+    const skippedProjects = screen.getByLabelText("Skipped projects");
+    expect(within(skippedProjects).getByText("Already active:")).toBeInTheDocument();
+    expect(within(skippedProjects).getByText(/Busy Song A \(proj_bulk_skip_a\)/)).toBeInTheDocument();
+    expect(within(skippedProjects).getByText(/Busy Song B \(proj_bulk_skip_b\)/)).toBeInTheDocument();
+  });
+
+  it("uses default chord backend and stem model preferences for bulk refresh actions", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({
+        defaultChordBackend: "crema-advanced",
+        defaultStemModel: "htdemucs_ft",
+      }),
+    );
+
+    renderApp(["/activity"]);
+
+    expect(await screen.findByRole("heading", { level: 2, name: "Jobs" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Refresh chords for all projects" }));
+    await waitFor(() =>
+      expect(mockBulkJobs).toHaveBeenCalledWith({
+        job_type: "chords",
+        chord_backend: "crema-advanced",
+      }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Refresh existing stems" }));
+    await waitFor(() =>
+      expect(mockBulkJobs).toHaveBeenCalledWith({
+        job_type: "stems",
+        chord_backend: "crema-advanced",
+        stem_model: "htdemucs_ft",
+      }),
+    );
+  });
+
+  it("uses chord backend fallback preferences for bulk stem refresh", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({
+        defaultChordBackend: "crema-advanced",
+        defaultStemModel: "htdemucs_ft",
+      }),
+    );
+    setChordBackends([
+      { id: "tuneforge-fast", available: true },
+      { id: "crema-advanced", available: false },
+    ]);
+
+    renderApp(["/activity"]);
+
+    expect(await screen.findByRole("heading", { level: 2, name: "Jobs" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Refresh existing stems" }));
+
+    await waitFor(() =>
+      expect(mockBulkJobs).toHaveBeenCalledWith({
+        job_type: "stems",
+        chord_backend: "tuneforge-fast",
+        chord_backend_fallback_from: "crema-advanced",
+        stem_model: "htdemucs_ft",
+      }),
+    );
+  });
+
+  it("shows bulk job errors without clearing the existing list", async () => {
+    const user = userEvent.setup();
+    setJobs([
+      job({
+        id: "job_existing",
+        type: "preview",
+        status: "completed",
+        progress: 100,
+        completed_at: "2026-04-18T13:20:00.000Z",
+      }),
+    ]);
+    mockBulkJobs.mockRejectedValueOnce(new Error("Bulk enqueue failed."));
+
+    renderApp(["/activity"]);
+
+    expect(await screen.findByRole("article", { name: "preview completed job" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Refresh existing stems" }));
+
+    expect(await screen.findByText("Bulk enqueue failed.")).toBeInTheDocument();
+    expect(screen.getByRole("article", { name: "preview completed job" })).toBeInTheDocument();
   });
 
   it("refreshes active jobs until they reach a terminal status", async () => {

--- a/apps/desktop/src/features/activity/ActivityView.tsx
+++ b/apps/desktop/src/features/activity/ActivityView.tsx
@@ -1,9 +1,13 @@
 import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { useInfiniteQuery, useMutation, useQueries, useQueryClient } from "@tanstack/react-query";
+import { Activity, Layers, Mic, RefreshCw } from "lucide-react";
 import { Link } from "react-router-dom";
-import { api, type JobSchema, type ProjectSchema } from "../../lib/api";
+import { confirm } from "@tauri-apps/plugin-dialog";
+import { api, type BulkJobRequest, type BulkJobsResponse, type JobSchema, type ProjectSchema } from "../../lib/api";
 import { formatLocalDateTime, normalizeApiDateTime, parseApiDateTime } from "../../lib/datetime";
 import { useLazyLoadSentinel } from "../../lib/useLazyLoadSentinel";
+import { usePreferences } from "../../lib/preferences";
+import { useChordBackendActionSelection } from "../projects/hooks/useChordBackendActionSelection";
 import { formatJobStatusSummary } from "../projects/projectViewUtils";
 import { ActivitySyncPanel } from "./ActivitySyncPanel";
 
@@ -22,8 +26,52 @@ const ACTIVITY_TABS = [
   { id: "jobs", label: "Jobs" },
   { id: "sync", label: "Sync" },
 ] as const;
+const BULK_JOB_ACTIONS = [
+  {
+    jobType: "analyze",
+    label: "Analyze all projects",
+    pendingLabel: "Queueing analyze jobs...",
+    resultLabel: "Analyze jobs",
+    confirmTitle: "Analyze all projects",
+    confirmBody: "Re-analyze every project? This may take time and may use CPU/GPU heavily.",
+    okLabel: "Analyze all",
+    icon: Activity,
+  },
+  {
+    jobType: "chords",
+    label: "Refresh chords for all projects",
+    pendingLabel: "Queueing chord jobs...",
+    resultLabel: "Chord jobs",
+    confirmTitle: "Refresh chords for all projects",
+    confirmBody: "Refresh chords for every project with your default chord backend? Existing chord timelines and tab suggestions may be replaced. This may take time and may use CPU/GPU heavily.",
+    okLabel: "Refresh chords",
+    icon: RefreshCw,
+  },
+  {
+    jobType: "lyrics",
+    label: "Refresh lyrics for all projects",
+    pendingLabel: "Queueing lyrics jobs...",
+    resultLabel: "Lyrics jobs",
+    confirmTitle: "Refresh lyrics for all projects",
+    confirmBody: "Refresh lyrics for every project? Existing transcripts and imported tab suggestions may be replaced. This may take time and may use CPU/GPU heavily.",
+    okLabel: "Refresh lyrics",
+    icon: Mic,
+  },
+  {
+    jobType: "stems",
+    label: "Refresh existing stems",
+    pendingLabel: "Queueing stem jobs...",
+    resultLabel: "Stem jobs",
+    confirmTitle: "Refresh existing stems",
+    confirmBody: "Refresh only source tracks and practice mixes that already have stems, using your default stem model. This may take time and may use CPU/GPU heavily.",
+    okLabel: "Refresh stems",
+    icon: Layers,
+  },
+] as const;
 
 type ActivityTab = (typeof ACTIVITY_TABS)[number]["id"];
+type BulkJobAction = (typeof BULK_JOB_ACTIONS)[number];
+type BulkJobSkippedProject = BulkJobsResponse["skipped"][number];
 
 type DisplayJob = {
   job: JobSchema;
@@ -110,6 +158,65 @@ function progressValue(job: JobSchema) {
 
 function hasActiveJob(jobs: JobSchema[] | undefined) {
   return jobs?.some((job) => CANCELABLE_JOB_STATUSES.has(job.status)) ?? false;
+}
+
+function bulkJobsSummary(action: BulkJobAction, response: BulkJobsResponse) {
+  return `${action.resultLabel}: ${response.created_jobs?.length ?? 0} queued, ${response.skipped?.length ?? 0} skipped.`;
+}
+
+function bulkJobSkipReasonLabel(reason: BulkJobSkippedProject["reason"]) {
+  switch (reason) {
+    case "active_job":
+      return "Already active";
+    case "locked":
+      return "Locked by sync";
+    case "no_existing_stems":
+      return "No existing stems";
+    case "creation_failed":
+      return "Could not queue";
+    default:
+      return "Skipped";
+  }
+}
+
+function bulkJobSkippedProjectLabel(project: BulkJobSkippedProject) {
+  return project.project_name ? `${project.project_name} (${project.project_id})` : project.project_id;
+}
+
+function groupedBulkJobSkips(skipped: BulkJobSkippedProject[] | undefined) {
+  const groups: Array<{ reason: BulkJobSkippedProject["reason"]; projects: BulkJobSkippedProject[] }> = [];
+  const groupByReason = new Map<BulkJobSkippedProject["reason"], BulkJobSkippedProject[]>();
+  for (const skippedProject of skipped ?? []) {
+    const existingGroup = groupByReason.get(skippedProject.reason);
+    if (existingGroup) {
+      existingGroup.push(skippedProject);
+      continue;
+    }
+    const projects = [skippedProject];
+    groupByReason.set(skippedProject.reason, projects);
+    groups.push({ reason: skippedProject.reason, projects });
+  }
+  return groups;
+}
+
+function BulkJobSkipDetails({ response }: { response: BulkJobsResponse }) {
+  const skipGroups = groupedBulkJobSkips(response.skipped);
+  if (!skipGroups.length) {
+    return null;
+  }
+
+  return (
+    <div aria-label="Skipped projects" className="activity-bulk-skip-details">
+      <ul>
+        {skipGroups.map((group) => (
+          <li key={group.reason}>
+            <strong>{bulkJobSkipReasonLabel(group.reason)}:</strong>{" "}
+            <span>{group.projects.map(bulkJobSkippedProjectLabel).join(", ")}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }
 
 function uniqueJobs(jobs: JobSchema[]) {
@@ -233,9 +340,15 @@ function JobRow({
 export function ActivityView() {
   const [activeTab, setActiveTab] = useState<ActivityTab>("jobs");
   const [searchDraft, setSearchDraft] = useState("");
+  const [bulkJobResult, setBulkJobResult] = useState<{
+    action: BulkJobAction;
+    response: BulkJobsResponse;
+  } | null>(null);
   const deferredSearch = useDeferredValue(searchDraft.trim());
   const previousActiveJobIds = useRef<Set<string>>(new Set());
   const queryClient = useQueryClient();
+  const { defaultStemModel } = usePreferences();
+  const { chordBackendForAction } = useChordBackendActionSelection();
   const activeJobsQueryKey = useMemo(
     () => [...ACTIVE_JOBS_QUERY_KEY, deferredSearch] as const,
     [deferredSearch],
@@ -337,6 +450,29 @@ export function ActivityView() {
       await queryClient.invalidateQueries({ queryKey: ["jobs"] });
     },
   });
+  const bulkJobsMutation = useMutation({
+    mutationFn: async (action: BulkJobAction) => {
+      const request: BulkJobRequest = { job_type: action.jobType };
+      if (action.jobType === "chords" || action.jobType === "stems") {
+        const backendSelection = await chordBackendForAction();
+        request.chord_backend = backendSelection.backend;
+        if (backendSelection.backend_fallback_from) {
+          request.chord_backend_fallback_from = backendSelection.backend_fallback_from;
+        }
+      }
+      if (action.jobType === "stems") {
+        request.stem_model = defaultStemModel;
+      }
+      return api.bulkJobs(request);
+    },
+    onMutate: () => {
+      setBulkJobResult(null);
+    },
+    onSuccess: async (response, action) => {
+      setBulkJobResult({ action, response });
+      await queryClient.invalidateQueries({ queryKey: ["jobs"] });
+    },
+  });
 
   const projectsById = useMemo(
     () => new Map(jobProjectIds.map((projectId, index) => [projectId, projectQueries[index]?.data ?? null])),
@@ -392,6 +528,21 @@ export function ActivityView() {
     }
   }, [activeJobs, isActiveJobsSuccess, queryClient, terminalJobsQueryKey]);
 
+  async function handleBulkJobAction(action: BulkJobAction) {
+    bulkJobsMutation.reset();
+    setBulkJobResult(null);
+    const approved = await confirm(action.confirmBody, {
+      title: action.confirmTitle,
+      kind: "warning",
+      okLabel: action.okLabel,
+      cancelLabel: "Cancel",
+    });
+    if (!approved) {
+      return;
+    }
+    bulkJobsMutation.mutate(action);
+  }
+
   return (
     <section className="screen activity-screen">
       <div className="screen__header">
@@ -437,18 +588,62 @@ export function ActivityView() {
                   : "No pending or running jobs."}
               </p>
             </div>
-            <label className="search-field">
-              <span className="search-field__label">Search jobs</span>
-              <input
-                aria-label="Search jobs by project"
-                className="search-field__input"
-                placeholder="Search project names"
-                type="search"
-                value={searchDraft}
-                onChange={(event) => setSearchDraft(event.target.value)}
-              />
-            </label>
+            <div className="activity-jobs-panel__heading-actions">
+              <label className="search-field">
+                <span className="search-field__label">Search jobs</span>
+                <input
+                  aria-label="Search jobs by project"
+                  className="search-field__input"
+                  placeholder="Search project names"
+                  type="search"
+                  value={searchDraft}
+                  onChange={(event) => setSearchDraft(event.target.value)}
+                />
+              </label>
+            </div>
           </div>
+          <div aria-label="Bulk job actions" className="activity-bulk-actions" role="group">
+            {BULK_JOB_ACTIONS.map((action) => {
+              const Icon = action.icon;
+              const isPending = bulkJobsMutation.isPending &&
+                bulkJobsMutation.variables?.jobType === action.jobType;
+              return (
+                <button
+                  className="button button--ghost button--small activity-bulk-actions__button"
+                  disabled={bulkJobsMutation.isPending}
+                  key={action.jobType}
+                  onClick={() => {
+                    void handleBulkJobAction(action);
+                  }}
+                  type="button"
+                >
+                  <Icon aria-hidden="true" size={16} />
+                  <span>{isPending ? "Queueing..." : action.label}</span>
+                </button>
+              );
+            })}
+          </div>
+
+          {bulkJobsMutation.isPending ? (
+            <div className="activity-jobs-panel__state" role="status">
+              {bulkJobsMutation.variables?.pendingLabel ?? "Queueing bulk jobs..."}
+            </div>
+          ) : null}
+
+          {bulkJobResult ? (
+            <div className="activity-jobs-panel__state activity-jobs-panel__state--success" role="status">
+              {bulkJobsSummary(bulkJobResult.action, bulkJobResult.response)}
+              <BulkJobSkipDetails response={bulkJobResult.response} />
+            </div>
+          ) : null}
+
+          {bulkJobsMutation.isError ? (
+            <div className="activity-jobs-panel__state activity-jobs-panel__state--error" role="alert">
+              {bulkJobsMutation.error instanceof Error
+                ? bulkJobsMutation.error.message
+                : "Could not queue bulk jobs."}
+            </div>
+          ) : null}
 
           {isLoading ? (
             <div className="activity-jobs-panel__state" role="status">

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -35,6 +35,9 @@ export type LyricsWordSchema = components["schemas"]["LyricsWordSchema"];
 export type ArtifactSchema = components["schemas"]["ArtifactSchema"];
 export type JobSchema = components["schemas"]["JobSchema"];
 export type JobsResponse = components["schemas"]["JobsResponse"];
+export type BulkJobType = components["schemas"]["BulkJobRequest"]["job_type"];
+export type BulkJobRequest = components["schemas"]["BulkJobRequest"];
+export type BulkJobsResponse = components["schemas"]["BulkJobsResponse"];
 export type ListProjectsParams = NonNullable<paths["/api/v1/projects"]["get"]["parameters"]["query"]>;
 export type ListJobsParams = NonNullable<paths["/api/v1/jobs"]["get"]["parameters"]["query"]>;
 export type PreviewRequest = components["schemas"]["PreviewRequest"];
@@ -1145,6 +1148,7 @@ export type TuneForgeClient = {
   listJobs: (params?: ListJobsParams) => Promise<JobsResponse>;
   getJob: (jobId: string) => Promise<components["schemas"]["JobResponse"]>;
   cancelJob: (jobId: string) => Promise<components["schemas"]["JobResponse"]>;
+  bulkJobs: (body: BulkJobRequest) => Promise<BulkJobsResponse>;
   getSyncIdentity: () => Promise<SyncLocalIdentityResponse>;
   createSyncPairingOffer: (body: SyncPairingOfferRequest) => Promise<SyncPairingOfferResponse>;
   answerSyncPairingOffer: (body: SyncPairingAnswerRequest) => Promise<SyncPairingAnswerResponse>;
@@ -1356,6 +1360,7 @@ function createHttpTuneForgeClient(): TuneForgeClient {
     getJob: (jobId: string) => unwrap(client.GET("/api/v1/jobs/{job_id}", { params: { path: { job_id: jobId } } })),
     cancelJob: (jobId: string) =>
       unwrap(client.POST("/api/v1/jobs/{job_id}/cancel", { params: { path: { job_id: jobId } } })),
+    bulkJobs: (body: BulkJobRequest) => unwrap(client.POST("/api/v1/jobs/bulk", { body })),
     getSyncIdentity: () => unwrap(client.GET("/api/v1/sync/identity")),
     createSyncPairingOffer: (body: SyncPairingOfferRequest) =>
       isTauriRuntime()
@@ -1446,6 +1451,9 @@ function createMobileTuneForgeClient(capabilities: MobileCapabilities): TuneForg
     listJobs: (params?: ListJobsParams) => invokeMobile("mobile_list_jobs", { params: params ?? null }),
     getJob: (jobId: string) => invokeMobile("mobile_get_job", { jobId }),
     cancelJob: (jobId: string) => invokeMobile("mobile_cancel_job", { jobId }),
+    bulkJobs: async () => {
+      throw unsupportedRuntimeError("Bulk jobs");
+    },
     getSyncIdentity: () => invokeMobile("mobile_get_sync_identity"),
     createSyncPairingOffer: (body: SyncPairingOfferRequest) =>
       invokeMobile("mobile_create_sync_pairing_offer", { payload: body }),
@@ -1547,6 +1555,7 @@ export const api: TuneForgeClient = {
   listJobs: (params?: ListJobsParams) => activeClient.listJobs(params),
   getJob: (jobId: string) => activeClient.getJob(jobId),
   cancelJob: (jobId: string) => activeClient.cancelJob(jobId),
+  bulkJobs: (body: BulkJobRequest) => activeClient.bulkJobs(body),
   getSyncIdentity: () => activeClient.getSyncIdentity(),
   createSyncPairingOffer: (body: SyncPairingOfferRequest) => activeClient.createSyncPairingOffer(body),
   answerSyncPairingOffer: (body: SyncPairingAnswerRequest) => activeClient.answerSyncPairingOffer(body),

--- a/apps/desktop/src/styles/activity.css
+++ b/apps/desktop/src/styles/activity.css
@@ -15,6 +15,14 @@
   width: min(20rem, 100%);
 }
 
+.activity-jobs-panel__heading-actions {
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
 .activity-jobs-panel__heading .search-field__input {
   min-height: 3.2rem;
 }
@@ -30,6 +38,52 @@
 .activity-jobs-panel__state--error {
   border-color: color-mix(in srgb, var(--danger) 44%, transparent);
   color: var(--danger);
+}
+
+.activity-jobs-panel__state--success {
+  border-color: color-mix(in srgb, var(--playback-accent) 44%, transparent);
+}
+
+.activity-bulk-skip-details {
+  display: grid;
+  gap: 0.35rem;
+  margin-top: 0.7rem;
+  padding-top: 0.7rem;
+  border-top: 1px solid color-mix(in srgb, var(--divider) 76%, transparent);
+  color: var(--text);
+}
+
+.activity-bulk-skip-details ul {
+  display: grid;
+  gap: 0.32rem;
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.activity-bulk-skip-details li {
+  overflow-wrap: anywhere;
+}
+
+.activity-bulk-actions {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.activity-bulk-actions__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  width: 100%;
+  min-height: 2.75rem;
+  line-height: 1.2;
+  text-align: center;
+  white-space: normal;
+}
+
+.activity-bulk-actions__button svg {
+  flex: 0 0 auto;
 }
 
 .activity-jobs-panel__empty {
@@ -469,6 +523,18 @@
 }
 
 @media (max-width: 920px) {
+  .activity-jobs-panel__heading-actions {
+    justify-content: flex-start;
+  }
+
+  .activity-jobs-panel__heading-actions {
+    width: 100%;
+  }
+
+  .activity-bulk-actions {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .activity-job-row__main {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -492,5 +558,11 @@
 
   .activity-sync-peer-row__actions {
     justify-content: flex-start;
+  }
+}
+
+@media (max-width: 620px) {
+  .activity-bulk-actions {
+    grid-template-columns: minmax(0, 1fr);
   }
 }

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -4,6 +4,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { vi } from "vitest";
 import App from "../App";
 import type {
+  BulkJobRequest,
+  BulkJobsResponse,
   ListJobsParams,
   ListProjectsParams,
   SyncPairingAnswerRequest,
@@ -55,6 +57,7 @@ const {
   mockListArtifacts,
   mockListJobs,
   mockCancelJob,
+  mockBulkJobs,
   mockGetSyncIdentity,
   mockGetSyncTransportStatus,
   mockStartSyncListener,
@@ -1428,6 +1431,44 @@ const {
     state.jobs = state.jobs.map((job, index) => (index === jobIndex ? cancelledJob : job));
     return { job: clone(cancelledJob) };
   });
+  const mockBulkJobs = vi.fn(async (body: BulkJobRequest): Promise<BulkJobsResponse> => {
+    const activeStatuses = new Set(["pending", "running"]);
+    const jobs: Array<Record<string, unknown>> = [];
+    const skipped: NonNullable<BulkJobsResponse["skipped"]> = [];
+
+    state.projects.forEach((project) => {
+      const projectId = String(project.id);
+      const projectName = String(project.display_name ?? projectId);
+      const hasActiveDuplicate = state.jobs.some(
+        (job) =>
+          job.project_id === projectId &&
+          job.type === body.job_type &&
+          typeof job.status === "string" &&
+          activeStatuses.has(job.status),
+      );
+      if (hasActiveDuplicate) {
+        skipped.push({ project_id: projectId, project_name: projectName, reason: "active_job" });
+        return;
+      }
+
+      const queuedJob = makeMockJob({
+        project_id: projectId,
+        type: body.job_type,
+        status: "pending",
+        progress: 0,
+        created_at: createdAt,
+        updated_at: createdAt,
+      });
+      jobs.push(queuedJob);
+    });
+
+    state.jobs = [...jobs, ...state.jobs];
+    return {
+      created_jobs: clone(jobs) as NonNullable<BulkJobsResponse["created_jobs"]>,
+      total_projects: state.projects.length,
+      skipped,
+    };
+  });
   function normalizeSyncPeer(peer: Record<string, unknown>): SyncTrustedPeerSchema {
     return {
       device_id: String(peer.device_id ?? "device_peer"),
@@ -2132,6 +2173,7 @@ const {
     mockListArtifacts,
     mockListJobs,
     mockCancelJob,
+    mockBulkJobs,
     mockGetSyncIdentity,
     mockGetSyncTransportStatus,
     mockStartSyncListener,
@@ -2199,6 +2241,7 @@ export {
   mockListArtifacts,
   mockListJobs,
   mockCancelJob,
+  mockBulkJobs,
   mockGetSyncIdentity,
   mockGetSyncTransportStatus,
   mockStartSyncListener,
@@ -2261,6 +2304,7 @@ vi.mock("../lib/api", async (importOriginal) => {
       listArtifacts: mockListArtifacts,
       listJobs: mockListJobs,
       cancelJob: mockCancelJob,
+      bulkJobs: mockBulkJobs,
       getSyncIdentity: mockGetSyncIdentity,
       getSyncTransportStatus: mockGetSyncTransportStatus,
       startSyncListener: mockStartSyncListener,
@@ -2650,6 +2694,7 @@ export function resetAppTestHarness() {
   mockListArtifacts.mockClear();
   mockListJobs.mockClear();
   mockCancelJob.mockClear();
+  mockBulkJobs.mockClear();
   mockGetSyncIdentity.mockClear();
   mockGetSyncTransportStatus.mockClear();
   mockStartSyncListener.mockClear();

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -383,6 +383,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/jobs/bulk": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Bulk Jobs */
+        post: operations["create_bulk_jobs_api_v1_jobs_bulk_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/jobs/{job_id}": {
         parameters: {
             query?: never;
@@ -802,6 +819,42 @@ export interface components {
         ArtifactsResponse: {
             /** Artifacts */
             artifacts: components["schemas"]["ArtifactSchema"][];
+        };
+        /** BulkJobRequest */
+        BulkJobRequest: {
+            /**
+             * Job Type
+             * @description Project job type to enqueue for every project.
+             * @enum {string}
+             */
+            job_type: "analyze" | "chords" | "lyrics" | "stems";
+            /** Chord Backend */
+            chord_backend?: string | null;
+            /** Chord Backend Fallback From */
+            chord_backend_fallback_from?: string | null;
+            /** Stem Model */
+            stem_model?: string | null;
+        };
+        /** BulkJobSkippedProjectSchema */
+        BulkJobSkippedProjectSchema: {
+            /** Project Id */
+            project_id: string;
+            /** Project Name */
+            project_name: string;
+            /**
+             * Reason
+             * @enum {string}
+             */
+            reason: "active_job" | "locked" | "creation_failed" | "no_existing_stems";
+        };
+        /** BulkJobsResponse */
+        BulkJobsResponse: {
+            /** Created Jobs */
+            created_jobs: components["schemas"]["JobSchema"][];
+            /** Total Projects */
+            total_projects: number;
+            /** Skipped */
+            skipped: components["schemas"]["BulkJobSkippedProjectSchema"][];
         };
         /** ChordBackendCapabilitiesSchema */
         ChordBackendCapabilitiesSchema: {
@@ -3121,6 +3174,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["JobsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_bulk_jobs_api_v1_jobs_bulk_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BulkJobRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BulkJobsResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary

- Add `POST /api/v1/jobs/bulk` for analyze, chords, lyrics, and stems.
- Reuse shared job creation paths with per-project skip reporting.
- Add Activity bulk controls with confirmation, queued/skipped summaries, and skip details.
- Respect chord and stem defaults; refresh analyze/chords/lyrics, and refresh only existing stems.

## Testing

- `cd apps/backend && uv run --python 3.11 pytest`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `pnpm contracts:generate`
- `pnpm --filter @tuneforge/desktop test -- --run src/App.activity.test.tsx`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
- `git diff --check`
