### PR TITLE
feat: add playback E2E telemetry

### DIFF
--- a/apps/desktop/src/App.project-precount.test.tsx
+++ b/apps/desktop/src/App.project-precount.test.tsx
@@ -69,6 +69,14 @@ async function flushMicrotasks(count = 6) {
   }
 }
 
+function readPlaybackE2ETelemetry() {
+  const telemetry = window.__TUNEFORGE_PLAYBACK_E2E__?.read();
+  if (!telemetry) {
+    throw new Error("Playback E2E telemetry bridge was not exposed.");
+  }
+  return telemetry;
+}
+
 describe("Desktop app project playback pre-count", () => {
   beforeEach(resetAppTestHarness);
 
@@ -139,6 +147,16 @@ describe("Desktop app project playback pre-count", () => {
     const audioContext = getMockAudioContexts()[0];
     expect(audioContext?.createdOscillators).toHaveLength(4);
     expect(audioContext?.createdSources).toHaveLength(0);
+    let telemetry = readPlaybackE2ETelemetry();
+    expect(telemetry.countIn.active).toBe(true);
+    expect(telemetry.countIn.lastScheduled).toMatchObject({
+      activePath: "none",
+      clickCount: 4,
+      startTimeSeconds: 0,
+      tempoBpm: 120,
+      trigger: "song-start",
+    });
+    expect(telemetry.countIn.lastFired).toBeNull();
     const clickStartTimes = audioContext?.createdOscillators.map(
       (oscillator) => oscillator.start.mock.calls[0]?.[0],
     ) ?? [];
@@ -159,6 +177,12 @@ describe("Desktop app project playback pre-count", () => {
     expect(audioContext?.createdSources[0]?.start.mock.calls[0]?.[0]).toBeCloseTo(2.035, 3);
     expect(audioContext?.createdSources[0]?.start.mock.calls[0]?.[1]).toBe(0);
     expect(sourceAudio.currentTime).toBe(0);
+    telemetry = readPlaybackE2ETelemetry();
+    expect(telemetry.countIn.active).toBe(false);
+    expect(telemetry.countIn.lastFired).toMatchObject({
+      sequence: telemetry.countIn.lastScheduled?.sequence,
+      trigger: "song-start",
+    });
     expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
   });
 
@@ -186,7 +210,62 @@ describe("Desktop app project playback pre-count", () => {
     expect(vi.mocked(window.HTMLMediaElement.prototype.play)).not.toHaveBeenCalled();
     expect(audioContext?.createdSources).toHaveLength(0);
     expect(sourceAudio.currentTime).toBe(0);
+    expect(readPlaybackE2ETelemetry().countIn.lastCancelled).toMatchObject({
+      reason: "playback-stopped",
+      sequence: readPlaybackE2ETelemetry().countIn.lastScheduled?.sequence,
+      trigger: "song-start",
+    });
     expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+  });
+
+  it("records pre-count cancellation reasons for superseded, session, and unavailable states", async () => {
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    const rendered = renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByLabelText("Enable pre-count"));
+    fireEvent.click(screen.getByRole("button", { name: "Play playback" }));
+    await flushMicrotasks();
+    let scheduledSequence = readPlaybackE2ETelemetry().countIn.lastScheduled?.sequence;
+    setPlaybackPosition("12.5");
+    expect(readPlaybackE2ETelemetry().countIn.lastCancelled).toMatchObject({
+      reason: "superseded",
+      sequence: scheduledSequence,
+      trigger: "song-start",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop playback" }));
+    setPlaybackPosition("0");
+    fireEvent.click(screen.getByRole("button", { name: "Play playback" }));
+    await flushMicrotasks();
+    scheduledSequence = readPlaybackE2ETelemetry().countIn.lastScheduled?.sequence;
+    const sourceList = screen.getByRole("group", { name: "Playback source and mix list" });
+    fireEvent.click(within(sourceList).getByRole("button", { name: /Practice Mix/i }));
+    await flushMicrotasks();
+    expect(readPlaybackE2ETelemetry().countIn.lastCancelled).toMatchObject({
+      reason: "session-changed",
+      sequence: scheduledSequence,
+      trigger: "song-start",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop playback" }));
+    setPlaybackPosition("0");
+    fireEvent.click(screen.getByRole("button", { name: "Play playback" }));
+    await flushMicrotasks();
+    scheduledSequence = readPlaybackE2ETelemetry().countIn.lastScheduled?.sequence;
+    rendered.unmount();
+    expect(readPlaybackE2ETelemetry().countIn.lastCancelled).toMatchObject({
+      reason: "unavailable",
+      sequence: scheduledSequence,
+      trigger: "song-start",
+    });
+    vi.useRealTimers();
   });
 
   it("does not pre-count when resuming mid-song", async () => {
@@ -271,6 +350,16 @@ describe("Desktop app project playback pre-count", () => {
     const audioContext = getMockAudioContexts()[0];
     expect(audioContext?.createdSources).toHaveLength(0);
     expect(audioContext?.createdOscillators).toHaveLength(4);
+    let telemetry = readPlaybackE2ETelemetry();
+    expect(telemetry.loopRange).toEqual({ startSeconds: 12.25, endSeconds: 24.5 });
+    expect(telemetry.countIn.active).toBe(true);
+    expect(telemetry.countIn.lastScheduled).toMatchObject({
+      clickCount: 4,
+      startTimeSeconds: 12.25,
+      tempoBpm: 120,
+      trigger: "loop-start",
+    });
+    const firstSequence = telemetry.countIn.lastScheduled?.sequence;
     act(() => {
       vi.advanceTimersByTime(2035);
     });
@@ -278,6 +367,12 @@ describe("Desktop app project playback pre-count", () => {
     expect(audioContext?.createdSources).toHaveLength(1);
     expect(audioContext?.createdSources[0]?.start.mock.calls[0]?.[1]).toBeCloseTo(12.25, 3);
     expect(sourceAudio.currentTime).toBeCloseTo(12.25, 3);
+    telemetry = readPlaybackE2ETelemetry();
+    expect(telemetry.countIn.active).toBe(false);
+    expect(telemetry.countIn.lastFired).toMatchObject({
+      sequence: firstSequence,
+      trigger: "loop-start",
+    });
     expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
 
     act(() => {
@@ -286,6 +381,13 @@ describe("Desktop app project playback pre-count", () => {
     });
     await flushMicrotasks();
     expect(audioContext?.createdOscillators).toHaveLength(8);
+    telemetry = readPlaybackE2ETelemetry();
+    expect(telemetry.countIn.active).toBe(true);
+    expect(telemetry.countIn.lastScheduled).toMatchObject({
+      startTimeSeconds: 12.25,
+      trigger: "loop-start",
+    });
+    expect(telemetry.countIn.lastScheduled?.sequence).not.toBe(firstSequence);
     const sourceCountBeforeRollover = audioContext?.createdSources.length ?? 0;
     act(() => {
       vi.advanceTimersByTime(2035);
@@ -296,6 +398,12 @@ describe("Desktop app project playback pre-count", () => {
       12.25,
       3,
     );
+    telemetry = readPlaybackE2ETelemetry();
+    expect(telemetry.countIn.active).toBe(false);
+    expect(telemetry.countIn.lastFired).toMatchObject({
+      sequence: telemetry.countIn.lastScheduled?.sequence,
+      trigger: "loop-start",
+    });
     vi.useRealTimers();
   }, 15000);
 

--- a/apps/desktop/src/App.project-tempo.test.tsx
+++ b/apps/desktop/src/App.project-tempo.test.tsx
@@ -94,6 +94,14 @@ function latestNativeSessionId() {
   return payload.sessionId;
 }
 
+function readPlaybackE2ETelemetry() {
+  const telemetry = window.__TUNEFORGE_PLAYBACK_E2E__?.read();
+  if (!telemetry) {
+    throw new Error("Playback E2E telemetry bridge was not exposed.");
+  }
+  return telemetry;
+}
+
 describe("Desktop app project playback tempo", () => {
   beforeEach(resetAppTestHarness);
   afterEach(() => {
@@ -216,6 +224,55 @@ describe("Desktop app project playback tempo", () => {
     restoreTauriRuntime();
   });
 
+  it("reports native playback transport and buffer health for E2E assertions", async () => {
+    const restoreTauriRuntime = mockTauriRuntime();
+    const user = userEvent.setup();
+    setupTempoAnalysis(120);
+    setMockNativeAudioState({
+      capabilities: {
+        nativePlaybackSupported: true,
+        fallbackRequired: false,
+        fallbackReason: null,
+        backend: "desktop-cpal",
+      },
+    });
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    await waitFor(() =>
+      expect(
+        getMockInvoke().mock.calls.some(([command]) => command === "audio_play"),
+      ).toBe(true),
+    );
+    await waitFor(() =>
+      expect(readPlaybackE2ETelemetry()).toMatchObject({
+        activePath: "native",
+        durationSeconds: 182,
+        playbackRate: 1,
+        transportState: "playing",
+      }),
+    );
+    expect(readPlaybackE2ETelemetry().nativeBufferHealth).toEqual([
+      expect.objectContaining({
+        artifactId: "art_source",
+        laneId: "art_source",
+        role: "primary",
+      }),
+    ]);
+
+    emitMockNativePlaybackPosition({
+      sessionId: latestNativeSessionId(),
+      positionSeconds: 5.25,
+      durationSeconds: 182,
+      state: "playing",
+    });
+    await waitFor(() => expect(readPlaybackE2ETelemetry().positionSeconds).toBe(5.25));
+    restoreTauriRuntime();
+  });
+
   it("falls back to Web Audio when native play reports an underrun fallback", async () => {
     const restoreTauriRuntime = mockTauriRuntime();
     const user = userEvent.setup();
@@ -250,8 +307,90 @@ describe("Desktop app project playback tempo", () => {
     expect(window.localStorage.getItem("tuneforge.playback-native-error")).toBe(
       "Native playback underrun persisted; falling back to Web Audio.",
     );
+    expect(readPlaybackE2ETelemetry()).toMatchObject({
+      activePath: "web-audio",
+      transportState: "playing",
+    });
     expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
     restoreTauriRuntime();
+  });
+
+  it("keeps Web Audio telemetry when delayed native stop cleanup resolves after fallback", async () => {
+    const restoreTauriRuntime = mockTauriRuntime();
+    const user = userEvent.setup();
+    const mockInvoke = getMockInvoke();
+    const defaultInvoke = mockInvoke.getMockImplementation();
+    if (!defaultInvoke) {
+      throw new Error("Mock invoke implementation was not installed.");
+    }
+    const nativeStopBlock: { resolve: (() => void) | null } = { resolve: null };
+    let resolveNativeStopSettled: (() => void) | null = null;
+    const nativeStopSettled = new Promise<void>((resolve) => {
+      resolveNativeStopSettled = resolve;
+    });
+    mockInvoke.mockImplementation(async (command: string, args?: Record<string, unknown>) => {
+      if (command === "audio_stop") {
+        await new Promise<void>((resolve) => {
+          nativeStopBlock.resolve = () => {
+            nativeStopBlock.resolve = null;
+            resolve();
+          };
+        });
+        const result = await defaultInvoke(command, args);
+        resolveNativeStopSettled?.();
+        return result;
+      }
+      return defaultInvoke(command, args);
+    });
+
+    try {
+      setupTempoAnalysis(120);
+      setMockNativeAudioState({
+        capabilities: {
+          nativePlaybackSupported: true,
+          fallbackRequired: false,
+          fallbackReason: null,
+          backend: "desktop-cpal",
+        },
+      });
+      renderApp(["/projects/proj_123"]);
+
+      expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+      await openPlaybackWorkspace(user);
+      await user.click(screen.getByRole("button", { name: "Play playback" }));
+      await waitFor(() =>
+        expect(readPlaybackE2ETelemetry()).toMatchObject({
+          activePath: "native",
+          transportState: "playing",
+        }),
+      );
+
+      emitMockNativePlaybackError({
+        sessionId: latestNativeSessionId(),
+        message: "Native playback underrun persisted; falling back to Web Audio.",
+      });
+      await waitFor(() => expect(nativeStopBlock.resolve).not.toBeNull());
+      const sourceAudio = findAudioByArtifactId("art_source");
+      markAudioReady(sourceAudio);
+      await waitFor(() =>
+        expect(readPlaybackE2ETelemetry()).toMatchObject({
+          activePath: "web-audio",
+          transportState: "playing",
+        }),
+      );
+
+      nativeStopBlock.resolve?.();
+      await nativeStopSettled;
+      await Promise.resolve();
+      expect(readPlaybackE2ETelemetry()).toMatchObject({
+        activePath: "web-audio",
+        transportState: "playing",
+      });
+    } finally {
+      nativeStopBlock.resolve?.();
+      mockInvoke.mockImplementation(defaultInvoke);
+      restoreTauriRuntime();
+    }
   });
 
   it("falls back to Web Audio at the current native time after a runtime underrun error", async () => {

--- a/apps/desktop/src/features/projects/playback.test.tsx
+++ b/apps/desktop/src/features/projects/playback.test.tsx
@@ -5,6 +5,7 @@ import {
   getMockAudioContexts,
   resetAppTestHarness,
 } from "../../test/appTestHarness";
+import { readPlaybackE2ETelemetry } from "../../lib/playbackE2ETelemetry";
 import { PlaybackProvider } from "./playback";
 import {
   usePlayback,
@@ -131,5 +132,43 @@ describe("PlaybackProvider", () => {
       PRESERVED_PLAYBACK_TIME_SECONDS,
       3,
     );
+  });
+
+  it("records generic cancellation when play is requested during an active count-in", async () => {
+    let playback: PlaybackContextValue | null = null;
+    const onPlayback = (nextPlayback: PlaybackContextValue) => {
+      playback = nextPlayback;
+    };
+    const sourceSession = {
+      ...makePlaybackSession("art_source", {
+        stageTitle: "Source Track",
+      }),
+      precountEnabled: true,
+      precountTempoBpm: 120,
+    };
+
+    render(
+      <PlaybackProvider>
+        <PlaybackHarness onPlayback={onPlayback} session={sourceSession} />
+      </PlaybackProvider>,
+    );
+    await flushPlaybackWork();
+
+    await act(async () => {
+      await playback?.playPlayback();
+    });
+    const scheduledSequence = readPlaybackE2ETelemetry().countIn.lastScheduled?.sequence;
+    expect(readPlaybackE2ETelemetry().countIn.active).toBe(true);
+
+    await act(async () => {
+      await playback?.playPlayback();
+    });
+
+    expect(readPlaybackE2ETelemetry().countIn.active).toBe(false);
+    expect(readPlaybackE2ETelemetry().countIn.lastCancelled).toMatchObject({
+      reason: "cancelled",
+      sequence: scheduledSequence,
+      trigger: "song-start",
+    });
   });
 });

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -29,6 +29,17 @@ import {
   rememberPlaybackBackend,
 } from "../../lib/playbackDiagnostics";
 import {
+  patchPlaybackE2ETelemetry,
+  type PlaybackE2EActivePath,
+  type PlaybackE2ECountInCancelReason,
+  type PlaybackE2ECountInCancelled,
+  type PlaybackE2ECountInFired,
+  type PlaybackE2ECountInSchedule,
+  type PlaybackE2ECountInState,
+  type PlaybackE2ETelemetryPatch,
+  type PlaybackE2ETransportState,
+} from "../../lib/playbackE2ETelemetry";
+import {
   activateWebAudioContext,
   getWebAudioContextConstructor,
   primeWebAudioContext,
@@ -78,6 +89,7 @@ type ActivePrecount = {
   ownsContext: boolean;
   sequence: number;
   signature: string;
+  telemetry: PlaybackE2ECountInEvent;
   timeoutId: number;
 };
 
@@ -95,6 +107,57 @@ type NativePlaybackState = {
   sessionSignature: string | null;
   playbackSignature: string | null;
 };
+
+type PlaybackE2ECountInEvent = PlaybackE2ECountInSchedule;
+type PlaybackE2ETelemetryOverrides = Omit<PlaybackE2ETelemetryPatch, "countIn">;
+
+function playbackTelemetryPathForBackend(
+  backend: PlaybackControlBackend,
+): PlaybackE2EActivePath {
+  if (backend === "native") {
+    return "native";
+  }
+  if (backend === "web") {
+    return "web-audio";
+  }
+  return "none";
+}
+
+function playbackTelemetryTransportState(
+  backend: PlaybackControlBackend,
+  isPlaying: boolean,
+): PlaybackE2ETransportState {
+  if (isPlaying) {
+    return "playing";
+  }
+  return backend === "none" ? "stopped" : "paused";
+}
+
+function playbackCountInCancelledEvent(
+  schedule: PlaybackE2ECountInSchedule,
+  context: AudioContext,
+  reason: PlaybackE2ECountInCancelReason,
+): PlaybackE2ECountInCancelled {
+  return {
+    sequence: schedule.sequence,
+    trigger: schedule.trigger,
+    playbackStartTimeSeconds: schedule.playbackStartTimeSeconds,
+    cancelledAtContextTimeSeconds: context.state === "closed" ? null : context.currentTime,
+    reason,
+  };
+}
+
+function playbackCountInFiredEvent(
+  schedule: PlaybackE2ECountInSchedule,
+  context: AudioContext,
+): PlaybackE2ECountInFired {
+  return {
+    sequence: schedule.sequence,
+    trigger: schedule.trigger,
+    playbackStartTimeSeconds: schedule.playbackStartTimeSeconds,
+    firedAtContextTimeSeconds: context.state === "closed" ? null : context.currentTime,
+  };
+}
 
 const mediaPlaybackRateRampFrames = new WeakMap<
   HTMLAudioElement,
@@ -289,45 +352,144 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   const playbackTimeSecondsRef = useRef(0);
   const playbackDurationSecondsRef = useRef(0);
   const isPlayingRef = useRef(false);
+  const playbackControlBackendRef = useRef<PlaybackControlBackend>("none");
+  const playbackTelemetryGenerationRef = useRef(0);
+  const nativeSnapshotRef = useRef<NativeAudioSnapshot | null>(null);
+  const countInTelemetryRef = useRef<PlaybackE2ECountInState>({
+    active: false,
+    lastScheduled: null,
+    lastFired: null,
+    lastCancelled: null,
+  });
   const [session, setSession] = useState<ProjectPlaybackSession | null>(null);
   const [playbackTimeSeconds, setPlaybackTimeSecondsState] = useState(0);
-  const [playbackDurationSeconds, setPlaybackDurationSeconds] = useState(0);
-  const [isPrecounting, setIsPrecounting] = useState(false);
-  const [isPlaying, setIsPlaying] = useState(false);
+  const [playbackDurationSeconds, setPlaybackDurationSecondsState] = useState(0);
+  const [isPrecounting, setIsPrecountingState] = useState(false);
+  const [isPlaying, setIsPlayingState] = useState(false);
   const [webMediaSourcesEnabled, setWebMediaSourcesEnabled] = useState(
     initialWebMediaSourcesEnabled,
   );
-  const [playbackControlBackend, setPlaybackControlBackend] =
+  const [playbackControlBackend, setPlaybackControlBackendState] =
     useState<PlaybackControlBackend>("none");
 
   useEffect(() => {
     sessionRef.current = session;
   }, [session]);
 
+  const writePlaybackE2ETelemetry = useStableCallback(function writePlaybackE2ETelemetry(
+    overrides: PlaybackE2ETelemetryOverrides = {},
+  ) {
+    playbackTelemetryGenerationRef.current += 1;
+    const activeSession = sessionRef.current;
+    const activePath =
+      overrides.activePath ??
+      playbackTelemetryPathForBackend(playbackControlBackendRef.current);
+    const durationSeconds =
+      overrides.durationSeconds ??
+      (playbackDurationSecondsRef.current || activeSession?.durationHintSeconds || 0);
+    const loopRange = overrides.loopRange ?? getPlayableLoopRange(activeSession);
+    const nativeSnapshot = nativeSnapshotRef.current;
+    patchPlaybackE2ETelemetry({
+      activePath,
+      transportState:
+        overrides.transportState ??
+        playbackTelemetryTransportState(
+          playbackControlBackendRef.current,
+          isPlayingRef.current,
+        ),
+      positionSeconds: overrides.positionSeconds ?? playbackTimeSecondsRef.current,
+      durationSeconds,
+      playbackRate:
+        overrides.playbackRate ??
+        (activePath === "native" && nativeSnapshot
+          ? nativeSnapshot.playbackRate
+          : playbackRateForSession(activeSession)),
+      loopRange,
+      nativeBufferHealth:
+        overrides.nativeBufferHealth ?? nativeSnapshot?.bufferHealth ?? [],
+      countIn: { ...countInTelemetryRef.current },
+    });
+  });
+
   useEffect(() => {
     playbackTimeSecondsRef.current = playbackTimeSeconds;
   }, [playbackTimeSeconds]);
 
-  const setPlaybackTimeSeconds = useCallback((nextTimeSeconds: number) => {
+  const setPlaybackTimeSeconds = useStableCallback(function setPlaybackTimeSeconds(
+    nextTimeSeconds: number,
+  ) {
     playbackTimeSecondsRef.current = nextTimeSeconds;
     setPlaybackTimeSecondsState(nextTimeSeconds);
-  }, []);
+    writePlaybackE2ETelemetry({ positionSeconds: nextTimeSeconds });
+  });
 
   useEffect(() => {
     playbackDurationSecondsRef.current = playbackDurationSeconds;
   }, [playbackDurationSeconds]);
 
+  const setPlaybackDurationSeconds = useStableCallback(function setPlaybackDurationSeconds(
+    nextDurationSeconds: number,
+  ) {
+    playbackDurationSecondsRef.current = nextDurationSeconds;
+    setPlaybackDurationSecondsState(nextDurationSeconds);
+    writePlaybackE2ETelemetry({ durationSeconds: nextDurationSeconds });
+  });
+
   useEffect(() => {
     isPlayingRef.current = isPlaying;
   }, [isPlaying]);
 
+  const setIsPrecounting = useStableCallback(function setIsPrecounting(
+    nextIsPrecounting: boolean,
+  ) {
+    setIsPrecountingState(nextIsPrecounting);
+    writePlaybackE2ETelemetry();
+  });
+
+  const setIsPlaying = useStableCallback(function setIsPlaying(nextIsPlaying: boolean) {
+    isPlayingRef.current = nextIsPlaying;
+    setIsPlayingState(nextIsPlaying);
+    writePlaybackE2ETelemetry({
+      transportState: playbackTelemetryTransportState(
+        playbackControlBackendRef.current,
+        nextIsPlaying,
+      ),
+    });
+  });
+
+  const setPlaybackControlBackend = useStableCallback(function setPlaybackControlBackend(
+    nextBackend: PlaybackControlBackend,
+  ) {
+    playbackControlBackendRef.current = nextBackend;
+    setPlaybackControlBackendState(nextBackend);
+    writePlaybackE2ETelemetry({
+      activePath: playbackTelemetryPathForBackend(nextBackend),
+      transportState: playbackTelemetryTransportState(nextBackend, isPlayingRef.current),
+    });
+  });
+
+  const recordNativeSnapshot = useStableCallback(function recordNativeSnapshot(
+    snapshot: NativeAudioSnapshot,
+    overrides: PlaybackE2ETelemetryOverrides = {},
+  ) {
+    nativeSnapshotRef.current = snapshot;
+    writePlaybackE2ETelemetry({
+      positionSeconds: snapshot.positionSeconds,
+      durationSeconds: snapshot.durationSeconds || sessionRef.current?.durationHintSeconds || 0,
+      playbackRate: snapshot.playbackRate,
+      nativeBufferHealth: snapshot.bufferHealth,
+      transportState: snapshot.state,
+      ...overrides,
+    });
+  });
+
   const clearPlaybackControlBackend = useCallback(() => {
     setPlaybackControlBackend("none");
-  }, []);
+  }, [setPlaybackControlBackend]);
 
   const markWebPlaybackStartResult = useCallback((started: boolean) => {
     setPlaybackControlBackend(started ? "web" : "none");
-  }, []);
+  }, [setPlaybackControlBackend]);
 
   function setPrimaryAudioRef(element: HTMLAudioElement | null) {
     primaryAudioRef.current = element;
@@ -438,7 +600,25 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   });
 
   const requestNativeStop = useStableCallback(function requestNativeStop() {
+    const stopTelemetryGeneration = playbackTelemetryGenerationRef.current;
+    const stoppedSessionSignature = nativePlaybackRef.current.sessionSignature;
     const stopPromise = stopNativeAudio()
+      .then((snapshot) => {
+        if (
+          nativeStopPromiseRef.current !== stopPromise ||
+          playbackTelemetryGenerationRef.current !== stopTelemetryGeneration ||
+          nativePlaybackRef.current.sessionSignature !== stoppedSessionSignature ||
+          playbackControlBackendRef.current === "web" ||
+          isPlayingRef.current ||
+          nativePlaybackRef.current.active
+        ) {
+          return;
+        }
+        recordNativeSnapshot(snapshot, {
+          activePath: "none",
+          transportState: "stopped",
+        });
+      })
       .catch(() => undefined)
       .then(() => undefined)
       .finally(() => {
@@ -465,7 +645,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     const sessionSignature = nativeSessionSignature(targetSession);
     const lanes = nativeLaneRequestsForSession(targetSession);
     if (nativePlaybackRef.current.sessionSignature === sessionSignature) {
-      await setNativeAudioLanes(nativeLaneUpdateForSession(targetSession));
+      const snapshot = await setNativeAudioLanes(nativeLaneUpdateForSession(targetSession));
+      recordNativeSnapshot(snapshot);
       return true;
     }
 
@@ -476,7 +657,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     ) {
       const prepared = await pendingPrepare.preparePromise;
       if (prepared && nativePlaybackRef.current.sessionSignature === sessionSignature) {
-        await setNativeAudioLanes(nativeLaneUpdateForSession(targetSession));
+        const snapshot = await setNativeAudioLanes(nativeLaneUpdateForSession(targetSession));
+        recordNativeSnapshot(snapshot);
       }
       return prepared;
     }
@@ -546,7 +728,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     try {
       const prepared = await preparePromise;
       if (prepared && nativePlaybackRef.current.sessionSignature === sessionSignature) {
-        await setNativeAudioLanes(nativeLaneUpdateForSession(targetSession));
+        const snapshot = await setNativeAudioLanes(nativeLaneUpdateForSession(targetSession));
+        recordNativeSnapshot(snapshot);
       }
       return prepared;
     } catch (error) {
@@ -594,7 +777,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         }
         return false;
       }
-      await setNativeAudioLanes(nativeLaneUpdateForSession(latestSession));
+      const lanesSnapshot = await setNativeAudioLanes(nativeLaneUpdateForSession(latestSession));
+      recordNativeSnapshot(lanesSnapshot);
       const snapshot = await playNativeAudio({
         startTimeSeconds:
           wasNativeActive || timeSeconds <= SEEK_TOLERANCE_SECONDS
@@ -604,6 +788,10 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       nativePlaybackRef.current.active = snapshot.nativePlaybackSupported;
       nativePlaybackRef.current.playbackSignature = playbackSignature(latestSession);
       if (!snapshot.nativePlaybackSupported) {
+        recordNativeSnapshot(snapshot, {
+          activePath: "none",
+          transportState: snapshot.state,
+        });
         rememberNativePlaybackError(
           snapshot.fallbackReason ?? "Native playback start fell back to Web Audio.",
         );
@@ -622,6 +810,10 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       setPlaybackDurationSeconds(snapshot.durationSeconds || latestSession.durationHintSeconds || 0);
       setPlaybackControlBackend("native");
       setIsPlaying(true);
+      recordNativeSnapshot(snapshot, {
+        activePath: "native",
+        transportState: snapshot.state,
+      });
       return true;
     } catch (error) {
       rememberNativePlaybackError(playbackErrorMessage(error));
@@ -704,10 +896,23 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     }
   });
 
-  const cancelPrecount = useStableCallback(function cancelPrecount() {
+  const cancelPrecount = useStableCallback(function cancelPrecount(
+    reason: PlaybackE2ECountInCancelReason,
+  ) {
     const activePrecount = activePrecountRef.current;
     activePrecountRef.current = null;
     precountSequenceRef.current += 1;
+    if (activePrecount) {
+      countInTelemetryRef.current = {
+        ...countInTelemetryRef.current,
+        active: false,
+        lastCancelled: playbackCountInCancelledEvent(
+          activePrecount.telemetry,
+          activePrecount.context,
+          reason,
+        ),
+      };
+    }
     setIsPrecounting(false);
 
     if (!activePrecount) {
@@ -1231,11 +1436,11 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       nativePlaybackRef.current.active &&
       nativePlaybackRef.current.sessionSignature === nativeSessionSignature(targetSession)
     ) {
-      void setNativeAudioLanes(nativeLaneUpdateForSession(targetSession)).catch(
-        (error) => {
+      void setNativeAudioLanes(nativeLaneUpdateForSession(targetSession))
+        .then((snapshot) => recordNativeSnapshot(snapshot))
+        .catch((error) => {
           rememberNativePlaybackError(playbackErrorMessage(error));
-        },
-      );
+        });
     }
   });
 
@@ -1699,7 +1904,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
   const pausePlayback = useCallback(() => {
     allowFreshPlaybackRef.current = false;
-    cancelPrecount();
+    cancelPrecount("playback-stopped");
     const pendingTransition = pendingTransitionRef.current;
     if (pendingTransition) {
       pendingTransition.shouldPlay = false;
@@ -1709,6 +1914,10 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     if (nativePlaybackRef.current.active) {
       void pauseNativeAudio()
         .then((snapshot) => {
+          recordNativeSnapshot(snapshot, {
+            activePath: "native",
+            transportState: "paused",
+          });
           setPlaybackTimeSeconds(snapshot.positionSeconds);
           setIsPlaying(false);
         })
@@ -1738,6 +1947,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     cancelPrecount,
     getActiveMediaElements,
     markNativePlaybackInactive,
+    recordNativeSnapshot,
+    setIsPlaying,
     setPlaybackTimeSeconds,
     stopStemSources,
   ]);
@@ -1859,7 +2070,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
     const clickCount = normalizePrecountClickCount(targetSession.precountClickCount);
     const signature = playbackSignature(targetSession);
-    cancelPrecount();
+    cancelPrecount("superseded");
     const sequence = ++precountSequenceRef.current;
 
     let preparedStemPlaybackState: StemPlaybackState | null = null;
@@ -1923,6 +2134,17 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     const firstClickTimeSeconds = precountAudio.context.currentTime + PRECOUNT_START_DELAY_SECONDS;
     const playbackStartTimeSeconds =
       firstClickTimeSeconds + countInIntervals.reduce((total, interval) => total + interval, 0);
+    const countInTelemetry: PlaybackE2ECountInEvent = {
+      clickCount,
+      trigger: shouldUseLoopPrecount ? "loop-start" : "song-start",
+      activePath: playbackTelemetryPathForBackend(playbackControlBackendRef.current),
+      scheduledAtContextTimeSeconds: precountAudio.context.currentTime,
+      firstClickTimeSeconds,
+      playbackStartTimeSeconds,
+      sequence,
+      startTimeSeconds,
+      tempoBpm,
+    };
     let nextClickTimeSeconds = firstClickTimeSeconds;
     for (let index = 0; index < clickCount; index += 1) {
       schedulePrecountClaveClick({
@@ -1939,6 +2161,11 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       }
 
       activePrecountRef.current = null;
+      countInTelemetryRef.current = {
+        ...countInTelemetryRef.current,
+        active: false,
+        lastFired: playbackCountInFiredEvent(activePrecount.telemetry, activePrecount.context),
+      };
       setIsPrecounting(false);
       closeOwnedPrecountContext(activePrecount);
 
@@ -1959,14 +2186,22 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       ownsContext: precountAudio.ownsContext,
       sequence,
       signature,
+      telemetry: countInTelemetry,
       timeoutId,
     };
+    countInTelemetryRef.current = {
+      ...countInTelemetryRef.current,
+      active: true,
+      lastScheduled: countInTelemetry,
+    };
     setIsPrecounting(true);
+    writePlaybackE2ETelemetry({ positionSeconds: startTimeSeconds });
     return true;
   });
 
   const playPlayback = useCallback(async () => {
     if (activePrecountRef.current) {
+      cancelPrecount("cancelled");
       return;
     }
 
@@ -1988,6 +2223,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     allowFreshPlaybackRef.current = false;
     await playPlaybackImmediately();
   }, [
+    cancelPrecount,
     playPlaybackImmediately,
     playbackStartTimeForSession,
     readMasterTime,
@@ -1997,7 +2233,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
   const togglePlayback = useCallback(async () => {
     if (activePrecountRef.current) {
-      cancelPrecount();
+      cancelPrecount("playback-stopped");
       return;
     }
     if (isPlayingRef.current) {
@@ -2009,7 +2245,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   }, [cancelPrecount, pausePlayback, playPlayback, primeWebAudioForGesture]);
 
   const seekTo = useCallback((timeSeconds: number) => {
-    cancelPrecount();
+    cancelPrecount("superseded");
     const targetSession = sessionRef.current;
     const nextTime = targetSession
       ? playbackStartTimeForSession(targetSession, timeSeconds)
@@ -2021,7 +2257,13 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
     if (nativePlaybackRef.current.active) {
       void seekNativeAudio({ timeSeconds: nextTime })
-        .then((snapshot) => setPlaybackTimeSeconds(snapshot.positionSeconds))
+        .then((snapshot) => {
+          recordNativeSnapshot(snapshot, {
+            activePath: "native",
+            transportState: snapshot.state,
+          });
+          setPlaybackTimeSeconds(snapshot.positionSeconds);
+        })
         .catch(() => {
           markNativePlaybackInactive();
           clearPlaybackControlBackend();
@@ -2058,6 +2300,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     getActiveMediaElements,
     markNativePlaybackInactive,
     playbackStartTimeForSession,
+    recordNativeSnapshot,
     setPlaybackTimeSeconds,
     startStemPlayback,
     syncStemElementTimes,
@@ -2072,7 +2315,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
   const stopPlayback = useCallback(() => {
     allowFreshPlaybackRef.current = true;
-    cancelPrecount();
+    cancelPrecount("playback-stopped");
     clearPendingTransition();
     const targetSession = sessionRef.current;
     const resetTime = playbackResetTimeForSession(targetSession);
@@ -2101,6 +2344,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     markNativePlaybackInactive,
     playbackResetTimeForSession,
     requestNativeStop,
+    setIsPlaying,
     setPlaybackTimeSeconds,
     stopStemSources,
     syncStemElementTimes,
@@ -2113,7 +2357,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     setSession(null);
     sessionRef.current = null;
     setPlaybackDurationSeconds(0);
-  }, [closePlaybackAudioContext, stopPlayback]);
+  }, [closePlaybackAudioContext, setPlaybackDurationSeconds, stopPlayback]);
 
   const registerProjectSession = useCallback((nextSession: ProjectPlaybackSession) => {
     const previousSession = sessionRef.current;
@@ -2122,7 +2366,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
     if (previousSession && previousSession.projectId !== nextSession.projectId) {
       const resetTime = playbackResetTimeForSession(nextSession);
-      cancelPrecount();
+      cancelPrecount("session-changed");
       clearPendingTransition();
       closePlaybackAudioContext();
       allowFreshPlaybackRef.current = true;
@@ -2135,7 +2379,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       clearPlaybackControlBackend();
       setIsPlaying(false);
     } else if (previousSession && previousSignature !== nextSignature) {
-      cancelPrecount();
+      cancelPrecount("session-changed");
       const activePendingTransition = pendingTransitionRef.current;
       const requestedTransitionTime =
         activePendingTransition?.signature === nextSignature
@@ -2215,6 +2459,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
             ) {
               return;
             }
+            recordNativeSnapshot(snapshot);
             if (!snapshot.nativePlaybackSupported) {
               fallbackFromNativeLaneUpdate(
                 snapshot.fallbackReason ?? "Native playback lane update fell back to Web Audio.",
@@ -2325,7 +2570,11 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     playbackStartTimeForSession,
     playPlaybackImmediately,
     readMasterTime,
+    recordNativeSnapshot,
     requestNativeStop,
+    setIsPlaying,
+    setPlaybackControlBackend,
+    setPlaybackDurationSeconds,
     setPlaybackTimeSeconds,
     syncStemElementTimes,
   ]);
@@ -2359,11 +2608,23 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
   useEffect(
     () => () => {
-      cancelPrecount();
+      cancelPrecount("unavailable");
       closePlaybackAudioContext();
     },
     [cancelPrecount, closePlaybackAudioContext],
   );
+
+  useEffect(() => {
+    writePlaybackE2ETelemetry();
+  }, [
+    isPlaying,
+    isPrecounting,
+    playbackControlBackend,
+    playbackDurationSeconds,
+    playbackTimeSeconds,
+    session,
+    writePlaybackE2ETelemetry,
+  ]);
 
   useEffect(() => {
     if (!isTauriRuntime()) {
@@ -2390,6 +2651,12 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           clearPlaybackControlBackend();
         }
         setIsPlaying(position.state === "playing");
+        writePlaybackE2ETelemetry({
+          activePath: position.state === "stopped" ? "none" : "native",
+          transportState: position.state,
+          positionSeconds: position.positionSeconds,
+          durationSeconds: position.durationSeconds || activeSession.durationHintSeconds || 0,
+        });
       }),
       listenNativeAudioEnded((snapshot: NativeAudioSnapshot) => {
         if (snapshot.sessionId !== nativePlaybackRef.current.sessionSignature) {
@@ -2398,6 +2665,10 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         const activeSession = sessionRef.current;
         markNativePlaybackInactive();
         void requestNativeStop();
+        recordNativeSnapshot(snapshot, {
+          activePath: "none",
+          transportState: "stopped",
+        });
         if (restartActiveLoopPlayback(activeSession)) {
           return;
         }
@@ -2436,6 +2707,11 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           element.currentTime = fallbackTime;
         });
         setPlaybackTimeSeconds(fallbackTime);
+        writePlaybackE2ETelemetry({
+          activePath: "none",
+          transportState: "paused",
+          positionSeconds: fallbackTime,
+        });
         void releaseSystemMediaControls()
           .then(() => {
             void playPlaybackImmediately();
@@ -2457,11 +2733,15 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     markNativePlaybackInactive,
     playbackResetTimeForSession,
     playPlaybackImmediately,
+    recordNativeSnapshot,
     requestNativeStop,
     restartActiveLoopPlayback,
     restartLoopIfNeeded,
+    setIsPlaying,
+    setPlaybackDurationSeconds,
     setPlaybackTimeSeconds,
     syncStemElementTimes,
+    writePlaybackE2ETelemetry,
   ]);
 
   useWebPlaybackWakeLock({

--- a/apps/desktop/src/lib/playbackE2ETelemetry.test.ts
+++ b/apps/desktop/src/lib/playbackE2ETelemetry.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  exposePlaybackE2ETelemetryApi,
+  patchPlaybackE2ETelemetry,
+  publishPlaybackE2ETelemetry,
+  readPlaybackE2ETelemetry,
+  resetPlaybackE2ETelemetry,
+  type PlaybackE2ETelemetrySnapshot,
+} from "./playbackE2ETelemetry";
+
+const nativeSnapshot: PlaybackE2ETelemetrySnapshot = {
+  activePath: "native",
+  transportState: "playing",
+  positionSeconds: 12,
+  durationSeconds: 180,
+  playbackRate: 0.9,
+  loopRange: {
+    startSeconds: 4,
+    endSeconds: 16,
+  },
+  nativeBufferHealth: [
+    {
+      laneId: "primary",
+      artifactId: "artifact-1",
+      role: "primary",
+      ringFillSamples: 4096,
+      ringCapacitySamples: 8192,
+      underrunCount: 0,
+      workerErrorCount: 0,
+      lastWorkerError: null,
+    },
+  ],
+  countIn: {
+    active: true,
+    lastScheduled: {
+      sequence: 7,
+      trigger: "song-start",
+      activePath: "native",
+      startTimeSeconds: 0,
+      clickCount: 4,
+      tempoBpm: 120,
+      scheduledAtContextTimeSeconds: 10,
+      firstClickTimeSeconds: 10.1,
+      playbackStartTimeSeconds: 12.1,
+    },
+    lastFired: null,
+    lastCancelled: null,
+  },
+};
+
+describe("playback E2E telemetry", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetPlaybackE2ETelemetry();
+    delete window.__TUNEFORGE_PLAYBACK_E2E__;
+  });
+
+  it("exposes a local window reader for the current snapshot", () => {
+    publishPlaybackE2ETelemetry(nativeSnapshot);
+
+    expect(window.__TUNEFORGE_PLAYBACK_E2E__?.read()).toEqual(nativeSnapshot);
+  });
+
+  it("returns cloned snapshots from direct and window reads", () => {
+    publishPlaybackE2ETelemetry(nativeSnapshot);
+
+    const firstRead = window.__TUNEFORGE_PLAYBACK_E2E__?.read();
+    expect(firstRead).toBeDefined();
+    if (!firstRead) {
+      return;
+    }
+
+    firstRead.nativeBufferHealth[0].ringFillSamples = 0;
+    firstRead.countIn.lastScheduled = null;
+
+    expect(readPlaybackE2ETelemetry()).toEqual(nativeSnapshot);
+  });
+
+  it("patches top-level and count-in fields without clearing prior count-in events", () => {
+    publishPlaybackE2ETelemetry(nativeSnapshot);
+
+    patchPlaybackE2ETelemetry({
+      activePath: "web-audio",
+      transportState: "paused",
+      countIn: {
+        active: false,
+        lastFired: {
+          sequence: 7,
+          trigger: "song-start",
+          playbackStartTimeSeconds: 12.1,
+          firedAtContextTimeSeconds: 12.1,
+        },
+      },
+    });
+
+    expect(readPlaybackE2ETelemetry()).toEqual({
+      ...nativeSnapshot,
+      activePath: "web-audio",
+      transportState: "paused",
+      countIn: {
+        ...nativeSnapshot.countIn,
+        active: false,
+        lastFired: {
+          sequence: 7,
+          trigger: "song-start",
+          playbackStartTimeSeconds: 12.1,
+          firedAtContextTimeSeconds: 12.1,
+        },
+      },
+    });
+  });
+
+  it("does not require a browser window", () => {
+    vi.stubGlobal("window", undefined);
+
+    expect(() => exposePlaybackE2ETelemetryApi()).not.toThrow();
+    expect(() => publishPlaybackE2ETelemetry(nativeSnapshot)).not.toThrow();
+  });
+});

--- a/apps/desktop/src/lib/playbackE2ETelemetry.ts
+++ b/apps/desktop/src/lib/playbackE2ETelemetry.ts
@@ -1,0 +1,166 @@
+import type { NativeAudioBufferHealth } from "./nativeAudio";
+
+export const PLAYBACK_E2E_WINDOW_KEY = "__TUNEFORGE_PLAYBACK_E2E__";
+
+export type PlaybackE2EActivePath = "native" | "web-audio" | "none";
+export type PlaybackE2ETransportState = "stopped" | "playing" | "paused";
+
+export type PlaybackE2ELoopRange = {
+  startSeconds: number;
+  endSeconds: number;
+};
+
+export type PlaybackE2ECountInTrigger = "song-start" | "loop-start";
+
+export type PlaybackE2ECountInCancelReason =
+  | "cancelled"
+  | "playback-stopped"
+  | "session-changed"
+  | "superseded"
+  | "unavailable";
+
+export type PlaybackE2ECountInSchedule = {
+  sequence: number;
+  trigger: PlaybackE2ECountInTrigger;
+  activePath: PlaybackE2EActivePath;
+  startTimeSeconds: number;
+  clickCount: number;
+  tempoBpm: number;
+  scheduledAtContextTimeSeconds: number;
+  firstClickTimeSeconds: number;
+  playbackStartTimeSeconds: number;
+};
+
+export type PlaybackE2ECountInFired = {
+  sequence: number;
+  trigger: PlaybackE2ECountInTrigger;
+  playbackStartTimeSeconds: number;
+  firedAtContextTimeSeconds: number | null;
+};
+
+export type PlaybackE2ECountInCancelled = {
+  sequence: number;
+  trigger: PlaybackE2ECountInTrigger;
+  playbackStartTimeSeconds: number;
+  cancelledAtContextTimeSeconds: number | null;
+  reason: PlaybackE2ECountInCancelReason;
+};
+
+export type PlaybackE2ECountInState = {
+  active: boolean;
+  lastScheduled: PlaybackE2ECountInSchedule | null;
+  lastFired: PlaybackE2ECountInFired | null;
+  lastCancelled: PlaybackE2ECountInCancelled | null;
+};
+
+export type PlaybackE2ETelemetrySnapshot = {
+  activePath: PlaybackE2EActivePath;
+  transportState: PlaybackE2ETransportState;
+  positionSeconds: number;
+  durationSeconds: number;
+  playbackRate: number;
+  loopRange: PlaybackE2ELoopRange | null;
+  nativeBufferHealth: NativeAudioBufferHealth[];
+  countIn: PlaybackE2ECountInState;
+};
+
+export type PlaybackE2ETelemetryPatch = Partial<Omit<PlaybackE2ETelemetrySnapshot, "countIn">> & {
+  countIn?: Partial<PlaybackE2ECountInState>;
+};
+
+export type PlaybackE2ETelemetryApi = {
+  read: () => PlaybackE2ETelemetrySnapshot;
+};
+
+const EMPTY_COUNT_IN: PlaybackE2ECountInState = {
+  active: false,
+  lastScheduled: null,
+  lastFired: null,
+  lastCancelled: null,
+};
+
+const EMPTY_SNAPSHOT: PlaybackE2ETelemetrySnapshot = {
+  activePath: "none",
+  transportState: "stopped",
+  positionSeconds: 0,
+  durationSeconds: 0,
+  playbackRate: 1,
+  loopRange: null,
+  nativeBufferHealth: [],
+  countIn: EMPTY_COUNT_IN,
+};
+
+let currentSnapshot = clonePlaybackE2ETelemetrySnapshot(EMPTY_SNAPSHOT);
+
+function cloneLoopRange(loopRange: PlaybackE2ELoopRange | null): PlaybackE2ELoopRange | null {
+  return loopRange ? { ...loopRange } : null;
+}
+
+function cloneNativeBufferHealth(bufferHealth: NativeAudioBufferHealth[]) {
+  return bufferHealth.map((health) => ({ ...health }));
+}
+
+function cloneCountIn(countIn: PlaybackE2ECountInState): PlaybackE2ECountInState {
+  return {
+    active: countIn.active,
+    lastScheduled: countIn.lastScheduled ? { ...countIn.lastScheduled } : null,
+    lastFired: countIn.lastFired ? { ...countIn.lastFired } : null,
+    lastCancelled: countIn.lastCancelled ? { ...countIn.lastCancelled } : null,
+  };
+}
+
+export function clonePlaybackE2ETelemetrySnapshot(
+  snapshot: PlaybackE2ETelemetrySnapshot,
+): PlaybackE2ETelemetrySnapshot {
+  return {
+    activePath: snapshot.activePath,
+    transportState: snapshot.transportState,
+    positionSeconds: snapshot.positionSeconds,
+    durationSeconds: snapshot.durationSeconds,
+    playbackRate: snapshot.playbackRate,
+    loopRange: cloneLoopRange(snapshot.loopRange),
+    nativeBufferHealth: cloneNativeBufferHealth(snapshot.nativeBufferHealth),
+    countIn: cloneCountIn(snapshot.countIn),
+  };
+}
+
+export function readPlaybackE2ETelemetry() {
+  return clonePlaybackE2ETelemetrySnapshot(currentSnapshot);
+}
+
+const playbackE2ETelemetryApi: PlaybackE2ETelemetryApi = {
+  read: readPlaybackE2ETelemetry,
+};
+
+export function exposePlaybackE2ETelemetryApi() {
+  if (typeof window === "undefined") {
+    return playbackE2ETelemetryApi;
+  }
+
+  window[PLAYBACK_E2E_WINDOW_KEY] = playbackE2ETelemetryApi;
+  return playbackE2ETelemetryApi;
+}
+
+export function publishPlaybackE2ETelemetry(snapshot: PlaybackE2ETelemetrySnapshot) {
+  currentSnapshot = clonePlaybackE2ETelemetrySnapshot(snapshot);
+  exposePlaybackE2ETelemetryApi();
+}
+
+export function patchPlaybackE2ETelemetry(patch: PlaybackE2ETelemetryPatch) {
+  currentSnapshot = clonePlaybackE2ETelemetrySnapshot({
+    ...currentSnapshot,
+    ...patch,
+    countIn: {
+      ...currentSnapshot.countIn,
+      ...patch.countIn,
+    },
+  });
+  exposePlaybackE2ETelemetryApi();
+}
+
+export function resetPlaybackE2ETelemetry() {
+  currentSnapshot = clonePlaybackE2ETelemetrySnapshot(EMPTY_SNAPSHOT);
+  exposePlaybackE2ETelemetryApi();
+}
+
+exposePlaybackE2ETelemetryApi();

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -20,6 +20,7 @@ import type {
   SyncTrustedPeerCreateRequest,
   SyncTrustedPeerResponse,
 } from "../lib/api";
+import { resetPlaybackE2ETelemetry } from "../lib/playbackE2ETelemetry";
 
 const DEFAULT_PROJECTS_LIMIT = 50;
 const DEFAULT_JOBS_LIMIT = 50;
@@ -2762,6 +2763,7 @@ export function getMockWakeLock() {
 
 export function resetAppTestHarness() {
   resetMockApiState();
+  resetPlaybackE2ETelemetry();
   delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
   window.localStorage.clear();
   window.sessionStorage.clear();

--- a/apps/desktop/src/vite-env.d.ts
+++ b/apps/desktop/src/vite-env.d.ts
@@ -1,2 +1,9 @@
 /// <reference types="vite/client" />
 
+import type { PlaybackE2ETelemetryApi } from "./lib/playbackE2ETelemetry";
+
+declare global {
+  interface Window {
+    __TUNEFORGE_PLAYBACK_E2E__?: PlaybackE2ETelemetryApi;
+  }
+}

--- a/docs/NATIVE_AUDIO.md
+++ b/docs/NATIVE_AUDIO.md
@@ -124,10 +124,16 @@ Run once with native playback selected per platform, then rerun with forced Web 
 
 ## Local-only Playwright Smoke Harness
 
-Scaffold file: `scripts/playback-smoke.mjs` (local only, not wired to CI). This is a
-browser-based smoke check for the frontend/Web Audio transport path; native output still needs the
-manual matrix above. `pnpm setup:dev` installs the Playwright Chromium browser needed by this
-smoke check; use `pnpm setup:dev -- --skip-playwright-browsers` to skip that download.
+Scaffold file: `scripts/playback-smoke.mjs` (local only, not wired to CI). This is a browser-based
+smoke check for the frontend transport path; native output still needs the manual matrix above.
+When the app exposes `window.__TUNEFORGE_PLAYBACK_E2E__.read()`, the smoke pass also polls that
+local telemetry bridge. It asserts song-start count-in scheduling/firing before loop setup, loop
+pre-count scheduling/firing during loop playback, and native transport/buffer health only when the
+telemetry reports native playback is the active path. Forced Web Audio and browser fallback runs
+continue to pass by skipping native-only buffer assertions.
+
+`pnpm setup:dev` installs the Playwright Chromium browser needed by this smoke check; use
+`pnpm setup:dev -- --skip-playwright-browsers` to skip that download.
 
 Check that the local smoke scaffold is available:
 
@@ -144,7 +150,7 @@ pnpm --filter @tuneforge/desktop test:e2e -- --run --project-name="Demo Song"
 
 For full coverage, use a fixture project with timed lyrics or chords. The smoke pass always checks
 stopped scrubber start, and it also checks stopped lyrics/chords start when a timed practice target
-is available.
+is available. It remains a local/manual diagnostic, not a CI gate and not part of `pnpm test`.
 
 If you already know the project ID, `--project-id=<id>` opens the project route directly.
 Set `TUNEFORGE_SMOKE_APP_URL` if the desktop frontend is not on `http://127.0.0.1:1420`.

--- a/scripts/playback-smoke.mjs
+++ b/scripts/playback-smoke.mjs
@@ -54,6 +54,10 @@ try {
 
   const durationSeconds = await readPlaybackDuration(page);
   logStep(`Playback tab ready. Duration: ${formatSeconds(durationSeconds)}.`);
+  const playbackBpmInput = page.getByRole("spinbutton", { name: "Playback BPM" });
+  await playbackBpmInput.fill("128");
+  await playbackBpmInput.press("Enter");
+  logStep("Playback tempo set to 128 BPM.");
   const scrubberStartSeconds = stoppedStartProbeTime(durationSeconds);
   await seekTo(page, scrubberStartSeconds);
   await expectPosition(page, scrubberStartSeconds, "after stopped scrubber seek");
@@ -66,6 +70,22 @@ try {
   } else {
     await verifyPlayStartsFromSelection(page, practiceStartSeconds, "stopped lyrics/chords selection");
     logStep(`Stopped lyrics/chords selection started at ${formatSeconds(practiceStartSeconds)}.`);
+  }
+
+  await page.getByLabel("Enable pre-count").check();
+  await seekTo(page, 0);
+  await expectPosition(page, 0, "before song-start pre-count");
+  await page.getByRole("button", { name: "Play playback" }).click();
+  const songCountInTelemetryAsserted = await assertCountInTelemetry(page, {
+    expectedKind: "song-start",
+    expectedStartSeconds: 0,
+    label: "song-start pre-count",
+  });
+  await page.getByRole("button", { name: "Pause playback" }).waitFor({ timeout: 5000 });
+  await page.getByRole("button", { name: "Stop playback" }).click();
+  await expectPosition(page, 0, "after song-start pre-count smoke");
+  if (songCountInTelemetryAsserted) {
+    logStep("Song-start pre-count telemetry passed.");
   }
 
   const loopStartSeconds = Math.min(12.25, Math.max(0.25, durationSeconds * 0.25));
@@ -94,15 +114,25 @@ try {
   await expectPosition(page, loopStartSeconds, "after seeking outside the loop");
   logStep("Seek outside loop snapped back to loop start.");
 
-  await page.getByLabel("Enable pre-count").check();
   await page.getByLabel("Enable loop pre-count").check();
-  const playbackBpmInput = page.getByRole("spinbutton", { name: "Playback BPM" });
-  await playbackBpmInput.fill("128");
-  await playbackBpmInput.press("Enter");
-  logStep("Song and loop pre-count enabled; tempo set to 128 BPM.");
+  logStep("Song and loop pre-count enabled.");
 
   await page.getByRole("button", { name: "Play playback" }).click();
+  const loopCountInTelemetryAsserted = await assertCountInTelemetry(page, {
+    expectedKind: "loop-start",
+    expectedStartSeconds: loopStartSeconds,
+    label: "loop pre-count",
+  });
+  if (loopCountInTelemetryAsserted) {
+    logStep("Loop pre-count telemetry passed.");
+  }
   await page.getByRole("button", { name: "Pause playback" }).waitFor();
+  await assertPlaybackTransportTelemetry(page, {
+    expectedLoopEndSeconds: loopEndSeconds,
+    expectedLoopStartSeconds: loopStartSeconds,
+    expectedState: "playing",
+    label: "loop playback",
+  });
   await page.getByRole("button", { name: "Pause playback" }).click();
   await page.getByRole("button", { name: "Play playback" }).click();
   await page.getByRole("button", { name: "Pause playback" }).waitFor();
@@ -214,9 +244,9 @@ function stoppedStartProbeTime(durationSeconds) {
 }
 
 async function verifyPlayStartsFromSelection(page, startSeconds, label) {
+  const minimumPositionSeconds = startSeconds - 0.05;
   await page.getByRole("button", { name: "Play playback" }).click();
-  await page.getByRole("button", { name: "Pause playback" }).waitFor({ timeout: 5000 });
-  await expectPositionAtLeast(page, startSeconds - 0.05, label, { timeout: 3500 });
+  await waitForPlaybackStartFromSelection(page, minimumPositionSeconds, label);
   await page.getByRole("button", { name: "Stop playback" }).click();
   await expectPosition(page, 0, `after stopping ${label}`);
 }
@@ -266,6 +296,642 @@ async function readPlaybackPosition(page) {
   });
   const positionSeconds = Number(rawValue);
   return Number.isFinite(positionSeconds) ? positionSeconds : 0;
+}
+
+async function readPlaybackE2EState(page) {
+  return page.evaluate(async () => {
+    const bridge = window.__TUNEFORGE_PLAYBACK_E2E__;
+    if (!bridge || typeof bridge.read !== "function") {
+      return null;
+    }
+    const value = bridge.read();
+    return value && typeof value.then === "function" ? await value : value;
+  });
+}
+
+async function waitForPlaybackStartFromSelection(page, minimumPositionSeconds, label, options = {}) {
+  const timeout = options.timeout ?? 5000;
+  const pollInterval = options.pollInterval ?? 100;
+  const deadline = Date.now() + timeout;
+
+  while (Date.now() <= deadline) {
+    const pauseVisible = await isPlaybackButtonVisible(page, "Pause playback");
+    const inputPositionSeconds = await readPlaybackPosition(page).catch(() => null);
+    if (
+      pauseVisible &&
+      typeof inputPositionSeconds === "number" &&
+      inputPositionSeconds >= minimumPositionSeconds
+    ) {
+      return;
+    }
+
+    const telemetry = await readPlaybackE2EState(page).catch(() => null);
+    if (
+      telemetry &&
+      telemetryReportsPlaybackStarted(telemetry) &&
+      telemetryPositionReached(telemetry, minimumPositionSeconds)
+    ) {
+      return;
+    }
+
+    await page.waitForTimeout(pollInterval);
+  }
+
+  throw new Error(
+    [
+      `Timed out waiting for playback to start from ${label}.`,
+      `Expected position at or after ${formatSeconds(minimumPositionSeconds)}.`,
+      await formatPlaybackStartDiagnostics(page),
+    ].join("\n"),
+  );
+}
+
+async function isPlaybackButtonVisible(page, name) {
+  return page.getByRole("button", { name }).isVisible().catch(() => false);
+}
+
+function telemetryReportsPlaybackStarted(state) {
+  const transport = transportTelemetry(state);
+  if (transportState(transport) === "playing") {
+    return true;
+  }
+
+  const nestedBackend = firstObjectField(state, [
+    "activeBackend",
+    "backendState",
+    "native",
+    "nativePlayback",
+    "webAudio",
+    "webPlayback",
+  ]);
+  if (transportState(nestedBackend) === "playing") {
+    return true;
+  }
+
+  const playing = firstBooleanField(transport, ["playing", "isPlaying"])
+    ?? firstBooleanField(nestedBackend, ["playing", "isPlaying"])
+    ?? firstBooleanField(state, ["playing", "isPlaying"]);
+  if (playing !== null) {
+    return playing;
+  }
+
+  const active = firstBooleanField(transport, ["active", "isActive"])
+    ?? firstBooleanField(nestedBackend, ["active", "isActive"]);
+  return active === true && (isNativePlaybackActive(state) || isWebPlaybackActive(state));
+}
+
+function telemetryPositionReached(state, minimumPositionSeconds) {
+  const positionSeconds = transportPositionSeconds(transportTelemetry(state));
+  return positionSeconds !== null && positionSeconds >= minimumPositionSeconds;
+}
+
+async function formatPlaybackStartDiagnostics(page) {
+  const diagnostics = await readPlaybackStartDiagnostics(page);
+  const telemetry = diagnostics.telemetry.available
+    ? formatTelemetryDiagnostic(diagnostics.telemetry)
+    : "bridge unavailable";
+  return [
+    `Position input: ${diagnostics.positionInputValue}`,
+    `Buttons: Play visible=${diagnostics.buttons.playVisible}, Pause visible=${diagnostics.buttons.pauseVisible}, Stop visible=${diagnostics.buttons.stopVisible}`,
+    `Telemetry: ${telemetry}`,
+    `localStorage tuneforge.playback-native-error: ${formatDiagnosticValue(diagnostics.nativeError)}`,
+    `localStorage tuneforge.playback-backend: ${formatDiagnosticValue(diagnostics.playbackBackend)}`,
+  ].join("\n");
+}
+
+async function readPlaybackStartDiagnostics(page) {
+  const [positionInputValue, playVisible, pauseVisible, stopVisible, storage, telemetry] =
+    await Promise.all([
+      readPlaybackPositionInputValue(page),
+      isPlaybackButtonVisible(page, "Play playback"),
+      isPlaybackButtonVisible(page, "Pause playback"),
+      isPlaybackButtonVisible(page, "Stop playback"),
+      readPlaybackDiagnosticStorage(page),
+      readPlaybackE2EDiagnostic(page),
+    ]);
+
+  return {
+    positionInputValue,
+    buttons: {
+      playVisible,
+      pauseVisible,
+      stopVisible,
+    },
+    nativeError: storage.nativeError,
+    playbackBackend: storage.playbackBackend,
+    telemetry,
+  };
+}
+
+async function readPlaybackPositionInputValue(page) {
+  return page
+    .getByLabel("Playback position")
+    .evaluate((element) => (element instanceof HTMLInputElement ? element.value : "not-input"))
+    .catch(() => "missing");
+}
+
+async function readPlaybackDiagnosticStorage(page) {
+  return page.evaluate(() => ({
+    nativeError: window.localStorage.getItem("tuneforge.playback-native-error"),
+    playbackBackend: window.localStorage.getItem("tuneforge.playback-backend"),
+  }));
+}
+
+async function readPlaybackE2EDiagnostic(page) {
+  return page.evaluate(async () => {
+    const bridge = window.__TUNEFORGE_PLAYBACK_E2E__;
+    if (!bridge || typeof bridge.read !== "function") {
+      return { available: false, snapshot: null, error: null };
+    }
+
+    try {
+      const value = bridge.read();
+      const snapshot = value && typeof value.then === "function" ? await value : value;
+      return { available: true, snapshot, error: null };
+    } catch (error) {
+      return { available: true, snapshot: null, error: String(error) };
+    }
+  });
+}
+
+function formatTelemetryDiagnostic(telemetry) {
+  if (telemetry.error) {
+    return `read failed: ${telemetry.error}`;
+  }
+  return formatTelemetryState(telemetry.snapshot);
+}
+
+function formatDiagnosticValue(value) {
+  return value === null ? "not present" : JSON.stringify(value);
+}
+
+async function waitForPlaybackE2EState(page, label, predicate, options = {}) {
+  const timeout = options.timeout ?? 3500;
+  const pollInterval = options.pollInterval ?? 100;
+  const deadline = Date.now() + timeout;
+  let lastState = null;
+  let bridgeWasAvailable = false;
+
+  while (Date.now() <= deadline) {
+    const state = await readPlaybackE2EState(page);
+    if (state !== null) {
+      bridgeWasAvailable = true;
+      lastState = state;
+      if (predicate(state)) {
+        return state;
+      }
+    }
+    await page.waitForTimeout(pollInterval);
+  }
+
+  if (!bridgeWasAvailable) {
+    logStep(`Skipped ${label}; playback E2E telemetry bridge unavailable.`);
+    return null;
+  }
+
+  throw new Error(
+    `Timed out waiting for ${label} telemetry. Last state: ${formatTelemetryState(lastState)}.`,
+  );
+}
+
+async function assertCountInTelemetry(page, { expectedKind, expectedStartSeconds, label }) {
+  const scheduledState = await waitForPlaybackE2EState(
+    page,
+    `${label} schedule`,
+    (candidate) => {
+      const countIn = countInTelemetry(candidate);
+      if (!countIn || !isCountInActive(countIn, candidate)) {
+        return false;
+      }
+      const scheduled = countInScheduledEvent(countIn);
+      const kind = scheduled ? countInEventKind(scheduled) : null;
+      if (kind && !kindMatches(kind, expectedKind)) {
+        return false;
+      }
+      return true;
+    },
+    { timeout: 2500 },
+  );
+  if (!scheduledState) {
+    return false;
+  }
+
+  const countIn = countInTelemetry(scheduledState);
+  if (!countIn) {
+    throw new Error(`${label} telemetry did not include count-in details.`);
+  }
+  const scheduled = countInScheduledEvent(countIn);
+  if (!scheduled) {
+    throw new Error(`${label} telemetry did not include a scheduled count-in event.`);
+  }
+  const kind = countInEventKind(scheduled);
+  if (!kind) {
+    throw new Error(`${label} telemetry did not include a count-in kind.`);
+  }
+  if (!kindMatches(kind, expectedKind)) {
+    throw new Error(`Expected ${label} kind ${expectedKind}, but saw ${kind}.`);
+  }
+  const startSeconds = firstNumberField(scheduled, [
+    "startTimeSeconds",
+    "targetStartSeconds",
+    "playbackStartSeconds",
+    "anchorTimeSeconds",
+    "anchorSeconds",
+  ]);
+  if (startSeconds === null) {
+    throw new Error(`${label} telemetry did not include a target start time.`);
+  }
+  if (Math.abs(startSeconds - expectedStartSeconds) > 0.05) {
+    throw new Error(
+      `Expected ${label} target near ${formatSeconds(expectedStartSeconds)}, but saw ${formatSeconds(startSeconds)}.`,
+    );
+  }
+  const scheduledCount = countInScheduledClickCount(countIn, scheduled);
+  if (scheduledCount === null || scheduledCount <= 0) {
+    throw new Error(`${label} telemetry did not include scheduled click count.`);
+  }
+  const scheduledSequence = firstNumberField(scheduled, ["sequence"]);
+
+  const firedState = await waitForPlaybackE2EState(
+    page,
+    `${label} fired`,
+    (candidate) => {
+      const candidateCountIn = countInTelemetry(candidate);
+      const fired = candidateCountIn ? countInFiredEvent(candidateCountIn) : null;
+      if (!fired) {
+        return false;
+      }
+      const firedKind = countInEventKind(fired);
+      if (firedKind && !kindMatches(firedKind, expectedKind)) {
+        return false;
+      }
+      const firedSequence = firstNumberField(fired, ["sequence"]);
+      return scheduledSequence === null || firedSequence === null || firedSequence === scheduledSequence;
+    },
+    { timeout: 5000 },
+  );
+  if (!firedState) {
+    return false;
+  }
+  const firedCountIn = countInTelemetry(firedState);
+  const fired = firedCountIn ? countInFiredEvent(firedCountIn) : null;
+  if (!fired) {
+    throw new Error(`${label} telemetry did not include a fired count-in event.`);
+  }
+  const firedKind = countInEventKind(fired);
+  if (firedKind && !kindMatches(firedKind, expectedKind)) {
+    throw new Error(`Expected ${label} fired kind ${expectedKind}, but saw ${firedKind}.`);
+  }
+  const firedSequence = firstNumberField(fired, ["sequence"]);
+  if (scheduledSequence !== null && firedSequence !== null && firedSequence !== scheduledSequence) {
+    throw new Error(
+      `${label} fired sequence ${firedSequence} did not match scheduled sequence ${scheduledSequence}.`,
+    );
+  }
+  return true;
+}
+
+async function assertPlaybackTransportTelemetry(
+  page,
+  { expectedLoopEndSeconds, expectedLoopStartSeconds, expectedState, label },
+) {
+  const state = await waitForPlaybackE2EState(
+    page,
+    `${label} transport`,
+    (candidate) => isNativePlaybackActive(candidate) || isWebPlaybackActive(candidate),
+    { timeout: 2500 },
+  );
+  if (!state) {
+    return;
+  }
+
+  const transport = transportTelemetry(state);
+  const activePath = isNativePlaybackActive(state) ? "native" : "Web Audio";
+  const stateName = transportState(transport);
+  if (stateName !== expectedState) {
+    throw new Error(`Expected ${label} ${activePath} transport state ${expectedState}, but saw ${stateName}.`);
+  }
+  const positionSeconds = transportPositionSeconds(transport);
+  if (positionSeconds === null) {
+    throw new Error(`${label} ${activePath} transport did not report positionSeconds.`);
+  }
+  if (
+    positionSeconds < expectedLoopStartSeconds - 0.1 ||
+    positionSeconds > expectedLoopEndSeconds + 1
+  ) {
+    throw new Error(
+      `${label} ${activePath} position ${formatSeconds(positionSeconds)} outside expected loop ${formatSeconds(expectedLoopStartSeconds)}-${formatSeconds(expectedLoopEndSeconds)}.`,
+    );
+  }
+  const playbackRate = firstNumberField(transport, ["playbackRate", "rate"]);
+  if (playbackRate === null || playbackRate <= 0) {
+    throw new Error(`${label} ${activePath} transport did not report a positive playback rate.`);
+  }
+  const durationSeconds = firstNumberField(transport, [
+    "durationSeconds",
+    "duration",
+    "totalDurationSeconds",
+  ]);
+  if (durationSeconds === null || durationSeconds <= 0) {
+    throw new Error(`${label} ${activePath} transport did not report a positive duration.`);
+  }
+
+  const loopRange = loopTelemetry(state);
+  if (!loopRange) {
+    throw new Error(`${label} ${activePath} transport did not report active loop range.`);
+  }
+  const loopStart = firstNumberField(loopRange, ["startSeconds", "start", "loopStartSeconds"]);
+  const loopEnd = firstNumberField(loopRange, ["endSeconds", "end", "loopEndSeconds"]);
+  if (loopStart === null || Math.abs(loopStart - expectedLoopStartSeconds) > 0.05) {
+    throw new Error(
+      `Expected ${label} ${activePath} loop start near ${formatSeconds(expectedLoopStartSeconds)}, but saw ${loopStart}.`,
+    );
+  }
+  if (loopEnd === null || Math.abs(loopEnd - expectedLoopEndSeconds) > 0.05) {
+    throw new Error(
+      `Expected ${label} ${activePath} loop end near ${formatSeconds(expectedLoopEndSeconds)}, but saw ${loopEnd}.`,
+    );
+  }
+
+  if (!isNativePlaybackActive(state)) {
+    logStep(`${label} Web Audio transport telemetry passed.`);
+    return;
+  }
+
+  const bufferHealth = nativeBufferHealthTelemetry(state);
+  if (!Array.isArray(bufferHealth) || bufferHealth.length === 0) {
+    throw new Error(`${label} native telemetry did not report buffer health.`);
+  }
+  bufferHealth.forEach((lane, index) => {
+    const laneId = firstStringField(lane, ["laneId", "id"]);
+    const role = firstStringField(lane, ["role", "laneRole"]);
+    const fill = firstNumberField(lane, ["ringFillSamples", "fillSamples", "bufferFillSamples"]);
+    const capacity = firstNumberField(lane, [
+      "ringCapacitySamples",
+      "capacitySamples",
+      "bufferCapacitySamples",
+    ]);
+    const underruns = firstNumberField(lane, ["underrunCount", "underruns"]);
+    const workerErrors = firstNumberField(lane, ["workerErrorCount", "workerErrors"]);
+    if (!laneId) {
+      throw new Error(`${label} native buffer health lane ${index} missing laneId.`);
+    }
+    if (!role) {
+      throw new Error(`${label} native buffer health lane ${laneId} missing role.`);
+    }
+    if (fill === null || fill < 0) {
+      throw new Error(`${label} native buffer health lane ${laneId} has invalid fill.`);
+    }
+    if (capacity === null || capacity <= 0) {
+      throw new Error(`${label} native buffer health lane ${laneId} has invalid capacity.`);
+    }
+    if (fill > capacity) {
+      throw new Error(`${label} native buffer health lane ${laneId} fill exceeds capacity.`);
+    }
+    if (underruns === null || underruns < 0) {
+      throw new Error(`${label} native buffer health lane ${laneId} has invalid underruns.`);
+    }
+    if (workerErrors === null || workerErrors < 0) {
+      throw new Error(`${label} native buffer health lane ${laneId} has invalid worker errors.`);
+    }
+  });
+  logStep(`${label} native transport and buffer telemetry passed.`);
+}
+
+function countInTelemetry(state) {
+  return firstObjectField(state, [
+    "countIn",
+    "countInState",
+    "precount",
+    "preCount",
+  ]) ?? firstObjectField(transportTelemetry(state), ["countIn", "countInState", "precount", "preCount"]);
+}
+
+function isCountInActive(countIn, state) {
+  const activeValue = firstBooleanField(countIn, ["active", "isActive", "running", "isRunning"])
+    ?? firstBooleanField(state, ["isPrecounting", "precounting"]);
+  if (activeValue !== null) {
+    return activeValue;
+  }
+  const stateName = firstStringField(countIn, ["state", "status", "phase"]);
+  return stateName ? ["active", "running", "scheduled", "firing"].includes(stateName.toLowerCase()) : false;
+}
+
+function countInScheduledEvent(countIn) {
+  return firstObjectField(countIn, ["lastScheduled", "scheduled"]) ?? countIn;
+}
+
+function countInFiredEvent(countIn) {
+  const event = firstObjectField(countIn, ["lastFired", "fired"]);
+  if (event) {
+    return event;
+  }
+  const firedCount = countInFiredClickCount(countIn);
+  return firedCount !== null && firedCount > 0 ? countIn : null;
+}
+
+function countInEventKind(event) {
+  return firstStringField(event, ["trigger", "kind", "type", "mode", "scope", "reason"]);
+}
+
+function countInScheduledClickCount(countIn, scheduledEvent) {
+  return firstCountField(scheduledEvent, [
+    "scheduledClickCount",
+    "scheduledClicks",
+    "clickCount",
+    "totalClicks",
+    "clicks",
+  ]) ?? firstCountField(countIn, [
+    "scheduledClickCount",
+    "scheduledClicks",
+    "clickCount",
+    "totalClicks",
+    "clicks",
+  ]);
+}
+
+function countInFiredClickCount(countIn) {
+  const count = firstCountField(countIn, ["firedClickCount", "firedClicks", "clicksFired"]);
+  if (count !== null) {
+    return count;
+  }
+  const lastIndex = firstNumberField(countIn, ["lastFiredClickIndex", "currentClickIndex"]);
+  return lastIndex === null ? null : lastIndex + 1;
+}
+
+function isNativePlaybackActive(state) {
+  const active = firstBooleanField(state, [
+    "nativeActive",
+    "nativePlaybackActive",
+    "isNativeActive",
+  ]) ?? firstBooleanField(firstObjectField(state, ["native", "nativePlayback"]), ["active", "isActive"]);
+  if (active !== null) {
+    return active;
+  }
+  const backend = activeBackendName(state);
+  return backend === "native" || backend?.startsWith("native-") === true;
+}
+
+function isWebPlaybackActive(state) {
+  const backend = activeBackendName(state);
+  const compactBackend = backend?.replace(/[^a-z0-9]/g, "") ?? "";
+  return (
+    backend === "browser" ||
+    compactBackend === "webaudio" ||
+    compactBackend === "browseraudio"
+  );
+}
+
+function activeBackendName(state) {
+  const backend = firstStringField(state, [
+    "activePath",
+    "activePlaybackPath",
+    "playbackPath",
+    "activeBackend",
+    "backend",
+    "playbackBackend",
+  ])
+    ?? firstStringField(transportTelemetry(state), ["backend", "owner", "playbackBackend"]);
+  return backend ? normalizeKind(backend) : null;
+}
+
+function transportTelemetry(state) {
+  return firstObjectField(state, ["transport", "playback", "nativeTransport"]) ?? state;
+}
+
+function transportState(transport) {
+  return firstStringField(transport, ["transportState", "state", "status"])?.toLowerCase() ?? "unknown";
+}
+
+function transportPositionSeconds(transport) {
+  return firstNumberField(transport, [
+    "positionSeconds",
+    "currentPositionSeconds",
+    "playbackTimeSeconds",
+    "currentTimeSeconds",
+    "timeSeconds",
+  ]);
+}
+
+function loopTelemetry(state) {
+  const transport = transportTelemetry(state);
+  return firstObjectField(transport, ["loop", "loopRange", "activeLoopRange"])
+    ?? firstObjectField(state, ["loop", "loopRange", "activeLoopRange"]);
+}
+
+function nativeBufferHealthTelemetry(state) {
+  return firstArrayField(state, ["bufferHealth", "nativeBufferHealth"])
+    ?? firstArrayField(firstObjectField(state, ["native", "nativePlayback"]), ["bufferHealth"])
+    ?? firstArrayField(transportTelemetry(state), ["bufferHealth", "nativeBufferHealth"]);
+}
+
+function kindMatches(actual, expected) {
+  const normalizedActual = normalizeKind(actual);
+  const normalizedExpected = normalizeKind(expected);
+  const compactActual = normalizedActual.replace(/[^a-z0-9]/g, "");
+  const compactExpected = normalizedExpected.replace(/[^a-z0-9]/g, "");
+  if (normalizedExpected === "song-start" && normalizedActual === "song") {
+    return true;
+  }
+  return (
+    normalizedActual === normalizedExpected ||
+    normalizedActual.includes(normalizedExpected) ||
+    compactActual === compactExpected ||
+    compactActual.includes(compactExpected)
+  );
+}
+
+function normalizeKind(value) {
+  return value.toLowerCase().replace(/[\s_]+/g, "-");
+}
+
+function firstObjectField(source, names) {
+  if (!source || typeof source !== "object") {
+    return null;
+  }
+  for (const name of names) {
+    const value = source[name];
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function firstArrayField(source, names) {
+  if (!source || typeof source !== "object") {
+    return null;
+  }
+  for (const name of names) {
+    const value = source[name];
+    if (Array.isArray(value)) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function firstStringField(source, names) {
+  if (!source || typeof source !== "object") {
+    return null;
+  }
+  for (const name of names) {
+    const value = source[name];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+function firstBooleanField(source, names) {
+  if (!source || typeof source !== "object") {
+    return null;
+  }
+  for (const name of names) {
+    const value = source[name];
+    if (typeof value === "boolean") {
+      return value;
+    }
+  }
+  return null;
+}
+
+function firstNumberField(source, names) {
+  if (!source || typeof source !== "object") {
+    return null;
+  }
+  for (const name of names) {
+    const value = source[name];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function firstCountField(source, names) {
+  if (!source || typeof source !== "object") {
+    return null;
+  }
+  for (const name of names) {
+    const value = source[name];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (Array.isArray(value)) {
+      return value.length;
+    }
+  }
+  return null;
+}
+
+function formatTelemetryState(state) {
+  try {
+    return JSON.stringify(state);
+  } catch {
+    return String(state);
+  }
 }
 
 async function expectPosition(page, value, label) {


### PR DESCRIPTION
## Summary
- Add local-only playback E2E telemetry exposed through `window.__TUNEFORGE_PLAYBACK_E2E__.read()`.
- Wire native, Web Audio, loop, transport, buffer-health, and count-in state into the telemetry snapshot.
- Extend the opt-in playback smoke harness and native audio docs without adding any CI or default local E2E gate.

## Testing
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test --run`
- `pnpm --filter @tuneforge/desktop test:e2e`
- Manual smoke with `--run` was exercised by the maintainer against local data; a follow-up playback-start race was filed separately.

Closes #98
