### PR TITLE
docs: polish release brand and version

### DIFF
--- a/.github/ISSUE_TEMPLATE/audio_engine_issue.yml
+++ b/.github/ISSUE_TEMPLATE/audio_engine_issue.yml
@@ -100,7 +100,7 @@ body:
   - type: input
     id: commit
     attributes:
-      label: Tuneforge commit
+      label: TuneForge commit
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Report a defect in Tuneforge.
+description: Report a defect in TuneForge.
 title: "[bug] "
 labels: ["bug"]
 body:
@@ -55,7 +55,7 @@ body:
   - type: input
     id: commit
     attributes:
-      label: Tuneforge commit or version
+      label: TuneForge commit or version
       description: Output of `git rev-parse --short HEAD` or the release version.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Tuneforge has an opinionated scope: local-only, single-user, focused on learning, rehearsing, and playing along with songs.
+        TuneForge has an opinionated scope: local-only, single-user, focused on learning, rehearsing, and playing along with songs.
         Please make sure your idea fits before opening this. See [CONTRIBUTING.md](../CONTRIBUTING.md).
 
   - type: textarea
@@ -21,7 +21,7 @@ body:
     id: proposal
     attributes:
       label: Proposed solution
-      description: Describe what you would like Tuneforge to do.
+      description: Describe what you would like TuneForge to do.
     validations:
       required: true
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,8 +30,8 @@
 - [ ] `pnpm typecheck` passes
 - [ ] `pnpm test` passes (desktop + Tauri shell + backend)
 - [ ] If backend routes or schemas changed, ran `pnpm contracts:generate` and committed the result
