### PR TITLE
feat: add accordion chord dictionary UI

### DIFF
--- a/apps/desktop/src/App.tools-chord-dictionary.test.tsx
+++ b/apps/desktop/src/App.tools-chord-dictionary.test.tsx
@@ -4,7 +4,10 @@ import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChordSegmentSchema } from "./lib/api";
 import { renderApp, resetAppTestHarness } from "./test/appTestHarness";
-import { ChordDictionaryPage } from "./features/tools/ChordDictionaryPage";
+import {
+  AccordionCandidateList,
+  ChordDictionaryPage,
+} from "./features/tools/ChordDictionaryPage";
 import { ChordDictionaryFollowArmProvider } from "./features/tools/chordDictionaryFollowArm";
 import {
   buildChordDictionaryFollowProjectContext,
@@ -24,6 +27,128 @@ import {
 
 const DICTIONARY_SHAPE_GROUP_NAME = "Global guitar shape preference choices";
 const LIVE_SHAPE_GROUP_NAME = "Project guitar shape preference choices";
+
+function getDictionaryInstrumentSelector() {
+  const scopedSelector =
+    screen.queryByRole("group", { name: "Instrument status" }) ??
+    screen.queryByRole("group", { name: "Live instrument" });
+  if (scopedSelector) {
+    return scopedSelector as HTMLElement;
+  }
+
+  const instrumentGroups = screen.getAllByRole("group", { name: /instrument/i });
+  const instrumentSelector = instrumentGroups.find(
+    (group) =>
+      within(group).queryByRole("button", { name: "Guitar" }) ||
+      within(group).queryByRole("button", { name: "Accordion" }),
+  );
+
+  if (!instrumentSelector) {
+    throw new Error("Expected a dictionary instrument selector with Guitar and Accordion choices");
+  }
+
+  return instrumentSelector as HTMLElement;
+}
+
+function expectSelectedOrHighlighted(element: HTMLElement) {
+  const className = String(element.className);
+  const isSelected =
+    element.getAttribute("aria-pressed") === "true" ||
+    element.getAttribute("aria-selected") === "true" ||
+    element.getAttribute("aria-current") === "true" ||
+    element.getAttribute("data-selected") === "true" ||
+    element.getAttribute("data-highlighted") === "true" ||
+    className.includes("--active") ||
+    className.includes("--selected") ||
+    className.includes("is-active") ||
+    className.includes("is-selected");
+
+  expect(isSelected).toBe(true);
+}
+
+function getAccordionSurface(selectorRoot: HTMLElement, selectors: string) {
+  const surface = selectorRoot.querySelector(selectors);
+  if (!(surface instanceof HTMLElement)) {
+    throw new Error(`Expected accordion surface matching ${selectors}`);
+  }
+  return surface;
+}
+
+function getSelectedAccordionButton(
+  container: HTMLElement,
+  name: RegExp | string,
+): HTMLElement {
+  const buttons = within(container).getAllByRole("button", { name });
+  const selectedButton = buttons.find((button) => {
+    const className = String(button.className);
+    return (
+      button.getAttribute("aria-pressed") === "true" ||
+      button.getAttribute("aria-selected") === "true" ||
+      button.getAttribute("data-selected") === "true" ||
+      button.getAttribute("data-highlighted") === "true" ||
+      className.includes("--active") ||
+      className.includes("--selected") ||
+      className.includes("is-active") ||
+      className.includes("is-selected")
+    );
+  });
+
+  if (!selectedButton) {
+    throw new Error(`Expected selected accordion button named ${String(name)}`);
+  }
+
+  return selectedButton as HTMLElement;
+}
+
+function readNumericStyleVar(element: HTMLElement, name: string) {
+  const rawValue = element.style.getPropertyValue(name);
+  expect(rawValue).not.toBe("");
+  const value = Number(rawValue);
+  expect(Number.isFinite(value)).toBe(true);
+  return value;
+}
+
+function getAccordionKeyByMidi(keyboard: HTMLElement, midi: number, color: "black" | "white") {
+  const key = keyboard.querySelector(`[data-midi="${midi}"][data-key-color="${color}"]`);
+  if (!(key instanceof HTMLElement)) {
+    throw new Error(`Expected ${color} accordion keyboard key for MIDI ${midi}`);
+  }
+  return key;
+}
+
+async function selectAccordionDictionary() {
+  const user = userEvent.setup();
+  await renderChordDictionary();
+
+  const instrumentSelector = getDictionaryInstrumentSelector();
+  expect(within(instrumentSelector).getByRole("button", { name: "Guitar" })).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+
+  const accordionButton = within(instrumentSelector).getByRole("button", {
+    name: "Accordion",
+  });
+  await user.click(accordionButton);
+
+  await waitFor(() =>
+    expect(within(getDictionaryInstrumentSelector()).getByRole("button", { name: "Accordion" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    ),
+  );
+  expect(within(getDictionaryInstrumentSelector()).getByRole("button", { name: "Guitar" })).toHaveAttribute(
+    "aria-pressed",
+    "false",
+  );
+  expect(within(getDictionaryInstrumentSelector()).getByRole("button", { name: "Accordion" })).toHaveClass(
+    "chord-instrument-button--active",
+  );
+  expect(within(getDictionaryInstrumentSelector()).getByRole("button", { name: "Guitar" })).not.toHaveClass(
+    "chord-instrument-button--active",
+  );
+  return user;
+}
 
 function renderChordDictionaryView() {
   const view = renderApp(["/tools?tool=chord-dictionary"]);
@@ -97,6 +222,17 @@ const cTimeline: ChordSegmentSchema[] = [
     end_seconds: 16,
     label: "C",
     pitch_class: 0,
+    quality: "major",
+    start_seconds: 0,
+  },
+];
+
+const fSharpTimeline: ChordSegmentSchema[] = [
+  {
+    confidence: 0.86,
+    end_seconds: 16,
+    label: "F#",
+    pitch_class: 6,
     quality: "major",
     start_seconds: 0,
   },
@@ -507,9 +643,14 @@ describe("Desktop app tools chord dictionary", () => {
     await renderChordDictionary();
 
     expect(screen.getByLabelText("Chord search")).toHaveValue("C");
-    const instrumentStatus = screen.getByRole("group", { name: "Instrument status" });
-    expect(within(instrumentStatus).getByText("Guitar")).toBeInTheDocument();
-    expect(within(instrumentStatus).queryByRole("button", { name: "Guitar" })).not.toBeInTheDocument();
+    const instrumentSelector = getDictionaryInstrumentSelector();
+    expect(within(instrumentSelector).getByRole("button", { name: "Guitar" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(
+      within(instrumentSelector).getByRole("button", { name: "Accordion" }),
+    ).toHaveAttribute("aria-pressed", "false");
     expectTextVisible("C E G");
     expect(
       screen.getAllByRole("button", { name: "C3 string 5 fret 3" }).length,
@@ -524,6 +665,277 @@ describe("Desktop app tools chord dictionary", () => {
       /Finger\s*3/,
       /Degree\s*1/,
     ]);
+  });
+
+  it("selects Accordion and renders C across left and right hand surfaces", async () => {
+    await selectAccordionDictionary();
+
+    expect(screen.getByRole("heading", { name: "C accordion positions" })).toBeInTheDocument();
+    expect(screen.getByText("Region C")).toBeInTheDocument();
+
+    const leftHand = screen.getByRole("group", { name: /Left hand/i });
+    const rightHand = screen.getByRole("group", { name: /Right hand/i });
+    expect(
+      Boolean(leftHand.compareDocumentPosition(rightHand) & Node.DOCUMENT_POSITION_FOLLOWING),
+    ).toBe(true);
+
+    const stradellaBoard = getAccordionSurface(
+      leftHand,
+      '[data-surface="stradella"], [data-surface="button-board"], .accordion-stradella, .accordion-button-board, .stradella-board',
+    );
+    const keyboard = getAccordionSurface(
+      rightHand,
+      '[data-surface="keyboard"], .accordion-keyboard, .piano-keyboard',
+    );
+
+    expect(stradellaBoard).toBeInTheDocument();
+    expect(keyboard).toBeInTheDocument();
+    expect(keyboard).toHaveAttribute("data-orientation", "vertical");
+    expect(keyboard).toHaveAttribute("data-black-offset", "true");
+    const whiteKeyCount = Number(keyboard.style.getPropertyValue("--accordion-white-key-count"));
+    expect(whiteKeyCount).toBeLessThanOrEqual(9);
+    const whiteKeyLayer = getAccordionSurface(keyboard, ".accordion-keyboard__white-keys");
+    const blackKeyLayer = getAccordionSurface(keyboard, ".accordion-keyboard__black-keys");
+    expect(keyboard.children[0]).toBe(whiteKeyLayer);
+    expect(keyboard.children[1]).toBe(blackKeyLayer);
+    expect(whiteKeyLayer.querySelectorAll(".accordion-keyboard__key--white")).toHaveLength(whiteKeyCount);
+    expect(blackKeyLayer.querySelectorAll(".accordion-keyboard__key--black").length).toBeGreaterThan(0);
+
+    const blackKey = keyboard.querySelector(
+      '[data-key-color="black"][data-key-position="black-overlay"]',
+    );
+    expect(blackKey).toBeInTheDocument();
+    expect((blackKey as HTMLElement).style.getPropertyValue("--accordion-white-index")).not.toBe("");
+    const whiteKeys = [...whiteKeyLayer.querySelectorAll<HTMLElement>('[data-key-color="white"]')];
+    const blackKeys = [...blackKeyLayer.querySelectorAll<HTMLElement>('[data-key-color="black"]')];
+    expect(whiteKeys.map((key) => key.dataset.midi)).toEqual([
+      "60",
+      "62",
+      "64",
+      "65",
+      "67",
+      "69",
+      "71",
+      "72",
+    ]);
+    expect(blackKeys.map((key) => key.dataset.midi)).toEqual(["61", "63", "66", "68", "70"]);
+    const cKey = getAccordionKeyByMidi(keyboard, 60, "white");
+    const cSharpKey = getAccordionKeyByMidi(keyboard, 61, "black");
+    const dKey = getAccordionKeyByMidi(keyboard, 62, "white");
+    const dSharpKey = getAccordionKeyByMidi(keyboard, 63, "black");
+    const eKey = getAccordionKeyByMidi(keyboard, 64, "white");
+    const fKey = getAccordionKeyByMidi(keyboard, 65, "white");
+    const fSharpKey = getAccordionKeyByMidi(keyboard, 66, "black");
+    const gKey = getAccordionKeyByMidi(keyboard, 67, "white");
+    const gSharpKey = getAccordionKeyByMidi(keyboard, 68, "black");
+    const aKey = getAccordionKeyByMidi(keyboard, 69, "white");
+    const aSharpKey = getAccordionKeyByMidi(keyboard, 70, "black");
+    const bKey = getAccordionKeyByMidi(keyboard, 71, "white");
+    const highCKey = getAccordionKeyByMidi(keyboard, 72, "white");
+    expect(whiteKeyLayer).toContainElement(cKey);
+    expect(whiteKeyLayer).toContainElement(dKey);
+    expect(blackKeyLayer).toContainElement(cSharpKey);
+    expect(cKey).toHaveClass("accordion-keyboard__key--white");
+    expect(cSharpKey).toHaveClass("accordion-keyboard__key--black");
+    expect(cKey.parentElement).toBe(whiteKeyLayer);
+    expect(cSharpKey.parentElement).toBe(blackKeyLayer);
+    const cWhiteIndex = readNumericStyleVar(cKey, "--accordion-white-index");
+    const cSharpBoundaryIndex = readNumericStyleVar(cSharpKey, "--accordion-white-index");
+    const dWhiteIndex = readNumericStyleVar(dKey, "--accordion-white-index");
+    const eWhiteIndex = readNumericStyleVar(eKey, "--accordion-white-index");
+    const fWhiteIndex = readNumericStyleVar(fKey, "--accordion-white-index");
+    const gWhiteIndex = readNumericStyleVar(gKey, "--accordion-white-index");
+    const aWhiteIndex = readNumericStyleVar(aKey, "--accordion-white-index");
+    const bWhiteIndex = readNumericStyleVar(bKey, "--accordion-white-index");
+    expect(cSharpBoundaryIndex).toBe(cWhiteIndex);
+    expect(dWhiteIndex).toBe(cWhiteIndex + 1);
+    expect(readNumericStyleVar(dSharpKey, "--accordion-white-index")).toBe(dWhiteIndex);
+    expect(readNumericStyleVar(eKey, "--accordion-white-index")).toBe(dWhiteIndex + 1);
+    expect(readNumericStyleVar(fSharpKey, "--accordion-white-index")).toBe(fWhiteIndex);
+    expect(readNumericStyleVar(gSharpKey, "--accordion-white-index")).toBe(gWhiteIndex);
+    expect(readNumericStyleVar(aSharpKey, "--accordion-white-index")).toBe(aWhiteIndex);
+    expect(readNumericStyleVar(highCKey, "--accordion-white-index")).toBe(bWhiteIndex + 1);
+    const blackBoundaryIndices = blackKeys.map((key) =>
+      readNumericStyleVar(key, "--accordion-white-index"),
+    );
+    expect(blackBoundaryIndices).toEqual([
+      cWhiteIndex,
+      dWhiteIndex,
+      fWhiteIndex,
+      gWhiteIndex,
+      aWhiteIndex,
+    ]);
+    expect(blackBoundaryIndices).not.toContain(eWhiteIndex);
+    expect(blackBoundaryIndices).not.toContain(bWhiteIndex);
+    expect(whiteKeys[cWhiteIndex]).toBe(cKey);
+    expect(whiteKeys[dWhiteIndex]).toBe(dKey);
+    expect(
+      keyboard.querySelector('[data-key-color="white"][data-key-position="white-surface-row"]'),
+    ).toBeInTheDocument();
+
+    expect(within(leftHand).getByText(/^C$/)).toBeInTheDocument();
+    expect(within(leftHand).getByText(/^CM$/)).toBeInTheDocument();
+
+    const selectedBass = getSelectedAccordionButton(
+      leftHand,
+      /(^C$|\bC bass\b|\bbass C\b)/i,
+    );
+    const selectedMajor = getSelectedAccordionButton(
+      leftHand,
+      /(^CM$|\bCM\b.*\bMaj(?:or)?\b|\bC maj(?:or)?\b|\bmaj(?:or)? C\b)/i,
+    );
+    const selectedRightKey = within(rightHand).getByRole("button", {
+      name: /C4 degree 1 accordion keyboard key/i,
+    });
+    const eRightKey = within(rightHand).getByRole("button", {
+      name: /E4 degree 3 accordion keyboard key/i,
+    });
+    const gRightKey = within(rightHand).getByRole("button", {
+      name: /G4 degree 5 accordion keyboard key/i,
+    });
+
+    expectSelectedOrHighlighted(selectedBass);
+    expectSelectedOrHighlighted(selectedMajor);
+    expect(selectedBass).toHaveClass("accordion-stradella__button--bass");
+    expect(selectedMajor).toHaveClass("accordion-stradella__button--major");
+    const bassColumn = readNumericStyleVar(selectedBass, "--accordion-button-column");
+    const bassRow = readNumericStyleVar(selectedBass, "--accordion-button-row");
+    const majorColumn = readNumericStyleVar(selectedMajor, "--accordion-button-column");
+    const majorRow = readNumericStyleVar(selectedMajor, "--accordion-button-row");
+    expect(majorColumn).toBeLessThan(bassColumn);
+    expect(majorRow).toBeGreaterThan(bassRow);
+    expectSelectedOrHighlighted(selectedRightKey);
+    expectSelectedOrHighlighted(eRightKey);
+    expectSelectedOrHighlighted(gRightKey);
+    const activeKeyboardMidi = [...keyboard.querySelectorAll(".accordion-keyboard__key--active-tone")]
+      .map((key) => (key as HTMLElement).dataset.midi)
+      .sort();
+    expect(activeKeyboardMidi).toEqual(["60", "64", "67"]);
+    expect([...blackKeyLayer.querySelectorAll(".accordion-keyboard__key--active-tone")]).toHaveLength(0);
+    expect(selectedRightKey).toHaveTextContent("C4");
+    expect(selectedRightKey).toHaveTextContent("1");
+    expect(eRightKey).toHaveTextContent("E4");
+    expect(eRightKey).toHaveTextContent("3");
+    expect(gRightKey).toHaveTextContent("G4");
+    expect(gRightKey).toHaveTextContent("5");
+  });
+
+  it("renders real accordion diff labels only for approximate candidates", async () => {
+    await selectAccordionDictionary();
+
+    expect(screen.queryByText(/Missing:\s*None/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Added:\s*None/i)).not.toBeInTheDocument();
+
+    changeChordSearch("C7b5");
+
+    await screen.findByRole("heading", { name: "C7b5 accordion positions" });
+    expect(screen.queryByLabelText("Accordion approximation differences")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Accordion left-hand candidates")).toHaveTextContent(
+      /C bass \+ C7[\s\S]*Missing:\s*Gb/i,
+    );
+
+    changeChordSearch("Csus4");
+
+    await screen.findByRole("heading", { name: "Csus4 accordion positions" });
+    const susApproximationDiff = await screen.findByLabelText(
+      "Accordion approximation differences",
+    );
+    expect(susApproximationDiff).not.toHaveTextContent(/Missing:/i);
+    expect(susApproximationDiff).toHaveTextContent(/Added:\s*(?!None\b).+/i);
+    const fMinorSusCandidate = screen
+      .getAllByRole("button", { name: /F bass \+ Cm/i })
+      .find((candidate) => candidate.textContent?.includes("Added: Eb"));
+    expect(fMinorSusCandidate).toBeDefined();
+    expect(fMinorSusCandidate as HTMLElement).not.toHaveTextContent(/Missing:/i);
+    expect(fMinorSusCandidate as HTMLElement).toHaveTextContent(/Added:\s*Eb/i);
+    expect(fMinorSusCandidate as HTMLElement).not.toHaveTextContent(/Added:\s*E(?:,|\b)/i);
+    expect(screen.queryByText(/Missing:\s*None/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Added:\s*None/i)).not.toBeInTheDocument();
+  });
+
+  it("renders accordion candidate added tones verbatim without inferred sus4 thirds", () => {
+    render(
+      <AccordionCandidateList
+        candidates={[
+          {
+            addedTones: ["Eb"],
+            buttons: [],
+            buttonIds: [],
+            detail: "C bass + Cm row",
+            fingering: null,
+            id: "c-sus-minor",
+            isExact: false,
+            label: "C bass + Cm",
+            missingTones: ["F"],
+            rank: 1,
+          },
+        ]}
+        selectedCandidateId="c-sus-minor"
+        onSelectCandidate={vi.fn()}
+      />,
+    );
+
+    const candidate = screen.getByRole("button", { name: /C bass \+ Cm/i });
+    expect(candidate).toHaveTextContent(/Missing:\s*F/i);
+    expect(candidate).toHaveTextContent(/Added:\s*Eb/i);
+    expect(candidate).not.toHaveTextContent(/Added:\s*E(?:,|\b)/i);
+
+    const selectedDiff = screen.getByLabelText("Accordion approximation differences");
+    expect(selectedDiff).toHaveTextContent(/Missing:\s*F/i);
+    expect(selectedDiff).toHaveTextContent(/Added:\s*Eb/i);
+    expect(selectedDiff).not.toHaveTextContent(/Added:\s*E(?:,|\b)/i);
+  });
+
+  it("keeps alternate full-board left-hand candidate buttons visible after selection", async () => {
+    const user = await selectAccordionDictionary();
+    changeChordSearch("C7b5");
+
+    await screen.findByRole("heading", { name: "C7b5 accordion positions" });
+    const candidatePanel = screen.getByLabelText("Accordion left-hand candidates");
+    const cSevenCandidates = within(candidatePanel).getAllByRole("button", {
+      name: /C bass \+ C7/i,
+    });
+    expect(cSevenCandidates.length).toBeGreaterThan(1);
+    await user.click(cSevenCandidates[cSevenCandidates.length - 1] as HTMLElement);
+
+    const leftHand = screen.getByRole("group", { name: /Left hand/i });
+    await waitFor(() => {
+      expectSelectedOrHighlighted(getSelectedAccordionButton(leftHand, /(^C$|\bC bass\b)/i));
+      expectSelectedOrHighlighted(getSelectedAccordionButton(leftHand, /(^C7$|\bC7\b)/i));
+      expectInspectorToShow([/Hand\s*Left|Left hand/i, /Surface\s*Stradella|Stradella/i]);
+    });
+  });
+
+  it("updates the accordion note inspector from left buttons and right keys", async () => {
+    const user = await selectAccordionDictionary();
+
+    const leftHand = screen.getByRole("group", { name: /Left hand/i });
+    const rightHand = screen.getByRole("group", { name: /Right hand/i });
+    const leftCButton = getSelectedAccordionButton(leftHand, /(^C$|\bC bass\b|\bbass C\b)/i);
+
+    await user.click(leftCButton);
+
+    await waitFor(() =>
+      expectInspectorToShow([
+        /C\d|Pitch\s*C/i,
+        /Hand\s*Left|Left hand/i,
+        /Side\s*(Left|Bass)|Bass side|Stradella/i,
+        /Surface\s*(Stradella|Button board|button-board)|Button board|button-board/i,
+        /Degree\s*1/i,
+      ]),
+    );
+
+    const rightCKey = getSelectedAccordionButton(rightHand, /\bC(4|5)?\b/i);
+    await user.click(rightCKey);
+
+    await waitFor(() =>
+      expectInspectorToShow([
+        /C\d|Pitch\s*C/i,
+        /Hand\s*Right|Right hand/i,
+        /Surface\s*Keyboard|Keyboard/i,
+        /Degree\s*1/i,
+      ]),
+    );
   });
 
   it("renders C open with standard vertical-string diagram semantics", async () => {
@@ -869,6 +1281,68 @@ describe("Desktop app tools chord dictionary", () => {
     expect(screen.queryByRole("heading", { name: "C guitar shapes" })).not.toBeInTheDocument();
   });
 
+  it("renders accordion positions from Live Follow project chord context", async () => {
+    const user = userEvent.setup();
+    await renderChordDictionaryWithPlayback({
+      playback: makePlaybackValue({
+        project: makeFollowProject({
+          authoritativeSourceTimeline: cTimeline,
+          displayedKey: { pitchClass: 0, mode: "major" },
+          displayedTimeline: cTimeline,
+          sourceKey: { pitchClass: 0, mode: "major" },
+          totalDisplayTransposeSemitones: 0,
+        }),
+      }),
+    });
+
+    await user.click(within(getDictionaryInstrumentSelector()).getByRole("button", { name: "Accordion" }));
+
+    await waitFor(() =>
+      expect(within(getDictionaryInstrumentSelector()).getByRole("button", { name: "Accordion" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      ),
+    );
+
+    const currentChord = screen.getByLabelText("Current chord");
+    expect(currentChord).toHaveTextContent(/Source chord\s*C/);
+    expect(currentChord).toHaveTextContent(/Display chord\s*C/);
+    expect(screen.getByRole("heading", { name: "C accordion positions" })).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: /Left hand/i })).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: /Right hand/i })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "C guitar shapes" })).not.toBeInTheDocument();
+  });
+
+  it("renders out-of-window accordion roots in Live Follow without moving the key region", async () => {
+    const user = userEvent.setup();
+    await renderChordDictionaryWithPlayback({
+      playback: makePlaybackValue({
+        project: makeFollowProject({
+          authoritativeSourceTimeline: fSharpTimeline,
+          displayedKey: { pitchClass: 0, mode: "major" },
+          displayedTimeline: fSharpTimeline,
+          sourceKey: { pitchClass: 0, mode: "major" },
+          totalDisplayTransposeSemitones: 0,
+        }),
+      }),
+    });
+
+    await user.click(within(getDictionaryInstrumentSelector()).getByRole("button", { name: "Accordion" }));
+
+    await waitFor(() =>
+      expect(within(getDictionaryInstrumentSelector()).getByRole("button", { name: "Accordion" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      ),
+    );
+
+    expect(screen.getByLabelText("Current chord")).toHaveTextContent(/Display chord\s*F#/);
+    expect(screen.getByText("Region C")).toBeInTheDocument();
+    const leftHand = screen.getByRole("group", { name: /Left hand/i });
+    expectSelectedOrHighlighted(getSelectedAccordionButton(leftHand, /(^F#$|\bF# bass\b)/i));
+    expectSelectedOrHighlighted(getSelectedAccordionButton(leftHand, /(^F#M$|\bF#M\b)/i));
+  });
+
   it("uses a Dictionary global C shape preference for Live Follow when the project has no pick", async () => {
     writeGlobalChordDictionaryPreferredShape(
       makeDictionaryShapePreferenceContext({ chordLabel: "C" }),
@@ -1155,29 +1629,28 @@ describe("Desktop app tools chord dictionary", () => {
     expect(toolsScreen.queryByRole("button", { name: "G/D" })).not.toBeInTheDocument();
     expect(toolsScreen.queryByRole("button", { name: "Am/C" })).not.toBeInTheDocument();
     expect(toolsScreen.queryByRole("button", { name: "F/C" })).not.toBeInTheDocument();
-    expect(toolsScreen.queryByRole("button", { name: "Accordion" })).not.toBeInTheDocument();
   });
 
-  it("does not expose fake instrument, library, playback, or settings affordances", async () => {
+  it("exposes only real instrument choices without fake library, playback, or settings affordances", async () => {
     await renderChordDictionary();
 
     const toolsScreen = within(getToolsScreen());
-    const instrumentStatus = toolsScreen.getByRole("group", { name: "Instrument status" });
-    expect(within(instrumentStatus).getByText("Guitar")).toBeInTheDocument();
+    const instrumentSelector = getDictionaryInstrumentSelector();
+    expect(within(instrumentSelector).getByRole("button", { name: "Guitar" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
     expect(
-      within(instrumentStatus).queryByRole("button", { name: "Guitar" }),
+      within(instrumentSelector).getByRole("button", { name: "Accordion" }),
+    ).toHaveAttribute("aria-pressed", "false");
+    expect(
+      within(instrumentSelector).queryByRole("button", { name: "Piano" }),
     ).not.toBeInTheDocument();
     expect(
-      within(instrumentStatus).queryByRole("button", { name: "Piano" }),
+      within(instrumentSelector).queryByRole("button", { name: "Organ" }),
     ).not.toBeInTheDocument();
     expect(
-      within(instrumentStatus).queryByRole("button", { name: "Accordion" }),
-    ).not.toBeInTheDocument();
-    expect(
-      within(instrumentStatus).queryByRole("button", { name: "Organ" }),
-    ).not.toBeInTheDocument();
-    expect(
-      within(instrumentStatus).queryByRole("button", { name: /48\s+More/i }),
+      within(instrumentSelector).queryByRole("button", { name: /48\s+More/i }),
     ).not.toBeInTheDocument();
     expect(
       toolsScreen.queryByRole("button", { name: /Toggle project follow/i }),

--- a/apps/desktop/src/features/tools/ChordDictionaryPage.tsx
+++ b/apps/desktop/src/features/tools/ChordDictionaryPage.tsx
@@ -9,12 +9,17 @@ import {
   SlidersHorizontal,
 } from "lucide-react";
 import {
+  ACCORDION_STANDARD_PROFILE,
   CHORD_QUALITY_DEFINITIONS,
   GUITAR_STANDARD_PROFILE,
   formatKey,
+  formatPitchClass,
   generateGuitarVoicings,
+  generateAccordionVoicings,
   midiToPitch,
+  parsePitch,
   spellChord,
+  type AccordionVoicing,
   type ChordDisplayContext,
   type GuitarVoicing,
   type MusicalKey,
@@ -38,6 +43,7 @@ import {
 } from "./chordDictionaryPreferences";
 
 type ChordDictionarySurface = "dictionary" | "follow";
+type ChordDictionaryInstrumentId = "guitar" | "accordion";
 type NotePoint = {
   degree: string;
   displayFret: number;
@@ -50,6 +56,89 @@ type NotePoint = {
   shapeNote?: string;
   string: number;
 };
+type AccordionInspectorPoint = {
+  degree: string | null;
+  finger: string | null;
+  hand: "Left" | "Right";
+  id: string;
+  label: string;
+  pitchLabel: string;
+  side: string;
+  source: string;
+  surface: string;
+};
+type AccordionButtonView = {
+  candidateIds: readonly string[];
+  column: number;
+  degree: string | null;
+  hand: "Left";
+  id: string;
+  isChordTone: boolean;
+  label: string;
+  noteLabel: string;
+  pitchClass: number | null;
+  pitchLabel: string;
+  rowId: AccordionStradellaRowIdView;
+  rowLabel: string;
+  side: string;
+  sourceColumn: number;
+  surface: "Stradella";
+};
+type AccordionKeyboardNoteView = {
+  degree: string;
+  finger: string | null;
+  hand: "Right";
+  id: string;
+  midi: number;
+  noteLabel: string;
+  pitchLabel: string;
+  side: "Treble";
+  surface: "Keyboard";
+};
+type AccordionKeyboardKeyView = {
+  isBlack: boolean;
+  midi: number;
+  note: AccordionKeyboardNoteView | null;
+  pitchLabel: string;
+  whiteIndex: number;
+};
+type AccordionKeyboardSlice = {
+  keys: readonly AccordionKeyboardKeyView[];
+  whiteKeyCount: number;
+};
+type AccordionLeftHandCandidateView = {
+  addedTones: readonly string[];
+  buttons: readonly AccordionButtonView[];
+  buttonIds: readonly string[];
+  detail: string;
+  fingering: string | null;
+  id: string;
+  isExact: boolean;
+  label: string;
+  missingTones: readonly string[];
+  rank: number;
+};
+type AccordionVoicingView = {
+  buttons: readonly AccordionButtonView[];
+  candidateIds: readonly string[];
+  chordLabel: string;
+  id: string;
+  keyboardSlice: AccordionKeyboardSlice;
+  label: string;
+  leftHandCandidates: readonly AccordionLeftHandCandidateView[];
+  rank: number;
+  regionRoot: string | null;
+  rightHandNotes: readonly AccordionKeyboardNoteView[];
+  selectedCandidateId: string | null;
+};
+type AccordionStradellaRowIdView =
+  | "diminished"
+  | "dominant7"
+  | "minor"
+  | "major"
+  | "bass"
+  | "counterbass"
+  | (string & {});
 type GuitarStringView = {
   displayString: number;
   label: string;
@@ -106,10 +195,33 @@ type GuitarShape = {
 };
 
 const COMMON_CHORD_LABELS = ["C", "Dm", "Em", "F", "G", "Am", "Bdim"] as const;
-const CHORD_DICTIONARY_INSTRUMENT_ID = GUITAR_STANDARD_PROFILE.id;
+const GUITAR_INSTRUMENT_ID = GUITAR_STANDARD_PROFILE.id;
+const ACCORDION_INSTRUMENT_ID = ACCORDION_STANDARD_PROFILE.id;
+const CHORD_DICTIONARY_INSTRUMENTS = [
+  { id: GUITAR_INSTRUMENT_ID, label: GUITAR_STANDARD_PROFILE.label },
+  { id: ACCORDION_INSTRUMENT_ID, label: ACCORDION_STANDARD_PROFILE.label },
+] as const satisfies ReadonlyArray<{ id: ChordDictionaryInstrumentId; label: string }>;
+const ACCORDION_STRADDELLA_ROWS = [
+  { id: "diminished", label: "Dim" },
+  { id: "dominant7", label: "7" },
+  { id: "minor", label: "Min" },
+  { id: "major", label: "Maj" },
+  { id: "bass", label: "Bass" },
+  { id: "counterbass", label: "CB" },
+] as const satisfies ReadonlyArray<{ id: AccordionStradellaRowIdView; label: string }>;
+const ACCORDION_STRADDELLA_ROW_INDEX = new Map<string, number>(
+  ACCORDION_STRADDELLA_ROWS.map((row, index) => [row.id, index]),
+);
 
 function classNames(...values: Array<string | false | null | undefined>) {
   return values.filter(Boolean).join(" ");
+}
+
+function getChordDictionaryInstrumentLabel(instrumentId: ChordDictionaryInstrumentId) {
+  return (
+    CHORD_DICTIONARY_INSTRUMENTS.find((instrument) => instrument.id === instrumentId)?.label ??
+    GUITAR_STANDARD_PROFILE.label
+  );
 }
 
 function formatPreferenceKeyLabel(key: MusicalKey | null | undefined) {
@@ -120,6 +232,7 @@ function buildShapePreferenceContext({
   capoFret,
   chordLabel,
   displayedKey,
+  instrumentId,
   projectId,
   sourceKey,
   transposeSemitones,
@@ -128,6 +241,7 @@ function buildShapePreferenceContext({
   capoFret: number | null;
   chordLabel: string;
   displayedKey: MusicalKey | null;
+  instrumentId: ChordDictionaryInstrumentId;
   projectId: string | null;
   sourceKey: MusicalKey | null;
   transposeSemitones: number | null;
@@ -137,7 +251,7 @@ function buildShapePreferenceContext({
     capoFret,
     chordLabel,
     displayedKeyLabel: formatPreferenceKeyLabel(displayedKey),
-    instrumentId: CHORD_DICTIONARY_INSTRUMENT_ID,
+    instrumentId,
     projectId,
     sourceKeyLabel: formatPreferenceKeyLabel(sourceKey),
     transposeSemitones,
@@ -197,6 +311,8 @@ export function ChordDictionaryPage() {
   const [surface, setSurface] = useState<ChordDictionarySurface>(() =>
     followArmed ? "follow" : "dictionary",
   );
+  const [instrumentId, setInstrumentId] =
+    useState<ChordDictionaryInstrumentId>(GUITAR_INSTRUMENT_ID);
 
   useEffect(() => {
     if (routeFollowPlayback) {
@@ -256,20 +372,38 @@ export function ChordDictionaryPage() {
         </div>
 
         {surface === "dictionary" ? (
-          <DictionarySurface />
+          <DictionarySurface
+            instrumentId={instrumentId}
+            onInstrumentChange={setInstrumentId}
+          />
         ) : (
-          <LiveFollowSurface context={followContext} requestedProjectId={routeProjectId} />
+          <LiveFollowSurface
+            context={followContext}
+            instrumentId={instrumentId}
+            requestedProjectId={routeProjectId}
+            onInstrumentChange={setInstrumentId}
+          />
         )}
       </div>
     </div>
   );
 }
 
-function DictionarySurface() {
+function DictionarySurface({
+  instrumentId,
+  onInstrumentChange,
+}: {
+  instrumentId: ChordDictionaryInstrumentId;
+  onInstrumentChange: (instrumentId: ChordDictionaryInstrumentId) => void;
+}) {
   const [activeChord, setActiveChord] = useState("C");
   const [activeShape, setActiveShape] = useState<string | null>(null);
+  const [activeAccordionVoicing, setActiveAccordionVoicing] = useState<string | null>(null);
+  const [activeAccordionCandidate, setActiveAccordionCandidate] = useState<string | null>(null);
+  const [previewAccordionPointId, setPreviewAccordionPointId] = useState<string | null>(null);
   const [previewNoteId, setPreviewNoteId] = useState<string | null>(null);
   const [, setPreferenceRevision] = useState(0);
+  const [selectedAccordionPointId, setSelectedAccordionPointId] = useState<string | null>(null);
   const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
   const displayContext = useMemo<Partial<ChordDisplayContext>>(
     () => ({
@@ -323,6 +457,7 @@ function DictionarySurface() {
             capoFret: displayContext.capoFret ?? null,
             chordLabel: chordSpelling.label,
             displayedKey: null,
+            instrumentId: GUITAR_INSTRUMENT_ID,
             projectId: null,
             sourceKey: displayContext.sourceKey ?? null,
             transposeSemitones: displayContext.transposeSemitones ?? null,
@@ -368,6 +503,104 @@ function DictionarySurface() {
   const displayedNote = previewNote ?? selectedNote;
   const activeTooltipNoteId = previewNote?.id ?? selectedNote?.id ?? null;
   const selectedVoicing = guitarVoicings.find((voicing) => voicing.id === selectedShape?.id) ?? null;
+  const accordionVoicings = useMemo(
+    () =>
+      chordSpelling
+        ? generateAccordionVoicings(chordSpelling, null)
+        : [],
+    [chordSpelling],
+  );
+  const generatedAccordionVoicingViews = useMemo(
+    () => toAccordionVoicingViews(accordionVoicings),
+    [accordionVoicings],
+  );
+  const generatedAccordionVoicingIds = useMemo(
+    () => generatedAccordionVoicingViews.map((voicing) => voicing.id),
+    [generatedAccordionVoicingViews],
+  );
+  const accordionPreferenceContext = useMemo(
+    () =>
+      chordSpelling
+        ? buildShapePreferenceContext({
+            capoFret: null,
+            chordLabel: chordSpelling.label,
+            displayedKey: null,
+            instrumentId: ACCORDION_INSTRUMENT_ID,
+            projectId: null,
+            sourceKey: null,
+            transposeSemitones: null,
+            useCapoShapes: null,
+          })
+        : null,
+    [chordSpelling],
+  );
+  const preferredAccordionVoicingId = resolveChordDictionaryPreferredShapeId(
+    accordionPreferenceContext,
+    generatedAccordionVoicingIds,
+  );
+  const hasGlobalAccordionPreference = hasGlobalChordDictionaryPreferredShape(
+    accordionPreferenceContext,
+    generatedAccordionVoicingIds,
+  );
+  const accordionVoicingViews = useMemo(
+    () => promoteShapeToFirst(generatedAccordionVoicingViews, preferredAccordionVoicingId),
+    [generatedAccordionVoicingViews, preferredAccordionVoicingId],
+  );
+  const accordionResultKey = accordionVoicingViews.map((voicing) => voicing.id).join("|");
+  const firstAccordionVoicingId = accordionVoicingViews[0]?.id ?? null;
+  const firstAccordionCandidateId =
+    accordionVoicingViews[0]?.selectedCandidateId ??
+    accordionVoicingViews[0]?.leftHandCandidates[0]?.id ??
+    null;
+  const firstAccordionPointId =
+    accordionVoicingViews[0]?.rightHandNotes[0]?.id ??
+    accordionVoicingViews[0]?.buttons.find((button) =>
+      firstAccordionCandidateId ? button.candidateIds.includes(firstAccordionCandidateId) : false,
+    )?.id ??
+    null;
+  const selectAccordionVoicing = (voicing: AccordionVoicingView) => {
+    writeGlobalChordDictionaryPreferredShape(accordionPreferenceContext, voicing.id);
+    bumpPreferenceRevision();
+    setActiveAccordionVoicing(voicing.id);
+    setActiveAccordionCandidate(voicing.selectedCandidateId ?? voicing.leftHandCandidates[0]?.id ?? null);
+    setPreviewAccordionPointId(null);
+    setSelectedAccordionPointId(voicing.rightHandNotes[0]?.id ?? null);
+  };
+  useEffect(() => {
+    setActiveAccordionVoicing(firstAccordionVoicingId);
+    setActiveAccordionCandidate(firstAccordionCandidateId);
+    setPreviewAccordionPointId(null);
+    setSelectedAccordionPointId(firstAccordionPointId);
+  }, [accordionResultKey, firstAccordionCandidateId, firstAccordionPointId, firstAccordionVoicingId]);
+  const selectedAccordionVoicing =
+    accordionVoicingViews.find((voicing) => voicing.id === activeAccordionVoicing) ??
+    accordionVoicingViews[0] ??
+    null;
+  const selectedAccordionCandidate =
+    selectedAccordionVoicing?.leftHandCandidates.find(
+      (candidate) => candidate.id === activeAccordionCandidate,
+    ) ??
+    selectedAccordionVoicing?.leftHandCandidates.find(
+      (candidate) => candidate.id === selectedAccordionVoicing.selectedCandidateId,
+    ) ??
+    selectedAccordionVoicing?.leftHandCandidates[0] ??
+    null;
+  const selectedAccordionPoint = selectedAccordionVoicing
+    ? findAccordionInspectorPoint(
+        selectedAccordionVoicing,
+        selectedAccordionCandidate,
+        selectedAccordionPointId,
+      )
+    : null;
+  const previewAccordionPoint = previewAccordionPointId && selectedAccordionVoicing
+    ? findAccordionInspectorPoint(
+        selectedAccordionVoicing,
+        selectedAccordionCandidate,
+        previewAccordionPointId,
+      )
+    : null;
+  const displayedAccordionPoint = previewAccordionPoint ?? selectedAccordionPoint;
+  const activeAccordionPointId = previewAccordionPoint?.id ?? selectedAccordionPoint?.id ?? null;
   const sourceKeyLabel = displayContext.sourceKey
     ? formatKey(displayContext.sourceKey, "long")
     : "No source key";
@@ -386,26 +619,67 @@ function DictionarySurface() {
             onChange={(event) => {
               setActiveChord(event.currentTarget.value);
               setPreviewNoteId(null);
+              setPreviewAccordionPointId(null);
             }}
             placeholder="C major"
             value={activeChord}
           />
         </label>
-        <div className="chord-toolbar-cluster" role="group" aria-label="Instrument status">
-          <span className="chord-pill chord-pill--active">
-            <Music2 aria-hidden="true" />
-            <span>{GUITAR_STANDARD_PROFILE.label}</span>
-          </span>
-        </div>
+        <InstrumentSelector
+          ariaLabel="Instrument status"
+          instrumentId={instrumentId}
+          onInstrumentChange={onInstrumentChange}
+        />
       </div>
 
       {unsupportedChord ? (
         <div className="chord-dictionary-status" role="status">
           <strong>{activeChord}</strong>
-          <span>Unsupported chord symbol. No backed spelling or guitar voicings available.</span>
+          <span>
+            Unsupported chord symbol. No backed spelling or{" "}
+            {instrumentId === ACCORDION_INSTRUMENT_ID ? "accordion voicings" : "guitar voicings"} available.
+          </span>
         </div>
       ) : null}
 
+      {instrumentId === ACCORDION_INSTRUMENT_ID ? (
+        <AccordionDictionaryContent
+          activePointId={activeAccordionPointId}
+          activeChord={activeChord}
+          chordSpelling={chordSpelling}
+          displayedPoint={displayedAccordionPoint}
+          hasGlobalPreference={hasGlobalAccordionPreference}
+          selectedCandidate={selectedAccordionCandidate}
+          selectedVoicing={selectedAccordionVoicing}
+          unsupportedChord={unsupportedChord}
+          voicings={accordionVoicingViews}
+          onClearPreference={() => {
+            resetGlobalChordDictionaryPreferredShape(accordionPreferenceContext);
+            bumpPreferenceRevision();
+          }}
+          onPreviewPoint={setPreviewAccordionPointId}
+          onSelectCandidate={(candidateId) => {
+            setActiveAccordionCandidate(candidateId);
+            setPreviewAccordionPointId(null);
+            const nextCandidate =
+              selectedAccordionVoicing?.leftHandCandidates.find((candidate) => candidate.id === candidateId) ??
+              null;
+            const nextPointId =
+              (selectedAccordionVoicing
+                ? getAccordionFirstCandidateButtonId(selectedAccordionVoicing, nextCandidate)
+                : null) ??
+              selectedAccordionVoicing?.rightHandNotes[0]?.id ??
+              null;
+            setSelectedAccordionPointId(nextPointId);
+          }}
+          onSelectPoint={(pointId) => {
+            setPreviewAccordionPointId(null);
+            setSelectedAccordionPointId(pointId);
+          }}
+          onSelectVoicing={selectAccordionVoicing}
+        />
+      ) : (
+        <>
       <div className="chord-context-strip" aria-label="Display context">
         <ContextChip icon="instrument" label={GUITAR_STANDARD_PROFILE.label} />
         <ContextChip icon="shape" label={tuningLabel} />
@@ -564,6 +838,7 @@ function DictionarySurface() {
                     onClick={() => {
                       setActiveChord(chord.label);
                       setPreviewNoteId(null);
+                      setPreviewAccordionPointId(null);
                     }}
                     type="button"
                   >
@@ -627,7 +902,549 @@ function DictionarySurface() {
           </div>
         </aside>
       </div>
+        </>
+      )}
     </div>
+  );
+}
+
+function InstrumentSelector({
+  ariaLabel,
+  instrumentId,
+  onInstrumentChange,
+}: {
+  ariaLabel: string;
+  instrumentId: ChordDictionaryInstrumentId;
+  onInstrumentChange: (instrumentId: ChordDictionaryInstrumentId) => void;
+}) {
+  return (
+    <div className="chord-toolbar-cluster chord-instrument-selector" role="group" aria-label={ariaLabel}>
+      {CHORD_DICTIONARY_INSTRUMENTS.map((instrument) => (
+        <button
+          key={instrument.id}
+          aria-pressed={instrumentId === instrument.id}
+          className={classNames(
+            "chord-pill",
+            "chord-instrument-button",
+            instrumentId === instrument.id && "chord-instrument-button--active",
+            instrumentId === instrument.id && "chord-pill--active",
+          )}
+          onClick={() => onInstrumentChange(instrument.id)}
+          type="button"
+        >
+          <Music2 aria-hidden="true" />
+          <span>{instrument.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function AccordionDictionaryContent({
+  activeChord,
+  activePointId,
+  chordSpelling,
+  displayedPoint,
+  hasGlobalPreference,
+  onClearPreference,
+  onPreviewPoint,
+  onSelectCandidate,
+  onSelectPoint,
+  onSelectVoicing,
+  selectedCandidate,
+  selectedVoicing,
+  unsupportedChord,
+  voicings,
+}: {
+  activeChord: string;
+  activePointId: string | null;
+  chordSpelling: NonNullable<ReturnType<typeof spellChord>> | null;
+  displayedPoint: AccordionInspectorPoint | null;
+  hasGlobalPreference: boolean;
+  selectedCandidate: AccordionLeftHandCandidateView | null;
+  selectedVoicing: AccordionVoicingView | null;
+  unsupportedChord: boolean;
+  voicings: readonly AccordionVoicingView[];
+  onClearPreference: () => void;
+  onPreviewPoint: (pointId: string | null) => void;
+  onSelectCandidate: (candidateId: string) => void;
+  onSelectPoint: (pointId: string) => void;
+  onSelectVoicing: (voicing: AccordionVoicingView) => void;
+}) {
+  const soundLabel = chordSpelling?.label ?? "No supported chord";
+  const regionLabel = selectedVoicing?.regionRoot ? `Region ${selectedVoicing.regionRoot}` : "No key region";
+
+  return (
+    <>
+      <div className="chord-context-strip" aria-label="Accordion display context">
+        <ContextChip icon="instrument" label={ACCORDION_STANDARD_PROFILE.label} />
+        <ContextChip icon="key" label={regionLabel} />
+        <ContextChip icon="sound" label={soundLabel} />
+      </div>
+
+      {!chordSpelling || unsupportedChord ? (
+        <EmptyDictionaryState
+          title="Unsupported chord"
+          copy="No spelling, accordion buttons, keyboard, or note inspector data shown for this search."
+        />
+      ) : voicings.length === 0 || !selectedVoicing ? (
+        <EmptyDictionaryState
+          title={`Accordion unavailable for ${chordSpelling.label}`}
+          copy="Chord spelling is supported, but the accordion generator returned no voicings."
+        />
+      ) : (
+        <div className="accordion-tool-grid">
+          <main className="accordion-tool-main">
+            <section className="chord-section" aria-label={`${chordSpelling.label} accordion positions`}>
+              <div className="chord-section-heading chord-section-heading--inline">
+                <div>
+                  <p className="metric-label">{chordSpelling.notes.join(" ")}</p>
+                  <h3>{chordSpelling.label} accordion positions</h3>
+                </div>
+                <div className="chord-shape-controls">
+                  <div className="chord-shape-control-row">
+                    <div
+                      aria-describedby="accordion-voicing-preference-copy"
+                      aria-label="Global accordion right-hand preference choices"
+                      className="chord-shape-tabs"
+                      role="group"
+                    >
+                      {voicings.map((voicing) => (
+                        <button
+                          key={voicing.id}
+                          aria-pressed={selectedVoicing.id === voicing.id}
+                          className={classNames(
+                            "chord-shape-tab",
+                            selectedVoicing.id === voicing.id && "chord-shape-tab--active",
+                          )}
+                          onClick={() => onSelectVoicing(voicing)}
+                          type="button"
+                        >
+                          {voicing.label}
+                        </button>
+                      ))}
+                    </div>
+                    {hasGlobalPreference ? (
+                      <button
+                        aria-label="Clear this chord/instrument global preference"
+                        className="chord-reset-button"
+                        onClick={onClearPreference}
+                        type="button"
+                      >
+                        Clear global preference
+                      </button>
+                    ) : null}
+                  </div>
+                  <p
+                    className="chord-shape-preference-copy"
+                    id="accordion-voicing-preference-copy"
+                  >
+                    Saves right-hand inversion only.
+                  </p>
+                </div>
+              </div>
+              <ChordSpellingSummary spelling={chordSpelling} />
+              <AccordionVoicingPanel
+                activeChord={activeChord}
+                activePointId={activePointId}
+                selectedCandidate={selectedCandidate}
+                voicing={selectedVoicing}
+                onPreviewPoint={onPreviewPoint}
+                onSelectPoint={onSelectPoint}
+              />
+            </section>
+          </main>
+
+          <aside className="accordion-tool-sidebar">
+          {displayedPoint ? <AccordionNoteInspector point={displayedPoint} /> : null}
+          <AccordionCandidateList
+            candidates={selectedVoicing.leftHandCandidates}
+            selectedCandidateId={selectedCandidate?.id ?? null}
+            onSelectCandidate={onSelectCandidate}
+          />
+          </aside>
+        </div>
+      )}
+    </>
+  );
+}
+
+function AccordionVoicingPanel({
+  activeChord,
+  activePointId,
+  onPreviewPoint,
+  onSelectPoint,
+  selectedCandidate,
+  voicing,
+}: {
+  activeChord: string;
+  activePointId: string | null;
+  selectedCandidate: AccordionLeftHandCandidateView | null;
+  voicing: AccordionVoicingView;
+  onPreviewPoint: (pointId: string | null) => void;
+  onSelectPoint: (pointId: string) => void;
+}) {
+  const visibleButtons = getAccordionVoicingButtonsForCandidate(voicing, selectedCandidate);
+  return (
+    <div className="accordion-position-grid">
+      <section className="accordion-position-card" aria-label="Left hand" role="group">
+        <div className="accordion-position-card__heading">
+          <h4>Left hand</h4>
+          {selectedCandidate ? (
+            <span
+              className={classNames(
+                "accordion-match-badge",
+                selectedCandidate.isExact && "accordion-match-badge--exact",
+              )}
+            >
+              {selectedCandidate.isExact ? "Exact" : "Approx"}
+            </span>
+          ) : null}
+        </div>
+        {visibleButtons.length > 0 ? (
+          <AccordionStradellaLattice
+            activePointId={activePointId}
+            buttons={visibleButtons}
+            selectedCandidate={selectedCandidate}
+            onPreviewPoint={onPreviewPoint}
+            onSelectPoint={onSelectPoint}
+          />
+        ) : (
+          <EmptyDictionaryState
+            title="No left-hand buttons"
+            copy="Accordion data did not include visible Stradella buttons for this voicing."
+          />
+        )}
+      </section>
+
+      <section className="accordion-position-card" aria-label="Right hand" role="group">
+        <div className="accordion-position-card__heading">
+          <h4>Right hand</h4>
+          <span className="accordion-match-badge accordion-match-badge--exact">Treble</span>
+        </div>
+        {voicing.keyboardSlice.keys.length > 0 ? (
+          <AccordionKeyboard
+            activeChord={activeChord}
+            activePointId={activePointId}
+            slice={voicing.keyboardSlice}
+            onPreviewPoint={onPreviewPoint}
+            onSelectPoint={onSelectPoint}
+          />
+        ) : (
+          <EmptyDictionaryState
+            title="No right-hand keyboard"
+            copy="Accordion data did not include right-hand notes for this voicing."
+          />
+        )}
+      </section>
+    </div>
+  );
+}
+
+function AccordionStradellaLattice({
+  activePointId,
+  buttons,
+  onPreviewPoint,
+  onSelectPoint,
+  selectedCandidate,
+}: {
+  activePointId: string | null;
+  buttons: readonly AccordionButtonView[];
+  selectedCandidate: AccordionLeftHandCandidateView | null;
+  onPreviewPoint: (pointId: string | null) => void;
+  onSelectPoint: (pointId: string) => void;
+}) {
+  const selectedButtonIds = new Set(selectedCandidate?.buttonIds ?? []);
+  const maxColumn = Math.max(10, ...buttons.map((button) => button.column)) + ACCORDION_STRADDELLA_ROWS.length;
+
+  return (
+    <div
+      className="accordion-stradella"
+      data-surface="stradella"
+      style={{ "--accordion-root-count": maxColumn + 2 } as CSSProperties}
+      aria-label="Accordion Stradella button lattice"
+      role="group"
+    >
+      <div className="accordion-stradella__headers" aria-hidden="true">
+        {ACCORDION_STRADDELLA_ROWS.map((row) => (
+          <span key={row.id}>{row.label}</span>
+        ))}
+      </div>
+      <div className="accordion-stradella__board">
+        {buttons.map((button) => {
+          const rowIndex = ACCORDION_STRADDELLA_ROW_INDEX.get(button.rowId) ?? 0;
+          const isSelectedButton = selectedButtonIds.has(button.id);
+          const isActiveButton = isSelectedButton || activePointId === button.id;
+          return (
+            <button
+              key={button.id}
+              aria-label={`${button.label} ${button.rowLabel} accordion button`}
+              aria-pressed={isSelectedButton}
+              className={classNames(
+                "accordion-stradella__button",
+                `accordion-stradella__button--${button.rowId}`,
+                isSelectedButton && "accordion-stradella__button--selected",
+                isActiveButton && "accordion-stradella__button--active",
+              )}
+              data-active={isActiveButton ? "true" : "false"}
+              data-label={button.label}
+              data-selected={isSelectedButton ? "true" : "false"}
+              data-row={button.rowId}
+              onBlur={() => onPreviewPoint(null)}
+              onClick={() => onSelectPoint(button.id)}
+              onFocus={() => onPreviewPoint(button.id)}
+              onPointerEnter={() => onPreviewPoint(button.id)}
+              onPointerLeave={() => onPreviewPoint(null)}
+              style={
+                {
+                  "--accordion-button-column": rowIndex + 1,
+                  "--accordion-button-row":
+                    button.column + ACCORDION_STRADDELLA_ROWS.length - rowIndex,
+                } as CSSProperties
+              }
+              title={`${button.label} ${button.rowLabel}`}
+              type="button"
+            >
+              {button.rowId === "counterbass" ? null : button.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function AccordionKeyboard({
+  activeChord,
+  activePointId,
+  onPreviewPoint,
+  onSelectPoint,
+  slice,
+}: {
+  activeChord: string;
+  activePointId: string | null;
+  slice: AccordionKeyboardSlice;
+  onPreviewPoint: (pointId: string | null) => void;
+  onSelectPoint: (pointId: string) => void;
+}) {
+  const whiteKeys = slice.keys.filter((key) => !key.isBlack);
+  const blackKeys = slice.keys.filter((key) => key.isBlack);
+
+  return (
+    <div
+      className="accordion-keyboard"
+      data-black-offset="true"
+      data-orientation="vertical"
+      data-surface="keyboard"
+      style={{ "--accordion-white-key-count": slice.whiteKeyCount } as CSSProperties}
+      aria-label={`${activeChord} right-hand accordion keyboard`}
+      role="group"
+    >
+      <div className="accordion-keyboard__white-keys">
+        {whiteKeys.map((key) => (
+          <AccordionKeyboardKey
+            key={key.midi}
+            activePointId={activePointId}
+            keyView={key}
+            onPreviewPoint={onPreviewPoint}
+            onSelectPoint={onSelectPoint}
+          />
+        ))}
+      </div>
+      <div className="accordion-keyboard__black-keys" aria-hidden={blackKeys.length === 0 ? "true" : undefined}>
+        {blackKeys.map((key) => (
+          <AccordionKeyboardKey
+            key={key.midi}
+            activePointId={activePointId}
+            keyView={key}
+            onPreviewPoint={onPreviewPoint}
+            onSelectPoint={onSelectPoint}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function AccordionKeyboardKey({
+  activePointId,
+  keyView,
+  onPreviewPoint,
+  onSelectPoint,
+}: {
+  activePointId: string | null;
+  keyView: AccordionKeyboardKeyView;
+  onPreviewPoint: (pointId: string | null) => void;
+  onSelectPoint: (pointId: string) => void;
+}) {
+  const note = keyView.note;
+  const className = classNames(
+    "accordion-keyboard__key",
+    keyView.isBlack ? "accordion-keyboard__key--black" : "accordion-keyboard__key--white",
+    note && "accordion-keyboard__key--active-tone",
+    note?.id === activePointId && "accordion-keyboard__key--selected",
+  );
+  const style = { "--accordion-white-index": keyView.whiteIndex } as CSSProperties;
+
+  if (!note) {
+    return (
+      <span
+        aria-hidden="true"
+        className={className}
+        data-midi={keyView.midi}
+        data-key-color={keyView.isBlack ? "black" : "white"}
+        data-key-position={keyView.isBlack ? "black-overlay" : "white-surface-row"}
+        style={style}
+      />
+    );
+  }
+
+  return (
+    <button
+      aria-label={`${note.pitchLabel} degree ${note.degree} accordion keyboard key`}
+      className={className}
+      data-key-color={keyView.isBlack ? "black" : "white"}
+      data-midi={keyView.midi}
+      data-key-position={keyView.isBlack ? "black-overlay" : "white-surface-row"}
+      onBlur={() => onPreviewPoint(null)}
+      onClick={() => onSelectPoint(note.id)}
+      onFocus={() => onPreviewPoint(note.id)}
+      onPointerEnter={() => onPreviewPoint(note.id)}
+      onPointerLeave={() => onPreviewPoint(null)}
+      style={style}
+      title={note.pitchLabel}
+      type="button"
+    >
+      <strong>{note.pitchLabel}</strong>
+      <span>{note.degree}</span>
+    </button>
+  );
+}
+
+export function AccordionCandidateList({
+  candidates,
+  onSelectCandidate,
+  selectedCandidateId,
+}: {
+  candidates: readonly AccordionLeftHandCandidateView[];
+  selectedCandidateId: string | null;
+  onSelectCandidate: (candidateId: string) => void;
+}) {
+  if (candidates.length === 0) {
+    return (
+      <section className="accordion-candidate-panel" aria-label="Accordion left-hand candidates">
+        <h4>Left hand</h4>
+        <EmptyDictionaryState
+          title="No left-hand candidates"
+          copy="Accordion data did not include a valid left-hand button combination."
+        />
+      </section>
+    );
+  }
+
+  const primaryCandidate =
+    candidates.find((candidate) => candidate.id === selectedCandidateId) ?? candidates[0] ?? null;
+  const missingToneSummary = primaryCandidate?.missingTones ?? [];
+  const addedToneSummary = primaryCandidate?.addedTones ?? [];
+
+  return (
+    <section className="accordion-candidate-panel" aria-label="Accordion left-hand candidates">
+      <h4>Left hand</h4>
+      <div className="accordion-candidate-list">
+        {candidates.map((candidate) => {
+          const isSelectedCandidate = selectedCandidateId === candidate.id;
+          return (
+            <button
+              key={candidate.id}
+              aria-pressed={isSelectedCandidate}
+              className={classNames(
+                "accordion-candidate-card",
+                isSelectedCandidate && "accordion-candidate-card--active",
+              )}
+              onClick={() => onSelectCandidate(candidate.id)}
+              type="button"
+            >
+              <span className="accordion-candidate-card__title">
+                <strong>{candidate.label}</strong>
+                <span
+                  className={classNames(
+                    "accordion-match-badge",
+                    candidate.isExact && "accordion-match-badge--exact",
+                  )}
+                >
+                  {candidate.isExact ? "Exact" : "Approx"}
+                </span>
+              </span>
+              <span>{candidate.detail}</span>
+              {candidate.fingering ? <span>Fingering {candidate.fingering}</span> : null}
+              {candidate.missingTones.length > 0 || candidate.addedTones.length > 0 ? (
+                <span className="accordion-candidate-card__diff">
+                  {candidate.missingTones.length > 0 ? (
+                    <small>Missing: {candidate.missingTones.join(", ")}</small>
+                  ) : null}
+                  {candidate.addedTones.length > 0 ? (
+                    <small>Added: {candidate.addedTones.join(", ")}</small>
+                  ) : null}
+                </span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+      {missingToneSummary.length > 0 || addedToneSummary.length > 0 ? (
+        <div className="accordion-candidate-diff" aria-label="Accordion approximation differences">
+          {missingToneSummary.length > 0 ? (
+            <small>Missing: {missingToneSummary.join(", ")}</small>
+          ) : null}
+          {addedToneSummary.length > 0 ? (
+            <small>Added: {addedToneSummary.join(", ")}</small>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function AccordionNoteInspector({ point }: { point: AccordionInspectorPoint }) {
+  return (
+    <section className="note-inspector accordion-note-inspector" aria-label="Note inspector">
+      <div className="note-inspector__badge">
+        <strong>{point.pitchLabel}</strong>
+        <span>{point.degree ?? point.label}</span>
+      </div>
+      <dl>
+        <div>
+          <dt>Pitch</dt>
+          <dd>{point.pitchLabel}</dd>
+        </div>
+        <div>
+          <dt>Degree</dt>
+          <dd>{point.degree ?? "Not a chord tone"}</dd>
+        </div>
+        <div>
+          <dt>Hand</dt>
+          <dd>{point.hand}</dd>
+        </div>
+        <div>
+          <dt>Side</dt>
+          <dd>{point.side}</dd>
+        </div>
+        <div>
+          <dt>Surface</dt>
+          <dd>{point.surface}</dd>
+        </div>
+        <div>
+          <dt>Source</dt>
+          <dd>{point.source}</dd>
+        </div>
+        {point.finger ? (
+          <div>
+            <dt>Finger</dt>
+            <dd>{point.finger}</dd>
+          </div>
+        ) : null}
+      </dl>
+    </section>
   );
 }
 
@@ -667,6 +1484,691 @@ function toGuitarShape(voicing: GuitarVoicing, profile: typeof GUITAR_STANDARD_P
     stringMarkers: getGuitarStringMarkers(strings, notes, mutedStringSet),
     strings,
   };
+}
+
+function toAccordionVoicingViews(voicings: readonly AccordionVoicing[]): readonly AccordionVoicingView[] {
+  return voicings.flatMap((voicing, voicingIndex): AccordionVoicingView[] => {
+    const record = asUnknownRecord(voicing);
+    if (!record) {
+      return [];
+    }
+
+    const id = readString(record, ["id"]) ?? `accordion-voicing-${voicingIndex + 1}`;
+    const rightHandNotes = readArray(record, ["rightHandNotes", "notes"]).flatMap((note, noteIndex) =>
+      toAccordionKeyboardNoteView(note, id, noteIndex),
+    );
+    const leftHandCandidates = readArray(record, ["leftHandCandidates", "candidates"]).flatMap(
+      (candidate, candidateIndex) => toAccordionCandidateView(candidate, id, candidateIndex),
+    );
+    const selectedCandidateRecord = asUnknownRecord(record.selectedLeftHandCandidate);
+    const selectedCandidateId =
+      readString(selectedCandidateRecord, ["id"]) ?? leftHandCandidates[0]?.id ?? null;
+    const chordLabel = readString(record, ["chordLabel"]) ?? "";
+    const buttons = annotateAccordionButtonDegrees(
+      normalizeAccordionButtonColumns(
+        readArray(record, ["visibleStradellaButtons", "buttons"]).flatMap((button, buttonIndex) =>
+          toAccordionButtonView(button, id, buttonIndex, leftHandCandidates),
+        ),
+      ),
+      chordLabel,
+    );
+
+    if (rightHandNotes.length === 0 && leftHandCandidates.length === 0 && buttons.length === 0) {
+      return [];
+    }
+
+    return [
+      {
+        buttons,
+        candidateIds: leftHandCandidates.map((candidate) => candidate.id),
+        chordLabel,
+        id,
+        keyboardSlice: buildAccordionKeyboardSlice(rightHandNotes),
+        label: readString(record, ["label"]) ?? `Voicing ${voicingIndex + 1}`,
+        leftHandCandidates,
+        rank: readNumber(record, ["rank"]) ?? voicingIndex,
+        regionRoot: readAccordionRegionRoot(record),
+        rightHandNotes,
+        selectedCandidateId,
+      },
+    ];
+  });
+}
+
+function toAccordionKeyboardNoteView(
+  value: unknown,
+  voicingId: string,
+  noteIndex: number,
+): AccordionKeyboardNoteView[] {
+  const record = asUnknownRecord(value);
+  if (!record) {
+    return [];
+  }
+  const pitch = readPitchDescriptor(record, ["pitch", "parsedPitch"]);
+  const midi = readNumber(record, ["midi", "pitchMidi"]) ?? pitch?.midi ?? null;
+  if (midi === null) {
+    return [];
+  }
+  const pitchLabel = pitch?.label ?? midiToPitch(midi)?.label ?? `MIDI ${midi}`;
+  return [
+    {
+      degree: readString(record, ["degree"]) ?? "",
+      finger: formatOptionalFinger(record.finger),
+      hand: "Right",
+      id: readString(record, ["id"]) ?? `${voicingId}-right-${noteIndex}`,
+      midi,
+      noteLabel: readString(record, ["note", "noteName"]) ?? pitch?.noteName ?? pitchLabel,
+      pitchLabel,
+      side: "Treble",
+      surface: "Keyboard",
+    },
+  ];
+}
+
+function toAccordionCandidateView(
+  value: unknown,
+  voicingId: string,
+  candidateIndex: number,
+): AccordionLeftHandCandidateView[] {
+  const record = asUnknownRecord(value);
+  if (!record) {
+    return [];
+  }
+  const id = readString(record, ["id"]) ?? `${voicingId}-left-${candidateIndex}`;
+  const missingTones = readStringArray(record, ["missingTones", "missing", "missingNotes"]);
+  const addedTones = readStringArray(record, ["addedTones", "added", "addedNotes", "extraTones"]);
+  const buttonIds = collectAccordionCandidateButtonIds(record);
+  const buttons = collectAccordionCandidateButtonViews(record, voicingId, candidateIndex, id);
+  const matchText = readString(record, ["match", "matchKind", "quality", "status"]);
+  const explicitExact = readBoolean(record, ["isExact", "exact"]);
+  const isExact =
+    explicitExact ??
+    (matchText ? matchText.toLowerCase().includes("exact") : missingTones.length === 0 && addedTones.length === 0);
+  const label =
+    readString(record, ["label"]) ??
+    formatAccordionCandidateLabel(record, buttonIds) ??
+    `Left ${candidateIndex + 1}`;
+  const detail =
+    readString(record, ["detail", "summary", "description"]) ??
+    formatAccordionCandidateDetail(record) ??
+    "Left-hand button combination";
+
+  return [
+    {
+      addedTones,
+      buttons,
+      buttonIds,
+      detail,
+      fingering: formatOptionalFinger(record.fingering ?? record.fingers),
+      id,
+      isExact,
+      label,
+      missingTones,
+      rank: readNumber(record, ["rank"]) ?? candidateIndex,
+    },
+  ];
+}
+
+function toAccordionButtonView(
+  value: unknown,
+  voicingId: string,
+  buttonIndex: number,
+  candidates: readonly AccordionLeftHandCandidateView[],
+): AccordionButtonView[] {
+  const record = asUnknownRecord(value);
+  if (!record) {
+    return [];
+  }
+  const rowId = normalizeAccordionRowId(readString(record, ["rowId", "row", "type", "kind"]));
+  const noteLabel = readAccordionButtonRoot(record) ?? `Button ${buttonIndex + 1}`;
+  const explicitLabel = readString(record, ["compactLabel"]);
+  const id = readString(record, ["id"]) ?? `${voicingId}-button-${rowId}-${buttonIndex}`;
+  const sourceColumn = readNumber(record, ["column", "rootIndex", "index"]) ?? buttonIndex;
+  const candidateIds = readStringArray(record, ["candidateIds", "matches"]).concat(
+    readString(record, ["candidateId"]) ? [readString(record, ["candidateId"]) as string] : [],
+  );
+  const inferredCandidateIds = candidateIds.length > 0
+    ? candidateIds
+    : candidates
+        .filter((candidate) => candidate.buttonIds.includes(id))
+        .map((candidate) => candidate.id);
+  const pitch = readPitchDescriptor(record, ["pitch", "parsedPitch"]);
+
+  return [
+    {
+      candidateIds: inferredCandidateIds,
+      column: sourceColumn,
+      degree: readString(record, ["degree"]),
+      hand: "Left",
+      id,
+      isChordTone: readBoolean(record, ["isChordTone", "target"]) ?? false,
+      label: formatAccordionButtonLabel(explicitLabel, noteLabel, rowId),
+      noteLabel,
+      pitchClass: readNumber(record, ["pitchClass"]),
+      pitchLabel: pitch?.label ?? readString(record, ["pitchLabel", "pitch"]) ?? noteLabel,
+      rowId,
+      rowLabel: formatAccordionRowLabel(rowId),
+      side: formatTitleCase(readString(record, ["side"]) ?? "Bass"),
+      sourceColumn,
+      surface: "Stradella",
+    },
+  ];
+}
+
+function collectAccordionCandidateButtonViews(
+  record: Record<string, unknown>,
+  voicingId: string,
+  candidateIndex: number,
+  candidateId: string,
+): readonly AccordionButtonView[] {
+  const buttonsById = new Map<string, AccordionButtonView>();
+  const candidateButtonValues = [
+    record.bassButton,
+    record.rootButton,
+    record.chordButton,
+    ...readArray(record, ["buttons", "pressedButtons"]),
+  ];
+
+  candidateButtonValues.forEach((button, buttonIndex) => {
+    const buttonView = toAccordionButtonView(
+      button,
+      voicingId,
+      candidateIndex * 10 + buttonIndex,
+      [],
+    )[0];
+    if (!buttonView) {
+      return;
+    }
+    buttonsById.set(buttonView.id, {
+      ...buttonView,
+      candidateIds: [...new Set([...buttonView.candidateIds, candidateId])],
+    });
+  });
+
+  return [...buttonsById.values()];
+}
+
+function normalizeAccordionButtonColumns(
+  buttons: readonly AccordionButtonView[],
+): readonly AccordionButtonView[] {
+  if (buttons.length === 0) {
+    return buttons;
+  }
+  const minColumn = Math.min(...buttons.map((button) => button.sourceColumn));
+  if (minColumn === 0) {
+    return buttons.map((button) => ({
+      ...button,
+      column: button.sourceColumn,
+    }));
+  }
+  return buttons.map((button) => ({
+    ...button,
+    column: button.sourceColumn - minColumn,
+  }));
+}
+
+function getAccordionVoicingButtonsForCandidate(
+  voicing: AccordionVoicingView,
+  selectedCandidate: AccordionLeftHandCandidateView | null,
+): readonly AccordionButtonView[] {
+  if (!selectedCandidate || selectedCandidate.buttons.length === 0) {
+    return voicing.buttons;
+  }
+
+  const buttonsById = new Map(voicing.buttons.map((button) => [button.id, button]));
+  selectedCandidate.buttons.forEach((button) => {
+    const existingButton = buttonsById.get(button.id);
+    buttonsById.set(button.id, {
+      ...(existingButton ?? button),
+      candidateIds: [
+        ...new Set([
+          ...(existingButton?.candidateIds ?? []),
+          ...button.candidateIds,
+          selectedCandidate.id,
+        ]),
+      ],
+      sourceColumn: existingButton?.sourceColumn ?? button.sourceColumn,
+    });
+  });
+
+  return annotateAccordionButtonDegrees(
+    normalizeAccordionButtonColumns([...buttonsById.values()]),
+    voicing.chordLabel,
+  );
+}
+
+function getAccordionFirstCandidateButtonId(
+  voicing: AccordionVoicingView,
+  selectedCandidate: AccordionLeftHandCandidateView | null,
+): string | null {
+  if (!selectedCandidate) {
+    return null;
+  }
+  return (
+    getAccordionVoicingButtonsForCandidate(voicing, selectedCandidate).find(
+      (button) =>
+        selectedCandidate.buttonIds.includes(button.id) ||
+        button.candidateIds.includes(selectedCandidate.id),
+    )?.id ?? null
+  );
+}
+
+function annotateAccordionButtonDegrees(
+  buttons: readonly AccordionButtonView[],
+  chordLabel: string,
+): readonly AccordionButtonView[] {
+  const spelling = spellChord(chordLabel);
+  if (!spelling) {
+    return buttons;
+  }
+  return buttons.map((button) => {
+    const buttonPitchClass = button.pitchClass;
+    if (button.degree || buttonPitchClass === null) {
+      return button;
+    }
+    const matchingTone = spelling.tones.find(
+      (tone) => normalizePitchClassView(tone.pitchClass) === normalizePitchClassView(buttonPitchClass),
+    );
+    if (!matchingTone) {
+      return button;
+    }
+    return {
+      ...button,
+      degree: matchingTone.degree,
+      isChordTone: true,
+    };
+  });
+}
+
+function buildAccordionKeyboardSlice(
+  notes: readonly AccordionKeyboardNoteView[],
+): AccordionKeyboardSlice {
+  if (notes.length === 0) {
+    return { keys: [], whiteKeyCount: 0 };
+  }
+
+  const noteByMidi = new Map(notes.map((note) => [note.midi, note]));
+  const minMidi = Math.min(...notes.map((note) => note.midi));
+  const maxMidi = Math.max(...notes.map((note) => note.midi));
+  let startMidi = minMidi;
+  while (normalizePitchClassView(startMidi) !== 0) {
+    startMidi -= 1;
+  }
+  let endMidi = maxMidi;
+  while (normalizePitchClassView(endMidi) !== 0) {
+    endMidi += 1;
+  }
+  if (endMidi - startMidi < 12) {
+    endMidi = startMidi + 12;
+  }
+
+  const keys: AccordionKeyboardKeyView[] = [];
+  let whiteIndex = 0;
+  for (let midi = startMidi; midi <= endMidi; midi += 1) {
+    const pitch = midiToPitch(midi);
+    const isBlack = isBlackPianoKey(midi);
+    keys.push({
+      isBlack,
+      midi,
+      note: noteByMidi.get(midi) ?? null,
+      pitchLabel: pitch?.label ?? `MIDI ${midi}`,
+      whiteIndex: isBlack ? Math.max(0, whiteIndex - 1) : whiteIndex,
+    });
+    if (!isBlack) {
+      whiteIndex += 1;
+    }
+  }
+
+  return { keys, whiteKeyCount: whiteIndex };
+}
+
+function findAccordionInspectorPoint(
+  voicing: AccordionVoicingView,
+  selectedCandidate: AccordionLeftHandCandidateView | null,
+  pointId: string | null,
+): AccordionInspectorPoint | null {
+  const candidateButtonIds = new Set(selectedCandidate?.buttonIds ?? []);
+  const visibleButtons = getAccordionVoicingButtonsForCandidate(voicing, selectedCandidate);
+  const fallbackButton =
+    visibleButtons.find((button) => candidateButtonIds.has(button.id)) ??
+    visibleButtons.find((button) =>
+      selectedCandidate ? button.candidateIds.includes(selectedCandidate.id) : false,
+    ) ??
+    null;
+  const fallbackPointId = pointId ?? voicing.rightHandNotes[0]?.id ?? fallbackButton?.id ?? null;
+  if (!fallbackPointId) {
+    return null;
+  }
+
+  const rightNote = voicing.rightHandNotes.find((note) => note.id === fallbackPointId);
+  if (rightNote) {
+    return {
+      degree: rightNote.degree,
+      finger: rightNote.finger,
+      hand: rightNote.hand,
+      id: rightNote.id,
+      label: rightNote.noteLabel,
+      pitchLabel: rightNote.pitchLabel,
+      side: rightNote.side,
+      source: "Target chord tone",
+      surface: rightNote.surface,
+    };
+  }
+
+  const button = visibleButtons.find((buttonView) => buttonView.id === fallbackPointId);
+  if (!button) {
+    return null;
+  }
+  return {
+    degree: button.degree,
+    finger: null,
+    hand: button.hand,
+    id: button.id,
+    label: button.noteLabel,
+    pitchLabel: button.pitchLabel,
+    side: button.side,
+    source: selectedCandidate?.label ?? "Left-hand button",
+    surface: button.surface,
+  };
+}
+
+function asUnknownRecord(value: unknown): Record<string, unknown> | null {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function readString(
+  record: Record<string, unknown> | null | undefined,
+  keys: readonly string[],
+): string | null {
+  if (!record) {
+    return null;
+  }
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return String(value);
+    }
+  }
+  return null;
+}
+
+function readNumber(
+  record: Record<string, unknown> | null | undefined,
+  keys: readonly string[],
+): number | null {
+  if (!record) {
+    return null;
+  }
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === "string") {
+      const numberValue = Number(value);
+      if (Number.isFinite(numberValue)) {
+        return numberValue;
+      }
+    }
+  }
+  return null;
+}
+
+function readBoolean(
+  record: Record<string, unknown> | null | undefined,
+  keys: readonly string[],
+): boolean | null {
+  if (!record) {
+    return null;
+  }
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "boolean") {
+      return value;
+    }
+  }
+  return null;
+}
+
+function readArray(
+  record: Record<string, unknown> | null | undefined,
+  keys: readonly string[],
+): readonly unknown[] {
+  if (!record) {
+    return [];
+  }
+  for (const key of keys) {
+    const value = record[key];
+    if (Array.isArray(value)) {
+      return value;
+    }
+  }
+  return [];
+}
+
+function readStringArray(
+  record: Record<string, unknown> | null | undefined,
+  keys: readonly string[],
+): readonly string[] {
+  return readArray(record, keys).flatMap((value) => {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return [value.trim()];
+    }
+    const nestedRecord = asUnknownRecord(value);
+    const nestedLabel = readString(nestedRecord, ["label", "note", "pitch", "degree"]);
+    return nestedLabel ? [nestedLabel] : [];
+  });
+}
+
+function readPitchDescriptor(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+): { label: string; midi: number; noteName: string } | null {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string") {
+      const parsedPitch = parsePitch(value);
+      if (parsedPitch) {
+        return {
+          label: parsedPitch.label,
+          midi: parsedPitch.midi,
+          noteName: parsedPitch.noteName,
+        };
+      }
+    }
+    const pitchRecord = asUnknownRecord(value);
+    if (pitchRecord) {
+      const midi = readNumber(pitchRecord, ["midi"]);
+      const label = readString(pitchRecord, ["label", "pitch", "noteName"]);
+      const noteName = readString(pitchRecord, ["noteName", "note", "label"]);
+      if (midi !== null && label) {
+        return { label, midi, noteName: noteName ?? label };
+      }
+    }
+  }
+  return null;
+}
+
+function readAccordionRegionRoot(record: Record<string, unknown>): string | null {
+  const directRegionRoot = readString(record, ["regionRoot", "region", "keyRoot"]);
+  if (directRegionRoot) {
+    return directRegionRoot;
+  }
+
+  for (const key of ["regionRoot", "region", "keyRoot"]) {
+    const regionRecord = asUnknownRecord(record[key]);
+    if (!regionRecord) {
+      continue;
+    }
+
+    const note = readString(regionRecord, ["note", "label", "root"]);
+    if (note) {
+      return note;
+    }
+
+    const pitchClass = readNumber(regionRecord, ["pitchClass"]);
+    if (pitchClass !== null) {
+      return formatPitchClass(pitchClass);
+    }
+  }
+
+  return null;
+}
+
+function collectAccordionCandidateButtonIds(record: Record<string, unknown>): readonly string[] {
+  const ids = new Set<string>(readStringArray(record, ["buttonIds"]));
+  for (const key of ["buttons", "pressedButtons"]) {
+    for (const button of readArray(record, [key])) {
+      const buttonRecord = asUnknownRecord(button);
+      const id = readString(buttonRecord, ["id"]);
+      if (id) {
+        ids.add(id);
+      }
+    }
+  }
+  for (const key of ["bassButton", "rootButton", "chordButton", "counterbassButton"]) {
+    const buttonRecord = asUnknownRecord(record[key]);
+    const id = readString(buttonRecord, ["id"]);
+    if (id) {
+      ids.add(id);
+    }
+  }
+  return [...ids];
+}
+
+function formatAccordionCandidateLabel(
+  record: Record<string, unknown>,
+  buttonIds: readonly string[],
+): string | null {
+  const bass = formatAccordionBassCandidateLabel(asUnknownRecord(record.bassButton ?? record.rootButton));
+  const chord = formatAccordionButtonRecordCompactLabel(asUnknownRecord(record.chordButton));
+  if (bass && chord) {
+    return `${bass} + ${chord}`;
+  }
+  return buttonIds.length > 0 ? buttonIds.join(" + ") : null;
+}
+
+function formatAccordionCandidateDetail(record: Record<string, unknown>): string | null {
+  const bass = formatAccordionBassCandidateLabel(asUnknownRecord(record.bassButton ?? record.rootButton));
+  const chord = formatAccordionButtonRecordCompactLabel(asUnknownRecord(record.chordButton));
+  if (bass && chord) {
+    return `${bass} + ${chord} row`;
+  }
+  return null;
+}
+
+function formatAccordionBassCandidateLabel(record: Record<string, unknown> | null): string | null {
+  const root = readAccordionButtonRoot(record);
+  if (!root) {
+    return null;
+  }
+  const rowId = normalizeAccordionRowId(readString(record, ["rowId", "row", "type", "kind"]));
+  return rowId === "counterbass" ? `${root} counterbass` : `${root} bass`;
+}
+
+function formatAccordionButtonRecordCompactLabel(record: Record<string, unknown> | null): string | null {
+  const root = readAccordionButtonRoot(record);
+  if (!root) {
+    return null;
+  }
+  const rowId = normalizeAccordionRowId(readString(record, ["rowId", "row", "type", "kind"]));
+  return formatAccordionButtonLabel(readString(record, ["compactLabel"]), root, rowId);
+}
+
+function readAccordionButtonRoot(record: Record<string, unknown> | null | undefined): string | null {
+  const root = readString(record, ["root", "note"]);
+  if (root) {
+    return root;
+  }
+  const label = readString(record, ["label", "button"]);
+  return label?.replace(/\s+(counterbass|bass|major|minor|seventh|diminished)$/i, "") ?? null;
+}
+
+function normalizeAccordionRowId(value: string | null): AccordionStradellaRowIdView {
+  const normalized = value?.trim().toLowerCase().replace(/[\s_-]+/g, "") ?? "";
+  if (normalized === "dim" || normalized === "dim7" || normalized === "diminished") {
+    return "diminished";
+  }
+  if (normalized === "7" || normalized === "seventh" || normalized === "dominant7") {
+    return "dominant7";
+  }
+  if (normalized === "m" || normalized === "minor") {
+    return "minor";
+  }
+  if (normalized === "maj" || normalized === "major") {
+    return "major";
+  }
+  if (normalized === "counter" || normalized === "counterbass") {
+    return "counterbass";
+  }
+  if (normalized === "bass" || normalized === "rootbass") {
+    return "bass";
+  }
+  return normalized || "bass";
+}
+
+function formatAccordionRowLabel(rowId: AccordionStradellaRowIdView) {
+  return ACCORDION_STRADDELLA_ROWS.find((row) => row.id === rowId)?.label ?? formatTitleCase(rowId);
+}
+
+function formatAccordionButtonLabel(
+  explicitLabel: string | null,
+  noteLabel: string,
+  rowId: AccordionStradellaRowIdView,
+) {
+  if (rowId === "bass" || rowId === "counterbass") {
+    return noteLabel;
+  }
+  if (explicitLabel && explicitLabel !== noteLabel) {
+    return explicitLabel;
+  }
+  switch (rowId) {
+    case "major":
+      return `${noteLabel}M`;
+    case "minor":
+      return `${noteLabel}m`;
+    case "dominant7":
+      return `${noteLabel}7`;
+    case "diminished":
+      return `${noteLabel}dim`;
+    default:
+      return noteLabel;
+  }
+}
+
+function formatOptionalFinger(value: unknown): string | null {
+  if (Array.isArray(value)) {
+    const fingers = value
+      .map((finger) => (typeof finger === "number" || typeof finger === "string" ? String(finger).trim() : ""))
+      .filter(Boolean);
+    return fingers.length > 0 ? fingers.join(" + ") : null;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+  return null;
+}
+
+function formatTitleCase(value: string) {
+  return value
+    .replace(/[-_]+/g, " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function isBlackPianoKey(midi: number) {
+  return [1, 3, 6, 8, 10].includes(((midi % 12) + 12) % 12);
+}
+
+function normalizePitchClassView(pitchClass: number) {
+  return ((Math.trunc(pitchClass) % 12) + 12) % 12;
 }
 
 function getGuitarStringViews(profile: typeof GUITAR_STANDARD_PROFILE): readonly GuitarStringView[] {
@@ -1124,9 +2626,13 @@ function NoteInspector({ capoFret, note }: { capoFret: number; note: NotePoint }
 
 function LiveFollowSurface({
   context,
+  instrumentId,
+  onInstrumentChange,
   requestedProjectId,
 }: {
   context: ChordDictionaryFollowContext;
+  instrumentId: ChordDictionaryInstrumentId;
+  onInstrumentChange: (instrumentId: ChordDictionaryInstrumentId) => void;
   requestedProjectId: string | null;
 }) {
   if (context.status !== "active") {
@@ -1136,17 +2642,47 @@ function LiveFollowSurface({
         className="live-follow-page live-follow-page--waiting"
         data-follow-status={context.status}
       >
-        <LiveFollowTopbar context={context} statusLabel={formatFollowStatusLabel(context.status)} />
+        <LiveFollowTopbar
+          context={context}
+          instrumentId={instrumentId}
+          statusLabel={formatFollowStatusLabel(context.status)}
+          onInstrumentChange={onInstrumentChange}
+        />
         <LiveFollowStatusCard context={context} requestedProjectId={requestedProjectId} />
-        {showDictionaryFallback ? <DictionarySurface /> : null}
+        {showDictionaryFallback ? (
+          <DictionarySurface
+            instrumentId={instrumentId}
+            onInstrumentChange={onInstrumentChange}
+          />
+        ) : null}
       </div>
     );
   }
 
-  return <LiveFollowActiveState context={context} />;
+  return instrumentId === ACCORDION_INSTRUMENT_ID ? (
+    <LiveFollowAccordionActiveState
+      context={context}
+      instrumentId={instrumentId}
+      onInstrumentChange={onInstrumentChange}
+    />
+  ) : (
+    <LiveFollowActiveState
+      context={context}
+      instrumentId={instrumentId}
+      onInstrumentChange={onInstrumentChange}
+    />
+  );
 }
 
-function LiveFollowActiveState({ context }: { context: ChordDictionaryFollowContext }) {
+function LiveFollowActiveState({
+  context,
+  instrumentId,
+  onInstrumentChange,
+}: {
+  context: ChordDictionaryFollowContext;
+  instrumentId: ChordDictionaryInstrumentId;
+  onInstrumentChange: (instrumentId: ChordDictionaryInstrumentId) => void;
+}) {
   const currentChord = context.currentChord;
   const project = context.project;
   const [activeShape, setActiveShape] = useState<string | null>(null);
@@ -1199,6 +2735,7 @@ function LiveFollowActiveState({ context }: { context: ChordDictionaryFollowCont
             capoFret: displayContext.capoFret ?? null,
             chordLabel: chordSpelling.label,
             displayedKey: project?.displayedKey ?? null,
+            instrumentId: GUITAR_INSTRUMENT_ID,
             projectId: project?.projectId ?? null,
             sourceKey: project?.sourceKey ?? null,
             transposeSemitones: project?.totalDisplayTransposeSemitones ?? null,
@@ -1248,7 +2785,12 @@ function LiveFollowActiveState({ context }: { context: ChordDictionaryFollowCont
   if (!currentChord || !project) {
     return (
       <div className="live-follow-page live-follow-page--waiting" data-follow-status="no-project">
-        <LiveFollowTopbar context={context} statusLabel="No Project" />
+        <LiveFollowTopbar
+          context={context}
+          instrumentId={instrumentId}
+          statusLabel="No Project"
+          onInstrumentChange={onInstrumentChange}
+        />
         <LiveFollowStatusCard context={context} requestedProjectId={null} />
       </div>
     );
@@ -1261,8 +2803,10 @@ function LiveFollowActiveState({ context }: { context: ChordDictionaryFollowCont
       <LiveFollowChordIssue
         context={context}
         copy="The project timeline chord cannot be parsed by the chord dictionary, so no guitar voicing or note inspector is shown."
+        instrumentId={instrumentId}
         statusLabel="Unsupported"
         title={`Unsupported chord: ${currentChord.displayLabel}`}
+        onInstrumentChange={onInstrumentChange}
       />
     );
   }
@@ -1272,8 +2816,10 @@ function LiveFollowActiveState({ context }: { context: ChordDictionaryFollowCont
       <LiveFollowChordIssue
         context={context}
         copy="Chord spelling is supported, but the standard guitar model returned no voicings for this chord."
+        instrumentId={instrumentId}
         statusLabel="No Voicing"
         title={`No guitar voicing for ${chordSpelling.label}`}
+        onInstrumentChange={onInstrumentChange}
       />
     );
   }
@@ -1291,7 +2837,13 @@ function LiveFollowActiveState({ context }: { context: ChordDictionaryFollowCont
 
   return (
     <div className="live-follow-page live-follow-page--active" data-follow-status="active">
-      <LiveFollowTopbar context={context} statusLabel="Live" />
+      <LiveFollowTopbar
+        allowInstrumentSelection
+        context={context}
+        instrumentId={instrumentId}
+        statusLabel="Live"
+        onInstrumentChange={onInstrumentChange}
+      />
 
       <div className="chord-context-strip" aria-label="Live follow display context">
         <ContextChip icon="instrument" label={GUITAR_STANDARD_PROFILE.label} />
@@ -1451,20 +3003,357 @@ function LiveFollowActiveState({ context }: { context: ChordDictionaryFollowCont
   );
 }
 
-function LiveFollowTopbar({
+function LiveFollowAccordionActiveState({
   context,
-  statusLabel,
+  instrumentId,
+  onInstrumentChange,
 }: {
   context: ChordDictionaryFollowContext;
+  instrumentId: ChordDictionaryInstrumentId;
+  onInstrumentChange: (instrumentId: ChordDictionaryInstrumentId) => void;
+}) {
+  const currentChord = context.currentChord;
+  const project = context.project;
+  const [activeVoicing, setActiveVoicing] = useState<string | null>(null);
+  const [activeCandidate, setActiveCandidate] = useState<string | null>(null);
+  const [previewPointId, setPreviewPointId] = useState<string | null>(null);
+  const [, setPreferenceRevision] = useState(0);
+  const [selectedPointId, setSelectedPointId] = useState<string | null>(null);
+  const chordSpelling = useMemo(
+    () =>
+      currentChord
+        ? spellChord(currentChord.displayLabel, {
+            activeKey: project?.displayedKey ?? undefined,
+          })
+        : null,
+    [currentChord, project?.displayedKey],
+  );
+  const accordionVoicings = useMemo(
+    () =>
+      chordSpelling
+        ? generateAccordionVoicings(
+            chordSpelling,
+            {
+              currentChordRoot: currentChord?.displayLabel ?? null,
+              regionKey: project?.displayedKey ?? null,
+            },
+            { activeKey: project?.displayedKey ?? undefined },
+          )
+        : [],
+    [chordSpelling, currentChord?.displayLabel, project?.displayedKey],
+  );
+  const generatedVoicingViews = useMemo(
+    () => toAccordionVoicingViews(accordionVoicings),
+    [accordionVoicings],
+  );
+  const generatedVoicingIds = useMemo(
+    () => generatedVoicingViews.map((voicing) => voicing.id),
+    [generatedVoicingViews],
+  );
+  const preferenceContext = useMemo(
+    () =>
+      chordSpelling
+        ? buildShapePreferenceContext({
+            capoFret: null,
+            chordLabel: chordSpelling.label,
+            displayedKey: project?.displayedKey ?? null,
+            instrumentId: ACCORDION_INSTRUMENT_ID,
+            projectId: project?.projectId ?? null,
+            sourceKey: project?.sourceKey ?? null,
+            transposeSemitones: project?.totalDisplayTransposeSemitones ?? null,
+            useCapoShapes: null,
+          })
+        : null,
+    [
+      chordSpelling,
+      project?.displayedKey,
+      project?.projectId,
+      project?.sourceKey,
+      project?.totalDisplayTransposeSemitones,
+    ],
+  );
+  const preferredVoicingId = resolveChordDictionaryPreferredShapeId(
+    preferenceContext,
+    generatedVoicingIds,
+  );
+  const hasProjectPreference = hasProjectChordDictionaryPreferredShape(
+    preferenceContext,
+    generatedVoicingIds,
+  );
+  const voicingViews = useMemo(
+    () => promoteShapeToFirst(generatedVoicingViews, preferredVoicingId),
+    [generatedVoicingViews, preferredVoicingId],
+  );
+  const resultKey = voicingViews.map((voicing) => voicing.id).join("|");
+  const firstVoicingId = voicingViews[0]?.id ?? null;
+  const firstCandidateId =
+    voicingViews[0]?.selectedCandidateId ?? voicingViews[0]?.leftHandCandidates[0]?.id ?? null;
+  const firstPointId =
+    voicingViews[0]?.rightHandNotes[0]?.id ??
+    voicingViews[0]?.buttons.find((button) =>
+      firstCandidateId ? button.candidateIds.includes(firstCandidateId) : false,
+    )?.id ??
+    null;
+  const bumpPreferenceRevision = () => setPreferenceRevision((revision) => revision + 1);
+  const selectVoicing = (voicing: AccordionVoicingView) => {
+    writeProjectChordDictionaryPreferredShape(preferenceContext, voicing.id);
+    bumpPreferenceRevision();
+    setActiveVoicing(voicing.id);
+    setActiveCandidate(voicing.selectedCandidateId ?? voicing.leftHandCandidates[0]?.id ?? null);
+    setPreviewPointId(null);
+    setSelectedPointId(voicing.rightHandNotes[0]?.id ?? null);
+  };
+
+  useEffect(() => {
+    setActiveVoicing(firstVoicingId);
+    setActiveCandidate(firstCandidateId);
+    setPreviewPointId(null);
+    setSelectedPointId(firstPointId);
+  }, [currentChord?.displayLabel, firstCandidateId, firstPointId, firstVoicingId, resultKey]);
+
+  if (!currentChord || !project) {
+    return (
+      <div className="live-follow-page live-follow-page--waiting" data-follow-status="no-project">
+        <LiveFollowTopbar
+          context={context}
+          instrumentId={instrumentId}
+          statusLabel="No Project"
+          onInstrumentChange={onInstrumentChange}
+        />
+        <LiveFollowStatusCard context={context} requestedProjectId={null} />
+      </div>
+    );
+  }
+
+  if (!chordSpelling) {
+    return (
+      <LiveFollowChordIssue
+        context={context}
+        copy="The project timeline chord cannot be parsed by the chord dictionary, so no accordion voicing or note inspector is shown."
+        instrumentId={instrumentId}
+        statusLabel="Unsupported"
+        title={`Unsupported chord: ${currentChord.displayLabel}`}
+        onInstrumentChange={onInstrumentChange}
+      />
+    );
+  }
+
+  if (voicingViews.length === 0) {
+    return (
+      <LiveFollowChordIssue
+        context={context}
+        copy="Chord spelling is supported, but the accordion model returned no voicings for this chord."
+        instrumentId={instrumentId}
+        statusLabel="No Voicing"
+        title={`Accordion unavailable for ${chordSpelling.label}`}
+        onInstrumentChange={onInstrumentChange}
+      />
+    );
+  }
+
+  const selectedVoicing =
+    voicingViews.find((voicing) => voicing.id === activeVoicing) ?? voicingViews[0] ?? null;
+  const selectedCandidate =
+    selectedVoicing?.leftHandCandidates.find((candidate) => candidate.id === activeCandidate) ??
+    selectedVoicing?.leftHandCandidates.find(
+      (candidate) => candidate.id === selectedVoicing.selectedCandidateId,
+    ) ??
+    selectedVoicing?.leftHandCandidates[0] ??
+    null;
+  const selectedPoint = selectedVoicing
+    ? findAccordionInspectorPoint(selectedVoicing, selectedCandidate, selectedPointId)
+    : null;
+  const previewPoint = previewPointId && selectedVoicing
+    ? findAccordionInspectorPoint(selectedVoicing, selectedCandidate, previewPointId)
+    : null;
+  const displayedPoint = previewPoint ?? selectedPoint;
+  const activePointId = previewPoint?.id ?? selectedPoint?.id ?? null;
+  const playbackSourceLabel = formatPlaybackProjectLabel(project.projectName);
+
+  if (!selectedVoicing) {
+    return null;
+  }
+
+  return (
+    <div className="live-follow-page live-follow-page--active" data-follow-status="active">
+      <LiveFollowTopbar
+        allowInstrumentSelection
+        context={context}
+        instrumentId={instrumentId}
+        statusLabel="Live"
+        onInstrumentChange={onInstrumentChange}
+      />
+
+      <div className="chord-context-strip" aria-label="Live follow accordion display context">
+        <ContextChip icon="instrument" label={ACCORDION_STANDARD_PROFILE.label} />
+        <ContextChip icon="key" label={`Source ${formatOptionalKey(project.sourceKey)}`} />
+        <ContextChip icon="key" label={`Display ${formatOptionalKey(project.displayedKey)}`} />
+        {selectedVoicing.regionRoot ? (
+          <ContextChip icon="key" label={`Region ${selectedVoicing.regionRoot}`} />
+        ) : null}
+        <ContextChip icon="sound" label={chordSpelling.label} />
+      </div>
+
+      <div className="live-follow-grid live-follow-grid--accordion">
+        <main className="live-follow-main">
+          <section className="live-current-chord" aria-label="Current chord">
+            <p className="metric-label">Current chord</p>
+            <h3>{currentChord.displayLabel}</h3>
+            <dl className="live-follow-provenance">
+              <div>
+                <dt>Source chord</dt>
+                <dd>{currentChord.sourceLabel}</dd>
+              </div>
+              <div>
+                <dt>Display chord</dt>
+                <dd>{currentChord.displayLabel}</dd>
+              </div>
+              <div>
+                <dt>Segment</dt>
+                <dd>
+                  {formatFollowTime(currentChord.sourceSegment.start_seconds)} -{" "}
+                  {formatFollowTime(currentChord.sourceSegment.end_seconds)}
+                </dd>
+              </div>
+              <div>
+                <dt>Playback source</dt>
+                <dd>{playbackSourceLabel}</dd>
+              </div>
+            </dl>
+          </section>
+
+          <section className="chord-section" aria-label="Current accordion voicing">
+            <div className="chord-section-heading chord-section-heading--inline">
+              <div>
+                <p className="metric-label">{chordSpelling.notes.join(" ")}</p>
+                <h3>{chordSpelling.label} accordion positions</h3>
+              </div>
+              <div className="chord-shape-controls">
+                <div className="chord-shape-control-row">
+                  <div
+                    aria-describedby="live-accordion-preference-copy"
+                    aria-label="Project accordion right-hand preference choices"
+                    className="chord-shape-tabs"
+                    role="group"
+                  >
+                    {voicingViews.map((voicing) => (
+                      <button
+                        key={voicing.id}
+                        aria-pressed={selectedVoicing.id === voicing.id}
+                        className={classNames(
+                          "chord-shape-tab",
+                          selectedVoicing.id === voicing.id && "chord-shape-tab--active",
+                        )}
+                        onClick={() => selectVoicing(voicing)}
+                        type="button"
+                      >
+                        {voicing.label}
+                      </button>
+                    ))}
+                  </div>
+                  {hasProjectPreference ? (
+                    <button
+                      aria-label="Clear this project override and fall back to global or default"
+                      className="chord-reset-button"
+                      onClick={() => {
+                        resetProjectChordDictionaryPreferredShape(preferenceContext);
+                        bumpPreferenceRevision();
+                      }}
+                      type="button"
+                    >
+                      Clear project override
+                    </button>
+                  ) : null}
+                </div>
+                <p className="chord-shape-preference-copy" id="live-accordion-preference-copy">
+                  Saves right-hand inversion for this project chord.
+                </p>
+              </div>
+            </div>
+            <ChordSpellingSummary spelling={chordSpelling} />
+            <AccordionVoicingPanel
+              activeChord={currentChord.displayLabel}
+              activePointId={activePointId}
+              selectedCandidate={selectedCandidate}
+              voicing={selectedVoicing}
+              onPreviewPoint={setPreviewPointId}
+              onSelectPoint={(pointId) => {
+                setPreviewPointId(null);
+                setSelectedPointId(pointId);
+              }}
+            />
+          </section>
+        </main>
+
+        <aside className="live-follow-sidebar">
+          <section className="live-next-chord" aria-label="Next chord">
+            <p className="metric-label">Next chord</p>
+            {context.nextChord ? (
+              <>
+                <strong>{context.nextChord.displayLabel}</strong>
+                <span>
+                  Source {context.nextChord.sourceLabel} at{" "}
+                  {formatFollowTime(context.nextChord.sourceSegment.start_seconds)}
+                </span>
+              </>
+            ) : (
+              <>
+                <strong>End of timeline</strong>
+                <span>No later project chord is available.</span>
+              </>
+            )}
+          </section>
+          {displayedPoint ? <AccordionNoteInspector point={displayedPoint} /> : null}
+          <AccordionCandidateList
+            candidates={selectedVoicing.leftHandCandidates}
+            selectedCandidateId={selectedCandidate?.id ?? null}
+            onSelectCandidate={(candidateId) => {
+              setActiveCandidate(candidateId);
+              setPreviewPointId(null);
+              const nextCandidate =
+                selectedVoicing.leftHandCandidates.find((candidate) => candidate.id === candidateId) ??
+                null;
+              const nextPointId =
+                getAccordionFirstCandidateButtonId(selectedVoicing, nextCandidate) ??
+                selectedVoicing.rightHandNotes[0]?.id ??
+                null;
+              setSelectedPointId(nextPointId);
+            }}
+          />
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function LiveFollowTopbar({
+  allowInstrumentSelection = false,
+  context,
+  instrumentId,
+  onInstrumentChange,
+  statusLabel,
+}: {
+  allowInstrumentSelection?: boolean;
+  context: ChordDictionaryFollowContext;
+  instrumentId: ChordDictionaryInstrumentId;
+  onInstrumentChange: (instrumentId: ChordDictionaryInstrumentId) => void;
   statusLabel: string;
 }) {
   return (
     <div className="live-follow-topbar">
       <div className="live-follow-controls" role="group" aria-label="Live chord display status">
-        <span className="chord-pill chord-pill--active">
-          <Music2 aria-hidden="true" />
-          <span>{GUITAR_STANDARD_PROFILE.label}</span>
-        </span>
+        {allowInstrumentSelection ? (
+          <InstrumentSelector
+            ariaLabel="Live instrument"
+            instrumentId={instrumentId}
+            onInstrumentChange={onInstrumentChange}
+          />
+        ) : (
+          <span className="chord-pill chord-pill--active">
+            <Music2 aria-hidden="true" />
+            <span>{getChordDictionaryInstrumentLabel(instrumentId)}</span>
+          </span>
+        )}
         <span
           className={classNames(
             "chord-pill",
@@ -1512,17 +3401,27 @@ function LiveFollowStatusCard({
 function LiveFollowChordIssue({
   context,
   copy,
+  instrumentId,
+  onInstrumentChange,
   statusLabel,
   title,
 }: {
   context: ChordDictionaryFollowContext;
   copy: string;
+  instrumentId: ChordDictionaryInstrumentId;
+  onInstrumentChange: (instrumentId: ChordDictionaryInstrumentId) => void;
   statusLabel: string;
   title: string;
 }) {
   return (
     <div className="live-follow-page live-follow-page--waiting" data-follow-status="unsupported">
-      <LiveFollowTopbar context={context} statusLabel={statusLabel} />
+      <LiveFollowTopbar
+        allowInstrumentSelection
+        context={context}
+        instrumentId={instrumentId}
+        statusLabel={statusLabel}
+        onInstrumentChange={onInstrumentChange}
+      />
       <div className="lyrics-follow-stage lyrics-follow-stage--empty" role="status" aria-live="polite">
         <div className="live-follow-empty">
           <AudioLines aria-hidden="true" />

--- a/apps/desktop/src/features/tools/chordDictionaryPreferences.test.ts
+++ b/apps/desktop/src/features/tools/chordDictionaryPreferences.test.ts
@@ -18,6 +18,11 @@ import {
 const SHAPE_IDS = ["c-open", "c-g-shape", "c-a-shape"] as const;
 const D_SHAPE_IDS = ["d-open", "d-a-shape-barre"] as const;
 const E_SHAPE_IDS = ["e-open", "e-a-shape-barre", "e-d-shape-barre"] as const;
+const ACCORDION_RIGHT_HAND_SHAPE_IDS = [
+  "accordion-c-right-close",
+  "accordion-c-right-first-inversion",
+  "accordion-c-right-spread",
+] as const;
 
 function makeContext(
   overrides: Partial<ChordDictionaryPreferenceContext> = {},
@@ -109,6 +114,67 @@ describe("chord dictionary preferences", () => {
     writeProjectChordDictionaryPreferredShape(projectContext, "c-a-shape");
 
     expect(resolveChordDictionaryPreferredShapeId(projectContext, SHAPE_IDS)).toBe("c-a-shape");
+  });
+
+  it("scopes accordion right-hand preferences under the accordion instrument", () => {
+    const accordionContext = makeContext({ instrumentId: "accordion" });
+    const accordionProjectContext = makeContext({
+      instrumentId: "accordion",
+      projectId: "project-accordion",
+    });
+    const guitarContext = makeContext();
+
+    writeGlobalChordDictionaryPreferredShape(
+      accordionContext,
+      "accordion-c-right-first-inversion",
+    );
+    writeProjectChordDictionaryPreferredShape(
+      accordionProjectContext,
+      "accordion-c-right-spread",
+    );
+
+    expect(
+      resolveChordDictionaryPreferredShapeId(
+        accordionContext,
+        ACCORDION_RIGHT_HAND_SHAPE_IDS,
+      ),
+    ).toBe("accordion-c-right-first-inversion");
+    expect(
+      resolveChordDictionaryPreferredShapeId(
+        accordionProjectContext,
+        ACCORDION_RIGHT_HAND_SHAPE_IDS,
+      ),
+    ).toBe("accordion-c-right-spread");
+    expect(resolveChordDictionaryPreferredShapeId(guitarContext, SHAPE_IDS)).toBe("c-open");
+
+    writeGlobalChordDictionaryPreferredShape(guitarContext, "c-g-shape");
+
+    expect(resolveChordDictionaryPreferredShapeId(guitarContext, SHAPE_IDS)).toBe("c-g-shape");
+    expect(
+      resolveChordDictionaryPreferredShapeId(
+        accordionContext,
+        ACCORDION_RIGHT_HAND_SHAPE_IDS,
+      ),
+    ).toBe("accordion-c-right-first-inversion");
+
+    const storedPreferences = JSON.parse(
+      window.localStorage.getItem(CHORD_DICTIONARY_PREFERENCES_STORAGE_KEY) ?? "{}",
+    ) as {
+      globalPreferredShapeIds?: Record<string, string>;
+      projectPreferredShapeIds?: Record<string, Record<string, string>>;
+    };
+
+    expect(storedPreferences.globalPreferredShapeIds?.[JSON.stringify(["accordion", "C"])]).toBe(
+      "accordion-c-right-first-inversion",
+    );
+    expect(storedPreferences.globalPreferredShapeIds?.[JSON.stringify(["guitar", "C"])]).toBe(
+      "c-g-shape",
+    );
+    expect(
+      storedPreferences.projectPreferredShapeIds?.["project-accordion"]?.[
+        JSON.stringify(["accordion", "C"])
+      ],
+    ).toBe("accordion-c-right-spread");
   });
 
   it("falls through project, global, and generated defaults for one displayed chord", () => {

--- a/apps/desktop/src/styles/tools.css
+++ b/apps/desktop/src/styles/tools.css
@@ -420,11 +420,15 @@
 }
 
 .chord-icon-button:focus-visible,
+.chord-instrument-button:focus-visible,
 .chord-reset-button:focus-visible,
 .chord-shape-tab:focus-visible,
 .guitar-fretboard__dot:focus-visible,
 .chord-shape-card__label:focus-visible,
-.chord-family-card:focus-visible {
+.chord-family-card:focus-visible,
+.accordion-stradella__button:focus-visible,
+.accordion-keyboard__key:focus-visible,
+.accordion-candidate-card:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
 }
@@ -483,6 +487,43 @@
   color: var(--text);
   font-size: 0.9rem;
   font-weight: 850;
+}
+
+.chord-instrument-button {
+  border-color: color-mix(in srgb, var(--divider) 78%, transparent);
+  background: color-mix(in srgb, var(--panel) 76%, var(--panel-strong) 24%);
+  box-shadow: none;
+  cursor: pointer;
+  transition:
+    border-color 140ms ease,
+    background 140ms ease,
+    box-shadow 140ms ease,
+    color 140ms ease;
+}
+
+.chord-instrument-selector .chord-instrument-button[aria-pressed="false"],
+.chord-instrument-selector .chord-instrument-button[aria-pressed="false"].chord-pill--active,
+.chord-instrument-selector .chord-instrument-button[aria-pressed="false"].chord-instrument-button--active {
+  border-color: color-mix(in srgb, var(--divider) 78%, transparent);
+  background: color-mix(in srgb, var(--panel) 76%, var(--panel-strong) 24%);
+  box-shadow: none;
+  color: var(--muted);
+}
+
+.chord-instrument-selector .chord-instrument-button[aria-pressed="false"]:hover,
+.chord-instrument-selector .chord-instrument-button[aria-pressed="false"]:focus-visible {
+  border-color: color-mix(in srgb, var(--divider) 72%, var(--text));
+  background: color-mix(in srgb, var(--panel) 84%, var(--panel-strong));
+  box-shadow: none;
+  color: var(--text);
+}
+
+.chord-instrument-selector .chord-instrument-button[aria-pressed="true"],
+.chord-instrument-selector .chord-instrument-button--active[aria-pressed="true"] {
+  border-color: color-mix(in srgb, var(--playback-accent) 72%, var(--divider));
+  background: color-mix(in srgb, var(--playback-accent) 24%, var(--panel-strong));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--playback-accent) 24%, transparent);
+  color: var(--text);
 }
 
 .chord-pill--muted {
@@ -1404,6 +1445,430 @@
   cursor: default;
 }
 
+.accordion-tool-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(18rem, 22rem);
+  gap: 1rem;
+  align-items: start;
+  min-width: 0;
+}
+
+.accordion-tool-main,
+.accordion-tool-sidebar {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.accordion-tool-main,
+.accordion-tool-sidebar,
+.accordion-position-card,
+.accordion-candidate-panel {
+  border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--surface-muted) 38%, transparent);
+}
+
+.accordion-tool-main,
+.accordion-tool-sidebar {
+  padding: 0.85rem;
+}
+
+.accordion-position-grid {
+  display: grid;
+  grid-template-columns: minmax(18rem, 0.85fr) minmax(24rem, 1.35fr);
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.accordion-position-card {
+  display: grid;
+  align-content: start;
+  gap: 0.75rem;
+  min-width: 0;
+  padding: 0.8rem;
+  overflow: hidden;
+}
+
+.accordion-position-card__heading,
+.accordion-candidate-card__title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.65rem;
+  min-width: 0;
+}
+
+.accordion-position-card__heading h4,
+.accordion-candidate-panel h4 {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.98rem;
+}
+
+.accordion-match-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.45rem;
+  padding: 0.22rem 0.45rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 74%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--panel-strong) 72%, transparent);
+  color: var(--muted);
+  font-size: 0.7rem;
+  font-weight: 900;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.accordion-match-badge--exact {
+  border-color: color-mix(in srgb, var(--playback-accent) 62%, var(--divider));
+  background: color-mix(in srgb, var(--playback-accent) 22%, var(--panel-strong));
+  color: color-mix(in srgb, var(--playback-accent) 54%, var(--text));
+}
+
+.accordion-stradella {
+  display: grid;
+  align-content: start;
+  gap: 0.4rem;
+  box-sizing: border-box;
+  inline-size: 100%;
+  min-width: 0;
+  overflow-x: hidden;
+  padding-bottom: 0.15rem;
+}
+
+.accordion-stradella__headers,
+.accordion-stradella__board {
+  box-sizing: border-box;
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  inline-size: 100%;
+  min-width: 0;
+}
+
+.accordion-stradella__headers {
+  gap: 0.14rem;
+  color: var(--muted);
+  font-size: 0.58rem;
+  font-weight: 900;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.accordion-stradella__board {
+  grid-template-rows: repeat(var(--accordion-root-count, 12), 1.58rem);
+  gap: 0.16rem 0.14rem;
+  min-height: 18.5rem;
+  padding: 0.3rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 72%, transparent);
+  border-radius: 8px;
+  background:
+    linear-gradient(90deg, transparent 0 49.75%, color-mix(in srgb, var(--divider) 20%, transparent) 49.75% 50.25%, transparent 50.25%),
+    color-mix(in srgb, var(--color-bg-inset) 74%, transparent);
+}
+
+.accordion-stradella__button {
+  box-sizing: border-box;
+  grid-column: var(--accordion-button-column);
+  grid-row: var(--accordion-button-row);
+  min-width: 0;
+  width: 100%;
+  min-height: 1.48rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+  border-radius: 999px;
+  padding: 0 0.08rem;
+  background:
+    radial-gradient(circle at 35% 28%, color-mix(in srgb, white 24%, transparent), transparent 42%),
+    color-mix(in srgb, var(--panel-strong) 80%, var(--surface-muted));
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.62rem;
+  font-weight: 900;
+  line-height: 1;
+  overflow: hidden;
+  text-overflow: clip;
+  transition:
+    border-color 140ms ease,
+    box-shadow 140ms ease,
+    transform 140ms ease;
+  white-space: nowrap;
+}
+
+.accordion-stradella__button:hover,
+.accordion-stradella__button:focus-visible {
+  z-index: 3;
+  border-color: color-mix(in srgb, var(--text) 54%, var(--divider));
+  transform: scale(1.12);
+}
+
+.accordion-stradella__button--bass,
+.accordion-stradella__button--counterbass {
+  background:
+    radial-gradient(circle at 35% 28%, color-mix(in srgb, white 18%, transparent), transparent 42%),
+    color-mix(in srgb, var(--panel) 82%, var(--panel-strong));
+}
+
+.accordion-stradella__button--counterbass::before {
+  content: attr(data-label);
+}
+
+.accordion-stradella__button--selected,
+.accordion-stradella__button--active {
+  border-color: color-mix(in srgb, var(--playback-accent) 72%, var(--divider));
+  background: var(--playback-accent);
+  color: var(--panel);
+  box-shadow: 0 0 0 0.18rem color-mix(in srgb, var(--playback-accent) 20%, transparent);
+}
+
+.accordion-keyboard {
+  --accordion-white-key-width: 10.8rem;
+  --accordion-white-key-height: 2.05rem;
+  --accordion-white-key-gap: 0rem;
+  --accordion-white-key-step: calc(var(--accordion-white-key-height) + var(--accordion-white-key-gap));
+  --accordion-black-key-width: 4.15rem;
+  --accordion-black-key-height: 1.08rem;
+  --accordion-black-key-offset: -0.22rem;
+  --accordion-keyboard-start-padding: 1.95rem;
+  --accordion-keyboard-top-padding: 0.22rem;
+  --accordion-keyboard-end-padding: 0.28rem;
+  --accordion-keyboard-bottom-padding: 0.22rem;
+
+  position: relative;
+  align-self: start;
+  justify-self: center;
+  box-sizing: border-box;
+  inline-size: fit-content;
+  max-inline-size: 100%;
+  min-width: 0;
+  padding:
+    var(--accordion-keyboard-top-padding)
+    var(--accordion-keyboard-end-padding)
+    var(--accordion-keyboard-bottom-padding)
+    var(--accordion-keyboard-start-padding);
+  overflow: visible;
+}
+
+.accordion-keyboard__white-keys {
+  display: grid;
+  grid-template-columns: var(--accordion-white-key-width);
+  grid-template-rows: repeat(var(--accordion-white-key-count, 15), var(--accordion-white-key-height));
+  gap: var(--accordion-white-key-gap) 0;
+  inline-size: var(--accordion-white-key-width);
+  min-width: 0;
+  min-height: calc(
+    (var(--accordion-white-key-count, 15) * var(--accordion-white-key-height)) +
+      ((var(--accordion-white-key-count, 15) - 1) * var(--accordion-white-key-gap))
+  );
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--divider) 82%, transparent);
+  border-radius: 5px;
+  background: color-mix(in srgb, white 94%, var(--panel-strong));
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, white 40%, transparent),
+    0 0.1rem 0.22rem color-mix(in srgb, black 16%, transparent);
+}
+
+.accordion-keyboard__black-keys {
+  position: absolute;
+  inset-block-start: var(--accordion-keyboard-top-padding);
+  inset-inline-start: var(--accordion-keyboard-start-padding);
+  inline-size: var(--accordion-white-key-width);
+  block-size: calc(
+    (var(--accordion-white-key-count, 15) * var(--accordion-white-key-height)) +
+      ((var(--accordion-white-key-count, 15) - 1) * var(--accordion-white-key-gap))
+  );
+  min-width: 0;
+  pointer-events: none;
+}
+
+.accordion-keyboard__key {
+  position: relative;
+  display: grid;
+  align-content: center;
+  justify-items: end;
+  gap: 0.02rem;
+  box-sizing: border-box;
+  min-width: 0;
+  border: 0;
+  padding: 0.16rem 0.68rem 0.15rem calc(var(--accordion-black-key-width) + 0.52rem);
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.74rem;
+  font-weight: 900;
+  line-height: 1.05;
+  text-align: center;
+}
+
+.accordion-keyboard__key--white {
+  inline-size: var(--accordion-white-key-width);
+  block-size: var(--accordion-white-key-height);
+  min-height: 0;
+  border-radius: 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--divider) 72%, transparent);
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--divider) 45%, transparent) 0 1px, transparent 1px),
+    color-mix(in srgb, white 94%, var(--panel-strong));
+  color: color-mix(in srgb, var(--text) 92%, black);
+  box-shadow: none;
+}
+
+.accordion-keyboard__key--black {
+  position: absolute;
+  inset-block-start: calc(
+    ((var(--accordion-white-index) + 1) * var(--accordion-white-key-step)) -
+      (var(--accordion-white-key-gap) / 2) -
+      (var(--accordion-black-key-height) / 2)
+  );
+  inset-inline-start: var(--accordion-black-key-offset);
+  z-index: 2;
+  inline-size: var(--accordion-black-key-width);
+  block-size: var(--accordion-black-key-height);
+  min-height: 0;
+  border: 1px solid color-mix(in srgb, black 82%, var(--divider));
+  border-radius: 4px 4px 3px 3px;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, white 10%, transparent), transparent 34%),
+    linear-gradient(90deg, color-mix(in srgb, black 86%, var(--panel-strong)), color-mix(in srgb, black 68%, var(--panel-strong)));
+  color: color-mix(in srgb, var(--text) 82%, white);
+  font-size: 0.56rem;
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 10%, transparent),
+    0.16rem 0.12rem 0.2rem color-mix(in srgb, black 28%, transparent);
+  pointer-events: auto;
+}
+
+span.accordion-keyboard__key--black {
+  pointer-events: none;
+}
+
+.accordion-keyboard__key--active-tone {
+  border-color: color-mix(in srgb, var(--playback-accent) 72%, var(--divider));
+  background: linear-gradient(90deg, color-mix(in srgb, var(--playback-accent) 78%, white), color-mix(in srgb, var(--playback-accent) 58%, white));
+  color: color-mix(in srgb, var(--panel) 92%, black);
+  cursor: pointer;
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, white 32%, transparent),
+    inset 0 -1px 0 color-mix(in srgb, var(--panel) 18%, transparent);
+}
+
+.accordion-keyboard__key--black.accordion-keyboard__key--active-tone {
+  background: color-mix(in srgb, var(--playback-accent) 54%, black);
+  color: var(--text);
+}
+
+.accordion-keyboard__key--selected {
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, white 32%, transparent),
+    0 0 0 0.22rem color-mix(in srgb, var(--playback-accent) 22%, transparent);
+}
+
+.accordion-keyboard__key strong,
+.accordion-keyboard__key span {
+  display: block;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
+.accordion-keyboard__key span {
+  margin-top: 0.02rem;
+  font-size: 0.64rem;
+  line-height: 1;
+  opacity: 0.82;
+}
+
+.accordion-keyboard__key--black span {
+  font-size: 0.5rem;
+}
+
+.accordion-candidate-panel {
+  display: grid;
+  gap: 0.65rem;
+  padding: 0.8rem;
+}
+
+.accordion-candidate-list {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.accordion-candidate-card {
+  display: grid;
+  gap: 0.28rem;
+  width: 100%;
+  border: 1px solid color-mix(in srgb, var(--divider) 76%, transparent);
+  border-radius: 8px;
+  padding: 0.65rem;
+  background: color-mix(in srgb, var(--panel) 74%, var(--panel-strong) 26%);
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.accordion-candidate-card--active {
+  border-color: color-mix(in srgb, var(--playback-accent) 68%, var(--divider));
+  background: color-mix(in srgb, var(--playback-accent) 12%, var(--panel-strong));
+}
+
+.accordion-candidate-card strong {
+  font-size: 0.95rem;
+  overflow-wrap: anywhere;
+}
+
+.accordion-candidate-card span,
+.accordion-candidate-card small {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 790;
+  overflow-wrap: anywhere;
+}
+
+.accordion-candidate-card__title strong {
+  color: var(--text);
+}
+
+.accordion-candidate-card__diff {
+  display: grid;
+  gap: 0.16rem;
+}
+
+.accordion-candidate-diff {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid color-mix(in srgb, var(--playback-accent) 36%, var(--divider));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--playback-accent) 10%, var(--panel-strong));
+}
+
+.accordion-candidate-diff small {
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 850;
+}
+
+.accordion-note-inspector .note-inspector__badge {
+  width: 4.75rem;
+  height: 4.75rem;
+  border-radius: 8px;
+}
+
+.accordion-note-inspector {
+  align-items: start;
+}
+
+.accordion-note-inspector dl {
+  grid-template-columns: repeat(2, minmax(5.25rem, 1fr));
+  gap: 0.65rem 0.75rem;
+}
+
+.accordion-note-inspector dt,
+.accordion-note-inspector dd {
+  overflow-wrap: anywhere;
+}
+
 .live-follow-page {
   min-height: 41rem;
 }
@@ -1529,8 +1994,13 @@
 
 @media (max-width: 1180px) {
   .chord-tool-grid,
-  .live-follow-grid {
+  .live-follow-grid,
+  .accordion-tool-grid {
     grid-template-columns: 1fr;
+  }
+
+  .accordion-position-grid {
+    grid-template-columns: minmax(16rem, 0.9fr) minmax(20rem, 1.1fr);
   }
 
   .chord-card-row {
@@ -1550,9 +2020,14 @@
   .chord-dictionary-header,
   .chord-dictionary-toolbar,
   .chord-section-heading,
-  .live-follow-topbar {
+  .live-follow-topbar,
+  .accordion-position-card__heading {
     align-items: stretch;
     flex-direction: column;
+  }
+
+  .accordion-position-grid {
+    grid-template-columns: 1fr;
   }
 
   .chord-search {
@@ -1628,13 +2103,33 @@
 
 @media (max-width: 560px) {
   .chord-dictionary-actions,
-  .chord-toolbar-cluster {
+  .chord-toolbar-cluster,
+  .live-follow-controls {
     width: 100%;
   }
 
   .chord-icon-button,
   .chord-pill {
     flex: 1 1 auto;
+  }
+
+  .accordion-stradella__headers,
+  .accordion-stradella__board {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    min-width: 0;
+  }
+
+  .accordion-stradella__button {
+    min-height: 1.5rem;
+    font-size: 0.6rem;
+  }
+
+  .accordion-keyboard {
+    --accordion-white-key-width: 8.9rem;
+    --accordion-white-key-height: 1.86rem;
+    --accordion-black-key-width: 3.55rem;
+    --accordion-black-key-height: 1rem;
+    --accordion-keyboard-start-padding: 1.7rem;
   }
 
   .chord-field-row,


### PR DESCRIPTION
## Summary

- Add Accordion to the Chord Dictionary instrument selector and render accordion positions.
- Render left-hand Stradella and right-hand treble keyboard surfaces in Dictionary and Live Follow.
- Preserve accordion truthfulness rules: no transpose/capo affordance, exact/approx labels, and real missing/added tones only.

Refs #267

## Testing

- `pnpm --filter @tuneforge/desktop test -- src/App.tools-chord-dictionary.test.tsx src/features/tools/chordDictionaryPreferences.test.ts`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop lint`
- `git diff --check`
