### PR TITLE
feat: add lyrics language override

### DIFF
--- a/apps/backend/alembic/versions/0020_lyrics_language_override.py
+++ b/apps/backend/alembic/versions/0020_lyrics_language_override.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0020_lyrics_language_override"
+down_revision = "0019_sync_project_state"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("lyrics_transcripts") as batch_op:
+        batch_op.add_column(sa.Column("language_override", sa.String(length=16), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("lyrics_transcripts") as batch_op:
+        batch_op.drop_column("language_override")

--- a/apps/backend/app/engines/lyrics.py
+++ b/apps/backend/app/engines/lyrics.py
@@ -26,6 +26,7 @@ class LyricsTranscription:
     model: str
     language: str | None
     segments: list[dict[str, Any]]
+    language_override: str | None = None
 
 
 def lyrics_transcription_to_payload(transcription: LyricsTranscription) -> dict[str, Any]:
@@ -35,12 +36,14 @@ def lyrics_transcription_to_payload(transcription: LyricsTranscription) -> dict[
         "device": transcription.device,
         "model": transcription.model,
         "language": transcription.language,
+        "language_override": transcription.language_override,
         "segments": transcription.segments,
     }
 
 
 def lyrics_transcription_from_payload(payload: dict[str, Any]) -> LyricsTranscription:
     language = payload.get("language")
+    language_override = payload.get("language_override")
     return LyricsTranscription(
         backend=str(payload.get("backend", "openai-whisper")),
         requested_device=str(payload.get("requested_device", "auto")),
@@ -48,6 +51,7 @@ def lyrics_transcription_from_payload(payload: dict[str, Any]) -> LyricsTranscri
         model=str(payload.get("model", "")),
         language=language if isinstance(language, str) else None,
         segments=cast(list[dict[str, Any]], payload.get("segments", [])),
+        language_override=language_override if isinstance(language_override, str) else None,
     )
 
 
@@ -187,8 +191,12 @@ def _transcribe_with_device(
     device: str,
     download_root: Path,
     whisper_module: Any,
+    language_override: str | None = None,
 ) -> LyricsTranscription:
     model = whisper_module.load_model(model_name, device=device, download_root=str(download_root))
+    transcribe_kwargs: dict[str, Any] = {}
+    if language_override is not None:
+        transcribe_kwargs["language"] = language_override
     result = whisper_module.transcribe(
         model,
         str(source_path),
@@ -196,15 +204,23 @@ def _transcribe_with_device(
         condition_on_previous_text=False,
         word_timestamps=True,
         fp16=device == "cuda",
+        **transcribe_kwargs,
     )
     segments = _normalize_segments(result.get("segments", []))
+    detected_language = result.get("language")
+    language = (
+        detected_language
+        if isinstance(detected_language, str) and detected_language.strip()
+        else language_override
+    )
     return LyricsTranscription(
         backend="openai-whisper",
         requested_device=requested_device,
         device=device,
         model=model_name,
-        language=result.get("language"),
+        language=language,
         segments=segments,
+        language_override=language_override,
     )
 
 
@@ -214,6 +230,7 @@ def transcribe_project_lyrics_in_process(
     model_name: str,
     requested_device: str,
     download_root: Path,
+    language_override: str | None = None,
 ) -> LyricsTranscription:
     torch_module, whisper_module = _load_runtime()
     candidates = resolve_whisper_device_candidates(requested_device, torch_module=torch_module)
@@ -230,6 +247,7 @@ def transcribe_project_lyrics_in_process(
                     device=device,
                     download_root=download_root,
                     whisper_module=whisper_module,
+                    language_override=language_override,
                 )
             except AppError:
                 raise
@@ -314,6 +332,7 @@ def transcribe_project_lyrics(
     model_name: str,
     requested_device: str,
     download_root: Path,
+    language_override: str | None = None,
     should_cancel: Callable[[], bool] | None = None,
     register_process: Callable[[subprocess.Popen[str]], None] | None = None,
     unregister_process: Callable[[], None] | None = None,
@@ -334,6 +353,8 @@ def transcribe_project_lyrics(
         "--download-root",
         str(download_root),
     ]
+    if language_override is not None:
+        command.extend(["--language", language_override])
     process = subprocess.Popen(
         command,
         stdout=subprocess.PIPE,

--- a/apps/backend/app/engines/lyrics_worker.py
+++ b/apps/backend/app/engines/lyrics_worker.py
@@ -18,6 +18,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--model", required=True)
     parser.add_argument("--requested-device", required=True)
     parser.add_argument("--download-root", required=True)
+    parser.add_argument("--language")
     return parser.parse_args()
 
 
@@ -33,6 +34,7 @@ def main() -> None:
             model_name=args.model,
             requested_device=args.requested_device,
             download_root=Path(args.download_root),
+            language_override=args.language,
         )
         _print_payload(
             {

--- a/apps/backend/app/models.py
+++ b/apps/backend/app/models.py
@@ -318,6 +318,7 @@ class LyricsTranscript(Base):
     device: Mapped[str | None] = mapped_column(String(16), nullable=True)
     model_name: Mapped[str | None] = mapped_column(String(64), nullable=True)
     language: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    language_override: Mapped[str | None] = mapped_column(String(16), nullable=True)
     source_segments_json: Mapped[list[dict[str, Any]]] = mapped_column(JSON(), default=list)
     segments_json: Mapped[list[dict[str, Any]]] = mapped_column(JSON(), default=list)
     has_user_edits: Mapped[bool] = mapped_column(Boolean(), default=False)

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -16,6 +16,20 @@ SUPPORTED_STEM_MODELS = {
     "two_stem",
     "htdemucs_ft",
 }
+LyricsLanguageOverride = Literal["none", "en", "pt", "es", "fr", "de", "it", "ja", "ko", "zh", "hi"]
+SUPPORTED_LYRICS_LANGUAGE_OVERRIDES: set[LyricsLanguageOverride] = {
+    "none",
+    "en",
+    "pt",
+    "es",
+    "fr",
+    "de",
+    "it",
+    "ja",
+    "ko",
+    "zh",
+    "hi",
+}
 SIX_STEM_MODEL_ALIASES = {"6_stems", "six_stems", "htdemucs_6s"}
 TWO_STEM_MODEL_ALIASES = {"2_stems", "two_stems", "two_stem", "htdemucs_ft"}
 SyncProjectStatus = Literal[
@@ -922,6 +936,21 @@ class StemModelsResponse(BaseModel):
 
 class LyricsGenerateRequest(BaseModel):
     force: bool = False
+    language_override: LyricsLanguageOverride | None = None
+
+    @field_validator("language_override", mode="before")
+    @classmethod
+    def validate_language_override(cls, value: object) -> object:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            return value
+        normalized = value.strip().lower()
+        if not normalized:
+            return None
+        if normalized not in SUPPORTED_LYRICS_LANGUAGE_OVERRIDES:
+            raise ValueError("Unsupported lyrics language override.")
+        return normalized
 
 
 class LyricsWordSchema(BaseModel):
@@ -957,6 +986,7 @@ class LyricsResponse(BaseModel):
     device: str | None = None
     model_name: str | None = None
     language: str | None = None
+    language_override: LyricsLanguageOverride | None = None
     source_segments: list[LyricsSegmentSchema] = Field(
         default_factory=list, validation_alias="source_segments_json"
     )

--- a/apps/backend/app/services/jobs.py
+++ b/apps/backend/app/services/jobs.py
@@ -730,11 +730,13 @@ class InProcessJobRunner:
 
     def _handle_lyrics(self, context: JobExecutionContext, session: Session, job: Job) -> JobExecutionResult:
         project = get_project(session, job.project_id or "")
+        payload = LyricsGenerateRequest.model_validate(job.payload_json)
         context.set_progress(15)
         lyrics = generate_project_lyrics(
             session,
             project=project,
-            force=bool(job.payload_json.get("force", False)),
+            force=payload.force,
+            language_override=payload.language_override,
             should_cancel=context.should_cancel,
             register_process=context.register_process,
             unregister_process=context.unregister_process,

--- a/apps/backend/app/services/lyrics.py
+++ b/apps/backend/app/services/lyrics.py
@@ -22,6 +22,7 @@ from app.services.sync_revisions import record_lyrics_revision
 from app.services.tab_state import clear_project_tab_state
 
 WORD_RE = re.compile(r"\S+")
+NO_LYRICS_LANGUAGE_OVERRIDE = "none"
 
 
 def _ensure_not_cancelled(should_cancel: Callable[[], bool] | None) -> None:
@@ -48,6 +49,7 @@ def _write_lyrics_snapshot(
         "device": lyrics.device,
         "model_name": lyrics.model_name,
         "language": lyrics.language,
+        "language_override": lyrics.language_override,
         "source_segments": lyrics.source_segments_json,
         "segments": lyrics.segments_json,
         "has_user_edits": lyrics.has_user_edits,
@@ -64,6 +66,7 @@ def generate_project_lyrics(
     *,
     project: Project,
     force: bool = False,
+    language_override: str | None = None,
     should_cancel: Callable[[], bool] | None = None,
     register_process: Callable[[Popen[str]], None] | None = None,
     unregister_process: Callable[[], None] | None = None,
@@ -73,16 +76,47 @@ def generate_project_lyrics(
     if existing is not None and existing.segments_json and not force:
         return existing
 
+    source_artifact = _source_artifact(project)
+    if language_override == NO_LYRICS_LANGUAGE_OVERRIDE:
+        _ensure_not_cancelled(should_cancel)
+        if force:
+            clear_project_tab_state(session, project_id=project.id)
+
+        _ensure_not_cancelled(should_cancel)
+        if existing is None:
+            existing = LyricsTranscript(project_id=project.id)
+            session.add(existing)
+
+        existing.backend = "none"
+        existing.source_artifact_id = source_artifact.id if source_artifact else None
+        existing.source_kind = "instrumental"
+        existing.requested_device = None
+        existing.device = None
+        existing.model_name = None
+        existing.language = None
+        existing.language_override = NO_LYRICS_LANGUAGE_OVERRIDE
+        existing.source_segments_json = []
+        existing.segments_json = []
+        existing.has_user_edits = False
+        session.flush()
+        session.refresh(existing)
+        _ensure_not_cancelled(should_cancel)
+        record_lyrics_revision(session, lyrics=existing, revision_type="generated")
+
+        _ensure_not_cancelled(should_cancel)
+        _write_lyrics_snapshot(project_id=project.id, lyrics=existing)
+        return existing
+
     transcription = transcribe_project_lyrics(
         Path(project.imported_path),
         model_name=get_settings().lyrics_model,
         requested_device=get_settings().lyrics_device,
         download_root=get_settings().lyrics_cache_dir,
+        language_override=language_override,
         should_cancel=should_cancel,
         register_process=register_process,
         unregister_process=unregister_process,
     )
-    source_artifact = _source_artifact(project)
     _ensure_not_cancelled(should_cancel)
     if force:
         clear_project_tab_state(session, project_id=project.id)
@@ -98,7 +132,12 @@ def generate_project_lyrics(
     existing.requested_device = transcription.requested_device
     existing.device = transcription.device
     existing.model_name = transcription.model
-    existing.language = transcription.language
+    existing.language = (
+        transcription.language
+        if transcription.language is not None and transcription.language.strip()
+        else transcription.language_override
+    )
+    existing.language_override = transcription.language_override
     existing.source_segments_json = cast(list[dict[str, Any]], deepcopy(transcription.segments))
     existing.segments_json = cast(list[dict[str, Any]], deepcopy(transcription.segments))
     existing.has_user_edits = False

--- a/apps/backend/app/services/sync_manifest.py
+++ b/apps/backend/app/services/sync_manifest.py
@@ -27,6 +27,7 @@ from app.models import (
     SyncDeleteTombstone,
     SyncEntityRevision,
 )
+from app.schemas import SUPPORTED_LYRICS_LANGUAGE_OVERRIDES
 from app.services.artifacts import register_artifact
 from app.services.paths import ensure_project_dirs, project_root
 from app.services.sync_identity import source_hash_to_project_id
@@ -1031,6 +1032,7 @@ def _hydrate_lyrics_revision(
     lyrics.device = _payload_optional_str(payload, "device")
     lyrics.model_name = _payload_optional_str(payload, "model_name")
     lyrics.language = _payload_optional_str(payload, "language")
+    lyrics.language_override = _payload_lyrics_language_override(payload)
     lyrics.source_segments_json = _payload_list(payload, ("source_segments", "source_segments_json"))
     lyrics.segments_json = _payload_list(payload, ("segments", "segments_json"))
     lyrics.has_user_edits = _payload_bool(payload, "has_user_edits", default=False)
@@ -1812,45 +1814,52 @@ def _duplicate_project_source_error(project_id: str, project_name: str) -> AppEr
 
 def _coerce_project_manifest(manifest: SyncProjectManifest | Mapping[str, Any] | object) -> SyncProjectManifest:
     if isinstance(manifest, SyncProjectManifest):
-        return manifest
+        project_manifest = manifest
+    else:
+        project_source = _field(manifest, "project", default=None)
+        project_fields = project_source if project_source is not None else manifest
+        raw_artifacts = _field(manifest, "artifacts")
+        if not isinstance(raw_artifacts, list):
+            raise _invalid_manifest("Project manifest artifacts must be a list.")
+        raw_entity_revisions = _field(manifest, "entity_revisions", default=[])
+        if not isinstance(raw_entity_revisions, list):
+            raise _invalid_manifest("Project manifest entity_revisions must be a list.")
+        raw_delete_tombstones = _field(manifest, "delete_tombstones", default=[])
+        if not isinstance(raw_delete_tombstones, list):
+            raise _invalid_manifest("Project manifest delete_tombstones must be a list.")
 
-    project_source = _field(manifest, "project", default=None)
-    project_fields = project_source if project_source is not None else manifest
-    raw_artifacts = _field(manifest, "artifacts")
-    if not isinstance(raw_artifacts, list):
-        raise _invalid_manifest("Project manifest artifacts must be a list.")
-    raw_entity_revisions = _field(manifest, "entity_revisions", default=[])
-    if not isinstance(raw_entity_revisions, list):
-        raise _invalid_manifest("Project manifest entity_revisions must be a list.")
-    raw_delete_tombstones = _field(manifest, "delete_tombstones", default=[])
-    if not isinstance(raw_delete_tombstones, list):
-        raise _invalid_manifest("Project manifest delete_tombstones must be a list.")
+        project_id = _required_str(project_fields, "project_id")
+        source_sha256 = _required_str(project_fields, "source_sha256").strip().lower()
 
-    project_id = _required_str(project_fields, "project_id")
-    source_sha256 = _required_str(project_fields, "source_sha256").strip().lower()
-
-    project_manifest = SyncProjectManifest(
-        schema_version=_optional_str(manifest, "schema_version") or SYNC_PROJECT_MANIFEST_SCHEMA_VERSION,
-        exported_at=_optional_datetime(manifest, "exported_at") or datetime.now(UTC),
-        project=SyncProjectManifestProject(
-            project_id=project_id,
-            display_name=_required_str(project_fields, "display_name"),
-            source_key_override=_optional_str(project_fields, "source_key_override"),
-            source_sha256=source_sha256,
-            duration_seconds=_optional_float(project_fields, "duration_seconds"),
-            sample_rate=_optional_int(project_fields, "sample_rate"),
-            channels=_optional_int(project_fields, "channels"),
-            created_at=_required_datetime(project_fields, "created_at"),
-            updated_at=_required_datetime(project_fields, "updated_at"),
-        ),
+        project_manifest = SyncProjectManifest(
+            schema_version=_optional_str(manifest, "schema_version") or SYNC_PROJECT_MANIFEST_SCHEMA_VERSION,
+            exported_at=_optional_datetime(manifest, "exported_at") or datetime.now(UTC),
+            project=SyncProjectManifestProject(
+                project_id=project_id,
+                display_name=_required_str(project_fields, "display_name"),
+                source_key_override=_optional_str(project_fields, "source_key_override"),
+                source_sha256=source_sha256,
+                duration_seconds=_optional_float(project_fields, "duration_seconds"),
+                sample_rate=_optional_int(project_fields, "sample_rate"),
+                channels=_optional_int(project_fields, "channels"),
+                created_at=_required_datetime(project_fields, "created_at"),
+                updated_at=_required_datetime(project_fields, "updated_at"),
+            ),
+            entity_revisions=[
+                _coerce_entity_revision_manifest(revision)
+                for revision in raw_entity_revisions
+            ],
+            artifacts=[_coerce_artifact_manifest(artifact) for artifact in raw_artifacts],
+            delete_tombstones=[
+                _coerce_delete_tombstone_manifest(tombstone)
+                for tombstone in raw_delete_tombstones
+            ],
+        )
+    project_manifest = replace(
+        project_manifest,
         entity_revisions=[
-            _coerce_entity_revision_manifest(revision)
-            for revision in raw_entity_revisions
-        ],
-        artifacts=[_coerce_artifact_manifest(artifact) for artifact in raw_artifacts],
-        delete_tombstones=[
-            _coerce_delete_tombstone_manifest(tombstone)
-            for tombstone in raw_delete_tombstones
+            _normalize_entity_revision_manifest_payload(revision)
+            for revision in project_manifest.entity_revisions
         ],
     )
     _validate_project_manifest_identity(project_manifest)
@@ -1923,6 +1932,42 @@ def _coerce_entity_revision_manifest(manifest: Mapping[str, Any] | object) -> Sy
     )
 
 
+def _normalize_entity_revision_manifest_payload(
+    revision: SyncEntityRevisionManifest,
+) -> SyncEntityRevisionManifest:
+    if revision.entity_type != "lyrics":
+        return revision
+
+    payload = deepcopy(revision.payload)
+    if "language_override" in payload:
+        payload["language_override"] = _normalize_lyrics_language_override_value(
+            payload["language_override"]
+        )
+    safe_payload = sanitize_revision_payload(payload)
+    if safe_payload != payload:
+        raise _invalid_manifest("Entity revision manifest payload must be sync-safe.")
+    return replace(
+        revision,
+        payload=safe_payload,
+        content_sha256=revision_payload_sha256(safe_payload),
+    )
+
+
+def _normalize_lyrics_language_override_value(value: object) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise _invalid_manifest(
+            "Entity revision payload field must be a string or null: language_override."
+        )
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    if normalized not in SUPPORTED_LYRICS_LANGUAGE_OVERRIDES:
+        raise _invalid_manifest("Lyrics revision language_override is unsupported.")
+    return normalized
+
+
 def _coerce_delete_tombstone_manifest(manifest: Mapping[str, Any] | object) -> SyncDeleteTombstoneManifest:
     prior_metadata = _field(manifest, "prior_metadata", default={})
     if not isinstance(prior_metadata, dict):
@@ -1956,6 +2001,10 @@ def _payload_optional_str(payload: Mapping[str, Any], name: str) -> str | None:
     if not isinstance(value, str):
         raise _invalid_manifest(f"Entity revision payload field must be a string or null: {name}.")
     return value
+
+
+def _payload_lyrics_language_override(payload: Mapping[str, Any]) -> str | None:
+    return _normalize_lyrics_language_override_value(payload.get("language_override"))
 
 
 def _payload_bool(payload: Mapping[str, Any], name: str, *, default: bool) -> bool:

--- a/apps/backend/app/services/sync_revisions.py
+++ b/apps/backend/app/services/sync_revisions.py
@@ -107,6 +107,7 @@ def record_lyrics_revision(
             "device": lyrics.device,
             "model_name": lyrics.model_name,
             "language": lyrics.language,
+            "language_override": lyrics.language_override,
             "has_user_edits": lyrics.has_user_edits,
             "source_segments": lyrics.source_segments_json or [],
             "segments": lyrics.segments_json or [],

--- a/apps/backend/tests/test_db_migrations.py
+++ b/apps/backend/tests/test_db_migrations.py
@@ -12,6 +12,28 @@ from app.services.sync_identity import source_hash_to_project_id, source_hash_to
 from app.utils.hashing import file_sha256
 
 
+def _create_legacy_lyrics_transcripts_table(connection: sqlite3.Connection) -> None:
+    connection.execute(
+        """
+        CREATE TABLE lyrics_transcripts (
+            project_id VARCHAR(32) PRIMARY KEY,
+            backend VARCHAR(64) NOT NULL DEFAULT 'openai-whisper',
+            source_artifact_id VARCHAR(32),
+            source_kind VARCHAR(32) NOT NULL DEFAULT 'ai',
+            requested_device VARCHAR(16),
+            device VARCHAR(16),
+            model_name VARCHAR(64),
+            language VARCHAR(32),
+            source_segments_json JSON NOT NULL DEFAULT '[]',
+            segments_json JSON NOT NULL DEFAULT '[]',
+            has_user_edits BOOLEAN NOT NULL DEFAULT 0,
+            created_at DATETIME,
+            updated_at DATETIME
+        )
+        """
+    )
+
+
 def test_run_migrations_reports_unknown_database_revision() -> None:
     settings = get_settings()
     ensure_data_dirs(settings)
@@ -200,6 +222,23 @@ def test_sync_delete_tombstones_migration_creates_table_columns_and_indexes() ->
     assert group_target_index_columns == ["sync_group_id", "target_type", "target_id"]
 
 
+def test_lyrics_language_override_migration_adds_nullable_column() -> None:
+    settings = get_settings()
+    ensure_data_dirs(settings)
+
+    reconfigure_engine(settings)
+    run_migrations(settings)
+
+    with sqlite3.connect(settings.database_path) as connection:
+        columns = {
+            row[1]: row
+            for row in connection.execute("PRAGMA table_info('lyrics_transcripts')")
+        }
+
+    assert "language_override" in columns
+    assert columns["language_override"][3] == 0
+
+
 def test_hash_storage_migration_backfills_existing_files(tmp_path: Path) -> None:
     settings = get_settings()
     ensure_data_dirs(settings)
@@ -273,6 +312,7 @@ def test_hash_storage_migration_backfills_existing_files(tmp_path: Path) -> None
             )
             """
         )
+        _create_legacy_lyrics_transcripts_table(connection)
         connection.execute(
             """
             INSERT INTO projects (
@@ -459,6 +499,7 @@ def test_sync_identity_migration_prefers_imported_copy_when_hash_missing(tmp_pat
             )
             """
         )
+        _create_legacy_lyrics_transcripts_table(connection)
         connection.execute(
             """
             INSERT INTO projects (
@@ -565,6 +606,7 @@ def test_sync_identity_migration_does_not_recover_moved_root_from_external_sourc
             )
             """
         )
+        _create_legacy_lyrics_transcripts_table(connection)
         connection.execute(
             """
             INSERT INTO projects (
@@ -690,6 +732,7 @@ def test_sync_identity_migration_recovers_artifacts_already_referenced_by_new_pr
             )
             """
         )
+        _create_legacy_lyrics_transcripts_table(connection)
         connection.execute(
             """
             INSERT INTO projects (
@@ -861,6 +904,7 @@ def test_sync_identity_migration_recovers_canonical_project_with_legacy_paths() 
             )
             """
         )
+        _create_legacy_lyrics_transcripts_table(connection)
         connection.execute(
             """
             INSERT INTO projects (
@@ -1029,6 +1073,7 @@ def test_sync_identity_migration_recovers_already_rewritten_project_root_and_sna
             )
             """
         )
+        _create_legacy_lyrics_transcripts_table(connection)
         connection.execute(
             """
             INSERT INTO projects (

--- a/apps/backend/tests/test_lyrics_engine.py
+++ b/apps/backend/tests/test_lyrics_engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -8,6 +9,7 @@ import pytest
 
 from app.engines.lyrics import (
     LyricsTranscription,
+    _transcribe_with_device,
     patch_whisper_timing_for_mps,
     resolve_whisper_device_candidates,
     resolve_whisper_model_candidates,
@@ -140,6 +142,7 @@ def test_transcribe_project_lyrics_falls_back_to_cpu(monkeypatch):
         device: str,
         download_root: Path,
         whisper_module: object,
+        language_override: str | None = None,
     ) -> LyricsTranscription:
         attempted_devices.append(device)
         if device == "mps":
@@ -189,6 +192,7 @@ def test_transcribe_project_lyrics_retries_smaller_model_on_cuda_oom(monkeypatch
         device: str,
         download_root: Path,
         whisper_module: object,
+        language_override: str | None = None,
     ) -> LyricsTranscription:
         attempts.append((device, model_name))
         if model_name == "turbo":
@@ -221,6 +225,122 @@ def test_transcribe_project_lyrics_retries_smaller_model_on_cuda_oom(monkeypatch
     assert result.device == "cuda"
     assert result.model == "small"
     assert result.requested_device == "auto"
+
+
+def test_transcribe_with_device_omits_language_for_auto_detect():
+    class FakeWhisper:
+        def __init__(self) -> None:
+            self.transcribe_kwargs: dict[str, object] | None = None
+
+        def load_model(self, model_name: str, *, device: str, download_root: str) -> str:
+            return f"{model_name}:{device}:{download_root}"
+
+        def transcribe(self, model: str, source_path: str, **kwargs: object) -> dict[str, object]:
+            self.transcribe_kwargs = kwargs
+            return {
+                "language": None,
+                "segments": [{"start": 0.0, "end": 1.0, "text": "hello"}],
+            }
+
+    whisper = FakeWhisper()
+
+    result = _transcribe_with_device(
+        Path("/tmp/fake.wav"),
+        requested_device="auto",
+        model_name="turbo",
+        device="cpu",
+        download_root=Path("/tmp/lyrics-cache"),
+        whisper_module=whisper,
+    )
+
+    assert whisper.transcribe_kwargs is not None
+    assert "language" not in whisper.transcribe_kwargs
+    assert result.language is None
+    assert result.language_override is None
+
+
+def test_transcribe_with_device_passes_language_override_and_falls_back_to_it():
+    class FakeWhisper:
+        def __init__(self) -> None:
+            self.transcribe_kwargs: dict[str, object] | None = None
+
+        def load_model(self, model_name: str, *, device: str, download_root: str) -> str:
+            return f"{model_name}:{device}:{download_root}"
+
+        def transcribe(self, model: str, source_path: str, **kwargs: object) -> dict[str, object]:
+            self.transcribe_kwargs = kwargs
+            return {
+                "language": None,
+                "segments": [{"start": 0.0, "end": 1.0, "text": "ola"}],
+            }
+
+    whisper = FakeWhisper()
+
+    result = _transcribe_with_device(
+        Path("/tmp/fake.wav"),
+        requested_device="auto",
+        model_name="turbo",
+        device="cpu",
+        download_root=Path("/tmp/lyrics-cache"),
+        whisper_module=whisper,
+        language_override="pt",
+    )
+
+    assert whisper.transcribe_kwargs is not None
+    assert whisper.transcribe_kwargs["language"] == "pt"
+    assert result.language == "pt"
+    assert result.language_override == "pt"
+
+
+def test_transcribe_project_lyrics_passes_language_override_to_worker(monkeypatch):
+    class FakeProcess:
+        returncode = 0
+
+        def poll(self) -> int:
+            return self.returncode
+
+        def communicate(self) -> tuple[str, str]:
+            return (
+                json.dumps(
+                    {
+                        "ok": True,
+                        "transcription": {
+                            "backend": "openai-whisper",
+                            "requested_device": "auto",
+                            "device": "cpu",
+                            "model": "turbo",
+                            "language": "pt",
+                            "language_override": "pt",
+                            "segments": [],
+                        },
+                    }
+                ),
+                "",
+            )
+
+        def kill(self) -> None:
+            raise AssertionError("completed process should not be killed")
+
+    process = FakeProcess()
+    commands: list[list[str]] = []
+
+    def fake_popen(command: list[str], **_kwargs: object) -> FakeProcess:
+        commands.append(command)
+        return process
+
+    monkeypatch.setattr("app.engines.lyrics.subprocess.Popen", fake_popen)
+
+    result = transcribe_project_lyrics(
+        Path("/tmp/fake.wav"),
+        model_name="turbo",
+        requested_device="auto",
+        download_root=Path("/tmp/lyrics-cache"),
+        language_override="pt",
+    )
+
+    assert commands[0][-2:] == ["--language", "pt"]
+    assert result.language == "pt"
+    assert result.language_override == "pt"
 
 
 def test_transcribe_project_lyrics_cancels_subprocess(monkeypatch):
@@ -280,6 +400,7 @@ def test_transcribe_project_lyrics_cancels_subprocess(monkeypatch):
         )
 
     assert commands[0][1:3] == ["-m", "app.engines.lyrics_worker"]
+    assert "--language" not in commands[0]
     assert process.terminated is True
     assert process.killed is True
     assert process.wait_timeouts == [2.0, 2.0]

--- a/apps/backend/tests/test_lyrics_flow.py
+++ b/apps/backend/tests/test_lyrics_flow.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
+import json
 import time
 from pathlib import Path
 from threading import Event
+from types import SimpleNamespace
+
+from sqlalchemy import select
 
 from app.db import SessionLocal
 from app.engines.lyrics import LyricsTranscription
 from app.errors import AppError
-from app.models import LyricsTranscript
+from app.models import LyricsTranscript, SyncEntityRevision
 from app.services.paths import project_analysis_dir
+from app.services.projects import import_project
+from app.services.stems import StemGenerationResult
 
 from .conftest import wait_for_job
 
@@ -18,7 +24,31 @@ def _first_source_artifact_id(client, project_id: str) -> str:
     return next(artifact["id"] for artifact in artifacts if artifact["type"] == "source_audio")
 
 
-def test_import_queues_lyrics_generation(client, sample_audio_file: Path):
+def _create_project_without_import_jobs(source_path: Path) -> str:
+    with SessionLocal() as session:
+        project = import_project(
+            session,
+            source_path=str(source_path),
+            copy_into_project=True,
+            display_name=None,
+        )
+        project_id = project.id
+        session.commit()
+    return project_id
+
+
+def test_import_queues_lyrics_generation(client, monkeypatch, sample_audio_file: Path):
+    # Keep this lyrics assertion independent from runtime of other import jobs queued ahead of it.
+    monkeypatch.setattr("app.services.jobs.analyze_project", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "app.services.jobs.detect_project_chords",
+        lambda *_args, **_kwargs: SimpleNamespace(metadata_json={}),
+    )
+    monkeypatch.setattr(
+        "app.services.jobs.generate_stems",
+        lambda *_args, **_kwargs: StemGenerationResult(artifacts=[], generated_this_job=False),
+    )
+
     project = client.post(
         "/api/v1/projects/import",
         json={"source_path": str(sample_audio_file), "copy_into_project": True},
@@ -66,25 +96,24 @@ def test_running_lyrics_cancel_does_not_persist_transcript_or_snapshot(
 
     monkeypatch.setattr("app.services.lyrics.transcribe_project_lyrics", fake_transcription)
 
-    project = client.post(
-        "/api/v1/projects/import",
-        json={"source_path": str(sample_audio_file), "copy_into_project": True},
-    ).json()["project"]
+    project_id = _create_project_without_import_jobs(sample_audio_file)
 
-    jobs = client.get("/api/v1/jobs").json()["jobs"]
-    lyrics_job = next(job for job in jobs if job["project_id"] == project["id"] and job["type"] == "lyrics")
+    lyrics_job = client.post(
+        f"/api/v1/projects/{project_id}/lyrics",
+        json={"force": True},
+    ).json()["job"]
     assert started.wait(timeout=2.0)
 
     response = client.post(f"/api/v1/jobs/{lyrics_job['id']}/cancel")
     assert response.status_code == 200
     assert wait_for_job(client, lyrics_job["id"])["status"] == "cancelled"
 
-    payload = client.get(f"/api/v1/projects/{project['id']}/lyrics").json()
+    payload = client.get(f"/api/v1/projects/{project_id}/lyrics").json()
     assert payload["backend"] is None
     assert payload["segments"] == []
     with SessionLocal() as session:
-        assert session.get(LyricsTranscript, project["id"]) is None
-    assert not (project_analysis_dir(project["id"]) / "lyrics.json").exists()
+        assert session.get(LyricsTranscript, project_id) is None
+    assert not (project_analysis_dir(project_id) / "lyrics.json").exists()
 
 
 def test_lyrics_job_persists_transcript_and_update_preserves_timings(
@@ -141,8 +170,11 @@ def test_lyrics_job_persists_transcript_and_update_preserves_timings(
     assert created["device"] == "cpu"
     assert created["model_name"] == "turbo"
     assert created["language"] == "en"
+    assert created["language_override"] is None
     assert created["segments"][0]["text"] == "First line"
     assert created["segments"][0]["words"][0]["text"] == "First"
+    snapshot = json.loads((project_analysis_dir(project["id"]) / "lyrics.json").read_text(encoding="utf-8"))
+    assert snapshot["language_override"] is None
 
     updated = client.put(
         f"/api/v1/projects/{project['id']}/lyrics",
@@ -157,6 +189,145 @@ def test_lyrics_job_persists_transcript_and_update_preserves_timings(
     assert updated["segments"][0]["words"][-1]["end_seconds"] == 1.2
     assert updated["source_segments"][0]["text"] == "First line"
     assert updated["has_user_edits"] is True
+
+
+def test_lyrics_language_override_reaches_service_and_persists_metadata(
+    client,
+    monkeypatch,
+    sample_audio_file: Path,
+):
+    requested_languages: list[str | None] = []
+
+    def fake_transcription(*_args, language_override=None, **_kwargs):
+        requested_languages.append(language_override)
+        return LyricsTranscription(
+            backend="openai-whisper",
+            requested_device="cpu",
+            device="cpu",
+            model="turbo",
+            language=None,
+            segments=[
+                {
+                    "start_seconds": 0.0,
+                    "end_seconds": 1.0,
+                    "text": "Ola mundo",
+                }
+            ],
+            language_override=language_override,
+        )
+
+    monkeypatch.setattr("app.services.lyrics.transcribe_project_lyrics", fake_transcription)
+
+    project = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_audio_file), "copy_into_project": True},
+    ).json()["project"]
+
+    job = client.post(
+        f"/api/v1/projects/{project['id']}/lyrics",
+        json={"force": True, "language_override": " PT "},
+    ).json()["job"]
+    assert wait_for_job(client, job["id"])["status"] == "completed"
+
+    created = client.get(f"/api/v1/projects/{project['id']}/lyrics").json()
+    assert requested_languages[-1] == "pt"
+    assert created["language"] == "pt"
+    assert created["language_override"] == "pt"
+    snapshot = json.loads((project_analysis_dir(project["id"]) / "lyrics.json").read_text(encoding="utf-8"))
+    assert snapshot["language"] == "pt"
+    assert snapshot["language_override"] == "pt"
+
+    with SessionLocal() as session:
+        lyrics = session.get(LyricsTranscript, project["id"])
+        assert lyrics is not None
+        assert lyrics.language_override == "pt"
+        revision = session.scalars(
+            select(SyncEntityRevision).where(
+                SyncEntityRevision.project_id == project["id"],
+                SyncEntityRevision.entity_type == "lyrics",
+                SyncEntityRevision.state == "active",
+            )
+        ).one()
+        assert revision.payload_json["language"] == "pt"
+        assert revision.payload_json["language_override"] == "pt"
+
+
+def test_lyrics_no_lyrics_override_clears_transcript_without_transcribing(
+    client,
+    monkeypatch,
+    sample_audio_file: Path,
+):
+    project = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_audio_file), "copy_into_project": True},
+    ).json()["project"]
+
+    def fail_transcription(*_args, **_kwargs):
+        raise AssertionError("lyrics transcription should not run for no-lyrics override")
+
+    monkeypatch.setattr("app.services.lyrics.transcribe_project_lyrics", fail_transcription)
+
+    job = client.post(
+        f"/api/v1/projects/{project['id']}/lyrics",
+        json={"force": True, "language_override": "none"},
+    ).json()["job"]
+    assert wait_for_job(client, job["id"])["status"] == "completed"
+
+    created = client.get(f"/api/v1/projects/{project['id']}/lyrics").json()
+    assert created["backend"] == "none"
+    assert created["source_kind"] == "instrumental"
+    assert created["language"] is None
+    assert created["language_override"] == "none"
+    assert created["source_segments"] == []
+    assert created["segments"] == []
+    assert created["has_user_edits"] is False
+
+    snapshot = json.loads((project_analysis_dir(project["id"]) / "lyrics.json").read_text())
+    assert snapshot["language_override"] == "none"
+    assert snapshot["segments"] == []
+
+
+def test_lyrics_language_override_invalid_code_rejected(client, sample_audio_file: Path):
+    project = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_audio_file), "copy_into_project": True},
+    ).json()["project"]
+
+    response = client.post(
+        f"/api/v1/projects/{project['id']}/lyrics",
+        json={"force": True, "language_override": "ru"},
+    )
+
+    assert response.status_code == 422
+
+
+def test_lyrics_short_circuit_ignores_override_when_force_false(
+    client,
+    monkeypatch,
+    sample_audio_file: Path,
+):
+    project = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_audio_file), "copy_into_project": True},
+    ).json()["project"]
+    jobs = client.get("/api/v1/jobs").json()["jobs"]
+    lyrics_job = next(job for job in jobs if job["project_id"] == project["id"] and job["type"] == "lyrics")
+    assert wait_for_job(client, lyrics_job["id"])["status"] == "completed"
+
+    def fail_transcription(*_args, **_kwargs):
+        raise AssertionError("existing lyrics should short-circuit without regeneration")
+
+    monkeypatch.setattr("app.services.lyrics.transcribe_project_lyrics", fail_transcription)
+
+    job = client.post(
+        f"/api/v1/projects/{project['id']}/lyrics",
+        json={"force": False, "language_override": "pt"},
+    ).json()["job"]
+    assert wait_for_job(client, job["id"])["status"] == "completed"
+
+    refreshed = client.get(f"/api/v1/projects/{project['id']}/lyrics").json()
+    assert refreshed["segments"][0]["text"] == "Test lyric"
+    assert refreshed["language_override"] is None
 
 
 def test_force_regenerate_replaces_current_and_clears_edit_flag(client, monkeypatch, sample_audio_file: Path):

--- a/apps/backend/tests/test_sync_manifest.py
+++ b/apps/backend/tests/test_sync_manifest.py
@@ -435,6 +435,7 @@ def _add_project_entity_revisions(session: Any, fixture: ManifestProjectFixture)
             "source_artifact_id": "art_source_audio",
             "source_kind": "user-edited",
             "language": "en",
+            "language_override": "en",
             "source_segments": [
                 {"start_seconds": 0.0, "end_seconds": 1.0, "text": "hello", "words": []}
             ],
@@ -1047,6 +1048,7 @@ def test_import_staged_project_manifest_hydrates_current_entity_revisions_and_sk
         assert lyrics.source_artifact_id == "art_source_audio"
         assert lyrics.source_kind == "user-edited"
         assert lyrics.language == "en"
+        assert lyrics.language_override == "en"
         assert lyrics.source_segments_json == [
             {"start_seconds": 0.0, "end_seconds": 1.0, "text": "hello", "words": []}
         ]
@@ -1080,6 +1082,29 @@ def test_import_staged_project_manifest_hydrates_current_entity_revisions_and_sk
 
         job_types = set(session.scalars(select(Job.type).where(Job.project_id == fixture.project_id)))
         assert job_types == set()
+
+
+def test_import_staged_project_manifest_rejects_invalid_lyrics_language_override(
+    client: object,
+    tmp_path: Path,
+) -> None:
+    export_manifest, import_manifest = _sync_manifest_services()
+    staging_root = tmp_path / "staging"
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path)
+        _add_project_entity_revisions(session, fixture)
+        manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+        lyrics_revision = _entity_revisions_by_id(manifest)["rev_lyrics_current"]
+        lyrics_revision["payload"]["language_override"] = "ru"
+        _stage_manifest_files(manifest, staging_root=staging_root, source_root=fixture.root)
+        _delete_live_project(session, fixture)
+
+        with pytest.raises(AppError) as exc:
+            import_manifest(session, manifest=manifest, staging_root=staging_root)
+
+    assert exc.value.code == "SYNC_MANIFEST_INVALID"
+    assert "language_override" in exc.value.message
 
 
 def test_import_staged_project_manifest_rejects_foreign_revision_base(

--- a/apps/backend/tests/test_sync_revisions.py
+++ b/apps/backend/tests/test_sync_revisions.py
@@ -160,6 +160,7 @@ def test_lyrics_and_section_revisions_are_listed_as_current_project_entities(
         device="cpu",
         model_name="base",
         language="en",
+        language_override="en",
         source_segments_json=[{"start": 0.0, "end": 1.0, "text": "hello"}],
         segments_json=[{"start": 0.0, "end": 1.0, "text": "hello edit"}],
         has_user_edits=True,
@@ -189,6 +190,7 @@ def test_lyrics_and_section_revisions_are_listed_as_current_project_entities(
     assert lyrics_revision.entity_type == LYRICS_ENTITY_TYPE
     assert lyrics_revision.revision_type == "user_edit"
     assert lyrics_revision.payload_json["has_user_edits"] is True
+    assert lyrics_revision.payload_json["language_override"] == "en"
     assert section_revision.entity_type == SECTION_ENTITY_TYPE
     assert section_revision.payload_json["metadata"] == {"color": "blue"}
     _assert_sync_safe(section_revision.payload_json, tmp_path)

--- a/apps/desktop/src-tauri/src/mobile_backend.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend.rs
@@ -18,13 +18,26 @@ const TRANSPORT_HANDSHAKE_CLOCK_SKEW_SECONDS: i64 = 30;
 #[cfg(not(target_os = "android"))]
 const MOBILE_UNAVAILABLE: &str = "Mobile embedded backend is only available in Android builds.";
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
-const MOBILE_DB_VERSION: i64 = 2;
+const MOBILE_DB_VERSION: i64 = 3;
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
 const DEFAULT_SYNC_STATUS: &str = "local";
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
 const DEFAULT_SYNC_LIST_JSON: &str = "[]";
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
 const MOBILE_CANCELLED_JOB_STATUS: &str = "cancelled";
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+const LYRICS_LANGUAGE_OVERRIDE_CODES: &[&str] = &[
+    "none", "en", "pt", "es", "fr", "de", "it", "ja", "ko", "zh", "hi",
+];
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+const LYRICS_LANGUAGE_OVERRIDE_ERROR: &str =
+    "language_override must be null or one of none, en, pt, es, fr, de, it, ja, ko, zh, hi.";
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+const LYRICS_SOURCE_KIND_AI: &str = "ai";
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+const LYRICS_SOURCE_KIND_INSTRUMENTAL: &str = "instrumental";
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+const LYRICS_BACKEND_NONE: &str = "none";
 #[cfg(target_os = "android")]
 const GPU_REQUIRED: &str = "Local generation requires GPU acceleration on this device.";
 #[cfg(target_os = "android")]
@@ -224,6 +237,7 @@ pub struct LyricsResponse {
     device: Option<String>,
     model_name: Option<String>,
     language: Option<String>,
+    language_override: Option<String>,
     source_segments: Vec<Value>,
     segments: Vec<Value>,
     has_user_edits: bool,
@@ -337,6 +351,42 @@ pub struct SyncTrustedPeerCreateRequest {
     payload: SyncPairingPayloadSchema,
     #[serde(default)]
     adopt_sync_group: bool,
+}
+
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+fn payload_lyrics_language_override(payload: &Value) -> Result<Option<String>, String> {
+    match payload.get("language_override") {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) => {
+            let normalized = value.trim().to_ascii_lowercase();
+            if normalized.is_empty() {
+                return Ok(None);
+            }
+            if LYRICS_LANGUAGE_OVERRIDE_CODES.contains(&normalized.as_str()) {
+                Ok(Some(normalized))
+            } else {
+                Err(LYRICS_LANGUAGE_OVERRIDE_ERROR.to_string())
+            }
+        }
+        Some(_) => Err("language_override must be a string or null.".to_string()),
+    }
+}
+
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+fn no_lyrics_transcript_metadata() -> (
+    &'static str,
+    &'static str,
+    Option<&'static str>,
+    Option<&'static str>,
+    Option<String>,
+) {
+    (
+        LYRICS_BACKEND_NONE,
+        LYRICS_SOURCE_KIND_INSTRUMENTAL,
+        None,
+        None,
+        None,
+    )
 }
 
 #[derive(Serialize)]
@@ -1699,7 +1749,7 @@ mobile_stub!(mobile_submit_chords, JobResponse, app: AppHandle, project_id: Stri
 #[cfg(not(target_os = "android"))]
 mobile_stub!(mobile_get_chords, ChordResponse, app: AppHandle, project_id: String);
 #[cfg(not(target_os = "android"))]
-mobile_stub!(mobile_submit_lyrics, JobResponse, app: AppHandle, project_id: String, payload: EmptyPayload);
+mobile_stub!(mobile_submit_lyrics, JobResponse, app: AppHandle, project_id: String, payload: Value);
 #[cfg(not(target_os = "android"))]
 mobile_stub!(mobile_get_lyrics, LyricsResponse, app: AppHandle, project_id: String);
 #[cfg(not(target_os = "android"))]
@@ -1905,6 +1955,7 @@ mod android {
             device TEXT,
             model_name TEXT,
             language TEXT,
+            language_override TEXT,
             source_segments_json TEXT NOT NULL,
             segments_json TEXT NOT NULL,
             has_user_edits INTEGER NOT NULL,
@@ -2038,10 +2089,12 @@ mod android {
 
     struct MobileLyricsTranscription {
         backend: &'static str,
-        requested_device: &'static str,
-        device: &'static str,
-        model_name: String,
+        source_kind: &'static str,
+        requested_device: Option<&'static str>,
+        device: Option<&'static str>,
+        model_name: Option<String>,
         language: Option<String>,
+        language_override: Option<String>,
         segments: Vec<Value>,
     }
 
@@ -2263,6 +2316,12 @@ mod android {
         )?;
         add_column_if_missing(connection, "artifacts", "content_sha256", "TEXT")?;
         add_column_if_missing(connection, "artifacts", "cache_key", "TEXT")?;
+        add_column_if_missing(
+            connection,
+            "lyrics_transcripts",
+            "language_override",
+            "TEXT",
+        )?;
         add_column_if_missing(
             connection,
             "jobs",
@@ -5684,11 +5743,11 @@ mod android {
     ) -> Result<LyricsResponse, String> {
         connection
             .query_row(
-                "SELECT project_id, backend, source_artifact_id, source_kind, requested_device, device, model_name, language, source_segments_json, segments_json, has_user_edits, created_at, updated_at FROM lyrics_transcripts WHERE project_id = ?1",
+                "SELECT project_id, backend, source_artifact_id, source_kind, requested_device, device, model_name, language, language_override, source_segments_json, segments_json, has_user_edits, created_at, updated_at FROM lyrics_transcripts WHERE project_id = ?1",
                 params![project_id],
                 |row| {
-                    let source_segments_raw: String = row.get(8)?;
-                    let segments_raw: String = row.get(9)?;
+                    let source_segments_raw: String = row.get(9)?;
+                    let segments_raw: String = row.get(10)?;
                     let source_segments =
                         serde_json::from_str(&source_segments_raw).unwrap_or_default();
                     let segments = serde_json::from_str(&segments_raw).unwrap_or_default();
@@ -5701,11 +5760,12 @@ mod android {
                         device: row.get(5)?,
                         model_name: row.get(6)?,
                         language: row.get(7)?,
+                        language_override: row.get(8)?,
                         source_segments,
                         segments,
-                        has_user_edits: row.get::<_, i64>(10)? != 0,
-                        created_at: row.get(11)?,
-                        updated_at: row.get(12)?,
+                        has_user_edits: row.get::<_, i64>(11)? != 0,
+                        created_at: row.get(12)?,
+                        updated_at: row.get(13)?,
                     })
                 },
             )
@@ -5743,17 +5803,19 @@ mod android {
         let segments_json = source_segments_json.clone();
         connection
             .execute(
-                "INSERT INTO lyrics_transcripts (project_id, backend, source_artifact_id, source_kind, requested_device, device, model_name, language, source_segments_json, segments_json, has_user_edits, created_at, updated_at)
-                 VALUES (?1, ?2, ?3, 'ai', ?4, ?5, ?6, ?7, ?8, ?9, 0, ?10, ?10)
-                 ON CONFLICT(project_id) DO UPDATE SET backend = excluded.backend, source_artifact_id = excluded.source_artifact_id, source_kind = excluded.source_kind, requested_device = excluded.requested_device, device = excluded.device, model_name = excluded.model_name, language = excluded.language, source_segments_json = excluded.source_segments_json, segments_json = excluded.segments_json, has_user_edits = excluded.has_user_edits, updated_at = excluded.updated_at",
+                "INSERT INTO lyrics_transcripts (project_id, backend, source_artifact_id, source_kind, requested_device, device, model_name, language, language_override, source_segments_json, segments_json, has_user_edits, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 0, ?12, ?12)
+                 ON CONFLICT(project_id) DO UPDATE SET backend = excluded.backend, source_artifact_id = excluded.source_artifact_id, source_kind = excluded.source_kind, requested_device = excluded.requested_device, device = excluded.device, model_name = excluded.model_name, language = excluded.language, language_override = excluded.language_override, source_segments_json = excluded.source_segments_json, segments_json = excluded.segments_json, has_user_edits = excluded.has_user_edits, updated_at = excluded.updated_at",
                 params![
                     project.id,
                     transcription.backend,
                     source_artifact.id,
+                    transcription.source_kind,
                     transcription.requested_device,
                     transcription.device,
                     transcription.model_name,
                     transcription.language,
+                    transcription.language_override,
                     source_segments_json,
                     segments_json,
                     timestamp,
@@ -5875,6 +5937,7 @@ mod android {
     fn transcribe_project_lyrics(
         source_path: &Path,
         model: &WhisperModel,
+        language_override: Option<&str>,
     ) -> Result<MobileLyricsTranscription, String> {
         let audio = read_resampled_mono_audio(source_path, WHISPER_SAMPLE_RATE)?;
         if audio.samples.is_empty() {
@@ -5896,7 +5959,7 @@ mod android {
             .unwrap_or(2);
         params.set_n_threads(thread_count);
         params.set_translate(false);
-        params.set_language(None);
+        params.set_language(language_override);
         params.set_no_context(true);
         params.set_token_timestamps(false);
         params.set_print_special(false);
@@ -5926,13 +5989,18 @@ mod android {
             }));
         }
 
+        let language = whisper_rs::get_lang_str(state.full_lang_id_from_state())
+            .map(ToString::to_string)
+            .or_else(|| language_override.map(ToString::to_string));
+
         Ok(MobileLyricsTranscription {
             backend: "whisper.cpp",
-            requested_device: "cpu",
-            device: "cpu",
-            model_name: model.name.to_string(),
-            language: whisper_rs::get_lang_str(state.full_lang_id_from_state())
-                .map(ToString::to_string),
+            source_kind: LYRICS_SOURCE_KIND_AI,
+            requested_device: Some("cpu"),
+            device: Some("cpu"),
+            model_name: Some(model.name.to_string()),
+            language,
+            language_override: language_override.map(ToString::to_string),
             segments,
         })
     }
@@ -5943,6 +6011,7 @@ mod android {
         project: ProjectSchema,
         source_artifact: ArtifactSchema,
         model: WhisperModel,
+        language_override: Option<String>,
     ) {
         let started = Instant::now();
         let connection = match db_at_root(&root) {
@@ -5952,8 +6021,11 @@ mod android {
 
         let result = (|| {
             update_job_progress(&connection, &job_id, 15)?;
-            let transcription =
-                transcribe_project_lyrics(Path::new(&project.imported_path), &model)?;
+            let transcription = transcribe_project_lyrics(
+                Path::new(&project.imported_path),
+                &model,
+                language_override.as_deref(),
+            )?;
             update_job_progress(&connection, &job_id, 90)?;
             store_lyrics_transcript(
                 &connection,
@@ -7085,6 +7157,14 @@ mod android {
         let root = app_data_root(&app)?;
         let project = require_sync_editable_project(&connection, &project_id)?;
         let force = payload_force(&payload);
+        let language_override = match payload_lyrics_language_override(&payload) {
+            Ok(language_override) => language_override,
+            Err(message) => {
+                return Ok(JobResponse {
+                    job: create_failed_job(&connection, &project_id, "lyrics", &message)?,
+                });
+            }
+        };
         let existing = get_lyrics_response(&connection, project_id.clone())?;
         if !force && !existing.segments.is_empty() {
             return Ok(JobResponse {
@@ -7104,6 +7184,34 @@ mod android {
                 });
             }
         };
+        if language_override.as_deref() == Some("none") {
+            let (backend, source_kind, requested_device, device, model_name) =
+                no_lyrics_transcript_metadata();
+            store_lyrics_transcript(
+                &connection,
+                &root,
+                &project,
+                &source_artifact,
+                MobileLyricsTranscription {
+                    backend,
+                    source_kind,
+                    requested_device,
+                    device,
+                    model_name,
+                    language: None,
+                    language_override,
+                    segments: Vec::new(),
+                },
+            )?;
+            return Ok(JobResponse {
+                job: create_completed_job(
+                    &connection,
+                    &project_id,
+                    "lyrics",
+                    Some(source_artifact.id),
+                )?,
+            });
+        }
         let model = match find_whisper_model(&root) {
             Some(model) => model,
             None => {
@@ -7124,7 +7232,16 @@ mod android {
             Some(source_artifact.id.clone()),
         )?;
         let job_id = job.id.clone();
-        thread::spawn(move || run_lyrics_job(root, job_id, project, source_artifact, model));
+        thread::spawn(move || {
+            run_lyrics_job(
+                root,
+                job_id,
+                project,
+                source_artifact,
+                model,
+                language_override,
+            )
+        });
         Ok(JobResponse { job })
     }
 
@@ -7157,6 +7274,7 @@ mod android {
             device: None,
             model_name: None,
             language: None,
+            language_override: None,
             source_segments: Vec::new(),
             segments: Vec::new(),
             has_user_edits: false,
@@ -7867,8 +7985,63 @@ mod mobile_backend_tests {
     }
 
     #[test]
+    fn mobile_lyrics_language_override_normalizes_auto_values() {
+        assert_eq!(payload_lyrics_language_override(&json!({})).unwrap(), None);
+        assert_eq!(
+            payload_lyrics_language_override(&json!({"language_override": null})).unwrap(),
+            None
+        );
+        assert_eq!(
+            payload_lyrics_language_override(&json!({"language_override": "   "})).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn mobile_lyrics_language_override_accepts_curated_codes() {
+        assert_eq!(
+            payload_lyrics_language_override(&json!({"language_override": "none"})).unwrap(),
+            Some("none".to_string())
+        );
+        assert_eq!(
+            payload_lyrics_language_override(&json!({"language_override": " PT "})).unwrap(),
+            Some("pt".to_string())
+        );
+        assert_eq!(
+            payload_lyrics_language_override(&json!({"language_override": "zh"})).unwrap(),
+            Some("zh".to_string())
+        );
+    }
+
+    #[test]
+    fn mobile_lyrics_language_override_rejects_bad_values() {
+        assert!(
+            payload_lyrics_language_override(&json!({"language_override": "ru"}))
+                .unwrap_err()
+                .contains("language_override must be null or one of")
+        );
+        assert!(
+            payload_lyrics_language_override(&json!({"language_override": 7}))
+                .unwrap_err()
+                .contains("language_override must be a string or null")
+        );
+    }
+
+    #[test]
+    fn mobile_lyrics_none_override_uses_instrumental_contract_metadata() {
+        let (backend, source_kind, requested_device, device, model_name) =
+            no_lyrics_transcript_metadata();
+
+        assert_eq!(backend, "none");
+        assert_eq!(source_kind, "instrumental");
+        assert_eq!(requested_device, None);
+        assert_eq!(device, None);
+        assert_eq!(model_name, None);
+    }
+
+    #[test]
     fn mobile_sync_defaults_match_local_project_contract() {
-        assert_eq!(MOBILE_DB_VERSION, 2);
+        assert_eq!(MOBILE_DB_VERSION, 3);
         assert!(sync_editable(DEFAULT_SYNC_STATUS));
         assert!(!sync_editable("remote_available"));
         assert!(!sync_editable("conflicted"));

--- a/apps/desktop/src/App.project-analysis-mix.test.tsx
+++ b/apps/desktop/src/App.project-analysis-mix.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LyricsResponse } from "./lib/api";
 import {
   resetAppTestHarness,
   findAudioByArtifactId,
@@ -18,6 +19,7 @@ import {
   mockCreateTabImport,
   mockDeleteProject,
   mockCreateExport,
+  mockGetLyrics,
   mockUpdateLyrics,
   mockUpdateProject,
   renderApp,
@@ -350,7 +352,147 @@ describe("Desktop app project analysis mix", () => {
     await openStudioPanel(user);
     await user.click(screen.getByRole("button", { name: "Generate Lyrics" }));
 
-    expect(mockCreateLyrics).toHaveBeenCalledWith("proj_123", { force: false });
+    expect(mockCreateLyrics).toHaveBeenCalledWith("proj_123", {
+      force: false,
+      language_override: null,
+    });
+  });
+
+  it("generates lyrics with a selected Portuguese override", async () => {
+    const user = userEvent.setup();
+    setProjectLyrics("proj_123", {
+      project_id: "proj_123",
+      backend: null,
+      source_artifact_id: null,
+      source_kind: null,
+      source_segments: [],
+      segments: [],
+      has_user_edits: false,
+      created_at: null,
+      updated_at: null,
+    });
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openStudioPanel(user);
+    await user.selectOptions(screen.getByLabelText("Lyrics language"), "pt");
+    await user.click(screen.getByRole("button", { name: "Generate Lyrics" }));
+
+    expect(mockCreateLyrics).toHaveBeenCalledWith("proj_123", {
+      force: false,
+      language_override: "pt",
+    });
+  });
+
+  it("marks an existing transcript as instrumental without running lyrics", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openStudioPanel(user);
+    await user.selectOptions(screen.getByLabelText("Lyrics language"), "none");
+    await user.click(screen.getByRole("button", { name: "Clear Lyrics" }));
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      "Clear lyrics? This removes the current transcript and marks the project as having no lyrics.",
+      expect.objectContaining({
+        title: "Clear lyrics",
+        kind: "warning",
+      }),
+    );
+    expect(mockCreateLyrics).toHaveBeenCalledWith("proj_123", {
+      force: true,
+      language_override: "none",
+    });
+  });
+
+  it("keeps a manual lyrics override when the initial lyrics query settles later", async () => {
+    const user = userEvent.setup();
+    let resolveLyrics: (lyrics: LyricsResponse) => void = () => {};
+    mockGetLyrics.mockImplementationOnce(
+      () =>
+        new Promise<LyricsResponse>((resolve) => {
+          resolveLyrics = resolve;
+        }),
+    );
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openStudioPanel(user);
+    await user.selectOptions(screen.getByLabelText("Lyrics language"), "pt");
+
+    await act(async () => {
+      resolveLyrics({
+        project_id: "proj_123",
+        backend: null,
+        source_artifact_id: null,
+        source_kind: null,
+        language_override: null,
+        source_segments: [],
+        segments: [],
+        has_user_edits: false,
+        created_at: null,
+        updated_at: null,
+      });
+    });
+
+    await waitFor(() => expect(screen.getByLabelText("Lyrics language")).toHaveValue("pt"));
+    await user.click(screen.getByRole("button", { name: "Generate Lyrics" }));
+
+    expect(mockCreateLyrics).toHaveBeenCalledWith("proj_123", {
+      force: false,
+      language_override: "pt",
+    });
+  });
+
+  it("shows effective lyrics language metadata", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openStudioPanel(user);
+
+    expect(screen.getByText("Language: English")).toBeInTheDocument();
+  });
+
+  it("shows lyrics override metadata when effective language differs", async () => {
+    const user = userEvent.setup();
+    setProjectLyrics("proj_123", {
+      project_id: "proj_123",
+      backend: "openai-whisper",
+      source_artifact_id: "art_source",
+      source_kind: "ai",
+      language: "en",
+      language_override: "pt",
+      source_segments: [
+        {
+          start_seconds: 0,
+          end_seconds: 8,
+          text: "Original lyric line",
+          words: [],
+        },
+      ],
+      segments: [
+        {
+          start_seconds: 0,
+          end_seconds: 8,
+          text: "Original lyric line",
+          words: [],
+        },
+      ],
+      has_user_edits: false,
+      created_at: "2026-04-18T13:16:00.000Z",
+      updated_at: "2026-04-18T13:16:00.000Z",
+    });
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openStudioPanel(user);
+
+    expect(screen.getByText("Override: Portuguese (effective English)")).toBeInTheDocument();
   });
 
   it("renders active lyrics and saves in-app edits", async () => {
@@ -657,6 +799,56 @@ describe("Desktop app project analysis mix", () => {
     expect(secondChord).toHaveAttribute("aria-pressed", "true");
   });
 
+  it("refreshes lyrics with the persisted language override", async () => {
+    const user = userEvent.setup();
+    setProjectLyrics("proj_123", {
+      project_id: "proj_123",
+      backend: "openai-whisper",
+      source_artifact_id: "art_source",
+      source_kind: "ai",
+      language: "pt",
+      language_override: "pt",
+      source_segments: [
+        {
+          start_seconds: 0,
+          end_seconds: 8,
+          text: "Linha original",
+          words: [],
+        },
+      ],
+      segments: [
+        {
+          start_seconds: 0,
+          end_seconds: 8,
+          text: "Linha original",
+          words: [],
+        },
+      ],
+      has_user_edits: false,
+      created_at: "2026-04-18T13:16:00.000Z",
+      updated_at: "2026-04-18T13:16:00.000Z",
+    });
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openStudioPanel(user);
+    await waitFor(() => expect(screen.getByLabelText("Lyrics language")).toHaveValue("pt"));
+    await user.click(screen.getByRole("button", { name: "Refresh Lyrics" }));
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      "Refresh lyrics? This replaces the current transcript with a new pass and clears the current tab import.",
+      expect.objectContaining({
+        title: "Refresh lyrics",
+        kind: "warning",
+      }),
+    );
+    expect(mockCreateLyrics).toHaveBeenCalledWith("proj_123", {
+      force: true,
+      language_override: "pt",
+    });
+  });
+
   it("refreshes edited lyrics with confirmation", async () => {
     const user = userEvent.setup();
     setProjectLyrics("proj_123", {
@@ -689,6 +881,7 @@ describe("Desktop app project analysis mix", () => {
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
     await openStudioPanel(user);
+    await user.selectOptions(screen.getByLabelText("Lyrics language"), "pt");
     await user.click(screen.getByRole("button", { name: "Refresh Lyrics" }));
 
     expect(mockConfirm).toHaveBeenCalledWith(
@@ -698,7 +891,10 @@ describe("Desktop app project analysis mix", () => {
         kind: "warning",
       }),
     );
-    expect(mockCreateLyrics).toHaveBeenCalledWith("proj_123", { force: true });
+    expect(mockCreateLyrics).toHaveBeenCalledWith("proj_123", {
+      force: true,
+      language_override: "pt",
+    });
   });
 
   it("refreshes edited chords with confirmation", async () => {

--- a/apps/desktop/src/features/projects/components/ProcessingPanel.tsx
+++ b/apps/desktop/src/features/projects/components/ProcessingPanel.tsx
@@ -1,3 +1,4 @@
+import type { ChangeEvent } from "react";
 import { useProjectViewModelContext } from "./useProjectViewModelContext";
 
 export function ProcessingPanel() {
@@ -20,17 +21,27 @@ export function ProcessingPanel() {
     isLyricsRunning,
     isMobileRuntime,
     isStemRunning,
+    lyricsLanguageMetadata,
+    lyricsLanguageOptions,
     lyricsMutation,
     mobileGenerationMessage,
     projectEditLocked,
     projectSyncLockReason,
+    selectedLyricsLanguageOverride,
+    setSelectedLyricsLanguageOverride,
     selectedPrimaryArtifactId,
     showSupportingCopy,
     stemMutation,
   } = useProjectViewModelContext();
 
   const analyzeDisabled = projectEditLocked || analyzeMutation.isPending || isAnalysisRunning || !canAnalyze;
-  const lyricsDisabled = lyricsMutation.isPending || isLyricsRunning || !canGenerateLyrics;
+  const noLyricsSelected = selectedLyricsLanguageOverride === "none";
+  const lyricsDisabled =
+    projectEditLocked ||
+    lyricsMutation.isPending ||
+    isLyricsRunning ||
+    (!canGenerateLyrics && !noLyricsSelected);
+  const lyricsSelectorDisabled = projectEditLocked || lyricsMutation.isPending || isLyricsRunning;
   const chordsDisabled = chordMutation.isPending || isChordRunning || !canGenerateChords;
   const stemsDisabled =
     projectEditLocked ||
@@ -39,6 +50,27 @@ export function ProcessingPanel() {
     !selectedPrimaryArtifactId ||
     !canGenerateStems;
   const editLockTitle = projectSyncLockReason ?? undefined;
+  const selectedLyricsLanguageValue = selectedLyricsLanguageOverride ?? "auto";
+  const lyricsActionLabel =
+    lyricsMutation.isPending || isLyricsRunning
+      ? noLyricsSelected
+        ? "Clearing..."
+        : "Generating..."
+      : noLyricsSelected
+        ? hasLyricsTranscript
+          ? "Clear Lyrics"
+          : "Mark Instrumental"
+        : hasLyricsTranscript
+          ? "Refresh Lyrics"
+          : "Generate Lyrics";
+
+  function handleLyricsLanguageChange(event: ChangeEvent<HTMLSelectElement>) {
+    const nextValue = event.target.value;
+    const nextOption = lyricsLanguageOptions.find(
+      (option) => (option.value ?? "auto") === nextValue,
+    );
+    setSelectedLyricsLanguageOverride(nextOption?.value ?? null);
+  }
 
   return (
     <div className="panel processing-panel">
@@ -78,19 +110,35 @@ export function ProcessingPanel() {
               ? "Refresh Chords"
               : "Generate Chords"}
         </button>
-        <button
-          className="button button--small"
-          disabled={lyricsDisabled}
-          onClick={() => void handleLyricsAction()}
-          title={editLockTitle}
-          type="button"
-        >
-          {lyricsMutation.isPending || isLyricsRunning
-            ? "Generating..."
-            : hasLyricsTranscript
-              ? "Refresh Lyrics"
-              : "Generate Lyrics"}
-        </button>
+        <div className="processing-panel__lyrics-actions" role="group" aria-label="Lyrics generation">
+          <button
+            className="button button--small"
+            disabled={lyricsDisabled}
+            onClick={() => void handleLyricsAction()}
+            title={editLockTitle}
+            type="button"
+          >
+            {lyricsActionLabel}
+          </button>
+          <label className="processing-panel__lyrics-language">
+            <select
+              aria-label="Lyrics language"
+              disabled={lyricsSelectorDisabled}
+              onChange={handleLyricsLanguageChange}
+              title={editLockTitle}
+              value={selectedLyricsLanguageValue}
+            >
+              {lyricsLanguageOptions.map((option) => (
+                <option key={option.value ?? "auto"} value={option.value ?? "auto"}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          {lyricsLanguageMetadata ? (
+            <span className="processing-panel__lyrics-meta">{lyricsLanguageMetadata}</span>
+          ) : null}
+        </div>
         <button
           className="button button--small"
           disabled={stemsDisabled}

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -7,6 +7,8 @@ import {
   getProjectSyncSummary,
   type ArtifactSchema,
   type JobSchema,
+  type LyricsGenerateRequest,
+  type LyricsResponse,
   type ProjectSchema,
 } from "../../../lib/api";
 import { usePreferences } from "../../../lib/preferences";
@@ -95,6 +97,35 @@ type DeleteArtifactsRequest = {
   nextSelectedPrimaryArtifactId?: string | null;
   stemArtifactIds?: string[];
 };
+type LyricsLanguageOverride = Exclude<LyricsGenerateRequest["language_override"], undefined>;
+type LyricsLanguageOption = {
+  label: string;
+  value: LyricsLanguageOverride;
+};
+type LyricsMutationVariables = {
+  force: boolean;
+  languageOverride: LyricsLanguageOverride;
+};
+
+const LYRICS_LANGUAGE_OPTIONS = [
+  { label: "Auto-detect", value: null },
+  { label: "No lyrics", value: "none" },
+  { label: "English", value: "en" },
+  { label: "Portuguese", value: "pt" },
+  { label: "Spanish", value: "es" },
+  { label: "French", value: "fr" },
+  { label: "German", value: "de" },
+  { label: "Italian", value: "it" },
+  { label: "Japanese", value: "ja" },
+  { label: "Korean", value: "ko" },
+  { label: "Chinese", value: "zh" },
+  { label: "Hindi", value: "hi" },
+] satisfies readonly LyricsLanguageOption[];
+const LYRICS_LANGUAGE_LABELS = new Map<string, string>(
+  LYRICS_LANGUAGE_OPTIONS.flatMap((option) =>
+    option.value === null ? [] : [[option.value, option.label] as const],
+  ),
+);
 
 function getNextJobsPageOffset(lastPage: { has_more: boolean; offset: number; jobs: JobSchema[] }) {
   return lastPage.has_more ? lastPage.offset + lastPage.jobs.length : undefined;
@@ -104,6 +135,28 @@ function uniqueJobsById(jobs: JobSchema[]) {
   const jobsById = new Map<string, JobSchema>();
   jobs.forEach((job) => jobsById.set(job.id, job));
   return Array.from(jobsById.values());
+}
+
+function lyricsLanguageLabel(language: string | null | undefined) {
+  if (!language) {
+    return null;
+  }
+  return LYRICS_LANGUAGE_LABELS.get(language) ?? language.toUpperCase();
+}
+
+function formatLyricsLanguageMetadata(lyrics: LyricsResponse | undefined) {
+  if (lyrics?.language_override === "none") {
+    return "No lyrics";
+  }
+  const overrideLabel = lyricsLanguageLabel(lyrics?.language_override);
+  const effectiveLabel = lyricsLanguageLabel(lyrics?.language);
+  if (overrideLabel) {
+    if (effectiveLabel && effectiveLabel !== overrideLabel) {
+      return `Override: ${overrideLabel} (effective ${effectiveLabel})`;
+    }
+    return `Override: ${overrideLabel}`;
+  }
+  return effectiveLabel ? `Language: ${effectiveLabel}` : null;
 }
 
 function resolveDefaultPlaybackDisplayMode(
@@ -250,6 +303,10 @@ export function useProjectViewModel() {
   const [dismissedStemJobIds, setDismissedStemJobIds] = useState<string[]>([]);
   const [isEditingLyrics, setIsEditingLyrics] = useState(false);
   const [lyricsDraft, setLyricsDraft] = useState<string[]>([]);
+  const [selectedLyricsLanguageOverride, setSelectedLyricsLanguageOverride] =
+    useState<LyricsLanguageOverride>(null);
+  const lyricsLanguageOverrideSeededProjectId = useRef<string | null>(null);
+  const lyricsLanguageOverrideDirtyProjectId = useRef<string | null>(null);
   const [isTabImportOpen, setIsTabImportOpen] = useState(false);
   const [tabImportDraft, setTabImportDraft] = useState("");
   const [acceptedTabSuggestionIds, setAcceptedTabSuggestionIds] = useState<string[]>([]);
@@ -422,9 +479,13 @@ export function useProjectViewModel() {
   });
 
   const lyricsMutation = useMutation({
-    mutationFn: async (force: boolean) => {
+    mutationFn: async ({ force, languageOverride }: LyricsMutationVariables) => {
       assertProjectEditable();
-      return api.createLyrics(projectId, { force });
+      const request: LyricsGenerateRequest = {
+        force,
+        language_override: languageOverride,
+      };
+      return api.createLyrics(projectId, request);
     },
     onSuccess: async () => {
       setIsEditingLyrics(false);
@@ -891,6 +952,7 @@ export function useProjectViewModel() {
   );
   const hasLyricsTranscript = displayedLyrics.length > 0;
   const hasTimedLyricsTranscript = displayedLyrics.some((segment) => hasTimedLyrics(segment));
+  const lyricsLanguageMetadata = formatLyricsLanguageMetadata(lyricsQuery.data);
   const activeLyricsIndex = findActiveLyricsIndex(displayedLyrics, playbackTimeSeconds);
   const activeLyricsSegment =
     activeLyricsIndex >= 0 ? displayedLyrics[activeLyricsIndex] : null;
@@ -1271,10 +1333,34 @@ export function useProjectViewModel() {
     if (projectEditLocked) {
       return;
     }
-    if (!canGenerateLyrics) {
+    const skipsLyricsGeneration = selectedLyricsLanguageOverride === "none";
+    if (!canGenerateLyrics && !skipsLyricsGeneration) {
       return;
     }
     const hasExistingLyrics = (lyricsQuery.data?.segments?.length ?? 0) > 0;
+    if (skipsLyricsGeneration) {
+      if (hasExistingLyrics) {
+        const approved = await confirm(
+          "Clear lyrics? This removes the current transcript and marks the project as having no lyrics.",
+          {
+            title: "Clear lyrics",
+            kind: "warning",
+            okLabel: "Clear Lyrics",
+            cancelLabel: "Cancel",
+          },
+        );
+        if (!approved) {
+          return;
+        }
+      }
+
+      lyricsMutation.mutate({
+        force: hasExistingLyrics,
+        languageOverride: selectedLyricsLanguageOverride,
+      });
+      return;
+    }
+
     if (hasExistingLyrics) {
       const approved = await confirm(
         lyricsQuery.data?.has_user_edits
@@ -1292,7 +1378,15 @@ export function useProjectViewModel() {
       }
     }
 
-    lyricsMutation.mutate(hasExistingLyrics);
+    lyricsMutation.mutate({
+      force: hasExistingLyrics,
+      languageOverride: selectedLyricsLanguageOverride,
+    });
+  }
+
+  function handleSelectedLyricsLanguageOverride(languageOverride: LyricsLanguageOverride) {
+    lyricsLanguageOverrideDirtyProjectId.current = projectId;
+    setSelectedLyricsLanguageOverride(languageOverride);
   }
 
   async function handleStemAction() {
@@ -1687,6 +1781,9 @@ export function useProjectViewModel() {
     setLoopAlignmentModeOverride(storedPlaybackState.loopAlignmentMode);
     setPendingLoopStartSeconds(null);
     setLoopStatusMessage(null);
+    lyricsLanguageOverrideSeededProjectId.current = null;
+    lyricsLanguageOverrideDirtyProjectId.current = null;
+    setSelectedLyricsLanguageOverride(null);
     setPlaybackDisplayModeSource(hasStoredPlayback ? "stored" : "default");
     setLyricsFollowEnabled(
       hasStoredPlayback
@@ -1708,6 +1805,19 @@ export function useProjectViewModel() {
     defaultProjectWorkspace,
     projectId,
   ]);
+
+  useEffect(() => {
+    if (
+      !lyricsQuery.isSuccess ||
+      lyricsLanguageOverrideDirtyProjectId.current === projectId ||
+      lyricsLanguageOverrideSeededProjectId.current === projectId
+    ) {
+      return;
+    }
+
+    setSelectedLyricsLanguageOverride(lyricsQuery.data?.language_override ?? null);
+    lyricsLanguageOverrideSeededProjectId.current = projectId;
+  }, [lyricsQuery.data?.language_override, lyricsQuery.isSuccess, projectId]);
 
   useEffect(() => {
     if (
@@ -2256,6 +2366,8 @@ export function useProjectViewModel() {
     mobileCapabilities,
     mobileGenerationMessage,
     lyricsFollowEnabled,
+    lyricsLanguageMetadata,
+    lyricsLanguageOptions: LYRICS_LANGUAGE_OPTIONS,
     lyricsDraft,
     lyricsJob,
     lyricsMutation,
@@ -2291,6 +2403,7 @@ export function useProjectViewModel() {
     selectedArtifactId,
     selectedTabSuggestionId,
     selectedArtifactTimestamp,
+    selectedLyricsLanguageOverride,
     selectedPlaybackArtifact,
     selectedPrimaryArtifact,
     selectedPrimaryArtifactId,
@@ -2311,6 +2424,7 @@ export function useProjectViewModel() {
     setTargetSelectorOpen,
     setTargetTransposeSemitones,
     setLyricsDraft,
+    setSelectedLyricsLanguageOverride: handleSelectedLyricsLanguageOverride,
     setSelectedTabSuggestionId,
     setTabImportDraft,
     showSupportingCopy,

--- a/apps/desktop/src/styles/project-layout.css
+++ b/apps/desktop/src/styles/project-layout.css
@@ -144,9 +144,56 @@
 }
 
 .processing-panel__actions {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(8.75rem, max-content));
+  align-items: start;
   gap: 0.65rem;
+}
+
+.processing-panel__lyrics-actions {
+  display: flex;
+  min-width: 10.5rem;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.42rem;
+}
+
+.processing-panel__lyrics-language {
+  display: flex;
+}
+
+.processing-panel__lyrics-language select {
+  width: 100%;
+  min-height: 2.3rem;
+  border: 1px solid var(--input-border);
+  border-radius: 999px;
+  padding: 0.45rem 0.65rem;
+  background: var(--input-bg);
+  color: var(--input-text);
+  font-weight: 700;
+}
+
+.processing-panel__lyrics-language select:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+.processing-panel__lyrics-language select:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.processing-panel__lyrics-meta {
+  align-self: flex-start;
+  max-width: 14rem;
+  border: 1px solid var(--chip-border);
+  border-radius: 999px;
+  padding: 0.35rem 0.62rem;
+  background: var(--chip-bg);
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1.1;
 }
 
 .stack,

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -6,6 +6,7 @@ import App from "../App";
 import type {
   BulkJobRequest,
   BulkJobsResponse,
+  LyricsGenerateRequest,
   ListJobsParams,
   ListProjectsParams,
   SyncPairingAnswerRequest,
@@ -262,7 +263,11 @@ const {
     };
   }
 
-  function makeLyricsTranscript(projectId: string) {
+  function makeLyricsTranscript(
+    projectId: string,
+    languageOverride: LyricsGenerateRequest["language_override"] = null,
+  ) {
+    const hasNoLyrics = languageOverride === "none";
     const segments = [
       {
         start_seconds: 0,
@@ -292,11 +297,13 @@ const {
 
     return {
       project_id: projectId,
-      backend: "openai-whisper",
+      backend: hasNoLyrics ? "none" : "openai-whisper",
       source_artifact_id: "art_source",
-      source_kind: "ai",
-      source_segments: clone(segments),
-      segments: clone(segments),
+      source_kind: hasNoLyrics ? "instrumental" : "ai",
+      language: hasNoLyrics ? null : languageOverride ?? "en",
+      language_override: languageOverride,
+      source_segments: hasNoLyrics ? [] : clone(segments),
+      segments: hasNoLyrics ? [] : clone(segments),
       has_user_edits: false,
       created_at: createdAt,
       updated_at: createdAt,
@@ -1671,9 +1678,11 @@ const {
     state.jobs.unshift(job);
     return { job: clone(job) };
   });
-  const mockCreateLyrics = vi.fn(async (projectId: string, body?: { force?: boolean }) => {
-    void body;
-    state.lyricsByProject[projectId] = makeLyricsTranscript(projectId);
+  const mockCreateLyrics = vi.fn(async (projectId: string, body?: LyricsGenerateRequest) => {
+    state.lyricsByProject[projectId] = makeLyricsTranscript(
+      projectId,
+      body?.language_override ?? null,
+    );
     const job = makeMockJob({
       project_id: projectId,
       type: "lyrics",

--- a/docs/API.md
+++ b/docs/API.md
@@ -558,6 +558,7 @@ Queues local lyrics generation.
 Request fields:
 
 - `force`
+- `language_override` (optional): `null` or omitted uses Whisper auto-detection. Supported overrides are `none`, `en`, `pt`, `es`, `fr`, `de`, `it`, `ja`, `ko`, `zh`, and `hi`. `none` marks the project as having no lyrics and does not run Whisper.
 
 Response: `JobResponse`.
 
@@ -565,7 +566,7 @@ Response: `JobResponse`.
 
 `GET /api/v1/projects/{project_id}/lyrics`
 
-Returns source transcript segments, current edited segments, backend, source artifact, model/device metadata, language, user-edit state, and timestamps. If no lyrics exist, the response contains empty segment lists.
+Returns source transcript segments, current edited segments, backend, source artifact, model/device metadata, effective language, language override, user-edit state, and timestamps. If no lyrics exist, the response contains empty segment lists.
 
 Lyrics segments are unpaginated project document payloads. Source and edited segments stay complete so lyric editing
 and playback highlighting do not depend on lazy-loaded fragments.

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -44,6 +44,8 @@ Side-load a Whisper model to enable local lyrics. Stem generation is unavailable
 
 Debug Android emulator builds may set `generationTestingAvailable` so the lyrics action can submit jobs during UI flow testing. This does not report Whisper or stem separation as available. Once a Whisper model is side-loaded, lyrics use the real local transcription path; stems stay disabled and still fail closed if invoked directly.
 
+Lyrics generation accepts the same nullable `language_override` payload as desktop. `null`, omission, or blank text keeps Whisper language detection on auto. Mobile validates explicit overrides against `none`, `en`, `pt`, `es`, `fr`, `de`, `it`, `ja`, `ko`, `zh`, and `hi`. `none` records an empty lyrics transcript without running `whisper.cpp`; other explicit codes are passed to `whisper.cpp`.
+
 For local lyrics testing, side-load one of these files before launching the app:
 
 ```sh

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -1109,6 +1109,8 @@ export interface components {
              * @default false
              */
             force?: boolean;
+            /** Language Override */
+            language_override?: ("none" | "en" | "pt" | "es" | "fr" | "de" | "it" | "ja" | "ko" | "zh" | "hi") | null;
         };
         /** LyricsResponse */
         LyricsResponse: {
@@ -1128,6 +1130,8 @@ export interface components {
             model_name?: string | null;
             /** Language */
             language?: string | null;
+            /** Language Override */
+            language_override?: ("none" | "en" | "pt" | "es" | "fr" | "de" | "it" | "ja" | "ko" | "zh" | "hi") | null;
             /** Source Segments */
             source_segments?: components["schemas"]["LyricsSegmentSchema"][];
             /** Segments */


### PR DESCRIPTION
## Summary

- Add lyrics transcription language override with curated language choices and Whisper auto-detect default.
- Add a no-lyrics option for instrumental tracks that clears/stores empty instrumental transcripts without running Whisper.
- Persist override metadata across backend, sync manifests, desktop UI, generated contracts, and mobile/Tauri parity.
- Fixes #195.

## Testing

- `cd apps/backend && uv run --python 3.11 pytest tests/test_lyrics_engine.py tests/test_lyrics_flow.py tests/test_sync_revisions.py tests/test_sync_manifest.py tests/test_db_migrations.py -q`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `pnpm --filter @tuneforge/desktop test -- App.project-analysis-mix.test.tsx App.mobile.test.tsx`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `cd apps/desktop/src-tauri && cargo check`
- `cd apps/desktop/src-tauri && cargo test mobile_lyrics -- --nocapture`
- `pnpm contracts:generate`
