### PR TITLE
fix: harden TUNEFORGE_HOST loopback handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Backend behavior is environment-driven. Full table is in [apps/backend/README.md
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `TUNEFORGE_HOST` | `127.0.0.1` | Bind address. Do not change to a public address. |
+| `TUNEFORGE_HOST` | `127.0.0.1` | Dev/test-only loopback override. Allowed values: `127.0.0.1` or `localhost`. |
 | `TUNEFORGE_PORT` | `8765` | Bind port. |
 | `TUNEFORGE_DATA_DIR` | OS-specific | Override the data directory. |
 | `TUNEFORGE_FFMPEG_PATH` / `TUNEFORGE_FFPROBE_PATH` | `ffmpeg` / `ffprobe` | Override binary lookup. |

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -169,7 +169,7 @@ All configuration is environment-driven (see [`app/config.py`](./app/config.py))
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `TUNEFORGE_HOST` | `127.0.0.1` | Bind address. **Do not change to a public address.** |
+| `TUNEFORGE_HOST` | `127.0.0.1` | Dev/test-only loopback override. Allowed values: `127.0.0.1` or `localhost`. |
 | `TUNEFORGE_PORT` | `8765` | Bind port. |
 | `TUNEFORGE_ADDITIONAL_CORS_ORIGINS` | unset | Comma-separated local HTTP origins to allow in addition to the desktop defaults. Only `http://127.0.0.1:<port>` and `http://localhost:<port>` are accepted. |
 | `TUNEFORGE_DATA_DIR` | OS-specific | Override for the data directory (database, projects, cache). |

--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -9,6 +9,9 @@ from urllib.parse import urlparse
 
 from app.utils.model_cache import whisper_cache_dir
 
+_ALLOWED_BACKEND_HOSTS = ("127.0.0.1", "localhost")
+_BACKEND_HOST_ERROR = "TUNEFORGE_HOST must be one of: 127.0.0.1, localhost."
+
 
 def _default_data_root() -> Path:
     override = os.environ.get("TUNEFORGE_DATA_DIR")
@@ -70,7 +73,7 @@ def get_settings() -> Settings:
         database_path=data_root / "app.sqlite",
         projects_root=data_root / "projects",
         cache_root=cache_root,
-        backend_host=os.environ.get("TUNEFORGE_HOST", "127.0.0.1"),
+        backend_host=_parse_backend_host(os.environ.get("TUNEFORGE_HOST", "127.0.0.1")),
         backend_port=int(os.environ.get("TUNEFORGE_PORT", "8765")),
         default_export_format="wav",
         supported_import_formats=("mp3", "wav", "flac", "m4a", "aac", "ogg", "mp4", "webm"),
@@ -117,6 +120,13 @@ def ensure_data_dirs(settings: Settings | None = None) -> None:
         from app.utils.model_bundle import seed_model_bundle_caches
 
         seed_model_bundle_caches(current)
+
+
+def _parse_backend_host(value: str) -> str:
+    host = value.strip()
+    if host not in _ALLOWED_BACKEND_HOSTS:
+        raise ValueError(_BACKEND_HOST_ERROR)
+    return host
 
 
 def _parse_additional_cors_origins(value: str) -> tuple[str, ...]:

--- a/apps/backend/tests/test_config.py
+++ b/apps/backend/tests/test_config.py
@@ -2,7 +2,66 @@ from __future__ import annotations
 
 import pytest
 
-from app.config import _parse_additional_cors_origins
+from app.config import _parse_additional_cors_origins, _parse_backend_host, get_settings
+
+_BACKEND_HOST_ERROR = r"TUNEFORGE_HOST must be one of: 127\.0\.0\.1, localhost\."
+
+
+@pytest.mark.parametrize(
+    ("host", "expected"),
+    [
+        ("127.0.0.1", "127.0.0.1"),
+        ("localhost", "localhost"),
+        (" localhost ", "localhost"),
+    ],
+)
+def test_backend_host_accepts_named_loopback_values(host: str, expected: str) -> None:
+    assert _parse_backend_host(host) == expected
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "",
+        " ",
+        "0.0.0.0",
+        "8.8.8.8",
+        "10.0.0.1",
+        "192.168.1.10",
+        "example.com",
+        "dev.local",
+        "http://127.0.0.1",
+        "https://localhost",
+        "127.0.0.1:8765",
+        "localhost:8765",
+        "127.0.0.1/api",
+        "localhost/api",
+        "::1",
+        "[::1]",
+    ],
+)
+def test_backend_host_rejects_non_loopback_or_shaped_values(host: str) -> None:
+    with pytest.raises(ValueError, match=_BACKEND_HOST_ERROR):
+        _parse_backend_host(host)
+
+
+def test_get_settings_uses_backend_host_parser(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TUNEFORGE_HOST", " localhost ")
+    get_settings.cache_clear()
+    try:
+        assert get_settings().backend_host == "localhost"
+    finally:
+        get_settings.cache_clear()
+
+
+def test_get_settings_rejects_invalid_backend_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TUNEFORGE_HOST", "0.0.0.0")
+    get_settings.cache_clear()
+    try:
+        with pytest.raises(ValueError, match=_BACKEND_HOST_ERROR):
+            get_settings()
+    finally:
+        get_settings.cache_clear()
 
 
 def test_additional_cors_origins_accepts_loopback_http_origins() -> None:


### PR DESCRIPTION
## Summary
- Closes #307
- Restrict `TUNEFORGE_HOST` to loopback-only values before backend startup.
- Document the host override as dev/test-only release-safe configuration.

## Testing
- `cd apps/backend && uv run --python 3.11 pytest tests/test_config.py`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
