### PR TITLE
fix(backend): bridge sparse timing gaps

### DIFF
--- a/apps/backend/app/engines/analysis.py
+++ b/apps/backend/app/engines/analysis.py
@@ -27,6 +27,24 @@ BEAT_PHASE_BOOKEND_MIN_RATIO = 0.72
 BEAT_PHASE_MAX_BURST_GRID_STEPS = BEATS_PER_BAR
 BEAT_PHASE_MIN_LOCAL_TEMPO_INTERVALS = BEATS_PER_BAR + 2
 BEAT_PHASE_LOCAL_TEMPO_MAX_DEVIATION_RATIO = 0.2
+SPARSE_BRIDGE_ACTIVE_COVERAGE_RATIO = 0.35
+SPARSE_BRIDGE_SILENT_COVERAGE_RATIO = 0.18
+SPARSE_BRIDGE_STABLE_CONTEXT_INTERVALS = BEATS_PER_BAR * 2
+SPARSE_BRIDGE_MIN_STABLE_INTERVALS = BEATS_PER_BAR
+SPARSE_BRIDGE_STABLE_DEVIATION_RATIO = 0.18
+SPARSE_BRIDGE_MIN_GRID_STEPS = BEATS_PER_BAR
+SPARSE_BRIDGE_CANDIDATE_TOLERANCE_RATIO = 0.12
+SPARSE_BRIDGE_MIN_CANDIDATE_TOLERANCE_SECONDS = 0.03
+SPARSE_BRIDGE_MAX_CANDIDATE_TOLERANCE_SECONDS = 0.07
+SPARSE_BRIDGE_RELOCK_TOLERANCE_RATIO = 0.3
+SPARSE_BRIDGE_MIN_RELOCK_TOLERANCE_SECONDS = 0.08
+SPARSE_BRIDGE_MAX_RELOCK_TOLERANCE_SECONDS = 0.24
+SPARSE_BRIDGE_RELOCK_LOOKAHEAD_CANDIDATES = BEATS_PER_BAR * 2
+SPARSE_BRIDGE_MUSICAL_CANDIDATE_STRENGTH_RATIO = 0.45
+SPARSE_BRIDGE_MUSICAL_MIN_CONTEXT_STRENGTH_RATIO = 0.2
+SPARSE_BRIDGE_MUSICAL_LOCAL_STRENGTH_RATIO = 0.65
+SPARSE_BRIDGE_MIN_MUSICAL_CANDIDATE_FRACTION = 0.5
+SPARSE_BRIDGE_RELOCK_CANDIDATE_STRENGTH_RATIO = 0.35
 
 MAJOR_PROFILE = np.array(
     [6.35, 2.23, 3.48, 2.33, 4.38, 4.09, 2.52, 5.19, 2.39, 3.66, 2.29, 2.88],
@@ -85,6 +103,9 @@ class AnalysisPayload(TypedDict):
     tuning_offset_cents: float | None
     tempo_bpm: float | None
     timing: AnalysisTimingPayload | None
+
+
+SparseBridgeRelockCandidate = tuple[int, float, int, float, float]
 
 
 def analyze_track(source_path: Path) -> AnalysisPayload:
@@ -157,9 +178,10 @@ def _detected_beat_times(features: HarmonicFeatures) -> np.ndarray:
     if beat_frames.size == 0:
         return np.zeros(0, dtype=np.float64)
     beat_times = features.times[beat_frames].astype(np.float64)
-    return _stabilize_detected_beat_phase(
+    stabilized_times = _stabilize_detected_beat_phase(
         _clean_beat_times(beat_times, features.duration_seconds)
     )
+    return _bridge_sparse_beat_gaps(stabilized_times, features)
 
 
 def _fallback_beat_times(tempo_bpm: float | None, duration_seconds: float) -> np.ndarray:
@@ -228,6 +250,755 @@ def _stabilize_detected_beat_phase(beat_times: np.ndarray) -> np.ndarray:
     if bool(np.all(keep)):
         return beat_times
     return beat_times[keep]
+
+
+def _bridge_sparse_beat_gaps(
+    beat_times: np.ndarray,
+    features: HarmonicFeatures,
+) -> np.ndarray:
+    if beat_times.size < SPARSE_BRIDGE_MIN_STABLE_INTERVALS + 2:
+        return beat_times
+    if features.duration_seconds <= 0.0:
+        return beat_times
+
+    intervals = np.diff(beat_times.astype(np.float64))
+    sparse_intervals = np.asarray(
+        [
+            _is_sparse_audio_region(
+                features,
+                float(beat_times[index]),
+                float(beat_times[index + 1]),
+            )
+            for index in range(intervals.size)
+        ],
+        dtype=np.bool_,
+    )
+    if not bool(np.any(sparse_intervals)):
+        return beat_times
+
+    bridged_times: list[float] = []
+    changed = False
+    index = 0
+    while index < beat_times.size:
+        bridged_times.append(float(beat_times[index]))
+        if index >= intervals.size or not sparse_intervals[index]:
+            index += 1
+            continue
+
+        run_start = index
+        run_end = index
+        while run_end + 1 < intervals.size and sparse_intervals[run_end + 1]:
+            run_end += 1
+
+        bridge = _sparse_gap_bridge_replacement(
+            beat_times,
+            intervals,
+            features,
+            run_start,
+            run_end,
+        )
+        if bridge is None:
+            index += 1
+            continue
+
+        replacement, consumed_index = bridge
+        original = beat_times[run_start + 1 : consumed_index + 1]
+        changed = changed or not _same_beat_times(original, replacement)
+        bridged_times.extend(replacement.tolist())
+        index = consumed_index + 1
+
+    if not changed:
+        return beat_times
+    return _clean_beat_times(
+        np.asarray(bridged_times, dtype=np.float64),
+        features.duration_seconds,
+    )
+
+
+def _sparse_gap_bridge_replacement(
+    beat_times: np.ndarray,
+    intervals: np.ndarray,
+    features: HarmonicFeatures,
+    run_start: int,
+    run_end: int,
+) -> tuple[np.ndarray, int] | None:
+    if run_end + 1 >= intervals.size:
+        return None
+
+    reference = _stable_bridge_interval_reference(intervals, run_start)
+    if reference <= 0.0:
+        return None
+
+    anchor_seconds = float(beat_times[run_start])
+    context_strength = _sparse_bridge_context_beat_strength(
+        features,
+        beat_times,
+        run_start,
+        reference,
+    )
+    if _has_musical_sparse_bridge_candidates(
+        features,
+        beat_times,
+        run_start,
+        run_end,
+        reference_seconds=reference,
+        context_strength=context_strength,
+    ):
+        return beat_times[run_start + 1 : run_end + 2], run_end + 1
+
+    relock_candidate = _sparse_bridge_relock_candidate(
+        beat_times,
+        features,
+        run_end,
+        anchor_seconds=anchor_seconds,
+        reference_seconds=reference,
+        context_strength=context_strength,
+    )
+    if relock_candidate is None:
+        return None
+    resume_index, resume_seconds, expected_step_count = relock_candidate
+
+    coverage = _active_frame_coverage(features, anchor_seconds, resume_seconds)
+    if (
+        coverage > SPARSE_BRIDGE_SILENT_COVERAGE_RATIO
+        and _is_consistent_local_tempo_phrase(intervals, run_start, run_end)
+    ):
+        return None
+
+    candidate_indices = np.arange(run_start + 1, resume_index + 1)
+    return _projected_sparse_gap_times(
+        beat_times,
+        candidate_indices,
+        anchor_seconds=anchor_seconds,
+        reference_seconds=reference,
+        expected_step_count=expected_step_count,
+        resume_candidate_seconds=resume_seconds,
+        candidate_tolerance_seconds=_sparse_bridge_candidate_tolerance(reference),
+        candidate_strength_ratios=_sparse_bridge_candidate_strength_ratios(
+            features,
+            beat_times[candidate_indices],
+            reference,
+            context_strength,
+        ),
+    ), resume_index
+
+
+def _sparse_bridge_relock_candidate(
+    beat_times: np.ndarray,
+    features: HarmonicFeatures,
+    run_end: int,
+    *,
+    anchor_seconds: float,
+    reference_seconds: float,
+    context_strength: float,
+) -> tuple[int, float, int] | None:
+    first_candidate_index = run_end + 1
+    candidates: list[SparseBridgeRelockCandidate] = []
+    for candidate_index in range(
+        first_candidate_index,
+        min(
+            beat_times.size,
+            first_candidate_index + SPARSE_BRIDGE_RELOCK_LOOKAHEAD_CANDIDATES,
+        ),
+    ):
+        candidate = _sparse_bridge_projected_relock_candidate(
+            beat_times,
+            candidate_index,
+            anchor_seconds=anchor_seconds,
+            reference_seconds=reference_seconds,
+            features=features,
+            context_strength=context_strength,
+        )
+        if candidate is not None:
+            candidates.append(candidate)
+    if not candidates:
+        return None
+
+    for position, candidate in enumerate(candidates[1:], start=1):
+        if _should_prefer_later_sparse_relock_candidate(
+            features,
+            reference_seconds,
+            earlier_candidates=candidates[:position],
+            later_candidate=candidate,
+        ):
+            return candidate[:3]
+
+    first_candidate = candidates[0]
+    if _is_valid_sparse_bridge_relock_candidate(
+        reference_seconds,
+        first_candidate[2],
+        first_candidate[3],
+    ) and _is_active_sparse_bridge_relock_candidate(
+        features,
+        reference_seconds,
+        first_candidate,
+    ):
+        return first_candidate[:3]
+    return None
+
+
+def _is_valid_sparse_bridge_relock_candidate(
+    reference_seconds: float,
+    expected_step_count: int,
+    grid_error_seconds: float,
+) -> bool:
+    return expected_step_count >= SPARSE_BRIDGE_MIN_GRID_STEPS and (
+        _is_aligned_sparse_bridge_relock_candidate(
+            reference_seconds,
+            grid_error_seconds,
+        )
+    )
+
+
+def _is_aligned_sparse_bridge_relock_candidate(
+    reference_seconds: float,
+    grid_error_seconds: float,
+) -> bool:
+    return grid_error_seconds <= _sparse_bridge_relock_tolerance(reference_seconds)
+
+
+def _should_prefer_later_sparse_relock_candidate(
+    features: HarmonicFeatures,
+    reference_seconds: float,
+    *,
+    earlier_candidates: list[SparseBridgeRelockCandidate],
+    later_candidate: SparseBridgeRelockCandidate,
+) -> bool:
+    if not _is_valid_sparse_bridge_relock_candidate(
+        reference_seconds,
+        later_candidate[2],
+        later_candidate[3],
+    ):
+        return False
+    if not _is_active_sparse_bridge_relock_candidate(
+        features,
+        reference_seconds,
+        later_candidate,
+    ):
+        return False
+    if not all(
+        _is_skippable_sparse_bridge_relock_candidate(
+            features,
+            reference_seconds,
+            earlier_candidate,
+            later_candidate,
+        )
+        for earlier_candidate in earlier_candidates
+    ):
+        return False
+
+    return True
+
+
+def _is_active_sparse_bridge_relock_candidate(
+    features: HarmonicFeatures,
+    reference_seconds: float,
+    candidate: SparseBridgeRelockCandidate,
+) -> bool:
+    return (
+        candidate[4] >= SPARSE_BRIDGE_RELOCK_CANDIDATE_STRENGTH_RATIO
+        and _sparse_bridge_relock_candidate_active_coverage(
+            features,
+            reference_seconds,
+            candidate,
+        )
+        > SPARSE_BRIDGE_ACTIVE_COVERAGE_RATIO
+    )
+
+
+def _is_skippable_sparse_bridge_relock_candidate(
+    features: HarmonicFeatures,
+    reference_seconds: float,
+    earlier_candidate: SparseBridgeRelockCandidate,
+    later_candidate: SparseBridgeRelockCandidate,
+) -> bool:
+    if _is_active_sparse_bridge_relock_candidate(
+        features,
+        reference_seconds,
+        earlier_candidate,
+    ):
+        return False
+
+    candidate_tolerance_seconds = _sparse_bridge_candidate_tolerance(reference_seconds)
+    relock_tolerance_seconds = _sparse_bridge_relock_tolerance(reference_seconds)
+    earlier_is_weak = (
+        earlier_candidate[4] < SPARSE_BRIDGE_RELOCK_CANDIDATE_STRENGTH_RATIO
+    )
+    earlier_is_too_early = earlier_candidate[2] < SPARSE_BRIDGE_MIN_GRID_STEPS
+    earlier_is_outside_relock = earlier_candidate[3] > relock_tolerance_seconds
+    earlier_is_off_grid = earlier_candidate[3] > candidate_tolerance_seconds
+    same_projected_step = earlier_candidate[2] == later_candidate[2]
+    return (
+        earlier_is_weak
+        or earlier_is_too_early
+        or earlier_is_outside_relock
+        or earlier_is_off_grid
+        or same_projected_step
+    )
+
+
+def _sparse_bridge_relock_candidate_active_coverage(
+    features: HarmonicFeatures,
+    reference_seconds: float,
+    candidate: SparseBridgeRelockCandidate,
+) -> float:
+    candidate_tolerance_seconds = _sparse_bridge_candidate_tolerance(reference_seconds)
+    return _active_frame_coverage(
+        features,
+        candidate[1] - candidate_tolerance_seconds,
+        candidate[1] + candidate_tolerance_seconds,
+    )
+
+
+def _sparse_bridge_projected_relock_candidate(
+    beat_times: np.ndarray,
+    candidate_index: int,
+    *,
+    anchor_seconds: float,
+    reference_seconds: float,
+    features: HarmonicFeatures,
+    context_strength: float,
+) -> SparseBridgeRelockCandidate | None:
+    if candidate_index >= beat_times.size:
+        return None
+
+    candidate_seconds = float(beat_times[candidate_index])
+    span_seconds = candidate_seconds - anchor_seconds
+    if span_seconds <= 0.0:
+        return None
+
+    expected_step_count = max(1, int(round(span_seconds / reference_seconds)))
+
+    expected_seconds = anchor_seconds + reference_seconds * expected_step_count
+    grid_error = abs(candidate_seconds - expected_seconds)
+    strength_ratio = _sparse_bridge_candidate_strength_ratio(
+        features,
+        candidate_seconds,
+        reference_seconds,
+        context_strength,
+    )
+    return (
+        candidate_index,
+        candidate_seconds,
+        expected_step_count,
+        grid_error,
+        strength_ratio,
+    )
+
+
+def _stable_bridge_interval_reference(intervals: np.ndarray, anchor_index: int) -> float:
+    start = max(0, anchor_index - SPARSE_BRIDGE_STABLE_CONTEXT_INTERVALS)
+    context = intervals[start:anchor_index]
+    context = context[np.isfinite(context) & (context > 0.0)]
+    max_context_size = min(context.size, SPARSE_BRIDGE_STABLE_CONTEXT_INTERVALS)
+    for context_size in range(
+        max_context_size,
+        SPARSE_BRIDGE_MIN_STABLE_INTERVALS - 1,
+        -1,
+    ):
+        candidate = context[-context_size:]
+        reference = float(np.median(candidate.astype(np.float64)))
+        if reference <= 0.0:
+            continue
+        max_deviation = float(np.max(np.abs(candidate - reference)))
+        if max_deviation <= reference * SPARSE_BRIDGE_STABLE_DEVIATION_RATIO:
+            return reference
+    return 0.0
+
+
+def _projected_sparse_gap_times(
+    beat_times: np.ndarray,
+    candidate_indices: np.ndarray,
+    *,
+    anchor_seconds: float,
+    reference_seconds: float,
+    expected_step_count: int,
+    resume_candidate_seconds: float,
+    candidate_tolerance_seconds: float,
+    candidate_strength_ratios: np.ndarray,
+) -> np.ndarray:
+    candidate_seconds = beat_times[candidate_indices]
+    projected_times: list[float] = []
+    used_candidate_positions: set[int] = set()
+    for step in range(1, expected_step_count + 1):
+        target_seconds = anchor_seconds + reference_seconds * step
+        if step == expected_step_count:
+            projected_times.append(resume_candidate_seconds)
+            continue
+        nearest_position = _nearest_unused_candidate_position(
+            candidate_seconds,
+            candidate_strength_ratios,
+            used_candidate_positions,
+            target_seconds,
+            candidate_tolerance_seconds,
+        )
+        if nearest_position is None:
+            projected_times.append(target_seconds)
+            continue
+        used_candidate_positions.add(nearest_position)
+        projected_times.append(float(candidate_seconds[nearest_position]))
+    return np.asarray(projected_times, dtype=np.float64)
+
+
+def _nearest_unused_candidate_position(
+    candidate_seconds: np.ndarray,
+    candidate_strength_ratios: np.ndarray,
+    used_candidate_positions: set[int],
+    target_seconds: float,
+    tolerance_seconds: float,
+) -> int | None:
+    distances = np.abs(candidate_seconds - target_seconds)
+    for candidate_position in np.argsort(distances).tolist():
+        if candidate_position in used_candidate_positions:
+            continue
+        if (
+            float(candidate_strength_ratios[candidate_position])
+            < SPARSE_BRIDGE_RELOCK_CANDIDATE_STRENGTH_RATIO
+        ):
+            continue
+        if float(distances[candidate_position]) > tolerance_seconds:
+            return None
+        return int(candidate_position)
+    return None
+
+
+def _is_sparse_audio_region(
+    features: HarmonicFeatures,
+    start_seconds: float,
+    end_seconds: float,
+) -> bool:
+    return (
+        _active_frame_coverage(features, start_seconds, end_seconds)
+        <= SPARSE_BRIDGE_ACTIVE_COVERAGE_RATIO
+    )
+
+
+def _active_frame_coverage(
+    features: HarmonicFeatures,
+    start_seconds: float,
+    end_seconds: float,
+) -> float:
+    if end_seconds <= start_seconds:
+        return 1.0
+    frame_count = min(features.times.size, features.active_frame_mask.size)
+    if frame_count == 0:
+        return 1.0
+
+    times = features.times[:frame_count]
+    active_frames = features.active_frame_mask[:frame_count]
+    start_index = int(np.searchsorted(times, start_seconds, side="left"))
+    end_index = int(np.searchsorted(times, end_seconds, side="right"))
+    if end_index <= start_index:
+        return 1.0
+    return float(np.mean(active_frames[start_index:end_index]))
+
+
+def _sparse_bridge_relock_tolerance(reference_seconds: float) -> float:
+    return float(
+        np.clip(
+            reference_seconds * SPARSE_BRIDGE_RELOCK_TOLERANCE_RATIO,
+            SPARSE_BRIDGE_MIN_RELOCK_TOLERANCE_SECONDS,
+            SPARSE_BRIDGE_MAX_RELOCK_TOLERANCE_SECONDS,
+        )
+    )
+
+
+def _sparse_bridge_candidate_tolerance(reference_seconds: float) -> float:
+    return float(
+        np.clip(
+            reference_seconds * SPARSE_BRIDGE_CANDIDATE_TOLERANCE_RATIO,
+            SPARSE_BRIDGE_MIN_CANDIDATE_TOLERANCE_SECONDS,
+            SPARSE_BRIDGE_MAX_CANDIDATE_TOLERANCE_SECONDS,
+        )
+    )
+
+
+def _has_musical_sparse_bridge_candidates(
+    features: HarmonicFeatures,
+    beat_times: np.ndarray,
+    run_start: int,
+    run_end: int,
+    *,
+    reference_seconds: float,
+    context_strength: float,
+) -> bool:
+    if context_strength <= 0.0:
+        return False
+
+    candidate_indices = _sparse_bridge_musical_candidate_indices(
+        features,
+        beat_times,
+        run_start,
+        run_end,
+        reference_seconds,
+        context_strength,
+    )
+    if candidate_indices.size < BEATS_PER_BAR:
+        return False
+
+    candidate_times = beat_times[candidate_indices]
+    if candidate_times.size >= 2:
+        local_interval = float(np.median(np.diff(candidate_times.astype(np.float64))))
+        if local_interval < reference_seconds * BEAT_PHASE_BOOKEND_MIN_RATIO:
+            return False
+
+    strength_ratios = _sparse_bridge_candidate_strength_ratios(
+        features,
+        candidate_times,
+        reference_seconds,
+        context_strength,
+    )
+    strong_candidates = (
+        strength_ratios >= SPARSE_BRIDGE_MUSICAL_CANDIDATE_STRENGTH_RATIO
+    )
+    if _has_supported_sparse_musical_candidate_set(strong_candidates):
+        return True
+
+    strengths = _sparse_bridge_candidate_strengths(
+        features,
+        candidate_times,
+        reference_seconds,
+    )
+    local_strength = _positive_median(strengths)
+    if (
+        local_strength
+        < context_strength * SPARSE_BRIDGE_MUSICAL_MIN_CONTEXT_STRENGTH_RATIO
+    ):
+        return False
+
+    active_candidates = (
+        _sparse_bridge_candidate_active_coverages(
+            features,
+            candidate_times,
+            reference_seconds,
+        )
+        > SPARSE_BRIDGE_ACTIVE_COVERAGE_RATIO
+    )
+    locally_supported_candidates = (
+        (
+            strengths
+            >= context_strength * SPARSE_BRIDGE_MUSICAL_MIN_CONTEXT_STRENGTH_RATIO
+        )
+        & (strengths >= local_strength * SPARSE_BRIDGE_MUSICAL_LOCAL_STRENGTH_RATIO)
+    )
+    return _has_supported_sparse_musical_candidate_set(
+        active_candidates & locally_supported_candidates
+    )
+
+
+def _sparse_bridge_musical_candidate_indices(
+    features: HarmonicFeatures,
+    beat_times: np.ndarray,
+    run_start: int,
+    run_end: int,
+    reference_seconds: float,
+    context_strength: float,
+) -> np.ndarray:
+    candidate_indices = np.arange(run_start + 1, run_end + 2)
+    if candidate_indices.size <= 1:
+        return candidate_indices
+    candidate_times = beat_times[candidate_indices]
+    if _sparse_bridge_endpoint_looks_like_relock(
+        features,
+        candidate_times,
+        reference_seconds,
+        context_strength,
+    ):
+        return candidate_indices[:-1]
+    return candidate_indices
+
+
+def _sparse_bridge_endpoint_looks_like_relock(
+    features: HarmonicFeatures,
+    candidate_times: np.ndarray,
+    reference_seconds: float,
+    context_strength: float,
+) -> bool:
+    if context_strength <= 0.0:
+        return False
+
+    candidate_intervals = np.diff(candidate_times.astype(np.float64))
+    if _sparse_bridge_intervals_are_phrase_like(
+        candidate_intervals,
+        reference_seconds,
+    ):
+        return False
+
+    strengths = _sparse_bridge_candidate_strengths(
+        features,
+        candidate_times,
+        reference_seconds,
+    )
+    previous_strength = _positive_median(strengths[:-1])
+    endpoint_strength = float(strengths[-1])
+    if previous_strength <= 0.0:
+        return False
+
+    previous_is_context_weak = (
+        previous_strength
+        < context_strength * SPARSE_BRIDGE_MUSICAL_CANDIDATE_STRENGTH_RATIO
+    )
+    endpoint_is_context_strong = (
+        endpoint_strength
+        >= context_strength * SPARSE_BRIDGE_MUSICAL_CANDIDATE_STRENGTH_RATIO
+    )
+    endpoint_is_local_jump = (
+        endpoint_strength
+        > previous_strength / SPARSE_BRIDGE_MUSICAL_LOCAL_STRENGTH_RATIO
+    )
+    if not (
+        previous_is_context_weak
+        and endpoint_is_context_strong
+        and endpoint_is_local_jump
+    ):
+        return False
+
+    return True
+
+
+def _sparse_bridge_intervals_are_phrase_like(
+    intervals: np.ndarray,
+    reference_seconds: float,
+) -> bool:
+    if intervals.size == 0:
+        return False
+    if not bool(np.all(np.isfinite(intervals) & (intervals > 0.0))):
+        return False
+    return bool(
+        np.all(intervals >= reference_seconds * BEAT_PHASE_BOOKEND_MIN_RATIO)
+        and np.all(intervals <= reference_seconds * BEAT_PHASE_PAUSE_GAP_RATIO)
+    )
+
+
+def _has_supported_sparse_musical_candidate_set(candidates: np.ndarray) -> bool:
+    return (
+        int(np.count_nonzero(candidates)) >= BEATS_PER_BAR
+        and float(np.mean(candidates)) >= SPARSE_BRIDGE_MIN_MUSICAL_CANDIDATE_FRACTION
+    )
+
+
+def _sparse_bridge_context_beat_strength(
+    features: HarmonicFeatures,
+    beat_times: np.ndarray,
+    anchor_index: int,
+    reference_seconds: float,
+) -> float:
+    start = max(0, anchor_index - SPARSE_BRIDGE_STABLE_CONTEXT_INTERVALS + 1)
+    context_times = beat_times[start : anchor_index + 1]
+    if context_times.size == 0:
+        return 0.0
+    strengths = _sparse_bridge_candidate_strengths(
+        features,
+        context_times,
+        reference_seconds,
+    )
+    strengths = strengths[np.isfinite(strengths) & (strengths > 0.0)]
+    if strengths.size == 0:
+        return 0.0
+    return float(np.median(strengths.astype(np.float64)))
+
+
+def _sparse_bridge_candidate_strength_ratio(
+    features: HarmonicFeatures,
+    candidate_seconds: float,
+    reference_seconds: float,
+    context_strength: float,
+) -> float:
+    return float(
+        _sparse_bridge_candidate_strength_ratios(
+            features,
+            np.asarray([candidate_seconds], dtype=np.float64),
+            reference_seconds,
+            context_strength,
+        )[0]
+    )
+
+
+def _sparse_bridge_candidate_strength_ratios(
+    features: HarmonicFeatures,
+    candidate_times: np.ndarray,
+    reference_seconds: float,
+    context_strength: float,
+) -> np.ndarray:
+    strengths = _sparse_bridge_candidate_strengths(
+        features,
+        candidate_times,
+        reference_seconds,
+    )
+    if context_strength <= 0.0:
+        return np.ones(candidate_times.size, dtype=np.float64)
+    return strengths / context_strength
+
+
+def _sparse_bridge_candidate_active_coverages(
+    features: HarmonicFeatures,
+    candidate_times: np.ndarray,
+    reference_seconds: float,
+) -> np.ndarray:
+    candidate_tolerance_seconds = _sparse_bridge_candidate_tolerance(reference_seconds)
+    return np.asarray(
+        [
+            _active_frame_coverage(
+                features,
+                float(candidate_seconds) - candidate_tolerance_seconds,
+                float(candidate_seconds) + candidate_tolerance_seconds,
+            )
+            for candidate_seconds in candidate_times.tolist()
+        ],
+        dtype=np.float64,
+    )
+
+
+def _sparse_bridge_candidate_strengths(
+    features: HarmonicFeatures,
+    candidate_times: np.ndarray,
+    reference_seconds: float,
+) -> np.ndarray:
+    return np.asarray(
+        [
+            _rms_peak(
+                features,
+                float(candidate_seconds)
+                - _sparse_bridge_candidate_tolerance(reference_seconds),
+                float(candidate_seconds)
+                + _sparse_bridge_candidate_tolerance(reference_seconds),
+            )
+            for candidate_seconds in candidate_times.tolist()
+        ],
+        dtype=np.float64,
+    )
+
+
+def _rms_peak(
+    features: HarmonicFeatures,
+    start_seconds: float,
+    end_seconds: float,
+) -> float:
+    if end_seconds <= start_seconds:
+        return 0.0
+    frame_count = min(features.times.size, features.rms.size)
+    if frame_count == 0:
+        return 0.0
+
+    times = features.times[:frame_count]
+    start_index = int(np.searchsorted(times, start_seconds, side="left"))
+    end_index = int(np.searchsorted(times, end_seconds, side="right"))
+    if end_index <= start_index:
+        return 0.0
+    return float(np.max(features.rms[:frame_count][start_index:end_index]))
+
+
+def _positive_median(values: np.ndarray) -> float:
+    positive_values = values[np.isfinite(values) & (values > 0.0)]
+    if positive_values.size == 0:
+        return 0.0
+    return float(np.median(positive_values.astype(np.float64)))
+
+
+def _same_beat_times(left: np.ndarray, right: np.ndarray) -> bool:
+    return left.size == right.size and bool(
+        np.allclose(left, right, atol=1e-9, rtol=0.0)
+    )
 
 
 def _local_beat_interval_references(intervals: np.ndarray) -> np.ndarray:

--- a/apps/backend/tests/test_audio_analysis_engines.py
+++ b/apps/backend/tests/test_audio_analysis_engines.py
@@ -439,6 +439,421 @@ def test_analysis_keeps_phase_after_short_mid_song_half_beat_burst(monkeypatch):
     assert abs(timing["bars"][2]["start_seconds"] - stable_beat_times[8]) <= 0.035
 
 
+def test_analysis_bridges_sparse_silent_mid_song_gap_without_downbeat_shift(
+    monkeypatch,
+):
+    stable_beat_times = 0.25 + np.arange(24, dtype=np.float64) * 0.5
+    weak_gap_noise_time = 5.38
+    detected_beat_times = np.concatenate(
+        [
+            stable_beat_times[:9],
+            np.asarray([weak_gap_noise_time], dtype=np.float64),
+            stable_beat_times[12:],
+        ]
+    )
+    features = _synthetic_timing_features(
+        detected_beat_times,
+        accent_indices=set(),
+        inactive_ranges=((4.55, 6.05),),
+        weak_indices={9},
+    )
+    chord_timeline = [
+        _synthetic_chord_segment(
+            0.0,
+            features.duration_seconds,
+            label="C",
+            pitch_class=0,
+        )
+    ]
+    _patch_synthetic_analysis(monkeypatch, features, chord_timeline)
+
+    analysis = analyze_track(Path("synthetic_sparse_silent_gap.wav"))
+
+    timing = _assert_detected_sorted_timing(analysis["timing"])
+    bridged_gap_beats = [_beat_near(timing, seconds) for seconds in stable_beat_times[8:13]]
+    assert [beat["beat_in_bar"] for beat in bridged_gap_beats] == [1, 2, 3, 4, 1]
+    assert [beat["bar_index"] for beat in bridged_gap_beats] == [2, 2, 2, 2, 3]
+    assert abs(timing["bars"][2]["start_seconds"] - stable_beat_times[8]) <= 0.035
+    assert abs(timing["bars"][3]["start_seconds"] - stable_beat_times[12]) <= 0.035
+    assert all(
+        abs(beat["seconds"] - weak_gap_noise_time) > 0.08 for beat in timing["beats"]
+    )
+
+
+def test_analysis_bridges_silent_gap_past_weak_transient_cluster(monkeypatch):
+    stable_beat_times = 0.25 + np.arange(28, dtype=np.float64) * 0.5
+    weak_gap_noise_times = np.asarray(
+        [5.34, 5.49, 5.63, 6.04, 6.42],
+        dtype=np.float64,
+    )
+    detected_beat_times = np.concatenate(
+        [
+            stable_beat_times[:9],
+            weak_gap_noise_times,
+            stable_beat_times[14:],
+        ]
+    )
+    weak_indices = set(
+        range(stable_beat_times[:9].size, stable_beat_times[:9].size + 5)
+    )
+    features = _synthetic_timing_features(
+        detected_beat_times,
+        accent_indices=set(),
+        inactive_ranges=((4.55, 7.05),),
+        weak_indices=weak_indices,
+        weak_active_indices=weak_indices,
+    )
+    cluster_mask = (
+        (features.times >= weak_gap_noise_times[0])
+        & (features.times <= weak_gap_noise_times[1])
+    )
+    assert float(np.mean(features.active_frame_mask[cluster_mask])) > (
+        analysis_engine.SPARSE_BRIDGE_ACTIVE_COVERAGE_RATIO
+    )
+    chord_timeline = [
+        _synthetic_chord_segment(
+            0.0,
+            features.duration_seconds,
+            label="C",
+            pitch_class=0,
+        )
+    ]
+    _patch_synthetic_analysis(monkeypatch, features, chord_timeline)
+
+    analysis = analyze_track(Path("synthetic_sparse_silent_gap_cluster.wav"))
+
+    timing = _assert_detected_sorted_timing(analysis["timing"])
+    for seconds in stable_beat_times[8:15]:
+        _beat_near(timing, seconds)
+    assert all(
+        abs(beat["seconds"] - noise_seconds) > 0.06
+        for noise_seconds in weak_gap_noise_times.tolist()
+        for beat in timing["beats"]
+    )
+    assert abs(timing["bars"][3]["start_seconds"] - stable_beat_times[12]) <= 0.035
+
+
+def test_analysis_bridges_silent_gap_with_three_blips_before_loud_resume(
+    monkeypatch,
+):
+    stable_beat_times = 0.25 + np.arange(28, dtype=np.float64) * 0.5
+    weak_gap_noise_times = np.asarray([5.34, 5.49, 5.64], dtype=np.float64)
+    detected_beat_times = np.concatenate(
+        [
+            stable_beat_times[:9],
+            weak_gap_noise_times,
+            stable_beat_times[14:],
+        ]
+    )
+    weak_indices = set(
+        range(stable_beat_times[:9].size, stable_beat_times[:9].size + 3)
+    )
+    features = _synthetic_timing_features(
+        detected_beat_times,
+        accent_indices={stable_beat_times[:9].size + weak_gap_noise_times.size},
+        inactive_ranges=((4.35, 7.05),),
+        weak_indices=weak_indices,
+        weak_active_indices=weak_indices,
+        weak_rms=0.04,
+    )
+    gap_mask = (
+        (features.times >= weak_gap_noise_times[0])
+        & (features.times <= weak_gap_noise_times[-1])
+    )
+    assert float(np.mean(features.active_frame_mask[gap_mask])) > (
+        analysis_engine.SPARSE_BRIDGE_ACTIVE_COVERAGE_RATIO
+    )
+    chord_timeline = [
+        _synthetic_chord_segment(
+            0.0,
+            features.duration_seconds,
+            label="C",
+            pitch_class=0,
+        )
+    ]
+    _patch_synthetic_analysis(monkeypatch, features, chord_timeline)
+
+    analysis = analyze_track(Path("synthetic_sparse_three_blips_loud_resume.wav"))
+
+    timing = _assert_detected_sorted_timing(analysis["timing"])
+    for seconds in stable_beat_times[8:15]:
+        _beat_near(timing, seconds)
+    assert all(
+        abs(beat["seconds"] - noise_seconds) > 0.06
+        for noise_seconds in weak_gap_noise_times.tolist()
+        for beat in timing["beats"]
+    )
+    _beat_near(timing, stable_beat_times[14])
+    assert abs(timing["bars"][3]["start_seconds"] - stable_beat_times[12]) <= 0.035
+
+
+def test_analysis_bridges_silent_gap_with_four_weak_active_blips(monkeypatch):
+    stable_beat_times = 0.25 + np.arange(30, dtype=np.float64) * 0.5
+    weak_gap_noise_times = np.asarray([5.07, 5.50, 5.93, 6.36], dtype=np.float64)
+    detected_beat_times = np.concatenate(
+        [
+            stable_beat_times[:9],
+            weak_gap_noise_times,
+            stable_beat_times[14:],
+        ]
+    )
+    weak_indices = set(
+        range(stable_beat_times[:9].size, stable_beat_times[:9].size + 4)
+    )
+    features = _synthetic_timing_features(
+        detected_beat_times,
+        accent_indices={stable_beat_times[:9].size + weak_gap_noise_times.size},
+        inactive_ranges=((4.35, 7.05),),
+        weak_indices=weak_indices,
+        weak_active_indices=weak_indices,
+        weak_rms=0.04,
+    )
+    context_strength = analysis_engine._sparse_bridge_context_beat_strength(
+        features,
+        features.times[features.beat_frames].astype(np.float64),
+        8,
+        0.5,
+    )
+    weak_strengths = analysis_engine._sparse_bridge_candidate_strengths(
+        features,
+        weak_gap_noise_times,
+        0.5,
+    )
+    weak_strength_ratio = float(np.median(weak_strengths)) / context_strength
+    assert 0.12 < weak_strength_ratio < (
+        analysis_engine.SPARSE_BRIDGE_MUSICAL_MIN_CONTEXT_STRENGTH_RATIO
+    )
+    weak_active_coverages = analysis_engine._sparse_bridge_candidate_active_coverages(
+        features,
+        weak_gap_noise_times,
+        0.5,
+    )
+    assert bool(np.all(weak_active_coverages > analysis_engine.SPARSE_BRIDGE_ACTIVE_COVERAGE_RATIO))
+    chord_timeline = [
+        _synthetic_chord_segment(
+            0.0,
+            features.duration_seconds,
+            label="C",
+            pitch_class=0,
+        )
+    ]
+    _patch_synthetic_analysis(monkeypatch, features, chord_timeline)
+
+    analysis = analyze_track(Path("synthetic_sparse_four_weak_blips.wav"))
+
+    timing = _assert_detected_sorted_timing(analysis["timing"])
+    for seconds in stable_beat_times[8:15]:
+        _beat_near(timing, seconds)
+    assert all(
+        abs(beat["seconds"] - noise_seconds) > 0.06
+        for noise_seconds in weak_gap_noise_times.tolist()
+        for beat in timing["beats"]
+    )
+    _beat_near(timing, stable_beat_times[14])
+    assert abs(timing["bars"][3]["start_seconds"] - stable_beat_times[12]) <= 0.035
+
+
+def test_analysis_preserves_sparse_gap_relock_onset_over_weak_noise(
+    monkeypatch,
+):
+    stable_beat_times = 0.25 + np.arange(9, dtype=np.float64) * 0.5
+    weak_relock_noise_time = 6.24
+    resume_time = 6.33
+    post_resume_times = resume_time + np.arange(1, 12, dtype=np.float64) * 0.5
+    detected_beat_times = np.concatenate(
+        [
+            stable_beat_times,
+            np.asarray([weak_relock_noise_time, resume_time], dtype=np.float64),
+            post_resume_times,
+        ]
+    )
+    features = _synthetic_timing_features(
+        detected_beat_times,
+        accent_indices=set(),
+        inactive_ranges=((4.55, 6.27),),
+        weak_indices={stable_beat_times.size},
+    )
+    weak_to_resume_mask = (
+        (features.times >= weak_relock_noise_time) & (features.times <= resume_time)
+    )
+    weak_to_resume_coverage = float(
+        np.mean(features.active_frame_mask[weak_to_resume_mask])
+    )
+    assert weak_to_resume_coverage > analysis_engine.SPARSE_BRIDGE_ACTIVE_COVERAGE_RATIO
+    chord_timeline = [
+        _synthetic_chord_segment(
+            0.0,
+            features.duration_seconds,
+            label="C",
+            pitch_class=0,
+        )
+    ]
+    _patch_synthetic_analysis(monkeypatch, features, chord_timeline)
+
+    analysis = analyze_track(Path("synthetic_sparse_relock_noise.wav"))
+
+    timing = _assert_detected_sorted_timing(analysis["timing"])
+    for seconds in (4.75, 5.25, 5.75, resume_time):
+        _beat_near(timing, seconds)
+    assert all(
+        abs(beat["seconds"] - weak_relock_noise_time) > 0.04
+        for beat in timing["beats"]
+    )
+
+
+def test_analysis_skips_off_grid_weak_sparse_relock_noise(monkeypatch):
+    stable_beat_times = 0.25 + np.arange(9, dtype=np.float64) * 0.5
+    weak_relock_noise_time = 6.07
+    resume_time = 6.25
+    post_resume_times = resume_time + np.arange(1, 12, dtype=np.float64) * 0.5
+    detected_beat_times = np.concatenate(
+        [
+            stable_beat_times,
+            np.asarray([weak_relock_noise_time, resume_time], dtype=np.float64),
+            post_resume_times,
+        ]
+    )
+    assert abs(weak_relock_noise_time - resume_time) > (
+        analysis_engine.SPARSE_BRIDGE_RELOCK_TOLERANCE_RATIO * 0.5
+    )
+    features = _synthetic_timing_features(
+        detected_beat_times,
+        accent_indices=set(),
+        inactive_ranges=((4.55, 6.10),),
+        weak_indices={stable_beat_times.size},
+    )
+    weak_to_resume_mask = (
+        (features.times >= weak_relock_noise_time) & (features.times <= resume_time)
+    )
+    weak_to_resume_coverage = float(
+        np.mean(features.active_frame_mask[weak_to_resume_mask])
+    )
+    assert weak_to_resume_coverage > analysis_engine.SPARSE_BRIDGE_ACTIVE_COVERAGE_RATIO
+    chord_timeline = [
+        _synthetic_chord_segment(
+            0.0,
+            features.duration_seconds,
+            label="C",
+            pitch_class=0,
+        )
+    ]
+    _patch_synthetic_analysis(monkeypatch, features, chord_timeline)
+
+    analysis = analyze_track(Path("synthetic_sparse_off_grid_relock_noise.wav"))
+
+    timing = _assert_detected_sorted_timing(analysis["timing"])
+    for seconds in (4.75, 5.25, 5.75, resume_time):
+        _beat_near(timing, seconds)
+    assert all(
+        abs(beat["seconds"] - weak_relock_noise_time) > 0.04
+        for beat in timing["beats"]
+    )
+
+
+def test_analysis_skips_off_grid_min_step_noise_before_later_relock(monkeypatch):
+    stable_beat_times = 0.25 + np.arange(9, dtype=np.float64) * 0.5
+    weak_relock_noise_time = 6.05
+    resume_time = 6.75
+    post_resume_times = resume_time + np.arange(1, 12, dtype=np.float64) * 0.5
+    detected_beat_times = np.concatenate(
+        [
+            stable_beat_times,
+            np.asarray([weak_relock_noise_time, resume_time], dtype=np.float64),
+            post_resume_times,
+        ]
+    )
+    weak_step_count = int(
+        round((weak_relock_noise_time - stable_beat_times[-1]) / 0.5)
+    )
+    resume_step_count = int(round((resume_time - stable_beat_times[-1]) / 0.5))
+    assert weak_step_count == analysis_engine.SPARSE_BRIDGE_MIN_GRID_STEPS
+    assert resume_step_count == analysis_engine.SPARSE_BRIDGE_MIN_GRID_STEPS + 1
+    features = _synthetic_timing_features(
+        detected_beat_times,
+        accent_indices=set(),
+        inactive_ranges=((4.55, 6.13),),
+        weak_indices={stable_beat_times.size},
+    )
+    weak_to_resume_mask = (
+        (features.times >= weak_relock_noise_time) & (features.times <= resume_time)
+    )
+    weak_to_resume_coverage = float(
+        np.mean(features.active_frame_mask[weak_to_resume_mask])
+    )
+    assert weak_to_resume_coverage > analysis_engine.SPARSE_BRIDGE_ACTIVE_COVERAGE_RATIO
+    chord_timeline = [
+        _synthetic_chord_segment(
+            0.0,
+            features.duration_seconds,
+            label="C",
+            pitch_class=0,
+        )
+    ]
+    _patch_synthetic_analysis(monkeypatch, features, chord_timeline)
+
+    analysis = analyze_track(Path("synthetic_sparse_later_relock.wav"))
+
+    timing = _assert_detected_sorted_timing(analysis["timing"])
+    for seconds in (4.75, 5.25, 5.75, 6.25, resume_time):
+        _beat_near(timing, seconds)
+    assert all(
+        abs(beat["seconds"] - weak_relock_noise_time) > 0.04
+        for beat in timing["beats"]
+    )
+
+
+def test_analysis_skips_too_early_weak_sparse_relock_noise(monkeypatch):
+    stable_beat_times = 0.25 + np.arange(9, dtype=np.float64) * 0.5
+    weak_relock_noise_time = 5.90
+    resume_time = 6.25
+    post_resume_times = resume_time + np.arange(1, 12, dtype=np.float64) * 0.5
+    detected_beat_times = np.concatenate(
+        [
+            stable_beat_times,
+            np.asarray([weak_relock_noise_time, resume_time], dtype=np.float64),
+            post_resume_times,
+        ]
+    )
+    weak_step_count = int(
+        round((weak_relock_noise_time - stable_beat_times[-1]) / 0.5)
+    )
+    resume_step_count = int(round((resume_time - stable_beat_times[-1]) / 0.5))
+    assert weak_step_count < analysis_engine.SPARSE_BRIDGE_MIN_GRID_STEPS
+    assert resume_step_count == analysis_engine.SPARSE_BRIDGE_MIN_GRID_STEPS
+    features = _synthetic_timing_features(
+        detected_beat_times,
+        accent_indices=set(),
+        inactive_ranges=((4.55, 5.93),),
+        weak_indices={stable_beat_times.size},
+    )
+    weak_to_resume_mask = (
+        (features.times >= weak_relock_noise_time) & (features.times <= resume_time)
+    )
+    weak_to_resume_coverage = float(
+        np.mean(features.active_frame_mask[weak_to_resume_mask])
+    )
+    assert weak_to_resume_coverage > analysis_engine.SPARSE_BRIDGE_ACTIVE_COVERAGE_RATIO
+    chord_timeline = [
+        _synthetic_chord_segment(
+            0.0,
+            features.duration_seconds,
+            label="C",
+            pitch_class=0,
+        )
+    ]
+    _patch_synthetic_analysis(monkeypatch, features, chord_timeline)
+
+    analysis = analyze_track(Path("synthetic_sparse_too_early_relock_noise.wav"))
+
+    timing = _assert_detected_sorted_timing(analysis["timing"])
+    for seconds in (4.75, 5.25, 5.75, resume_time):
+        _beat_near(timing, seconds)
+    assert all(
+        abs(beat["seconds"] - weak_relock_noise_time) > 0.04
+        for beat in timing["beats"]
+    )
+
+
 def test_analysis_recovers_early_fast_start_burst_without_shifting_downbeat_offset(
     monkeypatch,
 ):
@@ -501,6 +916,298 @@ def test_analysis_preserves_sustained_local_tempo_change(monkeypatch):
     local_tempo_beats = [_beat_near(timing, seconds) for seconds in beat_times[8:12]]
     assert [beat["beat_in_bar"] for beat in local_tempo_beats] == [1, 2, 3, 4]
     assert max(np.diff([beat["seconds"] for beat in local_tempo_beats])) < 0.35
+
+
+def test_analysis_preserves_active_slow_tempo_phrase_when_gap_bridge_enabled(
+    monkeypatch,
+):
+    slow_interval_seconds = 0.625
+    slow_phrase_times = 4.375 + np.arange(8, dtype=np.float64) * slow_interval_seconds
+    beat_times = np.concatenate(
+        [
+            0.25 + np.arange(8, dtype=np.float64) * 0.5,
+            slow_phrase_times,
+            9.25 + np.arange(8, dtype=np.float64) * 0.5,
+        ]
+    )
+    active_edge_seconds = 0.08
+    sparse_phrase_inactive_ranges = tuple(
+        (
+            float(beat_times[index] + active_edge_seconds),
+            float(beat_times[index + 1] - active_edge_seconds),
+        )
+        for index in range(7, 15)
+    )
+    features = _synthetic_timing_features(
+        beat_times,
+        accent_indices=set(),
+        inactive_ranges=sparse_phrase_inactive_ranges,
+    )
+    phrase_mask = (features.times >= beat_times[7]) & (features.times <= beat_times[15])
+    phrase_coverage = float(np.mean(features.active_frame_mask[phrase_mask]))
+    assert 0.18 < phrase_coverage <= 0.35
+    chord_timeline = [
+        _synthetic_chord_segment(
+            0.0,
+            features.duration_seconds,
+            label="C",
+            pitch_class=0,
+        )
+    ]
+    _patch_synthetic_analysis(monkeypatch, features, chord_timeline)
+
+    analysis = analyze_track(Path("synthetic_active_slow_tempo_phrase.wav"))
+
+    timing = _assert_detected_sorted_timing(analysis["timing"])
+    assert len(timing["beats"]) == beat_times.size
+    slow_tempo_beats = [_beat_near(timing, seconds) for seconds in beat_times[8:16]]
+    assert [beat["beat_in_bar"] for beat in slow_tempo_beats] == [
+        1,
+        2,
+        3,
+        4,
+        1,
+        2,
+        3,
+        4,
+    ]
+    slow_tempo_intervals = np.diff([beat["seconds"] for beat in slow_tempo_beats])
+    assert min(slow_tempo_intervals) >= 0.60
+    assert max(slow_tempo_intervals) <= 0.65
+
+
+def test_analysis_preserves_sparse_active_musical_phrase_with_rubato(monkeypatch):
+    sparse_phrase_times = np.asarray(
+        [4.31, 4.94, 5.46, 6.19, 6.76, 7.51, 8.04, 8.68],
+        dtype=np.float64,
+    )
+    beat_times = np.concatenate(
+        [
+            0.25 + np.arange(8, dtype=np.float64) * 0.5,
+            sparse_phrase_times,
+            9.25 + np.arange(8, dtype=np.float64) * 0.5,
+        ]
+    )
+    active_edge_seconds = 0.08
+    sparse_phrase_inactive_ranges = tuple(
+        (
+            float(beat_times[index] + active_edge_seconds),
+            float(beat_times[index + 1] - active_edge_seconds),
+        )
+        for index in range(7, 15)
+    )
+    features = _synthetic_timing_features(
+        beat_times,
+        accent_indices=set(),
+        inactive_ranges=sparse_phrase_inactive_ranges,
+    )
+    phrase_mask = (features.times >= beat_times[7]) & (features.times <= beat_times[15])
+    phrase_coverage = float(np.mean(features.active_frame_mask[phrase_mask]))
+    assert phrase_coverage <= analysis_engine.SPARSE_BRIDGE_ACTIVE_COVERAGE_RATIO
+    chord_timeline = [
+        _synthetic_chord_segment(
+            0.0,
+            features.duration_seconds,
+            label="C",
+            pitch_class=0,
+        )
+    ]
+    _patch_synthetic_analysis(monkeypatch, features, chord_timeline)
+
+    analysis = analyze_track(Path("synthetic_sparse_active_rubato_phrase.wav"))
+
+    timing = _assert_detected_sorted_timing(analysis["timing"])
+    assert len(timing["beats"]) == beat_times.size
+    for seconds in sparse_phrase_times.tolist():
+        _beat_near(timing, seconds)
+    phrase_intervals = np.diff(
+        [_beat_near(timing, seconds)["seconds"] for seconds in sparse_phrase_times]
+    )
+    assert max(phrase_intervals) - min(phrase_intervals) > 0.15
+
+
+def test_analysis_preserves_one_bar_sparse_phrase_when_endpoint_is_phrase_beat(
+    monkeypatch,
+):
+    sparse_phrase_times = np.asarray([4.31, 4.94, 5.46, 6.19], dtype=np.float64)
+    beat_times = np.concatenate(
+        [
+            0.25 + np.arange(8, dtype=np.float64) * 0.5,
+            sparse_phrase_times,
+            6.75 + np.arange(8, dtype=np.float64) * 0.5,
+        ]
+    )
+    active_edge_seconds = 0.08
+    sparse_phrase_inactive_ranges = tuple(
+        (
+            float(beat_times[index] + active_edge_seconds),
+            float(beat_times[index + 1] - active_edge_seconds),
+        )
+        for index in range(7, 11)
+    )
+    features = _synthetic_timing_features(
+        beat_times,
+        accent_indices=set(),
+        inactive_ranges=sparse_phrase_inactive_ranges,
+    )
+    phrase_mask = (features.times >= beat_times[7]) & (features.times <= beat_times[11])
+    assert float(np.mean(features.active_frame_mask[phrase_mask])) <= (
+        analysis_engine.SPARSE_BRIDGE_ACTIVE_COVERAGE_RATIO
+    )
+    chord_timeline = [
+        _synthetic_chord_segment(
+            0.0,
+            features.duration_seconds,
+            label="C",
+            pitch_class=0,
+        )
+    ]
+    _patch_synthetic_analysis(monkeypatch, features, chord_timeline)
+
+    analysis = analyze_track(Path("synthetic_one_bar_sparse_active_phrase.wav"))
+
+    timing = _assert_detected_sorted_timing(analysis["timing"])
+    assert len(timing["beats"]) == beat_times.size
+    for seconds in sparse_phrase_times.tolist():
+        _beat_near(timing, seconds)
+    phrase_intervals = np.diff(
+        [_beat_near(timing, seconds)["seconds"] for seconds in sparse_phrase_times]
+    )
+    assert max(phrase_intervals) - min(phrase_intervals) > 0.15
+
+
+def test_analysis_preserves_one_bar_sparse_phrase_with_accented_endpoint(
+    monkeypatch,
+):
+    sparse_phrase_times = np.asarray([4.31, 4.94, 5.46, 6.02], dtype=np.float64)
+    beat_times = np.concatenate(
+        [
+            0.25 + np.arange(8, dtype=np.float64) * 0.5,
+            sparse_phrase_times,
+            6.75 + np.arange(8, dtype=np.float64) * 0.5,
+        ]
+    )
+    accented_endpoint_index = 11
+    loud_indices = set(range(8)) | {accented_endpoint_index}
+    active_edge_seconds = 0.08
+    sparse_phrase_inactive_ranges = tuple(
+        (
+            float(beat_times[index] + active_edge_seconds),
+            float(beat_times[index + 1] - active_edge_seconds),
+        )
+        for index in range(7, 11)
+    )
+    features = _synthetic_timing_features(
+        beat_times,
+        accent_indices=loud_indices,
+        inactive_ranges=sparse_phrase_inactive_ranges,
+    )
+    context_strength = analysis_engine._sparse_bridge_context_beat_strength(
+        features,
+        beat_times,
+        7,
+        0.5,
+    )
+    phrase_strengths = analysis_engine._sparse_bridge_candidate_strengths(
+        features,
+        sparse_phrase_times,
+        0.5,
+    )
+    assert float(np.median(phrase_strengths[:-1])) < (
+        context_strength * analysis_engine.SPARSE_BRIDGE_MUSICAL_CANDIDATE_STRENGTH_RATIO
+    )
+    assert phrase_strengths[-1] >= (
+        context_strength * analysis_engine.SPARSE_BRIDGE_MUSICAL_CANDIDATE_STRENGTH_RATIO
+    )
+    chord_timeline = [
+        _synthetic_chord_segment(
+            0.0,
+            features.duration_seconds,
+            label="C",
+            pitch_class=0,
+        )
+    ]
+    _patch_synthetic_analysis(monkeypatch, features, chord_timeline)
+
+    analysis = analyze_track(Path("synthetic_one_bar_sparse_accented_endpoint.wav"))
+
+    timing = _assert_detected_sorted_timing(analysis["timing"])
+    assert len(timing["beats"]) == beat_times.size
+    for seconds in sparse_phrase_times.tolist():
+        _beat_near(timing, seconds)
+    phrase_intervals = np.diff(
+        [_beat_near(timing, seconds)["seconds"] for seconds in sparse_phrase_times]
+    )
+    assert max(phrase_intervals) - min(phrase_intervals) > 0.08
+
+
+def test_analysis_preserves_quiet_sparse_musical_phrase_after_loud_context(
+    monkeypatch,
+):
+    sparse_phrase_times = np.asarray(
+        [4.31, 4.94, 5.46, 6.19, 6.76, 7.51, 8.04, 8.68],
+        dtype=np.float64,
+    )
+    loud_resume_times = 9.25 + np.arange(8, dtype=np.float64) * 0.5
+    beat_times = np.concatenate(
+        [
+            0.25 + np.arange(8, dtype=np.float64) * 0.5,
+            sparse_phrase_times,
+            loud_resume_times,
+        ]
+    )
+    loud_indices = set(range(8)) | set(range(16, beat_times.size))
+    active_edge_seconds = 0.08
+    sparse_phrase_inactive_ranges = tuple(
+        (
+            float(beat_times[index] + active_edge_seconds),
+            float(beat_times[index + 1] - active_edge_seconds),
+        )
+        for index in range(7, 15)
+    )
+    features = _synthetic_timing_features(
+        beat_times,
+        accent_indices=loud_indices,
+        inactive_ranges=sparse_phrase_inactive_ranges,
+    )
+    context_strength = analysis_engine._sparse_bridge_context_beat_strength(
+        features,
+        beat_times,
+        7,
+        0.5,
+    )
+    phrase_strengths = analysis_engine._sparse_bridge_candidate_strengths(
+        features,
+        sparse_phrase_times,
+        0.5,
+    )
+    assert float(np.median(phrase_strengths)) < (
+        context_strength * analysis_engine.SPARSE_BRIDGE_MUSICAL_CANDIDATE_STRENGTH_RATIO
+    )
+    phrase_mask = (features.times >= beat_times[7]) & (features.times <= beat_times[15])
+    assert float(np.mean(features.active_frame_mask[phrase_mask])) <= (
+        analysis_engine.SPARSE_BRIDGE_ACTIVE_COVERAGE_RATIO
+    )
+    chord_timeline = [
+        _synthetic_chord_segment(
+            0.0,
+            features.duration_seconds,
+            label="C",
+            pitch_class=0,
+        )
+    ]
+    _patch_synthetic_analysis(monkeypatch, features, chord_timeline)
+
+    analysis = analyze_track(Path("synthetic_quiet_sparse_active_rubato_phrase.wav"))
+
+    timing = _assert_detected_sorted_timing(analysis["timing"])
+    assert len(timing["beats"]) == beat_times.size
+    for seconds in sparse_phrase_times.tolist():
+        _beat_near(timing, seconds)
+    phrase_intervals = np.diff(
+        [_beat_near(timing, seconds)["seconds"] for seconds in sparse_phrase_times]
+    )
+    assert max(phrase_intervals) - min(phrase_intervals) > 0.15
 
 
 def test_analysis_preserves_one_bar_double_time_phrase(monkeypatch):
@@ -700,7 +1407,13 @@ def _synthetic_timing_features(
     beat_times: np.ndarray,
     *,
     accent_indices: set[int],
+    inactive_ranges: tuple[tuple[float, float], ...] = (),
+    weak_indices: set[int] | None = None,
+    weak_active_indices: set[int] | None = None,
+    weak_rms: float = 0.01,
 ) -> HarmonicFeatures:
+    weak_indices = set() if weak_indices is None else weak_indices
+    weak_active_indices = set() if weak_active_indices is None else weak_active_indices
     duration_seconds = float(beat_times[-1] + 0.6)
     frame_seconds = ANALYSIS_HOP_LENGTH / ANALYSIS_SAMPLE_RATE
     frame_count = int(np.ceil(duration_seconds / frame_seconds)) + 1
@@ -713,7 +1426,21 @@ def _synthetic_timing_features(
     for index, beat_frame in enumerate(beat_frames.tolist()):
         start_frame = max(0, beat_frame - 1)
         end_frame = min(frame_count, beat_frame + 2)
-        rms[start_frame:end_frame] = 0.85 if index in accent_indices else 0.28
+        if index in weak_indices:
+            rms[start_frame:end_frame] = weak_rms
+        else:
+            rms[start_frame:end_frame] = 0.85 if index in accent_indices else 0.28
+    active_frame_mask = np.ones(frame_count, dtype=bool)
+    for start_seconds, end_seconds in inactive_ranges:
+        inactive = (times >= start_seconds) & (times <= end_seconds)
+        rms[inactive] = 0.001
+        active_frame_mask[inactive] = False
+    for index in weak_active_indices:
+        beat_frame = int(beat_frames[index])
+        start_frame = max(0, beat_frame - 1)
+        end_frame = min(frame_count, beat_frame + 2)
+        rms[start_frame:end_frame] = weak_rms
+        active_frame_mask[start_frame:end_frame] = True
 
     timeline = np.linspace(
         0.0,
@@ -724,8 +1451,14 @@ def _synthetic_timing_features(
     accent_times = (
         beat_times[sorted(accent_indices)] if accent_indices else np.zeros(0, dtype=np.float64)
     )
+    weak_times = beat_times[sorted(weak_indices)] if weak_indices else np.zeros(0, dtype=np.float64)
+    strong_indices = [
+        index for index in range(beat_times.size) if index not in weak_indices
+    ]
+    strong_times = beat_times[strong_indices]
     percussive_signal = (
-        _pulse_train_at_times(timeline, beat_times, amplitude=0.18)
+        _pulse_train_at_times(timeline, strong_times, amplitude=0.18)
+        + _pulse_train_at_times(timeline, weak_times, amplitude=0.02)
         + _pulse_train_at_times(timeline, accent_times, amplitude=0.48)
     ).astype(np.float32)
     chroma = np.zeros((12, frame_count), dtype=np.float32)
@@ -741,7 +1474,7 @@ def _synthetic_timing_features(
         chroma_cens=chroma,
         rms=rms,
         times=times,
-        active_frame_mask=np.ones(frame_count, dtype=bool),
+        active_frame_mask=active_frame_mask,
         beat_frames=beat_frames,
         tempo_bpm=120.0,
         estimated_reference_hz=None,


### PR DESCRIPTION
## Summary

- Bridge sparse or silent timing-grid gaps by projecting stable local tempo through pauses.
- Preserve sparse musical/rubato timing with active RMS evidence instead of flattening quiet phrases.
- Add synthetic coverage for weak silence blips, relock behavior, and sparse musical phrases.

Closes #191

## Testing

- `cd apps/backend && uv --cache-dir /private/tmp/uv-cache run --python 3.11 pytest tests/test_audio_analysis_engines.py -q`
- `cd apps/backend && uv --cache-dir /private/tmp/uv-cache run --python 3.11 pytest tests/test_analysis_flow.py tests/test_pagination_contract.py -q`
- `cd apps/backend && uv --cache-dir /private/tmp/uv-cache run --python 3.11 ruff check app/engines/analysis.py tests/test_audio_analysis_engines.py`
- `cd apps/backend && uv --cache-dir /private/tmp/uv-cache run --python 3.11 mypy app`
- `git diff --check`
