### PR TITLE
feat(sync): add backend preflight

### DIFF
--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -184,6 +184,7 @@ SyncPreflightSourceHashSource = Literal[
     "database",
     "original_copy_path",
 ]
+SyncPreflightJobStateValue = Literal["ready", "busy"]
 
 
 class SyncPreflightProjectSchema(BaseModel):
@@ -214,10 +215,37 @@ class SyncPreflightDuplicateGroupSchema(BaseModel):
     projects: list[SyncPreflightDuplicateProjectSchema]
 
 
+class SyncPreflightBlockingJobSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    project_id: str | None
+    project_name: str | None
+    type: str
+    status: str
+    progress: int
+    started_at: datetime | None
+    updated_at: datetime
+
+
+class SyncPreflightJobStateSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    state: SyncPreflightJobStateValue
+    running_job_count: int
+    pending_job_count: int
+    blocking_job_count: int
+    blocking_job_counts: dict[str, int]
+    blocking_jobs: list[SyncPreflightBlockingJobSchema]
+    blocking_jobs_truncated: bool
+    guidance: list[str]
+
+
 class SyncPreflightResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     ok: bool
+    library_ok: bool
     total_projects: int
     ready_projects: int
     missing_source_hash_projects: int
@@ -226,6 +254,7 @@ class SyncPreflightResponse(BaseModel):
     noncanonical_project_id_projects: int
     projects: list[SyncPreflightProjectSchema]
     duplicate_groups: list[SyncPreflightDuplicateGroupSchema]
+    job_state: SyncPreflightJobStateSchema
     manual_cleanup_required: bool
     manual_cleanup_guidance: list[str]
 

--- a/apps/backend/app/services/sync_identity.py
+++ b/apps/backend/app/services/sync_identity.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 from collections import Counter, defaultdict
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
-from sqlalchemy import select
+from sqlalchemy import case, func, select
 from sqlalchemy.orm import Session
 
 from app.config import get_settings
-from app.models import Artifact, Project
+from app.models import Artifact, Job, Project
 from app.utils.hashing import file_sha256
 
 PROJECT_ID_PREFIX = "proj_sha256_"
@@ -28,6 +29,9 @@ SyncPreflightSourceHashSource = Literal[
     "database",
     "original_copy_path",
 ]
+SyncPreflightJobStateValue = Literal["ready", "busy"]
+ACTIVE_SYNC_BLOCKING_JOB_STATUSES = ("pending", "running")
+SYNC_PREFLIGHT_BLOCKING_JOBS_LIMIT = 20
 
 
 @dataclass(frozen=True)
@@ -56,8 +60,33 @@ class SyncPreflightDuplicateGroup:
 
 
 @dataclass(frozen=True)
+class SyncPreflightBlockingJob:
+    id: str
+    project_id: str | None
+    project_name: str | None
+    type: str
+    status: str
+    progress: int
+    started_at: datetime | None
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class SyncPreflightJobState:
+    state: SyncPreflightJobStateValue
+    running_job_count: int
+    pending_job_count: int
+    blocking_job_count: int
+    blocking_job_counts: dict[str, int]
+    blocking_jobs: list[SyncPreflightBlockingJob]
+    blocking_jobs_truncated: bool
+    guidance: list[str]
+
+
+@dataclass(frozen=True)
 class SyncPreflightResult:
     ok: bool
+    library_ok: bool
     total_projects: int
     ready_projects: int
     missing_source_hash_projects: int
@@ -66,6 +95,7 @@ class SyncPreflightResult:
     noncanonical_project_id_projects: int
     projects: list[SyncPreflightProject]
     duplicate_groups: list[SyncPreflightDuplicateGroup]
+    job_state: SyncPreflightJobState
     manual_cleanup_required: bool
     manual_cleanup_guidance: list[str]
 
@@ -120,10 +150,17 @@ def run_sync_preflight(session: Session) -> SyncPreflightResult:
     duplicate_count = sum(1 for project in final_projects if project.status == "duplicate_source_hash")
     noncanonical_count = sum(1 for project in final_projects if project.status == "noncanonical_project_id")
     ready_count = sum(1 for project in final_projects if project.status == "ready")
-    ok = missing_count == 0 and invalid_count == 0 and duplicate_count == 0 and noncanonical_count == 0
+    library_ok = (
+        missing_count == 0
+        and invalid_count == 0
+        and duplicate_count == 0
+        and noncanonical_count == 0
+    )
+    job_state = _sync_preflight_job_state(session)
 
     return SyncPreflightResult(
-        ok=ok,
+        ok=library_ok,
+        library_ok=library_ok,
         total_projects=len(final_projects),
         ready_projects=ready_count,
         missing_source_hash_projects=missing_count,
@@ -132,7 +169,8 @@ def run_sync_preflight(session: Session) -> SyncPreflightResult:
         noncanonical_project_id_projects=noncanonical_count,
         projects=final_projects,
         duplicate_groups=duplicate_groups,
-        manual_cleanup_required=not ok,
+        job_state=job_state,
+        manual_cleanup_required=not library_ok,
         manual_cleanup_guidance=_manual_cleanup_guidance(
             missing_count=missing_count,
             invalid_count=invalid_count,
@@ -140,6 +178,68 @@ def run_sync_preflight(session: Session) -> SyncPreflightResult:
             noncanonical_count=noncanonical_count,
         ),
     )
+
+
+def _sync_preflight_job_state(session: Session) -> SyncPreflightJobState:
+    counts = {status: 0 for status in ACTIVE_SYNC_BLOCKING_JOB_STATUSES}
+    count_stmt = (
+        select(Job.status, func.count())
+        .where(Job.status.in_(ACTIVE_SYNC_BLOCKING_JOB_STATUSES))
+        .group_by(Job.status)
+    )
+    for status, count in session.execute(count_stmt):
+        if status in counts:
+            counts[status] = int(count)
+
+    blocking_job_count = sum(counts.values())
+    jobs = _sync_preflight_blocking_jobs(session)
+    blocking_jobs_truncated = blocking_job_count > len(jobs)
+    return SyncPreflightJobState(
+        state="busy" if blocking_job_count else "ready",
+        running_job_count=counts["running"],
+        pending_job_count=counts["pending"],
+        blocking_job_count=blocking_job_count,
+        blocking_job_counts=counts,
+        blocking_jobs=jobs,
+        blocking_jobs_truncated=blocking_jobs_truncated,
+        guidance=_sync_preflight_job_guidance(blocking_job_count),
+    )
+
+
+def _sync_preflight_blocking_jobs(session: Session) -> list[SyncPreflightBlockingJob]:
+    status_rank = case(
+        (Job.status == "running", 0),
+        (Job.status == "pending", 1),
+        else_=2,
+    )
+    stmt = (
+        select(Job, Project.display_name)
+        .outerjoin(Project, Project.id == Job.project_id)
+        .where(Job.status.in_(ACTIVE_SYNC_BLOCKING_JOB_STATUSES))
+        .order_by(status_rank.asc(), Job.updated_at.asc(), Job.id.asc())
+        .limit(SYNC_PREFLIGHT_BLOCKING_JOBS_LIMIT)
+    )
+    return [
+        SyncPreflightBlockingJob(
+            id=job.id,
+            project_id=job.project_id,
+            project_name=project_name,
+            type=job.type,
+            status=job.status,
+            progress=job.progress,
+            started_at=job.started_at,
+            updated_at=job.updated_at,
+        )
+        for job, project_name in session.execute(stmt)
+    ]
+
+
+def _sync_preflight_job_guidance(blocking_job_count: int) -> list[str]:
+    if blocking_job_count == 0:
+        return []
+    return [
+        "Backend jobs are running. Sync can start, but backend work may delay sync endpoint responses."
+    ]
 
 
 def _source_artifacts_by_project(session: Session) -> dict[str, Artifact]:

