### PR TITLE
feat: persist source stem analysis metadata

### DIFF
--- a/apps/backend/app/services/chords.py
+++ b/apps/backend/app/services/chords.py
@@ -20,6 +20,7 @@ from app.services.chord_backends import (
 )
 from app.services.paths import project_analysis_dir
 from app.services.stem_models import NON_VOCAL_SIX_STEM_SOURCES, model_output_artifact_type
+from app.services.stem_signal_metadata import stem_signal_analysis_usable
 from app.services.sync_revisions import record_chord_revision
 from app.services.tab_state import clear_project_tab_state
 
@@ -133,26 +134,34 @@ def _source_instrumental_stem(project: Project, source_artifact: Artifact | None
         if artifact.type == "instrumental_stem"
         and Path(artifact.path).exists()
         and artifact.metadata_json.get("source_artifact_id") == source_artifact.id
+        and artifact.metadata_json.get("source_artifact_type") in {None, "source_audio"}
     ]
-    if instrumental_stems:
-        return max(instrumental_stems, key=lambda artifact: artifact.created_at)
-    return None
+    if not instrumental_stems:
+        return None
+    latest_stem = max(instrumental_stems, key=lambda artifact: artifact.created_at)
+    return latest_stem if stem_signal_analysis_usable(latest_stem.metadata_json) else None
 
 
 def _source_non_vocal_stems(project: Project, source_artifact: Artifact | None) -> list[Artifact]:
     if source_artifact is None:
         return []
-    stems_by_source = {
-        artifact.metadata_json.get("stem_source"): artifact
-        for artifact in project.artifacts
-        if artifact.type in {model_output_artifact_type(source) for source in NON_VOCAL_SIX_STEM_SOURCES}
-        and Path(artifact.path).exists()
-        and artifact.metadata_json.get("source_artifact_id") == source_artifact.id
-    }
-    stems = [stems_by_source.get(source) for source in NON_VOCAL_SIX_STEM_SOURCES]
-    if any(stem is None for stem in stems):
-        return []
-    return [stem for stem in stems if stem is not None]
+    expected_artifact_types = {model_output_artifact_type(source) for source in NON_VOCAL_SIX_STEM_SOURCES}
+    stems_by_source: dict[str, Artifact] = {}
+    for artifact in project.artifacts:
+        stem_source = artifact.metadata_json.get("stem_source")
+        if (
+            artifact.type not in expected_artifact_types
+            or stem_source not in NON_VOCAL_SIX_STEM_SOURCES
+            or not Path(artifact.path).exists()
+            or artifact.metadata_json.get("source_artifact_id") != source_artifact.id
+            or artifact.metadata_json.get("source_artifact_type") not in {None, "source_audio"}
+            or not stem_signal_analysis_usable(artifact.metadata_json)
+        ):
+            continue
+        existing = stems_by_source.get(str(stem_source))
+        if existing is None or artifact.created_at > existing.created_at:
+            stems_by_source[str(stem_source)] = artifact
+    return [stems_by_source[source] for source in NON_VOCAL_SIX_STEM_SOURCES if source in stems_by_source]
 
 
 def _source_stem_analysis_available(project: Project, source_artifact: Artifact | None) -> bool:

--- a/apps/backend/app/services/jobs.py
+++ b/apps/backend/app/services/jobs.py
@@ -20,7 +20,14 @@ from app.services.chord_backends import resolve_chord_backend
 from app.services.chords import detect_project_chords, project_chord_detection_source
 from app.services.lyrics import generate_project_lyrics
 from app.services.projects import get_mutable_project, get_project
-from app.services.stem_models import STEM_ARTIFACT_TYPES, TWO_STEMS_MODEL_ID, resolve_stem_model
+from app.services.stem_models import (
+    NON_VOCAL_SIX_STEM_SOURCES,
+    STEM_ARTIFACT_TYPE_SOURCES,
+    STEM_ARTIFACT_TYPES,
+    TWO_STEMS_MODEL_ID,
+    resolve_stem_model,
+)
+from app.services.stem_signal_metadata import stem_signal_analysis_usable
 from app.services.stems import generate_stems, resolve_stem_source_artifact
 from app.services.transformations import (
     build_preview_plan,
@@ -795,11 +802,13 @@ class InProcessJobRunner:
             unregister_process=context.unregister_process,
         )
         artifacts = stem_result.artifacts
+        chord_source = _stem_artifacts_chord_source(artifacts)
         if _should_enqueue_chord_refresh_after_stems(
             job,
             artifacts,
             session.get(ChordTimeline, project.id),
             generated_this_job=stem_result.generated_this_job,
+            signal_metadata_hydrated=stem_result.signal_metadata_hydrated,
         ):
             selected_chord_backend = resolve_chord_backend(
                 str(payload.get("chord_backend", "default")),
@@ -817,7 +826,7 @@ class InProcessJobRunner:
                     "force": True,
                     "overwrite_user_edits": bool(payload.get("overwrite_chord_edits", False)),
                     "chord_backend": selected_chord_backend.id,
-                    "chord_source": "source+stem",
+                    "chord_source": chord_source,
                 },
             )
             self.enqueue(chord_job.id)
@@ -841,21 +850,40 @@ def _should_enqueue_chord_refresh_after_stems(
     chords: ChordTimeline | None,
     *,
     generated_this_job: bool,
+    signal_metadata_hydrated: bool,
 ) -> bool:
-    if not generated_this_job:
+    if not generated_this_job and not signal_metadata_hydrated:
         return False
-    source_stem = next(
-        (
-            artifact
-            for artifact in artifacts
-            if artifact.metadata_json.get("source_artifact_type") == "source_audio"
-            and artifact.metadata_json.get("source_artifact_id")
-        ),
-        None,
-    )
-    if source_stem is None:
+    if _stem_artifacts_chord_source(artifacts) != "source+stem":
         return False
     overwrite_chord_edits = bool(job.payload_json.get("overwrite_chord_edits", False))
     if chords is not None and chords.has_user_edits and not overwrite_chord_edits:
         return False
     return True
+
+
+def _stem_artifacts_chord_source(artifacts: list[Artifact]) -> Literal["source", "source+stem"]:
+    if any(_is_signal_bearing_chord_stem(artifact) for artifact in artifacts):
+        return "source+stem"
+    return "source"
+
+
+def _is_signal_bearing_chord_stem(artifact: Artifact) -> bool:
+    metadata = artifact.metadata_json
+    source_artifact_id = metadata.get("source_artifact_id")
+    if not isinstance(source_artifact_id, str) or not source_artifact_id:
+        return False
+    source_artifact_type = metadata.get("source_artifact_type")
+    if source_artifact_type not in {None, "source_audio"}:
+        return False
+    if not stem_signal_analysis_usable(metadata):
+        return False
+    if artifact.type == "instrumental_stem":
+        return True
+
+    stem_source = metadata.get("stem_source")
+    return (
+        isinstance(stem_source, str)
+        and stem_source in NON_VOCAL_SIX_STEM_SOURCES
+        and STEM_ARTIFACT_TYPE_SOURCES.get(artifact.type) == stem_source
+    )

