### PR TITLE
feat: simplify sync pairing flow

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -76,6 +76,12 @@ This document is an engineering notice and distribution checklist, not legal adv
 - **Source:** <https://github.com/tauri-apps/tauri>
 - **Notes:** The Rust crate inventory is primarily MIT / Apache-2.0 / BSD / ISC / Zlib family. It also includes MPL-2.0 and Unicode-3.0 notice obligations. Crates with LGPL-2.1-or-later as one license option, such as `r-efi`, also provide MIT or Apache-2.0 alternatives in the resolved metadata.
 
+### Tauri barcode scanner plugin
+
+- **License:** MIT OR Apache-2.0
+- **Source:** <https://github.com/tauri-apps/plugins-workspace>
+- **Notes:** Used by the Android-only QR pairing scanner. The desktop shell does not enable the barcode scanner plugin.
+
 ### TuneForge LAN sync transport Rust crates
 
 - **License:** Apache-2.0 / MIT for `snow`, `base64`, `rand`, `sha2`, and the RustCrypto AEAD/hash stack; BSD-3-Clause for `ed25519-dalek` and `curve25519-dalek`; MIT / BSD-3-Clause for `if-addrs`.
@@ -129,6 +135,12 @@ This document is an engineering notice and distribution checklist, not legal adv
 - **License:** Unlicense for whisper-rs; MIT for whisper.cpp
 - **Source:** <https://codeberg.org/tazz4843/whisper-rs> and <https://github.com/ggml-org/whisper.cpp>
 - **Notes:** Used by the embedded Android backend for side-loaded local lyrics transcription. Tuneforge does not redistribute Whisper model weights.
+
+### qrcode.react
+
+- **License:** ISC
+- **Source:** <https://github.com/zpao/qrcode.react>
+- **Notes:** Used to render pairing QR codes. The package license also notes bundled QR Code Generator code under MIT terms.
 
 ### React, Vite, TanStack Query, openapi-fetch, openapi-typescript, lucide-react
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,10 +20,12 @@
   "dependencies": {
     "@tanstack/react-query": "^5.100.11",
     "@tauri-apps/api": "^2.11.0",
+    "@tauri-apps/plugin-barcode-scanner": "~2.4.4",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tuneforge/shared-types": "workspace:*",
     "lucide-react": "^1.16.0",
     "openapi-fetch": "^0.17.0",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-router-dom": "^7.15.1"

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -859,7 +859,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -5257,7 +5257,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "rustix",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -6767,6 +6767,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-barcode-scanner"
+version = "2.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "485cbcf227f04117e930be748ea71d835900466dcd1d455d5ec284d36107a305"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7407,6 +7421,7 @@ dependencies = [
  "symphonia",
  "tauri",
  "tauri-build",
+ "tauri-plugin-barcode-scanner",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tokio",
@@ -8575,7 +8590,7 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.18",
- "windows 0.61.3",
+ "windows 0.62.2",
  "windows-core 0.62.2",
 ]
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -60,5 +60,6 @@ rand = "0.8.6"
 rusqlite = { version = "0.39.0", features = ["bundled"] }
 sha2 = "0.10.9"
 snow = "0.9.6"
+tauri-plugin-barcode-scanner = "2"
 tokio = { version = "1", features = ["time"] }
 whisper-rs = "0.16.0"

