### PR TITLE
feat: Add Library import guidance

### DIFF
--- a/apps/desktop/src/App.library.test.tsx
+++ b/apps/desktop/src/App.library.test.tsx
@@ -238,6 +238,11 @@ describe("Desktop app library", () => {
     expect(await screen.findByText("Loading projects...")).toBeInTheDocument();
     resolveProjects();
     expect(await screen.findByRole("heading", { name: "No projects yet" })).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Import audio or video to create a local project. Processing stays on this device, and Activity shows queue progress.",
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByText("0 projects ready")).toBeInTheDocument();
 
     unmount();
@@ -405,8 +410,54 @@ describe("Desktop app library", () => {
 
     const summary = await screen.findByRole("status");
     expect(within(summary).getByText("2 tracks imported, 0 duplicates skipped, 0 failed.")).toBeInTheDocument();
+    expect(within(summary).getByRole("link", { name: "View Activity" })).toHaveAttribute(
+      "href",
+      "/activity",
+    );
     expect(screen.getByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
     expect(mockGetProject).not.toHaveBeenCalled();
+  });
+
+  it("shows truthful pending guidance while choosing files and importing selected tracks", async () => {
+    const user = userEvent.setup();
+    let resolveOpen!: (selection: string[]) => void;
+    let resolveImport!: () => void;
+    const pendingProject = { ...makeLibraryProject(90), source_key_override: null };
+    const pickerGuidanceText = "Choose audio or video to import.";
+    const selectedGuidanceText =
+      "Importing selected tracks locally. Local processing may continue in Activity.";
+    const openPromise = new Promise<string[]>((resolve) => {
+      resolveOpen = resolve;
+    });
+    const importPromise = new Promise<{ project: typeof pendingProject }>((resolve) => {
+      resolveImport = () => resolve({ project: pendingProject });
+    });
+    mockOpen.mockImplementation(async () => openPromise);
+    mockImportProject.mockImplementation(async () => importPromise);
+
+    renderApp(["/"]);
+
+    expect(await screen.findByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Import Track(s)" }));
+
+    const pickerGuidance = await screen.findByText(pickerGuidanceText);
+    expect(pickerGuidance.closest('[role="status"]')).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Choosing files..." })).toBeDisabled();
+    expect(screen.queryByText(selectedGuidanceText)).not.toBeInTheDocument();
+
+    act(() => {
+      resolveOpen(["/tmp/first-song.mp4", "/tmp/second-song.wav"]);
+    });
+
+    const selectedGuidance = await screen.findByText(selectedGuidanceText);
+    expect(selectedGuidance.closest('[role="status"]')).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Importing..." })).toBeDisabled();
+
+    resolveImport();
+    await waitFor(() => expect(mockImportProject).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryByText(selectedGuidanceText)).not.toBeInTheDocument());
+    const summary = await screen.findByRole("status");
+    expect(within(summary).getByText("2 tracks imported, 0 duplicates skipped, 0 failed.")).toBeInTheDocument();
   });
 
   it("deduplicates selected import paths before importing", async () => {
@@ -509,6 +560,10 @@ describe("Desktop app library", () => {
         "1 track imported, 0 duplicates skipped, 1 failed. Failed: Unsupported codec.",
       ),
     ).toBeInTheDocument();
+    expect(within(summary).getByRole("link", { name: "View Activity" })).toHaveAttribute(
+      "href",
+      "/activity",
+    );
     expect(mockGetProject).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/features/projects/LibraryView.tsx
+++ b/apps/desktop/src/features/projects/LibraryView.tsx
@@ -111,11 +111,28 @@ function ProjectCard({ project }: { project: ProjectSchema }) {
   );
 }
 
-type ImportNotice =
-  | { kind: "duplicate"; message: string; projectId: string }
-  | { kind: "summary"; message: string }
-  | { kind: "warning"; message: string }
-  | { kind: "error"; message: string };
+type ImportNotice = {
+  activityLink?: boolean;
+  message: string;
+} & (
+  | { kind: "duplicate"; projectId: string }
+  | { kind: "summary" }
+  | { kind: "warning" }
+  | { kind: "error" }
+);
+
+type ImportPendingPhase = "picker" | "selected";
+
+const importPendingCopy: Record<ImportPendingPhase, { buttonLabel: string; guidance: string }> = {
+  picker: {
+    buttonLabel: "Choosing files...",
+    guidance: "Choose audio or video to import.",
+  },
+  selected: {
+    buttonLabel: "Importing...",
+    guidance: "Importing selected tracks locally. Local processing may continue in Activity.",
+  },
+};
 
 type BatchImportSummary = {
   failures: Array<{ message: string }>;
@@ -248,6 +265,7 @@ export function LibraryView() {
   const { chordBackendForAction } = useChordBackendActionSelection();
   const [searchDraft, setSearchDraft] = useState("");
   const [importNotice, setImportNotice] = useState<ImportNotice | null>(null);
+  const [importPendingPhase, setImportPendingPhase] = useState<ImportPendingPhase | null>(null);
   const deferredSearch = useDeferredValue(searchDraft.trim());
   const showSubtitle = informationDensity !== "minimal";
 
@@ -291,6 +309,7 @@ export function LibraryView() {
       if (!selectedPaths.length) {
         return { kind: "none" } satisfies ImportMutationResult;
       }
+      setImportPendingPhase("selected");
       const { duplicateCount, uniquePaths } = getUniqueImportPaths(selectedPaths);
       if (uniquePaths.length > MAX_IMPORT_SELECTION) {
         return { kind: "selectionLimit" } satisfies ImportMutationResult;
@@ -348,6 +367,7 @@ export function LibraryView() {
     },
     onMutate: () => {
       setImportNotice(null);
+      setImportPendingPhase("picker");
     },
     onSuccess: async (result) => {
       if (result.kind === "none") {
@@ -369,12 +389,16 @@ export function LibraryView() {
         queryClient.invalidateQueries({ queryKey: ["jobs"] }),
       ]);
       setImportNotice({
+        activityLink: result.summary.importedCount > 0,
         kind: result.summary.failedCount ? "warning" : "summary",
         message: formatBatchImportNotice(result.summary),
       });
     },
     onError: (error) => {
       setImportNotice(getImportErrorNotice(error));
+    },
+    onSettled: () => {
+      setImportPendingPhase(null);
     },
   });
 
@@ -389,6 +413,7 @@ export function LibraryView() {
   const showEmptyState = !showInitialLoading && !isProjectsError && !projects.length;
   const showPaginationStatus = showList && !showInitialLoading && !showInitialError;
   const showRefetchError = isRefetchError && !isFetchNextPageError && projects.length > 0;
+  const pendingImportCopy = importPendingPhase ? importPendingCopy[importPendingPhase] : null;
   const { loadNextPage: fetchNextProjectPage, sentinelRef: loadMoreSentinelRef } =
     useLazyLoadSentinel({
       enabled: showPaginationStatus && !isFetching && !isProjectsError,
@@ -410,14 +435,21 @@ export function LibraryView() {
             </p>
           ) : null}
         </div>
-        <button
-          className="button button--primary"
-          onClick={() => importMutation.mutate()}
-          disabled={importMutation.isPending}
-        >
-          {importMutation.isPending ? "Importing..." : "Import Track(s)"}
-          <Upload aria-hidden="true" className="button__icon" />
-        </button>
+        <div className="screen__title-block">
+          <button
+            className="button button--primary"
+            onClick={() => importMutation.mutate()}
+            disabled={importMutation.isPending}
+          >
+            {pendingImportCopy ? pendingImportCopy.buttonLabel : "Import Track(s)"}
+            <Upload aria-hidden="true" className="button__icon" />
+          </button>
+          {pendingImportCopy ? (
+            <p className="screen__subtitle" role="status" aria-live="polite">
+              {pendingImportCopy.guidance}
+            </p>
+          ) : null}
+        </div>
       </div>
 
       {importNotice ? (
@@ -429,6 +461,11 @@ export function LibraryView() {
           {importNotice.kind === "duplicate" ? (
             <Link className="button button--ghost button--small" to={`/projects/${importNotice.projectId}`}>
               Open project
+            </Link>
+          ) : null}
+          {importNotice.activityLink ? (
+            <Link className="button button--ghost button--small" to="/activity">
+              View Activity
             </Link>
           ) : null}
         </div>
@@ -506,7 +543,7 @@ export function LibraryView() {
             <p>
               {deferredSearch
                 ? "Try a different name or clear the search."
-                : "Import a track to create the first playback-ready project."}
+                : "Import audio or video to create a local project. Processing stays on this device, and Activity shows queue progress."}
             </p>
           </div>
         ) : null}


### PR DESCRIPTION
## Summary
- Add first-run Library copy for local import and Activity queue guidance.
- Split import pending copy between file selection and selected-track import.
- Add Activity handoff links for batch import notices with imported tracks.

Closes #308

## Testing
- pnpm --filter @tuneforge/desktop test --run src/App.library.test.tsx
- pnpm --filter @tuneforge/desktop typecheck
- pnpm --filter @tuneforge/desktop lint
- git diff --check
