### PR TITLE
feat(sync): harden sync lifecycle handling

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -62,7 +62,8 @@ fn write_settings_snapshot_file(path: String, contents: String) -> Result<(), St
 
 #[tauri::command]
 fn write_sync_evidence_file(path: String, contents: String) -> Result<(), String> {
-    fs::write(&path, contents).map_err(|error| format!("Could not write sync evidence file: {error}"))
+    fs::write(&path, contents)
+        .map_err(|error| format!("Could not write sync evidence file: {error}"))
 }
 
 #[cfg(not(target_os = "android"))]
@@ -385,6 +386,7 @@ pub fn run() {
             sync_transport::sync_transport_start_listener,
             sync_transport::sync_transport_stop_listener,
             sync_transport::sync_transport_status,
+            sync_transport::sync_transport_record_lifecycle_event,
             sync_transport::sync_transport_create_pairing_offer,
             sync_transport::sync_transport_sync_now,
             mobile_backend::mobile_capabilities,

--- a/apps/desktop/src-tauri/src/sync_transport.rs
+++ b/apps/desktop/src-tauri/src/sync_transport.rs
@@ -32,6 +32,27 @@ pub struct SyncTransportPairingOfferRequest {
     pub ttl_seconds: Option<u32>,
 }
 
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncTransportLifecycleEventRequest {
+    pub kind: String,
+    pub occurred_at: Option<String>,
+    pub message: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncTransportLifecycleEvent {
+    pub kind: String,
+    pub occurred_at: String,
+    pub message: Option<String>,
+    pub retryable: bool,
+    pub interruption_code: Option<String>,
+    pub retry_guidance: Option<String>,
+    pub peer_device_id: Option<String>,
+    pub run_id: Option<String>,
+}
+
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SyncTransportNearbyPeer {
@@ -62,6 +83,11 @@ pub struct SyncTransportStatus {
     pub last_error: Option<String>,
     pub last_sync: Option<SyncTransportSyncResult>,
     pub active_progress: Option<SyncTransportActiveProgress>,
+    pub last_lifecycle_event: Option<SyncTransportLifecycleEvent>,
+    pub lifecycle_events: Vec<SyncTransportLifecycleEvent>,
+    pub retryable_interruption_code: Option<String>,
+    pub retryable_interruption_peer_device_id: Option<String>,
+    pub retry_guidance: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -361,6 +387,9 @@ pub struct SyncTransportSyncResult {
     pub remote_manifest_count: usize,
     pub local_manifest_count: usize,
     pub manifest_errors: Vec<SyncTransportManifestError>,
+    pub lifecycle_events: Vec<SyncTransportLifecycleEvent>,
+    pub retryable_interruption_code: Option<String>,
+    pub retry_guidance: Option<String>,
     pub phase_timings: Vec<SyncTransportTimingEvidence>,
     #[serde(flatten)]
     pub diagnostics: SyncTransportDiagnostics,
@@ -385,7 +414,7 @@ mod sync_core {
     use serde::{Deserialize, Serialize};
     use serde_json::{json, Value};
     use sha2::{Digest, Sha256};
-    use std::{io, time::Duration};
+    use std::{io, net::TcpStream, sync::Arc, time::Duration};
 
     pub(crate) const TCP_TRANSPORT_ID: &str = "tuneforge-sync+tcp";
     pub(crate) const IROH_TRANSPORT_ID: &str = "tuneforge-sync+iroh";
@@ -986,6 +1015,9 @@ mod sync_core {
         fn read_exact(&mut self, buffer: &mut [u8]) -> io::Result<()>;
         fn write_all(&mut self, buffer: &[u8]) -> io::Result<()>;
         fn set_read_timeout(&mut self, timeout: Duration) -> io::Result<()>;
+        fn tcp_abort_stream(&self) -> Option<Arc<TcpStream>> {
+            None
+        }
     }
 
     pub(crate) trait ProtocolConnection {
@@ -1549,6 +1581,7 @@ mod sync_core {
 mod desktop {
     use super::{
         sync_core::*, SyncTransportActiveProgress, SyncTransportDiagnostics,
+        SyncTransportLifecycleEvent, SyncTransportLifecycleEventRequest,
         SyncTransportManifestError, SyncTransportNearbyPeer, SyncTransportPairingOffer,
         SyncTransportPairingOfferRequest, SyncTransportProjectResult,
         SyncTransportStartListenerRequest, SyncTransportStatus, SyncTransportSyncNowRequest,
@@ -1575,8 +1608,8 @@ mod desktop {
         fs::{self, File},
         io::{self, Read, Write},
         net::{
-            IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, TcpStream, ToSocketAddrs,
-            UdpSocket,
+            IpAddr, Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr, TcpListener, TcpStream,
+            ToSocketAddrs, UdpSocket,
         },
         path::{Path, PathBuf},
         process,
@@ -1630,6 +1663,13 @@ mod desktop {
     const BACKEND_PREFLIGHT_UNRESPONSIVE_MESSAGE: &str = "Local backend is unresponsive during sync preflight. Wait for backend work to finish or restart TuneForge, then retry sync.";
     const BACKEND_BUSY_RETRY_GUIDANCE: &str =
         "Wait for those jobs to finish or cancel them, then retry sync.";
+    const LIFECYCLE_EVENT_HISTORY_LIMIT: usize = 20;
+    const LIFECYCLE_INTERRUPTION_DEFAULT_GUIDANCE: &str =
+        "Restore the device state, then retry sync.";
+    const LIFECYCLE_INTERRUPTION_NETWORK_GUIDANCE: &str =
+        "Restore network connectivity, then retry sync.";
+    const LIFECYCLE_INTERRUPTION_FOREGROUND_GUIDANCE: &str =
+        "Bring TuneForge back to the foreground, then retry sync.";
     #[cfg(not(target_os = "android"))]
     const HTTP_TIMEOUT: Duration = Duration::from_secs(45);
     #[cfg(not(target_os = "android"))]
@@ -1771,6 +1811,7 @@ mod desktop {
                 status.last_sync = None;
                 status.active_progress = None;
                 status.active_progress_owner_run_id = None;
+                clear_retryable_interruption(status);
             });
 
             Ok(self.status())
@@ -1848,7 +1889,31 @@ mod desktop {
                 last_error: shared.last_error,
                 last_sync: shared.last_sync,
                 active_progress: shared.active_progress,
+                last_lifecycle_event: shared.last_lifecycle_event,
+                lifecycle_events: shared.lifecycle_events,
+                retryable_interruption_code: shared.retryable_interruption_code,
+                retryable_interruption_peer_device_id: shared.retryable_interruption_peer_device_id,
+                retry_guidance: shared.retry_guidance,
             }
+        }
+
+        fn record_lifecycle_event(
+            &self,
+            payload: SyncTransportLifecycleEventRequest,
+        ) -> SyncTransportStatus {
+            let outcome = self
+                .shared_status
+                .lock()
+                .map(|mut status| record_lifecycle_event_in_status(&mut status, payload))
+                .unwrap_or_else(|_| LifecycleRecordOutcome::default());
+
+            if outcome.refresh_endpoint_hints {
+                self.refresh_listener_endpoint_hints();
+            }
+
+            interrupt_active_runs_for_lifecycle(&outcome.event, outcome.interrupted_runs);
+
+            self.status()
         }
 
         fn create_pairing_offer(
@@ -1878,7 +1943,12 @@ mod desktop {
             payload: SyncTransportSyncNowRequest,
         ) -> Result<SyncTransportSyncResult, String> {
             let run_id = sync_run_id();
-            let result = self.run_sync_now(payload, run_id.clone());
+            let run_cancel = register_active_run(
+                &self.shared_status,
+                &run_id,
+                Some(payload.peer_device_id.clone()),
+            );
+            let result = self.run_sync_now(payload, run_id.clone(), run_cancel);
             update_status(&self.shared_status, |status| {
                 apply_sync_now_status_result(status, &result, &run_id);
             });
@@ -1889,9 +1959,11 @@ mod desktop {
             &self,
             payload: SyncTransportSyncNowRequest,
             run_id: String,
+            run_cancel: RunCancellationToken,
         ) -> Result<SyncTransportSyncResult, String> {
             let run_started_at = Utc::now();
             let run_started_instant = Instant::now();
+            let requested_peer_device_id = payload.peer_device_id.clone();
             record_active_progress(
                 &self.shared_status,
                 &run_id,
@@ -1905,10 +1977,46 @@ mod desktop {
             );
             let mut timings = Vec::new();
             let mut metrics = SyncRunMetrics::start(run_started_instant);
+            if let Some(interruption) = run_cancel.interruption() {
+                let lifecycle_events =
+                    lifecycle_events_for_interruption(&self.shared_status, &run_id, &interruption);
+                return Ok(lifecycle_interrupted_sync_result(
+                    run_id.clone(),
+                    requested_peer_device_id.clone(),
+                    requested_peer_device_id,
+                    NOT_STARTED_TRANSPORT_ID.to_string(),
+                    Vec::new(),
+                    interruption,
+                    lifecycle_events,
+                    run_started_at,
+                    run_started_instant,
+                    Vec::new(),
+                    0,
+                    metrics,
+                    timings,
+                ));
+            }
             let client = BackendClient::new(&self.backend)?;
             let preflight = match client.sync_preflight() {
                 Ok(preflight) => preflight,
                 Err(_) => {
+                    if let Some(result) = lifecycle_interrupted_sync_result_for_run(
+                        &self.shared_status,
+                        &run_cancel,
+                        &run_id,
+                        &requested_peer_device_id,
+                        &requested_peer_device_id,
+                        NOT_STARTED_TRANSPORT_ID,
+                        Vec::new(),
+                        &run_started_at,
+                        run_started_instant,
+                        &[],
+                        0,
+                        &metrics,
+                        &timings,
+                    ) {
+                        return Ok(result);
+                    }
                     return Ok(failed_preflight_sync_result(
                         run_id,
                         payload.peer_device_id,
@@ -1920,6 +2028,23 @@ mod desktop {
                 }
             };
             if let Some(failure) = sync_preflight_failure(&preflight) {
+                if let Some(result) = lifecycle_interrupted_sync_result_for_run(
+                    &self.shared_status,
+                    &run_cancel,
+                    &run_id,
+                    &requested_peer_device_id,
+                    &requested_peer_device_id,
+                    NOT_STARTED_TRANSPORT_ID,
+                    Vec::new(),
+                    &run_started_at,
+                    run_started_instant,
+                    &[],
+                    0,
+                    &metrics,
+                    &timings,
+                ) {
+                    return Ok(result);
+                }
                 return Ok(failed_preflight_sync_result(
                     run_id,
                     payload.peer_device_id,
@@ -1931,6 +2056,23 @@ mod desktop {
             }
             if client.sync_metadata_preflight_probe().is_err() {
                 let failure = sync_endpoint_unresponsive_failure(&preflight);
+                if let Some(result) = lifecycle_interrupted_sync_result_for_run(
+                    &self.shared_status,
+                    &run_cancel,
+                    &run_id,
+                    &requested_peer_device_id,
+                    &requested_peer_device_id,
+                    NOT_STARTED_TRANSPORT_ID,
+                    Vec::new(),
+                    &run_started_at,
+                    run_started_instant,
+                    &[],
+                    0,
+                    &metrics,
+                    &timings,
+                ) {
+                    return Ok(result);
+                }
                 return Ok(failed_preflight_sync_result(
                     run_id,
                     payload.peer_device_id,
@@ -1979,31 +2121,110 @@ mod desktop {
             )?;
             let mut transport_selection = transport_selection;
             let timer = SyncPhaseTimer::start("peer_connect");
-            let mut connection = connect_selected_transport(
+            let mut connection = match connect_selected_transport(
                 &mut transport_selection,
                 local_iroh,
                 &payload.peer_device_id,
-            )?;
+            ) {
+                Ok(connection) => connection,
+                Err(error) => {
+                    let TransportEvidence {
+                        selected_transport,
+                        attempted_transports,
+                        ..
+                    } = transport_selection.evidence();
+                    if let Some(result) = lifecycle_interrupted_sync_result_for_run(
+                        &self.shared_status,
+                        &run_cancel,
+                        &run_id,
+                        &requested_peer_device_id,
+                        &requested_peer_device_id,
+                        &selected_transport,
+                        attempted_transports,
+                        &run_started_at,
+                        run_started_instant,
+                        &[],
+                        0,
+                        &metrics,
+                        &timings,
+                    ) {
+                        return Ok(result);
+                    }
+                    return Err(error);
+                }
+            };
             timings.push(timer.finish());
 
             let timer = SyncPhaseTimer::start("peer_authentication");
             let local_endpoint_hints = self.current_endpoint_hints();
-            let session = authenticate_session(
+            let session = match authenticate_session(
                 &mut connection,
                 &client,
                 Some(payload.peer_device_id.clone()),
                 &local_endpoint_hints,
             )
-            .map_err(|error| phase_context_error("peer authentication", error))?;
+            .map_err(|error| phase_context_error("peer authentication", error))
+            {
+                Ok(session) => session,
+                Err(error) => {
+                    let TransportEvidence {
+                        selected_transport,
+                        attempted_transports,
+                        ..
+                    } = transport_selection.evidence();
+                    if let Some(result) = lifecycle_interrupted_sync_result_for_run(
+                        &self.shared_status,
+                        &run_cancel,
+                        &run_id,
+                        &requested_peer_device_id,
+                        &requested_peer_device_id,
+                        &selected_transport,
+                        attempted_transports,
+                        &run_started_at,
+                        run_started_instant,
+                        &[],
+                        0,
+                        &metrics,
+                        &timings,
+                    ) {
+                        return Ok(result);
+                    }
+                    return Err(error);
+                }
+            };
             connection.set_established_read_timeout()?;
             timings.push(timer.finish());
             let connection = SharedPeerConnection::new(connection);
+            attach_active_run_connection(&self.shared_status, &run_id, connection.clone());
             let progress = ProgressReporter::new(
                 run_id.clone(),
                 run_started_instant,
                 Arc::clone(&self.shared_status),
                 connection.clone(),
+                run_cancel.clone(),
             );
+            let TransportEvidence {
+                selected_transport: current_transport,
+                attempted_transports: current_attempted_transports,
+                ..
+            } = transport_selection.evidence();
+            if let Some(result) = lifecycle_interrupted_sync_result_for_run(
+                &self.shared_status,
+                &run_cancel,
+                &run_id,
+                &requested_peer_device_id,
+                &session.remote_device_id,
+                &current_transport,
+                current_attempted_transports,
+                &run_started_at,
+                run_started_instant,
+                &[],
+                0,
+                &metrics,
+                &timings,
+            ) {
+                return Ok(result);
+            }
             let mut refreshed_endpoint_hints_after_auth = false;
             if authenticated_hints_make_trusted_iroh_hint_stale(
                 &peer.endpoint_hints,
@@ -2031,13 +2252,65 @@ mod desktop {
             timings.push(timer.finish());
             let local_manifest_count = local_offer.project_manifests.len();
             let timer = SyncPhaseTimer::start("manifest_exchange");
-            connection.send_message_for_phase(
+            if let Err(error) = connection.send_message_for_phase(
                 "manifest exchange",
                 &ProtocolMessage::ManifestOffer(local_offer.clone()),
-            )?;
-            let remote_offer = match connection
-                .read_message_accepting_status_for_phase("manifest exchange", &progress)?
+            ) {
+                let TransportEvidence {
+                    selected_transport,
+                    attempted_transports,
+                    ..
+                } = transport_selection.evidence();
+                if let Some(result) = lifecycle_interrupted_sync_result_for_run(
+                    &self.shared_status,
+                    &run_cancel,
+                    &run_id,
+                    &requested_peer_device_id,
+                    &session.remote_device_id,
+                    &selected_transport,
+                    attempted_transports,
+                    &run_started_at,
+                    run_started_instant,
+                    &[],
+                    0,
+                    &metrics,
+                    &timings,
+                ) {
+                    return Ok(result);
+                }
+                return Err(error);
+            }
+            let remote_message = match connection
+                .read_message_accepting_status_for_phase("manifest exchange", &progress)
             {
+                Ok(message) => message,
+                Err(error) => {
+                    let TransportEvidence {
+                        selected_transport,
+                        attempted_transports,
+                        ..
+                    } = transport_selection.evidence();
+                    if let Some(result) = lifecycle_interrupted_sync_result_for_run(
+                        &self.shared_status,
+                        &run_cancel,
+                        &run_id,
+                        &requested_peer_device_id,
+                        &session.remote_device_id,
+                        &selected_transport,
+                        attempted_transports,
+                        &run_started_at,
+                        run_started_instant,
+                        &[],
+                        0,
+                        &metrics,
+                        &timings,
+                    ) {
+                        return Ok(result);
+                    }
+                    return Err(error);
+                }
+            };
+            let remote_offer = match remote_message {
                 ProtocolMessage::ManifestOffer(offer) => offer,
                 ProtocolMessage::Error(error) => {
                     return Err(phase_context_error(
@@ -2072,6 +2345,31 @@ mod desktop {
                 received_artifacts = prepared.received_artifacts.clone();
                 prepared_remote_import = Some(prepared);
             }
+            if let Some(interruption) = run_cancel.interruption() {
+                finish_staged_remote_import_for_failure(prepared_remote_import);
+                let TransportEvidence {
+                    selected_transport,
+                    attempted_transports,
+                    ..
+                } = transport_selection.evidence();
+                let lifecycle_events =
+                    lifecycle_events_for_interruption(&self.shared_status, &run_id, &interruption);
+                return Ok(lifecycle_interrupted_sync_result(
+                    run_id.clone(),
+                    requested_peer_device_id,
+                    session.remote_device_id,
+                    selected_transport,
+                    attempted_transports,
+                    interruption,
+                    lifecycle_events,
+                    run_started_at,
+                    run_started_instant,
+                    received_artifacts,
+                    0,
+                    metrics,
+                    timings,
+                ));
+            }
             if let Err(error) = connection.send_message_for_phase(
                 "reconciliation staging",
                 &ProtocolMessage::PhaseDone {
@@ -2079,6 +2377,28 @@ mod desktop {
                 },
             ) {
                 finish_staged_remote_import_for_failure(prepared_remote_import);
+                let TransportEvidence {
+                    selected_transport,
+                    attempted_transports,
+                    ..
+                } = transport_selection.evidence();
+                if let Some(result) = lifecycle_interrupted_sync_result_for_run(
+                    &self.shared_status,
+                    &run_cancel,
+                    &run_id,
+                    &requested_peer_device_id,
+                    &session.remote_device_id,
+                    &selected_transport,
+                    attempted_transports,
+                    &run_started_at,
+                    run_started_instant,
+                    &received_artifacts,
+                    0,
+                    &metrics,
+                    &timings,
+                ) {
+                    return Ok(result);
+                }
                 return Err(error);
             }
             let timer = SyncPhaseTimer::start("serve_artifact_requests");
@@ -2092,10 +2412,57 @@ mod desktop {
                 Ok(served_artifact_requests) => served_artifact_requests,
                 Err(error) => {
                     finish_staged_remote_import_for_failure(prepared_remote_import);
+                    let TransportEvidence {
+                        selected_transport,
+                        attempted_transports,
+                        ..
+                    } = transport_selection.evidence();
+                    if let Some(result) = lifecycle_interrupted_sync_result_for_run(
+                        &self.shared_status,
+                        &run_cancel,
+                        &run_id,
+                        &requested_peer_device_id,
+                        &session.remote_device_id,
+                        &selected_transport,
+                        attempted_transports,
+                        &run_started_at,
+                        run_started_instant,
+                        &received_artifacts,
+                        0,
+                        &metrics,
+                        &timings,
+                    ) {
+                        return Ok(result);
+                    }
                     return Err(error);
                 }
             };
             timings.push(timer.finish());
+            if let Some(interruption) = run_cancel.interruption() {
+                finish_staged_remote_import_for_failure(prepared_remote_import);
+                let TransportEvidence {
+                    selected_transport,
+                    attempted_transports,
+                    ..
+                } = transport_selection.evidence();
+                let lifecycle_events =
+                    lifecycle_events_for_interruption(&self.shared_status, &run_id, &interruption);
+                return Ok(lifecycle_interrupted_sync_result(
+                    run_id.clone(),
+                    requested_peer_device_id,
+                    session.remote_device_id,
+                    selected_transport,
+                    attempted_transports,
+                    interruption,
+                    lifecycle_events,
+                    run_started_at,
+                    run_started_instant,
+                    received_artifacts,
+                    served_artifact_requests,
+                    metrics,
+                    timings,
+                ));
+            }
             let imported_projects = prepared_remote_import
                 .map(|prepared| finish_staged_remote_import(prepared, &mut timings))
                 .unwrap_or_default();
@@ -2159,6 +2526,9 @@ mod desktop {
                 remote_manifest_count: remote_offer.project_manifests.len(),
                 local_manifest_count,
                 manifest_errors,
+                lifecycle_events: Vec::new(),
+                retryable_interruption_code: None,
+                retry_guidance: None,
                 phase_timings: timings,
                 diagnostics: metrics.diagnostics,
             })
@@ -2178,6 +2548,56 @@ mod desktop {
                 .ok()
                 .and_then(|guard| guard.as_ref().map(|handle| handle.endpoint_hints.clone()))
                 .unwrap_or_default()
+        }
+
+        fn refresh_listener_endpoint_hints(&self) {
+            let client = match BackendClient::new(&self.backend) {
+                Ok(client) => client,
+                Err(error) => {
+                    update_status(&self.shared_status, |status| {
+                        status.last_error =
+                            Some(format!("Could not refresh sync endpoint hints: {error}"));
+                    });
+                    return;
+                }
+            };
+            let identity = match client.local_identity() {
+                Ok(identity) => identity,
+                Err(error) => {
+                    update_status(&self.shared_status, |status| {
+                        status.last_error =
+                            Some(format!("Could not refresh sync endpoint hints: {error}"));
+                    });
+                    return;
+                }
+            };
+            let refreshed = self
+                .listener
+                .lock()
+                .ok()
+                .and_then(|mut guard| {
+                    let handle = guard.as_mut()?;
+                    let mut endpoint_hints = handle
+                        .iroh_transport
+                        .as_ref()
+                        .map(|transport| iroh_endpoint_hints(transport, &identity.device_id))
+                        .unwrap_or_default();
+                    endpoint_hints.extend(endpoint_hints_for_port(
+                        handle.bind_addr.port(),
+                        &identity.device_id,
+                    ));
+                    handle.endpoint_hints = endpoint_hints;
+                    Some(())
+                })
+                .is_some();
+
+            if refreshed {
+                update_status(&self.shared_status, |status| {
+                    status.last_status =
+                        Some("Sync transport endpoint hints refreshed.".to_string());
+                    status.last_error = None;
+                });
+            }
         }
     }
 
@@ -2343,9 +2763,109 @@ mod desktop {
             remote_manifest_count: 0,
             local_manifest_count: 0,
             manifest_errors: Vec::new(),
+            lifecycle_events: Vec::new(),
+            retryable_interruption_code: None,
+            retry_guidance: None,
             phase_timings: Vec::new(),
             diagnostics: SyncTransportDiagnostics::default(),
         }
+    }
+
+    fn lifecycle_interrupted_sync_result(
+        run_id: String,
+        peer_device_id: String,
+        remote_device_id: String,
+        selected_transport: String,
+        attempted_transports: Vec<String>,
+        interruption: LifecycleInterruptionEvidence,
+        lifecycle_events: Vec<SyncTransportLifecycleEvent>,
+        run_started_at: DateTime<Utc>,
+        run_started_instant: Instant,
+        received_artifacts: Vec<SyncTransportTransferResult>,
+        served_artifact_requests: u64,
+        metrics: SyncRunMetrics,
+        phase_timings: Vec<SyncTransportTimingEvidence>,
+    ) -> SyncTransportSyncResult {
+        let completed_at = Utc::now();
+        let transfer_counts = transfer_counts(&received_artifacts);
+        SyncTransportSyncResult {
+            run_id,
+            peer_device_id,
+            remote_device_id,
+            status: "failed".to_string(),
+            message: format!(
+                "Sync interrupted by lifecycle event {}. {}",
+                interruption.event.kind, interruption.guidance
+            ),
+            selected_transport,
+            fallback_reason: None,
+            fallback_code: None,
+            attempted_transports,
+            started_at: run_started_at.to_rfc3339(),
+            completed_at: completed_at.to_rfc3339(),
+            duration_ms: duration_millis(run_started_instant.elapsed()),
+            project_results: Vec::new(),
+            imported_projects: Vec::new(),
+            imported_project_count: 0,
+            skipped_project_count: 0,
+            failed_project_count: 0,
+            received_artifacts,
+            transfer_counts,
+            served_artifact_requests,
+            total_received_bytes: metrics.total_received_bytes,
+            total_served_bytes: metrics.total_served_bytes,
+            time_to_first_artifact_ms: metrics.time_to_first_artifact_ms(),
+            throughput_bytes_per_second: metrics
+                .throughput_bytes_per_second(run_started_instant.elapsed()),
+            scratch_peak_bytes: metrics.scratch_peak_bytes,
+            staging_peak_bytes: metrics.staging_peak_bytes,
+            max_active_streams: metrics.max_active_streams,
+            credit_grants: metrics.credit_grants,
+            credit_revokes: metrics.credit_revokes,
+            remote_manifest_count: 0,
+            local_manifest_count: 0,
+            manifest_errors: Vec::new(),
+            lifecycle_events,
+            retryable_interruption_code: Some(interruption.code),
+            retry_guidance: Some(interruption.guidance),
+            phase_timings,
+            diagnostics: metrics.diagnostics,
+        }
+    }
+
+    fn lifecycle_interrupted_sync_result_for_run(
+        shared_status: &Arc<Mutex<SharedStatus>>,
+        run_cancel: &RunCancellationToken,
+        run_id: &str,
+        peer_device_id: &str,
+        remote_device_id: &str,
+        selected_transport: &str,
+        attempted_transports: Vec<String>,
+        run_started_at: &DateTime<Utc>,
+        run_started_instant: Instant,
+        received_artifacts: &[SyncTransportTransferResult],
+        served_artifact_requests: u64,
+        metrics: &SyncRunMetrics,
+        phase_timings: &[SyncTransportTimingEvidence],
+    ) -> Option<SyncTransportSyncResult> {
+        let interruption = run_cancel.interruption()?;
+        let lifecycle_events =
+            lifecycle_events_for_interruption(shared_status, run_id, &interruption);
+        Some(lifecycle_interrupted_sync_result(
+            run_id.to_string(),
+            peer_device_id.to_string(),
+            remote_device_id.to_string(),
+            selected_transport.to_string(),
+            attempted_transports,
+            interruption,
+            lifecycle_events,
+            run_started_at.clone(),
+            run_started_instant,
+            received_artifacts.to_vec(),
+            served_artifact_requests,
+            metrics.clone(),
+            phase_timings.to_vec(),
+        ))
     }
 
     fn blocking_job_state_summary(job_state: &Value) -> Option<BackendJobStateSummary> {
@@ -2644,6 +3164,13 @@ mod desktop {
         state.status()
     }
 
+    pub fn sync_transport_record_lifecycle_event(
+        state: State<'_, SyncTransportState>,
+        payload: SyncTransportLifecycleEventRequest,
+    ) -> SyncTransportStatus {
+        state.record_lifecycle_event(payload)
+    }
+
     pub async fn sync_transport_create_pairing_offer(
         state: State<'_, SyncTransportState>,
         payload: SyncTransportPairingOfferRequest,
@@ -2690,12 +3217,75 @@ mod desktop {
         active_progress: Option<SyncTransportActiveProgress>,
         active_progress_owner_run_id: Option<String>,
         nearby_peers: HashMap<String, DiscoveryPeerEntry>,
+        lifecycle_events: Vec<SyncTransportLifecycleEvent>,
+        last_lifecycle_event: Option<SyncTransportLifecycleEvent>,
+        retryable_interruption_code: Option<String>,
+        retryable_interruption_peer_device_id: Option<String>,
+        retry_guidance: Option<String>,
+        active_runs: HashMap<String, ActiveSyncRun>,
     }
 
     #[derive(Clone)]
     struct DiscoveryPeerEntry {
         peer: SyncTransportNearbyPeer,
         expires_at_instant: Instant,
+    }
+
+    #[derive(Clone)]
+    struct ActiveSyncRun {
+        peer_device_id: Option<String>,
+        cancel: RunCancellationToken,
+        connection: Option<SharedPeerConnection>,
+    }
+
+    #[derive(Clone)]
+    struct ActiveRunSnapshot {
+        run_id: String,
+        peer_device_id: Option<String>,
+        cancel: RunCancellationToken,
+        connection: Option<SharedPeerConnection>,
+    }
+
+    #[derive(Clone, Debug)]
+    struct LifecycleInterruptionEvidence {
+        code: String,
+        guidance: String,
+        event: SyncTransportLifecycleEvent,
+    }
+
+    #[derive(Clone, Default)]
+    struct RunCancellationToken {
+        cancelled: Arc<AtomicBool>,
+        interruption: Arc<Mutex<Option<LifecycleInterruptionEvidence>>>,
+    }
+
+    impl RunCancellationToken {
+        fn interrupt(&self, evidence: LifecycleInterruptionEvidence) {
+            self.cancelled.store(true, Ordering::SeqCst);
+            if let Ok(mut interruption) = self.interruption.lock() {
+                if interruption.is_none() {
+                    *interruption = Some(evidence);
+                }
+            }
+        }
+
+        fn is_cancelled(&self) -> bool {
+            self.cancelled.load(Ordering::SeqCst)
+        }
+
+        fn interruption(&self) -> Option<LifecycleInterruptionEvidence> {
+            self.interruption
+                .lock()
+                .ok()
+                .and_then(|interruption| interruption.clone())
+        }
+    }
+
+    #[derive(Default)]
+    struct LifecycleRecordOutcome {
+        event: SyncTransportLifecycleEvent,
+        interrupted_runs: Vec<ActiveRunSnapshot>,
+        refresh_endpoint_hints: bool,
     }
 
     #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2952,6 +3542,270 @@ mod desktop {
                 .then_with(|| left.device_id.cmp(&right.device_id))
         });
         peers
+    }
+
+    fn register_active_run(
+        shared_status: &Arc<Mutex<SharedStatus>>,
+        run_id: &str,
+        peer_device_id: Option<String>,
+    ) -> RunCancellationToken {
+        let cancel = RunCancellationToken::default();
+        update_status(shared_status, |status| {
+            status.active_runs.insert(
+                run_id.to_string(),
+                ActiveSyncRun {
+                    peer_device_id,
+                    cancel: cancel.clone(),
+                    connection: None,
+                },
+            );
+        });
+        cancel
+    }
+
+    fn attach_active_run_connection(
+        shared_status: &Arc<Mutex<SharedStatus>>,
+        run_id: &str,
+        connection: SharedPeerConnection,
+    ) {
+        update_status(shared_status, |status| {
+            if let Some(active_run) = status.active_runs.get_mut(run_id) {
+                active_run.connection = Some(connection);
+            }
+        });
+    }
+
+    fn update_active_run_peer(
+        shared_status: &Arc<Mutex<SharedStatus>>,
+        run_id: &str,
+        peer_device_id: String,
+    ) {
+        update_status(shared_status, |status| {
+            if let Some(active_run) = status.active_runs.get_mut(run_id) {
+                active_run.peer_device_id = Some(peer_device_id);
+            }
+        });
+    }
+
+    fn remove_active_run(status: &mut SharedStatus, run_id: &str) {
+        status.active_runs.remove(run_id);
+    }
+
+    fn active_run_snapshots(status: &SharedStatus) -> Vec<ActiveRunSnapshot> {
+        let mut runs = status
+            .active_runs
+            .iter()
+            .map(|(run_id, active_run)| ActiveRunSnapshot {
+                run_id: run_id.clone(),
+                peer_device_id: active_run.peer_device_id.clone(),
+                cancel: active_run.cancel.clone(),
+                connection: active_run.connection.clone(),
+            })
+            .collect::<Vec<_>>();
+        runs.sort_by(|left, right| left.run_id.cmp(&right.run_id));
+        runs
+    }
+
+    fn record_lifecycle_event_in_status(
+        status: &mut SharedStatus,
+        payload: SyncTransportLifecycleEventRequest,
+    ) -> LifecycleRecordOutcome {
+        let kind = normalize_lifecycle_kind(&payload.kind);
+        let active_runs = active_run_snapshots(status);
+        let first_run = active_runs.first();
+        let interruption_code = lifecycle_interruption_code(&kind).map(str::to_string);
+        let retry_guidance = interruption_code
+            .as_deref()
+            .map(|_| lifecycle_retry_guidance(&kind).to_string());
+        let event = SyncTransportLifecycleEvent {
+            kind: kind.clone(),
+            occurred_at: lifecycle_event_occurred_at(payload.occurred_at),
+            message: sanitize_lifecycle_message(payload.message),
+            retryable: interruption_code.is_some(),
+            interruption_code: interruption_code.clone(),
+            retry_guidance: retry_guidance.clone(),
+            peer_device_id: first_run.and_then(|run| run.peer_device_id.clone()),
+            run_id: first_run.map(|run| run.run_id.clone()),
+        };
+        push_lifecycle_event(status, event.clone());
+
+        if let Some(code) = interruption_code.as_ref() {
+            status.retryable_interruption_code = Some(code.clone());
+            status.retryable_interruption_peer_device_id = event.peer_device_id.clone();
+            status.retry_guidance = retry_guidance;
+        }
+
+        let refresh_endpoint_hints = lifecycle_refreshes_endpoint_hints(&kind);
+        if interruption_code.is_none() && refresh_endpoint_hints {
+            clear_retryable_interruption(status);
+        }
+        if refresh_endpoint_hints {
+            status.nearby_peers.clear();
+        }
+
+        LifecycleRecordOutcome {
+            event,
+            interrupted_runs: if lifecycle_interruption_code(&kind).is_some() {
+                active_runs
+            } else {
+                Vec::new()
+            },
+            refresh_endpoint_hints,
+        }
+    }
+
+    fn lifecycle_event_for_active_run(
+        event: &SyncTransportLifecycleEvent,
+        active_run: &ActiveRunSnapshot,
+    ) -> SyncTransportLifecycleEvent {
+        let mut event = event.clone();
+        event.peer_device_id = active_run.peer_device_id.clone();
+        event.run_id = Some(active_run.run_id.clone());
+        event
+    }
+
+    fn interrupt_active_runs_for_lifecycle(
+        event: &SyncTransportLifecycleEvent,
+        active_runs: Vec<ActiveRunSnapshot>,
+    ) {
+        for active_run in active_runs {
+            let event = lifecycle_event_for_active_run(event, &active_run);
+            active_run.cancel.interrupt(LifecycleInterruptionEvidence {
+                code: event
+                    .interruption_code
+                    .clone()
+                    .unwrap_or_else(|| "lifecycle_interrupted".to_string()),
+                guidance: event
+                    .retry_guidance
+                    .clone()
+                    .unwrap_or_else(|| LIFECYCLE_INTERRUPTION_DEFAULT_GUIDANCE.to_string()),
+                event,
+            });
+            if let Some(connection) = active_run.connection {
+                connection.abort_for_lifecycle_interruption();
+            }
+        }
+    }
+
+    fn push_lifecycle_event(status: &mut SharedStatus, event: SyncTransportLifecycleEvent) {
+        status.lifecycle_events.push(event.clone());
+        let overflow = status
+            .lifecycle_events
+            .len()
+            .saturating_sub(LIFECYCLE_EVENT_HISTORY_LIMIT);
+        if overflow > 0 {
+            status.lifecycle_events.drain(0..overflow);
+        }
+        status.last_lifecycle_event = Some(event);
+    }
+
+    fn normalize_lifecycle_kind(kind: &str) -> String {
+        kind.trim()
+            .chars()
+            .map(|ch| {
+                if ch.is_ascii_alphanumeric() {
+                    ch.to_ascii_lowercase()
+                } else {
+                    '_'
+                }
+            })
+            .collect::<String>()
+            .split('_')
+            .filter(|part| !part.is_empty())
+            .collect::<Vec<_>>()
+            .join("_")
+    }
+
+    fn lifecycle_event_occurred_at(occurred_at: Option<String>) -> String {
+        occurred_at
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| Utc::now().to_rfc3339())
+    }
+
+    fn sanitize_lifecycle_message(message: Option<String>) -> Option<String> {
+        let message = message?.trim().to_string();
+        if message.is_empty()
+            || message.len() > 240
+            || message.contains('/')
+            || message.contains('\\')
+            || message.contains("://")
+            || message.contains("tuneforge-sync+")
+        {
+            return None;
+        }
+        Some(message)
+    }
+
+    fn lifecycle_interruption_code(kind: &str) -> Option<&'static str> {
+        match kind {
+            "sleep" => Some("lifecycle_interrupted_sleep"),
+            "network_offline" | "networkoffline" => Some("lifecycle_interrupted_network_offline"),
+            "android_background" | "androidbackground" => {
+                Some("lifecycle_interrupted_android_background")
+            }
+            "android_screen_lock" | "androidscreenlock" => {
+                Some("lifecycle_interrupted_android_screen_lock")
+            }
+            _ => None,
+        }
+    }
+
+    fn lifecycle_retry_guidance(kind: &str) -> &'static str {
+        match kind {
+            "network_offline" | "networkoffline" => LIFECYCLE_INTERRUPTION_NETWORK_GUIDANCE,
+            "android_background"
+            | "androidbackground"
+            | "android_screen_lock"
+            | "androidscreenlock" => LIFECYCLE_INTERRUPTION_FOREGROUND_GUIDANCE,
+            _ => LIFECYCLE_INTERRUPTION_DEFAULT_GUIDANCE,
+        }
+    }
+
+    fn lifecycle_refreshes_endpoint_hints(kind: &str) -> bool {
+        matches!(
+            kind,
+            "wake"
+                | "network_online"
+                | "networkonline"
+                | "foreground"
+                | "android_foreground"
+                | "androidforeground"
+        )
+    }
+
+    fn lifecycle_events_for_run(
+        shared_status: &Arc<Mutex<SharedStatus>>,
+        run_id: &str,
+    ) -> Vec<SyncTransportLifecycleEvent> {
+        shared_status
+            .lock()
+            .map(|status| {
+                status
+                    .lifecycle_events
+                    .iter()
+                    .filter(|event| event.run_id.as_deref().is_none_or(|id| id == run_id))
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn lifecycle_events_for_interruption(
+        shared_status: &Arc<Mutex<SharedStatus>>,
+        run_id: &str,
+        interruption: &LifecycleInterruptionEvidence,
+    ) -> Vec<SyncTransportLifecycleEvent> {
+        let mut events = lifecycle_events_for_run(shared_status, run_id);
+        let has_interruption = events.iter().any(|event| {
+            event.run_id == interruption.event.run_id
+                && event.kind == interruption.event.kind
+                && event.occurred_at == interruption.event.occurred_at
+        });
+        if !has_interruption {
+            events.push(interruption.event.clone());
+        }
+        events
     }
 
     #[derive(Clone)]
@@ -3434,6 +4288,7 @@ mod desktop {
         let run_id = sync_run_id();
         let run_started_at = Utc::now();
         let run_started_instant = Instant::now();
+        let run_cancel = register_active_run(&shared_status, &run_id, None);
         record_active_progress(
             &shared_status,
             &run_id,
@@ -3448,6 +4303,7 @@ mod desktop {
         update_status(&shared_status, |status| {
             status.active_sessions += 1;
         });
+        let transport_for_result = transport.clone();
         let result = serve_incoming_session(
             backend,
             transport,
@@ -3456,16 +4312,51 @@ mod desktop {
             endpoint_hints,
             Arc::clone(&shared_status),
             run_id.clone(),
+            run_cancel.clone(),
             run_started_at,
             run_started_instant,
         );
+        let result = match (result, run_cancel.interruption()) {
+            (Err(_), Some(interruption)) => {
+                let peer_device_id = interruption
+                    .event
+                    .peer_device_id
+                    .clone()
+                    .unwrap_or_else(|| "unknown".to_string());
+                let sync_result = lifecycle_interrupted_sync_result(
+                    run_id.clone(),
+                    peer_device_id.clone(),
+                    peer_device_id.clone(),
+                    transport_for_result.id().to_string(),
+                    vec![transport_for_result.id().to_string()],
+                    interruption,
+                    lifecycle_events_for_run(&shared_status, &run_id),
+                    run_started_at,
+                    run_started_instant,
+                    Vec::new(),
+                    0,
+                    SyncRunMetrics::start(run_started_instant),
+                    Vec::new(),
+                );
+                Ok(IncomingSessionResult {
+                    message: sync_result.message.clone(),
+                    sync_result,
+                })
+            }
+            (result, _) => result,
+        };
         update_status(&shared_status, |status| {
             status.active_sessions = status.active_sessions.saturating_sub(1);
+            remove_active_run(status, &run_id);
             clear_active_progress_for_run(status, &run_id);
             match result {
                 Ok(result) => {
                     status.last_status = Some(result.message);
-                    status.last_sync = Some(result.sync_result);
+                    let sync_result = result.sync_result;
+                    if !sync_result_has_retryable_interruption(&sync_result) {
+                        clear_retryable_interruption(status);
+                    }
+                    status.last_sync = Some(sync_result);
                     status.last_error = None;
                 }
                 Err(error) => {
@@ -3484,6 +4375,7 @@ mod desktop {
         endpoint_hints: Vec<String>,
         shared_status: Arc<Mutex<SharedStatus>>,
         run_id: String,
+        run_cancel: RunCancellationToken,
         run_started_at: DateTime<Utc>,
         run_started_instant: Instant,
     ) -> Result<IncomingSessionResult, String> {
@@ -3494,14 +4386,17 @@ mod desktop {
         let mut connection = SecurePeerConnection::connect_responder(stream, transport, iroh_data)?;
         let session = authenticate_session(&mut connection, &client, None, &endpoint_hints)
             .map_err(|error| phase_context_error("peer authentication", error))?;
+        update_active_run_peer(&shared_status, &run_id, session.remote_device_id.clone());
         connection.set_established_read_timeout()?;
         timings.push(timer.finish());
         let connection = SharedPeerConnection::new(connection);
+        attach_active_run_connection(&shared_status, &run_id, connection.clone());
         let progress = ProgressReporter::new(
             run_id.clone(),
             run_started_instant,
             shared_status,
             connection.clone(),
+            run_cancel.clone(),
         );
         let timer = SyncPhaseTimer::start("manifest_exchange");
         let remote_offer = match connection
@@ -3634,6 +4529,9 @@ mod desktop {
             remote_manifest_count: remote_offer.project_manifests.len(),
             local_manifest_count,
             manifest_errors,
+            lifecycle_events: Vec::new(),
+            retryable_interruption_code: None,
+            retry_guidance: None,
             phase_timings: timings,
             diagnostics: metrics.diagnostics,
         };
@@ -3771,6 +4669,20 @@ mod desktop {
         }
     }
 
+    fn clear_retryable_interruption(status: &mut SharedStatus) {
+        status.retryable_interruption_code = None;
+        status.retryable_interruption_peer_device_id = None;
+        status.retry_guidance = None;
+    }
+
+    fn sync_result_has_retryable_interruption(sync_result: &SyncTransportSyncResult) -> bool {
+        sync_result.retryable_interruption_code.is_some()
+            || sync_result
+                .lifecycle_events
+                .iter()
+                .any(|event| event.retryable)
+    }
+
     fn apply_sync_now_status_result(
         status: &mut SharedStatus,
         result: &Result<SyncTransportSyncResult, String>,
@@ -3781,10 +4693,15 @@ mod desktop {
                 status.last_status = Some(sync_result.message.clone());
                 status.last_sync = Some(sync_result.clone());
                 status.last_error = None;
+                if !sync_result_has_retryable_interruption(sync_result) {
+                    clear_retryable_interruption(status);
+                }
+                remove_active_run(status, &sync_result.run_id);
                 clear_active_progress_for_run(status, &sync_result.run_id);
             }
             Err(error) => {
                 status.last_error = Some(error.clone());
+                remove_active_run(status, run_id);
                 clear_active_progress_for_run(status, run_id);
             }
         }
@@ -3796,6 +4713,7 @@ mod desktop {
         run_started_instant: Instant,
         shared_status: Arc<Mutex<SharedStatus>>,
         connection: SharedPeerConnection,
+        cancel: RunCancellationToken,
     }
 
     impl ProgressReporter {
@@ -3804,12 +4722,14 @@ mod desktop {
             run_started_instant: Instant,
             shared_status: Arc<Mutex<SharedStatus>>,
             connection: SharedPeerConnection,
+            cancel: RunCancellationToken,
         ) -> Self {
             Self {
                 run_id,
                 run_started_instant,
                 shared_status,
                 connection,
+                cancel,
             }
         }
 
@@ -3879,6 +4799,34 @@ mod desktop {
 
         fn record_peer_status(&self, status: ProtocolStatusPayload) {
             record_active_progress(&self.shared_status, &self.run_id, active_progress(status));
+        }
+
+        fn is_cancelled(&self) -> bool {
+            self.cancel.is_cancelled()
+        }
+
+        fn interruption(&self) -> Option<LifecycleInterruptionEvidence> {
+            self.cancel.interruption()
+        }
+
+        fn interruption_message(&self) -> Option<String> {
+            self.interruption().map(|interruption| {
+                format!(
+                    "Sync interrupted by lifecycle event {}. {}",
+                    interruption.event.kind, interruption.guidance
+                )
+            })
+        }
+
+        fn check_not_cancelled(&self) -> Result<(), String> {
+            match self.interruption_message() {
+                Some(message) => Err(message),
+                None => Ok(()),
+            }
+        }
+
+        fn cancel_token(&self) -> RunCancellationToken {
+            self.cancel.clone()
         }
     }
 
@@ -4091,12 +5039,17 @@ mod desktop {
 
     struct TcpPeerStream {
         stream: TcpStream,
+        abort_stream: Option<Arc<TcpStream>>,
     }
 
     impl TcpPeerStream {
         fn new(stream: TcpStream) -> Result<Self, String> {
             configure_stream(&stream)?;
-            Ok(Self { stream })
+            let abort_stream = stream.try_clone().ok().map(Arc::new);
+            Ok(Self {
+                stream,
+                abort_stream,
+            })
         }
     }
 
@@ -4111,6 +5064,10 @@ mod desktop {
 
         fn set_read_timeout(&mut self, timeout: Duration) -> io::Result<()> {
             self.stream.set_read_timeout(Some(timeout))
+        }
+
+        fn tcp_abort_stream(&self) -> Option<Arc<TcpStream>> {
+            self.abort_stream.clone()
         }
     }
 
@@ -4458,16 +5415,50 @@ mod desktop {
         }
     }
 
+    #[derive(Clone, Default)]
+    struct ConnectionAbortHandle {
+        tcp_stream: Option<Arc<TcpStream>>,
+        iroh_connection: Option<Connection>,
+    }
+
+    impl ConnectionAbortHandle {
+        fn from_connection(connection: &SecurePeerConnection) -> Self {
+            Self {
+                tcp_stream: connection.stream.tcp_abort_stream(),
+                iroh_connection: connection
+                    .iroh_data
+                    .as_ref()
+                    .map(|iroh_data| iroh_data.connection.clone()),
+            }
+        }
+
+        fn abort(&self) {
+            if let Some(stream) = &self.tcp_stream {
+                let _ = stream.shutdown(Shutdown::Both);
+            }
+            if let Some(connection) = &self.iroh_connection {
+                connection.close(VarInt::from_u32(0), b"lifecycle interrupted");
+            }
+        }
+    }
+
     #[derive(Clone)]
     struct SharedPeerConnection {
         inner: Arc<Mutex<SecurePeerConnection>>,
+        abort_handle: ConnectionAbortHandle,
     }
 
     impl SharedPeerConnection {
         fn new(connection: SecurePeerConnection) -> Self {
+            let abort_handle = ConnectionAbortHandle::from_connection(&connection);
             Self {
                 inner: Arc::new(Mutex::new(connection)),
+                abort_handle,
             }
+        }
+
+        fn abort_for_lifecycle_interruption(&self) {
+            self.abort_handle.abort();
         }
 
         fn with_connection<T>(
@@ -4941,6 +5932,14 @@ mod desktop {
             transport_id,
             progress.clone(),
         );
+        if progress.is_cancelled() {
+            apply_worker.cancel_pending_apply();
+            return StagedRemoteImport {
+                plan_failures: Vec::new(),
+                apply_worker: Some(apply_worker),
+                received_artifacts,
+            };
+        }
         let (planned_projects, plan_failures) =
             plan_remote_manifest_projects(manifests, remote_metadata, |request| {
                 let project_ids = request.project_ids();
@@ -5043,6 +6042,10 @@ mod desktop {
         progress: &ProgressReporter,
     ) {
         for planned in planned_projects {
+            if progress.is_cancelled() {
+                apply_worker.cancel_pending_apply();
+                break;
+            }
             match planned.manifest {
                 Some(manifest) => {
                     let staged = stage_remote_manifest_project_artifacts(
@@ -5250,14 +6253,30 @@ mod desktop {
                                 let mut stage_timings = Vec::new();
                                 let mut diagnostics = SyncTransportDiagnostics::default();
                                 diagnostics.record_stage_queue_wait(queued_at.elapsed());
-                                let transfer = stage_received_iroh_artifact(
-                                    &client,
-                                    &transport_id,
-                                    &peer_device_id,
-                                    received,
-                                    &mut stage_timings,
-                                    &mut diagnostics,
-                                );
+                                let transfer =
+                                    if let Some(message) = progress.interruption_message() {
+                                        let artifact = received.artifact.clone();
+                                        let cleanup_timer = SyncPhaseTimer::start_artifact(
+                                            "artifact_cleanup",
+                                            &artifact,
+                                        );
+                                        let _ = fs::remove_file(&received.temp_path);
+                                        stage_timings.push(cleanup_timer.finish());
+                                        Err(post_receive_transfer_failure(
+                                            &artifact,
+                                            received.timing,
+                                            message,
+                                        ))
+                                    } else {
+                                        stage_received_iroh_artifact(
+                                            &client,
+                                            &transport_id,
+                                            &peer_device_id,
+                                            received,
+                                            &mut stage_timings,
+                                            &mut diagnostics,
+                                        )
+                                    };
                                 BackendWriteEvent::Stage(IrohStageResult {
                                     transfer,
                                     timings: stage_timings,
@@ -5271,6 +6290,8 @@ mod desktop {
                                         &project_id,
                                         "Remote sync import skipped after Iroh artifact transfer aborted.",
                                     )
+                                } else if let Some(message) = progress.interruption_message() {
+                                    failed_project_result(&project_id, &message)
                                 } else {
                                     match task {
                                         RemoteApplyTask::Project(project) => {
@@ -5763,6 +6784,10 @@ mod desktop {
         let registered_projects = register_planned_iroh_projects(planned_projects, &mut scheduler);
 
         for planned in registered_projects {
+            if progress.is_cancelled() {
+                apply_worker.cancel_pending_apply();
+                break;
+            }
             match planned {
                 IrohRegisteredPlannedRemoteProject::Manifest {
                     project_index,
@@ -5843,6 +6868,10 @@ mod desktop {
         }
 
         if !pending.is_empty() {
+            if progress.is_cancelled() {
+                apply_worker.cancel_pending_apply();
+                return;
+            }
             let pending = round_robin_pending_artifacts_by_project(pending);
             let can_apply_after_iroh = request_and_stage_global_iroh_artifact_batch_on_write_lane(
                 client,
@@ -7021,6 +8050,14 @@ mod desktop {
 
         for entry in entries {
             let artifact = &entry.artifact;
+            if let Some(message) = progress.interruption_message() {
+                results.push(Err(transfer_failure(
+                    artifact,
+                    TransferTimer::zero_now(),
+                    message,
+                )));
+                continue;
+            }
             let timer = SyncPhaseTimer::start_artifact("artifact_staging_check", artifact);
             let staged = {
                 let _progress =
@@ -7103,6 +8140,18 @@ mod desktop {
         if pending.is_empty() {
             return Vec::new();
         }
+        if let Some(message) = progress.interruption_message() {
+            return pending
+                .into_iter()
+                .map(|pending| {
+                    Err(transfer_failure(
+                        &pending.artifact,
+                        TransferTimer::zero_now(),
+                        message.clone(),
+                    ))
+                })
+                .collect();
+        }
 
         let request = ArtifactBatchRequest {
             batch_token: None,
@@ -7131,6 +8180,21 @@ mod desktop {
         let mut results = Vec::new();
         let mut pending = pending.into_iter();
         while let Some(pending_transfer) = pending.next() {
+            if let Some(message) = progress.interruption_message() {
+                results.push(Err(transfer_failure(
+                    &pending_transfer.artifact,
+                    TransferTimer::zero_now(),
+                    message.clone(),
+                )));
+                results.extend(pending.map(|pending| {
+                    Err(transfer_failure(
+                        &pending.artifact,
+                        TransferTimer::zero_now(),
+                        message.clone(),
+                    ))
+                }));
+                break;
+            }
             match receive_and_stage_artifact(
                 client,
                 connection,
@@ -7749,6 +8813,21 @@ mod desktop {
         if pending.is_empty() {
             return true;
         }
+        if let Some(message) = progress.interruption_message() {
+            for pending in pending {
+                record_transfer(
+                    Err(transfer_failure(
+                        &pending.artifact,
+                        TransferTimer::zero_now(),
+                        message.clone(),
+                    )),
+                    false,
+                    apply_worker,
+                );
+            }
+            apply_worker.cancel_pending_apply();
+            return false;
+        }
 
         if let Some(message) = repeated_pending_iroh_artifact_message(&pending) {
             for pending in pending {
@@ -7968,6 +9047,12 @@ mod desktop {
                 || active_workers > 0
                 || apply_worker.pending_stage_jobs > 0)
         {
+            if let Some(message) = progress.interruption_message() {
+                fatal_error.get_or_insert(message);
+                apply_worker.cancel_pending_apply();
+                cancel_receivers.store(true, Ordering::SeqCst);
+                break;
+            }
             if !control_done {
                 match poll_iroh_artifact_batch_control(connection, &batch_token, progress) {
                     Ok(IrohBatchControlStatus::Pending) => {
@@ -8776,6 +9861,14 @@ mod desktop {
         let transfer_timer = TransferTimer::start();
         let timer = SyncPhaseTimer::start_artifact("artifact_transfer", &artifact);
         let _progress = progress.start_phase("artifact_transfer", "Transferring artifact content.");
+        if let Some(message) = progress.interruption_message() {
+            timings.push(timer.finish());
+            return Err(transfer_failure(
+                &artifact,
+                transfer_timer.finish(0),
+                message,
+            ));
+        }
 
         match connection
             .read_message_accepting_status_for_phase("artifact request/transfer", progress)
@@ -8857,6 +9950,9 @@ mod desktop {
         let mut hasher = Sha256::new();
         let mut size_bytes = 0_u64;
         let receive_result = loop {
+            if let Some(message) = progress.interruption_message() {
+                break Err(message);
+            }
             match connection.read_artifact_transfer_frame_accepting_status_for_phase(
                 "artifact request/transfer",
                 progress,
@@ -8922,6 +10018,12 @@ mod desktop {
             let _ = fs::remove_file(&temp_path);
             timings.push(cleanup_timer.finish());
             return Err(transfer_failure(&artifact, transfer_timing, error));
+        }
+        if let Some(message) = progress.interruption_message() {
+            let cleanup_timer = SyncPhaseTimer::start_artifact("artifact_cleanup", &artifact);
+            let _ = fs::remove_file(&temp_path);
+            timings.push(cleanup_timer.finish());
+            return Err(transfer_failure(&artifact, transfer_timing, message));
         }
 
         let body = json!({
@@ -9050,14 +10152,13 @@ mod desktop {
             } else {
                 fs::remove_file(&path)
             };
-            result.map_err(|error| {
-                format!(
-                    "Could not remove stale sync transport artifact temp entry {}: {error}",
-                    path.display()
-                )
-            })?;
+            result.map_err(stale_transport_temp_cleanup_error)?;
         }
         Ok(())
+    }
+
+    fn stale_transport_temp_cleanup_error(error: io::Error) -> String {
+        format!("Could not remove stale sync transport artifact temp entry: {error}")
     }
 
     fn sync_transport_temp_root_from_health(health: &Value) -> Result<PathBuf, String> {
@@ -9084,6 +10185,7 @@ mod desktop {
         progress
             .report_local_progress("serve_artifact_requests", "Serving peer artifact requests.");
         loop {
+            progress.check_not_cancelled()?;
             match connection
                 .read_message_accepting_status_for_phase("serve artifact requests", progress)?
             {
@@ -9183,6 +10285,7 @@ mod desktop {
             .resolve_artifact_files(artifacts)
             .map_err(|error| phase_context_error("artifact request/transfer", error.to_string()))?;
         let _progress = progress.start_phase("artifact_transfer", "Transferring artifact content.");
+        progress.check_not_cancelled()?;
         connection.send_message_for_phase(
             "artifact request/transfer",
             &ProtocolMessage::ArtifactBatchStart {
@@ -9197,6 +10300,7 @@ mod desktop {
             .collect();
         let mut served_artifact_ids = HashSet::new();
         while served_artifact_ids.len() < artifacts.len() {
+            progress.check_not_cancelled()?;
             let credit_wait_started = Instant::now();
             let credit_message = connection
                 .read_message_accepting_status_for_phase("artifact request/transfer", progress)?;
@@ -9273,6 +10377,7 @@ mod desktop {
                 let data = iroh_data.clone();
                 let batch_token = batch_token.to_string();
                 let run_started_instant = metrics.started_instant;
+                let cancel = progress.cancel_token();
                 handles.push(thread::spawn(move || {
                     stream_iroh_artifact_file(
                         data,
@@ -9280,6 +10385,7 @@ mod desktop {
                         artifact,
                         local_file,
                         run_started_instant,
+                        cancel,
                     )
                 }));
             }
@@ -9320,6 +10426,7 @@ mod desktop {
         artifact: RemoteArtifact,
         local_file: LocalArtifactFile,
         run_started_instant: Instant,
+        cancel: RunCancellationToken,
     ) -> Result<StreamedIrohArtifact, String> {
         let mut diagnostics = SyncTransportDiagnostics::default();
         local_file.verify_matches(&artifact)?;
@@ -9343,6 +10450,12 @@ mod desktop {
         let mut actual_size = 0_u64;
         let mut first_bytes_at = None;
         loop {
+            if let Some(interruption) = cancel.interruption() {
+                return Err(format!(
+                    "Sync interrupted by lifecycle event {}. {}",
+                    interruption.event.kind, interruption.guidance
+                ));
+            }
             let read = file.read(&mut buffer).map_err(|error| {
                 phase_context_error(
                     "artifact request/transfer",
@@ -9386,6 +10499,7 @@ mod desktop {
         let mut body = {
             let _progress =
                 progress.start_phase("artifact_transfer", "Transferring artifact content.");
+            progress.check_not_cancelled()?;
             client.open_artifact_body(artifact).map_err(|error| {
                 phase_context_error(
                     "artifact request/transfer",
@@ -9397,6 +10511,7 @@ mod desktop {
             })?
         };
         let _progress = progress.start_phase("artifact_transfer", "Transferring artifact content.");
+        progress.check_not_cancelled()?;
         connection.send_message_for_phase(
             "artifact request/transfer",
             &ProtocolMessage::ArtifactStart {
@@ -9410,6 +10525,7 @@ mod desktop {
         let mut hasher = Sha256::new();
         let mut actual_size = 0_u64;
         loop {
+            progress.check_not_cancelled()?;
             let read = body.read(&mut buffer).map_err(|error| {
                 phase_context_error(
                     "artifact request/transfer",
@@ -11335,6 +12451,228 @@ mod desktop {
         }
 
         #[test]
+        fn passive_lifecycle_event_records_without_retry_or_abort() {
+            let cancel = RunCancellationToken::default();
+            let mut status = SharedStatus::default();
+            status.active_runs.insert(
+                "sync_passive".to_string(),
+                ActiveSyncRun {
+                    peer_device_id: Some("dev_peer".to_string()),
+                    cancel: cancel.clone(),
+                    connection: None,
+                },
+            );
+
+            let outcome = record_lifecycle_event_in_status(
+                &mut status,
+                SyncTransportLifecycleEventRequest {
+                    kind: "blur".to_string(),
+                    occurred_at: Some("2026-01-01T00:00:00Z".to_string()),
+                    message: Some("window blurred".to_string()),
+                },
+            );
+
+            assert!(outcome.interrupted_runs.is_empty());
+            assert!(!cancel.is_cancelled());
+            assert_eq!(status.lifecycle_events.len(), 1);
+            assert_eq!(status.lifecycle_events[0].kind, "blur");
+            assert!(!status.lifecycle_events[0].retryable);
+            assert_eq!(
+                status.lifecycle_events[0].message.as_deref(),
+                Some("window blurred")
+            );
+            assert!(status.retryable_interruption_code.is_none());
+        }
+
+        #[test]
+        fn retryable_lifecycle_event_sets_interruption_evidence() {
+            let cancel = RunCancellationToken::default();
+            let mut status = SharedStatus::default();
+            status.active_runs.insert(
+                "sync_retry".to_string(),
+                ActiveSyncRun {
+                    peer_device_id: Some("dev_peer".to_string()),
+                    cancel: cancel.clone(),
+                    connection: None,
+                },
+            );
+
+            let outcome = record_lifecycle_event_in_status(
+                &mut status,
+                SyncTransportLifecycleEventRequest {
+                    kind: "network_offline".to_string(),
+                    occurred_at: Some("2026-01-01T00:00:01Z".to_string()),
+                    message: Some("lost tuneforge-sync+tcp://192.0.2.2:47619 endpoint".to_string()),
+                },
+            );
+            interrupt_active_runs_for_lifecycle(&outcome.event, outcome.interrupted_runs);
+
+            assert_eq!(
+                status.retryable_interruption_code.as_deref(),
+                Some("lifecycle_interrupted_network_offline")
+            );
+            assert_eq!(
+                status.retryable_interruption_peer_device_id.as_deref(),
+                Some("dev_peer")
+            );
+            assert_eq!(
+                status.retry_guidance.as_deref(),
+                Some(LIFECYCLE_INTERRUPTION_NETWORK_GUIDANCE)
+            );
+            let event = status.last_lifecycle_event.expect("last lifecycle event");
+            assert!(event.retryable);
+            assert_eq!(event.run_id.as_deref(), Some("sync_retry"));
+            assert_eq!(event.peer_device_id.as_deref(), Some("dev_peer"));
+            assert!(event.message.is_none());
+
+            let interruption = cancel.interruption().expect("run interrupted");
+            assert_eq!(interruption.code, "lifecycle_interrupted_network_offline");
+            assert_eq!(interruption.event.run_id.as_deref(), Some("sync_retry"));
+            assert_eq!(
+                interruption.event.peer_device_id.as_deref(),
+                Some("dev_peer")
+            );
+        }
+
+        #[test]
+        fn retryable_lifecycle_event_cancels_pending_remote_apply_before_drain() {
+            let (sender, receiver) =
+                mpsc::sync_channel::<BackendWriteTask>(IROH_ARTIFACT_STAGING_QUEUE_CAPACITY);
+            let (event_sender, event_receiver) = mpsc::channel::<BackendWriteEvent>();
+            let (observed_cancel_sender, observed_cancel_receiver) = mpsc::channel::<bool>();
+            let queued_project_ids = Arc::new(Mutex::new(Vec::new()));
+            let enqueue_failures = Arc::new(Mutex::new(Vec::new()));
+            let apply_cancelled = Arc::new(AtomicBool::new(false));
+            let run_cancel = RunCancellationToken::default();
+            let worker_run_cancel = run_cancel.clone();
+            let handle = thread::spawn(move || {
+                while let Ok(task) = receiver.recv() {
+                    let BackendWriteTask::Apply { project_id, .. } = task else {
+                        continue;
+                    };
+                    let wait_started = Instant::now();
+                    while !worker_run_cancel.is_cancelled()
+                        && wait_started.elapsed() < Duration::from_secs(2)
+                    {
+                        thread::sleep(Duration::from_millis(1));
+                    }
+                    let cancelled = worker_run_cancel.is_cancelled();
+                    let _ = observed_cancel_sender.send(cancelled);
+                    let message = if cancelled {
+                        "Remote sync import skipped after lifecycle interruption."
+                    } else {
+                        "Remote sync import worker drained without lifecycle cancellation."
+                    };
+                    let _ = event_sender.send(BackendWriteEvent::Apply {
+                        project_id: project_id.clone(),
+                        result: failed_project_result(&project_id, message),
+                        timings: Vec::new(),
+                    });
+                }
+            });
+            let mut apply_worker = RemoteApplyWorker {
+                sender: Some(sender),
+                event_receiver,
+                handle: Some(handle),
+                queued_project_ids,
+                completed_project_ids: HashSet::new(),
+                enqueue_failures,
+                apply_cancelled,
+                project_results: Vec::new(),
+                pending_stage_jobs: 0,
+                pending_stage_bytes: 0,
+                staging_peak_bytes: 0,
+            };
+            apply_worker.enqueue_tombstone("proj_lifecycle_abort".to_string());
+            let mut status = SharedStatus::default();
+            status.active_runs.insert(
+                "sync_lifecycle_abort".to_string(),
+                ActiveSyncRun {
+                    peer_device_id: Some("dev_peer".to_string()),
+                    cancel: run_cancel,
+                    connection: None,
+                },
+            );
+
+            let outcome = record_lifecycle_event_in_status(
+                &mut status,
+                SyncTransportLifecycleEventRequest {
+                    kind: "sleep".to_string(),
+                    occurred_at: None,
+                    message: None,
+                },
+            );
+            interrupt_active_runs_for_lifecycle(&outcome.event, outcome.interrupted_runs);
+            let results = apply_worker.finish(&mut Vec::new());
+
+            assert!(
+                observed_cancel_receiver
+                    .recv_timeout(Duration::from_secs(1))
+                    .expect("worker observed lifecycle cancellation"),
+                "lifecycle abort must cancel pending reconciliation apply before draining worker"
+            );
+            assert_eq!(results.len(), 1);
+            assert_eq!(results[0].status, "failed");
+            assert!(results[0]
+                .message
+                .as_deref()
+                .unwrap_or("")
+                .contains("lifecycle interruption"));
+        }
+
+        #[test]
+        fn recovery_lifecycle_event_clears_nearby_peers_and_requests_refresh() {
+            let mut status = SharedStatus {
+                retryable_interruption_code: Some(
+                    "lifecycle_interrupted_network_offline".to_string(),
+                ),
+                retryable_interruption_peer_device_id: Some("dev_peer".to_string()),
+                retry_guidance: Some(LIFECYCLE_INTERRUPTION_NETWORK_GUIDANCE.to_string()),
+                ..SharedStatus::default()
+            };
+            status.nearby_peers.insert(
+                "dev_stale".to_string(),
+                DiscoveryPeerEntry {
+                    peer: SyncTransportNearbyPeer {
+                        device_id: "dev_stale".to_string(),
+                        sync_group_id: "syncgrp_one".to_string(),
+                        display_name: None,
+                        public_key: "peer_public".to_string(),
+                        endpoint_hints: Vec::new(),
+                        protocol_version: DISCOVERY_PROTOCOL_VERSION.to_string(),
+                        timestamp: "2026-01-01T00:00:00Z".to_string(),
+                        observed_at: "2026-01-01T00:00:00Z".to_string(),
+                        expires_at: "2026-01-01T00:01:00Z".to_string(),
+                    },
+                    expires_at_instant: Instant::now() + DISCOVERY_PEER_TTL,
+                },
+            );
+
+            let outcome = record_lifecycle_event_in_status(
+                &mut status,
+                SyncTransportLifecycleEventRequest {
+                    kind: "network_online".to_string(),
+                    occurred_at: None,
+                    message: None,
+                },
+            );
+
+            assert!(outcome.refresh_endpoint_hints);
+            assert!(outcome.interrupted_runs.is_empty());
+            assert!(status.nearby_peers.is_empty());
+            assert_eq!(
+                status
+                    .last_lifecycle_event
+                    .as_ref()
+                    .map(|event| event.kind.as_str()),
+                Some("network_online")
+            );
+            assert!(status.retryable_interruption_code.is_none());
+            assert!(status.retryable_interruption_peer_device_id.is_none());
+            assert!(status.retry_guidance.is_none());
+        }
+
+        #[test]
         fn sync_now_request_missing_preferred_transport_selects_tcp_default() {
             let request: SyncTransportSyncNowRequest = serde_json::from_value(json!({
                 "peerDeviceId": "dev_peer"
@@ -12033,6 +13371,7 @@ mod desktop {
                 Instant::now(),
                 Arc::new(Mutex::new(SharedStatus::default())),
                 connection.clone(),
+                RunCancellationToken::default(),
             )
         }
 
@@ -12400,6 +13739,7 @@ mod desktop {
                 started,
                 Arc::new(Mutex::new(SharedStatus::default())),
                 connection.clone(),
+                RunCancellationToken::default(),
             );
 
             let error =
@@ -12569,6 +13909,44 @@ mod desktop {
                 unrelated_status.active_progress_owner_run_id.as_deref(),
                 Some("inbound_local_run")
             );
+        }
+
+        #[test]
+        fn sync_now_non_interrupted_result_clears_retryable_interruption() {
+            let mut status = SharedStatus {
+                retryable_interruption_code: Some(
+                    "lifecycle_interrupted_android_background".to_string(),
+                ),
+                retryable_interruption_peer_device_id: Some("dev_peer".to_string()),
+                retry_guidance: Some(LIFECYCLE_INTERRUPTION_FOREGROUND_GUIDANCE.to_string()),
+                ..SharedStatus::default()
+            };
+            let result = Ok(failed_preflight_sync_result(
+                "sync_run_recovered".to_string(),
+                "dev_peer".to_string(),
+                BACKEND_PREFLIGHT_UNRESPONSIVE_CODE,
+                "Local backend was unavailable.".to_string(),
+                Utc::now(),
+                Instant::now(),
+            ));
+
+            apply_sync_now_status_result(&mut status, &result, "sync_run_recovered");
+
+            assert!(status.retryable_interruption_code.is_none());
+            assert!(status.retryable_interruption_peer_device_id.is_none());
+            assert!(status.retry_guidance.is_none());
+        }
+
+        #[test]
+        fn stale_transport_temp_cleanup_error_omits_entry_path() {
+            let message = stale_transport_temp_cleanup_error(io::Error::from_raw_os_error(13));
+
+            assert!(
+                message.starts_with("Could not remove stale sync transport artifact temp entry:")
+            );
+            assert!(message.contains("Permission denied"));
+            assert!(!message.contains("/"));
+            assert!(!message.contains("transport-tmp"));
         }
 
         #[test]
@@ -12857,6 +14235,7 @@ mod desktop {
                 started,
                 Arc::new(Mutex::new(SharedStatus::default())),
                 connection.clone(),
+                RunCancellationToken::default(),
             );
             let mut metrics = SyncRunMetrics::start(started);
             let served = serve_artifact_requests_until_done(
@@ -12949,6 +14328,7 @@ mod desktop {
                 started,
                 Arc::new(Mutex::new(SharedStatus::default())),
                 connection.clone(),
+                RunCancellationToken::default(),
             );
             let mut apply_worker = RemoteApplyWorker::start(
                 &client,
@@ -13136,6 +14516,7 @@ mod desktop {
                 started,
                 Arc::new(Mutex::new(SharedStatus::default())),
                 connection.clone(),
+                RunCancellationToken::default(),
             );
             let mut apply_worker = RemoteApplyWorker::start(
                 &client,
@@ -13411,6 +14792,7 @@ mod desktop {
                 first_started,
                 Arc::new(Mutex::new(SharedStatus::default())),
                 first_connection.clone(),
+                RunCancellationToken::default(),
             );
             let mut first_apply_worker = RemoteApplyWorker::start(
                 &client,
@@ -13551,6 +14933,7 @@ mod desktop {
                 second_started,
                 Arc::new(Mutex::new(SharedStatus::default())),
                 second_connection.clone(),
+                RunCancellationToken::default(),
             );
             let mut second_apply_worker = RemoteApplyWorker::start(
                 &retry_client,
@@ -13945,6 +15328,7 @@ mod desktop {
                 started,
                 Arc::new(Mutex::new(SharedStatus::default())),
                 connection.clone(),
+                RunCancellationToken::default(),
             );
             let mut metrics = SyncRunMetrics::start(started);
             let mut timings = Vec::new();
@@ -15416,6 +16800,9 @@ mod desktop {
                 remote_manifest_count: 0,
                 local_manifest_count: 0,
                 manifest_errors: Vec::new(),
+                lifecycle_events: Vec::new(),
+                retryable_interruption_code: None,
+                retry_guidance: None,
                 phase_timings: vec![SyncTransportTimingEvidence {
                     phase: "artifact_transfer".to_string(),
                     project_id: Some("proj_one".to_string()),
@@ -15545,6 +16932,9 @@ mod desktop {
                 remote_manifest_count: 0,
                 local_manifest_count: 0,
                 manifest_errors: Vec::new(),
+                lifecycle_events: Vec::new(),
+                retryable_interruption_code: None,
+                retry_guidance: None,
                 phase_timings: Vec::new(),
                 diagnostics: SyncTransportDiagnostics::default(),
             };
@@ -15870,6 +17260,14 @@ pub fn sync_transport_status(
     state: tauri::State<'_, desktop::SyncTransportState>,
 ) -> SyncTransportStatus {
     desktop::sync_transport_status(state)
+}
+
+#[tauri::command]
+pub fn sync_transport_record_lifecycle_event(
+    state: tauri::State<'_, desktop::SyncTransportState>,
+    payload: SyncTransportLifecycleEventRequest,
+) -> SyncTransportStatus {
+    desktop::sync_transport_record_lifecycle_event(state, payload)
 }
 
 #[tauri::command]

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -22,6 +22,7 @@ import {
   mockGetMobileCapabilities,
   mockGetSyncIdentity,
   mockGetSyncTransportStatus,
+  mockRecordSyncLifecycleEvent,
   mockAnswerSyncPairingOffer,
   mockCreateSyncPairingOffer,
   mockListSyncTrustedPeers,
@@ -321,6 +322,13 @@ async function exportEvidenceFromCurrentSyncResult(user: ReturnType<typeof userE
     clickSpy.mockRestore();
     setTimeoutSpy.mockRestore();
   }
+}
+
+function setDocumentVisibility(value: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    value,
+  });
 }
 
 describe("Desktop app activity", () => {
@@ -906,6 +914,356 @@ describe("Desktop app activity", () => {
       setIntervalSpy.mockRestore();
       clearIntervalSpy.mockRestore();
     }
+  });
+
+	  it("records passive blur and hidden lifecycle events without showing retry", async () => {
+    const user = userEvent.setup();
+    setSyncTrustedPeers([
+      {
+        device_id: "device_peer_1",
+        sync_group_id: "sync_group_local",
+        display_name: "Laptop Rig",
+        public_key: "pub_peer_1",
+        endpoint_hints: syncEndpointHints,
+        trusted_at: "2026-04-18T13:16:00.000Z",
+      },
+    ]);
+    const retryableStatus = {
+      active: false,
+      status: "stopped",
+      endpoint_hints: [],
+      nearby_peers: [],
+      last_lifecycle_event: {
+        kind: "background",
+        occurred_at: "2026-04-18T13:16:30.000Z",
+        message: "window blurred",
+        retryable: true,
+        interruption_code: "network_offline",
+        retry_guidance: "Retry with Laptop Rig.",
+        peer_device_id: "device_peer_1",
+        run_id: "sync_run_background_1",
+      },
+      lifecycle_events: [],
+      retryable_interruption_code: "network_offline",
+      retryable_interruption_peer_device_id: "device_peer_1",
+      retry_guidance: "Retry with Laptop Rig.",
+      last_sync: null,
+      updated_at: "2026-04-18T13:16:30.000Z",
+    };
+    mockRecordSyncLifecycleEvent.mockResolvedValue(retryableStatus);
+
+    try {
+      await openSyncTab(user);
+      mockRecordSyncLifecycleEvent.mockClear();
+
+      fireEvent.blur(window);
+      setDocumentVisibility("hidden");
+      fireEvent(document, new Event("visibilitychange"));
+
+      await waitFor(() => expect(mockRecordSyncLifecycleEvent).toHaveBeenCalledTimes(2));
+      expect(mockRecordSyncLifecycleEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: "background", message: "window blurred" }),
+      );
+      expect(mockRecordSyncLifecycleEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: "background", message: "document hidden" }),
+      );
+      expect(screen.queryByRole("button", { name: "Retry Sync" })).not.toBeInTheDocument();
+    } finally {
+      setDocumentVisibility("visible");
+    }
+	  });
+
+	  it("records Android background and screen-lock lifecycle events as retryable", async () => {
+	    const user = userEvent.setup();
+	    mockGetMobileCapabilities.mockResolvedValue(androidCapabilities);
+	    setSyncTrustedPeers([
+	      {
+	        device_id: "device_peer_1",
+	        sync_group_id: "sync_group_local",
+	        display_name: "Laptop Rig",
+	        public_key: "pub_peer_1",
+	        endpoint_hints: syncEndpointHints,
+	        trusted_at: "2026-04-18T13:16:00.000Z",
+	      },
+	    ]);
+	    mockRecordSyncLifecycleEvent.mockImplementation(async (event) => {
+	      const retryableStatus = {
+	        active: true,
+	        status: "listening",
+	        endpoint_hints: listenerEndpointHints,
+	        nearby_peers: [],
+	        last_lifecycle_event: {
+	          kind: event.kind,
+	          occurred_at: event.occurredAt ?? "2026-04-18T13:16:30.000Z",
+	          message: event.message ?? null,
+	          retryable: true,
+	          interruption_code: event.kind === "android_screen_lock"
+	            ? "lifecycle_interrupted_android_screen_lock"
+	            : "lifecycle_interrupted_android_background",
+	          retry_guidance: "Bring Android back to the foreground, then retry sync.",
+	          peer_device_id: "device_peer_1",
+	          run_id: "sync_run_android_lifecycle_1",
+	        },
+	        lifecycle_events: [],
+	        retryable_interruption_code: event.kind === "android_screen_lock"
+	          ? "lifecycle_interrupted_android_screen_lock"
+	          : "lifecycle_interrupted_android_background",
+	        retryable_interruption_peer_device_id: "device_peer_1",
+	        retry_guidance: "Bring Android back to the foreground, then retry sync.",
+	        last_sync: null,
+	        updated_at: "2026-04-18T13:16:30.000Z",
+	      };
+	      setSyncTransportStatus(retryableStatus);
+	      return retryableStatus;
+	    });
+
+	    try {
+	      await openSyncTab(user);
+	      await waitFor(() => expect(screen.getByRole("button", { name: "Scan QR" })).toBeEnabled());
+	      mockRecordSyncLifecycleEvent.mockClear();
+
+	      fireEvent.blur(window);
+	      setDocumentVisibility("hidden");
+	      fireEvent(document, new Event("visibilitychange"));
+
+	      await waitFor(() => expect(mockRecordSyncLifecycleEvent).toHaveBeenCalledTimes(2));
+	      expect(mockRecordSyncLifecycleEvent).toHaveBeenCalledWith(
+	        expect.objectContaining({ kind: "android_screen_lock", message: "android window blurred" }),
+	      );
+	      expect(mockRecordSyncLifecycleEvent).toHaveBeenCalledWith(
+	        expect.objectContaining({ kind: "android_background", message: "android background or screen lock" }),
+	      );
+	      expect(await screen.findByRole("button", { name: "Retry Sync" })).toBeInTheDocument();
+	    } finally {
+	      setDocumentVisibility("visible");
+	    }
+	  });
+
+	  it("records desktop sleep and wake after a long visible timer gap", async () => {
+	    const user = userEvent.setup();
+	    const setIntervalSpy = vi.spyOn(window, "setInterval");
+	    const clearIntervalSpy = vi.spyOn(window, "clearInterval");
+	    const dateNowSpy = vi.spyOn(Date, "now");
+	    const intervalHandlers: Array<() => void> = [];
+	    let now = 1_000_000;
+	    dateNowSpy.mockImplementation(() => now);
+	    setIntervalSpy.mockImplementation((handler: TimerHandler, timeout?: number) => {
+	      if (timeout === 10_000 && typeof handler === "function") {
+	        intervalHandlers.push(handler as () => void);
+	      }
+	      return 1;
+	    });
+
+	    try {
+	      setDocumentVisibility("visible");
+	      mockRecordSyncLifecycleEvent.mockResolvedValue({
+	        active: true,
+	        status: "listening",
+	        endpoint_hints: listenerEndpointHints,
+	        nearby_peers: [],
+	        lifecycle_events: [],
+	        last_sync: null,
+	      });
+
+	      await openSyncTab(user);
+	      mockRecordSyncLifecycleEvent.mockClear();
+	      expect(intervalHandlers.length).toBeGreaterThan(0);
+
+	      now += 120_000;
+	      await act(async () => {
+	        intervalHandlers[intervalHandlers.length - 1]?.();
+	      });
+
+	      await waitFor(() => expect(mockRecordSyncLifecycleEvent).toHaveBeenCalledTimes(2));
+	      expect(mockRecordSyncLifecycleEvent).toHaveBeenNthCalledWith(
+	        1,
+	        expect.objectContaining({ kind: "sleep", message: "desktop suspended for 120 seconds" }),
+	      );
+	      expect(mockRecordSyncLifecycleEvent).toHaveBeenNthCalledWith(
+	        2,
+	        expect.objectContaining({ kind: "wake", message: "desktop woke after suspension" }),
+	      );
+	    } finally {
+	      dateNowSpy.mockRestore();
+	      setIntervalSpy.mockRestore();
+	      clearIntervalSpy.mockRestore();
+	      setDocumentVisibility("visible");
+	    }
+	  });
+
+	  it("records offline lifecycle state and retries sync through preflight with nearby endpoints", async () => {
+    const user = userEvent.setup();
+    setSyncTrustedPeers([
+      {
+        device_id: "device_peer_1",
+        sync_group_id: "sync_group_local",
+        display_name: "Laptop Rig",
+        public_key: "pub_peer_1",
+        endpoint_hints: syncEndpointHints,
+        trusted_at: "2026-04-18T13:16:00.000Z",
+      },
+    ]);
+    setSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: listenerEndpointHints,
+      nearby_peers: [
+        {
+          device_id: "device_peer_1",
+          display_name: "Laptop Rig",
+          public_key: "pub_peer_1",
+          trust_status: "match",
+          endpoint_hints: [nearbyIrohEndpointHint, nearbyTcpEndpointHint],
+        },
+      ],
+    });
+    mockRecordSyncLifecycleEvent.mockImplementation(async (event) => {
+      const retryableStatus = {
+        active: true,
+        status: "listening",
+        endpoint_hints: listenerEndpointHints,
+        nearby_peers: [
+          {
+            device_id: "device_peer_1",
+            display_name: "Laptop Rig",
+            public_key: "pub_peer_1",
+            trust_status: "match",
+            endpoint_hints: [nearbyIrohEndpointHint, nearbyTcpEndpointHint],
+          },
+        ],
+        last_lifecycle_event: {
+          kind: event.kind,
+          occurred_at: event.occurredAt ?? "2026-04-18T13:17:00.000Z",
+          message: event.message ?? null,
+          retryable: true,
+          interruption_code: "network_offline",
+          retry_guidance: "Network restored. Retry sync.",
+          peer_device_id: "device_peer_1",
+          run_id: "sync_run_offline_1",
+        },
+        lifecycle_events: [
+          {
+            kind: event.kind,
+            occurred_at: event.occurredAt ?? "2026-04-18T13:17:00.000Z",
+            message: event.message ?? null,
+            retryable: true,
+            interruption_code: "network_offline",
+            retry_guidance: "Network restored. Retry sync.",
+            peer_device_id: "device_peer_1",
+            run_id: "sync_run_offline_1",
+          },
+        ],
+        retryable_interruption_code: "network_offline",
+        retryable_interruption_peer_device_id: "device_peer_1",
+        retry_guidance: "Network restored. Retry sync.",
+        last_sync: null,
+        updated_at: "2026-04-18T13:17:00.000Z",
+      };
+      setSyncTransportStatus(retryableStatus);
+      return retryableStatus;
+    });
+
+    await openSyncTab(user);
+    mockRecordSyncLifecycleEvent.mockClear();
+    mockGetSyncPreflight.mockClear();
+    mockSyncTrustedPeerNow.mockClear();
+
+    fireEvent(window, new Event("offline"));
+
+    await waitFor(() =>
+      expect(mockRecordSyncLifecycleEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: "network_offline", message: "network offline" }),
+      ),
+    );
+    expect(await screen.findByRole("button", { name: "Retry Sync" })).toBeInTheDocument();
+    expect(screen.getByText("Network restored. Retry sync.")).toBeInTheDocument();
+
+	    const retryButton = screen.getByRole("button", { name: "Retry Sync" });
+	    expect(retryButton).toBeEnabled();
+	    mockSyncTrustedPeerNow.mockImplementationOnce(async () => {
+	      const result = syncRunStatus({
+	        run_id: "sync_run_retry_success_1",
+	        status: "completed",
+	        message: "Retry completed.",
+	        lifecycle_events: [],
+	        retryable_interruption_code: null,
+	        retryable_interruption_peer_device_id: null,
+	        retry_guidance: null,
+	      });
+	      setSyncTransportStatus({
+	        nearby_peers: [],
+	        retryable_interruption_code: null,
+	        retryable_interruption_peer_device_id: null,
+	        retry_guidance: null,
+	        last_sync: result,
+	      });
+	      return result;
+	    });
+	    fireEvent.click(retryButton);
+
+    await waitFor(() => expect(mockGetSyncPreflight).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(mockSyncTrustedPeerNow).toHaveBeenCalledWith("device_peer_1", {
+        endpointHints: [nearbyIrohEndpointHint, nearbyTcpEndpointHint],
+      }),
+    );
+	    expect(mockGetSyncPreflight.mock.invocationCallOrder[0]).toBeLessThan(
+	      mockSyncTrustedPeerNow.mock.invocationCallOrder[0],
+	    );
+	    await waitFor(() => expect(screen.queryByRole("button", { name: "Retry Sync" })).not.toBeInTheDocument());
+	    expect(await screen.findAllByText("Retry completed.")).not.toHaveLength(0);
+	  });
+
+  it("records foreground and online lifecycle events while refreshing listener status", async () => {
+    const user = userEvent.setup();
+    mockRecordSyncLifecycleEvent.mockImplementation(async (event) => ({
+      active: false,
+      status: "stopped",
+      endpoint_hints: [],
+      nearby_peers: [],
+      last_lifecycle_event: {
+        kind: event.kind,
+        occurred_at: event.occurredAt ?? "2026-04-18T13:18:00.000Z",
+        message: event.message ?? null,
+        retryable: false,
+      },
+      lifecycle_events: [],
+      last_sync: null,
+      updated_at: "2026-04-18T13:18:00.000Z",
+    }));
+    await openSyncTab(user);
+    mockRecordSyncLifecycleEvent.mockClear();
+    mockGetSyncTransportStatus.mockClear();
+
+    fireEvent(window, new Event("online"));
+
+    await waitFor(() =>
+      expect(mockRecordSyncLifecycleEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: "network_online", message: "network online" }),
+      ),
+    );
+    await waitFor(() => expect(mockGetSyncTransportStatus.mock.calls.length).toBeGreaterThan(0));
+
+    mockGetSyncTransportStatus.mockClear();
+    fireEvent.focus(window);
+
+    await waitFor(() =>
+      expect(mockRecordSyncLifecycleEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: "foreground", message: "window focused" }),
+      ),
+    );
+    await waitFor(() => expect(mockGetSyncTransportStatus.mock.calls.length).toBeGreaterThan(0));
+
+    mockGetSyncTransportStatus.mockClear();
+    setDocumentVisibility("visible");
+    fireEvent(document, new Event("visibilitychange"));
+
+    await waitFor(() =>
+      expect(mockRecordSyncLifecycleEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: "foreground", message: "document visible" }),
+      ),
+    );
+    await waitFor(() => expect(mockGetSyncTransportStatus.mock.calls.length).toBeGreaterThan(0));
   });
 
   it("shows nearby devices and syncs trusted matches with discovered endpoints", async () => {
@@ -2210,6 +2568,41 @@ describe("Desktop app activity", () => {
         'Receiving artifact art_export_alpha from "C:\\Users\\test\\Music\\Secret Demo.wav" via tuneforge-sync+tcp://192.168.1.42:48625',
       active_progress_at: "2026-04-18T13:16:00.300Z",
       active_elapsed_ms: 900,
+      last_lifecycle_event: {
+        kind: "network_offline",
+        occurred_at: "2026-04-18T13:16:00.700Z",
+        message:
+          "Lost device_peer_1 while reading /Users/test/Music/Secret Demo.wav via tuneforge-sync+tcp://192.168.1.42:48625.",
+        retryable: true,
+        interruption_code: "network_offline",
+        retry_guidance: "Reconnect device_peer_1 and retry Secret Demo.wav.",
+        peer_device_id: "device_peer_1",
+        run_id: "sync_run_export_listener",
+      },
+      lifecycle_events: [
+        {
+          kind: "background",
+          occurred_at: "2026-04-18T13:15:59.000Z",
+          message: "Window blurred during sync_run_export_listener.",
+          retryable: false,
+          peer_device_id: "device_peer_1",
+          run_id: "sync_run_export_listener",
+        },
+        {
+          kind: "network_offline",
+          occurred_at: "2026-04-18T13:16:00.700Z",
+          message:
+            "Lost device_peer_1 while reading /Users/test/Music/Secret Demo.wav via tuneforge-sync+tcp://192.168.1.42:48625.",
+          retryable: true,
+          interruption_code: "network_offline",
+          retry_guidance: "Reconnect device_peer_1 and retry Secret Demo.wav.",
+          peer_device_id: "device_peer_1",
+          run_id: "sync_run_export_listener",
+        },
+      ],
+      retryable_interruption_code: "network_offline",
+      retryable_interruption_peer_device_id: "device_peer_1",
+      retry_guidance: "Reconnect device_peer_1 and retry Secret Demo.wav.",
       last_sync: {
         run_id: "sync_run_export_listener",
         session_id: "sync_session_export_listener",
@@ -2238,6 +2631,33 @@ describe("Desktop app activity", () => {
           credit_revokes: 2,
           staging_post_ms_total: 300,
         },
+        last_lifecycle_event: {
+          kind: "network_offline",
+          occurred_at: "2026-04-18T13:16:00.700Z",
+          message:
+            "Run sync_run_export_listener interrupted by device_peer_1 at /Users/test/Music/Secret Demo.wav.",
+          retryable: true,
+          interruption_code: "network_offline",
+          retry_guidance: "Reconnect device_peer_1 and retry Secret Demo.wav.",
+          peer_device_id: "device_peer_1",
+          run_id: "sync_run_export_listener",
+        },
+        lifecycle_events: [
+          {
+            kind: "network_offline",
+            occurred_at: "2026-04-18T13:16:00.700Z",
+            message:
+              "Run sync_run_export_listener interrupted by device_peer_1 at /Users/test/Music/Secret Demo.wav.",
+            retryable: true,
+            interruption_code: "network_offline",
+            retry_guidance: "Reconnect device_peer_1 and retry Secret Demo.wav.",
+            peer_device_id: "device_peer_1",
+            run_id: "sync_run_export_listener",
+          },
+        ],
+        retryable_interruption_code: "network_offline",
+        retryable_interruption_peer_device_id: "device_peer_1",
+        retry_guidance: "Reconnect device_peer_1 and retry Secret Demo.wav.",
         imported_project_count: 1,
         applied_project_count: 1,
         skipped_project_count: 0,
@@ -2386,11 +2806,47 @@ describe("Desktop app activity", () => {
       }),
     ]);
     expect(exportedJson.lifecycle).toMatchObject({
+      events: expect.arrayContaining([
+        expect.objectContaining({
+          kind: "background",
+          peer: "peer_1",
+          hasRunId: true,
+        }),
+        expect.objectContaining({
+          kind: "network_offline",
+          retryable: true,
+          interruptionCode: "network_offline",
+          peer: "peer_1",
+          hasRunId: true,
+        }),
+      ]),
+      lastLifecycleEvent: expect.objectContaining({
+        kind: "network_offline",
+        retryable: true,
+        interruptionCode: "network_offline",
+        retryGuidance: expect.stringContaining("peer_1"),
+        peer: "peer_1",
+        hasRunId: true,
+      }),
+      retryableInterruptionCode: "network_offline",
+      retryGuidance: expect.stringContaining("peer_1"),
       listener: {
         active: true,
         status: "listening",
         activePhase: "artifact_transfer",
         hasLastError: false,
+        lastLifecycleEvent: expect.objectContaining({
+          kind: "network_offline",
+          peer: "peer_1",
+        }),
+        retryableInterruptionCode: "network_offline",
+      },
+      run: {
+        lastLifecycleEvent: expect.objectContaining({
+          kind: "network_offline",
+          peer: "peer_1",
+        }),
+        retryableInterruptionCode: "network_offline",
       },
       phaseTimings: [
         expect.objectContaining({
@@ -2421,6 +2877,7 @@ describe("Desktop app activity", () => {
     expect(serialized).toContain("project_1");
     expect(serialized).toContain("artifact_1");
     expect(serialized).not.toContain("device_peer_1");
+    expect(serialized).not.toContain("sync_run_export_listener");
     expect(serialized).not.toContain("proj_export_alpha");
     expect(serialized).not.toContain("art_export_alpha");
     expect(serialized).not.toContain("sha256-export-alpha");

--- a/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
+++ b/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
@@ -11,8 +11,10 @@ import {
   type SyncNearbyPeerTrustStatus,
   type SyncPreflightBlockingJob,
   type SyncPreflightResponse,
+  type SyncTransportLifecycleEvent,
   type SyncTransportProjectResult,
   type SyncTransportRunStatus,
+  type SyncTransportStatus,
   type SyncTransportTransferResult,
   type SyncTrustedPeerSchema,
 } from "../../lib/api";
@@ -27,6 +29,8 @@ import {
 
 const PAIRING_OFFER_TTL_SECONDS = 600;
 const SYNC_LISTENER_POLL_INTERVAL_MS = 2000;
+const DESKTOP_SLEEP_CHECK_INTERVAL_MS = 10_000;
+const DESKTOP_SLEEP_ELAPSED_THRESHOLD_MS = 90_000;
 const EMPTY_NEARBY_PEERS: SyncNearbyPeer[] = [];
 const PROJECT_MUTATION_QUERY_KEYS = [
   ["projects"],
@@ -67,6 +71,26 @@ type PairingOutput = {
 type SyncNowRequest = {
   deviceId: string;
   endpointHints?: string[];
+};
+type SyncLifecycleRecordOptions = {
+  message?: string;
+  refreshListener?: boolean;
+  updateListenerStatus?: boolean;
+};
+type RetryableSyncInterruption = {
+  peerDeviceId: string;
+  endpointHints?: string[];
+  code: string;
+  guidance: string | null;
+};
+type SyncRetrySource = {
+  retryable_interruption_code?: string | null;
+  retryable_interruption_peer_device_id?: string | null;
+  retry_guidance?: string | null;
+  last_lifecycle_event?: SyncTransportLifecycleEvent | null;
+  lifecycle_events?: SyncTransportLifecycleEvent[];
+  peer_device_id?: string | null;
+  remote_device_id?: string | null;
 };
 
 function statusLabel(value: string | null | undefined) {
@@ -260,6 +284,58 @@ function syncStatusText(status: SyncTransportRunStatus | null | undefined, peers
   return status.message ?? `${statusLabel(status.status)} for ${peerName}.`;
 }
 
+function retryableLifecycleEvent(source: SyncRetrySource | null | undefined) {
+  if (!source) {
+    return null;
+  }
+  const events = [
+    source.last_lifecycle_event,
+    ...[...(source.lifecycle_events ?? [])].reverse(),
+  ];
+  return events.find((event): event is SyncTransportLifecycleEvent => Boolean(event?.retryable)) ?? null;
+}
+
+function hasSyncRetryField(source: SyncRetrySource | null | undefined, key: keyof SyncRetrySource) {
+  return Boolean(source && Object.prototype.hasOwnProperty.call(source, key));
+}
+
+function retryableInterruptionFromSource(
+  source: SyncRetrySource | null | undefined,
+  peersById: Map<string, SyncTrustedPeerSchema>,
+  trustedNearbyPeerByDeviceId: Map<string, SyncNearbyPeer>,
+): RetryableSyncInterruption | null {
+  const lifecycleEvent = retryableLifecycleEvent(source);
+  const hasExplicitCode = hasSyncRetryField(source, "retryable_interruption_code");
+  const hasExplicitPeer = hasSyncRetryField(source, "retryable_interruption_peer_device_id");
+  const hasExplicitGuidance = hasSyncRetryField(source, "retry_guidance");
+  const hasExplicitInterruptionState = hasExplicitCode || hasExplicitPeer || hasExplicitGuidance;
+  const code = hasExplicitInterruptionState
+    ? source?.retryable_interruption_code ?? null
+    : lifecycleEvent?.interruption_code ?? null;
+  const peerDeviceId = hasExplicitInterruptionState
+    ? source?.retryable_interruption_peer_device_id ?? null
+    : lifecycleEvent?.peer_device_id ??
+      source?.peer_device_id ??
+      source?.remote_device_id ??
+      null;
+  if (!code || !peerDeviceId || !peersById.has(peerDeviceId)) {
+    return null;
+  }
+  const endpointHints = trustedNearbyPeerByDeviceId.get(peerDeviceId)?.endpoint_hints;
+  return {
+    peerDeviceId,
+    endpointHints: endpointHints?.length ? endpointHints : undefined,
+    code,
+    guidance: hasExplicitInterruptionState
+      ? source?.retry_guidance ?? null
+      : lifecycleEvent?.retry_guidance ?? null,
+  };
+}
+
+function retryableInterruptionText(interruption: RetryableSyncInterruption) {
+  return interruption.guidance?.trim() || `${statusLabel(interruption.code)}. Retry when peer is reachable.`;
+}
+
 function syncNowFailureText(error: unknown) {
   if (error instanceof Error) {
     const message = error.message.trim();
@@ -386,6 +462,11 @@ function syncResultKey(status: SyncTransportRunStatus | null | undefined) {
     fallbackReason: status.fallback_reason,
     fallbackCode: status.fallback_code,
     attemptedTransports: status.attempted_transports,
+    retryableInterruptionCode: status.retryable_interruption_code,
+    retryableInterruptionPeerDeviceId: status.retryable_interruption_peer_device_id,
+    retryGuidance: status.retry_guidance,
+    lastLifecycleEvent: status.last_lifecycle_event,
+    lifecycleEvents: status.lifecycle_events ?? [],
     timeToFirstArtifactMs: status.time_to_first_artifact_ms,
     totalReceivedBytes: status.total_received_bytes,
     totalServedBytes: status.total_served_bytes,
@@ -893,10 +974,18 @@ function createEvidenceLabelMap(values: Array<string | null | undefined>, prefix
   return labels;
 }
 
-function createSyncEvidenceRedactionContext(status: SyncTransportRunStatus): SyncEvidenceRedactionContext {
+function createSyncEvidenceRedactionContext(
+  status: SyncTransportRunStatus,
+  extraPeerDeviceIds: Array<string | null | undefined> = [],
+  extraRunIds: Array<string | null | undefined> = [],
+): SyncEvidenceRedactionContext {
   const peerLabels = createEvidenceLabelMap([
     status.peer_device_id,
     status.remote_device_id,
+    status.retryable_interruption_peer_device_id,
+    status.last_lifecycle_event?.peer_device_id,
+    ...(status.lifecycle_events ?? []).map((event) => event.peer_device_id),
+    ...extraPeerDeviceIds,
   ], "peer");
   const projectLabels = createEvidenceLabelMap([
     ...status.project_results.map((result) => result.project_id),
@@ -907,10 +996,18 @@ function createSyncEvidenceRedactionContext(status: SyncTransportRunStatus): Syn
     ...status.received_artifacts.map((artifact) => artifact.artifact_id),
     ...(status.phase_timings ?? []).map((timing) => timing.artifact_id),
   ], "artifact");
+  const runLabels = createEvidenceLabelMap([
+    status.run_id,
+    status.session_id,
+    status.last_lifecycle_event?.run_id,
+    ...(status.lifecycle_events ?? []).map((event) => event.run_id),
+    ...extraRunIds,
+  ], "run");
   const tokenReplacements = [
     ...Array.from(peerLabels.entries()),
     ...Array.from(projectLabels.entries()),
     ...Array.from(artifactLabels.entries()),
+    ...Array.from(runLabels.entries()),
   ].sort(([left], [right]) => right.length - left.length);
   return {
     peerLabels,
@@ -949,6 +1046,34 @@ function redactSyncEvidenceText(
   );
   redacted = redacted.replace(SYNC_EVIDENCE_FILENAME_PATTERN, "[redacted_filename]");
   return redacted;
+}
+
+function syncEvidenceLifecycleEvent(
+  event: SyncTransportLifecycleEvent | null | undefined,
+  context: SyncEvidenceRedactionContext,
+) {
+  if (!event) {
+    return null;
+  }
+  return {
+    kind: event.kind,
+    occurredAt: event.occurred_at ?? null,
+    message: redactSyncEvidenceText(event.message, context),
+    retryable: event.retryable,
+    interruptionCode: event.interruption_code ?? null,
+    retryGuidance: redactSyncEvidenceText(event.retry_guidance, context),
+    peer: event.peer_device_id ? context.peerLabels.get(event.peer_device_id) ?? "peer_1" : null,
+    hasRunId: Boolean(event.run_id),
+  };
+}
+
+function syncEvidenceLifecycleEvents(
+  events: SyncTransportLifecycleEvent[],
+  context: SyncEvidenceRedactionContext,
+) {
+  return events
+    .map((event) => syncEvidenceLifecycleEvent(event, context))
+    .filter((event): event is NonNullable<ReturnType<typeof syncEvidenceLifecycleEvent>> => event !== null);
 }
 
 function syncEvidenceProjectCadence(status: SyncTransportRunStatus) {
@@ -1080,10 +1205,20 @@ function buildSyncEvidenceExport(
     listenerActiveElapsedMs: number | null | undefined;
     listenerLastStatus: string | null | undefined;
     listenerLastError: string | null | undefined;
+    listenerLifecycleEvents: SyncTransportLifecycleEvent[];
+    listenerLastLifecycleEvent: SyncTransportLifecycleEvent | null | undefined;
+    listenerRetryableInterruptionCode: string | null | undefined;
+    listenerRetryGuidance: string | null | undefined;
     showListenerSyncResult: boolean;
   },
 ) {
-  const redactionContext = createSyncEvidenceRedactionContext(status);
+  const redactionContext = createSyncEvidenceRedactionContext(status, [
+    options.listenerLastLifecycleEvent?.peer_device_id,
+    ...options.listenerLifecycleEvents.map((event) => event.peer_device_id),
+  ], [
+    options.listenerLastLifecycleEvent?.run_id,
+    ...options.listenerLifecycleEvents.map((event) => event.run_id),
+  ]);
   const projectAppearances = syncEvidenceProjectCadence(status);
   const mergedProjectResults = mergeSyncProjectResults(status.project_results, status.manifest_errors);
   const artifactStatusCounts = status.received_artifacts.reduce<Record<string, number>>((counts, artifact) => {
@@ -1124,6 +1259,14 @@ function buildSyncEvidenceExport(
     ? importedProjectCount / (durationMs / 60000)
     : null;
   const evidenceTransferCounts = syncRunTransferCountsEvidence(status, artifactStatusCounts);
+  const evidenceLifecycleEvents = [
+    ...options.listenerLifecycleEvents,
+    ...(status.lifecycle_events ?? []),
+  ];
+  const lastLifecycleEvent = status.last_lifecycle_event ?? options.listenerLastLifecycleEvent ?? null;
+  const retryableInterruptionCode =
+    status.retryable_interruption_code ?? options.listenerRetryableInterruptionCode ?? null;
+  const retryGuidance = status.retry_guidance ?? options.listenerRetryGuidance ?? null;
 
   return {
     capturedAt: options.capturedAt,
@@ -1267,6 +1410,10 @@ function buildSyncEvidenceExport(
       reused: artifact.status === "already_staged",
     })),
     lifecycle: {
+      events: syncEvidenceLifecycleEvents(evidenceLifecycleEvents, redactionContext),
+      lastLifecycleEvent: syncEvidenceLifecycleEvent(lastLifecycleEvent, redactionContext),
+      retryableInterruptionCode,
+      retryGuidance: redactSyncEvidenceText(retryGuidance, redactionContext),
       listener: {
         active: options.listenerActive,
         status: options.listenerStatus,
@@ -1277,6 +1424,14 @@ function buildSyncEvidenceExport(
         lastStatus: redactSyncEvidenceText(options.listenerLastStatus, redactionContext),
         hasLastError: Boolean(options.listenerLastError),
         updatedAt: options.listenerUpdatedAt ?? null,
+        lastLifecycleEvent: syncEvidenceLifecycleEvent(options.listenerLastLifecycleEvent, redactionContext),
+        retryableInterruptionCode: options.listenerRetryableInterruptionCode ?? null,
+        retryGuidance: redactSyncEvidenceText(options.listenerRetryGuidance, redactionContext),
+      },
+      run: {
+        lastLifecycleEvent: syncEvidenceLifecycleEvent(status.last_lifecycle_event, redactionContext),
+        retryableInterruptionCode: status.retryable_interruption_code ?? null,
+        retryGuidance: redactSyncEvidenceText(status.retry_guidance, redactionContext),
       },
       phaseTimings: (status.phase_timings ?? []).map((timing, index) => ({
         label: `phase_${index + 1}`,
@@ -1406,9 +1561,11 @@ export function ActivitySyncPanel() {
   const [syncNowPolling, setSyncNowPolling] = useState(false);
   const [evidenceMessage, setEvidenceMessage] = useState<string | null>(null);
   const [evidenceError, setEvidenceError] = useState<string | null>(null);
-  const pairingCodeOutputRef = useRef<HTMLTextAreaElement | null>(null);
-  const rawPairingOutputRef = useRef<HTMLTextAreaElement | null>(null);
-  const refreshedProjectSyncKeyRef = useRef<string | null>(null);
+	  const pairingCodeOutputRef = useRef<HTMLTextAreaElement | null>(null);
+	  const rawPairingOutputRef = useRef<HTMLTextAreaElement | null>(null);
+	  const refreshedProjectSyncKeyRef = useRef<string | null>(null);
+	  const desktopLifecycleLastObservedAtRef = useRef(Date.now());
+	  const desktopLifecyclePassiveAwayRef = useRef(false);
 
   const identityQuery = useQuery({
     queryKey: ["sync", "identity"],
@@ -1465,6 +1622,23 @@ export function ActivitySyncPanel() {
     ? lastSyncMessage ?? lastSyncStatus
     : lastSyncStatus;
   const visibleSyncSummary = syncRunSummaryText(visibleSyncResult);
+  const retryableInterruption = useMemo(() => {
+    const sources: Array<SyncRetrySource | null | undefined> = [
+      listenerQuery.data,
+      visibleSyncResult,
+    ];
+    for (const source of sources) {
+      const interruption = retryableInterruptionFromSource(
+        source,
+        peersById,
+        trustedNearbyPeerByDeviceId,
+      );
+      if (interruption) {
+        return interruption;
+      }
+    }
+    return null;
+  }, [listenerQuery.data, visibleSyncResult, peersById, trustedNearbyPeerByDeviceId]);
   const pairingInputValue = pairingCodeDraft.trim() || rawPairingPayloadDraft.trim();
   const decodedPairingInput = useMemo(() => {
     if (!pairingInputValue) {
@@ -1479,7 +1653,8 @@ export function ActivitySyncPanel() {
       };
     }
   }, [pairingInputValue]);
-  const qrScanSupported = mobileCapabilitiesQuery.data?.platform === "android";
+	  const qrScanSupported = mobileCapabilitiesQuery.data?.platform === "android";
+	  const isAndroidRuntime = mobileCapabilitiesQuery.data?.platform === "android";
 
   const refreshSyncQueries = useCallback(async () => {
     await Promise.all([
@@ -1489,11 +1664,185 @@ export function ActivitySyncPanel() {
     ]);
   }, [queryClient]);
 
+	  const recordLifecycleEvent = useCallback(
+	    async (kind: string, options: SyncLifecycleRecordOptions = {}) => {
+	      const occurredAt = new Date().toISOString();
+	      let status: SyncTransportStatus | null = null;
+	      try {
+	        status = await api.recordSyncLifecycleEvent({
+	          kind,
+	          occurredAt,
+	          message: options.message,
+	        });
+	      } catch {
+	        // Lifecycle recording is best-effort; still refresh listener state when requested.
+	      }
+      if (status && options.updateListenerStatus) {
+        queryClient.setQueryData(["sync", "listener"], status);
+      }
+      if (options.refreshListener) {
+        await queryClient.invalidateQueries({ queryKey: ["sync", "listener"] });
+      }
+    },
+    [queryClient],
+  );
+
   const refreshProjectMutationQueries = useCallback(async () => {
     await Promise.all(
       PROJECT_MUTATION_QUERY_KEYS.map((queryKey) => queryClient.invalidateQueries({ queryKey })),
     );
   }, [queryClient]);
+
+	  useEffect(() => {
+	    const markDesktopLifecycleObserved = () => {
+	      desktopLifecycleLastObservedAtRef.current = Date.now();
+	    };
+	    const recordDesktopSuspensionIfNeeded = (wakeMessage: string) => {
+	      const now = Date.now();
+	      const elapsedMs = now - desktopLifecycleLastObservedAtRef.current;
+	      desktopLifecycleLastObservedAtRef.current = now;
+	      if (
+	        isAndroidRuntime ||
+	        desktopLifecyclePassiveAwayRef.current ||
+	        document.visibilityState !== "visible" ||
+	        elapsedMs < DESKTOP_SLEEP_ELAPSED_THRESHOLD_MS
+	      ) {
+	        return;
+	      }
+	      void (async () => {
+	        await recordLifecycleEvent("sleep", {
+	          message: `desktop suspended for ${Math.round(elapsedMs / 1000)} seconds`,
+	          updateListenerStatus: true,
+	        });
+	        await recordLifecycleEvent("wake", {
+	          message: wakeMessage,
+	          refreshListener: true,
+	          updateListenerStatus: true,
+	        });
+	      })();
+	    };
+	    const recordPassiveBackground = (message: string) => {
+	      desktopLifecyclePassiveAwayRef.current = true;
+	      markDesktopLifecycleObserved();
+	      void recordLifecycleEvent("background", { message });
+	    };
+	    const recordAndroidBackground = (message: string) => {
+	      void recordLifecycleEvent("android_background", {
+	        message,
+	        updateListenerStatus: true,
+	      });
+	    };
+	    const recordAndroidScreenLock = (message: string) => {
+	      void recordLifecycleEvent("android_screen_lock", {
+	        message,
+	        updateListenerStatus: true,
+	      });
+	    };
+	    const recordForeground = (message: string) => {
+	      const wasDesktopPassiveAway = desktopLifecyclePassiveAwayRef.current;
+	      desktopLifecyclePassiveAwayRef.current = false;
+	      if (!wasDesktopPassiveAway) {
+	        recordDesktopSuspensionIfNeeded(message);
+	      } else {
+	        markDesktopLifecycleObserved();
+	      }
+	      void recordLifecycleEvent("foreground", {
+	        message,
+	        refreshListener: true,
+	        updateListenerStatus: true,
+	      });
+	    };
+	    const recordAndroidForeground = (message: string) => {
+	      void recordLifecycleEvent("android_foreground", {
+	        message,
+	        refreshListener: true,
+	        updateListenerStatus: true,
+	      });
+	    };
+	    const handleVisibilityChange = () => {
+	      if (document.visibilityState === "hidden") {
+	        if (isAndroidRuntime) {
+	          recordAndroidBackground("android background or screen lock");
+	          return;
+	        }
+	        recordPassiveBackground("document hidden");
+	        return;
+	      }
+	      if (document.visibilityState === "visible") {
+	        if (isAndroidRuntime) {
+	          recordAndroidForeground("android foreground");
+	          return;
+	        }
+	        recordForeground("document visible");
+	      }
+	    };
+	    const handleBlur = () => {
+	      if (isAndroidRuntime) {
+	        recordAndroidScreenLock("android window blurred");
+	        return;
+	      }
+	      recordPassiveBackground("window blurred");
+	    };
+	    const handleFocus = () => {
+	      if (isAndroidRuntime) {
+	        recordAndroidForeground("android window focused");
+	        return;
+	      }
+	      recordForeground("window focused");
+	    };
+    const handleOnline = () => {
+      void recordLifecycleEvent("network_online", {
+        message: "network online",
+        refreshListener: true,
+        updateListenerStatus: true,
+      });
+    };
+    const handleOffline = () => {
+      void recordLifecycleEvent("network_offline", {
+        message: "network offline",
+        updateListenerStatus: true,
+      });
+    };
+	    const handlePageHide = () => {
+	      if (isAndroidRuntime) {
+	        recordAndroidBackground("android page hidden");
+	        return;
+	      }
+	      recordPassiveBackground("page hidden");
+	    };
+	    const handlePageShow = () => {
+	      if (isAndroidRuntime) {
+	        recordAndroidForeground("android page shown");
+	        return;
+	      }
+	      recordForeground("page shown");
+	    };
+	    const handleDesktopSleepCheck = () => {
+	      recordDesktopSuspensionIfNeeded("desktop woke after suspension");
+	    };
+
+	    document.addEventListener("visibilitychange", handleVisibilityChange);
+	    window.addEventListener("blur", handleBlur);
+	    window.addEventListener("focus", handleFocus);
+	    window.addEventListener("online", handleOnline);
+	    window.addEventListener("offline", handleOffline);
+	    window.addEventListener("pagehide", handlePageHide);
+	    window.addEventListener("pageshow", handlePageShow);
+	    const desktopSleepCheckId = window.setInterval(
+	      handleDesktopSleepCheck,
+	      DESKTOP_SLEEP_CHECK_INTERVAL_MS,
+	    );
+	    return () => {
+	      document.removeEventListener("visibilitychange", handleVisibilityChange);
+	      window.removeEventListener("blur", handleBlur);
+	      window.removeEventListener("focus", handleFocus);
+	      window.removeEventListener("online", handleOnline);
+	      window.removeEventListener("offline", handleOffline);
+	      window.removeEventListener("pagehide", handlePageHide);
+	      window.removeEventListener("pageshow", handlePageShow);
+	      window.clearInterval(desktopSleepCheckId);
+	    };
+	  }, [isAndroidRuntime, recordLifecycleEvent]);
 
   useEffect(() => {
     if (!listenerSyncKey || refreshedProjectSyncKeyRef.current === listenerSyncKey) {
@@ -1582,7 +1931,8 @@ export function ActivitySyncPanel() {
       await refreshSyncQueries();
     },
   });
-  const syncNowMutation = useMutation({
+	  const syncNowMutation = useMutation({
+    networkMode: "always",
     mutationFn: async (request: SyncNowRequest) => {
       let preflight: SyncPreflightResponse;
       try {
@@ -1603,13 +1953,26 @@ export function ActivitySyncPanel() {
     onMutate: () => {
       void queryClient.invalidateQueries({ queryKey: ["sync", "listener"] });
     },
-    onSuccess: async (status) => {
-      setLastSyncMessage(syncStatusText(status, peersById));
-      setLastSyncResult(status);
-      setHiddenListenerSyncKey(listenerSyncKey);
-      const shouldRefreshProjectQueries = syncResultMutatedLocalProjectCaches(status);
-      if (shouldRefreshProjectQueries) {
-        refreshedProjectSyncKeyRef.current = syncResultKey(status);
+	    onSuccess: async (status) => {
+	      setLastSyncMessage(syncStatusText(status, peersById));
+	      setLastSyncResult(status);
+	      setHiddenListenerSyncKey(listenerSyncKey);
+	      if (!status.retryable_interruption_code) {
+	        queryClient.setQueryData<SyncTransportStatus | undefined>(
+	          ["sync", "listener"],
+	          (current) => current
+	            ? {
+	                ...current,
+	                retryable_interruption_code: null,
+	                retryable_interruption_peer_device_id: null,
+	                retry_guidance: null,
+	              }
+	            : current,
+	        );
+	      }
+	      const shouldRefreshProjectQueries = syncResultMutatedLocalProjectCaches(status);
+	      if (shouldRefreshProjectQueries) {
+	        refreshedProjectSyncKeyRef.current = syncResultKey(status);
       }
       await Promise.all([
         refreshSyncQueries(),
@@ -1748,6 +2111,10 @@ export function ActivitySyncPanel() {
       listenerActiveElapsedMs: listenerQuery.data?.active_elapsed_ms ?? null,
       listenerLastStatus: listenerQuery.data?.last_status ?? null,
       listenerLastError: listenerQuery.data?.last_error ?? null,
+      listenerLifecycleEvents: listenerQuery.data?.lifecycle_events ?? [],
+      listenerLastLifecycleEvent: listenerQuery.data?.last_lifecycle_event ?? null,
+      listenerRetryableInterruptionCode: listenerQuery.data?.retryable_interruption_code ?? null,
+      listenerRetryGuidance: listenerQuery.data?.retry_guidance ?? null,
       showListenerSyncResult,
     });
     return {
@@ -1890,6 +2257,24 @@ export function ActivitySyncPanel() {
           <div className="activity-sync-section__header">
             <h3 id="activity-sync-listener-heading">Listener</h3>
             <div className="activity-sync-section__actions">
+              {retryableInterruption ? (
+                <button
+                  className="button button--primary button--small"
+                  disabled={syncNowMutation.isPending}
+                  onClick={() => {
+                    syncNowMutation.mutate({
+                      deviceId: retryableInterruption.peerDeviceId,
+                      endpointHints: retryableInterruption.endpointHints,
+                    });
+                  }}
+                  type="button"
+                >
+                  {syncNowMutation.isPending &&
+                    syncNowMutation.variables?.deviceId === retryableInterruption.peerDeviceId
+                    ? "Retrying..."
+                    : "Retry Sync"}
+                </button>
+              ) : null}
               <button
                 className="button button--ghost button--small"
                 disabled={!visibleSyncResult}
@@ -1963,6 +2348,11 @@ export function ActivitySyncPanel() {
           {listenerQuery.data?.last_error ? (
             <p className="activity-sync-alert activity-sync-alert--error" role="alert">
               {listenerQuery.data.last_error}
+            </p>
+          ) : null}
+          {retryableInterruption ? (
+            <p className="activity-sync-alert" role="status">
+              {retryableInterruptionText(retryableInterruption)}
             </p>
           ) : null}
           {startListenerMutation.isError || stopListenerMutation.isError ? (

--- a/apps/desktop/src/lib/api.mobile-sync.test.ts
+++ b/apps/desktop/src/lib/api.mobile-sync.test.ts
@@ -280,4 +280,174 @@ describe("mobile sync API adapter", () => {
       },
     });
   });
-});
+
+	  it("routes lifecycle events to native transport and normalizes camelCase lifecycle fields", async () => {
+    mockInvoke.mockImplementation(async (command: string) => {
+      if (command === "mobile_capabilities") {
+        return mobileCapabilities;
+      }
+      if (command === "sync_transport_record_lifecycle_event") {
+        return {
+          running: true,
+          status: "listening",
+          endpointHints: [],
+          nearbyPeers: [],
+          lastLifecycleEvent: {
+            kind: "network_offline",
+            occurredAt: "2026-05-22 12:04:00",
+            message: "Network dropped.",
+            retryable: true,
+            interruptionCode: "android_screen_locked",
+            retryGuidance: "Wake the phone and retry sync.",
+            peerDeviceId: "device_peer_1",
+            runId: "sync_run_lifecycle_1",
+          },
+          lifecycleEvents: [
+            {
+              kind: "background",
+              occurredAt: "2026-05-22T12:03:58.000Z",
+              message: "App backgrounded.",
+              retryable: false,
+            },
+            {
+              kind: "network_offline",
+              occurredAt: "2026-05-22 12:04:00",
+              message: "Network dropped.",
+              retryable: true,
+              interruptionCode: "android_screen_locked",
+              retryGuidance: "Wake the phone and retry sync.",
+              peerDeviceId: "device_peer_1",
+              runId: "sync_run_lifecycle_1",
+            },
+          ],
+          retryableInterruptionCode: "android_screen_locked",
+          retryableInterruptionPeerDeviceId: "device_peer_1",
+          retryGuidance: "Wake the phone and retry sync.",
+          lastSync: {
+            peerDeviceId: "device_peer_1",
+            status: "failed",
+            message: "Sync paused by lifecycle interruption.",
+            projectResults: [],
+            manifestErrors: [],
+            receivedArtifacts: [],
+            lastLifecycleEvent: {
+              kind: "network_offline",
+              occurredAt: "2026-05-22 12:04:00",
+              message: "Network dropped.",
+              retryable: true,
+              interruptionCode: "android_screen_locked",
+              retryGuidance: "Wake the phone and retry sync.",
+              peerDeviceId: "device_peer_1",
+              runId: "sync_run_lifecycle_1",
+            },
+            lifecycleEvents: [
+              {
+                kind: "network_offline",
+                occurredAt: "2026-05-22 12:04:00",
+                retryable: true,
+                interruptionCode: "android_screen_locked",
+                retryGuidance: "Wake the phone and retry sync.",
+                peerDeviceId: "device_peer_1",
+                runId: "sync_run_lifecycle_1",
+              },
+            ],
+            retryableInterruptionCode: "android_screen_locked",
+            retryableInterruptionPeerDeviceId: "device_peer_1",
+            retryGuidance: "Wake the phone and retry sync.",
+          },
+        };
+      }
+      return {};
+    });
+    const api = await loadMobileApi();
+
+    await expect(
+      api.recordSyncLifecycleEvent({
+        kind: "network_offline",
+        occurredAt: "2026-05-22T12:04:00.000Z",
+        message: "Network dropped.",
+      }),
+    ).resolves.toMatchObject({
+      active: true,
+      status: "listening",
+      last_lifecycle_event: {
+        kind: "network_offline",
+        occurred_at: "2026-05-22T12:04:00.000Z",
+        message: "Network dropped.",
+        retryable: true,
+        interruption_code: "android_screen_locked",
+        retry_guidance: "Wake the phone and retry sync.",
+        peer_device_id: "device_peer_1",
+        run_id: "sync_run_lifecycle_1",
+      },
+      lifecycle_events: [
+        expect.objectContaining({ kind: "background", retryable: false }),
+        expect.objectContaining({
+          kind: "network_offline",
+          retryable: true,
+          interruption_code: "android_screen_locked",
+        }),
+      ],
+      retryable_interruption_code: "android_screen_locked",
+      retryable_interruption_peer_device_id: "device_peer_1",
+      retry_guidance: "Wake the phone and retry sync.",
+      last_sync: {
+        status: "failed",
+        lifecycle_events: [
+          expect.objectContaining({
+            kind: "network_offline",
+            retryable: true,
+            interruption_code: "android_screen_locked",
+          }),
+        ],
+        retryable_interruption_code: "android_screen_locked",
+        retryable_interruption_peer_device_id: "device_peer_1",
+      },
+    });
+    expect(mockInvoke).toHaveBeenCalledWith("sync_transport_record_lifecycle_event", {
+      payload: {
+        kind: "network_offline",
+        occurredAt: "2026-05-22T12:04:00.000Z",
+        message: "Network dropped.",
+      },
+	    });
+	  });
+
+	  it("keeps retry interruption cleared when native status returns explicit null fields", async () => {
+	    const { normalizeSyncTransportStatus } = await import("./api");
+
+	    expect(normalizeSyncTransportStatus({
+	      running: true,
+	      status: "listening",
+	      endpointHints: [],
+	      nearbyPeers: [],
+	      lastLifecycleEvent: {
+	        kind: "network_offline",
+	        occurredAt: "2026-05-22T12:04:00.000Z",
+	        retryable: true,
+	        interruptionCode: "lifecycle_interrupted_network_offline",
+	        retryGuidance: "Retry when the peer is reachable.",
+	        peerDeviceId: "device_peer_1",
+	        runId: "sync_run_old_interruption",
+	      },
+	      lifecycleEvents: [
+	        {
+	          kind: "network_offline",
+	          occurredAt: "2026-05-22T12:04:00.000Z",
+	          retryable: true,
+	          interruptionCode: "lifecycle_interrupted_network_offline",
+	          retryGuidance: "Retry when the peer is reachable.",
+	          peerDeviceId: "device_peer_1",
+	          runId: "sync_run_old_interruption",
+	        },
+	      ],
+	      retryableInterruptionCode: null,
+	      retryableInterruptionPeerDeviceId: null,
+	      retryGuidance: null,
+	    })).toMatchObject({
+	      retryable_interruption_code: null,
+	      retryable_interruption_peer_device_id: null,
+	      retry_guidance: null,
+	    });
+	  });
+	});

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -121,6 +121,21 @@ export type SyncTransportPhaseTiming = {
   throughput_bytes_per_second?: number | null;
 };
 export type SyncTransportTiming = Record<string, unknown> | Record<string, unknown>[];
+export type SyncLifecycleEventRequest = {
+  kind: string;
+  occurredAt?: string | null;
+  message?: string | null;
+};
+export type SyncTransportLifecycleEvent = {
+  kind: string;
+  occurred_at?: string | null;
+  message?: string | null;
+  retryable: boolean;
+  interruption_code?: string | null;
+  retry_guidance?: string | null;
+  peer_device_id?: string | null;
+  run_id?: string | null;
+};
 type SyncTransportDiagnosticField =
   | "credit_wait_ms_total"
   | "credit_wait_ms_max"
@@ -178,6 +193,11 @@ export type SyncTransportRunStatus = {
   max_active_streams?: number | null;
   credit_grants?: number | null;
   credit_revokes?: number | null;
+  last_lifecycle_event?: SyncTransportLifecycleEvent | null;
+  lifecycle_events?: SyncTransportLifecycleEvent[];
+  retryable_interruption_code?: string | null;
+  retryable_interruption_peer_device_id?: string | null;
+  retry_guidance?: string | null;
   error?: string | null;
   project_results: SyncTransportProjectResult[];
   manifest_errors: SyncTransportManifestError[];
@@ -255,6 +275,11 @@ export type SyncTransportStatus = {
   last_status?: string | null;
   last_error?: string | null;
   fallback_code?: string | null;
+  last_lifecycle_event?: SyncTransportLifecycleEvent | null;
+  lifecycle_events?: SyncTransportLifecycleEvent[];
+  retryable_interruption_code?: string | null;
+  retryable_interruption_peer_device_id?: string | null;
+  retry_guidance?: string | null;
   last_sync?: SyncTransportRunStatus | null;
   updated_at?: string | null;
 };
@@ -303,6 +328,26 @@ function firstStringField(records: Array<Record<string, unknown> | null>, keys: 
     }
   }
   return null;
+}
+
+function firstNullableStringField(records: Array<Record<string, unknown> | null>, keys: string[]) {
+  let present = false;
+  for (const record of records) {
+    if (!record) {
+      continue;
+    }
+    for (const key of keys) {
+      if (!Object.prototype.hasOwnProperty.call(record, key)) {
+        continue;
+      }
+      present = true;
+      const value = record[key];
+      if (typeof value === "string" && value.trim()) {
+        return { present, value: value.trim() };
+      }
+    }
+  }
+  return { present, value: null };
 }
 
 function firstBooleanField(records: Array<Record<string, unknown> | null>, keys: string[]) {
@@ -984,6 +1029,114 @@ function normalizedEndpointHints(endpointHints: string[] | null | undefined) {
   return normalized;
 }
 
+function normalizeSyncLifecycleEvent(value: unknown): SyncTransportLifecycleEvent | null {
+  const record = asRecord(value);
+  if (!record) {
+    return null;
+  }
+  const kind = firstStringField([record], ["kind", "event", "type"]);
+  if (!kind) {
+    return null;
+  }
+  return {
+    kind: normalizeTransportStatusToken(kind),
+    occurred_at: dateTimeField(record, [
+      "occurred_at",
+      "occurredAt",
+      "timestamp",
+      "created_at",
+      "createdAt",
+      "updated_at",
+      "updatedAt",
+    ]),
+    message: firstStringField([record], ["message", "reason", "detail", "details"]),
+    retryable: firstBooleanField([record], ["retryable", "can_retry", "canRetry"]) ?? false,
+    interruption_code: firstStringField([
+      record,
+    ], [
+      "interruption_code",
+      "interruptionCode",
+      "retryable_interruption_code",
+      "retryableInterruptionCode",
+      "code",
+    ]),
+    retry_guidance: firstStringField([record], ["retry_guidance", "retryGuidance", "guidance"]),
+    peer_device_id: firstStringField([
+      record,
+    ], [
+      "peer_device_id",
+      "peerDeviceId",
+      "retryable_interruption_peer_device_id",
+      "retryableInterruptionPeerDeviceId",
+      "device_id",
+      "deviceId",
+    ]),
+    run_id: firstStringField([record], ["run_id", "runId", "sync_run_id", "syncRunId"]),
+  };
+}
+
+function lifecycleEventsField(record: Record<string, unknown>) {
+  return recordArrayField(record, ["lifecycle_events", "lifecycleEvents", "events"])
+    .map((item) => normalizeSyncLifecycleEvent(item))
+    .filter((item): item is SyncTransportLifecycleEvent => item !== null);
+}
+
+function lastLifecycleEventField(
+  record: Record<string, unknown>,
+  lifecycleEvents: SyncTransportLifecycleEvent[],
+) {
+  return normalizeSyncLifecycleEvent(record.last_lifecycle_event ?? record.lastLifecycleEvent ?? null) ??
+    lifecycleEvents[lifecycleEvents.length - 1] ??
+    null;
+}
+
+function syncLifecycleInterruptionFields(
+  record: Record<string, unknown>,
+  lifecycleEvents: SyncTransportLifecycleEvent[],
+  lastLifecycleEvent: SyncTransportLifecycleEvent | null,
+) {
+  const retryableLifecycleEvent = [
+    lastLifecycleEvent,
+    ...[...lifecycleEvents].reverse(),
+  ].find((event): event is SyncTransportLifecycleEvent => Boolean(event?.retryable));
+  const explicitCode = firstNullableStringField([
+    record,
+  ], [
+    "retryable_interruption_code",
+    "retryableInterruptionCode",
+    "interruption_code",
+    "interruptionCode",
+  ]);
+  const explicitPeerDeviceId = firstNullableStringField([
+    record,
+  ], [
+    "retryable_interruption_peer_device_id",
+    "retryableInterruptionPeerDeviceId",
+    "interruption_peer_device_id",
+    "interruptionPeerDeviceId",
+    "peer_device_id",
+    "peerDeviceId",
+  ]);
+  const explicitGuidance = firstNullableStringField([
+    record,
+  ], [
+    "retry_guidance",
+    "retryGuidance",
+    "retryable_interruption_guidance",
+    "retryableInterruptionGuidance",
+  ]);
+  const explicitInterruptionState =
+    explicitCode.present || explicitPeerDeviceId.present || explicitGuidance.present;
+  return {
+    retryable_interruption_code: explicitCode.value ??
+      (explicitInterruptionState ? null : retryableLifecycleEvent?.interruption_code ?? null),
+    retryable_interruption_peer_device_id: explicitPeerDeviceId.value ??
+      (explicitInterruptionState ? null : retryableLifecycleEvent?.peer_device_id ?? null),
+    retry_guidance: explicitGuidance.value ??
+      (explicitInterruptionState ? null : retryableLifecycleEvent?.retry_guidance ?? null),
+  };
+}
+
 const SYNC_PROJECT_RESULT_PROGRESS_STATES = new Set([
   "applying",
   "downloading",
@@ -1336,6 +1489,13 @@ export function normalizeSyncRunStatus(value: unknown): SyncTransportRunStatus |
     ...numericMetricsFromRecord(explicitRunMetricRecord),
     ...numericMetricsFromRecord(transferCountRecord),
   };
+  const lifecycleEvents = lifecycleEventsField(record);
+  const lastLifecycleEvent = lastLifecycleEventField(record, lifecycleEvents);
+  const lifecycleInterruptionFields = syncLifecycleInterruptionFields(
+    record,
+    lifecycleEvents,
+    lastLifecycleEvent,
+  );
   const durationMs =
     numberField(record, ["duration_ms", "durationMs", "elapsed_ms", "elapsedMs"]) ??
     durationMsFromDateTimes(runStartedAt, runCompletedAt);
@@ -1491,6 +1651,9 @@ export function normalizeSyncRunStatus(value: unknown): SyncTransportRunStatus |
     max_active_streams: maxActiveStreams,
     credit_grants: creditGrants,
     credit_revokes: creditRevokes,
+    last_lifecycle_event: lastLifecycleEvent,
+    lifecycle_events: lifecycleEvents,
+    ...lifecycleInterruptionFields,
     error: explicitError,
     project_results: projectResults,
     manifest_errors: manifestErrors,
@@ -1516,6 +1679,7 @@ export function normalizeSyncTransportStatus(value: unknown): SyncTransportStatu
       status: "unavailable",
       endpoint_hints: [],
       nearby_peers: [],
+      lifecycle_events: [],
       last_error: "Native sync transport returned an invalid status.",
     };
   }
@@ -1535,6 +1699,13 @@ export function normalizeSyncTransportStatus(value: unknown): SyncTransportStatu
     "updated_at",
     "updatedAt",
   ]);
+  const lifecycleEvents = lifecycleEventsField(record);
+  const lastLifecycleEvent = lastLifecycleEventField(record, lifecycleEvents);
+  const lifecycleInterruptionFields = syncLifecycleInterruptionFields(
+    record,
+    lifecycleEvents,
+    lastLifecycleEvent,
+  );
   return {
     active,
     status,
@@ -1572,6 +1743,9 @@ export function normalizeSyncTransportStatus(value: unknown): SyncTransportStatu
     last_status: firstStringField([record], ["last_status", "lastStatus"]),
     last_error: firstStringField([record], ["last_error", "lastError", "error"]),
     fallback_code: firstStringField([record], ["fallback_code", "fallbackCode"]),
+    last_lifecycle_event: lastLifecycleEvent,
+    lifecycle_events: lifecycleEvents,
+    ...lifecycleInterruptionFields,
     last_sync: normalizeSyncRunStatus(record.last_sync ?? record.lastSync ?? null),
     updated_at: firstStringField([record], ["updated_at", "updatedAt"]),
   };
@@ -1587,6 +1761,19 @@ async function startSyncListener() {
 
 async function stopSyncListener() {
   return normalizeSyncTransportStatus(await invokeDesktopNative<unknown>("sync_transport_stop_listener"));
+}
+
+async function recordSyncLifecycleEvent(event: SyncLifecycleEventRequest) {
+  const payload: Record<string, unknown> = { kind: event.kind };
+  if (event.occurredAt !== undefined) {
+    payload.occurredAt = event.occurredAt;
+  }
+  if (event.message !== undefined) {
+    payload.message = event.message;
+  }
+  return normalizeSyncTransportStatus(
+    await invokeDesktopNative<unknown>("sync_transport_record_lifecycle_event", { payload }),
+  );
 }
 
 async function syncTrustedPeerNow(deviceId: string, options?: SyncTransportSyncNowOptions) {
@@ -1673,6 +1860,7 @@ export type TuneForgeClient = {
   getSyncTransportStatus: () => Promise<SyncTransportStatus>;
   startSyncListener: () => Promise<SyncTransportStatus>;
   stopSyncListener: () => Promise<SyncTransportStatus>;
+  recordSyncLifecycleEvent: (event: SyncLifecycleEventRequest) => Promise<SyncTransportStatus>;
   syncTrustedPeerNow: (
     deviceId: string,
     options?: SyncTransportSyncNowOptions,
@@ -1926,6 +2114,7 @@ function createHttpTuneForgeClient(): TuneForgeClient {
     getSyncTransportStatus,
     startSyncListener,
     stopSyncListener,
+    recordSyncLifecycleEvent,
     syncTrustedPeerNow,
     streamArtifactUrl: (artifactId: string) => `${getApiBaseUrl()}/api/v1/artifacts/${artifactId}/stream`,
   };
@@ -2031,6 +2220,7 @@ function createMobileTuneForgeClient(capabilities: MobileCapabilities): TuneForg
     getSyncTransportStatus,
     startSyncListener,
     stopSyncListener,
+    recordSyncLifecycleEvent,
     syncTrustedPeerNow,
     streamArtifactUrl: (artifactId: string) => {
       const artifactPath = mobileArtifactPaths.get(artifactId);
@@ -2123,6 +2313,7 @@ export const api: TuneForgeClient = {
   getSyncTransportStatus: () => activeClient.getSyncTransportStatus(),
   startSyncListener: () => activeClient.startSyncListener(),
   stopSyncListener: () => activeClient.stopSyncListener(),
+  recordSyncLifecycleEvent: (event: SyncLifecycleEventRequest) => activeClient.recordSyncLifecycleEvent(event),
   syncTrustedPeerNow: (deviceId: string, options?: SyncTransportSyncNowOptions) =>
     activeClient.syncTrustedPeerNow(deviceId, options),
   streamArtifactUrl: (artifactId: string) => activeClient.streamArtifactUrl(artifactId),

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -10,6 +10,7 @@ import type {
   LyricsGenerateRequest,
   ListJobsParams,
   ListProjectsParams,
+  SyncLifecycleEventRequest,
   SyncPreflightResponse,
   SyncPairingAnswerRequest,
   SyncPairingAnswerResponse,
@@ -70,6 +71,7 @@ const {
   mockGetSyncTransportStatus,
   mockStartSyncListener,
   mockStopSyncListener,
+  mockRecordSyncLifecycleEvent,
   mockCreateSyncPairingOffer,
   mockAnswerSyncPairingOffer,
   mockListSyncTrustedPeers,
@@ -1635,6 +1637,29 @@ const {
     };
     return clone(state.syncTransportStatus);
   });
+  const mockRecordSyncLifecycleEvent = vi.fn(async (event: SyncLifecycleEventRequest) => {
+    const occurredAt = event.occurredAt ?? createdAt;
+    const lifecycleEvent = {
+      kind: event.kind,
+      occurred_at: occurredAt,
+      message: event.message ?? null,
+      retryable: false,
+      interruption_code: null,
+      retry_guidance: null,
+      peer_device_id: null,
+      run_id: null,
+    };
+    const lifecycleEvents = Array.isArray(state.syncTransportStatus.lifecycle_events)
+      ? state.syncTransportStatus.lifecycle_events
+      : [];
+    state.syncTransportStatus = {
+      ...state.syncTransportStatus,
+      last_lifecycle_event: lifecycleEvent,
+      lifecycle_events: [...lifecycleEvents, lifecycleEvent],
+      updated_at: occurredAt,
+    };
+    return clone(state.syncTransportStatus);
+  });
   const mockCreateSyncPairingOffer = vi.fn(async (
     body: SyncPairingOfferRequest,
   ): Promise<SyncPairingOfferResponse> => ({
@@ -2314,6 +2339,7 @@ const {
     mockGetSyncTransportStatus,
     mockStartSyncListener,
     mockStopSyncListener,
+    mockRecordSyncLifecycleEvent,
     mockCreateSyncPairingOffer,
     mockAnswerSyncPairingOffer,
     mockListSyncTrustedPeers,
@@ -2387,6 +2413,7 @@ export {
   mockGetSyncTransportStatus,
   mockStartSyncListener,
   mockStopSyncListener,
+  mockRecordSyncLifecycleEvent,
   mockCreateSyncPairingOffer,
   mockAnswerSyncPairingOffer,
   mockListSyncTrustedPeers,
@@ -2454,6 +2481,7 @@ vi.mock("../lib/api", async (importOriginal) => {
       getSyncTransportStatus: mockGetSyncTransportStatus,
       startSyncListener: mockStartSyncListener,
       stopSyncListener: mockStopSyncListener,
+      recordSyncLifecycleEvent: mockRecordSyncLifecycleEvent,
       createSyncPairingOffer: mockCreateSyncPairingOffer,
       answerSyncPairingOffer: mockAnswerSyncPairingOffer,
       listSyncTrustedPeers: mockListSyncTrustedPeers,
@@ -2854,6 +2882,7 @@ export function resetAppTestHarness() {
   mockGetSyncTransportStatus.mockClear();
   mockStartSyncListener.mockClear();
   mockStopSyncListener.mockClear();
+  mockRecordSyncLifecycleEvent.mockClear();
   mockCreateSyncPairingOffer.mockClear();
   mockAnswerSyncPairingOffer.mockClear();
   mockListSyncTrustedPeers.mockClear();

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -139,9 +139,23 @@ staging peaks. Do not record audio content, file contents, filenames, absolute p
 raw device/project/artifact IDs, endpoint hints, or pairing payloads.
 
 For listener lifecycle validation, start, stop, restart, pause, and resume the Android listener where
-the build supports it. Record whether desktop peers recover, whether fallback was used, and whether
-synced projects remain deduped after reconnect. If Android still reports the transport stub, record
-that blocker and limit the run to pairing, storage, and playback checks.
+the build supports it. The UI records native-only lifecycle events through
+`sync_transport_record_lifecycle_event`: desktop background events from `visibilitychange` hidden,
+window blur, and `pagehide` stay passive; Android hidden/pagehide records `android_background`, and
+Android window blur records `android_screen_lock` so active sync runs are interrupted for retry.
+Foreground events from window focus, `visibilitychange` visible, and `pageshow` refresh listener
+state; Android foreground uses `android_foreground`. Browser `online` and `offline` events record
+network recovery/interruption. Offline or Android lifecycle interruptions may expose native retry
+guidance and a trusted peer ID; when they do, the UI shows Retry Sync and reuses the normal preflight
+plus Sync Now path, including nearby endpoint hints.
+
+Desktop sleep/wake has no native command bridge. The UI uses an elapsed-time check while visible: a
+long timer gap records `sleep` followed by `wake`, while ordinary desktop hidden/blur/pagehide remains
+passive. Current Android builds still do not expose a separate OS screen-lock callback to React, so
+screen lock is inferred from Android focus/visibility changes.
+Record whether desktop peers recover, whether fallback was used, and whether synced projects remain
+deduped after reconnect. If Android still reports the transport stub, record that blocker and limit
+the run to pairing, storage, and playback checks.
 
 For QR pairing validation, grant the camera permission, scan a pairing QR code with the Android
 build, and record whether the scan produced the expected pairing payload before trusting the peer.


### PR DESCRIPTION
## Summary
- Add native sync lifecycle event handling for retryable interruptions.
- Surface retry guidance, lifecycle evidence, and a Retry Sync path in desktop sync UI.
- Document lifecycle validation behavior for desktop and Android.

Closes #201

## Testing
- `git diff --check`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test`
- `pnpm --filter @tuneforge/desktop test -- App.activity.test.tsx src/lib/api.mobile-sync.test.ts`
- `cd apps/desktop/src-tauri && cargo check`
- `cd apps/desktop/src-tauri && cargo test sync_transport` outside sandbox: 104 passed
- Manual VM smoke: hide/blur sync continued; network-offline sync interrupted with retry guidance; retry reused staged artifacts and completed.
- Manual VM smoke: sleep/wake recorded lifecycle evidence; retry completed after interruption.

