### PR TITLE
fix: Interrupt running jobs

### DIFF
--- a/apps/backend/app/engines/lyrics.py
+++ b/apps/backend/app/engines/lyrics.py
@@ -1,15 +1,21 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
+import subprocess
+import sys
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
 from fastapi import status
 
-from app.errors import AppError
+from app.errors import AppError, JobCancelledError
 from app.utils.torch_runtime import choose_torch_device, with_mps_fallback_env
+
+LYRICS_WORKER_CANCEL_TIMEOUT_SECONDS = 2.0
 
 
 @dataclass(frozen=True)
@@ -20,6 +26,29 @@ class LyricsTranscription:
     model: str
     language: str | None
     segments: list[dict[str, Any]]
+
+
+def lyrics_transcription_to_payload(transcription: LyricsTranscription) -> dict[str, Any]:
+    return {
+        "backend": transcription.backend,
+        "requested_device": transcription.requested_device,
+        "device": transcription.device,
+        "model": transcription.model,
+        "language": transcription.language,
+        "segments": transcription.segments,
+    }
+
+
+def lyrics_transcription_from_payload(payload: dict[str, Any]) -> LyricsTranscription:
+    language = payload.get("language")
+    return LyricsTranscription(
+        backend=str(payload.get("backend", "openai-whisper")),
+        requested_device=str(payload.get("requested_device", "auto")),
+        device=str(payload.get("device", "cpu")),
+        model=str(payload.get("model", "")),
+        language=language if isinstance(language, str) else None,
+        segments=cast(list[dict[str, Any]], payload.get("segments", [])),
+    )
 
 
 def _require_dependency(module_name: str, message: str) -> None:
@@ -179,7 +208,7 @@ def _transcribe_with_device(
     )
 
 
