### PR TITLE
feat: externalize chord knowledge data

### DIFF
--- a/apps/desktop/src/lib/instrumentKnowledge.test.ts
+++ b/apps/desktop/src/lib/instrumentKnowledge.test.ts
@@ -1,0 +1,433 @@
+import { describe, expect, it } from "vitest";
+import {
+  INSTRUMENT_KNOWLEDGE_BUNDLE_V1,
+  normalizeInstrumentKnowledgeBundle,
+  normalizeObservedGuitarGzipVoicingSeeds,
+} from "./instrumentKnowledge";
+
+describe("instrument knowledge bundle", () => {
+  it("exposes first-party harmonic and guitar data in normalized form", () => {
+    expect(INSTRUMENT_KNOWLEDGE_BUNDLE_V1.schemaVersion).toBe(1);
+    expect(INSTRUMENT_KNOWLEDGE_BUNDLE_V1.harmonicDefinitions.hdim7?.tones).toContainEqual({
+      degree: "b5",
+      interval: 6,
+    });
+    expect(INSTRUMENT_KNOWLEDGE_BUNDLE_V1.instrumentProfiles.guitar).toMatchObject({
+      id: "guitar",
+      label: "Guitar",
+      executionLayer: "fretboard",
+      fretboard: {
+        frets: 22,
+        stringOrder: [6, 5, 4, 3, 2, 1],
+        canCapo: true,
+        canRetune: true,
+      },
+    });
+    expect(INSTRUMENT_KNOWLEDGE_BUNDLE_V1.voicingSeeds.guitar?.common).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "c-open",
+          chordLabel: "C",
+          source: "first-party",
+        }),
+        expect.objectContaining({
+          id: "esus4-open",
+          chordLabel: "Esus4",
+          source: "first-party",
+        }),
+      ]),
+    );
+    expect(INSTRUMENT_KNOWLEDGE_BUNDLE_V1.voicingSeeds.guitar?.moveableDefinitions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "e-shape-barre",
+          shapeFamily: "E",
+          quality: "major",
+        }),
+      ]),
+    );
+  });
+
+  it("returns safe empty structures for invalid bundles", () => {
+    expect(normalizeInstrumentKnowledgeBundle(null)).toMatchObject({
+      schemaVersion: 1,
+      harmonicDefinitions: {},
+      instrumentProfiles: {},
+      voicingSeeds: {},
+      importAdapters: {},
+    });
+    expect(
+      normalizeInstrumentKnowledgeBundle({
+        schemaVersion: 1,
+        harmonicDefinitions: {
+          major: {
+            id: "major",
+            label: "Major",
+            suffix: "",
+            tones: [{ degree: "bogus", interval: 0 }],
+          },
+        },
+        instrumentProfiles: {
+          guitar: {
+            id: "guitar",
+            label: "Guitar",
+          },
+        },
+      }).harmonicDefinitions,
+    ).toEqual({});
+  });
+
+  it("drops invalid profile, seed, and adapter chunks into safe empty structures", () => {
+    const bundle = normalizeInstrumentKnowledgeBundle({
+      schemaVersion: 1,
+      bundleId: "fixture",
+      version: "0.0.0",
+      instrumentProfiles: {
+        missingFamily: {
+          id: "missing-family",
+          label: "Missing family",
+          executionLayer: "fretboard",
+        },
+        missingLabel: {
+          id: "missing-label",
+          family: "fretted-strings",
+          executionLayer: "fretboard",
+        },
+      },
+      voicingSeeds: {
+        guitar: {
+          common: [
+            {
+              id: "bad-seed",
+              label: "Bad seed",
+              chordLabel: "C",
+              rank: 1,
+              notes: [{ string: 0, fret: -1 }],
+            },
+          ],
+          moveableDefinitions: [
+            {
+              id: "bad-moveable",
+              label: "Bad moveable",
+              shapeFamily: "not-caged",
+              quality: "major",
+              rank: 1,
+              baseFrets: [0, 2, 2, 1, 0, 0],
+              roots: [{ label: "F", offset: 0 }],
+            },
+          ],
+        },
+        piano: {
+          executionLayer: "keyboard",
+          seeds: [
+            {
+              id: "bad-keyboard-seed",
+              label: "Bad keyboard seed",
+              chordLabel: "C",
+              rank: 1,
+              positions: [{ hand: "right", finger: 1 }],
+            },
+          ],
+        },
+        accordion: {
+          executionLayer: "button-board",
+          seeds: [
+            {
+              id: "bad-button-seed",
+              label: "Bad button seed",
+              chordLabel: "C",
+              rank: 1,
+              positions: [{ side: "treble", row: 0, column: 1, button: "C" }],
+            },
+          ],
+        },
+      },
+      importAdapters: {
+        missingSchema: { description: "missing schema" },
+        wrongSchema: { schemaVersion: 2, stringOrder: [6, 5, 4, 3, 2, 1] },
+      },
+    });
+
+    expect(bundle.instrumentProfiles).toEqual({});
+    expect(bundle.voicingSeeds).toEqual({});
+    expect(bundle.importAdapters).toEqual({});
+  });
+
+  it("drops malformed moveable guitar definitions without compacting base frets", () => {
+    const bundle = normalizeInstrumentKnowledgeBundle({
+      schemaVersion: 1,
+      bundleId: "fixture",
+      version: "0.0.0",
+      voicingSeeds: {
+        guitar: {
+          moveableDefinitions: [
+            {
+              id: "bad-middle-fret",
+              label: "Bad middle fret",
+              shapeFamily: "E",
+              quality: "major",
+              rank: 1,
+              baseFrets: [0, 2, "bad", 1, 0, 0],
+              roots: [{ label: "F", offset: 1 }],
+            },
+            {
+              id: "good-muted-string",
+              label: "Good muted string",
+              shapeFamily: "A",
+              quality: "major",
+              rank: 2,
+              baseFrets: [null, 0, 2, 2, 2, 0],
+              roots: [{ label: "Bb", offset: 1 }],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(bundle.voicingSeeds.guitar?.moveableDefinitions).toEqual([
+      {
+        id: "good-muted-string",
+        instrumentId: "guitar",
+        label: "Good muted string",
+        shapeFamily: "A",
+        quality: "major",
+        baseFrets: [null, 0, 2, 2, 2, 0],
+        rank: 2,
+        roots: [{ label: "Bb", offset: 1 }],
+      },
+    ]);
+  });
+
+  it("rejects partial and invalid guitar string orders", () => {
+    const bundle = normalizeInstrumentKnowledgeBundle({
+      schemaVersion: 1,
+      bundleId: "fixture",
+      version: "0.0.0",
+      instrumentProfiles: {
+        partialOrder: {
+          id: "partialOrder",
+          label: "Partial order",
+          family: "fretted-strings",
+          executionLayer: "fretboard",
+          fretboard: {
+            frets: 22,
+            stringOrder: [6, 5, 4],
+            canCapo: true,
+            canRetune: true,
+          },
+        },
+        invalidOrder: {
+          id: "invalidOrder",
+          label: "Invalid order",
+          family: "fretted-strings",
+          executionLayer: "fretboard",
+          fretboard: {
+            frets: 22,
+            stringOrder: [6, 5, 4, 3, 2, 9],
+            canCapo: true,
+            canRetune: true,
+          },
+        },
+        duplicateOrder: {
+          id: "duplicateOrder",
+          label: "Duplicate order",
+          family: "fretted-strings",
+          executionLayer: "fretboard",
+          fretboard: {
+            frets: 22,
+            stringOrder: [6, 5, 4, 3, 2, 2],
+            canCapo: true,
+            canRetune: true,
+          },
+        },
+      },
+      importAdapters: {
+        partial: { schemaVersion: 1, stringOrder: [6, 5, 4] },
+        invalid: { schemaVersion: 1, stringOrder: [6, 5, 4, 3, 2, 9] },
+      },
+    });
+
+    expect(bundle.instrumentProfiles.partialOrder?.fretboard?.stringOrder).toEqual([]);
+    expect(bundle.instrumentProfiles.invalidOrder?.fretboard?.stringOrder).toEqual([]);
+    expect(bundle.instrumentProfiles.duplicateOrder?.fretboard?.stringOrder).toEqual([]);
+    expect(bundle.importAdapters).toEqual({
+      partial: { schemaVersion: 1 },
+      invalid: { schemaVersion: 1 },
+    });
+  });
+
+  it("normalizes future non-guitar instrument profile and seed shapes from synthetic fixtures", () => {
+    const bundle = normalizeInstrumentKnowledgeBundle({
+      schemaVersion: 1,
+      bundleId: "fixture",
+      version: "0.0.0",
+      instrumentProfiles: {
+        piano: {
+          id: "piano",
+          label: "Piano",
+          family: "keyboard",
+          executionLayer: "keyboard",
+          keyboard: {
+            keyCount: 88,
+            lowestPitch: "A0",
+            highestPitch: "C8",
+            canTranspose: true,
+          },
+        },
+        accordion: {
+          id: "accordion",
+          label: "Accordion",
+          family: "free-reed",
+          executionLayer: "button-board",
+          buttonBoard: {
+            layout: "chromatic",
+            buttons: 120,
+            rows: 5,
+            columns: 24,
+            canTranspose: false,
+          },
+        },
+      },
+      voicingSeeds: {
+        piano: {
+          executionLayer: "keyboard",
+          seeds: [
+            {
+              id: "piano-c-triad",
+              label: "Piano C triad",
+              chordLabel: "C",
+              rank: 10,
+              tags: ["triad", "synthetic"],
+              positions: [
+                { pitch: "C4", note: "C", hand: "right", finger: 1 },
+                { pitch: "E4", note: "E", hand: "right", finger: 3 },
+                { pitch: "G4", note: "G", hand: "right", finger: 5 },
+                { pitch: "", hand: "left", finger: 6 },
+              ],
+            },
+            {
+              id: "invalid-piano-seed",
+              label: "Invalid piano seed",
+              chordLabel: "C",
+              rank: 11,
+              positions: [{ note: "C" }],
+            },
+          ],
+        },
+        accordion: {
+          executionLayer: "button-board",
+          seeds: [
+            {
+              id: "accordion-c-triad",
+              label: "Accordion C triad",
+              chordLabel: "C",
+              rank: 20,
+              positions: [
+                { side: "treble", row: 2, column: 4, button: "C", pitch: "C4", finger: 1 },
+                { side: "treble", row: 2, column: 6, button: "E", note: "E", finger: 3 },
+                { side: "treble", row: 2, column: 8, button: "G", note: "G", finger: 5 },
+                { side: "treble", row: 0, column: 8, button: "bad" },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(bundle.instrumentProfiles.piano).toMatchObject({
+      id: "piano",
+      executionLayer: "keyboard",
+      keyboard: {
+        keyCount: 88,
+        lowestPitch: "A0",
+        highestPitch: "C8",
+        canTranspose: true,
+      },
+    });
+    expect(bundle.instrumentProfiles.accordion).toMatchObject({
+      id: "accordion",
+      executionLayer: "button-board",
+      buttonBoard: {
+        layout: "chromatic",
+        buttons: 120,
+        rows: 5,
+        columns: 24,
+        canTranspose: false,
+      },
+    });
+    expect(bundle.voicingSeeds.piano).toEqual({
+      executionLayer: "keyboard",
+      seeds: [
+        {
+          id: "piano-c-triad",
+          instrumentId: "piano",
+          label: "Piano C triad",
+          chordLabel: "C",
+          rank: 10,
+          tags: ["triad", "synthetic"],
+          executionLayer: "keyboard",
+          positions: [
+            { pitch: "C4", note: "C", hand: "right", finger: 1 },
+            { pitch: "E4", note: "E", hand: "right", finger: 3 },
+            { pitch: "G4", note: "G", hand: "right", finger: 5 },
+          ],
+        },
+      ],
+    });
+    expect(bundle.voicingSeeds.accordion).toEqual({
+      executionLayer: "button-board",
+      seeds: [
+        {
+          id: "accordion-c-triad",
+          instrumentId: "accordion",
+          label: "Accordion C triad",
+          chordLabel: "C",
+          rank: 20,
+          executionLayer: "button-board",
+          positions: [
+            { side: "treble", row: 2, column: 4, button: "C", pitch: "C4", finger: 1 },
+            { side: "treble", row: 2, column: 6, button: "E", note: "E", finger: 3 },
+            { side: "treble", row: 2, column: 8, button: "G", note: "G", finger: 5 },
+          ],
+        },
+      ],
+    });
+    expect(INSTRUMENT_KNOWLEDGE_BUNDLE_V1.instrumentProfiles.piano).toBeUndefined();
+    expect(INSTRUMENT_KNOWLEDGE_BUNDLE_V1.voicingSeeds.piano).toBeUndefined();
+  });
+});
+
+describe("observed guitar gzip adapter", () => {
+  it("maps observed row-shaped fingerings to guitar voicing seeds", () => {
+    expect(
+      normalizeObservedGuitarGzipVoicingSeeds(
+        {
+          C: [
+            {
+              positions: ["x", "3", "2", "0", "1", "0"],
+              fingerings: [["0", "3", "2", "0", "1", "0"]],
+            },
+          ],
+          Bad: [{ positions: [0, 1, 2] }],
+        },
+        { sourceId: "fixture", rankStart: 50 },
+      ),
+    ).toEqual([
+      {
+        id: "fixture-c-1",
+        instrumentId: "guitar",
+        label: "C observed 1",
+        chordLabel: "C",
+        rank: 50,
+        source: "observed-gzip",
+        notes: [
+          { string: 5, fret: 3, finger: 3 },
+          { string: 4, fret: 2, finger: 2 },
+          { string: 3, fret: 0 },
+          { string: 2, fret: 1, finger: 1 },
+          { string: 1, fret: 0 },
+        ],
+      },
+    ]);
+  });
+});

--- a/apps/desktop/src/lib/instrumentKnowledge.ts
+++ b/apps/desktop/src/lib/instrumentKnowledge.ts
@@ -1,0 +1,875 @@
+import rawInstrumentKnowledgeBundle from "./instrumentKnowledgeData.json";
+
+export type InstrumentKnowledgeBundleSchemaVersion = 1;
+
+export type HarmonicDegree =
+  | "1"
+  | "b2"
+  | "#1"
+  | "2"
+  | "#2"
+  | "b3"
+  | "3"
+  | "4"
+  | "#4"
+  | "b5"
+  | "5"
+  | "#5"
+  | "b6"
+  | "6"
+  | "#6"
+  | "bb7"
+  | "b7"
+  | "7";
+
+export type HarmonicToneDefinitionV1 = {
+  degree: HarmonicDegree;
+  interval: number;
+};
+
+export type HarmonicDefinitionV1 = {
+  id: string;
+  label: string;
+  suffix: string;
+  aliases: readonly string[];
+  tones: readonly HarmonicToneDefinitionV1[];
+};
+
+export type InstrumentExecutionLayerV1 = "fretboard" | "keyboard" | "button-board" | (string & {});
+
+export type InstrumentTuningStringV1 = {
+  string: number;
+  openPitch: string;
+};
+
+export type FretboardProfileV1 = {
+  frets: number;
+  stringOrder: readonly number[];
+  canCapo: boolean;
+  canRetune: boolean;
+};
+
+export type KeyboardProfileV1 = {
+  keyCount: number;
+  lowestPitch: string;
+  highestPitch: string;
+  canTranspose: boolean;
+};
+
+export type ButtonBoardProfileV1 = {
+  layout: string;
+  buttons: number;
+  rows?: number;
+  columns?: number;
+  canTranspose: boolean;
+};
+
+export type InstrumentProfileV1 = {
+  id: string;
+  label: string;
+  family: string;
+  executionLayer: InstrumentExecutionLayerV1;
+  tuning?: readonly InstrumentTuningStringV1[];
+  fretboard?: FretboardProfileV1;
+  keyboard?: KeyboardProfileV1;
+  buttonBoard?: ButtonBoardProfileV1;
+};
+
+export type GuitarShapeFamilyV1 = "C" | "A" | "G" | "E" | "D";
+export type GuitarFingerV1 = 1 | 2 | 3 | 4;
+export type KeyboardFingerV1 = 1 | 2 | 3 | 4 | 5;
+export type KeyboardHandV1 = "left" | "right";
+
+export type VoicingSeedBaseV1 = {
+  id: string;
+  instrumentId: string;
+  label: string;
+  chordLabel: string;
+  rank: number;
+  tags?: readonly string[];
+};
+
+export type GuitarVoicingSeedNoteV1 = {
+  string: number;
+  fret: number;
+  finger?: GuitarFingerV1;
+};
+
+export type GuitarVoicingSeedSourceV1 = "first-party" | "observed-gzip";
+
+export type GuitarVoicingSeedV1 = VoicingSeedBaseV1 & {
+  shapeFamily?: GuitarShapeFamilyV1;
+  source: GuitarVoicingSeedSourceV1;
+  notes: readonly GuitarVoicingSeedNoteV1[];
+};
+
+export type KeyboardVoicingSeedPositionV1 = {
+  pitch: string;
+  note?: string;
+  hand?: KeyboardHandV1;
+  finger?: KeyboardFingerV1;
+};
+
+export type KeyboardVoicingSeedV1 = VoicingSeedBaseV1 & {
+  executionLayer: "keyboard";
+  positions: readonly KeyboardVoicingSeedPositionV1[];
+};
+
+export type ButtonBoardVoicingSeedPositionV1 = {
+  side: string;
+  row: number;
+  column: number;
+  button: string;
+  pitch?: string;
+  note?: string;
+  finger?: KeyboardFingerV1;
+};
+
+export type ButtonBoardVoicingSeedV1 = VoicingSeedBaseV1 & {
+  executionLayer: "button-board";
+  positions: readonly ButtonBoardVoicingSeedPositionV1[];
+};
+
+export type GuitarMoveableRootV1 = {
+  label: string;
+  offset: number;
+};
+
+export type GuitarMoveableVoicingSeedDefinitionV1 = {
+  id: string;
+  instrumentId: string;
+  label: string;
+  shapeFamily: GuitarShapeFamilyV1;
+  quality: string;
+  baseFrets: readonly (number | null)[];
+  rank: number;
+  roots: readonly GuitarMoveableRootV1[];
+};
+
+export type GuitarVoicingSeedsV1 = {
+  common: readonly GuitarVoicingSeedV1[];
+  moveableDefinitions: readonly GuitarMoveableVoicingSeedDefinitionV1[];
+};
+
+export type KeyboardVoicingSeedsV1 = {
+  executionLayer: "keyboard";
+  seeds: readonly KeyboardVoicingSeedV1[];
+};
+
+export type ButtonBoardVoicingSeedsV1 = {
+  executionLayer: "button-board";
+  seeds: readonly ButtonBoardVoicingSeedV1[];
+};
+
+export type InstrumentVoicingSeedsV1 = GuitarVoicingSeedsV1 | KeyboardVoicingSeedsV1 | ButtonBoardVoicingSeedsV1;
+
+export type ImportAdapterDefinitionV1 = {
+  schemaVersion: InstrumentKnowledgeBundleSchemaVersion;
+  description?: string;
+  stringOrder?: readonly number[];
+};
+
+export type InstrumentKnowledgeBundleV1 = {
+  schemaVersion: InstrumentKnowledgeBundleSchemaVersion;
+  bundleId: string;
+  version: string;
+  harmonicDefinitions: Readonly<Record<string, HarmonicDefinitionV1>>;
+  instrumentProfiles: Readonly<Record<string, InstrumentProfileV1>>;
+  voicingSeeds: Readonly<Record<string, InstrumentVoicingSeedsV1> & { guitar?: GuitarVoicingSeedsV1 }>;
+  importAdapters: Readonly<Record<string, ImportAdapterDefinitionV1>>;
+};
+
+export type ObservedGuitarGzipVoicing = {
+  positions: readonly unknown[];
+  fingerings?: readonly unknown[];
+};
+
+export type NormalizeObservedGuitarGzipOptions = {
+  instrumentId?: string;
+  sourceId?: string;
+  rankStart?: number;
+};
+
+const EMPTY_INSTRUMENT_KNOWLEDGE_BUNDLE_V1: InstrumentKnowledgeBundleV1 = {
+  schemaVersion: 1,
+  bundleId: "",
+  version: "",
+  harmonicDefinitions: {},
+  instrumentProfiles: {},
+  voicingSeeds: {},
+  importAdapters: {},
+};
+
+const HARMONIC_DEGREES = new Set<HarmonicDegree>([
+  "1",
+  "b2",
+  "#1",
+  "2",
+  "#2",
+  "b3",
+  "3",
+  "4",
+  "#4",
+  "b5",
+  "5",
+  "#5",
+  "b6",
+  "6",
+  "#6",
+  "bb7",
+  "b7",
+  "7",
+]);
+const GUITAR_SHAPE_FAMILIES = new Set<GuitarShapeFamilyV1>(["C", "A", "G", "E", "D"]);
+const GUITAR_FINGERS = new Set<GuitarFingerV1>([1, 2, 3, 4]);
+const KEYBOARD_FINGERS = new Set<KeyboardFingerV1>([1, 2, 3, 4, 5]);
+const KEYBOARD_HANDS = new Set<KeyboardHandV1>(["left", "right"]);
+const DEFAULT_GUITAR_STRING_ORDER = [6, 5, 4, 3, 2, 1] as const;
+const DEFAULT_GUITAR_STRING_ORDER_SET = new Set<number>(DEFAULT_GUITAR_STRING_ORDER);
+
+export const INSTRUMENT_KNOWLEDGE_BUNDLE_V1: InstrumentKnowledgeBundleV1 =
+  normalizeInstrumentKnowledgeBundle(rawInstrumentKnowledgeBundle);
+
+export function normalizeInstrumentKnowledgeBundle(input: unknown): InstrumentKnowledgeBundleV1 {
+  const record = asRecord(input);
+  if (!record || record.schemaVersion !== 1) {
+    return EMPTY_INSTRUMENT_KNOWLEDGE_BUNDLE_V1;
+  }
+
+  return {
+    schemaVersion: 1,
+    bundleId: asNonEmptyString(record.bundleId) ?? "",
+    version: asNonEmptyString(record.version) ?? "",
+    harmonicDefinitions: normalizeHarmonicDefinitions(record.harmonicDefinitions),
+    instrumentProfiles: normalizeInstrumentProfiles(record.instrumentProfiles),
+    voicingSeeds: normalizeVoicingSeedGroups(record.voicingSeeds),
+    importAdapters: normalizeImportAdapters(record.importAdapters),
+  };
+}
+
+export function normalizeObservedGuitarGzipVoicingSeeds(
+  input: unknown,
+  options: NormalizeObservedGuitarGzipOptions = {},
+): readonly GuitarVoicingSeedV1[] {
+  const record = asRecord(input);
+  if (!record) {
+    return [];
+  }
+
+  const instrumentId = options.instrumentId ?? "guitar";
+  const sourceId = options.sourceId ?? "observed-gzip";
+  const rankStart = options.rankStart ?? 1000;
+  const seeds: GuitarVoicingSeedV1[] = [];
+
+  for (const [chordLabel, rawShapes] of Object.entries(record)) {
+    const normalizedChordLabel = chordLabel.trim();
+    if (!normalizedChordLabel || !Array.isArray(rawShapes)) {
+      continue;
+    }
+
+    rawShapes.forEach((rawShape, shapeIndex) => {
+      const shape = normalizeObservedGuitarGzipShape(rawShape, normalizedChordLabel, shapeIndex, instrumentId, sourceId);
+      if (shape) {
+        seeds.push({ ...shape, rank: rankStart + seeds.length });
+      }
+    });
+  }
+
+  return seeds;
+}
+
+function normalizeHarmonicDefinitions(input: unknown): Readonly<Record<string, HarmonicDefinitionV1>> {
+  const record = asRecord(input);
+  if (!record) {
+    return {};
+  }
+
+  const definitions: Record<string, HarmonicDefinitionV1> = {};
+  for (const [key, value] of Object.entries(record)) {
+    const rawDefinition = asRecord(value);
+    const id = asNonEmptyString(rawDefinition?.id) ?? key.trim();
+    const label = asNonEmptyString(rawDefinition?.label);
+    const suffix = typeof rawDefinition?.suffix === "string" ? rawDefinition.suffix : null;
+    const tones = normalizeHarmonicTones(rawDefinition?.tones);
+    if (!id || !label || suffix === null || tones.length === 0) {
+      continue;
+    }
+
+    definitions[id] = {
+      id,
+      label,
+      suffix,
+      aliases: normalizeStringArray(rawDefinition?.aliases),
+      tones,
+    };
+  }
+  return definitions;
+}
+
+function normalizeHarmonicTones(input: unknown): readonly HarmonicToneDefinitionV1[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+
+  return input.flatMap((rawTone): HarmonicToneDefinitionV1[] => {
+    const tone = asRecord(rawTone);
+    if (!tone || !isHarmonicDegree(tone.degree) || !isSafeInteger(tone.interval)) {
+      return [];
+    }
+    return [{ degree: tone.degree, interval: tone.interval }];
+  });
+}
+
+function normalizeInstrumentProfiles(input: unknown): Readonly<Record<string, InstrumentProfileV1>> {
+  const record = asRecord(input);
+  if (!record) {
+    return {};
+  }
+
+  const profiles: Record<string, InstrumentProfileV1> = {};
+  for (const [key, value] of Object.entries(record)) {
+    const rawProfile = asRecord(value);
+    const id = asNonEmptyString(rawProfile?.id) ?? key.trim();
+    const label = asNonEmptyString(rawProfile?.label);
+    const family = asNonEmptyString(rawProfile?.family);
+    const executionLayer = asNonEmptyString(rawProfile?.executionLayer);
+    if (!id || !label || !family || !executionLayer) {
+      continue;
+    }
+
+    const tuning = normalizeInstrumentTuning(rawProfile?.tuning);
+    const fretboard = normalizeFretboardProfile(rawProfile?.fretboard);
+    const keyboard = normalizeKeyboardProfile(rawProfile?.keyboard);
+    const buttonBoard = normalizeButtonBoardProfile(rawProfile?.buttonBoard);
+    profiles[id] = {
+      id,
+      label,
+      family,
+      executionLayer,
+      ...(tuning.length > 0 ? { tuning } : {}),
+      ...(fretboard ? { fretboard } : {}),
+      ...(keyboard ? { keyboard } : {}),
+      ...(buttonBoard ? { buttonBoard } : {}),
+    };
+  }
+  return profiles;
+}
+
+function normalizeInstrumentTuning(input: unknown): readonly InstrumentTuningStringV1[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+
+  return input.flatMap((rawTuning): InstrumentTuningStringV1[] => {
+    const tuning = asRecord(rawTuning);
+    const openPitch = asNonEmptyString(tuning?.openPitch);
+    if (!tuning || !isPositiveInteger(tuning.string) || !openPitch) {
+      return [];
+    }
+    return [{ string: tuning.string, openPitch }];
+  });
+}
+
+function normalizeFretboardProfile(input: unknown): FretboardProfileV1 | null {
+  const rawFretboard = asRecord(input);
+  if (!rawFretboard || !isPositiveInteger(rawFretboard.frets)) {
+    return null;
+  }
+
+  return {
+    frets: rawFretboard.frets,
+    stringOrder: normalizeGuitarStringOrder(rawFretboard.stringOrder),
+    canCapo: rawFretboard.canCapo === true,
+    canRetune: rawFretboard.canRetune === true,
+  };
+}
+
+function normalizeKeyboardProfile(input: unknown): KeyboardProfileV1 | null {
+  const rawKeyboard = asRecord(input);
+  const lowestPitch = asNonEmptyString(rawKeyboard?.lowestPitch);
+  const highestPitch = asNonEmptyString(rawKeyboard?.highestPitch);
+  if (!rawKeyboard || !isPositiveInteger(rawKeyboard.keyCount) || !lowestPitch || !highestPitch) {
+    return null;
+  }
+
+  return {
+    keyCount: rawKeyboard.keyCount,
+    lowestPitch,
+    highestPitch,
+    canTranspose: rawKeyboard.canTranspose === true,
+  };
+}
+
+function normalizeButtonBoardProfile(input: unknown): ButtonBoardProfileV1 | null {
+  const rawButtonBoard = asRecord(input);
+  const layout = asNonEmptyString(rawButtonBoard?.layout);
+  if (!rawButtonBoard || !layout || !isPositiveInteger(rawButtonBoard.buttons)) {
+    return null;
+  }
+
+  const rows = isPositiveInteger(rawButtonBoard.rows) ? rawButtonBoard.rows : null;
+  const columns = isPositiveInteger(rawButtonBoard.columns) ? rawButtonBoard.columns : null;
+  return {
+    layout,
+    buttons: rawButtonBoard.buttons,
+    ...(rows ? { rows } : {}),
+    ...(columns ? { columns } : {}),
+    canTranspose: rawButtonBoard.canTranspose === true,
+  };
+}
+
+function normalizeVoicingSeedGroups(input: unknown): InstrumentKnowledgeBundleV1["voicingSeeds"] {
+  const record = asRecord(input);
+  if (!record) {
+    return {};
+  }
+
+  const groups: Record<string, InstrumentVoicingSeedsV1> = {};
+  for (const [instrumentId, value] of Object.entries(record)) {
+    const rawGroup = asRecord(value);
+    if (!rawGroup) {
+      continue;
+    }
+    const common = normalizeGuitarVoicingSeeds(rawGroup.common, instrumentId);
+    const moveableDefinitions = normalizeGuitarMoveableDefinitions(rawGroup.moveableDefinitions, instrumentId);
+    if (common.length > 0 || moveableDefinitions.length > 0) {
+      groups[instrumentId] = { common, moveableDefinitions };
+      continue;
+    }
+
+    const layeredGroup = normalizeLayeredVoicingSeedGroup(rawGroup, instrumentId);
+    if (layeredGroup) {
+      groups[instrumentId] = layeredGroup;
+    }
+  }
+  return groups as InstrumentKnowledgeBundleV1["voicingSeeds"];
+}
+
+function normalizeGuitarVoicingSeeds(input: unknown, instrumentId: string): readonly GuitarVoicingSeedV1[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+
+  return input.flatMap((rawSeed): GuitarVoicingSeedV1[] => {
+    const seed = asRecord(rawSeed);
+    const id = asNonEmptyString(seed?.id);
+    const label = asNonEmptyString(seed?.label);
+    const chordLabel = asNonEmptyString(seed?.chordLabel);
+    const rank = seed && isSafeInteger(seed.rank) ? seed.rank : null;
+    const notes = normalizeGuitarVoicingNotes(seed?.notes);
+    if (!id || !label || !chordLabel || rank === null || notes.length === 0) {
+      return [];
+    }
+
+    const shapeFamily = normalizeGuitarShapeFamily(seed?.shapeFamily);
+    return [
+      {
+        id,
+        instrumentId,
+        label,
+        chordLabel,
+        ...(shapeFamily ? { shapeFamily } : {}),
+        rank,
+        source: "first-party",
+        notes,
+      },
+    ];
+  });
+}
+
+function normalizeGuitarMoveableDefinitions(
+  input: unknown,
+  instrumentId: string,
+): readonly GuitarMoveableVoicingSeedDefinitionV1[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+
+  return input.flatMap((rawDefinition): GuitarMoveableVoicingSeedDefinitionV1[] => {
+    const definition = asRecord(rawDefinition);
+    const id = asNonEmptyString(definition?.id);
+    const label = asNonEmptyString(definition?.label);
+    const quality = asNonEmptyString(definition?.quality);
+    const shapeFamily = normalizeGuitarShapeFamily(definition?.shapeFamily);
+    const rank = definition && isSafeInteger(definition.rank) ? definition.rank : null;
+    const baseFrets = normalizeBaseFrets(definition?.baseFrets);
+    const roots = normalizeMoveableRoots(definition?.roots);
+    if (
+      !id ||
+      !label ||
+      !quality ||
+      !shapeFamily ||
+      rank === null ||
+      baseFrets.length !== DEFAULT_GUITAR_STRING_ORDER.length ||
+      roots.length === 0
+    ) {
+      return [];
+    }
+
+    return [{ id, instrumentId, label, shapeFamily, quality, baseFrets, rank, roots }];
+  });
+}
+
+function normalizeGuitarVoicingNotes(input: unknown): readonly GuitarVoicingSeedNoteV1[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+
+  return input.flatMap((rawNote): GuitarVoicingSeedNoteV1[] => {
+    const note = asRecord(rawNote);
+    if (!note || !isPositiveInteger(note.string) || !isNonNegativeInteger(note.fret)) {
+      return [];
+    }
+
+    const finger = normalizeGuitarFinger(note.finger);
+    return [{ string: note.string, fret: note.fret, ...(finger ? { finger } : {}) }];
+  });
+}
+
+function normalizeLayeredVoicingSeedGroup(input: Record<string, unknown>, instrumentId: string): InstrumentVoicingSeedsV1 | null {
+  if (input.executionLayer === "keyboard") {
+    const seeds = normalizeKeyboardVoicingSeeds(input.seeds, instrumentId);
+    return seeds.length > 0 ? { executionLayer: "keyboard", seeds } : null;
+  }
+
+  if (input.executionLayer === "button-board") {
+    const seeds = normalizeButtonBoardVoicingSeeds(input.seeds, instrumentId);
+    return seeds.length > 0 ? { executionLayer: "button-board", seeds } : null;
+  }
+
+  return null;
+}
+
+function normalizeKeyboardVoicingSeeds(input: unknown, instrumentId: string): readonly KeyboardVoicingSeedV1[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+
+  return input.flatMap((rawSeed): KeyboardVoicingSeedV1[] => {
+    const seed = asRecord(rawSeed);
+    const base = normalizeVoicingSeedBase(seed, instrumentId);
+    const positions = normalizeKeyboardVoicingPositions(seed?.positions);
+    if (!base || positions.length === 0) {
+      return [];
+    }
+
+    return [{ ...base, executionLayer: "keyboard", positions }];
+  });
+}
+
+function normalizeButtonBoardVoicingSeeds(input: unknown, instrumentId: string): readonly ButtonBoardVoicingSeedV1[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+
+  return input.flatMap((rawSeed): ButtonBoardVoicingSeedV1[] => {
+    const seed = asRecord(rawSeed);
+    const base = normalizeVoicingSeedBase(seed, instrumentId);
+    const positions = normalizeButtonBoardVoicingPositions(seed?.positions);
+    if (!base || positions.length === 0) {
+      return [];
+    }
+
+    return [{ ...base, executionLayer: "button-board", positions }];
+  });
+}
+
+function normalizeVoicingSeedBase(input: Record<string, unknown> | null, instrumentId: string): VoicingSeedBaseV1 | null {
+  const id = asNonEmptyString(input?.id);
+  const label = asNonEmptyString(input?.label);
+  const chordLabel = asNonEmptyString(input?.chordLabel);
+  const rank = input && isSafeInteger(input.rank) ? input.rank : null;
+  if (!id || !label || !chordLabel || rank === null) {
+    return null;
+  }
+
+  const tags = normalizeStringArray(input?.tags);
+  return {
+    id,
+    instrumentId,
+    label,
+    chordLabel,
+    rank,
+    ...(tags.length > 0 ? { tags } : {}),
+  };
+}
+
+function normalizeKeyboardVoicingPositions(input: unknown): readonly KeyboardVoicingSeedPositionV1[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+
+  return input.flatMap((rawPosition): KeyboardVoicingSeedPositionV1[] => {
+    const position = asRecord(rawPosition);
+    const pitch = asNonEmptyString(position?.pitch);
+    if (!position || !pitch) {
+      return [];
+    }
+
+    const note = asNonEmptyString(position.note);
+    const hand = normalizeKeyboardHand(position.hand);
+    const finger = normalizeKeyboardFinger(position.finger);
+    return [
+      {
+        pitch,
+        ...(note ? { note } : {}),
+        ...(hand ? { hand } : {}),
+        ...(finger ? { finger } : {}),
+      },
+    ];
+  });
+}
+
+function normalizeButtonBoardVoicingPositions(input: unknown): readonly ButtonBoardVoicingSeedPositionV1[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+
+  return input.flatMap((rawPosition): ButtonBoardVoicingSeedPositionV1[] => {
+    const position = asRecord(rawPosition);
+    const side = asNonEmptyString(position?.side);
+    const button = asNonEmptyString(position?.button);
+    if (!position || !side || !button || !isPositiveInteger(position.row) || !isPositiveInteger(position.column)) {
+      return [];
+    }
+
+    const pitch = asNonEmptyString(position.pitch);
+    const note = asNonEmptyString(position.note);
+    const finger = normalizeKeyboardFinger(position.finger);
+    return [
+      {
+        side,
+        row: position.row,
+        column: position.column,
+        button,
+        ...(pitch ? { pitch } : {}),
+        ...(note ? { note } : {}),
+        ...(finger ? { finger } : {}),
+      },
+    ];
+  });
+}
+
+function normalizeBaseFrets(input: unknown): readonly (number | null)[] {
+  if (!Array.isArray(input) || input.length !== DEFAULT_GUITAR_STRING_ORDER.length) {
+    return [];
+  }
+
+  const frets: (number | null)[] = [];
+  for (const value of input) {
+    if (value === null) {
+      frets.push(null);
+      continue;
+    }
+    if (!isNonNegativeInteger(value)) {
+      return [];
+    }
+    frets.push(value);
+  }
+  return frets;
+}
+
+function normalizeMoveableRoots(input: unknown): readonly GuitarMoveableRootV1[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+
+  return input.flatMap((rawRoot): GuitarMoveableRootV1[] => {
+    const root = asRecord(rawRoot);
+    const label = asNonEmptyString(root?.label);
+    if (!root || !label || !isPositiveInteger(root.offset)) {
+      return [];
+    }
+    return [{ label, offset: root.offset }];
+  });
+}
+
+function normalizeImportAdapters(input: unknown): Readonly<Record<string, ImportAdapterDefinitionV1>> {
+  const record = asRecord(input);
+  if (!record) {
+    return {};
+  }
+
+  const adapters: Record<string, ImportAdapterDefinitionV1> = {};
+  for (const [id, value] of Object.entries(record)) {
+    const rawAdapter = asRecord(value);
+    if (!rawAdapter || rawAdapter.schemaVersion !== 1) {
+      continue;
+    }
+    const description = asNonEmptyString(rawAdapter.description);
+    const stringOrder = normalizeGuitarStringOrder(rawAdapter.stringOrder);
+    adapters[id] = {
+      schemaVersion: 1,
+      ...(description ? { description } : {}),
+      ...(stringOrder.length > 0 ? { stringOrder } : {}),
+    };
+  }
+  return adapters;
+}
+
+function normalizeObservedGuitarGzipShape(
+  input: unknown,
+  chordLabel: string,
+  shapeIndex: number,
+  instrumentId: string,
+  sourceId: string,
+): GuitarVoicingSeedV1 | null {
+  const shape = asRecord(input);
+  if (!shape || !Array.isArray(shape.positions) || shape.positions.length !== DEFAULT_GUITAR_STRING_ORDER.length) {
+    return null;
+  }
+
+  const notes = shape.positions.flatMap((position, index): GuitarVoicingSeedNoteV1[] => {
+    const fret = normalizeObservedFret(position);
+    if (fret === null) {
+      return [];
+    }
+
+    const finger = normalizeObservedFingerForString(shape.fingerings, index);
+    return [
+      {
+        string: DEFAULT_GUITAR_STRING_ORDER[index],
+        fret,
+        ...(finger ? { finger } : {}),
+      },
+    ];
+  });
+  if (notes.length === 0) {
+    return null;
+  }
+
+  const ordinal = shapeIndex + 1;
+  return {
+    id: `${sourceId}-${slugify(chordLabel)}-${ordinal}`,
+    instrumentId,
+    label: `${chordLabel} observed ${ordinal}`,
+    chordLabel,
+    rank: 0,
+    source: "observed-gzip",
+    notes,
+  };
+}
+
+function normalizeObservedFret(value: unknown): number | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed || trimmed.toLowerCase() === "x") {
+      return null;
+    }
+    const parsed = Number(trimmed);
+    return isNonNegativeInteger(parsed) ? parsed : null;
+  }
+  return isNonNegativeInteger(value) ? value : null;
+}
+
+function normalizeObservedFingerForString(input: unknown, stringIndex: number): GuitarFingerV1 | null {
+  if (!Array.isArray(input)) {
+    return null;
+  }
+
+  const firstRow = input[0];
+  if (Array.isArray(firstRow) && firstRow.length === DEFAULT_GUITAR_STRING_ORDER.length) {
+    return normalizeObservedFingerValue(firstRow[stringIndex]);
+  }
+
+  return normalizeObservedFinger(input[stringIndex]);
+}
+
+function normalizeObservedFinger(value: unknown): GuitarFingerV1 | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  for (const candidate of value) {
+    const finger = normalizeObservedFingerValue(candidate);
+    if (finger) {
+      return finger;
+    }
+  }
+  return null;
+}
+
+function normalizeObservedFingerValue(value: unknown): GuitarFingerV1 | null {
+  const numeric = typeof value === "string" ? Number(value.trim()) : value;
+  return normalizeGuitarFinger(numeric);
+}
+
+function normalizeGuitarFinger(value: unknown): GuitarFingerV1 | null {
+  return isSafeInteger(value) && GUITAR_FINGERS.has(value as GuitarFingerV1) ? (value as GuitarFingerV1) : null;
+}
+
+function normalizeKeyboardFinger(value: unknown): KeyboardFingerV1 | null {
+  return isSafeInteger(value) && KEYBOARD_FINGERS.has(value as KeyboardFingerV1) ? (value as KeyboardFingerV1) : null;
+}
+
+function normalizeKeyboardHand(value: unknown): KeyboardHandV1 | null {
+  return typeof value === "string" && KEYBOARD_HANDS.has(value as KeyboardHandV1) ? (value as KeyboardHandV1) : null;
+}
+
+function normalizeGuitarShapeFamily(value: unknown): GuitarShapeFamilyV1 | null {
+  return typeof value === "string" && GUITAR_SHAPE_FAMILIES.has(value as GuitarShapeFamilyV1)
+    ? (value as GuitarShapeFamilyV1)
+    : null;
+}
+
+function normalizeStringArray(input: unknown): readonly string[] {
+  return Array.isArray(input) ? input.flatMap((value) => asNonEmptyString(value) ?? []) : [];
+}
+
+function normalizeNumberArray(input: unknown): readonly number[] {
+  return Array.isArray(input) ? input.flatMap((value) => (isSafeInteger(value) ? [value] : [])) : [];
+}
+
+function normalizeGuitarStringOrder(input: unknown): readonly number[] {
+  if (!Array.isArray(input) || input.length !== DEFAULT_GUITAR_STRING_ORDER.length) {
+    return [];
+  }
+
+  const stringOrder = normalizeNumberArray(input);
+  if (
+    stringOrder.length !== DEFAULT_GUITAR_STRING_ORDER.length ||
+    new Set(stringOrder).size !== DEFAULT_GUITAR_STRING_ORDER.length
+  ) {
+    return [];
+  }
+
+  return stringOrder.every((string) => DEFAULT_GUITAR_STRING_ORDER_SET.has(string)) ? stringOrder : [];
+}
+
+function isHarmonicDegree(value: unknown): value is HarmonicDegree {
+  return typeof value === "string" && HARMONIC_DEGREES.has(value as HarmonicDegree);
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return isSafeInteger(value) && value > 0;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return isSafeInteger(value) && value >= 0;
+}
+
+function isSafeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function slugify(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replaceAll("#", "sharp")
+    .replaceAll("/", "-")
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/apps/desktop/src/lib/instrumentKnowledgeData.json
+++ b/apps/desktop/src/lib/instrumentKnowledgeData.json
@@ -1,0 +1,223 @@
+{
+  "schemaVersion": 1,
+  "bundleId": "tuneforge.instrument-knowledge.first-party",
+  "version": "1.0.0",
+  "harmonicDefinitions": {
+    "major": {
+      "id": "major",
+      "label": "Major",
+      "suffix": "",
+      "aliases": ["", "maj", "major"],
+      "tones": [
+        { "degree": "1", "interval": 0 },
+        { "degree": "3", "interval": 4 },
+        { "degree": "5", "interval": 7 }
+      ]
+    },
+    "minor": {
+      "id": "minor",
+      "label": "Minor",
+      "suffix": "m",
+      "aliases": ["min", "minor", "m"],
+      "tones": [
+        { "degree": "1", "interval": 0 },
+        { "degree": "b3", "interval": 3 },
+        { "degree": "5", "interval": 7 }
+      ]
+    },
+    "sus2": {
+      "id": "sus2",
+      "label": "Suspended 2",
+      "suffix": "sus2",
+      "aliases": ["sus2"],
+      "tones": [
+        { "degree": "1", "interval": 0 },
+        { "degree": "2", "interval": 2 },
+        { "degree": "5", "interval": 7 }
+      ]
+    },
+    "sus4": {
+      "id": "sus4",
+      "label": "Suspended 4",
+      "suffix": "sus4",
+      "aliases": ["sus", "sus4"],
+      "tones": [
+        { "degree": "1", "interval": 0 },
+        { "degree": "4", "interval": 5 },
+        { "degree": "5", "interval": 7 }
+      ]
+    },
+    "dim": {
+      "id": "dim",
+      "label": "Diminished",
+      "suffix": "dim",
+      "aliases": ["dim", "diminished"],
+      "tones": [
+        { "degree": "1", "interval": 0 },
+        { "degree": "b3", "interval": 3 },
+        { "degree": "b5", "interval": 6 }
+      ]
+    },
+    "aug": {
+      "id": "aug",
+      "label": "Augmented",
+      "suffix": "aug",
+      "aliases": ["aug", "augmented", "+"],
+      "tones": [
+        { "degree": "1", "interval": 0 },
+        { "degree": "3", "interval": 4 },
+        { "degree": "#5", "interval": 8 }
+      ]
+    },
+    "7": {
+      "id": "7",
+      "label": "Dominant 7",
+      "suffix": "7",
+      "aliases": ["7", "dom7"],
+      "tones": [
+        { "degree": "1", "interval": 0 },
+        { "degree": "3", "interval": 4 },
+        { "degree": "5", "interval": 7 },
+        { "degree": "b7", "interval": 10 }
+      ]
+    },
+    "maj7": {
+      "id": "maj7",
+      "label": "Major 7",
+      "suffix": "maj7",
+      "aliases": ["maj7", "major7"],
+      "tones": [
+        { "degree": "1", "interval": 0 },
+        { "degree": "3", "interval": 4 },
+        { "degree": "5", "interval": 7 },
+        { "degree": "7", "interval": 11 }
+      ]
+    },
+    "m7": {
+      "id": "m7",
+      "label": "Minor 7",
+      "suffix": "m7",
+      "aliases": ["min7", "minor7", "m7"],
+      "tones": [
+        { "degree": "1", "interval": 0 },
+        { "degree": "b3", "interval": 3 },
+        { "degree": "5", "interval": 7 },
+        { "degree": "b7", "interval": 10 }
+      ]
+    },
+    "dim7": {
+      "id": "dim7",
+      "label": "Diminished 7",
+      "suffix": "dim7",
+      "aliases": ["dim7"],
+      "tones": [
+        { "degree": "1", "interval": 0 },
+        { "degree": "b3", "interval": 3 },
+        { "degree": "b5", "interval": 6 },
+        { "degree": "bb7", "interval": 9 }
+      ]
+    },
+    "hdim7": {
+      "id": "hdim7",
+      "label": "Half-diminished 7",
+      "suffix": "m7b5",
+      "aliases": ["hdim7", "half-diminished", "half-diminished7", "min7(b5)", "m7(b5)", "min7b5", "m7b5"],
+      "tones": [
+        { "degree": "1", "interval": 0 },
+        { "degree": "b3", "interval": 3 },
+        { "degree": "b5", "interval": 6 },
+        { "degree": "b7", "interval": 10 }
+      ]
+    }
+  },
+  "instrumentProfiles": {
+    "guitar": {
+      "id": "guitar",
+      "label": "Guitar",
+      "family": "fretted-strings",
+      "executionLayer": "fretboard",
+      "tuning": [
+        { "string": 6, "openPitch": "E2" },
+        { "string": 5, "openPitch": "A2" },
+        { "string": 4, "openPitch": "D3" },
+        { "string": 3, "openPitch": "G3" },
+        { "string": 2, "openPitch": "B3" },
+        { "string": 1, "openPitch": "E4" }
+      ],
+      "fretboard": {
+        "frets": 22,
+        "stringOrder": [6, 5, 4, 3, 2, 1],
+        "canCapo": true,
+        "canRetune": true
+      }
+    }
+  },
+  "voicingSeeds": {
+    "guitar": {
+      "common": [
+        { "id": "c-open", "label": "C open", "chordLabel": "C", "shapeFamily": "C", "rank": 10, "notes": [{ "string": 5, "fret": 3, "finger": 3 }, { "string": 4, "fret": 2, "finger": 2 }, { "string": 3, "fret": 0 }, { "string": 2, "fret": 1, "finger": 1 }, { "string": 1, "fret": 0 }] },
+        { "id": "c-over-e-open", "label": "C/E open", "chordLabel": "C/E", "shapeFamily": "C", "rank": 12, "notes": [{ "string": 6, "fret": 0 }, { "string": 5, "fret": 3, "finger": 3 }, { "string": 4, "fret": 2, "finger": 2 }, { "string": 3, "fret": 0 }, { "string": 2, "fret": 1, "finger": 1 }, { "string": 1, "fret": 0 }] },
+        { "id": "c-over-g-open", "label": "C/G open", "chordLabel": "C/G", "shapeFamily": "C", "rank": 12, "notes": [{ "string": 6, "fret": 3, "finger": 4 }, { "string": 5, "fret": 3, "finger": 3 }, { "string": 4, "fret": 2, "finger": 2 }, { "string": 3, "fret": 0 }, { "string": 2, "fret": 1, "finger": 1 }, { "string": 1, "fret": 0 }] },
+        { "id": "a-open", "label": "A open", "chordLabel": "A", "shapeFamily": "A", "rank": 10, "notes": [{ "string": 5, "fret": 0 }, { "string": 4, "fret": 2, "finger": 1 }, { "string": 3, "fret": 2, "finger": 2 }, { "string": 2, "fret": 2, "finger": 3 }, { "string": 1, "fret": 0 }] },
+        { "id": "a-over-csharp-open", "label": "A/C# open", "chordLabel": "A/C#", "shapeFamily": "A", "rank": 12, "notes": [{ "string": 5, "fret": 4, "finger": 4 }, { "string": 4, "fret": 2, "finger": 1 }, { "string": 3, "fret": 2, "finger": 2 }, { "string": 2, "fret": 2, "finger": 3 }, { "string": 1, "fret": 0 }] },
+        { "id": "d-open", "label": "D open", "chordLabel": "D", "shapeFamily": "D", "rank": 10, "notes": [{ "string": 4, "fret": 0 }, { "string": 3, "fret": 2, "finger": 1 }, { "string": 2, "fret": 3, "finger": 3 }, { "string": 1, "fret": 2, "finger": 2 }] },
+        { "id": "d-over-fsharp-open", "label": "D/F# open", "chordLabel": "D/F#", "shapeFamily": "D", "rank": 12, "notes": [{ "string": 6, "fret": 2, "finger": 1 }, { "string": 4, "fret": 0 }, { "string": 3, "fret": 2, "finger": 2 }, { "string": 2, "fret": 3, "finger": 4 }, { "string": 1, "fret": 2, "finger": 3 }] },
+        { "id": "g-open", "label": "G open", "chordLabel": "G", "shapeFamily": "G", "rank": 10, "notes": [{ "string": 6, "fret": 3, "finger": 2 }, { "string": 5, "fret": 2, "finger": 1 }, { "string": 4, "fret": 0 }, { "string": 3, "fret": 0 }, { "string": 2, "fret": 0 }, { "string": 1, "fret": 3, "finger": 3 }] },
+        { "id": "g-over-b-open", "label": "G/B open", "chordLabel": "G/B", "shapeFamily": "G", "rank": 12, "notes": [{ "string": 5, "fret": 2, "finger": 1 }, { "string": 4, "fret": 0 }, { "string": 3, "fret": 0 }, { "string": 2, "fret": 3, "finger": 2 }, { "string": 1, "fret": 3, "finger": 3 }] },
+        { "id": "g-over-d-open", "label": "G/D open", "chordLabel": "G/D", "shapeFamily": "G", "rank": 12, "notes": [{ "string": 4, "fret": 0 }, { "string": 3, "fret": 0 }, { "string": 2, "fret": 0 }, { "string": 1, "fret": 3, "finger": 3 }] },
+        { "id": "am-open", "label": "Am open", "chordLabel": "Am", "shapeFamily": "A", "rank": 10, "notes": [{ "string": 5, "fret": 0 }, { "string": 4, "fret": 2, "finger": 2 }, { "string": 3, "fret": 2, "finger": 3 }, { "string": 2, "fret": 1, "finger": 1 }, { "string": 1, "fret": 0 }] },
+        { "id": "dm-open", "label": "Dm open", "chordLabel": "Dm", "shapeFamily": "D", "rank": 10, "notes": [{ "string": 4, "fret": 0 }, { "string": 3, "fret": 2, "finger": 2 }, { "string": 2, "fret": 3, "finger": 3 }, { "string": 1, "fret": 1, "finger": 1 }] },
+        { "id": "em-open", "label": "Em open", "chordLabel": "Em", "shapeFamily": "E", "rank": 10, "notes": [{ "string": 6, "fret": 0 }, { "string": 5, "fret": 2, "finger": 2 }, { "string": 4, "fret": 2, "finger": 3 }, { "string": 3, "fret": 0 }, { "string": 2, "fret": 0 }, { "string": 1, "fret": 0 }] },
+        { "id": "am7-open", "label": "Am7 open", "chordLabel": "Am7", "shapeFamily": "A", "rank": 10, "notes": [{ "string": 5, "fret": 0 }, { "string": 4, "fret": 2, "finger": 2 }, { "string": 3, "fret": 0 }, { "string": 2, "fret": 1, "finger": 1 }, { "string": 1, "fret": 0 }] },
+        { "id": "dm7-open", "label": "Dm7 open", "chordLabel": "Dm7", "shapeFamily": "D", "rank": 10, "notes": [{ "string": 4, "fret": 0 }, { "string": 3, "fret": 2, "finger": 2 }, { "string": 2, "fret": 1, "finger": 1 }, { "string": 1, "fret": 1, "finger": 1 }] },
+        { "id": "em7-open", "label": "Em7 open", "chordLabel": "Em7", "shapeFamily": "E", "rank": 10, "notes": [{ "string": 6, "fret": 0 }, { "string": 5, "fret": 2, "finger": 2 }, { "string": 4, "fret": 0 }, { "string": 3, "fret": 0 }, { "string": 2, "fret": 0 }, { "string": 1, "fret": 0 }] },
+        { "id": "f-e-barre", "label": "F E-shape barre", "chordLabel": "F", "shapeFamily": "E", "rank": 10, "notes": [{ "string": 6, "fret": 1, "finger": 1 }, { "string": 5, "fret": 3, "finger": 3 }, { "string": 4, "fret": 3, "finger": 4 }, { "string": 3, "fret": 2, "finger": 2 }, { "string": 2, "fret": 1, "finger": 1 }, { "string": 1, "fret": 1, "finger": 1 }] },
+        { "id": "f-partial", "label": "F partial", "chordLabel": "F", "shapeFamily": "E", "rank": 20, "notes": [{ "string": 4, "fret": 3, "finger": 3 }, { "string": 3, "fret": 2, "finger": 2 }, { "string": 2, "fret": 1, "finger": 1 }, { "string": 1, "fret": 1, "finger": 1 }] },
+        { "id": "cmaj7-open", "label": "Cmaj7 open", "chordLabel": "Cmaj7", "shapeFamily": "C", "rank": 10, "notes": [{ "string": 5, "fret": 3, "finger": 3 }, { "string": 4, "fret": 2, "finger": 2 }, { "string": 3, "fret": 0 }, { "string": 2, "fret": 0 }, { "string": 1, "fret": 0 }] },
+        { "id": "amaj7-open", "label": "Amaj7 open", "chordLabel": "Amaj7", "shapeFamily": "A", "rank": 10, "notes": [{ "string": 5, "fret": 0 }, { "string": 4, "fret": 2, "finger": 2 }, { "string": 3, "fret": 1, "finger": 1 }, { "string": 2, "fret": 2, "finger": 3 }, { "string": 1, "fret": 0 }] },
+        { "id": "dmaj7-open", "label": "Dmaj7 open", "chordLabel": "Dmaj7", "shapeFamily": "D", "rank": 10, "notes": [{ "string": 4, "fret": 0 }, { "string": 3, "fret": 2, "finger": 1 }, { "string": 2, "fret": 2, "finger": 2 }, { "string": 1, "fret": 2, "finger": 3 }] },
+        { "id": "g7-open", "label": "G7 open", "chordLabel": "G7", "shapeFamily": "G", "rank": 10, "notes": [{ "string": 6, "fret": 3, "finger": 3 }, { "string": 5, "fret": 2, "finger": 2 }, { "string": 4, "fret": 0 }, { "string": 3, "fret": 0 }, { "string": 2, "fret": 0 }, { "string": 1, "fret": 1, "finger": 1 }] },
+        { "id": "a7-open", "label": "A7 open", "chordLabel": "A7", "shapeFamily": "A", "rank": 10, "notes": [{ "string": 5, "fret": 0 }, { "string": 4, "fret": 2, "finger": 1 }, { "string": 3, "fret": 0 }, { "string": 2, "fret": 2, "finger": 2 }, { "string": 1, "fret": 0 }] },
+        { "id": "c7-open", "label": "C7 open", "chordLabel": "C7", "shapeFamily": "C", "rank": 10, "notes": [{ "string": 5, "fret": 3, "finger": 3 }, { "string": 4, "fret": 2, "finger": 2 }, { "string": 3, "fret": 3, "finger": 4 }, { "string": 2, "fret": 1, "finger": 1 }, { "string": 1, "fret": 0 }] },
+        { "id": "d7-open", "label": "D7 open", "chordLabel": "D7", "shapeFamily": "D", "rank": 10, "notes": [{ "string": 4, "fret": 0 }, { "string": 3, "fret": 2, "finger": 2 }, { "string": 2, "fret": 1, "finger": 1 }, { "string": 1, "fret": 2, "finger": 3 }] },
+        { "id": "e-open", "label": "E open", "chordLabel": "E", "shapeFamily": "E", "rank": 10, "notes": [{ "string": 6, "fret": 0 }, { "string": 5, "fret": 2, "finger": 2 }, { "string": 4, "fret": 2, "finger": 3 }, { "string": 3, "fret": 1, "finger": 1 }, { "string": 2, "fret": 0 }, { "string": 1, "fret": 0 }] },
+        { "id": "e7-open", "label": "E7 open", "chordLabel": "E7", "shapeFamily": "E", "rank": 10, "notes": [{ "string": 6, "fret": 0 }, { "string": 5, "fret": 2, "finger": 2 }, { "string": 4, "fret": 0 }, { "string": 3, "fret": 1, "finger": 1 }, { "string": 2, "fret": 0 }, { "string": 1, "fret": 0 }] },
+        { "id": "emaj7-open", "label": "Emaj7 open", "chordLabel": "Emaj7", "shapeFamily": "E", "rank": 10, "notes": [{ "string": 6, "fret": 0 }, { "string": 5, "fret": 2, "finger": 3 }, { "string": 4, "fret": 1, "finger": 1 }, { "string": 3, "fret": 1, "finger": 2 }, { "string": 2, "fret": 0 }, { "string": 1, "fret": 0 }] },
+        { "id": "asus2-open", "label": "Asus2 open", "chordLabel": "Asus2", "shapeFamily": "A", "rank": 10, "notes": [{ "string": 5, "fret": 0 }, { "string": 4, "fret": 2, "finger": 1 }, { "string": 3, "fret": 2, "finger": 2 }, { "string": 2, "fret": 0 }, { "string": 1, "fret": 0 }] },
+        { "id": "asus4-open", "label": "Asus4 open", "chordLabel": "Asus4", "shapeFamily": "A", "rank": 10, "notes": [{ "string": 5, "fret": 0 }, { "string": 4, "fret": 2, "finger": 1 }, { "string": 3, "fret": 2, "finger": 2 }, { "string": 2, "fret": 3, "finger": 3 }, { "string": 1, "fret": 0 }] },
+        { "id": "dsus2-open", "label": "Dsus2 open", "chordLabel": "Dsus2", "shapeFamily": "D", "rank": 10, "notes": [{ "string": 4, "fret": 0 }, { "string": 3, "fret": 2, "finger": 2 }, { "string": 2, "fret": 3, "finger": 3 }, { "string": 1, "fret": 0 }] },
+        { "id": "dsus4-open", "label": "Dsus4 open", "chordLabel": "Dsus4", "shapeFamily": "D", "rank": 10, "notes": [{ "string": 4, "fret": 0 }, { "string": 3, "fret": 2, "finger": 1 }, { "string": 2, "fret": 3, "finger": 2 }, { "string": 1, "fret": 3, "finger": 3 }] },
+        { "id": "esus4-open", "label": "Esus4 open", "chordLabel": "Esus4", "shapeFamily": "E", "rank": 10, "notes": [{ "string": 6, "fret": 0 }, { "string": 5, "fret": 2, "finger": 1 }, { "string": 4, "fret": 2, "finger": 2 }, { "string": 3, "fret": 2, "finger": 3 }, { "string": 2, "fret": 0 }, { "string": 1, "fret": 0 }] }
+      ],
+      "moveableDefinitions": [
+        { "id": "e-shape-barre", "label": "E-shape barre", "shapeFamily": "E", "quality": "major", "baseFrets": [0, 2, 2, 1, 0, 0], "rank": 30, "roots": [{ "label": "F", "offset": 1 }, { "label": "F#", "offset": 2 }, { "label": "G", "offset": 3 }, { "label": "Ab", "offset": 4 }, { "label": "A", "offset": 5 }, { "label": "Bb", "offset": 6 }, { "label": "B", "offset": 7 }, { "label": "C", "offset": 8 }] },
+        { "id": "em-shape-barre", "label": "Em-shape barre", "shapeFamily": "E", "quality": "minor", "baseFrets": [0, 2, 2, 0, 0, 0], "rank": 32, "roots": [{ "label": "F", "offset": 1 }, { "label": "F#", "offset": 2 }, { "label": "G", "offset": 3 }, { "label": "Ab", "offset": 4 }, { "label": "A", "offset": 5 }, { "label": "Bb", "offset": 6 }, { "label": "B", "offset": 7 }, { "label": "C", "offset": 8 }] },
+        { "id": "e7-shape-barre", "label": "E7-shape barre", "shapeFamily": "E", "quality": "7", "baseFrets": [0, 2, 0, 1, 0, 0], "rank": 34, "roots": [{ "label": "F", "offset": 1 }, { "label": "F#", "offset": 2 }, { "label": "G", "offset": 3 }, { "label": "Ab", "offset": 4 }, { "label": "A", "offset": 5 }, { "label": "Bb", "offset": 6 }, { "label": "B", "offset": 7 }, { "label": "C", "offset": 8 }] },
+        { "id": "emaj7-shape-barre", "label": "Emaj7-shape barre", "shapeFamily": "E", "quality": "maj7", "baseFrets": [0, 2, 1, 1, 0, 0], "rank": 36, "roots": [{ "label": "F", "offset": 1 }, { "label": "F#", "offset": 2 }, { "label": "G", "offset": 3 }, { "label": "Ab", "offset": 4 }, { "label": "A", "offset": 5 }, { "label": "Bb", "offset": 6 }, { "label": "B", "offset": 7 }, { "label": "C", "offset": 8 }] },
+        { "id": "em7-shape-barre", "label": "Em7-shape barre", "shapeFamily": "E", "quality": "m7", "baseFrets": [0, 2, 0, 0, 0, 0], "rank": 34, "roots": [{ "label": "F", "offset": 1 }, { "label": "F#", "offset": 2 }, { "label": "G", "offset": 3 }, { "label": "Ab", "offset": 4 }, { "label": "A", "offset": 5 }, { "label": "Bb", "offset": 6 }, { "label": "B", "offset": 7 }, { "label": "C", "offset": 8 }] },
+        { "id": "esus4-shape-barre", "label": "Esus4-shape barre", "shapeFamily": "E", "quality": "sus4", "baseFrets": [0, 2, 2, 2, 0, 0], "rank": 38, "roots": [{ "label": "F", "offset": 1 }, { "label": "F#", "offset": 2 }, { "label": "G", "offset": 3 }, { "label": "Ab", "offset": 4 }, { "label": "A", "offset": 5 }, { "label": "Bb", "offset": 6 }, { "label": "B", "offset": 7 }, { "label": "C", "offset": 8 }] },
+        { "id": "a-shape-barre", "label": "A-shape barre", "shapeFamily": "A", "quality": "major", "baseFrets": [null, 0, 2, 2, 2, 0], "rank": 31, "roots": [{ "label": "Bb", "offset": 1 }, { "label": "B", "offset": 2 }, { "label": "C", "offset": 3 }, { "label": "C#", "offset": 4 }, { "label": "D", "offset": 5 }, { "label": "Eb", "offset": 6 }, { "label": "E", "offset": 7 }, { "label": "F", "offset": 8 }] },
+        { "id": "am-shape-barre", "label": "Am-shape barre", "shapeFamily": "A", "quality": "minor", "baseFrets": [null, 0, 2, 2, 1, 0], "rank": 33, "roots": [{ "label": "Bb", "offset": 1 }, { "label": "B", "offset": 2 }, { "label": "C", "offset": 3 }, { "label": "C#", "offset": 4 }, { "label": "D", "offset": 5 }, { "label": "Eb", "offset": 6 }, { "label": "E", "offset": 7 }, { "label": "F", "offset": 8 }] },
+        { "id": "a7-shape-barre", "label": "A7-shape barre", "shapeFamily": "A", "quality": "7", "baseFrets": [null, 0, 2, 0, 2, 0], "rank": 35, "roots": [{ "label": "Bb", "offset": 1 }, { "label": "B", "offset": 2 }, { "label": "C", "offset": 3 }, { "label": "C#", "offset": 4 }, { "label": "D", "offset": 5 }, { "label": "Eb", "offset": 6 }, { "label": "E", "offset": 7 }, { "label": "F", "offset": 8 }] },
+        { "id": "amaj7-shape-barre", "label": "Amaj7-shape barre", "shapeFamily": "A", "quality": "maj7", "baseFrets": [null, 0, 2, 1, 2, 0], "rank": 37, "roots": [{ "label": "Bb", "offset": 1 }, { "label": "B", "offset": 2 }, { "label": "C", "offset": 3 }, { "label": "C#", "offset": 4 }, { "label": "D", "offset": 5 }, { "label": "Eb", "offset": 6 }, { "label": "E", "offset": 7 }, { "label": "F", "offset": 8 }] },
+        { "id": "am7-shape-barre", "label": "Am7-shape barre", "shapeFamily": "A", "quality": "m7", "baseFrets": [null, 0, 2, 0, 1, 0], "rank": 35, "roots": [{ "label": "Bb", "offset": 1 }, { "label": "B", "offset": 2 }, { "label": "C", "offset": 3 }, { "label": "C#", "offset": 4 }, { "label": "D", "offset": 5 }, { "label": "Eb", "offset": 6 }, { "label": "E", "offset": 7 }, { "label": "F", "offset": 8 }] },
+        { "id": "asus2-shape-barre", "label": "Asus2-shape barre", "shapeFamily": "A", "quality": "sus2", "baseFrets": [null, 0, 2, 2, 0, 0], "rank": 38, "roots": [{ "label": "Bb", "offset": 1 }, { "label": "B", "offset": 2 }, { "label": "C", "offset": 3 }, { "label": "C#", "offset": 4 }, { "label": "D", "offset": 5 }, { "label": "Eb", "offset": 6 }, { "label": "E", "offset": 7 }, { "label": "F", "offset": 8 }] },
+        { "id": "asus4-shape-barre", "label": "Asus4-shape barre", "shapeFamily": "A", "quality": "sus4", "baseFrets": [null, 0, 2, 2, 3, 0], "rank": 38, "roots": [{ "label": "Bb", "offset": 1 }, { "label": "B", "offset": 2 }, { "label": "C", "offset": 3 }, { "label": "C#", "offset": 4 }, { "label": "D", "offset": 5 }, { "label": "Eb", "offset": 6 }, { "label": "E", "offset": 7 }, { "label": "F", "offset": 8 }] },
+        { "id": "d-shape-barre", "label": "D-shape barre", "shapeFamily": "D", "quality": "major", "baseFrets": [null, null, 0, 2, 3, 2], "rank": 43, "roots": [{ "label": "Eb", "offset": 1 }, { "label": "E", "offset": 2 }, { "label": "F", "offset": 3 }, { "label": "F#", "offset": 4 }, { "label": "G", "offset": 5 }, { "label": "Ab", "offset": 6 }, { "label": "A", "offset": 7 }] },
+        { "id": "dm-shape-barre", "label": "Dm-shape barre", "shapeFamily": "D", "quality": "minor", "baseFrets": [null, null, 0, 2, 3, 1], "rank": 45, "roots": [{ "label": "Eb", "offset": 1 }, { "label": "E", "offset": 2 }, { "label": "F", "offset": 3 }, { "label": "F#", "offset": 4 }, { "label": "G", "offset": 5 }, { "label": "Ab", "offset": 6 }, { "label": "A", "offset": 7 }] },
+        { "id": "d7-shape-barre", "label": "D7-shape barre", "shapeFamily": "D", "quality": "7", "baseFrets": [null, null, 0, 2, 1, 2], "rank": 47, "roots": [{ "label": "Eb", "offset": 1 }, { "label": "E", "offset": 2 }, { "label": "F", "offset": 3 }, { "label": "F#", "offset": 4 }, { "label": "G", "offset": 5 }, { "label": "Ab", "offset": 6 }, { "label": "A", "offset": 7 }] },
+        { "id": "dmaj7-shape-barre", "label": "Dmaj7-shape barre", "shapeFamily": "D", "quality": "maj7", "baseFrets": [null, null, 0, 2, 2, 2], "rank": 47, "roots": [{ "label": "Eb", "offset": 1 }, { "label": "E", "offset": 2 }, { "label": "F", "offset": 3 }, { "label": "F#", "offset": 4 }, { "label": "G", "offset": 5 }, { "label": "Ab", "offset": 6 }, { "label": "A", "offset": 7 }] },
+        { "id": "dm7-shape-barre", "label": "Dm7-shape barre", "shapeFamily": "D", "quality": "m7", "baseFrets": [null, null, 0, 2, 1, 1], "rank": 47, "roots": [{ "label": "Eb", "offset": 1 }, { "label": "E", "offset": 2 }, { "label": "F", "offset": 3 }, { "label": "F#", "offset": 4 }, { "label": "G", "offset": 5 }, { "label": "Ab", "offset": 6 }, { "label": "A", "offset": 7 }] },
+        { "id": "dsus2-shape-barre", "label": "Dsus2-shape barre", "shapeFamily": "D", "quality": "sus2", "baseFrets": [null, null, 0, 2, 3, 0], "rank": 49, "roots": [{ "label": "Eb", "offset": 1 }, { "label": "E", "offset": 2 }, { "label": "F", "offset": 3 }, { "label": "F#", "offset": 4 }, { "label": "G", "offset": 5 }, { "label": "Ab", "offset": 6 }, { "label": "A", "offset": 7 }] },
+        { "id": "dsus4-shape-barre", "label": "Dsus4-shape barre", "shapeFamily": "D", "quality": "sus4", "baseFrets": [null, null, 0, 2, 3, 3], "rank": 49, "roots": [{ "label": "Eb", "offset": 1 }, { "label": "E", "offset": 2 }, { "label": "F", "offset": 3 }, { "label": "F#", "offset": 4 }, { "label": "G", "offset": 5 }, { "label": "Ab", "offset": 6 }, { "label": "A", "offset": 7 }] }
+      ]
+    }
+  },
+  "importAdapters": {
+    "observedGuitarGzip": {
+      "schemaVersion": 1,
+      "description": "Observed chord-label keyed gzip export shape. Positions are six guitar strings ordered 6 to 1.",
+      "stringOrder": [6, 5, 4, 3, 2, 1]
+    }
+  }
+}

--- a/apps/desktop/src/lib/music.test.ts
+++ b/apps/desktop/src/lib/music.test.ts
@@ -355,6 +355,20 @@ describe("chord parsing and spelling", () => {
 });
 
 describe("guitar chord voicings", () => {
+  it("preserves externalized guitar catalog runtime parity", () => {
+    expect(requireFirstVoicing("C").id).toBe("c-open");
+    expect(requireVoicings("F").map((voicing) => voicing.id).slice(0, 2)).toEqual(["f-e-barre", "f-partial"]);
+    expect(requireFirstVoicing("F#").id).toBe("fsharp-e-shape-barre");
+    expect(
+      requireFirstVoicing("F#", {
+        sourceKey: { pitchClass: 6, mode: "major" },
+        capoFret: 2,
+        useCapoShapes: true,
+        canCapo: true,
+      }).id,
+    ).toBe("e-open-capo-2");
+  });
+
   it("keeps common shapes ordered before generated alternatives", () => {
     const voicings = requireVoicings("C");
     const firstGeneratedIndex = voicings.findIndex((voicing) => voicing.source === "generated");

--- a/apps/desktop/src/lib/music.ts
+++ b/apps/desktop/src/lib/music.ts
@@ -1,3 +1,10 @@
+import {
+  INSTRUMENT_KNOWLEDGE_BUNDLE_V1,
+  type GuitarMoveableVoicingSeedDefinitionV1,
+  type GuitarVoicingSeedV1,
+  type InstrumentProfileV1,
+} from "./instrumentKnowledge";
+
 export type KeyMode = "major" | "minor";
 export type ChordQuality =
   | "major"
@@ -372,7 +379,7 @@ export const DEFAULT_CHORD_DISPLAY_CONTEXT: ChordDisplayContext = {
   canCapo: true,
 };
 
-export const GUITAR_STANDARD_PROFILE: GuitarProfile = {
+const FALLBACK_GUITAR_STANDARD_PROFILE: GuitarProfile = {
   id: "guitar",
   label: "Guitar",
   tuning: [
@@ -388,12 +395,20 @@ export const GUITAR_STANDARD_PROFILE: GuitarProfile = {
   canRetune: true,
 };
 
+export const GUITAR_STANDARD_PROFILE: GuitarProfile =
+  buildGuitarStandardProfile(INSTRUMENT_KNOWLEDGE_BUNDLE_V1.instrumentProfiles.guitar) ??
+  FALLBACK_GUITAR_STANDARD_PROFILE;
+
 export const INSTRUMENT_PROFILES = {
   guitar: GUITAR_STANDARD_PROFILE,
 } as const;
 
-const GUITAR_TEMPLATE_STRINGS = [6, 5, 4, 3, 2, 1] as const;
-const GUITAR_TEMPLATE_QUALITY_SUFFIXES = {
+const FALLBACK_GUITAR_TEMPLATE_STRINGS = [6, 5, 4, 3, 2, 1] as const;
+const GUITAR_TEMPLATE_STRINGS =
+  INSTRUMENT_KNOWLEDGE_BUNDLE_V1.instrumentProfiles.guitar?.fretboard?.stringOrder.length
+    ? INSTRUMENT_KNOWLEDGE_BUNDLE_V1.instrumentProfiles.guitar.fretboard.stringOrder
+    : FALLBACK_GUITAR_TEMPLATE_STRINGS;
+const GUITAR_TEMPLATE_QUALITY_SUFFIXES: Readonly<Record<ChordSpellingQuality, string>> = {
   major: "",
   minor: "m",
   "7": "7",
@@ -402,734 +417,114 @@ const GUITAR_TEMPLATE_QUALITY_SUFFIXES = {
   sus2: "sus2",
   sus4: "sus4",
   dim: "dim",
-} as const;
-type GuitarCommonTemplateQuality = keyof typeof GUITAR_TEMPLATE_QUALITY_SUFFIXES;
-
-type GuitarMoveableRoot = {
-  label: string;
-  offset: number;
+  aug: "aug",
+  dim7: "dim7",
+  hdim7: "m7b5",
 };
 
-const E_SHAPE_BARRE_ROOTS: readonly GuitarMoveableRoot[] = [
-  { label: "F", offset: 1 },
-  { label: "F#", offset: 2 },
-  { label: "G", offset: 3 },
-  { label: "Ab", offset: 4 },
-  { label: "A", offset: 5 },
-  { label: "Bb", offset: 6 },
-  { label: "B", offset: 7 },
-  { label: "C", offset: 8 },
-] as const;
+export const GUITAR_COMMON_VOICING_TEMPLATES: readonly GuitarVoicingTemplate[] = buildGuitarCommonVoicingTemplates();
 
-const A_SHAPE_BARRE_ROOTS: readonly GuitarMoveableRoot[] = [
-  { label: "Bb", offset: 1 },
-  { label: "B", offset: 2 },
-  { label: "C", offset: 3 },
-  { label: "C#", offset: 4 },
-  { label: "D", offset: 5 },
-  { label: "Eb", offset: 6 },
-  { label: "E", offset: 7 },
-  { label: "F", offset: 8 },
-] as const;
+function buildGuitarStandardProfile(profile: InstrumentProfileV1 | undefined): GuitarProfile | null {
+  if (!profile || profile.id !== "guitar" || !profile.fretboard || !profile.tuning?.length) {
+    return null;
+  }
 
-const D_SHAPE_BARRE_ROOTS: readonly GuitarMoveableRoot[] = [
-  { label: "Eb", offset: 1 },
-  { label: "E", offset: 2 },
-  { label: "F", offset: 3 },
-  { label: "F#", offset: 4 },
-  { label: "G", offset: 5 },
-  { label: "Ab", offset: 6 },
-  { label: "A", offset: 7 },
-] as const;
+  const tuning = profile.tuning.flatMap((stringTuning): GuitarStringTuning[] => {
+    try {
+      return [
+        {
+          string: stringTuning.string,
+          openPitch: parsePitchRequired(stringTuning.openPitch),
+        },
+      ];
+    } catch {
+      return [];
+    }
+  });
+  if (tuning.length !== profile.tuning.length) {
+    return null;
+  }
 
-export const GUITAR_COMMON_VOICING_TEMPLATES: readonly GuitarVoicingTemplate[] = [
-  {
-    id: "c-open",
-    label: "C open",
-    shapeChordLabel: "C",
-    shapeFamily: "C",
-    rank: 10,
-    notes: [
-      { string: 5, fret: 3, finger: 3 },
-      { string: 4, fret: 2, finger: 2 },
-      { string: 3, fret: 0 },
-      { string: 2, fret: 1, finger: 1 },
-      { string: 1, fret: 0 },
-    ],
-  },
-  {
-    id: "c-over-e-open",
-    label: "C/E open",
-    shapeChordLabel: "C/E",
-    shapeFamily: "C",
-    rank: 12,
-    notes: [
-      { string: 6, fret: 0 },
-      { string: 5, fret: 3, finger: 3 },
-      { string: 4, fret: 2, finger: 2 },
-      { string: 3, fret: 0 },
-      { string: 2, fret: 1, finger: 1 },
-      { string: 1, fret: 0 },
-    ],
-  },
-  {
-    id: "c-over-g-open",
-    label: "C/G open",
-    shapeChordLabel: "C/G",
-    shapeFamily: "C",
-    rank: 12,
-    notes: [
-      { string: 6, fret: 3, finger: 4 },
-      { string: 5, fret: 3, finger: 3 },
-      { string: 4, fret: 2, finger: 2 },
-      { string: 3, fret: 0 },
-      { string: 2, fret: 1, finger: 1 },
-      { string: 1, fret: 0 },
-    ],
-  },
-  {
-    id: "a-open",
-    label: "A open",
-    shapeChordLabel: "A",
-    shapeFamily: "A",
-    rank: 10,
-    notes: [
-      { string: 5, fret: 0 },
-      { string: 4, fret: 2, finger: 1 },
-      { string: 3, fret: 2, finger: 2 },
-      { string: 2, fret: 2, finger: 3 },
-      { string: 1, fret: 0 },
-    ],
-  },
-  {
-    id: "a-over-csharp-open",
-    label: "A/C# open",
-    shapeChordLabel: "A/C#",
-    shapeFamily: "A",
-    rank: 12,
-    notes: [
-      { string: 5, fret: 4, finger: 4 },
-      { string: 4, fret: 2, finger: 1 },
-      { string: 3, fret: 2, finger: 2 },
-      { string: 2, fret: 2, finger: 3 },
-      { string: 1, fret: 0 },
-    ],
-  },
-  {
-    id: "d-open",
-    label: "D open",
-    shapeChordLabel: "D",
-    shapeFamily: "D",
-    rank: 10,
-    notes: [
-      { string: 4, fret: 0 },
-      { string: 3, fret: 2, finger: 1 },
-      { string: 2, fret: 3, finger: 3 },
-      { string: 1, fret: 2, finger: 2 },
-    ],
-  },
-  {
-    id: "d-over-fsharp-open",
-    label: "D/F# open",
-    shapeChordLabel: "D/F#",
-    shapeFamily: "D",
-    rank: 12,
-    notes: [
-      { string: 6, fret: 2, finger: 1 },
-      { string: 4, fret: 0 },
-      { string: 3, fret: 2, finger: 2 },
-      { string: 2, fret: 3, finger: 4 },
-      { string: 1, fret: 2, finger: 3 },
-    ],
-  },
-  {
-    id: "g-open",
-    label: "G open",
-    shapeChordLabel: "G",
-    shapeFamily: "G",
-    rank: 10,
-    notes: [
-      { string: 6, fret: 3, finger: 2 },
-      { string: 5, fret: 2, finger: 1 },
-      { string: 4, fret: 0 },
-      { string: 3, fret: 0 },
-      { string: 2, fret: 0 },
-      { string: 1, fret: 3, finger: 3 },
-    ],
-  },
-  {
-    id: "g-over-b-open",
-    label: "G/B open",
-    shapeChordLabel: "G/B",
-    shapeFamily: "G",
-    rank: 12,
-    notes: [
-      { string: 5, fret: 2, finger: 1 },
-      { string: 4, fret: 0 },
-      { string: 3, fret: 0 },
-      { string: 2, fret: 3, finger: 2 },
-      { string: 1, fret: 3, finger: 3 },
-    ],
-  },
-  {
-    id: "g-over-d-open",
-    label: "G/D open",
-    shapeChordLabel: "G/D",
-    shapeFamily: "G",
-    rank: 12,
-    notes: [
-      { string: 4, fret: 0 },
-      { string: 3, fret: 0 },
-      { string: 2, fret: 0 },
-      { string: 1, fret: 3, finger: 3 },
-    ],
-  },
-  {
-    id: "am-open",
-    label: "Am open",
-    shapeChordLabel: "Am",
-    shapeFamily: "A",
-    rank: 10,
-    notes: [
-      { string: 5, fret: 0 },
-      { string: 4, fret: 2, finger: 2 },
-      { string: 3, fret: 2, finger: 3 },
-      { string: 2, fret: 1, finger: 1 },
-      { string: 1, fret: 0 },
-    ],
-  },
-  {
-    id: "dm-open",
-    label: "Dm open",
-    shapeChordLabel: "Dm",
-    shapeFamily: "D",
-    rank: 10,
-    notes: [
-      { string: 4, fret: 0 },
-      { string: 3, fret: 2, finger: 2 },
-      { string: 2, fret: 3, finger: 3 },
-      { string: 1, fret: 1, finger: 1 },
-    ],
-  },
-  {
-    id: "em-open",
-    label: "Em open",
-    shapeChordLabel: "Em",
-    shapeFamily: "E",
-    rank: 10,
-    notes: [
-      { string: 6, fret: 0 },
-      { string: 5, fret: 2, finger: 2 },
-      { string: 4, fret: 2, finger: 3 },
-      { string: 3, fret: 0 },
-      { string: 2, fret: 0 },
-      { string: 1, fret: 0 },
-    ],
-  },
-  {
-    id: "am7-open",
-    label: "Am7 open",
-    shapeChordLabel: "Am7",
-    shapeFamily: "A",
-    rank: 10,
-    notes: [
-      { string: 5, fret: 0 },
-      { string: 4, fret: 2, finger: 2 },
-      { string: 3, fret: 0 },
-      { string: 2, fret: 1, finger: 1 },
-      { string: 1, fret: 0 },
-    ],
-  },
-  {
-    id: "dm7-open",
-    label: "Dm7 open",
-    shapeChordLabel: "Dm7",
-    shapeFamily: "D",
-    rank: 10,
-    notes: [
-      { string: 4, fret: 0 },
-      { string: 3, fret: 2, finger: 2 },
-      { string: 2, fret: 1, finger: 1 },
-      { string: 1, fret: 1, finger: 1 },
-    ],
-  },
-  {
-    id: "em7-open",
-    label: "Em7 open",
-    shapeChordLabel: "Em7",
-    shapeFamily: "E",
-    rank: 10,
-    notes: [
-      { string: 6, fret: 0 },
-      { string: 5, fret: 2, finger: 2 },
-      { string: 4, fret: 0 },
-      { string: 3, fret: 0 },
-      { string: 2, fret: 0 },
-      { string: 1, fret: 0 },
-    ],
-  },
-  {
-    id: "f-e-barre",
-    label: "F E-shape barre",
-    shapeChordLabel: "F",
-    shapeFamily: "E",
-    rank: 10,
-    notes: [
-      { string: 6, fret: 1, finger: 1 },
-      { string: 5, fret: 3, finger: 3 },
-      { string: 4, fret: 3, finger: 4 },
-      { string: 3, fret: 2, finger: 2 },
-      { string: 2, fret: 1, finger: 1 },
-      { string: 1, fret: 1, finger: 1 },
-    ],
-  },
-  {
-    id: "f-partial",
-    label: "F partial",
-    shapeChordLabel: "F",
-    shapeFamily: "E",
-    rank: 20,
-    notes: [
-      { string: 4, fret: 3, finger: 3 },
-      { string: 3, fret: 2, finger: 2 },
-      { string: 2, fret: 1, finger: 1 },
-      { string: 1, fret: 1, finger: 1 },
-    ],
-  },
-  {
-    id: "cmaj7-open",
-    label: "Cmaj7 open",
-    shapeChordLabel: "Cmaj7",
-    shapeFamily: "C",
-    rank: 10,
-    notes: [
-      { string: 5, fret: 3, finger: 3 },
-      { string: 4, fret: 2, finger: 2 },
-      { string: 3, fret: 0 },
-      { string: 2, fret: 0 },
-      { string: 1, fret: 0 },
-    ],
-  },
-  {
-    id: "amaj7-open",
-    label: "Amaj7 open",
-    shapeChordLabel: "Amaj7",
-    shapeFamily: "A",
-    rank: 10,
-    notes: [
-      { string: 5, fret: 0 },
-      { string: 4, fret: 2, finger: 2 },
-      { string: 3, fret: 1, finger: 1 },
-      { string: 2, fret: 2, finger: 3 },
-      { string: 1, fret: 0 },
-    ],
-  },
-  {
-    id: "dmaj7-open",
-    label: "Dmaj7 open",
-    shapeChordLabel: "Dmaj7",
-    shapeFamily: "D",
-    rank: 10,
-    notes: [
-      { string: 4, fret: 0 },
-      { string: 3, fret: 2, finger: 1 },
-      { string: 2, fret: 2, finger: 2 },
-      { string: 1, fret: 2, finger: 3 },
-    ],
-  },
-  {
-    id: "g7-open",
-    label: "G7 open",
-    shapeChordLabel: "G7",
-    shapeFamily: "G",
-    rank: 10,
-    notes: [
-      { string: 6, fret: 3, finger: 3 },
-      { string: 5, fret: 2, finger: 2 },
-      { string: 4, fret: 0 },
-      { string: 3, fret: 0 },
-      { string: 2, fret: 0 },
-      { string: 1, fret: 1, finger: 1 },
-    ],
-  },
-  {
-    id: "a7-open",
-    label: "A7 open",
-    shapeChordLabel: "A7",
-    shapeFamily: "A",
-    rank: 10,
-    notes: [
-      { string: 5, fret: 0 },
-      { string: 4, fret: 2, finger: 1 },
-      { string: 3, fret: 0 },
-      { string: 2, fret: 2, finger: 2 },
-      { string: 1, fret: 0 },
-    ],
-  },
-  {
-    id: "c7-open",
-    label: "C7 open",
-    shapeChordLabel: "C7",
-    shapeFamily: "C",
-    rank: 10,
-    notes: [
-      { string: 5, fret: 3, finger: 3 },
-      { string: 4, fret: 2, finger: 2 },
-      { string: 3, fret: 3, finger: 4 },
-      { string: 2, fret: 1, finger: 1 },
-      { string: 1, fret: 0 },
-    ],
-  },
-  {
-    id: "d7-open",
-    label: "D7 open",
-    shapeChordLabel: "D7",
-    shapeFamily: "D",
-    rank: 10,
-    notes: [
-      { string: 4, fret: 0 },
-      { string: 3, fret: 2, finger: 2 },
-      { string: 2, fret: 1, finger: 1 },
-      { string: 1, fret: 2, finger: 3 },
-    ],
-  },
-  {
-    id: "e-open",
-    label: "E open",
-    shapeChordLabel: "E",
-    shapeFamily: "E",
-    rank: 10,
-    notes: [
-      { string: 6, fret: 0 },
-      { string: 5, fret: 2, finger: 2 },
-      { string: 4, fret: 2, finger: 3 },
-      { string: 3, fret: 1, finger: 1 },
-      { string: 2, fret: 0 },
-      { string: 1, fret: 0 },
-    ],
-  },
-  {
-    id: "e7-open",
-    label: "E7 open",
-    shapeChordLabel: "E7",
-    shapeFamily: "E",
-    rank: 10,
-    notes: [
-      { string: 6, fret: 0 },
-      { string: 5, fret: 2, finger: 2 },
-      { string: 4, fret: 0 },
-      { string: 3, fret: 1, finger: 1 },
-      { string: 2, fret: 0 },
-      { string: 1, fret: 0 },
-    ],
-  },
-  {
-    id: "emaj7-open",
-    label: "Emaj7 open",
-    shapeChordLabel: "Emaj7",
-    shapeFamily: "E",
-    rank: 10,
-    notes: [
-      { string: 6, fret: 0 },
-      { string: 5, fret: 2, finger: 3 },
-      { string: 4, fret: 1, finger: 1 },
-      { string: 3, fret: 1, finger: 2 },
-      { string: 2, fret: 0 },
-      { string: 1, fret: 0 },
-    ],
-  },
-  {
-    id: "asus2-open",
-    label: "Asus2 open",
-    shapeChordLabel: "Asus2",
-    shapeFamily: "A",
-    rank: 10,
-    notes: [
-      { string: 5, fret: 0 },
-      { string: 4, fret: 2, finger: 1 },
-      { string: 3, fret: 2, finger: 2 },
-      { string: 2, fret: 0 },
-      { string: 1, fret: 0 },
-    ],
-  },
-  {
-    id: "asus4-open",
-    label: "Asus4 open",
-    shapeChordLabel: "Asus4",
-    shapeFamily: "A",
-    rank: 10,
-    notes: [
-      { string: 5, fret: 0 },
-      { string: 4, fret: 2, finger: 1 },
-      { string: 3, fret: 2, finger: 2 },
-      { string: 2, fret: 3, finger: 3 },
-      { string: 1, fret: 0 },
-    ],
-  },
-  {
-    id: "dsus2-open",
-    label: "Dsus2 open",
-    shapeChordLabel: "Dsus2",
-    shapeFamily: "D",
-    rank: 10,
-    notes: [
-      { string: 4, fret: 0 },
-      { string: 3, fret: 2, finger: 2 },
-      { string: 2, fret: 3, finger: 3 },
-      { string: 1, fret: 0 },
-    ],
-  },
-  {
-    id: "dsus4-open",
-    label: "Dsus4 open",
-    shapeChordLabel: "Dsus4",
-    shapeFamily: "D",
-    rank: 10,
-    notes: [
-      { string: 4, fret: 0 },
-      { string: 3, fret: 2, finger: 1 },
-      { string: 2, fret: 3, finger: 2 },
-      { string: 1, fret: 3, finger: 3 },
-    ],
-  },
-  {
-    id: "esus4-open",
-    label: "Esus4 open",
-    shapeChordLabel: "Esus4",
-    shapeFamily: "E",
-    rank: 10,
-    notes: [
-      { string: 6, fret: 0 },
-      { string: 5, fret: 2, finger: 1 },
-      { string: 4, fret: 2, finger: 2 },
-      { string: 3, fret: 2, finger: 3 },
-      { string: 2, fret: 0 },
-      { string: 1, fret: 0 },
-    ],
-  },
-  ...buildMoveableGuitarTemplates(),
-] as const;
+  return {
+    id: "guitar",
+    label: profile.label,
+    tuning,
+    frets: profile.fretboard.frets,
+    canCapo: profile.fretboard.canCapo,
+    canRetune: profile.fretboard.canRetune,
+  };
+}
 
-type GuitarMoveableTemplateDefinition = {
-  id: string;
-  label: string;
-  shapeFamily: GuitarShapeFamily;
-  quality: GuitarCommonTemplateQuality;
-  baseFrets: readonly (number | null)[];
-  rank: number;
-  roots: readonly GuitarMoveableRoot[];
-};
+function buildGuitarCommonVoicingTemplates(): readonly GuitarVoicingTemplate[] {
+  const guitarSeeds = INSTRUMENT_KNOWLEDGE_BUNDLE_V1.voicingSeeds.guitar;
+  if (!guitarSeeds) {
+    return [];
+  }
 
-function buildMoveableGuitarTemplates(): readonly GuitarVoicingTemplate[] {
-  const definitions: readonly GuitarMoveableTemplateDefinition[] = [
-    {
-      id: "e-shape-barre",
-      label: "E-shape barre",
-      shapeFamily: "E",
-      quality: "major",
-      baseFrets: [0, 2, 2, 1, 0, 0],
-      rank: 30,
-      roots: E_SHAPE_BARRE_ROOTS,
-    },
-    {
-      id: "em-shape-barre",
-      label: "Em-shape barre",
-      shapeFamily: "E",
-      quality: "minor",
-      baseFrets: [0, 2, 2, 0, 0, 0],
-      rank: 32,
-      roots: E_SHAPE_BARRE_ROOTS,
-    },
-    {
-      id: "e7-shape-barre",
-      label: "E7-shape barre",
-      shapeFamily: "E",
-      quality: "7",
-      baseFrets: [0, 2, 0, 1, 0, 0],
-      rank: 34,
-      roots: E_SHAPE_BARRE_ROOTS,
-    },
-    {
-      id: "emaj7-shape-barre",
-      label: "Emaj7-shape barre",
-      shapeFamily: "E",
-      quality: "maj7",
-      baseFrets: [0, 2, 1, 1, 0, 0],
-      rank: 36,
-      roots: E_SHAPE_BARRE_ROOTS,
-    },
-    {
-      id: "em7-shape-barre",
-      label: "Em7-shape barre",
-      shapeFamily: "E",
-      quality: "m7",
-      baseFrets: [0, 2, 0, 0, 0, 0],
-      rank: 34,
-      roots: E_SHAPE_BARRE_ROOTS,
-    },
-    {
-      id: "esus4-shape-barre",
-      label: "Esus4-shape barre",
-      shapeFamily: "E",
-      quality: "sus4",
-      baseFrets: [0, 2, 2, 2, 0, 0],
-      rank: 38,
-      roots: E_SHAPE_BARRE_ROOTS,
-    },
-    {
-      id: "a-shape-barre",
-      label: "A-shape barre",
-      shapeFamily: "A",
-      quality: "major",
-      baseFrets: [null, 0, 2, 2, 2, 0],
-      rank: 31,
-      roots: A_SHAPE_BARRE_ROOTS,
-    },
-    {
-      id: "am-shape-barre",
-      label: "Am-shape barre",
-      shapeFamily: "A",
-      quality: "minor",
-      baseFrets: [null, 0, 2, 2, 1, 0],
-      rank: 33,
-      roots: A_SHAPE_BARRE_ROOTS,
-    },
-    {
-      id: "a7-shape-barre",
-      label: "A7-shape barre",
-      shapeFamily: "A",
-      quality: "7",
-      baseFrets: [null, 0, 2, 0, 2, 0],
-      rank: 35,
-      roots: A_SHAPE_BARRE_ROOTS,
-    },
-    {
-      id: "amaj7-shape-barre",
-      label: "Amaj7-shape barre",
-      shapeFamily: "A",
-      quality: "maj7",
-      baseFrets: [null, 0, 2, 1, 2, 0],
-      rank: 37,
-      roots: A_SHAPE_BARRE_ROOTS,
-    },
-    {
-      id: "am7-shape-barre",
-      label: "Am7-shape barre",
-      shapeFamily: "A",
-      quality: "m7",
-      baseFrets: [null, 0, 2, 0, 1, 0],
-      rank: 35,
-      roots: A_SHAPE_BARRE_ROOTS,
-    },
-    {
-      id: "asus2-shape-barre",
-      label: "Asus2-shape barre",
-      shapeFamily: "A",
-      quality: "sus2",
-      baseFrets: [null, 0, 2, 2, 0, 0],
-      rank: 38,
-      roots: A_SHAPE_BARRE_ROOTS,
-    },
-    {
-      id: "asus4-shape-barre",
-      label: "Asus4-shape barre",
-      shapeFamily: "A",
-      quality: "sus4",
-      baseFrets: [null, 0, 2, 2, 3, 0],
-      rank: 38,
-      roots: A_SHAPE_BARRE_ROOTS,
-    },
-    {
-      id: "d-shape-barre",
-      label: "D-shape barre",
-      shapeFamily: "D",
-      quality: "major",
-      baseFrets: [null, null, 0, 2, 3, 2],
-      rank: 43,
-      roots: D_SHAPE_BARRE_ROOTS,
-    },
-    {
-      id: "dm-shape-barre",
-      label: "Dm-shape barre",
-      shapeFamily: "D",
-      quality: "minor",
-      baseFrets: [null, null, 0, 2, 3, 1],
-      rank: 45,
-      roots: D_SHAPE_BARRE_ROOTS,
-    },
-    {
-      id: "d7-shape-barre",
-      label: "D7-shape barre",
-      shapeFamily: "D",
-      quality: "7",
-      baseFrets: [null, null, 0, 2, 1, 2],
-      rank: 47,
-      roots: D_SHAPE_BARRE_ROOTS,
-    },
-    {
-      id: "dmaj7-shape-barre",
-      label: "Dmaj7-shape barre",
-      shapeFamily: "D",
-      quality: "maj7",
-      baseFrets: [null, null, 0, 2, 2, 2],
-      rank: 47,
-      roots: D_SHAPE_BARRE_ROOTS,
-    },
-    {
-      id: "dm7-shape-barre",
-      label: "Dm7-shape barre",
-      shapeFamily: "D",
-      quality: "m7",
-      baseFrets: [null, null, 0, 2, 1, 1],
-      rank: 47,
-      roots: D_SHAPE_BARRE_ROOTS,
-    },
-    {
-      id: "dsus2-shape-barre",
-      label: "Dsus2-shape barre",
-      shapeFamily: "D",
-      quality: "sus2",
-      baseFrets: [null, null, 0, 2, 3, 0],
-      rank: 49,
-      roots: D_SHAPE_BARRE_ROOTS,
-    },
-    {
-      id: "dsus4-shape-barre",
-      label: "Dsus4-shape barre",
-      shapeFamily: "D",
-      quality: "sus4",
-      baseFrets: [null, null, 0, 2, 3, 3],
-      rank: 49,
-      roots: D_SHAPE_BARRE_ROOTS,
-    },
+  return [
+    ...guitarSeeds.common.flatMap((seed) => {
+      const template = buildCommonGuitarTemplate(seed);
+      return template ? [template] : [];
+    }),
+    ...buildMoveableGuitarTemplates(guitarSeeds.moveableDefinitions),
   ];
+}
 
-  return definitions.flatMap((definition) =>
-    definition.roots.map((root) => {
-      const shapeChordLabel = formatGuitarTemplateChordLabel(root.label, definition.quality);
+function buildCommonGuitarTemplate(seed: GuitarVoicingSeedV1): GuitarVoicingTemplate | null {
+  if (!seed.shapeFamily) {
+    return null;
+  }
+
+  const notes = seed.notes.map((note): GuitarVoicingTemplateNote => ({
+    string: note.string,
+    fret: note.fret,
+    ...(note.finger ? { finger: note.finger } : {}),
+  }));
+  return {
+    id: seed.id,
+    label: seed.label,
+    shapeChordLabel: seed.chordLabel,
+    shapeFamily: seed.shapeFamily,
+    rank: seed.rank,
+    notes,
+  };
+}
+
+function buildMoveableGuitarTemplates(
+  definitions: readonly GuitarMoveableVoicingSeedDefinitionV1[],
+): readonly GuitarVoicingTemplate[] {
+  return definitions.flatMap((definition) => {
+    const quality = definition.quality;
+    if (!isChordSpellingQuality(quality) || definition.baseFrets.length !== GUITAR_TEMPLATE_STRINGS.length) {
+      return [];
+    }
+
+    return definition.roots.map((root) => {
+      const shapeChordLabel = formatGuitarTemplateChordLabel(root.label, quality);
       return {
-        id: `${formatGuitarTemplateId(shapeChordLabel)}-${definition.id}`,
-        label: `${shapeChordLabel} ${definition.label}`,
+        id: formatGuitarTemplateId(shapeChordLabel) + "-" + definition.id,
+        label: shapeChordLabel + " " + definition.label,
         shapeChordLabel,
         shapeFamily: definition.shapeFamily,
         rank: definition.rank + root.offset,
-        notes: definition.baseFrets.flatMap((fret, index) =>
-          typeof fret === "number" && typeof GUITAR_TEMPLATE_STRINGS[index] === "number"
+        notes: definition.baseFrets.flatMap((fret, index): GuitarVoicingTemplateNote[] => {
+          const string = GUITAR_TEMPLATE_STRINGS[index];
+          return typeof fret === "number" && typeof string === "number"
             ? [
                 {
-                  string: GUITAR_TEMPLATE_STRINGS[index],
+                  string,
                   fret: fret + root.offset,
                 },
               ]
-            : [],
-        ),
+            : [];
+        }),
       };
-    }),
-  );
+    });
+  });
 }
 
-function formatGuitarTemplateChordLabel(rootLabel: string, quality: GuitarCommonTemplateQuality): string {
-  return `${rootLabel}${GUITAR_TEMPLATE_QUALITY_SUFFIXES[quality]}`;
+function formatGuitarTemplateChordLabel(rootLabel: string, quality: ChordSpellingQuality): string {
+  return rootLabel + GUITAR_TEMPLATE_QUALITY_SUFFIXES[quality];
 }
 
 function formatGuitarTemplateId(label: string): string {


### PR DESCRIPTION
## Summary
- Closes #272.
- Move first-party Chord Dictionary guitar knowledge into a versioned local instrument bundle.
- Add universal harmonic definitions plus fretboard, keyboard, and button-board seed/profile schema.
- Keep guitar runtime behavior loading from normalized local data while preserving voicing parity.

## Testing
- `pnpm --filter @tuneforge/desktop test -- src/lib/instrumentKnowledge.test.ts src/lib/music.test.ts`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop test`
- `git diff --check`
- reviewer: fixed data-integrity findings in base-fret and string-order normalization
- tuneforge_contract_guard: clean
