### PR TITLE
feat: add correctable timing grid

### DIFF
--- a/apps/backend/app/api/routes/projects.py
+++ b/apps/backend/app/api/routes/projects.py
@@ -12,6 +12,8 @@ from app.schemas import (
     AnalysisRequest,
     AnalysisResponse,
     AnalysisSchema,
+    AnalysisTimingCorrectionRequest,
+    AnalysisTimingCorrectionResponse,
     ArtifactSchema,
     ArtifactsResponse,
     ChordRequest,
@@ -41,6 +43,7 @@ from app.schemas import (
     TabImportSchema,
     TransposeRequest,
 )
+from app.services.analysis import correct_analysis_timing
 from app.services.artifacts import delete_project_artifact
 from app.services.chord_backends import FAST_CHORD_BACKEND_ID, ChordDetectionBackend, resolve_chord_backend
 from app.services.jobs import create_project_activity_job
@@ -225,6 +228,23 @@ def project_analysis(project_id: str, session: Session = Depends(get_db)) -> Ana
     get_project(session, project_id)
     analysis = session.get(AnalysisResult, project_id)
     return AnalysisResponse(analysis=AnalysisSchema.model_validate(analysis) if analysis else None)
+
+
+@router.patch("/{project_id}/analysis/timing", response_model=AnalysisTimingCorrectionResponse)
+def project_analysis_timing_update(
+    project_id: str,
+    payload: AnalysisTimingCorrectionRequest,
+    session: Session = Depends(get_db),
+) -> AnalysisTimingCorrectionResponse:
+    project = get_mutable_project(session, project_id)
+    analysis = correct_analysis_timing(
+        session,
+        project=project,
+        action=payload.action,
+        playhead_seconds=payload.playhead_seconds,
+        beats_per_bar=payload.beats_per_bar,
+    )
+    return AnalysisTimingCorrectionResponse(analysis=AnalysisSchema.model_validate(analysis))
 
 
 @router.post("/{project_id}/chords", response_model=JobResponse)

--- a/apps/backend/app/engines/analysis.py
+++ b/apps/backend/app/engines/analysis.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
-from typing import TypedDict
+from typing import NamedTuple, TypedDict
 
 import numpy as np
 
@@ -9,6 +10,15 @@ from app.engines.audio_features import HarmonicFeatures, active_chroma_mean, ext
 from app.engines.chords import ChordSegment, detect_chords_from_features
 
 BEATS_PER_BAR = 4
+DEFAULT_METER = "4/4"
+METER_CANDIDATES: tuple[tuple[str, int], ...] = (("3/4", 3), (DEFAULT_METER, 4), ("6/8", 6))
+MIN_METER_CANDIDATE_BARS = 3
+MIN_METER_CANDIDATE_BEATS = BEATS_PER_BAR * 2
+METER_MIN_SCORE = 0.38
+METER_MIN_CONFIDENCE = 0.52
+METER_MIN_SWITCH_MARGIN = 0.06
+METER_DEFAULT_CONFIDENCE = 0.0
+SIX_EIGHT_COMPOUND_WEIGHT = 0.28
 MIN_DOWNBEAT_INFERENCE_BEATS = BEATS_PER_BAR * 2
 DOWNBEAT_PROXIMITY_BEAT_FRACTION = 0.28
 MIN_DOWNBEAT_PROXIMITY_SECONDS = 0.08
@@ -92,6 +102,10 @@ class AnalysisTimingBarPayload(TypedDict):
 class AnalysisTimingPayload(TypedDict):
     beats_per_bar: int
     source: str
+    meter: str
+    meter_confidence: float
+    downbeat_source: str
+    downbeat_confidence: float
     beats: list[AnalysisTimingBeatPayload]
     bars: list[AnalysisTimingBarPayload]
 
@@ -108,7 +122,21 @@ class AnalysisPayload(TypedDict):
 SparseBridgeRelockCandidate = tuple[int, float, int, float, float]
 
 
-def analyze_track(source_path: Path) -> AnalysisPayload:
+class _TimingInference(NamedTuple):
+    meter: str
+    beats_per_bar: int
+    meter_confidence: float
+    downbeat_offset: int
+    downbeat_source: str
+    downbeat_confidence: float
+    meter_score: float
+
+
+def analyze_track(
+    source_path: Path,
+    *,
+    source_stem_paths: Sequence[Path] | None = None,
+) -> AnalysisPayload:
     features = extract_harmonic_features(source_path)
     if features.signal.size == 0:
         return {
@@ -120,6 +148,7 @@ def analyze_track(source_path: Path) -> AnalysisPayload:
             "timing": None,
         }
 
+    source_stem_features = _extract_source_stem_features(source_stem_paths)
     chord_timeline = detect_chords_from_features(features)
     estimated_key, key_confidence = _estimate_key(features, chord_timeline)
     return {
@@ -128,13 +157,33 @@ def analyze_track(source_path: Path) -> AnalysisPayload:
         "estimated_reference_hz": features.estimated_reference_hz,
         "tuning_offset_cents": features.tuning_offset_cents,
         "tempo_bpm": features.tempo_bpm,
-        "timing": _build_timing_payload(features, chord_timeline),
+        "timing": _build_timing_payload(
+            features,
+            chord_timeline,
+            source_stem_features=source_stem_features,
+        ),
     }
+
+
+def _extract_source_stem_features(
+    source_stem_paths: Sequence[Path] | None,
+) -> tuple[HarmonicFeatures, ...]:
+    if not source_stem_paths:
+        return ()
+
+    stem_features: list[HarmonicFeatures] = []
+    for stem_path in source_stem_paths:
+        features = extract_harmonic_features(stem_path)
+        if features.signal.size > 0:
+            stem_features.append(features)
+    return tuple(stem_features)
 
 
 def _build_timing_payload(
     features: HarmonicFeatures,
     chord_timeline: list[ChordSegment],
+    *,
+    source_stem_features: Sequence[HarmonicFeatures] = (),
 ) -> AnalysisTimingPayload | None:
     if features.duration_seconds <= 0.0:
         return None
@@ -147,15 +196,29 @@ def _build_timing_payload(
     if beat_times.size < 2:
         return None
 
-    downbeat_offset = (
-        _infer_downbeat_offset(features, beat_times, chord_timeline) if source == "detected" else 0
+    timing_inference = (
+        _infer_timing_metadata(
+            features,
+            beat_times,
+            chord_timeline,
+            source_stem_features=source_stem_features,
+        )
+        if source == "detected"
+        else _default_timing_inference(downbeat_source=source)
     )
     beats: list[AnalysisTimingBeatPayload] = [
         {
             "index": index,
             "seconds": round(float(seconds), 6),
-            "bar_index": _timing_beat_bar_index(index, downbeat_offset),
-            "beat_in_bar": ((index - downbeat_offset) % BEATS_PER_BAR) + 1,
+            "bar_index": _timing_beat_bar_index(
+                index,
+                timing_inference.downbeat_offset,
+                timing_inference.beats_per_bar,
+            ),
+            "beat_in_bar": (
+                (index - timing_inference.downbeat_offset) % timing_inference.beats_per_bar
+            )
+            + 1,
         }
         for index, seconds in enumerate(beat_times.tolist())
     ]
@@ -163,8 +226,12 @@ def _build_timing_payload(
     if not bars:
         return None
     payload: AnalysisTimingPayload = {
-        "beats_per_bar": BEATS_PER_BAR,
+        "beats_per_bar": timing_inference.beats_per_bar,
         "source": source,
+        "meter": timing_inference.meter,
+        "meter_confidence": timing_inference.meter_confidence,
+        "downbeat_source": timing_inference.downbeat_source,
+        "downbeat_confidence": timing_inference.downbeat_confidence,
         "beats": beats,
         "bars": bars,
     }
@@ -1173,12 +1240,12 @@ def _projected_grid_step_count(
     return max(1, int(round(last_candidate_delta / reference_seconds)))
 
 
-def _timing_beat_bar_index(index: int, downbeat_offset: int) -> int:
+def _timing_beat_bar_index(index: int, downbeat_offset: int, beats_per_bar: int) -> int:
     if downbeat_offset <= 0:
-        return index // BEATS_PER_BAR
+        return index // beats_per_bar
     if index < downbeat_offset:
         return 0
-    return 1 + ((index - downbeat_offset) // BEATS_PER_BAR)
+    return 1 + ((index - downbeat_offset) // beats_per_bar)
 
 
 def _infer_downbeat_offset(
@@ -1186,31 +1253,206 @@ def _infer_downbeat_offset(
     beat_times: np.ndarray,
     chord_timeline: list[ChordSegment],
 ) -> int:
-    if beat_times.size < MIN_DOWNBEAT_INFERENCE_BEATS:
-        return 0
+    return _infer_timing_metadata(features, beat_times, chord_timeline).downbeat_offset
+
+
+def _infer_timing_metadata(
+    features: HarmonicFeatures,
+    beat_times: np.ndarray,
+    chord_timeline: list[ChordSegment],
+    *,
+    source_stem_features: Sequence[HarmonicFeatures] = (),
+) -> _TimingInference:
+    if beat_times.size < MIN_METER_CANDIDATE_BEATS:
+        return _default_timing_inference()
 
     beat_interval = _median_beat_interval(beat_times)
     if beat_interval <= 0.0:
-        return 0
+        return _default_timing_inference()
 
     proximity_seconds = _downbeat_proximity_seconds(beat_interval)
-    chord_scores = _downbeat_chord_scores(beat_times, chord_timeline, proximity_seconds)
-    accent_scores = _downbeat_accent_scores(features, beat_times, beat_interval)
+    candidates = [
+        candidate
+        for meter, beats_per_bar in METER_CANDIDATES
+        if (
+            candidate := _timing_meter_candidate(
+                meter,
+                beats_per_bar,
+                features,
+                beat_times,
+                chord_timeline,
+                proximity_seconds=proximity_seconds,
+                beat_interval=beat_interval,
+                source_stem_features=source_stem_features,
+            )
+        )
+        is not None
+    ]
+    if not candidates:
+        return _default_timing_inference()
+
+    return _select_timing_inference(candidates)
+
+
+def _timing_meter_candidate(
+    meter: str,
+    beats_per_bar: int,
+    features: HarmonicFeatures,
+    beat_times: np.ndarray,
+    chord_timeline: list[ChordSegment],
+    *,
+    proximity_seconds: float,
+    beat_interval: float,
+    source_stem_features: Sequence[HarmonicFeatures],
+) -> _TimingInference | None:
+    min_bars = 2 if meter == DEFAULT_METER else MIN_METER_CANDIDATE_BARS
+    if beat_times.size < max(MIN_METER_CANDIDATE_BEATS, beats_per_bar * min_bars):
+        return None
+
+    chord_scores = _downbeat_chord_scores(
+        beat_times,
+        chord_timeline,
+        proximity_seconds,
+        beats_per_bar,
+    )
+    source_accent_scores = _downbeat_accent_scores(
+        features,
+        beat_times,
+        beat_interval,
+        beats_per_bar,
+    )
+    stem_accent_scores = _source_stem_downbeat_accent_scores(
+        source_stem_features,
+        beat_times,
+        beat_interval,
+        beats_per_bar,
+    )
+    accent_scores = np.maximum(source_accent_scores, stem_accent_scores)
     scores = DOWNBEAT_CHORD_WEIGHT * chord_scores + DOWNBEAT_ACCENT_WEIGHT * accent_scores
+    if meter == "6/8":
+        scores = scores + SIX_EIGHT_COMPOUND_WEIGHT * _six_eight_compound_scores(
+            features,
+            source_stem_features,
+            beat_times,
+            beat_interval,
+        )
 
     best_offset = int(np.argmax(scores))
-    if best_offset == 0:
-        return 0
-
     best_score = float(scores[best_offset])
     second_score = float(np.max(np.delete(scores, best_offset)))
+    downbeat_confidence = _downbeat_confidence(
+        best_score,
+        second_score,
+        zero_score=float(scores[0]),
+        best_offset=best_offset,
+    )
+    meter_confidence = _meter_confidence(best_score, second_score)
+    return _TimingInference(
+        meter=meter,
+        beats_per_bar=beats_per_bar,
+        meter_confidence=meter_confidence,
+        downbeat_offset=best_offset if downbeat_confidence > 0.0 else 0,
+        downbeat_source=(
+            _downbeat_source(
+                chord_score=float(chord_scores[best_offset]),
+                source_accent_score=float(source_accent_scores[best_offset]),
+                stem_accent_score=float(stem_accent_scores[best_offset]),
+            )
+            if downbeat_confidence > 0.0
+            else "default"
+        ),
+        downbeat_confidence=downbeat_confidence,
+        meter_score=best_score,
+    )
+
+
+def _select_timing_inference(candidates: list[_TimingInference]) -> _TimingInference:
+    default_candidate = next(
+        (candidate for candidate in candidates if candidate.meter == DEFAULT_METER),
+        _default_timing_inference(),
+    )
+    best_candidate = max(candidates, key=lambda candidate: candidate.meter_score)
+    if best_candidate.meter == DEFAULT_METER:
+        return best_candidate
+
+    competing_score = max(
+        (candidate.meter_score for candidate in candidates if candidate.meter != best_candidate.meter),
+        default=0.0,
+    )
+    clear_switch = (
+        best_candidate.meter_score >= METER_MIN_SCORE
+        and best_candidate.meter_confidence >= METER_MIN_CONFIDENCE
+        and best_candidate.meter_score - competing_score >= METER_MIN_SWITCH_MARGIN
+        and best_candidate.meter_score - default_candidate.meter_score >= METER_MIN_SWITCH_MARGIN
+    )
+    if clear_switch:
+        return best_candidate
+    return default_candidate
+
+
+def _default_timing_inference(*, downbeat_source: str = "default") -> _TimingInference:
+    return _TimingInference(
+        meter=DEFAULT_METER,
+        beats_per_bar=BEATS_PER_BAR,
+        meter_confidence=METER_DEFAULT_CONFIDENCE,
+        downbeat_offset=0,
+        downbeat_source=downbeat_source,
+        downbeat_confidence=0.0,
+        meter_score=0.0,
+    )
+
+
+def _meter_confidence(best_score: float, second_score: float) -> float:
+    if best_score < METER_MIN_SCORE:
+        return METER_DEFAULT_CONFIDENCE
+    margin = max(0.0, best_score - second_score)
+    confidence = float(np.clip(0.18 + best_score * 0.55 + margin * 1.15, 0.0, 0.95))
+    return round(confidence, 3)
+
+
+def _downbeat_confidence(
+    best_score: float,
+    second_score: float,
+    *,
+    zero_score: float,
+    best_offset: int,
+) -> float:
     if best_score < DOWNBEAT_MIN_SCORE:
-        return 0
+        return 0.0
     if best_score - second_score < DOWNBEAT_MIN_SCORE_MARGIN:
-        return 0
-    if best_score - float(scores[0]) < DOWNBEAT_MIN_ZERO_MARGIN:
-        return 0
-    return best_offset
+        return 0.0
+    if best_offset != 0 and best_score - zero_score < DOWNBEAT_MIN_ZERO_MARGIN:
+        return 0.0
+
+    confidence = float(
+        np.clip(
+            0.2 + best_score * 0.52 + (best_score - second_score) * 1.1,
+            0.0,
+            0.95,
+        )
+    )
+    return round(confidence, 3)
+
+
+def _downbeat_source(
+    *,
+    chord_score: float,
+    source_accent_score: float,
+    stem_accent_score: float,
+) -> str:
+    strongest = max(chord_score, source_accent_score, stem_accent_score)
+    if strongest <= 0.0:
+        return "default"
+
+    threshold = max(0.08, strongest * 0.45)
+    sources: list[str] = []
+    if chord_score >= threshold:
+        sources.append("chord")
+    if source_accent_score >= threshold:
+        sources.append("accent")
+    if stem_accent_score >= threshold:
+        sources.append("source_stem")
+    return "+".join(sources) if sources else "default"
 
 
 def _median_beat_interval(beat_times: np.ndarray) -> float:
@@ -1235,8 +1477,9 @@ def _downbeat_chord_scores(
     beat_times: np.ndarray,
     chord_timeline: list[ChordSegment],
     proximity_seconds: float,
+    beats_per_bar: int,
 ) -> np.ndarray:
-    scores = np.zeros(BEATS_PER_BAR, dtype=np.float32)
+    scores = np.zeros(beats_per_bar, dtype=np.float32)
     change_starts = _usable_chord_change_starts(beat_times, chord_timeline, proximity_seconds)
     if not change_starts:
         return scores
@@ -1247,7 +1490,7 @@ def _downbeat_chord_scores(
         distance = float(distances[nearest_index])
         if distance > proximity_seconds:
             continue
-        offset = nearest_index % BEATS_PER_BAR
+        offset = nearest_index % beats_per_bar
         scores[offset] += np.float32(1.0 - distance / proximity_seconds)
 
     return (scores / max(len(change_starts), 3)).astype(np.float32)
@@ -1280,14 +1523,15 @@ def _downbeat_accent_scores(
     features: HarmonicFeatures,
     beat_times: np.ndarray,
     beat_interval: float,
+    beats_per_bar: int,
 ) -> np.ndarray:
-    scores = np.zeros(BEATS_PER_BAR, dtype=np.float32)
+    scores = np.zeros(beats_per_bar, dtype=np.float32)
     strengths = _beat_accent_strengths(features, beat_times, beat_interval)
-    if strengths.size < MIN_DOWNBEAT_INFERENCE_BEATS:
+    if strengths.size < max(MIN_DOWNBEAT_INFERENCE_BEATS, beats_per_bar * 2):
         return scores
 
-    beat_positions = np.arange(strengths.size) % BEATS_PER_BAR
-    for offset in range(BEATS_PER_BAR):
+    beat_positions = np.arange(strengths.size) % beats_per_bar
+    for offset in range(beats_per_bar):
         candidate_strengths = strengths[beat_positions == offset]
         other_strengths = strengths[beat_positions != offset]
         if candidate_strengths.size < 2 or other_strengths.size == 0:
@@ -1298,6 +1542,102 @@ def _downbeat_accent_scores(
             continue
         scores[offset] = np.float32((candidate_mean - other_mean) / max(candidate_mean, 1e-6))
     return scores
+
+
+def _source_stem_downbeat_accent_scores(
+    source_stem_features: Sequence[HarmonicFeatures],
+    beat_times: np.ndarray,
+    beat_interval: float,
+    beats_per_bar: int,
+) -> np.ndarray:
+    scores = np.zeros(beats_per_bar, dtype=np.float32)
+    for features in source_stem_features:
+        if not _features_cover_beat_times(features, beat_times, beat_interval):
+            continue
+        scores = np.maximum(
+            scores,
+            _downbeat_accent_scores(features, beat_times, beat_interval, beats_per_bar),
+        )
+    return scores
+
+
+def _six_eight_compound_scores(
+    features: HarmonicFeatures,
+    source_stem_features: Sequence[HarmonicFeatures],
+    beat_times: np.ndarray,
+    beat_interval: float,
+) -> np.ndarray:
+    scores = np.zeros(6, dtype=np.float32)
+    strengths = _combined_beat_accent_strengths(
+        features,
+        source_stem_features,
+        beat_times,
+        beat_interval,
+    )
+    if strengths.size < 12:
+        return scores
+
+    beat_positions = np.arange(strengths.size) % 6
+    for offset in range(6):
+        primary = strengths[beat_positions == offset]
+        secondary = strengths[beat_positions == ((offset + 3) % 6)]
+        weak = strengths[(beat_positions != offset) & (beat_positions != ((offset + 3) % 6))]
+        if primary.size < 2 or secondary.size < 2 or weak.size == 0:
+            continue
+
+        primary_mean = float(np.mean(primary))
+        secondary_mean = float(np.mean(secondary))
+        weak_mean = float(np.mean(weak))
+        if primary_mean <= 0.0:
+            continue
+        if secondary_mean <= weak_mean or primary_mean <= secondary_mean:
+            continue
+        if secondary_mean < primary_mean * 0.25:
+            continue
+
+        primary_contrast = (primary_mean - weak_mean) / max(primary_mean, 1e-6)
+        secondary_support = (secondary_mean - weak_mean) / max(primary_mean, 1e-6)
+        primary_dominance = (primary_mean - secondary_mean) / max(primary_mean, 1e-6)
+        if primary_dominance < 0.12:
+            continue
+        scores[offset] = np.float32(
+            np.clip(
+                (primary_contrast * 0.65 + secondary_support * 0.35)
+                * min(1.0, primary_dominance / 0.35),
+                0.0,
+                1.0,
+            )
+        )
+    return scores
+
+
+def _combined_beat_accent_strengths(
+    features: HarmonicFeatures,
+    source_stem_features: Sequence[HarmonicFeatures],
+    beat_times: np.ndarray,
+    beat_interval: float,
+) -> np.ndarray:
+    strengths = _beat_accent_strengths(features, beat_times, beat_interval)
+    if strengths.size == 0:
+        strengths = np.zeros(beat_times.size, dtype=np.float32)
+
+    for stem_features in source_stem_features:
+        if not _features_cover_beat_times(stem_features, beat_times, beat_interval):
+            continue
+        stem_strengths = _beat_accent_strengths(stem_features, beat_times, beat_interval)
+        if stem_strengths.size == strengths.size:
+            strengths = np.maximum(strengths, stem_strengths)
+    return strengths
+
+
+def _features_cover_beat_times(
+    features: HarmonicFeatures,
+    beat_times: np.ndarray,
+    beat_interval: float,
+) -> bool:
+    if features.duration_seconds <= 0.0 or beat_times.size == 0:
+        return False
+    return features.duration_seconds + beat_interval >= float(beat_times[-1])
 
 
 def _beat_accent_strengths(

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -803,6 +803,24 @@ class AnalysisRequest(BaseModel):
     force: bool = False
 
 
+AnalysisTimingCorrectionAction = Literal["set_bar_1_beat_1", "shift_left", "shift_right", "set_meter"]
+AnalysisTimingBeatsPerBar = Literal[3, 4, 6]
+
+
+class AnalysisTimingCorrectionRequest(BaseModel):
+    action: AnalysisTimingCorrectionAction
+    playhead_seconds: float | None = Field(default=None, ge=0.0)
+    beats_per_bar: AnalysisTimingBeatsPerBar | None = None
+
+    @model_validator(mode="after")
+    def validate_timing_correction(self) -> AnalysisTimingCorrectionRequest:
+        if self.action == "set_bar_1_beat_1" and self.playhead_seconds is None:
+            raise ValueError("playhead_seconds is required when setting bar 1 beat 1.")
+        if self.action == "set_meter" and self.beats_per_bar is None:
+            raise ValueError("beats_per_bar is required when setting meter.")
+        return self
+
+
 class AnalysisTimingBeatSchema(BaseModel):
     index: int
     seconds: float
@@ -819,6 +837,10 @@ class AnalysisTimingBarSchema(BaseModel):
 class AnalysisTimingSchema(BaseModel):
     beats_per_bar: int
     source: str
+    meter: str | None = None
+    meter_confidence: float | None = None
+    downbeat_source: str | None = None
+    downbeat_confidence: float | None = None
     beats: list[AnalysisTimingBeatSchema] = Field(default_factory=list)
     bars: list[AnalysisTimingBarSchema] = Field(default_factory=list)
 
@@ -840,6 +862,10 @@ class AnalysisSchema(BaseModel):
 
 class AnalysisResponse(BaseModel):
     analysis: AnalysisSchema | None
+
+
+class AnalysisTimingCorrectionResponse(BaseModel):
+    analysis: AnalysisSchema
 
 
 class ChordRequest(BaseModel):

--- a/apps/backend/app/services/analysis.py
+++ b/apps/backend/app/services/analysis.py
@@ -1,25 +1,39 @@
 from __future__ import annotations
 
 import json
+from collections import defaultdict
+from collections.abc import Mapping
+from math import isfinite
 from pathlib import Path
+from typing import Any, Literal, cast
 
+from fastapi import status
 from sqlalchemy.orm import Session
 
 from app.engines.analysis import analyze_track
+from app.errors import AppError
 from app.models import AnalysisResult, Artifact, Project
 from app.services.artifacts import refresh_artifact_file_metadata, register_artifact
 from app.services.paths import project_analysis_dir
 
+TimingCorrectionAction = Literal["set_bar_1_beat_1", "shift_left", "shift_right", "set_meter"]
+SUPPORTED_TIMING_BEATS_PER_BAR = frozenset({3, 4, 6})
+SOURCE_STEM_ARTIFACT_TYPES = ("drums_stem", "bass_stem")
+
 
 def analyze_project(session: Session, project: Project) -> AnalysisResult:
-    results = analyze_track(Path(project.imported_path))
+    source_artifact = _project_source_artifact(project)
+    source_stem_paths = _source_stem_paths(project, source_artifact) if source_artifact is not None else ()
+    if source_stem_paths:
+        results = analyze_track(Path(project.imported_path), source_stem_paths=source_stem_paths)
+    else:
+        results = analyze_track(Path(project.imported_path))
     analysis = session.get(AnalysisResult, project.id)
-    source_artifact = next((artifact for artifact in project.artifacts if artifact.type == "source_audio"), None)
     if analysis is None:
         analysis = AnalysisResult(project_id=project.id)
         session.add(analysis)
 
-    analysis.source_artifact_id = source_artifact.id if isinstance(source_artifact, Artifact) else None
+    analysis.source_artifact_id = source_artifact.id if source_artifact is not None else None
     analysis.estimated_key = results["estimated_key"]  # type: ignore[assignment]
     analysis.key_confidence = results["key_confidence"]  # type: ignore[assignment]
     analysis.estimated_reference_hz = results["estimated_reference_hz"]  # type: ignore[assignment]
@@ -29,6 +43,100 @@ def analyze_project(session: Session, project: Project) -> AnalysisResult:
     analysis.analysis_version = "v3"
     session.flush()
 
+    _write_analysis_artifact(session, project=project, analysis=analysis)
+
+    return analysis
+
+
+def _project_source_artifact(project: Project) -> Artifact | None:
+    return next((artifact for artifact in project.artifacts if artifact.type == "source_audio"), None)
+
+
+def _source_stem_paths(project: Project, source_artifact: Artifact) -> tuple[Path, ...]:
+    latest_by_type: dict[str, Artifact] = {}
+    for artifact in project.artifacts:
+        if not _is_source_analysis_stem(artifact, source_artifact):
+            continue
+        current = latest_by_type.get(artifact.type)
+        if current is None or (artifact.created_at, artifact.id) > (current.created_at, current.id):
+            latest_by_type[artifact.type] = artifact
+
+    source_stem_paths: list[Path] = []
+    for artifact_type in SOURCE_STEM_ARTIFACT_TYPES:
+        selected_artifact = latest_by_type.get(artifact_type)
+        if selected_artifact is not None:
+            source_stem_paths.append(Path(selected_artifact.path))
+    return tuple(source_stem_paths)
+
+
+def _is_source_analysis_stem(artifact: Artifact, source_artifact: Artifact) -> bool:
+    if artifact.type not in SOURCE_STEM_ARTIFACT_TYPES:
+        return False
+    metadata = artifact.metadata_json
+    if metadata.get("source_artifact_id") != source_artifact.id:
+        return False
+    if metadata.get("source_artifact_type") not in {None, "source_audio"}:
+        return False
+    return Path(artifact.path).exists()
+
+
+def correct_analysis_timing(
+    session: Session,
+    *,
+    project: Project,
+    action: TimingCorrectionAction,
+    playhead_seconds: float | None = None,
+    beats_per_bar: int | None = None,
+) -> AnalysisResult:
+    analysis = session.get(AnalysisResult, project.id)
+    if analysis is None or analysis.timing_json is None:
+        raise AppError(
+            "ANALYSIS_TIMING_NOT_FOUND",
+            "Analysis timing has not been generated for this project.",
+            status_code=status.HTTP_404_NOT_FOUND,
+        )
+
+    timing = _normalize_timing_payload(analysis.timing_json)
+    if not timing["beats"]:
+        raise AppError(
+            "ANALYSIS_TIMING_NOT_FOUND",
+            "Analysis timing has no beats to correct.",
+            status_code=status.HTTP_404_NOT_FOUND,
+        )
+
+    meter = timing["beats_per_bar"]
+    anchor_index = _timing_anchor_index(
+        timing,
+        prefer_pickup_phase=action in {"shift_left", "shift_right"},
+    )
+    if action == "set_bar_1_beat_1":
+        if playhead_seconds is None:
+            raise AppError("INVALID_REQUEST", "playhead_seconds is required for this timing correction.")
+        anchor_index = _nearest_beat_index(timing["beats"], playhead_seconds)
+    elif action == "shift_left":
+        anchor_index -= 1
+    elif action == "shift_right":
+        anchor_index += 1
+    elif action == "set_meter":
+        if beats_per_bar is None:
+            raise AppError("INVALID_REQUEST", "beats_per_bar is required for this timing correction.")
+        if beats_per_bar not in SUPPORTED_TIMING_BEATS_PER_BAR:
+            raise AppError("INVALID_REQUEST", "beats_per_bar must be one of 3, 4, or 6.")
+        meter = beats_per_bar
+
+    analysis.timing_json = _retime_grid(
+        timing,
+        beats_per_bar=meter,
+        anchor_index=anchor_index,
+        duration_seconds=project.duration_seconds,
+    )
+    session.flush()
+    _write_analysis_artifact(session, project=project, analysis=analysis)
+    session.refresh(analysis)
+    return analysis
+
+
+def _write_analysis_artifact(session: Session, *, project: Project, analysis: AnalysisResult) -> None:
     analysis_payload = {
         "project_id": project.id,
         "source_artifact_id": analysis.source_artifact_id,
@@ -40,7 +148,9 @@ def analyze_project(session: Session, project: Project) -> AnalysisResult:
         "timing": analysis.timing_json,
         "analysis_version": analysis.analysis_version,
     }
-    analysis_path = project_analysis_dir(project.id) / "analysis.json"
+    analysis_dir = project_analysis_dir(project.id)
+    analysis_dir.mkdir(parents=True, exist_ok=True)
+    analysis_path = analysis_dir / "analysis.json"
     analysis_path.write_text(
         json.dumps(analysis_payload, indent=2),
         encoding="utf-8",
@@ -74,4 +184,230 @@ def analyze_project(session: Session, project: Project) -> AnalysisResult:
             "source_artifact_id": analysis.source_artifact_id,
         }
 
-    return analysis
+    session.flush()
+
+
+def _normalize_timing_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    meter = _supported_beats_per_bar(payload.get("beats_per_bar"), fallback=4)
+    beats = [
+        normalized
+        for beat in payload.get("beats", [])
+        if isinstance(beat, Mapping) and (normalized := _normalize_timing_beat(beat)) is not None
+    ]
+    bars = [
+        normalized
+        for bar in payload.get("bars", [])
+        if isinstance(bar, Mapping) and (normalized := _normalize_timing_bar(bar)) is not None
+    ]
+    beats.sort(key=lambda beat: (beat["index"], beat["seconds"]))
+    bars.sort(key=lambda bar: (bar["start_seconds"], bar["index"]))
+    return {
+        "beats_per_bar": meter,
+        "source": str(payload.get("source") or "detected"),
+        "meter": _optional_str(payload.get("meter")) or _meter_label(meter),
+        "meter_confidence": _optional_float(payload.get("meter_confidence")),
+        "downbeat_source": _optional_str(payload.get("downbeat_source")),
+        "downbeat_confidence": _optional_float(payload.get("downbeat_confidence")),
+        "beats": beats,
+        "bars": bars,
+    }
+
+
+def _normalize_timing_beat(beat: Mapping[str, Any]) -> dict[str, int | float] | None:
+    index = _optional_int(beat.get("index"))
+    seconds = _optional_float(beat.get("seconds"))
+    bar_index = _optional_int(beat.get("bar_index"))
+    beat_in_bar = _optional_int(beat.get("beat_in_bar"))
+    if index is None or seconds is None or bar_index is None or beat_in_bar is None:
+        return None
+    return {
+        "index": index,
+        "seconds": max(0.0, seconds),
+        "bar_index": bar_index,
+        "beat_in_bar": max(1, beat_in_bar),
+    }
+
+
+def _normalize_timing_bar(bar: Mapping[str, Any]) -> dict[str, int | float] | None:
+    index = _optional_int(bar.get("index"))
+    start_seconds = _optional_float(bar.get("start_seconds"))
+    end_seconds = _optional_float(bar.get("end_seconds"))
+    if index is None or start_seconds is None or end_seconds is None:
+        return None
+    return {
+        "index": index,
+        "start_seconds": max(0.0, start_seconds),
+        "end_seconds": max(0.0, end_seconds),
+    }
+
+
+def _timing_anchor_index(timing: Mapping[str, Any], *, prefer_pickup_phase: bool = False) -> int:
+    meter = cast(int, timing["beats_per_bar"])
+    beats = cast(list[dict[str, int | float]], timing["beats"])
+    first_beat = beats[0]
+    if (
+        prefer_pickup_phase
+        and int(first_beat["bar_index"]) == 0
+        and int(first_beat["beat_in_bar"]) > 1
+    ):
+        return int(first_beat["index"]) - int(first_beat["beat_in_bar"]) + 1
+    for beat in beats:
+        if int(beat["bar_index"]) > 0 and int(beat["beat_in_bar"]) == 1:
+            return int(beat["index"]) - ((int(beat["bar_index"]) - 1) * meter)
+    for beat in beats:
+        if int(beat["bar_index"]) == 0 and int(beat["beat_in_bar"]) == 1:
+            return int(beat["index"])
+    return int(first_beat["index"]) - int(first_beat["beat_in_bar"]) + 1
+
+
+def _nearest_beat_index(beats: list[dict[str, int | float]], playhead_seconds: float) -> int:
+    return int(min(beats, key=lambda beat: abs(float(beat["seconds"]) - playhead_seconds))["index"])
+
+
+def _retime_grid(
+    timing: Mapping[str, Any],
+    *,
+    beats_per_bar: int,
+    anchor_index: int,
+    duration_seconds: float | None,
+) -> dict[str, Any]:
+    beats = []
+    timing_beats = cast(list[dict[str, int | float]], timing["beats"])
+    first_beat_index = int(timing_beats[0]["index"])
+    first_visible_downbeat_index = _first_visible_downbeat_index(
+        anchor_index=anchor_index,
+        first_beat_index=first_beat_index,
+        beats_per_bar=beats_per_bar,
+    )
+    for beat in timing_beats:
+        beat_index = int(beat["index"])
+        relative_position = beat_index - anchor_index
+        beats.append(
+            {
+                "index": beat_index,
+                "seconds": float(beat["seconds"]),
+                "bar_index": _retimed_beat_bar_index(
+                    beat_index,
+                    first_visible_downbeat_index=first_visible_downbeat_index,
+                    beats_per_bar=beats_per_bar,
+                ),
+                "beat_in_bar": (relative_position % beats_per_bar) + 1,
+            }
+        )
+    return {
+        "beats_per_bar": beats_per_bar,
+        "source": "user_corrected",
+        "meter": _meter_label(beats_per_bar),
+        "meter_confidence": 1.0,
+        "downbeat_source": "user",
+        "downbeat_confidence": 1.0,
+        "beats": beats,
+        "bars": _retimed_bars(beats, _timing_duration_seconds(timing, beats, duration_seconds)),
+    }
+
+
+def _retimed_bars(beats: list[dict[str, int | float]], duration_seconds: float) -> list[dict[str, int | float]]:
+    beats_by_bar: dict[int, list[dict[str, int | float]]] = defaultdict(list)
+    for beat in beats:
+        beats_by_bar[int(beat["bar_index"])].append(beat)
+
+    bars: list[dict[str, int | float]] = []
+    sorted_bar_indices = sorted(beats_by_bar)
+    for position, bar_index in enumerate(sorted_bar_indices):
+        bar_beats = sorted(beats_by_bar[bar_index], key=lambda beat: float(beat["seconds"]))
+        start_seconds = float(bar_beats[0]["seconds"])
+        if position + 1 < len(sorted_bar_indices):
+            next_bar_beats = sorted(
+                beats_by_bar[sorted_bar_indices[position + 1]],
+                key=lambda beat: float(beat["seconds"]),
+            )
+            end_seconds = float(next_bar_beats[0]["seconds"])
+        else:
+            end_seconds = max(duration_seconds, start_seconds)
+        if end_seconds <= start_seconds:
+            continue
+        bars.append(
+            {
+                "index": bar_index,
+                "start_seconds": round(start_seconds, 6),
+                "end_seconds": round(end_seconds, 6),
+            }
+        )
+    return bars
+
+
+def _retimed_beat_bar_index(
+    beat_index: int,
+    *,
+    first_visible_downbeat_index: int,
+    beats_per_bar: int,
+) -> int:
+    if beat_index < first_visible_downbeat_index:
+        return 0
+    return 1 + ((beat_index - first_visible_downbeat_index) // beats_per_bar)
+
+
+def _first_visible_downbeat_index(
+    *,
+    anchor_index: int,
+    first_beat_index: int,
+    beats_per_bar: int,
+) -> int:
+    if anchor_index >= first_beat_index:
+        return anchor_index
+    beats_after_anchor = (first_beat_index - anchor_index) % beats_per_bar
+    if beats_after_anchor == 0:
+        return first_beat_index
+    return first_beat_index + beats_per_bar - beats_after_anchor
+
+
+def _timing_duration_seconds(
+    timing: Mapping[str, Any],
+    beats: list[dict[str, int | float]],
+    duration_seconds: float | None,
+) -> float:
+    if duration_seconds is not None and isfinite(duration_seconds) and duration_seconds > 0.0:
+        return duration_seconds
+    bar_end_seconds = [
+        float(bar["end_seconds"])
+        for bar in cast(list[dict[str, int | float]], timing.get("bars", []))
+        if float(bar["end_seconds"]) > 0.0
+    ]
+    if bar_end_seconds:
+        return max(bar_end_seconds)
+    return max(float(beat["seconds"]) for beat in beats)
+
+
+def _supported_beats_per_bar(value: object, *, fallback: int) -> int:
+    parsed = _optional_int(value)
+    return parsed if parsed in SUPPORTED_TIMING_BEATS_PER_BAR else fallback
+
+
+def _meter_label(beats_per_bar: int) -> str:
+    if beats_per_bar == 6:
+        return "6/8"
+    return f"{beats_per_bar}/4"
+
+
+def _optional_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and isfinite(value):
+        return int(value)
+    return None
+
+
+def _optional_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float) and isfinite(value):
+        return float(value)
+    return None
+
+
+def _optional_str(value: object) -> str | None:
+    if isinstance(value, str) and value:
+        return value
+    return None

--- a/apps/backend/tests/test_analysis_flow.py
+++ b/apps/backend/tests/test_analysis_flow.py
@@ -1,7 +1,17 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
+
+import pytest
+
+from app.db import SessionLocal
+from app.errors import AppError
+from app.models import AnalysisResult, Project
+from app.services import analysis as analysis_service
+from app.services.artifacts import register_artifact
+from app.services.paths import ensure_project_dirs
 
 from .conftest import wait_for_job
 
@@ -57,3 +67,376 @@ def test_analysis_job_persists_results(client, sample_rhythmic_audio_file: Path)
 
     refreshed_artifacts = client.get(f"/api/v1/projects/{project['id']}/artifacts").json()["artifacts"]
     assert len([artifact for artifact in refreshed_artifacts if artifact["type"] == "analysis_json"]) == 1
+
+
+def test_analysis_passes_latest_source_drums_and_bass_stems_only(
+    client,
+    sample_audio_file: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    assert client is not None
+    project_id = "analysis_source_stem_project"
+    source_drums_path = tmp_path / "source-drums.wav"
+    source_bass_path = tmp_path / "source-bass.wav"
+    preview_drums_path = tmp_path / "preview-drums.wav"
+    preview_bass_path = tmp_path / "preview-bass.wav"
+    for path in (
+        source_drums_path,
+        source_bass_path,
+        preview_drums_path,
+        preview_bass_path,
+    ):
+        path.write_bytes(path.name.encode("utf-8"))
+
+    _seed_project_with_source_stems(
+        project_id=project_id,
+        source_path=sample_audio_file,
+        source_drums_path=source_drums_path,
+        source_bass_path=source_bass_path,
+        preview_drums_path=preview_drums_path,
+        preview_bass_path=preview_bass_path,
+    )
+
+    captured: dict[str, object] = {}
+
+    def fake_analyze_track(track_path: Path, *, source_stem_paths: tuple[Path, ...] | None = None):
+        captured["track_path"] = track_path
+        captured["source_stem_paths"] = source_stem_paths
+        return {
+            "estimated_key": "C major",
+            "key_confidence": 0.8,
+            "estimated_reference_hz": 440.0,
+            "tuning_offset_cents": 0.0,
+            "tempo_bpm": 120.0,
+            "timing": _timing_payload(),
+        }
+
+    monkeypatch.setattr(analysis_service, "analyze_track", fake_analyze_track)
+
+    with SessionLocal() as session:
+        project = session.get(Project, project_id)
+        assert project is not None
+        analysis = analysis_service.analyze_project(session, project)
+        session.commit()
+
+    assert analysis.source_artifact_id == "art_analysis_source"
+    assert captured["track_path"] == sample_audio_file
+    assert captured["source_stem_paths"] == (source_drums_path, source_bass_path)
+
+
+def test_analysis_timing_patch_updates_current_grid_and_reanalysis_overwrites(
+    client,
+    sample_audio_file: Path,
+    monkeypatch,
+):
+    project_id = "analysis_timing_patch_project"
+    _seed_analysis_project(project_id, sample_audio_file)
+
+    response = client.patch(
+        f"/api/v1/projects/{project_id}/analysis/timing",
+        json={"action": "set_bar_1_beat_1", "playhead_seconds": 1.1},
+    )
+
+    assert response.status_code == 200
+    timing = response.json()["analysis"]["timing"]
+    assert timing["source"] == "user_corrected"
+    assert timing["beats_per_bar"] == 4
+    assert timing["beats"][2] == {
+        "index": 2,
+        "seconds": 1.0,
+        "bar_index": 1,
+        "beat_in_bar": 1,
+    }
+    assert timing["beats"][0]["bar_index"] == 0
+    assert timing["beats"][0]["beat_in_bar"] == 3
+    _assert_timing_bar_indexes_are_nonnegative(timing)
+
+    shifted_response = client.patch(
+        f"/api/v1/projects/{project_id}/analysis/timing",
+        json={"action": "shift_right"},
+    )
+
+    assert shifted_response.status_code == 200
+    shifted_timing = shifted_response.json()["analysis"]["timing"]
+    assert shifted_timing["source"] == "user_corrected"
+    assert shifted_timing["beats"][3]["bar_index"] == 1
+    assert shifted_timing["beats"][3]["beat_in_bar"] == 1
+    _assert_timing_bar_indexes_are_nonnegative(shifted_timing)
+
+    meter_response = client.patch(
+        f"/api/v1/projects/{project_id}/analysis/timing",
+        json={"action": "set_meter", "beats_per_bar": 6},
+    )
+
+    assert meter_response.status_code == 200
+    meter_timing = meter_response.json()["analysis"]["timing"]
+    assert meter_timing["source"] == "user_corrected"
+    assert meter_timing["beats_per_bar"] == 6
+    assert meter_timing["meter"] == "6/8"
+    assert meter_timing["beats"][3]["bar_index"] == 1
+    assert meter_timing["beats"][3]["beat_in_bar"] == 1
+    _assert_timing_bar_indexes_are_nonnegative(meter_timing)
+
+    artifact = client.get(f"/api/v1/projects/{project_id}/artifacts").json()["artifacts"][0]
+    artifact_payload = json.loads(Path(artifact["path"]).read_text(encoding="utf-8"))
+    assert artifact_payload["timing"] == meter_timing
+
+    monkeypatch.setattr(
+        analysis_service,
+        "analyze_track",
+        lambda _path: {
+            "estimated_key": "G major",
+            "key_confidence": 0.9,
+            "estimated_reference_hz": 440.0,
+            "tuning_offset_cents": 0.0,
+            "tempo_bpm": 120.0,
+            "timing": _timing_payload(source="detected"),
+        },
+    )
+    with SessionLocal() as session:
+        project = session.get(Project, project_id)
+        assert project is not None
+        analysis_service.analyze_project(session, project)
+        session.commit()
+
+    refreshed = client.get(f"/api/v1/projects/{project_id}/analysis").json()["analysis"]["timing"]
+    assert refreshed["source"] == "detected"
+    assert refreshed["beats_per_bar"] == 4
+
+
+def test_analysis_timing_shift_left_from_first_visible_downbeat_creates_pickup(
+    client,
+    sample_audio_file: Path,
+):
+    project_id = "analysis_timing_shift_left_boundary_project"
+    _seed_analysis_project(
+        project_id,
+        sample_audio_file,
+        timing=_first_visible_downbeat_timing_payload(),
+    )
+
+    response = client.patch(
+        f"/api/v1/projects/{project_id}/analysis/timing",
+        json={"action": "shift_left"},
+    )
+
+    assert response.status_code == 200
+    timing = response.json()["analysis"]["timing"]
+    assert timing["source"] == "user_corrected"
+    assert timing["beats"][0] == {
+        "index": 0,
+        "seconds": 0.0,
+        "bar_index": 0,
+        "beat_in_bar": 2,
+    }
+    assert timing["beats"][1]["bar_index"] == 0
+    assert timing["beats"][1]["beat_in_bar"] == 3
+    assert timing["beats"][2]["bar_index"] == 0
+    assert timing["beats"][2]["beat_in_bar"] == 4
+    assert timing["beats"][3]["bar_index"] == 1
+    assert timing["beats"][3]["beat_in_bar"] == 1
+    _assert_timing_bar_indexes_are_nonnegative(timing)
+
+    restored_response = client.patch(
+        f"/api/v1/projects/{project_id}/analysis/timing",
+        json={"action": "shift_right"},
+    )
+
+    assert restored_response.status_code == 200
+    restored_timing = restored_response.json()["analysis"]["timing"]
+    original_timing = _first_visible_downbeat_timing_payload()
+    assert restored_timing["beats"] == original_timing["beats"]
+    assert restored_timing["bars"] == original_timing["bars"]
+    _assert_timing_bar_indexes_are_nonnegative(restored_timing)
+
+
+def test_analysis_timing_patch_rejects_unsupported_meter(
+    client,
+    sample_audio_file: Path,
+):
+    project_id = "analysis_timing_invalid_meter_project"
+    _seed_analysis_project(project_id, sample_audio_file)
+
+    response = client.patch(
+        f"/api/v1/projects/{project_id}/analysis/timing",
+        json={"action": "set_meter", "beats_per_bar": 5},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "INVALID_REQUEST"
+    persisted_timing = client.get(f"/api/v1/projects/{project_id}/analysis").json()["analysis"]["timing"]
+    assert persisted_timing["beats_per_bar"] == 4
+
+    with SessionLocal() as session:
+        project = session.get(Project, project_id)
+        assert project is not None
+        with pytest.raises(AppError, match="beats_per_bar must be one of 3, 4, or 6"):
+            analysis_service.correct_analysis_timing(
+                session,
+                project=project,
+                action="set_meter",
+                beats_per_bar=5,
+            )
+
+
+def _seed_analysis_project(project_id: str, source_path: Path, *, timing: dict | None = None) -> None:
+    ensure_project_dirs(project_id)
+    with SessionLocal() as session:
+        project = Project(
+            id=project_id,
+            display_name="Timing Patch Project",
+            source_path=str(source_path),
+            imported_path=str(source_path),
+            duration_seconds=4.0,
+        )
+        analysis = AnalysisResult(
+            project_id=project_id,
+            estimated_key="C major",
+            key_confidence=0.8,
+            estimated_reference_hz=440.0,
+            tuning_offset_cents=0.0,
+            tempo_bpm=120.0,
+            timing_json=timing or _timing_payload(),
+            analysis_version="v3",
+        )
+        session.add_all([project, analysis])
+        session.commit()
+
+
+def _seed_project_with_source_stems(
+    *,
+    project_id: str,
+    source_path: Path,
+    source_drums_path: Path,
+    source_bass_path: Path,
+    preview_drums_path: Path,
+    preview_bass_path: Path,
+) -> None:
+    ensure_project_dirs(project_id)
+    created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    with SessionLocal() as session:
+        project = Project(
+            id=project_id,
+            display_name="Source Stem Analysis Project",
+            source_path=str(source_path),
+            imported_path=str(source_path),
+            duration_seconds=4.0,
+        )
+        session.add(project)
+        source_artifact = register_artifact(
+            session,
+            project_id=project_id,
+            artifact_id="art_analysis_source",
+            artifact_type="source_audio",
+            artifact_format="wav",
+            path=source_path,
+            metadata={},
+            generated_by="import",
+            can_delete=False,
+            can_regenerate=False,
+            created_at=created_at,
+        )
+        preview_artifact = register_artifact(
+            session,
+            project_id=project_id,
+            artifact_id="art_analysis_preview",
+            artifact_type="preview_mix",
+            artifact_format="wav",
+            path=source_path,
+            metadata={"source_artifact_id": source_artifact.id},
+            generated_by="ffmpeg",
+            created_at=created_at + timedelta(seconds=1),
+        )
+        register_artifact(
+            session,
+            project_id=project_id,
+            artifact_id="art_source_drums",
+            artifact_type="drums_stem",
+            artifact_format="wav",
+            path=source_drums_path,
+            metadata={"source_artifact_id": source_artifact.id, "source_artifact_type": "source_audio"},
+            generated_by="demucs",
+            created_at=created_at + timedelta(seconds=2),
+        )
+        register_artifact(
+            session,
+            project_id=project_id,
+            artifact_id="art_source_bass",
+            artifact_type="bass_stem",
+            artifact_format="wav",
+            path=source_bass_path,
+            metadata={"source_artifact_id": source_artifact.id, "source_artifact_type": "source_audio"},
+            generated_by="demucs",
+            created_at=created_at + timedelta(seconds=3),
+        )
+        register_artifact(
+            session,
+            project_id=project_id,
+            artifact_id="art_preview_drums",
+            artifact_type="drums_stem",
+            artifact_format="wav",
+            path=preview_drums_path,
+            metadata={"source_artifact_id": preview_artifact.id, "source_artifact_type": "preview_mix"},
+            generated_by="demucs",
+            created_at=created_at + timedelta(seconds=4),
+        )
+        register_artifact(
+            session,
+            project_id=project_id,
+            artifact_id="art_preview_bass",
+            artifact_type="bass_stem",
+            artifact_format="wav",
+            path=preview_bass_path,
+            metadata={"source_artifact_id": preview_artifact.id, "source_artifact_type": "preview_mix"},
+            generated_by="demucs",
+            created_at=created_at + timedelta(seconds=5),
+        )
+        session.commit()
+
+
+def _assert_timing_bar_indexes_are_nonnegative(timing: dict) -> None:
+    assert all(beat["bar_index"] >= 0 for beat in timing["beats"])
+    assert all(bar["index"] >= 0 for bar in timing["bars"])
+
+
+def _timing_payload(*, source: str = "detected") -> dict:
+    return {
+        "beats_per_bar": 4,
+        "source": source,
+        "beats": [
+            {"index": 0, "seconds": 0.0, "bar_index": 0, "beat_in_bar": 1},
+            {"index": 1, "seconds": 0.5, "bar_index": 0, "beat_in_bar": 2},
+            {"index": 2, "seconds": 1.0, "bar_index": 0, "beat_in_bar": 3},
+            {"index": 3, "seconds": 1.5, "bar_index": 0, "beat_in_bar": 4},
+            {"index": 4, "seconds": 2.0, "bar_index": 1, "beat_in_bar": 1},
+            {"index": 5, "seconds": 2.5, "bar_index": 1, "beat_in_bar": 2},
+        ],
+        "bars": [
+            {"index": 0, "start_seconds": 0.0, "end_seconds": 2.0},
+            {"index": 1, "start_seconds": 2.0, "end_seconds": 4.0},
+        ],
+    }
+
+
+def _first_visible_downbeat_timing_payload() -> dict:
+    return {
+        "beats_per_bar": 4,
+        "source": "user_corrected",
+        "meter": "4/4",
+        "meter_confidence": 1.0,
+        "downbeat_source": "user",
+        "downbeat_confidence": 1.0,
+        "beats": [
+            {"index": 0, "seconds": 0.0, "bar_index": 1, "beat_in_bar": 1},
+            {"index": 1, "seconds": 0.5, "bar_index": 1, "beat_in_bar": 2},
+            {"index": 2, "seconds": 1.0, "bar_index": 1, "beat_in_bar": 3},
+            {"index": 3, "seconds": 1.5, "bar_index": 1, "beat_in_bar": 4},
+            {"index": 4, "seconds": 2.0, "bar_index": 2, "beat_in_bar": 1},
+            {"index": 5, "seconds": 2.5, "bar_index": 2, "beat_in_bar": 2},
+        ],
+        "bars": [
+            {"index": 1, "start_seconds": 0.0, "end_seconds": 2.0},
+            {"index": 2, "start_seconds": 2.0, "end_seconds": 4.0},
+        ],
+    }

--- a/apps/backend/tests/test_audio_analysis_engines.py
+++ b/apps/backend/tests/test_audio_analysis_engines.py
@@ -281,6 +281,10 @@ def test_analysis_infers_downbeat_offset_from_chord_changes_and_accents(monkeypa
     timing = analysis["timing"]
     assert timing is not None
     assert timing["source"] == "detected"
+    assert timing["meter"] == "4/4"
+    assert timing["meter_confidence"] >= 0.5
+    assert set(timing["downbeat_source"].split("+")) == {"chord", "accent"}
+    assert timing["downbeat_confidence"] >= 0.5
     assert [beat["beat_in_bar"] for beat in timing["beats"][:10]] == [
         4,
         1,
@@ -320,6 +324,89 @@ def test_analysis_infers_downbeat_offset_from_chord_changes_and_accents(monkeypa
         "start_seconds": timing["beats"][5]["seconds"],
         "end_seconds": timing["beats"][9]["seconds"],
     }
+    _assert_beats_map_to_bar_spans(timing)
+
+
+def test_analysis_infers_three_four_meter_metadata(monkeypatch):
+    beat_times = 0.25 + np.arange(18, dtype=np.float64) * 0.5
+    downbeat_indices = set(range(0, beat_times.size, 3))
+    features = _synthetic_timing_features(
+        beat_times,
+        accent_indices=downbeat_indices,
+        weak_indices=set(range(beat_times.size)) - downbeat_indices,
+        weak_rms=0.02,
+    )
+    chord_timeline = _synthetic_chord_timeline(
+        beat_times,
+        downbeat_offset=0,
+        duration_seconds=features.duration_seconds,
+        beats_per_bar=3,
+    )
+    _patch_synthetic_analysis(monkeypatch, features, chord_timeline)
+
+    analysis = analyze_track(Path("synthetic_three_four_meter.wav"))
+
+    timing = analysis["timing"]
+    assert timing is not None
+    assert timing["source"] == "detected"
+    assert timing["meter"] == "3/4"
+    assert timing["beats_per_bar"] == 3
+    assert timing["meter_confidence"] >= 0.5
+    assert timing["downbeat_source"] == "chord+accent"
+    assert timing["downbeat_confidence"] >= 0.5
+    assert [beat["beat_in_bar"] for beat in timing["beats"][:9]] == [1, 2, 3, 1, 2, 3, 1, 2, 3]
+    assert [bar["start_seconds"] for bar in timing["bars"][:3]] == [
+        timing["beats"][0]["seconds"],
+        timing["beats"][3]["seconds"],
+        timing["beats"][6]["seconds"],
+    ]
+    _assert_beats_map_to_bar_spans(timing)
+
+
+def test_analysis_infers_six_eight_meter_metadata(monkeypatch):
+    beat_times = 0.1 + np.arange(24, dtype=np.float64) * 0.25
+    primary_indices = set(range(0, beat_times.size, 6))
+    secondary_indices = set(range(3, beat_times.size, 6))
+    weak_indices = set(range(beat_times.size)) - primary_indices - secondary_indices
+    features = _synthetic_timing_features(
+        beat_times,
+        accent_indices=primary_indices,
+        weak_indices=weak_indices,
+        weak_rms=0.02,
+    )
+    chord_timeline = _synthetic_chord_timeline(
+        beat_times,
+        downbeat_offset=0,
+        duration_seconds=features.duration_seconds,
+        beats_per_bar=6,
+    )
+    _patch_synthetic_analysis(monkeypatch, features, chord_timeline)
+
+    analysis = analyze_track(Path("synthetic_six_eight_meter.wav"))
+
+    timing = analysis["timing"]
+    assert timing is not None
+    assert timing["source"] == "detected"
+    assert timing["meter"] == "6/8"
+    assert timing["beats_per_bar"] == 6
+    assert timing["meter_confidence"] >= 0.5
+    assert timing["downbeat_source"] == "chord+accent"
+    assert timing["downbeat_confidence"] >= 0.5
+    assert [beat["beat_in_bar"] for beat in timing["beats"][:12]] == [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+    ]
+    assert timing["bars"][1]["start_seconds"] == timing["beats"][6]["seconds"]
     _assert_beats_map_to_bar_spans(timing)
 
 
@@ -396,6 +483,10 @@ def test_analysis_keeps_ambiguous_downbeat_alignment(monkeypatch):
     timing = analysis["timing"]
     assert timing is not None
     assert timing["source"] == "detected"
+    assert timing["meter"] == "4/4"
+    assert timing["meter_confidence"] == 0.0
+    assert timing["downbeat_source"] == "default"
+    assert timing["downbeat_confidence"] == 0.0
     assert [beat["beat_in_bar"] for beat in timing["beats"][:8]] == [1, 2, 3, 4, 1, 2, 3, 4]
     assert [beat["bar_index"] for beat in timing["beats"][:8]] == [0, 0, 0, 0, 1, 1, 1, 1]
     assert timing["bars"][0] == {
@@ -403,6 +494,50 @@ def test_analysis_keeps_ambiguous_downbeat_alignment(monkeypatch):
         "start_seconds": timing["beats"][0]["seconds"],
         "end_seconds": timing["beats"][4]["seconds"],
     }
+    _assert_beats_map_to_bar_spans(timing)
+
+
+def test_analysis_uses_source_stem_evidence_for_downbeat_metadata(monkeypatch):
+    beat_times = 0.25 + np.arange(16, dtype=np.float64) * 0.5
+    source_features = _synthetic_timing_features(beat_times, accent_indices=set())
+    stem_downbeats = {2, 6, 10, 14}
+    stem_features = _synthetic_timing_features(
+        beat_times,
+        accent_indices=stem_downbeats,
+        weak_indices=set(range(beat_times.size)) - stem_downbeats,
+        weak_rms=0.02,
+    )
+    chord_timeline = [
+        _synthetic_chord_segment(
+            0.0,
+            source_features.duration_seconds,
+            label="C",
+            pitch_class=0,
+        )
+    ]
+
+    def extract_features(path: Path) -> HarmonicFeatures:
+        return stem_features if path.name == "source-drums.wav" else source_features
+
+    monkeypatch.setattr(analysis_engine, "extract_harmonic_features", extract_features)
+    monkeypatch.setattr(
+        analysis_engine,
+        "detect_chords_from_features",
+        lambda _features: chord_timeline,
+    )
+
+    analysis = analyze_track(
+        Path("source.wav"),
+        source_stem_paths=(Path("source-drums.wav"),),
+    )
+
+    timing = analysis["timing"]
+    assert timing is not None
+    assert timing["source"] == "detected"
+    assert timing["meter"] == "4/4"
+    assert timing["downbeat_source"] == "source_stem"
+    assert timing["downbeat_confidence"] >= 0.5
+    assert [beat["beat_in_bar"] for beat in timing["beats"][:8]] == [3, 4, 1, 2, 3, 4, 1, 2]
     _assert_beats_map_to_bar_spans(timing)
 
 
@@ -1264,9 +1399,22 @@ def test_analysis_timing_payload_keeps_consumer_fields(monkeypatch):
 
     timing = analysis["timing"]
     assert timing is not None
-    assert set(timing) == {"beats_per_bar", "source", "beats", "bars"}
+    assert set(timing) == {
+        "beats_per_bar",
+        "source",
+        "meter",
+        "meter_confidence",
+        "downbeat_source",
+        "downbeat_confidence",
+        "beats",
+        "bars",
+    }
     assert timing["beats_per_bar"] == 4
     assert timing["source"] == "detected"
+    assert timing["meter"] == "4/4"
+    assert isinstance(timing["meter_confidence"], float)
+    assert isinstance(timing["downbeat_source"], str)
+    assert isinstance(timing["downbeat_confidence"], float)
     assert timing["beats"]
     assert timing["bars"]
     assert set(timing["beats"][0]) == {"index", "seconds", "bar_index", "beat_in_bar"}
@@ -1488,8 +1636,9 @@ def _synthetic_chord_timeline(
     *,
     downbeat_offset: int,
     duration_seconds: float,
+    beats_per_bar: int = 4,
 ) -> list[ChordSegment]:
-    downbeat_times = beat_times[downbeat_offset::4]
+    downbeat_times = beat_times[downbeat_offset::beats_per_bar]
     boundaries = [0.0, *downbeat_times.tolist(), duration_seconds]
     chords = [
         ("G", 7),

--- a/apps/desktop/src/App.project-analysis-mix.test.tsx
+++ b/apps/desktop/src/App.project-analysis-mix.test.tsx
@@ -20,6 +20,7 @@ import {
   mockDeleteProject,
   mockCreateExport,
   mockGetLyrics,
+  mockUpdateAnalysisTiming,
   mockUpdateLyrics,
   mockUpdateProject,
   renderApp,
@@ -89,6 +90,38 @@ describe("Desktop app project analysis mix", () => {
     }
   }
 
+  function setTimingGridAnalysis(source = "detected") {
+    setProjectAnalysis("proj_123", {
+      project_id: "proj_123",
+      estimated_key: "G major",
+      key_confidence: 0.82,
+      estimated_reference_hz: 440,
+      tuning_offset_cents: 0,
+      tempo_bpm: 121.48,
+      timing: {
+        beats_per_bar: 4,
+        meter: "4/4",
+        source,
+        downbeat_source: "source_stems",
+        downbeat_confidence: 0.86,
+        meter_confidence: 0.91,
+        beats: [
+          { index: 0, seconds: 0, bar_index: 0, beat_in_bar: 1 },
+          { index: 1, seconds: 0.5, bar_index: 0, beat_in_bar: 2 },
+          { index: 2, seconds: 1, bar_index: 0, beat_in_bar: 3 },
+          { index: 3, seconds: 1.5, bar_index: 0, beat_in_bar: 4 },
+          { index: 4, seconds: 2, bar_index: 1, beat_in_bar: 1 },
+        ],
+        bars: [
+          { index: 0, start_seconds: 0, end_seconds: 2 },
+          { index: 1, start_seconds: 2, end_seconds: 4 },
+        ],
+      },
+      analysis_version: "v1",
+      created_at: "2026-04-18T13:16:00.000Z",
+    });
+  }
+
   function installScrollMock(element: HTMLElement, axis: "vertical" | "horizontal" = "vertical") {
     const scrollTo = vi.fn();
     Object.defineProperty(element, "scrollTo", {
@@ -130,6 +163,76 @@ describe("Desktop app project analysis mix", () => {
     await user.click(screen.getByRole("button", { name: "Analyze Track" }));
 
     expect(mockAnalyzeProject).toHaveBeenCalledWith("proj_123");
+  });
+
+  it("shows timing grid controls in the playback rail", async () => {
+    const user = userEvent.setup();
+    setTimingGridAnalysis();
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+
+    const timingPanel = screen.getByRole("heading", { name: "Timing Grid" }).closest("section");
+    expect(timingPanel).not.toBeNull();
+    const panel = timingPanel as HTMLElement;
+
+    expect(within(panel).getAllByText("Detected").length).toBeGreaterThan(0);
+    expect(within(panel).getByText("86%")).toBeInTheDocument();
+    expect(within(panel).getByText("Source + stems")).toBeInTheDocument();
+
+    await user.click(within(panel).getByRole("button", { name: "3/4" }));
+    await waitFor(() =>
+      expect(mockUpdateAnalysisTiming).toHaveBeenLastCalledWith("proj_123", {
+        action: "set_meter",
+        beats_per_bar: 3,
+      }),
+    );
+
+    await user.click(within(panel).getByRole("button", { name: "Shift timing grid left one beat" }));
+    await waitFor(() =>
+      expect(mockUpdateAnalysisTiming).toHaveBeenLastCalledWith("proj_123", {
+        action: "shift_left",
+      }),
+    );
+
+    await user.click(within(panel).getByRole("button", { name: "Set nearest playhead beat as bar 1 beat 1" }));
+    await waitFor(() =>
+      expect(mockUpdateAnalysisTiming).toHaveBeenLastCalledWith("proj_123", {
+        action: "set_bar_1_beat_1",
+        playhead_seconds: 0,
+      }),
+    );
+
+    await user.click(within(panel).getByRole("button", { name: "Shift timing grid right one beat" }));
+    await waitFor(() =>
+      expect(mockUpdateAnalysisTiming).toHaveBeenLastCalledWith("proj_123", {
+        action: "shift_right",
+      }),
+    );
+  });
+
+  it("confirms before analyze when the timing grid was corrected", async () => {
+    const user = userEvent.setup();
+    setTimingGridAnalysis("user_corrected");
+    mockConfirm.mockResolvedValueOnce(false);
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openStudioPanel(user);
+    await user.click(screen.getByRole("button", { name: "Analyze Track" }));
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.stringContaining("Re-analysis clears"),
+      expect.objectContaining({ title: "Refresh timing grid" }),
+    );
+    expect(mockAnalyzeProject).not.toHaveBeenCalled();
+
+    mockConfirm.mockResolvedValueOnce(true);
+    await user.click(screen.getByRole("button", { name: "Analyze Track" }));
+    await waitFor(() => expect(mockAnalyzeProject).toHaveBeenCalledWith("proj_123"));
   });
 
   it("shows sync lock reason and disables project mutation controls for locked projects", async () => {

--- a/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
@@ -1,6 +1,21 @@
 import { type KeyboardEvent, useEffect, useRef, useState } from "react";
-import { ArrowUpDown, AudioLines, Drumstick, Gauge, Layers } from "lucide-react";
-import { LOOP_ALIGNMENT_MODES, type LoopAlignmentMode } from "../../../lib/timingGrid";
+import {
+  ArrowUpDown,
+  AudioLines,
+  ChevronLeft,
+  ChevronRight,
+  Drumstick,
+  Gauge,
+  Grid3X3,
+  Layers,
+  LocateFixed,
+} from "lucide-react";
+import {
+  LOOP_ALIGNMENT_MODES,
+  TIMING_GRID_METERS,
+  type LoopAlignmentMode,
+  type TimingGridMeter,
+} from "../../../lib/timingGrid";
 import {
   artifactLabel,
   artifactSummary,
@@ -20,12 +35,16 @@ export function PlaybackPracticeRail() {
     capoShiftSummary,
     capoSourceKey,
     enharmonicDisplayMode,
+    canEditTimingGrid,
     canUseTempo,
     handleSetPlaybackTempo,
+    handleSetNearestTimingBeatAsBarOne,
     handleSetLoopAlignmentMode,
     handleResetPlaybackTempo,
+    handleSetTimingGridMeter,
     handleSelectPrimaryArtifact,
     handleSelectStemArtifact,
+    handleShiftTimingGrid,
     higherCapoPreview,
     higherCapoShiftOptions,
     handleSetPrecountClickCount,
@@ -63,6 +82,12 @@ export function PlaybackPracticeRail() {
     tempoOriginalBpm,
     tempoPlaybackRate,
     tempoTargetBpm,
+    timingGridConfidenceLabel,
+    timingGridDisabledReason,
+    timingGridMeter,
+    timingGridMutation,
+    timingGridSourceLabel,
+    timingGridStatusLabel,
     toggleStemControl,
     visibleStemArtifacts,
   } = useProjectViewModelContext();
@@ -78,6 +103,7 @@ export function PlaybackPracticeRail() {
     if (mode === "bar") return "Bar";
     return "Exact";
   };
+  const meterLabel = (meter: TimingGridMeter) => meter;
   const [tempoDraftText, setTempoDraftText] = useState(() =>
     tempoDisplayBpm === null
       ? ""
@@ -198,6 +224,9 @@ export function PlaybackPracticeRail() {
         <span title="Pre-count">
           <Drumstick aria-hidden="true" />
         </span>
+        <span title="Timing Grid">
+          <Grid3X3 aria-hidden="true" />
+        </span>
         <span title="Tempo">
           <Gauge aria-hidden="true" />
         </span>
@@ -309,6 +338,96 @@ export function PlaybackPracticeRail() {
             ? `${precountClickCount} clicks at ${precountTempoBpm.toFixed(1)} BPM`
             : precountDisabledReason}
         </p>
+      </section>
+
+      <section
+        className={`playback-timing-grid-control${
+          canEditTimingGrid ? "" : " playback-timing-grid-control--disabled"
+        }`}
+        aria-labelledby="playback-timing-grid-heading"
+      >
+        <div className="playback-timing-grid-control__header">
+          <div>
+            <p className="metric-label">Timing</p>
+            <h3 id="playback-timing-grid-heading">Timing Grid</h3>
+          </div>
+          <span className="playback-timing-grid-control__badge">{timingGridStatusLabel}</span>
+        </div>
+        <div className="playback-timing-grid-control__segments" role="group" aria-label="Timing grid meter">
+          {TIMING_GRID_METERS.map((meter) => (
+            <button
+              aria-pressed={timingGridMeter === meter}
+              className="button button--ghost button--small"
+              disabled={!canEditTimingGrid}
+              key={meter}
+              onClick={() => handleSetTimingGridMeter(meter)}
+              type="button"
+            >
+              {meterLabel(meter)}
+            </button>
+          ))}
+        </div>
+        <div className="playback-timing-grid-control__actions" role="group" aria-label="Timing grid correction">
+          <button
+            aria-label="Shift timing grid left one beat"
+            className="button button--ghost button--small"
+            disabled={!canEditTimingGrid}
+            onClick={() => handleShiftTimingGrid(-1)}
+            title="Shift left one beat"
+            type="button"
+          >
+            <ChevronLeft aria-hidden="true" />
+            <span>Beat</span>
+          </button>
+          <button
+            aria-label="Set nearest playhead beat as bar 1 beat 1"
+            className="button button--ghost button--small"
+            disabled={!canEditTimingGrid}
+            onClick={handleSetNearestTimingBeatAsBarOne}
+            title="Set nearest playhead beat as bar 1 beat 1"
+            type="button"
+          >
+            <LocateFixed aria-hidden="true" />
+            <span>Bar 1</span>
+          </button>
+          <button
+            aria-label="Shift timing grid right one beat"
+            className="button button--ghost button--small"
+            disabled={!canEditTimingGrid}
+            onClick={() => handleShiftTimingGrid(1)}
+            title="Shift right one beat"
+            type="button"
+          >
+            <span>Beat</span>
+            <ChevronRight aria-hidden="true" />
+          </button>
+        </div>
+        <dl className="playback-timing-grid-control__status" aria-label="Timing grid status">
+          <div>
+            <dt>Status</dt>
+            <dd>{timingGridStatusLabel}</dd>
+          </div>
+          <div>
+            <dt>Meter</dt>
+            <dd>{timingGridMeter}</dd>
+          </div>
+          <div>
+            <dt>Confidence</dt>
+            <dd>{timingGridConfidenceLabel}</dd>
+          </div>
+          <div>
+            <dt>Source</dt>
+            <dd>{timingGridSourceLabel}</dd>
+          </div>
+        </dl>
+        {timingGridDisabledReason ? (
+          <p className="artifact-meta playback-timing-grid-control__summary">
+            {timingGridDisabledReason}
+          </p>
+        ) : null}
+        {timingGridMutation.isError ? (
+          <p className="inline-error">Timing grid update failed.</p>
+        ) : null}
       </section>
 
       <section className="playback-loop-alignment-control" aria-labelledby="playback-loop-alignment-heading">

--- a/apps/desktop/src/features/projects/components/ProcessingPanel.tsx
+++ b/apps/desktop/src/features/projects/components/ProcessingPanel.tsx
@@ -91,7 +91,7 @@ export function ProcessingPanel() {
         <button
           className="button button--small"
           disabled={analyzeDisabled}
-          onClick={handleAnalyzeAction}
+          onClick={() => void handleAnalyzeAction()}
           title={editLockTitle}
           type="button"
         >

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -5,6 +5,7 @@ import { confirm, save } from "@tauri-apps/plugin-dialog";
 import {
   api,
   getProjectSyncSummary,
+  type AnalysisTimingUpdateRequest,
   type ArtifactSchema,
   type JobSchema,
   type LyricsGenerateRequest,
@@ -13,11 +14,13 @@ import {
 } from "../../../lib/api";
 import { usePreferences } from "../../../lib/preferences";
 import {
+  beatsPerBarForTimingGridMeter,
   normalizeAnalysisTimingGrid,
   normalizeLoopAlignmentMode,
   snapLoopPointToTiming,
   type AnalysisTimingGrid,
   type LoopAlignmentMode,
+  type TimingGridMeter,
 } from "../../../lib/timingGrid";
 import { usePlayback } from "../playback-context";
 import {
@@ -90,6 +93,29 @@ const TERMINAL_PROJECT_JOB_STATUSES = ["completed", "failed", "cancelled"] as co
 const ACTIVE_PROJECT_JOBS_LIMIT = 200;
 const PROJECT_HISTORY_JOBS_PAGE_SIZE = 50;
 const EMPTY_JOBS: JobSchema[] = [];
+
+function isUserCorrectedTimingGrid(timingGrid: AnalysisTimingGrid | null) {
+  return timingGrid?.source.toLowerCase() === "user_corrected";
+}
+
+function formatTimingGridConfidence(timingGrid: AnalysisTimingGrid | null) {
+  const confidence = timingGrid?.downbeat_confidence ?? timingGrid?.meter_confidence ?? null;
+  if (confidence === null) {
+    return "Unknown";
+  }
+  const percentage = confidence <= 1 ? confidence * 100 : confidence;
+  return `${Math.round(Math.max(0, Math.min(100, percentage)))}%`;
+}
+
+function formatTimingGridSource(timingGrid: AnalysisTimingGrid | null) {
+  if (!timingGrid) {
+    return "No grid";
+  }
+  const source = (timingGrid.downbeat_source ?? timingGrid.source).toLowerCase();
+  return source.includes("stem") || source.includes("drum") || source.includes("bass")
+    ? "Source + stems"
+    : "Source";
+}
 
 type DeleteArtifactsRequest = {
   artifactIds: string[];
@@ -402,6 +428,17 @@ export function useProjectViewModel() {
         queryClient.invalidateQueries({ queryKey: ["project", projectId] }),
         queryClient.invalidateQueries({ queryKey: ["projects"] }),
       ]);
+    },
+  });
+
+  const timingGridMutation = useMutation({
+    mutationFn: (body: AnalysisTimingUpdateRequest) => {
+      assertProjectEditable();
+      return api.updateAnalysisTiming(projectId, body);
+    },
+    onSuccess: async (response) => {
+      queryClient.setQueryData(["analysis", projectId], response.analysis);
+      await queryClient.invalidateQueries({ queryKey: ["analysis", projectId] });
     },
   });
 
@@ -803,6 +840,14 @@ export function useProjectViewModel() {
     () => normalizeAnalysisTimingGrid(analysisQuery.data?.timing),
     [analysisQuery.data?.timing],
   );
+  const timingGridStatusLabel = isUserCorrectedTimingGrid(analysisTimingGrid)
+    ? "Corrected"
+    : analysisTimingGrid
+      ? "Detected"
+      : "No grid";
+  const timingGridMeter = analysisTimingGrid?.meter ?? "4/4";
+  const timingGridConfidenceLabel = formatTimingGridConfidence(analysisTimingGrid);
+  const timingGridSourceLabel = formatTimingGridSource(analysisTimingGrid);
   const detectedKey = parseKey(analysisQuery.data?.estimated_key);
   const loopAlignmentMode = loopAlignmentModeOverride ?? defaultLoopAlignmentMode;
   const tempoOriginalBpm = normalizeTempoBpm(analysisQuery.data?.tempo_bpm);
@@ -816,6 +861,20 @@ export function useProjectViewModel() {
   const canUsePrecount = tempoOriginalBpm !== null;
   const canUseTempo = tempoOriginalBpm !== null;
   const precountDisabledReason = canUsePrecount ? null : "Waiting for BPM analysis";
+  const mobileCapabilities = mobileCapabilitiesQuery.data ?? null;
+  const isMobileRuntime = mobileCapabilities !== null;
+  const canEditTimingGrid =
+    !projectEditLocked &&
+    !isMobileRuntime &&
+    analysisTimingGrid !== null &&
+    !timingGridMutation.isPending;
+  const timingGridDisabledReason = analysisTimingGrid
+    ? projectEditLocked
+      ? projectSyncLockReason
+      : isMobileRuntime
+        ? "Timing grid correction is not available on mobile yet."
+      : null
+    : "Waiting for timing analysis";
   const sourceKeyOverride = parseStoredKey(projectQuery.data?.source_key_override);
   const sourceKeyBasis = sourceKeyOverride ?? detectedKey ?? null;
   const sourceKey = sourceKeyBasis ?? DEFAULT_KEY;
@@ -837,8 +896,6 @@ export function useProjectViewModel() {
   const isAnyExportJobRunning = exportJobs.some((job) =>
     ["pending", "running"].includes(job.status),
   );
-  const mobileCapabilities = mobileCapabilitiesQuery.data ?? null;
-  const isMobileRuntime = mobileCapabilities !== null;
   const mobileGenerationTestingAvailable =
     mobileCapabilities?.generationTestingAvailable === true;
   const mobileGenerationMessage = isMobileRuntime
@@ -1114,9 +1171,23 @@ export function useProjectViewModel() {
     handleSetPlaybackDisplayMode("combined");
   }
 
-  function handleAnalyzeAction() {
+  async function handleAnalyzeAction() {
     if (projectEditLocked) {
       return;
+    }
+    if (isUserCorrectedTimingGrid(analysisTimingGrid)) {
+      const approved = await confirm(
+        "Analyze track again? Re-analysis clears the current timing grid correction.",
+        {
+          title: "Refresh timing grid",
+          kind: "warning",
+          okLabel: "Analyze",
+          cancelLabel: "Cancel",
+        },
+      );
+      if (!approved) {
+        return;
+      }
     }
     analyzeMutation.mutate();
   }
@@ -1244,6 +1315,35 @@ export function useProjectViewModel() {
 
   function handleSetLoopAlignmentMode(value: LoopAlignmentMode) {
     setLoopAlignmentModeOverride(normalizeLoopAlignmentMode(value));
+  }
+
+  function handleSetTimingGridMeter(meter: TimingGridMeter) {
+    if (!canEditTimingGrid || timingGridMeter === meter) {
+      return;
+    }
+    timingGridMutation.mutate({
+      action: "set_meter",
+      beats_per_bar: beatsPerBarForTimingGridMeter(meter),
+    });
+  }
+
+  function handleShiftTimingGrid(shiftBeats: -1 | 1) {
+    if (!canEditTimingGrid) {
+      return;
+    }
+    timingGridMutation.mutate({
+      action: shiftBeats < 0 ? "shift_left" : "shift_right",
+    });
+  }
+
+  function handleSetNearestTimingBeatAsBarOne() {
+    if (!canEditTimingGrid) {
+      return;
+    }
+    timingGridMutation.mutate({
+      action: "set_bar_1_beat_1",
+      playhead_seconds: Math.max(0, playbackTimeSeconds),
+    });
   }
 
   function handleDecreasePlaybackTempo() {
@@ -2246,6 +2346,7 @@ export function useProjectViewModel() {
     activeLyricsWordIndex,
     activeStemCount,
     analysisQuery,
+    analysisTimingGrid,
     analyzeMutation,
     canAnalyze,
     canDeleteSelectedStem,
@@ -2255,6 +2356,7 @@ export function useProjectViewModel() {
     canGenerateChords,
     canGenerateLyrics,
     canGenerateStems,
+    canEditTimingGrid,
     canUseTempo,
     capoKey,
     capoOptionRefs,
@@ -2309,8 +2411,11 @@ export function useProjectViewModel() {
     handleSetPrecountEnabled,
     handleSetPrecountLoopEnabled,
     handleSetLoopAlignmentMode,
+    handleSetNearestTimingBeatAsBarOne,
     handleIncreasePlaybackTempo,
     handleSetPlaybackTempo,
+    handleSetTimingGridMeter,
+    handleShiftTimingGrid,
     handleAcceptTabSuggestionGroup,
     handleApplyTabSuggestions,
     handleCloseTabImport,
@@ -2465,6 +2570,12 @@ export function useProjectViewModel() {
     tempoOriginalBpm,
     tempoPlaybackRate: tempoPlaybackRateValue,
     tempoTargetBpm: tempoTargetBpmForPlayback,
+    timingGridConfidenceLabel,
+    timingGridDisabledReason,
+    timingGridMeter,
+    timingGridMutation,
+    timingGridSourceLabel,
+    timingGridStatusLabel,
     togglePlayback: handleTogglePlayback,
     toggleStemControl,
     transposeSemitones,

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -52,6 +52,8 @@ export type ChordBackendSchema = components["schemas"]["ChordBackendSchema"];
 export type ChordBackendsResponse = components["schemas"]["ChordBackendsResponse"];
 export type LyricsGenerateRequest = components["schemas"]["LyricsGenerateRequest"];
 export type LyricsUpdateRequest = components["schemas"]["LyricsUpdateRequest"];
+export type AnalysisTimingUpdateRequest = components["schemas"]["AnalysisTimingCorrectionRequest"];
+export type AnalysisTimingUpdateResponse = components["schemas"]["AnalysisTimingCorrectionResponse"];
 export type SongSectionSchema = components["schemas"]["SongSectionSchema"];
 export type SongSectionsResponse = components["schemas"]["SongSectionsResponse"];
 export type TabImportApplyRequest = components["schemas"]["TabImportApplyRequest"];
@@ -1123,6 +1125,10 @@ export type TuneForgeClient = {
   deleteProject: (projectId: string) => Promise<components["schemas"]["DeleteResponse"]>;
   analyzeProject: (projectId: string) => Promise<components["schemas"]["JobResponse"]>;
   getAnalysis: (projectId: string) => Promise<AnalysisResponse>;
+  updateAnalysisTiming: (
+    projectId: string,
+    body: AnalysisTimingUpdateRequest,
+  ) => Promise<AnalysisTimingUpdateResponse>;
   listChordBackends: () => Promise<ChordBackendsResponse>;
   listStemModels: () => Promise<StemModelsResponse>;
   createChords: (projectId: string, body: ChordRequest) => Promise<components["schemas"]["JobResponse"]>;
@@ -1308,6 +1314,13 @@ function createHttpTuneForgeClient(): TuneForgeClient {
       ),
     getAnalysis: (projectId: string) =>
       unwrap(client.GET("/api/v1/projects/{project_id}/analysis", { params: { path: { project_id: projectId } } })),
+    updateAnalysisTiming: (projectId: string, body: AnalysisTimingUpdateRequest) =>
+      unwrap(
+        client.PATCH("/api/v1/projects/{project_id}/analysis/timing", {
+          params: { path: { project_id: projectId } },
+          body,
+        }),
+      ),
     listChordBackends: () => unwrap(client.GET("/api/v1/chord-backends")),
     listStemModels: () => unwrap(client.GET("/api/v1/stem-models")),
     createChords: (projectId: string, body: ChordRequest) =>
@@ -1399,6 +1412,13 @@ function createMobileTuneForgeClient(capabilities: MobileCapabilities): TuneForg
     deleteProject: (projectId: string) => invokeMobile("mobile_delete_project", { projectId }),
     analyzeProject: (projectId: string) => invokeMobile("mobile_submit_analyze", { projectId }),
     getAnalysis: (projectId: string) => invokeMobile("mobile_get_analysis", { projectId }),
+    updateAnalysisTiming: async () => {
+      throw new ApiError({
+        code: "UNSUPPORTED_RUNTIME",
+        message: "Timing grid correction is not available on mobile yet.",
+        details: {},
+      });
+    },
     listChordBackends: async () => mobileChordBackendsResponse,
     listStemModels: async () => mobileStemModelsResponse,
     createChords: (projectId: string, body: ChordRequest) =>
@@ -1525,6 +1545,8 @@ export const api: TuneForgeClient = {
   deleteProject: (projectId: string) => activeClient.deleteProject(projectId),
   analyzeProject: (projectId: string) => activeClient.analyzeProject(projectId),
   getAnalysis: (projectId: string) => activeClient.getAnalysis(projectId),
+  updateAnalysisTiming: (projectId: string, body: AnalysisTimingUpdateRequest) =>
+    activeClient.updateAnalysisTiming(projectId, body),
   listChordBackends: () => activeClient.listChordBackends(),
   listStemModels: () => activeClient.listStemModels(),
   createChords: (projectId: string, body: ChordRequest) => activeClient.createChords(projectId, body),

--- a/apps/desktop/src/lib/timingGrid.test.ts
+++ b/apps/desktop/src/lib/timingGrid.test.ts
@@ -10,7 +10,11 @@ import {
 
 const timingGrid: AnalysisTimingGrid = {
   beats_per_bar: 4,
+  meter: "4/4",
   source: "detected",
+  downbeat_source: "source",
+  downbeat_confidence: 0.82,
+  meter_confidence: 0.91,
   beats: [
     { index: 0, seconds: 0, bar_index: 0, beat_in_bar: 1 },
     { index: 1, seconds: 0.48, bar_index: 0, beat_in_bar: 2 },
@@ -69,5 +73,27 @@ describe("timing grid helpers", () => {
         timingGrid,
       }),
     ).toBe(3);
+  });
+
+  it("resets scheduled beat lookup after a backward seek", () => {
+    expect(
+      nextTimedBeatIndex({
+        lastPlaybackTimeSeconds: 1.5,
+        lastScheduledBeatIndex: 3,
+        playbackTimeSeconds: 0.49,
+        timingGrid,
+      }),
+    ).toBe(2);
+  });
+
+  it("resets scheduled beat lookup after a forward seek", () => {
+    expect(
+      nextTimedBeatIndex({
+        lastPlaybackTimeSeconds: 0.51,
+        lastScheduledBeatIndex: 2,
+        playbackTimeSeconds: 2.04,
+        timingGrid,
+      }),
+    ).toBe(4);
   });
 });

--- a/apps/desktop/src/lib/timingGrid.ts
+++ b/apps/desktop/src/lib/timingGrid.ts
@@ -1,4 +1,6 @@
 export type LoopAlignmentMode = "free" | "beat" | "bar";
+export const TIMING_GRID_METERS = ["4/4", "3/4", "6/8"] as const;
+export type TimingGridMeter = (typeof TIMING_GRID_METERS)[number];
 
 export type AnalysisTimingBeat = {
   index: number;
@@ -15,7 +17,11 @@ export type AnalysisTimingBar = {
 
 export type AnalysisTimingGrid = {
   beats_per_bar: number;
+  meter: TimingGridMeter;
   source: string;
+  downbeat_source: string | null;
+  downbeat_confidence: number | null;
+  meter_confidence: number | null;
   beats: AnalysisTimingBeat[];
   bars: AnalysisTimingBar[];
 };
@@ -66,10 +72,44 @@ export function normalizeAnalysisTimingGrid(value: unknown): AnalysisTimingGrid 
   }
   return {
     beats_per_bar: beatsPerBar,
+    meter: normalizeTimingGridMeter(candidate.meter, beatsPerBar),
     source: typeof candidate.source === "string" ? candidate.source : "detected",
+    downbeat_source: nullableString(candidate.downbeat_source),
+    downbeat_confidence: nullableFiniteNumber(candidate.downbeat_confidence),
+    meter_confidence: nullableFiniteNumber(candidate.meter_confidence),
     beats,
     bars,
   };
+}
+
+export function isTimingGridMeter(value: unknown): value is TimingGridMeter {
+  return TIMING_GRID_METERS.some((meter) => meter === value);
+}
+
+export function normalizeTimingGridMeter(
+  value: unknown,
+  fallbackBeatsPerBar = 4,
+): TimingGridMeter {
+  if (isTimingGridMeter(value)) {
+    return value;
+  }
+  if (fallbackBeatsPerBar === 3) {
+    return "3/4";
+  }
+  if (fallbackBeatsPerBar === 6) {
+    return "6/8";
+  }
+  return "4/4";
+}
+
+export function beatsPerBarForTimingGridMeter(meter: TimingGridMeter) {
+  if (meter === "3/4") {
+    return 3;
+  }
+  if (meter === "6/8") {
+    return 6;
+  }
+  return 4;
 }
 
 export function snapLoopPointToTiming(
@@ -169,6 +209,14 @@ function normalizeTimingBeat(value: unknown): AnalysisTimingBeat | null {
     bar_index: Math.max(0, Math.trunc(candidate.bar_index)),
     beat_in_bar: Math.max(1, Math.trunc(candidate.beat_in_bar)),
   };
+}
+
+function nullableString(value: unknown) {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function nullableFiniteNumber(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
 function normalizeTimingBar(value: unknown): AnalysisTimingBar | null {

--- a/apps/desktop/src/styles/project-playback.css
+++ b/apps/desktop/src/styles/project-playback.css
@@ -914,6 +914,118 @@
   margin: 0;
 }
 
+.playback-timing-grid-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  padding: 0.8rem;
+  border: 1px solid var(--divider);
+  border-radius: 18px;
+  background: color-mix(in srgb, var(--surface-muted) 74%, transparent);
+}
+
+.playback-timing-grid-control--disabled {
+  opacity: 0.72;
+}
+
+.playback-timing-grid-control__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.playback-timing-grid-control__header h3 {
+  margin: 0.15rem 0 0;
+  font-size: 1rem;
+}
+
+.playback-timing-grid-control__badge {
+  display: inline-grid;
+  place-items: center;
+  min-height: 1.75rem;
+  padding: 0.25rem 0.55rem;
+  border: 1px solid color-mix(in srgb, var(--playback-accent) 34%, var(--divider));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface-highlight) 18%, var(--panel-strong));
+  color: var(--text);
+  font-size: 0.72rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.playback-timing-grid-control__segments {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.45rem;
+}
+
+.playback-timing-grid-control__segments .button,
+.playback-timing-grid-control__actions .button {
+  min-width: 0;
+  justify-content: center;
+  padding-inline: 0.4rem;
+}
+
+.playback-timing-grid-control__segments .button[aria-pressed="true"] {
+  border-color: color-mix(in srgb, var(--playback-accent) 52%, var(--divider));
+  background: color-mix(in srgb, var(--surface-highlight) 20%, var(--panel-strong));
+  color: var(--text);
+}
+
+.playback-timing-grid-control__actions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.45rem;
+}
+
+.playback-timing-grid-control__actions .button {
+  gap: 0.25rem;
+}
+
+.playback-timing-grid-control__actions svg {
+  width: 0.95rem;
+  height: 0.95rem;
+  flex: 0 0 auto;
+}
+
+.playback-timing-grid-control__status {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.45rem;
+  margin: 0;
+}
+
+.playback-timing-grid-control__status div {
+  min-width: 0;
+  padding: 0.48rem 0.55rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 72%, transparent);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--panel) 62%, transparent);
+}
+
+.playback-timing-grid-control__status dt {
+  margin: 0 0 0.15rem;
+  color: var(--muted);
+  font-size: 0.64rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.playback-timing-grid-control__status dd {
+  margin: 0;
+  overflow: hidden;
+  color: var(--text);
+  font-size: 0.82rem;
+  font-weight: 850;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.playback-timing-grid-control__summary {
+  margin: 0;
+}
+
 .playback-loop-alignment-control {
   display: flex;
   flex-direction: column;

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { vi } from "vitest";
 import App from "../App";
 import type {
+  AnalysisTimingUpdateRequest,
   BulkJobRequest,
   BulkJobsResponse,
   LyricsGenerateRequest,
@@ -75,6 +76,7 @@ const {
   mockCreatePreview,
   mockCreateStems,
   mockAnalyzeProject,
+  mockUpdateAnalysisTiming,
   mockUpdateLyrics,
   mockUpdateProject,
   mockGetTabImport,
@@ -1821,6 +1823,29 @@ const {
     state.jobs.unshift(job);
     return { job: clone(job) };
   });
+  const mockUpdateAnalysisTiming = vi.fn(
+    async (projectId: string, body: AnalysisTimingUpdateRequest) => {
+      const analysis = state.analysisByProject[projectId];
+      if (!analysis) {
+        throw new Error("Analysis not found.");
+      }
+      const currentTiming =
+        typeof analysis.timing === "object" && analysis.timing !== null
+          ? analysis.timing as Record<string, unknown>
+          : {};
+      const nextTiming = {
+        ...currentTiming,
+        source: "user_corrected",
+        ...(body.action === "set_meter" && body.beats_per_bar
+          ? {
+              beats_per_bar: body.beats_per_bar,
+            }
+          : {}),
+      };
+      analysis.timing = nextTiming;
+      return { analysis: clone(analysis) };
+    },
+  );
   const mockUpdateProject = vi.fn(async (projectId: string, body: { display_name?: string; source_key_override?: string | null }) => {
     const project = getProjectOrThrow(projectId);
     if (body.display_name !== undefined) {
@@ -2199,6 +2224,7 @@ const {
     mockCreatePreview,
     mockCreateStems,
     mockAnalyzeProject,
+    mockUpdateAnalysisTiming,
     mockUpdateLyrics,
     mockUpdateProject,
     mockGetTabImport,
@@ -2267,6 +2293,7 @@ export {
   mockCreatePreview,
   mockCreateStems,
   mockAnalyzeProject,
+  mockUpdateAnalysisTiming,
   mockUpdateLyrics,
   mockUpdateProject,
   mockGetTabImport,
@@ -2333,6 +2360,7 @@ vi.mock("../lib/api", async (importOriginal) => {
       createPreview: mockCreatePreview,
       createStems: mockCreateStems,
       analyzeProject: mockAnalyzeProject,
+      updateAnalysisTiming: mockUpdateAnalysisTiming,
       updateLyrics: mockUpdateLyrics,
       updateProject: mockUpdateProject,
       createExport: mockCreateExport,
@@ -2723,6 +2751,7 @@ export function resetAppTestHarness() {
   mockCreatePreview.mockClear();
   mockCreateStems.mockClear();
   mockAnalyzeProject.mockClear();
+  mockUpdateAnalysisTiming.mockClear();
   mockUpdateLyrics.mockClear();
   mockUpdateProject.mockClear();
   mockCreateExport.mockClear();

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -142,6 +142,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/projects/{project_id}/analysis/timing": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Project Analysis Timing Update */
+        patch: operations["project_analysis_timing_update_api_v1_projects__project_id__analysis_timing_patch"];
+        trace?: never;
+    };
     "/api/v1/projects/{project_id}/chords": {
         parameters: {
             query?: never;
@@ -774,12 +791,36 @@ export interface components {
             /** Beat In Bar */
             beat_in_bar: number;
         };
+        /** AnalysisTimingCorrectionRequest */
+        AnalysisTimingCorrectionRequest: {
+            /**
+             * Action
+             * @enum {string}
+             */
+            action: "set_bar_1_beat_1" | "shift_left" | "shift_right" | "set_meter";
+            /** Playhead Seconds */
+            playhead_seconds?: number | null;
+            /** Beats Per Bar */
+            beats_per_bar?: (3 | 4 | 6) | null;
+        };
+        /** AnalysisTimingCorrectionResponse */
+        AnalysisTimingCorrectionResponse: {
+            analysis: components["schemas"]["AnalysisSchema"];
+        };
         /** AnalysisTimingSchema */
         AnalysisTimingSchema: {
             /** Beats Per Bar */
             beats_per_bar: number;
             /** Source */
             source: string;
+            /** Meter */
+            meter?: string | null;
+            /** Meter Confidence */
+            meter_confidence?: number | null;
+            /** Downbeat Source */
+            downbeat_source?: string | null;
+            /** Downbeat Confidence */
+            downbeat_confidence?: number | null;
             /** Beats */
             beats?: components["schemas"]["AnalysisTimingBeatSchema"][];
             /** Bars */
@@ -2595,6 +2636,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AnalysisResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    project_analysis_timing_update_api_v1_projects__project_id__analysis_timing_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AnalysisTimingCorrectionRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AnalysisTimingCorrectionResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary

- Add stem-aware timing metadata and conservative meter/downbeat inference for 3/4, 4/4, and 6/8.
- Add timing-grid correction API for setting bar 1 beat 1, shifting the grid, and setting supported meter.
- Add Playback Timing Grid controls, re-analysis warning for corrected grids, generated contracts, and seek behavior tests.

Fixes #107

## Testing

- `uv --cache-dir /private/tmp/uv-cache run --python 3.11 pytest tests/test_audio_analysis_engines.py -q`
- `uv --cache-dir /private/tmp/uv-cache run --python 3.11 pytest tests/test_analysis_flow.py tests/test_pagination_contract.py -q`
- `uv --cache-dir /private/tmp/uv-cache run --python 3.11 ruff check app tests`
- `uv --cache-dir /private/tmp/uv-cache run --python 3.11 mypy app`
- `pnpm contracts:generate`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test`
- `pnpm --filter @tuneforge/desktop test -- App.project-analysis-mix`
