### PR TITLE
fix: honor explicit export filenames

### DIFF
--- a/apps/backend/app/api/routes/projects.py
+++ b/apps/backend/app/api/routes/projects.py
@@ -61,6 +61,7 @@ from app.services.tabs import (
     get_tab_import,
     list_project_sections,
 )
+from app.services.transformations import ensure_export_destination_available
 
 router = APIRouter(prefix="/projects", tags=["projects"])
 
@@ -460,6 +461,10 @@ def project_export(
         artifact = session.get(Artifact, artifact_id)
         if artifact is None or artifact.project_id != project.id:
             raise AppError("ARTIFACT_NOT_FOUND", "Artifact does not belong to this project.", status_code=404)
+    ensure_export_destination_available(
+        destination_file_path=payload.destination_file_path,
+        overwrite_existing=payload.overwrite_existing,
+    )
     job = runner.create_job(
         session,
         project_id=project_id,

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -1396,6 +1396,8 @@ class ExportRequest(BaseModel):
     mixdown_mode: str = "copy"
     output_format: str = "wav"
     destination_path: str | None = None
+    destination_file_path: str | None = None
+    overwrite_existing: bool = False
 
     @model_validator(mode="after")
     def validate_export(self) -> ExportRequest:

--- a/apps/backend/app/services/jobs.py
+++ b/apps/backend/app/services/jobs.py
@@ -1013,6 +1013,8 @@ class InProcessJobRunner:
             artifact_ids=list(payload.get("artifact_ids", [])),
             output_format=payload.get("output_format", "wav"),
             destination_path=payload.get("destination_path"),
+            destination_file_path=payload.get("destination_file_path"),
+            overwrite_existing=bool(payload.get("overwrite_existing", False)),
             on_progress=context.progress_reporter(),
             should_cancel=context.should_cancel,
             register_process=context.register_process,

--- a/apps/backend/app/services/transformations.py
+++ b/apps/backend/app/services/transformations.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -44,6 +45,49 @@ def _preview_cache_key(project_id: str, payload: dict[str, Any]) -> str:
 def _ensure_not_cancelled(should_cancel: Callable[[], bool] | None) -> None:
     if should_cancel and should_cancel():
         raise JobCancelledError()
+
+
+def _resolve_export_file_path(
+    artifact: Artifact,
+    *,
+    output_format: str,
+    destination_path: str | None,
+    destination_file_path: str | None,
+) -> Path:
+    if destination_file_path:
+        return Path(destination_file_path).expanduser().resolve()
+    source_path = Path(artifact.path)
+    root = (
+        Path(destination_path).expanduser().resolve()
+        if destination_path
+        else project_exports_dir(artifact.project_id)
+    )
+    return root / f"{source_path.stem}.{output_format}"
+
+
+def _new_sibling_temp_paths(target: Path, output_format: str) -> tuple[Path, Path]:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        dir=target.parent,
+        prefix="tuneforge-export-",
+        delete=False,
+    ) as temp_file:
+        temp_base_path = Path(temp_file.name)
+    temp_base_path.unlink(missing_ok=True)
+    return temp_base_path, temp_base_path.with_suffix(f".{output_format}")
+
+
+def ensure_export_destination_available(*, destination_file_path: str | None, overwrite_existing: bool) -> None:
+    if not destination_file_path or overwrite_existing:
+        return
+    target = Path(destination_file_path).expanduser().resolve()
+    if target.exists():
+        raise AppError(
+            "EXPORT_DESTINATION_EXISTS",
+            "Export destination already exists.",
+            status_code=status.HTTP_409_CONFLICT,
+            details={"destination_file_path": str(target)},
+        )
 
 
 def build_preview_plan(
@@ -164,6 +208,8 @@ def export_artifacts(
     artifact_ids: list[str],
     output_format: str,
     destination_path: str | None,
+    destination_file_path: str | None = None,
+    overwrite_existing: bool = False,
     on_progress: Callable[[int], None] | None = None,
     should_cancel: Callable[[], bool] | None = None,
     register_process: Callable[[subprocess.Popen[str]], None] | None = None,
@@ -175,26 +221,44 @@ def export_artifacts(
     if artifact is None or artifact.project_id != project.id:
         raise AppError("ARTIFACT_NOT_FOUND", "Artifact not found.", status_code=status.HTTP_404_NOT_FOUND)
     source_path = Path(artifact.path)
-    root = Path(destination_path).expanduser().resolve() if destination_path else project_exports_dir(project.id)
-    root.mkdir(parents=True, exist_ok=True)
-    target = root / f"{source_path.stem}.{output_format}"
-    if artifact.format == output_format:
-        _ensure_not_cancelled(should_cancel)
-        shutil.copy2(source_path, target)
-        _ensure_not_cancelled(should_cancel)
-    else:
-        sample_rate = project.sample_rate or 44100
-        run_ffmpeg_transform(
-            source_path,
-            target.with_suffix(""),
-            sample_rate,
-            0.0,
-            output_format,
-            on_progress=on_progress,
-            should_cancel=should_cancel,
-            register_process=register_process,
-            unregister_process=unregister_process,
+    target = _resolve_export_file_path(
+        artifact,
+        output_format=output_format,
+        destination_path=destination_path,
+        destination_file_path=destination_file_path,
+    )
+    ensure_export_destination_available(
+        destination_file_path=destination_file_path,
+        overwrite_existing=overwrite_existing,
+    )
+    temp_base_path, temp_path = _new_sibling_temp_paths(target, output_format)
+    try:
+        if artifact.format == output_format:
+            _ensure_not_cancelled(should_cancel)
+            shutil.copy2(source_path, temp_path)
+            _ensure_not_cancelled(should_cancel)
+        else:
+            sample_rate = project.sample_rate or 44100
+            run_ffmpeg_transform(
+                source_path,
+                temp_base_path,
+                sample_rate,
+                0.0,
+                output_format,
+                on_progress=on_progress,
+                should_cancel=should_cancel,
+                register_process=register_process,
+                unregister_process=unregister_process,
+            )
+            _ensure_not_cancelled(should_cancel)
+        ensure_export_destination_available(
+            destination_file_path=destination_file_path,
+            overwrite_existing=overwrite_existing,
         )
+        temp_path.replace(target)
+    finally:
+        temp_base_path.unlink(missing_ok=True)
+        temp_path.unlink(missing_ok=True)
     return register_artifact(
         session,
         project_id=project.id,

--- a/apps/backend/tests/test_transform_flow.py
+++ b/apps/backend/tests/test_transform_flow.py
@@ -35,6 +35,38 @@ def _fake_separate_sources(
     return {"engine": "demucs", "model": model, "requested_device": device, "device": "cpu"}
 
 
+def _create_export_fixture(
+    tmp_path: Path,
+    *,
+    project_id: str,
+    artifact_id: str,
+    source_bytes: bytes = b"source audio bytes",
+) -> tuple[str, str, Path]:
+    source_path = tmp_path / f"{artifact_id}.wav"
+    source_path.write_bytes(source_bytes)
+    with SessionLocal() as session:
+        project = Project(
+            id=project_id,
+            display_name="Export Fixture",
+            source_path=str(source_path),
+            imported_path=str(source_path),
+        )
+        source_artifact = Artifact(
+            id=artifact_id,
+            project_id=project.id,
+            type="preview_mix",
+            format="wav",
+            path=str(source_path),
+            generated_by="test",
+            can_delete=True,
+            can_regenerate=True,
+            metadata_json={},
+        )
+        session.add_all([project, source_artifact])
+        session.commit()
+    return project_id, artifact_id, source_path
+
+
 def test_preview_generation_cache_and_export(client, sample_audio_file: Path):
     project = client.post(
         "/api/v1/projects/import",
@@ -103,6 +135,87 @@ def test_preview_generation_cache_and_export(client, sample_audio_file: Path):
     assert any(Path(artifact["path"]).suffix == ".mp3" for artifact in exported)
 
 
+def test_export_uses_exact_destination_file_path(client, tmp_path: Path):
+    project_id, artifact_id, source_path = _create_export_fixture(
+        tmp_path,
+        project_id="proj_export_exact_destination",
+        artifact_id="art_export_exact_destination",
+    )
+    selected_path = tmp_path / "exports" / "selected-name.custom"
+
+    export_job = client.post(
+        f"/api/v1/projects/{project_id}/export",
+        json={
+            "artifact_ids": [artifact_id],
+            "mixdown_mode": "copy",
+            "output_format": "wav",
+            "destination_file_path": str(selected_path),
+        },
+    ).json()["job"]
+
+    export_final = wait_for_job(client, export_job["id"])
+    assert export_final["status"] == "completed"
+    assert selected_path.read_bytes() == source_path.read_bytes()
+    assert not (selected_path.parent / f"{source_path.stem}.wav").exists()
+
+    artifacts = client.get(f"/api/v1/projects/{project_id}/artifacts").json()["artifacts"]
+    exported = next(artifact for artifact in artifacts if artifact["type"] == "export_mix")
+    assert Path(exported["path"]) == selected_path.resolve()
+
+
+def test_export_rejects_existing_explicit_destination_without_overwrite(client, tmp_path: Path):
+    project_id, artifact_id, _source_path = _create_export_fixture(
+        tmp_path,
+        project_id="proj_export_conflict",
+        artifact_id="art_export_conflict",
+        source_bytes=b"new bytes",
+    )
+    selected_path = tmp_path / "exports" / "selected.wav"
+    selected_path.parent.mkdir(parents=True)
+    selected_path.write_bytes(b"existing bytes")
+
+    response = client.post(
+        f"/api/v1/projects/{project_id}/export",
+        json={
+            "artifact_ids": [artifact_id],
+            "mixdown_mode": "copy",
+            "output_format": "wav",
+            "destination_file_path": str(selected_path),
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "EXPORT_DESTINATION_EXISTS"
+    assert selected_path.read_bytes() == b"existing bytes"
+
+
+def test_export_overwrites_existing_explicit_destination_when_requested(client, tmp_path: Path):
+    project_id, artifact_id, _source_path = _create_export_fixture(
+        tmp_path,
+        project_id="proj_export_overwrite",
+        artifact_id="art_export_overwrite",
+        source_bytes=b"replacement bytes",
+    )
+    selected_path = tmp_path / "exports" / "selected.wav"
+    selected_path.parent.mkdir(parents=True)
+    selected_path.write_bytes(b"existing bytes")
+
+    export_job = client.post(
+        f"/api/v1/projects/{project_id}/export",
+        json={
+            "artifact_ids": [artifact_id],
+            "mixdown_mode": "copy",
+            "output_format": "wav",
+            "destination_file_path": str(selected_path),
+            "overwrite_existing": True,
+        },
+    ).json()["job"]
+
+    export_final = wait_for_job(client, export_job["id"])
+    assert export_final["status"] == "completed"
+    assert selected_path.read_bytes() == b"replacement bytes"
+
+
 def test_preview_mix_creation_does_not_auto_queue_stems(
     client,
     sample_audio_file: Path,
@@ -142,7 +255,9 @@ def test_preview_mix_creation_does_not_auto_queue_stems(
 def test_same_format_export_cancelled_after_copy_skips_artifact_registration(client, tmp_path: Path):
     source_path = tmp_path / "source.wav"
     source_path.write_bytes(b"source audio bytes")
-    destination = tmp_path / "exports"
+    destination = tmp_path / "exports" / "selected.wav"
+    destination.parent.mkdir(parents=True)
+    destination.write_bytes(b"existing audio bytes")
 
     with SessionLocal() as session:
         project = Project(
@@ -176,7 +291,9 @@ def test_same_format_export_cancelled_after_copy_skips_artifact_registration(cli
                 project=project,
                 artifact_ids=[source_artifact.id],
                 output_format="wav",
-                destination_path=str(destination),
+                destination_path=None,
+                destination_file_path=str(destination),
+                overwrite_existing=True,
                 should_cancel=should_cancel,
             )
 
@@ -187,5 +304,6 @@ def test_same_format_export_cancelled_after_copy_skips_artifact_registration(cli
             )
         )
 
-    assert (destination / "source.wav").exists()
+    assert destination.read_bytes() == b"existing audio bytes"
+    assert not list(destination.parent.glob("tuneforge-export-*"))
     assert export_count is None

--- a/apps/desktop/src/App.project-playback-artifacts.test.tsx
+++ b/apps/desktop/src/App.project-playback-artifacts.test.tsx
@@ -16,6 +16,7 @@ import {
   setJobs,
   setProjectChords,
 } from "./test/appTestHarness";
+import { ApiError } from "./lib/api";
 import {
   ensureInspectorVisible,
   generateStems,
@@ -74,6 +75,23 @@ function terminalJob(index: number, overrides: Record<string, unknown> = {}) {
     updated_at: timestamp,
     ...overrides,
   };
+}
+
+function exportDestinationExistsError() {
+  return new ApiError({
+    code: "EXPORT_DESTINATION_EXISTS",
+    message: "Export destination already exists.",
+    details: {},
+  });
+}
+
+async function exportSelectedSourceAudio(user: ReturnType<typeof userEvent.setup>) {
+  expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+  await ensureInspectorVisible(user);
+  const sourceList = screen.getByRole("group", { name: "Source and mix list" });
+  await user.click(within(sourceList).getByRole("button", { name: /Source Track/i }));
+  await openAnalysisPanel(user);
+  await user.click(screen.getByRole("button", { name: "Export Selected Audio" }));
 }
 
 describe("Desktop app project playback artifacts", () => {
@@ -592,22 +610,96 @@ describe("Desktop app project playback artifacts", () => {
 
     renderApp(["/projects/proj_123"]);
 
-    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
-    await ensureInspectorVisible(user);
-    const sourceList = screen.getByRole("group", { name: "Source and mix list" });
-    await user.click(within(sourceList).getByRole("button", { name: /Source Track/i }));
-    await openAnalysisPanel(user);
-    await user.click(screen.getByRole("button", { name: "Export Selected Audio" }));
+    await exportSelectedSourceAudio(user);
 
-    expect(mockSave).toHaveBeenCalled();
+    expect(mockSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: expect.arrayContaining([
+          expect.objectContaining({ extensions: ["wav"] }),
+          expect.objectContaining({ extensions: ["mp3"] }),
+          expect.objectContaining({ extensions: ["flac"] }),
+        ]),
+      }),
+    );
     expect(mockCreateExport).toHaveBeenCalledWith(
       "proj_123",
       expect.objectContaining({
         artifact_ids: ["art_source"],
         output_format: "flac",
-        destination_path: "/tmp/exports",
+        destination_file_path: "/tmp/exports/demo-source.flac",
       }),
     );
+    expect(mockCreateExport.mock.calls[0]?.[1]).not.toHaveProperty("destination_path");
+  });
+
+  it("does not create an export when the save dialog is canceled", async () => {
+    const user = userEvent.setup();
+    mockSave.mockResolvedValue(null);
+
+    renderApp(["/projects/proj_123"]);
+
+    await exportSelectedSourceAudio(user);
+
+    expect(mockSave).toHaveBeenCalled();
+    expect(mockCreateExport).not.toHaveBeenCalled();
+  });
+
+  it("does not retry export when an existing destination warning is canceled", async () => {
+    const user = userEvent.setup();
+    mockSave.mockResolvedValue("/tmp/exports/demo-source.wav");
+    mockConfirm.mockResolvedValueOnce(false);
+    mockCreateExport.mockRejectedValueOnce(exportDestinationExistsError());
+
+    renderApp(["/projects/proj_123"]);
+
+    await exportSelectedSourceAudio(user);
+
+    await waitFor(() =>
+      expect(mockConfirm).toHaveBeenCalledWith(
+        expect.stringContaining("already exists"),
+        expect.objectContaining({
+          title: "Replace existing export?",
+          kind: "warning",
+          okLabel: "Replace",
+        }),
+      ),
+    );
+    expect(mockCreateExport).toHaveBeenCalledTimes(1);
+    expect(mockCreateExport.mock.calls[0]?.[1]).not.toHaveProperty("overwrite_existing");
+  });
+
+  it("retries export once with overwrite when an existing destination warning is approved", async () => {
+    const user = userEvent.setup();
+    mockSave.mockResolvedValue("/tmp/exports/demo-source.mp3");
+    mockConfirm.mockResolvedValueOnce(true);
+    mockCreateExport.mockRejectedValueOnce(exportDestinationExistsError());
+
+    renderApp(["/projects/proj_123"]);
+
+    await exportSelectedSourceAudio(user);
+
+    await waitFor(() => expect(mockCreateExport).toHaveBeenCalledTimes(2));
+    expect(mockCreateExport).toHaveBeenNthCalledWith(
+      1,
+      "proj_123",
+      expect.objectContaining({
+        artifact_ids: ["art_source"],
+        output_format: "mp3",
+        destination_file_path: "/tmp/exports/demo-source.mp3",
+      }),
+    );
+    expect(mockCreateExport.mock.calls[0]?.[1]).not.toHaveProperty("overwrite_existing");
+    expect(mockCreateExport).toHaveBeenNthCalledWith(
+      2,
+      "proj_123",
+      expect.objectContaining({
+        artifact_ids: ["art_source"],
+        output_format: "mp3",
+        destination_file_path: "/tmp/exports/demo-source.mp3",
+        overwrite_existing: true,
+      }),
+    );
+    expect(mockCreateExport.mock.calls[1]?.[1]).not.toHaveProperty("destination_path");
   });
 
   it("renames project from the title row", async () => {

--- a/apps/desktop/src/features/projects/components/InspectorPanel.tsx
+++ b/apps/desktop/src/features/projects/components/InspectorPanel.tsx
@@ -487,7 +487,7 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
           title={editLockTitle}
           type="button"
         >
-          {exportMutation.isPending ? "Queueing..." : "Export Selected Audio"}
+          {exportMutation.isPending ? "Preparing..." : "Export Selected Audio"}
         </button>
       </div>
 

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -3,9 +3,11 @@ import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tansta
 import { useNavigate, useParams } from "react-router-dom";
 import { confirm, save } from "@tauri-apps/plugin-dialog";
 import {
+  ApiError,
   api,
   getProjectSyncSummary,
   type ArtifactSchema,
+  type ExportRequest,
   type JobSchema,
   type LyricsGenerateRequest,
   type LyricsResponse,
@@ -96,6 +98,11 @@ const ACTIVE_PROJECT_JOBS_LIMIT = 200;
 const PROJECT_HISTORY_JOBS_PAGE_SIZE = 50;
 const EMPTY_JOBS: JobSchema[] = [];
 const PROJECT_PLAYBACK_FALLBACK_NAME = "Project playback";
+const DESKTOP_EXPORT_FILTERS = [
+  { name: "WAV Audio", extensions: ["wav"] },
+  { name: "MP3 Audio", extensions: ["mp3"] },
+  { name: "FLAC Audio", extensions: ["flac"] },
+];
 
 type DeleteArtifactsRequest = {
   artifactIds: string[];
@@ -163,6 +170,24 @@ function formatLyricsLanguageMetadata(lyrics: LyricsResponse | undefined) {
     return `Override: ${overrideLabel}`;
   }
   return effectiveLabel ? `Language: ${effectiveLabel}` : null;
+}
+
+function supportedExportFormat(format: string | null | undefined) {
+  const normalizedFormat = format?.toLowerCase();
+  if (normalizedFormat === "mp3" || normalizedFormat === "flac" || normalizedFormat === "wav") {
+    return normalizedFormat;
+  }
+  return "wav";
+}
+
+function exportFormatFromFilePath(filePath: string) {
+  const fileName = filePath.split(/[\\/]/).pop() ?? filePath;
+  const extension = fileName.includes(".") ? fileName.split(".").pop() : null;
+  return supportedExportFormat(extension);
+}
+
+function isExportDestinationExistsError(error: unknown) {
+  return error instanceof ApiError && error.code === "EXPORT_DESTINATION_EXISTS";
 }
 
 function resolveDefaultPlaybackDisplayMode(
@@ -627,23 +652,49 @@ export function useProjectViewModel() {
       if (!exportArtifact) {
         throw new Error("Nothing available to export yet.");
       }
-      const suggestedFormat = exportArtifact.format;
+      const defaultExportName = projectQuery.data?.display_name ?? artifactLabel(exportArtifact);
+      const suggestedFormat = supportedExportFormat(exportArtifact.format);
       const exportTarget = await save({
-        defaultPath: `${projectQuery.data?.display_name ?? artifactLabel(exportArtifact)}.${suggestedFormat}`,
+        defaultPath: `${defaultExportName}.${suggestedFormat}`,
+        filters: DESKTOP_EXPORT_FILTERS,
       });
-      const destinationPath = exportTarget
-        ? exportTarget.slice(0, exportTarget.lastIndexOf("/"))
-        : undefined;
-      const extension = exportTarget?.split(".").pop()?.toLowerCase();
-      return api.createExport(projectId, {
+      if (exportTarget === null || exportTarget.length === 0) {
+        return null;
+      }
+      const exportRequest: ExportRequest = {
         artifact_ids: [exportArtifact.id],
         mixdown_mode: "copy",
-        output_format:
-          extension === "mp3" || extension === "flac" ? extension : "wav",
-        destination_path: destinationPath,
-      });
+        output_format: exportFormatFromFilePath(exportTarget),
+        destination_file_path: exportTarget,
+      };
+      try {
+        return await api.createExport(projectId, exportRequest);
+      } catch (error) {
+        if (!isExportDestinationExistsError(error)) {
+          throw error;
+        }
+        const shouldOverwrite = await confirm(
+          "A file already exists with that name. Replace it?",
+          {
+            title: "Replace existing export?",
+            kind: "warning",
+            okLabel: "Replace",
+            cancelLabel: "Cancel",
+          },
+        );
+        if (!shouldOverwrite) {
+          return null;
+        }
+        return api.createExport(projectId, {
+          ...exportRequest,
+          overwrite_existing: true,
+        });
+      }
     },
-    onSuccess: async () => {
+    onSuccess: async (response) => {
+      if (!response) {
+        return;
+      }
       await queryClient.invalidateQueries({ queryKey: ["jobs"] });
     },
   });

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -1124,6 +1124,13 @@ export interface components {
             output_format?: string;
             /** Destination Path */
             destination_path?: string | null;
+            /** Destination File Path */
+            destination_file_path?: string | null;
+            /**
+             * Overwrite Existing
+             * @default false
+             */
+            overwrite_existing?: boolean;
         };
         /** HTTPValidationError */
         HTTPValidationError: {


### PR DESCRIPTION
## Summary

- Honor the exact save-dialog export filename through the backend export request.
- Add explicit overwrite conflict handling with a confirmed desktop retry.
- Write exports through sibling temp files before atomic replacement.
- Regenerate the shared export contract and add backend/frontend regression tests.

Closes #302

## Testing

- `cd apps/backend && uv run --python 3.11 pytest tests/test_transform_flow.py`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `pnpm contracts:generate`
- `pnpm --filter @tuneforge/desktop test -- App.project-playback-artifacts.test.tsx`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
