### PR TITLE
fix: refresh sync imports after remote changes

### DIFF
--- a/apps/backend/app/services/sync_reconciliation.py
+++ b/apps/backend/app/services/sync_reconciliation.py
@@ -14,6 +14,8 @@ from sqlalchemy.orm import Session
 from app.errors import AppError
 from app.models import (
     Artifact,
+    ChordTimeline,
+    LyricsTranscript,
     Project,
     SyncDeleteTombstone,
     SyncEntityRevision,
@@ -210,6 +212,8 @@ class _LocalState:
     artifacts_by_content_sha256: dict[str, tuple[Artifact, ...]]
     entity_revisions: dict[str, SyncEntityRevision]
     entity_revisions_by_entity: dict[tuple[str, str, str], tuple[SyncEntityRevision, ...]]
+    chord_project_ids: frozenset[str]
+    lyrics_transcripts_by_project: dict[str, LyricsTranscript]
     tombstones: tuple[SyncDeleteTombstone, ...]
 
 
@@ -347,6 +351,13 @@ def plan_sync_reconciliation(
         )
 
     planned_artifact_project_ids = _planned_artifact_project_ids(actions)
+    embedded_revision_import_ids = _embedded_missing_current_revision_chain_ids(
+        remote,
+        local=local,
+        effective_tombstones=effective_tombstones,
+        planned_project_ids=planned_project_ids,
+        planned_artifact_project_ids=planned_artifact_project_ids,
+    )
     planned_revision_ids = set(local.entity_revisions)
     planned_remote_revisions_by_id: dict[str, _RemoteEntityRevision] = {}
     for revision in _sorted_remote_entity_revisions(remote.entity_revisions.values()):
@@ -364,6 +375,7 @@ def plan_sync_reconciliation(
             and revision.revision_id in remote.manifest_revision_ids_by_project.get(revision.project_id, frozenset())
             and revision.project_id not in planned_project_ids
             and _has_imported_local_project(local, revision.project_id)
+            and revision.revision_id not in embedded_revision_import_ids
             and not _is_deleted(
                 ITEM_ENTITY_REVISION,
                 revision.revision_id,
@@ -464,6 +476,13 @@ def _load_local_state(session: Session) -> _LocalState:
             )
         )
     )
+    chord_project_ids = frozenset(
+        session.scalars(select(ChordTimeline.project_id).order_by(ChordTimeline.project_id.asc()))
+    )
+    lyrics_transcripts = {
+        lyrics.project_id: lyrics
+        for lyrics in session.scalars(select(LyricsTranscript).order_by(LyricsTranscript.project_id.asc()))
+    }
 
     return _LocalState(
         identity=identity,
@@ -479,6 +498,8 @@ def _load_local_state(session: Session) -> _LocalState:
             key: tuple(sorted(rows, key=lambda revision: revision.id))
             for key, rows in revisions_by_entity.items()
         },
+        chord_project_ids=chord_project_ids,
+        lyrics_transcripts_by_project=lyrics_transcripts,
         tombstones=tombstones,
     )
 
@@ -486,6 +507,187 @@ def _load_local_state(session: Session) -> _LocalState:
 def _has_imported_local_project(local: _LocalState, project_id: str) -> bool:
     project = local.projects.get(project_id)
     return project is not None and not _is_sync_project_placeholder(project)
