### PR TITLE
feat: add stem signal detection helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ apps/desktop/src-tauri/gen/
 
 # Generated / local data
 packages/shared-types/openapi.json
+stem-waveforms/
 data/
 *.sqlite3
 *.db

--- a/apps/backend/app/engines/stem_signal.py
+++ b/apps/backend/app/engines/stem_signal.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+
+PEAK_THRESHOLD = 1e-3
+RMS_THRESHOLD = 5e-5
+ACTIVE_DURATION_THRESHOLD_SECONDS = 0.20
+ANALYSIS_WINDOW_SECONDS = 0.05
+
+
+@dataclass(frozen=True)
+class StemSignalSummary:
+    has_signal: bool
+    peak: float
+    rms: float
+    active_duration_seconds: float
+    inspected_duration_seconds: float
+    sample_rate: int = 0
+    channels: int = 0
+
+
+def inspect_stem_signal(
+    path: Path,
+    *,
+    max_duration_seconds: float | None = None,
+) -> StemSignalSummary:
+    if max_duration_seconds is not None and (
+        not math.isfinite(max_duration_seconds) or max_duration_seconds < 0.0
+    ):
+        raise ValueError("max_duration_seconds must be finite and non-negative.")
+
+    with sf.SoundFile(path, mode="r") as audio:
+        sample_rate = int(audio.samplerate)
+        channels = int(audio.channels)
+        max_frames = None if max_duration_seconds is None else int(max_duration_seconds * sample_rate)
+        window_frames = max(1, int(round(sample_rate * ANALYSIS_WINDOW_SECONDS)))
+
+        peak = 0.0
+        square_sum = 0.0
+        inspected_frames = 0
+        active_frames = 0
+        remaining_frames = max_frames
+
+        while remaining_frames is None or remaining_frames > 0:
+            frames_to_read = window_frames if remaining_frames is None else min(window_frames, remaining_frames)
+            block = audio.read(frames_to_read, dtype="float32", always_2d=True)
+            frame_count = int(block.shape[0])
+            if frame_count == 0:
+                break
+
+            frame_magnitudes = np.max(np.abs(block), axis=1).astype(np.float64, copy=False)
+            window_peak = float(np.max(frame_magnitudes))
+            window_square_sum = float(np.sum(frame_magnitudes * frame_magnitudes))
+            window_rms = math.sqrt(window_square_sum / frame_count)
+
+            peak = max(peak, window_peak)
+            square_sum += window_square_sum
+            inspected_frames += frame_count
+            if window_peak >= PEAK_THRESHOLD and window_rms >= RMS_THRESHOLD:
+                active_frames += int(np.count_nonzero(frame_magnitudes >= RMS_THRESHOLD))
+
+            if remaining_frames is not None:
+                remaining_frames -= frame_count
+
+    rms = math.sqrt(square_sum / inspected_frames) if inspected_frames > 0 else 0.0
+    active_duration_seconds = active_frames / sample_rate if inspected_frames > 0 else 0.0
+    inspected_duration_seconds = inspected_frames / sample_rate if inspected_frames > 0 else 0.0
+    has_signal = (
+        peak >= PEAK_THRESHOLD
+        and rms >= RMS_THRESHOLD
+        and active_duration_seconds >= ACTIVE_DURATION_THRESHOLD_SECONDS
+    )
+
+    return StemSignalSummary(
+        has_signal=has_signal,
+        peak=peak,
+        rms=rms,
+        active_duration_seconds=active_duration_seconds,
+        inspected_duration_seconds=inspected_duration_seconds,
+        sample_rate=sample_rate,
+        channels=channels,
+    )

