### PR TITLE
fix(sync): handle generated analysis divergence

### DIFF
--- a/apps/backend/app/services/analysis.py
+++ b/apps/backend/app/services/analysis.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import json
 from collections import defaultdict
 from collections.abc import Mapping
+from datetime import UTC, datetime
 from math import isfinite
 from pathlib import Path
 from typing import Any, Literal, cast
 
 from fastapi import status
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.engines.analysis import AnalysisPayload, analyze_track
@@ -31,10 +33,12 @@ def analyze_project(
     beat_backend: str = BUILT_IN_BEAT_BACKEND,
 ) -> AnalysisResult:
     source_artifact = _project_source_artifact(project)
-    source_stem_paths = _source_stem_paths(project, source_artifact) if source_artifact is not None else ()
+    source_stem_artifacts = (
+        _source_stem_artifacts(project, source_artifact) if source_artifact is not None else ()
+    )
     results = _analyze_track_with_backend(
         Path(project.imported_path),
-        source_stem_paths=source_stem_paths,
+        source_stem_paths=tuple(Path(artifact.path) for artifact in source_stem_artifacts),
         beat_backend=beat_backend,
         duration_seconds=project.duration_seconds,
     )
@@ -53,7 +57,14 @@ def analyze_project(
     analysis.analysis_version = "v3"
     session.flush()
 
-    _write_analysis_artifact(session, project=project, analysis=analysis)
+    _write_analysis_artifact(
+        session,
+        project=project,
+        analysis=analysis,
+        analysis_backend=beat_backend,
+        source_artifact=source_artifact,
+        source_stem_artifacts=source_stem_artifacts,
+    )
 
     return analysis
 
@@ -105,7 +116,7 @@ def _project_source_artifact(project: Project) -> Artifact | None:
     return next((artifact for artifact in project.artifacts if artifact.type == "source_audio"), None)
 
 
-def _source_stem_paths(project: Project, source_artifact: Artifact) -> tuple[Path, ...]:
+def _source_stem_artifacts(project: Project, source_artifact: Artifact) -> tuple[Artifact, ...]:
     latest_by_type: dict[str, Artifact] = {}
     for artifact in project.artifacts:
         if not _is_source_analysis_stem(artifact, source_artifact):
@@ -114,12 +125,12 @@ def _source_stem_paths(project: Project, source_artifact: Artifact) -> tuple[Pat
         if current is None or (artifact.created_at, artifact.id) > (current.created_at, current.id):
             latest_by_type[artifact.type] = artifact
 
-    source_stem_paths: list[Path] = []
+    source_stem_artifacts: list[Artifact] = []
     for artifact_type in SOURCE_STEM_ARTIFACT_TYPES:
         selected_artifact = latest_by_type.get(artifact_type)
         if selected_artifact is not None:
-            source_stem_paths.append(Path(selected_artifact.path))
-    return tuple(source_stem_paths)
+            source_stem_artifacts.append(selected_artifact)
+    return tuple(source_stem_artifacts)
 
 
 def _is_source_analysis_stem(artifact: Artifact, source_artifact: Artifact) -> bool:
@@ -184,22 +195,45 @@ def correct_analysis_timing(
         duration_seconds=project.duration_seconds,
     )
     session.flush()
-    _write_analysis_artifact(session, project=project, analysis=analysis)
+    source_artifact = _analysis_source_artifact(session, project, analysis)
+    _write_analysis_artifact(
+        session,
+        project=project,
+        analysis=analysis,
+        analysis_backend=None,
+        source_artifact=source_artifact,
+        source_stem_artifacts=None,
+    )
     session.refresh(analysis)
     return analysis
 
 
-def _write_analysis_artifact(session: Session, *, project: Project, analysis: AnalysisResult) -> None:
+def _write_analysis_artifact(
+    session: Session,
+    *,
+    project: Project,
+    analysis: AnalysisResult,
+    analysis_backend: str | None,
+    source_artifact: Artifact | None,
+    source_stem_artifacts: tuple[Artifact, ...] | None,
+) -> None:
+    existing_artifact = _existing_analysis_artifact(session, project.id)
+    analysis_metadata = _analysis_artifact_metadata(
+        existing_artifact=existing_artifact,
+        analysis=analysis,
+        analysis_backend=analysis_backend,
+        source_artifact=source_artifact,
+        source_stem_artifacts=source_stem_artifacts,
+    )
     analysis_payload = {
         "project_id": project.id,
-        "source_artifact_id": analysis.source_artifact_id,
         "estimated_key": analysis.estimated_key,
         "key_confidence": analysis.key_confidence,
         "estimated_reference_hz": analysis.estimated_reference_hz,
         "tuning_offset_cents": analysis.tuning_offset_cents,
         "tempo_bpm": analysis.tempo_bpm,
         "timing": analysis.timing_json,
-        "analysis_version": analysis.analysis_version,
+        **analysis_metadata,
     }
     analysis_dir = project_analysis_dir(project.id)
     analysis_dir.mkdir(parents=True, exist_ok=True)
@@ -209,11 +243,6 @@ def _write_analysis_artifact(session: Session, *, project: Project, analysis: An
         encoding="utf-8",
     )
 
-    existing_artifact = None
-    for artifact in project.artifacts:
-        if artifact.type == "analysis_json":
-            existing_artifact = artifact
-            break
     if existing_artifact is None:
         register_artifact(
             session,
@@ -221,10 +250,7 @@ def _write_analysis_artifact(session: Session, *, project: Project, analysis: An
             artifact_type="analysis_json",
             artifact_format="json",
             path=analysis_path,
-            metadata={
-                "analysis_version": analysis.analysis_version,
-                "source_artifact_id": analysis.source_artifact_id,
-            },
+            metadata=analysis_metadata,
             generated_by="analysis",
         )
     else:
@@ -232,12 +258,100 @@ def _write_analysis_artifact(session: Session, *, project: Project, analysis: An
         existing_artifact.generated_by = "analysis"
         existing_artifact.can_delete = True
         existing_artifact.can_regenerate = True
-        existing_artifact.metadata_json = {
-            "analysis_version": analysis.analysis_version,
-            "source_artifact_id": analysis.source_artifact_id,
-        }
+        existing_artifact.metadata_json = analysis_metadata
 
     session.flush()
+
+
+def _existing_analysis_artifact(session: Session, project_id: str) -> Artifact | None:
+    return session.scalar(
+        select(Artifact)
+        .where(Artifact.project_id == project_id, Artifact.type == "analysis_json")
+        .order_by(Artifact.created_at.asc(), Artifact.id.asc())
+    )
+
+
+def _analysis_source_artifact(
+    session: Session,
+    project: Project,
+    analysis: AnalysisResult,
+) -> Artifact | None:
+    if analysis.source_artifact_id is not None:
+        source_artifact = session.get(Artifact, analysis.source_artifact_id)
+        if source_artifact is not None and source_artifact.project_id == project.id:
+            return source_artifact
+    return _project_source_artifact(project)
+
+
+def _analysis_artifact_metadata(
+    *,
+    existing_artifact: Artifact | None,
+    analysis: AnalysisResult,
+    analysis_backend: str | None,
+    source_artifact: Artifact | None,
+    source_stem_artifacts: tuple[Artifact, ...] | None,
+) -> dict[str, Any]:
+    existing_metadata = existing_artifact.metadata_json if existing_artifact is not None else {}
+    if not isinstance(existing_metadata, dict):
+        existing_metadata = {}
+
+    return {
+        "analysis_generated_at": _analysis_generated_at_iso(),
+        "analysis_backend": _analysis_backend_for_write(analysis_backend, existing_metadata),
+        "analysis_version": analysis.analysis_version,
+        "source_artifact_id": analysis.source_artifact_id,
+        "source_artifact_sha256": source_artifact.content_sha256 if source_artifact is not None else None,
+        "source_stem_artifact_ids": _source_stem_artifact_ids(
+            source_stem_artifacts,
+            existing_metadata,
+        ),
+        "source_stem_content_sha256s": _source_stem_content_sha256s(
+            source_stem_artifacts,
+            existing_metadata,
+        ),
+    }
+
+
+def _analysis_backend_for_write(
+    analysis_backend: str | None,
+    existing_metadata: Mapping[str, Any],
+) -> str:
+    if analysis_backend in {BUILT_IN_BEAT_BACKEND, BEAT_THIS_BACKEND}:
+        return analysis_backend
+    existing_backend = existing_metadata.get("analysis_backend")
+    if existing_backend in {BUILT_IN_BEAT_BACKEND, BEAT_THIS_BACKEND}:
+        return cast(str, existing_backend)
+    return BUILT_IN_BEAT_BACKEND
+
+
+def _source_stem_artifact_ids(
+    source_stem_artifacts: tuple[Artifact, ...] | None,
+    existing_metadata: Mapping[str, Any],
+) -> list[str]:
+    if source_stem_artifacts is not None:
+        return [artifact.id for artifact in source_stem_artifacts]
+    existing_ids = existing_metadata.get("source_stem_artifact_ids")
+    if isinstance(existing_ids, list) and all(isinstance(item, str) for item in existing_ids):
+        return list(existing_ids)
+    return []
+
+
+def _source_stem_content_sha256s(
+    source_stem_artifacts: tuple[Artifact, ...] | None,
+    existing_metadata: Mapping[str, Any],
+) -> list[str | None]:
+    if source_stem_artifacts is not None:
+        return [artifact.content_sha256 for artifact in source_stem_artifacts]
+    existing_sha256s = existing_metadata.get("source_stem_content_sha256s")
+    if isinstance(existing_sha256s, list) and all(
+        isinstance(item, str) or item is None for item in existing_sha256s
+    ):
+        return list(existing_sha256s)
+    return []
+
+
+def _analysis_generated_at_iso() -> str:
+    return datetime.now(UTC).isoformat()
 
 
 def _normalize_timing_payload(payload: Mapping[str, Any]) -> dict[str, Any]:

--- a/apps/backend/app/services/sync_manifest.py
+++ b/apps/backend/app/services/sync_manifest.py
@@ -31,7 +31,7 @@ from app.schemas import SUPPORTED_LYRICS_LANGUAGE_OVERRIDES
 from app.services.artifacts import register_artifact
 from app.services.paths import ensure_project_dirs, project_root
 from app.services.sync_identity import source_hash_to_project_id
-from app.services.sync_metadata import project_relative_artifact_path, sanitize_sync_metadata
+from app.services.sync_metadata import artifact_sync_metadata, project_relative_artifact_path, sanitize_sync_metadata
 from app.services.sync_project_status import mark_project_sync_local
 from app.services.sync_revisions import (
     CURRENT_REVISION_STATE,
@@ -685,7 +685,7 @@ def _export_artifact_manifest(artifact: Artifact) -> SyncArtifactManifest:
         can_delete=artifact.can_delete,
         can_regenerate=artifact.can_regenerate,
         cache_key=artifact.cache_key,
-        metadata=cast(dict[str, Any], sanitize_sync_metadata(artifact.metadata_json or {})),
+        metadata=artifact_sync_metadata(artifact),
         created_at=artifact.created_at,
     )
 

--- a/apps/backend/app/services/sync_metadata.py
+++ b/apps/backend/app/services/sync_metadata.py
@@ -18,6 +18,8 @@ LOCAL_METADATA_PATH_KEYS = {
     "playback_path",
     "imported_path",
 }
+ANALYSIS_ARTIFACT_TYPE = "analysis_json"
+ANALYSIS_GENERATED_AT_KEY = "analysis_generated_at"
 
 
 @dataclass(frozen=True)
@@ -150,7 +152,7 @@ def _artifact_metadata(artifact: Artifact) -> SyncMetadataArtifact:
         can_delete=artifact.can_delete,
         can_regenerate=artifact.can_regenerate,
         cache_key=artifact.cache_key,
-        metadata=_sanitize_metadata(artifact.metadata_json or {}),
+        metadata=artifact_sync_metadata(artifact),
         created_at=artifact.created_at,
     )
 
@@ -178,10 +180,32 @@ def sanitize_sync_metadata(value: Any) -> Any:
     return _sanitize_metadata(value)
 
 
+def artifact_sync_metadata(artifact: Artifact) -> dict[str, Any]:
+    sanitized = sanitize_sync_metadata(artifact.metadata_json or {})
+    metadata = sanitized if isinstance(sanitized, dict) else {}
+    if artifact.type != ANALYSIS_ARTIFACT_TYPE or ANALYSIS_GENERATED_AT_KEY in metadata:
+        return metadata
+    generated_at = _artifact_file_mtime_iso(artifact)
+    if generated_at is None:
+        return metadata
+    return {
+        **metadata,
+        ANALYSIS_GENERATED_AT_KEY: generated_at,
+    }
+
+
 def cast_metadata(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         return {}
     return cast(dict[str, Any], _sanitize_metadata(value))
+
+
+def _artifact_file_mtime_iso(artifact: Artifact) -> str | None:
+    try:
+        mtime = Path(artifact.path).expanduser().stat().st_mtime
+    except OSError:
+        return None
+    return datetime.fromtimestamp(mtime, UTC).isoformat()
 
 
 def _list_delete_tombstones(session: Session) -> list[SyncDeleteTombstone]:

--- a/apps/backend/app/services/sync_reconciliation.py
+++ b/apps/backend/app/services/sync_reconciliation.py
@@ -49,6 +49,21 @@ ITEM_ARTIFACT = "artifact"
 ITEM_ENTITY_REVISION = "entity_revision"
 ITEM_DELETE_TOMBSTONE = "delete_tombstone"
 
+ANALYSIS_ARTIFACT_TYPE = "analysis_json"
+_ANALYSIS_SOURCE_STEM_HASH_METADATA_KEYS = (
+    "source_stem_input_hashes",
+    "source_stem_content_sha256s",
+    "source_stem_sha256s",
+    "source_stem_hashes",
+    "input_source_stem_hashes",
+    "analysis_source_stem_sha256s",
+)
+_ANALYSIS_SOURCE_STEM_ARTIFACT_METADATA_KEYS = (
+    "source_stem_input_artifacts",
+    "source_stem_artifacts",
+)
+_ANALYSIS_SOURCE_STEM_ARTIFACT_TYPES = frozenset({"drums_stem", "bass_stem"})
+
 PROJECT_SYNC_STATUS_LOCAL = "local"
 PROJECT_SYNC_STATUS_SYNCING = "syncing"
 PROJECT_SYNC_STATUS_REMOTE_AVAILABLE = "remote_available"
@@ -196,6 +211,14 @@ class _LocalState:
     entity_revisions: dict[str, SyncEntityRevision]
     entity_revisions_by_entity: dict[tuple[str, str, str], tuple[SyncEntityRevision, ...]]
     tombstones: tuple[SyncDeleteTombstone, ...]
+
+
+@dataclass(frozen=True)
+class _GeneratedAnalysisDivergence:
+    resolvable: bool
+    keep_local: bool
+    reason: str
+    details: dict[str, Any]
 
 
 def plan_sync_reconciliation(
@@ -1214,6 +1237,109 @@ def _plan_artifact(
     if local_artifact is not None:
         local_hash = _normalize_sha256(local_artifact.content_sha256)
         if local_hash != artifact.content_sha256:
+            generated_divergence = _generated_analysis_divergence(
+                local_artifact,
+                artifact,
+                local_hash=local_hash,
+                local=local,
+                remote=remote,
+            )
+            if generated_divergence is not None:
+                if generated_divergence.resolvable:
+                    if generated_divergence.keep_local:
+                        _upsert_item(
+                            items_by_key,
+                            SyncReconciliationItem(
+                                item_type=ITEM_ARTIFACT,
+                                item_id=artifact.artifact_id,
+                                project_id=artifact.project_id,
+                                status="noop",
+                                action_type=ACTION_NOOP,
+                                content_sha256=artifact.content_sha256,
+                                reason=generated_divergence.reason,
+                                details=generated_divergence.details,
+                            ),
+                        )
+                        return
+
+                    provider_device_id = _choose_provider(remote, artifact.content_sha256)
+                    if provider_device_id is None:
+                        _upsert_item(
+                            items_by_key,
+                            SyncReconciliationItem(
+                                item_type=ITEM_ARTIFACT,
+                                item_id=artifact.artifact_id,
+                                project_id=artifact.project_id,
+                                status="missing_provider",
+                                content_sha256=artifact.content_sha256,
+                                reason=(
+                                    "Remote regenerable analysis_json is newer, but no trusted provider "
+                                    "advertises its content."
+                                ),
+                                details={
+                                    **generated_divergence.details,
+                                    "resolution": "waiting_for_remote_provider",
+                                },
+                            ),
+                        )
+                        return
+
+                    details = {
+                        **generated_divergence.details,
+                        "provider_device_id": provider_device_id,
+                    }
+                    _upsert_item(
+                        items_by_key,
+                        SyncReconciliationItem(
+                            item_type=ITEM_ARTIFACT,
+                            item_id=artifact.artifact_id,
+                            project_id=artifact.project_id,
+                            status="remote_available",
+                            action_type=ACTION_FETCH_ARTIFACT_CONTENT,
+                            content_sha256=artifact.content_sha256,
+                            chosen_provider_device_id=provider_device_id,
+                            reason=generated_divergence.reason,
+                            details=details,
+                        ),
+                    )
+                    actions.append(
+                        _action(
+                            ACTION_FETCH_ARTIFACT_CONTENT,
+                            item_type=ITEM_ARTIFACT,
+                            item_id=artifact.artifact_id,
+                            project_id=artifact.project_id,
+                            content_sha256=artifact.content_sha256,
+                            provider_device_id=provider_device_id,
+                            reason="Fetch newer remote regenerable analysis_json artifact bytes.",
+                            details=details,
+                        )
+                    )
+                    actions.append(
+                        _action(
+                            ACTION_IMPORT_ARTIFACT_MANIFEST,
+                            item_type=ITEM_ARTIFACT,
+                            item_id=artifact.artifact_id,
+                            project_id=artifact.project_id,
+                            content_sha256=artifact.content_sha256,
+                            provider_device_id=provider_device_id,
+                            reason="Import newer remote regenerable analysis_json artifact manifest.",
+                            details=details,
+                        )
+                    )
+                    return
+
+                _record_conflict(
+                    items_by_key,
+                    actions,
+                    item_type=ITEM_ARTIFACT,
+                    item_id=artifact.artifact_id,
+                    project_id=artifact.project_id,
+                    content_sha256=artifact.content_sha256,
+                    reason=generated_divergence.reason,
+                    details=generated_divergence.details,
+                )
+                return
+
             _record_conflict(
                 items_by_key,
                 actions,
@@ -1222,10 +1348,12 @@ def _plan_artifact(
                 project_id=artifact.project_id,
                 content_sha256=artifact.content_sha256,
                 reason="Local and remote artifacts share an ID but have different content hashes.",
-                details={
-                    "local_content_sha256": local_hash,
-                    "remote_content_sha256": artifact.content_sha256,
-                },
+                details=_artifact_conflict_details(
+                    local_artifact,
+                    artifact,
+                    local_content_sha256=local_hash,
+                    generated_divergence_reason="Artifact is not a regenerable analysis_json divergence candidate.",
+                ),
             )
             return
 
@@ -2526,6 +2654,491 @@ def _artifact_has_recorded_content(
     return size_bytes is None or artifact.size_bytes == size_bytes
 
 
+def _generated_analysis_divergence(
+    local_artifact: Artifact,
+    remote_artifact: _RemoteArtifact,
+    *,
+    local_hash: str | None,
+    local: _LocalState,
+    remote: _RemoteRequest,
+) -> _GeneratedAnalysisDivergence | None:
+    details = _artifact_conflict_details(
+        local_artifact,
+        remote_artifact,
+        local_content_sha256=local_hash,
+    )
+    local_type = _normalize_artifact_type(local_artifact.type)
+    remote_type = _normalize_artifact_type(remote_artifact.type)
+    if local_type != ANALYSIS_ARTIFACT_TYPE or remote_type != ANALYSIS_ARTIFACT_TYPE:
+        if ANALYSIS_ARTIFACT_TYPE not in {local_type, remote_type}:
+            return None
+        return _unresolvable_generated_analysis_divergence(
+            details,
+            "Local and remote artifacts are not both analysis_json artifacts.",
+        )
+
+    details["generated_divergence_candidate"] = True
+    if local_artifact.can_regenerate is not True or _remote_artifact_can_regenerate(remote_artifact) is not True:
+        return _unresolvable_generated_analysis_divergence(
+            details,
+            "Both analysis_json artifacts must be marked regenerable.",
+        )
+
+    if local_artifact.project_id != remote_artifact.project_id:
+        return _unresolvable_generated_analysis_divergence(
+            details,
+            "Local and remote analysis_json artifacts belong to different projects.",
+        )
+
+    project_details, project_error = _generated_analysis_project_input_details(
+        local_artifact,
+        remote_artifact,
+        local=local,
+        remote=remote,
+    )
+    details.update(project_details)
+    if project_error is not None:
+        return _unresolvable_generated_analysis_divergence(details, project_error)
+
+    source_details, source_error = _generated_analysis_source_input_details(
+        local_artifact,
+        remote_artifact,
+        local=local,
+        remote=remote,
+    )
+    details.update(source_details)
+    if source_error is not None:
+        return _unresolvable_generated_analysis_divergence(details, source_error)
+
+    local_source_artifact_id = source_details.get("local_source_artifact_id")
+    remote_source_artifact_id = source_details.get("remote_source_artifact_id")
+    if not isinstance(local_source_artifact_id, str) or not isinstance(remote_source_artifact_id, str):
+        return _unresolvable_generated_analysis_divergence(
+            details,
+            "Analysis source artifact identity is missing.",
+        )
+
+    stem_details, stem_error = _generated_analysis_source_stem_details(
+        local_artifact,
+        remote_artifact,
+        local=local,
+        remote=remote,
+        local_source_artifact_id=local_source_artifact_id,
+        remote_source_artifact_id=remote_source_artifact_id,
+    )
+    details.update(stem_details)
+    if stem_error is not None:
+        return _unresolvable_generated_analysis_divergence(details, stem_error)
+
+    timestamp_details, keep_local, timestamp_reason = _generated_analysis_timestamp_resolution(
+        local_artifact,
+        remote_artifact,
+    )
+    details.update(timestamp_details)
+    details.update(
+        {
+            "generated_divergence_resolvable": True,
+            "resolution": "keep_local" if keep_local else "fetch_remote",
+            "resolution_reason": timestamp_reason,
+        }
+    )
+    if keep_local:
+        return _GeneratedAnalysisDivergence(
+            resolvable=True,
+            keep_local=True,
+            reason=timestamp_reason,
+            details=details,
+        )
+    return _GeneratedAnalysisDivergence(
+        resolvable=True,
+        keep_local=False,
+        reason="Remote regenerable analysis_json is newer for matching source inputs.",
+        details=details,
+    )
+
+
+def _unresolvable_generated_analysis_divergence(
+    details: dict[str, Any],
+    reason: str,
+) -> _GeneratedAnalysisDivergence:
+    details.update(
+        {
+            "generated_divergence_resolvable": False,
+            "generated_divergence_unresolvable_reason": reason,
+        }
+    )
+    return _GeneratedAnalysisDivergence(
+        resolvable=False,
+        keep_local=True,
+        reason="Local and remote analysis_json artifacts diverge and cannot be auto-resolved.",
+        details=details,
+    )
+
+
+def _artifact_conflict_details(
+    local_artifact: Artifact,
+    remote_artifact: _RemoteArtifact,
+    *,
+    local_content_sha256: str | None,
+    generated_divergence_reason: str | None = None,
+) -> dict[str, Any]:
+    details: dict[str, Any] = {
+        "artifact_type": remote_artifact.type or local_artifact.type,
+        "artifact_id": remote_artifact.artifact_id,
+        "local_content_sha256": local_content_sha256,
+        "remote_content_sha256": remote_artifact.content_sha256,
+        "local_can_regenerate": bool(local_artifact.can_regenerate),
+        "remote_can_regenerate": _remote_artifact_can_regenerate(remote_artifact),
+    }
+    if generated_divergence_reason is not None:
+        details.update(
+            {
+                "generated_divergence_candidate": False,
+                "generated_divergence_resolvable": False,
+                "generated_divergence_unresolvable_reason": generated_divergence_reason,
+            }
+        )
+    return details
+
+
+def _generated_analysis_project_input_details(
+    local_artifact: Artifact,
+    remote_artifact: _RemoteArtifact,
+    *,
+    local: _LocalState,
+    remote: _RemoteRequest,
+) -> tuple[dict[str, Any], str | None]:
+    local_project = local.projects.get(local_artifact.project_id)
+    remote_project = remote.projects.get(remote_artifact.project_id)
+    local_source_sha256 = None if local_project is None else _normalize_sha256(local_project.source_sha256)
+    remote_source_sha256 = None if remote_project is None else remote_project.source_sha256
+    details = {
+        "local_project_id": local_artifact.project_id,
+        "remote_project_id": remote_artifact.project_id,
+        "local_project_source_sha256": local_source_sha256,
+        "remote_project_source_sha256": remote_source_sha256,
+    }
+    if local_project is None:
+        return details, "Local project metadata is missing."
+    if (
+        local_source_sha256 is not None
+        and remote_source_sha256 is not None
+        and local_source_sha256 != remote_source_sha256
+    ):
+        return details, "Project source_sha256 differs."
+    return details, None
+
+
+def _generated_analysis_source_input_details(
+    local_artifact: Artifact,
+    remote_artifact: _RemoteArtifact,
+    *,
+    local: _LocalState,
+    remote: _RemoteRequest,
+) -> tuple[dict[str, Any], str | None]:
+    local_metadata = _local_artifact_metadata(local_artifact)
+    remote_metadata = _remote_artifact_metadata(remote_artifact)
+    local_source_artifact = _analysis_local_source_artifact(
+        local,
+        project_id=local_artifact.project_id,
+        source_artifact_id=_str_field(local_metadata, "source_artifact_id"),
+    )
+    remote_source_artifact = _analysis_remote_source_artifact(
+        remote,
+        project_id=remote_artifact.project_id,
+        source_artifact_id=_str_field(remote_metadata, "source_artifact_id"),
+    )
+    local_metadata_source_id = _str_field(local_metadata, "source_artifact_id")
+    remote_metadata_source_id = _str_field(remote_metadata, "source_artifact_id")
+    local_metadata_source_hash = _metadata_source_artifact_sha256(local_metadata)
+    remote_metadata_source_hash = _metadata_source_artifact_sha256(remote_metadata)
+    local_source_id = (
+        local_source_artifact.id if local_source_artifact is not None else local_metadata_source_id
+    )
+    remote_source_id = (
+        remote_source_artifact.artifact_id
+        if remote_source_artifact is not None
+        else remote_metadata_source_id
+    )
+    local_source_hash = (
+        _normalize_sha256(local_source_artifact.content_sha256)
+        if local_source_artifact is not None
+        else local_metadata_source_hash
+    )
+    remote_source_hash = (
+        remote_source_artifact.content_sha256
+        if remote_source_artifact is not None
+        else remote_metadata_source_hash
+    )
+    details = {
+        "local_source_artifact_id": local_source_id,
+        "remote_source_artifact_id": remote_source_id,
+        "local_source_content_sha256": local_source_hash,
+        "remote_source_content_sha256": remote_source_hash,
+    }
+    if local_source_id is None or remote_source_id is None:
+        return details, "Analysis source artifact metadata is missing."
+    if local_source_id != remote_source_id:
+        return details, "Analysis source artifact IDs differ."
+    if local_source_hash is None or remote_source_hash is None or local_source_hash != remote_source_hash:
+        return details, "Analysis source artifact content hash differs."
+    return details, None
+
+
+def _generated_analysis_source_stem_details(
+    local_artifact: Artifact,
+    remote_artifact: _RemoteArtifact,
+    *,
+    local: _LocalState,
+    remote: _RemoteRequest,
+    local_source_artifact_id: str,
+    remote_source_artifact_id: str,
+) -> tuple[dict[str, Any], str | None]:
+    local_metadata = _local_artifact_metadata(local_artifact)
+    remote_metadata = _remote_artifact_metadata(remote_artifact)
+    local_stem_hashes = _analysis_metadata_source_stem_hashes(local_metadata)
+    remote_stem_hashes = _analysis_metadata_source_stem_hashes(remote_metadata)
+    source = "metadata" if local_stem_hashes is not None or remote_stem_hashes is not None else "artifacts"
+    if local_stem_hashes is None:
+        local_stem_hashes = _local_source_stem_hashes(
+            local,
+            project_id=local_artifact.project_id,
+            source_artifact_id=local_source_artifact_id,
+        )
+    if remote_stem_hashes is None:
+        remote_stem_hashes = _remote_source_stem_hashes(
+            remote,
+            project_id=remote_artifact.project_id,
+            source_artifact_id=remote_source_artifact_id,
+        )
+    details = {
+        "source_stem_hash_source": source,
+        "local_source_stem_content_sha256s": list(local_stem_hashes),
+        "remote_source_stem_content_sha256s": list(remote_stem_hashes),
+    }
+    if local_stem_hashes != remote_stem_hashes:
+        return details, "Analysis source-stem input hashes differ."
+    return details, None
+
+
+def _generated_analysis_timestamp_resolution(
+    local_artifact: Artifact,
+    remote_artifact: _RemoteArtifact,
+) -> tuple[dict[str, Any], bool, str]:
+    local_metadata = _local_artifact_metadata(local_artifact)
+    remote_metadata = _remote_artifact_metadata(remote_artifact)
+    local_timestamp, local_timestamp_source = _analysis_resolution_timestamp(
+        metadata=local_metadata,
+    )
+    remote_timestamp, remote_timestamp_source = _analysis_resolution_timestamp(
+        metadata=remote_metadata,
+    )
+    details = {
+        "local_resolution_timestamp": _datetime_detail(local_timestamp),
+        "local_resolution_timestamp_source": local_timestamp_source,
+        "remote_resolution_timestamp": _datetime_detail(remote_timestamp),
+        "remote_resolution_timestamp_source": remote_timestamp_source,
+    }
+    if local_timestamp is None or remote_timestamp is None:
+        return details, True, "Analysis generation timestamp is missing; keeping local analysis_json."
+    if remote_timestamp > local_timestamp:
+        return details, False, "Remote analysis_json generation timestamp is newer."
+    if local_timestamp > remote_timestamp:
+        return details, True, "Local analysis_json generation timestamp is newer."
+    return details, True, "Analysis generation timestamps tie; keeping local analysis_json."
+
+
+def _analysis_resolution_timestamp(
+    *,
+    metadata: Mapping[str, Any],
+) -> tuple[datetime | None, str]:
+    generated_at = _coerce_datetime(_first_field(metadata, "analysis_generated_at", default=None))
+    if generated_at is not None:
+        return generated_at, "metadata.analysis_generated_at"
+    return None, "missing"
+
+
+def _analysis_local_source_artifact(
+    local: _LocalState,
+    *,
+    project_id: str,
+    source_artifact_id: str | None,
+) -> Artifact | None:
+    if source_artifact_id is not None:
+        artifact = local.artifacts.get(source_artifact_id)
+        if artifact is None or artifact.project_id != project_id:
+            return None
+        return artifact
+    return _single_local_artifact_by_type(local, project_id=project_id, artifact_type="source_audio")
+
+
+def _analysis_remote_source_artifact(
+    remote: _RemoteRequest,
+    *,
+    project_id: str,
+    source_artifact_id: str | None,
+) -> _RemoteArtifact | None:
+    if source_artifact_id is not None:
+        artifact = remote.artifacts.get(source_artifact_id)
+        if artifact is None or artifact.project_id != project_id:
+            return None
+        return artifact
+    return _single_remote_artifact_by_type(remote, project_id=project_id, artifact_type="source_audio")
+
+
+def _single_local_artifact_by_type(
+    local: _LocalState,
+    *,
+    project_id: str,
+    artifact_type: str,
+) -> Artifact | None:
+    matches = [
+        artifact
+        for artifact in local.artifacts.values()
+        if artifact.project_id == project_id and _normalize_artifact_type(artifact.type) == artifact_type
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _single_remote_artifact_by_type(
+    remote: _RemoteRequest,
+    *,
+    project_id: str,
+    artifact_type: str,
+) -> _RemoteArtifact | None:
+    matches = [
+        artifact
+        for artifact in remote.artifacts.values()
+        if artifact.project_id == project_id and _normalize_artifact_type(artifact.type) == artifact_type
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _analysis_metadata_source_stem_hashes(metadata: Mapping[str, Any]) -> tuple[str, ...] | None:
+    for key in _ANALYSIS_SOURCE_STEM_HASH_METADATA_KEYS:
+        if key in metadata:
+            return _stable_hashes_from_value(metadata[key])
+    for key in _ANALYSIS_SOURCE_STEM_ARTIFACT_METADATA_KEYS:
+        if key in metadata:
+            return _stable_hashes_from_value(metadata[key])
+    return None
+
+
+def _metadata_source_artifact_sha256(metadata: Mapping[str, Any]) -> str | None:
+    for key in (
+        "source_artifact_sha256",
+        "source_artifact_content_sha256",
+        "source_content_sha256",
+        "source_sha256",
+    ):
+        content_hash = _normalize_sha256(metadata.get(key))
+        if content_hash is not None and _is_sha256(content_hash):
+            return content_hash
+    return None
+
+
+def _stable_hashes_from_value(value: object) -> tuple[str, ...]:
+    hashes: set[str] = set()
+
+    def collect(candidate: object) -> None:
+        if isinstance(candidate, Mapping):
+            for hash_key in ("content_sha256", "sha256", "content_hash"):
+                content_hash = _normalize_sha256(candidate.get(hash_key))
+                if content_hash is not None and _is_sha256(content_hash):
+                    hashes.add(content_hash)
+                    return
+            for child in candidate.values():
+                collect(child)
+            return
+        if isinstance(candidate, (list, tuple, set, frozenset)):
+            for child in candidate:
+                collect(child)
+            return
+        content_hash = _normalize_sha256(candidate)
+        if content_hash is not None and _is_sha256(content_hash):
+            hashes.add(content_hash)
+
+    collect(value)
+    return tuple(sorted(hashes))
+
+
+def _local_source_stem_hashes(
+    local: _LocalState,
+    *,
+    project_id: str,
+    source_artifact_id: str,
+) -> tuple[str, ...]:
+    hashes = [
+        content_hash
+        for artifact in local.artifacts.values()
+        if artifact.project_id == project_id
+        and _is_source_stem_artifact_type(artifact.type)
+        and _artifact_uses_source_artifact(artifact, source_artifact_id)
+        if (content_hash := _normalize_sha256(artifact.content_sha256)) is not None
+    ]
+    return tuple(sorted(hashes))
+
+
+def _remote_source_stem_hashes(
+    remote: _RemoteRequest,
+    *,
+    project_id: str,
+    source_artifact_id: str,
+) -> tuple[str, ...]:
+    hashes = [
+        artifact.content_sha256
+        for artifact in remote.artifacts.values()
+        if artifact.project_id == project_id
+        and _is_source_stem_artifact_type(artifact.type)
+        and _remote_artifact_uses_source_artifact(artifact, source_artifact_id)
+        and artifact.content_sha256 is not None
+    ]
+    return tuple(sorted(hashes))
+
+
+def _is_source_stem_artifact_type(artifact_type: str | None) -> bool:
+    normalized = _normalize_artifact_type(artifact_type)
+    return normalized in _ANALYSIS_SOURCE_STEM_ARTIFACT_TYPES
+
+
+def _artifact_uses_source_artifact(artifact: Artifact, source_artifact_id: str) -> bool:
+    metadata = _local_artifact_metadata(artifact)
+    if _str_field(metadata, "source_artifact_id") != source_artifact_id:
+        return False
+    source_type = _str_field(metadata, "source_artifact_type")
+    return source_type in {None, "source_audio"}
+
+
+def _remote_artifact_uses_source_artifact(artifact: _RemoteArtifact, source_artifact_id: str) -> bool:
+    metadata = _remote_artifact_metadata(artifact)
+    if _str_field(metadata, "source_artifact_id") != source_artifact_id:
+        return False
+    source_type = _str_field(metadata, "source_artifact_type")
+    return source_type in {None, "source_audio"}
+
+
+def _local_artifact_metadata(artifact: Artifact) -> Mapping[str, Any]:
+    metadata = artifact.metadata_json
+    return metadata if isinstance(metadata, Mapping) else {}
+
+
+def _remote_artifact_metadata(artifact: _RemoteArtifact) -> Mapping[str, Any]:
+    metadata = _first_field(artifact.raw, "metadata", "metadata_json", default={})
+    return metadata if isinstance(metadata, Mapping) else {}
+
+
+def _remote_artifact_can_regenerate(artifact: _RemoteArtifact) -> bool | None:
+    return _bool_field(artifact.raw, "can_regenerate")
+
+
+def _normalize_artifact_type(value: str | None) -> str:
+    return (value or "").strip().lower()
+
+
+def _datetime_detail(value: datetime | None) -> str | None:
+    return None if value is None else value.isoformat()
+
+
 def _divergent_local_revision(
     remote_revision: _RemoteEntityRevision,
     local: _LocalState,
@@ -2730,6 +3343,19 @@ def _int_field(source: object, *names: str) -> int | None:
         return value
     if isinstance(value, str) and value.isdecimal():
         return int(value)
+    return None
+
+
+def _bool_field(source: object, *names: str) -> bool | None:
+    value = _first_field(source, *names, default=None)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == "true":
+            return True
+        if normalized == "false":
+            return False
     return None
 
 

--- a/apps/backend/app/services/sync_reconciliation_apply.py
+++ b/apps/backend/app/services/sync_reconciliation_apply.py
@@ -8,7 +8,9 @@ from datetime import UTC, datetime
 from pathlib import Path
 from time import perf_counter
 from typing import Any
+from uuid import uuid4
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.errors import AppError
@@ -16,6 +18,7 @@ from app.models import Artifact, Project, SyncDeleteTombstone, SyncEntityRevisio
 from app.services.artifacts import register_artifact
 from app.services.paths import project_root
 from app.services.sync_manifest import (
+    SyncArtifactManifest,
     _coerce_project_manifest,
     _hydrate_current_entity_revisions,
     _normalize_revision_state,
@@ -33,6 +36,7 @@ from app.services.sync_reconciliation import (
     ACTION_NOOP,
     ACTION_RECORD_CONFLICT,
     ACTION_UPSERT_PROJECT_STATUS,
+    ITEM_ARTIFACT,
     ITEM_ENTITY_REVISION,
     ITEM_PROJECT,
     SyncReconciliationAction,
@@ -55,6 +59,7 @@ TIMING_PHASE_ACTION = "action"
 TIMING_PHASE_STAGING_CLEANUP = "staging_cleanup"
 
 _MISSING = object()
+_CANONICAL_ANALYSIS_JSON_RELATIVE_PATH = Path("analysis") / "analysis.json"
 
 
 @dataclass(frozen=True)
@@ -311,43 +316,78 @@ def _import_artifact_manifest(
     if artifact_manifest.project_id != project_id:
         return _result(action, APPLY_STATUS_FAILED, "Artifact manifest belongs to a different project.")
 
+    destination_has_manifest_bytes = False
     existing_artifact = session.get(Artifact, artifact_manifest.artifact_id)
     if existing_artifact is not None:
-        if (
+        has_manifest_conflict = (
             existing_artifact.project_id != project_id
             or existing_artifact.content_sha256 != artifact_manifest.content_sha256
             or existing_artifact.size_bytes != artifact_manifest.size_bytes
-        ):
+        )
+        overwrite_generated_analysis = _can_overwrite_generated_analysis_artifact(
+            action,
+            existing_artifact,
+            artifact_manifest,
+        )
+        if has_manifest_conflict and not overwrite_generated_analysis:
             return _result(action, APPLY_STATUS_FAILED, "Artifact manifest conflicts with a local artifact.")
         existing_path = Path(existing_artifact.path)
-        if (
+        existing_resolved_path = existing_path.resolve(strict=False)
+        if not has_manifest_conflict and (
             existing_path.exists()
             and existing_path.stat().st_size == artifact_manifest.size_bytes
             and file_sha256(existing_path) == artifact_manifest.content_sha256
         ):
             return _result(action, APPLY_STATUS_SATISFIED, "Artifact manifest is already imported locally.")
-        destination_path = existing_path
+        if overwrite_generated_analysis:
+            destination_path = _generated_analysis_overwrite_destination(project_id, existing_artifact)
+            if _destination_conflicts_with_existing_artifact(
+                session,
+                destination_path,
+                existing_artifact,
+            ) or (
+                destination_path.exists()
+                and existing_resolved_path != destination_path.resolve(strict=False)
+                and not _copied_artifact_matches_manifest(destination_path, artifact_manifest)
+            ):
+                return _result(action, APPLY_STATUS_FAILED, "Artifact destination already exists locally.")
+            destination_has_manifest_bytes = _copied_artifact_matches_manifest(destination_path, artifact_manifest)
+        else:
+            destination_path = existing_path
     else:
-        destination_path = project_root(project_id) / _safe_relative_path(artifact_manifest.relative_path)
+        destination_path = _resolve_project_destination_path(project_id, artifact_manifest.relative_path)
         if destination_path.exists():
-            return _result(action, APPLY_STATUS_FAILED, "Artifact destination already exists locally.")
+            if _destination_owned_by_other_artifact(
+                session,
+                destination_path,
+                exclude_artifact_id=artifact_manifest.artifact_id,
+            ) or not _copied_artifact_matches_manifest(destination_path, artifact_manifest):
+                return _result(action, APPLY_STATUS_FAILED, "Artifact destination already exists locally.")
+            destination_has_manifest_bytes = True
 
-    try:
-        staged_artifact = require_staged_artifact(
-            session,
-            content_sha256=artifact_manifest.content_sha256,
-            size_bytes=artifact_manifest.size_bytes,
-        )
-    except AppError as exc:
-        return _result(
-            action,
-            APPLY_STATUS_SKIPPED,
-            "Artifact manifest import is waiting for staged artifact content.",
-            details={"error_code": exc.code, "error_details": exc.details},
-        )
+    if not destination_has_manifest_bytes:
+        try:
+            staged_artifact = require_staged_artifact(
+                session,
+                content_sha256=artifact_manifest.content_sha256,
+                size_bytes=artifact_manifest.size_bytes,
+            )
+        except AppError as exc:
+            return _result(
+                action,
+                APPLY_STATUS_SKIPPED,
+                "Artifact manifest import is waiting for staged artifact content.",
+                details={"error_code": exc.code, "error_details": exc.details},
+            )
 
-    destination_path.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(staged_artifact.resolved_path, destination_path)
+        if not _copy_staged_artifact_verified(
+            staged_artifact.resolved_path,
+            destination_path,
+            artifact_manifest,
+        ):
+            return _result(action, APPLY_STATUS_FAILED, "Copied artifact bytes do not match the manifest.")
+    if not _copied_artifact_matches_manifest(destination_path, artifact_manifest):
+        return _result(action, APPLY_STATUS_FAILED, "Copied artifact bytes do not match the manifest.")
     if existing_artifact is None:
         imported_artifact = register_artifact(
             session,
@@ -364,18 +404,17 @@ def _import_artifact_manifest(
             created_at=artifact_manifest.created_at,
         )
     else:
-        existing_artifact.path = str(destination_path)
-        existing_artifact.metadata_json = deepcopy(artifact_manifest.metadata)
-        existing_artifact.cache_key = artifact_manifest.cache_key
-        existing_artifact.generated_by = artifact_manifest.generated_by
-        existing_artifact.can_delete = artifact_manifest.can_delete
-        existing_artifact.can_regenerate = artifact_manifest.can_regenerate
+        _update_existing_artifact_from_manifest(existing_artifact, artifact_manifest, destination_path)
         imported_artifact = existing_artifact
     if (
         imported_artifact.content_sha256 != artifact_manifest.content_sha256
         or imported_artifact.size_bytes != artifact_manifest.size_bytes
+        or not _copied_artifact_matches_manifest(Path(imported_artifact.path), artifact_manifest)
     ):
-        return _result(action, APPLY_STATUS_FAILED, "Copied artifact bytes do not match the manifest.")
+        raise AppError(
+            "SYNC_RECONCILIATION_COPIED_ARTIFACT_MISMATCH",
+            "Copied artifact bytes do not match the manifest.",
+        )
     if artifact_manifest.type == "analysis_json":
         hydrate_project_analysis_result_from_artifact(session, project_id)
     session.flush()
@@ -385,6 +424,164 @@ def _import_artifact_manifest(
         "Artifact manifest was imported into the existing project.",
         details={"artifact_id": artifact_manifest.artifact_id, "project_id": project_id},
     )
+
+
+def _can_overwrite_generated_analysis_artifact(
+    action: SyncReconciliationAction,
+    existing_artifact: Artifact,
+    artifact_manifest: SyncArtifactManifest,
+) -> bool:
+    return (
+        action.item_type == ITEM_ARTIFACT
+        and action.details.get("generated_divergence_candidate") is True
+        and action.details.get("generated_divergence_resolvable") is True
+        and action.details.get("resolution") == "fetch_remote"
+        and action.details.get("resolution_reason") == "Remote analysis_json generation timestamp is newer."
+        and action.details.get("artifact_type") == "analysis_json"
+        and action.details.get("artifact_id") == artifact_manifest.artifact_id
+        and action.details.get("remote_content_sha256") == artifact_manifest.content_sha256
+        and action.content_sha256 == artifact_manifest.content_sha256
+        and existing_artifact.id == artifact_manifest.artifact_id
+        and existing_artifact.project_id == artifact_manifest.project_id
+        and existing_artifact.type == "analysis_json"
+        and artifact_manifest.type == "analysis_json"
+        and existing_artifact.can_regenerate is True
+        and artifact_manifest.can_regenerate is True
+    )
+
+
+def _generated_analysis_overwrite_destination(
+    project_id: str,
+    existing_artifact: Artifact,
+) -> Path:
+    root = _resolved_project_root(project_id)
+    existing_path = Path(existing_artifact.path).resolve(strict=False)
+    if _is_safe_analysis_json_destination(root, existing_path):
+        return existing_path
+
+    destination_path = (root / _CANONICAL_ANALYSIS_JSON_RELATIVE_PATH).resolve(strict=False)
+    _ensure_path_under_project_root(root, destination_path)
+    return destination_path
+
+
+def _resolve_project_destination_path(project_id: str, relative_path: str) -> Path:
+    root = _resolved_project_root(project_id)
+    destination_path = (root / _safe_relative_path(relative_path)).resolve(strict=False)
+    _ensure_path_under_project_root(root, destination_path)
+    return destination_path
+
+
+def _resolved_project_root(project_id: str) -> Path:
+    return project_root(project_id).resolve(strict=False)
+
+
+def _ensure_path_under_project_root(root: Path, path: Path) -> None:
+    try:
+        path.relative_to(root)
+    except ValueError as exc:
+        raise AppError(
+            "SYNC_RECONCILIATION_ARTIFACT_DESTINATION_INVALID",
+            "Artifact destination escapes the project root.",
+        ) from exc
+
+
+def _is_safe_analysis_json_destination(root: Path, path: Path) -> bool:
+    try:
+        relative_path = path.relative_to(root)
+    except ValueError:
+        return False
+    return (
+        len(relative_path.parts) == 2
+        and relative_path.parts[0] == "analysis"
+        and relative_path.suffix.lower() == ".json"
+    )
+
+
+def _copy_staged_artifact_verified(
+    source_path: Path,
+    destination_path: Path,
+    artifact_manifest: SyncArtifactManifest,
+) -> bool:
+    destination_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = _temporary_artifact_copy_path(destination_path)
+    try:
+        shutil.copy2(source_path, temp_path)
+        if not _copied_artifact_matches_manifest(temp_path, artifact_manifest):
+            return False
+        temp_path.replace(destination_path)
+    except OSError as exc:
+        raise AppError(
+            "SYNC_RECONCILIATION_ARTIFACT_COPY_FAILED",
+            "A staged artifact could not be copied into the local project store.",
+        ) from exc
+    finally:
+        try:
+            temp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+    return True
+
+
+def _temporary_artifact_copy_path(destination_path: Path) -> Path:
+    return destination_path.with_name(f".{destination_path.name}.{uuid4().hex}.tmp")
+
+
+def _destination_conflicts_with_existing_artifact(
+    session: Session,
+    destination_path: Path,
+    existing_artifact: Artifact,
+) -> bool:
+    destination_resolved = destination_path.resolve(strict=False)
+    existing_resolved = Path(existing_artifact.path).resolve(strict=False)
+    if destination_resolved == existing_resolved:
+        return False
+
+    for _artifact_id, artifact_path in session.execute(
+        select(Artifact.id, Artifact.path).where(Artifact.id != existing_artifact.id)
+    ):
+        if destination_resolved == Path(artifact_path).resolve(strict=False):
+            return True
+    return False
+
+
+def _destination_owned_by_other_artifact(
+    session: Session,
+    destination_path: Path,
+    *,
+    exclude_artifact_id: str,
+) -> bool:
+    destination_resolved = destination_path.resolve(strict=False)
+    for _artifact_id, artifact_path in session.execute(
+        select(Artifact.id, Artifact.path).where(Artifact.id != exclude_artifact_id)
+    ):
+        if destination_resolved == Path(artifact_path).resolve(strict=False):
+            return True
+    return False
+
+
+def _update_existing_artifact_from_manifest(
+    artifact: Artifact,
+    artifact_manifest: SyncArtifactManifest,
+    destination_path: Path,
+) -> None:
+    artifact.path = str(destination_path.resolve(strict=False))
+    artifact.metadata_json = deepcopy(artifact_manifest.metadata)
+    artifact.cache_key = artifact_manifest.cache_key
+    artifact.generated_by = artifact_manifest.generated_by
+    artifact.can_delete = artifact_manifest.can_delete
+    artifact.can_regenerate = artifact_manifest.can_regenerate
+    artifact.content_sha256 = artifact_manifest.content_sha256
+    artifact.size_bytes = artifact_manifest.size_bytes
+    artifact.created_at = artifact_manifest.created_at
+
+
+def _copied_artifact_matches_manifest(path: Path, artifact_manifest: SyncArtifactManifest) -> bool:
+    try:
+        if not path.exists() or path.stat().st_size != artifact_manifest.size_bytes:
+            return False
+    except OSError:
+        return False
+    return file_sha256(path) == artifact_manifest.content_sha256
 
 
 def _import_entity_revision(

--- a/apps/backend/tests/test_analysis_flow.py
+++ b/apps/backend/tests/test_analysis_flow.py
@@ -9,7 +9,7 @@ from sqlalchemy import select
 
 from app.db import SessionLocal
 from app.errors import AppError
-from app.models import AnalysisResult, Job, Project
+from app.models import AnalysisResult, Artifact, Job, Project
 from app.services import analysis as analysis_service
 from app.services.artifacts import register_artifact
 from app.services.paths import ensure_project_dirs
@@ -125,6 +125,128 @@ def test_analysis_passes_latest_source_drums_and_bass_stems_only(
     assert analysis.source_artifact_id == "art_analysis_source"
     assert captured["track_path"] == sample_audio_file
     assert captured["source_stem_paths"] == (source_drums_path, source_bass_path)
+
+
+def test_reanalysis_updates_analysis_artifact_sync_metadata(
+    client,
+    sample_audio_file: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    del client
+    project_id = "analysis_metadata_project"
+    source_drums_path = tmp_path / "metadata-source-drums.wav"
+    source_bass_path = tmp_path / "metadata-source-bass.wav"
+    preview_drums_path = tmp_path / "metadata-preview-drums.wav"
+    preview_bass_path = tmp_path / "metadata-preview-bass.wav"
+    for path in (
+        source_drums_path,
+        source_bass_path,
+        preview_drums_path,
+        preview_bass_path,
+    ):
+        path.write_bytes(path.name.encode("utf-8"))
+
+    _seed_project_with_source_stems(
+        project_id=project_id,
+        source_path=sample_audio_file,
+        source_drums_path=source_drums_path,
+        source_bass_path=source_bass_path,
+        preview_drums_path=preview_drums_path,
+        preview_bass_path=preview_bass_path,
+    )
+
+    timestamps = iter(
+        [
+            "2026-01-02T03:04:05+00:00",
+            "2026-01-03T03:04:05+00:00",
+        ]
+    )
+    monkeypatch.setattr(analysis_service, "_analysis_generated_at_iso", lambda: next(timestamps))
+
+    def fake_analyze_track(track_path: Path, *, source_stem_paths: tuple[Path, ...] | None = None):
+        assert track_path == sample_audio_file
+        assert source_stem_paths == (source_drums_path, source_bass_path)
+        return {
+            "estimated_key": "C major",
+            "key_confidence": 0.8,
+            "estimated_reference_hz": 440.0,
+            "tuning_offset_cents": 0.0,
+            "tempo_bpm": 120.0,
+            "timing": _timing_payload(source="built-in"),
+        }
+
+    def fake_beat_this(
+        track_path: Path,
+        *,
+        source_stem_paths: tuple[Path, ...] | None = None,
+        duration_seconds: float | None = None,
+    ):
+        assert track_path == sample_audio_file
+        assert source_stem_paths == (source_drums_path, source_bass_path)
+        assert duration_seconds == 4.0
+        return {
+            "estimated_key": "D minor",
+            "key_confidence": 0.7,
+            "estimated_reference_hz": 441.0,
+            "tuning_offset_cents": 1.5,
+            "tempo_bpm": 90.0,
+            "timing": _timing_payload(source="beat-this"),
+        }
+
+    monkeypatch.setattr(analysis_service, "analyze_track", fake_analyze_track)
+    monkeypatch.setattr(analysis_service, "beat_this_dependency_status", lambda: (True, None))
+    monkeypatch.setattr(analysis_service, "analyze_track_with_beat_this", fake_beat_this)
+
+    with SessionLocal() as session:
+        project = session.get(Project, project_id)
+        assert project is not None
+        analysis_service.analyze_project(session, project)
+        first_artifact = _analysis_artifact(session, project_id)
+        source_artifact = session.get(Artifact, "art_analysis_source")
+        drums_artifact = session.get(Artifact, "art_source_drums")
+        bass_artifact = session.get(Artifact, "art_source_bass")
+        assert source_artifact is not None
+        assert drums_artifact is not None
+        assert bass_artifact is not None
+        expected_source_sha = source_artifact.content_sha256
+        expected_stem_sha256s = [drums_artifact.content_sha256, bass_artifact.content_sha256]
+        first_artifact_id = first_artifact.id
+        first_content_sha256 = first_artifact.content_sha256
+        session.commit()
+
+    expected_common_metadata = {
+        "analysis_version": "v3",
+        "source_artifact_id": "art_analysis_source",
+        "source_artifact_sha256": expected_source_sha,
+        "source_stem_artifact_ids": ["art_source_drums", "art_source_bass"],
+        "source_stem_content_sha256s": expected_stem_sha256s,
+    }
+    first_payload = _analysis_payload(first_artifact)
+    assert first_artifact.metadata_json == {
+        "analysis_generated_at": "2026-01-02T03:04:05+00:00",
+        "analysis_backend": "built-in",
+        **expected_common_metadata,
+    }
+    assert {key: first_payload[key] for key in first_artifact.metadata_json} == first_artifact.metadata_json
+
+    with SessionLocal() as session:
+        project = session.get(Project, project_id)
+        assert project is not None
+        analysis_service.analyze_project(session, project, beat_backend="beat-this")
+        second_artifact = _analysis_artifact(session, project_id)
+        session.commit()
+
+    second_payload = _analysis_payload(second_artifact)
+    assert second_artifact.id == first_artifact_id
+    assert second_artifact.content_sha256 != first_content_sha256
+    assert second_artifact.metadata_json == {
+        "analysis_generated_at": "2026-01-03T03:04:05+00:00",
+        "analysis_backend": "beat-this",
+        **expected_common_metadata,
+    }
+    assert {key: second_payload[key] for key in second_artifact.metadata_json} == second_artifact.metadata_json
+    assert second_payload["estimated_key"] == "D minor"
 
 
 def test_project_import_carries_beat_backend_to_initial_analysis_job(
@@ -515,6 +637,23 @@ def _seed_project_with_source_stems(
 def _assert_timing_bar_indexes_are_nonnegative(timing: dict) -> None:
     assert all(beat["bar_index"] >= 0 for beat in timing["beats"])
     assert all(bar["index"] >= 0 for bar in timing["bars"])
+
+
+def _analysis_artifact(session, project_id: str) -> Artifact:
+    artifact = session.scalar(
+        select(Artifact).where(
+            Artifact.project_id == project_id,
+            Artifact.type == "analysis_json",
+        )
+    )
+    assert artifact is not None
+    return artifact
+
+
+def _analysis_payload(artifact: Artifact) -> dict:
+    payload = json.loads(Path(artifact.path).read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
 
 
 def _timing_payload(*, source: str = "detected") -> dict:

--- a/apps/backend/tests/test_sync_identity.py
+++ b/apps/backend/tests/test_sync_identity.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -123,13 +124,18 @@ def test_sync_metadata_exposes_sync_safe_project_and_artifact_metadata(
     project_id = source_hash_to_project_id(source_hash)
     root = project_root(project_id)
     project_artifact_path = root / "stems" / "vocals.wav"
+    analysis_artifact_path = root / "analysis" / "analysis.json"
     external_artifact_path = tmp_path / "external.wav"
     project_artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    analysis_artifact_path.parent.mkdir(parents=True, exist_ok=True)
     project_artifact_path.write_bytes(b"project artifact")
+    analysis_artifact_path.write_text(json.dumps({"project_id": project_id}), encoding="utf-8")
     external_artifact_path.write_bytes(b"external artifact")
     project_artifact_hash = file_sha256(project_artifact_path)
+    analysis_artifact_hash = file_sha256(analysis_artifact_path)
     external_artifact_hash = file_sha256(external_artifact_path)
     assert project_artifact_hash is not None
+    assert analysis_artifact_hash is not None
     assert external_artifact_hash is not None
 
     with SessionLocal() as session:
@@ -183,6 +189,28 @@ def test_sync_metadata_exposes_sync_safe_project_and_artifact_metadata(
                     },
                 ),
                 Artifact(
+                    id="art_analysis_json",
+                    project_id=project.id,
+                    type="analysis_json",
+                    format="json",
+                    path=str(analysis_artifact_path),
+                    content_sha256=analysis_artifact_hash,
+                    size_bytes=analysis_artifact_path.stat().st_size,
+                    generated_by="analysis",
+                    can_delete=True,
+                    can_regenerate=True,
+                    metadata_json={
+                        "analysis_generated_at": "2026-01-02T03:04:05+00:00",
+                        "analysis_backend": "built-in",
+                        "analysis_version": "v3",
+                        "source_artifact_id": "art_source",
+                        "source_artifact_sha256": source_hash,
+                        "source_stem_artifact_ids": ["art_project_safe"],
+                        "source_stem_content_sha256s": [project_artifact_hash],
+                        "source_path": str(sample_audio_file),
+                    },
+                ),
+                Artifact(
                     id="art_external",
                     project_id=project.id,
                     type="external_reference",
@@ -220,7 +248,7 @@ def test_sync_metadata_exposes_sync_safe_project_and_artifact_metadata(
     assert "imported_path" not in project_payload
 
     artifacts = {artifact["artifact_id"]: artifact for artifact in payload["artifacts"]}
-    assert set(artifacts) == {"art_project_safe", "art_external"}
+    assert set(artifacts) == {"art_project_safe", "art_analysis_json", "art_external"}
     safe_artifact = artifacts["art_project_safe"]
     assert safe_artifact["project_id"] == project_id
     assert safe_artifact["type"] == "vocals"
@@ -241,6 +269,19 @@ def test_sync_metadata_exposes_sync_safe_project_and_artifact_metadata(
     }
     assert "path" not in safe_artifact
     assert "result_artifact_ids_json" not in safe_artifact
+
+    analysis_artifact = artifacts["art_analysis_json"]
+    assert analysis_artifact["relative_path"] == "analysis/analysis.json"
+    assert analysis_artifact["content_sha256"] == analysis_artifact_hash
+    assert analysis_artifact["metadata"] == {
+        "analysis_generated_at": "2026-01-02T03:04:05+00:00",
+        "analysis_backend": "built-in",
+        "analysis_version": "v3",
+        "source_artifact_id": "art_source",
+        "source_artifact_sha256": source_hash,
+        "source_stem_artifact_ids": ["art_project_safe"],
+        "source_stem_content_sha256s": [project_artifact_hash],
+    }
 
     external_artifact = artifacts["art_external"]
     assert external_artifact["relative_path"] is None

--- a/apps/backend/tests/test_sync_manifest.py
+++ b/apps/backend/tests/test_sync_manifest.py
@@ -632,6 +632,103 @@ def test_export_project_manifest_omits_local_paths_and_includes_sync_safe_fields
     }
 
 
+def test_export_project_manifest_includes_analysis_divergence_metadata(
+    client: object,
+    tmp_path: Path,
+) -> None:
+    del client
+    export_manifest, _ = _sync_manifest_services()
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path)
+        analysis_path = fixture.root / "analysis" / "analysis.json"
+        analysis_metadata = {
+            "analysis_generated_at": "2026-01-02T03:04:05+00:00",
+            "analysis_backend": "beat-this",
+            "analysis_version": "v3",
+            "source_artifact_id": "art_source_audio",
+            "source_artifact_sha256": fixture.artifact_hashes["art_source_audio"],
+            "source_stem_artifact_ids": ["art_vocals"],
+            "source_stem_content_sha256s": [fixture.artifact_hashes["art_vocals"]],
+        }
+        analysis_payload = {"project_id": fixture.project_id, **analysis_metadata}
+        analysis_hash, analysis_size = _write_bytes(
+            analysis_path,
+            json.dumps(analysis_payload, sort_keys=True).encode("utf-8"),
+        )
+        session.add(
+            Artifact(
+                id="art_analysis_json",
+                project_id=fixture.project_id,
+                type="analysis_json",
+                format="json",
+                path=str(analysis_path),
+                content_sha256=analysis_hash,
+                size_bytes=analysis_size,
+                generated_by="analysis",
+                can_delete=True,
+                can_regenerate=True,
+                metadata_json={
+                    **analysis_metadata,
+                    "source_path": str(tmp_path / "local-source.wav"),
+                },
+            )
+        )
+        session.commit()
+
+        manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+
+    analysis_artifact = _artifacts_by_id(manifest)["art_analysis_json"]
+    assert analysis_artifact["relative_path"] == "analysis/analysis.json"
+    assert analysis_artifact["content_sha256"] == analysis_hash
+    assert analysis_artifact["metadata"] == analysis_metadata
+
+
+def test_export_project_manifest_backfills_analysis_generated_at_from_file_mtime(
+    client: object,
+    tmp_path: Path,
+) -> None:
+    del client
+    export_manifest, _ = _sync_manifest_services()
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path)
+        analysis_path = fixture.root / "analysis" / "analysis.json"
+        analysis_metadata = {
+            "analysis_backend": "beat-this",
+            "analysis_version": "v3",
+            "source_artifact_id": "art_source_audio",
+            "source_artifact_sha256": fixture.artifact_hashes["art_source_audio"],
+        }
+        analysis_hash, analysis_size = _write_bytes(
+            analysis_path,
+            json.dumps({"project_id": fixture.project_id, **analysis_metadata}).encode("utf-8"),
+        )
+        generated_at = datetime.fromtimestamp(analysis_path.stat().st_mtime, UTC).isoformat()
+        session.add(
+            Artifact(
+                id="art_legacy_analysis_json",
+                project_id=fixture.project_id,
+                type="analysis_json",
+                format="json",
+                path=str(analysis_path),
+                content_sha256=analysis_hash,
+                size_bytes=analysis_size,
+                generated_by="analysis",
+                can_delete=True,
+                can_regenerate=True,
+                metadata_json=analysis_metadata,
+            )
+        )
+        session.commit()
+
+        manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+
+    analysis_artifact = _artifacts_by_id(manifest)["art_legacy_analysis_json"]
+    assert analysis_artifact["metadata"] == {
+        **analysis_metadata,
+        "analysis_generated_at": generated_at,
+    }
+
+
 def test_export_project_manifest_includes_entity_revisions_without_local_paths(
     client: object,
     tmp_path: Path,

--- a/apps/backend/tests/test_sync_reconciliation.py
+++ b/apps/backend/tests/test_sync_reconciliation.py
@@ -165,6 +165,185 @@ def test_artifact_classification_uses_recorded_metadata_and_trusted_provider_cho
     assert _action(plan, ACTION_IMPORT_ARTIFACT_MANIFEST, ITEM_ARTIFACT, "art_duplicate_content") is not None
 
 
+def test_generated_analysis_same_hash_noops_even_when_remote_timestamp_is_newer(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    local_generated_at = datetime(2026, 1, 1, tzinfo=UTC)
+    remote_generated_at = datetime(2026, 1, 2, tzinfo=UTC)
+    analysis_hash = _sha("same generated analysis")
+    request = _seed_generated_analysis_divergence(
+        db_session,
+        tmp_path,
+        local_analysis_hash=analysis_hash,
+        remote_analysis_hash=analysis_hash,
+        local_generated_at=local_generated_at,
+        remote_generated_at=remote_generated_at,
+    )
+
+    plan = plan_sync_reconciliation(db_session, request)
+
+    analysis_item = _item(plan, ITEM_ARTIFACT, "art_generated_analysis")
+    assert analysis_item.status == "identical_content"
+    assert analysis_item.action_type == ACTION_NOOP
+    assert _action(plan, ACTION_FETCH_ARTIFACT_CONTENT, ITEM_ARTIFACT, "art_generated_analysis") is None
+    assert _action(plan, ACTION_IMPORT_ARTIFACT_MANIFEST, ITEM_ARTIFACT, "art_generated_analysis") is None
+    assert _action(plan, ACTION_RECORD_CONFLICT, ITEM_ARTIFACT, "art_generated_analysis") is None
+
+
+def test_generated_analysis_remote_newer_fetches_and_imports_without_conflict(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    local_hash = _sha("local generated analysis")
+    remote_hash = _sha("remote generated analysis")
+    request = _seed_generated_analysis_divergence(
+        db_session,
+        tmp_path,
+        local_analysis_hash=local_hash,
+        remote_analysis_hash=remote_hash,
+        local_generated_at=datetime(2026, 1, 1, tzinfo=UTC),
+        remote_generated_at=datetime(2026, 1, 2, tzinfo=UTC),
+    )
+
+    plan = plan_sync_reconciliation(db_session, request)
+
+    analysis_item = _item(plan, ITEM_ARTIFACT, "art_generated_analysis")
+    assert analysis_item.status == "remote_available"
+    assert analysis_item.action_type == ACTION_FETCH_ARTIFACT_CONTENT
+    assert analysis_item.chosen_provider_device_id == "peer-a"
+    assert analysis_item.details["artifact_type"] == "analysis_json"
+    assert analysis_item.details["artifact_id"] == "art_generated_analysis"
+    assert analysis_item.details["local_content_sha256"] == local_hash
+    assert analysis_item.details["remote_content_sha256"] == remote_hash
+    assert analysis_item.details["generated_divergence_resolvable"] is True
+    assert analysis_item.details["resolution"] == "fetch_remote"
+    assert _item(plan, ITEM_PROJECT, "proj_generated_analysis").status == "noop"
+    assert plan.summary.total_conflicts == 0
+    assert _action(plan, ACTION_RECORD_CONFLICT, ITEM_ARTIFACT, "art_generated_analysis") is None
+    assert _action(plan, ACTION_FETCH_ARTIFACT_CONTENT, ITEM_ARTIFACT, "art_generated_analysis") is not None
+    assert _action(plan, ACTION_IMPORT_ARTIFACT_MANIFEST, ITEM_ARTIFACT, "art_generated_analysis") is not None
+
+
+@pytest.mark.parametrize(
+    ("remote_generated_at", "expected_reason"),
+    [
+        (datetime(2025, 12, 31, tzinfo=UTC), "Local analysis_json generation timestamp is newer."),
+        (datetime(2026, 1, 1, tzinfo=UTC), "Analysis generation timestamps tie; keeping local analysis_json."),
+    ],
+)
+def test_generated_analysis_local_newer_or_tie_keeps_local_noop(
+    db_session: Session,
+    tmp_path: Path,
+    remote_generated_at: datetime,
+    expected_reason: str,
+) -> None:
+    local_hash = _sha("kept local generated analysis")
+    remote_hash = _sha(f"remote generated analysis {remote_generated_at.isoformat()}")
+    request = _seed_generated_analysis_divergence(
+        db_session,
+        tmp_path,
+        local_analysis_hash=local_hash,
+        remote_analysis_hash=remote_hash,
+        local_generated_at=datetime(2026, 1, 1, tzinfo=UTC),
+        remote_generated_at=remote_generated_at,
+    )
+
+    plan = plan_sync_reconciliation(db_session, request)
+
+    analysis_item = _item(plan, ITEM_ARTIFACT, "art_generated_analysis")
+    assert analysis_item.status == "noop"
+    assert analysis_item.action_type == ACTION_NOOP
+    assert analysis_item.reason == expected_reason
+    assert analysis_item.details["generated_divergence_resolvable"] is True
+    assert analysis_item.details["resolution"] == "keep_local"
+    assert _action(plan, ACTION_FETCH_ARTIFACT_CONTENT, ITEM_ARTIFACT, "art_generated_analysis") is None
+    assert _action(plan, ACTION_IMPORT_ARTIFACT_MANIFEST, ITEM_ARTIFACT, "art_generated_analysis") is None
+    assert _action(plan, ACTION_RECORD_CONFLICT, ITEM_ARTIFACT, "art_generated_analysis") is None
+
+
+@pytest.mark.parametrize(
+    ("missing_side", "expected_local_source", "expected_remote_source"),
+    [
+        ("local", "missing", "metadata.analysis_generated_at"),
+        ("remote", "metadata.analysis_generated_at", "missing"),
+    ],
+)
+def test_generated_analysis_missing_generation_metadata_keeps_local_noop(
+    db_session: Session,
+    tmp_path: Path,
+    missing_side: str,
+    expected_local_source: str,
+    expected_remote_source: str,
+) -> None:
+    request = _seed_generated_analysis_divergence(
+        db_session,
+        tmp_path,
+        local_analysis_hash=_sha("local generated analysis missing timestamp"),
+        remote_analysis_hash=_sha(f"remote generated analysis missing {missing_side} timestamp"),
+        local_generated_at=None if missing_side == "local" else datetime(2026, 1, 1, tzinfo=UTC),
+        remote_generated_at=None if missing_side == "remote" else datetime(2026, 1, 2, tzinfo=UTC),
+    )
+
+    plan = plan_sync_reconciliation(db_session, request)
+
+    analysis_item = _item(plan, ITEM_ARTIFACT, "art_generated_analysis")
+    assert analysis_item.status == "noop"
+    assert analysis_item.action_type == ACTION_NOOP
+    assert analysis_item.reason == "Analysis generation timestamp is missing; keeping local analysis_json."
+    assert analysis_item.details["resolution"] == "keep_local"
+    assert analysis_item.details["local_resolution_timestamp_source"] == expected_local_source
+    assert analysis_item.details["remote_resolution_timestamp_source"] == expected_remote_source
+    assert _action(plan, ACTION_FETCH_ARTIFACT_CONTENT, ITEM_ARTIFACT, "art_generated_analysis") is None
+    assert _action(plan, ACTION_IMPORT_ARTIFACT_MANIFEST, ITEM_ARTIFACT, "art_generated_analysis") is None
+    assert _action(plan, ACTION_RECORD_CONFLICT, ITEM_ARTIFACT, "art_generated_analysis") is None
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_detail"),
+    [
+        ("non_regenerable", "Both analysis_json artifacts must be marked regenerable."),
+        ("source_mismatch", "Analysis source artifact content hash differs."),
+    ],
+)
+def test_generated_analysis_unresolvable_divergence_stays_conflicted(
+    db_session: Session,
+    tmp_path: Path,
+    case: str,
+    expected_detail: str,
+) -> None:
+    source_hash = _sha("generated analysis source")
+    request = _seed_generated_analysis_divergence(
+        db_session,
+        tmp_path,
+        local_analysis_hash=_sha("local unresolvable analysis"),
+        remote_analysis_hash=_sha(f"remote unresolvable analysis {case}"),
+        local_generated_at=datetime(2026, 1, 1, tzinfo=UTC),
+        remote_generated_at=datetime(2026, 1, 2, tzinfo=UTC),
+        local_can_regenerate=case != "non_regenerable",
+        remote_source_hash=_sha("remote changed source") if case == "source_mismatch" else source_hash,
+    )
+
+    plan = plan_sync_reconciliation(db_session, request)
+
+    analysis_item = _item(plan, ITEM_ARTIFACT, "art_generated_analysis")
+    assert analysis_item.status == "conflicted"
+    assert analysis_item.action_type == ACTION_RECORD_CONFLICT
+    assert analysis_item.details["artifact_type"] == "analysis_json"
+    assert analysis_item.details["artifact_id"] == "art_generated_analysis"
+    assert analysis_item.details["local_content_sha256"] == _sha("local unresolvable analysis")
+    assert analysis_item.details["remote_content_sha256"] == _sha(f"remote unresolvable analysis {case}")
+    assert analysis_item.details["generated_divergence_resolvable"] is False
+    assert analysis_item.details["generated_divergence_unresolvable_reason"] == expected_detail
+    assert _action(plan, ACTION_FETCH_ARTIFACT_CONTENT, ITEM_ARTIFACT, "art_generated_analysis") is None
+    assert _action(plan, ACTION_IMPORT_ARTIFACT_MANIFEST, ITEM_ARTIFACT, "art_generated_analysis") is None
+    assert _action(plan, ACTION_RECORD_CONFLICT, ITEM_ARTIFACT, "art_generated_analysis") is not None
+    if case == "source_mismatch":
+        source_item = _item(plan, ITEM_ARTIFACT, "art_generated_source")
+        assert source_item.status == "conflicted"
+        assert source_item.details["artifact_type"] == "source_audio"
+
+
 def test_issue120_three_peer_group_uses_online_trusted_provider_deterministically(
     db_session: Session,
 ) -> None:
@@ -1464,19 +1643,27 @@ def _add_artifact(
     content_sha256: str,
     size_bytes: int,
     artifact_type: str = "stem",
+    artifact_format: str = "wav",
+    can_regenerate: bool = False,
+    metadata_json: dict[str, Any] | None = None,
+    created_at: datetime | None = None,
 ) -> Artifact:
+    artifact_kwargs: dict[str, Any] = {}
+    if created_at is not None:
+        artifact_kwargs["created_at"] = created_at
     artifact = Artifact(
         id=artifact_id,
         project_id=project_id,
         type=artifact_type,
-        format="wav",
+        format=artifact_format,
         path=str(path),
         content_sha256=content_sha256,
         size_bytes=size_bytes,
         generated_by="test",
         can_delete=True,
-        can_regenerate=False,
-        metadata_json={},
+        can_regenerate=can_regenerate,
+        metadata_json=metadata_json or {},
+        **artifact_kwargs,
     )
     session.add(artifact)
     session.flush()
@@ -1515,6 +1702,127 @@ def _add_revision(
     return revision
 
 
+def _seed_generated_analysis_divergence(
+    session: Session,
+    tmp_path: Path,
+    *,
+    local_analysis_hash: str,
+    remote_analysis_hash: str,
+    local_generated_at: datetime | None,
+    remote_generated_at: datetime | None,
+    local_can_regenerate: bool = True,
+    remote_can_regenerate: bool = True,
+    remote_source_hash: str | None = None,
+) -> dict[str, Any]:
+    _add_identity_and_peers(session)
+    project_id = "proj_generated_analysis"
+    source_artifact_id = "art_generated_source"
+    stem_artifact_id = "art_generated_drums"
+    analysis_artifact_id = "art_generated_analysis"
+    source_hash = _sha("generated analysis source")
+    source_size = 64
+    stem_hash = _sha("generated analysis source stem")
+    stem_size = 32
+    local_created_at = local_generated_at or datetime(2026, 1, 1, tzinfo=UTC)
+    remote_created_at = remote_generated_at or datetime(2026, 1, 2, tzinfo=UTC)
+    local_metadata = {"source_artifact_id": source_artifact_id}
+    if local_generated_at is not None:
+        local_metadata["analysis_generated_at"] = local_generated_at.isoformat()
+    remote_metadata = {"source_artifact_id": source_artifact_id}
+    if remote_generated_at is not None:
+        remote_metadata["analysis_generated_at"] = remote_generated_at.isoformat()
+    _add_project(session, project_id, source_sha256=source_hash)
+    _add_artifact(
+        session,
+        artifact_id=source_artifact_id,
+        project_id=project_id,
+        path=tmp_path / "source.wav",
+        content_sha256=source_hash,
+        size_bytes=source_size,
+        artifact_type="source_audio",
+        can_regenerate=False,
+    )
+    _add_artifact(
+        session,
+        artifact_id=stem_artifact_id,
+        project_id=project_id,
+        path=tmp_path / "drums.wav",
+        content_sha256=stem_hash,
+        size_bytes=stem_size,
+        artifact_type="drums_stem",
+        can_regenerate=True,
+        metadata_json={
+            "source_artifact_id": source_artifact_id,
+            "source_artifact_type": "source_audio",
+        },
+    )
+    _add_artifact(
+        session,
+        artifact_id=analysis_artifact_id,
+        project_id=project_id,
+        path=tmp_path / "analysis.json",
+        content_sha256=local_analysis_hash,
+        size_bytes=128,
+        artifact_type="analysis_json",
+        artifact_format="json",
+        can_regenerate=local_can_regenerate,
+        metadata_json=local_metadata,
+        created_at=local_created_at,
+    )
+    session.commit()
+
+    remote_source_hash = remote_source_hash or source_hash
+    return {
+        "remote_library": {
+            "projects": [{"project_id": project_id, "source_sha256": source_hash}],
+            "artifacts": [
+                _artifact_manifest(
+                    project_id,
+                    source_artifact_id,
+                    remote_source_hash,
+                    source_size,
+                    artifact_type="source_audio",
+                    can_regenerate=False,
+                    relative_path="source/source.wav",
+                    created_at=remote_created_at,
+                ),
+                _artifact_manifest(
+                    project_id,
+                    stem_artifact_id,
+                    stem_hash,
+                    stem_size,
+                    artifact_type="drums_stem",
+                    can_regenerate=True,
+                    metadata={
+                        "source_artifact_id": source_artifact_id,
+                        "source_artifact_type": "source_audio",
+                    },
+                    relative_path="stems/drums.wav",
+                    created_at=remote_created_at,
+                ),
+                _artifact_manifest(
+                    project_id,
+                    analysis_artifact_id,
+                    remote_analysis_hash,
+                    128,
+                    artifact_type="analysis_json",
+                    artifact_format="json",
+                    can_regenerate=remote_can_regenerate,
+                    metadata=remote_metadata,
+                    relative_path="analysis/analysis.json",
+                    created_at=remote_created_at,
+                ),
+            ],
+        },
+        "peer_inventory": [
+            {
+                "device_id": "peer-a",
+                "available_content_hashes": [remote_analysis_hash, remote_source_hash, stem_hash],
+            }
+        ],
+    }
+
+
 def _artifact_manifest(
     project_id: str,
     artifact_id: str,
@@ -1522,21 +1830,27 @@ def _artifact_manifest(
     size_bytes: int,
     *,
     artifact_type: str = "stem",
+    artifact_format: str = "wav",
+    can_regenerate: bool = False,
+    metadata: dict[str, Any] | None = None,
+    relative_path: str | None = None,
+    created_at: datetime | None = None,
 ) -> dict[str, Any]:
+    created = created_at or datetime.now(UTC)
     return {
         "artifact_id": artifact_id,
         "project_id": project_id,
         "type": artifact_type,
-        "format": "wav",
-        "relative_path": f"stems/{artifact_id}.wav",
+        "format": artifact_format,
+        "relative_path": relative_path or f"stems/{artifact_id}.wav",
         "content_sha256": content_sha256,
         "size_bytes": size_bytes,
         "generated_by": "test",
         "can_delete": True,
-        "can_regenerate": False,
+        "can_regenerate": can_regenerate,
         "cache_key": None,
-        "metadata": {},
-        "created_at": datetime.now(UTC),
+        "metadata": metadata or {},
+        "created_at": created,
     }
 
 

--- a/apps/backend/tests/test_sync_reconciliation_apply_batch_import.py
+++ b/apps/backend/tests/test_sync_reconciliation_apply_batch_import.py
@@ -25,6 +25,7 @@ from app.models import (
     SyncStagedArtifact,
     SyncTrustedPeer,
 )
+from app.services import sync_reconciliation_apply as sync_reconciliation_apply_service
 from app.services.paths import project_root
 from app.services.projects import delete_project
 from app.services.sync_identity import source_hash_to_project_id
@@ -323,6 +324,584 @@ def test_issue119_apply_hydrates_analysis_from_synced_analysis_artifact(
         assert repaired_analysis is not None
         assert repaired_analysis.tempo_bpm == 118.5
         assert repaired_analysis.estimated_key == "F major"
+
+
+def test_issue221_apply_overwrites_approved_remote_newer_generated_analysis(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    peer_id = "peer-issue221-analysis-overwrite"
+    artifact_id = "art_issue119_analysis_json"
+    local_generated_at = datetime(2026, 1, 1, tzinfo=UTC)
+    remote_generated_at = datetime(2026, 1, 2, tzinfo=UTC)
+    remote_relative_path = "analysis/analysis.json"
+    _ensure_identity_and_peers(peer_id)
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path, slug="issue221", source_frames=72)
+        _add_analysis_artifact(session, fixture)
+        local_artifact = session.get(Artifact, artifact_id)
+        assert local_artifact is not None
+        local_artifact.metadata_json = {
+            "analysis_version": "v3",
+            "source_artifact_id": fixture.source_artifact_id,
+            "analysis_generated_at": local_generated_at.isoformat(),
+        }
+        local_artifact.created_at = local_generated_at
+        local_path = Path(local_artifact.path)
+        legacy_path = fixture.root / "analysis" / "legacy-analysis.json"
+        shutil.copy2(local_path, legacy_path)
+        local_artifact.path = str(legacy_path)
+        session.commit()
+
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        remote_payload = {
+            "project_id": fixture.project_id,
+            "source_artifact_id": fixture.source_artifact_id,
+            "estimated_key": "G major",
+            "key_confidence": 0.91,
+            "estimated_reference_hz": 442.0,
+            "tuning_offset_cents": -3.5,
+            "tempo_bpm": 132.25,
+            "timing": {
+                "beats_per_bar": 4,
+                "source": "remote-detected",
+                "beats": [{"time_seconds": 0.0, "beat_in_bar": 1}],
+                "bars": [{"index": 1, "start_seconds": 0.0, "end_seconds": 1.75}],
+            },
+            "analysis_version": "v4",
+        }
+        remote_bytes = json.dumps(
+            remote_payload,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        remote_hash, remote_size = _write_bytes(tmp_path / "issue221" / "remote-analysis.json", remote_bytes)
+        remote_artifact = _artifact_by_id(manifest, artifact_id)
+        remote_artifact.update(
+            {
+                "relative_path": remote_relative_path,
+                "content_sha256": remote_hash,
+                "size_bytes": remote_size,
+                "generated_by": "remote-analysis",
+                "can_delete": True,
+                "can_regenerate": True,
+                "cache_key": f"analysis:{fixture.project_id}:remote",
+                "metadata": {
+                    "analysis_version": "v4",
+                    "source_artifact_id": fixture.source_artifact_id,
+                    "analysis_generated_at": remote_generated_at.isoformat(),
+                },
+                "created_at": remote_generated_at.isoformat(),
+            }
+        )
+        fixture.artifact_hashes[artifact_id] = remote_hash
+        fixture.artifact_sizes[artifact_id] = remote_size
+        fixture.artifact_bytes[artifact_id] = remote_bytes
+        _stage_manifest_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=fixture.artifact_bytes,
+            provider_device_id=peer_id,
+        )
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": {
+                "projects": [manifest["project"]],
+                "artifacts": manifest["artifacts"],
+                "entity_revisions": [],
+                "delete_tombstones": [],
+            },
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": peer_id,
+                    "available_content_sha256": _manifest_content_hashes([manifest]),
+                }
+            ],
+            "project_ids": [fixture.project_id],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 0
+    assert payload["plan"]["summary"]["total_conflicts"] == 0
+    assert all(
+        result["action"]["action_type"] != "record_conflict"
+        for result in payload["results"]
+    )
+    assert any(
+        result["action"]["action_type"] == "import_artifact_manifest"
+        and result["action"]["item_id"] == artifact_id
+        and result["status"] == "applied"
+        for result in payload["results"]
+    )
+
+    with SessionLocal() as session:
+        artifact = session.get(Artifact, artifact_id)
+        assert artifact is not None
+        expected_path = legacy_path
+        assert Path(artifact.path) == expected_path
+        assert file_sha256(expected_path) == remote_hash
+        assert artifact.content_sha256 == remote_hash
+        assert artifact.size_bytes == remote_size
+        assert artifact.metadata_json == {
+            "analysis_version": "v4",
+            "source_artifact_id": fixture.source_artifact_id,
+            "analysis_generated_at": remote_generated_at.isoformat(),
+        }
+        assert artifact.cache_key == f"analysis:{fixture.project_id}:remote"
+        assert artifact.generated_by == "remote-analysis"
+        assert artifact.can_delete is True
+        assert artifact.can_regenerate is True
+        assert artifact.created_at.replace(tzinfo=UTC) == remote_generated_at
+
+        analysis = session.get(AnalysisResult, fixture.project_id)
+        assert analysis is not None
+        assert analysis.source_artifact_id == fixture.source_artifact_id
+        assert analysis.estimated_key == "G major"
+        assert analysis.key_confidence == 0.91
+        assert analysis.estimated_reference_hz == 442.0
+        assert analysis.tuning_offset_cents == -3.5
+        assert analysis.tempo_bpm == 132.25
+        assert analysis.timing_json == remote_payload["timing"]
+        assert analysis.analysis_version == "v4"
+
+
+def test_issue221_generated_analysis_overwrite_rejects_unowned_canonical_destination(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    peer_id = "peer-issue221-analysis-unowned"
+    artifact_id = "art_issue119_analysis_json"
+    local_generated_at = datetime(2026, 1, 1, tzinfo=UTC)
+    remote_generated_at = datetime(2026, 1, 2, tzinfo=UTC)
+    _ensure_identity_and_peers(peer_id)
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="issue221-unowned",
+            source_frames=73,
+        )
+        _add_analysis_artifact(session, fixture)
+        local_artifact = session.get(Artifact, artifact_id)
+        assert local_artifact is not None
+        local_artifact.metadata_json = {
+            "analysis_version": "v3",
+            "source_artifact_id": fixture.source_artifact_id,
+            "analysis_generated_at": local_generated_at.isoformat(),
+        }
+        local_artifact.created_at = local_generated_at
+        original_hash = local_artifact.content_sha256
+        canonical_path = fixture.root / "analysis" / "analysis.json"
+        unsafe_owned_path = fixture.root / "stems" / "local-analysis.json"
+        shutil.copy2(canonical_path, unsafe_owned_path)
+        local_artifact.path = str(unsafe_owned_path)
+        canonical_path.write_bytes(b"unowned local analysis bytes")
+        unowned_hash = file_sha256(canonical_path)
+        assert unowned_hash is not None
+        session.commit()
+
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        remote_payload = {
+            "project_id": fixture.project_id,
+            "source_artifact_id": fixture.source_artifact_id,
+            "estimated_key": "G major",
+            "key_confidence": 0.91,
+            "estimated_reference_hz": 442.0,
+            "tuning_offset_cents": -3.5,
+            "tempo_bpm": 132.25,
+            "timing": {
+                "beats_per_bar": 4,
+                "source": "remote-detected",
+                "beats": [{"time_seconds": 0.0, "beat_in_bar": 1}],
+                "bars": [{"index": 1, "start_seconds": 0.0, "end_seconds": 1.75}],
+            },
+            "analysis_version": "v4",
+        }
+        remote_bytes = json.dumps(
+            remote_payload,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        remote_hash, remote_size = _write_bytes(
+            tmp_path / "issue221" / "unowned-remote-analysis.json",
+            remote_bytes,
+        )
+        remote_artifact = _artifact_by_id(manifest, artifact_id)
+        remote_artifact.update(
+            {
+                "relative_path": "analysis/analysis.json",
+                "content_sha256": remote_hash,
+                "size_bytes": remote_size,
+                "generated_by": "remote-analysis",
+                "can_delete": True,
+                "can_regenerate": True,
+                "cache_key": f"analysis:{fixture.project_id}:remote",
+                "metadata": {
+                    "analysis_version": "v4",
+                    "source_artifact_id": fixture.source_artifact_id,
+                    "analysis_generated_at": remote_generated_at.isoformat(),
+                },
+                "created_at": remote_generated_at.isoformat(),
+            }
+        )
+        fixture.artifact_hashes[artifact_id] = remote_hash
+        fixture.artifact_sizes[artifact_id] = remote_size
+        fixture.artifact_bytes[artifact_id] = remote_bytes
+        _stage_manifest_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=fixture.artifact_bytes,
+            provider_device_id=peer_id,
+        )
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": {
+                "projects": [manifest["project"]],
+                "artifacts": manifest["artifacts"],
+                "entity_revisions": [],
+                "delete_tombstones": [],
+            },
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": peer_id,
+                    "available_content_sha256": _manifest_content_hashes([manifest]),
+                }
+            ],
+            "project_ids": [fixture.project_id],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 1
+    assert any(
+        result["action"]["action_type"] == "import_artifact_manifest"
+        and result["action"]["item_id"] == artifact_id
+        and result["status"] == "failed"
+        and result["reason"] == "Artifact destination already exists locally."
+        for result in payload["results"]
+    )
+
+    with SessionLocal() as session:
+        artifact = session.get(Artifact, artifact_id)
+        assert artifact is not None
+        assert Path(artifact.path) == unsafe_owned_path
+        assert artifact.content_sha256 == original_hash
+        assert file_sha256(unsafe_owned_path) == original_hash
+        assert file_sha256(canonical_path) == unowned_hash
+
+        analysis = session.get(AnalysisResult, fixture.project_id)
+        assert analysis is not None
+        assert analysis.estimated_key == "F major"
+        assert analysis.analysis_version == "v3"
+
+
+def test_issue221_generated_analysis_overwrite_copy_mismatch_keeps_local_bytes(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    peer_id = "peer-issue221-analysis-copy-mismatch"
+    artifact_id = "art_issue119_analysis_json"
+    local_generated_at = datetime(2026, 1, 1, tzinfo=UTC)
+    remote_generated_at = datetime(2026, 1, 2, tzinfo=UTC)
+    _ensure_identity_and_peers(peer_id)
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="issue221-copy-mismatch",
+            source_frames=77,
+        )
+        _add_analysis_artifact(session, fixture)
+        local_artifact = session.get(Artifact, artifact_id)
+        assert local_artifact is not None
+        local_metadata = {
+            "analysis_version": "v3",
+            "source_artifact_id": fixture.source_artifact_id,
+            "analysis_generated_at": local_generated_at.isoformat(),
+        }
+        local_artifact.metadata_json = local_metadata
+        local_artifact.created_at = local_generated_at
+        local_path = Path(local_artifact.path)
+        legacy_path = fixture.root / "analysis" / "legacy-analysis.json"
+        shutil.copy2(local_path, legacy_path)
+        local_artifact.path = str(legacy_path)
+        original_hash = local_artifact.content_sha256
+        original_size = local_artifact.size_bytes
+        original_bytes = legacy_path.read_bytes()
+        session.commit()
+
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        remote_payload = {
+            "project_id": fixture.project_id,
+            "source_artifact_id": fixture.source_artifact_id,
+            "estimated_key": "G major",
+            "key_confidence": 0.91,
+            "estimated_reference_hz": 442.0,
+            "tuning_offset_cents": -3.5,
+            "tempo_bpm": 132.25,
+            "timing": {
+                "beats_per_bar": 4,
+                "source": "remote-detected",
+                "beats": [{"time_seconds": 0.0, "beat_in_bar": 1}],
+                "bars": [{"index": 1, "start_seconds": 0.0, "end_seconds": 1.75}],
+            },
+            "analysis_version": "v4",
+        }
+        remote_bytes = json.dumps(
+            remote_payload,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        remote_hash, remote_size = _write_bytes(
+            tmp_path / "issue221" / "copy-mismatch-remote-analysis.json",
+            remote_bytes,
+        )
+        remote_artifact = _artifact_by_id(manifest, artifact_id)
+        remote_artifact.update(
+            {
+                "relative_path": "analysis/analysis.json",
+                "content_sha256": remote_hash,
+                "size_bytes": remote_size,
+                "generated_by": "remote-analysis",
+                "can_delete": True,
+                "can_regenerate": True,
+                "cache_key": f"analysis:{fixture.project_id}:remote",
+                "metadata": {
+                    "analysis_version": "v4",
+                    "source_artifact_id": fixture.source_artifact_id,
+                    "analysis_generated_at": remote_generated_at.isoformat(),
+                },
+                "created_at": remote_generated_at.isoformat(),
+            }
+        )
+        fixture.artifact_hashes[artifact_id] = remote_hash
+        fixture.artifact_sizes[artifact_id] = remote_size
+        fixture.artifact_bytes[artifact_id] = remote_bytes
+        _stage_manifest_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=fixture.artifact_bytes,
+            provider_device_id=peer_id,
+        )
+        session.commit()
+
+    def copy_corrupt_bytes(src: str | Path, dst: str | Path, *args: Any, **kwargs: Any) -> Path:
+        _ = src, args, kwargs
+        destination = Path(dst)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"x" * remote_size)
+        return destination
+
+    monkeypatch.setattr(sync_reconciliation_apply_service.shutil, "copy2", copy_corrupt_bytes)
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": {
+                "projects": [manifest["project"]],
+                "artifacts": manifest["artifacts"],
+                "entity_revisions": [],
+                "delete_tombstones": [],
+            },
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": peer_id,
+                    "available_content_sha256": _manifest_content_hashes([manifest]),
+                }
+            ],
+            "project_ids": [fixture.project_id],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 1
+    assert any(
+        result["action"]["action_type"] == "import_artifact_manifest"
+        and result["action"]["item_id"] == artifact_id
+        and result["status"] == "failed"
+        and result["reason"] == "Copied artifact bytes do not match the manifest."
+        for result in payload["results"]
+    )
+
+    with SessionLocal() as session:
+        artifact = session.get(Artifact, artifact_id)
+        assert artifact is not None
+        assert Path(artifact.path) == legacy_path
+        assert artifact.content_sha256 == original_hash
+        assert artifact.size_bytes == original_size
+        assert artifact.metadata_json == local_metadata
+        assert legacy_path.read_bytes() == original_bytes
+        assert file_sha256(legacy_path) == original_hash
+        assert not list(legacy_path.parent.glob(f".{legacy_path.name}.*.tmp"))
+
+        analysis = session.get(AnalysisResult, fixture.project_id)
+        assert analysis is not None
+        assert analysis.estimated_key == "F major"
+        assert analysis.analysis_version == "v3"
+
+
+def test_issue221_apply_adopts_matching_orphan_destination_artifact(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    peer_id = "peer-issue221-orphan-destination"
+    _ensure_identity_and_peers(peer_id)
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="issue221-orphan",
+            source_frames=72,
+        )
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        stem_artifact = session.get(Artifact, fixture.stem_artifact_id)
+        assert stem_artifact is not None
+        orphan_path = Path(stem_artifact.path)
+        assert orphan_path.exists()
+        session.delete(stem_artifact)
+        _stage_manifest_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=fixture.artifact_bytes,
+            provider_device_id=peer_id,
+        )
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": {
+                "projects": [manifest["project"]],
+                "artifacts": manifest["artifacts"],
+                "entity_revisions": [],
+                "delete_tombstones": [],
+            },
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": peer_id,
+                    "available_content_sha256": _manifest_content_hashes([manifest]),
+                }
+            ],
+            "project_ids": [fixture.project_id],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 0
+    assert any(
+        result["action"]["action_type"] == "import_artifact_manifest"
+        and result["action"]["item_id"] == fixture.stem_artifact_id
+        and result["status"] == "applied"
+        for result in payload["results"]
+    )
+
+    with SessionLocal() as session:
+        artifact = session.get(Artifact, fixture.stem_artifact_id)
+        assert artifact is not None
+        assert Path(artifact.path) == orphan_path
+        assert artifact.content_sha256 == fixture.artifact_hashes[fixture.stem_artifact_id]
+        assert artifact.size_bytes == fixture.artifact_sizes[fixture.stem_artifact_id]
+        assert file_sha256(orphan_path) == fixture.artifact_hashes[fixture.stem_artifact_id]
+
+
+def test_issue221_apply_rejects_orphan_destination_symlink_escape(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    peer_id = "peer-issue221-orphan-symlink"
+    _ensure_identity_and_peers(peer_id)
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="issue221-symlink",
+            source_frames=75,
+        )
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        stem_artifact = session.get(Artifact, fixture.stem_artifact_id)
+        assert stem_artifact is not None
+        session.delete(stem_artifact)
+        shutil.rmtree(fixture.root / "stems")
+        outside_stem_path = tmp_path / "outside-stems" / Path(fixture.stem_relative_path).name
+        _write_bytes(outside_stem_path, fixture.artifact_bytes[fixture.stem_artifact_id])
+        (fixture.root / "stems").symlink_to(outside_stem_path.parent, target_is_directory=True)
+        _stage_manifest_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=fixture.artifact_bytes,
+            provider_device_id=peer_id,
+        )
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": {
+                "projects": [manifest["project"]],
+                "artifacts": manifest["artifacts"],
+                "entity_revisions": [],
+                "delete_tombstones": [],
+            },
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": peer_id,
+                    "available_content_sha256": _manifest_content_hashes([manifest]),
+                }
+            ],
+            "project_ids": [fixture.project_id],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 1
+    assert any(
+        result["action"]["action_type"] == "import_artifact_manifest"
+        and result["action"]["item_id"] == fixture.stem_artifact_id
+        and result["status"] == "failed"
+        and result["reason"] == "Artifact destination escapes the project root."
+        for result in payload["results"]
+    )
+
+    with SessionLocal() as session:
+        assert session.get(Artifact, fixture.stem_artifact_id) is None
+        assert outside_stem_path.exists()
+        assert file_sha256(outside_stem_path) == fixture.artifact_hashes[fixture.stem_artifact_id]
 
 
 def test_issue119_apply_reports_analysis_repair_failure_without_rolling_back_import(
@@ -1588,6 +2167,74 @@ def test_issue120_existing_project_imports_late_manifest_artifacts(
         assert restored_artifact is not None
         assert Path(restored_artifact.path).exists()
         assert restored_artifact.content_sha256 == fixture.artifact_hashes[fixture.stem_artifact_id]
+
+
+def test_issue120_late_manifest_copy_mismatch_does_not_persist_artifact(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    _ensure_identity_and_peers("peer-issue120-copy-mismatch")
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="issue120-copy-mismatch",
+            source_frames=130,
+        )
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        late_artifact_path = project_root(fixture.project_id) / fixture.stem_relative_path
+        late_artifact = session.get(Artifact, fixture.stem_artifact_id)
+        assert late_artifact is not None
+        session.delete(late_artifact)
+        late_artifact_path.unlink()
+        _stage_manifest_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=fixture.artifact_bytes,
+            provider_device_id="peer-issue120-copy-mismatch",
+        )
+        session.commit()
+
+    def copy_corrupt_bytes(src: str | Path, dst: str | Path, *args: Any, **kwargs: Any) -> Path:
+        _ = src, args, kwargs
+        destination = Path(dst)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"corrupt copied artifact bytes")
+        return destination
+
+    monkeypatch.setattr(sync_reconciliation_apply_service.shutil, "copy2", copy_corrupt_bytes)
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": "peer-issue120-copy-mismatch",
+                    "available_content_sha256": _manifest_content_hashes([manifest]),
+                }
+            ],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 1
+    assert any(
+        result["action"]["action_type"] == "import_artifact_manifest"
+        and result["action"]["item_id"] == fixture.stem_artifact_id
+        and result["status"] == "failed"
+        and result["reason"] == "Copied artifact bytes do not match the manifest."
+        for result in payload["results"]
+    )
+
+    with SessionLocal() as session:
+        assert session.get(Artifact, fixture.stem_artifact_id) is None
 
 
 def test_issue120_remote_tombstone_from_trusted_peer_wins_over_stale_manifest(

--- a/apps/desktop/src-tauri/src/sync_transport.rs
+++ b/apps/desktop/src-tauri/src/sync_transport.rs
@@ -4571,11 +4571,25 @@ mod desktop {
                 _ => self.skipped_actions = self.skipped_actions.saturating_add(1),
             }
             if let Some(reason) = reason {
-                let priority = action_reason_priority(status, action);
-                if self.selected_reason.is_none() || priority >= self.selected_reason_priority {
-                    self.selected_reason = Some(reason.to_string());
-                    self.selected_reason_priority = priority;
-                }
+                self.select_reason(reason, action_reason_priority(status, action));
+            }
+        }
+
+        fn record_plan_item(&mut self, item: &Value) {
+            let Some(reason) = item.get("reason").and_then(Value::as_str) else {
+                return;
+            };
+            self.select_reason(reason, plan_item_reason_priority(item));
+        }
+
+        fn select_reason(&mut self, reason: &str, priority: u8) {
+            let reason = reason.trim();
+            if reason.is_empty() {
+                return;
+            }
+            if self.selected_reason.is_none() || priority >= self.selected_reason_priority {
+                self.selected_reason = Some(reason.to_string());
+                self.selected_reason_priority = priority;
             }
         }
 
@@ -4588,6 +4602,8 @@ mod desktop {
                 "deleted"
             } else if self.imported_project_manifest {
                 "imported"
+            } else if self.applied_actions > 0 {
+                "applied"
             } else {
                 "skipped"
             }
@@ -4629,6 +4645,86 @@ mod desktop {
         }
     }
 
+    fn plan_item_reason_priority(item: &Value) -> u8 {
+        if let Some(reason) = item.get("reason").and_then(Value::as_str) {
+            if generated_analysis_reason(reason, item) {
+                return 35;
+            }
+        }
+        match item.get("status").and_then(Value::as_str) {
+            Some("conflicted") => 42,
+            Some("missing_provider") | Some("missing_local_bytes") | Some("remote_available") => 15,
+            Some("identical_content") | Some("noop") => 12,
+            _ => 5,
+        }
+    }
+
+    fn apply_result_reason<'a>(result: &'a Value, action: &'a Value) -> Option<&'a str> {
+        let result_reason = result.get("reason").and_then(Value::as_str);
+        let action_reason = action.get("reason").and_then(Value::as_str);
+        if action.get("action_type").and_then(Value::as_str) == Some("record_conflict") {
+            return action_reason.or(result_reason);
+        }
+        if action_reason.is_some_and(|reason| generated_analysis_reason(reason, action)) {
+            return action_reason;
+        }
+        if result_reason.is_some_and(is_generic_apply_reason) {
+            return action_reason.or(result_reason);
+        }
+        result_reason.or(action_reason)
+    }
+
+    fn is_generic_apply_reason(reason: &str) -> bool {
+        matches!(
+            reason.trim(),
+            "Action is already satisfied."
+                | "Required artifact content is staged."
+                | "Required artifact content is staged and verified locally."
+                | "Artifact manifest was imported into the existing project."
+                | "Artifact manifest was imported through the mobile sync manifest service."
+                | "Project sync status was updated through the mobile sync status service."
+        )
+    }
+
+    fn generated_analysis_reason(reason: &str, value: &Value) -> bool {
+        let reason = reason.to_ascii_lowercase();
+        if reason.contains("generated analysis")
+            || reason.contains("analysis artifact")
+            || reason.contains("analysis_json")
+        {
+            return true;
+        }
+        if !value_contains_text(value, "analysis_json") {
+            return false;
+        }
+        [
+            "diverg",
+            "newer",
+            "updated",
+            "kept",
+            "keep",
+            "local",
+            "remote",
+            "tie",
+            "generated",
+        ]
+        .iter()
+        .any(|needle| reason.contains(needle))
+    }
+
+    fn value_contains_text(value: &Value, needle: &str) -> bool {
+        match value {
+            Value::String(value) => value.to_ascii_lowercase().contains(needle),
+            Value::Array(values) => values
+                .iter()
+                .any(|value| value_contains_text(value, needle)),
+            Value::Object(values) => values.iter().any(|(key, value)| {
+                key.to_ascii_lowercase().contains(needle) || value_contains_text(value, needle)
+            }),
+            _ => false,
+        }
+    }
+
     fn map_batch_apply_response(
         manifests: &[Value],
         response: &Value,
@@ -4642,6 +4738,8 @@ mod desktop {
                 )
             })
             .collect();
+
+        record_plan_item_reasons(&mut outcomes, response);
 
         for result in response
             .get("results")
@@ -4660,17 +4758,7 @@ mod desktop {
                 .get("status")
                 .and_then(Value::as_str)
                 .unwrap_or("skipped");
-            let reason = result
-                .get("reason")
-                .and_then(Value::as_str)
-                .or_else(|| action.get("reason").and_then(Value::as_str));
-            let reason =
-                if action.get("action_type").and_then(Value::as_str) == Some("record_conflict") {
-                    action.get("reason").and_then(Value::as_str).or(reason)
-                } else {
-                    reason
-                };
-            outcome.record(status, action, reason);
+            outcome.record(status, action, apply_result_reason(result, action));
         }
 
         manifests
@@ -4692,6 +4780,8 @@ mod desktop {
             .map(|project_id| (project_id.clone(), ProjectApplyOutcome::default()))
             .collect();
 
+        record_plan_item_reasons(&mut outcomes, response);
+
         for result in response
             .get("results")
             .and_then(Value::as_array)
@@ -4709,17 +4799,7 @@ mod desktop {
                 .get("status")
                 .and_then(Value::as_str)
                 .unwrap_or("skipped");
-            let reason = result
-                .get("reason")
-                .and_then(Value::as_str)
-                .or_else(|| action.get("reason").and_then(Value::as_str));
-            let reason =
-                if action.get("action_type").and_then(Value::as_str) == Some("record_conflict") {
-                    action.get("reason").and_then(Value::as_str).or(reason)
-                } else {
-                    reason
-                };
-            outcome.record(status, action, reason);
+            outcome.record(status, action, apply_result_reason(result, action));
         }
 
         project_ids
@@ -4729,6 +4809,36 @@ mod desktop {
                 outcome_to_project_result(project_id.clone(), outcome)
             })
             .collect()
+    }
+
+    fn record_plan_item_reasons(
+        outcomes: &mut HashMap<String, ProjectApplyOutcome>,
+        response: &Value,
+    ) {
+        for item in response
+            .get("plan")
+            .and_then(|plan| plan.get("items"))
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            let Some(project_id) = plan_item_project_id(item) else {
+                continue;
+            };
+            if let Some(outcome) = outcomes.get_mut(project_id) {
+                outcome.record_plan_item(item);
+            }
+        }
+    }
+
+    fn plan_item_project_id(item: &Value) -> Option<&str> {
+        item.get("project_id").and_then(Value::as_str).or_else(|| {
+            if item.get("item_type").and_then(Value::as_str) == Some("project") {
+                item.get("item_id").and_then(Value::as_str)
+            } else {
+                None
+            }
+        })
     }
 
     fn outcome_to_project_result(
@@ -7528,6 +7638,116 @@ mod desktop {
                     skipped: 1,
                     failed: 2,
                 }
+            );
+        }
+
+        #[test]
+        fn batch_apply_response_surfaces_generated_analysis_remote_newer_resolution() {
+            let manifests = vec![json!({
+                "project": { "project_id": "proj_generated" },
+                "artifacts": []
+            })];
+            let response = json!({
+                "plan": {
+                    "items": [{
+                        "item_type": "artifact",
+                        "item_id": "art_analysis",
+                        "project_id": "proj_generated",
+                        "status": "remote_available",
+                        "action_type": "import_artifact_manifest",
+                        "content_sha256": "hash_remote_analysis",
+                        "reason": "Generated analysis artifact updated from newer peer analysis.",
+                        "details": {
+                            "artifact_type": "analysis_json",
+                            "resolution": "remote_newer_import",
+                            "can_regenerate": true
+                        }
+                    }]
+                },
+                "results": [{
+                    "action": {
+                        "action_type": "import_artifact_manifest",
+                        "item_type": "artifact",
+                        "item_id": "art_analysis",
+                        "project_id": "proj_generated",
+                        "content_sha256": "hash_remote_analysis",
+                        "reason": "Generated analysis artifact updated from newer peer analysis.",
+                        "details": {
+                            "artifact_type": "analysis_json",
+                            "resolution": "remote_newer_import",
+                            "can_regenerate": true
+                        }
+                    },
+                    "status": "applied",
+                    "reason": "Artifact manifest was imported into the existing project."
+                }]
+            });
+
+            let results = map_batch_apply_response(&manifests, &response);
+
+            assert_eq!(results.len(), 1);
+            assert_eq!(results[0].project_id, "proj_generated");
+            assert_eq!(results[0].status, "applied");
+            assert_eq!(
+                results[0].message.as_deref(),
+                Some(
+                    "Reconciliation apply: 1 applied, 0 satisfied, 0 skipped, 0 failed, 0 conflicted action(s). Generated analysis artifact updated from newer peer analysis."
+                )
+            );
+        }
+
+        #[test]
+        fn batch_apply_response_surfaces_generated_analysis_kept_local_resolution() {
+            let manifests = vec![json!({
+                "project": { "project_id": "proj_generated" },
+                "artifacts": []
+            })];
+            let response = json!({
+                "plan": {
+                    "items": [{
+                        "item_type": "artifact",
+                        "item_id": "art_analysis",
+                        "project_id": "proj_generated",
+                        "status": "identical_content",
+                        "action_type": "noop",
+                        "content_sha256": "hash_local_analysis",
+                        "reason": "Generated analysis artifact kept local because local analysis is newer.",
+                        "details": {
+                            "artifact_type": "analysis_json",
+                            "resolution": "local_newer_keep_local",
+                            "can_regenerate": true
+                        }
+                    }]
+                },
+                "results": [{
+                    "action": {
+                        "action_type": "noop",
+                        "item_type": "artifact",
+                        "item_id": "art_analysis",
+                        "project_id": "proj_generated",
+                        "content_sha256": "hash_local_analysis",
+                        "reason": "Generated analysis artifact kept local because local analysis is newer.",
+                        "details": {
+                            "artifact_type": "analysis_json",
+                            "resolution": "local_newer_keep_local",
+                            "can_regenerate": true
+                        }
+                    },
+                    "status": "satisfied",
+                    "reason": "Action is already satisfied."
+                }]
+            });
+
+            let results = map_batch_apply_response(&manifests, &response);
+
+            assert_eq!(results.len(), 1);
+            assert_eq!(results[0].project_id, "proj_generated");
+            assert_eq!(results[0].status, "skipped");
+            assert_eq!(
+                results[0].message.as_deref(),
+                Some(
+                    "Reconciliation apply: 0 applied, 1 satisfied, 0 skipped, 0 failed, 0 conflicted action(s). Generated analysis artifact kept local because local analysis is newer."
+                )
             );
         }
 


### PR DESCRIPTION
## Summary

- Add generated-analysis metadata so same-ID analysis divergence can be resolved only when inputs match and hashes differ.
- Apply planner-approved generated analysis overwrites and matching orphan artifacts with path ownership, project-root, and atomic-copy safety checks.
- Surface generated-analysis sync outcomes without changing HTTP contracts.
- Closes #221

## Testing

- `uv run --python 3.11 python -m pytest tests/test_sync_reconciliation_apply_batch_import.py tests/test_sync_reconciliation.py tests/test_sync_manifest.py -q`
- `uv run --python 3.11 ruff check app tests/test_sync_reconciliation_apply_batch_import.py tests/test_sync_reconciliation.py tests/test_sync_manifest.py`
- `uv run --python 3.11 mypy app`
- `git diff --check`
- `@reviewer`: no findings after remediation
- `@tuneforge_contract_guard`: no contract drift; no contract generation needed