+
+
+def _embedded_current_revision_missing_locally(
+    revision: _RemoteEntityRevision,
+    local: _LocalState,
+) -> bool:
+    if revision.entity_type not in {"chords", "lyrics"}:
+        return False
+    if not _remote_revision_is_current(revision):
+        return False
+    entity_key = (revision.project_id, revision.entity_type, revision.entity_id)
+    if revision.entity_type == "chords":
+        if local.entity_revisions_by_entity.get(entity_key):
+            return False
+        return revision.project_id not in local.chord_project_ids
+    if not _remote_lyrics_revision_has_segments(revision):
+        return False
+    if _local_lyrics_revisions_block_embedded_import(local.entity_revisions_by_entity.get(entity_key, ())):
+        return False
+    local_lyrics = local.lyrics_transcripts_by_project.get(revision.project_id)
+    if local_lyrics is not None and _local_lyrics_transcript_blocks_embedded_import(local_lyrics):
+        return False
+    return True
+
+
+def _remote_lyrics_revision_has_segments(revision: _RemoteEntityRevision) -> bool:
+    payload = _first_field(revision.raw, "payload", default={})
+    return isinstance(payload, Mapping) and _lyrics_payload_has_segments(payload)
+
+
+def _local_lyrics_revisions_block_embedded_import(
+    revisions: Iterable[SyncEntityRevision],
+) -> bool:
+    return any(_local_lyrics_revision_blocks_embedded_import(revision) for revision in revisions)
+
+
+def _local_lyrics_revision_blocks_embedded_import(revision: SyncEntityRevision) -> bool:
+    payload = revision.payload_json
+    if not isinstance(payload, Mapping):
+        return True
+    if _lyrics_payload_has_segments(payload):
+        return True
+    if _bool_field(payload, "has_user_edits") is True:
+        return True
+    return _lyrics_fields_are_intentional_no_lyrics(
+        language_override=_str_field(payload, "language_override"),
+        source_kind=_str_field(payload, "source_kind"),
+    )
+
+
+def _local_lyrics_transcript_blocks_embedded_import(lyrics: LyricsTranscript) -> bool:
+    if _has_non_empty_segments(lyrics.segments_json):
+        return True
+    if lyrics.has_user_edits:
+        return True
+    return _lyrics_fields_are_intentional_no_lyrics(
+        language_override=lyrics.language_override,
+        source_kind=lyrics.source_kind,
+    )
+
+
+def _lyrics_payload_has_segments(payload: Mapping[str, Any]) -> bool:
+    return (
+        _has_non_empty_segments(_first_field(payload, "segments", default=[]))
+        or _has_non_empty_segments(_first_field(payload, "segments_json", default=[]))
+    )
+
+
+def _has_non_empty_segments(value: object) -> bool:
+    return isinstance(value, (list, tuple)) and len(value) > 0
+
+
+def _lyrics_fields_are_intentional_no_lyrics(
+    *,
+    language_override: str | None,
+    source_kind: str | None,
+) -> bool:
+    return (
+        _normalized_optional_string(language_override) == "none"
+        or _normalized_optional_string(source_kind) == "instrumental"
+    )
+
+
+def _normalized_optional_string(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    return normalized or None
+
+
+def _embedded_missing_current_revision_chain_ids(
+    remote: _RemoteRequest,
+    *,
+    local: _LocalState,
+    effective_tombstones: frozenset[tuple[str, str]],
+    planned_project_ids: frozenset[str],
+    planned_artifact_project_ids: Mapping[str, str],
+) -> frozenset[str]:
+    revision_ids: set[str] = set()
+    for project_id in sorted(remote.project_manifests_by_id):
+        if project_id in planned_project_ids or not _has_imported_local_project(local, project_id):
+            continue
+        manifest_revision_ids = remote.manifest_revision_ids_by_project.get(project_id, frozenset())
+        manifest_revisions_by_id = {
+            revision_id: remote.entity_revisions[revision_id]
+            for revision_id in manifest_revision_ids
+            if revision_id in remote.entity_revisions
+        }
+        current_counts = Counter(
+            (revision.project_id, revision.entity_type)
+            for revision in manifest_revisions_by_id.values()
+            if revision.entity_type in {"chords", "lyrics"} and _remote_revision_is_current(revision)
+        )
+        for revision in _sorted_remote_entity_revisions(manifest_revisions_by_id.values()):
+            if not _embedded_current_revision_missing_locally(revision, local):
+                continue
+            entity_key = (revision.project_id, revision.entity_type)
+            if current_counts[entity_key] != 1:
+                continue
+            chain = _embedded_revision_chain(revision, manifest_revisions_by_id)
+            if chain is None:
+                continue
+            if not _embedded_revision_chain_is_importable(
+                chain,
+                local=local,
+                effective_tombstones=effective_tombstones,
+                planned_artifact_project_ids=planned_artifact_project_ids,
+            ):
+                continue
+            revision_ids.update(chain_revision.revision_id for chain_revision in chain)
+    return frozenset(revision_ids)
+
+
+def _embedded_revision_chain(
+    revision: _RemoteEntityRevision,
+    manifest_revisions_by_id: Mapping[str, _RemoteEntityRevision],
+) -> list[_RemoteEntityRevision] | None:
+    chain: list[_RemoteEntityRevision] = []
+    current: _RemoteEntityRevision | None = revision
+    seen: set[str] = set()
+    entity_key = (revision.project_id, revision.entity_type, revision.entity_id)
+    while current is not None:
+        if current.revision_id in seen:
+            return None
+        if (current.project_id, current.entity_type, current.entity_id) != entity_key:
+            return None
+        seen.add(current.revision_id)
+        chain.append(current)
+        if current.base_revision_id is None:
+            break
+        current = manifest_revisions_by_id.get(current.base_revision_id)
+    return list(reversed(chain))
+
+
+def _embedded_revision_chain_is_importable(
+    chain: list[_RemoteEntityRevision],
+    *,
+    local: _LocalState,
+    effective_tombstones: frozenset[tuple[str, str]],
+    planned_artifact_project_ids: Mapping[str, str],
+) -> bool:
+    planned_remote_revisions_by_id: dict[str, _RemoteEntityRevision] = {}
+    for revision in chain:
+        if _is_deleted(ITEM_ENTITY_REVISION, revision.revision_id, revision.project_id, effective_tombstones):
+            return False
+        if _entity_revision_manifest_contract_error(revision) is not None:
+            return False
+        if _standalone_entity_revision_reference_error(
+            revision,
+            local=local,
+            planned_remote_revisions_by_id=planned_remote_revisions_by_id,
+            planned_artifact_project_ids=planned_artifact_project_ids,
+        ) is not None:
+            return False
+        planned_remote_revisions_by_id[revision.revision_id] = revision
+    return True
+
+
+def _remote_revision_is_current(revision: _RemoteEntityRevision) -> bool:
+    state = _str_field(revision.raw, "state")
+    return state is not None and state.lower() in {"active", "current"}
 
 
 def _is_sync_project_placeholder(project: Project) -> bool:
@@ -3154,6 +3356,12 @@ def _divergent_local_revision(
         if local_revision.base_revision_id != remote_revision.base_revision_id:
             continue
         if _local_revision_content_sha256(local_revision) == remote_revision.content_sha256:
+            continue
+        if (
+            remote_revision.entity_type == "lyrics"
+            and _remote_lyrics_revision_has_segments(remote_revision)
+            and not _local_lyrics_revision_blocks_embedded_import(local_revision)
+        ):
             continue
         return local_revision
     return None

--- a/apps/backend/tests/test_sync_reconciliation.py
+++ b/apps/backend/tests/test_sync_reconciliation.py
@@ -14,6 +14,8 @@ from app.config import ensure_data_dirs, get_settings
 from app.db import SessionLocal, reconfigure_engine, run_migrations
 from app.models import (
     Artifact,
+    ChordTimeline,
+    LyricsTranscript,
     Project,
     SyncDeleteTombstone,
     SyncEntityRevision,
@@ -814,6 +816,892 @@ def test_existing_project_manifest_scoped_revision_does_not_create_standalone_co
     )
     assert plan.summary.total_conflicts == 0
     assert _action(plan, ACTION_RECORD_CONFLICT, ITEM_ENTITY_REVISION, "rev_legacy_hash") is None
+
+
+def test_existing_project_imports_missing_embedded_current_chords_and_lyrics(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash, source_size = _write_file(tmp_path / "embedded-revisions-source.wav", b"source")
+    project_id = source_hash_to_project_id(source_hash)
+    _add_project(db_session, project_id, source_sha256=source_hash)
+    _add_artifact(
+        db_session,
+        artifact_id=f"art_source_{project_id}",
+        project_id=project_id,
+        path=tmp_path / "embedded-revisions-source.wav",
+        content_sha256=source_hash,
+        size_bytes=source_size,
+        artifact_type="source_audio",
+    )
+    db_session.commit()
+
+    chord_payload = {
+        "revision_id": "rev_embedded_current_chords",
+        "segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "C"}],
+    }
+    lyrics_payload = {
+        "revision_id": "rev_embedded_current_lyrics",
+        "segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "text": "hello"}],
+    }
+    manifest = _project_manifest(
+        project_id,
+        source_hash,
+        source_size_bytes=source_size,
+        extra_revisions=[
+            _current_revision_manifest(
+                project_id,
+                revision_id="rev_embedded_current_chords",
+                entity_type="chords",
+                payload=chord_payload,
+            ),
+            _current_revision_manifest(
+                project_id,
+                revision_id="rev_embedded_current_lyrics",
+                entity_type="lyrics",
+                payload=lyrics_payload,
+            ),
+        ],
+    )
+
+    plan = plan_sync_reconciliation(
+        db_session,
+        {
+            "remote_library": {},
+            "project_manifests": [manifest],
+            "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [source_hash]}],
+        },
+    )
+
+    assert _item(plan, ITEM_PROJECT, project_id).status == "noop"
+    chord_item = _item(plan, ITEM_ENTITY_REVISION, "rev_embedded_current_chords")
+    assert chord_item.status == "remote_available"
+    assert chord_item.action_type == ACTION_IMPORT_ENTITY_REVISION
+    lyrics_item = _item(plan, ITEM_ENTITY_REVISION, "rev_embedded_current_lyrics")
+    assert lyrics_item.status == "remote_available"
+    assert lyrics_item.action_type == ACTION_IMPORT_ENTITY_REVISION
+    assert _action(
+        plan,
+        ACTION_IMPORT_ENTITY_REVISION,
+        ITEM_ENTITY_REVISION,
+        "rev_embedded_current_chords",
+    ) is not None
+    assert _action(
+        plan,
+        ACTION_IMPORT_ENTITY_REVISION,
+        ITEM_ENTITY_REVISION,
+        "rev_embedded_current_lyrics",
+    ) is not None
+
+
+def test_existing_project_imports_remote_lyrics_over_empty_local_fillers(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    source_hash, source_size, project_id = _seed_existing_project_with_source(
+        db_session,
+        tmp_path,
+        filename="embedded-empty-local-lyrics-source.wav",
+    )
+    db_session.add(
+        LyricsTranscript(
+            project_id=project_id,
+            segments_json=[],
+            source_segments_json=[],
+            has_user_edits=False,
+            language_override=None,
+            source_kind="ai",
+        )
+    )
+    local_payload = {"revision_id": "rev_empty_local_lyrics", "segments": []}
+    _add_revision(
+        db_session,
+        project_id=project_id,
+        revision_id="rev_empty_local_lyrics",
+        content_sha256=revision_payload_sha256(local_payload),
+        base_revision_id=None,
+        entity_type="lyrics",
+        payload=local_payload,
+    )
+    db_session.commit()
+
+    remote_payload = {
+        "revision_id": "rev_remote_current_lyrics_after_empty_local",
+        "segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "text": "hello"}],
+    }
+    manifest = _project_manifest(
+        project_id,
+        source_hash,
+        source_size_bytes=source_size,
+        extra_revisions=[
+            _current_revision_manifest(
+                project_id,
+                revision_id="rev_remote_current_lyrics_after_empty_local",
+                entity_type="lyrics",
+                payload=remote_payload,
+            )
+        ],
+    )
+
+    plan = plan_sync_reconciliation(
+        db_session,
+        {
+            "remote_library": {},
+            "project_manifests": [manifest],
+            "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [source_hash]}],
+        },
+    )
+
+    lyrics_item = _item(plan, ITEM_ENTITY_REVISION, "rev_remote_current_lyrics_after_empty_local")
+    assert lyrics_item.status == "remote_available"
+    assert lyrics_item.action_type == ACTION_IMPORT_ENTITY_REVISION
+    assert _action(
+        plan,
+        ACTION_IMPORT_ENTITY_REVISION,
+        ITEM_ENTITY_REVISION,
+        "rev_remote_current_lyrics_after_empty_local",
+    ) is not None
+
+
+@pytest.mark.parametrize(
+    ("intentional_source", "payload"),
+    [
+        ("row", {"language_override": "none"}),
+        ("row", {"source_kind": "instrumental"}),
+        ("revision", {"language_override": "none"}),
+        ("revision", {"source_kind": "instrumental"}),
+    ],
+)
+def test_existing_project_keeps_intentional_no_lyrics_over_remote_embedded_lyrics(
+    db_session: Session,
+    tmp_path: Path,
+    intentional_source: str,
+    payload: dict[str, str],
+) -> None:
+    intentional_key = next(iter(payload))
+    source_hash, source_size, project_id = _seed_existing_project_with_source(
+        db_session,
+        tmp_path,
+        filename=f"embedded-intentional-no-lyrics-{intentional_source}-{intentional_key}.wav",
+    )
+    db_session.add(
+        LyricsTranscript(
+            project_id=project_id,
+            segments_json=[],
+            source_segments_json=[],
+            has_user_edits=False,
+            language_override=payload.get("language_override") if intentional_source == "row" else None,
+            source_kind=payload.get("source_kind") if intentional_source == "row" else "ai",
+        )
+    )
+    local_revision_id = f"rev_intentional_no_lyrics_{intentional_source}_{intentional_key}"
+    local_payload = {
+        "revision_id": local_revision_id,
+        "segments": [],
+        **(payload if intentional_source == "revision" else {}),
+    }
+    _add_revision(
+        db_session,
+        project_id=project_id,
+        revision_id=local_revision_id,
+        content_sha256=revision_payload_sha256(local_payload),
+        base_revision_id=None,
+        entity_type="lyrics",
+        payload=local_payload,
+    )
+    db_session.commit()
+
+    remote_payload = {
+        "revision_id": "rev_remote_current_lyrics_blocked_by_intentional_local",
+        "segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "text": "hello"}],
+    }
+    manifest = _project_manifest(
+        project_id,
+        source_hash,
+        source_size_bytes=source_size,
+        extra_revisions=[
+            _current_revision_manifest(
+                project_id,
+                revision_id="rev_remote_current_lyrics_blocked_by_intentional_local",
+                entity_type="lyrics",
+                payload=remote_payload,
+            )
+        ],
+    )
+
+    plan = plan_sync_reconciliation(
+        db_session,
+        {
+            "remote_library": {},
+            "project_manifests": [manifest],
+            "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [source_hash]}],
+        },
+    )
+
+    assert all(
+        item.item_id != "rev_remote_current_lyrics_blocked_by_intentional_local"
+        for item in plan.items
+        if item.item_type == ITEM_ENTITY_REVISION
+    )
+    assert _action(
+        plan,
+        ACTION_IMPORT_ENTITY_REVISION,
+        ITEM_ENTITY_REVISION,
+        "rev_remote_current_lyrics_blocked_by_intentional_local",
+    ) is None
+
+
+def test_existing_project_skips_empty_remote_embedded_lyrics_over_empty_local_row(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    source_hash, source_size, project_id = _seed_existing_project_with_source(
+        db_session,
+        tmp_path,
+        filename="embedded-empty-remote-lyrics-source.wav",
+    )
+    db_session.add(
+        LyricsTranscript(
+            project_id=project_id,
+            segments_json=[],
+            source_segments_json=[],
+            has_user_edits=False,
+            language_override=None,
+            source_kind="ai",
+        )
+    )
+    db_session.commit()
+
+    remote_payload = {
+        "revision_id": "rev_remote_empty_lyrics",
+        "segments": [],
+    }
+    manifest = _project_manifest(
+        project_id,
+        source_hash,
+        source_size_bytes=source_size,
+        extra_revisions=[
+            _current_revision_manifest(
+                project_id,
+                revision_id="rev_remote_empty_lyrics",
+                entity_type="lyrics",
+                payload=remote_payload,
+            )
+        ],
+    )
+
+    plan = plan_sync_reconciliation(
+        db_session,
+        {
+            "remote_library": {},
+            "project_manifests": [manifest],
+            "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [source_hash]}],
+        },
+    )
+
+    assert all(
+        item.item_id != "rev_remote_empty_lyrics"
+        for item in plan.items
+        if item.item_type == ITEM_ENTITY_REVISION
+    )
+    assert _action(
+        plan,
+        ACTION_IMPORT_ENTITY_REVISION,
+        ITEM_ENTITY_REVISION,
+        "rev_remote_empty_lyrics",
+    ) is None
+
+
+def test_existing_project_imports_missing_embedded_revision_chain_in_order(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash, source_size = _write_file(tmp_path / "embedded-revision-chain-source.wav", b"source")
+    project_id = source_hash_to_project_id(source_hash)
+    _add_project(db_session, project_id, source_sha256=source_hash)
+    _add_artifact(
+        db_session,
+        artifact_id=f"art_source_{project_id}",
+        project_id=project_id,
+        path=tmp_path / "embedded-revision-chain-source.wav",
+        content_sha256=source_hash,
+        size_bytes=source_size,
+        artifact_type="source_audio",
+    )
+    db_session.commit()
+
+    base_payload = {
+        "revision_id": "rev_embedded_base_chords",
+        "segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "C"}],
+    }
+    current_payload = {
+        "revision_id": "rev_embedded_current_child_chords",
+        "segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "G"}],
+    }
+    manifest = _project_manifest(
+        project_id,
+        source_hash,
+        source_size_bytes=source_size,
+        extra_revisions=[
+            _current_revision_manifest(
+                project_id,
+                revision_id="rev_embedded_base_chords",
+                entity_type="chords",
+                payload=base_payload,
+                state="superseded",
+            ),
+            _current_revision_manifest(
+                project_id,
+                revision_id="rev_embedded_current_child_chords",
+                entity_type="chords",
+                payload=current_payload,
+                base_revision_id="rev_embedded_base_chords",
+            ),
+        ],
+    )
+
+    plan = plan_sync_reconciliation(
+        db_session,
+        {
+            "remote_library": {},
+            "project_manifests": [manifest],
+            "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [source_hash]}],
+        },
+    )
+
+    base_item = _item(plan, ITEM_ENTITY_REVISION, "rev_embedded_base_chords")
+    assert base_item.status == "remote_available"
+    assert base_item.action_type == ACTION_IMPORT_ENTITY_REVISION
+    current_item = _item(plan, ITEM_ENTITY_REVISION, "rev_embedded_current_child_chords")
+    assert current_item.status == "remote_available"
+    assert current_item.action_type == ACTION_IMPORT_ENTITY_REVISION
+    import_revision_action_ids = [
+        action.item_id
+        for action in plan.actions
+        if action.action_type == ACTION_IMPORT_ENTITY_REVISION
+    ]
+    assert import_revision_action_ids.index("rev_embedded_base_chords") < import_revision_action_ids.index(
+        "rev_embedded_current_child_chords"
+    )
+
+
+@pytest.mark.parametrize("case", ["bad_payload_hash", "missing_source_artifact"])
+def test_existing_project_skips_embedded_revision_chain_when_current_is_invalid(
+    db_session: Session,
+    tmp_path: Path,
+    case: str,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash, source_size = _write_file(tmp_path / f"embedded-invalid-chain-{case}.wav", b"source")
+    project_id = source_hash_to_project_id(source_hash)
+    _add_project(db_session, project_id, source_sha256=source_hash)
+    _add_artifact(
+        db_session,
+        artifact_id=f"art_source_{project_id}",
+        project_id=project_id,
+        path=tmp_path / f"embedded-invalid-chain-{case}.wav",
+        content_sha256=source_hash,
+        size_bytes=source_size,
+        artifact_type="source_audio",
+    )
+    db_session.commit()
+
+    base_payload = {
+        "revision_id": f"rev_invalid_chain_base_{case}",
+        "segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "C"}],
+    }
+    current_payload = {
+        "revision_id": f"rev_invalid_chain_current_{case}",
+        "segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "G"}],
+    }
+    current_revision = _current_revision_manifest(
+        project_id,
+        revision_id=f"rev_invalid_chain_current_{case}",
+        entity_type="chords",
+        payload=current_payload,
+        base_revision_id=f"rev_invalid_chain_base_{case}",
+        content_sha256=(
+            _sha("invalid child payload hash")
+            if case == "bad_payload_hash"
+            else None
+        ),
+        source_artifact_id=(
+            "art_missing_revision_source"
+            if case == "missing_source_artifact"
+            else None
+        ),
+    )
+    manifest = _project_manifest(
+        project_id,
+        source_hash,
+        source_size_bytes=source_size,
+        extra_revisions=[
+            _current_revision_manifest(
+                project_id,
+                revision_id=f"rev_invalid_chain_base_{case}",
+                entity_type="chords",
+                payload=base_payload,
+                state="superseded",
+            ),
+            current_revision,
+        ],
+    )
+
+    plan = plan_sync_reconciliation(
+        db_session,
+        {
+            "remote_library": {},
+            "project_manifests": [manifest],
+            "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [source_hash]}],
+        },
+    )
+
+    assert _item(plan, ITEM_PROJECT, project_id).status == "noop"
+    for revision_id in (
+        f"rev_invalid_chain_base_{case}",
+        f"rev_invalid_chain_current_{case}",
+    ):
+        assert _action(
+            plan,
+            ACTION_IMPORT_ENTITY_REVISION,
+            ITEM_ENTITY_REVISION,
+            revision_id,
+        ) is None
+
+
+def test_existing_project_skips_duplicate_embedded_current_revisions(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash, source_size = _write_file(tmp_path / "embedded-duplicate-current-source.wav", b"source")
+    project_id = source_hash_to_project_id(source_hash)
+    _add_project(db_session, project_id, source_sha256=source_hash)
+    _add_artifact(
+        db_session,
+        artifact_id=f"art_source_{project_id}",
+        project_id=project_id,
+        path=tmp_path / "embedded-duplicate-current-source.wav",
+        content_sha256=source_hash,
+        size_bytes=source_size,
+        artifact_type="source_audio",
+    )
+    db_session.commit()
+
+    first_payload = {
+        "revision_id": "rev_duplicate_current_chords_a",
+        "segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "C"}],
+    }
+    second_payload = {
+        "revision_id": "rev_duplicate_current_chords_b",
+        "segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "G"}],
+    }
+    manifest = _project_manifest(
+        project_id,
+        source_hash,
+        source_size_bytes=source_size,
+        extra_revisions=[
+            _current_revision_manifest(
+                project_id,
+                revision_id="rev_duplicate_current_chords_a",
+                entity_type="chords",
+                payload=first_payload,
+            ),
+            _current_revision_manifest(
+                project_id,
+                revision_id="rev_duplicate_current_chords_b",
+                entity_type="chords",
+                payload=second_payload,
+            ),
+        ],
+    )
+
+    plan = plan_sync_reconciliation(
+        db_session,
+        {
+            "remote_library": {},
+            "project_manifests": [manifest],
+            "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [source_hash]}],
+        },
+    )
+
+    assert _item(plan, ITEM_PROJECT, project_id).status == "noop"
+    for revision_id in ("rev_duplicate_current_chords_a", "rev_duplicate_current_chords_b"):
+        assert _action(
+            plan,
+            ACTION_IMPORT_ENTITY_REVISION,
+            ITEM_ENTITY_REVISION,
+            revision_id,
+        ) is None
+
+
+def test_existing_project_skips_duplicate_embedded_current_singleton_with_different_entity_ids(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash, source_size = _write_file(tmp_path / "embedded-duplicate-singleton-source.wav", b"source")
+    project_id = source_hash_to_project_id(source_hash)
+    _add_project(db_session, project_id, source_sha256=source_hash)
+    _add_artifact(
+        db_session,
+        artifact_id=f"art_source_{project_id}",
+        project_id=project_id,
+        path=tmp_path / "embedded-duplicate-singleton-source.wav",
+        content_sha256=source_hash,
+        size_bytes=source_size,
+        artifact_type="source_audio",
+    )
+    db_session.commit()
+
+    first_payload = {
+        "revision_id": "rev_duplicate_singleton_chords_a",
+        "segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "C"}],
+    }
+    second_payload = {
+        "revision_id": "rev_duplicate_singleton_chords_b",
+        "segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "G"}],
+    }
+    manifest = _project_manifest(
+        project_id,
+        source_hash,
+        source_size_bytes=source_size,
+        extra_revisions=[
+            _current_revision_manifest(
+                project_id,
+                revision_id="rev_duplicate_singleton_chords_a",
+                entity_type="chords",
+                payload=first_payload,
+            ),
+            _current_revision_manifest(
+                project_id,
+                revision_id="rev_duplicate_singleton_chords_b",
+                entity_type="chords",
+                entity_id="other-chord-entity",
+                payload=second_payload,
+            ),
+        ],
+    )
+
+    plan = plan_sync_reconciliation(
+        db_session,
+        {
+            "remote_library": {},
+            "project_manifests": [manifest],
+            "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [source_hash]}],
+        },
+    )
+
+    assert _item(plan, ITEM_PROJECT, project_id).status == "noop"
+    for revision_id in ("rev_duplicate_singleton_chords_a", "rev_duplicate_singleton_chords_b"):
+        assert _action(
+            plan,
+            ACTION_IMPORT_ENTITY_REVISION,
+            ITEM_ENTITY_REVISION,
+            revision_id,
+        ) is None
+
+
+def test_existing_project_skips_embedded_chain_with_foreign_base(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash, source_size = _write_file(tmp_path / "embedded-foreign-base-source.wav", b"source")
+    project_id = source_hash_to_project_id(source_hash)
+    _add_project(db_session, project_id, source_sha256=source_hash)
+    _add_artifact(
+        db_session,
+        artifact_id=f"art_source_{project_id}",
+        project_id=project_id,
+        path=tmp_path / "embedded-foreign-base-source.wav",
+        content_sha256=source_hash,
+        size_bytes=source_size,
+        artifact_type="source_audio",
+    )
+    db_session.commit()
+
+    foreign_payload = {
+        "revision_id": "rev_foreign_lyrics_base",
+        "segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "text": "base"}],
+    }
+    current_payload = {
+        "revision_id": "rev_current_chords_foreign_base",
+        "segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "G"}],
+    }
+    manifest = _project_manifest(
+        project_id,
+        source_hash,
+        source_size_bytes=source_size,
+        extra_revisions=[
+            _current_revision_manifest(
+                project_id,
+                revision_id="rev_foreign_lyrics_base",
+                entity_type="lyrics",
+                payload=foreign_payload,
+                state="superseded",
+            ),
+            _current_revision_manifest(
+                project_id,
+                revision_id="rev_current_chords_foreign_base",
+                entity_type="chords",
+                payload=current_payload,
+                base_revision_id="rev_foreign_lyrics_base",
+            ),
+        ],
+    )
+
+    plan = plan_sync_reconciliation(
+        db_session,
+        {
+            "remote_library": {},
+            "project_manifests": [manifest],
+            "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [source_hash]}],
+        },
+    )
+
+    assert _item(plan, ITEM_PROJECT, project_id).status == "noop"
+    for revision_id in ("rev_foreign_lyrics_base", "rev_current_chords_foreign_base"):
+        assert _action(
+            plan,
+            ACTION_IMPORT_ENTITY_REVISION,
+            ITEM_ENTITY_REVISION,
+            revision_id,
+        ) is None
+
+
+def test_existing_project_skips_embedded_chain_when_current_is_tombstoned(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash, source_size = _write_file(tmp_path / "embedded-tombstoned-current-source.wav", b"source")
+    project_id = source_hash_to_project_id(source_hash)
+    _add_project(db_session, project_id, source_sha256=source_hash)
+    _add_artifact(
+        db_session,
+        artifact_id=f"art_source_{project_id}",
+        project_id=project_id,
+        path=tmp_path / "embedded-tombstoned-current-source.wav",
+        content_sha256=source_hash,
+        size_bytes=source_size,
+        artifact_type="source_audio",
+    )
+    db_session.commit()
+
+    base_payload = {
+        "revision_id": "rev_tombstone_chain_base_chords",
+        "segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "C"}],
+    }
+    current_payload = {
+        "revision_id": "rev_tombstone_chain_current_chords",
+        "segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "G"}],
+    }
+    manifest = _project_manifest(
+        project_id,
+        source_hash,
+        source_size_bytes=source_size,
+        extra_revisions=[
+            _current_revision_manifest(
+                project_id,
+                revision_id="rev_tombstone_chain_base_chords",
+                entity_type="chords",
+                payload=base_payload,
+                state="superseded",
+            ),
+            _current_revision_manifest(
+                project_id,
+                revision_id="rev_tombstone_chain_current_chords",
+                entity_type="chords",
+                payload=current_payload,
+                base_revision_id="rev_tombstone_chain_base_chords",
+            ),
+        ],
+    )
+    manifest["delete_tombstones"] = [
+        _tombstone(
+            tombstone_id="tomb_current_chords",
+            project_id=project_id,
+            target_type=ITEM_ENTITY_REVISION,
+            target_id="rev_tombstone_chain_current_chords",
+            author_device_id="peer-a",
+        )
+    ]
+
+    plan = plan_sync_reconciliation(
+        db_session,
+        {
+            "remote_library": {},
+            "project_manifests": [manifest],
+            "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [source_hash]}],
+        },
+    )
+
+    assert _item(plan, ITEM_PROJECT, project_id).status == "noop"
+    for revision_id in ("rev_tombstone_chain_base_chords", "rev_tombstone_chain_current_chords"):
+        assert _action(
+            plan,
+            ACTION_IMPORT_ENTITY_REVISION,
+            ITEM_ENTITY_REVISION,
+            revision_id,
+        ) is None
+
+
+def test_existing_project_skips_embedded_current_revision_when_local_content_exists(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash, source_size = _write_file(tmp_path / "embedded-local-content-source.wav", b"source")
+    project_id = source_hash_to_project_id(source_hash)
+    _add_project(db_session, project_id, source_sha256=source_hash)
+    _add_artifact(
+        db_session,
+        artifact_id=f"art_source_{project_id}",
+        project_id=project_id,
+        path=tmp_path / "embedded-local-content-source.wav",
+        content_sha256=source_hash,
+        size_bytes=source_size,
+        artifact_type="source_audio",
+    )
+    db_session.add_all(
+        [
+            ChordTimeline(project_id=project_id),
+            LyricsTranscript(
+                project_id=project_id,
+                segments_json=[{"start_seconds": 0.0, "end_seconds": 1.0, "text": "local"}],
+            ),
+        ]
+    )
+    db_session.commit()
+
+    chord_payload = {
+        "revision_id": "rev_local_content_chords",
+        "segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "C"}],
+    }
+    lyrics_payload = {
+        "revision_id": "rev_local_content_lyrics",
+        "segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "text": "hello"}],
+    }
+    manifest = _project_manifest(
+        project_id,
+        source_hash,
+        source_size_bytes=source_size,
+        extra_revisions=[
+            _current_revision_manifest(
+                project_id,
+                revision_id="rev_local_content_chords",
+                entity_type="chords",
+                payload=chord_payload,
+            ),
+            _current_revision_manifest(
+                project_id,
+                revision_id="rev_local_content_lyrics",
+                entity_type="lyrics",
+                payload=lyrics_payload,
+            ),
+        ],
+    )
+
+    plan = plan_sync_reconciliation(
+        db_session,
+        {
+            "remote_library": {},
+            "project_manifests": [manifest],
+            "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [source_hash]}],
+        },
+    )
+
+    assert _item(plan, ITEM_PROJECT, project_id).status == "noop"
+    for revision_id in ("rev_local_content_chords", "rev_local_content_lyrics"):
+        assert _action(
+            plan,
+            ACTION_IMPORT_ENTITY_REVISION,
+            ITEM_ENTITY_REVISION,
+            revision_id,
+        ) is None
+
+
+def test_existing_project_skips_embedded_current_revision_when_local_revision_exists(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash, source_size = _write_file(tmp_path / "embedded-local-revision-source.wav", b"source")
+    project_id = source_hash_to_project_id(source_hash)
+    _add_project(db_session, project_id, source_sha256=source_hash)
+    _add_artifact(
+        db_session,
+        artifact_id=f"art_source_{project_id}",
+        project_id=project_id,
+        path=tmp_path / "embedded-local-revision-source.wav",
+        content_sha256=source_hash,
+        size_bytes=source_size,
+        artifact_type="source_audio",
+    )
+    _add_revision(
+        db_session,
+        project_id=project_id,
+        revision_id="rev_local_current_chords",
+        content_sha256=_revision_payload_sha("rev_local_current_chords"),
+        base_revision_id=None,
+    )
+    db_session.commit()
+
+    base_payload = {
+        "revision_id": "rev_remote_base_chords",
+        "segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "C"}],
+    }
+    remote_payload = {
+        "revision_id": "rev_remote_current_chords",
+        "segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "G"}],
+    }
+    manifest = _project_manifest(
+        project_id,
+        source_hash,
+        source_size_bytes=source_size,
+        extra_revisions=[
+            _current_revision_manifest(
+                project_id,
+                revision_id="rev_remote_base_chords",
+                entity_type="chords",
+                payload=base_payload,
+                state="superseded",
+            ),
+            _current_revision_manifest(
+                project_id,
+                revision_id="rev_remote_current_chords",
+                entity_type="chords",
+                payload=remote_payload,
+                base_revision_id="rev_remote_base_chords",
+            )
+        ],
+    )
+
+    plan = plan_sync_reconciliation(
+        db_session,
+        {
+            "remote_library": {},
+            "project_manifests": [manifest],
+            "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [source_hash]}],
+        },
+    )
+
+    assert _item(plan, ITEM_PROJECT, project_id).status == "noop"
+    for revision_id in ("rev_remote_base_chords", "rev_remote_current_chords"):
+        assert all(
+            item.item_id != revision_id
+            for item in plan.items
+            if item.item_type == ITEM_ENTITY_REVISION
+        )
+        assert _action(
+            plan,
+            ACTION_IMPORT_ENTITY_REVISION,
+            ITEM_ENTITY_REVISION,
+            revision_id,
+        ) is None
 
 
 @pytest.mark.parametrize(
@@ -1670,6 +2558,28 @@ def _add_artifact(
     return artifact
 
 
+def _seed_existing_project_with_source(
+    session: Session,
+    tmp_path: Path,
+    *,
+    filename: str,
+) -> tuple[str, int, str]:
+    _add_identity_and_peers(session)
+    source_hash, source_size = _write_file(tmp_path / filename, b"source")
+    project_id = source_hash_to_project_id(source_hash)
+    _add_project(session, project_id, source_sha256=source_hash)
+    _add_artifact(
+        session,
+        artifact_id=f"art_source_{project_id}",
+        project_id=project_id,
+        path=tmp_path / filename,
+        content_sha256=source_hash,
+        size_bytes=source_size,
+        artifact_type="source_audio",
+    )
+    return source_hash, source_size, project_id
+
+
 def _add_revision(
     session: Session,
     *,
@@ -1679,12 +2589,15 @@ def _add_revision(
     base_revision_id: str | None,
     entity_id: str | None = None,
     source_artifact_id: str | None = None,
+    entity_type: str = "chords",
+    payload: dict[str, Any] | None = None,
 ) -> SyncEntityRevision:
     now = datetime.now(UTC)
+    payload_json = {"revision_id": revision_id} if payload is None else payload
     revision = SyncEntityRevision(
         id=revision_id,
         project_id=project_id,
-        entity_type="chords",
+        entity_type=entity_type,
         entity_id=entity_id or project_id,
         revision_type="manual",
         base_revision_id=base_revision_id,
@@ -1693,7 +2606,7 @@ def _add_revision(
         author_device_id="dev-local",
         state="current",
         metadata_json={},
-        payload_json={"revision_id": revision_id},
+        payload_json=payload_json,
         created_at=now,
         updated_at=now,
     )
@@ -1914,6 +2827,37 @@ def _revision_manifest(
         "state": "current",
         "metadata": {},
         "payload": {"revision_id": revision_id},
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
+def _current_revision_manifest(
+    project_id: str,
+    *,
+    revision_id: str,
+    entity_type: str,
+    payload: dict[str, Any],
+    entity_id: str | None = None,
+    base_revision_id: str | None = None,
+    content_sha256: str | None = None,
+    source_artifact_id: str | None = None,
+    state: str = "current",
+) -> dict[str, Any]:
+    now = datetime.now(UTC)
+    return {
+        "revision_id": revision_id,
+        "project_id": project_id,
+        "entity_type": entity_type,
+        "entity_id": entity_id or project_id,
+        "revision_type": "generated",
+        "base_revision_id": base_revision_id,
+        "author_device_id": "peer-a",
+        "source_artifact_id": source_artifact_id,
+        "content_sha256": content_sha256 or revision_payload_sha256(payload),
+        "state": state,
+        "metadata": {},
+        "payload": payload,
         "created_at": now,
         "updated_at": now,
     }

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -20,7 +20,7 @@ tauri = { version = "2.11.2", features = ["protocol-asset"] }
 tauri-plugin-dialog = "2.7.1"
 tauri-plugin-fs = "2.5.0"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["arbitrary_precision"] }
 chrono = { version = "0.4.44", features = ["serde"] }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]

--- a/apps/desktop/src-tauri/src/sync_transport.rs
+++ b/apps/desktop/src-tauri/src/sync_transport.rs
@@ -7613,6 +7613,85 @@ mod desktop {
         }
 
         #[test]
+        fn manifest_offer_round_trip_preserves_hash_bound_lyrics_payload_numbers() {
+            let lyrics_payload_json = concat!(
+                r#"{"segments":[{"end":12.209999999999999,"#,
+                r#""start":11.639999999999999,"text":"first line"},"#,
+                r#"{"end":21.540000000000003,"#,
+                r#""start":20.329999999999998,"text":"second line"}]}"#
+            );
+            let lyrics_payload =
+                serde_json::from_str::<Value>(lyrics_payload_json).expect("parse lyrics payload");
+            let content_sha256 =
+                hex_digest(Sha256::digest(lyrics_payload_json.as_bytes()).as_slice());
+            let manifest = json!({
+                "artifacts": [],
+                "entity_revisions": [{
+                    "content_sha256": content_sha256,
+                    "entity_id": "lyrics-main",
+                    "entity_type": "lyrics",
+                    "metadata": {},
+                    "payload": lyrics_payload,
+                    "revision_id": "lyrics-rev",
+                    "revision_type": "snapshot",
+                    "state": "active",
+                }],
+                "project": { "project_id": "proj_lyrics" },
+            });
+            let message = ProtocolMessage::ManifestOffer(ManifestOffer {
+                metadata: json!({ "projects": [] }),
+                project_manifests: vec![manifest],
+                manifest_errors: Vec::new(),
+            });
+
+            let encoded = serde_json::to_vec(&message).expect("serialize manifest offer");
+            let decoded =
+                serde_json::from_slice::<ProtocolMessage>(&encoded).expect("decode manifest offer");
+            let decoded_manifest = match decoded {
+                ProtocolMessage::ManifestOffer(offer) => offer
+                    .project_manifests
+                    .into_iter()
+                    .next()
+                    .expect("project manifest"),
+                other => panic!("expected manifest offer, got {}", other.kind()),
+            };
+            let decoded_payload = decoded_manifest
+                .pointer("/entity_revisions/0/payload")
+                .expect("lyrics payload");
+            let decoded_payload_bytes =
+                serde_json::to_vec(decoded_payload).expect("serialize decoded lyrics payload");
+            let decoded_payload_json =
+                std::str::from_utf8(&decoded_payload_bytes).expect("utf8 payload json");
+
+            assert_eq!(decoded_payload_json, lyrics_payload_json);
+            assert!(decoded_payload_json.contains("11.639999999999999"));
+            assert!(decoded_payload_json.contains("20.329999999999998"));
+            assert_eq!(
+                hex_digest(Sha256::digest(&decoded_payload_bytes).as_slice()),
+                content_sha256
+            );
+
+            let apply_body = reconciliation_apply_body(
+                "dev_peer",
+                &json!({ "projects": [{ "project_id": "proj_lyrics" }] }),
+                &[decoded_manifest],
+                &[],
+                "tcp",
+            );
+            let apply_body_payload = apply_body
+                .pointer("/project_manifests/0/entity_revisions/0/payload")
+                .expect("apply body lyrics payload");
+            let apply_body_payload_bytes =
+                serde_json::to_vec(apply_body_payload).expect("serialize apply body payload");
+
+            assert_eq!(apply_body_payload_bytes, decoded_payload_bytes);
+            assert_eq!(
+                hex_digest(Sha256::digest(&apply_body_payload_bytes).as_slice()),
+                content_sha256
+            );
+        }
+
+        #[test]
         fn offered_artifacts_are_scoped_to_manifest_metadata() {
             let manifests = vec![json!({
                 "artifacts": [{

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -14,6 +14,9 @@ import { encodePairingCode, pairingFingerprint } from "./features/activity/syncP
 import {
   mockCancelJob,
   mockConfirm,
+  mockGetAnalysis,
+  mockGetChords,
+  mockGetLyrics,
   mockGetProject,
   mockGetMobileCapabilities,
   mockGetSyncIdentity,
@@ -22,9 +25,11 @@ import {
   mockCreateSyncPairingOffer,
   mockListSyncTrustedPeers,
   getMockInvoke,
+  mockListArtifacts,
   mockStartSyncListener,
   mockStopSyncListener,
   mockScanPairingQrCode,
+  mockListSections,
   mockSyncTrustedPeerNow,
   mockTrustSyncPeer,
   mockListJobs,
@@ -178,6 +183,100 @@ async function openSyncTab(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole("tab", { name: "Sync" }));
 
   expect(await screen.findByRole("heading", { level: 2, name: "Sync" })).toBeInTheDocument();
+}
+
+async function primeProjectDataQueries(
+  queryClient: ReturnType<typeof renderApp>["queryClient"],
+  projectId: string,
+) {
+  await Promise.all([
+    queryClient.fetchQuery({
+      queryKey: ["projects", ""],
+      queryFn: () => mockListProjects({ limit: 50, offset: 0 }),
+    }),
+    queryClient.fetchQuery({
+      queryKey: ["project", projectId],
+      queryFn: async () => (await mockGetProject(projectId)).project,
+    }),
+    queryClient.fetchQuery({
+      queryKey: ["lyrics", projectId],
+      queryFn: () => mockGetLyrics(projectId),
+    }),
+    queryClient.fetchQuery({
+      queryKey: ["chords", projectId],
+      queryFn: () => mockGetChords(projectId),
+    }),
+    queryClient.fetchQuery({
+      queryKey: ["analysis", projectId],
+      queryFn: async () => (await mockGetAnalysis(projectId)).analysis,
+    }),
+    queryClient.fetchQuery({
+      queryKey: ["sections", projectId],
+      queryFn: () => mockListSections(projectId),
+    }),
+    queryClient.fetchQuery({
+      queryKey: ["artifacts", projectId],
+      queryFn: async () => (await mockListArtifacts(projectId)).artifacts,
+    }),
+    queryClient.fetchQuery({
+      queryKey: ["jobs", { projectId, scope: "project", status: "active" }],
+      queryFn: () =>
+        mockListJobs({
+          project_id: projectId,
+          status: ["running", "pending"],
+          limit: 200,
+          offset: 0,
+        }),
+    }),
+    queryClient.fetchQuery({
+      queryKey: ["jobs", { projectId, scope: "project", status: "terminal" }],
+      queryFn: () =>
+        mockListJobs({
+          project_id: projectId,
+          status: ["completed", "failed", "cancelled"],
+          limit: 50,
+          offset: 0,
+        }),
+    }),
+  ]);
+}
+
+function expectProjectDataQueriesInvalidationState(
+  queryClient: ReturnType<typeof renderApp>["queryClient"],
+  projectId: string,
+  isInvalidated: boolean,
+) {
+  [
+    ["projects", ""],
+    ["project", projectId],
+    ["lyrics", projectId],
+    ["chords", projectId],
+    ["analysis", projectId],
+    ["sections", projectId],
+    ["artifacts", projectId],
+    ["jobs", { projectId, scope: "project", status: "active" }],
+    ["jobs", { projectId, scope: "project", status: "terminal" }],
+  ].forEach((queryKey) => {
+    const queryState = queryClient.getQueryState(queryKey);
+    expect(queryState, `Expected query ${JSON.stringify(queryKey)} to be primed`).toBeDefined();
+    expect(queryState?.isInvalidated, `Expected query ${JSON.stringify(queryKey)} invalidation state`).toBe(
+      isInvalidated,
+    );
+  });
+}
+
+function expectProjectDataQueriesInvalidated(
+  queryClient: ReturnType<typeof renderApp>["queryClient"],
+  projectId: string,
+) {
+  expectProjectDataQueriesInvalidationState(queryClient, projectId, true);
+}
+
+function expectProjectDataQueriesNotInvalidated(
+  queryClient: ReturnType<typeof renderApp>["queryClient"],
+  projectId: string,
+) {
+  expectProjectDataQueriesInvalidationState(queryClient, projectId, false);
 }
 
 describe("Desktop app activity", () => {
@@ -892,6 +991,165 @@ describe("Desktop app activity", () => {
     expect(within(resultRows[3]).getByText("Failed")).toBeInTheDocument();
     expect(within(resultRows[3]).getByText("proj_missing_audio")).toBeInTheDocument();
     expect(within(resultRows[3]).getByText("Peer did not provide the required source audio.")).toBeInTheDocument();
+  });
+
+  it("refreshes project data queries after sync now imports or applies project data", async () => {
+    const user = userEvent.setup();
+    const projectId = "proj_cache_target";
+    setProjects([project({ id: projectId, display_name: "Cache Target" })]);
+    setJobs([]);
+    setSyncTrustedPeers([
+      {
+        device_id: "device_peer_1",
+        sync_group_id: "sync_group_local",
+        display_name: "Laptop Rig",
+        public_key: "pub_peer_1",
+        endpoint_hints: syncEndpointHints,
+        trusted_at: "2026-04-18T13:16:00.000Z",
+      },
+    ]);
+    mockSyncTrustedPeerNow.mockImplementationOnce(async (deviceId) =>
+      syncRunStatus({
+        peer_device_id: deviceId,
+        remote_device_id: deviceId,
+        selected_transport: irohTransportId,
+        attempted_transports: [irohTransportId],
+        status: "completed",
+        message: "Applied and imported project data.",
+        imported_project_count: 1,
+        applied_project_count: 1,
+        project_results: [
+          {
+            project_id: projectId,
+            status: "applied",
+            message: "Applied remote lyrics, chords, analysis, sections, artifacts, and jobs.",
+          },
+          {
+            project_id: "proj_imported",
+            status: "imported",
+            message: "Imported project from trusted peer.",
+          },
+        ],
+      }),
+    );
+
+    const { queryClient } = renderApp(["/activity"]);
+    expect(await screen.findByRole("heading", { level: 2, name: "Jobs" })).toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "Sync" }));
+    expect(await screen.findByRole("heading", { level: 2, name: "Sync" })).toBeInTheDocument();
+    const peers = await screen.findByRole("list", { name: "Trusted sync peers" });
+    const peerRow = within(peers).getByText("Laptop Rig").closest("li");
+    expect(peerRow).not.toBeNull();
+
+    await primeProjectDataQueries(queryClient, projectId);
+
+    await user.click(within(peerRow as HTMLElement).getByRole("button", { name: "Sync Now" }));
+
+    await waitFor(() => expect(mockSyncTrustedPeerNow).toHaveBeenCalledWith("device_peer_1"));
+    expect(await screen.findAllByText("Applied and imported project data.")).not.toHaveLength(0);
+    const projectResults = await screen.findByRole("list", { name: "Last sync project results" });
+    const resultRows = within(projectResults).getAllByRole("listitem");
+    expect(resultRows).toHaveLength(2);
+    expect(within(resultRows[0]).getByText("Applied")).toBeInTheDocument();
+    expect(within(resultRows[0]).getByText(projectId)).toBeInTheDocument();
+    expect(within(resultRows[1]).getByText("Imported")).toBeInTheDocument();
+    expect(within(resultRows[1]).getByText("proj_imported")).toBeInTheDocument();
+
+    expectProjectDataQueriesInvalidated(queryClient, projectId);
+  });
+
+  it("refreshes project data queries once for new listener-side sync results", async () => {
+    const user = userEvent.setup();
+    const projectId = "proj_listener_cache_target";
+    setProjects([project({ id: projectId, display_name: "Listener Cache Target" })]);
+    setJobs([]);
+    const listenerLastSync = syncRunStatus({
+      run_id: "listener_sync_run_cache_1",
+      session_id: "listener_sync_session_cache_1",
+      peer_device_id: "device_peer_1",
+      remote_device_id: "device_peer_1",
+      selected_transport: irohTransportId,
+      attempted_transports: [irohTransportId],
+      status: "completed_with_errors",
+      message: "Listener applied cached project data.",
+      imported_project_count: 1,
+      applied_project_count: 1,
+      deleted_project_count: 1,
+      project_results: [
+        {
+          project_id: projectId,
+          status: "applied",
+          message: "Applied listener-side project data.",
+        },
+        {
+          project_id: "proj_listener_imported",
+          status: "imported",
+          message: "Imported listener-side project data.",
+        },
+        {
+          project_id: "proj_listener_deleted",
+          status: "deleted",
+          message: "Deleted listener-side project data.",
+        },
+        {
+          project_id: "proj_listener_conflicted",
+          status: "conflicted",
+          message: "Conflicted listener-side project data.",
+        },
+      ],
+      manifest_errors: [],
+      received_artifacts: [],
+      started_at: "2026-04-18T13:16:00.000Z",
+      completed_at: "2026-04-18T13:16:01.000Z",
+    });
+
+    const { queryClient } = renderApp(["/activity"]);
+    expect(await screen.findByRole("heading", { level: 2, name: "Jobs" })).toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "Sync" }));
+    expect(await screen.findByRole("heading", { level: 2, name: "Sync" })).toBeInTheDocument();
+
+    await primeProjectDataQueries(queryClient, projectId);
+    expectProjectDataQueriesNotInvalidated(queryClient, projectId);
+
+    setSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: syncEndpointHints,
+      last_sync: listenerLastSync,
+    });
+    const listenerStatusCalls = mockGetSyncTransportStatus.mock.calls.length;
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: ["sync", "listener"] });
+    });
+    await waitFor(() => expect(mockGetSyncTransportStatus.mock.calls.length).toBeGreaterThan(listenerStatusCalls));
+    expect(await screen.findAllByText("Listener applied cached project data.")).not.toHaveLength(0);
+
+    const projectResults = await screen.findByRole("list", { name: "Last sync project results" });
+    const resultRows = within(projectResults).getAllByRole("listitem");
+    expect(resultRows).toHaveLength(4);
+    expect(within(resultRows[0]).getByText("Applied")).toBeInTheDocument();
+    expect(within(resultRows[0]).getByText(projectId)).toBeInTheDocument();
+    expect(within(resultRows[1]).getByText("Imported")).toBeInTheDocument();
+    expect(within(resultRows[1]).getByText("proj_listener_imported")).toBeInTheDocument();
+    expect(within(resultRows[2]).getByText("Deleted")).toBeInTheDocument();
+    expect(within(resultRows[2]).getByText("proj_listener_deleted")).toBeInTheDocument();
+    expect(within(resultRows[3]).getByText("Conflicted")).toBeInTheDocument();
+    expect(within(resultRows[3]).getByText("proj_listener_conflicted")).toBeInTheDocument();
+    await waitFor(() => expectProjectDataQueriesInvalidated(queryClient, projectId));
+
+    await primeProjectDataQueries(queryClient, projectId);
+    expectProjectDataQueriesNotInvalidated(queryClient, projectId);
+
+    const repeatedListenerStatusCalls = mockGetSyncTransportStatus.mock.calls.length;
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: ["sync", "listener"] });
+    });
+    await waitFor(() =>
+      expect(mockGetSyncTransportStatus.mock.calls.length).toBeGreaterThan(repeatedListenerStatusCalls),
+    );
+    await act(async () => {});
+
+    expectProjectDataQueriesNotInvalidated(queryClient, projectId);
   });
 
   it("busy preflight shows job counts while allowing sync now", async () => {

--- a/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
+++ b/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { QRCodeSVG } from "qrcode.react";
 import {
@@ -26,6 +26,17 @@ import {
 const PAIRING_OFFER_TTL_SECONDS = 600;
 const SYNC_LISTENER_POLL_INTERVAL_MS = 2000;
 const EMPTY_NEARBY_PEERS: SyncNearbyPeer[] = [];
+const PROJECT_MUTATION_QUERY_KEYS = [
+  ["projects"],
+  ["project"],
+  ["lyrics"],
+  ["chords"],
+  ["analysis"],
+  ["sections"],
+  ["artifacts"],
+  ["jobs"],
+] as const;
+const SYNC_PROJECT_MUTATION_STATUSES = new Set(["applied", "conflicted", "deleted", "imported"]);
 
 type PairingOutputKind = "offer" | "response";
 type PairingOutput = {
@@ -360,6 +371,27 @@ function syncResultKey(status: SyncTransportRunStatus | null | undefined) {
   });
 }
 
+function positiveSyncCount(value: number | null | undefined) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function syncProjectResultMutatedLocalCache(result: SyncTransportProjectResult) {
+  return SYNC_PROJECT_MUTATION_STATUSES.has(result.status) ||
+    positiveSyncCount(result.imported_count) ||
+    positiveSyncCount(result.applied_count) ||
+    positiveSyncCount(result.deleted_count);
+}
+
+function syncResultMutatedLocalProjectCaches(status: SyncTransportRunStatus | null | undefined) {
+  if (!status) {
+    return false;
+  }
+  return positiveSyncCount(status.imported_project_count) ||
+    positiveSyncCount(status.applied_project_count) ||
+    positiveSyncCount(status.deleted_project_count) ||
+    mergeSyncProjectResults(status.project_results, status.manifest_errors).some(syncProjectResultMutatedLocalCache);
+}
+
 function formatSyncDuration(seconds: number | null | undefined) {
   if (typeof seconds !== "number" || !Number.isFinite(seconds) || seconds < 0) {
     return null;
@@ -627,6 +659,7 @@ export function ActivitySyncPanel() {
   const [syncNowPolling, setSyncNowPolling] = useState(false);
   const pairingCodeOutputRef = useRef<HTMLTextAreaElement | null>(null);
   const rawPairingOutputRef = useRef<HTMLTextAreaElement | null>(null);
+  const refreshedProjectSyncKeyRef = useRef<string | null>(null);
 
   const identityQuery = useQuery({
     queryKey: ["sync", "identity"],
@@ -699,13 +732,29 @@ export function ActivitySyncPanel() {
   }, [pairingInputValue]);
   const qrScanSupported = mobileCapabilitiesQuery.data?.platform === "android";
 
-  const refreshSyncQueries = async () => {
+  const refreshSyncQueries = useCallback(async () => {
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: ["sync", "listener"] }),
       queryClient.invalidateQueries({ queryKey: ["sync", "preflight"] }),
       queryClient.invalidateQueries({ queryKey: ["sync", "trusted-peers"] }),
     ]);
-  };
+  }, [queryClient]);
+
+  const refreshProjectMutationQueries = useCallback(async () => {
+    await Promise.all(
+      PROJECT_MUTATION_QUERY_KEYS.map((queryKey) => queryClient.invalidateQueries({ queryKey })),
+    );
+  }, [queryClient]);
+
+  useEffect(() => {
+    if (!listenerSyncKey || refreshedProjectSyncKeyRef.current === listenerSyncKey) {
+      return;
+    }
+    refreshedProjectSyncKeyRef.current = listenerSyncKey;
+    if (syncResultMutatedLocalProjectCaches(listenerSyncResult)) {
+      void refreshProjectMutationQueries();
+    }
+  }, [listenerSyncKey, listenerSyncResult, refreshProjectMutationQueries]);
 
   const startListenerMutation = useMutation({
     mutationFn: () => api.startSyncListener(),
@@ -809,7 +858,14 @@ export function ActivitySyncPanel() {
       setLastSyncMessage(syncStatusText(status, peersById));
       setLastSyncResult(status);
       setHiddenListenerSyncKey(listenerSyncKey);
-      await refreshSyncQueries();
+      const shouldRefreshProjectQueries = syncResultMutatedLocalProjectCaches(status);
+      if (shouldRefreshProjectQueries) {
+        refreshedProjectSyncKeyRef.current = syncResultKey(status);
+      }
+      await Promise.all([
+        refreshSyncQueries(),
+        shouldRefreshProjectQueries ? refreshProjectMutationQueries() : Promise.resolve(),
+      ]);
     },
     onError: (error) => {
       setLastSyncMessage(syncNowFailureText(error));


### PR DESCRIPTION
## Summary

- Refresh project data caches after sync imports, applies, deletes, or conflicts with project data.
- Import missing embedded chords and lyrics revisions for already-synced projects, including empty local lyrics placeholders when remote lyrics has content.
- Preserve JSON number precision across the Rust sync transport so hash-bound lyrics payloads survive manifest exchange.

Closes #237

## Testing

- `uv run --python 3.11 pytest tests/test_sync_reconciliation.py`
- `pnpm --filter @tuneforge/desktop test -- App.activity.test.tsx`
- `cargo test manifest_offer_round_trip_preserves_hash_bound_lyrics_payload_numbers --manifest-path apps/desktop/src-tauri/Cargo.toml`
- `git diff --check`
- Manual two-device sync repair: synced an existing broken peer state and verified missing lyrics imported on the VM.
