### PR TITLE
feat: Add standard guitar diagrams

### DIFF
--- a/apps/desktop/src/App.tools-chord-dictionary.test.tsx
+++ b/apps/desktop/src/App.tools-chord-dictionary.test.tsx
@@ -34,6 +34,197 @@ function expectTextVisible(text: RegExp | string) {
   expect(screen.getAllByText(text).length).toBeGreaterThan(0);
 }
 
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function getStandardDisplayString(stringNumber: number) {
+  return 7 - stringNumber;
+}
+
+function getShapeCard(label: string) {
+  const shapeLabel = screen
+    .getAllByRole("button", { name: label })
+    .find((button) => button.closest(".chord-shape-card"));
+  if (!shapeLabel) {
+    throw new Error(`Expected ${label} shape card`);
+  }
+
+  const shapeCard = shapeLabel.closest(".chord-shape-card");
+  if (!shapeCard) {
+    throw new Error(`Expected ${label} label inside a shape card`);
+  }
+  return shapeCard as HTMLElement;
+}
+
+function getStandardDiagram(label: string) {
+  const shapeCard = getShapeCard(label);
+  const diagram = within(shapeCard).getByRole("group", {
+    name: new RegExp(`${escapeRegExp(label)}.*standard guitar diagram`, "i"),
+  });
+
+  expect(diagram).toHaveClass("guitar-fretboard");
+  expect(diagram).toHaveClass("guitar-fretboard--standard");
+  expect(diagram).toHaveAttribute("data-string-orientation", "vertical");
+  expect(diagram).toHaveAttribute("data-fret-orientation", "horizontal");
+  expect(diagram.querySelector(".guitar-fretboard__board")).toBeInTheDocument();
+  expect(diagram.querySelector(".guitar-fretboard__numbers")).toBeInTheDocument();
+  expect(diagram.querySelector(".guitar-fretboard__strings")).toBeInTheDocument();
+  return diagram as HTMLElement;
+}
+
+function expectStandardStringLabels(diagram: HTMLElement) {
+  const expectedLabels = [
+    [6, "E"],
+    [5, "A"],
+    [4, "D"],
+    [3, "G"],
+    [2, "B"],
+    [1, "E"],
+  ] as const;
+  const stringLabels = Array.from(diagram.querySelectorAll(".guitar-fretboard__strings span"));
+
+  expect(stringLabels.map((label) => label.getAttribute("data-string"))).toEqual([
+    "6",
+    "5",
+    "4",
+    "3",
+    "2",
+    "1",
+  ]);
+
+  for (const [stringNumber, label] of expectedLabels) {
+    const stringLabel = within(diagram).getByLabelText(
+      new RegExp(`string\\s*${stringNumber}.*\\b${label}\\b`, "i"),
+    );
+    expect(stringLabel).toHaveAttribute("data-string", String(stringNumber));
+  }
+}
+
+function expectPlayableNote(
+  diagram: HTMLElement,
+  note: string,
+  stringNumber: number,
+  fret: number,
+) {
+  const noteButton = within(diagram).getByRole("button", {
+    name: `${note} string ${stringNumber} fret ${fret}`,
+  });
+
+  expect(noteButton).toHaveAttribute("data-string", String(stringNumber));
+  expect(noteButton).toHaveAttribute("data-fret", String(fret));
+  expect(noteButton).toHaveAttribute("data-note", note);
+  expect(noteButton).toHaveAttribute("data-note-kind", fret === 0 ? "open" : "fretted");
+  expect(noteButton).toHaveAttribute("title", note);
+  expect(noteButton.style.getPropertyValue("--string")).toBe(
+    String(getStandardDisplayString(stringNumber)),
+  );
+  expect(within(noteButton).getByText(note)).toHaveClass("guitar-fretboard__note-tooltip");
+  return noteButton as HTMLElement;
+}
+
+function expectActiveTooltipNotes(expectedNotes: string[]) {
+  const activeDots = Array.from(document.querySelectorAll(".guitar-fretboard__dot--tooltip-active"));
+  expect(activeDots.map((dot) => dot.getAttribute("data-note"))).toEqual(expectedNotes);
+  expect(document.querySelectorAll('.guitar-fretboard__dot[data-tooltip-active="true"]')).toHaveLength(
+    expectedNotes.length,
+  );
+}
+
+function expectOpenMarker(diagram: HTMLElement, stringNumber: number) {
+  const marker = within(diagram).getByLabelText(
+    new RegExp(`(?:open\\s*string\\s*${stringNumber}|string\\s*${stringNumber}\\s*open)`, "i"),
+  );
+  expect(marker).toHaveAttribute("data-string", String(stringNumber));
+  expect(marker).toHaveClass("guitar-fretboard__marker--open");
+  expect(marker.style.getPropertyValue("--string")).toBe(
+    String(getStandardDisplayString(stringNumber)),
+  );
+}
+
+function expectMutedMarker(diagram: HTMLElement, stringNumber: number) {
+  const marker = within(diagram).getByLabelText(
+    new RegExp(`(?:muted\\s*string\\s*${stringNumber}|string\\s*${stringNumber}\\s*muted)`, "i"),
+  );
+  expect(marker).toHaveAttribute("data-string", String(stringNumber));
+  expect(marker).toHaveClass("guitar-fretboard__marker--muted");
+  expect(marker.style.getPropertyValue("--string")).toBe(
+    String(getStandardDisplayString(stringNumber)),
+  );
+}
+
+function expectNoOpenMarker(diagram: HTMLElement, stringNumber: number) {
+  expect(
+    within(diagram).queryByLabelText(
+      new RegExp(`(?:open\\s*string\\s*${stringNumber}|string\\s*${stringNumber}\\s*open)`, "i"),
+    ),
+  ).not.toBeInTheDocument();
+}
+
+function expectNoMutedMarker(diagram: HTMLElement, stringNumber: number) {
+  expect(
+    within(diagram).queryByLabelText(
+      new RegExp(`(?:muted\\s*string\\s*${stringNumber}|string\\s*${stringNumber}\\s*muted)`, "i"),
+    ),
+  ).not.toBeInTheDocument();
+}
+
+function expectContinuousBarre(
+  diagram: HTMLElement,
+  {
+    fret,
+    fromString,
+    toString,
+  }: { fret: number; fromString: number; toString: number },
+) {
+  const barre = within(diagram).getByLabelText(
+    new RegExp(
+      `barre.*fret\\s*${fret}.*strings?\\s*${fromString}.*${toString}`,
+      "i",
+    ),
+  );
+
+  expect(barre).toHaveClass("guitar-fretboard__barre");
+  expect(barre).toHaveAttribute("data-barre-fret", String(fret));
+  expect(barre).toHaveAttribute("data-barre-from-string", String(fromString));
+  expect(barre).toHaveAttribute("data-barre-to-string", String(toString));
+  expect(barre.style.getPropertyValue("--barre-start-string")).toBe(String(fromString));
+  expect(barre.style.getPropertyValue("--barre-end-string")).toBe(String(toString));
+  expect(barre.style.getPropertyValue("--string-start")).toBe(
+    String(Math.min(getStandardDisplayString(fromString), getStandardDisplayString(toString))),
+  );
+  expect(barre.style.getPropertyValue("--string-end")).toBe(
+    String(Math.max(getStandardDisplayString(fromString), getStandardDisplayString(toString))),
+  );
+  return barre as HTMLElement;
+}
+
+function setNarrowViewport(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    value: width,
+  });
+  Object.defineProperty(document.documentElement, "clientWidth", {
+    configurable: true,
+    value: width,
+  });
+  window.dispatchEvent(new Event("resize"));
+}
+
+function getCommonChordCard(label: string) {
+  const chordCard = Array.from(document.querySelectorAll(".chord-family-card")).find(
+    (card) => card.querySelector("strong")?.textContent === label,
+  );
+  if (!chordCard) {
+    throw new Error(`Expected ${label} common chord card`);
+  }
+  return chordCard as HTMLElement;
+}
+
+function expectContainedHorizontalOverflow(element: HTMLElement, viewportWidth: number) {
+  expect(element.scrollWidth).toBeLessThanOrEqual(Math.max(element.clientWidth, viewportWidth));
+}
+
 describe("Desktop app tools chord dictionary", () => {
   beforeEach(resetAppTestHarness);
 
@@ -58,6 +249,165 @@ describe("Desktop app tools chord dictionary", () => {
       /Finger\s*3/,
       /Degree\s*1/,
     ]);
+  });
+
+  it("renders C open with standard vertical-string diagram semantics", async () => {
+    const user = userEvent.setup();
+    await renderChordDictionary();
+
+    const diagram = getStandardDiagram("C open");
+
+    expectStandardStringLabels(diagram);
+    expectPlayableNote(diagram, "C3", 5, 3);
+    expectPlayableNote(diagram, "E3", 4, 2);
+    const openStringNote = expectPlayableNote(diagram, "G3", 3, 0);
+    expectPlayableNote(diagram, "C4", 2, 1);
+    expectPlayableNote(diagram, "E4", 1, 0);
+    expectOpenMarker(diagram, 3);
+    expectOpenMarker(diagram, 1);
+    expectMutedMarker(diagram, 6);
+    expectNoOpenMarker(diagram, 6);
+    expectNoMutedMarker(diagram, 3);
+    expect(within(getShapeCard("C open")).getByText(/Common.*5 notes.*frets 0-3.*1 muted string/)).toBeInTheDocument();
+
+    await user.click(openStringNote);
+
+    await waitFor(() =>
+      expectInspectorToShow([/G3/, /String\s*3/, /Fret\s*0/, /Degree\s*5/]),
+    );
+    expectActiveTooltipNotes(["G3"]);
+  });
+
+  it("previews hovered and focused notes with one active tooltip", async () => {
+    const user = userEvent.setup();
+    await renderChordDictionary();
+
+    const diagram = getStandardDiagram("C open");
+    const selectedRoot = expectPlayableNote(diagram, "C3", 5, 3);
+    const previewNote = expectPlayableNote(diagram, "E3", 4, 2);
+
+    expect(selectedRoot).toHaveClass("guitar-fretboard__dot--tooltip-active");
+    expectActiveTooltipNotes(["C3"]);
+    expectInspectorToShow([/C3/, /String\s*5/, /Fret\s*3/]);
+
+    await user.hover(previewNote);
+
+    await waitFor(() => expectInspectorToShow([/E3/, /String\s*4/, /Fret\s*2/]));
+    expectActiveTooltipNotes(["E3"]);
+
+    await user.unhover(previewNote);
+
+    await waitFor(() => expectInspectorToShow([/C3/, /String\s*5/, /Fret\s*3/]));
+    expectActiveTooltipNotes(["C3"]);
+
+    previewNote.focus();
+
+    await waitFor(() => expectInspectorToShow([/E3/, /String\s*4/, /Fret\s*2/]));
+    expectActiveTooltipNotes(["E3"]);
+
+    previewNote.blur();
+
+    await waitFor(() => expectInspectorToShow([/C3/, /String\s*5/, /Fret\s*3/]));
+    expectActiveTooltipNotes(["C3"]);
+  });
+
+  it("renders F barre as one continuous E-shape barre with note buttons intact", async () => {
+    await renderChordDictionary();
+
+    changeChordSearch("F");
+
+    const diagram = getStandardDiagram("F E-shape barre");
+
+    expectStandardStringLabels(diagram);
+    const barre = expectContinuousBarre(diagram, { fret: 1, fromString: 6, toString: 1 });
+    const miniBarre = getCommonChordCard("F").querySelector(".mini-fretboard__barre");
+
+    expect(barre.style.getPropertyValue("--fret-position")).toBe("1");
+    expect(miniBarre).toBeInTheDocument();
+    expect((miniBarre as HTMLElement).style.getPropertyValue("--barre-start-string")).toBe("6");
+    expect((miniBarre as HTMLElement).style.getPropertyValue("--barre-end-string")).toBe("1");
+    expect((miniBarre as HTMLElement).style.getPropertyValue("--string-start")).toBe("1");
+    expect((miniBarre as HTMLElement).style.getPropertyValue("--string-end")).toBe("6");
+    expectPlayableNote(diagram, "F2", 6, 1);
+    expectPlayableNote(diagram, "C3", 5, 3);
+    expectPlayableNote(diagram, "F3", 4, 3);
+    expectPlayableNote(diagram, "A3", 3, 2);
+    expectPlayableNote(diagram, "C4", 2, 1);
+    expectPlayableNote(diagram, "F4", 1, 1);
+    expect(diagram.querySelector(".guitar-fretboard__marker--open")).not.toBeInTheDocument();
+    expect(diagram.querySelector(".guitar-fretboard__marker--muted")).not.toBeInTheDocument();
+    expect(within(getShapeCard("F E-shape barre")).getByText(/Common.*6 notes.*frets 1-3/)).toBeInTheDocument();
+  });
+
+  it("keeps C moved E-shape barre labelled by left fret numbers without position marker text", async () => {
+    const user = userEvent.setup();
+    await renderChordDictionary();
+
+    const shapeChoices = within(screen.getByRole("group", { name: "Guitar shape choices" }));
+    const movedShapeButton = shapeChoices.getByRole("button", { name: "C E-shape barre" });
+
+    await user.click(movedShapeButton);
+
+    const diagram = getStandardDiagram("C E-shape barre");
+    const movedShapeCard = getShapeCard("C E-shape barre");
+
+    expect(movedShapeButton).toHaveAttribute("aria-pressed", "true");
+    expect(diagram).toHaveAttribute("data-start-fret", "8");
+    expect(diagram.querySelector(".guitar-fretboard__position-marker")).not.toBeInTheDocument();
+    expect(within(diagram).queryByText(/8\s*fr/i)).not.toBeInTheDocument();
+    expect(movedShapeCard).toHaveTextContent(/Common.*6 notes.*frets 8-10/);
+    expect(movedShapeCard).not.toHaveTextContent(/8\s*fr/i);
+    expect(
+      Array.from(diagram.querySelectorAll(".guitar-fretboard__numbers span")).map(
+        (fretNumber) => fretNumber.textContent,
+      ),
+    ).toEqual(["8", "9", "10", "11"]);
+    const barre = expectContinuousBarre(diagram, { fret: 8, fromString: 6, toString: 1 });
+    const rootButton = expectPlayableNote(diagram, "C3", 6, 8);
+
+    expect(barre.style.getPropertyValue("--fret-position")).toBe("1");
+    expectPlayableNote(diagram, "G3", 5, 10);
+    expectPlayableNote(diagram, "C4", 4, 10);
+    expectPlayableNote(diagram, "E4", 3, 9);
+    expectPlayableNote(diagram, "G4", 2, 8);
+    expectPlayableNote(diagram, "C5", 1, 8);
+
+    await user.hover(rootButton);
+    expect(within(rootButton).getByText("C3")).toHaveClass("guitar-fretboard__note-tooltip");
+
+    await user.click(rootButton);
+
+    await waitFor(() =>
+      expectInspectorToShow([/C3/, /String\s*6/, /Fret\s*8/, /Degree\s*1/]),
+    );
+  });
+
+  it("keeps standard diagrams compact and labelled in a narrow layout", async () => {
+    setNarrowViewport(360);
+    await renderChordDictionary();
+
+    const diagram = getStandardDiagram("C open");
+    const shell = document.querySelector(".chord-dictionary-shell");
+    const panel = document.querySelector(".chord-dictionary-panel");
+    const mainPanel = document.querySelector(".chord-tool-main");
+    const shapeGrid = document.querySelector(".chord-shape-grid");
+    const shapeTabs = document.querySelector(".chord-shape-tabs");
+
+    expect(shapeGrid).toHaveAttribute("data-layout", "responsive");
+    expect(diagram).toHaveAttribute("data-layout", "compact");
+    expect(diagram.style.getPropertyValue("--display-frets")).toBe("4");
+    expect(shell).toBeInTheDocument();
+    expect(panel).toBeInTheDocument();
+    expect(mainPanel).toBeInTheDocument();
+    expect(shapeTabs).toBeInTheDocument();
+    expectContainedHorizontalOverflow(shell as HTMLElement, 360);
+    expectContainedHorizontalOverflow(panel as HTMLElement, 360);
+    expectContainedHorizontalOverflow(mainPanel as HTMLElement, 360);
+    expectContainedHorizontalOverflow(shapeGrid as HTMLElement, 360);
+    expectStandardStringLabels(diagram);
+    expectPlayableNote(diagram, "C3", 5, 3);
+    expectOpenMarker(diagram, 1);
+    expectMutedMarker(diagram, 6);
   });
 
   it("updates a supported slash-chord search with backed guitar spelling and shape data", async () => {
@@ -112,7 +462,12 @@ describe("Desktop app tools chord dictionary", () => {
       throw new Error("Expected a selectable E3 string 4 fret 2 note");
     }
 
+    noteButton.focus();
+    expect(noteButton).toHaveFocus();
+    expect(within(noteButton).getByText("E3")).toHaveClass("guitar-fretboard__note-tooltip");
+
     await user.click(noteButton);
+    expect(noteButton).toHaveFocus();
     await waitFor(() =>
       expectInspectorToShow([
         /E3/,

--- a/apps/desktop/src/features/tools/ChordDictionaryPage.tsx
+++ b/apps/desktop/src/features/tools/ChordDictionaryPage.tsx
@@ -21,18 +21,69 @@ import {
 type ChordDictionarySurface = "dictionary" | "follow";
 type NotePoint = {
   degree: string;
+  displayFret: number;
+  displayString: number;
   finger: string | null;
   fret: number;
   id: string;
+  isOpen: boolean;
   note: string;
   shapeNote?: string;
   string: number;
 };
+type GuitarStringView = {
+  displayString: number;
+  label: string;
+  string: number;
+};
+type GuitarStringMarker =
+  | {
+      degree: string;
+      displayString: number;
+      id: string;
+      kind: "open";
+      note: string;
+      noteId: string;
+      string: number;
+    }
+  | {
+      displayString: number;
+      id: string;
+      kind: "muted";
+      string: number;
+    }
+  | {
+      displayString: number;
+      id: string;
+      kind: "empty";
+      string: number;
+    };
+type GuitarBarreGroup = {
+  displayFret: number;
+  endDisplayString: number;
+  endString: number;
+  finger: string;
+  fret: number;
+  id: string;
+  noteIds: readonly string[];
+  startDisplayString: number;
+  startString: number;
+};
+type GuitarFretWindow = {
+  fretCount: number;
+  frets: readonly number[];
+  startFret: number;
+};
 type GuitarShape = {
+  barreGroups: readonly GuitarBarreGroup[];
+  fretWindow: GuitarFretWindow;
   id: string;
   label: string;
   meta: string;
+  mutedStrings: readonly number[];
   notes: NotePoint[];
+  stringMarkers: readonly GuitarStringMarker[];
+  strings: readonly GuitarStringView[];
 };
 
 const COMMON_CHORD_LABELS = ["C", "Dm", "Em", "F", "G", "Am", "Bdim"] as const;
@@ -91,6 +142,7 @@ export function ChordDictionaryPage() {
 function DictionarySurface() {
   const [activeChord, setActiveChord] = useState("C");
   const [activeShape, setActiveShape] = useState<string | null>(null);
+  const [previewNoteId, setPreviewNoteId] = useState<string | null>(null);
   const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
   const displayContext = useMemo<Partial<ChordDisplayContext>>(
     () => ({
@@ -113,12 +165,13 @@ function DictionarySurface() {
           return [];
         }
         const voicings = generateGuitarVoicings(spelling, GUITAR_STANDARD_PROFILE, displayContext);
+        const voicing = voicings[0] ?? null;
         return {
           id: spelling.label,
           label: spelling.label,
           notes: spelling.notes.join(" "),
           quality: CHORD_QUALITY_DEFINITIONS[spelling.quality].label,
-          voicing: voicings[0] ?? null,
+          shape: voicing ? toGuitarShape(voicing, GUITAR_STANDARD_PROFILE) : null,
           voicingCount: voicings.length,
         };
       }),
@@ -129,7 +182,7 @@ function DictionarySurface() {
     [chordSpelling, displayContext],
   );
   const guitarShapes = useMemo(
-    () => guitarVoicings.map((voicing) => toGuitarShape(voicing)),
+    () => guitarVoicings.map((voicing) => toGuitarShape(voicing, GUITAR_STANDARD_PROFILE)),
     [guitarVoicings],
   );
   const resultKey = guitarShapes.map((shape) => shape.id).join("|");
@@ -137,11 +190,17 @@ function DictionarySurface() {
   const firstNoteId = guitarShapes[0]?.notes[0]?.id ?? null;
   useEffect(() => {
     setActiveShape(firstShapeId);
+    setPreviewNoteId(null);
     setSelectedNoteId(firstNoteId);
   }, [firstNoteId, firstShapeId, resultKey]);
   const selectedShape = guitarShapes.find((shape) => shape.id === activeShape) ?? guitarShapes[0] ?? null;
   const selectedNote =
     selectedShape?.notes.find((note) => note.id === selectedNoteId) ?? selectedShape?.notes[0] ?? null;
+  const previewNote = previewNoteId
+    ? guitarShapes.flatMap((shape) => shape.notes).find((note) => note.id === previewNoteId) ?? null
+    : null;
+  const displayedNote = previewNote ?? selectedNote;
+  const activeTooltipNoteId = previewNote?.id ?? selectedNote?.id ?? null;
   const selectedVoicing = guitarVoicings.find((voicing) => voicing.id === selectedShape?.id) ?? null;
   const sourceKeyLabel = displayContext.sourceKey
     ? formatKey(displayContext.sourceKey, "long")
@@ -149,7 +208,6 @@ function DictionarySurface() {
   const transposeLabel = `${displayContext.transposeSemitones ?? 0} semitones`;
   const capoLabel = displayContext.capoFret ? `Capo ${displayContext.capoFret}` : "No capo";
   const tuningLabel = formatGuitarTuning(GUITAR_STANDARD_PROFILE);
-  const stringLabels = getGuitarStringLabels(GUITAR_STANDARD_PROFILE);
 
   return (
     <div className="chord-dictionary">
@@ -159,7 +217,10 @@ function DictionarySurface() {
           <Music2 aria-hidden="true" />
           <input
             aria-label="Chord search"
-            onChange={(event) => setActiveChord(event.currentTarget.value)}
+            onChange={(event) => {
+              setActiveChord(event.currentTarget.value);
+              setPreviewNoteId(null);
+            }}
             placeholder="C major"
             value={activeChord}
           />
@@ -228,6 +289,7 @@ function DictionarySurface() {
                       )}
                       onClick={() => {
                         setActiveShape(shape.id);
+                        setPreviewNoteId(null);
                         setSelectedNoteId(shape.notes[0]?.id ?? null);
                       }}
                       type="button"
@@ -257,7 +319,7 @@ function DictionarySurface() {
                 copy="Type a supported chord symbol to show spelling, degrees, and guitar voicings."
               />
             ) : (
-              <div className="chord-shape-grid">
+              <div className="chord-shape-grid" data-layout="responsive">
                 {guitarShapes.map((shape) => (
                   <div
                     key={shape.id}
@@ -270,6 +332,7 @@ function DictionarySurface() {
                       className="chord-shape-card__label"
                       onClick={() => {
                         setActiveShape(shape.id);
+                        setPreviewNoteId(null);
                         setSelectedNoteId(shape.notes[0]?.id ?? null);
                       }}
                       type="button"
@@ -277,11 +340,15 @@ function DictionarySurface() {
                       {shape.label}
                     </button>
                     <GuitarFretboard
-                      maxFret={Math.max(...shape.notes.map((note) => note.fret), 4)}
+                      activeTooltipNoteId={activeTooltipNoteId}
                       notes={shape.notes}
                       selectedNoteId={selectedNoteId}
-                      onSelectNote={setSelectedNoteId}
-                      stringLabels={stringLabels}
+                      shape={shape}
+                      onPreviewNote={setPreviewNoteId}
+                      onSelectNote={(noteId) => {
+                        setPreviewNoteId(null);
+                        setSelectedNoteId(noteId);
+                      }}
                     />
                     <span className="chord-shape-card__meta">{shape.meta}</span>
                   </div>
@@ -290,7 +357,7 @@ function DictionarySurface() {
             )}
           </section>
 
-          {selectedNote ? <NoteInspector note={selectedNote} capoFret={displayContext.capoFret ?? 0} /> : null}
+          {displayedNote ? <NoteInspector note={displayedNote} capoFret={displayContext.capoFret ?? 0} /> : null}
 
           {chordSpelling ? (
             <section className="chord-section">
@@ -308,12 +375,15 @@ function DictionarySurface() {
                       "chord-family-card",
                       activeChord === chord.label && "chord-family-card--active",
                     )}
-                    onClick={() => setActiveChord(chord.label)}
+                    onClick={() => {
+                      setActiveChord(chord.label);
+                      setPreviewNoteId(null);
+                    }}
                     type="button"
                   >
                     <strong>{chord.label}</strong>
                     <span>{chord.quality}</span>
-                    <MiniFretboard notes={chord.voicing?.notes ?? []} />
+                    <MiniFretboard shape={chord.shape} />
                     <small>{chord.notes}</small>
                     <small>{formatCount(chord.voicingCount, "shape")}</small>
                   </button>
@@ -375,30 +445,211 @@ function DictionarySurface() {
   );
 }
 
-function toGuitarShape(voicing: GuitarVoicing): GuitarShape {
-  const frets = voicing.notes.map((note) => note.fret);
-  const minFret = Math.min(...frets);
-  const maxFret = Math.max(...frets);
+function toGuitarShape(voicing: GuitarVoicing, profile: typeof GUITAR_STANDARD_PROFILE): GuitarShape {
+  const strings = getGuitarStringViews(profile);
+  const displayStringByString = new Map(strings.map((string) => [string.string, string.displayString]));
+  const fretWindow = getGuitarFretWindow(voicing.notes);
   const sourceLabel = voicing.source === "common" ? "Common" : "Generated";
   const mutedLabel = voicing.mutedStrings.length > 0 ? ` · ${formatCount(voicing.mutedStrings.length, "muted string")}` : "";
+  const notes = voicing.notes.map((note) => {
+    const shapePitch =
+      voicing.capoFret > 0 ? midiToPitch(note.pitch.midi - voicing.capoFret)?.label : null;
+    return {
+      degree: note.degree,
+      displayFret: getDisplayFret(note.fret, fretWindow),
+      displayString: displayStringByString.get(note.string) ?? note.string,
+      finger: note.finger ? String(note.finger) : null,
+      fret: note.fret,
+      id: `${voicing.id}-${note.string}-${note.fret}`,
+      isOpen: note.fret === 0,
+      note: note.note,
+      shapeNote: shapePitch ?? undefined,
+      string: note.string,
+    };
+  });
+  const mutedStrings = [...voicing.mutedStrings];
+  const mutedStringSet = new Set(mutedStrings);
+  const frettedLabel = formatFretWindowLabel(notes);
   return {
+    barreGroups: getGuitarBarreGroups(notes, mutedStringSet, voicing.label.toLowerCase().includes("barre")),
+    fretWindow,
     id: voicing.id,
     label: voicing.label,
-    meta: `${sourceLabel} · ${formatCount(voicing.notes.length, "note")} · frets ${minFret}-${maxFret}${mutedLabel}`,
-    notes: voicing.notes.map((note) => {
-      const shapePitch =
-        voicing.capoFret > 0 ? midiToPitch(note.pitch.midi - voicing.capoFret)?.label : null;
-      return {
-        degree: note.degree,
-        finger: note.finger ? String(note.finger) : null,
-        fret: note.fret,
-        id: `${voicing.id}-${note.string}-${note.fret}`,
-        note: note.note,
-        shapeNote: shapePitch ?? undefined,
-        string: note.string,
-      };
-    }),
+    meta: `${sourceLabel} · ${formatCount(voicing.notes.length, "note")} · ${frettedLabel}${mutedLabel}`,
+    mutedStrings,
+    notes,
+    stringMarkers: getGuitarStringMarkers(strings, notes, mutedStringSet),
+    strings,
   };
+}
+
+function getGuitarStringViews(profile: typeof GUITAR_STANDARD_PROFILE): readonly GuitarStringView[] {
+  return profile.tuning
+    .slice()
+    .sort((left, right) => right.string - left.string)
+    .map((stringTuning, index) => ({
+      displayString: index + 1,
+      label: stringTuning.openPitch.noteName,
+      string: stringTuning.string,
+    }));
+}
+
+function getGuitarFretWindow(notes: readonly GuitarVoicing["notes"][number][]): GuitarFretWindow {
+  const frettedFrets = notes.map((note) => note.fret).filter((fret) => fret > 0);
+  const maxFret = frettedFrets.length > 0 ? Math.max(...frettedFrets) : 0;
+  const minFret = frettedFrets.length > 0 ? Math.min(...frettedFrets) : 0;
+  const hasOpenString = notes.some((note) => note.fret === 0);
+  const startFret = !hasOpenString && minFret > 1 ? minFret : 0;
+  const neededFrets = startFret > 0 ? maxFret - startFret + 1 : Math.max(maxFret, 4);
+  const fretCount = Math.max(4, neededFrets);
+  const firstFretNumber = startFret > 0 ? startFret : 1;
+  return {
+    fretCount,
+    frets: Array.from({ length: fretCount }, (_, index) => firstFretNumber + index),
+    startFret,
+  };
+}
+
+function getDisplayFret(fret: number, fretWindow: GuitarFretWindow) {
+  if (fret === 0) {
+    return 0;
+  }
+  return fretWindow.startFret > 0 ? fret - fretWindow.startFret + 1 : fret;
+}
+
+function formatFretWindowLabel(notes: readonly NotePoint[]) {
+  const frets = notes.map((note) => note.fret);
+  if (frets.length === 0) {
+    return "open strings";
+  }
+  const minFret = Math.min(...frets);
+  const maxFret = Math.max(...frets);
+  return minFret === maxFret ? `fret ${minFret}` : `frets ${minFret}-${maxFret}`;
+}
+
+function getGuitarStringMarkers(
+  strings: readonly GuitarStringView[],
+  notes: readonly NotePoint[],
+  mutedStrings: ReadonlySet<number>,
+): readonly GuitarStringMarker[] {
+  const openNotesByString = new Map(notes.filter((note) => note.isOpen).map((note) => [note.string, note]));
+  return strings.map((string) => {
+    const openNote = openNotesByString.get(string.string);
+    if (openNote) {
+      return {
+        degree: openNote.degree,
+        displayString: string.displayString,
+        id: `${openNote.id}-open-marker`,
+        kind: "open",
+        note: openNote.note,
+        noteId: openNote.id,
+        string: string.string,
+      };
+    }
+    if (mutedStrings.has(string.string)) {
+      return {
+        displayString: string.displayString,
+        id: `muted-string-${string.string}`,
+        kind: "muted",
+        string: string.string,
+      };
+    }
+    return {
+      displayString: string.displayString,
+      id: `empty-string-${string.string}`,
+      kind: "empty",
+      string: string.string,
+    };
+  });
+}
+
+function getGuitarBarreGroups(
+  notes: readonly NotePoint[],
+  mutedStrings: ReadonlySet<number>,
+  inferUnfingeredBarre: boolean,
+): readonly GuitarBarreGroup[] {
+  const groupedNotes = new Map<string, NotePoint[]>();
+  for (const note of notes) {
+    if (!note.finger || note.fret === 0) {
+      continue;
+    }
+    const key = `${note.finger}-${note.fret}`;
+    groupedNotes.set(key, [...(groupedNotes.get(key) ?? []), note]);
+  }
+
+  const barreGroups: GuitarBarreGroup[] = [];
+  for (const group of groupedNotes.values()) {
+    const barreGroup = makeGuitarBarreGroup(group, mutedStrings, group[0]?.finger ?? "fingered");
+    if (barreGroup) {
+      barreGroups.push(barreGroup);
+    }
+  }
+
+  if (inferUnfingeredBarre && barreGroups.length === 0) {
+    const frettedNotes = notes.filter((note) => note.fret > 0);
+    const lowestFret = frettedNotes.length > 0 ? Math.min(...frettedNotes.map((note) => note.fret)) : null;
+    const lowestFretNotes = lowestFret === null ? [] : frettedNotes.filter((note) => note.fret === lowestFret);
+    const inferredBarre = makeGuitarBarreGroup(lowestFretNotes, mutedStrings, "unfingered");
+    if (inferredBarre) {
+      barreGroups.push(inferredBarre);
+    }
+  }
+
+  return barreGroups.sort(
+    (left, right) =>
+      left.displayFret - right.displayFret ||
+      left.startDisplayString - right.startDisplayString ||
+      right.endDisplayString - left.endDisplayString,
+  );
+}
+
+function makeGuitarBarreGroup(
+  group: readonly NotePoint[],
+  mutedStrings: ReadonlySet<number>,
+  idPrefix: string,
+): GuitarBarreGroup | null {
+  if (group.length < 2) {
+    return null;
+  }
+  const sortedGroup = [...group].sort((left, right) => left.displayString - right.displayString);
+  const numericStrings = sortedGroup.map((note) => note.string);
+  const lowString = Math.min(...numericStrings);
+  const highString = Math.max(...numericStrings);
+  if (hasMutedStringBetween(lowString, highString, mutedStrings)) {
+    return null;
+  }
+  const displayStrings = sortedGroup.map((note) => note.displayString);
+  const startDisplayString = Math.min(...displayStrings);
+  const endDisplayString = Math.max(...displayStrings);
+  const firstNote = sortedGroup[0];
+  return {
+    displayFret: firstNote.displayFret,
+    endDisplayString,
+    endString: lowString,
+    finger: firstNote.finger ?? "",
+    fret: firstNote.fret,
+    id: `barre-${idPrefix}-${firstNote.fret}-${highString}-${lowString}`,
+    noteIds: sortedGroup.map((note) => note.id),
+    startDisplayString,
+    startString: highString,
+  };
+}
+
+function hasMutedStringBetween(
+  lowString: number,
+  highString: number,
+  mutedStrings: ReadonlySet<number>,
+) {
+  for (let string = lowString; string <= highString; string += 1) {
+    if (mutedStrings.has(string)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function formatNoteButtonLabel(note: NotePoint) {
+  return `${note.note} string ${note.string} fret ${note.fret}`;
 }
 
 function ContextChip({ icon, label }: { icon: "capo" | "instrument" | "key" | "shape" | "sound" | "transpose"; label: string }) {
@@ -412,18 +663,67 @@ function ContextChip({ icon, label }: { icon: "capo" | "instrument" | "key" | "s
   );
 }
 
-function MiniFretboard({ notes }: { notes: readonly GuitarVoicing["notes"][number][] }) {
-  const dots = notes.slice(0, 4).map((note) => ({
-    fret: Math.max(1, Math.min(4, note.fret + 1)),
-    string: Math.max(1, Math.min(6, note.string)),
-  }));
+function MiniFretboard({ shape }: { shape: GuitarShape | null }) {
+  if (!shape) {
+    return <span className="mini-fretboard" aria-hidden="true" />;
+  }
   return (
-    <span className="mini-fretboard" aria-hidden="true">
-      {dots.map((dot) => (
+    <span
+      className="mini-fretboard"
+      style={
+        {
+          "--display-frets": shape.fretWindow.fretCount,
+        } as CSSProperties
+      }
+      aria-hidden="true"
+    >
+      <span className="mini-fretboard__markers">
+        {shape.stringMarkers.map((marker) => (
+          <span
+            key={marker.id}
+            className={classNames(
+              "mini-fretboard__marker",
+              marker.kind === "open" && "mini-fretboard__marker--open",
+              marker.kind === "muted" && "mini-fretboard__marker--muted",
+            )}
+            style={{ "--string": marker.displayString } as CSSProperties}
+          >
+            {marker.kind === "open" ? "O" : marker.kind === "muted" ? "X" : ""}
+          </span>
+        ))}
+      </span>
+      {shape.barreGroups.map((barre) => (
         <span
-          key={`${dot.string}-${dot.fret}`}
+          key={barre.id}
+          className="mini-fretboard__barre"
+          style={
+            {
+              "--barre-end-string": barre.endString,
+              "--barre-fret": barre.fret,
+              "--barre-start-string": barre.startString,
+              "--end-string": barre.endDisplayString,
+              "--fret": barre.fret,
+              "--fret-position": barre.displayFret,
+              "--start-string": barre.startDisplayString,
+              "--string-end": barre.endDisplayString,
+              "--string-start": barre.startDisplayString,
+              "--visible-fret": barre.displayFret,
+            } as CSSProperties
+          }
+        />
+      ))}
+      {shape.notes.map((note) => (
+        <span
+          key={note.id}
           className="mini-fretboard__dot"
-          style={{ "--fret": dot.fret, "--string": dot.string } as CSSProperties}
+          style={
+            {
+              "--fret": note.fret,
+              "--fret-position": note.displayFret,
+              "--string": note.displayString,
+              "--visible-fret": note.displayFret,
+            } as CSSProperties
+          }
         />
       ))}
     </span>
@@ -431,54 +731,164 @@ function MiniFretboard({ notes }: { notes: readonly GuitarVoicing["notes"][numbe
 }
 
 function GuitarFretboard({
-  maxFret,
+  activeTooltipNoteId,
   notes,
+  onPreviewNote,
   onSelectNote,
   selectedNoteId,
-  stringLabels,
+  shape,
 }: {
-  maxFret: number;
+  activeTooltipNoteId: string | null;
   notes: readonly NotePoint[];
+  onPreviewNote: (noteId: string | null) => void;
   onSelectNote: (noteId: string | null) => void;
   selectedNoteId: string | null;
-  stringLabels: readonly string[];
+  shape: GuitarShape;
 }) {
-  const displayFrets = Math.max(4, Math.min(8, maxFret));
   return (
     <span
-      className="guitar-fretboard"
-      style={{ "--display-frets": displayFrets } as CSSProperties}
-      aria-label="Guitar fretboard"
+      className="guitar-fretboard guitar-fretboard--standard"
+      data-fret-orientation="horizontal"
+      data-layout="compact"
+      data-start-fret={shape.fretWindow.startFret}
+      data-string-orientation="vertical"
+      style={
+        {
+          "--display-frets": shape.fretWindow.fretCount,
+        } as CSSProperties
+      }
+      aria-label={`${shape.label} standard guitar diagram`}
       role="group"
     >
-      <span className="guitar-fretboard__numbers" aria-hidden="true">
-        {Array.from({ length: displayFrets + 1 }, (_, fret) => (
-          <span key={fret}>{fret}</span>
-        ))}
+      <span className="guitar-fretboard__markers" role="group" aria-label="String status markers">
+        {shape.stringMarkers.map((marker) =>
+          marker.kind === "open" ? (
+            <span
+              key={marker.id}
+              aria-label={`Open string ${marker.string}`}
+              className={classNames(
+                "guitar-fretboard__marker",
+                "guitar-fretboard__marker--open",
+                "guitar-fretboard__string-marker",
+                "guitar-fretboard__string-marker--open",
+              )}
+              data-string={marker.string}
+              role="img"
+              style={{ "--string": marker.displayString } as CSSProperties}
+            >
+              O
+            </span>
+          ) : marker.kind === "muted" ? (
+            <span
+              key={marker.id}
+              aria-label={`Muted string ${marker.string}`}
+              className="guitar-fretboard__marker guitar-fretboard__marker--muted guitar-fretboard__string-marker guitar-fretboard__string-marker--muted"
+              data-string={marker.string}
+              role="img"
+              style={{ "--string": marker.displayString } as CSSProperties}
+            >
+              X
+            </span>
+          ) : (
+            <span
+              key={marker.id}
+              aria-hidden="true"
+              className="guitar-fretboard__marker guitar-fretboard__marker--empty"
+              data-string={marker.string}
+              style={{ "--string": marker.displayString } as CSSProperties}
+            />
+          ),
+        )}
       </span>
       <span className="guitar-fretboard__board">
+        {shape.barreGroups.map((barre) => (
+          <span
+            key={barre.id}
+            aria-label={
+              barre.finger
+                ? `Barre finger ${barre.finger} fret ${barre.fret} strings ${barre.startString} to ${barre.endString}`
+                : `Barre fret ${barre.fret} strings ${barre.startString} to ${barre.endString}`
+            }
+            className="guitar-fretboard__barre"
+            data-barre-fret={barre.fret}
+            data-barre-from-string={barre.startString}
+            data-barre-to-string={barre.endString}
+            data-finger={barre.finger}
+            style={
+              {
+                "--barre-end-string": barre.endString,
+                "--barre-fret": barre.fret,
+                "--barre-start-string": barre.startString,
+                "--end-string": barre.endDisplayString,
+                "--fret": barre.fret,
+                "--fret-position": barre.displayFret,
+                "--start-string": barre.startDisplayString,
+                "--string-end": barre.endDisplayString,
+                "--string-start": barre.startDisplayString,
+                "--visible-fret": barre.displayFret,
+              } as CSSProperties
+            }
+          />
+        ))}
         {notes.map((note) => (
           <button
             key={note.id}
-            aria-label={`${note.note} string ${note.string} fret ${note.fret}`}
+            aria-label={formatNoteButtonLabel(note)}
             className={classNames(
               "guitar-fretboard__dot",
+              note.isOpen && "guitar-fretboard__dot--open",
+              shape.barreGroups.some((barre) => barre.noteIds.includes(note.id)) &&
+                "guitar-fretboard__dot--over-barre",
               selectedNoteId === note.id && "guitar-fretboard__dot--selected",
+              activeTooltipNoteId === note.id && "guitar-fretboard__dot--tooltip-active",
             )}
+            data-fret={note.fret}
+            data-note={note.note}
+            data-note-kind={note.isOpen ? "open" : "fretted"}
+            data-tooltip-active={activeTooltipNoteId === note.id ? "true" : "false"}
+            data-string={note.string}
+            onBlur={() => onPreviewNote(null)}
             onClick={(event) => {
               event.stopPropagation();
               onSelectNote(note.id);
             }}
-            style={{ "--fret": note.fret, "--string": note.string } as CSSProperties}
+            onFocus={() => onPreviewNote(note.id)}
+            onPointerEnter={() => onPreviewNote(note.id)}
+            onPointerLeave={() => onPreviewNote(null)}
+            style={
+              {
+                "--fret": note.fret,
+                "--fret-position": note.displayFret,
+                "--string": note.displayString,
+                "--visible-fret": note.displayFret,
+              } as CSSProperties
+            }
+            title={note.note}
             type="button"
           >
-            {note.finger}
+            <span className="guitar-fretboard__dot-finger" aria-hidden="true">
+              {note.finger}
+            </span>
+            <span className="guitar-fretboard__note-tooltip" aria-hidden="true">
+              {note.note}
+            </span>
           </button>
         ))}
       </span>
-      <span className="guitar-fretboard__strings" aria-hidden="true">
-        {stringLabels.map((label, index) => (
-          <span key={`${label}-${index}`}>{label}</span>
+      <span className="guitar-fretboard__numbers" aria-hidden="true">
+        {shape.fretWindow.frets.map((fret) => (
+          <span key={fret}>{fret}</span>
+        ))}
+      </span>
+      <span className="guitar-fretboard__strings">
+        {shape.strings.map((string) => (
+          <span
+            key={string.string}
+            aria-label={`String ${string.string} ${string.label}`}
+            data-string={string.string}
+          >
+            {string.label}
+          </span>
         ))}
       </span>
     </span>

--- a/apps/desktop/src/styles/tools.css
+++ b/apps/desktop/src/styles/tools.css
@@ -333,11 +333,17 @@
 
 .chord-dictionary-shell {
   max-width: min(100%, 1360px);
+  min-width: 0;
+  width: 100%;
+  overflow-x: clip;
 }
 
 .chord-dictionary-panel {
   display: grid;
   gap: 1rem;
+  min-width: 0;
+  max-width: 100%;
+  overflow-x: clip;
   border-color: color-mix(in srgb, var(--playback-accent) 18%, var(--panel-border));
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--panel-strong) 88%, transparent), transparent 48%),
@@ -469,6 +475,8 @@
 .chord-dictionary {
   display: grid;
   gap: 1rem;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .chord-dictionary-toolbar {
@@ -533,6 +541,8 @@
   align-items: center;
   flex-wrap: wrap;
   gap: 0.55rem;
+  min-width: 0;
+  max-width: 100%;
   min-height: 3rem;
   padding: 0.55rem 0.65rem;
   border: 1px solid color-mix(in srgb, var(--divider) 70%, transparent);
@@ -566,6 +576,8 @@
   grid-template-columns: minmax(0, 1fr) minmax(17rem, 21rem);
   gap: 1rem;
   align-items: start;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .chord-tool-main,
@@ -650,6 +662,12 @@
 
 .chord-section-heading {
   align-items: center;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.chord-section-heading > * {
+  min-width: 0;
 }
 
 .chord-card-row {
@@ -690,29 +708,25 @@
 }
 
 .mini-fretboard {
-  --mini-dot-size: 0.66rem;
-  --mini-string-inset: 8%;
+  --mini-display-frets: var(--display-frets, 4);
+  --mini-dot-size: 0.58rem;
+  --mini-string-inset: 10%;
   --mini-string-span: calc(100% - (2 * var(--mini-string-inset)));
 
   position: relative;
   display: block;
-  width: 4.7rem;
-  height: 5.25rem;
+  width: 4.25rem;
+  height: 5rem;
   margin: 0.15rem 0;
+  overflow: visible;
   border-top: 3px solid color-mix(in srgb, var(--text) 86%, transparent);
   background:
-    linear-gradient(
+    repeating-linear-gradient(
       to bottom,
-      transparent 0 20%,
-      color-mix(in srgb, var(--divider) 70%, transparent) 20% 21%,
-      transparent 21% 40%,
-      color-mix(in srgb, var(--divider) 70%, transparent) 40% 41%,
-      transparent 41% 60%,
-      color-mix(in srgb, var(--divider) 70%, transparent) 60% 61%,
-      transparent 61% 80%,
-      color-mix(in srgb, var(--divider) 70%, transparent) 80% 81%,
-      transparent 81%
-    );
+      color-mix(in srgb, var(--divider) 70%, transparent) 0 1px,
+      transparent 1px calc(100% / var(--mini-display-frets))
+    ),
+    color-mix(in srgb, var(--color-bg-inset) 74%, transparent);
 }
 
 .mini-fretboard::before {
@@ -771,20 +785,87 @@
 
 .mini-fretboard__dot {
   position: absolute;
-  z-index: 1;
+  z-index: 2;
   left: calc(
     var(--mini-string-inset) + ((var(--string) - 1) * (var(--mini-string-span) / 5)) -
       (var(--mini-dot-size) / 2)
   );
-  top: calc((var(--fret) - 0.55) * 20%);
+  top: calc(
+    ((var(--fret-position, var(--visible-fret, var(--fret))) - 0.5) * (100% / var(--mini-display-frets))) -
+      (var(--mini-dot-size) / 2)
+  );
   width: var(--mini-dot-size);
   height: var(--mini-dot-size);
   border-radius: 999px;
   background: var(--text);
 }
 
+.mini-fretboard__markers {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.mini-fretboard__marker {
+  position: absolute;
+  z-index: 3;
+  left: calc(var(--mini-string-inset) + ((var(--string) - 1) * (var(--mini-string-span) / 5)) - 0.3rem);
+  top: -0.95rem;
+  display: grid;
+  width: 0.6rem;
+  height: 0.6rem;
+  place-items: center;
+  color: color-mix(in srgb, var(--muted) 90%, transparent);
+  font-size: 0;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.mini-fretboard__marker--open {
+  border: 1.5px solid currentColor;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--panel) 88%, transparent);
+}
+
+.mini-fretboard__marker--muted::before,
+.mini-fretboard__marker--muted::after {
+  content: "";
+  position: absolute;
+  width: 0.62rem;
+  height: 1.5px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.mini-fretboard__marker--muted::before {
+  transform: rotate(45deg);
+}
+
+.mini-fretboard__marker--muted::after {
+  transform: rotate(-45deg);
+}
+
+.mini-fretboard__barre {
+  --mini-barre-fret-position: var(--fret-position, var(--visible-fret, var(--fret, var(--barre-fret, 1))));
+  --mini-barre-start: var(--string-start, var(--start-string, var(--barre-start-string, 1)));
+  --mini-barre-end: var(--string-end, var(--end-string, var(--barre-end-string, 6)));
+
+  position: absolute;
+  z-index: 1;
+  left: calc(
+    var(--mini-string-inset) + ((var(--mini-barre-start) - 1) * (var(--mini-string-span) / 5)) -
+      (var(--mini-dot-size) / 2)
+  );
+  top: calc(((var(--mini-barre-fret-position) - 0.5) * (100% / var(--mini-display-frets))) - (var(--mini-dot-size) / 2));
+  width: calc(((var(--mini-barre-end) - var(--mini-barre-start)) * (var(--mini-string-span) / 5)) + var(--mini-dot-size));
+  height: var(--mini-dot-size);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text) 88%, var(--panel));
+}
+
 .chord-shape-tab {
   min-height: 2rem;
+  min-width: 0;
   border-radius: 8px;
   padding: 0.34rem 0.65rem;
   color: var(--text);
@@ -794,7 +875,7 @@
 
 .chord-shape-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 12.25rem), 1fr));
   gap: 0.75rem;
   min-width: 0;
 }
@@ -822,11 +903,28 @@
   font: inherit;
   font-weight: 900;
   text-align: left;
+  overflow-wrap: anywhere;
 }
 
 .guitar-fretboard {
+  --guitar-visible-frets: var(--display-frets, 4);
+  --guitar-board-height: clamp(8.8rem, calc(var(--guitar-visible-frets) * 1.9rem), 13.2rem);
+  --guitar-dot-size: 1.12rem;
+  --guitar-fret-row-size: calc(var(--guitar-board-height) / var(--display-frets));
+  --guitar-marker-row-height: 1.08rem;
+  --guitar-string-inset: 8%;
+  --guitar-string-span: calc(100% - (2 * var(--guitar-string-inset)));
+
+  position: relative;
   display: grid;
-  gap: 0.3rem;
+  grid-template-columns: minmax(1.45rem, auto) minmax(0, 1fr);
+  grid-template-areas:
+    ". markers"
+    "numbers board"
+    ". strings";
+  column-gap: 0.45rem;
+  row-gap: 0.32rem;
+  align-items: start;
   min-width: 0;
 }
 
@@ -837,20 +935,50 @@
   color: var(--muted);
   font-size: 0.72rem;
   font-weight: 800;
+  line-height: 1;
+}
+
+.guitar-fretboard__numbers {
+  grid-area: numbers;
+  flex-direction: column;
+  align-self: stretch;
+  height: var(--guitar-board-height);
+  padding-block: 0 0.08rem;
+  text-align: right;
+}
+
+.guitar-fretboard__numbers span {
+  display: block;
+  min-width: 1.25rem;
+  transform: translateY(-0.35em);
+}
+
+.guitar-fretboard__numbers span:first-child {
+  color: color-mix(in srgb, var(--muted) 72%, transparent);
+}
+
+.guitar-fretboard__strings {
+  grid-area: strings;
+  padding-inline: var(--guitar-string-inset, 8%);
+  text-align: center;
+}
+
+.guitar-fretboard__strings span {
+  min-width: 1.15rem;
 }
 
 .guitar-fretboard__board {
-  --guitar-dot-size: 1.35rem;
-  --guitar-string-inset: calc(var(--guitar-dot-size) / 2);
-  --guitar-string-span: calc(100% - (2 * var(--guitar-string-inset)));
-
   position: relative;
+  grid-area: board;
   display: block;
-  height: 8.6rem;
-  border-left: 4px solid color-mix(in srgb, var(--text) 82%, transparent);
+  width: 100%;
+  height: var(--guitar-board-height);
+  min-width: 0;
+  overflow: visible;
+  border-top: 4px solid color-mix(in srgb, var(--text) 82%, transparent);
   background:
     repeating-linear-gradient(
-      to right,
+      to bottom,
       color-mix(in srgb, var(--divider) 78%, transparent) 0 1px,
       transparent 1px calc(100% / var(--display-frets))
     ),
@@ -863,14 +991,14 @@
   inset: 0;
   background:
     linear-gradient(
-      to bottom,
+      to right,
       transparent calc(var(--guitar-string-inset) - 0.5px),
       color-mix(in srgb, var(--divider) 78%, transparent) calc(var(--guitar-string-inset) - 0.5px)
         calc(var(--guitar-string-inset) + 0.5px),
       transparent calc(var(--guitar-string-inset) + 0.5px)
     ),
     linear-gradient(
-      to bottom,
+      to right,
       transparent calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.2) - 0.5px),
       color-mix(in srgb, var(--divider) 78%, transparent)
         calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.2) - 0.5px)
@@ -878,7 +1006,7 @@
       transparent calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.2) + 0.5px)
     ),
     linear-gradient(
-      to bottom,
+      to right,
       transparent calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.4) - 0.5px),
       color-mix(in srgb, var(--divider) 78%, transparent)
         calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.4) - 0.5px)
@@ -886,7 +1014,7 @@
       transparent calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.4) + 0.5px)
     ),
     linear-gradient(
-      to bottom,
+      to right,
       transparent calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.6) - 0.5px),
       color-mix(in srgb, var(--divider) 78%, transparent)
         calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.6) - 0.5px)
@@ -894,7 +1022,7 @@
       transparent calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.6) + 0.5px)
     ),
     linear-gradient(
-      to bottom,
+      to right,
       transparent calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.8) - 0.5px),
       color-mix(in srgb, var(--divider) 78%, transparent)
         calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.8) - 0.5px)
@@ -902,7 +1030,7 @@
       transparent calc(var(--guitar-string-inset) + (var(--guitar-string-span) * 0.8) + 0.5px)
     ),
     linear-gradient(
-      to bottom,
+      to right,
       transparent calc(100% - var(--guitar-string-inset) - 0.5px),
       color-mix(in srgb, var(--divider) 78%, transparent) calc(100% - var(--guitar-string-inset) - 0.5px)
         calc(100% - var(--guitar-string-inset) + 0.5px),
@@ -913,29 +1041,226 @@
 
 .guitar-fretboard__dot {
   position: absolute;
-  z-index: 1;
-  left: calc((var(--fret) - 0.5) * (100% / var(--display-frets)) - 0.72rem);
-  top: calc(
+  z-index: 2;
+  left: calc(
     var(--guitar-string-inset) + ((var(--string) - 1) * (var(--guitar-string-span) / 5)) -
+      (var(--guitar-dot-size) / 2)
+  );
+  top: calc(
+    ((var(--fret-position, var(--visible-fret, var(--fret))) - 0.5) * (100% / var(--display-frets))) -
       (var(--guitar-dot-size) / 2)
   );
   display: grid;
   width: var(--guitar-dot-size);
   height: var(--guitar-dot-size);
   place-items: center;
+  box-sizing: border-box;
   border: 1px solid color-mix(in srgb, white 42%, transparent);
   border-radius: 999px;
+  padding: 0;
   background: color-mix(in srgb, var(--text) 88%, var(--panel));
   color: var(--panel);
-  font-size: 0.78rem;
+  font-size: 0.72rem;
+  font-family: inherit;
   font-weight: 900;
+  line-height: 1;
+  text-align: center;
   cursor: pointer;
+}
+
+.guitar-fretboard__dot-finger {
+  display: grid;
+  grid-area: 1 / 1;
+  width: 100%;
+  height: 100%;
+  place-items: center;
+  line-height: 1;
+}
+
+.guitar-fretboard__note-tooltip {
+  position: absolute;
+  z-index: 5;
+  top: calc(100% + 0.35rem);
+  left: 50%;
+  min-width: max-content;
+  padding: 0.16rem 0.34rem;
+  border: 1px solid color-mix(in srgb, var(--playback-accent) 42%, var(--divider));
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--panel-strong) 94%, var(--panel));
+  color: var(--text);
+  font-size: 0.7rem;
+  font-weight: 900;
+  line-height: 1;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(-50%) translateY(-0.12rem);
+  transition:
+    opacity 100ms ease,
+    transform 100ms ease;
+}
+
+.guitar-fretboard__dot--tooltip-active .guitar-fretboard__note-tooltip,
+.guitar-fretboard__dot[data-tooltip-active="true"] .guitar-fretboard__note-tooltip {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+.guitar-fretboard__dot[style*="--fret: 0"],
+.guitar-fretboard__dot[style*="--fret:0"] {
+  top: -1.28rem;
+  width: 0.86rem;
+  height: 0.86rem;
+  border: 2px solid color-mix(in srgb, var(--text) 74%, transparent);
+  background: color-mix(in srgb, var(--panel) 88%, transparent);
+  color: transparent;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--panel) 86%, transparent);
+}
+
+.guitar-fretboard__dot--over-barre,
+.guitar-fretboard__dot--barre-overlay {
+  z-index: 3;
 }
 
 .guitar-fretboard__dot--selected {
   background: var(--playback-accent);
   color: var(--panel);
   box-shadow: 0 0 0 0.2rem color-mix(in srgb, var(--playback-accent) 22%, transparent);
+}
+
+.guitar-fretboard__dot--selected[style*="--fret: 0"],
+.guitar-fretboard__dot--selected[style*="--fret:0"] {
+  border-color: var(--playback-accent);
+  background: color-mix(in srgb, var(--panel) 82%, var(--playback-accent) 18%);
+  box-shadow: 0 0 0 0.18rem color-mix(in srgb, var(--playback-accent) 22%, transparent);
+}
+
+.guitar-fretboard__barre {
+  --barre-fret-position: var(--fret-position, var(--visible-fret, var(--fret, var(--barre-fret, 1))));
+  --barre-start: var(--string-start, var(--start-string, var(--barre-start-string, 1)));
+  --barre-end: var(--string-end, var(--end-string, var(--barre-end-string, 6)));
+
+  position: absolute;
+  z-index: 1;
+  left: calc(
+    var(--guitar-string-inset) + ((var(--barre-start) - 1) * (var(--guitar-string-span) / 5)) -
+      (var(--guitar-dot-size) / 2)
+  );
+  top: calc(
+    ((var(--barre-fret-position) - 0.5) * (100% / var(--display-frets))) -
+      (var(--guitar-dot-size) / 2)
+  );
+  display: grid;
+  width: var(
+    --barre-width,
+    calc(((var(--barre-end) - var(--barre-start)) * (var(--guitar-string-span) / 5)) + var(--guitar-dot-size))
+  );
+  height: var(--guitar-dot-size);
+  place-items: center;
+  border: 1px solid color-mix(in srgb, white 36%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text) 86%, var(--panel));
+  color: var(--panel);
+  font-size: 0.7rem;
+  font-weight: 900;
+  line-height: 1;
+  pointer-events: none;
+}
+
+.guitar-fretboard__barre--selected {
+  background: var(--playback-accent);
+  box-shadow: 0 0 0 0.2rem color-mix(in srgb, var(--playback-accent) 20%, transparent);
+}
+
+.guitar-fretboard__markers {
+  position: relative;
+  grid-area: markers;
+  display: block;
+  height: var(--guitar-marker-row-height);
+  min-width: 0;
+  pointer-events: none;
+}
+
+.guitar-fretboard__marker,
+.guitar-fretboard__string-marker,
+.guitar-fretboard__open-marker,
+.guitar-fretboard__muted-marker {
+  position: absolute;
+  z-index: 3;
+  border: 0;
+  padding: 0;
+  left: calc(
+    var(--guitar-string-inset) + ((var(--string) - 1) * (var(--guitar-string-span) / 5)) -
+      0.43rem
+  );
+  top: 0.08rem;
+  display: grid;
+  width: 0.86rem;
+  height: 0.86rem;
+  place-items: center;
+  background: transparent;
+  color: color-mix(in srgb, var(--text) 82%, transparent);
+  font-size: 0;
+  font-weight: 900;
+  line-height: 1;
+  pointer-events: none;
+}
+
+.guitar-fretboard__marker--empty {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.guitar-fretboard__marker--open,
+.guitar-fretboard__string-marker--open,
+.guitar-fretboard__open-marker {
+  border: 2px solid currentColor;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--panel) 90%, transparent);
+  color: color-mix(in srgb, var(--text) 74%, transparent);
+}
+
+.guitar-fretboard__marker--muted,
+.guitar-fretboard__string-marker--muted,
+.guitar-fretboard__muted-marker {
+  color: color-mix(in srgb, var(--muted) 88%, transparent);
+  pointer-events: none;
+}
+
+.guitar-fretboard__marker--muted::before,
+.guitar-fretboard__marker--muted::after,
+.guitar-fretboard__string-marker--muted::before,
+.guitar-fretboard__string-marker--muted::after,
+.guitar-fretboard__muted-marker::before,
+.guitar-fretboard__muted-marker::after {
+  content: "";
+  position: absolute;
+  width: 0.78rem;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.guitar-fretboard__marker--muted::before,
+.guitar-fretboard__string-marker--muted::before,
+.guitar-fretboard__muted-marker::before {
+  transform: rotate(45deg);
+}
+
+.guitar-fretboard__marker--muted::after,
+.guitar-fretboard__string-marker--muted::after,
+.guitar-fretboard__muted-marker::after {
+  transform: rotate(-45deg);
+}
+
+.guitar-fretboard__marker--selected,
+.guitar-fretboard__marker--open.guitar-fretboard__marker--selected {
+  color: var(--playback-accent);
+  box-shadow: 0 0 0 0.18rem color-mix(in srgb, var(--playback-accent) 22%, transparent);
+}
+
+.guitar-fretboard__marker:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
 }
 
 .note-inspector {
@@ -1091,7 +1416,7 @@
   }
 
   .chord-card-row {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(8rem, 1fr));
   }
 
   .chord-field-row {
@@ -1110,11 +1435,45 @@
 
   .chord-search {
     grid-template-columns: auto minmax(0, 1fr);
+    width: 100%;
   }
 
   .chord-card-row,
   .note-inspector dl {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .chord-shape-tabs {
+    min-width: 0;
+    max-width: 100%;
+    width: 100%;
+  }
+
+  .chord-shape-tab {
+    flex: 1 1 7rem;
+  }
+
+  .chord-context-chip,
+  .chord-family-card small,
+  .chord-shape-card__meta {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    white-space: normal;
+  }
+
+  .chord-shape-grid {
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 10.75rem), 1fr));
+  }
+
+  .guitar-fretboard {
+    --guitar-board-height: clamp(8.5rem, calc(var(--guitar-visible-frets) * 1.75rem), 12rem);
+
+    grid-template-columns: minmax(1.25rem, auto) minmax(0, 1fr);
+    column-gap: 0.35rem;
+  }
+
+  .guitar-fretboard__board {
+    --guitar-dot-size: 1.04rem;
   }
 
   .note-inspector,
@@ -1124,6 +1483,54 @@
 
   .lyrics-follow-stage {
     padding: 2rem 1rem;
+  }
+}
+
+@media (max-width: 560px) {
+  .chord-dictionary-actions,
+  .chord-toolbar-cluster {
+    width: 100%;
+  }
+
+  .chord-icon-button,
+  .chord-pill {
+    flex: 1 1 auto;
+  }
+
+  .chord-field-row,
+  .chord-card-row,
+  .note-inspector dl {
+    grid-template-columns: 1fr;
+  }
+
+  .chord-shape-card {
+    padding: 0.62rem;
+  }
+
+  .chord-shape-tabs {
+    box-sizing: border-box;
+    flex-wrap: nowrap;
+    min-width: 0;
+    max-width: 100%;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    padding-bottom: 0.1rem;
+  }
+
+  .chord-shape-tab {
+    flex: 0 0 auto;
+    min-width: min(8rem, 80vw);
+    max-width: 11rem;
+  }
+
+  .guitar-fretboard {
+    --guitar-string-inset: 10%;
+    --guitar-board-height: clamp(8.25rem, calc(var(--guitar-visible-frets) * 1.6rem), 11.4rem);
+  }
+
+  .guitar-fretboard__numbers,
+  .guitar-fretboard__strings {
+    font-size: 0.66rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- Closes #279
- Add standard vertical-string guitar diagrams with open, muted, fret-window, and barre rendering.
- Add truthful note hover/focus/click previews and keep the note inspector synced with previewed notes.
- Preserve open-string click behavior and add chord dictionary regression coverage.

## Testing
- `pnpm --filter @tuneforge/desktop test -- App.tools-chord-dictionary`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
- `git diff --check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- Browser probe for C3 click, E3 hover preview, hover-leave restore, and open G3 click-through.
