### PR TITLE
fix: reset playback stop state

### DIFF
--- a/apps/desktop/src/App.project-precount.test.tsx
+++ b/apps/desktop/src/App.project-precount.test.tsx
@@ -125,6 +125,27 @@ function audioPlayStartTime(callIndex = 0) {
   return payload?.startTimeSeconds ?? null;
 }
 
+function expectPrecountClicksCancelled(
+  audioContext: ReturnType<typeof getMockAudioContexts>[number] | undefined,
+) {
+  expect(audioContext?.createdOscillators).toHaveLength(4);
+  audioContext?.createdOscillators.forEach((oscillator) => {
+    expect(oscillator.stop).toHaveBeenCalledTimes(2);
+    expect(oscillator.disconnect).toHaveBeenCalledTimes(1);
+  });
+}
+
+function createDeferred<T>(_type?: T) {
+  void _type;
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (error: Error) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, reject, resolve };
+}
+
 describe("Desktop app project playback pre-count", () => {
   beforeEach(resetAppTestHarness);
 
@@ -250,6 +271,7 @@ describe("Desktop app project playback pre-count", () => {
     await flushMicrotasks();
     const audioContext = getMockAudioContexts()[0];
     fireEvent.click(screen.getByRole("button", { name: "Stop playback" }));
+    expectPrecountClicksCancelled(audioContext);
 
     act(() => {
       vi.advanceTimersByTime(2500);
@@ -262,6 +284,54 @@ describe("Desktop app project playback pre-count", () => {
       reason: "playback-stopped",
       sequence: readPlaybackE2ETelemetry().countIn.lastScheduled?.sequence,
       trigger: "song-start",
+    });
+    expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+  });
+
+  it("cancels loop pre-count clicks and resets to loop start on stop", async () => {
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    setPlaybackPosition("12.25");
+    await user.click(screen.getByRole("button", { name: "Set loop start" }));
+    setPlaybackPosition("24.5");
+    await user.click(screen.getByRole("button", { name: "Set loop end" }));
+
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByLabelText("Enable loop pre-count"));
+    fireEvent.click(screen.getByRole("button", { name: "Play playback" }));
+    await flushMicrotasks();
+
+    const audioContext = getMockAudioContexts()[0];
+    expect(audioContext?.createdSources).toHaveLength(0);
+    expect(audioContext?.createdOscillators).toHaveLength(4);
+    fireEvent.click(screen.getByRole("button", { name: "Stop playback" }));
+    expectPrecountClicksCancelled(audioContext);
+
+    act(() => {
+      vi.advanceTimersByTime(2500);
+    });
+
+    expect(audioContext?.createdSources).toHaveLength(0);
+    expect(sourceAudio.currentTime).toBeCloseTo(12.25, 3);
+    expect(readPlaybackE2ETelemetry()).toMatchObject({
+      countIn: {
+        active: false,
+        lastCancelled: {
+          reason: "playback-stopped",
+          sequence: readPlaybackE2ETelemetry().countIn.lastScheduled?.sequence,
+          trigger: "loop-start",
+        },
+      },
+      loopRange: { startSeconds: 12.25, endSeconds: 24.5 },
+      positionSeconds: 12.25,
+      transportState: "stopped",
     });
     expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
   });
@@ -505,6 +575,611 @@ describe("Desktop app project playback pre-count", () => {
         transportState: "playing",
       }),
     );
+    restoreTauriRuntime();
+  });
+
+  it("stops paused native playback before replaying from song start", async () => {
+    const restoreTauriRuntime = enableNativePlayback();
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    setPlaybackPosition("18.75");
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(1));
+    expect(audioPlayStartTime()).toBeCloseTo(18.75, 3);
+
+    act(() => {
+      emitMockNativePlaybackPosition({
+        sessionId: latestNativeSessionId(),
+        positionSeconds: 23.5,
+        durationSeconds: 182,
+        state: "playing",
+      });
+    });
+    await waitFor(() =>
+      expect(readPlaybackE2ETelemetry()).toMatchObject({
+        activePath: "native",
+        positionSeconds: 23.5,
+        transportState: "playing",
+      }),
+    );
+
+    const pauseDeferred = createDeferred({
+      sessionId: latestNativeSessionId(),
+      state: "paused",
+      positionSeconds: 23.5,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      fallbackReason: null,
+      lanes: [],
+      bufferHealth: [],
+    });
+    const stopDeferred = createDeferred({
+      sessionId: latestNativeSessionId(),
+      state: "stopped",
+      positionSeconds: 0,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      fallbackReason: null,
+      lanes: [],
+      bufferHealth: [],
+    });
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation();
+    invoke.mockImplementation(async (command, args) => {
+      if (command === "audio_pause") {
+        return pauseDeferred.promise;
+      }
+      if (command === "audio_stop") {
+        return stopDeferred.promise;
+      }
+      if (!originalInvoke) {
+        throw new Error(`Unhandled invoke command ${command}`);
+      }
+      return originalInvoke(command, args);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Pause playback" }));
+    await waitFor(() => expect(invokeCalls("audio_pause")).toHaveLength(1));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument(),
+    );
+    expect(readPlaybackE2ETelemetry()).toMatchObject({
+      activePath: "native",
+      positionSeconds: 23.5,
+      transportState: "paused",
+    });
+    expect(invokeCalls("audio_stop")).toHaveLength(0);
+
+    await user.click(screen.getByRole("button", { name: "Stop playback" }));
+    await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(1));
+    await waitFor(() =>
+      expect(readPlaybackE2ETelemetry()).toMatchObject({
+        activePath: "none",
+        positionSeconds: 0,
+        transportState: "stopped",
+      }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await flushMicrotasks();
+    expect(invokeCalls("audio_play")).toHaveLength(1);
+    pauseDeferred.resolve({
+      sessionId: latestNativeSessionId(),
+      state: "paused",
+      positionSeconds: 23.5,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      fallbackReason: null,
+      lanes: [],
+      bufferHealth: [],
+    });
+    await flushMicrotasks();
+    expect(readPlaybackE2ETelemetry()).toMatchObject({
+      activePath: "none",
+      positionSeconds: 0,
+      transportState: "stopped",
+    });
+    expect(invokeCalls("audio_play")).toHaveLength(1);
+    stopDeferred.resolve({
+      sessionId: latestNativeSessionId(),
+      state: "stopped",
+      positionSeconds: 0,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      fallbackReason: null,
+      lanes: [],
+      bufferHealth: [],
+    });
+    await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(2));
+    expect(audioPlayStartTime(1)).toBe(0);
+    await waitFor(() =>
+      expect(readPlaybackE2ETelemetry()).toMatchObject({
+        activePath: "native",
+        positionSeconds: 0,
+        transportState: "playing",
+      }),
+    );
+    if (originalInvoke) {
+      invoke.mockImplementation(originalInvoke);
+    }
+    restoreTauriRuntime();
+  });
+
+  it("ignores stale native play completion after stop", async () => {
+    const restoreTauriRuntime = enableNativePlayback();
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    setPlaybackPosition("18.75");
+
+    const playDeferred = createDeferred({
+      sessionId: "proj_123:art_source",
+      state: "playing",
+      positionSeconds: 18.75,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      fallbackReason: null,
+      lanes: [],
+      bufferHealth: [],
+    });
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation();
+    invoke.mockImplementation(async (command, args) => {
+      if (command === "audio_play") {
+        return playDeferred.promise;
+      }
+      if (!originalInvoke) {
+        throw new Error(`Unhandled invoke command ${command}`);
+      }
+      return originalInvoke(command, args);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(1));
+    expect(audioPlayStartTime()).toBeCloseTo(18.75, 3);
+
+    await user.click(screen.getByRole("button", { name: "Stop playback" }));
+    await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(1));
+    await waitFor(() =>
+      expect(readPlaybackE2ETelemetry()).toMatchObject({
+        activePath: "none",
+        positionSeconds: 0,
+        transportState: "stopped",
+      }),
+    );
+
+    playDeferred.resolve({
+      sessionId: latestNativeSessionId(),
+      state: "playing",
+      positionSeconds: 18.75,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      fallbackReason: null,
+      lanes: [],
+      bufferHealth: [],
+    });
+    await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(2));
+    expect(readPlaybackE2ETelemetry()).toMatchObject({
+      activePath: "none",
+      positionSeconds: 0,
+      transportState: "stopped",
+    });
+    expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+    if (originalInvoke) {
+      invoke.mockImplementation(originalInvoke);
+    }
+    restoreTauriRuntime();
+  });
+
+  it("does not stop newer native replay when stale play completes", async () => {
+    const restoreTauriRuntime = enableNativePlayback();
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    setPlaybackPosition("18.75");
+
+    const firstPlayDeferred = createDeferred({
+      sessionId: "proj_123:art_source",
+      state: "playing",
+      positionSeconds: 18.75,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      fallbackReason: null,
+      lanes: [],
+      bufferHealth: [],
+    });
+    const secondPlayDeferred = createDeferred({
+      sessionId: "proj_123:art_source",
+      state: "playing",
+      positionSeconds: 0,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      fallbackReason: null,
+      lanes: [],
+      bufferHealth: [],
+    });
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation();
+    invoke.mockImplementation(async (command, args) => {
+      if (command === "audio_play") {
+        return invokeCalls("audio_play").length === 1
+          ? firstPlayDeferred.promise
+          : secondPlayDeferred.promise;
+      }
+      if (!originalInvoke) {
+        throw new Error(`Unhandled invoke command ${command}`);
+      }
+      return originalInvoke(command, args);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(1));
+    expect(audioPlayStartTime()).toBeCloseTo(18.75, 3);
+
+    await user.click(screen.getByRole("button", { name: "Stop playback" }));
+    await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(1));
+    await waitFor(() =>
+      expect(readPlaybackE2ETelemetry()).toMatchObject({
+        activePath: "none",
+        positionSeconds: 0,
+        transportState: "stopped",
+      }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(2));
+    expect(audioPlayStartTime(1)).toBe(0);
+    secondPlayDeferred.resolve({
+      sessionId: latestNativeSessionId(),
+      state: "playing",
+      positionSeconds: 0,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      fallbackReason: null,
+      lanes: [],
+      bufferHealth: [],
+    });
+    firstPlayDeferred.resolve({
+      sessionId: latestNativeSessionId(),
+      state: "playing",
+      positionSeconds: 18.75,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      fallbackReason: null,
+      lanes: [],
+      bufferHealth: [],
+    });
+    await waitFor(() =>
+      expect(readPlaybackE2ETelemetry()).toMatchObject({
+        activePath: "native",
+        positionSeconds: 0,
+        transportState: "playing",
+      }),
+    );
+    expect(invokeCalls("audio_stop")).toHaveLength(1);
+    expect(readPlaybackE2ETelemetry()).toMatchObject({
+      activePath: "native",
+      positionSeconds: 0,
+      transportState: "playing",
+    });
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+    if (originalInvoke) {
+      invoke.mockImplementation(originalInvoke);
+    }
+    restoreTauriRuntime();
+  });
+
+  it("ignores stale native play failure after newer replay starts", async () => {
+    const restoreTauriRuntime = enableNativePlayback();
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    setPlaybackPosition("18.75");
+
+    const firstPlayDeferred = createDeferred({
+      sessionId: "proj_123:art_source",
+      state: "playing",
+      positionSeconds: 18.75,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      fallbackReason: null,
+      lanes: [],
+      bufferHealth: [],
+    });
+    const secondPlayDeferred = createDeferred({
+      sessionId: "proj_123:art_source",
+      state: "playing",
+      positionSeconds: 0,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      fallbackReason: null,
+      lanes: [],
+      bufferHealth: [],
+    });
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation();
+    invoke.mockImplementation(async (command, args) => {
+      if (command === "audio_play") {
+        return invokeCalls("audio_play").length === 1
+          ? firstPlayDeferred.promise
+          : secondPlayDeferred.promise;
+      }
+      if (!originalInvoke) {
+        throw new Error(`Unhandled invoke command ${command}`);
+      }
+      return originalInvoke(command, args);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(1));
+
+    await user.click(screen.getByRole("button", { name: "Stop playback" }));
+    await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(1));
+    await waitFor(() =>
+      expect(readPlaybackE2ETelemetry()).toMatchObject({
+        activePath: "none",
+        positionSeconds: 0,
+        transportState: "stopped",
+      }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(2));
+    secondPlayDeferred.resolve({
+      sessionId: latestNativeSessionId(),
+      state: "playing",
+      positionSeconds: 0,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      fallbackReason: null,
+      lanes: [],
+      bufferHealth: [],
+    });
+    await waitFor(() =>
+      expect(readPlaybackE2ETelemetry()).toMatchObject({
+        activePath: "native",
+        positionSeconds: 0,
+        transportState: "playing",
+      }),
+    );
+
+    firstPlayDeferred.reject(new Error("stale native play failed"));
+    await flushMicrotasks();
+    expect(invokeCalls("audio_stop")).toHaveLength(1);
+    expect(readPlaybackE2ETelemetry()).toMatchObject({
+      activePath: "native",
+      positionSeconds: 0,
+      transportState: "playing",
+    });
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+    if (originalInvoke) {
+      invoke.mockImplementation(originalInvoke);
+    }
+    restoreTauriRuntime();
+  });
+
+  it("does not stop pending newer native replay when stale play completes", async () => {
+    const restoreTauriRuntime = enableNativePlayback();
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    setPlaybackPosition("18.75");
+
+    const firstPlayDeferred = createDeferred({
+      sessionId: "proj_123:art_source",
+      state: "playing",
+      positionSeconds: 18.75,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      fallbackReason: null,
+      lanes: [],
+      bufferHealth: [],
+    });
+    const secondPlayDeferred = createDeferred({
+      sessionId: "proj_123:art_source",
+      state: "playing",
+      positionSeconds: 0,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      fallbackReason: null,
+      lanes: [],
+      bufferHealth: [],
+    });
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation();
+    invoke.mockImplementation(async (command, args) => {
+      if (command === "audio_play") {
+        return invokeCalls("audio_play").length === 1
+          ? firstPlayDeferred.promise
+          : secondPlayDeferred.promise;
+      }
+      if (!originalInvoke) {
+        throw new Error(`Unhandled invoke command ${command}`);
+      }
+      return originalInvoke(command, args);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(1));
+
+    await user.click(screen.getByRole("button", { name: "Stop playback" }));
+    await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(1));
+    await waitFor(() =>
+      expect(readPlaybackE2ETelemetry()).toMatchObject({
+        activePath: "none",
+        positionSeconds: 0,
+        transportState: "stopped",
+      }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(2));
+    expect(audioPlayStartTime(1)).toBe(0);
+
+    firstPlayDeferred.resolve({
+      sessionId: latestNativeSessionId(),
+      state: "playing",
+      positionSeconds: 18.75,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      fallbackReason: null,
+      lanes: [],
+      bufferHealth: [],
+    });
+    await flushMicrotasks();
+    expect(invokeCalls("audio_stop")).toHaveLength(1);
+    expect(readPlaybackE2ETelemetry()).toMatchObject({
+      activePath: "none",
+      positionSeconds: 0,
+      transportState: "stopped",
+    });
+
+    secondPlayDeferred.resolve({
+      sessionId: latestNativeSessionId(),
+      state: "playing",
+      positionSeconds: 0,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      fallbackReason: null,
+      lanes: [],
+      bufferHealth: [],
+    });
+    await waitFor(() =>
+      expect(readPlaybackE2ETelemetry()).toMatchObject({
+        activePath: "native",
+        positionSeconds: 0,
+        transportState: "playing",
+      }),
+    );
+    expect(invokeCalls("audio_stop")).toHaveLength(1);
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+    if (originalInvoke) {
+      invoke.mockImplementation(originalInvoke);
+    }
+    restoreTauriRuntime();
+  });
+
+  it("stops stale native play if pending newer replay fails", async () => {
+    const restoreTauriRuntime = enableNativePlayback();
+    const user = userEvent.setup();
+    setupTempoAnalysis();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    setPlaybackPosition("18.75");
+
+    const firstPlayDeferred = createDeferred({
+      sessionId: "proj_123:art_source",
+      state: "playing",
+      positionSeconds: 18.75,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      fallbackReason: null,
+      lanes: [],
+      bufferHealth: [],
+    });
+    const secondPlayDeferred = createDeferred({
+      sessionId: "proj_123:art_source",
+      state: "playing",
+      positionSeconds: 0,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      fallbackReason: null,
+      lanes: [],
+      bufferHealth: [],
+    });
+    const invoke = getMockInvoke();
+    const originalInvoke = invoke.getMockImplementation();
+    invoke.mockImplementation(async (command, args) => {
+      if (command === "audio_play") {
+        return invokeCalls("audio_play").length === 1
+          ? firstPlayDeferred.promise
+          : secondPlayDeferred.promise;
+      }
+      if (!originalInvoke) {
+        throw new Error(`Unhandled invoke command ${command}`);
+      }
+      return originalInvoke(command, args);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(1));
+
+    await user.click(screen.getByRole("button", { name: "Stop playback" }));
+    await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(1));
+    await waitFor(() =>
+      expect(readPlaybackE2ETelemetry()).toMatchObject({
+        activePath: "none",
+        positionSeconds: 0,
+        transportState: "stopped",
+      }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(2));
+
+    firstPlayDeferred.resolve({
+      sessionId: latestNativeSessionId(),
+      state: "playing",
+      positionSeconds: 18.75,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      fallbackReason: null,
+      lanes: [],
+      bufferHealth: [],
+    });
+    await flushMicrotasks();
+    expect(invokeCalls("audio_stop")).toHaveLength(1);
+
+    secondPlayDeferred.reject(new Error("native play failed"));
+    await waitFor(() => expect(invokeCalls("audio_stop")).toHaveLength(2));
+    expect(readPlaybackE2ETelemetry()).toMatchObject({
+      activePath: "none",
+      positionSeconds: 0,
+      transportState: "stopped",
+    });
+    expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+    if (originalInvoke) {
+      invoke.mockImplementation(originalInvoke);
+    }
     restoreTauriRuntime();
   });
 

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -82,9 +82,14 @@ import {
   useWebPlaybackWakeLock,
   type PlaybackControlBackend,
 } from "./playbackEffects";
-import { PRECOUNT_START_DELAY_SECONDS, schedulePrecountClaveClick } from "./precountSound";
+import {
+  PRECOUNT_START_DELAY_SECONDS,
+  schedulePrecountClaveClick,
+  type PrecountClaveClickHandle,
+} from "./precountSound";
 
 type ActivePrecount = {
+  clickHandles: PrecountClaveClickHandle[];
   context: AudioContext;
   ownsContext: boolean;
   sequence: number;
@@ -343,6 +348,13 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     playbackSignature: null,
   });
   const nativeStopPromiseRef = useRef<Promise<void> | null>(null);
+  const nativeControlGenerationRef = useRef(0);
+  const pendingNativePlayRef = useRef<{
+    generation: number;
+    sessionSignature: string;
+    playbackSignature: string;
+    stopOnFailure: boolean;
+  } | null>(null);
   const nativeCapabilitiesPromiseRef = useRef<ReturnType<typeof getNativeAudioCapabilities> | null>(null);
   const webMediaSourcesEnabledRef = useRef(initialWebMediaSourcesEnabled);
   const pendingTransitionRef = useRef<PendingTransition | null>(null);
@@ -600,6 +612,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   });
 
   const requestNativeStop = useStableCallback(function requestNativeStop() {
+    nativeControlGenerationRef.current += 1;
     const stopTelemetryGeneration = playbackTelemetryGenerationRef.current;
     const stoppedSessionSignature = nativePlaybackRef.current.sessionSignature;
     const stopPromise = stopNativeAudio()
@@ -644,6 +657,12 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     }
     const sessionSignature = nativeSessionSignature(targetSession);
     const lanes = nativeLaneRequestsForSession(targetSession);
+    if (
+      nativeStopPromiseRef.current &&
+      nativePlaybackRef.current.sessionSignature === sessionSignature
+    ) {
+      await nativeStopPromiseRef.current;
+    }
     if (nativePlaybackRef.current.sessionSignature === sessionSignature) {
       const snapshot = await setNativeAudioLanes(nativeLaneUpdateForSession(targetSession));
       recordNativeSnapshot(snapshot);
@@ -757,6 +776,11 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     const wasNativeActive =
       nativePlaybackRef.current.active &&
       nativePlaybackRef.current.sessionSignature === sessionSignature;
+    let playAttempt: {
+      generation: number;
+      sessionSignature: string;
+      playbackSignature: string;
+    } | null = null;
     try {
       if (!(await ensureNativePlaybackSession(targetSession))) {
         clearPlaybackControlBackend();
@@ -779,14 +803,78 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       }
       const lanesSnapshot = await setNativeAudioLanes(nativeLaneUpdateForSession(latestSession));
       recordNativeSnapshot(lanesSnapshot);
-      const snapshot = await playNativeAudio({
-        startTimeSeconds:
-          wasNativeActive || timeSeconds <= SEEK_TOLERANCE_SECONDS
+      const playGeneration = nativeControlGenerationRef.current + 1;
+      nativeControlGenerationRef.current = playGeneration;
+      const playPlaybackSignature = playbackSignature(latestSession);
+      playAttempt = {
+        generation: playGeneration,
+        sessionSignature,
+        playbackSignature: playPlaybackSignature,
+      };
+      pendingNativePlayRef.current = {
+        generation: playGeneration,
+        sessionSignature,
+        playbackSignature: playPlaybackSignature,
+        stopOnFailure: false,
+      };
+      let snapshot: NativeAudioSnapshot;
+      try {
+        snapshot = await playNativeAudio({
+          startTimeSeconds: wasNativeActive
             ? null
             : clampTime(timeSeconds, latestSession.durationHintSeconds || 0),
-      });
+        });
+      } catch (error) {
+        const pendingNativePlay = pendingNativePlayRef.current;
+        if (pendingNativePlay?.generation === playGeneration) {
+          pendingNativePlayRef.current = null;
+          if (pendingNativePlay.stopOnFailure) {
+            void requestNativeStop();
+          }
+        }
+        throw error;
+      }
+      if (pendingNativePlayRef.current?.generation === playGeneration) {
+        pendingNativePlayRef.current = null;
+      }
+      const currentSession = sessionRef.current;
+      if (
+        nativeControlGenerationRef.current !== playGeneration ||
+        nativePlaybackRef.current.sessionSignature !== sessionSignature ||
+        !currentSession ||
+        nativeSessionSignature(currentSession) !== sessionSignature ||
+        playbackSignature(currentSession) !== playPlaybackSignature
+      ) {
+        const newerNativePlaybackCurrent =
+          currentSession &&
+          nativePlaybackRef.current.active &&
+          nativePlaybackRef.current.sessionSignature === nativeSessionSignature(currentSession) &&
+          nativePlaybackRef.current.playbackSignature === playbackSignature(currentSession);
+        const pendingNativePlay = pendingNativePlayRef.current;
+        const newerPendingNativePlaybackCurrent =
+          currentSession &&
+          pendingNativePlay &&
+          pendingNativePlay.sessionSignature === nativeSessionSignature(currentSession) &&
+          pendingNativePlay.playbackSignature === playbackSignature(currentSession);
+        if (
+          snapshot.nativePlaybackSupported &&
+          snapshot.state === "playing" &&
+          newerPendingNativePlaybackCurrent
+        ) {
+          pendingNativePlay.stopOnFailure = true;
+        }
+        if (
+          snapshot.nativePlaybackSupported &&
+          snapshot.state === "playing" &&
+          !newerNativePlaybackCurrent &&
+          !newerPendingNativePlaybackCurrent
+        ) {
+          void requestNativeStop();
+        }
+        return true;
+      }
       nativePlaybackRef.current.active = snapshot.nativePlaybackSupported;
-      nativePlaybackRef.current.playbackSignature = playbackSignature(latestSession);
+      nativePlaybackRef.current.playbackSignature = playPlaybackSignature;
       if (!snapshot.nativePlaybackSupported) {
         recordNativeSnapshot(snapshot, {
           activePath: "none",
@@ -802,6 +890,13 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         return false;
       }
       const capabilities = await getNativeAudioCapabilityState();
+      if (
+        nativeControlGenerationRef.current !== playGeneration ||
+        nativePlaybackRef.current.sessionSignature !== sessionSignature ||
+        playbackSignature(sessionRef.current) !== playPlaybackSignature
+      ) {
+        return true;
+      }
       rememberPlaybackBackend({ backend: "native", detail: capabilities?.backend ?? null });
       clearRememberedNativePlaybackError();
       disposeStemPlaybackState();
@@ -816,6 +911,17 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       });
       return true;
     } catch (error) {
+      const currentSession = sessionRef.current;
+      if (
+        playAttempt &&
+        (nativeControlGenerationRef.current !== playAttempt.generation ||
+          nativePlaybackRef.current.sessionSignature !== playAttempt.sessionSignature ||
+          !currentSession ||
+          nativeSessionSignature(currentSession) !== playAttempt.sessionSignature ||
+          playbackSignature(currentSession) !== playAttempt.playbackSignature)
+      ) {
+        return true;
+      }
       rememberNativePlaybackError(playbackErrorMessage(error));
       nativePlaybackRef.current.blockedSessionSignature = sessionSignature;
       markNativePlaybackInactive();
@@ -920,6 +1026,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     }
 
     window.clearTimeout(activePrecount.timeoutId);
+    activePrecount.clickHandles.forEach((handle) => handle.cancel());
     if (!activePrecount.ownsContext) {
       return;
     }
@@ -1912,8 +2019,18 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
     const targetSession = sessionRef.current;
     if (nativePlaybackRef.current.active) {
+      const pauseGeneration = nativeControlGenerationRef.current + 1;
+      nativeControlGenerationRef.current = pauseGeneration;
+      const pausedSessionSignature = nativePlaybackRef.current.sessionSignature;
       void pauseNativeAudio()
         .then((snapshot) => {
+          if (
+            nativeControlGenerationRef.current !== pauseGeneration ||
+            nativePlaybackRef.current.sessionSignature !== pausedSessionSignature ||
+            playbackControlBackendRef.current !== "native"
+          ) {
+            return;
+          }
           recordNativeSnapshot(snapshot, {
             activePath: "native",
             transportState: "paused",
@@ -2146,11 +2263,14 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       tempoBpm,
     };
     let nextClickTimeSeconds = firstClickTimeSeconds;
+    const clickHandles: PrecountClaveClickHandle[] = [];
     for (let index = 0; index < clickCount; index += 1) {
-      schedulePrecountClaveClick({
-        audioContext: precountAudio.context,
-        startTimeSeconds: nextClickTimeSeconds,
-      });
+      clickHandles.push(
+        schedulePrecountClaveClick({
+          audioContext: precountAudio.context,
+          startTimeSeconds: nextClickTimeSeconds,
+        }),
+      );
       nextClickTimeSeconds += countInIntervals[index] ?? beatSeconds;
     }
 
@@ -2182,6 +2302,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     }, Math.max(0, (playbackStartTimeSeconds - precountAudio.context.currentTime) * 1000));
 
     activePrecountRef.current = {
+      clickHandles,
       context: precountAudio.context,
       ownsContext: precountAudio.ownsContext,
       sequence,
@@ -2256,8 +2377,17 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     }
 
     if (nativePlaybackRef.current.active) {
+      const seekGeneration = nativeControlGenerationRef.current + 1;
+      nativeControlGenerationRef.current = seekGeneration;
+      const seekSessionSignature = nativePlaybackRef.current.sessionSignature;
       void seekNativeAudio({ timeSeconds: nextTime })
         .then((snapshot) => {
+          if (
+            nativeControlGenerationRef.current !== seekGeneration ||
+            nativePlaybackRef.current.sessionSignature !== seekSessionSignature
+          ) {
+            return;
+          }
           recordNativeSnapshot(snapshot, {
             activePath: "native",
             transportState: snapshot.state,
@@ -2265,6 +2395,12 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           setPlaybackTimeSeconds(snapshot.positionSeconds);
         })
         .catch(() => {
+          if (
+            nativeControlGenerationRef.current !== seekGeneration ||
+            nativePlaybackRef.current.sessionSignature !== seekSessionSignature
+          ) {
+            return;
+          }
           markNativePlaybackInactive();
           clearPlaybackControlBackend();
         });
@@ -2319,7 +2455,15 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     clearPendingTransition();
     const targetSession = sessionRef.current;
     const resetTime = playbackResetTimeForSession(targetSession);
-    if (nativePlaybackRef.current.active) {
+    const targetNativeSessionSignature = targetSession
+      ? nativeSessionSignature(targetSession)
+      : null;
+    const shouldStopNativeSession =
+      nativePlaybackRef.current.active ||
+      (nativePlaybackRef.current.sessionSignature !== null &&
+        (targetNativeSessionSignature === null ||
+          nativePlaybackRef.current.sessionSignature === targetNativeSessionSignature));
+    if (shouldStopNativeSession) {
       void requestNativeStop();
       markNativePlaybackInactive();
     }

--- a/apps/desktop/src/features/projects/precountSound.ts
+++ b/apps/desktop/src/features/projects/precountSound.ts
@@ -5,18 +5,40 @@ const PRECOUNT_CLICK_ATTACK_SECONDS = 0.002;
 const PRECOUNT_CLICK_DURATION_SECONDS = 0.045;
 const PRECOUNT_STOP_TAIL_SECONDS = 0.004;
 
+export type PrecountClaveClickHandle = {
+  cancel: () => void;
+};
+
+function disconnectAudioNode(node: AudioNode) {
+  try {
+    node.disconnect();
+  } catch {
+    // Node may already be disconnected by the audio engine.
+  }
+}
+
 export function schedulePrecountClaveClick({
   audioContext,
   startTimeSeconds,
 }: {
   audioContext: AudioContext;
   startTimeSeconds: number;
-}) {
+}): PrecountClaveClickHandle {
   const oscillator = audioContext.createOscillator();
   const gainNode = audioContext.createGain();
   const safeStartTimeSeconds = Math.max(audioContext.currentTime, startTimeSeconds);
   const peakTimeSeconds = safeStartTimeSeconds + PRECOUNT_CLICK_ATTACK_SECONDS;
   const stopTimeSeconds = safeStartTimeSeconds + PRECOUNT_CLICK_DURATION_SECONDS;
+  let disconnected = false;
+
+  const disconnectNodes = () => {
+    if (disconnected) {
+      return;
+    }
+    disconnected = true;
+    disconnectAudioNode(oscillator);
+    disconnectAudioNode(gainNode);
+  };
 
   oscillator.type = "square";
   oscillator.frequency.setValueAtTime(PRECOUNT_FREQUENCY_HZ, safeStartTimeSeconds);
@@ -27,9 +49,18 @@ export function schedulePrecountClaveClick({
   oscillator.connect(gainNode);
   gainNode.connect(audioContext.destination);
   oscillator.onended = () => {
-    oscillator.disconnect();
-    gainNode.disconnect();
+    disconnectNodes();
   };
   oscillator.start(safeStartTimeSeconds);
   oscillator.stop(stopTimeSeconds + PRECOUNT_STOP_TAIL_SECONDS);
+  return {
+    cancel: () => {
+      try {
+        oscillator.stop(audioContext.currentTime);
+      } catch {
+        // If the browser already ended the oscillator, disconnect still silences the route.
+      }
+      disconnectNodes();
+    },
+  };
 }

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -2693,6 +2693,7 @@ export function getMockAudioContexts() {
           setSamples: (samples: Float32Array | null) => void;
         }>;
         createdOscillators: Array<{
+          disconnect: ReturnType<typeof vi.fn>;
           frequency: {
             setValueAtTime: ReturnType<typeof vi.fn>;
           };


### PR DESCRIPTION
## Summary

- Reset native playback cleanly when Stop follows pause or pending native start.
- Cancel scheduled pre-count clicks when Stop is pressed, including loop pre-counts.
- Add regression coverage for native stop/replay races and count-in cancellation.

Closes #227

## Testing

- `pnpm --filter @tuneforge/desktop test -- App.project-media-controls.test.tsx App.project-tempo.test.tsx App.project-precount.test.tsx App.tools-metronome.test.tsx --run`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- Manual E2E and playback/count-in validation passed.
