### PR TITLE
chore: update Codex environment actions

### DIFF
--- a/.codex/environments/development.toml
+++ b/.codex/environments/development.toml
@@ -5,7 +5,7 @@ name = "development"
 [setup]
 script = '''
 cd "$CODEX_WORKTREE_PATH"
-pnpm setup:dev --crema
+pnpm setup:dev -- --beat-this --crema
 '''
 
 [[actions]]
@@ -14,9 +14,9 @@ icon = "run"
 command = "pnpm dev"
 
 [[actions]]
-name = "Advanced chords"
+name = "Advanced"
 icon = "tool"
-command = "pnpm setup:dev --crema"
+command = "pnpm setup:dev -- --beat-this --crema"
 
 [[actions]]
 name = "Setup dev"

--- a/.codex/environments/legacy-nvidia.toml
+++ b/.codex/environments/legacy-nvidia.toml
@@ -5,7 +5,7 @@ name = "linux legacy nvidia"
 [setup]
 script = '''
 cd "$CODEX_WORKTREE_PATH"
-pnpm setup:dev --crema --legacy-nvidia
+pnpm setup:dev -- --beat-this --crema --legacy-nvidia
 '''
 
 [[actions]]
@@ -14,9 +14,9 @@ icon = "run"
 command = "pnpm dev"
 
 [[actions]]
-name = "Advanced chords"
+name = "Advanced"
 icon = "tool"
-command = "pnpm setup:dev --crema"
+command = "pnpm setup:dev -- --beat-this --crema --legacy-nvidia"
 
 [[actions]]
 name = "Setup dev"
@@ -26,7 +26,7 @@ command = "pnpm setup:dev"
 [[actions]]
 name = "Legacy Nvidia Backend"
 icon = "tool"
-command = "pnpm sync:backend:legacy-nvidia --crema"
+command = "pnpm sync:backend:legacy-nvidia -- --beat-this --crema"
 platform = "linux"
 
 [[actions]]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           if [[ -s "${changed_files}" ]]; then
             while IFS= read -r path; do
               case "${path}" in
-                .github/workflows/*|scripts/*|package.json|pnpm-lock.yaml|apps/backend/pyproject.toml|apps/backend/uv.lock)
+                scripts/*|package.json|pnpm-lock.yaml|apps/backend/pyproject.toml|apps/backend/uv.lock)
                   full_gate=true
                   ;;
                 apps/backend/app/api/*|apps/backend/app/schemas.py|apps/backend/app/main.py)
@@ -65,7 +65,7 @@ jobs:
                 apps/desktop/*|packages/shared-types/*)
                   desktop=true
                   ;;
-                docs/*|README.md|CONTRIBUTING.md|CODE_OF_CONDUCT.md|LICENSE|THIRD_PARTY_NOTICES.md|SECURITY.md|AGENTS.md|.github/ISSUE_TEMPLATE/*|.github/PULL_REQUEST_TEMPLATE.md)
+                .github/workflows/ci.yml|.codex/environments/*|docs/*|README.md|CONTRIBUTING.md|CODE_OF_CONDUCT.md|LICENSE|THIRD_PARTY_NOTICES.md|SECURITY.md|AGENTS.md|.github/ISSUE_TEMPLATE/*|.github/PULL_REQUEST_TEMPLATE.md)
                   ;;
                 *)
                   full_gate=true
@@ -79,6 +79,22 @@ jobs:
             backend_ffmpeg=true
             desktop=true
           fi
+
+          print_scope_decision() {
+            local label="$1"
+            local enabled="$2"
+
+            if [[ "${enabled}" == "true" ]]; then
+              echo "- Include ${label}"
+            else
+              echo "- Skip ${label}"
+            fi
+          }
+
+          echo "Final CI scope decision:"
+          print_scope_decision "backend static checks" "${backend_static}"
+          print_scope_decision "backend FFmpeg tests" "${backend_ffmpeg}"
+          print_scope_decision "desktop checks" "${desktop}"
 
           {
             echo "backend_static=${backend_static}"
@@ -144,7 +160,7 @@ jobs:
 
   backend:
     needs: ci-scope
-    if: ${{ always() }}
+    if: ${{ always() && (needs.ci-scope.result != 'success' || needs.ci-scope.outputs.backend_static == 'true' || needs.ci-scope.outputs.backend_ffmpeg == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - name: Require CI scope
@@ -210,7 +226,7 @@ jobs:
 
   desktop:
     needs: ci-scope
-    if: ${{ always() }}
+    if: ${{ always() && (needs.ci-scope.result != 'success' || needs.ci-scope.outputs.desktop == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - name: Require CI scope


### PR DESCRIPTION
## Summary
- Add `--beat-this` passthrough flags to Codex development and legacy Nvidia setup/actions.
- Rename advanced Codex environment action labels to `Advanced`.
- Exclude Codex environment files and this CI scope workflow from backend/desktop app scope.
- Skip backend and desktop jobs entirely when their scope outputs are false.
- Print the final include/skip scope decision in the CI scope job logs.

## Testing
- `actionlint .github/workflows/ci.yml`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'yaml ok'"`
- Current PR file scope simulation prints skip decisions for backend static, backend FFmpeg, and desktop.
- `python3 -c "import tomllib; paths=['.codex/environments/development.toml','.codex/environments/legacy-nvidia.toml']; [tomllib.load(open(path,'rb')) for path in paths]; print('toml ok')"`
- `git diff --check origin/main...HEAD`
- Not run: `pnpm lint`, `pnpm typecheck`, `pnpm test` because no backend or desktop code changed.