### PR TITLE
feat: add isolated playback E2E fixture prep

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -135,6 +135,7 @@ All configuration is environment-driven (see [`app/config.py`](./app/config.py))
 | --- | --- | --- |
 | `TUNEFORGE_HOST` | `127.0.0.1` | Bind address. **Do not change to a public address.** |
 | `TUNEFORGE_PORT` | `8765` | Bind port. |
+| `TUNEFORGE_ADDITIONAL_CORS_ORIGINS` | unset | Comma-separated local HTTP origins to allow in addition to the desktop defaults. Only `http://127.0.0.1:<port>` and `http://localhost:<port>` are accepted. |
 | `TUNEFORGE_DATA_DIR` | OS-specific | Override for the data directory (database, projects, cache). |
 | `TUNEFORGE_FFMPEG_PATH` | `ffmpeg` | Override the `ffmpeg` binary location. |
 | `TUNEFORGE_FFPROBE_PATH` | `ffprobe` | Override the `ffprobe` binary location. |

--- a/apps/backend/app/cli/playback_e2e_fixture.py
+++ b/apps/backend/app/cli/playback_e2e_fixture.py
@@ -1,0 +1,432 @@
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import math
+import os
+import struct
+import sys
+import wave
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.errors import AppError
+from app.models import AnalysisResult, Artifact, ChordTimeline, LyricsTranscript, Project, SongSection
+from app.services.projects import import_project
+from app.services.sync_identity import source_hash_to_project_id
+from app.utils.hashing import file_sha256
+from app.utils.ids import new_id
+
+DEFAULT_PROJECT_NAME = "Tuneforge E2E Fixture"
+FIXTURE_FILE_NAME = "tuneforge-e2e-fixture.wav"
+FIXTURE_DURATION_SECONDS = 40.0
+FIXTURE_BPM = 120.0
+FIXTURE_SAMPLE_RATE = 22_050
+BEATS_PER_BAR = 4
+
+
+class PlaybackE2EFixtureCliError(RuntimeError):
+    pass
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    try:
+        args = parser.parse_args(argv)
+        summary = _run_command(args)
+    except AppError as exc:
+        sys.stderr.write(f"error: {exc.message}\n")
+        return 1
+    except PlaybackE2EFixtureCliError as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 1
+    except Exception as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 1
+
+    sys.stdout.write(json.dumps(summary, sort_keys=True))
+    sys.stdout.write("\n")
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m app.cli.playback_e2e_fixture",
+        description="Create a deterministic local playback E2E fixture project.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    create_parser = subparsers.add_parser(
+        "create",
+        help="Create or refresh the playback E2E fixture.",
+    )
+    create_parser.add_argument("--data-dir", required=True, type=Path, metavar="PATH")
+    create_parser.add_argument("--work-dir", required=True, type=Path, metavar="PATH")
+    create_parser.add_argument(
+        "--project-name",
+        default=DEFAULT_PROJECT_NAME,
+        help=f"Visible project name. Defaults to {DEFAULT_PROJECT_NAME!r}.",
+    )
+    return parser
+
+
+def _run_command(args: argparse.Namespace) -> dict[str, Any]:
+    if args.command != "create":
+        raise PlaybackE2EFixtureCliError(f"unsupported command: {args.command}")
+
+    data_dir = _resolve_path(args.data_dir)
+    work_dir = _resolve_path(args.work_dir)
+    project_name = _normalize_project_name(args.project_name)
+    _configure_backend(data_dir)
+    source_path = _write_fixture_wav(work_dir)
+
+    from app.db import session_scope
+
+    with session_scope() as session:
+        project = _import_or_get_project(
+            session,
+            source_path=source_path,
+            project_name=project_name,
+        )
+        source_artifact = _source_artifact(session, project_id=project.id)
+        _seed_fixture_data(
+            session,
+            project=project,
+            source_artifact=source_artifact,
+        )
+        session.flush()
+        session.refresh(project)
+        return _build_summary(
+            project=project,
+            data_dir=data_dir,
+            work_dir=work_dir,
+            source_path=source_path,
+        )
+
+
+def _resolve_path(path: Path) -> Path:
+    return path.expanduser().resolve()
+
+
+def _normalize_project_name(value: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise PlaybackE2EFixtureCliError("--project-name cannot be empty")
+    return normalized
+
+
+def _configure_backend(data_dir: Path) -> None:
+    os.environ["TUNEFORGE_DATA_DIR"] = str(data_dir)
+    from app.config import ensure_data_dirs, get_settings
+    from app.db import reconfigure_engine, run_migrations
+
+    get_settings.cache_clear()
+    settings = get_settings()
+    ensure_data_dirs(settings)
+    reconfigure_engine(settings)
+    with contextlib.redirect_stderr(io.StringIO()):
+        run_migrations(settings)
+
+
+def _write_fixture_wav(work_dir: Path) -> Path:
+    work_dir.mkdir(parents=True, exist_ok=True)
+    source_path = work_dir / FIXTURE_FILE_NAME
+    total_frames = int(FIXTURE_SAMPLE_RATE * FIXTURE_DURATION_SECONDS)
+    chord_frequencies = (
+        (261.63, 329.63, 392.0),
+        (196.0, 246.94, 293.66),
+        (220.0, 261.63, 329.63),
+        (174.61, 220.0, 261.63),
+    )
+
+    with wave.open(str(source_path), "wb") as output:
+        output.setnchannels(1)
+        output.setsampwidth(2)
+        output.setframerate(FIXTURE_SAMPLE_RATE)
+        frames = bytearray()
+        for frame_index in range(total_frames):
+            seconds = frame_index / FIXTURE_SAMPLE_RATE
+            chord = chord_frequencies[int(seconds // 4.0) % len(chord_frequencies)]
+            harmonic = sum(math.sin(2.0 * math.pi * frequency * seconds) for frequency in chord)
+            beat_phase = seconds % (60.0 / FIXTURE_BPM)
+            pulse = math.exp(-((beat_phase / 0.015) ** 2))
+            sample = (0.16 * harmonic) + (0.32 * pulse)
+            clipped = max(-0.95, min(0.95, sample))
+            frames.extend(struct.pack("<h", int(clipped * 32767)))
+        output.writeframes(frames)
+
+    return source_path
+
+
+def _import_or_get_project(
+    session: Session,
+    *,
+    source_path: Path,
+    project_name: str,
+) -> Project:
+    source_sha256 = file_sha256(source_path)
+    if source_sha256 is None:
+        raise PlaybackE2EFixtureCliError(f"could not hash fixture WAV: {source_path}")
+
+    expected_project_id = source_hash_to_project_id(source_sha256)
+    project = session.get(Project, expected_project_id)
+    if project is None or project.sync_status == "deleted":
+        project = import_project(
+            session,
+            source_path=str(source_path),
+            copy_into_project=True,
+            display_name=project_name,
+        )
+    project.display_name = project_name
+    return project
+
+
+def _source_artifact(session: Session, *, project_id: str) -> Artifact:
+    artifact = session.scalar(
+        select(Artifact)
+        .where(Artifact.project_id == project_id)
+        .where(Artifact.type == "source_audio")
+        .order_by(Artifact.created_at.desc(), Artifact.id.desc())
+    )
+    if artifact is None:
+        raise PlaybackE2EFixtureCliError(f"project {project_id} has no source_audio artifact")
+    return artifact
+
+
+def _seed_fixture_data(
+    session: Session,
+    *,
+    project: Project,
+    source_artifact: Artifact,
+) -> None:
+    _upsert_analysis(session, project=project, source_artifact=source_artifact)
+    _upsert_lyrics(session, project=project, source_artifact=source_artifact)
+    _upsert_chords(session, project=project, source_artifact=source_artifact)
+    _replace_sections(session, project=project)
+
+
+def _upsert_analysis(
+    session: Session,
+    *,
+    project: Project,
+    source_artifact: Artifact,
+) -> None:
+    analysis = session.get(AnalysisResult, project.id)
+    if analysis is None:
+        analysis = AnalysisResult(project_id=project.id)
+        session.add(analysis)
+
+    analysis.source_artifact_id = source_artifact.id
+    analysis.estimated_key = "C major"
+    analysis.key_confidence = 0.94
+    analysis.estimated_reference_hz = 440.0
+    analysis.tuning_offset_cents = 0.0
+    analysis.tempo_bpm = FIXTURE_BPM
+    analysis.timing_json = _timing_payload()
+    analysis.analysis_version = "fixture-v1"
+
+
+def _upsert_lyrics(
+    session: Session,
+    *,
+    project: Project,
+    source_artifact: Artifact,
+) -> None:
+    segments = _lyrics_segments()
+    lyrics = session.get(LyricsTranscript, project.id)
+    if lyrics is None:
+        lyrics = LyricsTranscript(project_id=project.id)
+        session.add(lyrics)
+
+    lyrics.backend = "fixture"
+    lyrics.source_artifact_id = source_artifact.id
+    lyrics.source_kind = "fixture"
+    lyrics.requested_device = None
+    lyrics.device = None
+    lyrics.model_name = "deterministic"
+    lyrics.language = "en"
+    lyrics.language_override = None
+    lyrics.source_segments_json = deepcopy(segments)
+    lyrics.segments_json = deepcopy(segments)
+    lyrics.has_user_edits = False
+
+
+def _upsert_chords(
+    session: Session,
+    *,
+    project: Project,
+    source_artifact: Artifact,
+) -> None:
+    segments = _chord_segments()
+    chords = session.get(ChordTimeline, project.id)
+    if chords is None:
+        chords = ChordTimeline(project_id=project.id)
+        session.add(chords)
+
+    chords.backend = "fixture"
+    chords.source_artifact_id = source_artifact.id
+    chords.source_segments_json = deepcopy(segments)
+    chords.segments_json = deepcopy(segments)
+    chords.timeline_json = deepcopy(segments)
+    chords.source_kind = "generated"
+    chords.metadata_json = {
+        "backend_id": "fixture",
+        "backend_label": "Deterministic Fixture",
+        "bpm": FIXTURE_BPM,
+    }
+    chords.has_user_edits = False
+
+
+def _replace_sections(session: Session, *, project: Project) -> None:
+    existing_sections = list(
+        session.scalars(
+            select(SongSection)
+            .where(SongSection.project_id == project.id)
+            .where(SongSection.source == "fixture")
+        )
+    )
+    for section in existing_sections:
+        session.delete(section)
+    session.flush()
+
+    for label, start_seconds, end_seconds in (
+        ("Intro", 0.0, 4.0),
+        ("Verse", 4.0, 16.0),
+        ("Chorus", 16.0, 28.0),
+        ("Bridge", 28.0, 34.0),
+        ("Outro", 34.0, FIXTURE_DURATION_SECONDS),
+    ):
+        session.add(
+            SongSection(
+                id=new_id("sec"),
+                project_id=project.id,
+                label=label,
+                start_seconds=start_seconds,
+                end_seconds=end_seconds,
+                source="fixture",
+                metadata_json={"fixture": True},
+            )
+        )
+
+
+def _timing_payload() -> dict[str, Any]:
+    beat_seconds = 60.0 / FIXTURE_BPM
+    total_beats = int(FIXTURE_DURATION_SECONDS / beat_seconds)
+    beats = [
+        {
+            "index": index,
+            "seconds": round(index * beat_seconds, 6),
+            "bar_index": index // BEATS_PER_BAR,
+            "beat_in_bar": (index % BEATS_PER_BAR) + 1,
+        }
+        for index in range(total_beats)
+    ]
+    bars = [
+        {
+            "index": bar_index,
+            "start_seconds": round(bar_index * BEATS_PER_BAR * beat_seconds, 6),
+            "end_seconds": round(
+                min((bar_index + 1) * BEATS_PER_BAR * beat_seconds, FIXTURE_DURATION_SECONDS),
+                6,
+            ),
+        }
+        for bar_index in range(math.ceil(total_beats / BEATS_PER_BAR))
+    ]
+    return {
+        "beats_per_bar": BEATS_PER_BAR,
+        "source": "fixture",
+        "meter": "4/4",
+        "meter_confidence": 1.0,
+        "downbeat_source": "fixture",
+        "downbeat_confidence": 1.0,
+        "beats": beats,
+        "bars": bars,
+    }
+
+
+def _lyrics_segments() -> list[dict[str, Any]]:
+    return [
+        _lyric_segment(0.5, 4.5, "Count in steady"),
+        _lyric_segment(4.5, 8.5, "Verse line one"),
+        _lyric_segment(8.5, 12.5, "Verse line two"),
+        _lyric_segment(12.5, 16.5, "Lift into chorus"),
+        _lyric_segment(16.5, 21.0, "Chorus anchor phrase"),
+        _lyric_segment(21.0, 25.5, "Chorus answer phrase"),
+        _lyric_segment(28.0, 32.5, "Bridge opens wide"),
+        _lyric_segment(34.0, 38.5, "Outro lands clean"),
+    ]
+
+
+def _lyric_segment(start_seconds: float, end_seconds: float, text: str) -> dict[str, Any]:
+    words = text.split()
+    word_duration = (end_seconds - start_seconds) / max(1, len(words))
+    return {
+        "start_seconds": start_seconds,
+        "end_seconds": end_seconds,
+        "text": text,
+        "words": [
+            {
+                "text": word,
+                "start_seconds": round(start_seconds + index * word_duration, 6),
+                "end_seconds": round(start_seconds + (index + 1) * word_duration, 6),
+                "confidence": 1.0,
+            }
+            for index, word in enumerate(words)
+        ],
+    }
+
+
+def _chord_segments() -> list[dict[str, Any]]:
+    progression = (
+        ("C", "C", 0, "major"),
+        ("G", "G", 7, "major"),
+        ("Am", "Am", 9, "minor"),
+        ("F", "F", 5, "major"),
+    )
+    segments: list[dict[str, Any]] = []
+    segment_seconds = 4.0
+    for index in range(int(FIXTURE_DURATION_SECONDS / segment_seconds)):
+        label, display_label, pitch_class, quality = progression[index % len(progression)]
+        start_seconds = index * segment_seconds
+        segments.append(
+            {
+                "start_seconds": start_seconds,
+                "end_seconds": min(start_seconds + segment_seconds, FIXTURE_DURATION_SECONDS),
+                "label": label,
+                "display_label": display_label,
+                "raw_label": label,
+                "confidence": 0.98,
+                "pitch_class": pitch_class,
+                "root_pitch_class": pitch_class,
+                "quality": quality,
+            }
+        )
+    return segments
+
+
+def _build_summary(
+    *,
+    project: Project,
+    data_dir: Path,
+    work_dir: Path,
+    source_path: Path,
+) -> dict[str, Any]:
+    return {
+        "app_url_path": f"/#/projects/{project.id}",
+        "bpm": FIXTURE_BPM,
+        "data_dir": str(data_dir),
+        "duration_seconds": project.duration_seconds or FIXTURE_DURATION_SECONDS,
+        "project_id": project.id,
+        "project_name": project.display_name,
+        "source_path": str(source_path),
+        "work_dir": str(work_dir),
+    }
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -5,6 +5,7 @@ import sys
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
+from urllib.parse import urlparse
 
 
 def _default_data_root() -> Path:
@@ -41,6 +42,7 @@ class Settings:
     lyrics_cache_dir: Path
     default_chord_backend: str
     runtime_platform: str
+    additional_cors_origins: tuple[str, ...]
     max_workers: int
     backend_root: Path
 
@@ -85,6 +87,9 @@ def get_settings() -> Settings:
         lyrics_cache_dir=Path(os.environ.get("TUNEFORGE_LYRICS_CACHE_DIR", str(cache_root / "lyrics"))),
         default_chord_backend=os.environ.get("TUNEFORGE_DEFAULT_CHORD_BACKEND", "tuneforge-fast"),
         runtime_platform=os.environ.get("TUNEFORGE_RUNTIME_PLATFORM", "desktop").strip().lower(),
+        additional_cors_origins=_parse_additional_cors_origins(
+            os.environ.get("TUNEFORGE_ADDITIONAL_CORS_ORIGINS", "")
+        ),
         max_workers=1,
         backend_root=backend_root,
     )
@@ -96,3 +101,32 @@ def ensure_data_dirs(settings: Settings | None = None) -> None:
     current.projects_root.mkdir(parents=True, exist_ok=True)
     current.cache_root.mkdir(parents=True, exist_ok=True)
     current.lyrics_cache_dir.mkdir(parents=True, exist_ok=True)
+
+
+def _parse_additional_cors_origins(value: str) -> tuple[str, ...]:
+    origins: list[str] = []
+    for raw_origin in value.split(","):
+        origin = raw_origin.strip().rstrip("/")
+        if not origin:
+            continue
+        if not _is_loopback_http_origin(origin):
+            raise ValueError(
+                "TUNEFORGE_ADDITIONAL_CORS_ORIGINS only accepts http://127.0.0.1:<port> "
+                "or http://localhost:<port> origins."
+            )
+        if origin not in origins:
+            origins.append(origin)
+    return tuple(origins)
+
+
+def _is_loopback_http_origin(origin: str) -> bool:
+    parsed = urlparse(origin)
+    if parsed.scheme != "http" or parsed.hostname not in {"127.0.0.1", "localhost"}:
+        return False
+    try:
+        port = parsed.port
+    except ValueError:
+        return False
+    if port is None:
+        return False
+    return not parsed.path and not parsed.params and not parsed.query and not parsed.fragment

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -26,6 +26,12 @@ from app.services.jobs import InProcessJobRunner
 
 logger = logging.getLogger("tuneforge.startup")
 
+DEFAULT_CORS_ORIGINS = (
+    "http://127.0.0.1:1420",
+    "http://localhost:1420",
+    "tauri://localhost",
+)
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -48,14 +54,11 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(title="Tuneforge API", version=__version__, lifespan=lifespan)
+settings = get_settings()
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://127.0.0.1:1420",
-        "http://localhost:1420",
-        "tauri://localhost",
-    ],
+    allow_origins=[*DEFAULT_CORS_ORIGINS, *settings.additional_cors_origins],
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -80,11 +83,11 @@ async def validation_error_handler(_: Request, exc: RequestValidationError) -> J
     return JSONResponse(status_code=422, content=payload.model_dump())
 
 
-app.include_router(health_router, prefix=get_settings().api_prefix)
-app.include_router(beat_backends_router, prefix=get_settings().api_prefix)
-app.include_router(chord_backends_router, prefix=get_settings().api_prefix)
-app.include_router(stem_models_router, prefix=get_settings().api_prefix)
-app.include_router(projects_router, prefix=get_settings().api_prefix)
-app.include_router(jobs_router, prefix=get_settings().api_prefix)
-app.include_router(artifacts_router, prefix=get_settings().api_prefix)
-app.include_router(sync_router, prefix=get_settings().api_prefix)
+app.include_router(health_router, prefix=settings.api_prefix)
+app.include_router(beat_backends_router, prefix=settings.api_prefix)
+app.include_router(chord_backends_router, prefix=settings.api_prefix)
+app.include_router(stem_models_router, prefix=settings.api_prefix)
+app.include_router(projects_router, prefix=settings.api_prefix)
+app.include_router(jobs_router, prefix=settings.api_prefix)
+app.include_router(artifacts_router, prefix=settings.api_prefix)
+app.include_router(sync_router, prefix=settings.api_prefix)

--- a/apps/backend/tests/test_config.py
+++ b/apps/backend/tests/test_config.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+from app.config import _parse_additional_cors_origins
+
+
+def test_additional_cors_origins_accepts_loopback_http_origins() -> None:
+    assert _parse_additional_cors_origins(
+        "http://127.0.0.1:5173, http://localhost:1420/"
+    ) == (
+        "http://127.0.0.1:5173",
+        "http://localhost:1420",
+    )
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "https://127.0.0.1:5173",
+        "http://0.0.0.0:5173",
+        "http://example.com:5173",
+        "http://127.0.0.1:5173/path",
+        "http://127.0.0.1:999999",
+        "http://127.0.0.1",
+    ],
+)
+def test_additional_cors_origins_rejects_non_loopback_http_origins(origin: str) -> None:
+    with pytest.raises(ValueError):
+        _parse_additional_cors_origins(origin)

