### PR TITLE
feat: report source-only beat analysis input

### DIFF
--- a/apps/backend/app/engines/beat_this.py
+++ b/apps/backend/app/engines/beat_this.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, cast
@@ -42,10 +42,9 @@ def beat_this_dependency_status() -> tuple[bool, str | None]:
 def analyze_track_with_beat_this(
     source_path: Path,
     *,
-    source_stem_paths: Sequence[Path] | None = None,
     duration_seconds: float | None = None,
 ) -> AnalysisPayload:
-    payload = analyze_track(source_path, source_stem_paths=source_stem_paths)
+    payload = analyze_track(source_path)
     timing = detect_beat_this_timing(source_path, duration_seconds=duration_seconds)
     if timing is None:
         raise BeatThisRuntimeError("Advanced Beat Analysis did not produce usable beat timing.")

--- a/apps/backend/app/models.py
+++ b/apps/backend/app/models.py
@@ -440,6 +440,12 @@ class Job(Base):
         return value if isinstance(value, str) else "built-in"
 
     @property
+    def beat_input(self) -> str | None:
+        if self.type != "analyze":
+            return None
+        return "source"
+
+    @property
     def chord_source(self) -> str | None:
         if self.type != "chords":
             return None

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -1237,6 +1237,7 @@ class JobSchema(BaseModel):
     progress: int
     source_artifact_id: str | None = None
     beat_backend: str | None = None
+    beat_input: str | None = None
     chord_backend: str | None = None
     chord_backend_fallback_from: str | None = None
     chord_source: str | None = None

--- a/apps/backend/app/services/analysis.py
+++ b/apps/backend/app/services/analysis.py
@@ -63,7 +63,7 @@ def analyze_project(
         analysis=analysis,
         analysis_backend=beat_backend,
         source_artifact=source_artifact,
-        source_stem_artifacts=source_stem_artifacts,
+        source_stem_artifacts=() if beat_backend == BEAT_THIS_BACKEND else source_stem_artifacts,
     )
 
     return analysis
