### PR TITLE
fix: Polish accordion chord dictionary

### DIFF
--- a/apps/desktop/src/App.tools-chord-dictionary.test.tsx
+++ b/apps/desktop/src/App.tools-chord-dictionary.test.tsx
@@ -116,6 +116,31 @@ function getAccordionKeyByMidi(keyboard: HTMLElement, midi: number, color: "blac
   return key;
 }
 
+function getAccordionKeyboardMidiByColor(keyboard: HTMLElement, color: "black" | "white") {
+  return [...keyboard.querySelectorAll<HTMLElement>(`[data-key-color="${color}"]`)].map(
+    (key) => key.dataset.midi,
+  );
+}
+
+function getAccordionActiveKeyboardMidi(keyboard: HTMLElement) {
+  return [...keyboard.querySelectorAll<HTMLElement>(".accordion-keyboard__key--active-tone")]
+    .map((key) => key.dataset.midi)
+    .sort();
+}
+
+function expectAccordionInstrumentSelected() {
+  const instrumentSelector = getDictionaryInstrumentSelector();
+  const guitarButton = within(instrumentSelector).getByRole("button", { name: "Guitar" });
+  const accordionButton = within(instrumentSelector).getByRole("button", { name: "Accordion" });
+
+  expect(guitarButton).toHaveAttribute("aria-pressed", "false");
+  expect(guitarButton).toHaveAttribute("data-selected", "false");
+  expect(guitarButton).not.toHaveClass("chord-instrument-button--active");
+  expect(accordionButton).toHaveAttribute("aria-pressed", "true");
+  expect(accordionButton).toHaveAttribute("data-selected", "true");
+  expect(accordionButton).toHaveClass("chord-instrument-button--active");
+}
+
 async function selectAccordionDictionary() {
   const user = userEvent.setup();
   await renderChordDictionary();
@@ -137,16 +162,7 @@ async function selectAccordionDictionary() {
       "true",
     ),
   );
-  expect(within(getDictionaryInstrumentSelector()).getByRole("button", { name: "Guitar" })).toHaveAttribute(
-    "aria-pressed",
-    "false",
-  );
-  expect(within(getDictionaryInstrumentSelector()).getByRole("button", { name: "Accordion" })).toHaveClass(
-    "chord-instrument-button--active",
-  );
-  expect(within(getDictionaryInstrumentSelector()).getByRole("button", { name: "Guitar" })).not.toHaveClass(
-    "chord-instrument-button--active",
-  );
+  expectAccordionInstrumentSelected();
   return user;
 }
 
