### PR TITLE
feat(sync): add validation harness

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -60,6 +60,11 @@ fn write_settings_snapshot_file(path: String, contents: String) -> Result<(), St
     fs::write(&path, contents).map_err(|error| format!("Could not write settings file: {error}"))
 }
 
+#[tauri::command]
+fn write_sync_evidence_file(path: String, contents: String) -> Result<(), String> {
+    fs::write(&path, contents).map_err(|error| format!("Could not write sync evidence file: {error}"))
+}
+
 #[cfg(not(target_os = "android"))]
 fn allocate_port() -> Result<u16, Box<dyn std::error::Error>> {
     let listener = TcpListener::bind(("127.0.0.1", 0))?;
@@ -356,6 +361,7 @@ pub fn run() {
             backend_base_url,
             read_settings_snapshot_file,
             write_settings_snapshot_file,
+            write_sync_evidence_file,
             native_audio::system_input::get_system_default_input_volume,
             native_audio::system_input::set_system_default_input_volume,
             native_audio::audio_get_capabilities,

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -14,6 +14,7 @@ import { encodePairingCode, pairingFingerprint } from "./features/activity/syncP
 import {
   mockCancelJob,
   mockConfirm,
+  mockSave,
   mockGetAnalysis,
   mockGetChords,
   mockGetLyrics,
@@ -277,6 +278,49 @@ function expectProjectDataQueriesNotInvalidated(
   projectId: string,
 ) {
   expectProjectDataQueriesInvalidationState(queryClient, projectId, false);
+}
+
+async function exportEvidenceFromCurrentSyncResult(user: ReturnType<typeof userEvent.setup>) {
+  let exportedBlob: Blob | null = null;
+  const createObjectURL = vi.fn((blob: Blob) => {
+    exportedBlob = blob;
+    return "blob:sync-evidence";
+  });
+  const revokeObjectURL = vi.fn();
+  const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+  const originalSetTimeout = window.setTimeout.bind(window);
+  const setTimeoutSpy = vi
+    .spyOn(window, "setTimeout")
+    .mockImplementation((handler: TimerHandler, timeout?: number) => {
+      if (timeout === 5000 && typeof handler === "function") {
+        handler();
+        return 0;
+      }
+      return originalSetTimeout(handler, timeout);
+    });
+  Object.defineProperty(window.URL, "createObjectURL", {
+    configurable: true,
+    writable: true,
+    value: createObjectURL,
+  });
+  Object.defineProperty(window.URL, "revokeObjectURL", {
+    configurable: true,
+    writable: true,
+    value: revokeObjectURL,
+  });
+
+  try {
+    await user.click(screen.getByRole("button", { name: "Export Evidence" }));
+
+    await waitFor(() => expect(createObjectURL).toHaveBeenCalledOnce());
+    expect(clickSpy).toHaveBeenCalledOnce();
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:sync-evidence");
+    expect(exportedBlob).not.toBeNull();
+    return JSON.parse(await exportedBlob!.text()) as Record<string, unknown>;
+  } finally {
+    clickSpy.mockRestore();
+    setTimeoutSpy.mockRestore();
+  }
 }
 
 describe("Desktop app activity", () => {
@@ -2143,6 +2187,511 @@ describe("Desktop app activity", () => {
     expect(transferRows).toHaveLength(1);
     expect(within(transferRows[0]).getByText("art_retry_source")).toBeInTheDocument();
     expect(within(transferRows[0]).getByText("500 ms / 2.0 MB/s")).toBeInTheDocument();
+  });
+
+  it("disables evidence export when no sync result is available", async () => {
+    const user = userEvent.setup();
+    await openSyncTab(user);
+
+    expect(screen.getByRole("button", { name: "Copy Evidence" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Export Evidence" })).toBeDisabled();
+  });
+
+  it("exports privacy-safe evidence from listener last_sync", async () => {
+    const user = userEvent.setup();
+    setSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: listenerEndpointHints,
+      display_name: "Studio Desktop",
+      last_status: "Listener imported project proj_export_alpha from device_peer_1.",
+      active_phase: "artifact_transfer",
+      active_message:
+        'Receiving artifact art_export_alpha from "C:\\Users\\test\\Music\\Secret Demo.wav" via tuneforge-sync+tcp://192.168.1.42:48625',
+      active_progress_at: "2026-04-18T13:16:00.300Z",
+      active_elapsed_ms: 900,
+      last_sync: {
+        run_id: "sync_run_export_listener",
+        session_id: "sync_session_export_listener",
+        peer_device_id: "device_peer_1",
+        remote_device_id: "device_peer_1",
+        selected_transport: tcpTransportId,
+        fallback_reason: "Iroh endpoint tuneforge-sync+iroh://device_peer_1 was unavailable; used TCP.",
+        fallback_code: "stale_iroh_hint",
+        attempted_transports: [irohTransportId, tcpTransportId],
+        status: "completed",
+        message:
+          'Imported "/Users/test/Music/Secret Demo.wav" for proj_export_alpha after retry using art_export_alpha.',
+        error: "Previous artifact art_export_beta failed from file:///Users/test/Music/Mix.wav",
+        started_at: "2026-04-18T13:16:00.000Z",
+        completed_at: "2026-04-18T13:16:01.250Z",
+        duration_ms: 1250,
+        time_to_first_artifact_ms: 650,
+        total_received_bytes: 1_000_000,
+        total_served_bytes: 9_000_000,
+        throughput_bytes_per_second: 3_200_000,
+        scratch_peak_bytes: 128_000_000,
+        transfer_counts: {
+          staging_peak_bytes: 16_000_000,
+          max_active_streams: 8,
+          credit_grants: 64,
+          credit_revokes: 2,
+          staging_post_ms_total: 300,
+        },
+        imported_project_count: 1,
+        applied_project_count: 1,
+        skipped_project_count: 0,
+        failed_project_count: 0,
+        project_results: [
+          {
+            project_id: "proj_export_alpha",
+            status: "failed",
+            message: "Old failure for proj_export_alpha.",
+            is_final: true,
+            completed_at: "2026-04-18T13:15:30.000Z",
+            failed_count: 1,
+          },
+          {
+            project_id: "proj_export_alpha",
+            status: "applied",
+            message: "Retry imported proj_export_alpha from '/Users/test/Music/Secret Demo.wav'.",
+            is_final: true,
+            started_at: "2026-04-18T13:16:00.500Z",
+            completed_at: "2026-04-18T13:16:01.100Z",
+            applied_count: 2,
+            reused_artifact_count: 1,
+          },
+        ],
+        manifest_errors: [],
+        phase_timings: [
+          {
+            phase: "artifact_transfer",
+            project_id: "proj_export_alpha",
+            artifact_id: "art_export_alpha",
+            started_at: "2026-04-18T13:16:00.200Z",
+            completed_at: "2026-04-18T13:16:00.650Z",
+            duration_ms: 450,
+            throughput_bytes_per_second: 2_000_000,
+          },
+        ],
+        received_artifacts: [
+          {
+            artifact_id: "art_export_alpha",
+            content_sha256: "sha256-export-alpha",
+            size_bytes: 1_000_000,
+            status: "received",
+            message: "Fetched art_export_alpha from file:///Users/test/Music/Secret%20Demo.wav",
+            started_at: "2026-04-18T13:16:00.200Z",
+            completed_at: "2026-04-18T13:16:00.650Z",
+            duration_ms: 450,
+            throughput_bytes_per_second: 2_000_000,
+          },
+          {
+            artifact_id: "art_export_beta",
+            content_sha256: "sha256-export-beta",
+            size_bytes: 500_000,
+            status: "already_staged",
+            message: "Reused art_export_beta from Mix.wav",
+            completed_at: "2026-04-18T13:16:00.150Z",
+          },
+        ],
+      },
+    });
+
+    await openSyncTab(user);
+
+    expect(screen.getByRole("button", { name: "Export Evidence" })).toBeEnabled();
+    const exportedJson = await exportEvidenceFromCurrentSyncResult(user);
+
+    expect(await screen.findByText(/Sync evidence exported/)).toBeInTheDocument();
+    expect(Object.keys(exportedJson)).toEqual([
+      "capturedAt",
+      "scenario",
+      "source",
+      "run",
+      "transport",
+      "metrics",
+      "projects",
+      "artifacts",
+      "lifecycle",
+      "storage",
+      "validation",
+    ]);
+    expect(exportedJson.scenario).toBe("listener-last-sync");
+    expect(exportedJson.source).toMatchObject({
+      kind: "listener.last_sync",
+      listenerActive: true,
+      listenerStatus: "listening",
+    });
+    expect(exportedJson.run).toMatchObject({
+      label: "run_1",
+      peer: "peer_1",
+      remotePeer: "peer_1",
+      hasRunId: true,
+      hasSessionId: true,
+      status: "completed",
+    });
+    expect(exportedJson.transport).toMatchObject({
+      selected: tcpTransportId,
+      attempted: [irohTransportId, tcpTransportId],
+      fallback: {
+        code: "stale_iroh_hint",
+        reason: expect.stringContaining("[redacted_endpoint]"),
+      },
+    });
+    expect(exportedJson.metrics).toMatchObject({
+      timeToFirstArtifactMs: 650,
+      throughputBytesPerSecond: 3_200_000,
+      retryIndicators: {
+        duplicateProjectEvents: true,
+        messageMentionsRetry: true,
+      },
+      reuseIndicators: {
+        reusedArtifacts: true,
+        reusedProjectArtifacts: true,
+        messageMentionsReuse: false,
+      },
+    });
+    const exportedMetrics = exportedJson.metrics as {
+      backend_staging_throughput_bytes_per_second?: number;
+    };
+    expect(exportedMetrics.backend_staging_throughput_bytes_per_second).toBeCloseTo(
+      1_000_000 / 0.3,
+    );
+    expect(exportedJson.projects).toEqual([
+      expect.objectContaining({
+        label: "project_1",
+        status: "applied",
+        counts: expect.objectContaining({
+          applied: 2,
+          reusedArtifacts: 1,
+        }),
+        appearance: expect.objectContaining({
+          eventCount: 5,
+          cadenceMs: 7775,
+        }),
+      }),
+    ]);
+    expect(exportedJson.artifacts).toEqual([
+      expect.objectContaining({
+        label: "artifact_1",
+        status: "received",
+        throughputBytesPerSecond: 2_000_000,
+        reused: false,
+      }),
+      expect.objectContaining({
+        label: "artifact_2",
+        status: "already_staged",
+        reused: true,
+      }),
+    ]);
+    expect(exportedJson.lifecycle).toMatchObject({
+      listener: {
+        active: true,
+        status: "listening",
+        activePhase: "artifact_transfer",
+        hasLastError: false,
+      },
+      phaseTimings: [
+        expect.objectContaining({
+          label: "phase_1",
+          project: "project_1",
+          artifact: "artifact_1",
+        }),
+      ],
+    });
+    expect(exportedJson.storage).toMatchObject({
+      scratch_peak_bytes: 128_000_000,
+      staging_peak_bytes: 16_000_000,
+      scratchPeakBytes: 128_000_000,
+      stagingPeakBytes: 16_000_000,
+    });
+    expect(exportedJson.validation).toMatchObject({
+      schema: "tuneforge-sync-evidence-v1",
+      privacySafe: true,
+      redactionCounts: {
+        peers: 1,
+        projects: 1,
+        artifacts: 2,
+      },
+    });
+
+    const serialized = JSON.stringify(exportedJson);
+    expect(serialized).toContain("peer_1");
+    expect(serialized).toContain("project_1");
+    expect(serialized).toContain("artifact_1");
+    expect(serialized).not.toContain("device_peer_1");
+    expect(serialized).not.toContain("proj_export_alpha");
+    expect(serialized).not.toContain("art_export_alpha");
+    expect(serialized).not.toContain("sha256-export-alpha");
+    expect(serialized).not.toContain("Studio Desktop");
+    expect(serialized).not.toContain("endpoint_hints");
+    expect(serialized).not.toContain("Mix.wav");
+    expect(serialized).not.toContain("Secret Demo.wav");
+    expect(serialized).not.toContain("C:\\Users");
+    expect(serialized).not.toContain("C:\\\\Users");
+    expect(serialized).not.toContain("file://");
+    expect(serialized).not.toContain("/Users/test/Music");
+    expect(serialized).not.toContain("/tmp/demo.wav");
+    expect(serialized).not.toContain("tuneforge-sync+tcp://192.168.1.42:48625");
+  });
+
+  it("does not export UI fallback listener status with trusted peer display names", async () => {
+    const user = userEvent.setup();
+    setSyncTrustedPeers([
+      {
+        device_id: "device_peer_1",
+        sync_group_id: "sync_group_local",
+        display_name: "Laptop Rig",
+        public_key: "pub_peer_1",
+        endpoint_hints: syncEndpointHints,
+        trusted_at: "2026-04-18T13:16:00.000Z",
+      },
+    ]);
+    setSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: listenerEndpointHints,
+      last_sync: syncRunStatus({
+        run_id: "sync_run_display_name_fallback",
+        session_id: "sync_session_display_name_fallback",
+        peer_device_id: "device_peer_1",
+        remote_device_id: "device_peer_1",
+        status: "completed",
+        message: null,
+        project_results: [
+          {
+            project_id: "proj_display_name_fallback",
+            status: "imported",
+            message: "Imported proj_display_name_fallback.",
+            imported_count: 1,
+          },
+        ],
+      }),
+    });
+
+    await openSyncTab(user);
+
+    expect(await screen.findByText("Completed for Laptop Rig.")).toBeInTheDocument();
+    const exportedJson = await exportEvidenceFromCurrentSyncResult(user);
+    const serialized = JSON.stringify(exportedJson);
+    expect(exportedJson.lifecycle).toMatchObject({
+      listener: {
+        lastStatus: null,
+      },
+    });
+    expect(serialized).not.toContain("Completed for Laptop Rig.");
+    expect(serialized).not.toContain("Laptop Rig");
+    expect(serialized).not.toContain("proj_display_name_fallback");
+  });
+
+  it("copies privacy-safe evidence JSON from listener last_sync", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    setSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: listenerEndpointHints,
+      last_status: "Listener imported proj_copy_alpha from device_peer_1.",
+      last_sync: syncRunStatus({
+        run_id: "sync_run_copy_listener",
+        session_id: "sync_session_copy_listener",
+        peer_device_id: "device_peer_1",
+        remote_device_id: "device_peer_1",
+        selected_transport: tcpTransportId,
+        attempted_transports: [tcpTransportId],
+        status: "completed",
+        message: 'Imported "/Users/test/Music/Secret Demo.wav" for proj_copy_alpha with art_copy_alpha.',
+        project_results: [
+          {
+            project_id: "proj_copy_alpha",
+            status: "imported",
+            message: "Imported proj_copy_alpha from file:///Users/test/Music/Secret%20Demo.wav.",
+            imported_count: 1,
+          },
+        ],
+        received_artifacts: [
+          {
+            artifact_id: "art_copy_alpha",
+            content_sha256: "sha256-copy-alpha",
+            size_bytes: 1_000_000,
+            status: "received",
+            message: "Fetched art_copy_alpha from Secret Demo.wav",
+          },
+        ],
+      }),
+    });
+
+    await openSyncTab(user);
+    await user.click(screen.getByRole("button", { name: "Copy Evidence" }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledOnce());
+    const copiedJson = JSON.parse(writeText.mock.calls[0]?.[0] as string) as Record<string, unknown>;
+    expect(await screen.findByText("Sync evidence copied.")).toBeInTheDocument();
+    expect(copiedJson.validation).toMatchObject({
+      schema: "tuneforge-sync-evidence-v1",
+      privacySafe: true,
+    });
+    const serialized = JSON.stringify(copiedJson);
+    expect(serialized).toContain("project_1");
+    expect(serialized).toContain("artifact_1");
+    expect(serialized).not.toContain("device_peer_1");
+    expect(serialized).not.toContain("proj_copy_alpha");
+    expect(serialized).not.toContain("art_copy_alpha");
+    expect(serialized).not.toContain("sha256-copy-alpha");
+    expect(serialized).not.toContain("Secret Demo.wav");
+    expect(serialized).not.toContain("/Users/test/Music");
+    expect(serialized).not.toContain("file://");
+  });
+
+  it("exports evidence through the Tauri save command when available", async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: {},
+    });
+    mockSave.mockResolvedValue("/tmp/tuneforge-sync-evidence.json");
+    setSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: listenerEndpointHints,
+      last_sync: syncRunStatus({
+        run_id: "sync_run_tauri_export",
+        session_id: "sync_session_tauri_export",
+        message: "Imported proj_tauri_export from device_peer_1.",
+        project_results: [
+          {
+            project_id: "proj_tauri_export",
+            status: "imported",
+            message: "Imported proj_tauri_export.",
+            imported_count: 1,
+          },
+        ],
+      }),
+    });
+
+    await openSyncTab(user);
+    await user.click(screen.getByRole("button", { name: "Export Evidence" }));
+
+    await waitFor(() =>
+      expect(mockSave).toHaveBeenCalledWith({
+        defaultPath: expect.stringMatching(/^tuneforge-sync-evidence-.+\.json$/),
+        filters: [{ name: "JSON", extensions: ["json"] }],
+      }),
+    );
+    const mockInvoke = getMockInvoke();
+    await waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith("write_sync_evidence_file", {
+        contents: expect.any(String),
+        path: "/tmp/tuneforge-sync-evidence.json",
+      }),
+    );
+    const writeCall = mockInvoke.mock.calls.find(([command]) => command === "write_sync_evidence_file");
+    expect(writeCall).toBeDefined();
+    const exportedJson = JSON.parse((writeCall?.[1] as { contents: string }).contents) as Record<string, unknown>;
+    expect(await screen.findByText(/Sync evidence exported/)).toBeInTheDocument();
+    expect(exportedJson.scenario).toBe("listener-last-sync");
+    expect(exportedJson.run).toMatchObject({
+      label: "run_1",
+      hasRunId: true,
+      hasSessionId: true,
+      status: "completed",
+    });
+    expect(JSON.stringify(exportedJson)).not.toContain("proj_tauri_export");
+    expect(JSON.stringify(exportedJson)).not.toContain("device_peer_1");
+  });
+
+  it("exports the latest sync now result when listener last_sync is hidden", async () => {
+    const user = userEvent.setup();
+    setSyncTrustedPeers([
+      {
+        device_id: "device_peer_1",
+        sync_group_id: "sync_group_local",
+        display_name: "Laptop Rig",
+        public_key: "pub_peer_1",
+        endpoint_hints: syncEndpointHints,
+        trusted_at: "2026-04-18T13:16:00.000Z",
+      },
+    ]);
+    setSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: syncEndpointHints,
+      last_sync: {
+        peer_device_id: "device_peer_1",
+        remote_device_id: "device_peer_1",
+        status: "completed",
+        message: "Listener sync completed first.",
+        project_results: [
+          {
+            project_id: "proj_listener_old",
+            status: "imported",
+            message: "Old listener result.",
+          },
+        ],
+        manifest_errors: [],
+        received_artifacts: [],
+      },
+    });
+    mockSyncTrustedPeerNow.mockResolvedValueOnce(syncRunStatus({
+      run_id: "sync_run_now_export",
+      session_id: "sync_session_now_export",
+      selected_transport: irohTransportId,
+      attempted_transports: [irohTransportId],
+      status: "completed",
+      message: "Sync now imported proj_now_result.",
+      project_results: [
+        {
+          project_id: "proj_now_result",
+          status: "imported",
+          message: "Imported proj_now_result.",
+          imported_count: 1,
+        },
+      ],
+      received_artifacts: [],
+      imported_project_count: 1,
+    }));
+
+    await openSyncTab(user);
+
+    const peers = await screen.findByRole("list", { name: "Trusted sync peers" });
+    const peerRow = within(peers).getByText("Laptop Rig").closest("li");
+    expect(peerRow).not.toBeNull();
+    await user.click(within(peerRow as HTMLElement).getByRole("button", { name: "Sync Now" }));
+
+    expect(await screen.findAllByText("Sync now imported proj_now_result.")).not.toHaveLength(0);
+    const exportedJson = await exportEvidenceFromCurrentSyncResult(user);
+
+    expect(exportedJson.scenario).toBe("sync-now-result");
+    expect(exportedJson.source).toMatchObject({
+      kind: "sync_now",
+      listenerActive: true,
+      listenerStatus: "listening",
+    });
+    expect(exportedJson.run).toMatchObject({
+      status: "completed",
+      hasRunId: true,
+      hasSessionId: true,
+    });
+    expect(exportedJson.transport).toMatchObject({
+      selected: irohTransportId,
+      attempted: [irohTransportId],
+    });
+    expect(exportedJson.projects).toEqual([
+      expect.objectContaining({
+        label: "project_1",
+        status: "imported",
+        counts: expect.objectContaining({
+          imported: 1,
+        }),
+      }),
+    ]);
+    expect(JSON.stringify(exportedJson)).not.toContain("proj_listener_old");
+    expect(JSON.stringify(exportedJson)).not.toContain("proj_now_result");
   });
 
   it("shows newer listener sync results after a prior sync now result", async () => {

--- a/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
+++ b/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { invoke, isTauri } from "@tauri-apps/api/core";
+import { save } from "@tauri-apps/plugin-dialog";
 import { QRCodeSVG } from "qrcode.react";
 import {
   api,
@@ -37,6 +39,22 @@ const PROJECT_MUTATION_QUERY_KEYS = [
   ["jobs"],
 ] as const;
 const SYNC_PROJECT_MUTATION_STATUSES = new Set(["applied", "conflicted", "deleted", "imported"]);
+const SYNC_EVIDENCE_FILE_EXTENSIONS = "wav|mp3|flac|m4a|aac|ogg|aiff|aif|json|sqlite|db|txt|csv|log|zip|png|jpe?g";
+const SYNC_EVIDENCE_QUOTED_PATH_PATTERN = new RegExp(
+  `(^|[\\s(])(["'])((?:file:\\/\\/(?:localhost)?(?:[A-Za-z]:[\\\\/]|\\/)?|[A-Za-z]:[\\\\/]|\\/)[^"'\\r\\n]*)\\2`,
+  "gi",
+);
+const SYNC_EVIDENCE_PATH_WITH_EXTENSION_PATTERN = new RegExp(
+  `(^|[\\s(])((?:file:\\/\\/(?:localhost)?(?:[A-Za-z]:[\\\\/]|\\/)?|[A-Za-z]:[\\\\/]|\\/)[^"'\\r\\n,;)]*?\\.(?:${SYNC_EVIDENCE_FILE_EXTENSIONS})\\b)`,
+  "gi",
+);
+const SYNC_EVIDENCE_FILE_URI_PATTERN = /\bfile:\/\/[^\s"'<>),;]+/gi;
+const SYNC_EVIDENCE_WINDOWS_PATH_PATTERN = /\b[A-Za-z]:[\\/][^\s"'<>),;]+(?:[\\/][^\s"'<>),;]+)*/g;
+const SYNC_EVIDENCE_POSIX_PATH_PATTERN = /(^|[\s(])\/[^\s"'<>),;]+(?:\/[^\s"'<>),;]+)*/g;
+const SYNC_EVIDENCE_FILENAME_PATTERN = new RegExp(
+  `\\b[^/\\\\\\s]+\\.(?:${SYNC_EVIDENCE_FILE_EXTENSIONS})\\b`,
+  "gi",
+);
 
 type PairingOutputKind = "offer" | "response";
 type PairingOutput = {
@@ -122,6 +140,36 @@ async function copyToClipboard(value: string, source?: HTMLTextAreaElement | nul
     return document.execCommand("copy");
   }
   return false;
+}
+
+function syncEvidenceFileName(capturedAt: string) {
+  return `tuneforge-sync-evidence-${capturedAt.replace(/[:.]/g, "-")}.json`;
+}
+
+function downloadSyncEvidenceJson(fileName: string, json: string) {
+  const blob = new Blob([json], { type: "application/json" });
+  const downloadUrl = window.URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = downloadUrl;
+  link.download = fileName;
+  document.body.append(link);
+  link.click();
+  window.setTimeout(() => {
+    link.remove();
+    window.URL.revokeObjectURL(downloadUrl);
+  }, 5000);
+}
+
+async function saveSyncEvidenceJson(fileName: string, json: string) {
+  const path = await save({
+    defaultPath: fileName,
+    filters: [{ name: "JSON", extensions: ["json"] }],
+  });
+  if (!path) {
+    return false;
+  }
+  await invoke("write_sync_evidence_file", { contents: json, path });
+  return true;
 }
 
 function peerLabel(peer: SyncTrustedPeerSchema) {
@@ -825,6 +873,468 @@ function syncTransferMetricText(artifact: SyncTransportTransferResult) {
   return parts.length ? parts.join(" / ") : null;
 }
 
+type SyncEvidenceRedactionContext = {
+  peerLabels: Map<string, string>;
+  projectLabels: Map<string, string>;
+  artifactLabels: Map<string, string>;
+  tokenReplacements: Array<[string, string]>;
+};
+
+function createEvidenceLabelMap(values: Array<string | null | undefined>, prefix: string) {
+  const labels = new Map<string, string>();
+  values
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .sort((left, right) => left.localeCompare(right))
+    .forEach((value) => {
+      if (!labels.has(value)) {
+        labels.set(value, `${prefix}_${labels.size + 1}`);
+      }
+    });
+  return labels;
+}
+
+function createSyncEvidenceRedactionContext(status: SyncTransportRunStatus): SyncEvidenceRedactionContext {
+  const peerLabels = createEvidenceLabelMap([
+    status.peer_device_id,
+    status.remote_device_id,
+  ], "peer");
+  const projectLabels = createEvidenceLabelMap([
+    ...status.project_results.map((result) => result.project_id),
+    ...status.manifest_errors.map((error) => error.project_id),
+    ...(status.phase_timings ?? []).map((timing) => timing.project_id),
+  ], "project");
+  const artifactLabels = createEvidenceLabelMap([
+    ...status.received_artifacts.map((artifact) => artifact.artifact_id),
+    ...(status.phase_timings ?? []).map((timing) => timing.artifact_id),
+  ], "artifact");
+  const tokenReplacements = [
+    ...Array.from(peerLabels.entries()),
+    ...Array.from(projectLabels.entries()),
+    ...Array.from(artifactLabels.entries()),
+  ].sort(([left], [right]) => right.length - left.length);
+  return {
+    peerLabels,
+    projectLabels,
+    artifactLabels,
+    tokenReplacements,
+  };
+}
+
+function redactSyncEvidenceText(
+  value: string | null | undefined,
+  context: SyncEvidenceRedactionContext,
+) {
+  const normalized = value?.trim();
+  if (!normalized) {
+    return null;
+  }
+  let redacted = normalized;
+  context.tokenReplacements.forEach(([rawValue, label]) => {
+    redacted = redacted.split(rawValue).join(label);
+  });
+  redacted = redacted.replace(/\btuneforge-sync\+[a-z0-9_-]+:\/\/[^\s,;]+/gi, "[redacted_endpoint]");
+  redacted = redacted.replace(
+    SYNC_EVIDENCE_QUOTED_PATH_PATTERN,
+    (_match, prefix: string, quote: string) => `${prefix}${quote}[redacted_path]${quote}`,
+  );
+  redacted = redacted.replace(
+    SYNC_EVIDENCE_PATH_WITH_EXTENSION_PATTERN,
+    (_match, prefix: string) => `${prefix}[redacted_path]`,
+  );
+  redacted = redacted.replace(SYNC_EVIDENCE_FILE_URI_PATTERN, "[redacted_path]");
+  redacted = redacted.replace(SYNC_EVIDENCE_WINDOWS_PATH_PATTERN, "[redacted_path]");
+  redacted = redacted.replace(
+    SYNC_EVIDENCE_POSIX_PATH_PATTERN,
+    (_match, prefix: string) => `${prefix}[redacted_path]`,
+  );
+  redacted = redacted.replace(SYNC_EVIDENCE_FILENAME_PATTERN, "[redacted_filename]");
+  return redacted;
+}
+
+function syncEvidenceProjectCadence(status: SyncTransportRunStatus) {
+  const appearances = new Map<string, string[]>();
+  status.project_results.forEach((result) => {
+    const timestamps = [result.started_at, result.completed_at].filter(
+      (value): value is string => typeof value === "string" && value.trim().length > 0,
+    );
+    if (!timestamps.length) {
+      return;
+    }
+    const existing = appearances.get(result.project_id) ?? [];
+    appearances.set(result.project_id, existing.concat(timestamps));
+  });
+  status.phase_timings?.forEach((timing) => {
+    if (!timing.project_id) {
+      return;
+    }
+    const timestamps = [timing.started_at, timing.completed_at].filter(
+      (value): value is string => typeof value === "string" && value.trim().length > 0,
+    );
+    if (!timestamps.length) {
+      return;
+    }
+    const existing = appearances.get(timing.project_id) ?? [];
+    appearances.set(timing.project_id, existing.concat(timestamps));
+  });
+  return appearances;
+}
+
+function sumSyncPhaseDurations(status: SyncTransportRunStatus, matcher: RegExp) {
+  const total = status.phase_timings?.reduce((durationMs, timing) => {
+    if (!timing.phase || typeof timing.duration_ms !== "number" || !matcher.test(timing.phase)) {
+      return durationMs;
+    }
+    return durationMs + timing.duration_ms;
+  }, 0) ?? 0;
+  return total > 0 ? total : null;
+}
+
+function syncRunTotalEvidenceBytes(status: SyncTransportRunStatus) {
+  const directReceived = typeof status.total_received_bytes === "number" &&
+    Number.isFinite(status.total_received_bytes)
+    ? status.total_received_bytes
+    : null;
+  if (directReceived !== null) {
+    return directReceived;
+  }
+  const artifactBytes = status.received_artifacts.reduce((total, artifact) => (
+    typeof artifact.size_bytes === "number" && Number.isFinite(artifact.size_bytes)
+      ? total + artifact.size_bytes
+      : total
+  ), 0);
+  return artifactBytes > 0 ? artifactBytes : null;
+}
+
+function throughputFromEvidenceBytes(bytes: number | null, durationMs: number | null) {
+  if (bytes === null || durationMs === null || durationMs <= 0) {
+    return null;
+  }
+  return bytes / (durationMs / 1000);
+}
+
+function syncRunProjectApplyDurationMs(status: SyncTransportRunStatus) {
+  const directApply = sumSyncPhaseDurations(status, /reconciliation|apply/i);
+  if (directApply !== null) {
+    return directApply;
+  }
+  const projectDuration = status.project_results.reduce((durationMs, result) => {
+    if (!["applied", "deleted", "imported"].includes(result.status)) {
+      return durationMs;
+    }
+    if (typeof result.duration_ms === "number" && Number.isFinite(result.duration_ms)) {
+      return durationMs + result.duration_ms;
+    }
+    if (result.started_at && result.completed_at) {
+      const startedAt = new Date(normalizeApiDateTime(result.started_at)).getTime();
+      const completedAt = new Date(normalizeApiDateTime(result.completed_at)).getTime();
+      if (Number.isFinite(startedAt) && Number.isFinite(completedAt) && completedAt >= startedAt) {
+        return durationMs + (completedAt - startedAt);
+      }
+    }
+    return durationMs;
+  }, 0);
+  return projectDuration > 0 ? projectDuration : null;
+}
+
+function syncRunTransferCountsEvidence(
+  status: SyncTransportRunStatus,
+  artifactStatusCounts: Record<string, number>,
+) {
+  return {
+    requested: syncRunMetricValue(status, "requested") ?? status.received_artifacts.length,
+    received: syncRunMetricValue(status, "received") ?? artifactStatusCounts.received ?? 0,
+    skipped: syncRunMetricValue(status, "skipped") ?? syncRunMetricValue(status, "already_local") ?? 0,
+    already_staged: syncRunMetricValue(status, "already_staged") ?? artifactStatusCounts.already_staged ?? 0,
+    failed: syncRunMetricValue(status, "failed") ?? artifactStatusCounts.failed ?? 0,
+    retried: syncRunMetricValue(status, "retried") ?? syncRunMetricValue(status, "retries") ?? 0,
+  };
+}
+
+function syncProjectAvailabilityGapMs(projectAppearances: Map<string, string[]>) {
+  const firstSeen = Array.from(projectAppearances.values())
+    .map((timestamps) => timestamps
+      .map((timestamp) => new Date(normalizeApiDateTime(timestamp)).getTime())
+      .filter((value) => Number.isFinite(value))
+      .sort((left, right) => left - right)[0] ?? null)
+    .filter((value): value is number => value !== null)
+    .sort((left, right) => left - right);
+  if (firstSeen.length <= 1) {
+    return firstSeen.length === 1 ? 0 : null;
+  }
+  return Math.round(
+    firstSeen.slice(1).reduce((total, timestamp, index) => total + (timestamp - firstSeen[index]!), 0) /
+      (firstSeen.length - 1),
+  );
+}
+
+function buildSyncEvidenceExport(
+  status: SyncTransportRunStatus,
+  options: {
+    capturedAt: string;
+    listenerActive: boolean;
+    listenerStatus: string;
+    listenerUpdatedAt: string | null | undefined;
+    listenerActivePhase: string | null | undefined;
+    listenerActiveMessage: string | null | undefined;
+    listenerActiveProgressAt: string | null | undefined;
+    listenerActiveElapsedMs: number | null | undefined;
+    listenerLastStatus: string | null | undefined;
+    listenerLastError: string | null | undefined;
+    showListenerSyncResult: boolean;
+  },
+) {
+  const redactionContext = createSyncEvidenceRedactionContext(status);
+  const projectAppearances = syncEvidenceProjectCadence(status);
+  const mergedProjectResults = mergeSyncProjectResults(status.project_results, status.manifest_errors);
+  const artifactStatusCounts = status.received_artifacts.reduce<Record<string, number>>((counts, artifact) => {
+    counts[artifact.status] = (counts[artifact.status] ?? 0) + 1;
+    return counts;
+  }, {});
+  const projectRetryCount = status.project_results.reduce<Record<string, number>>((counts, result) => {
+    counts[result.project_id] = (counts[result.project_id] ?? 0) + 1;
+    return counts;
+  }, {});
+  const projectResultCountByStatus = mergedProjectResults.reduce<Record<string, number>>((counts, result) => {
+    counts[result.status] = (counts[result.status] ?? 0) + 1;
+    return counts;
+  }, {});
+  const retryIndicators = {
+    duplicateProjectEvents: Object.values(projectRetryCount).some((count) => count > 1),
+    messageMentionsRetry: Boolean(
+      redactSyncEvidenceText(status.message, redactionContext)?.match(/\bretry|retried\b/i),
+    ),
+  };
+  const reuseIndicators = {
+    reusedArtifacts: status.received_artifacts.some((artifact) => artifact.status === "already_staged"),
+    reusedProjectArtifacts: mergedProjectResults.some((result) => (result.reused_artifact_count ?? 0) > 0),
+    messageMentionsReuse: Boolean(
+      redactSyncEvidenceText(status.message, redactionContext)?.match(/\breused?|reuse\b/i),
+    ),
+  };
+  const totalEvidenceBytes = syncRunTotalEvidenceBytes(status);
+  const stagingDurationMs = sumSyncPhaseDurations(status, /staging|stage/i) ??
+    syncRunMetricValue(status, "staging_post_ms_total");
+  const applyDurationMs = syncRunProjectApplyDurationMs(status);
+  const durationMs = status.duration_ms ?? (
+    typeof status.duration_seconds === "number" ? Math.round(status.duration_seconds * 1000) : null
+  );
+  const importedProjectCount = status.imported_project_count ??
+    status.project_results.filter((result) => ["applied", "deleted", "imported"].includes(result.status)).length;
+  const projectImportsPerMinute = durationMs && durationMs > 0
+    ? importedProjectCount / (durationMs / 60000)
+    : null;
+  const evidenceTransferCounts = syncRunTransferCountsEvidence(status, artifactStatusCounts);
+
+  return {
+    capturedAt: options.capturedAt,
+    scenario: options.showListenerSyncResult ? "listener-last-sync" : "sync-now-result",
+    source: {
+      kind: options.showListenerSyncResult ? "listener.last_sync" : "sync_now",
+      listenerActive: options.listenerActive,
+      listenerStatus: options.listenerStatus,
+      listenerUpdatedAt: options.listenerUpdatedAt ?? null,
+    },
+    run: {
+      label: "run_1",
+      status: status.status,
+      message: redactSyncEvidenceText(status.message, redactionContext),
+      error: redactSyncEvidenceText(status.error, redactionContext),
+      startedAt: status.started_at ?? null,
+      completedAt: status.completed_at ?? null,
+      durationMs: status.duration_ms ?? null,
+      durationSeconds: status.duration_seconds ?? syncRunDurationSeconds(status),
+      direction: status.direction ?? null,
+      peer: status.peer_device_id ? redactionContext.peerLabels.get(status.peer_device_id) ?? "peer_1" : null,
+      remotePeer: status.remote_device_id
+        ? redactionContext.peerLabels.get(status.remote_device_id) ?? "peer_1"
+        : null,
+      hasRunId: Boolean(status.run_id),
+      hasSessionId: Boolean(status.session_id),
+    },
+    transport: {
+      selected_transport: status.selected_transport ?? null,
+      selected: status.selected_transport ?? null,
+      selectedLabel: transportLabel(status.selected_transport),
+      candidate_transports: status.attempted_transports ?? [],
+      attempted: status.attempted_transports ?? [],
+      attemptedLabels: (status.attempted_transports ?? []).map((transport) => transportLabel(transport) ?? transport),
+      fallback_code: status.fallback_code ?? null,
+      fallback_reason: redactSyncEvidenceText(status.fallback_reason, redactionContext),
+      fallback: {
+        code: status.fallback_code ?? null,
+        reason: redactSyncEvidenceText(status.fallback_reason, redactionContext),
+      },
+    },
+    metrics: {
+      network_receive_throughput_bytes_per_second: status.throughput_bytes_per_second ?? null,
+      backend_staging_throughput_bytes_per_second: throughputFromEvidenceBytes(totalEvidenceBytes, stagingDurationMs),
+      reconciliation_apply_ms: applyDurationMs,
+      project_imports_per_minute: projectImportsPerMinute,
+      project_availability_gap_ms: syncProjectAvailabilityGapMs(projectAppearances),
+      ttfa_ms: status.time_to_first_artifact_ms ?? null,
+      transfer_counts: evidenceTransferCounts,
+      timeToFirstArtifactMs: status.time_to_first_artifact_ms ?? null,
+      throughputBytesPerSecond: status.throughput_bytes_per_second ?? null,
+      transferCounts: {
+        statuses: artifactStatusCounts,
+        counts: evidenceTransferCounts,
+        servedArtifactRequests: status.served_artifact_requests ?? null,
+        localManifestCount: status.local_manifest_count ?? null,
+        remoteManifestCount: status.remote_manifest_count ?? null,
+        importedProjectCount: status.imported_project_count ?? null,
+        appliedProjectCount: status.applied_project_count ?? null,
+        deletedProjectCount: status.deleted_project_count ?? null,
+        skippedProjectCount: status.skipped_project_count ?? null,
+        failedProjectCount: status.failed_project_count ?? null,
+        totalProjectCount: status.total_project_count ?? null,
+      },
+      projectResultsByStatus: projectResultCountByStatus,
+      retryIndicators,
+      reuseIndicators,
+      maxActiveStreams: syncRunEvidenceValue(status, "max_active_streams", [
+        "max_active_streams",
+        "active_streams_peak",
+        "max_streams",
+        "max_stream_count",
+      ]),
+      creditGrants: syncRunEvidenceValue(status, "credit_grants", [
+        "credit_grants",
+        "credit_grant_count",
+        "credit_grants_count",
+        "credits_granted",
+      ]),
+      creditRevokes: syncRunEvidenceValue(status, "credit_revokes", [
+        "credit_revokes",
+        "credit_revoke_count",
+        "credit_revokes_count",
+        "credit_revocation_count",
+        "credits_revoked",
+      ]),
+      diagnostics: status.transfer_counts ?? null,
+    },
+    projects: mergedProjectResults.map((result) => {
+      const projectTimestamps = (projectAppearances.get(result.project_id) ?? [])
+        .map((timestamp) => new Date(normalizeApiDateTime(timestamp)).getTime())
+        .filter((value) => Number.isFinite(value))
+        .sort((left, right) => left - right);
+      const cadenceMs = projectTimestamps.length > 1
+        ? Math.round(
+          projectTimestamps.slice(1).reduce((total, timestamp, index) => (
+            total + (timestamp - projectTimestamps[index]!)
+          ), 0) / (projectTimestamps.length - 1),
+        )
+        : null;
+      return {
+        label: redactionContext.projectLabels.get(result.project_id) ?? "project_1",
+        status: result.status,
+        phase: result.phase ?? null,
+        action: result.action ?? null,
+        message: redactSyncEvidenceText(result.message, redactionContext),
+        isFinal: result.is_final ?? null,
+        startedAt: result.started_at ?? null,
+        completedAt: result.completed_at ?? null,
+        durationMs: result.duration_ms ?? null,
+        durationSeconds: result.duration_seconds ?? null,
+        counts: {
+          imported: result.imported_count ?? null,
+          applied: result.applied_count ?? null,
+          deleted: result.deleted_count ?? null,
+          satisfied: result.satisfied_count ?? null,
+          skipped: result.skipped_count ?? null,
+          failed: result.failed_count ?? null,
+          receivedArtifacts: result.received_artifact_count ?? null,
+          reusedArtifacts: result.reused_artifact_count ?? null,
+        },
+        appearance: {
+          eventCount: projectTimestamps.length,
+          firstSeenAt: projectTimestamps.length ? new Date(projectTimestamps[0]!).toISOString() : null,
+          lastSeenAt: projectTimestamps.length
+            ? new Date(projectTimestamps[projectTimestamps.length - 1]!).toISOString()
+            : null,
+          cadenceMs,
+        },
+      };
+    }),
+    artifacts: status.received_artifacts.map((artifact) => ({
+      label: redactionContext.artifactLabels.get(artifact.artifact_id) ?? "artifact_1",
+      status: artifact.status,
+      message: redactSyncEvidenceText(artifact.message, redactionContext),
+      sizeBytes: artifact.size_bytes ?? null,
+      startedAt: artifact.started_at ?? null,
+      completedAt: artifact.completed_at ?? null,
+      durationMs: artifact.duration_ms ?? null,
+      throughputBytesPerSecond: artifact.throughput_bytes_per_second ?? null,
+      reused: artifact.status === "already_staged",
+    })),
+    lifecycle: {
+      listener: {
+        active: options.listenerActive,
+        status: options.listenerStatus,
+        activePhase: options.listenerActivePhase ?? null,
+        activeMessage: redactSyncEvidenceText(options.listenerActiveMessage, redactionContext),
+        activeProgressAt: options.listenerActiveProgressAt ?? null,
+        activeElapsedMs: options.listenerActiveElapsedMs ?? null,
+        lastStatus: redactSyncEvidenceText(options.listenerLastStatus, redactionContext),
+        hasLastError: Boolean(options.listenerLastError),
+        updatedAt: options.listenerUpdatedAt ?? null,
+      },
+      phaseTimings: (status.phase_timings ?? []).map((timing, index) => ({
+        label: `phase_${index + 1}`,
+        phase: timing.phase ?? null,
+        project: timing.project_id ? redactionContext.projectLabels.get(timing.project_id) ?? "project_1" : null,
+        artifact: timing.artifact_id
+          ? redactionContext.artifactLabels.get(timing.artifact_id) ?? "artifact_1"
+          : null,
+        startedAt: timing.started_at ?? null,
+        completedAt: timing.completed_at ?? null,
+        durationMs: timing.duration_ms ?? null,
+        throughputBytesPerSecond: timing.throughput_bytes_per_second ?? null,
+      })),
+    },
+    storage: {
+      scratch_peak_bytes: syncRunEvidenceValue(status, "scratch_peak_bytes", [
+        "scratch_peak_bytes",
+        "scratch_bytes_peak",
+        "scratch_storage_peak_bytes",
+      ]),
+      staging_peak_bytes: syncRunEvidenceValue(status, "staging_peak_bytes", [
+        "staging_peak_bytes",
+        "staging_bytes_peak",
+        "staging_storage_peak_bytes",
+      ]),
+      scratchPeakBytes: syncRunEvidenceValue(status, "scratch_peak_bytes", [
+        "scratch_peak_bytes",
+        "scratch_bytes_peak",
+        "scratch_storage_peak_bytes",
+      ]),
+      stagingPeakBytes: syncRunEvidenceValue(status, "staging_peak_bytes", [
+        "staging_peak_bytes",
+        "staging_bytes_peak",
+        "staging_storage_peak_bytes",
+      ]),
+    },
+    validation: {
+      schema: "tuneforge-sync-evidence-v1",
+      ok: status.status !== "failed",
+      ui_visible: true,
+      privacySafe: true,
+      redactionCounts: {
+        peers: redactionContext.peerLabels.size,
+        projects: redactionContext.projectLabels.size,
+        artifacts: redactionContext.artifactLabels.size,
+      },
+      omittedSensitiveCategories: [
+        "network_locators",
+        "user_labels",
+        "pairing_material",
+        "raw_identifiers",
+        "paths_and_filenames",
+        "file_or_audio_contents",
+      ],
+    },
+  };
+}
+
 function syncProjectResultList(status: SyncTransportRunStatus | null | undefined) {
   const results = status ? mergeSyncProjectResults(status.project_results, status.manifest_errors) : [];
   if (!results.length) {
@@ -894,6 +1404,8 @@ export function ActivitySyncPanel() {
   const [lastSyncResult, setLastSyncResult] = useState<SyncTransportRunStatus | null>(null);
   const [hiddenListenerSyncKey, setHiddenListenerSyncKey] = useState<string | null>(null);
   const [syncNowPolling, setSyncNowPolling] = useState(false);
+  const [evidenceMessage, setEvidenceMessage] = useState<string | null>(null);
+  const [evidenceError, setEvidenceError] = useState<string | null>(null);
   const pairingCodeOutputRef = useRef<HTMLTextAreaElement | null>(null);
   const rawPairingOutputRef = useRef<HTMLTextAreaElement | null>(null);
   const refreshedProjectSyncKeyRef = useRef<string | null>(null);
@@ -1220,6 +1732,94 @@ export function ActivitySyncPanel() {
     startListenerMutation.mutate();
   }
 
+  function buildCurrentSyncEvidenceFile() {
+    if (!visibleSyncResult) {
+      return null;
+    }
+    const capturedAt = new Date().toISOString();
+    const payload = buildSyncEvidenceExport(visibleSyncResult, {
+      capturedAt,
+      listenerActive,
+      listenerStatus,
+      listenerUpdatedAt: listenerQuery.data?.updated_at,
+      listenerActivePhase: listenerQuery.data?.active_phase ?? null,
+      listenerActiveMessage: listenerQuery.data?.active_message ?? null,
+      listenerActiveProgressAt: listenerQuery.data?.active_progress_at ?? null,
+      listenerActiveElapsedMs: listenerQuery.data?.active_elapsed_ms ?? null,
+      listenerLastStatus: listenerQuery.data?.last_status ?? null,
+      listenerLastError: listenerQuery.data?.last_error ?? null,
+      showListenerSyncResult,
+    });
+    return {
+      fileName: syncEvidenceFileName(capturedAt),
+      json: JSON.stringify(payload, null, 2),
+    };
+  }
+
+  async function handleCopySyncEvidence() {
+    const evidence = buildCurrentSyncEvidenceFile();
+    if (!evidence) {
+      setEvidenceError("No sync result available to copy.");
+      setEvidenceMessage(null);
+      return;
+    }
+    try {
+      const copied = await copyToClipboard(evidence.json);
+      if (!copied) {
+        setEvidenceMessage(null);
+        setEvidenceError("Could not copy sync evidence.");
+        return;
+      }
+      setEvidenceError(null);
+      setEvidenceMessage("Sync evidence copied.");
+    } catch {
+      setEvidenceMessage(null);
+      setEvidenceError("Could not copy sync evidence.");
+    }
+  }
+
+  async function handleExportSyncEvidence() {
+    const evidence = buildCurrentSyncEvidenceFile();
+    if (!evidence) {
+      setEvidenceError("No sync result available to export.");
+      setEvidenceMessage(null);
+      return;
+    }
+    let copied: boolean;
+    try {
+      copied = await copyToClipboard(evidence.json);
+    } catch {
+      copied = false;
+    }
+
+    try {
+      if (isTauri()) {
+        const saved = await saveSyncEvidenceJson(evidence.fileName, evidence.json);
+        let message = "Sync evidence export canceled.";
+        if (saved) {
+          message = copied ? "Sync evidence exported and copied." : "Sync evidence exported.";
+        } else if (copied) {
+          message = "Sync evidence copied. Export canceled.";
+        }
+        setEvidenceError(null);
+        setEvidenceMessage(message);
+        return;
+      }
+
+      downloadSyncEvidenceJson(evidence.fileName, evidence.json);
+      setEvidenceError(null);
+      setEvidenceMessage(copied ? "Sync evidence exported and copied." : "Sync evidence exported.");
+    } catch {
+      if (copied) {
+        setEvidenceError("Could not export sync evidence file.");
+        setEvidenceMessage("Sync evidence copied.");
+        return;
+      }
+      setEvidenceMessage(null);
+      setEvidenceError("Could not export sync evidence.");
+    }
+  }
+
   const listenerMutationPending = startListenerMutation.isPending || stopListenerMutation.isPending;
   const pairingPayloadPending = answerPairingOfferMutation.isPending || trustPeerMutation.isPending;
   const pairingInputInvalid = Boolean(pairingInputValue && decodedPairingInput.error);
@@ -1287,7 +1887,27 @@ export function ActivitySyncPanel() {
 
       <div className="activity-sync-grid">
         <section className="activity-sync-section" aria-labelledby="activity-sync-listener-heading">
-          <h3 id="activity-sync-listener-heading">Listener</h3>
+          <div className="activity-sync-section__header">
+            <h3 id="activity-sync-listener-heading">Listener</h3>
+            <div className="activity-sync-section__actions">
+              <button
+                className="button button--ghost button--small"
+                disabled={!visibleSyncResult}
+                onClick={handleCopySyncEvidence}
+                type="button"
+              >
+                Copy Evidence
+              </button>
+              <button
+                className="button button--ghost button--small"
+                disabled={!visibleSyncResult}
+                onClick={handleExportSyncEvidence}
+                type="button"
+              >
+                Export Evidence
+              </button>
+            </div>
+          </div>
           <dl className="activity-sync-facts">
             <div>
               <dt>Status</dt>
@@ -1353,6 +1973,16 @@ export function ActivitySyncPanel() {
           {lastSyncMessage ? (
             <p className="activity-sync-alert" role="status">
               {lastSyncMessage}
+            </p>
+          ) : null}
+          {evidenceMessage ? (
+            <p className="activity-sync-alert" role="status">
+              {evidenceMessage}
+            </p>
+          ) : null}
+          {evidenceError ? (
+            <p className="activity-sync-alert activity-sync-alert--error" role="alert">
+              {evidenceError}
             </p>
           ) : null}
         </section>

--- a/apps/desktop/src/styles/activity.css
+++ b/apps/desktop/src/styles/activity.css
@@ -282,6 +282,13 @@
   flex-wrap: wrap;
 }
 
+.activity-sync-section__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
 .activity-sync-facts,
 .activity-sync-peer-row dl {
   display: grid;

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -1054,6 +1054,12 @@ const {
       return null;
     }
 
+    if (command === "write_sync_evidence_file") {
+      const path = String(args?.path ?? "");
+      state.snapshotFiles[path] = String(args?.contents ?? "");
+      return null;
+    }
+
     if (command === "read_settings_snapshot_file") {
       const path = String(args?.path ?? "");
       const contents = state.snapshotFiles[path];
@@ -2416,6 +2422,7 @@ vi.mock("@tauri-apps/plugin-dialog", () => ({
 vi.mock("@tauri-apps/api/core", () => ({
   convertFileSrc: (path: string) => path,
   invoke: mockInvoke,
+  isTauri: () => Boolean((window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__),
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
@@ -2824,6 +2831,10 @@ export function resetAppTestHarness() {
   mockSave.mockReset();
   mockConfirm.mockReset();
   mockInvoke.mockClear();
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: undefined,
+  });
   mockListen.mockClear();
   mockConfirm.mockResolvedValue(true);
   getMockMediaSession().reset();

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -112,7 +112,9 @@ permissions out of other platform capabilities unless a separate scanner flow is
 
 Real mobile sync validation must use an initialized Android target, a debug or release APK built
 through the package scripts above, and a physical Android device when collecting CPU and battery
-evidence. Record the selected transport path in the notes for each run:
+evidence. Use the privacy-safe evidence model and validation checklist in
+[MULTI_DEVICE_LIBRARY_SYNC_SPIKE.md](./MULTI_DEVICE_LIBRARY_SYNC_SPIKE.md#sync-validation-evidence-model).
+Record the selected transport path in the notes for each run:
 
 - `tuneforge-sync+tcp`
 - `tuneforge-sync+iroh`
@@ -129,6 +131,17 @@ For accepted mobile sync evidence, sync at least one desktop project to Android,
 source and synced WAV stem artifacts from app-local storage, and compare battery, CPU, storage, and
 transfer costs against AAC/M4A or another compressed baseline. Mobile sync remains library sync
 only; remote processing stays out of scope.
+
+For Android-to-desktop validation, import or change durable library data on Android, sync it to a
+desktop peer, and record redacted project import cadence, TTFA, transfer counts, selected transport,
+fallback reason/code, backend/mobile staging throughput, reconciliation apply time, and scratch or
+staging peaks. Do not record audio content, file contents, filenames, absolute paths, display names,
+raw device/project/artifact IDs, endpoint hints, or pairing payloads.
+
+For listener lifecycle validation, start, stop, restart, pause, and resume the Android listener where
+the build supports it. Record whether desktop peers recover, whether fallback was used, and whether
+synced projects remain deduped after reconnect. If Android still reports the transport stub, record
+that blocker and limit the run to pairing, storage, and playback checks.
 
 For QR pairing validation, grant the camera permission, scan a pairing QR code with the Android
 build, and record whether the scan produced the expected pairing payload before trusting the peer.

--- a/docs/MULTI_DEVICE_LIBRARY_SYNC_SPIKE.md
+++ b/docs/MULTI_DEVICE_LIBRARY_SYNC_SPIKE.md
@@ -477,6 +477,43 @@ Expected Syncthing speed is not the key question. The bake-off should emphasize 
 | Reuse behavior | Unchanged synced content can be reused without changing project semantics or bypassing TuneForge verification. |
 | Delete behavior | Tombstones remain authoritative, and stale folder contents do not resurrect deleted library state. |
 
+### Sync Validation Evidence Model
+
+Sync validation evidence should be privacy-safe before any persistent sync logs exist. Manual notes, screenshots, copied Activity output, and future logs must record only redacted identifiers and aggregate transfer facts.
+
+Do not record:
+
+- Audio content or file contents.
+- Filenames, original import names, absolute paths, or user-chosen display names.
+- Raw device IDs, project IDs, artifact IDs, endpoint hints, pairing payloads, QR payloads, public keys, or secrets.
+- LAN IP addresses, relay addresses, hostnames, or other endpoint material unless a future debug export adds explicit redaction.
+
+Acceptable evidence:
+
+- Redacted run labels such as `run-a`, `peer-a`, `project-1`, and `artifact-1`.
+- Relative sync phases, counts, byte totals, durations, status values, and redacted error codes.
+- Transport choice and fallback code when it does not expose endpoint hints or peer identity material.
+- Scratch and staging peak byte usage without local path disclosure.
+- Playback result summaries such as source/stem playable, duration matched, seek worked, or decoder failed with a redacted code.
+
+Required metrics for every sync validation run:
+
+| Metric | Evidence to capture |
+| --- | --- |
+| Network receive throughput | Received bytes divided by receive duration for the selected transport. |
+| Backend staging throughput | Staged bytes divided by staging duration before apply. |
+| Reconciliation apply time | Total backend/mobile service apply duration after staged content is verified. |
+| Project import cadence | Imported projects per minute and time between successive project availability events. |
+| TTFA | Time from sync start to first verified artifact becoming locally available. |
+| Transfer counts | Requested, received, skipped/already-local, already-staged, failed, and retried artifacts. |
+| Transport choice | Selected transport, candidate transports, and whether fallback was allowed or used. |
+| Fallback reason/code | Redacted fallback reason/code, without endpoint hints or raw peer IDs. |
+| Scratch/staging peaks | Peak scratch bytes and staging bytes during the run. |
+
+For `pnpm sync:validate -- storage-peaks`, use `--samples` and `--interval-ms` during an active
+run when possible. Output `peakBytes` is the max observed across samples; `sampleCount: 1` is only
+the current snapshot and is not proof of the run peak.
+
 ### Baseline Evidence Fields
 
 The current custom desktop transport records run-level and phase-level evidence that should be copied into bake-off notes before testing another candidate against the same dataset:
@@ -491,6 +528,8 @@ The current custom desktop transport records run-level and phase-level evidence 
 | Transport phase timing evidence | `phaseTimings[]` / `phase_timings[]` entries with `phase`, `projectId`, `artifactId`, `startedAt`, `completedAt`, and `durationMs` | Compare discovery/handshake, manifest exchange, staging checks, transfers, staging, reconciliation, cleanup, and serving phases. |
 | Backend reconciliation timing | `include_timing_evidence=true` on apply requests; response `timing_evidence[]` with `phase`, `duration_ms`, `action_type`, `item_type`, `item_id`, `project_id`, `status`, and `details` | Separate transport time from backend plan/apply/action/staging-cleanup time. |
 | Resumability evidence | `alreadyStaged`, `alreadyStagedBytes`, artifact statuses `already_staged`, `received`, or `failed` | The custom baseline currently proves full verified staged-content reuse on rerun; it does not prove mid-artifact byte-range resume. |
+
+When copying these fields into validation notes, redact raw IDs and endpoint material according to "Sync Validation Evidence Model". Schema/API examples can name existing fields, but persistent evidence should not preserve raw values.
 
 ### Candidate Comparison
 
@@ -515,6 +554,23 @@ Fill this table with real evidence from the fields above. Do not enter estimated
 | 2026-05-20 | Iroh | Stale endpoint hint fallback | Linux-to-Mac after Linux listener restart | 227 MB, 1 project, 8 artifacts | Stored Linux Iroh hint pointed at a previous UDP port | Fallback to TCP completed in 1:37 at 2.3 MB/s with TTFA 19 s; imported 1 project and skipped 5 | Follow-up: stable Iroh UDP port and endpoint-hint refresh. |
 
 The interrupted lyrics-job convergence edge case is a sync v2 follow-up and does not block the transport bake-off. Completed lyrics revisions and artifacts should still sync as durable library state, but interrupted runnable jobs are not part of the v1 sync truth and should not determine the transport bake-off outcome.
+
+### Sync Validation Checklist
+
+Use this checklist for manual sync validation evidence. Keep every row tied to redacted run labels from "Sync Validation Evidence Model" and compare candidates against the same dataset where possible.
+
+| Scenario | Pass evidence |
+| --- | --- |
+| Desktop to desktop | A desktop import on peer A becomes available on peer B after manifest exchange, transfer, staging, SHA-256 verification, and service-level import. Record required metrics, transfer counts, and TTFA. |
+| Desktop to Android | A desktop import becomes available on Android as normal library state. Android records selected transport, fallback reason/code if used, staging/apply timing, storage peaks, and playback results for synced source and stem artifacts. |
+| Android to desktop | An Android import or Android-origin durable project change becomes available on a desktop peer through the same sync group model. Record import cadence, transfer counts, staging/apply timing, selected transport, and fallback reason/code if any. |
+| Three-device join and catch-up | A third peer joins an existing group, catches up from trusted online peers, and reaches the same project/artifact/revision/tombstone state. Record which peers were online, project import cadence, TTFA, and missing-provider behavior without raw IDs. |
+| Retry and resume | Interrupt a run, restart sync, and prove completed verified staging is reused. Record retried counts, already-staged counts/bytes, failed counts, final verification status, and whether byte-range resume was actually proven. |
+| Listener lifecycle | Start, stop, restart, pause, and resume listeners on desktop and Android where supported. Record selected transport, fallback reason/code, stale-hint handling, and whether peers recover without duplicating imports. |
+| Playback validation | Open synced projects only after the minimum usable set is verified. Play synced source and desktop WAV stem artifacts on desktop and Android, then record playable/seek/duration-match outcomes and redacted decoder failures. |
+| Syncthing control benchmark | Use only an external user-managed Syncthing setup moving a TuneForge sync bundle. Record control timing, transfer counts if available, safe bundle boundary checks, and service-level import results. Do not treat Syncthing as a product dependency or implementation requirement. |
+
+Accepted sync validation evidence must not claim mid-artifact byte-range resume, Android transport parity, background sync lifecycle, or Syncthing product readiness unless the specific run proves it.
 
 ## Recommended Direction
 

--- a/docs/SYNCTHING.md
+++ b/docs/SYNCTHING.md
@@ -2,6 +2,9 @@
 
 Use this only for manual or power-user testing with an existing external Syncthing install. TuneForge does not bundle, launch, or supervise Syncthing.
 
+Syncthing is a control/reference path for comparing a TuneForge sync bundle against native
+transports. It is not a dependency, product requirement, or source of library truth.
+
 ## Safety Boundary
 
 - Sync only the bundle directory passed to `--bundle-root`.
@@ -50,6 +53,27 @@ pnpm sync:bundle -- import \
 ```
 
 Import stages and verifies content-addressed blobs, rewrites paths for the local install, then applies manifests, revisions, and tombstones through TuneForge services. It does not attach the project to the Syncthing folder.
+
+## Control Benchmark
+
+Use this benchmark only when an existing external Syncthing setup is already available. Compare it
+against the same dataset used for the custom LAN or Iroh run, and keep all evidence privacy-safe as
+defined in [MULTI_DEVICE_LIBRARY_SYNC_SPIKE.md](./MULTI_DEVICE_LIBRARY_SYNC_SPIKE.md#issue-203-evidence-model).
+
+Record:
+
+- Bundle export duration and byte count.
+- Syncthing folder receive duration and receive throughput when available.
+- TuneForge import staging throughput, reconciliation apply time, project import cadence, TTFA, and
+  transfer counts.
+- Scratch/staging peak bytes for the TuneForge import side.
+- Safe bundle boundary checks: no raw app data, SQLite files, logs, caches, settings, model files,
+  symlinks, absolute paths, filenames, display names, endpoint hints, raw IDs, or pairing payloads.
+- Conflict, temporary, partial, stale, and deleted-file observations before TuneForge import.
+
+Passing this benchmark means the external folder sync moved a sync-safe bundle and TuneForge
+imported it through services with verification. It does not make Syncthing required for TuneForge
+sync, and it does not validate raw folder sync of TuneForge app data.
 
 ## Bidirectional Runs
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "sync:bundle": "bash -c 'if [[ \"${1:-}\" == \"--\" ]]; then shift; fi; exec bash scripts/run-backend-module.sh app.cli.sync_bundle \"$@\"' --",
     "sync:backend:default": "bash scripts/sync-backend-default.sh",
     "sync:backend:legacy-nvidia": "bash scripts/sync-backend-legacy-nvidia.sh",
+    "sync:validate": "node scripts/sync-validation.mjs",
     "test": "bash scripts/run-tests.sh",
     "typecheck": "pnpm --filter @tuneforge/desktop typecheck",
     "commitlint": "commitlint --edit",

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -14,6 +14,15 @@ desktop_start=${SECONDS}
 desktop_elapsed=$((SECONDS - desktop_start))
 printf '\n[tests] Desktop tests finished in %ss\n' "${desktop_elapsed}"
 
+printf '\n[tests] Starting sync validation harness tests\n\n'
+sync_validation_start=${SECONDS}
+(
+  cd "${repo_root}"
+  node --test scripts/sync-validation.test.mjs
+)
+sync_validation_elapsed=$((SECONDS - sync_validation_start))
+printf '\n[tests] Sync validation harness tests finished in %ss\n' "${sync_validation_elapsed}"
+
 printf '\n[tests] Starting Tauri shell tests\n\n'
 tauri_start=${SECONDS}
 (

--- a/scripts/sync-validation.mjs
+++ b/scripts/sync-validation.mjs
@@ -1,0 +1,829 @@
+import { lstatSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const SCHEMA_VERSION = "v1";
+const TOP_LEVEL_KEYS = [
+  "capturedAt",
+  "scenario",
+  "source",
+  "run",
+  "transport",
+  "metrics",
+  "projects",
+  "artifacts",
+  "lifecycle",
+  "storage",
+  "validation",
+];
+const BOTTLENECK_CATEGORIES = new Set([
+  "network",
+  "staging",
+  "reconciliation_apply",
+  "lifecycle",
+  "ui_visibility",
+  "incomplete_evidence",
+]);
+const REDACTED_ID_PATTERN = /^(run|peer|project|artifact|device|session|listener)-[a-z0-9._-]+$/i;
+const ENDPOINT_VALUE_PATTERN = /\b(localhost|(?:\d{1,3}\.){3}\d{1,3}|[a-f0-9:]{2,}:[a-f0-9:]+|[a-z0-9-]+\.(?:local|lan|home|internal|corp|com|net|org))(?:[:/]\d+)?\b/i;
+const FILE_NAME_PATTERN = /\b[^/\s]+\.(?:wav|mp3|m4a|flac|aac|ogg|opus|json|sqlite|db|log|txt|csv|zip|png|jpe?g)\b/i;
+const PAIRING_KEY_PATTERN = /(pair(ing)?|qr|invite|secret|token|public_?key|private_?key|payload)/i;
+const RAW_ID_KEY_PATTERN = /(?:^|[_-])(id|ids|device_id|peer_id|project_id|artifact_id|run_id|session_id|listener_id)$/i;
+const SUSPICIOUS_CONTENT_KEY_PATTERN = /(audio|file|bytes|blob|content|payload|waveform|sample)/i;
+const PATH_FILE_EXTENSION_PATTERN = "wav|mp3|m4a|flac|aac|ogg|opus|json|sqlite|db|log|txt|csv|zip|png|jpe?g";
+const ABSOLUTE_PATH_VALUE_PATTERN = new RegExp(
+  `(?:^|[\\s"'(])(?:file:\\/\\/(?:localhost)?(?:[A-Za-z]:[\\\\/]|\\/)?|[A-Za-z]:[\\\\/]|\\/)[^\\r\\n"'<>]*(?:\\.(?:${PATH_FILE_EXTENSION_PATTERN})\\b|[\\\\/][^\\s"'<>),;]+)`,
+  "i",
+);
+const PHASE_CATEGORY_PATTERNS = [
+  { category: "reconciliation_apply", pattern: /(reconciliation|apply)/i },
+  { category: "staging", pattern: /(staging|stage|temp|hash|write)/i },
+  { category: "lifecycle", pattern: /(pause|resume|restart|listener|lifecycle|start|stop)/i },
+  { category: "ui_visibility", pattern: /(visible|visibility|ui|hydrate|render)/i },
+  { category: "network", pattern: /(network|transport|receive|recv|send|serve|read|download|upload)/i },
+];
+const TRANSFER_COUNT_KEYS = new Set([
+  "requested",
+  "requested_artifacts",
+  "received",
+  "completed",
+  "skipped",
+  "already_local",
+  "alreadyLocal",
+  "already_staged",
+  "alreadyStaged",
+  "failed",
+  "retried",
+  "retries",
+]);
+const LOCAL_PROJECT_MUTATION_STATUSES = new Set(["imported", "applied", "deleted"]);
+const PROJECT_MUTATION_COUNT_ALIASES = {
+  imported: [["imported"], ["importedProjectCount"], ["imported_project_count"]],
+  applied: [["applied"], ["appliedProjectCount"], ["applied_project_count"]],
+  deleted: [["deleted"], ["deletedProjectCount"], ["deleted_project_count"]],
+};
+
+function usage() {
+  return [
+    "Usage:",
+    "  pnpm sync:validate -- validate --input <file> [--scenario <name>]",
+    "  pnpm sync:validate -- summarize --input <file>",
+    "  pnpm sync:validate -- compare --candidate <file> --control <file>",
+    "  pnpm sync:validate -- storage-peaks --transport-root <path> --staging-root <path> [--samples <count>] [--interval-ms <ms>]",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const normalizedArgv = argv[0] === "--" ? argv.slice(1) : argv;
+  const [subcommand, ...rest] = normalizedArgv;
+  if (!subcommand) {
+    throw new Error(usage());
+  }
+  const options = { _: [] };
+  for (let index = 0; index < rest.length; index += 1) {
+    const token = rest[index];
+    if (!token.startsWith("--")) {
+      options._.push(token);
+      continue;
+    }
+    const name = token.slice(2);
+    const value = rest[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for --${name}`);
+    }
+    options[name] = value;
+    index += 1;
+  }
+  return { subcommand, options };
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function safeJsonParse(filePath) {
+  try {
+    return JSON.parse(readFileSync(filePath, "utf8"));
+  } catch (error) {
+    throw new Error(`Could not read JSON from ${filePath}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function getNestedValue(value, keyPath) {
+  let current = value;
+  for (const key of keyPath) {
+    if (!isPlainObject(current) && !Array.isArray(current)) {
+      return undefined;
+    }
+    current = current[key];
+  }
+  return current;
+}
+
+function findAliasValue(scope, aliasPaths) {
+  for (const aliasPath of aliasPaths) {
+    const keyPath = Array.isArray(aliasPath) ? aliasPath : [aliasPath];
+    const resolved = getNestedValue(scope, keyPath);
+    if (resolved !== undefined) {
+      return resolved;
+    }
+  }
+  return undefined;
+}
+
+function asFiniteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function asNonNegativeInteger(value) {
+  return Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function asString(value) {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function findFirstNonNegativeInteger(scope, aliasPaths) {
+  const value = findAliasValue(scope, aliasPaths);
+  return asNonNegativeInteger(value);
+}
+
+function maxNonNull(values) {
+  const presentValues = values.filter((value) => value !== null && value !== undefined);
+  return presentValues.length > 0 ? Math.max(...presentValues) : null;
+}
+
+function readProjectMutationStatusCount(scope, status) {
+  return isPlainObject(scope)
+    ? findFirstNonNegativeInteger(scope, PROJECT_MUTATION_COUNT_ALIASES[status])
+    : null;
+}
+
+function readAggregateProjectMutationCount(scope) {
+  if (!isPlainObject(scope)) {
+    return null;
+  }
+  const mutationCounts = [...LOCAL_PROJECT_MUTATION_STATUSES].map(
+    (status) => readProjectMutationStatusCount(scope, status),
+  );
+  const presentCounts = mutationCounts.filter((count) => count !== null);
+  return presentCounts.length > 0
+    ? presentCounts.reduce((total, count) => total + count, 0)
+    : null;
+}
+
+function inferLocalProjectMutationCount(projects) {
+  if (Array.isArray(projects)) {
+    return projects.filter(
+      (entry) => isPlainObject(entry) && LOCAL_PROJECT_MUTATION_STATUSES.has(entry.status),
+    ).length;
+  }
+  if (isPlainObject(projects)) {
+    return readAggregateProjectMutationCount(projects);
+  }
+  return null;
+}
+
+function normalizeTransferCountCandidate(value) {
+  const candidate = isPlainObject(value?.counts) ? value.counts : value;
+  return isPlainObject(candidate) ? candidate : null;
+}
+
+function hasTransferCountKey(candidate) {
+  return Object.keys(candidate).some((key) => TRANSFER_COUNT_KEYS.has(key));
+}
+
+function collectTransferCountCandidates(...values) {
+  return values
+    .map((value) => normalizeTransferCountCandidate(value))
+    .filter((candidate) => candidate !== null && hasTransferCountKey(candidate));
+}
+
+function findTransferCountValue(candidates, aliases) {
+  for (const candidate of candidates) {
+    for (const alias of aliases) {
+      if (alias in candidate) {
+        return candidate[alias];
+      }
+    }
+  }
+  return undefined;
+}
+
+function asPositiveIntegerOption(value, fallback, name) {
+  if (value === undefined) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function asNonNegativeIntegerOption(value, fallback, name) {
+  if (value === undefined) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
+function isIsoTimestamp(value) {
+  return /^\d{4}-\d{2}-\d{2}T/.test(value) && !Number.isNaN(Date.parse(value));
+}
+
+function collectPhaseTimings(evidence) {
+  const phaseSets = [
+    evidence?.run?.phaseTimings,
+    evidence?.run?.phase_timings,
+    evidence?.transport?.phaseTimings,
+    evidence?.transport?.phase_timings,
+    evidence?.lifecycle?.phaseTimings,
+    evidence?.lifecycle?.phase_timings,
+  ];
+  const collected = [];
+  for (const phaseSet of phaseSets) {
+    if (!Array.isArray(phaseSet)) {
+      continue;
+    }
+    for (const entry of phaseSet) {
+      if (!isPlainObject(entry)) {
+        continue;
+      }
+      const phase = asString(entry.phase ?? entry.name ?? entry.label);
+      const durationMs = asFiniteNumber(entry.durationMs ?? entry.duration_ms ?? entry.totalMs ?? entry.total_ms);
+      if (phase && durationMs !== null) {
+        collected.push({ phase, durationMs });
+      }
+    }
+  }
+  return collected;
+}
+
+function canonicalizeEvidence(evidence) {
+  const metrics = isPlainObject(evidence.metrics) ? evidence.metrics : {};
+  const transport = isPlainObject(evidence.transport) ? evidence.transport : {};
+  const lifecycle = isPlainObject(evidence.lifecycle) ? evidence.lifecycle : {};
+  const storage = isPlainObject(evidence.storage) ? evidence.storage : {};
+  const validation = isPlainObject(evidence.validation) ? evidence.validation : {};
+
+  const transferCountCandidates = collectTransferCountCandidates(
+    metrics.transfer_counts,
+    metrics.transferCounts,
+    metrics.artifact_transfer_counts,
+    evidence.artifacts?.transfer_counts,
+    evidence.artifacts?.transferCounts,
+  );
+
+  const requested = asNonNegativeInteger(findTransferCountValue(
+    transferCountCandidates,
+    ["requested", "requested_artifacts"],
+  ));
+  const received = asNonNegativeInteger(findTransferCountValue(
+    transferCountCandidates,
+    ["received", "completed"],
+  ));
+  const skipped = asNonNegativeInteger(findTransferCountValue(
+    transferCountCandidates,
+    ["skipped", "already_local", "alreadyLocal"],
+  ));
+  const alreadyStaged = asNonNegativeInteger(findTransferCountValue(
+    transferCountCandidates,
+    ["already_staged", "alreadyStaged"],
+  ));
+  const failed = asNonNegativeInteger(findTransferCountValue(transferCountCandidates, ["failed"]));
+  const retried = asNonNegativeInteger(findTransferCountValue(
+    transferCountCandidates,
+    ["retried", "retries"],
+  ));
+
+  const selectedTransport = asString(
+    transport.selected ?? transport.selected_transport ?? evidence.source,
+  );
+  const candidateTransports = Array.isArray(transport.candidates ?? transport.candidate_transports)
+    ? (transport.candidates ?? transport.candidate_transports).filter((entry) => typeof entry === "string")
+    : [];
+  const bottleneckHint = asString(validation.bottleneck ?? validation.bottleneck_category);
+  const servedArtifactRequests = asNonNegativeInteger(findAliasValue(metrics, [
+    ["transferCounts", "servedArtifactRequests"],
+    ["transferCounts", "served_artifact_requests"],
+    ["transfer_counts", "servedArtifactRequests"],
+    ["transfer_counts", "served_artifact_requests"],
+    ["servedArtifactRequests"],
+    ["served_artifact_requests"],
+  ]));
+  const totalServedBytes = asFiniteNumber(findAliasValue(metrics, [
+    ["diagnostics", "total_served_bytes"],
+    ["diagnostics", "totalServedBytes"],
+    ["total_served_bytes"],
+    ["totalServedBytes"],
+    ["served_bytes"],
+    ["servedBytes"],
+  ]));
+  const projectMutationMetricScopes = [
+    metrics.transferCounts,
+    metrics.transfer_counts,
+    metrics.diagnostics,
+    metrics,
+  ];
+  const importedProjectCount = maxNonNull(
+    projectMutationMetricScopes.map((scope) => readProjectMutationStatusCount(scope, "imported")),
+  );
+  const aggregateProjectMutationCount = maxNonNull(
+    projectMutationMetricScopes.map((scope) => readAggregateProjectMutationCount(scope)),
+  );
+  const localProjectMutationCount = maxNonNull([
+    inferLocalProjectMutationCount(evidence.projects),
+    aggregateProjectMutationCount,
+  ]);
+  const senderOnly = received === 0 &&
+    localProjectMutationCount === 0 &&
+    servedArtifactRequests !== null &&
+    servedArtifactRequests > 0 &&
+    totalServedBytes !== null &&
+    totalServedBytes > 0;
+
+  return {
+    runRole: senderOnly
+      ? "sender_only"
+      : received > 0 || localProjectMutationCount > 0
+        ? "receiver_or_import"
+        : "unknown",
+    selectedTransport,
+    candidateTransports,
+    networkReceiveThroughputBytesPerSecond: asFiniteNumber(findAliasValue(metrics, [
+      ["network_receive_throughput_bytes_per_second"],
+      ["receive_throughput_bytes_per_second"],
+      ["transport_receive_throughput_bytes_per_second"],
+      ["throughput_bytes_per_second"],
+    ])),
+    backendStagingThroughputBytesPerSecond: asFiniteNumber(findAliasValue(metrics, [
+      ["backend_staging_throughput_bytes_per_second"],
+      ["staging_throughput_bytes_per_second"],
+    ])),
+    reconciliationApplyMs: asFiniteNumber(findAliasValue(metrics, [
+      ["reconciliation_apply_ms"],
+      ["apply_ms"],
+      ["reconciliation", "apply_ms"],
+    ])),
+    projectImportsPerMinute: asFiniteNumber(findAliasValue(metrics, [
+      ["project_imports_per_minute"],
+      ["projects_per_minute"],
+    ])),
+    projectAvailabilityGapMs: asFiniteNumber(findAliasValue(metrics, [
+      ["project_availability_gap_ms"],
+      ["project_availability_gap_ms_avg"],
+      ["project_availability_gap_ms_p50"],
+    ])),
+    ttfaMs: asFiniteNumber(findAliasValue(metrics, [
+      ["ttfa_ms"],
+      ["time_to_first_artifact_ms"],
+    ])),
+    transferCounts: {
+      requested,
+      received,
+      skipped,
+      alreadyStaged,
+      failed,
+      retried,
+    },
+    servedArtifactRequests,
+    totalServedBytes,
+    importedProjectCount,
+    localProjectMutationCount,
+    fallbackReason: asString(
+      lifecycle.fallbackReason ??
+      lifecycle.fallback_reason ??
+      transport.fallbackReason ??
+      transport.fallback_reason ??
+      transport.fallback?.reason,
+    ),
+    fallbackCode: asString(
+      lifecycle.fallbackCode ??
+      lifecycle.fallback_code ??
+      transport.fallbackCode ??
+      transport.fallback_code ??
+      transport.fallback?.code,
+    ),
+    scratchPeakBytes: asFiniteNumber(findAliasValue(storage, [
+      ["scratch_peak_bytes"],
+      ["scratch_bytes_peak"],
+      ["scratch", "peakBytes"],
+      ["scratch", "peak_bytes"],
+    ])),
+    stagingPeakBytes: asFiniteNumber(findAliasValue(storage, [
+      ["staging_peak_bytes"],
+      ["staging_bytes_peak"],
+      ["staging", "peakBytes"],
+      ["staging", "peak_bytes"],
+    ])),
+    phaseTimings: collectPhaseTimings(evidence),
+    uiVisible: validation.ui_visible === false || lifecycle.ui_visible === false
+      ? false
+      : validation.ui_visible === true || lifecycle.ui_visible === true
+        ? true
+        : null,
+    validationPassed: validation.ok === false || validation.valid === false
+      ? false
+      : validation.ok === true || validation.valid === true
+        ? true
+        : null,
+    bottleneckHint,
+  };
+}
+
+function validateTopLevel(evidence, errors) {
+  if (!isPlainObject(evidence)) {
+    errors.push("Evidence must be a JSON object.");
+    return;
+  }
+  for (const key of TOP_LEVEL_KEYS) {
+    if (!(key in evidence)) {
+      errors.push(`Missing top-level key: ${key}`);
+    }
+  }
+  const capturedAt = evidence.capturedAt;
+  if (typeof capturedAt !== "string" || Number.isNaN(Date.parse(capturedAt))) {
+    errors.push("capturedAt must be an ISO-8601 timestamp string.");
+  }
+}
+
+function validateRequiredMetrics(evidence, errors) {
+  const normalized = canonicalizeEvidence(evidence);
+  const requiresReceiverMetrics = normalized.runRole !== "sender_only";
+  if (normalized.networkReceiveThroughputBytesPerSecond === null) {
+    errors.push("Missing required metric: network receive throughput.");
+  }
+  if (requiresReceiverMetrics && normalized.backendStagingThroughputBytesPerSecond === null) {
+    errors.push("Missing required metric: backend staging throughput.");
+  }
+  if (requiresReceiverMetrics && normalized.reconciliationApplyMs === null) {
+    errors.push("Missing required metric: reconciliation apply time.");
+  }
+  if (normalized.projectImportsPerMinute === null) {
+    errors.push("Missing required metric: project import cadence (projects per minute).");
+  }
+  if (requiresReceiverMetrics && normalized.projectAvailabilityGapMs === null) {
+    errors.push("Missing required metric: project import cadence gap.");
+  }
+  if (normalized.ttfaMs === null) {
+    errors.push("Missing required metric: TTFA.");
+  }
+  for (const [key, value] of Object.entries(normalized.transferCounts)) {
+    if (value === null) {
+      errors.push(`Missing required transfer count: ${key}`);
+    }
+  }
+  if (!normalized.selectedTransport) {
+    errors.push("Missing required transport choice.");
+  }
+}
+
+function validateScenario(evidence, expectedScenario, errors) {
+  if (!expectedScenario) {
+    return;
+  }
+  if (evidence.scenario !== expectedScenario) {
+    errors.push(`Scenario mismatch: expected ${expectedScenario}, got ${String(evidence.scenario)}`);
+  }
+}
+
+function inspectPrivacy(value, trail, errors) {
+  const key = trail[trail.length - 1] ?? "";
+  if (PAIRING_KEY_PATTERN.test(key)) {
+    errors.push(`Privacy guard: disallowed key ${trail.join(".")}`);
+  }
+  if (RAW_ID_KEY_PATTERN.test(key)) {
+    if (typeof value === "string" && !REDACTED_ID_PATTERN.test(value)) {
+      errors.push(`Privacy guard: raw identifier at ${trail.join(".")}`);
+    }
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        if (typeof entry === "string" && !REDACTED_ID_PATTERN.test(entry)) {
+          errors.push(`Privacy guard: raw identifier at ${trail.join(".")}`);
+          break;
+        }
+      }
+    }
+  }
+  if (typeof value === "string") {
+    if (ABSOLUTE_PATH_VALUE_PATTERN.test(value)) {
+      errors.push(`Privacy guard: absolute path at ${trail.join(".")}`);
+    }
+    if (!isIsoTimestamp(value) && (ENDPOINT_VALUE_PATTERN.test(value) || /^https?:\/\//i.test(value))) {
+      errors.push(`Privacy guard: endpoint hint at ${trail.join(".")}`);
+    }
+    if (FILE_NAME_PATTERN.test(value)) {
+      errors.push(`Privacy guard: filename-like value at ${trail.join(".")}`);
+    }
+    if (
+      (SUSPICIOUS_CONTENT_KEY_PATTERN.test(key) || /^data:/i.test(value)) &&
+      value.length > 96
+    ) {
+      errors.push(`Privacy guard: suspicious payload content at ${trail.join(".")}`);
+    }
+    if (/^[A-Za-z0-9+/=]{192,}$/.test(value)) {
+      errors.push(`Privacy guard: opaque payload at ${trail.join(".")}`);
+    }
+  }
+  if (Array.isArray(value)) {
+    if (SUSPICIOUS_CONTENT_KEY_PATTERN.test(key) && value.length > 32 && value.every((entry) => Number.isInteger(entry))) {
+      errors.push(`Privacy guard: byte payload at ${trail.join(".")}`);
+    }
+    value.forEach((entry, index) => inspectPrivacy(entry, trail.concat(String(index)), errors));
+    return;
+  }
+  if (isPlainObject(value)) {
+    for (const [childKey, childValue] of Object.entries(value)) {
+      inspectPrivacy(childValue, trail.concat(childKey), errors);
+    }
+  }
+}
+
+export function validateEvidence(evidence, { scenario } = {}) {
+  const errors = [];
+  validateTopLevel(evidence, errors);
+  if (isPlainObject(evidence)) {
+    validateRequiredMetrics(evidence, errors);
+    validateScenario(evidence, scenario, errors);
+    inspectPrivacy(evidence, [], errors);
+  }
+  return {
+    ok: errors.length === 0,
+    schemaVersion: SCHEMA_VERSION,
+    errors,
+    normalized: isPlainObject(evidence) ? canonicalizeEvidence(evidence) : null,
+  };
+}
+
+function phaseCategoryScore(phaseTimings) {
+  const scores = new Map();
+  for (const entry of phaseTimings) {
+    const matched = PHASE_CATEGORY_PATTERNS.find((item) => item.pattern.test(entry.phase));
+    if (!matched) {
+      continue;
+    }
+    scores.set(matched.category, (scores.get(matched.category) ?? 0) + entry.durationMs);
+  }
+  return Array.from(scores.entries()).sort((left, right) => right[1] - left[1])[0] ?? null;
+}
+
+export function summarizeEvidence(evidence) {
+  const validation = validateEvidence(evidence);
+  const normalized = validation.normalized;
+  let bottleneck = "incomplete_evidence";
+  const reasons = [];
+
+  if (!validation.ok || !normalized) {
+    reasons.push("validation_failed");
+  } else if (normalized.uiVisible === false) {
+    bottleneck = "ui_visibility";
+    reasons.push("ui_not_visible");
+  } else if (normalized.validationPassed === false) {
+    bottleneck = "incomplete_evidence";
+    reasons.push("validation_flag_failed");
+  } else if (normalized.fallbackCode || normalized.fallbackReason) {
+    bottleneck = "lifecycle";
+    reasons.push("fallback_used");
+  } else {
+    const phaseWinner = phaseCategoryScore(normalized.phaseTimings);
+    if (phaseWinner && BOTTLENECK_CATEGORIES.has(phaseWinner[0])) {
+      bottleneck = phaseWinner[0];
+      reasons.push(`phase:${phaseWinner[0]}`);
+    } else if (
+      normalized.reconciliationApplyMs !== null &&
+      normalized.ttfaMs !== null &&
+      normalized.reconciliationApplyMs >= Math.max(normalized.ttfaMs * 0.6, 1000)
+    ) {
+      bottleneck = "reconciliation_apply";
+      reasons.push("apply_time_dominant");
+    } else if (
+      normalized.networkReceiveThroughputBytesPerSecond !== null &&
+      normalized.backendStagingThroughputBytesPerSecond !== null &&
+      normalized.backendStagingThroughputBytesPerSecond < normalized.networkReceiveThroughputBytesPerSecond * 0.75
+    ) {
+      bottleneck = "staging";
+      reasons.push("staging_slower_than_network");
+    } else if (
+      normalized.networkReceiveThroughputBytesPerSecond !== null &&
+      normalized.backendStagingThroughputBytesPerSecond !== null &&
+      normalized.networkReceiveThroughputBytesPerSecond <= normalized.backendStagingThroughputBytesPerSecond * 0.8
+    ) {
+      bottleneck = "network";
+      reasons.push("network_slower_than_staging");
+    } else if (normalized.bottleneckHint && BOTTLENECK_CATEGORIES.has(normalized.bottleneckHint)) {
+      bottleneck = normalized.bottleneckHint;
+      reasons.push("validation_hint");
+    } else {
+      reasons.push("no_clear_signal");
+    }
+  }
+
+  return {
+    ok: validation.ok,
+    schemaVersion: SCHEMA_VERSION,
+    scenario: evidence?.scenario ?? null,
+    source: evidence?.source ?? null,
+    bottleneck,
+    reasons,
+    metrics: normalized,
+    errors: validation.errors,
+  };
+}
+
+function compareMetric(candidate, control, key, preferredDirection) {
+  const candidateValue = candidate?.[key];
+  const controlValue = control?.[key];
+  if (candidateValue === null || candidateValue === undefined || controlValue === null || controlValue === undefined) {
+    return { metric: key, candidate: candidateValue ?? null, control: controlValue ?? null, winner: "unknown" };
+  }
+  if (candidateValue === controlValue) {
+    return { metric: key, candidate: candidateValue, control: controlValue, winner: "tie" };
+  }
+  const winner = preferredDirection === "higher"
+    ? (candidateValue > controlValue ? "candidate" : "control")
+    : (candidateValue < controlValue ? "candidate" : "control");
+  return { metric: key, candidate: candidateValue, control: controlValue, winner };
+}
+
+export function compareEvidence(candidateEvidence, controlEvidence) {
+  const candidateSummary = summarizeEvidence(candidateEvidence);
+  const controlSummary = summarizeEvidence(controlEvidence);
+  const comparisons = [
+    compareMetric(candidateSummary.metrics, controlSummary.metrics, "networkReceiveThroughputBytesPerSecond", "higher"),
+    compareMetric(candidateSummary.metrics, controlSummary.metrics, "backendStagingThroughputBytesPerSecond", "higher"),
+    compareMetric(candidateSummary.metrics, controlSummary.metrics, "reconciliationApplyMs", "lower"),
+    compareMetric(candidateSummary.metrics, controlSummary.metrics, "projectImportsPerMinute", "higher"),
+    compareMetric(candidateSummary.metrics, controlSummary.metrics, "projectAvailabilityGapMs", "lower"),
+    compareMetric(candidateSummary.metrics, controlSummary.metrics, "ttfaMs", "lower"),
+  ];
+
+  const score = { candidate: 0, control: 0 };
+  for (const comparison of comparisons) {
+    if (comparison.winner === "candidate") {
+      score.candidate += 1;
+    } else if (comparison.winner === "control") {
+      score.control += 1;
+    }
+  }
+
+  return {
+    ok: candidateSummary.ok && controlSummary.ok,
+    schemaVersion: SCHEMA_VERSION,
+    candidate: candidateSummary,
+    control: controlSummary,
+    comparison: {
+      metrics: comparisons,
+      overall: score.candidate === score.control
+        ? "mixed"
+        : score.candidate > score.control
+          ? "candidate"
+          : "control",
+      score,
+    },
+  };
+}
+
+function directorySize(rootPath) {
+  const stat = lstatSync(rootPath, { throwIfNoEntry: false });
+  if (!stat) {
+    return 0;
+  }
+  if (stat.isSymbolicLink()) {
+    return 0;
+  }
+  if (stat.isFile()) {
+    return stat.size;
+  }
+  if (!stat.isDirectory()) {
+    return 0;
+  }
+  let total = 0;
+  for (const entry of readdirSync(rootPath, { withFileTypes: true })) {
+    total += directorySize(path.join(rootPath, entry.name));
+  }
+  return total;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function readStorageSample(transportRoot, stagingRoot) {
+  const transportBytes = directorySize(path.resolve(transportRoot));
+  const stagingBytes = directorySize(path.resolve(stagingRoot));
+  return {
+    sampledAt: new Date().toISOString(),
+    transportBytes,
+    stagingBytes,
+    combinedBytes: transportBytes + stagingBytes,
+  };
+}
+
+export async function sampleStoragePeaks({
+  transportRoot,
+  stagingRoot,
+  samples = 1,
+  intervalMs = 1000,
+}) {
+  if (!transportRoot || !stagingRoot) {
+    throw new Error("storage-peaks requires --transport-root and --staging-root");
+  }
+  const sampleCount = asPositiveIntegerOption(samples, 1, "--samples");
+  const sampleIntervalMs = asNonNegativeIntegerOption(intervalMs, 1000, "--interval-ms");
+  const observedSamples = [];
+  for (let index = 0; index < sampleCount; index += 1) {
+    observedSamples.push(readStorageSample(transportRoot, stagingRoot));
+    if (index < sampleCount - 1 && sampleIntervalMs > 0) {
+      await sleep(sampleIntervalMs);
+    }
+  }
+  const currentSample = observedSamples[observedSamples.length - 1];
+  const transportPeakBytes = Math.max(...observedSamples.map((sample) => sample.transportBytes));
+  const stagingPeakBytes = Math.max(...observedSamples.map((sample) => sample.stagingBytes));
+  const combinedPeakBytes = Math.max(...observedSamples.map((sample) => sample.combinedBytes));
+  return {
+    capturedAt: currentSample.sampledAt,
+    mode: "sampled",
+    sampleCount,
+    intervalMs: sampleIntervalMs,
+    peakSemantics: sampleCount === 1 ? "current_snapshot_not_run_peak" : "max_observed_across_samples",
+    samples: observedSamples,
+    storage: {
+      transport: {
+        currentBytes: currentSample.transportBytes,
+        peakBytes: transportPeakBytes,
+      },
+      staging: {
+        currentBytes: currentSample.stagingBytes,
+        peakBytes: stagingPeakBytes,
+      },
+      combined: {
+        currentBytes: currentSample.combinedBytes,
+        peakBytes: combinedPeakBytes,
+      },
+    },
+  };
+}
+
+function printJson(value) {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const { subcommand, options } = parseArgs(argv);
+  if (subcommand === "validate") {
+    if (!options.input) {
+      throw new Error("validate requires --input <file>");
+    }
+    const result = validateEvidence(safeJsonParse(options.input), { scenario: options.scenario });
+    printJson(result);
+    if (!result.ok) {
+      process.stderr.write(`Validation failed: ${result.errors.join("; ")}\n`);
+      process.exitCode = 1;
+    }
+    return;
+  }
+  if (subcommand === "summarize") {
+    if (!options.input) {
+      throw new Error("summarize requires --input <file>");
+    }
+    printJson(summarizeEvidence(safeJsonParse(options.input)));
+    return;
+  }
+  if (subcommand === "compare") {
+    if (!options.candidate || !options.control) {
+      throw new Error("compare requires --candidate <file> and --control <file>");
+    }
+    const result = compareEvidence(safeJsonParse(options.candidate), safeJsonParse(options.control));
+    printJson(result);
+    if (!result.ok) {
+      process.stderr.write("Comparison includes invalid evidence.\n");
+      process.exitCode = 1;
+    }
+    return;
+  }
+  if (subcommand === "storage-peaks") {
+    printJson(await sampleStoragePeaks({
+      transportRoot: options["transport-root"],
+      stagingRoot: options["staging-root"],
+      samples: options.samples,
+      intervalMs: options["interval-ms"],
+    }));
+    return;
+  }
+  throw new Error(`Unknown subcommand: ${subcommand}\n${usage()}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/sync-validation.test.mjs
+++ b/scripts/sync-validation.test.mjs
@@ -1,0 +1,458 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  compareEvidence,
+  sampleStoragePeaks,
+  summarizeEvidence,
+  validateEvidence,
+} from "./sync-validation.mjs";
+
+function makeEvidence(overrides = {}) {
+  return {
+    capturedAt: "2026-06-02T12:00:00.000Z",
+    scenario: "desktop-to-desktop",
+    source: "tuneforge-sync+iroh",
+    run: {
+      label: "run-a",
+      phase_timings: [
+        { phase: "network_receive", duration_ms: 1200 },
+        { phase: "staging_post", duration_ms: 400 },
+        { phase: "reconciliation_apply", duration_ms: 300 },
+      ],
+    },
+    transport: {
+      selected_transport: "tuneforge-sync+iroh",
+      candidate_transports: ["tuneforge-sync+tcp", "tuneforge-sync+iroh"],
+      fallback_code: null,
+      fallback_reason: null,
+    },
+    metrics: {
+      network_receive_throughput_bytes_per_second: 2_000_000,
+      backend_staging_throughput_bytes_per_second: 1_500_000,
+      reconciliation_apply_ms: 300,
+      project_imports_per_minute: 12,
+      project_availability_gap_ms: 5_000,
+      ttfa_ms: 900,
+      transfer_counts: {
+        requested: 8,
+        received: 8,
+        skipped: 0,
+        already_staged: 0,
+        failed: 0,
+        retried: 0,
+      },
+    },
+    projects: {
+      imported: 2,
+      labels: ["project-1", "project-2"],
+    },
+    artifacts: {
+      transfer_counts: {
+        requested: 8,
+        received: 8,
+        skipped: 0,
+        already_staged: 0,
+        failed: 0,
+        retried: 0,
+      },
+    },
+    lifecycle: {
+      fallback_code: null,
+      fallback_reason: null,
+      ui_visible: true,
+    },
+    storage: {
+      scratch_peak_bytes: 1234,
+      staging_peak_bytes: 4321,
+    },
+    validation: {
+      ok: true,
+      ui_visible: true,
+    },
+    ...overrides,
+  };
+}
+
+function makeSenderOnlyEvidence(overrides = {}) {
+  const transferCounts = {
+    requested: 0,
+    received: 0,
+    skipped: 0,
+    already_staged: 0,
+    failed: 0,
+    retried: 0,
+  };
+  return makeEvidence({
+    scenario: "listener-last-sync",
+    source: {
+      kind: "listener.last_sync",
+      listenerActive: true,
+      listenerStatus: "listening",
+    },
+    run: {
+      label: "run_1",
+      status: "completed",
+      message: "Exchanged 1 local and 0 remote manifest(s); imported 0 project(s), received 0 artifact(s).",
+    },
+    transport: {
+      selected_transport: "iroh",
+      selected: "iroh",
+      candidate_transports: ["iroh"],
+      fallback_code: null,
+      fallback_reason: null,
+    },
+    metrics: {
+      network_receive_throughput_bytes_per_second: 42_409_204.7,
+      backend_staging_throughput_bytes_per_second: null,
+      reconciliation_apply_ms: null,
+      project_imports_per_minute: 0,
+      project_availability_gap_ms: null,
+      ttfa_ms: 509,
+      transfer_counts: transferCounts,
+      transferCounts: {
+        counts: transferCounts,
+        servedArtifactRequests: 8,
+        localManifestCount: 1,
+        remoteManifestCount: 0,
+        importedProjectCount: 0,
+      },
+      diagnostics: {
+        total_received_bytes: 0,
+        total_served_bytes: 227_671_416,
+        imported_project_count: 0,
+      },
+    },
+    projects: [],
+    artifacts: [],
+    lifecycle: {
+      fallback_code: null,
+      fallback_reason: null,
+      ui_visible: true,
+      phaseTimings: [
+        { phase: "peer_authentication", durationMs: 17 },
+        { phase: "manifest_exchange", durationMs: 3 },
+        { phase: "local_manifest_export", durationMs: 166 },
+        { phase: "serve_artifact_requests", durationMs: 5_147 },
+      ],
+    },
+    storage: {
+      scratch_peak_bytes: 0,
+      staging_peak_bytes: 0,
+    },
+    validation: {
+      ok: true,
+      ui_visible: true,
+    },
+    ...overrides,
+  });
+}
+
+test("validateEvidence passes valid scenario evidence", () => {
+  const result = validateEvidence(makeEvidence(), { scenario: "desktop-to-desktop" });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.errors, []);
+});
+
+test("validateEvidence passes sender-only evidence without receiver metrics", () => {
+  const result = validateEvidence(makeSenderOnlyEvidence(), { scenario: "listener-last-sync" });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.normalized.runRole, "sender_only");
+  assert.equal(result.normalized.backendStagingThroughputBytesPerSecond, null);
+  assert.equal(result.normalized.reconciliationApplyMs, null);
+  assert.equal(result.normalized.projectAvailabilityGapMs, null);
+});
+
+test("validateEvidence reads nested counts when transfer_counts is diagnostic", () => {
+  const evidence = makeSenderOnlyEvidence();
+  evidence.metrics.transfer_counts = {
+    statuses: {},
+    localManifestCount: 1,
+    remoteManifestCount: 0,
+    servedArtifactRequests: 8,
+  };
+
+  const result = validateEvidence(evidence, { scenario: "listener-last-sync" });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.normalized.runRole, "sender_only");
+  assert.equal(result.normalized.transferCounts.requested, 0);
+  assert.equal(result.normalized.transferCounts.received, 0);
+});
+
+test("validateEvidence treats local project mutations as receiver/import evidence", () => {
+  for (const status of ["imported", "applied", "deleted"]) {
+    const result = validateEvidence(makeSenderOnlyEvidence({
+      projects: [{ label: "project_1", status }],
+    }));
+    assert.equal(result.ok, false, status);
+    assert.equal(result.normalized.runRole, "receiver_or_import", status);
+    assert.equal(result.normalized.localProjectMutationCount, 1, status);
+    assert.match(result.errors.join(" "), /backend staging throughput/, status);
+    assert.match(result.errors.join(" "), /reconciliation apply time/, status);
+    assert.match(result.errors.join(" "), /project import cadence gap/, status);
+  }
+});
+
+test("validateEvidence treats aggregate project mutations as receiver/import evidence", () => {
+  const cases = [
+    ["transferCounts imported", (metrics) => { metrics.transferCounts.importedProjectCount = 1; }],
+    ["transferCounts applied", (metrics) => { metrics.transferCounts.appliedProjectCount = 1; }],
+    ["transferCounts deleted", (metrics) => { metrics.transferCounts.deletedProjectCount = 1; }],
+    ["transfer_counts imported", (metrics) => { metrics.transfer_counts.imported_project_count = 1; }],
+    ["transfer_counts applied", (metrics) => { metrics.transfer_counts.applied_project_count = 1; }],
+    ["transfer_counts deleted", (metrics) => { metrics.transfer_counts.deleted_project_count = 1; }],
+    ["diagnostics imported", (metrics) => { metrics.diagnostics.imported_project_count = 1; }],
+    ["diagnostics applied", (metrics) => { metrics.diagnostics.applied_project_count = 1; }],
+    ["diagnostics deleted", (metrics) => { metrics.diagnostics.deleted_project_count = 1; }],
+    ["top-level applied", (metrics) => { metrics.appliedProjectCount = 1; }],
+  ];
+
+  for (const [name, mutateMetrics] of cases) {
+    const evidence = makeSenderOnlyEvidence({ projects: [] });
+    mutateMetrics(evidence.metrics);
+    const result = validateEvidence(evidence);
+    assert.equal(result.ok, false, name);
+    assert.equal(result.normalized.runRole, "receiver_or_import", name);
+    assert.equal(result.normalized.localProjectMutationCount, 1, name);
+    assert.match(result.errors.join(" "), /backend staging throughput/, name);
+    assert.match(result.errors.join(" "), /reconciliation apply time/, name);
+    assert.match(result.errors.join(" "), /project import cadence gap/, name);
+  }
+});
+
+test("summarizeEvidence reports sender-only network work", () => {
+  const summary = summarizeEvidence(makeSenderOnlyEvidence());
+  assert.equal(summary.ok, true);
+  assert.equal(summary.metrics.runRole, "sender_only");
+  assert.equal(summary.bottleneck, "network");
+  assert.deepEqual(summary.reasons, ["phase:network"]);
+});
+
+test("validateEvidence fails scenario mismatch and missing metrics", () => {
+  const evidence = makeEvidence({
+    scenario: "android-to-desktop",
+    metrics: {
+      ttfa_ms: 900,
+    },
+  });
+  const result = validateEvidence(evidence, { scenario: "desktop-to-desktop" });
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join(" "), /Scenario mismatch/);
+  assert.match(result.errors.join(" "), /network receive throughput/);
+});
+
+test("validateEvidence still requires receiver metrics for receiver evidence", () => {
+  const transferCounts = {
+    requested: 8,
+    received: 8,
+    skipped: 0,
+    already_staged: 0,
+    failed: 0,
+    retried: 0,
+  };
+  const result = validateEvidence(makeEvidence({
+    metrics: {
+      network_receive_throughput_bytes_per_second: 37_401_348.9,
+      backend_staging_throughput_bytes_per_second: null,
+      reconciliation_apply_ms: null,
+      project_imports_per_minute: 9.86,
+      project_availability_gap_ms: null,
+      ttfa_ms: 652,
+      transfer_counts: {
+        statuses: { received: 8 },
+        localManifestCount: 0,
+        remoteManifestCount: 1,
+      },
+      transferCounts: {
+        counts: transferCounts,
+        servedArtifactRequests: 0,
+        importedProjectCount: 1,
+      },
+      diagnostics: {
+        total_received_bytes: 227_671_416,
+        total_served_bytes: 0,
+        imported_project_count: 1,
+      },
+    },
+  }));
+  assert.equal(result.ok, false);
+  assert.equal(result.normalized.runRole, "receiver_or_import");
+  assert.match(result.errors.join(" "), /backend staging throughput/);
+  assert.match(result.errors.join(" "), /reconciliation apply time/);
+  assert.match(result.errors.join(" "), /project import cadence gap/);
+  assert.doesNotMatch(result.errors.join(" "), /Missing required transfer count/);
+});
+
+test("summarizeEvidence classifies network bottleneck from phase timings", () => {
+  const summary = summarizeEvidence(makeEvidence({
+    run: {
+      phase_timings: [
+        { phase: "network_receive", duration_ms: 5_000 },
+        { phase: "staging_post", duration_ms: 500 },
+        { phase: "reconciliation_apply", duration_ms: 300 },
+      ],
+    },
+  }));
+  assert.equal(summary.bottleneck, "network");
+});
+
+test("validateEvidence rejects privacy leaks", () => {
+  const leaked = makeEvidence({
+    projects: {
+      imported: 1,
+      file_name: "secret-song.wav",
+      absolute_path: "/Users/test/Music/secret-song.wav",
+    },
+    transport: {
+      selected_transport: "tuneforge-sync+tcp",
+      endpoint_hint: "192.168.1.24:47619",
+    },
+    validation: {
+      ok: true,
+      ui_visible: true,
+      pairing_payload: "opaque-value",
+    },
+    lifecycle: {
+      device_id: "abc123",
+      ui_visible: true,
+    },
+  });
+  const result = validateEvidence(leaked);
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join(" "), /absolute path/);
+  assert.match(result.errors.join(" "), /endpoint hint/);
+  assert.match(result.errors.join(" "), /filename-like value/);
+  assert.match(result.errors.join(" "), /disallowed key/);
+  assert.match(result.errors.join(" "), /raw identifier/);
+});
+
+test("validateEvidence rejects embedded path variants", () => {
+  const cases = [
+    ["windows", String.raw`Imported C:\Users\test\Music\secret song.wav from peer.`],
+    ["file-url", "Fetched file:///Users/test/Music/secret-song.wav during staging."],
+    ["quoted-posix", 'Imported "/Users/test/Music/secret song.wav" after retry.'],
+  ];
+  for (const [name, note] of cases) {
+    const result = validateEvidence(makeEvidence({
+      lifecycle: {
+        fallback_code: null,
+        fallback_reason: null,
+        ui_visible: true,
+        note,
+      },
+    }));
+    assert.equal(result.ok, false, name);
+    assert.match(result.errors.join(" "), /absolute path/, name);
+  }
+});
+
+test("sampleStoragePeaks reports one sample as current snapshot", async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "sync-validation-"));
+  const transportRoot = path.join(root, "transport");
+  const stagingRoot = path.join(root, "staging");
+  mkdirSync(transportRoot, { recursive: true });
+  mkdirSync(path.join(transportRoot, "nested"), { recursive: true });
+  mkdirSync(stagingRoot, { recursive: true });
+  writeFileSync(path.join(transportRoot, "a.bin"), Buffer.alloc(3));
+  writeFileSync(path.join(transportRoot, "nested", "b.bin"), Buffer.alloc(5));
+  writeFileSync(path.join(stagingRoot, "c.bin"), Buffer.alloc(7));
+
+  try {
+    const result = await sampleStoragePeaks({ transportRoot, stagingRoot });
+    assert.equal(result.mode, "sampled");
+    assert.equal(result.storage.transport.currentBytes, 8);
+    assert.equal(result.storage.staging.currentBytes, 7);
+    assert.equal(result.storage.combined.peakBytes, 15);
+    assert.equal(result.sampleCount, 1);
+    assert.equal(result.peakSemantics, "current_snapshot_not_run_peak");
+    assert.equal(result.samples.length, 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("sampleStoragePeaks tracks peak across repeated samples", async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "sync-validation-"));
+  const transportRoot = path.join(root, "transport");
+  const stagingRoot = path.join(root, "staging");
+  mkdirSync(transportRoot, { recursive: true });
+  mkdirSync(stagingRoot, { recursive: true });
+  writeFileSync(path.join(transportRoot, "a.bin"), Buffer.alloc(3));
+  writeFileSync(path.join(stagingRoot, "b.bin"), Buffer.alloc(5));
+
+  const addPeakFile = setTimeout(() => {
+    writeFileSync(path.join(stagingRoot, "peak.bin"), Buffer.alloc(11));
+  }, 1);
+  try {
+    const result = await sampleStoragePeaks({
+      transportRoot,
+      stagingRoot,
+      samples: 2,
+      intervalMs: 10,
+    });
+    clearTimeout(addPeakFile);
+    assert.equal(result.mode, "sampled");
+    assert.equal(result.sampleCount, 2);
+    assert.equal(result.intervalMs, 10);
+    assert.equal(result.peakSemantics, "max_observed_across_samples");
+    assert.equal(result.samples.length, 2);
+    assert.equal(result.storage.staging.currentBytes, 16);
+    assert.equal(result.storage.staging.peakBytes, 16);
+    assert.equal(result.storage.combined.peakBytes, 19);
+  } finally {
+    clearTimeout(addPeakFile);
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("compareEvidence compares candidate against Syncthing-like control without dependency", () => {
+  const candidate = makeEvidence({
+    source: "tuneforge-sync+iroh",
+    metrics: {
+      network_receive_throughput_bytes_per_second: 2_400_000,
+      backend_staging_throughput_bytes_per_second: 1_700_000,
+      reconciliation_apply_ms: 280,
+      project_imports_per_minute: 14,
+      project_availability_gap_ms: 4_000,
+      ttfa_ms: 800,
+      transfer_counts: {
+        requested: 8,
+        received: 8,
+        skipped: 0,
+        already_staged: 0,
+        failed: 0,
+        retried: 0,
+      },
+    },
+  });
+  const control = makeEvidence({
+    source: "syncthing-control",
+    metrics: {
+      network_receive_throughput_bytes_per_second: 2_100_000,
+      backend_staging_throughput_bytes_per_second: 1_600_000,
+      reconciliation_apply_ms: 400,
+      project_imports_per_minute: 11,
+      project_availability_gap_ms: 6_000,
+      ttfa_ms: 1_100,
+      transfer_counts: {
+        requested: 8,
+        received: 8,
+        skipped: 0,
+        already_staged: 0,
+        failed: 0,
+        retried: 0,
+      },
+    },
+  });
+
+  const result = compareEvidence(candidate, control);
+  assert.equal(result.ok, true);
+  assert.equal(result.comparison.overall, "candidate");
+  assert.equal(result.control.source, "syncthing-control");
+  assert.equal(result.comparison.metrics.find((entry) => entry.metric === "ttfaMs")?.winner, "candidate");
+});


### PR DESCRIPTION
## Summary

- Add privacy-safe sync evidence export and copy/save actions in the Activity sync panel.
- Add `pnpm sync:validate` with evidence validation, summaries, Syncthing comparison, and storage peak sampling.
- Document sync validation evidence, mobile checklist, and Syncthing control expectations.

Closes #203

## Testing

- `node --test scripts/sync-validation.test.mjs`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
