### PR TITLE
feat: Add piano chord dictionary model

### DIFF
--- a/apps/desktop/src/App.tools-chord-dictionary.test.tsx
+++ b/apps/desktop/src/App.tools-chord-dictionary.test.tsx
@@ -40,11 +40,12 @@ function getDictionaryInstrumentSelector() {
   const instrumentSelector = instrumentGroups.find(
     (group) =>
       within(group).queryByRole("button", { name: "Guitar" }) ||
-      within(group).queryByRole("button", { name: "Accordion" }),
+      within(group).queryByRole("button", { name: "Accordion" }) ||
+      within(group).queryByRole("button", { name: "Piano" }),
   );
 
   if (!instrumentSelector) {
-    throw new Error("Expected a dictionary instrument selector with Guitar and Accordion choices");
+    throw new Error("Expected a dictionary instrument selector with Guitar, Accordion, and Piano choices");
   }
 
   return instrumentSelector as HTMLElement;
@@ -128,10 +129,39 @@ function getAccordionActiveKeyboardMidi(keyboard: HTMLElement) {
     .sort();
 }
 
+function getPianoKeyboard() {
+  const keyboard = document.querySelector('[data-instrument="piano"][data-surface="piano-keyboard"]');
+  if (!(keyboard instanceof HTMLElement)) {
+    throw new Error("Expected piano keyboard surface");
+  }
+  return keyboard;
+}
+
+function getPianoKeyByMidi(keyboard: HTMLElement, midi: number, color: "black" | "white") {
+  const key = keyboard.querySelector(`[data-midi="${midi}"][data-key-color="${color}"]`);
+  if (!(key instanceof HTMLElement)) {
+    throw new Error(`Expected ${color} piano key for MIDI ${midi}`);
+  }
+  return key;
+}
+
+function getPianoActiveKeyboardMidi(keyboard: HTMLElement) {
+  return [...keyboard.querySelectorAll<HTMLElement>(".piano-keyboard__key--active-tone")]
+    .map((key) => key.dataset.midi)
+    .sort();
+}
+
+function getPianoKeyboardMidiByColor(keyboard: HTMLElement, color: "black" | "white") {
+  return [...keyboard.querySelectorAll<HTMLElement>(`[data-key-color="${color}"]`)].map(
+    (key) => key.dataset.midi,
+  );
+}
+
 function expectAccordionInstrumentSelected() {
   const instrumentSelector = getDictionaryInstrumentSelector();
   const guitarButton = within(instrumentSelector).getByRole("button", { name: "Guitar" });
   const accordionButton = within(instrumentSelector).getByRole("button", { name: "Accordion" });
+  const pianoButton = within(instrumentSelector).getByRole("button", { name: "Piano" });
 
   expect(guitarButton).toHaveAttribute("aria-pressed", "false");
   expect(guitarButton).toHaveAttribute("data-selected", "false");
@@ -139,6 +169,25 @@ function expectAccordionInstrumentSelected() {
   expect(accordionButton).toHaveAttribute("aria-pressed", "true");
   expect(accordionButton).toHaveAttribute("data-selected", "true");
   expect(accordionButton).toHaveClass("chord-instrument-button--active");
+  expect(pianoButton).toHaveAttribute("aria-pressed", "false");
+  expect(pianoButton).toHaveAttribute("data-selected", "false");
+}
+
+function expectPianoInstrumentSelected() {
+  const instrumentSelector = getDictionaryInstrumentSelector();
+  const guitarButton = within(instrumentSelector).getByRole("button", { name: "Guitar" });
+  const accordionButton = within(instrumentSelector).getByRole("button", { name: "Accordion" });
+  const pianoButton = within(instrumentSelector).getByRole("button", { name: "Piano" });
+
+  expect(guitarButton).toHaveAttribute("aria-pressed", "false");
+  expect(guitarButton).toHaveAttribute("data-selected", "false");
+  expect(guitarButton).not.toHaveClass("chord-instrument-button--active");
+  expect(accordionButton).toHaveAttribute("aria-pressed", "false");
+  expect(accordionButton).toHaveAttribute("data-selected", "false");
+  expect(accordionButton).not.toHaveClass("chord-instrument-button--active");
+  expect(pianoButton).toHaveAttribute("aria-pressed", "true");
+  expect(pianoButton).toHaveAttribute("data-selected", "true");
+  expect(pianoButton).toHaveClass("chord-instrument-button--active");
 }
 
 async function selectAccordionDictionary() {
@@ -163,6 +212,28 @@ async function selectAccordionDictionary() {
     ),
   );
   expectAccordionInstrumentSelected();
+  return user;
+}
+
+async function selectPianoDictionary() {
+  const user = userEvent.setup();
+  await renderChordDictionary();
+
+  const instrumentSelector = getDictionaryInstrumentSelector();
+  expect(within(instrumentSelector).getByRole("button", { name: "Guitar" })).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+
+  await user.click(within(instrumentSelector).getByRole("button", { name: "Piano" }));
+
+  await waitFor(() =>
+    expect(within(getDictionaryInstrumentSelector()).getByRole("button", { name: "Piano" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    ),
+  );
+  expectPianoInstrumentSelected();
   return user;
 }
 
@@ -667,6 +738,9 @@ describe("Desktop app tools chord dictionary", () => {
     expect(
       within(instrumentSelector).getByRole("button", { name: "Accordion" }),
     ).toHaveAttribute("aria-pressed", "false");
+    expect(
+      within(instrumentSelector).getByRole("button", { name: "Piano" }),
+    ).toHaveAttribute("aria-pressed", "false");
     expectTextVisible("C E G");
     expect(
       screen.getAllByRole("button", { name: "C3 string 5 fret 3" }).length,
@@ -840,6 +914,101 @@ describe("Desktop app tools chord dictionary", () => {
     expect(eRightKey).toHaveTextContent("3");
     expect(gRightKey).toHaveTextContent("G4");
     expect(gRightKey).toHaveTextContent("5");
+  });
+
+  it("selects Piano and renders C major generated keys with octave labels", async () => {
+    await selectPianoDictionary();
+
+    expect(screen.getByRole("heading", { name: "C piano voicings" })).toBeInTheDocument();
+    expect(screen.getByText("A0-C8 range")).toBeInTheDocument();
+    expect(screen.getByText("Region C")).toBeInTheDocument();
+
+    const keyboard = getPianoKeyboard();
+    expect(keyboard).toHaveAttribute("data-layout", "compact-piano");
+    expect(keyboard).toHaveAttribute("data-surface", "piano-keyboard");
+    expect(Number(keyboard.style.getPropertyValue("--piano-white-key-count"))).toBe(15);
+    expect(getPianoKeyboardMidiByColor(keyboard, "white")).toHaveLength(15);
+    expect(getPianoKeyboardMidiByColor(keyboard, "black")).toHaveLength(10);
+    expect(getPianoActiveKeyboardMidi(keyboard)).toEqual(["60", "64", "67"]);
+
+    const cKey = getPianoKeyByMidi(keyboard, 60, "white");
+    const eKey = getPianoKeyByMidi(keyboard, 64, "white");
+    const gKey = getPianoKeyByMidi(keyboard, 67, "white");
+    expect(cKey).toHaveTextContent("C4");
+    expect(cKey).toHaveTextContent("1");
+    expect(eKey).toHaveTextContent("E4");
+    expect(eKey).toHaveTextContent("3");
+    expect(gKey).toHaveTextContent("G4");
+    expect(gKey).toHaveTextContent("5");
+    expectSelectedOrHighlighted(cKey);
+    expectSelectedOrHighlighted(eKey);
+    expectSelectedOrHighlighted(gKey);
+
+    expectInspectorToShow([
+      /Pitch\s*C4|C4/,
+      /Degree\s*1/,
+      /Hand hint\s*Right hand area|Right hand area/,
+      /not fingering/i,
+    ]);
+    expect(within(screen.getByLabelText("Note inspector")).queryByText(/^Finger$/i)).not.toBeInTheDocument();
+  });
+
+  it("switches Piano seventh-chord inversions without fake or empty key data", async () => {
+    const user = await selectPianoDictionary();
+
+    changeChordSearch("G7");
+
+    await screen.findByRole("heading", { name: "G7 piano voicings" });
+    const preferenceChoices = screen.getByRole("group", {
+      name: "Global piano voicing preference choices",
+    });
+    const preferenceButtons = within(preferenceChoices).getAllByRole("button");
+    expect(preferenceButtons.map((button) => button.textContent)).toEqual([
+      "G7 root position",
+      "G7 first inversion",
+      "G7 second inversion",
+      "G7 third inversion",
+    ]);
+    expect(preferenceButtons[0]).toHaveAttribute("aria-pressed", "true");
+
+    let keyboard = getPianoKeyboard();
+    expect(getPianoActiveKeyboardMidi(keyboard)).toEqual(["55", "59", "62", "65"]);
+    expect(getPianoKeyByMidi(keyboard, 55, "white")).toHaveTextContent("G3");
+    expect(getPianoKeyByMidi(keyboard, 59, "white")).toHaveTextContent("B3");
+    expect(getPianoKeyByMidi(keyboard, 62, "white")).toHaveTextContent("D4");
+    expect(getPianoKeyByMidi(keyboard, 65, "white")).toHaveTextContent("F4");
+    expect(screen.getByText("Chord tones")).toBeInTheDocument();
+    const voicingOrder = screen.getByLabelText("Current piano voicing order");
+    expect(within(voicingOrder).getByText("Voicing order")).toBeInTheDocument();
+    const voicingOrderItems = within(voicingOrder).getAllByRole("listitem");
+    expect(voicingOrderItems.map((item) => item.querySelector("strong")?.textContent)).toEqual([
+      "G3",
+      "B3",
+      "D4",
+      "F4",
+    ]);
+    expect(voicingOrderItems.map((item) => item.querySelector("small")?.textContent)).toEqual([
+      "1",
+      "3",
+      "5",
+      "b7",
+    ]);
+    expect(screen.queryByText(/Piano unavailable|No piano keyboard|returned no voicings/i)).not.toBeInTheDocument();
+
+    await user.click(within(preferenceChoices).getByRole("button", { name: "G7 first inversion" }));
+
+    await waitFor(() =>
+      expect(within(preferenceChoices).getByRole("button", { name: "G7 first inversion" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      ),
+    );
+    keyboard = getPianoKeyboard();
+    expect(getPianoActiveKeyboardMidi(keyboard)).toEqual(["59", "62", "65", "67"]);
+    expect(getPianoKeyByMidi(keyboard, 59, "white")).toHaveTextContent("B3");
+    expect(getPianoKeyByMidi(keyboard, 62, "white")).toHaveTextContent("D4");
+    expect(getPianoKeyByMidi(keyboard, 65, "white")).toHaveTextContent("F4");
+    expect(getPianoKeyByMidi(keyboard, 67, "white")).toHaveTextContent("G4");
   });
 
   it.each([
@@ -1765,6 +1934,43 @@ describe("Desktop app tools chord dictionary", () => {
     expect(screen.queryByRole("heading", { name: "C guitar shapes" })).not.toBeInTheDocument();
   });
 
+  it("renders piano voicings from Live Follow project chord context", async () => {
+    const user = userEvent.setup();
+    await renderChordDictionaryWithPlayback();
+
+    await user.click(within(getDictionaryInstrumentSelector()).getByRole("button", { name: "Piano" }));
+
+    await waitFor(() =>
+      expect(within(getDictionaryInstrumentSelector()).getByRole("button", { name: "Piano" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      ),
+    );
+    expectPianoInstrumentSelected();
+
+    const currentChord = screen.getByLabelText("Current chord");
+    expect(currentChord).toHaveTextContent(/Source chord\s*G/);
+    expect(currentChord).toHaveTextContent(/Display chord\s*A/);
+    expect(currentChord).toHaveTextContent(/Detected\/imported project chords/);
+    expect(currentChord).toHaveTextContent(/Playback source\s*Demo Song/);
+    expect(screen.getByRole("heading", { name: "A piano voicings" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Next chord")).toHaveTextContent(/E/);
+    expect(screen.getByText("Region A")).toBeInTheDocument();
+
+    const keyboard = getPianoKeyboard();
+    expect(getPianoActiveKeyboardMidi(keyboard)).toEqual(["57", "61", "64"]);
+    expect(getPianoKeyByMidi(keyboard, 57, "white")).toHaveTextContent("A3");
+    expect(getPianoKeyByMidi(keyboard, 61, "black")).toHaveTextContent("C#4");
+    expect(getPianoKeyByMidi(keyboard, 64, "white")).toHaveTextContent("E4");
+    expectInspectorToShow([/A3/, /Degree\s*1/, /Left hand area/, /not fingering/i]);
+    expect(screen.queryByRole("heading", { name: "A guitar shapes" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: /Left hand/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: /Right hand/i })).not.toBeInTheDocument();
+    expect(document.querySelector(".guitar-fretboard")).not.toBeInTheDocument();
+    expect(document.querySelector(".accordion-keyboard")).not.toBeInTheDocument();
+    expect(document.querySelector(".accordion-stradella")).not.toBeInTheDocument();
+  });
+
   it("renders out-of-window accordion roots in Live Follow without moving the key region", async () => {
     const user = userEvent.setup();
     await renderChordDictionaryWithPlayback({
@@ -2097,8 +2303,8 @@ describe("Desktop app tools chord dictionary", () => {
       within(instrumentSelector).getByRole("button", { name: "Accordion" }),
     ).toHaveAttribute("aria-pressed", "false");
     expect(
-      within(instrumentSelector).queryByRole("button", { name: "Piano" }),
-    ).not.toBeInTheDocument();
+      within(instrumentSelector).getByRole("button", { name: "Piano" }),
+    ).toHaveAttribute("aria-pressed", "false");
     expect(
       within(instrumentSelector).queryByRole("button", { name: "Organ" }),
     ).not.toBeInTheDocument();

--- a/apps/desktop/src/features/tools/ChordDictionaryPage.tsx
+++ b/apps/desktop/src/features/tools/ChordDictionaryPage.tsx
@@ -12,10 +12,12 @@ import {
   ACCORDION_STANDARD_PROFILE,
   CHORD_QUALITY_DEFINITIONS,
   GUITAR_STANDARD_PROFILE,
+  PIANO_STANDARD_PROFILE,
   formatKey,
   formatPitchClass,
   generateGuitarVoicings,
   generateAccordionVoicings,
+  generatePianoVoicings,
   midiToPitch,
   parsePitch,
   spellChord,
@@ -23,6 +25,8 @@ import {
   type ChordDisplayContext,
   type GuitarVoicing,
   type MusicalKey,
+  type PianoVoicing,
+  type PianoVoicingNote,
 } from "../../lib/music";
 import {
   buildChordDictionaryFollowContext,
@@ -43,7 +47,7 @@ import {
 } from "./chordDictionaryPreferences";
 
 type ChordDictionarySurface = "dictionary" | "follow";
-type ChordDictionaryInstrumentId = "guitar" | "accordion";
+type ChordDictionaryInstrumentId = "guitar" | "accordion" | "piano";
 type NotePoint = {
   degree: string;
   displayFret: number;
@@ -106,12 +110,41 @@ type AccordionKeyboardSlice = {
   keys: readonly AccordionKeyboardKeyView[];
   whiteKeyCount: number;
 };
+type PianoNoteView = {
+  degree: string;
+  handHint: PianoVoicingNote["handHint"];
+  id: string;
+  midi: number;
+  pitchLabel: string;
+};
+type PianoKeyboardKeyView = {
+  isBlack: boolean;
+  midi: number;
+  note: PianoNoteView | null;
+  pitchLabel: string;
+  whiteIndex: number;
+};
+type PianoKeyboardSlice = {
+  keys: readonly PianoKeyboardKeyView[];
+  whiteKeyCount: number;
+};
+type PianoVoicingView = {
+  chordLabel: string;
+  id: string;
+  inversion: PianoVoicing["inversion"];
+  keyboardSlice: PianoKeyboardSlice;
+  label: string;
+  notes: readonly PianoNoteView[];
+  rank: number;
+  regionRoot: PianoVoicing["regionRoot"];
+};
 type CompactKeyboardWindow = {
   endMidi: number;
   startMidi: number;
 };
 const COMPACT_KEYBOARD_C_FAMILY_END_PITCH_CLASS = 4;
 const COMPACT_KEYBOARD_F_FAMILY_END_PITCH_CLASS = 11;
+const PIANO_KEYBOARD_CONTEXT_SEMITONES = 24;
 type AccordionLeftHandCandidateView = {
   addedTones: readonly string[];
   buttons: readonly AccordionButtonView[];
@@ -203,9 +236,11 @@ type GuitarShape = {
 const COMMON_CHORD_LABELS = ["C", "Dm", "Em", "F", "G", "Am", "Bdim"] as const;
 const GUITAR_INSTRUMENT_ID = GUITAR_STANDARD_PROFILE.id;
 const ACCORDION_INSTRUMENT_ID = ACCORDION_STANDARD_PROFILE.id;
+const PIANO_INSTRUMENT_ID = PIANO_STANDARD_PROFILE.id;
 const CHORD_DICTIONARY_INSTRUMENTS = [
   { id: GUITAR_INSTRUMENT_ID, label: GUITAR_STANDARD_PROFILE.label },
   { id: ACCORDION_INSTRUMENT_ID, label: ACCORDION_STANDARD_PROFILE.label },
+  { id: PIANO_INSTRUMENT_ID, label: PIANO_STANDARD_PROFILE.label },
 ] as const satisfies ReadonlyArray<{ id: ChordDictionaryInstrumentId; label: string }>;
 const ACCORDION_STRADDELLA_ROWS = [
   { id: "diminished", label: "Dim" },
@@ -405,11 +440,14 @@ function DictionarySurface({
   const [activeChord, setActiveChord] = useState("C");
   const [activeShape, setActiveShape] = useState<string | null>(null);
   const [activeAccordionVoicing, setActiveAccordionVoicing] = useState<string | null>(null);
+  const [activePianoVoicing, setActivePianoVoicing] = useState<string | null>(null);
   const [activeAccordionCandidate, setActiveAccordionCandidate] = useState<string | null>(null);
   const [previewAccordionPointId, setPreviewAccordionPointId] = useState<string | null>(null);
+  const [previewPianoNoteId, setPreviewPianoNoteId] = useState<string | null>(null);
   const [previewNoteId, setPreviewNoteId] = useState<string | null>(null);
   const [, setPreferenceRevision] = useState(0);
   const [selectedAccordionPointId, setSelectedAccordionPointId] = useState<string | null>(null);
+  const [selectedPianoNoteId, setSelectedPianoNoteId] = useState<string | null>(null);
   const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
   const displayContext = useMemo<Partial<ChordDisplayContext>>(
     () => ({
@@ -607,6 +645,75 @@ function DictionarySurface({
     : null;
   const displayedAccordionPoint = previewAccordionPoint ?? selectedAccordionPoint;
   const activeAccordionPointId = previewAccordionPoint?.id ?? selectedAccordionPoint?.id ?? null;
+  const pianoVoicings = useMemo(
+    () => (chordSpelling ? generatePianoVoicings(chordSpelling) : []),
+    [chordSpelling],
+  );
+  const generatedPianoVoicingViews = useMemo(
+    () => toPianoVoicingViews(pianoVoicings),
+    [pianoVoicings],
+  );
+  const generatedPianoVoicingIds = useMemo(
+    () => generatedPianoVoicingViews.map((voicing) => voicing.id),
+    [generatedPianoVoicingViews],
+  );
+  const pianoPreferenceContext = useMemo(
+    () =>
+      chordSpelling
+        ? buildShapePreferenceContext({
+            capoFret: null,
+            chordLabel: chordSpelling.label,
+            displayedKey: null,
+            instrumentId: PIANO_INSTRUMENT_ID,
+            projectId: null,
+            sourceKey: null,
+            transposeSemitones: null,
+            useCapoShapes: null,
+          })
+        : null,
+    [chordSpelling],
+  );
+  const preferredPianoVoicingId = resolveChordDictionaryPreferredShapeId(
+    pianoPreferenceContext,
+    generatedPianoVoicingIds,
+  );
+  const hasGlobalPianoPreference = hasGlobalChordDictionaryPreferredShape(
+    pianoPreferenceContext,
+    generatedPianoVoicingIds,
+  );
+  const pianoVoicingViews = useMemo(
+    () => promoteShapeToFirst(generatedPianoVoicingViews, preferredPianoVoicingId),
+    [generatedPianoVoicingViews, preferredPianoVoicingId],
+  );
+  const pianoResultKey = pianoVoicingViews.map((voicing) => voicing.id).join("|");
+  const firstPianoVoicingId = pianoVoicingViews[0]?.id ?? null;
+  const firstPianoNoteId = pianoVoicingViews[0]?.notes[0]?.id ?? null;
+  const selectPianoVoicing = (voicing: PianoVoicingView) => {
+    writeGlobalChordDictionaryPreferredShape(pianoPreferenceContext, voicing.id);
+    bumpPreferenceRevision();
+    setActivePianoVoicing(voicing.id);
+    setPreviewPianoNoteId(null);
+    setSelectedPianoNoteId(voicing.notes[0]?.id ?? null);
+  };
+  useEffect(() => {
+    setActivePianoVoicing(firstPianoVoicingId);
+    setPreviewPianoNoteId(null);
+    setSelectedPianoNoteId(firstPianoNoteId);
+  }, [firstPianoNoteId, firstPianoVoicingId, pianoResultKey]);
+  const selectedPianoVoicing =
+    pianoVoicingViews.find((voicing) => voicing.id === activePianoVoicing) ??
+    pianoVoicingViews[0] ??
+    null;
+  const selectedPianoNote =
+    selectedPianoVoicing?.notes.find((note) => note.id === selectedPianoNoteId) ??
+    selectedPianoVoicing?.notes[0] ??
+    null;
+  const previewPianoNote =
+    previewPianoNoteId && selectedPianoVoicing
+      ? selectedPianoVoicing.notes.find((note) => note.id === previewPianoNoteId) ?? null
+      : null;
+  const displayedPianoNote = previewPianoNote ?? selectedPianoNote;
+  const activePianoNoteId = previewPianoNote?.id ?? selectedPianoNote?.id ?? null;
   const sourceKeyLabel = displayContext.sourceKey
     ? formatKey(displayContext.sourceKey, "long")
     : "No source key";
@@ -626,6 +733,7 @@ function DictionarySurface({
               setActiveChord(event.currentTarget.value);
               setPreviewNoteId(null);
               setPreviewAccordionPointId(null);
+              setPreviewPianoNoteId(null);
             }}
             placeholder="C major"
             value={activeChord}
@@ -642,13 +750,33 @@ function DictionarySurface({
         <div className="chord-dictionary-status" role="status">
           <strong>{activeChord}</strong>
           <span>
-            Unsupported chord symbol. No backed spelling or{" "}
-            {instrumentId === ACCORDION_INSTRUMENT_ID ? "accordion voicings" : "guitar voicings"} available.
+            Unsupported chord symbol. No backed spelling or {getChordDictionaryInstrumentLabel(instrumentId).toLowerCase()} voicings available.
           </span>
         </div>
       ) : null}
 
-      {instrumentId === ACCORDION_INSTRUMENT_ID ? (
+      {instrumentId === PIANO_INSTRUMENT_ID ? (
+        <PianoDictionaryContent
+          activeChord={activeChord}
+          activeNoteId={activePianoNoteId}
+          chordSpelling={chordSpelling}
+          displayedNote={displayedPianoNote}
+          hasGlobalPreference={hasGlobalPianoPreference}
+          selectedVoicing={selectedPianoVoicing}
+          unsupportedChord={unsupportedChord}
+          voicings={pianoVoicingViews}
+          onClearPreference={() => {
+            resetGlobalChordDictionaryPreferredShape(pianoPreferenceContext);
+            bumpPreferenceRevision();
+          }}
+          onPreviewNote={setPreviewPianoNoteId}
+          onSelectNote={(noteId) => {
+            setPreviewPianoNoteId(null);
+            setSelectedPianoNoteId(noteId);
+          }}
+          onSelectVoicing={selectPianoVoicing}
+        />
+      ) : instrumentId === ACCORDION_INSTRUMENT_ID ? (
         <AccordionDictionaryContent
           activePointId={activeAccordionPointId}
           activeChord={activeChord}
@@ -943,6 +1071,396 @@ function InstrumentSelector({
         </button>
       ))}
     </div>
+  );
+}
+
+function PianoDictionaryContent({
+  activeChord,
+  activeNoteId,
+  chordSpelling,
+  displayedNote,
+  hasGlobalPreference,
+  onClearPreference,
+  onPreviewNote,
+  onSelectNote,
+  onSelectVoicing,
+  selectedVoicing,
+  unsupportedChord,
+  voicings,
+}: {
+  activeChord: string;
+  activeNoteId: string | null;
+  chordSpelling: NonNullable<ReturnType<typeof spellChord>> | null;
+  displayedNote: PianoNoteView | null;
+  hasGlobalPreference: boolean;
+  selectedVoicing: PianoVoicingView | null;
+  unsupportedChord: boolean;
+  voicings: readonly PianoVoicingView[];
+  onClearPreference: () => void;
+  onPreviewNote: (noteId: string | null) => void;
+  onSelectNote: (noteId: string) => void;
+  onSelectVoicing: (voicing: PianoVoicingView) => void;
+}) {
+  const soundLabel = chordSpelling?.label ?? "No supported chord";
+  const rangeLabel = formatPianoRange(PIANO_STANDARD_PROFILE);
+  const regionLabel = selectedVoicing?.regionRoot.note
+    ? `Region ${selectedVoicing.regionRoot.note}`
+    : "No key region";
+
+  return (
+    <>
+      <div className="chord-context-strip" aria-label="Piano display context">
+        <ContextChip icon="instrument" label={PIANO_STANDARD_PROFILE.label} />
+        <ContextChip icon="shape" label={`${rangeLabel} range`} />
+        <ContextChip icon="key" label={regionLabel} />
+        <ContextChip icon="sound" label={soundLabel} />
+      </div>
+
+      {!chordSpelling || unsupportedChord ? (
+        <EmptyDictionaryState
+          title="Unsupported chord"
+          copy="No spelling, piano keyboard, or note inspector data shown for this search."
+        />
+      ) : voicings.length === 0 || !selectedVoicing ? (
+        <EmptyDictionaryState
+          title={`Piano unavailable for ${chordSpelling.label}`}
+          copy="Chord spelling is supported, but the piano generator returned no voicings."
+        />
+      ) : (
+        <div className="piano-tool-grid">
+          <main className="piano-tool-main">
+            <section className="chord-section" aria-label={`${chordSpelling.label} piano voicings`}>
+              <div className="chord-section-heading chord-section-heading--inline">
+                <div>
+                  <p className="metric-label">{chordSpelling.notes.join(" ")}</p>
+                  <h3>{chordSpelling.label} piano voicings</h3>
+                </div>
+                <div className="chord-shape-controls chord-shape-controls--piano">
+                  <div className="chord-shape-control-row">
+                    <div
+                      aria-describedby="piano-voicing-preference-copy"
+                      aria-label="Global piano voicing preference choices"
+                      className="chord-shape-tabs"
+                      role="group"
+                    >
+                      {voicings.map((voicing) => (
+                        <button
+                          key={voicing.id}
+                          aria-pressed={selectedVoicing.id === voicing.id}
+                          className={classNames(
+                            "chord-shape-tab",
+                            selectedVoicing.id === voicing.id && "chord-shape-tab--active",
+                          )}
+                          onClick={() => onSelectVoicing(voicing)}
+                          type="button"
+                        >
+                          {voicing.label}
+                        </button>
+                      ))}
+                    </div>
+                    {hasGlobalPreference ? (
+                      <button
+                        aria-label="Clear this chord/instrument global preference"
+                        className="chord-reset-button"
+                        onClick={onClearPreference}
+                        type="button"
+                      >
+                        Clear global preference
+                      </button>
+                    ) : null}
+                  </div>
+                  <p className="chord-shape-preference-copy" id="piano-voicing-preference-copy">
+                    Saves locally as global for this chord and instrument.
+                  </p>
+                </div>
+              </div>
+              <ChordSpellingSummary spelling={chordSpelling} />
+              <PianoVoicingPanel
+                activeChord={activeChord}
+                activeNoteId={activeNoteId}
+                voicing={selectedVoicing}
+                onPreviewNote={onPreviewNote}
+                onSelectNote={onSelectNote}
+              />
+            </section>
+          </main>
+
+          <aside className="piano-tool-sidebar">
+            {displayedNote ? <PianoNoteInspector note={displayedNote} /> : null}
+            <PianoInstrumentFacts
+              chordLabel={chordSpelling.label}
+              selectedVoicing={selectedVoicing}
+              voicingCount={voicings.length}
+            />
+          </aside>
+        </div>
+      )}
+    </>
+  );
+}
+
+function PianoVoicingPanel({
+  activeChord,
+  activeNoteId,
+  onPreviewNote,
+  onSelectNote,
+  voicing,
+}: {
+  activeChord: string;
+  activeNoteId: string | null;
+  voicing: PianoVoicingView;
+  onPreviewNote: (noteId: string | null) => void;
+  onSelectNote: (noteId: string) => void;
+}) {
+  return (
+    <section
+      className="piano-position-card"
+      aria-label={`${voicing.label} piano voicing`}
+      data-instrument="piano"
+      role="group"
+    >
+      <div className="piano-position-card__heading">
+        <div>
+          <h4>{voicing.inversion.label}</h4>
+          <span>{formatCount(voicing.notes.length, "generated key")}</span>
+        </div>
+        <span className="accordion-match-badge accordion-match-badge--exact">
+          {voicing.regionRoot.note} region
+        </span>
+      </div>
+      <PianoVoicingOrder notes={voicing.notes} />
+      {voicing.keyboardSlice.keys.length > 0 ? (
+        <PianoKeyboard
+          activeChord={activeChord}
+          activeNoteId={activeNoteId}
+          slice={voicing.keyboardSlice}
+          onPreviewNote={onPreviewNote}
+          onSelectNote={onSelectNote}
+        />
+      ) : (
+        <EmptyDictionaryState
+          title="No piano keyboard"
+          copy="Piano data did not include generated pitch keys for this voicing."
+        />
+      )}
+    </section>
+  );
+}
+
+function PianoVoicingOrder({ notes }: { notes: readonly PianoNoteView[] }) {
+  return (
+    <div className="piano-voicing-order" aria-label="Current piano voicing order">
+      <span className="piano-voicing-order__label">Voicing order</span>
+      <ol>
+        {notes.map((note) => (
+          <li key={note.id}>
+            <strong>{note.pitchLabel}</strong>
+            <small>{note.degree}</small>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+function PianoKeyboard({
+  activeChord,
+  activeNoteId,
+  onPreviewNote,
+  onSelectNote,
+  slice,
+}: {
+  activeChord: string;
+  activeNoteId: string | null;
+  slice: PianoKeyboardSlice;
+  onPreviewNote: (noteId: string | null) => void;
+  onSelectNote: (noteId: string) => void;
+}) {
+  const whiteKeys = slice.keys.filter((key) => !key.isBlack);
+  const blackKeys = slice.keys.filter((key) => key.isBlack);
+
+  return (
+    <div
+      className="piano-keyboard"
+      data-instrument="piano"
+      data-layout="compact-piano"
+      data-surface="piano-keyboard"
+      style={{ "--piano-white-key-count": slice.whiteKeyCount } as CSSProperties}
+      aria-label={`${activeChord} piano keyboard`}
+      role="group"
+    >
+      <div className="piano-keyboard__white-keys">
+        {whiteKeys.map((key) => (
+          <PianoKeyboardKey
+            key={key.midi}
+            activeNoteId={activeNoteId}
+            keyView={key}
+            onPreviewNote={onPreviewNote}
+            onSelectNote={onSelectNote}
+          />
+        ))}
+      </div>
+      <div className="piano-keyboard__black-keys" aria-hidden={blackKeys.length === 0 ? "true" : undefined}>
+        {blackKeys.map((key) => (
+          <PianoKeyboardKey
+            key={key.midi}
+            activeNoteId={activeNoteId}
+            keyView={key}
+            onPreviewNote={onPreviewNote}
+            onSelectNote={onSelectNote}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function PianoKeyboardKey({
+  activeNoteId,
+  keyView,
+  onPreviewNote,
+  onSelectNote,
+}: {
+  activeNoteId: string | null;
+  keyView: PianoKeyboardKeyView;
+  onPreviewNote: (noteId: string | null) => void;
+  onSelectNote: (noteId: string) => void;
+}) {
+  const note = keyView.note;
+  const className = classNames(
+    "piano-keyboard__key",
+    keyView.isBlack ? "piano-keyboard__key--black" : "piano-keyboard__key--white",
+    note && "piano-keyboard__key--active-tone",
+    note?.id === activeNoteId && "piano-keyboard__key--selected",
+  );
+  const style = { "--piano-white-index": keyView.whiteIndex } as CSSProperties;
+
+  if (!note) {
+    return (
+      <span
+        aria-hidden="true"
+        className={className}
+        data-key-color={keyView.isBlack ? "black" : "white"}
+        data-midi={keyView.midi}
+        data-pitch-label={keyView.pitchLabel}
+        style={style}
+      />
+    );
+  }
+
+  return (
+    <button
+      aria-label={`${note.pitchLabel} degree ${note.degree} piano key`}
+      className={className}
+      data-degree={note.degree}
+      data-hand-hint={note.handHint}
+      data-key-color={keyView.isBlack ? "black" : "white"}
+      data-midi={keyView.midi}
+      data-pitch-label={note.pitchLabel}
+      onBlur={() => onPreviewNote(null)}
+      onClick={() => onSelectNote(note.id)}
+      onFocus={() => onPreviewNote(note.id)}
+      onPointerEnter={() => onPreviewNote(note.id)}
+      onPointerLeave={() => onPreviewNote(null)}
+      style={style}
+      title={note.pitchLabel}
+      type="button"
+    >
+      <strong>{note.pitchLabel}</strong>
+      <span>{note.degree}</span>
+    </button>
+  );
+}
+
+function PianoNoteInspector({ note }: { note: PianoNoteView }) {
+  return (
+    <section className="note-inspector piano-note-inspector" aria-label="Note inspector">
+      <div className="note-inspector__badge">
+        <strong>{note.pitchLabel}</strong>
+        <span>{note.degree}</span>
+      </div>
+      <div className="piano-note-inspector__body">
+        <dl>
+          <div>
+            <dt>Pitch</dt>
+            <dd>{note.pitchLabel}</dd>
+          </div>
+          <div>
+            <dt>Degree</dt>
+            <dd>{note.degree}</dd>
+          </div>
+          <div>
+            <dt>Hand hint</dt>
+            <dd>{formatPianoHandHint(note.handHint)}</dd>
+          </div>
+          <div>
+            <dt>Source</dt>
+            <dd>Generated pitch data</dd>
+          </div>
+        </dl>
+        <p>Hand hints describe keyboard area only, not fingering.</p>
+      </div>
+    </section>
+  );
+}
+
+function PianoInstrumentFacts({
+  chordLabel,
+  selectedVoicing,
+  voicingCount,
+}: {
+  chordLabel: string;
+  selectedVoicing: PianoVoicingView;
+  voicingCount: number;
+}) {
+  return (
+    <section className="piano-facts-panel" aria-label="Piano instrument facts">
+      <div className="chord-understanding-panel__header">
+        <div>
+          <p className="metric-label">Instrument</p>
+          <h3>{PIANO_STANDARD_PROFILE.label}</h3>
+        </div>
+        <SlidersHorizontal aria-hidden="true" />
+      </div>
+      <dl className="chord-fact-list">
+        <div>
+          <dt>Range</dt>
+          <dd>{formatPianoRange(PIANO_STANDARD_PROFILE)}</dd>
+        </div>
+        <div>
+          <dt>Keys</dt>
+          <dd>{formatCount(PIANO_STANDARD_PROFILE.keyboard.keyCount, "key")}</dd>
+        </div>
+        <div>
+          <dt>Region</dt>
+          <dd>{selectedVoicing.regionRoot.note}</dd>
+        </div>
+        <div>
+          <dt>Surface</dt>
+          <dd>88-key keyboard</dd>
+        </div>
+      </dl>
+      <div className="chord-accordion-list">
+        <div className="chord-accordion-row chord-accordion-row--static">
+          <span>
+            <strong>{formatCount(voicingCount, "voicing")}</strong>
+            <small>{chordLabel}</small>
+          </span>
+        </div>
+        <div className="chord-accordion-row chord-accordion-row--static">
+          <span>
+            <strong>{selectedVoicing.inversion.label}</strong>
+            <small>Bass degree {selectedVoicing.inversion.bassDegree}</small>
+          </span>
+        </div>
+        <div className="chord-accordion-row chord-accordion-row--static">
+          <span>
+            <strong>Hand hints</strong>
+            <small>Assistive keyboard areas, not fingering</small>
+          </span>
+        </div>
+      </div>
+    </section>
   );
 }
 
@@ -1493,6 +2011,81 @@ function toGuitarShape(voicing: GuitarVoicing, profile: typeof GUITAR_STANDARD_P
   };
 }
 
+function toPianoVoicingViews(voicings: readonly PianoVoicing[]): readonly PianoVoicingView[] {
+  return voicings.flatMap((voicing): PianoVoicingView[] => {
+    const notes = voicing.notes.map((note) => toPianoNoteView(note, voicing.id));
+    if (notes.length === 0) {
+      return [];
+    }
+
+    return [
+      {
+        chordLabel: voicing.chordLabel,
+        id: voicing.id,
+        inversion: voicing.inversion,
+        keyboardSlice: buildPianoKeyboardSlice(notes),
+        label: voicing.label,
+        notes,
+        rank: voicing.rank,
+        regionRoot: voicing.regionRoot,
+      },
+    ];
+  });
+}
+
+function toPianoNoteView(note: PianoVoicingNote, voicingId: string): PianoNoteView {
+  return {
+    degree: note.degree,
+    handHint: note.handHint,
+    id: `${voicingId}-${note.id}`,
+    midi: note.pitch.midi,
+    pitchLabel: note.pitch.label,
+  };
+}
+
+function buildPianoKeyboardSlice(notes: readonly PianoNoteView[]): PianoKeyboardSlice {
+  if (notes.length === 0) {
+    return { keys: [], whiteKeyCount: 0 };
+  }
+
+  const noteByMidi = new Map(notes.map((note) => [note.midi, note]));
+  const window = buildPianoKeyboardWindow(notes.map((note) => note.midi));
+  if (!window) {
+    return { keys: [], whiteKeyCount: 0 };
+  }
+
+  const keysByPitch: Array<
+    Omit<PianoKeyboardKeyView, "whiteIndex"> & {
+      lowerWhiteIndex: number;
+      whiteAscendingIndex: number | null;
+    }
+  > = [];
+  let whiteIndex = 0;
+  for (let midi = window.startMidi; midi <= window.endMidi; midi += 1) {
+    const pitch = midiToPitch(midi);
+    const isBlack = isBlackPianoKey(midi);
+    keysByPitch.push({
+      isBlack,
+      lowerWhiteIndex: isBlack ? Math.max(0, whiteIndex - 1) : whiteIndex,
+      midi,
+      note: noteByMidi.get(midi) ?? null,
+      pitchLabel: pitch?.label ?? `MIDI ${midi}`,
+      whiteAscendingIndex: isBlack ? null : whiteIndex,
+    });
+    if (!isBlack) {
+      whiteIndex += 1;
+    }
+  }
+
+  const whiteKeyCount = whiteIndex;
+  const keys = keysByPitch.map(({ lowerWhiteIndex, whiteAscendingIndex, ...key }) => ({
+    ...key,
+    whiteIndex: key.isBlack ? lowerWhiteIndex : whiteAscendingIndex ?? 0,
+  }));
+
+  return { keys, whiteKeyCount };
+}
+
 function toAccordionVoicingViews(voicings: readonly AccordionVoicing[]): readonly AccordionVoicingView[] {
   return voicings.flatMap((voicing, voicingIndex): AccordionVoicingView[] => {
     const record = asUnknownRecord(voicing);
@@ -1882,6 +2475,44 @@ function buildCompactKeyboardWindow(activeMidis: readonly number[]): CompactKeyb
   };
 }
 
+function buildPianoKeyboardWindow(activeMidis: readonly number[]): CompactKeyboardWindow | null {
+  if (activeMidis.length === 0) {
+    return null;
+  }
+
+  const lowestActiveMidi = Math.min(...activeMidis);
+  const highestActiveMidi = Math.max(...activeMidis);
+  const lowestKeyboardMidi = PIANO_STANDARD_PROFILE.keyboard.lowestPitch.midi;
+  const highestKeyboardMidi = PIANO_STANDARD_PROFILE.keyboard.highestPitch.midi;
+  const activeMidpoint = (lowestActiveMidi + highestActiveMidi) / 2;
+  let startMidi = findNearestWhiteKeyAtOrBelow(
+    Math.floor(activeMidpoint - PIANO_KEYBOARD_CONTEXT_SEMITONES / 2),
+  );
+  let endMidi = findNearestWhiteKeyAtOrAbove(startMidi + PIANO_KEYBOARD_CONTEXT_SEMITONES);
+
+  if (startMidi < lowestKeyboardMidi) {
+    startMidi = findNearestWhiteKeyAtOrAbove(lowestKeyboardMidi);
+    endMidi = findNearestWhiteKeyAtOrAbove(startMidi + PIANO_KEYBOARD_CONTEXT_SEMITONES);
+  }
+
+  if (endMidi > highestKeyboardMidi) {
+    endMidi = findNearestWhiteKeyAtOrBelow(highestKeyboardMidi);
+    startMidi = findNearestWhiteKeyAtOrBelow(endMidi - PIANO_KEYBOARD_CONTEXT_SEMITONES);
+  }
+
+  if (lowestActiveMidi < startMidi) {
+    startMidi = findNearestWhiteKeyAtOrBelow(lowestActiveMidi);
+  }
+  if (highestActiveMidi > endMidi) {
+    endMidi = findNearestWhiteKeyAtOrAbove(highestActiveMidi);
+  }
+
+  return {
+    startMidi: Math.max(startMidi, lowestKeyboardMidi),
+    endMidi: Math.min(endMidi, highestKeyboardMidi),
+  };
+}
+
 function findCompactKeyboardWindowStartMidi(lowestActiveMidi: number): number {
   return getCompactKeyboardFamilyStartMidi(lowestActiveMidi);
 }
@@ -1926,6 +2557,14 @@ function findNearestWhiteKeyAtOrAbove(midi: number): number {
   let keyMidi = midi;
   while (isBlackPianoKey(keyMidi)) {
     keyMidi += 1;
+  }
+  return keyMidi;
+}
+
+function findNearestWhiteKeyAtOrBelow(midi: number): number {
+  let keyMidi = midi;
+  while (isBlackPianoKey(keyMidi)) {
+    keyMidi -= 1;
   }
   return keyMidi;
 }
@@ -2767,7 +3406,13 @@ function LiveFollowSurface({
     );
   }
 
-  return instrumentId === ACCORDION_INSTRUMENT_ID ? (
+  return instrumentId === PIANO_INSTRUMENT_ID ? (
+    <LiveFollowPianoActiveState
+      context={context}
+      instrumentId={instrumentId}
+      onInstrumentChange={onInstrumentChange}
+    />
+  ) : instrumentId === ACCORDION_INSTRUMENT_ID ? (
     <LiveFollowAccordionActiveState
       context={context}
       instrumentId={instrumentId}
@@ -2779,6 +3424,305 @@ function LiveFollowSurface({
       instrumentId={instrumentId}
       onInstrumentChange={onInstrumentChange}
     />
+  );
+}
+
+function LiveFollowPianoActiveState({
+  context,
+  instrumentId,
+  onInstrumentChange,
+}: {
+  context: ChordDictionaryFollowContext;
+  instrumentId: ChordDictionaryInstrumentId;
+  onInstrumentChange: (instrumentId: ChordDictionaryInstrumentId) => void;
+}) {
+  const currentChord = context.currentChord;
+  const project = context.project;
+  const [activeVoicing, setActiveVoicing] = useState<string | null>(null);
+  const [previewNoteId, setPreviewNoteId] = useState<string | null>(null);
+  const [, setPreferenceRevision] = useState(0);
+  const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
+  const chordSpelling = useMemo(
+    () =>
+      currentChord
+        ? spellChord(currentChord.displayLabel, {
+            activeKey: project?.displayedKey ?? undefined,
+          })
+        : null,
+    [currentChord, project?.displayedKey],
+  );
+  const pianoVoicings = useMemo(
+    () =>
+      chordSpelling
+        ? generatePianoVoicings(
+            chordSpelling,
+            {
+              activeKey: project?.displayedKey ?? null,
+              currentChordRoot: currentChord?.displayLabel ?? null,
+              regionKey: project?.displayedKey ?? null,
+            },
+            project?.displayedKey ? { activeKey: project.displayedKey } : {},
+          )
+        : [],
+    [chordSpelling, currentChord?.displayLabel, project?.displayedKey],
+  );
+  const generatedVoicingViews = useMemo(
+    () => toPianoVoicingViews(pianoVoicings),
+    [pianoVoicings],
+  );
+  const generatedVoicingIds = useMemo(
+    () => generatedVoicingViews.map((voicing) => voicing.id),
+    [generatedVoicingViews],
+  );
+  const preferenceContext = useMemo(
+    () =>
+      chordSpelling
+        ? buildShapePreferenceContext({
+            capoFret: null,
+            chordLabel: chordSpelling.label,
+            displayedKey: project?.displayedKey ?? null,
+            instrumentId: PIANO_INSTRUMENT_ID,
+            projectId: project?.projectId ?? null,
+            sourceKey: project?.sourceKey ?? null,
+            transposeSemitones: project?.totalDisplayTransposeSemitones ?? null,
+            useCapoShapes: null,
+          })
+        : null,
+    [
+      chordSpelling,
+      project?.displayedKey,
+      project?.projectId,
+      project?.sourceKey,
+      project?.totalDisplayTransposeSemitones,
+    ],
+  );
+  const preferredVoicingId = resolveChordDictionaryPreferredShapeId(
+    preferenceContext,
+    generatedVoicingIds,
+  );
+  const hasProjectPreference = hasProjectChordDictionaryPreferredShape(
+    preferenceContext,
+    generatedVoicingIds,
+  );
+  const voicingViews = useMemo(
+    () => promoteShapeToFirst(generatedVoicingViews, preferredVoicingId),
+    [generatedVoicingViews, preferredVoicingId],
+  );
+  const resultKey = voicingViews.map((voicing) => voicing.id).join("|");
+  const firstVoicingId = voicingViews[0]?.id ?? null;
+  const firstNoteId = voicingViews[0]?.notes[0]?.id ?? null;
+  const bumpPreferenceRevision = () => setPreferenceRevision((revision) => revision + 1);
+  const selectVoicing = (voicing: PianoVoicingView) => {
+    writeProjectChordDictionaryPreferredShape(preferenceContext, voicing.id);
+    bumpPreferenceRevision();
+    setActiveVoicing(voicing.id);
+    setPreviewNoteId(null);
+    setSelectedNoteId(voicing.notes[0]?.id ?? null);
+  };
+
+  useEffect(() => {
+    setActiveVoicing(firstVoicingId);
+    setPreviewNoteId(null);
+    setSelectedNoteId(firstNoteId);
+  }, [currentChord?.displayLabel, firstNoteId, firstVoicingId, resultKey]);
+
+  if (!currentChord || !project) {
+    return (
+      <div className="live-follow-page live-follow-page--waiting" data-follow-status="no-project">
+        <LiveFollowTopbar
+          context={context}
+          instrumentId={instrumentId}
+          statusLabel="No Project"
+          onInstrumentChange={onInstrumentChange}
+        />
+        <LiveFollowStatusCard context={context} requestedProjectId={null} />
+      </div>
+    );
+  }
+
+  if (!chordSpelling) {
+    return (
+      <LiveFollowChordIssue
+        context={context}
+        copy="The project timeline chord cannot be parsed by the chord dictionary, so no piano voicing or note inspector is shown."
+        instrumentId={instrumentId}
+        statusLabel="Unsupported"
+        title={`Unsupported chord: ${currentChord.displayLabel}`}
+        onInstrumentChange={onInstrumentChange}
+      />
+    );
+  }
+
+  if (voicingViews.length === 0) {
+    return (
+      <LiveFollowChordIssue
+        context={context}
+        copy="Chord spelling is supported, but the piano generator returned no voicings for this chord."
+        instrumentId={instrumentId}
+        statusLabel="No Voicing"
+        title={`Piano unavailable for ${chordSpelling.label}`}
+        onInstrumentChange={onInstrumentChange}
+      />
+    );
+  }
+
+  const selectedVoicing =
+    voicingViews.find((voicing) => voicing.id === activeVoicing) ?? voicingViews[0] ?? null;
+  if (!selectedVoicing) {
+    return null;
+  }
+
+  const selectedNote =
+    selectedVoicing.notes.find((note) => note.id === selectedNoteId) ??
+    selectedVoicing.notes[0] ??
+    null;
+  const previewNote = previewNoteId
+    ? selectedVoicing.notes.find((note) => note.id === previewNoteId) ?? null
+    : null;
+  const displayedNote = previewNote ?? selectedNote;
+  const activeNoteId = previewNote?.id ?? selectedNote?.id ?? null;
+  const playbackSourceLabel = formatPlaybackProjectLabel(project.projectName);
+
+  return (
+    <div className="live-follow-page live-follow-page--active" data-follow-status="active">
+      <LiveFollowTopbar
+        allowInstrumentSelection
+        context={context}
+        instrumentId={instrumentId}
+        statusLabel="Live"
+        onInstrumentChange={onInstrumentChange}
+      />
+
+      <div className="chord-context-strip" aria-label="Live follow piano display context">
+        <ContextChip icon="instrument" label={PIANO_STANDARD_PROFILE.label} />
+        <ContextChip icon="shape" label={`${formatPianoRange(PIANO_STANDARD_PROFILE)} range`} />
+        <ContextChip icon="key" label={`Source ${formatOptionalKey(project.sourceKey)}`} />
+        <ContextChip icon="key" label={`Display ${formatOptionalKey(project.displayedKey)}`} />
+        <ContextChip icon="key" label={`Region ${selectedVoicing.regionRoot.note}`} />
+        <ContextChip icon="sound" label={chordSpelling.label} />
+      </div>
+
+      <div className="live-follow-grid live-follow-grid--piano">
+        <main className="live-follow-main">
+          <section className="live-current-chord" aria-label="Current chord">
+            <p className="metric-label">Current chord</p>
+            <h3>{currentChord.displayLabel}</h3>
+            <dl className="live-follow-provenance">
+              <div>
+                <dt>Source chord</dt>
+                <dd>{currentChord.sourceLabel}</dd>
+              </div>
+              <div>
+                <dt>Display chord</dt>
+                <dd>{currentChord.displayLabel}</dd>
+              </div>
+              <div>
+                <dt>Segment</dt>
+                <dd>
+                  {formatFollowTime(currentChord.sourceSegment.start_seconds)} -{" "}
+                  {formatFollowTime(currentChord.sourceSegment.end_seconds)}
+                </dd>
+              </div>
+              <div>
+                <dt>Timeline</dt>
+                <dd>Detected/imported project chords</dd>
+              </div>
+              <div>
+                <dt>Playback source</dt>
+                <dd>{playbackSourceLabel}</dd>
+              </div>
+            </dl>
+          </section>
+
+          <section className="chord-section" aria-label="Current piano voicing">
+            <div className="chord-section-heading chord-section-heading--inline">
+              <div>
+                <p className="metric-label">{chordSpelling.notes.join(" ")}</p>
+                <h3>{chordSpelling.label} piano voicings</h3>
+              </div>
+              <div className="chord-shape-controls chord-shape-controls--piano">
+                <div className="chord-shape-control-row">
+                  <div
+                    aria-describedby="live-piano-preference-copy"
+                    aria-label="Project piano voicing preference choices"
+                    className="chord-shape-tabs"
+                    role="group"
+                  >
+                    {voicingViews.map((voicing) => (
+                      <button
+                        key={voicing.id}
+                        aria-pressed={selectedVoicing.id === voicing.id}
+                        className={classNames(
+                          "chord-shape-tab",
+                          selectedVoicing.id === voicing.id && "chord-shape-tab--active",
+                        )}
+                        onClick={() => selectVoicing(voicing)}
+                        type="button"
+                      >
+                        {voicing.label}
+                      </button>
+                    ))}
+                  </div>
+                  {hasProjectPreference ? (
+                    <button
+                      aria-label="Clear this project override and fall back to global or default"
+                      className="chord-reset-button"
+                      onClick={() => {
+                        resetProjectChordDictionaryPreferredShape(preferenceContext);
+                        bumpPreferenceRevision();
+                      }}
+                      type="button"
+                    >
+                      Clear project override
+                    </button>
+                  ) : null}
+                </div>
+                <p className="chord-shape-preference-copy" id="live-piano-preference-copy">
+                  Saves locally for this project chord and instrument; clear uses global/default.
+                </p>
+              </div>
+            </div>
+            <ChordSpellingSummary spelling={chordSpelling} />
+            <PianoVoicingPanel
+              activeChord={currentChord.displayLabel}
+              activeNoteId={activeNoteId}
+              voicing={selectedVoicing}
+              onPreviewNote={setPreviewNoteId}
+              onSelectNote={(noteId) => {
+                setPreviewNoteId(null);
+                setSelectedNoteId(noteId);
+              }}
+            />
+          </section>
+        </main>
+
+        <aside className="live-follow-sidebar">
+          <section className="live-next-chord" aria-label="Next chord">
+            <p className="metric-label">Next chord</p>
+            {context.nextChord ? (
+              <>
+                <strong>{context.nextChord.displayLabel}</strong>
+                <span>
+                  Source {context.nextChord.sourceLabel} at{" "}
+                  {formatFollowTime(context.nextChord.sourceSegment.start_seconds)}
+                </span>
+              </>
+            ) : (
+              <>
+                <strong>End of timeline</strong>
+                <span>No later project chord is available.</span>
+              </>
+            )}
+          </section>
+          {displayedNote ? <PianoNoteInspector note={displayedNote} /> : null}
+          <PianoInstrumentFacts
+            chordLabel={chordSpelling.label}
+            selectedVoicing={selectedVoicing}
+            voicingCount={voicingViews.length}
+          />
+        </aside>
+      </div>
+    </div>
   );
 }
 
@@ -3611,6 +4555,7 @@ function formatPlaybackProjectLabel(projectName: string) {
 function ChordSpellingSummary({ spelling }: { spelling: NonNullable<ReturnType<typeof spellChord>> }) {
   return (
     <div className="chord-spelling-summary" aria-label={`${spelling.label} chord spelling`}>
+      <p className="chord-spelling-summary__label">Chord tones</p>
       {spelling.tones.map((tone) => (
         <span key={`${tone.degree}-${tone.noteName}`}>
           <strong>{tone.noteName}</strong>
@@ -3647,6 +4592,14 @@ function formatGuitarRange(profile: typeof GUITAR_STANDARD_PROFILE) {
   const highestOpen = openPitches.reduce((highest, pitch) => (pitch.midi > highest.midi ? pitch : highest), openPitches[0]);
   const highestFretted = midiToPitch(highestOpen.midi + profile.frets);
   return `${lowestOpen.label} - ${highestFretted?.label ?? highestOpen.label}`;
+}
+
+function formatPianoRange(profile: typeof PIANO_STANDARD_PROFILE) {
+  return `${profile.keyboard.lowestPitch.label}-${profile.keyboard.highestPitch.label}`;
+}
+
+function formatPianoHandHint(handHint: PianoVoicingNote["handHint"]) {
+  return handHint === "left" ? "Left hand area" : "Right hand area";
 }
 
 function formatOptionalKey(key: MusicalKey | null) {

--- a/apps/desktop/src/lib/instrumentKnowledge.test.ts
+++ b/apps/desktop/src/lib/instrumentKnowledge.test.ts
@@ -497,7 +497,16 @@ describe("instrument knowledge bundle", () => {
         },
       ],
     });
-    expect(INSTRUMENT_KNOWLEDGE_BUNDLE_V1.instrumentProfiles.piano).toBeUndefined();
+    expect(INSTRUMENT_KNOWLEDGE_BUNDLE_V1.instrumentProfiles.piano).toMatchObject({
+      id: "piano",
+      executionLayer: "keyboard",
+      keyboard: {
+        keyCount: 88,
+        lowestPitch: "A0",
+        highestPitch: "C8",
+        canTranspose: false,
+      },
+    });
     expect(INSTRUMENT_KNOWLEDGE_BUNDLE_V1.voicingSeeds.piano).toBeUndefined();
   });
 });

--- a/apps/desktop/src/lib/instrumentKnowledgeData.json
+++ b/apps/desktop/src/lib/instrumentKnowledgeData.json
@@ -249,6 +249,18 @@
           ]
         }
       }
+    },
+    "piano": {
+      "id": "piano",
+      "label": "Piano",
+      "family": "keyboards",
+      "executionLayer": "keyboard",
+      "keyboard": {
+        "keyCount": 88,
+        "lowestPitch": "A0",
+        "highestPitch": "C8",
+        "canTranspose": false
+      }
     }
   },
   "voicingSeeds": {

--- a/apps/desktop/src/lib/music.test.ts
+++ b/apps/desktop/src/lib/music.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   ACCORDION_STANDARD_PROFILE,
+  INSTRUMENT_PROFILES,
+  PIANO_STANDARD_PROFILE,
   formatParsedChordLabel,
   formatPitch,
   formatChordDisplay,
@@ -10,6 +12,7 @@ import {
   formatPitchClass,
   generateAccordionVoicings,
   generateGuitarVoicings,
+  generatePianoVoicings,
   getCapoShapeChord,
   getEnharmonicContext,
   midiToPitch,
@@ -25,6 +28,7 @@ import {
   type ChordSpelling,
   type GuitarVoicing,
   type MusicalKey,
+  type PianoVoicing,
 } from "./music";
 
 describe("enharmonic formatting", () => {
@@ -120,6 +124,30 @@ function requireAccordionVoicing(label: string, context: AccordionVoicingContext
   const voicing = generateAccordionVoicings(label, context)[0];
   if (!voicing) {
     throw new Error(`Expected ${label} to produce an accordion voicing`);
+  }
+  return voicing;
+}
+
+function requirePianoVoicings(label: string, context: MusicalKey | null = null): readonly PianoVoicing[] {
+  const voicings = generatePianoVoicings(label, context);
+  if (voicings.length === 0) {
+    throw new Error(`Expected ${label} to produce piano voicings`);
+  }
+  return voicings;
+}
+
+function requirePianoVoicing(label: string, context: MusicalKey | null = null): PianoVoicing {
+  const voicing = requirePianoVoicings(label, context)[0];
+  if (!voicing) {
+    throw new Error(`Expected ${label} to produce a piano voicing`);
+  }
+  return voicing;
+}
+
+function requirePianoInversion(label: string, inversionIndex: number): PianoVoicing {
+  const voicing = requirePianoVoicings(label).find((candidate) => candidate.inversion.index === inversionIndex);
+  if (!voicing) {
+    throw new Error(`Expected ${label} to include piano inversion ${inversionIndex}`);
   }
   return voicing;
 }
@@ -412,6 +440,155 @@ describe("chord parsing and spelling", () => {
       expect(transposeChordLabel(label, 2)).toBeNull();
       expect(generateGuitarVoicings(label)).toEqual([]);
     }
+  });
+});
+
+describe("piano chord voicings", () => {
+  it("exports standard piano profile with 88-key A0-C8 metadata", () => {
+    expect(PIANO_STANDARD_PROFILE).toMatchObject({
+      id: "piano",
+      label: "Piano",
+      family: "keyboards",
+      keyboard: {
+        keyCount: 88,
+        lowestPitch: { label: "A0", midi: 21 },
+        highestPitch: { label: "C8", midi: 108 },
+        canTranspose: false,
+      },
+    });
+    expect(INSTRUMENT_PROFILES.piano).toBe(PIANO_STANDARD_PROFILE);
+  });
+
+  it("generates C major root position with exact octave labels and degrees", () => {
+    const voicing = requirePianoInversion("C", 0);
+
+    expect(voicing).toMatchObject({
+      chordLabel: "C",
+      label: "C root position",
+      inversion: {
+        index: 0,
+        label: "root position",
+        bassDegree: "1",
+        isRootPosition: true,
+      },
+      regionRoot: { pitchClass: 0, note: "C" },
+    });
+    expect(voicing.notes.map(({ note, degree, pitch, handHint }) => ({ note, degree, pitch, handHint }))).toEqual([
+      {
+        note: "C4",
+        degree: "1",
+        pitch: { pitchClass: 0, octave: 4, midi: 60, noteName: "C", label: "C4" },
+        handHint: "right",
+      },
+      {
+        note: "E4",
+        degree: "3",
+        pitch: { pitchClass: 4, octave: 4, midi: 64, noteName: "E", label: "E4" },
+        handHint: "right",
+      },
+      {
+        note: "G4",
+        degree: "5",
+        pitch: { pitchClass: 7, octave: 4, midi: 67, noteName: "G", label: "G4" },
+        handHint: "right",
+      },
+    ]);
+  });
+
+  it("exposes exact pitch data for major, minor, and seventh chords inside range", () => {
+    for (const label of ["C", "Am", "G7", "Cmaj7", "Dm7"]) {
+      const voicing = requirePianoVoicing(label);
+      const chord = requireChord(label);
+      expect(new Set(voicing.notes.map((note) => note.degree))).toEqual(
+        new Set(chord.tones.map((tone) => tone.degree)),
+      );
+      expect(voicing.notes.map((note) => note.pitch.midi)).toEqual(
+        [...voicing.notes].map((note) => note.pitch.midi).sort((left, right) => left - right),
+      );
+      for (const note of voicing.notes) {
+        expect(note.pitch.label).toBe(note.note);
+        expect(note.pitch.label).toMatch(/^[A-G](?:#|b)?-?\d+$/);
+        expect(note.pitch.midi).toBeGreaterThanOrEqual(PIANO_STANDARD_PROFILE.keyboard.lowestPitch.midi);
+        expect(note.pitch.midi).toBeLessThanOrEqual(PIANO_STANDARD_PROFILE.keyboard.highestPitch.midi);
+      }
+    }
+  });
+
+  it("defaults unconstrained major and minor piano chords to root position across roots", () => {
+    const roots = ["C", "C#", "Db", "D", "D#", "Eb", "E", "F", "F#", "Gb", "G", "G#", "Ab", "A", "A#", "Bb", "B"];
+
+    for (const label of roots.flatMap((root) => [root, `${root}m`])) {
+      const voicings = requirePianoVoicings(label);
+      const chord = requireChord(label);
+
+      expect(voicings[0]?.rank).toBe(1);
+      expect(voicings[0]?.inversion).toMatchObject({
+        index: 0,
+        label: "root position",
+        bassDegree: "1",
+        isRootPosition: true,
+      });
+      expect(voicings[0]?.notes[0]?.degree).toBe("1");
+      expect(voicings[0]?.notes[0]?.pitch.pitchClass).toBe(chord.rootPitchClass);
+    }
+  });
+
+  it("keeps generated close inversions available after the root-position default", () => {
+    const cVoicings = requirePianoVoicings("C", { pitchClass: 0, mode: "major" });
+    expect(cVoicings.map((voicing) => voicing.rank)).toEqual([1, 2, 3]);
+    expect(cVoicings[0]?.inversion.index).toBe(0);
+    expect([...cVoicings].map((voicing) => voicing.inversion.index).sort()).toEqual([0, 1, 2]);
+
+    const gRegionVoicings = generatePianoVoicings("C", {
+      regionKey: { pitchClass: 7, mode: "major" },
+    });
+    expect(gRegionVoicings[0]).toMatchObject({
+      regionRoot: { pitchClass: 7, note: "G" },
+      inversion: { index: 2, label: "second inversion", bassDegree: "5" },
+    });
+    expect(gRegionVoicings[0]?.notes.map((note) => note.note)).toEqual(["G3", "C4", "E4"]);
+    expect(gRegionVoicings.find((voicing) => voicing.inversion.index === 0)?.notes.map((note) => note.note)).toEqual([
+      "C4",
+      "E4",
+      "G4",
+    ]);
+
+    const fRootVoicings = generatePianoVoicings("C", { currentChordRoot: "F" });
+    expect(fRootVoicings[0]?.regionRoot).toEqual({ pitchClass: 5, note: "F" });
+    expect(fRootVoicings[0]).toMatchObject({
+      inversion: { index: 1, label: "first inversion", bassDegree: "3" },
+    });
+    expect(fRootVoicings[0]?.notes.map((note) => note.note)).toEqual(["E4", "G4", "C5"]);
+  });
+
+  it("keeps supported slash bass as the lowest piano note", () => {
+    const cOverE = requirePianoVoicing("C/E");
+    expect(cOverE).toMatchObject({
+      chordLabel: "C/E",
+      inversion: { index: 1, label: "first inversion", bassDegree: "3", isRootPosition: false },
+    });
+    expect(cOverE.notes[0]).toMatchObject({
+      note: "E4",
+      degree: "3",
+      pitch: { pitchClass: 4 },
+    });
+
+    const gOverD = requirePianoVoicing("G/D");
+    expect(gOverD).toMatchObject({
+      chordLabel: "G/D",
+      inversion: { index: 2, label: "second inversion", bassDegree: "5", isRootPosition: false },
+    });
+    expect(gOverD.notes[0]).toMatchObject({
+      note: "D4",
+      degree: "5",
+      pitch: { pitchClass: 2 },
+    });
+  });
+
+  it("returns no piano voicings for unsupported chord symbols", () => {
+    expect(generatePianoVoicings("Cadd9")).toEqual([]);
+    expect(generatePianoVoicings("N.C.")).toEqual([]);
+    expect(generatePianoVoicings("C/F#")).toEqual([]);
   });
 });
 

--- a/apps/desktop/src/lib/music.ts
+++ b/apps/desktop/src/lib/music.ts
@@ -7,6 +7,7 @@ import {
   type GuitarVoicingSeedV1,
   type InstrumentProfileV1,
   type KeyboardFingerV1,
+  type KeyboardHandV1,
 } from "./instrumentKnowledge";
 
 export type KeyMode = "major" | "minor";
@@ -187,6 +188,58 @@ export type GuitarVoicing = {
   mutedStrings: readonly number[];
   notes: readonly GuitarVoicingNote[];
 };
+
+export type PianoProfile = {
+  id: "piano";
+  label: string;
+  family: string;
+  keyboard: {
+    keyCount: number;
+    lowestPitch: ParsedPitch;
+    highestPitch: ParsedPitch;
+    canTranspose: boolean;
+  };
+};
+
+export type PianoHandHint = KeyboardHandV1;
+
+export type PianoVoicingNote = {
+  id: string;
+  pitch: ParsedPitch;
+  note: string;
+  degree: ChordDegree;
+  handHint: PianoHandHint;
+};
+
+export type PianoRegionRoot = {
+  pitchClass: number;
+  note: string;
+};
+
+export type PianoVoicingInversion = {
+  index: number;
+  label: string;
+  bassDegree: ChordDegree;
+  isRootPosition: boolean;
+};
+
+export type PianoVoicing = {
+  id: string;
+  label: string;
+  chordLabel: string;
+  rank: number;
+  notes: readonly PianoVoicingNote[];
+  inversion: PianoVoicingInversion;
+  regionRoot: PianoRegionRoot;
+};
+
+export type PianoVoicingContext =
+  | MusicalKey
+  | {
+      activeKey?: MusicalKey | null;
+      regionKey?: MusicalKey | null;
+      currentChordRoot?: ChordInput | number | null;
+    };
 
 export type AccordionStradellaRowId = ButtonBoardStradellaRowIdV1;
 export type AccordionLeftHandQuality = "exact" | "approx";
@@ -512,6 +565,18 @@ export const GUITAR_STANDARD_PROFILE: GuitarProfile =
   buildGuitarStandardProfile(INSTRUMENT_KNOWLEDGE_BUNDLE_V1.instrumentProfiles.guitar) ??
   FALLBACK_GUITAR_STANDARD_PROFILE;
 
+const FALLBACK_PIANO_STANDARD_PROFILE: PianoProfile = {
+  id: "piano",
+  label: "Piano",
+  family: "keyboards",
+  keyboard: {
+    keyCount: 88,
+    lowestPitch: parsePitchRequired("A0"),
+    highestPitch: parsePitchRequired("C8"),
+    canTranspose: false,
+  },
+};
+
 const FALLBACK_ACCORDION_STRADELLA_PROFILE: ButtonBoardStradellaProfileV1 = {
   rootAxis: [
     { root: "B", pitchClass: 11, column: 1, visualColumn: 0, visualOrder: 0 },
@@ -617,9 +682,14 @@ export const ACCORDION_STANDARD_PROFILE: AccordionProfile =
   buildAccordionStandardProfile(INSTRUMENT_KNOWLEDGE_BUNDLE_V1.instrumentProfiles.accordion) ??
   FALLBACK_ACCORDION_STANDARD_PROFILE;
 
+export const PIANO_STANDARD_PROFILE: PianoProfile =
+  buildPianoStandardProfile(INSTRUMENT_KNOWLEDGE_BUNDLE_V1.instrumentProfiles.piano) ??
+  FALLBACK_PIANO_STANDARD_PROFILE;
+
 export const INSTRUMENT_PROFILES = {
   guitar: GUITAR_STANDARD_PROFILE,
   accordion: ACCORDION_STANDARD_PROFILE,
+  piano: PIANO_STANDARD_PROFILE,
 } as const;
 
 const FALLBACK_GUITAR_TEMPLATE_STRINGS = [6, 5, 4, 3, 2, 1] as const;
@@ -710,6 +780,30 @@ function buildAccordionStandardProfile(profile: InstrumentProfileV1 | undefined)
       columns: profile.buttonBoard.columns,
       canTranspose: profile.buttonBoard.canTranspose,
       stradella: profile.buttonBoard.stradella,
+    },
+  };
+}
+
+function buildPianoStandardProfile(profile: InstrumentProfileV1 | undefined): PianoProfile | null {
+  if (!profile || profile.id !== "piano" || !profile.keyboard) {
+    return null;
+  }
+
+  const lowestPitch = parsePitch(profile.keyboard.lowestPitch);
+  const highestPitch = parsePitch(profile.keyboard.highestPitch);
+  if (!lowestPitch || !highestPitch || lowestPitch.midi >= highestPitch.midi) {
+    return null;
+  }
+
+  return {
+    id: "piano",
+    label: profile.label,
+    family: profile.family,
+    keyboard: {
+      keyCount: profile.keyboard.keyCount,
+      lowestPitch,
+      highestPitch,
+      canTranspose: profile.keyboard.canTranspose,
     },
   };
 }
@@ -1428,6 +1522,286 @@ export function generateGuitarVoicings(
     }
     return left.rank - right.rank;
   });
+}
+
+const PIANO_REGION_TARGET_MIDI = 60;
+const PIANO_MAX_VOICINGS = 8;
+
+type ResolvedPianoContext = {
+  regionKey: MusicalKey | null;
+  currentChordRootPitchClass: number | null;
+};
+
+type PianoGeneratedCandidate = {
+  inversion: number;
+  notes: readonly PianoVoicingNote[];
+  score: number;
+  shapeKey: string;
+};
+
+export function generatePianoVoicings(
+  chord: ChordInput,
+  context: PianoVoicingContext | null = null,
+  options: PitchFormatOptions = {},
+): readonly PianoVoicing[] {
+  const parsedChord = parseChordInput(chord);
+  if (!parsedChord) {
+    return [];
+  }
+
+  const resolvedContext = resolvePianoVoicingContext(context);
+  const regionRootPitchClass =
+    resolvedContext.regionKey?.pitchClass ?? resolvedContext.currentChordRootPitchClass ?? 0;
+  const resolvedChordOptions = resolveChordFormatOptions(parsedChord, options);
+  const chordOptions = {
+    ...resolvedChordOptions,
+    activeKey: options.activeKey ?? resolvedContext.regionKey ?? resolvedChordOptions.activeKey,
+  };
+  const chordSpelling = spellChord(parsedChord, chordOptions);
+  if (!chordSpelling || !isPianoVoicingSupportedChord(chordSpelling)) {
+    return [];
+  }
+  const bassInversionConstraint = resolvePianoBassInversionConstraint(chordSpelling);
+  if (bassInversionConstraint === "unsupported") {
+    return [];
+  }
+  const preferRootPosition = bassInversionConstraint === null && !hasPianoVoicingRegionContext(resolvedContext);
+
+  const regionRoot: PianoRegionRoot = {
+    pitchClass: normalizePitchClass(regionRootPitchClass),
+    note: formatPitchClass(regionRootPitchClass, chordOptions),
+  };
+  return generatePianoCloseVoicingCandidates(
+    chordSpelling,
+    PIANO_STANDARD_PROFILE,
+    regionRoot.pitchClass,
+    chordOptions,
+    bassInversionConstraint,
+    preferRootPosition,
+  ).map((candidate, index): PianoVoicing => {
+    const inversionLabel = formatPianoInversionName(candidate.inversion);
+    const bassDegree = candidate.notes[0]?.degree ?? "1";
+    return {
+      id: `piano-${slugifyMusicId(chordSpelling.label)}-${slugifyMusicId(inversionLabel)}-${candidate.shapeKey}`,
+      label: `${chordSpelling.label} ${inversionLabel}`,
+      chordLabel: chordSpelling.label,
+      rank: index + 1,
+      notes: candidate.notes,
+      inversion: {
+        index: candidate.inversion,
+        label: inversionLabel,
+        bassDegree,
+        isRootPosition: candidate.inversion === 0,
+      },
+      regionRoot,
+    };
+  });
+}
+
+function resolvePianoVoicingContext(context: PianoVoicingContext | null): ResolvedPianoContext {
+  if (!context) {
+    return { regionKey: null, currentChordRootPitchClass: null };
+  }
+  if (isMusicalKeyLike(context)) {
+    return { regionKey: context, currentChordRootPitchClass: null };
+  }
+
+  return {
+    regionKey: context.regionKey ?? context.activeKey ?? null,
+    currentChordRootPitchClass: resolvePianoChordRootPitchClass(context.currentChordRoot),
+  };
+}
+
+function hasPianoVoicingRegionContext(context: ResolvedPianoContext): boolean {
+  return context.regionKey !== null || context.currentChordRootPitchClass !== null;
+}
+
+function resolvePianoChordRootPitchClass(input: ChordInput | number | null | undefined): number | null {
+  if (typeof input === "number") {
+    return Number.isFinite(input) ? normalizePitchClass(input) : null;
+  }
+  if (input === null || input === undefined) {
+    return null;
+  }
+
+  const parsedChord = parseChordInput(input);
+  return parsedChord ? parsedChord.rootPitchClass : null;
+}
+
+function isPianoVoicingSupportedChord(chord: ChordSpelling): boolean {
+  return chord.tones.length >= 3 && chord.tones.length <= 4;
+}
+
+function resolvePianoBassInversionConstraint(chord: ChordSpelling): number | "unsupported" | null {
+  if (typeof chord.bassPitchClass !== "number") {
+    return null;
+  }
+
+  const bassPitchClass = normalizePitchClass(chord.bassPitchClass);
+  const bassToneIndex = chord.tones.findIndex((tone) => normalizePitchClass(tone.pitchClass) === bassPitchClass);
+  return bassToneIndex === -1 ? "unsupported" : bassToneIndex;
+}
+
+function generatePianoCloseVoicingCandidates(
+  chord: ChordSpelling,
+  profile: PianoProfile,
+  regionRootPitchClass: number,
+  options: PitchFormatOptions,
+  bassInversionConstraint: number | null,
+  preferRootPosition: boolean,
+): readonly PianoGeneratedCandidate[] {
+  const targetMidi = getPianoRegionAnchorMidi(regionRootPitchClass, profile);
+  const candidates: PianoGeneratedCandidate[] = [];
+  const inversionIndexes =
+    typeof bassInversionConstraint === "number"
+      ? [bassInversionConstraint]
+      : chord.tones.map((_, inversion) => inversion);
+
+  for (const inversion of inversionIndexes) {
+    let bestCandidate: PianoGeneratedCandidate | null = null;
+    for (let baseMidi = profile.keyboard.lowestPitch.midi; baseMidi <= profile.keyboard.highestPitch.midi; baseMidi += 1) {
+      if (normalizePitchClass(baseMidi) !== chord.tones[inversion]?.pitchClass) {
+        continue;
+      }
+
+      const midiSequence = buildKeyboardRightHandInversionMidiSequence(
+        chord,
+        inversion,
+        baseMidi,
+        profile.keyboard.lowestPitch.midi,
+        profile.keyboard.highestPitch.midi,
+      );
+      const notes = renderPianoVoicingNotes(midiSequence, options);
+      if (notes.length !== chord.tones.length) {
+        continue;
+      }
+
+      const shapeKey = notes.map((note) => note.pitch.midi).join("-");
+      const score = scorePianoCloseVoicingCandidate(notes, targetMidi, inversion, chord.rootPitchClass, regionRootPitchClass);
+      if (!bestCandidate || score < bestCandidate.score) {
+        bestCandidate = {
+          inversion,
+          notes,
+          score,
+          shapeKey,
+        };
+      }
+    }
+
+    if (bestCandidate) {
+      candidates.push(bestCandidate);
+    }
+  }
+
+  return candidates
+    .sort((left, right) =>
+      comparePianoCloseVoicingCandidates(left, right, preferRootPosition),
+    )
+    .slice(0, PIANO_MAX_VOICINGS);
+}
+
+function comparePianoCloseVoicingCandidates(
+  left: PianoGeneratedCandidate,
+  right: PianoGeneratedCandidate,
+  preferRootPosition: boolean,
+): number {
+  if (preferRootPosition && left.inversion !== right.inversion) {
+    if (left.inversion === 0) {
+      return -1;
+    }
+    if (right.inversion === 0) {
+      return 1;
+    }
+  }
+
+  return left.score - right.score || left.shapeKey.localeCompare(right.shapeKey);
+}
+
+function renderPianoVoicingNotes(
+  midiSequence: ReadonlyArray<{ midi: number; tone: ChordTone }>,
+  options: PitchFormatOptions,
+): readonly PianoVoicingNote[] {
+  return midiSequence.flatMap(({ midi, tone }, index): PianoVoicingNote[] => {
+    const pitch = midiToPitch(midi, options);
+    if (!pitch) {
+      return [];
+    }
+
+    return [
+      {
+        id: `piano-note-${index}-${midi}`,
+        pitch,
+        note: pitch.label,
+        degree: tone.degree,
+        handHint: getPianoHandHint(midi),
+      },
+    ];
+  });
+}
+
+function scorePianoCloseVoicingCandidate(
+  notes: readonly PianoVoicingNote[],
+  targetMidi: number,
+  inversion: number,
+  chordRootPitchClass: number,
+  regionRootPitchClass: number,
+): number {
+  const lowestMidi = notes[0]?.pitch.midi ?? targetMidi;
+  const highestMidi = notes[notes.length - 1]?.pitch.midi ?? targetMidi;
+  const center = notes.reduce((total, note) => total + note.pitch.midi, 0) / notes.length;
+  const averageDistance = notes.reduce((total, note) => total + Math.abs(note.pitch.midi - targetMidi), 0) / notes.length;
+  const tonicRootBonus =
+    normalizePitchClass(chordRootPitchClass) === normalizePitchClass(regionRootPitchClass) && inversion === 0 ? -40 : 0;
+  return (
+    Math.abs(lowestMidi - targetMidi) * 20 +
+    Math.abs(center - targetMidi) * 3 +
+    averageDistance * 2 +
+    (highestMidi - lowestMidi) +
+    inversion * 0.5 +
+    tonicRootBonus
+  );
+}
+
+function getPianoRegionAnchorMidi(regionRootPitchClass: number, profile: PianoProfile): number {
+  const targetMidi = clampNumber(
+    PIANO_REGION_TARGET_MIDI,
+    profile.keyboard.lowestPitch.midi,
+    profile.keyboard.highestPitch.midi,
+  );
+  let bestMidi = targetMidi;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  for (let midi = profile.keyboard.lowestPitch.midi; midi <= profile.keyboard.highestPitch.midi; midi += 1) {
+    if (normalizePitchClass(midi) !== normalizePitchClass(regionRootPitchClass)) {
+      continue;
+    }
+    const distance = Math.abs(midi - targetMidi);
+    if (distance < bestDistance) {
+      bestMidi = midi;
+      bestDistance = distance;
+    }
+  }
+
+  return bestMidi;
+}
+
+function getPianoHandHint(midi: number): PianoHandHint {
+  return midi < PIANO_REGION_TARGET_MIDI ? "left" : "right";
+}
+
+function formatPianoInversionName(inversion: number): string {
+  switch (inversion) {
+    case 0:
+      return "root position";
+    case 1:
+      return "first inversion";
+    case 2:
+      return "second inversion";
+    case 3:
+      return "third inversion";
+    default:
+      return `${formatOrdinal(inversion + 1)} inversion`;
+  }
 }
 
 const ACCORDION_VISIBLE_ROOT_RADIUS = 5;

--- a/apps/desktop/src/styles/tools.css
+++ b/apps/desktop/src/styles/tools.css
@@ -385,9 +385,38 @@
   min-width: 0;
 }
 
+.chord-shape-controls--piano {
+  inline-size: min(100%, 42rem);
+  justify-items: stretch;
+}
+
 .chord-shape-control-row {
   justify-content: flex-end;
   min-width: 0;
+}
+
+.chord-shape-controls--piano .chord-shape-control-row {
+  align-items: stretch;
+  justify-content: flex-start;
+  inline-size: 100%;
+}
+
+.chord-shape-controls--piano .chord-shape-tabs {
+  flex: 1 1 16rem;
+  min-inline-size: 0;
+  max-inline-size: 100%;
+}
+
+.chord-shape-controls--piano .chord-shape-tab {
+  flex: 1 1 8.75rem;
+  min-inline-size: min(100%, 7.75rem);
+  max-inline-size: none;
+  white-space: normal;
+}
+
+.chord-shape-controls--piano .chord-reset-button {
+  flex: 0 1 auto;
+  white-space: normal;
 }
 
 .chord-toolbar-cluster--end {
@@ -426,6 +455,7 @@
 .guitar-fretboard__dot:focus-visible,
 .chord-shape-card__label:focus-visible,
 .chord-family-card:focus-visible,
+.piano-keyboard__key:focus-visible,
 .accordion-stradella__button:focus-visible,
 .accordion-keyboard__key:focus-visible,
 .accordion-candidate-card:focus-visible {
@@ -494,11 +524,7 @@
   background: color-mix(in srgb, var(--panel) 88%, transparent);
   box-shadow: none;
   cursor: pointer;
-  transition:
-    border-color 140ms ease,
-    background 140ms ease,
-    box-shadow 140ms ease,
-    color 140ms ease;
+  transition: none;
 }
 
 .chord-instrument-selector .chord-instrument-button[aria-pressed="false"],
@@ -517,25 +543,62 @@
 
 .chord-instrument-selector .chord-instrument-button[aria-pressed="false"]:hover,
 .chord-instrument-selector .chord-instrument-button[aria-pressed="false"]:focus-visible {
-  border-color: color-mix(in srgb, var(--divider) 72%, var(--text));
-  background: color-mix(in srgb, var(--panel) 84%, var(--panel-strong));
+  border-color: color-mix(in srgb, var(--divider) 80%, var(--text) 20%);
+  background: color-mix(in srgb, var(--panel) 94%, var(--panel-strong));
   box-shadow: none;
-  color: var(--text);
+  color: color-mix(in srgb, var(--muted) 86%, var(--text));
+}
+
+.chord-instrument-selector .chord-instrument-button[aria-pressed="false"]:hover svg,
+.chord-instrument-selector .chord-instrument-button[aria-pressed="false"]:focus-visible svg {
+  color: color-mix(in srgb, var(--muted) 82%, transparent);
 }
 
 .chord-instrument-selector .chord-instrument-button[aria-pressed="true"],
 .chord-instrument-selector .chord-instrument-button[data-selected="true"],
 .chord-instrument-selector .chord-instrument-button--active[aria-pressed="true"] {
-  border-color: color-mix(in srgb, var(--playback-accent) 82%, var(--text));
-  background: color-mix(in srgb, var(--playback-accent) 42%, var(--panel-strong));
+  border-color: color-mix(in srgb, var(--playback-accent) 88%, var(--text));
+  background: color-mix(in srgb, var(--playback-accent) 56%, var(--panel));
   box-shadow:
-    inset 0 0 0 1px color-mix(in srgb, var(--playback-accent) 38%, transparent),
-    0 0 0 0.16rem color-mix(in srgb, var(--playback-accent) 18%, transparent);
+    inset 0 0 0 1px color-mix(in srgb, white 32%, transparent),
+    0 0 0 0.18rem color-mix(in srgb, var(--playback-accent) 24%, transparent);
   color: var(--text);
 }
 
 .chord-instrument-selector .chord-instrument-button[data-selected="true"] svg {
   color: color-mix(in srgb, var(--playback-accent) 72%, var(--text));
+}
+
+.chord-instrument-selector .chord-instrument-button[data-selected="false"],
+.chord-instrument-selector .chord-instrument-button[aria-pressed="false"],
+.chord-instrument-selector .chord-instrument-button[data-selected="false"].chord-pill--active,
+.chord-instrument-selector .chord-instrument-button[data-selected="false"].chord-instrument-button--active {
+  border-color: color-mix(in srgb, var(--divider) 62%, transparent);
+  background: color-mix(in srgb, var(--panel) 92%, transparent);
+  box-shadow: none;
+  color: var(--muted);
+}
+
+.chord-instrument-selector .chord-instrument-button[data-selected="false"] svg,
+.chord-instrument-selector .chord-instrument-button[aria-pressed="false"] svg {
+  color: color-mix(in srgb, var(--muted) 78%, transparent);
+}
+
+.chord-instrument-selector .chord-instrument-button[data-selected="false"]:hover,
+.chord-instrument-selector .chord-instrument-button[data-selected="false"]:focus-visible,
+.chord-instrument-selector .chord-instrument-button[aria-pressed="false"]:hover,
+.chord-instrument-selector .chord-instrument-button[aria-pressed="false"]:focus-visible {
+  border-color: color-mix(in srgb, var(--divider) 84%, var(--text));
+  background: color-mix(in srgb, var(--panel) 94%, transparent);
+  box-shadow: none;
+  color: color-mix(in srgb, var(--muted) 88%, var(--text));
+}
+
+.chord-instrument-selector .chord-instrument-button[data-selected="false"]:hover svg,
+.chord-instrument-selector .chord-instrument-button[data-selected="false"]:focus-visible svg,
+.chord-instrument-selector .chord-instrument-button[aria-pressed="false"]:hover svg,
+.chord-instrument-selector .chord-instrument-button[aria-pressed="false"]:focus-visible svg {
+  color: color-mix(in srgb, var(--muted) 82%, transparent);
 }
 
 .chord-pill--muted {
@@ -707,6 +770,16 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+}
+
+.chord-spelling-summary__label {
+  flex-basis: 100%;
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 900;
+  line-height: 1;
+  text-transform: uppercase;
 }
 
 .chord-spelling-summary span {
@@ -1914,6 +1987,290 @@ span.accordion-keyboard__key--black {
   overflow-wrap: anywhere;
 }
 
+.piano-tool-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(18rem, 22rem);
+  gap: 1rem;
+  align-items: start;
+  min-width: 0;
+}
+
+.piano-tool-main,
+.piano-tool-sidebar {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+}
+
+.piano-tool-main,
+.piano-tool-sidebar,
+.piano-position-card,
+.piano-facts-panel {
+  border: 1px solid color-mix(in srgb, var(--divider) 78%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--surface-muted) 38%, transparent);
+}
+
+.piano-tool-main,
+.piano-tool-sidebar,
+.piano-facts-panel {
+  padding: 0.85rem;
+}
+
+.piano-position-card {
+  display: grid;
+  gap: 0.85rem;
+  min-width: 0;
+  padding: 0.85rem;
+  overflow: hidden;
+}
+
+.piano-position-card__heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.65rem;
+  min-width: 0;
+}
+
+.piano-position-card__heading h4 {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.98rem;
+}
+
+.piano-position-card__heading span:not(.accordion-match-badge) {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.piano-voicing-order {
+  display: grid;
+  gap: 0.42rem;
+  min-width: 0;
+}
+
+.piano-voicing-order__label {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 900;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.piano-voicing-order ol {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.piano-voicing-order li {
+  display: inline-grid;
+  justify-items: center;
+  min-inline-size: 3.75rem;
+  gap: 0.06rem;
+  padding: 0.42rem 0.48rem;
+  border: 1px solid color-mix(in srgb, var(--divider) 76%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel) 68%, var(--panel-strong) 32%);
+}
+
+.piano-voicing-order strong {
+  color: var(--text);
+  font-size: 0.92rem;
+  line-height: 1;
+}
+
+.piano-voicing-order small {
+  color: var(--muted);
+  font-size: 0.68rem;
+  font-weight: 850;
+}
+
+.piano-keyboard {
+  --piano-white-key-count: 8;
+  --piano-white-key-width: 2.85rem;
+  --piano-keyboard-height: 10.75rem;
+  --piano-black-key-height: 6.35rem;
+  --piano-black-key-width: clamp(0.9rem, calc((100% / var(--piano-white-key-count)) * 0.58), 1.65rem);
+
+  position: relative;
+  box-sizing: border-box;
+  inline-size: min(100%, calc(var(--piano-white-key-count) * var(--piano-white-key-width)));
+  min-width: 0;
+  padding-block-start: 0.4rem;
+  justify-self: start;
+  overflow: visible;
+}
+
+.piano-keyboard__white-keys {
+  display: grid;
+  grid-template-columns: repeat(var(--piano-white-key-count), minmax(0, 1fr));
+  min-width: 0;
+  block-size: var(--piano-keyboard-height);
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--divider) 82%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, white 92%, var(--panel-strong));
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, white 40%, transparent),
+    0 0.16rem 0.3rem color-mix(in srgb, black 16%, transparent);
+}
+
+.piano-keyboard__black-keys {
+  position: absolute;
+  inset-block-start: 0.4rem;
+  inset-inline: 0;
+  block-size: var(--piano-black-key-height);
+  min-width: 0;
+  pointer-events: none;
+}
+
+.piano-keyboard__key {
+  box-sizing: border-box;
+  min-width: 0;
+  border: 0;
+  color: var(--muted);
+  font: inherit;
+  font-weight: 900;
+  line-height: 1.05;
+  text-align: center;
+}
+
+.piano-keyboard__key--white {
+  display: grid;
+  align-content: end;
+  justify-items: center;
+  gap: 0.14rem;
+  min-height: 0;
+  padding: 0.45rem 0.18rem 0.62rem;
+  border-inline-end: 1px solid color-mix(in srgb, var(--divider) 72%, transparent);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, white 98%, var(--panel-strong)) 0%, color-mix(in srgb, white 86%, var(--panel-strong)) 100%),
+    color-mix(in srgb, white 92%, var(--panel-strong));
+  color: color-mix(in srgb, var(--text) 92%, black);
+}
+
+.piano-keyboard__key--white:last-child {
+  border-inline-end: 0;
+}
+
+.piano-keyboard__key--black {
+  position: absolute;
+  inset-block-start: 0;
+  inset-inline-start: calc(
+    ((var(--piano-white-index) + 1) * (100% / var(--piano-white-key-count))) -
+      (var(--piano-black-key-width) / 2)
+  );
+  z-index: 2;
+  display: grid;
+  align-content: end;
+  justify-items: center;
+  gap: 0.1rem;
+  inline-size: var(--piano-black-key-width);
+  block-size: var(--piano-black-key-height);
+  min-height: 0;
+  border: 1px solid color-mix(in srgb, black 82%, var(--divider));
+  border-radius: 0 0 5px 5px;
+  padding: 0.34rem 0.16rem 0.48rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, white 10%, transparent), transparent 34%),
+    linear-gradient(180deg, color-mix(in srgb, black 86%, var(--panel-strong)), color-mix(in srgb, black 66%, var(--panel-strong)));
+  color: color-mix(in srgb, white 88%, var(--panel));
+  pointer-events: auto;
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 10%, transparent),
+    0 0.14rem 0.22rem color-mix(in srgb, black 30%, transparent);
+}
+
+span.piano-keyboard__key--black {
+  pointer-events: none;
+}
+
+.piano-keyboard__key--active-tone {
+  border-color: color-mix(in srgb, var(--playback-accent) 72%, var(--divider));
+  background: linear-gradient(180deg, color-mix(in srgb, var(--playback-accent) 70%, white), color-mix(in srgb, var(--playback-accent) 54%, white));
+  color: color-mix(in srgb, black 88%, var(--playback-accent));
+  cursor: pointer;
+  text-shadow: 0 1px 0 color-mix(in srgb, white 36%, transparent);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, white 34%, transparent),
+    inset 0 -1px 0 color-mix(in srgb, var(--panel) 20%, transparent);
+}
+
+.piano-keyboard__key--white.piano-keyboard__key--selected {
+  color: color-mix(in srgb, black 92%, var(--playback-accent));
+}
+
+.piano-keyboard__key--black.piano-keyboard__key--active-tone {
+  background:
+    linear-gradient(180deg, color-mix(in srgb, white 14%, transparent), transparent 36%),
+    linear-gradient(180deg, color-mix(in srgb, var(--playback-accent) 76%, black), color-mix(in srgb, var(--playback-accent) 58%, black));
+  color: color-mix(in srgb, white 96%, var(--panel));
+  text-shadow: 0 1px 0 color-mix(in srgb, black 42%, transparent);
+}
+
+.piano-keyboard__key--selected {
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, white 32%, transparent),
+    0 0 0 0.22rem color-mix(in srgb, var(--playback-accent) 22%, transparent);
+}
+
+.piano-keyboard__key strong,
+.piano-keyboard__key span {
+  display: block;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
+.piano-keyboard__key strong {
+  font-size: 0.74rem;
+}
+
+.piano-keyboard__key span {
+  font-size: 0.62rem;
+  opacity: 0.9;
+}
+
+.piano-note-inspector {
+  align-items: start;
+}
+
+.piano-note-inspector .note-inspector__badge {
+  width: 4.9rem;
+  height: 4.9rem;
+  border-radius: 8px;
+}
+
+.piano-note-inspector__body {
+  display: grid;
+  gap: 0.55rem;
+  min-width: 0;
+}
+
+.piano-note-inspector dl {
+  grid-template-columns: repeat(2, minmax(5.25rem, 1fr));
+  gap: 0.65rem 0.75rem;
+}
+
+.piano-note-inspector p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 780;
+  line-height: 1.35;
+}
+
+.piano-facts-panel {
+  display: grid;
+  gap: 1rem;
+}
+
 .live-follow-page {
   min-height: 41rem;
 }
@@ -2040,6 +2397,7 @@ span.accordion-keyboard__key--black {
 @media (max-width: 1180px) {
   .chord-tool-grid,
   .live-follow-grid,
+  .piano-tool-grid,
   .accordion-tool-grid {
     grid-template-columns: 1fr;
   }
@@ -2066,6 +2424,7 @@ span.accordion-keyboard__key--black {
   .chord-dictionary-toolbar,
   .chord-section-heading,
   .live-follow-topbar,
+  .piano-position-card__heading,
   .accordion-position-card__heading {
     align-items: stretch;
     flex-direction: column;
@@ -2178,6 +2537,11 @@ span.accordion-keyboard__key--black {
     --accordion-keyboard-start-padding: 0.58rem;
   }
 
+  .piano-keyboard {
+    --piano-keyboard-height: 8.75rem;
+    --piano-black-key-height: 5.35rem;
+  }
+
   .chord-field-row,
   .chord-card-row,
   .note-inspector dl,
@@ -2203,6 +2567,27 @@ span.accordion-keyboard__key--black {
     flex: 0 0 auto;
     min-width: min(8rem, 80vw);
     max-width: 11rem;
+  }
+
+  .chord-shape-controls--piano,
+  .chord-shape-controls--piano .chord-shape-control-row,
+  .chord-shape-controls--piano .chord-shape-tabs,
+  .chord-shape-controls--piano .chord-reset-button {
+    inline-size: 100%;
+  }
+
+  .chord-shape-controls--piano .chord-shape-control-row,
+  .chord-shape-controls--piano .chord-shape-tabs {
+    flex-wrap: wrap;
+    overflow-x: visible;
+    overscroll-behavior-x: auto;
+    padding-bottom: 0;
+  }
+
+  .chord-shape-controls--piano .chord-shape-tab {
+    flex: 1 1 8.6rem;
+    min-width: min(100%, 8rem);
+    max-width: none;
   }
 
   .guitar-fretboard {


### PR DESCRIPTION
## Summary
- Closes #268
- Add generated piano voicings, an 88-key piano profile, and Piano selection in Chord Dictionary.
- Render a wider two-octave piano keyboard with chord tones, voicing order, note inspector, and truthful hand-hint/source copy.
- Default dictionary piano chords to root position while preserving Live Follow context-aware close inversions and slash-bass constraints.

## Testing
- `git diff --check`
- `CI=true pnpm --filter @tuneforge/desktop typecheck`
- `CI=true pnpm --filter @tuneforge/desktop lint`
- `CI=true pnpm --filter @tuneforge/desktop test -- apps/desktop/src/lib/music.test.ts apps/desktop/src/lib/instrumentKnowledge.test.ts apps/desktop/src/App.tools-chord-dictionary.test.tsx --run`
