### PR TITLE
feat: define chord follow context

### DIFF
--- a/apps/desktop/src/App.responsive-ui.test.tsx
+++ b/apps/desktop/src/App.responsive-ui.test.tsx
@@ -32,6 +32,22 @@ describe("Desktop app responsive UI revamp", () => {
     expect(screen.getAllByRole("link", { name: "Settings" }).length).toBeGreaterThan(0);
   });
 
+  it("keeps sidebar Library navigation usable after entering Playback", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "Playback" }));
+    expect(screen.getByRole("tab", { name: "Playback" })).toHaveAttribute("aria-selected", "true");
+
+    const sidebarNav = document.querySelector(".sidebar .nav");
+    expect(sidebarNav).not.toBeNull();
+    await user.click(within(sidebarNav as HTMLElement).getByRole("link", { name: "Library" }));
+
+    expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
+    expect(document.querySelector(".app-shell")).not.toHaveClass("app-shell--compact");
+  });
+
   it("splits project work into Studio and Analysis panels", async () => {
     const user = userEvent.setup();
     renderApp(["/projects/proj_123"]);

--- a/apps/desktop/src/features/projects/chordDictionaryFollowContext.test.ts
+++ b/apps/desktop/src/features/projects/chordDictionaryFollowContext.test.ts
@@ -1,0 +1,338 @@
+import { describe, expect, it } from "vitest";
+import type { ChordSegmentSchema } from "../../lib/api";
+import type { MusicalKey } from "../../lib/music";
+import {
+  buildChordDictionaryFollowContext,
+  buildChordDictionaryFollowProjectContext,
+  type ChordDictionaryFollowProjectContext,
+} from "./chordDictionaryFollowContext";
+
+function chordSegment(
+  startSeconds: number,
+  endSeconds: number,
+  label: string,
+  overrides: Partial<ChordSegmentSchema> = {},
+): ChordSegmentSchema {
+  return {
+    confidence: 0.94,
+    end_seconds: endSeconds,
+    label,
+    pitch_class: null,
+    quality: null,
+    start_seconds: startSeconds,
+    ...overrides,
+  };
+}
+
+const SOURCE_KEY: MusicalKey = { pitchClass: 0, mode: "major" };
+const DISPLAYED_KEY: MusicalKey = { pitchClass: 2, mode: "major" };
+
+const SOURCE_TIMELINE: ChordSegmentSchema[] = [
+  chordSegment(4, 8, "C", {
+    display_label: "C",
+    pitch_class: 0,
+    quality: "major",
+    raw_label: "C:maj",
+  }),
+  chordSegment(8, 12, "G", {
+    display_label: "G",
+    pitch_class: 7,
+    quality: "major",
+    raw_label: "G:maj",
+  }),
+];
+
+const DISPLAYED_TIMELINE: ChordSegmentSchema[] = [
+  chordSegment(4, 8, "D", {
+    display_label: "C",
+    pitch_class: 2,
+    quality: "major",
+    raw_label: "C:maj",
+  }),
+  chordSegment(8, 12, "A", {
+    display_label: "G",
+    pitch_class: 9,
+    quality: "major",
+    raw_label: "G:maj",
+  }),
+];
+
+function makeProject(
+  overrides: Partial<ChordDictionaryFollowProjectContext> = {},
+): ChordDictionaryFollowProjectContext {
+  return {
+    authoritativeSourceTimeline: SOURCE_TIMELINE,
+    displayedKey: DISPLAYED_KEY,
+    displayedTimeline: DISPLAYED_TIMELINE,
+    projectId: "project_chord_dictionary_follow",
+    projectName: "Chord Dictionary Session",
+    selectedPlaybackArtifactId: "artifact_practice_mix",
+    sourceKey: SOURCE_KEY,
+    totalDisplayTransposeSemitones: 2,
+    visualCapoSemitoneShift: 5,
+    ...overrides,
+  };
+}
+
+describe("buildChordDictionaryFollowContext", () => {
+  it("returns no-project when project is null", () => {
+    const context = buildChordDictionaryFollowContext({
+      followArmed: true,
+      playbackActive: true,
+      playbackTimeSeconds: 6,
+      project: null,
+    });
+
+    expect(context).toMatchObject({
+      currentChord: null,
+      nextChord: null,
+      playbackTimeSeconds: 6,
+      project: null,
+      status: "no-project",
+    });
+  });
+
+  it("returns follow-off when project exists but follow is not armed", () => {
+    const project = makeProject();
+
+    const context = buildChordDictionaryFollowContext({
+      followArmed: false,
+      playbackActive: true,
+      playbackTimeSeconds: 6,
+      project,
+    });
+
+    expect(context).toMatchObject({
+      currentChord: null,
+      nextChord: null,
+      playbackTimeSeconds: 6,
+      project,
+      status: "follow-off",
+    });
+  });
+
+  it("returns paused when follow is armed but playback is not active", () => {
+    const project = makeProject();
+
+    const context = buildChordDictionaryFollowContext({
+      followArmed: true,
+      playbackActive: false,
+      playbackTimeSeconds: 6,
+      project,
+    });
+
+    expect(context).toMatchObject({
+      currentChord: null,
+      nextChord: null,
+      playbackTimeSeconds: 6,
+      project,
+      status: "paused",
+    });
+  });
+
+  it.each([
+    [
+      "source timeline",
+      { authoritativeSourceTimeline: [] },
+    ],
+    [
+      "displayed timeline",
+      { displayedTimeline: [] },
+    ],
+  ] satisfies Array<[string, Partial<ChordDictionaryFollowProjectContext>]>)(
+    "returns no-chord-timeline when %s is empty",
+    (_timelineName, projectOverrides) => {
+      const project = makeProject(projectOverrides);
+
+      const context = buildChordDictionaryFollowContext({
+        followArmed: true,
+        playbackActive: true,
+        playbackTimeSeconds: 6,
+        project,
+      });
+
+      expect(context).toMatchObject({
+        currentChord: null,
+        nextChord: null,
+        playbackTimeSeconds: 6,
+        project,
+        status: "no-chord-timeline",
+      });
+    },
+  );
+
+  it.each([
+    ["before the first chord", 2, 0],
+    ["after the chord range", 14, null],
+  ] satisfies Array<[string, number, number | null]>)(
+    "returns no-current-chord for playback %s",
+    (_position, playbackTimeSeconds, expectedNextIndex) => {
+      const project = makeProject();
+
+      const context = buildChordDictionaryFollowContext({
+        followArmed: true,
+        playbackActive: true,
+        playbackTimeSeconds,
+        project,
+      });
+
+      expect(context.status).toBe("no-current-chord");
+      expect(context.currentChord).toBeNull();
+      expect(context.playbackTimeSeconds).toBe(playbackTimeSeconds);
+      expect(context.project).toBe(project);
+      if (expectedNextIndex === null) {
+        expect(context.nextChord).toBeNull();
+      } else {
+        expect(context.nextChord).toMatchObject({
+          displayedSegment: DISPLAYED_TIMELINE[expectedNextIndex],
+          index: expectedNextIndex,
+          sourceSegment: SOURCE_TIMELINE[expectedNextIndex],
+        });
+      }
+    },
+  );
+
+  it("returns active with current chord and next chord during playback", () => {
+    const project = makeProject();
+
+    const context = buildChordDictionaryFollowContext({
+      followArmed: true,
+      playbackActive: true,
+      playbackTimeSeconds: 6,
+      project,
+    });
+
+    expect(context).toMatchObject({
+      playbackTimeSeconds: 6,
+      project,
+      status: "active",
+    });
+    expect(context.currentChord).toMatchObject({
+      displayedSegment: DISPLAYED_TIMELINE[0],
+      displayLabel: "D",
+      index: 0,
+      sourceLabel: "C",
+      sourceSegment: SOURCE_TIMELINE[0],
+    });
+    expect(context.nextChord).toMatchObject({
+      displayedSegment: DISPLAYED_TIMELINE[1],
+      displayLabel: "A",
+      index: 1,
+      sourceLabel: "G",
+      sourceSegment: SOURCE_TIMELINE[1],
+    });
+  });
+
+  it("uses safe explicit labels when displayed segment source labels are stale", () => {
+    const project = makeProject();
+
+    const context = buildChordDictionaryFollowContext({
+      followArmed: true,
+      playbackActive: true,
+      playbackTimeSeconds: 6,
+      project,
+    });
+
+    expect(context.currentChord?.sourceLabel).toBe("C");
+    expect(context.currentChord?.displayLabel).toBe("D");
+    expect(context.currentChord?.sourceSegment.display_label).toBe("C");
+    expect(context.currentChord?.sourceSegment.raw_label).toBe("C:maj");
+    expect(context.currentChord?.displayedSegment.label).toBe("D");
+    expect(context.currentChord?.displayedSegment.display_label).toBe("C");
+    expect(context.currentChord?.displayedSegment.raw_label).toBe("C:maj");
+  });
+
+  it("preserves playback artifact, key, transpose, and visual capo fields", () => {
+    const project = makeProject();
+
+    const context = buildChordDictionaryFollowContext({
+      followArmed: true,
+      playbackActive: true,
+      playbackTimeSeconds: 6,
+      project,
+    });
+
+    expect(context.project).toMatchObject({
+      displayedKey: DISPLAYED_KEY,
+      selectedPlaybackArtifactId: "artifact_practice_mix",
+      sourceKey: SOURCE_KEY,
+      totalDisplayTransposeSemitones: 2,
+      visualCapoSemitoneShift: 5,
+    });
+  });
+
+  it("keeps source and displayed chord timelines distinct", () => {
+    const project = makeProject();
+
+    const context = buildChordDictionaryFollowContext({
+      followArmed: true,
+      playbackActive: true,
+      playbackTimeSeconds: 6,
+      project,
+    });
+
+    expect(context.project?.authoritativeSourceTimeline).toBe(SOURCE_TIMELINE);
+    expect(context.project?.displayedTimeline).toBe(DISPLAYED_TIMELINE);
+    expect(context.currentChord?.sourceSegment).toBe(SOURCE_TIMELINE[0]);
+    expect(context.currentChord?.displayedSegment).toBe(DISPLAYED_TIMELINE[0]);
+    expect(context.currentChord?.sourceLabel).toBe("C");
+    expect(context.currentChord?.displayLabel).toBe("D");
+    expect(context.currentChord?.sourceSegment.label).toBe("C");
+    expect(context.currentChord?.displayedSegment.label).toBe("D");
+  });
+});
+
+describe("buildChordDictionaryFollowProjectContext", () => {
+  it("preserves project mapping fields and source/display timelines", () => {
+    const sourceTimeline = [
+      chordSegment(0, 4, "C", {
+        display_label: "C",
+        pitch_class: 0,
+        quality: "major",
+        raw_label: "C:maj",
+      }),
+    ];
+    const displayedTimeline = [
+      chordSegment(0, 4, "D", {
+        display_label: "C",
+        pitch_class: 2,
+        quality: "major",
+        raw_label: "C:maj",
+      }),
+    ];
+
+    const project = buildChordDictionaryFollowProjectContext({
+      authoritativeSourceTimeline: sourceTimeline,
+      displayedKey: DISPLAYED_KEY,
+      displayedTimeline,
+      projectId: "project_mapping",
+      projectName: "Project Mapping",
+      selectedPlaybackArtifactId: "artifact_practice_mix",
+      sourceKey: SOURCE_KEY,
+      totalDisplayTransposeSemitones: 2,
+      visualCapoSemitoneShift: 5,
+    });
+
+    expect(project).toMatchObject({
+      displayedKey: DISPLAYED_KEY,
+      projectId: "project_mapping",
+      projectName: "Project Mapping",
+      selectedPlaybackArtifactId: "artifact_practice_mix",
+      sourceKey: SOURCE_KEY,
+      totalDisplayTransposeSemitones: 2,
+      visualCapoSemitoneShift: 5,
+    });
+    expect(project.authoritativeSourceTimeline).toBe(sourceTimeline);
+    expect(project.displayedTimeline).toBe(displayedTimeline);
+    expect(project.authoritativeSourceTimeline[0]).toMatchObject({
+      display_label: "C",
+      label: "C",
+      raw_label: "C:maj",
+    });
+    expect(project.displayedTimeline[0]).toMatchObject({
+      display_label: "C",
+      label: "D",
+      raw_label: "C:maj",
+    });
+  });
+});

--- a/apps/desktop/src/features/projects/chordDictionaryFollowContext.ts
+++ b/apps/desktop/src/features/projects/chordDictionaryFollowContext.ts
@@ -1,0 +1,189 @@
+import type { ChordSegmentSchema } from "../../lib/api";
+import type { MusicalKey } from "../../lib/music";
+
+export type ChordDictionaryFollowStatus =
+  | "no-project"
+  | "follow-off"
+  | "paused"
+  | "no-chord-timeline"
+  | "no-current-chord"
+  | "active";
+
+export type ChordDictionaryFollowProjectContext = {
+  projectId: string;
+  projectName: string;
+  selectedPlaybackArtifactId: string | null;
+  sourceKey: MusicalKey | null;
+  displayedKey: MusicalKey | null;
+  totalDisplayTransposeSemitones: number;
+  visualCapoSemitoneShift: number;
+  authoritativeSourceTimeline: ChordSegmentSchema[];
+  displayedTimeline: ChordSegmentSchema[];
+};
+
+export type ChordDictionaryFollowChordContext = {
+  index: number;
+  sourceLabel: string;
+  displayLabel: string;
+  sourceSegment: ChordSegmentSchema;
+  displayedSegment: ChordSegmentSchema;
+};
+
+export type ChordDictionaryFollowContext = {
+  status: ChordDictionaryFollowStatus;
+  project: ChordDictionaryFollowProjectContext | null;
+  playbackTimeSeconds: number;
+  currentChord: ChordDictionaryFollowChordContext | null;
+  nextChord: ChordDictionaryFollowChordContext | null;
+};
+
+export type BuildChordDictionaryFollowContextParams = {
+  project: ChordDictionaryFollowProjectContext | null;
+  followArmed: boolean;
+  playbackActive: boolean;
+  playbackTimeSeconds: number;
+};
+
+export type BuildChordDictionaryFollowProjectContextParams = {
+  projectId: string;
+  projectName: string;
+  selectedPlaybackArtifactId: string | null;
+  sourceKey: MusicalKey | null;
+  displayedKey: MusicalKey | null;
+  totalDisplayTransposeSemitones: number;
+  visualCapoSemitoneShift: number;
+  authoritativeSourceTimeline: ChordSegmentSchema[];
+  displayedTimeline: ChordSegmentSchema[];
+};
+
+export function buildChordDictionaryFollowProjectContext({
+  projectId,
+  projectName,
+  selectedPlaybackArtifactId,
+  sourceKey,
+  displayedKey,
+  totalDisplayTransposeSemitones,
+  visualCapoSemitoneShift,
+  authoritativeSourceTimeline,
+  displayedTimeline,
+}: BuildChordDictionaryFollowProjectContextParams): ChordDictionaryFollowProjectContext {
+  return {
+    projectId,
+    projectName,
+    selectedPlaybackArtifactId,
+    sourceKey,
+    displayedKey,
+    totalDisplayTransposeSemitones,
+    visualCapoSemitoneShift,
+    authoritativeSourceTimeline,
+    displayedTimeline,
+  };
+}
+
+function chordContextAtIndex(
+  project: ChordDictionaryFollowProjectContext,
+  index: number,
+): ChordDictionaryFollowChordContext | null {
+  const sourceSegment = project.authoritativeSourceTimeline[index];
+  const displayedSegment = project.displayedTimeline[index];
+  if (!sourceSegment || !displayedSegment) {
+    return null;
+  }
+  return {
+    index,
+    sourceLabel: sourceSegment.label,
+    displayLabel: displayedSegment.label,
+    sourceSegment,
+    displayedSegment,
+  };
+}
+
+function findCurrentChordIndex(timeline: ChordSegmentSchema[], playbackTimeSeconds: number) {
+  if (!Number.isFinite(playbackTimeSeconds)) {
+    return -1;
+  }
+  return timeline.findIndex(
+    (segment) =>
+      playbackTimeSeconds >= segment.start_seconds &&
+      playbackTimeSeconds < segment.end_seconds,
+  );
+}
+
+function findNextChordIndex(timeline: ChordSegmentSchema[], playbackTimeSeconds: number) {
+  if (!Number.isFinite(playbackTimeSeconds)) {
+    return -1;
+  }
+  return timeline.findIndex((segment) => segment.start_seconds > playbackTimeSeconds);
+}
+
+export function buildChordDictionaryFollowContext({
+  project,
+  followArmed,
+  playbackActive,
+  playbackTimeSeconds,
+}: BuildChordDictionaryFollowContextParams): ChordDictionaryFollowContext {
+  const baseContext = {
+    project,
+    playbackTimeSeconds,
+    currentChord: null,
+    nextChord: null,
+  } satisfies Omit<ChordDictionaryFollowContext, "status">;
+
+  if (!project) {
+    return {
+      ...baseContext,
+      status: "no-project",
+    };
+  }
+  if (!followArmed) {
+    return {
+      ...baseContext,
+      status: "follow-off",
+    };
+  }
+  if (!playbackActive) {
+    return {
+      ...baseContext,
+      status: "paused",
+    };
+  }
+  if (
+    project.authoritativeSourceTimeline.length === 0 ||
+    project.displayedTimeline.length === 0
+  ) {
+    return {
+      ...baseContext,
+      status: "no-chord-timeline",
+    };
+  }
+
+  const currentChordIndex = findCurrentChordIndex(
+    project.authoritativeSourceTimeline,
+    playbackTimeSeconds,
+  );
+  const currentChord =
+    currentChordIndex >= 0 ? chordContextAtIndex(project, currentChordIndex) : null;
+  const nextChordIndex =
+    currentChordIndex >= 0
+      ? currentChordIndex + 1
+      : findNextChordIndex(project.authoritativeSourceTimeline, playbackTimeSeconds);
+  const nextChord = nextChordIndex >= 0 ? chordContextAtIndex(project, nextChordIndex) : null;
+
+  if (!currentChord) {
+    return {
+      project,
+      playbackTimeSeconds,
+      currentChord: null,
+      nextChord,
+      status: "no-current-chord",
+    };
+  }
+
+  return {
+    project,
+    playbackTimeSeconds,
+    currentChord,
+    nextChord,
+    status: "active",
+  };
+}

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -21,6 +21,10 @@ import {
 } from "../../../lib/timingGrid";
 import { usePlayback } from "../playback-context";
 import {
+  buildChordDictionaryFollowProjectContext,
+  type ChordDictionaryFollowProjectContext,
+} from "../chordDictionaryFollowContext";
+import {
   DEFAULT_PRECOUNT_CLICK_COUNT,
   MIN_PLAYBACK_LOOP_SECONDS,
   MAX_PRECOUNT_CLICK_COUNT,
@@ -806,7 +810,10 @@ export function useProjectViewModel() {
     () => normalizeAnalysisTimingGrid(analysisQuery.data?.timing),
     [analysisQuery.data?.timing],
   );
-  const detectedKey = parseKey(analysisQuery.data?.estimated_key);
+  const detectedKey = useMemo(
+    () => parseKey(analysisQuery.data?.estimated_key),
+    [analysisQuery.data?.estimated_key],
+  );
   const loopAlignmentMode = loopAlignmentModeOverride ?? defaultLoopAlignmentMode;
   const tempoOriginalBpm = normalizeTempoBpm(analysisQuery.data?.tempo_bpm);
   const tempoTargetBpmForPlayback = tempoOriginalBpm === null ? null : tempoTargetBpm;
@@ -821,11 +828,17 @@ export function useProjectViewModel() {
   const precountDisabledReason = canUsePrecount ? null : "Waiting for BPM analysis";
   const mobileCapabilities = mobileCapabilitiesQuery.data ?? null;
   const isMobileRuntime = mobileCapabilities !== null;
-  const sourceKeyOverride = parseStoredKey(projectQuery.data?.source_key_override);
+  const sourceKeyOverride = useMemo(
+    () => parseStoredKey(projectQuery.data?.source_key_override),
+    [projectQuery.data?.source_key_override],
+  );
   const sourceKeyBasis = sourceKeyOverride ?? detectedKey ?? null;
   const sourceKey = sourceKeyBasis ?? DEFAULT_KEY;
   const transposeSemitones = clampTargetTranspose(targetTransposeSemitones);
-  const targetKey = transposeKey(sourceKey, transposeSemitones);
+  const targetKey = useMemo(
+    () => transposeKey(sourceKey, transposeSemitones),
+    [sourceKey, transposeSemitones],
+  );
   const capoSemitones = clampTargetTranspose(capoTransposeSemitones);
   const hasTransformChange = retuneMode !== "off" || transposeSemitones !== 0;
   const isAnalysisRunning = Boolean(
@@ -922,13 +935,23 @@ export function useProjectViewModel() {
     selectedPlaybackArtifact,
     selectableArtifacts,
   );
-  const capoSourceKey = transposeKey(sourceKey, chordTransposeSemitones);
-  const capoKey = transposeKey(capoSourceKey, capoSemitones);
+  const capoSourceKey = useMemo(
+    () => transposeKey(sourceKey, chordTransposeSemitones),
+    [chordTransposeSemitones, sourceKey],
+  );
+  const capoKey = useMemo(
+    () => transposeKey(capoSourceKey, capoSemitones),
+    [capoSemitones, capoSourceKey],
+  );
   const displayedChordSemitones =
     chordTransposeSemitones + correctedSourceChordSemitones + capoSemitones;
-  const activeEnharmonicKeyContext = sourceKeyBasis
-    ? transposeKey(sourceKeyBasis, chordTransposeSemitones + capoSemitones)
-    : null;
+  const activeEnharmonicKeyContext = useMemo(
+    () =>
+      sourceKeyBasis
+        ? transposeKey(sourceKeyBasis, chordTransposeSemitones + capoSemitones)
+        : null,
+    [capoSemitones, chordTransposeSemitones, sourceKeyBasis],
+  );
   const displayedChords = useMemo(
     () =>
       (chordsQuery.data?.timeline ?? []).map((segment) =>
@@ -938,6 +961,33 @@ export function useProjectViewModel() {
         }),
       ),
     [activeEnharmonicKeyContext, chordsQuery.data?.timeline, displayedChordSemitones, enharmonicDisplayMode],
+  );
+  const chordDictionaryFollowProject = useMemo<ChordDictionaryFollowProjectContext | null>(
+    () =>
+      projectId
+        ? buildChordDictionaryFollowProjectContext({
+            projectId,
+            projectName: projectQuery.data?.display_name ?? "Project",
+            selectedPlaybackArtifactId: selectedPlaybackArtifact?.id ?? null,
+            sourceKey: sourceKeyBasis,
+            displayedKey: activeEnharmonicKeyContext,
+            totalDisplayTransposeSemitones: displayedChordSemitones,
+            visualCapoSemitoneShift: capoSemitones,
+            authoritativeSourceTimeline: chordsQuery.data?.timeline ?? [],
+            displayedTimeline: displayedChords,
+          })
+        : null,
+    [
+      activeEnharmonicKeyContext,
+      capoSemitones,
+      chordsQuery.data?.timeline,
+      displayedChordSemitones,
+      displayedChords,
+      projectId,
+      projectQuery.data?.display_name,
+      selectedPlaybackArtifact?.id,
+      sourceKeyBasis,
+    ],
   );
   const activeChordIndex = findActiveChordIndex(displayedChords, playbackTimeSeconds);
   const currentChord =
@@ -998,18 +1048,34 @@ export function useProjectViewModel() {
   const capoSelectionSummary = formatTargetSelectionSummary(capoSemitones);
   const sourceKeySelectorCurrentKey = sourceKeyOverride ?? detectedKey ?? sourceKey;
   const sourceKeySelectorCurrentBadge = sourceKeyOverride ? null : detectedKey ? "Original" : "No override";
-  const lowerTargetPreview =
-    transposeSemitones > MIN_TARGET_TRANSPOSE
-      ? transposeKey(sourceKey, transposeSemitones - 1)
-      : null;
-  const higherTargetPreview =
-    transposeSemitones < MAX_TARGET_TRANSPOSE
-      ? transposeKey(sourceKey, transposeSemitones + 1)
-      : null;
-  const lowerCapoPreview =
-    capoSemitones > MIN_TARGET_TRANSPOSE ? transposeKey(capoSourceKey, capoSemitones - 1) : null;
-  const higherCapoPreview =
-    capoSemitones < MAX_TARGET_TRANSPOSE ? transposeKey(capoSourceKey, capoSemitones + 1) : null;
+  const lowerTargetPreview = useMemo(
+    () =>
+      transposeSemitones > MIN_TARGET_TRANSPOSE
+        ? transposeKey(sourceKey, transposeSemitones - 1)
+        : null,
+    [sourceKey, transposeSemitones],
+  );
+  const higherTargetPreview = useMemo(
+    () =>
+      transposeSemitones < MAX_TARGET_TRANSPOSE
+        ? transposeKey(sourceKey, transposeSemitones + 1)
+        : null,
+    [sourceKey, transposeSemitones],
+  );
+  const lowerCapoPreview = useMemo(
+    () =>
+      capoSemitones > MIN_TARGET_TRANSPOSE
+        ? transposeKey(capoSourceKey, capoSemitones - 1)
+        : null,
+    [capoSemitones, capoSourceKey],
+  );
+  const higherCapoPreview = useMemo(
+    () =>
+      capoSemitones < MAX_TARGET_TRANSPOSE
+        ? transposeKey(capoSourceKey, capoSemitones + 1)
+        : null,
+    [capoSemitones, capoSourceKey],
+  );
   const targetShiftOptions = useMemo<TargetShiftOption[]>(
     () =>
       Array.from(
@@ -2190,9 +2256,11 @@ export function useProjectViewModel() {
       tempoTargetBpm: tempoTargetBpmForPlayback,
       timingGrid: analysisTimingGrid,
       loopRange,
+      chordDictionaryFollowProject,
     });
   }, [
     analysisTimingGrid,
+    chordDictionaryFollowProject,
     hydratedProjectId,
     isStemPlayback,
     projectId,

--- a/apps/desktop/src/features/projects/playback-context.ts
+++ b/apps/desktop/src/features/projects/playback-context.ts
@@ -1,5 +1,6 @@
 import { createContext, useContext } from "react";
 import type { AnalysisTimingGrid } from "../../lib/timingGrid";
+import type { ChordDictionaryFollowProjectContext } from "./chordDictionaryFollowContext";
 import type { PlaybackLoopRange, StemControlState } from "./projectPlaybackState";
 
 export type ProjectPlaybackSession = {
@@ -23,6 +24,7 @@ export type ProjectPlaybackSession = {
   tempoTargetBpm: number | null;
   timingGrid: AnalysisTimingGrid | null;
   loopRange: PlaybackLoopRange | null;
+  chordDictionaryFollowProject: ChordDictionaryFollowProjectContext | null;
 };
 
 export type PlaybackSnapshot = {

--- a/apps/desktop/src/features/projects/playback.test.tsx
+++ b/apps/desktop/src/features/projects/playback.test.tsx
@@ -40,6 +40,7 @@ function makePlaybackSession(
     tempoTargetBpm: null,
     timingGrid: null,
     loopRange: null,
+    chordDictionaryFollowProject: null,
   };
 }
 


### PR DESCRIPTION
## Summary
- Add a typed Chord Dictionary follow context for project playback state.
- Carry source/display chord timelines, labels, keys, transpose, visual capo, and selected artifact metadata without wiring live UI behavior.
- Fix playback-route session churn so sidebar navigation stays usable after entering Playback.

Closes #264

## Testing
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `cd apps/desktop && ./node_modules/.bin/vitest run src/App.responsive-ui.test.tsx`
- `cd apps/desktop && ./node_modules/.bin/vitest run src/features/projects/chordDictionaryFollowContext.test.ts src/features/projects/playback.test.tsx`
- `cd apps/desktop && ./node_modules/.bin/vitest run`
- `./node_modules/.bin/commitlint --config commitlint.config.cjs --edit "$(git rev-parse --git-path COMMIT_EDITMSG)"`