--- a/apps/backend/app/services/stem_signal_metadata.py
+++ b/apps/backend/app/services/stem_signal_metadata.py
@@ -1,0 +1,430 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from app.engines.audio_signal import inspect_audio_signal_file
+from app.engines.stem_signal import STEM_SIGNAL_THRESHOLDS
+
+STEM_SIGNAL_METADATA_KEY = "stem_signal"
+STEM_SIGNAL_METADATA_VERSION = 1
+STEM_SIGNAL_ANALYSIS_USABILITY_KEY = "analysis_usability"
+STEM_SIGNAL_ANALYSIS_USABILITY_VERSION = 1
+STEM_SIGNAL_ANALYSIS_MIN_RMS_RATIO = 0.10
+STEM_SIGNAL_ANALYSIS_MIN_ACTIVE_RATIO = 0.20
+STEM_SIGNAL_ANALYSIS_CLEAR_ABSENT_RMS_RATIO = 0.01
+
+_STEM_SIGNAL_METADATA_FIELDS = {
+    "version",
+    "has_signal",
+    "peak",
+    "rms",
+    "active_duration_seconds",
+    "inspected_duration_seconds",
+    "active_ratio",
+    "sample_rate",
+    "channels",
+    "thresholds",
+}
+_STEM_SIGNAL_ALLOWED_METADATA_FIELDS = _STEM_SIGNAL_METADATA_FIELDS | {
+    STEM_SIGNAL_ANALYSIS_USABILITY_KEY,
+}
+_STEM_SIGNAL_THRESHOLD_FIELDS = {
+    "peak",
+    "rms",
+    "active_duration_seconds",
+    "window_seconds",
+}
+_STEM_SIGNAL_ANALYSIS_USABILITY_FIELDS = {
+    "version",
+    "usable",
+    "reason",
+    "rms_ratio",
+    "rms_db_below_reference",
+    "active_ratio",
+    "peak_ratio",
+    "reference",
+    "thresholds",
+}
+_STEM_SIGNAL_ANALYSIS_REFERENCE_FIELDS = {
+    "max_rms",
+    "max_active_duration_seconds",
+    "max_peak",
+}
+_STEM_SIGNAL_ANALYSIS_THRESHOLD_FIELDS = {
+    "min_rms_ratio",
+    "min_active_ratio",
+    "clear_absent_rms_ratio",
+}
+_STEM_SIGNAL_ANALYSIS_REASONS = {
+    "absolute_no_signal",
+    "relative_absent",
+    "relative_leakage",
+    "usable",
+}
+
+
+def build_stem_signal_metadata(path: Path) -> dict[str, Any]:
+    summary = inspect_audio_signal_file(path, STEM_SIGNAL_THRESHOLDS)
+    return {
+        "version": STEM_SIGNAL_METADATA_VERSION,
+        "has_signal": bool(summary.has_signal),
+        "peak": float(summary.peak),
+        "rms": float(summary.rms),
+        "active_duration_seconds": float(summary.active_duration_seconds),
+        "inspected_duration_seconds": float(summary.inspected_duration_seconds),
+        "active_ratio": float(summary.active_ratio),
+        "sample_rate": int(summary.sample_rate),
+        "channels": int(summary.channels),
+        "thresholds": {
+            "peak": float(STEM_SIGNAL_THRESHOLDS.peak),
+            "rms": float(STEM_SIGNAL_THRESHOLDS.rms),
+            "active_duration_seconds": float(STEM_SIGNAL_THRESHOLDS.active_duration_seconds),
+            "window_seconds": float(STEM_SIGNAL_THRESHOLDS.window_seconds),
+        },
+    }
+
+
+def has_current_stem_signal_metadata(metadata: Mapping[str, Any]) -> bool:
+    return _current_stem_signal_metadata(metadata) is not None
+
+
+def stem_signal_has_signal(metadata: Mapping[str, Any]) -> bool | None:
+    stem_signal = _current_stem_signal_metadata(metadata)
+    if stem_signal is None:
+        return None
+    return bool(stem_signal["has_signal"])
+
+
+def stem_signal_analysis_usable(metadata: Mapping[str, Any]) -> bool:
+    usability = _current_stem_signal_analysis_usability(metadata)
+    if usability is None:
+        return False
+    return bool(usability["usable"])
+
+
+def has_current_stem_signal_analysis_usability(metadata: Mapping[str, Any]) -> bool:
+    return _current_stem_signal_analysis_usability(metadata) is not None
+
+
+def add_analysis_usability_to_stem_signal_metadatas(
+    metadatas: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    stem_signals: list[Mapping[str, Any]] = []
+    for metadata in metadatas:
+        stem_signal = _current_stem_signal_metadata(metadata)
+        if stem_signal is None:
+            raise ValueError("Current stem_signal metadata is required for analysis usability.")
+        stem_signals.append(stem_signal)
+
+    usabilities = _build_stem_signal_analysis_usabilities(stem_signals)
+    updated_metadatas: list[dict[str, Any]] = []
+    for metadata, stem_signal_metadata, usability in zip(metadatas, stem_signals, usabilities, strict=True):
+        updated_metadata = dict(metadata)
+        stem_signal = dict(stem_signal_metadata)
+        stem_signal[STEM_SIGNAL_ANALYSIS_USABILITY_KEY] = usability
+        updated_metadata[STEM_SIGNAL_METADATA_KEY] = stem_signal
+        updated_metadatas.append(updated_metadata)
+    return updated_metadatas
+
+
+def _current_stem_signal_metadata(metadata: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    stem_signal = metadata.get(STEM_SIGNAL_METADATA_KEY)
+    if not isinstance(stem_signal, Mapping):
+        return None
+    stem_signal_keys = set(stem_signal.keys())
+    if not _STEM_SIGNAL_METADATA_FIELDS.issubset(stem_signal_keys):
+        return None
+    if stem_signal_keys - _STEM_SIGNAL_ALLOWED_METADATA_FIELDS:
+        return None
+    if not _is_current_metadata_version(stem_signal.get("version")):
+        return None
+    if not isinstance(stem_signal.get("has_signal"), bool):
+        return None
+    if not _has_signal_metrics(stem_signal):
+        return None
+
+    thresholds = stem_signal.get("thresholds")
+    if not isinstance(thresholds, Mapping):
+        return None
+    if set(thresholds.keys()) != _STEM_SIGNAL_THRESHOLD_FIELDS:
+        return None
+    if not all(_is_non_negative_number(thresholds.get(key)) for key in _STEM_SIGNAL_THRESHOLD_FIELDS):
+        return None
+    if not _is_positive_number(thresholds.get("window_seconds")):
+        return None
+
+    return stem_signal
+
+
+def _current_stem_signal_analysis_usability(metadata: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    stem_signal = _current_stem_signal_metadata(metadata)
+    if stem_signal is None:
+        return None
+    usability = stem_signal.get(STEM_SIGNAL_ANALYSIS_USABILITY_KEY)
+    if not isinstance(usability, Mapping):
+        return None
+    if set(usability.keys()) != _STEM_SIGNAL_ANALYSIS_USABILITY_FIELDS:
+        return None
+    if not _is_current_analysis_usability_version(usability.get("version")):
+        return None
+    if not isinstance(usability.get("usable"), bool):
+        return None
+    if usability.get("reason") not in _STEM_SIGNAL_ANALYSIS_REASONS:
+        return None
+    if not all(
+        _is_non_negative_number(usability.get(field))
+        for field in ("rms_ratio", "active_ratio", "peak_ratio")
+    ):
+        return None
+    rms_db_below_reference = usability.get("rms_db_below_reference")
+    if rms_db_below_reference is not None and not _is_finite_number(rms_db_below_reference):
+        return None
+
+    reference = usability.get("reference")
+    if not isinstance(reference, Mapping):
+        return None
+    if set(reference.keys()) != _STEM_SIGNAL_ANALYSIS_REFERENCE_FIELDS:
+        return None
+    if not all(_is_non_negative_number(reference.get(key)) for key in _STEM_SIGNAL_ANALYSIS_REFERENCE_FIELDS):
+        return None
+
+    thresholds = usability.get("thresholds")
+    if not isinstance(thresholds, Mapping):
+        return None
+    if set(thresholds.keys()) != _STEM_SIGNAL_ANALYSIS_THRESHOLD_FIELDS:
+        return None
+    if not all(_is_non_negative_number(thresholds.get(key)) for key in _STEM_SIGNAL_ANALYSIS_THRESHOLD_FIELDS):
+        return None
+    if not _has_current_analysis_thresholds(thresholds):
+        return None
+    if not _is_consistent_analysis_usability(stem_signal, usability, reference, thresholds):
+        return None
+
+    return usability
+
+
+def _build_stem_signal_analysis_usabilities(
+    stem_signals: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    max_rms = max((float(stem_signal["rms"]) for stem_signal in stem_signals), default=0.0)
+    max_active_duration = max(
+        (float(stem_signal["active_duration_seconds"]) for stem_signal in stem_signals),
+        default=0.0,
+    )
+    max_peak = max((float(stem_signal["peak"]) for stem_signal in stem_signals), default=0.0)
+    reference = {
+        "max_rms": float(max_rms),
+        "max_active_duration_seconds": float(max_active_duration),
+        "max_peak": float(max_peak),
+    }
+    thresholds = {
+        "min_rms_ratio": float(STEM_SIGNAL_ANALYSIS_MIN_RMS_RATIO),
+        "min_active_ratio": float(STEM_SIGNAL_ANALYSIS_MIN_ACTIVE_RATIO),
+        "clear_absent_rms_ratio": float(STEM_SIGNAL_ANALYSIS_CLEAR_ABSENT_RMS_RATIO),
+    }
+
+    return [
+        _build_stem_signal_analysis_usability(
+            stem_signal,
+            reference=reference,
+            thresholds=thresholds,
+        )
+        for stem_signal in stem_signals
+    ]
+
+
+def _build_stem_signal_analysis_usability(
+    stem_signal: Mapping[str, Any],
+    *,
+    reference: Mapping[str, float],
+    thresholds: Mapping[str, float],
+) -> dict[str, Any]:
+    rms_ratio = _safe_ratio(float(stem_signal["rms"]), reference["max_rms"])
+    active_ratio = _safe_ratio(
+        float(stem_signal["active_duration_seconds"]),
+        reference["max_active_duration_seconds"],
+    )
+    peak_ratio = _safe_ratio(float(stem_signal["peak"]), reference["max_peak"])
+    if stem_signal["has_signal"] is not True:
+        usable = False
+        reason = "absolute_no_signal"
+    elif rms_ratio < thresholds["clear_absent_rms_ratio"]:
+        usable = False
+        reason = "relative_absent"
+    elif rms_ratio < thresholds["min_rms_ratio"] and active_ratio < thresholds["min_active_ratio"]:
+        usable = False
+        reason = "relative_leakage"
+    else:
+        usable = True
+        reason = "usable"
+
+    rms_db_below_reference = 20.0 * math.log10(rms_ratio) if rms_ratio > 0.0 else None
+    return {
+        "version": STEM_SIGNAL_ANALYSIS_USABILITY_VERSION,
+        "usable": usable,
+        "reason": reason,
+        "rms_ratio": float(rms_ratio),
+        "rms_db_below_reference": rms_db_below_reference,
+        "active_ratio": float(active_ratio),
+        "peak_ratio": float(peak_ratio),
+        "reference": dict(reference),
+        "thresholds": dict(thresholds),
+    }
+
+
+def _has_signal_metrics(stem_signal: Mapping[str, Any]) -> bool:
+    float_fields = (
+        "peak",
+        "rms",
+        "active_duration_seconds",
+        "inspected_duration_seconds",
+        "active_ratio",
+    )
+    if not all(_is_non_negative_number(stem_signal.get(field)) for field in float_fields):
+        return False
+    if not _is_positive_int(stem_signal.get("sample_rate")):
+        return False
+    return _is_positive_int(stem_signal.get("channels"))
+
+
+def _is_non_negative_number(value: object) -> bool:
+    return (
+        isinstance(value, int | float)
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+        and float(value) >= 0.0
+    )
+
+
+def _is_finite_number(value: object) -> bool:
+    return _finite_float(value) is not None
+
+
+def _has_current_analysis_thresholds(thresholds: Mapping[str, Any]) -> bool:
+    return (
+        _is_close_float(thresholds.get("min_rms_ratio"), STEM_SIGNAL_ANALYSIS_MIN_RMS_RATIO)
+        and _is_close_float(thresholds.get("min_active_ratio"), STEM_SIGNAL_ANALYSIS_MIN_ACTIVE_RATIO)
+        and _is_close_float(
+            thresholds.get("clear_absent_rms_ratio"),
+            STEM_SIGNAL_ANALYSIS_CLEAR_ABSENT_RMS_RATIO,
+        )
+    )
+
+
+def _is_consistent_analysis_usability(
+    stem_signal: Mapping[str, Any],
+    usability: Mapping[str, Any],
+    reference: Mapping[str, Any],
+    thresholds: Mapping[str, Any],
+) -> bool:
+    if not _reference_covers_stem_signal(stem_signal, reference):
+        return False
+    expected_rms_ratio = _safe_ratio(float(stem_signal["rms"]), float(reference["max_rms"]))
+    expected_active_ratio = _safe_ratio(
+        float(stem_signal["active_duration_seconds"]),
+        float(reference["max_active_duration_seconds"]),
+    )
+    expected_peak_ratio = _safe_ratio(float(stem_signal["peak"]), float(reference["max_peak"]))
+    if not (
+        _is_close_float(usability.get("rms_ratio"), expected_rms_ratio)
+        and _is_close_float(usability.get("active_ratio"), expected_active_ratio)
+        and _is_close_float(usability.get("peak_ratio"), expected_peak_ratio)
+    ):
+        return False
+
+    expected_rms_db = 20.0 * math.log10(expected_rms_ratio) if expected_rms_ratio > 0.0 else None
+    rms_db_below_reference = usability.get("rms_db_below_reference")
+    if expected_rms_db is None:
+        if rms_db_below_reference is not None:
+            return False
+    elif not _is_close_float(rms_db_below_reference, expected_rms_db):
+        return False
+
+    expected_usable, expected_reason = _analysis_usability_decision(
+        stem_signal,
+        rms_ratio=expected_rms_ratio,
+        active_ratio=expected_active_ratio,
+        thresholds=thresholds,
+    )
+    return usability.get("usable") is expected_usable and usability.get("reason") == expected_reason
+
+
+def _analysis_usability_decision(
+    stem_signal: Mapping[str, Any],
+    *,
+    rms_ratio: float,
+    active_ratio: float,
+    thresholds: Mapping[str, Any],
+) -> tuple[bool, str]:
+    if stem_signal["has_signal"] is not True:
+        return False, "absolute_no_signal"
+    if rms_ratio < float(thresholds["clear_absent_rms_ratio"]):
+        return False, "relative_absent"
+    if rms_ratio < float(thresholds["min_rms_ratio"]) and active_ratio < float(thresholds["min_active_ratio"]):
+        return False, "relative_leakage"
+    return True, "usable"
+
+
+def _reference_covers_stem_signal(stem_signal: Mapping[str, Any], reference: Mapping[str, Any]) -> bool:
+    return (
+        _is_at_least(reference.get("max_rms"), float(stem_signal["rms"]))
+        and _is_at_least(
+            reference.get("max_active_duration_seconds"),
+            float(stem_signal["active_duration_seconds"]),
+        )
+        and _is_at_least(reference.get("max_peak"), float(stem_signal["peak"]))
+    )
+
+
+def _is_at_least(value: object, expected_minimum: float) -> bool:
+    finite_value = _finite_float(value)
+    return finite_value is not None and finite_value + 1e-12 >= expected_minimum
+
+
+def _is_close_float(value: object, expected: float) -> bool:
+    finite_value = _finite_float(value)
+    return finite_value is not None and math.isclose(finite_value, expected, rel_tol=1e-9, abs_tol=1e-12)
+
+
+def _finite_float(value: object) -> float | None:
+    if isinstance(value, int | float) and not isinstance(value, bool) and math.isfinite(float(value)):
+        return float(value)
+    return None
+
+
+def _is_positive_number(value: object) -> bool:
+    return (
+        isinstance(value, int | float)
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+        and float(value) > 0.0
+    )
+
+
+def _is_positive_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+def _is_current_metadata_version(value: object) -> bool:
+    return (
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and value == STEM_SIGNAL_METADATA_VERSION
+    )
+
+
+def _is_current_analysis_usability_version(value: object) -> bool:
+    return (
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and value == STEM_SIGNAL_ANALYSIS_USABILITY_VERSION
+    )
+
+
+def _safe_ratio(value: float, reference: float) -> float:
+    if reference <= 0.0:
+        return 0.0
+    return value / reference

--- a/apps/backend/app/services/stems.py
+++ b/apps/backend/app/services/stems.py
@@ -23,6 +23,13 @@ from app.services.stem_models import (
     model_output_artifact_type,
     resolve_stem_model,
 )
+from app.services.stem_signal_metadata import (
+    STEM_SIGNAL_METADATA_KEY,
+    add_analysis_usability_to_stem_signal_metadatas,
+    build_stem_signal_metadata,
+    has_current_stem_signal_analysis_usability,
+    has_current_stem_signal_metadata,
+)
 from app.services.sync_tombstones import record_artifact_delete_tombstone
 from app.utils.ids import new_id
 
@@ -39,6 +46,7 @@ class StemOutputPlan:
 class StemGenerationResult:
     artifacts: list[Artifact]
     generated_this_job: bool
+    signal_metadata_hydrated: bool = False
 
 
 def _default_source_artifact(session: Session, *, project_id: str) -> Artifact:
@@ -289,6 +297,32 @@ def _cleanup_stem_outputs(plan: list[StemOutputPlan]) -> None:
         _cleanup_artifact_path(output.path)
 
 
+def _hydrate_stem_signal_metadata(session: Session, artifacts: list[Artifact]) -> bool:
+    updated = False
+    for artifact in artifacts:
+        if has_current_stem_signal_metadata(artifact.metadata_json):
+            continue
+        metadata = dict(artifact.metadata_json)
+        metadata[STEM_SIGNAL_METADATA_KEY] = build_stem_signal_metadata(Path(artifact.path))
+        artifact.metadata_json = metadata
+        updated = True
+
+    if artifacts and any(
+        not has_current_stem_signal_analysis_usability(artifact.metadata_json)
+        for artifact in artifacts
+    ):
+        updated_metadatas = add_analysis_usability_to_stem_signal_metadatas(
+            [artifact.metadata_json for artifact in artifacts]
+        )
+        for artifact, metadata in zip(artifacts, updated_metadatas, strict=True):
+            artifact.metadata_json = metadata
+        updated = True
+
+    if updated:
+        session.flush()
+    return updated
+
+
 def generate_stems(
     session: Session,
     *,
@@ -320,9 +354,16 @@ def generate_stems(
             stem_model=selected_model,
         )
         if existing:
+            signal_metadata_hydrated = False
+            if source_artifact.type == "source_audio":
+                signal_metadata_hydrated = _hydrate_stem_signal_metadata(session, existing)
             if on_progress:
                 on_progress(100)
-            return StemGenerationResult(artifacts=existing, generated_this_job=False)
+            return StemGenerationResult(
+                artifacts=existing,
+                generated_this_job=False,
+                signal_metadata_hydrated=signal_metadata_hydrated,
+            )
 
     plan = build_stem_plan(
         source_artifact,
@@ -358,6 +399,7 @@ def generate_stems(
     existing_by_type = {artifact.type: artifact for artifact in existing_artifacts}
     saved_artifacts: list[Artifact] = []
 
+    stem_output_metadatas: list[tuple[StemOutputPlan, dict[str, Any]]] = []
     for output in plan:
         stem_metadata = {
             "mode": selected_model.mode,
@@ -368,6 +410,24 @@ def generate_stems(
             "source_artifact_type": source_artifact.type,
             **metadata,
         }
+        if source_artifact.type == "source_audio":
+            stem_metadata[STEM_SIGNAL_METADATA_KEY] = build_stem_signal_metadata(output.path)
+        stem_output_metadatas.append((output, stem_metadata))
+
+    if source_artifact.type == "source_audio":
+        updated_metadatas = add_analysis_usability_to_stem_signal_metadatas(
+            [stem_metadata for _, stem_metadata in stem_output_metadatas]
+        )
+        stem_output_metadatas = [
+            (output, updated_metadata)
+            for (output, _), updated_metadata in zip(
+                stem_output_metadatas,
+                updated_metadatas,
+                strict=True,
+            )
+        ]
+
+    for output, stem_metadata in stem_output_metadatas:
         saved_artifacts.append(
             _upsert_stem_artifact(
                 session,

--- a/apps/backend/tests/test_chord_flow.py
+++ b/apps/backend/tests/test_chord_flow.py
@@ -10,8 +10,13 @@ from app.db import SessionLocal
 from app.models import SongSection, TabImport
 from app.services.artifacts import register_artifact
 from app.services.chord_backends import ChordDetectionResult
-from app.services.chords import detect_project_chords
+from app.services.chords import detect_project_chords, project_chord_detection_source
 from app.services.projects import get_project
+from app.services.stem_signal_metadata import (
+    STEM_SIGNAL_METADATA_KEY,
+    STEM_SIGNAL_METADATA_VERSION,
+    stem_signal_analysis_usable,
+)
 
 from .conftest import wait_for_job
 
@@ -25,6 +30,77 @@ def _segment(label: str, *, confidence: float, pitch_class: int, quality: str) -
         "pitch_class": pitch_class,
         "quality": quality,
     }
+
+
+def _stem_signal_metadata(
+    *,
+    has_signal: bool,
+    version: int = STEM_SIGNAL_METADATA_VERSION,
+    include_usability: bool = True,
+    usable: bool | None = None,
+    analysis_version: int = 1,
+) -> dict[str, Any]:
+    peak = 0.4 if has_signal else 0.0
+    rms = 0.2 if has_signal else 0.0
+    active_duration = 2.0 if has_signal else 0.0
+    stem_signal: dict[str, Any] = {
+        "version": version,
+        "has_signal": has_signal,
+        "peak": peak,
+        "rms": rms,
+        "active_duration_seconds": active_duration,
+        "inspected_duration_seconds": 4.0,
+        "active_ratio": active_duration / 4.0,
+        "sample_rate": 44_100,
+        "channels": 2,
+        "thresholds": {
+            "peak": 0.001,
+            "rms": 0.0005,
+            "active_duration_seconds": 0.2,
+            "window_seconds": 0.05,
+        },
+    }
+    if include_usability:
+        analysis_usable = has_signal if usable is None else usable
+        stem_signal["analysis_usability"] = {
+            "version": analysis_version,
+            "usable": analysis_usable,
+            "reason": "usable"
+            if analysis_usable
+            else ("absolute_no_signal" if not has_signal else "relative_leakage"),
+            "rms_ratio": 1.0 if has_signal else 0.0,
+            "rms_db_below_reference": 0.0 if has_signal else None,
+            "active_ratio": 1.0 if has_signal else 0.0,
+            "peak_ratio": 1.0 if has_signal else 0.0,
+            "reference": {
+                "max_rms": rms,
+                "max_active_duration_seconds": active_duration,
+                "max_peak": peak,
+            },
+            "thresholds": {
+                "min_rms_ratio": 0.10,
+                "min_active_ratio": 0.20,
+                "clear_absent_rms_ratio": 0.01,
+            },
+        }
+    return {
+        STEM_SIGNAL_METADATA_KEY: stem_signal
+    }
+
+
+def _forbid_chord_signal_inspection(monkeypatch) -> None:
+    def raise_if_called(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("chord flow must only read persisted stem_signal metadata")
+
+    monkeypatch.setattr("app.services.stem_signal_metadata.build_stem_signal_metadata", raise_if_called)
+    monkeypatch.setattr("app.services.stem_signal_metadata.inspect_audio_signal_file", raise_if_called)
+    monkeypatch.setattr("app.engines.audio_signal.inspect_audio_signal_file", raise_if_called)
+
+
+def test_stem_signal_analysis_usability_rejects_raw_no_signal_with_usable_flag():
+    metadata = _stem_signal_metadata(has_signal=False, usable=True)
+
+    assert stem_signal_analysis_usable(metadata) is False
 
 
 def test_chord_job_persists_timeline(client, sample_chord_audio_file: Path):
@@ -160,12 +236,22 @@ def test_import_chord_job_falls_back_when_requested_advanced_backend_is_unavaila
 
 
 @pytest.mark.parametrize("backend_id", ["tuneforge-fast", "crema-advanced"])
-def test_chord_refresh_uses_source_stems_only_for_augmentation(
+@pytest.mark.parametrize(
+    ("stem_has_signal", "expected_label", "expected_detection_source"),
+    [
+        (True, "G", "source+stem"),
+        (False, "Em", "source"),
+    ],
+)
+def test_chord_refresh_uses_signal_bearing_source_stems_only_for_augmentation(
     client,
     sample_chord_audio_file: Path,
     tmp_path: Path,
     monkeypatch,
     backend_id: str,
+    stem_has_signal: bool,
+    expected_label: str,
+    expected_detection_source: str,
 ):
     project = client.post(
         "/api/v1/projects/import",
@@ -203,7 +289,11 @@ def test_chord_refresh_uses_source_stems_only_for_augmentation(
             artifact_type="instrumental_stem",
             artifact_format="wav",
             path=mix_stem_path,
-            metadata={"source_artifact_id": mix_artifact.id, "source_artifact_type": "preview_mix"},
+            metadata={
+                "source_artifact_id": mix_artifact.id,
+                "source_artifact_type": "preview_mix",
+                **_stem_signal_metadata(has_signal=True),
+            },
             generated_by="demucs",
         )
         register_artifact(
@@ -212,10 +302,17 @@ def test_chord_refresh_uses_source_stems_only_for_augmentation(
             artifact_type="instrumental_stem",
             artifact_format="wav",
             path=source_stem_path,
-            metadata={"source_artifact_id": source_artifact.id, "source_artifact_type": "source_audio"},
+            metadata={
+                "source_artifact_id": source_artifact.id,
+                "source_artifact_type": "source_audio",
+                **_stem_signal_metadata(has_signal=stem_has_signal),
+            },
             generated_by="demucs",
         )
         session.commit()
+
+    _forbid_chord_signal_inspection(monkeypatch)
+    detected_paths: list[Path] = []
 
     def fake_resolve_chord_backend(requested_backend: str, *, require_available: bool = False):
         del require_available
@@ -228,6 +325,7 @@ def test_chord_refresh_uses_source_stems_only_for_augmentation(
 
     def fake_detect_timeline(path: Path, selected_backend_id: str) -> ChordDetectionResult:
         assert selected_backend_id == backend_id
+        detected_paths.append(path)
         if path == source_stem_path:
             segments = [_segment("G", confidence=0.88, pitch_class=7, quality="major")]
             return ChordDetectionResult(segments=segments, backend_id=selected_backend_id, metadata={})
@@ -242,13 +340,78 @@ def test_chord_refresh_uses_source_stems_only_for_augmentation(
 
     with SessionLocal() as session:
         project_model = get_project(session, project["id"])
+        assert project_chord_detection_source(project_model, backend=backend_id) == expected_detection_source
         chords = detect_project_chords(session, project_model, backend=backend_id, force=True)
         session.commit()
 
     assert chords.backend == backend_id
     assert chords.source_artifact_id == source_artifact.id
     assert [segment["label"] for segment in chords.source_segments_json] == ["Em"]
-    assert [segment["label"] for segment in chords.segments_json] == ["G"]
+    assert [segment["label"] for segment in chords.segments_json] == [expected_label]
+    assert (source_stem_path in detected_paths) is stem_has_signal
+    assert mix_stem_path not in detected_paths
+
+
+def test_chord_refresh_ignores_instrumental_stem_with_non_source_artifact_type(
+    client,
+    sample_chord_audio_file: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    project = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_chord_audio_file), "copy_into_project": True},
+    ).json()["project"]
+
+    initial_jobs = client.get("/api/v1/jobs").json()["jobs"]
+    initial_chord_job = next(
+        job for job in initial_jobs if job["project_id"] == project["id"] and job["type"] == "chords"
+    )
+    assert wait_for_job(client, initial_chord_job["id"])["status"] == "completed"
+
+    wrong_source_type_stem_path = tmp_path / "wrong-source-type-instrumental.wav"
+    wrong_source_type_stem_path.write_bytes(b"bad-stem")
+
+    with SessionLocal() as session:
+        project_model = get_project(session, project["id"])
+        source_artifact = next(artifact for artifact in project_model.artifacts if artifact.type == "source_audio")
+        register_artifact(
+            session,
+            project_id=project_model.id,
+            artifact_type="instrumental_stem",
+            artifact_format="wav",
+            path=wrong_source_type_stem_path,
+            metadata={
+                "source_artifact_id": source_artifact.id,
+                "source_artifact_type": "preview_mix",
+                **_stem_signal_metadata(has_signal=True),
+            },
+            generated_by="demucs",
+        )
+        session.commit()
+
+    _forbid_chord_signal_inspection(monkeypatch)
+    detected_paths: list[Path] = []
+
+    def fake_detect_timeline(path: Path, selected_backend_id: str) -> ChordDetectionResult:
+        detected_paths.append(path)
+        return ChordDetectionResult(
+            segments=[_segment("Em", confidence=0.35, pitch_class=4, quality="minor")],
+            backend_id=selected_backend_id,
+            metadata={},
+        )
+
+    monkeypatch.setattr("app.services.chords._detect_timeline", fake_detect_timeline)
+
+    with SessionLocal() as session:
+        project_model = get_project(session, project["id"])
+        assert project_chord_detection_source(project_model) == "source"
+        chords = detect_project_chords(session, project_model, force=True)
+        session.commit()
+
+    assert [segment["label"] for segment in chords.source_segments_json] == ["Em"]
+    assert [segment["label"] for segment in chords.segments_json] == ["Em"]
+    assert wrong_source_type_stem_path not in detected_paths
 
 
 def test_chord_refresh_uses_temporary_six_stem_non_vocal_mix(
@@ -271,6 +434,13 @@ def test_chord_refresh_uses_temporary_six_stem_non_vocal_mix(
     with SessionLocal() as session:
         project_model = get_project(session, project["id"])
         source_artifact = next(artifact for artifact in project_model.artifacts if artifact.type == "source_audio")
+        metadata_by_source = {
+            "drums": _stem_signal_metadata(has_signal=True),
+            "bass": _stem_signal_metadata(has_signal=False),
+            "guitar": _stem_signal_metadata(has_signal=True),
+            "piano": {"source_artifact_type": "preview_mix", **_stem_signal_metadata(has_signal=True)},
+            "other": _stem_signal_metadata(has_signal=True, version=0),
+        }
         for source, artifact_type in [
             ("drums", "drums_stem"),
             ("bass", "bass_stem"),
@@ -291,11 +461,13 @@ def test_chord_refresh_uses_temporary_six_stem_non_vocal_mix(
                     "source_artifact_type": "source_audio",
                     "stem_model": "htdemucs_6s",
                     "stem_source": source,
+                    **metadata_by_source[source],
                 },
                 generated_by="demucs",
             )
         session.commit()
 
+    _forbid_chord_signal_inspection(monkeypatch)
     temp_mix_paths: list[Path] = []
 
     def fake_mix_audio_files(
@@ -306,7 +478,7 @@ def test_chord_refresh_uses_temporary_six_stem_non_vocal_mix(
         block_size: int = 0,
     ):
         assert subtype == "FLOAT"
-        assert [path.name for path in source_paths] == ["drums.wav", "bass.wav", "guitar.wav", "piano.wav", "other.wav"]
+        assert [path.name for path in source_paths] == ["drums.wav", "guitar.wav"]
         output_path.write_bytes(b"non-vocal")
         temp_mix_paths.append(output_path)
 
@@ -330,6 +502,7 @@ def test_chord_refresh_uses_temporary_six_stem_non_vocal_mix(
 
     with SessionLocal() as session:
         project_model = get_project(session, project["id"])
+        assert project_chord_detection_source(project_model) == "source+stem"
         chords = detect_project_chords(session, project_model, force=True)
         session.commit()
 
@@ -337,6 +510,85 @@ def test_chord_refresh_uses_temporary_six_stem_non_vocal_mix(
     assert [segment["label"] for segment in chords.segments_json] == ["G"]
     assert temp_mix_paths
     assert all(not path.exists() for path in temp_mix_paths)
+
+
+def test_chord_refresh_skips_six_stem_mix_without_signal_bearing_non_vocal_stems(
+    client,
+    sample_chord_audio_file: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    project = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_chord_audio_file), "copy_into_project": True},
+    ).json()["project"]
+
+    initial_jobs = client.get("/api/v1/jobs").json()["jobs"]
+    initial_chord_job = next(
+        job for job in initial_jobs if job["project_id"] == project["id"] and job["type"] == "chords"
+    )
+    assert wait_for_job(client, initial_chord_job["id"])["status"] == "completed"
+
+    with SessionLocal() as session:
+        project_model = get_project(session, project["id"])
+        source_artifact = next(artifact for artifact in project_model.artifacts if artifact.type == "source_audio")
+        metadata_by_source = {
+            "drums": {},
+            "bass": _stem_signal_metadata(has_signal=False),
+            "guitar": _stem_signal_metadata(has_signal=True, version=0),
+            "piano": {STEM_SIGNAL_METADATA_KEY: {"version": STEM_SIGNAL_METADATA_VERSION, "has_signal": True}},
+            "other": _stem_signal_metadata(has_signal=True, include_usability=False),
+        }
+        for source, artifact_type in [
+            ("drums", "drums_stem"),
+            ("bass", "bass_stem"),
+            ("guitar", "guitar_stem"),
+            ("piano", "piano_stem"),
+            ("other", "other_stem"),
+        ]:
+            path = tmp_path / f"{source}.wav"
+            path.write_bytes(source.encode("utf-8"))
+            register_artifact(
+                session,
+                project_id=project_model.id,
+                artifact_type=artifact_type,
+                artifact_format="wav",
+                path=path,
+                metadata={
+                    "source_artifact_id": source_artifact.id,
+                    "source_artifact_type": "source_audio",
+                    "stem_model": "htdemucs_6s",
+                    "stem_source": source,
+                    **metadata_by_source[source],
+                },
+                generated_by="demucs",
+            )
+        session.commit()
+
+    _forbid_chord_signal_inspection(monkeypatch)
+
+    def fail_mix_audio_files(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("six-stem mix should not run without signal-bearing stems")
+
+    def fake_detect_timeline(path: Path, selected_backend_id: str) -> ChordDetectionResult:
+        del path
+        return ChordDetectionResult(
+            segments=[_segment("Em", confidence=0.35, pitch_class=4, quality="minor")],
+            backend_id=selected_backend_id,
+            metadata={},
+        )
+
+    monkeypatch.setattr("app.services.chords.mix_audio_files", fail_mix_audio_files)
+    monkeypatch.setattr("app.services.chords._detect_timeline", fake_detect_timeline)
+
+    with SessionLocal() as session:
+        project_model = get_project(session, project["id"])
+        assert project_chord_detection_source(project_model) == "source"
+        chords = detect_project_chords(session, project_model, force=True)
+        session.commit()
+
+    assert [segment["label"] for segment in chords.source_segments_json] == ["Em"]
+    assert [segment["label"] for segment in chords.segments_json] == ["Em"]
 
 
 def test_chord_refresh_preserves_user_edits_without_overwrite(

--- a/apps/backend/tests/test_stem_flow.py
+++ b/apps/backend/tests/test_stem_flow.py
@@ -4,16 +4,19 @@ import threading
 import time
 from pathlib import Path
 
+import numpy as np
 import pytest
 import soundfile as sf
 from sqlalchemy.exc import IntegrityError
 
 from app.config import get_settings
 from app.db import SessionLocal
+from app.engines.stem_signal import STEM_SIGNAL_THRESHOLDS
 from app.errors import AppError, JobCancelledError
-from app.models import Job
+from app.models import Artifact, Job
 from app.services.artifacts import register_artifact
 from app.services.projects import get_project, import_project
+from app.services.stem_signal_metadata import STEM_SIGNAL_METADATA_KEY, STEM_SIGNAL_METADATA_VERSION
 from app.utils.ids import new_id
 
 from .conftest import wait_for_job
@@ -30,6 +33,91 @@ def _create_project_without_import_jobs(source_path: Path) -> str:
         project_id = project.id
         session.commit()
     return project_id
+
+
+def _assert_current_stem_signal_metadata(
+    metadata: dict[str, object],
+    *,
+    expected_has_signal: bool = True,
+    expected_usable: bool = True,
+    expected_reason: str = "usable",
+) -> None:
+    stem_signal = metadata[STEM_SIGNAL_METADATA_KEY]
+    assert isinstance(stem_signal, dict)
+    assert set(stem_signal) == {
+        "version",
+        "has_signal",
+        "peak",
+        "rms",
+        "active_duration_seconds",
+        "inspected_duration_seconds",
+        "active_ratio",
+        "sample_rate",
+        "channels",
+        "thresholds",
+        "analysis_usability",
+    }
+    assert stem_signal["version"] == STEM_SIGNAL_METADATA_VERSION
+    assert stem_signal["has_signal"] is expected_has_signal
+    if expected_has_signal:
+        assert float(stem_signal["peak"]) > 0.0
+        assert float(stem_signal["rms"]) > 0.0
+        assert float(stem_signal["active_duration_seconds"]) >= 0.20
+    assert float(stem_signal["inspected_duration_seconds"]) == pytest.approx(2.0)
+    assert 0.0 <= float(stem_signal["active_ratio"]) <= 1.0
+    assert stem_signal["sample_rate"] == 44_100
+    assert stem_signal["channels"] == 2
+
+    thresholds = stem_signal["thresholds"]
+    assert isinstance(thresholds, dict)
+    assert set(thresholds) == {"peak", "rms", "active_duration_seconds", "window_seconds"}
+    assert thresholds["peak"] == pytest.approx(STEM_SIGNAL_THRESHOLDS.peak)
+    assert thresholds["rms"] == pytest.approx(STEM_SIGNAL_THRESHOLDS.rms)
+    assert thresholds["active_duration_seconds"] == pytest.approx(
+        STEM_SIGNAL_THRESHOLDS.active_duration_seconds
+    )
+    assert thresholds["window_seconds"] == pytest.approx(STEM_SIGNAL_THRESHOLDS.window_seconds)
+
+    analysis_usability = stem_signal["analysis_usability"]
+    assert isinstance(analysis_usability, dict)
+    assert set(analysis_usability) == {
+        "version",
+        "usable",
+        "reason",
+        "rms_ratio",
+        "rms_db_below_reference",
+        "active_ratio",
+        "peak_ratio",
+        "reference",
+        "thresholds",
+    }
+    assert analysis_usability["version"] == 1
+    assert analysis_usability["usable"] is expected_usable
+    assert analysis_usability["reason"] == expected_reason
+    assert 0.0 <= float(analysis_usability["rms_ratio"]) <= 1.0
+    assert 0.0 <= float(analysis_usability["active_ratio"]) <= 1.0
+    assert 0.0 <= float(analysis_usability["peak_ratio"]) <= 1.0
+    rms_db_below_reference = analysis_usability["rms_db_below_reference"]
+    if float(analysis_usability["rms_ratio"]) > 0.0:
+        assert isinstance(rms_db_below_reference, int | float)
+        assert float(rms_db_below_reference) <= 0.0
+    else:
+        assert rms_db_below_reference is None
+
+    reference = analysis_usability["reference"]
+    assert isinstance(reference, dict)
+    assert set(reference) == {"max_rms", "max_active_duration_seconds", "max_peak"}
+    assert float(reference["max_rms"]) >= float(stem_signal["rms"])
+    assert float(reference["max_active_duration_seconds"]) >= float(stem_signal["active_duration_seconds"])
+    assert float(reference["max_peak"]) >= float(stem_signal["peak"])
+
+    usability_thresholds = analysis_usability["thresholds"]
+    assert isinstance(usability_thresholds, dict)
+    assert usability_thresholds == {
+        "min_rms_ratio": pytest.approx(0.10),
+        "min_active_ratio": pytest.approx(0.20),
+        "clear_absent_rms_ratio": pytest.approx(0.01),
+    }
 
 
 def test_default_stem_generation_creates_six_stem_artifacts(client, sample_stereo_audio_file: Path, monkeypatch):
@@ -88,6 +176,8 @@ def test_default_stem_generation_creates_six_stem_artifacts(client, sample_stere
         "piano",
         "other",
     }
+    for artifact in stem_artifacts:
+        _assert_current_stem_signal_metadata(artifact["metadata"])
     assert stem_job["stem_model"] == "htdemucs_6s"
     assert stem_job["stem_model_label"] == "Default (6 stems model)"
     assert final_job["stem_model"] == "htdemucs_6s"
@@ -432,6 +522,443 @@ def test_stem_generation_creates_vocal_and_instrumental_artifacts(client, sample
     assert len([artifact for artifact in all_artifacts if artifact["type"] == "vocal_stem"]) == 2
     assert len([artifact for artifact in all_artifacts if artifact["type"] == "instrumental_stem"]) == 2
     assert seen_sources == [source_artifact["path"], source_artifact["path"], preview_artifact["path"]]
+
+
+def test_source_audio_stem_generation_stores_signal_metadata(
+    client,
+    sample_stereo_audio_file: Path,
+    monkeypatch,
+):
+    def fake_separate_two_stems(
+        source_path: Path,
+        vocal_path: Path,
+        instrumental_path: Path,
+        *,
+        model: str,
+        device: str,
+        model_repo=None,
+        on_progress=None,
+        should_cancel=None,
+        register_process=None,
+        unregister_process=None,
+    ):
+        signal, sample_rate = sf.read(source_path, always_2d=True)
+        vocal_path.parent.mkdir(parents=True, exist_ok=True)
+        instrumental_path.parent.mkdir(parents=True, exist_ok=True)
+        sf.write(vocal_path, signal * 0.7, sample_rate)
+        sf.write(instrumental_path, signal * 0.3, sample_rate)
+        return {"engine": "demucs", "model": model, "requested_device": device, "device": "cpu"}
+
+    monkeypatch.setattr("app.services.stems.separate_two_stems", fake_separate_two_stems)
+
+    project = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_stereo_audio_file), "copy_into_project": True},
+    ).json()["project"]
+
+    stem_job = client.post(
+        f"/api/v1/projects/{project['id']}/stems",
+        json={"mode": "two_stem", "stem_model": "htdemucs_ft", "output_format": "wav", "force": False},
+    ).json()["job"]
+    assert wait_for_job(client, stem_job["id"])["status"] == "completed"
+
+    artifacts = client.get(f"/api/v1/projects/{project['id']}/artifacts").json()["artifacts"]
+    source_artifact = next(artifact for artifact in artifacts if artifact["type"] == "source_audio")
+    source_stems = [
+        artifact
+        for artifact in artifacts
+        if artifact["metadata"].get("source_artifact_id") == source_artifact["id"]
+        and artifact["metadata"].get("stem_model") == "htdemucs_ft"
+    ]
+
+    assert {artifact["type"] for artifact in source_stems} == {"vocal_stem", "instrumental_stem"}
+    for artifact in source_stems:
+        _assert_current_stem_signal_metadata(artifact["metadata"])
+
+
+def test_source_audio_stem_generation_marks_relative_leakage_unusable(
+    client,
+    sample_stereo_audio_file: Path,
+    monkeypatch,
+):
+    def fake_separate_sources(
+        source_path: Path,
+        output_paths: dict[str, Path],
+        *,
+        model: str,
+        device: str,
+        model_repo=None,
+        on_progress=None,
+        should_cancel=None,
+        register_process=None,
+        unregister_process=None,
+    ):
+        del source_path, model, device, model_repo, should_cancel, register_process, unregister_process
+        sample_rate = 44_100
+        duration_seconds = 2.0
+        timeline = np.linspace(0.0, duration_seconds, int(sample_rate * duration_seconds), endpoint=False)
+        reference_signal = np.column_stack(
+            [
+                0.4 * np.sin(2 * np.pi * 220.0 * timeline),
+                0.4 * np.sin(2 * np.pi * 220.0 * timeline),
+            ]
+        ).astype(np.float32)
+        leakage_signal = np.zeros_like(reference_signal)
+        active_frames = int(sample_rate * 0.25)
+        leakage_timeline = timeline[:active_frames]
+        leakage_signal[:active_frames, 0] = 0.04 * np.sin(2 * np.pi * 440.0 * leakage_timeline)
+        leakage_signal[:active_frames, 1] = leakage_signal[:active_frames, 0]
+        for source, output_path in output_paths.items():
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            sf.write(output_path, leakage_signal if source == "piano" else reference_signal, sample_rate)
+        if on_progress:
+            on_progress(98)
+        return {"engine": "demucs", "model": "htdemucs_6s", "requested_device": "cpu", "device": "cpu"}
+
+    monkeypatch.setattr("app.services.stems.separate_sources", fake_separate_sources)
+
+    project = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_stereo_audio_file), "copy_into_project": True},
+    ).json()["project"]
+
+    stem_job = client.post(
+        f"/api/v1/projects/{project['id']}/stems",
+        json={"mode": "stems", "stem_model": "htdemucs_6s", "output_format": "wav", "force": False},
+    ).json()["job"]
+    assert wait_for_job(client, stem_job["id"])["status"] == "completed"
+
+    artifacts = client.get(f"/api/v1/projects/{project['id']}/artifacts").json()["artifacts"]
+    piano_artifact = next(
+        artifact
+        for artifact in artifacts
+        if artifact["type"] == "piano_stem" and artifact["metadata"].get("stem_model") == "htdemucs_6s"
+    )
+    piano_signal = piano_artifact["metadata"][STEM_SIGNAL_METADATA_KEY]
+    piano_usability = piano_signal["analysis_usability"]
+    assert piano_signal["has_signal"] is True
+    assert piano_usability["usable"] is False
+    assert piano_usability["reason"] == "relative_leakage"
+    assert piano_usability["rms_ratio"] < 0.10
+    assert piano_usability["active_ratio"] < 0.20
+
+
+def test_preview_mix_stem_generation_does_not_store_signal_metadata(
+    client,
+    sample_stereo_audio_file: Path,
+    monkeypatch,
+):
+    def fake_separate_two_stems(
+        source_path: Path,
+        vocal_path: Path,
+        instrumental_path: Path,
+        *,
+        model: str,
+        device: str,
+        model_repo=None,
+        on_progress=None,
+        should_cancel=None,
+        register_process=None,
+        unregister_process=None,
+    ):
+        signal, sample_rate = sf.read(source_path, always_2d=True)
+        vocal_path.parent.mkdir(parents=True, exist_ok=True)
+        instrumental_path.parent.mkdir(parents=True, exist_ok=True)
+        sf.write(vocal_path, signal * 0.7, sample_rate)
+        sf.write(instrumental_path, signal * 0.3, sample_rate)
+        return {"engine": "demucs", "model": model, "requested_device": device, "device": "cpu"}
+
+    monkeypatch.setattr("app.services.stems.separate_two_stems", fake_separate_two_stems)
+
+    project = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_stereo_audio_file), "copy_into_project": True},
+    ).json()["project"]
+    preview_job = client.post(
+        f"/api/v1/projects/{project['id']}/preview",
+        json={"transpose": {"semitones": 1}, "output_format": "wav"},
+    ).json()["job"]
+    assert wait_for_job(client, preview_job["id"])["status"] == "completed"
+
+    artifacts = client.get(f"/api/v1/projects/{project['id']}/artifacts").json()["artifacts"]
+    preview_artifact = next(artifact for artifact in artifacts if artifact["type"] == "preview_mix")
+
+    stem_job = client.post(
+        f"/api/v1/projects/{project['id']}/stems",
+        json={
+            "mode": "two_stem",
+            "stem_model": "htdemucs_ft",
+            "output_format": "wav",
+            "force": False,
+            "source_artifact_id": preview_artifact["id"],
+        },
+    ).json()["job"]
+    assert wait_for_job(client, stem_job["id"])["status"] == "completed"
+
+    all_artifacts = client.get(f"/api/v1/projects/{project['id']}/artifacts").json()["artifacts"]
+    preview_stems = [
+        artifact
+        for artifact in all_artifacts
+        if artifact["metadata"].get("source_artifact_id") == preview_artifact["id"]
+        and artifact["metadata"].get("stem_model") == "htdemucs_ft"
+    ]
+
+    assert {artifact["type"] for artifact in preview_stems} == {"vocal_stem", "instrumental_stem"}
+    assert all(STEM_SIGNAL_METADATA_KEY not in artifact["metadata"] for artifact in preview_stems)
+
+
+def test_cached_source_audio_stems_missing_signal_metadata_are_hydrated_and_refresh_chords(
+    client,
+    sample_stereo_audio_file: Path,
+    monkeypatch,
+):
+    separation_count = 0
+
+    def fake_separate_two_stems(
+        source_path: Path,
+        vocal_path: Path,
+        instrumental_path: Path,
+        *,
+        model: str,
+        device: str,
+        model_repo=None,
+        on_progress=None,
+        should_cancel=None,
+        register_process=None,
+        unregister_process=None,
+    ):
+        nonlocal separation_count
+        separation_count += 1
+        signal, sample_rate = sf.read(source_path, always_2d=True)
+        vocal_path.parent.mkdir(parents=True, exist_ok=True)
+        instrumental_path.parent.mkdir(parents=True, exist_ok=True)
+        sf.write(vocal_path, signal * 0.7, sample_rate)
+        sf.write(instrumental_path, signal * 0.3, sample_rate)
+        return {"engine": "demucs", "model": model, "requested_device": device, "device": "cpu"}
+
+    monkeypatch.setattr("app.services.stems.separate_two_stems", fake_separate_two_stems)
+
+    project = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_stereo_audio_file), "copy_into_project": True},
+    ).json()["project"]
+
+    initial_jobs = client.get("/api/v1/jobs").json()["jobs"]
+    initial_chord_job = next(
+        job for job in initial_jobs if job["project_id"] == project["id"] and job["type"] == "chords"
+    )
+    assert wait_for_job(client, initial_chord_job["id"])["status"] == "completed"
+
+    stem_job = client.post(
+        f"/api/v1/projects/{project['id']}/stems",
+        json={"mode": "two_stem", "stem_model": "htdemucs_ft", "output_format": "wav", "force": False},
+    ).json()["job"]
+    assert wait_for_job(client, stem_job["id"])["status"] == "completed"
+
+    chord_jobs_after_generation = [
+        job
+        for job in client.get("/api/v1/jobs").json()["jobs"]
+        if job["project_id"] == project["id"] and job["type"] == "chords" and job["id"] != initial_chord_job["id"]
+    ]
+    assert len(chord_jobs_after_generation) == 1
+    assert chord_jobs_after_generation[0]["chord_source"] == "source+stem"
+    assert wait_for_job(client, chord_jobs_after_generation[0]["id"])["status"] == "completed"
+
+    artifacts = client.get(f"/api/v1/projects/{project['id']}/artifacts").json()["artifacts"]
+    source_artifact = next(artifact for artifact in artifacts if artifact["type"] == "source_audio")
+    stem_ids = [
+        artifact["id"]
+        for artifact in artifacts
+        if artifact["metadata"].get("source_artifact_id") == source_artifact["id"]
+        and artifact["metadata"].get("stem_model") == "htdemucs_ft"
+    ]
+    assert len(stem_ids) == 2
+
+    with SessionLocal() as session:
+        missing_metadata_artifact = session.get(Artifact, stem_ids[0])
+        assert missing_metadata_artifact is not None
+        missing_metadata = dict(missing_metadata_artifact.metadata_json)
+        missing_metadata.pop(STEM_SIGNAL_METADATA_KEY, None)
+        missing_metadata_artifact.metadata_json = missing_metadata
+
+        stale_metadata_artifact = session.get(Artifact, stem_ids[1])
+        assert stale_metadata_artifact is not None
+        stale_metadata = dict(stale_metadata_artifact.metadata_json)
+        stale_metadata[STEM_SIGNAL_METADATA_KEY] = {"version": 0}
+        stale_metadata_artifact.metadata_json = stale_metadata
+        session.commit()
+
+    cached_job = client.post(
+        f"/api/v1/projects/{project['id']}/stems",
+        json={"mode": "two_stem", "stem_model": "htdemucs_ft", "output_format": "wav", "force": False},
+    ).json()["job"]
+    assert wait_for_job(client, cached_job["id"])["status"] == "completed"
+
+    hydrated_artifacts = client.get(f"/api/v1/projects/{project['id']}/artifacts").json()["artifacts"]
+    hydrated_stems = [artifact for artifact in hydrated_artifacts if artifact["id"] in stem_ids]
+    assert separation_count == 1
+    for artifact in hydrated_stems:
+        _assert_current_stem_signal_metadata(artifact["metadata"])
+
+    chord_jobs_after_hydration = [
+        job
+        for job in client.get("/api/v1/jobs").json()["jobs"]
+        if job["project_id"] == project["id"]
+        and job["type"] == "chords"
+        and job["id"] not in {initial_chord_job["id"], chord_jobs_after_generation[0]["id"]}
+    ]
+    assert len(chord_jobs_after_hydration) == 1
+    assert chord_jobs_after_hydration[0]["chord_source"] == "source+stem"
+    assert wait_for_job(client, chord_jobs_after_hydration[0]["id"])["status"] == "completed"
+
+
+def test_cached_source_audio_stems_raw_only_metadata_gets_usability_without_audio_read(
+    client,
+    sample_stereo_audio_file: Path,
+    monkeypatch,
+):
+    separation_count = 0
+
+    def fake_separate_two_stems(
+        source_path: Path,
+        vocal_path: Path,
+        instrumental_path: Path,
+        *,
+        model: str,
+        device: str,
+        model_repo=None,
+        on_progress=None,
+        should_cancel=None,
+        register_process=None,
+        unregister_process=None,
+    ):
+        nonlocal separation_count
+        del model, device, model_repo, should_cancel, register_process, unregister_process
+        separation_count += 1
+        signal, sample_rate = sf.read(source_path, always_2d=True)
+        vocal_path.parent.mkdir(parents=True, exist_ok=True)
+        instrumental_path.parent.mkdir(parents=True, exist_ok=True)
+        sf.write(vocal_path, signal * 0.7, sample_rate)
+        sf.write(instrumental_path, signal * 0.3, sample_rate)
+        if on_progress:
+            on_progress(98)
+        return {"engine": "demucs", "model": "htdemucs_ft", "requested_device": "cpu", "device": "cpu"}
+
+    monkeypatch.setattr("app.services.stems.separate_two_stems", fake_separate_two_stems)
+
+    project = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_stereo_audio_file), "copy_into_project": True},
+    ).json()["project"]
+
+    stem_job = client.post(
+        f"/api/v1/projects/{project['id']}/stems",
+        json={"mode": "two_stem", "stem_model": "htdemucs_ft", "output_format": "wav", "force": False},
+    ).json()["job"]
+    assert wait_for_job(client, stem_job["id"])["status"] == "completed"
+
+    artifacts = client.get(f"/api/v1/projects/{project['id']}/artifacts").json()["artifacts"]
+    source_artifact = next(artifact for artifact in artifacts if artifact["type"] == "source_audio")
+    stem_ids = [
+        artifact["id"]
+        for artifact in artifacts
+        if artifact["metadata"].get("source_artifact_id") == source_artifact["id"]
+        and artifact["metadata"].get("stem_model") == "htdemucs_ft"
+    ]
+
+    with SessionLocal() as session:
+        for index, stem_id in enumerate(stem_ids):
+            artifact = session.get(Artifact, stem_id)
+            assert artifact is not None
+            metadata = dict(artifact.metadata_json)
+            stem_signal = dict(metadata[STEM_SIGNAL_METADATA_KEY])
+            if index == 0:
+                stem_signal.pop("analysis_usability", None)
+            else:
+                analysis_usability = dict(stem_signal["analysis_usability"])
+                analysis_usability["version"] = 0
+                stem_signal["analysis_usability"] = analysis_usability
+            metadata[STEM_SIGNAL_METADATA_KEY] = stem_signal
+            artifact.metadata_json = metadata
+        session.commit()
+
+    def fail_build_stem_signal_metadata(_path: Path) -> dict[str, object]:
+        raise AssertionError("raw stem_signal metadata should not be re-read when only usability is missing")
+
+    monkeypatch.setattr("app.services.stems.build_stem_signal_metadata", fail_build_stem_signal_metadata)
+
+    cached_job = client.post(
+        f"/api/v1/projects/{project['id']}/stems",
+        json={"mode": "two_stem", "stem_model": "htdemucs_ft", "output_format": "wav", "force": False},
+    ).json()["job"]
+    assert wait_for_job(client, cached_job["id"])["status"] == "completed"
+
+    hydrated_artifacts = client.get(f"/api/v1/projects/{project['id']}/artifacts").json()["artifacts"]
+    hydrated_stems = [artifact for artifact in hydrated_artifacts if artifact["id"] in stem_ids]
+    assert separation_count == 1
+    for artifact in hydrated_stems:
+        _assert_current_stem_signal_metadata(artifact["metadata"])
+
+
+def test_vocal_only_signal_stems_do_not_enqueue_chord_refresh(
+    client,
+    sample_stereo_audio_file: Path,
+    monkeypatch,
+):
+    def fake_separate_two_stems(
+        source_path: Path,
+        vocal_path: Path,
+        instrumental_path: Path,
+        *,
+        model: str,
+        device: str,
+        model_repo=None,
+        on_progress=None,
+        should_cancel=None,
+        register_process=None,
+        unregister_process=None,
+    ):
+        signal, sample_rate = sf.read(source_path, always_2d=True)
+        vocal_path.parent.mkdir(parents=True, exist_ok=True)
+        instrumental_path.parent.mkdir(parents=True, exist_ok=True)
+        sf.write(vocal_path, signal * 0.7, sample_rate)
+        sf.write(instrumental_path, signal * 0.0, sample_rate)
+        return {"engine": "demucs", "model": model, "requested_device": device, "device": "cpu"}
+
+    monkeypatch.setattr("app.services.stems.separate_two_stems", fake_separate_two_stems)
+
+    project = client.post(
+        "/api/v1/projects/import",
+        json={"source_path": str(sample_stereo_audio_file), "copy_into_project": True},
+    ).json()["project"]
+
+    initial_jobs = client.get("/api/v1/jobs").json()["jobs"]
+    initial_chord_job = next(
+        job for job in initial_jobs if job["project_id"] == project["id"] and job["type"] == "chords"
+    )
+    assert wait_for_job(client, initial_chord_job["id"])["status"] == "completed"
+
+    stem_job = client.post(
+        f"/api/v1/projects/{project['id']}/stems",
+        json={"mode": "two_stem", "stem_model": "htdemucs_ft", "output_format": "wav", "force": False},
+    ).json()["job"]
+    assert wait_for_job(client, stem_job["id"])["status"] == "completed"
+
+    artifacts = client.get(f"/api/v1/projects/{project['id']}/artifacts").json()["artifacts"]
+    vocal_artifact = next(artifact for artifact in artifacts if artifact["type"] == "vocal_stem")
+    instrumental_artifact = next(artifact for artifact in artifacts if artifact["type"] == "instrumental_stem")
+    assert vocal_artifact["metadata"][STEM_SIGNAL_METADATA_KEY]["has_signal"] is True
+    assert instrumental_artifact["metadata"][STEM_SIGNAL_METADATA_KEY]["has_signal"] is False
+    instrumental_usability = instrumental_artifact["metadata"][STEM_SIGNAL_METADATA_KEY]["analysis_usability"]
+    assert instrumental_usability["usable"] is False
+    assert instrumental_usability["reason"] == "absolute_no_signal"
+
+    chord_jobs_after_stems = [
+        job
+        for job in client.get("/api/v1/jobs").json()["jobs"]
+        if job["project_id"] == project["id"] and job["type"] == "chords"
+    ]
+    assert [job["id"] for job in chord_jobs_after_stems] == [initial_chord_job["id"]]
 
 
 def test_omitted_stem_mode_uses_configured_default_model(client, sample_stereo_audio_file: Path, monkeypatch):


### PR DESCRIPTION
## Summary
- Persist raw source-stem signal metrics plus relative analysis usability metadata.
- Hydrate cached source stems only inside source stem generation, while preview/practice stems stay untagged.
- Gate chord source-stem selection on persisted analysis usability so silent/leakage stems are skipped.
- Closes #242.

## Testing
- `cd apps/backend && UV_CACHE_DIR=/private/tmp/uv-cache uv run --python 3.11 pytest tests/test_chord_flow.py tests/test_stem_flow.py tests/test_audio_signal.py tests/test_stem_signal.py`
- `cd apps/backend && UV_CACHE_DIR=/private/tmp/uv-cache uv run --python 3.11 ruff check .`
- `cd apps/backend && UV_CACHE_DIR=/private/tmp/uv-cache uv run --python 3.11 mypy app`
- `cd apps/backend && UV_CACHE_DIR=/private/tmp/uv-cache uv run --python 3.11 pytest tests/test_stem_flow.py tests/test_chord_flow.py tests/test_analysis_flow.py tests/test_sync_manifest.py tests/test_sync_identity.py`