--- a/apps/desktop/src-tauri/capabilities/mobile.json
+++ b/apps/desktop/src-tauri/capabilities/mobile.json
@@ -1,0 +1,12 @@
+{
+  "identifier": "mobile-capability",
+  "platforms": [
+    "android"
+  ],
+  "windows": [
+    "main"
+  ],
+  "permissions": [
+    "barcode-scanner:default"
+  ]
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -324,7 +324,11 @@ fn install_linux_media_permission_handler(
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    let app = tauri::Builder::default()
+    let builder = tauri::Builder::default();
+    #[cfg(target_os = "android")]
+    let builder = builder.plugin(tauri_plugin_barcode_scanner::init());
+
+    let app = builder
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .setup(|app| {

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -1,11 +1,19 @@
 import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { normalizeSyncTransportStatus, type JobSchema, type ProjectSchema } from "./lib/api";
+import type { MobileCapabilities } from "@tuneforge/shared-types";
+import {
+  normalizeSyncTransportStatus,
+  type JobSchema,
+  type ProjectSchema,
+  type SyncPairingPayloadSchema,
+} from "./lib/api";
+import { encodePairingCode, pairingFingerprint } from "./features/activity/syncPairingCode";
 import {
   mockCancelJob,
   mockConfirm,
   mockGetProject,
+  mockGetMobileCapabilities,
   mockGetSyncIdentity,
   mockGetSyncTransportStatus,
   mockAnswerSyncPairingOffer,
@@ -14,6 +22,7 @@ import {
   getMockInvoke,
   mockStartSyncListener,
   mockStopSyncListener,
+  mockScanPairingQrCode,
   mockSyncTrustedPeerNow,
   mockTrustSyncPeer,
   mockListJobs,
@@ -35,6 +44,20 @@ const irohEndpointHint = `${irohTransportId}://device_peer_1`;
 const tcpEndpointHint = `${tcpTransportId}://192.168.1.57:48625`;
 const listenerTcpEndpointHint = `${tcpTransportId}://192.168.1.42:48625`;
 const syncEndpointHints = [irohEndpointHint, tcpEndpointHint];
+const listenerEndpointHints = [irohEndpointHint, listenerTcpEndpointHint];
+const androidCapabilities: MobileCapabilities = {
+  platform: "android",
+  mediaBackend: "android_media_codec",
+  isEmulator: false,
+  gpuBackend: null,
+  analysisAvailable: true,
+  basicChordsAvailable: true,
+  whisperAvailable: false,
+  stemSeparationAvailable: false,
+  generationTestingAvailable: false,
+  maxRecommendedModel: null,
+  cpuFallbackAllowed: false,
+};
 
 function project(overrides: Partial<ProjectSchema>): Record<string, unknown> {
   return {
@@ -81,7 +104,7 @@ function terminalHistoryJobs(count: number) {
   });
 }
 
-function pairingPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+function pairingPayload(overrides: Partial<SyncPairingPayloadSchema> = {}): SyncPairingPayloadSchema {
   return {
     sync_group_id: "sync_group_local",
     device_id: "device_peer_1",
@@ -91,7 +114,7 @@ function pairingPayload(overrides: Record<string, unknown> = {}): Record<string,
     protocol_version: "tuneforge-sync-v1",
     pairing_offer_id: "pair_offer_peer_1",
     pairing_secret: "pair_secret_peer_1",
-    expires_at: "2026-04-18T13:26:00.000Z",
+    expires_at: "2099-04-18T13:26:00.000Z",
     signature: "pair_signature_peer_1",
     ...overrides,
   };
@@ -316,11 +339,14 @@ describe("Desktop app activity", () => {
   it("answers a peer pairing offer", async () => {
     const user = userEvent.setup();
     const payload = pairingPayload();
+    const compactCode = encodePairingCode(payload);
     await openSyncTab(user);
 
-    fireEvent.change(screen.getByLabelText("Peer offer or response payload"), {
-      target: { value: JSON.stringify(payload) },
+    fireEvent.change(screen.getByLabelText("Peer pairing code"), {
+      target: { value: compactCode },
     });
+    expect(screen.getByLabelText("Peer pairing confirmation")).toHaveTextContent("Laptop Rig");
+    expect(screen.getByLabelText("Peer pairing confirmation")).toHaveTextContent(pairingFingerprint(payload));
     await user.click(screen.getByRole("button", { name: "Answer Offer" }));
 
     await waitFor(() =>
@@ -335,11 +361,13 @@ describe("Desktop app activity", () => {
     );
     expect(await screen.findByText("Laptop Rig")).toBeInTheDocument();
     expect(
-      screen.getByText(/Trusted Laptop Rig\. Pairing response (ready|copied)\./),
+      screen.getByText("Trusted Laptop Rig. Pairing response ready for the offering device."),
     ).toBeInTheDocument();
-    expect((screen.getByLabelText("Pairing response") as HTMLTextAreaElement).value).toContain(
-      '"device_id": "device_local"',
-    );
+    expect(screen.getByText("answer received")).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Pairing response QR code" })).toBeInTheDocument();
+    const responseCode = (screen.getByLabelText("Pairing response code") as HTMLTextAreaElement).value;
+    expect(responseCode).toMatch(/^TFPAIR1\./);
+    expect(responseCode).not.toContain('"device_id"');
   });
 
   it("creates a local pairing offer from the header without copying it", async () => {
@@ -355,13 +383,20 @@ describe("Desktop app activity", () => {
     expect(await screen.findByText("Listening")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Create Pairing Offer" }));
 
-    await waitFor(() => expect(mockCreateSyncPairingOffer).toHaveBeenCalled());
-    expect(writeText).not.toHaveBeenCalled();
-    expect(await screen.findByText(/Pairing offer ready\./)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Copy Pairing Offer" })).toBeInTheDocument();
-    expect((screen.getByLabelText("Local pairing offer") as HTMLTextAreaElement).value).toContain(
-      '"signature": "pair_signature_1"',
+    await waitFor(() =>
+      expect(mockCreateSyncPairingOffer).toHaveBeenCalledWith({
+        endpoint_hints: listenerEndpointHints,
+        ttl_seconds: 600,
+      }),
     );
+    expect(writeText).not.toHaveBeenCalled();
+    expect(await screen.findByText(/Pairing offer waiting\./)).toBeInTheDocument();
+    expect(screen.getByText("waiting")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy Pairing Code" })).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Pairing offer QR code" })).toBeInTheDocument();
+    const offerCode = (screen.getByLabelText("Local pairing code") as HTMLTextAreaElement).value;
+    expect(offerCode).toMatch(/^TFPAIR1\./);
+    expect(offerCode).not.toContain('"signature"');
   });
 
   it("falls back to the visible pairing text when clipboard write rejects", async () => {
@@ -382,19 +417,17 @@ describe("Desktop app activity", () => {
     expect(await screen.findByText("Listening")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Create Pairing Offer" }));
 
-    const output = (await screen.findByLabelText("Local pairing offer")) as HTMLTextAreaElement;
+    const output = (await screen.findByLabelText("Local pairing code")) as HTMLTextAreaElement;
     const focus = vi.spyOn(output, "focus");
     const select = vi.spyOn(output, "select");
-    await user.click(screen.getByRole("button", { name: "Copy Pairing Offer" }));
+    await user.click(screen.getByRole("button", { name: "Copy Pairing Code" }));
 
     await waitFor(() => expect(writeText).toHaveBeenCalled());
-    expect(writeText).toHaveBeenLastCalledWith(
-      expect.stringContaining('"signature": "pair_signature_1"'),
-    );
+    expect(writeText).toHaveBeenLastCalledWith(expect.stringMatching(/^TFPAIR1\./));
     expect(focus).toHaveBeenCalled();
     expect(select).toHaveBeenCalled();
     expect(execCommand).toHaveBeenCalledWith("copy");
-    expect(screen.getByText("Pairing offer copied.")).toBeInTheDocument();
+    expect(screen.getByText("Pairing offer code copied.")).toBeInTheDocument();
   });
 
   it("copies the visible pairing response without creating a new offer", async () => {
@@ -407,20 +440,18 @@ describe("Desktop app activity", () => {
     const payload = pairingPayload();
     await openSyncTab(user);
 
-    fireEvent.change(screen.getByLabelText("Peer offer or response payload"), {
-      target: { value: JSON.stringify(payload) },
+    fireEvent.change(screen.getByLabelText("Peer pairing code"), {
+      target: { value: encodePairingCode(payload) },
     });
     await user.click(screen.getByRole("button", { name: "Answer Offer" }));
 
-    expect(await screen.findByLabelText("Pairing response")).toBeInTheDocument();
+    expect(await screen.findByLabelText("Pairing response code")).toBeInTheDocument();
     mockCreateSyncPairingOffer.mockClear();
-    await user.click(screen.getByRole("button", { name: "Copy Pairing Response" }));
+    await user.click(screen.getByRole("button", { name: "Copy Response Code" }));
 
     expect(mockCreateSyncPairingOffer).not.toHaveBeenCalled();
-    expect(writeText).toHaveBeenLastCalledWith(
-      expect.stringContaining('"signature": "pair_response_signature_1"'),
-    );
-    expect(screen.getByText("Pairing response copied.")).toBeInTheDocument();
+    expect(writeText).toHaveBeenLastCalledWith(expect.stringMatching(/^TFPAIR1\./));
+    expect(screen.getByText("Pairing response code copied.")).toBeInTheDocument();
   });
 
   it("trusts a peer from a pasted pairing response", async () => {
@@ -428,9 +459,11 @@ describe("Desktop app activity", () => {
     const payload = pairingPayload();
     await openSyncTab(user);
 
-    fireEvent.change(screen.getByLabelText("Peer offer or response payload"), {
-      target: { value: JSON.stringify(payload) },
+    fireEvent.change(screen.getByLabelText("Peer pairing code"), {
+      target: { value: encodePairingCode(payload) },
     });
+    expect(screen.getByLabelText("Peer pairing confirmation")).toHaveTextContent("Laptop Rig");
+    expect(screen.getByLabelText("Peer pairing confirmation")).toHaveTextContent(pairingFingerprint(payload));
     await user.click(screen.getByRole("button", { name: "Trust Response" }));
 
     await waitFor(() =>
@@ -443,7 +476,94 @@ describe("Desktop app activity", () => {
       }),
     );
     expect(await screen.findByText("Laptop Rig")).toBeInTheDocument();
-    expect(screen.getByText("Trusted Laptop Rig.")).toBeInTheDocument();
+    expect(screen.getByText(`Trusted Laptop Rig. Fingerprint ${pairingFingerprint(payload)}.`)).toBeInTheDocument();
+  });
+
+  it("keeps raw pairing JSON in Advanced and can answer from raw JSON", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    const payload = pairingPayload();
+    await openSyncTab(user);
+
+    await user.click(screen.getByRole("button", { name: "Start Listener" }));
+    expect(await screen.findByText("Listening")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Create Pairing Offer" }));
+    expect(await screen.findByLabelText("Local pairing code")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Advanced"));
+    expect((screen.getByLabelText("Local pairing offer raw JSON") as HTMLTextAreaElement).value).toContain(
+      '"signature": "pair_signature_1"',
+    );
+    await user.click(screen.getByRole("button", { name: "Copy Raw Offer" }));
+    expect(writeText).toHaveBeenLastCalledWith(expect.stringContaining('"signature": "pair_signature_1"'));
+
+    fireEvent.change(screen.getByLabelText("Peer pairing code"), {
+      target: { value: encodePairingCode(pairingPayload({ device_id: "stale_device" })) },
+    });
+    expect(screen.getByLabelText("Peer pairing confirmation")).toHaveTextContent("stale_device");
+    fireEvent.change(screen.getByLabelText("Pasted raw JSON payload"), {
+      target: { value: JSON.stringify(payload) },
+    });
+    expect(screen.getByLabelText("Peer pairing code")).toHaveValue("");
+    expect(screen.getByLabelText("Peer pairing confirmation")).toHaveTextContent(pairingFingerprint(payload));
+    expect(screen.getByLabelText(/Adopt peer sync group for third-device join/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Answer Offer" }));
+
+    await waitFor(() =>
+      expect(mockAnswerSyncPairingOffer).toHaveBeenCalledWith({
+        offer: expect.objectContaining({ device_id: "device_peer_1" }),
+        endpoint_hints: listenerEndpointHints,
+        adopt_sync_group: false,
+      }),
+    );
+  });
+
+  it("hides QR scanning on desktop", async () => {
+    const user = userEvent.setup();
+    await openSyncTab(user);
+
+    expect(screen.queryByRole("button", { name: "Scan QR" })).not.toBeInTheDocument();
+    expect(screen.queryByText("QR scanning is available on Android devices.")).not.toBeInTheDocument();
+  });
+
+  it("scans compact pairing codes on Android", async () => {
+    const user = userEvent.setup();
+    const payload = pairingPayload();
+    const compactCode = encodePairingCode(payload);
+    mockGetMobileCapabilities.mockResolvedValue(androidCapabilities);
+    mockScanPairingQrCode.mockResolvedValue(compactCode);
+    await openSyncTab(user);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Scan QR" })).toBeEnabled());
+    await user.click(screen.getByRole("button", { name: "Scan QR" }));
+
+    await waitFor(() => expect(mockScanPairingQrCode).toHaveBeenCalled());
+    expect(screen.getByLabelText("Peer pairing code")).toHaveValue(compactCode);
+    expect(screen.getByText("QR code scanned. Confirm peer name and fingerprint before continuing.")).toBeInTheDocument();
+    expect(screen.getByLabelText("Peer pairing confirmation")).toHaveTextContent("Laptop Rig");
+  });
+
+  it("blocks invalid and expired pairing inputs", async () => {
+    const user = userEvent.setup();
+    await openSyncTab(user);
+
+    fireEvent.change(screen.getByLabelText("Peer pairing code"), {
+      target: { value: "not-json" },
+    });
+    expect(await screen.findByRole("alert")).toHaveTextContent("Pairing payload must be valid JSON.");
+    expect(screen.getByRole("button", { name: "Answer Offer" })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Peer pairing code"), {
+      target: { value: encodePairingCode(pairingPayload({ expires_at: "2020-01-01T00:00:00.000Z" })) },
+    });
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("Pairing payload expired."));
+    expect(screen.getByRole("button", { name: "Trust Response" })).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: "Answer Offer" }));
+    expect(mockAnswerSyncPairingOffer).not.toHaveBeenCalled();
   });
 
   it("starts and stops the native sync listener", async () => {
@@ -1099,8 +1219,8 @@ describe("Desktop app activity", () => {
         remote_manifest_count: 1,
       },
     });
-    fireEvent.change(screen.getByLabelText("Peer offer or response payload"), {
-      target: { value: JSON.stringify(pairingPayload({ device_id: "device_peer_2" })) },
+    fireEvent.change(screen.getByLabelText("Peer pairing code"), {
+      target: { value: encodePairingCode(pairingPayload({ device_id: "device_peer_2" })) },
     });
     await user.click(screen.getByRole("button", { name: "Answer Offer" }));
 

--- a/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
+++ b/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { QRCodeSVG } from "qrcode.react";
 import {
   api,
   mergeSyncProjectResults,
@@ -10,8 +11,24 @@ import {
   type SyncTrustedPeerSchema,
 } from "../../lib/api";
 import { formatLocalDateTime, normalizeApiDateTime } from "../../lib/datetime";
+import { scanPairingQrCode } from "../../lib/pairingQrScanner";
+import {
+  decodePairingCode,
+  encodePairingCode,
+  pairingCodeIsExpired,
+  pairingFingerprint,
+} from "./syncPairingCode";
 
 const PAIRING_OFFER_TTL_SECONDS = 600;
+
+type PairingOutputKind = "offer" | "response";
+type PairingOutput = {
+  kind: PairingOutputKind;
+  code: string;
+  rawJson: string;
+  payload: SyncPairingPayloadSchema;
+  state: "waiting" | "answer received";
+};
 
 function statusLabel(value: string | null | undefined) {
   const normalized = value?.trim();
@@ -69,70 +86,6 @@ function formatTimestamp(value: string | null | undefined) {
   });
 }
 
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return typeof value === "object" && value !== null ? value as Record<string, unknown> : null;
-}
-
-function requiredPairingString(
-  payloadRecord: Record<string, unknown>,
-  fieldName: keyof SyncPairingPayloadSchema,
-): string {
-  const value = payloadRecord[fieldName];
-  if (typeof value !== "string" || !value.trim()) {
-    throw new Error(`Pairing payload is missing ${fieldName}.`);
-  }
-  return value;
-}
-
-function pairingEndpointHints(value: unknown): string[] {
-  if (value === undefined) {
-    return [];
-  }
-  if (
-    !Array.isArray(value) ||
-    !value.every((hint): hint is string => typeof hint === "string" && Boolean(hint.trim()))
-  ) {
-    throw new Error("Pairing payload endpoint_hints must be a list of strings.");
-  }
-  return value;
-}
-
-function parsePairingPayload(rawValue: string): SyncPairingPayloadSchema {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(rawValue);
-  } catch {
-    throw new Error("Pairing payload must be valid JSON.");
-  }
-
-  const parsedRecord = asRecord(parsed);
-  const payloadRecord = asRecord(parsedRecord?.payload) ?? parsedRecord;
-  if (!payloadRecord) {
-    throw new Error("Pairing payload must be a JSON object.");
-  }
-  const displayName = payloadRecord.display_name;
-  if (displayName !== undefined && displayName !== null && typeof displayName !== "string") {
-    throw new Error("Pairing payload display_name must be a string.");
-  }
-  const expiresAt = requiredPairingString(payloadRecord, "expires_at");
-  if (Number.isNaN(new Date(expiresAt).getTime())) {
-    throw new Error("Pairing payload expires_at must be a valid date.");
-  }
-
-  return {
-    sync_group_id: requiredPairingString(payloadRecord, "sync_group_id"),
-    device_id: requiredPairingString(payloadRecord, "device_id"),
-    display_name: displayName ?? null,
-    public_key: requiredPairingString(payloadRecord, "public_key"),
-    endpoint_hints: pairingEndpointHints(payloadRecord.endpoint_hints),
-    protocol_version: requiredPairingString(payloadRecord, "protocol_version"),
-    pairing_offer_id: requiredPairingString(payloadRecord, "pairing_offer_id"),
-    pairing_secret: requiredPairingString(payloadRecord, "pairing_secret"),
-    expires_at: expiresAt,
-    signature: requiredPairingString(payloadRecord, "signature"),
-  };
-}
-
 async function copyToClipboard(value: string, source?: HTMLTextAreaElement | null) {
   if (navigator.clipboard?.writeText) {
     try {
@@ -156,6 +109,28 @@ function peerLabel(peer: SyncTrustedPeerSchema) {
 
 function peerEndpointSummary(peer: SyncTrustedPeerSchema) {
   return peer.endpoint_hints?.length ? peer.endpoint_hints.join(", ") : "No endpoint hints";
+}
+
+function pairingPayloadLabel(payload: SyncPairingPayloadSchema) {
+  return payload.display_name?.trim() || payload.device_id;
+}
+
+function pairingOutputForPayload(kind: PairingOutputKind, payload: SyncPairingPayloadSchema): PairingOutput {
+  return {
+    kind,
+    code: encodePairingCode(payload),
+    rawJson: JSON.stringify(payload, null, 2),
+    payload,
+    state: kind === "offer" ? "waiting" : "answer received",
+  };
+}
+
+function parsePairingInput(value: string) {
+  const payload = decodePairingCode(value);
+  if (pairingCodeIsExpired(payload)) {
+    throw new Error("Pairing payload expired.");
+  }
+  return payload;
 }
 
 function syncStatusText(status: SyncTransportRunStatus | null | undefined, peersById: Map<string, SyncTrustedPeerSchema>) {
@@ -472,16 +447,17 @@ function endpointList(endpointHints: string[]) {
 
 export function ActivitySyncPanel() {
   const queryClient = useQueryClient();
-  const [pairingPayloadDraft, setPairingPayloadDraft] = useState("");
-  const [pairingOfferText, setPairingOfferText] = useState("");
-  const [pairingOfferLabel, setPairingOfferLabel] = useState("Local pairing offer");
+  const [pairingCodeDraft, setPairingCodeDraft] = useState("");
+  const [rawPairingPayloadDraft, setRawPairingPayloadDraft] = useState("");
+  const [pairingOutput, setPairingOutput] = useState<PairingOutput | null>(null);
   const [adoptSyncGroup, setAdoptSyncGroup] = useState(false);
   const [pairingMessage, setPairingMessage] = useState<string | null>(null);
   const [pairingError, setPairingError] = useState<string | null>(null);
   const [lastSyncMessage, setLastSyncMessage] = useState<string | null>(null);
   const [lastSyncResult, setLastSyncResult] = useState<SyncTransportRunStatus | null>(null);
   const [hiddenListenerSyncKey, setHiddenListenerSyncKey] = useState<string | null>(null);
-  const pairingOutputRef = useRef<HTMLTextAreaElement | null>(null);
+  const pairingCodeOutputRef = useRef<HTMLTextAreaElement | null>(null);
+  const rawPairingOutputRef = useRef<HTMLTextAreaElement | null>(null);
 
   const identityQuery = useQuery({
     queryKey: ["sync", "identity"],
@@ -494,6 +470,10 @@ export function ActivitySyncPanel() {
   const peersQuery = useQuery({
     queryKey: ["sync", "trusted-peers"],
     queryFn: async () => (await api.listSyncTrustedPeers()).trusted_peers,
+  });
+  const mobileCapabilitiesQuery = useQuery({
+    queryKey: ["runtime", "mobile-capabilities"],
+    queryFn: () => api.getMobileCapabilities(),
   });
 
   const peersById = useMemo(
@@ -514,6 +494,21 @@ export function ActivitySyncPanel() {
     ? lastSyncMessage ?? lastSyncStatus
     : lastSyncStatus;
   const visibleSyncSummary = syncRunSummaryText(visibleSyncResult);
+  const pairingInputValue = pairingCodeDraft.trim() || rawPairingPayloadDraft.trim();
+  const decodedPairingInput = useMemo(() => {
+    if (!pairingInputValue) {
+      return { error: null, payload: null };
+    }
+    try {
+      return { error: null, payload: parsePairingInput(pairingInputValue) };
+    } catch (error) {
+      return {
+        error: error instanceof Error ? error.message : "Pairing payload is invalid.",
+        payload: null,
+      };
+    }
+  }, [pairingInputValue]);
+  const qrScanSupported = mobileCapabilitiesQuery.data?.platform === "android";
 
   const refreshSyncQueries = async () => {
     await Promise.all([
@@ -547,12 +542,10 @@ export function ActivitySyncPanel() {
         ttl_seconds: PAIRING_OFFER_TTL_SECONDS,
       }),
     onSuccess: async (response) => {
-      const nextOfferText = JSON.stringify(response.pairing_offer.payload, null, 2);
       const expiresAt = formatTimestamp(response.pairing_offer.expires_at);
-      setPairingOfferText(nextOfferText);
-      setPairingOfferLabel("Local pairing offer");
+      setPairingOutput(pairingOutputForPayload("offer", response.pairing_offer.payload));
       setPairingError(null);
-      setPairingMessage(`Pairing offer ready.${expiresAt ? ` Expires ${expiresAt}.` : ""}`);
+      setPairingMessage(`Pairing offer waiting.${expiresAt ? ` Expires ${expiresAt}.` : ""}`);
     },
   });
   const answerPairingOfferMutation = useMutation({
@@ -563,23 +556,13 @@ export function ActivitySyncPanel() {
         adopt_sync_group: adoptSyncGroup,
       }),
     onSuccess: async (response) => {
-      const nextResponseText = JSON.stringify(response.pairing_response, null, 2);
-      setPairingPayloadDraft("");
-      setPairingOfferText(nextResponseText);
-      setPairingOfferLabel("Pairing response");
+      setPairingCodeDraft("");
+      setRawPairingPayloadDraft("");
+      setPairingOutput(pairingOutputForPayload("response", response.pairing_response));
       setPairingError(null);
-      try {
-        const copied = await copyToClipboard(nextResponseText);
-        setPairingMessage(
-          copied
-            ? `Trusted ${peerLabel(
-                response.trusted_peer,
-              )}. Pairing response copied. Paste it on the offering device and choose Trust Response.`
-            : `Trusted ${peerLabel(response.trusted_peer)}. Pairing response ready.`,
-        );
-      } catch {
-        setPairingMessage(`Trusted ${peerLabel(response.trusted_peer)}. Pairing response ready.`);
-      }
+      setPairingMessage(
+        `Trusted ${peerLabel(response.trusted_peer)}. Pairing response ready for the offering device.`,
+      );
       await refreshSyncQueries();
     },
     onError: () => {
@@ -589,10 +572,11 @@ export function ActivitySyncPanel() {
   const trustPeerMutation = useMutation({
     mutationFn: (payload: SyncPairingPayloadSchema) =>
       api.trustSyncPeer({ payload, adopt_sync_group: adoptSyncGroup }),
-    onSuccess: async (response) => {
-      setPairingPayloadDraft("");
+    onSuccess: async (response, payload) => {
+      setPairingCodeDraft("");
+      setRawPairingPayloadDraft("");
       setPairingError(null);
-      setPairingMessage(`Trusted ${peerLabel(response.trusted_peer)}.`);
+      setPairingMessage(`Trusted ${peerLabel(response.trusted_peer)}. Fingerprint ${pairingFingerprint(payload)}.`);
       await refreshSyncQueries();
     },
     onError: () => {
@@ -624,12 +608,52 @@ export function ActivitySyncPanel() {
       setHiddenListenerSyncKey(listenerSyncKey);
     },
   });
+  const scanPairingQrMutation = useMutation({
+    mutationFn: scanPairingQrCode,
+    onSuccess: (value) => {
+      setPairingCodeDraft(value);
+      setRawPairingPayloadDraft("");
+      setPairingError(null);
+      setPairingMessage("QR code scanned. Confirm peer name and fingerprint before continuing.");
+    },
+    onError: (error) => {
+      setPairingError(
+        qrScanSupported
+          ? error instanceof Error ? error.message : "Could not scan QR code."
+          : "QR scanning is available on Android devices.",
+      );
+    },
+  });
+
+  function handlePairingCodeDraftChange(value: string) {
+    setPairingCodeDraft(value);
+    if (value.trim()) {
+      setRawPairingPayloadDraft("");
+    }
+  }
+
+  function handleRawPairingPayloadDraftChange(value: string) {
+    setRawPairingPayloadDraft(value);
+    if (value.trim()) {
+      setPairingCodeDraft("");
+    }
+  }
+
+  function handleCreatePairingOffer() {
+    setPairingError(null);
+    setPairingMessage(null);
+    if (!listenerActive) {
+      setPairingError("Start the listener before creating a pairing offer.");
+      return;
+    }
+    createPairingOfferMutation.mutate();
+  }
 
   function handleTrustPeer() {
     setPairingError(null);
-      setPairingMessage(null);
+    setPairingMessage(null);
     try {
-      trustPeerMutation.mutate(parsePairingPayload(pairingPayloadDraft));
+      trustPeerMutation.mutate(parsePairingInput(pairingInputValue));
     } catch (error) {
       setPairingError(error instanceof Error ? error.message : "Pairing payload is invalid.");
     }
@@ -639,21 +663,40 @@ export function ActivitySyncPanel() {
     setPairingError(null);
     setPairingMessage(null);
     try {
-      answerPairingOfferMutation.mutate(parsePairingPayload(pairingPayloadDraft));
+      answerPairingOfferMutation.mutate(parsePairingInput(pairingInputValue));
     } catch (error) {
       setPairingError(error instanceof Error ? error.message : "Pairing payload is invalid.");
     }
   }
 
-  async function handleCopyVisiblePairingPayload() {
+  async function handleCopyPairingCode() {
     setPairingError(null);
-    const label = pairingOfferLabel === "Pairing response" ? "Pairing response" : "Pairing offer";
-    if (!pairingOfferText.trim()) {
+    const label = pairingOutput?.kind === "response" ? "Pairing response" : "Pairing offer";
+    if (!pairingOutput?.code.trim()) {
       setPairingError(`No ${label.toLowerCase()} to copy.`);
       return;
     }
     try {
-      const copied = await copyToClipboard(pairingOfferText, pairingOutputRef.current);
+      const copied = await copyToClipboard(pairingOutput.code, pairingCodeOutputRef.current);
+      setPairingMessage(
+        copied
+          ? `${label} code copied.`
+          : `${label} ready. Select the text from the box if clipboard access is unavailable.`,
+      );
+    } catch {
+      setPairingMessage(`${label} ready. Select the text from the box if clipboard access is unavailable.`);
+    }
+  }
+
+  async function handleCopyRawPairingPayload() {
+    setPairingError(null);
+    const label = pairingOutput?.kind === "response" ? "Pairing response raw JSON" : "Pairing offer raw JSON";
+    if (!pairingOutput?.rawJson.trim()) {
+      setPairingError(`No ${label.toLowerCase()} to copy.`);
+      return;
+    }
+    try {
+      const copied = await copyToClipboard(pairingOutput.rawJson, rawPairingOutputRef.current);
       setPairingMessage(
         copied
           ? `${label} copied.`
@@ -674,6 +717,7 @@ export function ActivitySyncPanel() {
 
   const listenerMutationPending = startListenerMutation.isPending || stopListenerMutation.isPending;
   const pairingPayloadPending = answerPairingOfferMutation.isPending || trustPeerMutation.isPending;
+  const pairingInputInvalid = Boolean(pairingInputValue && decodedPairingInput.error);
   const trustedPeers = peersQuery.data ?? [];
   const lastListenerUpdatedAt = formatTimestamp(listenerQuery.data?.updated_at);
 
@@ -768,7 +812,7 @@ export function ActivitySyncPanel() {
             <button
               className="button button--ghost button--small"
               disabled={!listenerActive || createPairingOfferMutation.isPending}
-              onClick={() => createPairingOfferMutation.mutate()}
+              onClick={handleCreatePairingOffer}
               title={
                 listenerActive
                   ? "Creates a fresh local pairing offer."
@@ -780,49 +824,110 @@ export function ActivitySyncPanel() {
             </button>
           </div>
 
-          {pairingOfferText ? (
-            <div className="activity-sync-field">
-              <div className="activity-sync-field__header">
-                <label htmlFor="activity-sync-pairing-output">{pairingOfferLabel}</label>
-                <button
-                  className="button button--ghost button--small"
-                  onClick={handleCopyVisiblePairingPayload}
-                  type="button"
-                >
-                  {pairingOfferLabel === "Pairing response" ? "Copy Pairing Response" : "Copy Pairing Offer"}
-                </button>
+          {pairingOutput ? (
+            <div className="activity-sync-pairing-output">
+              <div className="activity-sync-pairing-output__meta">
+                <span className="activity-sync-pairing-state">{pairingOutput.state}</span>
+                <span>{pairingOutput.kind === "response" ? "Pairing response code" : "Local pairing code"}</span>
+                <span>Fingerprint {pairingFingerprint(pairingOutput.payload)}</span>
               </div>
-              <textarea
-                aria-label={pairingOfferLabel}
-                id="activity-sync-pairing-output"
-                onFocus={(event) => event.currentTarget.select()}
-                readOnly
-                ref={pairingOutputRef}
-                value={pairingOfferText}
-              />
+              <div className="activity-sync-pairing-output__body">
+                <label className="activity-sync-field">
+                  <span>{pairingOutput.kind === "response" ? "Pairing response code" : "Local pairing code"}</span>
+                  <textarea
+                    aria-label={pairingOutput.kind === "response" ? "Pairing response code" : "Local pairing code"}
+                    onFocus={(event) => event.currentTarget.select()}
+                    readOnly
+                    ref={pairingCodeOutputRef}
+                    value={pairingOutput.code}
+                  />
+                </label>
+                <div
+                  aria-label={
+                    pairingOutput.kind === "response"
+                      ? "Pairing response QR code"
+                      : "Pairing offer QR code"
+                  }
+                  className="activity-sync-pairing-qr"
+                  role="img"
+                >
+                  <QRCodeSVG
+                    bgColor="#ffffff"
+                    fgColor="#111827"
+                    level="L"
+                    marginSize={4}
+                    size={288}
+                    value={pairingOutput.code}
+                  />
+                </div>
+              </div>
+              <button
+                className="button button--ghost button--small"
+                onClick={handleCopyPairingCode}
+                type="button"
+              >
+                {pairingOutput.kind === "response" ? "Copy Response Code" : "Copy Pairing Code"}
+              </button>
             </div>
           ) : null}
 
           <label className="activity-sync-field">
-            <span>Peer offer or response payload</span>
+            <span>Peer pairing code</span>
             <textarea
-              onChange={(event) => setPairingPayloadDraft(event.currentTarget.value)}
-              placeholder='{"device_id":"...","pairing_offer_id":"..."}'
-              value={pairingPayloadDraft}
+              aria-label="Peer pairing code"
+              onChange={(event) => handlePairingCodeDraftChange(event.currentTarget.value)}
+              placeholder="TFPAIR1..."
+              value={pairingCodeDraft}
             />
           </label>
+
+          {qrScanSupported ? (
+            <div className="activity-sync-actions">
+              <button
+                className="button button--ghost button--small"
+                disabled={scanPairingQrMutation.isPending}
+                onClick={() => scanPairingQrMutation.mutate()}
+                title="Scan a pairing QR code with this device camera."
+                type="button"
+              >
+                {scanPairingQrMutation.isPending ? "Scanning..." : "Scan QR"}
+              </button>
+            </div>
+          ) : null}
+
+          {decodedPairingInput.payload ? (
+            <div className="activity-sync-peer-preview" aria-label="Peer pairing confirmation">
+              <strong>{pairingPayloadLabel(decodedPairingInput.payload)}</strong>
+              <dl>
+                <div>
+                  <dt>Fingerprint</dt>
+                  <dd>{pairingFingerprint(decodedPairingInput.payload)}</dd>
+                </div>
+                <div>
+                  <dt>Device</dt>
+                  <dd>{decodedPairingInput.payload.device_id}</dd>
+                </div>
+              </dl>
+            </div>
+          ) : null}
+          {decodedPairingInput.error ? (
+            <p className="activity-sync-alert activity-sync-alert--error" role="alert">
+              {decodedPairingInput.error}
+            </p>
+          ) : null}
+
           <label className="activity-sync-checkbox">
             <input
               checked={adoptSyncGroup}
               onChange={(event) => setAdoptSyncGroup(event.currentTarget.checked)}
               type="checkbox"
             />
-            <span>Adopt peer sync group</span>
+            <span>Adopt peer sync group for third-device join</span>
           </label>
           <div className="activity-sync-actions">
             <button
               className="button button--primary button--small"
-              disabled={!pairingPayloadDraft.trim() || pairingPayloadPending}
+              disabled={!pairingInputValue || pairingInputInvalid || pairingPayloadPending}
               onClick={handleAnswerPairingOffer}
               type="button"
             >
@@ -830,13 +935,51 @@ export function ActivitySyncPanel() {
             </button>
             <button
               className="button button--ghost button--small"
-              disabled={!pairingPayloadDraft.trim() || pairingPayloadPending}
+              disabled={!pairingInputValue || pairingInputInvalid || pairingPayloadPending}
               onClick={handleTrustPeer}
               type="button"
             >
               {trustPeerMutation.isPending ? "Trusting..." : "Trust Response"}
             </button>
           </div>
+          <details className="activity-sync-advanced">
+            <summary>Advanced</summary>
+            <label className="activity-sync-field">
+              <span>Pasted raw JSON payload</span>
+              <textarea
+                aria-label="Pasted raw JSON payload"
+                onChange={(event) => handleRawPairingPayloadDraftChange(event.currentTarget.value)}
+                placeholder='{"device_id":"...","pairing_offer_id":"..."}'
+                value={rawPairingPayloadDraft}
+              />
+            </label>
+            {pairingOutput ? (
+              <div className="activity-sync-field">
+                <div className="activity-sync-field__header">
+                  <label htmlFor="activity-sync-pairing-output-raw">
+                    {pairingOutput.kind === "response" ? "Pairing response raw JSON" : "Local pairing offer raw JSON"}
+                  </label>
+                  <button
+                    className="button button--ghost button--small"
+                    onClick={handleCopyRawPairingPayload}
+                    type="button"
+                  >
+                    {pairingOutput.kind === "response" ? "Copy Raw Response" : "Copy Raw Offer"}
+                  </button>
+                </div>
+                <textarea
+                  aria-label={
+                    pairingOutput.kind === "response" ? "Pairing response raw JSON" : "Local pairing offer raw JSON"
+                  }
+                  id="activity-sync-pairing-output-raw"
+                  onFocus={(event) => event.currentTarget.select()}
+                  readOnly
+                  ref={rawPairingOutputRef}
+                  value={pairingOutput.rawJson}
+                />
+              </div>
+            ) : null}
+          </details>
           {pairingMessage ? (
             <p className="activity-sync-alert" role="status">
               {pairingMessage}

--- a/apps/desktop/src/features/activity/syncPairingCode.test.ts
+++ b/apps/desktop/src/features/activity/syncPairingCode.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import type { SyncPairingPayloadSchema } from "../../lib/api";
+import {
+  decodePairingCode,
+  encodePairingCode,
+  PAIRING_CODE_PREFIX,
+  pairingCodeIsExpired,
+  pairingFingerprint,
+} from "./syncPairingCode";
+
+const pairingPayload: SyncPairingPayloadSchema = {
+  sync_group_id: "sync_group_1",
+  device_id: "device_peer_1",
+  display_name: "Peer Phone",
+  public_key: "public-key-peer-1",
+  endpoint_hints: ["tuneforge-sync+iroh://device_peer_1"],
+  protocol_version: "1",
+  pairing_offer_id: "pairing_offer_1",
+  pairing_secret: "pairing-secret-peer-1",
+  expires_at: "2026-05-22T12:00:00.000Z",
+  signature: "pairing-signature",
+};
+
+describe("sync pairing code helpers", () => {
+  it("roundtrips compact pairing codes", () => {
+    const encoded = encodePairingCode(pairingPayload);
+    const legacyCompactCode = `${PAIRING_CODE_PREFIX}.${btoa(JSON.stringify(pairingPayload))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/g, "")}`;
+
+    expect(encoded.startsWith(`${PAIRING_CODE_PREFIX}.`)).toBe(true);
+    expect(encoded).not.toContain(pairingPayload.pairing_secret);
+    expect(encoded.length).toBeLessThan(legacyCompactCode.length);
+    expect(decodePairingCode(encoded)).toEqual(pairingPayload);
+    expect(decodePairingCode(legacyCompactCode)).toEqual(pairingPayload);
+  });
+
+  it("decodes legacy JSON payloads", () => {
+    expect(decodePairingCode(JSON.stringify(pairingPayload))).toEqual(pairingPayload);
+  });
+
+  it("decodes legacy wrapped JSON payloads", () => {
+    expect(decodePairingCode(JSON.stringify({ payload: pairingPayload }))).toEqual(pairingPayload);
+  });
+
+  it("rejects compact codes with an unsupported prefix", () => {
+    expect(() => decodePairingCode("TFPAIR2.invalid")).toThrow("unsupported prefix");
+  });
+
+  it("rejects payloads missing required signed fields", () => {
+    const missingSignature: Partial<SyncPairingPayloadSchema> = { ...pairingPayload };
+    delete missingSignature.signature;
+
+    expect(() => decodePairingCode(JSON.stringify(missingSignature))).toThrow("signature");
+  });
+
+  it("checks expiration relative to the provided time", () => {
+    expect(pairingCodeIsExpired(pairingPayload, new Date("2026-05-22T11:59:59.999Z"))).toBe(false);
+    expect(pairingCodeIsExpired(pairingPayload, new Date("2026-05-22T12:00:00.000Z"))).toBe(true);
+  });
+
+  it("creates stable fingerprints without using pairing secrets", () => {
+    const rotatedSecretPayload: SyncPairingPayloadSchema = {
+      ...pairingPayload,
+      pairing_secret: "different-secret",
+    };
+    const fingerprint = pairingFingerprint(pairingPayload);
+
+    expect(fingerprint).toBe("FAC0-7B9E-6D8E-FC91");
+    expect(fingerprint).toMatch(/^[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}$/);
+    expect(pairingFingerprint(pairingPayload)).toBe(fingerprint);
+    expect(pairingFingerprint(rotatedSecretPayload)).toBe(fingerprint);
+    expect(pairingFingerprint({ ...pairingPayload, public_key: "different-public-key" })).not.toBe(fingerprint);
+    expect(pairingFingerprint({ ...pairingPayload, device_id: "different-device-id" })).not.toBe(fingerprint);
+  });
+
+  it("falls back to device id for fingerprints when public key is missing", () => {
+    expect(pairingFingerprint({ device_id: "device_peer_1" })).toBe(
+      pairingFingerprint({ device_id: "device_peer_1", public_key: " " }),
+    );
+    expect(pairingFingerprint({})).toBe("0000-0000-0000-0000");
+  });
+});

--- a/apps/desktop/src/features/activity/syncPairingCode.ts
+++ b/apps/desktop/src/features/activity/syncPairingCode.ts
@@ -1,0 +1,388 @@
+import type { SyncPairingPayloadSchema } from "../../lib/api";
+
+export const PAIRING_CODE_PREFIX = "TFPAIR1";
+
+const BASE64_URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+const COMPACT_CODE_PATTERN = /^([A-Z0-9]+)\.(.*)$/;
+const FINGERPRINT_VERSION = 1;
+const FINGERPRINT_HEX_LENGTH = 16;
+const SHA256_INITIAL_HASH = [
+  0x6a09e667,
+  0xbb67ae85,
+  0x3c6ef372,
+  0xa54ff53a,
+  0x510e527f,
+  0x9b05688c,
+  0x1f83d9ab,
+  0x5be0cd19,
+] as const;
+const SHA256_ROUND_CONSTANTS = [
+  0x428a2f98,
+  0x71374491,
+  0xb5c0fbcf,
+  0xe9b5dba5,
+  0x3956c25b,
+  0x59f111f1,
+  0x923f82a4,
+  0xab1c5ed5,
+  0xd807aa98,
+  0x12835b01,
+  0x243185be,
+  0x550c7dc3,
+  0x72be5d74,
+  0x80deb1fe,
+  0x9bdc06a7,
+  0xc19bf174,
+  0xe49b69c1,
+  0xefbe4786,
+  0x0fc19dc6,
+  0x240ca1cc,
+  0x2de92c6f,
+  0x4a7484aa,
+  0x5cb0a9dc,
+  0x76f988da,
+  0x983e5152,
+  0xa831c66d,
+  0xb00327c8,
+  0xbf597fc7,
+  0xc6e00bf3,
+  0xd5a79147,
+  0x06ca6351,
+  0x14292967,
+  0x27b70a85,
+  0x2e1b2138,
+  0x4d2c6dfc,
+  0x53380d13,
+  0x650a7354,
+  0x766a0abb,
+  0x81c2c92e,
+  0x92722c85,
+  0xa2bfe8a1,
+  0xa81a664b,
+  0xc24b8b70,
+  0xc76c51a3,
+  0xd192e819,
+  0xd6990624,
+  0xf40e3585,
+  0x106aa070,
+  0x19a4c116,
+  0x1e376c08,
+  0x2748774c,
+  0x34b0bcb5,
+  0x391c0cb3,
+  0x4ed8aa4a,
+  0x5b9cca4f,
+  0x682e6ff3,
+  0x748f82ee,
+  0x78a5636f,
+  0x84c87814,
+  0x8cc70208,
+  0x90befffa,
+  0xa4506ceb,
+  0xbef9a3f7,
+  0xc67178f2,
+] as const;
+
+type PairingPayloadRecord = Record<string, unknown>;
+type CompactPairingPayload = [
+  syncGroupId: string,
+  deviceId: string,
+  displayName: string | null,
+  publicKey: string,
+  endpointHints: string[],
+  protocolVersion: string,
+  pairingOfferId: string,
+  pairingSecret: string,
+  expiresAt: string,
+  signature: string,
+];
+
+export type PairingFingerprintSource = {
+  device_id?: string | null;
+  public_key?: string | null;
+};
+
+function asRecord(value: unknown): PairingPayloadRecord | null {
+  return typeof value === "object" && value !== null ? value as PairingPayloadRecord : null;
+}
+
+function requiredPairingString(
+  payloadRecord: PairingPayloadRecord,
+  fieldName: keyof SyncPairingPayloadSchema,
+): string {
+  const value = payloadRecord[fieldName];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`Pairing payload is missing ${fieldName}.`);
+  }
+  return value;
+}
+
+function pairingEndpointHints(value: unknown): string[] {
+  if (value === undefined) {
+    return [];
+  }
+  if (
+    !Array.isArray(value) ||
+    !value.every((hint): hint is string => typeof hint === "string" && Boolean(hint.trim()))
+  ) {
+    throw new Error("Pairing payload endpoint_hints must be a list of strings.");
+  }
+  return value;
+}
+
+function parseJson(value: string, errorMessage: string): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    throw new Error(errorMessage);
+  }
+}
+
+function encodeBase64Url(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (let index = 0; index < bytes.length; index += 0x8000) {
+    binary += String.fromCharCode(...bytes.slice(index, index + 0x8000));
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function decodeBase64Url(value: string): string {
+  if (!BASE64_URL_PATTERN.test(value)) {
+    throw new Error("Pairing code payload must be base64url.");
+  }
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const remainder = normalized.length % 4;
+  if (remainder === 1) {
+    throw new Error("Pairing code payload is malformed.");
+  }
+  const padded = normalized.padEnd(
+    normalized.length + (remainder === 0 ? 0 : 4 - remainder),
+    "=",
+  );
+
+  let binary: string;
+  try {
+    binary = atob(padded);
+  } catch {
+    throw new Error("Pairing code payload is malformed.");
+  }
+
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new Error("Pairing code payload must be valid UTF-8.");
+  }
+}
+
+function pairingPayloadRecord(parsed: unknown): PairingPayloadRecord {
+  if (Array.isArray(parsed)) {
+    return pairingPayloadRecordFromCompactArray(parsed);
+  }
+  const parsedRecord = asRecord(parsed);
+  const pairingOfferRecord = asRecord(parsedRecord?.pairing_offer);
+  const payloadRecord =
+    asRecord(parsedRecord?.payload) ??
+    asRecord(pairingOfferRecord?.payload) ??
+    asRecord(parsedRecord?.pairing_response) ??
+    parsedRecord;
+  if (!payloadRecord) {
+    throw new Error("Pairing payload must be a JSON object.");
+  }
+  return payloadRecord;
+}
+
+function pairingPayloadRecordFromCompactArray(value: unknown[]): PairingPayloadRecord {
+  if (value.length !== 10) {
+    throw new Error("Pairing code compact payload is malformed.");
+  }
+  const [
+    syncGroupId,
+    deviceId,
+    displayName,
+    publicKey,
+    endpointHints,
+    protocolVersion,
+    pairingOfferId,
+    pairingSecret,
+    expiresAt,
+    signature,
+  ] = value;
+
+  return {
+    sync_group_id: syncGroupId,
+    device_id: deviceId,
+    display_name: displayName,
+    public_key: publicKey,
+    endpoint_hints: endpointHints,
+    protocol_version: protocolVersion,
+    pairing_offer_id: pairingOfferId,
+    pairing_secret: pairingSecret,
+    expires_at: expiresAt,
+    signature,
+  };
+}
+
+function validatePairingPayload(parsed: unknown): SyncPairingPayloadSchema {
+  const payloadRecord = pairingPayloadRecord(parsed);
+  const displayName = payloadRecord.display_name;
+  if (displayName !== undefined && displayName !== null && typeof displayName !== "string") {
+    throw new Error("Pairing payload display_name must be a string.");
+  }
+  const expiresAt = requiredPairingString(payloadRecord, "expires_at");
+  if (Number.isNaN(new Date(expiresAt).getTime())) {
+    throw new Error("Pairing payload expires_at must be a valid date.");
+  }
+
+  return {
+    sync_group_id: requiredPairingString(payloadRecord, "sync_group_id"),
+    device_id: requiredPairingString(payloadRecord, "device_id"),
+    display_name: displayName ?? null,
+    public_key: requiredPairingString(payloadRecord, "public_key"),
+    endpoint_hints: pairingEndpointHints(payloadRecord.endpoint_hints),
+    protocol_version: requiredPairingString(payloadRecord, "protocol_version"),
+    pairing_offer_id: requiredPairingString(payloadRecord, "pairing_offer_id"),
+    pairing_secret: requiredPairingString(payloadRecord, "pairing_secret"),
+    expires_at: expiresAt,
+    signature: requiredPairingString(payloadRecord, "signature"),
+  };
+}
+
+function rotateRight(value: number, bits: number) {
+  return (value >>> bits) | (value << (32 - bits));
+}
+
+function sha256Hex(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  const bitLength = bytes.length * 8;
+  const paddedLength = Math.ceil((bytes.length + 9) / 64) * 64;
+  const padded = new Uint8Array(paddedLength);
+  padded.set(bytes);
+  padded[bytes.length] = 0x80;
+
+  const view = new DataView(padded.buffer);
+  view.setUint32(paddedLength - 8, Math.floor(bitLength / 0x100000000), false);
+  view.setUint32(paddedLength - 4, bitLength >>> 0, false);
+
+  const words = new Uint32Array(64);
+  const hash: number[] = [...SHA256_INITIAL_HASH];
+  for (let chunkOffset = 0; chunkOffset < paddedLength; chunkOffset += 64) {
+    for (let index = 0; index < 16; index += 1) {
+      words[index] = view.getUint32(chunkOffset + index * 4, false);
+    }
+    for (let index = 16; index < 64; index += 1) {
+      const s0 =
+        rotateRight(words[index - 15], 7) ^
+        rotateRight(words[index - 15], 18) ^
+        (words[index - 15] >>> 3);
+      const s1 =
+        rotateRight(words[index - 2], 17) ^
+        rotateRight(words[index - 2], 19) ^
+        (words[index - 2] >>> 10);
+      words[index] = (words[index - 16] + s0 + words[index - 7] + s1) >>> 0;
+    }
+
+    let [a, b, c, d, e, f, g, h] = hash;
+    for (let index = 0; index < 64; index += 1) {
+      const s1 = rotateRight(e, 6) ^ rotateRight(e, 11) ^ rotateRight(e, 25);
+      const ch = (e & f) ^ (~e & g);
+      const temp1 = (h + s1 + ch + SHA256_ROUND_CONSTANTS[index] + words[index]) >>> 0;
+      const s0 = rotateRight(a, 2) ^ rotateRight(a, 13) ^ rotateRight(a, 22);
+      const maj = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = (s0 + maj) >>> 0;
+
+      h = g;
+      g = f;
+      f = e;
+      e = (d + temp1) >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (temp1 + temp2) >>> 0;
+    }
+
+    hash[0] = (hash[0] + a) >>> 0;
+    hash[1] = (hash[1] + b) >>> 0;
+    hash[2] = (hash[2] + c) >>> 0;
+    hash[3] = (hash[3] + d) >>> 0;
+    hash[4] = (hash[4] + e) >>> 0;
+    hash[5] = (hash[5] + f) >>> 0;
+    hash[6] = (hash[6] + g) >>> 0;
+    hash[7] = (hash[7] + h) >>> 0;
+  }
+
+  return hash.map((part) => part.toString(16).padStart(8, "0")).join("");
+}
+
+function pairingFingerprintMaterial(payloadOrPeer: PairingFingerprintSource) {
+  const publicKey = payloadOrPeer.public_key?.trim() ?? "";
+  const deviceId = payloadOrPeer.device_id?.trim() ?? "";
+  if (publicKey) {
+    return JSON.stringify({
+      version: FINGERPRINT_VERSION,
+      public_key: publicKey,
+      device_id: deviceId,
+    });
+  }
+  if (deviceId) {
+    return JSON.stringify({
+      version: FINGERPRINT_VERSION,
+      device_id: deviceId,
+    });
+  }
+  return null;
+}
+
+export function encodePairingCode(payload: SyncPairingPayloadSchema): string {
+  const compactPayload: CompactPairingPayload = [
+    payload.sync_group_id,
+    payload.device_id,
+    payload.display_name ?? null,
+    payload.public_key,
+    payload.endpoint_hints ?? [],
+    payload.protocol_version,
+    payload.pairing_offer_id,
+    payload.pairing_secret,
+    payload.expires_at,
+    payload.signature,
+  ];
+  return `${PAIRING_CODE_PREFIX}.${encodeBase64Url(JSON.stringify(compactPayload))}`;
+}
+
+export function decodePairingCode(raw: string): SyncPairingPayloadSchema {
+  const trimmed = raw.trim();
+  const compactMatch = COMPACT_CODE_PATTERN.exec(trimmed);
+  if (compactMatch) {
+    const [, prefix, encodedPayload] = compactMatch;
+    if (prefix !== PAIRING_CODE_PREFIX) {
+      throw new Error("Pairing code uses an unsupported prefix.");
+    }
+    if (!encodedPayload) {
+      throw new Error("Pairing code payload is missing.");
+    }
+    return validatePairingPayload(
+      parseJson(decodeBase64Url(encodedPayload), "Pairing code payload must be valid JSON."),
+    );
+  }
+
+  return validatePairingPayload(parseJson(trimmed, "Pairing payload must be valid JSON."));
+}
+
+export function pairingFingerprint(payloadOrPeer: PairingFingerprintSource): string {
+  const material = pairingFingerprintMaterial(payloadOrPeer);
+  if (!material) {
+    return "0000-0000-0000-0000";
+  }
+
+  const hex = sha256Hex(material).slice(0, FINGERPRINT_HEX_LENGTH).toUpperCase();
+  return hex.match(/.{1,4}/g)?.join("-") ?? "0000-0000-0000-0000";
+}
+
+export function pairingCodeIsExpired(payload: SyncPairingPayloadSchema, now: Date = new Date()): boolean {
+  const expiresAt = new Date(payload.expires_at).getTime();
+  return Number.isNaN(expiresAt) || expiresAt <= now.getTime();
+}

--- a/apps/desktop/src/lib/pairingQrScanner.test.ts
+++ b/apps/desktop/src/lib/pairingQrScanner.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockCheckPermissions, mockIsTauri, mockRequestPermissions, mockScan } = vi.hoisted(() => ({
+  mockCheckPermissions: vi.fn(),
+  mockIsTauri: vi.fn(),
+  mockRequestPermissions: vi.fn(),
+  mockScan: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  isTauri: mockIsTauri,
+}));
+
+vi.mock("@tauri-apps/plugin-barcode-scanner", () => ({
+  Format: {
+    QRCode: "QR_CODE",
+  },
+  checkPermissions: mockCheckPermissions,
+  requestPermissions: mockRequestPermissions,
+  scan: mockScan,
+}));
+
+import { scanPairingQrCode } from "./pairingQrScanner";
+
+const originalUserAgent = navigator.userAgent;
+
+function setUserAgent(userAgent: string) {
+  Object.defineProperty(window.navigator, "userAgent", {
+    configurable: true,
+    value: userAgent,
+  });
+}
+
+describe("pairing QR scanner", () => {
+  beforeEach(() => {
+    mockIsTauri.mockReturnValue(true);
+    mockCheckPermissions.mockResolvedValue("granted");
+    mockRequestPermissions.mockResolvedValue("granted");
+    mockScan.mockReset();
+    setUserAgent("Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36");
+  });
+
+  afterEach(() => {
+    setUserAgent(originalUserAgent);
+    vi.resetAllMocks();
+  });
+
+  it("scans QR codes with the back camera", async () => {
+    mockScan.mockResolvedValue({
+      bounds: {},
+      content: " tuneforge-sync://pairing-offer ",
+      format: "QR_CODE",
+    });
+
+    await expect(scanPairingQrCode()).resolves.toBe("tuneforge-sync://pairing-offer");
+    expect(mockScan).toHaveBeenCalledWith({
+      cameraDirection: "back",
+      formats: ["QR_CODE"],
+    });
+    expect(mockRequestPermissions).not.toHaveBeenCalled();
+  });
+
+  it("requests camera permission before scanning", async () => {
+    mockCheckPermissions.mockResolvedValue("prompt");
+    mockRequestPermissions.mockResolvedValue("granted");
+    mockScan.mockResolvedValue({
+      bounds: {},
+      content: "TFPAIR1.code",
+      format: "QR_CODE",
+    });
+
+    await expect(scanPairingQrCode()).resolves.toBe("TFPAIR1.code");
+    expect(mockRequestPermissions).toHaveBeenCalledTimes(1);
+    expect(mockScan).toHaveBeenCalledWith({
+      cameraDirection: "back",
+      formats: ["QR_CODE"],
+    });
+  });
+
+  it("rejects denied camera permission before starting the scanner", async () => {
+    mockCheckPermissions.mockResolvedValue("prompt");
+    mockRequestPermissions.mockResolvedValue("denied");
+
+    await expect(scanPairingQrCode()).rejects.toThrow("Camera permission denied.");
+    expect(mockScan).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-Tauri runtimes before starting the scanner", async () => {
+    mockIsTauri.mockReturnValue(false);
+
+    await expect(scanPairingQrCode()).rejects.toThrow(
+      "Pairing QR scanning is only available in the TuneForge Android app.",
+    );
+    expect(mockScan).not.toHaveBeenCalled();
+  });
+
+  it("rejects desktop Tauri runtimes before starting the scanner", async () => {
+    setUserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15");
+
+    await expect(scanPairingQrCode()).rejects.toThrow(
+      "Pairing QR scanning is only available in the TuneForge Android app.",
+    );
+    expect(mockScan).not.toHaveBeenCalled();
+  });
+
+  it("rejects iOS Tauri runtimes before starting the scanner", async () => {
+    setUserAgent("Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15");
+
+    await expect(scanPairingQrCode()).rejects.toThrow(
+      "Pairing QR scanning is only available in the TuneForge Android app.",
+    );
+    expect(mockScan).not.toHaveBeenCalled();
+  });
+
+  it("maps scanner errors to concise messages", async () => {
+    mockScan.mockRejectedValue(new Error("camera permission denied"));
+
+    await expect(scanPairingQrCode()).rejects.toThrow("Camera permission denied.");
+
+    mockScan.mockRejectedValue(new Error("No permission to use camera. Did you request it yet?"));
+
+    await expect(scanPairingQrCode()).rejects.toThrow("Camera permission denied.");
+
+    mockScan.mockRejectedValue("plugin barcode-scanner not found");
+
+    await expect(scanPairingQrCode()).rejects.toThrow(
+      "Pairing QR scanning is only available in the TuneForge Android app.",
+    );
+  });
+});

--- a/apps/desktop/src/lib/pairingQrScanner.ts
+++ b/apps/desktop/src/lib/pairingQrScanner.ts
@@ -1,0 +1,89 @@
+import { isTauri } from "@tauri-apps/api/core";
+import { Format, checkPermissions, requestPermissions, scan } from "@tauri-apps/plugin-barcode-scanner";
+
+const unsupportedScannerMessage =
+  "Pairing QR scanning is only available in the TuneForge Android app.";
+
+export async function scanPairingQrCode(): Promise<string> {
+  if (!isPairingQrScannerAvailable()) {
+    throw new Error(unsupportedScannerMessage);
+  }
+
+  try {
+    await ensureCameraPermission();
+    const scanned = await scan({
+      cameraDirection: "back",
+      formats: [Format.QRCode],
+    });
+    const content = scanned.content.trim();
+    if (!content) {
+      throw new Error("Scanned QR code was empty.");
+    }
+    return content;
+  } catch (error) {
+    throw createPairingQrScanError(error);
+  }
+}
+
+async function ensureCameraPermission() {
+  const currentPermission = await checkPermissions();
+  if (currentPermission === "granted") {
+    return;
+  }
+
+  const requestedPermission = await requestPermissions();
+  if (requestedPermission !== "granted") {
+    throw new Error("Camera permission denied.");
+  }
+}
+
+function isPairingQrScannerAvailable() {
+  return isTauri() && isMobileUserAgent();
+}
+
+function isMobileUserAgent() {
+  return typeof navigator !== "undefined" && /\bAndroid\b/i.test(navigator.userAgent);
+}
+
+function pairingQrScanErrorMessage(error: unknown) {
+  const message = errorMessage(error);
+  const normalizedMessage = message.toLowerCase();
+
+  if (normalizedMessage.includes("empty")) {
+    return "Scanned QR code was empty.";
+  }
+  if (
+    normalizedMessage.includes("permission") &&
+    (normalizedMessage.includes("denied") || normalizedMessage.includes("no permission"))
+  ) {
+    return "Camera permission denied.";
+  }
+  if (normalizedMessage.includes("cancel")) {
+    return "QR scan canceled.";
+  }
+  if (
+    normalizedMessage.includes("plugin") ||
+    normalizedMessage.includes("not found") ||
+    normalizedMessage.includes("not implemented") ||
+    normalizedMessage.includes("unavailable") ||
+    normalizedMessage.includes("unsupported")
+  ) {
+    return unsupportedScannerMessage;
+  }
+
+  return "Could not scan pairing QR code.";
+}
+
+function createPairingQrScanError(error: unknown) {
+  return Object.assign(new Error(pairingQrScanErrorMessage(error)), { cause: error });
+}
+
+function errorMessage(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return String(error);
+}

--- a/apps/desktop/src/styles/activity.css
+++ b/apps/desktop/src/styles/activity.css
@@ -472,6 +472,102 @@
   outline-offset: 2px;
 }
 
+.activity-sync-pairing-output,
+.activity-sync-peer-preview,
+.activity-sync-advanced {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.activity-sync-pairing-output {
+  border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+  border-radius: 8px;
+  padding: 0.85rem;
+  background: color-mix(in srgb, var(--surface-muted) 52%, transparent);
+}
+
+.activity-sync-pairing-output__meta {
+  display: flex;
+  gap: 0.55rem;
+  align-items: center;
+  flex-wrap: wrap;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 760;
+}
+
+.activity-sync-pairing-state {
+  border: 1px solid color-mix(in srgb, var(--playback-accent) 38%, var(--chip-border));
+  border-radius: 999px;
+  padding: 0.16rem 0.48rem;
+  background: color-mix(in srgb, var(--chip-bg) 78%, transparent);
+  color: var(--text);
+}
+
+.activity-sync-pairing-output__body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.85rem;
+  align-items: start;
+}
+
+.activity-sync-pairing-qr {
+  display: grid;
+  place-items: center;
+  width: min(100%, 18rem);
+  aspect-ratio: 1;
+  border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+  border-radius: 8px;
+  background: #ffffff;
+  color: var(--text);
+}
+
+.activity-sync-pairing-qr svg {
+  width: 100%;
+  height: auto;
+}
+
+.activity-sync-peer-preview {
+  border-left: 3px solid var(--playback-accent);
+  padding-left: 0.75rem;
+}
+
+.activity-sync-peer-preview dl {
+  display: grid;
+  gap: 0.35rem;
+  margin: 0;
+}
+
+.activity-sync-peer-preview dt {
+  color: var(--muted);
+  font-size: 0.74rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.activity-sync-peer-preview dd {
+  margin: 0.12rem 0 0;
+  overflow-wrap: anywhere;
+}
+
+.activity-sync-unsupported {
+  align-self: center;
+  color: var(--muted);
+  font-size: 0.86rem;
+  font-weight: 720;
+}
+
+.activity-sync-advanced {
+  border-top: 1px solid color-mix(in srgb, var(--divider) 74%, transparent);
+  padding-top: 0.75rem;
+}
+
+.activity-sync-advanced summary {
+  cursor: pointer;
+  color: var(--text);
+  font-weight: 800;
+}
+
 .activity-sync-checkbox {
   display: flex;
   gap: 0.5rem;
@@ -558,8 +654,13 @@
   }
 
   .activity-sync-grid,
-  .activity-sync-peer-row {
+  .activity-sync-peer-row,
+  .activity-sync-pairing-output__body {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .activity-sync-pairing-qr {
+    width: min(100%, 18rem);
   }
 
   .activity-sync-project-result {

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -87,6 +87,7 @@ const {
   mockDeleteProject,
   mockGetHealth,
   mockGetMobileCapabilities,
+  mockScanPairingQrCode,
   setMockSystemInputVolume,
   setMockNativeAudio,
   emitMockNativeAudioError,
@@ -1250,6 +1251,9 @@ const {
     preview_format: "wav",
   }));
   const mockGetMobileCapabilities = vi.fn(async (): Promise<unknown> => null);
+  const mockScanPairingQrCode = vi.fn(async (): Promise<string> => {
+    throw new Error("QR scanner unavailable.");
+  });
   const mockListChordBackends = vi.fn(async () => ({ backends: clone(state.chordBackends) }));
   const mockListStemModels = vi.fn(async () => ({ models: clone(state.stemModels) }));
   const mockListProjects = vi.fn(async (params?: ListProjectsParams) => {
@@ -1528,10 +1532,10 @@ const {
         protocol_version: "tuneforge-sync-v1",
         pairing_offer_id: "pair_offer_1",
         pairing_secret: "pair_secret_1",
-        expires_at: "2026-04-18T13:26:00.000Z",
+        expires_at: "2099-04-18T13:26:00.000Z",
         signature: "pair_signature_1",
       },
-      expires_at: "2026-04-18T13:26:00.000Z",
+      expires_at: "2099-04-18T13:26:00.000Z",
       ttl_seconds: body.ttl_seconds,
     },
   }));
@@ -2235,6 +2239,7 @@ const {
     mockDeleteProject,
     mockGetHealth,
     mockGetMobileCapabilities,
+    mockScanPairingQrCode,
     setMockSystemInputVolume,
     setMockNativeAudio,
     emitMockNativeAudioError,
@@ -2304,6 +2309,7 @@ export {
   mockDeleteProject,
   mockGetHealth,
   mockGetMobileCapabilities,
+  mockScanPairingQrCode,
   mockListen,
 };
 
@@ -2370,6 +2376,10 @@ vi.mock("../lib/api", async (importOriginal) => {
     },
   };
 });
+
+vi.mock("../lib/pairingQrScanner", () => ({
+  scanPairingQrCode: mockScanPairingQrCode,
+}));
 
 export function renderApp(initialEntries: string[]) {
   if (
@@ -2758,7 +2768,10 @@ export function resetAppTestHarness() {
   mockDeleteArtifact.mockClear();
   mockDeleteProject.mockClear();
   mockGetHealth.mockClear();
-  mockGetMobileCapabilities.mockClear();
+  mockGetMobileCapabilities.mockReset();
+  mockGetMobileCapabilities.mockResolvedValue(null);
+  mockScanPairingQrCode.mockReset();
+  mockScanPairingQrCode.mockRejectedValue(new Error("QR scanner unavailable."));
   vi.mocked(window.HTMLMediaElement.prototype.play).mockClear();
   vi.mocked(window.HTMLMediaElement.prototype.pause).mockClear();
   getMockFetch().mockClear();

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -99,11 +99,14 @@ build. It keeps these manifest permissions present:
 - `android.permission.INTERNET` for same-LAN TCP/QUIC/UDP sync sockets.
 - `android.permission.RECORD_AUDIO` and `android.permission.MODIFY_AUDIO_SETTINGS` for mobile audio
   flows.
+- `android.permission.CAMERA` for the Android-only QR pairing scanner.
 
 These are package-level permissions only. They do not change the local-only product rule, and they
 must not be used to add cloud, telemetry, account, or remote-processing behavior. Do not add
 Android nearby-device, Bluetooth, location, or Wi-Fi multicast permissions until a concrete local
 discovery implementation requires them.
+The barcode scanner capability is scoped to `android` in the mobile capability file. Keep scanner
+permissions out of other platform capabilities unless a separate scanner flow is designed.
 
 ## Mobile Sync Validation
 
@@ -126,6 +129,11 @@ For accepted mobile sync evidence, sync at least one desktop project to Android,
 source and synced WAV stem artifacts from app-local storage, and compare battery, CPU, storage, and
 transfer costs against AAC/M4A or another compressed baseline. Mobile sync remains library sync
 only; remote processing stays out of scope.
+
+For QR pairing validation, grant the camera permission, scan a pairing QR code with the Android
+build, and record whether the scan produced the expected pairing payload before trusting the peer.
+If the camera permission is denied or the scanner is unavailable, record that blocker and do not
+count QR pairing as validated.
 
 ## Stem Separation Spike
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.11.0
         version: 2.11.0
+      '@tauri-apps/plugin-barcode-scanner':
+        specifier: ~2.4.4
+        version: 2.4.4
       '@tauri-apps/plugin-dialog':
         specifier: ^2.7.1
         version: 2.7.1
@@ -41,6 +44,9 @@ importers:
       openapi-fetch:
         specifier: ^0.17.0
         version: 0.17.0
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -631,6 +637,9 @@ packages:
     resolution: {integrity: sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-barcode-scanner@2.4.4':
+    resolution: {integrity: sha512-uXvyMI8UgQjSrGxzTU5isNoQarMGRxFmTmb4TsgiWZHf/g7LsIyAQCwoFShjax0fXCK5mdVKDOvlkfOr21fo6g==}
 
   '@tauri-apps/plugin-dialog@2.7.1':
     resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
@@ -1541,6 +1550,11 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-dom@19.2.6:
     resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
     peerDependencies:
@@ -2431,6 +2445,10 @@ snapshots:
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.2
       '@tauri-apps/cli-win32-x64-msvc': 2.11.2
 
+  '@tauri-apps/plugin-barcode-scanner@2.4.4':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
   '@tauri-apps/plugin-dialog@2.7.1':
     dependencies:
       '@tauri-apps/api': 2.11.0
@@ -3302,6 +3320,10 @@ snapshots:
       react-is: 17.0.2
 
   punycode@2.3.1: {}
+
+  qrcode.react@4.2.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
 
   react-dom@19.2.6(react@19.2.6):
     dependencies:

--- a/scripts/android-prepare-generated.sh
+++ b/scripts/android-prepare-generated.sh
@@ -41,6 +41,7 @@ ensure_permission() {
 ensure_permission "android.permission.INTERNET"
 ensure_permission "android.permission.RECORD_AUDIO"
 ensure_permission "android.permission.MODIFY_AUDIO_SETTINGS"
+ensure_permission "android.permission.CAMERA"
 
 cat > "$MAIN_ACTIVITY" <<'KOTLIN'
 package com.tuneforge.desktop


### PR DESCRIPTION
## Summary

- Add compact signed `TFPAIR1` pairing codes and QR rendering for sync offers/responses.
- Add Android QR scanning with camera permission handling and Android-only capability wiring.
- Simplify Activity sync pairing UI while keeping raw JSON under Advanced fallback.
- Show peer name and short fingerprint before trust, with explicit third-device sync-group adoption.

Fixes #197

## Testing

- `pnpm --filter @tuneforge/desktop test -- src/App.activity.test.tsx src/lib/pairingQrScanner.test.ts`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm package:android:debug`
- `adb install -r apps/desktop/src-tauri/gen/android/app/build/outputs/apk/universal/debug/app-universal-debug.apk`
- Manual: Android QR scan pairing worked.
- Manual: 3-way macOS/Linux/Android sync passed, including Linux import propagating through Mac to Android.