--- a/apps/backend/tests/test_stem_signal.py
+++ b/apps/backend/tests/test_stem_signal.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from app.engines.stem_signal import inspect_stem_signal
+
+SAMPLE_RATE = 44_100
+
+
+def test_silent_wav_has_no_stem_signal(tmp_path: Path):
+    path = _write_wav(tmp_path, "silence.wav", np.zeros(SAMPLE_RATE, dtype=np.float32))
+
+    summary = inspect_stem_signal(path)
+
+    assert _has_signal(summary) is False
+    assert _float_metric(summary, "peak") == pytest.approx(0.0)
+    assert _float_metric(summary, "rms") == pytest.approx(0.0)
+    assert _float_metric(summary, "active_duration_seconds") == pytest.approx(0.0)
+    assert _float_metric(summary, "inspected_duration_seconds") == pytest.approx(1.0)
+
+
+def test_near_silent_low_amplitude_wav_has_no_stem_signal(tmp_path: Path):
+    path = _write_wav(tmp_path, "near_silence.wav", _tone(duration_seconds=1.0, amplitude=2e-5))
+
+    summary = inspect_stem_signal(path)
+
+    assert _has_signal(summary) is False
+    assert 0.0 < _float_metric(summary, "peak") < 1e-3
+    assert 0.0 < _float_metric(summary, "rms") < 5e-5
+    assert _float_metric(summary, "inspected_duration_seconds") == pytest.approx(1.0)
+
+
+def test_short_transient_above_peak_is_not_enough_signal(tmp_path: Path):
+    signal = np.zeros(SAMPLE_RATE, dtype=np.float32)
+    signal[SAMPLE_RATE // 2] = 0.75
+    path = _write_wav(tmp_path, "click.wav", signal)
+
+    summary = inspect_stem_signal(path)
+
+    assert _has_signal(summary) is False
+    assert _float_metric(summary, "peak") > 0.5
+    assert _float_metric(summary, "active_duration_seconds") < 0.20
+    assert _float_metric(summary, "inspected_duration_seconds") == pytest.approx(1.0)
+
+
+def test_repeated_sparse_clicks_do_not_accumulate_window_duration(tmp_path: Path):
+    signal = np.zeros(SAMPLE_RATE, dtype=np.float32)
+    window_frames = int(SAMPLE_RATE * 0.05)
+    signal[[window_frames * index for index in range(4)]] = 0.05
+    path = _write_wav(tmp_path, "repeated_clicks.wav", signal)
+
+    summary = inspect_stem_signal(path)
+
+    assert _has_signal(summary) is False
+    assert _float_metric(summary, "peak") >= 1e-3
+    assert _float_metric(summary, "rms") >= 5e-5
+    assert _float_metric(summary, "active_duration_seconds") < 0.01
+    assert _float_metric(summary, "inspected_duration_seconds") == pytest.approx(1.0)
+
+
+def test_usable_mono_tone_has_stem_signal(tmp_path: Path):
+    path = _write_wav(tmp_path, "mono_tone.wav", _tone(duration_seconds=1.0, amplitude=0.2))
+
+    summary = inspect_stem_signal(path)
+
+    assert _has_signal(summary) is True
+    assert _float_metric(summary, "peak") > 0.15
+    assert _float_metric(summary, "rms") > 0.10
+    assert _float_metric(summary, "active_duration_seconds") >= 0.20
+    assert _float_metric(summary, "inspected_duration_seconds") == pytest.approx(1.0)
+
+
+def test_phase_opposed_stereo_tone_has_stem_signal(tmp_path: Path):
+    mono = _tone(duration_seconds=1.0, amplitude=0.2)
+    stereo = np.column_stack([mono, -mono])
+    path = _write_wav(tmp_path, "phase_opposed_stereo.wav", stereo)
+
+    summary = inspect_stem_signal(path)
+
+    assert _has_signal(summary) is True
+    assert _float_metric(summary, "peak") > 0.15
+    assert _float_metric(summary, "rms") > 0.10
+    assert _float_metric(summary, "active_duration_seconds") >= 0.20
+
+
+def test_max_duration_seconds_limits_inspected_duration(tmp_path: Path):
+    path = _write_wav(tmp_path, "long_tone.wav", _tone(duration_seconds=2.0, amplitude=0.2))
+
+    full_summary = inspect_stem_signal(path)
+    limited_summary = inspect_stem_signal(path, max_duration_seconds=0.25)
+
+    assert _float_metric(full_summary, "inspected_duration_seconds") == pytest.approx(2.0)
+    assert _float_metric(limited_summary, "inspected_duration_seconds") == pytest.approx(0.25)
+    assert _float_metric(limited_summary, "inspected_duration_seconds") < _float_metric(
+        full_summary,
+        "inspected_duration_seconds",
+    )
+    assert _float_metric(limited_summary, "active_duration_seconds") <= _float_metric(
+        limited_summary,
+        "inspected_duration_seconds",
+    )
+
+
+def _tone(
+    *,
+    duration_seconds: float,
+    amplitude: float,
+    frequency_hz: float = 440.0,
+) -> np.ndarray:
+    timeline = np.linspace(0.0, duration_seconds, int(SAMPLE_RATE * duration_seconds), endpoint=False)
+    return (amplitude * np.sin(2 * np.pi * frequency_hz * timeline)).astype(np.float32)
+
+
+def _write_wav(tmp_path: Path, filename: str, signal: np.ndarray) -> Path:
+    path = tmp_path / filename
+    sf.write(path, signal.astype(np.float32), SAMPLE_RATE, subtype="FLOAT")
+    return path
+
+
+def _has_signal(summary: object) -> bool:
+    return bool(_metric(summary, "has_signal"))
+
+
+def _float_metric(summary: object, name: str) -> float:
+    return float(_metric(summary, name))
+
+
+def _metric(summary: object, name: str) -> object:
+    if isinstance(summary, Mapping):
+        return summary[name]
+    return getattr(summary, name)

--- a/apps/backend/tests/test_stem_waveforms_script.py
+++ b/apps/backend/tests/test_stem_waveforms_script.py
@@ -1,0 +1,444 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import re
+import sqlite3
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = BACKEND_ROOT.parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "stem-waveforms.py"
+SAMPLE_RATE = 8_000
+STEM_ARTIFACT_TYPES = {
+    "vocals": "vocal_stem",
+    "instrumental": "instrumental_stem",
+    "drums": "drums_stem",
+    "bass": "bass_stem",
+    "guitar": "guitar_stem",
+    "piano": "piano_stem",
+    "other": "other_stem",
+}
+
+
+@dataclass(frozen=True)
+class StemFixture:
+    name: str
+    amplitude: float
+
+
+@dataclass(frozen=True)
+class ProjectFixture:
+    title: str
+    seed: str
+    stems: tuple[StemFixture, ...]
+
+    @property
+    def project_id(self) -> str:
+        return f"proj_sha256_{hashlib.sha256(self.seed.encode()).hexdigest()}"
+
+    @property
+    def storage_key(self) -> str:
+        return f"proj_{self.project_id.removeprefix('proj_sha256_')[:24]}"
+
+
+def test_stem_waveforms_writes_svg_summary_without_touching_data_dir(tmp_path: Path):
+    project = ProjectFixture(
+        title="Loud Project",
+        seed="loud-project",
+        stems=(
+            StemFixture("drums", 0.7),
+            StemFixture("bass", 0.0),
+        ),
+    )
+    data_dir = _create_data_dir(tmp_path, [project])
+    output_dir = tmp_path / "waveforms"
+    before = _snapshot_files(data_dir)
+
+    result = _run_script(data_dir=data_dir, output_dir=output_dir, width=360)
+
+    assert _snapshot_files(data_dir) == before
+    summary = _json_stdout(result)
+    assert summary["projects_written"] == 1
+    assert summary["stems_scanned"] == 2
+    assert summary["thresholds"]["peak"] == pytest.approx(0.001)
+    assert summary["thresholds"]["rms"] == pytest.approx(0.00005)
+
+    svg = _read_one_svg(output_dir)
+    assert project.title in svg
+    assert "drums" in svg
+    assert "bass" in svg
+    _assert_label_status(svg, label="drums", status="PASS")
+    _assert_label_status(svg, label="bass", status="NO SIGNAL")
+    _assert_contains_any(svg, ("peak", "rms", "active"), description="threshold labels")
+    _assert_contains_any(svg, ("0.001", "1e-03", "1.0e-03"), description="peak threshold")
+    _assert_contains_any(svg, ("0.00005", "5e-05", "5.0e-05"), description="rms threshold")
+    _assert_contains_any(svg, ("0.20", "0.2"), description="active-duration threshold")
+
+
+def test_project_id_filter_is_repeatable_and_limits_output_to_selected_storage_keys(tmp_path: Path):
+    selected_drums = ProjectFixture(
+        title="Selected Drums",
+        seed="selected-drums",
+        stems=(StemFixture("drums", 0.6),),
+    )
+    selected_vocals = ProjectFixture(
+        title="Selected Vocals",
+        seed="selected-vocals",
+        stems=(StemFixture("vocals", 0.5),),
+    )
+    excluded = ProjectFixture(
+        title="Excluded Bass",
+        seed="excluded-bass",
+        stems=(StemFixture("bass", 0.6),),
+    )
+    data_dir = _create_data_dir(tmp_path, [selected_drums, selected_vocals, excluded])
+    output_dir = tmp_path / "filtered-waveforms"
+    before = _snapshot_files(data_dir)
+
+    result = _run_script(
+        data_dir=data_dir,
+        output_dir=output_dir,
+        project_ids=(selected_drums.project_id, selected_vocals.project_id),
+        width=280,
+    )
+
+    assert _snapshot_files(data_dir) == before
+    summary = _json_stdout(result)
+    assert summary["projects_written"] == 2
+    assert summary["stems_scanned"] == 2
+
+    svgs = sorted(output_dir.glob("*.svg"))
+    assert len(svgs) == 2
+    combined_svg = "\n".join(path.read_text() for path in svgs)
+    assert selected_drums.title in combined_svg
+    assert selected_vocals.title in combined_svg
+    assert excluded.title not in combined_svg
+    assert not any(excluded.storage_key in path.stem for path in svgs)
+
+
+def test_stem_waveforms_ignores_orphan_wavs_not_registered_as_artifacts(tmp_path: Path):
+    project = ProjectFixture(
+        title="Registered Only",
+        seed="registered-only",
+        stems=(StemFixture("drums", 0.7),),
+    )
+    data_dir = _create_data_dir(tmp_path, [project])
+    orphan_path = (
+        data_dir
+        / "projects"
+        / project.storage_key
+        / "stems"
+        / "orphan-source"
+        / "htdemucs"
+        / "orphan-stemset"
+        / "vocals.wav"
+    )
+    orphan_path.parent.mkdir(parents=True)
+    _write_wav(orphan_path, 0.8)
+    output_dir = tmp_path / "registered-waveforms"
+    before = _snapshot_files(data_dir)
+
+    result = _run_script(data_dir=data_dir, output_dir=output_dir, width=240)
+
+    assert _snapshot_files(data_dir) == before
+    summary = _json_stdout(result)
+    assert summary["projects_written"] == 1
+    assert summary["stems_scanned"] == 1
+    svg = _read_one_svg(output_dir)
+    assert "drums" in svg
+    assert "vocals" not in svg
+
+
+def test_analyze_stem_width_one_reads_bounded_chunks(monkeypatch: pytest.MonkeyPatch):
+    module = _load_script_module()
+    fake_audio = _FakeSoundFile(total_frames=SAMPLE_RATE * 10)
+
+    monkeypatch.setattr(module.sf, "SoundFile", lambda *_args, **_kwargs: fake_audio)
+
+    metrics = module.analyze_stem(
+        Path("registered.wav"),
+        width=1,
+        thresholds=module.Thresholds(
+            peak=0.001,
+            rms=0.00005,
+            active_duration=0.0,
+            window_seconds=0.05,
+        ),
+    )
+
+    assert metrics.inspected_duration_seconds == pytest.approx(10.0)
+    assert max(fake_audio.read_sizes) == SAMPLE_RATE
+    assert len(fake_audio.read_sizes) > 1
+
+
+def _create_data_dir(tmp_path: Path, projects: list[ProjectFixture]) -> Path:
+    data_dir = tmp_path / "tuneforge-data"
+    data_dir.mkdir()
+    stem_paths: dict[tuple[str, str], Path] = {}
+    for project in projects:
+        stems_dir = data_dir / "projects" / project.storage_key / "stems" / "source-fixture" / "htdemucs" / "separated"
+        stems_dir.mkdir(parents=True)
+        for stem in project.stems:
+            stem_path = stems_dir / f"{stem.name}.wav"
+            _write_wav(stem_path, stem.amplitude)
+            stem_paths[(project.project_id, stem.name)] = stem_path
+    _write_database(data_dir / "app.sqlite", projects, stem_paths)
+    return data_dir
+
+
+def _write_database(
+    path: Path,
+    projects: list[ProjectFixture],
+    stem_paths: dict[tuple[str, str], Path],
+) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE projects (
+                id TEXT PRIMARY KEY,
+                display_name TEXT NOT NULL,
+                source_key_override TEXT,
+                source_sha256 TEXT,
+                source_path TEXT NOT NULL,
+                imported_path TEXT NOT NULL,
+                duration_seconds REAL,
+                sample_rate INTEGER,
+                channels INTEGER,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                sync_status TEXT NOT NULL,
+                sync_status_reason TEXT,
+                sync_required_artifact_ids_json TEXT NOT NULL,
+                sync_provider_device_ids_json TEXT NOT NULL,
+                sync_conflict_count INTEGER NOT NULL,
+                sync_status_updated_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE artifacts (
+                id TEXT PRIMARY KEY,
+                project_id TEXT NOT NULL,
+                type TEXT NOT NULL,
+                format TEXT NOT NULL,
+                path TEXT NOT NULL,
+                metadata_json JSON NOT NULL,
+                cache_key TEXT,
+                created_at TEXT NOT NULL,
+                size_bytes INTEGER NOT NULL,
+                generated_by TEXT NOT NULL,
+                can_delete BOOLEAN NOT NULL,
+                can_regenerate BOOLEAN NOT NULL,
+                content_sha256 TEXT
+            )
+            """
+        )
+        for project in projects:
+            source_sha256 = project.project_id.removeprefix("proj_sha256_")
+            conn.execute(
+                """
+                INSERT INTO projects (
+                    id,
+                    display_name,
+                    source_key_override,
+                    source_sha256,
+                    source_path,
+                    imported_path,
+                    duration_seconds,
+                    sample_rate,
+                    channels,
+                    created_at,
+                    updated_at,
+                    sync_status,
+                    sync_status_reason,
+                    sync_required_artifact_ids_json,
+                    sync_provider_device_ids_json,
+                    sync_conflict_count,
+                    sync_status_updated_at
+                )
+                VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)
+                """,
+                (
+                    project.project_id,
+                    project.title,
+                    source_sha256,
+                    f"/fixtures/{project.storage_key}.wav",
+                    f"projects/{project.storage_key}/source.wav",
+                    0.5,
+                    SAMPLE_RATE,
+                    1,
+                    "2026-05-29T00:00:00Z",
+                    "2026-05-29T00:00:00Z",
+                    "local",
+                    "[]",
+                    "[]",
+                    0,
+                    "2026-05-29T00:00:00Z",
+                ),
+            )
+            for stem in project.stems:
+                stem_path = stem_paths[(project.project_id, stem.name)]
+                metadata = {
+                    "mode": "six_stems",
+                    "stem_model": "htdemucs",
+                    "stem_model_label": "fixture model",
+                    "stem_source": stem.name,
+                    "source_artifact_id": "source-fixture",
+                    "source_artifact_type": "source_audio",
+                }
+                conn.execute(
+                    """
+                    INSERT INTO artifacts (
+                        id,
+                        project_id,
+                        type,
+                        format,
+                        path,
+                        metadata_json,
+                        cache_key,
+                        created_at,
+                        size_bytes,
+                        generated_by,
+                        can_delete,
+                        can_regenerate,
+                        content_sha256
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        f"art_{project.storage_key}_{stem.name}",
+                        project.project_id,
+                        STEM_ARTIFACT_TYPES[stem.name],
+                        "wav",
+                        str(stem_path.resolve()),
+                        json.dumps(metadata),
+                        "2026-05-29T00:00:00Z",
+                        stem_path.stat().st_size,
+                        "demucs",
+                        1,
+                        1,
+                        hashlib.sha256(stem_path.read_bytes()).hexdigest(),
+                    ),
+                )
+
+
+def _write_wav(path: Path, amplitude: float) -> None:
+    duration_seconds = 0.5
+    if amplitude == 0.0:
+        signal = np.zeros(int(SAMPLE_RATE * duration_seconds), dtype=np.float32)
+    else:
+        timeline = np.linspace(0.0, duration_seconds, int(SAMPLE_RATE * duration_seconds), endpoint=False)
+        signal = (amplitude * np.sin(2 * np.pi * 220.0 * timeline)).astype(np.float32)
+    sf.write(path, signal, SAMPLE_RATE, subtype="FLOAT")
+
+
+def _run_script(
+    *,
+    data_dir: Path,
+    output_dir: Path,
+    project_ids: tuple[str, ...] = (),
+    width: int,
+) -> subprocess.CompletedProcess[str]:
+    assert SCRIPT_PATH.exists(), f"{SCRIPT_PATH} missing; Worker A must add script before tests can pass."
+    command = [
+        sys.executable,
+        str(SCRIPT_PATH),
+        "--data-dir",
+        str(data_dir),
+        "--output-dir",
+        str(output_dir),
+        "--width",
+        str(width),
+    ]
+    for project_id in project_ids:
+        command.extend(["--project-id", project_id])
+    return subprocess.run(
+        command,
+        cwd=BACKEND_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _snapshot_files(root: Path) -> dict[str, tuple[int, str]]:
+    snapshot: dict[str, tuple[int, str]] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+            snapshot[str(path.relative_to(root))] = (path.stat().st_size, digest)
+    return snapshot
+
+
+def _json_stdout(result: subprocess.CompletedProcess[str]) -> Any:
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(
+            f"Expected JSON stdout, got: {result.stdout!r}\nstderr: {result.stderr!r}"
+        ) from exc
+
+
+def _read_one_svg(output_dir: Path) -> str:
+    svgs = sorted(output_dir.glob("*.svg"))
+    assert len(svgs) == 1
+    return svgs[0].read_text()
+
+
+def _load_script_module() -> Any:
+    spec = importlib.util.spec_from_file_location("stem_waveforms_script", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeSoundFile:
+    def __init__(self, *, total_frames: int) -> None:
+        self.samplerate = SAMPLE_RATE
+        self.channels = 1
+        self.frames = total_frames
+        self._remaining = total_frames
+        self.read_sizes: list[int] = []
+
+    def __enter__(self) -> _FakeSoundFile:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self, frames: int, *, dtype: str, always_2d: bool) -> np.ndarray:
+        assert dtype == "float32"
+        assert always_2d is True
+        self.read_sizes.append(frames)
+        frame_count = min(frames, self._remaining)
+        self._remaining -= frame_count
+        return np.zeros((frame_count, 1), dtype=np.float32)
+
+
+def _assert_label_status(svg: str, *, label: str, status: str) -> None:
+    label_pattern = re.escape(label)
+    status_pattern = re.escape(status)
+    pattern = (
+        rf"({label_pattern}[\s\S]{{0,800}}{status_pattern})"
+        rf"|({status_pattern}[\s\S]{{0,800}}{label_pattern})"
+    )
+    assert re.search(pattern, svg, flags=re.IGNORECASE), f"Expected {label!r} row to include {status!r}."
+
+
+def _assert_contains_any(svg: str, candidates: tuple[str, ...], *, description: str) -> None:
+    normalized = svg.lower()
+    assert any(candidate.lower() in normalized for candidate in candidates), f"Missing {description}: {candidates!r}"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "package:mac:app": "pnpm --filter @tuneforge/desktop tauri build --bundles app",
     "package:mac:dmg": "node scripts/package-dmg.mjs",
     "setup:dev": "bash scripts/setup-dev.sh",
+    "stems:waveforms": "bash -c 'if [[ \"${1:-}\" == \"--\" ]]; then shift; fi; invocation_dir=\"${INIT_CWD:-$PWD}\"; cd apps/backend && uv run --python 3.11 python ../../scripts/stem-waveforms.py --output-dir \"${invocation_dir}/stem-waveforms\" \"$@\"' --",
     "sync:bundle": "bash -c 'if [[ \"${1:-}\" == \"--\" ]]; then shift; fi; exec bash scripts/run-backend-module.sh app.cli.sync_bundle \"$@\"' --",
     "sync:backend:default": "bash scripts/sync-backend-default.sh",
     "sync:backend:legacy-nvidia": "bash scripts/sync-backend-legacy-nvidia.sh",

--- a/scripts/stem-waveforms.py
+++ b/scripts/stem-waveforms.py
@@ -1,0 +1,709 @@
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import math
+import os
+import re
+import sqlite3
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from urllib.request import pathname2url
+
+import numpy as np
+import soundfile as sf
+
+PEAK_THRESHOLD = 0.001
+RMS_THRESHOLD = 0.00005
+ACTIVE_DURATION_THRESHOLD_SECONDS = 0.20
+ANALYSIS_WINDOW_SECONDS = 0.05
+DEFAULT_WIDTH = 1600
+MAX_READ_FRAMES = 65_536
+PROJECT_ID_PREFIX = "proj_sha256_"
+PROJECT_STORAGE_KEY_PREFIX = "proj_"
+PROJECT_STORAGE_HASH_LENGTH = 24
+HEX_DIGITS = frozenset("0123456789abcdef")
+STEM_ORDER = ("drums", "bass", "other", "guitar", "piano", "vocals")
+EXPECTED_STEM_SOURCES = (*STEM_ORDER, "instrumental")
+STEM_ARTIFACT_TYPE_TO_SOURCE = {
+    "vocal_stem": "vocals",
+    "instrumental_stem": "instrumental",
+    **{f"{stem_name}_stem": stem_name for stem_name in STEM_ORDER if stem_name != "vocals"},
+}
+SAFE_FILENAME_PATTERN = re.compile(r"[^a-z0-9._-]+")
+
+
+@dataclass(frozen=True)
+class Thresholds:
+    peak: float
+    rms: float
+    active_duration: float
+    window_seconds: float
+
+
+@dataclass(frozen=True)
+class ProjectInfo:
+    project_id: str
+    storage_key: str
+    display_name: str
+    duration_seconds: float | None
+
+
+@dataclass(frozen=True)
+class StemPath:
+    storage_key: str
+    artifact_id: str
+    source_artifact_id: str
+    model: str
+    stemset: str
+    stem_name: str
+    path: Path
+
+
+@dataclass(frozen=True)
+class StemMetrics:
+    has_signal: bool
+    peak: float
+    rms: float
+    active_duration_seconds: float
+    inspected_duration_seconds: float
+    sample_rate: int
+    channels: int
+    bins: list[float]
+
+
+@dataclass(frozen=True)
+class StemArtifactRow:
+    artifact_id: str
+    project_id: str
+    artifact_type: str
+    artifact_format: str
+    path: str
+    metadata: dict[str, object]
+
+
+@dataclass
+class StemsetRender:
+    source_artifact_id: str
+    model: str
+    stemset: str
+    stems: dict[str, StemMetrics] = field(default_factory=dict)
+
+
+def main() -> int:
+    start_time = time.perf_counter()
+    parser = build_parser()
+    args = parser.parse_args()
+
+    try:
+        thresholds = Thresholds(
+            peak=positive_float(args.peak_threshold, "--peak-threshold"),
+            rms=positive_float(args.rms_threshold, "--rms-threshold"),
+            active_duration=positive_float(
+                args.active_duration_threshold,
+                "--active-duration-threshold",
+                allow_zero=True,
+            ),
+            window_seconds=positive_float(args.window_seconds, "--window-seconds"),
+        )
+        width = positive_int(args.width, "--width")
+        data_dir = Path(args.data_dir).expanduser().resolve() if args.data_dir else default_data_dir()
+        output_dir = Path(args.output_dir).expanduser().resolve()
+        if is_relative_to(output_dir, data_dir):
+            raise DiagnosticError(
+                f"Output dir must be outside the TuneForge data dir: {output_dir}"
+            )
+
+        if not data_dir.is_dir():
+            raise DiagnosticError(f"Data dir not found: {data_dir}")
+        database_path = data_dir / "app.sqlite"
+        if not database_path.is_file():
+            raise DiagnosticError(f"Database not found: {database_path}")
+
+        project_info = load_project_info(database_path)
+        stem_paths = load_stem_paths(database_path, data_dir)
+        if not stem_paths:
+            raise DiagnosticError(f"No DB-registered stem WAV artifacts found in: {database_path}")
+
+        selected_keys = selected_storage_keys(args.project_id, project_info)
+        if selected_keys is not None:
+            stem_paths = [stem for stem in stem_paths if stem.storage_key in selected_keys]
+            if not stem_paths:
+                raise DiagnosticError("No stem WAV files matched selected project ids/storage keys.")
+
+        projects = group_projects(stem_paths)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        projects_written = 0
+        stems_scanned = 0
+        for storage_key, stemsets in sorted(projects.items()):
+            rendered_stemsets: list[StemsetRender] = []
+            for stemset_key, stems in sorted(stemsets.items()):
+                source_artifact_id, model, stemset = stemset_key
+                rendered = StemsetRender(
+                    source_artifact_id=source_artifact_id,
+                    model=model,
+                    stemset=stemset,
+                )
+                for stem in sorted_stems(stems):
+                    rendered.stems[stem.stem_name] = analyze_stem(
+                        stem.path,
+                        width=width,
+                        thresholds=thresholds,
+                    )
+                    stems_scanned += 1
+                rendered_stemsets.append(rendered)
+
+            info = project_info.get(storage_key)
+            project_label = info.display_name if info is not None else storage_key
+            svg = render_project_svg(
+                storage_key=storage_key,
+                project_info=info,
+                project_label=project_label,
+                stemsets=rendered_stemsets,
+                thresholds=thresholds,
+                width=width,
+            )
+            output_path = output_dir / f"{safe_slug(project_label)}-{storage_key}.svg"
+            output_path.write_text(svg, encoding="utf-8")
+            projects_written += 1
+
+        summary = {
+            "data_dir": str(data_dir),
+            "output_dir": str(output_dir),
+            "projects_written": projects_written,
+            "stems_scanned": stems_scanned,
+            "elapsed_seconds": round(time.perf_counter() - start_time, 3),
+            "thresholds": {
+                "peak": thresholds.peak,
+                "rms": thresholds.rms,
+                "active_duration_seconds": thresholds.active_duration,
+                "window_seconds": thresholds.window_seconds,
+            },
+        }
+        print(json.dumps(summary, sort_keys=True))
+        return 0
+    except DiagnosticError as error:
+        print(f"stem-waveforms: {error}", file=sys.stderr)
+        return 2
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Render read-only SVG waveform diagnostics for existing TuneForge stems.",
+    )
+    parser.add_argument("--data-dir", type=Path, default=None)
+    parser.add_argument("--output-dir", type=Path, default=Path("stem-waveforms"))
+    parser.add_argument("--project-id", action="append", default=[])
+    parser.add_argument("--peak-threshold", type=float, default=PEAK_THRESHOLD)
+    parser.add_argument("--rms-threshold", type=float, default=RMS_THRESHOLD)
+    parser.add_argument(
+        "--active-duration-threshold",
+        type=float,
+        default=ACTIVE_DURATION_THRESHOLD_SECONDS,
+    )
+    parser.add_argument("--window-seconds", type=float, default=ANALYSIS_WINDOW_SECONDS)
+    parser.add_argument("--width", type=int, default=DEFAULT_WIDTH)
+    return parser
+
+
+class DiagnosticError(Exception):
+    pass
+
+
+def positive_float(value: float, name: str, *, allow_zero: bool = False) -> float:
+    if not math.isfinite(value) or value < 0.0 or (value == 0.0 and not allow_zero):
+        qualifier = "non-negative" if allow_zero else "positive"
+        raise DiagnosticError(f"{name} must be finite and {qualifier}.")
+    return value
+
+
+def positive_int(value: int, name: str) -> int:
+    if value <= 0:
+        raise DiagnosticError(f"{name} must be positive.")
+    return value
+
+
+def default_data_dir() -> Path:
+    override = os.environ.get("TUNEFORGE_DATA_DIR")
+    if override:
+        return Path(override).expanduser().resolve()
+    home = Path.home()
+    if sys.platform == "darwin":
+        return home / "Library" / "Application Support" / "Tuneforge"
+    return home / ".local" / "share" / "tuneforge"
+
+
+def is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def load_project_info(database_path: Path) -> dict[str, ProjectInfo]:
+    uri = f"file:{pathname2url(str(database_path))}?mode=ro"
+    try:
+        with sqlite3.connect(uri, uri=True) as connection:
+            rows = connection.execute(
+                "SELECT id, display_name, duration_seconds FROM projects ORDER BY id"
+            ).fetchall()
+    except sqlite3.Error as error:
+        raise DiagnosticError(f"Could not read database in read-only mode: {error}") from error
+
+    projects: dict[str, ProjectInfo] = {}
+    for project_id, display_name, duration_seconds in rows:
+        storage_key = project_id_to_storage_key(str(project_id))
+        projects[storage_key] = ProjectInfo(
+            project_id=str(project_id),
+            storage_key=storage_key,
+            display_name=str(display_name),
+            duration_seconds=float(duration_seconds) if duration_seconds is not None else None,
+        )
+    return projects
+
+
+def load_stem_paths(database_path: Path, data_dir: Path) -> list[StemPath]:
+    projects_dir = data_dir / "projects"
+    if not projects_dir.is_dir():
+        raise DiagnosticError(f"Projects dir not found: {projects_dir}")
+
+    stems: list[StemPath] = []
+    for artifact in load_stem_artifact_rows(database_path):
+        parsed = parse_artifact_stem_path(data_dir, artifact)
+        if parsed is not None:
+            stems.append(parsed)
+    return stems
+
+
+def load_stem_artifact_rows(database_path: Path) -> list[StemArtifactRow]:
+    uri = f"file:{pathname2url(str(database_path))}?mode=ro"
+    try:
+        with sqlite3.connect(uri, uri=True) as connection:
+            rows = connection.execute(
+                """
+                SELECT id, project_id, type, format, path, metadata_json
+                FROM artifacts
+                WHERE lower(format) = 'wav'
+                ORDER BY project_id, type, id
+                """
+            ).fetchall()
+    except sqlite3.Error as error:
+        raise DiagnosticError(f"Could not read artifacts in read-only mode: {error}") from error
+
+    artifacts: list[StemArtifactRow] = []
+    for artifact_id, project_id, artifact_type, artifact_format, path, metadata_json in rows:
+        normalized_type = str(artifact_type)
+        normalized_format = str(artifact_format).lower()
+        if not is_stem_artifact_type(normalized_type) or normalized_format != "wav":
+            continue
+        artifacts.append(
+            StemArtifactRow(
+                artifact_id=str(artifact_id),
+                project_id=str(project_id),
+                artifact_type=normalized_type,
+                artifact_format=normalized_format,
+                path=str(path),
+                metadata=parse_artifact_metadata(metadata_json),
+            )
+        )
+    return artifacts
+
+
+def parse_artifact_metadata(raw_metadata: object) -> dict[str, object]:
+    if raw_metadata is None:
+        return {}
+    if isinstance(raw_metadata, bytes):
+        raw_metadata = raw_metadata.decode("utf-8", errors="replace")
+    if not isinstance(raw_metadata, str):
+        return {}
+    try:
+        parsed: object = json.loads(raw_metadata)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return {str(key): value for key, value in parsed.items()}
+
+
+def is_stem_artifact_type(artifact_type: str) -> bool:
+    return (
+        artifact_type.endswith("_stem")
+        or artifact_type in STEM_ARTIFACT_TYPE_TO_SOURCE
+        or artifact_type in EXPECTED_STEM_SOURCES
+    )
+
+
+def metadata_string(metadata: dict[str, object], key: str) -> str | None:
+    value = metadata.get(key)
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def source_from_artifact_type(artifact_type: str) -> str | None:
+    if artifact_type in STEM_ARTIFACT_TYPE_TO_SOURCE:
+        return STEM_ARTIFACT_TYPE_TO_SOURCE[artifact_type]
+    if artifact_type in EXPECTED_STEM_SOURCES:
+        return artifact_type
+    if artifact_type.endswith("_stem"):
+        source = artifact_type.removesuffix("_stem")
+        if source == "vocal":
+            return "vocals"
+        return source
+    return None
+
+
+def project_id_to_storage_key(project_id: str) -> str:
+    if not project_id.startswith(PROJECT_ID_PREFIX):
+        return project_id
+    source_sha256 = project_id.removeprefix(PROJECT_ID_PREFIX).strip().lower()
+    if len(source_sha256) != 64 or any(character not in HEX_DIGITS for character in source_sha256):
+        return project_id
+    return f"{PROJECT_STORAGE_KEY_PREFIX}{source_sha256[:PROJECT_STORAGE_HASH_LENGTH]}"
+
+
+def selected_storage_keys(
+    project_ids: list[str],
+    project_info: dict[str, ProjectInfo],
+) -> set[str] | None:
+    if not project_ids:
+        return None
+
+    by_project_id = {info.project_id: storage_key for storage_key, info in project_info.items()}
+    selected: set[str] = set()
+    for raw_project_id in project_ids:
+        project_id = raw_project_id.strip()
+        if not project_id:
+            raise DiagnosticError("--project-id cannot be empty.")
+        selected.add(project_id_to_storage_key(project_id))
+        if project_id in by_project_id:
+            selected.add(by_project_id[project_id])
+    return selected
+
+
+def parse_artifact_stem_path(data_dir: Path, artifact: StemArtifactRow) -> StemPath | None:
+    path = resolve_artifact_path(data_dir, artifact.path)
+    if not path.is_file():
+        return None
+
+    projects_dir = data_dir / "projects"
+    if not is_relative_to(path, projects_dir):
+        return None
+
+    relative = path.relative_to(projects_dir)
+    parts = relative.parts
+    if len(parts) < 5 or parts[1] != "stems":
+        return None
+
+    storage_key = project_id_to_storage_key(artifact.project_id)
+    if parts[0] != storage_key:
+        return None
+
+    after_stems = parts[2:]
+    if len(after_stems) < 3:
+        return None
+
+    source_artifact_id = metadata_string(artifact.metadata, "source_artifact_id") or after_stems[0]
+    model = metadata_string(artifact.metadata, "stem_model") or after_stems[1]
+    stemset = "/".join(after_stems[2:-1]) or "default"
+    stem_name = (
+        metadata_string(artifact.metadata, "stem_source")
+        or source_from_artifact_type(artifact.artifact_type)
+        or path.stem
+    )
+    return StemPath(
+        storage_key=storage_key,
+        artifact_id=artifact.artifact_id,
+        source_artifact_id=source_artifact_id,
+        model=model,
+        stemset=stemset,
+        stem_name=stem_name,
+        path=path,
+    )
+
+
+def resolve_artifact_path(data_dir: Path, raw_path: str) -> Path:
+    path = Path(raw_path).expanduser()
+    if not path.is_absolute():
+        path = data_dir / path
+    return path.resolve()
+
+
+def group_projects(
+    stems: list[StemPath],
+) -> dict[str, dict[tuple[str, str, str], list[StemPath]]]:
+    grouped: dict[str, dict[tuple[str, str, str], list[StemPath]]] = {}
+    for stem in stems:
+        project = grouped.setdefault(stem.storage_key, {})
+        stemset_key = (stem.source_artifact_id, stem.model, stem.stemset)
+        project.setdefault(stemset_key, []).append(stem)
+    return grouped
+
+
+def sorted_stems(stems: list[StemPath]) -> list[StemPath]:
+    order = {stem_name: index for index, stem_name in enumerate(STEM_ORDER)}
+    return sorted(stems, key=lambda stem: (order.get(stem.stem_name, len(order)), stem.stem_name))
+
+
+def analyze_stem(path: Path, *, width: int, thresholds: Thresholds) -> StemMetrics:
+    try:
+        with sf.SoundFile(path, mode="r") as audio:
+            sample_rate = int(audio.samplerate)
+            channels = int(audio.channels)
+            total_frames = int(audio.frames)
+            bin_count = max(1, width)
+            bins = [0.0] * bin_count
+            frames_per_bin = max(1, math.ceil(max(total_frames, 1) / bin_count))
+            window_frames = max(1, int(round(sample_rate * thresholds.window_seconds)))
+            chunk_frame_cap = max(1, min(sample_rate if sample_rate > 0 else MAX_READ_FRAMES, MAX_READ_FRAMES))
+            read_frames = min(
+                max(window_frames, min(frames_per_bin, chunk_frame_cap)),
+                chunk_frame_cap,
+            )
+
+            peak = 0.0
+            square_sum = 0.0
+            inspected_frames = 0
+            active_frames = 0
+            pending_window_peak = 0.0
+            pending_window_square_sum = 0.0
+            pending_window_frames = 0
+            pending_window_active_frames = 0
+
+            while True:
+                block = audio.read(read_frames, dtype="float32", always_2d=True)
+                frame_count = int(block.shape[0])
+                if frame_count == 0:
+                    break
+
+                frame_magnitudes = np.max(np.abs(block), axis=1).astype(np.float64, copy=False)
+                peak = max(peak, float(np.max(frame_magnitudes)))
+                square_sum += float(np.sum(frame_magnitudes * frame_magnitudes))
+
+                offset = 0
+                while offset < frame_count:
+                    absolute_frame = inspected_frames + offset
+                    bin_index = min(bin_count - 1, absolute_frame // frames_per_bin)
+                    frames_for_bin = min(frame_count - offset, frames_per_bin - (absolute_frame % frames_per_bin))
+                    slice_magnitudes = frame_magnitudes[offset : offset + frames_for_bin]
+                    bins[bin_index] = max(bins[bin_index], float(np.max(slice_magnitudes)))
+                    offset += frames_for_bin
+
+                offset = 0
+                while offset < frame_count:
+                    available = min(frame_count - offset, window_frames - pending_window_frames)
+                    window_slice = frame_magnitudes[offset : offset + available]
+                    pending_window_peak = max(pending_window_peak, float(np.max(window_slice)))
+                    pending_window_square_sum += float(np.sum(window_slice * window_slice))
+                    pending_window_frames += available
+                    pending_window_active_frames += int(np.count_nonzero(window_slice >= thresholds.rms))
+                    if pending_window_frames == window_frames:
+                        active_frames += active_frame_count(
+                            pending_window_peak,
+                            pending_window_square_sum,
+                            pending_window_frames,
+                            threshold_rms=thresholds.rms,
+                            threshold_peak=thresholds.peak,
+                            active_frames=pending_window_active_frames,
+                        )
+                        pending_window_peak = 0.0
+                        pending_window_square_sum = 0.0
+                        pending_window_frames = 0
+                        pending_window_active_frames = 0
+                    offset += available
+
+                inspected_frames += frame_count
+
+            if pending_window_frames > 0:
+                active_frames += active_frame_count(
+                    pending_window_peak,
+                    pending_window_square_sum,
+                    pending_window_frames,
+                    threshold_rms=thresholds.rms,
+                    threshold_peak=thresholds.peak,
+                    active_frames=pending_window_active_frames,
+                )
+    except (OSError, RuntimeError) as error:
+        raise DiagnosticError(f"Could not read stem audio {path}: {error}") from error
+
+    rms = math.sqrt(square_sum / inspected_frames) if inspected_frames > 0 else 0.0
+    active_duration_seconds = active_frames / sample_rate if inspected_frames > 0 else 0.0
+    inspected_duration_seconds = inspected_frames / sample_rate if inspected_frames > 0 else 0.0
+    has_signal = (
+        peak >= thresholds.peak
+        and rms >= thresholds.rms
+        and active_duration_seconds >= thresholds.active_duration
+    )
+    return StemMetrics(
+        has_signal=has_signal,
+        peak=peak,
+        rms=rms,
+        active_duration_seconds=active_duration_seconds,
+        inspected_duration_seconds=inspected_duration_seconds,
+        sample_rate=sample_rate,
+        channels=channels,
+        bins=bins,
+    )
+
+
+def active_frame_count(
+    window_peak: float,
+    window_square_sum: float,
+    window_frames: int,
+    *,
+    threshold_rms: float,
+    threshold_peak: float,
+    active_frames: int,
+) -> int:
+    window_rms = math.sqrt(window_square_sum / window_frames)
+    if window_peak < threshold_peak or window_rms < threshold_rms:
+        return 0
+    return active_frames
+
+
+def render_project_svg(
+    *,
+    storage_key: str,
+    project_info: ProjectInfo | None,
+    project_label: str,
+    stemsets: list[StemsetRender],
+    thresholds: Thresholds,
+    width: int,
+) -> str:
+    label_width = 330
+    plot_width = width
+    row_height = 64
+    row_gap = 12
+    stemset_header_height = 58
+    top_height = 120
+    bottom_margin = 36
+    svg_width = label_width + plot_width + 48
+    svg_height = top_height + bottom_margin + sum(
+        stemset_header_height + len(stemset.stems) * (row_height + row_gap)
+        for stemset in stemsets
+    )
+
+    lines = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{svg_width}" height="{svg_height}" '
+        f'viewBox="0 0 {svg_width} {svg_height}" role="img">',
+        "<style>",
+        "text{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;fill:#17202a}",
+        ".muted{fill:#64748b}.pass{fill:#166534}.fail{fill:#991b1b}",
+        ".axis{stroke:#cbd5e1;stroke-width:1}.wave{fill:#2563eb;fill-opacity:.72}",
+        ".strip{fill:#f8fafc;stroke:#d7dee8;stroke-width:1}",
+        "</style>",
+        f"<title>{escape(project_label)} stem waveforms</title>",
+        '<rect width="100%" height="100%" fill="#ffffff"/>',
+        f'<text x="24" y="38" font-size="24" font-weight="700">{escape(project_label)}</text>',
+        f'<text x="24" y="64" font-size="13" class="muted">storage key: {escape(storage_key)}</text>',
+    ]
+    if project_info is not None:
+        duration = (
+            f"{project_info.duration_seconds:.2f}s"
+            if project_info.duration_seconds is not None
+            else "unknown"
+        )
+        lines.append(
+            f'<text x="24" y="84" font-size="13" class="muted">'
+            f'project id: {escape(project_info.project_id)} - duration: {duration}</text>'
+        )
+    lines.append(
+        f'<text x="24" y="106" font-size="13" class="muted">thresholds: '
+        f'peak &gt;= {thresholds.peak:g}, RMS &gt;= {thresholds.rms:g}, '
+        f'active &gt;= {thresholds.active_duration:g}s, '
+        f'window {thresholds.window_seconds:g}s</text>'
+    )
+
+    y = top_height
+    for stemset in stemsets:
+        stemset_peak = max((max(metrics.bins, default=0.0) for metrics in stemset.stems.values()), default=0.0)
+        scale = stemset_peak if stemset_peak > 0 else 1.0
+        lines.append(
+            f'<text x="24" y="{y + 24}" font-size="16" font-weight="700">'
+            f'{escape(stemset.model)} / {escape(stemset.stemset)}</text>'
+        )
+        lines.append(
+            f'<text x="24" y="{y + 44}" font-size="12" class="muted">'
+            f'source artifact: {escape(stemset.source_artifact_id)} - '
+            f'shared scale peak: {scale:.6g}</text>'
+        )
+        y += stemset_header_height
+        for stem_name, metrics in sorted_rendered_stems(stemset.stems):
+            lines.extend(
+                render_stem_row(
+                    stem_name=stem_name,
+                    metrics=metrics,
+                    x=24,
+                    y=y,
+                    label_width=label_width,
+                    plot_width=plot_width,
+                    row_height=row_height,
+                    scale=scale,
+                )
+            )
+            y += row_height + row_gap
+
+    lines.append("</svg>")
+    return "\n".join(lines)
+
+
+def sorted_rendered_stems(stems: dict[str, StemMetrics]) -> list[tuple[str, StemMetrics]]:
+    order = {stem_name: index for index, stem_name in enumerate(STEM_ORDER)}
+    return sorted(stems.items(), key=lambda item: (order.get(item[0], len(order)), item[0]))
+
+
+def render_stem_row(
+    *,
+    stem_name: str,
+    metrics: StemMetrics,
+    x: int,
+    y: int,
+    label_width: int,
+    plot_width: int,
+    row_height: int,
+    scale: float,
+) -> list[str]:
+    plot_x = x + label_width
+    mid_y = y + row_height / 2
+    half_height = row_height * 0.34
+    status = "PASS" if metrics.has_signal else "NO SIGNAL"
+    status_class = "pass" if metrics.has_signal else "fail"
+    label = (
+        f"peak {metrics.peak:.6g} - RMS {metrics.rms:.6g} - "
+        f"active {metrics.active_duration_seconds:.3f}s - {status}"
+    )
+    points_top: list[str] = []
+    points_bottom: list[str] = []
+    for index, value in enumerate(metrics.bins):
+        point_x = plot_x + (index / max(1, len(metrics.bins) - 1)) * plot_width
+        amplitude = min(1.0, value / scale) * half_height
+        points_top.append(f"{point_x:.2f},{mid_y - amplitude:.2f}")
+        points_bottom.append(f"{point_x:.2f},{mid_y + amplitude:.2f}")
+    polygon = " ".join([*points_top, *reversed(points_bottom)])
+    return [
+        f'<text x="{x}" y="{y + 22}" font-size="14" font-weight="700">{escape(stem_name)}</text>',
+        f'<text x="{x}" y="{y + 44}" font-size="12" class="{status_class}">{escape(label)}</text>',
+        f'<rect x="{plot_x}" y="{y}" width="{plot_width}" height="{row_height}" rx="4" class="strip"/>',
+        f'<line x1="{plot_x}" y1="{mid_y:.2f}" x2="{plot_x + plot_width}" '
+        f'y2="{mid_y:.2f}" class="axis"/>',
+        f'<polygon points="{polygon}" class="wave"/>',
+    ]
+
+
+def safe_slug(value: str) -> str:
+    slug = SAFE_FILENAME_PATTERN.sub("-", value.strip().lower()).strip("-._")
+    return slug[:80] or "project"
+
+
+def escape(value: str) -> str:
+    return html.escape(value, quote=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add a streamed WAV stem signal helper with peak, RMS, active duration, and inspected duration metrics.
- Add synthetic backend coverage for silent, near-silent, transient, mono, and stereo stems.
- Add a read-only `pnpm stems:waveforms` diagnostic for threshold tuning against local TuneForge stem artifacts.

Closes #215

## Testing

- `cd apps/backend && uv run --python 3.11 pytest tests/test_stem_signal.py tests/test_stem_waveforms_script.py`
- `cd apps/backend && UV_CACHE_DIR="$TMPDIR/uv-cache" uv run --python 3.11 ruff check app/engines/stem_signal.py tests/test_stem_signal.py tests/test_stem_waveforms_script.py ../../scripts/stem-waveforms.py`
- `cd apps/backend && UV_CACHE_DIR="$TMPDIR/uv-cache" uv run --python 3.11 mypy app/engines/stem_signal.py ../../scripts/stem-waveforms.py`
- `git diff --check origin/main...HEAD`