--- a/apps/backend/tests/test_playback_e2e_fixture.py
+++ b/apps/backend/tests/test_playback_e2e_fixture.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+
+from app.cli import playback_e2e_fixture
+from app.models import AnalysisResult, Artifact, ChordTimeline, LyricsTranscript, Project, SongSection
+
+
+def test_create_playback_e2e_fixture_seeds_project_data(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    data_dir = tmp_path / "fixture-data"
+    work_dir = tmp_path / "fixture-work"
+
+    exit_code = playback_e2e_fixture.main(
+        [
+            "create",
+            "--data-dir",
+            str(data_dir),
+            "--work-dir",
+            str(work_dir),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload["project_name"] == "Tuneforge E2E Fixture"
+    assert payload["duration_seconds"] > 30.0
+    assert payload["bpm"] == 120.0
+    assert payload["data_dir"] == str(data_dir.resolve())
+    assert payload["work_dir"] == str(work_dir.resolve())
+    assert payload["source_path"] == str((work_dir / "tuneforge-e2e-fixture.wav").resolve())
+    assert payload["app_url_path"] == f"/#/projects/{payload['project_id']}"
+    assert Path(payload["source_path"]).exists()
+    assert (data_dir / "app.sqlite").exists()
+
+    from app.db import SessionLocal
+
+    with SessionLocal() as session:
+        project = session.get(Project, payload["project_id"])
+        assert project is not None
+        assert project.display_name == payload["project_name"]
+        assert project.duration_seconds == pytest.approx(payload["duration_seconds"])
+        assert project.duration_seconds is not None
+        assert project.duration_seconds > 30.0
+
+        source_artifact = session.scalar(
+            select(Artifact)
+            .where(Artifact.project_id == project.id)
+            .where(Artifact.type == "source_audio")
+        )
+        assert source_artifact is not None
+        assert source_artifact.format == "wav"
+        assert source_artifact.generated_by == "import"
+        assert source_artifact.can_delete is False
+        assert source_artifact.can_regenerate is False
+        assert source_artifact.content_sha256
+        assert source_artifact.metadata_json["source_path"] == payload["source_path"]
+        assert Path(source_artifact.path).exists()
+
+        analysis = session.get(AnalysisResult, project.id)
+        assert analysis is not None
+        assert analysis.source_artifact_id == source_artifact.id
+        assert analysis.tempo_bpm == 120.0
+        assert analysis.analysis_version == "fixture-v1"
+        timing = analysis.timing_json
+        assert timing is not None
+        assert timing["source"] == "fixture"
+        assert timing["beats_per_bar"] == 4
+        assert len(timing["beats"]) >= 64
+        assert len(timing["bars"]) >= 16
+        assert timing["beats"][0] == {
+            "index": 0,
+            "seconds": 0.0,
+            "bar_index": 0,
+            "beat_in_bar": 1,
+        }
+
+        lyrics = session.get(LyricsTranscript, project.id)
+        assert lyrics is not None
+        assert lyrics.source_artifact_id == source_artifact.id
+        assert lyrics.backend == "fixture"
+        assert lyrics.has_user_edits is False
+        assert lyrics.source_segments_json == lyrics.segments_json
+        assert len(lyrics.segments_json) >= 8
+        assert all(
+            segment["end_seconds"] - segment["start_seconds"] > 3.0
+            for segment in lyrics.segments_json
+        )
+        assert lyrics.segments_json[0]["words"][0]["text"] == "Count"
+
+        chords = session.get(ChordTimeline, project.id)
+        assert chords is not None
+        assert chords.source_artifact_id == source_artifact.id
+        assert chords.backend == "fixture"
+        assert chords.timeline_json == chords.segments_json
+        assert len(chords.segments_json) >= 8
+        assert chords.segments_json[0]["label"] == "C"
+        assert chords.segments_json[1]["label"] == "G"
+        assert all(
+            segment["end_seconds"] > segment["start_seconds"]
+            for segment in chords.segments_json
+        )
+
+        sections = list(
+            session.scalars(
+                select(SongSection)
+                .where(SongSection.project_id == project.id)
+                .order_by(SongSection.start_seconds)
+            )
+        )
+        assert [section.label for section in sections] == [
+            "Intro",
+            "Verse",
+            "Chorus",
+            "Bridge",
+            "Outro",
+        ]
+        assert sections[0].start_seconds == 0.0
+        assert sections[-1].end_seconds == pytest.approx(project.duration_seconds)

--- a/docs/NATIVE_AUDIO.md
+++ b/docs/NATIVE_AUDIO.md
@@ -124,13 +124,14 @@ Run once with native playback selected per platform, then rerun with forced Web 
 
 ## Local-only Playwright Smoke Harness
 
-Scaffold file: `scripts/playback-smoke.mjs` (local only, not wired to CI). This is a browser-based
-smoke check for the frontend transport path; native output still needs the manual matrix above.
-When the app exposes `window.__TUNEFORGE_PLAYBACK_E2E__.read()`, the smoke pass also polls that
-local telemetry bridge. It asserts song-start count-in scheduling/firing before loop setup, loop
-pre-count scheduling/firing during loop playback, and native transport/buffer health only when the
-telemetry reports native playback is the active path. Forced Web Audio and browser fallback runs
-continue to pass by skipping native-only buffer assertions.
+Scaffold file: `scripts/playback-smoke.mjs` (local only, not wired to CI or default gates). This is
+a browser-based smoke check for the frontend transport path; native output still needs the manual
+matrix above. The automated path uses generated fixture audio only; do not use copyrighted audio.
+The isolated smoke pass requires `window.__TUNEFORGE_PLAYBACK_E2E__.read()` and asserts song-start
+count-in scheduling/firing before loop setup, loop pre-count scheduling/firing during loop playback,
+and transport telemetry. Native transport/buffer health is checked only when telemetry reports native
+playback is the active path. Manual app mode remains backward-compatible and skips telemetry-only
+assertions when that bridge is unavailable.
 
 `pnpm setup:dev` installs the Playwright Chromium browser needed by this smoke check; use
 `pnpm setup:dev -- --skip-playwright-browsers` to skip that download.
@@ -141,16 +142,29 @@ Check that the local smoke scaffold is available:
 pnpm --filter @tuneforge/desktop test:e2e
 ```
 
-Start the dev app first with `pnpm dev`, or `pnpm dev:desktop` when the backend is already
-running. Then execute the smoke pass with the visible project name from the library:
+Run the isolated smoke pass:
 
 ```sh
-pnpm --filter @tuneforge/desktop test:e2e -- --run --project-name="Demo Song"
+pnpm --filter @tuneforge/desktop test:e2e -- --run
 ```
+
+The isolated run prepares temporary app data and a temporary database, creates a deterministic
+generated fixture project, starts the backend and frontend, runs the smoke flow, then cleans the
+temporary data by default. Use `--keep-artifacts` to retain temporary paths and logs for debugging.
+If a local port is already in use, pass `--backend-port=<port>` or `--app-port=<port>`. The isolated
+backend allows only the selected loopback frontend origin so browser CORS stays enabled.
+
+To run against an existing personal library or a pre-running app, opt into manual app mode and pass
+the project selector explicitly:
+
+```sh
+pnpm --filter @tuneforge/desktop test:e2e -- --run --manual-app --project-name="Demo Song"
+pnpm --filter @tuneforge/desktop test:e2e -- --run --manual-app --project-id=<id>
+```
+
+Manual app mode requires the app to already be running. Use it only when you need an existing
+personal project instead of the generated fixture.
 
 For full coverage, use a fixture project with timed lyrics or chords. The smoke pass always checks
 stopped scrubber start, and it also checks stopped lyrics/chords start when a timed practice target
 is available. It remains a local/manual diagnostic, not a CI gate and not part of `pnpm test`.
-
-If you already know the project ID, `--project-id=<id>` opens the project route directly.
-Set `TUNEFORGE_SMOKE_APP_URL` if the desktop frontend is not on `http://127.0.0.1:1420`.

--- a/scripts/playback-smoke.mjs
+++ b/scripts/playback-smoke.mjs
@@ -1,55 +1,199 @@
 #!/usr/bin/env node
 
 import process from "node:process";
+import net from "node:net";
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 
 const desktopRequire = createRequire(new URL("../apps/desktop/package.json", import.meta.url));
+const repoRoot = fileURLToPath(new URL("../", import.meta.url));
+const DEFAULT_MANUAL_APP_URL = "http://127.0.0.1:1420";
+const DEFAULT_STARTUP_TIMEOUT_MS = 45_000;
+const CHILD_TAIL_LINES = 40;
 
-const appUrl = process.env.TUNEFORGE_SMOKE_APP_URL || "http://127.0.0.1:1420";
-const projectId = readOption("project-id") || process.env.TUNEFORGE_SMOKE_PROJECT_ID || "";
-const projectName = readOption("project-name") || process.env.TUNEFORGE_SMOKE_PROJECT_NAME || "";
-const run = process.argv.includes("--run");
-const headed = process.argv.includes("--headed");
+try {
+  await main();
+} catch (error) {
+  console.error(`[playback-smoke] ${errorMessage(error)}`);
+  process.exitCode = 1;
+}
 
-if (!run) {
+async function main() {
+  const options = parseOptions(process.argv.slice(2));
+  if (!options.run) {
+    printScaffold();
+    return;
+  }
+
+  if (options.manualApp) {
+    await runManualSmoke(options);
+    return;
+  }
+
+  if (options.projectId) {
+    throw new Error(
+      [
+        "Isolated playback smoke creates its own fixture project.",
+        'Use manual mode for an existing project: pnpm --filter @tuneforge/desktop test:e2e -- --run --manual-app --project-id="<id>"',
+      ].join("\n"),
+    );
+  }
+
+  await runIsolatedSmoke(options);
+}
+
+function printScaffold() {
   console.log("[playback-smoke] Local smoke scaffold is available.");
-  console.log("Start the desktop dev frontend, then run:");
+  console.log("Run isolated smoke with generated fixture data:");
+  console.log("  pnpm --filter @tuneforge/desktop test:e2e -- --run");
+  console.log("Run against an existing personal library app:");
   console.log(
-    '  pnpm --filter @tuneforge/desktop test:e2e -- --run --project-name="Demo Song"',
+    '  pnpm --filter @tuneforge/desktop test:e2e -- --run --manual-app --project-name="Demo Song"',
   );
-  process.exit(0);
 }
 
-if (!projectId && !projectName) {
-  console.error(
-    "[playback-smoke] Missing --project-name/--project-id or TUNEFORGE_SMOKE_PROJECT_NAME/TUNEFORGE_SMOKE_PROJECT_ID.",
-  );
-  process.exit(1);
+async function runManualSmoke(options) {
+  if (!options.projectId && !options.projectName) {
+    throw new Error(
+      [
+        "Manual app smoke requires --project-id or --project-name.",
+        'Example: pnpm --filter @tuneforge/desktop test:e2e -- --run --manual-app --project-name="Demo Song"',
+      ].join("\n"),
+    );
+  }
+
+  await runSmoke({
+    appUrl: options.appUrl,
+    projectId: options.projectId,
+    projectName: options.projectName,
+    headed: options.headed,
+    requireTelemetry: false,
+  });
 }
 
-let chromium;
-try {
-  ({ chromium } = desktopRequire("playwright"));
-} catch {
-  console.error("[playback-smoke] Playwright is not installed locally.");
-  console.error("  pnpm setup:dev");
-  console.error("or:");
-  console.error("  pnpm install");
-  console.error("  pnpm --filter @tuneforge/desktop exec playwright install chromium");
-  process.exit(1);
+async function runIsolatedSmoke(options) {
+  const appPort = await selectPort(options.appPort, new Set(), "desktop dev server");
+  const backendPort = await selectPort(options.backendPort, new Set([appPort]), "backend");
+  const tempRoot = await mkdtemp(join(tmpdir(), "tuneforge-playback-smoke-"));
+  const dataDir = join(tempRoot, "data");
+  const workDir = join(tempRoot, "work");
+  const children = [];
+  let fixture = null;
+
+  try {
+    await mkdir(dataDir, { recursive: true });
+    await mkdir(workDir, { recursive: true });
+    logStep(`Using temp root ${tempRoot}.`);
+    fixture = await createPlaybackFixture({ dataDir, workDir, projectName: options.projectName });
+    logStep(
+      `Seeded fixture project ${fixture.project_id} (${fixture.project_name ?? "unnamed"}) in ${dataDir}.`,
+    );
+
+    const backendUrl = `http://127.0.0.1:${backendPort}`;
+    const appUrl = `http://127.0.0.1:${appPort}`;
+    const backend = startChild("backend", "bash", [
+      "scripts/run-backend-module.sh",
+      "uvicorn",
+      "app.main:app",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(backendPort),
+    ], {
+      TUNEFORGE_DATA_DIR: dataDir,
+      TUNEFORGE_HOST: "127.0.0.1",
+      TUNEFORGE_PORT: String(backendPort),
+      TUNEFORGE_ADDITIONAL_CORS_ORIGINS: appUrl,
+      PYTHONUNBUFFERED: "1",
+    });
+    children.push(backend);
+    await waitForHttp(`${backendUrl}/api/v1/health`, {
+      label: "backend health",
+      child: backend,
+      timeoutMs: DEFAULT_STARTUP_TIMEOUT_MS,
+    });
+    logStep(`Backend ready on ${backendUrl}.`);
+
+    const app = startChild("desktop dev server", "pnpm", [
+      "--filter",
+      "@tuneforge/desktop",
+      "dev",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(appPort),
+      "--strictPort",
+    ], {
+      VITE_API_BASE_URL: backendUrl,
+    });
+    children.push(app);
+    await waitForHttp(appUrl, {
+      label: "desktop dev server",
+      child: app,
+      timeoutMs: DEFAULT_STARTUP_TIMEOUT_MS,
+    });
+    logStep(`Desktop dev server ready on ${appUrl}.`);
+
+    const fixturePath = fixture.app_url_path || `/#/projects/${fixture.project_id}`;
+    await runSmoke({
+      appUrl,
+      projectId: fixture.project_id,
+      projectName: fixture.project_name ?? "",
+      projectUrl: appendAppPath(appUrl, fixturePath),
+      headed: options.headed,
+      requireTelemetry: true,
+    });
+  } finally {
+    await stopChildren(children);
+    if (options.keepArtifacts) {
+      logStep(`Kept artifacts at ${tempRoot}.`);
+    } else {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  }
 }
 
-const browser = await chromium.launch({ headless: !headed });
+async function runSmoke({
+  appUrl,
+  projectId,
+  projectName,
+  projectUrl = "",
+  headed,
+  requireTelemetry = false,
+}) {
+  let chromium;
+  try {
+    ({ chromium } = desktopRequire("playwright"));
+  } catch {
+    throw new Error(
+      [
+        "Playwright is not installed locally.",
+        "  pnpm setup:dev",
+        "or:",
+        "  pnpm install",
+        "  pnpm --filter @tuneforge/desktop exec playwright install chromium",
+      ].join("\n"),
+    );
+  }
 
-try {
+  const browser = await chromium.launch({ headless: !headed });
+
+  try {
   const page = await browser.newPage();
   logStep(
-    `Running ${headed ? "headed" : "headless"} smoke against ${appUrl} (${projectId ? `project ${projectId}` : `project "${projectName}"`}).`,
+    `Running ${headed ? "headed" : "headless"} smoke against ${projectUrl || appUrl} (${projectId ? `project ${projectId}` : `project "${projectName}"`}).`,
   );
-  await openProject(page, { appUrl, projectId, projectName });
+  await openProject(page, { appUrl, projectId, projectName, projectUrl });
   await page.getByRole("heading", { name: /.+/ }).first().waitFor();
   logStep("Project opened.");
   await openPlayback(page);
+  if (requireTelemetry) {
+    await assertPlaybackE2EBridge(page);
+  }
   await resetSmokePlaybackState(page);
 
   const durationSeconds = await readPlaybackDuration(page);
@@ -80,6 +224,7 @@ try {
     expectedKind: "song-start",
     expectedStartSeconds: 0,
     label: "song-start pre-count",
+    requireTelemetry,
   });
   await page.getByRole("button", { name: "Pause playback" }).waitFor({ timeout: 5000 });
   await page.getByRole("button", { name: "Stop playback" }).click();
@@ -122,6 +267,7 @@ try {
     expectedKind: "loop-start",
     expectedStartSeconds: loopStartSeconds,
     label: "loop pre-count",
+    requireTelemetry,
   });
   if (loopCountInTelemetryAsserted) {
     logStep("Loop pre-count telemetry passed.");
@@ -132,6 +278,7 @@ try {
     expectedLoopStartSeconds: loopStartSeconds,
     expectedState: "playing",
     label: "loop playback",
+    requireTelemetry,
   });
   await page.getByRole("button", { name: "Pause playback" }).click();
   await page.getByRole("button", { name: "Play playback" }).click();
@@ -140,16 +287,389 @@ try {
   await expectPosition(page, loopStartSeconds, "after stop with active loop");
   logStep("Play, pause, resume, and stop passed.");
   logStep("Passed.");
-} catch (error) {
-  console.error(`[playback-smoke] ${errorMessage(error)}`);
-  process.exitCode = 1;
 } finally {
   await browser.close();
 }
+}
 
-function readOption(name) {
-  const prefix = `--${name}=`;
-  return process.argv.find((arg) => arg.startsWith(prefix))?.slice(prefix.length) ?? "";
+function parseOptions(argv) {
+  const parsed = parseCliArgs(argv);
+  const manualApp = readFlag(parsed, "manual-app");
+  const projectId = readStringOption(parsed, "project-id")
+    || (manualApp ? process.env.TUNEFORGE_SMOKE_PROJECT_ID || "" : "");
+  const projectName = readStringOption(parsed, "project-name")
+    || process.env.TUNEFORGE_SMOKE_PROJECT_NAME
+    || "";
+
+  return {
+    run: readFlag(parsed, "run"),
+    manualApp,
+    keepArtifacts: readFlag(parsed, "keep-artifacts"),
+    headed: readFlag(parsed, "headed"),
+    backendPort: readPortOption(parsed, "backend-port"),
+    appPort: readPortOption(parsed, "app-port"),
+    appUrl: readStringOption(parsed, "app-url")
+      || process.env.TUNEFORGE_SMOKE_APP_URL
+      || DEFAULT_MANUAL_APP_URL,
+    projectId,
+    projectName,
+  };
+}
+
+function parseCliArgs(argv) {
+  const flags = new Set();
+  const values = new Map();
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith("--")) {
+      continue;
+    }
+
+    const body = arg.slice(2);
+    const equalsIndex = body.indexOf("=");
+    if (equalsIndex >= 0) {
+      values.set(body.slice(0, equalsIndex), body.slice(equalsIndex + 1));
+      continue;
+    }
+
+    const next = argv[index + 1];
+    if (next && !next.startsWith("--")) {
+      values.set(body, next);
+      index += 1;
+      continue;
+    }
+
+    flags.add(body);
+  }
+
+  return { flags, values };
+}
+
+function readFlag(parsed, name) {
+  if (parsed.flags.has(name)) {
+    return true;
+  }
+  const value = parsed.values.get(name);
+  return value === "true" || value === "1";
+}
+
+function readStringOption(parsed, name) {
+  return parsed.values.get(name)?.trim() ?? "";
+}
+
+function readPortOption(parsed, name) {
+  const value = readStringOption(parsed, name);
+  return value ? parsePort(value, name) : null;
+}
+
+function parsePort(value, name) {
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(`Invalid --${name} value "${value}". Expected TCP port 1-65535.`);
+  }
+  return port;
+}
+
+async function selectPort(preferredPort, excludedPorts, label) {
+  if (preferredPort !== null) {
+    if (excludedPorts.has(preferredPort)) {
+      throw new Error(`Port ${preferredPort} conflicts with another smoke process port.`);
+    }
+    await assertPortAvailable(preferredPort, label);
+    return preferredPort;
+  }
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const port = await getFreePort();
+    if (!excludedPorts.has(port) && port !== 8765 && port !== 1420) {
+      return port;
+    }
+  }
+
+  throw new Error("Could not allocate a free local port for isolated playback smoke.");
+}
+
+async function getFreePort() {
+  const server = net.createServer();
+  server.unref();
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      server.close(() => {
+        if (address && typeof address === "object") {
+          resolve(address.port);
+          return;
+        }
+        reject(new Error("Could not inspect allocated local port."));
+      });
+    });
+  });
+}
+
+async function assertPortAvailable(port, label) {
+  const server = net.createServer();
+  server.unref();
+  const available = await new Promise((resolve) => {
+    server.once("error", () => resolve(false));
+    server.listen(port, "127.0.0.1", () => {
+      server.close(() => resolve(true));
+    });
+  });
+
+  if (!available) {
+    throw new Error(
+      [
+        `Port ${port} is already in use for the ${label}.`,
+        `Pass --${label === "backend" ? "backend" : "app"}-port=<free-port> or use --manual-app against a pre-running app.`,
+      ].join("\n"),
+    );
+  }
+}
+
+async function createPlaybackFixture({ dataDir, workDir, projectName }) {
+  const args = [
+    "scripts/run-backend-module.sh",
+    "app.cli.playback_e2e_fixture",
+    "create",
+    "--data-dir",
+    dataDir,
+    "--work-dir",
+    workDir,
+  ];
+  if (projectName) {
+    args.push("--project-name", projectName);
+  }
+
+  const result = await runCommand("fixture seed", "bash", args, {
+    env: {
+      TUNEFORGE_DATA_DIR: dataDir,
+      PYTHONUNBUFFERED: "1",
+    },
+    timeoutMs: DEFAULT_STARTUP_TIMEOUT_MS,
+  });
+  const fixture = parseJsonOutput(result.stdout, "fixture seed");
+
+  if (!fixture || typeof fixture !== "object" || typeof fixture.project_id !== "string") {
+    throw new Error("Fixture seed did not return JSON with project_id.");
+  }
+  return fixture;
+}
+
+function parseJsonOutput(stdout, label) {
+  const trimmed = stdout.trim();
+  if (!trimmed) {
+    throw new Error(`${label} did not write JSON to stdout.`);
+  }
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const lines = trimmed.split(/\r?\n/).reverse();
+    for (const line of lines) {
+      try {
+        return JSON.parse(line);
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  throw new Error(`${label} stdout was not valid JSON:\n${trimmed}`);
+}
+
+async function runCommand(label, command, args, { env = {}, timeoutMs = DEFAULT_STARTUP_TIMEOUT_MS } = {}) {
+  const child = spawn(command, args, {
+    cwd: repoRoot,
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: process.platform !== "win32",
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout?.on("data", (chunk) => {
+    stdout += chunk.toString();
+  });
+  child.stderr?.on("data", (chunk) => {
+    stderr += chunk.toString();
+  });
+
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    killChild(child, "SIGTERM");
+  }, timeoutMs);
+
+  const exit = await new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+  }).finally(() => clearTimeout(timeout));
+
+  if (timedOut) {
+    killChild(child, "SIGKILL");
+    throw new Error(`${label} timed out after ${timeoutMs}ms.\n${stderr.trim()}`);
+  }
+  if (exit.code !== 0) {
+    throw new Error(
+      [
+        `${label} failed with exit code ${exit.code ?? "null"}${exit.signal ? ` signal ${exit.signal}` : ""}.`,
+        stderr.trim(),
+      ].filter(Boolean).join("\n"),
+    );
+  }
+
+  return { stdout, stderr };
+}
+
+function startChild(label, command, args, env = {}) {
+  const child = spawn(command, args, {
+    cwd: repoRoot,
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: process.platform !== "win32",
+  });
+  const handle = {
+    label,
+    child,
+    tail: [],
+    spawnError: null,
+    exit: null,
+    exitPromise: null,
+  };
+
+  handle.exitPromise = new Promise((resolve) => {
+    let settled = false;
+    const finish = (exit) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      handle.exit = exit;
+      resolve(exit);
+    };
+
+    child.once("error", (error) => {
+      handle.spawnError = error;
+      pushChildTail(handle, error.message);
+      finish({ code: null, signal: null });
+    });
+    child.once("exit", (code, signal) => finish({ code, signal }));
+  });
+
+  child.stdout?.on("data", (chunk) => pushChildTail(handle, chunk.toString()));
+  child.stderr?.on("data", (chunk) => pushChildTail(handle, chunk.toString()));
+  return handle;
+}
+
+async function waitForHttp(url, { label, child, timeoutMs }) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = "";
+
+  while (Date.now() <= deadline) {
+    throwIfChildExited(child, label);
+    try {
+      const response = await fetch(url, {
+        cache: "no-store",
+        signal: AbortSignal.timeout(1500),
+      });
+      if (response.ok) {
+        return;
+      }
+      lastError = `${response.status} ${response.statusText}`;
+    } catch (error) {
+      lastError = errorMessage(error);
+    }
+
+    await delay(250);
+  }
+
+  throw new Error(
+    [
+      `Timed out waiting for ${label} at ${url}.`,
+      lastError ? `Last error: ${lastError}` : "",
+      formatChildTail(child),
+    ].filter(Boolean).join("\n"),
+  );
+}
+
+function throwIfChildExited(handle, label) {
+  if (handle.spawnError) {
+    throw new Error(`${label} failed to start: ${handle.spawnError.message}`);
+  }
+  if (handle.exit) {
+    throw new Error(
+      [
+        `${label} exited before becoming ready with code ${handle.exit.code ?? "null"}${handle.exit.signal ? ` signal ${handle.exit.signal}` : ""}.`,
+        formatChildTail(handle),
+      ].filter(Boolean).join("\n"),
+    );
+  }
+}
+
+async function stopChildren(children) {
+  await Promise.all(children.slice().reverse().map((child) => stopChild(child)));
+}
+
+async function stopChild(handle) {
+  if (handle.exit || !handle.child.pid) {
+    return;
+  }
+
+  killChild(handle.child, "SIGTERM");
+  await Promise.race([handle.exitPromise, delay(3000)]);
+  if (!handle.exit) {
+    killChild(handle.child, "SIGKILL");
+    await Promise.race([handle.exitPromise, delay(1000)]);
+  }
+}
+
+function killChild(child, signal) {
+  if (!child.pid) {
+    return;
+  }
+
+  try {
+    if (process.platform !== "win32") {
+      process.kill(-child.pid, signal);
+      return;
+    }
+  } catch {
+    // Fall through to direct child kill.
+  }
+
+  try {
+    child.kill(signal);
+  } catch {
+    // Process already exited.
+  }
+}
+
+function pushChildTail(handle, output) {
+  const lines = output.split(/\r?\n/).filter(Boolean);
+  handle.tail.push(...lines);
+  if (handle.tail.length > CHILD_TAIL_LINES) {
+    handle.tail.splice(0, handle.tail.length - CHILD_TAIL_LINES);
+  }
+}
+
+function formatChildTail(handle) {
+  if (!handle?.tail?.length) {
+    return "";
+  }
+  return `${handle.label} output:\n${handle.tail.join("\n")}`;
+}
+
+function appendAppPath(appUrl, path) {
+  const base = appUrl.replace(/\/$/, "");
+  if (!path) {
+    return base;
+  }
+  return `${base}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function logStep(message) {
@@ -160,10 +680,15 @@ function formatSeconds(value) {
   return `${value.toFixed(3)}s`;
 }
 
-async function openProject(page, { appUrl, projectId, projectName }) {
+async function openProject(page, { appUrl, projectId, projectName, projectUrl = "" }) {
+  if (projectUrl) {
+    await gotoApp(page, projectUrl);
+    return;
+  }
+
   const baseUrl = appUrl.replace(/\/$/, "");
   if (projectId) {
-    await gotoApp(page, `${baseUrl}/projects/${projectId}`);
+    await gotoApp(page, appendAppPath(baseUrl, `/#/projects/${projectId}`));
     return;
   }
 
