### PR TITLE
fix: improve dependency diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ The built-in chord and beat backends remain available as fallbacks when advanced
 missing, unsupported, or disabled. Mobile paths do not run the desktop Python/FastAPI stack and must
 keep clear disabled/fallback states instead of requiring crema, TensorFlow, or beat-this.
 
+Release diagnostics distinguish host tools from local model/cache dependencies. If an import or
+metadata error names `ffmpeg` or `ffprobe`, install FFmpeg on the host or set
+`TUNEFORGE_FFMPEG_PATH` / `TUNEFORGE_FFPROBE_PATH`; TuneForge does not bundle those binaries.
+Diagnostics that name Demucs, Whisper, crema, or beat-this refer to local runtime dependencies or
+model/checkpoint caches, which are prepared by setup/model prewarm or by packages built with
+`--model-bundle`.
+
 ### Linux legacy NVIDIA profile
 
 If you are on Linux `x86_64` with an older NVIDIA GPU that the default PyTorch build rejects at runtime, use the backend's opt-in legacy NVIDIA sync:

--- a/apps/backend/app/dependency_diagnostics.py
+++ b/apps/backend/app/dependency_diagnostics.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+
+from fastapi import status
+
+from app.errors import AppError
+from app.utils.model_cache import InvalidModelFile
+
+HOST_FFMPEG_REMEDIATION = (
+    "Install FFmpeg locally and make sure this host-installed tool is available on PATH."
+)
+DEMUCS_DEPENDENCY_REMEDIATION = (
+    "Install the local backend stem dependencies, then retry stem separation."
+)
+DEMUCS_CACHE_REMEDIATION = (
+    "Re-run local setup to download Demucs model assets, then retry stem separation."
+)
+WHISPER_DEPENDENCY_REMEDIATION = (
+    "Install the local backend lyrics dependencies, then retry lyrics generation."
+)
+WHISPER_CACHE_REMEDIATION = (
+    "Re-run local setup to download the Whisper model asset, then retry lyrics generation."
+)
+SAFE_DIAGNOSTIC_DETAIL_KEYS = frozenset({"dependency", "operation", "remediation", "cache_status"})
+OPERATION_LABELS = {
+    "audio_import_normalization": "audio import normalization",
+    "audio_transform": "audio transform",
+    "lyrics_transcription": "lyrics generation",
+    "metadata_extraction": "metadata extraction",
+    "stem_separation": "stem separation",
+}
+IMPORT_FAILURE_MARKERS = (
+    "modulenotfounderror",
+    "importerror",
+    "no module named",
+    "cannot import name",
+    "dlopen",
+    "shared object file",
+    "symbol not found",
+)
+
+
+def dependency_diagnostic_error(
+    code: str,
+    message: str,
+    *,
+    dependency: str,
+    operation: str,
+    remediation: str,
+    status_code: int = status.HTTP_500_INTERNAL_SERVER_ERROR,
+    cache_status: str | None = None,
+) -> AppError:
+    details = {
+        "dependency": dependency,
+        "operation": operation_label(operation),
+        "remediation": remediation,
+    }
+    if cache_status is not None:
+        details["cache_status"] = cache_status
+    return AppError(code, message, status_code=status_code, details=details)
+
+
+def missing_host_tool_error(*, tool: str, operation: str, impact: str) -> AppError:
+    return dependency_diagnostic_error(
+        "DEPENDENCY_MISSING",
+        f"{tool} is missing, so TuneForge cannot {impact}.",
+        dependency=tool,
+        operation=operation,
+        remediation=HOST_FFMPEG_REMEDIATION,
+    )
+
+
+def demucs_dependency_missing_error(*, dependency: str = "demucs") -> AppError:
+    return dependency_diagnostic_error(
+        "DEPENDENCY_MISSING",
+        "Demucs is unavailable, so TuneForge cannot separate stems.",
+        dependency=dependency,
+        operation="stem_separation",
+        remediation=DEMUCS_DEPENDENCY_REMEDIATION,
+    )
+
+
+def demucs_failure_error(*, cache_status: str | None = None) -> AppError:
+    if cache_status == "missing":
+        message = "Demucs model cache is missing, so TuneForge cannot separate stems."
+        remediation = DEMUCS_CACHE_REMEDIATION
+    elif cache_status == "corrupt":
+        message = "Demucs model cache is corrupt, so TuneForge cannot separate stems."
+        remediation = (
+            "Re-run local setup to replace Demucs model assets, then retry stem separation."
+        )
+    elif cache_status == "unreadable":
+        message = "Demucs model cache is unreadable, so TuneForge cannot separate stems."
+        remediation = (
+            "Fix local cache permissions or re-run setup from an account that can read the model cache."
+        )
+    elif cache_status == "download_failed":
+        message = "Demucs model download failed, so TuneForge cannot separate stems."
+        remediation = "Check local network access for first-run model download, then retry setup."
+    else:
+        message = "Demucs is unavailable, so TuneForge cannot separate stems."
+        remediation = (
+            "Verify local Demucs setup and model assets, then retry stem separation."
+        )
+    return dependency_diagnostic_error(
+        "PROCESSING_FAILED",
+        message,
+        dependency="demucs",
+        operation="stem_separation",
+        remediation=remediation,
+        cache_status=cache_status,
+    )
+
+
+def whisper_dependency_missing_error(*, dependency: str = "openai-whisper") -> AppError:
+    return dependency_diagnostic_error(
+        "DEPENDENCY_MISSING",
+        "Whisper is unavailable, so TuneForge cannot generate lyrics.",
+        dependency=dependency,
+        operation="lyrics_transcription",
+        remediation=WHISPER_DEPENDENCY_REMEDIATION,
+    )
+
+
+def whisper_failure_error(*, cache_status: str | None = None) -> AppError:
+    if cache_status == "missing":
+        message = "Whisper model cache is missing, so TuneForge cannot generate lyrics."
+        remediation = WHISPER_CACHE_REMEDIATION
+    elif cache_status == "corrupt":
+        message = "Whisper model cache is corrupt, so TuneForge cannot generate lyrics."
+        remediation = (
+            "Re-run local setup to replace the Whisper model asset, then retry lyrics generation."
+        )
+    elif cache_status == "unreadable":
+        message = "Whisper model cache is unreadable, so TuneForge cannot generate lyrics."
+        remediation = (
+            "Fix local cache permissions or re-run setup from an account that can read the model cache."
+        )
+    elif cache_status == "download_failed":
+        message = "Whisper model download failed, so TuneForge cannot generate lyrics."
+        remediation = "Check local network access for first-run model download, then retry setup."
+    elif cache_status == "unsupported":
+        message = "Whisper model is unsupported, so TuneForge cannot generate lyrics."
+        remediation = "Choose a supported local Whisper model, then retry lyrics generation."
+    else:
+        message = "Whisper is unavailable, so TuneForge cannot generate lyrics."
+        remediation = (
+            "Verify local Whisper runtime and model cache setup, then retry lyrics generation."
+        )
+    return dependency_diagnostic_error(
+        "PROCESSING_FAILED",
+        message,
+        dependency="whisper",
+        operation="lyrics_transcription",
+        remediation=remediation,
+        cache_status=cache_status,
+    )
+
+
+def cache_status_from_invalid_files(invalid_files: Sequence[InvalidModelFile]) -> str | None:
+    if not invalid_files:
+        return None
+    reasons = {invalid_file.reason for invalid_file in invalid_files}
+    if any("permission" in reason or reason == "unreadable" for reason in reasons):
+        return "unreadable"
+    if any(
+        reason in {"sha256", "size", "metadata-sha256"}
+        or "hash" in reason
+        or "corrupt" in reason
+        for reason in reasons
+    ):
+        return "corrupt"
+    if "unsupported-model" in reasons:
+        return "unsupported"
+    if "missing" in reasons:
+        return "missing"
+    return "unreadable"
+
+
+def operation_label(operation: str) -> str:
+    normalized = operation.strip()
+    if not normalized:
+        return operation
+    return OPERATION_LABELS.get(normalized, normalized.replace("_", " "))
+
+
+def safe_dependency_remediation(details: Mapping[str, object]) -> str | None:
+    if not set(details).issubset(SAFE_DIAGNOSTIC_DETAIL_KEYS):
+        return None
+    remediation = details.get("remediation")
+    if not isinstance(remediation, str):
+        return None
+    normalized = remediation.strip()
+    if (
+        not normalized
+        or any(character in normalized for character in "\r\n\t\\/")
+        or any(ord(character) < 32 or ord(character) == 127 for character in normalized)
+    ):
+        return None
+    return normalized
+
+
+def _normalized_failure_text(text_parts: Iterable[object]) -> str:
+    return " ".join(str(part).lower() for part in text_parts if part is not None)
+
+
+def has_dependency_import_failure_text(text_parts: Iterable[object]) -> bool:
+    text = _normalized_failure_text(text_parts)
+    return any(marker in text for marker in IMPORT_FAILURE_MARKERS)
+
+
+def dependency_from_import_failure_text(
+    text_parts: Iterable[object],
+    module_dependencies: Mapping[str, str],
+) -> str | None:
+    text = _normalized_failure_text(text_parts)
+    if not any(marker in text for marker in IMPORT_FAILURE_MARKERS):
+        return None
+    for module_name, dependency in module_dependencies.items():
+        module = module_name.lower()
+        if any(
+            marker in text
+            for marker in (
+                f"no module named '{module}'",
+                f'no module named "{module}"',
+                f"import {module}",
+                f"from {module}",
+                f"{module}.",
+            )
+        ):
+            return dependency
+    return None
+
+
+def cache_status_from_failure_text(text_parts: Iterable[object]) -> str | None:
+    text = _normalized_failure_text(text_parts)
+    if not text:
+        return None
+    if any(marker in text for marker in IMPORT_FAILURE_MARKERS):
+        return None
+    if any(
+        marker in text
+        for marker in (
+            "http error",
+            "urlerror",
+            "ssl",
+            "timed out",
+            "connection",
+            "download",
+            "temporary failure",
+            "network is unreachable",
+        )
+    ):
+        return "download_failed"
+    if "permission denied" in text or "permissionerror" in text:
+        return "unreadable"
+    if any(
+        marker in text
+        for marker in (
+            "checksum",
+            "sha256",
+            "hash mismatch",
+            "corrupt",
+            "unexpected size",
+            "eof",
+            "invalid load key",
+            "unpicklingerror",
+            "failed finding central directory",
+            "not a zip archive",
+        )
+    ):
+        return "corrupt"
+    if any(
+        marker in text
+        for marker in (
+            "no such file",
+            "not found",
+            "missing",
+        )
+    ):
+        return "missing"
+    return None

--- a/apps/backend/app/engines/lyrics.py
+++ b/apps/backend/app/engines/lyrics.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import sys
 import threading
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -15,6 +15,12 @@ from typing import Any, cast
 
 from fastapi import status
 
+from app.dependency_diagnostics import (
+    cache_status_from_failure_text,
+    cache_status_from_invalid_files,
+    whisper_dependency_missing_error,
+    whisper_failure_error,
+)
 from app.errors import AppError, JobCancelledError
 from app.runtime_status import (
     JobRuntimeStage,
@@ -148,13 +154,12 @@ def lyrics_transcription_from_payload(payload: dict[str, Any]) -> LyricsTranscri
     )
 
 
