### PR TITLE
fix: polish chord dictionary accessibility

### DIFF
--- a/apps/desktop/src/App.tools-chord-dictionary-responsive.test.tsx
+++ b/apps/desktop/src/App.tools-chord-dictionary-responsive.test.tsx
@@ -1,0 +1,312 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildChordDictionaryFollowProjectContext,
+  type ChordDictionaryFollowProjectContext,
+} from "./features/projects/chordDictionaryFollowContext";
+import {
+  PlaybackContext,
+  type PlaybackContextValue,
+  type ProjectPlaybackSession,
+} from "./features/projects/playback-context";
+import { ChordDictionaryPage } from "./features/tools/ChordDictionaryPage";
+import { ChordDictionaryFollowArmProvider } from "./features/tools/chordDictionaryFollowArm";
+import type { ChordSegmentSchema } from "./lib/api";
+import { resetAppTestHarness } from "./test/appTestHarness";
+
+const sourceTimeline: ChordSegmentSchema[] = [
+  {
+    confidence: 0.81,
+    end_seconds: 16,
+    label: "G",
+    pitch_class: 7,
+    quality: "major",
+    start_seconds: 0,
+  },
+  {
+    confidence: 0.79,
+    end_seconds: 32,
+    label: "D",
+    pitch_class: 2,
+    quality: "major",
+    start_seconds: 16,
+  },
+];
+
+const displayedTimeline: ChordSegmentSchema[] = [
+  {
+    confidence: 0.81,
+    end_seconds: 16,
+    label: "A",
+    pitch_class: 9,
+    quality: "major",
+    start_seconds: 0,
+  },
+  {
+    confidence: 0.79,
+    end_seconds: 32,
+    label: "E",
+    pitch_class: 4,
+    quality: "major",
+    start_seconds: 16,
+  },
+];
+
+function makeFollowProject(
+  overrides: Partial<ChordDictionaryFollowProjectContext> = {},
+): ChordDictionaryFollowProjectContext {
+  return buildChordDictionaryFollowProjectContext({
+    authoritativeSourceTimeline: sourceTimeline,
+    displayedKey: { pitchClass: 9, mode: "major" },
+    displayedTimeline,
+    projectId: "proj_123",
+    projectName: "Demo Song",
+    selectedPlaybackArtifactId: "art_source",
+    sourceKey: { pitchClass: 7, mode: "major" },
+    totalDisplayTransposeSemitones: 2,
+    visualCapoSemitoneShift: 0,
+    ...overrides,
+  });
+}
+
+function makePlaybackSession(
+  project: ChordDictionaryFollowProjectContext,
+): ProjectPlaybackSession {
+  return {
+    artifactFormatsById: { art_source: "wav" },
+    artifactPathsById: { art_source: "/tmp/demo.wav" },
+    chordDictionaryFollowProject: project,
+    durationHintSeconds: 96,
+    isStemPlayback: false,
+    loopRange: null,
+    playbackArtifactIds: ["art_source"],
+    precountClickCount: 4,
+    precountEnabled: false,
+    precountLoopEnabled: false,
+    precountTempoBpm: null,
+    projectId: project.projectId,
+    projectName: project.projectName,
+    selectedPlaybackArtifactId: "art_source",
+    stageSummary: "Source mix",
+    stageTitle: "Source audio",
+    stemControls: {},
+    tempoOriginalBpm: null,
+    tempoTargetBpm: null,
+    timingGrid: null,
+    visibleStemArtifactIds: [],
+  };
+}
+
+function makePlaybackValue({
+  isPlaying = true,
+  playbackTimeSeconds = 6,
+  project = makeFollowProject(),
+}: {
+  isPlaying?: boolean;
+  playbackTimeSeconds?: number;
+  project?: ChordDictionaryFollowProjectContext | null;
+} = {}): PlaybackContextValue {
+  const session = project ? makePlaybackSession(project) : null;
+  return {
+    activateStemPlayback: vi.fn(async () => undefined),
+    dismissSession: vi.fn(),
+    getPlaybackSnapshot: () => ({
+      isPlaying,
+      isPrecounting: false,
+      playbackDurationSeconds: 96,
+      playbackTimeSeconds,
+      session,
+    }),
+    isPlaying,
+    isPrecounting: false,
+    pausePlayback: vi.fn(),
+    playPlayback: vi.fn(async () => undefined),
+    playbackDurationSeconds: 96,
+    playbackTimeSeconds,
+    primeWebAudioForGesture: vi.fn(async () => undefined),
+    registerProjectSession: vi.fn(),
+    seekBy: vi.fn(),
+    seekTo: vi.fn(),
+    session,
+    stopPlayback: vi.fn(),
+    togglePlayback: vi.fn(async () => undefined),
+  };
+}
+
+function renderLiveFollow({
+  playback = makePlaybackValue(),
+}: {
+  playback?: PlaybackContextValue;
+} = {}) {
+  render(
+    <MemoryRouter initialEntries={["/tools?tool=chord-dictionary&followPlayback=1&projectId=proj_123"]}>
+      <PlaybackContext.Provider value={playback}>
+        <ChordDictionaryFollowArmProvider>
+          <ChordDictionaryPage />
+        </ChordDictionaryFollowArmProvider>
+      </PlaybackContext.Provider>
+    </MemoryRouter>,
+  );
+  return screen.findByRole("heading", { name: "Chord Dictionary" });
+}
+
+function renderDictionary({
+  playback = makePlaybackValue({ isPlaying: false, project: null }),
+}: {
+  playback?: PlaybackContextValue;
+} = {}) {
+  render(
+    <MemoryRouter initialEntries={["/tools?tool=chord-dictionary"]}>
+      <PlaybackContext.Provider value={playback}>
+        <ChordDictionaryFollowArmProvider>
+          <ChordDictionaryPage />
+        </ChordDictionaryFollowArmProvider>
+      </PlaybackContext.Provider>
+    </MemoryRouter>,
+  );
+  return screen.findByRole("heading", { name: "Chord Dictionary" });
+}
+
+function getLivePage() {
+  const page = document.querySelector(".live-follow-page");
+  if (!(page instanceof HTMLElement)) {
+    throw new Error("Expected Live Follow page");
+  }
+  return page;
+}
+
+function getLiveInstrumentSelector() {
+  return screen.getByRole("group", { name: "Live instrument" });
+}
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    value: width,
+  });
+  Object.defineProperty(document.documentElement, "clientWidth", {
+    configurable: true,
+    value: width,
+  });
+  window.dispatchEvent(new Event("resize"));
+}
+
+describe("Desktop app tools chord dictionary responsive layout", () => {
+  beforeEach(() => {
+    setViewportWidth(1024);
+    resetAppTestHarness();
+  });
+
+  it("keeps Dictionary guitar metadata fields shrinkable in the desktop split layout", async () => {
+    setViewportWidth(1280);
+    await renderDictionary();
+
+    const fieldRow = document.querySelector(".chord-field-row");
+    if (!(fieldRow instanceof HTMLElement)) {
+      throw new Error("Expected guitar metadata field row");
+    }
+
+    expect(within(fieldRow).getByText("Instrument")).toBeInTheDocument();
+    expect(within(fieldRow).getByText("Tuning")).toBeInTheDocument();
+    expect(within(fieldRow).getByText("Capo")).toBeInTheDocument();
+    expect(within(fieldRow).getByText("Retune")).toBeInTheDocument();
+    expect(fieldRow).toHaveAttribute("data-layout", "responsive");
+    expect(fieldRow.querySelectorAll(".chord-field")).toHaveLength(4);
+  });
+
+  it("keeps Live Follow active regions compact without hiding provenance", async () => {
+    const user = userEvent.setup();
+    await renderLiveFollow();
+
+    const page = getLivePage();
+    expect(page).toHaveClass("live-follow-page--active");
+    expect(page).toHaveAttribute("data-follow-status", "active");
+
+    const currentChord = screen.getByLabelText("Current chord");
+    expect(within(currentChord).getByRole("heading", { name: "A" })).toBeInTheDocument();
+    expect(currentChord.querySelectorAll(".live-follow-provenance div")).toHaveLength(5);
+    expect(currentChord).toHaveTextContent(/Source chord\s*G/);
+    expect(currentChord).toHaveTextContent(/Display chord\s*A/);
+    expect(currentChord).toHaveTextContent(/Detected\/imported project chords/);
+    expect(currentChord).toHaveTextContent(/Playback source\s*Demo Song/);
+    expect(screen.getByLabelText("Next chord")).toHaveTextContent(/E/);
+    expect(document.querySelector(".guitar-fretboard")).toBeInTheDocument();
+
+    await user.click(within(getLiveInstrumentSelector()).getByRole("button", { name: "Accordion" }));
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "A accordion positions" })).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("group", { name: /Left hand/i })).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: /Right hand/i })).toBeInTheDocument();
+    expect(document.querySelector(".accordion-stradella")).toBeInTheDocument();
+    expect(document.querySelector(".accordion-keyboard")).toBeInTheDocument();
+    expect(document.querySelector(".guitar-fretboard")).not.toBeInTheDocument();
+
+    await user.click(within(getLiveInstrumentSelector()).getByRole("button", { name: "Piano" }));
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "A piano voicings" })).toBeInTheDocument(),
+    );
+    expect(screen.getByText("Region A")).toBeInTheDocument();
+    expect(document.querySelector(".piano-keyboard")).toBeInTheDocument();
+    expect(document.querySelector(".accordion-stradella")).not.toBeInTheDocument();
+    expect(document.querySelector(".accordion-keyboard")).not.toBeInTheDocument();
+  });
+
+  it("keeps Live Follow waiting state to one status card", async () => {
+    await renderLiveFollow({ playback: makePlaybackValue({ project: null }) });
+
+    const page = getLivePage();
+    expect(page).toHaveClass("live-follow-page--waiting");
+    expect(page).toHaveAttribute("data-follow-status", "no-project");
+    expect(screen.getByRole("status")).toHaveTextContent("No matching project playback");
+    expect(screen.getByRole("group", { name: "Live chord display status" })).toHaveTextContent(
+      "No Project",
+    );
+    expect(screen.queryByLabelText("Current chord")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Next chord")).not.toBeInTheDocument();
+  });
+
+  it("keeps 360px Live Follow controls and instrument regions addressable", async () => {
+    const user = userEvent.setup();
+    setViewportWidth(360);
+    await renderLiveFollow();
+
+    const controls = screen.getByRole("group", { name: "Live chord display status" });
+    expect(within(controls).getByRole("button", { name: "Guitar" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(within(controls).getByRole("button", { name: "Accordion" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(within(controls).getByRole("button", { name: "Piano" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(screen.getByLabelText("Current chord")).toHaveTextContent(/Display chord\s*A/);
+    expect(screen.getByLabelText("Next chord")).toHaveTextContent(/E/);
+    expect(screen.getByRole("group", { name: "Project guitar shape preference choices" }))
+      .toBeInTheDocument();
+    expect(document.querySelector(".chord-shape-grid")).toHaveAttribute("data-layout", "responsive");
+
+    await user.click(within(getLiveInstrumentSelector()).getByRole("button", { name: "Piano" }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("group", { name: "Project piano voicing preference choices" }),
+      ).toBeInTheDocument(),
+    );
+    expect(document.querySelector(".piano-keyboard")).toBeInTheDocument();
+
+    await user.click(within(getLiveInstrumentSelector()).getByRole("button", { name: "Accordion" }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("group", { name: "Project accordion right-hand preference choices" }),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("group", { name: /Left hand/i })).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: /Right hand/i })).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/App.tools-chord-dictionary.test.tsx
+++ b/apps/desktop/src/App.tools-chord-dictionary.test.tsx
@@ -723,6 +723,104 @@ function expectContainedHorizontalOverflow(element: HTMLElement, viewportWidth: 
   expect(element.scrollWidth).toBeLessThanOrEqual(Math.max(element.clientWidth, viewportWidth));
 }
 
+function setWindowScrollPosition(scrollX: number, scrollY: number) {
+  Object.defineProperty(window, "scrollX", {
+    configurable: true,
+    value: scrollX,
+  });
+  Object.defineProperty(window, "scrollY", {
+    configurable: true,
+    value: scrollY,
+  });
+}
+
+function installWindowScrollMock() {
+  const scrollTo = vi.fn();
+  Object.defineProperty(window, "scrollTo", {
+    configurable: true,
+    value: scrollTo,
+  });
+  return scrollTo;
+}
+
+function getMainContent() {
+  const mainContent = document.querySelector(".main-content");
+  if (!(mainContent instanceof HTMLElement)) {
+    throw new Error("Expected app main content scroll container");
+  }
+  return mainContent;
+}
+
+function installElementScrollMock(
+  element: HTMLElement,
+  { scrollLeft = 0, scrollTop }: { scrollLeft?: number; scrollTop: number },
+) {
+  let currentScrollLeft = scrollLeft;
+  let currentScrollTop = scrollTop;
+  const scrollLeftSetter = vi.fn((value: number) => {
+    currentScrollLeft = value;
+  });
+  const scrollTopSetter = vi.fn((value: number) => {
+    currentScrollTop = value;
+  });
+
+  Object.defineProperty(element, "scrollLeft", {
+    configurable: true,
+    get: () => currentScrollLeft,
+    set: scrollLeftSetter,
+  });
+  Object.defineProperty(element, "scrollTop", {
+    configurable: true,
+    get: () => currentScrollTop,
+    set: scrollTopSetter,
+  });
+
+  return { scrollLeftSetter, scrollTopSetter };
+}
+
+function expectDescribedBy(element: HTMLElement, pattern: RegExp) {
+  const describedBy = element.getAttribute("aria-describedby");
+  expect(describedBy).toBeTruthy();
+  const description = describedBy
+    ?.split(/\s+/)
+    .map((id) => document.getElementById(id)?.textContent ?? "")
+    .join(" ");
+  expect(description).toMatch(pattern);
+}
+
+function getActiveShapeCard() {
+  const shapeCard = document.querySelector(".chord-shape-card--active");
+  if (!(shapeCard instanceof HTMLElement)) {
+    throw new Error("Expected an active chord shape card");
+  }
+  return shapeCard;
+}
+
+function getSelectedButton(group: HTMLElement) {
+  const button = within(group).getAllByRole("button").find(
+    (candidate) => candidate.getAttribute("aria-pressed") === "true",
+  );
+  if (!button) {
+    throw new Error("Expected a selected button");
+  }
+  return button as HTMLElement;
+}
+
+function expectInspectorMatchesGuitarNote(noteButton: HTMLElement) {
+  const note = noteButton.dataset.note;
+  const stringNumber = noteButton.dataset.string;
+  const fret = noteButton.dataset.fret;
+
+  expect(note).toBeTruthy();
+  expect(stringNumber).toBeTruthy();
+  expect(fret).toBeTruthy();
+  expectInspectorToShow([
+    new RegExp(escapeRegExp(note ?? "")),
+    new RegExp(`String\\s*${stringNumber ?? ""}`),
+    new RegExp(`Fret\\s*${fret ?? ""}`),
+  ]);
+}
+
 describe("Desktop app tools chord dictionary", () => {
   beforeEach(resetAppTestHarness);
 
@@ -1803,6 +1901,215 @@ describe("Desktop app tools chord dictionary", () => {
     expect(shapeButtons[1]).toHaveAttribute("aria-pressed", "true");
   });
 
+  it("activates the owning Dictionary guitar shape when selecting a note in an inactive card", async () => {
+    const user = userEvent.setup();
+    await renderChordDictionary();
+
+    const shapeGroup = screen.getByRole("group", { name: DICTIONARY_SHAPE_GROUP_NAME });
+    const inactiveShapeButton = within(shapeGroup).getByRole("button", {
+      name: "C E-shape barre",
+    });
+    const inactiveShapeCard = getShapeCard("C E-shape barre");
+    const noteButton = expectPlayableNote(
+      getStandardDiagram("C E-shape barre"),
+      "C3",
+      6,
+      8,
+    );
+
+    expect(inactiveShapeButton).toHaveAttribute("aria-pressed", "false");
+    expect(inactiveShapeCard).not.toHaveClass("chord-shape-card--active");
+
+    await user.click(noteButton);
+
+    await waitFor(() => expect(inactiveShapeButton).toHaveAttribute("aria-pressed", "true"));
+    expect(inactiveShapeCard).toHaveClass("chord-shape-card--active");
+    expect(noteButton).toHaveClass("guitar-fretboard__dot--selected");
+    expectInspectorMatchesGuitarNote(noteButton);
+  });
+
+  it("preserves search focus and viewport while typing across instruments and live fallback", async () => {
+    const user = userEvent.setup();
+    const scrollTo = installWindowScrollMock();
+    const dictionaryView = renderChordDictionaryView();
+    await dictionaryView.findHeading();
+
+    const expectStableSearchChange = async (value: string, scrollY: number) => {
+      const elementScroll = installElementScrollMock(getMainContent(), {
+        scrollLeft: 6,
+        scrollTop: scrollY,
+      });
+      setWindowScrollPosition(8, scrollY + 1);
+      const input = screen.getByLabelText("Chord search");
+      input.focus();
+      fireEvent.change(input, { target: { value } });
+      expect(input).toHaveFocus();
+      await waitFor(() => expect(elementScroll.scrollTopSetter).toHaveBeenCalledWith(scrollY));
+      expect(elementScroll.scrollLeftSetter).toHaveBeenCalledWith(6);
+      expect(scrollTo).toHaveBeenLastCalledWith(8, scrollY + 1);
+    };
+
+    await expectStableSearchChange("D", 420);
+
+    await user.click(within(getDictionaryInstrumentSelector()).getByRole("button", { name: "Accordion" }));
+    await expectStableSearchChange("E", 512);
+
+    await user.click(within(getDictionaryInstrumentSelector()).getByRole("button", { name: "Piano" }));
+    await expectStableSearchChange("F", 640);
+
+    dictionaryView.unmount();
+    await renderChordDictionaryWithPlayback({
+      playback: makePlaybackValue({ isPlaying: false }),
+    });
+    expect(screen.getByText("Playback paused")).toBeInTheDocument();
+    setWindowScrollPosition(8, 720);
+    const input = screen.getByLabelText("Chord search");
+    input.focus();
+    fireEvent.change(input, { target: { value: "G" } });
+    expect(input).toHaveFocus();
+    expect(scrollTo).toHaveBeenLastCalledWith(8, 720);
+  });
+
+  it("supports keyboard-only guitar shape and fretboard note selection", async () => {
+    const user = userEvent.setup();
+    await renderChordDictionary();
+
+    const shapeGroup = screen.getByRole("group", { name: DICTIONARY_SHAPE_GROUP_NAME });
+    const initialShapeButtons = within(shapeGroup).getAllByRole("button");
+    initialShapeButtons[0]?.focus();
+
+    await user.keyboard("{ArrowRight}");
+    const focusedShapeButton = document.activeElement as HTMLElement;
+    expect(focusedShapeButton).toHaveClass("chord-shape-tab");
+    expect(focusedShapeButton).not.toBe(initialShapeButtons[0]);
+    await user.keyboard("{Enter}");
+    await waitFor(() => expect(focusedShapeButton).toHaveAttribute("aria-pressed", "true"));
+    expectDescribedBy(focusedShapeButton, /C .*Guitar.*choice .*tuning/i);
+
+    const activeShapeCard = getActiveShapeCard();
+    const noteButtons = within(activeShapeCard).getAllByRole("button", {
+      name: /string \d fret \d/i,
+    });
+    const firstNoteButton = noteButtons[0] as HTMLElement;
+    firstNoteButton.focus();
+
+    await user.keyboard("{ArrowRight}");
+    const focusedNote = document.activeElement as HTMLElement;
+    expect(focusedNote).toHaveAttribute("data-note-id");
+    expect(focusedNote).not.toBe(firstNoteButton);
+    await user.keyboard(" ");
+
+    await waitFor(() =>
+      expectInspectorToShow([
+        new RegExp(escapeRegExp(focusedNote.dataset.note ?? "")),
+        new RegExp(`String\\s*${focusedNote.dataset.string ?? ""}`),
+        new RegExp(`Fret\\s*${focusedNote.dataset.fret ?? ""}`),
+      ]),
+    );
+    expectDescribedBy(focusedNote, /Guitar.*shape .*degree .*string .*fret/i);
+
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(getSelectedButton(shapeGroup)).toHaveFocus());
+  });
+
+  it("supports keyboard-only piano voicing and key selection", async () => {
+    const user = await selectPianoDictionary();
+
+    changeChordSearch("G7");
+    await screen.findByRole("heading", { name: "G7 piano voicings" });
+    const voicingGroup = screen.getByRole("group", {
+      name: "Global piano voicing preference choices",
+    });
+    const voicingButtons = within(voicingGroup).getAllByRole("button");
+    voicingButtons[0]?.focus();
+
+    await user.keyboard("{ArrowRight}");
+    const focusedVoicing = document.activeElement as HTMLElement;
+    expect(focusedVoicing).toHaveTextContent("G7 first inversion");
+    await user.keyboard("{Enter}");
+    await waitFor(() => expect(focusedVoicing).toHaveAttribute("aria-pressed", "true"));
+    expectDescribedBy(focusedVoicing, /G7 .*Piano.*choice .*range/i);
+
+    const keyboard = getPianoKeyboard();
+    const keyButtons = within(keyboard).getAllByRole("button", { name: /piano key/i });
+    keyButtons[0]?.focus();
+    await user.keyboard("{ArrowRight}");
+    const focusedKey = document.activeElement as HTMLElement;
+    expect(focusedKey).toHaveAttribute("data-note-id");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() =>
+      expectInspectorToShow([
+        new RegExp(escapeRegExp(focusedKey.dataset.pitchLabel ?? "")),
+        new RegExp(`Degree\\s*${focusedKey.dataset.degree ?? ""}`),
+      ]),
+    );
+    expectDescribedBy(focusedKey, /Piano.*voicing .*range.*degree/i);
+
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(getSelectedButton(voicingGroup)).toHaveFocus());
+  });
+
+  it("supports keyboard-only accordion voicing, keys, left buttons, and candidates", async () => {
+    const user = await selectAccordionDictionary();
+
+    const voicingGroup = screen.getByRole("group", {
+      name: "Global accordion right-hand preference choices",
+    });
+    const voicingButtons = within(voicingGroup).getAllByRole("button");
+    voicingButtons[0]?.focus();
+    await user.keyboard("{ArrowRight}");
+    const focusedVoicing = document.activeElement as HTMLElement;
+    expect(focusedVoicing).toHaveClass("chord-shape-tab");
+    await user.keyboard("{Enter}");
+    await waitFor(() => expect(focusedVoicing).toHaveAttribute("aria-pressed", "true"));
+    expectDescribedBy(focusedVoicing, /Accordion.*choice/i);
+
+    const rightHand = screen.getByRole("group", { name: /Right hand/i });
+    const keyboard = getAccordionSurface(
+      rightHand,
+      '[data-surface="keyboard"], .accordion-keyboard, .piano-keyboard',
+    );
+    const keyButtons = within(keyboard).getAllByRole("button", {
+      name: /accordion keyboard key/i,
+    });
+    keyButtons[0]?.focus();
+    await user.keyboard("{ArrowRight}");
+    const focusedKey = document.activeElement as HTMLElement;
+    expect(focusedKey).toHaveAttribute("data-note-id");
+    await user.keyboard("{Enter}");
+    await waitFor(() =>
+      expectInspectorToShow([
+        new RegExp(escapeRegExp(focusedKey.querySelector("strong")?.textContent ?? "")),
+        /Hand\s*Right|Right hand/i,
+      ]),
+    );
+    expectDescribedBy(focusedKey, /Accordion.*voicing .*degree/i);
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(getSelectedButton(voicingGroup)).toHaveFocus());
+
+    const leftHand = screen.getByRole("group", { name: /Left hand/i });
+    const leftButton = getSelectedAccordionButton(leftHand, /(^C$|\bC bass\b|\bbass C\b)/i);
+    leftButton.focus();
+    await user.keyboard("{ArrowDown}");
+    const focusedLeftButton = document.activeElement as HTMLElement;
+    expect(focusedLeftButton.closest('[data-surface="stradella"]')).toBeInTheDocument();
+    await user.keyboard(" ");
+    await waitFor(() => expectInspectorToShow([/Hand\s*Left|Left hand/i, /Stradella/i]));
+    expectDescribedBy(focusedLeftButton, /Accordion.*Stradella.*row.*column/i);
+
+    changeChordSearch("Csus4");
+    await screen.findByRole("heading", { name: "Csus4 accordion positions" });
+    const candidatePanel = screen.getByLabelText("Accordion left-hand candidates");
+    const candidateButtons = within(candidatePanel).getAllByRole("button");
+    expect(candidateButtons.length).toBeGreaterThan(1);
+    candidateButtons[0]?.focus();
+    await user.keyboard("{ArrowDown}");
+    expect(document.activeElement).toBe(candidateButtons[1]);
+    await user.keyboard(" ");
+    await waitFor(() => expect(candidateButtons[1]).toHaveAttribute("aria-pressed", "true"));
+  });
+
   it("persists a dictionary shape choice globally and promotes it when reopened", async () => {
     const user = userEvent.setup();
     const view = renderChordDictionaryView();
@@ -2114,6 +2421,34 @@ describe("Desktop app tools chord dictionary", () => {
 
     await waitFor(() => expectFirstShapeChoice(LIVE_SHAPE_GROUP_NAME, "A D-shape barre"));
     expectFirstShapeCard("A D-shape barre");
+  });
+
+  it("activates the owning Live Follow guitar shape when keyboard-selecting an inactive-card note", async () => {
+    const user = userEvent.setup();
+    await renderChordDictionaryWithPlayback();
+
+    const shapeGroup = screen.getByRole("group", { name: LIVE_SHAPE_GROUP_NAME });
+    const inactiveShapeButton = within(shapeGroup).getByRole("button", {
+      name: "A D-shape barre",
+    });
+    const inactiveShapeCard = getShapeCard("A D-shape barre");
+    const noteButton = within(inactiveShapeCard).getAllByRole("button", {
+      name: /string \d fret \d/i,
+    })[0] as HTMLElement | undefined;
+    if (!noteButton) {
+      throw new Error("Expected a selectable Live Follow guitar note");
+    }
+
+    expect(inactiveShapeButton).toHaveAttribute("aria-pressed", "false");
+    expect(inactiveShapeCard).not.toHaveClass("chord-shape-card--active");
+
+    noteButton.focus();
+    await user.keyboard(" ");
+
+    await waitFor(() => expect(inactiveShapeButton).toHaveAttribute("aria-pressed", "true"));
+    expect(inactiveShapeCard).toHaveClass("chord-shape-card--active");
+    expect(noteButton).toHaveClass("guitar-fretboard__dot--selected");
+    expectInspectorMatchesGuitarNote(noteButton);
   });
 
   it("resets a Live Follow project E shape choice back to the global fallback", async () => {

--- a/apps/desktop/src/features/tools/ChordDictionaryPage.tsx
+++ b/apps/desktop/src/features/tools/ChordDictionaryPage.tsx
@@ -1,4 +1,14 @@
-import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import {
+  Fragment,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+  type RefObject,
+} from "react";
 import { useSearchParams } from "react-router-dom";
 import {
   ArrowUpDown,
@@ -258,6 +268,429 @@ function classNames(...values: Array<string | false | null | undefined>) {
   return values.filter(Boolean).join(" ");
 }
 
+type FocusableElement = HTMLButtonElement | HTMLInputElement;
+type FocusableRef = RefObject<FocusableElement | null>;
+type ButtonRefMap = RefObject<Record<string, HTMLButtonElement | null>>;
+type ScrollContainerSnapshot = {
+  element: HTMLElement;
+  scrollLeft: number;
+  scrollTop: number;
+};
+type ViewportSnapshot = {
+  containers: ScrollContainerSnapshot[];
+  scrollX: number;
+  scrollY: number;
+};
+
+function focusElement(element: FocusableElement | null | undefined) {
+  element?.focus({ preventScroll: true });
+}
+
+function focusRef(ref: FocusableRef) {
+  focusElement(ref.current);
+}
+
+function setButtonRef(refs: ButtonRefMap, id: string, element: HTMLButtonElement | null) {
+  refs.current[id] = element;
+}
+
+function isRestorableScrollContainer(element: HTMLElement) {
+  const style = window.getComputedStyle(element);
+  const overflow = `${style.overflow} ${style.overflowX} ${style.overflowY}`;
+  return (
+    /(auto|scroll|overlay)/.test(overflow) ||
+    element.scrollTop !== 0 ||
+    element.scrollLeft !== 0 ||
+    element.scrollHeight > element.clientHeight ||
+    element.scrollWidth > element.clientWidth
+  );
+}
+
+function getScrollContainerSnapshots(element: HTMLElement) {
+  const snapshots: ScrollContainerSnapshot[] = [];
+  let current = element.parentElement;
+  while (current) {
+    if (isRestorableScrollContainer(current)) {
+      snapshots.push({
+        element: current,
+        scrollLeft: current.scrollLeft,
+        scrollTop: current.scrollTop,
+      });
+    }
+    current = current.parentElement;
+  }
+  return snapshots;
+}
+
+function captureViewportSnapshot(element: HTMLElement): ViewportSnapshot {
+  return {
+    containers: getScrollContainerSnapshots(element),
+    scrollX: window.scrollX,
+    scrollY: window.scrollY,
+  };
+}
+
+function restoreViewportSnapshot(snapshot: ViewportSnapshot) {
+  for (const container of snapshot.containers) {
+    if (!container.element.isConnected) {
+      continue;
+    }
+    container.element.scrollLeft = container.scrollLeft;
+    container.element.scrollTop = container.scrollTop;
+  }
+  if (typeof window.scrollTo === "function") {
+    window.scrollTo(snapshot.scrollX, snapshot.scrollY);
+  }
+}
+
+function getButtonGroupButtons(root: HTMLElement) {
+  return [...root.querySelectorAll<HTMLButtonElement>("button:not(:disabled)")];
+}
+
+function handleButtonGroupKeyDown(
+  event: KeyboardEvent<HTMLElement>,
+  onEscapeFocus?: () => void,
+) {
+  if (event.key === "Escape") {
+    if (!onEscapeFocus) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    onEscapeFocus();
+    return;
+  }
+
+  if (!isLinearNavigationKey(event.key)) {
+    return;
+  }
+
+  const buttons = getButtonGroupButtons(event.currentTarget);
+  const target = event.target instanceof HTMLButtonElement ? event.target : null;
+  const currentIndex = target ? buttons.indexOf(target) : -1;
+  if (currentIndex === -1 || buttons.length === 0) {
+    return;
+  }
+
+  event.preventDefault();
+  event.stopPropagation();
+  const nextIndex = getLinearNavigationIndex(event.key, currentIndex, buttons.length);
+  focusElement(buttons[nextIndex] ?? null);
+}
+
+function isLinearNavigationKey(key: string) {
+  return key === "ArrowRight" || key === "ArrowDown" || key === "ArrowLeft" || key === "ArrowUp" || key === "Home" || key === "End";
+}
+
+function getLinearNavigationIndex(key: string, currentIndex: number, itemCount: number) {
+  if (itemCount <= 0) {
+    return currentIndex;
+  }
+  switch (key) {
+    case "ArrowRight":
+    case "ArrowDown":
+      return (currentIndex + 1) % itemCount;
+    case "ArrowLeft":
+    case "ArrowUp":
+      return (currentIndex - 1 + itemCount) % itemCount;
+    case "Home":
+      return 0;
+    case "End":
+      return itemCount - 1;
+    default:
+      return currentIndex;
+  }
+}
+
+function handleEscapeFocus(
+  event: KeyboardEvent<HTMLElement>,
+  onEscapeFocus?: () => void,
+) {
+  if (event.key !== "Escape" || !onEscapeFocus) {
+    return false;
+  }
+  event.preventDefault();
+  event.stopPropagation();
+  onEscapeFocus();
+  return true;
+}
+
+function focusSurfaceButtonByData(
+  root: HTMLElement | null,
+  dataKey: keyof HTMLElement["dataset"],
+  value: string,
+) {
+  const target = root
+    ? [...root.querySelectorAll<HTMLButtonElement>("button")].find(
+        (button) => button.dataset[dataKey] === value,
+      )
+    : null;
+  focusElement(target);
+}
+
+function getCircularNeighbor<T>(
+  items: readonly T[],
+  currentIndex: number,
+  direction: -1 | 1,
+) {
+  if (items.length === 0 || currentIndex < 0) {
+    return null;
+  }
+  return items[(currentIndex + direction + items.length) % items.length] ?? null;
+}
+
+function getClosestByFret(notes: readonly NotePoint[], displayFret: number) {
+  return [...notes].sort(
+    (left, right) =>
+      Math.abs(left.displayFret - displayFret) - Math.abs(right.displayFret - displayFret) ||
+      left.displayFret - right.displayFret ||
+      left.displayString - right.displayString,
+  )[0] ?? null;
+}
+
+function getGuitarNavigationTargetId(
+  notes: readonly NotePoint[],
+  currentNoteId: string,
+  key: string,
+) {
+  const sortedNotes = [...notes].sort(
+    (left, right) =>
+      left.displayString - right.displayString ||
+      left.displayFret - right.displayFret ||
+      left.string - right.string,
+  );
+  const currentIndex = sortedNotes.findIndex((note) => note.id === currentNoteId);
+  const currentNote = sortedNotes[currentIndex] ?? null;
+  if (!currentNote) {
+    return null;
+  }
+
+  if (key === "Home") {
+    return sortedNotes[0]?.id ?? null;
+  }
+  if (key === "End") {
+    return sortedNotes[sortedNotes.length - 1]?.id ?? null;
+  }
+  if (key === "ArrowLeft" || key === "ArrowRight") {
+    const sameString = sortedNotes.filter((note) => note.string === currentNote.string);
+    const sameStringTarget = key === "ArrowLeft"
+      ? sameString
+          .filter((note) => note.displayFret < currentNote.displayFret)
+          .sort((left, right) => right.displayFret - left.displayFret)[0]
+      : sameString
+          .filter((note) => note.displayFret > currentNote.displayFret)
+          .sort((left, right) => left.displayFret - right.displayFret)[0];
+    return (
+      sameStringTarget ??
+      getCircularNeighbor(sortedNotes, currentIndex, key === "ArrowLeft" ? -1 : 1)
+    )?.id ?? null;
+  }
+
+  if (key === "ArrowUp" || key === "ArrowDown") {
+    const stringTarget = key === "ArrowUp"
+      ? Math.max(
+          -Infinity,
+          ...sortedNotes
+            .filter((note) => note.displayString < currentNote.displayString)
+            .map((note) => note.displayString),
+        )
+      : Math.min(
+          Infinity,
+          ...sortedNotes
+            .filter((note) => note.displayString > currentNote.displayString)
+            .map((note) => note.displayString),
+        );
+    const rowTarget = Number.isFinite(stringTarget)
+      ? getClosestByFret(
+          sortedNotes.filter((note) => note.displayString === stringTarget),
+          currentNote.displayFret,
+        )
+      : null;
+    return (
+      rowTarget ??
+      getCircularNeighbor(sortedNotes, currentIndex, key === "ArrowUp" ? -1 : 1)
+    )?.id ?? null;
+  }
+
+  return null;
+}
+
+function getKeyboardNoteNavigationTargetId<
+  TNote extends { id: string; midi: number },
+>(
+  notes: readonly TNote[],
+  currentNoteId: string,
+  key: string,
+) {
+  const sortedNotes = [...notes].sort((left, right) => left.midi - right.midi);
+  const currentIndex = sortedNotes.findIndex((note) => note.id === currentNoteId);
+  if (currentIndex === -1) {
+    return null;
+  }
+  if (key === "Home") {
+    return sortedNotes[0]?.id ?? null;
+  }
+  if (key === "End") {
+    return sortedNotes[sortedNotes.length - 1]?.id ?? null;
+  }
+  const direction = key === "ArrowRight" || key === "ArrowUp" ? 1 : -1;
+  return getCircularNeighbor(sortedNotes, currentIndex, direction)?.id ?? null;
+}
+
+function getAccordionButtonNavigationTargetId(
+  buttons: readonly AccordionButtonView[],
+  currentButtonId: string,
+  key: string,
+) {
+  const sortedButtons = [...buttons].sort(
+    (left, right) =>
+      left.column - right.column ||
+      (ACCORDION_STRADDELLA_ROW_INDEX.get(left.rowId) ?? 0) -
+        (ACCORDION_STRADDELLA_ROW_INDEX.get(right.rowId) ?? 0),
+  );
+  const currentIndex = sortedButtons.findIndex((button) => button.id === currentButtonId);
+  const currentButton = sortedButtons[currentIndex] ?? null;
+  if (!currentButton) {
+    return null;
+  }
+  if (key === "Home") {
+    return sortedButtons[0]?.id ?? null;
+  }
+  if (key === "End") {
+    return sortedButtons[sortedButtons.length - 1]?.id ?? null;
+  }
+
+  const currentRowIndex = ACCORDION_STRADDELLA_ROW_INDEX.get(currentButton.rowId) ?? 0;
+  const rowMatch = key === "ArrowLeft" || key === "ArrowRight"
+    ? sortedButtons
+        .filter((button) => button.rowId === currentButton.rowId)
+        .filter((button) =>
+          key === "ArrowLeft"
+            ? button.column < currentButton.column
+            : button.column > currentButton.column,
+        )
+        .sort((left, right) =>
+          key === "ArrowLeft" ? right.column - left.column : left.column - right.column,
+        )[0]
+    : null;
+  const columnMatch = key === "ArrowUp" || key === "ArrowDown"
+    ? sortedButtons
+        .filter((button) => button.column === currentButton.column)
+        .filter((button) => {
+          const rowIndex = ACCORDION_STRADDELLA_ROW_INDEX.get(button.rowId) ?? 0;
+          return key === "ArrowUp" ? rowIndex < currentRowIndex : rowIndex > currentRowIndex;
+        })
+        .sort((left, right) => {
+          const leftRow = ACCORDION_STRADDELLA_ROW_INDEX.get(left.rowId) ?? 0;
+          const rightRow = ACCORDION_STRADDELLA_ROW_INDEX.get(right.rowId) ?? 0;
+          return key === "ArrowUp" ? rightRow - leftRow : leftRow - rightRow;
+        })[0]
+    : null;
+  return (
+    rowMatch ??
+    columnMatch ??
+    getCircularNeighbor(
+      sortedButtons,
+      currentIndex,
+      key === "ArrowLeft" || key === "ArrowUp" ? -1 : 1,
+    )
+  )?.id ?? null;
+}
+
+function toDescriptionId(prefix: string, id: string) {
+  return `${prefix}-${id.replace(/[^a-z0-9_-]+/gi, "-")}-description`;
+}
+
+function formatShapeChoiceDescription({
+  chordLabel,
+  index,
+  instrumentLabel,
+  shapeLabel,
+  total,
+  visibleContext,
+}: {
+  chordLabel: string;
+  index: number;
+  instrumentLabel: string;
+  shapeLabel: string;
+  total: number;
+  visibleContext: string;
+}) {
+  return `${chordLabel} ${instrumentLabel} ${shapeLabel}, choice ${index + 1} of ${total}. ${visibleContext}.`;
+}
+
+function formatGuitarNoteButtonDescription({
+  chordLabel,
+  note,
+  shape,
+  shapeIndex,
+  shapeCount,
+  tuningLabel,
+}: {
+  chordLabel: string;
+  note: NotePoint;
+  shape: GuitarShape;
+  shapeIndex: number;
+  shapeCount: number;
+  tuningLabel: string;
+}) {
+  const fingerLabel = note.finger ? ` Finger ${note.finger}.` : "";
+  return `${chordLabel} ${GUITAR_STANDARD_PROFILE.label}, ${shape.label} shape ${shapeIndex + 1} of ${shapeCount}, ${tuningLabel} tuning. ${note.note} degree ${note.degree}, string ${note.string}, fret ${note.fret}.${fingerLabel}`;
+}
+
+function formatPianoKeyDescription({
+  activeChord,
+  note,
+  voicing,
+  voicingIndex,
+  voicingCount,
+}: {
+  activeChord: string;
+  note: PianoNoteView;
+  voicing: PianoVoicingView;
+  voicingIndex: number;
+  voicingCount: number;
+}) {
+  return `${activeChord} ${PIANO_STANDARD_PROFILE.label}, ${voicing.label} voicing ${voicingIndex + 1} of ${voicingCount}, ${formatPianoRange(PIANO_STANDARD_PROFILE)} range. ${note.pitchLabel} degree ${note.degree}, ${formatPianoHandHint(note.handHint)}.`;
+}
+
+function formatAccordionKeyDescription({
+  activeChord,
+  note,
+  voicing,
+  voicingIndex,
+  voicingCount,
+}: {
+  activeChord: string;
+  note: AccordionKeyboardNoteView;
+  voicing: AccordionVoicingView;
+  voicingIndex: number;
+  voicingCount: number;
+}) {
+  const fingerLabel = note.finger ? ` Finger ${note.finger}.` : "";
+  return `${activeChord} ${ACCORDION_STANDARD_PROFILE.label}, ${voicing.label} voicing ${voicingIndex + 1} of ${voicingCount}. ${note.pitchLabel} degree ${note.degree}, ${note.side} ${note.surface}.${fingerLabel}`;
+}
+
+function formatAccordionButtonDescription({
+  activeChord,
+  button,
+  selectedCandidate,
+  voicing,
+  voicingIndex,
+  voicingCount,
+}: {
+  activeChord: string;
+  button: AccordionButtonView;
+  selectedCandidate: AccordionLeftHandCandidateView | null;
+  voicing: AccordionVoicingView;
+  voicingIndex: number;
+  voicingCount: number;
+}) {
+  const degreeLabel = button.degree ? ` degree ${button.degree}` : "";
+  const candidateLabel = selectedCandidate ? ` ${selectedCandidate.label}.` : "";
+  return `${activeChord} ${ACCORDION_STANDARD_PROFILE.label}, ${voicing.label} voicing ${voicingIndex + 1} of ${voicingCount}.${candidateLabel} ${button.pitchLabel}${degreeLabel}, ${button.side} ${button.surface}, ${button.rowLabel} row, column ${button.sourceColumn + 1}.`;
+}
+
 function getChordDictionaryInstrumentLabel(instrumentId: ChordDictionaryInstrumentId) {
   return (
     CHORD_DICTIONARY_INSTRUMENTS.find((instrument) => instrument.id === instrumentId)?.label ??
@@ -449,6 +882,19 @@ function DictionarySurface({
   const [selectedAccordionPointId, setSelectedAccordionPointId] = useState<string | null>(null);
   const [selectedPianoNoteId, setSelectedPianoNoteId] = useState<string | null>(null);
   const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const pendingSearchViewportRef = useRef<ViewportSnapshot | null>(null);
+  const guitarShapeTabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const accordionVoicingTabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const pianoVoicingTabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const focusSearchInput = () => focusRef(searchInputRef);
+  const preserveSearchViewport = () => {
+    const searchInput = searchInputRef.current;
+    if (!searchInput || document.activeElement !== searchInput) {
+      return;
+    }
+    pendingSearchViewportRef.current = captureViewportSnapshot(searchInput);
+  };
   const displayContext = useMemo<Partial<ChordDisplayContext>>(
     () => ({
       canCapo: GUITAR_STANDARD_PROFILE.canCapo,
@@ -721,6 +1167,16 @@ function DictionarySurface({
   const capoLabel = displayContext.capoFret ? `Capo ${displayContext.capoFret}` : "No capo";
   const tuningLabel = formatGuitarTuning(GUITAR_STANDARD_PROFILE);
 
+  useLayoutEffect(() => {
+    const pendingViewport = pendingSearchViewportRef.current;
+    if (!pendingViewport) {
+      return;
+    }
+    pendingSearchViewportRef.current = null;
+    focusSearchInput();
+    restoreViewportSnapshot(pendingViewport);
+  }, [accordionResultKey, activeChord, pianoResultKey, resultKey]);
+
   return (
     <div className="chord-dictionary">
       <div className="chord-dictionary-toolbar">
@@ -728,8 +1184,10 @@ function DictionarySurface({
           <span className="sr-only">Chord search</span>
           <Music2 aria-hidden="true" />
           <input
+            ref={searchInputRef}
             aria-label="Chord search"
             onChange={(event) => {
+              preserveSearchViewport();
               setActiveChord(event.currentTarget.value);
               setPreviewNoteId(null);
               setPreviewAccordionPointId(null);
@@ -764,11 +1222,13 @@ function DictionarySurface({
           hasGlobalPreference={hasGlobalPianoPreference}
           selectedVoicing={selectedPianoVoicing}
           unsupportedChord={unsupportedChord}
+          voicingButtonRefs={pianoVoicingTabRefs}
           voicings={pianoVoicingViews}
           onClearPreference={() => {
             resetGlobalChordDictionaryPreferredShape(pianoPreferenceContext);
             bumpPreferenceRevision();
           }}
+          onEscapeFocus={focusSearchInput}
           onPreviewNote={setPreviewPianoNoteId}
           onSelectNote={(noteId) => {
             setPreviewPianoNoteId(null);
@@ -786,11 +1246,13 @@ function DictionarySurface({
           selectedCandidate={selectedAccordionCandidate}
           selectedVoicing={selectedAccordionVoicing}
           unsupportedChord={unsupportedChord}
+          voicingButtonRefs={accordionVoicingTabRefs}
           voicings={accordionVoicingViews}
           onClearPreference={() => {
             resetGlobalChordDictionaryPreferredShape(accordionPreferenceContext);
             bumpPreferenceRevision();
           }}
+          onEscapeFocus={focusSearchInput}
           onPreviewPoint={setPreviewAccordionPointId}
           onSelectCandidate={(candidateId) => {
             setActiveAccordionCandidate(candidateId);
@@ -826,7 +1288,7 @@ function DictionarySurface({
 
       <div className="chord-tool-grid">
         <main className="chord-tool-main">
-          <div className="chord-field-row">
+          <div className="chord-field-row" data-layout="responsive">
             <div className="chord-field">
               <span>Instrument</span>
               <strong>{GUITAR_STANDARD_PROFILE.label}</strong>
@@ -858,22 +1320,40 @@ function DictionarySurface({
                       aria-describedby="dictionary-shape-preference-copy"
                       aria-label="Global guitar shape preference choices"
                       className="chord-shape-tabs"
+                      onKeyDown={(event) => handleButtonGroupKeyDown(event, focusSearchInput)}
                       role="group"
                     >
-                      {guitarShapes.map((shape) => (
-                        <button
-                          key={shape.id}
-                          aria-pressed={selectedShape?.id === shape.id}
-                          className={classNames(
-                            "chord-shape-tab",
-                            selectedShape?.id === shape.id && "chord-shape-tab--active",
-                          )}
-                          onClick={() => selectShape(shape)}
-                          type="button"
-                        >
-                          {shape.label}
-                        </button>
-                      ))}
+                      {guitarShapes.map((shape, shapeIndex) => {
+                        const descriptionId = toDescriptionId("dictionary-guitar-shape", shape.id);
+                        return (
+                          <Fragment key={shape.id}>
+                            <button
+                              ref={(element) => setButtonRef(guitarShapeTabRefs, shape.id, element)}
+                              aria-describedby={descriptionId}
+                              aria-label={shape.label}
+                              aria-pressed={selectedShape?.id === shape.id}
+                              className={classNames(
+                                "chord-shape-tab",
+                                selectedShape?.id === shape.id && "chord-shape-tab--active",
+                              )}
+                              onClick={() => selectShape(shape)}
+                              type="button"
+                            >
+                              {shape.label}
+                            </button>
+                            <span className="sr-only" id={descriptionId}>
+                              {formatShapeChoiceDescription({
+                                chordLabel: chordSpelling?.label ?? activeChord,
+                                index: shapeIndex,
+                                instrumentLabel: GUITAR_STANDARD_PROFILE.label,
+                                shapeLabel: shape.label,
+                                total: guitarShapes.length,
+                                visibleContext: `${tuningLabel} tuning`,
+                              })}
+                            </span>
+                          </Fragment>
+                        );
+                      })}
                     </div>
                     {hasGlobalShapePreference ? (
                       <button
@@ -918,7 +1398,9 @@ function DictionarySurface({
               />
             ) : (
               <div className="chord-shape-grid" data-layout="responsive">
-                {guitarShapes.map((shape) => (
+                {guitarShapes.map((shape, shapeIndex) => {
+                  const cardDescriptionId = toDescriptionId("dictionary-guitar-shape-card", shape.id);
+                  return (
                   <div
                     key={shape.id}
                     className={classNames(
@@ -927,26 +1409,47 @@ function DictionarySurface({
                     )}
                   >
                     <button
+                      aria-describedby={cardDescriptionId}
+                      aria-label={shape.label}
                       className="chord-shape-card__label"
                       onClick={() => selectShape(shape)}
                       type="button"
                     >
                       {shape.label}
+                      <span className="sr-only" id={cardDescriptionId}>
+                        {formatShapeChoiceDescription({
+                          chordLabel: chordSpelling?.label ?? activeChord,
+                          index: shapeIndex,
+                          instrumentLabel: GUITAR_STANDARD_PROFILE.label,
+                          shapeLabel: shape.label,
+                          total: guitarShapes.length,
+                          visibleContext: `${tuningLabel} tuning`,
+                        })}
+                      </span>
                     </button>
                     <GuitarFretboard
+                      activeChord={chordSpelling?.label ?? activeChord}
                       activeTooltipNoteId={activeTooltipNoteId}
                       notes={shape.notes}
                       selectedNoteId={selectedNoteId}
                       shape={shape}
+                      shapeCount={guitarShapes.length}
+                      shapeIndex={shapeIndex}
+                      tuningLabel={tuningLabel}
+                      onEscapeFocus={() =>
+                        focusElement(guitarShapeTabRefs.current[shape.id] ?? searchInputRef.current)
+                      }
                       onPreviewNote={setPreviewNoteId}
                       onSelectNote={(noteId) => {
+                        setActiveShape(shape.id);
                         setPreviewNoteId(null);
                         setSelectedNoteId(noteId);
                       }}
                     />
                     <span className="chord-shape-card__meta">{shape.meta}</span>
                   </div>
-                ))}
+                  );
+                })}
               </div>
             )}
           </section>
@@ -1052,7 +1555,12 @@ function InstrumentSelector({
   onInstrumentChange: (instrumentId: ChordDictionaryInstrumentId) => void;
 }) {
   return (
-    <div className="chord-toolbar-cluster chord-instrument-selector" role="group" aria-label={ariaLabel}>
+    <div
+      className="chord-toolbar-cluster chord-instrument-selector"
+      role="group"
+      aria-label={ariaLabel}
+      onKeyDown={handleButtonGroupKeyDown}
+    >
       {CHORD_DICTIONARY_INSTRUMENTS.map((instrument) => (
         <button
           key={instrument.id}
@@ -1081,11 +1589,13 @@ function PianoDictionaryContent({
   displayedNote,
   hasGlobalPreference,
   onClearPreference,
+  onEscapeFocus,
   onPreviewNote,
   onSelectNote,
   onSelectVoicing,
   selectedVoicing,
   unsupportedChord,
+  voicingButtonRefs,
   voicings,
 }: {
   activeChord: string;
@@ -1095,8 +1605,10 @@ function PianoDictionaryContent({
   hasGlobalPreference: boolean;
   selectedVoicing: PianoVoicingView | null;
   unsupportedChord: boolean;
+  voicingButtonRefs: ButtonRefMap;
   voicings: readonly PianoVoicingView[];
   onClearPreference: () => void;
+  onEscapeFocus: () => void;
   onPreviewNote: (noteId: string | null) => void;
   onSelectNote: (noteId: string) => void;
   onSelectVoicing: (voicing: PianoVoicingView) => void;
@@ -1141,22 +1653,40 @@ function PianoDictionaryContent({
                       aria-describedby="piano-voicing-preference-copy"
                       aria-label="Global piano voicing preference choices"
                       className="chord-shape-tabs"
+                      onKeyDown={(event) => handleButtonGroupKeyDown(event, onEscapeFocus)}
                       role="group"
                     >
-                      {voicings.map((voicing) => (
-                        <button
-                          key={voicing.id}
-                          aria-pressed={selectedVoicing.id === voicing.id}
-                          className={classNames(
-                            "chord-shape-tab",
-                            selectedVoicing.id === voicing.id && "chord-shape-tab--active",
-                          )}
-                          onClick={() => onSelectVoicing(voicing)}
-                          type="button"
-                        >
-                          {voicing.label}
-                        </button>
-                      ))}
+                      {voicings.map((voicing, voicingIndex) => {
+                        const descriptionId = toDescriptionId("dictionary-piano-voicing", voicing.id);
+                        return (
+                          <Fragment key={voicing.id}>
+                            <button
+                              ref={(element) => setButtonRef(voicingButtonRefs, voicing.id, element)}
+                              aria-describedby={descriptionId}
+                              aria-label={voicing.label}
+                              aria-pressed={selectedVoicing.id === voicing.id}
+                              className={classNames(
+                                "chord-shape-tab",
+                                selectedVoicing.id === voicing.id && "chord-shape-tab--active",
+                              )}
+                              onClick={() => onSelectVoicing(voicing)}
+                              type="button"
+                            >
+                              {voicing.label}
+                            </button>
+                            <span className="sr-only" id={descriptionId}>
+                              {formatShapeChoiceDescription({
+                                chordLabel: chordSpelling.label,
+                                index: voicingIndex,
+                                instrumentLabel: PIANO_STANDARD_PROFILE.label,
+                                shapeLabel: voicing.label,
+                                total: voicings.length,
+                                visibleContext: `${formatPianoRange(PIANO_STANDARD_PROFILE)} range`,
+                              })}
+                            </span>
+                          </Fragment>
+                        );
+                      })}
                     </div>
                     {hasGlobalPreference ? (
                       <button
@@ -1178,7 +1708,17 @@ function PianoDictionaryContent({
               <PianoVoicingPanel
                 activeChord={activeChord}
                 activeNoteId={activeNoteId}
+                voicingCount={voicings.length}
+                voicingIndex={Math.max(0, voicings.findIndex((voicing) => voicing.id === selectedVoicing.id))}
                 voicing={selectedVoicing}
+                onEscapeFocus={() => {
+                  const target = voicingButtonRefs.current[selectedVoicing.id] ?? null;
+                  if (target) {
+                    focusElement(target);
+                    return;
+                  }
+                  onEscapeFocus();
+                }}
                 onPreviewNote={onPreviewNote}
                 onSelectNote={onSelectNote}
               />
@@ -1202,13 +1742,19 @@ function PianoDictionaryContent({
 function PianoVoicingPanel({
   activeChord,
   activeNoteId,
+  onEscapeFocus,
   onPreviewNote,
   onSelectNote,
   voicing,
+  voicingCount,
+  voicingIndex,
 }: {
   activeChord: string;
   activeNoteId: string | null;
   voicing: PianoVoicingView;
+  voicingCount: number;
+  voicingIndex: number;
+  onEscapeFocus: () => void;
   onPreviewNote: (noteId: string | null) => void;
   onSelectNote: (noteId: string) => void;
 }) {
@@ -1234,6 +1780,10 @@ function PianoVoicingPanel({
           activeChord={activeChord}
           activeNoteId={activeNoteId}
           slice={voicing.keyboardSlice}
+          voicing={voicing}
+          voicingCount={voicingCount}
+          voicingIndex={voicingIndex}
+          onEscapeFocus={onEscapeFocus}
           onPreviewNote={onPreviewNote}
           onSelectNote={onSelectNote}
         />
@@ -1266,18 +1816,27 @@ function PianoVoicingOrder({ notes }: { notes: readonly PianoNoteView[] }) {
 function PianoKeyboard({
   activeChord,
   activeNoteId,
+  onEscapeFocus,
   onPreviewNote,
   onSelectNote,
   slice,
+  voicing,
+  voicingCount,
+  voicingIndex,
 }: {
   activeChord: string;
   activeNoteId: string | null;
   slice: PianoKeyboardSlice;
+  voicing: PianoVoicingView;
+  voicingCount: number;
+  voicingIndex: number;
+  onEscapeFocus: () => void;
   onPreviewNote: (noteId: string | null) => void;
   onSelectNote: (noteId: string) => void;
 }) {
   const whiteKeys = slice.keys.filter((key) => !key.isBlack);
   const blackKeys = slice.keys.filter((key) => key.isBlack);
+  const activeNotes = slice.keys.flatMap((key) => (key.note ? [key.note] : []));
 
   return (
     <div
@@ -1294,7 +1853,13 @@ function PianoKeyboard({
           <PianoKeyboardKey
             key={key.midi}
             activeNoteId={activeNoteId}
+            activeNotes={activeNotes}
+            activeChord={activeChord}
             keyView={key}
+            voicing={voicing}
+            voicingCount={voicingCount}
+            voicingIndex={voicingIndex}
+            onEscapeFocus={onEscapeFocus}
             onPreviewNote={onPreviewNote}
             onSelectNote={onSelectNote}
           />
@@ -1305,7 +1870,13 @@ function PianoKeyboard({
           <PianoKeyboardKey
             key={key.midi}
             activeNoteId={activeNoteId}
+            activeNotes={activeNotes}
+            activeChord={activeChord}
             keyView={key}
+            voicing={voicing}
+            voicingCount={voicingCount}
+            voicingIndex={voicingIndex}
+            onEscapeFocus={onEscapeFocus}
             onPreviewNote={onPreviewNote}
             onSelectNote={onSelectNote}
           />
@@ -1317,12 +1888,24 @@ function PianoKeyboard({
 
 function PianoKeyboardKey({
   activeNoteId,
+  activeNotes,
+  activeChord,
   keyView,
+  onEscapeFocus,
   onPreviewNote,
   onSelectNote,
+  voicing,
+  voicingCount,
+  voicingIndex,
 }: {
   activeNoteId: string | null;
+  activeNotes: readonly PianoNoteView[];
+  activeChord: string;
   keyView: PianoKeyboardKeyView;
+  voicing: PianoVoicingView;
+  voicingCount: number;
+  voicingIndex: number;
+  onEscapeFocus: () => void;
   onPreviewNote: (noteId: string | null) => void;
   onSelectNote: (noteId: string) => void;
 }) {
@@ -1348,18 +1931,41 @@ function PianoKeyboardKey({
     );
   }
 
+  const descriptionId = toDescriptionId("piano-key", note.id);
+
   return (
     <button
+      aria-describedby={descriptionId}
       aria-label={`${note.pitchLabel} degree ${note.degree} piano key`}
       className={className}
       data-degree={note.degree}
       data-hand-hint={note.handHint}
       data-key-color={keyView.isBlack ? "black" : "white"}
       data-midi={keyView.midi}
+      data-note-id={note.id}
       data-pitch-label={note.pitchLabel}
       onBlur={() => onPreviewNote(null)}
       onClick={() => onSelectNote(note.id)}
       onFocus={() => onPreviewNote(note.id)}
+      onKeyDown={(event) => {
+        if (handleEscapeFocus(event, onEscapeFocus)) {
+          return;
+        }
+        if (!isLinearNavigationKey(event.key)) {
+          return;
+        }
+        const targetId = getKeyboardNoteNavigationTargetId(activeNotes, note.id, event.key);
+        if (!targetId) {
+          return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        focusSurfaceButtonByData(
+          event.currentTarget.closest<HTMLElement>('[data-surface="piano-keyboard"]'),
+          "noteId",
+          targetId,
+        );
+      }}
       onPointerEnter={() => onPreviewNote(note.id)}
       onPointerLeave={() => onPreviewNote(null)}
       style={style}
@@ -1368,6 +1974,15 @@ function PianoKeyboardKey({
     >
       <strong>{note.pitchLabel}</strong>
       <span>{note.degree}</span>
+      <span className="sr-only" id={descriptionId}>
+        {formatPianoKeyDescription({
+          activeChord,
+          note,
+          voicing,
+          voicingCount,
+          voicingIndex,
+        })}
+      </span>
     </button>
   );
 }
@@ -1471,6 +2086,7 @@ function AccordionDictionaryContent({
   displayedPoint,
   hasGlobalPreference,
   onClearPreference,
+  onEscapeFocus,
   onPreviewPoint,
   onSelectCandidate,
   onSelectPoint,
@@ -1478,6 +2094,7 @@ function AccordionDictionaryContent({
   selectedCandidate,
   selectedVoicing,
   unsupportedChord,
+  voicingButtonRefs,
   voicings,
 }: {
   activeChord: string;
@@ -1488,8 +2105,10 @@ function AccordionDictionaryContent({
   selectedCandidate: AccordionLeftHandCandidateView | null;
   selectedVoicing: AccordionVoicingView | null;
   unsupportedChord: boolean;
+  voicingButtonRefs: ButtonRefMap;
   voicings: readonly AccordionVoicingView[];
   onClearPreference: () => void;
+  onEscapeFocus: () => void;
   onPreviewPoint: (pointId: string | null) => void;
   onSelectCandidate: (candidateId: string) => void;
   onSelectPoint: (pointId: string) => void;
@@ -1531,22 +2150,42 @@ function AccordionDictionaryContent({
                       aria-describedby="accordion-voicing-preference-copy"
                       aria-label="Global accordion right-hand preference choices"
                       className="chord-shape-tabs"
+                      onKeyDown={(event) => handleButtonGroupKeyDown(event, onEscapeFocus)}
                       role="group"
                     >
-                      {voicings.map((voicing) => (
-                        <button
-                          key={voicing.id}
-                          aria-pressed={selectedVoicing.id === voicing.id}
-                          className={classNames(
-                            "chord-shape-tab",
-                            selectedVoicing.id === voicing.id && "chord-shape-tab--active",
-                          )}
-                          onClick={() => onSelectVoicing(voicing)}
-                          type="button"
-                        >
-                          {voicing.label}
-                        </button>
-                      ))}
+                      {voicings.map((voicing, voicingIndex) => {
+                        const descriptionId = toDescriptionId("dictionary-accordion-voicing", voicing.id);
+                        return (
+                          <Fragment key={voicing.id}>
+                            <button
+                              ref={(element) => setButtonRef(voicingButtonRefs, voicing.id, element)}
+                              aria-describedby={descriptionId}
+                              aria-label={voicing.label}
+                              aria-pressed={selectedVoicing.id === voicing.id}
+                              className={classNames(
+                                "chord-shape-tab",
+                                selectedVoicing.id === voicing.id && "chord-shape-tab--active",
+                              )}
+                              onClick={() => onSelectVoicing(voicing)}
+                              type="button"
+                            >
+                              {voicing.label}
+                            </button>
+                            <span className="sr-only" id={descriptionId}>
+                              {formatShapeChoiceDescription({
+                                chordLabel: chordSpelling.label,
+                                index: voicingIndex,
+                                instrumentLabel: ACCORDION_STANDARD_PROFILE.label,
+                                shapeLabel: voicing.label,
+                                total: voicings.length,
+                                visibleContext: voicing.regionRoot
+                                  ? `Region ${voicing.regionRoot}`
+                                  : "No key region",
+                              })}
+                            </span>
+                          </Fragment>
+                        );
+                      })}
                     </div>
                     {hasGlobalPreference ? (
                       <button
@@ -1573,6 +2212,16 @@ function AccordionDictionaryContent({
                 activePointId={activePointId}
                 selectedCandidate={selectedCandidate}
                 voicing={selectedVoicing}
+                voicingCount={voicings.length}
+                voicingIndex={Math.max(0, voicings.findIndex((voicing) => voicing.id === selectedVoicing.id))}
+                onEscapeFocus={() => {
+                  const target = voicingButtonRefs.current[selectedVoicing.id] ?? null;
+                  if (target) {
+                    focusElement(target);
+                    return;
+                  }
+                  onEscapeFocus();
+                }}
                 onPreviewPoint={onPreviewPoint}
                 onSelectPoint={onSelectPoint}
               />
@@ -1584,6 +2233,14 @@ function AccordionDictionaryContent({
           <AccordionCandidateList
             candidates={selectedVoicing.leftHandCandidates}
             selectedCandidateId={selectedCandidate?.id ?? null}
+            onEscapeFocus={() => {
+              const target = voicingButtonRefs.current[selectedVoicing.id] ?? null;
+              if (target) {
+                focusElement(target);
+                return;
+              }
+              onEscapeFocus();
+            }}
             onSelectCandidate={onSelectCandidate}
           />
           </aside>
@@ -1596,15 +2253,21 @@ function AccordionDictionaryContent({
 function AccordionVoicingPanel({
   activeChord,
   activePointId,
+  onEscapeFocus,
   onPreviewPoint,
   onSelectPoint,
   selectedCandidate,
   voicing,
+  voicingCount,
+  voicingIndex,
 }: {
   activeChord: string;
   activePointId: string | null;
   selectedCandidate: AccordionLeftHandCandidateView | null;
   voicing: AccordionVoicingView;
+  voicingCount: number;
+  voicingIndex: number;
+  onEscapeFocus: () => void;
   onPreviewPoint: (pointId: string | null) => void;
   onSelectPoint: (pointId: string) => void;
 }) {
@@ -1630,6 +2293,11 @@ function AccordionVoicingPanel({
             activePointId={activePointId}
             buttons={visibleButtons}
             selectedCandidate={selectedCandidate}
+            voicing={voicing}
+            voicingCount={voicingCount}
+            voicingIndex={voicingIndex}
+            activeChord={activeChord}
+            onEscapeFocus={onEscapeFocus}
             onPreviewPoint={onPreviewPoint}
             onSelectPoint={onSelectPoint}
           />
@@ -1651,6 +2319,10 @@ function AccordionVoicingPanel({
             activeChord={activeChord}
             activePointId={activePointId}
             slice={voicing.keyboardSlice}
+            voicing={voicing}
+            voicingCount={voicingCount}
+            voicingIndex={voicingIndex}
+            onEscapeFocus={onEscapeFocus}
             onPreviewPoint={onPreviewPoint}
             onSelectPoint={onSelectPoint}
           />
@@ -1666,15 +2338,25 @@ function AccordionVoicingPanel({
 }
 
 function AccordionStradellaLattice({
+  activeChord,
   activePointId,
   buttons,
+  onEscapeFocus,
   onPreviewPoint,
   onSelectPoint,
   selectedCandidate,
+  voicing,
+  voicingCount,
+  voicingIndex,
 }: {
+  activeChord: string;
   activePointId: string | null;
   buttons: readonly AccordionButtonView[];
   selectedCandidate: AccordionLeftHandCandidateView | null;
+  voicing: AccordionVoicingView;
+  voicingCount: number;
+  voicingIndex: number;
+  onEscapeFocus: () => void;
   onPreviewPoint: (pointId: string | null) => void;
   onSelectPoint: (pointId: string) => void;
 }) {
@@ -1699,9 +2381,11 @@ function AccordionStradellaLattice({
           const rowIndex = ACCORDION_STRADDELLA_ROW_INDEX.get(button.rowId) ?? 0;
           const isSelectedButton = selectedButtonIds.has(button.id);
           const isActiveButton = isSelectedButton || activePointId === button.id;
+          const descriptionId = toDescriptionId("accordion-stradella-button", button.id);
           return (
             <button
               key={button.id}
+              aria-describedby={descriptionId}
               aria-label={`${button.label} ${button.rowLabel} accordion button`}
               aria-pressed={isSelectedButton}
               className={classNames(
@@ -1711,12 +2395,34 @@ function AccordionStradellaLattice({
                 isActiveButton && "accordion-stradella__button--active",
               )}
               data-active={isActiveButton ? "true" : "false"}
+              data-button-id={button.id}
               data-label={button.label}
               data-selected={isSelectedButton ? "true" : "false"}
               data-row={button.rowId}
+              data-row-index={rowIndex}
+              data-source-column={button.sourceColumn}
               onBlur={() => onPreviewPoint(null)}
               onClick={() => onSelectPoint(button.id)}
               onFocus={() => onPreviewPoint(button.id)}
+              onKeyDown={(event) => {
+                if (handleEscapeFocus(event, onEscapeFocus)) {
+                  return;
+                }
+                if (!isLinearNavigationKey(event.key)) {
+                  return;
+                }
+                const targetId = getAccordionButtonNavigationTargetId(buttons, button.id, event.key);
+                if (!targetId) {
+                  return;
+                }
+                event.preventDefault();
+                event.stopPropagation();
+                focusSurfaceButtonByData(
+                  event.currentTarget.closest<HTMLElement>('[data-surface="stradella"]'),
+                  "buttonId",
+                  targetId,
+                );
+              }}
               onPointerEnter={() => onPreviewPoint(button.id)}
               onPointerLeave={() => onPreviewPoint(null)}
               style={
@@ -1730,6 +2436,16 @@ function AccordionStradellaLattice({
               type="button"
             >
               {button.rowId === "counterbass" ? null : button.label}
+              <span className="sr-only" id={descriptionId}>
+                {formatAccordionButtonDescription({
+                  activeChord,
+                  button,
+                  selectedCandidate,
+                  voicing,
+                  voicingCount,
+                  voicingIndex,
+                })}
+              </span>
             </button>
           );
         })}
@@ -1741,18 +2457,27 @@ function AccordionStradellaLattice({
 function AccordionKeyboard({
   activeChord,
   activePointId,
+  onEscapeFocus,
   onPreviewPoint,
   onSelectPoint,
   slice,
+  voicing,
+  voicingCount,
+  voicingIndex,
 }: {
   activeChord: string;
   activePointId: string | null;
   slice: AccordionKeyboardSlice;
+  voicing: AccordionVoicingView;
+  voicingCount: number;
+  voicingIndex: number;
+  onEscapeFocus: () => void;
   onPreviewPoint: (pointId: string | null) => void;
   onSelectPoint: (pointId: string) => void;
 }) {
   const whiteKeys = slice.keys.filter((key) => !key.isBlack);
   const blackKeys = slice.keys.filter((key) => key.isBlack);
+  const activeNotes = slice.keys.flatMap((key) => (key.note ? [key.note] : []));
 
   return (
     <div
@@ -1770,7 +2495,13 @@ function AccordionKeyboard({
           <AccordionKeyboardKey
             key={key.midi}
             activePointId={activePointId}
+            activeChord={activeChord}
+            activeNotes={activeNotes}
             keyView={key}
+            voicing={voicing}
+            voicingCount={voicingCount}
+            voicingIndex={voicingIndex}
+            onEscapeFocus={onEscapeFocus}
             onPreviewPoint={onPreviewPoint}
             onSelectPoint={onSelectPoint}
           />
@@ -1781,7 +2512,13 @@ function AccordionKeyboard({
           <AccordionKeyboardKey
             key={key.midi}
             activePointId={activePointId}
+            activeChord={activeChord}
+            activeNotes={activeNotes}
             keyView={key}
+            voicing={voicing}
+            voicingCount={voicingCount}
+            voicingIndex={voicingIndex}
+            onEscapeFocus={onEscapeFocus}
             onPreviewPoint={onPreviewPoint}
             onSelectPoint={onSelectPoint}
           />
@@ -1793,12 +2530,24 @@ function AccordionKeyboard({
 
 function AccordionKeyboardKey({
   activePointId,
+  activeChord,
+  activeNotes,
   keyView,
+  onEscapeFocus,
   onPreviewPoint,
   onSelectPoint,
+  voicing,
+  voicingCount,
+  voicingIndex,
 }: {
   activePointId: string | null;
+  activeChord: string;
+  activeNotes: readonly AccordionKeyboardNoteView[];
   keyView: AccordionKeyboardKeyView;
+  voicing: AccordionVoicingView;
+  voicingCount: number;
+  voicingIndex: number;
+  onEscapeFocus: () => void;
   onPreviewPoint: (pointId: string | null) => void;
   onSelectPoint: (pointId: string) => void;
 }) {
@@ -1824,16 +2573,39 @@ function AccordionKeyboardKey({
     );
   }
 
+  const descriptionId = toDescriptionId("accordion-keyboard-key", note.id);
+
   return (
     <button
+      aria-describedby={descriptionId}
       aria-label={`${note.pitchLabel} degree ${note.degree} accordion keyboard key`}
       className={className}
       data-key-color={keyView.isBlack ? "black" : "white"}
       data-midi={keyView.midi}
+      data-note-id={note.id}
       data-key-position={keyView.isBlack ? "black-overlay" : "white-surface-row"}
       onBlur={() => onPreviewPoint(null)}
       onClick={() => onSelectPoint(note.id)}
       onFocus={() => onPreviewPoint(note.id)}
+      onKeyDown={(event) => {
+        if (handleEscapeFocus(event, onEscapeFocus)) {
+          return;
+        }
+        if (!isLinearNavigationKey(event.key)) {
+          return;
+        }
+        const targetId = getKeyboardNoteNavigationTargetId(activeNotes, note.id, event.key);
+        if (!targetId) {
+          return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        focusSurfaceButtonByData(
+          event.currentTarget.closest<HTMLElement>('[data-surface="keyboard"]'),
+          "noteId",
+          targetId,
+        );
+      }}
       onPointerEnter={() => onPreviewPoint(note.id)}
       onPointerLeave={() => onPreviewPoint(null)}
       style={style}
@@ -1842,17 +2614,28 @@ function AccordionKeyboardKey({
     >
       <strong>{note.pitchLabel}</strong>
       <span>{note.degree}</span>
+      <span className="sr-only" id={descriptionId}>
+        {formatAccordionKeyDescription({
+          activeChord,
+          note,
+          voicing,
+          voicingCount,
+          voicingIndex,
+        })}
+      </span>
     </button>
   );
 }
 
 export function AccordionCandidateList({
   candidates,
+  onEscapeFocus,
   onSelectCandidate,
   selectedCandidateId,
 }: {
   candidates: readonly AccordionLeftHandCandidateView[];
   selectedCandidateId: string | null;
+  onEscapeFocus?: () => void;
   onSelectCandidate: (candidateId: string) => void;
 }) {
   if (candidates.length === 0) {
@@ -1875,12 +2658,17 @@ export function AccordionCandidateList({
   return (
     <section className="accordion-candidate-panel" aria-label="Accordion left-hand candidates">
       <h4>Left hand</h4>
-      <div className="accordion-candidate-list">
+      <div
+        className="accordion-candidate-list"
+        onKeyDown={(event) => handleButtonGroupKeyDown(event, onEscapeFocus)}
+      >
         {candidates.map((candidate) => {
           const isSelectedCandidate = selectedCandidateId === candidate.id;
+          const descriptionId = toDescriptionId("accordion-candidate", candidate.id);
           return (
             <button
               key={candidate.id}
+              aria-describedby={descriptionId}
               aria-pressed={isSelectedCandidate}
               className={classNames(
                 "accordion-candidate-card",
@@ -1912,6 +2700,9 @@ export function AccordionCandidateList({
                   ) : null}
                 </span>
               ) : null}
+              <span className="sr-only" id={descriptionId}>
+                {`Accordion left-hand candidate ${candidate.rank + 1}: ${candidate.label}. ${candidate.detail}. ${candidate.isExact ? "Exact match" : "Approximate match"}.`}
+              </span>
             </button>
           );
         })}
@@ -3166,19 +3957,29 @@ function MiniFretboard({ shape }: { shape: GuitarShape | null }) {
 }
 
 function GuitarFretboard({
+  activeChord,
   activeTooltipNoteId,
   notes,
+  onEscapeFocus,
   onPreviewNote,
   onSelectNote,
   selectedNoteId,
   shape,
+  shapeCount,
+  shapeIndex,
+  tuningLabel,
 }: {
+  activeChord: string;
   activeTooltipNoteId: string | null;
   notes: readonly NotePoint[];
+  onEscapeFocus: () => void;
   onPreviewNote: (noteId: string | null) => void;
   onSelectNote: (noteId: string | null) => void;
   selectedNoteId: string | null;
   shape: GuitarShape;
+  shapeCount: number;
+  shapeIndex: number;
+  tuningLabel: string;
 }) {
   return (
     <span
@@ -3193,6 +3994,7 @@ function GuitarFretboard({
         } as CSSProperties
       }
       aria-label={`${shape.label} standard guitar diagram`}
+      data-surface="guitar-fretboard"
       role="group"
     >
       <span className="guitar-fretboard__markers" role="group" aria-label="String status markers">
@@ -3265,50 +4067,84 @@ function GuitarFretboard({
             }
           />
         ))}
-        {notes.map((note) => (
-          <button
-            key={note.id}
-            aria-label={formatNoteButtonLabel(note)}
-            className={classNames(
-              "guitar-fretboard__dot",
-              note.isOpen && "guitar-fretboard__dot--open",
-              shape.barreGroups.some((barre) => barre.noteIds.includes(note.id)) &&
-                "guitar-fretboard__dot--over-barre",
-              selectedNoteId === note.id && "guitar-fretboard__dot--selected",
-              activeTooltipNoteId === note.id && "guitar-fretboard__dot--tooltip-active",
-            )}
-            data-fret={note.fret}
-            data-note={note.note}
-            data-note-kind={note.isOpen ? "open" : "fretted"}
-            data-tooltip-active={activeTooltipNoteId === note.id ? "true" : "false"}
-            data-string={note.string}
-            onBlur={() => onPreviewNote(null)}
-            onClick={(event) => {
-              event.stopPropagation();
-              onSelectNote(note.id);
-            }}
-            onFocus={() => onPreviewNote(note.id)}
-            onPointerEnter={() => onPreviewNote(note.id)}
-            onPointerLeave={() => onPreviewNote(null)}
-            style={
-              {
-                "--fret": note.fret,
-                "--fret-position": note.displayFret,
-                "--string": note.displayString,
-                "--visible-fret": note.displayFret,
-              } as CSSProperties
-            }
-            title={note.note}
-            type="button"
-          >
-            <span className="guitar-fretboard__dot-finger" aria-hidden="true">
-              {note.finger}
-            </span>
-            <span className="guitar-fretboard__note-tooltip" aria-hidden="true">
-              {note.note}
-            </span>
-          </button>
-        ))}
+        {notes.map((note) => {
+          const descriptionId = toDescriptionId("guitar-note", note.id);
+          return (
+            <button
+              key={note.id}
+              aria-describedby={descriptionId}
+              aria-label={formatNoteButtonLabel(note)}
+              className={classNames(
+                "guitar-fretboard__dot",
+                note.isOpen && "guitar-fretboard__dot--open",
+                shape.barreGroups.some((barre) => barre.noteIds.includes(note.id)) &&
+                  "guitar-fretboard__dot--over-barre",
+                selectedNoteId === note.id && "guitar-fretboard__dot--selected",
+                activeTooltipNoteId === note.id && "guitar-fretboard__dot--tooltip-active",
+              )}
+              data-fret={note.fret}
+              data-note={note.note}
+              data-note-id={note.id}
+              data-note-kind={note.isOpen ? "open" : "fretted"}
+              data-tooltip-active={activeTooltipNoteId === note.id ? "true" : "false"}
+              data-string={note.string}
+              onBlur={() => onPreviewNote(null)}
+              onClick={(event) => {
+                event.stopPropagation();
+                onSelectNote(note.id);
+              }}
+              onFocus={() => onPreviewNote(note.id)}
+              onKeyDown={(event) => {
+                if (handleEscapeFocus(event, onEscapeFocus)) {
+                  return;
+                }
+                if (!isLinearNavigationKey(event.key)) {
+                  return;
+                }
+                const targetId = getGuitarNavigationTargetId(notes, note.id, event.key);
+                if (!targetId) {
+                  return;
+                }
+                event.preventDefault();
+                event.stopPropagation();
+                focusSurfaceButtonByData(
+                  event.currentTarget.closest<HTMLElement>('[data-surface="guitar-fretboard"]'),
+                  "noteId",
+                  targetId,
+                );
+              }}
+              onPointerEnter={() => onPreviewNote(note.id)}
+              onPointerLeave={() => onPreviewNote(null)}
+              style={
+                {
+                  "--fret": note.fret,
+                  "--fret-position": note.displayFret,
+                  "--string": note.displayString,
+                  "--visible-fret": note.displayFret,
+                } as CSSProperties
+              }
+              title={note.note}
+              type="button"
+            >
+              <span className="guitar-fretboard__dot-finger" aria-hidden="true">
+                {note.finger}
+              </span>
+              <span className="guitar-fretboard__note-tooltip" aria-hidden="true">
+                {note.note}
+              </span>
+              <span className="sr-only" id={descriptionId}>
+                {formatGuitarNoteButtonDescription({
+                  chordLabel: activeChord,
+                  note,
+                  shape,
+                  shapeCount,
+                  shapeIndex,
+                  tuningLabel,
+                })}
+              </span>
+            </button>
+          );
+        })}
       </span>
       <span className="guitar-fretboard__numbers" aria-hidden="true">
         {shape.fretWindow.frets.map((fret) => (
@@ -3442,6 +4278,7 @@ function LiveFollowPianoActiveState({
   const [previewNoteId, setPreviewNoteId] = useState<string | null>(null);
   const [, setPreferenceRevision] = useState(0);
   const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
+  const voicingTabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const chordSpelling = useMemo(
     () =>
       currentChord
@@ -3646,22 +4483,40 @@ function LiveFollowPianoActiveState({
                     aria-describedby="live-piano-preference-copy"
                     aria-label="Project piano voicing preference choices"
                     className="chord-shape-tabs"
+                    onKeyDown={handleButtonGroupKeyDown}
                     role="group"
                   >
-                    {voicingViews.map((voicing) => (
-                      <button
-                        key={voicing.id}
-                        aria-pressed={selectedVoicing.id === voicing.id}
-                        className={classNames(
-                          "chord-shape-tab",
-                          selectedVoicing.id === voicing.id && "chord-shape-tab--active",
-                        )}
-                        onClick={() => selectVoicing(voicing)}
-                        type="button"
-                      >
-                        {voicing.label}
-                      </button>
-                    ))}
+                    {voicingViews.map((voicing, voicingIndex) => {
+                      const descriptionId = toDescriptionId("live-piano-voicing", voicing.id);
+                      return (
+                        <Fragment key={voicing.id}>
+                          <button
+                            ref={(element) => setButtonRef(voicingTabRefs, voicing.id, element)}
+                            aria-describedby={descriptionId}
+                            aria-label={voicing.label}
+                            aria-pressed={selectedVoicing.id === voicing.id}
+                            className={classNames(
+                              "chord-shape-tab",
+                              selectedVoicing.id === voicing.id && "chord-shape-tab--active",
+                            )}
+                            onClick={() => selectVoicing(voicing)}
+                            type="button"
+                          >
+                            {voicing.label}
+                          </button>
+                          <span className="sr-only" id={descriptionId}>
+                            {formatShapeChoiceDescription({
+                              chordLabel: chordSpelling.label,
+                              index: voicingIndex,
+                              instrumentLabel: PIANO_STANDARD_PROFILE.label,
+                              shapeLabel: voicing.label,
+                              total: voicingViews.length,
+                              visibleContext: `${formatPianoRange(PIANO_STANDARD_PROFILE)} range`,
+                            })}
+                          </span>
+                        </Fragment>
+                      );
+                    })}
                   </div>
                   {hasProjectPreference ? (
                     <button
@@ -3687,6 +4542,9 @@ function LiveFollowPianoActiveState({
               activeChord={currentChord.displayLabel}
               activeNoteId={activeNoteId}
               voicing={selectedVoicing}
+              voicingCount={voicingViews.length}
+              voicingIndex={Math.max(0, voicingViews.findIndex((voicing) => voicing.id === selectedVoicing.id))}
+              onEscapeFocus={() => focusElement(voicingTabRefs.current[selectedVoicing.id])}
               onPreviewNote={setPreviewNoteId}
               onSelectNote={(noteId) => {
                 setPreviewNoteId(null);
@@ -3741,6 +4599,7 @@ function LiveFollowActiveState({
   const [previewNoteId, setPreviewNoteId] = useState<string | null>(null);
   const [, setPreferenceRevision] = useState(0);
   const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
+  const shapeTabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const displayContext = useMemo<Partial<ChordDisplayContext>>(
     () => ({
       canCapo: GUITAR_STANDARD_PROFILE.canCapo,
@@ -3956,22 +4815,40 @@ function LiveFollowActiveState({
                     aria-describedby="live-shape-preference-copy"
                     aria-label="Project guitar shape preference choices"
                     className="chord-shape-tabs"
+                    onKeyDown={handleButtonGroupKeyDown}
                     role="group"
                   >
-                    {guitarShapes.map((shape) => (
-                      <button
-                        key={shape.id}
-                        aria-pressed={selectedShape?.id === shape.id}
-                        className={classNames(
-                          "chord-shape-tab",
-                          selectedShape?.id === shape.id && "chord-shape-tab--active",
-                        )}
-                        onClick={() => selectShape(shape)}
-                        type="button"
-                      >
-                        {shape.label}
-                      </button>
-                    ))}
+                    {guitarShapes.map((shape, shapeIndex) => {
+                      const descriptionId = toDescriptionId("live-guitar-shape", shape.id);
+                      return (
+                        <Fragment key={shape.id}>
+                          <button
+                            ref={(element) => setButtonRef(shapeTabRefs, shape.id, element)}
+                            aria-describedby={descriptionId}
+                            aria-label={shape.label}
+                            aria-pressed={selectedShape?.id === shape.id}
+                            className={classNames(
+                              "chord-shape-tab",
+                              selectedShape?.id === shape.id && "chord-shape-tab--active",
+                            )}
+                            onClick={() => selectShape(shape)}
+                            type="button"
+                          >
+                            {shape.label}
+                          </button>
+                          <span className="sr-only" id={descriptionId}>
+                            {formatShapeChoiceDescription({
+                              chordLabel: chordSpelling.label,
+                              index: shapeIndex,
+                              instrumentLabel: GUITAR_STANDARD_PROFILE.label,
+                              shapeLabel: shape.label,
+                              total: guitarShapes.length,
+                              visibleContext: `${formatGuitarTuning(GUITAR_STANDARD_PROFILE)} tuning`,
+                            })}
+                          </span>
+                        </Fragment>
+                      );
+                    })}
                   </div>
                   {hasProjectShapePreference ? (
                     <button
@@ -3997,7 +4874,9 @@ function LiveFollowActiveState({
             </div>
             <ChordSpellingSummary spelling={chordSpelling} />
             <div className="chord-shape-grid" data-layout="responsive">
-              {guitarShapes.map((shape) => (
+              {guitarShapes.map((shape, shapeIndex) => {
+                const cardDescriptionId = toDescriptionId("live-guitar-shape-card", shape.id);
+                return (
                 <div
                   key={shape.id}
                   className={classNames(
@@ -4006,26 +4885,45 @@ function LiveFollowActiveState({
                   )}
                 >
                   <button
+                    aria-describedby={cardDescriptionId}
+                    aria-label={shape.label}
                     className="chord-shape-card__label"
                     onClick={() => selectShape(shape)}
                     type="button"
                   >
                     {shape.label}
+                    <span className="sr-only" id={cardDescriptionId}>
+                      {formatShapeChoiceDescription({
+                        chordLabel: chordSpelling.label,
+                        index: shapeIndex,
+                        instrumentLabel: GUITAR_STANDARD_PROFILE.label,
+                        shapeLabel: shape.label,
+                        total: guitarShapes.length,
+                        visibleContext: `${formatGuitarTuning(GUITAR_STANDARD_PROFILE)} tuning`,
+                      })}
+                    </span>
                   </button>
                   <GuitarFretboard
+                    activeChord={currentChord.displayLabel}
                     activeTooltipNoteId={activeTooltipNoteId}
                     notes={shape.notes}
                     selectedNoteId={selectedNoteId}
                     shape={shape}
+                    shapeCount={guitarShapes.length}
+                    shapeIndex={shapeIndex}
+                    tuningLabel={formatGuitarTuning(GUITAR_STANDARD_PROFILE)}
+                    onEscapeFocus={() => focusElement(shapeTabRefs.current[shape.id])}
                     onPreviewNote={setPreviewNoteId}
                     onSelectNote={(noteId) => {
+                      setActiveShape(shape.id);
                       setPreviewNoteId(null);
                       setSelectedNoteId(noteId);
                     }}
                   />
                   <span className="chord-shape-card__meta">{shape.meta}</span>
                 </div>
-              ))}
+                );
+              })}
             </div>
           </section>
         </main>
@@ -4071,6 +4969,7 @@ function LiveFollowAccordionActiveState({
   const [previewPointId, setPreviewPointId] = useState<string | null>(null);
   const [, setPreferenceRevision] = useState(0);
   const [selectedPointId, setSelectedPointId] = useState<string | null>(null);
+  const voicingTabRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const chordSpelling = useMemo(
     () =>
       currentChord
@@ -4286,22 +5185,42 @@ function LiveFollowAccordionActiveState({
                     aria-describedby="live-accordion-preference-copy"
                     aria-label="Project accordion right-hand preference choices"
                     className="chord-shape-tabs"
+                    onKeyDown={handleButtonGroupKeyDown}
                     role="group"
                   >
-                    {voicingViews.map((voicing) => (
-                      <button
-                        key={voicing.id}
-                        aria-pressed={selectedVoicing.id === voicing.id}
-                        className={classNames(
-                          "chord-shape-tab",
-                          selectedVoicing.id === voicing.id && "chord-shape-tab--active",
-                        )}
-                        onClick={() => selectVoicing(voicing)}
-                        type="button"
-                      >
-                        {voicing.label}
-                      </button>
-                    ))}
+                    {voicingViews.map((voicing, voicingIndex) => {
+                      const descriptionId = toDescriptionId("live-accordion-voicing", voicing.id);
+                      return (
+                        <Fragment key={voicing.id}>
+                          <button
+                            ref={(element) => setButtonRef(voicingTabRefs, voicing.id, element)}
+                            aria-describedby={descriptionId}
+                            aria-label={voicing.label}
+                            aria-pressed={selectedVoicing.id === voicing.id}
+                            className={classNames(
+                              "chord-shape-tab",
+                              selectedVoicing.id === voicing.id && "chord-shape-tab--active",
+                            )}
+                            onClick={() => selectVoicing(voicing)}
+                            type="button"
+                          >
+                            {voicing.label}
+                          </button>
+                          <span className="sr-only" id={descriptionId}>
+                            {formatShapeChoiceDescription({
+                              chordLabel: chordSpelling.label,
+                              index: voicingIndex,
+                              instrumentLabel: ACCORDION_STANDARD_PROFILE.label,
+                              shapeLabel: voicing.label,
+                              total: voicingViews.length,
+                              visibleContext: voicing.regionRoot
+                                ? `Region ${voicing.regionRoot}`
+                                : "No key region",
+                            })}
+                          </span>
+                        </Fragment>
+                      );
+                    })}
                   </div>
                   {hasProjectPreference ? (
                     <button
@@ -4328,6 +5247,9 @@ function LiveFollowAccordionActiveState({
               activePointId={activePointId}
               selectedCandidate={selectedCandidate}
               voicing={selectedVoicing}
+              voicingCount={voicingViews.length}
+              voicingIndex={Math.max(0, voicingViews.findIndex((voicing) => voicing.id === selectedVoicing.id))}
+              onEscapeFocus={() => focusElement(voicingTabRefs.current[selectedVoicing.id])}
               onPreviewPoint={setPreviewPointId}
               onSelectPoint={(pointId) => {
                 setPreviewPointId(null);
@@ -4359,6 +5281,7 @@ function LiveFollowAccordionActiveState({
           <AccordionCandidateList
             candidates={selectedVoicing.leftHandCandidates}
             selectedCandidateId={selectedCandidate?.id ?? null}
+            onEscapeFocus={() => focusElement(voicingTabRefs.current[selectedVoicing.id])}
             onSelectCandidate={(candidateId) => {
               setActiveCandidate(candidateId);
               setPreviewPointId(null);

--- a/apps/desktop/src/styles/tools.css
+++ b/apps/desktop/src/styles/tools.css
@@ -732,14 +732,16 @@
 
 .chord-field-row {
   display: grid;
-  grid-template-columns: minmax(10rem, 1.25fr) minmax(12rem, 1.1fr) repeat(2, minmax(6rem, 0.55fr));
+  grid-template-columns: repeat(4, minmax(min(100%, 7rem), 1fr));
   gap: 0.7rem;
+  min-width: 0;
 }
 
 .chord-field {
   display: grid;
   justify-items: start;
   gap: 0.12rem;
+  min-width: 0;
   min-height: 3.2rem;
   padding: 0.6rem 0.72rem;
   border: 1px solid color-mix(in srgb, var(--divider) 70%, transparent);
@@ -757,6 +759,8 @@
 }
 
 .chord-field strong {
+  max-width: 100%;
+  overflow-wrap: anywhere;
   font-size: 0.95rem;
 }
 
@@ -2272,38 +2276,73 @@ span.piano-keyboard__key--black {
 }
 
 .live-follow-page {
-  min-height: 41rem;
+  min-height: 0;
+}
+
+.live-follow-page--active,
+.live-follow-page--waiting {
+  align-content: start;
 }
 
 .live-follow-page--active {
-  align-content: start;
+  gap: 0.7rem;
+  padding: 0.75rem;
 }
 
 .live-follow-topbar {
   align-items: center;
+  gap: 0.65rem;
+}
+
+.live-follow-page--active .live-follow-controls {
+  gap: 0.4rem;
+}
+
+.live-follow-page--active .chord-pill,
+.live-follow-page--active .chord-instrument-button {
+  min-height: 2.5rem;
+  padding: 0.48rem 0.66rem;
+  font-size: 0.84rem;
+}
+
+.live-follow-page--active .chord-context-strip {
+  gap: 0.4rem;
+  min-height: 0;
+  padding: 0.42rem 0.5rem;
+}
+
+.live-follow-page--active .chord-context-chip {
+  min-height: 1.85rem;
+  padding: 0.24rem 0.46rem;
+  font-size: 0.78rem;
 }
 
 .live-follow-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(17rem, 22rem);
-  gap: 1rem;
+  grid-template-columns: minmax(0, 1fr) minmax(14rem, 18rem);
+  gap: 0.75rem;
   align-items: start;
   min-width: 0;
+}
+
+.live-follow-grid--accordion,
+.live-follow-grid--piano {
+  grid-template-columns: minmax(0, 1.25fr) minmax(14rem, 18rem);
 }
 
 .live-follow-main,
 .live-follow-sidebar {
   display: grid;
-  gap: 1rem;
+  gap: 0.75rem;
   min-width: 0;
 }
 
 .live-current-chord,
 .live-next-chord {
   display: grid;
-  gap: 0.45rem;
+  gap: 0.35rem;
   min-width: 0;
-  padding: 0.85rem;
+  padding: 0.68rem;
   border: 1px solid color-mix(in srgb, var(--divider) 76%, transparent);
   border-radius: 8px;
   background: color-mix(in srgb, var(--panel) 72%, transparent);
@@ -2312,26 +2351,28 @@ span.piano-keyboard__key--black {
 .live-current-chord h3 {
   margin: 0;
   color: var(--text);
-  font-size: 3.4rem;
-  line-height: 0.95;
+  font-size: 2.95rem;
+  line-height: 1;
+  overflow-wrap: anywhere;
 }
 
 .live-next-chord strong {
   color: var(--text);
-  font-size: 1.6rem;
+  font-size: 1.32rem;
   line-height: 1.05;
+  overflow-wrap: anywhere;
 }
 
 .live-next-chord span {
   color: var(--muted);
-  font-size: 0.88rem;
+  font-size: 0.8rem;
   font-weight: 800;
 }
 
 .live-follow-provenance {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.55rem;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 8.5rem), 1fr));
+  gap: 0.4rem;
   margin: 0;
 }
 
@@ -2339,7 +2380,7 @@ span.piano-keyboard__key--black {
   display: grid;
   gap: 0.12rem;
   min-width: 0;
-  padding: 0.55rem 0.6rem;
+  padding: 0.42rem 0.5rem;
   border: 1px solid color-mix(in srgb, var(--divider) 70%, transparent);
   border-radius: 8px;
   background: color-mix(in srgb, var(--panel-strong) 56%, transparent);
@@ -2347,7 +2388,7 @@ span.piano-keyboard__key--black {
 
 .live-follow-provenance dt {
   color: var(--muted);
-  font-size: 0.72rem;
+  font-size: 0.68rem;
   font-weight: 800;
   text-transform: uppercase;
 }
@@ -2357,7 +2398,106 @@ span.piano-keyboard__key--black {
   margin: 0;
   color: var(--text);
   font-weight: 850;
+  font-size: 0.84rem;
   overflow-wrap: anywhere;
+}
+
+.live-follow-page--active .chord-section {
+  gap: 0.65rem;
+}
+
+.live-follow-page--active .chord-section-heading--inline {
+  gap: 0.65rem;
+}
+
+.live-follow-page--active .chord-spelling-summary {
+  gap: 0.35rem;
+}
+
+.live-follow-page--active .chord-spelling-summary span {
+  min-width: 3.35rem;
+  padding: 0.34rem 0.48rem;
+}
+
+.live-follow-page--active .chord-spelling-summary strong {
+  font-size: 0.94rem;
+}
+
+.live-follow-page--active .chord-spelling-summary small,
+.live-follow-page--active .chord-shape-preference-copy {
+  font-size: 0.72rem;
+}
+
+.live-follow-page--active .chord-shape-grid {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 10.5rem), 1fr));
+  gap: 0.55rem;
+}
+
+.live-follow-page--active .chord-shape-card {
+  gap: 0.4rem;
+  padding: 0.6rem;
+}
+
+.live-follow-page--active .guitar-fretboard {
+  --guitar-board-height: clamp(8.1rem, calc(var(--guitar-visible-frets) * 1.7rem), 11.6rem);
+  --guitar-dot-size: 1.04rem;
+}
+
+.live-follow-page--active .note-inspector {
+  gap: 0.55rem;
+  align-items: start;
+  padding: 0.6rem;
+}
+
+.live-follow-page--active .note-inspector__badge {
+  width: 3.85rem;
+  height: 3.85rem;
+}
+
+.live-follow-page--active .note-inspector dl {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 5rem), 1fr));
+  gap: 0.45rem 0.55rem;
+}
+
+.live-follow-page--active .accordion-position-grid {
+  grid-template-columns: minmax(14rem, 0.85fr) minmax(17rem, 1.15fr);
+  gap: 0.55rem;
+}
+
+.live-follow-page--active .accordion-position-card,
+.live-follow-page--active .accordion-candidate-panel,
+.live-follow-page--active .piano-position-card,
+.live-follow-page--active .piano-facts-panel {
+  gap: 0.6rem;
+  padding: 0.65rem;
+}
+
+.live-follow-page--active .accordion-stradella__board {
+  grid-template-rows: repeat(var(--accordion-root-count, 12), 1.42rem);
+  min-height: 16.9rem;
+}
+
+.live-follow-page--active .accordion-keyboard {
+  --accordion-white-key-height: 2.16rem;
+  --accordion-black-key-height: 1.26rem;
+  --accordion-black-key-width: 5.4rem;
+}
+
+.live-follow-page--active .piano-keyboard {
+  --piano-white-key-width: 2.45rem;
+  --piano-keyboard-height: 9.35rem;
+  --piano-black-key-height: 5.5rem;
+}
+
+.live-follow-page--active .piano-voicing-order li {
+  min-inline-size: 3.25rem;
+  padding: 0.34rem 0.42rem;
+}
+
+.live-follow-page--active .piano-note-inspector .note-inspector__badge,
+.live-follow-page--active .accordion-note-inspector .note-inspector__badge {
+  width: 4.1rem;
+  height: 4.1rem;
 }
 
 .lyrics-follow-stage {
@@ -2417,6 +2557,14 @@ span.piano-keyboard__key--black {
   .live-follow-provenance {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+
+  .live-follow-page--active .live-follow-sidebar {
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 15rem), 1fr));
+  }
+
+  .live-follow-page--active .accordion-position-grid {
+    grid-template-columns: minmax(14rem, 0.9fr) minmax(17rem, 1.1fr);
+  }
 }
 
 @media (max-width: 760px) {
@@ -2446,10 +2594,12 @@ span.piano-keyboard__key--black {
 
   .chord-shape-controls {
     justify-items: start;
+    width: 100%;
   }
 
   .chord-shape-control-row {
     justify-content: flex-start;
+    width: 100%;
   }
 
   .chord-shape-preference-copy {
@@ -2497,11 +2647,33 @@ span.piano-keyboard__key--black {
   }
 
   .live-current-chord h3 {
-    font-size: 2.6rem;
+    font-size: 2.35rem;
   }
 
   .lyrics-follow-stage {
     padding: 2rem 1rem;
+  }
+
+  .live-follow-page--active {
+    gap: 0.62rem;
+    padding: 0.65rem;
+  }
+
+  .live-follow-page--active .live-follow-sidebar,
+  .live-follow-page--active .accordion-position-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .live-follow-page--active .chord-section-heading--inline {
+    align-items: stretch;
+  }
+
+  .live-follow-page--active .note-inspector {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .live-follow-page--active .chord-context-chip {
+    white-space: normal;
   }
 }
 
@@ -2515,6 +2687,11 @@ span.piano-keyboard__key--black {
   .chord-icon-button,
   .chord-pill {
     flex: 1 1 auto;
+  }
+
+  .live-follow-page--active .chord-pill,
+  .live-follow-page--active .chord-instrument-button {
+    justify-content: center;
   }
 
   .accordion-stradella__headers,
@@ -2547,6 +2724,38 @@ span.piano-keyboard__key--black {
   .note-inspector dl,
   .live-follow-provenance {
     grid-template-columns: 1fr;
+  }
+
+  .live-follow-page--active .live-follow-provenance,
+  .live-follow-page--active .note-inspector,
+  .live-follow-page--active .piano-note-inspector,
+  .live-follow-page--active .accordion-note-inspector {
+    grid-template-columns: 1fr;
+  }
+
+  .live-follow-page--active .chord-context-strip {
+    gap: 0.35rem;
+    padding: 0.4rem;
+  }
+
+  .live-follow-page--active .chord-context-chip {
+    flex: 1 1 9rem;
+    justify-content: center;
+    min-height: 2.2rem;
+    text-align: center;
+  }
+
+  .live-follow-page--active .live-current-chord,
+  .live-follow-page--active .live-next-chord {
+    padding: 0.58rem;
+  }
+
+  .live-follow-page--active .live-current-chord h3 {
+    font-size: 2.1rem;
+  }
+
+  .live-follow-page--active .live-next-chord strong {
+    font-size: 1.18rem;
   }
 
   .chord-shape-card {


### PR DESCRIPTION
## Summary

- Closes #269.
- Add Chord Dictionary keyboard navigation and richer screen-reader context across guitar, piano, and accordion.
- Preserve chord search focus/scroll state and tighten Live Follow responsive layouts.

## Testing

- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test -- apps/desktop/src/App.tools-chord-dictionary.test.tsx apps/desktop/src/App.tools-chord-dictionary-entrypoint.test.tsx apps/desktop/src/App.tools-chord-dictionary-responsive.test.tsx --run`
- `git diff --check`
- Reviewer, contract guard, and Product Design QA passes completed