@@ -307,6 +832,23 @@ async function readPlaybackE2EState(page) {
     const value = bridge.read();
     return value && typeof value.then === "function" ? await value : value;
   });
+}
+
+async function assertPlaybackE2EBridge(page) {
+  const telemetry = await readPlaybackE2EDiagnostic(page);
+  if (!telemetry.available) {
+    throw new Error(
+      "Isolated playback smoke requires window.__TUNEFORGE_PLAYBACK_E2E__.read(), but the bridge was unavailable.",
+    );
+  }
+  if (telemetry.error) {
+    throw new Error(`Playback E2E telemetry bridge read failed: ${telemetry.error}`);
+  }
+  if (!telemetry.snapshot || typeof telemetry.snapshot !== "object") {
+    throw new Error(
+      `Playback E2E telemetry bridge returned no snapshot: ${formatTelemetryState(telemetry.snapshot)}.`,
+    );
+  }
 }
 
 async function waitForPlaybackStartFromSelection(page, minimumPositionSeconds, label, options = {}) {
@@ -468,6 +1010,7 @@ function formatDiagnosticValue(value) {
 async function waitForPlaybackE2EState(page, label, predicate, options = {}) {
   const timeout = options.timeout ?? 3500;
   const pollInterval = options.pollInterval ?? 100;
+  const requireTelemetry = options.requireTelemetry === true;
   const deadline = Date.now() + timeout;
   let lastState = null;
   let bridgeWasAvailable = false;
@@ -485,6 +1028,10 @@ async function waitForPlaybackE2EState(page, label, predicate, options = {}) {
   }
 
   if (!bridgeWasAvailable) {
+    const message = `${label} telemetry bridge unavailable. Isolated playback smoke requires window.__TUNEFORGE_PLAYBACK_E2E__.read().`;
+    if (requireTelemetry) {
+      throw new Error(message);
+    }
     logStep(`Skipped ${label}; playback E2E telemetry bridge unavailable.`);
     return null;
   }
@@ -494,7 +1041,10 @@ async function waitForPlaybackE2EState(page, label, predicate, options = {}) {
   );
 }
 
-async function assertCountInTelemetry(page, { expectedKind, expectedStartSeconds, label }) {
+async function assertCountInTelemetry(
+  page,
+  { expectedKind, expectedStartSeconds, label, requireTelemetry = false },
+) {
   const scheduledState = await waitForPlaybackE2EState(
     page,
     `${label} schedule`,
@@ -510,7 +1060,7 @@ async function assertCountInTelemetry(page, { expectedKind, expectedStartSeconds
       }
       return true;
     },
-    { timeout: 2500 },
+    { timeout: 2500, requireTelemetry },
   );
   if (!scheduledState) {
     return false;
@@ -568,7 +1118,7 @@ async function assertCountInTelemetry(page, { expectedKind, expectedStartSeconds
       const firedSequence = firstNumberField(fired, ["sequence"]);
       return scheduledSequence === null || firedSequence === null || firedSequence === scheduledSequence;
     },
-    { timeout: 5000 },
+    { timeout: 5000, requireTelemetry },
   );
   if (!firedState) {
     return false;
@@ -593,13 +1143,13 @@ async function assertCountInTelemetry(page, { expectedKind, expectedStartSeconds
 
 async function assertPlaybackTransportTelemetry(
   page,
-  { expectedLoopEndSeconds, expectedLoopStartSeconds, expectedState, label },
+  { expectedLoopEndSeconds, expectedLoopStartSeconds, expectedState, label, requireTelemetry = false },
 ) {
   const state = await waitForPlaybackE2EState(
     page,
     `${label} transport`,
     (candidate) => isNativePlaybackActive(candidate) || isWebPlaybackActive(candidate),
-    { timeout: 2500 },
+    { timeout: 2500, requireTelemetry },
   );
   if (!state) {
     return;


### PR DESCRIPTION
## Summary
- Add deterministic generated playback fixture seeding for isolated E2E smoke runs.
- Make playback smoke default to temp app data, temp DB, local backend/frontend, and cleanup.
- Keep existing-library smoke behind explicit manual-app opt-in, with loopback-only CORS for random local ports.

Fixes #224

## Testing
- `git diff --check HEAD~1..HEAD`
- `node --check scripts/playback-smoke.mjs`
- `UV_CACHE_DIR=$PWD/.uv-cache uv run --python 3.11 pytest tests/test_playback_e2e_fixture.py tests/test_config.py`
- `UV_CACHE_DIR=$PWD/.uv-cache uv run --python 3.11 ruff check app tests/test_config.py tests/test_playback_e2e_fixture.py`
- `UV_CACHE_DIR=$PWD/.uv-cache uv run --python 3.11 mypy app`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test --run`
- `pnpm --filter @tuneforge/desktop test:e2e`
- `pnpm --filter @tuneforge/desktop test:e2e -- --run`
