### PR TITLE
test: Benchmark beat-this full checkpoint

### DIFF
--- a/apps/backend/app/benchmarks/timing.py
+++ b/apps/backend/app/benchmarks/timing.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import argparse
+import inspect
 import json
+import os
 import re
 import sys
 import time
@@ -12,10 +14,46 @@ from typing import Any
 import numpy as np
 import soundfile as sf
 
+from app.engines import beat_this as beat_this_engine
 from app.engines.analysis import AnalysisTimingPayload, analyze_track
 
 AUDIO_EXTENSIONS = {".aac", ".aif", ".aiff", ".flac", ".m4a", ".mp3", ".ogg", ".opus", ".wav", ".webm"}
 SAFE_NAME_PATTERN = re.compile(r"[^A-Za-z0-9._/-]+")
+BUILT_IN_BACKEND_ID = "built-in"
+BEAT_THIS_SMALL_BACKEND_ID = "beat-this-small0"
+BEAT_THIS_FINAL_BACKEND_ID = "beat-this-final0"
+DEFAULT_BENCHMARK_BACKENDS = (BUILT_IN_BACKEND_ID,)
+COMPARISON_BENCHMARK_BACKENDS = (
+    BUILT_IN_BACKEND_ID,
+    BEAT_THIS_SMALL_BACKEND_ID,
+    BEAT_THIS_FINAL_BACKEND_ID,
+)
+BEAT_THIS_BACKEND_CHECKPOINTS = {
+    BEAT_THIS_SMALL_BACKEND_ID: "small0",
+    BEAT_THIS_FINAL_BACKEND_ID: "final0",
+}
+BACKEND_ALIASES = {
+    "default": BUILT_IN_BACKEND_ID,
+    "detected": BUILT_IN_BACKEND_ID,
+    "heuristic": BUILT_IN_BACKEND_ID,
+    "built-in": BUILT_IN_BACKEND_ID,
+    "tuneforge": BUILT_IN_BACKEND_ID,
+    "tuneforge-built-in": BUILT_IN_BACKEND_ID,
+    "beat-this-small0": BEAT_THIS_SMALL_BACKEND_ID,
+    "beat-this-small": BEAT_THIS_SMALL_BACKEND_ID,
+    "small0": BEAT_THIS_SMALL_BACKEND_ID,
+    "small": BEAT_THIS_SMALL_BACKEND_ID,
+    "beat-this-final0": BEAT_THIS_FINAL_BACKEND_ID,
+    "beat-this-final": BEAT_THIS_FINAL_BACKEND_ID,
+    "final0": BEAT_THIS_FINAL_BACKEND_ID,
+    "final": BEAT_THIS_FINAL_BACKEND_ID,
+    "full": BEAT_THIS_FINAL_BACKEND_ID,
+}
+BACKEND_LABELS = {
+    BUILT_IN_BACKEND_ID: "built-in",
+    BEAT_THIS_SMALL_BACKEND_ID: "beat-this small0",
+    BEAT_THIS_FINAL_BACKEND_ID: "beat-this final0",
+}
 
 
 def build_benchmark_report(
@@ -24,11 +62,18 @@ def build_benchmark_report(
     audio_root: Path | None = None,
     include_relative_paths: bool = False,
     include_beats: bool = False,
+    backend_ids: list[str] | None = None,
+    include_warm_runs: bool | None = None,
 ) -> dict[str, Any]:
     resolved_audio_paths = [path.expanduser().resolve() for path in audio_paths]
     resolved_audio_root = audio_root.expanduser().resolve() if audio_root else None
+    selected_backend_ids = _resolve_backend_ids(backend_ids)
+    run_warm = len(selected_backend_ids) > 1 if include_warm_runs is None else include_warm_runs
     return {
         "benchmark": "tuneforge-timing-grid-heuristic",
+        "benchmark_version": 2,
+        "selected_backends": selected_backend_ids,
+        "warm_runs": run_warm,
         "track_count": len(resolved_audio_paths),
         "tracks": [
             _benchmark_track(
@@ -37,6 +82,8 @@ def build_benchmark_report(
                 audio_root=resolved_audio_root,
                 include_relative_paths=include_relative_paths,
                 include_beats=include_beats,
+                backend_ids=selected_backend_ids,
+                include_warm_runs=run_warm,
             )
             for index, audio_path in enumerate(resolved_audio_paths, start=1)
         ],
@@ -46,35 +93,77 @@ def build_benchmark_report(
 def summarize_report(report: dict[str, Any]) -> str:
     lines = [f"Timing benchmark: {report['track_count']} track(s)"]
     for track in report["tracks"]:
-        if not track["available"]:
-            lines.append(f"- {track['track_id']}: unavailable ({track['error']})")
-            continue
-        timing = track["timing"]
-        if not timing["available"]:
-            lines.append(
-                "- {track_id}: {runtime:.3f}s, no timing grid, tempo {tempo}".format(
-                    track_id=track["track_id"],
-                    runtime=track["analysis_runtime_seconds"],
-                    tempo=track["tempo_bpm"],
+        label = _track_summary_label(track)
+        backend_results = track.get("backend_results") or []
+        if len(backend_results) <= 1:
+            result = backend_results[0] if backend_results else track
+            lines.append(_summarize_single_backend(label, result, track))
+        else:
+            duration = track.get("track_duration_seconds")
+            lines.append(f"- {label}: duration {_seconds_label(duration)}")
+            for result in backend_results:
+                lines.append(
+                    "  - {backend}: {summary}".format(
+                        backend=result["backend_label"],
+                        summary=_backend_summary(result),
+                    )
                 )
-            )
-            continue
-        lines.append(
-            "- {track_id}: {runtime:.3f}s, {ratio}, tempo {tempo}, {source}, {meter}, "
-            "{beats} beats, {bars} bars, downbeat {downbeat_confidence}, meter {meter_confidence}".format(
-                track_id=track["track_id"],
-                runtime=track["analysis_runtime_seconds"],
-                ratio=_ratio_label(track["runtime_ratio"]),
-                tempo=track["tempo_bpm"],
-                source=timing["source"],
-                meter=timing["meter"],
-                beats=timing["beat_count"],
-                bars=timing["bar_count"],
-                downbeat_confidence=timing["downbeat_confidence"],
-                meter_confidence=timing["meter_confidence"],
+    return "\n".join(lines)
+
+
+def _summarize_single_backend(label: str, result: dict[str, Any], track: dict[str, Any]) -> str:
+    if not result["available"]:
+        return f"- {label}: unavailable ({result['error']})"
+    timing = result["timing"]
+    runtime_seconds = result.get("runtime_seconds", track.get("analysis_runtime_seconds"))
+    if not timing["available"]:
+        return f"- {label}: {_seconds_label(runtime_seconds)}, no timing grid, tempo {result.get('tempo_bpm')}"
+    return f"- {label}: {_backend_summary(result)}"
+
+
+def _backend_summary(result: dict[str, Any]) -> str:
+    if not result["available"]:
+        return f"unavailable ({result['unavailable_reason']})"
+
+    timing = result["timing"]
+    if not timing["available"]:
+        return (
+            "{runtime:.3f}s, {ratio}, no timing grid, cold {cold}, warm {warm}, load {load}, "
+            "cache {cache}".format(
+                runtime=result["runtime_seconds"],
+                ratio=_ratio_label(result["runtime_ratio"]),
+                cold=_seconds_label(result["cold_runtime_seconds"]),
+                warm=_seconds_label(result["warm_runtime_seconds"]),
+                load=_seconds_label(result["model_load_runtime_seconds"]),
+                cache=_cache_label(result["checkpoint_cache"]),
             )
         )
-    return "\n".join(lines)
+
+    return (
+        "{runtime:.3f}s, {ratio}, cold {cold}, warm {warm}, load {load}, tempo {tempo}, "
+        "{source}, {meter}, {beats} beats, {downbeats} downbeats, {bars} bars, "
+        "first beats {first_beats}, gaps {gaps}, CV {cv}, MAD {mad}, "
+        "anchor drift {drift}, alignment {alignment}, cache {cache}".format(
+            runtime=result["runtime_seconds"],
+            ratio=_ratio_label(result["runtime_ratio"]),
+            cold=_seconds_label(result["cold_runtime_seconds"]),
+            warm=_seconds_label(result["warm_runtime_seconds"]),
+            load=_seconds_label(result["model_load_runtime_seconds"]),
+            tempo=result["tempo_bpm"],
+            source=timing["source"],
+            meter=timing["meter"],
+            beats=timing["beat_count"],
+            downbeats=timing["downbeat_count"],
+            bars=timing["bar_count"],
+            first_beats=_first_beats_label(timing["first_beat_numbers"]),
+            gaps=timing["large_gap_count"],
+            cv=_number_label(timing["beat_interval_cv"]),
+            mad=_number_label(timing["beat_interval_mad_ratio"]),
+            drift=_single_anchor_drift_label(timing["single_anchor_drift_seconds"]),
+            alignment=_reference_alignment_label(result.get("reference_alignment_to_built_in")),
+            cache=_cache_label(result["checkpoint_cache"]),
+        )
+    )
 
 
 def collect_audio_paths(audio_dir: Path) -> list[Path]:
@@ -108,6 +197,25 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--limit", type=int, help="Maximum number of discovered tracks to analyze.")
     parser.add_argument("--include-beats", action="store_true", help="Include full detected beat payloads.")
     parser.add_argument(
+        "--backend",
+        action="append",
+        dest="backends",
+        help=(
+            "Timing backend to benchmark. Repeat for multiple. Supported aliases include "
+            "built-in, beat-this-small0, and beat-this-final0."
+        ),
+    )
+    parser.add_argument(
+        "--compare-beat-this",
+        action="store_true",
+        help="Compare built-in, beat-this small0, and beat-this final0 timing on each track.",
+    )
+    parser.add_argument(
+        "--warm-runs",
+        action="store_true",
+        help="Run each selected backend twice and report cold/warm timings.",
+    )
+    parser.add_argument(
         "--include-relative-paths",
         action="store_true",
         help="Include sanitized paths relative to --audio-dir or each file parent in JSON output.",
@@ -128,11 +236,19 @@ def main(argv: list[str] | None = None) -> int:
         audio_paths = args.audio or []
         audio_root = None
 
+    requested_backends = list(COMPARISON_BENCHMARK_BACKENDS) if args.compare_beat_this else args.backends
+    try:
+        backend_ids = _resolve_backend_ids(requested_backends)
+    except ValueError as exc:
+        parser.error(str(exc))
+
     report = build_benchmark_report(
         audio_paths,
         audio_root=audio_root,
         include_relative_paths=args.include_relative_paths,
         include_beats=args.include_beats,
+        backend_ids=backend_ids,
+        include_warm_runs=args.warm_runs or args.compare_beat_this,
     )
     sys.stdout.write(json.dumps(report, indent=2))
     sys.stdout.write("\n")
@@ -149,44 +265,218 @@ def _benchmark_track(
     audio_root: Path | None,
     include_relative_paths: bool,
     include_beats: bool,
+    backend_ids: list[str],
+    include_warm_runs: bool,
 ) -> dict[str, Any]:
     base: dict[str, Any] = {
         "track_id": f"track_{index:03d}",
         "relative_path": _relative_path(audio_path, audio_root) if include_relative_paths else None,
         **_track_metadata(audio_path),
     }
+    backend_results = [
+        _benchmark_timing_backend(
+            audio_path,
+            backend_id,
+            duration_seconds=base["track_duration_seconds"],
+            include_beats=include_beats,
+            include_warm_runs=include_warm_runs,
+        )
+        for backend_id in backend_ids
+    ]
+    backend_results = _attach_reference_alignment(backend_results)
+    legacy_result = _legacy_result(backend_results)
+    return {
+        **base,
+        **_legacy_track_fields(legacy_result),
+        "backend_results": backend_results,
+    }
+
+
+def _benchmark_timing_backend(
+    audio_path: Path,
+    backend_id: str,
+    *,
+    duration_seconds: float | None,
+    include_beats: bool,
+    include_warm_runs: bool,
+) -> dict[str, Any]:
+    checkpoint = BEAT_THIS_BACKEND_CHECKPOINTS.get(backend_id)
+    base = {
+        "backend_id": backend_id,
+        "backend_label": BACKEND_LABELS[backend_id],
+        "checkpoint": checkpoint,
+    }
+    cache_before = _checkpoint_cache_snapshot(checkpoint)
     tracemalloc.start()
-    started_at = time.perf_counter()
     try:
-        analysis = analyze_track(audio_path)
+        if checkpoint is not None:
+            _clear_beat_this_model_cache()
+        cold = _timed_timing_backend(audio_path, backend_id, duration_seconds=duration_seconds)
+        warm = (
+            _timed_timing_backend(audio_path, backend_id, duration_seconds=duration_seconds)
+            if include_warm_runs
+            else None
+        )
     except Exception as exc:  # pragma: no cover - command reports per-track failures.
         _, peak_memory_bytes = tracemalloc.get_traced_memory()
         tracemalloc.stop()
-        runtime_seconds = round(time.perf_counter() - started_at, 6)
+        cache_after = _checkpoint_cache_snapshot(checkpoint)
         return {
             **base,
             "available": False,
+            "unavailable_reason": _unavailable_reason(exc),
             "error": _benchmark_error(exc),
-            "analysis_runtime_seconds": runtime_seconds,
-            "runtime_ratio": _runtime_ratio(runtime_seconds, base["track_duration_seconds"]),
+            "runtime_seconds": None,
+            "runtime_ratio": None,
+            "cold_runtime_seconds": None,
+            "warm_runtime_seconds": None,
+            "cold_runtime_ratio": None,
+            "warm_runtime_ratio": None,
+            "model_load_runtime_seconds": None,
             "peak_memory_bytes": peak_memory_bytes,
+            "cold_peak_memory_bytes": None,
+            "warm_peak_memory_bytes": None,
             "tempo_bpm": None,
             "timing": _empty_timing_metrics(include_beats=include_beats),
+            "checkpoint_cache": _checkpoint_cache_summary(checkpoint, cache_before, cache_after),
+            "reference_alignment_to_built_in": None,
+            "_reference_beat_seconds": [],
         }
 
-    runtime_seconds = round(time.perf_counter() - started_at, 6)
     _, peak_memory_bytes = tracemalloc.get_traced_memory()
     tracemalloc.stop()
+    cache_after = _checkpoint_cache_snapshot(checkpoint)
+    selected = warm or cold
+    selected_timing = selected["timing"]
     return {
         **base,
         "available": True,
+        "unavailable_reason": None,
         "error": None,
-        "analysis_runtime_seconds": runtime_seconds,
-        "runtime_ratio": _runtime_ratio(runtime_seconds, base["track_duration_seconds"]),
+        "runtime_seconds": selected["runtime_seconds"],
+        "runtime_ratio": _runtime_ratio(selected["runtime_seconds"], duration_seconds),
+        "cold_runtime_seconds": cold["runtime_seconds"],
+        "warm_runtime_seconds": warm["runtime_seconds"] if warm else None,
+        "cold_runtime_ratio": _runtime_ratio(cold["runtime_seconds"], duration_seconds),
+        "warm_runtime_ratio": _runtime_ratio(warm["runtime_seconds"], duration_seconds) if warm else None,
+        "model_load_runtime_seconds": _model_load_runtime(cold, warm),
         "peak_memory_bytes": peak_memory_bytes,
-        "tempo_bpm": analysis["tempo_bpm"],
-        "timing": _timing_metrics(analysis["timing"], include_beats=include_beats),
+        "cold_peak_memory_bytes": cold["peak_memory_bytes"],
+        "warm_peak_memory_bytes": warm["peak_memory_bytes"] if warm else None,
+        "tempo_bpm": selected["tempo_bpm"],
+        "timing": _timing_metrics(selected_timing, include_beats=include_beats),
+        "checkpoint_cache": _checkpoint_cache_summary(checkpoint, cache_before, cache_after),
+        "reference_alignment_to_built_in": None,
+        "_reference_beat_seconds": _beat_seconds(selected_timing),
     }
+
+
+def _timed_timing_backend(
+    audio_path: Path,
+    backend_id: str,
+    *,
+    duration_seconds: float | None,
+) -> dict[str, Any]:
+    started_at = time.perf_counter()
+    if backend_id == BUILT_IN_BACKEND_ID:
+        analysis = analyze_track(audio_path)
+        timing = analysis["timing"]
+        tempo_bpm = analysis["tempo_bpm"]
+    else:
+        checkpoint = BEAT_THIS_BACKEND_CHECKPOINTS[backend_id]
+        timing = _detect_beat_this_timing(
+            audio_path,
+            duration_seconds=duration_seconds,
+            checkpoint=checkpoint,
+        )
+        tempo_bpm = _tempo_bpm_from_timing(timing)
+    runtime_seconds = round(time.perf_counter() - started_at, 6)
+    _, peak_memory_bytes = tracemalloc.get_traced_memory()
+    return {
+        "runtime_seconds": runtime_seconds,
+        "peak_memory_bytes": peak_memory_bytes,
+        "tempo_bpm": tempo_bpm,
+        "timing": timing,
+    }
+
+
+def _detect_beat_this_timing(
+    audio_path: Path,
+    *,
+    duration_seconds: float | None,
+    checkpoint: str,
+) -> AnalysisTimingPayload | None:
+    detector = beat_this_engine.detect_beat_this_timing
+    signature = inspect.signature(detector)
+    supports_checkpoint = "checkpoint" in signature.parameters or any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    )
+    if supports_checkpoint:
+        return detector(audio_path, duration_seconds=duration_seconds, checkpoint=checkpoint)
+    if checkpoint != "small0":
+        raise RuntimeError("beat-this checkpoint selection is unavailable in this backend build")
+    return detector(audio_path, duration_seconds=duration_seconds)
+
+
+def _clear_beat_this_model_cache() -> None:
+    get_file2beats = getattr(beat_this_engine, "_get_file2beats", None)
+    cache_clear = getattr(get_file2beats, "cache_clear", None)
+    if cache_clear is not None:
+        cache_clear()
+
+
+def _model_load_runtime(cold: dict[str, Any], warm: dict[str, Any] | None) -> float | None:
+    if warm is None:
+        return None
+    cold_runtime = cold["runtime_seconds"]
+    warm_runtime = warm["runtime_seconds"]
+    if not isinstance(cold_runtime, (int, float)) or not isinstance(warm_runtime, (int, float)):
+        return None
+    return round(max(float(cold_runtime) - float(warm_runtime), 0.0), 6)
+
+
+def _legacy_result(backend_results: list[dict[str, Any]]) -> dict[str, Any]:
+    for result in backend_results:
+        if result["backend_id"] == BUILT_IN_BACKEND_ID:
+            return result
+    return backend_results[0]
+
+
+def _legacy_track_fields(result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "available": result["available"],
+        "error": result["error"],
+        "analysis_runtime_seconds": result["runtime_seconds"],
+        "runtime_ratio": result["runtime_ratio"],
+        "peak_memory_bytes": result["peak_memory_bytes"],
+        "tempo_bpm": result["tempo_bpm"],
+        "timing": result["timing"],
+    }
+
+
+def _attach_reference_alignment(backend_results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    built_in_beats: list[float] | None = None
+    for result in backend_results:
+        if result["backend_id"] == BUILT_IN_BACKEND_ID and result["available"]:
+            beats = result.get("_reference_beat_seconds")
+            if isinstance(beats, list) and beats:
+                built_in_beats = beats
+            break
+
+    cleaned_results: list[dict[str, Any]] = []
+    for result in backend_results:
+        cleaned = dict(result)
+        beat_seconds = cleaned.pop("_reference_beat_seconds", None)
+        if result["backend_id"] in BEAT_THIS_BACKEND_CHECKPOINTS and built_in_beats is not None:
+            cleaned["reference_alignment_to_built_in"] = _reference_alignment_metrics(
+                beat_seconds if isinstance(beat_seconds, list) else None,
+                built_in_beats,
+            )
+        else:
+            cleaned["reference_alignment_to_built_in"] = None
+        cleaned_results.append(cleaned)
+    return cleaned_results
 
 
 def _timing_metrics(timing: AnalysisTimingPayload | None, *, include_beats: bool) -> dict[str, Any]:
@@ -227,6 +517,7 @@ def _timing_metrics(timing: AnalysisTimingPayload | None, *, include_beats: bool
         "beat_interval_mad_ratio": interval_mad_ratio,
         "beat_interval_cv": _interval_cv(intervals),
         "large_gap_count": _large_gap_count(intervals, median_interval),
+        "single_anchor_drift_seconds": _single_anchor_drift_metrics(beat_seconds, median_interval),
         "first_beat_numbers": [
             beat["beat_in_bar"]
             for beat in beats[:16]
@@ -259,6 +550,7 @@ def _empty_timing_metrics(*, include_beats: bool) -> dict[str, Any]:
         "beat_interval_mad_ratio": None,
         "beat_interval_cv": None,
         "large_gap_count": 0,
+        "single_anchor_drift_seconds": _empty_single_anchor_drift_metrics(),
         "first_beat_numbers": [],
     }
     if include_beats:
@@ -281,6 +573,95 @@ def _sanitize_relative_path(relative_path: str) -> str:
 
 def _benchmark_error(exc: Exception) -> str:
     return f"{type(exc).__name__}: analysis failed"
+
+
+def _unavailable_reason(exc: Exception) -> str:
+    if type(exc).__name__ == "BeatThisRuntimeError":
+        return str(exc)
+    message = str(exc)
+    if message == "beat-this checkpoint selection is unavailable in this backend build":
+        return message
+    return _benchmark_error(exc)
+
+
+def _tempo_bpm_from_timing(timing: AnalysisTimingPayload | None) -> float | None:
+    if timing is None:
+        return None
+    beat_seconds = [
+        beat["seconds"]
+        for beat in timing["beats"]
+        if _is_finite_number(beat["seconds"])
+    ]
+    if len(beat_seconds) < 2:
+        return None
+    intervals = np.diff(np.asarray(beat_seconds, dtype=np.float64))
+    median_interval = float(np.median(intervals)) if intervals.size else 0.0
+    if median_interval <= 0.0:
+        return None
+    return round(60.0 / median_interval, 3)
+
+
+def _checkpoint_cache_snapshot(checkpoint: str | None) -> dict[str, Any] | None:
+    if checkpoint is None:
+        return None
+    checkpoint_path = _torch_checkpoint_cache_path(checkpoint)
+    size_bytes = checkpoint_path.stat().st_size if checkpoint_path.exists() else None
+    return {
+        "available": size_bytes is not None,
+        "checkpoint_file": checkpoint_path.name,
+        "size_bytes": size_bytes,
+    }
+
+
+def _torch_checkpoint_cache_path(checkpoint: str) -> Path:
+    file_name = f"beat_this-{checkpoint}.ckpt"
+    torch_home = os.environ.get("TORCH_HOME")
+    if torch_home:
+        return Path(torch_home).expanduser() / "hub" / "checkpoints" / file_name
+    xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
+    if xdg_cache_home:
+        return Path(xdg_cache_home).expanduser() / "torch" / "hub" / "checkpoints" / file_name
+    return Path.home() / ".cache" / "torch" / "hub" / "checkpoints" / file_name
+
+
+def _checkpoint_cache_summary(
+    checkpoint: str | None,
+    before: dict[str, Any] | None,
+    after: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if checkpoint is None:
+        return {
+            "available": False,
+            "checkpoint_file": None,
+            "cache_size_bytes_before": None,
+            "cache_size_bytes_after": None,
+            "downloaded_during_run": None,
+            "behavior": "not_applicable",
+        }
+    before_size = before.get("size_bytes") if before else None
+    after_size = after.get("size_bytes") if after else None
+    downloaded = None
+    if isinstance(after_size, int):
+        downloaded = not isinstance(before_size, int) or after_size > before_size
+    available = bool((before and before.get("available")) or (after and after.get("available")))
+    return {
+        "available": available,
+        "checkpoint_file": after.get("checkpoint_file") if after else before.get("checkpoint_file") if before else None,
+        "cache_size_bytes_before": before_size,
+        "cache_size_bytes_after": after_size,
+        "downloaded_during_run": downloaded,
+        "behavior": _cache_behavior(available, downloaded),
+    }
+
+
+def _cache_behavior(available: bool, downloaded: bool | None) -> str:
+    if not available:
+        return "unknown"
+    if downloaded is True:
+        return "downloaded_or_cache_grew"
+    if downloaded is False:
+        return "cache_unchanged"
+    return "observed"
 
 
 def _is_finite_number(value: Any) -> bool:
@@ -313,6 +694,70 @@ def _interval_cv(intervals: np.ndarray) -> float | None:
     if mean_interval <= 0.0:
         return None
     return round(float(np.std(intervals) / mean_interval), 6)
+
+
+def _beat_seconds(timing: AnalysisTimingPayload | None) -> list[float]:
+    if timing is None:
+        return []
+    return [
+        float(beat["seconds"])
+        for beat in timing["beats"]
+        if _is_finite_number(beat["seconds"])
+    ]
+
+
+def _single_anchor_drift_metrics(beat_seconds: np.ndarray, median_interval: float | None) -> dict[str, Any]:
+    if beat_seconds.size < 2 or median_interval is None or median_interval <= 0.0:
+        return _empty_single_anchor_drift_metrics()
+    anchored_grid = beat_seconds[0] + np.arange(beat_seconds.size, dtype=np.float64) * median_interval
+    absolute_residuals = np.abs(beat_seconds - anchored_grid)
+    return {
+        "median_absolute_residual_seconds": round(float(np.median(absolute_residuals)), 6),
+        "p95_absolute_residual_seconds": round(float(np.percentile(absolute_residuals, 95)), 6),
+        "max_absolute_residual_seconds": round(float(np.max(absolute_residuals)), 6),
+    }
+
+
+def _empty_single_anchor_drift_metrics() -> dict[str, Any]:
+    return {
+        "median_absolute_residual_seconds": None,
+        "p95_absolute_residual_seconds": None,
+        "max_absolute_residual_seconds": None,
+    }
+
+
+def _reference_alignment_metrics(
+    beat_seconds: list[float] | None,
+    reference_beat_seconds: list[float],
+) -> dict[str, Any] | None:
+    if not beat_seconds or not reference_beat_seconds:
+        return None
+    beats = np.sort(np.asarray(beat_seconds, dtype=np.float64))
+    reference = np.sort(np.asarray(reference_beat_seconds, dtype=np.float64))
+    if beats.size == 0 or reference.size == 0:
+        return None
+
+    positions = np.searchsorted(reference, beats)
+    deltas: list[float] = []
+    for beat, position in zip(beats, positions, strict=True):
+        candidates = []
+        if position < reference.size:
+            candidates.append(abs(float(reference[position] - beat)))
+        if position > 0:
+            candidates.append(abs(float(beat - reference[position - 1])))
+        if candidates:
+            deltas.append(min(candidates))
+    if not deltas:
+        return None
+
+    deltas_array = np.asarray(deltas, dtype=np.float64)
+    return {
+        "reference_backend_id": BUILT_IN_BACKEND_ID,
+        "median_nearest_beat_delta_seconds": round(float(np.median(deltas_array)), 6),
+        "p95_nearest_beat_delta_seconds": round(float(np.percentile(deltas_array, 95)), 6),
+        "max_nearest_beat_delta_seconds": round(float(np.max(deltas_array)), 6),
+        "beat_count_delta": int(beats.size - reference.size),
+    }
 
 
 def _large_gap_count(intervals: np.ndarray, median_interval: float | None) -> int:
@@ -349,6 +794,72 @@ def _runtime_ratio(runtime_seconds: float, duration_seconds: Any) -> float | Non
 
 def _ratio_label(value: Any) -> str:
     return f"{value:.2f}x track" if isinstance(value, (int, float)) else "unknown ratio"
+
+
+def _resolve_backend_ids(backend_ids: list[str] | None) -> list[str]:
+    requested_backend_ids = backend_ids or list(DEFAULT_BENCHMARK_BACKENDS)
+    resolved_backend_ids: list[str] = []
+    for backend_id in requested_backend_ids:
+        normalized = backend_id.strip().lower()
+        resolved = BACKEND_ALIASES.get(normalized)
+        if resolved is None:
+            supported = ", ".join(COMPARISON_BENCHMARK_BACKENDS)
+            raise ValueError(f"unsupported timing backend {backend_id!r}; expected one of {supported}")
+        if resolved not in resolved_backend_ids:
+            resolved_backend_ids.append(resolved)
+    return resolved_backend_ids
+
+
+def _track_summary_label(track: dict[str, Any]) -> str:
+    relative_path = track.get("relative_path")
+    if isinstance(relative_path, str) and relative_path:
+        return f"{track['track_id']} ({relative_path})"
+    return track["track_id"]
+
+
+def _seconds_label(value: Any) -> str:
+    return f"{value:.3f}s" if isinstance(value, (int, float)) else "unknown"
+
+
+def _number_label(value: Any) -> str:
+    return f"{value:.3f}" if isinstance(value, (int, float)) else "unknown"
+
+
+def _single_anchor_drift_label(value: Any) -> str:
+    if not isinstance(value, dict):
+        return "unknown"
+    median = _seconds_label(value.get("median_absolute_residual_seconds"))
+    p95 = _seconds_label(value.get("p95_absolute_residual_seconds"))
+    maximum = _seconds_label(value.get("max_absolute_residual_seconds"))
+    return f"median {median}/p95 {p95}/max {maximum}"
+
+
+def _reference_alignment_label(value: Any) -> str:
+    if value is None:
+        return "n/a"
+    if not isinstance(value, dict):
+        return "unknown"
+    median = _seconds_label(value.get("median_nearest_beat_delta_seconds"))
+    p95 = _seconds_label(value.get("p95_nearest_beat_delta_seconds"))
+    count_delta = value.get("beat_count_delta")
+    return f"built-in median {median}/p95 {p95}/count delta {count_delta}"
+
+
+def _first_beats_label(values: Any) -> str:
+    if not isinstance(values, list) or not values:
+        return "none"
+    return ",".join(str(value) for value in values[:8])
+
+
+def _cache_label(cache: Any) -> str:
+    if not isinstance(cache, dict):
+        return "not_applicable"
+    behavior = cache.get("behavior")
+    after = cache.get("cache_size_bytes_after")
+    downloaded = cache.get("downloaded_during_run")
+    if isinstance(after, int):
+        return f"{behavior}:{after} bytes:download {downloaded}"
+    return str(behavior)
 
 
 if __name__ == "__main__":

--- a/apps/backend/app/engines/beat_this.py
+++ b/apps/backend/app/engines/beat_this.py
@@ -61,9 +61,11 @@ def detect_beat_this_timing(
     source_path: Path,
     *,
     duration_seconds: float | None = None,
+    checkpoint: str | None = None,
 ) -> AnalysisTimingPayload | None:
+    checkpoint_path = BEAT_THIS_CHECKPOINT if checkpoint is None else checkpoint
     try:
-        raw_beats, raw_downbeats = _get_file2beats()(str(source_path))
+        raw_beats, raw_downbeats = _get_file2beats(checkpoint=checkpoint_path)(str(source_path))
     except BeatThisRuntimeError:
         raise
     except Exception as exc:
@@ -104,8 +106,8 @@ def detect_beat_this_timing(
     }
 
 
-@lru_cache(maxsize=1)
-def _get_file2beats() -> File2BeatsCallable:
+@lru_cache(maxsize=4)
+def _get_file2beats(*, checkpoint: str = BEAT_THIS_CHECKPOINT) -> File2BeatsCallable:
     try:
         from beat_this.inference import File2Beats
     except Exception as exc:
@@ -116,7 +118,7 @@ def _get_file2beats() -> File2BeatsCallable:
     try:
         return cast(
             File2BeatsCallable,
-            File2Beats(checkpoint_path=BEAT_THIS_CHECKPOINT, device="cpu", dbn=False),
+            File2Beats(checkpoint_path=checkpoint, device="cpu", dbn=False),
         )
     except Exception as exc:
         raise BeatThisRuntimeError("Advanced Beat Analysis could not load the beat-this model.") from exc

--- a/apps/backend/tests/test_beat_this_engine.py
+++ b/apps/backend/tests/test_beat_this_engine.py
@@ -4,7 +4,6 @@ import sys
 import types
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
 
 import numpy as np
 import pytest
@@ -20,7 +19,11 @@ def clear_file2beats_cache() -> Iterator[None]:
 
 
 def test_detect_beat_this_timing_uses_stubbed_file2beats(monkeypatch) -> None:
-    def fake_get_file2beats(**_kwargs: Any):
+    calls: list[str] = []
+
+    def fake_get_file2beats(*, checkpoint: str = beat_this_engine.BEAT_THIS_CHECKPOINT):
+        calls.append(checkpoint)
+
         def fake_file2beats(_source_path: str):
             return np.arange(0.0, 6.5, 0.5), np.asarray([0.0, 2.0, 4.0, 6.0])
 
@@ -39,6 +42,7 @@ def test_detect_beat_this_timing_uses_stubbed_file2beats(monkeypatch) -> None:
     assert timing["meter"] == "4/4"
     assert timing["meter_confidence"] == 1.0
     assert timing["downbeat_confidence"] == 1.0
+    assert calls == ["small0"]
     assert timing["beats"][0] == {
         "index": 0,
         "seconds": 0.0,
@@ -48,6 +52,30 @@ def test_detect_beat_this_timing_uses_stubbed_file2beats(monkeypatch) -> None:
     assert timing["beats"][4]["bar_index"] == 1
     assert timing["beats"][4]["beat_in_bar"] == 1
     assert timing["bars"][0] == {"index": 0, "start_seconds": 0.0, "end_seconds": 2.0}
+
+
+def test_detect_beat_this_timing_accepts_checkpoint_override(monkeypatch) -> None:
+    calls: list[str] = []
+
+    def fake_get_file2beats(*, checkpoint: str = beat_this_engine.BEAT_THIS_CHECKPOINT):
+        calls.append(checkpoint)
+
+        def fake_file2beats(_source_path: str):
+            return np.arange(0.0, 4.5, 0.5), np.asarray([0.0, 2.0, 4.0])
+
+        return fake_file2beats
+
+    monkeypatch.setattr(beat_this_engine, "_get_file2beats", fake_get_file2beats)
+
+    timing = beat_this_engine.detect_beat_this_timing(
+        Path("synthetic_beat_this.wav"),
+        duration_seconds=4.5,
+        checkpoint="final0",
+    )
+
+    assert timing is not None
+    assert timing["source"] == "beat-this"
+    assert calls == ["final0"]
 
 
 def test_analyze_track_with_beat_this_replaces_timing_and_tempo(monkeypatch) -> None:
@@ -107,6 +135,27 @@ def test_get_file2beats_initializes_beat_this_with_small_cpu_model(monkeypatch) 
     np.testing.assert_array_equal(beats, np.asarray([0.0, 1.0]))
     np.testing.assert_array_equal(downbeats, np.asarray([0.0]))
     assert calls == [("small0", "cpu", False)]
+
+
+def test_get_file2beats_initializes_beat_this_with_requested_checkpoint(monkeypatch) -> None:
+    calls: list[tuple[str, str, bool]] = []
+
+    class FakeFile2Beats:
+        def __init__(self, checkpoint_path: str, *, device: str, dbn: bool) -> None:
+            calls.append((checkpoint_path, device, dbn))
+
+        def __call__(self, _source_path: str):
+            return np.asarray([0.0, 1.0]), np.asarray([0.0])
+
+    _install_fake_beat_this(monkeypatch, FakeFile2Beats)
+    beat_this_engine._get_file2beats.cache_clear()
+
+    file2beats = beat_this_engine._get_file2beats(checkpoint="final0")
+
+    beats, downbeats = file2beats("song.wav")
+    np.testing.assert_array_equal(beats, np.asarray([0.0, 1.0]))
+    np.testing.assert_array_equal(downbeats, np.asarray([0.0]))
+    assert calls == [("final0", "cpu", False)]
 
 
 def _install_fake_beat_this(monkeypatch, file2beats_class: type) -> None:

--- a/apps/backend/tests/test_timing_benchmarks.py
+++ b/apps/backend/tests/test_timing_benchmarks.py
@@ -5,8 +5,14 @@ from pathlib import Path
 
 import pytest
 
-from app.benchmarks.timing import build_benchmark_report
-from app.benchmarks.timing import main as benchmark_main
+from app.benchmarks.timing import (
+    _checkpoint_cache_summary,
+    build_benchmark_report,
+    summarize_report,
+)
+from app.benchmarks.timing import (
+    main as benchmark_main,
+)
 
 
 def test_timing_benchmark_command_emits_json_without_paths(sample_rhythmic_audio_file: Path, capsys):
@@ -77,3 +83,180 @@ def test_timing_benchmark_rejects_missing_audio_dir(tmp_path: Path, capsys: pyte
     assert "track_count" not in captured.out
     assert "--audio-dir must be an existing directory" in captured.err
     assert str(missing_audio_dir) not in captured.err
+
+
+def test_timing_benchmark_marks_first_checkpoint_download():
+    summary = _checkpoint_cache_summary(
+        "small0",
+        {"available": False, "checkpoint_file": "beat_this-small0.ckpt", "size_bytes": None},
+        {"available": True, "checkpoint_file": "beat_this-small0.ckpt", "size_bytes": 8_451_101},
+    )
+
+    assert summary["available"] is True
+    assert summary["cache_size_bytes_before"] is None
+    assert summary["cache_size_bytes_after"] == 8_451_101
+    assert summary["downloaded_during_run"] is True
+    assert summary["behavior"] == "downloaded_or_cache_grew"
+
+
+def test_timing_benchmark_compares_backends_without_exposing_absolute_paths(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    private_audio_path = Path("/Users/example/Music/Private Session/Secret Take.wav")
+    ticks = iter(
+        [
+            0.0,
+            2.0,
+            2.0,
+            3.0,
+            3.0,
+            4.5,
+            4.5,
+            5.1,
+            5.1,
+            7.1,
+            7.1,
+            7.8,
+        ]
+    )
+    checkpoints: list[str] = []
+
+    monkeypatch.setattr("app.benchmarks.timing.time.perf_counter", lambda: next(ticks))
+    monkeypatch.setattr(
+        "app.benchmarks.timing._track_metadata",
+        lambda _audio_path: {
+            "track_duration_seconds": 10.0,
+            "sample_rate": 44_100,
+            "channels": 2,
+        },
+    )
+    monkeypatch.setattr(
+        "app.benchmarks.timing._checkpoint_cache_snapshot",
+        lambda checkpoint: None
+        if checkpoint is None
+        else {"available": True, "size_bytes": 100 if checkpoint == "small0" else 400},
+    )
+
+    def fake_analyze_track(_audio_path: Path):
+        return {
+            "estimated_key": None,
+            "key_confidence": None,
+            "estimated_reference_hz": None,
+            "tuning_offset_cents": None,
+            "tempo_bpm": 120.0,
+            "timing": _timing_payload("detected", [0.0, 0.5, 1.0, 1.5, 2.0]),
+        }
+
+    def fake_detect_beat_this_timing(
+        _audio_path: Path,
+        *,
+        duration_seconds: float | None = None,
+        checkpoint: str,
+    ):
+        assert duration_seconds == 10.0
+        checkpoints.append(checkpoint)
+        if checkpoint == "small0":
+            return _timing_payload("beat-this", [0.0, 0.5, 1.0, 1.5, 2.4])
+        return _timing_payload("beat-this", [0.0, 0.5, 1.05, 1.55, 2.05])
+
+    monkeypatch.setattr("app.benchmarks.timing.analyze_track", fake_analyze_track)
+    monkeypatch.setattr(
+        "app.benchmarks.timing.beat_this_engine.detect_beat_this_timing",
+        fake_detect_beat_this_timing,
+    )
+
+    report = build_benchmark_report(
+        [private_audio_path],
+        audio_root=Path("/Users/example/Music"),
+        include_relative_paths=True,
+        backend_ids=["built-in", "beat-this-small0", "beat-this-final0"],
+        include_warm_runs=True,
+    )
+    rendered = json.dumps(report, indent=2)
+    summary = summarize_report(report)
+    track = report["tracks"][0]
+    results = {result["backend_id"]: result for result in track["backend_results"]}
+
+    assert report["selected_backends"] == ["built-in", "beat-this-small0", "beat-this-final0"]
+    assert track["relative_path"] == "Private_Session/Secret_Take.wav"
+    assert track["analysis_runtime_seconds"] == 1.0
+    assert results["built-in"]["cold_runtime_seconds"] == 2.0
+    assert results["built-in"]["warm_runtime_seconds"] == 1.0
+    assert results["built-in"]["model_load_runtime_seconds"] == 1.0
+    assert results["built-in"]["reference_alignment_to_built_in"] is None
+    assert results["built-in"]["timing"]["single_anchor_drift_seconds"] == {
+        "median_absolute_residual_seconds": 0.0,
+        "p95_absolute_residual_seconds": 0.0,
+        "max_absolute_residual_seconds": 0.0,
+    }
+    assert results["beat-this-small0"]["checkpoint"] == "small0"
+    assert results["beat-this-small0"]["runtime_ratio"] == 0.06
+    assert results["beat-this-small0"]["timing"]["beat_count"] == 5
+    assert results["beat-this-small0"]["timing"]["downbeat_count"] == 2
+    assert results["beat-this-small0"]["timing"]["meter"] == "4/4"
+    assert results["beat-this-small0"]["timing"]["first_beat_numbers"] == [1, 2, 3, 4, 1]
+    assert results["beat-this-small0"]["timing"]["large_gap_count"] == 1
+    assert results["beat-this-small0"]["timing"]["beat_interval_cv"] is not None
+    assert results["beat-this-small0"]["timing"]["beat_interval_mad_ratio"] is not None
+    assert results["beat-this-small0"]["timing"]["single_anchor_drift_seconds"] == {
+        "median_absolute_residual_seconds": 0.0,
+        "p95_absolute_residual_seconds": 0.32,
+        "max_absolute_residual_seconds": 0.4,
+    }
+    assert results["beat-this-small0"]["reference_alignment_to_built_in"] == {
+        "reference_backend_id": "built-in",
+        "median_nearest_beat_delta_seconds": 0.0,
+        "p95_nearest_beat_delta_seconds": 0.32,
+        "max_nearest_beat_delta_seconds": 0.4,
+        "beat_count_delta": 0,
+    }
+    assert results["beat-this-small0"]["checkpoint_cache"]["cache_size_bytes_after"] == 100
+    assert results["beat-this-small0"]["checkpoint_cache"]["downloaded_during_run"] is False
+    assert results["beat-this-final0"]["checkpoint"] == "final0"
+    assert results["beat-this-final0"]["reference_alignment_to_built_in"] == {
+        "reference_backend_id": "built-in",
+        "median_nearest_beat_delta_seconds": 0.05,
+        "p95_nearest_beat_delta_seconds": 0.05,
+        "max_nearest_beat_delta_seconds": 0.05,
+        "beat_count_delta": 0,
+    }
+    assert checkpoints == ["small0", "small0", "final0", "final0"]
+    assert "beat-this small0" in summary
+    assert "beat-this final0" in summary
+    assert "CV" in summary
+    assert "MAD" in summary
+    assert "anchor drift" in summary
+    assert "alignment built-in" in summary
+    assert "_reference_beat_seconds" not in rendered
+    assert str(private_audio_path) not in rendered
+    assert str(private_audio_path) not in summary
+    assert "/Users/" not in rendered
+    assert "/Users/" not in summary
+
+
+def _timing_payload(source: str, seconds: list[float]) -> dict:
+    beats = [
+        {
+            "index": index,
+            "seconds": second,
+            "bar_index": index // 4,
+            "beat_in_bar": (index % 4) + 1,
+        }
+        for index, second in enumerate(seconds)
+    ]
+    return {
+        "beats_per_bar": 4,
+        "source": source,
+        "meter": "4/4",
+        "meter_confidence": 1.0,
+        "downbeat_source": source,
+        "downbeat_confidence": 1.0,
+        "beats": beats,
+        "bars": [
+            {
+                "index": 0,
+                "start_seconds": 0.0,
+                "end_seconds": seconds[-1] if seconds else 0.0,
+            }
+        ],
+    }

--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -109,20 +109,24 @@ TuneForge should keep lyrics local and project-owned.
 
 This evaluation checked whether TuneForge should integrate a local ML beat/downbeat/meter model after the first
 correctable timing-grid work. The recommendation is to keep the heuristic and correction path as the product route for
-now, and treat CPJKU Beat This as the only promising spike candidate after local-track bake-off evidence and explicit
-model-weight redistribution confirmation.
+now, and use CPJKU Beat This `small0` as the optional full-profile model after local-track bake-off evidence and
+explicit model-weight redistribution confirmation.
 
 Local-track baseline evidence from a read-only sample of 8 converted source WAVs in local app data: 8/8 completed,
 8/8 produced timing grids, median heuristic runtime was 12.686 seconds, median runtime ratio was 0.0531x track length,
-and 5/8 tracks had at least one large beat-gap flag. Candidate model runtime and quality estimates still require a
-separate optional-model spike against the same kind of non-committed local tracks.
+and 5/8 tracks had at least one large beat-gap flag.
 
-First `beat-this` smoke evidence used the `small0` checkpoint on CPU with minimal post-processing over the same 8
-converted source WAVs. The checkpoint downloaded once at 8.06 MB, warm model load was 0.04 seconds, median model
-runtime was 1.183 seconds, and median model runtime ratio was 0.0057x track length. Beat counts stayed close on 4/8
-tracks and differed by more than 10% on 4/8 tracks, including several tracks where the heuristic had large beat-gap
-flags. This is promising enough for a focused optional-backend spike, but it is not yet enough to replace the
-heuristic path without listening checks on the known out-of-sync songs.
+Follow-up benchmark evidence compared the built-in analyzer, Beat This `small0`, and Beat This `final0` on the same
+kind of 8 local, non-committed tracks, including known timing failures and stable baselines. All 8 tracks completed for
+all 3 backends without source paths in the benchmark output. Median warm runtime ratios were 0.047267x for the
+built-in analyzer, 0.006145x for `small0`, and 0.007968x for `final0`; `final0` was about 1.30x slower than `small0`
+and about 9.6x larger.
+
+Quality evidence does not justify switching the default or exposing a model-size setting yet. `final0` reduced large
+gap flags on some tracks, but it still showed tempo and meter risks on known benchmark cases. The benchmark now records
+single-anchor drift and Beat This alignment against the built-in grid for future bake-offs, but the current
+recommendation is to keep `small0` as the default optional model until listening checks show `final0` improves practice
+sync without tempo or meter regressions.
 
 Several candidates were kept as research-only or excluded because their upstream project activity, release freshness,
 or supported Python/ML stack did not fit a new desktop runtime dependency.


### PR DESCRIPTION
## Summary

- Add benchmark support for comparing built-in timing, Beat This `small0`, and Beat This `final0`.
- Keep production Advanced Beat Analysis on `small0`; `final0` is benchmark-only.
- Record the local benchmark recommendation to keep `small0` as the optional default.

Closes #212

## Testing

- `cd apps/backend && UV_CACHE_DIR=/private/tmp/uv-cache uv run --python 3.11 pytest`
- `cd apps/backend && UV_CACHE_DIR=/private/tmp/uv-cache uv run --python 3.11 ruff check .`
- `cd apps/backend && UV_CACHE_DIR=/private/tmp/uv-cache uv run --python 3.11 mypy app`
- `git diff --check origin/main...HEAD`
- Local 8-track benchmark run with `bash scripts/run-backend-module.sh app.benchmarks.timing --compare-beat-this ...`
