### PR TITLE
feat: add virtual audio capture smoke

### DIFF
--- a/apps/backend/app/cli/playback_capture_analyze.py
+++ b/apps/backend/app/cli/playback_capture_analyze.py
@@ -1,0 +1,785 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import soundfile as sf
+
+DEFAULT_MIN_DURATION_SECONDS = 1.0
+DEFAULT_RMS_THRESHOLD = 0.002
+DEFAULT_MARKER_TOLERANCE_SECONDS = 0.08
+DEFAULT_SPACING_TOLERANCE_SECONDS = 0.08
+DEFAULT_QUIET_WINDOW_MAX_RMS = 0.003
+DEFAULT_LOOP_MIN_SIMILARITY = 0.7
+
+
+class PlaybackCaptureAnalyzeCliError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class AudioCapture:
+    samples: np.ndarray
+    sample_rate: int
+
+    @property
+    def duration_seconds(self) -> float:
+        return float(self.samples.size / self.sample_rate)
+
+
+@dataclass(frozen=True)
+class PulseMarker:
+    kind: str
+    time_seconds: float
+    playback_seconds: float | None = None
+
+
+@dataclass(frozen=True)
+class QuietWindow:
+    start_seconds: float
+    end_seconds: float
+    max_rms: float
+
+
+@dataclass(frozen=True)
+class LoopExpectation:
+    start_seconds: float
+    end_seconds: float
+    restart_seconds: float | None
+    start_capture_seconds: float | None
+    min_similarity: float
+    require_similarity: bool
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    try:
+        args = parser.parse_args(argv)
+        summary = _run_analysis(args)
+    except PlaybackCaptureAnalyzeCliError as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 1
+    except Exception as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 1
+
+    sys.stdout.write(json.dumps(summary, sort_keys=True))
+    sys.stdout.write("\n")
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m app.cli.playback_capture_analyze",
+        description="Analyze a local playback smoke audio capture against its timing sidecar.",
+    )
+    parser.add_argument("--audio", required=True, type=Path, metavar="PATH")
+    parser.add_argument("--sidecar", required=True, type=Path, metavar="PATH")
+    parser.add_argument(
+        "--min-duration",
+        type=float,
+        metavar="SECONDS",
+        help="Minimum capture duration. Overrides sidecar minDurationSeconds.",
+    )
+    parser.add_argument(
+        "--rms-threshold",
+        type=float,
+        metavar="RMS",
+        help="Minimum full-capture RMS. Overrides sidecar rmsThreshold.",
+    )
+    parser.add_argument(
+        "--marker-tolerance",
+        type=float,
+        metavar="SECONDS",
+        help="Tolerance for expected beat/click markers. Overrides sidecar beatToleranceSeconds.",
+    )
+    return parser
+
+
+def _run_analysis(args: argparse.Namespace) -> dict[str, Any]:
+    sidecar = _read_sidecar(args.sidecar)
+    capture = _read_capture(args)
+    rms = _rms(capture.samples)
+    peak = _peak(capture.samples)
+
+    min_duration_seconds = cast(
+        float,
+        _first_float(
+            [args.min_duration, sidecar, _object_field(sidecar, "audio")],
+            ("minDurationSeconds", "minimumDurationSeconds", "min_capture_duration_seconds", "minDuration"),
+            DEFAULT_MIN_DURATION_SECONDS,
+        ),
+    )
+    rms_threshold = cast(
+        float,
+        _first_float(
+            [args.rms_threshold, sidecar, _object_field(sidecar, "audio")],
+            ("rmsThreshold", "rms_threshold", "minRms", "minimumRms"),
+            DEFAULT_RMS_THRESHOLD,
+        ),
+    )
+    marker_tolerance_seconds = cast(
+        float,
+        _first_float(
+            [args.marker_tolerance, sidecar],
+            ("beatToleranceSeconds", "markerToleranceSeconds", "clickToleranceSeconds", "toleranceSeconds"),
+            DEFAULT_MARKER_TOLERANCE_SECONDS,
+        ),
+    )
+
+    if capture.duration_seconds < min_duration_seconds:
+        raise PlaybackCaptureAnalyzeCliError(
+            f"capture duration {capture.duration_seconds:.3f}s below minimum {min_duration_seconds:.3f}s"
+        )
+    if rms < rms_threshold:
+        raise PlaybackCaptureAnalyzeCliError(f"capture RMS {rms:.6f} below threshold {rms_threshold:.6f}")
+
+    markers = _extract_pulse_markers(sidecar)
+    marker_summary = _analyze_pulse_markers(
+        capture,
+        markers,
+        sidecar=sidecar,
+        marker_tolerance_seconds=marker_tolerance_seconds,
+    )
+
+    quiet_windows = _extract_quiet_windows(sidecar)
+    quiet_summary = _analyze_quiet_windows(capture, quiet_windows)
+
+    loop_expectations = _extract_loop_expectations(sidecar)
+    loop_summary = _analyze_loop_restarts(
+        capture,
+        loops=loop_expectations,
+        markers=markers,
+        sidecar=sidecar,
+        marker_tolerance_seconds=marker_tolerance_seconds,
+    )
+
+    return {
+        "audio_path": str(args.audio.expanduser().resolve()),
+        "sidecar_path": str(args.sidecar.expanduser().resolve()),
+        "duration_seconds": round(capture.duration_seconds, 6),
+        "sample_rate": capture.sample_rate,
+        "rms": round(rms, 8),
+        "peak": round(peak, 8),
+        "min_duration_seconds": min_duration_seconds,
+        "rms_threshold": rms_threshold,
+        "pulse_markers": marker_summary,
+        "quiet_windows": quiet_summary,
+        "loop_restarts": loop_summary,
+    }
+
+
+def _read_sidecar(path: Path) -> dict[str, Any]:
+    resolved = path.expanduser().resolve()
+    if not resolved.exists():
+        raise PlaybackCaptureAnalyzeCliError(f"sidecar not found: {resolved}")
+    try:
+        payload = json.loads(resolved.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise PlaybackCaptureAnalyzeCliError(f"sidecar is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise PlaybackCaptureAnalyzeCliError("sidecar root must be a JSON object")
+    return payload
+
+
+def _read_capture(args: argparse.Namespace) -> AudioCapture:
+    path = args.audio.expanduser().resolve()
+    if not path.exists():
+        raise PlaybackCaptureAnalyzeCliError(f"audio capture not found: {path}")
+
+    try:
+        data, effective_sample_rate = sf.read(str(path), dtype="float32", always_2d=True)
+    except PlaybackCaptureAnalyzeCliError:
+        raise
+    except Exception as exc:
+        raise PlaybackCaptureAnalyzeCliError(f"could not read audio capture: {exc}") from exc
+
+    if data.size == 0:
+        raise PlaybackCaptureAnalyzeCliError("audio capture is empty")
+    if not np.all(np.isfinite(data)):
+        raise PlaybackCaptureAnalyzeCliError("audio capture contains non-finite samples")
+
+    mono = np.mean(data.astype(np.float64, copy=False), axis=1)
+    return AudioCapture(samples=mono, sample_rate=int(effective_sample_rate))
+
+
+def _analyze_pulse_markers(
+    capture: AudioCapture,
+    markers: list[PulseMarker],
+    *,
+    sidecar: dict[str, Any],
+    marker_tolerance_seconds: float,
+) -> dict[str, Any]:
+    markers_in_range = [
+        marker
+        for marker in sorted(markers, key=lambda item: item.time_seconds)
+        if 0 <= marker.time_seconds <= capture.duration_seconds
+    ]
+    if not markers_in_range:
+        return {"checked": 0, "matched": 0, "max_offset_seconds": None}
+
+    peak_floor = cast(
+        float,
+        _first_float(
+            [sidecar],
+            ("markerPeakThreshold", "clickPeakThreshold", "pulsePeakThreshold"),
+            max(DEFAULT_RMS_THRESHOLD * 4, _rms(capture.samples) * 1.8),
+        ),
+    )
+    matched_times: list[float] = []
+    offsets: list[float] = []
+
+    for marker in markers_in_range:
+        match_time = _nearest_peak_time(
+            capture,
+            marker.time_seconds,
+            tolerance_seconds=marker_tolerance_seconds,
+            peak_floor=peak_floor,
+        )
+        if match_time is None:
+            raise PlaybackCaptureAnalyzeCliError(
+                f"expected {marker.kind} pulse near {marker.time_seconds:.3f}s within "
+                f"{marker_tolerance_seconds:.3f}s"
+            )
+        matched_times.append(match_time)
+        offsets.append(abs(match_time - marker.time_seconds))
+
+    spacing_tolerance_seconds = cast(
+        float,
+        _first_float(
+            [sidecar],
+            ("spacingToleranceSeconds", "beatSpacingToleranceSeconds", "clickSpacingToleranceSeconds"),
+            max(marker_tolerance_seconds, DEFAULT_SPACING_TOLERANCE_SECONDS),
+        ),
+    )
+    expected_gaps = np.diff([marker.time_seconds for marker in markers_in_range])
+    observed_gaps = np.diff(matched_times)
+    if expected_gaps.size:
+        gap_errors = np.abs(observed_gaps - expected_gaps)
+        max_gap_error = float(np.max(gap_errors))
+        if max_gap_error > spacing_tolerance_seconds:
+            raise PlaybackCaptureAnalyzeCliError(
+                f"pulse spacing drift {max_gap_error:.3f}s exceeds tolerance "
+                f"{spacing_tolerance_seconds:.3f}s"
+            )
+    else:
+        max_gap_error = 0.0
+
+    bpm = _first_float([sidecar], ("bpm", "tempoBpm", "fixtureBpm"), None)
+    median_gap_seconds = float(np.median(observed_gaps)) if observed_gaps.size else None
+    if bpm is not None and median_gap_seconds is not None:
+        expected_beat_seconds = 60.0 / bpm
+        multiplier = max(1, round(median_gap_seconds / expected_beat_seconds))
+        expected_marker_gap = expected_beat_seconds * multiplier
+        bpm_gap_error = abs(median_gap_seconds - expected_marker_gap)
+        if bpm_gap_error > spacing_tolerance_seconds:
+            raise PlaybackCaptureAnalyzeCliError(
+                f"median pulse gap {median_gap_seconds:.3f}s does not match {bpm:.3f} BPM "
+                f"grid within {spacing_tolerance_seconds:.3f}s"
+            )
+
+    return {
+        "checked": len(markers_in_range),
+        "matched": len(matched_times),
+        "max_offset_seconds": round(max(offsets), 6) if offsets else None,
+        "max_spacing_error_seconds": round(max_gap_error, 6),
+        "median_gap_seconds": round(median_gap_seconds, 6) if median_gap_seconds is not None else None,
+    }
+
+
+def _analyze_quiet_windows(capture: AudioCapture, quiet_windows: list[QuietWindow]) -> dict[str, Any]:
+    measured: list[dict[str, Any]] = []
+    for window in quiet_windows:
+        start_index = _sample_index(capture, window.start_seconds)
+        end_index = _sample_index(capture, window.end_seconds)
+        if end_index <= start_index:
+            raise PlaybackCaptureAnalyzeCliError(
+                f"quiet window {window.start_seconds:.3f}-{window.end_seconds:.3f}s is empty"
+            )
+        window_rms = _rms(capture.samples[start_index:end_index])
+        if window_rms > window.max_rms:
+            raise PlaybackCaptureAnalyzeCliError(
+                f"quiet window {window.start_seconds:.3f}-{window.end_seconds:.3f}s RMS "
+                f"{window_rms:.6f} exceeds {window.max_rms:.6f}"
+            )
+        measured.append(
+            {
+                "start_seconds": window.start_seconds,
+                "end_seconds": window.end_seconds,
+                "rms": round(window_rms, 8),
+                "max_rms": window.max_rms,
+            }
+        )
+    return {"checked": len(quiet_windows), "windows": measured}
+
+
+def _analyze_loop_restarts(
+    capture: AudioCapture,
+    *,
+    loops: list[LoopExpectation],
+    markers: list[PulseMarker],
+    sidecar: dict[str, Any],
+    marker_tolerance_seconds: float,
+) -> dict[str, Any]:
+    require_loop_restart = _first_bool([sidecar], ("requireLoopRestart", "require_loop_restart"), bool(loops))
+    checked: list[dict[str, Any]] = []
+    marker_restart_count = _marker_loop_restart_count(loops, markers, marker_tolerance_seconds)
+    phase_restart_count = _phase_loop_restart_count(loops, sidecar, marker_tolerance_seconds)
+
+    for loop in loops:
+        restart_seconds = loop.restart_seconds
+        if restart_seconds is not None and (restart_seconds < 0 or restart_seconds >= capture.duration_seconds):
+            raise PlaybackCaptureAnalyzeCliError(
+                f"loop restart {restart_seconds:.3f}s outside capture duration {capture.duration_seconds:.3f}s"
+            )
+
+        loop_marker_restart_count = _marker_loop_restart_count([loop], markers, marker_tolerance_seconds)
+        loop_phase_restart_count = _phase_loop_restart_count([loop], sidecar, marker_tolerance_seconds)
+        similarity: float | None = None
+        if loop.require_similarity:
+            if restart_seconds is None:
+                raise PlaybackCaptureAnalyzeCliError("loop waveform similarity requires restart capture seconds")
+            start_seconds = loop.start_capture_seconds if loop.start_capture_seconds is not None else loop.start_seconds
+            similarity = _best_snippet_similarity(
+                capture,
+                reference_seconds=start_seconds,
+                candidate_seconds=restart_seconds,
+                loop_seconds=loop.end_seconds - loop.start_seconds,
+                search_radius_seconds=marker_tolerance_seconds,
+            )
+            if similarity < loop.min_similarity:
+                raise PlaybackCaptureAnalyzeCliError(
+                    f"loop restart at {restart_seconds:.3f}s similarity {similarity:.3f} below "
+                    f"{loop.min_similarity:.3f}"
+                )
+        elif require_loop_restart and loop_marker_restart_count + loop_phase_restart_count == 0:
+            raise PlaybackCaptureAnalyzeCliError(
+                "sidecar loop restart telemetry did not show wrap from near loop end to near loop start"
+            )
+
+        result = {
+            "start_seconds": loop.start_seconds,
+            "end_seconds": loop.end_seconds,
+            "restart_seconds": restart_seconds,
+            "marker_restart_count": loop_marker_restart_count,
+            "phase_restart_count": loop_phase_restart_count,
+            "waveform_similarity_required": loop.require_similarity,
+        }
+        if similarity is not None:
+            result["similarity"] = round(similarity, 6)
+        checked.append(result)
+
+    return {
+        "checked": len(checked),
+        "explicit_restarts": checked,
+        "marker_restart_count": marker_restart_count,
+        "phase_restart_count": phase_restart_count,
+    }
+
+
+def _extract_pulse_markers(sidecar: dict[str, Any]) -> list[PulseMarker]:
+    markers: list[PulseMarker] = []
+    markers.extend(_markers_from_sequence(sidecar.get("markers"), default_kind="marker"))
+    markers.extend(_markers_from_sequence(sidecar.get("beats"), default_kind="beat"))
+    markers.extend(_markers_from_sequence(sidecar.get("clicks"), default_kind="click"))
+    for key in ("countIn", "count_in", "precount", "preCount"):
+        count_in = _object_field(sidecar, key)
+        if count_in:
+            markers.extend(_markers_from_sequence(count_in.get("clicks"), default_kind="count-in-click"))
+            markers.extend(_markers_from_sequence(count_in.get("markers"), default_kind="count-in-click"))
+    return [
+        marker
+        for marker in markers
+        if any(token in marker.kind for token in ("beat", "click", "pulse", "marker"))
+    ]
+
+
+def _extract_quiet_windows(sidecar: dict[str, Any]) -> list[QuietWindow]:
+    raw_windows = _first_sequence(
+        sidecar,
+        ("quietWindows", "expectedQuietWindows", "silenceWindows", "silentWindows"),
+    )
+    windows: list[QuietWindow] = []
+    for raw_window in raw_windows:
+        if not isinstance(raw_window, dict):
+            continue
+        start_seconds = _number_from_mapping(
+            raw_window,
+            ("startSeconds", "start", "fromSeconds", "from", "beginSeconds"),
+        )
+        end_seconds = _number_from_mapping(raw_window, ("endSeconds", "end", "toSeconds", "to"))
+        if start_seconds is None or end_seconds is None:
+            continue
+        max_rms = _number_from_mapping(raw_window, ("maxRms", "rmsThreshold", "maximumRms"))
+        windows.append(
+            QuietWindow(
+                start_seconds=start_seconds,
+                end_seconds=end_seconds,
+                max_rms=max_rms if max_rms is not None else DEFAULT_QUIET_WINDOW_MAX_RMS,
+            )
+        )
+    return windows
+
+
+def _extract_loop_expectations(sidecar: dict[str, Any]) -> list[LoopExpectation]:
+    raw_loops = _first_sequence(sidecar, ("loops", "loopWindows", "loopRanges"))
+    single_loop = _object_field(sidecar, "loop") or _object_field(sidecar, "loopRange")
+    if single_loop:
+        raw_loops = [single_loop, *raw_loops]
+
+    loops: list[LoopExpectation] = []
+    for raw_loop in raw_loops:
+        if not isinstance(raw_loop, dict):
+            continue
+        start_seconds = _number_from_mapping(
+            raw_loop,
+            ("startSeconds", "loopStartSeconds", "start", "loop_start_seconds"),
+        )
+        end_seconds = _number_from_mapping(raw_loop, ("endSeconds", "loopEndSeconds", "end", "loop_end_seconds"))
+        if start_seconds is None or end_seconds is None or end_seconds <= start_seconds:
+            continue
+        restart_seconds = _number_from_mapping(
+            raw_loop,
+            (
+                "restartSeconds",
+                "restartCaptureSeconds",
+                "loopRestartSeconds",
+                "loopRestartCaptureSeconds",
+                "wrapSeconds",
+                "wrappedAtSeconds",
+            ),
+        )
+        start_capture_seconds = _number_from_mapping(
+            raw_loop,
+            ("startCaptureSeconds", "loopStartCaptureSeconds", "referenceCaptureSeconds"),
+        )
+        min_similarity = _number_from_mapping(raw_loop, ("minSimilarity", "minimumSimilarity"))
+        require_similarity = _first_bool(
+            [raw_loop],
+            ("requireSimilarity", "requireWaveformSimilarity", "require_similarity", "require_waveform_similarity"),
+            False,
+        )
+        loops.append(
+            LoopExpectation(
+                start_seconds=start_seconds,
+                end_seconds=end_seconds,
+                restart_seconds=restart_seconds,
+                start_capture_seconds=start_capture_seconds,
+                min_similarity=min_similarity if min_similarity is not None else DEFAULT_LOOP_MIN_SIMILARITY,
+                require_similarity=require_similarity,
+            )
+        )
+    return loops
+
+
+def _markers_from_sequence(value: object, *, default_kind: str) -> list[PulseMarker]:
+    if not isinstance(value, list):
+        return []
+    markers: list[PulseMarker] = []
+    for item in value:
+        if isinstance(item, int | float) and math.isfinite(float(item)):
+            markers.append(PulseMarker(kind=default_kind, time_seconds=float(item)))
+            continue
+        if not isinstance(item, dict):
+            continue
+        time_seconds = _marker_capture_seconds(item)
+        if time_seconds is None:
+            continue
+        kind = _marker_kind(item, default_kind)
+        playback_seconds = _number_from_mapping(
+            item,
+            (
+                "playbackSeconds",
+                "playbackTimeSeconds",
+                "sourceSeconds",
+                "sourceTimeSeconds",
+                "targetStartSeconds",
+                "startTimeSeconds",
+            ),
+        )
+        markers.append(PulseMarker(kind=kind, time_seconds=time_seconds, playback_seconds=playback_seconds))
+    return markers
+
+
+def _marker_capture_seconds(item: dict[str, Any]) -> float | None:
+    value = _number_from_mapping(
+        item,
+        (
+            "captureSeconds",
+            "captureTimeSeconds",
+            "audioSeconds",
+            "audioTimeSeconds",
+            "timeSeconds",
+            "seconds",
+            "time",
+        ),
+    )
+    if value is not None:
+        return value
+    milliseconds = _number_from_mapping(item, ("captureMs", "captureTimeMs", "timeMs", "timestampMs"))
+    return None if milliseconds is None else milliseconds / 1000.0
+
+
+def _marker_kind(item: dict[str, Any], default: str) -> str:
+    for key in ("kind", "type", "name", "label", "event"):
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().lower().replace("_", "-")
+    return default
+
+
+def _marker_loop_restart_count(
+    loops: list[LoopExpectation],
+    markers: list[PulseMarker],
+    tolerance_seconds: float,
+) -> int:
+    markers_with_playback = sorted(
+        (marker for marker in markers if marker.playback_seconds is not None),
+        key=lambda marker: marker.time_seconds,
+    )
+    if not loops or len(markers_with_playback) < 2:
+        return 0
+    restart_count = 0
+    for previous, current in zip(markers_with_playback, markers_with_playback[1:], strict=False):
+        if previous.playback_seconds is None or current.playback_seconds is None:
+            continue
+        for loop in loops:
+            edge_tolerance_seconds = _loop_edge_tolerance_seconds(loop, tolerance_seconds)
+            min_backward_jump_seconds = _loop_min_backward_jump_seconds(loop)
+            previous_near_end = _near_loop_end(previous.playback_seconds, loop, edge_tolerance_seconds)
+            current_near_start = _near_loop_start(current.playback_seconds, loop, edge_tolerance_seconds)
+            jumped_backward = previous.playback_seconds - current.playback_seconds >= min_backward_jump_seconds
+            if previous_near_end and current_near_start:
+                if not jumped_backward:
+                    continue
+                restart_count += 1
+                break
+    return restart_count
+
+
+def _phase_loop_restart_count(
+    loops: list[LoopExpectation],
+    sidecar: dict[str, Any],
+    tolerance_seconds: float,
+) -> int:
+    if not loops:
+        return 0
+    count = 0
+    seen: set[tuple[float | None, float | None, float | None, float | None]] = set()
+    for phase in _loop_restart_phases(sidecar):
+        details = _object_field(phase, "details") or phase
+        restart_from_seconds = _number_from_mapping(
+            details,
+            ("restartFromSeconds", "restartFrom", "fromSeconds", "previousPositionSeconds"),
+        )
+        position_seconds = _number_from_mapping(
+            details,
+            ("positionSeconds", "playbackPositionSeconds", "playbackSeconds", "loopStartSeconds"),
+        )
+        if restart_from_seconds is None or position_seconds is None:
+            continue
+        phase_loop_start = _number_from_mapping(details, ("loopStartSeconds", "startSeconds", "loopStart"))
+        phase_loop_end = _number_from_mapping(details, ("loopEndSeconds", "endSeconds", "loopEnd"))
+        key = (restart_from_seconds, position_seconds, phase_loop_start, phase_loop_end)
+        if key in seen:
+            continue
+        seen.add(key)
+        for loop in loops:
+            edge_tolerance_seconds = _loop_edge_tolerance_seconds(loop, tolerance_seconds)
+            if phase_loop_start is not None and abs(phase_loop_start - loop.start_seconds) > edge_tolerance_seconds:
+                continue
+            if phase_loop_end is not None and abs(phase_loop_end - loop.end_seconds) > edge_tolerance_seconds:
+                continue
+            if not _near_loop_end(restart_from_seconds, loop, edge_tolerance_seconds):
+                continue
+            if not _near_loop_start(position_seconds, loop, edge_tolerance_seconds):
+                continue
+            if restart_from_seconds - position_seconds < _loop_min_backward_jump_seconds(loop):
+                continue
+            count += 1
+            break
+    return count
+
+
+def _loop_restart_phases(sidecar: dict[str, Any]) -> list[dict[str, Any]]:
+    phases: list[dict[str, Any]] = []
+    for key in ("phaseMarkers", "phases"):
+        value = sidecar.get(key)
+        if not isinstance(value, list):
+            continue
+        for phase in value:
+            if not isinstance(phase, dict):
+                continue
+            name = _marker_kind(phase, default="").replace("_", "-")
+            if name == "loop:restart-detected":
+                phases.append(phase)
+    return phases
+
+
+def _loop_edge_tolerance_seconds(loop: LoopExpectation, base_tolerance_seconds: float) -> float:
+    loop_seconds = loop.end_seconds - loop.start_seconds
+    telemetry_edge_seconds = min(0.35, max(0.08, loop_seconds * 0.15))
+    return max(base_tolerance_seconds, telemetry_edge_seconds)
+
+
+def _loop_min_backward_jump_seconds(loop: LoopExpectation) -> float:
+    loop_seconds = loop.end_seconds - loop.start_seconds
+    return min(0.25, max(0.05, loop_seconds * 0.25))
+
+
+def _near_loop_end(playback_seconds: float, loop: LoopExpectation, tolerance_seconds: float) -> bool:
+    return loop.end_seconds - tolerance_seconds <= playback_seconds <= loop.end_seconds + max(0.5, tolerance_seconds)
+
+
+def _near_loop_start(playback_seconds: float, loop: LoopExpectation, tolerance_seconds: float) -> bool:
+    return loop.start_seconds - tolerance_seconds <= playback_seconds <= loop.start_seconds + tolerance_seconds
+
+
+def _nearest_peak_time(
+    capture: AudioCapture,
+    expected_seconds: float,
+    *,
+    tolerance_seconds: float,
+    peak_floor: float,
+) -> float | None:
+    start_index = _sample_index(capture, max(0.0, expected_seconds - tolerance_seconds))
+    end_index = _sample_index(capture, min(capture.duration_seconds, expected_seconds + tolerance_seconds))
+    if end_index <= start_index:
+        return None
+    window = np.abs(capture.samples[start_index:end_index])
+    peak_index = int(np.argmax(window))
+    peak_value = float(window[peak_index])
+    if peak_value < peak_floor:
+        return None
+    return (start_index + peak_index) / capture.sample_rate
+
+
+def _best_snippet_similarity(
+    capture: AudioCapture,
+    *,
+    reference_seconds: float,
+    candidate_seconds: float,
+    loop_seconds: float,
+    search_radius_seconds: float,
+) -> float:
+    snippet_seconds = max(0.08, min(0.5, loop_seconds / 2.0))
+    candidate_offsets = np.linspace(-search_radius_seconds, search_radius_seconds, num=9)
+    similarities = [
+        _snippet_similarity(
+            capture,
+            reference_seconds=reference_seconds,
+            candidate_seconds=candidate_seconds + float(offset),
+            snippet_seconds=snippet_seconds,
+        )
+        for offset in candidate_offsets
+    ]
+    return max(similarities) if similarities else 0.0
+
+
+def _snippet_similarity(
+    capture: AudioCapture,
+    *,
+    reference_seconds: float,
+    candidate_seconds: float,
+    snippet_seconds: float,
+) -> float:
+    reference = _snippet(capture, reference_seconds, snippet_seconds)
+    candidate = _snippet(capture, candidate_seconds, snippet_seconds)
+    if reference.size == 0 or candidate.size == 0 or reference.size != candidate.size:
+        return 0.0
+    reference = reference - np.mean(reference)
+    candidate = candidate - np.mean(candidate)
+    reference_norm = float(np.linalg.norm(reference))
+    candidate_norm = float(np.linalg.norm(candidate))
+    if reference_norm == 0.0 or candidate_norm == 0.0:
+        return 0.0
+    return float(np.dot(reference, candidate) / (reference_norm * candidate_norm))
+
+
+def _snippet(capture: AudioCapture, start_seconds: float, duration_seconds: float) -> np.ndarray:
+    if start_seconds < 0 or duration_seconds <= 0:
+        return np.asarray([], dtype=np.float64)
+    start_index = _sample_index(capture, start_seconds)
+    end_index = _sample_index(capture, start_seconds + duration_seconds)
+    if end_index > capture.samples.size:
+        return np.asarray([], dtype=np.float64)
+    return capture.samples[start_index:end_index]
+
+
+def _sample_index(capture: AudioCapture, seconds: float) -> int:
+    return int(np.clip(round(seconds * capture.sample_rate), 0, capture.samples.size))
+
+
+def _rms(samples: np.ndarray) -> float:
+    if samples.size == 0:
+        return 0.0
+    return float(np.sqrt(np.mean(np.square(samples, dtype=np.float64))))
+
+
+def _peak(samples: np.ndarray) -> float:
+    if samples.size == 0:
+        return 0.0
+    return float(np.max(np.abs(samples)))
+
+
+def _first_sequence(mapping: dict[str, Any], keys: tuple[str, ...]) -> list[Any]:
+    for key in keys:
+        value = mapping.get(key)
+        if isinstance(value, list):
+            return value
+    return []
+
+
+def _object_field(mapping: dict[str, Any], key: str) -> dict[str, Any]:
+    value = mapping.get(key)
+    return value if isinstance(value, dict) else {}
+
+
+def _first_float(candidates: list[object], keys: tuple[str, ...], default: float | None) -> float | None:
+    for candidate in candidates:
+        if isinstance(candidate, int | float) and math.isfinite(float(candidate)):
+            return float(candidate)
+        if not isinstance(candidate, dict):
+            continue
+        value = _number_from_mapping(candidate, keys)
+        if value is not None:
+            return value
+    return default
+
+
+def _first_bool(candidates: list[object], keys: tuple[str, ...], default: bool) -> bool:
+    for candidate in candidates:
+        if isinstance(candidate, bool):
+            return candidate
+        if not isinstance(candidate, dict):
+            continue
+        for key in keys:
+            value = candidate.get(key)
+            if isinstance(value, bool):
+                return value
+    return default
+
+
+def _number_from_mapping(mapping: dict[str, Any], keys: tuple[str, ...]) -> float | None:
+    for key in keys:
+        value = mapping.get(key)
+        if isinstance(value, int | float) and math.isfinite(float(value)):
+            return float(value)
+        if isinstance(value, str):
+            try:
+                parsed = float(value)
+            except ValueError:
+                continue
+            if math.isfinite(parsed):
+                return parsed
+    return None
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/backend/tests/test_playback_capture_analyze.py
+++ b/apps/backend/tests/test_playback_capture_analyze.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from app.cli import playback_capture_analyze
+
+
+def test_cli_analyzes_wav_capture_with_markers_loop_and_quiet_window(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    audio_path = tmp_path / "capture.wav"
+    sidecar_path = tmp_path / "capture.json"
+    marker_seconds = [0.5, 1.0, 1.5, 2.0, 2.5]
+    _write_loop_capture(audio_path, marker_seconds=marker_seconds)
+    _write_json(
+        sidecar_path,
+        {
+            "minDurationSeconds": 3.2,
+            "rmsThreshold": 0.005,
+            "bpm": 120,
+            "beatToleranceSeconds": 0.04,
+            "markers": [
+                {"kind": "count-in-click", "timeSeconds": seconds}
+                for seconds in marker_seconds
+            ],
+            "loops": [
+                {
+                    "startSeconds": 1.0,
+                    "endSeconds": 2.0,
+                    "restartSeconds": 2.0,
+                    "minSimilarity": 0.85,
+                    "requireSimilarity": True,
+                }
+            ],
+            "quietWindows": [{"startSeconds": 3.1, "endSeconds": 3.3, "maxRms": 0.001}],
+        },
+    )
+
+    exit_code = playback_capture_analyze.main(
+        ["--audio", str(audio_path), "--sidecar", str(sidecar_path)]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0, captured.err
+    payload = json.loads(captured.out)
+    assert captured.err == ""
+    assert payload["duration_seconds"] == pytest.approx(3.4)
+    assert payload["rms"] > 0.005
+    assert payload["pulse_markers"]["checked"] == len(marker_seconds)
+    assert payload["pulse_markers"]["matched"] == len(marker_seconds)
+    assert payload["pulse_markers"]["max_spacing_error_seconds"] < 0.02
+    assert payload["loop_restarts"]["checked"] == 1
+    assert payload["loop_restarts"]["explicit_restarts"][0]["similarity"] > 0.99
+    assert payload["quiet_windows"]["checked"] == 1
+
+
+def test_cli_accepts_playback_smoke_sidecar_shape(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    audio_path = tmp_path / "playback-smoke-capture.wav"
+    sidecar_path = tmp_path / "playback-smoke-capture.timing.json"
+    phases = [
+        _phase("capture:prepared", 0, {"provider": "pulse", "routeOutput": True}),
+        _phase("capture:start", 100, {"provider": "pulse", "device": "tuneforge.monitor"}),
+        _phase("smoke:start", 500, {"appUrl": "http://127.0.0.1:1420"}),
+        _phase("tempo:set", 800, {"bpm": 120}),
+        _phase("song-precount:telemetry-passed", 500, {"startTimeSeconds": 0}),
+        _phase("loop:set", 900, {"startSeconds": 1.0, "endSeconds": 2.0}),
+        _phase("loop-precount:telemetry-passed", 1000, {"startTimeSeconds": 1.0}),
+        _phase(
+            "loop:restart-detected",
+            2000,
+            {
+                "loopStartSeconds": 1.0,
+                "loopEndSeconds": 2.0,
+                "restartFromSeconds": 1.96,
+                "positionSeconds": 1.02,
+            },
+        ),
+        _phase("smoke:passed", 3100, {}),
+        _phase("capture:stopped", 3400, {"exists": True, "sizeBytes": 4096}),
+    ]
+    _write_loop_capture(audio_path, marker_seconds=[0.5, 1.0, 2.0], repeat_loop_segment=False)
+    _write_json(
+        sidecar_path,
+        {
+            "schema_version": 1,
+            "provider": "pulse",
+            "provider_command": "parecord",
+            "route_output": True,
+            "sample_rate_hz": 8_000,
+            "channels": 1,
+            "audio": {"sampleRate": 8_000, "channels": 1, "path": str(audio_path)},
+            "minDurationSeconds": 3.2,
+            "rmsThreshold": 0.005,
+            "markerToleranceSeconds": 0.08,
+            "spacingToleranceSeconds": 0.08,
+            "phaseMarkers": phases,
+            "phases": phases,
+            "markers": [
+                {"kind": "song-precount-playback-marker", "timeSeconds": 0.5, "playbackSeconds": 0},
+                {"kind": "loop-precount-playback-marker", "timeSeconds": 1.0, "playbackSeconds": 1.0},
+                {"kind": "loop-restart-marker", "timeSeconds": 2.0, "playbackSeconds": 1.0},
+            ],
+            "quietWindows": [{"startSeconds": 0.2, "endSeconds": 0.35, "maxRms": 0.001}],
+            "loops": [
+                {
+                    "startSeconds": 1.0,
+                    "endSeconds": 2.0,
+                }
+            ],
+            "requireLoopRestart": True,
+            "capture_file": {"exists": True, "sizeBytes": 4096},
+        },
+    )
+
+    exit_code = playback_capture_analyze.main(
+        ["--audio", str(audio_path), "--sidecar", str(sidecar_path)]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0, captured.err
+    payload = json.loads(captured.out)
+    assert captured.err == ""
+    assert payload["pulse_markers"]["checked"] == 3
+    assert payload["loop_restarts"]["checked"] == 1
+    assert payload["loop_restarts"]["phase_restart_count"] == 1
+    assert payload["loop_restarts"]["explicit_restarts"][0]["waveform_similarity_required"] is False
+    assert payload["loop_restarts"]["explicit_restarts"][0]["restart_seconds"] is None
+    assert "similarity" not in payload["loop_restarts"]["explicit_restarts"][0]
+    assert payload["quiet_windows"]["checked"] == 1
+
+
+def test_cli_rejects_required_loop_restart_without_valid_wrap_telemetry(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    audio_path = tmp_path / "playback-smoke-capture.wav"
+    sidecar_path = tmp_path / "playback-smoke-capture.timing.json"
+    phases = [
+        _phase("capture:start", 100, {"provider": "pipewire", "device": "tuneforge.monitor"}),
+        _phase("smoke:start", 500, {"appUrl": "http://127.0.0.1:1420"}),
+        _phase("song-precount:telemetry-passed", 500, {"startTimeSeconds": 0}),
+        _phase("loop:set", 900, {"startSeconds": 1.0, "endSeconds": 2.0}),
+        _phase("loop-precount:telemetry-passed", 1000, {"startTimeSeconds": 1.0}),
+        _phase(
+            "loop:restart-detected",
+            2000,
+            {
+                "loopStartSeconds": 1.0,
+                "loopEndSeconds": 2.0,
+                "restartFromSeconds": 1.2,
+                "positionSeconds": 1.0,
+            },
+        ),
+        _phase("smoke:passed", 3100, {}),
+        _phase("capture:stopped", 3400, {"exists": True, "sizeBytes": 4096}),
+    ]
+    _write_loop_capture(audio_path, marker_seconds=[0.5, 1.0, 2.0], repeat_loop_segment=False)
+    _write_json(
+        sidecar_path,
+        {
+            "audio": {"sampleRate": 8_000, "channels": 1, "path": str(audio_path)},
+            "minDurationSeconds": 3.2,
+            "rmsThreshold": 0.005,
+            "markerToleranceSeconds": 0.08,
+            "phaseMarkers": phases,
+            "phases": phases,
+            "markers": [
+                {"kind": "song-precount-playback-marker", "timeSeconds": 0.5, "playbackSeconds": 0},
+                {"kind": "loop-precount-playback-marker", "timeSeconds": 1.0, "playbackSeconds": 1.0},
+                {"kind": "loop-restart-marker", "timeSeconds": 2.0, "playbackSeconds": 1.0},
+            ],
+            "quietWindows": [{"startSeconds": 0.2, "endSeconds": 0.35, "maxRms": 0.001}],
+            "loops": [
+                {
+                    "startSeconds": 1.0,
+                    "endSeconds": 2.0,
+                    "startCaptureSeconds": 1.0,
+                    "restartSeconds": 2.0,
+                    "minSimilarity": 0.65,
+                }
+            ],
+            "requireLoopRestart": True,
+        },
+    )
+
+    exit_code = playback_capture_analyze.main(
+        ["--audio", str(audio_path), "--sidecar", str(sidecar_path)]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert captured.out == ""
+    assert "did not show wrap from near loop end to near loop start" in captured.err
+
+
+def test_cli_rejects_silent_capture(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    audio_path = tmp_path / "silent.wav"
+    sidecar_path = tmp_path / "capture.json"
+    sf.write(audio_path, np.zeros(8_000, dtype=np.float32), 8_000)
+    _write_json(sidecar_path, {"minDurationSeconds": 0.5, "rmsThreshold": 0.01})
+
+    exit_code = playback_capture_analyze.main(
+        ["--audio", str(audio_path), "--sidecar", str(sidecar_path)]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert captured.out == ""
+    assert "capture RMS" in captured.err
+
+
+def test_cli_rejects_missing_expected_pulse(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    audio_path = tmp_path / "capture.wav"
+    sidecar_path = tmp_path / "capture.json"
+    _write_pulse_capture(audio_path, marker_seconds=[0.5])
+    _write_json(
+        sidecar_path,
+        {
+            "minDurationSeconds": 1.5,
+            "rmsThreshold": 0.002,
+            "beatToleranceSeconds": 0.04,
+            "markers": [
+                {"kind": "count-in-click", "timeSeconds": 0.5},
+                {"kind": "count-in-click", "timeSeconds": 1.0},
+            ],
+        },
+    )
+
+    exit_code = playback_capture_analyze.main(
+        ["--audio", str(audio_path), "--sidecar", str(sidecar_path)]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert captured.out == ""
+    assert "expected count-in-click pulse near 1.000s" in captured.err
+
+
+def _write_loop_capture(
+    path: Path,
+    *,
+    marker_seconds: list[float],
+    sample_rate: int = 8_000,
+    repeat_loop_segment: bool = True,
+) -> None:
+    total_seconds = 3.4
+    signal = np.zeros(int(sample_rate * total_seconds), dtype=np.float32)
+    loop_t = np.arange(0, sample_rate, dtype=np.float32) / sample_rate
+    loop_segment = 0.08 * np.sin(2 * np.pi * 220 * loop_t)
+    restart_segment = loop_segment if repeat_loop_segment else 0.08 * np.sin(2 * np.pi * 330 * loop_t)
+    signal[sample_rate : sample_rate * 2] += loop_segment
+    signal[sample_rate * 2 : sample_rate * 3] += restart_segment
+    _add_clicks(signal, marker_seconds=marker_seconds, sample_rate=sample_rate)
+    sf.write(path, signal, sample_rate)
+
+
+def _write_pulse_capture(
+    path: Path,
+    *,
+    marker_seconds: list[float],
+    sample_rate: int = 8_000,
+) -> None:
+    signal = np.zeros(sample_rate * 2, dtype=np.float32)
+    _add_clicks(signal, marker_seconds=marker_seconds, sample_rate=sample_rate)
+    sf.write(path, signal, sample_rate)
+
+
+def _add_clicks(signal: np.ndarray, *, marker_seconds: list[float], sample_rate: int) -> None:
+    click_frames = int(0.02 * sample_rate)
+    click = (0.8 * np.hanning(click_frames)).astype(np.float32)
+    for seconds in marker_seconds:
+        start = int(seconds * sample_rate)
+        end = min(signal.size, start + click_frames)
+        signal[start:end] += click[: end - start]
+
+
+def _phase(name: str, elapsed_ms: float, details: dict[str, object]) -> dict[str, object]:
+    return {
+        "name": name,
+        "at": "2026-05-28T00:00:00.000Z",
+        "elapsed_ms": elapsed_ms,
+        "details": details,
+    }
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")

--- a/docs/NATIVE_AUDIO.md
+++ b/docs/NATIVE_AUDIO.md
@@ -148,11 +148,83 @@ Run the isolated smoke pass:
 pnpm --filter @tuneforge/desktop test:e2e -- --run
 ```
 
+Run the optional Linux virtual-audio capture smoke:
+
+```sh
+pnpm --filter @tuneforge/desktop test:e2e -- --run --route-output
+```
+
+Run the optional macOS AVFoundation capture smoke with an explicit capture device:
+
+```sh
+pnpm --filter @tuneforge/desktop test:e2e -- --run --capture-provider=avfoundation --capture-device="BlackHole 2ch"
+```
+
+Use the same local debugging flags when needed. On macOS, replace `--route-output` with the explicit
+`--capture-provider=avfoundation --capture-device=<name-or-id>` pair:
+
+```sh
+pnpm --filter @tuneforge/desktop test:e2e -- --run --route-output --headed
+pnpm --filter @tuneforge/desktop test:e2e -- --run --route-output --keep-artifacts
+pnpm --filter @tuneforge/desktop test:e2e -- --run --route-output --backend-port=<port> --app-port=<port>
+```
+
 The isolated run prepares temporary app data and a temporary database, creates a deterministic
 generated fixture project, starts the backend and frontend, runs the smoke flow, then cleans the
 temporary data by default. Use `--keep-artifacts` to retain temporary paths and logs for debugging.
 If a local port is already in use, pass `--backend-port=<port>` or `--app-port=<port>`. The isolated
 backend allows only the selected loopback frontend origin so browser CORS stays enabled.
+
+`--route-output` is Linux-only and should be used only for isolated generated-fixture runs. It must
+not be combined with `--manual-app`, because virtual output capture is intended to avoid personal
+libraries and user audio. Without `--route-output`, the smoke does not change system audio routing.
+With `--route-output` on Linux, the smoke records the fixture playback through a temporary virtual
+output path and restores the previous output route during cleanup. If routing, recording, or platform
+support is missing, the virtual-capture portion fails or skips with a clear message; the standard
+browser smoke still reports its own pass/fail result separately.
+
+On Linux, use a PipeWire desktop with the PulseAudio compatibility service (`pipewire-pulse`) or a
+PulseAudio session, and make sure `pactl` plus either `pw-record` or `parecord` are available on
+`PATH`. Example setup:
+
+```sh
+# Arch
+sudo pacman -S pipewire-pulse pipewire-audio libpulse
+
+# Debian/Ubuntu
+sudo apt-get install pipewire-pulse pulseaudio-utils pipewire-bin
+```
+
+The smoke creates a temporary null sink only when `--route-output` is present, routes playback to
+that sink, records the sink through the selected local provider, then restores the previous default
+sink and unloads the temporary sink. With PipeWire, the smoke resolves the temp sink's
+`object.serial` and passes that serial to `pw-record --target`; the sidecar still records the
+Pulse/PipeWire monitor source as the logical device. If `pactl` cannot create the sink, no default
+sink can be restored, or capture is unavailable, keep artifacts and inspect the smoke logs before
+rerunning.
+
+On macOS, install a local BlackHole device and `ffmpeg` first, then verify AVFoundation can see it:
+
+```sh
+# Homebrew-managed setup
+brew install blackhole-2ch ffmpeg
+
+# Device discovery
+ffmpeg -f avfoundation -list_devices true -i ""
+```
+
+Select the BlackHole device with `--capture-device=<name-or-id>` if more than one virtual audio
+device is installed. macOS capture does not support `--route-output` and the smoke does not switch or
+restore the default output device. Configure any Multi-Output Device or output routing manually
+before running the smoke if you want to listen while capturing. Tauri WebDriver cannot automate the
+WKWebView on macOS, so this capture path validates the local browser smoke and explicit AVFoundation
+capture rather than automating the packaged Tauri WebView.
+
+With `--keep-artifacts`, virtual-capture runs retain the temporary root printed by the smoke. Expect
+the fixture data directory, backend/frontend child-process logs, the captured audio file, and any
+platform routing logs or metadata that describe the selected virtual sink/device. Custom
+`--capture-output` paths must end in `.wav`, because the capture analyzer reads WAV output. Without
+`--keep-artifacts`, these outputs are temporary diagnostics and are removed during cleanup.
 
 To run against an existing personal library or a pre-running app, opt into manual app mode and pass
 the project selector explicitly:

--- a/scripts/playback-smoke.mjs
+++ b/scripts/playback-smoke.mjs
@@ -3,10 +3,11 @@
 import process from "node:process";
 import net from "node:net";
 import { spawn } from "node:child_process";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { dirname, extname, join, resolve } from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { createRequire } from "node:module";
 
 const desktopRequire = createRequire(new URL("../apps/desktop/package.json", import.meta.url));
@@ -14,12 +15,23 @@ const repoRoot = fileURLToPath(new URL("../", import.meta.url));
 const DEFAULT_MANUAL_APP_URL = "http://127.0.0.1:1420";
 const DEFAULT_STARTUP_TIMEOUT_MS = 45_000;
 const CHILD_TAIL_LINES = 40;
+const CAPTURE_SAMPLE_RATE = 48_000;
+const CAPTURE_CHANNELS = 2;
+const CAPTURE_STARTUP_GRACE_MS = 1000;
+const CAPTURE_ANALYZER_TIMEOUT_MS = 120_000;
+const SUPPORTED_CAPTURE_PROVIDERS = new Set(["auto", "pipewire", "pulse", "avfoundation"]);
 
-try {
-  await main();
-} catch (error) {
-  console.error(`[playback-smoke] ${errorMessage(error)}`);
-  process.exitCode = 1;
+if (isDirectRun()) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(`[playback-smoke] ${errorMessage(error)}`);
+    process.exitCode = 1;
+  }
+}
+
+function isDirectRun() {
+  return Boolean(process.argv[1]) && import.meta.url === pathToFileURL(process.argv[1]).href;
 }
 
 async function main() {
@@ -54,6 +66,10 @@ function printScaffold() {
   console.log(
     '  pnpm --filter @tuneforge/desktop test:e2e -- --run --manual-app --project-name="Demo Song"',
   );
+  console.log("Optional local virtual-audio capture:");
+  console.log(
+    "  pnpm --filter @tuneforge/desktop test:e2e -- --run --capture-audio --route-output",
+  );
 }
 
 async function runManualSmoke(options) {
@@ -65,14 +81,43 @@ async function runManualSmoke(options) {
       ].join("\n"),
     );
   }
+  if (options.routeOutput) {
+    throw new Error(
+      [
+        "--route-output is supported only by isolated generated-fixture smoke.",
+        "Use --capture-device=<name-or-id> for explicit manual-app capture without system output routing.",
+      ].join("\n"),
+    );
+  }
 
-  await runSmoke({
-    appUrl: options.appUrl,
-    projectId: options.projectId,
-    projectName: options.projectName,
-    headed: options.headed,
-    requireTelemetry: false,
-  });
+  const captureTempRoot = options.captureAudio && !options.captureOutput
+    ? await mkdtemp(join(tmpdir(), "tuneforge-playback-capture-"))
+    : null;
+  const defaultCaptureOutput = captureTempRoot
+    ? join(captureTempRoot, "playback-smoke-capture.wav")
+    : null;
+  let captureResult = null;
+
+  try {
+    captureResult = await runWithOptionalAudioCapture(options, {
+      defaultOutputPath: defaultCaptureOutput,
+      onStop: (result) => {
+        captureResult = result;
+      },
+      run: async (capture) => runSmoke({
+        appUrl: options.appUrl,
+        projectId: options.projectId,
+        projectName: options.projectName,
+        headed: options.headed,
+        requireTelemetry: false,
+        recordPhase: capture?.recordPhase,
+        captureTiming: Boolean(capture),
+        captureTimingRequired: Boolean(capture) && options.requireAudioCapture,
+      }),
+    });
+  } finally {
+    await cleanupCaptureTempRoot(captureTempRoot, options, captureResult);
+  }
 }
 
 async function runIsolatedSmoke(options) {
@@ -83,6 +128,7 @@ async function runIsolatedSmoke(options) {
   const workDir = join(tempRoot, "work");
   const children = [];
   let fixture = null;
+  let captureResult = null;
 
   try {
     await mkdir(dataDir, { recursive: true });
@@ -139,17 +185,26 @@ async function runIsolatedSmoke(options) {
     logStep(`Desktop dev server ready on ${appUrl}.`);
 
     const fixturePath = fixture.app_url_path || `/#/projects/${fixture.project_id}`;
-    await runSmoke({
-      appUrl,
-      projectId: fixture.project_id,
-      projectName: fixture.project_name ?? "",
-      projectUrl: appendAppPath(appUrl, fixturePath),
-      headed: options.headed,
-      requireTelemetry: true,
+    captureResult = await runWithOptionalAudioCapture(options, {
+      defaultOutputPath: join(tempRoot, "capture", "playback-smoke-capture.wav"),
+      onStop: (result) => {
+        captureResult = result;
+      },
+      run: async (capture) => runSmoke({
+        appUrl,
+        projectId: fixture.project_id,
+        projectName: fixture.project_name ?? "",
+        projectUrl: appendAppPath(appUrl, fixturePath),
+        headed: options.headed,
+        requireTelemetry: true,
+        recordPhase: capture?.recordPhase,
+        captureTiming: Boolean(capture),
+        captureTimingRequired: Boolean(capture) && options.requireAudioCapture,
+      }),
     });
   } finally {
     await stopChildren(children);
-    if (options.keepArtifacts) {
+    if (options.keepArtifacts || captureResult?.keepArtifacts) {
       logStep(`Kept artifacts at ${tempRoot}.`);
     } else {
       await rm(tempRoot, { recursive: true, force: true });
@@ -164,6 +219,9 @@ async function runSmoke({
   projectUrl = "",
   headed,
   requireTelemetry = false,
+  recordPhase = () => {},
+  captureTiming = false,
+  captureTimingRequired = false,
 }) {
   let chromium;
   try {
@@ -184,43 +242,54 @@ async function runSmoke({
 
   try {
   const page = await browser.newPage();
+  recordPhase("smoke:start", { appUrl: projectUrl || appUrl });
   logStep(
     `Running ${headed ? "headed" : "headless"} smoke against ${projectUrl || appUrl} (${projectId ? `project ${projectId}` : `project "${projectName}"`}).`,
   );
   await openProject(page, { appUrl, projectId, projectName, projectUrl });
   await page.getByRole("heading", { name: /.+/ }).first().waitFor();
+  recordPhase("project:opened", { projectId: projectId || null, projectName: projectName || null });
   logStep("Project opened.");
   await openPlayback(page);
+  recordPhase("playback:opened");
   if (requireTelemetry) {
     await assertPlaybackE2EBridge(page);
+    recordPhase("telemetry:ready");
   }
   await resetSmokePlaybackState(page);
+  recordPhase("playback:reset");
 
   const durationSeconds = await readPlaybackDuration(page);
+  recordPhase("playback:ready", { durationSeconds });
   logStep(`Playback tab ready. Duration: ${formatSeconds(durationSeconds)}.`);
   const playbackBpmInput = page.getByRole("spinbutton", { name: "Playback BPM" });
   await playbackBpmInput.fill("128");
   await playbackBpmInput.press("Enter");
+  recordPhase("tempo:set", { bpm: 128 });
   logStep("Playback tempo set to 128 BPM.");
   const scrubberStartSeconds = stoppedStartProbeTime(durationSeconds);
   await seekTo(page, scrubberStartSeconds);
   await expectPosition(page, scrubberStartSeconds, "after stopped scrubber seek");
   await verifyPlayStartsFromSelection(page, scrubberStartSeconds, "stopped scrubber selection");
+  recordPhase("scrubber-selection:played", { startSeconds: scrubberStartSeconds });
   logStep(`Stopped scrubber selection started at ${formatSeconds(scrubberStartSeconds)}.`);
 
   const practiceStartSeconds = await chooseStoppedPracticeSelection(page);
   if (practiceStartSeconds === null) {
+    recordPhase("practice-selection:skipped");
     logStep("Skipped stopped lyrics/chords selection; no timed practice target was available.");
   } else {
     await verifyPlayStartsFromSelection(page, practiceStartSeconds, "stopped lyrics/chords selection");
+    recordPhase("practice-selection:played", { startSeconds: practiceStartSeconds });
     logStep(`Stopped lyrics/chords selection started at ${formatSeconds(practiceStartSeconds)}.`);
   }
 
   await page.getByLabel("Enable pre-count").check();
   await seekTo(page, 0);
   await expectPosition(page, 0, "before song-start pre-count");
+  recordPhase("song-precount:start", { startSeconds: 0 });
   await page.getByRole("button", { name: "Play playback" }).click();
-  const songCountInTelemetryAsserted = await assertCountInTelemetry(page, {
+  const songCountInTelemetry = await assertCountInTelemetry(page, {
     expectedKind: "song-start",
     expectedStartSeconds: 0,
     label: "song-start pre-count",
@@ -229,7 +298,8 @@ async function runSmoke({
   await page.getByRole("button", { name: "Pause playback" }).waitFor({ timeout: 5000 });
   await page.getByRole("button", { name: "Stop playback" }).click();
   await expectPosition(page, 0, "after song-start pre-count smoke");
-  if (songCountInTelemetryAsserted) {
+  if (songCountInTelemetry) {
+    recordPhase("song-precount:telemetry-passed", songCountInTelemetry);
     logStep("Song-start pre-count telemetry passed.");
   }
 
@@ -253,23 +323,28 @@ async function runSmoke({
   await expectPosition(page, loopEndSeconds, "after seeking to loop end");
   await page.getByRole("button", { name: "Set loop end" }).click();
   await expectPosition(page, loopStartSeconds, "after setting loop end");
+  recordPhase("loop:set", { startSeconds: loopStartSeconds, endSeconds: loopEndSeconds });
   logStep(`Loop set: ${formatSeconds(loopStartSeconds)} to ${formatSeconds(loopEndSeconds)}.`);
 
   await seekTo(page, outsideLoopSeconds);
   await expectPosition(page, loopStartSeconds, "after seeking outside the loop");
+  recordPhase("loop:snapback", { requestedSeconds: outsideLoopSeconds, snappedSeconds: loopStartSeconds });
   logStep("Seek outside loop snapped back to loop start.");
 
   await page.getByLabel("Enable loop pre-count").check();
+  recordPhase("loop-precount:enabled");
   logStep("Song and loop pre-count enabled.");
 
+  recordPhase("loop-playback:start", { startSeconds: loopStartSeconds, endSeconds: loopEndSeconds });
   await page.getByRole("button", { name: "Play playback" }).click();
-  const loopCountInTelemetryAsserted = await assertCountInTelemetry(page, {
+  const loopCountInTelemetry = await assertCountInTelemetry(page, {
     expectedKind: "loop-start",
     expectedStartSeconds: loopStartSeconds,
     label: "loop pre-count",
     requireTelemetry,
   });
-  if (loopCountInTelemetryAsserted) {
+  if (loopCountInTelemetry) {
+    recordPhase("loop-precount:telemetry-passed", loopCountInTelemetry);
     logStep("Loop pre-count telemetry passed.");
   }
   await page.getByRole("button", { name: "Pause playback" }).waitFor();
@@ -280,13 +355,38 @@ async function runSmoke({
     label: "loop playback",
     requireTelemetry,
   });
+  if (captureTiming && requireTelemetry) {
+    try {
+      const loopRestart = await waitForLoopRestartTelemetry(page, {
+        expectedLoopEndSeconds: loopEndSeconds,
+        expectedLoopStartSeconds: loopStartSeconds,
+        label: "loop playback",
+        requireTelemetry,
+      });
+      if (loopRestart) {
+        recordPhase("loop:restart-detected", loopRestart);
+        logStep("Loop restart telemetry passed.");
+      }
+    } catch (error) {
+      recordPhase("loop:restart-missing", { message: errorMessage(error) });
+      if (captureTimingRequired) {
+        throw error;
+      }
+      logStep(`Skipped capture loop restart timing check: ${errorMessage(error)}`);
+    }
+  }
   await page.getByRole("button", { name: "Pause playback" }).click();
   await page.getByRole("button", { name: "Play playback" }).click();
   await page.getByRole("button", { name: "Pause playback" }).waitFor();
   await page.getByRole("button", { name: "Stop playback" }).click();
   await expectPosition(page, loopStartSeconds, "after stop with active loop");
+  recordPhase("pause-resume-stop:passed");
   logStep("Play, pause, resume, and stop passed.");
+  recordPhase("smoke:passed");
   logStep("Passed.");
+} catch (error) {
+  recordPhase("smoke:error", { message: errorMessage(error) });
+  throw error;
 } finally {
   await browser.close();
 }
@@ -295,6 +395,17 @@ async function runSmoke({
 function parseOptions(argv) {
   const parsed = parseCliArgs(argv);
   const manualApp = readFlag(parsed, "manual-app");
+  const requireAudioCapture = readFlag(parsed, "require-audio-capture");
+  const routeOutput = readFlag(parsed, "route-output");
+  const captureProvider = readCaptureProviderOption(parsed);
+  const captureDevice = readStringOption(parsed, "capture-device");
+  const captureOutput = readStringOption(parsed, "capture-output");
+  const captureAudio = readFlag(parsed, "capture-audio")
+    || requireAudioCapture
+    || routeOutput
+    || Boolean(captureDevice)
+    || Boolean(captureOutput)
+    || parsed.values.has("capture-provider");
   const projectId = readStringOption(parsed, "project-id")
     || (manualApp ? process.env.TUNEFORGE_SMOKE_PROJECT_ID || "" : "");
   const projectName = readStringOption(parsed, "project-name")
@@ -308,6 +419,12 @@ function parseOptions(argv) {
     headed: readFlag(parsed, "headed"),
     backendPort: readPortOption(parsed, "backend-port"),
     appPort: readPortOption(parsed, "app-port"),
+    captureAudio,
+    requireAudioCapture,
+    routeOutput,
+    captureProvider,
+    captureDevice,
+    captureOutput,
     appUrl: readStringOption(parsed, "app-url")
       || process.env.TUNEFORGE_SMOKE_APP_URL
       || DEFAULT_MANUAL_APP_URL,
@@ -363,12 +480,926 @@ function readPortOption(parsed, name) {
   return value ? parsePort(value, name) : null;
 }
 
+function readCaptureProviderOption(parsed) {
+  const value = readStringOption(parsed, "capture-provider") || "auto";
+  if (!SUPPORTED_CAPTURE_PROVIDERS.has(value)) {
+    throw new Error(
+      `Invalid --capture-provider value "${value}". Expected auto, pipewire, pulse, or avfoundation.`,
+    );
+  }
+  return value;
+}
+
 function parsePort(value, name) {
   const port = Number(value);
   if (!Number.isInteger(port) || port < 1 || port > 65_535) {
     throw new Error(`Invalid --${name} value "${value}". Expected TCP port 1-65535.`);
   }
   return port;
+}
+
+async function runWithOptionalAudioCapture(options, { defaultOutputPath, run, onStop = () => {} }) {
+  const capture = await startOptionalAudioCapture(options, { defaultOutputPath });
+  let runError = null;
+  let stopResult = { keepArtifacts: false, error: null };
+
+  try {
+    await run(capture);
+  } catch (error) {
+    runError = error;
+  }
+
+  stopResult = await stopOptionalAudioCapture(capture, { runError });
+  onStop(stopResult);
+
+  if (runError) {
+    throw runError;
+  }
+  if (stopResult.error && options.requireAudioCapture) {
+    throw stopResult.error;
+  }
+
+  return stopResult;
+}
+
+async function startOptionalAudioCapture(options, { defaultOutputPath }) {
+  if (!options.captureAudio) {
+    return null;
+  }
+
+  let plan;
+  try {
+    plan = await buildAudioCapturePlan(options, { defaultOutputPath });
+  } catch (error) {
+    return handleCaptureUnavailable(options, errorMessage(error));
+  }
+  if (!plan) {
+    return null;
+  }
+  if (plan.skipReason) {
+    return handleCaptureUnavailable(options, plan.skipReason);
+  }
+
+  const capture = createAudioCaptureSession(plan, options);
+  try {
+    await startAudioCaptureSession(capture);
+    return capture;
+  } catch (error) {
+    await cleanupAudioRoute(capture.route);
+    return handleCaptureUnavailable(options, errorMessage(error));
+  }
+}
+
+function handleCaptureUnavailable(options, reason) {
+  if (options.requireAudioCapture) {
+    throw new Error(`Audio capture required but unavailable: ${reason}`);
+  }
+  logStep(`Skipped audio capture: ${reason}`);
+  return null;
+}
+
+async function buildAudioCapturePlan(options, { defaultOutputPath }) {
+  const outputPath = resolveCaptureOutputPath(options.captureOutput, defaultOutputPath);
+  if (!outputPath) {
+    return { skipReason: "no --capture-output path and no temporary output path available" };
+  }
+  const outputSkipReason = validateCaptureOutputPath(outputPath);
+  if (outputSkipReason) {
+    return { skipReason: outputSkipReason };
+  }
+  const sidecarPath = `${stripWavExtension(outputPath)}.timing.json`;
+  const analysisOutputPath = `${stripWavExtension(outputPath)}.analysis.json`;
+
+  if (process.platform === "darwin") {
+    return buildMacAudioCapturePlan(options, { outputPath, sidecarPath, analysisOutputPath });
+  }
+  if (process.platform === "linux") {
+    return buildLinuxAudioCapturePlan(options, { outputPath, sidecarPath, analysisOutputPath });
+  }
+
+  return {
+    skipReason: `platform ${process.platform} has no supported virtual-audio capture provider`,
+  };
+}
+
+async function buildMacAudioCapturePlan(options, paths) {
+  if (options.captureProvider !== "auto" && options.captureProvider !== "avfoundation") {
+    return { skipReason: `capture provider ${options.captureProvider} is not supported on macOS` };
+  }
+  if (options.routeOutput) {
+    return {
+      skipReason: "macOS --route-output is unsupported; system output was not changed",
+    };
+  }
+  if (!options.captureDevice) {
+    return {
+      skipReason: "macOS AVFoundation capture requires --capture-device=<audio-device-name-or-id>",
+    };
+  }
+  if (!(await commandExists("ffmpeg"))) {
+    return { skipReason: "ffmpeg was not found for AVFoundation capture" };
+  }
+
+  return {
+    ...paths,
+    provider: "avfoundation",
+    providerCommand: "ffmpeg",
+    device: options.captureDevice,
+    captureTarget: options.captureDevice,
+    captureTargetKind: "avfoundation-device",
+    routeOutput: false,
+  };
+}
+
+async function buildLinuxAudioCapturePlan(options, paths) {
+  if (options.captureProvider === "avfoundation") {
+    return { skipReason: "AVFoundation capture is only supported on macOS" };
+  }
+  if (options.routeOutput && options.captureDevice) {
+    return {
+      skipReason: "use --route-output without --capture-device; the temp virtual sink supplies the capture device",
+    };
+  }
+
+  const provider = await resolveLinuxCaptureProvider(options.captureProvider);
+  if (!provider) {
+    return { skipReason: "neither pw-record nor parecord was found" };
+  }
+  if (provider === "pipewire" && !(await commandExists("pw-record"))) {
+    return { skipReason: "pw-record was not found for PipeWire capture" };
+  }
+  if (provider === "pulse" && !(await commandExists("parecord"))) {
+    return { skipReason: "parecord was not found for PulseAudio capture" };
+  }
+  if (options.routeOutput && !(await commandExists("pactl"))) {
+    return { skipReason: "--route-output requires pactl to create and restore a virtual sink" };
+  }
+
+  let device = options.captureDevice;
+  if (!device && !options.routeOutput) {
+    const discovery = await discoverLinuxMonitorSource();
+    if (!discovery.device) {
+      return {
+        skipReason: discovery.reason
+          || "no Pulse/PipeWire monitor source found; pass --capture-device or --route-output",
+      };
+    }
+    device = discovery.device;
+  }
+
+  return {
+    ...paths,
+    provider,
+    providerCommand: provider === "pipewire" ? "pw-record" : "parecord",
+    device,
+    captureTarget: device,
+    captureTargetKind: device ? "capture-device" : "",
+    routeOutput: options.routeOutput,
+  };
+}
+
+async function resolveLinuxCaptureProvider(requestedProvider) {
+  if (requestedProvider === "pipewire" || requestedProvider === "pulse") {
+    return requestedProvider;
+  }
+  if (await commandExists("pw-record")) {
+    return "pipewire";
+  }
+  if (await commandExists("parecord")) {
+    return "pulse";
+  }
+  return null;
+}
+
+function resolveCaptureOutputPath(captureOutput, defaultOutputPath) {
+  const rawPath = captureOutput || defaultOutputPath || "";
+  return rawPath ? resolve(rawPath) : "";
+}
+
+export function validateCaptureOutputPath(outputPath) {
+  return extname(outputPath).toLowerCase() === ".wav"
+    ? ""
+    : "--capture-output must end in .wav; playback capture analyzer reads WAV output";
+}
+
+function stripWavExtension(path) {
+  return extname(path).toLowerCase() === ".wav" ? path.slice(0, -4) : path;
+}
+
+function createAudioCaptureSession(plan, options) {
+  const phaseRecorder = createPhaseRecorder({
+    provider: plan.provider,
+    outputPath: plan.outputPath,
+    routeOutput: plan.routeOutput,
+  });
+  return {
+    plan,
+    options,
+    handle: null,
+    route: null,
+    started: false,
+    recordPhase: phaseRecorder.recordPhase,
+    phases: phaseRecorder.phases,
+    captureStartedAt: phaseRecorder.startedAt,
+    perfOriginMs: phaseRecorder.perfOriginMs,
+  };
+}
+
+function createPhaseRecorder(context) {
+  const phases = [];
+  const perfOriginMs = performance.now();
+  const startedAt = new Date().toISOString();
+  const recordPhase = (name, details = {}) => {
+    phases.push({
+      name,
+      at: new Date().toISOString(),
+      elapsed_ms: roundMillis(performance.now() - perfOriginMs),
+      details,
+    });
+  };
+  recordPhase("capture:prepared", context);
+  return { phases, startedAt, perfOriginMs, recordPhase };
+}
+
+async function startAudioCaptureSession(capture) {
+  await mkdir(dirname(capture.plan.outputPath), { recursive: true });
+  if (capture.plan.routeOutput) {
+    capture.route = await setupPulseVirtualSink();
+    capture.plan.device = capture.route.monitorSource;
+    capture.plan.captureTarget = capture.route.monitorSource;
+    capture.plan.captureTargetKind = "monitor-source";
+    if (capture.plan.provider === "pipewire") {
+      capture.plan.captureTarget = await resolvePipeWireSinkObjectSerial(capture.route.sinkName);
+      capture.plan.captureTargetKind = "pipewire-object-serial";
+    }
+    logStep(
+      `Routed Linux output to temp virtual sink ${capture.route.sinkName}; previous default will be restored.`,
+    );
+  }
+
+  const { command, args } = buildCaptureCommand(capture.plan);
+  capture.handle = startChild("audio capture", command, args);
+  await delay(CAPTURE_STARTUP_GRACE_MS);
+  throwIfChildExited(capture.handle, "audio capture");
+  capture.started = true;
+  capture.recordPhase("capture:start", {
+    provider: capture.plan.provider,
+    device: capture.plan.device || null,
+    captureTarget: captureProviderTarget(capture.plan) || null,
+    captureTargetKind: capture.plan.captureTargetKind || null,
+    outputPath: capture.plan.outputPath,
+  });
+  logStep(
+    `Audio capture started with ${capture.plan.provider} target ${captureProviderTarget(capture.plan) || "(default)"} -> ${capture.plan.outputPath}.`,
+  );
+}
+
+function captureProviderTarget(plan) {
+  return plan.captureTarget || plan.device || "";
+}
+
+function buildCaptureCommand(plan) {
+  if (plan.provider === "avfoundation") {
+    return {
+      command: "ffmpeg",
+      args: [
+        "-hide_banner",
+        "-loglevel",
+        "warning",
+        "-y",
+        "-f",
+        "avfoundation",
+        "-i",
+        `:${plan.device}`,
+        "-ac",
+        String(CAPTURE_CHANNELS),
+        "-ar",
+        String(CAPTURE_SAMPLE_RATE),
+        plan.outputPath,
+      ],
+    };
+  }
+  if (plan.provider === "pipewire") {
+    const args = [
+      "--format",
+      "s16",
+      "--rate",
+      String(CAPTURE_SAMPLE_RATE),
+      "--channels",
+      String(CAPTURE_CHANNELS),
+    ];
+    const target = captureProviderTarget(plan);
+    if (target) {
+      args.push("--target", target);
+    }
+    args.push(plan.outputPath);
+    return { command: "pw-record", args };
+  }
+
+  const args = [
+    "--file-format=wav",
+    `--rate=${CAPTURE_SAMPLE_RATE}`,
+    `--channels=${CAPTURE_CHANNELS}`,
+  ];
+  if (plan.device) {
+    args.push(`--device=${plan.device}`);
+  }
+  args.push(plan.outputPath);
+  return { command: "parecord", args };
+}
+
+async function stopOptionalAudioCapture(capture, { runError = null } = {}) {
+  if (!capture) {
+    return { keepArtifacts: false, error: null };
+  }
+
+  let error = null;
+  let keepArtifacts = capture.options.keepArtifacts || Boolean(runError);
+  if (runError) {
+    capture.recordPhase("smoke:failed", { message: errorMessage(runError) });
+  }
+  capture.recordPhase("capture:stop-requested");
+
+  try {
+    await stopCaptureChild(capture.handle);
+  } catch (captureStopError) {
+    error = captureStopError;
+  }
+
+  const fileInfo = await readCaptureFileInfo(capture.plan.outputPath);
+  capture.recordPhase("capture:stopped", {
+    outputPath: capture.plan.outputPath,
+    exists: fileInfo.exists,
+    sizeBytes: fileInfo.sizeBytes,
+    durationSeconds: fileInfo.durationSeconds,
+    sampleRate: fileInfo.sampleRate,
+    channels: fileInfo.channels,
+  });
+
+  await cleanupAudioRoute(capture.route);
+  try {
+    const sidecar = buildCaptureSidecar(capture, fileInfo, { runError });
+    await writeFile(capture.plan.sidecarPath, `${JSON.stringify(sidecar, null, 2)}\n`);
+    logStep(`Audio capture timing sidecar written to ${capture.plan.sidecarPath}.`);
+  } catch (sidecarError) {
+    error ??= sidecarError;
+  }
+
+  if (!fileInfo.exists || fileInfo.sizeBytes <= 44) {
+    error ??= new Error(`Audio capture did not produce a non-empty WAV at ${capture.plan.outputPath}.`);
+  } else {
+    logStep(
+      `Audio capture wrote ${capture.plan.outputPath} (${fileInfo.sizeBytes} bytes).`,
+    );
+    const analyzerError = await runCaptureAnalyzer(capture).catch((analyzerRunError) => analyzerRunError);
+    if (analyzerError) {
+      error ??= analyzerError;
+    }
+  }
+
+  if (error) {
+    keepArtifacts = true;
+    const message = `Audio capture post-processing failed: ${errorMessage(error)}`;
+    if (capture.options.requireAudioCapture) {
+      logStep(message);
+    } else {
+      logStep(`${message}; smoke result kept.`);
+      error = null;
+    }
+  }
+
+  return {
+    keepArtifacts,
+    error,
+    outputPath: capture.plan.outputPath,
+    sidecarPath: capture.plan.sidecarPath,
+    analysisOutputPath: capture.plan.analysisOutputPath,
+  };
+}
+
+async function stopCaptureChild(handle) {
+  if (!handle) {
+    return;
+  }
+  if (handle.exit) {
+    return;
+  }
+
+  killChild(handle.child, "SIGINT");
+  await Promise.race([handle.exitPromise, delay(3000)]);
+  if (handle.exit) {
+    return;
+  }
+  killChild(handle.child, "SIGTERM");
+  await Promise.race([handle.exitPromise, delay(3000)]);
+  if (handle.exit) {
+    return;
+  }
+  killChild(handle.child, "SIGKILL");
+  await Promise.race([handle.exitPromise, delay(1000)]);
+}
+
+async function setupPulseVirtualSink() {
+  const sinkName = `tuneforge_playback_smoke_${process.pid}_${Date.now()}`;
+  const previousDefault = (await runCommand(
+    "read default audio sink",
+    "pactl",
+    ["get-default-sink"],
+    { timeoutMs: 5000 },
+  )).stdout.trim();
+  let moduleId = "";
+  try {
+    const loadResult = await runCommand(
+      "create virtual audio sink",
+      "pactl",
+      [
+        "load-module",
+        "module-null-sink",
+        `sink_name=${sinkName}`,
+        "sink_properties=device.description=TuneForge Playback Smoke",
+      ],
+      { timeoutMs: 5000 },
+    );
+    moduleId = loadResult.stdout.trim();
+    await runCommand(
+      "route audio to virtual sink",
+      "pactl",
+      ["set-default-sink", sinkName],
+      { timeoutMs: 5000 },
+    );
+  } catch (error) {
+    if (moduleId) {
+      await runOptionalCommand(
+        "unload virtual audio sink after route failure",
+        "pactl",
+        ["unload-module", moduleId],
+        { timeoutMs: 5000 },
+      );
+    }
+    throw error;
+  }
+
+  return {
+    sinkName,
+    monitorSource: `${sinkName}.monitor`,
+    moduleId,
+    previousDefault,
+  };
+}
+
+async function resolvePipeWireSinkObjectSerial(sinkName) {
+  const result = await runOptionalCommand(
+    "resolve PipeWire sink object serial",
+    "pactl",
+    ["list", "sinks"],
+    { timeoutMs: 5000 },
+  );
+  if (!result.ok) {
+    throw new Error(`could not inspect PipeWire sinks for ${sinkName}: ${result.error}`);
+  }
+  const sinkBlock = findPactlSinkBlock(result.stdout, sinkName);
+  if (!sinkBlock) {
+    throw new Error(`could not find temp sink ${sinkName} while resolving PipeWire target`);
+  }
+  const serial = pactlProperty(sinkBlock, "object.serial");
+  if (!serial) {
+    throw new Error(`temp sink ${sinkName} has no PipeWire object.serial`);
+  }
+  return serial;
+}
+
+export function findPactlSinkBlock(output, sinkName) {
+  return output
+    .split(/\n(?=Sink #)/)
+    .find((block) => block.split(/\r?\n/).some((line) => line.trim() === `Name: ${sinkName}`))
+    || "";
+}
+
+export function pactlProperty(block, key) {
+  const prefix = `${key} =`;
+  const line = block
+    .split(/\r?\n/)
+    .map((candidate) => candidate.trim())
+    .find((candidate) => candidate.startsWith(prefix));
+  if (!line) {
+    return "";
+  }
+  return line.slice(prefix.length).trim().replace(/^"|"$/g, "");
+}
+
+async function cleanupAudioRoute(route) {
+  if (!route) {
+    return;
+  }
+
+  if (route.previousDefault) {
+    const restore = await runOptionalCommand(
+      "restore default audio sink",
+      "pactl",
+      ["set-default-sink", route.previousDefault],
+      { timeoutMs: 5000 },
+    );
+    if (!restore.ok) {
+      logStep(`Could not restore default audio sink ${route.previousDefault}: ${restore.error}`);
+    }
+  }
+  if (route.moduleId) {
+    const unload = await runOptionalCommand(
+      "unload virtual audio sink",
+      "pactl",
+      ["unload-module", route.moduleId],
+      { timeoutMs: 5000 },
+    );
+    if (!unload.ok) {
+      logStep(`Could not unload temp virtual audio sink ${route.sinkName}: ${unload.error}`);
+    }
+  }
+}
+
+async function discoverLinuxMonitorSource() {
+  if (!(await commandExists("pactl"))) {
+    return { device: "", reason: "pactl was not found for Linux monitor source discovery" };
+  }
+
+  const sourcesResult = await runOptionalCommand(
+    "list audio sources",
+    "pactl",
+    ["list", "short", "sources"],
+    { timeoutMs: 5000 },
+  );
+  if (!sourcesResult.ok) {
+    return { device: "", reason: sourcesResult.error };
+  }
+
+  const sourceNames = sourcesResult.stdout
+    .split(/\r?\n/)
+    .map((line) => line.split(/\s+/)[1])
+    .filter(Boolean);
+
+  const defaultSinkResult = await runOptionalCommand(
+    "read default audio sink",
+    "pactl",
+    ["get-default-sink"],
+    { timeoutMs: 5000 },
+  );
+  if (defaultSinkResult.ok) {
+    const defaultMonitor = `${defaultSinkResult.stdout.trim()}.monitor`;
+    if (sourceNames.includes(defaultMonitor)) {
+      return { device: defaultMonitor, reason: "" };
+    }
+  }
+
+  const monitorSource = sourceNames.find((name) => name.endsWith(".monitor"));
+  if (monitorSource) {
+    return { device: monitorSource, reason: "" };
+  }
+
+  return { device: "", reason: "no Pulse/PipeWire monitor source is available" };
+}
+
+async function readCaptureFileInfo(path) {
+  try {
+    const stats = await stat(path);
+    const wavInfo = await readWavInfo(path).catch(() => null);
+    return {
+      exists: true,
+      sizeBytes: stats.size,
+      modifiedAt: stats.mtime.toISOString(),
+      durationSeconds: wavInfo?.durationSeconds ?? null,
+      sampleRate: wavInfo?.sampleRate ?? null,
+      channels: wavInfo?.channels ?? null,
+      bitsPerSample: wavInfo?.bitsPerSample ?? null,
+    };
+  } catch {
+    return {
+      exists: false,
+      sizeBytes: 0,
+      modifiedAt: null,
+      durationSeconds: null,
+      sampleRate: null,
+      channels: null,
+      bitsPerSample: null,
+    };
+  }
+}
+
+async function readWavInfo(path) {
+  const buffer = await readFile(path);
+  return parseWavInfo(buffer);
+}
+
+function parseWavInfo(buffer) {
+  if (
+    buffer.length < 44
+    || buffer.toString("ascii", 0, 4) !== "RIFF"
+    || buffer.toString("ascii", 8, 12) !== "WAVE"
+  ) {
+    return null;
+  }
+
+  let offset = 12;
+  let fmt = null;
+  let dataBytes = null;
+  while (offset + 8 <= buffer.length) {
+    const chunkId = buffer.toString("ascii", offset, offset + 4);
+    const chunkSize = buffer.readUInt32LE(offset + 4);
+    const chunkStart = offset + 8;
+    const chunkEnd = chunkStart + chunkSize;
+    if (chunkEnd > buffer.length) {
+      break;
+    }
+    if (chunkId === "fmt " && chunkSize >= 16) {
+      fmt = {
+        channels: buffer.readUInt16LE(chunkStart + 2),
+        sampleRate: buffer.readUInt32LE(chunkStart + 4),
+        blockAlign: buffer.readUInt16LE(chunkStart + 12),
+        bitsPerSample: buffer.readUInt16LE(chunkStart + 14),
+      };
+    } else if (chunkId === "data") {
+      dataBytes = chunkSize;
+    }
+    offset = chunkEnd + (chunkSize % 2);
+  }
+
+  if (!fmt || dataBytes === null || fmt.sampleRate <= 0 || fmt.blockAlign <= 0) {
+    return null;
+  }
+  return {
+    durationSeconds: roundSeconds(dataBytes / fmt.blockAlign / fmt.sampleRate),
+    sampleRate: fmt.sampleRate,
+    channels: fmt.channels,
+    bitsPerSample: fmt.bitsPerSample,
+  };
+}
+
+function buildCaptureAnalysisExpectations(phases, fileInfo) {
+  const timingNormalization = buildCaptureTimingNormalization(phases, fileInfo);
+  return {
+    timingNormalization,
+    markers: buildCaptureMarkers(phases, timingNormalization),
+    quietWindows: buildCaptureQuietWindows(phases, timingNormalization),
+    loops: buildCaptureLoops(phases, timingNormalization),
+  };
+}
+
+function buildCaptureTimingNormalization(phases, fileInfo) {
+  const stopSeconds = phaseElapsedSeconds(lastPhaseNamed(phases, "capture:stopped"));
+  const durationSeconds = firstNumberField(fileInfo, ["durationSeconds"]);
+  if (stopSeconds === null || durationSeconds === null || durationSeconds <= 0) {
+    return {
+      applied: false,
+      offsetSeconds: 0,
+      stopElapsedSeconds: stopSeconds,
+      durationSeconds,
+      reason: "capture WAV duration unavailable",
+    };
+  }
+  const offsetSeconds = Math.max(0, stopSeconds - durationSeconds);
+  return {
+    applied: offsetSeconds > 0.001,
+    offsetSeconds: roundSeconds(offsetSeconds),
+    stopElapsedSeconds: roundSeconds(stopSeconds),
+    durationSeconds: roundSeconds(durationSeconds),
+    reason: "capture:stopped elapsed minus WAV duration",
+  };
+}
+
+function buildCaptureMarkers(phases, timingNormalization) {
+  return [
+    ["song-precount:telemetry-passed", "song-precount-playback-marker"],
+    ["loop-precount:telemetry-passed", "loop-precount-playback-marker"],
+    ["loop:restart-detected", "loop-restart-marker"],
+  ].flatMap(([name, kind]) => {
+    const phase = lastPhaseNamed(phases, name);
+    const timeSeconds = phaseElapsedSeconds(phase);
+    if (timeSeconds === null) {
+      return [];
+    }
+    const captureSeconds = normalizeCaptureSeconds(timeSeconds, timingNormalization);
+    if (!captureSecondsInRange(captureSeconds, timingNormalization)) {
+      return [];
+    }
+    const details = phaseDetails(phase);
+    const playbackSeconds = firstNumberField(details, [
+      "startTimeSeconds",
+      "positionSeconds",
+      "playbackPositionSeconds",
+      "loopStartSeconds",
+    ]);
+    const marker = { kind, timeSeconds: captureSeconds };
+    if (playbackSeconds !== null) {
+      marker.playbackSeconds = playbackSeconds;
+    }
+    return [marker];
+  });
+}
+
+function buildCaptureQuietWindows(phases, timingNormalization) {
+  const captureStart = phaseElapsedSeconds(lastPhaseNamed(phases, "capture:start"));
+  const smokeStart = phaseElapsedSeconds(firstPhaseNamed(phases, "smoke:start"));
+  if (captureStart === null || smokeStart === null) {
+    return [];
+  }
+  const startSeconds = captureStart + 0.1;
+  const endSeconds = smokeStart - 0.1;
+  const normalizedStartSeconds = normalizeCaptureSeconds(startSeconds, timingNormalization);
+  const normalizedEndSeconds = normalizeCaptureSeconds(endSeconds, timingNormalization);
+  if (normalizedStartSeconds === null || normalizedEndSeconds === null) {
+    return [];
+  }
+  const clippedStartSeconds = Math.max(0, normalizedStartSeconds);
+  const clippedEndSeconds = timingNormalization.durationSeconds !== null
+    ? Math.min(timingNormalization.durationSeconds, normalizedEndSeconds)
+    : normalizedEndSeconds;
+  if (clippedEndSeconds - clippedStartSeconds < 0.25) {
+    return [];
+  }
+  return [
+    {
+      startSeconds: roundSeconds(clippedStartSeconds),
+      endSeconds: roundSeconds(clippedEndSeconds),
+      maxRms: 0.003,
+    },
+  ];
+}
+
+function buildCaptureLoops(phases, timingNormalization) {
+  const loopSet = lastPhaseNamed(phases, "loop:set");
+  const loopRestart = lastPhaseNamed(phases, "loop:restart-detected");
+  const loopPlayback = lastPhaseNamed(phases, "loop-precount:telemetry-passed")
+    ?? lastPhaseNamed(phases, "loop-playback:start");
+  const startSeconds = firstNumberField(phaseDetails(loopSet), ["startSeconds"]);
+  const endSeconds = firstNumberField(phaseDetails(loopSet), ["endSeconds"]);
+  const startCaptureSeconds = phaseElapsedSeconds(loopPlayback);
+  const restartSeconds = phaseElapsedSeconds(loopRestart);
+  if (
+    startSeconds === null
+    || endSeconds === null
+    || endSeconds <= startSeconds
+  ) {
+    return [];
+  }
+  const loop = { startSeconds, endSeconds };
+  const normalizedStartCaptureSeconds = normalizeCaptureSeconds(startCaptureSeconds, timingNormalization);
+  if (captureSecondsInRange(normalizedStartCaptureSeconds, timingNormalization)) {
+    loop.startCaptureSeconds = normalizedStartCaptureSeconds;
+  }
+  const normalizedRestartSeconds = normalizeCaptureSeconds(restartSeconds, timingNormalization);
+  if (captureSecondsInRange(normalizedRestartSeconds, timingNormalization)) {
+    loop.restartSeconds = normalizedRestartSeconds;
+  }
+  return [loop];
+}
+
+function normalizeCaptureSeconds(seconds, timingNormalization) {
+  if (seconds === null || !Number.isFinite(seconds)) {
+    return null;
+  }
+  return roundSeconds(seconds - timingNormalization.offsetSeconds);
+}
+
+function captureSecondsInRange(seconds, timingNormalization) {
+  if (seconds === null || seconds < 0) {
+    return false;
+  }
+  return timingNormalization.durationSeconds === null || seconds <= timingNormalization.durationSeconds;
+}
+
+function firstPhaseNamed(phases, name) {
+  return Array.isArray(phases) ? phases.find((phase) => phase?.name === name) ?? null : null;
+}
+
+function lastPhaseNamed(phases, name) {
+  if (!Array.isArray(phases)) {
+    return null;
+  }
+  for (let index = phases.length - 1; index >= 0; index -= 1) {
+    const phase = phases[index];
+    if (phase?.name === name) {
+      return phase;
+    }
+  }
+  return null;
+}
+
+function phaseDetails(phase) {
+  return phase && typeof phase.details === "object" && !Array.isArray(phase.details)
+    ? phase.details
+    : {};
+}
+
+function phaseElapsedSeconds(phase) {
+  const elapsedMs = firstNumberField(phase, ["elapsed_ms", "elapsedMs"]);
+  return elapsedMs === null ? null : elapsedMs / 1000;
+}
+
+export function buildCaptureSidecar(capture, fileInfo, { runError }) {
+  const expectations = buildCaptureAnalysisExpectations(capture.phases, fileInfo);
+  return {
+    schema_version: 1,
+    created_at: new Date().toISOString(),
+    provider: capture.plan.provider,
+    provider_command: capture.plan.providerCommand,
+    device: capture.plan.device || null,
+    capture_target: captureProviderTarget(capture.plan) || null,
+    capture_target_kind: capture.plan.captureTargetKind || null,
+    route_output: capture.plan.routeOutput,
+    output_path: capture.plan.outputPath,
+    analysis_output_path: capture.plan.analysisOutputPath,
+    sample_rate_hz: CAPTURE_SAMPLE_RATE,
+    channels: CAPTURE_CHANNELS,
+    audio: {
+      sampleRate: CAPTURE_SAMPLE_RATE,
+      channels: CAPTURE_CHANNELS,
+      path: capture.plan.outputPath,
+    },
+    minDurationSeconds: 1.0,
+    rmsThreshold: 0.002,
+    markerToleranceSeconds: 0.2,
+    spacingToleranceSeconds: capture.plan.provider === "avfoundation" ? 0.25 : 0.2,
+    smoke_status: runError ? "failed" : "passed",
+    smoke_error: runError ? errorMessage(runError) : null,
+    capture_file: fileInfo,
+    timing_normalization: expectations.timingNormalization,
+    phaseMarkers: capture.phases,
+    phases: capture.phases,
+    markers: expectations.markers,
+    quietWindows: expectations.quietWindows,
+    loops: expectations.loops,
+    requireLoopRestart: expectations.loops.length > 0,
+  };
+}
+
+async function runCaptureAnalyzer(capture) {
+  const result = await runOptionalCommand(
+    "audio capture analyzer",
+    "bash",
+    [
+      "scripts/run-backend-module.sh",
+      "app.cli.playback_capture_analyze",
+      "--audio",
+      capture.plan.outputPath,
+      "--sidecar",
+      capture.plan.sidecarPath,
+    ],
+    { timeoutMs: CAPTURE_ANALYZER_TIMEOUT_MS },
+  );
+  if (!result.ok) {
+    return new Error(result.error);
+  }
+  await writeFile(capture.plan.analysisOutputPath, normalizeCommandOutput(result.stdout));
+  logStep(`Audio capture analyzer wrote ${capture.plan.analysisOutputPath}.`);
+  return null;
+}
+
+function normalizeCommandOutput(output) {
+  const text = output.trim();
+  return text ? `${text}\n` : "{}\n";
+}
+
+async function commandExists(command) {
+  const result = await runOptionalCommand(
+    `find ${command}`,
+    "bash",
+    ["-lc", `command -v ${shellWord(command)}`],
+    { timeoutMs: 5000 },
+  );
+  return result.ok && Boolean(result.stdout.trim());
+}
+
+function shellWord(value) {
+  if (!/^[A-Za-z0-9._-]+$/.test(value)) {
+    throw new Error(`Unsafe shell word: ${value}`);
+  }
+  return value;
+}
+
+async function runOptionalCommand(label, command, args, options = {}) {
+  try {
+    const result = await runCommand(label, command, args, options);
+    return { ok: true, stdout: result.stdout, stderr: result.stderr, error: "" };
+  } catch (error) {
+    return { ok: false, stdout: "", stderr: "", error: errorMessage(error) };
+  }
+}
+
+async function cleanupCaptureTempRoot(tempRoot, options, captureResult) {
+  if (!tempRoot) {
+    return;
+  }
+  if (options.keepArtifacts || captureResult?.keepArtifacts) {
+    logStep(`Kept audio capture artifacts at ${tempRoot}.`);
+    return;
+  }
+  await rm(tempRoot, { recursive: true, force: true });
+}
+
+function roundMillis(value) {
+  return Math.round(value * 1000) / 1000;
+}
+
+function roundSeconds(value) {
+  return Math.round(value * 1_000_000) / 1_000_000;
 }
 
 async function selectPort(preferredPort, excludedPorts, label) {
@@ -1138,7 +2169,17 @@ async function assertCountInTelemetry(
       `${label} fired sequence ${firedSequence} did not match scheduled sequence ${scheduledSequence}.`,
     );
   }
-  return true;
+  return {
+    trigger: expectedKind,
+    sequence: firedSequence ?? scheduledSequence,
+    clickCount: scheduledCount,
+    startTimeSeconds: startSeconds,
+    tempoBpm: firstNumberField(scheduled, ["tempoBpm", "bpm"]),
+    scheduledAtContextTimeSeconds: firstNumberField(scheduled, ["scheduledAtContextTimeSeconds"]),
+    firstClickTimeSeconds: firstNumberField(scheduled, ["firstClickTimeSeconds"]),
+    playbackStartTimeSeconds: firstNumberField(scheduled, ["playbackStartTimeSeconds"]),
+    firedAtContextTimeSeconds: firstNumberField(fired, ["firedAtContextTimeSeconds"]),
+  };
 }
 
 async function assertPlaybackTransportTelemetry(
@@ -1246,6 +2287,82 @@ async function assertPlaybackTransportTelemetry(
     }
   });
   logStep(`${label} native transport and buffer telemetry passed.`);
+}
+
+async function waitForLoopRestartTelemetry(
+  page,
+  { expectedLoopEndSeconds, expectedLoopStartSeconds, label, requireTelemetry = false },
+) {
+  const loopSeconds = expectedLoopEndSeconds - expectedLoopStartSeconds;
+  if (loopSeconds <= 0) {
+    throw new Error(`${label} loop range is invalid.`);
+  }
+
+  const edgeSeconds = Math.min(0.35, Math.max(0.08, loopSeconds * 0.15));
+  const nearEndSeconds = expectedLoopEndSeconds - edgeSeconds;
+  const nearStartSeconds = expectedLoopStartSeconds + edgeSeconds;
+  const minBackwardJumpSeconds = Math.min(0.25, Math.max(0.05, loopSeconds * 0.25));
+  const timeout = Math.max(4000, Math.min(30000, (loopSeconds + 6) * 1000));
+  let sawNearEnd = false;
+  let previousPositionSeconds = null;
+  let restartFromSeconds = null;
+
+  const state = await waitForPlaybackE2EState(
+    page,
+    `${label} loop restart`,
+    (candidate) => {
+      if (!isNativePlaybackActive(candidate) && !isWebPlaybackActive(candidate)) {
+        return false;
+      }
+      const transport = transportTelemetry(candidate);
+      if (transportState(transport) !== "playing") {
+        return false;
+      }
+      const loopRange = loopTelemetry(candidate);
+      if (!loopRange) {
+        return false;
+      }
+      const loopStart = firstNumberField(loopRange, ["startSeconds", "start", "loopStartSeconds"]);
+      const loopEnd = firstNumberField(loopRange, ["endSeconds", "end", "loopEndSeconds"]);
+      if (
+        loopStart === null
+        || loopEnd === null
+        || Math.abs(loopStart - expectedLoopStartSeconds) > 0.05
+        || Math.abs(loopEnd - expectedLoopEndSeconds) > 0.05
+      ) {
+        return false;
+      }
+
+      const positionSeconds = transportPositionSeconds(transport);
+      if (positionSeconds === null) {
+        return false;
+      }
+      if (positionSeconds >= nearEndSeconds && positionSeconds <= expectedLoopEndSeconds + 0.5) {
+        sawNearEnd = true;
+        restartFromSeconds = positionSeconds;
+      }
+      const restarted = Boolean(
+        sawNearEnd
+        && restartFromSeconds !== null
+        && positionSeconds <= nearStartSeconds
+        && previousPositionSeconds !== null
+        && positionSeconds < previousPositionSeconds - minBackwardJumpSeconds,
+      );
+      previousPositionSeconds = positionSeconds;
+      return restarted;
+    },
+    { timeout, pollInterval: 100, requireTelemetry },
+  );
+  if (!state) {
+    return null;
+  }
+
+  return {
+    loopStartSeconds: expectedLoopStartSeconds,
+    loopEndSeconds: expectedLoopEndSeconds,
+    positionSeconds: transportPositionSeconds(transportTelemetry(state)),
+    restartFromSeconds,
+  };
 }
 
 function countInTelemetry(state) {

--- a/scripts/playback-smoke.test.mjs
+++ b/scripts/playback-smoke.test.mjs
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildCaptureSidecar,
+  findPactlSinkBlock,
+  pactlProperty,
+  validateCaptureOutputPath,
+} from "./playback-smoke.mjs";
+
+test("parses PipeWire object serial from pactl sink output", () => {
+  const pactlOutput = [
+    "Sink #41",
+    "\tState: IDLE",
+    "\tName: alsa_output.pci-0000_00_1f.3.analog-stereo",
+    "\tProperties:",
+    '\t\tobject.serial = "214"',
+    "",
+    "Sink #42",
+    "\tState: RUNNING",
+    "\tName: tuneforge_playback_smoke_123_456",
+    "\tProperties:",
+    '\t\tmedia.class = "Audio/Sink"',
+    '\t\tobject.serial = "9384"',
+    '\t\tnode.name = "tuneforge_playback_smoke_123_456"',
+  ].join("\n");
+
+  const block = findPactlSinkBlock(pactlOutput, "tuneforge_playback_smoke_123_456");
+
+  assert.match(block, /Name: tuneforge_playback_smoke_123_456/);
+  assert.equal(pactlProperty(block, "object.serial"), "9384");
+});
+
+test("normalizes generated sidecar timings to capture file clock", () => {
+  const sidecar = buildCaptureSidecar(
+    captureWithPhases([
+      phase("capture:start", 1000),
+      phase("smoke:start", 3000),
+      phase("song-precount:telemetry-passed", 5500, { startTimeSeconds: 0 }),
+      phase("loop:set", 6000, { startSeconds: 10, endSeconds: 20 }),
+      phase("loop-precount:telemetry-passed", 7000, { startTimeSeconds: 10 }),
+      phase("loop:restart-detected", 12000, {
+        loopStartSeconds: 10,
+        loopEndSeconds: 20,
+        restartFromSeconds: 19.8,
+        positionSeconds: 10.1,
+      }),
+      phase("capture:stopped", 20529),
+    ]),
+    fileInfo({ durationSeconds: 19.115 }),
+    { runError: null },
+  );
+
+  assert.equal(sidecar.device, "tuneforge_playback_smoke.monitor");
+  assert.equal(sidecar.capture_target, "9384");
+  assert.equal(sidecar.capture_target_kind, "pipewire-object-serial");
+  assert.equal(sidecar.timing_normalization.offsetSeconds, 1.414);
+  assert.deepEqual(
+    sidecar.markers.map((marker) => marker.timeSeconds),
+    [4.086, 5.586, 10.586],
+  );
+  assert.equal(sidecar.loops[0].startCaptureSeconds, 5.586);
+  assert.equal(sidecar.loops[0].restartSeconds, 10.586);
+  assert.equal(sidecar.loops[0].startSeconds, 10);
+  assert.equal(sidecar.loops[0].endSeconds, 20);
+});
+
+test("clips or drops quiet windows that begin before capture file start", () => {
+  const clipped = buildCaptureSidecar(
+    captureWithPhases([
+      phase("capture:start", 1000),
+      phase("smoke:start", 2500),
+      phase("capture:stopped", 20000),
+    ]),
+    fileInfo({ durationSeconds: 18 }),
+    { runError: null },
+  );
+
+  assert.deepEqual(clipped.quietWindows, [{ startSeconds: 0, endSeconds: 0.4, maxRms: 0.003 }]);
+
+  const dropped = buildCaptureSidecar(
+    captureWithPhases([
+      phase("capture:start", 1000),
+      phase("smoke:start", 2300),
+      phase("capture:stopped", 20000),
+    ]),
+    fileInfo({ durationSeconds: 18 }),
+    { runError: null },
+  );
+
+  assert.deepEqual(dropped.quietWindows, []);
+});
+
+test("requires WAV capture output", () => {
+  assert.equal(validateCaptureOutputPath("/tmp/playback-smoke-capture.wav"), "");
+  assert.match(validateCaptureOutputPath("/tmp/playback-smoke-capture.raw"), /must end in \.wav/);
+});
+
+test("uses wider spacing tolerance only for AVFoundation capture", () => {
+  const linuxSidecar = buildCaptureSidecar(
+    captureWithPhases([]),
+    fileInfo(),
+    { runError: null },
+  );
+  const macSidecar = buildCaptureSidecar(
+    captureWithPhases([], { provider: "avfoundation", providerCommand: "ffmpeg" }),
+    fileInfo(),
+    { runError: null },
+  );
+
+  assert.equal(linuxSidecar.markerToleranceSeconds, 0.2);
+  assert.equal(linuxSidecar.spacingToleranceSeconds, 0.2);
+  assert.equal(macSidecar.markerToleranceSeconds, 0.2);
+  assert.equal(macSidecar.spacingToleranceSeconds, 0.25);
+});
+
+function captureWithPhases(phases, planOverrides = {}) {
+  return {
+    plan: {
+      provider: "pipewire",
+      providerCommand: "pw-record",
+      device: "tuneforge_playback_smoke.monitor",
+      captureTarget: "9384",
+      captureTargetKind: "pipewire-object-serial",
+      routeOutput: true,
+      outputPath: "/tmp/playback-smoke-capture.wav",
+      analysisOutputPath: "/tmp/playback-smoke-capture.analysis.json",
+      ...planOverrides,
+    },
+    phases,
+  };
+}
+
+function fileInfo(overrides = {}) {
+  return {
+    exists: true,
+    sizeBytes: 4096,
+    modifiedAt: "2026-05-28T00:00:00.000Z",
+    durationSeconds: null,
+    sampleRate: 48000,
+    channels: 2,
+    bitsPerSample: 16,
+    ...overrides,
+  };
+}
+
+function phase(name, elapsedMs, details = {}) {
+  return {
+    name,
+    at: "2026-05-28T00:00:00.000Z",
+    elapsed_ms: elapsedMs,
+    details,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds optional virtual-audio capture to the playback smoke for local headed host gates.
- Adds a backend WAV analyzer for non-silence, marker spacing, loop restart evidence, and quiet windows.
- Documents Linux PipeWire/Pulse routing and macOS BlackHole/AVFoundation setup.
- Fixes #100.
- Refs #235.

## Testing
- `node --check scripts/playback-smoke.mjs`
- `node --test scripts/playback-smoke.test.mjs`
- `cd apps/backend && uv --cache-dir /private/tmp/uv-cache run --python 3.11 pytest tests/test_playback_capture_analyze.py`
- `git diff --check origin/main...HEAD`
- `pnpm --filter @tuneforge/desktop test:e2e -- --run` (run before final rebase)
- User-validated headed Linux capture smoke with `--route-output --require-audio-capture --keep-artifacts --headed`
- User-validated headed macOS capture smoke with BlackHole and AVFoundation
- Headless capture remains unsupported for host audio on Linux/macOS because browser audio is silent there
