### PR TITLE
feat: add local peer discovery

### DIFF
--- a/apps/backend/app/api/routes/sync.py
+++ b/apps/backend/app/api/routes/sync.py
@@ -33,6 +33,7 @@ from app.schemas import (
     SyncTransportHandshakeSignatureResponse,
     SyncTransportHandshakeSignRequest,
     SyncTrustedPeerCreateRequest,
+    SyncTrustedPeerEndpointHintsRequest,
     SyncTrustedPeerResponse,
     SyncTrustedPeerSchema,
     SyncTrustedPeersResponse,
@@ -48,6 +49,7 @@ from app.services.sync_trust import (
     revoke_trusted_peer,
     trust_peer_from_pairing_payload,
     update_local_identity_display_name,
+    update_trusted_peer_endpoint_hints,
 )
 
 router = APIRouter(prefix="/sync", tags=["sync"])
@@ -222,6 +224,20 @@ def sync_trusted_peer_delete(
     session: Session = Depends(get_db),
 ) -> SyncTrustedPeerResponse:
     trusted_peer = revoke_trusted_peer(session, device_id=device_id)
+    return SyncTrustedPeerResponse(trusted_peer=SyncTrustedPeerSchema.model_validate(trusted_peer))
+
+
+@router.patch("/trusted-peers/{device_id}/endpoint-hints", response_model=SyncTrustedPeerResponse)
+def sync_trusted_peer_endpoint_hints_update(
+    device_id: str,
+    payload: SyncTrustedPeerEndpointHintsRequest,
+    session: Session = Depends(get_db),
+) -> SyncTrustedPeerResponse:
+    trusted_peer = update_trusted_peer_endpoint_hints(
+        session,
+        device_id=device_id,
+        endpoint_hints=payload.endpoint_hints,
+    )
     return SyncTrustedPeerResponse(trusted_peer=SyncTrustedPeerSchema.model_validate(trusted_peer))
 
 

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -787,6 +787,18 @@ class SyncTrustedPeerCreateRequest(BaseModel):
         return {"payload": payload, "adopt_sync_group": adopt_sync_group}
 
 
+class SyncTrustedPeerEndpointHintsRequest(BaseModel):
+    endpoint_hints: list[str]
+
+    @field_validator("endpoint_hints")
+    @classmethod
+    def validate_endpoint_hints(cls, value: list[str]) -> list[str]:
+        normalized = [hint.strip() for hint in value]
+        if any(not hint for hint in normalized):
+            raise ValueError("Endpoint hints cannot be empty.")
+        return normalized
+
+
 class SyncTrustedPeerResponse(BaseModel):
     trusted_peer: SyncTrustedPeerSchema
 

--- a/apps/backend/app/services/sync_trust.py
+++ b/apps/backend/app/services/sync_trust.py
@@ -237,6 +237,31 @@ def revoke_trusted_peer(session: Session, device_id: str) -> TrustedSyncPeer:
     return _trusted_peer_from_orm(peer)
 
 
+def update_trusted_peer_endpoint_hints(
+    session: Session,
+    *,
+    device_id: str,
+    endpoint_hints: list[str] | None,
+) -> TrustedSyncPeer:
+    normalized_device_id = _normalize_required_string(device_id, "device_id")
+    normalized_endpoint_hints = _normalize_endpoint_hints(endpoint_hints)
+    peer = session.get(SyncTrustedPeer, normalized_device_id)
+    if peer is None or peer.revoked_at is not None:
+        raise AppError(
+            SYNC_PEER_UNTRUSTED,
+            "Trusted peer is unknown.",
+            status_code=status.HTTP_404_NOT_FOUND,
+            details={"device_id": normalized_device_id},
+        )
+
+    if _normalize_endpoint_hints(peer.endpoint_hints_json) != normalized_endpoint_hints:
+        peer.endpoint_hints_json = normalized_endpoint_hints
+        peer.updated_at = _utcnow()
+        session.flush()
+
+    return _trusted_peer_from_orm(peer)
+
+
 def list_trusted_peers(session: Session) -> list[TrustedSyncPeer]:
     peers = [
         _trusted_peer_from_orm(peer)

--- a/apps/backend/tests/test_sync_trust.py
+++ b/apps/backend/tests/test_sync_trust.py
@@ -53,6 +53,7 @@ class SyncTrustServices:
     list_trusted_peers: SyncTrustService
     revoke_trusted_peer: SyncTrustService
     require_trusted_peer: SyncTrustService
+    update_trusted_peer_endpoint_hints: SyncTrustService
     derive_device_id: SyncTrustService
 
 
@@ -98,6 +99,7 @@ def sync_trust_services() -> SyncTrustServices:
         list_trusted_peers=_require_callable(module, "list_trusted_peers"),
         revoke_trusted_peer=_require_callable(module, "revoke_trusted_peer"),
         require_trusted_peer=_require_callable(module, "require_trusted_peer"),
+        update_trusted_peer_endpoint_hints=_require_callable(module, "update_trusted_peer_endpoint_hints"),
         derive_device_id=derive_device_id,
     )
 
@@ -342,6 +344,95 @@ def test_revoked_peer_is_not_trusted_and_stale_payload_cannot_repair_revocation(
         sync_trust_services.trust_peer(db_session, peer_offer)
 
 
+def test_update_trusted_peer_endpoint_hints_normalizes_and_is_idempotent(
+    db_session: Session,
+    sync_trust_services: SyncTrustServices,
+) -> None:
+    identity = _local_identity(sync_trust_services, db_session)
+    template_offer = _pairing_payload(_pairing_offer(sync_trust_services, db_session))
+    peer_offer = _remote_pairing_offer(
+        sync_trust_services,
+        sync_group_id=identity["sync_group_id"],
+        public_key_like=identity["public_key"],
+        template_offer=template_offer,
+    )
+    sync_trust_services.trust_peer(db_session, peer_offer)
+
+    updated_peer = _plain_mapping(
+        sync_trust_services.update_trusted_peer_endpoint_hints(
+            db_session,
+            device_id=peer_offer["device_id"],
+            endpoint_hints=[
+                " tuneforge-sync+tcp://192.168.1.42:48625?device_id=device_peer&v=1 ",
+                "tuneforge-sync+iroh://peer.example?device_id=device_peer&v=1",
+            ],
+        )
+    )
+    unchanged_peer = _plain_mapping(
+        sync_trust_services.update_trusted_peer_endpoint_hints(
+            db_session,
+            device_id=peer_offer["device_id"],
+            endpoint_hints=[
+                "tuneforge-sync+tcp://192.168.1.42:48625?device_id=device_peer&v=1",
+                "tuneforge-sync+iroh://peer.example?device_id=device_peer&v=1",
+            ],
+        )
+    )
+
+    assert updated_peer["endpoint_hints"] == [
+        "tuneforge-sync+tcp://192.168.1.42:48625?device_id=device_peer&v=1",
+        "tuneforge-sync+iroh://peer.example?device_id=device_peer&v=1",
+    ]
+    assert unchanged_peer["endpoint_hints"] == updated_peer["endpoint_hints"]
+    assert unchanged_peer["updated_at"] == updated_peer["updated_at"]
+
+
+def test_update_trusted_peer_endpoint_hints_rejects_invalid_unknown_and_revoked(
+    db_session: Session,
+    sync_trust_services: SyncTrustServices,
+) -> None:
+    identity = _local_identity(sync_trust_services, db_session)
+    template_offer = _pairing_payload(_pairing_offer(sync_trust_services, db_session))
+    peer_offer = _remote_pairing_offer(
+        sync_trust_services,
+        sync_group_id=identity["sync_group_id"],
+        public_key_like=identity["public_key"],
+        template_offer=template_offer,
+    )
+    sync_trust_services.trust_peer(db_session, peer_offer)
+
+    with pytest.raises(AppError) as invalid_exc:
+        sync_trust_services.update_trusted_peer_endpoint_hints(
+            db_session,
+            device_id=peer_offer["device_id"],
+            endpoint_hints=[" "],
+        )
+    assert invalid_exc.value.code == "SYNC_PAIRING_INVALID"
+    assert invalid_exc.value.status_code == 400
+
+    with pytest.raises(AppError) as unknown_exc:
+        sync_trust_services.update_trusted_peer_endpoint_hints(
+            db_session,
+            device_id="device_unknown",
+            endpoint_hints=[],
+        )
+    assert unknown_exc.value.code == "SYNC_PEER_UNTRUSTED"
+    assert unknown_exc.value.status_code == 404
+    assert unknown_exc.value.details == {"device_id": "device_unknown"}
+
+    sync_trust_services.revoke_trusted_peer(db_session, peer_offer["device_id"])
+
+    with pytest.raises(AppError) as revoked_exc:
+        sync_trust_services.update_trusted_peer_endpoint_hints(
+            db_session,
+            device_id=peer_offer["device_id"],
+            endpoint_hints=[],
+        )
+    assert revoked_exc.value.code == "SYNC_PEER_UNTRUSTED"
+    assert revoked_exc.value.status_code == 404
+    assert revoked_exc.value.details == {"device_id": peer_offer["device_id"]}
+
+
 def test_expired_pairing_payload_is_rejected(
     db_session: Session,
     sync_trust_services: SyncTrustServices,
@@ -398,6 +489,37 @@ def test_trusted_peer_routes_create_list_and_revoke(client, sync_trust_services:
     listed_peers = _unwrap_list(list_response.json(), "trusted_peers")
     assert _peer_by_device_id(listed_peers, peer_offer["device_id"])["public_key"] == peer_offer["public_key"]
 
+    patch_response = client.patch(
+        f"/api/v1/sync/trusted-peers/{peer_offer['device_id']}/endpoint-hints",
+        json={
+            "endpoint_hints": [
+                " tuneforge-sync+tcp://192.168.1.42:48625?device_id=device_peer&v=1 ",
+                "tuneforge-sync+iroh://peer.example?device_id=device_peer&v=1",
+            ]
+        },
+    )
+    assert patch_response.status_code == 200
+    patched_peer = _unwrap_mapping(patch_response.json(), "trusted_peer")
+    assert patched_peer["endpoint_hints"] == [
+        "tuneforge-sync+tcp://192.168.1.42:48625?device_id=device_peer&v=1",
+        "tuneforge-sync+iroh://peer.example?device_id=device_peer&v=1",
+    ]
+
+    unchanged_response = client.patch(
+        f"/api/v1/sync/trusted-peers/{peer_offer['device_id']}/endpoint-hints",
+        json={"endpoint_hints": patched_peer["endpoint_hints"]},
+    )
+    assert unchanged_response.status_code == 200
+    unchanged_peer = _unwrap_mapping(unchanged_response.json(), "trusted_peer")
+    assert unchanged_peer["endpoint_hints"] == patched_peer["endpoint_hints"]
+    assert unchanged_peer["updated_at"] == patched_peer["updated_at"]
+
+    invalid_patch_response = client.patch(
+        f"/api/v1/sync/trusted-peers/{peer_offer['device_id']}/endpoint-hints",
+        json={"endpoint_hints": [" "]},
+    )
+    assert invalid_patch_response.status_code == 422
+
     revoke_response = client.request(
         "DELETE",
         f"/api/v1/sync/trusted-peers/{peer_offer['device_id']}",
@@ -406,6 +528,20 @@ def test_trusted_peer_routes_create_list_and_revoke(client, sync_trust_services:
     revoked_peer = _unwrap_mapping(revoke_response.json(), "trusted_peer")
     assert revoked_peer["device_id"] == peer_offer["device_id"]
     assert revoked_peer["revoked_at"] is not None
+
+    revoked_patch_response = client.patch(
+        f"/api/v1/sync/trusted-peers/{peer_offer['device_id']}/endpoint-hints",
+        json={"endpoint_hints": []},
+    )
+    assert revoked_patch_response.status_code == 404
+    assert revoked_patch_response.json()["error"]["code"] == "SYNC_PEER_UNTRUSTED"
+
+    unknown_patch_response = client.patch(
+        "/api/v1/sync/trusted-peers/device_unknown/endpoint-hints",
+        json={"endpoint_hints": []},
+    )
+    assert unknown_patch_response.status_code == 404
+    assert unknown_patch_response.json()["error"]["code"] == "SYNC_PEER_UNTRUSTED"
 
 
 def test_pairing_response_route_answers_remote_offer(client, sync_trust_services: SyncTrustServices) -> None:

--- a/apps/desktop/src-tauri/src/mobile_backend/android.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/android.rs
@@ -62,6 +62,7 @@ pub use identity::{
     mobile_answer_sync_pairing_offer, mobile_create_sync_pairing_offer, mobile_get_sync_identity,
     mobile_list_sync_trusted_peers, mobile_revoke_sync_trusted_peer,
     mobile_sign_transport_handshake, mobile_trust_sync_peer,
+    mobile_update_sync_trusted_peer_endpoint_hints,
 };
 pub use lyrics::{mobile_get_lyrics, mobile_submit_lyrics, mobile_update_lyrics};
 pub use manifests::{
@@ -79,8 +80,11 @@ pub use transport_bridge::{
     mobile_sync_transport_create_pairing_offer_value, mobile_sync_transport_local_identity_value,
     mobile_sync_transport_metadata_value, mobile_sync_transport_project_manifest_value,
     mobile_sync_transport_reconciliation_apply_value,
-    mobile_sync_transport_reconciliation_plan_value, mobile_sync_transport_stage_artifact_value,
-    mobile_sync_transport_staged_artifact_value, mobile_sync_transport_trusted_peers_value,
+    mobile_sync_transport_reconciliation_plan_value,
+    mobile_sync_transport_refresh_peer_endpoint_hints_value,
+    mobile_sync_transport_stage_artifact_value, mobile_sync_transport_staged_artifact_value,
+    mobile_sync_transport_trusted_peers_value,
+    mobile_sync_transport_update_trusted_peer_endpoint_hints_value,
 };
 
 const WHISPER_SAMPLE_RATE: u32 = 16_000;

--- a/apps/desktop/src-tauri/src/mobile_backend/identity.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/identity.rs
@@ -591,3 +591,37 @@ pub fn mobile_revoke_sync_trusted_peer(
         trusted_peer: get_trusted_peer(&connection, &normalized)?,
     })
 }
+
+pub fn mobile_update_sync_trusted_peer_endpoint_hints(
+    app: AppHandle,
+    device_id: String,
+    payload: SyncTrustedPeerEndpointHintsRequest,
+) -> Result<SyncTrustedPeerResponse, String> {
+    let connection = db(&app)?;
+    let normalized_device_id = device_id.trim().to_string();
+    if normalized_device_id.is_empty() {
+        return Err("device_id must not be empty.".to_string());
+    }
+    let endpoint_hints = normalize_endpoint_hints(payload.endpoint_hints)?;
+    let trusted_peer = find_trusted_peer(&connection, &normalized_device_id)?
+        .filter(|peer| peer.revoked_at.is_none())
+        .ok_or_else(|| "Trusted peer is unknown.".to_string())?;
+    if trusted_peer.endpoint_hints == endpoint_hints {
+        return Ok(SyncTrustedPeerResponse { trusted_peer });
+    }
+
+    let timestamp = now_iso();
+    connection
+        .execute(
+            "UPDATE sync_trusted_peers SET endpoint_hints_json = ?1, updated_at = ?2 WHERE device_id = ?3 AND revoked_at IS NULL",
+            params![
+                serde_json::to_string(&endpoint_hints).map_err(|error| error.to_string())?,
+                timestamp,
+                normalized_device_id,
+            ],
+        )
+        .map_err(|error| error.to_string())?;
+    Ok(SyncTrustedPeerResponse {
+        trusted_peer: get_trusted_peer(&connection, &normalized_device_id)?,
+    })
+}

--- a/apps/desktop/src-tauri/src/mobile_backend/mod.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/mod.rs
@@ -14,8 +14,11 @@ pub use android::{
     mobile_sync_transport_create_pairing_offer_value, mobile_sync_transport_local_identity_value,
     mobile_sync_transport_metadata_value, mobile_sync_transport_project_manifest_value,
     mobile_sync_transport_reconciliation_apply_value,
-    mobile_sync_transport_reconciliation_plan_value, mobile_sync_transport_stage_artifact_value,
-    mobile_sync_transport_staged_artifact_value, mobile_sync_transport_trusted_peers_value,
+    mobile_sync_transport_reconciliation_plan_value,
+    mobile_sync_transport_refresh_peer_endpoint_hints_value,
+    mobile_sync_transport_stage_artifact_value, mobile_sync_transport_staged_artifact_value,
+    mobile_sync_transport_trusted_peers_value,
+    mobile_sync_transport_update_trusted_peer_endpoint_hints_value,
 };
 
 #[cfg(not(target_os = "android"))]

--- a/apps/desktop/src-tauri/src/mobile_backend/schemas.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/schemas.rs
@@ -304,6 +304,13 @@ pub struct SyncTrustedPeerCreateRequest {
     adopt_sync_group: bool,
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+pub struct SyncTrustedPeerEndpointHintsRequest {
+    endpoint_hints: Vec<String>,
+}
+
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
 fn payload_lyrics_language_override(payload: &Value) -> Result<Option<String>, String> {
     match payload.get("language_override") {

--- a/apps/desktop/src-tauri/src/mobile_backend/transport_bridge.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/transport_bridge.rs
@@ -12,6 +12,30 @@ pub fn mobile_sync_transport_trusted_peers_value(app: AppHandle) -> Result<Value
     sync_transport_value(mobile_list_sync_trusted_peers(app)?)
 }
 
+pub fn mobile_sync_transport_update_trusted_peer_endpoint_hints_value(
+    app: AppHandle,
+    peer_device_id: String,
+    endpoint_hints: Vec<String>,
+) -> Result<Value, String> {
+    sync_transport_value(mobile_update_sync_trusted_peer_endpoint_hints(
+        app,
+        peer_device_id,
+        SyncTrustedPeerEndpointHintsRequest { endpoint_hints },
+    )?)
+}
+
+pub fn mobile_sync_transport_refresh_peer_endpoint_hints_value(
+    app: AppHandle,
+    peer_device_id: String,
+    endpoint_hints: Vec<String>,
+) -> Result<Value, String> {
+    mobile_sync_transport_update_trusted_peer_endpoint_hints_value(
+        app,
+        peer_device_id,
+        endpoint_hints,
+    )
+}
+
 pub fn mobile_sync_transport_create_pairing_offer_value(
     app: AppHandle,
     endpoint_hints: Vec<String>,

--- a/apps/desktop/src-tauri/src/sync_transport.rs
+++ b/apps/desktop/src-tauri/src/sync_transport.rs
@@ -17,6 +17,7 @@ pub struct SyncTransportStartListenerRequest {
 pub struct SyncTransportSyncNowRequest {
     pub peer_device_id: String,
     pub endpoint_hint: Option<String>,
+    pub endpoint_hints: Option<Vec<String>>,
     pub preferred_transport: Option<String>,
     pub project_ids: Option<Vec<String>>,
     #[serde(default = "default_true")]
@@ -33,12 +34,27 @@ pub struct SyncTransportPairingOfferRequest {
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct SyncTransportNearbyPeer {
+    pub device_id: String,
+    pub sync_group_id: String,
+    pub display_name: Option<String>,
+    pub public_key: String,
+    pub endpoint_hints: Vec<String>,
+    pub protocol_version: String,
+    pub timestamp: String,
+    pub observed_at: String,
+    pub expires_at: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SyncTransportStatus {
     pub supported: bool,
     pub running: bool,
     pub bind_host: Option<String>,
     pub port: Option<u16>,
     pub endpoint_hints: Vec<String>,
+    pub nearby_peers: Vec<SyncTransportNearbyPeer>,
     pub active_sessions: usize,
     pub accepted_sessions: u64,
     pub failed_sessions: u64,
@@ -108,6 +124,7 @@ pub struct SyncTransportSyncResult {
     pub message: String,
     pub selected_transport: String,
     pub fallback_reason: Option<String>,
+    pub fallback_code: Option<String>,
     pub attempted_transports: Vec<String>,
     pub started_at: String,
     pub completed_at: String,
@@ -205,7 +222,27 @@ mod sync_core {
         endpoint_hint: Option<String>,
         pub(crate) tcp_fallback_endpoint_hint: Option<String>,
         fallback_reason: Option<String>,
+        fallback_code: Option<TransportFallbackCode>,
         attempted_transports: Vec<TransportKind>,
+    }
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub(crate) enum TransportFallbackCode {
+        MissingIrohHint,
+        IrohUnavailable,
+        IrohConnectFailed,
+        StaleIrohHint,
+    }
+
+    impl TransportFallbackCode {
+        fn as_str(self) -> &'static str {
+            match self {
+                Self::MissingIrohHint => "missing_iroh_hint",
+                Self::IrohUnavailable => "iroh_unavailable",
+                Self::IrohConnectFailed => "iroh_connect_failed",
+                Self::StaleIrohHint => "stale_iroh_hint",
+            }
+        }
     }
 
     impl TransportSelection {
@@ -215,16 +252,22 @@ mod sync_core {
                 endpoint_hint: None,
                 tcp_fallback_endpoint_hint: None,
                 fallback_reason: None,
+                fallback_code: None,
                 attempted_transports: vec![selected],
             }
         }
 
-        fn tcp(endpoint_hint: Option<String>, fallback_reason: Option<String>) -> Self {
+        fn tcp(
+            endpoint_hint: Option<String>,
+            fallback_reason: Option<String>,
+            fallback_code: Option<TransportFallbackCode>,
+        ) -> Self {
             Self {
                 selected: TransportKind::Tcp,
                 endpoint_hint,
                 tcp_fallback_endpoint_hint: None,
                 fallback_reason,
+                fallback_code,
                 attempted_transports: vec![TransportKind::Tcp],
             }
         }
@@ -235,6 +278,7 @@ mod sync_core {
                 endpoint_hint: Some(endpoint_hint),
                 tcp_fallback_endpoint_hint,
                 fallback_reason: None,
+                fallback_code: None,
                 attempted_transports: vec![TransportKind::Iroh],
             }
         }
@@ -243,12 +287,14 @@ mod sync_core {
             endpoint_hint: String,
             preferred_transport: TransportKind,
             fallback_reason: String,
+            fallback_code: Option<TransportFallbackCode>,
         ) -> Self {
             Self {
                 selected: TransportKind::Tcp,
                 endpoint_hint: Some(endpoint_hint),
                 tcp_fallback_endpoint_hint: None,
                 fallback_reason: Some(fallback_reason),
+                fallback_code,
                 attempted_transports: vec![preferred_transport, TransportKind::Tcp],
             }
         }
@@ -264,8 +310,15 @@ mod sync_core {
             self.endpoint_hint = Some(endpoint_hint);
             self.tcp_fallback_endpoint_hint = None;
             self.fallback_reason = Some(reason);
+            self.fallback_code = Some(TransportFallbackCode::IrohConnectFailed);
             self.attempted_transports = vec![TransportKind::Iroh, TransportKind::Tcp];
             Ok(())
+        }
+
+        pub(crate) fn mark_stale_iroh_hint(&mut self) {
+            if self.fallback_code == Some(TransportFallbackCode::IrohConnectFailed) {
+                self.fallback_code = Some(TransportFallbackCode::StaleIrohHint);
+            }
         }
 
         pub(crate) fn endpoint_hint(&self) -> Option<&str> {
@@ -276,6 +329,7 @@ mod sync_core {
             TransportEvidence {
                 selected_transport: self.selected.id().to_string(),
                 fallback_reason: self.fallback_reason.clone(),
+                fallback_code: self.fallback_code.map(|code| code.as_str().to_string()),
                 attempted_transports: self
                     .attempted_transports
                     .iter()
@@ -289,6 +343,7 @@ mod sync_core {
     pub(crate) struct TransportEvidence {
         pub(crate) selected_transport: String,
         pub(crate) fallback_reason: Option<String>,
+        pub(crate) fallback_code: Option<String>,
         pub(crate) attempted_transports: Vec<String>,
     }
 
@@ -306,7 +361,7 @@ mod sync_core {
 
         match preferred_transport.map(TransportKind::from_id) {
             Some(TransportKind::Tcp) => tcp_endpoint_hint
-                .map(|hint| TransportSelection::tcp(Some(hint), None))
+                .map(|hint| TransportSelection::tcp(Some(hint), None, None))
                 .ok_or_else(|| {
                     format!(
                         "Trusted sync peer {peer_device_id} does not have a TuneForge TCP endpoint hint."
@@ -332,8 +387,11 @@ mod sync_core {
                     );
                     tcp_endpoint_hint
                         .map(|hint| {
-                            let mut selection =
-                                TransportSelection::tcp(Some(hint), Some(fallback_reason));
+                            let mut selection = TransportSelection::tcp(
+                                Some(hint),
+                                Some(fallback_reason),
+                                Some(TransportFallbackCode::MissingIrohHint),
+                            );
                             selection.attempted_transports =
                                 vec![TransportKind::Iroh, TransportKind::Tcp];
                             selection
@@ -349,8 +407,11 @@ mod sync_core {
                     );
                     tcp_endpoint_hint
                         .map(|hint| {
-                            let mut selection =
-                                TransportSelection::tcp(Some(hint), Some(fallback_reason));
+                            let mut selection = TransportSelection::tcp(
+                                Some(hint),
+                                Some(fallback_reason),
+                                Some(TransportFallbackCode::IrohUnavailable),
+                            );
                             selection.attempted_transports =
                                 vec![TransportKind::Iroh, TransportKind::Tcp];
                             selection
@@ -374,6 +435,7 @@ mod sync_core {
                             hint,
                             preferred_transport,
                             fallback_reason,
+                            None,
                         )
                     })
                     .ok_or_else(|| {
@@ -383,6 +445,38 @@ mod sync_core {
                     })
             }
         }
+    }
+
+    pub(crate) fn sync_now_selection_endpoint_hints(
+        endpoint_hint: Option<&str>,
+        endpoint_hints: Option<&[String]>,
+        peer_endpoint_hints: &[String],
+    ) -> Vec<String> {
+        let mut merged = Vec::new();
+        if let Some(endpoint_hint) = endpoint_hint {
+            push_selection_endpoint_hint(&mut merged, endpoint_hint);
+        }
+        if let Some(endpoint_hints) = endpoint_hints {
+            for endpoint_hint in endpoint_hints {
+                push_selection_endpoint_hint(&mut merged, endpoint_hint);
+            }
+        }
+        for endpoint_hint in peer_endpoint_hints {
+            push_selection_endpoint_hint(&mut merged, endpoint_hint);
+        }
+        merged
+    }
+
+    fn push_selection_endpoint_hint(endpoint_hints: &mut Vec<String>, endpoint_hint: &str) {
+        let endpoint_hint = endpoint_hint.trim();
+        if endpoint_hint.is_empty()
+            || endpoint_hints
+                .iter()
+                .any(|existing| existing == endpoint_hint)
+        {
+            return;
+        }
+        endpoint_hints.push(endpoint_hint.to_string());
     }
 
     fn select_iroh_transport(
@@ -414,6 +508,7 @@ mod sync_core {
                         hint,
                         TransportKind::Iroh,
                         fallback_reason,
+                        Some(TransportFallbackCode::MissingIrohHint),
                     )
                 })
                 .ok_or_else(|| {
@@ -432,7 +527,12 @@ mod sync_core {
         };
         tcp_endpoint_hint
             .map(|hint| {
-                TransportSelection::tcp_fallback(hint, TransportKind::Iroh, fallback_reason)
+                TransportSelection::tcp_fallback(
+                    hint,
+                    TransportKind::Iroh,
+                    fallback_reason,
+                    Some(TransportFallbackCode::IrohUnavailable),
+                )
             })
             .ok_or_else(|| {
                 format!(
@@ -495,6 +595,11 @@ mod sync_core {
         AuthProof {
             handshake_signature: Value,
         },
+        EndpointHints {
+            protocol_version: String,
+            endpoint_hints: Vec<String>,
+            observed_at: String,
+        },
         ManifestOffer(ManifestOffer),
         ArtifactRequest {
             artifact_id: String,
@@ -525,6 +630,7 @@ mod sync_core {
             match self {
                 Self::AuthChallenge { .. } => "auth_challenge",
                 Self::AuthProof { .. } => "auth_proof",
+                Self::EndpointHints { .. } => "endpoint_hints",
                 Self::ManifestOffer(_) => "manifest_offer",
                 Self::ArtifactRequest { .. } => "artifact_request",
                 Self::ArtifactStart { .. } => "artifact_start",
@@ -661,11 +767,15 @@ mod sync_core {
     #[derive(Debug)]
     pub(crate) struct AuthenticatedSession {
         pub(crate) remote_device_id: String,
+        pub(crate) remote_endpoint_hints: Vec<String>,
     }
 
     #[derive(Clone, Debug, Deserialize)]
     pub(crate) struct SyncLocalIdentity {
         pub(crate) device_id: String,
+        pub(crate) sync_group_id: String,
+        pub(crate) display_name: Option<String>,
+        pub(crate) public_key: String,
     }
 
     #[derive(Clone, Debug, Deserialize)]
@@ -690,6 +800,7 @@ mod sync_core {
         connection: &mut impl ProtocolConnection,
         client: &impl SyncTransportAuthBackend,
         expected_peer_device_id: Option<String>,
+        local_endpoint_hints: &[String],
     ) -> Result<AuthenticatedSession, String> {
         let identity = client
             .local_identity()
@@ -779,7 +890,59 @@ mod sync_core {
             connection.handshake_hash(),
         )?;
 
-        Ok(AuthenticatedSession { remote_device_id })
+        let endpoint_hints = normalize_advisory_endpoint_hints(local_endpoint_hints.to_vec())?;
+        connection.send_message(&ProtocolMessage::EndpointHints {
+            protocol_version: TRANSPORT_PROTOCOL_VERSION.to_string(),
+            endpoint_hints,
+            observed_at: Utc::now().to_rfc3339(),
+        })?;
+        let remote_endpoint_hints = match connection.read_message()? {
+            ProtocolMessage::EndpointHints {
+                protocol_version,
+                endpoint_hints,
+                ..
+            } => {
+                if protocol_version != TRANSPORT_PROTOCOL_VERSION {
+                    return Err(format!(
+                        "Sync peer endpoint hints use unsupported transport protocol version {protocol_version}."
+                    ));
+                }
+                normalize_advisory_endpoint_hints(endpoint_hints)?
+            }
+            ProtocolMessage::Error(error) => {
+                return Err(format!(
+                    "Sync peer returned an endpoint hint error: {}",
+                    error.message
+                ));
+            }
+            other => {
+                return Err(format!(
+                    "Sync peer sent unexpected endpoint hint message: {}",
+                    other.kind()
+                ));
+            }
+        };
+
+        Ok(AuthenticatedSession {
+            remote_device_id,
+            remote_endpoint_hints,
+        })
+    }
+
+    pub(crate) fn normalize_advisory_endpoint_hints(
+        endpoint_hints: Vec<String>,
+    ) -> Result<Vec<String>, String> {
+        let mut normalized = Vec::with_capacity(endpoint_hints.len());
+        for hint in endpoint_hints {
+            let trimmed = hint.trim();
+            if trimmed.is_empty() {
+                return Err("Sync endpoint hints cannot contain empty values.".to_string());
+            }
+            if !normalized.iter().any(|existing| existing == trimmed) {
+                normalized.push(trimmed.to_string());
+            }
+        }
+        Ok(normalized)
     }
 
     pub(crate) fn transport_handshake_challenge(
@@ -1060,8 +1223,8 @@ mod sync_core {
 
 mod desktop {
     use super::{
-        sync_core::*, SyncTransportManifestError, SyncTransportPairingOffer,
-        SyncTransportPairingOfferRequest, SyncTransportProjectResult,
+        sync_core::*, SyncTransportManifestError, SyncTransportNearbyPeer,
+        SyncTransportPairingOffer, SyncTransportPairingOfferRequest, SyncTransportProjectResult,
         SyncTransportStartListenerRequest, SyncTransportStatus, SyncTransportSyncNowRequest,
         SyncTransportSyncResult, SyncTransportTimingEvidence, SyncTransportTransferCounts,
         SyncTransportTransferResult,
@@ -1072,7 +1235,7 @@ mod desktop {
         Endpoint, EndpointAddr, EndpointId, SecretKey,
     };
     use iroh_blobs::store::fs::FsStore;
-    use serde::Deserialize;
+    use serde::{Deserialize, Serialize};
     use serde_json::{json, Value};
     use sha2::{Digest, Sha256};
     use snow::{params::NoiseParams, Builder};
@@ -1083,7 +1246,7 @@ mod desktop {
         env,
         fs::{self, File},
         io::{self, Read, Write},
-        net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, TcpStream},
+        net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, TcpStream, UdpSocket},
         path::{Path, PathBuf},
         process,
         str::FromStr,
@@ -1101,6 +1264,12 @@ mod desktop {
     const DEFAULT_BIND_HOST: &str = "0.0.0.0";
     const DEFAULT_LISTENER_PORT: u16 = 47619;
     const IROH_LISTENER_PORT_OFFSET: u16 = 1;
+    const DISCOVERY_PROTOCOL_VERSION: &str = "tuneforge-sync-discovery-v1";
+    const DISCOVERY_PORT: u16 = 47621;
+    const DISCOVERY_BEACON_INTERVAL: Duration = Duration::from_secs(5);
+    const DISCOVERY_PEER_TTL: Duration = Duration::from_secs(60);
+    const DISCOVERY_SOCKET_TIMEOUT: Duration = Duration::from_millis(250);
+    const DISCOVERY_MAX_PACKET_BYTES: usize = 8192;
     const IROH_ALPN: &[u8] = b"tuneforge-sync/iroh/v1";
     const NOISE_PATTERN: &str = "Noise_XX_25519_ChaChaPoly_BLAKE2s";
     const READ_TIMEOUT: Duration = Duration::from_secs(45);
@@ -1183,18 +1352,39 @@ mod desktop {
             let tcp_stop = Arc::clone(&stop);
             let backend = self.backend.clone();
             let shared_status = Arc::clone(&self.shared_status);
+            let tcp_endpoint_hints_for_sessions = endpoint_hints.clone();
             let tcp_thread = thread::spawn(move || {
-                accept_loop(listener, backend, tcp_stop, shared_status);
+                accept_loop(
+                    listener,
+                    backend,
+                    tcp_stop,
+                    shared_status,
+                    tcp_endpoint_hints_for_sessions,
+                );
             });
             let iroh_thread = iroh_transport.as_ref().map(|transport| {
                 let transport = transport.clone();
                 let backend = self.backend.clone();
                 let shared_status = Arc::clone(&self.shared_status);
                 let iroh_stop = Arc::clone(&stop);
+                let endpoint_hints = endpoint_hints.clone();
                 thread::spawn(move || {
-                    iroh_accept_loop(transport, backend, iroh_stop, shared_status);
+                    iroh_accept_loop(transport, backend, iroh_stop, shared_status, endpoint_hints);
                 })
             });
+            let mut discovery_error = None;
+            let discovery_thread = match start_discovery(
+                identity,
+                endpoint_hints.clone(),
+                Arc::clone(&self.shared_status),
+                Arc::clone(&stop),
+            ) {
+                Ok(thread) => Some(thread),
+                Err(error) => {
+                    discovery_error = Some(error);
+                    None
+                }
+            };
 
             let handle = ListenerHandle {
                 bind_addr,
@@ -1203,6 +1393,7 @@ mod desktop {
                 stop,
                 tcp_thread: Some(tcp_thread),
                 iroh_thread,
+                discovery_thread,
             };
             {
                 let mut guard = self
@@ -1212,7 +1403,14 @@ mod desktop {
                 *guard = Some(handle);
             }
             update_status(&self.shared_status, |status| {
-                status.last_status = Some("Sync transport listener started.".to_string());
+                status.last_status = Some(match discovery_error {
+                    Some(error) => {
+                        format!(
+                            "Sync transport listener started; sync discovery unavailable: {error}"
+                        )
+                    }
+                    None => "Sync transport listener started.".to_string(),
+                });
                 status.last_error = None;
                 status.last_sync = None;
             });
@@ -1244,8 +1442,14 @@ mod desktop {
                         .join()
                         .map_err(|_| "Iroh sync transport listener thread panicked.".to_string())?;
                 }
+                if let Some(thread) = listener.discovery_thread.take() {
+                    thread
+                        .join()
+                        .map_err(|_| "Sync discovery listener thread panicked.".to_string())?;
+                }
                 update_status(&self.shared_status, |status| {
                     status.last_status = Some("Sync transport listener stopped.".to_string());
+                    status.nearby_peers.clear();
                 });
             }
 
@@ -1260,7 +1464,10 @@ mod desktop {
             let shared = self
                 .shared_status
                 .lock()
-                .map(|status| status.clone())
+                .map(|mut status| {
+                    prune_nearby_peers(&mut status, Instant::now());
+                    status.clone()
+                })
                 .unwrap_or_default();
             let listener = self.listener.lock().ok();
             let listener = listener.as_ref().and_then(|guard| guard.as_ref());
@@ -1273,6 +1480,7 @@ mod desktop {
                 endpoint_hints: listener
                     .map(|handle| handle.endpoint_hints.clone())
                     .unwrap_or_default(),
+                nearby_peers: nearby_peers_from_status(shared.nearby_peers.clone()),
                 active_sessions: shared.active_sessions,
                 accepted_sessions: shared.accepted_sessions,
                 failed_sessions: shared.failed_sessions,
@@ -1346,10 +1554,15 @@ mod desktop {
                 .as_deref()
                 .and_then(normalized_transport_id);
             let local_iroh = self.local_iroh_transport();
+            let selection_endpoint_hints = sync_now_selection_endpoint_hints(
+                payload.endpoint_hint.as_deref(),
+                payload.endpoint_hints.as_deref(),
+                &peer.endpoint_hints,
+            );
             let transport_selection = select_sync_transport(
                 preferred_transport,
-                payload.endpoint_hint.as_deref(),
-                &peer.endpoint_hints,
+                None,
+                &selection_endpoint_hints,
                 &payload.peer_device_id,
                 local_iroh.is_some(),
             )?;
@@ -1363,12 +1576,27 @@ mod desktop {
             timings.push(timer.finish());
 
             let timer = SyncPhaseTimer::start("peer_authentication");
+            let local_endpoint_hints = self.current_endpoint_hints();
             let session = authenticate_session(
                 &mut connection,
                 &client,
                 Some(payload.peer_device_id.clone()),
+                &local_endpoint_hints,
             )?;
             timings.push(timer.finish());
+            let mut refreshed_endpoint_hints_after_auth = false;
+            if authenticated_hints_make_trusted_iroh_hint_stale(
+                &peer.endpoint_hints,
+                &session.remote_endpoint_hints,
+            ) {
+                transport_selection.mark_stale_iroh_hint();
+                refresh_authenticated_endpoint_hints(
+                    &client,
+                    &session.remote_device_id,
+                    &session.remote_endpoint_hints,
+                );
+                refreshed_endpoint_hints_after_auth = true;
+            }
 
             let timer = SyncPhaseTimer::start("local_manifest_export");
             let local_offer = load_local_manifest_offer(
@@ -1444,8 +1672,16 @@ mod desktop {
             let TransportEvidence {
                 selected_transport,
                 fallback_reason,
+                fallback_code,
                 attempted_transports,
             } = transport_selection.evidence();
+            if !refreshed_endpoint_hints_after_auth {
+                refresh_authenticated_endpoint_hints(
+                    &client,
+                    &session.remote_device_id,
+                    &session.remote_endpoint_hints,
+                );
+            }
 
             Ok(SyncTransportSyncResult {
                 run_id,
@@ -1460,6 +1696,7 @@ mod desktop {
                 ),
                 selected_transport,
                 fallback_reason,
+                fallback_code,
                 attempted_transports,
                 started_at: run_started_at.to_rfc3339(),
                 completed_at: completed_at.to_rfc3339(),
@@ -1490,6 +1727,14 @@ mod desktop {
                     .as_ref()
                     .and_then(|handle| handle.iroh_transport.clone())
             })
+        }
+
+        fn current_endpoint_hints(&self) -> Vec<String> {
+            self.listener
+                .lock()
+                .ok()
+                .and_then(|guard| guard.as_ref().map(|handle| handle.endpoint_hints.clone()))
+                .unwrap_or_default()
         }
     }
 
@@ -1544,6 +1789,7 @@ mod desktop {
         stop: Arc<AtomicBool>,
         tcp_thread: Option<JoinHandle<()>>,
         iroh_thread: Option<JoinHandle<()>>,
+        discovery_thread: Option<JoinHandle<()>>,
     }
 
     struct IncomingSessionResult {
@@ -1559,6 +1805,264 @@ mod desktop {
         last_status: Option<String>,
         last_error: Option<String>,
         last_sync: Option<SyncTransportSyncResult>,
+        nearby_peers: HashMap<String, DiscoveryPeerEntry>,
+    }
+
+    #[derive(Clone)]
+    struct DiscoveryPeerEntry {
+        peer: SyncTransportNearbyPeer,
+        expires_at_instant: Instant,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[serde(rename_all = "snake_case")]
+    struct DiscoveryBeaconPayload {
+        protocol_version: String,
+        device_id: String,
+        sync_group_id: String,
+        display_name: Option<String>,
+        public_key: String,
+        endpoint_hints: Vec<String>,
+        timestamp: String,
+    }
+
+    fn start_discovery(
+        identity: SyncLocalIdentity,
+        endpoint_hints: Vec<String>,
+        shared_status: Arc<Mutex<SharedStatus>>,
+        stop: Arc<AtomicBool>,
+    ) -> Result<JoinHandle<()>, String> {
+        let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, DISCOVERY_PORT)).map_err(|error| {
+            format!("Could not bind sync discovery UDP port {DISCOVERY_PORT}: {error}")
+        })?;
+        socket
+            .set_broadcast(true)
+            .map_err(|error| format!("Could not enable sync discovery broadcast: {error}"))?;
+        socket
+            .set_read_timeout(Some(DISCOVERY_SOCKET_TIMEOUT))
+            .map_err(|error| {
+                format!("Could not configure sync discovery receive timeout: {error}")
+            })?;
+        Ok(thread::spawn(move || {
+            discovery_loop(socket, identity, endpoint_hints, shared_status, stop);
+        }))
+    }
+
+    fn discovery_loop(
+        socket: UdpSocket,
+        identity: SyncLocalIdentity,
+        endpoint_hints: Vec<String>,
+        shared_status: Arc<Mutex<SharedStatus>>,
+        stop: Arc<AtomicBool>,
+    ) {
+        let mut last_broadcast = Instant::now()
+            .checked_sub(DISCOVERY_BEACON_INTERVAL)
+            .unwrap_or_else(Instant::now);
+        let broadcast_targets = discovery_broadcast_targets();
+        let mut buffer = [0_u8; DISCOVERY_MAX_PACKET_BYTES];
+
+        while !stop.load(Ordering::SeqCst) {
+            if last_broadcast.elapsed() >= DISCOVERY_BEACON_INTERVAL {
+                let timestamp = Utc::now();
+                for target in &broadcast_targets {
+                    let _ =
+                        send_discovery_beacon(&socket, *target, &identity, &endpoint_hints, timestamp);
+                }
+                last_broadcast = Instant::now();
+            }
+
+            match socket.recv_from(&mut buffer) {
+                Ok((size, _)) => {
+                    record_discovery_beacon(
+                        &shared_status,
+                        &buffer[..size],
+                        &identity.device_id,
+                        Utc::now(),
+                        Instant::now() + DISCOVERY_PEER_TTL,
+                    );
+                }
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+                    ) => {}
+                Err(_) => thread::sleep(ACCEPT_SLEEP),
+            }
+        }
+    }
+
+    fn send_discovery_beacon(
+        socket: &UdpSocket,
+        target: SocketAddr,
+        identity: &SyncLocalIdentity,
+        endpoint_hints: &[String],
+        timestamp: DateTime<Utc>,
+    ) -> Result<(), String> {
+        let payload = discovery_beacon_payload(identity, endpoint_hints, timestamp)?;
+        let bytes = serde_json::to_vec(&payload)
+            .map_err(|error| format!("Could not encode sync discovery beacon: {error}"))?;
+        if bytes.len() > DISCOVERY_MAX_PACKET_BYTES {
+            return Err("Sync discovery beacon exceeded the maximum packet size.".to_string());
+        }
+        socket
+            .send_to(&bytes, target)
+            .map(|_| ())
+            .map_err(|error| format!("Could not send sync discovery beacon: {error}"))
+    }
+
+    fn discovery_broadcast_targets() -> Vec<SocketAddr> {
+        let addresses = if_addrs::get_if_addrs()
+            .map(|interfaces| {
+                interfaces
+                    .into_iter()
+                    .filter_map(|interface| match interface.addr {
+                        if_addrs::IfAddr::V4(addr) => Some((addr.ip, addr.broadcast)),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        discovery_broadcast_targets_from_ipv4(addresses)
+    }
+
+    fn discovery_broadcast_targets_from_ipv4(
+        addresses: impl IntoIterator<Item = (Ipv4Addr, Option<Ipv4Addr>)>,
+    ) -> Vec<SocketAddr> {
+        let mut targets = Vec::new();
+        for (ip, broadcast) in addresses {
+            if ip.is_loopback() || ip.is_link_local() {
+                continue;
+            }
+            if let Some(broadcast) = broadcast {
+                if broadcast.is_unspecified()
+                    || broadcast.is_loopback()
+                    || broadcast.is_link_local()
+                {
+                    continue;
+                }
+                push_discovery_broadcast_target(&mut targets, broadcast);
+            }
+        }
+        push_discovery_broadcast_target(&mut targets, Ipv4Addr::BROADCAST);
+        targets
+    }
+
+    fn push_discovery_broadcast_target(targets: &mut Vec<SocketAddr>, broadcast: Ipv4Addr) {
+        let target = SocketAddr::from((broadcast, DISCOVERY_PORT));
+        if !targets.contains(&target) {
+            targets.push(target);
+        }
+    }
+
+    fn discovery_beacon_payload(
+        identity: &SyncLocalIdentity,
+        endpoint_hints: &[String],
+        timestamp: DateTime<Utc>,
+    ) -> Result<DiscoveryBeaconPayload, String> {
+        Ok(DiscoveryBeaconPayload {
+            protocol_version: DISCOVERY_PROTOCOL_VERSION.to_string(),
+            device_id: required_discovery_string(&identity.device_id, "device_id")?,
+            sync_group_id: required_discovery_string(&identity.sync_group_id, "sync_group_id")?,
+            display_name: optional_discovery_string(identity.display_name.as_deref()),
+            public_key: required_discovery_string(&identity.public_key, "public_key")?,
+            endpoint_hints: normalize_advisory_endpoint_hints(endpoint_hints.to_vec())?,
+            timestamp: timestamp.to_rfc3339(),
+        })
+    }
+
+    fn record_discovery_beacon(
+        shared_status: &Arc<Mutex<SharedStatus>>,
+        bytes: &[u8],
+        local_device_id: &str,
+        observed_at: DateTime<Utc>,
+        expires_at_instant: Instant,
+    ) {
+        if let Ok(Some(entry)) =
+            parse_discovery_beacon(bytes, local_device_id, observed_at, expires_at_instant)
+        {
+            update_status(shared_status, |status| {
+                status
+                    .nearby_peers
+                    .insert(entry.peer.device_id.clone(), entry);
+            });
+        }
+    }
+
+    fn parse_discovery_beacon(
+        bytes: &[u8],
+        local_device_id: &str,
+        observed_at: DateTime<Utc>,
+        expires_at_instant: Instant,
+    ) -> Result<Option<DiscoveryPeerEntry>, String> {
+        if bytes.len() > DISCOVERY_MAX_PACKET_BYTES {
+            return Err("Sync discovery beacon exceeded the maximum packet size.".to_string());
+        }
+        let payload: DiscoveryBeaconPayload = serde_json::from_slice(bytes)
+            .map_err(|error| format!("Could not decode sync discovery beacon: {error}"))?;
+        if payload.protocol_version != DISCOVERY_PROTOCOL_VERSION {
+            return Ok(None);
+        }
+        let device_id = required_discovery_string(&payload.device_id, "device_id")?;
+        if device_id == local_device_id {
+            return Ok(None);
+        }
+        let observed_at_text = observed_at.to_rfc3339();
+        let expires_at =
+            observed_at + chrono::Duration::seconds(DISCOVERY_PEER_TTL.as_secs() as i64);
+        let peer = SyncTransportNearbyPeer {
+            device_id,
+            sync_group_id: required_discovery_string(&payload.sync_group_id, "sync_group_id")?,
+            display_name: optional_discovery_string(payload.display_name.as_deref()),
+            public_key: required_discovery_string(&payload.public_key, "public_key")?,
+            endpoint_hints: normalize_advisory_endpoint_hints(payload.endpoint_hints)?,
+            protocol_version: payload.protocol_version,
+            timestamp: required_discovery_string(&payload.timestamp, "timestamp")?,
+            observed_at: observed_at_text,
+            expires_at: expires_at.to_rfc3339(),
+        };
+        Ok(Some(DiscoveryPeerEntry {
+            peer,
+            expires_at_instant,
+        }))
+    }
+
+    fn required_discovery_string(value: &str, field: &str) -> Result<String, String> {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Err(format!("Sync discovery beacon {field} cannot be empty."));
+        }
+        if trimmed.len() > 512 {
+            return Err(format!("Sync discovery beacon {field} is too long."));
+        }
+        Ok(trimmed.to_string())
+    }
+
+    fn optional_discovery_string(value: Option<&str>) -> Option<String> {
+        value
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|value| value.chars().take(128).collect())
+    }
+
+    fn prune_nearby_peers(status: &mut SharedStatus, now: Instant) {
+        status
+            .nearby_peers
+            .retain(|_, entry| entry.expires_at_instant > now);
+    }
+
+    fn nearby_peers_from_status(
+        nearby_peers: HashMap<String, DiscoveryPeerEntry>,
+    ) -> Vec<SyncTransportNearbyPeer> {
+        let mut peers: Vec<SyncTransportNearbyPeer> =
+            nearby_peers.into_values().map(|entry| entry.peer).collect();
+        peers.sort_by(|left, right| {
+            left.display_name
+                .as_deref()
+                .unwrap_or("")
+                .cmp(right.display_name.as_deref().unwrap_or(""))
+                .then_with(|| left.device_id.cmp(&right.device_id))
+        });
+        peers
     }
 
     #[derive(Clone)]
@@ -1775,12 +2279,14 @@ mod desktop {
         backend: BackendAccess,
         stop: Arc<AtomicBool>,
         shared_status: Arc<Mutex<SharedStatus>>,
+        endpoint_hints: Vec<String>,
     ) {
         while !stop.load(Ordering::SeqCst) {
             match listener.accept() {
                 Ok((stream, address)) => {
                     let backend = backend.clone();
                     let shared_status = Arc::clone(&shared_status);
+                    let endpoint_hints = endpoint_hints.clone();
                     update_status(&shared_status, |status| {
                         status.accepted_sessions += 1;
                         status.last_status =
@@ -1795,6 +2301,7 @@ mod desktop {
                             Box::new(stream),
                             None,
                             shared_status,
+                            endpoint_hints,
                         ),
                         Err(error) => {
                             update_status(&shared_status, |status| {
@@ -1824,6 +2331,7 @@ mod desktop {
         backend: BackendAccess,
         stop: Arc<AtomicBool>,
         shared_status: Arc<Mutex<SharedStatus>>,
+        endpoint_hints: Vec<String>,
     ) {
         tauri::async_runtime::block_on(async move {
             while !stop.load(Ordering::SeqCst) {
@@ -1832,6 +2340,7 @@ mod desktop {
                         let backend = backend.clone();
                         let shared_status = Arc::clone(&shared_status);
                         let blob_store = transport.blob_store.clone();
+                        let endpoint_hints = endpoint_hints.clone();
                         update_status(&shared_status, |status| {
                             status.accepted_sessions += 1;
                             status.last_status =
@@ -1865,6 +2374,7 @@ mod desktop {
                                             stream,
                                             Some(Arc::new(blob_store) as TransportBlobRecorderRef),
                                             session_status,
+                                            endpoint_hints,
                                         );
                                     });
                                     if let Err(error) = join.await {
@@ -1952,6 +2462,34 @@ mod desktop {
         SecurePeerConnection::connect_initiator(Box::new(stream), TransportKind::Tcp, None)
     }
 
+    fn authenticated_hints_make_trusted_iroh_hint_stale(
+        trusted_endpoint_hints: &[String],
+        authenticated_endpoint_hints: &[String],
+    ) -> bool {
+        let Some(authenticated_iroh_hint) = first_iroh_hint(authenticated_endpoint_hints) else {
+            return false;
+        };
+        first_iroh_hint(trusted_endpoint_hints) != Some(authenticated_iroh_hint)
+    }
+
+    fn first_iroh_hint(endpoint_hints: &[String]) -> Option<&str> {
+        endpoint_hints
+            .iter()
+            .find(|hint| hint.starts_with(IROH_ENDPOINT_SCHEME))
+            .map(String::as_str)
+    }
+
+    fn refresh_authenticated_endpoint_hints(
+        client: &BackendClient,
+        peer_device_id: &str,
+        endpoint_hints: &[String],
+    ) {
+        if endpoint_hints.is_empty() {
+            return;
+        }
+        let _ = client.refresh_trusted_peer_endpoint_hints(peer_device_id, endpoint_hints);
+    }
+
     fn connect_iroh_peer_connection(
         transport: &IrohTransport,
         endpoint_addr: EndpointAddr,
@@ -1982,11 +2520,12 @@ mod desktop {
         stream: Box<dyn PeerStream>,
         blob_store: Option<TransportBlobRecorderRef>,
         shared_status: Arc<Mutex<SharedStatus>>,
+        endpoint_hints: Vec<String>,
     ) {
         update_status(&shared_status, |status| {
             status.active_sessions += 1;
         });
-        let result = serve_incoming_session(backend, transport, stream, blob_store);
+        let result = serve_incoming_session(backend, transport, stream, blob_store, endpoint_hints);
         update_status(&shared_status, |status| {
             status.active_sessions = status.active_sessions.saturating_sub(1);
             match result {
@@ -2008,6 +2547,7 @@ mod desktop {
         transport: TransportKind,
         stream: Box<dyn PeerStream>,
         blob_store: Option<TransportBlobRecorderRef>,
+        endpoint_hints: Vec<String>,
     ) -> Result<IncomingSessionResult, String> {
         let run_id = sync_run_id();
         let run_started_at = Utc::now();
@@ -2018,7 +2558,7 @@ mod desktop {
         let timer = SyncPhaseTimer::start("peer_authentication");
         let mut connection =
             SecurePeerConnection::connect_responder(stream, transport, blob_store)?;
-        let session = authenticate_session(&mut connection, &client, None)?;
+        let session = authenticate_session(&mut connection, &client, None, &endpoint_hints)?;
         timings.push(timer.finish());
         let timer = SyncPhaseTimer::start("manifest_exchange");
         let remote_offer = match connection.read_message()? {
@@ -2087,8 +2627,14 @@ mod desktop {
         let TransportEvidence {
             selected_transport,
             fallback_reason,
+            fallback_code,
             attempted_transports,
         } = TransportSelection::single(connection.transport()).evidence();
+        refresh_authenticated_endpoint_hints(
+            &client,
+            &session.remote_device_id,
+            &session.remote_endpoint_hints,
+        );
         let sync_result = SyncTransportSyncResult {
             run_id,
             peer_device_id: session.remote_device_id.clone(),
@@ -2102,6 +2648,7 @@ mod desktop {
             ),
             selected_transport,
             fallback_reason,
+            fallback_code,
             attempted_transports,
             started_at: run_started_at.to_rfc3339(),
             completed_at: completed_at.to_rfc3339(),
@@ -4246,6 +4793,43 @@ mod desktop {
             }
         }
 
+        fn refresh_trusted_peer_endpoint_hints(
+            &self,
+            device_id: &str,
+            endpoint_hints: &[String],
+        ) -> Result<(), BackendError> {
+            let endpoint_hints = normalize_advisory_endpoint_hints(endpoint_hints.to_vec())
+                .map_err(BackendError::local)?;
+            if endpoint_hints.is_empty() {
+                return Ok(());
+            }
+
+            #[cfg(target_os = "android")]
+            {
+                crate::mobile_backend::mobile_sync_transport_update_trusted_peer_endpoint_hints_value(
+                    self.app.clone(),
+                    device_id.to_string(),
+                    endpoint_hints,
+                )
+                .map(|_| ())
+                .map_err(BackendError::local)
+            }
+
+            #[cfg(not(target_os = "android"))]
+            {
+                let body = json!({ "endpoint_hints": endpoint_hints });
+                let path = format!(
+                    "/api/v1/sync/trusted-peers/{}/endpoint-hints",
+                    percent_encode_path_segment(device_id)
+                );
+                match self.request_json_value("PATCH", &path, Some(&body)) {
+                    Ok(_) => Ok(()),
+                    Err(error) if matches!(error.status, Some(404 | 405)) => Ok(()),
+                    Err(error) => Err(error),
+                }
+            }
+        }
+
         fn sign_transport_handshake(
             &self,
             peer_device_id: &str,
@@ -4782,6 +5366,7 @@ mod desktop {
                 TransportEvidence {
                     selected_transport: IROH_TRANSPORT_ID.to_string(),
                     fallback_reason: None,
+                    fallback_code: None,
                     attempted_transports: vec![IROH_TRANSPORT_ID.to_string()],
                 }
             );
@@ -4801,6 +5386,121 @@ mod desktop {
                 .iter()
                 .skip(1)
                 .any(|hint| hint.starts_with(ENDPOINT_SCHEME)));
+        }
+
+        #[test]
+        fn discovery_beacon_payload_contains_advisory_fields_only() {
+            let identity = SyncLocalIdentity {
+                device_id: "dev_local".to_string(),
+                sync_group_id: "syncgrp_one".to_string(),
+                display_name: Some("Studio Mac".to_string()),
+                public_key: "public_key".to_string(),
+            };
+            let endpoint_hints = vec![format!(
+                "{ENDPOINT_SCHEME}192.0.2.2:47619?device_id=dev_local&v=1"
+            )];
+            let payload = discovery_beacon_payload(
+                &identity,
+                &endpoint_hints,
+                DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+                    .expect("timestamp")
+                    .with_timezone(&Utc),
+            )
+            .expect("beacon payload");
+            let value = serde_json::to_value(&payload).expect("serialize beacon");
+
+            assert_eq!(
+                value.get("protocol_version").and_then(Value::as_str),
+                Some(DISCOVERY_PROTOCOL_VERSION)
+            );
+            assert_eq!(value.get("endpoint_hints"), Some(&json!(endpoint_hints)));
+            assert!(value.get("pairing_secret").is_none());
+            assert!(value.get("source_path").is_none());
+        }
+
+        #[test]
+        fn discovery_broadcast_targets_include_directed_and_limited_broadcasts() {
+            let targets = discovery_broadcast_targets_from_ipv4([
+                (
+                    Ipv4Addr::new(192, 0, 2, 10),
+                    Some(Ipv4Addr::new(192, 0, 2, 255)),
+                ),
+                (
+                    Ipv4Addr::new(192, 0, 2, 11),
+                    Some(Ipv4Addr::new(192, 0, 2, 255)),
+                ),
+                (
+                    Ipv4Addr::new(198, 51, 100, 20),
+                    Some(Ipv4Addr::new(198, 51, 100, 255)),
+                ),
+                (
+                    Ipv4Addr::new(127, 0, 0, 1),
+                    Some(Ipv4Addr::new(127, 255, 255, 255)),
+                ),
+                (
+                    Ipv4Addr::new(169, 254, 1, 20),
+                    Some(Ipv4Addr::new(169, 254, 255, 255)),
+                ),
+                (Ipv4Addr::new(203, 0, 113, 7), None),
+            ]);
+
+            assert_eq!(
+                targets,
+                vec![
+                    SocketAddr::from((Ipv4Addr::new(192, 0, 2, 255), DISCOVERY_PORT)),
+                    SocketAddr::from((Ipv4Addr::new(198, 51, 100, 255), DISCOVERY_PORT)),
+                    SocketAddr::from((Ipv4Addr::BROADCAST, DISCOVERY_PORT)),
+                ]
+            );
+        }
+
+        #[test]
+        fn discovery_beacon_parser_ignores_self_and_expires_peers() {
+            let payload = DiscoveryBeaconPayload {
+                protocol_version: DISCOVERY_PROTOCOL_VERSION.to_string(),
+                device_id: "dev_peer".to_string(),
+                sync_group_id: "syncgrp_one".to_string(),
+                display_name: Some("Peer Phone".to_string()),
+                public_key: "peer_public".to_string(),
+                endpoint_hints: vec![format!(
+                    "{ENDPOINT_SCHEME}192.0.2.3:47619?device_id=dev_peer&v=1"
+                )],
+                timestamp: "2026-01-01T00:00:00Z".to_string(),
+            };
+            let bytes = serde_json::to_vec(&payload).expect("encode beacon");
+            let observed_at = DateTime::parse_from_rfc3339("2026-01-01T00:00:02Z")
+                .expect("timestamp")
+                .with_timezone(&Utc);
+            let now = Instant::now();
+            let entry =
+                parse_discovery_beacon(&bytes, "dev_local", observed_at, now + DISCOVERY_PEER_TTL)
+                    .expect("parse beacon")
+                    .expect("peer entry");
+
+            assert_eq!(entry.peer.device_id, "dev_peer");
+            assert_eq!(entry.peer.observed_at, "2026-01-01T00:00:02+00:00");
+            assert!(parse_discovery_beacon(
+                &bytes,
+                "dev_peer",
+                observed_at,
+                now + DISCOVERY_PEER_TTL
+            )
+            .expect("ignore self")
+            .is_none());
+
+            let mut status = SharedStatus::default();
+            status
+                .nearby_peers
+                .insert(entry.peer.device_id.clone(), entry);
+            assert_eq!(
+                nearby_peers_from_status(status.nearby_peers.clone()).len(),
+                1
+            );
+            prune_nearby_peers(
+                &mut status,
+                now + DISCOVERY_PEER_TTL + Duration::from_secs(1),
+            );
+            assert!(status.nearby_peers.is_empty());
         }
 
         #[test]
@@ -4845,6 +5545,7 @@ mod desktop {
                     fallback_reason: Some(format!(
                         "Iroh sync transport is not available locally; using {TCP_TRANSPORT_ID}."
                     )),
+                    fallback_code: Some("iroh_unavailable".to_string()),
                     attempted_transports: vec![
                         IROH_TRANSPORT_ID.to_string(),
                         TCP_TRANSPORT_ID.to_string()
@@ -4856,6 +5557,7 @@ mod desktop {
                 TransportEvidence {
                     selected_transport: TCP_TRANSPORT_ID.to_string(),
                     fallback_reason: None,
+                    fallback_code: None,
                     attempted_transports: vec![TCP_TRANSPORT_ID.to_string()],
                 }
             );
@@ -4893,12 +5595,83 @@ mod desktop {
                 TransportEvidence {
                     selected_transport: IROH_TRANSPORT_ID.to_string(),
                     fallback_reason: None,
+                    fallback_code: None,
                     attempted_transports: vec![IROH_TRANSPORT_ID.to_string()],
                 }
             );
             assert_eq!(
                 selection.tcp_fallback_endpoint_hint,
                 Some(endpoint_hints[0].clone())
+            );
+        }
+
+        #[test]
+        fn sync_now_request_uses_discovered_tcp_hint_for_iroh_fallback() {
+            let discovered_iroh_hint = format!(
+                "{IROH_ENDPOINT_SCHEME}iroh_peer?device_id=dev_peer&v=1&addr=127.0.0.1%3A47620"
+            );
+            let discovered_tcp_hint =
+                format!("{ENDPOINT_SCHEME}127.0.0.1:47619?device_id=dev_peer&v=1");
+            let stored_stale_iroh_hint = format!(
+                "{IROH_ENDPOINT_SCHEME}old_peer?device_id=dev_peer&v=1&addr=127.0.0.1%3A47621"
+            );
+            let request: SyncTransportSyncNowRequest = serde_json::from_value(json!({
+                "peerDeviceId": "dev_peer",
+                "endpointHint": discovered_iroh_hint.clone(),
+                "endpointHints": [
+                    discovered_iroh_hint.clone(),
+                    discovered_tcp_hint.clone()
+                ],
+                "preferredTransport": "auto"
+            }))
+            .expect("deserialize sync now request");
+            let selection_endpoint_hints = sync_now_selection_endpoint_hints(
+                request.endpoint_hint.as_deref(),
+                request.endpoint_hints.as_deref(),
+                &[stored_stale_iroh_hint.clone()],
+            );
+
+            assert_eq!(
+                selection_endpoint_hints,
+                vec![
+                    discovered_iroh_hint.clone(),
+                    discovered_tcp_hint.clone(),
+                    stored_stale_iroh_hint
+                ]
+            );
+
+            let mut selection = select_sync_transport(
+                request
+                    .preferred_transport
+                    .as_deref()
+                    .and_then(normalized_transport_id),
+                None,
+                &selection_endpoint_hints,
+                &request.peer_device_id,
+                true,
+            )
+            .expect("select discovered iroh");
+
+            assert_eq!(
+                selection.endpoint_hint(),
+                Some(discovered_iroh_hint.as_str())
+            );
+            assert_eq!(
+                selection.tcp_fallback_endpoint_hint.as_deref(),
+                Some(discovered_tcp_hint.as_str())
+            );
+            selection
+                .record_iroh_connect_fallback(format!(
+                    "Iroh sync transport was unavailable (connect failed); using {TCP_TRANSPORT_ID}."
+                ))
+                .expect("record discovered tcp fallback");
+            assert_eq!(
+                selection.endpoint_hint(),
+                Some(discovered_tcp_hint.as_str())
+            );
+            assert_eq!(
+                selection.evidence().fallback_code.as_deref(),
+                Some("iroh_connect_failed")
             );
         }
 
@@ -4927,11 +5700,71 @@ mod desktop {
                     fallback_reason: Some(format!(
                         "Preferred sync transport {IROH_TRANSPORT_ID} is not available locally; using {TCP_TRANSPORT_ID}."
                     )),
+                    fallback_code: Some("iroh_unavailable".to_string()),
                     attempted_transports: vec![
                         IROH_TRANSPORT_ID.to_string(),
                         TCP_TRANSPORT_ID.to_string()
                     ],
                 }
+            );
+        }
+
+        #[test]
+        fn missing_iroh_hint_records_fallback_code() {
+            let endpoint_hints = vec![format!(
+                "{ENDPOINT_SCHEME}127.0.0.1:47619?device_id=dev_peer&v=1"
+            )];
+
+            let selection = select_sync_transport(None, None, &endpoint_hints, "dev_peer", true)
+                .expect("select tcp fallback");
+
+            assert_eq!(
+                selection.evidence().fallback_code.as_deref(),
+                Some("missing_iroh_hint")
+            );
+        }
+
+        #[test]
+        fn iroh_connect_failure_can_be_marked_as_stale_hint_after_auth() {
+            let endpoint_hints = vec![
+                format!(
+                    "{IROH_ENDPOINT_SCHEME}old_peer?device_id=dev_peer&v=1&addr=127.0.0.1%3A47620"
+                ),
+                format!("{ENDPOINT_SCHEME}127.0.0.1:47619?device_id=dev_peer&v=1"),
+            ];
+            let authenticated_hints = vec![format!(
+                "{IROH_ENDPOINT_SCHEME}new_peer?device_id=dev_peer&v=1&addr=127.0.0.1%3A47620"
+            )];
+            let mut selection =
+                select_sync_transport(None, None, &endpoint_hints, "dev_peer", true)
+                    .expect("select iroh");
+
+            selection
+                .record_iroh_connect_fallback(format!(
+                    "Iroh sync transport was unavailable (connect failed); using {TCP_TRANSPORT_ID}."
+                ))
+                .expect("record fallback");
+            assert_eq!(
+                selection.evidence().fallback_code.as_deref(),
+                Some("iroh_connect_failed")
+            );
+            if authenticated_hints_make_trusted_iroh_hint_stale(
+                &endpoint_hints,
+                &authenticated_hints,
+            ) {
+                selection.mark_stale_iroh_hint();
+            }
+
+            assert_eq!(
+                selection.evidence().fallback_code.as_deref(),
+                Some("stale_iroh_hint")
+            );
+            let expected_reason = format!(
+                "Iroh sync transport was unavailable (connect failed); using {TCP_TRANSPORT_ID}."
+            );
+            assert_eq!(
+                selection.evidence().fallback_reason.as_deref(),
+                Some(expected_reason.as_str())
             );
         }
 
@@ -5397,6 +6230,7 @@ mod desktop {
                 message: "done".to_string(),
                 selected_transport: TCP_TRANSPORT_ID.to_string(),
                 fallback_reason: None,
+                fallback_code: None,
                 attempted_transports: vec![TCP_TRANSPORT_ID.to_string()],
                 started_at: "2026-01-01T00:00:00Z".to_string(),
                 completed_at: "2026-01-01T00:00:02Z".to_string(),
@@ -5435,6 +6269,7 @@ mod desktop {
                 Some(&json!(TCP_TRANSPORT_ID))
             );
             assert_eq!(value.get("fallbackReason"), Some(&Value::Null));
+            assert_eq!(value.get("fallbackCode"), Some(&Value::Null));
             assert_eq!(
                 value.get("attemptedTransports"),
                 Some(&json!([TCP_TRANSPORT_ID]))
@@ -5457,6 +6292,7 @@ mod desktop {
                 fallback_reason: Some(format!(
                     "Iroh sync transport was unavailable (direct path failed); using {TCP_TRANSPORT_ID}."
                 )),
+                fallback_code: Some("iroh_connect_failed".to_string()),
                 attempted_transports: vec![
                     IROH_TRANSPORT_ID.to_string(),
                     TCP_TRANSPORT_ID.to_string(),
@@ -5497,6 +6333,10 @@ mod desktop {
                 Some(&json!(format!(
                     "Iroh sync transport was unavailable (direct path failed); using {TCP_TRANSPORT_ID}."
                 )))
+            );
+            assert_eq!(
+                value.get("fallbackCode"),
+                Some(&json!("iroh_connect_failed"))
             );
         }
 

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -44,6 +44,8 @@ const tcpTransportId = "tuneforge-sync+tcp";
 const irohEndpointHint = `${irohTransportId}://device_peer_1`;
 const tcpEndpointHint = `${tcpTransportId}://192.168.1.57:48625`;
 const listenerTcpEndpointHint = `${tcpTransportId}://192.168.1.42:48625`;
+const nearbyIrohEndpointHint = `${irohTransportId}://device_peer_1?direct=192.168.1.58%3A47620`;
+const nearbyTcpEndpointHint = `${tcpTransportId}://192.168.1.58:48625?device_id=device_peer_1&v=1`;
 const syncEndpointHints = [irohEndpointHint, tcpEndpointHint];
 const listenerEndpointHints = [irohEndpointHint, listenerTcpEndpointHint];
 const androidCapabilities: MobileCapabilities = {
@@ -585,6 +587,87 @@ describe("Desktop app activity", () => {
     expect(await screen.findByText("Stopped")).toBeInTheDocument();
   });
 
+  it("shows nearby devices and syncs trusted matches with discovered endpoints", async () => {
+    const user = userEvent.setup();
+    setSyncTrustedPeers([
+      {
+        device_id: "device_peer_1",
+        sync_group_id: "sync_group_local",
+        display_name: "Laptop Rig",
+        public_key: "pub_peer_1",
+        endpoint_hints: syncEndpointHints,
+        trusted_at: "2026-04-18T13:16:00.000Z",
+      },
+      {
+        device_id: "device_peer_2",
+        sync_group_id: "sync_group_local",
+        display_name: "Old Laptop",
+        public_key: "pub_peer_2",
+        endpoint_hints: [],
+        trusted_at: "2026-04-18T13:17:00.000Z",
+      },
+    ]);
+    setSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: listenerEndpointHints,
+      nearby_peers: [
+        {
+          device_id: "device_peer_1",
+          display_name: "Laptop Rig",
+          public_key: "pub_peer_1",
+          short_fingerprint: "A1B2-C3D4-E5F6-7890",
+          trust_status: "match",
+          endpoint_hints: [nearbyIrohEndpointHint, nearbyTcpEndpointHint],
+          last_seen_at: "2026-04-18T13:19:00.000Z",
+        },
+        {
+          device_id: "device_unknown",
+          display_name: "Guest Phone",
+          short_fingerprint: "1111-2222-3333-4444",
+          trust_status: "unknown",
+          endpoint_hints: ["tuneforge-sync+tcp://192.168.1.70:48625?device_id=device_unknown&v=1"],
+          last_seen_at: "2026-04-18T13:18:00.000Z",
+        },
+        {
+          device_id: "device_peer_2",
+          display_name: "Old Laptop",
+          public_key: "unexpected_pub_peer_2",
+          short_fingerprint: "9999-8888-7777-6666",
+          trust_status: "mismatch",
+          endpoint_hints: ["tuneforge-sync+tcp://192.168.1.71:48625?device_id=device_peer_2&v=1"],
+        },
+      ],
+    });
+    await openSyncTab(user);
+
+    const nearbyDevices = await screen.findByRole("list", { name: "Nearby sync devices" });
+    const laptopRow = within(nearbyDevices).getByText("Laptop Rig").closest("li");
+    const guestRow = within(nearbyDevices).getByText("Guest Phone").closest("li");
+    const mismatchRow = within(nearbyDevices).getByText("Old Laptop").closest("li");
+    expect(laptopRow).not.toBeNull();
+    expect(guestRow).not.toBeNull();
+    expect(mismatchRow).not.toBeNull();
+    expect(within(laptopRow as HTMLElement).getByText("A1B2-C3D4-E5F6-7890")).toBeInTheDocument();
+    expect(within(laptopRow as HTMLElement).getByText("Trusted")).toBeInTheDocument();
+    expect(
+      within(laptopRow as HTMLElement).getByText((content) => content.includes(nearbyIrohEndpointHint)),
+    ).toBeInTheDocument();
+    expect(within(laptopRow as HTMLElement).getByText(/Apr 18/)).toBeInTheDocument();
+    expect(within(guestRow as HTMLElement).getByText("Unknown")).toBeInTheDocument();
+    expect(within(guestRow as HTMLElement).getByRole("button", { name: "Pair Required" })).toBeDisabled();
+    expect(within(mismatchRow as HTMLElement).getByText("Trust mismatch")).toBeInTheDocument();
+    expect(within(mismatchRow as HTMLElement).getByRole("button", { name: "Trust Mismatch" })).toBeDisabled();
+
+    await user.click(within(laptopRow as HTMLElement).getByRole("button", { name: "Sync Now" }));
+
+    await waitFor(() =>
+      expect(mockSyncTrustedPeerNow).toHaveBeenCalledWith("device_peer_1", {
+        endpointHints: [nearbyIrohEndpointHint, nearbyTcpEndpointHint],
+      }),
+    );
+  });
+
   it("runs sync now for a trusted peer", async () => {
     const user = userEvent.setup();
     setSyncTrustedPeers([
@@ -731,6 +814,18 @@ describe("Desktop app activity", () => {
       running: true,
       state: "listening",
       endpointHints: syncEndpointHints,
+      fallbackCode: "iroh_unavailable",
+      nearbyPeers: [
+        {
+          deviceId: "device_peer_1",
+          displayName: "Laptop Rig",
+          publicKey: "pub_peer_1",
+          shortFingerprint: "A1B2-C3D4-E5F6-7890",
+          trustStatus: "match",
+          endpointHints: [nearbyIrohEndpointHint, nearbyTcpEndpointHint],
+          lastSeenAt: "2026-04-18 13:17:00",
+        },
+      ],
       lastSync: {
         runId: "sync_run_retry_2",
         sessionId: "sync_session_retry_2",
@@ -738,6 +833,7 @@ describe("Desktop app activity", () => {
         remoteDeviceId: "device_peer_1",
         selectedTransport: tcpTransportId,
         fallbackReason: "Iroh endpoint was unavailable; used TCP.",
+        fallbackCode: "stale_iroh_hint",
         attemptedTransports: [irohTransportId, tcpTransportId],
         status: "completed_with_errors",
         message: "Retry completed after staged bytes were reused.",
@@ -831,6 +927,7 @@ describe("Desktop app activity", () => {
       session_id: "sync_session_retry_2",
       selected_transport: "tcp",
       fallback_reason: "Iroh endpoint was unavailable; used TCP.",
+      fallback_code: "stale_iroh_hint",
       attempted_transports: ["iroh", "tcp"],
       status: "completed",
       started_at: "2026-04-18T13:16:00.000Z",
@@ -844,6 +941,17 @@ describe("Desktop app activity", () => {
       failed_project_count: 0,
     });
     expect(normalized.endpoint_hints).toEqual(syncEndpointHints);
+    expect(normalized.fallback_code).toBe("iroh_unavailable");
+    expect(normalized.nearby_peers).toEqual([
+      expect.objectContaining({
+        device_id: "device_peer_1",
+        display_name: "Laptop Rig",
+        short_fingerprint: "A1B2-C3D4-E5F6-7890",
+        trust_status: "match",
+        endpoint_hints: [nearbyIrohEndpointHint, nearbyTcpEndpointHint],
+        last_seen_at: "2026-04-18T13:17:00.000Z",
+      }),
+    ]);
     expect(normalized.last_sync?.timing).toEqual({
       planningMs: 10,
       transferMs: 25,

--- a/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
+++ b/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
@@ -5,6 +5,8 @@ import {
   api,
   mergeSyncProjectResults,
   type SyncPairingPayloadSchema,
+  type SyncNearbyPeer,
+  type SyncNearbyPeerTrustStatus,
   type SyncTransportProjectResult,
   type SyncTransportRunStatus,
   type SyncTransportTransferResult,
@@ -20,6 +22,7 @@ import {
 } from "./syncPairingCode";
 
 const PAIRING_OFFER_TTL_SECONDS = 600;
+const EMPTY_NEARBY_PEERS: SyncNearbyPeer[] = [];
 
 type PairingOutputKind = "offer" | "response";
 type PairingOutput = {
@@ -28,6 +31,10 @@ type PairingOutput = {
   rawJson: string;
   payload: SyncPairingPayloadSchema;
   state: "waiting" | "answer received";
+};
+type SyncNowRequest = {
+  deviceId: string;
+  endpointHints?: string[];
 };
 
 function statusLabel(value: string | null | undefined) {
@@ -111,6 +118,52 @@ function peerEndpointSummary(peer: SyncTrustedPeerSchema) {
   return peer.endpoint_hints?.length ? peer.endpoint_hints.join(", ") : "No endpoint hints";
 }
 
+function nearbyPeerLabel(peer: SyncNearbyPeer) {
+  return peer.display_name?.trim() || peer.device_id || "Nearby TuneForge device";
+}
+
+function nearbyPeerEndpointSummary(peer: SyncNearbyPeer) {
+  return peer.endpoint_hints.length ? peer.endpoint_hints.join(", ") : "No endpoint hints";
+}
+
+function nearbyPeerFingerprint(peer: SyncNearbyPeer, trustedPeer: SyncTrustedPeerSchema | null) {
+  return peer.short_fingerprint?.trim() ||
+    pairingFingerprint({
+      device_id: peer.device_id ?? trustedPeer?.device_id,
+      public_key: peer.public_key ?? trustedPeer?.public_key,
+    });
+}
+
+function nearbyTrustedDeviceId(peer: SyncNearbyPeer) {
+  return peer.trusted_peer_device_id ?? peer.device_id ?? null;
+}
+
+function nearbyTrustStatus(
+  peer: SyncNearbyPeer,
+  trustedPeer: SyncTrustedPeerSchema | null,
+): SyncNearbyPeerTrustStatus {
+  if (peer.trust_status === "mismatch") {
+    return "mismatch";
+  }
+  if (!trustedPeer) {
+    return "unknown";
+  }
+  if (peer.public_key && trustedPeer.public_key && peer.public_key !== trustedPeer.public_key) {
+    return "mismatch";
+  }
+  return peer.trust_status === "unknown" ? "match" : peer.trust_status;
+}
+
+function nearbyTrustLabel(value: SyncNearbyPeerTrustStatus) {
+  if (value === "match") {
+    return "Trusted";
+  }
+  if (value === "mismatch") {
+    return "Trust mismatch";
+  }
+  return "Unknown";
+}
+
 function pairingPayloadLabel(payload: SyncPairingPayloadSchema) {
   return payload.display_name?.trim() || payload.device_id;
 }
@@ -161,6 +214,7 @@ function syncResultKey(status: SyncTransportRunStatus | null | undefined) {
     durationMs: status.duration_ms,
     selectedTransport: status.selected_transport,
     fallbackReason: status.fallback_reason,
+    fallbackCode: status.fallback_code,
     attemptedTransports: status.attempted_transports,
     timeToFirstArtifactMs: status.time_to_first_artifact_ms,
     totalReceivedBytes: status.total_received_bytes,
@@ -310,6 +364,9 @@ function syncRunSummaryText(status: SyncTransportRunStatus | null | undefined) {
   }
   if (status.fallback_reason) {
     parts.push(`Fallback: ${status.fallback_reason}`);
+  }
+  if (status.fallback_code) {
+    parts.push(`Fallback code ${status.fallback_code}`);
   }
   const counters = syncRunProjectCounterText(status);
   if (counters) {
@@ -481,6 +538,18 @@ export function ActivitySyncPanel() {
     [peersQuery.data],
   );
   const endpointHints = listenerQuery.data?.endpoint_hints ?? [];
+  const nearbyPeers = listenerQuery.data?.nearby_peers ?? EMPTY_NEARBY_PEERS;
+  const trustedNearbyPeerByDeviceId = useMemo(() => {
+    const trustedNearbyPeers = new Map<string, SyncNearbyPeer>();
+    nearbyPeers.forEach((peer) => {
+      const trustedDeviceId = nearbyTrustedDeviceId(peer);
+      const trustedPeer = trustedDeviceId ? peersById.get(trustedDeviceId) ?? null : null;
+      if (trustedDeviceId && nearbyTrustStatus(peer, trustedPeer) === "match") {
+        trustedNearbyPeers.set(trustedDeviceId, peer);
+      }
+    });
+    return trustedNearbyPeers;
+  }, [nearbyPeers, peersById]);
   const listenerActive = listenerQuery.data?.active ?? false;
   const listenerStatus = listenerQuery.isError ? "unavailable" : listenerQuery.data?.status ?? "checking";
   const listenerSyncResult = listenerQuery.data?.last_sync ?? null;
@@ -595,7 +664,10 @@ export function ActivitySyncPanel() {
     },
   });
   const syncNowMutation = useMutation({
-    mutationFn: (deviceId: string) => api.syncTrustedPeerNow(deviceId),
+    mutationFn: (request: SyncNowRequest) =>
+      request.endpointHints?.length
+        ? api.syncTrustedPeerNow(request.deviceId, { endpointHints: request.endpointHints })
+        : api.syncTrustedPeerNow(request.deviceId),
     onSuccess: async (status) => {
       setLastSyncMessage(syncStatusText(status, peersById));
       setLastSyncResult(status);
@@ -993,6 +1065,92 @@ export function ActivitySyncPanel() {
         </section>
       </div>
 
+      <section className="activity-sync-section activity-sync-section--nearby" aria-labelledby="activity-sync-nearby-heading">
+        <div className="activity-sync-section__header">
+          <h3 id="activity-sync-nearby-heading">Nearby Devices</h3>
+          <span className="metric-label">{nearbyPeers.length} nearby</span>
+        </div>
+
+        {!nearbyPeers.length ? (
+          <p className="activity-sync-empty">No nearby devices.</p>
+        ) : null}
+        {nearbyPeers.length ? (
+          <ul className="activity-sync-peer-list" aria-label="Nearby sync devices">
+            {nearbyPeers.map((nearbyPeer, index) => {
+              const trustedDeviceId = nearbyTrustedDeviceId(nearbyPeer);
+              const trustedPeer = trustedDeviceId ? peersById.get(trustedDeviceId) ?? null : null;
+              const trustStatus = nearbyTrustStatus(nearbyPeer, trustedPeer);
+              const canSync = trustStatus === "match" && trustedPeer !== null && nearbyPeer.endpoint_hints.length > 0;
+              const isSyncing = syncNowMutation.isPending &&
+                syncNowMutation.variables?.deviceId === trustedPeer?.device_id;
+              const lastSeenAt = formatTimestamp(nearbyPeer.last_seen_at);
+
+              return (
+                <li
+                  className="activity-sync-peer-row activity-sync-peer-row--nearby"
+                  key={`${nearbyPeer.device_id ?? "nearby"}-${nearbyPeer.short_fingerprint ?? index}`}
+                >
+                  <div className="activity-sync-peer-row__main">
+                    <strong>{nearbyPeerLabel(nearbyPeer)}</strong>
+                    <dl>
+                      <div>
+                        <dt>Fingerprint</dt>
+                        <dd>{nearbyPeerFingerprint(nearbyPeer, trustedPeer)}</dd>
+                      </div>
+                      <div>
+                        <dt>Trust</dt>
+                        <dd>
+                          <span className={`activity-sync-trust activity-sync-trust--${trustStatus}`}>
+                            {nearbyTrustLabel(trustStatus)}
+                          </span>
+                        </dd>
+                      </div>
+                      <div>
+                        <dt>Endpoints</dt>
+                        <dd>{nearbyPeerEndpointSummary(nearbyPeer)}</dd>
+                      </div>
+                      {lastSeenAt ? (
+                        <div>
+                          <dt>Last Seen</dt>
+                          <dd>
+                            <time dateTime={normalizeApiDateTime(nearbyPeer.last_seen_at ?? "")}>
+                              {lastSeenAt}
+                            </time>
+                          </dd>
+                        </div>
+                      ) : null}
+                    </dl>
+                  </div>
+                  <div className="activity-sync-peer-row__actions">
+                    <button
+                      className="button button--ghost button--small"
+                      disabled={!canSync || isSyncing}
+                      onClick={() => {
+                        if (trustedPeer) {
+                          syncNowMutation.mutate({
+                            deviceId: trustedPeer.device_id,
+                            endpointHints: nearbyPeer.endpoint_hints,
+                          });
+                        }
+                      }}
+                      type="button"
+                    >
+                      {isSyncing
+                        ? "Syncing..."
+                        : canSync
+                          ? "Sync Now"
+                          : trustStatus === "mismatch"
+                            ? "Trust Mismatch"
+                            : "Pair Required"}
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        ) : null}
+      </section>
+
       <section className="activity-sync-section activity-sync-section--peers" aria-labelledby="activity-sync-peers-heading">
         <div className="activity-sync-section__header">
           <h3 id="activity-sync-peers-heading">Trusted Peers</h3>
@@ -1015,8 +1173,10 @@ export function ActivitySyncPanel() {
         {trustedPeers.length ? (
           <ul className="activity-sync-peer-list" aria-label="Trusted sync peers">
             {trustedPeers.map((peer) => {
+              const nearbyPeer = trustedNearbyPeerByDeviceId.get(peer.device_id);
+              const nearbyEndpointHints = nearbyPeer?.endpoint_hints ?? [];
               const isRevoking = revokePeerMutation.isPending && revokePeerMutation.variables === peer.device_id;
-              const isSyncing = syncNowMutation.isPending && syncNowMutation.variables === peer.device_id;
+              const isSyncing = syncNowMutation.isPending && syncNowMutation.variables?.deviceId === peer.device_id;
               const trustedAt = formatTimestamp(peer.trusted_at);
 
               return (
@@ -1046,7 +1206,12 @@ export function ActivitySyncPanel() {
                     <button
                       className="button button--ghost button--small"
                       disabled={isSyncing}
-                      onClick={() => syncNowMutation.mutate(peer.device_id)}
+                      onClick={() =>
+                        syncNowMutation.mutate({
+                          deviceId: peer.device_id,
+                          endpointHints: nearbyEndpointHints.length ? nearbyEndpointHints : undefined,
+                        })
+                      }
                       type="button"
                     >
                       {isSyncing ? "Syncing..." : "Sync Now"}

--- a/apps/desktop/src/lib/api.mobile-sync.test.ts
+++ b/apps/desktop/src/lib/api.mobile-sync.test.ts
@@ -214,4 +214,26 @@ describe("mobile sync API adapter", () => {
       payload: { peerDeviceId: "device_peer_1", preferredTransport: "auto" },
     });
   });
+
+  it("passes discovered endpoint hints to native sync now", async () => {
+    const api = await loadMobileApi();
+    const currentEndpointHints = [
+      " tuneforge-sync+iroh://device_peer_1?direct=192.168.1.57%3A47620 ",
+      "tuneforge-sync+tcp://192.168.1.57:48625?device_id=device_peer_1&v=1",
+    ];
+
+    await api.syncTrustedPeerNow("device_peer_1", { endpointHints: currentEndpointHints });
+
+    expect(mockInvoke).toHaveBeenCalledWith("sync_transport_sync_now", {
+      payload: {
+        peerDeviceId: "device_peer_1",
+        preferredTransport: "auto",
+        endpointHint: "tuneforge-sync+iroh://device_peer_1?direct=192.168.1.57%3A47620",
+        endpointHints: [
+          "tuneforge-sync+iroh://device_peer_1?direct=192.168.1.57%3A47620",
+          "tuneforge-sync+tcp://192.168.1.57:48625?device_id=device_peer_1&v=1",
+        ],
+      },
+    });
+  });
 });

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -106,7 +106,9 @@ export type SyncTransportRunStatus = {
   direction?: string | null;
   selected_transport?: string | null;
   fallback_reason?: string | null;
+  fallback_code?: string | null;
   attempted_transports?: string[];
+  nearby_peers?: SyncNearbyPeer[];
   status: string;
   message?: string | null;
   started_at?: string | null;
@@ -173,14 +175,31 @@ export type SyncTransportTransferResult = {
   duration_ms?: number | null;
   throughput_bytes_per_second?: number | null;
 };
+export type SyncNearbyPeerTrustStatus = "match" | "mismatch" | "unknown";
+export type SyncNearbyPeer = {
+  device_id?: string | null;
+  display_name?: string | null;
+  public_key?: string | null;
+  short_fingerprint?: string | null;
+  trust_status: SyncNearbyPeerTrustStatus;
+  trusted_peer_device_id?: string | null;
+  endpoint_hints: string[];
+  last_seen_at?: string | null;
+};
 export type SyncTransportStatus = {
   active: boolean;
   status: string;
   endpoint_hints: string[];
+  nearby_peers: SyncNearbyPeer[];
   last_status?: string | null;
   last_error?: string | null;
+  fallback_code?: string | null;
   last_sync?: SyncTransportRunStatus | null;
   updated_at?: string | null;
+};
+export type SyncTransportSyncNowOptions = {
+  endpointHint?: string | null;
+  endpointHints?: string[];
 };
 
 const LOCAL_SYNC_STATES = new Set(["local", "noop", "identical_content"]);
@@ -594,6 +613,114 @@ function normalizeSyncTransportToken(value: string | null) {
     return "auto";
   }
   return normalizeTransportStatusToken(normalized).replace(/\+/g, "_");
+}
+
+function normalizeNearbyPeerTrustStatus(record: Record<string, unknown>): SyncNearbyPeerTrustStatus {
+  const explicit = firstStringField([
+    record,
+  ], [
+    "trust_status",
+    "trustStatus",
+    "trust_state",
+    "trustState",
+    "trust",
+    "match_status",
+    "matchStatus",
+  ]);
+  const normalized = explicit ? normalizeTransportStatusToken(explicit) : null;
+  if (normalized) {
+    if (normalized.includes("mismatch") || normalized.includes("conflict")) {
+      return "mismatch";
+    }
+    if (normalized.includes("match") || normalized === "trusted" || normalized === "known") {
+      return "match";
+    }
+    if (normalized === "unknown" || normalized === "untrusted" || normalized === "new") {
+      return "unknown";
+    }
+  }
+
+  const trustMatches = firstBooleanField([
+    record,
+  ], ["trust_match", "trustMatch", "matches_trusted_peer", "matchesTrustedPeer"]);
+  if (trustMatches !== null) {
+    return trustMatches ? "match" : "mismatch";
+  }
+  const trusted = firstBooleanField([record], ["trusted", "is_trusted", "isTrusted"]);
+  return trusted ? "match" : "unknown";
+}
+
+function normalizeNearbyPeer(value: unknown): SyncNearbyPeer | null {
+  const record = asRecord(value);
+  if (!record) {
+    return null;
+  }
+  const endpointHints = stringArrayField(record, [
+    "endpoint_hints",
+    "endpointHints",
+    "endpoints",
+    "current_endpoint_hints",
+    "currentEndpointHints",
+  ]);
+  return {
+    device_id: firstStringField([record], ["device_id", "deviceId", "id"]),
+    display_name: firstStringField([record], ["display_name", "displayName", "name"]),
+    public_key: firstStringField([record], ["public_key", "publicKey"]),
+    short_fingerprint: firstStringField([
+      record,
+    ], [
+      "short_fingerprint",
+      "shortFingerprint",
+      "fingerprint_short",
+      "fingerprintShort",
+      "fingerprint",
+    ]),
+    trust_status: normalizeNearbyPeerTrustStatus(record),
+    trusted_peer_device_id: firstStringField([
+      record,
+    ], ["trusted_peer_device_id", "trustedPeerDeviceId", "trusted_device_id", "trustedDeviceId"]),
+    endpoint_hints: endpointHints,
+    last_seen_at: dateTimeField(record, [
+      "last_seen_at",
+      "lastSeenAt",
+      "last_seen",
+      "lastSeen",
+      "observed_at",
+      "observedAt",
+      "discovered_at",
+      "discoveredAt",
+      "timestamp",
+      "updated_at",
+      "updatedAt",
+    ]),
+  };
+}
+
+function nearbyPeersField(record: Record<string, unknown>) {
+  return recordArrayOrObjectValuesField(record, [
+    "nearby_peers",
+    "nearbyPeers",
+    "discovered_peers",
+    "discoveredPeers",
+    "local_peers",
+    "localPeers",
+  ])
+    .map((item) => normalizeNearbyPeer(item))
+    .filter((item): item is SyncNearbyPeer => item !== null);
+}
+
+function normalizedEndpointHints(endpointHints: string[] | null | undefined) {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  (endpointHints ?? []).forEach((hint) => {
+    const trimmed = hint.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      return;
+    }
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  });
+  return normalized;
 }
 
 const SYNC_PROJECT_RESULT_PROGRESS_STATES = new Set([
@@ -1023,9 +1150,11 @@ export function normalizeSyncRunStatus(value: unknown): SyncTransportRunStatus |
       firstStringField([record], ["selected_transport", "selectedTransport"]),
     ),
     fallback_reason: firstStringField([record], ["fallback_reason", "fallbackReason"]),
+    fallback_code: firstStringField([record], ["fallback_code", "fallbackCode"]),
     attempted_transports: stringArrayField(record, ["attempted_transports", "attemptedTransports"])
       .map((transport) => normalizeSyncTransportToken(transport))
       .filter((transport): transport is string => transport !== null),
+    nearby_peers: nearbyPeersField(record),
     status,
     message: firstStringField([record], ["message", "status_message", "statusMessage"]) ?? summary,
     started_at: runStartedAt,
@@ -1062,6 +1191,7 @@ export function normalizeSyncTransportStatus(value: unknown): SyncTransportStatu
       active: false,
       status: "unavailable",
       endpoint_hints: [],
+      nearby_peers: [],
       last_error: "Native sync transport returned an invalid status.",
     };
   }
@@ -1073,8 +1203,10 @@ export function normalizeSyncTransportStatus(value: unknown): SyncTransportStatu
     active,
     status,
     endpoint_hints: stringArrayField(record, ["endpoint_hints", "endpointHints", "endpoints"]),
+    nearby_peers: nearbyPeersField(record),
     last_status: firstStringField([record], ["last_status", "lastStatus"]),
     last_error: firstStringField([record], ["last_error", "lastError", "error"]),
+    fallback_code: firstStringField([record], ["fallback_code", "fallbackCode"]),
     last_sync: normalizeSyncRunStatus(record.last_sync ?? record.lastSync ?? null),
     updated_at: firstStringField([record], ["updated_at", "updatedAt"]),
   };
@@ -1092,10 +1224,19 @@ async function stopSyncListener() {
   return normalizeSyncTransportStatus(await invokeDesktopNative<unknown>("sync_transport_stop_listener"));
 }
 
-async function syncTrustedPeerNow(deviceId: string) {
+async function syncTrustedPeerNow(deviceId: string, options?: SyncTransportSyncNowOptions) {
+  const endpointHints = normalizedEndpointHints(options?.endpointHints);
+  const endpointHint = options?.endpointHint?.trim() || endpointHints[0];
+  const payload: Record<string, unknown> = { peerDeviceId: deviceId, preferredTransport: "auto" };
+  if (endpointHint) {
+    payload.endpointHint = endpointHint;
+  }
+  if (endpointHints.length) {
+    payload.endpointHints = endpointHints;
+  }
   const result = normalizeSyncRunStatus(
     await invokeDesktopNative<unknown>("sync_transport_sync_now", {
-      payload: { peerDeviceId: deviceId, preferredTransport: "auto" },
+      payload,
     }),
   );
   if (!result) {
@@ -1170,7 +1311,10 @@ export type TuneForgeClient = {
   getSyncTransportStatus: () => Promise<SyncTransportStatus>;
   startSyncListener: () => Promise<SyncTransportStatus>;
   stopSyncListener: () => Promise<SyncTransportStatus>;
-  syncTrustedPeerNow: (deviceId: string) => Promise<SyncTransportRunStatus>;
+  syncTrustedPeerNow: (
+    deviceId: string,
+    options?: SyncTransportSyncNowOptions,
+  ) => Promise<SyncTransportRunStatus>;
   streamArtifactUrl: (artifactId: string) => string;
 };
 
@@ -1629,6 +1773,7 @@ export const api: TuneForgeClient = {
   getSyncTransportStatus: () => activeClient.getSyncTransportStatus(),
   startSyncListener: () => activeClient.startSyncListener(),
   stopSyncListener: () => activeClient.stopSyncListener(),
-  syncTrustedPeerNow: (deviceId: string) => activeClient.syncTrustedPeerNow(deviceId),
+  syncTrustedPeerNow: (deviceId: string, options?: SyncTransportSyncNowOptions) =>
+    activeClient.syncTrustedPeerNow(deviceId, options),
   streamArtifactUrl: (artifactId: string) => activeClient.streamArtifactUrl(artifactId),
 };

--- a/apps/desktop/src/styles/activity.css
+++ b/apps/desktop/src/styles/activity.css
@@ -327,6 +327,26 @@
   border-color: color-mix(in srgb, var(--playback-accent) 42%, var(--chip-border));
 }
 
+.activity-sync-trust {
+  display: inline-flex;
+  width: fit-content;
+  border: 1px solid color-mix(in srgb, var(--chip-border) 82%, transparent);
+  border-radius: 999px;
+  padding: 0.18rem 0.5rem;
+  background: color-mix(in srgb, var(--chip-bg) 78%, transparent);
+  font-size: 0.76rem;
+  font-weight: 820;
+}
+
+.activity-sync-trust--match {
+  border-color: color-mix(in srgb, var(--playback-accent) 42%, var(--chip-border));
+}
+
+.activity-sync-trust--mismatch {
+  border-color: color-mix(in srgb, var(--danger) 52%, var(--chip-border));
+  color: var(--danger);
+}
+
 .activity-sync-status--error,
 .activity-sync-status--unavailable {
   border-color: color-mix(in srgb, var(--danger) 48%, var(--chip-border));

--- a/docs/API.md
+++ b/docs/API.md
@@ -293,6 +293,22 @@ Trusting a peer records its `device_id`, public identity, display name, endpoint
 peer can later be revoked without deleting local projects or changing this install's own `device_id`.
 Standalone payloads that do not reference a local pending offer are rejected.
 
+### Update trusted peer endpoint hints
+
+`PATCH /api/v1/sync/trusted-peers/{device_id}/endpoint-hints`
+
+Replaces advisory endpoint hints for an active trusted peer.
+
+Request fields:
+
+- `endpoint_hints` - advisory peer endpoints. Values are trimmed and empty values are rejected.
+
+Response wrapper:
+
+- `trusted_peer`
+
+Unknown or revoked peers return `404`.
+
 ### Revoke trusted peer
 
 `DELETE /api/v1/sync/trusted-peers/{device_id}`

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -657,6 +657,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/sync/trusted-peers/{device_id}/endpoint-hints": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Sync Trusted Peer Endpoint Hints Update */
+        patch: operations["sync_trusted_peer_endpoint_hints_update_api_v1_sync_trusted_peers__device_id__endpoint_hints_patch"];
+        trace?: never;
+    };
     "/api/v1/sync/projects/{project_id}/manifest": {
         parameters: {
             query?: never;
@@ -2241,6 +2258,11 @@ export interface components {
              */
             adopt_sync_group?: boolean;
         };
+        /** SyncTrustedPeerEndpointHintsRequest */
+        SyncTrustedPeerEndpointHintsRequest: {
+            /** Endpoint Hints */
+            endpoint_hints: string[];
+        };
         /** SyncTrustedPeerResponse */
         SyncTrustedPeerResponse: {
             trusted_peer: components["schemas"]["SyncTrustedPeerSchema"];
@@ -3797,6 +3819,41 @@ export interface operations {
             cookie?: never;
         };
         requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncTrustedPeerResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    sync_trusted_peer_endpoint_hints_update_api_v1_sync_trusted_peers__device_id__endpoint_hints_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                device_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SyncTrustedPeerEndpointHintsRequest"];
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {


### PR DESCRIPTION
## Summary

- Add UDP LAN peer discovery on the fixed local discovery port and expose trusted/advisory nearby peers in Activity Sync.
- Add trusted-peer endpoint hint refresh across backend, generated contracts, desktop transport, and Android embedded storage.
- Use authenticated endpoint hints after sync/fallback and add fallback evidence codes for Iroh hint/connect cases.
- Fix LAN discovery broadcast coverage by sending to per-interface directed broadcasts plus limited broadcast.

Fixes #198

## Testing

- `cd apps/backend && uv run --python 3.11 pytest tests/test_sync_trust.py tests/test_sync_transport_api.py`
- `pnpm contracts:generate`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test`
- `cd apps/desktop/src-tauri && cargo test sync_transport`
- `cd apps/desktop/src-tauri && cargo check`
- `pnpm package:android:debug`
- `adb install -r apps/desktop/src-tauri/gen/android/app/build/outputs/apk/universal/debug/app-universal-debug.apk`
- Manual 3-way sync validation across desktop and physical Android device.
