### PR TITLE
chore: Prepare release readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       backend_static: ${{ steps.scope.outputs.backend_static }}
       backend_ffmpeg: ${{ steps.scope.outputs.backend_ffmpeg }}
       desktop: ${{ steps.scope.outputs.desktop }}
+      site: ${{ steps.scope.outputs.site }}
     steps:
       - name: Check out code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -31,6 +32,7 @@ jobs:
           backend_static=false
           backend_ffmpeg=false
           desktop=false
+          site=false
           full_gate=false
           changed_files="${RUNNER_TEMP}/changed-files.txt"
 
@@ -50,8 +52,22 @@ jobs:
           if [[ -s "${changed_files}" ]]; then
             while IFS= read -r path; do
               case "${path}" in
-                scripts/*|package.json|pnpm-lock.yaml|apps/backend/pyproject.toml|apps/backend/uv.lock)
+                scripts/capture-release-media.mjs|scripts/check-release-version.mjs)
+                  site=true
+                  ;;
+                scripts/package-options*|scripts/flatpak-options*|scripts/playback-smoke*|scripts/sync-validation*|scripts/setup-dev*)
+                  ;;
+                scripts/*)
                   full_gate=true
+                  ;;
+                package.json|pnpm-lock.yaml|pnpm-workspace.yaml)
+                  site=true
+                  ;;
+                apps/backend/pyproject.toml|apps/backend/uv.lock)
+                  backend_static=true
+                  backend_ffmpeg=true
+                  ;;
+                apps/backend/README.md)
                   ;;
                 apps/backend/app/api/*|apps/backend/app/schemas.py|apps/backend/app/main.py)
                   backend_static=true
@@ -62,10 +78,15 @@ jobs:
                   backend_static=true
                   backend_ffmpeg=true
                   ;;
+                packages/shared-types/AGENTS.md)
+                  ;;
                 apps/desktop/*|packages/shared-types/*)
                   desktop=true
                   ;;
-                .github/workflows/ci.yml|.codex/environments/*|docs/*|README.md|CONTRIBUTING.md|CODE_OF_CONDUCT.md|LICENSE|THIRD_PARTY_NOTICES.md|SECURITY.md|AGENTS.md|.github/ISSUE_TEMPLATE/*|.github/PULL_REQUEST_TEMPLATE.md)
+                apps/site/*|.github/workflows/pages.yml)
+                  site=true
+                  ;;
+                .github/workflows/ci.yml|.codex/environments/*|docs/*|README.md|CONTRIBUTING.md|CODE_OF_CONDUCT.md|LICENSE|THIRD_PARTY_NOTICES.md|SECURITY.md|AGENTS.md|.gitignore|packaging/flatpak/*|.github/ISSUE_TEMPLATE/*|.github/PULL_REQUEST_TEMPLATE.md)
                   ;;
                 *)
                   full_gate=true
@@ -78,6 +99,7 @@ jobs:
             backend_static=true
             backend_ffmpeg=true
             desktop=true
+            site=true
           fi
 
           print_scope_decision() {
@@ -95,11 +117,13 @@ jobs:
           print_scope_decision "backend static checks" "${backend_static}"
           print_scope_decision "backend FFmpeg tests" "${backend_ffmpeg}"
           print_scope_decision "desktop checks" "${desktop}"
+          print_scope_decision "site checks" "${site}"
 
           {
             echo "backend_static=${backend_static}"
             echo "backend_ffmpeg=${backend_ffmpeg}"
             echo "desktop=${desktop}"
+            echo "site=${site}"
           } >> "${GITHUB_OUTPUT}"
 
           {
@@ -108,6 +132,7 @@ jobs:
             echo "- Backend static checks: ${backend_static}"
             echo "- Backend FFmpeg tests: ${backend_ffmpeg}"
             echo "- Desktop checks: ${desktop}"
+            echo "- Site checks: ${site}"
             if [[ -s "${changed_files}" ]]; then
               echo
               echo "<details><summary>Changed files</summary>"
@@ -157,6 +182,75 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: echo "$PR_TITLE" | pnpm exec commitlint --config commitlint.pr-title.config.cjs
+
+  script-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+
+      - name: Test deterministic Node scripts
+        run: node --test scripts/package-options.test.mjs scripts/flatpak-options.test.mjs scripts/playback-smoke.test.mjs scripts/sync-validation.test.mjs
+
+      - name: Check release script syntax
+        run: |
+          node --check scripts/capture-release-media.mjs
+          node --check scripts/check-release-version.mjs
+
+      - name: Check release version consistency
+        run: node scripts/check-release-version.mjs
+
+      - name: Test setup-dev script
+        run: bash scripts/setup-dev.test.sh
+
+  site:
+    needs: ci-scope
+    if: ${{ always() && (needs.ci-scope.result != 'success' || needs.ci-scope.outputs.site == 'true') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require CI scope
+        if: needs.ci-scope.result != 'success'
+        run: |
+          echo "ci-scope did not complete successfully; failing site required check."
+          exit 1
+
+      - name: Check out code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Skip site checks
+        if: needs.ci-scope.outputs.site != 'true'
+        run: echo "No site paths changed; skipping site setup."
+
+      - name: Set up pnpm
+        if: needs.ci-scope.outputs.site == 'true'
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10.33.0
+
+      - name: Set up Node
+        if: needs.ci-scope.outputs.site == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        if: needs.ci-scope.outputs.site == 'true'
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Type-check site
+        if: needs.ci-scope.outputs.site == 'true'
+        run: pnpm --filter @tuneforge/site typecheck
+
+      - name: Build site
+        if: needs.ci-scope.outputs.site == 'true'
+        run: pnpm --filter @tuneforge/site build
 
   backend:
     needs: ci-scope

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,72 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - apps/site/**
+      - .github/workflows/pages.yml
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10.33.0
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Configure Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Install capture browser
+        run: pnpm --filter @tuneforge/desktop exec playwright install --with-deps chromium
+
+      - name: Capture release media
+        run: node scripts/capture-release-media.mjs --run
+
+      - name: Build site
+        run: pnpm --filter @tuneforge/site build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        with:
+          path: apps/site/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ apps/desktop/src-tauri/gen/
 
 # Generated / local data
 packages/shared-types/openapi.json
+apps/site/public/media/generated/
 stem-waveforms/
 data/
 *.sqlite3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Tuneforge is a local-first desktop app for musicians learning songs: stem separa
 - **Monorepo**: pnpm workspace.
 - **Backend**: `apps/backend` — FastAPI + SQLAlchemy 2 + Pydantic v2, Python 3.11, managed with `uv`. SQLite persistence, single-process job runner, audio engines (Demucs, FFmpeg, librosa-style analysis).
 - **Desktop**: `apps/desktop` — Tauri 2 (Rust) shell + React/Vite/TypeScript frontend, Vitest + Testing Library.
-- **Shared types**: `packages/shared-types` — TypeScript types generated from the backend OpenAPI schema. **Always regenerate after backend route/schema changes.**
+- **Shared types**: `packages/shared-types` — TypeScript types generated from the backend OpenAPI schema. **Always regenerate after backend route/schema changes.** The JSON export is local generator output; the generated TypeScript contract is committed.
 
 ## Hard Rules
 
@@ -77,7 +77,7 @@ When asked to implement a change:
    ```sh
    pnpm contracts:generate
    ```
-   Commit the resulting `packages/shared-types/src/generated/openapi.ts`. CI fails on drift.
+   Commit `packages/shared-types/src/generated/openapi.ts` if it changes. Keep `packages/shared-types/openapi.json` ignored and local. CI fails on TypeScript contract drift.
 6. **Verify Tauri compiles** if you touched anything in `apps/desktop/src-tauri/`:
    ```sh
    cd apps/desktop/src-tauri && cargo check
@@ -129,8 +129,8 @@ The following files are generated. **Do not edit by hand.**
 
 | File | Generator |
 | --- | --- |
-| `packages/shared-types/openapi.json` | `pnpm contracts:generate` (writes from backend OpenAPI export) |
-| `packages/shared-types/src/generated/openapi.ts` | `pnpm contracts:generate` |
+| `packages/shared-types/openapi.json` | `pnpm contracts:generate` (ignored local backend OpenAPI export; do not commit) |
+| `packages/shared-types/src/generated/openapi.ts` | `pnpm contracts:generate` (committed TypeScript contract; CI checks drift) |
 | `apps/desktop/src-tauri/gen/schemas/*` | Tauri build |
 | `apps/desktop/src-tauri/Cargo.lock` | cargo |
 | `pnpm-lock.yaml` | pnpm |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,14 @@ Think "AI-assisted song toolkit for the player at home" — but **fully local, s
 
 ## Status
 
-Pre-1.0. The desktop dev flow (`pnpm dev`) is the fastest way to iterate. Local macOS app/DMG packaging is available with `pnpm package:mac`; generated builds are unsigned, not notarized, and require `ffmpeg`/`ffprobe` on the host `PATH`.
+Pre-1.0. The desktop dev flow (`pnpm dev`) is the fastest way to iterate. Local macOS app/DMG and Linux Flatpak packaging are available, but generated builds are unsigned and not notarized. Development/source runs and macOS packages require `ffmpeg`/`ffprobe` on the host `PATH`; Flatpak uses `/app/bin/ffmpeg` and `/app/bin/ffprobe` wrappers backed by the Flatpak runtime sandbox.
+
+Current 1.0 release limits:
+
+- Desktop is the supported full workflow. Android/mobile remains a local-first companion path in progress.
+- Packages are local build artifacts, not signed distribution releases.
+- Model weights are cached locally and may download on first setup/use unless a package was built with `--model-bundle`.
+- Advanced Chords, Advanced Beat Analysis, GPU acceleration, loopback/browser playback smoke, and BlackHole or virtual-audio capture need manual or special coverage unless a specific CI job says otherwise.
 
 ## Features
 
@@ -41,6 +48,7 @@ Security reports follow the process in [SECURITY.md](./SECURITY.md). "There is n
 - [Stem separation](./docs/STEM_SEPARATION.md)
 - [Architecture](./docs/ARCHITECTURE.md)
 - [API](./docs/API.md)
+- [Native audio and playback QA](./docs/NATIVE_AUDIO.md)
 - [Packaging](./docs/PACKAGING.md)
 - [Roadmap](./docs/ROADMAP.md)
 - [Mobile architecture](./docs/MOBILE.md)
@@ -51,7 +59,7 @@ Security reports follow the process in [SECURITY.md](./SECURITY.md). "There is n
 - `pnpm` (version pinned in [package.json](./package.json))
 - [`uv`](https://docs.astral.sh/uv/)
 - Python 3.11
-- `ffmpeg` and `ffprobe` available on `PATH` (install via `brew install ffmpeg`, `apt install ffmpeg`, etc.)
+- `ffmpeg` and `ffprobe` available on `PATH` for development/source runs and macOS packages (install via `brew install ffmpeg`, `apt install ffmpeg`, etc.)
 - macOS system mic volume control uses the built-in CoreAudio API.
 - Linux system mic volume control uses `wpctl` or `pactl` for the active PipeWire/PulseAudio session.
 - Linux native tempo playback builds require Clang/libclang for `bindgen` (`sudo pacman -S clang`
@@ -229,7 +237,11 @@ For faster Flatpak testing, skip the single-file bundle step:
 pnpm package:linux:flatpak -- --no-bundle
 ```
 
-Packaged builds require host `ffmpeg` / `ffprobe`; Tuneforge does not bundle FFmpeg. See [Packaging](./docs/PACKAGING.md) for output paths, package flags, local repo install commands, data-directory behavior, and size expectations.
+macOS packaging writes a `.app` bundle and DMG. Flatpak packaging writes either a local `.flatpak`
+bundle or, with `--no-bundle`, a local repository install flow. Source distribution is the source
+checkout/archive; the package commands do not create a separate source tarball.
+
+macOS packages require host `ffmpeg` / `ffprobe`; Flatpak routes backend lookups to sandbox wrappers at `/app/bin/ffmpeg` and `/app/bin/ffprobe`. Tuneforge does not bundle FFmpeg. See [Packaging](./docs/PACKAGING.md) for output paths, package flags, local repo install commands, data-directory behavior, and size expectations.
 
 ## CI
 
@@ -237,6 +249,13 @@ GitHub Actions runs path-aware checks on pull requests and full checks on `main`
 
 - `backend`: `uv sync`, `ruff`, `mypy`, and FFmpeg-backed `pytest` only when backend/runtime paths require it
 - `desktop`: `pnpm install`, `pnpm contracts:generate`, generated-contract drift check, desktop `lint`, `typecheck`, `test`
+
+Manual or special coverage unless a workflow explicitly runs it:
+
+- local macOS packaging, Linux Flatpak packaging, and source/archive release checks
+- crema/TensorFlow Advanced Chords and beat-this Advanced Beat Analysis runtime/package checks
+- CUDA, MPS, and legacy NVIDIA GPU profiles
+- loopback browser playback E2E, Linux virtual-output capture, and macOS BlackHole capture
 
 ## Contributing
 

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -4,9 +4,9 @@ FastAPI backend for Tuneforge. It owns persistence, artifact management, audio a
 
 ## Layout
 
-- `app/api/routes/` — HTTP route handlers (projects, jobs, artifacts, health)
+- `app/api/routes/` — HTTP route handlers (projects, jobs, artifacts, health, sync, backend capability lists)
 - `app/services/` — orchestration, persistence, caching
-- `app/engines/` — pure computation: analysis, chord detection, stems (Demucs), transforms (FFmpeg / pitch)
+- `app/engines/` — pure computation: analysis, beat/chord detection, lyrics, stems (Demucs), transforms (FFmpeg / pitch)
 - `app/models.py` / `app/schemas.py` — SQLAlchemy ORM models and Pydantic request/response schemas
 - `app/errors.py` — central `AppError` exception and FastAPI error handlers
 - `alembic/` — database migrations, run automatically on startup
@@ -58,6 +58,10 @@ pnpm setup:dev -- --no-advanced-chords
 
 If `crema`, TensorFlow, Keras, or JAMS are missing, `/api/v1/chord-backends` reports `crema-advanced` as unavailable and normal Built-in Chords detection keeps working.
 
+Release coverage label: full crema/TensorFlow runtime, package inclusion, and model-artifact review
+are manual or special checks unless a CI workflow explicitly installs and exercises the advanced
+dependency stack. Built-in Chords fallback should stay available when that stack is missing.
+
 ### Advanced Beat Analysis backend
 
 Advanced Beat Analysis is the default desktop timing-grid backend when the desktop dependency stack
@@ -77,6 +81,9 @@ The backend loads `beat-this` lazily and uses its `small0` checkpoint on CPU. `p
 verifies the checkpoint with size and SHA-256 before importing beat-this; if it is missing or
 invalid, setup preloads it. If the dependency or checkpoint is unavailable, the advanced settings
 option is disabled and Built-in Beat Analysis keeps working.
+
+Release coverage label: full beat-this runtime and checkpoint behavior are manual or special checks
+unless a CI workflow explicitly installs the advanced beat dependency stack and exercises it.
 
 `pnpm setup:dev` may download the checkpoint into the local PyTorch cache during setup. Opt out when
 testing built-in fallback behavior or unsupported profiles:
@@ -128,6 +135,9 @@ This profile is an opt-in local override for Linux `x86_64`. The committed lockf
 setup stay unchanged. When the override is active, use the repository commands (`pnpm dev:backend`, `pnpm test`,
 `pnpm lint`, `pnpm contracts:generate`) so the backend keeps using the overridden `.venv` instead of asking `uv` to
 resync it.
+
+Release coverage label: CUDA, MPS, and legacy NVIDIA GPU behavior are manual or special checks
+unless a CI workflow explicitly runs on matching hardware/profile.
 
 Both backend sync helpers recreate `.venv` from scratch before installing packages. That avoids stale mixed CUDA stacks after switching between the default and legacy NVIDIA profiles, while still letting `uv` reuse its shared cache for faster reinstalls.
 

--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Tuneforge is a local-first desktop practice app for stem separation, chords, lyrics, pitch shift, retune, and export."
+    />
+    <title>Tuneforge</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@tuneforge/site",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc && vite build",
+    "dev": "vite --host 127.0.0.1",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "lucide-react": "^1.21.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.1.2",
+    "@vitejs/plugin-react": "^6.0.2",
+    "typescript": "~6.0.3",
+    "vite": "^8.0.16"
+  }
+}

--- a/apps/site/src/App.tsx
+++ b/apps/site/src/App.tsx
@@ -1,0 +1,391 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  BadgeCheck,
+  CircleAlert,
+  Code2,
+  Download,
+  ExternalLink,
+  FileText,
+  HardDrive,
+  ListMusic,
+  Mic,
+  Music2,
+  PackageCheck,
+  ShieldOff,
+  SlidersHorizontal,
+  Video,
+  Wrench,
+} from "lucide-react";
+
+type MediaItem = {
+  id: string;
+  title: string;
+  kind: "screenshot" | "video";
+  src: string;
+  alt?: string;
+  caption?: string;
+  label?: string;
+  simulated?: boolean;
+};
+
+type MediaManifest = {
+  schemaVersion: number;
+  status: "pending" | "partial" | "captured";
+  generatedAt: string | null;
+  source: string;
+  items: MediaItem[];
+  notes?: string[];
+};
+
+const repoUrl = "https://github.com/grazzolini/tuneforge";
+const defaultManifest: MediaManifest = {
+  schemaVersion: 1,
+  status: "pending",
+  generatedAt: null,
+  source: "apps/site fallback",
+  items: [],
+  notes: ["Release media has not been generated yet."],
+};
+
+const capabilities = [
+  {
+    icon: ListMusic,
+    title: "Practice library",
+    body: "Import common audio and video formats, keep per-song analysis, and return to saved practice state.",
+  },
+  {
+    icon: SlidersHorizontal,
+    title: "Local stem and mix tools",
+    body: "Split stems with local Demucs, create practice mixes, transpose, retune, preview, and export.",
+  },
+  {
+    icon: Mic,
+    title: "Chords and lyrics",
+    body: "Generate editable chord timelines and local Whisper transcripts with timestamps when available.",
+  },
+  {
+    icon: Wrench,
+    title: "Player utilities",
+    body: "Use the chromatic tuner, metronome, chord dictionary, count-in, loop, and tempo controls from one shell.",
+  },
+];
+
+const packageRows = [
+  ["macOS", "Local unsigned app and DMG build", "Requires host ffmpeg and ffprobe on PATH"],
+  ["Linux", "Local Flatpak build", "Uses /app/bin/ffmpeg and /app/bin/ffprobe sandbox wrappers"],
+  ["Android", "Optional/manual while mobile evolves", "Capability-gated local workflow, not the full desktop stack"],
+  ["Models", "Caches used by default", "Bundling model weights is explicit and separate from dependency inclusion"],
+];
+
+const limitationRows = [
+  "Pre-1.0: local development and unsigned package builds are the supported paths today.",
+  "No cloud sync, no account system, no telemetry, and no public backend exposure.",
+  "FFmpeg and FFprobe are intentionally not bundled; development and macOS packages use host PATH, while Flatpak uses sandbox runtime wrappers.",
+  "First heavy ML use may need local model downloads or existing caches.",
+  "Flatpak builds are large because desktop ML dependencies are included by default.",
+  "Mobile remains in transition and should present clear disabled states for unsupported local capabilities.",
+];
+
+const links = [
+  { label: "GitHub", href: repoUrl, icon: Code2 },
+  { label: "Releases", href: `${repoUrl}/releases`, icon: Download },
+  { label: "Product spec", href: `${repoUrl}/blob/main/docs/SPEC.md`, icon: FileText },
+  { label: "Packaging", href: `${repoUrl}/blob/main/docs/PACKAGING.md`, icon: PackageCheck },
+];
+
+function mediaUrl(src: string) {
+  const base = import.meta.env.BASE_URL.endsWith("/")
+    ? import.meta.env.BASE_URL
+    : `${import.meta.env.BASE_URL}/`;
+  return `${base}${src.replace(/^\/+/, "")}`;
+}
+
+function useMediaManifest() {
+  const [manifest, setManifest] = useState<MediaManifest>(defaultManifest);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const manifestPath = mediaUrl("media/generated/manifest.json");
+
+    async function loadManifest() {
+      try {
+        const response = await fetch(manifestPath, {
+          cache: "no-store",
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error(`Media manifest returned ${response.status}.`);
+        }
+        const data = (await response.json()) as MediaManifest;
+        setManifest({
+          ...defaultManifest,
+          ...data,
+          items: Array.isArray(data.items) ? data.items : [],
+        });
+      } catch {
+        if (!controller.signal.aborted) {
+          setManifest(defaultManifest);
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoaded(true);
+        }
+      }
+    }
+
+    void loadManifest();
+    return () => controller.abort();
+  }, []);
+
+  return { loaded, manifest };
+}
+
+function HeroPreview() {
+  return (
+    <div className="hero-preview" aria-label="Tuneforge interface summary">
+      <div className="hero-preview__header">
+        <span className="dot dot--red" />
+        <span className="dot dot--yellow" />
+        <span className="dot dot--green" />
+        <strong>Tuneforge local session</strong>
+      </div>
+      <div className="hero-preview__grid">
+        <div className="hero-preview__timeline">
+          <span style={{ inlineSize: "26%" }} />
+          <span style={{ inlineSize: "18%" }} />
+          <span style={{ inlineSize: "31%" }} />
+          <span style={{ inlineSize: "15%" }} />
+        </div>
+        <div className="hero-preview__chords">
+          {["G", "D", "Em", "C"].map((chord) => (
+            <span key={chord}>{chord}</span>
+          ))}
+        </div>
+        <div className="hero-preview__mix">
+          {["Vocals", "Drums", "Bass", "Guitar"].map((stem, index) => (
+            <div key={stem}>
+              <span>{stem}</span>
+              <meter min={0} max={100} value={[58, 82, 66, 74][index]} />
+            </div>
+          ))}
+        </div>
+      </div>
+      <p>Deterministic demo data. No user audio, mic input, or network transfer.</p>
+    </div>
+  );
+}
+
+function MediaCard({ item }: { item: MediaItem }) {
+  return (
+    <article className="media-card">
+      <div className="media-card__asset">
+        {item.kind === "video" ? (
+          <video controls muted playsInline preload="metadata" src={mediaUrl(item.src)} />
+        ) : (
+          <img alt={item.alt ?? item.title} src={mediaUrl(item.src)} loading="lazy" />
+        )}
+      </div>
+      <div className="media-card__copy">
+        <span className="tag">{item.label ?? item.kind}</span>
+        <h3>{item.title}</h3>
+        {item.caption ? <p>{item.caption}</p> : null}
+        {item.simulated ? <p className="media-card__note">Simulated/demo state. No real microphone or LAN transfer.</p> : null}
+      </div>
+    </article>
+  );
+}
+
+function MediaFallback({ manifest }: { manifest: MediaManifest }) {
+  return (
+    <div className="media-fallback">
+      <Video aria-hidden="true" />
+      <div>
+        <h3>Release media not captured yet</h3>
+        <p>
+          The site is ready for generated screenshots and video, but this checkout has only the
+          placeholder manifest. Capture output will appear from <code>apps/site/public/media/generated</code>.
+        </p>
+        <pre>{`node scripts/capture-release-media.mjs --run`}</pre>
+        {manifest.notes?.length ? (
+          <ul>
+            {manifest.notes.map((note) => (
+              <li key={note}>{note}</li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function App() {
+  const { loaded, manifest } = useMediaManifest();
+  const mediaItems = useMemo(() => manifest.items.filter((item) => item.src), [manifest.items]);
+
+  return (
+    <div className="site-shell">
+      <header className="site-nav" aria-label="Primary">
+        <a className="brand" href="#top">
+          <span className="brand__mark">
+            <Music2 aria-hidden="true" />
+          </span>
+          <span>
+            <strong>Tuneforge</strong>
+            <small>Local practice rig</small>
+          </span>
+        </a>
+        <nav>
+          <a href="#media">Media</a>
+          <a href="#packages">Packages</a>
+          <a href="#limits">Limits</a>
+          <a href={`${repoUrl}/releases`}>Releases</a>
+        </nav>
+      </header>
+
+      <main id="top">
+        <section className="hero-section" aria-labelledby="hero-title">
+          <div className="hero-section__content">
+            <p className="eyebrow">Local-first desktop app for musicians</p>
+            <h1 id="hero-title">Tuneforge</h1>
+            <p className="hero-section__lede">
+              Split stems, inspect chords and lyrics, retune, transpose, rehearse, and export
+              practice mixes without accounts, cloud processing, analytics, or telemetry.
+            </p>
+            <div className="hero-section__actions" aria-label="Primary links">
+              <a className="button button--primary" href={`${repoUrl}/releases`}>
+                <Download aria-hidden="true" />
+                Releases
+              </a>
+              <a className="button" href={`${repoUrl}/blob/main/README.md`}>
+                <FileText aria-hidden="true" />
+                Read docs
+              </a>
+            </div>
+            <dl className="truth-strip">
+              <div>
+                <dt>No account</dt>
+                <dd>Single-user local library</dd>
+              </div>
+              <div>
+                <dt>No cloud</dt>
+                <dd>Processing stays on host</dd>
+              </div>
+              <div>
+                <dt>FFmpeg</dt>
+                <dd>Host PATH or Flatpak runtime</dd>
+              </div>
+            </dl>
+          </div>
+          <HeroPreview />
+        </section>
+
+        <section className="section section--capabilities" aria-labelledby="capabilities-title">
+          <div className="section__header">
+            <p className="eyebrow">What works locally</p>
+            <h2 id="capabilities-title">A player-focused song toolkit</h2>
+          </div>
+          <div className="capability-grid">
+            {capabilities.map((capability) => {
+              const Icon = capability.icon;
+              return (
+                <article className="capability-card" key={capability.title}>
+                  <Icon aria-hidden="true" />
+                  <h3>{capability.title}</h3>
+                  <p>{capability.body}</p>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="section" id="media" aria-labelledby="media-title">
+          <div className="section__header section__header--split">
+            <div>
+              <p className="eyebrow">Screenshots and video</p>
+              <h2 id="media-title">Release media</h2>
+            </div>
+            <span className={`status-pill status-pill--${manifest.status}`}>
+              {loaded ? manifest.status : "loading"}
+            </span>
+          </div>
+          {mediaItems.length ? (
+            <div className="media-grid">
+              {mediaItems.map((item) => (
+                <MediaCard item={item} key={item.id} />
+              ))}
+            </div>
+          ) : (
+            <MediaFallback manifest={manifest} />
+          )}
+        </section>
+
+        <section className="section section--split" id="packages" aria-labelledby="packages-title">
+          <div className="section__header">
+            <p className="eyebrow">Distribution status</p>
+            <h2 id="packages-title">Packages are local and unsigned today</h2>
+            <p>
+              Desktop packaging exists for local builds. The generated apps do not include FFmpeg or
+              FFprobe; macOS uses host PATH and Flatpak uses sandbox runtime wrappers. macOS
+              artifacts are not signed or notarized.
+            </p>
+          </div>
+          <div className="package-table" role="table" aria-label="Package status">
+            {packageRows.map(([platform, status, note]) => (
+              <div role="row" key={platform}>
+                <strong role="cell">{platform}</strong>
+                <span role="cell">{status}</span>
+                <small role="cell">{note}</small>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="section section--links" aria-labelledby="links-title">
+          <div className="section__header">
+            <p className="eyebrow">Project links</p>
+            <h2 id="links-title">Docs and release notes</h2>
+          </div>
+          <div className="link-grid">
+            {links.map((link) => {
+              const Icon = link.icon;
+              return (
+                <a href={link.href} key={link.label}>
+                  <Icon aria-hidden="true" />
+                  <span>{link.label}</span>
+                  <ExternalLink aria-hidden="true" />
+                </a>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="section section--limits" id="limits" aria-labelledby="limits-title">
+          <div className="section__header">
+            <p className="eyebrow">Known limitations</p>
+            <h2 id="limits-title">Clear boundaries</h2>
+          </div>
+          <ul className="limit-list">
+            {limitationRows.map((limitation, index) => (
+              <li key={limitation}>
+                {index === 0 ? <CircleAlert aria-hidden="true" /> : <ShieldOff aria-hidden="true" />}
+                <span>{limitation}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </main>
+
+      <footer className="site-footer">
+        <span>
+          <HardDrive aria-hidden="true" />
+          Local-first, no trackers.
+        </span>
+        <span>
+          <BadgeCheck aria-hidden="true" />
+          Built from repository content and generated media only.
+        </span>
+      </footer>
+    </div>
+  );
+}

--- a/apps/site/src/main.tsx
+++ b/apps/site/src/main.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import "./styles.css";
+
+const rootElement = document.getElementById("root");
+
+if (!rootElement) {
+  throw new Error("Root element was not found.");
+}
+
+createRoot(rootElement).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/site/src/styles.css
+++ b/apps/site/src/styles.css
@@ -1,0 +1,657 @@
+:root {
+  color: #1f2421;
+  background: #f6f4ef;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  --bg: #f6f4ef;
+  --ink: #1f2421;
+  --muted: #667064;
+  --panel: #ffffff;
+  --panel-soft: #ebe8df;
+  --line: #d8d3c6;
+  --green: #176b4d;
+  --green-dark: #0f4633;
+  --rust: #a33d1c;
+  --gold: #a46b16;
+  --blue: #27667b;
+  --shadow: 0 18px 50px rgba(48, 43, 34, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+code,
+pre {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+}
+
+.site-shell {
+  min-height: 100vh;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(246, 244, 239, 0.9) 28rem),
+    var(--bg);
+}
+
+.site-nav {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem clamp(1rem, 4vw, 4rem);
+  border-bottom: 1px solid rgba(31, 36, 33, 0.1);
+  background: rgba(246, 244, 239, 0.92);
+  backdrop-filter: blur(16px);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.brand__mark {
+  display: grid;
+  place-items: center;
+  inline-size: 2.4rem;
+  block-size: 2.4rem;
+  border-radius: 8px;
+  color: #fff;
+  background: var(--green);
+}
+
+.brand svg,
+.button svg,
+.link-grid svg,
+.site-footer svg {
+  inline-size: 1.1rem;
+  block-size: 1.1rem;
+  flex: 0 0 auto;
+}
+
+.brand strong,
+.brand small {
+  display: block;
+}
+
+.brand small {
+  color: var(--muted);
+}
+
+.site-nav nav {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.site-nav nav a {
+  border-radius: 8px;
+  padding: 0.6rem 0.8rem;
+  color: var(--muted);
+  font-weight: 700;
+}
+
+.site-nav nav a:hover,
+.site-nav nav a:focus-visible {
+  color: var(--ink);
+  background: rgba(31, 36, 33, 0.07);
+}
+
+main {
+  overflow: hidden;
+}
+
+.hero-section,
+.section,
+.site-footer {
+  inline-size: min(1160px, calc(100% - 2rem));
+  margin-inline: auto;
+}
+
+.hero-section {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.92fr);
+  gap: clamp(2rem, 5vw, 4.5rem);
+  align-items: center;
+  min-height: calc(100vh - 4.2rem);
+  padding-block: clamp(3rem, 8vw, 6rem);
+}
+
+.hero-section__content {
+  min-width: 0;
+}
+
+.eyebrow {
+  margin: 0 0 0.85rem;
+  color: var(--rust);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-block-start: 0;
+}
+
+h1 {
+  margin-block-end: 1rem;
+  color: var(--ink);
+  font-size: clamp(3.2rem, 9vw, 7.8rem);
+  line-height: 0.88;
+  letter-spacing: 0;
+}
+
+h2 {
+  margin-block-end: 0.8rem;
+  font-size: clamp(2rem, 4vw, 3.6rem);
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+h3 {
+  margin-block-end: 0.5rem;
+  font-size: 1.08rem;
+  line-height: 1.2;
+  letter-spacing: 0;
+}
+
+.hero-section__lede {
+  max-inline-size: 58rem;
+  color: #394039;
+  font-size: clamp(1.08rem, 2vw, 1.35rem);
+  line-height: 1.55;
+}
+
+.hero-section__actions,
+.truth-strip,
+.link-grid,
+.site-footer,
+.media-card__copy,
+.section__header--split {
+  display: flex;
+  align-items: center;
+}
+
+.hero-section__actions {
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-block: 2rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  min-block-size: 2.9rem;
+  border: 1px solid rgba(31, 36, 33, 0.16);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  color: var(--ink);
+  background: #fff;
+  box-shadow: 0 6px 18px rgba(48, 43, 34, 0.08);
+  font-weight: 900;
+}
+
+.button--primary {
+  color: #fff;
+  border-color: var(--green-dark);
+  background: var(--green);
+}
+
+.truth-strip {
+  align-items: stretch;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin: 0;
+}
+
+.truth-strip div {
+  min-inline-size: 10rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.85rem;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.truth-strip dt {
+  color: var(--ink);
+  font-weight: 900;
+}
+
+.truth-strip dd {
+  margin: 0.18rem 0 0;
+  color: var(--muted);
+}
+
+.hero-preview {
+  border: 1px solid rgba(31, 36, 33, 0.12);
+  border-radius: 8px;
+  padding: clamp(1rem, 2vw, 1.4rem);
+  background: #22271f;
+  box-shadow: var(--shadow);
+  color: #f8f7f1;
+}
+
+.hero-preview__header,
+.hero-preview__mix div,
+.package-table div,
+.limit-list li {
+  display: flex;
+  align-items: center;
+}
+
+.hero-preview__header {
+  gap: 0.45rem;
+  padding-block-end: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.dot {
+  inline-size: 0.72rem;
+  block-size: 0.72rem;
+  border-radius: 999px;
+}
+
+.dot--red {
+  background: #d86d55;
+}
+
+.dot--yellow {
+  background: #d6b354;
+}
+
+.dot--green {
+  background: #5eb17a;
+}
+
+.hero-preview__grid {
+  display: grid;
+  gap: 1rem;
+  padding-block: 1.25rem;
+}
+
+.hero-preview__timeline {
+  display: flex;
+  gap: 0.35rem;
+  block-size: 5rem;
+  align-items: end;
+  padding: 0.75rem;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.hero-preview__timeline span {
+  display: block;
+  block-size: 100%;
+  min-inline-size: 2.5rem;
+  border-radius: 4px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.65), rgba(255, 255, 255, 0)),
+    var(--gold);
+}
+
+.hero-preview__chords {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.hero-preview__chords span {
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  padding: 0.85rem 0.5rem;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.07);
+  font-size: 1.35rem;
+  font-weight: 900;
+}
+
+.hero-preview__mix {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.hero-preview__mix div {
+  gap: 0.8rem;
+}
+
+.hero-preview__mix span {
+  inline-size: 4rem;
+  color: #cfd5cc;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.hero-preview meter {
+  flex: 1;
+  inline-size: 100%;
+}
+
+.hero-preview p {
+  margin: 0;
+  color: #cfd5cc;
+  font-size: 0.9rem;
+}
+
+.section {
+  padding-block: clamp(3rem, 7vw, 5.5rem);
+}
+
+.section__header {
+  max-inline-size: 54rem;
+  margin-block-end: 1.5rem;
+}
+
+.section__header p {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.section__header--split {
+  justify-content: space-between;
+  gap: 1rem;
+  max-inline-size: none;
+}
+
+.capability-grid,
+.media-grid,
+.link-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.capability-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.capability-card,
+.media-card,
+.media-fallback,
+.package-table,
+.link-grid a,
+.limit-list li {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: 0 10px 30px rgba(48, 43, 34, 0.06);
+}
+
+.capability-card {
+  min-block-size: 15rem;
+  padding: 1.25rem;
+}
+
+.capability-card svg {
+  inline-size: 1.35rem;
+  block-size: 1.35rem;
+  margin-block-end: 1rem;
+  color: var(--green);
+}
+
+.capability-card p,
+.media-card p,
+.media-fallback p,
+.limit-list {
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.status-pill,
+.tag {
+  display: inline-flex;
+  align-items: center;
+  min-block-size: 2rem;
+  border-radius: 999px;
+  padding-inline: 0.85rem;
+  background: var(--panel-soft);
+  color: var(--ink);
+  font-size: 0.82rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.status-pill--captured {
+  color: #fff;
+  background: var(--green);
+}
+
+.status-pill--partial {
+  color: #fff;
+  background: var(--gold);
+}
+
+.media-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.media-card {
+  overflow: hidden;
+}
+
+.media-card__asset {
+  display: grid;
+  place-items: center;
+  aspect-ratio: 16 / 10;
+  background: #20251f;
+}
+
+.media-card__asset img,
+.media-card__asset video {
+  display: block;
+  inline-size: 100%;
+  block-size: 100%;
+  object-fit: contain;
+}
+
+.media-card__copy {
+  align-items: flex-start;
+  flex-direction: column;
+  padding: 1rem;
+}
+
+.media-card__note {
+  margin: 0;
+  color: var(--rust);
+  font-weight: 800;
+}
+
+.media-fallback {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 1rem;
+  padding: 1.25rem;
+}
+
+.media-fallback svg {
+  inline-size: 2rem;
+  block-size: 2rem;
+  color: var(--gold);
+}
+
+.media-fallback pre {
+  overflow-x: auto;
+  border-radius: 8px;
+  padding: 0.85rem;
+  background: #22271f;
+  color: #f8f7f1;
+}
+
+.section--split {
+  display: grid;
+  grid-template-columns: minmax(0, 0.72fr) minmax(320px, 1fr);
+  gap: 2rem;
+  align-items: start;
+}
+
+.package-table {
+  overflow: hidden;
+}
+
+.package-table div {
+  display: grid;
+  grid-template-columns: 0.7fr 1fr 1.2fr;
+  gap: 1rem;
+  padding: 1rem;
+  border-block-end: 1px solid var(--line);
+}
+
+.package-table div:last-child {
+  border-block-end: 0;
+}
+
+.package-table small {
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.section--links {
+  padding-block-start: 2rem;
+}
+
+.link-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.link-grid a {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  min-block-size: 4.2rem;
+  padding: 1rem;
+  font-weight: 900;
+}
+
+.link-grid a svg:last-child {
+  margin-inline-start: auto;
+  color: var(--muted);
+}
+
+.limit-list {
+  display: grid;
+  gap: 0.65rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.limit-list li {
+  gap: 0.8rem;
+  padding: 0.9rem 1rem;
+}
+
+.limit-list svg {
+  inline-size: 1.1rem;
+  block-size: 1.1rem;
+  flex: 0 0 auto;
+  color: var(--rust);
+}
+
+.site-footer {
+  justify-content: space-between;
+  gap: 1rem;
+  padding-block: 2rem;
+  color: var(--muted);
+  border-top: 1px solid var(--line);
+}
+
+.site-footer span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+@media (max-width: 980px) {
+  .hero-section,
+  .section--split {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-section {
+    min-height: auto;
+  }
+
+  .capability-grid,
+  .link-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .site-nav {
+    position: static;
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .site-nav nav {
+    justify-content: flex-start;
+  }
+
+  .site-nav nav a {
+    padding-inline: 0.5rem;
+  }
+
+  .hero-section,
+  .section,
+  .site-footer {
+    inline-size: min(100% - 1rem, 1160px);
+  }
+
+  .truth-strip,
+  .site-footer,
+  .section__header--split {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .capability-grid,
+  .media-grid,
+  .link-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .package-table div {
+    grid-template-columns: 1fr;
+    gap: 0.35rem;
+  }
+
+  .media-fallback {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/site/src/vite-env.d.ts
+++ b/apps/site/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/site/tsconfig.json
+++ b/apps/site/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/apps/site/tsconfig.node.json
+++ b/apps/site/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/site/vite.config.ts
+++ b/apps/site/vite.config.ts
@@ -1,0 +1,7 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  base: "./",
+  plugins: [react()],
+});

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -16,7 +16,9 @@ Use the root `AGENTS.md` for global product/safety constraints. This file adds d
 - `ARCHITECTURE.md`: architecture and component boundaries.
 - `SPEC.md`: product behavior/spec details.
 - `API.md`: API behavior and contracts.
+- `NATIVE_AUDIO.md`: native/Web Audio behavior and manual playback QA.
 - `PACKAGING.md`: desktop package commands, package flags, and local install notes.
 - `ROADMAP.md`: planned work and sequencing.
+- `STEM_SEPARATION.md`: Demucs models, cache/bundle behavior, and stem validation notes.
 - `MOBILE.md`: mobile-specific notes/constraints.
 - `REFERENCES.md`: external references and supporting material.

--- a/docs/API.md
+++ b/docs/API.md
@@ -61,6 +61,7 @@ describe current pagination behavior or explicit unpaginated exceptions.
 | Endpoint or payload | List field | Pagination decision |
 | --- | --- | --- |
 | `GET /api/v1/jobs` | `jobs` | Paginated growable list with `status`, `project_id`, and project-name `search` filters plus `sort_by`/`sort_order`. Default ordering is active-first and deterministic. |
+| `POST /api/v1/jobs/bulk` | `created_jobs`, `skipped` | Explicit unpaginated bounded bulk-action result. The response is bounded by the current project library and the requested job type. |
 | `GET /api/v1/projects` | `projects` | Paginated growable list. `search` filters the full matching collection before pagination. Default ordering is `updated_at DESC, id DESC`. Desktop Library consumers should lazy-load this list. |
 | `GET /api/v1/projects/{project_id}/artifacts` | `artifacts` | Explicit unpaginated bounded project inventory exception: source audio, generated stems, practice mixes, exports, and cache artifacts. Ordered by `created_at DESC`; no pagination. |
 | `GET /api/v1/projects/{project_id}/sections` | `sections` | Explicit unpaginated project document/song-structure exception. Sections are bounded by the song arrangement and must stay complete for editing and playback. |
@@ -71,6 +72,8 @@ describe current pagination behavior or explicit unpaginated exceptions.
 | `GET /api/v1/sync/metadata` | `projects`, `artifacts`, `delete_tombstones` | Explicit unpaginated sync snapshot exception. The payload is a complete sync inventory used by native sync and reconciliation, not an interactive scroll list. If scale requires chunking, it should be a sync protocol change rather than this generic pagination contract. |
 | `GET /api/v1/sync/preflight` | `projects`, `duplicate_groups`, `manual_cleanup_guidance` | Explicit unpaginated diagnostic exception. The response is a complete local-library health report. |
 | `GET /api/v1/sync/projects/{project_id}/manifest` | `entity_revisions`, `artifacts`, `delete_tombstones` | Explicit unpaginated manifest exception. The response is an atomic project export unit. |
+| `POST /api/v1/sync/projects/manifests` | `project_manifests`, `manifest_errors` | Explicit unpaginated batch manifest export result, bounded by the requested `project_ids`. |
+| `POST /api/v1/sync/artifacts/files/resolve` | `records`, `errors` | Explicit unpaginated artifact-file resolution result, bounded by the requested `artifact_ids`. |
 | `POST /api/v1/sync/reconciliation/plan` | `items`, `actions` | Explicit unpaginated planning exception. The response is a complete computed plan for the supplied sync inventory. |
 | `POST /api/v1/sync/reconciliation/apply` | `plan.items`, `plan.actions`, `results`, `timing_evidence` | Explicit unpaginated apply exception. Partial pages would make apply summaries and results incomplete. |
 | Project document payloads, including analysis timing, chords, lyrics, tab imports, and tab apply results | nested content arrays and result arrays | Explicit unpaginated document exceptions unless a future endpoint exposes them as standalone growable collections. These arrays are part of a single project document or edit result, not top-level list browsing. |
@@ -254,6 +257,24 @@ artifact bytes from that device. The payload submitted to this endpoint must ref
 issued `pairing_offer_id`; that local offer must still be unused, unexpired, and match the
 payload's `pairing_secret`.
 
+### Answer sync pairing offer
+
+`POST /api/v1/sync/pairing/responses`
+
+Answers a copied pairing offer, stores trust for the peer, and returns a signed response payload the
+offer creator can verify through the manual exchange.
+
+Request fields:
+
+- `offer` - copied pairing offer payload.
+- `endpoint_hints` - optional advisory endpoints, default `[]`.
+- `adopt_sync_group` - whether this install should adopt the offer's `sync_group_id`, default `false`.
+
+Response fields:
+
+- `pairing_response`
+- `trusted_peer`
+
 ### List trusted peers
 
 `GET /api/v1/sync/trusted-peers`
@@ -430,7 +451,48 @@ Planner statuses are `noop`, `identical_content`, `missing_local_bytes`, `remote
 `missing_provider`, `deleted`, and `conflicted`.
 
 Action types are `apply_delete_tombstone`, `import_project_manifest`, `import_entity_revision`,
-`fetch_artifact_content`, `import_artifact_manifest`, `record_conflict`, and `noop`.
+`fetch_artifact_content`, `import_artifact_manifest`, `upsert_project_status`, `record_conflict`,
+and `noop`.
+
+### Apply sync reconciliation
+
+`POST /api/v1/sync/reconciliation/apply`
+
+Computes a reconciliation plan and applies selected local state changes. This endpoint writes local
+project status, imports manifests/revisions, applies tombstones, records conflicts, and can consume
+staged artifact files prepared by the native sync layer.
+
+Request fields:
+
+- `remote_library`
+- `project_manifests`
+- `peer_inventory`
+- `staging_root`
+- `use_content_addressed_staging`
+- `project_ids`
+- `include_timing_evidence`
+
+Response fields:
+
+- `summary`
+- `plan`
+- `results`
+- `timing_evidence`
+
+### Sign sync transport handshake
+
+`POST /api/v1/sync/transport/handshake/sign`
+
+Signs a native sync transport handshake challenge with this install's local sync identity. This is
+metadata for the native sync transport; it does not expose FastAPI beyond loopback.
+
+Request fields:
+
+- `peer_device_id`
+- `challenge`
+
+Response fields include `protocol_version`, `challenge_type`, `local_device_id`, `peer_device_id`,
+`public_key`, `challenge`, `canonical_challenge_json`, `signature`, and `signed_at`.
 
 ### Export project sync manifest
 
@@ -450,6 +512,86 @@ Manifest paths are project-root relative and use portable path separators. The r
 `entity_revisions` carries durable sync records for project metadata, chords, lyrics, sections, regeneration events, and other editable or generated project entities. Each revision records `revision_id`, `project_id`, `entity_type`, `entity_id`, `revision_type`, optional `base_revision_id`, `author_device_id`, optional `source_artifact_id`, `content_sha256`, `state`, `metadata`, `payload`, `created_at`, and `updated_at`.
 
 `delete_tombstones` carries durable group-delete records for project, artifact, and entity revision targets so offline peers do not resurrect deleted records when they reconnect. Each tombstone records the author device, delete timestamp, target type, target ID, sync group/project context, and prior metadata needed for diagnostics.
+
+### Export project sync manifests
+
+`POST /api/v1/sync/projects/manifests`
+
+Exports manifests for multiple requested projects. Failures for individual projects are returned in
+`manifest_errors` instead of discarding successful exports.
+
+Request fields:
+
+- `project_ids`
+
+Response fields:
+
+- `project_manifests`
+- `manifest_errors`
+
+### Update project sync status
+
+`PATCH /api/v1/sync/projects/{project_id}/status`
+
+Updates local sync status metadata for a project placeholder or imported project.
+
+Request fields:
+
+- `sync_status`
+- `sync_status_reason`
+- `sync_required_artifact_ids`
+- `sync_provider_device_ids`
+- `sync_conflict_count`
+- `manifest`
+- `project`
+
+Provide either `manifest` or `project`, not both.
+
+Response wrapper:
+
+- `project`
+
+### Stage sync artifact file
+
+`POST /api/v1/sync/artifacts/staging`
+
+Stages a local artifact file for sync import/export handoff, verifies its SHA-256 and size, and
+returns the content-addressed staging record. This endpoint reads a local path supplied by the native
+sync layer and does not expose arbitrary file content over the API.
+
+Request fields:
+
+- `source_path`
+- `content_sha256`
+- `size_bytes`
+- `provider_device_id`
+- `metadata`
+
+Response fields include `content_sha256`, `size_bytes`, `relative_path`, `provider_device_id`,
+`metadata`, `verified_at`, `created_at`, and `updated_at`.
+
+### Resolve sync artifact files
+
+`POST /api/v1/sync/artifacts/files/resolve`
+
+Resolves project artifact IDs into local file records for the native sync layer.
+
+Request fields:
+
+- `artifact_ids`
+
+Response fields:
+
+- `records`
+- `errors`
+
+### Get staged sync artifact
+
+`GET /api/v1/sync/artifacts/staging/{content_sha256}`
+
+Returns the staging record for a previously staged artifact content hash.
+
+Response: `SyncStagedArtifactSchema`.
 
 ### Import staged project sync manifest
 
@@ -483,12 +625,17 @@ Request fields:
 - `source_path`
 - `copy_into_project`
 - `display_name`
+- `chord_backend`
+- `chord_backend_fallback_from`
 - `stem_model`
+- `beat_backend`
 
 Response: `ProjectResponse`.
 
 `stem_model` is optional. Desktop imports send the user's default stem model so automatic source stems match
-manual stem generation preferences; if omitted, the backend stem model default is used.
+manual stem generation preferences; if omitted, the backend stem model default is used. `beat_backend`
+defaults to `built-in`; desktop preferences may send `beat-this` when Advanced Beat Analysis is
+available. Chord backend fields follow the same validation as explicit chord generation.
 
 `source_path` records where the user imported the file from on this install. Sync treats it as local provenance, not a durable source of original bytes or an operational sync input. `copy_into_project=false` is accepted for compatibility, but new imports still create an app-managed operational WAV source artifact under the project root.
 
@@ -548,6 +695,7 @@ Request fields:
 
 - `include_tempo`
 - `force`
+- `beat_backend`
 
 Response: `JobResponse`.
 
@@ -627,6 +775,42 @@ Each segment currently accepts:
 - `text`
 
 Response: `LyricsResponse`.
+
+## Tab Imports
+
+### Create tab import proposals
+
+`POST /api/v1/projects/{project_id}/tabs/proposals`
+
+Parses pasted local tab/chord text and returns proposed lyrics, chord, or section edits for review.
+The endpoint stores proposals but does not apply them.
+
+Request fields:
+
+- `raw_text`
+
+Response: `TabImportResponse`.
+
+### Get tab import
+
+`GET /api/v1/projects/{project_id}/tabs/{tab_import_id}`
+
+Returns a stored tab import and its suggestion groups.
+
+Response: `TabImportResponse`.
+
+### Accept tab import suggestions
+
+`POST /api/v1/projects/{project_id}/tabs/{tab_import_id}/accept`
+
+Applies selected suggestions from a tab import to editable project documents.
+
+Request fields:
+
+- `accepted_suggestion_ids`
+
+Response: `TabImportApplyResponse`, including the updated tab import, accepted/ignored IDs, and any
+updated lyrics, chords, sections, or project metadata.
 
 ## Sections
 
@@ -796,6 +980,22 @@ Status ordering:
 - Jobs inside each status group use the same deterministic tie-breakers as activity ordering for that group.
 
 Response: `JobsResponse`.
+
+### Create bulk jobs
+
+`POST /api/v1/jobs/bulk`
+
+Queues the same project activity job for eligible projects in the local library.
+
+Request fields:
+
+- `job_type` - `analyze`, `chords`, `lyrics`, or `stems`.
+- `chord_backend`
+- `chord_backend_fallback_from`
+- `stem_model`
+- `beat_backend`
+
+Response: `BulkJobsResponse`, with `created_jobs`, `total_projects`, and `skipped`.
 
 ### Get job
 

--- a/docs/NATIVE_AUDIO.md
+++ b/docs/NATIVE_AUDIO.md
@@ -103,6 +103,10 @@ Audio is active.
 Use this matrix for local regressions against source, practice-mix, and stems.
 Run once with native playback selected per platform, then rerun with forced Web Audio.
 
+Coverage label: manual/special unless a CI workflow explicitly runs the same command and capture
+mode. The matrix, loopback browser smoke, Linux `--route-output`, macOS AVFoundation capture, and
+BlackHole capture are release checks, not default `pnpm test` coverage.
+
 | Check | Native macOS | Native Linux | Forced Web Audio (`VITE_TUNEFORGE_FORCE_WEB_AUDIO=1`) |
 | --- | --- | --- | --- |
 | Source playback | start/seek/pause/resume/stop works | start/seek/pause/resume/stop works | start/seek/pause/resume/stop works |

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -1,6 +1,14 @@
 # Packaging
 
-Tuneforge packaging is currently intended for local unsigned desktop builds. Packaged builds launch the bundled backend locally, include the default desktop Advanced Chords and Advanced Beat Analysis dependency stacks, do not bundle external model weights by default, and still require host-installed `ffmpeg` and `ffprobe`; Tuneforge does not bundle FFmpeg.
+Tuneforge packaging is currently intended for local unsigned desktop builds. Packaged builds launch the bundled backend locally, include the default desktop Advanced Chords and Advanced Beat Analysis dependency stacks, and do not bundle external model weights by default. Tuneforge does not bundle FFmpeg: macOS packages use host-installed `ffmpeg` and `ffprobe`, while Flatpak routes backend lookups through sandbox wrappers at `/app/bin/ffmpeg` and `/app/bin/ffprobe`.
+
+## Release Artifact Truth
+
+- macOS packaging creates a local `.app` bundle and DMG. The app is unsigned and not notarized.
+- Linux Flatpak packaging creates either a single-file `.flatpak` bundle or, with `--no-bundle`, a local Flatpak repository install flow.
+- Source distribution is the repository checkout or source archive from version control. These package commands do not create a separate source tarball.
+- Packaging, model-bundle review, crema/TensorFlow, beat-this, CUDA/MPS/legacy NVIDIA GPU behavior, and install smoke checks are manual or special coverage unless a CI workflow explicitly runs them.
+- Release/default package commands must not use `--model-bundle`; publishable artifacts must not include Demucs, Whisper, or beat-this model weights unless redistribution has been explicitly reviewed.
 
 ## macOS
 
@@ -46,6 +54,8 @@ pnpm package:linux:flatpak -- --no-bundle
 ```
 
 The Flatpak build generates local dependency source manifests, builds inside the SDK sandbox, and installs the backend under `/app/lib/tuneforge/backend`. It bundles `pactl` for microphone volume control but does not bundle FFmpeg.
+
+Flatpak runtime lookups are not host `PATH` lookups. The manifest sets `TUNEFORGE_FFMPEG_PATH=/app/bin/ffmpeg` and `TUNEFORGE_FFPROBE_PATH=/app/bin/ffprobe`; those files are wrappers that search for `ffmpeg` and `ffprobe` inside the sandbox runtime/extension paths. If the runtime does not provide them, the Flatpak build or app reports the missing sandbox binary rather than falling back to the host shell.
 
 Plain Linux packages include crema Advanced Chords and beat-this Advanced Beat Analysis dependency
 stacks by default. Feature flags are independent:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -65,8 +65,9 @@ Roadmap items are grouped by track so related work can move independently.
 
 ## Packaging & Distribution
 
-- Keep macOS packaging available for local unsigned builds.
-- Create a Flatpak package for Linux.
+- Keep macOS app/DMG packaging available for local unsigned builds.
+- Keep Linux Flatpak packaging available for local unsigned builds and local repository installs.
+- Treat source distribution as the repository checkout or version-control source archive unless a dedicated source artifact is added.
 - Create package recipes for Arch Linux's pacman (`PKGBUILD`), rpm, and deb.
 - Document host-installed FFmpeg and FFprobe requirements clearly.
 - Avoid bundling FFmpeg for licensing and distribution reasons.
@@ -79,6 +80,7 @@ Roadmap items are grouped by track so related work can move independently.
 - Keep backend gates: Ruff, mypy, and pytest.
 - Keep desktop gates: lint, typecheck, and Vitest.
 - Keep OpenAPI contract drift checks in CI.
+- Keep release copy honest about manual/special checks for packaging, crema/TensorFlow, beat-this, GPU profiles, loopback browser E2E, BlackHole capture, and virtual-output capture.
 - Add focused tests when new timing artifacts, practice loops, mobile capability gates, or destructive-regeneration flows are introduced.
 - Prefer deterministic timing tests over wall-clock-dependent assertions.
 - Keep generated or ignored mobile build artifacts out of commits unless they are intentionally tracked.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -8,6 +8,14 @@ The product direction is desktop-first with an active Android/mobile path. Deskt
 
 TuneForge is not a SaaS product, web service, or multi-user system. It has no account model, cloud backend, telemetry, or remote processing requirement.
 
+## 1.0 Release Scope and Limits
+
+- Desktop is the complete supported workflow for import, local analysis/generation, playback practice, and export.
+- Android/mobile remains an in-progress local companion path, not a replacement for desktop processing.
+- macOS and Linux packages are local unsigned build artifacts until release signing/notarization work exists.
+- Host-installed `ffmpeg` and `ffprobe` remain required; TuneForge does not bundle FFmpeg.
+- Advanced Chords, Advanced Beat Analysis, GPU acceleration, loopback/browser playback, BlackHole capture, and virtual-output capture require manual or special validation unless a CI workflow explicitly covers them.
+
 ## Product Goals
 
 - Import common audio and video containers into a local project workspace.
@@ -101,8 +109,9 @@ Capo-relative display is a harmonic presentation feature. It should not alter au
 
 ### Stems
 
-- Generate two-stem output on desktop with Demucs.
-- Store vocal and instrumental artifacts.
+- Generate desktop stems with Demucs, defaulting to the 6-stem `htdemucs_6s` model.
+- Also support the 2-stem `htdemucs_ft` model for vocals/instrumental workflows.
+- Store generated stem artifacts as project-local practice assets.
 - Allow practice playback against source audio or generated stems.
 - Keep mobile stems experimental until local acceleration, storage, and native media handling are proven.
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "package:mac": "node scripts/package-mac.mjs",
     "package:mac:app": "node scripts/package-mac.mjs --app-only",
     "package:mac:dmg": "node scripts/package-dmg.mjs",
+    "release:check-version": "node scripts/check-release-version.mjs",
     "setup:dev": "bash scripts/setup-dev.sh",
     "stems:waveforms": "bash -c 'if [[ \"${1:-}\" == \"--\" ]]; then shift; fi; invocation_dir=\"${INIT_CWD:-$PWD}\"; cd apps/backend && uv run --python 3.11 python ../../scripts/stem-waveforms.py --output-dir \"${invocation_dir}/stem-waveforms\" \"$@\"' --",
     "sync:bundle": "bash -c 'if [[ \"${1:-}\" == \"--\" ]]; then shift; fi; exec bash scripts/run-backend-module.sh app.cli.sync_bundle \"$@\"' --",

--- a/packages/shared-types/AGENTS.md
+++ b/packages/shared-types/AGENTS.md
@@ -6,8 +6,8 @@ This package is generated-contract focused.
 
 - Source of truth is backend OpenAPI output, not manual edits.
 - Do not hand-edit:
-  - `openapi.json`
-  - `src/generated/openapi.ts`
+  - `openapi.json` (ignored local generator output; do not commit)
+  - `src/generated/openapi.ts` (committed generated contract; CI checks drift)
 - After backend API changes, regenerate from repo root:
   - `pnpm contracts:generate`
-- If generated output changes, commit it in the same PR as backend API changes.
+- If the generated TypeScript contract changes, commit `src/generated/openapi.ts` in the same PR as backend API changes.

--- a/packaging/flatpak/com.tuneforge.desktop.metainfo.xml
+++ b/packaging/flatpak/com.tuneforge.desktop.metainfo.xml
@@ -27,6 +27,6 @@
   </categories>
   <content_rating type="oars-1.1" />
   <releases>
-    <release version="0.1.0" date="2026-04-30" />
+    <release version="0.1.0" date="2026-06-27" />
   </releases>
 </component>

--- a/packaging/flatpak/com.tuneforge.desktop.yml
+++ b/packaging/flatpak/com.tuneforge.desktop.yml
@@ -31,7 +31,6 @@ cleanup:
   - /include
   - /lib/pnpm
   - /lib/pkgconfig
-  - /share/doc
   - /share/gtk-doc
   - /share/man
   - /share/pkgconfig
@@ -172,7 +171,14 @@ modules:
       - type: file
         path: ../../pnpm-workspace.yaml
       - type: file
+        path: ../../README.md
+      - type: file
         path: ../../LICENSE
+      - type: file
+        path: ../../THIRD_PARTY_NOTICES.md
+      - type: file
+        path: ../../docs/PACKAGING.md
+        dest: docs
       - type: file
         path: ../../scripts/build-info.mjs
         dest: scripts
@@ -272,6 +278,10 @@ modules:
       - install -Dm644 apps/backend/pyproject.toml /app/lib/tuneforge/backend/src/pyproject.toml
       - install -Dm644 com.tuneforge.desktop.desktop /app/share/applications/com.tuneforge.desktop.desktop
       - install -Dm644 com.tuneforge.desktop.metainfo.xml /app/share/metainfo/com.tuneforge.desktop.metainfo.xml
+      - install -Dm644 README.md /app/share/doc/tuneforge/README.md
+      - install -Dm644 LICENSE /app/share/doc/tuneforge/LICENSE
+      - install -Dm644 THIRD_PARTY_NOTICES.md /app/share/doc/tuneforge/THIRD_PARTY_NOTICES.md
+      - install -Dm644 docs/PACKAGING.md /app/share/doc/tuneforge/PACKAGING.md
       - install -Dm644 apps/desktop/src-tauri/icons/32x32.png /app/share/icons/hicolor/32x32/apps/com.tuneforge.desktop.png
       - install -Dm644 apps/desktop/src-tauri/icons/128x128.png /app/share/icons/hicolor/128x128/apps/com.tuneforge.desktop.png
       - install -Dm644 apps/desktop/src-tauri/icons/512x512.png /app/share/icons/hicolor/512x512/apps/com.tuneforge.desktop.png

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,34 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@types/node@26.0.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.0)(jiti@2.6.1))
 
+  apps/site:
+    dependencies:
+      lucide-react:
+        specifier: ^1.21.0
+        version: 1.21.0(react@19.2.7)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.1.2
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.2
+        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(jiti@2.6.1))
+      typescript:
+        specifier: ~6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@26.0.0)(jiti@2.6.1)
+
   packages/shared-types:
     devDependencies:
       openapi-typescript:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 packages:
   - apps/desktop
+  - apps/site
   - packages/shared-types
-

--- a/scripts/capture-release-media.mjs
+++ b/scripts/capture-release-media.mjs
@@ -1,0 +1,1531 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+import net from "node:net";
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { basename, join, resolve } from "node:path";
+import process from "node:process";
+
+const desktopRequire = createRequire(new URL("../apps/desktop/package.json", import.meta.url));
+const repoRoot = fileURLToPath(new URL("../", import.meta.url));
+const defaultOutputDir = resolve(repoRoot, "apps/site/public/media/generated");
+const fixtureTimestamp = "2026-04-18T13:16:00.000Z";
+const childTailLines = 40;
+const capturePlan = [
+  {
+    id: "library",
+    kind: "screenshot",
+    fileName: "library.png",
+    title: "Library with deterministic demo projects",
+    route: "/",
+  },
+  {
+    id: "playback",
+    kind: "screenshot",
+    fileName: "playback.png",
+    title: "Playback workspace with lyrics and chords follow",
+    route: "/projects/proj_release_demo",
+  },
+  {
+    id: "tuner-simulated",
+    kind: "screenshot",
+    fileName: "tuner-simulated.png",
+    title: "Chromatic tuner simulated/demo state, slightly sharp",
+    route: "/tools",
+    simulated: true,
+  },
+  {
+    id: "chord-dictionary",
+    kind: "screenshot",
+    fileName: "chord-dictionary.png",
+    title: "Chord dictionary reference screen",
+    route: "/tools?tool=chord-dictionary",
+  },
+  {
+    id: "jobs",
+    kind: "screenshot",
+    fileName: "jobs.png",
+    title: "Activity jobs screen",
+    route: "/activity",
+  },
+  {
+    id: "settings",
+    kind: "screenshot",
+    fileName: "settings.png",
+    title: "Settings screen",
+    route: "/settings",
+  },
+];
+
+if (isDirectRun()) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(`[capture-release-media] ${errorMessage(error)}`);
+    process.exitCode = 1;
+  }
+}
+
+function isDirectRun() {
+  return Boolean(process.argv[1]) && import.meta.url === pathToFileURL(process.argv[1]).href;
+}
+
+async function main() {
+  const options = parseOptions(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+  if (options.dryRun) {
+    printPlan(options);
+    return;
+  }
+  if (options.manifestOnly) {
+    await writeManifest(options.outputDir, {
+      status: "pending",
+      items: [],
+      notes: [
+        "Manifest placeholder generated without screenshots or video.",
+        "Run node scripts/capture-release-media.mjs --run to capture deterministic desktop UI media.",
+      ],
+    });
+    console.log(`[capture-release-media] Wrote placeholder manifest to ${options.outputDir}.`);
+    return;
+  }
+  if (!options.run) {
+    printHelp();
+    return;
+  }
+
+  await captureReleaseMedia(options);
+}
+
+function parseOptions(args) {
+  const options = {
+    allowPartial: false,
+    appUrl: null,
+    dryRun: false,
+    headed: false,
+    help: false,
+    manifestOnly: false,
+    outputDir: defaultOutputDir,
+    recordVideo: true,
+    run: false,
+    theme: "dark",
+    timeoutMs: 45_000,
+    videoHoldMs: 1_800,
+    viewport: { width: 1920, height: 980 },
+  };
+
+  for (const arg of args) {
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else if (arg === "--allow-partial") {
+      options.allowPartial = true;
+    } else if (arg === "--run") {
+      options.run = true;
+    } else if (arg === "--dry-run") {
+      options.dryRun = true;
+    } else if (arg === "--headed") {
+      options.headed = true;
+    } else if (arg === "--manifest-only") {
+      options.manifestOnly = true;
+    } else if (arg === "--no-video") {
+      options.recordVideo = false;
+    } else if (arg.startsWith("--app-url=")) {
+      options.appUrl = readOptionValue(arg, "--app-url");
+    } else if (arg.startsWith("--output-dir=")) {
+      options.outputDir = resolve(repoRoot, readOptionValue(arg, "--output-dir"));
+    } else if (arg.startsWith("--timeout-ms=")) {
+      const timeoutMs = Number(readOptionValue(arg, "--timeout-ms"));
+      if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+        throw new Error("--timeout-ms must be a positive integer.");
+      }
+      options.timeoutMs = timeoutMs;
+    } else if (arg.startsWith("--theme=")) {
+      const theme = readOptionValue(arg, "--theme");
+      if (!["dark", "light", "system"].includes(theme)) {
+        throw new Error("--theme must be one of dark, light, or system.");
+      }
+      options.theme = theme;
+    } else if (arg.startsWith("--video-hold-ms=")) {
+      const videoHoldMs = Number(readOptionValue(arg, "--video-hold-ms"));
+      if (!Number.isInteger(videoHoldMs) || videoHoldMs < 0) {
+        throw new Error("--video-hold-ms must be a non-negative integer.");
+      }
+      options.videoHoldMs = videoHoldMs;
+    } else if (arg.startsWith("--viewport=")) {
+      options.viewport = parseViewport(readOptionValue(arg, "--viewport"));
+    } else {
+      throw new Error(`Unknown option ${arg}. Use --help.`);
+    }
+  }
+
+  return options;
+}
+
+function readOptionValue(arg, name) {
+  const value = arg.slice(`${name}=`.length).trim();
+  if (!value) {
+    throw new Error(`${name} requires a value.`);
+  }
+  return value;
+}
+
+function parseViewport(value) {
+  const match = /^(\d+)x(\d+)$/.exec(value);
+  if (!match) {
+    throw new Error("--viewport must use WIDTHxHEIGHT, for example 1920x980.");
+  }
+  const width = Number(match[1]);
+  const height = Number(match[2]);
+  if (width < 320 || height < 320) {
+    throw new Error("--viewport dimensions must be at least 320.");
+  }
+  return { width, height };
+}
+
+function printHelp() {
+  console.log(`Capture deterministic release media for the GitHub Pages site.
+
+Usage:
+  node scripts/capture-release-media.mjs --run
+  node scripts/capture-release-media.mjs --run --app-url=http://127.0.0.1:1420
+  node scripts/capture-release-media.mjs --dry-run
+  node scripts/capture-release-media.mjs --manifest-only
+
+Options:
+  --run                  Capture screenshots and an overview video.
+  --app-url=<url>        Use an already running desktop Vite app. Defaults to starting one.
+  --output-dir=<path>    Output directory. Defaults to apps/site/public/media/generated.
+  --viewport=1920x980    Browser viewport for deterministic screenshots.
+  --theme=<mode>         Theme to capture: dark, light, or system. Defaults to dark.
+  --headed               Show the browser while capturing.
+  --no-video             Skip overview WebM recording.
+  --timeout-ms=<ms>      Startup and selector timeout. Defaults to 45000.
+  --video-hold-ms=<ms>   Hold each captured screen in the overview video. Defaults to 1800.
+  --allow-partial        Write a partial manifest without failing when screenshots miss.
+  --manifest-only        Write a placeholder manifest without media files.
+  --dry-run              Print planned outputs without writing files.
+
+Notes:
+  - Browser capture mocks backend HTTP with synthetic project data.
+  - No real microphone input is used. Tuner media is labeled simulated/demo.
+  - The script never downloads assets or calls external runtime services.`);
+}
+
+function printPlan(options) {
+  console.log("[capture-release-media] Dry run. Planned outputs:");
+  for (const item of capturePlan) {
+    console.log(`- ${join(options.outputDir, item.fileName)} (${item.title})`);
+  }
+  if (options.recordVideo) {
+    console.log(`- ${join(options.outputDir, "overview.webm")} (browser-recorded overview)`);
+  }
+  console.log(`- ${join(options.outputDir, "manifest.json")} (capture manifest)`);
+}
+
+async function captureReleaseMedia(options) {
+  const { chromium } = loadPlaywright();
+  await mkdir(options.outputDir, { recursive: true });
+
+  const children = [];
+  const capturedItems = [];
+  const notes = [
+    "Captured from current desktop React UI with synthetic backend data.",
+    "No user audio, microphone input, external services, or real LAN transfer were used.",
+  ];
+  let appUrl = options.appUrl;
+
+  try {
+    if (!appUrl) {
+      const port = await selectPort();
+      appUrl = `http://127.0.0.1:${port}`;
+      const child = startDesktopDevServer(port);
+      children.push(child);
+      await waitForHttp(appUrl, { child, timeoutMs: options.timeoutMs });
+      console.log(`[capture-release-media] Desktop dev server ready on ${appUrl}.`);
+    }
+
+    const browser = await chromium.launch({ headless: !options.headed });
+    const context = await browser.newContext({
+      colorScheme: options.theme === "light" ? "light" : "dark",
+      deviceScaleFactor: 1,
+      reducedMotion: "reduce",
+      recordVideo: options.recordVideo
+        ? { dir: options.outputDir, size: options.viewport }
+        : undefined,
+      viewport: options.viewport,
+    });
+    await context.route("**/*", async (route) => {
+      const handled = await maybeFulfillMockApi(route);
+      if (!handled) {
+        await route.continue();
+      }
+    });
+
+    const page = await context.newPage();
+    await installPageStabilizers(page, options);
+
+    for (const item of capturePlan) {
+      try {
+        await captureScreenshot(page, appUrl, item, options);
+        capturedItems.push(mediaItemForPlanItem(item));
+      } catch (error) {
+        notes.push(`${item.id} capture skipped: ${errorMessage(error)}`);
+        console.warn(`[capture-release-media] ${item.id} skipped: ${errorMessage(error)}`);
+      }
+    }
+
+    const video = options.recordVideo ? page.video() : null;
+
+    await context.close();
+    await browser.close();
+
+    const videoItem = video ? await saveOverviewVideo(video, options.outputDir) : null;
+    if (videoItem) {
+      capturedItems.push(videoItem);
+    }
+  } finally {
+    await stopChildren(children);
+  }
+
+  const missingRequiredScreenshots = requiredScreenshotIds().filter((id) =>
+    !capturedItems.some((item) => item.id === id),
+  );
+  if (missingRequiredScreenshots.length) {
+    notes.push(`Required screenshots missing: ${missingRequiredScreenshots.join(", ")}.`);
+  }
+
+  const status = capturedItems.length === capturePlan.length + (options.recordVideo ? 1 : 0)
+      ? "captured"
+      : capturedItems.length
+        ? "partial"
+        : "pending";
+
+  await writeManifest(options.outputDir, {
+    status,
+    items: capturedItems,
+    notes,
+  });
+  console.log(`[capture-release-media] Wrote ${capturedItems.length} media item(s) to ${options.outputDir}.`);
+
+  if (!options.allowPartial && missingRequiredScreenshots.length) {
+    throw new Error(
+      `Required screenshot capture failed: ${missingRequiredScreenshots.join(", ")}. ` +
+        "Manifest was written for debugging; rerun with --allow-partial to keep exit 0.",
+    );
+  }
+}
+
+function loadPlaywright() {
+  try {
+    return desktopRequire("playwright");
+  } catch {
+    throw new Error(
+      [
+        "Playwright is not installed for the desktop workspace.",
+        "Run pnpm install, then pnpm --filter @tuneforge/desktop exec playwright install chromium if browsers are missing.",
+      ].join("\n"),
+    );
+  }
+}
+
+function startDesktopDevServer(port) {
+  const desktopDir = resolve(repoRoot, "apps/desktop");
+  const localViteBin = resolve(desktopDir, "node_modules/.bin/vite");
+  if (existsSync(localViteBin)) {
+    return startChild("desktop dev server", localViteBin, [
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(port),
+      "--strictPort",
+    ], {
+      VITE_API_BASE_URL: "http://127.0.0.1:8765",
+    }, {
+      cwd: desktopDir,
+    });
+  }
+
+  return startChild("desktop dev server", "pnpm", [
+    "--filter",
+    "@tuneforge/desktop",
+    "dev",
+    "--host",
+    "127.0.0.1",
+    "--port",
+    String(port),
+    "--strictPort",
+  ], {
+    VITE_API_BASE_URL: "http://127.0.0.1:8765",
+  });
+}
+
+function startChild(label, command, args, env = {}, options = {}) {
+  const child = spawn(command, args, {
+    cwd: options.cwd ?? repoRoot,
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const output = [];
+
+  function pushOutput(chunk) {
+    output.push(String(chunk).trimEnd());
+    while (output.length > childTailLines) {
+      output.shift();
+    }
+  }
+
+  child.stdout.on("data", pushOutput);
+  child.stderr.on("data", pushOutput);
+  child.tail = () => output.filter(Boolean).join("\n");
+  child.label = label;
+  child.on("exit", (code, signal) => {
+    if (code !== 0 && signal !== "SIGTERM") {
+      console.warn(`[capture-release-media] ${label} exited with ${code ?? signal}.`);
+    }
+  });
+  return child;
+}
+
+async function stopChildren(children) {
+  await Promise.all(
+    children.map(
+      (child) =>
+        new Promise((resolveStop) => {
+          if (child.exitCode !== null || child.signalCode !== null) {
+            resolveStop();
+            return;
+          }
+          child.once("exit", resolveStop);
+          child.kill("SIGTERM");
+          setTimeout(() => {
+            if (child.exitCode === null && child.signalCode === null) {
+              child.kill("SIGKILL");
+            }
+          }, 1500).unref();
+        }),
+    ),
+  );
+}
+
+async function selectPort() {
+  return new Promise((resolvePort, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("Could not allocate a local port.")));
+        return;
+      }
+      const port = address.port;
+      server.close(() => resolvePort(port));
+    });
+  });
+}
+
+async function waitForHttp(url, { child, timeoutMs }) {
+  const startedAt = Date.now();
+  let lastError = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error(`${child.label} exited before becoming ready.\n${child.tail()}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return;
+      }
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(250);
+  }
+  throw new Error(`Timed out waiting for ${url}: ${errorMessage(lastError)}\n${child.tail()}`);
+}
+
+async function installPageStabilizers(page, options) {
+  await page.addInitScript(({ theme }) => {
+    const fixedNow = Date.parse("2026-04-18T13:16:00.000Z");
+    let callbackId = 1;
+    const callbacks = new Map();
+    const eventListeners = new Map();
+    let tunerFrameTimer = null;
+    let playbackPositionTimer = null;
+    let playbackSnapshot = {
+      sessionId: null,
+      state: "stopped",
+      positionSeconds: 0,
+      durationSeconds: 182,
+      playbackRate: 1,
+      nativePlaybackSupported: true,
+      fallbackReason: null,
+      lanes: [],
+      bufferHealth: [],
+    };
+
+    try {
+      window.localStorage.setItem("tuneforge.theme-preference", theme);
+      window.localStorage.setItem(
+        "tuneforge.project-playback-state",
+        JSON.stringify({
+          proj_release_demo: {
+            selectedArtifactId: "art_source",
+            selectedPrimaryArtifactId: "art_source",
+            selectedStemSourceArtifactId: null,
+            activeWorkspace: "playback",
+            activeProjectPanel: "studio",
+            playbackDisplayMode: "combined",
+            capoTransposeSemitones: 0,
+            precountEnabled: false,
+            precountLoopEnabled: false,
+            precountClickCount: 4,
+            tempoTargetBpm: 104,
+            loopRange: null,
+            loopAlignmentMode: null,
+            lyricsFollowEnabled: true,
+            chordsFollowEnabled: true,
+            stemControls: {},
+            dismissedStemJobIds: [],
+          },
+        }),
+      );
+    } catch {
+      // Local storage may be unavailable on about:blank before the app origin exists.
+    }
+
+    function createTunerFrame(index) {
+      const sampleRate = 48_000;
+      const sampleCount = 2_048;
+      const frequencyHz = 442;
+      const samples = Array.from({ length: sampleCount }, (_, sampleIndex) => {
+        const phase = (2 * Math.PI * frequencyHz * (sampleIndex + index * sampleCount)) / sampleRate;
+        return Math.sin(phase) * 0.28;
+      });
+      return {
+        deviceId: "release-media-default-input",
+        inputLevel: 0.28,
+        sampleRate,
+        samples,
+        timestampMs: fixedNow + index * 24,
+      };
+    }
+
+    function emitReleaseMediaEvent(event, payload) {
+      const listenerIds = eventListeners.get(event) ?? [];
+      for (const listenerId of listenerIds) {
+        const callbackEntry = callbacks.get(listenerId);
+        if (!callbackEntry) {
+          continue;
+        }
+        callbackEntry.callback({
+          event,
+          id: listenerId,
+          payload,
+        });
+        if (callbackEntry.once) {
+          callbacks.delete(listenerId);
+        }
+      }
+    }
+
+    function startTunerFrames() {
+      if (tunerFrameTimer) {
+        window.clearInterval(tunerFrameTimer);
+      }
+      let frameIndex = 0;
+      const emitFrame = () => {
+        emitReleaseMediaEvent("audio://input-frame", createTunerFrame(frameIndex));
+        frameIndex += 1;
+      };
+      emitFrame();
+      tunerFrameTimer = window.setInterval(emitFrame, 48);
+    }
+
+    function stopTunerFrames() {
+      if (tunerFrameTimer) {
+        window.clearInterval(tunerFrameTimer);
+        tunerFrameTimer = null;
+      }
+    }
+
+    function playbackLanesFromRequests(lanes) {
+      return lanes.map((lane) => ({
+        id: lane.id,
+        artifactId: lane.artifactId ?? null,
+        role: lane.role,
+        effectiveGain: lane.gain,
+        muted: Boolean(lane.muted),
+        solo: Boolean(lane.solo),
+      }));
+    }
+
+    function bufferHealthForLanes(lanes) {
+      return lanes.map((lane) => ({
+        laneId: lane.id,
+        artifactId: lane.artifactId ?? null,
+        role: lane.role,
+        ringFillSamples: 48_000,
+        ringCapacitySamples: 96_000,
+        underrunCount: 0,
+        workerErrorCount: 0,
+        lastWorkerError: null,
+      }));
+    }
+
+    function updatePlaybackSnapshot(overrides = {}) {
+      playbackSnapshot = {
+        ...playbackSnapshot,
+        ...overrides,
+      };
+      playbackSnapshot.bufferHealth = bufferHealthForLanes(playbackSnapshot.lanes);
+      return { ...playbackSnapshot };
+    }
+
+    function emitPlaybackPosition() {
+      emitReleaseMediaEvent("audio://position", {
+        sessionId: playbackSnapshot.sessionId,
+        positionSeconds: playbackSnapshot.positionSeconds,
+        durationSeconds: playbackSnapshot.durationSeconds,
+        state: playbackSnapshot.state,
+      });
+    }
+
+    function startPlaybackPosition() {
+      if (playbackPositionTimer) {
+        window.clearInterval(playbackPositionTimer);
+      }
+      emitPlaybackPosition();
+      playbackPositionTimer = window.setInterval(() => {
+        const nextPosition = Math.min(
+          playbackSnapshot.durationSeconds,
+          playbackSnapshot.positionSeconds + 0.5,
+        );
+        updatePlaybackSnapshot({ positionSeconds: nextPosition });
+        emitPlaybackPosition();
+      }, 500);
+    }
+
+    function stopPlaybackPosition() {
+      if (playbackPositionTimer) {
+        window.clearInterval(playbackPositionTimer);
+        playbackPositionTimer = null;
+      }
+    }
+
+    function releaseMediaSyncStatus() {
+      return {
+        active: true,
+        status: "listening",
+        endpoint_hints: [
+          "tuneforge-sync+tcp://127.0.0.1:48625?device_id=release_media_device_local&v=1",
+        ],
+        nearby_peers: [
+          {
+            device_id: "release_media_device_peer",
+            display_name: "Demo Rehearsal Laptop",
+            public_key: "release-media-peer-public-key",
+            short_fingerprint: "7d3f 91ac",
+            trust_status: "match",
+            trusted_peer_device_id: "release_media_device_peer",
+            endpoint_hints: [
+              "tuneforge-sync+tcp://127.0.0.1:48626?device_id=release_media_device_peer&v=1",
+            ],
+            last_seen_at: "2026-04-18T13:15:30.000Z",
+          },
+        ],
+        active_run_id: "sync_demo_001",
+        active_phase: "receiving",
+        active_message: "Deterministic demo transfer from trusted peer.",
+        active_progress_at: "2026-04-18T13:15:58.000Z",
+        active_elapsed_ms: 24_000,
+        last_sync: {
+          run_id: "sync_demo_previous",
+          peer_device_id: "release_media_device_peer",
+          status: "completed",
+          message: "Demo sync completed.",
+          started_at: "2026-04-18T13:10:00.000Z",
+          completed_at: "2026-04-18T13:10:09.000Z",
+          duration_ms: 9_000,
+          total_received_bytes: 12_582_912,
+          total_served_bytes: 0,
+          received_project_count: 1,
+          skipped_project_count: 2,
+          failed_project_count: 0,
+          total_project_count: 3,
+          received_artifacts: [
+            {
+              artifact_id: "proj_release_sync",
+              bytes: 12_582_912,
+              status: "received",
+              duration_ms: 4_200,
+            },
+          ],
+        },
+        updated_at: "2026-04-18T13:16:00.000Z",
+      };
+    }
+
+    async function invokeReleaseMediaCommand(command, args) {
+      if (command === "backend_base_url") {
+        return "http://127.0.0.1:8765";
+      }
+      if (command === "mobile_capabilities") {
+        throw new Error("Mobile runtime unavailable in release media capture.");
+      }
+      if (command === "audio_get_capabilities") {
+        return {
+          platform: "release-media",
+          backend: "release-media-demo",
+          nativePlaybackSupported: true,
+          micCaptureSupported: true,
+          micMonitoringSupported: false,
+          systemInputVolumeSupported: false,
+          emitsEvents: ["audio://position", "audio://ended", "audio://error", "audio://input-frame"],
+          fallbackRequired: false,
+          fallbackReason: null,
+        };
+      }
+      if (command === "audio_list_input_devices") {
+        return {
+          supported: true,
+          devices: [{ id: "release-media-default-input", label: "Release media demo input", isDefault: true }],
+          error: null,
+        };
+      }
+      if (command === "audio_list_output_devices") {
+        return { supported: true, devices: [], error: null };
+      }
+      if (command === "audio_prepare_session") {
+        const payload = args?.payload ?? {};
+        const lanes = playbackLanesFromRequests(payload.lanes ?? []);
+        updatePlaybackSnapshot({
+          sessionId: payload.sessionId ?? "release-media-playback",
+          state: "stopped",
+          positionSeconds: 0,
+          durationSeconds: payload.durationSeconds ?? 182,
+          playbackRate: payload.playbackRate ?? 1,
+          nativePlaybackSupported: true,
+          fallbackReason: null,
+          lanes,
+        });
+        return {
+          id: playbackSnapshot.sessionId,
+          nativePlaybackSupported: true,
+          fallbackReason: null,
+          laneCount: lanes.length,
+        };
+      }
+      if (command === "audio_play") {
+        const payload = args?.payload ?? {};
+        const requestedStart = payload.startTimeSeconds;
+        const startTimeSeconds =
+          typeof requestedStart === "number" && Number.isFinite(requestedStart) && requestedStart > 0
+            ? requestedStart
+            : 10.2;
+        const snapshot = updatePlaybackSnapshot({
+          state: "playing",
+          positionSeconds: startTimeSeconds,
+          nativePlaybackSupported: true,
+          fallbackReason: null,
+        });
+        startPlaybackPosition();
+        return snapshot;
+      }
+      if (command === "audio_pause") {
+        stopPlaybackPosition();
+        return updatePlaybackSnapshot({ state: "paused" });
+      }
+      if (command === "audio_stop") {
+        stopPlaybackPosition();
+        return updatePlaybackSnapshot({ state: "stopped", positionSeconds: 0 });
+      }
+      if (command === "audio_seek") {
+        const nextPosition = Number(args?.payload?.timeSeconds ?? 0);
+        const snapshot = updatePlaybackSnapshot({
+          positionSeconds: Number.isFinite(nextPosition) ? Math.max(0, nextPosition) : 0,
+        });
+        if (playbackSnapshot.state === "playing") {
+          emitPlaybackPosition();
+        }
+        return snapshot;
+      }
+      if (command === "audio_set_lanes") {
+        const payload = args?.payload ?? {};
+        return updatePlaybackSnapshot({
+          playbackRate: payload.playbackRate ?? playbackSnapshot.playbackRate,
+          lanes: playbackLanesFromRequests(payload.lanes ?? []),
+        });
+      }
+      if (command === "audio_set_click" || command === "audio_get_snapshot") {
+        return updatePlaybackSnapshot();
+      }
+      if (command === "audio_get_input_state") {
+        return {
+          active: Boolean(tunerFrameTimer),
+          deviceId: tunerFrameTimer ? "release-media-default-input" : null,
+          inputLevel: tunerFrameTimer ? 0.28 : 0,
+          monitorEnabled: false,
+          monitorGain: 0,
+          sampleRate: tunerFrameTimer ? 48_000 : null,
+        };
+      }
+      if (command === "audio_start_input") {
+        startTunerFrames();
+        return {
+          active: true,
+          deviceId: "release-media-default-input",
+          inputLevel: 0.28,
+          monitorEnabled: false,
+          monitorGain: 0,
+          sampleRate: 48_000,
+        };
+      }
+      if (command === "audio_stop_input") {
+        stopTunerFrames();
+        return {
+          active: false,
+          deviceId: null,
+          inputLevel: 0,
+          monitorEnabled: false,
+          monitorGain: 0,
+          sampleRate: null,
+        };
+      }
+      if (command === "audio_set_monitor") {
+        return {
+          active: Boolean(tunerFrameTimer),
+          deviceId: tunerFrameTimer ? "release-media-default-input" : null,
+          inputLevel: tunerFrameTimer ? 0.28 : 0,
+          monitorEnabled: Boolean(args?.payload?.enabled),
+          monitorGain: Number(args?.payload?.gain ?? 0),
+          sampleRate: tunerFrameTimer ? 48_000 : null,
+        };
+      }
+      if (command === "get_system_default_input_volume" || command === "set_system_default_input_volume") {
+        return {
+          supported: false,
+          volumePercent: null,
+          muted: null,
+          backend: null,
+          error: "System input volume unavailable in simulated release media capture.",
+        };
+      }
+      if (command === "sync_transport_status" || command === "sync_transport_start_listener") {
+        return releaseMediaSyncStatus();
+      }
+      if (command === "sync_transport_stop_listener") {
+        return { ...releaseMediaSyncStatus(), active: false, status: "stopped" };
+      }
+      if (command === "sync_transport_sync_now") {
+        return {
+          ...releaseMediaSyncStatus(),
+          active: false,
+          status: "completed",
+          last_sync: {
+            ...releaseMediaSyncStatus().last_sync,
+            run_id: "sync_demo_manual",
+            peer_device_id: args?.payload?.peerDeviceId ?? "release_media_device_peer",
+          },
+        };
+      }
+      if (command === "sync_transport_record_lifecycle_event") {
+        return releaseMediaSyncStatus();
+      }
+      if (command === "plugin:event|listen") {
+        const event = args?.event;
+        const handlerId = args?.handler;
+        if (typeof event === "string" && typeof handlerId === "number") {
+          const listenerIds = eventListeners.get(event) ?? [];
+          listenerIds.push(handlerId);
+          eventListeners.set(event, listenerIds);
+          return handlerId;
+        }
+        return callbackId++;
+      }
+      if (command === "plugin:event|unlisten") {
+        const event = args?.event;
+        const eventId = args?.eventId ?? args?.id;
+        if (typeof event === "string" && typeof eventId === "number") {
+          eventListeners.set(
+            event,
+            (eventListeners.get(event) ?? []).filter((listenerId) => listenerId !== eventId),
+          );
+        }
+        return null;
+      }
+      throw new Error(`Release media mock does not implement native command ${command}.`);
+    }
+
+    Date.now = () => fixedNow;
+    window.matchMedia = window.matchMedia || ((query) => ({
+      addEventListener: () => undefined,
+      addListener: () => undefined,
+      dispatchEvent: () => false,
+      matches: query.includes("prefers-reduced-motion") || (
+        query.includes("prefers-color-scheme: dark") && theme !== "light"
+      ),
+      media: query,
+      onchange: null,
+      removeEventListener: () => undefined,
+      removeListener: () => undefined,
+    }));
+    window.isTauri = true;
+    window.__TAURI_INTERNALS__ = {
+      convertFileSrc: (filePath) => `asset://localhost/${encodeURIComponent(filePath)}`,
+      invoke: invokeReleaseMediaCommand,
+      transformCallback: (callback, once = false) => {
+        const id = callbackId++;
+        callbacks.set(id, { callback, once });
+        return id;
+      },
+      unregisterCallback: (id) => {
+        callbacks.delete(id);
+      },
+    };
+    window.__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+      unregisterListener: (event, eventId) => {
+        if (typeof event === "string" && typeof eventId === "number") {
+          eventListeners.set(
+            event,
+            (eventListeners.get(event) ?? []).filter((listenerId) => listenerId !== eventId),
+          );
+        }
+      },
+    };
+  }, { theme: options.theme });
+}
+
+async function captureScreenshot(page, appUrl, item, options) {
+  await page.goto(`${appUrl}/#${item.route}`, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: options.timeoutMs });
+  await waitForRouteContent(page, item, options.timeoutMs);
+  if (item.simulated) {
+    await addDemoLabel(page, "Simulated tuner demo - no real microphone input");
+  } else {
+    await clearDemoLabel(page);
+  }
+  await page.screenshot({
+    animations: "disabled",
+    fullPage: false,
+    path: join(options.outputDir, item.fileName),
+  });
+  if (options.recordVideo && options.videoHoldMs > 0) {
+    await sleep(options.videoHoldMs);
+  }
+}
+
+async function waitForRouteContent(page, item, timeoutMs) {
+  if (item.id === "library") {
+    await page.getByRole("heading", { name: "Practice Projects" }).waitFor({ timeout: timeoutMs });
+    await page.getByText(/3 projects ready/i).waitFor({ timeout: timeoutMs });
+    await page.getByRole("link", { name: /Open Midnight Count-In project/i }).waitFor({ timeout: timeoutMs });
+  } else if (item.id === "playback") {
+    await page.getByRole("heading", { name: "Midnight Count-In" }).waitFor({ timeout: timeoutMs });
+    await page.getByRole("tab", { name: "Playback" }).waitFor({ timeout: timeoutMs });
+    await page.getByRole("heading", { name: "Lyrics + chords" }).waitFor({ timeout: timeoutMs });
+    await page.locator(".lead-sheet").waitFor({ timeout: timeoutMs });
+    await page.locator(".lead-sheet-word .lyrics-word", { hasText: /^Count$/ }).waitFor({ timeout: timeoutMs });
+    const playButton = page.getByRole("button", { name: "Play playback" });
+    if (await playButton.count()) {
+      await playButton.click();
+    }
+    await page.getByRole("button", { name: "Pause playback" }).waitFor({ timeout: timeoutMs });
+  } else if (item.id === "tuner-simulated") {
+    await page.getByRole("heading", { name: "Tools" }).waitFor({ timeout: timeoutMs });
+    await page.getByRole("tab", { name: "Chromatic Tuner" }).waitFor({ timeout: timeoutMs });
+    const startButton = page.getByRole("button", { name: "Start" });
+    if (await startButton.count()) {
+      await startButton.click();
+    }
+    await page.locator(".tuner-readout__note", { hasText: /^A$/ }).waitFor({ timeout: timeoutMs });
+    await page.getByText(/442\.00 Hz -> target 440\.00 Hz/i).waitFor({ timeout: timeoutMs });
+  } else if (item.id === "chord-dictionary") {
+    await page.getByRole("heading", { name: "Tools" }).waitFor({ timeout: timeoutMs });
+    await page.getByRole("heading", { name: "Chord Dictionary" }).waitFor({ timeout: timeoutMs });
+    await page.getByRole("tab", { name: "Chord Dictionary" }).waitFor({ timeout: timeoutMs });
+  } else if (item.id === "jobs") {
+    await page.getByRole("heading", { name: "Activity" }).waitFor({ timeout: timeoutMs });
+    await page.getByRole("tab", { name: "Jobs" }).waitFor({ timeout: timeoutMs });
+    await page.getByRole("heading", { name: "Jobs" }).waitFor({ timeout: timeoutMs });
+    await page.getByText(/Transcript ready/i).waitFor({ timeout: timeoutMs });
+  } else if (item.id === "settings") {
+    await page.getByRole("heading", { name: "Control Room" }).waitFor({ timeout: timeoutMs });
+  }
+}
+
+function requiredScreenshotIds() {
+  return capturePlan.filter((item) => item.kind === "screenshot").map((item) => item.id);
+}
+
+async function clearDemoLabel(page) {
+  await page.evaluate(() => {
+    document.querySelectorAll("[data-release-media-label]").forEach((node) => node.remove());
+  });
+}
+
+async function addDemoLabel(page, label) {
+  await page.evaluate((text) => {
+    document.querySelectorAll("[data-release-media-label]").forEach((node) => node.remove());
+    const badge = document.createElement("div");
+    badge.textContent = text;
+    badge.setAttribute("data-release-media-label", "true");
+    Object.assign(badge.style, {
+      background: "#176b4d",
+      border: "1px solid rgba(255, 255, 255, 0.55)",
+      borderRadius: "8px",
+      boxShadow: "0 10px 30px rgba(0, 0, 0, 0.24)",
+      color: "#fff",
+      font: "700 14px system-ui, sans-serif",
+      left: "24px",
+      padding: "10px 12px",
+      position: "fixed",
+      top: "24px",
+      zIndex: "9999",
+    });
+    document.body.append(badge);
+  }, label);
+}
+
+async function saveOverviewVideo(video, outputDir) {
+  const videoPath = await video.path();
+  const outputPath = join(outputDir, "overview.webm");
+  await rename(videoPath, outputPath);
+  return {
+    id: "overview-video",
+    title: "Release media capture overview",
+    kind: "video",
+    src: "media/generated/overview.webm",
+    caption: "Browser-recorded walkthrough of deterministic demo screens.",
+    label: "video",
+    simulated: true,
+  };
+}
+
+function mediaItemForPlanItem(item) {
+  return {
+    id: item.id,
+    title: item.title,
+    kind: item.kind,
+    src: `media/generated/${item.fileName}`,
+    alt: item.title,
+    caption: item.simulated
+      ? "Captured from current UI with deterministic demo state. Not real microphone input."
+      : "Captured from current UI with deterministic synthetic project data.",
+    label: item.simulated ? "simulated demo" : "screenshot",
+    simulated: Boolean(item.simulated),
+  };
+}
+
+async function writeManifest(outputDir, { status, items, notes }) {
+  await mkdir(outputDir, { recursive: true });
+  const manifest = {
+    schemaVersion: 1,
+    status,
+    generatedAt: generatedAt(),
+    source: "scripts/capture-release-media.mjs",
+    fixtureTimestamp,
+    items,
+    notes,
+  };
+  await writeFile(join(outputDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+}
+
+function generatedAt() {
+  const sourceDateEpoch = process.env.SOURCE_DATE_EPOCH;
+  if (sourceDateEpoch) {
+    const seconds = Number(sourceDateEpoch);
+    if (Number.isFinite(seconds) && seconds >= 0) {
+      return new Date(seconds * 1000).toISOString();
+    }
+  }
+  return fixtureTimestamp;
+}
+
+async function maybeFulfillMockApi(route) {
+  const request = route.request();
+  const url = new URL(request.url());
+  if (!url.pathname.startsWith("/api/v1/")) {
+    return false;
+  }
+
+  const payload = mockApiResponse(request.method(), url);
+  if (!payload) {
+    await route.fulfill({
+      contentType: "application/json",
+      status: 404,
+      body: JSON.stringify({ error: { code: "NOT_FOUND", message: "Mock endpoint not found." } }),
+    });
+    return true;
+  }
+  await route.fulfill({
+    contentType: "application/json",
+    status: payload.status ?? 200,
+    body: JSON.stringify(payload.body),
+  });
+  return true;
+}
+
+function mockApiResponse(method, url) {
+  const path = url.pathname;
+  if (method !== "GET" && method !== "POST" && method !== "PATCH") {
+    return null;
+  }
+  if (path === "/api/v1/health") {
+    return { body: healthResponse() };
+  }
+  if (method === "GET" && path === "/api/v1/projects") {
+    return { body: projectsResponse(url.searchParams) };
+  }
+  if (method === "GET" && path === "/api/v1/beat-backends") {
+    return { body: { backends: beatBackends() } };
+  }
+  if (method === "GET" && path === "/api/v1/chord-backends") {
+    return { body: { backends: chordBackends() } };
+  }
+  if (method === "GET" && path === "/api/v1/stem-models") {
+    return { body: { models: stemModels() } };
+  }
+  if (method === "GET" && path === "/api/v1/jobs") {
+    return { body: jobsResponse(url.searchParams) };
+  }
+  if (method === "GET" && path === "/api/v1/sync/preflight") {
+    return { body: syncPreflight() };
+  }
+  if (method === "GET" && path === "/api/v1/sync/identity") {
+    return { body: syncIdentity() };
+  }
+  if (method === "GET" && path === "/api/v1/sync/trusted-peers") {
+    return { body: { trusted_peers: syncPeers() } };
+  }
+
+  const projectMatch = /^\/api\/v1\/projects\/([^/]+)(?:\/(.+))?$/.exec(path);
+  if (!projectMatch) {
+    return null;
+  }
+  const projectId = decodeURIComponent(projectMatch[1]);
+  const child = projectMatch[2] ?? "";
+  const project = projects().find((item) => item.id === projectId);
+  if (!project) {
+    return { status: 404, body: { error: { code: "PROJECT_NOT_FOUND", message: "Project not found." } } };
+  }
+  if (!child) {
+    return { body: { project } };
+  }
+  if (child === "analysis") {
+    return { body: { analysis: analysis(projectId) } };
+  }
+  if (child === "chords") {
+    return { body: chords(projectId) };
+  }
+  if (child === "lyrics") {
+    return { body: lyrics(projectId) };
+  }
+  if (child === "artifacts") {
+    return { body: { artifacts: artifacts(projectId) } };
+  }
+  if (child === "sections") {
+    return { body: { sections: sections(projectId) } };
+  }
+  return null;
+}
+
+function healthResponse() {
+  return {
+    name: "Tuneforge",
+    version: "release-media-demo",
+    backend_version: {
+      package_version: "0.1.0",
+      git_ref: "release-media-demo",
+    },
+    frontend_version: {
+      package_version: "0.1.0",
+      git_ref: "release-media-demo",
+    },
+    status: "ok",
+    api_base_url: "http://127.0.0.1:8765/api/v1",
+    data_root: "/tmp/tuneforge-release-media",
+    default_export_format: "wav",
+    preview_format: "wav",
+  };
+}
+
+function projectsResponse(searchParams) {
+  const search = searchParams.get("search")?.trim().toLowerCase() ?? "";
+  const limit = Number(searchParams.get("limit") ?? 50);
+  const offset = Number(searchParams.get("offset") ?? 0);
+  const filtered = search
+    ? projects().filter((project) =>
+        `${project.display_name} ${project.source_path}`.toLowerCase().includes(search),
+      )
+    : projects();
+  const page = filtered.slice(offset, offset + limit);
+  return {
+    projects: page,
+    total: filtered.length,
+    limit,
+    offset,
+    has_more: offset + page.length < filtered.length,
+  };
+}
+
+function projects() {
+  return [
+    project("proj_release_demo", "Midnight Count-In", "/release-media/midnight-count-in.wav", 182),
+    project("proj_release_sync", "Sync Rehearsal Draft", "/release-media/sync-rehearsal.wav", 214, {
+      sync_state: "local",
+    }),
+    project("proj_release_tuner", "Tuner Reference Tone", "/release-media/a440-reference.wav", 46),
+  ];
+}
+
+function project(id, displayName, sourcePath, durationSeconds, extra = {}) {
+  return {
+    id,
+    display_name: displayName,
+    source_path: sourcePath,
+    imported_path: `/tmp/tuneforge-release-media/${basename(sourcePath)}`,
+    duration_seconds: durationSeconds,
+    sample_rate: 48_000,
+    channels: 2,
+    created_at: fixtureTimestamp,
+    updated_at: fixtureTimestamp,
+    ...extra,
+  };
+}
+
+function analysis(projectId) {
+  return {
+    project_id: projectId,
+    estimated_key: "G major",
+    key_confidence: 0.86,
+    estimated_reference_hz: 439.8,
+    tuning_offset_cents: -8,
+    tempo_bpm: 116,
+    analysis_version: "release-media-demo",
+    created_at: fixtureTimestamp,
+  };
+}
+
+function chords(projectId) {
+  const timeline = [
+    { start_seconds: 0, end_seconds: 16, label: "G", confidence: 0.84, pitch_class: 7, quality: "major" },
+    { start_seconds: 16, end_seconds: 32, label: "D", confidence: 0.81, pitch_class: 2, quality: "major" },
+    { start_seconds: 32, end_seconds: 48, label: "Em", confidence: 0.78, pitch_class: 4, quality: "minor" },
+    { start_seconds: 48, end_seconds: 64, label: "C", confidence: 0.8, pitch_class: 0, quality: "major" },
+    { start_seconds: 64, end_seconds: 80, label: "G", confidence: 0.83, pitch_class: 7, quality: "major" },
+  ];
+  return {
+    project_id: projectId,
+    backend: "tuneforge-fast",
+    source_artifact_id: "art_source",
+    source_segments: timeline,
+    has_user_edits: false,
+    created_at: fixtureTimestamp,
+    updated_at: fixtureTimestamp,
+    timeline,
+  };
+}
+
+function lyrics(projectId) {
+  const segments = [
+    {
+      start_seconds: 0,
+      end_seconds: 7.5,
+      text: "Count the bar and breathe in time",
+      words: [
+        { text: "Count", start_seconds: 0, end_seconds: 1.1, confidence: 0.92 },
+        { text: "the", start_seconds: 1.1, end_seconds: 1.5, confidence: 0.91 },
+        { text: "bar", start_seconds: 1.5, end_seconds: 2.3, confidence: 0.9 },
+        { text: "and", start_seconds: 2.3, end_seconds: 2.9, confidence: 0.88 },
+        { text: "breathe", start_seconds: 2.9, end_seconds: 4.2, confidence: 0.89 },
+        { text: "in", start_seconds: 4.2, end_seconds: 4.8, confidence: 0.9 },
+        { text: "time", start_seconds: 4.8, end_seconds: 6.3, confidence: 0.91 },
+      ],
+    },
+    {
+      start_seconds: 8,
+      end_seconds: 15.5,
+      text: "Bring the chorus down to practice speed",
+      words: [],
+    },
+  ];
+  return {
+    project_id: projectId,
+    backend: "openai-whisper",
+    source_artifact_id: "art_source",
+    source_kind: "ai",
+    language: "en",
+    language_override: null,
+    source_segments: segments,
+    segments,
+    has_user_edits: false,
+    created_at: fixtureTimestamp,
+    updated_at: fixtureTimestamp,
+  };
+}
+
+function artifacts(projectId) {
+  return [
+    {
+      id: "art_preview",
+      project_id: projectId,
+      type: "preview_mix",
+      format: "wav",
+      path: "/tmp/tuneforge-release-media/midnight-count-in-preview.wav",
+      metadata: {
+        retune: { reference_hz: 440 },
+        transpose: { semitones: 2 },
+      },
+      created_at: fixtureTimestamp,
+    },
+    {
+      id: "art_stems",
+      project_id: projectId,
+      type: "stems",
+      format: "wav",
+      path: "/tmp/tuneforge-release-media/stems",
+      metadata: {
+        model: "htdemucs_6s",
+        sources: ["vocals", "drums", "bass", "guitar", "piano", "other"],
+      },
+      created_at: fixtureTimestamp,
+    },
+    {
+      id: "art_source",
+      project_id: projectId,
+      type: "source_audio",
+      format: "wav",
+      path: "/tmp/tuneforge-release-media/midnight-count-in.wav",
+      metadata: {},
+      created_at: fixtureTimestamp,
+    },
+  ];
+}
+
+function sections(projectId) {
+  return [
+    { id: "intro", project_id: projectId, label: "Intro", start_seconds: 0, end_seconds: 16 },
+    { id: "verse", project_id: projectId, label: "Verse", start_seconds: 16, end_seconds: 48 },
+    { id: "chorus", project_id: projectId, label: "Chorus", start_seconds: 48, end_seconds: 80 },
+  ];
+}
+
+function jobsResponse(searchParams) {
+  const statusFilters = searchParams.getAll("status");
+  const projectId = searchParams.get("project_id");
+  const limit = Number(searchParams.get("limit") ?? 50);
+  const offset = Number(searchParams.get("offset") ?? 0);
+  const filtered = jobs().filter((job) => {
+    const statusMatches = !statusFilters.length || statusFilters.includes(job.status);
+    const projectMatches = !projectId || job.project_id === projectId;
+    return statusMatches && projectMatches;
+  });
+  const page = filtered.slice(offset, offset + limit);
+  return {
+    jobs: page,
+    total: filtered.length,
+    limit,
+    offset,
+    has_more: offset + page.length < filtered.length,
+  };
+}
+
+function jobs() {
+  return [
+    {
+      id: "job_release_stems",
+      project_id: "proj_release_demo",
+      type: "stems",
+      status: "completed",
+      progress: 100,
+      error_message: null,
+      created_at: fixtureTimestamp,
+      started_at: fixtureTimestamp,
+      updated_at: fixtureTimestamp,
+      completed_at: fixtureTimestamp,
+      stem_model: "htdemucs_6s",
+      stem_model_label: "Default (6 stems model)",
+      stage: "complete",
+      stage_label: "Stems ready",
+    },
+    {
+      id: "job_release_lyrics",
+      project_id: "proj_release_demo",
+      type: "lyrics",
+      status: "completed",
+      progress: 100,
+      error_message: null,
+      created_at: fixtureTimestamp,
+      started_at: fixtureTimestamp,
+      updated_at: fixtureTimestamp,
+      completed_at: fixtureTimestamp,
+      stage: "complete",
+      stage_label: "Transcript ready",
+    },
+    {
+      id: "job_release_chords",
+      project_id: "proj_release_demo",
+      type: "chords",
+      status: "completed",
+      progress: 100,
+      error_message: null,
+      created_at: fixtureTimestamp,
+      started_at: fixtureTimestamp,
+      updated_at: fixtureTimestamp,
+      completed_at: fixtureTimestamp,
+      chord_backend: "tuneforge-fast",
+      chord_source: "source",
+    },
+  ];
+}
+
+function beatBackends() {
+  return [
+    {
+      availability: "available",
+      available: true,
+      description: "Tuneforge built-in beat detector.",
+      desktopOnly: false,
+      experimental: false,
+      id: "built-in",
+      label: "Built-in Beat Analysis",
+      runtime_device: "cpu",
+      unavailable_reason: null,
+    },
+    {
+      availability: "available",
+      available: true,
+      description: "Advanced local beat detector.",
+      desktopOnly: true,
+      experimental: true,
+      id: "beat-this",
+      label: "Advanced Beat Analysis",
+      runtime_device: "cpu",
+      unavailable_reason: null,
+    },
+  ];
+}
+
+function chordBackends() {
+  return [
+    {
+      availability: "available",
+      available: true,
+      capabilities: {
+        desktopOnly: false,
+        estimatedSpeed: "medium",
+        experimental: false,
+        supportsConfidence: true,
+        supportsInversions: false,
+        supportsNoChord: true,
+        supportsSevenths: true,
+      },
+      description: "Tuneforge built-in chord detector.",
+      desktopOnly: false,
+      experimental: false,
+      id: "tuneforge-fast",
+      label: "Built-in Chords",
+      unavailable_reason: null,
+    },
+  ];
+}
+
+function stemModels() {
+  return [
+    {
+      availability: "available",
+      available: true,
+      default: true,
+      description: "Demucs six-source model.",
+      id: "htdemucs_6s",
+      label: "Default (6 stems model)",
+      sourceCount: 6,
+      sources: ["vocals", "drums", "bass", "guitar", "piano", "other"],
+      unavailable_reason: null,
+    },
+    {
+      availability: "available",
+      available: true,
+      default: false,
+      description: "Demucs two-source model.",
+      id: "htdemucs_ft",
+      label: "2 stems model",
+      sourceCount: 2,
+      sources: ["vocals", "instrumental"],
+      unavailable_reason: null,
+    },
+  ];
+}
+
+function syncPreflight() {
+  return {
+    ok: true,
+    library_ok: true,
+    total_projects: 3,
+    ready_projects: 3,
+    missing_source_hash_projects: 0,
+    invalid_source_hash_projects: 0,
+    duplicate_source_hash_projects: 0,
+    noncanonical_project_id_projects: 0,
+    projects: [],
+    duplicate_groups: [],
+    data_root: "/tmp/tuneforge-release-media",
+    sync_group_id: "release-media-demo",
+    checks: [],
+    blocking_reasons: [],
+    job_state: {
+      state: "ready",
+      running_job_count: 0,
+      pending_job_count: 0,
+      blocking_job_count: 0,
+      blocking_job_counts: {},
+      blocking_jobs: [],
+      blocking_jobs_truncated: false,
+      guidance: ["Synthetic release-media sync state. No LAN transfer is running."],
+    },
+    manual_cleanup_required: false,
+    manual_cleanup_guidance: [],
+  };
+}
+
+function syncIdentity() {
+  return {
+    device_id: "release_media_device_local",
+    sync_group_id: "release-media-demo",
+    display_name: "Demo Studio Mac",
+    public_key: "release-media-public-key",
+    created_at: fixtureTimestamp,
+    updated_at: fixtureTimestamp,
+  };
+}
+
+function syncPeers() {
+  return [
+    {
+      device_id: "release_media_device_peer",
+      display_name: "Demo Rehearsal Laptop",
+      public_key: "release-media-peer-public-key",
+      endpoint_hints: ["tuneforge-sync+tcp://127.0.0.1:48625"],
+      trusted_at: fixtureTimestamp,
+      revoked_at: null,
+      created_at: fixtureTimestamp,
+      updated_at: fixtureTimestamp,
+    },
+  ];
+}
+
+function sleep(ms) {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}
+
+function errorMessage(error) {
+  return error instanceof Error && error.message ? error.message : String(error);
+}

--- a/scripts/check-release-version.mjs
+++ b/scripts/check-release-version.mjs
@@ -1,0 +1,111 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const workspaceRoot = path.resolve(path.dirname(__filename), "..");
+
+function readText(relativePath) {
+  return readFileSync(path.join(workspaceRoot, relativePath), "utf8");
+}
+
+function readJsonVersion(relativePath) {
+  const parsed = JSON.parse(readText(relativePath));
+  if (typeof parsed.version !== "string" || parsed.version.trim() === "") {
+    throw new Error(`${relativePath} does not define a string "version" field.`);
+  }
+  return parsed.version;
+}
+
+function readTomlSectionVersion(relativePath, sectionName) {
+  const lines = readText(relativePath).split(/\r?\n/);
+  let inSection = false;
+
+  for (const line of lines) {
+    const sectionMatch = line.match(/^\s*\[([^\]]+)\]\s*$/);
+    if (sectionMatch) {
+      inSection = sectionMatch[1] === sectionName;
+      continue;
+    }
+    if (!inSection) {
+      continue;
+    }
+
+    const versionMatch = line.match(/^\s*version\s*=\s*"([^"]+)"\s*$/);
+    if (versionMatch) {
+      return versionMatch[1];
+    }
+  }
+
+  throw new Error(`${relativePath} does not define "${sectionName}.version".`);
+}
+
+function readMetainfoReleaseVersion(relativePath) {
+  const contents = readText(relativePath);
+  const releaseMatch = contents.match(/<release\b[^>]*\bversion="([^"]+)"[^>]*>/);
+  if (!releaseMatch) {
+    throw new Error(`${relativePath} does not define a release version.`);
+  }
+  return releaseMatch[1];
+}
+
+const versionSources = [
+  {
+    label: "backend package",
+    path: "apps/backend/pyproject.toml",
+    version: () => readTomlSectionVersion("apps/backend/pyproject.toml", "project"),
+  },
+  {
+    label: "desktop package",
+    path: "apps/desktop/package.json",
+    version: () => readJsonVersion("apps/desktop/package.json"),
+  },
+  {
+    label: "tauri config",
+    path: "apps/desktop/src-tauri/tauri.conf.json",
+    version: () => readJsonVersion("apps/desktop/src-tauri/tauri.conf.json"),
+  },
+  {
+    label: "tauri cargo package",
+    path: "apps/desktop/src-tauri/Cargo.toml",
+    version: () => readTomlSectionVersion("apps/desktop/src-tauri/Cargo.toml", "package"),
+  },
+  {
+    label: "shared types package",
+    path: "packages/shared-types/package.json",
+    version: () => readJsonVersion("packages/shared-types/package.json"),
+  },
+  {
+    label: "Flatpak metainfo latest release",
+    path: "packaging/flatpak/com.tuneforge.desktop.metainfo.xml",
+    version: () => readMetainfoReleaseVersion("packaging/flatpak/com.tuneforge.desktop.metainfo.xml"),
+  },
+];
+
+function main() {
+  const versions = versionSources.map((source) => ({
+    label: source.label,
+    path: source.path,
+    version: source.version(),
+  }));
+  const expectedVersion = versions[0].version;
+  const mismatches = versions.filter((source) => source.version !== expectedVersion);
+
+  if (mismatches.length > 0) {
+    process.stderr.write("Release versions do not match:\n");
+    for (const source of versions) {
+      process.stderr.write(`  ${source.version.padEnd(12)} ${source.path} (${source.label})\n`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  process.stdout.write(`Release version check passed: ${expectedVersion}\n`);
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+}

--- a/scripts/package-options.test.mjs
+++ b/scripts/package-options.test.mjs
@@ -55,6 +55,15 @@ test("package option parser includes advanced dependencies by default", () => {
   ]);
 });
 
+test("release default package options do not bundle model weights", () => {
+  for (const platform of ["mac", "linux"]) {
+    const options = parsePackageOptions([], { platform });
+
+    assert.equal(options.modelBundle, false);
+    assert.equal(packageOptionsToGeneratorArgs(options).includes("--model-bundle"), false);
+  }
+});
+
 test("package option parser accepts advanced dependency opt-outs", () => {
   const options = parsePackageOptions(["--no-crema", "--no-beat-this"], { platform: "linux" });
 


### PR DESCRIPTION
## Summary

- Add release-readiness docs, CI/script gates, and release version consistency checks.
- Add GitHub Pages site package plus Pages workflow and deterministic media capture.
- Clarify packaging truth: unsigned local artifacts, no default model-weight bundle, FFmpeg handling.

## Testing

- `node --check scripts/capture-release-media.mjs`
- `node scripts/capture-release-media.mjs --dry-run --theme=light --no-video`
- `node scripts/check-release-version.mjs`
- `CI=true /opt/homebrew/bin/pnpm install --frozen-lockfile --ignore-scripts`
- `/opt/homebrew/bin/pnpm --filter @tuneforge/site typecheck`
- `/opt/homebrew/bin/pnpm --filter @tuneforge/site build`
- `/opt/homebrew/bin/pnpm lint`
- `/opt/homebrew/bin/pnpm typecheck`
- `/opt/homebrew/bin/pnpm test`
- `uv run --python 3.11 pytest`
- `cargo check`
- `node --test scripts/package-options.test.mjs scripts/flatpak-options.test.mjs scripts/playback-smoke.test.mjs scripts/sync-validation.test.mjs`
- `bash scripts/setup-dev.test.sh`

Notes:
- Local media capture was also run with `node scripts/capture-release-media.mjs --run --timeout-ms=60000`; generated screenshots/video are ignored and not committed.