-def _require_dependency(module_name: str, message: str) -> None:
+_SAFE_DIAGNOSTIC_DETAIL_KEYS = {"dependency", "operation", "remediation", "cache_status"}
+
+
+def _require_dependency(module_name: str, *, dependency: str) -> None:
     if importlib.util.find_spec(module_name) is None:
-        raise AppError(
-            "DEPENDENCY_MISSING",
-            message,
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        )
+        raise whisper_dependency_missing_error(dependency=dependency)
 
 
 def patch_whisper_timing_for_mps(timing_module: Any) -> None:
@@ -175,15 +180,18 @@ def patch_whisper_timing_for_mps(timing_module: Any) -> None:
 
 
 def _load_runtime() -> tuple[Any, Any]:
-    _require_dependency("torch", "PyTorch is required for lyrics generation. Install the backend dependencies first.")
-    _require_dependency(
-        "whisper",
-        "openai-whisper is required for lyrics generation. Install the backend dependencies first.",
-    )
+    _require_dependency("torch", dependency="pytorch")
+    _require_dependency("whisper", dependency="openai-whisper")
     os.environ.update(with_mps_fallback_env(os.environ))
-    import torch  # type: ignore[import-not-found]
-    import whisper  # type: ignore[import-not-found]
-    from whisper import timing as whisper_timing  # type: ignore[import-not-found]
+    try:
+        import torch  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise whisper_dependency_missing_error(dependency="pytorch") from exc
+    try:
+        import whisper  # type: ignore[import-not-found]
+        from whisper import timing as whisper_timing  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise whisper_dependency_missing_error(dependency="openai-whisper") from exc
 
     patch_whisper_timing_for_mps(whisper_timing)
 
@@ -531,7 +539,7 @@ def transcribe_project_lyrics_in_process(
         for device in candidates
     )
     attempt_index = 0
-    errors: list[dict[str, str]] = []
+    errors: list[Exception] = []
 
     requested_normalized = requested_device.strip().lower()
     if requested_normalized in {"mps", "cuda"} and candidates == ["cpu"]:
