### PR TITLE
feat: persist chord dictionary shape choices

### DIFF
--- a/apps/desktop/src/App.tools-chord-dictionary.test.tsx
+++ b/apps/desktop/src/App.tools-chord-dictionary.test.tsx
@@ -11,14 +11,30 @@ import {
   type ChordDictionaryFollowProjectContext,
 } from "./features/projects/chordDictionaryFollowContext";
 import {
+  CHORD_DICTIONARY_PREFERENCES_STORAGE_KEY,
+  writeGlobalChordDictionaryPreferredShape,
+  writeProjectChordDictionaryPreferredShape,
+  type ChordDictionaryPreferenceContext,
+} from "./features/tools/chordDictionaryPreferences";
+import {
   PlaybackContext,
   type PlaybackContextValue,
   type ProjectPlaybackSession,
 } from "./features/projects/playback-context";
 
+const DICTIONARY_SHAPE_GROUP_NAME = "Global guitar shape preference choices";
+const LIVE_SHAPE_GROUP_NAME = "Project guitar shape preference choices";
+
+function renderChordDictionaryView() {
+  const view = renderApp(["/tools?tool=chord-dictionary"]);
+  return {
+    ...view,
+    findHeading: () => screen.findByRole("heading", { name: "Chord Dictionary" }),
+  };
+}
+
 function renderChordDictionary() {
-  renderApp(["/tools?tool=chord-dictionary"]);
-  return screen.findByRole("heading", { name: "Chord Dictionary" });
+  return renderChordDictionaryView().findHeading();
 }
 
 const sourceTimeline: ChordSegmentSchema[] = [
@@ -75,6 +91,28 @@ const displayedTimeline: ChordSegmentSchema[] = [
   },
 ];
 
+const cTimeline: ChordSegmentSchema[] = [
+  {
+    confidence: 0.88,
+    end_seconds: 16,
+    label: "C",
+    pitch_class: 0,
+    quality: "major",
+    start_seconds: 0,
+  },
+];
+
+const dTimeline: ChordSegmentSchema[] = [
+  {
+    confidence: 0.86,
+    end_seconds: 16,
+    label: "D",
+    pitch_class: 2,
+    quality: "major",
+    start_seconds: 0,
+  },
+];
+
 function makeFollowProject(
   overrides: Partial<ChordDictionaryFollowProjectContext> = {},
 ): ChordDictionaryFollowProjectContext {
@@ -90,6 +128,38 @@ function makeFollowProject(
     visualCapoSemitoneShift: 0,
     ...overrides,
   });
