### PR TITLE
fix: verify warm model caches before preload

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -24,8 +24,8 @@ uv sync --python 3.11 --all-groups --extra advanced-chords --extra advanced-beat
 ```
 
 From the workspace root, `pnpm setup:dev` also runs the full developer setup: `pnpm install`,
-backend sync with default desktop advanced engine dependencies, model prewarm, and shared contract
-generation.
+backend sync with default desktop advanced engine dependencies, model cache/asset verification with
+preload/download only for missing or invalid assets, and shared contract generation.
 
 ### Advanced Chords backend
 
@@ -93,14 +93,14 @@ pnpm setup:dev -- --no-beat-this
 pnpm setup:dev -- --no-advanced-beats
 ```
 
-To preload manually:
+To verify or preload manually:
 
 ```sh
 uv sync --python 3.11 --all-groups --extra advanced-beats
-uv run --python 3.11 python -c "from beat_this.inference import File2Beats; File2Beats(checkpoint_path='small0', device='cpu', dbn=False)"
+uv run --python 3.11 python -m app.cli.prewarm_models --skip-demucs --skip-whisper --include-beat-this
 ```
 
-The preload is stored at `$TORCH_HOME/hub/checkpoints/beat_this-small0.ckpt` when `TORCH_HOME` is set, `$XDG_CACHE_HOME/torch/hub/checkpoints/beat_this-small0.ckpt` when `XDG_CACHE_HOME` is set, or `~/.cache/torch/hub/checkpoints/beat_this-small0.ckpt` by default. Warm setup skips beat-this import/download when that file already matches the expected size and SHA-256.
+The preload is stored at `$TORCH_HOME/hub/checkpoints/beat_this-small0.ckpt` when `TORCH_HOME` is set, `$XDG_CACHE_HOME/torch/hub/checkpoints/beat_this-small0.ckpt` when `XDG_CACHE_HOME` is set, or `~/.cache/torch/hub/checkpoints/beat_this-small0.ckpt` by default. When that file already matches the expected size and SHA-256, setup only verifies it and skips beat-this import/download.
 
 ### Linux legacy NVIDIA profile
 
@@ -190,7 +190,7 @@ Default data directory:
 - macOS: `~/Library/Application Support/Tuneforge`
 - Linux: `~/.local/share/tuneforge`
 
-Lyrics models are downloaded on demand into the lyrics cache directory, then reused offline on later runs. In development, `pnpm setup:dev` preloads Demucs, Whisper, crema, and beat-this `small0` assets into their default caches; if they are not preloaded, first use may download them through the model loaders. The Torch cache path is `$TORCH_HOME/hub/checkpoints` when `TORCH_HOME` is set, `$XDG_CACHE_HOME/torch/hub/checkpoints` when `XDG_CACHE_HOME` is set, or `~/.cache/torch/hub/checkpoints` by default. Packaged desktop builds use these same caches by default. Packages built with `--model-bundle` seed Demucs and Whisper caches from package resources on startup, and also seed the beat-this `small0` checkpoint when beat-this dependencies are included.
+Lyrics models are downloaded on demand into the lyrics cache directory, then reused offline on later runs. In development, `pnpm setup:dev` verifies Demucs, Whisper, crema, and beat-this `small0` caches/assets, then preloads or downloads only missing, corrupt, or partial assets through the existing model loader paths. A successful setup verification means the local cache/assets are usable; runtime models may still load lazily on first use. The Torch cache path is `$TORCH_HOME/hub/checkpoints` when `TORCH_HOME` is set, `$XDG_CACHE_HOME/torch/hub/checkpoints` when `XDG_CACHE_HOME` is set, or `~/.cache/torch/hub/checkpoints` by default. Packaged desktop builds use these same caches by default. Packages built with `--model-bundle` seed Demucs and Whisper caches from package resources on startup, and also seed the beat-this `small0` checkpoint when beat-this dependencies are included.
 
 ## Chord backends
 