@@ -577,7 +585,7 @@ def transcribe_project_lyrics_in_process(
             except AppError:
                 raise
             except Exception as exc:  # pragma: no cover - defensive fallback around whisper runtime
-                errors.append({"device": device, "model": candidate_model, "message": str(exc)})
+                errors.append(exc)
                 should_retry_smaller_cuda_model = (
                     device == "cuda"
                     and index < len(model_candidates) - 1
@@ -605,11 +613,8 @@ def transcribe_project_lyrics_in_process(
         if device == "cpu":
             break
 
-    raise AppError(
-        "PROCESSING_FAILED",
-        "Lyrics generation failed.",
-        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        details={"errors": errors},
+    raise whisper_failure_error(
+        cache_status=_whisper_failure_cache_status(model_name, download_root=download_root, errors=errors)
     )
 
 
@@ -690,7 +695,7 @@ def _raise_worker_failure(payload: dict[str, Any] | None) -> None:
             code,
             message,
             status_code=status_code if isinstance(status_code, int) else status.HTTP_500_INTERNAL_SERVER_ERROR,
-            details=details if isinstance(details, dict) else {},
+            details=_safe_worker_error_details(details if isinstance(details, dict) else {}),
         )
 
     raise AppError(
@@ -778,7 +783,6 @@ def transcribe_project_lyrics(
                 "PROCESSING_FAILED",
                 "Lyrics generation failed.",
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                details={"stdout": stdout.strip(), "stderr": stderr.strip()},
             )
         return lyrics_transcription_from_payload(transcription_payload)
     finally:
@@ -786,3 +790,28 @@ def transcribe_project_lyrics(
             unregister_process()
         if process.poll() is None:
             process.kill()
+
+
+def _safe_worker_error_details(details: dict[str, Any]) -> dict[str, Any]:
+    return {key: details[key] for key in _SAFE_DIAGNOSTIC_DETAIL_KEYS if key in details}
+
+
+def _whisper_failure_cache_status(
+    model_name: str,
+    *,
+    download_root: Path,
+    errors: Sequence[Exception],
+) -> str | None:
+    invalid_files = invalid_whisper_model_cache_files(model_name, cache_dir=download_root)
+    invalid_cache_status = cache_status_from_invalid_files(invalid_files)
+    if invalid_cache_status == "unsupported":
+        return invalid_cache_status
+
+    text_status = cache_status_from_failure_text(errors)
+    if text_status is not None:
+        return text_status
+
+    failure_text = " ".join(str(error).lower() for error in errors)
+    if any(marker in failure_text for marker in ("cache", "checkpoint", "download", "model", "whisper")):
+        return invalid_cache_status
+    return None

--- a/apps/backend/app/engines/lyrics_worker.py
+++ b/apps/backend/app/engines/lyrics_worker.py
@@ -64,7 +64,7 @@ def main() -> None:
                     "code": "PROCESSING_FAILED",
                     "message": "Lyrics generation failed.",
                     "status_code": 500,
-                    "details": {"message": str(exc)},
+                    "details": {},
                 },
             }
         )

--- a/apps/backend/app/engines/stems.py
+++ b/apps/backend/app/engines/stems.py
@@ -12,8 +12,14 @@ from pathlib import Path
 
 import numpy as np
 import soundfile as sf
-from fastapi import status
 
+from app.dependency_diagnostics import (
+    cache_status_from_failure_text,
+    demucs_dependency_missing_error,
+    demucs_failure_error,
+    dependency_from_import_failure_text,
+    has_dependency_import_failure_text,
+)
 from app.errors import AppError, JobCancelledError
 from app.runtime_status import is_runtime_event_payload, parse_json_payload
 from app.utils.torch_runtime import with_mps_fallback_env
@@ -21,11 +27,7 @@ from app.utils.torch_runtime import with_mps_fallback_env
 
 def _require_demucs_dependency() -> None:
     if importlib.util.find_spec("demucs") is None:
-        raise AppError(
-            "DEPENDENCY_MISSING",
-            "Demucs is required for stem separation. Install the backend stem dependencies first.",
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        )
+        raise demucs_dependency_missing_error()
 
 
 def separate_two_stems(
@@ -190,20 +192,10 @@ def _run_demucs_worker(
         if process.returncode != 0:
             if should_cancel and should_cancel():
                 raise JobCancelledError()
-            raise AppError(
-                "PROCESSING_FAILED",
-                "Demucs failed to separate the track.",
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                details={"stdout": (stdout or "").strip(), "stderr": (stderr or "").strip()},
-            )
+            raise _demucs_worker_failure_error(stdout, stderr)
 
         if any(not output_path.exists() for output_path in expected_outputs):
-            raise AppError(
-                "PROCESSING_FAILED",
-                "Demucs completed without producing the expected stem files.",
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                details={"stdout": (stdout or "").strip(), "stderr": (stderr or "").strip()},
-            )
+            raise demucs_failure_error()
 
         if on_progress:
             on_progress(98)
@@ -230,6 +222,23 @@ def _run_demucs_worker(
     finally:
         if process and process.poll() is None:
             process.kill()
+
+
+def _demucs_worker_failure_error(stdout: str, stderr: str) -> AppError:
+    dependency = dependency_from_import_failure_text(
+        (stdout, stderr),
+        {
+            "demucs": "demucs",
+            "numpy": "numpy",
+            "soundfile": "soundfile",
+            "torch": "pytorch",
+        },
+    )
+    if dependency is not None:
+        return demucs_dependency_missing_error(dependency=dependency)
+    if has_dependency_import_failure_text((stdout, stderr)):
+        return demucs_dependency_missing_error()
+    return demucs_failure_error(cache_status=cache_status_from_failure_text((stdout, stderr)))
 
 
 def _start_output_reader(

--- a/apps/backend/app/engines/transform.py
+++ b/apps/backend/app/engines/transform.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from app.config import get_settings
+from app.dependency_diagnostics import missing_host_tool_error
 from app.errors import AppError, JobCancelledError
 
 
@@ -56,7 +57,14 @@ def run_ffmpeg_transform(
         filter_graph,
         str(destination_path.with_suffix(f".{output_format}")),
     ]
-    proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    try:
+        proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    except FileNotFoundError as exc:
+        raise missing_host_tool_error(
+            tool="ffmpeg",
+            operation="audio_transform",
+            impact="create transformed audio",
+        ) from exc
     if register_process:
         register_process(proc)
     if on_progress:
@@ -77,12 +85,11 @@ def run_ffmpeg_transform(
         if unregister_process:
             unregister_process()
 
-    stdout, stderr = proc.communicate()
+    proc.communicate()
     if proc.returncode != 0:
         raise AppError(
             "PROCESSING_FAILED",
             "FFmpeg failed to produce the requested artifact.",
-            details={"stdout": stdout.strip(), "stderr": stderr.strip()},
         )
     if on_progress:
         on_progress(90)

--- a/apps/backend/app/services/jobs.py
+++ b/apps/backend/app/services/jobs.py
@@ -11,6 +11,7 @@ from typing import Any, Literal, cast
 from sqlalchemy import case, func, select
 from sqlalchemy.orm import Session, sessionmaker
 
+from app.dependency_diagnostics import safe_dependency_remediation
 from app.errors import AppError, JobCancelledError
 from app.models import Artifact, Job, Project, utcnow
 from app.runtime_status import (
@@ -79,6 +80,19 @@ _PREPARING_STAGE_LABELS = {
     "stems": "Preparing stem separation.",
     "export": "Preparing export.",
 }
+
+
+def _as_sentence(value: str) -> str:
+    stripped = value.strip()
+    return stripped if stripped.endswith((".", "!", "?")) else f"{stripped}."
+
+
+def _job_error_message(exc: AppError) -> str:
+    message = exc.message.strip() or "Job failed."
+    remediation = safe_dependency_remediation(exc.details)
+    if remediation is None or "next:" in message.lower():
+        return message
+    return f"{_as_sentence(message)} Next: {_as_sentence(remediation)}"
 
 
 @dataclass(frozen=True, slots=True)
@@ -824,7 +838,7 @@ class InProcessJobRunner:
             if self.is_cancel_requested(job_id):
                 self.update_job(job_id, status="cancelled", error_message=None)
             else:
-                self.update_job(job_id, status="failed", error_message=exc.message)
+                self.update_job(job_id, status="failed", error_message=_job_error_message(exc))
         except Exception as exc:  # pragma: no cover - defensive fallback
             if self.is_cancel_requested(job_id):
                 self.update_job(job_id, status="cancelled", error_message=None)

--- a/apps/backend/app/services/metadata.py
+++ b/apps/backend/app/services/metadata.py
@@ -8,6 +8,7 @@ from typing import Any
 from fastapi import status
 
 from app.config import get_settings
+from app.dependency_diagnostics import missing_host_tool_error
 from app.errors import AppError
 
 
@@ -36,17 +37,16 @@ def extract_audio_metadata(source_path: Path) -> dict[str, Any]:
     try:
         result = subprocess.run(command, check=True, capture_output=True, text=True)
     except FileNotFoundError as exc:
-        raise AppError(
-            "DEPENDENCY_MISSING",
-            "ffprobe is required for metadata extraction.",
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        raise missing_host_tool_error(
+            tool="ffprobe",
+            operation="metadata_extraction",
+            impact="inspect audio metadata before import",
         ) from exc
     except subprocess.CalledProcessError as exc:
         raise AppError(
             "UNSUPPORTED_AUDIO_FORMAT",
             "Could not read audio metadata from the provided file.",
             status_code=status.HTTP_400_BAD_REQUEST,
-            details={"stderr": exc.stderr.strip()},
         ) from exc
 
     payload = json.loads(result.stdout or "{}")
@@ -77,15 +77,14 @@ def normalize_audio_to_wav(source_path: Path, destination_path: Path) -> None:
     try:
         subprocess.run(command, check=True, capture_output=True, text=True)
     except FileNotFoundError as exc:
-        raise AppError(
-            "DEPENDENCY_MISSING",
-            "ffmpeg is required to normalize imported audio.",
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        raise missing_host_tool_error(
+            tool="ffmpeg",
+            operation="audio_import_normalization",
+            impact="prepare imported audio for local processing",
         ) from exc
     except subprocess.CalledProcessError as exc:
         raise AppError(
             "PROCESSING_FAILED",
             "Could not normalize imported audio to WAV.",
             status_code=status.HTTP_400_BAD_REQUEST,
-            details={"stderr": exc.stderr.strip()},
         ) from exc

--- a/apps/backend/app/services/stem_models.py
+++ b/apps/backend/app/services/stem_models.py
@@ -7,6 +7,11 @@ from pathlib import Path
 from typing import Any
 
 from app.config import get_settings
+from app.dependency_diagnostics import (
+    DEMUCS_CACHE_REMEDIATION,
+    DEMUCS_DEPENDENCY_REMEDIATION,
+    dependency_diagnostic_error,
+)
 from app.errors import AppError
 from app.utils.hashing import file_sha256
 
@@ -43,6 +48,8 @@ class StemModelDefinition:
 class StemModelAvailability:
     available: bool
     unavailable_reason: str | None = None
+    remediation: str | None = None
+    cache_status: str | None = None
 
 
 @dataclass(frozen=True)
@@ -86,45 +93,75 @@ def _load_manifest_model_files(
 ) -> tuple[StemModelAvailability, tuple[StemModelManifestFile, ...]]:
     manifest_path = repo / "manifest.json"
     if not manifest_path.is_file():
-        return StemModelAvailability(False, "Bundled Demucs model manifest is missing"), ()
+        return _demucs_cache_unavailable(
+            "Bundled Demucs model manifest is missing, so TuneForge cannot separate stems.",
+            cache_status="missing",
+        ), ()
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        return StemModelAvailability(False, "Bundled Demucs model manifest is unreadable"), ()
+        return _demucs_cache_unavailable(
+            "Bundled Demucs model manifest is unreadable, so TuneForge cannot separate stems.",
+            cache_status="unreadable",
+        ), ()
 
     models = manifest.get("models")
     model_entry = models.get(model_id) if isinstance(models, dict) else None
     if not isinstance(model_entry, dict):
-        return StemModelAvailability(False, f"Bundled {model_id} manifest entry is missing"), ()
+        return _demucs_cache_unavailable(
+            f"Bundled {model_id} model cache is missing manifest data.",
+            cache_status="missing",
+        ), ()
 
     manifest_mode = model_entry.get("mode")
     if manifest_mode != STEM_MODELS[model_id].mode:
-        return StemModelAvailability(False, f"Bundled {model_id} manifest mode is invalid"), ()
+        return _demucs_cache_unavailable(
+            f"Bundled {model_id} model cache metadata is corrupt.",
+            cache_status="corrupt",
+        ), ()
 
     yaml_file = model_entry.get("yaml")
     if not isinstance(yaml_file, str) or Path(yaml_file).name != yaml_file:
-        return StemModelAvailability(False, f"Bundled {model_id} manifest yaml is invalid"), ()
+        return _demucs_cache_unavailable(
+            f"Bundled {model_id} model cache metadata is corrupt.",
+            cache_status="corrupt",
+        ), ()
 
     files = model_entry.get("files")
     if not isinstance(files, list):
-        return StemModelAvailability(False, f"Bundled {model_id} manifest files are invalid"), ()
+        return _demucs_cache_unavailable(
+            f"Bundled {model_id} model cache metadata is corrupt.",
+            cache_status="corrupt",
+        ), ()
 
     parsed_files: list[StemModelManifestFile] = []
     for file_entry in files:
         if not isinstance(file_entry, dict):
-            return StemModelAvailability(False, f"Bundled {model_id} manifest files are invalid"), ()
+            return _demucs_cache_unavailable(
+                f"Bundled {model_id} model cache metadata is corrupt.",
+                cache_status="corrupt",
+            ), ()
         name = file_entry.get("name")
         size_bytes = file_entry.get("size_bytes")
         sha256 = file_entry.get("sha256")
         if not isinstance(name, str) or not isinstance(size_bytes, int) or not isinstance(sha256, str):
-            return StemModelAvailability(False, f"Bundled {model_id} manifest files are invalid"), ()
+            return _demucs_cache_unavailable(
+                f"Bundled {model_id} model cache metadata is corrupt.",
+                cache_status="corrupt",
+            ), ()
         if Path(name).name != name:
-            return StemModelAvailability(False, f"Bundled {model_id} manifest files are invalid"), ()
+            return _demucs_cache_unavailable(
+                f"Bundled {model_id} model cache metadata is corrupt.",
+                cache_status="corrupt",
+            ), ()
         parsed_files.append(StemModelManifestFile(name=name, size_bytes=size_bytes, sha256=sha256))
 
     manifest_names = {file.name for file in parsed_files}
     if yaml_file not in manifest_names:
-        return StemModelAvailability(False, f"Bundled {model_id} manifest yaml is missing from files"), ()
+        return _demucs_cache_unavailable(
+            f"Bundled {model_id} model cache metadata is corrupt.",
+            cache_status="corrupt",
+        ), ()
 
     return StemModelAvailability(True), tuple(parsed_files)
 
@@ -146,11 +183,14 @@ def resolve_stem_model(
     model = STEM_MODELS[model_id]
     availability = stem_model_availability(model_id)
     if require_available and not availability.available:
-        raise AppError(
+        raise dependency_diagnostic_error(
             "STEM_MODEL_UNAVAILABLE",
             availability.unavailable_reason or f"{model.label} is unavailable.",
+            dependency="demucs",
+            operation="stem_separation",
+            remediation=availability.remediation or DEMUCS_DEPENDENCY_REMEDIATION,
             status_code=409,
-            details={"stem_model": model_id},
+            cache_status=availability.cache_status,
         )
     return model
 
@@ -181,39 +221,87 @@ def stem_model_availability(model_id: str) -> StemModelAvailability:
     repo = configured_stem_model_repo()
     if repo is None:
         if importlib.util.find_spec("demucs") is None:
-            return StemModelAvailability(False, "Demucs is not installed")
+            return StemModelAvailability(
+                False,
+                "Demucs is unavailable, so TuneForge cannot separate stems.",
+                DEMUCS_DEPENDENCY_REMEDIATION,
+            )
         return StemModelAvailability(True)
     if not repo.is_dir():
-        return StemModelAvailability(False, f"Bundled Demucs model repo is missing: {repo}")
+        return _demucs_cache_unavailable(
+            "Bundled Demucs model assets are missing, so TuneForge cannot separate stems.",
+            cache_status="missing",
+        )
 
     manifest_availability, manifest_files = _load_manifest_model_files(repo, model_id)
     if not manifest_availability.available:
         return manifest_availability
 
-    missing_files = [file.name for file in manifest_files if not (repo / file.name).is_file()]
+    missing_files: list[str] = []
+    unreadable_files: list[str] = []
+    for file in manifest_files:
+        try:
+            is_file = (repo / file.name).is_file()
+        except OSError:
+            unreadable_files.append(file.name)
+            continue
+        if not is_file:
+            missing_files.append(file.name)
+    if unreadable_files:
+        return _demucs_cache_unavailable(
+            f"Bundled {model_id} model cache is unreadable.",
+            cache_status="unreadable",
+        )
     if missing_files:
-        return StemModelAvailability(
-            False,
-            f"Bundled {model_id} files are missing: {', '.join(missing_files)}",
+        return _demucs_cache_unavailable(
+            f"Bundled {model_id} model cache is missing required files.",
+            cache_status="missing",
         )
-    wrong_size_files = [
-        file.name for file in manifest_files if (repo / file.name).stat().st_size != file.size_bytes
-    ]
+
+    wrong_size_files: list[str] = []
+    for file in manifest_files:
+        try:
+            actual_size = (repo / file.name).stat().st_size
+        except OSError:
+            unreadable_files.append(file.name)
+            continue
+        if actual_size != file.size_bytes:
+            wrong_size_files.append(file.name)
+    if unreadable_files:
+        return _demucs_cache_unavailable(
+            f"Bundled {model_id} model cache is unreadable.",
+            cache_status="unreadable",
+        )
     if wrong_size_files:
-        return StemModelAvailability(
-            False,
-            f"Bundled {model_id} files have unexpected sizes: {', '.join(wrong_size_files)}",
+        return _demucs_cache_unavailable(
+            f"Bundled {model_id} model cache is corrupt.",
+            cache_status="corrupt",
         )
-    wrong_hash_files = [
-        file.name for file in manifest_files if file_sha256(repo / file.name) != file.sha256
-    ]
+
+    wrong_hash_files: list[str] = []
+    for file in manifest_files:
+        actual_sha256 = file_sha256(repo / file.name)
+        if actual_sha256 is None:
+            unreadable_files.append(file.name)
+            continue
+        if actual_sha256 != file.sha256:
+            wrong_hash_files.append(file.name)
+    if unreadable_files:
+        return _demucs_cache_unavailable(
+            f"Bundled {model_id} model cache is unreadable.",
+            cache_status="unreadable",
+        )
     if wrong_hash_files:
-        return StemModelAvailability(
-            False,
-            f"Bundled {model_id} files have unexpected hashes: {', '.join(wrong_hash_files)}",
+        return _demucs_cache_unavailable(
+            f"Bundled {model_id} model cache is corrupt.",
+            cache_status="corrupt",
         )
     if importlib.util.find_spec("demucs") is None:
-        return StemModelAvailability(False, "Demucs is not installed")
+        return StemModelAvailability(
+            False,
+            "Demucs is unavailable, so TuneForge cannot separate stems.",
+            DEMUCS_DEPENDENCY_REMEDIATION,
+        )
     return StemModelAvailability(True)
 
 
@@ -226,6 +314,18 @@ def model_output_artifact_type(source: str) -> str:
 
 def stem_source_for_artifact_type(artifact_type: str) -> str | None:
     return STEM_ARTIFACT_TYPE_SOURCES.get(artifact_type)
+
+
+def _demucs_cache_unavailable(message: str, *, cache_status: str) -> StemModelAvailability:
+    if cache_status == "unreadable":
+        remediation = (
+            "Fix local cache permissions or re-run setup from an account that can read the model cache."
+        )
+    elif cache_status == "corrupt":
+        remediation = "Re-run local setup to replace Demucs model assets, then retry stem separation."
+    else:
+        remediation = DEMUCS_CACHE_REMEDIATION
+    return StemModelAvailability(False, message, remediation, cache_status)
 
 
 def _model_info(model: StemModelDefinition) -> dict[str, Any]:

--- a/apps/backend/app/utils/model_cache.py
+++ b/apps/backend/app/utils/model_cache.py
@@ -77,7 +77,16 @@ def sha256_file(path: Path) -> str:
 
 
 def _invalid_model_file(expected_file: ExpectedModelFile) -> InvalidModelFile | None:
-    if not expected_file.path.is_file():
+    try:
+        is_file = expected_file.path.is_file()
+    except OSError:
+        return InvalidModelFile(
+            label=expected_file.label,
+            path=expected_file.path,
+            reason="unreadable",
+            expected_size=expected_file.size,
+        )
+    if not is_file:
         return InvalidModelFile(
             label=expected_file.label,
             path=expected_file.path,
@@ -85,7 +94,15 @@ def _invalid_model_file(expected_file: ExpectedModelFile) -> InvalidModelFile | 
             expected_size=expected_file.size,
         )
 
-    actual_size = expected_file.path.stat().st_size
+    try:
+        actual_size = expected_file.path.stat().st_size
+    except OSError:
+        return InvalidModelFile(
+            label=expected_file.label,
+            path=expected_file.path,
+            reason="unreadable",
+            expected_size=expected_file.size,
+        )
     if actual_size != expected_file.size:
         return InvalidModelFile(
             label=expected_file.label,
@@ -95,7 +112,17 @@ def _invalid_model_file(expected_file: ExpectedModelFile) -> InvalidModelFile | 
             actual_size=actual_size,
         )
 
-    if sha256_file(expected_file.path) != expected_file.sha256:
+    try:
+        actual_sha256 = sha256_file(expected_file.path)
+    except OSError:
+        return InvalidModelFile(
+            label=expected_file.label,
+            path=expected_file.path,
+            reason="unreadable",
+            expected_size=expected_file.size,
+            actual_size=actual_size,
+        )
+    if actual_sha256 != expected_file.sha256:
         return InvalidModelFile(
             label=expected_file.label,
             path=expected_file.path,

--- a/apps/backend/tests/test_dependency_diagnostics.py
+++ b/apps/backend/tests/test_dependency_diagnostics.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+import builtins
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app.dependency_diagnostics import (
+    DEMUCS_DEPENDENCY_REMEDIATION,
+    HOST_FFMPEG_REMEDIATION,
+    WHISPER_DEPENDENCY_REMEDIATION,
+)
+from app.engines import lyrics, stems, transform
+from app.errors import AppError
+from app.services import metadata
+from app.services.stem_models import resolve_stem_model
+
+
+def test_missing_ffprobe_returns_host_tool_diagnostic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_path = tmp_path / "source.wav"
+    source_path.write_bytes(b"not inspected")
+
+    def fail_run(*_args: object, **_kwargs: object) -> object:
+        raise FileNotFoundError("ffprobe")
+
+    monkeypatch.setattr(metadata.subprocess, "run", fail_run)
+
+    with pytest.raises(AppError) as exc_info:
+        metadata.extract_audio_metadata(source_path)
+
+    assert exc_info.value.code == "DEPENDENCY_MISSING"
+    assert exc_info.value.message == (
+        "ffprobe is missing, so TuneForge cannot inspect audio metadata before import."
+    )
+    assert exc_info.value.details == {
+        "dependency": "ffprobe",
+        "operation": "metadata extraction",
+        "remediation": HOST_FFMPEG_REMEDIATION,
+    }
+
+
+def test_missing_ffmpeg_transform_returns_host_tool_diagnostic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_popen(*_args: object, **_kwargs: object) -> object:
+        raise FileNotFoundError("ffmpeg")
+
+    monkeypatch.setattr(transform.subprocess, "Popen", fail_popen)
+
+    with pytest.raises(AppError) as exc_info:
+        transform.run_ffmpeg_transform(
+            tmp_path / "source.wav",
+            tmp_path / "output.wav",
+            sample_rate=44_100,
+            total_cents=100.0,
+            output_format="wav",
+        )
+
+    assert exc_info.value.message == "ffmpeg is missing, so TuneForge cannot create transformed audio."
+    assert exc_info.value.details == {
+        "dependency": "ffmpeg",
+        "operation": "audio transform",
+        "remediation": HOST_FFMPEG_REMEDIATION,
+    }
+
+
+def test_demucs_worker_failure_reports_safe_cache_diagnostic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeDemucsProcess:
+        returncode = 1
+        stdout = None
+        stderr = None
+
+        def poll(self) -> int:
+            return self.returncode
+
+        def communicate(self) -> tuple[str, str]:
+            return "", "sha256 mismatch in /Users/private/.cache/torch/checkpoints/model.th"
+
+        def kill(self) -> None:
+            raise AssertionError("completed process should not be killed")
+
+    monkeypatch.setattr(stems.importlib.util, "find_spec", lambda _name: object())
+    monkeypatch.setattr(stems.subprocess, "Popen", lambda *_args, **_kwargs: FakeDemucsProcess())
+
+    with pytest.raises(AppError) as exc_info:
+        stems.separate_two_stems(
+            tmp_path / "source.wav",
+            tmp_path / "vocals.wav",
+            tmp_path / "instrumental.wav",
+            model="htdemucs_ft",
+        )
+
+    assert exc_info.value.message == "Demucs model cache is corrupt, so TuneForge cannot separate stems."
+    assert exc_info.value.details == {
+        "dependency": "demucs",
+        "operation": "stem separation",
+        "remediation": "Re-run local setup to replace Demucs model assets, then retry stem separation.",
+        "cache_status": "corrupt",
+    }
+    assert "/Users/private" not in str(exc_info.value.details)
+
+
+def test_demucs_worker_missing_torch_reports_dependency_diagnostic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeDemucsProcess:
+        returncode = 1
+        stdout = None
+        stderr = None
+
+        def poll(self) -> int:
+            return self.returncode
+
+        def communicate(self) -> tuple[str, str]:
+            return "", "ModuleNotFoundError: No module named 'torch'"
+
+        def kill(self) -> None:
+            raise AssertionError("completed process should not be killed")
+
+    monkeypatch.setattr(stems.importlib.util, "find_spec", lambda _name: object())
+    monkeypatch.setattr(stems.subprocess, "Popen", lambda *_args, **_kwargs: FakeDemucsProcess())
+
+    with pytest.raises(AppError) as exc_info:
+        stems.separate_two_stems(
+            tmp_path / "source.wav",
+            tmp_path / "vocals.wav",
+            tmp_path / "instrumental.wav",
+            model="htdemucs_ft",
+        )
+
+    assert exc_info.value.code == "DEPENDENCY_MISSING"
+    assert exc_info.value.message == "Demucs is unavailable, so TuneForge cannot separate stems."
+    assert exc_info.value.details == {
+        "dependency": "pytorch",
+        "operation": "stem separation",
+        "remediation": DEMUCS_DEPENDENCY_REMEDIATION,
+    }
+
+
+def test_whisper_missing_runtime_reports_safe_dependency_diagnostic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        lyrics.importlib.util,
+        "find_spec",
+        lambda module_name: object() if module_name == "torch" else None,
+    )
+
+    with pytest.raises(AppError) as exc_info:
+        lyrics.transcribe_project_lyrics_in_process(
+            tmp_path / "source.wav",
+            model_name="turbo",
+            requested_device="cpu",
+            download_root=tmp_path / "whisper-cache",
+        )
+
+    assert exc_info.value.message == "Whisper is unavailable, so TuneForge cannot generate lyrics."
+    assert exc_info.value.details == {
+        "dependency": "openai-whisper",
+        "operation": "lyrics generation",
+        "remediation": "Install the local backend lyrics dependencies, then retry lyrics generation.",
+    }
+
+
+def test_whisper_torch_import_failure_reports_dependency_diagnostic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_import = builtins.__import__
+
+    def fake_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if name == "torch":
+            raise ImportError("dlopen(/Users/private/libtorch.dylib): Library not loaded")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(lyrics.importlib.util, "find_spec", lambda _name: object())
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(AppError) as exc_info:
+        lyrics.transcribe_project_lyrics_in_process(
+            tmp_path / "source.wav",
+            model_name="turbo",
+            requested_device="cpu",
+            download_root=tmp_path / "whisper-cache",
+        )
+
+    assert exc_info.value.code == "DEPENDENCY_MISSING"
+    assert exc_info.value.details == {
+        "dependency": "pytorch",
+        "operation": "lyrics generation",
+        "remediation": WHISPER_DEPENDENCY_REMEDIATION,
+    }
+    assert "/Users/private" not in str(exc_info.value.details)
+
+
+def test_whisper_import_failure_reports_dependency_diagnostic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_import = builtins.__import__
+    fake_torch = SimpleNamespace()
+
+    def fake_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if name == "torch":
+            return fake_torch
+        if name == "whisper":
+            raise ModuleNotFoundError("No module named 'tiktoken'")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setattr(lyrics.importlib.util, "find_spec", lambda _name: object())
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(AppError) as exc_info:
+        lyrics.transcribe_project_lyrics_in_process(
+            tmp_path / "source.wav",
+            model_name="turbo",
+            requested_device="cpu",
+            download_root=tmp_path / "whisper-cache",
+        )
+
+    assert exc_info.value.code == "DEPENDENCY_MISSING"
+    assert exc_info.value.details == {
+        "dependency": "openai-whisper",
+        "operation": "lyrics generation",
+        "remediation": WHISPER_DEPENDENCY_REMEDIATION,
+    }
+
+
+def test_whisper_runtime_failure_reports_safe_cache_diagnostic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_torch = SimpleNamespace(
+        backends=SimpleNamespace(mps=SimpleNamespace(is_available=lambda: False)),
+        cuda=SimpleNamespace(is_available=lambda: False),
+    )
+
+    class FakeWhisper:
+        def load_model(self, *_args: object, **_kwargs: object) -> object:
+            raise RuntimeError("checksum mismatch in /Users/private/.cache/whisper/turbo.pt")
+
+    monkeypatch.setattr(lyrics, "_load_runtime", lambda: (fake_torch, FakeWhisper()))
+
+    with pytest.raises(AppError) as exc_info:
+        lyrics.transcribe_project_lyrics_in_process(
+            tmp_path / "source.wav",
+            model_name="turbo",
+            requested_device="cpu",
+            download_root=tmp_path / "whisper-cache",
+        )
+
+    assert exc_info.value.message == "Whisper model cache is corrupt, so TuneForge cannot generate lyrics."
+    assert exc_info.value.details == {
+        "dependency": "whisper",
+        "operation": "lyrics generation",
+        "remediation": "Re-run local setup to replace the Whisper model asset, then retry lyrics generation.",
+        "cache_status": "corrupt",
+    }
+    assert "/Users/private" not in str(exc_info.value.details)
+
+
+def test_lyrics_worker_dependency_payload_remains_dependency_diagnostic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeLyricsProcess:
+        returncode = 1
+        stdout = None
+        stderr = None
+
+        def poll(self) -> int:
+            return self.returncode
+
+        def communicate(self) -> tuple[str, str]:
+            return (
+                json.dumps(
+                    {
+                        "ok": False,
+                        "error": {
+                            "code": "DEPENDENCY_MISSING",
+                            "message": "Whisper is unavailable, so TuneForge cannot generate lyrics.",
+                            "status_code": 500,
+                            "details": {
+                                "dependency": "pytorch",
+                                "operation": "lyrics generation",
+                                "remediation": WHISPER_DEPENDENCY_REMEDIATION,
+                            },
+                        },
+                    }
+                ),
+                "private stderr should stay ignored",
+            )
+
+        def kill(self) -> None:
+            raise AssertionError("completed process should not be killed")
+
+    monkeypatch.setattr(lyrics.subprocess, "Popen", lambda *_args, **_kwargs: FakeLyricsProcess())
+
+    with pytest.raises(AppError) as exc_info:
+        lyrics.transcribe_project_lyrics(
+            tmp_path / "source.wav",
+            model_name="turbo",
+            requested_device="cpu",
+            download_root=tmp_path / "whisper-cache",
+        )
+
+    assert exc_info.value.code == "DEPENDENCY_MISSING"
+    assert exc_info.value.message == "Whisper is unavailable, so TuneForge cannot generate lyrics."
+    assert exc_info.value.details == {
+        "dependency": "pytorch",
+        "operation": "lyrics generation",
+        "remediation": WHISPER_DEPENDENCY_REMEDIATION,
+    }
+
+
+def test_configured_demucs_cache_error_details_use_safe_fields(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TUNEFORGE_DEMUCS_MODEL_REPO", str(tmp_path / "missing-demucs"))
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+
+    with pytest.raises(AppError) as exc_info:
+        resolve_stem_model("htdemucs_6s", require_available=True)
+
+    assert exc_info.value.message == (
+        "Bundled Demucs model assets are missing, so TuneForge cannot separate stems."
+    )
+    assert exc_info.value.details == {
+        "dependency": "demucs",
+        "operation": "stem separation",
+        "remediation": "Re-run local setup to download Demucs model assets, then retry stem separation.",
+        "cache_status": "missing",
+    }
+    assert str(tmp_path) not in str(exc_info.value.details)

--- a/apps/backend/tests/test_stem_flow.py
+++ b/apps/backend/tests/test_stem_flow.py
@@ -11,8 +11,9 @@ from sqlalchemy.exc import IntegrityError
 
 from app.config import get_settings
 from app.db import SessionLocal
+from app.dependency_diagnostics import demucs_dependency_missing_error
 from app.engines.stem_signal import STEM_SIGNAL_THRESHOLDS
-from app.errors import AppError, JobCancelledError
+from app.errors import JobCancelledError
 from app.models import Artifact, Job
 from app.services.artifacts import register_artifact
 from app.services.projects import get_project, import_project
@@ -1358,7 +1359,7 @@ def test_stem_artifact_unique_constraint_rejects_duplicates(client, sample_stere
 
 def test_stem_generation_reports_missing_dependency(client, sample_stereo_audio_file: Path, monkeypatch):
     def fake_separate_two_stems(*args, **kwargs):
-        raise AppError("DEPENDENCY_MISSING", "Demucs is required for stem separation.")
+        raise demucs_dependency_missing_error()
 
     monkeypatch.setattr("app.services.stems.separate_two_stems", fake_separate_two_stems)
 
@@ -1373,7 +1374,10 @@ def test_stem_generation_reports_missing_dependency(client, sample_stereo_audio_
     ).json()["job"]
     final_job = wait_for_job(client, stem_job["id"])
     assert final_job["status"] == "failed"
-    assert final_job["error_message"] == "Demucs is required for stem separation."
+    assert final_job["error_message"] == (
+        "Demucs is unavailable, so TuneForge cannot separate stems. "
+        "Next: Install the local backend stem dependencies, then retry stem separation."
+    )
 
 
 def test_running_stem_cancel_after_subprocess_exit_marks_job_cancelled(

--- a/apps/backend/tests/test_stem_models.py
+++ b/apps/backend/tests/test_stem_models.py
@@ -91,18 +91,18 @@ def test_configured_missing_model_repo_fails_stem_job(client, sample_stereo_audi
     monkeypatch.setenv("TUNEFORGE_DEMUCS_MODEL_REPO", str(tmp_path / "missing-demucs"))
     get_settings.cache_clear()
 
-    project = client.post(
-        "/api/v1/projects/import",
-        json={"source_path": str(sample_stereo_audio_file), "copy_into_project": True},
-    ).json()["project"]
+    project_id = _create_project_without_import_jobs(sample_stereo_audio_file)
     stem_job = client.post(
-        f"/api/v1/projects/{project['id']}/stems",
+        f"/api/v1/projects/{project_id}/stems",
         json={"mode": "stems", "stem_model": "htdemucs_6s", "output_format": "wav"},
     ).json()["job"]
     final_job = wait_for_job(client, stem_job["id"])
 
     assert final_job["status"] == "failed"
-    assert "Bundled Demucs model repo is missing" in final_job["error_message"]
+    assert final_job["error_message"] == (
+        "Bundled Demucs model assets are missing, so TuneForge cannot separate stems. "
+        "Next: Re-run local setup to download Demucs model assets, then retry stem separation."
+    )
 
 
 def test_configured_model_repo_requires_manifest(client, sample_stereo_audio_file, tmp_path, monkeypatch):
@@ -113,18 +113,18 @@ def test_configured_model_repo_requires_manifest(client, sample_stereo_audio_fil
     monkeypatch.setenv("TUNEFORGE_DEMUCS_MODEL_REPO", str(repo))
     get_settings.cache_clear()
 
-    project = client.post(
-        "/api/v1/projects/import",
-        json={"source_path": str(sample_stereo_audio_file), "copy_into_project": True},
-    ).json()["project"]
+    project_id = _create_project_without_import_jobs(sample_stereo_audio_file)
     stem_job = client.post(
-        f"/api/v1/projects/{project['id']}/stems",
+        f"/api/v1/projects/{project_id}/stems",
         json={"mode": "stems", "stem_model": "htdemucs_6s", "output_format": "wav"},
     ).json()["job"]
     final_job = wait_for_job(client, stem_job["id"])
 
     assert final_job["status"] == "failed"
-    assert final_job["error_message"] == "Bundled Demucs model manifest is missing"
+    assert final_job["error_message"] == (
+        "Bundled Demucs model manifest is missing, so TuneForge cannot separate stems. "
+        "Next: Re-run local setup to download Demucs model assets, then retry stem separation."
+    )
 
 
 def test_configured_model_repo_checks_manifest_sizes(client, sample_stereo_audio_file, tmp_path, monkeypatch):
@@ -136,18 +136,18 @@ def test_configured_model_repo_checks_manifest_sizes(client, sample_stereo_audio
     monkeypatch.setenv("TUNEFORGE_DEMUCS_MODEL_REPO", str(repo))
     get_settings.cache_clear()
 
-    project = client.post(
-        "/api/v1/projects/import",
-        json={"source_path": str(sample_stereo_audio_file), "copy_into_project": True},
-    ).json()["project"]
+    project_id = _create_project_without_import_jobs(sample_stereo_audio_file)
     stem_job = client.post(
-        f"/api/v1/projects/{project['id']}/stems",
+        f"/api/v1/projects/{project_id}/stems",
         json={"mode": "stems", "stem_model": "htdemucs_6s", "output_format": "wav"},
     ).json()["job"]
     final_job = wait_for_job(client, stem_job["id"])
 
     assert final_job["status"] == "failed"
-    assert final_job["error_message"] == "Bundled htdemucs_6s files have unexpected sizes: htdemucs_6s.yaml"
+    assert final_job["error_message"] == (
+        "Bundled htdemucs_6s model cache is corrupt. "
+        "Next: Re-run local setup to replace Demucs model assets, then retry stem separation."
+    )
 
 
 def test_configured_model_repo_checks_manifest_hashes(client, sample_stereo_audio_file, tmp_path, monkeypatch):
@@ -159,18 +159,18 @@ def test_configured_model_repo_checks_manifest_hashes(client, sample_stereo_audi
     monkeypatch.setenv("TUNEFORGE_DEMUCS_MODEL_REPO", str(repo))
     get_settings.cache_clear()
 
-    project = client.post(
-        "/api/v1/projects/import",
-        json={"source_path": str(sample_stereo_audio_file), "copy_into_project": True},
-    ).json()["project"]
+    project_id = _create_project_without_import_jobs(sample_stereo_audio_file)
     stem_job = client.post(
-        f"/api/v1/projects/{project['id']}/stems",
+        f"/api/v1/projects/{project_id}/stems",
         json={"mode": "stems", "stem_model": "htdemucs_6s", "output_format": "wav"},
     ).json()["job"]
     final_job = wait_for_job(client, stem_job["id"])
 
     assert final_job["status"] == "failed"
-    assert final_job["error_message"] == "Bundled htdemucs_6s files have unexpected hashes: htdemucs_6s.yaml"
+    assert final_job["error_message"] == (
+        "Bundled htdemucs_6s model cache is corrupt. "
+        "Next: Re-run local setup to replace Demucs model assets, then retry stem separation."
+    )
 
 
 def _write_six_stem_manifest(

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -3919,6 +3919,32 @@ describe("Desktop app activity", () => {
     expect(within(cancelledRow).getByText("advanced / source")).toBeInTheDocument();
   });
 
+  it("shows dependency job errors without raw output or paths", async () => {
+    setJobs([
+      job({
+        id: "job_stems_missing_demucs",
+        project_id: "proj_123",
+        type: "stems",
+        status: "failed",
+        progress: 45,
+        error_message: "Demucs is required for stem separation. stderr: /Users/test/Music/Secret Demo.wav",
+        stem_model: "htdemucs_6s",
+        stem_model_label: "Default (6 stems model)",
+        created_at: "2026-04-18T13:21:00.000Z",
+        updated_at: "2026-04-18T13:23:00.000Z",
+      }),
+    ]);
+
+    renderApp(["/activity"]);
+
+    const row = await screen.findByRole("article", { name: "stems failed job" });
+    const alert = within(row).getByRole("alert");
+    expect(alert).toHaveTextContent(
+      "Demucs is required for stem separation. Dependency: Demucs. Next: Install local backend stem dependencies, then retry stem separation.",
+    );
+    expect(alert).not.toHaveTextContent(/stderr|Secret Demo|Users|\.wav/i);
+  });
+
   it("renders old jobs with null stage and runtime fields", async () => {
     setJobs([
       job({

--- a/apps/desktop/src/App.library.test.tsx
+++ b/apps/desktop/src/App.library.test.tsx
@@ -492,7 +492,7 @@ describe("Desktop app library", () => {
     expect(mockGetProject).not.toHaveBeenCalled();
   });
 
-  it("summarizes failed batch imports with file and error details", async () => {
+  it("summarizes failed batch imports with error details", async () => {
     const user = userEvent.setup();
     mockOpen.mockResolvedValue(["/tmp/broken.wav", "/tmp/new-song.wav"]);
     mockImportProject.mockRejectedValueOnce(new Error("Unsupported codec."));
@@ -506,10 +506,43 @@ describe("Desktop app library", () => {
     const summary = await screen.findByRole("status");
     expect(
       within(summary).getByText(
-        "1 track imported, 0 duplicates skipped, 1 failed. Failed: /tmp/broken.wav: Unsupported codec.",
+        "1 track imported, 0 duplicates skipped, 1 failed. Failed: Unsupported codec.",
       ),
     ).toBeInTheDocument();
     expect(mockGetProject).not.toHaveBeenCalled();
+  });
+
+  it("summarizes dependency batch failures without raw output or paths", async () => {
+    const user = userEvent.setup();
+    mockOpen.mockResolvedValue(["/Users/test/Music/Secret Demo.wav", "/tmp/new-song.wav"]);
+    mockImportProject.mockRejectedValueOnce(
+      Object.assign(
+        new Error(
+          "ffmpeg is required to normalize imported audio. stderr: /Users/test/Music/Secret Demo.wav",
+        ),
+        {
+          code: "DEPENDENCY_MISSING",
+          details: {
+            dependency: "ffmpeg",
+            dependency_kind: "host_tool",
+            local_action: "Install FFmpeg and ensure ffmpeg is on PATH",
+            operation: "normalize imported audio",
+          },
+        },
+      ),
+    );
+
+    renderApp(["/"]);
+
+    expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Import Track(s)" }));
+
+    await waitFor(() => expect(mockImportProject).toHaveBeenCalledTimes(2));
+    const summary = await screen.findByRole("status");
+    expect(summary).toHaveTextContent(
+      "1 track imported, 0 duplicates skipped, 1 failed. Failed: ffmpeg is required to normalize imported audio. Host tool: ffmpeg. Next: Install FFmpeg and ensure ffmpeg is on PATH.",
+    );
+    expect(summary).not.toHaveTextContent(/stderr|Secret Demo|Users|\.wav/i);
   });
 
   it("shows duplicate import warning with a link to the existing project", async () => {
@@ -582,6 +615,37 @@ describe("Desktop app library", () => {
 
     await waitFor(() => expect(mockGetProject).toHaveBeenCalledWith("proj_123"));
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+  });
+
+  it("shows dependency import errors without raw output or paths", async () => {
+    const user = userEvent.setup();
+    mockOpen.mockResolvedValue("/Users/test/Music/Secret Demo.wav");
+    mockImportProject.mockRejectedValueOnce(
+      Object.assign(
+        new Error("ffprobe is required for metadata extraction. stdout: /Users/test/Music/Secret Demo.wav"),
+        {
+          code: "DEPENDENCY_MISSING",
+          details: {
+            dependency: "ffprobe",
+            dependency_kind: "host_tool",
+            local_action: "Install FFmpeg and ensure ffprobe is on PATH",
+            operation: "metadata extraction",
+          },
+        },
+      ),
+    );
+
+    renderApp(["/"]);
+
+    expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Import Track(s)" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(
+      "Could not import track. ffprobe is required for metadata extraction. Host tool: ffprobe. Next: Install FFmpeg and ensure ffprobe is on PATH.",
+    );
+    expect(alert).not.toHaveTextContent(/stdout|Secret Demo|Users|\.wav/i);
+    expect(within(alert).queryByRole("link", { name: "Open project" })).not.toBeInTheDocument();
   });
 
   it("uses the selected default chord backend and stem model when importing a track", async () => {

--- a/apps/desktop/src/App.project-playback-artifacts.test.tsx
+++ b/apps/desktop/src/App.project-playback-artifacts.test.tsx
@@ -254,6 +254,36 @@ describe("Desktop app project playback artifacts", () => {
     expect(jobHistory).not.toHaveTextContent(/stderr|song\.wav|ETA/i);
   });
 
+  it("shows dependency job history errors without raw output or paths", async () => {
+    const user = userEvent.setup();
+    setJobs([
+      {
+        id: "job_stems_missing_demucs",
+        project_id: "proj_123",
+        type: "stems",
+        status: "failed",
+        progress: 15,
+        source_artifact_id: "art_source",
+        error_message: "Demucs is required for stem separation. stderr: /Users/test/Music/Secret Demo.wav",
+        created_at: "2026-04-18T13:16:00.000Z",
+        updated_at: "2026-04-18T13:16:00.000Z",
+      },
+    ]);
+
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openAnalysisPanel(user);
+    await user.click(screen.getByText("Show raw artifacts and processing history"));
+    await expectProjectJobsRequested("proj_123");
+
+    const jobHistory = getJobsHistoryDetails();
+    expect(jobHistory).toHaveTextContent(
+      "Demucs is required for stem separation. Dependency: Demucs. Next: Install local backend stem dependencies, then retry stem separation.",
+    );
+    expect(jobHistory).not.toHaveTextContent(/stderr|Secret Demo|Users|\.wav/i);
+  });
+
   it("loads later project terminal job pages with scoped filters", async () => {
     const user = userEvent.setup();
     setJobs([

--- a/apps/desktop/src/features/activity/ActivityView.tsx
+++ b/apps/desktop/src/features/activity/ActivityView.tsx
@@ -11,6 +11,7 @@ import { useBeatBackendActionSelection } from "../projects/hooks/useBeatBackendA
 import { useChordBackendActionSelection } from "../projects/hooks/useChordBackendActionSelection";
 import {
   formatJobProgressValue,
+  formatJobErrorMessage,
   formatJobRuntimeSummary,
   formatJobStageLabel,
   formatJobStatusSummary,
@@ -292,6 +293,7 @@ function JobRow({
   const stageLabel = formatJobStageLabel(job);
   const runtimeSummary = stageLabel ? formatJobRuntimeSummary(job) : null;
   const details = formatJobDetails(job, { includeRuntimeDevice: !runtimeSummary });
+  const errorMessage = formatJobErrorMessage(job.error_message, job);
   const progress = formatJobProgressValue(job);
   const canCancel = CANCELABLE_JOB_STATUSES.has(job.status);
   const stageTone = TERMINAL_JOB_STATUSES.has(job.status) ? "terminal" : "active";
@@ -348,9 +350,9 @@ function JobRow({
 
         <JobTimestamps job={job} />
 
-        {job.error_message ? (
+        {errorMessage ? (
           <p className="activity-job-row__error" role="alert">
-            {job.error_message}
+            {errorMessage}
           </p>
         ) : null}
       </article>

--- a/apps/desktop/src/features/projects/LibraryView.tsx
+++ b/apps/desktop/src/features/projects/LibraryView.tsx
@@ -7,6 +7,7 @@ import { api, getProjectSyncSummary, type ProjectSchema } from "../../lib/api";
 import { formatLocalDateTime, normalizeApiDateTime } from "../../lib/datetime";
 import { usePreferences } from "../../lib/preferences";
 import { useLazyLoadSentinel } from "../../lib/useLazyLoadSentinel";
+import { formatApiErrorMessage } from "./projectViewUtils";
 import { useBeatBackendActionSelection } from "./hooks/useBeatBackendActionSelection";
 import { useChordBackendActionSelection } from "./hooks/useChordBackendActionSelection";
 
@@ -117,7 +118,7 @@ type ImportNotice =
   | { kind: "error"; message: string };
 
 type BatchImportSummary = {
-  failures: Array<{ message: string; sourcePath: string }>;
+  failures: Array<{ message: string }>;
   importedCount: number;
   skippedCount: number;
   failedCount: number;
@@ -172,7 +173,7 @@ function formatBatchFailureSummary(failures: BatchImportSummary["failures"]) {
   const visibleFailures = failures.slice(0, 3);
   const hiddenFailureCount = failures.length - visibleFailures.length;
   const failureSummary = visibleFailures
-    .map((failure) => `${failure.sourcePath}: ${trimTrailingPeriod(failure.message)}`)
+    .map((failure) => trimTrailingPeriod(failure.message))
     .join("; ");
   return ` Failed: ${failureSummary}${hiddenFailureCount ? `; and ${hiddenFailureCount} more` : ""}.`;
 }
@@ -222,8 +223,7 @@ function getImportErrorNotice(error: unknown): ImportNotice {
 }
 
 function getImportErrorMessage(error: unknown) {
-  const message = error instanceof Error && error.message.trim() ? error.message.trim() : "The request failed.";
-  return message;
+  return formatApiErrorMessage(error);
 }
 
 function getImportNoticeClassName(importNotice: ImportNotice) {
@@ -336,7 +336,7 @@ export function LibraryView() {
             skippedCount += 1;
           } else {
             failedCount += 1;
-            failures.push({ sourcePath, message: getImportErrorMessage(error) });
+            failures.push({ message: getImportErrorMessage(error) });
           }
         }
       }

--- a/apps/desktop/src/features/projects/components/JobsHistory.tsx
+++ b/apps/desktop/src/features/projects/components/JobsHistory.tsx
@@ -4,6 +4,7 @@ import {
   artifactSummary,
   formatArtifactTimestamp,
   formatJobProgressValue,
+  formatJobErrorMessage,
   formatJobStageLabel,
   formatJobStatusSummary,
 } from "../projectViewUtils";
@@ -78,6 +79,7 @@ export function JobsHistory() {
               {hasJobs
                 ? visibleJobs.map((job) => {
                     const progress = formatJobProgressValue(job);
+                    const errorMessage = formatJobErrorMessage(job.error_message, job);
                     const stageLabel = formatJobStageLabel(job);
                     return (
                       <li key={job.id}>
@@ -88,9 +90,7 @@ export function JobsHistory() {
                         </div>
                         <progress aria-label={`${job.type} job progress`} max={100} value={progress} />
                         <small>{formatArtifactTimestamp(job.completed_at ?? job.updated_at)}</small>
-                        {job.error_message ? (
-                          <small className="inline-error">{job.error_message}</small>
-                        ) : null}
+                        {errorMessage ? <small className="inline-error">{errorMessage}</small> : null}
                       </li>
                     );
                   })

--- a/apps/desktop/src/features/projects/components/PlaybackPracticeSurface.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackPracticeSurface.tsx
@@ -3,6 +3,7 @@ import { MusicalChordLabel } from "../../../components/MusicalLabel";
 import type { TabSuggestionGroupSchema, TabSuggestionSchema } from "../../../lib/api";
 import type { LeadSheetChord, LeadSheetLyricsRow, LeadSheetRow } from "../projectViewUtils";
 import {
+  formatJobErrorMessage,
   formatPlaybackClock,
   hasTimedLyrics,
 } from "../projectViewUtils";
@@ -476,6 +477,8 @@ function LyricsPracticePanel() {
     return <LyricsEditor />;
   }
 
+  const lyricsErrorMessage = formatJobErrorMessage(lyricsJob?.error_message, lyricsJob);
+
   return (
     <div className="playback-practice-body">
       {hasLyricsTranscript ? (
@@ -530,10 +533,9 @@ function LyricsPracticePanel() {
             : "Lyrics could not be saved."}
         </p>
       ) : null}
-      {lyricsJob?.error_message ? <p className="inline-error">{lyricsJob.error_message}</p> : null}
+      {lyricsErrorMessage ? <p className="inline-error">{lyricsErrorMessage}</p> : null}
     </div>
   );
-
 }
 
 function LyricsEditor() {
@@ -615,6 +617,7 @@ function ChordsPracticePanel() {
     showSupportingCopy,
   } = useProjectViewModelContext();
   const handlePracticeTargetSpacePlayback = usePracticeTargetSpacePlayback();
+  const chordErrorMessage = formatJobErrorMessage(chordJob?.error_message, chordJob);
 
   return (
     <div className="playback-practice-body playback-practice-body--chords">
@@ -716,7 +719,7 @@ function ChordsPracticePanel() {
           <span className="artifact-meta">Follow keeps the active chord in view while playback moves.</span>
         </div>
       ) : null}
-      {chordJob?.error_message ? <p className="inline-error">{chordJob.error_message}</p> : null}
+      {chordErrorMessage ? <p className="inline-error">{chordErrorMessage}</p> : null}
     </div>
   );
 }
@@ -739,6 +742,8 @@ function CombinedLeadSheetPanel() {
   if (isEditingLyrics) {
     return <LyricsPracticePanel />;
   }
+
+  const lyricsErrorMessage = formatJobErrorMessage(lyricsJob?.error_message, lyricsJob);
 
   return (
     <div className="playback-practice-body">
@@ -789,7 +794,7 @@ function CombinedLeadSheetPanel() {
             : "Lyrics could not be saved."}
         </p>
       ) : null}
-      {lyricsJob?.error_message ? <p className="inline-error">{lyricsJob.error_message}</p> : null}
+      {lyricsErrorMessage ? <p className="inline-error">{lyricsErrorMessage}</p> : null}
     </div>
   );
 }

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -66,6 +66,7 @@ import {
   findActiveLyricsWordIndex,
   formatArtifactTimestamp,
   formatCapoShiftSummary,
+  formatJobErrorMessage,
   formatRetuneSummary,
   formatSemitoneShift,
   formatTargetSelectionSummary,
@@ -936,7 +937,7 @@ export function useProjectViewModel() {
   const hasVisibleStems = visibleStemArtifacts.length > 0;
   const stemErrorMessage =
     stemJob?.error_message && !dismissedStemJobIds.includes(stemJob.id)
-      ? stemJob.error_message
+      ? formatJobErrorMessage(stemJob.error_message, stemJob)
       : null;
   const visibleJobs = projectJobs;
   const tuningSummary = formatRetuneSummary(retuneMode, referenceHz, centsOffset);

--- a/apps/desktop/src/features/projects/projectViewUtils.test.ts
+++ b/apps/desktop/src/features/projects/projectViewUtils.test.ts
@@ -3,6 +3,8 @@ import type { ChordSegmentSchema, JobSchema, LyricsSegmentSchema } from "../../l
 import {
   buildLeadSheetRows,
   findActiveLyricsIndex,
+  formatApiErrorMessage,
+  formatJobErrorMessage,
   formatJobRuntimeSummary,
   formatJobStageLabel,
   formatJobStatusSummary,
@@ -400,6 +402,74 @@ describe("formatJobRuntimeSummary", () => {
         }),
       ),
     ).toBe("CPU");
+  });
+});
+
+describe("dependency diagnostic formatting", () => {
+  it("marks host-tool import errors and removes raw output", () => {
+    const error = Object.assign(
+      new Error("ffmpeg is required to normalize imported audio. stderr: /Users/test/Music/Secret Demo.wav"),
+      {
+        code: "DEPENDENCY_MISSING",
+        details: {
+          dependency: "ffmpeg",
+          dependency_kind: "host_tool",
+          local_action: "Install FFmpeg and ensure ffmpeg is on PATH",
+          operation: "normalize imported audio",
+        },
+      },
+    );
+
+    const formatted = formatApiErrorMessage(error);
+
+    expect(formatted).toBe(
+      "ffmpeg is required to normalize imported audio. Host tool: ffmpeg. Next: Install FFmpeg and ensure ffmpeg is on PATH.",
+    );
+    expect(formatted).not.toMatch(/stderr|Secret Demo|Users|\.wav/i);
+  });
+
+  it("formats snake-case diagnostic operations as plain text", () => {
+    const error = Object.assign(new Error("ffmpeg is missing, so TuneForge cannot create output."), {
+      code: "DEPENDENCY_MISSING",
+      details: {
+        dependency: "ffmpeg",
+        operation: "audio_transform",
+        remediation: "Install FFmpeg locally and make sure this host-installed tool is available on PATH.",
+      },
+    });
+
+    expect(formatApiErrorMessage(error)).toBe(
+      "ffmpeg is missing, so TuneForge cannot create output. Host tool: ffmpeg. Operation: audio transform. Next: Install FFmpeg locally and make sure this host-installed tool is available on PATH.",
+    );
+  });
+
+  it("marks runtime dependency job errors and removes raw output", () => {
+    const formatted = formatJobErrorMessage(
+      "Demucs is required for stem separation. stderr: /Users/test/Music/Secret Demo.wav",
+      testJob({ type: "stems" }),
+    );
+
+    expect(formatted).toBe(
+      "Demucs is required for stem separation. Dependency: Demucs. Next: Install local backend stem dependencies, then retry stem separation.",
+    );
+    expect(formatted).not.toMatch(/stderr|Secret Demo|Users|\.wav/i);
+  });
+
+  it("keeps cache-specific job next actions when state is known", () => {
+    expect(
+      formatJobErrorMessage(
+        "Whisper model cache is unreadable, so TuneForge cannot generate lyrics.",
+        testJob({ type: "lyrics" }),
+      ),
+    ).toBe(
+      "Whisper model cache is unreadable, so TuneForge cannot generate lyrics. Model/cache: Whisper. Next: Fix local cache permissions or re-run setup from an account that can read the model cache.",
+    );
+  });
+
+  it("keeps non-dependency job errors unchanged", () => {
+    expect(formatJobErrorMessage("Could not finish stems.", testJob({ type: "stems" }))).toBe(
+      "Could not finish stems.",
+    );
   });
 });
 

--- a/apps/desktop/src/features/projects/projectViewUtils.ts
+++ b/apps/desktop/src/features/projects/projectViewUtils.ts
@@ -141,6 +141,7 @@ type FormatJobStatusSummaryOptions = {
 
 const RUNTIME_LABEL_LIMIT = 160;
 const RUNTIME_DETAIL_LIMIT = 240;
+const DIAGNOSTIC_TEXT_LIMIT = 320;
 const SAFE_RUNTIME_DETAIL_PHRASES = new Set([
   "CPU fallback after accelerator became unavailable.",
   "CUDA failed, retrying CPU.",
@@ -151,6 +152,43 @@ const SAFE_RUNTIME_DETAIL_PHRASES = new Set([
   "Whisper switched to CPU because the requested accelerator is unavailable.",
   "Whisper switched to a smaller model after CUDA memory pressure.",
 ]);
+
+type DependencyDiagnosticKind = "host_tool" | "model_cache" | "dependency";
+
+type DependencyDiagnosticInput = {
+  code?: string | null;
+  details?: unknown;
+  fallbackOperation?: string | null;
+  message: string | null | undefined;
+};
+
+const DETAIL_DEPENDENCY_KEYS = ["dependency", "tool", "package", "backend"] as const;
+const DETAIL_MODEL_KEYS = ["model"] as const;
+const DETAIL_KIND_KEYS = ["dependency_kind", "dependency_type", "diagnostic_kind"] as const;
+const DETAIL_OPERATION_KEYS = ["operation", "affected_operation", "context"] as const;
+const DETAIL_ACTION_KEYS = [
+  "local_action",
+  "next_action",
+  "recovery_hint",
+  "action",
+  "guidance",
+  "remediation",
+] as const;
+const OPERATION_LABELS: Record<string, string> = {
+  audio_import_normalization: "audio import normalization",
+  audio_transform: "audio transform",
+  lyrics_transcription: "lyrics generation",
+  metadata_extraction: "metadata extraction",
+  stem_separation: "stem separation",
+};
+const OPERATION_MESSAGE_PATTERNS: Record<string, RegExp> = {
+  "audio import normalization": /\b(audio import normalization|normalize imported audio)\b/i,
+  "audio transform": /\b(audio transform|create transformed audio|transformed audio)\b/i,
+  "lyrics generation": /\b(lyrics generation|lyrics transcription|generate lyrics)\b/i,
+  "metadata extraction": /\b(metadata extraction|inspect audio metadata)\b/i,
+  "stem separation": /\b(stem separation|separate stems)\b/i,
+};
+
 export function formatJobRuntimeDevice(device: string | null | undefined) {
   const trimmed = typeof device === "string" ? device.trim() : "";
   return trimmed ? trimmed.toUpperCase() : null;
@@ -188,6 +226,341 @@ function formatSafeRuntimeText(value: string | null | undefined, limit: number) 
     return null;
   }
   return normalized;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function formatDiagnosticText(value: string | null | undefined, limit = DIAGNOSTIC_TEXT_LIMIT) {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  if (!trimmed || hasControlCharacter(trimmed)) {
+    return null;
+  }
+
+  let normalized = trimmed.replace(/\s+/g, " ");
+  const rawOutputIndex = normalized.search(/\b(stdout|stderr|traceback|stack trace)\b/i);
+  if (rawOutputIndex >= 0) {
+    normalized = normalized.slice(0, rawOutputIndex).trim();
+  }
+
+  normalized = normalized.replace(/\bfile:\/\/[^\s,;)"']+/gi, "[redacted path]");
+  normalized = normalized.replace(/\b[A-Za-z]:\\[^\s,;)"']+/g, "[redacted path]");
+  normalized = normalized.replace(
+    /(^|[\s(["'])\/(?:Users|home|private|tmp|var|Volumes|[^/\s]+\/)[^\s,;)"']+/g,
+    (_match, prefix: string) => `${prefix}[redacted path]`,
+  );
+  normalized = normalized.replace(
+    /\b[^\s\\/]+\.(wav|mp3|flac|m4a|aac|ogg|mp4|webm)\b/gi,
+    "[redacted file]",
+  );
+  normalized = normalized.replace(/\s+/g, " ").trim();
+
+  if (!normalized) {
+    return null;
+  }
+  return normalized.length > limit ? `${normalized.slice(0, limit - 3).trimEnd()}...` : normalized;
+}
+
+function detailText(details: unknown, keys: readonly string[]) {
+  if (!isRecord(details)) {
+    return null;
+  }
+  for (const key of keys) {
+    const value = details[key];
+    if (typeof value === "string") {
+      const formatted = formatDiagnosticText(value, 160);
+      if (formatted) {
+        return formatted;
+      }
+    }
+  }
+  return null;
+}
+
+function operationLabel(value: string) {
+  const normalized = value.trim().replace(/\s+/g, " ");
+  const key = normalized.toLowerCase().replace(/\s+/g, "_");
+  return OPERATION_LABELS[key] ?? normalized.replace(/_/g, " ");
+}
+
+function detailOperationText(details: unknown) {
+  const operation = detailText(details, DETAIL_OPERATION_KEYS);
+  return operation ? operationLabel(operation) : null;
+}
+
+function dependencyFromMessage(message: string | null | undefined) {
+  const normalized = message?.toLowerCase() ?? "";
+  if (/\bffprobe\b/.test(normalized)) {
+    return "ffprobe";
+  }
+  if (/\bffmpeg\b/.test(normalized)) {
+    return "ffmpeg";
+  }
+  if (/\bopenai-whisper\b/.test(normalized)) {
+    return "openai-whisper";
+  }
+  if (/\bwhisper\b/.test(normalized)) {
+    return "Whisper";
+  }
+  if (/\bdemucs\b/.test(normalized)) {
+    return "Demucs";
+  }
+  if (/\bbeat-this\b/.test(normalized)) {
+    return "beat-this";
+  }
+  if (/\bcrema\b|\badvanced chords\b/.test(normalized)) {
+    return "Advanced Chords";
+  }
+  if (/\btensorflow\b/.test(normalized)) {
+    return "TensorFlow";
+  }
+  if (/\bkeras\b/.test(normalized)) {
+    return "Keras";
+  }
+  return null;
+}
+
+function operationFromMessage(
+  message: string | null | undefined,
+  fallbackOperation: string | null | undefined,
+): string | null {
+  const normalized = message?.toLowerCase() ?? "";
+  if (normalized.includes("metadata extraction")) {
+    return "metadata extraction";
+  }
+  if (normalized.includes("normalize imported audio")) {
+    return "audio import normalization";
+  }
+  if (normalized.includes("stem separation")) {
+    return "stem separation";
+  }
+  if (normalized.includes("lyrics generation") || normalized.includes("lyrics transcription")) {
+    return "lyrics generation";
+  }
+  if (normalized.includes("advanced beat analysis")) {
+    return "advanced beat analysis";
+  }
+  if (normalized.includes("chord")) {
+    return "chord detection";
+  }
+  return fallbackOperation ?? null;
+}
+
+function dependencyKind(
+  dependency: string | null,
+  message: string | null | undefined,
+  details: unknown,
+): DependencyDiagnosticKind {
+  const explicitKind = detailText(details, DETAIL_KIND_KEYS)?.toLowerCase() ?? "";
+  if (/\b(host|tool|binary|path)\b/.test(explicitKind)) {
+    return "host_tool";
+  }
+  if (/\b(model|cache|checkpoint|download)\b/.test(explicitKind)) {
+    return "model_cache";
+  }
+
+  const normalizedDependency = dependency?.toLowerCase() ?? "";
+  if (normalizedDependency === "ffmpeg" || normalizedDependency === "ffprobe") {
+    return "host_tool";
+  }
+
+  const normalizedMessage = message?.toLowerCase() ?? "";
+  if (
+    /\b(model|cache|checkpoint|download|prewarm)\b/.test(normalizedMessage)
+  ) {
+    return "model_cache";
+  }
+  return "dependency";
+}
+
+function dependencyKindLabel(kind: DependencyDiagnosticKind) {
+  switch (kind) {
+    case "host_tool":
+      return "Host tool";
+    case "model_cache":
+      return "Model/cache";
+    default:
+      return "Dependency";
+  }
+}
+
+function defaultDependencyAction(dependency: string | null, kind: DependencyDiagnosticKind) {
+  const normalizedDependency = dependency?.toLowerCase() ?? "";
+  if (normalizedDependency === "ffmpeg") {
+    return "Install FFmpeg and ensure ffmpeg is on PATH";
+  }
+  if (normalizedDependency === "ffprobe") {
+    return "Install FFmpeg and ensure ffprobe is on PATH";
+  }
+  if (normalizedDependency === "demucs") {
+    if (kind === "model_cache") {
+      return "Run setup with model prewarm enabled, then retry stem separation";
+    }
+    return "Install local backend stem dependencies, then retry stem separation";
+  }
+  if (normalizedDependency === "whisper" || normalizedDependency === "openai-whisper") {
+    if (kind === "model_cache") {
+      return "Run setup with model prewarm enabled, then retry lyrics generation";
+    }
+    return "Install local backend lyrics dependencies, then retry lyrics generation";
+  }
+  if (normalizedDependency === "beat-this") {
+    return "Install Advanced Beat Analysis dependencies or switch to Built-in Beat Analysis";
+  }
+  if (normalizedDependency === "advanced chords" || normalizedDependency === "crema") {
+    return "Install Advanced Chords dependencies or switch to built-in chords";
+  }
+  if (kind === "model_cache") {
+    return "Run setup with model prewarm enabled, then retry";
+  }
+  return null;
+}
+
+function cacheActionFromMessage(
+  dependency: string | null,
+  message: string | null | undefined,
+): string | null {
+  const normalizedDependency = dependency?.toLowerCase() ?? "";
+  const normalizedMessage = message?.toLowerCase() ?? "";
+  const isDemucs = normalizedDependency === "demucs";
+  const isWhisper = normalizedDependency === "whisper" || normalizedDependency === "openai-whisper";
+  if (!isDemucs && !isWhisper) {
+    return null;
+  }
+  if (normalizedMessage.includes("download failed")) {
+    return "Check local network access for first-run model download, then retry setup";
+  }
+  if (normalizedMessage.includes("unreadable")) {
+    return "Fix local cache permissions or re-run setup from an account that can read the model cache";
+  }
+  if (normalizedMessage.includes("corrupt")) {
+    return isDemucs
+      ? "Re-run local setup to replace Demucs model assets, then retry stem separation"
+      : "Re-run local setup to replace the Whisper model asset, then retry lyrics generation";
+  }
+  if (normalizedMessage.includes("missing")) {
+    return isDemucs
+      ? "Re-run local setup to download Demucs model assets, then retry stem separation"
+      : "Re-run local setup to download the Whisper model asset, then retry lyrics generation";
+  }
+  if (isWhisper && normalizedMessage.includes("unsupported")) {
+    return "Choose a supported local Whisper model, then retry lyrics generation";
+  }
+  return null;
+}
+
+function hasActionInMessage(message: string) {
+  return /\b(install|run setup|retry|switch to|ensure|make .+ available)\b/i.test(message);
+}
+
+function asSentence(value: string) {
+  return /[.!?]$/.test(value) ? value : `${value}.`;
+}
+
+function messageMentions(value: string, candidate: string | null | undefined) {
+  if (!candidate) {
+    return false;
+  }
+  const operationPattern = OPERATION_MESSAGE_PATTERNS[candidate.toLowerCase()];
+  if (operationPattern?.test(value)) {
+    return true;
+  }
+  return value.toLowerCase().includes(candidate.toLowerCase());
+}
+
+function isDependencyDiagnostic(input: DependencyDiagnosticInput, dependency: string | null) {
+  const code = input.code?.toUpperCase() ?? "";
+  if (
+    code.includes("DEPENDENCY") ||
+    code.includes("BACKEND_UNAVAILABLE") ||
+    code.includes("BACKEND_FAILED")
+  ) {
+    return true;
+  }
+  if (detailText(input.details, DETAIL_DEPENDENCY_KEYS)) {
+    return true;
+  }
+  if (dependency && detailText(input.details, DETAIL_KIND_KEYS)) {
+    return true;
+  }
+  const message = input.message?.toLowerCase() ?? "";
+  return Boolean(
+    dependency &&
+      /\b(required|dependency|unavailable|missing|model|cache|checkpoint|download)\b/.test(message),
+  );
+}
+
+function formatDependencyDiagnostic(input: DependencyDiagnosticInput) {
+  const message = formatDiagnosticText(input.message);
+  const dependency =
+    detailText(input.details, DETAIL_DEPENDENCY_KEYS) ??
+    dependencyFromMessage(message) ??
+    detailText(input.details, DETAIL_MODEL_KEYS);
+  if (!isDependencyDiagnostic(input, dependency)) {
+    return null;
+  }
+
+  const kind = dependencyKind(dependency, message, input.details);
+  const operation = detailOperationText(input.details) ?? operationFromMessage(message, input.fallbackOperation);
+  const explicitAction = detailText(input.details, DETAIL_ACTION_KEYS);
+  const action =
+    explicitAction ?? cacheActionFromMessage(dependency, message) ?? defaultDependencyAction(dependency, kind);
+  const pieces = [asSentence(message ?? "A required dependency is unavailable.")];
+
+  if (dependency) {
+    pieces.push(`${dependencyKindLabel(kind)}: ${dependency}.`);
+  }
+  if (operation && !messageMentions(message ?? "", operation)) {
+    pieces.push(`Operation: ${operation}.`);
+  }
+  if (action && (explicitAction || !hasActionInMessage(message ?? ""))) {
+    pieces.push(`Next: ${asSentence(action)}`);
+  }
+
+  return pieces.join(" ");
+}
+
+export function formatApiErrorMessage(error: unknown, fallback = "The request failed.") {
+  const message = error instanceof Error && error.message.trim() ? error.message.trim() : fallback;
+  const code = isRecord(error) && typeof error.code === "string" ? error.code : null;
+  const details = isRecord(error) ? error.details : null;
+  return formatDependencyDiagnostic({ code, details, message }) ?? message;
+}
+
+function operationForJobType(type: string | null | undefined) {
+  switch (type) {
+    case "analyze":
+      return "analysis";
+    case "chords":
+      return "chord detection";
+    case "export":
+      return "export";
+    case "lyrics":
+      return "lyrics generation";
+    case "preview":
+      return "preview rendering";
+    case "stems":
+      return "stem separation";
+    default:
+      return null;
+  }
+}
+
+export function formatJobErrorMessage(
+  message: string | null | undefined,
+  job?: Pick<JobSchema, "type"> | null,
+) {
+  const trimmed = typeof message === "string" ? message.trim() : "";
+  if (!trimmed) {
+    return null;
+  }
+  return (
+    formatDependencyDiagnostic({
+      fallbackOperation: operationForJobType(job?.type),
+      message: trimmed,
+    }) ?? trimmed
+  );
 }
 
 function formatJobRuntimeDetail(detail: string | null | undefined) {


### PR DESCRIPTION
## Summary
- Add safe dependency diagnostics for FFmpeg/ffprobe, Demucs, Whisper, and model/cache failures.
- Preserve `ErrorResponse.error.message` as the primary surface and restrict details to safe dependency, operation, remediation, and cache status fields.
- Update desktop error presentation so import, activity, and job history failures show concise local remediation without leaking raw stderr or paths.
- Document the host-tool versus model/cache distinction for release support.

Closes #306.

## Testing
- `cd apps/backend && uv run --python 3.11 pytest tests/test_dependency_diagnostics.py tests/test_stem_models.py tests/test_stem_flow.py tests/test_lyrics_flow.py tests/test_lyrics_engine.py tests/test_jobs_api.py`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `pnpm --filter @tuneforge/desktop test`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test:e2e -- --run` excluding audio capture
- `git diff --check`