-- [ ] If release/package behavior changed or this PR prepares an RC, included RC gate evidence from
-  `docs/PACKAGING.md#release-candidate-gate` (package build plus packaged launch smoke with OS,
+- [ ] If release/package behavior changed or this PR prepares a release package, included Release Package Gate evidence from
+  `docs/PACKAGING.md#release-package-gate` (package build plus packaged launch smoke with OS,
   artifact type, commit SHA, and pass/fail evidence); when release/package behavior changed, also
   refreshed license/dependency inventory evidence, documented model-weight download/cache policy,
   and verified no model weights, cache dirs, or package artifacts were added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Tuneforge
+# TuneForge
 
-Tuneforge is a local-first, open-source desktop app for musicians who want to learn, rehearse, and play along with songs. Drop in any track and Tuneforge will split it into vocals, drums, bass, guitar, piano, and other stems, work out the key, tempo, chord progression, and lyrics, and let you shift the pitch, retune to a reference frequency, follow the transcript during playback, and export a custom version to practice with.
+TuneForge is a local-first, open-source desktop app for musicians who want to learn, rehearse, and play along with songs. Drop in any track and TuneForge will split it into vocals, drums, bass, guitar, piano, and other stems, work out the key, tempo, chord progression, and lyrics, and let you shift the pitch, retune to a reference frequency, follow the transcript during playback, and export a custom version to practice with.
 
 Think "AI-assisted song toolkit for the player at home" — but **fully local, single-user, and with no cloud component**. Every track stays on your machine, no account, no upload.
 
@@ -8,9 +8,9 @@ Local-first does not mean first use is always offline: setup or first use can do
 
 ## Status
 
-Pre-1.0. The desktop dev flow (`pnpm dev`) is the fastest way to iterate. Local macOS app/DMG and Linux Flatpak packaging are available, but generated builds are unsigned and not notarized. Development/source runs and macOS packages require `ffmpeg`/`ffprobe` on the host `PATH`; Flatpak uses `/app/bin/ffmpeg` and `/app/bin/ffprobe` wrappers backed by the Flatpak runtime sandbox.
+The desktop workflow is the supported full TuneForge experience. The dev flow (`pnpm dev`) is the fastest way to iterate. Local macOS app/DMG and Linux Flatpak packaging are available, but generated builds are unsigned and not notarized. Development/source runs and macOS packages require `ffmpeg`/`ffprobe` on the host `PATH`; Flatpak uses `/app/bin/ffmpeg` and `/app/bin/ffprobe` wrappers backed by the Flatpak runtime sandbox.
 
-Current 1.0 release limits:
+Current release limits:
 
 - Desktop is the supported full workflow. Android/mobile remains a local-first companion path in progress.
 - Packages are local build artifacts, not signed distribution releases.
@@ -30,7 +30,7 @@ Current 1.0 release limits:
 
 ## Threat Model and Scope
 
-Tuneforge is **local-only by design**:
+TuneForge is **local-only by design**:
 
 - The backend binds to `127.0.0.1` only.
 - There is **no authentication, no authorization, and no per-user model**.
@@ -222,7 +222,7 @@ pnpm package:mac
 pnpm package:linux:flatpak
 ```
 
-Before marking an RC ready, follow the [Release Candidate Gate](./docs/PACKAGING.md#release-candidate-gate)
+Before publishing a release package, follow the [Release Package Gate](./docs/PACKAGING.md#release-package-gate)
 and record package build plus packaged launch-smoke evidence from the built artifact.
 
 Plain package commands include crema Advanced Chords and beat-this Advanced Beat Analysis
@@ -259,7 +259,7 @@ macOS packaging writes a `.app` bundle and DMG. Flatpak packaging writes either 
 bundle or, with `--no-bundle`, a local repository install flow. Source distribution is the source
 checkout/archive; the package commands do not create a separate source tarball.
 
-macOS packages require host `ffmpeg` / `ffprobe`; Flatpak routes backend lookups to sandbox wrappers at `/app/bin/ffmpeg` and `/app/bin/ffprobe`. Tuneforge does not bundle FFmpeg. See [Packaging](./docs/PACKAGING.md) for output paths, package flags, local repo install commands, data-directory behavior, and size expectations.
+macOS packages require host `ffmpeg` / `ffprobe`; Flatpak routes backend lookups to sandbox wrappers at `/app/bin/ffmpeg` and `/app/bin/ffprobe`. TuneForge does not bundle FFmpeg. See [Packaging](./docs/PACKAGING.md) for output paths, package flags, local repo install commands, data-directory behavior, and size expectations.
 
 ## CI
 

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -1,6 +1,6 @@
-# Tuneforge Backend
+# TuneForge Backend
 
-FastAPI backend for Tuneforge. It owns persistence, artifact management, audio analysis, transform orchestration, and the in-process background job queue.
+FastAPI backend for TuneForge. It owns persistence, artifact management, audio analysis, transform orchestration, and the in-process background job queue.
 
 ## Layout
 

--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -67,7 +67,7 @@ def get_settings() -> Settings:
     data_root = _default_data_root()
     cache_root = data_root / "cache"
     return Settings(
-        app_name="Tuneforge",
+        app_name="TuneForge",
         api_prefix="/api/v1",
         data_root=data_root,
         database_path=data_root / "app.sqlite",

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "tuneforge-backend"
-version = "0.1.0"
-description = "Local API and processing backend for Tuneforge."
+version = "1.0.0"
+description = "Local API and processing backend for TuneForge."
 readme = "README.md"
 requires-python = ">=3.11,<3.12"
 dependencies = [

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -1919,7 +1919,7 @@ wheels = [
 
 [[package]]
 name = "tuneforge-backend"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <title>Tuneforge</title>
+    <title>TuneForge</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tuneforge/desktop",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -7381,7 +7381,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuneforge"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "android_system_properties",
  "base64 0.22.1",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tuneforge"
-version = "0.1.0"
-description = "Tuneforge desktop shell"
+version = "1.0.0"
+description = "TuneForge desktop shell"
 edition = "2021"
 license = "MIT"
 

--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
   <key>NSMicrophoneUsageDescription</key>
-  <string>Tuneforge uses the microphone for the chromatic tuner.</string>
+  <string>TuneForge uses the microphone for the chromatic tuner.</string>
 </dict>
 </plist>

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Default desktop capabilities for Tuneforge.",
+  "description": "Default desktop capabilities for TuneForge.",
   "windows": ["main"],
   "permissions": [
     "core:event:allow-listen",

--- a/apps/desktop/src-tauri/src/mobile_backend/storage.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/storage.rs
@@ -1371,7 +1371,7 @@ pub fn mobile_get_health(app: AppHandle) -> Result<HealthResponse, String> {
         git_ref: git_ref.clone(),
     };
     Ok(HealthResponse {
-        name: "Tuneforge Mobile".to_string(),
+        name: "TuneForge Mobile".to_string(),
         version: git_ref,
         backend_version: version_info.clone(),
         frontend_version: version_info,

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "Tuneforge",
-  "version": "0.1.0",
+  "productName": "TuneForge",
+  "version": "1.0.0",
   "identifier": "com.tuneforge.desktop",
   "build": {
     "beforeDevCommand": "pnpm --filter @tuneforge/desktop dev",
@@ -19,7 +19,7 @@
     },
     "windows": [
       {
-        "title": "Tuneforge",
+        "title": "TuneForge",
         "width": 1400,
         "height": 960,
         "resizable": true

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -163,12 +163,12 @@ function AppChrome() {
   return (
     <div className={`app-shell${compactChrome ? " app-shell--compact" : ""}`}>
       <aside className="sidebar">
-        <Link aria-label="Tuneforge library" className="brand" title="Tuneforge" to="/">
+        <Link aria-label="TuneForge library" className="brand" title="TuneForge" to="/">
           <span className="brand__mark" aria-hidden="true">
             <Music2 className="brand__icon" />
           </span>
           <span className="brand__copy">
-            <span className="brand__eyebrow">Tuneforge</span>
+            <span className="brand__eyebrow">TuneForge</span>
             <strong>Local Practice Rig</strong>
           </span>
         </Link>

--- a/apps/desktop/src/BootScreen.tsx
+++ b/apps/desktop/src/BootScreen.tsx
@@ -2,7 +2,7 @@ export function BootScreen({ message, title }: { message?: string; title: string
   return (
     <main className="boot-screen">
       <section className="boot-screen__panel" role="status">
-        <span className="boot-screen__eyebrow">Tuneforge</span>
+        <span className="boot-screen__eyebrow">TuneForge</span>
         <h1>{title}</h1>
         {message ? <p>{message}</p> : null}
       </section>

--- a/apps/desktop/src/features/settings/ThemeStudioView.tsx
+++ b/apps/desktop/src/features/settings/ThemeStudioView.tsx
@@ -159,7 +159,7 @@ function ThemeStudioPreview({
         <div className="theme-studio-preview__shell">
           <aside className="theme-studio-preview__sidebar">
             <div className="brand">
-              <span className="brand__eyebrow">Tuneforge</span>
+              <span className="brand__eyebrow">TuneForge</span>
               <strong>Local Practice Rig</strong>
             </div>
             <div className="theme-studio-preview__nav" aria-label={`${mode} theme sample navigation`}>

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -42,7 +42,7 @@ async function bootstrap() {
   }
 
   const root = ReactDOM.createRoot(rootElement);
-  root.render(<BootScreen title="Starting Tuneforge" />);
+  root.render(<BootScreen title="Starting TuneForge" />);
 
   try {
     await withTimeout(initializeApi(), 8000);
@@ -57,10 +57,10 @@ async function bootstrap() {
       </React.StrictMode>,
     );
   } catch (error) {
-    console.error("Tuneforge failed to initialize.", error);
+    console.error("TuneForge failed to initialize.", error);
     root.render(
       <BootScreen
-        title="Tuneforge could not start"
+        title="TuneForge could not start"
         message={formatBootError(error)}
       />,
     );

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -1283,14 +1283,14 @@ const {
     throw new Error(`Unexpected invoke command: ${command}`);
   });
   const mockGetHealth = vi.fn(async () => ({
-    name: "Tuneforge",
+    name: "TuneForge",
     version: "backend-test-ref",
     backend_version: {
-      package_version: "0.1.0",
+      package_version: "1.0.0",
       git_ref: "backend-test-ref",
     },
     frontend_version: {
-      package_version: "0.1.0",
+      package_version: "1.0.0",
       git_ref: "frontend-test-ref",
     },
     status: "ok",

--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -5,10 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Tuneforge is a local-first desktop practice app for stem separation, chords, lyrics, pitch shift, retune, and export."
+      content="TuneForge is a local-first desktop practice app for stem separation, chords, lyrics, pitch shift, retune, and export."
     />
     <meta name="color-scheme" content="light dark" />
-    <title>Tuneforge</title>
+    <title>TuneForge</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tuneforge/site",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/site/src/App.tsx
+++ b/apps/site/src/App.tsx
@@ -78,7 +78,7 @@ const packageRows = [
 ];
 
 const limitationRows = [
-  "Pre-1.0: local development and unsigned package builds are the supported paths today.",
+  "Local development and package builds keep the same local-only workflow; generated packages are unsigned and not notarized.",
   "No cloud sync, no account system, no telemetry, and no public backend exposure.",
   "FFmpeg and FFprobe are intentionally not bundled; development and macOS packages use host PATH, while Flatpak uses sandbox runtime wrappers.",
   "First heavy ML use may need local model downloads or existing caches.",
@@ -143,12 +143,12 @@ function useMediaManifest() {
 
 function HeroPreview() {
   return (
-    <div className="hero-preview" aria-label="Tuneforge interface summary">
+    <div className="hero-preview" aria-label="TuneForge interface summary">
       <div className="hero-preview__header">
         <span className="dot dot--red" />
         <span className="dot dot--yellow" />
         <span className="dot dot--green" />
-        <strong>Tuneforge local session</strong>
+        <strong>TuneForge local session</strong>
       </div>
       <div className="hero-preview__grid">
         <div className="hero-preview__timeline">
@@ -236,7 +236,7 @@ export function App() {
             <Music2 aria-hidden="true" />
           </span>
           <span>
-            <strong>Tuneforge</strong>
+            <strong>TuneForge</strong>
             <small>Local practice rig</small>
           </span>
         </a>
@@ -252,7 +252,7 @@ export function App() {
         <section className="hero-section" aria-labelledby="hero-title">
           <div className="hero-section__content">
             <p className="eyebrow">Local-first desktop app for musicians</p>
-            <h1 id="hero-title">Tuneforge</h1>
+            <h1 id="hero-title">TuneForge</h1>
             <p className="hero-section__lede">
               Split stems, inspect chords and lyrics, retune, transpose, rehearse, and export
               practice mixes without accounts, cloud processing, analytics, or telemetry.
@@ -328,7 +328,7 @@ export function App() {
         <section className="section section--split" id="packages" aria-labelledby="packages-title">
           <div className="section__header">
             <p className="eyebrow">Distribution status</p>
-            <h2 id="packages-title">Packages are local and unsigned today</h2>
+            <h2 id="packages-title">Packages are local and unsigned</h2>
             <p>
               Desktop packaging exists for local builds. The generated apps do not include FFmpeg or
               FFprobe; macOS uses host PATH and Flatpak uses sandbox runtime wrappers. macOS

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -1,6 +1,6 @@
 # Packaging
 
-Tuneforge packaging is currently intended for local unsigned desktop builds. Packaged builds launch the bundled backend locally, include the default desktop Advanced Chords and Advanced Beat Analysis dependency stacks, and do not bundle external model weights by default. Crema's wheel-embedded chord model assets are the dependency-owned exception and may be included with Advanced Chords. Tuneforge does not bundle FFmpeg: macOS packages use host-installed `ffmpeg` and `ffprobe`, while Flatpak routes backend lookups through sandbox wrappers at `/app/bin/ffmpeg` and `/app/bin/ffprobe`.
+TuneForge packaging creates local unsigned desktop builds. Packaged builds launch the bundled backend locally, include the default desktop Advanced Chords and Advanced Beat Analysis dependency stacks, and do not bundle external model weights by default. Crema's wheel-embedded chord model assets are the dependency-owned exception and may be included with Advanced Chords. TuneForge does not bundle FFmpeg: macOS packages use host-installed `ffmpeg` and `ffprobe`, while Flatpak routes backend lookups through sandbox wrappers at `/app/bin/ffmpeg` and `/app/bin/ffprobe`.
 
 See [Third-party notices](../THIRD_PARTY_NOTICES.md) for the dependency and model-weight distribution policy.
 
@@ -14,9 +14,9 @@ See [Third-party notices](../THIRD_PARTY_NOTICES.md) for the dependency and mode
 - Default packages may still download Demucs, Whisper, or beat-this weights on first use when caches are missing. Fully offline operation requires host/sandbox FFmpeg access plus the relevant local caches or package assets to already exist.
 - Crema chord model files come from the crema dependency and ship with Advanced Chords unless that dependency stack is excluded; Demucs, Whisper, and beat-this external weights remain cache/download assets unless `--model-bundle` is explicitly passed.
 
-## Release Candidate Gate
+## Release Package Gate
 
-A release candidate is not ready to tag or publish until package build evidence and a
+A release package is not ready to publish until package build evidence and a
 packaged launch smoke pass are both recorded for each intended artifact. Missing build
 or smoke evidence fails the gate closed; do not substitute `pnpm dev`, a dev server, or
 an unpackaged Tauri run for packaged-artifact proof.
@@ -32,7 +32,7 @@ pnpm package:linux:flatpak
 
 Run `pnpm package:mac` only on supported macOS release hosts, and run
 `pnpm package:linux:flatpak` only on supported Linux hosts with Flatpak packaging
-tooling. If an RC includes only one platform artifact, run and record the package
+tooling. If a release includes only one platform artifact, run and record the package
 command for that artifact.
 
 For the manual launch smoke, install or open the built package artifact and confirm:
@@ -45,7 +45,7 @@ For the manual launch smoke, install or open the built package artifact and conf
   builds, no bundled FFmpeg, and no external Demucs, Whisper, or beat-this model
   weights unless `--model-bundle` was explicitly reviewed and used.
 
-Record RC gate evidence with:
+Record release gate evidence with:
 
 - OS and version;
 - artifact type, such as macOS `.app`/DMG or Linux `.flatpak`;
@@ -85,8 +85,8 @@ pnpm package:mac -- --model-bundle
 
 The generated artifacts are written under `apps/desktop/src-tauri/target/release/bundle/`:
 
-- `macos/Tuneforge.app`
-- `dmg/Tuneforge_<version>_<arch>.dmg`
+- `macos/TuneForge.app`
+- `dmg/TuneForge_<version>_<arch>.dmg`
 
 Run packaging from a normal macOS shell so `hdiutil` can create the disk image. The generated app is unsigned and not notarized.
 
@@ -133,7 +133,7 @@ By default, the Flatpak grants access to `xdg-data/tuneforge`, `xdg-cache/torch`
 `xdg-cache/whisper`. Packaged runs therefore use the same data root and model caches as
 `pnpm dev`: `~/.local/share/tuneforge`, `~/.cache/torch`, and `~/.cache/whisper`. Do
 not run the Flatpak app and `pnpm dev` against that shared library at the same time;
-SQLite is local and Tuneforge is not designed for concurrent backends writing the same
+SQLite is local and TuneForge is not designed for concurrent backends writing the same
 library.
 
 ## Flatpak Local Repo Installs

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tuneforge/shared-types",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "exports": {
@@ -16,4 +16,3 @@
     "openapi-typescript": "^7.6.1"
   }
 }
-

--- a/packaging/flatpak/com.tuneforge.desktop.desktop
+++ b/packaging/flatpak/com.tuneforge.desktop.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Name=Tuneforge
+Name=TuneForge
 Comment=Local-first music practice toolkit
 Exec=tuneforge
 Icon=com.tuneforge.desktop

--- a/packaging/flatpak/com.tuneforge.desktop.metainfo.xml
+++ b/packaging/flatpak/com.tuneforge.desktop.metainfo.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>com.tuneforge.desktop</id>
-  <name>Tuneforge</name>
+  <name>TuneForge</name>
   <summary>Local-first music practice toolkit</summary>
   <developer id="com.tuneforge">
-    <name>Tuneforge contributors</name>
+    <name>TuneForge contributors</name>
   </developer>
   <metadata_license>MIT</metadata_license>
   <project_license>MIT</project_license>
   <description>
     <p>
-      Tuneforge helps musicians work locally with songs for practice, analysis,
+      TuneForge helps musicians work locally with songs for practice, analysis,
       lyrics transcription, stem separation, pitch shifts, retuning, and exports.
     </p>
     <p>
-      Tuneforge runs a loopback backend on the same machine and does not require
+      TuneForge runs a loopback backend on the same machine and does not require
       accounts or cloud services.
     </p>
   </description>
@@ -27,6 +27,6 @@
   </categories>
   <content_rating type="oars-1.1" />
   <releases>
-    <release version="0.1.0" date="2026-06-27" />
+    <release version="1.0.0" date="2026-06-27" />
   </releases>
 </component>

--- a/packaging/flatpak/ffmpeg-wrapper.sh
+++ b/packaging/flatpak/ffmpeg-wrapper.sh
@@ -13,7 +13,7 @@ do
 done
 
 cat >&2 <<'EOF'
-Tuneforge Flatpak could not find ffmpeg inside the runtime sandbox.
+TuneForge Flatpak could not find ffmpeg inside the runtime sandbox.
 This build intentionally does not bundle FFmpeg; install/use a Flatpak runtime that provides ffmpeg.
 EOF
 exit 127

--- a/packaging/flatpak/ffprobe-wrapper.sh
+++ b/packaging/flatpak/ffprobe-wrapper.sh
@@ -13,7 +13,7 @@ do
 done
 
 cat >&2 <<'EOF'
-Tuneforge Flatpak could not find ffprobe inside the runtime sandbox.
+TuneForge Flatpak could not find ffprobe inside the runtime sandbox.
 This build intentionally does not bundle FFmpeg; install/use a Flatpak runtime that provides ffprobe.
 EOF
 exit 127

--- a/scripts/capture-release-media.mjs
+++ b/scripts/capture-release-media.mjs
@@ -1100,14 +1100,14 @@ function mockApiResponse(method, url) {
 
 function healthResponse() {
   return {
-    name: "Tuneforge",
+    name: "TuneForge",
     version: "release-media-fixture",
     backend_version: {
-      package_version: "0.1.0",
+      package_version: "1.0.0",
       git_ref: "release-media-fixture",
     },
     frontend_version: {
-      package_version: "0.1.0",
+      package_version: "1.0.0",
       git_ref: "release-media-fixture",
     },
     status: "ok",
@@ -1353,7 +1353,7 @@ function beatBackends() {
     {
       availability: "available",
       available: true,
-      description: "Tuneforge built-in beat detector.",
+      description: "TuneForge built-in beat detector.",
       desktopOnly: false,
       experimental: false,
       id: "built-in",
@@ -1389,7 +1389,7 @@ function chordBackends() {
         supportsNoChord: true,
         supportsSevenths: true,
       },
-      description: "Tuneforge built-in chord detector.",
+      description: "TuneForge built-in chord detector.",
       desktopOnly: false,
       experimental: false,
       id: "tuneforge-fast",

--- a/scripts/configure-tauri-build-env.sh
+++ b/scripts/configure-tauri-build-env.sh
@@ -32,7 +32,7 @@ if [[ "$(uname -s)" == "Linux" ]]; then
 
   if [[ -z "${LIBCLANG_PATH:-}" ]]; then
     cat >&2 <<'EOF'
-Tuneforge native tempo playback uses signalsmith-stretch, which runs bindgen during the Tauri build.
+TuneForge native tempo playback uses signalsmith-stretch, which runs bindgen during the Tauri build.
 bindgen requires libclang. Install Clang/libclang development files, then rerun this command.
 
 Arch:

--- a/scripts/package-flatpak.mjs
+++ b/scripts/package-flatpak.mjs
@@ -166,7 +166,7 @@ function main() {
   const packageOptions = parsePackageOptions(process.argv.slice(2), { platform: "linux" });
   const skipBundle = packageOptions.noBundle || process.env.FLATPAK_NO_BUNDLE === "1";
   if (process.arch !== "x64") {
-    throw new Error("Tuneforge Flatpak packaging currently targets Linux x86_64 only.");
+    throw new Error("TuneForge Flatpak packaging currently targets Linux x86_64 only.");
   }
   if (!existsSync(baseManifestPath)) {
     throw new Error(`Flatpak manifest not found at ${baseManifestPath}`);


### PR DESCRIPTION
## Summary
- Normalize release-facing product casing to TuneForge across desktop, site, docs, and packaging surfaces.
- Bump checked release version metadata to 1.0.0 while preserving technical identifiers.
- Remove RC/pre-1.0 wording from release templates and packaging copy.

Closes #309

## Testing
- `node scripts/check-release-version.mjs`
- `rg -n "Tuneforge|pre-release|pre 1\\.0|pre-1\\.0|before 1\\.0|0\\.1\\.0" README.md docs apps packages packaging .github scripts -g '!apps/desktop/src-tauri/Cargo.lock' -g '!apps/desktop/src-tauri/gen/**' -g '!node_modules'`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test -- --run`
- `pnpm --filter @tuneforge/site typecheck`
- `pnpm --filter @tuneforge/site build`
- `cd apps/desktop/src-tauri && cargo check`
- `node --check scripts/capture-release-media.mjs`
- `bash -n scripts/configure-tauri-build-env.sh`
- `git diff --check`
- Reviewer, contract guard, and Product Design QA re-checks clean.
