### PR TITLE
feat(import): prefer stem-aware processing

### DIFF
--- a/apps/backend/app/api/routes/projects.py
+++ b/apps/backend/app/api/routes/projects.py
@@ -103,26 +103,6 @@ def create_project(
         payload.chord_backend,
         payload.chord_backend_fallback_from,
     )
-    chords_job = runner.create_job(
-        session,
-        project_id=project.id,
-        job_type="chords",
-        payload={
-            **ChordRequest(
-                backend=selected_chord_backend.id,
-                backend_fallback_from=chord_backend_fallback_from,
-                force=False,
-            ).model_dump(),
-            "chord_backend": selected_chord_backend.id,
-            "chord_source": "source",
-        },
-    )
-    lyrics_job = runner.create_job(
-        session,
-        project_id=project.id,
-        job_type="lyrics",
-        payload=LyricsGenerateRequest(force=False).model_dump(),
-    )
     source_artifact = resolve_stem_source_artifact(
         session,
         project=project,
@@ -147,12 +127,32 @@ def create_project(
             "stem_model_label": selected_stem_model.label,
         },
     )
+    chords_job = runner.create_job(
+        session,
+        project_id=project.id,
+        job_type="chords",
+        payload={
+            **ChordRequest(
+                backend=selected_chord_backend.id,
+                backend_fallback_from=chord_backend_fallback_from,
+                force=False,
+            ).model_dump(),
+            "chord_backend": selected_chord_backend.id,
+            "chord_source": "source",
+        },
+    )
+    lyrics_job = runner.create_job(
+        session,
+        project_id=project.id,
+        job_type="lyrics",
+        payload=LyricsGenerateRequest(force=False).model_dump(),
+    )
     session.commit()
     session.refresh(project)
     runner.enqueue(analyze_job.id)
+    runner.enqueue(stem_job.id)
     runner.enqueue(chords_job.id)
     runner.enqueue(lyrics_job.id)
-    runner.enqueue(stem_job.id)
     return ProjectResponse(project=ProjectSchema.model_validate(project))
 
 

--- a/apps/backend/app/models.py
+++ b/apps/backend/app/models.py
@@ -453,6 +453,13 @@ class Job(Base):
         return value if isinstance(value, str) else None
 
     @property
+    def lyrics_source(self) -> str | None:
+        if self.type != "lyrics":
+            return None
+        value = self.payload_json.get("lyrics_source")
+        return value if isinstance(value, str) else None
+
+    @property
     def chord_backend(self) -> str | None:
         if self.type != "chords":
             return None

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -1219,6 +1219,7 @@ class JobSchema(BaseModel):
     chord_backend: str | None = None
     chord_backend_fallback_from: str | None = None
     chord_source: str | None = None
+    lyrics_source: str | None = None
     stem_model: str | None = None
     stem_model_label: str | None = None
     error_message: str | None

--- a/apps/backend/app/services/jobs.py
+++ b/apps/backend/app/services/jobs.py
@@ -12,7 +12,7 @@ from sqlalchemy import case, func, select
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.errors import AppError, JobCancelledError
-from app.models import Artifact, ChordTimeline, Job, Project, utcnow
+from app.models import Artifact, Job, Project, utcnow
 from app.schemas import AnalysisRequest, BulkJobRequest, ChordRequest, LyricsGenerateRequest, StemRequest
 from app.services.analysis import analyze_project
 from app.services.beat_backends import beat_backend_runtime_device
@@ -21,13 +21,10 @@ from app.services.chords import detect_project_chords, project_chord_detection_s
 from app.services.lyrics import generate_project_lyrics
 from app.services.projects import get_mutable_project, get_project
 from app.services.stem_models import (
-    NON_VOCAL_SIX_STEM_SOURCES,
-    STEM_ARTIFACT_TYPE_SOURCES,
     STEM_ARTIFACT_TYPES,
     TWO_STEMS_MODEL_ID,
     resolve_stem_model,
 )
-from app.services.stem_signal_metadata import stem_signal_analysis_usable
 from app.services.stems import generate_stems, resolve_stem_source_artifact
 from app.services.transformations import (
     build_preview_plan,
@@ -761,6 +758,12 @@ class InProcessJobRunner:
             register_process=context.register_process,
             unregister_process=context.unregister_process,
         )
+        job.payload_json = {
+            **job.payload_json,
+            "lyrics_source": _lyrics_job_source(lyrics.source_kind),
+            "source_artifact_id": lyrics.source_artifact_id,
+        }
+        session.flush()
         context.set_progress(90)
         return JobExecutionResult(artifact_ids=[], runtime_device=lyrics.device)
 
@@ -808,34 +811,6 @@ class InProcessJobRunner:
             unregister_process=context.unregister_process,
         )
         artifacts = stem_result.artifacts