--- a/apps/backend/tests/test_sync_identity.py
+++ b/apps/backend/tests/test_sync_identity.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from app.db import SessionLocal
-from app.models import Artifact, Project, SyncDeleteTombstone
+from app.models import Artifact, Job, Project, SyncDeleteTombstone
 from app.services.paths import project_root
 from app.services.sync_identity import (
     project_id_to_storage_key,
@@ -58,12 +58,23 @@ def test_sync_preflight_reports_ready_projects(client, sample_audio_file: Path) 
     assert response.status_code == 200
     payload = response.json()
     assert payload["ok"] is True
+    assert payload["library_ok"] is True
     assert payload["total_projects"] == 1
     assert payload["ready_projects"] == 1
     assert payload["missing_source_hash_projects"] == 0
     assert payload["invalid_source_hash_projects"] == 0
     assert payload["duplicate_source_hash_projects"] == 0
     assert payload["noncanonical_project_id_projects"] == 0
+    assert payload["job_state"] == {
+        "state": "ready",
+        "running_job_count": 0,
+        "pending_job_count": 0,
+        "blocking_job_count": 0,
+        "blocking_job_counts": {"pending": 0, "running": 0},
+        "blocking_jobs": [],
+        "blocking_jobs_truncated": False,
+        "guidance": [],
+    }
     assert payload["manual_cleanup_required"] is False
     assert payload["projects"] == [
         {
@@ -112,6 +123,168 @@ def test_sync_preflight_uses_stored_source_hash_before_original_copy(client, tmp
     assert payload["ok"] is True
     assert payload["projects"][0]["source_sha256"] == stored_hash
     assert payload["projects"][0]["source_hash_source"] == "database"
+
+
+def test_sync_preflight_blocks_pending_jobs_without_payload_leakage(
+    client,
+    sample_audio_file: Path,
+    tmp_path: Path,
+) -> None:
+    expected_hash = file_sha256(sample_audio_file)
+    assert expected_hash is not None
+    project_id = source_hash_to_project_id(expected_hash)
+    updated_at = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
+    secret_path = tmp_path / "secret-source.wav"
+    with SessionLocal() as session:
+        session.add(
+            Project(
+                id=project_id,
+                display_name="Pending Fixture",
+                source_sha256=expected_hash,
+                source_path=str(sample_audio_file),
+                imported_path=str(sample_audio_file),
+            )
+        )
+        session.add(
+            Job(
+                id="job_pending_preflight",
+                project_id=project_id,
+                type="analyze",
+                status="pending",
+                progress=12,
+                payload_json={
+                    "source_path": str(secret_path),
+                    "audio_data": "raw-audio-bytes",
+                    "endpoint": "https://peer.example/sync",
+                },
+                created_at=updated_at,
+                updated_at=updated_at,
+            )
+        )
+        session.commit()
+
+    response = client.get("/api/v1/sync/preflight")
+
+    assert response.status_code == 200
+    assert str(tmp_path) not in response.text
+    assert "raw-audio-bytes" not in response.text
+    assert "peer.example" not in response.text
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["library_ok"] is True
+    assert payload["manual_cleanup_required"] is False
+    assert payload["job_state"]["state"] == "busy"
+    assert payload["job_state"]["pending_job_count"] == 1
+    assert payload["job_state"]["running_job_count"] == 0
+    assert payload["job_state"]["blocking_job_count"] == 1
+    assert payload["job_state"]["blocking_job_counts"] == {"pending": 1, "running": 0}
+    assert payload["job_state"]["blocking_jobs_truncated"] is False
+    assert payload["job_state"]["guidance"] == [
+        "Backend jobs are running. Sync can start, but backend work may delay sync endpoint responses."
+    ]
+    assert payload["job_state"]["blocking_jobs"] == [
+        {
+            "id": "job_pending_preflight",
+            "project_id": project_id,
+            "project_name": "Pending Fixture",
+            "type": "analyze",
+            "status": "pending",
+            "progress": 12,
+            "started_at": None,
+            "updated_at": "2026-01-02T03:04:05",
+        }
+    ]
+
+
+def test_sync_preflight_blocks_running_jobs(client, sample_audio_file: Path) -> None:
+    expected_hash = file_sha256(sample_audio_file)
+    assert expected_hash is not None
+    project_id = source_hash_to_project_id(expected_hash)
+    started_at = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
+    updated_at = datetime(2026, 1, 2, 3, 5, 6, tzinfo=UTC)
+    with SessionLocal() as session:
+        session.add(
+            Project(
+                id=project_id,
+                display_name="Running Fixture",
+                source_sha256=expected_hash,
+                source_path=str(sample_audio_file),
+                imported_path=str(sample_audio_file),
+            )
+        )
+        session.add(
+            Job(
+                id="job_running_preflight",
+                project_id=project_id,
+                type="stems",
+                status="running",
+                progress=50,
+                payload_json={},
+                created_at=started_at,
+                started_at=started_at,
+                updated_at=updated_at,
+            )
+        )
+        session.commit()
+
+    response = client.get("/api/v1/sync/preflight")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["library_ok"] is True
+    assert payload["job_state"]["state"] == "busy"
+    assert payload["job_state"]["pending_job_count"] == 0
+    assert payload["job_state"]["running_job_count"] == 1
+    assert payload["job_state"]["blocking_job_count"] == 1
+    assert payload["job_state"]["blocking_jobs"][0] == {
+        "id": "job_running_preflight",
+        "project_id": project_id,
+        "project_name": "Running Fixture",
+        "type": "stems",
+        "status": "running",
+        "progress": 50,
+        "started_at": "2026-01-02T03:04:05",
+        "updated_at": "2026-01-02T03:05:06",
+    }
+
+
+def test_sync_preflight_caps_and_truncates_blocking_jobs(client) -> None:
+    created_at = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
+    with SessionLocal() as session:
+        session.add_all(
+            [
+                Job(
+                    id=f"job_cap_{index:02d}",
+                    project_id=None,
+                    type="export",
+                    status="pending",
+                    progress=index,
+                    payload_json={"path": f"/tmp/private-{index}.wav"},
+                    created_at=created_at,
+                    updated_at=created_at,
+                )
+                for index in range(25)
+            ]
+        )
+        session.commit()
+
+    response = client.get("/api/v1/sync/preflight")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["library_ok"] is True
+    assert payload["job_state"]["pending_job_count"] == 25
+    assert payload["job_state"]["running_job_count"] == 0
+    assert payload["job_state"]["blocking_job_count"] == 25
+    assert payload["job_state"]["blocking_job_counts"] == {"pending": 25, "running": 0}
+    assert len(payload["job_state"]["blocking_jobs"]) == 20
+    assert payload["job_state"]["blocking_jobs_truncated"] is True
+    assert {job["id"] for job in payload["job_state"]["blocking_jobs"]} == {
+        f"job_cap_{index:02d}" for index in range(20)
+    }
+    assert "/tmp/private" not in response.text
 
 
 def test_sync_metadata_exposes_sync_safe_project_and_artifact_metadata(

--- a/apps/desktop/src-tauri/src/sync_transport.rs
+++ b/apps/desktop/src-tauri/src/sync_transport.rs
@@ -1323,11 +1323,14 @@ mod desktop {
     #[cfg(not(target_os = "android"))]
     use std::io::{BufRead, BufReader};
     use std::{
-        collections::{HashMap, HashSet},
+        collections::{BTreeMap, HashMap, HashSet},
         env,
         fs::{self, File},
         io::{self, Read, Write},
-        net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, TcpStream, UdpSocket},
+        net::{
+            IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, TcpStream, ToSocketAddrs,
+            UdpSocket,
+        },
         path::{Path, PathBuf},
         process,
         str::FromStr,
@@ -1361,8 +1364,17 @@ mod desktop {
     const WRITE_TIMEOUT: Duration = Duration::from_secs(45);
     const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
     const ACCEPT_SLEEP: Duration = Duration::from_millis(100);
+    const NOT_STARTED_TRANSPORT_ID: &str = "not_started";
+    const BACKEND_PREFLIGHT_UNRESPONSIVE_CODE: &str = "backend_preflight_unresponsive";
+    const BACKEND_BUSY_CODE: &str = "backend_busy";
+    const LIBRARY_PREFLIGHT_FAILED_CODE: &str = "library_preflight_failed";
+    const BACKEND_PREFLIGHT_UNRESPONSIVE_MESSAGE: &str = "Local backend is unresponsive during sync preflight. Wait for backend work to finish or restart TuneForge, then retry sync.";
+    const BACKEND_BUSY_RETRY_GUIDANCE: &str =
+        "Wait for those jobs to finish or cancel them, then retry sync.";
     #[cfg(not(target_os = "android"))]
     const HTTP_TIMEOUT: Duration = Duration::from_secs(45);
+    #[cfg(not(target_os = "android"))]
+    const BACKEND_PREFLIGHT_TIMEOUT: Duration = Duration::from_secs(3);
 
     #[derive(Clone)]
     pub struct SyncTransportState {
@@ -1626,8 +1638,8 @@ mod desktop {
                 &run_id,
                 active_progress(protocol_status_payload(
                     run_id.clone(),
-                    "peer_connect",
-                    "Connecting to sync peer.",
+                    "backend_preflight",
+                    "Checking local backend readiness before sync.",
                     Utc::now().to_rfc3339(),
                     0,
                 )),
@@ -1635,6 +1647,51 @@ mod desktop {
             let mut timings = Vec::new();
             let mut metrics = SyncRunMetrics::start(run_started_instant);
             let client = BackendClient::new(&self.backend)?;
+            let preflight = match client.sync_preflight() {
+                Ok(preflight) => preflight,
+                Err(_) => {
+                    return Ok(failed_preflight_sync_result(
+                        run_id,
+                        payload.peer_device_id,
+                        BACKEND_PREFLIGHT_UNRESPONSIVE_CODE,
+                        BACKEND_PREFLIGHT_UNRESPONSIVE_MESSAGE.to_string(),
+                        run_started_at,
+                        run_started_instant,
+                    ));
+                }
+            };
+            if let Some(failure) = sync_preflight_failure(&preflight) {
+                return Ok(failed_preflight_sync_result(
+                    run_id,
+                    payload.peer_device_id,
+                    failure.fallback_code,
+                    failure.message,
+                    run_started_at,
+                    run_started_instant,
+                ));
+            }
+            if client.sync_metadata_preflight_probe().is_err() {
+                let failure = sync_endpoint_unresponsive_failure(&preflight);
+                return Ok(failed_preflight_sync_result(
+                    run_id,
+                    payload.peer_device_id,
+                    failure.fallback_code,
+                    failure.message,
+                    run_started_at,
+                    run_started_instant,
+                ));
+            }
+            record_active_progress(
+                &self.shared_status,
+                &run_id,
+                active_progress(protocol_status_payload(
+                    run_id.clone(),
+                    "peer_connect",
+                    "Connecting to sync peer.",
+                    Utc::now().to_rfc3339(),
+                    duration_millis(run_started_instant.elapsed()),
+                )),
+            );
             let peer = client
                 .trusted_peer(&payload.peer_device_id)
                 .map_err(|error| format!("Could not load trusted sync peer: {error}"))?
@@ -1864,6 +1921,439 @@ mod desktop {
         base_url: String,
         #[cfg_attr(not(target_os = "android"), allow(dead_code))]
         app: AppHandle,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct SyncBackendPreflight {
+        #[serde(default = "sync_backend_preflight_default_ok")]
+        ok: bool,
+        #[serde(default = "sync_backend_preflight_default_library_ok")]
+        library_ok: bool,
+        #[serde(default)]
+        total_projects: usize,
+        #[serde(default)]
+        ready_projects: usize,
+        #[serde(default)]
+        missing_source_hash_projects: usize,
+        #[serde(default)]
+        invalid_source_hash_projects: usize,
+        #[serde(default)]
+        duplicate_source_hash_projects: usize,
+        #[serde(default)]
+        noncanonical_project_id_projects: usize,
+        #[serde(default)]
+        manual_cleanup_required: bool,
+        #[serde(default)]
+        manual_cleanup_guidance: Vec<String>,
+        #[serde(default)]
+        job_state: Option<Value>,
+    }
+
+    impl SyncBackendPreflight {
+        #[cfg(target_os = "android")]
+        fn ready() -> Self {
+            Self {
+                ok: true,
+                library_ok: true,
+                total_projects: 0,
+                ready_projects: 0,
+                missing_source_hash_projects: 0,
+                invalid_source_hash_projects: 0,
+                duplicate_source_hash_projects: 0,
+                noncanonical_project_id_projects: 0,
+                manual_cleanup_required: false,
+                manual_cleanup_guidance: Vec::new(),
+                job_state: None,
+            }
+        }
+    }
+
+    fn sync_backend_preflight_default_ok() -> bool {
+        true
+    }
+
+    fn sync_backend_preflight_default_library_ok() -> bool {
+        true
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    struct BackendPreflightFailure {
+        fallback_code: &'static str,
+        message: String,
+    }
+
+    #[derive(Clone, Debug, Default, Eq, PartialEq)]
+    struct BackendJobStateSummary {
+        running_count: usize,
+        pending_count: usize,
+        running_type_counts: BTreeMap<String, usize>,
+        pending_type_counts: BTreeMap<String, usize>,
+    }
+
+    fn sync_preflight_failure(preflight: &SyncBackendPreflight) -> Option<BackendPreflightFailure> {
+        if library_preflight_failed(preflight) {
+            return Some(BackendPreflightFailure {
+                fallback_code: LIBRARY_PREFLIGHT_FAILED_CODE,
+                message: library_preflight_failed_message(preflight),
+            });
+        }
+
+        if !preflight.ok {
+            return Some(BackendPreflightFailure {
+                fallback_code: LIBRARY_PREFLIGHT_FAILED_CODE,
+                message: library_preflight_failed_message(preflight),
+            });
+        }
+
+        None
+    }
+
+    fn sync_endpoint_unresponsive_failure(
+        preflight: &SyncBackendPreflight,
+    ) -> BackendPreflightFailure {
+        if let Some(summary) = preflight
+            .job_state
+            .as_ref()
+            .and_then(blocking_job_state_summary)
+        {
+            return BackendPreflightFailure {
+                fallback_code: BACKEND_BUSY_CODE,
+                message: backend_busy_message(&summary),
+            };
+        }
+        BackendPreflightFailure {
+            fallback_code: BACKEND_PREFLIGHT_UNRESPONSIVE_CODE,
+            message: BACKEND_PREFLIGHT_UNRESPONSIVE_MESSAGE.to_string(),
+        }
+    }
+
+    fn library_preflight_failed(preflight: &SyncBackendPreflight) -> bool {
+        !preflight.library_ok
+            || preflight.manual_cleanup_required
+            || preflight.missing_source_hash_projects > 0
+            || preflight.invalid_source_hash_projects > 0
+            || preflight.duplicate_source_hash_projects > 0
+            || preflight.noncanonical_project_id_projects > 0
+    }
+
+    fn failed_preflight_sync_result(
+        run_id: String,
+        peer_device_id: String,
+        fallback_code: &'static str,
+        message: String,
+        run_started_at: DateTime<Utc>,
+        run_started_instant: Instant,
+    ) -> SyncTransportSyncResult {
+        let completed_at = Utc::now();
+        SyncTransportSyncResult {
+            run_id,
+            peer_device_id: peer_device_id.clone(),
+            remote_device_id: peer_device_id,
+            status: "failed".to_string(),
+            message,
+            selected_transport: NOT_STARTED_TRANSPORT_ID.to_string(),
+            fallback_reason: None,
+            fallback_code: Some(fallback_code.to_string()),
+            attempted_transports: Vec::new(),
+            started_at: run_started_at.to_rfc3339(),
+            completed_at: completed_at.to_rfc3339(),
+            duration_ms: duration_millis(run_started_instant.elapsed()),
+            project_results: Vec::new(),
+            imported_projects: Vec::new(),
+            imported_project_count: 0,
+            skipped_project_count: 0,
+            failed_project_count: 0,
+            received_artifacts: Vec::new(),
+            transfer_counts: SyncTransportTransferCounts::default(),
+            served_artifact_requests: 0,
+            total_received_bytes: 0,
+            total_served_bytes: 0,
+            time_to_first_artifact_ms: None,
+            throughput_bytes_per_second: 0.0,
+            remote_manifest_count: 0,
+            local_manifest_count: 0,
+            manifest_errors: Vec::new(),
+            phase_timings: Vec::new(),
+        }
+    }
+
+    fn blocking_job_state_summary(job_state: &Value) -> Option<BackendJobStateSummary> {
+        let mut summary = BackendJobStateSummary {
+            running_count: job_state_count(
+                job_state,
+                &[
+                    "running_job_count",
+                    "running_count",
+                    "running_jobs_count",
+                    "active_count",
+                    "running",
+                ],
+            )
+            .unwrap_or(0),
+            pending_count: job_state_count(
+                job_state,
+                &[
+                    "pending_job_count",
+                    "pending_count",
+                    "pending_jobs_count",
+                    "queued_count",
+                    "pending",
+                    "queued",
+                ],
+            )
+            .unwrap_or(0),
+            running_type_counts: BTreeMap::new(),
+            pending_type_counts: BTreeMap::new(),
+        };
+        let blocking_job_count = job_state_count(job_state, &["blocking_job_count"]).unwrap_or(0);
+
+        if let Some(status_counts) = job_state.get("blocking_job_counts") {
+            if summary.running_count == 0 {
+                summary.running_count = status_count(status_counts, "running").unwrap_or(0);
+            }
+            if summary.pending_count == 0 {
+                summary.pending_count = status_count(status_counts, "pending").unwrap_or(0);
+            }
+        }
+
+        merge_type_counts(
+            &mut summary.running_type_counts,
+            job_state_type_counts(job_state.get("running_types")),
+        );
+        merge_type_counts(
+            &mut summary.running_type_counts,
+            job_state_type_counts(job_state.get("running_job_types")),
+        );
+        merge_type_counts(
+            &mut summary.running_type_counts,
+            job_state_type_counts(job_state.get("running_jobs")),
+        );
+        merge_type_counts(
+            &mut summary.running_type_counts,
+            job_state_type_counts(job_state.get("running")),
+        );
+        merge_type_counts(
+            &mut summary.pending_type_counts,
+            job_state_type_counts(job_state.get("pending_types")),
+        );
+        merge_type_counts(
+            &mut summary.pending_type_counts,
+            job_state_type_counts(job_state.get("pending_job_types")),
+        );
+        merge_type_counts(
+            &mut summary.pending_type_counts,
+            job_state_type_counts(job_state.get("pending_jobs")),
+        );
+        merge_type_counts(
+            &mut summary.pending_type_counts,
+            job_state_type_counts(job_state.get("pending")),
+        );
+        merge_type_counts(
+            &mut summary.running_type_counts,
+            job_state_status_type_counts(job_state, "running"),
+        );
+        merge_type_counts(
+            &mut summary.pending_type_counts,
+            job_state_status_type_counts(job_state, "pending"),
+        );
+
+        if summary.running_count == 0 {
+            summary.running_count = job_state_array_len(job_state, &["running_jobs", "running"])
+                .unwrap_or_else(|| summary.running_type_counts.values().sum());
+        }
+        if summary.pending_count == 0 {
+            summary.pending_count = job_state_array_len(job_state, &["pending_jobs", "pending"])
+                .unwrap_or_else(|| summary.pending_type_counts.values().sum());
+        }
+
+        let state_busy = job_state
+            .get("state")
+            .and_then(Value::as_str)
+            .is_some_and(|state| state == "busy");
+        let legacy_blocks_sync = job_state_bool(job_state, &["blocks_sync", "blocked", "busy"])
+            .or_else(|| job_state_bool(job_state, &["can_sync"]).map(|can_sync| !can_sync))
+            .or_else(|| job_state_bool(job_state, &["ready"]).map(|ready| !ready));
+        let blocks_sync = state_busy
+            || blocking_job_count > 0
+            || legacy_blocks_sync
+                .unwrap_or_else(|| summary.running_count + summary.pending_count > 0);
+        if blocks_sync {
+            Some(summary)
+        } else {
+            None
+        }
+    }
+
+    fn job_state_count(job_state: &Value, keys: &[&str]) -> Option<usize> {
+        keys.iter()
+            .find_map(|key| job_state.get(*key).and_then(value_as_usize))
+    }
+
+    fn job_state_array_len(job_state: &Value, keys: &[&str]) -> Option<usize> {
+        keys.iter().find_map(|key| {
+            job_state
+                .get(*key)
+                .and_then(Value::as_array)
+                .map(std::vec::Vec::len)
+        })
+    }
+
+    fn job_state_bool(job_state: &Value, keys: &[&str]) -> Option<bool> {
+        keys.iter()
+            .find_map(|key| job_state.get(*key).and_then(Value::as_bool))
+    }
+
+    fn value_as_usize(value: &Value) -> Option<usize> {
+        value.as_u64().and_then(|count| usize::try_from(count).ok())
+    }
+
+    fn status_count(value: &Value, status: &str) -> Option<usize> {
+        value.get(status).and_then(value_as_usize)
+    }
+
+    fn job_state_status_type_counts(job_state: &Value, status: &str) -> BTreeMap<String, usize> {
+        let mut counts = BTreeMap::new();
+        let jobs = ["blocking_jobs", "jobs"]
+            .into_iter()
+            .filter_map(|key| job_state.get(key).and_then(Value::as_array))
+            .flatten();
+        for job in jobs {
+            if job.get("status").and_then(Value::as_str) == Some(status) {
+                if let Some(job_type) = job.get("type").and_then(Value::as_str) {
+                    *counts.entry(job_type.to_string()).or_insert(0) += 1;
+                }
+            }
+        }
+        counts
+    }
+
+    fn job_state_type_counts(value: Option<&Value>) -> BTreeMap<String, usize> {
+        let mut counts = BTreeMap::new();
+        match value {
+            Some(Value::Object(object)) => {
+                for (job_type, count) in object {
+                    if let Some(count) = value_as_usize(count) {
+                        counts.insert(job_type.clone(), count);
+                    }
+                }
+            }
+            Some(Value::Array(values)) => {
+                for value in values {
+                    let job_type = value
+                        .as_str()
+                        .or_else(|| value.get("type").and_then(Value::as_str));
+                    if let Some(job_type) = job_type {
+                        *counts.entry(job_type.to_string()).or_insert(0) += 1;
+                    }
+                }
+            }
+            _ => {}
+        }
+        counts
+    }
+
+    fn merge_type_counts(target: &mut BTreeMap<String, usize>, source: BTreeMap<String, usize>) {
+        for (job_type, count) in source {
+            *target.entry(job_type).or_insert(0) += count;
+        }
+    }
+
+    fn backend_busy_message(summary: &BackendJobStateSummary) -> String {
+        let mut parts = Vec::new();
+        if summary.running_count > 0 {
+            parts.push(format!(
+                "{}{}",
+                plural_count(summary.running_count, "running job", "running jobs"),
+                job_type_count_suffix(&summary.running_type_counts)
+            ));
+        }
+        if summary.pending_count > 0 {
+            parts.push(format!(
+                "{}{}",
+                plural_count(summary.pending_count, "pending job", "pending jobs"),
+                job_type_count_suffix(&summary.pending_type_counts)
+            ));
+        }
+        let job_summary = if parts.is_empty() {
+            "active backend job work".to_string()
+        } else {
+            parts.join(" and ")
+        };
+        format!("Local backend is busy with {job_summary}. {BACKEND_BUSY_RETRY_GUIDANCE}")
+    }
+
+    fn job_type_count_suffix(type_counts: &BTreeMap<String, usize>) -> String {
+        if type_counts.is_empty() {
+            return String::new();
+        }
+        let parts: Vec<String> = type_counts
+            .iter()
+            .map(|(job_type, count)| format!("{job_type}: {count}"))
+            .collect();
+        format!(" ({})", parts.join(", "))
+    }
+
+    fn library_preflight_failed_message(preflight: &SyncBackendPreflight) -> String {
+        let mut count_parts = Vec::new();
+        push_preflight_count(
+            &mut count_parts,
+            preflight.missing_source_hash_projects,
+            "missing source hash project",
+        );
+        push_preflight_count(
+            &mut count_parts,
+            preflight.invalid_source_hash_projects,
+            "invalid source hash project",
+        );
+        push_preflight_count(
+            &mut count_parts,
+            preflight.duplicate_source_hash_projects,
+            "duplicate source hash project",
+        );
+        push_preflight_count(
+            &mut count_parts,
+            preflight.noncanonical_project_id_projects,
+            "noncanonical project ID project",
+        );
+        if count_parts.is_empty() && preflight.total_projects > preflight.ready_projects {
+            push_preflight_count(
+                &mut count_parts,
+                preflight.total_projects - preflight.ready_projects,
+                "not-ready project",
+            );
+        }
+        let count_summary = if count_parts.is_empty() {
+            "local library is not ready for sync".to_string()
+        } else {
+            count_parts.join(", ")
+        };
+        let guidance = preflight
+            .manual_cleanup_guidance
+            .iter()
+            .map(|guidance| guidance.trim())
+            .filter(|guidance| !guidance.is_empty())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let guidance = if guidance.is_empty() {
+            "Review local library cleanup requirements, then retry sync.".to_string()
+        } else {
+            guidance
+        };
+        format!("Library sync preflight failed: {count_summary}. Manual cleanup: {guidance}")
+    }
+
+    fn push_preflight_count(parts: &mut Vec<String>, count: usize, singular: &str) {
+        if count > 0 {
+            parts.push(plural_count(count, singular, &format!("{singular}s")));
+        }
+    }
+
+    fn plural_count(count: usize, singular: &str, plural: &str) -> String {
+        if count == 1 {
+            format!("{count} {singular}")
+        } else {
+            format!("{count} {plural}")
+        }
     }
 
     pub fn sync_transport_start_listener(
@@ -5657,6 +6147,27 @@ mod desktop {
             }
         }
 
+        fn sync_preflight(&self) -> Result<SyncBackendPreflight, BackendError> {
+            #[cfg(target_os = "android")]
+            {
+                return Ok(SyncBackendPreflight::ready());
+            }
+
+            #[cfg(not(target_os = "android"))]
+            self.get_json_with_timeout("/api/v1/sync/preflight", BACKEND_PREFLIGHT_TIMEOUT)
+        }
+
+        fn sync_metadata_preflight_probe(&self) -> Result<(), BackendError> {
+            #[cfg(target_os = "android")]
+            {
+                return Ok(());
+            }
+
+            #[cfg(not(target_os = "android"))]
+            self.get_json_with_timeout::<Value>("/api/v1/sync/metadata", BACKEND_PREFLIGHT_TIMEOUT)
+                .map(|_| ())
+        }
+
         fn local_identity(&self) -> Result<SyncLocalIdentity, BackendError> {
             #[cfg(target_os = "android")]
             {
@@ -5807,6 +6318,16 @@ mod desktop {
             serde_json::from_value(value).map_err(|error| BackendError::local(error.to_string()))
         }
 
+        #[cfg(not(target_os = "android"))]
+        fn get_json_with_timeout<T: for<'de> Deserialize<'de>>(
+            &self,
+            path: &str,
+            timeout: Duration,
+        ) -> Result<T, BackendError> {
+            let value = self.request_json_value_with_timeout("GET", path, None, timeout)?;
+            serde_json::from_value(value).map_err(|error| BackendError::local(error.to_string()))
+        }
+
         fn get_json_value(&self, path: &str) -> Result<Value, BackendError> {
             #[cfg(target_os = "android")]
             {
@@ -5891,7 +6412,18 @@ mod desktop {
             path: &str,
             body: Option<&Value>,
         ) -> Result<Value, BackendError> {
-            let mut response = self.request_body(method, path, body)?;
+            self.request_json_value_with_timeout(method, path, body, HTTP_TIMEOUT)
+        }
+
+        #[cfg(not(target_os = "android"))]
+        fn request_json_value_with_timeout(
+            &self,
+            method: &str,
+            path: &str,
+            body: Option<&Value>,
+            timeout: Duration,
+        ) -> Result<Value, BackendError> {
+            let mut response = self.request_body_with_timeout(method, path, body, timeout)?;
             let mut bytes = Vec::new();
             response
                 .read_to_end(&mut bytes)
@@ -5940,13 +6472,23 @@ mod desktop {
             path: &str,
             body: Option<&Value>,
         ) -> Result<BackendBody, BackendError> {
-            let mut stream = TcpStream::connect((self.host.as_str(), self.port))
+            self.request_body_with_timeout(method, path, body, HTTP_TIMEOUT)
+        }
+
+        #[cfg(not(target_os = "android"))]
+        fn request_body_with_timeout(
+            &self,
+            method: &str,
+            path: &str,
+            body: Option<&Value>,
+            timeout: Duration,
+        ) -> Result<BackendBody, BackendError> {
+            let mut stream = self.connect_with_timeout(timeout)?;
+            stream
+                .set_read_timeout(Some(timeout))
                 .map_err(|error| BackendError::local(error.to_string()))?;
             stream
-                .set_read_timeout(Some(HTTP_TIMEOUT))
-                .map_err(|error| BackendError::local(error.to_string()))?;
-            stream
-                .set_write_timeout(Some(HTTP_TIMEOUT))
+                .set_write_timeout(Some(timeout))
                 .map_err(|error| BackendError::local(error.to_string()))?;
 
             let body_bytes = match body {
@@ -6005,6 +6547,38 @@ mod desktop {
                 reader: Box::new(reader),
                 remaining: content_length,
             })
+        }
+
+        #[cfg(not(target_os = "android"))]
+        fn connect_with_timeout(&self, timeout: Duration) -> Result<TcpStream, BackendError> {
+            let host = self
+                .host
+                .strip_prefix('[')
+                .and_then(|value| value.strip_suffix(']'))
+                .unwrap_or(&self.host);
+            let addresses: Vec<SocketAddr> = (host, self.port)
+                .to_socket_addrs()
+                .map_err(|error| BackendError::local(error.to_string()))?
+                .collect();
+            if addresses.is_empty() {
+                return Err(BackendError::local(
+                    "Backend loopback address did not resolve.".to_string(),
+                ));
+            }
+
+            let mut last_error = None;
+            for address in addresses {
+                match TcpStream::connect_timeout(&address, timeout) {
+                    Ok(stream) => return Ok(stream),
+                    Err(error) => last_error = Some(error),
+                }
+            }
+
+            Err(BackendError::local(
+                last_error
+                    .map(|error| error.to_string())
+                    .unwrap_or_else(|| "Could not connect to backend.".to_string()),
+            ))
         }
     }
 
@@ -6192,6 +6766,11 @@ mod desktop {
     #[cfg(test)]
     mod tests {
         use super::*;
+
+        const MISSING_SOURCE_HASH_GUIDANCE: &str =
+            "Restore the original source file or re-import affected projects so TuneForge can compute source hashes.";
+        const DUPLICATE_SOURCE_HASH_GUIDANCE: &str =
+            "Delete duplicate same-source projects or keep one canonical project before enabling sync.";
 
         fn test_transfer_result(
             artifact_id: &str,
@@ -7771,10 +8350,172 @@ mod desktop {
                 sync_result_status(&[], counts.failed),
                 "completed_with_errors"
             );
-            assert_eq!(
-                sync_result_message(4, 5, &transfer_counts, counts),
-                "Exchanged 4 local and 5 remote manifest(s); imported 2 project(s), skipped 1 project(s), failed 1 project(s), received 6 artifact(s), reused 1 staged artifact(s), failed 1 transfer(s)."
+            let message = sync_result_message(4, 5, &transfer_counts, counts);
+            let expected = "Exchanged 4 local and 5 remote manifest(s); imported 2 project(s), skipped 1 project(s), failed 1 project(s), received 6 artifact(s), reused 1 staged artifact(s), failed 1 transfer(s).";
+            assert_eq!(message, expected);
+        }
+
+        #[test]
+        fn backend_preflight_failed_result_serializes_not_started_transport() {
+            let started_at = DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+                .expect("timestamp")
+                .with_timezone(&Utc);
+            let result = failed_preflight_sync_result(
+                "sync_preflight".to_string(),
+                "dev_peer".to_string(),
+                BACKEND_PREFLIGHT_UNRESPONSIVE_CODE,
+                BACKEND_PREFLIGHT_UNRESPONSIVE_MESSAGE.to_string(),
+                started_at,
+                Instant::now(),
             );
+
+            let value = serde_json::to_value(result).expect("serialize failed result");
+
+            assert_eq!(value.get("status"), Some(&json!("failed")));
+            assert_eq!(
+                value.get("selectedTransport"),
+                Some(&json!(NOT_STARTED_TRANSPORT_ID))
+            );
+            assert_eq!(value.get("attemptedTransports"), Some(&json!([])));
+            assert_eq!(
+                value.get("fallbackCode"),
+                Some(&json!(BACKEND_PREFLIGHT_UNRESPONSIVE_CODE))
+            );
+            assert_eq!(value.get("remoteDeviceId"), Some(&json!("dev_peer")));
+        }
+
+        #[test]
+        fn backend_preflight_gate_allows_busy_job_state() {
+            let preflight: SyncBackendPreflight = serde_json::from_value(json!({
+                "ok": true,
+                "library_ok": true,
+                "total_projects": 1,
+                "ready_projects": 1,
+                "missing_source_hash_projects": 0,
+                "invalid_source_hash_projects": 0,
+                "duplicate_source_hash_projects": 0,
+                "noncanonical_project_id_projects": 0,
+                "job_state": {
+                    "state": "busy",
+                    "running_job_count": 0,
+                    "pending_job_count": 1,
+                    "blocking_job_count": 1,
+                    "blocking_job_counts": { "pending": 1, "running": 0 },
+                    "blocking_jobs": [
+                        {
+                            "id": "job_pending_preflight",
+                            "project_id": "project_pending",
+                            "project_name": "Pending Fixture",
+                            "type": "analyze",
+                            "status": "pending",
+                            "progress": 12,
+                            "started_at": null,
+                            "updated_at": "2026-01-02T03:04:05"
+                        }
+                    ],
+                    "blocking_jobs_truncated": false,
+                    "guidance": [
+                        "Backend jobs are running. Sync can start, but backend work may delay sync endpoint responses."
+                    ]
+                },
+                "manual_cleanup_required": false,
+                "manual_cleanup_guidance": []
+            }))
+            .expect("preflight");
+
+            assert!(sync_preflight_failure(&preflight).is_none());
+
+            let failure = sync_endpoint_unresponsive_failure(&preflight);
+            assert_eq!(failure.fallback_code, BACKEND_BUSY_CODE);
+            assert!(!failure.message.contains("Library sync preflight failed"));
+            assert!(failure.message.contains("1 pending job"));
+            assert!(failure.message.contains("analyze: 1"));
+        }
+
+        #[test]
+        fn backend_preflight_gate_uses_blocking_job_counts_without_jobs() {
+            let preflight: SyncBackendPreflight = serde_json::from_value(json!({
+                "ok": true,
+                "library_ok": true,
+                "job_state": {
+                    "state": "busy",
+                    "running_job_count": 0,
+                    "pending_job_count": 1,
+                    "blocking_job_count": 1,
+                    "blocking_job_counts": { "pending": 1, "running": 0 },
+                    "blocking_jobs": [],
+                    "blocking_jobs_truncated": true,
+                    "guidance": []
+                },
+                "manual_cleanup_required": false,
+                "manual_cleanup_guidance": []
+            }))
+            .expect("preflight");
+
+            assert!(sync_preflight_failure(&preflight).is_none());
+
+            let failure = sync_endpoint_unresponsive_failure(&preflight);
+            assert_eq!(failure.fallback_code, BACKEND_BUSY_CODE);
+            assert!(failure.message.contains("1 pending job"));
+        }
+
+        #[test]
+        fn backend_preflight_gate_blocks_unexplained_not_ok() {
+            let preflight: SyncBackendPreflight = serde_json::from_value(json!({
+                "ok": false,
+                "library_ok": true,
+                "total_projects": 1,
+                "ready_projects": 1,
+                "missing_source_hash_projects": 0,
+                "invalid_source_hash_projects": 0,
+                "duplicate_source_hash_projects": 0,
+                "noncanonical_project_id_projects": 0,
+                "job_state": {
+                    "state": "ready",
+                    "running_job_count": 0,
+                    "pending_job_count": 0,
+                    "blocking_job_count": 0,
+                    "blocking_job_counts": { "pending": 0, "running": 0 },
+                    "blocking_jobs": [],
+                    "blocking_jobs_truncated": false,
+                    "guidance": []
+                },
+                "manual_cleanup_required": false,
+                "manual_cleanup_guidance": []
+            }))
+            .expect("preflight");
+
+            let failure = sync_preflight_failure(&preflight).expect("not ok failure");
+
+            assert_eq!(failure.fallback_code, LIBRARY_PREFLIGHT_FAILED_CODE);
+            assert!(failure.message.contains("Library sync preflight failed"));
+        }
+
+        #[test]
+        fn backend_preflight_gate_blocks_library_cleanup_failures() {
+            let preflight: SyncBackendPreflight = serde_json::from_value(json!({
+                "ok": false,
+                "library_ok": false,
+                "total_projects": 4,
+                "ready_projects": 1,
+                "missing_source_hash_projects": 1,
+                "duplicate_source_hash_projects": 2,
+                "manual_cleanup_required": true,
+                "manual_cleanup_guidance": [
+                    MISSING_SOURCE_HASH_GUIDANCE,
+                    DUPLICATE_SOURCE_HASH_GUIDANCE
+                ]
+            }))
+            .expect("preflight");
+
+            let failure = sync_preflight_failure(&preflight).expect("library failure");
+
+            assert_eq!(failure.fallback_code, LIBRARY_PREFLIGHT_FAILED_CODE);
+            assert!(failure.message.contains("1 missing source hash project"));
+            assert!(failure.message.contains("2 duplicate source hash projects"));
+            assert!(failure.message.contains("Manual cleanup:"));
+            assert!(failure.message.contains("re-import affected projects"));
+            assert!(!failure.message.contains("source_path"));
         }
 
         #[test]

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -7,6 +7,7 @@ import {
   type JobSchema,
   type ProjectSchema,
   type SyncPairingPayloadSchema,
+  type SyncPreflightResponse,
   type SyncTransportRunStatus,
 } from "./lib/api";
 import { encodePairingCode, pairingFingerprint } from "./features/activity/syncPairingCode";
@@ -28,6 +29,7 @@ import {
   mockTrustSyncPeer,
   mockListJobs,
   mockBulkJobs,
+  mockGetSyncPreflight,
   mockListProjects,
   renderApp,
   resetAppTestHarness,
@@ -35,6 +37,7 @@ import {
   setBeatBackends,
   setChordBackends,
   setProjects,
+  setSyncPreflight,
   setSyncTransportStatus,
   setSyncTrustedPeers,
   triggerMockIntersectionObserver,
@@ -136,6 +139,34 @@ function syncRunStatus(overrides: Partial<SyncTransportRunStatus> = {}): SyncTra
     project_results: [],
     manifest_errors: [],
     received_artifacts: [],
+    ...overrides,
+  };
+}
+
+function syncPreflight(overrides: Partial<SyncPreflightResponse> = {}): SyncPreflightResponse {
+  return {
+    ok: true,
+    library_ok: true,
+    total_projects: 1,
+    ready_projects: 1,
+    missing_source_hash_projects: 0,
+    invalid_source_hash_projects: 0,
+    duplicate_source_hash_projects: 0,
+    noncanonical_project_id_projects: 0,
+    projects: [],
+    duplicate_groups: [],
+    job_state: {
+      state: "ready",
+      running_job_count: 0,
+      pending_job_count: 0,
+      blocking_job_count: 0,
+      blocking_job_counts: { running: 0, pending: 0 },
+      blocking_jobs: [],
+      blocking_jobs_truncated: false,
+      guidance: [],
+    },
+    manual_cleanup_required: false,
+    manual_cleanup_guidance: [],
     ...overrides,
   };
 }
@@ -815,7 +846,7 @@ describe("Desktop app activity", () => {
     );
   });
 
-  it("runs sync now for a trusted peer", async () => {
+  it("ready preflight allows sync now for a trusted peer", async () => {
     const user = userEvent.setup();
     setSyncTrustedPeers([
       {
@@ -833,10 +864,18 @@ describe("Desktop app activity", () => {
     const peerRow = within(peers).getByText("Laptop Rig").closest("li");
     expect(peerRow).not.toBeNull();
     expect(within(peerRow as HTMLElement).getByText(syncEndpointHints.join(", "))).toBeInTheDocument();
+    const preflightSection = screen.getByRole("heading", { name: "Local Readiness" }).closest("section");
+    expect(preflightSection).not.toBeNull();
+    expect(within(preflightSection as HTMLElement).getByText("Ready")).toBeInTheDocument();
+    mockGetSyncPreflight.mockClear();
 
     await user.click(within(peerRow as HTMLElement).getByRole("button", { name: "Sync Now" }));
 
+    await waitFor(() => expect(mockGetSyncPreflight).toHaveBeenCalled());
     await waitFor(() => expect(mockSyncTrustedPeerNow).toHaveBeenCalledWith("device_peer_1"));
+    expect(mockGetSyncPreflight.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSyncTrustedPeerNow.mock.invocationCallOrder[0],
+    );
     expect(await screen.findAllByText("Manifest exchange completed with 4 project results.")).not.toHaveLength(0);
     expect(screen.getByText(/Transport Iroh/)).toBeInTheDocument();
 
@@ -853,6 +892,156 @@ describe("Desktop app activity", () => {
     expect(within(resultRows[3]).getByText("Failed")).toBeInTheDocument();
     expect(within(resultRows[3]).getByText("proj_missing_audio")).toBeInTheDocument();
     expect(within(resultRows[3]).getByText("Peer did not provide the required source audio.")).toBeInTheDocument();
+  });
+
+  it("busy preflight shows job counts while allowing sync now", async () => {
+    const user = userEvent.setup();
+    setSyncTrustedPeers([
+      {
+        device_id: "device_peer_1",
+        sync_group_id: "sync_group_local",
+        display_name: "Laptop Rig",
+        public_key: "pub_peer_1",
+        endpoint_hints: syncEndpointHints,
+        trusted_at: "2026-04-18T13:16:00.000Z",
+      },
+    ]);
+    setJobs([
+      job({
+        id: "job_running_analyze",
+        type: "analyze",
+        status: "running",
+        progress: 25,
+        started_at: "2026-04-18T13:15:00.000Z",
+      }),
+      job({
+        id: "job_pending_stems",
+        type: "stems",
+        status: "pending",
+        progress: 0,
+      }),
+    ]);
+    await openSyncTab(user);
+
+    const preflightSection = await screen.findByRole("heading", { name: "Local Readiness" });
+    const readiness = preflightSection.closest("section");
+    expect(readiness).not.toBeNull();
+    expect(within(readiness as HTMLElement).getByText("Ready With Jobs")).toBeInTheDocument();
+    expect(within(readiness as HTMLElement).getAllByText(/2 blocking jobs \(1 running, 1 pending\)\./)).not.toHaveLength(0);
+    expect(within(readiness as HTMLElement).getByText("1 analyze, 1 stems")).toBeInTheDocument();
+    mockGetSyncPreflight.mockClear();
+    mockSyncTrustedPeerNow.mockClear();
+
+    const peers = await screen.findByRole("list", { name: "Trusted sync peers" });
+    const peerRow = within(peers).getByText("Laptop Rig").closest("li");
+    expect(peerRow).not.toBeNull();
+    await user.click(within(peerRow as HTMLElement).getByRole("button", { name: "Sync Now" }));
+
+    await waitFor(() => expect(mockGetSyncPreflight).toHaveBeenCalled());
+    await waitFor(() => expect(mockSyncTrustedPeerNow).toHaveBeenCalledWith("device_peer_1"));
+    expect(await screen.findAllByText("Manifest exchange completed with 4 project results.")).not.toHaveLength(0);
+  });
+
+  it("hides preflight job details and cancel controls while showing compact job summary", async () => {
+    const user = userEvent.setup();
+    setJobs([
+      job({
+        id: "job_pending",
+        type: "analyze",
+        status: "pending",
+        progress: 0,
+      }),
+    ]);
+    await openSyncTab(user);
+
+    const preflightSection = screen.getByRole("heading", { name: "Local Readiness" }).closest("section");
+    expect(preflightSection).not.toBeNull();
+    expect(within(preflightSection as HTMLElement).getByText("Ready With Jobs")).toBeInTheDocument();
+    expect(within(preflightSection as HTMLElement).getAllByText(/1 blocking job \(1 pending\)\./)).not.toHaveLength(0);
+    expect(within(preflightSection as HTMLElement).getByText("1 analyze")).toBeInTheDocument();
+    expect(
+      within(preflightSection as HTMLElement).queryByRole("list", { name: "Sync preflight blocking jobs" }),
+    ).not.toBeInTheDocument();
+    expect(within(preflightSection as HTMLElement).queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument();
+    expect(mockCancelJob).not.toHaveBeenCalled();
+  });
+
+  it("marks truncated preflight job type summaries as samples", async () => {
+    const user = userEvent.setup();
+    setSyncPreflight(syncPreflight({
+      job_state: {
+        state: "busy",
+        running_job_count: 0,
+        pending_job_count: 25,
+        blocking_job_count: 25,
+        blocking_job_counts: { running: 0, pending: 25 },
+        blocking_jobs: Array.from({ length: 20 }, (_, index) => ({
+          id: `job_export_${index + 1}`,
+          project_id: `proj_${index + 1}`,
+          project_name: `Export Song ${index + 1}`,
+          type: "export",
+          status: "pending",
+          progress: 0,
+          started_at: null,
+          updated_at: "2026-04-18T13:16:00.000Z",
+        })),
+        blocking_jobs_truncated: true,
+        guidance: [],
+      },
+    }));
+    await openSyncTab(user);
+
+    const preflightSection = screen.getByRole("heading", { name: "Local Readiness" }).closest("section");
+    expect(preflightSection).not.toBeNull();
+    expect(within(preflightSection as HTMLElement).getByText("Ready With Jobs")).toBeInTheDocument();
+    expect(within(preflightSection as HTMLElement).getAllByText(/25 blocking jobs \(25 pending\)\./)).not.toHaveLength(0);
+    expect(
+      within(preflightSection as HTMLElement).getByText("sample: 20 export (first 20 jobs shown)"),
+    ).toBeInTheDocument();
+    expect(
+      within(preflightSection as HTMLElement).queryByRole("list", { name: "Sync preflight blocking jobs" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows library preflight failures before sync now", async () => {
+    const user = userEvent.setup();
+    setSyncTrustedPeers([
+      {
+        device_id: "device_peer_1",
+        sync_group_id: "sync_group_local",
+        display_name: "Laptop Rig",
+        public_key: "pub_peer_1",
+        endpoint_hints: syncEndpointHints,
+        trusted_at: "2026-04-18T13:16:00.000Z",
+      },
+    ]);
+    setSyncPreflight(syncPreflight({
+      ok: false,
+      library_ok: false,
+      total_projects: 1,
+      ready_projects: 0,
+      missing_source_hash_projects: 1,
+      manual_cleanup_required: true,
+      manual_cleanup_guidance: [
+        "Restore the original source file or re-import affected projects so TuneForge can compute source hashes.",
+      ],
+    }));
+    await openSyncTab(user);
+
+    expect(await screen.findAllByText(/Library preflight failed: 1 missing source hash project\./)).not.toHaveLength(0);
+    mockGetSyncPreflight.mockClear();
+    mockSyncTrustedPeerNow.mockClear();
+
+    const peers = await screen.findByRole("list", { name: "Trusted sync peers" });
+    const peerRow = within(peers).getByText("Laptop Rig").closest("li");
+    expect(peerRow).not.toBeNull();
+    await user.click(within(peerRow as HTMLElement).getByRole("button", { name: "Sync Now" }));
+
+    await waitFor(() => expect(mockGetSyncPreflight).toHaveBeenCalled());
+    expect(mockSyncTrustedPeerNow).not.toHaveBeenCalled();
+    expect(
+      await screen.findAllByText(/Sync now failed: Library preflight failed: 1 missing source hash project\./),
+    ).not.toHaveLength(0);
   });
 
   it("shows listener-side sync project results from native status", async () => {

--- a/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
+++ b/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
@@ -7,6 +7,8 @@ import {
   type SyncPairingPayloadSchema,
   type SyncNearbyPeer,
   type SyncNearbyPeerTrustStatus,
+  type SyncPreflightBlockingJob,
+  type SyncPreflightResponse,
   type SyncTransportProjectResult,
   type SyncTransportRunStatus,
   type SyncTransportTransferResult,
@@ -213,6 +215,98 @@ function syncNowFailureText(error: unknown) {
     }
   }
   return "Sync now failed.";
+}
+
+function pluralize(count: number, singular: string, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function syncPreflightLibraryIssueItems(preflight: SyncPreflightResponse) {
+  const entries: Array<[number, string]> = [
+    [preflight.missing_source_hash_projects, "missing source hash project"],
+    [preflight.invalid_source_hash_projects, "invalid source hash project"],
+    [preflight.duplicate_source_hash_projects, "duplicate source hash project"],
+    [preflight.noncanonical_project_id_projects, "noncanonical project ID"],
+  ];
+  return entries
+    .filter((entry): entry is [number, string] => entry[0] > 0)
+    .map(([count, label]) => pluralize(count, label));
+}
+
+function syncPreflightLibraryIssueText(preflight: SyncPreflightResponse) {
+  const issues = syncPreflightLibraryIssueItems(preflight);
+  return issues.length ? issues.join(", ") : null;
+}
+
+function syncPreflightJobStatusSummary(preflight: SyncPreflightResponse) {
+  const counts = preflight.job_state.blocking_job_counts;
+  const entries: Array<[string, number]> = [
+    ["running", counts.running ?? preflight.job_state.running_job_count],
+    ["pending", counts.pending ?? preflight.job_state.pending_job_count],
+    ...Object.entries(counts).filter(([status]) => status !== "running" && status !== "pending"),
+  ];
+  const ordered = entries.filter((entry): entry is [string, number] => entry[1] > 0);
+  return ordered.length
+    ? ordered.map(([status, count]) => `${count} ${statusLabel(status).toLowerCase()}`).join(", ")
+    : null;
+}
+
+function syncPreflightBlockingTypeSummary(jobs: SyncPreflightBlockingJob[], truncated = false) {
+  const counts = new Map<string, number>();
+  jobs.forEach((job) => {
+    counts.set(job.type, (counts.get(job.type) ?? 0) + 1);
+  });
+  const parts = Array.from(counts.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([type, count]) => `${count} ${type}`);
+  if (!parts.length) {
+    return null;
+  }
+  const summary = parts.join(", ");
+  return truncated ? `sample: ${summary} (first ${pluralize(jobs.length, "job")} shown)` : summary;
+}
+
+function syncPreflightJobSummary(preflight: SyncPreflightResponse) {
+  const blockingCount = preflight.job_state.blocking_job_count;
+  if (blockingCount === 0) {
+    return "No blocking backend jobs.";
+  }
+  const statusSummary = syncPreflightJobStatusSummary(preflight);
+  return `${pluralize(blockingCount, "blocking job")}${statusSummary ? ` (${statusSummary})` : ""}.`;
+}
+
+function syncPreflightBlockedText(preflight: SyncPreflightResponse) {
+  if (!preflight.library_ok) {
+    const issueText = syncPreflightLibraryIssueText(preflight);
+    return `Library preflight failed${issueText ? `: ${issueText}` : ""}.`;
+  }
+  return "Local sync preflight failed.";
+}
+
+function syncPreflightUnavailableText(error: unknown) {
+  if (error instanceof Error && error.message.trim()) {
+    return `Backend preflight unavailable: ${error.message.trim()}`;
+  }
+  return "Backend preflight unavailable.";
+}
+
+function syncPreflightReadinessLabel(preflight: SyncPreflightResponse | undefined, isError: boolean) {
+  if (isError) {
+    return "Unavailable";
+  }
+  if (!preflight) {
+    return "Checking";
+  }
+  if (!preflight.library_ok) {
+    return "Library Cleanup Required";
+  }
+  if (preflight.job_state.blocking_job_count > 0) {
+    return "Ready With Jobs";
+  }
+  if (preflight.ok) {
+    return "Ready";
+  }
+  return "Not Ready";
 }
 
 function syncResultKey(status: SyncTransportRunStatus | null | undefined) {
@@ -546,6 +640,10 @@ export function ActivitySyncPanel() {
       return syncNowPolling || status?.active ? SYNC_LISTENER_POLL_INTERVAL_MS : false;
     },
   });
+  const preflightQuery = useQuery({
+    queryKey: ["sync", "preflight"],
+    queryFn: () => api.getSyncPreflight(),
+  });
   const peersQuery = useQuery({
     queryKey: ["sync", "trusted-peers"],
     queryFn: async () => (await api.listSyncTrustedPeers()).trusted_peers,
@@ -604,6 +702,7 @@ export function ActivitySyncPanel() {
   const refreshSyncQueries = async () => {
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: ["sync", "listener"] }),
+      queryClient.invalidateQueries({ queryKey: ["sync", "preflight"] }),
       queryClient.invalidateQueries({ queryKey: ["sync", "trusted-peers"] }),
     ]);
   };
@@ -686,12 +785,24 @@ export function ActivitySyncPanel() {
     },
   });
   const syncNowMutation = useMutation({
-    mutationFn: (request: SyncNowRequest) =>
-      request.endpointHints?.length
-        ? api.syncTrustedPeerNow(request.deviceId, { endpointHints: request.endpointHints })
-        : api.syncTrustedPeerNow(request.deviceId),
-    onMutate: () => {
+    mutationFn: async (request: SyncNowRequest) => {
+      let preflight: SyncPreflightResponse;
+      try {
+        preflight = await api.getSyncPreflight();
+        queryClient.setQueryData(["sync", "preflight"], preflight);
+      } catch (error) {
+        throw Object.assign(new Error(syncPreflightUnavailableText(error)), { cause: error });
+      }
+      if (!preflight.ok) {
+        throw new Error(syncPreflightBlockedText(preflight));
+      }
       setSyncNowPolling(true);
+      void queryClient.invalidateQueries({ queryKey: ["sync", "listener"] });
+      return request.endpointHints?.length
+        ? api.syncTrustedPeerNow(request.deviceId, { endpointHints: request.endpointHints })
+        : api.syncTrustedPeerNow(request.deviceId);
+    },
+    onMutate: () => {
       void queryClient.invalidateQueries({ queryKey: ["sync", "listener"] });
     },
     onSuccess: async (status) => {
@@ -845,6 +956,19 @@ export function ActivitySyncPanel() {
         currentSyncElapsed
       ),
   );
+  const preflight = preflightQuery.data;
+  const preflightReadiness = syncPreflightReadinessLabel(preflight, preflightQuery.isError);
+  const preflightLibraryIssues = preflight ? syncPreflightLibraryIssueText(preflight) : null;
+  const preflightJobText = preflight ? syncPreflightJobSummary(preflight) : "Checking backend jobs.";
+  const preflightJobTypeText = preflight
+    ? syncPreflightBlockingTypeSummary(
+        preflight.job_state.blocking_jobs,
+        preflight.job_state.blocking_jobs_truncated,
+      )
+    : null;
+  const preflightGuidance = preflight
+    ? Array.from(new Set([...preflight.manual_cleanup_guidance, ...preflight.job_state.guidance]))
+    : [];
 
   return (
     <section
@@ -1126,6 +1250,74 @@ export function ActivitySyncPanel() {
           ) : null}
         </section>
       </div>
+
+      <section className="activity-sync-section" aria-labelledby="activity-sync-preflight-heading">
+        <div className="activity-sync-section__header">
+          <h3 id="activity-sync-preflight-heading">Local Readiness</h3>
+          <button
+            className="button button--ghost button--small"
+            disabled={preflightQuery.isFetching}
+            onClick={() => {
+              void preflightQuery.refetch();
+            }}
+            type="button"
+          >
+            {preflightQuery.isFetching ? "Checking..." : "Refresh"}
+          </button>
+        </div>
+
+        <dl className="activity-sync-facts">
+          <div>
+            <dt>Status</dt>
+            <dd>
+              <span className={`activity-sync-status activity-sync-status--${statusClassName(preflightReadiness)}`}>
+                {preflightReadiness}
+              </span>
+            </dd>
+          </div>
+          <div>
+            <dt>Library</dt>
+            <dd>
+              {preflight
+                ? preflight.library_ok
+                  ? `${preflight.ready_projects}/${preflight.total_projects} projects ready.`
+                  : `Library preflight failed${preflightLibraryIssues ? `: ${preflightLibraryIssues}` : ""}.`
+                : "Checking local library."}
+            </dd>
+          </div>
+          <div>
+            <dt>Backend Jobs</dt>
+            <dd>{preflightJobText}</dd>
+          </div>
+          {preflightJobTypeText ? (
+            <div>
+              <dt>Job Types</dt>
+              <dd>{preflightJobTypeText}</dd>
+            </div>
+          ) : null}
+        </dl>
+
+        {preflightQuery.isError ? (
+          <p className="activity-sync-alert activity-sync-alert--error" role="alert">
+            Backend preflight unavailable. Retry when the local backend responds.
+          </p>
+        ) : null}
+        {preflight && !preflight.library_ok ? (
+          <p className="activity-sync-alert activity-sync-alert--error" role="alert">
+            Library preflight failed{preflightLibraryIssues ? `: ${preflightLibraryIssues}` : ""}.
+          </p>
+        ) : null}
+        {preflight && preflight.job_state.blocking_job_count > 0 ? (
+          <p className="activity-sync-alert" role="status">
+            Backend jobs running: {preflightJobText}
+          </p>
+        ) : null}
+        {preflightGuidance.map((guidance) => (
+          <p className="activity-sync-alert" key={guidance} role="status">
+            {guidance}
+          </p>
+        ))}
+      </section>
 
       <section className="activity-sync-section activity-sync-section--nearby" aria-labelledby="activity-sync-nearby-heading">
         <div className="activity-sync-section__header">

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -79,6 +79,31 @@ export type SyncTrustedPeerCreateRequest = components["schemas"]["SyncTrustedPee
 export type SyncTrustedPeerResponse = components["schemas"]["SyncTrustedPeerResponse"];
 export type SyncTrustedPeerSchema = components["schemas"]["SyncTrustedPeerSchema"];
 export type SyncTrustedPeersResponse = components["schemas"]["SyncTrustedPeersResponse"];
+type GeneratedSyncPreflightResponse = components["schemas"]["SyncPreflightResponse"];
+export type SyncPreflightBlockingJob = {
+  id: string;
+  project_id: string | null;
+  project_name: string | null;
+  type: string;
+  status: string;
+  progress: number;
+  started_at: string | null;
+  updated_at: string;
+};
+export type SyncPreflightJobState = {
+  state: "ready" | "busy";
+  running_job_count: number;
+  pending_job_count: number;
+  blocking_job_count: number;
+  blocking_job_counts: Record<string, number>;
+  blocking_jobs: SyncPreflightBlockingJob[];
+  blocking_jobs_truncated: boolean;
+  guidance: string[];
+};
+export type SyncPreflightResponse = GeneratedSyncPreflightResponse & {
+  library_ok: boolean;
+  job_state: SyncPreflightJobState;
+};
 export type RuntimeCapabilities = MobileCapabilities | null;
 export type ProjectSyncSummary = {
   state: string;
@@ -383,6 +408,126 @@ function recordArrayField(record: Record<string, unknown> | null, keys: string[]
     }
   }
   return [];
+}
+
+function normalizeSyncPreflightBlockingJob(value: unknown): SyncPreflightBlockingJob | null {
+  const record = asRecord(value);
+  if (!record) {
+    return null;
+  }
+  const id = firstStringField([record], ["id", "job_id", "jobId"]);
+  if (!id) {
+    return null;
+  }
+  return {
+    id,
+    project_id: firstStringField([record], ["project_id", "projectId"]),
+    project_name: firstStringField(
+      [record],
+      ["project_name", "projectName", "project_display_name", "projectDisplayName"],
+    ),
+    type: firstStringField([record], ["type", "job_type", "jobType"]) ?? "job",
+    status: firstStringField([record], ["status", "state"]) ?? "pending",
+    progress: numberField(record, ["progress", "progress_percent", "progressPercent"]) ?? 0,
+    started_at: dateTimeField(record, ["started_at", "startedAt"]),
+    updated_at: dateTimeField(record, ["updated_at", "updatedAt"]) ?? "",
+  };
+}
+
+function normalizeSyncPreflightJobCounts(value: unknown): Record<string, number> {
+  const record = asRecord(value);
+  if (!record) {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(record).filter(
+      (entry): entry is [string, number] => typeof entry[1] === "number" && Number.isFinite(entry[1]),
+    ),
+  );
+}
+
+function normalizeSyncPreflightJobState(value: unknown): SyncPreflightJobState {
+  const record = asRecord(value);
+  const rawBlockingJobs = Array.isArray(record?.blocking_jobs)
+    ? record.blocking_jobs
+    : Array.isArray(record?.blockingJobs)
+      ? record.blockingJobs
+      : [];
+  const blockingJobs = rawBlockingJobs
+    .map(normalizeSyncPreflightBlockingJob)
+    .filter((job): job is SyncPreflightBlockingJob => job !== null);
+  const blockingJobCounts = normalizeSyncPreflightJobCounts(record?.blocking_job_counts ?? record?.blockingJobCounts);
+  const runningJobCount =
+    numberField(record, ["running_job_count", "runningJobCount"]) ?? blockingJobCounts.running ?? 0;
+  const pendingJobCount =
+    numberField(record, ["pending_job_count", "pendingJobCount"]) ?? blockingJobCounts.pending ?? 0;
+  const countedBlockingJobs = Object.values(blockingJobCounts).reduce((total, count) => total + count, 0);
+  const explicitBlockingJobCount = numberField(record, ["blocking_job_count", "blockingJobCount"]);
+  const blockingJobCount = explicitBlockingJobCount ?? (countedBlockingJobs || blockingJobs.length);
+  const rawState = firstStringField([record], ["state", "status"]);
+  const state = rawState === "ready" || rawState === "busy"
+    ? rawState
+    : blockingJobCount > 0 ? "busy" : "ready";
+  return {
+    state,
+    running_job_count: runningJobCount,
+    pending_job_count: pendingJobCount,
+    blocking_job_count: blockingJobCount,
+    blocking_job_counts: {
+      ...blockingJobCounts,
+      pending: blockingJobCounts.pending ?? pendingJobCount,
+      running: blockingJobCounts.running ?? runningJobCount,
+    },
+    blocking_jobs: blockingJobs,
+    blocking_jobs_truncated: firstBooleanField([record], ["blocking_jobs_truncated", "blockingJobsTruncated"]) ?? false,
+    guidance: stringArrayField(record, ["guidance", "messages"]),
+  };
+}
+
+function normalizeSyncPreflightResponse(response: GeneratedSyncPreflightResponse): SyncPreflightResponse {
+  const record = asRecord(response);
+  const jobState = normalizeSyncPreflightJobState(record?.job_state ?? record?.jobState);
+  const libraryOk = firstBooleanField([record], ["library_ok", "libraryOk"]) ??
+    (
+      (record?.manual_cleanup_required === false || record?.manualCleanupRequired === false) &&
+      (response.missing_source_hash_projects ?? 0) === 0 &&
+      (response.invalid_source_hash_projects ?? 0) === 0 &&
+      (response.duplicate_source_hash_projects ?? 0) === 0 &&
+      (response.noncanonical_project_id_projects ?? 0) === 0
+    );
+  return {
+    ...response,
+    ok: Boolean(response.ok && libraryOk && jobState.blocking_job_count === 0),
+    library_ok: libraryOk,
+    job_state: jobState,
+  };
+}
+
+function mobileReadySyncPreflightResponse(): GeneratedSyncPreflightResponse {
+  return {
+    ok: true,
+    library_ok: true,
+    total_projects: 0,
+    ready_projects: 0,
+    missing_source_hash_projects: 0,
+    invalid_source_hash_projects: 0,
+    duplicate_source_hash_projects: 0,
+    noncanonical_project_id_projects: 0,
+    projects: [],
+    duplicate_groups: [],
+    job_state: {
+      state: "ready",
+      running_job_count: 0,
+      pending_job_count: 0,
+      blocking_job_count: 0,
+      blocking_job_counts: { running: 0, pending: 0 },
+      blocking_jobs: [],
+      blocking_jobs_truncated: false,
+      guidance: [],
+    },
+    manual_cleanup_required: false,
+    manual_cleanup_guidance: [],
+  };
 }
 
 function normalizeMetricKey(value: string) {
@@ -1348,6 +1493,7 @@ export type TuneForgeClient = {
   getJob: (jobId: string) => Promise<components["schemas"]["JobResponse"]>;
   cancelJob: (jobId: string) => Promise<components["schemas"]["JobResponse"]>;
   bulkJobs: (body: BulkJobRequest) => Promise<BulkJobsResponse>;
+  getSyncPreflight: () => Promise<SyncPreflightResponse>;
   getSyncIdentity: () => Promise<SyncLocalIdentityResponse>;
   createSyncPairingOffer: (body: SyncPairingOfferRequest) => Promise<SyncPairingOfferResponse>;
   answerSyncPairingOffer: (body: SyncPairingAnswerRequest) => Promise<SyncPairingAnswerResponse>;
@@ -1597,6 +1743,7 @@ function createHttpTuneForgeClient(): TuneForgeClient {
     cancelJob: (jobId: string) =>
       unwrap(client.POST("/api/v1/jobs/{job_id}/cancel", { params: { path: { job_id: jobId } } })),
     bulkJobs: (body: BulkJobRequest) => unwrap(client.POST("/api/v1/jobs/bulk", { body })),
+    getSyncPreflight: async () => normalizeSyncPreflightResponse(await unwrap(client.GET("/api/v1/sync/preflight"))),
     getSyncIdentity: () => unwrap(client.GET("/api/v1/sync/identity")),
     createSyncPairingOffer: (body: SyncPairingOfferRequest) =>
       isTauriRuntime()
@@ -1713,6 +1860,8 @@ function createMobileTuneForgeClient(capabilities: MobileCapabilities): TuneForg
     bulkJobs: async () => {
       throw unsupportedRuntimeError("Bulk jobs");
     },
+    getSyncPreflight: async () =>
+      normalizeSyncPreflightResponse(mobileReadySyncPreflightResponse()),
     getSyncIdentity: () => invokeMobile("mobile_get_sync_identity"),
     createSyncPairingOffer: (body: SyncPairingOfferRequest) =>
       invokeMobile("mobile_create_sync_pairing_offer", { payload: body }),
@@ -1810,6 +1959,7 @@ export const api: TuneForgeClient = {
   getJob: (jobId: string) => activeClient.getJob(jobId),
   cancelJob: (jobId: string) => activeClient.cancelJob(jobId),
   bulkJobs: (body: BulkJobRequest) => activeClient.bulkJobs(body),
+  getSyncPreflight: () => activeClient.getSyncPreflight(),
   getSyncIdentity: () => activeClient.getSyncIdentity(),
   createSyncPairingOffer: (body: SyncPairingOfferRequest) => activeClient.createSyncPairingOffer(body),
   answerSyncPairingOffer: (body: SyncPairingAnswerRequest) => activeClient.answerSyncPairingOffer(body),

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -11,6 +11,7 @@ import type {
   LyricsGenerateRequest,
   ListJobsParams,
   ListProjectsParams,
+  SyncPreflightResponse,
   SyncPairingAnswerRequest,
   SyncPairingAnswerResponse,
   SyncPairingOfferRequest,
@@ -44,6 +45,7 @@ const {
   setStemModels,
   setJobs,
   setSyncTransportStatus,
+  setSyncPreflight,
   setSyncTrustedPeers,
   setDeferredPreviewCompletion,
   flushPendingPreview,
@@ -64,6 +66,7 @@ const {
   mockListJobs,
   mockCancelJob,
   mockBulkJobs,
+  mockGetSyncPreflight,
   mockGetSyncIdentity,
   mockGetSyncTransportStatus,
   mockStartSyncListener,
@@ -183,6 +186,7 @@ const {
     stemModels: Array<Record<string, unknown>>;
     pendingPreviewArtifactsByProject: Record<string, Array<Record<string, unknown>>>;
     jobs: Array<Record<string, unknown>>;
+    syncPreflight: Record<string, unknown> | null;
     syncIdentity: Record<string, unknown>;
     syncTransportStatus: Record<string, unknown>;
     syncTrustedPeers: Array<Record<string, unknown>>;
@@ -671,6 +675,10 @@ const {
     };
   }
 
+  function setSyncPreflight(preflight: Record<string, unknown> | null) {
+    state.syncPreflight = preflight ? clone(preflight) : null;
+  }
+
   function setSyncTrustedPeers(peers: Array<Record<string, unknown>>) {
     state.syncTrustedPeers = clone(peers);
   }
@@ -782,6 +790,7 @@ const {
           updated_at: createdAt,
         },
       ],
+      syncPreflight: null,
       syncIdentity: {
         device_id: "device_local",
         sync_group_id: "sync_group_local",
@@ -1521,6 +1530,67 @@ const {
       skipped,
     };
   });
+  function buildMockSyncPreflight(): SyncPreflightResponse {
+    const blockingJobs = state.jobs
+      .map((item, index) => normalizeMockJob(item, index))
+      .filter((item) => item.status === "pending" || item.status === "running")
+      .sort(compareActivityJobs);
+    const runningJobCount = blockingJobs.filter((item) => item.status === "running").length;
+    const pendingJobCount = blockingJobs.filter((item) => item.status === "pending").length;
+    const visibleBlockingJobs = blockingJobs.slice(0, 20).map((item) => {
+      const projectId = typeof item.project_id === "string" ? item.project_id : null;
+      const project = projectId ? state.projects.find((candidate) => candidate.id === projectId) : null;
+      return {
+        id: String(item.id),
+        project_id: projectId,
+        project_name: typeof project?.display_name === "string" ? project.display_name : null,
+        type: String(item.type ?? "job"),
+        status: String(item.status ?? "pending"),
+        progress: typeof item.progress === "number" ? item.progress : 0,
+        started_at: typeof item.started_at === "string" ? item.started_at : null,
+        updated_at: typeof item.updated_at === "string" ? item.updated_at : createdAt,
+      };
+    });
+
+    return {
+      ok: true,
+      library_ok: true,
+      total_projects: state.projects.length,
+      ready_projects: state.projects.length,
+      missing_source_hash_projects: 0,
+      invalid_source_hash_projects: 0,
+      duplicate_source_hash_projects: 0,
+      noncanonical_project_id_projects: 0,
+      projects: state.projects.map((item) => ({
+        project_id: String(item.id),
+        display_name: String(item.display_name ?? item.id),
+        status: "ready",
+        source_sha256: null,
+        expected_project_id: null,
+        expected_storage_key: null,
+        source_hash_source: null,
+        reason: null,
+      })),
+      duplicate_groups: [],
+      job_state: {
+        state: blockingJobs.length ? "busy" : "ready",
+        running_job_count: runningJobCount,
+        pending_job_count: pendingJobCount,
+        blocking_job_count: blockingJobs.length,
+        blocking_job_counts: {
+          running: runningJobCount,
+          pending: pendingJobCount,
+        },
+        blocking_jobs: visibleBlockingJobs,
+        blocking_jobs_truncated: blockingJobs.length > visibleBlockingJobs.length,
+        guidance: blockingJobs.length
+          ? ["Backend jobs are running. Sync can start, but backend work may delay sync endpoint responses."]
+          : [],
+      },
+      manual_cleanup_required: false,
+      manual_cleanup_guidance: [],
+    };
+  }
   function normalizeSyncPeer(peer: Record<string, unknown>): SyncTrustedPeerSchema {
     return {
       device_id: String(peer.device_id ?? "device_peer"),
@@ -1535,6 +1605,9 @@ const {
       updated_at: typeof peer.updated_at === "string" ? peer.updated_at : createdAt,
     };
   }
+  const mockGetSyncPreflight = vi.fn(async (): Promise<SyncPreflightResponse> =>
+    clone((state.syncPreflight as SyncPreflightResponse | null) ?? buildMockSyncPreflight()),
+  );
   const mockGetSyncIdentity = vi.fn(async () => ({ identity: clone(state.syncIdentity) }));
   const mockGetSyncTransportStatus = vi.fn(async () => clone(state.syncTransportStatus));
   const mockStartSyncListener = vi.fn(async () => {
@@ -2234,6 +2307,7 @@ const {
     setStemModels,
     setJobs,
     setSyncTransportStatus,
+    setSyncPreflight,
     setSyncTrustedPeers,
     setDeferredPreviewCompletion,
     flushPendingPreview,
@@ -2254,6 +2328,7 @@ const {
     mockListJobs,
     mockCancelJob,
     mockBulkJobs,
+    mockGetSyncPreflight,
     mockGetSyncIdentity,
     mockGetSyncTransportStatus,
     mockStartSyncListener,
@@ -2306,6 +2381,7 @@ export {
   setStemModels,
   setJobs,
   setSyncTransportStatus,
+  setSyncPreflight,
   setSyncTrustedPeers,
   setDeferredPreviewCompletion,
   flushPendingPreview,
@@ -2326,6 +2402,7 @@ export {
   mockListJobs,
   mockCancelJob,
   mockBulkJobs,
+  mockGetSyncPreflight,
   mockGetSyncIdentity,
   mockGetSyncTransportStatus,
   mockStartSyncListener,
@@ -2392,6 +2469,7 @@ vi.mock("../lib/api", async (importOriginal) => {
       listJobs: mockListJobs,
       cancelJob: mockCancelJob,
       bulkJobs: mockBulkJobs,
+      getSyncPreflight: mockGetSyncPreflight,
       getSyncIdentity: mockGetSyncIdentity,
       getSyncTransportStatus: mockGetSyncTransportStatus,
       startSyncListener: mockStartSyncListener,

--- a/docs/API.md
+++ b/docs/API.md
@@ -330,11 +330,22 @@ Checks the local library before multi-device sync is enabled. The endpoint retur
 
 The response includes:
 
-- `ok`
+- `ok` - overall sync readiness. This is `true` when library checks pass. Pending or running jobs
+  are diagnostic state, not a hard sync blocker.
+- `library_ok` - library-only readiness, matching the previous `ok` behavior.
 - project status counts
 - per-project sync identity status
 - duplicate source-hash groups
+- `job_state` - active job diagnostics for sync startup and backend responsiveness failures.
 - manual cleanup guidance
+
+`job_state` includes `state` (`ready` or `busy`), `running_job_count`, `pending_job_count`,
+`blocking_job_count`, `blocking_job_counts`, `blocking_jobs`, `blocking_jobs_truncated`, and
+`guidance`. Pending and running jobs do not block sync by themselves; they are included so the UI can
+explain backend-busy or endpoint-timeout failures. `blocking_jobs` is capped at 20 entries and
+exposes only sync-safe fields: `id`, `project_id`, `project_name`, `type`, `status`, `progress`,
+`started_at`, and `updated_at`. It does not expose job payloads, file paths, audio data, or endpoint
+details.
 
 Project status values are `ready`, `missing_source_hash`, `invalid_source_hash`, `duplicate_source_hash`, and `noncanonical_project_id`. Canonical project IDs use `proj_sha256_<full_source_sha256>`, while project storage directories use a shorter derived key such as `proj_<first_24_sha256_hex>`. Preflight uses a stored `projects.source_sha256` when present. If that field is missing, preflight only recovers it from an explicit app-managed original-byte copy and otherwise reports `missing_source_hash`; `source_path` is provenance only and is not hashed during recovery. This endpoint is sync-specific; general project responses do not expose source hashes.
 

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -1743,6 +1743,28 @@ export interface components {
                 [key: string]: unknown;
             };
         };
+        /** SyncPreflightBlockingJobSchema */
+        SyncPreflightBlockingJobSchema: {
+            /** Id */
+            id: string;
+            /** Project Id */
+            project_id: string | null;
+            /** Project Name */
+            project_name: string | null;
+            /** Type */
+            type: string;
+            /** Status */
+            status: string;
+            /** Progress */
+            progress: number;
+            /** Started At */
+            started_at: string | null;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+        };
         /** SyncPreflightDuplicateGroupSchema */
         SyncPreflightDuplicateGroupSchema: {
             /** Source Sha256 */
@@ -1758,6 +1780,30 @@ export interface components {
             project_id: string;
             /** Display Name */
             display_name: string;
+        };
+        /** SyncPreflightJobStateSchema */
+        SyncPreflightJobStateSchema: {
+            /**
+             * State
+             * @enum {string}
+             */
+            state: "ready" | "busy";
+            /** Running Job Count */
+            running_job_count: number;
+            /** Pending Job Count */
+            pending_job_count: number;
+            /** Blocking Job Count */
+            blocking_job_count: number;
+            /** Blocking Job Counts */
+            blocking_job_counts: {
+                [key: string]: number;
+            };
+            /** Blocking Jobs */
+            blocking_jobs: components["schemas"]["SyncPreflightBlockingJobSchema"][];
+            /** Blocking Jobs Truncated */
+            blocking_jobs_truncated: boolean;
+            /** Guidance */
+            guidance: string[];
         };
         /** SyncPreflightProjectSchema */
         SyncPreflightProjectSchema: {
@@ -1785,6 +1831,8 @@ export interface components {
         SyncPreflightResponse: {
             /** Ok */
             ok: boolean;
+            /** Library Ok */
+            library_ok: boolean;
             /** Total Projects */
             total_projects: number;
             /** Ready Projects */
@@ -1801,6 +1849,7 @@ export interface components {
             projects: components["schemas"]["SyncPreflightProjectSchema"][];
             /** Duplicate Groups */
             duplicate_groups: components["schemas"]["SyncPreflightDuplicateGroupSchema"][];
+            job_state: components["schemas"]["SyncPreflightJobStateSchema"];
             /** Manual Cleanup Required */
             manual_cleanup_required: boolean;
             /** Manual Cleanup Guidance */


### PR DESCRIPTION
## Summary

- Add sync backend preflight diagnostics for library readiness and local job state.
- Surface compact local readiness in the Sync tab and keep detailed job handling in Jobs.
- Start native sync with a local backend preflight and preserve transport fallback boundaries.
- Fixes #223. Refs #237.

## Testing

- `cd apps/backend && uv run --python 3.11 pytest tests/test_sync_identity.py tests/test_pagination_contract.py`
- `pnpm contracts:generate`
- `pnpm --filter @tuneforge/desktop test -- App.activity.test.tsx`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `cd apps/desktop/src-tauri && cargo test sync_transport`
- `cd apps/desktop/src-tauri && cargo check`
- `git diff --check`
