### PR TITLE
fix: use torch cache for demucs dev setup

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -141,7 +141,7 @@ All configuration is environment-driven (see [`app/config.py`](./app/config.py))
 | `TUNEFORGE_FFPROBE_PATH` | `ffprobe` | Override the `ffprobe` binary location. |
 | `TUNEFORGE_STEM_MODEL` | `htdemucs_6s` | Default Demucs model used for stem separation. |
 | `TUNEFORGE_STEM_DEVICE` | `auto` | One of `auto`, `cpu`, `mps`, `cuda`. `auto` prefers compatible CUDA, then MPS, then CPU. |
-| `TUNEFORGE_DEMUCS_MODEL_REPO` | unset | Local Demucs model repo containing packaged `.yaml` and `.th` files. `pnpm setup:dev` and packaged desktop builds set this automatically so stem weights are never downloaded at runtime. |
+| `TUNEFORGE_DEMUCS_MODEL_REPO` | unset | Optional local Demucs model repo containing packaged `.yaml` and `.th` files. When unset, Demucs uses the Torch checkpoint cache. Packaged desktop builds set this to the bundled repo so stem weights are never downloaded at runtime. |
 | `TUNEFORGE_LYRICS_MODEL` | `turbo` | Whisper model used for lyrics generation. |
 | `TUNEFORGE_LYRICS_DEVICE` | `auto` | One of `auto`, `cpu`, `mps`, `cuda`. `auto` prefers compatible CUDA, then MPS, then CPU. |
 | `TUNEFORGE_LYRICS_CACHE_DIR` | `<data>/cache/lyrics` | Override where Whisper model weights are cached. |
@@ -153,7 +153,7 @@ Default data directory:
 - macOS: `~/Library/Application Support/Tuneforge`
 - Linux: `~/.local/share/tuneforge`
 
-Lyrics models are downloaded on demand into the lyrics cache directory, then reused offline on later runs. Stem generation does not use Demucs runtime downloads; run `pnpm models:demucs:prepare`, configure `TUNEFORGE_DEMUCS_MODEL_REPO`, or use a packaged desktop build.
+Lyrics models are downloaded on demand into the lyrics cache directory, then reused offline on later runs. In development, `pnpm setup:dev` preloads Demucs weights into the Torch checkpoint cache; if they are not preloaded, the first stem generation may download them through Demucs. The Torch cache path is `$TORCH_HOME/hub/checkpoints` when `TORCH_HOME` is set, `$XDG_CACHE_HOME/torch/hub/checkpoints` when `XDG_CACHE_HOME` is set, or `~/.cache/torch/hub/checkpoints` by default. Packaged desktop builds and explicit `TUNEFORGE_DEMUCS_MODEL_REPO` configurations use a local verified repo instead.
 
 ## Chord backends
 

