### PR TITLE
refactor: consolidate audio signal detection

### DIFF
--- a/apps/backend/app/cli/playback_capture_analyze.py
+++ b/apps/backend/app/cli/playback_capture_analyze.py
@@ -11,12 +11,21 @@ from typing import Any, cast
 import numpy as np
 import soundfile as sf
 
+from app.engines.audio_signal import AudioSignalThresholds, inspect_audio_signal_array
+
 DEFAULT_MIN_DURATION_SECONDS = 1.0
 DEFAULT_RMS_THRESHOLD = 0.002
 DEFAULT_MARKER_TOLERANCE_SECONDS = 0.08
 DEFAULT_SPACING_TOLERANCE_SECONDS = 0.08
 DEFAULT_QUIET_WINDOW_MAX_RMS = 0.003
 DEFAULT_LOOP_MIN_SIMILARITY = 0.7
+PLAYBACK_CAPTURE_SIGNAL_WINDOW_SECONDS = 0.05
+PLAYBACK_CAPTURE_SIGNAL_THRESHOLDS = AudioSignalThresholds(
+    peak=DEFAULT_RMS_THRESHOLD,
+    rms=DEFAULT_RMS_THRESHOLD,
+    active_duration_seconds=0.0,
+    window_seconds=PLAYBACK_CAPTURE_SIGNAL_WINDOW_SECONDS,
+)
 
 
 class PlaybackCaptureAnalyzeCliError(RuntimeError):
@@ -31,6 +40,14 @@ class AudioCapture:
     @property
     def duration_seconds(self) -> float:
         return float(self.samples.size / self.sample_rate)
+
+
+@dataclass(frozen=True)
+class AudioCaptureSignalSummary:
+    duration_seconds: float
+    sample_rate: int
+    rms: float
+    peak: float
 
 
 @dataclass(frozen=True)
@@ -105,8 +122,7 @@ def _build_parser() -> argparse.ArgumentParser:
 def _run_analysis(args: argparse.Namespace) -> dict[str, Any]:
     sidecar = _read_sidecar(args.sidecar)
     capture = _read_capture(args)
-    rms = _rms(capture.samples)
-    peak = _peak(capture.samples)
+    signal_summary = _summarize_capture_signal(capture)
 
     min_duration_seconds = cast(
         float,
@@ -133,12 +149,14 @@ def _run_analysis(args: argparse.Namespace) -> dict[str, Any]:
         ),
     )
 
-    if capture.duration_seconds < min_duration_seconds:
+    if signal_summary.duration_seconds < min_duration_seconds:
         raise PlaybackCaptureAnalyzeCliError(
-            f"capture duration {capture.duration_seconds:.3f}s below minimum {min_duration_seconds:.3f}s"
+            f"capture duration {signal_summary.duration_seconds:.3f}s below minimum {min_duration_seconds:.3f}s"
         )
