### PR TITLE
feat: Add chord dictionary foundation

### DIFF
--- a/apps/desktop/src/App.tools-chord-dictionary.test.tsx
+++ b/apps/desktop/src/App.tools-chord-dictionary.test.tsx
@@ -1,0 +1,43 @@
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import { renderApp, resetAppTestHarness } from "./test/appTestHarness";
+
+describe("Desktop app tools chord dictionary", () => {
+  beforeEach(resetAppTestHarness);
+
+  it("renders the chord dictionary page from the tools route", async () => {
+    renderApp(["/tools?tool=chord-dictionary"]);
+
+    expect(await screen.findByRole("heading", { name: "Chord Dictionary" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Chord Dictionary" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByLabelText("Chord search")).toHaveValue("C");
+    expect(screen.getByRole("button", { name: "Guitar" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByLabelText("Display context")).toBeInTheDocument();
+    expect(screen.getAllByText("CAGED").length).toBeGreaterThan(0);
+    expect(screen.getByText("C E G")).toBeInTheDocument();
+  });
+
+  it("switches between dictionary and live follow surfaces", async () => {
+    const user = userEvent.setup();
+    renderApp(["/tools?tool=chord-dictionary"]);
+
+    expect(await screen.findByRole("heading", { name: "Chord Dictionary" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Live Follow" }));
+
+    expect(screen.queryByRole("dialog", { name: "C chord preview" })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "C" }));
+    expect(screen.getByRole("dialog", { name: "C chord preview" })).toBeInTheDocument();
+
+    await user.click(
+      within(screen.getByRole("group", { name: "Chord dictionary views" })).getByRole(
+        "button",
+        { name: "Dictionary" },
+      ),
+    );
+    expect(screen.getByLabelText("Note inspector")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/features/tools/ChordDictionaryPage.tsx
+++ b/apps/desktop/src/features/tools/ChordDictionaryPage.tsx
@@ -1,0 +1,728 @@
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import {
+  ArrowUpDown,
+  AudioLines,
+  Gauge,
+  Layers,
+  Music2,
+  RefreshCw,
+  Settings,
+  SlidersHorizontal,
+} from "lucide-react";
+import {
+  CHORD_QUALITY_DEFINITIONS,
+  GUITAR_STANDARD_PROFILE,
+  formatKey,
+  generateGuitarVoicings,
+  midiToPitch,
+  spellChord,
+  type ChordDisplayContext,
+  type GuitarVoicing,
+} from "../../lib/music";
+
+type ChordDictionarySurface = "dictionary" | "follow";
+type InstrumentId = "guitar" | "piano" | "accordion" | "organ";
+type NotePoint = {
+  degree: string;
+  finger: string;
+  fret: number;
+  id: string;
+  note: string;
+  shapeNote?: string;
+  string: number;
+};
+type GuitarShape = {
+  id: string;
+  label: string;
+  meta: string;
+  notes: NotePoint[];
+};
+
+const COMMON_CHORD_LABELS = ["C", "Dm", "Em", "F", "G", "Am", "Bdim"] as const;
+
+const liveProgression = [
+  { chord: "C", shape: "C", seconds: "0:38", notes: "C4 E4 G4" },
+  { chord: "G/D", shape: "close", seconds: "0:42", notes: "D4 G4 B4" },
+  { chord: "Am/C", shape: "close", seconds: "0:46", notes: "C4 E4 A4" },
+  { chord: "F/C", shape: "close", seconds: "0:50", notes: "C4 F4 A4" },
+] as const;
+
+const instrumentOptions: Array<{ id: InstrumentId; label: string }> = [
+  { id: "guitar", label: "Guitar" },
+  { id: "piano", label: "Piano" },
+  { id: "accordion", label: "Accordion" },
+  { id: "organ", label: "Organ" },
+];
+
+function classNames(...values: Array<string | false | null | undefined>) {
+  return values.filter(Boolean).join(" ");
+}
+
+export function ChordDictionaryPage() {
+  const [surface, setSurface] = useState<ChordDictionarySurface>("dictionary");
+
+  return (
+    <div className="chord-dictionary-shell">
+      <div className="panel chord-dictionary-panel">
+        <div className="chord-dictionary-header">
+          <div>
+            <h2>Chord Dictionary</h2>
+            <p className="subpanel__copy">Shapes, voicings, notes.</p>
+          </div>
+          <div className="chord-dictionary-actions" role="group" aria-label="Chord dictionary views">
+            <button
+              aria-pressed={surface === "dictionary"}
+              className={classNames(
+                "chord-icon-button",
+                surface === "dictionary" && "chord-icon-button--active",
+              )}
+              onClick={() => setSurface("dictionary")}
+              title="Dictionary"
+              type="button"
+            >
+              <Layers aria-hidden="true" />
+              <span>Dictionary</span>
+            </button>
+            <button
+              aria-pressed={surface === "follow"}
+              className={classNames(
+                "chord-icon-button",
+                surface === "follow" && "chord-icon-button--active",
+              )}
+              onClick={() => setSurface("follow")}
+              title="Live follow"
+              type="button"
+            >
+              <AudioLines aria-hidden="true" />
+              <span>Live Follow</span>
+            </button>
+          </div>
+        </div>
+
+        {surface === "dictionary" ? <DictionarySurface /> : <LiveFollowSurface />}
+      </div>
+    </div>
+  );
+}
+
+function DictionarySurface() {
+  const [instrument, setInstrument] = useState<InstrumentId>("guitar");
+  const [activeChord, setActiveChord] = useState("C");
+  const [activeShape, setActiveShape] = useState("c-open");
+  const [selectedNoteId, setSelectedNoteId] = useState("c-open-4");
+  const [followArmed, setFollowArmed] = useState(false);
+  const [previewActive, setPreviewActive] = useState(false);
+  const displayContext = useMemo<Partial<ChordDisplayContext>>(
+    () =>
+      followArmed && previewActive
+        ? {
+            canCapo: true,
+            capoFret: 2,
+            sourceKey: { pitchClass: 6, mode: "major" },
+            useCapoShapes: true,
+          }
+        : {
+            canCapo: true,
+            capoFret: 0,
+            sourceKey: { pitchClass: 0, mode: "major" },
+            useCapoShapes: false,
+          },
+    [followArmed, previewActive],
+  );
+  const effectiveChord = followArmed && previewActive ? "F#" : activeChord;
+  const chordSpelling = spellChord(effectiveChord);
+  const commonChords = useMemo(
+    () =>
+      COMMON_CHORD_LABELS.map((label) => {
+        const spelling = spellChord(label);
+        const voicing = generateGuitarVoicings(label)[0] ?? null;
+        return {
+          id: label,
+          label,
+          notes: spelling?.notes.join(" ") ?? "",
+          quality: spelling ? CHORD_QUALITY_DEFINITIONS[spelling.quality].label : "",
+          voicing,
+        };
+      }),
+    [],
+  );
+  const guitarVoicings = useMemo(
+    () => generateGuitarVoicings(effectiveChord, GUITAR_STANDARD_PROFILE, displayContext),
+    [displayContext, effectiveChord],
+  );
+  const cagedShapes = useMemo(
+    () => guitarVoicings.map((voicing) => toGuitarShape(voicing)),
+    [guitarVoicings],
+  );
+  useEffect(() => {
+    const firstShape = cagedShapes[0];
+    if (!firstShape) {
+      return;
+    }
+    setActiveShape(firstShape.id);
+    setSelectedNoteId(firstShape.notes[0]?.id ?? "empty-note");
+  }, [cagedShapes]);
+  const selectedShape = cagedShapes.find((shape) => shape.id === activeShape) ?? cagedShapes[0];
+  const selectedNote =
+    cagedShapes.flatMap((shape) => shape.notes).find((note) => note.id === selectedNoteId) ??
+    selectedShape?.notes[0] ??
+    emptyNotePoint;
+  const shapeFamily =
+    guitarVoicings.find((voicing) => voicing.id === selectedShape?.id)?.shapeFamily ??
+    selectedShape?.label.slice(0, 1) ??
+    "C";
+  const sourceKeyLabel = displayContext.sourceKey
+    ? formatKey(displayContext.sourceKey, "long")
+    : "C major";
+  const transposeLabel = `${displayContext.transposeSemitones ?? 0}`;
+  const capoLabel = displayContext.capoFret ? `+${displayContext.capoFret}` : "0";
+
+  return (
+    <div className="chord-dictionary">
+      <div className="chord-dictionary-toolbar">
+        <label className="chord-search">
+          <span className="sr-only">Chord search</span>
+          <Music2 aria-hidden="true" />
+          <input
+            aria-label="Chord search"
+            onChange={(event) => setActiveChord(event.currentTarget.value || "C")}
+            placeholder="C major"
+            value={activeChord}
+          />
+        </label>
+        <div className="chord-toolbar-cluster" aria-label="Instrument controls">
+          {instrumentOptions.map((option) => (
+            <button
+              key={option.id}
+              aria-pressed={instrument === option.id}
+              className={classNames(
+                "chord-pill",
+                instrument === option.id && "chord-pill--active",
+              )}
+              onClick={() => setInstrument(option.id)}
+              type="button"
+            >
+              <Music2 aria-hidden="true" />
+              <span>{option.label}</span>
+            </button>
+          ))}
+          <button className="chord-pill chord-pill--muted" type="button">
+            <span>48</span>
+            <span>More</span>
+          </button>
+        </div>
+        <div className="chord-toolbar-cluster chord-toolbar-cluster--end">
+          <button
+            aria-label="Toggle project follow"
+            aria-pressed={followArmed}
+            className={classNames("chord-icon-button", followArmed && "chord-icon-button--active")}
+            onClick={() => setFollowArmed((current) => !current)}
+            title="Follow project playback"
+            type="button"
+          >
+            <RefreshCw aria-hidden="true" />
+            <span className="chord-live-dot" aria-hidden="true" />
+          </button>
+          <button
+            aria-label="Preview playback active state"
+            aria-pressed={previewActive}
+            className={classNames("chord-icon-button", previewActive && "chord-icon-button--active")}
+            onClick={() => setPreviewActive((current) => !current)}
+            title="Playback active"
+            type="button"
+          >
+            <AudioLines aria-hidden="true" />
+          </button>
+          <button className="chord-icon-button" title="Saved shapes" type="button">
+            <Music2 aria-hidden="true" />
+          </button>
+          <button className="chord-icon-button" title="Settings" type="button">
+            <Settings aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+
+      <div className="chord-context-strip" aria-label="Display context">
+        <ContextChip icon="key" label={sourceKeyLabel} />
+        <ContextChip icon="transpose" label={transposeLabel} />
+        <ContextChip icon="capo" label={capoLabel} />
+        <span className="chord-context-arrow" aria-hidden="true">-&gt;</span>
+        <ContextChip icon="shape" label={`${shapeFamily} shape`} />
+        <ContextChip icon="sound" label={effectiveChord} />
+      </div>
+
+      <div className="chord-tool-grid">
+        <main className="chord-tool-main">
+          <div className="chord-field-row">
+            <button className="chord-field" type="button">
+              <span>Instrument</span>
+              <strong>{instrumentOptions.find((option) => option.id === instrument)?.label}</strong>
+            </button>
+            <button className="chord-field" type="button">
+              <span>Tuning</span>
+              <strong>E A D G B E</strong>
+            </button>
+            <button className="chord-field chord-field--compact" type="button">
+              <span>Capo</span>
+              <strong>Yes</strong>
+            </button>
+            <button className="chord-field chord-field--compact" type="button">
+              <span>Retune</span>
+              <strong>Yes</strong>
+            </button>
+          </div>
+
+          <section className="chord-section">
+            <div className="chord-section-heading">
+              <div>
+                <p className="metric-label">Basic chords</p>
+                <h3>C major</h3>
+              </div>
+              <div className="chord-view-toggle" role="group" aria-label="Dictionary filters">
+                <button className="chord-mini-button chord-mini-button--active" type="button">
+                  Major
+                </button>
+                <button className="chord-mini-button" type="button">Minor</button>
+                <button className="chord-mini-button" type="button">7ths</button>
+              </div>
+            </div>
+            <div className="chord-card-row">
+              {commonChords.map((chord) => (
+                <button
+                  key={chord.id}
+                  className={classNames(
+                    "chord-family-card",
+                    activeChord === chord.label && "chord-family-card--active",
+                  )}
+                  onClick={() => setActiveChord(chord.label)}
+                  type="button"
+                >
+                  <strong>{chord.label}</strong>
+                  <span>{chord.quality}</span>
+                  <MiniFretboard notes={chord.voicing?.notes ?? []} />
+                  <small>{chord.notes}</small>
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <section className="chord-section">
+            <div className="chord-section-heading chord-section-heading--inline">
+              <div>
+                <p className="metric-label">{chordSpelling?.label ?? effectiveChord}</p>
+                <h3>CAGED</h3>
+              </div>
+              <div className="chord-shape-tabs" role="tablist" aria-label="CAGED shape family">
+                {cagedShapes.map((shape) => (
+                  <button
+                    key={shape.id}
+                    aria-selected={selectedShape?.id === shape.id}
+                    className={classNames(
+                      "chord-shape-tab",
+                      selectedShape?.id === shape.id && "chord-shape-tab--active",
+                    )}
+                    onClick={() => {
+                      setActiveShape(shape.id);
+                      setSelectedNoteId(shape.notes[0]?.id ?? selectedNoteId);
+                    }}
+                    role="tab"
+                    type="button"
+                  >
+                    {shape.label.replace(/\s.*$/, "")}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="chord-shape-grid">
+              {cagedShapes.map((shape) => (
+                <div
+                  key={shape.id}
+                  className={classNames(
+                    "chord-shape-card",
+                    shape.id === activeShape && "chord-shape-card--active",
+                  )}
+                >
+                  <button
+                    className="chord-shape-card__label"
+                    onClick={() => {
+                      setActiveShape(shape.id);
+                      setSelectedNoteId(shape.notes[0]?.id ?? selectedNoteId);
+                    }}
+                    type="button"
+                  >
+                    {shape.label}
+                  </button>
+                  <GuitarFretboard
+                    maxFret={Math.max(...shape.notes.map((note) => note.fret), 4)}
+                    notes={shape.notes}
+                    selectedNoteId={selectedNoteId}
+                    onSelectNote={setSelectedNoteId}
+                  />
+                  <span className="chord-shape-card__meta">{shape.meta}</span>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <NoteInspector note={selectedNote} capoActive={followArmed && previewActive} />
+        </main>
+
+        <aside className="chord-understanding-panel">
+          <div className="chord-understanding-panel__header">
+            <div>
+              <p className="metric-label">Instrument</p>
+              <h3>Guitar</h3>
+            </div>
+            <SlidersHorizontal aria-hidden="true" />
+          </div>
+          <dl className="chord-fact-list">
+            <div>
+              <dt>Range</dt>
+              <dd>E2 - E6</dd>
+            </div>
+            <div>
+              <dt>Tuning</dt>
+              <dd>EADGBE</dd>
+            </div>
+            <div>
+              <dt>Surface</dt>
+              <dd>6 x 22</dd>
+            </div>
+            <div>
+              <dt>Capo</dt>
+              <dd>Yes</dd>
+            </div>
+          </dl>
+          <div className="chord-accordion-list">
+            {[
+              ["CAGED", "Common path"],
+              ["Generated", "All shapes"],
+              ["Setup", "Tunings"],
+              ["Atlas", "Piano, accordion, organ"],
+            ].map(([label, meta]) => (
+              <button key={label} className="chord-accordion-row" type="button">
+                <span>
+                  <strong>{label}</strong>
+                  <small>{meta}</small>
+                </span>
+                <span aria-hidden="true">-&gt;</span>
+              </button>
+            ))}
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+const emptyNotePoint: NotePoint = {
+  degree: "1",
+  finger: "",
+  fret: 0,
+  id: "empty-note",
+  note: "C4",
+  string: 1,
+};
+
+function toGuitarShape(voicing: GuitarVoicing): GuitarShape {
+  const frets = voicing.notes.map((note) => note.fret);
+  const minFret = Math.min(...frets);
+  const maxFret = Math.max(...frets);
+  return {
+    id: voicing.id,
+    label: voicing.label,
+    meta: `${voicing.source === "common" ? "Common" : "Generated"} · frets ${minFret}-${maxFret}`,
+    notes: voicing.notes.map((note) => {
+      const shapePitch =
+        voicing.capoFret > 0 ? midiToPitch(note.pitch.midi - voicing.capoFret)?.label : null;
+      return {
+        degree: note.degree,
+        finger: note.finger ? String(note.finger) : "",
+        fret: note.fret,
+        id: `${voicing.id}-${note.string}-${note.fret}`,
+        note: note.note,
+        shapeNote: shapePitch ?? undefined,
+        string: note.string,
+      };
+    }),
+  };
+}
+
+function ContextChip({ icon, label }: { icon: "capo" | "key" | "shape" | "sound" | "transpose"; label: string }) {
+  const Icon =
+    icon === "transpose" ? ArrowUpDown : icon === "capo" ? Gauge : icon === "shape" ? Layers : Music2;
+  return (
+    <span className="chord-context-chip">
+      <Icon aria-hidden="true" />
+      <span>{label}</span>
+    </span>
+  );
+}
+
+function MiniFretboard({ notes }: { notes: readonly GuitarVoicing["notes"][number][] }) {
+  const dots = notes.slice(0, 4).map((note) => ({
+    fret: Math.max(1, Math.min(4, note.fret + 1)),
+    string: Math.max(1, Math.min(5, note.string)),
+  }));
+  return (
+    <span className="mini-fretboard" aria-hidden="true">
+      {dots.map((dot) => (
+        <span
+          key={`${dot.string}-${dot.fret}`}
+          className="mini-fretboard__dot"
+          style={{ "--fret": dot.fret, "--string": dot.string } as CSSProperties}
+        />
+      ))}
+    </span>
+  );
+}
+
+function GuitarFretboard({
+  maxFret,
+  notes,
+  onSelectNote,
+  selectedNoteId,
+}: {
+  maxFret: number;
+  notes: readonly NotePoint[];
+  onSelectNote: (noteId: string) => void;
+  selectedNoteId: string;
+}) {
+  const displayFrets = Math.max(4, Math.min(8, maxFret));
+  return (
+    <span
+      className="guitar-fretboard"
+      style={{ "--display-frets": displayFrets } as CSSProperties}
+      aria-label="Guitar fretboard"
+      role="group"
+    >
+      <span className="guitar-fretboard__numbers" aria-hidden="true">
+        {Array.from({ length: displayFrets + 1 }, (_, fret) => (
+          <span key={fret}>{fret}</span>
+        ))}
+      </span>
+      <span className="guitar-fretboard__board">
+        {notes.map((note) => (
+          <button
+            key={note.id}
+            aria-label={`${note.note} string ${note.string} fret ${note.fret}`}
+            className={classNames(
+              "guitar-fretboard__dot",
+              selectedNoteId === note.id && "guitar-fretboard__dot--selected",
+            )}
+            onClick={(event) => {
+              event.stopPropagation();
+              onSelectNote(note.id);
+            }}
+            style={{ "--fret": note.fret, "--string": note.string } as CSSProperties}
+            type="button"
+          >
+            {note.finger}
+          </button>
+        ))}
+      </span>
+      <span className="guitar-fretboard__strings" aria-hidden="true">
+        <span>E</span>
+        <span>B</span>
+        <span>G</span>
+        <span>D</span>
+        <span>A</span>
+        <span>E</span>
+      </span>
+    </span>
+  );
+}
+
+function NoteInspector({ capoActive, note }: { capoActive: boolean; note: NotePoint }) {
+  return (
+    <section className="note-inspector" aria-label="Note inspector">
+      <div className="note-inspector__badge">
+        <strong>{note.note}</strong>
+        <span>{note.degree}</span>
+      </div>
+      <dl>
+        <div>
+          <dt>String</dt>
+          <dd>{note.string}</dd>
+        </div>
+        <div>
+          <dt>Fret</dt>
+          <dd>{note.fret}</dd>
+        </div>
+        <div>
+          <dt>Finger</dt>
+          <dd>{note.finger}</dd>
+        </div>
+        <div>
+          <dt>Degree</dt>
+          <dd>{note.degree}</dd>
+        </div>
+        {capoActive ? (
+          <>
+            <div>
+              <dt>Capo</dt>
+              <dd>+2</dd>
+            </div>
+            <div>
+              <dt>Shape note</dt>
+              <dd>{note.shapeNote ?? note.note}</dd>
+            </div>
+          </>
+        ) : null}
+      </dl>
+    </section>
+  );
+}
+
+function LiveFollowSurface() {
+  const [peekOpen, setPeekOpen] = useState(false);
+  const [activeShape, setActiveShape] = useState("close");
+
+  return (
+    <div className="live-follow-page">
+      <div className="live-follow-topbar">
+        <div className="live-follow-controls" role="group" aria-label="Live chord display controls">
+          <button className="chord-pill chord-pill--active" type="button">
+            <Music2 aria-hidden="true" />
+            <span>Accordion</span>
+          </button>
+          <button className="chord-pill" type="button">
+            <Layers aria-hidden="true" />
+            <span>{activeShape}</span>
+          </button>
+          <button className="chord-pill" type="button">
+            <ArrowUpDown aria-hidden="true" />
+            <span>C major</span>
+          </button>
+        </div>
+        <div className="live-follow-tray" aria-label="Upcoming chord shapes">
+          {liveProgression.map((item, index) => (
+            <button
+              key={item.chord}
+              className={classNames("live-shape-chip", index === 0 && "live-shape-chip--active")}
+              onClick={() => setActiveShape(item.shape)}
+              type="button"
+            >
+              <strong>{item.chord}</strong>
+              <span>{item.shape}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="lyrics-follow-stage">
+        <div className="lyrics-follow-line lyrics-follow-line--muted">
+          <div className="lyrics-chord-space" />
+          <span>Tonight is heavy on one side</span>
+        </div>
+        <div className="lyrics-follow-line lyrics-follow-line--active">
+          <div className="lyrics-chord-space">
+            <button
+              className="lyrics-chord-chip lyrics-chord-chip--active"
+              onFocus={() => setPeekOpen(true)}
+              onClick={() => setPeekOpen(true)}
+              onMouseEnter={() => setPeekOpen(true)}
+              type="button"
+            >
+              C
+            </button>
+            {peekOpen ? (
+              <div className="chord-peek" role="dialog" aria-label="C chord preview">
+                <div className="chord-peek__header">
+                  <strong>C</strong>
+                  <div className="chord-shape-tabs chord-shape-tabs--compact" role="group" aria-label="C shape choices">
+                    {["natural", "C/E", "C/G"].map((shape) => (
+                      <button
+                        key={shape}
+                        className={classNames(
+                          "chord-shape-tab",
+                          shape === "natural" && "chord-shape-tab--active",
+                        )}
+                        type="button"
+                      >
+                        {shape}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <AccordionPreview />
+                <div className="chord-note-row">
+                  {["C4", "E4", "G4"].map((note) => (
+                    <span key={note}>{note}</span>
+                  ))}
+                </div>
+                <div className="chord-peek__actions">
+                  <button className="chord-mini-button chord-mini-button--active" type="button">
+                    Pin
+                  </button>
+                  <button className="chord-mini-button" type="button">Dictionary</button>
+                </div>
+              </div>
+            ) : null}
+          </div>
+          <span>You've got something on your mind and so have I</span>
+        </div>
+        <div className="lyrics-follow-line">
+          <div className="lyrics-chord-space">
+            <button className="lyrics-chord-chip" type="button">G/D</button>
+            <button className="lyrics-chord-chip" type="button">Am/C</button>
+          </div>
+          <span>I can see it from here, oh</span>
+        </div>
+        <div className="lyrics-follow-line lyrics-follow-line--muted">
+          <div className="lyrics-chord-space">
+            <button className="lyrics-chord-chip" type="button">F/C</button>
+          </div>
+          <span>Ten years later, it's been a decade</span>
+        </div>
+      </div>
+
+      <div className="live-follow-bottom">
+        <div className="live-follow-timeline">
+          {liveProgression.map((item, index) => (
+            <button
+              key={item.chord}
+              className={classNames("live-timeline-segment", index === 0 && "live-timeline-segment--active")}
+              type="button"
+            >
+              <strong>{item.chord}</strong>
+              <span>{item.seconds}</span>
+            </button>
+          ))}
+        </div>
+        <div className="live-transport-strip">
+          <button aria-label="Seek back" className="chord-icon-button" type="button">
+            <RefreshCw aria-hidden="true" />
+          </button>
+          <button aria-label="Play playback" className="chord-icon-button chord-icon-button--active" type="button">
+            <AudioLines aria-hidden="true" />
+          </button>
+          <input aria-label="Playback position" max="100" min="0" type="range" value="38" readOnly />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AccordionPreview() {
+  return (
+    <div className="accordion-preview" aria-label="Accordion C chord">
+      <div className="accordion-buttons" aria-hidden="true">
+        {Array.from({ length: 36 }, (_, index) => {
+          const active = index === 14 || index === 20;
+          return <span key={index} className={active ? "accordion-buttons__dot accordion-buttons__dot--active" : "accordion-buttons__dot"} />;
+        })}
+      </div>
+      <div className="accordion-keys" aria-hidden="true">
+        {Array.from({ length: 15 }, (_, index) => {
+          const active = index === 4 || index === 7 || index === 11;
+          return <span key={index} className={active ? "accordion-keys__key accordion-keys__key--active" : "accordion-keys__key"} />;
+        })}
+      </div>
+      <div className="accordion-preview__hint">
+        <span>E4</span>
+        <small>3</small>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/tools/ToolsView.tsx
+++ b/apps/desktop/src/features/tools/ToolsView.tsx
@@ -46,11 +46,12 @@ import {
   calculateTunerInputLevel,
   type TunerPitchReading,
 } from "./tunerPitch";
+import { ChordDictionaryPage } from "./ChordDictionaryPage";
 
 const SYSTEM_INPUT_VOLUME_COMMIT_DELAY_MS = 180;
 
 type TunerStatus = "idle" | "starting" | "listening" | "unsupported" | "error";
-type ToolId = "tuner" | "metronome";
+type ToolId = "tuner" | "metronome" | "chord-dictionary";
 type CaptureBackend = "native" | "web";
 
 export function ToolsView() {
@@ -64,8 +65,13 @@ export function ToolsView() {
       nextSearchParams.delete("bpm");
       nextSearchParams.delete("followPlayback");
       nextSearchParams.delete("projectId");
-    } else {
+    } else if (tool === "metronome") {
       nextSearchParams.set("tool", "metronome");
+    } else {
+      nextSearchParams.set("tool", "chord-dictionary");
+      nextSearchParams.delete("bpm");
+      nextSearchParams.delete("followPlayback");
+      nextSearchParams.delete("projectId");
     }
     setSearchParams(nextSearchParams);
   }
@@ -84,6 +90,7 @@ export function ToolsView() {
         {[
           { id: "tuner", label: "Chromatic Tuner" },
           { id: "metronome", label: "Metronome" },
+          { id: "chord-dictionary", label: "Chord Dictionary" },
         ].map((tool) => (
           <button
             key={tool.id}
@@ -100,13 +107,23 @@ export function ToolsView() {
         ))}
       </div>
 
-      {activeTool === "tuner" ? <ChromaticTunerPage /> : <MetronomePage />}
+      {activeTool === "tuner" ? (
+        <ChromaticTunerPage />
+      ) : activeTool === "metronome" ? (
+        <MetronomePage />
+      ) : (
+        <ChordDictionaryPage />
+      )}
     </section>
   );
 }
 
 function readToolId(searchParams: URLSearchParams): ToolId {
-  return searchParams.get("tool") === "metronome" ? "metronome" : "tuner";
+  const tool = searchParams.get("tool");
+  if (tool === "metronome" || tool === "chord-dictionary") {
+    return tool;
+  }
+  return "tuner";
 }
 
 function ChromaticTunerPage() {

--- a/apps/desktop/src/lib/music.test.ts
+++ b/apps/desktop/src/lib/music.test.ts
@@ -1,11 +1,24 @@
 import { describe, expect, it } from "vitest";
 import {
+  formatParsedChordLabel,
+  formatPitch,
   formatChordDisplay,
   formatChordLabel,
   formatKey,
   formatKeyDisplay,
   formatPitchClass,
+  generateGuitarVoicings,
+  getCapoShapeChord,
   getEnharmonicContext,
+  midiToPitch,
+  parseChordLabel,
+  parsePitch,
+  pitchToMidi,
+  spellChord,
+  transposeChordLabel,
+  type ChordDisplayContext,
+  type ChordSpelling,
+  type GuitarVoicing,
   type MusicalKey,
 } from "./music";
 
@@ -71,5 +84,209 @@ describe("enharmonic formatting", () => {
     expect(formatChordLabel(2, "major", { mode: "sharps" }, 6)).toBe("D/F#");
     expect(formatChordLabel(0, "minor", { mode: "flats" }, 7)).toBe("Cm/G");
     expect(formatChordLabel(0, "hdim7")).toBe("Cm7b5");
+  });
+});
+
+function requireChord(label: string): ChordSpelling {
+  const chord = spellChord(label);
+  if (!chord) {
+    throw new Error(`Expected ${label} to parse`);
+  }
+  return chord;
+}
+
+function requireFirstVoicing(label: string, context: Partial<ChordDisplayContext> = {}): GuitarVoicing {
+  const voicing = generateGuitarVoicings(label, undefined, context)[0];
+  if (!voicing) {
+    throw new Error(`Expected ${label} to produce a voicing`);
+  }
+  return voicing;
+}
+
+describe("pitch parsing and midi conversion", () => {
+  it("parses pitch labels with octaves", () => {
+    expect(parsePitch("C4")).toEqual({
+      pitchClass: 0,
+      octave: 4,
+      midi: 60,
+      noteName: "C",
+      label: "C4",
+    });
+    expect(parsePitch("Db3")).toMatchObject({
+      pitchClass: 1,
+      octave: 3,
+      midi: 49,
+      noteName: "Db",
+      label: "Db3",
+    });
+    expect(parsePitch("E2")?.midi).toBe(40);
+    expect(parsePitch("H2")).toBeNull();
+  });
+
+  it("formats pitches and converts midi values", () => {
+    expect(pitchToMidi({ pitchClass: 6, octave: 4 })).toBe(66);
+    expect(formatPitch({ pitchClass: 10, octave: 3 }, { mode: "sharps" })).toBe("A#3");
+    expect(midiToPitch(61, { mode: "flats" })).toEqual({
+      pitchClass: 1,
+      octave: 4,
+      midi: 61,
+      noteName: "Db",
+      label: "Db4",
+    });
+  });
+});
+
+describe("chord parsing and spelling", () => {
+  it("parses compact chord labels and slash bass notes", () => {
+    expect(parseChordLabel("G/D")).toEqual({
+      root: "G",
+      rootPitchClass: 7,
+      quality: "major",
+      bass: "D",
+      bassPitchClass: 2,
+    });
+    expect(parseChordLabel("Cmaj7")?.quality).toBe("maj7");
+    expect(parseChordLabel("Am7")?.quality).toBe("m7");
+    expect(parseChordLabel("Bdim")?.quality).toBe("dim");
+  });
+
+  it("spells requested chord qualities", () => {
+    expect(requireChord("C").notes).toEqual(["C", "E", "G"]);
+    expect(requireChord("Dm").notes).toEqual(["D", "F", "A"]);
+    expect(requireChord("Bdim").tones.map((tone) => `${tone.degree}:${tone.noteName}`)).toEqual([
+      "1:B",
+      "b3:D",
+      "b5:F",
+    ]);
+    expect(requireChord("G7").tones.map((tone) => `${tone.degree}:${tone.noteName}`)).toEqual([
+      "1:G",
+      "3:B",
+      "5:D",
+      "b7:F",
+    ]);
+    expect(requireChord("Cmaj7").notes).toEqual(["C", "E", "G", "B"]);
+    expect(requireChord("Am7").notes).toEqual(["A", "C", "E", "G"]);
+    expect(requireChord("G/D").bassNoteName).toBe("D");
+  });
+
+  it("transposes chord labels by semitones", () => {
+    expect(transposeChordLabel("C", 2)).toBe("D");
+    expect(transposeChordLabel("G/D", 2)).toBe("A/E");
+    expect(formatParsedChordLabel(requireChord("Cmaj7"), { mode: "flats" })).toBe("Cmaj7");
+  });
+});
+
+describe("guitar chord voicings", () => {
+  it("ranks C major open shape first with exact sounding notes", () => {
+    const voicing = requireFirstVoicing("C");
+    expect(voicing).toMatchObject({
+      id: "c-open",
+      shapeFamily: "C",
+      source: "common",
+      mutedStrings: [6],
+    });
+    expect(voicing.notes.map(({ string, fret, note, degree }) => ({ string, fret, note, degree }))).toEqual([
+      { string: 5, fret: 3, note: "C3", degree: "1" },
+      { string: 4, fret: 2, note: "E3", degree: "3" },
+      { string: 3, fret: 0, note: "G3", degree: "5" },
+      { string: 2, fret: 1, note: "C4", degree: "1" },
+      { string: 1, fret: 0, note: "E4", degree: "3" },
+    ]);
+  });
+
+  it("returns G major open shape", () => {
+    const voicing = requireFirstVoicing("G");
+    expect(voicing.shapeFamily).toBe("G");
+    expect(voicing.notes.map(({ string, fret, note, degree }) => ({ string, fret, note, degree }))).toEqual([
+      { string: 6, fret: 3, note: "G2", degree: "1" },
+      { string: 5, fret: 2, note: "B2", degree: "3" },
+      { string: 4, fret: 0, note: "D3", degree: "5" },
+      { string: 3, fret: 0, note: "G3", degree: "1" },
+      { string: 2, fret: 0, note: "B3", degree: "3" },
+      { string: 1, fret: 3, note: "G4", degree: "1" },
+    ]);
+  });
+
+  it("returns Am open shape", () => {
+    const voicing = requireFirstVoicing("Am");
+    expect(voicing.shapeFamily).toBe("A");
+    expect(voicing.notes.map(({ string, fret, note, degree }) => ({ string, fret, note, degree }))).toEqual([
+      { string: 5, fret: 0, note: "A2", degree: "1" },
+      { string: 4, fret: 2, note: "E3", degree: "5" },
+      { string: 3, fret: 2, note: "A3", degree: "1" },
+      { string: 2, fret: 1, note: "C4", degree: "b3" },
+      { string: 1, fret: 0, note: "E4", degree: "5" },
+    ]);
+  });
+
+  it("returns F barre before open partial shape", () => {
+    const voicings = generateGuitarVoicings("F");
+    expect(voicings.map((voicing) => voicing.id).slice(0, 2)).toEqual(["f-e-barre", "f-partial"]);
+    expect(voicings[0]?.notes.map(({ string, fret, note, degree }) => ({ string, fret, note, degree }))).toEqual([
+      { string: 6, fret: 1, note: "F2", degree: "1" },
+      { string: 5, fret: 3, note: "C3", degree: "5" },
+      { string: 4, fret: 3, note: "F3", degree: "1" },
+      { string: 3, fret: 2, note: "A3", degree: "3" },
+      { string: 2, fret: 1, note: "C4", degree: "5" },
+      { string: 1, fret: 1, note: "F4", degree: "1" },
+    ]);
+  });
+
+  it("returns Cmaj7 and G7 open extensions", () => {
+    expect(requireFirstVoicing("Cmaj7").notes.map(({ note, degree }) => `${note}:${degree}`)).toEqual([
+      "C3:1",
+      "E3:3",
+      "G3:5",
+      "B3:7",
+      "E4:3",
+    ]);
+    expect(requireFirstVoicing("G7").notes.map(({ note, degree }) => `${note}:${degree}`)).toEqual([
+      "G2:1",
+      "B2:3",
+      "D3:5",
+      "G3:1",
+      "B3:3",
+      "F4:b7",
+    ]);
+  });
+
+  it("keeps slash chord bass as the lowest sounding guitar note", () => {
+    const voicing = requireFirstVoicing("G/D");
+    expect(voicing).toMatchObject({
+      id: "g-over-d-open",
+      chordLabel: "G/D",
+    });
+    expect(voicing.notes[0]).toMatchObject({
+      note: "D3",
+      degree: "5",
+      string: 4,
+      fret: 0,
+    });
+  });
+
+  it("uses capo shapes while preserving sounding chord notes", () => {
+    const context: Partial<ChordDisplayContext> = {
+      sourceKey: { pitchClass: 6, mode: "major" },
+      capoFret: 2,
+      useCapoShapes: true,
+      canCapo: true,
+    };
+    expect(formatParsedChordLabel(getCapoShapeChord("F#", context) ?? requireChord("E"))).toBe("E");
+
+    const voicing = requireFirstVoicing("F#", context);
+    expect(voicing).toMatchObject({
+      shapeFamily: "E",
+      chordLabel: "F#",
+      shapeChordLabel: "E",
+      capoFret: 2,
+    });
+    expect(voicing.notes.map(({ string, fret, note, degree }) => ({ string, fret, note, degree }))).toEqual([
+      { string: 6, fret: 0, note: "F#2", degree: "1" },
+      { string: 5, fret: 2, note: "C#3", degree: "5" },
+      { string: 4, fret: 2, note: "F#3", degree: "1" },
+      { string: 3, fret: 1, note: "A#3", degree: "3" },
+      { string: 2, fret: 0, note: "C#4", degree: "5" },
+      { string: 1, fret: 0, note: "F#4", degree: "1" },
+    ]);
   });
 });

--- a/apps/desktop/src/lib/music.ts
+++ b/apps/desktop/src/lib/music.ts
@@ -23,6 +23,11 @@ export type PitchFormatOptions = {
   mode?: EnharmonicDisplayMode;
 };
 
+export type Pitch = ParsedPitch;
+export type ParsedChordSymbol = ChordSpelling;
+export type GuitarStringProfile = GuitarStringTuning;
+export type GuitarVoicingPosition = GuitarVoicingNote;
+
 type AccidentalFamily = "sharp" | "flat" | "neutral";
 
 export type EnharmonicContext = {
@@ -39,6 +44,116 @@ export type FormattedMusicalLabel = {
   ariaLabel: string;
   primary: MusicalLabelPart;
   secondary: MusicalLabelPart | null;
+};
+
+export type ParsedPitch = {
+  pitchClass: number;
+  octave: number;
+  midi: number;
+  noteName: string;
+  label: string;
+};
+
+export type PitchLike = Pick<ParsedPitch, "octave" | "pitchClass">;
+
+export type ChordSpellingQuality = "major" | "minor" | "dim" | "7" | "maj7" | "m7";
+
+export type ChordDegree = "1" | "b3" | "3" | "b5" | "5" | "b7" | "7";
+
+export type ChordToneDefinition = {
+  degree: ChordDegree;
+  interval: number;
+};
+
+export type ChordQualityDefinition = {
+  label: string;
+  suffix: string;
+  tones: readonly ChordToneDefinition[];
+};
+
+export type ParsedChord = {
+  root: string;
+  rootPitchClass: number;
+  quality: ChordSpellingQuality;
+  bass: string | null;
+  bassPitchClass: number | null;
+};
+
+export type ChordTone = ChordToneDefinition & {
+  pitchClass: number;
+  noteName: string;
+};
+
+export type ChordSpelling = ParsedChord & {
+  label: string;
+  tones: readonly ChordTone[];
+  notes: readonly string[];
+  bassNoteName: string | null;
+};
+
+export type ChordInput = string | ParsedChord | ChordSpelling;
+
+export type ChordDisplayContext = {
+  sourceKey: MusicalKey | null;
+  transposeSemitones: number;
+  capoFret: number;
+  useCapoShapes: boolean;
+  canCapo: boolean;
+};
+
+export type GuitarFinger = 1 | 2 | 3 | 4;
+export type GuitarShapeFamily = "C" | "A" | "G" | "E" | "D";
+
+export type GuitarStringTuning = {
+  string: number;
+  openPitch: ParsedPitch;
+};
+
+export type GuitarProfile = {
+  id: "guitar";
+  label: string;
+  tuning: readonly GuitarStringTuning[];
+  frets: number;
+  canCapo: boolean;
+  canRetune: boolean;
+};
+
+export type GuitarVoicingTemplateNote = {
+  string: number;
+  fret: number;
+  finger?: GuitarFinger;
+};
+
+export type GuitarVoicingTemplate = {
+  id: string;
+  label: string;
+  shapeChordLabel: string;
+  shapeFamily: GuitarShapeFamily;
+  rank: number;
+  notes: readonly GuitarVoicingTemplateNote[];
+};
+
+export type GuitarVoicingNote = {
+  string: number;
+  fret: number;
+  soundingFret: number;
+  degree: ChordDegree;
+  note: string;
+  pitch: ParsedPitch;
+  finger?: GuitarFinger;
+};
+
+export type GuitarVoicing = {
+  id: string;
+  label: string;
+  chordLabel: string;
+  shapeChordLabel: string;
+  shapeFamily?: GuitarShapeFamily;
+  source: "common" | "generated";
+  rank: number;
+  capoFret: number;
+  mutedStrings: readonly number[];
+  notes: readonly GuitarVoicingNote[];
 };
 
 const ENHARMONIC_ALIASES: Record<string, number> = {
@@ -64,6 +179,227 @@ const ENHARMONIC_ALIASES: Record<string, number> = {
   B: 11,
   Cb: 11,
 };
+
+export const CHORD_QUALITY_DEFINITIONS: Record<ChordSpellingQuality, ChordQualityDefinition> = {
+  major: {
+    label: "Major",
+    suffix: "",
+    tones: [
+      { degree: "1", interval: 0 },
+      { degree: "3", interval: 4 },
+      { degree: "5", interval: 7 },
+    ],
+  },
+  minor: {
+    label: "Minor",
+    suffix: "m",
+    tones: [
+      { degree: "1", interval: 0 },
+      { degree: "b3", interval: 3 },
+      { degree: "5", interval: 7 },
+    ],
+  },
+  dim: {
+    label: "Diminished",
+    suffix: "dim",
+    tones: [
+      { degree: "1", interval: 0 },
+      { degree: "b3", interval: 3 },
+      { degree: "b5", interval: 6 },
+    ],
+  },
+  "7": {
+    label: "Dominant 7",
+    suffix: "7",
+    tones: [
+      { degree: "1", interval: 0 },
+      { degree: "3", interval: 4 },
+      { degree: "5", interval: 7 },
+      { degree: "b7", interval: 10 },
+    ],
+  },
+  maj7: {
+    label: "Major 7",
+    suffix: "maj7",
+    tones: [
+      { degree: "1", interval: 0 },
+      { degree: "3", interval: 4 },
+      { degree: "5", interval: 7 },
+      { degree: "7", interval: 11 },
+    ],
+  },
+  m7: {
+    label: "Minor 7",
+    suffix: "m7",
+    tones: [
+      { degree: "1", interval: 0 },
+      { degree: "b3", interval: 3 },
+      { degree: "5", interval: 7 },
+      { degree: "b7", interval: 10 },
+    ],
+  },
+};
+
+const PARSED_CHORD_PATTERN = /^([A-G](?:#|b)?)(maj7|m7|dim|m|7)?(?:\/([A-G](?:#|b)?))?$/i;
+
+export const DEFAULT_CHORD_DISPLAY_CONTEXT: ChordDisplayContext = {
+  sourceKey: null,
+  transposeSemitones: 0,
+  capoFret: 0,
+  useCapoShapes: false,
+  canCapo: true,
+};
+
+export const GUITAR_STANDARD_PROFILE: GuitarProfile = {
+  id: "guitar",
+  label: "Guitar",
+  tuning: [
+    { string: 6, openPitch: parsePitchRequired("E2") },
+    { string: 5, openPitch: parsePitchRequired("A2") },
+    { string: 4, openPitch: parsePitchRequired("D3") },
+    { string: 3, openPitch: parsePitchRequired("G3") },
+    { string: 2, openPitch: parsePitchRequired("B3") },
+    { string: 1, openPitch: parsePitchRequired("E4") },
+  ],
+  frets: 22,
+  canCapo: true,
+  canRetune: true,
+};
+
+export const INSTRUMENT_PROFILES = {
+  guitar: GUITAR_STANDARD_PROFILE,
+} as const;
+
+export const GUITAR_COMMON_VOICING_TEMPLATES: readonly GuitarVoicingTemplate[] = [
+  {
+    id: "c-open",
+    label: "C open",
+    shapeChordLabel: "C",
+    shapeFamily: "C",
+    rank: 10,
+    notes: [
+      { string: 5, fret: 3, finger: 3 },
+      { string: 4, fret: 2, finger: 2 },
+      { string: 3, fret: 0 },
+      { string: 2, fret: 1, finger: 1 },
+      { string: 1, fret: 0 },
+    ],
+  },
+  {
+    id: "g-open",
+    label: "G open",
+    shapeChordLabel: "G",
+    shapeFamily: "G",
+    rank: 10,
+    notes: [
+      { string: 6, fret: 3, finger: 2 },
+      { string: 5, fret: 2, finger: 1 },
+      { string: 4, fret: 0 },
+      { string: 3, fret: 0 },
+      { string: 2, fret: 0 },
+      { string: 1, fret: 3, finger: 3 },
+    ],
+  },
+  {
+    id: "g-over-d-open",
+    label: "G/D open",
+    shapeChordLabel: "G/D",
+    shapeFamily: "G",
+    rank: 12,
+    notes: [
+      { string: 4, fret: 0 },
+      { string: 3, fret: 0 },
+      { string: 2, fret: 0 },
+      { string: 1, fret: 3, finger: 3 },
+    ],
+  },
+  {
+    id: "am-open",
+    label: "Am open",
+    shapeChordLabel: "Am",
+    shapeFamily: "A",
+    rank: 10,
+    notes: [
+      { string: 5, fret: 0 },
+      { string: 4, fret: 2, finger: 2 },
+      { string: 3, fret: 2, finger: 3 },
+      { string: 2, fret: 1, finger: 1 },
+      { string: 1, fret: 0 },
+    ],
+  },
+  {
+    id: "f-e-barre",
+    label: "F E-shape barre",
+    shapeChordLabel: "F",
+    shapeFamily: "E",
+    rank: 10,
+    notes: [
+      { string: 6, fret: 1, finger: 1 },
+      { string: 5, fret: 3, finger: 3 },
+      { string: 4, fret: 3, finger: 4 },
+      { string: 3, fret: 2, finger: 2 },
+      { string: 2, fret: 1, finger: 1 },
+      { string: 1, fret: 1, finger: 1 },
+    ],
+  },
+  {
+    id: "f-partial",
+    label: "F partial",
+    shapeChordLabel: "F",
+    shapeFamily: "E",
+    rank: 20,
+    notes: [
+      { string: 4, fret: 3, finger: 3 },
+      { string: 3, fret: 2, finger: 2 },
+      { string: 2, fret: 1, finger: 1 },
+      { string: 1, fret: 1, finger: 1 },
+    ],
+  },
+  {
+    id: "cmaj7-open",
+    label: "Cmaj7 open",
+    shapeChordLabel: "Cmaj7",
+    shapeFamily: "C",
+    rank: 10,
+    notes: [
+      { string: 5, fret: 3, finger: 3 },
+      { string: 4, fret: 2, finger: 2 },
+      { string: 3, fret: 0 },
+      { string: 2, fret: 0 },
+      { string: 1, fret: 0 },
+    ],
+  },
+  {
+    id: "g7-open",
+    label: "G7 open",
+    shapeChordLabel: "G7",
+    shapeFamily: "G",
+    rank: 10,
+    notes: [
+      { string: 6, fret: 3, finger: 3 },
+      { string: 5, fret: 2, finger: 2 },
+      { string: 4, fret: 0 },
+      { string: 3, fret: 0 },
+      { string: 2, fret: 0 },
+      { string: 1, fret: 1, finger: 1 },
+    ],
+  },
+  {
+    id: "e-open",
+    label: "E open",
+    shapeChordLabel: "E",
+    shapeFamily: "E",
+    rank: 10,
+    notes: [
+      { string: 6, fret: 0 },
+      { string: 5, fret: 2, finger: 2 },
+      { string: 4, fret: 2, finger: 3 },
+      { string: 3, fret: 1, finger: 1 },
+      { string: 2, fret: 0 },
+      { string: 1, fret: 0 },
+    ],
+  },
+] as const;
 
 const SHARP_PITCH_CLASSES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"] as const;
 const FLAT_PITCH_CLASSES = ["C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"] as const;
@@ -378,6 +714,468 @@ export function semitoneDelta(source: MusicalKey, target: MusicalKey): number {
     return 0;
   }
   return upwardDistance <= 6 ? upwardDistance : upwardDistance - 12;
+}
+
+export function parsePitch(value: string | null | undefined): ParsedPitch | null {
+  if (!value) {
+    return null;
+  }
+
+  const match = value.trim().match(/^([A-G](?:#|b)?)(-?\d+)$/i);
+  if (!match) {
+    return null;
+  }
+
+  const noteName = normalizeNoteName(match[1]);
+  const pitchClass = ENHARMONIC_ALIASES[noteName];
+  const octave = Number(match[2]);
+  if (pitchClass === undefined || !Number.isInteger(octave)) {
+    return null;
+  }
+
+  const midi = pitchToMidi({ octave, pitchClass });
+  return {
+    pitchClass,
+    octave,
+    midi,
+    noteName,
+    label: `${noteName}${octave}`,
+  };
+}
+
+export function formatPitch(pitch: PitchLike, options: PitchFormatOptions = {}): string {
+  return `${formatPitchClass(pitch.pitchClass, options)}${pitch.octave}`;
+}
+
+export function pitchToMidi(pitch: PitchLike): number {
+  return (pitch.octave + 1) * 12 + normalizePitchClass(pitch.pitchClass);
+}
+
+export function midiToPitch(midi: number, options: PitchFormatOptions = {}): ParsedPitch | null {
+  if (!Number.isInteger(midi)) {
+    return null;
+  }
+
+  const pitchClass = normalizePitchClass(midi);
+  const octave = Math.floor(midi / 12) - 1;
+  const noteName = formatPitchClass(pitchClass, options);
+  return {
+    pitchClass,
+    octave,
+    midi,
+    noteName,
+    label: `${noteName}${octave}`,
+  };
+}
+
+export function parseChordLabel(label: string | null | undefined): ParsedChord | null {
+  if (!label) {
+    return null;
+  }
+
+  const match = label.trim().match(PARSED_CHORD_PATTERN);
+  if (!match) {
+    return null;
+  }
+
+  const root = normalizeNoteName(match[1]);
+  const rootPitchClass = ENHARMONIC_ALIASES[root];
+  const quality = parseChordQualitySuffix(match[2] ?? "");
+  if (rootPitchClass === undefined || !quality) {
+    return null;
+  }
+
+  const bass = match[3] ? normalizeNoteName(match[3]) : null;
+  const bassPitchClass = bass ? ENHARMONIC_ALIASES[bass] : null;
+  if (bass && bassPitchClass === undefined) {
+    return null;
+  }
+
+  return {
+    root,
+    rootPitchClass,
+    quality,
+    bass,
+    bassPitchClass,
+  };
+}
+
+export function isChordSpellingQuality(quality: string | null | undefined): quality is ChordSpellingQuality {
+  return (
+    quality === "major" ||
+    quality === "minor" ||
+    quality === "dim" ||
+    quality === "7" ||
+    quality === "maj7" ||
+    quality === "m7"
+  );
+}
+
+export function formatParsedChordLabel(chord: ParsedChord, options: PitchFormatOptions = {}): string {
+  return formatChordLabel(
+    chord.rootPitchClass,
+    chord.quality,
+    resolveChordFormatOptions(chord, options),
+    chord.bassPitchClass,
+  );
+}
+
+export function spellChord(chord: ChordInput, options: PitchFormatOptions = {}): ChordSpelling | null {
+  const parsedChord = parseChordInput(chord);
+  if (!parsedChord) {
+    return null;
+  }
+
+  const chordOptions = resolveChordFormatOptions(parsedChord, options);
+  const definition = CHORD_QUALITY_DEFINITIONS[parsedChord.quality];
+  const tones = definition.tones.map((tone) => {
+    const pitchClass = transposePitchClass(parsedChord.rootPitchClass, tone.interval);
+    return {
+      ...tone,
+      pitchClass,
+      noteName: formatPitchClass(pitchClass, chordOptions),
+    };
+  });
+
+  const bassNoteName =
+    typeof parsedChord.bassPitchClass === "number" ? formatPitchClass(parsedChord.bassPitchClass, chordOptions) : null;
+
+  return {
+    ...parsedChord,
+    label: formatParsedChordLabel(parsedChord, chordOptions),
+    tones,
+    notes: tones.map((tone) => tone.noteName),
+    bassNoteName,
+  };
+}
+
+export function transposeChord(chord: ChordInput, semitones: number): ParsedChord | null {
+  const parsedChord = parseChordInput(chord);
+  if (!parsedChord) {
+    return null;
+  }
+  return transposeParsedChord(parsedChord, semitones);
+}
+
+export function transposeChordLabel(
+  chord: ChordInput,
+  semitones: number,
+  options: PitchFormatOptions = {},
+): string | null {
+  const transposed = transposeChord(chord, semitones);
+  return transposed ? formatParsedChordLabel(transposed, options) : null;
+}
+
+export function resolveChordDisplayContext(
+  context: Partial<ChordDisplayContext> = {},
+  profile: Pick<GuitarProfile, "canCapo"> = GUITAR_STANDARD_PROFILE,
+): ChordDisplayContext {
+  const capoFret = Math.max(0, Math.trunc(context.capoFret ?? DEFAULT_CHORD_DISPLAY_CONTEXT.capoFret));
+  const canCapo = context.canCapo ?? profile.canCapo;
+  return {
+    sourceKey: context.sourceKey ?? DEFAULT_CHORD_DISPLAY_CONTEXT.sourceKey,
+    transposeSemitones: context.transposeSemitones ?? DEFAULT_CHORD_DISPLAY_CONTEXT.transposeSemitones,
+    capoFret,
+    useCapoShapes: context.useCapoShapes ?? DEFAULT_CHORD_DISPLAY_CONTEXT.useCapoShapes,
+    canCapo,
+  };
+}
+
+export function getCapoShapeSemitones(
+  context: Partial<ChordDisplayContext> = {},
+  profile: Pick<GuitarProfile, "canCapo"> = GUITAR_STANDARD_PROFILE,
+): number {
+  const resolvedContext = resolveChordDisplayContext(context, profile);
+  return resolvedContext.useCapoShapes && resolvedContext.canCapo ? -resolvedContext.capoFret : 0;
+}
+
+export function getCapoShapeChord(
+  chord: ChordInput,
+  context: Partial<ChordDisplayContext> = {},
+  profile: Pick<GuitarProfile, "canCapo"> = GUITAR_STANDARD_PROFILE,
+): ParsedChord | null {
+  const parsedChord = parseChordInput(chord);
+  if (!parsedChord) {
+    return null;
+  }
+  const resolvedContext = resolveChordDisplayContext(context, profile);
+  const soundingChord = transposeParsedChord(parsedChord, resolvedContext.transposeSemitones);
+  return transposeParsedChord(soundingChord, getCapoShapeSemitones(resolvedContext, profile));
+}
+
+export function generateGuitarVoicings(
+  chord: ChordInput,
+  profile: GuitarProfile = GUITAR_STANDARD_PROFILE,
+  context: Partial<ChordDisplayContext> = {},
+  options: PitchFormatOptions = {},
+): readonly GuitarVoicing[] {
+  const parsedChord = parseChordInput(chord);
+  if (!parsedChord) {
+    return [];
+  }
+
+  const resolvedContext = resolveChordDisplayContext(context, profile);
+  const soundingChord = transposeParsedChord(parsedChord, resolvedContext.transposeSemitones);
+  const shapeChord = transposeParsedChord(soundingChord, getCapoShapeSemitones(resolvedContext, profile));
+  const chordOptions = {
+    ...resolveChordFormatOptions(soundingChord, options),
+    activeKey: options.activeKey ?? resolvedContext.sourceKey ?? resolveChordFormatOptions(soundingChord).activeKey,
+  };
+  const soundingSpelling = spellChord(soundingChord, chordOptions);
+  const shapeLabel = formatParsedChordLabel(shapeChord, chordOptions);
+  if (!soundingSpelling) {
+    return [];
+  }
+
+  const commonVoicings = GUITAR_COMMON_VOICING_TEMPLATES.flatMap((template) => {
+    const templateChord = parseChordLabel(template.shapeChordLabel);
+    if (
+      !templateChord ||
+      templateChord.rootPitchClass !== shapeChord.rootPitchClass ||
+      templateChord.quality !== shapeChord.quality ||
+      templateChord.bassPitchClass !== shapeChord.bassPitchClass
+    ) {
+      return [];
+    }
+
+    const voicing = renderGuitarTemplate(template, soundingSpelling, shapeLabel, profile, resolvedContext, chordOptions);
+    return voicing ? [voicing] : [];
+  });
+
+  const generatedVoicing = generateFallbackGuitarVoicing(
+    soundingSpelling,
+    shapeLabel,
+    profile,
+    resolvedContext,
+    chordOptions,
+  );
+  return [...commonVoicings, ...(generatedVoicing ? [generatedVoicing] : [])].sort((left, right) => {
+    if (left.source !== right.source) {
+      return left.source === "common" ? -1 : 1;
+    }
+    return left.rank - right.rank;
+  });
+}
+
+function parsePitchRequired(label: string): ParsedPitch {
+  const pitch = parsePitch(label);
+  if (!pitch) {
+    throw new Error(`Invalid pitch label: ${label}`);
+  }
+  return pitch;
+}
+
+function parseChordQualitySuffix(suffix: string): ChordSpellingQuality | null {
+  switch (suffix.toLowerCase()) {
+    case "":
+      return "major";
+    case "m":
+      return "minor";
+    case "dim":
+      return "dim";
+    case "7":
+      return "7";
+    case "maj7":
+      return "maj7";
+    case "m7":
+      return "m7";
+    default:
+      return null;
+  }
+}
+
+function parseChordInput(chord: ChordInput): ParsedChord | null {
+  if (typeof chord === "string") {
+    return parseChordLabel(chord);
+  }
+  return {
+    root: chord.root,
+    rootPitchClass: normalizePitchClass(chord.rootPitchClass),
+    quality: chord.quality,
+    bass: chord.bass,
+    bassPitchClass: typeof chord.bassPitchClass === "number" ? normalizePitchClass(chord.bassPitchClass) : null,
+  };
+}
+
+function transposeParsedChord(chord: ParsedChord, semitones: number): ParsedChord {
+  const rootPitchClass = transposePitchClass(chord.rootPitchClass, semitones);
+  const bassPitchClass =
+    typeof chord.bassPitchClass === "number" ? transposePitchClass(chord.bassPitchClass, semitones) : null;
+  return {
+    root: formatPitchClass(rootPitchClass, resolveChordFormatOptions({ ...chord, rootPitchClass })),
+    rootPitchClass,
+    quality: chord.quality,
+    bass: typeof bassPitchClass === "number" ? formatPitchClass(bassPitchClass) : null,
+    bassPitchClass,
+  };
+}
+
+function resolveChordFormatOptions(
+  chord: Pick<ParsedChord, "quality" | "rootPitchClass">,
+  options: PitchFormatOptions = {},
+): PitchFormatOptions {
+  if (options.activeKey || options.mode) {
+    return options;
+  }
+  return {
+    activeKey: {
+      pitchClass: normalizePitchClass(chord.rootPitchClass),
+      mode: chord.quality === "minor" || chord.quality === "m7" ? "minor" : "major",
+    } satisfies MusicalKey,
+  };
+}
+
+function renderGuitarTemplate(
+  template: GuitarVoicingTemplate,
+  chord: ChordSpelling,
+  shapeChordLabel: string,
+  profile: GuitarProfile,
+  context: ChordDisplayContext,
+  options: PitchFormatOptions,
+): GuitarVoicing | null {
+  const notes = template.notes
+    .map((templateNote) => renderGuitarNote(templateNote, chord, profile, context, options))
+    .filter((note): note is GuitarVoicingNote => Boolean(note));
+  if (notes.length !== template.notes.length) {
+    return null;
+  }
+  if (!hasRequiredChordDegrees(chord, notes) || !hasRequiredBass(chord, notes)) {
+    return null;
+  }
+
+  return {
+    id: `${template.id}${context.capoFret > 0 ? `-capo-${context.capoFret}` : ""}`,
+    label: template.label,
+    chordLabel: chord.label,
+    shapeChordLabel,
+    shapeFamily: template.shapeFamily,
+    source: "common",
+    rank: template.rank,
+    capoFret: context.useCapoShapes && context.canCapo ? context.capoFret : 0,
+    mutedStrings: getMutedStrings(profile, template.notes),
+    notes,
+  };
+}
+
+function renderGuitarNote(
+  templateNote: GuitarVoicingTemplateNote,
+  chord: ChordSpelling,
+  profile: GuitarProfile,
+  context: ChordDisplayContext,
+  options: PitchFormatOptions,
+): GuitarVoicingNote | null {
+  const tuning = profile.tuning.find((stringTuning) => stringTuning.string === templateNote.string);
+  const capoFret = context.useCapoShapes && context.canCapo ? context.capoFret : 0;
+  const soundingFret = capoFret + templateNote.fret;
+  if (!tuning || soundingFret > profile.frets) {
+    return null;
+  }
+
+  const pitch = midiToPitch(tuning.openPitch.midi + soundingFret, options);
+  if (!pitch) {
+    return null;
+  }
+
+  const degree = getChordDegreeForPitchClass(chord, pitch.pitchClass);
+  if (!degree) {
+    return null;
+  }
+
+  return {
+    string: templateNote.string,
+    fret: templateNote.fret,
+    soundingFret,
+    degree,
+    note: pitch.label,
+    pitch,
+    ...(templateNote.finger ? { finger: templateNote.finger } : {}),
+  };
+}
+
+function generateFallbackGuitarVoicing(
+  chord: ChordSpelling,
+  shapeChordLabel: string,
+  profile: GuitarProfile,
+  context: ChordDisplayContext,
+  options: PitchFormatOptions,
+): GuitarVoicing | null {
+  const capoFret = context.useCapoShapes && context.canCapo ? context.capoFret : 0;
+  const maxShapeFret = Math.min(5, profile.frets - capoFret);
+  const notes = profile.tuning
+    .map((stringTuning) => {
+      const match = findLowestChordFret(stringTuning, chord, capoFret, maxShapeFret, options);
+      return match;
+    })
+    .filter((note): note is GuitarVoicingNote => Boolean(note));
+
+  if (notes.length < 3 || !hasRequiredChordDegrees(chord, notes) || !hasRequiredBass(chord, notes)) {
+    return null;
+  }
+
+  return {
+    id: `${chord.label.toLowerCase().replaceAll("/", "-")}-generated`,
+    label: `${chord.label} generated`,
+    chordLabel: chord.label,
+    shapeChordLabel,
+    source: "generated",
+    rank: 1000,
+    capoFret,
+    mutedStrings: getMutedStrings(profile, notes),
+    notes,
+  };
+}
+
+function findLowestChordFret(
+  tuning: GuitarStringTuning,
+  chord: ChordSpelling,
+  capoFret: number,
+  maxShapeFret: number,
+  options: PitchFormatOptions,
+): GuitarVoicingNote | null {
+  for (let fret = 0; fret <= maxShapeFret; fret += 1) {
+    const soundingFret = capoFret + fret;
+    const pitch = midiToPitch(tuning.openPitch.midi + soundingFret, options);
+    if (!pitch) {
+      return null;
+    }
+    const degree = getChordDegreeForPitchClass(chord, pitch.pitchClass);
+    if (degree) {
+      return {
+        string: tuning.string,
+        fret,
+        soundingFret,
+        degree,
+        note: pitch.label,
+        pitch,
+      };
+    }
+  }
+  return null;
+}
+
+function getChordDegreeForPitchClass(chord: ChordSpelling, pitchClass: number): ChordDegree | null {
+  return chord.tones.find((tone) => tone.pitchClass === normalizePitchClass(pitchClass))?.degree ?? null;
+}
+
+function hasRequiredChordDegrees(chord: ChordSpelling, notes: readonly GuitarVoicingNote[]): boolean {
+  const presentDegrees = new Set(notes.map((note) => note.degree));
+  return chord.tones.every((tone) => presentDegrees.has(tone.degree));
+}
+
+function hasRequiredBass(chord: ChordSpelling, notes: readonly GuitarVoicingNote[]): boolean {
+  if (typeof chord.bassPitchClass !== "number") {
+    return true;
+  }
+  const lowestNote = [...notes].sort((left, right) => left.pitch.midi - right.pitch.midi)[0];
+  return lowestNote?.pitch.pitchClass === chord.bassPitchClass;
+}
+
+function getMutedStrings(
+  profile: GuitarProfile,
+  playedNotes: readonly Pick<GuitarVoicingTemplateNote, "string">[],
+): readonly number[] {
+  const playedStrings = new Set(playedNotes.map((note) => note.string));
+  return profile.tuning.map((stringTuning) => stringTuning.string).filter((stringNumber) => !playedStrings.has(stringNumber));
 }
 
 function normalizeNoteName(noteName: string): string {

--- a/apps/desktop/src/styles/tools.css
+++ b/apps/desktop/src/styles/tools.css
@@ -319,6 +319,842 @@
   color: var(--muted);
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.chord-dictionary-shell {
+  max-width: min(100%, 1360px);
+}
+
+.chord-dictionary-panel {
+  display: grid;
+  gap: 1rem;
+  border-color: color-mix(in srgb, var(--playback-accent) 18%, var(--panel-border));
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--panel-strong) 88%, transparent), transparent 48%),
+    color-mix(in srgb, var(--panel) 94%, transparent);
+}
+
+.chord-dictionary-header,
+.chord-dictionary-toolbar,
+.chord-section-heading,
+.chord-section-heading--inline,
+.live-follow-topbar,
+.live-follow-bottom {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.chord-dictionary-header h2,
+.chord-section-heading h3,
+.chord-understanding-panel h3 {
+  margin: 0;
+}
+
+.chord-dictionary-actions,
+.chord-toolbar-cluster,
+.live-follow-controls,
+.live-follow-tray,
+.chord-view-toggle,
+.chord-shape-tabs,
+.chord-peek__actions,
+.chord-note-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.chord-toolbar-cluster--end {
+  margin-left: auto;
+}
+
+.chord-icon-button,
+.chord-pill,
+.chord-mini-button,
+.chord-shape-tab,
+.live-shape-chip,
+.lyrics-chord-chip,
+.live-timeline-segment {
+  border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+  background: color-mix(in srgb, var(--panel) 76%, var(--panel-strong) 24%);
+  color: var(--text);
+  cursor: pointer;
+  transition:
+    border-color 140ms ease,
+    background 140ms ease,
+    transform 140ms ease;
+}
+
+.chord-icon-button:hover,
+.chord-pill:hover,
+.chord-mini-button:hover,
+.chord-shape-tab:hover,
+.live-shape-chip:hover,
+.lyrics-chord-chip:hover,
+.live-timeline-segment:hover {
+  border-color: color-mix(in srgb, var(--playback-accent) 42%, var(--divider));
+}
+
+.chord-icon-button:focus-visible,
+.chord-pill:focus-visible,
+.chord-mini-button:focus-visible,
+.chord-shape-tab:focus-visible,
+.live-shape-chip:focus-visible,
+.lyrics-chord-chip:focus-visible,
+.live-timeline-segment:focus-visible,
+.guitar-fretboard__dot:focus-visible,
+.chord-shape-card__label:focus-visible,
+.chord-family-card:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.chord-icon-button {
+  min-width: 2.65rem;
+  min-height: 2.65rem;
+  border-radius: 8px;
+  padding: 0.55rem 0.7rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  font-weight: 850;
+}
+
+.chord-icon-button svg,
+.chord-pill svg,
+.chord-context-chip svg,
+.chord-understanding-panel__header svg {
+  width: 1rem;
+  height: 1rem;
+  flex: 0 0 auto;
+}
+
+.chord-icon-button--active,
+.chord-pill--active,
+.chord-mini-button--active,
+.chord-shape-tab--active,
+.live-shape-chip--active,
+.live-timeline-segment--active {
+  border-color: color-mix(in srgb, var(--playback-accent) 62%, var(--divider));
+  background: color-mix(in srgb, var(--playback-accent) 18%, var(--panel-strong));
+}
+
+.chord-live-dot {
+  width: 0.58rem;
+  height: 0.58rem;
+  border-radius: 999px;
+  background: var(--muted);
+}
+
+.chord-icon-button--active .chord-live-dot {
+  background: var(--playback-accent);
+  box-shadow: 0 0 0 0.22rem color-mix(in srgb, var(--playback-accent) 18%, transparent);
+}
+
+.chord-pill {
+  min-height: 2.65rem;
+  border-radius: 8px;
+  padding: 0.56rem 0.78rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--text);
+  font-size: 0.9rem;
+  font-weight: 850;
+}
+
+.chord-pill--muted {
+  color: var(--muted);
+}
+
+.chord-dictionary {
+  display: grid;
+  gap: 1rem;
+}
+
+.chord-dictionary-toolbar {
+  align-items: center;
+}
+
+.chord-search {
+  display: grid;
+  grid-template-columns: auto minmax(10rem, 18rem);
+  align-items: center;
+  gap: 0.6rem;
+  min-height: 2.75rem;
+  padding: 0 0.75rem;
+  border: 1px solid var(--input-border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--input-bg) 90%, var(--panel-strong));
+}
+
+.chord-search svg {
+  width: 1.05rem;
+  height: 1.05rem;
+  color: var(--muted);
+}
+
+.chord-search input {
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: var(--input-text);
+  font: inherit;
+  font-weight: 850;
+}
+
+.chord-search input:focus {
+  outline: 0;
+}
+
+.chord-context-strip {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-height: 3rem;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 70%, transparent);
+  border-radius: 8px;
+  overflow-x: auto;
+  background: color-mix(in srgb, var(--surface-muted) 48%, transparent);
+}
+
+.chord-context-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+  white-space: nowrap;
+  min-height: 2rem;
+  padding: 0.3rem 0.55rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 70%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 70%, var(--surface-muted));
+  color: var(--text);
+  font-size: 0.86rem;
+  font-weight: 850;
+}
+
+.chord-context-arrow {
+  color: var(--muted);
+  font-weight: 900;
+}
+
+.chord-tool-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(17rem, 21rem);
+  gap: 1rem;
+  align-items: start;
+}
+
+.chord-tool-main,
+.chord-understanding-panel,
+.live-follow-page {
+  min-width: 0;
+  border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--surface-muted) 38%, transparent);
+}
+
+.chord-tool-main,
+.live-follow-page {
+  display: grid;
+  gap: 1rem;
+  padding: 0.85rem;
+}
+
+.chord-field-row {
+  display: grid;
+  grid-template-columns: minmax(10rem, 1.25fr) minmax(12rem, 1.1fr) repeat(2, minmax(6rem, 0.55fr));
+  gap: 0.7rem;
+}
+
+.chord-field {
+  display: grid;
+  justify-items: start;
+  gap: 0.12rem;
+  min-height: 3.2rem;
+  padding: 0.6rem 0.72rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 70%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 76%, var(--panel-strong) 24%);
+  color: var(--text);
+  text-align: left;
+}
+
+.chord-field span {
+  color: var(--muted);
+  font-size: 0.74rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.chord-field strong {
+  font-size: 0.95rem;
+}
+
+.chord-section {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.chord-section-heading {
+  align-items: center;
+}
+
+.chord-card-row {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.7rem;
+}
+
+.chord-family-card {
+  display: grid;
+  justify-items: center;
+  gap: 0.25rem;
+  min-height: 10.5rem;
+  padding: 0.65rem 0.45rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 76%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 78%, var(--panel-strong) 22%);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.chord-family-card--active {
+  border-color: var(--playback-accent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--playback-accent) 26%, transparent);
+}
+
+.chord-family-card strong {
+  font-size: 1.28rem;
+  line-height: 1.1;
+}
+
+.chord-family-card span,
+.chord-family-card small,
+.chord-shape-card__meta {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 750;
+}
+
+.mini-fretboard {
+  position: relative;
+  display: block;
+  width: 4.7rem;
+  height: 5.25rem;
+  margin: 0.15rem 0;
+  border-top: 3px solid color-mix(in srgb, var(--text) 86%, transparent);
+  background:
+    linear-gradient(to right, transparent 0 8%, color-mix(in srgb, var(--divider) 70%, transparent) 8% 9%, transparent 9% 25%, color-mix(in srgb, var(--divider) 70%, transparent) 25% 26%, transparent 26% 42%, color-mix(in srgb, var(--divider) 70%, transparent) 42% 43%, transparent 43% 59%, color-mix(in srgb, var(--divider) 70%, transparent) 59% 60%, transparent 60% 76%, color-mix(in srgb, var(--divider) 70%, transparent) 76% 77%, transparent 77% 93%, color-mix(in srgb, var(--divider) 70%, transparent) 93% 94%, transparent 94%),
+    linear-gradient(to bottom, transparent 0 20%, color-mix(in srgb, var(--divider) 70%, transparent) 20% 21%, transparent 21% 40%, color-mix(in srgb, var(--divider) 70%, transparent) 40% 41%, transparent 41% 60%, color-mix(in srgb, var(--divider) 70%, transparent) 60% 61%, transparent 61% 80%, color-mix(in srgb, var(--divider) 70%, transparent) 80% 81%, transparent 81%);
+}
+
+.mini-fretboard__dot {
+  position: absolute;
+  left: calc((var(--string) - 1) * 17% + 7%);
+  top: calc((var(--fret) - 0.55) * 20%);
+  width: 0.66rem;
+  height: 0.66rem;
+  border-radius: 999px;
+  background: var(--text);
+}
+
+.chord-mini-button,
+.chord-shape-tab {
+  min-height: 2rem;
+  border-radius: 8px;
+  padding: 0.34rem 0.65rem;
+  color: var(--text);
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.chord-shape-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.chord-shape-card {
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.72rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 74%, var(--panel-strong) 26%);
+}
+
+.chord-shape-card--active {
+  border-color: var(--playback-accent);
+}
+
+.chord-shape-card__label {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 900;
+  text-align: left;
+}
+
+.guitar-fretboard {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.guitar-fretboard__numbers,
+.guitar-fretboard__strings {
+  display: flex;
+  justify-content: space-between;
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.guitar-fretboard__board {
+  position: relative;
+  display: block;
+  height: 8.6rem;
+  border-left: 4px solid color-mix(in srgb, var(--text) 82%, transparent);
+  background:
+    repeating-linear-gradient(
+      to right,
+      color-mix(in srgb, var(--divider) 78%, transparent) 0 1px,
+      transparent 1px calc(100% / var(--display-frets))
+    ),
+    repeating-linear-gradient(
+      to bottom,
+      color-mix(in srgb, var(--divider) 78%, transparent) 0 1px,
+      transparent 1px calc(100% / 6)
+    ),
+    color-mix(in srgb, var(--color-bg-inset) 82%, transparent);
+}
+
+.guitar-fretboard__dot {
+  position: absolute;
+  left: calc((var(--fret) - 0.5) * (100% / var(--display-frets)) - 0.72rem);
+  top: calc((var(--string) - 0.52) * (100% / 6) - 0.68rem);
+  display: grid;
+  width: 1.35rem;
+  height: 1.35rem;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, white 42%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text) 88%, var(--panel));
+  color: var(--panel);
+  font-size: 0.78rem;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.guitar-fretboard__dot--selected {
+  background: var(--playback-accent);
+  color: var(--panel);
+  box-shadow: 0 0 0 0.2rem color-mix(in srgb, var(--playback-accent) 22%, transparent);
+}
+
+.note-inspector {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.85rem;
+  align-items: center;
+  padding: 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 76%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 72%, transparent);
+}
+
+.note-inspector__badge {
+  display: grid;
+  place-items: center;
+  width: 4.3rem;
+  height: 4.3rem;
+  border: 1px solid color-mix(in srgb, var(--playback-accent) 58%, var(--divider));
+  border-radius: 999px;
+  color: var(--text);
+}
+
+.note-inspector__badge strong {
+  font-size: 1.1rem;
+}
+
+.note-inspector__badge span {
+  color: var(--playback-accent);
+  font-size: 0.82rem;
+  font-weight: 900;
+}
+
+.note-inspector dl {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0.55rem;
+  margin: 0;
+}
+
+.note-inspector dt,
+.chord-fact-list dt {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.note-inspector dd,
+.chord-fact-list dd {
+  margin: 0;
+  color: var(--text);
+  font-weight: 850;
+}
+
+.chord-understanding-panel {
+  display: grid;
+  gap: 1rem;
+  padding: 0.9rem;
+}
+
+.chord-understanding-panel__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.chord-fact-list {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.7rem;
+  margin: 0;
+}
+
+.chord-accordion-list {
+  display: grid;
+  border-top: 1px solid color-mix(in srgb, var(--divider) 70%, transparent);
+}
+
+.chord-accordion-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+  min-height: 3.2rem;
+  border: 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--divider) 70%, transparent);
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+}
+
+.chord-accordion-row span:first-child {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.chord-accordion-row small {
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.live-follow-page {
+  min-height: 41rem;
+}
+
+.live-follow-topbar,
+.live-follow-bottom {
+  align-items: center;
+}
+
+.live-shape-chip {
+  display: grid;
+  min-width: 5.25rem;
+  gap: 0.05rem;
+  border-radius: 8px;
+  padding: 0.45rem 0.6rem;
+  text-align: left;
+}
+
+.live-shape-chip span {
+  color: var(--muted);
+  font-size: 0.74rem;
+  font-weight: 800;
+}
+
+.lyrics-follow-stage {
+  position: relative;
+  display: grid;
+  gap: 1.45rem;
+  align-content: center;
+  min-height: 28rem;
+  padding: 3.2rem 2rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 72%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, black 18%, var(--color-bg-inset));
+}
+
+.lyrics-follow-line {
+  display: grid;
+  grid-template-columns: minmax(6rem, 10rem) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: end;
+  color: var(--text);
+  font-size: clamp(1.15rem, 2vw, 1.65rem);
+  font-weight: 750;
+}
+
+.lyrics-follow-line--muted {
+  color: var(--muted);
+}
+
+.lyrics-follow-line--active {
+  color: var(--text);
+}
+
+.lyrics-chord-space {
+  position: relative;
+  min-height: 2.1rem;
+  display: flex;
+  align-items: flex-end;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.lyrics-chord-chip {
+  min-width: 3rem;
+  border-radius: 8px;
+  padding: 0.26rem 0.5rem;
+  color: var(--playback-accent);
+  font-weight: 900;
+}
+
+.lyrics-chord-chip--active {
+  background: var(--playback-accent);
+  color: var(--panel);
+}
+
+.chord-peek {
+  position: absolute;
+  z-index: 2;
+  left: 0;
+  bottom: calc(100% + 0.65rem);
+  width: min(24rem, 78vw);
+  display: grid;
+  gap: 0.65rem;
+  padding: 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--playback-accent) 45%, var(--divider));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel-strong) 94%, black);
+  box-shadow: 0 1rem 2rem color-mix(in srgb, black 32%, transparent);
+}
+
+.chord-peek::after {
+  content: "";
+  position: absolute;
+  left: 1.1rem;
+  top: 100%;
+  border: 0.5rem solid transparent;
+  border-top-color: color-mix(in srgb, var(--panel-strong) 94%, black);
+}
+
+.chord-peek__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+}
+
+.chord-peek__header strong {
+  color: var(--text);
+  font-size: 1.45rem;
+}
+
+.chord-shape-tabs--compact .chord-shape-tab {
+  min-height: 1.8rem;
+  padding: 0.22rem 0.45rem;
+}
+
+.accordion-preview {
+  position: relative;
+  display: grid;
+  grid-template-columns: 8rem minmax(8rem, 1fr);
+  gap: 0.85rem;
+  align-items: center;
+}
+
+.accordion-buttons {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.25rem;
+  padding: 0.45rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 72%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--color-bg-inset) 84%, transparent);
+}
+
+.accordion-buttons__dot {
+  aspect-ratio: 1;
+  border: 1px solid color-mix(in srgb, var(--divider) 80%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--panel-strong) 80%, transparent);
+}
+
+.accordion-buttons__dot--active,
+.accordion-keys__key--active {
+  background: var(--playback-accent);
+  border-color: color-mix(in srgb, white 35%, var(--playback-accent));
+}
+
+.accordion-keys {
+  display: grid;
+  grid-template-columns: repeat(15, minmax(0, 1fr));
+  align-items: stretch;
+  height: 5.8rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 72%, transparent);
+  border-radius: 8px;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--text) 90%, white);
+}
+
+.accordion-keys__key {
+  border-right: 1px solid color-mix(in srgb, black 24%, transparent);
+  background: color-mix(in srgb, var(--text) 92%, white);
+}
+
+.accordion-keys__key:nth-child(2),
+.accordion-keys__key:nth-child(4),
+.accordion-keys__key:nth-child(7),
+.accordion-keys__key:nth-child(9),
+.accordion-keys__key:nth-child(11),
+.accordion-keys__key:nth-child(14) {
+  height: 60%;
+  background: #111827;
+}
+
+.accordion-preview__hint {
+  position: absolute;
+  right: 1.6rem;
+  top: 0.4rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.1rem;
+  min-width: 2.4rem;
+  padding: 0.28rem 0.35rem;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel-strong) 86%, black);
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 850;
+}
+
+.accordion-preview__hint small {
+  color: var(--playback-accent);
+}
+
+.chord-note-row span {
+  min-width: 3rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 72%, transparent);
+  border-radius: 8px;
+  padding: 0.24rem 0.45rem;
+  color: var(--text);
+  font-size: 0.82rem;
+  font-weight: 900;
+  text-align: center;
+}
+
+.live-follow-timeline {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.55rem;
+  flex: 1;
+}
+
+.live-timeline-segment {
+  display: grid;
+  gap: 0.12rem;
+  min-height: 3.2rem;
+  border-radius: 8px;
+  padding: 0.45rem 0.6rem;
+  text-align: left;
+}
+
+.live-timeline-segment span {
+  color: var(--muted);
+  font-size: 0.76rem;
+  font-weight: 800;
+}
+
+.live-transport-strip {
+  display: grid;
+  grid-template-columns: auto auto minmax(10rem, 16rem);
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.live-transport-strip input {
+  accent-color: var(--playback-accent);
+}
+
+@media (max-width: 1180px) {
+  .chord-tool-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .chord-card-row {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .chord-field-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .chord-dictionary-header,
+  .chord-dictionary-toolbar,
+  .chord-section-heading,
+  .live-follow-topbar,
+  .live-follow-bottom {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .chord-search {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .chord-card-row,
+  .chord-shape-grid,
+  .note-inspector dl,
+  .live-follow-timeline {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .note-inspector,
+  .accordion-preview,
+  .lyrics-follow-line,
+  .live-transport-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .lyrics-follow-stage {
+    padding: 2rem 1rem;
+  }
+}
+
 .simple-tuner-meter__status {
   color: var(--muted);
   font-size: 0.9rem;


### PR DESCRIPTION
## Summary

- Add a Chord Dictionary tools page backed by the shared music core.
- Add guitar-first pitch, chord spelling, capo, slash-bass, and voicing helpers.
- Add focused tests for the music core and chord dictionary route.

Closes #260

## Testing

- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test music.test.ts App.tools-chord-dictionary.test.tsx`
