### PR TITLE
fix: scope Tauri file paths

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -36,6 +36,7 @@ tokio = { version = "1", features = ["time"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 cpal = "0.18.1"
+rusqlite = { version = "0.40.0", features = ["bundled"] }
 signalsmith-stretch = "0.1.3"
 symphonia = { version = "0.6.0", default-features = false, features = ["all"] }
 

--- a/apps/desktop/src-tauri/src/file_dialog_scope.rs
+++ b/apps/desktop/src-tauri/src/file_dialog_scope.rs
@@ -1,0 +1,410 @@
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+use tauri::AppHandle;
+use tauri_plugin_dialog::{DialogExt, FilePath};
+
+const JSON_FILTER_NAME: &str = "JSON";
+const JSON_EXTENSION: &str = "json";
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum JsonFilePathError {
+    NonLocalFileSelection,
+    WrongExtension,
+    MissingReadTarget,
+    ReadTargetSymlink,
+    ReadTargetDirectory,
+    ReadTargetNotFile,
+    ReadTargetUnavailable,
+    MissingParent,
+    ParentSymlink,
+    ParentNotDirectory,
+    ParentUnavailable,
+    DestinationSymlink,
+    DestinationDirectory,
+    DestinationNotFile,
+    DestinationUnavailable,
+}
+
+impl JsonFilePathError {
+    fn read_message(&self) -> &'static str {
+        match self {
+            Self::WrongExtension => "Selected settings file must be a JSON file.",
+            Self::MissingReadTarget => "Selected settings file no longer exists.",
+            Self::ReadTargetDirectory => "Selected settings file is a directory.",
+            Self::ReadTargetSymlink | Self::ReadTargetNotFile | Self::NonLocalFileSelection => {
+                "Selected settings file is not a supported local JSON file."
+            }
+            Self::ReadTargetUnavailable => "Selected settings file could not be checked.",
+            Self::MissingParent
+            | Self::ParentSymlink
+            | Self::ParentNotDirectory
+            | Self::ParentUnavailable
+            | Self::DestinationSymlink
+            | Self::DestinationDirectory
+            | Self::DestinationNotFile
+            | Self::DestinationUnavailable => "Selected settings file is not readable.",
+        }
+    }
+
+    fn write_message(&self, purpose: &str) -> String {
+        match self {
+            Self::WrongExtension => format!("Selected {purpose} location must be a JSON file."),
+            Self::MissingParent => {
+                format!("Selected {purpose} folder no longer exists.")
+            }
+            Self::ParentSymlink | Self::ParentNotDirectory | Self::NonLocalFileSelection => {
+                format!("Selected {purpose} folder is not a supported local folder.")
+            }
+            Self::DestinationSymlink | Self::DestinationDirectory | Self::DestinationNotFile => {
+                format!("Selected {purpose} location is not safe to write.")
+            }
+            Self::ParentUnavailable | Self::DestinationUnavailable => {
+                format!("Selected {purpose} location could not be checked.")
+            }
+            Self::MissingReadTarget
+            | Self::ReadTargetSymlink
+            | Self::ReadTargetDirectory
+            | Self::ReadTargetNotFile
+            | Self::ReadTargetUnavailable => {
+                format!("Selected {purpose} location is not writable.")
+            }
+        }
+    }
+}
+
+pub(crate) fn read_user_selected_json_file(
+    app: &AppHandle,
+    title: &str,
+) -> Result<Option<String>, String> {
+    let Some(path) = pick_user_selected_json_file(app, title)? else {
+        return Ok(None);
+    };
+    validate_user_selected_json_read_path(&path).map_err(|error| error.read_message())?;
+    let contents = fs::read_to_string(path)
+        .map_err(|error| format!("Could not read selected settings file: {error}"))?;
+    Ok(Some(contents))
+}
+
+pub(crate) fn write_user_selected_json_file(
+    app: &AppHandle,
+    title: &str,
+    default_file_name: String,
+    fallback_file_name: &str,
+    contents: String,
+    purpose: &str,
+) -> Result<bool, String> {
+    validate_json_contents(&contents, purpose)?;
+    let default_file_name = sanitized_json_file_name(&default_file_name, fallback_file_name);
+    let Some(path) = pick_user_selected_json_save_path(app, title, default_file_name)? else {
+        return Ok(false);
+    };
+    validate_user_selected_json_write_path(&path).map_err(|error| error.write_message(purpose))?;
+    fs::write(path, contents)
+        .map_err(|error| format!("Could not write selected {purpose} file: {error}"))?;
+    Ok(true)
+}
+
+// User-selected JSON snapshot/evidence files are the only allowed roots.
+fn pick_user_selected_json_file(app: &AppHandle, title: &str) -> Result<Option<PathBuf>, String> {
+    app.dialog()
+        .file()
+        .set_title(title)
+        .add_filter(JSON_FILTER_NAME, &[JSON_EXTENSION])
+        .blocking_pick_file()
+        .map(selected_file_path_to_local_path)
+        .transpose()
+        .map_err(|error| error.read_message().to_string())
+}
+
+// Renderer supplies only a default name; native dialog supplies the destination.
+fn pick_user_selected_json_save_path(
+    app: &AppHandle,
+    title: &str,
+    default_file_name: String,
+) -> Result<Option<PathBuf>, String> {
+    app.dialog()
+        .file()
+        .set_title(title)
+        .set_file_name(default_file_name)
+        .add_filter(JSON_FILTER_NAME, &[JSON_EXTENSION])
+        .blocking_save_file()
+        .map(selected_file_path_to_local_path)
+        .transpose()
+        .map_err(|error| error.write_message("JSON file"))
+}
+
+fn selected_file_path_to_local_path(selection: FilePath) -> Result<PathBuf, JsonFilePathError> {
+    let path = match selection {
+        FilePath::Path(path) => path,
+        FilePath::Url(url) if url.scheme() == "file" => url
+            .to_file_path()
+            .map_err(|_| JsonFilePathError::NonLocalFileSelection)?,
+        FilePath::Url(_) => return Err(JsonFilePathError::NonLocalFileSelection),
+    };
+
+    if path.is_absolute() {
+        Ok(path)
+    } else {
+        Err(JsonFilePathError::NonLocalFileSelection)
+    }
+}
+
+pub(crate) fn validate_user_selected_json_read_path(path: &Path) -> Result<(), JsonFilePathError> {
+    validate_json_extension(path)?;
+    let metadata = fs::symlink_metadata(path).map_err(|error| match error.kind() {
+        io::ErrorKind::NotFound => JsonFilePathError::MissingReadTarget,
+        _ => JsonFilePathError::ReadTargetUnavailable,
+    })?;
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() {
+        return Err(JsonFilePathError::ReadTargetSymlink);
+    }
+    if file_type.is_dir() {
+        return Err(JsonFilePathError::ReadTargetDirectory);
+    }
+    if !file_type.is_file() {
+        return Err(JsonFilePathError::ReadTargetNotFile);
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_user_selected_json_write_path(path: &Path) -> Result<(), JsonFilePathError> {
+    validate_json_extension(path)?;
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .ok_or(JsonFilePathError::MissingParent)?;
+    let parent_metadata = fs::symlink_metadata(parent).map_err(|error| match error.kind() {
+        io::ErrorKind::NotFound => JsonFilePathError::MissingParent,
+        _ => JsonFilePathError::ParentUnavailable,
+    })?;
+    let parent_type = parent_metadata.file_type();
+    if parent_type.is_symlink() {
+        return Err(JsonFilePathError::ParentSymlink);
+    }
+    if !parent_type.is_dir() {
+        return Err(JsonFilePathError::ParentNotDirectory);
+    }
+
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            let file_type = metadata.file_type();
+            if file_type.is_symlink() {
+                Err(JsonFilePathError::DestinationSymlink)
+            } else if file_type.is_dir() {
+                Err(JsonFilePathError::DestinationDirectory)
+            } else if !file_type.is_file() {
+                Err(JsonFilePathError::DestinationNotFile)
+            } else {
+                Ok(())
+            }
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(_) => Err(JsonFilePathError::DestinationUnavailable),
+    }
+}
+
+fn validate_json_extension(path: &Path) -> Result<(), JsonFilePathError> {
+    match path.extension().and_then(|extension| extension.to_str()) {
+        Some(extension) if extension.eq_ignore_ascii_case(JSON_EXTENSION) => Ok(()),
+        _ => Err(JsonFilePathError::WrongExtension),
+    }
+}
+
+fn validate_json_contents(contents: &str, purpose: &str) -> Result<(), String> {
+    serde_json::from_str::<serde_json::Value>(contents)
+        .map(|_| ())
+        .map_err(|error| format!("Selected {purpose} contents are not valid JSON: {error}"))
+}
+
+fn sanitized_json_file_name(default_file_name: &str, fallback_file_name: &str) -> String {
+    let file_name = Path::new(default_file_name)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or(fallback_file_name);
+
+    if has_json_extension(Path::new(file_name)) {
+        file_name.to_string()
+    } else {
+        format!("{file_name}.{JSON_EXTENSION}")
+    }
+}
+
+fn has_json_extension(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case(JSON_EXTENSION))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        fs::{self, File},
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    struct TestDir {
+        root: PathBuf,
+    }
+
+    impl TestDir {
+        fn new(test_name: &str) -> Self {
+            let stamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system time")
+                .as_nanos();
+            let root = std::env::temp_dir().join(format!(
+                "tuneforge-file-dialog-scope-{test_name}-{}-{stamp}",
+                std::process::id()
+            ));
+            fs::create_dir(&root).expect("create temp test directory");
+            Self { root }
+        }
+
+        fn path(&self, name: &str) -> PathBuf {
+            self.root.join(name)
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    #[test]
+    fn validate_read_accepts_json_file() {
+        let dir = TestDir::new("read-accepts-json");
+        let path = dir.path("settings.json");
+        fs::write(&path, "{}").expect("write json fixture");
+
+        assert_eq!(validate_user_selected_json_read_path(&path), Ok(()));
+    }
+
+    #[test]
+    fn validate_read_rejects_wrong_extension() {
+        let dir = TestDir::new("read-rejects-extension");
+        let path = dir.path("settings.txt");
+        fs::write(&path, "{}").expect("write fixture");
+
+        assert_eq!(
+            validate_user_selected_json_read_path(&path),
+            Err(JsonFilePathError::WrongExtension)
+        );
+    }
+
+    #[test]
+    fn validate_read_rejects_missing_target() {
+        let dir = TestDir::new("read-rejects-missing");
+        let path = dir.path("missing.json");
+
+        assert_eq!(
+            validate_user_selected_json_read_path(&path),
+            Err(JsonFilePathError::MissingReadTarget)
+        );
+    }
+
+    #[test]
+    fn validate_read_rejects_directory() {
+        let dir = TestDir::new("read-rejects-directory");
+        let path = dir.path("directory.json");
+        fs::create_dir(&path).expect("create directory fixture");
+
+        assert_eq!(
+            validate_user_selected_json_read_path(&path),
+            Err(JsonFilePathError::ReadTargetDirectory)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_read_rejects_symlink() {
+        let dir = TestDir::new("read-rejects-symlink");
+        let target = dir.path("target.json");
+        let symlink = dir.path("link.json");
+        fs::write(&target, "{}").expect("write symlink target");
+        std::os::unix::fs::symlink(&target, &symlink).expect("create symlink");
+
+        assert_eq!(
+            validate_user_selected_json_read_path(&symlink),
+            Err(JsonFilePathError::ReadTargetSymlink)
+        );
+    }
+
+    #[test]
+    fn validate_write_accepts_new_json_file() {
+        let dir = TestDir::new("write-accepts-json");
+        let path = dir.path("settings.json");
+
+        assert_eq!(validate_user_selected_json_write_path(&path), Ok(()));
+    }
+
+    #[test]
+    fn validate_write_rejects_missing_parent() {
+        let dir = TestDir::new("write-rejects-missing-parent");
+        let path = dir.path("missing-parent").join("settings.json");
+
+        assert_eq!(
+            validate_user_selected_json_write_path(&path),
+            Err(JsonFilePathError::MissingParent)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_write_rejects_parent_symlink() {
+        let dir = TestDir::new("write-rejects-parent-symlink");
+        let target_parent = dir.path("target-parent");
+        let symlink_parent = dir.path("linked-parent");
+        fs::create_dir(&target_parent).expect("create parent target");
+        std::os::unix::fs::symlink(&target_parent, &symlink_parent).expect("create parent symlink");
+        let path = symlink_parent.join("settings.json");
+
+        assert_eq!(
+            validate_user_selected_json_write_path(&path),
+            Err(JsonFilePathError::ParentSymlink)
+        );
+    }
+
+    #[test]
+    fn validate_write_rejects_directory_destination() {
+        let dir = TestDir::new("write-rejects-directory");
+        let path = dir.path("settings.json");
+        fs::create_dir(&path).expect("create directory fixture");
+
+        assert_eq!(
+            validate_user_selected_json_write_path(&path),
+            Err(JsonFilePathError::DestinationDirectory)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_write_rejects_unsafe_existing_destination() {
+        let dir = TestDir::new("write-rejects-symlink");
+        let target = dir.path("target.json");
+        let symlink = dir.path("link.json");
+        fs::write(&target, "{}").expect("write symlink target");
+        std::os::unix::fs::symlink(&target, &symlink).expect("create symlink");
+
+        assert_eq!(
+            validate_user_selected_json_write_path(&symlink),
+            Err(JsonFilePathError::DestinationSymlink)
+        );
+    }
+
+    #[test]
+    fn validate_write_accepts_existing_json_file() {
+        let dir = TestDir::new("write-accepts-existing-file");
+        let path = dir.path("settings.json");
+        File::create(&path).expect("create file fixture");
+
+        assert_eq!(validate_user_selected_json_write_path(&path), Ok(()));
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,9 +1,10 @@
-use std::{fs, process::Child, sync::Mutex};
+use std::{process::Child, sync::Mutex};
 
 #[cfg(not(target_os = "android"))]
 use std::{
     env,
     ffi::OsString,
+    fs,
     io::{Read, Write},
     net::{TcpListener, TcpStream},
     path::{Path, PathBuf},
@@ -12,10 +13,9 @@ use std::{
     time::{Duration, Instant},
 };
 
-#[cfg(not(target_os = "android"))]
-use tauri::AppHandle;
-use tauri::{Manager, State};
+use tauri::{AppHandle, Manager, State};
 
+mod file_dialog_scope;
 mod mobile_backend;
 mod native_audio;
 mod sync_transport;
@@ -51,19 +51,40 @@ fn backend_base_url(runtime: State<'_, BackendRuntime>) -> String {
 }
 
 #[tauri::command]
-fn read_settings_snapshot_file(path: String) -> Result<String, String> {
-    fs::read_to_string(&path).map_err(|error| format!("Could not read settings file: {error}"))
+fn read_settings_snapshot_file(app: AppHandle) -> Result<Option<String>, String> {
+    file_dialog_scope::read_user_selected_json_file(&app, "Import Settings Snapshot")
 }
 
 #[tauri::command]
-fn write_settings_snapshot_file(path: String, contents: String) -> Result<(), String> {
-    fs::write(&path, contents).map_err(|error| format!("Could not write settings file: {error}"))
+fn write_settings_snapshot_file(
+    app: AppHandle,
+    default_file_name: String,
+    contents: String,
+) -> Result<bool, String> {
+    file_dialog_scope::write_user_selected_json_file(
+        &app,
+        "Export Settings Snapshot",
+        default_file_name,
+        "tuneforge-settings.json",
+        contents,
+        "settings snapshot",
+    )
 }
 
 #[tauri::command]
-fn write_sync_evidence_file(path: String, contents: String) -> Result<(), String> {
-    fs::write(&path, contents)
-        .map_err(|error| format!("Could not write sync evidence file: {error}"))
+fn write_sync_evidence_file(
+    app: AppHandle,
+    default_file_name: String,
+    contents: String,
+) -> Result<bool, String> {
+    file_dialog_scope::write_user_selected_json_file(
+        &app,
+        "Export Sync Evidence",
+        default_file_name,
+        "tuneforge-sync-evidence.json",
+        contents,
+        "sync evidence",
+    )
 }
 
 #[cfg(not(target_os = "android"))]

--- a/apps/desktop/src-tauri/src/native_audio/mod.rs
+++ b/apps/desktop/src-tauri/src/native_audio/mod.rs
@@ -7,6 +7,8 @@ pub mod capture;
 pub mod decode;
 pub mod mixer;
 pub mod platform;
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+mod source_scope;
 pub mod system_input;
 pub mod transport;
 

--- a/apps/desktop/src-tauri/src/native_audio/source_scope.rs
+++ b/apps/desktop/src-tauri/src/native_audio/source_scope.rs
@@ -1,0 +1,544 @@
+use std::{
+    env,
+    ffi::OsStr,
+    fs,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use rusqlite::{params, Connection, Error as SqliteError, OpenFlags, OptionalExtension};
+
+const BACKEND_DATABASE_NAME: &str = "app.sqlite";
+const BACKEND_PROJECTS_DIR: &str = "projects";
+const PLAYBACK_SOURCE_MISSING_MESSAGE: &str = "Native playback source is missing or unavailable.";
+const PLAYBACK_SOURCE_UNAVAILABLE_MESSAGE: &str =
+    "Native playback source is unavailable for native playback.";
+const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(30);
+const TUNEFORGE_DATA_DIR: &str = "TUNEFORGE_DATA_DIR";
+
+pub(super) struct PlaybackSourceScope {
+    database_path: PathBuf,
+    projects_root: PathBuf,
+}
+
+impl PlaybackSourceScope {
+    pub(super) fn from_backend_config() -> Result<Self, String> {
+        let data_root = backend_data_root()?;
+        Self::from_backend_data_root(&data_root).map_err(|error| error.message().to_string())
+    }
+
+    fn from_backend_data_root(data_root: &Path) -> Result<Self, PlaybackSourceError> {
+        let database_path = data_root.join(BACKEND_DATABASE_NAME);
+        let projects_root = data_root.join(BACKEND_PROJECTS_DIR);
+        let metadata =
+            fs::metadata(&projects_root).map_err(|_| PlaybackSourceError::Unavailable)?;
+        if !metadata.is_dir() {
+            return Err(PlaybackSourceError::Unavailable);
+        }
+        let projects_root = projects_root
+            .canonicalize()
+            .map_err(|_| PlaybackSourceError::Unavailable)?;
+        Ok(Self {
+            database_path,
+            projects_root,
+        })
+    }
+
+    pub(super) fn validate(
+        &self,
+        artifact_id: Option<&str>,
+        source_path: &str,
+    ) -> Result<PathBuf, PlaybackSourceError> {
+        let artifact_id = artifact_id
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or(PlaybackSourceError::Unavailable)?;
+        let canonical_path = validate_playback_source_path(source_path, &self.projects_root)?;
+        let artifact_path = artifact_path_for_id(&self.database_path, artifact_id)?;
+        let canonical_artifact_path =
+            validate_artifact_record_path(&artifact_path, &self.projects_root)?;
+        if canonical_artifact_path != canonical_path {
+            return Err(PlaybackSourceError::Unavailable);
+        }
+        Ok(canonical_path)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum PlaybackSourceError {
+    Missing,
+    Unavailable,
+}
+
+impl PlaybackSourceError {
+    pub(super) fn message(self) -> &'static str {
+        match self {
+            Self::Missing => PLAYBACK_SOURCE_MISSING_MESSAGE,
+            Self::Unavailable => PLAYBACK_SOURCE_UNAVAILABLE_MESSAGE,
+        }
+    }
+}
+
+fn backend_data_root() -> Result<PathBuf, String> {
+    let home = home_dir()?;
+    let cwd = env::current_dir().unwrap_or_else(|_| home.clone());
+    Ok(backend_data_root_from_parts(
+        env::var_os(TUNEFORGE_DATA_DIR).as_deref(),
+        &home,
+        &cwd,
+        BackendPlatform::current(),
+    ))
+}
+
+fn home_dir() -> Result<PathBuf, String> {
+    env::var("HOME")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .ok_or_else(|| PLAYBACK_SOURCE_UNAVAILABLE_MESSAGE.to_string())
+}
+
+fn backend_data_root_from_parts(
+    override_dir: Option<&OsStr>,
+    home: &Path,
+    cwd: &Path,
+    platform: BackendPlatform,
+) -> PathBuf {
+    if let Some(value) = override_dir.filter(|value| !value.is_empty()) {
+        return absolute_path(&expand_home(Path::new(value), home), cwd);
+    }
+    default_backend_data_root(home, platform)
+}
+
+fn default_backend_data_root(home: &Path, platform: BackendPlatform) -> PathBuf {
+    match platform {
+        #[cfg(any(target_os = "macos", test))]
+        BackendPlatform::Macos => home
+            .join("Library")
+            .join("Application Support")
+            .join("Tuneforge"),
+        #[cfg(any(target_os = "linux", test))]
+        BackendPlatform::Linux => home.join(".local").join("share").join("tuneforge"),
+    }
+}
+
+fn expand_home(path: &Path, home: &Path) -> PathBuf {
+    let value = path.as_os_str().to_string_lossy();
+    if value == "~" {
+        return home.to_path_buf();
+    }
+    if let Some(rest) = value.strip_prefix("~/") {
+        return home.join(rest);
+    }
+    path.to_path_buf()
+}
+
+fn absolute_path(path: &Path, cwd: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    }
+}
+
+fn validate_playback_source_path(
+    source_path: &str,
+    canonical_projects_root: &Path,
+) -> Result<PathBuf, PlaybackSourceError> {
+    let path = PathBuf::from(source_path);
+    if !path.is_absolute() {
+        return Err(PlaybackSourceError::Unavailable);
+    }
+
+    let metadata = fs::symlink_metadata(&path).map_err(|_| PlaybackSourceError::Missing)?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(PlaybackSourceError::Unavailable);
+    }
+
+    let canonical_path = path
+        .canonicalize()
+        .map_err(|_| PlaybackSourceError::Missing)?;
+    if !canonical_path.starts_with(canonical_projects_root) {
+        return Err(PlaybackSourceError::Unavailable);
+    }
+
+    Ok(canonical_path)
+}
+
+fn artifact_path_for_id(
+    database_path: &Path,
+    artifact_id: &str,
+) -> Result<PathBuf, PlaybackSourceError> {
+    let connection = Connection::open_with_flags(
+        database_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|_| PlaybackSourceError::Unavailable)?;
+    connection
+        .busy_timeout(SQLITE_BUSY_TIMEOUT)
+        .map_err(|_| PlaybackSourceError::Unavailable)?;
+    let artifact_path = connection
+        .query_row(
+            "SELECT path FROM artifacts WHERE id = ?1",
+            params![artifact_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(|error| match error {
+            SqliteError::QueryReturnedNoRows => PlaybackSourceError::Unavailable,
+            _ => PlaybackSourceError::Unavailable,
+        })?;
+    artifact_path
+        .filter(|value| !value.trim().is_empty())
+        .map(PathBuf::from)
+        .ok_or(PlaybackSourceError::Unavailable)
+}
+
+fn validate_artifact_record_path(
+    artifact_path: &Path,
+    canonical_projects_root: &Path,
+) -> Result<PathBuf, PlaybackSourceError> {
+    if !artifact_path.is_absolute() {
+        return Err(PlaybackSourceError::Unavailable);
+    }
+
+    let metadata =
+        fs::symlink_metadata(artifact_path).map_err(|_| PlaybackSourceError::Unavailable)?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(PlaybackSourceError::Unavailable);
+    }
+
+    let canonical_artifact_path = artifact_path
+        .canonicalize()
+        .map_err(|_| PlaybackSourceError::Unavailable)?;
+    if !canonical_artifact_path.starts_with(canonical_projects_root) {
+        return Err(PlaybackSourceError::Unavailable);
+    }
+
+    Ok(canonical_artifact_path)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BackendPlatform {
+    #[cfg(any(target_os = "macos", test))]
+    Macos,
+    #[cfg(any(target_os = "linux", test))]
+    Linux,
+}
+
+impl BackendPlatform {
+    fn current() -> Self {
+        #[cfg(target_os = "macos")]
+        {
+            Self::Macos
+        }
+        #[cfg(target_os = "linux")]
+        {
+            Self::Linux
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    struct TestTempDir {
+        path: PathBuf,
+    }
+
+    impl TestTempDir {
+        fn new(label: &str) -> Self {
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time")
+                .as_nanos();
+            let path = env::temp_dir().join(format!(
+                "tuneforge-native-audio-{label}-{}-{nanos}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&path).expect("create temp dir");
+            Self { path }
+        }
+    }
+
+    impl Drop for TestTempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn test_source_scope(temp: &TestTempDir) -> (PlaybackSourceScope, PathBuf) {
+        let data_root = temp.path.join("backend-data");
+        let projects_root = data_root.join(BACKEND_PROJECTS_DIR);
+        fs::create_dir_all(&projects_root).expect("create projects root");
+        create_artifacts_database(&data_root);
+        (
+            PlaybackSourceScope::from_backend_data_root(&data_root).expect("source scope"),
+            projects_root,
+        )
+    }
+
+    fn create_artifacts_database(data_root: &Path) {
+        fs::create_dir_all(data_root).expect("create data root");
+        let connection =
+            Connection::open(data_root.join(BACKEND_DATABASE_NAME)).expect("open test database");
+        connection
+            .execute(
+                "CREATE TABLE artifacts (id TEXT PRIMARY KEY, path TEXT NOT NULL)",
+                [],
+            )
+            .expect("create artifacts table");
+    }
+
+    fn register_artifact(data_root: &Path, artifact_id: &str, path: &Path) {
+        let connection =
+            Connection::open(data_root.join(BACKEND_DATABASE_NAME)).expect("open test database");
+        connection
+            .execute(
+                "INSERT INTO artifacts (id, path) VALUES (?1, ?2)",
+                params![artifact_id, source_path_string(path)],
+            )
+            .expect("insert artifact");
+    }
+
+    fn data_root_for_scope(projects_root: &Path) -> &Path {
+        projects_root.parent().expect("data root")
+    }
+
+    fn source_path_string(path: &Path) -> String {
+        path.to_str().expect("utf-8 test path").to_string()
+    }
+
+    #[test]
+    fn backend_data_root_default_matches_python_macos() {
+        let home = PathBuf::from("/Users/example");
+        let cwd = PathBuf::from("/work");
+
+        let root = backend_data_root_from_parts(None, &home, &cwd, BackendPlatform::Macos);
+
+        assert_eq!(
+            root,
+            PathBuf::from("/Users/example/Library/Application Support/Tuneforge")
+        );
+    }
+
+    #[test]
+    fn backend_data_root_default_matches_python_linux() {
+        let home = PathBuf::from("/home/example");
+        let cwd = PathBuf::from("/work");
+
+        let root = backend_data_root_from_parts(None, &home, &cwd, BackendPlatform::Linux);
+
+        assert_eq!(root, PathBuf::from("/home/example/.local/share/tuneforge"));
+    }
+
+    #[test]
+    fn backend_data_root_uses_tuneforge_data_dir_override() {
+        let home = PathBuf::from("/Users/example");
+        let cwd = PathBuf::from("/work");
+
+        let root = backend_data_root_from_parts(
+            Some(OsStr::new("~/TuneForgeData")),
+            &home,
+            &cwd,
+            BackendPlatform::Macos,
+        );
+
+        assert_eq!(root, PathBuf::from("/Users/example/TuneForgeData"));
+    }
+
+    #[test]
+    fn backend_data_root_absolutizes_relative_override() {
+        let home = PathBuf::from("/Users/example");
+        let cwd = PathBuf::from("/work");
+
+        let root = backend_data_root_from_parts(
+            Some(OsStr::new("tmp/tuneforge")),
+            &home,
+            &cwd,
+            BackendPlatform::Macos,
+        );
+
+        assert_eq!(root, PathBuf::from("/work/tmp/tuneforge"));
+    }
+
+    #[test]
+    fn playback_source_scope_allows_backend_project_artifact_record_path() {
+        let temp = TestTempDir::new("allowed");
+        let (scope, projects_root) = test_source_scope(&temp);
+        let source_dir = projects_root.join("project_123").join("source");
+        fs::create_dir_all(&source_dir).expect("create source dir");
+        let source_path = source_dir.join("source.wav");
+        fs::write(&source_path, b"data").expect("write source");
+        register_artifact(
+            data_root_for_scope(&projects_root),
+            "artifact_1",
+            &source_path,
+        );
+
+        let validated = scope
+            .validate(Some("artifact_1"), &source_path_string(&source_path))
+            .expect("validate source");
+
+        assert_eq!(
+            validated,
+            source_path.canonicalize().expect("canonical file")
+        );
+    }
+
+    #[test]
+    fn playback_source_scope_rejects_project_file_without_matching_artifact() {
+        let temp = TestTempDir::new("unregistered");
+        let (scope, projects_root) = test_source_scope(&temp);
+        let project_dir = projects_root.join("project_123");
+        fs::create_dir_all(&project_dir).expect("create project dir");
+        let registered_path = project_dir.join("registered.wav");
+        let unregistered_path = project_dir.join("unregistered.wav");
+        fs::write(&registered_path, b"registered").expect("write registered");
+        fs::write(&unregistered_path, b"unregistered").expect("write unregistered");
+        register_artifact(
+            data_root_for_scope(&projects_root),
+            "artifact_1",
+            &registered_path,
+        );
+
+        let error = scope
+            .validate(Some("artifact_1"), &source_path_string(&unregistered_path))
+            .expect_err("reject unregistered source");
+
+        assert_eq!(error, PlaybackSourceError::Unavailable);
+        assert!(!error
+            .message()
+            .contains(unregistered_path.to_str().expect("path")));
+    }
+
+    #[test]
+    fn playback_source_scope_rejects_missing_artifact_id() {
+        let temp = TestTempDir::new("missing-artifact-id");
+        let (scope, projects_root) = test_source_scope(&temp);
+        let source_dir = projects_root.join("project_123").join("source");
+        fs::create_dir_all(&source_dir).expect("create source dir");
+        let source_path = source_dir.join("source.wav");
+        fs::write(&source_path, b"data").expect("write source");
+        register_artifact(
+            data_root_for_scope(&projects_root),
+            "artifact_1",
+            &source_path,
+        );
+
+        let error = scope
+            .validate(None, &source_path_string(&source_path))
+            .expect_err("reject source without artifact id");
+
+        assert_eq!(error, PlaybackSourceError::Unavailable);
+        assert!(!error
+            .message()
+            .contains(source_path.to_str().expect("path")));
+    }
+
+    #[test]
+    fn playback_source_scope_rejects_wrong_artifact_id_path() {
+        let temp = TestTempDir::new("wrong-artifact-id");
+        let (scope, projects_root) = test_source_scope(&temp);
+        let project_dir = projects_root.join("project_123");
+        fs::create_dir_all(&project_dir).expect("create project dir");
+        let requested_path = project_dir.join("requested.wav");
+        let other_path = project_dir.join("other.wav");
+        fs::write(&requested_path, b"requested").expect("write requested");
+        fs::write(&other_path, b"other").expect("write other");
+        register_artifact(
+            data_root_for_scope(&projects_root),
+            "requested_artifact",
+            &requested_path,
+        );
+        register_artifact(
+            data_root_for_scope(&projects_root),
+            "other_artifact",
+            &other_path,
+        );
+
+        let error = scope
+            .validate(Some("other_artifact"), &source_path_string(&requested_path))
+            .expect_err("reject wrong artifact id");
+
+        assert_eq!(error, PlaybackSourceError::Unavailable);
+        assert!(!error
+            .message()
+            .contains(requested_path.to_str().expect("path")));
+    }
+
+    #[test]
+    fn playback_source_scope_rejects_out_of_scope_file() {
+        let temp = TestTempDir::new("out-of-scope");
+        let (scope, _) = test_source_scope(&temp);
+        let outside_path = temp.path.join("outside.wav");
+        fs::write(&outside_path, b"data").expect("write outside");
+
+        let error = scope
+            .validate(Some("artifact_1"), &source_path_string(&outside_path))
+            .expect_err("reject outside file");
+
+        assert_eq!(error, PlaybackSourceError::Unavailable);
+        assert!(!error
+            .message()
+            .contains(outside_path.to_str().expect("path")));
+    }
+
+    #[test]
+    fn playback_source_scope_rejects_symlink_escape() {
+        let temp = TestTempDir::new("symlink");
+        let (scope, projects_root) = test_source_scope(&temp);
+        let outside_path = temp.path.join("outside.wav");
+        fs::write(&outside_path, b"data").expect("write outside");
+        let source_dir = projects_root.join("project_123").join("source");
+        fs::create_dir_all(&source_dir).expect("create source dir");
+        let symlink_path = source_dir.join("source.wav");
+        std::os::unix::fs::symlink(&outside_path, &symlink_path).expect("create symlink");
+
+        let error = scope
+            .validate(Some("artifact_1"), &source_path_string(&symlink_path))
+            .expect_err("reject symlink");
+
+        assert_eq!(error, PlaybackSourceError::Unavailable);
+        assert!(!error
+            .message()
+            .contains(symlink_path.to_str().expect("path")));
+    }
+
+    #[test]
+    fn playback_source_scope_reports_missing_project_file() {
+        let temp = TestTempDir::new("missing");
+        let (scope, projects_root) = test_source_scope(&temp);
+        let source_path = projects_root
+            .join("project_123")
+            .join("source")
+            .join("missing.wav");
+
+        let error = scope
+            .validate(Some("artifact_1"), &source_path_string(&source_path))
+            .expect_err("reject missing file");
+
+        assert_eq!(error, PlaybackSourceError::Missing);
+        assert!(!error
+            .message()
+            .contains(source_path.to_str().expect("path")));
+    }
+
+    #[test]
+    fn playback_source_scope_rejects_directory() {
+        let temp = TestTempDir::new("directory");
+        let (scope, projects_root) = test_source_scope(&temp);
+        let source_dir = projects_root.join("project_123").join("source");
+        fs::create_dir_all(&source_dir).expect("create source dir");
+
+        let error = scope
+            .validate(Some("artifact_1"), &source_path_string(&source_dir))
+            .expect_err("reject directory");
+
+        assert_eq!(error, PlaybackSourceError::Unavailable);
+        assert!(!error.message().contains(source_dir.to_str().expect("path")));
+    }
+}

--- a/apps/desktop/src-tauri/src/native_audio/transport.rs
+++ b/apps/desktop/src-tauri/src/native_audio/transport.rs
@@ -40,6 +40,7 @@ use super::{
         convert_interleaved_channels, decode_wav_sample, read_u16_le, read_u32_le,
         resample_interleaved,
     },
+    source_scope::PlaybackSourceScope,
     AUDIO_EVENT_ENDED, AUDIO_EVENT_ERROR, AUDIO_EVENT_POSITION, AUDIO_EVENT_STATE,
 };
 
@@ -1454,15 +1455,20 @@ fn load_playback_lanes(
     let mut lanes = Vec::new();
     let mut worker_control_senders = Vec::new();
     let mut worker_threads = Vec::new();
+    let mut source_scope = None;
 
     for lane in raw_lanes {
         let Some(source_path) = &lane.source_path else {
             continue;
         };
-        let path = PathBuf::from(source_path);
-        if !path.exists() {
-            return Err(format!("Native playback source is missing: {source_path}"));
+        if source_scope.is_none() {
+            source_scope = Some(PlaybackSourceScope::from_backend_config()?);
         }
+        let path = source_scope
+            .as_ref()
+            .expect("source scope initialized")
+            .validate(lane.artifact_id.as_deref(), source_path)
+            .map_err(|error| error.message().to_string())?;
 
         let capacity_samples = (sample_rate as usize)
             .saturating_mul(channels)

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -14,7 +14,6 @@ import { encodePairingCode, pairingFingerprint } from "./features/activity/syncP
 import {
   mockCancelJob,
   mockConfirm,
-  mockSave,
   mockGetAnalysis,
   mockGetChords,
   mockGetLyrics,
@@ -3171,6 +3170,72 @@ describe("Desktop app activity", () => {
     expect(serialized).not.toContain("proj_display_name_fallback");
   });
 
+  it("marks partial or conflicted sync evidence as not OK", async () => {
+    const user = userEvent.setup();
+    setSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: listenerEndpointHints,
+      last_sync: syncRunStatus({
+        run_id: "sync_run_partial_truth",
+        session_id: "sync_session_partial_truth",
+        status: "completed_with_errors",
+        message: "Sync completed with project conflicts.",
+        failed_project_count: 1,
+        project_results: [
+          {
+            project_id: "proj_partial_truth",
+            status: "conflicted",
+            message: "Project had a conflict.",
+            failed_count: 1,
+          },
+        ],
+        received_artifacts: [
+          {
+            artifact_id: "art_partial_truth",
+            content_sha256: "sha256-partial-truth",
+            size_bytes: 42,
+            status: "failed",
+            message: "Artifact transfer failed.",
+          },
+        ],
+      }),
+    });
+
+    await openSyncTab(user);
+    const exportedJson = await exportEvidenceFromCurrentSyncResult(user);
+
+    expect(exportedJson.validation).toMatchObject({
+      ok: false,
+      issues: expect.arrayContaining([
+        "artifact_status_failed",
+        "failed_project_count",
+        "project_failed_count",
+        "project_status_conflicted",
+        "run_status_completed_with_errors",
+      ]),
+    });
+  });
+
+  it("sanitizes path-like listener errors before rendering", async () => {
+    const user = userEvent.setup();
+    const rawError = "Sync listener failed while opening /Users/test/private/Secret Demo.wav";
+    setSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: listenerEndpointHints,
+      last_error: rawError,
+      last_sync: null,
+    });
+
+    await openSyncTab(user);
+
+    expect(await screen.findByText("Sync listener error: details redacted.")).toBeInTheDocument();
+    expect(screen.queryByText(rawError)).not.toBeInTheDocument();
+    expect(document.body.textContent ?? "").not.toContain("/Users/test/private");
+    expect(document.body.textContent ?? "").not.toContain("Secret Demo.wav");
+  });
+
   it("copies privacy-safe evidence JSON from listener last_sync", async () => {
     const user = userEvent.setup();
     const writeText = vi.fn().mockResolvedValue(undefined);
@@ -3240,7 +3305,6 @@ describe("Desktop app activity", () => {
       configurable: true,
       value: {},
     });
-    mockSave.mockResolvedValue("/tmp/tuneforge-sync-evidence.json");
     setSyncTransportStatus({
       active: true,
       status: "listening",
@@ -3263,17 +3327,11 @@ describe("Desktop app activity", () => {
     await openSyncTab(user);
     await user.click(screen.getByRole("button", { name: "Export Evidence" }));
 
-    await waitFor(() =>
-      expect(mockSave).toHaveBeenCalledWith({
-        defaultPath: expect.stringMatching(/^tuneforge-sync-evidence-.+\.json$/),
-        filters: [{ name: "JSON", extensions: ["json"] }],
-      }),
-    );
     const mockInvoke = getMockInvoke();
     await waitFor(() =>
       expect(mockInvoke).toHaveBeenCalledWith("write_sync_evidence_file", {
         contents: expect.any(String),
-        path: "/tmp/tuneforge-sync-evidence.json",
+        defaultFileName: expect.stringMatching(/^tuneforge-sync-evidence-.+\.json$/),
       }),
     );
     const writeCall = mockInvoke.mock.calls.find(([command]) => command === "write_sync_evidence_file");
@@ -3289,6 +3347,111 @@ describe("Desktop app activity", () => {
     });
     expect(JSON.stringify(exportedJson)).not.toContain("proj_tauri_export");
     expect(JSON.stringify(exportedJson)).not.toContain("device_peer_1");
+  });
+
+  it("keeps canceled Tauri evidence export quiet", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: {},
+    });
+    const mockInvoke = getMockInvoke();
+    const defaultInvoke = mockInvoke.getMockImplementation();
+    if (!defaultInvoke) {
+      throw new Error("Mock invoke implementation was not installed.");
+    }
+    mockInvoke.mockImplementation(async (command: string, args?: Record<string, unknown>) => {
+      if (command === "write_sync_evidence_file") {
+        return false;
+      }
+      return defaultInvoke(command, args);
+    });
+    setSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: listenerEndpointHints,
+      last_sync: syncRunStatus({
+        run_id: "sync_run_tauri_cancel",
+        session_id: "sync_session_tauri_cancel",
+        project_results: [
+          {
+            project_id: "proj_tauri_cancel",
+            status: "imported",
+            message: "Imported proj_tauri_cancel.",
+            imported_count: 1,
+          },
+        ],
+      }),
+    });
+
+    try {
+      await openSyncTab(user);
+      await user.click(screen.getByRole("button", { name: "Export Evidence" }));
+
+      await waitFor(() => expect(mockInvoke).toHaveBeenCalledWith(
+        "write_sync_evidence_file",
+        expect.objectContaining({ defaultFileName: expect.any(String) }),
+      ));
+      expect(writeText).not.toHaveBeenCalled();
+      expect(screen.queryByText(/Sync evidence exported/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Could not export sync evidence/)).not.toBeInTheDocument();
+    } finally {
+      mockInvoke.mockImplementation(defaultInvoke);
+    }
+  });
+
+  it("shows retryable Tauri evidence export errors without native paths", async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: {},
+    });
+    const mockInvoke = getMockInvoke();
+    const defaultInvoke = mockInvoke.getMockImplementation();
+    if (!defaultInvoke) {
+      throw new Error("Mock invoke implementation was not installed.");
+    }
+    mockInvoke.mockImplementation(async (command: string, args?: Record<string, unknown>) => {
+      if (command === "write_sync_evidence_file") {
+        throw new Error("Could not write sync evidence file: /Users/test/private/sync.json");
+      }
+      return defaultInvoke(command, args);
+    });
+    setSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: listenerEndpointHints,
+      last_sync: syncRunStatus({
+        run_id: "sync_run_tauri_error",
+        session_id: "sync_session_tauri_error",
+        project_results: [
+          {
+            project_id: "proj_tauri_error",
+            status: "imported",
+            message: "Imported proj_tauri_error.",
+            imported_count: 1,
+          },
+        ],
+      }),
+    });
+
+    try {
+      await openSyncTab(user);
+      await user.click(screen.getByRole("button", { name: "Export Evidence" }));
+
+      expect(
+        await screen.findByText("Could not export sync evidence. Choose another location and try again."),
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/\/Users\/test\/private/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Sync evidence exported/)).not.toBeInTheDocument();
+    } finally {
+      mockInvoke.mockImplementation(defaultInvoke);
+    }
   });
 
   it("exports the latest sync now result when listener last_sync is hidden", async () => {

--- a/apps/desktop/src/App.settings-theme.test.tsx
+++ b/apps/desktop/src/App.settings-theme.test.tsx
@@ -10,8 +10,6 @@ import {
   mockInvoke,
   mockListBeatBackends,
   mockListChordBackends,
-  mockOpen,
-  mockSave,
   queryByAriaKeyLabel,
   renderApp,
   setBeatBackends,
@@ -585,8 +583,6 @@ describe("Desktop app settings theme", () => {
 
   it("exports and imports a full settings snapshot", async () => {
     const user = userEvent.setup();
-    mockSave.mockResolvedValue("/tmp/tuneforge-settings.json");
-    mockOpen.mockResolvedValue("/tmp/tuneforge-settings.json");
 
     renderApp(["/settings"]);
 
@@ -612,7 +608,10 @@ describe("Desktop app settings theme", () => {
     await waitFor(() =>
       expect(mockInvoke).toHaveBeenCalledWith(
         "write_settings_snapshot_file",
-        expect.objectContaining({ path: "/tmp/tuneforge-settings.json" }),
+        expect.objectContaining({
+          contents: expect.any(String),
+          defaultFileName: expect.stringMatching(/^tuneforge-settings-\d{4}-\d{2}-\d{2}\.json$/),
+        }),
       ),
     );
     expect(screen.getByText("Settings exported.")).toBeInTheDocument();
@@ -627,6 +626,7 @@ describe("Desktop app settings theme", () => {
 
     await user.click(screen.getByRole("button", { name: "Import Settings" }));
 
+    await waitFor(() => expect(mockInvoke).toHaveBeenCalledWith("read_settings_snapshot_file"));
     await waitFor(() =>
       expect(document.documentElement).toHaveAttribute("data-theme", "dark"),
     );
@@ -637,5 +637,128 @@ describe("Desktop app settings theme", () => {
     expect(screen.getAllByText("Lyrics + chords").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Advanced Chords").length).toBeGreaterThan(0);
     expect(document.documentElement.style.getPropertyValue("--color-bg-app")).toBe("#123456");
+  });
+
+  it("keeps settings snapshot cancel quiet", async () => {
+    const user = userEvent.setup();
+    const defaultInvoke = mockInvoke.getMockImplementation();
+    if (!defaultInvoke) {
+      throw new Error("Mock invoke implementation was not installed.");
+    }
+
+    renderApp(["/settings"]);
+
+    expect(await screen.findByRole("heading", { name: "Control Room" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Export Settings" }));
+    await screen.findByText("Settings exported.");
+
+    mockInvoke.mockImplementation(async (command: string, args?: Record<string, unknown>) => {
+      if (command === "read_settings_snapshot_file") {
+        return null;
+      }
+      return defaultInvoke(command, args);
+    });
+
+    try {
+      await user.click(screen.getByRole("button", { name: "Import Settings" }));
+
+      await waitFor(() => expect(mockInvoke).toHaveBeenCalledWith("read_settings_snapshot_file"));
+      expect(screen.queryByText("Settings exported.")).not.toBeInTheDocument();
+      expect(screen.queryByText("Settings imported.")).not.toBeInTheDocument();
+      expect(screen.queryByText(/Could not import settings/i)).not.toBeInTheDocument();
+    } finally {
+      mockInvoke.mockImplementation(defaultInvoke);
+    }
+  });
+
+  it("shows a parse error for empty settings snapshot files", async () => {
+    const user = userEvent.setup();
+    const defaultInvoke = mockInvoke.getMockImplementation();
+    if (!defaultInvoke) {
+      throw new Error("Mock invoke implementation was not installed.");
+    }
+    mockInvoke.mockImplementation(async (command: string, args?: Record<string, unknown>) => {
+      if (command === "read_settings_snapshot_file") {
+        return "";
+      }
+      return defaultInvoke(command, args);
+    });
+
+    try {
+      renderApp(["/settings"]);
+
+      expect(await screen.findByRole("heading", { name: "Control Room" })).toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: "Import Settings" }));
+
+      expect(await screen.findByText("Could not parse the settings file.")).toBeInTheDocument();
+      expect(screen.queryByText("Settings imported.")).not.toBeInTheDocument();
+    } finally {
+      mockInvoke.mockImplementation(defaultInvoke);
+    }
+  });
+
+  it("rejects corrupt settings snapshots instead of reporting full success", async () => {
+    const user = userEvent.setup();
+    const defaultInvoke = mockInvoke.getMockImplementation();
+    if (!defaultInvoke) {
+      throw new Error("Mock invoke implementation was not installed.");
+    }
+    mockInvoke.mockImplementation(async (command: string, args?: Record<string, unknown>) => {
+      if (command === "read_settings_snapshot_file") {
+        return JSON.stringify({
+          exportedAt: "2026-04-18T13:16:00.000Z",
+          kind: "tuneforge.settings",
+          preferences: {
+            informationDensity: "detailed",
+          },
+          themeOverrides: {},
+          themePreference: "dark",
+          version: 1,
+        });
+      }
+      return defaultInvoke(command, args);
+    });
+
+    try {
+      renderApp(["/settings"]);
+
+      expect(await screen.findByRole("heading", { name: "Control Room" })).toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: "Import Settings" }));
+
+      expect(await screen.findByText("Unsupported settings file.")).toBeInTheDocument();
+      expect(screen.queryByText("Settings imported.")).not.toBeInTheDocument();
+    } finally {
+      mockInvoke.mockImplementation(defaultInvoke);
+    }
+  });
+
+  it("shows retryable settings export errors without native paths", async () => {
+    const user = userEvent.setup();
+    const defaultInvoke = mockInvoke.getMockImplementation();
+    if (!defaultInvoke) {
+      throw new Error("Mock invoke implementation was not installed.");
+    }
+
+    mockInvoke.mockImplementation(async (command: string, args?: Record<string, unknown>) => {
+      if (command === "write_settings_snapshot_file") {
+        throw new Error("Could not write settings file: /Users/test/private/settings.json");
+      }
+      return defaultInvoke(command, args);
+    });
+
+    try {
+      renderApp(["/settings"]);
+
+      expect(await screen.findByRole("heading", { name: "Control Room" })).toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: "Export Settings" }));
+
+      expect(
+        await screen.findByText("Could not export settings. Choose another location and try again."),
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/\/Users\/test\/private/)).not.toBeInTheDocument();
+      expect(screen.queryByText("Settings exported.")).not.toBeInTheDocument();
+    } finally {
+      mockInvoke.mockImplementation(defaultInvoke);
+    }
   });
 });

--- a/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
+++ b/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { invoke, isTauri } from "@tauri-apps/api/core";
-import { save } from "@tauri-apps/plugin-dialog";
 import { QRCodeSVG } from "qrcode.react";
 import {
   api,
@@ -186,15 +185,14 @@ function downloadSyncEvidenceJson(fileName: string, json: string) {
 }
 
 async function saveSyncEvidenceJson(fileName: string, json: string) {
-  const path = await save({
-    defaultPath: fileName,
-    filters: [{ name: "JSON", extensions: ["json"] }],
-  });
-  if (!path) {
-    return false;
+  try {
+    return await invoke<boolean | null>("write_sync_evidence_file", {
+      contents: json,
+      defaultFileName: fileName,
+    }) === true;
+  } catch {
+    throw new Error("Could not export sync evidence. Choose another location and try again.");
   }
-  await invoke("write_sync_evidence_file", { contents: json, path });
-  return true;
 }
 
 function peerLabel(peer: SyncTrustedPeerSchema) {
@@ -438,6 +436,17 @@ function syncNowFailureText(error: unknown) {
   return "Sync now failed.";
 }
 
+function syncListenerLastErrorText(message: string | null | undefined) {
+  const detail = message?.trim();
+  if (!detail) {
+    return null;
+  }
+  if (syncNowFailureDetailIsSensitive(detail)) {
+    return "Sync listener error: details redacted.";
+  }
+  return detail;
+}
+
 function pluralize(count: number, singular: string, plural = `${singular}s`) {
   return `${count} ${count === 1 ? singular : plural}`;
 }
@@ -595,6 +604,49 @@ function syncResultKey(status: SyncTransportRunStatus | null | undefined) {
 
 function positiveSyncCount(value: number | null | undefined) {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function syncEvidenceStatusIndicatesProblem(status: string | null | undefined) {
+  const normalized = status?.trim().toLowerCase();
+  return normalized === "failed" ||
+    normalized === "completed_with_errors" ||
+    normalized === "conflicted" ||
+    normalized === "error" ||
+    normalized === "errored";
+}
+
+function syncEvidenceValidation(
+  status: SyncTransportRunStatus,
+  mergedProjectResults: SyncTransportProjectResult[],
+  artifactStatusCounts: Record<string, number>,
+) {
+  const issues = new Set<string>();
+  if (syncEvidenceStatusIndicatesProblem(status.status)) {
+    issues.add(`run_status_${status.status}`);
+  }
+  if (positiveSyncCount(status.failed_project_count)) {
+    issues.add("failed_project_count");
+  }
+  for (const result of mergedProjectResults) {
+    if (syncEvidenceStatusIndicatesProblem(result.status)) {
+      issues.add(`project_status_${result.status}`);
+    }
+    if (positiveSyncCount(result.failed_count)) {
+      issues.add("project_failed_count");
+    }
+    if (positiveSyncCount(result.counters?.failed_count)) {
+      issues.add("project_counter_failed_count");
+    }
+  }
+  for (const [artifactStatus, count] of Object.entries(artifactStatusCounts)) {
+    if (positiveSyncCount(count) && syncEvidenceStatusIndicatesProblem(artifactStatus)) {
+      issues.add(`artifact_status_${artifactStatus}`);
+    }
+  }
+  return {
+    ok: issues.size === 0,
+    issues: Array.from(issues).sort(),
+  };
 }
 
 function syncProjectResultMutatedLocalCache(result: SyncTransportProjectResult) {
@@ -1353,6 +1405,7 @@ function buildSyncEvidenceExport(
   const retryableInterruptionCode =
     status.retryable_interruption_code ?? options.listenerRetryableInterruptionCode ?? null;
   const retryGuidance = status.retry_guidance ?? options.listenerRetryGuidance ?? null;
+  const validation = syncEvidenceValidation(status, mergedProjectResults, artifactStatusCounts);
 
   return {
     capturedAt: options.capturedAt,
@@ -1556,7 +1609,8 @@ function buildSyncEvidenceExport(
     },
     validation: {
       schema: "tuneforge-sync-evidence-v1",
-      ok: status.status !== "failed",
+      ok: validation.ok,
+      issues: validation.issues,
       ui_visible: true,
       privacySafe: true,
       redactionCounts: {
@@ -1725,6 +1779,7 @@ export function ActivitySyncPanel() {
     }
     return null;
   }, [listenerQuery.data, visibleSyncResult, peersById, trustedNearbyPeerByDeviceId]);
+  const listenerLastErrorMessage = syncListenerLastErrorText(listenerQuery.data?.last_error);
   const pairingInputValue = pairingCodeDraft.trim() || rawPairingPayloadDraft.trim();
   const decodedPairingInput = useMemo(() => {
     if (!pairingInputValue) {
@@ -2239,38 +2294,39 @@ export function ActivitySyncPanel() {
       setEvidenceMessage(null);
       return;
     }
-    let copied: boolean;
-    try {
-      copied = await copyToClipboard(evidence.json);
-    } catch {
-      copied = false;
-    }
+    setEvidenceError(null);
+    setEvidenceMessage(null);
 
     try {
       if (isTauri()) {
         const saved = await saveSyncEvidenceJson(evidence.fileName, evidence.json);
-        let message = "Sync evidence export canceled.";
-        if (saved) {
-          message = copied ? "Sync evidence exported and copied." : "Sync evidence exported.";
-        } else if (copied) {
-          message = "Sync evidence copied. Export canceled.";
+        if (!saved) {
+          return;
+        }
+
+        let copied: boolean;
+        try {
+          copied = await copyToClipboard(evidence.json);
+        } catch {
+          copied = false;
         }
         setEvidenceError(null);
-        setEvidenceMessage(message);
+        setEvidenceMessage(copied ? "Sync evidence exported and copied." : "Sync evidence exported.");
         return;
       }
 
+      let copied: boolean;
+      try {
+        copied = await copyToClipboard(evidence.json);
+      } catch {
+        copied = false;
+      }
       downloadSyncEvidenceJson(evidence.fileName, evidence.json);
       setEvidenceError(null);
       setEvidenceMessage(copied ? "Sync evidence exported and copied." : "Sync evidence exported.");
-    } catch {
-      if (copied) {
-        setEvidenceError("Could not export sync evidence file.");
-        setEvidenceMessage("Sync evidence copied.");
-        return;
-      }
+    } catch (error) {
       setEvidenceMessage(null);
-      setEvidenceError("Could not export sync evidence.");
+      setEvidenceError(error instanceof Error ? error.message : "Could not export sync evidence.");
     }
   }
 
@@ -2432,9 +2488,9 @@ export function ActivitySyncPanel() {
               Native sync transport is unavailable.
             </p>
           ) : null}
-          {listenerQuery.data?.last_error ? (
+          {listenerLastErrorMessage ? (
             <p className="activity-sync-alert activity-sync-alert--error" role="alert">
-              {listenerQuery.data.last_error}
+              {listenerLastErrorMessage}
             </p>
           ) : null}
           {retryableInterruption ? (

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { open, save } from "@tauri-apps/plugin-dialog";
 import { Link } from "react-router-dom";
 import { api, type BeatBackendSchema, type ChordBackendSchema, type StemModelSchema } from "../../lib/api";
 import { FRONTEND_VERSION_INFO } from "../../lib/buildInfo";
@@ -689,15 +688,7 @@ export function SettingsView() {
     setSnapshotStatus(null);
 
     try {
-      const path = await save({
-        defaultPath: `tuneforge-settings-${new Date().toISOString().slice(0, 10)}.json`,
-        filters: [{ name: "JSON", extensions: ["json"] }],
-      });
-
-      if (!path) {
-        return;
-      }
-
+      const defaultFileName = `tuneforge-settings-${new Date().toISOString().slice(0, 10)}.json`;
       const contents = serializeSettingsSnapshot({
         preferences: {
           defaultChordsFollowEnabled,
@@ -720,7 +711,11 @@ export function SettingsView() {
         themePreference,
       });
 
-      await writeSettingsSnapshotFile(path, contents);
+      const exported = await writeSettingsSnapshotFile(defaultFileName, contents);
+      if (!exported) {
+        return;
+      }
+
       setSnapshotStatus({ message: "Settings exported.", tone: "default" });
     } catch (error) {
       setSnapshotStatus({
@@ -737,17 +732,11 @@ export function SettingsView() {
     setSnapshotStatus(null);
 
     try {
-      const selected = await open({
-        filters: [{ name: "JSON", extensions: ["json"] }],
-        multiple: false,
-      });
-      const path = Array.isArray(selected) ? selected[0] : selected;
-
-      if (!path) {
+      const contents = await readSettingsSnapshotFile();
+      if (contents === null) {
         return;
       }
 
-      const contents = await readSettingsSnapshotFile(path);
       const snapshot = parseSettingsSnapshot(contents);
 
       replaceThemeState({

--- a/apps/desktop/src/lib/settingsSnapshot.ts
+++ b/apps/desktop/src/lib/settingsSnapshot.ts
@@ -1,5 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import {
+  MAX_TUNER_REFERENCE_HZ,
+  MIN_TUNER_REFERENCE_HZ,
   normalizePreferences,
   type UiPreferences,
 } from "./preferences";
@@ -8,10 +10,29 @@ import {
   normalizeThemePreference,
   type ThemePreference,
 } from "./theme";
-import type { ThemeOverrides } from "./themeTokens";
+import { isThemeVariableName, type ThemeOverrides } from "./themeTokens";
 
 export const SETTINGS_SNAPSHOT_KIND = "tuneforge.settings";
 export const SETTINGS_SNAPSHOT_VERSION = 1;
+const SETTINGS_PARSE_ERROR = "Could not parse the settings file.";
+const SETTINGS_UNSUPPORTED_ERROR = "Unsupported settings file.";
+const REQUIRED_PREFERENCE_KEYS = [
+  "informationDensity",
+  "enharmonicDisplayMode",
+  "defaultInspectorOpen",
+  "defaultSourcesRailCollapsed",
+  "defaultProjectWorkspace",
+  "defaultPlaybackDisplayMode",
+  "defaultLoopAlignmentMode",
+  "defaultBeatAnalysisBackend",
+  "defaultChordBackend",
+  "defaultStemModel",
+  "defaultLyricsFollowEnabled",
+  "defaultChordsFollowEnabled",
+  "defaultTunerInputDeviceId",
+  "defaultTunerReferenceHz",
+  "defaultTunerVisualMode",
+] as const satisfies readonly (keyof UiPreferences)[];
 
 export type SettingsSnapshot = {
   exportedAt: string;
@@ -44,17 +65,85 @@ export function serializeSettingsSnapshot(input: SettingsSnapshotInput) {
   return JSON.stringify(buildSettingsSnapshot(input), null, 2);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasOwn(record: Record<string, unknown>, key: string) {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function isOneOf<T extends string>(value: unknown, values: readonly T[]): value is T {
+  return typeof value === "string" && values.includes(value as T);
+}
+
+function requireSupported(condition: boolean): asserts condition {
+  if (!condition) {
+    throw new Error(SETTINGS_UNSUPPORTED_ERROR);
+  }
+}
+
+function validateExportedAt(value: unknown) {
+  requireSupported(typeof value === "string" && value.trim().length > 0);
+  requireSupported(Number.isFinite(Date.parse(value)));
+}
+
+function validatePreferences(value: unknown): UiPreferences {
+  requireSupported(isRecord(value));
+  for (const key of REQUIRED_PREFERENCE_KEYS) {
+    requireSupported(hasOwn(value, key));
+  }
+  requireSupported(isOneOf(value.informationDensity, ["minimal", "balanced", "detailed"]));
+  requireSupported(isOneOf(value.enharmonicDisplayMode, ["auto", "sharps", "flats", "neutral", "dual"]));
+  requireSupported(typeof value.defaultInspectorOpen === "boolean");
+  requireSupported(typeof value.defaultSourcesRailCollapsed === "boolean");
+  requireSupported(isOneOf(value.defaultProjectWorkspace, ["project", "playback"]));
+  requireSupported(isOneOf(value.defaultPlaybackDisplayMode, ["auto", "lyrics", "chords", "combined"]));
+  requireSupported(isOneOf(value.defaultLoopAlignmentMode, ["free", "beat", "bar"]));
+  requireSupported(isOneOf(value.defaultBeatAnalysisBackend, ["built-in", "beat-this"]));
+  requireSupported(isOneOf(value.defaultChordBackend, ["tuneforge-fast", "crema-advanced"]));
+  requireSupported(isOneOf(value.defaultStemModel, ["htdemucs_6s", "htdemucs_ft"]));
+  requireSupported(typeof value.defaultLyricsFollowEnabled === "boolean");
+  requireSupported(typeof value.defaultChordsFollowEnabled === "boolean");
+  requireSupported(value.defaultTunerInputDeviceId === null || typeof value.defaultTunerInputDeviceId === "string");
+  requireSupported(
+    typeof value.defaultTunerReferenceHz === "number" &&
+      Number.isFinite(value.defaultTunerReferenceHz) &&
+      value.defaultTunerReferenceHz >= MIN_TUNER_REFERENCE_HZ &&
+      value.defaultTunerReferenceHz <= MAX_TUNER_REFERENCE_HZ,
+  );
+  requireSupported(isOneOf(value.defaultTunerVisualMode, ["simple", "wide-arc"]));
+  return normalizePreferences(value);
+}
+
+function validateThemeOverrides(value: unknown): ThemeOverrides {
+  requireSupported(isRecord(value));
+  for (const [mode, modeOverrides] of Object.entries(value)) {
+    requireSupported(mode === "dark" || mode === "light");
+    requireSupported(isRecord(modeOverrides));
+    for (const [variable, variableValue] of Object.entries(modeOverrides)) {
+      requireSupported(isThemeVariableName(variable) && typeof variableValue === "string");
+    }
+  }
+  return normalizeThemeOverrides(value);
+}
+
+function validateThemePreference(value: unknown): ThemePreference {
+  requireSupported(isOneOf(value, ["dark", "light", "system"]));
+  return normalizeThemePreference(value);
+}
+
 export function parseSettingsSnapshot(text: string): SettingsSnapshot {
   let parsed: unknown;
 
   try {
     parsed = JSON.parse(text);
   } catch {
-    throw new Error("Could not parse the settings file.");
+    throw new Error(SETTINGS_PARSE_ERROR);
   }
 
-  if (!parsed || typeof parsed !== "object") {
-    throw new Error("Could not parse the settings file.");
+  if (!isRecord(parsed)) {
+    throw new Error(SETTINGS_PARSE_ERROR);
   }
 
   const candidate = parsed as Partial<SettingsSnapshot>;
@@ -62,21 +151,31 @@ export function parseSettingsSnapshot(text: string): SettingsSnapshot {
     candidate.kind !== SETTINGS_SNAPSHOT_KIND ||
     candidate.version !== SETTINGS_SNAPSHOT_VERSION
   ) {
-    throw new Error("Unsupported settings file.");
+    throw new Error(SETTINGS_UNSUPPORTED_ERROR);
   }
+
+  validateExportedAt(candidate.exportedAt);
 
   return buildSettingsSnapshot({
     exportedAt: candidate.exportedAt,
-    preferences: candidate.preferences as UiPreferences,
-    themeOverrides: candidate.themeOverrides as ThemeOverrides,
-    themePreference: candidate.themePreference as ThemePreference,
+    preferences: validatePreferences(candidate.preferences),
+    themeOverrides: validateThemeOverrides(candidate.themeOverrides),
+    themePreference: validateThemePreference(candidate.themePreference),
   });
 }
 
-export async function readSettingsSnapshotFile(path: string) {
-  return invoke<string>("read_settings_snapshot_file", { path });
+export async function readSettingsSnapshotFile() {
+  try {
+    return await invoke<string | null>("read_settings_snapshot_file");
+  } catch {
+    throw new Error("Could not read settings file. Choose another file and try again.");
+  }
 }
 
-export async function writeSettingsSnapshotFile(path: string, contents: string) {
-  await invoke("write_settings_snapshot_file", { contents, path });
+export async function writeSettingsSnapshotFile(defaultFileName: string, contents: string) {
+  try {
+    return await invoke<boolean | null>("write_settings_snapshot_file", { contents, defaultFileName }) === true;
+  } catch {
+    throw new Error("Could not export settings. Choose another location and try again.");
+  }
 }

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -1051,24 +1051,21 @@ const {
     }
 
     if (command === "write_settings_snapshot_file") {
-      const path = String(args?.path ?? "");
-      state.snapshotFiles[path] = String(args?.contents ?? "");
-      return null;
+      const defaultFileName = String(args?.defaultFileName ?? "tuneforge-settings.json");
+      const contents = String(args?.contents ?? "");
+      state.snapshotFiles[defaultFileName] = contents;
+      state.snapshotFiles.__settings_snapshot__ = contents;
+      return true as boolean;
     }
 
     if (command === "write_sync_evidence_file") {
-      const path = String(args?.path ?? "");
-      state.snapshotFiles[path] = String(args?.contents ?? "");
-      return null;
+      const defaultFileName = String(args?.defaultFileName ?? "tuneforge-sync-evidence.json");
+      state.snapshotFiles[defaultFileName] = String(args?.contents ?? "");
+      return true as boolean;
     }
 
     if (command === "read_settings_snapshot_file") {
-      const path = String(args?.path ?? "");
-      const contents = state.snapshotFiles[path];
-      if (contents === undefined) {
-        throw new Error(`Missing snapshot file: ${path}`);
-      }
-      return contents;
+      return state.snapshotFiles.__settings_snapshot__ ?? null;
     }
 
     if (command === "get_system_default_input_volume") {


### PR DESCRIPTION
## Summary

- Route settings and sync evidence file operations through native dialogs.
- Add JSON path validation and stricter settings/evidence truthfulness checks.
- Bind native playback source paths to backend artifact records before decoder startup.
- Closes #303

## Testing

- `cargo test file_dialog_scope --lib --manifest-path apps/desktop/src-tauri/Cargo.toml`
- `cargo test native_audio::source_scope --lib --manifest-path apps/desktop/src-tauri/Cargo.toml`
- `cargo test native_audio::transport --lib --manifest-path apps/desktop/src-tauri/Cargo.toml`
- `cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml`
- `git diff --check`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test -- --run`