-        chord_source = _stem_artifacts_chord_source(artifacts)
-        if _should_enqueue_chord_refresh_after_stems(
-            job,
-            artifacts,
-            session.get(ChordTimeline, project.id),
-            generated_this_job=stem_result.generated_this_job,
-            signal_metadata_hydrated=stem_result.signal_metadata_hydrated,
-        ):
-            selected_chord_backend = resolve_chord_backend(
-                str(payload.get("chord_backend", "default")),
-                require_available=False,
-            )
-            chord_job = self.create_job(
-                session,
-                project_id=project.id,
-                job_type="chords",
-                payload={
-                    "backend": selected_chord_backend.id,
-                    "backend_fallback_from": payload.get("chord_backend_fallback_from")
-                    if isinstance(payload.get("chord_backend_fallback_from"), str)
-                    else None,
-                    "force": True,
-                    "overwrite_user_edits": bool(payload.get("overwrite_chord_edits", False)),
-                    "chord_backend": selected_chord_backend.id,
-                    "chord_source": chord_source,
-                },
-            )
-            self.enqueue(chord_job.id)
         runtime_device = next(
             (
                 artifact.metadata_json.get("device")
@@ -856,46 +831,11 @@ def _job_payload_for_create(*, job_type: str, payload: dict[str, Any]) -> dict[s
     return payload
 
 
-def _should_enqueue_chord_refresh_after_stems(
-    job: Job,
-    artifacts: list[Artifact],
-    chords: ChordTimeline | None,
-    *,
-    generated_this_job: bool,
-    signal_metadata_hydrated: bool,
-) -> bool:
-    if not generated_this_job and not signal_metadata_hydrated:
-        return False
-    if _stem_artifacts_chord_source(artifacts) != "source+stem":
-        return False
-    overwrite_chord_edits = bool(job.payload_json.get("overwrite_chord_edits", False))
-    if chords is not None and chords.has_user_edits and not overwrite_chord_edits:
-        return False
-    return True
-
-
-def _stem_artifacts_chord_source(artifacts: list[Artifact]) -> Literal["source", "source+stem"]:
-    if any(_is_signal_bearing_chord_stem(artifact) for artifact in artifacts):
-        return "source+stem"
-    return "source"
-
-
-def _is_signal_bearing_chord_stem(artifact: Artifact) -> bool:
-    metadata = artifact.metadata_json
-    source_artifact_id = metadata.get("source_artifact_id")
-    if not isinstance(source_artifact_id, str) or not source_artifact_id:
-        return False
-    source_artifact_type = metadata.get("source_artifact_type")
-    if source_artifact_type not in {None, "source_audio"}:
-        return False
-    if not stem_signal_analysis_usable(metadata):
-        return False
-    if artifact.type == "instrumental_stem":
-        return True
-
-    stem_source = metadata.get("stem_source")
-    return (
-        isinstance(stem_source, str)
-        and stem_source in NON_VOCAL_SIX_STEM_SOURCES
-        and STEM_ARTIFACT_TYPE_SOURCES.get(artifact.type) == stem_source
-    )
+def _lyrics_job_source(source_kind: str | None) -> str | None:
+    if source_kind == "vocal_stem":
+        return "vocals"
+    if source_kind == "instrumental":
+        return "none"
+    if source_kind == "ai":
+        return "source_preferred"
+    return None

--- a/apps/backend/app/services/lyrics.py
+++ b/apps/backend/app/services/lyrics.py
@@ -10,6 +10,7 @@ from subprocess import Popen
 from typing import Any, cast
 
 from fastapi import status
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.config import get_settings
@@ -18,6 +19,7 @@ from app.errors import AppError, JobCancelledError
 from app.models import Artifact, LyricsTranscript, Project
 from app.schemas import LyricsEditSegmentSchema
 from app.services.paths import project_analysis_dir
+from app.services.stem_signal_metadata import stem_signal_analysis_usable
 from app.services.sync_revisions import record_lyrics_revision
 from app.services.tab_state import clear_project_tab_state
 
@@ -33,6 +35,33 @@ def _ensure_not_cancelled(should_cancel: Callable[[], bool] | None) -> None:
 def _source_artifact(project: Project) -> Artifact | None:
     artifact = next((artifact for artifact in project.artifacts if artifact.type == "source_audio"), None)
     return artifact if isinstance(artifact, Artifact) else None
+
+
+def _latest_usable_source_vocal_stem(
+    session: Session,
+    *,
+    project_id: str,
+    source_artifact: Artifact | None,
+) -> Artifact | None:
+    if source_artifact is None:
+        return None
+    stmt = (
+        select(Artifact)
+        .where(
+            Artifact.project_id == project_id,
+            Artifact.type == "vocal_stem",
+        )
+        .order_by(Artifact.created_at.desc(), Artifact.id.desc())
+    )
+    for artifact in session.scalars(stmt):
+        if (
+            artifact.metadata_json.get("source_artifact_id") == source_artifact.id
+            and artifact.metadata_json.get("source_artifact_type") in {None, "source_audio"}
+            and Path(artifact.path).exists()
+            and stem_signal_analysis_usable(artifact.metadata_json)
+        ):
+            return artifact
+    return None
 
 
 def _write_lyrics_snapshot(
@@ -107,8 +136,18 @@ def generate_project_lyrics(
         _write_lyrics_snapshot(project_id=project.id, lyrics=existing)
         return existing
 
+    lyrics_source_artifact = _latest_usable_source_vocal_stem(
+        session,
+        project_id=project.id,
+        source_artifact=source_artifact,
+    )
+    transcription_source_path = (
+        Path(lyrics_source_artifact.path)
+        if lyrics_source_artifact is not None
+        else Path(project.imported_path)
+    )
     transcription = transcribe_project_lyrics(
-        Path(project.imported_path),
+        transcription_source_path,
         model_name=get_settings().lyrics_model,
         requested_device=get_settings().lyrics_device,
         download_root=get_settings().lyrics_cache_dir,
@@ -127,8 +166,14 @@ def generate_project_lyrics(
         session.add(existing)
 
     existing.backend = transcription.backend
-    existing.source_artifact_id = source_artifact.id if source_artifact else None
-    existing.source_kind = "ai"
+    if lyrics_source_artifact is not None:
+        lyrics_source_artifact_id = lyrics_source_artifact.id
+    elif source_artifact is not None:
+        lyrics_source_artifact_id = source_artifact.id
+    else:
+        lyrics_source_artifact_id = None
+    existing.source_artifact_id = lyrics_source_artifact_id
+    existing.source_kind = "vocal_stem" if lyrics_source_artifact is not None else "ai"
     existing.requested_device = transcription.requested_device
     existing.device = transcription.device
     existing.model_name = transcription.model

--- a/apps/backend/tests/test_lyrics_flow.py
+++ b/apps/backend/tests/test_lyrics_flow.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import json
 import time
+from datetime import UTC, datetime
 from pathlib import Path
 from threading import Event
 from types import SimpleNamespace
+from typing import Any
 
 from sqlalchemy import select
 
@@ -12,8 +14,10 @@ from app.db import SessionLocal
 from app.engines.lyrics import LyricsTranscription
 from app.errors import AppError
 from app.models import LyricsTranscript, SyncEntityRevision
+from app.services.artifacts import register_artifact
 from app.services.paths import project_analysis_dir
 from app.services.projects import import_project
+from app.services.stem_signal_metadata import STEM_SIGNAL_METADATA_KEY, STEM_SIGNAL_METADATA_VERSION
 from app.services.stems import StemGenerationResult
 
 from .conftest import wait_for_job
@@ -35,6 +39,85 @@ def _create_project_without_import_jobs(source_path: Path) -> str:
         project_id = project.id
         session.commit()
     return project_id
+
+
+def _stem_signal_metadata(*, usable: bool) -> dict[str, Any]:
+    peak = 0.4 if usable else 0.0
+    rms = 0.2 if usable else 0.0
+    active_duration = 2.0 if usable else 0.0
+    return {
+        STEM_SIGNAL_METADATA_KEY: {
+            "version": STEM_SIGNAL_METADATA_VERSION,
+            "has_signal": usable,
+            "peak": peak,
+            "rms": rms,
+            "active_duration_seconds": active_duration,
+            "inspected_duration_seconds": 4.0,
+            "active_ratio": active_duration / 4.0,
+            "sample_rate": 44_100,
+            "channels": 2,
+            "thresholds": {
+                "peak": 0.001,
+                "rms": 0.0005,
+                "active_duration_seconds": 0.2,
+                "window_seconds": 0.05,
+            },
+            "analysis_usability": {
+                "version": 1,
+                "usable": usable,
+                "reason": "usable" if usable else "absolute_no_signal",
+                "rms_ratio": 1.0 if usable else 0.0,
+                "rms_db_below_reference": 0.0 if usable else None,
+                "active_ratio": 1.0 if usable else 0.0,
+                "peak_ratio": 1.0 if usable else 0.0,
+                "reference": {
+                    "max_rms": rms,
+                    "max_active_duration_seconds": active_duration,
+                    "max_peak": peak,
+                },
+                "thresholds": {
+                    "min_rms_ratio": 0.10,
+                    "min_active_ratio": 0.20,
+                    "clear_absent_rms_ratio": 0.01,
+                },
+            },
+        },
+    }
+
+
+def _register_source_vocal_stem(
+    *,
+    project_id: str,
+    source_artifact_id: str,
+    path: Path,
+    created_at: datetime,
+    usable: bool = True,
+    stem_model: str = "htdemucs_ft",
+) -> str:
+    mode = "six_stems" if stem_model == "htdemucs_6s" else "two_stems"
+    with SessionLocal() as session:
+        artifact = register_artifact(
+            session,
+            project_id=project_id,
+            artifact_type="vocal_stem",
+            artifact_format="wav",
+            path=path,
+            metadata={
+                "mode": mode,
+                "stem_model": stem_model,
+                "stem_source": "vocals",
+                "source_artifact_id": source_artifact_id,
+                "source_artifact_type": "source_audio",
+                **_stem_signal_metadata(usable=usable),
+            },
+            generated_by="demucs",
+            can_delete=True,
+            can_regenerate=True,
+        )
+        artifact.created_at = created_at
+        artifact_id = artifact.id
+        session.commit()
+    return artifact_id
 
 
 def test_import_queues_lyrics_generation(client, monkeypatch, sample_audio_file: Path):
@@ -161,11 +244,13 @@ def test_lyrics_job_persists_transcript_and_update_preserves_timings(
     final_job = wait_for_job(client, job["id"])
     assert final_job["status"] == "completed"
     assert final_job["runtime_device"] == "cpu"
+    assert final_job["lyrics_source"] == "source_preferred"
     assert final_job["duration_seconds"] is not None
 
     created = client.get(f"/api/v1/projects/{project['id']}/lyrics").json()
     assert created["backend"] == "openai-whisper"
     assert created["source_artifact_id"] == _first_source_artifact_id(client, project["id"])
+    assert final_job["source_artifact_id"] == created["source_artifact_id"]
     assert created["requested_device"] == "cpu"
     assert created["device"] == "cpu"
     assert created["model_name"] == "turbo"
@@ -189,6 +274,178 @@ def test_lyrics_job_persists_transcript_and_update_preserves_timings(
     assert updated["segments"][0]["words"][-1]["end_seconds"] == 1.2
     assert updated["source_segments"][0]["text"] == "First line"
     assert updated["has_user_edits"] is True
+
+
+def test_lyrics_generation_uses_usable_source_vocal_stem(
+    client,
+    monkeypatch,
+    sample_audio_file: Path,
+):
+    transcribed_paths: list[Path] = []
+
+    def fake_transcription(source_path: Path, *_args, **_kwargs):
+        transcribed_paths.append(source_path)
+        return LyricsTranscription(
+            backend="openai-whisper",
+            requested_device="cpu",
+            device="cpu",
+            model="turbo",
+            language="en",
+            segments=[
+                {
+                    "start_seconds": 0.0,
+                    "end_seconds": 1.0,
+                    "text": "Vocal stem lyric",
+                }
+            ],
+        )
+
+    monkeypatch.setattr("app.services.lyrics.transcribe_project_lyrics", fake_transcription)
+
+    project_id = _create_project_without_import_jobs(sample_audio_file)
+    source_artifact_id = _first_source_artifact_id(client, project_id)
+    vocal_path = sample_audio_file.parent / "vocals.wav"
+    vocal_path.write_bytes(sample_audio_file.read_bytes())
+    vocal_id = _register_source_vocal_stem(
+        project_id=project_id,
+        source_artifact_id=source_artifact_id,
+        path=vocal_path,
+        created_at=datetime(2026, 1, 2, tzinfo=UTC),
+    )
+
+    job = client.post(f"/api/v1/projects/{project_id}/lyrics", json={"force": True}).json()["job"]
+    final_job = wait_for_job(client, job["id"])
+    assert final_job["status"] == "completed"
+    assert final_job["lyrics_source"] == "vocals"
+    assert final_job["source_artifact_id"] == vocal_id
+
+    created = client.get(f"/api/v1/projects/{project_id}/lyrics").json()
+    assert transcribed_paths == [vocal_path]
+    assert created["source_artifact_id"] == vocal_id
+    assert created["source_kind"] == "vocal_stem"
+    assert created["segments"][0]["text"] == "Vocal stem lyric"
+
+
+def test_lyrics_generation_skips_newer_unusable_source_vocal_stem(
+    client,
+    monkeypatch,
+    sample_audio_file: Path,
+):
+    transcribed_paths: list[Path] = []
+
+    def fake_transcription(source_path: Path, *_args, **_kwargs):
+        transcribed_paths.append(source_path)
+        return LyricsTranscription(
+            backend="openai-whisper",
+            requested_device="cpu",
+            device="cpu",
+            model="turbo",
+            language="en",
+            segments=[
+                {
+                    "start_seconds": 0.0,
+                    "end_seconds": 1.0,
+                    "text": "Older usable vocal lyric",
+                }
+            ],
+        )
+
+    monkeypatch.setattr("app.services.lyrics.transcribe_project_lyrics", fake_transcription)
+
+    project_id = _create_project_without_import_jobs(sample_audio_file)
+    source_artifact_id = _first_source_artifact_id(client, project_id)
+    older_vocal_path = sample_audio_file.parent / "older-usable-vocals.wav"
+    newer_vocal_path = sample_audio_file.parent / "newer-unusable-vocals.wav"
+    older_vocal_path.write_bytes(sample_audio_file.read_bytes())
+    newer_vocal_path.write_bytes(sample_audio_file.read_bytes())
+    older_vocal_id = _register_source_vocal_stem(
+        project_id=project_id,
+        source_artifact_id=source_artifact_id,
+        path=older_vocal_path,
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        stem_model="htdemucs_ft",
+    )
+    newer_vocal_id = _register_source_vocal_stem(
+        project_id=project_id,
+        source_artifact_id=source_artifact_id,
+        path=newer_vocal_path,
+        created_at=datetime(2026, 1, 2, tzinfo=UTC),
+        usable=False,
+        stem_model="htdemucs_6s",
+    )
+
+    job = client.post(f"/api/v1/projects/{project_id}/lyrics", json={"force": True}).json()["job"]
+    final_job = wait_for_job(client, job["id"])
+    assert final_job["status"] == "completed"
+    assert final_job["lyrics_source"] == "vocals"
+    assert final_job["source_artifact_id"] == older_vocal_id
+
+    created = client.get(f"/api/v1/projects/{project_id}/lyrics").json()
+    assert transcribed_paths == [older_vocal_path]
+    assert created["source_artifact_id"] == older_vocal_id
+    assert created["source_artifact_id"] != newer_vocal_id
+    assert created["source_kind"] == "vocal_stem"
+
+
+def test_lyrics_generation_falls_back_to_source_audio_without_usable_source_vocal_stem(
+    client,
+    monkeypatch,
+    sample_audio_file: Path,
+):
+    transcribed_paths: list[Path] = []
+
+    def fake_transcription(source_path: Path, *_args, **_kwargs):
+        transcribed_paths.append(source_path)
+        return LyricsTranscription(
+            backend="openai-whisper",
+            requested_device="cpu",
+            device="cpu",
+            model="turbo",
+            language="en",
+            segments=[
+                {
+                    "start_seconds": 0.0,
+                    "end_seconds": 1.0,
+                    "text": "Source lyric",
+                }
+            ],
+        )
+
+    monkeypatch.setattr("app.services.lyrics.transcribe_project_lyrics", fake_transcription)
+
+    project_id = _create_project_without_import_jobs(sample_audio_file)
+    artifacts = client.get(f"/api/v1/projects/{project_id}/artifacts").json()["artifacts"]
+    source_artifact = next(artifact for artifact in artifacts if artifact["type"] == "source_audio")
+    missing_vocal_path = sample_audio_file.parent / "missing-vocals.wav"
+    wrong_source_vocal_path = sample_audio_file.parent / "wrong-source-vocals.wav"
+    wrong_source_vocal_path.write_bytes(sample_audio_file.read_bytes())
+    _register_source_vocal_stem(
+        project_id=project_id,
+        source_artifact_id=source_artifact["id"],
+        path=missing_vocal_path,
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        stem_model="htdemucs_ft",
+    )
+    wrong_source_vocal_id = _register_source_vocal_stem(
+        project_id=project_id,
+        source_artifact_id="art_wrong_source",
+        path=wrong_source_vocal_path,
+        created_at=datetime(2026, 1, 2, tzinfo=UTC),
+        stem_model="htdemucs_6s",
+    )
+
+    job = client.post(f"/api/v1/projects/{project_id}/lyrics", json={"force": True}).json()["job"]
+    final_job = wait_for_job(client, job["id"])
+    assert final_job["status"] == "completed"
+    assert final_job["lyrics_source"] == "source_preferred"
+    assert final_job["source_artifact_id"] == source_artifact["id"]
+
+    created = client.get(f"/api/v1/projects/{project_id}/lyrics").json()
+    assert transcribed_paths == [Path(source_artifact["path"])]
+    assert created["source_artifact_id"] == source_artifact["id"]
+    assert created["source_artifact_id"] != wrong_source_vocal_id
+    assert created["source_kind"] == "ai"
+    assert created["segments"][0]["text"] == "Source lyric"
 
 
 def test_lyrics_language_override_reaches_service_and_persists_metadata(
@@ -257,10 +514,16 @@ def test_lyrics_no_lyrics_override_clears_transcript_without_transcribing(
     monkeypatch,
     sample_audio_file: Path,
 ):
-    project = client.post(
-        "/api/v1/projects/import",
-        json={"source_path": str(sample_audio_file), "copy_into_project": True},
-    ).json()["project"]
+    project_id = _create_project_without_import_jobs(sample_audio_file)
+    source_artifact_id = _first_source_artifact_id(client, project_id)
+    vocal_path = sample_audio_file.parent / "no-lyrics-vocals.wav"
+    vocal_path.write_bytes(sample_audio_file.read_bytes())
+    vocal_stem_id = _register_source_vocal_stem(
+        project_id=project_id,
+        source_artifact_id=source_artifact_id,
+        path=vocal_path,
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
 
     def fail_transcription(*_args, **_kwargs):
         raise AssertionError("lyrics transcription should not run for no-lyrics override")
@@ -268,13 +531,18 @@ def test_lyrics_no_lyrics_override_clears_transcript_without_transcribing(
     monkeypatch.setattr("app.services.lyrics.transcribe_project_lyrics", fail_transcription)
 
     job = client.post(
-        f"/api/v1/projects/{project['id']}/lyrics",
+        f"/api/v1/projects/{project_id}/lyrics",
         json={"force": True, "language_override": "none"},
     ).json()["job"]
-    assert wait_for_job(client, job["id"])["status"] == "completed"
+    final_job = wait_for_job(client, job["id"])
+    assert final_job["status"] == "completed"
+    assert final_job["lyrics_source"] == "none"
+    assert final_job["source_artifact_id"] == source_artifact_id
 
-    created = client.get(f"/api/v1/projects/{project['id']}/lyrics").json()
+    created = client.get(f"/api/v1/projects/{project_id}/lyrics").json()
     assert created["backend"] == "none"
+    assert created["source_artifact_id"] == source_artifact_id
+    assert created["source_artifact_id"] != vocal_stem_id
     assert created["source_kind"] == "instrumental"
     assert created["language"] is None
     assert created["language_override"] == "none"
@@ -282,7 +550,7 @@ def test_lyrics_no_lyrics_override_clears_transcript_without_transcribing(
     assert created["segments"] == []
     assert created["has_user_edits"] is False
 
-    snapshot = json.loads((project_analysis_dir(project["id"]) / "lyrics.json").read_text())
+    snapshot = json.loads((project_analysis_dir(project_id) / "lyrics.json").read_text())
     assert snapshot["language_override"] == "none"
     assert snapshot["segments"] == []
 

--- a/apps/backend/tests/test_projects.py
+++ b/apps/backend/tests/test_projects.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -12,7 +11,7 @@ from sqlalchemy.exc import IntegrityError
 from app.config import ensure_data_dirs, get_settings
 from app.db import SessionLocal, reconfigure_engine, run_migrations
 from app.errors import AppError
-from app.models import Artifact, Project, SyncDeleteTombstone, SyncEntityRevision
+from app.models import Artifact, Job, Project, SyncDeleteTombstone, SyncEntityRevision
 from app.services.analysis import analyze_project
 from app.services.artifacts import delete_project_artifact, register_artifact
 from app.services.paths import project_root
@@ -35,17 +34,6 @@ def _prepare_database() -> None:
     ensure_data_dirs(settings)
     reconfigure_engine(settings)
     run_migrations(settings)
-
-
-def _wait_for_project_job(client, project_id: str, predicate, *, timeout: float = 5.0) -> dict:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        jobs = client.get("/api/v1/jobs").json()["jobs"]
-        for job in jobs:
-            if job["project_id"] == project_id and predicate(job):
-                return job
-        time.sleep(0.1)
-    raise AssertionError(f"Timed out waiting for matching job in project {project_id}")
 
 
 def _insert_project_rows(
@@ -444,6 +432,39 @@ def test_pruning_stem_artifacts_records_tombstones(tmp_path: Path) -> None:
         }
 
 
+def test_import_project_enqueues_source_processing_after_stems(
+    client,
+    sample_chord_audio_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    enqueued_job_ids: list[str] = []
+    monkeypatch.setattr(client.app.state.job_runner, "enqueue", enqueued_job_ids.append)
+
+    response = client.post(
+        "/api/v1/projects/import",
+        json={
+            "source_path": str(sample_chord_audio_file),
+            "copy_into_project": True,
+            "stem_model": "htdemucs_ft",
+        },
+    )
+
+    assert response.status_code == 200
+    project = response.json()["project"]
+    with SessionLocal() as session:
+        jobs_by_id = {
+            job.id: job
+            for job in session.scalars(select(Job).where(Job.project_id == project["id"]))
+        }
+
+    assert [jobs_by_id[job_id].type for job_id in enqueued_job_ids] == [
+        "analyze",
+        "stems",
+        "chords",
+        "lyrics",
+    ]
+
+
 def test_import_project_enqueues_full_source_processing(
     client,
     sample_chord_audio_file: Path,
@@ -492,41 +513,33 @@ def test_import_project_enqueues_full_source_processing(
 
     jobs = client.get("/api/v1/jobs").json()["jobs"]
     analyze_job = next(job for job in jobs if job["project_id"] == project["id"] and job["type"] == "analyze")
-    chord_job = next(
-        job
-        for job in jobs
-        if job["project_id"] == project["id"] and job["type"] == "chords" and job["chord_source"] == "source"
-    )
+    chord_job = next(job for job in jobs if job["project_id"] == project["id"] and job["type"] == "chords")
     lyrics_job = next(job for job in jobs if job["project_id"] == project["id"] and job["type"] == "lyrics")
     stem_job = next(job for job in jobs if job["project_id"] == project["id"] and job["type"] == "stems")
 
     assert wait_for_job(client, analyze_job["id"], timeout=90.0)["status"] == "completed"
-    completed_chord_job = wait_for_job(client, chord_job["id"], timeout=90.0)
-    assert completed_chord_job["status"] == "completed"
-    assert completed_chord_job["chord_backend"] == "tuneforge-fast"
-    assert completed_chord_job["chord_source"] == "source"
-    assert wait_for_job(client, lyrics_job["id"])["status"] == "completed"
     completed_stem_job = wait_for_job(client, stem_job["id"])
     assert completed_stem_job["status"] == "completed"
     assert completed_stem_job["source_artifact_id"] == source_artifact["id"]
     assert completed_stem_job["stem_model"] == "htdemucs_ft"
     assert completed_stem_job["stem_model_label"] == "2 stems model"
-
-    chord_refresh_job = _wait_for_project_job(
-        client,
-        project["id"],
-        lambda job: job["type"] == "chords" and job["id"] != chord_job["id"],
-    )
-    completed_chord_refresh_job = wait_for_job(client, chord_refresh_job["id"])
-    assert completed_chord_refresh_job["status"] == "completed"
-    assert completed_chord_refresh_job["chord_backend"] == "tuneforge-fast"
-    assert completed_chord_refresh_job["chord_source"] == "source+stem"
+    completed_chord_job = wait_for_job(client, chord_job["id"], timeout=90.0)
+    assert completed_chord_job["status"] == "completed"
+    assert completed_chord_job["chord_backend"] == "tuneforge-fast"
+    assert completed_chord_job["chord_source"] == "source+stem"
+    assert wait_for_job(client, lyrics_job["id"])["status"] == "completed"
 
     analysis = client.get(f"/api/v1/projects/{project['id']}/analysis").json()["analysis"]
     chords = client.get(f"/api/v1/projects/{project['id']}/chords").json()
     lyrics = client.get(f"/api/v1/projects/{project['id']}/lyrics").json()
+    project_jobs = [
+        job
+        for job in client.get("/api/v1/jobs").json()["jobs"]
+        if job["project_id"] == project["id"]
+    ]
 
     assert analysis is not None
+    assert len([job for job in project_jobs if job["type"] == "chords"]) == 1
     assert len(chords["timeline"]) >= 3
     assert lyrics["segments"][0]["text"] == "Test lyric"
 

--- a/apps/backend/tests/test_stem_flow.py
+++ b/apps/backend/tests/test_stem_flow.py
@@ -707,7 +707,7 @@ def test_preview_mix_stem_generation_does_not_store_signal_metadata(
     assert all(STEM_SIGNAL_METADATA_KEY not in artifact["metadata"] for artifact in preview_stems)
 
 
-def test_cached_source_audio_stems_missing_signal_metadata_are_hydrated_and_refresh_chords(
+def test_cached_source_audio_stems_missing_signal_metadata_are_hydrated_without_refreshing_chords(
     client,
     sample_stereo_audio_file: Path,
     monkeypatch,
@@ -758,11 +758,9 @@ def test_cached_source_audio_stems_missing_signal_metadata_are_hydrated_and_refr
     chord_jobs_after_generation = [
         job
         for job in client.get("/api/v1/jobs").json()["jobs"]
-        if job["project_id"] == project["id"] and job["type"] == "chords" and job["id"] != initial_chord_job["id"]
+        if job["project_id"] == project["id"] and job["type"] == "chords"
     ]
-    assert len(chord_jobs_after_generation) == 1
-    assert chord_jobs_after_generation[0]["chord_source"] == "source+stem"
-    assert wait_for_job(client, chord_jobs_after_generation[0]["id"])["status"] == "completed"
+    assert [job["id"] for job in chord_jobs_after_generation] == [initial_chord_job["id"]]
 
     artifacts = client.get(f"/api/v1/projects/{project['id']}/artifacts").json()["artifacts"]
     source_artifact = next(artifact for artifact in artifacts if artifact["type"] == "source_audio")
@@ -803,16 +801,12 @@ def test_cached_source_audio_stems_missing_signal_metadata_are_hydrated_and_refr
     chord_jobs_after_hydration = [
         job
         for job in client.get("/api/v1/jobs").json()["jobs"]
-        if job["project_id"] == project["id"]
-        and job["type"] == "chords"
-        and job["id"] not in {initial_chord_job["id"], chord_jobs_after_generation[0]["id"]}
+        if job["project_id"] == project["id"] and job["type"] == "chords"
     ]
-    assert len(chord_jobs_after_hydration) == 1
-    assert chord_jobs_after_hydration[0]["chord_source"] == "source+stem"
-    assert wait_for_job(client, chord_jobs_after_hydration[0]["id"])["status"] == "completed"
+    assert [job["id"] for job in chord_jobs_after_hydration] == [initial_chord_job["id"]]
 
 
-def test_cached_source_audio_stems_raw_only_signal_metadata_gets_usability_and_refreshes_chords_without_audio_read(
+def test_cached_source_audio_stems_raw_only_signal_metadata_gets_usability_without_audio_read(
     client,
     sample_stereo_audio_file: Path,
     monkeypatch,
@@ -865,11 +859,9 @@ def test_cached_source_audio_stems_raw_only_signal_metadata_gets_usability_and_r
     chord_jobs_after_generation = [
         job
         for job in client.get("/api/v1/jobs").json()["jobs"]
-        if job["project_id"] == project["id"] and job["type"] == "chords" and job["id"] != initial_chord_job["id"]
+        if job["project_id"] == project["id"] and job["type"] == "chords"
     ]
-    assert len(chord_jobs_after_generation) == 1
-    assert wait_for_job(client, chord_jobs_after_generation[0]["id"])["status"] == "completed"
-    chord_job_ids_before_hydration = {initial_chord_job["id"], chord_jobs_after_generation[0]["id"]}
+    assert [job["id"] for job in chord_jobs_after_generation] == [initial_chord_job["id"]]
 
     artifacts = client.get(f"/api/v1/projects/{project['id']}/artifacts").json()["artifacts"]
     source_artifact = next(artifact for artifact in artifacts if artifact["type"] == "source_audio")
@@ -915,13 +907,9 @@ def test_cached_source_audio_stems_raw_only_signal_metadata_gets_usability_and_r
     chord_jobs_after_hydration = [
         job
         for job in client.get("/api/v1/jobs").json()["jobs"]
-        if job["project_id"] == project["id"]
-        and job["type"] == "chords"
-        and job["id"] not in chord_job_ids_before_hydration
+        if job["project_id"] == project["id"] and job["type"] == "chords"
     ]
-    assert len(chord_jobs_after_hydration) == 1
-    assert chord_jobs_after_hydration[0]["chord_source"] == "source+stem"
-    assert wait_for_job(client, chord_jobs_after_hydration[0]["id"])["status"] == "completed"
+    assert [job["id"] for job in chord_jobs_after_hydration] == [initial_chord_job["id"]]
 
 
 def test_cached_source_audio_stems_hydrated_unusable_signal_metadata_does_not_refresh_chords(
@@ -1175,7 +1163,7 @@ def test_two_stem_mode_with_default_uses_two_stem_model(client, sample_stereo_au
     assert {artifact["type"] for artifact in stems} == {"vocal_stem", "instrumental_stem"}
 
 
-def test_source_stem_generation_enqueues_chord_refresh_job(
+def test_source_stem_generation_does_not_enqueue_chord_refresh_job(
     client,
     sample_stereo_audio_file: Path,
     monkeypatch,
@@ -1222,15 +1210,12 @@ def test_source_stem_generation_enqueues_chord_refresh_job(
     assert wait_for_job(client, stem_job["id"])["status"] == "completed"
 
     source_stem_jobs = client.get("/api/v1/jobs").json()["jobs"]
-    chord_refresh_jobs = [
+    chord_jobs_after_source_stems = [
         job
         for job in source_stem_jobs
-        if job["project_id"] == project["id"] and job["type"] == "chords" and job["id"] != initial_chord_job["id"]
+        if job["project_id"] == project["id"] and job["type"] == "chords"
     ]
-    assert len(chord_refresh_jobs) == 1
-    assert chord_refresh_jobs[0]["chord_backend"] == "tuneforge-fast"
-    assert chord_refresh_jobs[0]["chord_source"] == "source+stem"
-    assert wait_for_job(client, chord_refresh_jobs[0]["id"])["status"] == "completed"
+    assert [job["id"] for job in chord_jobs_after_source_stems] == [initial_chord_job["id"]]
 
     preview_job = client.post(
         f"/api/v1/projects/{project['id']}/preview",
@@ -1253,19 +1238,14 @@ def test_source_stem_generation_enqueues_chord_refresh_job(
     assert wait_for_job(client, preview_stem_job["id"])["status"] == "completed"
 
     preview_stem_jobs = client.get("/api/v1/jobs").json()["jobs"]
-    assert (
-        len(
-            [
-                job
-                for job in preview_stem_jobs
-                if job["project_id"] == project["id"] and job["type"] == "chords"
-            ]
-        )
-        == 2
-    )
+    assert [
+        job["id"]
+        for job in preview_stem_jobs
+        if job["project_id"] == project["id"] and job["type"] == "chords"
+    ] == [initial_chord_job["id"]]
 
 
-def test_source_stems_do_not_refresh_edited_chords_without_overwrite(
+def test_source_stems_do_not_refresh_edited_chords_even_with_overwrite_flag(
     client,
     sample_stereo_audio_file: Path,
     monkeypatch,
@@ -1334,7 +1314,7 @@ def test_source_stems_do_not_refresh_edited_chords_without_overwrite(
     chord_jobs_after_rebuild = [
         job for job in jobs_after_rebuild if job["project_id"] == project["id"] and job["type"] == "chords"
     ]
-    assert len(chord_jobs_after_rebuild) == 2
+    assert [job["id"] for job in chord_jobs_after_rebuild] == [initial_chord_job["id"]]
 
 
 def test_stem_artifact_unique_constraint_rejects_duplicates(client, sample_stereo_audio_file: Path):

--- a/apps/desktop/src/App.project-playback-artifacts.test.tsx
+++ b/apps/desktop/src/App.project-playback-artifacts.test.tsx
@@ -637,7 +637,7 @@ describe("Desktop app project playback artifacts", () => {
     );
   });
 
-  it("warns before source stem generation can replace chord edits", async () => {
+  it("does not warn about chord edits for source stem generation", async () => {
     const user = userEvent.setup();
     const timeline = [
       { start_seconds: 0, end_seconds: 16, label: "G", confidence: 0.81, pitch_class: 7, quality: "major" },
@@ -657,19 +657,12 @@ describe("Desktop app project playback artifacts", () => {
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
     await generateStems(user);
 
-    expect(mockConfirm).toHaveBeenCalledWith(
-      expect.stringContaining("Existing chord edits will be replaced"),
-      expect.objectContaining({
-        title: "Generate stems",
-        kind: "warning",
-        okLabel: "Generate",
-      }),
-    );
+    expect(mockConfirm).not.toHaveBeenCalled();
     expect(mockCreateStems).toHaveBeenCalledWith(
       "proj_123",
       expect.objectContaining({
         force: false,
-        overwrite_chord_edits: true,
+        overwrite_chord_edits: false,
         source_artifact_id: "art_source",
       }),
     );

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -1403,19 +1403,12 @@ export function useProjectViewModel() {
       return;
     }
 
-    const affectsSourceChords = selectedPrimaryArtifact?.type === "source_audio";
-    const hasUserChordEdits = affectsSourceChords && chordsQuery.data?.has_user_edits === true;
-    let overwriteChordEdits = false;
-
     if (hasVisibleStems) {
       const stemTargetLabel = selectedPrimaryArtifact
         ? artifactLabel(selectedPrimaryArtifact)
         : "selected audio";
-      const rebuildMessage = hasUserChordEdits
-        ? `Rebuild stems for ${stemTargetLabel}? Existing chord edits will be replaced. Existing stems will be replaced. On desktop, Demucs uses GPU when available; CPU rebuilds may take longer.`
-        : `Rebuild stems for ${stemTargetLabel}? Existing stems will be replaced. On desktop, Demucs uses GPU when available; CPU rebuilds may take longer.`;
       const approved = await confirm(
-        rebuildMessage,
+        `Rebuild stems for ${stemTargetLabel}? Existing stems will be replaced. On desktop, Demucs uses GPU when available; CPU rebuilds may take longer.`,
         {
           title: "Rebuild stems",
           kind: "warning",
@@ -1426,27 +1419,9 @@ export function useProjectViewModel() {
       if (!approved) {
         return;
       }
-      overwriteChordEdits = hasUserChordEdits;
-    } else if (hasUserChordEdits) {
-      const stemTargetLabel = selectedPrimaryArtifact
-        ? artifactLabel(selectedPrimaryArtifact)
-        : "selected audio";
-      const approved = await confirm(
-        `Generate stems for ${stemTargetLabel}? Existing chord edits will be replaced when chords refresh after stem generation. On desktop, Demucs uses GPU when available; CPU generation may take longer.`,
-        {
-          title: "Generate stems",
-          kind: "warning",
-          okLabel: "Generate",
-          cancelLabel: "Cancel",
-        },
-      );
-      if (!approved) {
-        return;
-      }
-      overwriteChordEdits = true;
     }
 
-    stemMutation.mutate(overwriteChordEdits);
+    stemMutation.mutate(false);
   }
 
   function toggleStemControl(

--- a/apps/desktop/src/features/projects/projectViewUtils.test.ts
+++ b/apps/desktop/src/features/projects/projectViewUtils.test.ts
@@ -275,6 +275,52 @@ describe("formatJobStatusSummary", () => {
     expect(formatJobStatusSummary(job)).toBe("completed / CPU / 1.8 s");
   });
 
+  it.each([
+    ["vocals", "vocals"],
+    ["source_preferred", "source preferred"],
+    ["none", "no lyrics"],
+  ])("includes lyrics source label for %s jobs", (lyricsSource, label) => {
+    const job: JobSchema = {
+      completed_at: "2026-04-18T13:17:37.000Z",
+      created_at: "2026-04-18T13:16:00.000Z",
+      duration_seconds: 97,
+      error_message: null,
+      id: `job_lyrics_${lyricsSource}`,
+      lyrics_source: lyricsSource,
+      progress: 100,
+      project_id: "proj_123",
+      runtime_device: "mps",
+      source_artifact_id: "art_source",
+      started_at: "2026-04-18T13:16:00.000Z",
+      status: "completed",
+      type: "lyrics",
+      updated_at: "2026-04-18T13:17:37.000Z",
+    };
+
+    expect(formatJobStatusSummary(job)).toBe(`completed / ${label} / MPS / 1:37`);
+  });
+
+  it("omits unknown lyrics source labels", () => {
+    const job: JobSchema = {
+      completed_at: "2026-04-18T13:16:02.000Z",
+      created_at: "2026-04-18T13:16:00.000Z",
+      duration_seconds: 1.8,
+      error_message: null,
+      id: "job_lyrics_unknown_source",
+      lyrics_source: "unknown",
+      progress: 100,
+      project_id: "proj_123",
+      runtime_device: "cpu",
+      source_artifact_id: "art_source",
+      started_at: "2026-04-18T13:16:00.000Z",
+      status: "completed",
+      type: "lyrics",
+      updated_at: "2026-04-18T13:16:02.000Z",
+    };
+
+    expect(formatJobStatusSummary(job)).toBe("completed / CPU / 1.8 s");
+  });
+
   it("includes chord detection source for chord jobs", () => {
     const job: JobSchema = {
       chord_backend: "tuneforge-fast",

--- a/apps/desktop/src/features/projects/projectViewUtils.ts
+++ b/apps/desktop/src/features/projects/projectViewUtils.ts
@@ -139,6 +139,7 @@ export function formatJobStatusSummary(job: JobSchema) {
     job.type === "analyze" ? formatBeatInput(job.beat_input) : null,
     job.type === "chords" ? formatChordBackend(job.chord_backend) : null,
     job.type === "chords" ? job.chord_source : null,
+    job.type === "lyrics" ? formatLyricsSource(job.lyrics_source) : null,
     job.type === "stems" ? formatStemModel(job.stem_model_label ?? job.stem_model) : null,
     typeof job.runtime_device === "string" ? job.runtime_device.toUpperCase() : null,
     formatJobDuration(job.duration_seconds),
@@ -175,6 +176,19 @@ function formatStemModel(model: string | null | undefined) {
     return "2 stems model";
   }
   return model;
+}
+
+function formatLyricsSource(source: string | null | undefined) {
+  if (source === "vocals") {
+    return "vocals";
+  }
+  if (source === "source_preferred") {
+    return "source preferred";
+  }
+  if (source === "none") {
+    return "no lyrics";
+  }
+  return null;
 }
 
 function formatChordBackend(backend: string | null | undefined) {

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -1177,6 +1177,8 @@ export interface components {
             chord_backend_fallback_from?: string | null;
             /** Chord Source */
             chord_source?: string | null;
+            /** Lyrics Source */
+            lyrics_source?: string | null;
             /** Stem Model */
             stem_model?: string | null;
             /** Stem Model Label */


### PR DESCRIPTION
## Summary
- Run import processing as analysis, stems, chords, then lyrics so chord detection and lyrics can use stem outputs.
- Prefer usable vocal stems for lyrics transcription and expose lyrics source on completed job summaries.
- Stop stem generation from auto-refreshing chords, while keeping explicit chord jobs and compatibility fields.
- Motivation: https://huggingface.co/papers/2506.15514 reports lower Whisper word error rates when using separated vocals.

## Testing
- `cd apps/backend && uv run --python 3.11 pytest tests/test_projects.py tests/test_stem_flow.py tests/test_lyrics_flow.py`
- `cd apps/backend && uv run --python 3.11 pytest tests/test_lyrics_flow.py tests/test_jobs_api.py`
- `cd apps/backend && uv run --python 3.11 ruff check app/models.py app/schemas.py app/services/jobs.py tests/test_lyrics_flow.py tests/test_jobs_api.py`
- `pnpm contracts:generate`
- `pnpm --filter @tuneforge/desktop test`
- `pnpm --filter @tuneforge/desktop test projectViewUtils.test.ts`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `git diff --check`
