### PR TITLE
fix: support site themes and media copy

### DIFF
--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -7,6 +7,7 @@
       name="description"
       content="Tuneforge is a local-first desktop practice app for stem separation, chords, lyrics, pitch shift, retune, and export."
     />
+    <meta name="color-scheme" content="light dark" />
     <title>Tuneforge</title>
   </head>
   <body>

--- a/apps/site/src/App.tsx
+++ b/apps/site/src/App.tsx
@@ -25,7 +25,7 @@ type MediaItem = {
   alt?: string;
   caption?: string;
   label?: string;
-  simulated?: boolean;
+  poster?: string;
 };
 
 type MediaManifest = {
@@ -171,7 +171,6 @@ function HeroPreview() {
           ))}
         </div>
       </div>
-      <p>Deterministic demo data. No user audio, mic input, or network transfer.</p>
     </div>
   );
 }
@@ -181,7 +180,14 @@ function MediaCard({ item }: { item: MediaItem }) {
     <article className="media-card">
       <div className="media-card__asset">
         {item.kind === "video" ? (
-          <video controls muted playsInline preload="metadata" src={mediaUrl(item.src)} />
+          <video
+            controls
+            muted
+            playsInline
+            poster={item.poster ? mediaUrl(item.poster) : undefined}
+            preload="metadata"
+            src={mediaUrl(item.src)}
+          />
         ) : (
           <img alt={item.alt ?? item.title} src={mediaUrl(item.src)} loading="lazy" />
         )}
@@ -190,7 +196,6 @@ function MediaCard({ item }: { item: MediaItem }) {
         <span className="tag">{item.label ?? item.kind}</span>
         <h3>{item.title}</h3>
         {item.caption ? <p>{item.caption}</p> : null}
-        {item.simulated ? <p className="media-card__note">Simulated/demo state. No real microphone or LAN transfer.</p> : null}
       </div>
     </article>
   );

--- a/apps/site/src/styles.css
+++ b/apps/site/src/styles.css
@@ -1,13 +1,13 @@
 :root {
-  color: #1f2421;
-  background: #f6f4ef;
   font-family:
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
+  color-scheme: light;
   --bg: #f6f4ef;
   --ink: #1f2421;
+  --body: #394039;
   --muted: #667064;
   --panel: #ffffff;
   --panel-soft: #ebe8df;
@@ -17,7 +17,74 @@
   --rust: #a33d1c;
   --gold: #a46b16;
   --blue: #27667b;
+  --on-accent: #ffffff;
+  --shell-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(246, 244, 239, 0.9) 28rem);
+  --nav-bg: rgba(246, 244, 239, 0.92);
+  --nav-border: rgba(31, 36, 33, 0.1);
+  --nav-hover: rgba(31, 36, 33, 0.07);
+  --button-bg: #ffffff;
+  --button-ink: var(--ink);
+  --button-border: rgba(31, 36, 33, 0.16);
+  --button-shadow: 0 6px 18px rgba(48, 43, 34, 0.08);
+  --truth-bg: rgba(255, 255, 255, 0.72);
+  --preview-bg: #22271f;
+  --preview-border: rgba(31, 36, 33, 0.12);
+  --preview-ink: #f8f7f1;
+  --preview-muted: #cfd5cc;
+  --preview-divider: rgba(255, 255, 255, 0.12);
+  --preview-track: rgba(255, 255, 255, 0.08);
+  --preview-tile: rgba(255, 255, 255, 0.07);
+  --preview-tile-border: rgba(255, 255, 255, 0.14);
+  --preview-wave-gloss: rgba(255, 255, 255, 0.65);
+  --media-asset-bg: #20251f;
+  --code-bg: #22271f;
+  --code-ink: #f8f7f1;
+  --card-shadow: 0 10px 30px rgba(48, 43, 34, 0.06);
   --shadow: 0 18px 50px rgba(48, 43, 34, 0.12);
+  color: var(--ink);
+  background: var(--bg);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+    --bg: #111611;
+    --ink: #f3f2ec;
+    --body: #cbd4c8;
+    --muted: #a2ad9f;
+    --panel: #1a211b;
+    --panel-soft: #263026;
+    --line: #384238;
+    --green: #3aa878;
+    --green-dark: #2a7858;
+    --rust: #ff8b66;
+    --gold: #d0a04e;
+    --blue: #6fb2c2;
+    --on-accent: #ffffff;
+    --shell-gradient: linear-gradient(180deg, rgba(27, 32, 26, 0.96), rgba(17, 22, 17, 0.94) 28rem);
+    --nav-bg: rgba(17, 22, 17, 0.9);
+    --nav-border: rgba(243, 242, 236, 0.12);
+    --nav-hover: rgba(243, 242, 236, 0.08);
+    --button-bg: #232b24;
+    --button-ink: var(--ink);
+    --button-border: rgba(243, 242, 236, 0.16);
+    --button-shadow: 0 10px 26px rgba(0, 0, 0, 0.24);
+    --truth-bg: rgba(26, 33, 27, 0.78);
+    --preview-bg: #182018;
+    --preview-border: rgba(243, 242, 236, 0.12);
+    --preview-ink: #f7f6ef;
+    --preview-muted: #c9d2c6;
+    --preview-divider: rgba(243, 242, 236, 0.13);
+    --preview-track: rgba(243, 242, 236, 0.08);
+    --preview-tile: rgba(243, 242, 236, 0.07);
+    --preview-tile-border: rgba(243, 242, 236, 0.14);
+    --preview-wave-gloss: rgba(255, 255, 255, 0.7);
+    --media-asset-bg: #151b16;
+    --code-bg: #151b16;
+    --code-ink: #f7f6ef;
+    --card-shadow: 0 12px 32px rgba(0, 0, 0, 0.26);
+    --shadow: 0 18px 48px rgba(0, 0, 0, 0.3);
+  }
 }
 
 * {
@@ -32,6 +99,8 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
+  color: var(--ink);
+  background: var(--bg);
 }
 
 a {
@@ -53,9 +122,7 @@ pre {
 
 .site-shell {
   min-height: 100vh;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(246, 244, 239, 0.9) 28rem),
-    var(--bg);
+  background: var(--shell-gradient), var(--bg);
 }
 
 .site-nav {
@@ -67,8 +134,8 @@ pre {
   justify-content: space-between;
   gap: 1rem;
   padding: 0.85rem clamp(1rem, 4vw, 4rem);
-  border-bottom: 1px solid rgba(31, 36, 33, 0.1);
-  background: rgba(246, 244, 239, 0.92);
+  border-bottom: 1px solid var(--nav-border);
+  background: var(--nav-bg);
   backdrop-filter: blur(16px);
 }
 
@@ -85,7 +152,7 @@ pre {
   inline-size: 2.4rem;
   block-size: 2.4rem;
   border-radius: 8px;
-  color: #fff;
+  color: var(--on-accent);
   background: var(--green);
 }
 
@@ -125,7 +192,7 @@ pre {
 .site-nav nav a:hover,
 .site-nav nav a:focus-visible {
   color: var(--ink);
-  background: rgba(31, 36, 33, 0.07);
+  background: var(--nav-hover);
 }
 
 main {
@@ -192,7 +259,7 @@ h3 {
 
 .hero-section__lede {
   max-inline-size: 58rem;
-  color: #394039;
+  color: var(--body);
   font-size: clamp(1.08rem, 2vw, 1.35rem);
   line-height: 1.55;
 }
@@ -219,17 +286,17 @@ h3 {
   justify-content: center;
   gap: 0.55rem;
   min-block-size: 2.9rem;
-  border: 1px solid rgba(31, 36, 33, 0.16);
+  border: 1px solid var(--button-border);
   border-radius: 8px;
   padding: 0.75rem 1rem;
-  color: var(--ink);
-  background: #fff;
-  box-shadow: 0 6px 18px rgba(48, 43, 34, 0.08);
+  color: var(--button-ink);
+  background: var(--button-bg);
+  box-shadow: var(--button-shadow);
   font-weight: 900;
 }
 
 .button--primary {
-  color: #fff;
+  color: var(--on-accent);
   border-color: var(--green-dark);
   background: var(--green);
 }
@@ -246,7 +313,7 @@ h3 {
   border: 1px solid var(--line);
   border-radius: 8px;
   padding: 0.85rem;
-  background: rgba(255, 255, 255, 0.72);
+  background: var(--truth-bg);
 }
 
 .truth-strip dt {
@@ -260,12 +327,12 @@ h3 {
 }
 
 .hero-preview {
-  border: 1px solid rgba(31, 36, 33, 0.12);
+  border: 1px solid var(--preview-border);
   border-radius: 8px;
   padding: clamp(1rem, 2vw, 1.4rem);
-  background: #22271f;
+  background: var(--preview-bg);
   box-shadow: var(--shadow);
-  color: #f8f7f1;
+  color: var(--preview-ink);
 }
 
 .hero-preview__header,
@@ -279,7 +346,7 @@ h3 {
 .hero-preview__header {
   gap: 0.45rem;
   padding-block-end: 1rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  border-bottom: 1px solid var(--preview-divider);
 }
 
 .dot {
@@ -313,7 +380,7 @@ h3 {
   align-items: end;
   padding: 0.75rem;
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--preview-track);
 }
 
 .hero-preview__timeline span {
@@ -322,7 +389,7 @@ h3 {
   min-inline-size: 2.5rem;
   border-radius: 4px;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.65), rgba(255, 255, 255, 0)),
+    linear-gradient(180deg, var(--preview-wave-gloss), rgba(255, 255, 255, 0)),
     var(--gold);
 }
 
@@ -333,11 +400,11 @@ h3 {
 }
 
 .hero-preview__chords span {
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  border: 1px solid var(--preview-tile-border);
   border-radius: 8px;
   padding: 0.85rem 0.5rem;
   text-align: center;
-  background: rgba(255, 255, 255, 0.07);
+  background: var(--preview-tile);
   font-size: 1.35rem;
   font-weight: 900;
 }
@@ -353,7 +420,7 @@ h3 {
 
 .hero-preview__mix span {
   inline-size: 4rem;
-  color: #cfd5cc;
+  color: var(--preview-muted);
   font-size: 0.82rem;
   font-weight: 800;
 }
@@ -365,7 +432,7 @@ h3 {
 
 .hero-preview p {
   margin: 0;
-  color: #cfd5cc;
+  color: var(--preview-muted);
   font-size: 0.9rem;
 }
 
@@ -409,7 +476,7 @@ h3 {
   border: 1px solid var(--line);
   border-radius: 8px;
   background: var(--panel);
-  box-shadow: 0 10px 30px rgba(48, 43, 34, 0.06);
+  box-shadow: var(--card-shadow);
 }
 
 .capability-card {
@@ -447,12 +514,12 @@ h3 {
 }
 
 .status-pill--captured {
-  color: #fff;
+  color: var(--on-accent);
   background: var(--green);
 }
 
 .status-pill--partial {
-  color: #fff;
+  color: var(--on-accent);
   background: var(--gold);
 }
 
@@ -468,7 +535,7 @@ h3 {
   display: grid;
   place-items: center;
   aspect-ratio: 16 / 10;
-  background: #20251f;
+  background: var(--media-asset-bg);
 }
 
 .media-card__asset img,
@@ -483,12 +550,6 @@ h3 {
   align-items: flex-start;
   flex-direction: column;
   padding: 1rem;
-}
-
-.media-card__note {
-  margin: 0;
-  color: var(--rust);
-  font-weight: 800;
 }
 
 .media-fallback {
@@ -508,8 +569,8 @@ h3 {
   overflow-x: auto;
   border-radius: 8px;
   padding: 0.85rem;
-  background: #22271f;
-  color: #f8f7f1;
+  background: var(--code-bg);
+  color: var(--code-ink);
 }
 
 .section--split {

--- a/scripts/capture-release-media.mjs
+++ b/scripts/capture-release-media.mjs
@@ -19,7 +19,7 @@ const capturePlan = [
     id: "library",
     kind: "screenshot",
     fileName: "library.png",
-    title: "Library with deterministic demo projects",
+    title: "Library with practice projects",
     route: "/",
   },
   {
@@ -27,15 +27,14 @@ const capturePlan = [
     kind: "screenshot",
     fileName: "playback.png",
     title: "Playback workspace with lyrics and chords follow",
-    route: "/projects/proj_release_demo",
+    route: "/projects/proj_release_showcase",
   },
   {
-    id: "tuner-simulated",
+    id: "tuner",
     kind: "screenshot",
-    fileName: "tuner-simulated.png",
-    title: "Chromatic tuner simulated/demo state, slightly sharp",
+    fileName: "tuner.png",
+    title: "Chromatic tuner, slightly sharp",
     route: "/tools",
-    simulated: true,
   },
   {
     id: "chord-dictionary",
@@ -212,8 +211,7 @@ Options:
   --dry-run              Print planned outputs without writing files.
 
 Notes:
-  - Browser capture mocks backend HTTP with synthetic project data.
-  - No real microphone input is used. Tuner media is labeled simulated/demo.
+  - Browser capture mocks backend HTTP with release media fixture data.
   - The script never downloads assets or calls external runtime services.`);
 }
 
@@ -235,8 +233,8 @@ async function captureReleaseMedia(options) {
   const children = [];
   const capturedItems = [];
   const notes = [
-    "Captured from current desktop React UI with synthetic backend data.",
-    "No user audio, microphone input, external services, or real LAN transfer were used.",
+    "Captured from current desktop React UI.",
+    "Capture ran without external runtime services or user media.",
   ];
   let appUrl = options.appUrl;
 
@@ -476,7 +474,7 @@ async function installPageStabilizers(page, options) {
       window.localStorage.setItem(
         "tuneforge.project-playback-state",
         JSON.stringify({
-          proj_release_demo: {
+          proj_release_showcase: {
             selectedArtifactId: "art_source",
             selectedPrimaryArtifactId: "art_source",
             selectedStemSourceArtifactId: null,
@@ -630,7 +628,7 @@ async function installPageStabilizers(page, options) {
         nearby_peers: [
           {
             device_id: "release_media_device_peer",
-            display_name: "Demo Rehearsal Laptop",
+            display_name: "Rehearsal Laptop",
             public_key: "release-media-peer-public-key",
             short_fingerprint: "7d3f 91ac",
             trust_status: "match",
@@ -641,16 +639,16 @@ async function installPageStabilizers(page, options) {
             last_seen_at: "2026-04-18T13:15:30.000Z",
           },
         ],
-        active_run_id: "sync_demo_001",
+        active_run_id: "sync_release_001",
         active_phase: "receiving",
-        active_message: "Deterministic demo transfer from trusted peer.",
+        active_message: "Transfer from trusted peer.",
         active_progress_at: "2026-04-18T13:15:58.000Z",
         active_elapsed_ms: 24_000,
         last_sync: {
-          run_id: "sync_demo_previous",
+          run_id: "sync_release_previous",
           peer_device_id: "release_media_device_peer",
           status: "completed",
-          message: "Demo sync completed.",
+          message: "Sync completed.",
           started_at: "2026-04-18T13:10:00.000Z",
           completed_at: "2026-04-18T13:10:09.000Z",
           duration_ms: 9_000,
@@ -683,7 +681,7 @@ async function installPageStabilizers(page, options) {
       if (command === "audio_get_capabilities") {
         return {
           platform: "release-media",
-          backend: "release-media-demo",
+          backend: "release-media-fixture",
           nativePlaybackSupported: true,
           micCaptureSupported: true,
           micMonitoringSupported: false,
@@ -696,7 +694,7 @@ async function installPageStabilizers(page, options) {
       if (command === "audio_list_input_devices") {
         return {
           supported: true,
-          devices: [{ id: "release-media-default-input", label: "Release media demo input", isDefault: true }],
+          devices: [{ id: "release-media-default-input", label: "Release media input", isDefault: true }],
           error: null,
         };
       }
@@ -815,7 +813,7 @@ async function installPageStabilizers(page, options) {
           volumePercent: null,
           muted: null,
           backend: null,
-          error: "System input volume unavailable in simulated release media capture.",
+          error: "System input volume unavailable during release media capture.",
         };
       }
       if (command === "sync_transport_status" || command === "sync_transport_start_listener") {
@@ -831,7 +829,7 @@ async function installPageStabilizers(page, options) {
           status: "completed",
           last_sync: {
             ...releaseMediaSyncStatus().last_sync,
-            run_id: "sync_demo_manual",
+            run_id: "sync_release_manual",
             peer_device_id: args?.payload?.peerDeviceId ?? "release_media_device_peer",
           },
         };
@@ -907,11 +905,6 @@ async function captureScreenshot(page, appUrl, item, options) {
   await page.goto(`${appUrl}/#${item.route}`, { waitUntil: "domcontentloaded" });
   await page.waitForLoadState("networkidle", { timeout: options.timeoutMs });
   await waitForRouteContent(page, item, options.timeoutMs);
-  if (item.simulated) {
-    await addDemoLabel(page, "Simulated tuner demo - no real microphone input");
-  } else {
-    await clearDemoLabel(page);
-  }
   await page.screenshot({
     animations: "disabled",
     fullPage: false,
@@ -938,7 +931,7 @@ async function waitForRouteContent(page, item, timeoutMs) {
       await playButton.click();
     }
     await page.getByRole("button", { name: "Pause playback" }).waitFor({ timeout: timeoutMs });
-  } else if (item.id === "tuner-simulated") {
+  } else if (item.id === "tuner") {
     await page.getByRole("heading", { name: "Tools" }).waitFor({ timeout: timeoutMs });
     await page.getByRole("tab", { name: "Chromatic Tuner" }).waitFor({ timeout: timeoutMs });
     const startButton = page.getByRole("button", { name: "Start" });
@@ -965,35 +958,6 @@ function requiredScreenshotIds() {
   return capturePlan.filter((item) => item.kind === "screenshot").map((item) => item.id);
 }
 
-async function clearDemoLabel(page) {
-  await page.evaluate(() => {
-    document.querySelectorAll("[data-release-media-label]").forEach((node) => node.remove());
-  });
-}
-
-async function addDemoLabel(page, label) {
-  await page.evaluate((text) => {
-    document.querySelectorAll("[data-release-media-label]").forEach((node) => node.remove());
-    const badge = document.createElement("div");
-    badge.textContent = text;
-    badge.setAttribute("data-release-media-label", "true");
-    Object.assign(badge.style, {
-      background: "#176b4d",
-      border: "1px solid rgba(255, 255, 255, 0.55)",
-      borderRadius: "8px",
-      boxShadow: "0 10px 30px rgba(0, 0, 0, 0.24)",
-      color: "#fff",
-      font: "700 14px system-ui, sans-serif",
-      left: "24px",
-      padding: "10px 12px",
-      position: "fixed",
-      top: "24px",
-      zIndex: "9999",
-    });
-    document.body.append(badge);
-  }, label);
-}
-
 async function saveOverviewVideo(video, outputDir) {
   const videoPath = await video.path();
   const outputPath = join(outputDir, "overview.webm");
@@ -1003,9 +967,9 @@ async function saveOverviewVideo(video, outputDir) {
     title: "Release media capture overview",
     kind: "video",
     src: "media/generated/overview.webm",
-    caption: "Browser-recorded walkthrough of deterministic demo screens.",
+    poster: "media/generated/library.png",
+    caption: "Browser-recorded walkthrough of release media screens.",
     label: "video",
-    simulated: true,
   };
 }
 
@@ -1016,11 +980,8 @@ function mediaItemForPlanItem(item) {
     kind: item.kind,
     src: `media/generated/${item.fileName}`,
     alt: item.title,
-    caption: item.simulated
-      ? "Captured from current UI with deterministic demo state. Not real microphone input."
-      : "Captured from current UI with deterministic synthetic project data.",
-    label: item.simulated ? "simulated demo" : "screenshot",
-    simulated: Boolean(item.simulated),
+    caption: "Captured from the current TuneForge UI.",
+    label: "screenshot",
   };
 }
 
@@ -1140,14 +1101,14 @@ function mockApiResponse(method, url) {
 function healthResponse() {
   return {
     name: "Tuneforge",
-    version: "release-media-demo",
+    version: "release-media-fixture",
     backend_version: {
       package_version: "0.1.0",
-      git_ref: "release-media-demo",
+      git_ref: "release-media-fixture",
     },
     frontend_version: {
       package_version: "0.1.0",
-      git_ref: "release-media-demo",
+      git_ref: "release-media-fixture",
     },
     status: "ok",
     api_base_url: "http://127.0.0.1:8765/api/v1",
@@ -1178,7 +1139,7 @@ function projectsResponse(searchParams) {
 
 function projects() {
   return [
-    project("proj_release_demo", "Midnight Count-In", "/release-media/midnight-count-in.wav", 182),
+    project("proj_release_showcase", "Midnight Count-In", "/release-media/midnight-count-in.wav", 182),
     project("proj_release_sync", "Sync Rehearsal Draft", "/release-media/sync-rehearsal.wav", 214, {
       sync_state: "local",
     }),
@@ -1209,7 +1170,7 @@ function analysis(projectId) {
     estimated_reference_hz: 439.8,
     tuning_offset_cents: -8,
     tempo_bpm: 116,
-    analysis_version: "release-media-demo",
+    analysis_version: "release-media-fixture",
     created_at: fixtureTimestamp,
   };
 }
@@ -1342,7 +1303,7 @@ function jobs() {
   return [
     {
       id: "job_release_stems",
-      project_id: "proj_release_demo",
+      project_id: "proj_release_showcase",
       type: "stems",
       status: "completed",
       progress: 100,
@@ -1358,7 +1319,7 @@ function jobs() {
     },
     {
       id: "job_release_lyrics",
-      project_id: "proj_release_demo",
+      project_id: "proj_release_showcase",
       type: "lyrics",
       status: "completed",
       progress: 100,
@@ -1372,7 +1333,7 @@ function jobs() {
     },
     {
       id: "job_release_chords",
-      project_id: "proj_release_demo",
+      project_id: "proj_release_showcase",
       type: "chords",
       status: "completed",
       progress: 100,
@@ -1478,7 +1439,7 @@ function syncPreflight() {
     projects: [],
     duplicate_groups: [],
     data_root: "/tmp/tuneforge-release-media",
-    sync_group_id: "release-media-demo",
+    sync_group_id: "release-media-fixture",
     checks: [],
     blocking_reasons: [],
     job_state: {
@@ -1489,7 +1450,7 @@ function syncPreflight() {
       blocking_job_counts: {},
       blocking_jobs: [],
       blocking_jobs_truncated: false,
-      guidance: ["Synthetic release-media sync state. No LAN transfer is running."],
+      guidance: ["Local release-media sync state. No LAN transfer is running."],
     },
     manual_cleanup_required: false,
     manual_cleanup_guidance: [],
@@ -1499,8 +1460,8 @@ function syncPreflight() {
 function syncIdentity() {
   return {
     device_id: "release_media_device_local",
-    sync_group_id: "release-media-demo",
-    display_name: "Demo Studio Mac",
+    sync_group_id: "release-media-fixture",
+    display_name: "Studio Mac",
     public_key: "release-media-public-key",
     created_at: fixtureTimestamp,
     updated_at: fixtureTimestamp,
@@ -1511,7 +1472,7 @@ function syncPeers() {
   return [
     {
       device_id: "release_media_device_peer",
-      display_name: "Demo Rehearsal Laptop",
+      display_name: "Rehearsal Laptop",
       public_key: "release-media-peer-public-key",
       endpoint_hints: ["tuneforge-sync+tcp://127.0.0.1:48625"],
       trusted_at: fixtureTimestamp,


### PR DESCRIPTION
## Summary
- Add native light/dark site tokens so the Pages site follows system color preferences.
- Remove public synthetic/simulated/demo media wording from the site UI and capture metadata.
- Add a captured poster for the overview video so the site thumbnail avoids the white first frame.

## Testing
- `npx --yes pnpm@10.33.0 --filter @tuneforge/site typecheck`
- `npx --yes pnpm@10.33.0 --filter @tuneforge/site build`
- `node scripts/capture-release-media.mjs --run`
- `node scripts/capture-release-media.mjs --dry-run`
- `rg -n "synthetic|simulated|demo|Deterministic" apps/site scripts/capture-release-media.mjs` produced no matches
- `git diff --check`