--- a/apps/backend/app/engines/demucs_cache.py
+++ b/apps/backend/app/engines/demucs_cache.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from app.engines.demucs_worker import _trusted_demucs_checkpoint_loading
+
+DEFAULT_DEMUCS_MODEL_IDS = ("htdemucs_6s", "htdemucs_ft")
+
+
+@dataclass(frozen=True)
+class DemucsCacheFile:
+    file_name: str
+    size: int
+    sha256: str
+
+
+@dataclass(frozen=True)
+class DemucsCacheModel:
+    id: str
+    files: tuple[DemucsCacheFile, ...]
+
+
+@dataclass(frozen=True)
+class DemucsPreloadResult:
+    model_id: str
+    cache_hit: bool
+
+
+@dataclass(frozen=True)
+class InvalidDemucsCacheFile:
+    file_name: str
+    reason: str
+
+
+def default_demucs_model_manifest_path() -> Path:
+    return Path(__file__).resolve().parents[4] / "packaging" / "demucs" / "models.json"
+
+
+def torch_checkpoint_dir() -> Path:
+    return Path(torch.hub.get_dir()).expanduser().resolve() / "checkpoints"
+
+
+def preload_demucs_torch_cache(
+    *,
+    manifest_path: Path | None = None,
+    checkpoint_dir: Path | None = None,
+    model_ids: Sequence[str] = DEFAULT_DEMUCS_MODEL_IDS,
+    get_model_func: Callable[[str], object] | None = None,
+) -> tuple[DemucsPreloadResult, ...]:
+    resolved_manifest_path = manifest_path or default_demucs_model_manifest_path()
+    resolved_checkpoint_dir = checkpoint_dir or torch_checkpoint_dir()
+    models = _read_manifest_models(resolved_manifest_path, model_ids=model_ids)
+    resolved_checkpoint_dir.mkdir(parents=True, exist_ok=True)
+
+    if get_model_func is None:
+        from demucs.pretrained import get_model
+
+        get_model_func = get_model
+
+    results: list[DemucsPreloadResult] = []
+    for model in models:
+        invalid_files = _invalid_cache_files(resolved_checkpoint_dir, model)
+        if not invalid_files:
+            results.append(DemucsPreloadResult(model_id=model.id, cache_hit=True))
+            continue
+
+        with _trusted_demucs_checkpoint_loading():
+            get_model_func(model.id)
+
+        remaining_invalid_files = _invalid_cache_files(resolved_checkpoint_dir, model)
+        if remaining_invalid_files:
+            details = ", ".join(
+                f"{invalid_file.file_name} ({invalid_file.reason})"
+                for invalid_file in remaining_invalid_files
+            )
+            raise RuntimeError(f"Demucs model cache is missing or invalid after preload for {model.id}: {details}")
+        results.append(DemucsPreloadResult(model_id=model.id, cache_hit=False))
+    return tuple(results)
+
+
+def _read_manifest_models(manifest_path: Path, *, model_ids: Sequence[str]) -> tuple[DemucsCacheModel, ...]:
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    raw_models = manifest.get("models")
+    if not isinstance(raw_models, list):
+        raise RuntimeError("Demucs model manifest must contain a models list.")
+
+    models_by_id = {
+        str(model["id"]): _parse_manifest_model(model)
+        for model in raw_models
+        if isinstance(model, dict) and isinstance(model.get("id"), str)
+    }
+    missing_model_ids = [model_id for model_id in model_ids if model_id not in models_by_id]
+    if missing_model_ids:
+        raise RuntimeError(f"Demucs model manifest is missing model(s): {', '.join(missing_model_ids)}")
+    return tuple(models_by_id[model_id] for model_id in model_ids)
+
+
+def _parse_manifest_model(model: dict[str, Any]) -> DemucsCacheModel:
+    raw_files = model.get("files")
+    if not isinstance(raw_files, list):
+        raise RuntimeError(f"Demucs model manifest entry has invalid files: {model.get('id')}")
+    files: list[DemucsCacheFile] = []
+    for file_entry in raw_files:
+        if not isinstance(file_entry, dict):
+            raise RuntimeError(f"Demucs model manifest entry has invalid file: {model.get('id')}")
+        file_name = file_entry.get("fileName")
+        file_size = file_entry.get("size")
+        file_sha256 = file_entry.get("sha256")
+        if not isinstance(file_name, str) or Path(file_name).name != file_name:
+            raise RuntimeError(f"Demucs model manifest entry has invalid file name: {model.get('id')}")
+        if not isinstance(file_size, int) or file_size <= 0:
+            raise RuntimeError(f"Demucs model manifest entry has invalid file size: {model.get('id')}")
+        if not isinstance(file_sha256, str):
+            raise RuntimeError(f"Demucs model manifest entry has invalid file hash: {model.get('id')}")
+        files.append(DemucsCacheFile(file_name=file_name, size=file_size, sha256=file_sha256))
+    return DemucsCacheModel(id=str(model["id"]), files=tuple(files))
+
+
+def _invalid_cache_files(checkpoint_dir: Path, model: DemucsCacheModel) -> tuple[InvalidDemucsCacheFile, ...]:
+    invalid_files: list[InvalidDemucsCacheFile] = []
+    for expected_file in model.files:
+        path = checkpoint_dir / expected_file.file_name
+        if not path.is_file():
+            invalid_files.append(InvalidDemucsCacheFile(file_name=expected_file.file_name, reason="missing"))
+            continue
+        if path.stat().st_size != expected_file.size:
+            invalid_files.append(InvalidDemucsCacheFile(file_name=expected_file.file_name, reason="size"))
+            continue
+        if _sha256_file(path) != expected_file.sha256:
+            invalid_files.append(InvalidDemucsCacheFile(file_name=expected_file.file_name, reason="sha256"))
+    return tuple(invalid_files)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = sha256()
+    with path.open("rb") as file:
+        while chunk := file.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/apps/backend/app/services/stem_models.py
+++ b/apps/backend/app/services/stem_models.py
@@ -180,7 +180,9 @@ def stem_model_availability(model_id: str) -> StemModelAvailability:
 
     repo = configured_stem_model_repo()
     if repo is None:
-        return StemModelAvailability(False, "Bundled Demucs model repo is not configured")
+        if importlib.util.find_spec("demucs") is None:
+            return StemModelAvailability(False, "Demucs is not installed")
+        return StemModelAvailability(True)
     if not repo.is_dir():
         return StemModelAvailability(False, f"Bundled Demucs model repo is missing: {repo}")
 

--- a/apps/backend/tests/test_stem_models.py
+++ b/apps/backend/tests/test_stem_models.py
@@ -4,7 +4,11 @@ import hashlib
 import json
 from pathlib import Path
 
+import soundfile as sf
+
 from app.config import get_settings
+from app.db import SessionLocal
+from app.services.projects import import_project
 from app.services.stem_models import resolve_stem_model
 
 from .conftest import wait_for_job
@@ -30,22 +34,57 @@ def test_stem_model_resolver_defaults_to_six_stems_model():
     assert resolve_stem_model(None).id == "htdemucs_6s"
 
 
-def test_unconfigured_model_repo_fails_stem_job(client, sample_stereo_audio_file, monkeypatch):
+def _create_project_without_import_jobs(source_path: Path) -> str:
+    with SessionLocal() as session:
+        project = import_project(
+            session,
+            source_path=str(source_path),
+            copy_into_project=True,
+            display_name=None,
+        )
+        project_id = project.id
+        session.commit()
+    return project_id
+
+
+def test_unconfigured_model_repo_uses_demucs_torch_cache_mode(client, sample_stereo_audio_file, monkeypatch):
     monkeypatch.delenv("TUNEFORGE_DEMUCS_MODEL_REPO")
     get_settings.cache_clear()
+    seen_model_repos: list[Path | None] = []
 
-    project = client.post(
-        "/api/v1/projects/import",
-        json={"source_path": str(sample_stereo_audio_file), "copy_into_project": True},
-    ).json()["project"]
+    def fake_separate_sources(
+        source_path: Path,
+        output_paths: dict[str, Path],
+        *,
+        model: str,
+        device: str,
+        model_repo: Path | None = None,
+        on_progress=None,
+        should_cancel=None,
+        register_process=None,
+        unregister_process=None,
+    ):
+        del model, device, should_cancel, register_process, unregister_process
+        seen_model_repos.append(model_repo)
+        signal, sample_rate = sf.read(source_path, always_2d=True)
+        for output_path in output_paths.values():
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            sf.write(output_path, signal, sample_rate)
+        if on_progress:
+            on_progress(98)
+        return {"engine": "demucs", "model": "htdemucs_6s", "requested_device": "auto", "device": "cpu"}
+
+    monkeypatch.setattr("app.services.stems.separate_sources", fake_separate_sources)
+
+    project_id = _create_project_without_import_jobs(sample_stereo_audio_file)
     stem_job = client.post(
-        f"/api/v1/projects/{project['id']}/stems",
+        f"/api/v1/projects/{project_id}/stems",
         json={"mode": "stems", "stem_model": "htdemucs_6s", "output_format": "wav"},
     ).json()["job"]
     final_job = wait_for_job(client, stem_job["id"])
 
-    assert final_job["status"] == "failed"
-    assert final_job["error_message"] == "Bundled Demucs model repo is not configured"
+    assert final_job["status"] == "completed"
+    assert seen_model_repos == [None]
 
 
 def test_configured_missing_model_repo_fails_stem_job(client, sample_stereo_audio_file, tmp_path, monkeypatch):

--- a/apps/backend/tests/test_torch_runtime.py
+++ b/apps/backend/tests/test_torch_runtime.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import hashlib
+import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -102,3 +105,120 @@ def test_demucs_worker_uses_trusted_checkpoint_loading(monkeypatch):
 
     assert calls == [{"weights_only": False}]
     assert demucs_worker.torch.load is fake_load
