### PR TITLE
feat: integrate chord live follow

### DIFF
--- a/apps/desktop/src/App.tools-chord-dictionary-entrypoint.test.tsx
+++ b/apps/desktop/src/App.tools-chord-dictionary-entrypoint.test.tsx
@@ -1,0 +1,120 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  renderApp,
+  resetAppTestHarness,
+  setProjectChords,
+} from "./test/appTestHarness";
+
+describe("Desktop app chord dictionary project entrypoint", () => {
+  beforeEach(resetAppTestHarness);
+
+  it("opens Chord Dictionary from project analysis with playback follow params", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "Analysis" }));
+
+    const dictionaryLink = await screen.findByRole("link", {
+      name: "Follow chords in Chord Dictionary",
+    });
+    expect(dictionaryLink).toHaveAttribute(
+      "href",
+      "/tools?tool=chord-dictionary&followPlayback=1&projectId=proj_123",
+    );
+
+    await user.click(dictionaryLink);
+
+    expect(await screen.findByRole("heading", { name: "Chord Dictionary" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Chord Dictionary" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("does not show the project entrypoint without a chord timeline", async () => {
+    const user = userEvent.setup();
+    setProjectChords("proj_123", {
+      project_id: "proj_123",
+      backend: "default",
+      source_artifact_id: "art_source",
+      source_segments: [],
+      has_user_edits: false,
+      created_at: "2026-04-18T13:16:00.000Z",
+      updated_at: "2026-04-18T13:16:00.000Z",
+      timeline: [],
+    });
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "Analysis" }));
+
+    expect(
+      screen.queryByRole("link", { name: "Follow chords in Chord Dictionary" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("arms Live Follow from query params without active project playback", async () => {
+    renderApp(["/tools?tool=chord-dictionary&followPlayback=1&projectId=proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Chord Dictionary" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Chord Dictionary" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Dictionary" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(screen.getByRole("button", { name: "Live Follow" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByText("No matching project playback")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Live Follow is armed from a project, but no matching playback session is active.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/proj_123/)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Current chord")).not.toBeInTheDocument();
+  });
+
+  it("lets route-armed Live Follow return to Dictionary without rearming on tool remount", async () => {
+    const user = userEvent.setup();
+    renderApp(["/tools?tool=chord-dictionary&followPlayback=1&projectId=proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Chord Dictionary" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Live Follow" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Dictionary" }));
+
+    expect(screen.getByRole("button", { name: "Dictionary" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByLabelText("Chord search")).toHaveValue("C");
+    expect(screen.queryByText("No matching project playback")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Metronome" }));
+    expect(await screen.findByRole("heading", { name: "Metronome" })).toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "Chord Dictionary" }));
+
+    expect(await screen.findByRole("heading", { name: "Chord Dictionary" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Dictionary" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Live Follow" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(screen.getByLabelText("Chord search")).toHaveValue("C");
+    expect(screen.queryByText("No matching project playback")).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/App.tools-chord-dictionary.test.tsx
+++ b/apps/desktop/src/App.tools-chord-dictionary.test.tsx
@@ -1,11 +1,196 @@
-import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChordSegmentSchema } from "./lib/api";
 import { renderApp, resetAppTestHarness } from "./test/appTestHarness";
+import { ChordDictionaryPage } from "./features/tools/ChordDictionaryPage";
+import { ChordDictionaryFollowArmProvider } from "./features/tools/chordDictionaryFollowArm";
+import {
+  buildChordDictionaryFollowProjectContext,
+  type ChordDictionaryFollowProjectContext,
+} from "./features/projects/chordDictionaryFollowContext";
+import {
+  PlaybackContext,
+  type PlaybackContextValue,
+  type ProjectPlaybackSession,
+} from "./features/projects/playback-context";
 
 function renderChordDictionary() {
   renderApp(["/tools?tool=chord-dictionary"]);
   return screen.findByRole("heading", { name: "Chord Dictionary" });
+}
+
+const sourceTimeline: ChordSegmentSchema[] = [
+  {
+    confidence: 0.81,
+    end_seconds: 16,
+    label: "G",
+    pitch_class: 7,
+    quality: "major",
+    start_seconds: 0,
+  },
+  {
+    confidence: 0.79,
+    end_seconds: 32,
+    label: "D",
+    pitch_class: 2,
+    quality: "major",
+    start_seconds: 16,
+  },
+  {
+    confidence: 0.74,
+    end_seconds: 48,
+    label: "Em",
+    pitch_class: 4,
+    quality: "minor",
+    start_seconds: 32,
+  },
+];
+
+const displayedTimeline: ChordSegmentSchema[] = [
+  {
+    confidence: 0.81,
+    end_seconds: 16,
+    label: "A",
+    pitch_class: 9,
+    quality: "major",
+    start_seconds: 0,
+  },
+  {
+    confidence: 0.79,
+    end_seconds: 32,
+    label: "E",
+    pitch_class: 4,
+    quality: "major",
+    start_seconds: 16,
+  },
+  {
+    confidence: 0.74,
+    end_seconds: 48,
+    label: "F#m",
+    pitch_class: 6,
+    quality: "minor",
+    start_seconds: 32,
+  },
+];
+
+function makeFollowProject(
+  overrides: Partial<ChordDictionaryFollowProjectContext> = {},
+): ChordDictionaryFollowProjectContext {
+  return buildChordDictionaryFollowProjectContext({
+    authoritativeSourceTimeline: sourceTimeline,
+    displayedKey: { pitchClass: 9, mode: "major" },
+    displayedTimeline,
+    projectId: "proj_123",
+    projectName: "Demo Song",
+    selectedPlaybackArtifactId: "art_source",
+    sourceKey: { pitchClass: 7, mode: "major" },
+    totalDisplayTransposeSemitones: 2,
+    visualCapoSemitoneShift: 0,
+    ...overrides,
+  });
+}
+
+function makePlaybackSession(
+  project: ChordDictionaryFollowProjectContext,
+): ProjectPlaybackSession {
+  return {
+    artifactFormatsById: { art_source: "wav" },
+    artifactPathsById: { art_source: "/tmp/demo.wav" },
+    chordDictionaryFollowProject: project,
+    durationHintSeconds: 96,
+    isStemPlayback: false,
+    loopRange: null,
+    playbackArtifactIds: ["art_source"],
+    precountClickCount: 4,
+    precountEnabled: false,
+    precountLoopEnabled: false,
+    precountTempoBpm: null,
+    projectId: project.projectId,
+    projectName: project.projectName,
+    selectedPlaybackArtifactId: "art_source",
+    stageSummary: "Source mix",
+    stageTitle: "Source audio",
+    stemControls: {},
+    tempoOriginalBpm: null,
+    tempoTargetBpm: null,
+    timingGrid: null,
+    visibleStemArtifactIds: [],
+  };
+}
+
+function makePlaybackValue({
+  isPlaying = true,
+  playbackTimeSeconds = 6,
+  project = makeFollowProject(),
+}: {
+  isPlaying?: boolean;
+  playbackTimeSeconds?: number;
+  project?: ChordDictionaryFollowProjectContext | null;
+} = {}): PlaybackContextValue {
+  const session = project ? makePlaybackSession(project) : null;
+  return {
+    activateStemPlayback: vi.fn(async () => undefined),
+    dismissSession: vi.fn(),
+    getPlaybackSnapshot: () => ({
+      isPlaying,
+      isPrecounting: false,
+      playbackDurationSeconds: 96,
+      playbackTimeSeconds,
+      session,
+    }),
+    isPlaying,
+    isPrecounting: false,
+    pausePlayback: vi.fn(),
+    playPlayback: vi.fn(async () => undefined),
+    playbackDurationSeconds: 96,
+    playbackTimeSeconds,
+    primeWebAudioForGesture: vi.fn(async () => undefined),
+    registerProjectSession: vi.fn(),
+    seekBy: vi.fn(),
+    seekTo: vi.fn(),
+    session,
+    stopPlayback: vi.fn(),
+    togglePlayback: vi.fn(async () => undefined),
+  };
+}
+
+function renderChordDictionaryWithPlayback({
+  entry = "/tools?tool=chord-dictionary&followPlayback=1&projectId=proj_123",
+  playback = makePlaybackValue(),
+}: {
+  entry?: string;
+  playback?: PlaybackContextValue;
+} = {}) {
+  const view = renderChordDictionaryPlaybackHarness({ entry, playback });
+  return view.findHeading();
+}
+
+function renderChordDictionaryPlaybackHarness({
+  entry = "/tools?tool=chord-dictionary&followPlayback=1&projectId=proj_123",
+  playback = makePlaybackValue(),
+}: {
+  entry?: string;
+  playback?: PlaybackContextValue;
+} = {}) {
+  const renderTree = (playbackValue: PlaybackContextValue) => (
+    <MemoryRouter initialEntries={[entry]}>
+      <PlaybackContext.Provider value={playbackValue}>
+        <ChordDictionaryFollowArmProvider>
+          <ChordDictionaryPage />
+        </ChordDictionaryFollowArmProvider>
+      </PlaybackContext.Provider>
+    </MemoryRouter>
+  );
+
+  const view = render(renderTree(playback));
+  return {
+    findHeading: () => screen.findByRole("heading", { name: "Chord Dictionary" }),
+    rerenderWithPlayback: (nextPlayback: PlaybackContextValue) => {
+      view.rerender(renderTree(nextPlayback));
+    },
+  };
 }
 
 function getToolsScreen() {
@@ -496,6 +681,145 @@ describe("Desktop app tools chord dictionary", () => {
     expect(shapeButtons[1]).toHaveAttribute("aria-pressed", "true");
   });
 
+  it("opens live follow from query params and renders the active project chord", async () => {
+    await renderChordDictionaryWithPlayback();
+
+    const viewToggle = screen.getByRole("group", { name: "Chord dictionary views" });
+    expect(within(viewToggle).getByRole("button", { name: "Dictionary" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(within(viewToggle).getByRole("button", { name: "Live Follow" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    const liveStatus = screen.getByRole("group", { name: "Live chord display status" });
+    expect(within(liveStatus).getByText("Live")).toBeInTheDocument();
+    expect(within(liveStatus).getByText("Demo Song")).toBeInTheDocument();
+
+    const currentChord = screen.getByLabelText("Current chord");
+    expect(within(currentChord).getByRole("heading", { name: "A" })).toBeInTheDocument();
+    expect(currentChord).toHaveTextContent(/Source chord\s*G/);
+    expect(currentChord).toHaveTextContent(/Display chord\s*A/);
+    expect(currentChord).toHaveTextContent(/Detected\/imported project chords/);
+    expect(currentChord).toHaveTextContent(/Playback source\s*Demo Song/);
+    expect(currentChord).not.toHaveTextContent("art_source");
+
+    expect(screen.getByRole("heading", { name: "A guitar shapes" })).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "A open" }).length).toBeGreaterThan(0);
+    expect(screen.getByLabelText("Next chord")).toHaveTextContent(/E/);
+    expectInspectorToShow([/A2/, /String\s*5/, /Fret\s*0/, /Degree\s*1/]);
+    expect(screen.queryByRole("heading", { name: "C guitar shapes" })).not.toBeInTheDocument();
+  });
+
+  it("uses an honest generic playback source label without a project display name", async () => {
+    await renderChordDictionaryWithPlayback({
+      playback: makePlaybackValue({
+        project: makeFollowProject({ projectName: " " }),
+      }),
+    });
+
+    const liveStatus = screen.getByRole("group", { name: "Live chord display status" });
+    expect(within(liveStatus).getByText("Project playback")).toBeInTheDocument();
+
+    const currentChord = screen.getByLabelText("Current chord");
+    expect(currentChord).toHaveTextContent(/Playback source\s*Project playback/);
+    expect(currentChord).not.toHaveTextContent("art_source");
+  });
+
+  it("arms live follow from the Chord Dictionary page and follows future playback sessions", async () => {
+    const user = userEvent.setup();
+    const view = renderChordDictionaryPlaybackHarness({
+      entry: "/tools?tool=chord-dictionary",
+      playback: makePlaybackValue({ project: null }),
+    });
+
+    await view.findHeading();
+    await user.click(screen.getByRole("button", { name: "Live Follow" }));
+
+    const viewToggle = screen.getByRole("group", { name: "Chord dictionary views" });
+    expect(within(viewToggle).getByRole("button", { name: "Dictionary" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(within(viewToggle).getByRole("button", { name: "Live Follow" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByText("No matching project playback")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Current chord")).not.toBeInTheDocument();
+
+    view.rerenderWithPlayback(makePlaybackValue({ playbackTimeSeconds: 6 }));
+
+    expect(await screen.findByLabelText("Current chord")).toHaveTextContent(/Display chord\s*A/);
+    expect(screen.getByRole("heading", { name: "A guitar shapes" })).toBeInTheDocument();
+
+    view.rerenderWithPlayback(
+      makePlaybackValue({ isPlaying: false, playbackTimeSeconds: 6 }),
+    );
+
+    expect(screen.getByText("Playback paused")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Current chord")).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "C guitar shapes" })).toBeInTheDocument();
+
+    view.rerenderWithPlayback(makePlaybackValue({ project: null }));
+
+    expect(screen.getByText("No matching project playback")).toBeInTheDocument();
+    expect(within(viewToggle).getByRole("button", { name: "Live Follow" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    view.rerenderWithPlayback(makePlaybackValue({ playbackTimeSeconds: 20 }));
+
+    expect(await screen.findByLabelText("Current chord")).toHaveTextContent(/Display chord\s*E/);
+    expect(screen.getByRole("heading", { name: "E guitar shapes" })).toBeInTheDocument();
+  });
+
+  it("does not show a stale current chord when followed playback is paused", async () => {
+    await renderChordDictionaryWithPlayback({
+      playback: makePlaybackValue({ isPlaying: false }),
+    });
+
+    const liveStatus = screen.getByRole("group", { name: "Live chord display status" });
+    expect(within(liveStatus).getByText("Paused")).toBeInTheDocument();
+    expect(screen.getByText("Playback paused")).toBeInTheDocument();
+    expect(screen.getByText(/No stale live chord is shown/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText("Current chord")).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "A guitar shapes" })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "C guitar shapes" })).toBeInTheDocument();
+    expectInspectorToShow([/C3/, /Degree\s*1/]);
+  });
+
+  it("keeps unsupported followed chords honest without guitar voicings", async () => {
+    const unsupportedTimeline: ChordSegmentSchema[] = [
+      {
+        confidence: 0.62,
+        end_seconds: 16,
+        label: "H13",
+        pitch_class: null,
+        quality: null,
+        start_seconds: 0,
+      },
+    ];
+    await renderChordDictionaryWithPlayback({
+      playback: makePlaybackValue({
+        project: makeFollowProject({
+          authoritativeSourceTimeline: unsupportedTimeline,
+          displayedTimeline: unsupportedTimeline,
+        }),
+      }),
+    });
+
+    const liveStatus = screen.getByRole("group", { name: "Live chord display status" });
+    expect(within(liveStatus).getByText("Unsupported")).toBeInTheDocument();
+    expect(screen.getByText("Unsupported chord: H13")).toBeInTheDocument();
+    expect(screen.getByText(/cannot be parsed by the chord dictionary/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText("Current guitar voicing")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Note inspector")).not.toBeInTheDocument();
+  });
+
   it("shows live follow as an honest waiting state without fake progression previews", async () => {
     const user = userEvent.setup();
     await renderChordDictionary();
@@ -514,9 +838,9 @@ describe("Desktop app tools chord dictionary", () => {
     const toolsScreen = within(getToolsScreen());
     const liveStatus = toolsScreen.getByRole("group", { name: "Live chord display status" });
     expect(within(liveStatus).getByText("Guitar")).toBeInTheDocument();
-    expect(within(liveStatus).getByText("Waiting")).toBeInTheDocument();
+    expect(within(liveStatus).getByText("No Project")).toBeInTheDocument();
     expect(within(liveStatus).queryByRole("button", { name: "Guitar" })).not.toBeInTheDocument();
-    expect(within(liveStatus).queryByRole("button", { name: "Waiting" })).not.toBeInTheDocument();
+    expect(within(liveStatus).queryByRole("button", { name: "No Project" })).not.toBeInTheDocument();
     expect(
       toolsScreen.getAllByText(
         /waiting|unavailable|inactive|no project|select a project|open a project/i,

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -8,6 +8,7 @@ import { usePlayback } from "./features/projects/playback-context";
 import { PlaybackProvider } from "./features/projects/playback";
 import { SettingsView } from "./features/settings/SettingsView";
 import { ThemeStudioView } from "./features/settings/ThemeStudioView";
+import { ChordDictionaryFollowArmProvider } from "./features/tools/chordDictionaryFollowArm";
 import { MetronomeProvider } from "./features/tools/metronome";
 import { ToolsView } from "./features/tools/ToolsView";
 import { PreferencesProvider } from "./lib/preferences";
@@ -233,7 +234,9 @@ export default function App() {
       <PreferencesProvider>
         <PlaybackProvider>
           <MetronomeProvider>
-            <AppChrome />
+            <ChordDictionaryFollowArmProvider>
+              <AppChrome />
+            </ChordDictionaryFollowArmProvider>
           </MetronomeProvider>
         </PlaybackProvider>
       </PreferencesProvider>

--- a/apps/desktop/src/features/projects/components/InspectorPanel.tsx
+++ b/apps/desktop/src/features/projects/components/InspectorPanel.tsx
@@ -22,6 +22,7 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
     handleDeleteAllStems,
     handleDeleteProject,
     handleDeleteSelectedPrimaryStems,
+    hasChordTimeline,
     hasTransformChange,
     higherTargetPreview,
     higherTargetShiftOptions,
@@ -37,6 +38,7 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
     projectSyncLockReason,
     referenceHz,
     retuneMode,
+    selectedPlaybackArtifact,
     selectedPrimaryStemArtifacts,
     selectedPrimaryStemDeleteLabel,
     setCentsOffset,
@@ -70,6 +72,9 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
   const editLockTitle = projectSyncLockReason ?? undefined;
   const tempoBpm = analysisQuery.data?.tempo_bpm;
   const canOpenMetronome = typeof tempoBpm === "number" && Number.isFinite(tempoBpm);
+  const canOpenChordDictionary = Boolean(
+    projectQuery.data?.id && selectedPlaybackArtifact && hasChordTimeline,
+  );
   const estimatedReferenceHz = analysisQuery.data?.estimated_reference_hz;
   const hasEstimatedReferenceHz =
     typeof estimatedReferenceHz === "number" && Number.isFinite(estimatedReferenceHz);
@@ -88,6 +93,12 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
     if (projectQuery.data?.id) {
       metronomeSearchParams.set("projectId", projectQuery.data.id);
     }
+  }
+  const chordDictionarySearchParams = new URLSearchParams();
+  if (canOpenChordDictionary && projectQuery.data?.id) {
+    chordDictionarySearchParams.set("tool", "chord-dictionary");
+    chordDictionarySearchParams.set("followPlayback", "1");
+    chordDictionarySearchParams.set("projectId", projectQuery.data.id);
   }
 
   return (
@@ -331,16 +342,27 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
             </strong>
           </div>
         </div>
-        {canOpenMetronome ? (
+        {canOpenMetronome || canOpenChordDictionary ? (
           <div className="analysis-action-row">
-            <Link
-              aria-label={`Follow on metronome at ${tempoBpm.toFixed(1)} BPM`}
-              className="button button--small analysis-stat__action"
-              onClick={() => void launchMetronome({ bpm: tempoBpm, followPlayback: true })}
-              to={`/tools?${metronomeSearchParams.toString()}`}
-            >
-              Follow on Metronome
-            </Link>
+            {canOpenMetronome ? (
+              <Link
+                aria-label={`Follow on metronome at ${tempoBpm.toFixed(1)} BPM`}
+                className="button button--small analysis-stat__action"
+                onClick={() => void launchMetronome({ bpm: tempoBpm, followPlayback: true })}
+                to={`/tools?${metronomeSearchParams.toString()}`}
+              >
+                Follow on Metronome
+              </Link>
+            ) : null}
+            {canOpenChordDictionary ? (
+              <Link
+                aria-label="Follow chords in Chord Dictionary"
+                className="button button--small analysis-stat__action"
+                to={`/tools?${chordDictionarySearchParams.toString()}`}
+              >
+                Chord Dictionary
+              </Link>
+            ) : null}
           </div>
         ) : null}
         <details className="details-block details-block--inset">

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -95,6 +95,7 @@ const TERMINAL_PROJECT_JOB_STATUSES = ["completed", "failed", "cancelled"] as co
 const ACTIVE_PROJECT_JOBS_LIMIT = 200;
 const PROJECT_HISTORY_JOBS_PAGE_SIZE = 50;
 const EMPTY_JOBS: JobSchema[] = [];
+const PROJECT_PLAYBACK_FALLBACK_NAME = "Project playback";
 
 type DeleteArtifactsRequest = {
   artifactIds: string[];
@@ -326,6 +327,8 @@ export function useProjectViewModel() {
     queryFn: async () => (await api.getProject(projectId)).project,
     enabled: Boolean(projectId),
   });
+  const projectPlaybackName =
+    projectQuery.data?.display_name?.trim() || PROJECT_PLAYBACK_FALLBACK_NAME;
   const analysisQuery = useQuery({
     queryKey: ["analysis", projectId],
     queryFn: async () => (await api.getAnalysis(projectId)).analysis,
@@ -967,7 +970,7 @@ export function useProjectViewModel() {
       projectId
         ? buildChordDictionaryFollowProjectContext({
             projectId,
-            projectName: projectQuery.data?.display_name ?? "Project",
+            projectName: projectPlaybackName,
             selectedPlaybackArtifactId: selectedPlaybackArtifact?.id ?? null,
             sourceKey: sourceKeyBasis,
             displayedKey: activeEnharmonicKeyContext,
@@ -984,7 +987,7 @@ export function useProjectViewModel() {
       displayedChordSemitones,
       displayedChords,
       projectId,
-      projectQuery.data?.display_name,
+      projectPlaybackName,
       selectedPlaybackArtifact?.id,
       sourceKeyBasis,
     ],
@@ -2233,7 +2236,7 @@ export function useProjectViewModel() {
 
     registerProjectSession({
       projectId,
-      projectName: projectQuery.data?.display_name ?? "Project",
+      projectName: projectPlaybackName,
       stageTitle,
       stageSummary,
       selectedPlaybackArtifactId: selectedPlaybackArtifact.id,
@@ -2264,8 +2267,8 @@ export function useProjectViewModel() {
     hydratedProjectId,
     isStemPlayback,
     projectId,
-    projectQuery.data?.display_name,
     projectQuery.data?.duration_seconds,
+    projectPlaybackName,
     precountClickCount,
     precountEnabled,
     precountLoopEnabled,

--- a/apps/desktop/src/features/tools/ChordDictionaryPage.tsx
+++ b/apps/desktop/src/features/tools/ChordDictionaryPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import { useSearchParams } from "react-router-dom";
 import {
   ArrowUpDown,
   AudioLines,
@@ -16,7 +17,15 @@ import {
   spellChord,
   type ChordDisplayContext,
   type GuitarVoicing,
+  type MusicalKey,
 } from "../../lib/music";
+import {
+  buildChordDictionaryFollowContext,
+  type ChordDictionaryFollowContext,
+  type ChordDictionaryFollowStatus,
+} from "../projects/chordDictionaryFollowContext";
+import { usePlayback } from "../projects/playback-context";
+import { useChordDictionaryFollowArm } from "./chordDictionaryFollowArm-context";
 
 type ChordDictionarySurface = "dictionary" | "follow";
 type NotePoint = {
@@ -93,7 +102,40 @@ function classNames(...values: Array<string | false | null | undefined>) {
 }
 
 export function ChordDictionaryPage() {
-  const [surface, setSurface] = useState<ChordDictionarySurface>("dictionary");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const routeFollowPlayback = searchParams.get("followPlayback") === "1";
+  const routeProjectId = searchParams.get("projectId");
+  const { manualFollowArmed, setManualFollowArmed } = useChordDictionaryFollowArm();
+  const { isPlaying, playbackTimeSeconds, session } = usePlayback();
+  const followArmed = routeFollowPlayback || manualFollowArmed;
+  const followProject = useMemo(() => {
+    if (!session) {
+      return null;
+    }
+    if (routeProjectId && session.projectId !== routeProjectId) {
+      return null;
+    }
+    return session.chordDictionaryFollowProject;
+  }, [routeProjectId, session]);
+  const followContext = useMemo(
+    () =>
+      buildChordDictionaryFollowContext({
+        followArmed,
+        playbackActive: isPlaying && Boolean(followProject),
+        playbackTimeSeconds,
+        project: followProject,
+      }),
+    [followArmed, followProject, isPlaying, playbackTimeSeconds],
+  );
+  const [surface, setSurface] = useState<ChordDictionarySurface>(() =>
+    followArmed ? "follow" : "dictionary",
+  );
+
+  useEffect(() => {
+    if (routeFollowPlayback) {
+      setSurface("follow");
+    }
+  }, [routeFollowPlayback, routeProjectId]);
 
   return (
     <div className="chord-dictionary-shell">
@@ -110,7 +152,17 @@ export function ChordDictionaryPage() {
                 "chord-icon-button",
                 surface === "dictionary" && "chord-icon-button--active",
               )}
-              onClick={() => setSurface("dictionary")}
+              onClick={() => {
+                setManualFollowArmed(false);
+                setSurface("dictionary");
+                if (routeFollowPlayback || routeProjectId) {
+                  const nextSearchParams = new URLSearchParams(searchParams);
+                  nextSearchParams.set("tool", "chord-dictionary");
+                  nextSearchParams.delete("followPlayback");
+                  nextSearchParams.delete("projectId");
+                  setSearchParams(nextSearchParams);
+                }
+              }}
               title="Dictionary"
               type="button"
             >
@@ -123,7 +175,10 @@ export function ChordDictionaryPage() {
                 "chord-icon-button",
                 surface === "follow" && "chord-icon-button--active",
               )}
-              onClick={() => setSurface("follow")}
+              onClick={() => {
+                setManualFollowArmed(true);
+                setSurface("follow");
+              }}
               title="Live follow"
               type="button"
             >
@@ -133,7 +188,11 @@ export function ChordDictionaryPage() {
           </div>
         </div>
 
-        {surface === "dictionary" ? <DictionarySurface /> : <LiveFollowSurface />}
+        {surface === "dictionary" ? (
+          <DictionarySurface />
+        ) : (
+          <LiveFollowSurface context={followContext} requestedProjectId={routeProjectId} />
+        )}
       </div>
     </div>
   );
@@ -936,33 +995,415 @@ function NoteInspector({ capoFret, note }: { capoFret: number; note: NotePoint }
   );
 }
 
-function LiveFollowSurface() {
+function LiveFollowSurface({
+  context,
+  requestedProjectId,
+}: {
+  context: ChordDictionaryFollowContext;
+  requestedProjectId: string | null;
+}) {
+  if (context.status !== "active") {
+    const showDictionaryFallback = context.status === "paused" || context.status === "follow-off";
+    return (
+      <div
+        className="live-follow-page live-follow-page--waiting"
+        data-follow-status={context.status}
+      >
+        <LiveFollowTopbar context={context} statusLabel={formatFollowStatusLabel(context.status)} />
+        <LiveFollowStatusCard context={context} requestedProjectId={requestedProjectId} />
+        {showDictionaryFallback ? <DictionarySurface /> : null}
+      </div>
+    );
+  }
+
+  return <LiveFollowActiveState context={context} />;
+}
+
+function LiveFollowActiveState({ context }: { context: ChordDictionaryFollowContext }) {
+  const currentChord = context.currentChord;
+  const project = context.project;
+  const [activeShape, setActiveShape] = useState<string | null>(null);
+  const [previewNoteId, setPreviewNoteId] = useState<string | null>(null);
+  const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
+  const displayContext = useMemo<Partial<ChordDisplayContext>>(
+    () => ({
+      canCapo: GUITAR_STANDARD_PROFILE.canCapo,
+      capoFret: Math.max(0, Math.trunc(project?.visualCapoSemitoneShift ?? 0)),
+      sourceKey: project?.displayedKey ?? null,
+      transposeSemitones: 0,
+      useCapoShapes: (project?.visualCapoSemitoneShift ?? 0) > 0,
+    }),
+    [project?.displayedKey, project?.visualCapoSemitoneShift],
+  );
+  const chordSpelling = useMemo(
+    () =>
+      currentChord
+        ? spellChord(currentChord.displayLabel, {
+            activeKey: project?.displayedKey ?? undefined,
+          })
+        : null,
+    [currentChord, project?.displayedKey],
+  );
+  const guitarVoicings = useMemo(
+    () =>
+      chordSpelling
+        ? generateGuitarVoicings(
+            chordSpelling,
+            GUITAR_STANDARD_PROFILE,
+            displayContext,
+            project?.displayedKey ? { activeKey: project.displayedKey } : {},
+          )
+        : [],
+    [chordSpelling, displayContext, project?.displayedKey],
+  );
+  const guitarShapes = useMemo(
+    () => guitarVoicings.map((voicing) => toGuitarShape(voicing, GUITAR_STANDARD_PROFILE)),
+    [guitarVoicings],
+  );
+  const resultKey = guitarShapes.map((shape) => shape.id).join("|");
+  const firstShapeId = guitarShapes[0]?.id ?? null;
+  const firstNoteId = guitarShapes[0]?.notes[0]?.id ?? null;
+
+  useEffect(() => {
+    setActiveShape(firstShapeId);
+    setPreviewNoteId(null);
+    setSelectedNoteId(firstNoteId);
+  }, [currentChord?.displayLabel, firstNoteId, firstShapeId, resultKey]);
+
+  if (!currentChord || !project) {
+    return (
+      <div className="live-follow-page live-follow-page--waiting" data-follow-status="no-project">
+        <LiveFollowTopbar context={context} statusLabel="No Project" />
+        <LiveFollowStatusCard context={context} requestedProjectId={null} />
+      </div>
+    );
+  }
+
+  const playbackSourceLabel = formatPlaybackProjectLabel(project.projectName);
+
+  if (!chordSpelling) {
+    return (
+      <LiveFollowChordIssue
+        context={context}
+        copy="The project timeline chord cannot be parsed by the chord dictionary, so no guitar voicing or note inspector is shown."
+        statusLabel="Unsupported"
+        title={`Unsupported chord: ${currentChord.displayLabel}`}
+      />
+    );
+  }
+
+  if (guitarShapes.length === 0) {
+    return (
+      <LiveFollowChordIssue
+        context={context}
+        copy="Chord spelling is supported, but the standard guitar model returned no voicings for this chord."
+        statusLabel="No Voicing"
+        title={`No guitar voicing for ${chordSpelling.label}`}
+      />
+    );
+  }
+
+  const selectedShape = guitarShapes.find((shape) => shape.id === activeShape) ?? guitarShapes[0] ?? null;
+  const selectedNote =
+    selectedShape?.notes.find((note) => note.id === selectedNoteId) ?? selectedShape?.notes[0] ?? null;
+  const previewNote = previewNoteId
+    ? guitarShapes.flatMap((shape) => shape.notes).find((note) => note.id === previewNoteId) ?? null
+    : null;
+  const displayedNote = previewNote ?? selectedNote;
+  const activeTooltipNoteId = previewNote?.id ?? selectedNote?.id ?? null;
+  const selectedVoicing = guitarVoicings.find((voicing) => voicing.id === selectedShape?.id) ?? null;
+  const capoFret = displayContext.capoFret ?? 0;
+
   return (
-    <div className="live-follow-page live-follow-page--waiting">
-      <div className="live-follow-topbar">
-        <div className="live-follow-controls" role="group" aria-label="Live chord display status">
-          <span className="chord-pill chord-pill--active">
-            <Music2 aria-hidden="true" />
-            <span>{GUITAR_STANDARD_PROFILE.label}</span>
-          </span>
-          <span className="chord-pill chord-pill--muted">
-            <AudioLines aria-hidden="true" />
-            <span>Waiting</span>
-          </span>
-        </div>
+    <div className="live-follow-page live-follow-page--active" data-follow-status="active">
+      <LiveFollowTopbar context={context} statusLabel="Live" />
+
+      <div className="chord-context-strip" aria-label="Live follow display context">
+        <ContextChip icon="instrument" label={GUITAR_STANDARD_PROFILE.label} />
+        <ContextChip icon="key" label={`Source ${formatOptionalKey(project.sourceKey)}`} />
+        <ContextChip icon="key" label={`Display ${formatOptionalKey(project.displayedKey)}`} />
+        <ContextChip
+          icon="transpose"
+          label={formatSemitoneContext(project.totalDisplayTransposeSemitones)}
+        />
+        <ContextChip icon="capo" label={capoFret > 0 ? `Capo ${capoFret}` : "No capo"} />
+        <ContextChip icon="sound" label={chordSpelling.label} />
+        {selectedVoicing?.shapeFamily ? (
+          <ContextChip icon="shape" label={`${selectedVoicing.shapeFamily} shape`} />
+        ) : null}
       </div>
 
+      <div className="live-follow-grid">
+        <main className="live-follow-main">
+          <section className="live-current-chord" aria-label="Current chord">
+            <p className="metric-label">Current chord</p>
+            <h3>{currentChord.displayLabel}</h3>
+            <dl className="live-follow-provenance">
+              <div>
+                <dt>Source chord</dt>
+                <dd>{currentChord.sourceLabel}</dd>
+              </div>
+              <div>
+                <dt>Display chord</dt>
+                <dd>{currentChord.displayLabel}</dd>
+              </div>
+              <div>
+                <dt>Segment</dt>
+                <dd>
+                  {formatFollowTime(currentChord.sourceSegment.start_seconds)} -{" "}
+                  {formatFollowTime(currentChord.sourceSegment.end_seconds)}
+                </dd>
+              </div>
+              <div>
+                <dt>Timeline</dt>
+                <dd>Detected/imported project chords</dd>
+              </div>
+              <div>
+                <dt>Playback source</dt>
+                <dd>{playbackSourceLabel}</dd>
+              </div>
+            </dl>
+          </section>
+
+          <section className="chord-section" aria-label="Current guitar voicing">
+            <div className="chord-section-heading chord-section-heading--inline">
+              <div>
+                <p className="metric-label">{chordSpelling.notes.join(" ")}</p>
+                <h3>{chordSpelling.label} guitar shapes</h3>
+              </div>
+              <div className="chord-shape-tabs" role="group" aria-label="Live guitar shape choices">
+                {guitarShapes.map((shape) => (
+                  <button
+                    key={shape.id}
+                    aria-pressed={selectedShape?.id === shape.id}
+                    className={classNames(
+                      "chord-shape-tab",
+                      selectedShape?.id === shape.id && "chord-shape-tab--active",
+                    )}
+                    onClick={() => {
+                      setActiveShape(shape.id);
+                      setPreviewNoteId(null);
+                      setSelectedNoteId(shape.notes[0]?.id ?? null);
+                    }}
+                    type="button"
+                  >
+                    {shape.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <ChordSpellingSummary spelling={chordSpelling} />
+            <div className="chord-shape-grid" data-layout="responsive">
+              {guitarShapes.map((shape) => (
+                <div
+                  key={shape.id}
+                  className={classNames(
+                    "chord-shape-card",
+                    shape.id === activeShape && "chord-shape-card--active",
+                  )}
+                >
+                  <button
+                    className="chord-shape-card__label"
+                    onClick={() => {
+                      setActiveShape(shape.id);
+                      setPreviewNoteId(null);
+                      setSelectedNoteId(shape.notes[0]?.id ?? null);
+                    }}
+                    type="button"
+                  >
+                    {shape.label}
+                  </button>
+                  <GuitarFretboard
+                    activeTooltipNoteId={activeTooltipNoteId}
+                    notes={shape.notes}
+                    selectedNoteId={selectedNoteId}
+                    shape={shape}
+                    onPreviewNote={setPreviewNoteId}
+                    onSelectNote={(noteId) => {
+                      setPreviewNoteId(null);
+                      setSelectedNoteId(noteId);
+                    }}
+                  />
+                  <span className="chord-shape-card__meta">{shape.meta}</span>
+                </div>
+              ))}
+            </div>
+          </section>
+        </main>
+
+        <aside className="live-follow-sidebar">
+          <section className="live-next-chord" aria-label="Next chord">
+            <p className="metric-label">Next chord</p>
+            {context.nextChord ? (
+              <>
+                <strong>{context.nextChord.displayLabel}</strong>
+                <span>
+                  Source {context.nextChord.sourceLabel} at{" "}
+                  {formatFollowTime(context.nextChord.sourceSegment.start_seconds)}
+                </span>
+              </>
+            ) : (
+              <>
+                <strong>End of timeline</strong>
+                <span>No later project chord is available.</span>
+              </>
+            )}
+          </section>
+          {displayedNote ? <NoteInspector note={displayedNote} capoFret={capoFret} /> : null}
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function LiveFollowTopbar({
+  context,
+  statusLabel,
+}: {
+  context: ChordDictionaryFollowContext;
+  statusLabel: string;
+}) {
+  return (
+    <div className="live-follow-topbar">
+      <div className="live-follow-controls" role="group" aria-label="Live chord display status">
+        <span className="chord-pill chord-pill--active">
+          <Music2 aria-hidden="true" />
+          <span>{GUITAR_STANDARD_PROFILE.label}</span>
+        </span>
+        <span
+          className={classNames(
+            "chord-pill",
+            context.status === "active" ? "chord-pill--active" : "chord-pill--muted",
+          )}
+        >
+          <AudioLines aria-hidden="true" />
+          <span>{statusLabel}</span>
+        </span>
+        {context.project ? (
+          <span className="chord-pill chord-pill--muted">
+            <span>{formatPlaybackProjectLabel(context.project.projectName)}</span>
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function LiveFollowStatusCard({
+  context,
+  requestedProjectId,
+}: {
+  context: ChordDictionaryFollowContext;
+  requestedProjectId: string | null;
+}) {
+  const statusCopy = getLiveFollowStatusCopy(context, requestedProjectId);
+  return (
+    <div className="lyrics-follow-stage lyrics-follow-stage--empty" role="status" aria-live="polite">
+      <div className="live-follow-empty">
+        <AudioLines aria-hidden="true" />
+        <h3>{statusCopy.title}</h3>
+        <p>{statusCopy.copy}</p>
+        {context.nextChord ? (
+          <p>
+            Next project chord: {context.nextChord.displayLabel} at{" "}
+            {formatFollowTime(context.nextChord.sourceSegment.start_seconds)}.
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function LiveFollowChordIssue({
+  context,
+  copy,
+  statusLabel,
+  title,
+}: {
+  context: ChordDictionaryFollowContext;
+  copy: string;
+  statusLabel: string;
+  title: string;
+}) {
+  return (
+    <div className="live-follow-page live-follow-page--waiting" data-follow-status="unsupported">
+      <LiveFollowTopbar context={context} statusLabel={statusLabel} />
       <div className="lyrics-follow-stage lyrics-follow-stage--empty" role="status" aria-live="polite">
         <div className="live-follow-empty">
           <AudioLines aria-hidden="true" />
-          <h3>Live Follow waiting for playback data</h3>
-          <p>
-            Project playback chord data is not connected yet. No progression, lyrics, shapes, or note previews are shown.
-          </p>
+          <h3>{title}</h3>
+          <p>{copy}</p>
+          {context.currentChord ? (
+            <p>
+              Source chord {context.currentChord.sourceLabel}; displayed as{" "}
+              {context.currentChord.displayLabel}.
+            </p>
+          ) : null}
         </div>
       </div>
     </div>
   );
+}
+
+function getLiveFollowStatusCopy(
+  context: ChordDictionaryFollowContext,
+  requestedProjectId: string | null,
+) {
+  switch (context.status) {
+    case "no-project":
+      return {
+        title: "No matching project playback",
+        copy: requestedProjectId
+          ? "Live Follow is armed from a project, but no matching playback session is active."
+          : "Live Follow needs an active project playback session before it can show song chords.",
+      };
+    case "follow-off":
+      return {
+        title: "Live Follow is off",
+        copy: "Chord Dictionary is not armed from project playback, so no live project chord is shown.",
+      };
+    case "paused":
+      return {
+        title: "Playback paused",
+        copy: "Paused playback returns to normal dictionary behavior. No stale live chord is shown.",
+      };
+    case "no-chord-timeline":
+      return {
+        title: "No project chord timeline",
+        copy: "The active playback session has no detected or imported chord timeline to follow.",
+      };
+    case "no-current-chord":
+      return {
+        title: "No current chord at playback time",
+        copy: `Playback is at ${formatFollowTime(context.playbackTimeSeconds)}, outside any current chord segment.`,
+      };
+    case "active":
+      return {
+        title: "Live chord active",
+        copy: "Project playback is providing the current chord.",
+      };
+  }
+}
+
+function formatFollowStatusLabel(status: ChordDictionaryFollowStatus) {
+  switch (status) {
+    case "no-project":
+      return "No Project";
+    case "follow-off":
+      return "Follow Off";
+    case "paused":
+      return "Paused";
+    case "no-chord-timeline":
+      return "No Timeline";
+    case "no-current-chord":
+      return "No Current Chord";
+    case "active":
+      return "Live";
+  }
+}
+
+function formatPlaybackProjectLabel(projectName: string) {
+  return projectName.trim() || "Project playback";
 }
 
 function ChordSpellingSummary({ spelling }: { spelling: NonNullable<ReturnType<typeof spellChord>> }) {
@@ -1004,6 +1445,29 @@ function formatGuitarRange(profile: typeof GUITAR_STANDARD_PROFILE) {
   const highestOpen = openPitches.reduce((highest, pitch) => (pitch.midi > highest.midi ? pitch : highest), openPitches[0]);
   const highestFretted = midiToPitch(highestOpen.midi + profile.frets);
   return `${lowestOpen.label} - ${highestFretted?.label ?? highestOpen.label}`;
+}
+
+function formatOptionalKey(key: MusicalKey | null) {
+  return key ? formatKey(key, "short") : "No key";
+}
+
+function formatSemitoneContext(semitones: number) {
+  if (semitones === 0) {
+    return "No transpose";
+  }
+  return `${semitones > 0 ? "+" : ""}${semitones} semitones`;
+}
+
+function formatFollowTime(seconds: number) {
+  if (!Number.isFinite(seconds)) {
+    return "0:00";
+  }
+  const clampedSeconds = Math.max(0, seconds);
+  const minutes = Math.floor(clampedSeconds / 60);
+  const remainder = Math.floor(clampedSeconds % 60)
+    .toString()
+    .padStart(2, "0");
+  return `${minutes}:${remainder}`;
 }
 
 function formatBooleanCapability(value: boolean) {

--- a/apps/desktop/src/features/tools/ToolsView.test.ts
+++ b/apps/desktop/src/features/tools/ToolsView.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { nextToolSearchParams } from "./toolRouting";
+
+describe("ToolsView routing", () => {
+  it("preserves playback follow params when selecting Chord Dictionary", () => {
+    const nextSearchParams = nextToolSearchParams(
+      new URLSearchParams("tool=metronome&bpm=121.5&followPlayback=1&projectId=proj_123"),
+      "chord-dictionary",
+    );
+
+    expect(nextSearchParams.toString()).toBe(
+      "tool=chord-dictionary&followPlayback=1&projectId=proj_123",
+    );
+  });
+
+  it("clears playback follow params when selecting the default tuner", () => {
+    const nextSearchParams = nextToolSearchParams(
+      new URLSearchParams("tool=chord-dictionary&followPlayback=1&projectId=proj_123"),
+      "tuner",
+    );
+
+    expect(nextSearchParams.toString()).toBe("");
+  });
+
+  it("does not leak Chord Dictionary follow params when selecting Metronome", () => {
+    const nextSearchParams = nextToolSearchParams(
+      new URLSearchParams("tool=chord-dictionary&followPlayback=1&projectId=proj_123"),
+      "metronome",
+    );
+
+    expect(nextSearchParams.toString()).toBe("tool=metronome");
+  });
+});

--- a/apps/desktop/src/features/tools/ToolsView.tsx
+++ b/apps/desktop/src/features/tools/ToolsView.tsx
@@ -47,11 +47,11 @@ import {
   type TunerPitchReading,
 } from "./tunerPitch";
 import { ChordDictionaryPage } from "./ChordDictionaryPage";
+import { nextToolSearchParams, type ToolId } from "./toolRouting";
 
 const SYSTEM_INPUT_VOLUME_COMMIT_DELAY_MS = 180;
 
 type TunerStatus = "idle" | "starting" | "listening" | "unsupported" | "error";
-type ToolId = "tuner" | "metronome" | "chord-dictionary";
 type CaptureBackend = "native" | "web";
 
 export function ToolsView() {
@@ -59,21 +59,7 @@ export function ToolsView() {
   const activeTool = readToolId(searchParams);
 
   function handleSelectTool(tool: ToolId) {
-    const nextSearchParams = new URLSearchParams(searchParams);
-    if (tool === "tuner") {
-      nextSearchParams.delete("tool");
-      nextSearchParams.delete("bpm");
-      nextSearchParams.delete("followPlayback");
-      nextSearchParams.delete("projectId");
-    } else if (tool === "metronome") {
-      nextSearchParams.set("tool", "metronome");
-    } else {
-      nextSearchParams.set("tool", "chord-dictionary");
-      nextSearchParams.delete("bpm");
-      nextSearchParams.delete("followPlayback");
-      nextSearchParams.delete("projectId");
-    }
-    setSearchParams(nextSearchParams);
+    setSearchParams(nextToolSearchParams(searchParams, tool));
   }
 
   return (

--- a/apps/desktop/src/features/tools/chordDictionaryFollowArm-context.ts
+++ b/apps/desktop/src/features/tools/chordDictionaryFollowArm-context.ts
@@ -1,0 +1,19 @@
+import { createContext, useContext } from "react";
+
+export type ChordDictionaryFollowArmContextValue = {
+  manualFollowArmed: boolean;
+  setManualFollowArmed: (armed: boolean) => void;
+};
+
+export const ChordDictionaryFollowArmContext =
+  createContext<ChordDictionaryFollowArmContextValue | null>(null);
+
+export function useChordDictionaryFollowArm() {
+  const context = useContext(ChordDictionaryFollowArmContext);
+  if (!context) {
+    throw new Error(
+      "useChordDictionaryFollowArm must be used within a ChordDictionaryFollowArmProvider.",
+    );
+  }
+  return context;
+}

--- a/apps/desktop/src/features/tools/chordDictionaryFollowArm.tsx
+++ b/apps/desktop/src/features/tools/chordDictionaryFollowArm.tsx
@@ -1,0 +1,19 @@
+import { useMemo, useState, type ReactNode } from "react";
+import { ChordDictionaryFollowArmContext } from "./chordDictionaryFollowArm-context";
+
+export function ChordDictionaryFollowArmProvider({ children }: { children: ReactNode }) {
+  const [manualFollowArmed, setManualFollowArmed] = useState(false);
+  const value = useMemo(
+    () => ({
+      manualFollowArmed,
+      setManualFollowArmed,
+    }),
+    [manualFollowArmed],
+  );
+
+  return (
+    <ChordDictionaryFollowArmContext.Provider value={value}>
+      {children}
+    </ChordDictionaryFollowArmContext.Provider>
+  );
+}

--- a/apps/desktop/src/features/tools/toolRouting.ts
+++ b/apps/desktop/src/features/tools/toolRouting.ts
@@ -1,0 +1,19 @@
+export type ToolId = "tuner" | "metronome" | "chord-dictionary";
+
+export function nextToolSearchParams(searchParams: URLSearchParams, tool: ToolId) {
+  const nextSearchParams = new URLSearchParams(searchParams);
+  if (tool === "tuner") {
+    nextSearchParams.delete("tool");
+    nextSearchParams.delete("bpm");
+    nextSearchParams.delete("followPlayback");
+    nextSearchParams.delete("projectId");
+  } else if (tool === "metronome") {
+    nextSearchParams.set("tool", "metronome");
+    nextSearchParams.delete("followPlayback");
+    nextSearchParams.delete("projectId");
+  } else {
+    nextSearchParams.set("tool", "chord-dictionary");
+    nextSearchParams.delete("bpm");
+  }
+  return nextSearchParams;
+}

--- a/apps/desktop/src/styles/project-layout.css
+++ b/apps/desktop/src/styles/project-layout.css
@@ -440,12 +440,14 @@
 
 .analysis-action-row {
   display: flex;
+  gap: 0.8rem;
   margin-top: 0.85rem;
 }
 
 .analysis-stat__action {
+  flex: 1 1 0;
   justify-content: center;
-  width: 100%;
+  min-width: 0;
 }
 
 .meta-stat {

--- a/apps/desktop/src/styles/tools.css
+++ b/apps/desktop/src/styles/tools.css
@@ -1372,8 +1372,89 @@
   min-height: 41rem;
 }
 
+.live-follow-page--active {
+  align-content: start;
+}
+
 .live-follow-topbar {
   align-items: center;
+}
+
+.live-follow-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(17rem, 22rem);
+  gap: 1rem;
+  align-items: start;
+  min-width: 0;
+}
+
+.live-follow-main,
+.live-follow-sidebar {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.live-current-chord,
+.live-next-chord {
+  display: grid;
+  gap: 0.45rem;
+  min-width: 0;
+  padding: 0.85rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 76%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 72%, transparent);
+}
+
+.live-current-chord h3 {
+  margin: 0;
+  color: var(--text);
+  font-size: 3.4rem;
+  line-height: 0.95;
+}
+
+.live-next-chord strong {
+  color: var(--text);
+  font-size: 1.6rem;
+  line-height: 1.05;
+}
+
+.live-next-chord span {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 800;
+}
+
+.live-follow-provenance {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.55rem;
+  margin: 0;
+}
+
+.live-follow-provenance div {
+  display: grid;
+  gap: 0.12rem;
+  min-width: 0;
+  padding: 0.55rem 0.6rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 70%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel-strong) 56%, transparent);
+}
+
+.live-follow-provenance dt {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.live-follow-provenance dd {
+  min-width: 0;
+  margin: 0;
+  color: var(--text);
+  font-weight: 850;
+  overflow-wrap: anywhere;
 }
 
 .lyrics-follow-stage {
@@ -1411,7 +1492,8 @@
 
 
 @media (max-width: 1180px) {
-  .chord-tool-grid {
+  .chord-tool-grid,
+  .live-follow-grid {
     grid-template-columns: 1fr;
   }
 
@@ -1420,6 +1502,10 @@
   }
 
   .chord-field-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .live-follow-provenance {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
@@ -1455,7 +1541,9 @@
 
   .chord-context-chip,
   .chord-family-card small,
-  .chord-shape-card__meta {
+  .chord-shape-card__meta,
+  .live-next-chord span,
+  .live-follow-provenance dd {
     min-width: 0;
     overflow-wrap: anywhere;
     white-space: normal;
@@ -1481,6 +1569,10 @@
     grid-template-columns: 1fr;
   }
 
+  .live-current-chord h3 {
+    font-size: 2.6rem;
+  }
+
   .lyrics-follow-stage {
     padding: 2rem 1rem;
   }
@@ -1499,7 +1591,8 @@
 
   .chord-field-row,
   .chord-card-row,
-  .note-inspector dl {
+  .note-inspector dl,
+  .live-follow-provenance {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary

- Closes #265.
- Add Chord Dictionary Live Follow for active project playback.
- Add project Analysis entrypoints, route handling, and in-app follow arming.
- Show real current/next project chords with honest paused, missing, and unsupported states.
- Use the project display name for playback source instead of artifact ids.

## Testing

- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop test`
- `git diff --check`
