### PR TITLE
fix(sync): import existing project deltas

### DIFF
--- a/apps/backend/app/services/sync_reconciliation.py
+++ b/apps/backend/app/services/sync_reconciliation.py
@@ -105,6 +105,7 @@ _ACTION_PRIORITY = {
 }
 
 _MISSING = object()
+PROJECT_METADATA_ENTITY_TYPE = "project_metadata"
 
 
 @dataclass(frozen=True)
@@ -368,6 +369,7 @@ def plan_sync_reconciliation(
             and local_revision is not None
             and local_revision.project_id == revision.project_id
             and _local_revision_content_sha256(local_revision) == revision.content_sha256
+            and _local_revision_matches_remote_state(local_revision, revision)
         ):
             continue
         if (
@@ -376,6 +378,7 @@ def plan_sync_reconciliation(
             and revision.project_id not in planned_project_ids
             and _has_imported_local_project(local, revision.project_id)
             and revision.revision_id not in embedded_revision_import_ids
+            and revision.entity_type != PROJECT_METADATA_ENTITY_TYPE
             and not _is_deleted(
                 ITEM_ENTITY_REVISION,
                 revision.revision_id,
@@ -686,8 +689,32 @@ def _embedded_revision_chain_is_importable(
 
 
 def _remote_revision_is_current(revision: _RemoteEntityRevision) -> bool:
-    state = _str_field(revision.raw, "state")
-    return state is not None and state.lower() in {"active", "current"}
+    return _remote_revision_state(revision) == "active"
+
+
+def _local_revision_matches_remote_state(
+    local_revision: SyncEntityRevision,
+    remote_revision: _RemoteEntityRevision,
+) -> bool:
+    remote_state = _remote_revision_state(remote_revision)
+    if remote_state is None:
+        return True
+    return _normalize_revision_state(local_revision.state) == remote_state
+
+
+def _remote_revision_state(revision: _RemoteEntityRevision) -> str | None:
+    return _normalize_revision_state(_str_field(revision.raw, "state"))
+
+
+def _normalize_revision_state(state: str | None) -> str | None:
+    if state is None:
+        return None
+    normalized = state.strip().lower()
+    if not normalized:
+        return None
+    if normalized == "current":
+        return "active"
+    return normalized
 
 
 def _is_sync_project_placeholder(project: Project) -> bool:
@@ -1727,6 +1754,32 @@ def _plan_entity_revision(
             )
             return False
         if local_content_sha256 == revision.content_sha256:
+            if not _local_revision_matches_remote_state(local_revision, revision):
+                _upsert_item(
+                    items_by_key,
+                    SyncReconciliationItem(
+                        item_type=ITEM_ENTITY_REVISION,
+                        item_id=revision.revision_id,
+                        project_id=revision.project_id,
+                        status="remote_available",
+                        action_type=ACTION_IMPORT_ENTITY_REVISION,
+                        content_sha256=revision.content_sha256,
+                        reason="Entity revision state changed remotely.",
+                        details={"base_revision_id": revision.base_revision_id},
+                    ),
+                )
+                actions.append(
+                    _action(
+                        ACTION_IMPORT_ENTITY_REVISION,
+                        item_type=ITEM_ENTITY_REVISION,
+                        item_id=revision.revision_id,
+                        project_id=revision.project_id,
+                        content_sha256=revision.content_sha256,
+                        reason="Sync remote entity revision state.",
+                        details={"base_revision_id": revision.base_revision_id},
+                    )
+                )
+                return True
             _upsert_item(
                 items_by_key,
                 SyncReconciliationItem(

--- a/apps/backend/app/services/sync_reconciliation_apply.py
+++ b/apps/backend/app/services/sync_reconciliation_apply.py
@@ -617,8 +617,19 @@ def _import_entity_revision(
     if revision is None:
         return _result(action, APPLY_STATUS_SKIPPED, "Entity revision is not present in the project manifest.")
     existing_revision = session.get(SyncEntityRevision, revision.revision_id)
+    remote_state = _normalize_revision_state(revision.state)
     if existing_revision is not None:
         if _local_revision_content_sha256(existing_revision) == revision.content_sha256:
+            if _normalize_revision_state(existing_revision.state) != remote_state:
+                existing_revision.state = remote_state
+                existing_revision.updated_at = revision.updated_at
+                session.flush()
+                return _result(
+                    action,
+                    APPLY_STATUS_APPLIED,
+                    "Entity revision state was updated from the project manifest.",
+                    details={"revision_id": revision.revision_id, "project_id": project_id},
+                )
             return _result(action, APPLY_STATUS_SATISFIED, "Entity revision is already imported locally.")
         return _result(action, APPLY_STATUS_FAILED, "Entity revision conflicts with a local revision.")
 
@@ -632,7 +643,7 @@ def _import_entity_revision(
         author_device_id=revision.author_device_id,
         source_artifact_id=revision.source_artifact_id,
         content_sha256=revision.content_sha256,
-        state=_normalize_revision_state(revision.state),
+        state=remote_state,
         metadata_json=deepcopy(revision.metadata),
         payload_json=deepcopy(revision.payload),
         created_at=revision.created_at,
@@ -776,12 +787,16 @@ def _cleanup_imported_content_addressed_staging(
     pending_hashes: set[str] = set()
     imported_references: list[dict[str, Any]] = []
     for project_id, manifest in context.project_manifests_by_id.items():
-        artifact_hashes = _manifest_artifact_hashes(manifest)
-        if _project_is_imported(session, project_id):
-            imported_hashes.update(artifact_hashes)
-            imported_references.extend(_manifest_artifact_references(manifest))
-        else:
-            pending_hashes.update(artifact_hashes)
+        imported_project_hashes, pending_project_hashes, imported_project_references = (
+            _manifest_artifact_import_state(
+                session,
+                manifest,
+                project_id=project_id,
+            )
+        )
+        imported_hashes.update(imported_project_hashes)
+        imported_references.extend(imported_project_references)
+        pending_hashes.update(pending_project_hashes)
 
     cleanup_hashes = imported_hashes - pending_hashes
     cleanup_references = [
@@ -861,30 +876,45 @@ def _manifest_has_analysis_artifact(manifest: object) -> bool:
     )
 
 
-def _manifest_artifact_hashes(manifest: object) -> set[str]:
-    return {
-        content_sha256
-        for artifact in _list_field(manifest, "artifacts")
-        if (content_sha256 := _string_field(artifact, "content_sha256")) is not None
-    }
-
-
-def _manifest_artifact_references(manifest: object) -> list[dict[str, Any]]:
-    references: list[dict[str, Any]] = []
+def _manifest_artifact_import_state(
+    session: Session,
+    manifest: object,
+    *,
+    project_id: str,
+) -> tuple[set[str], set[str], list[dict[str, Any]]]:
+    imported_hashes: set[str] = set()
+    pending_hashes: set[str] = set()
+    imported_references: list[dict[str, Any]] = []
     for artifact in _list_field(manifest, "artifacts"):
-        content_sha256 = _string_field(artifact, "content_sha256")
-        project_id = _string_field(artifact, "project_id")
         artifact_id = _string_field(artifact, "artifact_id", "id")
-        if content_sha256 is None or project_id is None or artifact_id is None:
+        artifact_project_id = _string_field(artifact, "project_id")
+        content_sha256 = _string_field(artifact, "content_sha256")
+        size_bytes = _int_field(artifact, "size_bytes")
+        if (
+            artifact_id is None
+            or artifact_project_id != project_id
+            or content_sha256 is None
+            or size_bytes is None
+        ):
             continue
-        references.append(
+        local_artifact = session.get(Artifact, artifact_id)
+        if (
+            local_artifact is None
+            or local_artifact.project_id != project_id
+            or local_artifact.content_sha256 != content_sha256
+            or local_artifact.size_bytes != size_bytes
+        ):
+            pending_hashes.add(content_sha256)
+            continue
+        imported_hashes.add(content_sha256)
+        imported_references.append(
             {
                 "content_sha256": content_sha256,
                 "project_id": project_id,
                 "artifact_id": artifact_id,
             }
         )
-    return references
+    return imported_hashes, pending_hashes, imported_references
 
 
 def _tombstone_for_action(
@@ -1073,7 +1103,13 @@ def _staged_manifest_import_actions(
         for action in plan.actions
         if action.action_type == ACTION_IMPORT_PROJECT_MANIFEST and action.item_type == ITEM_PROJECT
     }
-    priority = _project_manifest_import_priority(plan)
+    planned_import_artifact_ids = {
+        action.item_id
+        for action in plan.actions
+        if action.action_type == ACTION_IMPORT_ARTIFACT_MANIFEST and action.item_type == ITEM_ARTIFACT
+    }
+    project_priority = _project_manifest_import_priority(plan)
+    artifact_priority = _artifact_manifest_import_priority(plan)
     actions: list[SyncReconciliationAction] = []
     for project_id in sorted(context.project_manifests_by_id):
         if context.scoped_project_ids and project_id not in context.scoped_project_ids:
@@ -1082,9 +1118,18 @@ def _staged_manifest_import_actions(
             continue
         if _project_has_blocking_apply_action(plan, project_id):
             continue
-        if _project_is_imported(session, project_id):
-            continue
         manifest = context.project_manifests_by_id[project_id]
+        if _project_is_imported(session, project_id):
+            actions.extend(
+                _staged_existing_project_artifact_actions(
+                    session,
+                    manifest,
+                    project_id=project_id,
+                    planned_import_artifact_ids=planned_import_artifact_ids,
+                    priority=artifact_priority,
+                )
+            )
+            continue
         actions.append(
             SyncReconciliationAction(
                 action_type=ACTION_IMPORT_PROJECT_MANIFEST,
@@ -1094,6 +1139,53 @@ def _staged_manifest_import_actions(
                 content_sha256=_manifest_source_sha256(manifest),
                 provider_device_id=None,
                 reason="Import project manifest using artifact content that is already staged locally.",
+                priority=project_priority,
+                details={
+                    "source": "sync_staged_artifacts",
+                    "staged_content_required": True,
+                },
+            )
+        )
+    return actions
+
+
+def _staged_existing_project_artifact_actions(
+    session: Session,
+    manifest: object,
+    *,
+    project_id: str,
+    planned_import_artifact_ids: set[str],
+    priority: int,
+) -> list[SyncReconciliationAction]:
+    actions: list[SyncReconciliationAction] = []
+    for artifact in _list_field(manifest, "artifacts"):
+        artifact_id = _string_field(artifact, "artifact_id", "id")
+        artifact_project_id = _string_field(artifact, "project_id")
+        content_sha256 = _string_field(artifact, "content_sha256")
+        size_bytes = _int_field(artifact, "size_bytes")
+        if (
+            artifact_id is None
+            or artifact_project_id != project_id
+            or artifact_id in planned_import_artifact_ids
+            or content_sha256 is None
+            or size_bytes is None
+        ):
+            continue
+        if session.get(Artifact, artifact_id) is not None:
+            continue
+        try:
+            require_staged_artifact(session, content_sha256=content_sha256, size_bytes=size_bytes)
+        except AppError:
+            continue
+        actions.append(
+            SyncReconciliationAction(
+                action_type=ACTION_IMPORT_ARTIFACT_MANIFEST,
+                item_type=ITEM_ARTIFACT,
+                item_id=artifact_id,
+                project_id=project_id,
+                content_sha256=content_sha256,
+                provider_device_id=None,
+                reason="Import artifact manifest using content that is already staged locally.",
                 priority=priority,
                 details={
                     "source": "sync_staged_artifacts",
@@ -1139,6 +1231,13 @@ def _project_manifest_import_priority(plan: SyncReconciliationPlan) -> int:
         if action.action_type == ACTION_IMPORT_PROJECT_MANIFEST:
             return action.priority
     return 30
+
+
+def _artifact_manifest_import_priority(plan: SyncReconciliationPlan) -> int:
+    for action in plan.actions:
+        if action.action_type == ACTION_IMPORT_ARTIFACT_MANIFEST:
+            return action.priority
+    return 40
 
 
 def _manifest_source_sha256(manifest: object) -> str | None:

--- a/apps/backend/tests/test_sync_reconciliation_apply_batch_import.py
+++ b/apps/backend/tests/test_sync_reconciliation_apply_batch_import.py
@@ -30,7 +30,12 @@ from app.services.paths import project_root
 from app.services.projects import delete_project
 from app.services.sync_identity import source_hash_to_project_id
 from app.services.sync_manifest import export_project_manifest, import_staged_project_manifest
-from app.services.sync_revisions import CURRENT_REVISION_STATE, revision_payload_sha256, sanitize_revision_payload
+from app.services.sync_revisions import (
+    CURRENT_REVISION_STATE,
+    SUPERSEDED_REVISION_STATE,
+    revision_payload_sha256,
+    sanitize_revision_payload,
+)
 from app.services.sync_staging import stage_sync_artifact
 from app.services.sync_trust import get_or_create_local_identity
 from app.utils.hashing import file_sha256
@@ -2234,12 +2239,13 @@ def test_issue120_existing_project_imports_late_manifest_artifacts(
         assert late_artifact is not None
         session.delete(late_artifact)
         late_artifact_path.unlink()
-        _stage_manifest_content(
+        _stage_manifest_artifact_content(
             session,
             manifest,
             tmp_path=tmp_path,
             artifact_bytes=fixture.artifact_bytes,
             provider_device_id="peer-issue120-late-artifact",
+            artifact_id=fixture.stem_artifact_id,
         )
         session.commit()
 
@@ -2276,6 +2282,9 @@ def test_issue120_existing_project_imports_late_manifest_artifacts(
         restored_artifact = session.get(Artifact, fixture.stem_artifact_id)
         assert restored_artifact is not None
         assert Path(restored_artifact.path).exists()
+        assert restored_artifact.project_id == fixture.project_id
+        assert restored_artifact.type == "vocals"
+        assert restored_artifact.metadata_json == {"source_artifact_id": fixture.source_artifact_id}
         assert restored_artifact.content_sha256 == fixture.artifact_hashes[fixture.stem_artifact_id]
 
 
@@ -2299,12 +2308,13 @@ def test_issue120_late_manifest_copy_mismatch_does_not_persist_artifact(
         assert late_artifact is not None
         session.delete(late_artifact)
         late_artifact_path.unlink()
-        _stage_manifest_content(
+        _stage_manifest_artifact_content(
             session,
             manifest,
             tmp_path=tmp_path,
             artifact_bytes=fixture.artifact_bytes,
             provider_device_id="peer-issue120-copy-mismatch",
+            artifact_id=fixture.stem_artifact_id,
         )
         session.commit()
 
@@ -2345,6 +2355,167 @@ def test_issue120_late_manifest_copy_mismatch_does_not_persist_artifact(
 
     with SessionLocal() as session:
         assert session.get(Artifact, fixture.stem_artifact_id) is None
+        staged_artifact = session.get(
+            SyncStagedArtifact,
+            fixture.artifact_hashes[fixture.stem_artifact_id],
+        )
+        assert staged_artifact is not None
+        assert (get_settings().data_root / "sync" / "staging" / staged_artifact.relative_path).exists()
+
+
+def test_issue120_existing_project_imports_project_metadata_rename(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    peer_device_id = "peer-issue120-rename"
+    _ensure_identity_and_peers(peer_device_id)
+
+    old_revision_id = "rev_issue120_project_metadata_original"
+    rename_revision_id = "rev_issue120_project_metadata_rename"
+    remote_display_name = "Synced Delta Rename"
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="issue120-rename",
+            source_frames=132,
+        )
+        project = session.get(Project, fixture.project_id)
+        assert project is not None
+        project.display_name = "Local Delta Name"
+        local_updated_at = datetime(2026, 1, 1, tzinfo=UTC)
+        project.updated_at = local_updated_at
+        old_revision_payload = sanitize_revision_payload(
+            {
+                "project_id": fixture.project_id,
+                "display_name": project.display_name,
+                "source_key_override": project.source_key_override,
+                "source_sha256": project.source_sha256,
+                "duration_seconds": project.duration_seconds,
+                "sample_rate": project.sample_rate,
+                "channels": project.channels,
+            }
+        )
+        session.add(
+            SyncEntityRevision(
+                id=old_revision_id,
+                project_id=fixture.project_id,
+                entity_type="project_metadata",
+                entity_id=fixture.project_id,
+                revision_type="metadata_change",
+                base_revision_id=None,
+                author_device_id=peer_device_id,
+                source_artifact_id=None,
+                content_sha256=revision_payload_sha256(old_revision_payload),
+                state=CURRENT_REVISION_STATE,
+                metadata_json={},
+                payload_json=old_revision_payload,
+                created_at=local_updated_at,
+                updated_at=local_updated_at,
+            )
+        )
+        session.flush()
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        remote_updated_at = datetime(2026, 1, 2, tzinfo=UTC).isoformat()
+        manifest["project"]["display_name"] = remote_display_name
+        manifest["project"]["updated_at"] = remote_updated_at
+        old_revision_manifest = _revision_by_id(manifest, old_revision_id)
+        old_revision_manifest["state"] = SUPERSEDED_REVISION_STATE
+        old_revision_manifest["updated_at"] = remote_updated_at
+        revision_payload = sanitize_revision_payload(
+            {
+                "project_id": fixture.project_id,
+                "display_name": remote_display_name,
+                "source_key_override": project.source_key_override,
+                "source_sha256": project.source_sha256,
+                "duration_seconds": project.duration_seconds,
+                "sample_rate": project.sample_rate,
+                "channels": project.channels,
+            }
+        )
+        manifest["entity_revisions"].append(
+            {
+                "revision_id": rename_revision_id,
+                "project_id": fixture.project_id,
+                "entity_type": "project_metadata",
+                "entity_id": fixture.project_id,
+                "revision_type": "metadata_change",
+                "base_revision_id": old_revision_id,
+                "author_device_id": peer_device_id,
+                "source_artifact_id": None,
+                "content_sha256": revision_payload_sha256(revision_payload),
+                "state": CURRENT_REVISION_STATE,
+                "metadata": {},
+                "payload": revision_payload,
+                "created_at": remote_updated_at,
+                "updated_at": remote_updated_at,
+            }
+        )
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": peer_device_id,
+                    "available_content_sha256": _manifest_content_hashes([manifest]),
+                }
+            ],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 0
+    assert any(
+        result["action"]["action_type"] == "import_entity_revision"
+        and result["action"]["item_id"] == old_revision_id
+        and result["status"] == "applied"
+        for result in payload["results"]
+    )
+    assert any(
+        result["action"]["action_type"] == "import_entity_revision"
+        and result["action"]["item_id"] == rename_revision_id
+        and result["status"] == "applied"
+        for result in payload["results"]
+    )
+
+    with SessionLocal() as session:
+        project = session.get(Project, fixture.project_id)
+        old_revision = session.get(SyncEntityRevision, old_revision_id)
+        revision = session.get(SyncEntityRevision, rename_revision_id)
+        assert project is not None
+        assert old_revision is not None
+        assert revision is not None
+        assert project.display_name == remote_display_name
+        assert old_revision.state == SUPERSEDED_REVISION_STATE
+        assert revision.state == CURRENT_REVISION_STATE
+        assert revision.payload_json["display_name"] == remote_display_name
+        current_metadata_revisions = list(
+            session.scalars(
+                select(SyncEntityRevision).where(
+                    SyncEntityRevision.project_id == fixture.project_id,
+                    SyncEntityRevision.entity_type == "project_metadata",
+                    SyncEntityRevision.state.in_((CURRENT_REVISION_STATE, "current")),
+                )
+            )
+        )
+        assert [current.id for current in current_metadata_revisions] == [rename_revision_id]
+
+        exported_manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        exported_current_metadata_revisions = [
+            exported_revision
+            for exported_revision in exported_manifest["entity_revisions"]
+            if exported_revision["entity_type"] == "project_metadata"
+            and exported_revision["state"] in {CURRENT_REVISION_STATE, "current"}
+        ]
+        assert [revision["revision_id"] for revision in exported_current_metadata_revisions] == [
+            rename_revision_id
+        ]
 
 
 def test_issue120_remote_tombstone_from_trusted_peer_wins_over_stale_manifest(
@@ -2670,6 +2841,28 @@ def _stage_manifest_content(
             provider_device_id=provider_device_id,
             metadata={"artifact_id": artifact_id, "project_id": artifact["project_id"]},
         )
+
+
+def _stage_manifest_artifact_content(
+    session: Session,
+    manifest: dict[str, Any],
+    *,
+    tmp_path: Path,
+    artifact_bytes: dict[str, bytes],
+    provider_device_id: str,
+    artifact_id: str,
+) -> None:
+    artifact = _artifact_by_id(manifest, artifact_id)
+    source_path = tmp_path / "issue119-stage" / provider_device_id / artifact_id
+    _write_bytes(source_path, artifact_bytes[artifact_id])
+    stage_sync_artifact(
+        session,
+        source_path=source_path,
+        content_sha256=artifact["content_sha256"],
+        size_bytes=artifact["size_bytes"],
+        provider_device_id=provider_device_id,
+        metadata={"artifact_id": artifact_id, "project_id": artifact["project_id"]},
+    )
 
 
 def _delete_live_project(session: Session, fixture: Issue119ProjectFixture) -> None:


### PR DESCRIPTION
## Summary

- Apply staged artifact and metadata changes to already-imported sync projects.
- Keep staged bytes available when an apply path skips import work for a project.
- Add regression coverage for existing-project delta import and staging cleanup behavior.

## Testing

- `uv run --python 3.11 pytest tests/test_sync_reconciliation.py tests/test_sync_reconciliation_apply_batch_import.py tests/test_sync_reconciliation_apply_api.py`
- `uv run --python 3.11 pytest tests/test_sync_manifest.py tests/test_sync_bundle.py`
- `uv run --python 3.11 pytest`
