### PR TITLE
fix(sync): clear stale remote availability

### DIFF
--- a/apps/backend/app/services/sync_manifest.py
+++ b/apps/backend/app/services/sync_manifest.py
@@ -631,6 +631,8 @@ def _merge_staged_project_manifest(
         )
         _hydrate_current_entity_revisions(session, project, missing_revisions)
         hydrate_project_analysis_result_from_artifact(session, project.id)
+        if _stale_sync_status_can_be_cleared(session, project=project, manifest=manifest):
+            mark_project_sync_local(session, project)
     except OSError as exc:
         _cleanup_copied_artifacts(copied_paths, project_root_path)
         raise AppError(
@@ -653,6 +655,30 @@ def _merge_staged_project_manifest(
 
     session.flush()
     return project
+
+
+def _stale_sync_status_can_be_cleared(
+    session: Session,
+    *,
+    project: Project,
+    manifest: SyncProjectManifest,
+) -> bool:
+    if project.sync_status != "remote_available":
+        return False
+    required_artifact_ids = set(project.sync_required_artifact_ids)
+    manifest_artifact_ids = {artifact.artifact_id for artifact in manifest.artifacts}
+    if required_artifact_ids and not required_artifact_ids.issubset(manifest_artifact_ids):
+        return False
+    for manifest_artifact in manifest.artifacts:
+        artifact = session.get(Artifact, manifest_artifact.artifact_id)
+        if (
+            artifact is None
+            or artifact.project_id != project.id
+            or artifact.content_sha256 != manifest_artifact.content_sha256
+            or artifact.size_bytes != manifest_artifact.size_bytes
+        ):
+            return False
+    return True
 
 
 def _validate_existing_project_matches_manifest(
@@ -1870,14 +1896,9 @@ def _can_upgrade_project_placeholder(project: Project, manifest: SyncProjectMani
 
 
 def _is_project_placeholder(project: Project) -> bool:
-    for field_name in ("sync_status", "sync_state"):
-        value = getattr(project, field_name, None)
-        if isinstance(value, str) and value.strip().lower() != "local":
-            return True
-
     source_path = project.source_path.strip()
     imported_path = project.imported_path.strip()
-    if not source_path and not imported_path:
+    if not source_path or not imported_path:
         return True
     return source_path.startswith("sync-placeholder:") and imported_path.startswith("sync-placeholder:")
 

--- a/apps/backend/app/services/sync_reconciliation_apply.py
+++ b/apps/backend/app/services/sync_reconciliation_apply.py
@@ -755,6 +755,7 @@ def _missing_content_addressed_artifacts(
     missing: list[dict[str, Any]] = []
     for artifact in _list_field(manifest, "artifacts"):
         artifact_id = _string_field(artifact, "artifact_id", "id")
+        project_id = _string_field(artifact, "project_id")
         content_sha256 = _string_field(artifact, "content_sha256")
         size_bytes = _int_field(artifact, "size_bytes")
         if content_sha256 is None or size_bytes is None:
@@ -765,6 +766,14 @@ def _missing_content_addressed_artifacts(
                     "reason": "Artifact manifest does not include content_sha256 and size_bytes.",
                 }
             )
+            continue
+        if _local_artifact_satisfies_manifest(
+            session,
+            artifact_id=artifact_id,
+            project_id=project_id,
+            content_sha256=content_sha256,
+            size_bytes=size_bytes,
+        ):
             continue
         try:
             require_staged_artifact(session, content_sha256=content_sha256, size_bytes=size_bytes)
@@ -777,6 +786,25 @@ def _missing_content_addressed_artifacts(
                 }
             )
     return missing
+
+
+def _local_artifact_satisfies_manifest(
+    session: Session,
+    *,
+    artifact_id: str | None,
+    project_id: str | None,
+    content_sha256: str,
+    size_bytes: int,
+) -> bool:
+    if artifact_id is None or project_id is None:
+        return False
+    artifact = session.get(Artifact, artifact_id)
+    return (
+        artifact is not None
+        and artifact.project_id == project_id
+        and artifact.content_sha256 == content_sha256
+        and artifact.size_bytes == size_bytes
+    )
 
 
 def _cleanup_imported_content_addressed_staging(

--- a/apps/backend/tests/test_sync_reconciliation_apply_batch_import.py
+++ b/apps/backend/tests/test_sync_reconciliation_apply_batch_import.py
@@ -253,6 +253,70 @@ def test_issue200_repeated_apply_retry_reuses_staged_content_without_duplicate_r
     _assert_issue200_resume_counts(fixture.project_id, manifest, staged_count=0)
 
 
+def test_issue202_apply_clears_stale_remote_available_when_manifest_artifacts_are_local(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    peer_id = "peer-issue202-stale-local"
+    _ensure_identity_and_peers(peer_id)
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="issue202-stale-local",
+            source_frames=104,
+        )
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        project = session.get(Project, fixture.project_id)
+        assert project is not None
+        project.sync_status = "remote_available"
+        project.sync_status_reason = "Waiting for manifest artifact content."
+        project.sync_required_artifact_ids_json = [
+            artifact["artifact_id"]
+            for artifact in manifest["artifacts"]
+        ]
+        project.sync_provider_device_ids_json = [peer_id]
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": peer_id,
+                    "available_content_sha256": _manifest_content_hashes([manifest]),
+                }
+            ],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 0
+    import_results = [
+        result
+        for result in payload["results"]
+        if result["action"]["action_type"] == "import_project_manifest"
+        and result["action"]["project_id"] == fixture.project_id
+    ]
+    assert len(import_results) == 1
+    assert import_results[0]["status"] == "applied"
+
+    with SessionLocal() as session:
+        assert session.scalar(select(func.count()).select_from(SyncStagedArtifact)) == 0
+        project = session.get(Project, fixture.project_id)
+        assert project is not None
+        assert project.sync_status == "local"
+        assert project.sync_status_reason is None
+        assert project.sync_required_artifact_ids == []
+        assert project.sync_provider_device_ids == []
+        assert project.sync_conflict_count == 0
+
+
 def test_issue163_project_scoped_apply_ignores_unselected_remote_projects_and_reports_timing(
     client: TestClient,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- Clear stale `remote_available` project state when manifest artifacts already exist locally.
- Treat locally recorded artifacts as satisfying content-addressed manifest apply checks.
- Keep this split from the broader conflict-resolution branch.

## Testing
- `cd apps/backend && uv run --python 3.11 pytest tests/test_sync_reconciliation_apply_batch_import.py::test_issue202_apply_clears_stale_remote_available_when_manifest_artifacts_are_local -q`
- `cd apps/backend && uv run --python 3.11 pytest tests/test_sync_reconciliation_apply_batch_import.py`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