@@ -691,6 +707,7 @@ describe("Desktop app tools chord dictionary", () => {
     expect(stradellaBoard).toBeInTheDocument();
     expect(keyboard).toBeInTheDocument();
     expect(keyboard).toHaveAttribute("data-orientation", "vertical");
+    expect(keyboard).toHaveAttribute("data-layout", "piano-vertical");
     expect(keyboard).toHaveAttribute("data-black-offset", "true");
     const whiteKeyCount = Number(keyboard.style.getPropertyValue("--accordion-white-key-count"));
     expect(whiteKeyCount).toBeLessThanOrEqual(9);
@@ -706,9 +723,8 @@ describe("Desktop app tools chord dictionary", () => {
     );
     expect(blackKey).toBeInTheDocument();
     expect((blackKey as HTMLElement).style.getPropertyValue("--accordion-white-index")).not.toBe("");
-    const whiteKeys = [...whiteKeyLayer.querySelectorAll<HTMLElement>('[data-key-color="white"]')];
     const blackKeys = [...blackKeyLayer.querySelectorAll<HTMLElement>('[data-key-color="black"]')];
-    expect(whiteKeys.map((key) => key.dataset.midi)).toEqual([
+    expect(getAccordionKeyboardMidiByColor(keyboard, "white")).toEqual([
       "60",
       "62",
       "64",
@@ -718,7 +734,7 @@ describe("Desktop app tools chord dictionary", () => {
       "71",
       "72",
     ]);
-    expect(blackKeys.map((key) => key.dataset.midi)).toEqual(["61", "63", "66", "68", "70"]);
+    expect(getAccordionKeyboardMidiByColor(keyboard, "black")).toEqual(["61", "63", "66", "68", "70"]);
     const cKey = getAccordionKeyByMidi(keyboard, 60, "white");
     const cSharpKey = getAccordionKeyByMidi(keyboard, 61, "black");
     const dKey = getAccordionKeyByMidi(keyboard, 62, "white");
@@ -747,31 +763,37 @@ describe("Desktop app tools chord dictionary", () => {
     const gWhiteIndex = readNumericStyleVar(gKey, "--accordion-white-index");
     const aWhiteIndex = readNumericStyleVar(aKey, "--accordion-white-index");
     const bWhiteIndex = readNumericStyleVar(bKey, "--accordion-white-index");
-    expect(cSharpBoundaryIndex).toBe(cWhiteIndex);
-    expect(dWhiteIndex).toBe(cWhiteIndex + 1);
-    expect(readNumericStyleVar(dSharpKey, "--accordion-white-index")).toBe(dWhiteIndex);
-    expect(readNumericStyleVar(eKey, "--accordion-white-index")).toBe(dWhiteIndex + 1);
-    expect(readNumericStyleVar(fSharpKey, "--accordion-white-index")).toBe(fWhiteIndex);
-    expect(readNumericStyleVar(gSharpKey, "--accordion-white-index")).toBe(gWhiteIndex);
-    expect(readNumericStyleVar(aSharpKey, "--accordion-white-index")).toBe(aWhiteIndex);
-    expect(readNumericStyleVar(highCKey, "--accordion-white-index")).toBe(bWhiteIndex + 1);
+    expect([
+      cWhiteIndex,
+      dWhiteIndex,
+      eWhiteIndex,
+      fWhiteIndex,
+      gWhiteIndex,
+      aWhiteIndex,
+      bWhiteIndex,
+      readNumericStyleVar(highCKey, "--accordion-white-index"),
+    ]).toEqual([7, 6, 5, 4, 3, 2, 1, 0]);
+    expect(cSharpBoundaryIndex).toBe(dWhiteIndex);
+    expect(readNumericStyleVar(dSharpKey, "--accordion-white-index")).toBe(eWhiteIndex);
+    expect(readNumericStyleVar(fSharpKey, "--accordion-white-index")).toBe(gWhiteIndex);
+    expect(readNumericStyleVar(gSharpKey, "--accordion-white-index")).toBe(aWhiteIndex);
+    expect(readNumericStyleVar(aSharpKey, "--accordion-white-index")).toBe(bWhiteIndex);
     const blackBoundaryIndices = blackKeys.map((key) =>
       readNumericStyleVar(key, "--accordion-white-index"),
     );
     expect(blackBoundaryIndices).toEqual([
-      cWhiteIndex,
       dWhiteIndex,
-      fWhiteIndex,
+      eWhiteIndex,
       gWhiteIndex,
       aWhiteIndex,
+      bWhiteIndex,
     ]);
-    expect(blackBoundaryIndices).not.toContain(eWhiteIndex);
-    expect(blackBoundaryIndices).not.toContain(bWhiteIndex);
-    expect(whiteKeys[cWhiteIndex]).toBe(cKey);
-    expect(whiteKeys[dWhiteIndex]).toBe(dKey);
+    expect(blackBoundaryIndices).not.toContain(cWhiteIndex);
+    expect(blackBoundaryIndices).not.toContain(fWhiteIndex);
     expect(
       keyboard.querySelector('[data-key-color="white"][data-key-position="white-surface-row"]'),
     ).toBeInTheDocument();
+    expect(blackKeys.every((key) => key.dataset.keyPosition === "black-overlay")).toBe(true);
 
     expect(within(leftHand).getByText(/^C$/)).toBeInTheDocument();
     expect(within(leftHand).getByText(/^CM$/)).toBeInTheDocument();
@@ -818,6 +840,435 @@ describe("Desktop app tools chord dictionary", () => {
     expect(eRightKey).toHaveTextContent("3");
     expect(gRightKey).toHaveTextContent("G4");
     expect(gRightKey).toHaveTextContent("5");
+  });
+
+  it.each([
+    {
+      active: ["62", "66", "69"],
+      black: ["61", "63", "66", "68", "70", "73", "75"],
+      heading: "D accordion positions",
+      search: "D",
+      white: ["60", "62", "64", "65", "67", "69", "71", "72", "74", "76"],
+    },
+    {
+      active: ["63", "67", "70"],
+      black: ["61", "63", "66", "68", "70", "73", "75"],
+      heading: "Eb accordion positions",
+      search: "Eb",
+      white: ["60", "62", "64", "65", "67", "69", "71", "72", "74", "76"],
+    },
+    {
+      active: ["67", "71", "74"],
+      black: ["66", "68", "70", "73", "75", "78"],
+      heading: "G accordion positions",
+      search: "G",
+      white: ["65", "67", "69", "71", "72", "74", "76", "77", "79"],
+    },
+    {
+      active: ["69", "73", "76"],
+      black: ["66", "68", "70", "73", "75", "78", "80", "82"],
+      heading: "A accordion positions",
+      search: "A",
+      white: ["65", "67", "69", "71", "72", "74", "76", "77", "79", "81", "83"],
+    },
+    {
+      active: ["68", "72", "75"],
+      black: ["66", "68", "70", "73", "75", "78", "80"],
+      heading: "Ab accordion positions",
+      search: "Ab",
+      white: ["65", "67", "69", "71", "72", "74", "76", "77", "79", "81"],
+    },
+    {
+      active: ["70", "74", "77"],
+      black: ["66", "68", "70", "73", "75", "78", "80", "82"],
+      heading: "Bb accordion positions",
+      search: "Bb",
+      white: ["65", "67", "69", "71", "72", "74", "76", "77", "79", "81", "83"],
+    },
+    {
+      active: ["71", "75", "78"],
+      black: ["66", "68", "70", "73", "75", "78", "80", "82"],
+      heading: "B accordion positions",
+      search: "B",
+      white: ["65", "67", "69", "71", "72", "74", "76", "77", "79", "81", "83"],
+    },
+  ])("keeps $search accordion keyboard context on piano landmarks", async ({
+    active,
+    black,
+    heading,
+    search,
+    white,
+  }) => {
+    await selectAccordionDictionary();
+
+    changeChordSearch(search);
+
+    await screen.findByRole("heading", { name: heading });
+    const rightHand = screen.getByRole("group", { name: /Right hand/i });
+    const keyboard = getAccordionSurface(
+      rightHand,
+      '[data-surface="keyboard"], .accordion-keyboard, .piano-keyboard',
+    );
+
+    expect(keyboard).toHaveAttribute("data-orientation", "vertical");
+    expect(getAccordionKeyboardMidiByColor(keyboard, "white")).toEqual(white);
+    expect(getAccordionKeyboardMidiByColor(keyboard, "black")).toEqual(black);
+    expect(getAccordionActiveKeyboardMidi(keyboard)).toEqual(active);
+  });
+
+  it("keeps G accordion keyboard anchored with one octave of context", async () => {
+    await selectAccordionDictionary();
+
+    changeChordSearch("G");
+
+    await screen.findByRole("heading", { name: "G accordion positions" });
+    const rightHand = screen.getByRole("group", { name: /Right hand/i });
+    const keyboard = getAccordionSurface(
+      rightHand,
+      '[data-surface="keyboard"], .accordion-keyboard, .piano-keyboard',
+    );
+    const blackKeyLayer = getAccordionSurface(keyboard, ".accordion-keyboard__black-keys");
+    const activeKeyboardMidi = [...keyboard.querySelectorAll(".accordion-keyboard__key--active-tone")]
+      .map((key) => (key as HTMLElement).dataset.midi)
+      .sort();
+
+    expect(keyboard).toHaveAttribute("data-orientation", "vertical");
+    expect(getAccordionKeyboardMidiByColor(keyboard, "white")).toEqual([
+      "65",
+      "67",
+      "69",
+      "71",
+      "72",
+      "74",
+      "76",
+      "77",
+      "79",
+    ]);
+    expect(getAccordionKeyboardMidiByColor(keyboard, "black")).toEqual(["66", "68", "70", "73", "75", "78"]);
+    expect(activeKeyboardMidi).toEqual(["67", "71", "74"]);
+    expect([...blackKeyLayer.querySelectorAll(".accordion-keyboard__key--active-tone")]).toHaveLength(0);
+    expect(getAccordionKeyByMidi(keyboard, 65, "white")).toHaveAttribute("aria-hidden", "true");
+    expect(getAccordionKeyByMidi(keyboard, 66, "black")).toHaveAttribute("aria-hidden", "true");
+    expect(getAccordionKeyByMidi(keyboard, 68, "black")).toHaveAttribute("aria-hidden", "true");
+    expect(getAccordionKeyByMidi(keyboard, 73, "black")).toHaveAttribute("aria-hidden", "true");
+    expect(within(rightHand).getByRole("button", {
+      name: /G4 degree 1 accordion keyboard key/i,
+    })).toHaveTextContent("G4");
+  });
+
+  it("keeps G7 accordion keyboard context with F and F# before the root", async () => {
+    await selectAccordionDictionary();
+
+    changeChordSearch("G7");
+
+    await screen.findByRole("heading", { name: "G7 accordion positions" });
+    const rightHand = screen.getByRole("group", { name: /Right hand/i });
+    const keyboard = getAccordionSurface(
+      rightHand,
+      '[data-surface="keyboard"], .accordion-keyboard, .piano-keyboard',
+    );
+    const activeKeyboardMidi = [...keyboard.querySelectorAll(".accordion-keyboard__key--active-tone")]
+      .map((key) => (key as HTMLElement).dataset.midi)
+      .sort();
+    const lowerFKey = getAccordionKeyByMidi(keyboard, 65, "white");
+    const lowerFSharpKey = getAccordionKeyByMidi(keyboard, 66, "black");
+    const rootGKey = getAccordionKeyByMidi(keyboard, 67, "white");
+
+    expect(getAccordionKeyboardMidiByColor(keyboard, "white")).toEqual([
+      "65",
+      "67",
+      "69",
+      "71",
+      "72",
+      "74",
+      "76",
+      "77",
+      "79",
+    ]);
+    expect(getAccordionKeyboardMidiByColor(keyboard, "black")).toEqual(["66", "68", "70", "73", "75", "78"]);
+    expect(activeKeyboardMidi).toEqual(["67", "71", "74", "77"]);
+    expect(lowerFKey).toHaveAttribute("aria-hidden", "true");
+    expect(lowerFSharpKey).toHaveAttribute("aria-hidden", "true");
+    expect(readNumericStyleVar(lowerFKey, "--accordion-white-index")).toBeGreaterThan(
+      readNumericStyleVar(rootGKey, "--accordion-white-index"),
+    );
+    expect(readNumericStyleVar(lowerFSharpKey, "--accordion-white-index")).toBe(
+      readNumericStyleVar(rootGKey, "--accordion-white-index"),
+    );
+  });
+
+  it("keeps G#/Ab accordion keyboard context anchored to the lower three-black-key group", async () => {
+    await selectAccordionDictionary();
+
+    changeChordSearch("Ab");
+
+    await screen.findByRole("heading", { name: "Ab accordion positions" });
+    const rightHand = screen.getByRole("group", { name: /Right hand/i });
+    const keyboard = getAccordionSurface(
+      rightHand,
+      '[data-surface="keyboard"], .accordion-keyboard, .piano-keyboard',
+    );
+    const activeKeyboardMidi = [...keyboard.querySelectorAll(".accordion-keyboard__key--active-tone")]
+      .map((key) => (key as HTMLElement).dataset.midi)
+      .sort();
+
+    expect(getAccordionKeyboardMidiByColor(keyboard, "white")).toEqual([
+      "65",
+      "67",
+      "69",
+      "71",
+      "72",
+      "74",
+      "76",
+      "77",
+      "79",
+      "81",
+    ]);
+    expect(getAccordionKeyboardMidiByColor(keyboard, "black")).toEqual(["66", "68", "70", "73", "75", "78", "80"]);
+    expect(activeKeyboardMidi).toEqual(["68", "72", "75"]);
+    expect(getAccordionKeyByMidi(keyboard, 65, "white")).toHaveAttribute("aria-hidden", "true");
+    expect(getAccordionKeyByMidi(keyboard, 66, "black")).toHaveAttribute("aria-hidden", "true");
+    expectSelectedOrHighlighted(getAccordionKeyByMidi(keyboard, 68, "black"));
+    expect(getAccordionKeyByMidi(keyboard, 70, "black")).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("keeps A#/Bb accordion keyboard context with lower and upper three-black-key groups", async () => {
+    await selectAccordionDictionary();
+
+    changeChordSearch("Bb");
+
+    await screen.findByRole("heading", { name: "Bb accordion positions" });
+    const rightHand = screen.getByRole("group", { name: /Right hand/i });
+    const keyboard = getAccordionSurface(
+      rightHand,
+      '[data-surface="keyboard"], .accordion-keyboard, .piano-keyboard',
+    );
+    const activeKeyboardMidi = [...keyboard.querySelectorAll(".accordion-keyboard__key--active-tone")]
+      .map((key) => (key as HTMLElement).dataset.midi)
+      .sort();
+
+    expect(getAccordionKeyboardMidiByColor(keyboard, "white")).toEqual([
+      "65",
+      "67",
+      "69",
+      "71",
+      "72",
+      "74",
+      "76",
+      "77",
+      "79",
+      "81",
+      "83",
+    ]);
+    expect(getAccordionKeyboardMidiByColor(keyboard, "black")).toEqual([
+      "66",
+      "68",
+      "70",
+      "73",
+      "75",
+      "78",
+      "80",
+      "82",
+    ]);
+    expect(activeKeyboardMidi).toEqual(["70", "74", "77"]);
+    expect(getAccordionKeyByMidi(keyboard, 66, "black")).toHaveAttribute("aria-hidden", "true");
+    expect(getAccordionKeyByMidi(keyboard, 68, "black")).toHaveAttribute("aria-hidden", "true");
+    expectSelectedOrHighlighted(getAccordionKeyByMidi(keyboard, 70, "black"));
+    expect(getAccordionKeyByMidi(keyboard, 78, "black")).toHaveAttribute("aria-hidden", "true");
+    expect(getAccordionKeyByMidi(keyboard, 80, "black")).toHaveAttribute("aria-hidden", "true");
+    expect(getAccordionKeyByMidi(keyboard, 82, "black")).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("centers Dictionary accordion on non-C roots and shows active black-key labels", async () => {
+    await selectAccordionDictionary();
+
+    changeChordSearch("F#");
+
+    await screen.findByRole("heading", { name: "F# accordion positions" });
+    expect(screen.getByText("Region F#")).toBeInTheDocument();
+
+    const leftHand = screen.getByRole("group", { name: /Left hand/i });
+    const rightHand = screen.getByRole("group", { name: /Right hand/i });
+    const keyboard = getAccordionSurface(
+      rightHand,
+      '[data-surface="keyboard"], .accordion-keyboard, .piano-keyboard',
+    );
+    const blackKeyLayer = getAccordionSurface(keyboard, ".accordion-keyboard__black-keys");
+    const selectedBass = getSelectedAccordionButton(leftHand, /(^F#$|\bF# bass\b)/i);
+    const selectedMajor = getSelectedAccordionButton(leftHand, /(^F#M$|\bF#M\b)/i);
+    const rootBlackKey = within(rightHand).getByRole("button", {
+      name: /F#\d degree 1 accordion keyboard key/i,
+    });
+    const activeBlackKeys = [
+      ...blackKeyLayer.querySelectorAll<HTMLElement>(".accordion-keyboard__key--active-tone"),
+    ];
+
+    expect(screen.queryByText(/Capo/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Transpose/i)).not.toBeInTheDocument();
+    expectSelectedOrHighlighted(selectedBass);
+    expectSelectedOrHighlighted(selectedMajor);
+    expect(blackKeyLayer).toContainElement(rootBlackKey);
+    expect(rootBlackKey).toHaveAttribute("data-key-color", "black");
+    expect(rootBlackKey).toHaveClass("accordion-keyboard__key--black");
+    expect(rootBlackKey).toHaveClass("accordion-keyboard__key--active-tone");
+    expect(rootBlackKey).not.toHaveAttribute("aria-hidden");
+    expect(rootBlackKey.querySelector("strong")).toHaveTextContent(/^F#\d$/);
+    expect(rootBlackKey.querySelector("span")).toHaveTextContent("1");
+    expect(activeBlackKeys.length).toBeGreaterThan(0);
+    expect(activeBlackKeys.map((key) => key.textContent).join(" ")).toMatch(/F#\d/);
+  });
+
+  it("renders B root bottom-up on the vertical accordion keyboard", async () => {
+    const user = await selectAccordionDictionary();
+
+    changeChordSearch("B");
+
+    await screen.findByRole("heading", { name: "B accordion positions" });
+    const preferenceChoices = screen.getByRole("group", {
+      name: "Global accordion right-hand preference choices",
+    });
+    const preferenceButtons = within(preferenceChoices);
+    await user.click(preferenceButtons.getByRole("button", { name: "B root" }));
+
+    const rightHand = screen.getByRole("group", { name: /Right hand/i });
+    const keyboard = getAccordionSurface(
+      rightHand,
+      '[data-surface="keyboard"], .accordion-keyboard, .piano-keyboard',
+    );
+    const bKey = getAccordionKeyByMidi(keyboard, 71, "white");
+    const dSharpKey = getAccordionKeyByMidi(keyboard, 75, "black");
+    const fSharpKey = getAccordionKeyByMidi(keyboard, 78, "black");
+    const activeKeyboardMidi = [...keyboard.querySelectorAll(".accordion-keyboard__key--active-tone")]
+      .map((key) => (key as HTMLElement).dataset.midi)
+      .sort();
+
+    expect(keyboard).toHaveAttribute("data-orientation", "vertical");
+    expect(getAccordionKeyboardMidiByColor(keyboard, "white")).toEqual([
+      "65",
+      "67",
+      "69",
+      "71",
+      "72",
+      "74",
+      "76",
+      "77",
+      "79",
+      "81",
+      "83",
+    ]);
+    expect(getAccordionKeyboardMidiByColor(keyboard, "black")).toEqual([
+      "66",
+      "68",
+      "70",
+      "73",
+      "75",
+      "78",
+      "80",
+      "82",
+    ]);
+    expect(activeKeyboardMidi).toEqual(["71", "75", "78"]);
+    expect(getAccordionKeyByMidi(keyboard, 66, "black")).toHaveAttribute("aria-hidden", "true");
+    expect(getAccordionKeyByMidi(keyboard, 68, "black")).toHaveAttribute("aria-hidden", "true");
+    expect(getAccordionKeyByMidi(keyboard, 70, "black")).toHaveAttribute("aria-hidden", "true");
+    expectSelectedOrHighlighted(getAccordionKeyByMidi(keyboard, 78, "black"));
+    expect(getAccordionKeyByMidi(keyboard, 80, "black")).toHaveAttribute("aria-hidden", "true");
+    expect(getAccordionKeyByMidi(keyboard, 82, "black")).toHaveAttribute("aria-hidden", "true");
+    expectSelectedOrHighlighted(bKey);
+    expectSelectedOrHighlighted(dSharpKey);
+    expectSelectedOrHighlighted(fSharpKey);
+    expect(readNumericStyleVar(bKey, "--accordion-white-index")).toBeGreaterThan(
+      readNumericStyleVar(dSharpKey, "--accordion-white-index"),
+    );
+    expect(readNumericStyleVar(dSharpKey, "--accordion-white-index")).toBeGreaterThan(
+      readNumericStyleVar(fSharpKey, "--accordion-white-index"),
+    );
+    expect(within(rightHand).getByRole("button", {
+      name: /B4 degree 1 accordion keyboard key/i,
+    })).toHaveTextContent("B4");
+
+    await user.click(preferenceButtons.getByRole("button", { name: "B first inversion" }));
+    const firstInversionBass = getAccordionKeyByMidi(keyboard, 75, "black");
+    const firstInversionFifth = getAccordionKeyByMidi(keyboard, 78, "black");
+    const firstInversionRoot = getAccordionKeyByMidi(keyboard, 83, "white");
+    expect(readNumericStyleVar(firstInversionBass, "--accordion-white-index")).toBeGreaterThan(
+      readNumericStyleVar(firstInversionFifth, "--accordion-white-index"),
+    );
+    expect(readNumericStyleVar(firstInversionFifth, "--accordion-white-index")).toBeGreaterThan(
+      readNumericStyleVar(firstInversionRoot, "--accordion-white-index"),
+    );
+
+    await user.click(preferenceButtons.getByRole("button", { name: "B second inversion" }));
+    const secondInversionBass = getAccordionKeyByMidi(keyboard, 78, "black");
+    const secondInversionRoot = getAccordionKeyByMidi(keyboard, 83, "white");
+    const secondInversionThird = getAccordionKeyByMidi(keyboard, 87, "black");
+    expect(readNumericStyleVar(secondInversionBass, "--accordion-white-index")).toBeGreaterThan(
+      readNumericStyleVar(secondInversionRoot, "--accordion-white-index"),
+    );
+    expect(readNumericStyleVar(secondInversionRoot, "--accordion-white-index")).toBeGreaterThan(
+      readNumericStyleVar(secondInversionThird, "--accordion-white-index"),
+    );
+  });
+
+  it("selects root bass and same-root seventh buttons for accordion dominant sevenths", async () => {
+    await selectAccordionDictionary();
+
+    changeChordSearch("C7");
+
+    await screen.findByRole("heading", { name: "C7 accordion positions" });
+    let leftHand = screen.getByRole("group", { name: /Left hand/i });
+    expectSelectedOrHighlighted(getSelectedAccordionButton(leftHand, /(^C$|\bC bass\b)/i));
+    expectSelectedOrHighlighted(getSelectedAccordionButton(leftHand, /(^C7$|\bC7\b)/i));
+    expect(screen.getByLabelText("Accordion left-hand candidates")).toHaveTextContent(
+      /C bass \+ C7\(no5\)[\s\S]*Missing:\s*G/i,
+    );
+
+    changeChordSearch("B7");
+
+    await screen.findByRole("heading", { name: "B7 accordion positions" });
+    leftHand = screen.getByRole("group", { name: /Left hand/i });
+    expectSelectedOrHighlighted(getSelectedAccordionButton(leftHand, /(^B$|\bB bass\b)/i));
+    expectSelectedOrHighlighted(getSelectedAccordionButton(leftHand, /(^B7$|\bB7\b)/i));
+    expect(screen.getByLabelText("Accordion left-hand candidates")).toHaveTextContent(
+      /B bass \+ B7\(no5\)[\s\S]*Missing:\s*F#/i,
+    );
+  });
+
+  it("keeps accordion seventh and diminished row ids through DOM classes", async () => {
+    await selectAccordionDictionary();
+
+    changeChordSearch("C7");
+
+    await screen.findByRole("heading", { name: "C7 accordion positions" });
+    let leftHand = screen.getByRole("group", { name: /Left hand/i });
+    const seventhButtons = within(leftHand).getAllByRole("button", {
+      name: "C7 7 accordion button",
+    });
+    const seventhButton = seventhButtons[0] as HTMLElement;
+    expect(seventhButton).toHaveAttribute("data-row", "seventh");
+    expect(seventhButton).toHaveClass("accordion-stradella__button--seventh");
+    expect(seventhButton).not.toHaveClass("accordion-stradella__button--dominant7");
+    expect(seventhButton).not.toHaveClass("accordion-stradella__button--diminished");
+
+    changeChordSearch("Cdim");
+
+    await screen.findByRole("heading", { name: "Cdim accordion positions" });
+    leftHand = screen.getByRole("group", { name: /Left hand/i });
+    const diminishedButtons = within(leftHand).getAllByRole("button", {
+      name: "Cdim Dim accordion button",
+    });
+    const diminishedButton = diminishedButtons[0] as HTMLElement;
+    expect(diminishedButton).toHaveAttribute("data-row", "diminished");
+    expect(diminishedButton).toHaveClass("accordion-stradella__button--diminished");
+    expect(diminishedButton).not.toHaveClass("accordion-stradella__button--seventh");
+
+    let candidatePanel = screen.getByLabelText("Accordion left-hand candidates");
+    expect(candidatePanel).toHaveTextContent(/C bass \+ Cdim \(Ebdim7\(no5\) button\)/i);
+
+    changeChordSearch("Cdim7");
+
+    await screen.findByRole("heading", { name: "Cdim7 accordion positions" });
+    candidatePanel = screen.getByLabelText("Accordion left-hand candidates");
+    expect(candidatePanel).toHaveTextContent(/C bass \+ Cdim7 \(Gbdim7\(no5\) button\)/i);
   });
 
   it("renders real accordion diff labels only for approximate candidates", async () => {
@@ -886,7 +1337,7 @@ describe("Desktop app tools chord dictionary", () => {
     expect(selectedDiff).not.toHaveTextContent(/Added:\s*E(?:,|\b)/i);
   });
 
-  it("keeps alternate full-board left-hand candidate buttons visible after selection", async () => {
+  it("deduplicates repeated visible left-hand candidate cards", async () => {
     const user = await selectAccordionDictionary();
     changeChordSearch("C7b5");
 
@@ -895,8 +1346,8 @@ describe("Desktop app tools chord dictionary", () => {
     const cSevenCandidates = within(candidatePanel).getAllByRole("button", {
       name: /C bass \+ C7/i,
     });
-    expect(cSevenCandidates.length).toBeGreaterThan(1);
-    await user.click(cSevenCandidates[cSevenCandidates.length - 1] as HTMLElement);
+    expect(cSevenCandidates).toHaveLength(1);
+    await user.click(cSevenCandidates[0] as HTMLElement);
 
     const leftHand = screen.getByRole("group", { name: /Left hand/i });
     await waitFor(() => {
@@ -1303,6 +1754,7 @@ describe("Desktop app tools chord dictionary", () => {
         "true",
       ),
     );
+    expectAccordionInstrumentSelected();
 
     const currentChord = screen.getByLabelText("Current chord");
     expect(currentChord).toHaveTextContent(/Source chord\s*C/);
@@ -1335,6 +1787,7 @@ describe("Desktop app tools chord dictionary", () => {
         "true",
       ),
     );
+    expectAccordionInstrumentSelected();
 
     expect(screen.getByLabelText("Current chord")).toHaveTextContent(/Display chord\s*F#/);
     expect(screen.getByText("Region C")).toBeInTheDocument();

--- a/apps/desktop/src/features/tools/ChordDictionaryPage.tsx
+++ b/apps/desktop/src/features/tools/ChordDictionaryPage.tsx
@@ -106,6 +106,12 @@ type AccordionKeyboardSlice = {
   keys: readonly AccordionKeyboardKeyView[];
   whiteKeyCount: number;
 };
+type CompactKeyboardWindow = {
+  endMidi: number;
+  startMidi: number;
+};
+const COMPACT_KEYBOARD_C_FAMILY_END_PITCH_CLASS = 4;
+const COMPACT_KEYBOARD_F_FAMILY_END_PITCH_CLASS = 11;
 type AccordionLeftHandCandidateView = {
   addedTones: readonly string[];
   buttons: readonly AccordionButtonView[];
@@ -133,7 +139,7 @@ type AccordionVoicingView = {
 };
 type AccordionStradellaRowIdView =
   | "diminished"
-  | "dominant7"
+  | "seventh"
   | "minor"
   | "major"
   | "bass"
@@ -203,7 +209,7 @@ const CHORD_DICTIONARY_INSTRUMENTS = [
 ] as const satisfies ReadonlyArray<{ id: ChordDictionaryInstrumentId; label: string }>;
 const ACCORDION_STRADDELLA_ROWS = [
   { id: "diminished", label: "Dim" },
-  { id: "dominant7", label: "7" },
+  { id: "seventh", label: "7" },
   { id: "minor", label: "Min" },
   { id: "major", label: "Maj" },
   { id: "bass", label: "Bass" },
@@ -927,8 +933,8 @@ function InstrumentSelector({
             "chord-pill",
             "chord-instrument-button",
             instrumentId === instrument.id && "chord-instrument-button--active",
-            instrumentId === instrument.id && "chord-pill--active",
           )}
+          data-selected={instrumentId === instrument.id ? "true" : "false"}
           onClick={() => onInstrumentChange(instrument.id)}
           type="button"
         >
@@ -1234,6 +1240,7 @@ function AccordionKeyboard({
     <div
       className="accordion-keyboard"
       data-black-offset="true"
+      data-layout="piano-vertical"
       data-orientation="vertical"
       data-surface="keyboard"
       style={{ "--accordion-white-key-count": slice.whiteKeyCount } as CSSProperties}
@@ -1497,12 +1504,16 @@ function toAccordionVoicingViews(voicings: readonly AccordionVoicing[]): readonl
     const rightHandNotes = readArray(record, ["rightHandNotes", "notes"]).flatMap((note, noteIndex) =>
       toAccordionKeyboardNoteView(note, id, noteIndex),
     );
-    const leftHandCandidates = readArray(record, ["leftHandCandidates", "candidates"]).flatMap(
+    const rawLeftHandCandidates = readArray(record, ["leftHandCandidates", "candidates"]).flatMap(
       (candidate, candidateIndex) => toAccordionCandidateView(candidate, id, candidateIndex),
     );
+    const leftHandCandidates = dedupeAccordionCandidateViews(rawLeftHandCandidates);
     const selectedCandidateRecord = asUnknownRecord(record.selectedLeftHandCandidate);
+    const rawSelectedCandidateId = readString(selectedCandidateRecord, ["id"]);
     const selectedCandidateId =
-      readString(selectedCandidateRecord, ["id"]) ?? leftHandCandidates[0]?.id ?? null;
+      rawSelectedCandidateId && leftHandCandidates.some((candidate) => candidate.id === rawSelectedCandidateId)
+        ? rawSelectedCandidateId
+        : leftHandCandidates[0]?.id ?? null;
     const chordLabel = readString(record, ["chordLabel"]) ?? "";
     const buttons = annotateAccordionButtonDegrees(
       normalizeAccordionButtonColumns(
@@ -1607,6 +1618,31 @@ function toAccordionCandidateView(
       rank: readNumber(record, ["rank"]) ?? candidateIndex,
     },
   ];
+}
+
+function dedupeAccordionCandidateViews(
+  candidates: readonly AccordionLeftHandCandidateView[],
+): readonly AccordionLeftHandCandidateView[] {
+  const seenOptions = new Set<string>();
+  return candidates.filter((candidate) => {
+    const visibleKey = getAccordionCandidateVisibleKey(candidate);
+    if (seenOptions.has(visibleKey)) {
+      return false;
+    }
+    seenOptions.add(visibleKey);
+    return true;
+  });
+}
+
+function getAccordionCandidateVisibleKey(candidate: AccordionLeftHandCandidateView): string {
+  return [
+    candidate.label,
+    candidate.detail,
+    candidate.fingering ?? "",
+    candidate.isExact ? "exact" : "approx",
+    candidate.missingTones.join(","),
+    candidate.addedTones.join(","),
+  ].join("\u0000");
 }
 
 function toAccordionButtonView(
@@ -1788,38 +1824,110 @@ function buildAccordionKeyboardSlice(
   }
 
   const noteByMidi = new Map(notes.map((note) => [note.midi, note]));
-  const minMidi = Math.min(...notes.map((note) => note.midi));
-  const maxMidi = Math.max(...notes.map((note) => note.midi));
-  let startMidi = minMidi;
-  while (normalizePitchClassView(startMidi) !== 0) {
-    startMidi -= 1;
-  }
-  let endMidi = maxMidi;
-  while (normalizePitchClassView(endMidi) !== 0) {
-    endMidi += 1;
-  }
-  if (endMidi - startMidi < 12) {
-    endMidi = startMidi + 12;
+  const window = buildCompactKeyboardWindow(notes.map((note) => note.midi));
+  if (!window) {
+    return { keys: [], whiteKeyCount: 0 };
   }
 
-  const keys: AccordionKeyboardKeyView[] = [];
+  const keysByPitch: Array<
+    Omit<AccordionKeyboardKeyView, "whiteIndex"> & {
+      lowerWhiteIndex: number;
+      whiteAscendingIndex: number | null;
+    }
+  > = [];
   let whiteIndex = 0;
-  for (let midi = startMidi; midi <= endMidi; midi += 1) {
+  for (let midi = window.startMidi; midi <= window.endMidi; midi += 1) {
     const pitch = midiToPitch(midi);
     const isBlack = isBlackPianoKey(midi);
-    keys.push({
+    keysByPitch.push({
       isBlack,
+      lowerWhiteIndex: isBlack ? Math.max(0, whiteIndex - 1) : whiteIndex,
       midi,
       note: noteByMidi.get(midi) ?? null,
       pitchLabel: pitch?.label ?? `MIDI ${midi}`,
-      whiteIndex: isBlack ? Math.max(0, whiteIndex - 1) : whiteIndex,
+      whiteAscendingIndex: isBlack ? null : whiteIndex,
     });
     if (!isBlack) {
       whiteIndex += 1;
     }
   }
 
-  return { keys, whiteKeyCount: whiteIndex };
+  const whiteKeyCount = whiteIndex;
+  const keys = keysByPitch.map(({ lowerWhiteIndex, whiteAscendingIndex, ...key }) => ({
+    ...key,
+    whiteIndex: key.isBlack
+      ? Math.max(0, whiteKeyCount - 2 - lowerWhiteIndex)
+      : whiteKeyCount - 1 - (whiteAscendingIndex ?? 0),
+  }));
+
+  return { keys, whiteKeyCount };
+}
+
+function buildCompactKeyboardWindow(activeMidis: readonly number[]): CompactKeyboardWindow | null {
+  if (activeMidis.length === 0) {
+    return null;
+  }
+
+  const lowestActiveMidi = Math.min(...activeMidis);
+  const highestActiveMidi = Math.max(...activeMidis);
+  const contextStartMidi = findCompactKeyboardWindowStartMidi(lowestActiveMidi);
+  const minimumContextEndMidi = Math.max(
+    lowestActiveMidi + 12,
+    findCompactKeyboardWindowEndMidi(lowestActiveMidi, contextStartMidi),
+  );
+
+  return {
+    startMidi: contextStartMidi,
+    endMidi: findNearestWhiteKeyAtOrAbove(Math.max(highestActiveMidi, minimumContextEndMidi)),
+  };
+}
+
+function findCompactKeyboardWindowStartMidi(lowestActiveMidi: number): number {
+  return getCompactKeyboardFamilyStartMidi(lowestActiveMidi);
+}
+
+function getCompactKeyboardFamilyStartMidi(midi: number): number {
+  const pitchClass = normalizePitchClassView(midi);
+  return midi - (pitchClass < 5 ? pitchClass : pitchClass - 5);
+}
+
+function findCompactKeyboardWindowEndMidi(lowestActiveMidi: number, contextStartMidi: number): number {
+  switch (getCompactKeyboardFamilyEndPitchClass(lowestActiveMidi)) {
+    case null:
+      return lowestActiveMidi + 12;
+    case COMPACT_KEYBOARD_C_FAMILY_END_PITCH_CLASS:
+      return getNextMidiForPitchClassAtOrAbove(contextStartMidi + 12, COMPACT_KEYBOARD_C_FAMILY_END_PITCH_CLASS);
+    case COMPACT_KEYBOARD_F_FAMILY_END_PITCH_CLASS:
+      return getNextMidiForPitchClassAtOrAbove(contextStartMidi + 12, COMPACT_KEYBOARD_F_FAMILY_END_PITCH_CLASS);
+  }
+  return lowestActiveMidi + 12;
+}
+
+function getCompactKeyboardFamilyEndPitchClass(lowestActiveMidi: number): number | null {
+  const pitchClass = normalizePitchClassView(lowestActiveMidi);
+  if (pitchClass >= 2 && pitchClass <= COMPACT_KEYBOARD_C_FAMILY_END_PITCH_CLASS) {
+    return COMPACT_KEYBOARD_C_FAMILY_END_PITCH_CLASS;
+  }
+  if (pitchClass >= 9) {
+    return COMPACT_KEYBOARD_F_FAMILY_END_PITCH_CLASS;
+  }
+  return null;
+}
+
+function getNextMidiForPitchClassAtOrAbove(midi: number, pitchClass: number): number {
+  let keyMidi = midi;
+  while (normalizePitchClassView(keyMidi) !== pitchClass) {
+    keyMidi += 1;
+  }
+  return keyMidi;
+}
+
+function findNearestWhiteKeyAtOrAbove(midi: number): number {
+  let keyMidi = midi;
+  while (isBlackPianoKey(keyMidi)) {
+    keyMidi += 1;
+  }
+  return keyMidi;
 }
 
 function findAccordionInspectorPoint(
@@ -2095,7 +2203,7 @@ function normalizeAccordionRowId(value: string | null): AccordionStradellaRowIdV
     return "diminished";
   }
   if (normalized === "7" || normalized === "seventh" || normalized === "dominant7") {
-    return "dominant7";
+    return "seventh";
   }
   if (normalized === "m" || normalized === "minor") {
     return "minor";
@@ -2132,7 +2240,7 @@ function formatAccordionButtonLabel(
       return `${noteLabel}M`;
     case "minor":
       return `${noteLabel}m`;
-    case "dominant7":
+    case "seventh":
       return `${noteLabel}7`;
     case "diminished":
       return `${noteLabel}dim`;

--- a/apps/desktop/src/lib/music.test.ts
+++ b/apps/desktop/src/lib/music.test.ts
@@ -20,6 +20,7 @@ import {
   transposeChordLabel,
   type AccordionLeftHandCandidate,
   type AccordionVoicing,
+  type AccordionVoicingContext,
   type ChordDisplayContext,
   type ChordSpelling,
   type GuitarVoicing,
@@ -115,20 +116,33 @@ function requireVoicings(label: string, context: Partial<ChordDisplayContext> = 
   return voicings;
 }
 
-function requireAccordionVoicing(label: string, key?: MusicalKey): AccordionVoicing {
-  const voicing = generateAccordionVoicings(label, key)[0];
+function requireAccordionVoicing(label: string, context: AccordionVoicingContext | null = null): AccordionVoicing {
+  const voicing = generateAccordionVoicings(label, context)[0];
   if (!voicing) {
     throw new Error(`Expected ${label} to produce an accordion voicing`);
   }
   return voicing;
 }
 
-function requireSelectedAccordionLeftHand(label: string, key?: MusicalKey): AccordionLeftHandCandidate {
-  const selected = requireAccordionVoicing(label, key).selectedLeftHandCandidate;
+function requireSelectedAccordionLeftHand(
+  label: string,
+  context: AccordionVoicingContext | null = null,
+): AccordionLeftHandCandidate {
+  const selected = requireAccordionVoicing(label, context).selectedLeftHandCandidate;
   if (!selected) {
     throw new Error(`Expected ${label} to produce an accordion left-hand candidate`);
   }
   return selected;
+}
+
+function visibleStradellaBassColumns(voicing: AccordionVoicing): readonly number[] {
+  return [
+    ...new Set(
+      voicing.visibleStradellaButtons
+        .filter((button) => button.rowId === "bass")
+        .map((button) => button.column),
+    ),
+  ].sort((left, right) => left - right);
 }
 
 function findAccordionLeftHand(
@@ -496,6 +510,93 @@ describe("accordion chord voicings", () => {
     });
   });
 
+  it("uses root bass plus Stradella seventh buttons for dominant seventh left-hand voicings", () => {
+    expect(requireSelectedAccordionLeftHand("G7")).toMatchObject({
+      label: "G bass + G7(no5)",
+      quality: "approx",
+      bassButton: { rowId: "bass", root: "G" },
+      chordButton: { rowId: "seventh", root: "G" },
+      missingTones: ["D"],
+      addedTones: [],
+    });
+    expect(requireSelectedAccordionLeftHand("C7")).toMatchObject({
+      label: "C bass + C7(no5)",
+      quality: "approx",
+      bassButton: { rowId: "bass", root: "C" },
+      chordButton: { rowId: "seventh", root: "C" },
+      missingTones: ["G"],
+      addedTones: [],
+    });
+    expect(requireSelectedAccordionLeftHand("B7")).toMatchObject({
+      label: "B bass + B7(no5)",
+      quality: "approx",
+      bassButton: { rowId: "bass", root: "B" },
+      chordButton: { rowId: "seventh", root: "B" },
+      missingTones: ["F#"],
+      addedTones: [],
+    });
+  });
+
+  it("labels diminished Stradella candidates by searched chord and physical button", () => {
+    expect(requireSelectedAccordionLeftHand("Bdim")).toMatchObject({
+      label: "B bass + Bdim (Ddim7(no5) button)",
+      quality: "exact",
+      bassButton: { rowId: "bass", root: "B" },
+      chordButton: { rowId: "diminished", root: "D" },
+      missingTones: [],
+      addedTones: [],
+    });
+    expect(requireSelectedAccordionLeftHand("Cdim")).toMatchObject({
+      label: "C bass + Cdim (Ebdim7(no5) button)",
+      quality: "exact",
+      bassButton: { rowId: "bass", root: "C" },
+      chordButton: { rowId: "diminished", root: "Eb" },
+      missingTones: [],
+      addedTones: [],
+    });
+    expect(requireSelectedAccordionLeftHand("Cdim7")).toMatchObject({
+      label: "C bass + Cdim7 (Gbdim7(no5) button)",
+      quality: "exact",
+      bassButton: { rowId: "bass", root: "C" },
+      chordButton: { rowId: "diminished", root: "Gb" },
+      missingTones: [],
+      addedTones: [],
+    });
+  });
+
+  it("deduplicates identical visible left-hand candidates", () => {
+    const voicing = requireAccordionVoicing("C", cMajor);
+    const visibleOptions = voicing.leftHandCandidates.map((candidate) =>
+      [
+        candidate.label,
+        candidate.quality,
+        candidate.fingering.label,
+        candidate.missingTones.join(","),
+        candidate.addedTones.join(","),
+      ].join("|"),
+    );
+
+    expect(new Set(visibleOptions).size).toBe(visibleOptions.length);
+    expect(voicing.leftHandCandidates.filter((candidate) => candidate.label === "C bass + CM")).toHaveLength(1);
+  });
+
+  it("keeps static duplicated-root Stradella windows centered", () => {
+    const cVoicing = requireAccordionVoicing("C", null);
+    const bVoicing = requireAccordionVoicing("B", null);
+
+    expect(cVoicing.selectedLeftHandCandidate).toMatchObject({
+      bassButton: { column: 8, rowId: "bass", root: "C" },
+      chordButton: { column: 8, rowId: "major", root: "C" },
+    });
+    expect(visibleStradellaBassColumns(cVoicing)).toEqual([3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+
+    expect(bVoicing.selectedLeftHandCandidate).toMatchObject({
+      bassButton: { column: 13, rowId: "bass", root: "B" },
+      chordButton: { column: 13, rowId: "major", root: "B" },
+    });
+    expect(visibleStradellaBassColumns(bVoicing)).toEqual([8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]);
+  });
+
   it("labels generated C right-hand options uniquely", () => {
     const voicings = generateAccordionVoicings("C", cMajor);
     const ids = voicings.map((voicing) => voicing.id);
@@ -506,6 +607,48 @@ describe("accordion chord voicings", () => {
     expect(new Set(labels).size).toBe(labels.length);
     expect(labels).toEqual(expect.arrayContaining(["C root", "C first inversion", "C second inversion"]));
     expect(labels.some((label) => label.includes("right hand"))).toBe(false);
+  });
+
+  it("centers static dictionary voicings around non-C chord roots", () => {
+    const voicing = requireAccordionVoicing("F#", null);
+
+    expect(voicing.regionRoot).toEqual({ pitchClass: 6, note: "F#" });
+    expect(voicing.rightHandNotes.map((note) => `${note.degree}:${note.note}`)).toEqual([
+      "1:F#4",
+      "3:A#4",
+      "5:C#5",
+    ]);
+    expect(voicing.visibleStradellaButtons).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ rowId: "bass", root: "F#" }),
+        expect.objectContaining({ rowId: "major", root: "F#" }),
+      ]),
+    );
+  });
+
+  it("keeps B root right-hand notes ordered from lower to higher pitches", () => {
+    const voicing = requireAccordionVoicing("B", null);
+
+    expect(voicing.label).toBe("B root");
+    expect(voicing.rightHandNotes.map((note) => `${note.degree}:${note.note}`)).toEqual([
+      "1:B4",
+      "3:D#5",
+      "5:F#5",
+    ]);
+  });
+
+  it("labels B inversions by lowest played pitch semantics", () => {
+    const voicings = generateAccordionVoicings("B", null);
+    const notesByLabel = new Map(
+      voicings.map((voicing) => [
+        voicing.label,
+        voicing.rightHandNotes.map((note) => `${note.degree}:${note.note}`),
+      ]),
+    );
+
+    expect(notesByLabel.get("B root")).toEqual(["1:B4", "3:D#5", "5:F#5"]);
+    expect(notesByLabel.get("B first inversion")).toEqual(["3:D#5", "5:F#5", "1:B5"]);
+    expect(notesByLabel.get("B second inversion")).toEqual(["5:F#5", "1:B5", "3:D#6"]);
   });
 
   it("ranks right-hand inversions around C key root for C G Am F", () => {

--- a/apps/desktop/src/lib/music.ts
+++ b/apps/desktop/src/lib/music.ts
@@ -1433,6 +1433,7 @@ export function generateGuitarVoicings(
 const ACCORDION_VISIBLE_ROOT_RADIUS = 5;
 const ACCORDION_RIGHT_HAND_TARGET_MIDI = 60;
 const ACCORDION_RIGHT_HAND_MAX_VOICINGS = 6;
+const KEYBOARD_RIGHT_HAND_ROOT_REGISTER_START_MIDI = 60;
 const ACCORDION_BASS_ROW_IDS = new Set<AccordionStradellaRowId>(["counterbass", "bass"]);
 const ACCORDION_CHORD_ROW_IDS = new Set<AccordionStradellaRowId>(["major", "minor", "seventh", "diminished"]);
 
@@ -1449,6 +1450,11 @@ type AccordionRightHandCandidate = {
   score: number;
 };
 
+type KeyboardRightHandVoicingPlacement = {
+  anchorMidi: number;
+  preferredRootMidi: number | null;
+};
+
 export function generateAccordionVoicings(
   chord: ChordInput,
   context: AccordionVoicingContext | null = null,
@@ -1462,9 +1468,10 @@ export function generateAccordionVoicings(
   const resolvedContext = resolveAccordionVoicingContext(context);
   const regionRootPitchClass =
     resolvedContext.regionKey?.pitchClass ?? resolvedContext.currentChordRootPitchClass ?? parsedChord.rootPitchClass;
+  const resolvedChordOptions = resolveChordFormatOptions(parsedChord, options);
   const chordOptions = {
-    ...resolveChordFormatOptions(parsedChord, options),
-    activeKey: options.activeKey ?? resolvedContext.regionKey ?? options.activeKey,
+    ...resolvedChordOptions,
+    activeKey: options.activeKey ?? resolvedContext.regionKey ?? resolvedChordOptions.activeKey,
   };
   const chordSpelling = spellChord(parsedChord, chordOptions);
   if (!chordSpelling) {
@@ -1476,11 +1483,19 @@ export function generateAccordionVoicings(
     note: formatPitchClass(regionRootPitchClass, chordOptions),
   };
   const allStradellaButtons = buildAllStradellaButtons(ACCORDION_STANDARD_PROFILE, chordOptions);
-  const leftHandCandidates = generateAccordionLeftHandCandidates(chordSpelling, allStradellaButtons, chordOptions);
+  const leftHandCandidates = generateAccordionLeftHandCandidates(
+    chordSpelling,
+    allStradellaButtons,
+    ACCORDION_STANDARD_PROFILE.buttonBoard.stradella.rootAxis,
+    chordOptions,
+  );
+  const preferChordRootRegister =
+    resolvedContext.regionKey === null && resolvedContext.currentChordRootPitchClass === null;
   const rightHandCandidates = generateAccordionRightHandCandidates(
     chordSpelling,
     ACCORDION_STANDARD_PROFILE,
     regionRoot.pitchClass,
+    preferChordRootRegister,
     chordOptions,
   );
   const selectedLeftHandCandidate = leftHandCandidates[0] ?? null;
@@ -1774,6 +1789,7 @@ function formatStradellaButtonLabel(root: string, rowId: AccordionStradellaRowId
 function generateAccordionLeftHandCandidates(
   chord: ChordSpelling,
   visibleButtons: readonly AccordionStradellaButton[],
+  rootAxis: ButtonBoardStradellaProfileV1["rootAxis"],
   options: PitchFormatOptions,
 ): readonly AccordionLeftHandCandidate[] {
   const bassButtons = visibleButtons.filter((button) => ACCORDION_BASS_ROW_IDS.has(button.rowId));
@@ -1791,9 +1807,81 @@ function generateAccordionLeftHandCandidates(
     }
   }
 
-  return [...candidates.values()]
-    .sort((left, right) => left.rank - right.rank || left.id.localeCompare(right.id))
-    .slice(0, 16);
+  return dedupeAccordionLeftHandCandidatesByVisibleOption(
+    [...candidates.values()].sort((left, right) =>
+      compareAccordionLeftHandCandidates(left, right, rootAxis),
+    ),
+  ).slice(0, 16);
+}
+
+function compareAccordionLeftHandCandidates(
+  left: AccordionLeftHandCandidate,
+  right: AccordionLeftHandCandidate,
+  rootAxis: ButtonBoardStradellaProfileV1["rootAxis"],
+): number {
+  const rankDelta = left.rank - right.rank;
+  if (rankDelta !== 0) {
+    return rankDelta;
+  }
+
+  const centerDistanceDelta =
+    scoreAccordionLeftHandCandidateCenterDistance(left, rootAxis) -
+    scoreAccordionLeftHandCandidateCenterDistance(right, rootAxis);
+  if (centerDistanceDelta !== 0) {
+    return centerDistanceDelta;
+  }
+
+  return left.id.localeCompare(right.id);
+}
+
+function scoreAccordionLeftHandCandidateCenterDistance(
+  candidate: AccordionLeftHandCandidate,
+  rootAxis: ButtonBoardStradellaProfileV1["rootAxis"],
+): number {
+  return (
+    scoreAccordionButtonCenterDistance(candidate.bassButton, rootAxis) +
+    scoreAccordionButtonCenterDistance(candidate.chordButton, rootAxis)
+  );
+}
+
+function scoreAccordionButtonCenterDistance(
+  button: AccordionStradellaButton,
+  rootAxis: ButtonBoardStradellaProfileV1["rootAxis"],
+): number {
+  const axisPitchClass =
+    button.rowId === "counterbass" ? transposePitchClass(button.pitchClass, -4) : button.pitchClass;
+  const preferredColumn = findPreferredStradellaAxisColumn(rootAxis, axisPitchClass);
+  return preferredColumn === null ? 0 : Math.abs(button.column - preferredColumn);
+}
+
+function findPreferredStradellaAxisColumn(
+  rootAxis: ButtonBoardStradellaProfileV1["rootAxis"],
+  pitchClass: number,
+): number | null {
+  const preferredEntry = rootAxis[findStradellaAxisCenterIndex(rootAxis, pitchClass)];
+  return preferredEntry && preferredEntry.pitchClass === normalizePitchClass(pitchClass)
+    ? preferredEntry.column
+    : null;
+}
+
+function dedupeAccordionLeftHandCandidatesByVisibleOption(
+  candidates: readonly AccordionLeftHandCandidate[],
+): readonly AccordionLeftHandCandidate[] {
+  const seenOptions = new Set<string>();
+  return candidates.filter((candidate) => {
+    const visibleKey = [
+      candidate.label,
+      candidate.quality,
+      candidate.fingering.label,
+      candidate.missingTones.join(","),
+      candidate.addedTones.join(","),
+    ].join("\u0000");
+    if (seenOptions.has(visibleKey)) {
+      return false;
+    }
+    seenOptions.add(visibleKey);
+    return true;
+  });
 }
 
 function buildAccordionLeftHandCandidate(
@@ -1813,7 +1901,7 @@ function buildAccordionLeftHandCandidate(
 
   return {
     id: `${bassButton.id}-${chordButton.id}`,
-    label: `${bassButton.label} + ${chordButton.label}`,
+    label: formatAccordionLeftHandCandidateLabel(chord, bassButton, chordButton),
     quality,
     bassButton,
     chordButton,
@@ -1822,6 +1910,29 @@ function buildAccordionLeftHandCandidate(
     addedTones: addedPitchClasses.map((pitchClass) => formatPitchClass(pitchClass, options)),
     rank,
   };
+}
+
+function formatAccordionLeftHandCandidateLabel(
+  chord: ChordSpelling,
+  bassButton: AccordionStradellaButton,
+  chordButton: AccordionStradellaButton,
+): string {
+  const chordButtonLabel = formatAccordionChordButtonCandidateLabel(chordButton);
+  if (chordButton.rowId === "diminished" && chordButtonLabel !== chord.label) {
+    return `${bassButton.label} + ${chord.label} (${chordButtonLabel} button)`;
+  }
+  return `${bassButton.label} + ${chordButtonLabel}`;
+}
+
+function formatAccordionChordButtonCandidateLabel(chordButton: AccordionStradellaButton): string {
+  switch (chordButton.rowId) {
+    case "seventh":
+      return `${chordButton.root}7(no5)`;
+    case "diminished":
+      return `${chordButton.root}dim7(no5)`;
+    default:
+      return chordButton.label;
+  }
 }
 
 function getAccordionTargetPitchClasses(chord: ChordSpelling): ReadonlySet<number> {
@@ -1841,11 +1952,16 @@ function scoreAccordionLeftHandCandidate(
 ): number {
   const exactPenalty = missingPitchClasses.length === 0 && addedPitchClasses.length === 0 ? 0 : 1000;
   const bassTarget = chord.bassPitchClass ?? chord.rootPitchClass;
-  const bassPenalty = bassButton.pitchClass === normalizePitchClass(bassTarget) ? 0 : 40;
+  const bassPenalty =
+    bassButton.pitchClass === normalizePitchClass(bassTarget)
+      ? 0
+      : getAccordionBassMismatchPenalty(chord);
   const counterbassPenalty = bassButton.rowId === "counterbass" ? 8 : 0;
   const chordRootPenalty = chordButton.pitchClass === chord.rootPitchClass ? 0 : 4;
+  const chordRowPenalty = getAccordionChordRowMismatchPenalty(chord, chordButton);
   return (
     exactPenalty +
+    chordRowPenalty +
     missingPitchClasses.length * 120 +
     addedPitchClasses.length * 80 +
     bassPenalty +
@@ -1853,6 +1969,30 @@ function scoreAccordionLeftHandCandidate(
     chordRootPenalty +
     chordButton.visualOrder
   );
+}
+
+function getAccordionBassMismatchPenalty(chord: ChordSpelling): number {
+  if (chord.quality === "7" && typeof chord.bassPitchClass !== "number") {
+    // Stradella seventh buttons omit the fifth; prefer same-root bass and report the omission.
+    return 1200;
+  }
+  return 40;
+}
+
+function getAccordionChordRowMismatchPenalty(
+  chord: ChordSpelling,
+  chordButton: AccordionStradellaButton,
+): number {
+  switch (chord.quality) {
+    case "7":
+    case "7b5":
+      return chordButton.rowId === "seventh" ? 0 : 2000;
+    case "dim":
+    case "dim7":
+      return chordButton.rowId === "diminished" ? 0 : 2000;
+    default:
+      return 0;
+  }
 }
 
 function getAccordionLeftHandFingering(rowId: AccordionStradellaRowId): AccordionLeftHandCandidate["fingering"] {
@@ -1873,12 +2013,28 @@ function generateAccordionRightHandCandidates(
   chord: ChordSpelling,
   profile: AccordionProfile,
   regionRootPitchClass: number,
+  preferChordRootRegister: boolean,
   options: PitchFormatOptions,
 ): readonly AccordionRightHandCandidate[] {
   const candidates = new Map<string, AccordionRightHandCandidate>();
-  const anchorMidi = getAccordionRegionAnchorMidi(regionRootPitchClass);
+  const placement = getKeyboardRightHandVoicingPlacement(
+    chord.rootPitchClass,
+    profile.keyboard.lowestPitch.midi,
+    profile.keyboard.highestPitch.midi,
+    regionRootPitchClass,
+    preferChordRootRegister,
+  );
 
   for (let inversion = 0; inversion < chord.tones.length; inversion += 1) {
+    const preferredMidis = placement.preferredRootMidi === null
+      ? null
+      : buildKeyboardRightHandInversionMidiSequence(
+          chord,
+          inversion,
+          placement.preferredRootMidi,
+          profile.keyboard.lowestPitch.midi,
+          profile.keyboard.highestPitch.midi,
+        );
     for (let baseMidi = profile.keyboard.lowestPitch.midi; baseMidi <= profile.keyboard.highestPitch.midi; baseMidi += 1) {
       if (normalizePitchClass(baseMidi) !== chord.tones[inversion]?.pitchClass) {
         continue;
@@ -1892,7 +2048,9 @@ function generateAccordionRightHandCandidates(
       const shapeKey = notes.map((note) => note.pitch.midi).join("-");
       const tonicRootBonus =
         chord.rootPitchClass === normalizePitchClass(regionRootPitchClass) && inversion === 0 ? -20 : 0;
-      const score = scoreAccordionRightHandCandidate(notes, anchorMidi, inversion) + tonicRootBonus;
+      const score =
+        scoreAccordionRightHandCandidate(notes, placement.anchorMidi, inversion, preferredMidis) +
+        tonicRootBonus;
       const existing = candidates.get(shapeKey);
       if (!existing || score < existing.score) {
         candidates.set(shapeKey, {
@@ -1910,6 +2068,50 @@ function generateAccordionRightHandCandidates(
     .sort((left, right) => left.score - right.score || left.idSuffix.localeCompare(right.idSuffix))
     .slice(0, ACCORDION_RIGHT_HAND_MAX_VOICINGS);
   return withUniqueAccordionRightHandLabels(chord.label, rankedCandidates);
+}
+
+function getKeyboardRightHandVoicingPlacement(
+  chordRootPitchClass: number,
+  lowestMidi: number,
+  highestMidi: number,
+  regionRootPitchClass: number,
+  preferChordRootRegister: boolean,
+): KeyboardRightHandVoicingPlacement {
+  if (!preferChordRootRegister) {
+    return {
+      anchorMidi: getAccordionRegionAnchorMidi(regionRootPitchClass),
+      preferredRootMidi: null,
+    };
+  }
+
+  const preferredRootMidi = getKeyboardRightHandRootRegisterMidi(
+    chordRootPitchClass,
+    lowestMidi,
+    highestMidi,
+  );
+  return {
+    anchorMidi: preferredRootMidi ?? getAccordionRegionAnchorMidi(regionRootPitchClass),
+    preferredRootMidi,
+  };
+}
+
+function getKeyboardRightHandRootRegisterMidi(
+  rootPitchClass: number,
+  lowestMidi: number,
+  highestMidi: number,
+): number | null {
+  const rootRegisterStart = KEYBOARD_RIGHT_HAND_ROOT_REGISTER_START_MIDI;
+  let midi = rootRegisterStart;
+  while (normalizePitchClass(midi) !== normalizePitchClass(rootPitchClass)) {
+    midi += 1;
+  }
+  while (midi < lowestMidi) {
+    midi += 12;
+  }
+  while (midi > highestMidi) {
+    midi -= 12;
+  }
+  return midi >= lowestMidi && midi <= highestMidi ? midi : null;
 }
 
 function withUniqueAccordionRightHandLabels(
@@ -1990,25 +2192,21 @@ function renderAccordionRightHandInversion(
   profile: AccordionProfile,
   options: PitchFormatOptions,
 ): readonly AccordionKeyboardNote[] {
-  const rotatedTones = [...chord.tones.slice(inversion), ...chord.tones.slice(0, inversion)];
+  const midiSequence = buildKeyboardRightHandInversionMidiSequence(
+    chord,
+    inversion,
+    baseMidi,
+    profile.keyboard.lowestPitch.midi,
+    profile.keyboard.highestPitch.midi,
+  );
   const notes: AccordionKeyboardNote[] = [];
-  let previousMidi = baseMidi - 1;
 
-  rotatedTones.forEach((tone, index) => {
-    let midi = index === 0 ? baseMidi : previousMidi + 1;
-    while (normalizePitchClass(midi) !== tone.pitchClass) {
-      midi += 1;
-    }
-    previousMidi = midi;
-    if (midi < profile.keyboard.lowestPitch.midi || midi > profile.keyboard.highestPitch.midi) {
-      return;
-    }
-
+  midiSequence.forEach(({ midi, tone }, index) => {
     const pitch = midiToPitch(midi, options);
     if (!pitch) {
       return;
     }
-    const finger = getAccordionRightHandFinger(index, rotatedTones.length);
+    const finger = getAccordionRightHandFinger(index, midiSequence.length);
     notes.push({
       id: `accordion-rh-${index}-${midi}`,
       pitch,
@@ -2023,6 +2221,32 @@ function renderAccordionRightHandInversion(
   return notes;
 }
 
+function buildKeyboardRightHandInversionMidiSequence(
+  chord: ChordSpelling,
+  inversion: number,
+  baseMidi: number,
+  lowestMidi: number,
+  highestMidi: number,
+): ReadonlyArray<{ midi: number; tone: ChordTone }> {
+  const rotatedTones = [...chord.tones.slice(inversion), ...chord.tones.slice(0, inversion)];
+  const notes: Array<{ midi: number; tone: ChordTone }> = [];
+  let previousMidi = baseMidi - 1;
+
+  rotatedTones.forEach((tone, index) => {
+    let midi = index === 0 ? baseMidi : previousMidi + 1;
+    while (normalizePitchClass(midi) !== tone.pitchClass) {
+      midi += 1;
+    }
+    previousMidi = midi;
+    if (midi < lowestMidi || midi > highestMidi) {
+      return;
+    }
+    notes.push({ midi, tone });
+  });
+
+  return notes.length === rotatedTones.length ? notes : [];
+}
+
 function getAccordionRightHandFinger(index: number, noteCount: number): KeyboardFingerV1 | null {
   if (noteCount <= 3) {
     return ([1, 3, 5] as const)[index] ?? null;
@@ -2034,11 +2258,25 @@ function scoreAccordionRightHandCandidate(
   notes: readonly AccordionKeyboardNote[],
   anchorMidi: number,
   inversion: number,
+  preferredMidis: ReadonlyArray<{ midi: number }> | null,
 ): number {
   const averageDistance = notes.reduce((total, note) => total + Math.abs(note.pitch.midi - anchorMidi), 0) / notes.length;
   const span = notes[notes.length - 1].pitch.midi - notes[0].pitch.midi;
   const center = notes.reduce((total, note) => total + note.pitch.midi, 0) / notes.length;
-  return averageDistance * 10 + Math.abs(center - anchorMidi) * 2 + span + inversion * 0.25;
+  const preferredPlacementPenalty =
+    preferredMidis && preferredMidis.length === notes.length
+      ? notes.reduce(
+          (total, note, index) => total + Math.abs(note.pitch.midi - (preferredMidis[index]?.midi ?? note.pitch.midi)),
+          0,
+        ) * 1000
+      : 0;
+  return (
+    preferredPlacementPenalty +
+    averageDistance * 10 +
+    Math.abs(center - anchorMidi) * 2 +
+    span +
+    inversion * 0.25
+  );
 }
 
 function getAccordionRegionAnchorMidi(regionRootPitchClass: number): number {

--- a/apps/desktop/src/styles/tools.css
+++ b/apps/desktop/src/styles/tools.css
@@ -490,8 +490,8 @@
 }
 
 .chord-instrument-button {
-  border-color: color-mix(in srgb, var(--divider) 78%, transparent);
-  background: color-mix(in srgb, var(--panel) 76%, var(--panel-strong) 24%);
+  border-color: color-mix(in srgb, var(--divider) 70%, transparent);
+  background: color-mix(in srgb, var(--panel) 88%, transparent);
   box-shadow: none;
   cursor: pointer;
   transition:
@@ -502,12 +502,17 @@
 }
 
 .chord-instrument-selector .chord-instrument-button[aria-pressed="false"],
+.chord-instrument-selector .chord-instrument-button[data-selected="false"],
 .chord-instrument-selector .chord-instrument-button[aria-pressed="false"].chord-pill--active,
 .chord-instrument-selector .chord-instrument-button[aria-pressed="false"].chord-instrument-button--active {
-  border-color: color-mix(in srgb, var(--divider) 78%, transparent);
-  background: color-mix(in srgb, var(--panel) 76%, var(--panel-strong) 24%);
+  border-color: color-mix(in srgb, var(--divider) 62%, transparent);
+  background: color-mix(in srgb, var(--panel) 92%, transparent);
   box-shadow: none;
   color: var(--muted);
+}
+
+.chord-instrument-selector .chord-instrument-button[data-selected="false"] svg {
+  color: color-mix(in srgb, var(--muted) 78%, transparent);
 }
 
 .chord-instrument-selector .chord-instrument-button[aria-pressed="false"]:hover,
@@ -519,11 +524,18 @@
 }
 
 .chord-instrument-selector .chord-instrument-button[aria-pressed="true"],
+.chord-instrument-selector .chord-instrument-button[data-selected="true"],
 .chord-instrument-selector .chord-instrument-button--active[aria-pressed="true"] {
-  border-color: color-mix(in srgb, var(--playback-accent) 72%, var(--divider));
-  background: color-mix(in srgb, var(--playback-accent) 24%, var(--panel-strong));
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--playback-accent) 24%, transparent);
+  border-color: color-mix(in srgb, var(--playback-accent) 82%, var(--text));
+  background: color-mix(in srgb, var(--playback-accent) 42%, var(--panel-strong));
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--playback-accent) 38%, transparent),
+    0 0 0 0.16rem color-mix(in srgb, var(--playback-accent) 18%, transparent);
   color: var(--text);
+}
+
+.chord-instrument-selector .chord-instrument-button[data-selected="true"] svg {
+  color: color-mix(in srgb, var(--playback-accent) 72%, var(--text));
 }
 
 .chord-pill--muted {
@@ -1499,6 +1511,10 @@
   min-width: 0;
 }
 
+.accordion-candidate-card__title {
+  flex-wrap: nowrap;
+}
+
 .accordion-position-card__heading h4,
 .accordion-candidate-panel h4 {
   margin: 0;
@@ -1508,7 +1524,10 @@
 
 .accordion-match-badge {
   display: inline-flex;
+  flex: 0 0 auto;
   align-items: center;
+  justify-content: center;
+  min-inline-size: max-content;
   min-height: 1.45rem;
   padding: 0.22rem 0.45rem;
   border: 1px solid color-mix(in srgb, var(--divider) 74%, transparent);
@@ -1518,7 +1537,9 @@
   font-size: 0.7rem;
   font-weight: 900;
   line-height: 1;
+  overflow-wrap: normal;
   text-transform: uppercase;
+  white-space: nowrap;
 }
 
 .accordion-match-badge--exact {
@@ -1623,23 +1644,23 @@
 }
 
 .accordion-keyboard {
-  --accordion-white-key-width: 10.8rem;
-  --accordion-white-key-height: 2.05rem;
+  --accordion-white-key-width: min(100%, 13.25rem);
+  --accordion-white-key-height: 2.42rem;
   --accordion-white-key-gap: 0rem;
   --accordion-white-key-step: calc(var(--accordion-white-key-height) + var(--accordion-white-key-gap));
-  --accordion-black-key-width: 4.15rem;
-  --accordion-black-key-height: 1.08rem;
-  --accordion-black-key-offset: -0.22rem;
-  --accordion-keyboard-start-padding: 1.95rem;
-  --accordion-keyboard-top-padding: 0.22rem;
-  --accordion-keyboard-end-padding: 0.28rem;
-  --accordion-keyboard-bottom-padding: 0.22rem;
+  --accordion-black-key-width: 6.35rem;
+  --accordion-black-key-height: 1.42rem;
+  --accordion-black-key-offset: 0.48rem;
+  --accordion-keyboard-start-padding: 0.72rem;
+  --accordion-keyboard-top-padding: 0.38rem;
+  --accordion-keyboard-end-padding: 0.36rem;
+  --accordion-keyboard-bottom-padding: 0.38rem;
 
   position: relative;
   align-self: start;
   justify-self: center;
   box-sizing: border-box;
-  inline-size: fit-content;
+  inline-size: min(100%, calc(var(--accordion-white-key-width) + var(--accordion-keyboard-start-padding) + var(--accordion-keyboard-end-padding)));
   max-inline-size: 100%;
   min-width: 0;
   padding:
@@ -1652,18 +1673,18 @@
 
 .accordion-keyboard__white-keys {
   display: grid;
-  grid-template-columns: var(--accordion-white-key-width);
-  grid-template-rows: repeat(var(--accordion-white-key-count, 15), var(--accordion-white-key-height));
+  grid-template-columns: minmax(0, var(--accordion-white-key-width));
+  grid-template-rows: repeat(var(--accordion-white-key-count, 8), var(--accordion-white-key-height));
   gap: var(--accordion-white-key-gap) 0;
   inline-size: var(--accordion-white-key-width);
   min-width: 0;
   min-height: calc(
-    (var(--accordion-white-key-count, 15) * var(--accordion-white-key-height)) +
-      ((var(--accordion-white-key-count, 15) - 1) * var(--accordion-white-key-gap))
+    (var(--accordion-white-key-count, 8) * var(--accordion-white-key-height)) +
+      ((var(--accordion-white-key-count, 8) - 1) * var(--accordion-white-key-gap))
   );
   overflow: hidden;
   border: 1px solid color-mix(in srgb, var(--divider) 82%, transparent);
-  border-radius: 5px;
+  border-radius: 6px;
   background: color-mix(in srgb, white 94%, var(--panel-strong));
   box-shadow:
     inset 0 0 0 1px color-mix(in srgb, white 40%, transparent),
@@ -1676,8 +1697,8 @@
   inset-inline-start: var(--accordion-keyboard-start-padding);
   inline-size: var(--accordion-white-key-width);
   block-size: calc(
-    (var(--accordion-white-key-count, 15) * var(--accordion-white-key-height)) +
-      ((var(--accordion-white-key-count, 15) - 1) * var(--accordion-white-key-gap))
+    (var(--accordion-white-key-count, 8) * var(--accordion-white-key-height)) +
+      ((var(--accordion-white-key-count, 8) - 1) * var(--accordion-white-key-gap))
   );
   min-width: 0;
   pointer-events: none;
@@ -1692,26 +1713,32 @@
   box-sizing: border-box;
   min-width: 0;
   border: 0;
-  padding: 0.16rem 0.68rem 0.15rem calc(var(--accordion-black-key-width) + 0.52rem);
+  padding: 0.22rem 0.72rem 0.2rem calc(var(--accordion-black-key-width) + 0.9rem);
   color: var(--muted);
   font: inherit;
-  font-size: 0.74rem;
+  font-size: 0.76rem;
   font-weight: 900;
   line-height: 1.05;
   text-align: center;
 }
 
 .accordion-keyboard__key--white {
+  order: var(--accordion-white-index);
   inline-size: var(--accordion-white-key-width);
   block-size: var(--accordion-white-key-height);
   min-height: 0;
   border-radius: 0;
   border-bottom: 1px solid color-mix(in srgb, var(--divider) 72%, transparent);
   background:
-    linear-gradient(90deg, color-mix(in srgb, var(--divider) 45%, transparent) 0 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in srgb, var(--divider) 34%, transparent) 0 1px, transparent 1px),
+    linear-gradient(180deg, color-mix(in srgb, white 98%, var(--panel-strong)) 0%, color-mix(in srgb, white 88%, var(--panel-strong)) 100%),
     color-mix(in srgb, white 94%, var(--panel-strong));
   color: color-mix(in srgb, var(--text) 92%, black);
   box-shadow: none;
+}
+
+.accordion-keyboard__key--white:first-child {
+  border-bottom: 0;
 }
 
 .accordion-keyboard__key--black {
@@ -1727,15 +1754,17 @@
   block-size: var(--accordion-black-key-height);
   min-height: 0;
   border: 1px solid color-mix(in srgb, black 82%, var(--divider));
-  border-radius: 4px 4px 3px 3px;
+  border-radius: 0 5px 5px 0;
+  justify-items: center;
+  padding: 0.12rem 0.46rem;
   background:
     linear-gradient(180deg, color-mix(in srgb, white 10%, transparent), transparent 34%),
-    linear-gradient(90deg, color-mix(in srgb, black 86%, var(--panel-strong)), color-mix(in srgb, black 68%, var(--panel-strong)));
-  color: color-mix(in srgb, var(--text) 82%, white);
-  font-size: 0.56rem;
+    linear-gradient(90deg, color-mix(in srgb, black 88%, var(--panel-strong)), color-mix(in srgb, black 68%, var(--panel-strong)));
+  color: color-mix(in srgb, white 88%, var(--panel));
+  font-size: 0.64rem;
   box-shadow:
     inset 0 1px 0 color-mix(in srgb, white 10%, transparent),
-    0.16rem 0.12rem 0.2rem color-mix(in srgb, black 28%, transparent);
+    0.14rem 0.12rem 0.2rem color-mix(in srgb, black 28%, transparent);
   pointer-events: auto;
 }
 
@@ -1745,7 +1774,7 @@ span.accordion-keyboard__key--black {
 
 .accordion-keyboard__key--active-tone {
   border-color: color-mix(in srgb, var(--playback-accent) 72%, var(--divider));
-  background: linear-gradient(90deg, color-mix(in srgb, var(--playback-accent) 78%, white), color-mix(in srgb, var(--playback-accent) 58%, white));
+  background: linear-gradient(90deg, color-mix(in srgb, var(--playback-accent) 74%, white), color-mix(in srgb, var(--playback-accent) 56%, white));
   color: color-mix(in srgb, var(--panel) 92%, black);
   cursor: pointer;
   box-shadow:
@@ -1754,8 +1783,11 @@ span.accordion-keyboard__key--black {
 }
 
 .accordion-keyboard__key--black.accordion-keyboard__key--active-tone {
-  background: color-mix(in srgb, var(--playback-accent) 54%, black);
-  color: var(--text);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, white 14%, transparent), transparent 36%),
+    linear-gradient(90deg, color-mix(in srgb, var(--playback-accent) 76%, black), color-mix(in srgb, var(--playback-accent) 58%, black));
+  color: color-mix(in srgb, white 96%, var(--panel));
+  text-shadow: 0 1px 0 color-mix(in srgb, black 42%, transparent);
 }
 
 .accordion-keyboard__key--selected {
@@ -1769,6 +1801,7 @@ span.accordion-keyboard__key--black {
   display: block;
   max-width: 100%;
   overflow-wrap: anywhere;
+  text-wrap: balance;
 }
 
 .accordion-keyboard__key span {
@@ -1779,7 +1812,7 @@ span.accordion-keyboard__key--black {
 }
 
 .accordion-keyboard__key--black span {
-  font-size: 0.5rem;
+  font-size: 0.58rem;
 }
 
 .accordion-candidate-panel {
@@ -1826,7 +1859,19 @@ span.accordion-keyboard__key--black {
 }
 
 .accordion-candidate-card__title strong {
+  flex: 1 1 auto;
+  min-width: 0;
   color: var(--text);
+}
+
+.accordion-candidate-card__title .accordion-match-badge {
+  font-size: 0.68rem;
+  overflow-wrap: normal;
+  white-space: nowrap;
+}
+
+.accordion-candidate-card__title .accordion-match-badge--exact {
+  color: color-mix(in srgb, var(--playback-accent) 54%, var(--text));
 }
 
 .accordion-candidate-card__diff {
@@ -2125,11 +2170,12 @@ span.accordion-keyboard__key--black {
   }
 
   .accordion-keyboard {
-    --accordion-white-key-width: 8.9rem;
-    --accordion-white-key-height: 1.86rem;
-    --accordion-black-key-width: 3.55rem;
-    --accordion-black-key-height: 1rem;
-    --accordion-keyboard-start-padding: 1.7rem;
+    --accordion-white-key-width: min(100%, 11.25rem);
+    --accordion-white-key-height: 2.16rem;
+    --accordion-black-key-width: 5.35rem;
+    --accordion-black-key-height: 1.26rem;
+    --accordion-black-key-offset: 0.38rem;
+    --accordion-keyboard-start-padding: 0.58rem;
   }
 
   .chord-field-row,


### PR DESCRIPTION
## Summary

- Fix accordion Stradella 7th and diminished chord selection, including truthful missing/added tone reporting.
- Keep Dictionary accordion centered without project anchoring, while preserving Live Follow key/current-chord anchoring.
- Polish vertical right-hand keyboard rendering with generic piano landmark context for D/Eb/G/A/Ab/Bb/B edge cases.

Closes #288

## Testing

- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test -- --run --maxWorkers=2 --minWorkers=1`
- Product Design screenshot QA for accordion right-hand states: D, Eb, G, A, Ab, Bb, B
- Reviewer pass: no findings
- TuneForge contract guard: no backend/OpenAPI/shared-types drift