-def transcribe_project_lyrics(
+def transcribe_project_lyrics_in_process(
     source_path: Path,
     *,
     model_name: str,
@@ -224,3 +253,126 @@ def transcribe_project_lyrics(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         details={"errors": errors},
     )
+
+
+def _worker_payload_from_stdout(stdout: str) -> dict[str, Any] | None:
+    for line in reversed(stdout.splitlines()):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            payload = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            return payload
+    return None
+
+
+def _terminate_cancelled_worker(process: subprocess.Popen[str]) -> None:
+    process.terminate()
+    try:
+        process.wait(timeout=LYRICS_WORKER_CANCEL_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        try:
+            process.wait(timeout=LYRICS_WORKER_CANCEL_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            pass
+
+
+def _raise_worker_failure(
+    payload: dict[str, Any] | None,
+    *,
+    stdout: str,
+    stderr: str,
+) -> None:
+    error = payload.get("error") if payload else None
+    if isinstance(error, dict):
+        code = str(error.get("code", "PROCESSING_FAILED"))
+        message = str(error.get("message", "Lyrics generation failed."))
+        status_code = error.get("status_code")
+        details = error.get("details")
+        raise AppError(
+            code,
+            message,
+            status_code=status_code if isinstance(status_code, int) else status.HTTP_500_INTERNAL_SERVER_ERROR,
+            details=details if isinstance(details, dict) else {},
+        )
+
+    raise AppError(
+        "PROCESSING_FAILED",
+        "Lyrics generation failed.",
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        details={"stdout": stdout.strip(), "stderr": stderr.strip()},
+    )
+
+
+def transcribe_project_lyrics(
+    source_path: Path,
+    *,
+    model_name: str,
+    requested_device: str,
+    download_root: Path,
+    should_cancel: Callable[[], bool] | None = None,
+    register_process: Callable[[subprocess.Popen[str]], None] | None = None,
+    unregister_process: Callable[[], None] | None = None,
+) -> LyricsTranscription:
+    if should_cancel and should_cancel():
+        raise JobCancelledError()
+
+    command = [
+        sys.executable,
+        "-m",
+        "app.engines.lyrics_worker",
+        "--source",
+        str(source_path),
+        "--model",
+        model_name,
+        "--requested-device",
+        requested_device,
+        "--download-root",
+        str(download_root),
+    ]
+    process = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=with_mps_fallback_env(os.environ),
+    )
+    if register_process:
+        register_process(process)
+
+    try:
+        while process.poll() is None:
+            if should_cancel and should_cancel():
+                _terminate_cancelled_worker(process)
+                raise JobCancelledError()
+            try:
+                process.wait(timeout=0.25)
+            except subprocess.TimeoutExpired:
+                pass
+
+        stdout, stderr = process.communicate()
+        if should_cancel and should_cancel():
+            raise JobCancelledError()
+
+        payload = _worker_payload_from_stdout(stdout)
+        if process.returncode != 0:
+            _raise_worker_failure(payload, stdout=stdout, stderr=stderr)
+
+        transcription_payload = payload.get("transcription") if payload else None
+        if not isinstance(transcription_payload, dict):
+            raise AppError(
+                "PROCESSING_FAILED",
+                "Lyrics generation failed.",
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                details={"stdout": stdout.strip(), "stderr": stderr.strip()},
+            )
+        return lyrics_transcription_from_payload(transcription_payload)
+    finally:
+        if unregister_process:
+            unregister_process()
+        if process.poll() is None:
+            process.kill()

--- a/apps/backend/app/engines/lyrics_worker.py
+++ b/apps/backend/app/engines/lyrics_worker.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from app.engines.lyrics import (
+    lyrics_transcription_to_payload,
+    transcribe_project_lyrics_in_process,
+)
+from app.errors import AppError
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Transcribe lyrics with Whisper.")
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--requested-device", required=True)
+    parser.add_argument("--download-root", required=True)
+    return parser.parse_args()
+
+
+def _print_payload(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload), flush=True)
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        transcription = transcribe_project_lyrics_in_process(
+            Path(args.source),
+            model_name=args.model,
+            requested_device=args.requested_device,
+            download_root=Path(args.download_root),
+        )
+        _print_payload(
+            {
+                "ok": True,
+                "transcription": lyrics_transcription_to_payload(transcription),
+            }
+        )
+    except AppError as exc:
+        _print_payload(
+            {
+                "ok": False,
+                "error": {
+                    "code": exc.code,
+                    "message": exc.message,
+                    "status_code": exc.status_code,
+                    "details": exc.details,
+                },
+            }
+        )
+        raise SystemExit(1) from exc
+    except Exception as exc:
+        _print_payload(
+            {
+                "ok": False,
+                "error": {
+                    "code": "PROCESSING_FAILED",
+                    "message": "Lyrics generation failed.",
+                    "status_code": 500,
+                    "details": {"message": str(exc)},
+                },
+            }
+        )
+        raise SystemExit(1) from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/backend/app/engines/stems.py
+++ b/apps/backend/app/engines/stems.py
@@ -167,6 +167,8 @@ def _run_demucs_worker(
                 unregister_process()
 
         if process.returncode != 0:
+            if should_cancel and should_cancel():
+                raise JobCancelledError()
             raise AppError(
                 "PROCESSING_FAILED",
                 "Demucs failed to separate the track.",

--- a/apps/backend/app/services/jobs.py
+++ b/apps/backend/app/services/jobs.py
@@ -5,7 +5,7 @@ import threading
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from subprocess import Popen
+from subprocess import Popen, TimeoutExpired
 from typing import Any, Literal, cast
 
 from sqlalchemy import case, func, select
@@ -53,6 +53,7 @@ ProjectActivityJobPayload = AnalysisRequest | ChordRequest | LyricsGenerateReque
 _ACTIVE_JOB_STATUSES = ("pending", "running")
 _BULK_ACTIVITY_JOB_TYPES = frozenset({"analyze", "chords", "lyrics", "stems"})
 _TERMINAL_JOB_STATUSES = ("completed", "cancelled", "failed")
+_PROCESS_TERMINATION_GRACE_SECONDS = 1.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -544,10 +545,7 @@ class InProcessJobRunner:
                 job.progress = 0
                 job.completed_at = utcnow()
             session.commit()
-            with self._lock:
-                process = self._active_processes.get(job_id)
-                if process and process.poll() is None:
-                    process.terminate()
+            self._terminate_registered_process(job_id)
             session.refresh(job)
             return job
 
@@ -592,6 +590,22 @@ class InProcessJobRunner:
         with self._lock:
             self._active_processes.pop(job_id, None)
 
+    def _terminate_registered_process(self, job_id: str) -> None:
+        with self._lock:
+            process = self._active_processes.get(job_id)
+        if process is None or process.poll() is not None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=_PROCESS_TERMINATION_GRACE_SECONDS)
+        except TimeoutExpired:
+            if process.poll() is None:
+                process.kill()
+            try:
+                process.wait(timeout=_PROCESS_TERMINATION_GRACE_SECONDS)
+            except TimeoutExpired:
+                pass
+
     def _worker(self) -> None:
         while not self._stop_event.is_set():
             job_id = self._queue.get()
@@ -633,6 +647,7 @@ class InProcessJobRunner:
                     raise AppError("PROCESSING_FAILED", f"Unsupported job type: {job.type}")
                 if job.project_id is not None:
                     get_mutable_project(session, job.project_id)
+                context.ensure_not_cancelled()
                 result = handler(context, session, job)
                 job.status = "completed"
                 job.progress = 100
@@ -643,9 +658,15 @@ class InProcessJobRunner:
         except JobCancelledError:
             self.update_job(job_id, status="cancelled", error_message=None)
         except AppError as exc:
-            self.update_job(job_id, status="failed", error_message=exc.message)
+            if self.is_cancel_requested(job_id):
+                self.update_job(job_id, status="cancelled", error_message=None)
+            else:
+                self.update_job(job_id, status="failed", error_message=exc.message)
         except Exception as exc:  # pragma: no cover - defensive fallback
-            self.update_job(job_id, status="failed", error_message=str(exc))
+            if self.is_cancel_requested(job_id):
+                self.update_job(job_id, status="cancelled", error_message=None)
+            else:
+                self.update_job(job_id, status="failed", error_message=str(exc))
 
     def _handle_analyze(self, context: JobExecutionContext, session: Session, job: Job) -> JobExecutionResult:
         project = get_project(session, job.project_id or "")
@@ -710,7 +731,14 @@ class InProcessJobRunner:
     def _handle_lyrics(self, context: JobExecutionContext, session: Session, job: Job) -> JobExecutionResult:
         project = get_project(session, job.project_id or "")
         context.set_progress(15)
-        lyrics = generate_project_lyrics(session, project=project, force=bool(job.payload_json.get("force", False)))
+        lyrics = generate_project_lyrics(
+            session,
+            project=project,
+            force=bool(job.payload_json.get("force", False)),
+            should_cancel=context.should_cancel,
+            register_process=context.register_process,
+            unregister_process=context.unregister_process,
+        )
         context.set_progress(90)
         return JobExecutionResult(artifact_ids=[], runtime_device=lyrics.device)
 

--- a/apps/backend/app/services/lyrics.py
+++ b/apps/backend/app/services/lyrics.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Callable
 from copy import deepcopy
 from difflib import SequenceMatcher
 from pathlib import Path
+from subprocess import Popen
 from typing import Any, cast
 
 from fastapi import status
@@ -12,7 +14,7 @@ from sqlalchemy.orm import Session
 
 from app.config import get_settings
 from app.engines.lyrics import transcribe_project_lyrics
-from app.errors import AppError
+from app.errors import AppError, JobCancelledError
 from app.models import Artifact, LyricsTranscript, Project
 from app.schemas import LyricsEditSegmentSchema
 from app.services.paths import project_analysis_dir
@@ -20,6 +22,11 @@ from app.services.sync_revisions import record_lyrics_revision
 from app.services.tab_state import clear_project_tab_state
 
 WORD_RE = re.compile(r"\S+")
+
+
+def _ensure_not_cancelled(should_cancel: Callable[[], bool] | None) -> None:
+    if should_cancel and should_cancel():
+        raise JobCancelledError()
 
 
 def _source_artifact(project: Project) -> Artifact | None:
@@ -52,7 +59,16 @@ def _write_lyrics_snapshot(
     lyrics_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
 
-def generate_project_lyrics(session: Session, *, project: Project, force: bool = False) -> LyricsTranscript:
+def generate_project_lyrics(
+    session: Session,
+    *,
+    project: Project,
+    force: bool = False,
+    should_cancel: Callable[[], bool] | None = None,
+    register_process: Callable[[Popen[str]], None] | None = None,
+    unregister_process: Callable[[], None] | None = None,
+) -> LyricsTranscript:
+    _ensure_not_cancelled(should_cancel)
     existing = session.get(LyricsTranscript, project.id)
     if existing is not None and existing.segments_json and not force:
         return existing
@@ -62,11 +78,16 @@ def generate_project_lyrics(session: Session, *, project: Project, force: bool =
         model_name=get_settings().lyrics_model,
         requested_device=get_settings().lyrics_device,
         download_root=get_settings().lyrics_cache_dir,
+        should_cancel=should_cancel,
+        register_process=register_process,
+        unregister_process=unregister_process,
     )
     source_artifact = _source_artifact(project)
+    _ensure_not_cancelled(should_cancel)
     if force:
         clear_project_tab_state(session, project_id=project.id)
 
+    _ensure_not_cancelled(should_cancel)
     if existing is None:
         existing = LyricsTranscript(project_id=project.id)
         session.add(existing)
@@ -83,8 +104,10 @@ def generate_project_lyrics(session: Session, *, project: Project, force: bool =
     existing.has_user_edits = False
     session.flush()
     session.refresh(existing)
+    _ensure_not_cancelled(should_cancel)
     record_lyrics_revision(session, lyrics=existing, revision_type="generated")
 
+    _ensure_not_cancelled(should_cancel)
     _write_lyrics_snapshot(project_id=project.id, lyrics=existing)
     return existing
 

--- a/apps/backend/app/services/stems.py
+++ b/apps/backend/app/services/stems.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Session
 
 from app.config import get_settings
 from app.engines.stems import separate_sources, separate_two_stems
-from app.errors import AppError
+from app.errors import AppError, JobCancelledError
 from app.models import Artifact, Project
 from app.services.artifacts import refresh_artifact_file_metadata, register_artifact
 from app.services.paths import project_stems_dir
@@ -279,6 +279,16 @@ def _replace_stem_outputs(temp_plan: list[StemOutputPlan], final_plan: list[Stem
         temp_output.path.replace(final_output.path)
 
 
+def _ensure_not_cancelled(should_cancel: Callable[[], bool] | None) -> None:
+    if should_cancel and should_cancel():
+        raise JobCancelledError()
+
+
+def _cleanup_stem_outputs(plan: list[StemOutputPlan]) -> None:
+    for output in plan:
+        _cleanup_artifact_path(output.path)
+
+
 def generate_stems(
     session: Session,
     *,
@@ -331,7 +341,13 @@ def generate_stems(
             register_process=register_process,
             unregister_process=unregister_process,
         )
+        _ensure_not_cancelled(should_cancel)
         _replace_stem_outputs(temp_plan, plan)
+        try:
+            _ensure_not_cancelled(should_cancel)
+        except JobCancelledError:
+            _cleanup_stem_outputs(plan)
+            raise
 
     existing_artifacts = _stem_artifacts_for_source(
         session,

--- a/apps/backend/tests/test_jobs_api.py
+++ b/apps/backend/tests/test_jobs_api.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import threading
+import time
 from datetime import UTC, datetime, timedelta
+from subprocess import TimeoutExpired
 
 import pytest
 from fastapi.testclient import TestClient
@@ -8,7 +11,9 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.db import SessionLocal
+from app.errors import AppError
 from app.models import Artifact, Job, Project
+from app.services.jobs import InProcessJobRunner, JobExecutionContext, JobExecutionResult
 
 _BASE_TIME = datetime(2026, 1, 1, tzinfo=UTC)
 
@@ -730,3 +735,145 @@ def test_list_jobs_rejects_invalid_pagination_query(client: TestClient, params: 
 
     assert response.status_code == 422
     assert response.json()["error"]["code"] == "INVALID_REQUEST"
+
+
+def test_cancelled_pending_job_does_not_execute(client: TestClient) -> None:
+    runner = InProcessJobRunner(SessionLocal)
+    handler_called = False
+
+    def handler(_context: JobExecutionContext, _session: Session, _job: Job) -> JobExecutionResult:
+        nonlocal handler_called
+        handler_called = True
+        return JobExecutionResult(artifact_ids=[])
+
+    runner._handlers["test"] = handler
+    with SessionLocal() as session:
+        job = runner.create_job(session, project_id=None, job_type="test", payload={})
+        job_id = job.id
+        session.commit()
+
+    runner.cancel(job_id)
+    runner._execute_job(job_id)
+
+    assert handler_called is False
+    with SessionLocal() as session:
+        job = session.get(Job, job_id)
+        assert job is not None
+        assert job.cancel_requested is True
+        assert job.status == "cancelled"
+        assert job.started_at is None
+        assert job.completed_at is not None
+
+
+def test_cancel_requested_before_handler_start_finishes_cancelled(client: TestClient) -> None:
+    runner = InProcessJobRunner(SessionLocal)
+    handler_called = False
+
+    def handler(_context: JobExecutionContext, _session: Session, _job: Job) -> JobExecutionResult:
+        nonlocal handler_called
+        handler_called = True
+        return JobExecutionResult(artifact_ids=[])
+
+    runner._handlers["test"] = handler
+    with SessionLocal() as session:
+        job = runner.create_job(session, project_id=None, job_type="test", payload={})
+        job.cancel_requested = True
+        job_id = job.id
+        session.commit()
+
+    runner._execute_job(job_id)
+
+    assert handler_called is False
+    with SessionLocal() as session:
+        job = session.get(Job, job_id)
+        assert job is not None
+        assert job.cancel_requested is True
+        assert job.status == "cancelled"
+        assert job.started_at is not None
+        assert job.completed_at is not None
+        assert job.duration_seconds is not None
+        assert job.duration_seconds >= 0
+
+
+def test_running_cancelled_job_finishes_cancelled_when_handler_reports_failure(client: TestClient) -> None:
+    runner = InProcessJobRunner(SessionLocal)
+    handler_started = threading.Event()
+
+    def handler(context: JobExecutionContext, _session: Session, _job: Job) -> JobExecutionResult:
+        handler_started.set()
+        while not context.should_cancel():
+            time.sleep(0.01)
+        raise AppError("PROCESSING_FAILED", "Subprocess exited after cancellation.")
+
+    runner._handlers["test"] = handler
+    with SessionLocal() as session:
+        job = runner.create_job(session, project_id=None, job_type="test", payload={})
+        job_id = job.id
+        session.commit()
+
+    thread = threading.Thread(target=runner._execute_job, args=(job_id,))
+    thread.start()
+    assert handler_started.wait(timeout=2)
+
+    runner.cancel(job_id)
+    thread.join(timeout=2)
+
+    assert not thread.is_alive()
+    with SessionLocal() as session:
+        job = session.get(Job, job_id)
+        assert job is not None
+        assert job.cancel_requested is True
+        assert job.status == "cancelled"
+        assert job.error_message is None
+        assert job.started_at is not None
+        assert job.completed_at is not None
+        assert job.duration_seconds is not None
+        assert job.duration_seconds >= 0
+
+
+class _IgnoringTerminationProcess:
+    def __init__(self) -> None:
+        self.terminate_calls = 0
+        self.kill_calls = 0
+        self.wait_timeouts: list[float | None] = []
+
+    def poll(self) -> int | None:
+        if self.kill_calls:
+            return -9
+        return None
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+
+    def wait(self, timeout: float | None = None) -> int:
+        self.wait_timeouts.append(timeout)
+        if self.kill_calls:
+            return -9
+        raise TimeoutExpired(cmd="fake-process", timeout=timeout)
+
+
+def test_cancel_kills_registered_process_after_termination_grace(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("app.services.jobs._PROCESS_TERMINATION_GRACE_SECONDS", 0.0)
+    runner = InProcessJobRunner(SessionLocal)
+    with SessionLocal() as session:
+        _add_job(session, "job_running", "running", started_at=_timestamp(1))
+        session.commit()
+
+    process = _IgnoringTerminationProcess()
+    runner.register_process("job_running", process)
+
+    runner.cancel("job_running")
+
+    assert process.terminate_calls == 1
+    assert process.kill_calls == 1
+    assert process.wait_timeouts == [0.0, 0.0]
+    with SessionLocal() as session:
+        job = session.get(Job, "job_running")
+        assert job is not None
+        assert job.cancel_requested is True

--- a/apps/backend/tests/test_lyrics_engine.py
+++ b/apps/backend/tests/test_lyrics_engine.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
 
 from app.engines.lyrics import (
     LyricsTranscription,
@@ -9,7 +12,9 @@ from app.engines.lyrics import (
     resolve_whisper_device_candidates,
     resolve_whisper_model_candidates,
     transcribe_project_lyrics,
+    transcribe_project_lyrics_in_process,
 )
+from app.errors import JobCancelledError
 
 
 def make_fake_torch(*, has_mps: bool, has_cuda: bool):
@@ -156,7 +161,7 @@ def test_transcribe_project_lyrics_falls_back_to_cpu(monkeypatch):
 
     monkeypatch.setattr("app.engines.lyrics._transcribe_with_device", fake_transcribe_with_device)
 
-    result = transcribe_project_lyrics(
+    result = transcribe_project_lyrics_in_process(
         Path("/tmp/fake.wav"),
         model_name="turbo",
         requested_device="auto",
@@ -205,7 +210,7 @@ def test_transcribe_project_lyrics_retries_smaller_model_on_cuda_oom(monkeypatch
 
     monkeypatch.setattr("app.engines.lyrics._transcribe_with_device", fake_transcribe_with_device)
 
-    result = transcribe_project_lyrics(
+    result = transcribe_project_lyrics_in_process(
         Path("/tmp/fake.wav"),
         model_name="turbo",
         requested_device="auto",
@@ -216,3 +221,67 @@ def test_transcribe_project_lyrics_retries_smaller_model_on_cuda_oom(monkeypatch
     assert result.device == "cuda"
     assert result.model == "small"
     assert result.requested_device == "auto"
+
+
+def test_transcribe_project_lyrics_cancels_subprocess(monkeypatch):
+    class FakeProcess:
+        returncode: int | None = None
+
+        def __init__(self) -> None:
+            self.terminated = False
+            self.killed = False
+            self.wait_timeouts: list[float | None] = []
+
+        def poll(self) -> int | None:
+            return self.returncode
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+        def kill(self) -> None:
+            self.killed = True
+            self.returncode = -9
+
+        def wait(self, timeout: float | None = None) -> int:
+            self.wait_timeouts.append(timeout)
+            if self.killed:
+                self.returncode = -9
+                return self.returncode
+            raise subprocess.TimeoutExpired(cmd="lyrics-worker", timeout=timeout or 0)
+
+        def communicate(self) -> tuple[str, str]:
+            return "", ""
+
+    process = FakeProcess()
+    commands: list[list[str]] = []
+
+    def fake_popen(command: list[str], **_kwargs: object) -> FakeProcess:
+        commands.append(command)
+        return process
+
+    registered: list[object] = []
+    unregistered: list[bool] = []
+    cancel_checks = iter([False, True])
+
+    def should_cancel() -> bool:
+        return next(cancel_checks, True)
+
+    monkeypatch.setattr("app.engines.lyrics.subprocess.Popen", fake_popen)
+
+    with pytest.raises(JobCancelledError):
+        transcribe_project_lyrics(
+            Path("/tmp/fake.wav"),
+            model_name="turbo",
+            requested_device="auto",
+            download_root=Path("/tmp/lyrics-cache"),
+            should_cancel=should_cancel,
+            register_process=registered.append,
+            unregister_process=lambda: unregistered.append(True),
+        )
+
+    assert commands[0][1:3] == ["-m", "app.engines.lyrics_worker"]
+    assert process.terminated is True
+    assert process.killed is True
+    assert process.wait_timeouts == [2.0, 2.0]
+    assert registered == [process]
+    assert unregistered == [True]

--- a/apps/backend/tests/test_lyrics_flow.py
+++ b/apps/backend/tests/test_lyrics_flow.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import time
 from pathlib import Path
+from threading import Event
 
+from app.db import SessionLocal
 from app.engines.lyrics import LyricsTranscription
 from app.errors import AppError
+from app.models import LyricsTranscript
+from app.services.paths import project_analysis_dir
 
 from .conftest import wait_for_job
 
@@ -28,6 +33,58 @@ def test_import_queues_lyrics_generation(client, sample_audio_file: Path):
     assert payload["segments"][0]["text"] == "Test lyric"
     assert payload["source_segments"][0]["text"] == "Test lyric"
     assert payload["has_user_edits"] is False
+
+
+def test_running_lyrics_cancel_does_not_persist_transcript_or_snapshot(
+    client,
+    monkeypatch,
+    sample_audio_file: Path,
+):
+    started = Event()
+
+    def fake_transcription(*_args, should_cancel=None, **_kwargs):
+        started.set()
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if should_cancel and should_cancel():
+                return LyricsTranscription(
+                    backend="openai-whisper",
+                    requested_device="cpu",
+                    device="cpu",
+                    model="turbo",
+                    language="en",
+                    segments=[
+                        {
+                            "start_seconds": 0.0,
+                            "end_seconds": 1.0,
+                            "text": "Should not persist",
+                        }
+                    ],
+                )
+            time.sleep(0.01)
+        raise AssertionError("lyrics cancellation was not observed")
+
+    monkeypatch.setattr("app.services.lyrics.transcribe_project_lyrics", fake_transcription)
+
+    project = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_audio_file), "copy_into_project": True},
+    ).json()["project"]
+
+    jobs = client.get("/api/v1/jobs").json()["jobs"]
+    lyrics_job = next(job for job in jobs if job["project_id"] == project["id"] and job["type"] == "lyrics")
+    assert started.wait(timeout=2.0)
+
+    response = client.post(f"/api/v1/jobs/{lyrics_job['id']}/cancel")
+    assert response.status_code == 200
+    assert wait_for_job(client, lyrics_job["id"])["status"] == "cancelled"
+
+    payload = client.get(f"/api/v1/projects/{project['id']}/lyrics").json()
+    assert payload["backend"] is None
+    assert payload["segments"] == []
+    with SessionLocal() as session:
+        assert session.get(LyricsTranscript, project["id"]) is None
+    assert not (project_analysis_dir(project["id"]) / "lyrics.json").exists()
 
 
 def test_lyrics_job_persists_transcript_and_update_preserves_timings(

--- a/apps/backend/tests/test_stem_flow.py
+++ b/apps/backend/tests/test_stem_flow.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -8,13 +10,26 @@ from sqlalchemy.exc import IntegrityError
 
 from app.config import get_settings
 from app.db import SessionLocal
-from app.errors import AppError
+from app.errors import AppError, JobCancelledError
 from app.models import Job
 from app.services.artifacts import register_artifact
-from app.services.projects import get_project
+from app.services.projects import get_project, import_project
 from app.utils.ids import new_id
 
 from .conftest import wait_for_job
+
+
+def _create_project_without_import_jobs(source_path: Path) -> str:
+    with SessionLocal() as session:
+        project = import_project(
+            session,
+            source_path=str(source_path),
+            copy_into_project=True,
+            display_name=None,
+        )
+        project_id = project.id
+        session.commit()
+    return project_id
 
 
 def test_default_stem_generation_creates_six_stem_artifacts(client, sample_stereo_audio_file: Path, monkeypatch):
@@ -736,6 +751,268 @@ def test_stem_generation_reports_missing_dependency(client, sample_stereo_audio_
     final_job = wait_for_job(client, stem_job["id"])
     assert final_job["status"] == "failed"
     assert final_job["error_message"] == "Demucs is required for stem separation."
+
+
+def test_running_stem_cancel_after_subprocess_exit_marks_job_cancelled(
+    client,
+    sample_stereo_audio_file: Path,
+    monkeypatch,
+):
+    project_id = _create_project_without_import_jobs(sample_stereo_audio_file)
+    worker_sleeping = threading.Event()
+    terminated = threading.Event()
+    terminate_calls: list[str] = []
+    original_sleep = time.sleep
+
+    class FakeDemucsProcess:
+        def __init__(self, *_args, **_kwargs) -> None:
+            self.returncode: int | None = None
+            self.stdout = None
+            self.stderr = None
+
+        def poll(self) -> int | None:
+            return self.returncode
+
+        def terminate(self) -> None:
+            terminate_calls.append(threading.current_thread().name)
+            self.returncode = -15
+            terminated.set()
+
+        def kill(self) -> None:
+            self.returncode = -9
+            terminated.set()
+
+        def wait(self, timeout=None) -> int | None:
+            terminated.wait(timeout)
+            return self.returncode
+
+        def communicate(self) -> tuple[str, str]:
+            return "", "terminated"
+
+    def fake_sleep(seconds: float) -> None:
+        if threading.current_thread().name == "tuneforge-job-runner" and seconds == 0.25:
+            worker_sleeping.set()
+            terminated.wait(timeout=5)
+            return
+        original_sleep(seconds)
+
+    monkeypatch.setattr("app.engines.stems.importlib.util.find_spec", lambda _name: object())
+    monkeypatch.setattr("app.engines.stems.subprocess.Popen", FakeDemucsProcess)
+    monkeypatch.setattr("app.engines.stems.time.sleep", fake_sleep)
+
+    stem_job = client.post(
+        f"/api/v1/projects/{project_id}/stems",
+        json={"mode": "two_stem", "stem_model": "htdemucs_ft", "output_format": "wav", "force": False},
+    ).json()["job"]
+
+    assert worker_sleeping.wait(timeout=5)
+    cancel_response = client.post(f"/api/v1/jobs/{stem_job['id']}/cancel")
+    assert cancel_response.status_code == 200
+    assert terminated.wait(timeout=5)
+
+    final_job = wait_for_job(client, stem_job["id"])
+    assert final_job["status"] == "cancelled"
+    assert final_job["error_message"] is None
+    assert terminate_calls
+
+
+def test_demucs_nonzero_exit_after_cancel_raises_job_cancelled(tmp_path: Path, monkeypatch):
+    source_path = tmp_path / "source.wav"
+    source_path.write_bytes(b"fake audio")
+    poll_count = 0
+    cancel_checks = 0
+
+    class FakeDemucsProcess:
+        returncode: int | None = None
+
+        def poll(self) -> int | None:
+            nonlocal poll_count
+            poll_count += 1
+            if poll_count == 1:
+                return None
+            self.returncode = -15
+            return self.returncode
+
+        def terminate(self) -> None:
+            self.returncode = -15
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+        def wait(self, timeout=None) -> int | None:
+            return self.returncode
+
+        def communicate(self) -> tuple[str, str]:
+            return "", "terminated"
+
+    def should_cancel() -> bool:
+        nonlocal cancel_checks
+        cancel_checks += 1
+        return cancel_checks > 1
+
+    monkeypatch.setattr("app.engines.stems.importlib.util.find_spec", lambda _name: object())
+    monkeypatch.setattr("app.engines.stems.subprocess.Popen", lambda *_args, **_kwargs: FakeDemucsProcess())
+    monkeypatch.setattr("app.engines.stems.time.sleep", lambda _seconds: None)
+
+    from app.engines.stems import separate_two_stems
+
+    with pytest.raises(JobCancelledError):
+        separate_two_stems(
+            source_path,
+            tmp_path / "vocals.wav",
+            tmp_path / "instrumental.wav",
+            model="htdemucs_ft",
+            should_cancel=should_cancel,
+        )
+
+
+def test_cancelled_stem_generation_removes_temp_outputs_without_artifact_rows(
+    client,
+    sample_stereo_audio_file: Path,
+    monkeypatch,
+):
+    project_id = _create_project_without_import_jobs(sample_stereo_audio_file)
+    monkeypatch.setenv("TUNEFORGE_STEM_MODEL", "htdemucs_ft")
+    get_settings.cache_clear()
+    ready_to_cancel = threading.Event()
+    allow_return = threading.Event()
+    temp_paths: list[Path] = []
+
+    def fake_separate_two_stems(
+        source_path: Path,
+        vocal_path: Path,
+        instrumental_path: Path,
+        *,
+        model: str,
+        device: str,
+        model_repo=None,
+        on_progress=None,
+        should_cancel=None,
+        register_process=None,
+        unregister_process=None,
+    ):
+        signal, sample_rate = sf.read(source_path, always_2d=True)
+        vocal_path.parent.mkdir(parents=True, exist_ok=True)
+        instrumental_path.parent.mkdir(parents=True, exist_ok=True)
+        sf.write(vocal_path, signal * 0.7, sample_rate)
+        sf.write(instrumental_path, signal * 0.3, sample_rate)
+        temp_paths.extend([vocal_path, instrumental_path])
+        ready_to_cancel.set()
+        if not allow_return.wait(timeout=5):
+            raise AssertionError("Timed out waiting to release fake stem separation.")
+        return {"engine": "demucs", "model": model, "requested_device": device, "device": "cpu"}
+
+    monkeypatch.setattr("app.services.stems.separate_two_stems", fake_separate_two_stems)
+
+    stem_job = client.post(
+        f"/api/v1/projects/{project_id}/stems",
+        json={"mode": "two_stem", "stem_model": "htdemucs_ft", "output_format": "wav", "force": False},
+    ).json()["job"]
+
+    assert ready_to_cancel.wait(timeout=5)
+    cancel_response = client.post(f"/api/v1/jobs/{stem_job['id']}/cancel")
+    assert cancel_response.status_code == 200
+    allow_return.set()
+
+    final_job = wait_for_job(client, stem_job["id"])
+    assert final_job["status"] == "cancelled"
+    assert final_job["error_message"] is None
+    assert temp_paths
+    assert all(not path.exists() for path in temp_paths)
+
+    artifacts = client.get(f"/api/v1/projects/{project_id}/artifacts").json()["artifacts"]
+    assert not [artifact for artifact in artifacts if artifact["type"].endswith("_stem")]
+
+
+def test_cancelled_forced_stem_rebuild_preserves_existing_artifacts(
+    client,
+    sample_stereo_audio_file: Path,
+    monkeypatch,
+):
+    project_id = _create_project_without_import_jobs(sample_stereo_audio_file)
+    monkeypatch.setenv("TUNEFORGE_STEM_MODEL", "htdemucs_ft")
+    get_settings.cache_clear()
+    ready_to_cancel = threading.Event()
+    allow_return = threading.Event()
+    temp_paths: list[Path] = []
+    separation_count = 0
+
+    def fake_separate_two_stems(
+        source_path: Path,
+        vocal_path: Path,
+        instrumental_path: Path,
+        *,
+        model: str,
+        device: str,
+        model_repo=None,
+        on_progress=None,
+        should_cancel=None,
+        register_process=None,
+        unregister_process=None,
+    ):
+        nonlocal separation_count
+        separation_count += 1
+        signal, sample_rate = sf.read(source_path, always_2d=True)
+        vocal_path.parent.mkdir(parents=True, exist_ok=True)
+        instrumental_path.parent.mkdir(parents=True, exist_ok=True)
+        sf.write(vocal_path, signal * 0.7, sample_rate)
+        sf.write(instrumental_path, signal * 0.3, sample_rate)
+        if separation_count == 2:
+            temp_paths.extend([vocal_path, instrumental_path])
+            ready_to_cancel.set()
+            if not allow_return.wait(timeout=5):
+                raise AssertionError("Timed out waiting to release fake stem separation.")
+        return {"engine": "demucs", "model": model, "requested_device": device, "device": "cpu"}
+
+    monkeypatch.setattr("app.services.stems.separate_two_stems", fake_separate_two_stems)
+
+    initial_job = client.post(
+        f"/api/v1/projects/{project_id}/stems",
+        json={"mode": "two_stem", "stem_model": "htdemucs_ft", "output_format": "wav", "force": False},
+    ).json()["job"]
+    assert wait_for_job(client, initial_job["id"])["status"] == "completed"
+
+    artifacts_before = client.get(f"/api/v1/projects/{project_id}/artifacts").json()["artifacts"]
+    existing_stems = {
+        artifact["type"]: artifact
+        for artifact in artifacts_before
+        if artifact["metadata"].get("stem_model") == "htdemucs_ft"
+    }
+    assert set(existing_stems) == {"vocal_stem", "instrumental_stem"}
+    previous_rows = {
+        artifact_type: (artifact["id"], Path(artifact["path"]))
+        for artifact_type, artifact in existing_stems.items()
+    }
+    assert all(path.exists() for _artifact_id, path in previous_rows.values())
+
+    rebuild_job = client.post(
+        f"/api/v1/projects/{project_id}/stems",
+        json={"mode": "two_stem", "stem_model": "htdemucs_ft", "output_format": "wav", "force": True},
+    ).json()["job"]
+    assert ready_to_cancel.wait(timeout=5)
+    cancel_response = client.post(f"/api/v1/jobs/{rebuild_job['id']}/cancel")
+    assert cancel_response.status_code == 200
+    allow_return.set()
+
+    final_job = wait_for_job(client, rebuild_job["id"])
+    assert final_job["status"] == "cancelled"
+    assert final_job["error_message"] is None
+    assert temp_paths
+    assert all(not path.exists() for path in temp_paths)
+
+    artifacts_after = client.get(f"/api/v1/projects/{project_id}/artifacts").json()["artifacts"]
+    rebuilt_stems = {
+        artifact["type"]: artifact
+        for artifact in artifacts_after
+        if artifact["metadata"].get("stem_model") == "htdemucs_ft"
+    }
+    assert set(rebuilt_stems) == {"vocal_stem", "instrumental_stem"}
+    assert {
+        artifact_type: (artifact["id"], Path(artifact["path"]))
+        for artifact_type, artifact in rebuilt_stems.items()
+    } == previous_rows
+    assert all(path.exists() for _artifact_id, path in previous_rows.values())
+    assert not [artifact for artifact in artifacts_after if Path(artifact["path"]) in temp_paths]
 
 
 def test_deleting_practice_mix_removes_its_stems_only(client, sample_stereo_audio_file: Path, monkeypatch):


### PR DESCRIPTION
## Summary

- Make job cancellation interrupt running lyrics and stems work, not only pending jobs.
- Run lyrics transcription in a cancellable worker subprocess and preserve safe cleanup paths.
- Treat cancellation-triggered subprocess exits as cancelled jobs and preserve valid stem artifacts.
- Add follow-up issue #195 for language override on lyrics transcription.
- Fixes #188.

## Testing

- `cd apps/backend && uv run --python 3.11 pytest tests/test_jobs_api.py tests/test_lyrics_flow.py tests/test_lyrics_engine.py tests/test_stem_flow.py`
- `cd apps/backend && uv run --python 3.11 pytest`
- `cd apps/backend && uv run --python 3.11 ruff check .` (ran with a temporary uv cache override in local sandbox)
- `cd apps/backend && uv run --python 3.11 mypy app` (ran with a temporary uv cache override in local sandbox)
- `reviewer` subagent: no issues found
- `tuneforge_contract_guard` subagent: no contract drift found