+}
+
+function makeDictionaryShapePreferenceContext(
+  overrides: Partial<ChordDictionaryPreferenceContext> = {},
+): ChordDictionaryPreferenceContext {
+  return {
+    capoFret: 0,
+    chordLabel: "C",
+    displayedKeyLabel: null,
+    instrumentId: "guitar",
+    projectId: null,
+    sourceKeyLabel: null,
+    transposeSemitones: 0,
+    useCapoShapes: false,
+    ...overrides,
+  };
+}
+
+function makeLiveShapePreferenceContext(
+  overrides: Partial<ChordDictionaryPreferenceContext> = {},
+): ChordDictionaryPreferenceContext {
+  return {
+    capoFret: 0,
+    chordLabel: "A",
+    displayedKeyLabel: "A",
+    instrumentId: "guitar",
+    projectId: null,
+    sourceKeyLabel: "G",
+    transposeSemitones: 2,
+    useCapoShapes: false,
+    ...overrides,
+  };
 }
 
 function makePlaybackSession(
@@ -190,6 +260,7 @@ function renderChordDictionaryPlaybackHarness({
     rerenderWithPlayback: (nextPlayback: PlaybackContextValue) => {
       view.rerender(renderTree(nextPlayback));
     },
+    unmount: view.unmount,
   };
 }
 
@@ -240,6 +311,25 @@ function getShapeCard(label: string) {
     throw new Error(`Expected ${label} label inside a shape card`);
   }
   return shapeCard as HTMLElement;
+}
+
+function getShapeChoiceButtons(groupName: string) {
+  return within(screen.getByRole("group", { name: groupName })).getAllByRole("button");
+}
+
+function expectFirstShapeChoice(groupName: string, label: string) {
+  const shapeButtons = getShapeChoiceButtons(groupName);
+  expect(shapeButtons[0]).toHaveTextContent(label);
+  expect(shapeButtons[0]).toHaveAttribute("aria-pressed", "true");
+}
+
+function expectFirstShapeCard(label: string) {
+  const shapeLabels = Array.from(document.querySelectorAll(".chord-shape-card__label"));
+  expect(shapeLabels[0]).toHaveTextContent(label);
+}
+
+function getStoredChordDictionaryPreferences() {
+  return window.localStorage.getItem(CHORD_DICTIONARY_PREFERENCES_STORAGE_KEY) ?? "";
 }
 
 function getStandardDiagram(label: string) {
@@ -528,7 +618,7 @@ describe("Desktop app tools chord dictionary", () => {
     const user = userEvent.setup();
     await renderChordDictionary();
 
-    const shapeChoices = within(screen.getByRole("group", { name: "Guitar shape choices" }));
+    const shapeChoices = within(screen.getByRole("group", { name: DICTIONARY_SHAPE_GROUP_NAME }));
     const movedShapeButton = shapeChoices.getByRole("button", { name: "C E-shape barre" });
 
     await user.click(movedShapeButton);
@@ -665,7 +755,7 @@ describe("Desktop app tools chord dictionary", () => {
 
     const beforeShapeSwitch = screen.getByLabelText("Note inspector").textContent;
     const shapeButtons = within(
-      screen.getByRole("group", { name: "Guitar shape choices" }),
+      screen.getByRole("group", { name: DICTIONARY_SHAPE_GROUP_NAME }),
     ).getAllByRole("button");
     if (!shapeButtons[1]) {
       throw new Error("Expected at least two selectable CAGED shapes");
@@ -679,6 +769,72 @@ describe("Desktop app tools chord dictionary", () => {
       expect(screen.getByLabelText("Note inspector").textContent).not.toBe(beforeShapeSwitch),
     );
     expect(shapeButtons[1]).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("persists a dictionary shape choice globally and promotes it when reopened", async () => {
+    const user = userEvent.setup();
+    const view = renderChordDictionaryView();
+    await view.findHeading();
+
+    expect(
+      screen.getByText("Saves locally as global for this chord and instrument."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Clear this chord/instrument global preference" }),
+    ).not.toBeInTheDocument();
+
+    const shapeChoices = within(screen.getByRole("group", { name: DICTIONARY_SHAPE_GROUP_NAME }));
+    await user.click(shapeChoices.getByRole("button", { name: "C E-shape barre" }));
+
+    await waitFor(() => expectFirstShapeChoice(DICTIONARY_SHAPE_GROUP_NAME, "C E-shape barre"));
+    expect(
+      screen.getByRole("button", { name: "Clear this chord/instrument global preference" }),
+    ).toBeInTheDocument();
+    expectFirstShapeCard("C E-shape barre");
+    expect(getStoredChordDictionaryPreferences()).toContain("c-e-shape-barre");
+
+    view.unmount();
+    const reopenedView = renderChordDictionaryView();
+    await reopenedView.findHeading();
+
+    await waitFor(() => expectFirstShapeChoice(DICTIONARY_SHAPE_GROUP_NAME, "C E-shape barre"));
+    expectFirstShapeCard("C E-shape barre");
+  });
+
+  it("hides dictionary reset when the saved global shape is unavailable", async () => {
+    writeGlobalChordDictionaryPreferredShape(
+      makeDictionaryShapePreferenceContext(),
+      "missing-c-shape",
+    );
+
+    await renderChordDictionary();
+
+    await waitFor(() => expectFirstShapeChoice(DICTIONARY_SHAPE_GROUP_NAME, "C open"));
+    expectFirstShapeCard("C open");
+    expect(
+      screen.queryByRole("button", { name: "Clear this chord/instrument global preference" }),
+    ).not.toBeInTheDocument();
+    expect(getStoredChordDictionaryPreferences()).toContain("missing-c-shape");
+  });
+
+  it("resets the dictionary global shape choice to the generated C default", async () => {
+    const user = userEvent.setup();
+    await renderChordDictionary();
+
+    const shapeChoices = within(screen.getByRole("group", { name: DICTIONARY_SHAPE_GROUP_NAME }));
+    await user.click(shapeChoices.getByRole("button", { name: "C E-shape barre" }));
+    await waitFor(() => expectFirstShapeChoice(DICTIONARY_SHAPE_GROUP_NAME, "C E-shape barre"));
+
+    await user.click(
+      screen.getByRole("button", { name: "Clear this chord/instrument global preference" }),
+    );
+
+    await waitFor(() => expectFirstShapeChoice(DICTIONARY_SHAPE_GROUP_NAME, "C open"));
+    expectFirstShapeCard("C open");
+    expect(
+      screen.queryByRole("button", { name: "Clear this chord/instrument global preference" }),
+    ).not.toBeInTheDocument();
+    expect(getStoredChordDictionaryPreferences()).not.toContain("c-e-shape-barre");
   });
 
   it("opens live follow from query params and renders the active project chord", async () => {
@@ -711,6 +867,152 @@ describe("Desktop app tools chord dictionary", () => {
     expect(screen.getByLabelText("Next chord")).toHaveTextContent(/E/);
     expectInspectorToShow([/A2/, /String\s*5/, /Fret\s*0/, /Degree\s*1/]);
     expect(screen.queryByRole("heading", { name: "C guitar shapes" })).not.toBeInTheDocument();
+  });
+
+  it("uses a Dictionary global C shape preference for Live Follow when the project has no pick", async () => {
+    writeGlobalChordDictionaryPreferredShape(
+      makeDictionaryShapePreferenceContext({ chordLabel: "C" }),
+      "c-e-shape-barre",
+    );
+
+    await renderChordDictionaryWithPlayback({
+      playback: makePlaybackValue({
+        project: makeFollowProject({
+          authoritativeSourceTimeline: cTimeline,
+          displayedKey: { pitchClass: 0, mode: "major" },
+          displayedTimeline: cTimeline,
+          sourceKey: { pitchClass: 0, mode: "major" },
+          totalDisplayTransposeSemitones: 0,
+        }),
+      }),
+    });
+
+    await waitFor(() => expectFirstShapeChoice(LIVE_SHAPE_GROUP_NAME, "C E-shape barre"));
+    expect(
+      screen.getByText(
+        "Saves locally for this project chord and instrument; clear uses global/default.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: "Clear this project override and fall back to global or default",
+      }),
+    ).not.toBeInTheDocument();
+    expectFirstShapeCard("C E-shape barre");
+    expectInspectorToShow([/C3/, /String\s*6/, /Fret\s*8/, /Degree\s*1/]);
+  });
+
+  it("keeps transposed displayed D separate from a global C shape preference", async () => {
+    writeGlobalChordDictionaryPreferredShape(
+      makeDictionaryShapePreferenceContext({ chordLabel: "C" }),
+      "c-e-shape-barre",
+    );
+
+    const dProject = makeFollowProject({
+      authoritativeSourceTimeline: cTimeline,
+      displayedKey: { pitchClass: 2, mode: "major" },
+      displayedTimeline: dTimeline,
+      sourceKey: { pitchClass: 0, mode: "major" },
+      totalDisplayTransposeSemitones: 2,
+    });
+    const view = renderChordDictionaryPlaybackHarness({
+      playback: makePlaybackValue({ project: dProject }),
+    });
+    await view.findHeading();
+
+    await waitFor(() => expectFirstShapeChoice(LIVE_SHAPE_GROUP_NAME, "D open"));
+    expectFirstShapeCard("D open");
+
+    view.unmount();
+    writeGlobalChordDictionaryPreferredShape(
+      makeDictionaryShapePreferenceContext({ chordLabel: "D" }),
+      "d-a-shape-barre",
+    );
+
+    await renderChordDictionaryWithPlayback({
+      playback: makePlaybackValue({ project: dProject }),
+    });
+
+    await waitFor(() => expectFirstShapeChoice(LIVE_SHAPE_GROUP_NAME, "D A-shape barre"));
+    expectFirstShapeCard("D A-shape barre");
+  });
+
+  it("hides Live Follow reset when the saved project shape is unavailable", async () => {
+    writeProjectChordDictionaryPreferredShape(
+      makeLiveShapePreferenceContext({ projectId: "proj_123" }),
+      "missing-a-shape",
+    );
+
+    await renderChordDictionaryWithPlayback();
+
+    await waitFor(() => expectFirstShapeChoice(LIVE_SHAPE_GROUP_NAME, "A open"));
+    expectFirstShapeCard("A open");
+    expect(
+      screen.queryByRole("button", {
+        name: "Clear this project override and fall back to global or default",
+      }),
+    ).not.toBeInTheDocument();
+    expect(getStoredChordDictionaryPreferences()).toContain("missing-a-shape");
+  });
+
+  it("stores a Live Follow project override and restores it for the same project", async () => {
+    const user = userEvent.setup();
+    const view = renderChordDictionaryPlaybackHarness();
+    await view.findHeading();
+
+    const shapeChoices = within(screen.getByRole("group", { name: LIVE_SHAPE_GROUP_NAME }));
+    await user.click(shapeChoices.getByRole("button", { name: "A D-shape barre" }));
+
+    await waitFor(() => expectFirstShapeChoice(LIVE_SHAPE_GROUP_NAME, "A D-shape barre"));
+    expect(
+      screen.getByRole("button", {
+        name: "Clear this project override and fall back to global or default",
+      }),
+    ).toBeInTheDocument();
+    expectFirstShapeCard("A D-shape barre");
+    expect(getStoredChordDictionaryPreferences()).toContain("proj_123");
+    expect(getStoredChordDictionaryPreferences()).toContain("a-d-shape-barre");
+
+    view.rerenderWithPlayback(makePlaybackValue({ playbackTimeSeconds: 6 }));
+    await waitFor(() => expectFirstShapeChoice(LIVE_SHAPE_GROUP_NAME, "A D-shape barre"));
+
+    view.unmount();
+    await renderChordDictionaryWithPlayback();
+
+    await waitFor(() => expectFirstShapeChoice(LIVE_SHAPE_GROUP_NAME, "A D-shape barre"));
+    expectFirstShapeCard("A D-shape barre");
+  });
+
+  it("resets a Live Follow project E shape choice back to the global fallback", async () => {
+    const user = userEvent.setup();
+    writeGlobalChordDictionaryPreferredShape(
+      makeDictionaryShapePreferenceContext({ chordLabel: "E" }),
+      "e-a-shape-barre",
+    );
+    await renderChordDictionaryWithPlayback({
+      playback: makePlaybackValue({ playbackTimeSeconds: 20 }),
+    });
+
+    const shapeChoices = within(screen.getByRole("group", { name: LIVE_SHAPE_GROUP_NAME }));
+    await waitFor(() => expectFirstShapeChoice(LIVE_SHAPE_GROUP_NAME, "E A-shape barre"));
+    await user.click(shapeChoices.getByRole("button", { name: "E D-shape barre" }));
+    await waitFor(() => expectFirstShapeChoice(LIVE_SHAPE_GROUP_NAME, "E D-shape barre"));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Clear this project override and fall back to global or default",
+      }),
+    );
+
+    await waitFor(() => expectFirstShapeChoice(LIVE_SHAPE_GROUP_NAME, "E A-shape barre"));
+    expectFirstShapeCard("E A-shape barre");
+    expect(
+      screen.queryByRole("button", {
+        name: "Clear this project override and fall back to global or default",
+      }),
+    ).not.toBeInTheDocument();
+    expect(getStoredChordDictionaryPreferences()).toContain("e-a-shape-barre");
+    expect(getStoredChordDictionaryPreferences()).not.toContain("e-d-shape-barre");
   });
 
   it("uses an honest generic playback source label without a project display name", async () => {

--- a/apps/desktop/src/features/tools/ChordDictionaryPage.tsx
+++ b/apps/desktop/src/features/tools/ChordDictionaryPage.tsx
@@ -26,6 +26,16 @@ import {
 } from "../projects/chordDictionaryFollowContext";
 import { usePlayback } from "../projects/playback-context";
 import { useChordDictionaryFollowArm } from "./chordDictionaryFollowArm-context";
+import {
+  hasGlobalChordDictionaryPreferredShape,
+  hasProjectChordDictionaryPreferredShape,
+  resetGlobalChordDictionaryPreferredShape,
+  resetProjectChordDictionaryPreferredShape,
+  resolveChordDictionaryPreferredShapeId,
+  writeGlobalChordDictionaryPreferredShape,
+  writeProjectChordDictionaryPreferredShape,
+  type ChordDictionaryPreferenceContext,
+} from "./chordDictionaryPreferences";
 
 type ChordDictionarySurface = "dictionary" | "follow";
 type NotePoint = {
@@ -96,9 +106,66 @@ type GuitarShape = {
 };
 
 const COMMON_CHORD_LABELS = ["C", "Dm", "Em", "F", "G", "Am", "Bdim"] as const;
+const CHORD_DICTIONARY_INSTRUMENT_ID = GUITAR_STANDARD_PROFILE.id;
 
 function classNames(...values: Array<string | false | null | undefined>) {
   return values.filter(Boolean).join(" ");
+}
+
+function formatPreferenceKeyLabel(key: MusicalKey | null | undefined) {
+  return key ? formatKey(key, "short") : null;
+}
+
+function buildShapePreferenceContext({
+  capoFret,
+  chordLabel,
+  displayedKey,
+  projectId,
+  sourceKey,
+  transposeSemitones,
+  useCapoShapes,
+}: {
+  capoFret: number | null;
+  chordLabel: string;
+  displayedKey: MusicalKey | null;
+  projectId: string | null;
+  sourceKey: MusicalKey | null;
+  transposeSemitones: number | null;
+  useCapoShapes: boolean | null;
+}): ChordDictionaryPreferenceContext {
+  return {
+    capoFret,
+    chordLabel,
+    displayedKeyLabel: formatPreferenceKeyLabel(displayedKey),
+    instrumentId: CHORD_DICTIONARY_INSTRUMENT_ID,
+    projectId,
+    sourceKeyLabel: formatPreferenceKeyLabel(sourceKey),
+    transposeSemitones,
+    useCapoShapes,
+  };
+}
+
+function promoteShapeToFirst<T extends { id: string }>(
+  shapes: readonly T[],
+  preferredShapeId: string | null,
+): readonly T[] {
+  const preferredShapeIndex = preferredShapeId
+    ? shapes.findIndex((shape) => shape.id === preferredShapeId)
+    : -1;
+  if (preferredShapeIndex <= 0) {
+    return shapes;
+  }
+
+  const preferredShape = shapes[preferredShapeIndex];
+  if (!preferredShape) {
+    return shapes;
+  }
+
+  return [
+    preferredShape,
+    ...shapes.slice(0, preferredShapeIndex),
+    ...shapes.slice(preferredShapeIndex + 1),
+  ];
 }
 
 export function ChordDictionaryPage() {
@@ -202,6 +269,7 @@ function DictionarySurface() {
   const [activeChord, setActiveChord] = useState("C");
   const [activeShape, setActiveShape] = useState<string | null>(null);
   const [previewNoteId, setPreviewNoteId] = useState<string | null>(null);
+  const [, setPreferenceRevision] = useState(0);
   const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
   const displayContext = useMemo<Partial<ChordDisplayContext>>(
     () => ({
@@ -240,13 +308,52 @@ function DictionarySurface() {
     () => (chordSpelling ? generateGuitarVoicings(chordSpelling, GUITAR_STANDARD_PROFILE, displayContext) : []),
     [chordSpelling, displayContext],
   );
-  const guitarShapes = useMemo(
+  const generatedGuitarShapes = useMemo(
     () => guitarVoicings.map((voicing) => toGuitarShape(voicing, GUITAR_STANDARD_PROFILE)),
     [guitarVoicings],
+  );
+  const generatedShapeIds = useMemo(
+    () => generatedGuitarShapes.map((shape) => shape.id),
+    [generatedGuitarShapes],
+  );
+  const preferenceContext = useMemo(
+    () =>
+      chordSpelling
+        ? buildShapePreferenceContext({
+            capoFret: displayContext.capoFret ?? null,
+            chordLabel: chordSpelling.label,
+            displayedKey: null,
+            projectId: null,
+            sourceKey: displayContext.sourceKey ?? null,
+            transposeSemitones: displayContext.transposeSemitones ?? null,
+            useCapoShapes: displayContext.useCapoShapes ?? null,
+          })
+        : null,
+    [chordSpelling, displayContext],
+  );
+  const preferredShapeId = resolveChordDictionaryPreferredShapeId(
+    preferenceContext,
+    generatedShapeIds,
+  );
+  const hasGlobalShapePreference = hasGlobalChordDictionaryPreferredShape(
+    preferenceContext,
+    generatedShapeIds,
+  );
+  const guitarShapes = useMemo(
+    () => promoteShapeToFirst(generatedGuitarShapes, preferredShapeId),
+    [generatedGuitarShapes, preferredShapeId],
   );
   const resultKey = guitarShapes.map((shape) => shape.id).join("|");
   const firstShapeId = guitarShapes[0]?.id ?? null;
   const firstNoteId = guitarShapes[0]?.notes[0]?.id ?? null;
+  const bumpPreferenceRevision = () => setPreferenceRevision((revision) => revision + 1);
+  const selectShape = (shape: GuitarShape) => {
+    writeGlobalChordDictionaryPreferredShape(preferenceContext, shape.id);
+    bumpPreferenceRevision();
+    setActiveShape(shape.id);
+    setPreviewNoteId(null);
+    setSelectedNoteId(shape.notes[0]?.id ?? null);
+  };
   useEffect(() => {
     setActiveShape(firstShapeId);
     setPreviewNoteId(null);
@@ -337,25 +444,49 @@ function DictionarySurface() {
                 <h3>{chordSpelling ? `${chordSpelling.label} guitar shapes` : "Guitar shapes"}</h3>
               </div>
               {guitarShapes.length > 0 ? (
-                <div className="chord-shape-tabs" role="group" aria-label="Guitar shape choices">
-                  {guitarShapes.map((shape) => (
-                    <button
-                      key={shape.id}
-                      aria-pressed={selectedShape?.id === shape.id}
-                      className={classNames(
-                        "chord-shape-tab",
-                        selectedShape?.id === shape.id && "chord-shape-tab--active",
-                      )}
-                      onClick={() => {
-                        setActiveShape(shape.id);
-                        setPreviewNoteId(null);
-                        setSelectedNoteId(shape.notes[0]?.id ?? null);
-                      }}
-                      type="button"
+                <div className="chord-shape-controls">
+                  <div className="chord-shape-control-row">
+                    <div
+                      aria-describedby="dictionary-shape-preference-copy"
+                      aria-label="Global guitar shape preference choices"
+                      className="chord-shape-tabs"
+                      role="group"
                     >
-                      {shape.label}
-                    </button>
-                  ))}
+                      {guitarShapes.map((shape) => (
+                        <button
+                          key={shape.id}
+                          aria-pressed={selectedShape?.id === shape.id}
+                          className={classNames(
+                            "chord-shape-tab",
+                            selectedShape?.id === shape.id && "chord-shape-tab--active",
+                          )}
+                          onClick={() => selectShape(shape)}
+                          type="button"
+                        >
+                          {shape.label}
+                        </button>
+                      ))}
+                    </div>
+                    {hasGlobalShapePreference ? (
+                      <button
+                        aria-label="Clear this chord/instrument global preference"
+                        className="chord-reset-button"
+                        onClick={() => {
+                          resetGlobalChordDictionaryPreferredShape(preferenceContext);
+                          bumpPreferenceRevision();
+                        }}
+                        type="button"
+                      >
+                        Clear global preference
+                      </button>
+                    ) : null}
+                  </div>
+                  <p
+                    className="chord-shape-preference-copy"
+                    id="dictionary-shape-preference-copy"
+                  >
+                    Saves locally as global for this chord and instrument.
+                  </p>
                 </div>
               ) : null}
             </div>
@@ -389,11 +520,7 @@ function DictionarySurface() {
                   >
                     <button
                       className="chord-shape-card__label"
-                      onClick={() => {
-                        setActiveShape(shape.id);
-                        setPreviewNoteId(null);
-                        setSelectedNoteId(shape.notes[0]?.id ?? null);
-                      }}
+                      onClick={() => selectShape(shape)}
                       type="button"
                     >
                       {shape.label}
@@ -1024,6 +1151,7 @@ function LiveFollowActiveState({ context }: { context: ChordDictionaryFollowCont
   const project = context.project;
   const [activeShape, setActiveShape] = useState<string | null>(null);
   const [previewNoteId, setPreviewNoteId] = useState<string | null>(null);
+  const [, setPreferenceRevision] = useState(0);
   const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
   const displayContext = useMemo<Partial<ChordDisplayContext>>(
     () => ({
@@ -1056,13 +1184,60 @@ function LiveFollowActiveState({ context }: { context: ChordDictionaryFollowCont
         : [],
     [chordSpelling, displayContext, project?.displayedKey],
   );
-  const guitarShapes = useMemo(
+  const generatedGuitarShapes = useMemo(
     () => guitarVoicings.map((voicing) => toGuitarShape(voicing, GUITAR_STANDARD_PROFILE)),
     [guitarVoicings],
+  );
+  const generatedShapeIds = useMemo(
+    () => generatedGuitarShapes.map((shape) => shape.id),
+    [generatedGuitarShapes],
+  );
+  const preferenceContext = useMemo(
+    () =>
+      chordSpelling
+        ? buildShapePreferenceContext({
+            capoFret: displayContext.capoFret ?? null,
+            chordLabel: chordSpelling.label,
+            displayedKey: project?.displayedKey ?? null,
+            projectId: project?.projectId ?? null,
+            sourceKey: project?.sourceKey ?? null,
+            transposeSemitones: project?.totalDisplayTransposeSemitones ?? null,
+            useCapoShapes: displayContext.useCapoShapes ?? null,
+          })
+        : null,
+    [
+      chordSpelling,
+      displayContext.capoFret,
+      displayContext.useCapoShapes,
+      project?.displayedKey,
+      project?.projectId,
+      project?.sourceKey,
+      project?.totalDisplayTransposeSemitones,
+    ],
+  );
+  const preferredShapeId = resolveChordDictionaryPreferredShapeId(
+    preferenceContext,
+    generatedShapeIds,
+  );
+  const hasProjectShapePreference = hasProjectChordDictionaryPreferredShape(
+    preferenceContext,
+    generatedShapeIds,
+  );
+  const guitarShapes = useMemo(
+    () => promoteShapeToFirst(generatedGuitarShapes, preferredShapeId),
+    [generatedGuitarShapes, preferredShapeId],
   );
   const resultKey = guitarShapes.map((shape) => shape.id).join("|");
   const firstShapeId = guitarShapes[0]?.id ?? null;
   const firstNoteId = guitarShapes[0]?.notes[0]?.id ?? null;
+  const bumpPreferenceRevision = () => setPreferenceRevision((revision) => revision + 1);
+  const selectShape = (shape: GuitarShape) => {
+    writeProjectChordDictionaryPreferredShape(preferenceContext, shape.id);
+    bumpPreferenceRevision();
+    setActiveShape(shape.id);
+    setPreviewNoteId(null);
+    setSelectedNoteId(shape.notes[0]?.id ?? null);
+  };
 
   useEffect(() => {
     setActiveShape(firstShapeId);
@@ -1171,25 +1346,49 @@ function LiveFollowActiveState({ context }: { context: ChordDictionaryFollowCont
                 <p className="metric-label">{chordSpelling.notes.join(" ")}</p>
                 <h3>{chordSpelling.label} guitar shapes</h3>
               </div>
-              <div className="chord-shape-tabs" role="group" aria-label="Live guitar shape choices">
-                {guitarShapes.map((shape) => (
-                  <button
-                    key={shape.id}
-                    aria-pressed={selectedShape?.id === shape.id}
-                    className={classNames(
-                      "chord-shape-tab",
-                      selectedShape?.id === shape.id && "chord-shape-tab--active",
-                    )}
-                    onClick={() => {
-                      setActiveShape(shape.id);
-                      setPreviewNoteId(null);
-                      setSelectedNoteId(shape.notes[0]?.id ?? null);
-                    }}
-                    type="button"
+              <div className="chord-shape-controls">
+                <div className="chord-shape-control-row">
+                  <div
+                    aria-describedby="live-shape-preference-copy"
+                    aria-label="Project guitar shape preference choices"
+                    className="chord-shape-tabs"
+                    role="group"
                   >
-                    {shape.label}
-                  </button>
-                ))}
+                    {guitarShapes.map((shape) => (
+                      <button
+                        key={shape.id}
+                        aria-pressed={selectedShape?.id === shape.id}
+                        className={classNames(
+                          "chord-shape-tab",
+                          selectedShape?.id === shape.id && "chord-shape-tab--active",
+                        )}
+                        onClick={() => selectShape(shape)}
+                        type="button"
+                      >
+                        {shape.label}
+                      </button>
+                    ))}
+                  </div>
+                  {hasProjectShapePreference ? (
+                    <button
+                      aria-label="Clear this project override and fall back to global or default"
+                      className="chord-reset-button"
+                      onClick={() => {
+                        resetProjectChordDictionaryPreferredShape(preferenceContext);
+                        bumpPreferenceRevision();
+                      }}
+                      type="button"
+                    >
+                      Clear project override
+                    </button>
+                  ) : null}
+                </div>
+                <p
+                  className="chord-shape-preference-copy"
+                  id="live-shape-preference-copy"
+                >
+                  Saves locally for this project chord and instrument; clear uses global/default.
+                </p>
               </div>
             </div>
             <ChordSpellingSummary spelling={chordSpelling} />
@@ -1204,11 +1403,7 @@ function LiveFollowActiveState({ context }: { context: ChordDictionaryFollowCont
                 >
                   <button
                     className="chord-shape-card__label"
-                    onClick={() => {
-                      setActiveShape(shape.id);
-                      setPreviewNoteId(null);
-                      setSelectedNoteId(shape.notes[0]?.id ?? null);
-                    }}
+                    onClick={() => selectShape(shape)}
                     type="button"
                   >
                     {shape.label}

--- a/apps/desktop/src/features/tools/chordDictionaryPreferences.test.ts
+++ b/apps/desktop/src/features/tools/chordDictionaryPreferences.test.ts
@@ -1,0 +1,266 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CHORD_DICTIONARY_PREFERENCES_STORAGE_KEY,
+  clearGlobalChordDictionaryPreferredShape,
+  clearProjectChordDictionaryPreferredShape,
+  hasGlobalChordDictionaryPreferredShape,
+  hasProjectChordDictionaryPreferredShape,
+  readGlobalChordDictionaryPreferredShapeId,
+  readProjectChordDictionaryPreferredShapeId,
+  resetGlobalChordDictionaryPreferredShape,
+  resetProjectChordDictionaryPreferredShape,
+  resolveChordDictionaryPreferredShapeId,
+  writeGlobalChordDictionaryPreferredShape,
+  writeProjectChordDictionaryPreferredShape,
+  type ChordDictionaryPreferenceContext,
+} from "./chordDictionaryPreferences";
+
+const SHAPE_IDS = ["c-open", "c-g-shape", "c-a-shape"] as const;
+const D_SHAPE_IDS = ["d-open", "d-a-shape-barre"] as const;
+const E_SHAPE_IDS = ["e-open", "e-a-shape-barre", "e-d-shape-barre"] as const;
+
+function makeContext(
+  overrides: Partial<ChordDictionaryPreferenceContext> = {},
+): ChordDictionaryPreferenceContext {
+  return {
+    capoFret: 0,
+    chordLabel: "C",
+    displayedKeyLabel: null,
+    instrumentId: "guitar",
+    projectId: null,
+    sourceKeyLabel: null,
+    transposeSemitones: 0,
+    useCapoShapes: false,
+    ...overrides,
+  };
+}
+
+describe("chord dictionary preferences", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("saves and restores a global non-default C shape preference", () => {
+    const context = makeContext({
+      capoFret: 0.9,
+      chordLabel: " C ",
+      sourceKeyLabel: " ",
+      transposeSemitones: 0.4,
+    });
+
+    expect(resolveChordDictionaryPreferredShapeId(makeContext(), SHAPE_IDS)).toBe("c-open");
+
+    writeGlobalChordDictionaryPreferredShape(context, "c-g-shape");
+
+    expect(resolveChordDictionaryPreferredShapeId(makeContext(), SHAPE_IDS)).toBe("c-g-shape");
+    expect(window.localStorage.getItem(CHORD_DICTIONARY_PREFERENCES_STORAGE_KEY)).toContain(
+      "c-g-shape",
+    );
+    expect(window.localStorage.getItem("tuneforge.ui-preferences")).toBeNull();
+    expect(window.localStorage.getItem("tuneforge.project-playback-state")).toBeNull();
+  });
+
+  it("uses the same global key for dictionary and Live Follow contexts", () => {
+    const dictionaryContext = makeContext({
+      chordLabel: "C",
+      displayedKeyLabel: null,
+      sourceKeyLabel: null,
+      transposeSemitones: 0,
+    });
+    const liveFollowContext = makeContext({
+      chordLabel: "C",
+      displayedKeyLabel: "C",
+      sourceKeyLabel: "G",
+      transposeSemitones: 5,
+    });
+
+    writeGlobalChordDictionaryPreferredShape(dictionaryContext, "c-g-shape");
+
+    expect(resolveChordDictionaryPreferredShapeId(liveFollowContext, SHAPE_IDS)).toBe(
+      "c-g-shape",
+    );
+    expect(readGlobalChordDictionaryPreferredShapeId(liveFollowContext)).toBe("c-g-shape");
+  });
+
+  it("uses displayed chord labels so transposed D does not reuse a C preference", () => {
+    writeGlobalChordDictionaryPreferredShape(makeContext({ chordLabel: "C" }), "c-g-shape");
+
+    const displayedDContext = makeContext({
+      chordLabel: "D",
+      displayedKeyLabel: "D",
+      sourceKeyLabel: "C",
+      transposeSemitones: 2,
+    });
+
+    expect(resolveChordDictionaryPreferredShapeId(displayedDContext, D_SHAPE_IDS)).toBe("d-open");
+
+    writeGlobalChordDictionaryPreferredShape(displayedDContext, "d-a-shape-barre");
+
+    expect(resolveChordDictionaryPreferredShapeId(displayedDContext, D_SHAPE_IDS)).toBe(
+      "d-a-shape-barre",
+    );
+  });
+
+  it("lets a project override win over the global preference", () => {
+    const context = makeContext();
+    const projectContext = makeContext({ projectId: "project-1" });
+
+    writeGlobalChordDictionaryPreferredShape(context, "c-g-shape");
+    writeProjectChordDictionaryPreferredShape(projectContext, "c-a-shape");
+
+    expect(resolveChordDictionaryPreferredShapeId(projectContext, SHAPE_IDS)).toBe("c-a-shape");
+  });
+
+  it("falls through project, global, and generated defaults for one displayed chord", () => {
+    const globalContext = makeContext({ chordLabel: "E" });
+    const projectContext = makeContext({ chordLabel: "E", projectId: "project-1" });
+
+    writeGlobalChordDictionaryPreferredShape(globalContext, "e-a-shape-barre");
+    writeProjectChordDictionaryPreferredShape(projectContext, "e-d-shape-barre");
+
+    expect(resolveChordDictionaryPreferredShapeId(projectContext, E_SHAPE_IDS)).toBe(
+      "e-d-shape-barre",
+    );
+
+    clearProjectChordDictionaryPreferredShape(projectContext);
+    expect(resolveChordDictionaryPreferredShapeId(projectContext, E_SHAPE_IDS)).toBe(
+      "e-a-shape-barre",
+    );
+
+    clearGlobalChordDictionaryPreferredShape(globalContext);
+    expect(resolveChordDictionaryPreferredShapeId(projectContext, E_SHAPE_IDS)).toBe("e-open");
+  });
+
+  it("reports saved global and project shape preferences by scope", () => {
+    const context = makeContext();
+    const projectContext = makeContext({ projectId: "project-1" });
+
+    expect(readGlobalChordDictionaryPreferredShapeId(context)).toBeNull();
+    expect(readProjectChordDictionaryPreferredShapeId(projectContext)).toBeNull();
+    expect(hasGlobalChordDictionaryPreferredShape(context, SHAPE_IDS)).toBe(false);
+    expect(hasProjectChordDictionaryPreferredShape(projectContext, SHAPE_IDS)).toBe(false);
+
+    writeGlobalChordDictionaryPreferredShape(context, "c-g-shape");
+    writeProjectChordDictionaryPreferredShape(projectContext, "c-a-shape");
+
+    expect(readGlobalChordDictionaryPreferredShapeId(context)).toBe("c-g-shape");
+    expect(readProjectChordDictionaryPreferredShapeId(projectContext)).toBe("c-a-shape");
+    expect(hasGlobalChordDictionaryPreferredShape(context, SHAPE_IDS)).toBe(true);
+    expect(hasProjectChordDictionaryPreferredShape(projectContext, SHAPE_IDS)).toBe(true);
+    expect(hasGlobalChordDictionaryPreferredShape(context, ["c-open"])).toBe(false);
+    expect(hasProjectChordDictionaryPreferredShape(projectContext, ["c-open"])).toBe(false);
+
+    clearGlobalChordDictionaryPreferredShape(context);
+    clearProjectChordDictionaryPreferredShape(projectContext);
+
+    expect(hasGlobalChordDictionaryPreferredShape(context, SHAPE_IDS)).toBe(false);
+    expect(hasProjectChordDictionaryPreferredShape(projectContext, SHAPE_IDS)).toBe(false);
+  });
+
+  it("falls back to global preference when a project has no pick", () => {
+    writeGlobalChordDictionaryPreferredShape(makeContext(), "c-g-shape");
+
+    expect(
+      resolveChordDictionaryPreferredShapeId(makeContext({ projectId: "project-2" }), SHAPE_IDS),
+    ).toBe("c-g-shape");
+  });
+
+  it("falls back to generated default or null when saved shapes are unavailable", () => {
+    const context = makeContext({ projectId: "project-1" });
+
+    writeGlobalChordDictionaryPreferredShape(context, "c-a-shape");
+    writeProjectChordDictionaryPreferredShape(context, "c-a-shape");
+
+    expect(resolveChordDictionaryPreferredShapeId(context, ["c-open", "c-g-shape"])).toBe(
+      "c-open",
+    );
+    expect(resolveChordDictionaryPreferredShapeId(context, [])).toBeNull();
+  });
+
+  it("clears and resets global preferences", () => {
+    const context = makeContext();
+
+    writeGlobalChordDictionaryPreferredShape(context, "c-g-shape");
+    clearGlobalChordDictionaryPreferredShape(context);
+    expect(resolveChordDictionaryPreferredShapeId(context, SHAPE_IDS)).toBe("c-open");
+
+    writeGlobalChordDictionaryPreferredShape(context, "c-a-shape");
+    resetGlobalChordDictionaryPreferredShape(context);
+    expect(resolveChordDictionaryPreferredShapeId(context, SHAPE_IDS)).toBe("c-open");
+  });
+
+  it("clears and resets project preferences", () => {
+    const context = makeContext();
+    const projectContext = makeContext({ projectId: "project-1" });
+
+    writeGlobalChordDictionaryPreferredShape(context, "c-g-shape");
+    writeProjectChordDictionaryPreferredShape(projectContext, "c-a-shape");
+    clearProjectChordDictionaryPreferredShape(projectContext);
+    expect(resolveChordDictionaryPreferredShapeId(projectContext, SHAPE_IDS)).toBe("c-g-shape");
+
+    writeProjectChordDictionaryPreferredShape(projectContext, "c-a-shape");
+    resetProjectChordDictionaryPreferredShape(projectContext);
+    expect(resolveChordDictionaryPreferredShapeId(projectContext, SHAPE_IDS)).toBe("c-g-shape");
+  });
+
+  it("falls back silently for invalid JSON and malformed storage records", () => {
+    const context = makeContext();
+
+    window.localStorage.setItem(CHORD_DICTIONARY_PREFERENCES_STORAGE_KEY, "{not json");
+    expect(resolveChordDictionaryPreferredShapeId(context, SHAPE_IDS)).toBe("c-open");
+
+    window.localStorage.setItem(
+      CHORD_DICTIONARY_PREFERENCES_STORAGE_KEY,
+      JSON.stringify({
+        globalPreferredShapeIds: {
+          stale: 42,
+        },
+        projectPreferredShapeIds: {
+          "project-1": {
+            stale: null,
+          },
+          "project-2": "not-a-map",
+        },
+        version: 2,
+      }),
+    );
+    expect(resolveChordDictionaryPreferredShapeId(context, SHAPE_IDS)).toBe("c-open");
+  });
+
+  it("falls back and does not throw without window or localStorage", () => {
+    const originalWindow = window;
+    vi.stubGlobal("window", undefined);
+
+    try {
+      expect(resolveChordDictionaryPreferredShapeId(makeContext(), SHAPE_IDS)).toBe("c-open");
+      expect(() =>
+        writeGlobalChordDictionaryPreferredShape(makeContext(), "c-g-shape"),
+      ).not.toThrow();
+      expect(() =>
+        writeProjectChordDictionaryPreferredShape(
+          makeContext({ projectId: "project-1" }),
+          "c-a-shape",
+        ),
+      ).not.toThrow();
+      expect(() => clearGlobalChordDictionaryPreferredShape(makeContext())).not.toThrow();
+      expect(() =>
+        clearProjectChordDictionaryPreferredShape(makeContext({ projectId: "project-1" })),
+      ).not.toThrow();
+    } finally {
+      vi.stubGlobal("window", originalWindow);
+    }
+  });
+
+  it("ignores empty chord labels and malformed shape ids", () => {
+    const emptyChordContext = makeContext({ chordLabel: " " });
+
+    writeGlobalChordDictionaryPreferredShape(emptyChordContext, "c-g-shape");
+    writeProjectChordDictionaryPreferredShape(
+      { ...emptyChordContext, projectId: "project-1" },
+      "c-a-shape",
+    );
+
+    expect(resolveChordDictionaryPreferredShapeId(emptyChordContext, SHAPE_IDS)).toBe("c-open");
+    expect(resolveChordDictionaryPreferredShapeId(makeContext(), ["", "c-open"])).toBe("c-open");
+  });
+});

--- a/apps/desktop/src/features/tools/chordDictionaryPreferences.ts
+++ b/apps/desktop/src/features/tools/chordDictionaryPreferences.ts
@@ -1,0 +1,360 @@
+export const CHORD_DICTIONARY_PREFERENCES_STORAGE_KEY =
+  "tuneforge.chord-dictionary-preferences.v2";
+
+export type ChordDictionaryPreferenceContext = {
+  projectId?: string | null;
+  instrumentId: string;
+  chordLabel: string;
+  sourceKeyLabel?: string | null;
+  displayedKeyLabel?: string | null;
+  transposeSemitones?: number | null;
+  capoFret?: number | null;
+  useCapoShapes?: boolean | null;
+};
+
+type NormalizedChordDictionaryPreferenceContext = {
+  projectId: string | null;
+  instrumentId: string;
+  chordLabel: string;
+};
+
+type ChordDictionaryPreferencesStorage = {
+  version: 2;
+  globalPreferredShapeIds: Record<string, string>;
+  projectPreferredShapeIds: Record<string, Record<string, string>>;
+};
+
+function createEmptyChordDictionaryPreferences(): ChordDictionaryPreferencesStorage {
+  return {
+    version: 2,
+    globalPreferredShapeIds: {},
+    projectPreferredShapeIds: {},
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeRequiredText(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmedValue = value.trim();
+  return trimmedValue.length > 0 ? trimmedValue : null;
+}
+
+function normalizeOptionalText(value: unknown): string | null {
+  return normalizeRequiredText(value);
+}
+
+function normalizeShapeId(value: unknown): string | null {
+  return normalizeRequiredText(value);
+}
+
+function normalizeShapePreferenceMap(value: unknown): Record<string, string> {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  const normalizedEntries = Object.entries(value).flatMap(([contextKey, shapeId]) => {
+    const normalizedContextKey = normalizeRequiredText(contextKey);
+    const normalizedShapeId = normalizeShapeId(shapeId);
+    if (!normalizedContextKey || !normalizedShapeId) {
+      return [];
+    }
+    return [[normalizedContextKey, normalizedShapeId] satisfies [string, string]];
+  });
+
+  return Object.fromEntries(normalizedEntries);
+}
+
+function normalizeProjectShapePreferenceMap(
+  value: unknown,
+): Record<string, Record<string, string>> {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  const normalizedEntries = Object.entries(value).flatMap(([projectId, shapeMap]) => {
+    const normalizedProjectId = normalizeRequiredText(projectId);
+    const normalizedShapeMap = normalizeShapePreferenceMap(shapeMap);
+    if (!normalizedProjectId || Object.keys(normalizedShapeMap).length === 0) {
+      return [];
+    }
+    return [[normalizedProjectId, normalizedShapeMap] satisfies [string, Record<string, string>]];
+  });
+
+  return Object.fromEntries(normalizedEntries);
+}
+
+function normalizeStorage(value: unknown): ChordDictionaryPreferencesStorage {
+  if (!isRecord(value) || value.version !== 2) {
+    return createEmptyChordDictionaryPreferences();
+  }
+
+  return {
+    version: 2,
+    globalPreferredShapeIds: normalizeShapePreferenceMap(value.globalPreferredShapeIds),
+    projectPreferredShapeIds: normalizeProjectShapePreferenceMap(value.projectPreferredShapeIds),
+  };
+}
+
+function getLocalStorage(): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    return window.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function readPreferencesStorage(): ChordDictionaryPreferencesStorage {
+  const storage = getLocalStorage();
+  if (!storage) {
+    return createEmptyChordDictionaryPreferences();
+  }
+
+  let storedValue: string | null;
+  try {
+    storedValue = storage.getItem(CHORD_DICTIONARY_PREFERENCES_STORAGE_KEY);
+  } catch {
+    return createEmptyChordDictionaryPreferences();
+  }
+
+  if (!storedValue) {
+    return createEmptyChordDictionaryPreferences();
+  }
+
+  try {
+    return normalizeStorage(JSON.parse(storedValue));
+  } catch {
+    return createEmptyChordDictionaryPreferences();
+  }
+}
+
+function writePreferencesStorage(value: ChordDictionaryPreferencesStorage): void {
+  const storage = getLocalStorage();
+  if (!storage) {
+    return;
+  }
+
+  try {
+    storage.setItem(
+      CHORD_DICTIONARY_PREFERENCES_STORAGE_KEY,
+      JSON.stringify(normalizeStorage(value)),
+    );
+  } catch {
+    return;
+  }
+}
+
+function normalizePreferenceContext(
+  context: ChordDictionaryPreferenceContext | null | undefined,
+): NormalizedChordDictionaryPreferenceContext | null {
+  if (!context) {
+    return null;
+  }
+
+  const instrumentId = normalizeRequiredText(context.instrumentId);
+  const chordLabel = normalizeRequiredText(context.chordLabel);
+  if (!instrumentId || !chordLabel) {
+    return null;
+  }
+
+  return {
+    projectId: normalizeOptionalText(context.projectId),
+    instrumentId,
+    chordLabel,
+  };
+}
+
+function buildContextKey(
+  context: NormalizedChordDictionaryPreferenceContext,
+): string {
+  return JSON.stringify([context.instrumentId, context.chordLabel]);
+}
+
+function normalizeAvailableShapeIds(
+  availableShapeIds: readonly string[] | null | undefined,
+): string[] {
+  if (!Array.isArray(availableShapeIds)) {
+    return [];
+  }
+
+  const seenShapeIds = new Set<string>();
+  const normalizedShapeIds: string[] = [];
+  for (const availableShapeId of availableShapeIds) {
+    const shapeId = normalizeShapeId(availableShapeId);
+    if (!shapeId || seenShapeIds.has(shapeId)) {
+      continue;
+    }
+    seenShapeIds.add(shapeId);
+    normalizedShapeIds.push(shapeId);
+  }
+  return normalizedShapeIds;
+}
+
+export function resolveChordDictionaryPreferredShapeId(
+  context: ChordDictionaryPreferenceContext | null | undefined,
+  availableShapeIds: readonly string[] | null | undefined,
+): string | null {
+  const normalizedAvailableShapeIds = normalizeAvailableShapeIds(availableShapeIds);
+  const generatedDefaultShapeId = normalizedAvailableShapeIds[0] ?? null;
+  const normalizedContext = normalizePreferenceContext(context);
+  if (!normalizedContext) {
+    return generatedDefaultShapeId;
+  }
+
+  const availableShapeIdSet = new Set(normalizedAvailableShapeIds);
+  const contextKey = buildContextKey(normalizedContext);
+  const preferences = readPreferencesStorage();
+  if (normalizedContext.projectId) {
+    const projectShapeId =
+      preferences.projectPreferredShapeIds[normalizedContext.projectId]?.[contextKey] ?? null;
+    if (projectShapeId && availableShapeIdSet.has(projectShapeId)) {
+      return projectShapeId;
+    }
+  }
+
+  const globalShapeId = preferences.globalPreferredShapeIds[contextKey] ?? null;
+  if (globalShapeId && availableShapeIdSet.has(globalShapeId)) {
+    return globalShapeId;
+  }
+
+  return generatedDefaultShapeId;
+}
+
+export function readGlobalChordDictionaryPreferredShapeId(
+  context: ChordDictionaryPreferenceContext | null | undefined,
+): string | null {
+  const normalizedContext = normalizePreferenceContext(context);
+  if (!normalizedContext) {
+    return null;
+  }
+
+  const preferences = readPreferencesStorage();
+  return preferences.globalPreferredShapeIds[buildContextKey(normalizedContext)] ?? null;
+}
+
+export function readProjectChordDictionaryPreferredShapeId(
+  context: ChordDictionaryPreferenceContext | null | undefined,
+): string | null {
+  const normalizedContext = normalizePreferenceContext(context);
+  if (!normalizedContext?.projectId) {
+    return null;
+  }
+
+  const preferences = readPreferencesStorage();
+  return (
+    preferences.projectPreferredShapeIds[normalizedContext.projectId]?.[
+      buildContextKey(normalizedContext)
+    ] ?? null
+  );
+}
+
+export function hasGlobalChordDictionaryPreferredShape(
+  context: ChordDictionaryPreferenceContext | null | undefined,
+  availableShapeIds: readonly string[] | null | undefined,
+): boolean {
+  const savedShapeId = readGlobalChordDictionaryPreferredShapeId(context);
+  return (
+    savedShapeId !== null && normalizeAvailableShapeIds(availableShapeIds).includes(savedShapeId)
+  );
+}
+
+export function hasProjectChordDictionaryPreferredShape(
+  context: ChordDictionaryPreferenceContext | null | undefined,
+  availableShapeIds: readonly string[] | null | undefined,
+): boolean {
+  const savedShapeId = readProjectChordDictionaryPreferredShapeId(context);
+  return (
+    savedShapeId !== null && normalizeAvailableShapeIds(availableShapeIds).includes(savedShapeId)
+  );
+}
+
+export function writeGlobalChordDictionaryPreferredShape(
+  context: ChordDictionaryPreferenceContext | null | undefined,
+  shapeId: string,
+): void {
+  const normalizedContext = normalizePreferenceContext(context);
+  const normalizedShapeId = normalizeShapeId(shapeId);
+  if (!normalizedContext || !normalizedShapeId) {
+    return;
+  }
+
+  const contextKey = buildContextKey(normalizedContext);
+  const preferences = readPreferencesStorage();
+  preferences.globalPreferredShapeIds[contextKey] = normalizedShapeId;
+  writePreferencesStorage(preferences);
+}
+
+export function writeProjectChordDictionaryPreferredShape(
+  context: ChordDictionaryPreferenceContext | null | undefined,
+  shapeId: string,
+): void {
+  const normalizedContext = normalizePreferenceContext(context);
+  const normalizedShapeId = normalizeShapeId(shapeId);
+  if (!normalizedContext?.projectId || !normalizedShapeId) {
+    return;
+  }
+
+  const contextKey = buildContextKey(normalizedContext);
+  const preferences = readPreferencesStorage();
+  preferences.projectPreferredShapeIds[normalizedContext.projectId] = {
+    ...(preferences.projectPreferredShapeIds[normalizedContext.projectId] ?? {}),
+    [contextKey]: normalizedShapeId,
+  };
+  writePreferencesStorage(preferences);
+}
+
+export function clearGlobalChordDictionaryPreferredShape(
+  context: ChordDictionaryPreferenceContext | null | undefined,
+): void {
+  const normalizedContext = normalizePreferenceContext(context);
+  if (!normalizedContext) {
+    return;
+  }
+
+  const preferences = readPreferencesStorage();
+  delete preferences.globalPreferredShapeIds[buildContextKey(normalizedContext)];
+  writePreferencesStorage(preferences);
+}
+
+export function clearProjectChordDictionaryPreferredShape(
+  context: ChordDictionaryPreferenceContext | null | undefined,
+): void {
+  const normalizedContext = normalizePreferenceContext(context);
+  if (!normalizedContext?.projectId) {
+    return;
+  }
+
+  const contextKey = buildContextKey(normalizedContext);
+  const preferences = readPreferencesStorage();
+  const projectPreferences =
+    preferences.projectPreferredShapeIds[normalizedContext.projectId] ?? {};
+  delete projectPreferences[contextKey];
+
+  if (Object.keys(projectPreferences).length === 0) {
+    delete preferences.projectPreferredShapeIds[normalizedContext.projectId];
+  } else {
+    preferences.projectPreferredShapeIds[normalizedContext.projectId] = projectPreferences;
+  }
+
+  writePreferencesStorage(preferences);
+}
+
+export function resetGlobalChordDictionaryPreferredShape(
+  context: ChordDictionaryPreferenceContext | null | undefined,
+): void {
+  clearGlobalChordDictionaryPreferredShape(context);
+}
+
+export function resetProjectChordDictionaryPreferredShape(
+  context: ChordDictionaryPreferenceContext | null | undefined,
+): void {
+  clearProjectChordDictionaryPreferredShape(context);
+}

--- a/apps/desktop/src/styles/tools.css
+++ b/apps/desktop/src/styles/tools.css
@@ -370,11 +370,24 @@
 .chord-dictionary-actions,
 .chord-toolbar-cluster,
 .live-follow-controls,
+.chord-shape-control-row,
 .chord-shape-tabs {
   display: flex;
   align-items: center;
   gap: 0.5rem;
   flex-wrap: wrap;
+}
+
+.chord-shape-controls {
+  display: grid;
+  justify-items: end;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.chord-shape-control-row {
+  justify-content: flex-end;
+  min-width: 0;
 }
 
 .chord-toolbar-cluster--end {
@@ -383,6 +396,7 @@
 
 .chord-icon-button,
 .chord-pill,
+.chord-reset-button,
 .chord-shape-tab {
   border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
   background: color-mix(in srgb, var(--panel) 76%, var(--panel-strong) 24%);
@@ -394,16 +408,19 @@
 }
 
 .chord-icon-button,
+.chord-reset-button,
 .chord-shape-tab {
   cursor: pointer;
 }
 
 .chord-icon-button:hover,
+.chord-reset-button:hover,
 .chord-shape-tab:hover {
   border-color: color-mix(in srgb, var(--playback-accent) 42%, var(--divider));
 }
 
 .chord-icon-button:focus-visible,
+.chord-reset-button:focus-visible,
 .chord-shape-tab:focus-visible,
 .guitar-fretboard__dot:focus-visible,
 .chord-shape-card__label:focus-visible,
@@ -871,6 +888,25 @@
   color: var(--text);
   font-size: 0.82rem;
   font-weight: 850;
+}
+
+.chord-reset-button {
+  min-height: 2rem;
+  border-radius: 8px;
+  padding: 0.34rem 0.65rem;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.chord-shape-preference-copy {
+  max-width: min(100%, 32rem);
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.76rem;
+  font-weight: 760;
+  line-height: 1.35;
+  text-align: right;
 }
 
 .chord-shape-grid {
@@ -1527,6 +1563,18 @@
   .chord-card-row,
   .note-inspector dl {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .chord-shape-controls {
+    justify-items: start;
+  }
+
+  .chord-shape-control-row {
+    justify-content: flex-start;
+  }
+
+  .chord-shape-preference-copy {
+    text-align: left;
   }
 
   .chord-shape-tabs {


### PR DESCRIPTION
## Summary
- Add local Chord Dictionary shape preferences for global and per-project guitar choices.
- Resolve preferred shapes by project override, then global preference, then generated default.
- Scope persisted shape keys to instrument and displayed chord so live transpose uses the displayed chord's own preference.

Closes #266

## Testing
- git diff --check
- git diff --exit-code -- apps/backend packages/shared-types
- pnpm --filter @tuneforge/desktop lint
- pnpm --filter @tuneforge/desktop typecheck
- pnpm --filter @tuneforge/desktop test
- ./node_modules/.bin/commitlint --config commitlint.config.cjs --from origin/main --to HEAD