@@ -93,7 +93,6 @@ def _analyze_track_with_backend(
         try:
             return analyze_track_with_beat_this(
                 source_path,
-                source_stem_paths=source_stem_paths,
                 duration_seconds=duration_seconds,
             )
         except BeatThisRuntimeError as exc:

--- a/apps/backend/app/services/jobs.py
+++ b/apps/backend/app/services/jobs.py
@@ -514,13 +514,14 @@ class InProcessJobRunner:
     def create_job(self, session: Session, *, project_id: str | None, job_type: str, payload: dict[str, Any]) -> Job:
         if project_id is not None:
             get_mutable_project(session, project_id)
+        job_payload = _job_payload_for_create(job_type=job_type, payload=payload)
         job = Job(
             id=new_id("job"),
             project_id=project_id,
             type=job_type,
             status="pending",
             progress=0,
-            payload_json=payload,
+            payload_json=job_payload,
             result_artifact_ids_json=[],
             cancel_requested=False,
         )
@@ -679,10 +680,15 @@ class InProcessJobRunner:
     def _handle_analyze(self, context: JobExecutionContext, session: Session, job: Job) -> JobExecutionResult:
         project = get_project(session, job.project_id or "")
         payload = AnalysisRequest.model_validate(job.payload_json)
-        job.payload_json = {**job.payload_json, "beat_backend": payload.beat_backend}
+        job.payload_json = {**job.payload_json, "beat_backend": payload.beat_backend, "beat_input": "source"}
         session.flush()
         context.set_progress(20)
         analyze_project(session, project, beat_backend=payload.beat_backend)
+        job.payload_json = {
+            **job.payload_json,
+            "beat_backend": payload.beat_backend,
+            "beat_input": "source",
+        }
         context.set_progress(90)
         artifact_ids = [artifact.id for artifact in project.artifacts if artifact.type == "analysis_json"]
         return JobExecutionResult(
@@ -842,6 +848,12 @@ class InProcessJobRunner:
             artifact_ids=[artifact.id for artifact in artifacts],
             runtime_device=runtime_device,
         )
+
+
+def _job_payload_for_create(*, job_type: str, payload: dict[str, Any]) -> dict[str, Any]:
+    if job_type == "analyze":
+        return {**payload, "beat_input": "source"}
+    return payload
 
 
 def _should_enqueue_chord_refresh_after_stems(

--- a/apps/backend/tests/test_analysis_flow.py
+++ b/apps/backend/tests/test_analysis_flow.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import Any
 
 import pytest
 from sqlalchemy import select
@@ -13,6 +14,7 @@ from app.models import AnalysisResult, Artifact, Job, Project
 from app.services import analysis as analysis_service
 from app.services.artifacts import register_artifact
 from app.services.paths import ensure_project_dirs
+from app.services.stem_signal_metadata import STEM_SIGNAL_METADATA_KEY, STEM_SIGNAL_METADATA_VERSION
 
 from .conftest import wait_for_job
 
@@ -40,6 +42,7 @@ def test_analysis_job_persists_results(client, sample_rhythmic_audio_file: Path)
     final_job = wait_for_job(client, job["id"])
     assert final_job["status"] == "completed"
     assert final_job["beat_backend"] == "built-in"
+    assert final_job["beat_input"] == "source"
     assert final_job["runtime_device"] == "cpu"
     assert final_job["duration_seconds"] is not None
 
@@ -183,7 +186,7 @@ def test_reanalysis_updates_analysis_artifact_sync_metadata(
         duration_seconds: float | None = None,
     ):
         assert track_path == sample_audio_file
-        assert source_stem_paths == (source_drums_path, source_bass_path)
+        assert source_stem_paths is None
         assert duration_seconds == 4.0
         return {
             "estimated_key": "D minor",
@@ -219,14 +222,22 @@ def test_reanalysis_updates_analysis_artifact_sync_metadata(
         "analysis_version": "v3",
         "source_artifact_id": "art_analysis_source",
         "source_artifact_sha256": expected_source_sha,
+    }
+    expected_built_in_metadata = {
+        **expected_common_metadata,
         "source_stem_artifact_ids": ["art_source_drums", "art_source_bass"],
         "source_stem_content_sha256s": expected_stem_sha256s,
+    }
+    expected_beat_this_metadata = {
+        **expected_common_metadata,
+        "source_stem_artifact_ids": [],
+        "source_stem_content_sha256s": [],
     }
     first_payload = _analysis_payload(first_artifact)
     assert first_artifact.metadata_json == {
         "analysis_generated_at": "2026-01-02T03:04:05+00:00",
         "analysis_backend": "built-in",
-        **expected_common_metadata,
+        **expected_built_in_metadata,
     }
     assert {key: first_payload[key] for key in first_artifact.metadata_json} == first_artifact.metadata_json
 
@@ -243,7 +254,7 @@ def test_reanalysis_updates_analysis_artifact_sync_metadata(
     assert second_artifact.metadata_json == {
         "analysis_generated_at": "2026-01-03T03:04:05+00:00",
         "analysis_backend": "beat-this",
-        **expected_common_metadata,
+        **expected_beat_this_metadata,
     }
     assert {key: second_payload[key] for key in second_artifact.metadata_json} == second_artifact.metadata_json
     assert second_payload["estimated_key"] == "D minor"
@@ -272,6 +283,7 @@ def test_project_import_carries_beat_backend_to_initial_analysis_job(
         jobs = list(session.scalars(select(Job).where(Job.project_id == project_id)))
     analyze_job = next(job for job in jobs if job.type == "analyze")
     assert analyze_job.payload_json["beat_backend"] == "beat-this"
+    assert analyze_job.payload_json["beat_input"] == "source"
     assert analyze_job.id in enqueued
 
 
@@ -314,12 +326,72 @@ def test_analysis_uses_beat_this_backend_when_requested(
 
     assert captured == {
         "track_path": sample_audio_file,
-        "source_stem_paths": (),
+        "source_stem_paths": None,
         "duration_seconds": 4.0,
     }
     assert analysis.estimated_key == "D minor"
     assert analysis.tempo_bpm == 90.0
     assert analysis.timing_json["source"] == "beat-this"
+
+
+def test_analysis_beat_this_uses_source_only_even_when_source_stems_have_signal_metadata(
+    client,
+    sample_audio_file: Path,
+    tmp_path: Path,
+    monkeypatch,
+):
+    del client
+    project_id = "analysis_beat_this_source_only_project"
+    source_drums_path = tmp_path / "beat-this-source-drums.wav"
+    source_bass_path = tmp_path / "beat-this-source-bass.wav"
+    preview_drums_path = tmp_path / "beat-this-preview-drums.wav"
+    preview_bass_path = tmp_path / "beat-this-preview-bass.wav"
+    _write_paths(source_drums_path, source_bass_path, preview_drums_path, preview_bass_path)
+    _seed_project_with_source_stems(
+        project_id=project_id,
+        source_path=sample_audio_file,
+        source_drums_path=source_drums_path,
+        source_bass_path=source_bass_path,
+        preview_drums_path=preview_drums_path,
+        preview_bass_path=preview_bass_path,
+        source_drums_metadata=_stem_signal_metadata(has_signal=True),
+        source_bass_metadata=_stem_signal_metadata(has_signal=True),
+    )
+    _forbid_analysis_signal_inspection(monkeypatch)
+    monkeypatch.setattr(analysis_service, "beat_this_dependency_status", lambda: (True, None))
+    captured: dict[str, object] = {}
+
+    def fake_analyze_track_with_beat_this(
+        track_path: Path,
+        *,
+        source_stem_paths: tuple[Path, ...] | None = None,
+        duration_seconds: float | None = None,
+    ):
+        captured["track_path"] = track_path
+        captured["source_stem_paths"] = source_stem_paths
+        captured["duration_seconds"] = duration_seconds
+        return {
+            "estimated_key": "D minor",
+            "key_confidence": 0.7,
+            "estimated_reference_hz": 440.0,
+            "tuning_offset_cents": 0.0,
+            "tempo_bpm": 90.0,
+            "timing": _timing_payload(source="beat-this"),
+        }
+
+    monkeypatch.setattr(analysis_service, "analyze_track_with_beat_this", fake_analyze_track_with_beat_this)
+
+    with SessionLocal() as session:
+        project = session.get(Project, project_id)
+        assert project is not None
+        analysis_service.analyze_project(session, project, beat_backend="beat-this")
+        session.commit()
+
+    assert captured == {
+        "track_path": sample_audio_file,
+        "source_stem_paths": None,
+        "duration_seconds": 4.0,
+    }
 
 
 def test_analysis_beat_this_backend_fails_when_dependency_is_missing(
@@ -551,6 +623,8 @@ def _seed_project_with_source_stems(
     source_bass_path: Path,
     preview_drums_path: Path,
     preview_bass_path: Path,
+    source_drums_metadata: dict[str, Any] | None = None,
+    source_bass_metadata: dict[str, Any] | None = None,
 ) -> None:
     ensure_project_dirs(project_id)
     created_at = datetime(2026, 1, 1, tzinfo=UTC)
@@ -594,7 +668,7 @@ def _seed_project_with_source_stems(
             artifact_type="drums_stem",
             artifact_format="wav",
             path=source_drums_path,
-            metadata={"source_artifact_id": source_artifact.id, "source_artifact_type": "source_audio"},
+            metadata=_source_stem_artifact_metadata(source_artifact.id, source_drums_metadata),
             generated_by="demucs",
             created_at=created_at + timedelta(seconds=2),
         )
@@ -605,7 +679,7 @@ def _seed_project_with_source_stems(
             artifact_type="bass_stem",
             artifact_format="wav",
             path=source_bass_path,
-            metadata={"source_artifact_id": source_artifact.id, "source_artifact_type": "source_audio"},
+            metadata=_source_stem_artifact_metadata(source_artifact.id, source_bass_metadata),
             generated_by="demucs",
             created_at=created_at + timedelta(seconds=3),
         )
@@ -632,6 +706,69 @@ def _seed_project_with_source_stems(
             created_at=created_at + timedelta(seconds=5),
         )
         session.commit()
+
+
+def _source_stem_artifact_metadata(
+    source_artifact_id: str,
+    extra_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    metadata = {
+        "source_artifact_id": source_artifact_id,
+        "source_artifact_type": "source_audio",
+    }
+    if extra_metadata is not None:
+        metadata.update(_json_clone(extra_metadata))
+    return metadata
+
+
+def _stem_signal_metadata(
+    *,
+    has_signal: bool,
+    version: int = STEM_SIGNAL_METADATA_VERSION,
+) -> dict[str, Any]:
+    peak = 0.4 if has_signal else 0.0
+    rms = 0.2 if has_signal else 0.0
+    active_duration = 2.0 if has_signal else 0.0
+    return {
+        STEM_SIGNAL_METADATA_KEY: {
+            "version": version,
+            "has_signal": has_signal,
+            "peak": peak,
+            "rms": rms,
+            "active_duration_seconds": active_duration,
+            "inspected_duration_seconds": 4.0,
+            "active_ratio": active_duration / 4.0,
+            "sample_rate": 44_100,
+            "channels": 2,
+            "thresholds": {
+                "peak": 0.001,
+                "rms": 0.0005,
+                "active_duration_seconds": 0.2,
+                "window_seconds": 0.05,
+            },
+        }
+    }
+
+
+def _write_paths(*paths: Path) -> None:
+    for path in paths:
+        path.write_bytes(path.name.encode("utf-8"))
+
+
+def _json_clone(value: dict[str, Any]) -> dict[str, Any]:
+    cloned = json.loads(json.dumps(value))
+    assert isinstance(cloned, dict)
+    return cloned
+
+
+def _forbid_analysis_signal_inspection(monkeypatch) -> None:
+    def raise_if_called(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("analysis flow must only read persisted stem_signal metadata")
+
+    monkeypatch.setattr("app.services.stem_signal_metadata.build_stem_signal_metadata", raise_if_called)
+    monkeypatch.setattr("app.services.stem_signal_metadata.inspect_audio_signal_file", raise_if_called)
+    monkeypatch.setattr("app.engines.audio_signal.inspect_audio_signal_file", raise_if_called)
+    monkeypatch.setattr("app.engines.stem_signal.inspect_stem_signal", raise_if_called)
 
 
 def _assert_timing_bar_indexes_are_nonnegative(timing: dict) -> None:

--- a/apps/backend/tests/test_beat_candidates_script.py
+++ b/apps/backend/tests/test_beat_candidates_script.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "beat-candidates.py"
+
+
+def test_beat_candidates_script_writes_read_only_text_and_json_reports(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    module = _load_script_module()
+    data_dir = _create_data_dir(tmp_path)
+    output_dir = tmp_path / "beat-candidates"
+    before = _snapshot_files(data_dir)
+    calls: list[Path] = []
+
+    monkeypatch.setattr(module.beat_this_engine, "beat_this_dependency_status", lambda: (True, None))
+
+    def fake_detect(path: Path, *, duration_seconds: float | None = None) -> dict[str, Any]:
+        assert duration_seconds == 4.0
+        calls.append(path)
+        return _timing_payload()
+
+    monkeypatch.setattr(module.beat_this_engine, "detect_beat_this_timing", fake_detect)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "beat-candidates.py",
+            "--data-dir",
+            str(data_dir),
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    assert module.main() == 0
+
+    assert _snapshot_files(data_dir) == before
+    assert [path.name for path in calls] == ["source.wav", "drums.wav", "bass.wav"]
+    stdout = capsys.readouterr().out
+    assert "Product behavior: Advanced Beat Analysis uses source audio only." in stdout
+
+    text_report = (output_dir / "beat-candidates.txt").read_text(encoding="utf-8")
+    assert "stem_signal.has_signal=true" in text_report
+    json_report = json.loads((output_dir / "beat-candidates.json").read_text(encoding="utf-8"))
+    assert json_report["product_behavior"] == "advanced beat analysis uses source audio only"
+    candidates = json_report["projects"][0]["candidates"]
+    assert [candidate["input"] for candidate in candidates] == ["source", "drums", "bass"]
+    assert {candidate["status"] for candidate in candidates} == {"ok"}
+    assert candidates[1]["stem_signal_has_signal"] is True
+
+
+@pytest.mark.parametrize("filename", ["beat-candidates.txt", "beat-candidates.json"])
+def test_beat_candidates_script_rejects_output_symlink_into_data_dir(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+    filename: str,
+) -> None:
+    module = _load_script_module()
+    data_dir = _create_data_dir(tmp_path)
+    output_dir = tmp_path / "beat-candidates"
+    output_dir.mkdir()
+    protected_path = data_dir / "projects" / "project-a" / "source.wav"
+    symlink_path = output_dir / filename
+    symlink_path.symlink_to(protected_path)
+    before = _snapshot_files(data_dir)
+
+    monkeypatch.setattr(module.beat_this_engine, "beat_this_dependency_status", lambda: (True, None))
+    monkeypatch.setattr(module.beat_this_engine, "detect_beat_this_timing", lambda *_args, **_kwargs: _timing_payload())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "beat-candidates.py",
+            "--data-dir",
+            str(data_dir),
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    assert module.main() == 2
+
+    assert _snapshot_files(data_dir) == before
+    assert symlink_path.is_symlink()
+    assert symlink_path.resolve() == protected_path.resolve()
+    assert "Output path must not target the TuneForge data dir" in capsys.readouterr().err
+
+
+def _load_script_module() -> Any:
+    spec = importlib.util.spec_from_file_location("beat_candidates_script", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _create_data_dir(tmp_path: Path) -> Path:
+    data_dir = tmp_path / "tuneforge-data"
+    data_dir.mkdir()
+    source_path = data_dir / "projects" / "project-a" / "source.wav"
+    stems_dir = data_dir / "projects" / "project-a" / "stems"
+    drums_path = stems_dir / "drums.wav"
+    bass_path = stems_dir / "bass.wav"
+    for path in (source_path, drums_path, bass_path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(path.name.encode("utf-8"))
+    _write_database(data_dir / "app.sqlite", source_path, drums_path, bass_path)
+    return data_dir
+
+
+def _write_database(database_path: Path, source_path: Path, drums_path: Path, bass_path: Path) -> None:
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE projects (
+                id TEXT PRIMARY KEY,
+                display_name TEXT NOT NULL,
+                imported_path TEXT NOT NULL,
+                duration_seconds REAL
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE artifacts (
+                id TEXT PRIMARY KEY,
+                project_id TEXT NOT NULL,
+                type TEXT NOT NULL,
+                path TEXT NOT NULL,
+                metadata_json JSON NOT NULL,
+                created_at TEXT NOT NULL
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO projects (id, display_name, imported_path, duration_seconds)
+            VALUES ('project-a', 'Project A', ?, 4.0)
+            """,
+            (str(source_path),),
+        )
+        connection.execute(
+            """
+            INSERT INTO artifacts (id, project_id, type, path, metadata_json, created_at)
+            VALUES ('source-art', 'project-a', 'source_audio', ?, '{}', '2026-01-01T00:00:00Z')
+            """,
+            (str(source_path),),
+        )
+        for source_name, path in (("drums", drums_path), ("bass", bass_path)):
+            metadata = {
+                "source_artifact_id": "source-art",
+                "source_artifact_type": "source_audio",
+                "stem_signal": {
+                    "version": 1,
+                    "has_signal": True,
+                },
+            }
+            connection.execute(
+                """
+                INSERT INTO artifacts (id, project_id, type, path, metadata_json, created_at)
+                VALUES (?, 'project-a', ?, ?, ?, '2026-01-01T00:00:01Z')
+                """,
+                (
+                    f"{source_name}-art",
+                    f"{source_name}_stem",
+                    str(path),
+                    json.dumps(metadata),
+                ),
+            )
+
+
+def _timing_payload() -> dict[str, Any]:
+    return {
+        "beats_per_bar": 4,
+        "source": "beat-this",
+        "meter": "4/4",
+        "meter_confidence": 1.0,
+        "downbeat_source": "beat-this",
+        "downbeat_confidence": 1.0,
+        "beats": [
+            {"index": 0, "seconds": 0.0, "bar_index": 1, "beat_in_bar": 1},
+            {"index": 1, "seconds": 0.5, "bar_index": 1, "beat_in_bar": 2},
+            {"index": 2, "seconds": 1.0, "bar_index": 1, "beat_in_bar": 3},
+            {"index": 3, "seconds": 1.5, "bar_index": 1, "beat_in_bar": 4},
+            {"index": 4, "seconds": 2.0, "bar_index": 2, "beat_in_bar": 1},
+        ],
+        "bars": [
+            {"index": 1, "start_seconds": 0.0, "end_seconds": 2.0},
+            {"index": 2, "start_seconds": 2.0, "end_seconds": 4.0},
+        ],
+    }
+
+
+def _snapshot_files(root: Path) -> dict[str, tuple[int, str]]:
+    snapshot: dict[str, tuple[int, str]] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+            snapshot[str(path.relative_to(root))] = (path.stat().st_size, digest)
+    return snapshot

--- a/apps/backend/tests/test_beat_this_engine.py
+++ b/apps/backend/tests/test_beat_this_engine.py
@@ -80,6 +80,7 @@ def test_detect_beat_this_timing_accepts_checkpoint_override(monkeypatch) -> Non
 
 def test_analyze_track_with_beat_this_replaces_timing_and_tempo(monkeypatch) -> None:
     def fake_analyze_track(_source_path: Path, *, source_stem_paths=None):
+        assert source_stem_paths is None
         return {
             "estimated_key": "C major",
             "key_confidence": 0.8,
@@ -89,7 +90,8 @@ def test_analyze_track_with_beat_this_replaces_timing_and_tempo(monkeypatch) -> 
             "timing": None,
         }
 
-    def fake_detect_beat_this_timing(_source_path: Path, *, duration_seconds: float | None = None):
+    def fake_detect_beat_this_timing(source_path: Path, *, duration_seconds: float | None = None):
+        assert source_path == Path("synthetic_beat_this.wav")
         assert duration_seconds == 4.0
         return {
             "beats_per_bar": 4,
@@ -109,7 +111,10 @@ def test_analyze_track_with_beat_this_replaces_timing_and_tempo(monkeypatch) -> 
     monkeypatch.setattr(beat_this_engine, "analyze_track", fake_analyze_track)
     monkeypatch.setattr(beat_this_engine, "detect_beat_this_timing", fake_detect_beat_this_timing)
 
-    payload = beat_this_engine.analyze_track_with_beat_this(Path("synthetic_beat_this.wav"), duration_seconds=4.0)
+    payload = beat_this_engine.analyze_track_with_beat_this(
+        Path("synthetic_beat_this.wav"),
+        duration_seconds=4.0,
+    )
 
     assert payload["timing"] is not None
     assert payload["timing"]["source"] == "beat-this"

--- a/apps/backend/tests/test_jobs_api.py
+++ b/apps/backend/tests/test_jobs_api.py
@@ -4,6 +4,7 @@ import threading
 import time
 from datetime import UTC, datetime, timedelta
 from subprocess import TimeoutExpired
+from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
@@ -12,7 +13,7 @@ from sqlalchemy.orm import Session
 
 from app.db import SessionLocal
 from app.errors import AppError
-from app.models import Artifact, Job, Project
+from app.models import AnalysisResult, Artifact, Job, Project
 from app.services.jobs import InProcessJobRunner, JobExecutionContext, JobExecutionResult
 
 _BASE_TIME = datetime(2026, 1, 1, tzinfo=UTC)
@@ -53,6 +54,7 @@ def _add_job(
     started_at: datetime | None = None,
     completed_at: datetime | None = None,
     updated_at: datetime | None = None,
+    payload_json: dict[str, Any] | None = None,
 ) -> None:
     effective_created_at = created_at or _timestamp(0)
     session.add(
@@ -64,7 +66,7 @@ def _add_job(
             progress=0,
             error_message=None,
             runtime_device=None,
-            payload_json={},
+            payload_json=payload_json or {},
             result_artifact_ids_json=[],
             cancel_requested=False,
             created_at=effective_created_at,
@@ -295,6 +297,130 @@ def test_bulk_analyze_jobs_store_requested_beat_backend(
         jobs = list(session.scalars(select(Job).where(Job.id.in_(job_ids))))
 
     assert {job.payload_json["beat_backend"] for job in jobs} == {"beat-this"}
+    assert {job.payload_json["beat_input"] for job in jobs} == {"source"}
+
+
+@pytest.mark.parametrize(
+    "timing_json",
+    [
+        None,
+        {},
+        {"source": "detected"},
+        {"source": "beat-this"},
+    ],
+)
+def test_analyze_job_exposes_source_beat_input(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    timing_json: dict[str, str] | None,
+) -> None:
+    runner = InProcessJobRunner(SessionLocal)
+    project_id = "project_source_beat_input"
+
+    def fake_analyze_project(
+        _session: Session,
+        project: Project,
+        *,
+        beat_backend: str = "built-in",
+    ) -> AnalysisResult:
+        assert beat_backend == "beat-this"
+        return AnalysisResult(project_id=project.id, timing_json=None if timing_json is None else dict(timing_json))
+
+    monkeypatch.setattr("app.services.jobs.analyze_project", fake_analyze_project)
+    with SessionLocal() as session:
+        _add_project(session, project_id)
+        session.flush()
+        job = runner.create_job(
+            session,
+            project_id=project_id,
+            job_type="analyze",
+            payload={"beat_backend": "beat-this"},
+        )
+        assert job.payload_json["beat_input"] == "source"
+        job_id = job.id
+        session.commit()
+
+    runner._execute_job(job_id)
+
+    with SessionLocal() as session:
+        job = session.get(Job, job_id)
+        assert job is not None
+        assert job.status == "completed"
+        assert job.runtime_device == "cpu"
+        assert job.payload_json["beat_input"] == "source"
+        assert job.beat_input == "source"
+
+    response = client.get(f"/api/v1/jobs/{job_id}")
+    assert response.status_code == 200
+    payload = response.json()["job"]
+    assert payload["beat_backend"] == "beat-this"
+    assert payload["beat_input"] == "source"
+    assert payload["runtime_device"] == "cpu"
+
+
+def test_cancelled_analyze_job_keeps_source_beat_input(client: TestClient) -> None:
+    runner = InProcessJobRunner(SessionLocal)
+    with SessionLocal() as session:
+        _add_project(session, "project_cancelled_analyze")
+        session.flush()
+        job = runner.create_job(
+            session,
+            project_id="project_cancelled_analyze",
+            job_type="analyze",
+            payload={"beat_backend": "beat-this"},
+        )
+        job.cancel_requested = True
+        job_id = job.id
+        session.commit()
+
+    runner._execute_job(job_id)
+
+    response = client.get(f"/api/v1/jobs/{job_id}")
+    assert response.status_code == 200
+    payload = response.json()["job"]
+    assert payload["status"] == "cancelled"
+    assert payload["beat_backend"] == "beat-this"
+    assert payload["beat_input"] == "source"
+
+    with SessionLocal() as session:
+        job = session.get(Job, job_id)
+        assert job is not None
+        assert job.payload_json["beat_input"] == "source"
+
+
+@pytest.mark.parametrize(
+    "payload_json",
+    [
+        {},
+        {"beat_input": "percussion"},
+        {"beat_input": []},
+        {"beat_input": {}},
+    ],
+)
+def test_analyze_job_api_defaults_missing_or_unknown_beat_input_to_source(
+    client: TestClient,
+    payload_json: dict[str, Any],
+) -> None:
+    with SessionLocal() as session:
+        _add_job(
+            session,
+            "job_analyze_input",
+            "completed",
+            job_type="analyze",
+            payload_json=payload_json,
+            created_at=_timestamp(1),
+            completed_at=_timestamp(2),
+        )
+        session.commit()
+
+    get_response = client.get("/api/v1/jobs/job_analyze_input")
+    assert get_response.status_code == 200
+    assert get_response.json()["job"]["beat_input"] == "source"
+
+    list_response = client.get("/api/v1/jobs")
+    assert list_response.status_code == 200
+    listed_job = next(job for job in list_response.json()["jobs"] if job["id"] == "job_analyze_input")
+    assert listed_job["beat_input"] == "source"
 
 
 def test_bulk_jobs_rejects_unsupported_job_type(client: TestClient) -> None:

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -2152,7 +2152,7 @@ describe("Desktop app activity", () => {
     renderApp(["/activity"]);
 
     const row = await screen.findByRole("article", { name: "analyze completed job" });
-    expect(within(row).getByText("advanced / CPU / 1.8 s")).toBeInTheDocument();
+    expect(within(row).getByText("advanced / source / CPU / 1.8 s")).toBeInTheDocument();
   });
 
   it("loads additional terminal history pages on request", async () => {

--- a/apps/desktop/src/features/projects/projectViewUtils.test.ts
+++ b/apps/desktop/src/features/projects/projectViewUtils.test.ts
@@ -192,9 +192,10 @@ describe("transposeChordSegment", () => {
 });
 
 describe("formatJobStatusSummary", () => {
-  it("includes beat backend for analysis jobs", () => {
+  it("includes beat backend and source beat input for analysis jobs", () => {
     const job: JobSchema = {
       beat_backend: "beat-this",
+      beat_input: "source",
       completed_at: "2026-04-18T13:16:02.000Z",
       created_at: "2026-04-18T13:16:00.000Z",
       duration_seconds: 1.8,
@@ -210,7 +211,28 @@ describe("formatJobStatusSummary", () => {
       updated_at: "2026-04-18T13:16:02.000Z",
     };
 
-    expect(formatJobStatusSummary(job)).toBe("completed / advanced / CPU / 1.8 s");
+    expect(formatJobStatusSummary(job)).toBe("completed / advanced / source / CPU / 1.8 s");
+  });
+
+  it("defaults missing analysis beat input to source", () => {
+    const job: JobSchema = {
+      beat_backend: "beat-this",
+      completed_at: "2026-04-18T13:16:02.000Z",
+      created_at: "2026-04-18T13:16:00.000Z",
+      duration_seconds: 1.8,
+      error_message: null,
+      id: "job_analyze_missing_input",
+      progress: 100,
+      project_id: "proj_123",
+      runtime_device: "cpu",
+      source_artifact_id: null,
+      started_at: "2026-04-18T13:16:00.000Z",
+      status: "completed",
+      type: "analyze",
+      updated_at: "2026-04-18T13:16:02.000Z",
+    };
+
+    expect(formatJobStatusSummary(job)).toBe("completed / advanced / source / CPU / 1.8 s");
   });
 
   it("defaults missing analysis beat backend to built-in", () => {
@@ -230,7 +252,7 @@ describe("formatJobStatusSummary", () => {
       updated_at: "2026-04-18T13:16:02.000Z",
     };
 
-    expect(formatJobStatusSummary(job)).toBe("completed / built-in / CPU / 1.8 s");
+    expect(formatJobStatusSummary(job)).toBe("completed / built-in / source / CPU / 1.8 s");
   });
 
   it("does not show a beat backend for non-analysis jobs", () => {

--- a/apps/desktop/src/features/projects/projectViewUtils.ts
+++ b/apps/desktop/src/features/projects/projectViewUtils.ts
@@ -136,6 +136,7 @@ export function formatJobStatusSummary(job: JobSchema) {
   return [
     job.status,
     job.type === "analyze" ? formatBeatBackend(job.beat_backend) : null,
+    job.type === "analyze" ? formatBeatInput(job.beat_input) : null,
     job.type === "chords" ? formatChordBackend(job.chord_backend) : null,
     job.type === "chords" ? job.chord_source : null,
     job.type === "stems" ? formatStemModel(job.stem_model_label ?? job.stem_model) : null,
@@ -160,6 +161,10 @@ function formatBeatBackend(backend: string | null | undefined) {
     return "advanced";
   }
   return backend ?? null;
+}
+
+function formatBeatInput(input: string | null | undefined) {
+  return input === "source" ? input : "source";
 }
 
 function formatStemModel(model: string | null | undefined) {

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -1202,6 +1202,8 @@ export interface components {
             source_artifact_id?: string | null;
             /** Beat Backend */
             beat_backend?: string | null;
+            /** Beat Input */
+            beat_input?: string | null;
             /** Chord Backend */
             chord_backend?: string | null;
             /** Chord Backend Fallback From */

--- a/scripts/beat-candidates.py
+++ b/scripts/beat-candidates.py
@@ -1,0 +1,708 @@
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import math
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.request import pathname2url
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1] / "apps" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+beat_this_engine = importlib.import_module("app.engines.beat_this")
+
+SOURCE_INPUT = "source"
+STEM_INPUTS = ("drums", "bass")
+SOURCE_STEM_TYPES = {"drums": "drums_stem", "bass": "bass_stem"}
+MIN_STABLE_BEAT_COUNT = 4
+MAX_STABLE_INTERVAL_CV = 0.12
+MIN_STABLE_TIMING_CONFIDENCE = 0.5
+MATERIAL_INTERVAL_CV_ABSOLUTE_IMPROVEMENT = 0.05
+MATERIAL_INTERVAL_CV_RELATIVE_FACTOR = 0.8
+TIMING_ALIGNMENT_TOLERANCE_BEAT_FRACTION = 0.22
+MIN_TIMING_ALIGNMENT_TOLERANCE_SECONDS = 0.06
+MAX_TIMING_ALIGNMENT_TOLERANCE_SECONDS = 0.16
+MIN_BEAT_ALIGNMENT_MATCH_RATIO = 0.6
+MIN_DOWNBEAT_ALIGNMENT_MATCH_RATIO = 0.5
+
+
+@dataclass(frozen=True)
+class ProjectInfo:
+    project_id: str
+    display_name: str
+    imported_path: Path
+    duration_seconds: float | None
+
+
+@dataclass(frozen=True)
+class ArtifactRow:
+    artifact_id: str
+    project_id: str
+    artifact_type: str
+    path: Path
+    metadata: dict[str, Any]
+    created_at: str
+
+
+@dataclass(frozen=True)
+class Candidate:
+    input_id: str
+    path: Path | None
+    artifact_id: str | None
+    metadata: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class TimingQuality:
+    usable: bool
+    valid_bars: bool
+    beat_count: int
+    positive_intervals: bool
+    interval_cv: float | None
+    meter_confidence: float
+    downbeat_confidence: float
+
+
+@dataclass(frozen=True)
+class CandidateResult:
+    candidate: Candidate
+    status: str
+    error: str | None
+    elapsed_seconds: float | None
+    timing: Mapping[str, Any] | None
+    quality: TimingQuality
+
+
+class DiagnosticError(Exception):
+    pass
+
+
+def main() -> int:
+    start_time = time.perf_counter()
+    parser = build_parser()
+    args = parser.parse_args()
+
+    try:
+        data_dir = Path(args.data_dir).expanduser().resolve() if args.data_dir else default_data_dir()
+        output_dir = Path(args.output_dir).expanduser().resolve()
+        if is_relative_to(output_dir, data_dir):
+            raise DiagnosticError(f"Output dir must be outside the TuneForge data dir: {output_dir}")
+        if not data_dir.is_dir():
+            raise DiagnosticError(f"Data dir not found: {data_dir}")
+        database_path = data_dir / "app.sqlite"
+        if not database_path.is_file():
+            raise DiagnosticError(f"Database not found: {database_path}")
+
+        available, reason = beat_this_engine.beat_this_dependency_status()
+        if not available:
+            raise DiagnosticError(reason or "Advanced Beat Analysis dependency is unavailable.")
+
+        projects = load_projects(database_path, data_dir, args.project_id)
+        if not projects:
+            raise DiagnosticError("No projects found.")
+        artifacts = load_artifacts(database_path, data_dir, [project.project_id for project in projects])
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        project_reports = [
+            analyze_project_candidates(project, artifacts.get(project.project_id, ()))
+            for project in projects
+        ]
+        summary: dict[str, Any] = {
+            "data_dir": str(data_dir),
+            "database_path": str(database_path),
+            "output_dir": str(output_dir),
+            "product_behavior": "advanced beat analysis uses source audio only",
+            "project_count": len(project_reports),
+            "projects": project_reports,
+            "elapsed_seconds": round(time.perf_counter() - start_time, 3),
+        }
+
+        report_text = render_text_report(summary)
+        report_path = output_dir / "beat-candidates.txt"
+        json_path = output_dir / "beat-candidates.json"
+        validate_output_path(report_path, data_dir)
+        validate_output_path(json_path, data_dir)
+        write_output_file(report_path, report_text)
+        write_output_file(json_path, json.dumps(summary, indent=2, sort_keys=True))
+        print(report_text)
+        return 0
+    except DiagnosticError as error:
+        print(f"beat-candidates: {error}", file=sys.stderr)
+        return 2
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run read-only beat-this diagnostics for TuneForge source/drums/bass candidates.",
+    )
+    parser.add_argument("--data-dir", type=Path, default=None)
+    parser.add_argument("--output-dir", type=Path, default=Path("beat-candidates"))
+    parser.add_argument("--project-id", action="append", default=[])
+    return parser
+
+
+def default_data_dir() -> Path:
+    override = os.environ.get("TUNEFORGE_DATA_DIR")
+    if override:
+        return Path(override).expanduser().resolve()
+    home = Path.home()
+    if sys.platform == "darwin":
+        return home / "Library" / "Application Support" / "Tuneforge"
+    return home / ".local" / "share" / "tuneforge"
+
+
+def is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def validate_output_path(path: Path, data_dir: Path) -> None:
+    try:
+        resolved = path.resolve(strict=False)
+    except RuntimeError as error:
+        raise DiagnosticError(f"Output path cannot be resolved safely: {path}") from error
+    if is_relative_to(resolved, data_dir):
+        raise DiagnosticError(f"Output path must not target the TuneForge data dir: {path} -> {resolved}")
+
+
+def write_output_file(path: Path, content: str) -> None:
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            temp_file.write(content)
+            temp_path = Path(temp_file.name)
+        temp_path.replace(path)
+    finally:
+        if temp_path is not None and temp_path.exists():
+            temp_path.unlink()
+
+
+def load_projects(database_path: Path, data_dir: Path, project_ids: Sequence[str]) -> list[ProjectInfo]:
+    uri = f"file:{pathname2url(str(database_path))}?mode=ro"
+    try:
+        with sqlite3.connect(uri, uri=True) as connection:
+            rows = connection.execute(
+                """
+                SELECT id, display_name, imported_path, duration_seconds
+                FROM projects
+                ORDER BY display_name, id
+                """
+            ).fetchall()
+    except sqlite3.Error as error:
+        raise DiagnosticError(f"Could not read projects in read-only mode: {error}") from error
+
+    selected_ids: set[str] = set()
+    for raw_project_id in project_ids:
+        project_id = raw_project_id.strip()
+        if not project_id:
+            raise DiagnosticError("--project-id cannot be empty.")
+        selected_ids.add(project_id)
+
+    projects: list[ProjectInfo] = []
+    for project_id, display_name, imported_path, duration_seconds in rows:
+        normalized_id = str(project_id)
+        if selected_ids and normalized_id not in selected_ids:
+            continue
+        projects.append(
+            ProjectInfo(
+                project_id=normalized_id,
+                display_name=str(display_name),
+                imported_path=resolve_data_path(data_dir, str(imported_path)),
+                duration_seconds=optional_float(duration_seconds),
+            )
+        )
+    if selected_ids and not projects:
+        raise DiagnosticError("No projects matched selected --project-id values.")
+    return projects
+
+
+def load_artifacts(
+    database_path: Path,
+    data_dir: Path,
+    project_ids: Sequence[str],
+) -> dict[str, tuple[ArtifactRow, ...]]:
+    if not project_ids:
+        return {}
+    placeholders = ",".join("?" for _ in project_ids)
+    uri = f"file:{pathname2url(str(database_path))}?mode=ro"
+    try:
+        with sqlite3.connect(uri, uri=True) as connection:
+            rows = connection.execute(
+                f"""
+                SELECT id, project_id, type, path, metadata_json, created_at
+                FROM artifacts
+                WHERE project_id IN ({placeholders})
+                  AND type IN ('source_audio', 'drums_stem', 'bass_stem')
+                ORDER BY project_id, type, created_at, id
+                """,
+                tuple(project_ids),
+            ).fetchall()
+    except sqlite3.Error as error:
+        raise DiagnosticError(f"Could not read artifacts in read-only mode: {error}") from error
+
+    artifacts: dict[str, list[ArtifactRow]] = {}
+    for artifact_id, project_id, artifact_type, path, metadata_json, created_at in rows:
+        row = ArtifactRow(
+            artifact_id=str(artifact_id),
+            project_id=str(project_id),
+            artifact_type=str(artifact_type),
+            path=resolve_data_path(data_dir, str(path)),
+            metadata=parse_metadata(metadata_json),
+            created_at=str(created_at),
+        )
+        artifacts.setdefault(row.project_id, []).append(row)
+    return {project_id: tuple(rows) for project_id, rows in artifacts.items()}
+
+
+def analyze_project_candidates(project: ProjectInfo, artifacts: Sequence[ArtifactRow]) -> dict[str, Any]:
+    candidates = project_candidates(project, artifacts)
+    results = [run_candidate(candidate, duration_seconds=project.duration_seconds) for candidate in candidates]
+    source_result = results[0]
+    candidate_reports = [candidate_report(result, source_result) for result in results]
+    return {
+        "project_id": project.project_id,
+        "display_name": project.display_name,
+        "duration_seconds": project.duration_seconds,
+        "product_behavior": "source",
+        "candidates": candidate_reports,
+    }
+
+
+def project_candidates(project: ProjectInfo, artifacts: Sequence[ArtifactRow]) -> tuple[Candidate, ...]:
+    latest_source = latest_artifact([artifact for artifact in artifacts if artifact.artifact_type == "source_audio"])
+    source_candidate = Candidate(
+        input_id=SOURCE_INPUT,
+        path=project.imported_path,
+        artifact_id=latest_source.artifact_id if latest_source is not None else None,
+        metadata=latest_source.metadata if latest_source is not None else {},
+    )
+    source_artifact_id = latest_source.artifact_id if latest_source is not None else None
+
+    stem_candidates: list[Candidate] = []
+    for input_id in STEM_INPUTS:
+        artifact = latest_source_stem_artifact(
+            artifacts,
+            artifact_type=SOURCE_STEM_TYPES[input_id],
+            source_artifact_id=source_artifact_id,
+        )
+        stem_candidates.append(
+            Candidate(
+                input_id=input_id,
+                path=artifact.path if artifact is not None else None,
+                artifact_id=artifact.artifact_id if artifact is not None else None,
+                metadata=artifact.metadata if artifact is not None else {},
+            )
+        )
+    return (source_candidate, *stem_candidates)
+
+
+def latest_source_stem_artifact(
+    artifacts: Sequence[ArtifactRow],
+    *,
+    artifact_type: str,
+    source_artifact_id: str | None,
+) -> ArtifactRow | None:
+    if source_artifact_id is None:
+        return None
+    matches = [
+        artifact
+        for artifact in artifacts
+        if artifact.artifact_type == artifact_type
+        and artifact.metadata.get("source_artifact_id") == source_artifact_id
+        and artifact.metadata.get("source_artifact_type") in {None, "source_audio"}
+    ]
+    return latest_artifact(matches)
+
+
+def latest_artifact(artifacts: Sequence[ArtifactRow]) -> ArtifactRow | None:
+    return max(artifacts, key=lambda artifact: (artifact.created_at, artifact.artifact_id), default=None)
+
+
+def run_candidate(candidate: Candidate, *, duration_seconds: float | None) -> CandidateResult:
+    if candidate.path is None:
+        return failed_candidate(candidate, "missing_artifact", "No source-track artifact found.")
+    if not candidate.path.is_file():
+        return failed_candidate(candidate, "missing_file", f"File not found: {candidate.path}")
+
+    start_time = time.perf_counter()
+    try:
+        timing = beat_this_engine.detect_beat_this_timing(candidate.path, duration_seconds=duration_seconds)
+    except beat_this_engine.BeatThisRuntimeError as error:
+        elapsed = round(time.perf_counter() - start_time, 3)
+        return CandidateResult(candidate, "run_failed", str(error), elapsed, None, empty_quality())
+    except Exception as error:  # pragma: no cover - defensive CLI boundary
+        elapsed = round(time.perf_counter() - start_time, 3)
+        return CandidateResult(candidate, "run_failed", str(error), elapsed, None, empty_quality())
+
+    elapsed = round(time.perf_counter() - start_time, 3)
+    if timing is None:
+        return CandidateResult(
+            candidate,
+            "no_timing",
+            "beat-this did not return a usable timing grid.",
+            elapsed,
+            None,
+            empty_quality(),
+        )
+    return CandidateResult(candidate, "ok", None, elapsed, timing, timing_quality(timing))
+
+
+def failed_candidate(candidate: Candidate, status: str, error: str) -> CandidateResult:
+    return CandidateResult(candidate, status, error, None, None, empty_quality())
+
+
+def candidate_report(result: CandidateResult, source_result: CandidateResult) -> dict[str, Any]:
+    alignment = alignment_report(result.timing, source_result.timing)
+    gate, outcome = diagnostic_gate(result, source_result, alignment)
+    quality = result.quality
+    return {
+        "input": result.candidate.input_id,
+        "artifact_id": result.candidate.artifact_id,
+        "path": str(result.candidate.path) if result.candidate.path is not None else None,
+        "status": result.status,
+        "error": result.error,
+        "elapsed_seconds": result.elapsed_seconds,
+        "beat_count": quality.beat_count,
+        "interval_cv": quality.interval_cv,
+        "meter_confidence": quality.meter_confidence,
+        "downbeat_confidence": quality.downbeat_confidence,
+        "stem_signal_has_signal": stem_signal_has_signal(result.candidate.metadata),
+        "alignment_vs_source": alignment,
+        "diagnostic_gate": gate,
+        "diagnostic_outcome": outcome,
+    }
+
+
+def diagnostic_gate(
+    result: CandidateResult,
+    source_result: CandidateResult,
+    alignment: dict[str, Any] | None,
+) -> tuple[str, str]:
+    if result.candidate.input_id == SOURCE_INPUT:
+        if result.status != "ok":
+            return result.status, "product_source_unavailable"
+        if is_stable_timing(result.quality):
+            return "source_stable", "product_source"
+        return "source_baseline", "product_source"
+
+    if result.status != "ok":
+        return result.status, "diagnostic_not_run"
+    if source_result.status != "ok":
+        return "source_unavailable", "diagnostic_inconclusive"
+    if not result.quality.usable:
+        return "unusable_timing", "diagnostic_rejected"
+    if result.quality.beat_count < MIN_STABLE_BEAT_COUNT:
+        return "too_few_beats", "diagnostic_rejected"
+    if not has_material_interval_cv_improvement(result.quality, source_result.quality):
+        return "no_material_interval_cv_improvement", "diagnostic_rejected"
+    if not has_comparable_beat_count(result.quality, source_result.quality):
+        return "beat_count_not_comparable", "diagnostic_rejected"
+    if not has_comparable_timing_confidence(result.quality, source_result.quality):
+        return "confidence_not_comparable", "diagnostic_rejected"
+    if alignment is None or not alignment.get("aligned"):
+        return "not_source_aligned", "diagnostic_rejected"
+    return "diagnostic_candidate", "diagnostic_candidate_only"
+
+
+def timing_quality(timing: Mapping[str, Any]) -> TimingQuality:
+    beat_seconds = timing_beat_seconds(timing)
+    intervals = [second - first for first, second in zip(beat_seconds, beat_seconds[1:], strict=False)]
+    positive_intervals = bool(intervals and all(math.isfinite(value) and value > 0.0 for value in intervals))
+    interval_cv = None
+    if positive_intervals:
+        mean_interval = sum(intervals) / len(intervals)
+        if mean_interval > 0.0:
+            variance = sum((value - mean_interval) ** 2 for value in intervals) / len(intervals)
+            interval_cv = math.sqrt(variance) / mean_interval
+    valid_bars = bool(timing.get("bars"))
+    return TimingQuality(
+        usable=valid_bars and len(beat_seconds) >= 2 and positive_intervals,
+        valid_bars=valid_bars,
+        beat_count=len(beat_seconds),
+        positive_intervals=positive_intervals,
+        interval_cv=interval_cv,
+        meter_confidence=finite_confidence(timing.get("meter_confidence")),
+        downbeat_confidence=finite_confidence(timing.get("downbeat_confidence")),
+    )
+
+
+def empty_quality() -> TimingQuality:
+    return TimingQuality(
+        usable=False,
+        valid_bars=False,
+        beat_count=0,
+        positive_intervals=False,
+        interval_cv=None,
+        meter_confidence=0.0,
+        downbeat_confidence=0.0,
+    )
+
+
+def is_stable_timing(quality: TimingQuality) -> bool:
+    return (
+        quality.usable
+        and quality.valid_bars
+        and quality.beat_count >= MIN_STABLE_BEAT_COUNT
+        and quality.positive_intervals
+        and quality.interval_cv is not None
+        and quality.interval_cv <= MAX_STABLE_INTERVAL_CV
+        and timing_confidence(quality) >= MIN_STABLE_TIMING_CONFIDENCE
+    )
+
+
+def has_material_interval_cv_improvement(candidate: TimingQuality, source: TimingQuality) -> bool:
+    if candidate.interval_cv is None:
+        return False
+    if source.interval_cv is None:
+        return True
+    return (
+        candidate.interval_cv + MATERIAL_INTERVAL_CV_ABSOLUTE_IMPROVEMENT <= source.interval_cv
+        and candidate.interval_cv <= source.interval_cv * MATERIAL_INTERVAL_CV_RELATIVE_FACTOR
+    )
+
+
+def has_comparable_beat_count(candidate: TimingQuality, source: TimingQuality) -> bool:
+    return candidate.beat_count >= max(MIN_STABLE_BEAT_COUNT, source.beat_count - 1)
+
+
+def has_comparable_timing_confidence(candidate: TimingQuality, source: TimingQuality) -> bool:
+    return timing_confidence(candidate) >= max(0.0, timing_confidence(source) - 0.25)
+
+
+def timing_confidence(quality: TimingQuality) -> float:
+    return max(quality.meter_confidence, quality.downbeat_confidence)
+
+
+def alignment_report(
+    candidate_timing: Mapping[str, Any] | None,
+    source_timing: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    if candidate_timing is None or source_timing is None:
+        return None
+    source_beats = timing_beat_seconds(source_timing)
+    candidate_beats = timing_beat_seconds(candidate_timing)
+    if source_beats == candidate_beats:
+        return {
+            "tolerance_seconds": 0.0,
+            "beat_match_ratio": 1.0,
+            "downbeat_match_ratio": 1.0,
+            "aligned": True,
+        }
+    if not source_beats or not candidate_beats:
+        return {
+            "tolerance_seconds": None,
+            "beat_match_ratio": 0.0,
+            "downbeat_match_ratio": 0.0,
+            "aligned": False,
+        }
+
+    tolerance = timing_alignment_tolerance_seconds(source_beats, candidate_beats)
+    beat_match_ratio = min(
+        nearest_alignment_match_ratio(source_beats, candidate_beats, tolerance),
+        nearest_alignment_match_ratio(candidate_beats, source_beats, tolerance),
+    )
+    source_downbeats = timing_downbeat_seconds(source_timing)
+    candidate_downbeats = timing_downbeat_seconds(candidate_timing)
+    downbeat_match_ratio: float | None = None
+    downbeats_aligned = True
+    if len(source_downbeats) >= 2 and len(candidate_downbeats) >= 2:
+        downbeat_match_ratio = min(
+            nearest_alignment_match_ratio(source_downbeats, candidate_downbeats, tolerance),
+            nearest_alignment_match_ratio(candidate_downbeats, source_downbeats, tolerance),
+        )
+        downbeats_aligned = downbeat_match_ratio >= MIN_DOWNBEAT_ALIGNMENT_MATCH_RATIO
+    return {
+        "tolerance_seconds": round(tolerance, 6),
+        "beat_match_ratio": round(beat_match_ratio, 6),
+        "downbeat_match_ratio": None if downbeat_match_ratio is None else round(downbeat_match_ratio, 6),
+        "aligned": beat_match_ratio >= MIN_BEAT_ALIGNMENT_MATCH_RATIO and downbeats_aligned,
+    }
+
+
+def timing_alignment_tolerance_seconds(source_beats: Sequence[float], candidate_beats: Sequence[float]) -> float:
+    interval_seconds = min(median_positive_interval(source_beats), median_positive_interval(candidate_beats))
+    if interval_seconds <= 0.0:
+        return MIN_TIMING_ALIGNMENT_TOLERANCE_SECONDS
+    return min(
+        MAX_TIMING_ALIGNMENT_TOLERANCE_SECONDS,
+        max(MIN_TIMING_ALIGNMENT_TOLERANCE_SECONDS, interval_seconds * TIMING_ALIGNMENT_TOLERANCE_BEAT_FRACTION),
+    )
+
+
+def median_positive_interval(seconds: Sequence[float]) -> float:
+    intervals = sorted(
+        second - first
+        for first, second in zip(seconds, seconds[1:], strict=False)
+        if math.isfinite(second - first) and second - first > 0.0
+    )
+    if not intervals:
+        return 0.0
+    middle = len(intervals) // 2
+    if len(intervals) % 2:
+        return intervals[middle]
+    return (intervals[middle - 1] + intervals[middle]) / 2.0
+
+
+def nearest_alignment_match_ratio(reference: Sequence[float], candidate: Sequence[float], tolerance: float) -> float:
+    if not reference or not candidate:
+        return 0.0
+    matches = 0
+    for reference_seconds in reference:
+        nearest_distance = min(abs(reference_seconds - candidate_seconds) for candidate_seconds in candidate)
+        if nearest_distance <= tolerance:
+            matches += 1
+    return matches / len(reference)
+
+
+def timing_beat_seconds(timing: Mapping[str, Any]) -> list[float]:
+    beats = timing.get("beats")
+    if not isinstance(beats, Sequence):
+        return []
+    seconds: list[float] = []
+    for beat in beats:
+        if isinstance(beat, Mapping):
+            value = optional_float(beat.get("seconds"))
+            if value is not None and value >= 0.0:
+                seconds.append(value)
+    return seconds
+
+
+def timing_downbeat_seconds(timing: Mapping[str, Any]) -> list[float]:
+    beats = timing.get("beats")
+    if not isinstance(beats, Sequence):
+        return []
+    seconds: list[float] = []
+    for beat in beats:
+        if not isinstance(beat, Mapping):
+            continue
+        if beat.get("beat_in_bar") != 1:
+            continue
+        value = optional_float(beat.get("seconds"))
+        if value is not None and value >= 0.0:
+            seconds.append(value)
+    return seconds
+
+
+def finite_confidence(value: object) -> float:
+    parsed = optional_float(value)
+    if parsed is None:
+        return 0.0
+    return min(1.0, max(0.0, parsed))
+
+
+def stem_signal_has_signal(metadata: Mapping[str, Any]) -> bool | None:
+    stem_signal = metadata.get("stem_signal")
+    if not isinstance(stem_signal, Mapping):
+        return None
+    value = stem_signal.get("has_signal")
+    return value if isinstance(value, bool) else None
+
+
+def resolve_data_path(data_dir: Path, raw_path: str) -> Path:
+    path = Path(raw_path).expanduser()
+    if not path.is_absolute():
+        path = data_dir / path
+    return path.resolve()
+
+
+def parse_metadata(raw_metadata: object) -> dict[str, Any]:
+    if raw_metadata is None:
+        return {}
+    if isinstance(raw_metadata, bytes):
+        raw_metadata = raw_metadata.decode("utf-8", errors="replace")
+    if not isinstance(raw_metadata, str):
+        return {}
+    try:
+        parsed: object = json.loads(raw_metadata)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return {str(key): value for key, value in parsed.items()}
+
+
+def optional_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        parsed = float(value)
+        return parsed if math.isfinite(parsed) else None
+    return None
+
+
+def render_text_report(summary: Mapping[str, Any]) -> str:
+    lines = [
+        "TuneForge beat candidate diagnostic",
+        f"Data dir: {summary['data_dir']}",
+        f"Output dir: {summary['output_dir']}",
+        "Product behavior: Advanced Beat Analysis uses source audio only.",
+        f"Projects: {summary['project_count']}",
+        f"Elapsed: {summary['elapsed_seconds']}s",
+        "",
+    ]
+    for project in summary["projects"]:
+        lines.append(f"Project: {project['display_name']} ({project['project_id']})")
+        for candidate in project["candidates"]:
+            lines.append(render_candidate_line(candidate))
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_candidate_line(candidate: Mapping[str, Any]) -> str:
+    parts = [
+        f"  {candidate['input']}:",
+        f"status={candidate['status']}",
+        f"beats={candidate['beat_count']}",
+        f"cv={format_float(candidate['interval_cv'])}",
+        f"meter={format_float(candidate['meter_confidence'])}",
+        f"downbeat={format_float(candidate['downbeat_confidence'])}",
+    ]
+    if candidate["input"] != SOURCE_INPUT:
+        parts.append(f"stem_signal.has_signal={format_optional_bool(candidate['stem_signal_has_signal'])}")
+        alignment = candidate["alignment_vs_source"]
+        if isinstance(alignment, Mapping):
+            parts.append(f"align.beat={format_float(alignment.get('beat_match_ratio'))}")
+            parts.append(f"align.downbeat={format_float(alignment.get('downbeat_match_ratio'))}")
+    parts.append(f"gate={candidate['diagnostic_gate']}")
+    parts.append(f"outcome={candidate['diagnostic_outcome']}")
+    if candidate.get("error"):
+        parts.append(f"error={candidate['error']}")
+    return " ".join(parts)
+
+
+def format_float(value: object) -> str:
+    if not isinstance(value, int | float) or isinstance(value, bool):
+        return "n/a"
+    if not math.isfinite(float(value)):
+        return "n/a"
+    return f"{float(value):.3f}"
+
+
+def format_optional_bool(value: object) -> str:
+    if isinstance(value, bool):
+        return str(value).lower()
+    return "unknown"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Keep Advanced Beat Analysis source-only in product analysis and artifact metadata.
- Add analyze job `beat_input` so activity shows `advanced / source / CPU / ...`.
- Add read-only `scripts/beat-candidates.py` diagnostics for source/stem comparisons.

## Testing
- `cd apps/backend && UV_CACHE_DIR=$TMPDIR/uv-cache uv run --python 3.11 pytest tests/test_beat_this_engine.py tests/test_analysis_flow.py tests/test_jobs_api.py tests/test_beat_candidates_script.py`
- `cd apps/backend && UV_CACHE_DIR=$TMPDIR/uv-cache uv run --python 3.11 ruff check app tests ../../scripts/beat-candidates.py`
- `cd apps/backend && UV_CACHE_DIR=$TMPDIR/uv-cache uv run --python 3.11 mypy app`
- `pnpm contracts:generate`
- `pnpm --filter @tuneforge/desktop test -- --run src/features/projects/projectViewUtils.test.ts`
- `pnpm --filter @tuneforge/desktop typecheck`
- `git diff --check origin/main...HEAD`
- `git diff --check`

Refs #217
