### PR TITLE
feat(sync): apply last-writer-wins revisions

### DIFF
--- a/apps/backend/app/services/stems.py
+++ b/apps/backend/app/services/stems.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import Session
 from app.config import get_settings
 from app.engines.stems import separate_sources, separate_two_stems
 from app.errors import AppError, JobCancelledError
-from app.models import Artifact, Project
+from app.models import Artifact, Project, utcnow
 from app.services.artifacts import refresh_artifact_file_metadata, register_artifact
 from app.services.paths import project_stems_dir
 from app.services.stem_models import (
@@ -196,6 +196,7 @@ def _upsert_stem_artifact(
     existing_artifact.can_delete = True
     existing_artifact.can_regenerate = True
     existing_artifact.metadata_json = metadata
+    existing_artifact.created_at = utcnow()
     session.flush()
     return existing_artifact
 

--- a/apps/backend/app/services/sync_manifest.py
+++ b/apps/backend/app/services/sync_manifest.py
@@ -252,6 +252,7 @@ def export_project_manifest(session: Session, project_id: str) -> SyncProjectMan
             if not _live_target_supersedes_tombstone(
                 tombstone,
                 live_targets,
+                project_created_at=project.created_at,
                 project_resurrection_window=project_resurrection_window,
             )
         ],
@@ -785,12 +786,19 @@ def _live_target_supersedes_tombstone(
     tombstone: SyncDeleteTombstoneManifest,
     live_targets: dict[tuple[str, str], datetime],
     *,
+    project_created_at: datetime | None = None,
     project_resurrection_window: tuple[datetime, datetime] | None = None,
 ) -> bool:
+    tombstone_deleted_at = _as_utc(tombstone.deleted_at)
+    if (
+        tombstone.target_type != "project"
+        and project_created_at is not None
+        and _as_utc(project_created_at) > tombstone_deleted_at
+    ):
+        return True
     target_updated_at = live_targets.get((tombstone.target_type, tombstone.target_id))
     if target_updated_at is None:
         return False
-    tombstone_deleted_at = _as_utc(tombstone.deleted_at)
     if _as_utc(target_updated_at) > tombstone_deleted_at:
         return True
     return _tombstone_is_inside_project_resurrection_window(
@@ -973,6 +981,7 @@ def _import_delete_tombstones(
             )
         )
         if existing is not None:
+            _merge_newer_delete_tombstone(existing, tombstone)
             imported.append(existing)
             continue
         if session.get(SyncDeleteTombstone, tombstone.tombstone_id) is not None:
@@ -999,6 +1008,20 @@ def _import_delete_tombstones(
 
     session.flush()
     return imported
+
+
+def _merge_newer_delete_tombstone(
+    existing: SyncDeleteTombstone,
+    tombstone: SyncDeleteTombstoneManifest,
+) -> None:
+    if _as_utc(existing.deleted_at) >= _as_utc(tombstone.deleted_at):
+        return
+    existing.project_id = tombstone.project_id
+    existing.author_device_id = tombstone.author_device_id
+    existing.deleted_at = tombstone.deleted_at
+    existing.prior_metadata_json = deepcopy(tombstone.prior_metadata)
+    existing.created_at = tombstone.created_at
+    existing.updated_at = tombstone.updated_at
 
 
 def _apply_delete_tombstones(
@@ -1730,6 +1753,9 @@ def _manifest_target_supersedes_tombstone(
     project_resurrection_window: tuple[datetime, datetime] | None = None,
 ) -> bool:
     target_type = _normalize_tombstone_target_type(tombstone.target_type)
+    tombstone_deleted_at = _as_utc(tombstone.deleted_at)
+    if target_type != "project" and _as_utc(manifest.created_at) > tombstone_deleted_at:
+        return True
     target_updated_at = _manifest_target_updated_at(
         manifest,
         target_type=target_type,
@@ -1737,7 +1763,6 @@ def _manifest_target_supersedes_tombstone(
     )
     if target_updated_at is None:
         return False
-    tombstone_deleted_at = _as_utc(tombstone.deleted_at)
     if _as_utc(target_updated_at) > tombstone_deleted_at:
         return True
     return _tombstone_is_inside_project_resurrection_window(

--- a/apps/backend/app/services/sync_metadata.py
+++ b/apps/backend/app/services/sync_metadata.py
@@ -97,6 +97,7 @@ def get_sync_metadata(session: Session) -> SyncMetadataResult:
             )
         )
     )
+    project_created_at = {project.id: project.created_at for project in projects}
     live_targets = _live_target_updated_at(projects, artifacts, entity_revisions)
     all_delete_tombstones = _list_delete_tombstones(session)
     project_resurrection_windows = _project_resurrection_windows_for_live_targets(
@@ -109,6 +110,7 @@ def get_sync_metadata(session: Session) -> SyncMetadataResult:
         if not _live_target_supersedes_tombstone(
             tombstone,
             live_targets,
+            project_created_at=project_created_at,
             project_resurrection_windows=project_resurrection_windows,
         )
     ]
@@ -220,12 +222,20 @@ def _live_target_supersedes_tombstone(
     tombstone: SyncDeleteTombstone,
     live_targets: dict[tuple[str, str], datetime],
     *,
+    project_created_at: dict[str, datetime],
     project_resurrection_windows: dict[str, tuple[datetime, datetime]],
 ) -> bool:
+    tombstone_deleted_at = _as_utc(tombstone.deleted_at)
+    created_at = project_created_at.get(tombstone.project_id)
+    if (
+        tombstone.target_type != "project"
+        and created_at is not None
+        and _as_utc(created_at) > tombstone_deleted_at
+    ):
+        return True
     target_updated_at = live_targets.get((tombstone.target_type, tombstone.target_id))
     if target_updated_at is None:
         return False
-    tombstone_deleted_at = _as_utc(tombstone.deleted_at)
     if _as_utc(target_updated_at) > tombstone_deleted_at:
         return True
     return _tombstone_is_inside_project_resurrection_window(

--- a/apps/backend/app/services/sync_reconciliation.py
+++ b/apps/backend/app/services/sync_reconciliation.py
@@ -5,7 +5,7 @@ from collections import Counter
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from sqlalchemy import select
@@ -248,6 +248,7 @@ def plan_sync_reconciliation(
             ignored_remote_tombstones.append((tombstone, reason))
 
     fresh_remote_tombstones: list[_RemoteTombstone] = []
+    satisfied_tombstone_targets: set[tuple[str, str]] = set()
     remote_project_resurrection_windows = _project_resurrection_windows_for_tombstones(
         valid_remote_tombstones,
         local=local,
@@ -260,6 +261,7 @@ def plan_sync_reconciliation(
             local=local,
             remote=remote,
             include_remote=False,
+            include_remote_project_creation=True,
             project_resurrection_window=remote_project_resurrection_windows.get(tombstone.project_id),
         ):
             reason = (
@@ -270,6 +272,13 @@ def plan_sync_reconciliation(
             ignored_remote_tombstones.append(
                 (tombstone, reason)
             )
+        elif _remote_tombstone_already_satisfied(tombstone, local):
+            ignored_remote_tombstones.append(
+                (tombstone, "Delete tombstone is already applied locally.")
+            )
+            satisfied_tombstone_targets.add((tombstone.target_type, tombstone.target_id))
+            if tombstone.target_type == ITEM_PROJECT:
+                satisfied_tombstone_targets.add((ITEM_PROJECT, tombstone.project_id))
         else:
             fresh_remote_tombstones.append(tombstone)
     valid_remote_tombstones = fresh_remote_tombstones
@@ -325,6 +334,7 @@ def plan_sync_reconciliation(
             remote=remote,
             local=local,
             effective_tombstones=effective_tombstones,
+            satisfied_tombstone_targets=frozenset(satisfied_tombstone_targets),
             items_by_key=items_by_key,
             actions=actions,
         )
@@ -347,6 +357,7 @@ def plan_sync_reconciliation(
             local=local,
             effective_tombstones=effective_tombstones,
             planned_project_ids=planned_project_ids,
+            satisfied_tombstone_targets=frozenset(satisfied_tombstone_targets),
             items_by_key=items_by_key,
             actions=actions,
         )
@@ -409,6 +420,7 @@ def plan_sync_reconciliation(
             planned_revision_ids=frozenset(planned_revision_ids),
             planned_remote_revisions_by_id=planned_remote_revisions_by_id,
             planned_artifact_project_ids=planned_artifact_project_ids,
+            satisfied_tombstone_targets=frozenset(satisfied_tombstone_targets),
             items_by_key=items_by_key,
             actions=actions,
         ):
@@ -535,6 +547,24 @@ def _embedded_current_revision_missing_locally(
     return True
 
 
+def _embedded_current_revision_replaces_local(
+    revision: _RemoteEntityRevision,
+    local: _LocalState,
+) -> bool:
+    if revision.entity_type not in {"chords", "lyrics"}:
+        return False
+    if not _remote_revision_is_current(revision):
+        return False
+    local_revision = _local_current_revision_for_remote_entity(revision, local)
+    if local_revision is None:
+        return False
+    if local_revision.id == revision.revision_id:
+        return False
+    if _local_revision_content_sha256(local_revision) == revision.content_sha256:
+        return False
+    return _remote_revision_wins_lww(revision, local_revision)
+
+
 def _remote_lyrics_revision_has_segments(revision: _RemoteEntityRevision) -> bool:
     payload = _first_field(revision.raw, "payload", default={})
     return isinstance(payload, Mapping) and _lyrics_payload_has_segments(payload)
@@ -624,7 +654,10 @@ def _embedded_missing_current_revision_chain_ids(
             if revision.entity_type in {"chords", "lyrics"} and _remote_revision_is_current(revision)
         )
         for revision in _sorted_remote_entity_revisions(manifest_revisions_by_id.values()):
-            if not _embedded_current_revision_missing_locally(revision, local):
+            if not (
+                _embedded_current_revision_missing_locally(revision, local)
+                or _embedded_current_revision_replaces_local(revision, local)
+            ):
                 continue
             entity_key = (revision.project_id, revision.entity_type)
             if current_counts[entity_key] != 1:
@@ -1010,10 +1043,25 @@ def _plan_project(
     remote: _RemoteRequest,
     local: _LocalState,
     effective_tombstones: frozenset[tuple[str, str]],
+    satisfied_tombstone_targets: frozenset[tuple[str, str]],
     items_by_key: dict[tuple[str, str], SyncReconciliationItem],
     actions: list[SyncReconciliationAction],
 ) -> None:
     if _is_deleted(ITEM_PROJECT, project.project_id, project.project_id, effective_tombstones):
+        if (ITEM_PROJECT, project.project_id) in satisfied_tombstone_targets:
+            _upsert_item(
+                items_by_key,
+                SyncReconciliationItem(
+                    item_type=ITEM_PROJECT,
+                    item_id=project.project_id,
+                    project_id=project.project_id,
+                    status="noop",
+                    action_type=ACTION_NOOP,
+                    content_sha256=project.source_sha256,
+                    reason="Project delete tombstone is already applied locally.",
+                ),
+            )
+            return
         reason = "Project is covered by a sync delete tombstone."
         _upsert_item(
             items_by_key,
@@ -1411,10 +1459,25 @@ def _plan_artifact(
     local: _LocalState,
     effective_tombstones: frozenset[tuple[str, str]],
     planned_project_ids: frozenset[str],
+    satisfied_tombstone_targets: frozenset[tuple[str, str]],
     items_by_key: dict[tuple[str, str], SyncReconciliationItem],
     actions: list[SyncReconciliationAction],
 ) -> None:
     if _is_deleted(ITEM_ARTIFACT, artifact.artifact_id, artifact.project_id, effective_tombstones):
+        if (ITEM_ARTIFACT, artifact.artifact_id) in satisfied_tombstone_targets:
+            _upsert_item(
+                items_by_key,
+                SyncReconciliationItem(
+                    item_type=ITEM_ARTIFACT,
+                    item_id=artifact.artifact_id,
+                    project_id=artifact.project_id,
+                    status="noop",
+                    action_type=ACTION_NOOP,
+                    content_sha256=artifact.content_sha256,
+                    reason="Artifact delete tombstone is already applied locally.",
+                ),
+            )
+            return
         _upsert_item(
             items_by_key,
             SyncReconciliationItem(
@@ -1466,7 +1529,7 @@ def _plan_artifact(
     if local_artifact is not None:
         local_hash = _normalize_sha256(local_artifact.content_sha256)
         if local_hash != artifact.content_sha256:
-            generated_divergence = _generated_analysis_divergence(
+            generated_divergence = _generated_artifact_divergence(
                 local_artifact,
                 artifact,
                 local_hash=local_hash,
@@ -1502,7 +1565,7 @@ def _plan_artifact(
                                 status="missing_provider",
                                 content_sha256=artifact.content_sha256,
                                 reason=(
-                                    "Remote regenerable analysis_json is newer, but no trusted provider "
+                                    "Remote regenerable artifact is newer, but no trusted provider "
                                     "advertises its content."
                                 ),
                                 details={
@@ -1539,7 +1602,7 @@ def _plan_artifact(
                             project_id=artifact.project_id,
                             content_sha256=artifact.content_sha256,
                             provider_device_id=provider_device_id,
-                            reason="Fetch newer remote regenerable analysis_json artifact bytes.",
+                            reason="Fetch newer remote regenerable artifact bytes.",
                             details=details,
                         )
                     )
@@ -1551,7 +1614,7 @@ def _plan_artifact(
                             project_id=artifact.project_id,
                             content_sha256=artifact.content_sha256,
                             provider_device_id=provider_device_id,
-                            reason="Import newer remote regenerable analysis_json artifact manifest.",
+                            reason="Import newer remote regenerable artifact manifest.",
                             details=details,
                         )
                     )
@@ -1581,7 +1644,9 @@ def _plan_artifact(
                     local_artifact,
                     artifact,
                     local_content_sha256=local_hash,
-                    generated_divergence_reason="Artifact is not a regenerable analysis_json divergence candidate.",
+                    generated_divergence_reason=(
+                        "Artifact is not a supported regenerable generated divergence candidate."
+                    ),
                 ),
             )
             return
@@ -1612,7 +1677,7 @@ def _plan_artifact(
                 action_type=ACTION_FETCH_ARTIFACT_CONTENT if provider_device_id is not None else None,
                 content_sha256=artifact.content_sha256,
                 chosen_provider_device_id=provider_device_id,
-                reason="Local artifact metadata exists, but recorded size does not match remote metadata.",
+                reason="Local artifact metadata exists, but local artifact bytes are missing or truncated.",
             ),
         )
         if provider_device_id is not None:
@@ -1625,6 +1690,17 @@ def _plan_artifact(
                     content_sha256=artifact.content_sha256,
                     provider_device_id=provider_device_id,
                     reason="Fetch artifact bytes from the selected trusted provider.",
+                )
+            )
+            actions.append(
+                _action(
+                    ACTION_IMPORT_ARTIFACT_MANIFEST,
+                    item_type=ITEM_ARTIFACT,
+                    item_id=artifact.artifact_id,
+                    project_id=artifact.project_id,
+                    content_sha256=artifact.content_sha256,
+                    provider_device_id=provider_device_id,
+                    reason="Import artifact manifest after missing local bytes are fetched.",
                 )
             )
         return
@@ -1717,10 +1793,25 @@ def _plan_entity_revision(
     planned_revision_ids: frozenset[str],
     planned_remote_revisions_by_id: Mapping[str, _RemoteEntityRevision],
     planned_artifact_project_ids: Mapping[str, str],
+    satisfied_tombstone_targets: frozenset[tuple[str, str]],
     items_by_key: dict[tuple[str, str], SyncReconciliationItem],
     actions: list[SyncReconciliationAction],
 ) -> bool:
     if _is_deleted(ITEM_ENTITY_REVISION, revision.revision_id, revision.project_id, effective_tombstones):
+        if (ITEM_ENTITY_REVISION, revision.revision_id) in satisfied_tombstone_targets:
+            _upsert_item(
+                items_by_key,
+                SyncReconciliationItem(
+                    item_type=ITEM_ENTITY_REVISION,
+                    item_id=revision.revision_id,
+                    project_id=revision.project_id,
+                    status="noop",
+                    action_type=ACTION_NOOP,
+                    content_sha256=revision.content_sha256,
+                    reason="Entity revision delete tombstone is already applied locally.",
+                ),
+            )
+            return False
         _upsert_item(
             items_by_key,
             SyncReconciliationItem(
@@ -1877,23 +1968,47 @@ def _plan_entity_revision(
 
     divergent_revision = _divergent_local_revision(revision, local)
     if divergent_revision is not None:
-        _record_conflict(
+        details = _divergent_revision_lww_details(revision, divergent_revision)
+        if not _remote_revision_wins_lww(revision, divergent_revision):
+            _upsert_item(
+                items_by_key,
+                SyncReconciliationItem(
+                    item_type=ITEM_ENTITY_REVISION,
+                    item_id=revision.revision_id,
+                    project_id=revision.project_id,
+                    status="noop",
+                    action_type=ACTION_NOOP,
+                    content_sha256=revision.content_sha256,
+                    reason="Local entity revision is newer than the divergent remote revision.",
+                    details=details,
+                ),
+            )
+            return False
+        _upsert_item(
             items_by_key,
-            actions,
-            item_type=ITEM_ENTITY_REVISION,
-            item_id=revision.revision_id,
-            project_id=revision.project_id,
-            content_sha256=revision.content_sha256,
-            reason="Remote entity revision diverges from a local revision with the same base.",
-            details={
-                "base_revision_id": revision.base_revision_id,
-                "local_revision_id": divergent_revision.id,
-                "local_content_sha256": _local_revision_content_sha256(divergent_revision),
-                "stored_local_content_sha256": divergent_revision.content_sha256,
-                "remote_content_sha256": revision.content_sha256,
-            },
+            SyncReconciliationItem(
+                item_type=ITEM_ENTITY_REVISION,
+                item_id=revision.revision_id,
+                project_id=revision.project_id,
+                status="remote_available",
+                action_type=ACTION_IMPORT_ENTITY_REVISION,
+                content_sha256=revision.content_sha256,
+                reason="Remote entity revision is newer than the divergent local revision.",
+                details=details,
+            ),
         )
-        return False
+        actions.append(
+            _action(
+                ACTION_IMPORT_ENTITY_REVISION,
+                item_type=ITEM_ENTITY_REVISION,
+                item_id=revision.revision_id,
+                project_id=revision.project_id,
+                content_sha256=revision.content_sha256,
+                reason="Import newer divergent remote entity revision.",
+                details=details,
+            )
+        )
+        return True
 
     _upsert_item(
         items_by_key,
@@ -1932,6 +2047,55 @@ def _validate_remote_tombstone(tombstone: _RemoteTombstone, local: _LocalState) 
     if tombstone.author_device_id in local.trusted_device_ids:
         return True, ""
     return False, "Ignored remote tombstone from an untrusted or revoked author device."
+
+
+def _remote_tombstone_already_satisfied(tombstone: _RemoteTombstone, local: _LocalState) -> bool:
+    local_tombstone = _local_tombstone_for_remote_target(tombstone, local)
+    if local_tombstone is None:
+        return False
+    remote_deleted_at = _coerce_datetime(tombstone.deleted_at)
+    local_deleted_at = _coerce_datetime(local_tombstone.deleted_at)
+    if remote_deleted_at is None or local_deleted_at is None or local_deleted_at < remote_deleted_at:
+        return False
+    return not _local_tombstone_target_exists(
+        local,
+        target_type=tombstone.target_type,
+        target_id=tombstone.target_id,
+        project_id=tombstone.project_id,
+    )
+
+
+def _local_tombstone_for_remote_target(
+    tombstone: _RemoteTombstone,
+    local: _LocalState,
+) -> SyncDeleteTombstone | None:
+    for local_tombstone in local.tombstones:
+        if (
+            local_tombstone.sync_group_id == tombstone.sync_group_id
+            and _normalize_target_type(local_tombstone.target_type) == tombstone.target_type
+            and local_tombstone.target_id == tombstone.target_id
+        ):
+            return local_tombstone
+    return None
+
+
+def _local_tombstone_target_exists(
+    local: _LocalState,
+    *,
+    target_type: str,
+    target_id: str,
+    project_id: str,
+) -> bool:
+    if target_type == ITEM_PROJECT:
+        project = local.projects.get(target_id)
+        return project is not None and project.id == project_id
+    if target_type == ITEM_ARTIFACT:
+        artifact = local.artifacts.get(target_id)
+        return artifact is not None and artifact.project_id == project_id
+    if target_type == ITEM_ENTITY_REVISION:
+        revision = local.entity_revisions.get(target_id)
+        return revision is not None and revision.project_id == project_id
+    return False
 
 
 def _project_manifest_import_error(
@@ -2344,6 +2508,7 @@ def _effective_tombstone_targets(
             local=local,
             remote=remote,
             include_remote=False,
+            include_remote_project_creation=True,
             project_resurrection_window=remote_project_resurrection_windows.get(remote_tombstone.project_id),
         ):
             continue
@@ -2359,6 +2524,7 @@ def _tombstone_is_older_than_live_target(
     local: _LocalState,
     remote: _RemoteRequest,
     include_remote: bool,
+    include_remote_project_creation: bool = False,
     project_resurrection_window: tuple[datetime, datetime] | None = None,
 ) -> bool:
     target_type = _normalize_target_type(_str_field(tombstone, "target_type", default="") or "")
@@ -2374,6 +2540,7 @@ def _tombstone_is_older_than_live_target(
         local=local,
         remote=remote,
         include_remote=include_remote,
+        include_remote_project_creation=include_remote_project_creation,
         project_resurrection_window=project_resurrection_window,
     )
 
@@ -2387,6 +2554,7 @@ def _tombstone_fields_are_older_than_live_target(
     local: _LocalState,
     remote: _RemoteRequest,
     include_remote: bool,
+    include_remote_project_creation: bool = False,
     project_resurrection_window: tuple[datetime, datetime] | None = None,
 ) -> bool:
     tombstone_deleted_at = _coerce_datetime(deleted_at)
@@ -2406,6 +2574,13 @@ def _tombstone_fields_are_older_than_live_target(
         project_resurrection_window,
     ):
         return True
+    if _local_project_creation_supersedes_tombstone(
+        local,
+        target_type=target_type,
+        project_id=project_id,
+        tombstone_deleted_at=tombstone_deleted_at,
+    ):
+        return True
 
     if include_remote:
         remote_updated_at = _remote_live_target_updated_at(
@@ -2416,9 +2591,17 @@ def _tombstone_fields_are_older_than_live_target(
         )
         if remote_updated_at is not None and remote_updated_at > tombstone_deleted_at:
             return True
-        return remote_updated_at is not None and _tombstone_is_inside_project_resurrection_window(
+        if remote_updated_at is not None and _tombstone_is_inside_project_resurrection_window(
             tombstone_deleted_at,
             project_resurrection_window,
+        ):
+            return True
+    if include_remote or include_remote_project_creation:
+        return _remote_project_creation_supersedes_tombstone(
+            remote,
+            target_type=target_type,
+            project_id=project_id,
+            tombstone_deleted_at=tombstone_deleted_at,
         )
     return False
 
@@ -2538,6 +2721,41 @@ def _live_project_updated_at(
         if remote_updated_at is not None:
             candidates.append(remote_updated_at)
     return max(candidates) if candidates else None
+
+
+def _local_project_creation_supersedes_tombstone(
+    local: _LocalState,
+    *,
+    target_type: str,
+    project_id: str,
+    tombstone_deleted_at: datetime,
+) -> bool:
+    if target_type == ITEM_PROJECT:
+        return False
+    local_project = local.projects.get(project_id)
+    if local_project is None or local_project.sync_status == PROJECT_SYNC_STATUS_DELETED:
+        return False
+    project_created_at = _coerce_datetime(local_project.created_at)
+    return project_created_at is not None and project_created_at > tombstone_deleted_at
+
+
+def _remote_project_creation_supersedes_tombstone(
+    remote: _RemoteRequest,
+    *,
+    target_type: str,
+    project_id: str,
+    tombstone_deleted_at: datetime,
+) -> bool:
+    if target_type == ITEM_PROJECT:
+        return False
+    remote_project = remote.projects.get(project_id)
+    if remote_project is None:
+        return False
+    remote_status = _str_field(remote_project.raw, "sync_status", "sync_state")
+    if remote_status == PROJECT_SYNC_STATUS_DELETED:
+        return False
+    project_created_at = _coerce_datetime(_first_field(remote_project.raw, "created_at", default=None))
+    return project_created_at is not None and project_created_at > tombstone_deleted_at
 
 
 def _tombstone_is_inside_project_resurrection_window(
@@ -2906,7 +3124,81 @@ def _artifact_has_recorded_content(
 ) -> bool:
     if _normalize_sha256(artifact.content_sha256) != content_sha256:
         return False
-    return size_bytes is None or artifact.size_bytes == size_bytes
+    if size_bytes is not None and artifact.size_bytes != size_bytes:
+        return False
+    return _artifact_file_matches_recorded_size(artifact)
+
+
+def _artifact_file_matches_recorded_size(artifact: Artifact) -> bool:
+    try:
+        path = Path(artifact.path)
+        if not path.is_file():
+            return False
+        return artifact.size_bytes is None or path.stat().st_size == artifact.size_bytes
+    except (OSError, TypeError, ValueError):
+        return False
+
+
+def _generated_artifact_divergence(
+    local_artifact: Artifact,
+    remote_artifact: _RemoteArtifact,
+    *,
+    local_hash: str | None,
+    local: _LocalState,
+    remote: _RemoteRequest,
+) -> _GeneratedAnalysisDivergence | None:
+    analysis_divergence = _generated_analysis_divergence(
+        local_artifact,
+        remote_artifact,
+        local_hash=local_hash,
+        local=local,
+        remote=remote,
+    )
+    if analysis_divergence is not None:
+        return analysis_divergence
+
+    local_type = _normalize_artifact_type(local_artifact.type)
+    remote_type = _normalize_artifact_type(remote_artifact.type)
+
+    if local_type != remote_type:
+        return None
+    if local_artifact.can_regenerate is not True or _remote_artifact_can_regenerate(remote_artifact) is not True:
+        return None
+    if local_artifact.project_id != remote_artifact.project_id:
+        return None
+
+    local_timestamp = _coerce_datetime(local_artifact.created_at)
+    remote_timestamp = _coerce_datetime(_first_field(remote_artifact.raw, "created_at", default=None))
+    if local_timestamp is None or remote_timestamp is None:
+        return None
+
+    keep_local = local_timestamp >= remote_timestamp
+    reason = (
+        "Local regenerable artifact generation timestamp is newer."
+        if keep_local
+        else "Remote regenerable artifact generation timestamp is newer."
+    )
+    details = _artifact_conflict_details(
+        local_artifact,
+        remote_artifact,
+        local_content_sha256=local_hash,
+    )
+    details.update(
+        {
+            "generated_divergence_candidate": True,
+            "generated_divergence_resolvable": True,
+            "resolution": "keep_local" if keep_local else "fetch_remote",
+            "resolution_reason": reason,
+            "local_resolution_timestamp": local_timestamp.isoformat(),
+            "remote_resolution_timestamp": remote_timestamp.isoformat(),
+        }
+    )
+    return _GeneratedAnalysisDivergence(
+        resolvable=True,
+        keep_local=keep_local,
+        reason=reason,
+        details=details,
+    )
 
 
 def _generated_analysis_divergence(
@@ -3418,6 +3710,76 @@ def _divergent_local_revision(
             continue
         return local_revision
     return None
+
+
+def _local_current_revision_for_remote_entity(
+    remote_revision: _RemoteEntityRevision,
+    local: _LocalState,
+) -> SyncEntityRevision | None:
+    key = (
+        remote_revision.project_id,
+        remote_revision.entity_type,
+        remote_revision.entity_id,
+    )
+    current_revision: SyncEntityRevision | None = None
+    for local_revision in local.entity_revisions_by_entity.get(key, ()):
+        if _normalize_revision_state(local_revision.state) != "active":
+            continue
+        if current_revision is None or _local_revision_lww_key(local_revision) > _local_revision_lww_key(
+            current_revision
+        ):
+            current_revision = local_revision
+    return current_revision
+
+
+def _remote_revision_wins_lww(
+    remote_revision: _RemoteEntityRevision,
+    local_revision: SyncEntityRevision,
+) -> bool:
+    return _remote_revision_lww_key(remote_revision) > _local_revision_lww_key(local_revision)
+
+
+def _remote_revision_lww_key(revision: _RemoteEntityRevision) -> tuple[datetime, str, str]:
+    timestamp = _coerce_datetime(_first_field(revision.raw, "updated_at", "created_at", default=None))
+    if timestamp is None:
+        timestamp = datetime.min.replace(tzinfo=UTC)
+    return (
+        timestamp,
+        _str_field(revision.raw, "author_device_id", default="") or "",
+        revision.revision_id,
+    )
+
+
+def _local_revision_lww_key(revision: SyncEntityRevision) -> tuple[datetime, str, str]:
+    return (
+        _coerce_datetime(revision.updated_at) or datetime.min.replace(tzinfo=UTC),
+        revision.author_device_id or "",
+        revision.id,
+    )
+
+
+def _divergent_revision_lww_details(
+    remote_revision: _RemoteEntityRevision,
+    local_revision: SyncEntityRevision,
+) -> dict[str, Any]:
+    local_updated_at, local_author_device_id, local_revision_id = _local_revision_lww_key(local_revision)
+    remote_updated_at, remote_author_device_id, remote_revision_id = _remote_revision_lww_key(remote_revision)
+    remote_wins = _remote_revision_lww_key(remote_revision) > _local_revision_lww_key(local_revision)
+    return {
+        "base_revision_id": remote_revision.base_revision_id,
+        "local_revision_id": local_revision.id,
+        "remote_revision_id": remote_revision.revision_id,
+        "local_content_sha256": _local_revision_content_sha256(local_revision),
+        "stored_local_content_sha256": local_revision.content_sha256,
+        "remote_content_sha256": remote_revision.content_sha256,
+        "local_updated_at": _datetime_detail(local_updated_at),
+        "remote_updated_at": _datetime_detail(remote_updated_at),
+        "local_author_device_id": local_author_device_id,
+        "remote_author_device_id": remote_author_device_id,
+        "local_lww_revision_id": local_revision_id,
+        "remote_lww_revision_id": remote_revision_id,
+        "resolution": "fetch_remote" if remote_wins else "keep_local",
+    }
 
 
 def _local_revision_content_sha256(revision: SyncEntityRevision) -> str | None:

--- a/apps/backend/app/services/sync_reconciliation_apply.py
+++ b/apps/backend/app/services/sync_reconciliation_apply.py
@@ -43,9 +43,15 @@ from app.services.sync_reconciliation import (
     SyncReconciliationPlan,
     plan_sync_reconciliation,
 )
-from app.services.sync_revisions import revision_payload_sha256, sanitize_revision_payload
+from app.services.sync_revisions import (
+    CURRENT_REVISION_STATE,
+    SUPERSEDED_REVISION_STATE,
+    revision_payload_sha256,
+    sanitize_revision_payload,
+)
 from app.services.sync_staging import cleanup_staged_artifacts, require_staged_artifact
 from app.services.sync_tombstones import apply_delete_tombstone
+from app.services.sync_trust import get_or_create_local_identity
 from app.utils.hashing import file_sha256
 
 APPLY_STATUS_APPLIED = "applied"
@@ -331,12 +337,12 @@ def _import_artifact_manifest(
             or existing_artifact.content_sha256 != artifact_manifest.content_sha256
             or existing_artifact.size_bytes != artifact_manifest.size_bytes
         )
-        overwrite_generated_analysis = _can_overwrite_generated_analysis_artifact(
+        overwrite_generated_artifact = _can_overwrite_generated_artifact(
             action,
             existing_artifact,
             artifact_manifest,
         )
-        if has_manifest_conflict and not overwrite_generated_analysis:
+        if has_manifest_conflict and not overwrite_generated_artifact:
             return _result(action, APPLY_STATUS_FAILED, "Artifact manifest conflicts with a local artifact.")
         existing_path = Path(existing_artifact.path)
         existing_resolved_path = existing_path.resolve(strict=False)
@@ -346,7 +352,7 @@ def _import_artifact_manifest(
             and file_sha256(existing_path) == artifact_manifest.content_sha256
         ):
             return _result(action, APPLY_STATUS_SATISFIED, "Artifact manifest is already imported locally.")
-        if overwrite_generated_analysis:
+        if overwrite_generated_artifact and artifact_manifest.type == "analysis_json":
             destination_path = _generated_analysis_overwrite_destination(project_id, existing_artifact)
             if _destination_conflicts_with_existing_artifact(
                 session,
@@ -359,6 +365,8 @@ def _import_artifact_manifest(
             ):
                 return _result(action, APPLY_STATUS_FAILED, "Artifact destination already exists locally.")
             destination_has_manifest_bytes = _copied_artifact_matches_manifest(destination_path, artifact_manifest)
+        elif overwrite_generated_artifact:
+            destination_path = existing_path
         else:
             destination_path = existing_path
     else:
@@ -424,6 +432,7 @@ def _import_artifact_manifest(
         )
     if artifact_manifest.type == "analysis_json":
         hydrate_project_analysis_result_from_artifact(session, project_id)
+    _retire_superseded_artifact_tombstone(session, artifact_manifest)
     session.flush()
     return _result(
         action,
@@ -433,25 +442,28 @@ def _import_artifact_manifest(
     )
 
 
-def _can_overwrite_generated_analysis_artifact(
+def _can_overwrite_generated_artifact(
     action: SyncReconciliationAction,
     existing_artifact: Artifact,
     artifact_manifest: SyncArtifactManifest,
 ) -> bool:
+    reason = action.details.get("resolution_reason")
+    if reason == "Remote analysis_json generation timestamp is newer.":
+        if action.details.get("artifact_type") != "analysis_json":
+            return False
+    elif reason != "Remote regenerable artifact generation timestamp is newer.":
+        return False
     return (
         action.item_type == ITEM_ARTIFACT
         and action.details.get("generated_divergence_candidate") is True
         and action.details.get("generated_divergence_resolvable") is True
         and action.details.get("resolution") == "fetch_remote"
-        and action.details.get("resolution_reason") == "Remote analysis_json generation timestamp is newer."
-        and action.details.get("artifact_type") == "analysis_json"
         and action.details.get("artifact_id") == artifact_manifest.artifact_id
         and action.details.get("remote_content_sha256") == artifact_manifest.content_sha256
         and action.content_sha256 == artifact_manifest.content_sha256
         and existing_artifact.id == artifact_manifest.artifact_id
         and existing_artifact.project_id == artifact_manifest.project_id
-        and existing_artifact.type == "analysis_json"
-        and artifact_manifest.type == "analysis_json"
+        and existing_artifact.type == artifact_manifest.type
         and existing_artifact.can_regenerate is True
         and artifact_manifest.can_regenerate is True
     )
@@ -582,6 +594,30 @@ def _update_existing_artifact_from_manifest(
     artifact.created_at = artifact_manifest.created_at
 
 
+def _retire_superseded_artifact_tombstone(
+    session: Session,
+    artifact_manifest: SyncArtifactManifest,
+) -> None:
+    sync_group_id = get_or_create_local_identity(session).sync_group_id
+    tombstone = session.scalar(
+        select(SyncDeleteTombstone).where(
+            SyncDeleteTombstone.sync_group_id == sync_group_id,
+            SyncDeleteTombstone.target_type == ITEM_ARTIFACT,
+            SyncDeleteTombstone.target_id == artifact_manifest.artifact_id,
+        )
+    )
+    if tombstone is None:
+        return
+    if _as_utc(artifact_manifest.created_at) > _as_utc(tombstone.deleted_at):
+        session.delete(tombstone)
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
 def _copied_artifact_matches_manifest(path: Path, artifact_manifest: SyncArtifactManifest) -> bool:
     try:
         if not path.exists() or path.stat().st_size != artifact_manifest.size_bytes:
@@ -621,6 +657,7 @@ def _import_entity_revision(
     if existing_revision is not None:
         if _local_revision_content_sha256(existing_revision) == revision.content_sha256:
             if _normalize_revision_state(existing_revision.state) != remote_state:
+                _supersede_current_entity_revision_siblings(session, revision)
                 existing_revision.state = remote_state
                 existing_revision.updated_at = revision.updated_at
                 session.flush()
@@ -650,6 +687,7 @@ def _import_entity_revision(
         updated_at=revision.updated_at,
     )
     session.add(row)
+    _supersede_current_entity_revision_siblings(session, revision)
     _hydrate_current_entity_revisions(session, project, [revision])
     session.flush()
     return _result(
@@ -660,17 +698,50 @@ def _import_entity_revision(
     )
 
 
+def _supersede_current_entity_revision_siblings(
+    session: Session,
+    revision: Any,
+) -> None:
+    if _normalize_revision_state(revision.state) != CURRENT_REVISION_STATE:
+        return
+    siblings = session.scalars(
+        select(SyncEntityRevision).where(
+            SyncEntityRevision.project_id == revision.project_id,
+            SyncEntityRevision.entity_type == revision.entity_type,
+            SyncEntityRevision.entity_id == revision.entity_id,
+            SyncEntityRevision.id != revision.revision_id,
+            SyncEntityRevision.state.in_((CURRENT_REVISION_STATE, "current")),
+        )
+    )
+    for sibling in siblings:
+        sibling.state = SUPERSEDED_REVISION_STATE
+
+
 def _apply_delete_tombstone_action(
     session: Session,
     action: SyncReconciliationAction,
     context: _ApplyContext,
 ) -> SyncReconciliationApplyActionResult:
-    tombstone = _tombstone_for_action(session, action, context)
+    tombstone, already_persisted = _tombstone_for_action(session, action, context)
     if tombstone is None:
         return _result(
             action,
             APPLY_STATUS_SKIPPED,
             "Delete tombstone is not present in the apply request.",
+        )
+
+    if already_persisted and not _delete_tombstone_target_exists(session, tombstone):
+        return _result(
+            action,
+            APPLY_STATUS_SATISFIED,
+            "Delete tombstone is already applied locally.",
+            details={
+                "tombstone_id": tombstone.id,
+                "target_type": tombstone.target_type,
+                "target_id": tombstone.target_id,
+                "project_id": tombstone.project_id,
+                "persisted_tombstone": True,
+            },
         )
 
     apply_delete_tombstone(session, tombstone)
@@ -799,12 +870,36 @@ def _local_artifact_satisfies_manifest(
     if artifact_id is None or project_id is None:
         return False
     artifact = session.get(Artifact, artifact_id)
+    return artifact is not None and _artifact_matches_manifest_metadata(
+        artifact,
+        project_id=project_id,
+        content_sha256=content_sha256,
+        size_bytes=size_bytes,
+    ) and _artifact_file_matches_recorded_size(artifact)
+
+
+def _artifact_matches_manifest_metadata(
+    artifact: Artifact,
+    *,
+    project_id: str,
+    content_sha256: str,
+    size_bytes: int,
+) -> bool:
     return (
-        artifact is not None
-        and artifact.project_id == project_id
+        artifact.project_id == project_id
         and artifact.content_sha256 == content_sha256
         and artifact.size_bytes == size_bytes
     )
+
+
+def _artifact_file_matches_recorded_size(artifact: Artifact) -> bool:
+    try:
+        path = Path(artifact.path)
+        if not path.is_file():
+            return False
+        return artifact.size_bytes is None or path.stat().st_size == artifact.size_bytes
+    except (OSError, TypeError, ValueError):
+        return False
 
 
 def _cleanup_imported_content_addressed_staging(
@@ -926,12 +1021,12 @@ def _manifest_artifact_import_state(
         ):
             continue
         local_artifact = session.get(Artifact, artifact_id)
-        if (
-            local_artifact is None
-            or local_artifact.project_id != project_id
-            or local_artifact.content_sha256 != content_sha256
-            or local_artifact.size_bytes != size_bytes
-        ):
+        if local_artifact is None or not _artifact_matches_manifest_metadata(
+            local_artifact,
+            project_id=project_id,
+            content_sha256=content_sha256,
+            size_bytes=size_bytes,
+        ) or not _artifact_file_matches_recorded_size(local_artifact):
             pending_hashes.add(content_sha256)
             continue
         imported_hashes.add(content_sha256)
@@ -949,18 +1044,32 @@ def _tombstone_for_action(
     session: Session,
     action: SyncReconciliationAction,
     context: _ApplyContext,
-) -> SyncDeleteTombstone | None:
+) -> tuple[SyncDeleteTombstone | None, bool]:
     tombstone_id = _string_from_mapping(action.details, "tombstone_id")
     raw_tombstone = context.tombstones_by_id.get(tombstone_id) if tombstone_id is not None else None
     if raw_tombstone is None:
         raw_tombstone = context.tombstones_by_target.get((action.item_type, action.item_id))
     if raw_tombstone is None:
-        return None
+        return None, False
 
     raw_tombstone_id = _required_string(raw_tombstone, "tombstone_id", "id")
     persisted = session.get(SyncDeleteTombstone, raw_tombstone_id)
     if persisted is not None:
-        return persisted
+        return persisted, True
+
+    existing_target = session.scalar(
+        select(SyncDeleteTombstone).where(
+            SyncDeleteTombstone.sync_group_id == _required_string(raw_tombstone, "sync_group_id"),
+            SyncDeleteTombstone.target_type == _normalize_target_type(
+                _required_string(raw_tombstone, "target_type")
+            ),
+            SyncDeleteTombstone.target_id == _required_string(raw_tombstone, "target_id"),
+        )
+    )
+    if existing_target is not None:
+        _merge_remote_tombstone(existing_target, raw_tombstone)
+        session.flush()
+        return existing_target, True
 
     tombstone = SyncDeleteTombstone(
         id=raw_tombstone_id,
@@ -976,7 +1085,31 @@ def _tombstone_for_action(
     )
     session.add(tombstone)
     session.flush()
-    return tombstone
+    return tombstone, False
+
+
+def _merge_remote_tombstone(existing: SyncDeleteTombstone, raw_tombstone: object) -> None:
+    remote_deleted_at = _datetime_field(raw_tombstone, "deleted_at")
+    if remote_deleted_at is None or _as_utc(existing.deleted_at) >= remote_deleted_at:
+        return
+    existing.project_id = _required_string(raw_tombstone, "project_id")
+    existing.author_device_id = _required_string(raw_tombstone, "author_device_id")
+    existing.deleted_at = remote_deleted_at
+    existing.prior_metadata_json = _mapping_field(raw_tombstone, "prior_metadata", "prior_metadata_json") or {}
+    existing.updated_at = _datetime_field(raw_tombstone, "updated_at") or remote_deleted_at
+
+
+def _delete_tombstone_target_exists(session: Session, tombstone: SyncDeleteTombstone) -> bool:
+    if tombstone.target_type == ITEM_PROJECT:
+        project = session.get(Project, tombstone.target_id)
+        return project is not None and project.id == tombstone.project_id
+    if tombstone.target_type == ITEM_ARTIFACT:
+        artifact = session.get(Artifact, tombstone.target_id)
+        return artifact is not None and artifact.project_id == tombstone.project_id
+    if tombstone.target_type == ITEM_ENTITY_REVISION:
+        revision = session.get(SyncEntityRevision, tombstone.target_id)
+        return revision is not None and revision.project_id == tombstone.project_id
+    return False
 
 
 def _status_artifact_and_provider_ids(
@@ -1199,8 +1332,17 @@ def _staged_existing_project_artifact_actions(
             or size_bytes is None
         ):
             continue
-        if session.get(Artifact, artifact_id) is not None:
-            continue
+        local_artifact = session.get(Artifact, artifact_id)
+        if local_artifact is not None:
+            if not _artifact_matches_manifest_metadata(
+                local_artifact,
+                project_id=project_id,
+                content_sha256=content_sha256,
+                size_bytes=size_bytes,
+            ):
+                continue
+            if _artifact_file_matches_recorded_size(local_artifact):
+                continue
         try:
             require_staged_artifact(session, content_sha256=content_sha256, size_bytes=size_bytes)
         except AppError:

--- a/apps/backend/tests/test_sync_identity.py
+++ b/apps/backend/tests/test_sync_identity.py
@@ -663,9 +663,7 @@ def test_sync_metadata_omits_tombstones_superseded_by_live_targets(
 
     assert response.status_code == 200
     payload = response.json()
-    assert [tombstone["tombstone_id"] for tombstone in payload["delete_tombstones"]] == [
-        "tomb_deleted_artifact"
-    ]
+    assert payload["delete_tombstones"] == []
 
 
 def test_sync_preflight_does_not_recover_missing_hash_from_source_path(

--- a/apps/backend/tests/test_sync_manifest.py
+++ b/apps/backend/tests/test_sync_manifest.py
@@ -867,6 +867,9 @@ def test_export_project_manifest_includes_delete_tombstones_without_local_paths(
 
     with SessionLocal() as session:
         fixture = _create_project_with_artifacts(session, tmp_path)
+        project = session.get(Project, fixture.project_id)
+        assert project is not None
+        child_deleted_at = project.created_at + timedelta(seconds=1)
         tombstones = [
             _fake_delete_tombstone(
                 tombstone_id="tomb_art_live_source",
@@ -886,6 +889,7 @@ def test_export_project_manifest_includes_delete_tombstones_without_local_paths(
                     "path": str(tmp_path / "local-preview.wav"),
                     "relative_path": "previews/mix.wav",
                 },
+                deleted_at=child_deleted_at,
             ),
             _fake_delete_tombstone(
                 tombstone_id="tomb_revision_deleted",
@@ -893,6 +897,7 @@ def test_export_project_manifest_includes_delete_tombstones_without_local_paths(
                 target_type="entity_revision",
                 target_id="rev_deleted",
                 prior_metadata={"entity_type": "section", "source_path": str(tmp_path / "tab.txt")},
+                deleted_at=child_deleted_at,
             ),
         ]
         monkeypatch.setattr(module, "_list_project_delete_tombstones", lambda *args, **kwargs: tombstones)
@@ -1414,12 +1419,12 @@ def test_import_staged_project_manifest_persists_delete_tombstones(
 ) -> None:
     export_manifest, import_manifest = _sync_manifest_services()
     staging_root = tmp_path / "staging"
-    timestamp = "2026-01-02T00:00:00+00:00"
 
     with SessionLocal() as session:
         fixture = _create_project_with_artifacts(session, tmp_path)
         sync_group_id = get_or_create_local_identity(session).sync_group_id
         manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+        timestamp = (manifest["project"]["created_at"] + timedelta(seconds=1)).isoformat()
         manifest["delete_tombstones"] = [
             {
                 "tombstone_id": "tomb_deleted_mix",
@@ -1497,12 +1502,12 @@ def test_import_staged_project_manifest_applies_delete_tombstones_to_existing_pr
     tmp_path: Path,
 ) -> None:
     export_manifest, import_manifest = _sync_manifest_services()
-    timestamp = "2026-01-02T00:00:00+00:00"
 
     with SessionLocal() as session:
         fixture = _create_project_with_artifacts(session, tmp_path)
         sync_group_id = get_or_create_local_identity(session).sync_group_id
         manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+        timestamp = (manifest["project"]["created_at"] + timedelta(seconds=1)).isoformat()
         deleted_path = fixture.root / "previews" / "deleted-mix.wav"
         deleted_hash, deleted_size = _write_bytes(deleted_path, b"deleted mix")
         session.add(
@@ -1543,6 +1548,79 @@ def test_import_staged_project_manifest_applies_delete_tombstones_to_existing_pr
         assert session.get(Artifact, "art_deleted_mix") is None
         assert not deleted_path.exists()
         assert session.get(SyncDeleteTombstone, "tomb_existing_deleted_mix") is not None
+
+
+def test_import_staged_project_manifest_merges_newer_same_target_tombstone_before_retire(
+    client: object,
+    tmp_path: Path,
+) -> None:
+    export_manifest, import_manifest = _sync_manifest_services()
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path)
+        sync_group_id = get_or_create_local_identity(session).sync_group_id
+        manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+        project_created_at = manifest["project"]["created_at"]
+        stale_deleted_at = project_created_at - timedelta(seconds=1)
+        remote_deleted_at = project_created_at + timedelta(seconds=1)
+        target_id = "art_newer_same_target_deleted_mix"
+        deleted_path = fixture.root / "previews" / "newer-same-target-deleted-mix.wav"
+        deleted_hash, deleted_size = _write_bytes(deleted_path, b"newer same target deleted mix")
+        session.add(
+            Artifact(
+                id=target_id,
+                project_id=fixture.project_id,
+                type="preview_mix",
+                format="wav",
+                path=str(deleted_path),
+                content_sha256=deleted_hash,
+                size_bytes=deleted_size,
+                generated_by="preview",
+                can_delete=True,
+                can_regenerate=True,
+                metadata_json={"source_artifact_id": "art_source_audio"},
+            )
+        )
+        session.add(
+            SyncDeleteTombstone(
+                id="tomb_existing_same_target_deleted_mix",
+                sync_group_id=sync_group_id,
+                project_id=fixture.project_id,
+                target_type="artifact",
+                target_id=target_id,
+                author_device_id="device_old",
+                deleted_at=stale_deleted_at,
+                prior_metadata_json={"type": "old_preview_mix"},
+                created_at=stale_deleted_at,
+                updated_at=stale_deleted_at,
+            )
+        )
+        session.flush()
+        manifest["delete_tombstones"] = [
+            {
+                "tombstone_id": "tomb_remote_newer_same_target_deleted_mix",
+                "sync_group_id": sync_group_id,
+                "project_id": fixture.project_id,
+                "target_type": "artifact",
+                "target_id": target_id,
+                "author_device_id": "device_alpha",
+                "deleted_at": remote_deleted_at.isoformat(),
+                "prior_metadata": {"type": "preview_mix", "remote": True},
+                "created_at": remote_deleted_at.isoformat(),
+                "updated_at": remote_deleted_at.isoformat(),
+            }
+        ]
+
+        import_manifest(session, manifest=manifest, staging_root=None)
+        session.commit()
+
+        assert session.get(Artifact, target_id) is None
+        assert not deleted_path.exists()
+        tombstone = session.get(SyncDeleteTombstone, "tomb_existing_same_target_deleted_mix")
+        assert tombstone is not None
+        assert tombstone.deleted_at == remote_deleted_at
+        assert tombstone.author_device_id == "device_alpha"
+        assert tombstone.prior_metadata_json == {"type": "preview_mix", "remote": True}
 
 
 def test_import_staged_project_manifest_imports_content_addressed_staging(

--- a/apps/backend/tests/test_sync_reconciliation.py
+++ b/apps/backend/tests/test_sync_reconciliation.py
@@ -71,6 +71,10 @@ def test_artifact_classification_uses_recorded_metadata_and_trusted_provider_cho
         tmp_path / "size-mismatch.wav",
         b"size mismatch",
     )
+    missing_file_path = tmp_path / "missing-file.wav"
+    missing_file_hash, missing_file_size = _write_file(missing_file_path, b"missing file")
+    truncated_file_path = tmp_path / "truncated-file.wav"
+    truncated_file_hash, truncated_file_size = _write_file(truncated_file_path, b"full artifact content")
     remote_hash = _sha("remote")
     untrusted_hash = _sha("untrusted")
     missing_provider_hash = _sha("missing provider")
@@ -93,6 +97,22 @@ def test_artifact_classification_uses_recorded_metadata_and_trusted_provider_cho
     )
     _add_artifact(
         db_session,
+        artifact_id="art_missing_file",
+        project_id=project.id,
+        path=missing_file_path,
+        content_sha256=missing_file_hash,
+        size_bytes=missing_file_size,
+    )
+    _add_artifact(
+        db_session,
+        artifact_id="art_truncated_file",
+        project_id=project.id,
+        path=truncated_file_path,
+        content_sha256=truncated_file_hash,
+        size_bytes=truncated_file_size,
+    )
+    _add_artifact(
+        db_session,
         artifact_id="art_conflict",
         project_id=project.id,
         path=tmp_path / "conflict.wav",
@@ -100,6 +120,8 @@ def test_artifact_classification_uses_recorded_metadata_and_trusted_provider_cho
         size_bytes=(tmp_path / "conflict.wav").stat().st_size,
     )
     db_session.commit()
+    missing_file_path.unlink()
+    truncated_file_path.write_bytes(b"truncated")
 
     request = {
         "remote_library": {
@@ -113,6 +135,8 @@ def test_artifact_classification_uses_recorded_metadata_and_trusted_provider_cho
             "artifacts": [
                 _artifact_manifest(project.id, "art_identical", identical_hash, identical_size),
                 _artifact_manifest(project.id, "art_size_mismatch", size_mismatch_hash, size_mismatch_size + 1),
+                _artifact_manifest(project.id, "art_missing_file", missing_file_hash, missing_file_size),
+                _artifact_manifest(project.id, "art_truncated_file", truncated_file_hash, truncated_file_size),
                 _artifact_manifest(project.id, "art_remote_available", remote_hash, 64),
                 _artifact_manifest(project.id, "art_missing_provider", missing_provider_hash, 64),
                 _artifact_manifest(project.id, "art_conflict", _sha("remote conflict"), 64),
@@ -123,11 +147,21 @@ def test_artifact_classification_uses_recorded_metadata_and_trusted_provider_cho
         "peer_inventory": [
             {
                 "device_id": "peer-b",
-                "available_content_hashes": [size_mismatch_hash, remote_hash],
+                "available_content_hashes": [
+                    size_mismatch_hash,
+                    missing_file_hash,
+                    truncated_file_hash,
+                    remote_hash,
+                ],
             },
             {
                 "device_id": "peer-a",
-                "available_content_hashes": [size_mismatch_hash, remote_hash],
+                "available_content_hashes": [
+                    size_mismatch_hash,
+                    missing_file_hash,
+                    truncated_file_hash,
+                    remote_hash,
+                ],
             },
             {"device_id": "peer-revoked", "available_content_hashes": [untrusted_hash]},
             {"device_id": "peer-untrusted", "available_content_hashes": [untrusted_hash]},
@@ -146,6 +180,12 @@ def test_artifact_classification_uses_recorded_metadata_and_trusted_provider_cho
     missing_local = _item(plan, ITEM_ARTIFACT, "art_size_mismatch")
     assert missing_local.status == "missing_local_bytes"
     assert missing_local.chosen_provider_device_id == "peer-a"
+    missing_file = _item(plan, ITEM_ARTIFACT, "art_missing_file")
+    assert missing_file.status == "missing_local_bytes"
+    assert missing_file.chosen_provider_device_id == "peer-a"
+    truncated_file = _item(plan, ITEM_ARTIFACT, "art_truncated_file")
+    assert truncated_file.status == "missing_local_bytes"
+    assert truncated_file.chosen_provider_device_id == "peer-a"
     remote_available = _item(plan, ITEM_ARTIFACT, "art_remote_available")
     assert remote_available.status == "remote_available"
     assert remote_available.chosen_provider_device_id == "peer-a"
@@ -162,8 +202,12 @@ def test_artifact_classification_uses_recorded_metadata_and_trusted_provider_cho
         if action.action_type == ACTION_FETCH_ARTIFACT_CONTENT
     }
     assert fetch_actions["art_size_mismatch"].provider_device_id == "peer-a"
+    assert fetch_actions["art_missing_file"].provider_device_id == "peer-a"
+    assert fetch_actions["art_truncated_file"].provider_device_id == "peer-a"
     assert fetch_actions["art_remote_available"].provider_device_id == "peer-a"
     assert _action(plan, ACTION_RECORD_CONFLICT, ITEM_ARTIFACT, "art_conflict") is not None
+    assert _action(plan, ACTION_IMPORT_ARTIFACT_MANIFEST, ITEM_ARTIFACT, "art_missing_file") is not None
+    assert _action(plan, ACTION_IMPORT_ARTIFACT_MANIFEST, ITEM_ARTIFACT, "art_truncated_file") is not None
     assert _action(plan, ACTION_IMPORT_ARTIFACT_MANIFEST, ITEM_ARTIFACT, "art_duplicate_content") is not None
 
 
@@ -650,7 +694,222 @@ def test_older_remote_project_tombstone_does_not_delete_newer_local_project(
     assert _action(plan, ACTION_APPLY_DELETE_TOMBSTONE, ITEM_PROJECT, project_id) is None
 
 
-def test_entity_revision_ancestry_imports_descendants_and_conflicts_siblings(
+def test_repeated_project_tombstone_is_noop_after_local_delete_applied(
+    db_session: Session,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash = _sha("already deleted remote project")
+    project_id = source_hash_to_project_id(source_hash)
+    stale_at = datetime(2026, 1, 1, tzinfo=UTC)
+    deleted_at = datetime(2026, 1, 2, tzinfo=UTC)
+    db_session.add(
+        SyncDeleteTombstone(
+            id="tomb_known_project_delete",
+            sync_group_id="group-a",
+            project_id=project_id,
+            target_type=ITEM_PROJECT,
+            target_id=project_id,
+            author_device_id="peer-a",
+            deleted_at=deleted_at,
+            prior_metadata_json={"display_name": "Deleted Project"},
+            created_at=deleted_at,
+            updated_at=deleted_at,
+        )
+    )
+    db_session.commit()
+    remote_project = {
+        "project_id": project_id,
+        "display_name": "Deleted Project",
+        "source_sha256": source_hash,
+        "created_at": stale_at,
+        "updated_at": stale_at,
+    }
+    tombstone = _tombstone(
+        tombstone_id="tomb_known_project_delete",
+        project_id=project_id,
+        target_type=ITEM_PROJECT,
+        target_id=project_id,
+        author_device_id="peer-a",
+    )
+    tombstone["deleted_at"] = deleted_at
+    tombstone["created_at"] = deleted_at
+    tombstone["updated_at"] = deleted_at
+
+    plan = plan_sync_reconciliation(
+        db_session,
+        {
+            "remote_library": {
+                "projects": [remote_project],
+                "artifacts": [],
+                "entity_revisions": [],
+                "delete_tombstones": [tombstone],
+            },
+            "project_manifests": [],
+            "peer_inventory": [],
+        },
+    )
+
+    tombstone_item = _item(plan, ITEM_DELETE_TOMBSTONE, "tomb_known_project_delete")
+    assert tombstone_item.status == "noop"
+    assert tombstone_item.reason == "Delete tombstone is already applied locally."
+    project_item = _item(plan, ITEM_PROJECT, project_id)
+    assert project_item.status == "noop"
+    assert project_item.reason == "Project delete tombstone is already applied locally."
+    assert _action(plan, ACTION_APPLY_DELETE_TOMBSTONE, ITEM_PROJECT, project_id) is None
+    assert _action(plan, ACTION_UPSERT_PROJECT_STATUS, ITEM_PROJECT, project_id) is None
+    assert plan.summary.status_counts["deleted"] == 0
+
+
+def test_reimported_project_supersedes_older_child_tombstones_for_missing_old_ids(
+    db_session: Session,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash = _sha("reimported child tombstone source")
+    project_id = source_hash_to_project_id(source_hash)
+    deleted_at = datetime(2026, 1, 1, tzinfo=UTC)
+    reimported_at = datetime(2026, 1, 2, tzinfo=UTC)
+    project = _add_project(db_session, project_id, source_sha256=source_hash)
+    project.created_at = reimported_at
+    project.updated_at = reimported_at
+    db_session.add_all(
+        [
+            SyncDeleteTombstone(
+                id="tomb_old_local_artifact",
+                sync_group_id="group-a",
+                project_id=project_id,
+                target_type=ITEM_ARTIFACT,
+                target_id="art_old_deleted_stem",
+                author_device_id="dev-local",
+                deleted_at=deleted_at,
+                prior_metadata_json={"artifact_id": "art_old_deleted_stem"},
+                created_at=deleted_at,
+                updated_at=deleted_at,
+            ),
+            SyncDeleteTombstone(
+                id="tomb_old_local_revision",
+                sync_group_id="group-a",
+                project_id=project_id,
+                target_type=ITEM_ENTITY_REVISION,
+                target_id="rev_old_deleted_chords",
+                author_device_id="dev-local",
+                deleted_at=deleted_at,
+                prior_metadata_json={"revision_id": "rev_old_deleted_chords"},
+                created_at=deleted_at,
+                updated_at=deleted_at,
+            ),
+        ]
+    )
+    db_session.commit()
+    manifest = _project_manifest(project_id, source_hash)
+    manifest["project"]["created_at"] = reimported_at
+    manifest["project"]["updated_at"] = reimported_at
+    remote_artifact_tombstone = _tombstone(
+        tombstone_id="tomb_old_remote_artifact",
+        project_id=project_id,
+        target_type=ITEM_ARTIFACT,
+        target_id="art_old_deleted_stem",
+        author_device_id="peer-a",
+    )
+    remote_revision_tombstone = _tombstone(
+        tombstone_id="tomb_old_remote_revision",
+        project_id=project_id,
+        target_type=ITEM_ENTITY_REVISION,
+        target_id="rev_old_deleted_chords",
+        author_device_id="peer-a",
+    )
+    for tombstone in (remote_artifact_tombstone, remote_revision_tombstone):
+        tombstone["deleted_at"] = deleted_at
+        tombstone["created_at"] = deleted_at
+        tombstone["updated_at"] = deleted_at
+
+    plan = plan_sync_reconciliation(
+        db_session,
+        {
+            "remote_library": {
+                "projects": [manifest["project"]],
+                "artifacts": [],
+                "entity_revisions": [],
+                "delete_tombstones": [remote_artifact_tombstone, remote_revision_tombstone],
+            },
+            "project_manifests": [manifest],
+            "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [source_hash]}],
+        },
+    )
+
+    assert _item(plan, ITEM_PROJECT, project_id).status == "noop"
+    assert _item(plan, ITEM_DELETE_TOMBSTONE, "tomb_old_remote_artifact").status == "noop"
+    assert _item(plan, ITEM_DELETE_TOMBSTONE, "tomb_old_remote_revision").status == "noop"
+    assert all(item.status != "deleted" for item in plan.items)
+    assert _action(plan, ACTION_APPLY_DELETE_TOMBSTONE, ITEM_ARTIFACT, "art_old_deleted_stem") is None
+    assert (
+        _action(
+            plan,
+            ACTION_APPLY_DELETE_TOMBSTONE,
+            ITEM_ENTITY_REVISION,
+            "rev_old_deleted_chords",
+        )
+        is None
+    )
+
+
+def test_remote_reimported_project_supersedes_older_remote_child_tombstone_without_local_project(
+    db_session: Session,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash = _sha("remote reimported child tombstone source")
+    project_id = source_hash_to_project_id(source_hash)
+    deleted_at = datetime(2026, 1, 1, tzinfo=UTC)
+    reimported_at = datetime(2026, 1, 2, tzinfo=UTC)
+    newer_deleted_at = datetime(2026, 1, 3, tzinfo=UTC)
+    manifest = _project_manifest(project_id, source_hash)
+    manifest["project"]["created_at"] = reimported_at
+    manifest["project"]["updated_at"] = reimported_at
+    older_tombstone = _tombstone(
+        tombstone_id="tomb_older_remote_child",
+        project_id=project_id,
+        target_type=ITEM_ARTIFACT,
+        target_id="art_older_deleted_stem",
+        author_device_id="peer-a",
+    )
+    newer_tombstone = _tombstone(
+        tombstone_id="tomb_newer_remote_child",
+        project_id=project_id,
+        target_type=ITEM_ARTIFACT,
+        target_id="art_newer_deleted_stem",
+        author_device_id="peer-a",
+    )
+    older_tombstone["deleted_at"] = deleted_at
+    older_tombstone["created_at"] = deleted_at
+    older_tombstone["updated_at"] = deleted_at
+    newer_tombstone["deleted_at"] = newer_deleted_at
+    newer_tombstone["created_at"] = newer_deleted_at
+    newer_tombstone["updated_at"] = newer_deleted_at
+
+    plan = plan_sync_reconciliation(
+        db_session,
+        {
+            "remote_library": {
+                "projects": [manifest["project"]],
+                "artifacts": [],
+                "entity_revisions": [],
+                "delete_tombstones": [older_tombstone, newer_tombstone],
+            },
+            "project_manifests": [manifest],
+            "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [source_hash]}],
+        },
+    )
+
+    assert _item(plan, ITEM_PROJECT, project_id).status == "remote_available"
+    older_item = _item(plan, ITEM_DELETE_TOMBSTONE, "tomb_older_remote_child")
+    assert older_item.status == "noop"
+    assert older_item.reason == "Delete tombstone is older than a live sync target."
+    newer_item = _item(plan, ITEM_ARTIFACT, "art_newer_deleted_stem")
+    assert newer_item.status == "deleted"
+    assert _action(plan, ACTION_APPLY_DELETE_TOMBSTONE, ITEM_ARTIFACT, "art_older_deleted_stem") is None
+    assert _action(plan, ACTION_APPLY_DELETE_TOMBSTONE, ITEM_ARTIFACT, "art_newer_deleted_stem") is not None
+
+
+def test_entity_revision_ancestry_imports_descendants_and_lww_siblings(
     db_session: Session,
     tmp_path: Path,
 ) -> None:
@@ -715,8 +974,8 @@ def test_entity_revision_ancestry_imports_descendants_and_conflicts_siblings(
     assert grandchild.status == "remote_available"
     assert grandchild.action_type == ACTION_IMPORT_ENTITY_REVISION
     sibling = _item(plan, ITEM_ENTITY_REVISION, "rev_remote_sibling")
-    assert sibling.status == "conflicted"
-    assert sibling.action_type == ACTION_RECORD_CONFLICT
+    assert sibling.status == "remote_available"
+    assert sibling.action_type == ACTION_IMPORT_ENTITY_REVISION
     import_revision_action_ids = [
         action.item_id
         for action in plan.actions
@@ -725,7 +984,124 @@ def test_entity_revision_ancestry_imports_descendants_and_conflicts_siblings(
     assert import_revision_action_ids.index("rev_z_remote_descendant") < import_revision_action_ids.index(
         "rev_a_remote_grandchild"
     )
-    assert _action(plan, ACTION_RECORD_CONFLICT, ITEM_ENTITY_REVISION, "rev_remote_sibling") is not None
+    assert _action(plan, ACTION_IMPORT_ENTITY_REVISION, ITEM_ENTITY_REVISION, "rev_remote_sibling") is not None
+    assert _action(plan, ACTION_RECORD_CONFLICT, ITEM_ENTITY_REVISION, "rev_remote_sibling") is None
+
+
+def test_entity_revision_lww_imports_newer_same_base_sibling(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    del tmp_path
+    _add_identity_and_peers(db_session)
+    project = _add_project(db_session, "proj_revision_lww_remote", source_sha256=_sha("source"))
+    base_time = datetime(2026, 1, 1, tzinfo=UTC)
+    local_time = datetime(2026, 1, 2, tzinfo=UTC)
+    remote_time = datetime(2026, 1, 3, tzinfo=UTC)
+    _add_revision(
+        db_session,
+        project_id=project.id,
+        revision_id="rev_lww_remote_base",
+        content_sha256=_sha("base"),
+        base_revision_id=None,
+        created_at=base_time,
+        updated_at=base_time,
+    )
+    _add_revision(
+        db_session,
+        project_id=project.id,
+        revision_id="rev_lww_remote_local",
+        content_sha256=_revision_payload_sha("rev_lww_remote_local"),
+        base_revision_id="rev_lww_remote_base",
+        created_at=local_time,
+        updated_at=local_time,
+    )
+    db_session.commit()
+
+    plan = plan_sync_reconciliation(
+        db_session,
+        {
+            "remote_library": {
+                "projects": [{"project_id": project.id, "source_sha256": project.source_sha256}],
+                "entity_revisions": [
+                    _revision_manifest(
+                        project.id,
+                        revision_id="rev_lww_remote_newer",
+                        content_sha256=_revision_payload_sha("rev_lww_remote_newer"),
+                        base_revision_id="rev_lww_remote_base",
+                        created_at=remote_time,
+                        updated_at=remote_time,
+                    )
+                ],
+            }
+        },
+    )
+
+    item = _item(plan, ITEM_ENTITY_REVISION, "rev_lww_remote_newer")
+    assert item.status == "remote_available"
+    assert item.action_type == ACTION_IMPORT_ENTITY_REVISION
+    assert item.reason == "Remote entity revision is newer than the divergent local revision."
+    assert item.details["local_revision_id"] == "rev_lww_remote_local"
+    assert item.details["remote_revision_id"] == "rev_lww_remote_newer"
+    assert _action(plan, ACTION_IMPORT_ENTITY_REVISION, ITEM_ENTITY_REVISION, "rev_lww_remote_newer") is not None
+    assert _action(plan, ACTION_RECORD_CONFLICT, ITEM_ENTITY_REVISION, "rev_lww_remote_newer") is None
+
+
+def test_entity_revision_lww_keeps_newer_local_same_base_sibling(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    del tmp_path
+    _add_identity_and_peers(db_session)
+    project = _add_project(db_session, "proj_revision_lww_local", source_sha256=_sha("source"))
+    base_time = datetime(2026, 1, 1, tzinfo=UTC)
+    remote_time = datetime(2026, 1, 2, tzinfo=UTC)
+    local_time = datetime(2026, 1, 3, tzinfo=UTC)
+    _add_revision(
+        db_session,
+        project_id=project.id,
+        revision_id="rev_lww_local_base",
+        content_sha256=_sha("base"),
+        base_revision_id=None,
+        created_at=base_time,
+        updated_at=base_time,
+    )
+    _add_revision(
+        db_session,
+        project_id=project.id,
+        revision_id="rev_lww_local_current",
+        content_sha256=_revision_payload_sha("rev_lww_local_current"),
+        base_revision_id="rev_lww_local_base",
+        created_at=local_time,
+        updated_at=local_time,
+    )
+    db_session.commit()
+
+    plan = plan_sync_reconciliation(
+        db_session,
+        {
+            "remote_library": {
+                "projects": [{"project_id": project.id, "source_sha256": project.source_sha256}],
+                "entity_revisions": [
+                    _revision_manifest(
+                        project.id,
+                        revision_id="rev_lww_local_older_remote",
+                        content_sha256=_revision_payload_sha("rev_lww_local_older_remote"),
+                        base_revision_id="rev_lww_local_base",
+                        created_at=remote_time,
+                        updated_at=remote_time,
+                    )
+                ],
+            }
+        },
+    )
+
+    item = _item(plan, ITEM_ENTITY_REVISION, "rev_lww_local_older_remote")
+    assert item.status == "noop"
+    assert item.action_type == ACTION_NOOP
+    assert item.reason == "Local entity revision is newer than the divergent remote revision."
+    assert _action(plan, ACTION_IMPORT_ENTITY_REVISION, ITEM_ENTITY_REVISION, "rev_lww_local_older_remote") is None
+    assert _action(plan, ACTION_RECORD_CONFLICT, ITEM_ENTITY_REVISION, "rev_lww_local_older_remote") is None
 
 
 def test_existing_project_manifest_scoped_revision_does_not_create_standalone_conflict(
@@ -996,6 +1372,8 @@ def test_existing_project_keeps_intentional_no_lyrics_over_remote_embedded_lyric
         )
     )
     local_revision_id = f"rev_intentional_no_lyrics_{intentional_source}_{intentional_key}"
+    local_updated_at = datetime(2026, 1, 3, tzinfo=UTC)
+    remote_updated_at = datetime(2026, 1, 2, tzinfo=UTC)
     local_payload = {
         "revision_id": local_revision_id,
         "segments": [],
@@ -1009,6 +1387,8 @@ def test_existing_project_keeps_intentional_no_lyrics_over_remote_embedded_lyric
         base_revision_id=None,
         entity_type="lyrics",
         payload=local_payload,
+        created_at=local_updated_at,
+        updated_at=local_updated_at,
     )
     db_session.commit()
 
@@ -1026,6 +1406,8 @@ def test_existing_project_keeps_intentional_no_lyrics_over_remote_embedded_lyric
                 revision_id="rev_remote_current_lyrics_blocked_by_intentional_local",
                 entity_type="lyrics",
                 payload=remote_payload,
+                created_at=remote_updated_at,
+                updated_at=remote_updated_at,
             )
         ],
     )
@@ -1647,6 +2029,8 @@ def test_existing_project_skips_embedded_current_revision_when_local_revision_ex
         revision_id="rev_local_current_chords",
         content_sha256=_revision_payload_sha("rev_local_current_chords"),
         base_revision_id=None,
+        created_at=datetime(2026, 1, 3, tzinfo=UTC),
+        updated_at=datetime(2026, 1, 3, tzinfo=UTC),
     )
     db_session.commit()
 
@@ -1669,6 +2053,8 @@ def test_existing_project_skips_embedded_current_revision_when_local_revision_ex
                 entity_type="chords",
                 payload=base_payload,
                 state="superseded",
+                created_at=datetime(2026, 1, 1, tzinfo=UTC),
+                updated_at=datetime(2026, 1, 1, tzinfo=UTC),
             ),
             _current_revision_manifest(
                 project_id,
@@ -1676,6 +2062,8 @@ def test_existing_project_skips_embedded_current_revision_when_local_revision_ex
                 entity_type="chords",
                 payload=remote_payload,
                 base_revision_id="rev_remote_base_chords",
+                created_at=datetime(2026, 1, 2, tzinfo=UTC),
+                updated_at=datetime(2026, 1, 2, tzinfo=UTC),
             )
         ],
     )
@@ -1702,6 +2090,96 @@ def test_existing_project_skips_embedded_current_revision_when_local_revision_ex
             ITEM_ENTITY_REVISION,
             revision_id,
         ) is None
+
+
+def test_existing_project_imports_newer_embedded_current_revision_chain(
+    db_session: Session,
+    tmp_path: Path,
+) -> None:
+    _add_identity_and_peers(db_session)
+    source_hash, source_size = _write_file(tmp_path / "embedded-newer-revision-source.wav", b"source")
+    project_id = source_hash_to_project_id(source_hash)
+    _add_project(db_session, project_id, source_sha256=source_hash)
+    _add_artifact(
+        db_session,
+        artifact_id=f"art_source_{project_id}",
+        project_id=project_id,
+        path=tmp_path / "embedded-newer-revision-source.wav",
+        content_sha256=source_hash,
+        size_bytes=source_size,
+        artifact_type="source_audio",
+    )
+    _add_revision(
+        db_session,
+        project_id=project_id,
+        revision_id="rev_embedded_lww_local_chords",
+        content_sha256=_revision_payload_sha("rev_embedded_lww_local_chords"),
+        base_revision_id=None,
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    db_session.commit()
+
+    base_payload = {
+        "revision_id": "rev_embedded_lww_remote_base_chords",
+        "segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "C"}],
+    }
+    remote_payload = {
+        "revision_id": "rev_embedded_lww_remote_current_chords",
+        "segments": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "G"}],
+    }
+    manifest = _project_manifest(
+        project_id,
+        source_hash,
+        source_size_bytes=source_size,
+        extra_revisions=[
+            _current_revision_manifest(
+                project_id,
+                revision_id="rev_embedded_lww_remote_base_chords",
+                entity_type="chords",
+                payload=base_payload,
+                state="superseded",
+                created_at=datetime(2026, 1, 2, tzinfo=UTC),
+                updated_at=datetime(2026, 1, 2, tzinfo=UTC),
+            ),
+            _current_revision_manifest(
+                project_id,
+                revision_id="rev_embedded_lww_remote_current_chords",
+                entity_type="chords",
+                payload=remote_payload,
+                base_revision_id="rev_embedded_lww_remote_base_chords",
+                created_at=datetime(2026, 1, 3, tzinfo=UTC),
+                updated_at=datetime(2026, 1, 3, tzinfo=UTC),
+            ),
+        ],
+    )
+
+    plan = plan_sync_reconciliation(
+        db_session,
+        {
+            "remote_library": {},
+            "project_manifests": [manifest],
+            "peer_inventory": [{"device_id": "peer-a", "available_content_hashes": [source_hash]}],
+        },
+    )
+
+    current_item = _item(plan, ITEM_ENTITY_REVISION, "rev_embedded_lww_remote_current_chords")
+    assert current_item.status == "remote_available"
+    assert current_item.action_type == ACTION_IMPORT_ENTITY_REVISION
+    import_revision_action_ids = [
+        action.item_id
+        for action in plan.actions
+        if action.action_type == ACTION_IMPORT_ENTITY_REVISION
+    ]
+    assert import_revision_action_ids.index("rev_embedded_lww_remote_base_chords") < import_revision_action_ids.index(
+        "rev_embedded_lww_remote_current_chords"
+    )
+    assert _action(
+        plan,
+        ACTION_RECORD_CONFLICT,
+        ITEM_ENTITY_REVISION,
+        "rev_embedded_lww_remote_current_chords",
+    ) is None
 
 
 @pytest.mark.parametrize(
@@ -2591,6 +3069,8 @@ def _add_revision(
     source_artifact_id: str | None = None,
     entity_type: str = "chords",
     payload: dict[str, Any] | None = None,
+    created_at: datetime | None = None,
+    updated_at: datetime | None = None,
 ) -> SyncEntityRevision:
     now = datetime.now(UTC)
     payload_json = {"revision_id": revision_id} if payload is None else payload
@@ -2607,8 +3087,8 @@ def _add_revision(
         state="current",
         metadata_json={},
         payload_json=payload_json,
-        created_at=now,
-        updated_at=now,
+        created_at=created_at or now,
+        updated_at=updated_at or now,
     )
     session.add(revision)
     session.flush()
@@ -2636,6 +3116,12 @@ def _seed_generated_analysis_divergence(
     source_size = 64
     stem_hash = _sha("generated analysis source stem")
     stem_size = 32
+    source_path = tmp_path / "source.wav"
+    stem_path = tmp_path / "drums.wav"
+    analysis_path = tmp_path / "analysis.json"
+    source_path.write_bytes(b"s" * source_size)
+    stem_path.write_bytes(b"d" * stem_size)
+    analysis_path.write_bytes(b"a" * 128)
     local_created_at = local_generated_at or datetime(2026, 1, 1, tzinfo=UTC)
     remote_created_at = remote_generated_at or datetime(2026, 1, 2, tzinfo=UTC)
     local_metadata = {"source_artifact_id": source_artifact_id}
@@ -2649,7 +3135,7 @@ def _seed_generated_analysis_divergence(
         session,
         artifact_id=source_artifact_id,
         project_id=project_id,
-        path=tmp_path / "source.wav",
+        path=source_path,
         content_sha256=source_hash,
         size_bytes=source_size,
         artifact_type="source_audio",
@@ -2659,7 +3145,7 @@ def _seed_generated_analysis_divergence(
         session,
         artifact_id=stem_artifact_id,
         project_id=project_id,
-        path=tmp_path / "drums.wav",
+        path=stem_path,
         content_sha256=stem_hash,
         size_bytes=stem_size,
         artifact_type="drums_stem",
@@ -2673,7 +3159,7 @@ def _seed_generated_analysis_divergence(
         session,
         artifact_id=analysis_artifact_id,
         project_id=project_id,
-        path=tmp_path / "analysis.json",
+        path=analysis_path,
         content_sha256=local_analysis_hash,
         size_bytes=128,
         artifact_type="analysis_json",
@@ -2812,8 +3298,12 @@ def _revision_manifest(
     revision_id: str,
     content_sha256: str,
     base_revision_id: str | None,
+    created_at: datetime | None = None,
+    updated_at: datetime | None = None,
 ) -> dict[str, Any]:
     now = datetime.now(UTC)
+    created = created_at or now
+    updated = updated_at or created
     return {
         "revision_id": revision_id,
         "project_id": project_id,
@@ -2827,8 +3317,8 @@ def _revision_manifest(
         "state": "current",
         "metadata": {},
         "payload": {"revision_id": revision_id},
-        "created_at": now,
-        "updated_at": now,
+        "created_at": created,
+        "updated_at": updated,
     }
 
 
@@ -2843,8 +3333,12 @@ def _current_revision_manifest(
     content_sha256: str | None = None,
     source_artifact_id: str | None = None,
     state: str = "current",
+    created_at: datetime | None = None,
+    updated_at: datetime | None = None,
 ) -> dict[str, Any]:
     now = datetime.now(UTC)
+    created = created_at or now
+    updated = updated_at or created
     return {
         "revision_id": revision_id,
         "project_id": project_id,
@@ -2858,8 +3352,8 @@ def _current_revision_manifest(
         "state": state,
         "metadata": {},
         "payload": payload,
-        "created_at": now,
-        "updated_at": now,
+        "created_at": created,
+        "updated_at": updated,
     }
 
 

--- a/apps/backend/tests/test_sync_reconciliation_apply_api.py
+++ b/apps/backend/tests/test_sync_reconciliation_apply_api.py
@@ -735,32 +735,31 @@ def test_reconciliation_apply_does_not_recreate_deleted_project_placeholder(
     stale_manifest["project"]["created_at"] = stale_at.isoformat()
     stale_manifest["project"]["updated_at"] = stale_at.isoformat()
 
-    response = client.post(
-        "/api/v1/sync/reconciliation/apply",
-        json={
-            "remote_library": {
-                "projects": [remote_project],
-                "artifacts": [],
-                "entity_revisions": [],
-                "delete_tombstones": [
-                    {
-                        "tombstone_id": "tomb_apply_project",
-                        "sync_group_id": identity.sync_group_id,
-                        "project_id": project_id,
-                        "target_type": "project",
-                        "target_id": project_id,
-                        "author_device_id": "peer-apply-project-delete",
-                        "deleted_at": deleted_at.isoformat(),
-                        "prior_metadata": {},
-                        "created_at": deleted_at.isoformat(),
-                        "updated_at": deleted_at.isoformat(),
-                    }
-                ],
-            },
-            "project_manifests": [stale_manifest],
-            "peer_inventory": [],
+    request_payload = {
+        "remote_library": {
+            "projects": [remote_project],
+            "artifacts": [],
+            "entity_revisions": [],
+            "delete_tombstones": [
+                {
+                    "tombstone_id": "tomb_apply_project",
+                    "sync_group_id": identity.sync_group_id,
+                    "project_id": project_id,
+                    "target_type": "project",
+                    "target_id": project_id,
+                    "author_device_id": "peer-apply-project-delete",
+                    "deleted_at": deleted_at.isoformat(),
+                    "prior_metadata": {},
+                    "created_at": deleted_at.isoformat(),
+                    "updated_at": deleted_at.isoformat(),
+                }
+            ],
         },
-    )
+        "project_manifests": [stale_manifest],
+        "peer_inventory": [],
+    }
+
+    response = client.post("/api/v1/sync/reconciliation/apply", json=request_payload)
 
     assert response.status_code == 200
     payload = response.json()
@@ -784,6 +783,25 @@ def test_reconciliation_apply_does_not_recreate_deleted_project_placeholder(
         assert tombstone is not None
         assert tombstone.target_type == "project"
         assert tombstone.target_id == project_id
+
+    repeat_response = client.post("/api/v1/sync/reconciliation/apply", json=request_payload)
+
+    assert repeat_response.status_code == 200
+    repeat_payload = repeat_response.json()
+    assert repeat_payload["summary"]["failed_actions"] == 0
+    assert repeat_payload["summary"]["applied_actions"] == 0
+    assert not any(
+        item["item_type"] == "project"
+        and item["item_id"] == project_id
+        and item["status"] == "deleted"
+        for item in repeat_payload["plan"]["items"]
+    )
+    assert not any(
+        result["action"]["action_type"] == "apply_delete_tombstone"
+        and result["action"]["item_type"] == "project"
+        and result["status"] == "applied"
+        for result in repeat_payload["results"]
+    )
 
 
 def _ensure_identity_and_peer(peer_device_id: str) -> Any:

--- a/apps/backend/tests/test_sync_reconciliation_apply_batch_import.py
+++ b/apps/backend/tests/test_sync_reconciliation_apply_batch_import.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
@@ -315,6 +316,200 @@ def test_issue202_apply_clears_stale_remote_available_when_manifest_artifacts_ar
         assert project.sync_required_artifact_ids == []
         assert project.sync_provider_device_ids == []
         assert project.sync_conflict_count == 0
+
+
+def test_issue202_apply_restores_missing_existing_artifact_file_from_peer(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    peer_id = "peer-issue202-missing-file"
+    _ensure_identity_and_peers(peer_id)
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="issue202-missing-file",
+            source_frames=106,
+        )
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        _stage_manifest_artifact_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=fixture.artifact_bytes,
+            provider_device_id=peer_id,
+            artifact_id=fixture.source_artifact_id,
+        )
+        source_artifact = session.get(Artifact, fixture.source_artifact_id)
+        assert source_artifact is not None
+        source_path = Path(source_artifact.path)
+        source_path.unlink()
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": peer_id,
+                    "available_content_sha256": _manifest_content_hashes([manifest]),
+                }
+            ],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 0
+    assert any(
+        item["item_type"] == "artifact"
+        and item["item_id"] == fixture.source_artifact_id
+        and item["status"] == "missing_local_bytes"
+        for item in payload["plan"]["items"]
+    )
+    assert any(
+        result["action"]["action_type"] == "import_artifact_manifest"
+        and result["action"]["item_id"] == fixture.source_artifact_id
+        and result["status"] == "applied"
+        for result in payload["results"]
+    )
+
+    with SessionLocal() as session:
+        project = session.get(Project, fixture.project_id)
+        assert project is not None
+        assert project.sync_status == "local"
+        source_artifact = session.get(Artifact, fixture.source_artifact_id)
+        assert source_artifact is not None
+        restored_path = Path(source_artifact.path)
+        assert restored_path.exists()
+        assert file_sha256(restored_path) == fixture.artifact_hashes[fixture.source_artifact_id]
+        assert session.scalar(select(func.count()).select_from(SyncStagedArtifact)) == 0
+
+
+def test_issue202_apply_restores_missing_existing_artifact_file_from_staged_content_without_provider(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    peer_id = "peer-issue202-staged-repair"
+    _ensure_identity_and_peers(peer_id)
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="issue202-staged-repair",
+            source_frames=108,
+        )
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        _stage_manifest_artifact_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=fixture.artifact_bytes,
+            provider_device_id=peer_id,
+            artifact_id=fixture.source_artifact_id,
+        )
+        source_artifact = session.get(Artifact, fixture.source_artifact_id)
+        assert source_artifact is not None
+        source_path = Path(source_artifact.path)
+        source_path.unlink()
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [manifest],
+            "peer_inventory": [],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 0
+    assert any(
+        item["item_type"] == "artifact"
+        and item["item_id"] == fixture.source_artifact_id
+        and item["status"] == "missing_local_bytes"
+        and item["chosen_provider_device_id"] is None
+        for item in payload["plan"]["items"]
+    )
+    assert not any(
+        result["action"]["action_type"] == "fetch_artifact_content"
+        and result["action"]["item_id"] == fixture.source_artifact_id
+        for result in payload["results"]
+    )
+    assert any(
+        result["action"]["action_type"] == "import_artifact_manifest"
+        and result["action"]["item_id"] == fixture.source_artifact_id
+        and result["status"] == "applied"
+        and result["action"]["details"]["source"] == "sync_staged_artifacts"
+        for result in payload["results"]
+    )
+
+    with SessionLocal() as session:
+        source_artifact = session.get(Artifact, fixture.source_artifact_id)
+        assert source_artifact is not None
+        restored_path = Path(source_artifact.path)
+        assert restored_path.exists()
+        assert file_sha256(restored_path) == fixture.artifact_hashes[fixture.source_artifact_id]
+        assert session.scalar(select(func.count()).select_from(SyncStagedArtifact)) == 0
+
+
+def test_issue202_cleanup_keeps_staged_bytes_when_existing_artifact_file_is_missing(
+    tmp_path: Path,
+) -> None:
+    peer_id = "peer-issue202-cleanup-missing"
+    _ensure_identity_and_peers(peer_id)
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="issue202-cleanup-missing",
+            source_frames=110,
+        )
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        _stage_manifest_artifact_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=fixture.artifact_bytes,
+            provider_device_id=peer_id,
+            artifact_id=fixture.source_artifact_id,
+        )
+        source_artifact = session.get(Artifact, fixture.source_artifact_id)
+        assert source_artifact is not None
+        source_path = Path(source_artifact.path)
+        source_path.unlink()
+        source_hash = fixture.artifact_hashes[fixture.source_artifact_id]
+        staged_artifact = session.get(SyncStagedArtifact, source_hash)
+        assert staged_artifact is not None
+        staged_path = get_settings().data_root / "sync" / "staging" / staged_artifact.relative_path
+        assert staged_path.exists()
+
+        context = sync_reconciliation_apply_service._ApplyContext(
+            project_manifests_by_id={fixture.project_id: manifest},
+            tombstones_by_id={},
+            tombstones_by_target={},
+            scoped_project_ids=frozenset({fixture.project_id}),
+            staging_root=None,
+            use_content_addressed_staging=True,
+            include_timing_evidence=False,
+        )
+        details = sync_reconciliation_apply_service._cleanup_imported_content_addressed_staging(
+            session,
+            context,
+        )
+
+        assert details["pending_content_sha256_count"] == 1
+        assert session.get(SyncStagedArtifact, source_hash) is not None
+        assert staged_path.exists()
 
 
 def test_issue163_project_scoped_apply_ignores_unselected_remote_projects_and_reports_timing(
@@ -1577,6 +1772,151 @@ def test_issue163_existing_project_embedded_revision_drift_is_not_reported_as_co
     )
 
 
+def test_issue202_lww_apply_imports_newer_divergent_current_revision(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    peer_id = "peer-issue202-lww"
+    _ensure_identity_and_peers(peer_id)
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path, slug="issue202-lww", source_frames=80)
+        base_time = datetime(2026, 1, 1, tzinfo=UTC)
+        local_time = datetime(2026, 1, 2, tzinfo=UTC)
+        remote_time = datetime(2026, 1, 3, tzinfo=UTC)
+        base_revision_id = "rev_issue202_lww_base_chords"
+        local_revision_id = "rev_issue202_lww_local_chords"
+        remote_revision_id = "rev_issue202_lww_remote_chords"
+        base_payload = {
+            "project_id": fixture.project_id,
+            "timeline": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "C"}],
+        }
+        local_payload = {
+            "project_id": fixture.project_id,
+            "timeline": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "F"}],
+            "has_user_edits": True,
+        }
+        remote_payload = {
+            "project_id": fixture.project_id,
+            "timeline": [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "G"}],
+            "has_user_edits": True,
+        }
+        session.add_all(
+            [
+                SyncEntityRevision(
+                    id=base_revision_id,
+                    project_id=fixture.project_id,
+                    entity_type="chords",
+                    entity_id=fixture.project_id,
+                    revision_type="manual",
+                    base_revision_id=None,
+                    author_device_id=peer_id,
+                    source_artifact_id=fixture.source_artifact_id,
+                    content_sha256=revision_payload_sha256(base_payload),
+                    state=SUPERSEDED_REVISION_STATE,
+                    metadata_json={},
+                    payload_json=base_payload,
+                    created_at=base_time,
+                    updated_at=base_time,
+                ),
+                SyncEntityRevision(
+                    id=local_revision_id,
+                    project_id=fixture.project_id,
+                    entity_type="chords",
+                    entity_id=fixture.project_id,
+                    revision_type="manual",
+                    base_revision_id=base_revision_id,
+                    author_device_id="local-device",
+                    source_artifact_id=fixture.source_artifact_id,
+                    content_sha256=revision_payload_sha256(local_payload),
+                    state=CURRENT_REVISION_STATE,
+                    metadata_json={},
+                    payload_json=local_payload,
+                    created_at=local_time,
+                    updated_at=local_time,
+                ),
+                ChordTimeline(
+                    project_id=fixture.project_id,
+                    source_artifact_id=fixture.source_artifact_id,
+                    segments_json=local_payload["timeline"],
+                    timeline_json=local_payload["timeline"],
+                    has_user_edits=True,
+                    updated_at=local_time,
+                ),
+            ]
+        )
+        session.commit()
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        manifest["entity_revisions"] = [
+            {
+                "revision_id": base_revision_id,
+                "project_id": fixture.project_id,
+                "entity_type": "chords",
+                "entity_id": fixture.project_id,
+                "revision_type": "manual",
+                "base_revision_id": None,
+                "author_device_id": peer_id,
+                "source_artifact_id": fixture.source_artifact_id,
+                "content_sha256": revision_payload_sha256(base_payload),
+                "state": SUPERSEDED_REVISION_STATE,
+                "metadata": {},
+                "payload": base_payload,
+                "created_at": base_time.isoformat(),
+                "updated_at": base_time.isoformat(),
+            },
+            {
+                "revision_id": remote_revision_id,
+                "project_id": fixture.project_id,
+                "entity_type": "chords",
+                "entity_id": fixture.project_id,
+                "revision_type": "manual",
+                "base_revision_id": base_revision_id,
+                "author_device_id": peer_id,
+                "source_artifact_id": fixture.source_artifact_id,
+                "content_sha256": revision_payload_sha256(remote_payload),
+                "state": CURRENT_REVISION_STATE,
+                "metadata": {},
+                "payload": remote_payload,
+                "created_at": remote_time.isoformat(),
+                "updated_at": remote_time.isoformat(),
+            },
+        ]
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": peer_id,
+                    "available_content_sha256": _manifest_content_hashes([manifest]),
+                }
+            ],
+            "project_ids": [fixture.project_id],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 0
+    revision_item = _plan_item(payload["plan"]["items"], "entity_revision", remote_revision_id)
+    assert revision_item["status"] == "remote_available"
+    assert revision_item["reason"] == "Remote entity revision is newer than the divergent local revision."
+
+    with SessionLocal() as session:
+        local_revision = session.get(SyncEntityRevision, local_revision_id)
+        remote_revision = session.get(SyncEntityRevision, remote_revision_id)
+        chords = session.get(ChordTimeline, fixture.project_id)
+        assert local_revision is not None
+        assert local_revision.state == SUPERSEDED_REVISION_STATE
+        assert remote_revision is not None
+        assert remote_revision.state == CURRENT_REVISION_STATE
+        assert chords is not None
+        assert chords.segments_json == remote_payload["timeline"]
+        assert chords.has_user_edits is True
+
+
 def test_issue163_newer_manifest_reimports_project_after_local_project_tombstone(
     client: TestClient,
     tmp_path: Path,
@@ -1633,6 +1973,101 @@ def test_issue163_newer_manifest_reimports_project_after_local_project_tombstone
         assert project.sync_status == "local"
         assert session.get(Artifact, fixture.source_artifact_id) is not None
         assert session.get(Artifact, fixture.stem_artifact_id) is not None
+        assert (
+            session.scalar(
+                select(func.count())
+                .select_from(SyncDeleteTombstone)
+                .where(SyncDeleteTombstone.project_id == fixture.project_id)
+            )
+            == 0
+        )
+        exported_manifest = export_project_manifest(session, project_id=fixture.project_id)
+        assert exported_manifest.delete_tombstones == []
+
+
+def test_reimport_retire_older_child_tombstones_without_project_tombstone(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    _ensure_identity_and_peers("peer-reimport-child-tombstones")
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="reimport-child-tombstones",
+            source_frames=79,
+        )
+        session.add(
+            SyncEntityRevision(
+                id="rev_reimport_child_tombstone_chords",
+                project_id=fixture.project_id,
+                entity_type="chords",
+                entity_id=fixture.project_id,
+                revision_type="generated",
+                base_revision_id=None,
+                author_device_id="peer-reimport-child-tombstones",
+                source_artifact_id=fixture.source_artifact_id,
+                content_sha256=revision_payload_sha256({"timeline": [{"label": "C"}]}),
+                state=CURRENT_REVISION_STATE,
+                metadata_json={},
+                payload_json={"timeline": [{"label": "C"}]},
+                created_at=datetime(2026, 1, 1, tzinfo=UTC),
+                updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+        )
+        session.commit()
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        delete_project(session, fixture.project_id)
+        project_tombstone = session.scalar(
+            select(SyncDeleteTombstone).where(
+                SyncDeleteTombstone.project_id == fixture.project_id,
+                SyncDeleteTombstone.target_type == "project",
+            )
+        )
+        assert project_tombstone is not None
+        deleted_at = project_tombstone.deleted_at.replace(microsecond=0)
+        session.delete(project_tombstone)
+        resurrected_at = deleted_at + timedelta(seconds=1)
+        manifest["project"]["created_at"] = resurrected_at.isoformat()
+        manifest["project"]["updated_at"] = resurrected_at.isoformat()
+        _stage_manifest_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes=fixture.artifact_bytes,
+            provider_device_id="peer-reimport-child-tombstones",
+        )
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": "peer-reimport-child-tombstones",
+                    "available_content_sha256": _manifest_content_hashes([manifest]),
+                }
+            ],
+            "project_ids": [fixture.project_id],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 0
+    assert payload["plan"]["summary"]["status_counts"]["deleted"] == 0
+    assert all(
+        item["status"] != "deleted"
+        for item in payload["plan"]["items"]
+    )
+
+    with SessionLocal() as session:
+        project = session.get(Project, fixture.project_id)
+        assert project is not None
+        assert project.sync_status == "local"
         assert (
             session.scalar(
                 select(func.count())
@@ -2674,6 +3109,235 @@ def test_issue120_remote_tombstone_from_trusted_peer_wins_over_stale_manifest(
         persisted_tombstone = session.get(SyncDeleteTombstone, tombstone["tombstone_id"])
         assert persisted_tombstone is not None
         assert persisted_tombstone.author_device_id == "peer-issue120-tombstone"
+
+
+@pytest.mark.parametrize(
+    ("slug", "source_artifact_type"),
+    [
+        ("regenerated-source-stem", "source_audio"),
+        ("regenerated-practice-mix-stem", "preview_mix"),
+    ],
+)
+def test_regenerated_stem_newer_than_local_tombstone_applies_without_conflict(
+    client: TestClient,
+    tmp_path: Path,
+    slug: str,
+    source_artifact_type: str,
+) -> None:
+    identity = _ensure_identity_and_peers("peer-regenerated-stem")
+    remote_regenerated_at = datetime(2026, 1, 3, tzinfo=UTC)
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug=slug,
+            source_frames=132,
+        )
+        stem_artifact = session.get(Artifact, fixture.stem_artifact_id)
+        assert stem_artifact is not None
+        stem_source_artifact_id = fixture.source_artifact_id
+        if source_artifact_type == "preview_mix":
+            stem_source_artifact_id = f"art_{slug.replace('-', '_')}_preview_mix"
+            preview_hash, preview_size = _write_bytes(
+                fixture.root / "previews" / "practice-mix.wav",
+                b"practice mix bytes",
+            )
+            session.add(
+                Artifact(
+                    id=stem_source_artifact_id,
+                    project_id=fixture.project_id,
+                    type="preview_mix",
+                    format="wav",
+                    path=str(fixture.root / "previews" / "practice-mix.wav"),
+                    content_sha256=preview_hash,
+                    size_bytes=preview_size,
+                    generated_by="preview",
+                    can_delete=True,
+                    can_regenerate=True,
+                    metadata_json={"source_artifact_id": fixture.source_artifact_id},
+                    created_at=datetime(2026, 1, 2, tzinfo=UTC),
+                )
+            )
+        stem_metadata = {
+            "mode": "two_stems",
+            "stem_model": "htdemucs_ft",
+            "stem_model_label": "HTDemucs fine-tuned",
+            "stem_source": "vocals",
+            "source_artifact_id": stem_source_artifact_id,
+            "source_artifact_type": source_artifact_type,
+        }
+        stem_artifact.type = "vocal_stem"
+        stem_artifact.cache_key = f"stem:{stem_source_artifact_id}:vocals"
+        stem_artifact.metadata_json = stem_metadata
+        live_sibling_artifact_id: str | None = None
+        sibling_metadata: dict[str, Any] | None = None
+        if source_artifact_type == "source_audio":
+            live_sibling_artifact_id = f"art_{slug.replace('-', '_')}_instrumental_stem"
+            sibling_metadata = {
+                **stem_metadata,
+                "stem_source": "instrumental",
+                "source_artifact_type": "source_audio",
+            }
+            sibling_hash, sibling_size = _write_bytes(
+                fixture.root / "stems" / f"{slug}-instrumental.wav",
+                b"local instrumental before rebuild",
+            )
+            session.add(
+                Artifact(
+                    id=live_sibling_artifact_id,
+                    project_id=fixture.project_id,
+                    type="instrumental_stem",
+                    format="wav",
+                    path=str(fixture.root / "stems" / f"{slug}-instrumental.wav"),
+                    content_sha256=sibling_hash,
+                    size_bytes=sibling_size,
+                    generated_by="stems",
+                    can_delete=True,
+                    can_regenerate=True,
+                    cache_key=f"stem:{stem_source_artifact_id}:instrumental",
+                    metadata_json=sibling_metadata,
+                    created_at=datetime(2026, 1, 2, tzinfo=UTC),
+                )
+            )
+        session.flush()
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        session.delete(stem_artifact)
+        Path(stem_artifact.path).unlink()
+        deleted_at = datetime(2026, 1, 1, 12, tzinfo=UTC)
+        session.add(
+            SyncDeleteTombstone(
+                id="tomb_local_deleted_regenerated_stem",
+                sync_group_id=identity["sync_group_id"],
+                project_id=fixture.project_id,
+                target_type="artifact",
+                target_id=fixture.stem_artifact_id,
+                author_device_id=identity["device_id"],
+                deleted_at=deleted_at,
+                prior_metadata_json={
+                    "artifact_id": fixture.stem_artifact_id,
+                    "type": "vocal_stem",
+                    "metadata": stem_metadata,
+                },
+                created_at=deleted_at,
+                updated_at=deleted_at,
+            )
+        )
+        remote_bytes = f"remotely regenerated {slug} bytes".encode()
+        remote_hash, remote_size = _write_bytes(
+            tmp_path / slug / "remote-vocals.wav",
+            remote_bytes,
+        )
+        remote_stem = _artifact_by_id(manifest, fixture.stem_artifact_id)
+        remote_stem.update(
+            {
+                "content_sha256": remote_hash,
+                "size_bytes": remote_size,
+                "created_at": remote_regenerated_at.isoformat(),
+                "metadata": stem_metadata,
+                "can_regenerate": True,
+            }
+        )
+        available_hashes = [remote_hash]
+        _stage_manifest_artifact_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes={fixture.stem_artifact_id: remote_bytes},
+            provider_device_id="peer-regenerated-stem",
+            artifact_id=fixture.stem_artifact_id,
+        )
+        remote_sibling_hash: str | None = None
+        remote_sibling_size: int | None = None
+        if live_sibling_artifact_id is not None and sibling_metadata is not None:
+            remote_sibling_bytes = b"remotely regenerated sibling instrumental bytes"
+            remote_sibling_hash, remote_sibling_size = _write_bytes(
+                tmp_path / slug / "remote-instrumental.wav",
+                remote_sibling_bytes,
+            )
+            remote_sibling = _artifact_by_id(manifest, live_sibling_artifact_id)
+            remote_sibling.update(
+                {
+                    "content_sha256": remote_sibling_hash,
+                    "size_bytes": remote_sibling_size,
+                    "created_at": remote_regenerated_at.isoformat(),
+                    "metadata": sibling_metadata,
+                    "can_regenerate": True,
+                }
+            )
+            _stage_manifest_artifact_content(
+                session,
+                manifest,
+                tmp_path=tmp_path,
+                artifact_bytes={live_sibling_artifact_id: remote_sibling_bytes},
+                provider_device_id="peer-regenerated-stem",
+                artifact_id=live_sibling_artifact_id,
+            )
+            available_hashes.append(remote_sibling_hash)
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": {
+                "projects": [manifest["project"]],
+                "artifacts": manifest["artifacts"],
+                "entity_revisions": [],
+                "delete_tombstones": [],
+            },
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": "peer-regenerated-stem",
+                    "available_content_sha256": available_hashes,
+                }
+            ],
+            "project_ids": [fixture.project_id],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 0
+    assert payload["plan"]["summary"]["total_conflicts"] == 0
+    plan_item = _plan_item(payload["plan"]["items"], "artifact", fixture.stem_artifact_id)
+    assert plan_item["status"] == "remote_available"
+    if live_sibling_artifact_id is not None:
+        sibling_item = _plan_item(payload["plan"]["items"], "artifact", live_sibling_artifact_id)
+        assert sibling_item["status"] == "remote_available"
+        assert sibling_item["details"]["resolution"] == "fetch_remote"
+    assert all(
+        result["action"]["action_type"] != "record_conflict"
+        for result in payload["results"]
+    )
+    assert all(
+        result["action"]["action_type"] != "apply_delete_tombstone"
+        for result in payload["results"]
+    )
+    assert any(
+        result["action"]["action_type"] == "import_artifact_manifest"
+        and result["action"]["item_id"] == fixture.stem_artifact_id
+        and result["status"] == "applied"
+        for result in payload["results"]
+    )
+
+    with SessionLocal() as session:
+        artifact = session.get(Artifact, fixture.stem_artifact_id)
+        assert artifact is not None
+        assert artifact.type == "vocal_stem"
+        assert artifact.content_sha256 == remote_hash
+        assert artifact.size_bytes == remote_size
+        assert artifact.metadata_json["source_artifact_type"] == source_artifact_type
+        assert artifact.created_at.replace(tzinfo=UTC) == remote_regenerated_at
+        assert file_sha256(Path(artifact.path)) == remote_hash
+        if live_sibling_artifact_id is not None:
+            sibling = session.get(Artifact, live_sibling_artifact_id)
+            assert sibling is not None
+            assert sibling.content_sha256 == remote_sibling_hash
+            assert sibling.size_bytes == remote_sibling_size
+            assert sibling.created_at.replace(tzinfo=UTC) == remote_regenerated_at
+        assert session.get(SyncDeleteTombstone, "tomb_local_deleted_regenerated_stem") is None
 
 
 def _ensure_identity_and_peers(*peer_device_ids: str) -> dict[str, str]:


### PR DESCRIPTION
## Summary

- Replace manual sync conflict handling with deterministic last-writer-wins for entity
  revisions and regenerable artifacts.
- Repair missing or wrong-sized DB-known artifact files without rehashing the local
  library during sync planning.
- Make delete tombstones idempotent and retire stale child tombstones after project
  re-imports so repeated syncs stay clean.
- Closes #202.

## Testing

- `cd apps/backend && uv run --python 3.11 pytest`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- Manual sync checks: fresh import/sync, newest edit wins, project delete/re-import,
  missing and wrong-sized artifact repair, stem delete/rebuild.
