### PR TITLE
fix: report live lyrics progress

### DIFF
--- a/apps/backend/app/engines/lyrics.py
+++ b/apps/backend/app/engines/lyrics.py
@@ -6,9 +6,11 @@ import os
 import subprocess
 import sys
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
+from types import TracebackType
 from typing import Any, cast
 
 from fastapi import status
@@ -24,6 +26,8 @@ from app.utils.model_cache import ExpectedModelFile, InvalidModelFile, invalid_m
 from app.utils.torch_runtime import choose_torch_device, with_mps_fallback_env
 
 LYRICS_WORKER_CANCEL_TIMEOUT_SECONDS = 2.0
+_WHISPER_TRANSCRIPTION_PROGRESS_MIN = 20
+_WHISPER_TRANSCRIPTION_PROGRESS_MAX = 85
 
 
 @dataclass(frozen=True)
@@ -320,6 +324,146 @@ def _clear_cuda_cache(torch_module: Any) -> None:
         empty_cache()
 
 
+def _whisper_transcription_progress(
+    current: object,
+    total: object,
+    *,
+    progress_min: int = _WHISPER_TRANSCRIPTION_PROGRESS_MIN,
+    progress_max: int = _WHISPER_TRANSCRIPTION_PROGRESS_MAX,
+) -> int | None:
+    current_float = _coerce_float(current)
+    total_float = _coerce_float(total)
+    if current_float is None or total_float is None or total_float <= 0:
+        return None
+    ratio = min(1.0, max(0.0, current_float / total_float))
+    bounded_min = min(_WHISPER_TRANSCRIPTION_PROGRESS_MAX, max(_WHISPER_TRANSCRIPTION_PROGRESS_MIN, progress_min))
+    bounded_max = min(_WHISPER_TRANSCRIPTION_PROGRESS_MAX, max(bounded_min, progress_max))
+    progress_range = bounded_max - bounded_min
+    return bounded_min + int(progress_range * ratio)
+
+
+def _whisper_attempt_progress_range(attempt_index: int, attempt_count: int) -> tuple[int, int]:
+    bounded_attempt_count = max(1, attempt_count)
+    bounded_attempt_index = min(max(0, attempt_index), bounded_attempt_count - 1)
+    progress_range = _WHISPER_TRANSCRIPTION_PROGRESS_MAX - _WHISPER_TRANSCRIPTION_PROGRESS_MIN
+    progress_min = _WHISPER_TRANSCRIPTION_PROGRESS_MIN + (
+        progress_range * bounded_attempt_index // bounded_attempt_count
+    )
+    progress_max = _WHISPER_TRANSCRIPTION_PROGRESS_MIN + (
+        progress_range * (bounded_attempt_index + 1) // bounded_attempt_count
+    )
+    return progress_min, progress_max
+
+
+def _whisper_tqdm_module(whisper_module: Any) -> Any | None:
+    transcribe = getattr(whisper_module, "transcribe", None)
+    transcribe_module_name = getattr(transcribe, "__module__", None)
+    if isinstance(transcribe_module_name, str):
+        transcribe_module = sys.modules.get(transcribe_module_name)
+        transcribe_tqdm_module = getattr(transcribe_module, "tqdm", None)
+        if transcribe_tqdm_module is not None:
+            return transcribe_tqdm_module
+    return getattr(whisper_module, "tqdm", None)
+
+
+class _WhisperProgressObserver:
+    def __init__(
+        self,
+        wrapped: Any,
+        *,
+        on_runtime_event: Callable[[dict[str, Any]], None],
+        device: str,
+        progress_min: int,
+        progress_max: int,
+    ) -> None:
+        self._wrapped = wrapped
+        self._on_runtime_event = on_runtime_event
+        self._device = device
+        self._progress_min = progress_min
+        self._progress_max = progress_max
+        self._last_progress: int | None = None
+
+    def __enter__(self) -> _WhisperProgressObserver:
+        enter = getattr(self._wrapped, "__enter__", None)
+        if callable(enter):
+            entered = enter()
+            if entered is not None:
+                self._wrapped = entered
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        exit_method = getattr(self._wrapped, "__exit__", None)
+        if callable(exit_method):
+            return cast(bool | None, exit_method(exc_type, exc, traceback))
+        return None
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._wrapped, name)
+
+    def update(self, n: int | float = 1) -> Any:
+        result = self._wrapped.update(n)
+        self._emit_progress()
+        return result
+
+    def _emit_progress(self) -> None:
+        progress = _whisper_transcription_progress(
+            getattr(self._wrapped, "n", None),
+            getattr(self._wrapped, "total", None),
+            progress_min=self._progress_min,
+            progress_max=self._progress_max,
+        )
+        if progress is None or progress == self._last_progress:
+            return
+        self._last_progress = progress
+        _emit_lyrics_runtime_event(
+            self._on_runtime_event,
+            stage="processing",
+            stage_label=f"Transcribing lyrics on {self._device.upper()}.",
+            runtime_device=self._device,
+            progress=progress,
+        )
+
+
+@contextmanager
+def _observe_whisper_tqdm_progress(
+    whisper_module: Any,
+    *,
+    on_runtime_event: Callable[[dict[str, Any]], None] | None,
+    device: str,
+    progress_min: int = _WHISPER_TRANSCRIPTION_PROGRESS_MIN,
+    progress_max: int = _WHISPER_TRANSCRIPTION_PROGRESS_MAX,
+) -> Iterator[None]:
+    if on_runtime_event is None:
+        yield
+        return
+
+    tqdm_module = _whisper_tqdm_module(whisper_module)
+    original_tqdm = getattr(tqdm_module, "tqdm", None)
+    if tqdm_module is None or not callable(original_tqdm):
+        yield
+        return
+
+    def observed_tqdm(*args: Any, **kwargs: Any) -> _WhisperProgressObserver:
+        return _WhisperProgressObserver(
+            original_tqdm(*args, **kwargs),
+            on_runtime_event=on_runtime_event,
+            device=device,
+            progress_min=progress_min,
+            progress_max=progress_max,
+        )
+
+    tqdm_module.tqdm = observed_tqdm
+    try:
+        yield
+    finally:
+        tqdm_module.tqdm = original_tqdm
+
+
 def _transcribe_with_device(
     source_path: Path,
     *,
@@ -329,20 +473,30 @@ def _transcribe_with_device(
     download_root: Path,
     whisper_module: Any,
     language_override: str | None = None,
+    on_runtime_event: Callable[[dict[str, Any]], None] | None = None,
+    progress_min: int = _WHISPER_TRANSCRIPTION_PROGRESS_MIN,
+    progress_max: int = _WHISPER_TRANSCRIPTION_PROGRESS_MAX,
 ) -> LyricsTranscription:
     model = whisper_module.load_model(model_name, device=device, download_root=str(download_root))
     transcribe_kwargs: dict[str, Any] = {}
     if language_override is not None:
         transcribe_kwargs["language"] = language_override
-    result = whisper_module.transcribe(
-        model,
-        str(source_path),
-        verbose=False,
-        condition_on_previous_text=False,
-        word_timestamps=True,
-        fp16=device == "cuda",
-        **transcribe_kwargs,
-    )
+    with _observe_whisper_tqdm_progress(
+        whisper_module,
+        on_runtime_event=on_runtime_event,
+        device=device,
+        progress_min=progress_min,
+        progress_max=progress_max,
+    ):
+        result = whisper_module.transcribe(
+            model,
+            str(source_path),
+            verbose=False,
+            condition_on_previous_text=False,
+            word_timestamps=True,
+            fp16=device == "cuda",
+            **transcribe_kwargs,
+        )
     segments = _normalize_segments(result.get("segments", []))
     detected_language = result.get("language")
     language = (
@@ -372,6 +526,11 @@ def transcribe_project_lyrics_in_process(
 ) -> LyricsTranscription:
     torch_module, whisper_module = _load_runtime()
     candidates = resolve_whisper_device_candidates(requested_device, torch_module=torch_module)
+    attempt_count = sum(
+        len(resolve_whisper_model_candidates(model_name, device=device))
+        for device in candidates
+    )
+    attempt_index = 0
     errors: list[dict[str, str]] = []
 
     requested_normalized = requested_device.strip().lower()
@@ -387,6 +546,8 @@ def transcribe_project_lyrics_in_process(
     for device in candidates:
         model_candidates = resolve_whisper_model_candidates(model_name, device=device)
         for index, candidate_model in enumerate(model_candidates):
+            attempt_progress_min, attempt_progress_max = _whisper_attempt_progress_range(attempt_index, attempt_count)
+            attempt_index += 1
             try:
                 _emit_lyrics_runtime_event(
                     on_runtime_event,
@@ -399,6 +560,7 @@ def transcribe_project_lyrics_in_process(
                     stage="processing",
                     stage_label=f"Transcribing lyrics on {device.upper()}.",
                     runtime_device=device,
+                    progress=attempt_progress_min,
                 )
                 return _transcribe_with_device(
                     source_path,
@@ -408,6 +570,9 @@ def transcribe_project_lyrics_in_process(
                     download_root=download_root,
                     whisper_module=whisper_module,
                     language_override=language_override,
+                    on_runtime_event=on_runtime_event,
+                    progress_min=attempt_progress_min,
+                    progress_max=attempt_progress_max,
                 )
             except AppError:
                 raise
@@ -514,12 +679,7 @@ def _terminate_cancelled_worker(process: subprocess.Popen[str]) -> None:
             pass
 
 
-def _raise_worker_failure(
-    payload: dict[str, Any] | None,
-    *,
-    stdout: str,
-    stderr: str,
-) -> None:
+def _raise_worker_failure(payload: dict[str, Any] | None) -> None:
     error = payload.get("error") if payload else None
     if isinstance(error, dict):
         code = str(error.get("code", "PROCESSING_FAILED"))
@@ -537,7 +697,6 @@ def _raise_worker_failure(
         "PROCESSING_FAILED",
         "Lyrics generation failed.",
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        details={"stdout": stdout.strip(), "stderr": stderr.strip()},
     )
 
 
@@ -611,7 +770,7 @@ def transcribe_project_lyrics(
 
         payload = _worker_payload_from_stdout(stdout)
         if process.returncode != 0:
-            _raise_worker_failure(payload, stdout=stdout, stderr=stderr)
+            _raise_worker_failure(payload)
 
         transcription_payload = payload.get("transcription") if payload else None
         if not isinstance(transcription_payload, dict):

--- a/apps/backend/app/services/jobs.py
+++ b/apps/backend/app/services/jobs.py
@@ -472,13 +472,18 @@ def _apply_runtime_status_fields(
     progress: int | None,
     runtime_device: object,
     runtime_detail: object,
+    monotonic_progress: bool = False,
 ) -> None:
     if stage is not None:
         job.stage = stage
     if stage_label is not None:
         job.stage_label = safe_runtime_label(stage_label)
     if progress is not None:
-        job.progress = min(100, max(0, progress))
+        bounded_progress = min(100, max(0, progress))
+        if monotonic_progress and job.status == "running":
+            job.progress = max(job.progress, bounded_progress)
+        else:
+            job.progress = bounded_progress
     if runtime_device is not _RUNTIME_UNSET:
         job.runtime_device = safe_runtime_device(runtime_device) if runtime_device is not None else None
     if runtime_detail is not _RUNTIME_UNSET:
@@ -541,6 +546,7 @@ class JobExecutionContext:
             progress=event.progress,
             runtime_device=event.runtime_device if event.runtime_device is not None else _RUNTIME_UNSET,
             runtime_detail=event.runtime_detail if event.runtime_detail is not None else _RUNTIME_UNSET,
+            monotonic_progress=True,
         )
 
     def progress_reporter(self) -> _JobProgressReporter:
@@ -698,6 +704,7 @@ class InProcessJobRunner:
         progress: int | None = None,
         runtime_device: object = _RUNTIME_UNSET,
         runtime_detail: object = _RUNTIME_UNSET,
+        monotonic_progress: bool = False,
     ) -> None:
         with self.session_factory() as session:
             job = session.get(Job, job_id)
@@ -710,6 +717,7 @@ class InProcessJobRunner:
                 progress=progress,
                 runtime_device=runtime_device,
                 runtime_detail=runtime_detail,
+                monotonic_progress=monotonic_progress,
             )
             session.commit()
 

--- a/apps/backend/tests/test_jobs_api.py
+++ b/apps/backend/tests/test_jobs_api.py
@@ -210,6 +210,55 @@ def test_runtime_status_helper_updates_fields_and_drops_unsafe_detail(client: Te
         assert job.runtime_detail == safe_detail
 
 
+def test_runtime_event_progress_is_bounded_monotonic_and_private(client: TestClient) -> None:
+    runner = InProcessJobRunner(SessionLocal)
+    safe_detail = "Whisper switched to CPU after the accelerator attempt failed."
+    with SessionLocal() as session:
+        job = runner.create_job(session, project_id=None, job_type="test", payload={})
+        job_id = job.id
+        job.status = "running"
+        job.progress = 70
+        session.commit()
+
+    with SessionLocal() as session:
+        context = JobExecutionContext(runner, job_id, session)
+        context.handle_runtime_event(
+            runtime_event_payload(
+                stage="processing",
+                stage_label="/Users/private/song.wav",
+                runtime_device="cuda:0",
+                progress=-10,
+            )
+        )
+        context.handle_runtime_event(
+            runtime_event_payload(
+                stage="fallback",
+                stage_label="Falling back from CUDA to CPU.",
+                runtime_device="cpu",
+                runtime_detail=safe_detail,
+                progress=60,
+            )
+        )
+
+    with SessionLocal() as session:
+        job = session.get(Job, job_id)
+        assert job is not None
+        assert job.stage == "fallback"
+        assert job.stage_label == "Falling back from CUDA to CPU."
+        assert job.runtime_device == "cpu"
+        assert job.runtime_detail == safe_detail
+        assert job.progress == 70
+
+    with SessionLocal() as session:
+        context = JobExecutionContext(runner, job_id, session)
+        context.handle_runtime_event(runtime_event_payload(stage="processing", progress=250))
+
+    with SessionLocal() as session:
+        job = session.get(Job, job_id)
+        assert job is not None
+        assert job.progress == 100
+
+
 def test_jobs_api_drops_unsafe_runtime_text_before_exposure(client: TestClient) -> None:
     runner = InProcessJobRunner(SessionLocal)
     with SessionLocal() as session:

--- a/apps/backend/tests/test_lyrics_engine.py
+++ b/apps/backend/tests/test_lyrics_engine.py
@@ -2,13 +2,18 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
+from io import StringIO
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
+from app.db import SessionLocal
 from app.engines.lyrics import (
     LyricsTranscription,
+    _observe_whisper_tqdm_progress,
+    _start_output_reader,
     _transcribe_with_device,
     patch_whisper_timing_for_mps,
     resolve_whisper_device_candidates,
@@ -16,7 +21,10 @@ from app.engines.lyrics import (
     transcribe_project_lyrics,
     transcribe_project_lyrics_in_process,
 )
-from app.errors import JobCancelledError
+from app.errors import AppError, JobCancelledError
+from app.models import Job
+from app.runtime_status import JOB_RUNTIME_EVENT_TYPE, runtime_event_payload
+from app.services.jobs import InProcessJobRunner, JobExecutionContext
 
 
 def make_fake_torch(*, has_mps: bool, has_cuda: bool):
@@ -143,7 +151,11 @@ def test_transcribe_project_lyrics_falls_back_to_cpu(monkeypatch):
         download_root: Path,
         whisper_module: object,
         language_override: str | None = None,
+        on_runtime_event: object = None,
+        progress_min: int = 20,
+        progress_max: int = 85,
     ) -> LyricsTranscription:
+        del on_runtime_event, progress_min, progress_max
         attempted_devices.append(device)
         if device == "mps":
             raise RuntimeError("MPS kernel failed")
@@ -193,7 +205,11 @@ def test_transcribe_project_lyrics_retries_smaller_model_on_cuda_oom(monkeypatch
         download_root: Path,
         whisper_module: object,
         language_override: str | None = None,
+        on_runtime_event: object = None,
+        progress_min: int = 20,
+        progress_max: int = 85,
     ) -> LyricsTranscription:
+        del on_runtime_event, progress_min, progress_max
         attempts.append((device, model_name))
         if model_name == "turbo":
             raise RuntimeError("CUDA out of memory")
@@ -225,6 +241,125 @@ def test_transcribe_project_lyrics_retries_smaller_model_on_cuda_oom(monkeypatch
     assert result.device == "cuda"
     assert result.model == "small"
     assert result.requested_device == "auto"
+
+
+def test_transcribe_project_lyrics_retry_progress_advances_persisted_job(
+    client: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    del client
+
+    class FakeProgressBar:
+        def __init__(self, *, total: int) -> None:
+            self.total = total
+            self.n = 0
+
+        def __enter__(self) -> FakeProgressBar:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def update(self, n: int = 1) -> None:
+            self.n += n
+
+    class FakeWhisper:
+        def __init__(self) -> None:
+            self.tqdm = SimpleNamespace(tqdm=FakeProgressBar)
+
+        def load_model(self, model_name: str, *, device: str, download_root: str) -> tuple[str, str]:
+            del download_root
+            return model_name, device
+
+        def transcribe(self, model: tuple[str, str], source_path: str, **kwargs: object) -> dict[str, object]:
+            del source_path, kwargs
+            _model_name, device = model
+            with self.tqdm.tqdm(total=100) as progress_bar:
+                if device == "mps":
+                    progress_bar.update(95)
+                    raise RuntimeError("MPS kernel failed")
+                progress_bar.update(5)
+            return {
+                "language": "en",
+                "segments": [{"start": 0.0, "end": 1.0, "text": "hello"}],
+            }
+
+    monkeypatch.setattr(
+        "app.engines.lyrics._load_runtime",
+        lambda: (make_fake_torch(has_mps=True, has_cuda=False), FakeWhisper()),
+    )
+    runner = InProcessJobRunner(SessionLocal)
+    with SessionLocal() as session:
+        job = runner.create_job(session, project_id=None, job_type="test", payload={})
+        job_id = job.id
+        job.status = "running"
+        session.commit()
+
+    persisted_progress: list[int] = []
+
+    def capture_runtime_event(payload: dict[str, object]) -> None:
+        with SessionLocal() as session:
+            context = JobExecutionContext(runner, job_id, session)
+            context.handle_runtime_event(payload)
+        if payload.get("progress") is None:
+            return
+        with SessionLocal() as session:
+            persisted_job = session.get(Job, job_id)
+            assert persisted_job is not None
+            persisted_progress.append(persisted_job.progress)
+
+    result = transcribe_project_lyrics_in_process(
+        Path("/tmp/fake.wav"),
+        model_name="turbo",
+        requested_device="auto",
+        download_root=Path("/tmp/lyrics-cache"),
+        on_runtime_event=capture_runtime_event,
+    )
+
+    assert result.device == "cpu"
+    assert result.segments[0]["text"] == "hello"
+    assert persisted_progress == [20, 50, 52, 53]
+    assert persisted_progress[-1] > persisted_progress[1]
+
+
+def test_observe_whisper_tqdm_progress_maps_updates_to_runtime_events(monkeypatch: pytest.MonkeyPatch):
+    class FakeProgressBar:
+        def __init__(self, *, total: int) -> None:
+            self.total = total
+            self.n = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def update(self, n: int = 1) -> None:
+            self.n += n
+
+    transcribe_module = ModuleType("fake_whisper_transcribe_progress")
+    transcribe_module.tqdm = SimpleNamespace(tqdm=FakeProgressBar)
+
+    def fake_transcribe() -> None:
+        return None
+
+    fake_transcribe.__module__ = transcribe_module.__name__
+    monkeypatch.setitem(sys.modules, transcribe_module.__name__, transcribe_module)
+    whisper_module = SimpleNamespace(transcribe=fake_transcribe, tqdm=SimpleNamespace(tqdm=object()))
+    original_tqdm = transcribe_module.tqdm.tqdm
+    events: list[dict[str, object]] = []
+
+    with _observe_whisper_tqdm_progress(whisper_module, on_runtime_event=events.append, device="cpu"):
+        with transcribe_module.tqdm.tqdm(total=10) as progress_bar:
+            progress_bar.update(1)
+            progress_bar.update(4)
+            progress_bar.update(5)
+
+    assert transcribe_module.tqdm.tqdm is original_tqdm
+    assert [event["progress"] for event in events] == [26, 52, 85]
+    assert {event["stage"] for event in events} == {"processing"}
+    assert {event["stage_label"] for event in events} == {"Transcribing lyrics on CPU."}
+    assert {event["runtime_device"] for event in events} == {"cpu"}
 
 
 def test_transcribe_with_device_omits_language_for_auto_detect():
@@ -341,6 +476,65 @@ def test_transcribe_project_lyrics_passes_language_override_to_worker(monkeypatc
     assert commands[0][-2:] == ["--language", "pt"]
     assert result.language == "pt"
     assert result.language_override == "pt"
+
+
+def test_lyrics_output_reader_streams_only_runtime_events():
+    runtime_payload = runtime_event_payload(
+        stage="processing",
+        stage_label="Transcribing lyrics on CPU.",
+        runtime_device="cpu",
+        progress=45,
+    )
+    pipe = StringIO(
+        "\n".join(
+            [
+                "debug: /Users/private/song.wav",
+                json.dumps({"text": "raw lyric that must not become status"}),
+                json.dumps(runtime_payload),
+                json.dumps({"type": JOB_RUNTIME_EVENT_TYPE, "stage_label": "/tmp/private.wav"}),
+            ]
+        )
+        + "\n"
+    )
+    lines: list[str] = []
+    events: list[dict[str, object]] = []
+
+    thread = _start_output_reader(pipe, lines, events.append)
+
+    assert thread is not None
+    thread.join(timeout=1)
+    assert events == [
+        runtime_payload,
+        {"type": JOB_RUNTIME_EVENT_TYPE, "stage_label": "/tmp/private.wav"},
+    ]
+    assert any("raw lyric" in line for line in lines)
+
+
+def test_transcribe_project_lyrics_failure_does_not_expose_raw_worker_output(monkeypatch):
+    class FakeProcess:
+        returncode = 1
+
+        def poll(self) -> int:
+            return self.returncode
+
+        def communicate(self) -> tuple[str, str]:
+            return "/Users/private/song.wav\nraw lyric", "stderr with private path"
+
+        def kill(self) -> None:
+            raise AssertionError("completed process should not be killed")
+
+    monkeypatch.setattr("app.engines.lyrics.subprocess.Popen", lambda *_args, **_kwargs: FakeProcess())
+
+    with pytest.raises(AppError) as exc_info:
+        transcribe_project_lyrics(
+            Path("/tmp/fake.wav"),
+            model_name="turbo",
+            requested_device="auto",
+            download_root=Path("/tmp/lyrics-cache"),
+        )
+
+    assert exc_info.value.message == "Lyrics generation failed."
+    assert exc_info.value.details == {}
 
 
 def test_transcribe_project_lyrics_cancels_subprocess(monkeypatch):

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -3573,6 +3573,37 @@ describe("Desktop app activity", () => {
     expect(within(row).queryByText("Default (6 stems model) / MPS")).not.toBeInTheDocument();
   });
 
+  it("shows lyrics transcription progress without raw runtime output", async () => {
+    setJobs([
+      job({
+        id: "job_lyrics_transcribing",
+        project_id: "proj_123",
+        type: "lyrics",
+        status: "running",
+        progress: 68,
+        stage_label: "Transcribing lyrics.",
+        lyrics_source: "vocals",
+        runtime_device: "cuda",
+        runtime_detail: "stderr: /Users/example/song.wav ETA 00:12",
+        started_at: "2026-04-18T13:22:00.000Z",
+        created_at: "2026-04-18T13:22:00.000Z",
+        updated_at: "2026-04-18T13:23:00.000Z",
+      }),
+    ]);
+
+    renderApp(["/activity"]);
+
+    const row = await screen.findByRole("article", { name: "lyrics running job" });
+    const progressBar = within(row).getByRole("progressbar", { name: "lyrics job progress" });
+
+    expect(within(row).getByText("Transcribing lyrics")).toHaveClass("activity-job-row__stage");
+    expect(within(row).getByText("68%")).toBeInTheDocument();
+    expect(progressBar).toHaveAttribute("value", "68");
+    expect(progressBar).toHaveAttribute("max", "100");
+    expect(within(row).getByText("CUDA")).toHaveClass("activity-job-row__runtime");
+    expect(row).not.toHaveTextContent(/stderr|song\.wav|ETA/i);
+  });
+
   it("does not duplicate device text when reported stages already include it", async () => {
     setJobs([
       job({

--- a/apps/desktop/src/App.project-playback-artifacts.test.tsx
+++ b/apps/desktop/src/App.project-playback-artifacts.test.tsx
@@ -199,6 +199,43 @@ describe("Desktop app project playback artifacts", () => {
     expect(within(stemError).getByText("Selected project stems failed.")).toBeInTheDocument();
   });
 
+  it("shows live lyrics transcription progress in project job history without raw runtime output", async () => {
+    const user = userEvent.setup();
+    setJobs([
+      {
+        id: "job_lyrics_transcribing",
+        project_id: "proj_123",
+        type: "lyrics",
+        status: "running",
+        progress: 68,
+        stage_label: "Transcribing lyrics.",
+        lyrics_source: "vocals",
+        runtime_device: "cuda",
+        runtime_detail: "stderr: /Users/example/song.wav ETA 00:12",
+        source_artifact_id: null,
+        error_message: null,
+        created_at: "2026-04-18T13:22:00.000Z",
+        updated_at: "2026-04-18T13:23:00.000Z",
+      },
+    ]);
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openAnalysisPanel(user);
+    await user.click(screen.getByText("Show raw artifacts and processing history"));
+    await expectProjectJobsRequested("proj_123");
+
+    const jobHistory = getJobsHistoryDetails();
+    const progressBar = await within(jobHistory).findByRole("progressbar", { name: "lyrics job progress" });
+
+    expect(within(jobHistory).getByText("Transcribing lyrics")).toBeInTheDocument();
+    expect(within(jobHistory).getByText("running / vocals / CUDA")).toBeInTheDocument();
+    expect(progressBar).toHaveAttribute("value", "68");
+    expect(progressBar).toHaveAttribute("max", "100");
+    expect(jobHistory).not.toHaveTextContent(/stderr|song\.wav|ETA/i);
+  });
+
   it("loads later project terminal job pages with scoped filters", async () => {
     const user = userEvent.setup();
     setJobs([

--- a/apps/desktop/src/features/activity/ActivityView.tsx
+++ b/apps/desktop/src/features/activity/ActivityView.tsx
@@ -10,6 +10,7 @@ import { usePreferences } from "../../lib/preferences";
 import { useBeatBackendActionSelection } from "../projects/hooks/useBeatBackendActionSelection";
 import { useChordBackendActionSelection } from "../projects/hooks/useChordBackendActionSelection";
 import {
+  formatJobProgressValue,
   formatJobRuntimeSummary,
   formatJobStageLabel,
   formatJobStatusSummary,
@@ -157,10 +158,6 @@ function formatJobDetails(job: JobSchema, { includeRuntimeDevice = true } = {}) 
   return summary.startsWith(statusPrefix) ? summary.slice(statusPrefix.length) : summary;
 }
 
-function progressValue(job: JobSchema) {
-  return Math.max(0, Math.min(100, Math.round(job.progress)));
-}
-
 function activeStageStatusLabel(stageLabel: string, runtimeSummary: string | null) {
   return runtimeSummary ? `Current stage: ${stageLabel}, ${runtimeSummary}` : `Current stage: ${stageLabel}`;
 }
@@ -295,7 +292,7 @@ function JobRow({
   const stageLabel = formatJobStageLabel(job);
   const runtimeSummary = stageLabel ? formatJobRuntimeSummary(job) : null;
   const details = formatJobDetails(job, { includeRuntimeDevice: !runtimeSummary });
-  const progress = progressValue(job);
+  const progress = formatJobProgressValue(job);
   const canCancel = CANCELABLE_JOB_STATUSES.has(job.status);
   const stageTone = TERMINAL_JOB_STATUSES.has(job.status) ? "terminal" : "active";
 

--- a/apps/desktop/src/features/projects/components/JobsHistory.tsx
+++ b/apps/desktop/src/features/projects/components/JobsHistory.tsx
@@ -1,5 +1,12 @@
 import { useProjectViewModelContext } from "./useProjectViewModelContext";
-import { artifactLabel, artifactSummary, formatArtifactTimestamp, formatJobStatusSummary } from "../projectViewUtils";
+import {
+  artifactLabel,
+  artifactSummary,
+  formatArtifactTimestamp,
+  formatJobProgressValue,
+  formatJobStageLabel,
+  formatJobStatusSummary,
+} from "../projectViewUtils";
 
 export function JobsHistory() {
   const {
@@ -69,19 +76,24 @@ export function JobsHistory() {
               className="job-list"
             >
               {hasJobs
-                ? visibleJobs.map((job) => (
-                    <li key={job.id}>
-                      <div>
-                        <strong>{job.type}</strong>
-                        <span>{formatJobStatusSummary(job)}</span>
-                      </div>
-                      <progress max={100} value={job.progress} />
-                      <small>{formatArtifactTimestamp(job.completed_at ?? job.updated_at)}</small>
-                      {job.error_message ? (
-                        <small className="inline-error">{job.error_message}</small>
-                      ) : null}
-                    </li>
-                  ))
+                ? visibleJobs.map((job) => {
+                    const progress = formatJobProgressValue(job);
+                    const stageLabel = formatJobStageLabel(job);
+                    return (
+                      <li key={job.id}>
+                        <div>
+                          <strong>{job.type}</strong>
+                          <span>{formatJobStatusSummary(job)}</span>
+                          {stageLabel ? <small>{stageLabel}</small> : null}
+                        </div>
+                        <progress aria-label={`${job.type} job progress`} max={100} value={progress} />
+                        <small>{formatArtifactTimestamp(job.completed_at ?? job.updated_at)}</small>
+                        {job.error_message ? (
+                          <small className="inline-error">{job.error_message}</small>
+                        ) : null}
+                      </li>
+                    );
+                  })
                 : null}
             </ul>
 

--- a/apps/desktop/src/features/projects/projectViewUtils.ts
+++ b/apps/desktop/src/features/projects/projectViewUtils.ts
@@ -209,6 +209,10 @@ export function formatJobRuntimeSummary(job: JobSchema) {
     .join(" / ") || null;
 }
 
+export function formatJobProgressValue(job: Pick<JobSchema, "progress">) {
+  return Math.max(0, Math.min(100, Math.round(job.progress)));
+}
+
 function formatCompletedStageLabel(stageLabel: string) {
   const savingMatch = /^Saving\s+(.+)$/i.exec(stageLabel);
   return savingMatch ? `Saved ${savingMatch[1]}` : stageLabel;


### PR DESCRIPTION
## Summary
- Emit structured Whisper transcription progress events for lyrics jobs without exposing raw output.
- Keep job progress monotonic and bounded across fallback/retry attempts.
- Show safe runtime stage/progress consistently in Activity and project job history.

Closes #299

## Testing
- `cd apps/backend && uv run --python 3.11 pytest tests/test_lyrics_engine.py tests/test_jobs_api.py tests/test_lyrics_flow.py`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