-    if rms < rms_threshold:
-        raise PlaybackCaptureAnalyzeCliError(f"capture RMS {rms:.6f} below threshold {rms_threshold:.6f}")
+    if signal_summary.rms < rms_threshold:
+        raise PlaybackCaptureAnalyzeCliError(
+            f"capture RMS {signal_summary.rms:.6f} below threshold {rms_threshold:.6f}"
+        )
 
     markers = _extract_pulse_markers(sidecar)
     marker_summary = _analyze_pulse_markers(
@@ -163,10 +181,10 @@ def _run_analysis(args: argparse.Namespace) -> dict[str, Any]:
     return {
         "audio_path": str(args.audio.expanduser().resolve()),
         "sidecar_path": str(args.sidecar.expanduser().resolve()),
-        "duration_seconds": round(capture.duration_seconds, 6),
-        "sample_rate": capture.sample_rate,
-        "rms": round(rms, 8),
-        "peak": round(peak, 8),
+        "duration_seconds": round(signal_summary.duration_seconds, 6),
+        "sample_rate": signal_summary.sample_rate,
+        "rms": round(signal_summary.rms, 8),
+        "peak": round(signal_summary.peak, 8),
         "min_duration_seconds": min_duration_seconds,
         "rms_threshold": rms_threshold,
         "pulse_markers": marker_summary,
@@ -207,6 +225,20 @@ def _read_capture(args: argparse.Namespace) -> AudioCapture:
 
     mono = np.mean(data.astype(np.float64, copy=False), axis=1)
     return AudioCapture(samples=mono, sample_rate=int(effective_sample_rate))
+
+
+def _summarize_capture_signal(capture: AudioCapture) -> AudioCaptureSignalSummary:
+    shared_summary = inspect_audio_signal_array(
+        capture.samples,
+        capture.sample_rate,
+        PLAYBACK_CAPTURE_SIGNAL_THRESHOLDS,
+    )
+    return AudioCaptureSignalSummary(
+        duration_seconds=shared_summary.inspected_duration_seconds,
+        sample_rate=shared_summary.sample_rate,
+        rms=shared_summary.rms,
+        peak=shared_summary.peak,
+    )
 
 
 def _analyze_pulse_markers(
@@ -720,12 +752,6 @@ def _rms(samples: np.ndarray) -> float:
     if samples.size == 0:
         return 0.0
     return float(np.sqrt(np.mean(np.square(samples, dtype=np.float64))))
-
-
-def _peak(samples: np.ndarray) -> float:
-    if samples.size == 0:
-        return 0.0
-    return float(np.max(np.abs(samples)))
 
 
 def _first_sequence(mapping: dict[str, Any], keys: tuple[str, ...]) -> list[Any]:

--- a/apps/backend/app/engines/audio_signal.py
+++ b/apps/backend/app/engines/audio_signal.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import math
+import operator
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+
+MAX_READ_FRAMES = 65_536
+
+
+@dataclass(frozen=True)
+class AudioSignalThresholds:
+    peak: float
+    rms: float
+    active_duration_seconds: float
+    window_seconds: float
+
+    def __post_init__(self) -> None:
+        _validate_non_negative("peak", self.peak)
+        _validate_non_negative("rms", self.rms)
+        _validate_non_negative("active_duration_seconds", self.active_duration_seconds)
+        if not math.isfinite(self.window_seconds) or self.window_seconds <= 0.0:
+            raise ValueError("window_seconds must be finite and positive.")
+
+
+@dataclass(frozen=True)
+class AudioSignalSummary:
+    has_signal: bool
+    peak: float
+    rms: float
+    active_duration_seconds: float
+    inspected_duration_seconds: float
+    active_ratio: float
+    sample_rate: int
+    channels: int
+    bins: tuple[float, ...] | None = None
+
+
+def inspect_audio_signal(
+    path: Path,
+    thresholds: AudioSignalThresholds,
+    *,
+    max_duration_seconds: float | None = None,
+    bin_count: int | None = None,
+) -> AudioSignalSummary:
+    return inspect_audio_signal_file(
+        path,
+        thresholds,
+        max_duration_seconds=max_duration_seconds,
+        bin_count=bin_count,
+    )
+
+
+def inspect_audio_signal_file(
+    path: Path,
+    thresholds: AudioSignalThresholds,
+    *,
+    max_duration_seconds: float | None = None,
+    bin_count: int | None = None,
+) -> AudioSignalSummary:
+    normalized_bin_count = _normalize_bin_count(bin_count)
+
+    with sf.SoundFile(path, mode="r") as audio:
+        sample_rate = int(audio.samplerate)
+        channels = int(audio.channels)
+        inspected_frame_limit = _resolve_inspected_frame_limit(
+            int(audio.frames),
+            sample_rate,
+            max_duration_seconds,
+        )
+        accumulator = _AudioSignalAccumulator(
+            sample_rate=sample_rate,
+            channels=channels,
+            thresholds=thresholds,
+            bin_count=normalized_bin_count,
+            inspected_frame_limit=inspected_frame_limit,
+        )
+        read_frames = min(_window_frames(sample_rate, thresholds.window_seconds), MAX_READ_FRAMES)
+        remaining_frames = inspected_frame_limit
+
+        while remaining_frames > 0:
+            frames_to_read = min(read_frames, remaining_frames)
+            block = audio.read(frames_to_read, dtype="float32", always_2d=True)
+            frame_count = int(block.shape[0])
+            if frame_count == 0:
+                break
+
+            accumulator.add_block(block)
+            remaining_frames -= frame_count
+
+    return accumulator.summary()
+
+
+def inspect_audio_signal_array(
+    signal: np.ndarray,
+    sample_rate: int,
+    thresholds: AudioSignalThresholds,
+    *,
+    max_duration_seconds: float | None = None,
+    bin_count: int | None = None,
+) -> AudioSignalSummary:
+    frames = _as_frame_channel_array(signal)
+    sample_rate = _normalize_sample_rate(sample_rate)
+    normalized_bin_count = _normalize_bin_count(bin_count)
+    inspected_frame_limit = _resolve_inspected_frame_limit(
+        int(frames.shape[0]),
+        sample_rate,
+        max_duration_seconds,
+    )
+    accumulator = _AudioSignalAccumulator(
+        sample_rate=sample_rate,
+        channels=int(frames.shape[1]),
+        thresholds=thresholds,
+        bin_count=normalized_bin_count,
+        inspected_frame_limit=inspected_frame_limit,
+    )
+    window_frames = _window_frames(sample_rate, thresholds.window_seconds)
+    offset = 0
+    remaining_frames = inspected_frame_limit
+
+    while remaining_frames > 0:
+        frame_count = min(window_frames, remaining_frames)
+        accumulator.add_block(frames[offset : offset + frame_count])
+        offset += frame_count
+        remaining_frames -= frame_count
+
+    return accumulator.summary()
+
+
+class _AudioSignalAccumulator:
+    def __init__(
+        self,
+        *,
+        sample_rate: int,
+        channels: int,
+        thresholds: AudioSignalThresholds,
+        bin_count: int | None,
+        inspected_frame_limit: int,
+    ) -> None:
+        self._sample_rate = sample_rate
+        self._channels = channels
+        self._thresholds = thresholds
+        self._bin_peaks = None if bin_count is None else np.zeros(bin_count, dtype=np.float64)
+        self._frames_per_bin = (
+            None if bin_count is None else max(1, math.ceil(max(inspected_frame_limit, 1) / bin_count))
+        )
+        self._window_frames = _window_frames(sample_rate, thresholds.window_seconds)
+        self._peak = 0.0
+        self._square_sum = 0.0
+        self._inspected_frames = 0
+        self._active_frames = 0
+        self._pending_window_peak = 0.0
+        self._pending_window_square_sum = 0.0
+        self._pending_window_frames = 0
+        self._pending_window_active_frames = 0
+
+    def add_block(self, block: np.ndarray) -> None:
+        frame_count = int(block.shape[0])
+        if frame_count == 0:
+            return
+
+        frame_magnitudes = np.max(np.abs(block), axis=1).astype(np.float64, copy=False)
+        self._update_bins(frame_magnitudes)
+
+        self._peak = max(self._peak, float(np.max(frame_magnitudes)))
+        window_square_sum = float(np.sum(frame_magnitudes * frame_magnitudes))
+        self._square_sum += window_square_sum
+        self._update_active_windows(frame_magnitudes)
+        self._inspected_frames += frame_count
+
+    def summary(self) -> AudioSignalSummary:
+        rms = math.sqrt(self._square_sum / self._inspected_frames) if self._inspected_frames > 0 else 0.0
+        active_frames = self._active_frames + self._pending_window_active_frame_count()
+        active_duration_seconds = (
+            active_frames / self._sample_rate if self._inspected_frames > 0 else 0.0
+        )
+        inspected_duration_seconds = (
+            self._inspected_frames / self._sample_rate if self._inspected_frames > 0 else 0.0
+        )
+        active_ratio = (
+            active_duration_seconds / inspected_duration_seconds
+            if inspected_duration_seconds > 0.0
+            else 0.0
+        )
+        has_signal = (
+            self._peak >= self._thresholds.peak
+            and rms >= self._thresholds.rms
+            and active_duration_seconds >= self._thresholds.active_duration_seconds
+        )
+
+        return AudioSignalSummary(
+            has_signal=has_signal,
+            peak=self._peak,
+            rms=rms,
+            active_duration_seconds=active_duration_seconds,
+            inspected_duration_seconds=inspected_duration_seconds,
+            active_ratio=active_ratio,
+            sample_rate=self._sample_rate,
+            channels=self._channels,
+            bins=None if self._bin_peaks is None else tuple(float(value) for value in self._bin_peaks),
+        )
+
+    def _update_bins(self, frame_magnitudes: np.ndarray) -> None:
+        if self._bin_peaks is None or self._frames_per_bin is None:
+            return
+
+        bin_count = int(self._bin_peaks.shape[0])
+        start_frame = self._inspected_frames
+        stop_frame = start_frame + int(frame_magnitudes.shape[0])
+        frame_indexes = np.arange(start_frame, stop_frame, dtype=np.int64)
+        bin_indexes = np.minimum(frame_indexes // self._frames_per_bin, bin_count - 1)
+        np.maximum.at(self._bin_peaks, bin_indexes, frame_magnitudes)
+
+    def _update_active_windows(self, frame_magnitudes: np.ndarray) -> None:
+        offset = 0
+        frame_count = int(frame_magnitudes.shape[0])
+        while offset < frame_count:
+            available = min(frame_count - offset, self._window_frames - self._pending_window_frames)
+            window_slice = frame_magnitudes[offset : offset + available]
+            self._pending_window_peak = max(self._pending_window_peak, float(np.max(window_slice)))
+            self._pending_window_square_sum += float(np.sum(window_slice * window_slice))
+            self._pending_window_frames += available
+            self._pending_window_active_frames += int(np.count_nonzero(window_slice >= self._thresholds.rms))
+            if self._pending_window_frames == self._window_frames:
+                self._active_frames += self._pending_window_active_frame_count()
+                self._pending_window_peak = 0.0
+                self._pending_window_square_sum = 0.0
+                self._pending_window_frames = 0
+                self._pending_window_active_frames = 0
+            offset += available
+
+    def _pending_window_active_frame_count(self) -> int:
+        if self._pending_window_frames == 0:
+            return 0
+        window_rms = math.sqrt(self._pending_window_square_sum / self._pending_window_frames)
+        if self._pending_window_peak < self._thresholds.peak or window_rms < self._thresholds.rms:
+            return 0
+        return self._pending_window_active_frames
+
+
+def _as_frame_channel_array(signal: np.ndarray) -> np.ndarray:
+    frames = np.asarray(signal)
+    if frames.ndim == 1:
+        return frames.reshape(-1, 1)
+    if frames.ndim != 2:
+        raise ValueError("signal must be a mono vector or a frame-by-channel array.")
+    if frames.shape[1] <= 0:
+        raise ValueError("signal must have at least one channel.")
+    return frames
+
+
+def _normalize_sample_rate(sample_rate: int) -> int:
+    normalized_sample_rate = operator.index(sample_rate)
+    if normalized_sample_rate <= 0:
+        raise ValueError("sample_rate must be positive.")
+    return normalized_sample_rate
+
+
+def _normalize_bin_count(bin_count: int | None) -> int | None:
+    if bin_count is None:
+        return None
+
+    normalized_bin_count = operator.index(bin_count)
+    if normalized_bin_count <= 0:
+        raise ValueError("bin_count must be positive.")
+    return normalized_bin_count
+
+
+def _resolve_inspected_frame_limit(
+    total_frames: int,
+    sample_rate: int,
+    max_duration_seconds: float | None,
+) -> int:
+    if max_duration_seconds is None:
+        return total_frames
+    if not math.isfinite(max_duration_seconds) or max_duration_seconds < 0.0:
+        raise ValueError("max_duration_seconds must be finite and non-negative.")
+    return min(total_frames, int(max_duration_seconds * sample_rate))
+
+
+def _window_frames(sample_rate: int, window_seconds: float) -> int:
+    return max(1, int(round(sample_rate * window_seconds)))
+
+
+def _validate_non_negative(name: str, value: float) -> None:
+    if not math.isfinite(value) or value < 0.0:
+        raise ValueError(f"{name} must be finite and non-negative.")

--- a/apps/backend/app/engines/stem_signal.py
+++ b/apps/backend/app/engines/stem_signal.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
 from pathlib import Path
 
-import numpy as np
-import soundfile as sf
+from app.engines.audio_signal import AudioSignalThresholds, inspect_audio_signal_file
 
 PEAK_THRESHOLD = 1e-3
 RMS_THRESHOLD = 5e-5
 ACTIVE_DURATION_THRESHOLD_SECONDS = 0.20
 ANALYSIS_WINDOW_SECONDS = 0.05
+STEM_SIGNAL_THRESHOLDS = AudioSignalThresholds(
+    peak=PEAK_THRESHOLD,
+    rms=RMS_THRESHOLD,
+    active_duration_seconds=ACTIVE_DURATION_THRESHOLD_SECONDS,
+    window_seconds=ANALYSIS_WINDOW_SECONDS,
+)
 
 
 @dataclass(frozen=True)
@@ -29,59 +33,18 @@ def inspect_stem_signal(
     *,
     max_duration_seconds: float | None = None,
 ) -> StemSignalSummary:
-    if max_duration_seconds is not None and (
-        not math.isfinite(max_duration_seconds) or max_duration_seconds < 0.0
-    ):
-        raise ValueError("max_duration_seconds must be finite and non-negative.")
-
-    with sf.SoundFile(path, mode="r") as audio:
-        sample_rate = int(audio.samplerate)
-        channels = int(audio.channels)
-        max_frames = None if max_duration_seconds is None else int(max_duration_seconds * sample_rate)
-        window_frames = max(1, int(round(sample_rate * ANALYSIS_WINDOW_SECONDS)))
-
-        peak = 0.0
-        square_sum = 0.0
-        inspected_frames = 0
-        active_frames = 0
-        remaining_frames = max_frames
-
-        while remaining_frames is None or remaining_frames > 0:
-            frames_to_read = window_frames if remaining_frames is None else min(window_frames, remaining_frames)
-            block = audio.read(frames_to_read, dtype="float32", always_2d=True)
-            frame_count = int(block.shape[0])
-            if frame_count == 0:
-                break
-
-            frame_magnitudes = np.max(np.abs(block), axis=1).astype(np.float64, copy=False)
-            window_peak = float(np.max(frame_magnitudes))
-            window_square_sum = float(np.sum(frame_magnitudes * frame_magnitudes))
-            window_rms = math.sqrt(window_square_sum / frame_count)
-
-            peak = max(peak, window_peak)
-            square_sum += window_square_sum
-            inspected_frames += frame_count
-            if window_peak >= PEAK_THRESHOLD and window_rms >= RMS_THRESHOLD:
-                active_frames += int(np.count_nonzero(frame_magnitudes >= RMS_THRESHOLD))
-
-            if remaining_frames is not None:
-                remaining_frames -= frame_count
-
-    rms = math.sqrt(square_sum / inspected_frames) if inspected_frames > 0 else 0.0
-    active_duration_seconds = active_frames / sample_rate if inspected_frames > 0 else 0.0
-    inspected_duration_seconds = inspected_frames / sample_rate if inspected_frames > 0 else 0.0
-    has_signal = (
-        peak >= PEAK_THRESHOLD
-        and rms >= RMS_THRESHOLD
-        and active_duration_seconds >= ACTIVE_DURATION_THRESHOLD_SECONDS
+    summary = inspect_audio_signal_file(
+        path,
+        STEM_SIGNAL_THRESHOLDS,
+        max_duration_seconds=max_duration_seconds,
     )
 
     return StemSignalSummary(
-        has_signal=has_signal,
-        peak=peak,
-        rms=rms,
-        active_duration_seconds=active_duration_seconds,
-        inspected_duration_seconds=inspected_duration_seconds,
-        sample_rate=sample_rate,
-        channels=channels,
+        has_signal=summary.has_signal,
+        peak=summary.peak,
+        rms=summary.rms,
+        active_duration_seconds=summary.active_duration_seconds,
+        inspected_duration_seconds=summary.inspected_duration_seconds,
+        sample_rate=summary.sample_rate,
+        channels=summary.channels,
     )

--- a/apps/backend/tests/test_audio_signal.py
+++ b/apps/backend/tests/test_audio_signal.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from app.engines import audio_signal
+from app.engines.audio_signal import (
+    AudioSignalThresholds,
+    inspect_audio_signal_array,
+    inspect_audio_signal_file,
+)
+
+SAMPLE_RATE = 1_000
+THRESHOLDS = AudioSignalThresholds(
+    peak=0.01,
+    rms=0.005,
+    active_duration_seconds=0.20,
+    window_seconds=0.10,
+)
+
+
+def test_silent_array_has_no_signal():
+    summary = inspect_audio_signal_array(np.zeros(SAMPLE_RATE, dtype=np.float32), SAMPLE_RATE, THRESHOLDS)
+
+    assert summary.has_signal is False
+    assert summary.peak == pytest.approx(0.0)
+    assert summary.rms == pytest.approx(0.0)
+    assert summary.active_duration_seconds == pytest.approx(0.0)
+    assert summary.inspected_duration_seconds == pytest.approx(1.0)
+    assert summary.active_ratio == pytest.approx(0.0)
+    assert summary.sample_rate == SAMPLE_RATE
+    assert summary.channels == 1
+    assert summary.bins is None
+
+
+def test_low_amplitude_array_has_no_signal():
+    summary = inspect_audio_signal_array(np.full(SAMPLE_RATE, 0.002, dtype=np.float32), SAMPLE_RATE, THRESHOLDS)
+
+    assert summary.has_signal is False
+    assert 0.0 < summary.peak < THRESHOLDS.peak
+    assert 0.0 < summary.rms < THRESHOLDS.rms
+    assert summary.active_duration_seconds == pytest.approx(0.0)
+
+
+def test_sparse_clicks_do_not_accumulate_window_duration():
+    signal = np.zeros(SAMPLE_RATE, dtype=np.float32)
+    signal[[0, 100, 200, 300]] = 0.5
+
+    summary = inspect_audio_signal_array(signal, SAMPLE_RATE, THRESHOLDS)
+
+    assert summary.has_signal is False
+    assert summary.peak == pytest.approx(0.5)
+    assert summary.rms > THRESHOLDS.rms
+    assert summary.active_duration_seconds == pytest.approx(0.004)
+    assert summary.active_ratio == pytest.approx(0.004)
+
+
+def test_active_ratio_counts_active_frames_over_inspected_frames():
+    signal = np.zeros(SAMPLE_RATE, dtype=np.float32)
+    signal[:250] = 0.1
+
+    summary = inspect_audio_signal_array(signal, SAMPLE_RATE, THRESHOLDS)
+
+    assert summary.has_signal is True
+    assert summary.active_duration_seconds == pytest.approx(0.25)
+    assert summary.inspected_duration_seconds == pytest.approx(1.0)
+    assert summary.active_ratio == pytest.approx(0.25)
+
+
+def test_max_duration_seconds_limits_file_inspection(tmp_path: Path):
+    path = _write_wav(tmp_path, "long_tone.wav", np.full(SAMPLE_RATE * 2, 0.1, dtype=np.float32))
+
+    summary = inspect_audio_signal_file(path, THRESHOLDS, max_duration_seconds=0.25)
+
+    assert summary.has_signal is True
+    assert summary.active_duration_seconds == pytest.approx(0.25)
+    assert summary.inspected_duration_seconds == pytest.approx(0.25)
+    assert summary.active_ratio == pytest.approx(1.0)
+
+
+def test_bins_report_peak_magnitude_per_inspected_time_bin():
+    signal = np.zeros(SAMPLE_RATE, dtype=np.float32)
+    signal[:500] = 0.2
+
+    summary = inspect_audio_signal_array(signal, SAMPLE_RATE, THRESHOLDS, bin_count=4)
+
+    assert summary.bins == pytest.approx((0.2, 0.2, 0.0, 0.0))
+
+
+def test_bins_use_ceiling_frames_per_bin_for_uneven_counts():
+    signal = np.arange(1, 11, dtype=np.float32)
+
+    summary = inspect_audio_signal_array(signal, SAMPLE_RATE, THRESHOLDS, bin_count=4)
+
+    assert summary.bins == pytest.approx((3.0, 6.0, 9.0, 10.0))
+
+
+def test_file_reads_are_capped_without_splitting_logical_analysis_windows(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    sample_rate = 100_000
+    samples = np.zeros(sample_rate, dtype=np.float32)
+    samples[:100] = 1.0
+    fake_audio = _FakeSoundFile(samples=samples, sample_rate=sample_rate)
+    thresholds = AudioSignalThresholds(
+        peak=0.5,
+        rms=0.035,
+        active_duration_seconds=0.0,
+        window_seconds=1.0,
+    )
+
+    monkeypatch.setattr(audio_signal.sf, "SoundFile", lambda *_args, **_kwargs: fake_audio)
+
+    summary = inspect_audio_signal_file(Path("fake.wav"), thresholds)
+
+    assert fake_audio.read_sizes == [audio_signal.MAX_READ_FRAMES, sample_rate - audio_signal.MAX_READ_FRAMES]
+    assert max(fake_audio.read_sizes) <= audio_signal.MAX_READ_FRAMES
+    assert summary.rms == pytest.approx(np.sqrt(100 / sample_rate))
+    assert summary.active_duration_seconds == pytest.approx(0.0)
+
+
+def test_phase_opposed_stereo_uses_max_channel_magnitude():
+    mono = np.full(SAMPLE_RATE, 0.1, dtype=np.float32)
+    stereo = np.column_stack([mono, -mono])
+
+    summary = inspect_audio_signal_array(stereo, SAMPLE_RATE, THRESHOLDS)
+
+    assert summary.has_signal is True
+    assert summary.channels == 2
+    assert summary.peak == pytest.approx(0.1)
+    assert summary.rms == pytest.approx(0.1)
+    assert summary.active_duration_seconds == pytest.approx(1.0)
+
+
+def _write_wav(tmp_path: Path, filename: str, signal: np.ndarray) -> Path:
+    path = tmp_path / filename
+    sf.write(path, signal.astype(np.float32), SAMPLE_RATE, subtype="FLOAT")
+    return path
+
+
+class _FakeSoundFile:
+    def __init__(self, *, samples: np.ndarray, sample_rate: int) -> None:
+        self.samplerate = sample_rate
+        self.channels = 1
+        self.frames = int(samples.shape[0])
+        self.read_sizes: list[int] = []
+        self._samples = samples.reshape(-1, 1).astype(np.float32)
+        self._offset = 0
+
+    def __enter__(self) -> _FakeSoundFile:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self, frames: int, *, dtype: str, always_2d: bool) -> np.ndarray:
+        assert dtype == "float32"
+        assert always_2d is True
+        self.read_sizes.append(frames)
+        stop = min(self._offset + frames, self.frames)
+        block = self._samples[self._offset : stop]
+        self._offset = stop
+        return block

--- a/apps/backend/tests/test_playback_capture_analyze.py
+++ b/apps/backend/tests/test_playback_capture_analyze.py
@@ -221,6 +221,47 @@ def test_cli_rejects_silent_capture(
     assert "capture RMS" in captured.err
 
 
+def test_cli_uses_shared_audio_signal_summary_when_available(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audio_path = tmp_path / "capture.wav"
+    sidecar_path = tmp_path / "capture.json"
+    _write_pulse_capture(audio_path, marker_seconds=[])
+    _write_json(sidecar_path, {"minDurationSeconds": 1.0, "rmsThreshold": 0.2})
+
+    class SharedSummary:
+        inspected_duration_seconds = 1.25
+        sample_rate = 12_345
+        rms = 0.25
+        peak = 0.75
+
+    def inspect_audio_signal_array(
+        samples: np.ndarray,
+        sample_rate: int,
+        thresholds: object,
+    ) -> SharedSummary:
+        assert samples.size == 16_000
+        assert sample_rate == 8_000
+        assert thresholds is playback_capture_analyze.PLAYBACK_CAPTURE_SIGNAL_THRESHOLDS
+        return SharedSummary()
+
+    monkeypatch.setattr(playback_capture_analyze, "inspect_audio_signal_array", inspect_audio_signal_array)
+
+    exit_code = playback_capture_analyze.main(
+        ["--audio", str(audio_path), "--sidecar", str(sidecar_path)]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0, captured.err
+    payload = json.loads(captured.out)
+    assert payload["duration_seconds"] == pytest.approx(1.25)
+    assert payload["sample_rate"] == 12_345
+    assert payload["rms"] == pytest.approx(0.25)
+    assert payload["peak"] == pytest.approx(0.75)
+
+
 def test_cli_rejects_missing_expected_pulse(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/apps/backend/tests/test_stem_waveforms_script.py
+++ b/apps/backend/tests/test_stem_waveforms_script.py
@@ -163,7 +163,7 @@ def test_analyze_stem_width_one_reads_bounded_chunks(monkeypatch: pytest.MonkeyP
     module = _load_script_module()
     fake_audio = _FakeSoundFile(total_frames=SAMPLE_RATE * 10)
 
-    monkeypatch.setattr(module.sf, "SoundFile", lambda *_args, **_kwargs: fake_audio)
+    monkeypatch.setattr(module.audio_signal.sf, "SoundFile", lambda *_args, **_kwargs: fake_audio)
 
     metrics = module.analyze_stem(
         Path("registered.wav"),
@@ -177,7 +177,7 @@ def test_analyze_stem_width_one_reads_bounded_chunks(monkeypatch: pytest.MonkeyP
     )
 
     assert metrics.inspected_duration_seconds == pytest.approx(10.0)
-    assert max(fake_audio.read_sizes) == SAMPLE_RATE
+    assert max(fake_audio.read_sizes) <= SAMPLE_RATE
     assert len(fake_audio.read_sizes) > 1
 
 

--- a/scripts/stem-waveforms.py
+++ b/scripts/stem-waveforms.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import html
+import importlib
 import json
 import math
 import os
@@ -13,15 +14,17 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from urllib.request import pathname2url
 
-import numpy as np
-import soundfile as sf
+BACKEND_ROOT = Path(__file__).resolve().parents[1] / "apps" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+audio_signal = importlib.import_module("app.engines.audio_signal")
 
 PEAK_THRESHOLD = 0.001
 RMS_THRESHOLD = 0.00005
 ACTIVE_DURATION_THRESHOLD_SECONDS = 0.20
 ANALYSIS_WINDOW_SECONDS = 0.05
 DEFAULT_WIDTH = 1600
-MAX_READ_FRAMES = 65_536
 PROJECT_ID_PREFIX = "proj_sha256_"
 PROJECT_STORAGE_KEY_PREFIX = "proj_"
 PROJECT_STORAGE_HASH_LENGTH = 24
@@ -452,119 +455,32 @@ def sorted_stems(stems: list[StemPath]) -> list[StemPath]:
 
 
 def analyze_stem(path: Path, *, width: int, thresholds: Thresholds) -> StemMetrics:
+    shared_thresholds = audio_signal.AudioSignalThresholds(
+        peak=thresholds.peak,
+        rms=thresholds.rms,
+        active_duration_seconds=thresholds.active_duration,
+        window_seconds=thresholds.window_seconds,
+    )
     try:
-        with sf.SoundFile(path, mode="r") as audio:
-            sample_rate = int(audio.samplerate)
-            channels = int(audio.channels)
-            total_frames = int(audio.frames)
-            bin_count = max(1, width)
-            bins = [0.0] * bin_count
-            frames_per_bin = max(1, math.ceil(max(total_frames, 1) / bin_count))
-            window_frames = max(1, int(round(sample_rate * thresholds.window_seconds)))
-            chunk_frame_cap = max(1, min(sample_rate if sample_rate > 0 else MAX_READ_FRAMES, MAX_READ_FRAMES))
-            read_frames = min(
-                max(window_frames, min(frames_per_bin, chunk_frame_cap)),
-                chunk_frame_cap,
-            )
-
-            peak = 0.0
-            square_sum = 0.0
-            inspected_frames = 0
-            active_frames = 0
-            pending_window_peak = 0.0
-            pending_window_square_sum = 0.0
-            pending_window_frames = 0
-            pending_window_active_frames = 0
-
-            while True:
-                block = audio.read(read_frames, dtype="float32", always_2d=True)
-                frame_count = int(block.shape[0])
-                if frame_count == 0:
-                    break
-
-                frame_magnitudes = np.max(np.abs(block), axis=1).astype(np.float64, copy=False)
-                peak = max(peak, float(np.max(frame_magnitudes)))
-                square_sum += float(np.sum(frame_magnitudes * frame_magnitudes))
-
-                offset = 0
-                while offset < frame_count:
-                    absolute_frame = inspected_frames + offset
-                    bin_index = min(bin_count - 1, absolute_frame // frames_per_bin)
-                    frames_for_bin = min(frame_count - offset, frames_per_bin - (absolute_frame % frames_per_bin))
-                    slice_magnitudes = frame_magnitudes[offset : offset + frames_for_bin]
-                    bins[bin_index] = max(bins[bin_index], float(np.max(slice_magnitudes)))
-                    offset += frames_for_bin
-
-                offset = 0
-                while offset < frame_count:
-                    available = min(frame_count - offset, window_frames - pending_window_frames)
-                    window_slice = frame_magnitudes[offset : offset + available]
-                    pending_window_peak = max(pending_window_peak, float(np.max(window_slice)))
-                    pending_window_square_sum += float(np.sum(window_slice * window_slice))
-                    pending_window_frames += available
-                    pending_window_active_frames += int(np.count_nonzero(window_slice >= thresholds.rms))
-                    if pending_window_frames == window_frames:
-                        active_frames += active_frame_count(
-                            pending_window_peak,
-                            pending_window_square_sum,
-                            pending_window_frames,
-                            threshold_rms=thresholds.rms,
-                            threshold_peak=thresholds.peak,
-                            active_frames=pending_window_active_frames,
-                        )
-                        pending_window_peak = 0.0
-                        pending_window_square_sum = 0.0
-                        pending_window_frames = 0
-                        pending_window_active_frames = 0
-                    offset += available
-
-                inspected_frames += frame_count
-
-            if pending_window_frames > 0:
-                active_frames += active_frame_count(
-                    pending_window_peak,
-                    pending_window_square_sum,
-                    pending_window_frames,
-                    threshold_rms=thresholds.rms,
-                    threshold_peak=thresholds.peak,
-                    active_frames=pending_window_active_frames,
-                )
+        summary = audio_signal.inspect_audio_signal_file(
+            path,
+            shared_thresholds,
+            bin_count=width,
+        )
     except (OSError, RuntimeError) as error:
         raise DiagnosticError(f"Could not read stem audio {path}: {error}") from error
 
-    rms = math.sqrt(square_sum / inspected_frames) if inspected_frames > 0 else 0.0
-    active_duration_seconds = active_frames / sample_rate if inspected_frames > 0 else 0.0
-    inspected_duration_seconds = inspected_frames / sample_rate if inspected_frames > 0 else 0.0
-    has_signal = (
-        peak >= thresholds.peak
-        and rms >= thresholds.rms
-        and active_duration_seconds >= thresholds.active_duration
-    )
+    bins = summary.bins if summary.bins is not None else ()
     return StemMetrics(
-        has_signal=has_signal,
-        peak=peak,
-        rms=rms,
-        active_duration_seconds=active_duration_seconds,
-        inspected_duration_seconds=inspected_duration_seconds,
-        sample_rate=sample_rate,
-        channels=channels,
-        bins=bins,
+        has_signal=summary.has_signal,
+        peak=summary.peak,
+        rms=summary.rms,
+        active_duration_seconds=summary.active_duration_seconds,
+        inspected_duration_seconds=summary.inspected_duration_seconds,
+        sample_rate=summary.sample_rate,
+        channels=summary.channels,
+        bins=list(bins),
     )
-
-
-def active_frame_count(
-    window_peak: float,
-    window_square_sum: float,
-    window_frames: int,
-    *,
-    threshold_rms: float,
-    threshold_peak: float,
-    active_frames: int,
-) -> int:
-    window_rms = math.sqrt(window_square_sum / window_frames)
-    if window_peak < threshold_peak or window_rms < threshold_rms:
-        return 0
-    return active_frames
 
 
 def render_project_svg(


### PR DESCRIPTION
## Summary

- Add a shared backend audio signal detector for peak, RMS, active duration, active ratio, and optional waveform bins.
- Route stem signal detection, playback capture summary stats, and stem waveform diagnostics through the shared helper.
- Preserve stem thresholds, playback capture behavior, waveform binning, and bounded streaming reads.
- Closes #235.

## Testing

- `cd apps/backend && uv run --python 3.11 pytest tests/test_audio_signal.py tests/test_stem_signal.py tests/test_playback_capture_analyze.py tests/test_stem_waveforms_script.py`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `cd apps/backend && uv run --python 3.11 pytest`
- User ran Audio and Playback E2E tests locally.
- Linux not run locally; CI should cover platform-specific drift.