--- a/apps/backend/app/cli/prewarm_models.py
+++ b/apps/backend/app/cli/prewarm_models.py
@@ -10,7 +10,11 @@ from app.engines.beat_this import (
     invalid_beat_this_checkpoint_cache_files,
     preload_beat_this_checkpoint,
 )
-from app.engines.crema_chords import crema_dependency_status, preload_crema_model
+from app.engines.crema_chords import (
+    crema_dependency_status,
+    invalid_crema_model_asset_files,
+    preload_crema_model,
+)
 from app.engines.demucs_cache import (
     invalid_demucs_torch_cache_files,
     preload_demucs_torch_cache,
@@ -121,8 +125,19 @@ def _verify_or_prewarm_crema() -> None:
     available, reason = crema_dependency_status()
     if not available:
         raise RuntimeError(reason or "crema is unavailable")
+    invalid_files = invalid_crema_model_asset_files()
+    if not invalid_files:
+        sys.stdout.write("Crema model assets verified.\n")
+        return
+
+    sys.stdout.write(f"Crema model assets invalid: {format_invalid_model_files(invalid_files)}\n")
     preload_crema_model()
-    sys.stdout.write("Crema model verified.\n")
+    invalid_after_prewarm = invalid_crema_model_asset_files()
+    if invalid_after_prewarm:
+        raise RuntimeError(
+            f"Crema model assets remain invalid: {format_invalid_model_files(invalid_after_prewarm)}"
+        )
+    sys.stdout.write("Preloaded Crema model.\n")
 
 
 def _print_invalid_files(label: str, invalid_files: Sequence[InvalidModelFile]) -> None:

--- a/apps/backend/app/engines/crema_chords.py
+++ b/apps/backend/app/engines/crema_chords.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import binascii
 import importlib.metadata
 import importlib.util
 import io
@@ -10,8 +12,10 @@ from pathlib import Path
 from typing import Any
 
 from app.engines.chord_labels import chord_label_to_segment
+from app.utils.model_cache import ExpectedModelFile, InvalidModelFile, invalid_model_files
 
 CREMA_BACKEND_ID = "crema-advanced"
+_CREMA_CHORD_MODEL_ASSET_PREFIX = "crema/models/chord/"
 _CREMA_MODEL: Any | None = None
 
 
@@ -112,6 +116,78 @@ def preload_crema_model() -> None:
     _get_crema_model()
 
 
+def invalid_crema_model_asset_files() -> tuple[InvalidModelFile, ...]:
+    try:
+        package_files = importlib.metadata.files("crema")
+    except importlib.metadata.PackageNotFoundError:
+        return (
+            InvalidModelFile(
+                label="Crema chord model assets",
+                path=Path("crema"),
+                reason="missing-distribution",
+            ),
+        )
+
+    if package_files is None:
+        return (
+            InvalidModelFile(
+                label="Crema chord model assets",
+                path=Path(_CREMA_CHORD_MODEL_ASSET_PREFIX),
+                reason="metadata-unavailable",
+            ),
+        )
+
+    expected_files: list[ExpectedModelFile] = []
+    invalid_metadata_files: list[InvalidModelFile] = []
+    for package_file in package_files:
+        package_path = str(package_file)
+        if not package_path.startswith(_CREMA_CHORD_MODEL_ASSET_PREFIX):
+            continue
+
+        file_path = Path(package_file.locate())
+        label = f"Crema {package_path}"
+        file_size = getattr(package_file, "size", None)
+        file_sha256 = _crema_metadata_sha256(getattr(package_file, "hash", None))
+        if not isinstance(file_size, int) or file_size <= 0:
+            invalid_metadata_files.append(
+                InvalidModelFile(
+                    label=label,
+                    path=file_path,
+                    reason="metadata-size",
+                )
+            )
+            continue
+        if file_sha256 is None:
+            invalid_metadata_files.append(
+                InvalidModelFile(
+                    label=label,
+                    path=file_path,
+                    reason="metadata-sha256",
+                    expected_size=file_size,
+                )
+            )
+            continue
+        expected_files.append(
+            ExpectedModelFile(
+                label=label,
+                path=file_path,
+                size=file_size,
+                sha256=file_sha256,
+            )
+        )
+
+    if not expected_files and not invalid_metadata_files:
+        return (
+            InvalidModelFile(
+                label="Crema chord model assets",
+                path=Path(_CREMA_CHORD_MODEL_ASSET_PREFIX),
+                reason="metadata-missing-assets",
+            ),
+        )
+
+    return (*invalid_metadata_files, *invalid_model_files(tuple(expected_files)))
+
+
 def crema_model_metadata() -> dict[str, Any]:
     return {
         "backend_id": CREMA_BACKEND_ID,
@@ -131,6 +207,19 @@ def _get_crema_model() -> Any:
 
             _CREMA_MODEL = ChordModel()
     return _CREMA_MODEL
+
+
+def _crema_metadata_sha256(file_hash: Any) -> str | None:
+    if getattr(file_hash, "mode", None) != "sha256":
+        return None
+    hash_value = getattr(file_hash, "value", None)
+    if not isinstance(hash_value, str) or not hash_value:
+        return None
+    padding = "=" * (-len(hash_value) % 4)
+    try:
+        return base64.urlsafe_b64decode(hash_value + padding).hex()
+    except (ValueError, binascii.Error):
+        return None
 
 
 @contextmanager

--- a/apps/backend/tests/test_beat_this_engine.py
+++ b/apps/backend/tests/test_beat_this_engine.py
@@ -163,6 +163,29 @@ def test_get_file2beats_initializes_beat_this_with_requested_checkpoint(monkeypa
     assert calls == [("final0", "cpu", False)]
 
 
+def test_detect_beat_this_timing_first_use_initializes_file2beats(monkeypatch) -> None:
+    calls: list[tuple[str, str, bool]] = []
+
+    class FakeFile2Beats:
+        def __init__(self, checkpoint_path: str, *, device: str, dbn: bool) -> None:
+            calls.append((checkpoint_path, device, dbn))
+
+        def __call__(self, _source_path: str):
+            return np.asarray([0.0, 0.5, 1.0, 1.5, 2.0]), np.asarray([0.0, 2.0])
+
+    _install_fake_beat_this(monkeypatch, FakeFile2Beats)
+    beat_this_engine._get_file2beats.cache_clear()
+
+    timing = beat_this_engine.detect_beat_this_timing(
+        Path("synthetic_beat_this.wav"),
+        duration_seconds=2.0,
+    )
+
+    assert timing is not None
+    assert timing["source"] == "beat-this"
+    assert calls == [("small0", "cpu", False)]
+
+
 def _install_fake_beat_this(monkeypatch, file2beats_class: type) -> None:
     beat_this_module = types.ModuleType("beat_this")
     beat_this_module.__path__ = []

--- a/apps/backend/tests/test_chord_backends.py
+++ b/apps/backend/tests/test_chord_backends.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import json
+import sys
 import warnings
 from pathlib import Path
+from types import ModuleType
 from typing import Any
 
 from app.benchmarks.chords import main as benchmark_main
+from app.engines import crema_chords
 from app.engines.chord_labels import chord_label_to_segment, parse_chord_label
 from app.engines.crema_chords import crema_annotation_to_timeline, detect_crema_chord_timeline
 from app.services.chord_backends import (
@@ -108,6 +111,40 @@ def test_crema_detection_suppresses_known_runtime_noise(monkeypatch, capsys, rec
     captured = capsys.readouterr()
     assert captured.out == ""
     assert len(recwarn) == 0
+    assert timeline[0]["label"] == "C"
+
+
+def test_crema_first_feature_use_instantiates_chord_model(monkeypatch):
+    created: list[str] = []
+    predicted: list[str] = []
+
+    class FakeChordModel:
+        def __init__(self) -> None:
+            created.append("created")
+
+        def predict(self, filename: str) -> FakeAnnotation:
+            predicted.append(filename)
+            return FakeAnnotation([{"time": 0.0, "duration": 1.0, "value": "C:maj", "confidence": 0.9}])
+
+    crema_module = ModuleType("crema")
+    crema_module.__path__ = []
+    models_module = ModuleType("crema.models")
+    models_module.__path__ = []
+    chord_module = ModuleType("crema.models.chord")
+    chord_module.ChordModel = FakeChordModel
+    crema_module.models = models_module
+    models_module.chord = chord_module
+
+    crema_chords.clear_crema_model_cache()
+    monkeypatch.setattr(crema_chords, "_CREMA_MODEL", None)
+    monkeypatch.setitem(sys.modules, "crema", crema_module)
+    monkeypatch.setitem(sys.modules, "crema.models", models_module)
+    monkeypatch.setitem(sys.modules, "crema.models.chord", chord_module)
+
+    timeline = detect_crema_chord_timeline(Path("/tmp/first-use.wav"))
+
+    assert created == ["created"]
+    assert predicted == ["/tmp/first-use.wav"]
     assert timeline[0]["label"] == "C"
 
 

--- a/apps/backend/tests/test_lyrics_engine.py
+++ b/apps/backend/tests/test_lyrics_engine.py
@@ -394,6 +394,34 @@ def test_transcribe_with_device_omits_language_for_auto_detect():
     assert result.language_override is None
 
 
+def test_transcribe_with_device_first_use_loads_whisper_with_download_root(tmp_path: Path):
+    calls: list[tuple[str, str, str]] = []
+
+    class FakeWhisper:
+        def load_model(self, model_name: str, *, device: str, download_root: str) -> str:
+            calls.append((model_name, device, download_root))
+            return "model"
+
+        def transcribe(self, model: str, source_path: str, **kwargs: object) -> dict[str, object]:
+            del model, source_path, kwargs
+            return {
+                "language": "en",
+                "segments": [{"start": 0.0, "end": 1.0, "text": "hello"}],
+            }
+
+    result = _transcribe_with_device(
+        Path("/tmp/fake.wav"),
+        requested_device="auto",
+        model_name="tiny",
+        device="cpu",
+        download_root=tmp_path,
+        whisper_module=FakeWhisper(),
+    )
+
+    assert calls == [("tiny", "cpu", str(tmp_path))]
+    assert result.segments[0]["text"] == "hello"
+
+
 def test_transcribe_with_device_passes_language_override_and_falls_back_to_it():
     class FakeWhisper:
         def __init__(self) -> None:

--- a/apps/backend/tests/test_prewarm_models.py
+++ b/apps/backend/tests/test_prewarm_models.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.cli import prewarm_models
+from app.engines import crema_chords
+from app.utils.model_cache import InvalidModelFile
+
+
+def test_valid_whisper_cache_skips_preload(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr(prewarm_models, "invalid_whisper_model_cache_files", lambda _model_name: ())
+    monkeypatch.setattr(prewarm_models, "preload_whisper_model", lambda model_name: calls.append(model_name))
+
+    prewarm_models._verify_or_prewarm_whisper("tiny")
+
+    assert calls == []
+    assert capsys.readouterr().out == "Whisper tiny model cache verified.\n"
+
+
+@pytest.mark.parametrize("reason", ["missing", "sha256"])
+def test_missing_or_invalid_whisper_cache_preloads(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    reason: str,
+) -> None:
+    invalid_file = _invalid_file(tmp_path, label="Whisper tiny", reason=reason)
+    calls: list[str] = []
+    invalid_results = iter(((invalid_file,), ()))
+
+    monkeypatch.setattr(
+        prewarm_models,
+        "invalid_whisper_model_cache_files",
+        lambda _model_name: next(invalid_results),
+    )
+    monkeypatch.setattr(prewarm_models, "preload_whisper_model", lambda model_name: calls.append(model_name))
+
+    prewarm_models._verify_or_prewarm_whisper("tiny")
+
+    assert calls == ["tiny"]
+
+
+def test_valid_beat_this_cache_skips_preload(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr(prewarm_models, "invalid_beat_this_checkpoint_cache_files", lambda _checkpoint: ())
+    monkeypatch.setattr(
+        prewarm_models,
+        "preload_beat_this_checkpoint",
+        lambda checkpoint: calls.append(checkpoint),
+    )
+
+    prewarm_models._verify_or_prewarm_beat_this("small0")
+
+    assert calls == []
+    assert capsys.readouterr().out == "beat-this small0 checkpoint cache verified.\n"
+
+
+@pytest.mark.parametrize("reason", ["missing", "sha256"])
+def test_missing_or_invalid_beat_this_cache_preloads(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    reason: str,
+) -> None:
+    invalid_file = _invalid_file(tmp_path, label="beat-this small0", reason=reason)
+    calls: list[str] = []
+    invalid_results = iter(((invalid_file,), ()))
+
+    monkeypatch.setattr(
+        prewarm_models,
+        "invalid_beat_this_checkpoint_cache_files",
+        lambda _checkpoint: next(invalid_results),
+    )
+    monkeypatch.setattr(
+        prewarm_models,
+        "preload_beat_this_checkpoint",
+        lambda checkpoint: calls.append(checkpoint),
+    )
+
+    prewarm_models._verify_or_prewarm_beat_this("small0")
+
+    assert calls == ["small0"]
+
+
+def test_crema_model_asset_verifier_uses_distribution_record(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    payload = b"crema-fixture"
+    asset_path = tmp_path / "model.h5"
+    asset_path.write_bytes(payload)
+    package_file = _FakePackageFile(
+        "crema/models/chord/model.h5",
+        asset_path,
+        payload=payload,
+    )
+
+    monkeypatch.setattr(crema_chords.importlib.metadata, "files", lambda _package_name: (package_file,))
+
+    assert crema_chords.invalid_crema_model_asset_files() == ()
+
+
+def test_crema_valid_asset_verification_skips_preload(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(prewarm_models, "crema_dependency_status", lambda: (True, None))
+    monkeypatch.setattr(prewarm_models, "invalid_crema_model_asset_files", lambda: ())
+
+    def fail_preload() -> None:
+        raise AssertionError("Crema runtime loader should not run when assets are valid")
+
+    monkeypatch.setattr(prewarm_models, "preload_crema_model", fail_preload)
+
+    prewarm_models._verify_or_prewarm_crema()
+
+    assert capsys.readouterr().out == "Crema model assets verified.\n"
+
+
+def test_crema_invalid_asset_verification_falls_back_to_preload(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    invalid_file = _invalid_file(tmp_path, label="Crema model.h5", reason="metadata-sha256")
+    calls: list[str] = []
+    invalid_results = iter(((invalid_file,), ()))
+
+    monkeypatch.setattr(prewarm_models, "crema_dependency_status", lambda: (True, None))
+    monkeypatch.setattr(prewarm_models, "invalid_crema_model_asset_files", lambda: next(invalid_results))
+    monkeypatch.setattr(prewarm_models, "preload_crema_model", lambda: calls.append("loaded"))
+
+    prewarm_models._verify_or_prewarm_crema()
+
+    assert calls == ["loaded"]
+
+
+def test_crema_invalid_asset_verification_fails_when_assets_remain_invalid(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    invalid_file = _invalid_file(tmp_path, label="Crema model.h5", reason="metadata-sha256")
+    calls: list[str] = []
+
+    monkeypatch.setattr(prewarm_models, "crema_dependency_status", lambda: (True, None))
+    monkeypatch.setattr(prewarm_models, "invalid_crema_model_asset_files", lambda: (invalid_file,))
+    monkeypatch.setattr(prewarm_models, "preload_crema_model", lambda: calls.append("loaded"))
+
+    with pytest.raises(RuntimeError, match="Crema model assets remain invalid"):
+        prewarm_models._verify_or_prewarm_crema()
+
+    assert calls == ["loaded"]
+
+
+def _invalid_file(tmp_path: Path, *, label: str, reason: str) -> InvalidModelFile:
+    path = tmp_path / f"{reason}.bin"
+    if reason != "missing":
+        path.write_bytes(b"stale")
+    return InvalidModelFile(label=label, path=path, reason=reason)
+
+
+class _FakeFileHash:
+    mode = "sha256"
+
+    def __init__(self, payload: bytes) -> None:
+        self.value = base64.urlsafe_b64encode(hashlib.sha256(payload).digest()).decode("ascii").rstrip("=")
+
+
+class _FakePackageFile:
+    def __init__(self, package_path: str, local_path: Path, *, payload: bytes) -> None:
+        self._package_path = package_path
+        self._local_path = local_path
+        self.size = len(payload)
+        self.hash = _FakeFileHash(payload)
+
+    def __str__(self) -> str:
+        return self._package_path
+
+    def locate(self) -> Any:
+        return self._local_path

--- a/apps/backend/tests/test_torch_runtime.py
+++ b/apps/backend/tests/test_torch_runtime.py
@@ -499,7 +499,7 @@ def test_model_cache_verifier_imports_no_ml_runtimes():
         "import json, sys; "
         "import app.cli.prewarm_models; "
         "print(json.dumps({name: name in sys.modules "
-        "for name in ['torch', 'whisper', 'beat_this', 'demucs']}))"
+        "for name in ['torch', 'whisper', 'beat_this', 'demucs', 'crema', 'tensorflow', 'keras']}))"
     )
     completed = subprocess.run(
         [sys.executable, "-c", script],
@@ -514,6 +514,9 @@ def test_model_cache_verifier_imports_no_ml_runtimes():
         "whisper": False,
         "beat_this": False,
         "demucs": False,
+        "crema": False,
+        "tensorflow": False,
+        "keras": False,
     }
 
 

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -10,19 +10,19 @@ Runs the standard developer setup:
   pnpm --filter @tuneforge/desktop exec playwright install chromium
   uv sync --python 3.11 --all-groups
   pnpm contracts:generate
-  verify/preload model caches for selected local backends
+  verify model caches and preload/download only missing or invalid assets
 
 Options:
   --advanced-chords, --crema  Include the default crema/TensorFlow chord backend.
   --no-advanced-chords, --no-crema
                               Skip the crema/TensorFlow chord backend.
   --advanced-beats, --beat-this
-                              Include the default beat-this backend and preload small0.
+                              Include the default beat-this backend and verify/preload small0.
   --no-advanced-beats, --no-beat-this
-                              Skip the beat-this backend and checkpoint prewarm.
+                              Skip the beat-this backend and checkpoint verification/preload.
   --legacy-nvidia             Use the Linux x86_64 legacy NVIDIA Torch profile.
-  --skip-demucs-models        Skip preloading Demucs weights into the Torch cache.
-  --skip-model-prewarm        Skip all model cache verification/prewarm work.
+  --skip-demucs-models        Skip Demucs model cache verification/preload.
+  --skip-model-prewarm        Skip all model cache verification/preload work.
   --skip-playwright-browsers  Skip installing Playwright's Chromium browser.
   --skip-pnpm-install         Skip workspace dependency installation.
   --skip-contracts            Skip OpenAPI contract generation.
@@ -185,7 +185,7 @@ if [[ "${skip_model_prewarm}" -eq 0 ]]; then
   if [[ "${advanced_beats}" -eq 1 ]]; then
     prewarm_args+=(--include-beat-this)
   fi
-  echo "Verifying and preloading model caches..."
+  echo "Verifying model caches; preloading missing or invalid assets only..."
   if [[ "${#prewarm_args[@]}" -gt 0 ]]; then
     .venv/bin/python -m app.cli.prewarm_models "${prewarm_args[@]}"
   else

--- a/scripts/setup-dev.test.sh
+++ b/scripts/setup-dev.test.sh
@@ -39,30 +39,49 @@ chmod +x \
   "${fixture}/apps/backend/.venv/bin/python"
 
 python_args_file="${fixture}/python-args"
-output_file="${fixture}/setup-output"
 
-if ! PATH="${fixture}/bin:${PATH}" \
-  SETUP_DEV_TEST_PYTHON_ARGS="${python_args_file}" \
-  /bin/bash "${fixture}/scripts/setup-dev.sh" \
-    --no-crema \
-    --no-beat-this \
-    --skip-contracts \
-    --skip-playwright-browsers \
-    --skip-pnpm-install > "${output_file}" 2>&1; then
-  cat "${output_file}" >&2
-  exit 1
-fi
+run_setup_dev() {
+  local label="$1"
+  shift
+  local output_file="${fixture}/setup-output-${label}"
 
-expected_args_file="${fixture}/expected-python-args"
-cat > "${expected_args_file}" <<'EOF'
--m
-app.cli.prewarm_models
-EOF
+  : > "${python_args_file}"
+  if ! PATH="${fixture}/bin:${PATH}" \
+    SETUP_DEV_TEST_PYTHON_ARGS="${python_args_file}" \
+    /bin/bash "${fixture}/scripts/setup-dev.sh" \
+      --skip-contracts \
+      --skip-playwright-browsers \
+      --skip-pnpm-install \
+      "$@" > "${output_file}" 2>&1; then
+    cat "${output_file}" >&2
+    exit 1
+  fi
+}
 
-if ! cmp -s "${expected_args_file}" "${python_args_file}"; then
-  echo "unexpected prewarm_models args" >&2
-  diff -u "${expected_args_file}" "${python_args_file}" >&2 || true
-  exit 1
-fi
+assert_python_args() {
+  local label="$1"
+  shift
+  local expected_args_file="${fixture}/expected-python-args-${label}"
 
-echo "setup-dev opt-out prewarm test passed"
+  printf '%s\n' "$@" > "${expected_args_file}"
+
+  if ! cmp -s "${expected_args_file}" "${python_args_file}"; then
+    echo "unexpected prewarm_models args for ${label}" >&2
+    diff -u "${expected_args_file}" "${python_args_file}" >&2 || true
+    exit 1
+  fi
+}
+
+run_setup_dev "default"
+assert_python_args "default" \
+  -m \
+  app.cli.prewarm_models \
+  --include-crema \
+  --include-beat-this
+
+run_setup_dev "opt-out" --no-crema --no-beat-this
+assert_python_args "opt-out" \
+  -m \
+  app.cli.prewarm_models
+
+echo "setup-dev prewarm arg tests passed"


### PR DESCRIPTION
## Summary

- Verify warm model caches before loading advanced model runtimes during setup.
- Keep existing preload/download paths for missing, corrupt, or partial model assets.
- Add mocked first-use coverage for Whisper, beat-this, and Crema lazy loading.

## Testing

- `cd apps/backend && uv run --python 3.11 pytest tests/test_torch_runtime.py tests/test_beat_this_engine.py tests/test_prewarm_models.py tests/test_lyrics_engine.py tests/test_chord_backends.py`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `bash scripts/setup-dev.test.sh`
- Manual warm-cache `pnpm setup:dev` check
