### PR TITLE
fix(desktop): make chord dictionary data-backed

### DIFF
--- a/apps/desktop/src/App.tools-chord-dictionary.test.tsx
+++ b/apps/desktop/src/App.tools-chord-dictionary.test.tsx
@@ -1,43 +1,214 @@
-import { screen, within } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it } from "vitest";
 import { renderApp, resetAppTestHarness } from "./test/appTestHarness";
 
+function renderChordDictionary() {
+  renderApp(["/tools?tool=chord-dictionary"]);
+  return screen.findByRole("heading", { name: "Chord Dictionary" });
+}
+
+function getToolsScreen() {
+  const toolsTabs = screen.getByRole("tablist", { name: "Tools" });
+  const toolsScreen = toolsTabs.closest("section");
+  if (!toolsScreen) {
+    throw new Error("Expected Chord Dictionary to render inside the Tools screen");
+  }
+  return toolsScreen as HTMLElement;
+}
+
+function changeChordSearch(value: string) {
+  const input = screen.getByLabelText("Chord search");
+  fireEvent.change(input, { target: { value } });
+  return input;
+}
+
+function expectInspectorToShow(patterns: Array<RegExp | string>) {
+  const inspector = screen.getByLabelText("Note inspector");
+  for (const pattern of patterns) {
+    expect(inspector).toHaveTextContent(pattern);
+  }
+}
+
+function expectTextVisible(text: RegExp | string) {
+  expect(screen.getAllByText(text).length).toBeGreaterThan(0);
+}
+
 describe("Desktop app tools chord dictionary", () => {
   beforeEach(resetAppTestHarness);
 
-  it("renders the chord dictionary page from the tools route", async () => {
-    renderApp(["/tools?tool=chord-dictionary"]);
+  it("renders the default guitar dictionary from the tools route", async () => {
+    await renderChordDictionary();
 
-    expect(await screen.findByRole("heading", { name: "Chord Dictionary" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Chord Dictionary" })).toHaveAttribute(
-      "aria-selected",
-      "true",
-    );
     expect(screen.getByLabelText("Chord search")).toHaveValue("C");
-    expect(screen.getByRole("button", { name: "Guitar" })).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByLabelText("Display context")).toBeInTheDocument();
-    expect(screen.getAllByText("CAGED").length).toBeGreaterThan(0);
-    expect(screen.getByText("C E G")).toBeInTheDocument();
+    const instrumentStatus = screen.getByRole("group", { name: "Instrument status" });
+    expect(within(instrumentStatus).getByText("Guitar")).toBeInTheDocument();
+    expect(within(instrumentStatus).queryByRole("button", { name: "Guitar" })).not.toBeInTheDocument();
+    expectTextVisible("C E G");
+    expect(
+      screen.getAllByRole("button", { name: "C3 string 5 fret 3" }).length,
+    ).toBeGreaterThan(0);
+    expectTextVisible("E A D G B E");
+    expectTextVisible("E2 - D6");
+    expectTextVisible("6 strings x 22 frets");
+    expectInspectorToShow([
+      /C3/,
+      /String\s*5/,
+      /Fret\s*3/,
+      /Finger\s*3/,
+      /Degree\s*1/,
+    ]);
   });
 
-  it("switches between dictionary and live follow surfaces", async () => {
-    const user = userEvent.setup();
-    renderApp(["/tools?tool=chord-dictionary"]);
+  it("updates a supported slash-chord search with backed guitar spelling and shape data", async () => {
+    await renderChordDictionary();
 
-    expect(await screen.findByRole("heading", { name: "Chord Dictionary" })).toBeInTheDocument();
+    const input = changeChordSearch("G/D");
+
+    expect(input).toHaveValue("G/D");
+    const resultHeading = screen.getByRole("heading", { name: "G/D guitar shapes" });
+    const libraryHeading = screen.getByRole("heading", { name: "Common chord library" });
+    expect(
+      Boolean(resultHeading.compareDocumentPosition(libraryHeading) & Node.DOCUMENT_POSITION_FOLLOWING),
+    ).toBe(true);
+    expect((await screen.findAllByText("G/D open")).length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByRole("button", { name: "D3 string 4 fret 0" }).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByRole("button", { name: "G3 string 3 fret 0" }).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByRole("button", { name: "B3 string 2 fret 0" }).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByRole("button", { name: "G4 string 1 fret 3" }).length,
+    ).toBeGreaterThan(0);
+    expectTextVisible(/Common.*frets 0-3/);
+    expectInspectorToShow([/D3/, /String\s*4/, /Fret\s*0/, /Degree\s*5/]);
+  });
+
+  it("keeps unsupported search input honest without stale C chord data", async () => {
+    await renderChordDictionary();
+
+    const input = changeChordSearch("H13");
+
+    expect(input).toHaveValue("H13");
+    expectTextVisible(/unsupported|not supported|no guitar shapes|no shapes/i);
+    expect(screen.queryAllByText("C E G")).toHaveLength(0);
+    expect(screen.queryAllByRole("group", { name: "Guitar fretboard" })).toHaveLength(0);
+    expect(screen.queryAllByRole("button", { name: /C3.*string 5 fret 3/ })).toHaveLength(
+      0,
+    );
+    expect(screen.queryByLabelText("Note inspector")).not.toBeInTheDocument();
+  });
+
+  it("updates the note inspector from shape switching and note selection", async () => {
+    const user = userEvent.setup();
+    await renderChordDictionary();
+
+    const noteButton = screen.getAllByRole("button", { name: "E3 string 4 fret 2" })[0];
+    if (!noteButton) {
+      throw new Error("Expected a selectable E3 string 4 fret 2 note");
+    }
+
+    await user.click(noteButton);
+    await waitFor(() =>
+      expectInspectorToShow([
+        /E3/,
+        /String\s*4/,
+        /Fret\s*2/,
+        /Finger\s*2/,
+        /Degree\s*3/,
+      ]),
+    );
+
+    const beforeShapeSwitch = screen.getByLabelText("Note inspector").textContent;
+    const shapeButtons = within(
+      screen.getByRole("group", { name: "Guitar shape choices" }),
+    ).getAllByRole("button");
+    if (!shapeButtons[1]) {
+      throw new Error("Expected at least two selectable CAGED shapes");
+    }
+
+    expect(shapeButtons[0]).toHaveAttribute("aria-pressed", "true");
+    expect(shapeButtons[1]).toHaveAttribute("aria-pressed", "false");
+
+    await user.click(shapeButtons[1]);
+    await waitFor(() =>
+      expect(screen.getByLabelText("Note inspector").textContent).not.toBe(beforeShapeSwitch),
+    );
+    expect(shapeButtons[1]).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("shows live follow as an honest waiting state without fake progression previews", async () => {
+    const user = userEvent.setup();
+    await renderChordDictionary();
+
     await user.click(screen.getByRole("button", { name: "Live Follow" }));
 
-    expect(screen.queryByRole("dialog", { name: "C chord preview" })).not.toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "C" }));
-    expect(screen.getByRole("dialog", { name: "C chord preview" })).toBeInTheDocument();
-
-    await user.click(
-      within(screen.getByRole("group", { name: "Chord dictionary views" })).getByRole(
-        "button",
-        { name: "Dictionary" },
-      ),
+    const viewToggle = screen.getByRole("group", { name: "Chord dictionary views" });
+    expect(within(viewToggle).getByRole("button", { name: "Dictionary" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
     );
-    expect(screen.getByLabelText("Note inspector")).toBeInTheDocument();
+    expect(within(viewToggle).getByRole("button", { name: "Live Follow" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    const toolsScreen = within(getToolsScreen());
+    const liveStatus = toolsScreen.getByRole("group", { name: "Live chord display status" });
+    expect(within(liveStatus).getByText("Guitar")).toBeInTheDocument();
+    expect(within(liveStatus).getByText("Waiting")).toBeInTheDocument();
+    expect(within(liveStatus).queryByRole("button", { name: "Guitar" })).not.toBeInTheDocument();
+    expect(within(liveStatus).queryByRole("button", { name: "Waiting" })).not.toBeInTheDocument();
+    expect(
+      toolsScreen.getAllByText(
+        /waiting|unavailable|inactive|no project|select a project|open a project/i,
+      ).length,
+    ).toBeGreaterThan(0);
+    expect(toolsScreen.queryByRole("dialog", { name: /C chord preview/i })).not.toBeInTheDocument();
+    expect(toolsScreen.queryByLabelText(/Accordion C chord/i)).not.toBeInTheDocument();
+    expect(toolsScreen.queryByText("Tonight is heavy on one side")).not.toBeInTheDocument();
+    expect(toolsScreen.queryByRole("button", { name: "C" })).not.toBeInTheDocument();
+    expect(toolsScreen.queryByRole("button", { name: "G/D" })).not.toBeInTheDocument();
+    expect(toolsScreen.queryByRole("button", { name: "Am/C" })).not.toBeInTheDocument();
+    expect(toolsScreen.queryByRole("button", { name: "F/C" })).not.toBeInTheDocument();
+    expect(toolsScreen.queryByRole("button", { name: "Accordion" })).not.toBeInTheDocument();
+  });
+
+  it("does not expose fake instrument, library, playback, or settings affordances", async () => {
+    await renderChordDictionary();
+
+    const toolsScreen = within(getToolsScreen());
+    const instrumentStatus = toolsScreen.getByRole("group", { name: "Instrument status" });
+    expect(within(instrumentStatus).getByText("Guitar")).toBeInTheDocument();
+    expect(
+      within(instrumentStatus).queryByRole("button", { name: "Guitar" }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(instrumentStatus).queryByRole("button", { name: "Piano" }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(instrumentStatus).queryByRole("button", { name: "Accordion" }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(instrumentStatus).queryByRole("button", { name: "Organ" }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(instrumentStatus).queryByRole("button", { name: /48\s+More/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      toolsScreen.queryByRole("button", { name: /Toggle project follow/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      toolsScreen.queryByRole("button", { name: /Preview playback active state/i }),
+    ).not.toBeInTheDocument();
+    expect(toolsScreen.queryByRole("button", { name: /Saved shapes/i })).not.toBeInTheDocument();
+    expect(toolsScreen.queryByTitle("Saved shapes")).not.toBeInTheDocument();
+    expect(toolsScreen.queryByRole("button", { name: /Settings/i })).not.toBeInTheDocument();
+    expect(toolsScreen.queryByTitle("Settings")).not.toBeInTheDocument();
+    expect(toolsScreen.queryByText("Atlas")).not.toBeInTheDocument();
+    expect(toolsScreen.queryByText(/Piano, accordion, organ/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/features/tools/ChordDictionaryPage.tsx
+++ b/apps/desktop/src/features/tools/ChordDictionaryPage.tsx
@@ -5,8 +5,6 @@ import {
   Gauge,
   Layers,
   Music2,
-  RefreshCw,
-  Settings,
   SlidersHorizontal,
 } from "lucide-react";
 import {
@@ -21,10 +19,9 @@ import {
 } from "../../lib/music";
 
 type ChordDictionarySurface = "dictionary" | "follow";
-type InstrumentId = "guitar" | "piano" | "accordion" | "organ";
 type NotePoint = {
   degree: string;
-  finger: string;
+  finger: string | null;
   fret: number;
   id: string;
   note: string;
@@ -39,20 +36,6 @@ type GuitarShape = {
 };
 
 const COMMON_CHORD_LABELS = ["C", "Dm", "Em", "F", "G", "Am", "Bdim"] as const;
-
-const liveProgression = [
-  { chord: "C", shape: "C", seconds: "0:38", notes: "C4 E4 G4" },
-  { chord: "G/D", shape: "close", seconds: "0:42", notes: "D4 G4 B4" },
-  { chord: "Am/C", shape: "close", seconds: "0:46", notes: "C4 E4 A4" },
-  { chord: "F/C", shape: "close", seconds: "0:50", notes: "C4 F4 A4" },
-] as const;
-
-const instrumentOptions: Array<{ id: InstrumentId; label: string }> = [
-  { id: "guitar", label: "Guitar" },
-  { id: "piano", label: "Piano" },
-  { id: "accordion", label: "Accordion" },
-  { id: "organ", label: "Organ" },
-];
 
 function classNames(...values: Array<string | false | null | undefined>) {
   return values.filter(Boolean).join(" ");
@@ -106,76 +89,67 @@ export function ChordDictionaryPage() {
 }
 
 function DictionarySurface() {
-  const [instrument, setInstrument] = useState<InstrumentId>("guitar");
   const [activeChord, setActiveChord] = useState("C");
-  const [activeShape, setActiveShape] = useState("c-open");
-  const [selectedNoteId, setSelectedNoteId] = useState("c-open-4");
-  const [followArmed, setFollowArmed] = useState(false);
-  const [previewActive, setPreviewActive] = useState(false);
+  const [activeShape, setActiveShape] = useState<string | null>(null);
+  const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
   const displayContext = useMemo<Partial<ChordDisplayContext>>(
-    () =>
-      followArmed && previewActive
-        ? {
-            canCapo: true,
-            capoFret: 2,
-            sourceKey: { pitchClass: 6, mode: "major" },
-            useCapoShapes: true,
-          }
-        : {
-            canCapo: true,
-            capoFret: 0,
-            sourceKey: { pitchClass: 0, mode: "major" },
-            useCapoShapes: false,
-          },
-    [followArmed, previewActive],
-  );
-  const effectiveChord = followArmed && previewActive ? "F#" : activeChord;
-  const chordSpelling = spellChord(effectiveChord);
-  const commonChords = useMemo(
-    () =>
-      COMMON_CHORD_LABELS.map((label) => {
-        const spelling = spellChord(label);
-        const voicing = generateGuitarVoicings(label)[0] ?? null;
-        return {
-          id: label,
-          label,
-          notes: spelling?.notes.join(" ") ?? "",
-          quality: spelling ? CHORD_QUALITY_DEFINITIONS[spelling.quality].label : "",
-          voicing,
-        };
-      }),
+    () => ({
+      canCapo: GUITAR_STANDARD_PROFILE.canCapo,
+      capoFret: 0,
+      sourceKey: null,
+      transposeSemitones: 0,
+      useCapoShapes: false,
+    }),
     [],
   );
-  const guitarVoicings = useMemo(
-    () => generateGuitarVoicings(effectiveChord, GUITAR_STANDARD_PROFILE, displayContext),
-    [displayContext, effectiveChord],
+  const chordQuery = activeChord.trim();
+  const chordSpelling = useMemo(() => (chordQuery ? spellChord(chordQuery) : null), [chordQuery]);
+  const unsupportedChord = chordQuery.length > 0 && !chordSpelling;
+  const commonChords = useMemo(
+    () =>
+      COMMON_CHORD_LABELS.flatMap((label) => {
+        const spelling = spellChord(label);
+        if (!spelling) {
+          return [];
+        }
+        const voicings = generateGuitarVoicings(spelling, GUITAR_STANDARD_PROFILE, displayContext);
+        return {
+          id: spelling.label,
+          label: spelling.label,
+          notes: spelling.notes.join(" "),
+          quality: CHORD_QUALITY_DEFINITIONS[spelling.quality].label,
+          voicing: voicings[0] ?? null,
+          voicingCount: voicings.length,
+        };
+      }),
+    [displayContext],
   );
-  const cagedShapes = useMemo(
+  const guitarVoicings = useMemo(
+    () => (chordSpelling ? generateGuitarVoicings(chordSpelling, GUITAR_STANDARD_PROFILE, displayContext) : []),
+    [chordSpelling, displayContext],
+  );
+  const guitarShapes = useMemo(
     () => guitarVoicings.map((voicing) => toGuitarShape(voicing)),
     [guitarVoicings],
   );
+  const resultKey = guitarShapes.map((shape) => shape.id).join("|");
+  const firstShapeId = guitarShapes[0]?.id ?? null;
+  const firstNoteId = guitarShapes[0]?.notes[0]?.id ?? null;
   useEffect(() => {
-    const firstShape = cagedShapes[0];
-    if (!firstShape) {
-      return;
-    }
-    setActiveShape(firstShape.id);
-    setSelectedNoteId(firstShape.notes[0]?.id ?? "empty-note");
-  }, [cagedShapes]);
-  const selectedShape = cagedShapes.find((shape) => shape.id === activeShape) ?? cagedShapes[0];
+    setActiveShape(firstShapeId);
+    setSelectedNoteId(firstNoteId);
+  }, [firstNoteId, firstShapeId, resultKey]);
+  const selectedShape = guitarShapes.find((shape) => shape.id === activeShape) ?? guitarShapes[0] ?? null;
   const selectedNote =
-    cagedShapes.flatMap((shape) => shape.notes).find((note) => note.id === selectedNoteId) ??
-    selectedShape?.notes[0] ??
-    emptyNotePoint;
-  const shapeFamily =
-    guitarVoicings.find((voicing) => voicing.id === selectedShape?.id)?.shapeFamily ??
-    selectedShape?.label.slice(0, 1) ??
-    "C";
+    selectedShape?.notes.find((note) => note.id === selectedNoteId) ?? selectedShape?.notes[0] ?? null;
+  const selectedVoicing = guitarVoicings.find((voicing) => voicing.id === selectedShape?.id) ?? null;
   const sourceKeyLabel = displayContext.sourceKey
     ? formatKey(displayContext.sourceKey, "long")
-    : "C major";
-  const transposeLabel = `${displayContext.transposeSemitones ?? 0}`;
-  const capoLabel = displayContext.capoFret ? `+${displayContext.capoFret}` : "0";
+    : "No source key";
+  const transposeLabel = `${displayContext.transposeSemitones ?? 0} semitones`;
+  const capoLabel = displayContext.capoFret ? `Capo ${displayContext.capoFret}` : "No capo";
+  const tuningLabel = formatGuitarTuning(GUITAR_STANDARD_PROFILE);
+  const stringLabels = getGuitarStringLabels(GUITAR_STANDARD_PROFILE);
 
   return (
     <div className="chord-dictionary">
@@ -185,229 +159,215 @@ function DictionarySurface() {
           <Music2 aria-hidden="true" />
           <input
             aria-label="Chord search"
-            onChange={(event) => setActiveChord(event.currentTarget.value || "C")}
+            onChange={(event) => setActiveChord(event.currentTarget.value)}
             placeholder="C major"
             value={activeChord}
           />
         </label>
-        <div className="chord-toolbar-cluster" aria-label="Instrument controls">
-          {instrumentOptions.map((option) => (
-            <button
-              key={option.id}
-              aria-pressed={instrument === option.id}
-              className={classNames(
-                "chord-pill",
-                instrument === option.id && "chord-pill--active",
-              )}
-              onClick={() => setInstrument(option.id)}
-              type="button"
-            >
-              <Music2 aria-hidden="true" />
-              <span>{option.label}</span>
-            </button>
-          ))}
-          <button className="chord-pill chord-pill--muted" type="button">
-            <span>48</span>
-            <span>More</span>
-          </button>
-        </div>
-        <div className="chord-toolbar-cluster chord-toolbar-cluster--end">
-          <button
-            aria-label="Toggle project follow"
-            aria-pressed={followArmed}
-            className={classNames("chord-icon-button", followArmed && "chord-icon-button--active")}
-            onClick={() => setFollowArmed((current) => !current)}
-            title="Follow project playback"
-            type="button"
-          >
-            <RefreshCw aria-hidden="true" />
-            <span className="chord-live-dot" aria-hidden="true" />
-          </button>
-          <button
-            aria-label="Preview playback active state"
-            aria-pressed={previewActive}
-            className={classNames("chord-icon-button", previewActive && "chord-icon-button--active")}
-            onClick={() => setPreviewActive((current) => !current)}
-            title="Playback active"
-            type="button"
-          >
-            <AudioLines aria-hidden="true" />
-          </button>
-          <button className="chord-icon-button" title="Saved shapes" type="button">
+        <div className="chord-toolbar-cluster" role="group" aria-label="Instrument status">
+          <span className="chord-pill chord-pill--active">
             <Music2 aria-hidden="true" />
-          </button>
-          <button className="chord-icon-button" title="Settings" type="button">
-            <Settings aria-hidden="true" />
-          </button>
+            <span>{GUITAR_STANDARD_PROFILE.label}</span>
+          </span>
         </div>
       </div>
 
+      {unsupportedChord ? (
+        <div className="chord-dictionary-status" role="status">
+          <strong>{activeChord}</strong>
+          <span>Unsupported chord symbol. No backed spelling or guitar voicings available.</span>
+        </div>
+      ) : null}
+
       <div className="chord-context-strip" aria-label="Display context">
+        <ContextChip icon="instrument" label={GUITAR_STANDARD_PROFILE.label} />
+        <ContextChip icon="shape" label={tuningLabel} />
         <ContextChip icon="key" label={sourceKeyLabel} />
         <ContextChip icon="transpose" label={transposeLabel} />
         <ContextChip icon="capo" label={capoLabel} />
-        <span className="chord-context-arrow" aria-hidden="true">-&gt;</span>
-        <ContextChip icon="shape" label={`${shapeFamily} shape`} />
-        <ContextChip icon="sound" label={effectiveChord} />
+        <ContextChip icon="sound" label={chordSpelling?.label ?? "No supported chord"} />
+        {selectedVoicing?.shapeFamily ? <ContextChip icon="shape" label={`${selectedVoicing.shapeFamily} shape`} /> : null}
       </div>
 
       <div className="chord-tool-grid">
         <main className="chord-tool-main">
           <div className="chord-field-row">
-            <button className="chord-field" type="button">
+            <div className="chord-field">
               <span>Instrument</span>
-              <strong>{instrumentOptions.find((option) => option.id === instrument)?.label}</strong>
-            </button>
-            <button className="chord-field" type="button">
+              <strong>{GUITAR_STANDARD_PROFILE.label}</strong>
+            </div>
+            <div className="chord-field">
               <span>Tuning</span>
-              <strong>E A D G B E</strong>
-            </button>
-            <button className="chord-field chord-field--compact" type="button">
+              <strong>{tuningLabel}</strong>
+            </div>
+            <div className="chord-field chord-field--compact">
               <span>Capo</span>
-              <strong>Yes</strong>
-            </button>
-            <button className="chord-field chord-field--compact" type="button">
+              <strong>{formatBooleanCapability(GUITAR_STANDARD_PROFILE.canCapo)}</strong>
+            </div>
+            <div className="chord-field chord-field--compact">
               <span>Retune</span>
-              <strong>Yes</strong>
-            </button>
+              <strong>{formatBooleanCapability(GUITAR_STANDARD_PROFILE.canRetune)}</strong>
+            </div>
           </div>
-
-          <section className="chord-section">
-            <div className="chord-section-heading">
-              <div>
-                <p className="metric-label">Basic chords</p>
-                <h3>C major</h3>
-              </div>
-              <div className="chord-view-toggle" role="group" aria-label="Dictionary filters">
-                <button className="chord-mini-button chord-mini-button--active" type="button">
-                  Major
-                </button>
-                <button className="chord-mini-button" type="button">Minor</button>
-                <button className="chord-mini-button" type="button">7ths</button>
-              </div>
-            </div>
-            <div className="chord-card-row">
-              {commonChords.map((chord) => (
-                <button
-                  key={chord.id}
-                  className={classNames(
-                    "chord-family-card",
-                    activeChord === chord.label && "chord-family-card--active",
-                  )}
-                  onClick={() => setActiveChord(chord.label)}
-                  type="button"
-                >
-                  <strong>{chord.label}</strong>
-                  <span>{chord.quality}</span>
-                  <MiniFretboard notes={chord.voicing?.notes ?? []} />
-                  <small>{chord.notes}</small>
-                </button>
-              ))}
-            </div>
-          </section>
 
           <section className="chord-section">
             <div className="chord-section-heading chord-section-heading--inline">
               <div>
-                <p className="metric-label">{chordSpelling?.label ?? effectiveChord}</p>
-                <h3>CAGED</h3>
+                <p className="metric-label">{chordSpelling?.notes.join(" ") ?? "No chord spelling"}</p>
+                <h3>{chordSpelling ? `${chordSpelling.label} guitar shapes` : "Guitar shapes"}</h3>
               </div>
-              <div className="chord-shape-tabs" role="tablist" aria-label="CAGED shape family">
-                {cagedShapes.map((shape) => (
-                  <button
+              {guitarShapes.length > 0 ? (
+                <div className="chord-shape-tabs" role="group" aria-label="Guitar shape choices">
+                  {guitarShapes.map((shape) => (
+                    <button
+                      key={shape.id}
+                      aria-pressed={selectedShape?.id === shape.id}
+                      className={classNames(
+                        "chord-shape-tab",
+                        selectedShape?.id === shape.id && "chord-shape-tab--active",
+                      )}
+                      onClick={() => {
+                        setActiveShape(shape.id);
+                        setSelectedNoteId(shape.notes[0]?.id ?? null);
+                      }}
+                      type="button"
+                    >
+                      {shape.label}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+            {chordSpelling ? (
+              <ChordSpellingSummary spelling={chordSpelling} />
+            ) : null}
+            {chordSpelling && guitarShapes.length === 0 ? (
+              <EmptyDictionaryState
+                title={`No guitar shapes for ${chordSpelling.label}`}
+                copy="Chord spelling is supported, but the guitar generator returned no voicings for the standard profile."
+              />
+            ) : unsupportedChord ? (
+              <EmptyDictionaryState
+                title="Unsupported chord"
+                copy="No spelling, voicings, fretboard, or note inspector data shown for this search."
+              />
+            ) : chordQuery.length === 0 ? (
+              <EmptyDictionaryState
+                title="Enter a chord"
+                copy="Type a supported chord symbol to show spelling, degrees, and guitar voicings."
+              />
+            ) : (
+              <div className="chord-shape-grid">
+                {guitarShapes.map((shape) => (
+                  <div
                     key={shape.id}
-                    aria-selected={selectedShape?.id === shape.id}
                     className={classNames(
-                      "chord-shape-tab",
-                      selectedShape?.id === shape.id && "chord-shape-tab--active",
+                      "chord-shape-card",
+                      shape.id === activeShape && "chord-shape-card--active",
                     )}
-                    onClick={() => {
-                      setActiveShape(shape.id);
-                      setSelectedNoteId(shape.notes[0]?.id ?? selectedNoteId);
-                    }}
-                    role="tab"
+                  >
+                    <button
+                      className="chord-shape-card__label"
+                      onClick={() => {
+                        setActiveShape(shape.id);
+                        setSelectedNoteId(shape.notes[0]?.id ?? null);
+                      }}
+                      type="button"
+                    >
+                      {shape.label}
+                    </button>
+                    <GuitarFretboard
+                      maxFret={Math.max(...shape.notes.map((note) => note.fret), 4)}
+                      notes={shape.notes}
+                      selectedNoteId={selectedNoteId}
+                      onSelectNote={setSelectedNoteId}
+                      stringLabels={stringLabels}
+                    />
+                    <span className="chord-shape-card__meta">{shape.meta}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+
+          {selectedNote ? <NoteInspector note={selectedNote} capoFret={displayContext.capoFret ?? 0} /> : null}
+
+          {chordSpelling ? (
+            <section className="chord-section">
+              <div className="chord-section-heading">
+                <div>
+                  <p className="metric-label">Reference library</p>
+                  <h3>Common chord library</h3>
+                </div>
+              </div>
+              <div className="chord-card-row">
+                {commonChords.map((chord) => (
+                  <button
+                    key={chord.id}
+                    className={classNames(
+                      "chord-family-card",
+                      activeChord === chord.label && "chord-family-card--active",
+                    )}
+                    onClick={() => setActiveChord(chord.label)}
                     type="button"
                   >
-                    {shape.label.replace(/\s.*$/, "")}
+                    <strong>{chord.label}</strong>
+                    <span>{chord.quality}</span>
+                    <MiniFretboard notes={chord.voicing?.notes ?? []} />
+                    <small>{chord.notes}</small>
+                    <small>{formatCount(chord.voicingCount, "shape")}</small>
                   </button>
                 ))}
               </div>
-            </div>
-            <div className="chord-shape-grid">
-              {cagedShapes.map((shape) => (
-                <div
-                  key={shape.id}
-                  className={classNames(
-                    "chord-shape-card",
-                    shape.id === activeShape && "chord-shape-card--active",
-                  )}
-                >
-                  <button
-                    className="chord-shape-card__label"
-                    onClick={() => {
-                      setActiveShape(shape.id);
-                      setSelectedNoteId(shape.notes[0]?.id ?? selectedNoteId);
-                    }}
-                    type="button"
-                  >
-                    {shape.label}
-                  </button>
-                  <GuitarFretboard
-                    maxFret={Math.max(...shape.notes.map((note) => note.fret), 4)}
-                    notes={shape.notes}
-                    selectedNoteId={selectedNoteId}
-                    onSelectNote={setSelectedNoteId}
-                  />
-                  <span className="chord-shape-card__meta">{shape.meta}</span>
-                </div>
-              ))}
-            </div>
-          </section>
-
-          <NoteInspector note={selectedNote} capoActive={followArmed && previewActive} />
+            </section>
+          ) : null}
         </main>
 
         <aside className="chord-understanding-panel">
           <div className="chord-understanding-panel__header">
             <div>
               <p className="metric-label">Instrument</p>
-              <h3>Guitar</h3>
+              <h3>{GUITAR_STANDARD_PROFILE.label}</h3>
             </div>
             <SlidersHorizontal aria-hidden="true" />
           </div>
           <dl className="chord-fact-list">
             <div>
               <dt>Range</dt>
-              <dd>E2 - E6</dd>
+              <dd>{formatGuitarRange(GUITAR_STANDARD_PROFILE)}</dd>
             </div>
             <div>
               <dt>Tuning</dt>
-              <dd>EADGBE</dd>
+              <dd>{tuningLabel}</dd>
             </div>
             <div>
               <dt>Surface</dt>
-              <dd>6 x 22</dd>
+              <dd>{`${GUITAR_STANDARD_PROFILE.tuning.length} strings x ${GUITAR_STANDARD_PROFILE.frets} frets`}</dd>
             </div>
             <div>
               <dt>Capo</dt>
-              <dd>Yes</dd>
+              <dd>{formatBooleanCapability(GUITAR_STANDARD_PROFILE.canCapo)}</dd>
             </div>
           </dl>
           <div className="chord-accordion-list">
-            {[
-              ["CAGED", "Common path"],
-              ["Generated", "All shapes"],
-              ["Setup", "Tunings"],
-              ["Atlas", "Piano, accordion, organ"],
-            ].map(([label, meta]) => (
-              <button key={label} className="chord-accordion-row" type="button">
-                <span>
-                  <strong>{label}</strong>
-                  <small>{meta}</small>
-                </span>
-                <span aria-hidden="true">-&gt;</span>
-              </button>
-            ))}
+            <div className="chord-accordion-row chord-accordion-row--static">
+              <span>
+                <strong>{formatCount(guitarVoicings.filter((voicing) => voicing.source === "common").length, "common shape")}</strong>
+                <small>{chordSpelling?.label ?? "No supported chord"}</small>
+              </span>
+            </div>
+            <div className="chord-accordion-row chord-accordion-row--static">
+              <span>
+                <strong>{formatCount(guitarVoicings.filter((voicing) => voicing.source === "generated").length, "generated shape")}</strong>
+                <small>{formatCount(guitarVoicings.length, "total shape")}</small>
+              </span>
+            </div>
+            <div className="chord-accordion-row chord-accordion-row--static">
+              <span>
+                <strong>{formatCount(GUITAR_STANDARD_PROFILE.tuning.length, "string")}</strong>
+                <small>{formatGuitarRange(GUITAR_STANDARD_PROFILE)}</small>
+              </span>
+            </div>
           </div>
         </aside>
       </div>
@@ -415,29 +375,22 @@ function DictionarySurface() {
   );
 }
 
-const emptyNotePoint: NotePoint = {
-  degree: "1",
-  finger: "",
-  fret: 0,
-  id: "empty-note",
-  note: "C4",
-  string: 1,
-};
-
 function toGuitarShape(voicing: GuitarVoicing): GuitarShape {
   const frets = voicing.notes.map((note) => note.fret);
   const minFret = Math.min(...frets);
   const maxFret = Math.max(...frets);
+  const sourceLabel = voicing.source === "common" ? "Common" : "Generated";
+  const mutedLabel = voicing.mutedStrings.length > 0 ? ` · ${formatCount(voicing.mutedStrings.length, "muted string")}` : "";
   return {
     id: voicing.id,
     label: voicing.label,
-    meta: `${voicing.source === "common" ? "Common" : "Generated"} · frets ${minFret}-${maxFret}`,
+    meta: `${sourceLabel} · ${formatCount(voicing.notes.length, "note")} · frets ${minFret}-${maxFret}${mutedLabel}`,
     notes: voicing.notes.map((note) => {
       const shapePitch =
         voicing.capoFret > 0 ? midiToPitch(note.pitch.midi - voicing.capoFret)?.label : null;
       return {
         degree: note.degree,
-        finger: note.finger ? String(note.finger) : "",
+        finger: note.finger ? String(note.finger) : null,
         fret: note.fret,
         id: `${voicing.id}-${note.string}-${note.fret}`,
         note: note.note,
@@ -448,7 +401,7 @@ function toGuitarShape(voicing: GuitarVoicing): GuitarShape {
   };
 }
 
-function ContextChip({ icon, label }: { icon: "capo" | "key" | "shape" | "sound" | "transpose"; label: string }) {
+function ContextChip({ icon, label }: { icon: "capo" | "instrument" | "key" | "shape" | "sound" | "transpose"; label: string }) {
   const Icon =
     icon === "transpose" ? ArrowUpDown : icon === "capo" ? Gauge : icon === "shape" ? Layers : Music2;
   return (
@@ -462,7 +415,7 @@ function ContextChip({ icon, label }: { icon: "capo" | "key" | "shape" | "sound"
 function MiniFretboard({ notes }: { notes: readonly GuitarVoicing["notes"][number][] }) {
   const dots = notes.slice(0, 4).map((note) => ({
     fret: Math.max(1, Math.min(4, note.fret + 1)),
-    string: Math.max(1, Math.min(5, note.string)),
+    string: Math.max(1, Math.min(6, note.string)),
   }));
   return (
     <span className="mini-fretboard" aria-hidden="true">
@@ -482,11 +435,13 @@ function GuitarFretboard({
   notes,
   onSelectNote,
   selectedNoteId,
+  stringLabels,
 }: {
   maxFret: number;
   notes: readonly NotePoint[];
-  onSelectNote: (noteId: string) => void;
-  selectedNoteId: string;
+  onSelectNote: (noteId: string | null) => void;
+  selectedNoteId: string | null;
+  stringLabels: readonly string[];
 }) {
   const displayFrets = Math.max(4, Math.min(8, maxFret));
   return (
@@ -522,18 +477,15 @@ function GuitarFretboard({
         ))}
       </span>
       <span className="guitar-fretboard__strings" aria-hidden="true">
-        <span>E</span>
-        <span>B</span>
-        <span>G</span>
-        <span>D</span>
-        <span>A</span>
-        <span>E</span>
+        {stringLabels.map((label, index) => (
+          <span key={`${label}-${index}`}>{label}</span>
+        ))}
       </span>
     </span>
   );
 }
 
-function NoteInspector({ capoActive, note }: { capoActive: boolean; note: NotePoint }) {
+function NoteInspector({ capoFret, note }: { capoFret: number; note: NotePoint }) {
   return (
     <section className="note-inspector" aria-label="Note inspector">
       <div className="note-inspector__badge">
@@ -551,17 +503,17 @@ function NoteInspector({ capoActive, note }: { capoActive: boolean; note: NotePo
         </div>
         <div>
           <dt>Finger</dt>
-          <dd>{note.finger}</dd>
+          <dd>{note.finger ?? "Not specified"}</dd>
         </div>
         <div>
           <dt>Degree</dt>
           <dd>{note.degree}</dd>
         </div>
-        {capoActive ? (
+        {capoFret > 0 ? (
           <>
             <div>
               <dt>Capo</dt>
-              <dd>+2</dd>
+              <dd>{capoFret}</dd>
             </div>
             <div>
               <dt>Shape note</dt>
@@ -575,154 +527,79 @@ function NoteInspector({ capoActive, note }: { capoActive: boolean; note: NotePo
 }
 
 function LiveFollowSurface() {
-  const [peekOpen, setPeekOpen] = useState(false);
-  const [activeShape, setActiveShape] = useState("close");
-
   return (
-    <div className="live-follow-page">
+    <div className="live-follow-page live-follow-page--waiting">
       <div className="live-follow-topbar">
-        <div className="live-follow-controls" role="group" aria-label="Live chord display controls">
-          <button className="chord-pill chord-pill--active" type="button">
+        <div className="live-follow-controls" role="group" aria-label="Live chord display status">
+          <span className="chord-pill chord-pill--active">
             <Music2 aria-hidden="true" />
-            <span>Accordion</span>
-          </button>
-          <button className="chord-pill" type="button">
-            <Layers aria-hidden="true" />
-            <span>{activeShape}</span>
-          </button>
-          <button className="chord-pill" type="button">
-            <ArrowUpDown aria-hidden="true" />
-            <span>C major</span>
-          </button>
-        </div>
-        <div className="live-follow-tray" aria-label="Upcoming chord shapes">
-          {liveProgression.map((item, index) => (
-            <button
-              key={item.chord}
-              className={classNames("live-shape-chip", index === 0 && "live-shape-chip--active")}
-              onClick={() => setActiveShape(item.shape)}
-              type="button"
-            >
-              <strong>{item.chord}</strong>
-              <span>{item.shape}</span>
-            </button>
-          ))}
-        </div>
-      </div>
-
-      <div className="lyrics-follow-stage">
-        <div className="lyrics-follow-line lyrics-follow-line--muted">
-          <div className="lyrics-chord-space" />
-          <span>Tonight is heavy on one side</span>
-        </div>
-        <div className="lyrics-follow-line lyrics-follow-line--active">
-          <div className="lyrics-chord-space">
-            <button
-              className="lyrics-chord-chip lyrics-chord-chip--active"
-              onFocus={() => setPeekOpen(true)}
-              onClick={() => setPeekOpen(true)}
-              onMouseEnter={() => setPeekOpen(true)}
-              type="button"
-            >
-              C
-            </button>
-            {peekOpen ? (
-              <div className="chord-peek" role="dialog" aria-label="C chord preview">
-                <div className="chord-peek__header">
-                  <strong>C</strong>
-                  <div className="chord-shape-tabs chord-shape-tabs--compact" role="group" aria-label="C shape choices">
-                    {["natural", "C/E", "C/G"].map((shape) => (
-                      <button
-                        key={shape}
-                        className={classNames(
-                          "chord-shape-tab",
-                          shape === "natural" && "chord-shape-tab--active",
-                        )}
-                        type="button"
-                      >
-                        {shape}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-                <AccordionPreview />
-                <div className="chord-note-row">
-                  {["C4", "E4", "G4"].map((note) => (
-                    <span key={note}>{note}</span>
-                  ))}
-                </div>
-                <div className="chord-peek__actions">
-                  <button className="chord-mini-button chord-mini-button--active" type="button">
-                    Pin
-                  </button>
-                  <button className="chord-mini-button" type="button">Dictionary</button>
-                </div>
-              </div>
-            ) : null}
-          </div>
-          <span>You've got something on your mind and so have I</span>
-        </div>
-        <div className="lyrics-follow-line">
-          <div className="lyrics-chord-space">
-            <button className="lyrics-chord-chip" type="button">G/D</button>
-            <button className="lyrics-chord-chip" type="button">Am/C</button>
-          </div>
-          <span>I can see it from here, oh</span>
-        </div>
-        <div className="lyrics-follow-line lyrics-follow-line--muted">
-          <div className="lyrics-chord-space">
-            <button className="lyrics-chord-chip" type="button">F/C</button>
-          </div>
-          <span>Ten years later, it's been a decade</span>
-        </div>
-      </div>
-
-      <div className="live-follow-bottom">
-        <div className="live-follow-timeline">
-          {liveProgression.map((item, index) => (
-            <button
-              key={item.chord}
-              className={classNames("live-timeline-segment", index === 0 && "live-timeline-segment--active")}
-              type="button"
-            >
-              <strong>{item.chord}</strong>
-              <span>{item.seconds}</span>
-            </button>
-          ))}
-        </div>
-        <div className="live-transport-strip">
-          <button aria-label="Seek back" className="chord-icon-button" type="button">
-            <RefreshCw aria-hidden="true" />
-          </button>
-          <button aria-label="Play playback" className="chord-icon-button chord-icon-button--active" type="button">
+            <span>{GUITAR_STANDARD_PROFILE.label}</span>
+          </span>
+          <span className="chord-pill chord-pill--muted">
             <AudioLines aria-hidden="true" />
-          </button>
-          <input aria-label="Playback position" max="100" min="0" type="range" value="38" readOnly />
+            <span>Waiting</span>
+          </span>
+        </div>
+      </div>
+
+      <div className="lyrics-follow-stage lyrics-follow-stage--empty" role="status" aria-live="polite">
+        <div className="live-follow-empty">
+          <AudioLines aria-hidden="true" />
+          <h3>Live Follow waiting for playback data</h3>
+          <p>
+            Project playback chord data is not connected yet. No progression, lyrics, shapes, or note previews are shown.
+          </p>
         </div>
       </div>
     </div>
   );
 }
 
-function AccordionPreview() {
+function ChordSpellingSummary({ spelling }: { spelling: NonNullable<ReturnType<typeof spellChord>> }) {
   return (
-    <div className="accordion-preview" aria-label="Accordion C chord">
-      <div className="accordion-buttons" aria-hidden="true">
-        {Array.from({ length: 36 }, (_, index) => {
-          const active = index === 14 || index === 20;
-          return <span key={index} className={active ? "accordion-buttons__dot accordion-buttons__dot--active" : "accordion-buttons__dot"} />;
-        })}
-      </div>
-      <div className="accordion-keys" aria-hidden="true">
-        {Array.from({ length: 15 }, (_, index) => {
-          const active = index === 4 || index === 7 || index === 11;
-          return <span key={index} className={active ? "accordion-keys__key accordion-keys__key--active" : "accordion-keys__key"} />;
-        })}
-      </div>
-      <div className="accordion-preview__hint">
-        <span>E4</span>
-        <small>3</small>
-      </div>
+    <div className="chord-spelling-summary" aria-label={`${spelling.label} chord spelling`}>
+      {spelling.tones.map((tone) => (
+        <span key={`${tone.degree}-${tone.noteName}`}>
+          <strong>{tone.noteName}</strong>
+          <small>{tone.degree}</small>
+        </span>
+      ))}
     </div>
   );
+}
+
+function EmptyDictionaryState({ copy, title }: { copy: string; title: string }) {
+  return (
+    <div className="chord-empty-state" role="status">
+      <strong>{title}</strong>
+      <span>{copy}</span>
+    </div>
+  );
+}
+
+function formatGuitarTuning(profile: typeof GUITAR_STANDARD_PROFILE) {
+  return getGuitarStringLabels(profile).slice().reverse().join(" ");
+}
+
+function getGuitarStringLabels(profile: typeof GUITAR_STANDARD_PROFILE) {
+  return profile.tuning
+    .slice()
+    .sort((left, right) => left.string - right.string)
+    .map((string) => string.openPitch.noteName);
+}
+
+function formatGuitarRange(profile: typeof GUITAR_STANDARD_PROFILE) {
+  const openPitches = profile.tuning.map((string) => string.openPitch);
+  const lowestOpen = openPitches.reduce((lowest, pitch) => (pitch.midi < lowest.midi ? pitch : lowest), openPitches[0]);
+  const highestOpen = openPitches.reduce((highest, pitch) => (pitch.midi > highest.midi ? pitch : highest), openPitches[0]);
+  const highestFretted = midiToPitch(highestOpen.midi + profile.frets);
+  return `${lowestOpen.label} - ${highestFretted?.label ?? highestOpen.label}`;
+}
+
+function formatBooleanCapability(value: boolean) {
+  return value ? "Supported" : "Unavailable";
+}
+
+function formatCount(count: number, noun: string) {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
 }

--- a/apps/desktop/src/styles/tools.css
+++ b/apps/desktop/src/styles/tools.css
@@ -348,8 +348,7 @@
 .chord-dictionary-toolbar,
 .chord-section-heading,
 .chord-section-heading--inline,
-.live-follow-topbar,
-.live-follow-bottom {
+.live-follow-topbar {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
@@ -365,11 +364,7 @@
 .chord-dictionary-actions,
 .chord-toolbar-cluster,
 .live-follow-controls,
-.live-follow-tray,
-.chord-view-toggle,
-.chord-shape-tabs,
-.chord-peek__actions,
-.chord-note-row {
+.chord-shape-tabs {
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -382,38 +377,28 @@
 
 .chord-icon-button,
 .chord-pill,
-.chord-mini-button,
-.chord-shape-tab,
-.live-shape-chip,
-.lyrics-chord-chip,
-.live-timeline-segment {
+.chord-shape-tab {
   border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
   background: color-mix(in srgb, var(--panel) 76%, var(--panel-strong) 24%);
   color: var(--text);
-  cursor: pointer;
   transition:
     border-color 140ms ease,
     background 140ms ease,
     transform 140ms ease;
 }
 
+.chord-icon-button,
+.chord-shape-tab {
+  cursor: pointer;
+}
+
 .chord-icon-button:hover,
-.chord-pill:hover,
-.chord-mini-button:hover,
-.chord-shape-tab:hover,
-.live-shape-chip:hover,
-.lyrics-chord-chip:hover,
-.live-timeline-segment:hover {
+.chord-shape-tab:hover {
   border-color: color-mix(in srgb, var(--playback-accent) 42%, var(--divider));
 }
 
 .chord-icon-button:focus-visible,
-.chord-pill:focus-visible,
-.chord-mini-button:focus-visible,
 .chord-shape-tab:focus-visible,
-.live-shape-chip:focus-visible,
-.lyrics-chord-chip:focus-visible,
-.live-timeline-segment:focus-visible,
 .guitar-fretboard__dot:focus-visible,
 .chord-shape-card__label:focus-visible,
 .chord-family-card:focus-visible {
@@ -433,6 +418,22 @@
   font-weight: 850;
 }
 
+.chord-dictionary-actions .chord-icon-button {
+  background: color-mix(in srgb, var(--panel) 42%, transparent);
+  color: var(--muted);
+}
+
+.chord-dictionary-actions .chord-icon-button[aria-pressed="true"] {
+  border-color: color-mix(in srgb, var(--playback-accent) 72%, var(--divider));
+  background: color-mix(in srgb, var(--playback-accent) 24%, var(--panel-strong));
+  color: var(--text);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--playback-accent) 24%, transparent);
+}
+
+.chord-dictionary-actions .chord-icon-button[aria-pressed="false"]:hover {
+  color: var(--text);
+}
+
 .chord-icon-button svg,
 .chord-pill svg,
 .chord-context-chip svg,
@@ -444,24 +445,9 @@
 
 .chord-icon-button--active,
 .chord-pill--active,
-.chord-mini-button--active,
-.chord-shape-tab--active,
-.live-shape-chip--active,
-.live-timeline-segment--active {
+.chord-shape-tab--active {
   border-color: color-mix(in srgb, var(--playback-accent) 62%, var(--divider));
   background: color-mix(in srgb, var(--playback-accent) 18%, var(--panel-strong));
-}
-
-.chord-live-dot {
-  width: 0.58rem;
-  height: 0.58rem;
-  border-radius: 999px;
-  background: var(--muted);
-}
-
-.chord-icon-button--active .chord-live-dot {
-  background: var(--playback-accent);
-  box-shadow: 0 0 0 0.22rem color-mix(in srgb, var(--playback-accent) 18%, transparent);
 }
 
 .chord-pill {
@@ -520,15 +506,38 @@
   outline: 0;
 }
 
+.chord-dictionary-status,
+.chord-empty-state,
+.live-follow-empty {
+  display: grid;
+  gap: 0.35rem;
+  min-width: 0;
+  padding: 0.75rem 0.85rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 74%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 70%, var(--surface-muted));
+  color: var(--text);
+}
+
+.chord-dictionary-status span,
+.chord-empty-state span,
+.live-follow-empty p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  font-weight: 750;
+}
+
 .chord-context-strip {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 0.55rem;
   min-height: 3rem;
   padding: 0.55rem 0.65rem;
   border: 1px solid color-mix(in srgb, var(--divider) 70%, transparent);
   border-radius: 8px;
-  overflow-x: auto;
+  overflow: visible;
   background: color-mix(in srgb, var(--surface-muted) 48%, transparent);
 }
 
@@ -571,6 +580,7 @@
 .chord-tool-main,
 .live-follow-page {
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   gap: 1rem;
   padding: 0.85rem;
 }
@@ -608,6 +618,34 @@
 .chord-section {
   display: grid;
   gap: 0.8rem;
+  min-width: 0;
+}
+
+.chord-spelling-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.chord-spelling-summary span {
+  display: inline-grid;
+  min-width: 4rem;
+  gap: 0.08rem;
+  padding: 0.45rem 0.6rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 76%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 74%, var(--panel-strong) 26%);
+}
+
+.chord-spelling-summary strong {
+  color: var(--text);
+  font-size: 1rem;
+}
+
+.chord-spelling-summary small {
+  color: var(--muted);
+  font-size: 0.76rem;
+  font-weight: 850;
 }
 
 .chord-section-heading {
@@ -652,6 +690,10 @@
 }
 
 .mini-fretboard {
+  --mini-dot-size: 0.66rem;
+  --mini-string-inset: 8%;
+  --mini-string-span: calc(100% - (2 * var(--mini-string-inset)));
+
   position: relative;
   display: block;
   width: 4.7rem;
@@ -659,21 +701,88 @@
   margin: 0.15rem 0;
   border-top: 3px solid color-mix(in srgb, var(--text) 86%, transparent);
   background:
-    linear-gradient(to right, transparent 0 8%, color-mix(in srgb, var(--divider) 70%, transparent) 8% 9%, transparent 9% 25%, color-mix(in srgb, var(--divider) 70%, transparent) 25% 26%, transparent 26% 42%, color-mix(in srgb, var(--divider) 70%, transparent) 42% 43%, transparent 43% 59%, color-mix(in srgb, var(--divider) 70%, transparent) 59% 60%, transparent 60% 76%, color-mix(in srgb, var(--divider) 70%, transparent) 76% 77%, transparent 77% 93%, color-mix(in srgb, var(--divider) 70%, transparent) 93% 94%, transparent 94%),
-    linear-gradient(to bottom, transparent 0 20%, color-mix(in srgb, var(--divider) 70%, transparent) 20% 21%, transparent 21% 40%, color-mix(in srgb, var(--divider) 70%, transparent) 40% 41%, transparent 41% 60%, color-mix(in srgb, var(--divider) 70%, transparent) 60% 61%, transparent 61% 80%, color-mix(in srgb, var(--divider) 70%, transparent) 80% 81%, transparent 81%);
+    linear-gradient(
+      to bottom,
+      transparent 0 20%,
+      color-mix(in srgb, var(--divider) 70%, transparent) 20% 21%,
+      transparent 21% 40%,
+      color-mix(in srgb, var(--divider) 70%, transparent) 40% 41%,
+      transparent 41% 60%,
+      color-mix(in srgb, var(--divider) 70%, transparent) 60% 61%,
+      transparent 61% 80%,
+      color-mix(in srgb, var(--divider) 70%, transparent) 80% 81%,
+      transparent 81%
+    );
+}
+
+.mini-fretboard::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(
+      to right,
+      transparent calc(var(--mini-string-inset) - 0.5px),
+      color-mix(in srgb, var(--divider) 70%, transparent) calc(var(--mini-string-inset) - 0.5px)
+        calc(var(--mini-string-inset) + 0.5px),
+      transparent calc(var(--mini-string-inset) + 0.5px)
+    ),
+    linear-gradient(
+      to right,
+      transparent calc(var(--mini-string-inset) + (var(--mini-string-span) * 0.2) - 0.5px),
+      color-mix(in srgb, var(--divider) 70%, transparent)
+        calc(var(--mini-string-inset) + (var(--mini-string-span) * 0.2) - 0.5px)
+        calc(var(--mini-string-inset) + (var(--mini-string-span) * 0.2) + 0.5px),
+      transparent calc(var(--mini-string-inset) + (var(--mini-string-span) * 0.2) + 0.5px)
+    ),
+    linear-gradient(
+      to right,
+      transparent calc(var(--mini-string-inset) + (var(--mini-string-span) * 0.4) - 0.5px),
+      color-mix(in srgb, var(--divider) 70%, transparent)
+        calc(var(--mini-string-inset) + (var(--mini-string-span) * 0.4) - 0.5px)
+        calc(var(--mini-string-inset) + (var(--mini-string-span) * 0.4) + 0.5px),
+      transparent calc(var(--mini-string-inset) + (var(--mini-string-span) * 0.4) + 0.5px)
+    ),
+    linear-gradient(
+      to right,
+      transparent calc(var(--mini-string-inset) + (var(--mini-string-span) * 0.6) - 0.5px),
+      color-mix(in srgb, var(--divider) 70%, transparent)
+        calc(var(--mini-string-inset) + (var(--mini-string-span) * 0.6) - 0.5px)
+        calc(var(--mini-string-inset) + (var(--mini-string-span) * 0.6) + 0.5px),
+      transparent calc(var(--mini-string-inset) + (var(--mini-string-span) * 0.6) + 0.5px)
+    ),
+    linear-gradient(
+      to right,
+      transparent calc(var(--mini-string-inset) + (var(--mini-string-span) * 0.8) - 0.5px),
+      color-mix(in srgb, var(--divider) 70%, transparent)
+        calc(var(--mini-string-inset) + (var(--mini-string-span) * 0.8) - 0.5px)
+        calc(var(--mini-string-inset) + (var(--mini-string-span) * 0.8) + 0.5px),
+      transparent calc(var(--mini-string-inset) + (var(--mini-string-span) * 0.8) + 0.5px)
+    ),
+    linear-gradient(
+      to right,
+      transparent calc(100% - var(--mini-string-inset) - 0.5px),
+      color-mix(in srgb, var(--divider) 70%, transparent) calc(100% - var(--mini-string-inset) - 0.5px)
+        calc(100% - var(--mini-string-inset) + 0.5px),
+      transparent calc(100% - var(--mini-string-inset) + 0.5px)
+    );
+  pointer-events: none;
 }
 
 .mini-fretboard__dot {
   position: absolute;
-  left: calc((var(--string) - 1) * 17% + 7%);
+  z-index: 1;
+  left: calc(
+    var(--mini-string-inset) + ((var(--string) - 1) * (var(--mini-string-span) / 5)) -
+      (var(--mini-dot-size) / 2)
+  );
   top: calc((var(--fret) - 0.55) * 20%);
-  width: 0.66rem;
-  height: 0.66rem;
+  width: var(--mini-dot-size);
+  height: var(--mini-dot-size);
   border-radius: 999px;
   background: var(--text);
 }
 
-.chord-mini-button,
 .chord-shape-tab {
   min-height: 2rem;
   border-radius: 8px;
@@ -685,13 +794,15 @@
 
 .chord-shape-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
   gap: 0.75rem;
+  min-width: 0;
 }
 
 .chord-shape-card {
   display: grid;
   gap: 0.5rem;
+  min-width: 0;
   padding: 0.72rem;
   border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
   border-radius: 8px;
@@ -716,6 +827,7 @@
 .guitar-fretboard {
   display: grid;
   gap: 0.3rem;
+  min-width: 0;
 }
 
 .guitar-fretboard__numbers,
@@ -728,6 +840,10 @@
 }
 
 .guitar-fretboard__board {
+  --guitar-dot-size: 1.35rem;
+  --guitar-string-inset: calc(var(--guitar-dot-size) / 2);
+  --guitar-string-span: calc(100% - (2 * var(--guitar-string-inset)));
+
   position: relative;
   display: block;
   height: 8.6rem;
@@ -738,21 +854,74 @@
       color-mix(in srgb, var(--divider) 78%, transparent) 0 1px,
       transparent 1px calc(100% / var(--display-frets))
     ),
-    repeating-linear-gradient(
-      to bottom,
-      color-mix(in srgb, var(--divider) 78%, transparent) 0 1px,
-      transparent 1px calc(100% / 6)
-    ),
     color-mix(in srgb, var(--color-bg-inset) 82%, transparent);
+}
+
+.guitar-fretboard__board::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(
+      to bottom,
+      transparent calc(var(--guitar-string-inset) - 0.5px),
+      color-mix(in srgb, var(--divider) 78%, transparent) calc(var(--guitar-string-inset) - 0.5px)
+        calc(var(--guitar-string-inset) + 0.5px),
+      transparent calc(var(--guitar-string-inset) + 0.5px)
+    ),
+    linear-gradient(
+      to bottom,
+      transparent calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.2) - 0.5px),
+      color-mix(in srgb, var(--divider) 78%, transparent)
+        calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.2) - 0.5px)
+        calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.2) + 0.5px),
+      transparent calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.2) + 0.5px)
+    ),
+    linear-gradient(
+      to bottom,
+      transparent calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.4) - 0.5px),
+      color-mix(in srgb, var(--divider) 78%, transparent)
+        calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.4) - 0.5px)
+        calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.4) + 0.5px),
+      transparent calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.4) + 0.5px)
+    ),
+    linear-gradient(
+      to bottom,
+      transparent calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.6) - 0.5px),
+      color-mix(in srgb, var(--divider) 78%, transparent)
+        calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.6) - 0.5px)
+        calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.6) + 0.5px),
+      transparent calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.6) + 0.5px)
+    ),
+    linear-gradient(
+      to bottom,
+      transparent calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.8) - 0.5px),
+      color-mix(in srgb, var(--divider) 78%, transparent)
+        calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.8) - 0.5px)
+        calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.8) + 0.5px),
+      transparent calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.8) + 0.5px)
+    ),
+    linear-gradient(
+      to bottom,
+      transparent calc(100% - var(--guitar-string-inset) - 0.5px),
+      color-mix(in srgb, var(--divider) 78%, transparent) calc(100% - var(--guitar-string-inset) - 0.5px)
+        calc(100% - var(--guitar-string-inset) + 0.5px),
+      transparent calc(100% - var(--guitar-string-inset) + 0.5px)
+    );
+  pointer-events: none;
 }
 
 .guitar-fretboard__dot {
   position: absolute;
+  z-index: 1;
   left: calc((var(--fret) - 0.5) * (100% / var(--display-frets)) - 0.72rem);
-  top: calc((var(--string) - 0.52) * (100% / 6) - 0.68rem);
+  top: calc(
+    var(--guitar-string-inset) + ((var(--string) - 1) * (var(--guitar-string-span) / 5)) -
+      (var(--guitar-dot-size) / 2)
+  );
   display: grid;
-  width: 1.35rem;
-  height: 1.35rem;
+  width: var(--guitar-dot-size);
+  height: var(--guitar-dot-size);
   place-items: center;
   border: 1px solid color-mix(in srgb, white 42%, transparent);
   border-radius: 999px;
@@ -870,28 +1039,16 @@
   font-size: 0.78rem;
 }
 
+.chord-accordion-row--static {
+  cursor: default;
+}
+
 .live-follow-page {
   min-height: 41rem;
 }
 
-.live-follow-topbar,
-.live-follow-bottom {
+.live-follow-topbar {
   align-items: center;
-}
-
-.live-shape-chip {
-  display: grid;
-  min-width: 5.25rem;
-  gap: 0.05rem;
-  border-radius: 8px;
-  padding: 0.45rem 0.6rem;
-  text-align: left;
-}
-
-.live-shape-chip span {
-  color: var(--muted);
-  font-size: 0.74rem;
-  font-weight: 800;
 }
 
 .lyrics-follow-stage {
@@ -906,207 +1063,27 @@
   background: color-mix(in srgb, black 18%, var(--color-bg-inset));
 }
 
-.lyrics-follow-line {
-  display: grid;
-  grid-template-columns: minmax(6rem, 10rem) minmax(0, 1fr);
-  gap: 1rem;
-  align-items: end;
-  color: var(--text);
-  font-size: clamp(1.15rem, 2vw, 1.65rem);
-  font-weight: 750;
-}
-
-.lyrics-follow-line--muted {
-  color: var(--muted);
-}
-
-.lyrics-follow-line--active {
-  color: var(--text);
-}
-
-.lyrics-chord-space {
-  position: relative;
-  min-height: 2.1rem;
-  display: flex;
-  align-items: flex-end;
-  gap: 0.4rem;
-  flex-wrap: wrap;
-}
-
-.lyrics-chord-chip {
-  min-width: 3rem;
-  border-radius: 8px;
-  padding: 0.26rem 0.5rem;
-  color: var(--playback-accent);
-  font-weight: 900;
-}
-
-.lyrics-chord-chip--active {
-  background: var(--playback-accent);
-  color: var(--panel);
-}
-
-.chord-peek {
-  position: absolute;
-  z-index: 2;
-  left: 0;
-  bottom: calc(100% + 0.65rem);
-  width: min(24rem, 78vw);
-  display: grid;
-  gap: 0.65rem;
-  padding: 0.75rem;
-  border: 1px solid color-mix(in srgb, var(--playback-accent) 45%, var(--divider));
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--panel-strong) 94%, black);
-  box-shadow: 0 1rem 2rem color-mix(in srgb, black 32%, transparent);
-}
-
-.chord-peek::after {
-  content: "";
-  position: absolute;
-  left: 1.1rem;
-  top: 100%;
-  border: 0.5rem solid transparent;
-  border-top-color: color-mix(in srgb, var(--panel-strong) 94%, black);
-}
-
-.chord-peek__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.7rem;
-}
-
-.chord-peek__header strong {
-  color: var(--text);
-  font-size: 1.45rem;
-}
-
-.chord-shape-tabs--compact .chord-shape-tab {
-  min-height: 1.8rem;
-  padding: 0.22rem 0.45rem;
-}
-
-.accordion-preview {
-  position: relative;
-  display: grid;
-  grid-template-columns: 8rem minmax(8rem, 1fr);
-  gap: 0.85rem;
-  align-items: center;
-}
-
-.accordion-buttons {
-  display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  gap: 0.25rem;
-  padding: 0.45rem;
-  border: 1px solid color-mix(in srgb, var(--divider) 72%, transparent);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--color-bg-inset) 84%, transparent);
-}
-
-.accordion-buttons__dot {
-  aspect-ratio: 1;
-  border: 1px solid color-mix(in srgb, var(--divider) 80%, transparent);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--panel-strong) 80%, transparent);
-}
-
-.accordion-buttons__dot--active,
-.accordion-keys__key--active {
-  background: var(--playback-accent);
-  border-color: color-mix(in srgb, white 35%, var(--playback-accent));
-}
-
-.accordion-keys {
-  display: grid;
-  grid-template-columns: repeat(15, minmax(0, 1fr));
-  align-items: stretch;
-  height: 5.8rem;
-  border: 1px solid color-mix(in srgb, var(--divider) 72%, transparent);
-  border-radius: 8px;
-  overflow: hidden;
-  background: color-mix(in srgb, var(--text) 90%, white);
-}
-
-.accordion-keys__key {
-  border-right: 1px solid color-mix(in srgb, black 24%, transparent);
-  background: color-mix(in srgb, var(--text) 92%, white);
-}
-
-.accordion-keys__key:nth-child(2),
-.accordion-keys__key:nth-child(4),
-.accordion-keys__key:nth-child(7),
-.accordion-keys__key:nth-child(9),
-.accordion-keys__key:nth-child(11),
-.accordion-keys__key:nth-child(14) {
-  height: 60%;
-  background: #111827;
-}
-
-.accordion-preview__hint {
-  position: absolute;
-  right: 1.6rem;
-  top: 0.4rem;
-  display: grid;
+.lyrics-follow-stage--empty {
+  align-content: center;
   justify-items: center;
-  gap: 0.1rem;
-  min-width: 2.4rem;
-  padding: 0.28rem 0.35rem;
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--panel-strong) 86%, black);
-  color: var(--text);
-  font-size: 0.78rem;
-  font-weight: 850;
-}
-
-.accordion-preview__hint small {
-  color: var(--playback-accent);
-}
-
-.chord-note-row span {
-  min-width: 3rem;
-  border: 1px solid color-mix(in srgb, var(--divider) 72%, transparent);
-  border-radius: 8px;
-  padding: 0.24rem 0.45rem;
-  color: var(--text);
-  font-size: 0.82rem;
-  font-weight: 900;
+  padding: 2rem;
   text-align: center;
 }
 
-.live-follow-timeline {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.55rem;
-  flex: 1;
+.live-follow-empty {
+  max-width: 34rem;
 }
 
-.live-timeline-segment {
-  display: grid;
-  gap: 0.12rem;
-  min-height: 3.2rem;
-  border-radius: 8px;
-  padding: 0.45rem 0.6rem;
-  text-align: left;
+.live-follow-empty svg {
+  width: 2rem;
+  height: 2rem;
+  color: var(--playback-accent);
 }
 
-.live-timeline-segment span {
-  color: var(--muted);
-  font-size: 0.76rem;
-  font-weight: 800;
+.live-follow-empty h3 {
+  margin: 0;
 }
 
-.live-transport-strip {
-  display: grid;
-  grid-template-columns: auto auto minmax(10rem, 16rem);
-  align-items: center;
-  gap: 0.55rem;
-}
-
-.live-transport-strip input {
-  accent-color: var(--playback-accent);
-}
 
 @media (max-width: 1180px) {
   .chord-tool-grid {
@@ -1126,8 +1103,7 @@
   .chord-dictionary-header,
   .chord-dictionary-toolbar,
   .chord-section-heading,
-  .live-follow-topbar,
-  .live-follow-bottom {
+  .live-follow-topbar {
     align-items: stretch;
     flex-direction: column;
   }
@@ -1137,16 +1113,12 @@
   }
 
   .chord-card-row,
-  .chord-shape-grid,
-  .note-inspector dl,
-  .live-follow-timeline {
+  .note-inspector dl {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .note-inspector,
-  .accordion-preview,
-  .lyrics-follow-line,
-  .live-transport-strip {
+  .lyrics-follow-stage {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary
- Closes #263
- Replace placeholder Chord Dictionary UI with guitar-only data-backed search, shapes, note inspection, and honest Live Follow waiting state.
- Remove fake instrument/progression controls and align guitar fretboard dots with string lines in full and mini diagrams.

## Testing
- pnpm --filter @tuneforge/desktop lint
- pnpm --filter @tuneforge/desktop typecheck
- pnpm --filter @tuneforge/desktop test --run src/App.tools-chord-dictionary.test.tsx
- Note: pnpm --filter @tuneforge/desktop test -- App.tools-chord-dictionary.test.tsx currently invokes the broader suite locally and fails in App.background-playback.test.tsx.