+
+
+def test_demucs_torch_preload_skips_model_load_when_cache_is_valid(tmp_path: Path):
+    from app.engines.demucs_cache import preload_demucs_torch_cache
+
+    checkpoint_dir = tmp_path / "checkpoints"
+    first_file = _write_checkpoint(checkpoint_dir, "first.th", b"first")
+    second_file = _write_checkpoint(checkpoint_dir, "second.th", b"second")
+    manifest_path = _write_demucs_manifest(
+        tmp_path,
+        {
+            "model-a": [first_file],
+            "model-b": [second_file],
+        },
+    )
+    calls: list[str] = []
+
+    results = preload_demucs_torch_cache(
+        manifest_path=manifest_path,
+        checkpoint_dir=checkpoint_dir,
+        model_ids=("model-a", "model-b"),
+        get_model_func=lambda model_id: calls.append(model_id),
+    )
+
+    assert calls == []
+    assert [(result.model_id, result.cache_hit) for result in results] == [
+        ("model-a", True),
+        ("model-b", True),
+    ]
+
+
+def test_demucs_torch_preload_loads_only_affected_model(tmp_path: Path):
+    from app.engines.demucs_cache import preload_demucs_torch_cache
+
+    checkpoint_dir = tmp_path / "checkpoints"
+    first_file = _write_checkpoint(checkpoint_dir, "first.th", b"first")
+    missing_file = _expected_checkpoint("missing.th", b"missing")
+    manifest_path = _write_demucs_manifest(
+        tmp_path,
+        {
+            "model-a": [first_file],
+            "model-b": [missing_file],
+        },
+    )
+    calls: list[str] = []
+
+    def fake_get_model(model_id: str) -> None:
+        calls.append(model_id)
+        _write_checkpoint(checkpoint_dir, "missing.th", b"missing")
+
+    results = preload_demucs_torch_cache(
+        manifest_path=manifest_path,
+        checkpoint_dir=checkpoint_dir,
+        model_ids=("model-a", "model-b"),
+        get_model_func=fake_get_model,
+    )
+
+    assert calls == ["model-b"]
+    assert [(result.model_id, result.cache_hit) for result in results] == [
+        ("model-a", True),
+        ("model-b", False),
+    ]
+
+
+def test_demucs_torch_preload_raises_when_loaded_model_remains_invalid(tmp_path: Path):
+    from app.engines.demucs_cache import preload_demucs_torch_cache
+
+    checkpoint_dir = tmp_path / "checkpoints"
+    manifest_path = _write_demucs_manifest(
+        tmp_path,
+        {
+            "model-a": [_expected_checkpoint("missing.th", b"missing")],
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="missing.th \\(missing\\)"):
+        preload_demucs_torch_cache(
+            manifest_path=manifest_path,
+            checkpoint_dir=checkpoint_dir,
+            model_ids=("model-a",),
+            get_model_func=lambda _model_id: None,
+        )
+
+
+def _expected_checkpoint(file_name: str, contents: bytes) -> dict[str, object]:
+    return {
+        "fileName": file_name,
+        "size": len(contents),
+        "sha256": hashlib.sha256(contents).hexdigest(),
+    }
+
+
+def _write_checkpoint(checkpoint_dir: Path, file_name: str, contents: bytes) -> dict[str, object]:
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    (checkpoint_dir / file_name).write_bytes(contents)
+    return _expected_checkpoint(file_name, contents)
+
+
+def _write_demucs_manifest(tmp_path: Path, models: dict[str, list[dict[str, object]]]) -> Path:
+    manifest_path = tmp_path / "models.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "rootUrl": "https://example.invalid/",
+                "models": [
+                    {
+                        "id": model_id,
+                        "yaml": f"{model_id}.yaml",
+                        "files": files,
+                    }
+                    for model_id, files in models.items()
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return manifest_path

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -19,7 +19,7 @@ Run packaging from a normal macOS shell so `hdiutil` can create the disk image. 
 
 The packaged backend checks the inherited `PATH` plus common Homebrew and MacPorts install locations when looking for `ffmpeg` and `ffprobe`. System microphone volume control uses the built-in CoreAudio API on macOS.
 
-`pnpm package:mac` prepares `resources/backend/models/demucs` with pinned `htdemucs_6s` and `htdemucs_ft` weights. The app sets `TUNEFORGE_DEMUCS_MODEL_REPO` for the bundled backend so stem generation never downloads model weights at runtime. Use `pnpm models:demucs:prepare -- --cache-only` for offline packaging checks that must fail instead of downloading missing weights.
+`pnpm package:mac` prepares `resources/backend/models/demucs` with pinned `htdemucs_6s` and `htdemucs_ft` weights. The app sets `TUNEFORGE_DEMUCS_MODEL_REPO` for the bundled backend so stem generation never downloads model weights at runtime. `pnpm models:demucs:prepare` reads the Torch checkpoint cache by default, matching the `pnpm setup:dev` preload path, and downloads any missing pinned weights before staging the repo. Use `pnpm models:demucs:prepare -- --cache-only` for offline packaging checks that must fail instead of downloading missing weights.
 
 ## Linux Flatpak
 

--- a/docs/STEM_SEPARATION.md
+++ b/docs/STEM_SEPARATION.md
@@ -17,13 +17,25 @@ runtime behavior and security boundaries for model loading.
 - Stem artifacts are stored with metadata `source_artifact_id`, `stem_model`,
   `stem_model_label`, and `stem_source` for each generated file.
 
-## Bundled model repo and trusted boundary
+## Model loading modes and trusted boundary
 
-`TUNEFORGE_DEMUCS_MODEL_REPO` points to a local path containing Demucs model
-files and `manifest.json`. Backend behavior:
+Development uses Demucs' default Torch checkpoint cache when
+`TUNEFORGE_DEMUCS_MODEL_REPO` is unset:
 
-- If unset, stem jobs fail availability check with
-  `"Bundled Demucs model repo is not configured"`.
+- `pnpm setup:dev` preloads `htdemucs_6s` and `htdemucs_ft` into the Torch
+  checkpoint cache.
+- If the weights are not preloaded, the first stem job may download them through
+  Demucs, then later runs reuse the cache.
+- Cache path precedence matches Torch: `$TORCH_HOME/hub/checkpoints`,
+  `$XDG_CACHE_HOME/torch/hub/checkpoints`, then
+  `~/.cache/torch/hub/checkpoints`.
+- Availability in this mode only requires the local `demucs` package to be
+  installed.
+
+Packaged builds and explicit offline/pinned setups use
+`TUNEFORGE_DEMUCS_MODEL_REPO`, which points to a local path containing Demucs
+model files and `manifest.json`. Backend behavior:
+
 - If set, backend validates the repo before serving the model:
   - manifest exists and parses.
   - manifest entry exists for requested `stem_model`.
@@ -31,9 +43,7 @@ files and `manifest.json`. Backend behavior:
   - manifest file list has matching names, sizes, and SHA-256 hashes.
   - all declared files exist.
   - Demucs package is installed.
-- No HTTP downloads happen at generation time.
-- `pnpm setup:dev` (or model prepare commands) is the explicit preload step that
-  downloads model files.
+- No HTTP downloads happen at generation time when this repo is configured.
 - Trust boundary is the prepared local model repo. Treat the repo directory,
   `manifest.json`, YAML selectors, and checkpoint files as one trusted generated
   artifact.
@@ -44,9 +54,10 @@ files and `manifest.json`. Backend behavior:
 
 - Backend marks Demucs checkpoint loads as trusted checkpoint loading in
   `app/engines/demucs_worker.py` to support current Demucs pickle model format.
-- This is an explicit local-policy decision: checkpoint loading happens only for
-  files selected through the configured local repo manifest checks above.
-- Security control in this release is trusted local repo preparation plus
+- This is an explicit local-policy decision for two local sources: Demucs'
+  Torch cache in development, and the configured local repo in packaged/offline
+  builds.
+- Security control for configured repos is trusted local repo preparation plus
   runtime manifest checks, not arbitrary model repo verification. If an attacker
   can modify both `manifest.json` and checkpoint files in the configured repo,
   the manifest cannot protect checkpoint loading.

--- a/scripts/prepare-demucs-models.mjs
+++ b/scripts/prepare-demucs-models.mjs
@@ -10,6 +10,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -18,7 +19,7 @@ const scriptDir = path.dirname(__filename);
 const workspaceRoot = path.resolve(scriptDir, "..");
 const demucsRoot = path.join(workspaceRoot, "packaging", "demucs");
 const manifestPath = path.join(demucsRoot, "models.json");
-const defaultCacheRoot = path.join(demucsRoot, "cache");
+const defaultCacheRoot = defaultTorchCheckpointCacheRoot();
 export const defaultPreparedModelRoot = path.join(
   workspaceRoot,
   "apps",
@@ -29,6 +30,26 @@ export const defaultPreparedModelRoot = path.join(
   "models",
   "demucs",
 );
+
+function expandHome(value) {
+  if (value === "~") {
+    return homedir();
+  }
+  if (value.startsWith("~/")) {
+    return path.join(homedir(), value.slice(2));
+  }
+  return value;
+}
+
+function defaultTorchCheckpointCacheRoot() {
+  if (process.env.TORCH_HOME) {
+    return path.join(path.resolve(expandHome(process.env.TORCH_HOME)), "hub", "checkpoints");
+  }
+  if (process.env.XDG_CACHE_HOME) {
+    return path.join(path.resolve(expandHome(process.env.XDG_CACHE_HOME)), "torch", "hub", "checkpoints");
+  }
+  return path.join(homedir(), ".cache", "torch", "hub", "checkpoints");
+}
 
 function modelMode(modelId) {
   if (modelId === "htdemucs_6s") {

--- a/scripts/run-backend-module.sh
+++ b/scripts/run-backend-module.sh
@@ -9,13 +9,8 @@ fi
 repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 backend_dir="${repo_root}/apps/backend"
 marker_file="${backend_dir}/.venv/.tuneforge-legacy-nvidia"
-prepared_demucs_repo="${repo_root}/apps/desktop/src-tauri/resources/backend/models/demucs"
 module="$1"
 shift
-
-if [[ -z "${TUNEFORGE_DEMUCS_MODEL_REPO:-}" && -f "${prepared_demucs_repo}/manifest.json" ]]; then
-  export TUNEFORGE_DEMUCS_MODEL_REPO="${prepared_demucs_repo}"
-fi
 
 cd "${backend_dir}"
 

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -10,14 +10,14 @@ Runs the standard developer setup:
   pnpm --filter @tuneforge/desktop exec playwright install chromium
   uv sync --python 3.11 --all-groups
   pnpm contracts:generate
-  pnpm models:demucs:prepare
+  preload Demucs model weights into the Torch cache
 
 Options:
   --advanced-chords, --crema  Install the optional crema/TensorFlow chord backend.
   --advanced-beats, --beat-this
                               Install the optional beat-this backend and preload small0.
   --legacy-nvidia             Use the Linux x86_64 legacy NVIDIA Torch profile.
-  --skip-demucs-models        Skip preparing the local pinned Demucs model repo.
+  --skip-demucs-models        Skip preloading Demucs weights into the Torch cache.
   --skip-playwright-browsers  Skip installing Playwright's Chromium browser.
   --skip-pnpm-install         Skip workspace dependency installation.
   --skip-contracts            Skip OpenAPI contract generation.
@@ -169,9 +169,17 @@ if [[ "${skip_contracts}" -eq 0 ]]; then
 fi
 
 if [[ "${skip_demucs_models}" -eq 0 ]]; then
-  cd "${repo_root}"
-  echo "Preparing local Demucs model repo..."
-  pnpm models:demucs:prepare
+  cd "${backend_dir}"
+  echo "Preloading Demucs model weights into the Torch cache..."
+  .venv/bin/python - <<'PY'
+from app.engines.demucs_cache import preload_demucs_torch_cache
+
+for result in preload_demucs_torch_cache():
+    if result.cache_hit:
+        print(f"Demucs {result.model_id} checkpoint cache hit.")
+    else:
+        print(f"Preloaded Demucs {result.model_id} checkpoint(s).")
+PY
 fi
 
 echo "Setup complete."


### PR DESCRIPTION
## Summary

- Preload Demucs development weights through the Torch checkpoint cache instead of a per-worktree model repo.
- Skip Demucs model loading when cached checkpoint files already match the pinned manifest.
- Keep packaged/configured Demucs repos pinned and manifest-verified.

## Testing

- `bash -n scripts/setup-dev.sh scripts/run-backend-module.sh`
- `node --check scripts/prepare-demucs-models.mjs`
- `cd apps/backend && uv run --python 3.11 pytest tests/test_torch_runtime.py tests/test_stem_models.py tests/test_stem_flow.py`
- `cd apps/backend && uv run --python 3.11 ruff check app tests/test_torch_runtime.py tests/test_stem_models.py tests/test_stem_flow.py`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `pnpm setup:dev -- --skip-pnpm-install --skip-playwright-browsers --skip-contracts`
