### PR TITLE
fix: report truthful sync evidence

### DIFF
--- a/apps/desktop/src-tauri/src/sync_transport.rs
+++ b/apps/desktop/src-tauri/src/sync_transport.rs
@@ -370,8 +370,11 @@ pub struct SyncTransportSyncResult {
     pub project_results: Vec<SyncTransportProjectResult>,
     pub imported_projects: Vec<SyncTransportProjectResult>,
     pub imported_project_count: usize,
+    pub applied_project_count: usize,
+    pub deleted_project_count: usize,
     pub skipped_project_count: usize,
     pub failed_project_count: usize,
+    pub conflicted_project_count: usize,
     pub received_artifacts: Vec<SyncTransportTransferResult>,
     pub transfer_counts: SyncTransportTransferCounts,
     pub served_artifact_requests: u64,
@@ -2693,11 +2696,16 @@ mod desktop {
                 run_id,
                 peer_device_id: payload.peer_device_id,
                 remote_device_id: session.remote_device_id,
-                status: sync_result_status(&manifest_errors, import_counts.failed),
+                status: sync_result_status(
+                    &manifest_errors,
+                    import_counts.failed,
+                    import_counts.conflicted,
+                ),
                 message: sync_result_message(
                     local_manifest_count,
                     remote_offer.project_manifests.len(),
                     &transfer_counts,
+                    manifest_errors.len(),
                     import_counts,
                 ),
                 selected_transport,
@@ -2710,8 +2718,11 @@ mod desktop {
                 project_results,
                 imported_projects,
                 imported_project_count: import_counts.imported,
+                applied_project_count: import_counts.applied,
+                deleted_project_count: import_counts.deleted,
                 skipped_project_count: import_counts.skipped,
                 failed_project_count: import_counts.failed,
+                conflicted_project_count: import_counts.conflicted,
                 received_artifacts,
                 transfer_counts,
                 served_artifact_requests,
@@ -2948,8 +2959,11 @@ mod desktop {
             project_results: Vec::new(),
             imported_projects: Vec::new(),
             imported_project_count: 0,
+            applied_project_count: 0,
+            deleted_project_count: 0,
             skipped_project_count: 0,
             failed_project_count: 0,
+            conflicted_project_count: 0,
             received_artifacts: Vec::new(),
             transfer_counts: SyncTransportTransferCounts::default(),
             served_artifact_requests: 0,
@@ -3135,8 +3149,11 @@ mod desktop {
             project_results: Vec::new(),
             imported_projects: Vec::new(),
             imported_project_count: 0,
+            applied_project_count: 0,
+            deleted_project_count: 0,
             skipped_project_count: 0,
             failed_project_count: 0,
+            conflicted_project_count: 0,
             received_artifacts,
             transfer_counts,
             served_artifact_requests,
@@ -3197,8 +3214,11 @@ mod desktop {
             project_results: Vec::new(),
             imported_projects: Vec::new(),
             imported_project_count: 0,
+            applied_project_count: 0,
+            deleted_project_count: 0,
             skipped_project_count: 0,
             failed_project_count: 0,
+            conflicted_project_count: 0,
             received_artifacts,
             transfer_counts,
             served_artifact_requests,
@@ -3327,8 +3347,11 @@ mod desktop {
             project_results: Vec::new(),
             imported_projects: Vec::new(),
             imported_project_count: 0,
+            applied_project_count: 0,
+            deleted_project_count: 0,
             skipped_project_count: 0,
             failed_project_count: 0,
+            conflicted_project_count: 0,
             received_artifacts,
             transfer_counts,
             served_artifact_requests,
@@ -5197,15 +5220,6 @@ mod desktop {
         let imported_projects = finish_staged_remote_import(prepared_remote_import, &mut timings);
         let import_counts = import_outcome_counts(&imported_projects);
 
-        let message = format!(
-            "Sync session with {} completed: served {} artifact request(s), imported {} project(s), skipped {} project(s), failed {} project(s), offered {} local manifest(s).",
-            session.remote_device_id,
-            served_artifact_requests,
-            import_counts.imported,
-            import_counts.skipped,
-            import_counts.failed,
-            local_manifest_count
-        );
         let manifest_errors =
             sync_manifest_errors(&local_offer.manifest_errors, &remote_offer.manifest_errors);
         let completed_at = Utc::now();
@@ -5227,11 +5241,16 @@ mod desktop {
             run_id,
             peer_device_id: session.remote_device_id.clone(),
             remote_device_id: session.remote_device_id,
-            status: sync_result_status(&manifest_errors, import_counts.failed),
+            status: sync_result_status(
+                &manifest_errors,
+                import_counts.failed,
+                import_counts.conflicted,
+            ),
             message: sync_result_message(
                 local_manifest_count,
                 remote_offer.project_manifests.len(),
                 &transfer_counts,
+                manifest_errors.len(),
                 import_counts,
             ),
             selected_transport,
@@ -5244,8 +5263,11 @@ mod desktop {
             project_results,
             imported_projects,
             imported_project_count: import_counts.imported,
+            applied_project_count: import_counts.applied,
+            deleted_project_count: import_counts.deleted,
             skipped_project_count: import_counts.skipped,
             failed_project_count: import_counts.failed,
+            conflicted_project_count: import_counts.conflicted,
             received_artifacts,
             transfer_counts,
             served_artifact_requests,
@@ -5270,7 +5292,7 @@ mod desktop {
         };
 
         Ok(IncomingSessionResult {
-            message,
+            message: sync_result.message.clone(),
             sync_result,
         })
     }
@@ -6661,8 +6683,11 @@ mod desktop {
     #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
     struct ImportOutcomeCounts {
         imported: usize,
+        applied: usize,
+        deleted: usize,
         skipped: usize,
         failed: usize,
+        conflicted: usize,
     }
 
     fn stage_remote_manifest_artifacts(
@@ -8769,7 +8794,10 @@ mod desktop {
         for result in results {
             match result.status.as_str() {
                 "imported" => counts.imported += 1,
-                "failed" | "conflicted" => counts.failed += 1,
+                "applied" => counts.applied += 1,
+                "deleted" => counts.deleted += 1,
+                "failed" => counts.failed += 1,
+                "conflicted" => counts.conflicted += 1,
                 _ => counts.skipped += 1,
             }
         }
@@ -8779,8 +8807,9 @@ mod desktop {
     fn sync_result_status(
         manifest_errors: &[SyncTransportManifestError],
         failed_project_count: usize,
+        conflicted_project_count: usize,
     ) -> String {
-        if failed_project_count > 0 || !manifest_errors.is_empty() {
+        if failed_project_count > 0 || conflicted_project_count > 0 || !manifest_errors.is_empty() {
             "completed_with_errors"
         } else {
             "completed"
@@ -8812,16 +8841,21 @@ mod desktop {
         local_manifest_count: usize,
         remote_manifest_count: usize,
         transfer_counts: &SyncTransportTransferCounts,
+        manifest_error_count: usize,
         import_counts: ImportOutcomeCounts,
     ) -> String {
         format!(
-            "Exchanged {local_manifest_count} local and {remote_manifest_count} remote manifest(s); imported {} project(s), skipped {} project(s), failed {} project(s), received {} artifact(s), reused {} staged artifact(s), failed {} transfer(s).",
+            "Exchanged {local_manifest_count} local and {remote_manifest_count} remote manifest(s); final project outcomes: imported {}, applied {}, deleted {}, skipped {}, conflicted {}, failed {}; transfers: received {}, reused/already staged {}, failed {}; manifest export errors (separate from final project outcomes): {}.",
             import_counts.imported,
+            import_counts.applied,
+            import_counts.deleted,
             import_counts.skipped,
+            import_counts.conflicted,
             import_counts.failed,
             transfer_counts.received,
             transfer_counts.already_staged,
-            transfer_counts.failed
+            transfer_counts.failed,
+            manifest_error_count
         )
     }
 
@@ -17541,7 +17575,7 @@ mod desktop {
             let import_counts = import_outcome_counts(&project_results);
             assert_eq!(import_counts.failed, 4);
             assert_eq!(
-                sync_result_status(&[], import_counts.failed),
+                sync_result_status(&[], import_counts.failed, import_counts.conflicted),
                 "completed_with_errors"
             );
         }
@@ -20101,8 +20135,11 @@ mod desktop {
                 counts,
                 ImportOutcomeCounts {
                     imported: 1,
+                    applied: 0,
+                    deleted: 0,
                     skipped: 1,
-                    failed: 2,
+                    failed: 1,
+                    conflicted: 1,
                 }
             );
         }
@@ -20218,11 +20255,33 @@ mod desktop {
         }
 
         #[test]
-        fn sync_result_summary_distinguishes_import_skips_and_failures() {
+        fn sync_result_summary_reports_no_project_changes_without_errors() {
+            let counts = ImportOutcomeCounts::default();
+            assert_eq!(
+                sync_result_status(&[], counts.failed, counts.conflicted),
+                "completed"
+            );
+            assert_eq!(
+                sync_result_message(
+                    0,
+                    0,
+                    &SyncTransportTransferCounts::default(),
+                    0,
+                    counts,
+                ),
+                "Exchanged 0 local and 0 remote manifest(s); final project outcomes: imported 0, applied 0, deleted 0, skipped 0, conflicted 0, failed 0; transfers: received 0, reused/already staged 0, failed 0; manifest export errors (separate from final project outcomes): 0."
+            );
+        }
+
+        #[test]
+        fn sync_result_summary_distinguishes_failed_and_conflicted_projects() {
             let counts = ImportOutcomeCounts {
                 imported: 2,
+                applied: 1,
+                deleted: 1,
                 skipped: 1,
                 failed: 1,
+                conflicted: 1,
             };
             let transfer_counts = SyncTransportTransferCounts {
                 requested: 8,
@@ -20234,12 +20293,37 @@ mod desktop {
             };
 
             assert_eq!(
-                sync_result_status(&[], counts.failed),
+                sync_result_status(&[], counts.failed, counts.conflicted),
                 "completed_with_errors"
             );
-            let message = sync_result_message(4, 5, &transfer_counts, counts);
-            let expected = "Exchanged 4 local and 5 remote manifest(s); imported 2 project(s), skipped 1 project(s), failed 1 project(s), received 6 artifact(s), reused 1 staged artifact(s), failed 1 transfer(s).";
+            let message = sync_result_message(4, 5, &transfer_counts, 0, counts);
+            let expected = "Exchanged 4 local and 5 remote manifest(s); final project outcomes: imported 2, applied 1, deleted 1, skipped 1, conflicted 1, failed 1; transfers: received 6, reused/already staged 1, failed 1; manifest export errors (separate from final project outcomes): 0.";
             assert_eq!(message, expected);
+        }
+
+        #[test]
+        fn sync_result_summary_reports_manifest_errors_without_project_failures() {
+            let counts = ImportOutcomeCounts::default();
+            let transfer_counts = SyncTransportTransferCounts::default();
+            let manifest_errors = vec![
+                SyncTransportManifestError {
+                    project_id: "proj_local".to_string(),
+                    message: "Local manifest export failed: local".to_string(),
+                },
+                SyncTransportManifestError {
+                    project_id: "proj_peer".to_string(),
+                    message: "Peer manifest export failed: peer".to_string(),
+                },
+            ];
+
+            assert_eq!(
+                sync_result_status(&manifest_errors, counts.failed, counts.conflicted),
+                "completed_with_errors"
+            );
+            assert_eq!(
+                sync_result_message(1, 1, &transfer_counts, manifest_errors.len(), counts),
+                "Exchanged 1 local and 1 remote manifest(s); final project outcomes: imported 0, applied 0, deleted 0, skipped 0, conflicted 0, failed 0; transfers: received 0, reused/already staged 0, failed 0; manifest export errors (separate from final project outcomes): 2."
+            );
         }
 
         #[test]
@@ -20423,8 +20507,11 @@ mod desktop {
                 project_results: Vec::new(),
                 imported_projects: Vec::new(),
                 imported_project_count: 0,
+                applied_project_count: 0,
+                deleted_project_count: 0,
                 skipped_project_count: 0,
                 failed_project_count: 0,
+                conflicted_project_count: 0,
                 received_artifacts: Vec::new(),
                 transfer_counts: SyncTransportTransferCounts::default(),
                 served_artifact_requests: 1,
@@ -20497,6 +20584,7 @@ mod desktop {
             );
             assert_eq!(value.get("totalReceivedBytes"), Some(&json!(30)));
             assert_eq!(value.get("totalServedBytes"), Some(&json!(70)));
+            assert_eq!(value.get("conflictedProjectCount"), Some(&json!(0)));
             assert_eq!(value.get("timeToFirstArtifactMs"), Some(&json!(250)));
             assert_eq!(value.get("throughputBytesPerSecond"), Some(&json!(50.0)));
             assert_eq!(value.get("scratchPeakBytes"), Some(&json!(0)));
@@ -20555,8 +20643,11 @@ mod desktop {
                 project_results: Vec::new(),
                 imported_projects: Vec::new(),
                 imported_project_count: 0,
+                applied_project_count: 0,
+                deleted_project_count: 0,
                 skipped_project_count: 0,
                 failed_project_count: 0,
+                conflicted_project_count: 0,
                 received_artifacts: Vec::new(),
                 transfer_counts: SyncTransportTransferCounts::default(),
                 served_artifact_requests: 0,
@@ -20645,7 +20736,7 @@ mod desktop {
                 errors[1].message,
                 "Peer manifest export failed: peer failure"
             );
-            assert_eq!(sync_result_status(&errors, 0), "completed_with_errors");
+            assert_eq!(sync_result_status(&errors, 0, 0), "completed_with_errors");
         }
 
         #[test]

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -3,7 +3,9 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MobileCapabilities } from "@tuneforge/shared-types";
 import {
+  mergeSyncProjectResults,
   normalizeSyncTransportStatus,
+  syncRunCanonicalCounts,
   type JobSchema,
   type ProjectSchema,
   type SyncPairingPayloadSchema,
@@ -58,6 +60,45 @@ const nearbyIrohEndpointHint = `${irohTransportId}://device_peer_1?direct=192.16
 const nearbyTcpEndpointHint = `${tcpTransportId}://192.168.1.58:48625?device_id=device_peer_1&v=1`;
 const syncEndpointHints = [irohEndpointHint, tcpEndpointHint];
 const listenerEndpointHints = [irohEndpointHint, listenerTcpEndpointHint];
+
+type CanonicalSummaryCounts = Partial<Record<
+  "local" | "remote" | "imported" | "applied" | "deleted" | "skipped" | "conflicted" | "failed" |
+  "received" | "reused" | "failedTransfers" | "manifestErrors",
+  number | "unknown"
+>>;
+
+function canonicalSummary(overrides: CanonicalSummaryCounts = {}) {
+  const counts = {
+    local: "unknown",
+    remote: "unknown",
+    imported: 0,
+    applied: 0,
+    deleted: 0,
+    skipped: 0,
+    conflicted: 0,
+    failed: 0,
+    received: 0,
+    reused: 0,
+    failedTransfers: 0,
+    manifestErrors: 0,
+    ...overrides,
+  };
+  return `Exchanged ${counts.local} local and ${counts.remote} remote manifest(s); final project outcomes: imported ${counts.imported}, applied ${counts.applied}, deleted ${counts.deleted}, skipped ${counts.skipped}, conflicted ${counts.conflicted}, failed ${counts.failed}; transfers: received ${counts.received}, reused/already staged ${counts.reused}, failed ${counts.failedTransfers}; manifest export errors (separate from final project outcomes): ${counts.manifestErrors}.`;
+}
+
+const defaultSyncNowCanonicalSummary = canonicalSummary({
+  local: 2,
+  remote: 4,
+  applied: 1,
+  skipped: 1,
+  conflicted: 1,
+  failed: 1,
+  received: 1,
+  manifestErrors: 1,
+});
+const importedNoRemoteCanonicalSummary = canonicalSummary({ imported: 1 });
+const importedOneRemoteCanonicalSummary = canonicalSummary({ local: 0, remote: 1, imported: 1 });
+const listenerAppliedCanonicalSummary = canonicalSummary({ imported: 1, applied: 1, deleted: 1, conflicted: 1 });
 const androidCapabilities: MobileCapabilities = {
   platform: "android",
   mediaBackend: "android_media_codec",
@@ -134,6 +175,17 @@ function pairingPayload(overrides: Partial<SyncPairingPayloadSchema> = {}): Sync
 }
 
 function syncRunStatus(overrides: Partial<SyncTransportRunStatus> = {}): SyncTransportRunStatus {
+  const hasCompleteAccounting = [
+    "project_results",
+    "manifest_errors",
+    "imported_project_count",
+    "applied_project_count",
+    "deleted_project_count",
+    "skipped_project_count",
+    "conflicted_project_count",
+    "failed_project_count",
+    "manifest_export_error_count",
+  ].some((key) => Object.prototype.hasOwnProperty.call(overrides, key));
   return {
     peer_device_id: "device_peer_1",
     remote_device_id: "device_peer_1",
@@ -145,6 +197,13 @@ function syncRunStatus(overrides: Partial<SyncTransportRunStatus> = {}): SyncTra
     project_results: [],
     manifest_errors: [],
     received_artifacts: [],
+    ...(hasCompleteAccounting
+      ? {
+          project_results_complete: true,
+          manifest_errors_complete: true,
+          received_artifacts_complete: true,
+        }
+      : {}),
     ...overrides,
   };
 }
@@ -321,6 +380,20 @@ async function exportEvidenceFromCurrentSyncResult(user: ReturnType<typeof userE
     clickSpy.mockRestore();
     setTimeoutSpy.mockRestore();
   }
+}
+
+type SyncEvidenceValidationResult = {
+  ok: boolean;
+  schemaPrivacyOk: boolean;
+  errors: string[];
+};
+
+async function validateExportedEvidence(evidence: unknown): Promise<SyncEvidenceValidationResult> {
+  // @ts-expect-error JS validator has no TypeScript declaration.
+  const validator = await import("../../../scripts/sync-validation.mjs") as {
+    validateEvidence: (value: unknown) => SyncEvidenceValidationResult;
+  };
+  return validator.validateEvidence(evidence);
 }
 
 function setDocumentVisibility(value: DocumentVisibilityState) {
@@ -691,36 +764,31 @@ describe("Desktop app activity", () => {
     await openSyncTab(user);
 
     await user.click(screen.getByRole("button", { name: "Start Listener" }));
-    expect(await screen.findByText("Listening")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Create Pairing Offer" }));
-    expect(await screen.findByLabelText("Local pairing code")).toBeInTheDocument();
-
     await user.click(screen.getByText("Advanced"));
-    expect((screen.getByLabelText("Local pairing offer raw JSON") as HTMLTextAreaElement).value).toContain(
-      '"signature": "pair_signature_1"',
-    );
+    expect((await screen.findByLabelText("Local pairing offer raw JSON") as HTMLTextAreaElement).value)
+      .toContain('"signature": "pair_signature_1"');
     await user.click(screen.getByRole("button", { name: "Copy Raw Offer" }));
     expect(writeText).toHaveBeenLastCalledWith(expect.stringContaining('"signature": "pair_signature_1"'));
 
     fireEvent.change(screen.getByLabelText("Peer pairing code"), {
-      target: { value: encodePairingCode(pairingPayload({ device_id: "stale_device" })) },
+      target: { value: encodePairingCode(pairingPayload({ device_id: "device_stale" })) },
     });
-    expect(screen.getByLabelText("Peer pairing confirmation")).toHaveTextContent("stale_device");
+    expect(screen.getByLabelText("Peer pairing confirmation")).toHaveTextContent("device_stale");
+
     fireEvent.change(screen.getByLabelText("Pasted raw JSON payload"), {
       target: { value: JSON.stringify(payload) },
     });
     expect(screen.getByLabelText("Peer pairing code")).toHaveValue("");
     expect(screen.getByLabelText("Peer pairing confirmation")).toHaveTextContent(pairingFingerprint(payload));
-    expect(screen.getByLabelText(/Adopt peer sync group for third-device join/)).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "Adopt peer sync group for third-device join" }))
+      .not.toBeChecked();
     await user.click(screen.getByRole("button", { name: "Answer Offer" }));
-
-    await waitFor(() =>
-      expect(mockAnswerSyncPairingOffer).toHaveBeenCalledWith({
-        offer: expect.objectContaining({ device_id: "device_peer_1" }),
-        endpoint_hints: listenerEndpointHints,
-        adopt_sync_group: false,
-      }),
-    );
+    await waitFor(() => expect(mockAnswerSyncPairingOffer).toHaveBeenCalledWith({
+      offer: expect.objectContaining({ device_id: "device_peer_1" }),
+      endpoint_hints: listenerEndpointHints,
+      adopt_sync_group: false,
+    }));
   });
 
   it("hides QR scanning on desktop", async () => {
@@ -1329,14 +1397,13 @@ describe("Desktop app activity", () => {
     expect(within(laptopRow as HTMLElement).getByText("A1B2-C3D4-E5F6-7890")).toBeInTheDocument();
     expect(within(laptopRow as HTMLElement).getByText("Trusted")).toBeInTheDocument();
     expect(
-      within(laptopRow as HTMLElement).getByText((content) => content.includes(nearbyIrohEndpointHint)),
+      within(laptopRow as HTMLElement).getByText([nearbyIrohEndpointHint, nearbyTcpEndpointHint].join(", ")),
     ).toBeInTheDocument();
     expect(within(laptopRow as HTMLElement).getByText(/Apr 18/)).toBeInTheDocument();
     expect(within(guestRow as HTMLElement).getByText("Unknown")).toBeInTheDocument();
     expect(within(guestRow as HTMLElement).getByRole("button", { name: "Pair Required" })).toBeDisabled();
     expect(within(mismatchRow as HTMLElement).getByText("Trust mismatch")).toBeInTheDocument();
     expect(within(mismatchRow as HTMLElement).getByRole("button", { name: "Trust Mismatch" })).toBeDisabled();
-
     await user.click(within(laptopRow as HTMLElement).getByRole("button", { name: "Sync Now" }));
 
     await waitFor(() =>
@@ -1363,6 +1430,7 @@ describe("Desktop app activity", () => {
     const peers = await screen.findByRole("list", { name: "Trusted sync peers" });
     const peerRow = within(peers).getByText("Laptop Rig").closest("li");
     expect(peerRow).not.toBeNull();
+    expect(within(peerRow as HTMLElement).getByText("device_peer_1")).toBeInTheDocument();
     expect(within(peerRow as HTMLElement).getByText(syncEndpointHints.join(", "))).toBeInTheDocument();
     const preflightSection = screen.getByRole("heading", { name: "Local Readiness" }).closest("section");
     expect(preflightSection).not.toBeNull();
@@ -1376,10 +1444,11 @@ describe("Desktop app activity", () => {
     expect(mockGetSyncPreflight.mock.invocationCallOrder[0]).toBeLessThan(
       mockSyncTrustedPeerNow.mock.invocationCallOrder[0],
     );
-    expect(await screen.findAllByText("Manifest exchange completed with 4 project results.")).not.toHaveLength(0);
+    expect(await screen.findAllByText(defaultSyncNowCanonicalSummary)).not.toHaveLength(0);
+    expect(screen.queryByText("Manifest exchange completed with 4 project results.")).not.toBeInTheDocument();
     expect(screen.getByText(/Transport Iroh/)).toBeInTheDocument();
 
-    const projectResults = await screen.findByRole("list", { name: "Last sync project results" });
+    const projectResults = await screen.findByRole("list", { name: "Last sync project evidence" });
     const resultRows = within(projectResults).getAllByRole("listitem");
     expect(resultRows).toHaveLength(4);
     expect(within(resultRows[0]).getByText("Applied")).toBeInTheDocument();
@@ -1388,6 +1457,7 @@ describe("Desktop app activity", () => {
     expect(within(resultRows[1]).getByText("Skipped")).toBeInTheDocument();
     expect(within(resultRows[1]).getByText("proj_up_to_date")).toBeInTheDocument();
     expect(within(resultRows[2]).getByText("Conflicted")).toBeInTheDocument();
+    expect(within(resultRows[2]).getByText("proj_conflict")).toBeInTheDocument();
     expect(within(resultRows[2]).getByText("Local lyrics conflict with the trusted peer revision.")).toBeInTheDocument();
     expect(within(resultRows[3]).getByText("Failed")).toBeInTheDocument();
     expect(within(resultRows[3]).getByText("proj_missing_audio")).toBeInTheDocument();
@@ -1447,8 +1517,8 @@ describe("Desktop app activity", () => {
     await user.click(within(peerRow as HTMLElement).getByRole("button", { name: "Sync Now" }));
 
     await waitFor(() => expect(mockSyncTrustedPeerNow).toHaveBeenCalledWith("device_peer_1"));
-    expect(await screen.findAllByText("Applied and imported project data.")).not.toHaveLength(0);
-    const projectResults = await screen.findByRole("list", { name: "Last sync project results" });
+    expect(await screen.findAllByText(canonicalSummary({ imported: 1, applied: 1 }))).not.toHaveLength(0);
+    const projectResults = await screen.findByRole("list", { name: "Last sync project evidence" });
     const resultRows = within(projectResults).getAllByRole("listitem");
     expect(resultRows).toHaveLength(2);
     expect(within(resultRows[0]).getByText("Applied")).toBeInTheDocument();
@@ -1523,9 +1593,9 @@ describe("Desktop app activity", () => {
       await queryClient.invalidateQueries({ queryKey: ["sync", "listener"] });
     });
     await waitFor(() => expect(mockGetSyncTransportStatus.mock.calls.length).toBeGreaterThan(listenerStatusCalls));
-    expect(await screen.findAllByText("Listener applied cached project data.")).not.toHaveLength(0);
+    expect(await screen.findAllByText(listenerAppliedCanonicalSummary)).not.toHaveLength(0);
 
-    const projectResults = await screen.findByRole("list", { name: "Last sync project results" });
+    const projectResults = await screen.findByRole("list", { name: "Last sync project evidence" });
     const resultRows = within(projectResults).getAllByRole("listitem");
     expect(resultRows).toHaveLength(4);
     expect(within(resultRows[0]).getByText("Applied")).toBeInTheDocument();
@@ -1598,7 +1668,8 @@ describe("Desktop app activity", () => {
 
     await waitFor(() => expect(mockGetSyncPreflight).toHaveBeenCalled());
     await waitFor(() => expect(mockSyncTrustedPeerNow).toHaveBeenCalledWith("device_peer_1"));
-    expect(await screen.findAllByText("Manifest exchange completed with 4 project results.")).not.toHaveLength(0);
+    expect(await screen.findAllByText(defaultSyncNowCanonicalSummary)).not.toHaveLength(0);
+    expect(screen.queryByText("Manifest exchange completed with 4 project results.")).not.toBeInTheDocument();
   });
 
   it("hides preflight job details and cancel controls while showing compact job summary", async () => {
@@ -1724,8 +1795,11 @@ describe("Desktop app activity", () => {
             message: "Entity revision manifest content_sha256 must match payload.",
           },
         ],
+        project_results_complete: true,
         manifest_errors: [],
+        manifest_errors_complete: true,
         received_artifacts: [],
+        received_artifacts_complete: true,
         served_artifact_requests: 0,
         local_manifest_count: 0,
         remote_manifest_count: 2,
@@ -1734,20 +1808,19 @@ describe("Desktop app activity", () => {
 
     await openSyncTab(user);
 
+    expect(await screen.findByText(canonicalSummary({ local: 0, remote: 2, conflicted: 1 }))).toBeInTheDocument();
     expect(
-      await screen.findByText(
+      screen.queryByText(
         "Exchanged 0 local and 2 remote manifest(s); imported 0 project(s), skipped 0 project(s), failed 2 project(s), received 16 artifact(s).",
       ),
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
     expect(screen.getByText(/Transport Iroh/)).toBeInTheDocument();
-    const projectResults = await screen.findByRole("list", { name: "Last sync project results" });
+    const projectResults = await screen.findByRole("list", { name: "Last sync project evidence" });
     const resultRows = within(projectResults).getAllByRole("listitem");
     expect(resultRows).toHaveLength(1);
     expect(within(resultRows[0]).getByText("Conflicted")).toBeInTheDocument();
     expect(within(resultRows[0]).getByText("proj_conflicted")).toBeInTheDocument();
-    expect(
-      within(resultRows[0]).getByText("Entity revision manifest content_sha256 must match payload."),
-    ).toBeInTheDocument();
+    expect(within(resultRows[0]).getByText("Entity revision manifest content_sha256 must match payload.")).toBeInTheDocument();
   });
 
   it("shows partial planner failures from native status without transport fallback", async () => {
@@ -1776,19 +1849,22 @@ describe("Desktop app activity", () => {
             message: "Imported from trusted peer.",
           },
         ],
+        project_results_complete: true,
         manifest_errors: [],
+        manifest_errors_complete: true,
         received_artifacts: [],
+        received_artifacts_complete: true,
       },
     });
 
     await openSyncTab(user);
 
-    expect(await screen.findByText("Completed With Errors for device_peer_1.")).toBeInTheDocument();
+    expect(await screen.findByText(canonicalSummary({ imported: 1, failed: 1 }))).toBeInTheDocument();
     expect(screen.getByText(/Transport Iroh/)).toBeInTheDocument();
-    expect(screen.getByText(/1 imported, 0 skipped, 1 failed/)).toBeInTheDocument();
+    expect(screen.getByText(/1 imported, 0 applied, 0 deleted, 0 skipped, 0 conflicted, 1 failed/)).toBeInTheDocument();
     expect(screen.queryByText(/Fallback/)).not.toBeInTheDocument();
 
-    const projectResults = await screen.findByRole("list", { name: "Last sync project results" });
+    const projectResults = await screen.findByRole("list", { name: "Last sync project evidence" });
     const resultRows = within(projectResults).getAllByRole("listitem");
     expect(resultRows).toHaveLength(2);
     expect(within(resultRows[0]).getByText("Failed")).toBeInTheDocument();
@@ -1831,17 +1907,20 @@ describe("Desktop app activity", () => {
             message: "Previous listener result.",
           },
         ],
+        project_results_complete: true,
         manifest_errors: [],
+        manifest_errors_complete: true,
         received_artifacts: [],
+        received_artifacts_complete: true,
       },
     });
-    mockSyncTrustedPeerNow.mockRejectedValueOnce(
-      "artifact_transfer: Timed out reading from Iroh sync stream.",
-    );
+    const safeFailure = "artifact_transfer: Timed out reading from Iroh sync stream; " +
+      "checksum_mismatch hash_retry_pending sha256_mismatch.";
+    mockSyncTrustedPeerNow.mockRejectedValueOnce(safeFailure);
 
     await openSyncTab(user);
 
-    expect(await screen.findByText("Listener import completed before failed sync now.")).toBeInTheDocument();
+    expect(await screen.findByText(importedNoRemoteCanonicalSummary)).toBeInTheDocument();
     expect(screen.getByText("proj_listener_previous")).toBeInTheDocument();
 
     const peers = await screen.findByRole("list", { name: "Trusted sync peers" });
@@ -1851,11 +1930,11 @@ describe("Desktop app activity", () => {
 
     await waitFor(() => expect(mockSyncTrustedPeerNow).toHaveBeenCalledWith("device_peer_1"));
     expect(
-      await screen.findAllByText("Sync now failed: artifact_transfer: Timed out reading from Iroh sync stream."),
+      await screen.findAllByText(`Sync now failed: ${safeFailure}`),
     ).not.toHaveLength(0);
     expect(screen.queryByText("Listener import completed before failed sync now.")).not.toBeInTheDocument();
-    expect(screen.queryByText("proj_listener_previous")).not.toBeInTheDocument();
-    expect(screen.queryByRole("list", { name: "Last sync project results" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Previous listener result.")).not.toBeInTheDocument();
+    expect(screen.queryByRole("list", { name: "Last sync project evidence" })).not.toBeInTheDocument();
   });
 
   it("enables evidence actions from failed listener last_sync after sync now rejects", async () => {
@@ -1926,12 +2005,45 @@ describe("Desktop app activity", () => {
     await user.click(within(peerRow as HTMLElement).getByRole("button", { name: "Sync Now" }));
 
     await waitFor(() => expect(mockSyncTrustedPeerNow).toHaveBeenCalledWith("device_peer_1"));
-    expect(await screen.findAllByText(`Sync now failed: ${error}`)).not.toHaveLength(0);
+    expect(
+      await screen.findAllByText(`Sync now failed: ${error}`),
+    ).not.toHaveLength(0);
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Copy Evidence" })).toBeEnabled();
       expect(screen.getByRole("button", { name: "Export Evidence" })).toBeEnabled();
     });
     expect(screen.getByRole("list", { name: "Last sync artifact transfers" })).toBeInTheDocument();
+  });
+
+  it("sanitizes raw passive listener last_error details", async () => {
+    const user = userEvent.setup();
+    const privateValues = [
+      "/Users/test/Music/Passive Secret.wav",
+      "proj_passive_secret",
+      "tuneforge-sync+tcp://192.0.2.8:47619",
+      "checksum_deadbeefcafebabe",
+      "checksum_mismatch_shadow",
+      "hash_retry_pending_shadow",
+      "sha256_mismatch_shadow",
+      "content_sha256_deadbeefcafebabefeedface01234567",
+      "content.hash_deadbeefcafebabefeedface01234567",
+      "content-hash_deadbeefcafebabefeedface01234567",
+      "abcdefabcdefabcdefabcdefabcdefab_checksum_mismatch",
+    ];
+    setSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: syncEndpointHints,
+      last_error: `Sync transport artifact request/transfer failed: ${privateValues.join(" ")}`,
+      last_sync: null,
+    });
+
+    await openSyncTab(user);
+
+    expect(await screen.findByText("Sync transport artifact request/transfer failed: details redacted."))
+      .toBeInTheDocument();
+    const visibleText = document.body.textContent ?? "";
+    privateValues.forEach((privateValue) => expect(visibleText).not.toContain(privateValue));
   });
 
   it("sanitizes raw sync now rejection before rendering failed listener evidence", async () => {
@@ -2212,15 +2324,17 @@ describe("Desktop app activity", () => {
       fallback_reason: "Iroh endpoint was unavailable; used TCP.",
       fallback_code: "stale_iroh_hint",
       attempted_transports: ["iroh", "tcp"],
-      status: "completed",
+      status: "completed_with_errors",
       started_at: "2026-04-18T13:16:00.000Z",
       duration_ms: 1250,
       total_received_bytes: 3_000_000,
       total_served_bytes: 1_000_000,
       time_to_first_artifact_ms: 650,
       throughput_bytes_per_second: 3_200_000,
-      imported_project_count: 1,
-      skipped_project_count: 1,
+      imported_project_count: 0,
+      applied_project_count: 1,
+      deleted_project_count: 1,
+      skipped_project_count: 0,
       failed_project_count: 0,
     });
     expect(normalized.endpoint_hints).toEqual(syncEndpointHints);
@@ -2281,6 +2395,81 @@ describe("Desktop app activity", () => {
       status: "deleted",
       deleted_count: 1,
     });
+  });
+
+  it("normalizes legacy failed counts without hiding conflicted projects", () => {
+    const normalized = normalizeSyncTransportStatus({
+      active: true,
+      status: "listening",
+      lastSync: {
+        localManifestCount: 1,
+        remoteManifestCount: 1,
+        skippedProjectCount: 1,
+        failedProjectCount: 2,
+        projectResults: [
+          {
+            projectId: "proj_conflicted_legacy",
+            status: "conflicted",
+            message: "Local lyrics conflict with the trusted peer revision.",
+          },
+          {
+            projectId: "proj_failed_legacy",
+            status: "failed",
+            message: "Peer manifest export failed before transfer.",
+          },
+          {
+            projectId: "proj_skipped_legacy",
+            status: "skipped",
+            message: "Already up to date.",
+          },
+        ],
+        manifestErrors: [],
+        receivedArtifacts: [],
+      },
+    });
+
+    expect(normalized.last_sync).toMatchObject({
+      skipped_project_count: 1,
+      conflicted_project_count: 1,
+      failed_project_count: 1,
+      message:
+        canonicalSummary({ local: 1, remote: 1, skipped: 1, conflicted: 1, failed: 1 }),
+    });
+    expect(normalized.last_sync?.project_results).toEqual([
+      expect.objectContaining({ project_id: "proj_conflicted_legacy", status: "conflicted" }),
+      expect.objectContaining({ project_id: "proj_failed_legacy", status: "failed" }),
+      expect.objectContaining({ project_id: "proj_skipped_legacy", status: "skipped" }),
+    ]);
+  });
+
+  it.each([
+    { label: "failed", inputStatus: undefined, expectedStatus: "completed_with_errors",
+      counts: { failed_project_count: 2, total_project_count: 2 }, expectedMap: { failed: 2 } },
+    { label: "conflicted", inputStatus: "completed_with_errors", expectedStatus: "completed_with_errors",
+      counts: { conflicted_project_count: 1, total_project_count: 1 }, expectedMap: { conflicted: 1 } },
+    { label: "skipped", inputStatus: "completed", expectedStatus: "completed",
+      counts: { skipped_project_count: 3, total_project_count: 3 }, expectedMap: { skipped: 3 } },
+    {
+      label: "no-op",
+      inputStatus: "completed",
+      expectedStatus: "completed",
+      counts: { imported_project_count: 0, applied_project_count: 0, deleted_project_count: 0,
+        skipped_project_count: 0, conflicted_project_count: 0, failed_project_count: 0, total_project_count: 0 },
+      expectedMap: {},
+    },
+  ])("normalizes no-row aggregate $label accounting", ({ inputStatus, expectedStatus, counts, expectedMap }) => {
+    const lastSync = normalizeSyncTransportStatus({
+      active: true,
+      status: "listening",
+      last_sync: {
+        status: inputStatus,
+        received_artifacts: [],
+        ...counts,
+      },
+    }).last_sync;
+
+    expect(lastSync?.status).toBe(expectedStatus);
+    expect(syncRunCanonicalCounts(lastSync!)?.projectResultsByStatus).toEqual(expectedMap);
   });
 
   it("requests auto transport for native sync now runs and normalizes native Iroh IDs", async () => {
@@ -2425,6 +2614,32 @@ describe("Desktop app activity", () => {
     });
 
     expect(legacyPayload.last_sync?.time_to_first_artifact_ms).toBe(800);
+  });
+
+  it("counts only successful received artifact rows in canonical summaries", () => {
+    const normalized = normalizeSyncTransportStatus({
+      active: true,
+      status: "listening",
+      last_sync: {
+        local_manifest_count: 1,
+        remote_manifest_count: 1,
+        imported_project_count: 0,
+        applied_project_count: 0,
+        deleted_project_count: 0,
+        skipped_project_count: 0,
+        conflicted_project_count: 0,
+        failed_project_count: 1,
+        received_artifacts: [
+          { artifact_id: "art_received", status: "received" },
+          { artifact_id: "art_failed", status: "failed" },
+          { artifact_id: "art_reused", status: "already_staged" },
+        ],
+      },
+    });
+
+    expect(normalized.last_sync?.message).toContain(
+      "transfers: received 1, reused/already staged 1, failed 1",
+    );
   });
 
   it("normalizes Iroh flow-control evidence from snake and camel metrics", () => {
@@ -2608,13 +2823,55 @@ describe("Desktop app activity", () => {
     });
 
     expect(normalized.last_sync?.status).toBe("completed_with_errors");
-    expect(normalized.last_sync?.project_results).toEqual([
+    expect(normalized.last_sync?.failed_project_count).toBe(0);
+    expect(normalized.last_sync?.manifest_export_error_count).toBe(1);
+    expect(normalized.last_sync?.message).toContain(
+      "manifest export errors (separate from final project outcomes): 1",
+    );
+    expect(mergeSyncProjectResults(
+      normalized.last_sync?.project_results ?? [],
+      normalized.last_sync?.manifest_errors ?? [],
+    )).toEqual([
       expect.objectContaining({
         project_id: "proj_staging",
-        status: "failed",
+        status: "manifest_export_error",
         message: "Peer manifest export failed before apply.",
       }),
     ]);
+  });
+
+  it("preserves unknown legacy sync accounting instead of fabricating zero counts", () => {
+    const normalized = normalizeSyncTransportStatus({
+      active: true,
+      status: "listening",
+      last_sync: {
+        status: "completed",
+        message: "Legacy sync completed.",
+        local_manifest_count: 1,
+      },
+    });
+    const lastSync = normalized.last_sync;
+
+    expect(lastSync).not.toBeNull();
+    expect(lastSync).toMatchObject({
+      project_results_complete: false,
+      manifest_errors_complete: false,
+      received_artifacts_complete: false,
+      imported_project_count: null,
+      failed_project_count: null,
+      manifest_export_error_count: null,
+      message: "Legacy sync completed.",
+    });
+    expect(syncRunCanonicalCounts(lastSync!)).toMatchObject({
+      importedProjectCount: null,
+      failedProjectCount: null,
+      receivedArtifactCount: null,
+      reusedArtifactCount: null,
+      failedTransferCount: null,
+      manifestExportErrorCount: null,
+      totalProjectCount: null,
+      hasCompleteTransferEvidence: false,
+    });
   });
 
   it("shows final retry and delete catch-up rows without obsolete failures", async () => {
@@ -2736,16 +2993,20 @@ describe("Desktop app activity", () => {
 
     await openSyncTab(user);
 
-    expect(await screen.findByText("Retry completed after staged bytes were reused.")).toBeInTheDocument();
+    expect(
+      await screen.findByText(canonicalSummary({ applied: 1, deleted: 1, received: 1, manifestErrors: 2 })),
+    ).toBeInTheDocument();
     expect(screen.getByText(/Run sync_run_retry_2/)).toBeInTheDocument();
     expect(screen.getByText(/Duration 1\.4 s/)).toBeInTheDocument();
     expect(screen.getByText(/Transport TCP/)).toBeInTheDocument();
     expect(screen.getByText(/Fallback: Iroh endpoint was unavailable; used TCP\./)).toBeInTheDocument();
-    expect(screen.getByText(/1 imported, 1 skipped, 0 failed/)).toBeInTheDocument();
+    expect(screen.getByText(/0 imported, 1 applied, 1 deleted, 0 skipped, 0 conflicted, 0 failed/)).toBeInTheDocument();
     expect(screen.getByText(/TTFA 450 ms/)).toBeInTheDocument();
-    expect(screen.getByText(/4\.0 MB total/)).toBeInTheDocument();
-    expect(screen.getByText(/2\.5 MB\/s/)).toBeInTheDocument();
-    expect(screen.getByText(/Slowest Backend Staging 900 ms/)).toBeInTheDocument();
+    expect(screen.getByText(/3\.0 MB received/)).toBeInTheDocument();
+    expect(screen.getByText(/1\.0 MB sent/)).toBeInTheDocument();
+    expect(screen.getByText(/Receive 2\.1 MB\/s/)).toBeInTheDocument();
+    expect(screen.getByText(/Send 714 KB\/s/)).toBeInTheDocument();
+    expect(screen.getByText(/Largest aggregate phase Artifact Staging 900 ms/)).toBeInTheDocument();
     expect(screen.getByText(/Scratch peak 64 MB/)).toBeInTheDocument();
     expect(screen.getByText(/Staging peak 12 MB/)).toBeInTheDocument();
     expect(screen.getByText(/Max 8 streams/)).toBeInTheDocument();
@@ -2756,7 +3017,7 @@ describe("Desktop app activity", () => {
     );
     expect(diagnosticsSummary).not.toHaveTextContent(/\+\d+ more/);
 
-    const projectResults = await screen.findByRole("list", { name: "Last sync project results" });
+    const projectResults = await screen.findByRole("list", { name: "Last sync project evidence" });
     const resultRows = within(projectResults).getAllByRole("listitem");
     expect(resultRows).toHaveLength(2);
     expect(within(resultRows[0]).getByText("Applied")).toBeInTheDocument();
@@ -2785,6 +3046,11 @@ describe("Desktop app activity", () => {
 
   it("exports privacy-safe evidence from listener last_sync", async () => {
     const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
     setSyncTransportStatus({
       active: true,
       status: "listening",
@@ -2902,6 +3168,7 @@ describe("Desktop app activity", () => {
           {
             project_id: "proj_export_alpha",
             status: "applied",
+            phase: "backend_staging_shadow",
             message: "Retry imported proj_export_alpha from '/Users/test/Music/Secret Demo.wav'.",
             is_final: true,
             started_at: "2026-04-18T13:16:00.500Z",
@@ -2913,7 +3180,7 @@ describe("Desktop app activity", () => {
         manifest_errors: [],
         phase_timings: [
           {
-            phase: "artifact_transfer",
+            phase: "network_receive",
             project_id: "proj_export_alpha",
             artifact_id: "art_export_alpha",
             started_at: "2026-04-18T13:16:00.200Z",
@@ -2921,6 +3188,8 @@ describe("Desktop app activity", () => {
             duration_ms: 450,
             throughput_bytes_per_second: 2_000_000,
           },
+          { phase: "staging_post", duration_ms: null },
+          { phase: "staging_apply_plan", duration_ms: null },
         ],
         received_artifacts: [
           {
@@ -2948,6 +3217,14 @@ describe("Desktop app activity", () => {
 
     await openSyncTab(user);
 
+    await user.click(screen.getByRole("button", { name: "Copy Evidence" }));
+    await waitFor(() => expect(writeText).toHaveBeenCalledOnce());
+    const copiedSerialized = writeText.mock.calls[0]?.[0];
+    expect(typeof copiedSerialized).toBe("string");
+    expect(JSON.parse(copiedSerialized as string)).toMatchObject({
+      scenario: "listener-last-sync",
+      validation: { privacySafe: true },
+    });
     expect(screen.getByRole("button", { name: "Export Evidence" })).toBeEnabled();
     const exportedJson = await exportEvidenceFromCurrentSyncResult(user);
 
@@ -2972,7 +3249,7 @@ describe("Desktop app activity", () => {
       listenerStatus: "listening",
     });
     expect(exportedJson.run).toMatchObject({
-      label: "run_1",
+      label: "Run 1",
       peer: "peer_1",
       remotePeer: "peer_1",
       hasRunId: true,
@@ -2984,12 +3261,18 @@ describe("Desktop app activity", () => {
       attempted: [irohTransportId, tcpTransportId],
       fallback: {
         code: "stale_iroh_hint",
-        reason: expect.stringContaining("[redacted_endpoint]"),
+        reason: "details redacted.",
       },
     });
     expect(exportedJson.metrics).toMatchObject({
       timeToFirstArtifactMs: 650,
       throughputBytesPerSecond: 3_200_000,
+      network_receive_throughput_bytes_per_second: 800_000,
+      network_send_throughput_bytes_per_second: 7_200_000,
+      total_received_bytes: 1_000_000,
+      total_served_bytes: 9_000_000,
+      project_imports_per_minute: 0,
+      project_mutations_per_minute: 48,
       retryIndicators: {
         duplicateProjectEvents: true,
         messageMentionsRetry: true,
@@ -3008,8 +3291,9 @@ describe("Desktop app activity", () => {
     );
     expect(exportedJson.projects).toEqual([
       expect.objectContaining({
-        label: "project_1",
+        label: "Project 1",
         status: "applied",
+        phase: "phase_redacted",
         counts: expect.objectContaining({
           applied: 2,
           reusedArtifacts: 1,
@@ -3022,13 +3306,13 @@ describe("Desktop app activity", () => {
     ]);
     expect(exportedJson.artifacts).toEqual([
       expect.objectContaining({
-        label: "artifact_1",
+        label: "Artifact 1",
         status: "received",
         throughputBytesPerSecond: 2_000_000,
         reused: false,
       }),
       expect.objectContaining({
-        label: "artifact_2",
+        label: "Artifact 2",
         status: "already_staged",
         reused: true,
       }),
@@ -3052,12 +3336,12 @@ describe("Desktop app activity", () => {
         kind: "network_offline",
         retryable: true,
         interruptionCode: "network_offline",
-        retryGuidance: expect.stringContaining("peer_1"),
+        retryGuidance: "details redacted.",
         peer: "peer_1",
         hasRunId: true,
       }),
       retryableInterruptionCode: "network_offline",
-      retryGuidance: expect.stringContaining("peer_1"),
+      retryGuidance: "details redacted.",
       listener: {
         active: true,
         status: "listening",
@@ -3079,9 +3363,12 @@ describe("Desktop app activity", () => {
       phaseTimings: [
         expect.objectContaining({
           label: "phase_1",
-          project: "project_1",
-          artifact: "artifact_1",
+          phase: "artifact_transfer",
+          project: "Project 1",
+          artifact: "Artifact 1",
         }),
+        expect.objectContaining({ phase: "artifact_staging" }),
+        expect.objectContaining({ phase: "reconciliation_staging" }),
       ],
     });
     expect(exportedJson.storage).toMatchObject({
@@ -3100,26 +3387,65 @@ describe("Desktop app activity", () => {
       },
     });
 
-    const serialized = JSON.stringify(exportedJson);
-    expect(serialized).toContain("peer_1");
-    expect(serialized).toContain("project_1");
-    expect(serialized).toContain("artifact_1");
-    expect(serialized).not.toContain("device_peer_1");
-    expect(serialized).not.toContain("sync_run_export_listener");
-    expect(serialized).not.toContain("proj_export_alpha");
-    expect(serialized).not.toContain("art_export_alpha");
-    expect(serialized).not.toContain("sha256-export-alpha");
-    expect(serialized).not.toContain("Studio Desktop");
-    expect(serialized).not.toContain("endpoint_hints");
-    expect(serialized).not.toContain("Mix.wav");
-    expect(serialized).not.toContain("Secret Demo.wav");
-    expect(serialized).not.toContain("C:\\Users");
-    expect(serialized).not.toContain("C:\\\\Users");
-    expect(serialized).not.toContain("file://");
-    expect(serialized).not.toContain("/Users/test/Music");
-    expect(serialized).not.toContain("/tmp/demo.wav");
-    expect(serialized).not.toContain("tuneforge-sync+tcp://192.168.1.42:48625");
+    [copiedSerialized as string, JSON.stringify(exportedJson)].forEach((serialized) => {
+      expect(serialized).toContain("peer_1");
+      expect(serialized).toContain("Project 1");
+      expect(serialized).toContain("Artifact 1");
+      [
+        "device_peer_1",
+        "sync_run_export_listener",
+        "proj_export_alpha",
+        "art_export_alpha",
+        "sha256-export-alpha",
+        "Studio Desktop",
+        "endpoint_hints",
+        "Mix.wav",
+        "Secret Demo.wav",
+        "C:\\Users",
+        "C:\\\\Users",
+        "file://",
+        "/Users/test/Music",
+        "/tmp/demo.wav",
+        "tuneforge-sync+tcp://192.168.1.42:48625",
+      ].forEach((privateValue) => expect(serialized).not.toContain(privateValue));
+    });
   });
+
+  it.each([
+    [0, 0, false], [2, 2, true], [2, 0, false],
+  ])("exports message reuse %i with numeric reuse %i as %s", async (messageCount, reuseCount, expected) => {
+    const user = userEvent.setup();
+    setSyncTransportStatus({ active: true, status: "listening", endpoint_hints: listenerEndpointHints,
+      last_sync: syncRunStatus({ message: canonicalSummary({ local: 1, remote: 0, reused: messageCount }),
+        project_results: [], received_artifacts: Array.from({ length: reuseCount }, (_, index) => ({
+          artifact_id: `art_reuse_${index}`, status: "already_staged" })) }) });
+
+    await openSyncTab(user);
+    const exportedJson = await exportEvidenceFromCurrentSyncResult(user);
+    expect(exportedJson.metrics).toMatchObject({ reuseIndicators: { messageMentionsReuse: expected } });
+  });
+
+  it.each([[2, false, null], [1, false, 100], [2, true, null]])(
+    "exports received bytes for count %i complete %s as %s", async (receivedCount, complete, expected) => {
+      const user = userEvent.setup();
+      setSyncTransportStatus({ active: true, status: "listening", endpoint_hints: listenerEndpointHints,
+        last_sync: syncRunStatus({ duration_ms: 1000, transfer_counts: { received: receivedCount },
+          received_artifacts_complete: complete, received_artifacts: [
+            { artifact_id: "art_received", status: "received", size_bytes: 100 },
+            { artifact_id: "art_failed", status: "failed", size_bytes: 900 }] }) });
+      await openSyncTab(user);
+      const exportedJson = await exportEvidenceFromCurrentSyncResult(user);
+      expect(exportedJson.metrics).toMatchObject({ total_received_bytes: expected,
+        received_artifacts_complete: complete });
+      const issues = (exportedJson.validation as { issues: string[] }).issues;
+      expect(issues.includes("received_artifact_count_mismatch")).toBe(complete);
+      if (complete) {
+        expect(exportedJson.validation).toMatchObject({ ok: false });
+        expect((await validateExportedEvidence(exportedJson)).errors.join(" "))
+          .toMatch(/Complete received artifact rows disagree with authoritative received count/);
+      }
+    },
+  );
 
   it("does not export UI fallback listener status with trusted peer display names", async () => {
     const user = userEvent.setup();
@@ -3157,7 +3483,7 @@ describe("Desktop app activity", () => {
 
     await openSyncTab(user);
 
-    expect(await screen.findByText("Completed for Laptop Rig.")).toBeInTheDocument();
+    expect(await screen.findByText(importedNoRemoteCanonicalSummary)).toBeInTheDocument();
     const exportedJson = await exportEvidenceFromCurrentSyncResult(user);
     const serialized = JSON.stringify(exportedJson);
     expect(exportedJson.lifecycle).toMatchObject({
@@ -3170,7 +3496,7 @@ describe("Desktop app activity", () => {
     expect(serialized).not.toContain("proj_display_name_fallback");
   });
 
-  it("marks partial or conflicted sync evidence as not OK", async () => {
+  it("exports privacy-safe reviewer status corpus", async () => {
     const user = userEvent.setup();
     setSyncTransportStatus({
       active: true,
@@ -3179,8 +3505,14 @@ describe("Desktop app activity", () => {
       last_sync: syncRunStatus({
         run_id: "sync_run_partial_truth",
         session_id: "sync_session_partial_truth",
-        status: "completed_with_errors",
+        status: "failed",
         message: "Sync completed with project conflicts.",
+        duration_ms: 1000,
+        throughput_bytes_per_second: 0,
+        total_received_bytes: 0,
+        total_served_bytes: 0,
+        served_artifact_requests: 0,
+        transfer_counts: { requested: 1, received: 0, skipped: 0, already_staged: 0, failed: 1, retried: 0 },
         failed_project_count: 1,
         project_results: [
           {
@@ -3188,6 +3520,7 @@ describe("Desktop app activity", () => {
             status: "conflicted",
             message: "Project had a conflict.",
             failed_count: 1,
+            counters: { failed_count: 1 },
           },
         ],
         received_artifacts: [
@@ -3195,10 +3528,11 @@ describe("Desktop app activity", () => {
             artifact_id: "art_partial_truth",
             content_sha256: "sha256-partial-truth",
             size_bytes: 42,
-            status: "failed",
-            message: "Artifact transfer failed.",
+            status: "error",
+            message: "Artifact content_sha256_deadbeefcafebabefeedface01234567 failed.",
           },
         ],
+        phase_timings: [{ phase: "reconciliation_apply_project", duration_ms: 0 }],
       }),
     });
 
@@ -3208,95 +3542,712 @@ describe("Desktop app activity", () => {
     expect(exportedJson.validation).toMatchObject({
       ok: false,
       issues: expect.arrayContaining([
-        "artifact_status_failed",
-        "failed_project_count",
+        "artifact_status_error",
+        "conflicted_project_count",
         "project_failed_count",
+        "project_counter_failed_count",
         "project_status_conflicted",
-        "run_status_completed_with_errors",
+        "run_status_failed",
       ]),
     });
+    expect(JSON.stringify(exportedJson)).not.toContain("content_sha256_deadbeefcafebabefeedface01234567");
+    const validation = await validateExportedEvidence(exportedJson);
+    expect(validation).toMatchObject({ ok: true, schemaPrivacyOk: true });
   });
 
-  it("sanitizes path-like listener errors before rendering", async () => {
+  it("preserves incomplete no-row legacy project accounting through export", async () => {
     const user = userEvent.setup();
-    const rawError = "Sync listener failed while opening /Users/test/private/Secret Demo.wav";
+    const normalized = normalizeSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: listenerEndpointHints,
+      last_sync: {
+        selected_transport: irohTransportId,
+        attempted_transports: [irohTransportId],
+        duration_ms: 1000, throughput_bytes_per_second: 1000, time_to_first_artifact_ms: 0,
+        served_artifact_requests: 1, total_served_bytes: 1000,
+        imported_project_count: 0, failed_project_count: 1, total_project_count: 2,
+        received_artifacts: [],
+      },
+    });
+    const canonicalCounts = syncRunCanonicalCounts(normalized.last_sync!);
+
+    expect(normalized.last_sync).toMatchObject({ status: "completed_with_errors", imported_project_count: 0,
+      applied_project_count: null, failed_project_count: 1, total_project_count: 2 });
+    expect(canonicalCounts?.projectResultsByStatus).toBeNull();
+    setSyncTransportStatus(normalized);
+
+    await openSyncTab(user);
+    const exportedJson = await exportEvidenceFromCurrentSyncResult(user);
+    expect(exportedJson.metrics).toMatchObject({
+      network_receive_throughput_bytes_per_second: null,
+      network_send_throughput_bytes_per_second: 1000,
+      projectResultsByStatus: null,
+      transferCounts: { importedProjectCount: 0, appliedProjectCount: null,
+        failedProjectCount: 1, totalProjectCount: 2 },
+    });
+    const validation = await validateExportedEvidence(exportedJson);
+    expect(validation.errors).toEqual([]);
+    expect(validation).toMatchObject({ ok: true, schemaPrivacyOk: true });
+  });
+
+  it("exports no-row aggregate project outcomes with matching status buckets", async () => {
+    const user = userEvent.setup();
     setSyncTransportStatus({
       active: true,
       status: "listening",
       endpoint_hints: listenerEndpointHints,
-      last_error: rawError,
-      last_sync: null,
+      last_sync: syncRunStatus({
+        status: "completed_with_errors",
+        duration_ms: 1000, throughput_bytes_per_second: 1000, time_to_first_artifact_ms: 0,
+        served_artifact_requests: 1, total_served_bytes: 1000,
+        imported_project_count: 0, applied_project_count: 0, deleted_project_count: 0,
+        skipped_project_count: 2, conflicted_project_count: 1, failed_project_count: 1, total_project_count: 4,
+        project_results: [],
+      }),
     });
 
     await openSyncTab(user);
+    const exportedJson = await exportEvidenceFromCurrentSyncResult(user);
 
-    expect(await screen.findByText("Sync listener error: details redacted.")).toBeInTheDocument();
-    expect(screen.queryByText(rawError)).not.toBeInTheDocument();
-    expect(document.body.textContent ?? "").not.toContain("/Users/test/private");
-    expect(document.body.textContent ?? "").not.toContain("Secret Demo.wav");
+    expect(exportedJson.projects).toEqual([]);
+    expect(exportedJson.metrics).toMatchObject({
+      projectResultsByStatus: { skipped: 2, conflicted: 1, failed: 1 },
+      transferCounts: { skippedProjectCount: 2, conflictedProjectCount: 1,
+        failedProjectCount: 1, totalProjectCount: 4 },
+    });
+    expect(exportedJson.validation).toMatchObject({
+      outcomeOk: false,
+      issues: expect.arrayContaining([
+        "conflicted_project_count", "failed_project_count", "run_status_completed_with_errors",
+      ]),
+    });
+    expect(await validateExportedEvidence(exportedJson)).toMatchObject({ ok: true, schemaPrivacyOk: true });
   });
 
-  it("copies privacy-safe evidence JSON from listener last_sync", async () => {
+  it("excludes non-final project events from exported final outcome accounting", async () => {
     const user = userEvent.setup();
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: { writeText },
-    });
     setSyncTransportStatus({
       active: true,
       status: "listening",
       endpoint_hints: listenerEndpointHints,
-      last_status: "Listener imported proj_copy_alpha from device_peer_1.",
       last_sync: syncRunStatus({
-        run_id: "sync_run_copy_listener",
-        session_id: "sync_session_copy_listener",
-        peer_device_id: "device_peer_1",
-        remote_device_id: "device_peer_1",
-        selected_transport: tcpTransportId,
-        attempted_transports: [tcpTransportId],
         status: "completed",
-        message: 'Imported "/Users/test/Music/Secret Demo.wav" for proj_copy_alpha with art_copy_alpha.',
+        duration_ms: 1000, throughput_bytes_per_second: 1000, time_to_first_artifact_ms: 0,
+        served_artifact_requests: 1, total_served_bytes: 1000,
+        project_results: [
+          { project_id: "proj_progress_failure", status: "failed", is_final: false },
+          { project_id: "proj_final_skip", status: "skipped", is_final: true },
+        ],
+      }),
+    });
+
+    await openSyncTab(user);
+    const projectEvidence = await screen.findByRole("list", { name: "Last sync project evidence" });
+    expect(within(projectEvidence).getByText("Failed (event)")).toBeInTheDocument();
+    expect(within(projectEvidence).getByText("Skipped")).toBeInTheDocument();
+    const exportedJson = await exportEvidenceFromCurrentSyncResult(user);
+
+    expect(exportedJson.projects).toEqual(expect.arrayContaining([
+      expect.objectContaining({ status: "failed", isFinal: false }),
+      expect.objectContaining({ status: "skipped", isFinal: true }),
+    ]));
+    expect(exportedJson.metrics).toMatchObject({
+      projectResultsByStatus: { skipped: 1 },
+      transferCounts: { failedProjectCount: 0, skippedProjectCount: 1, totalProjectCount: 1 },
+    });
+    expect(exportedJson.validation).toMatchObject({ outcomeOk: true, issues: [] });
+    expect(await validateExportedEvidence(exportedJson)).toMatchObject({ ok: true, schemaPrivacyOk: true });
+  });
+
+  it("exports mixed failed and conflicted listener evidence with consistent counts", async () => {
+    const user = userEvent.setup();
+    setSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: listenerEndpointHints,
+      last_sync: syncRunStatus({
+        run_id: "sync_run_mixed_counts",
+        session_id: "sync_session_mixed_counts",
+        status: "completed_with_errors",
+        message: "Sync completed with failed and conflicted project results.",
+        started_at: "2026-04-18T13:16:00.000Z",
+        completed_at: "2026-04-18T13:16:00.600Z",
+        duration_ms: 600,
+        throughput_bytes_per_second: 4000,
+        imported_project_count: 0,
+        applied_project_count: 0,
+        deleted_project_count: 0,
+        skipped_project_count: 1,
+        conflicted_project_count: 1,
+        failed_project_count: 2,
         project_results: [
           {
-            project_id: "proj_copy_alpha",
-            status: "imported",
-            message: "Imported proj_copy_alpha from file:///Users/test/Music/Secret%20Demo.wav.",
-            imported_count: 1,
+            project_id: "proj_mixed_conflict",
+            status: "conflicted",
+            message: "Lyrics conflict requires manual review.",
+          },
+          {
+            project_id: "proj_mixed_failed",
+            status: "failed",
+            message: "Manifest export failed before transfer.",
+          },
+          {
+            project_id: "proj_mixed_skipped",
+            status: "skipped",
+            message: "Already up to date.",
           },
         ],
-        received_artifacts: [
+        manifest_errors: [
           {
-            artifact_id: "art_copy_alpha",
-            content_sha256: "sha256-copy-alpha",
-            size_bytes: 1_000_000,
-            status: "received",
-            message: "Fetched art_copy_alpha from Secret Demo.wav",
+            project_id: "proj_mixed_failed",
+            message: "Manifest export failed before transfer.",
+          },
+        ],
+        phase_timings: [
+          {
+            phase: "reconciliation_apply_project",
+            started_at: "2026-04-18T13:16:00.000Z",
+            completed_at: "2026-04-18T13:16:00.500Z",
+            duration_ms: 500,
+          },
+          {
+            phase: "reconciliation_apply_project",
+            started_at: "2026-04-18T13:16:00.100Z",
+            completed_at: "2026-04-18T13:16:00.600Z",
+            duration_ms: 500,
           },
         ],
       }),
     });
 
     await openSyncTab(user);
-    await user.click(screen.getByRole("button", { name: "Copy Evidence" }));
 
-    await waitFor(() => expect(writeText).toHaveBeenCalledOnce());
-    const copiedJson = JSON.parse(writeText.mock.calls[0]?.[0] as string) as Record<string, unknown>;
-    expect(await screen.findByText("Sync evidence copied.")).toBeInTheDocument();
-    expect(copiedJson.validation).toMatchObject({
-      schema: "tuneforge-sync-evidence-v1",
-      privacySafe: true,
+    expect(
+      await screen.findByText(canonicalSummary({ skipped: 1, conflicted: 1, failed: 1, manifestErrors: 1 })),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Sync completed with failed and conflicted project results.")).not.toBeInTheDocument();
+    expect(screen.getByText(/1 skipped, 1 conflicted, 1 failed/)).toBeInTheDocument();
+    expect(screen.getByText(/Largest aggregate phase Reconciliation Apply Project 1\.0 s/)).toBeInTheDocument();
+
+    const exportedJson = await exportEvidenceFromCurrentSyncResult(user);
+
+    expect(exportedJson.metrics).toMatchObject({
+      reconciliation_apply_ms: 600,
+      reconciliation_apply_aggregate_ms: 1000,
+      reconciliation_apply_timing: {
+        semantics: "wall_clock_interval_union_bounded_to_run",
+      },
+      projectResultsByStatus: {
+        conflicted: 1,
+        failed: 1,
+        skipped: 1,
+      },
+      transferCounts: {
+        skippedProjectCount: 1,
+        conflictedProjectCount: 1,
+        failedProjectCount: 1,
+        totalProjectCount: 3,
+        manifestExportErrorCount: 1,
+      },
     });
-    const serialized = JSON.stringify(copiedJson);
-    expect(serialized).toContain("project_1");
-    expect(serialized).toContain("artifact_1");
-    expect(serialized).not.toContain("device_peer_1");
-    expect(serialized).not.toContain("proj_copy_alpha");
-    expect(serialized).not.toContain("art_copy_alpha");
-    expect(serialized).not.toContain("sha256-copy-alpha");
-    expect(serialized).not.toContain("Secret Demo.wav");
-    expect(serialized).not.toContain("/Users/test/Music");
-    expect(serialized).not.toContain("file://");
+    expect(exportedJson.validation).toMatchObject({
+      ok: false,
+      issues: expect.arrayContaining([
+        "conflicted_project_count",
+        "failed_project_count",
+        "manifest_export_error_count",
+        "project_status_conflicted",
+        "project_status_failed",
+      ]),
+    });
+    const serialized = JSON.stringify(exportedJson);
+    expect(serialized).not.toContain("proj_mixed_conflict");
+    expect(serialized).not.toContain("proj_mixed_failed");
+  });
+
+  it("does not treat run bounds as source project apply timing", async () => {
+    const user = userEvent.setup();
+    const normalized = normalizeSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: listenerEndpointHints,
+      last_sync: {
+        status: "completed",
+        selected_transport: irohTransportId, attempted_transports: [irohTransportId],
+        started_at: "2026-04-18T13:16:00.000Z", completed_at: "2026-04-18T13:16:00.600Z",
+        duration_ms: 600, throughput_bytes_per_second: 1000, total_received_bytes: 100,
+        total_served_bytes: 0, served_artifact_requests: 0,
+        time_to_first_artifact_ms: 100,
+        project_results: [{ project_id: "proj_legacy_apply", status: "applied" }],
+        received_artifacts: [{ artifact_id: "art_legacy_apply", size_bytes: 100,
+          status: "received", duration_ms: 100 }],
+        phase_timings: [{ phase: "staging_post", project_id: "proj_legacy_apply",
+          started_at: "2026-04-18T13:16:00.000Z", completed_at: "2026-04-18T13:16:00.100Z",
+          duration_ms: 100 }],
+      },
+    });
+
+    expect(normalized.last_sync?.project_results[0]).toMatchObject({
+      project_id: "proj_legacy_apply", started_at: null, completed_at: null,
+    });
+    setSyncTransportStatus(normalized);
+    await openSyncTab(user);
+    expect(screen.getByText("proj_legacy_apply")).toBeInTheDocument();
+    expect(screen.getByText("Applied")).toBeInTheDocument();
+
+    const exportedJson = await exportEvidenceFromCurrentSyncResult(user);
+    expect(exportedJson.metrics).toMatchObject({
+      reconciliation_apply_ms: null,
+      reconciliation_apply_aggregate_ms: null,
+      reconciliation_apply_timing: { semantics: "not_reported" },
+    });
+    const validation = await validateExportedEvidence(exportedJson);
+    expect(validation).toMatchObject({ ok: false, schemaPrivacyOk: false });
+    expect(validation.errors).toEqual(["Missing required metric: reconciliation apply time."]);
+  });
+
+  it.each([
+    {
+      label: "duration-only entries",
+      phaseTimings: [
+        { phase: "reconciliation_apply_project", duration_ms: 500 },
+        { phase: "reconciliation_apply_project", duration_ms: 500 },
+      ],
+      wallClockMs: null, aggregateMs: 1000, semantics: "aggregate_only", assertUi: true, validatorErrors: [],
+    },
+    {
+      label: "mixed timestamped and duration-only entries",
+      phaseTimings: [
+        { phase: "reconciliation_apply_project", started_at: "2026-04-18T13:16:00.000Z",
+          completed_at: "2026-04-18T13:16:00.300Z", duration_ms: 300 },
+        { phase: "reconciliation_apply_project", duration_ms: 200 },
+      ],
+      wallClockMs: null, aggregateMs: 500, semantics: "aggregate_only", assertUi: false, validatorErrors: [],
+    },
+    {
+      label: "contradictory interval durations",
+      phaseTimings: [
+        { phase: "reconciliation_apply_project", started_at: "2026-04-18T13:16:00.100Z",
+          completed_at: "2026-04-18T13:16:00.300Z", duration_ms: 500 },
+      ],
+      wallClockMs: null, aggregateMs: null, semantics: "not_reported", assertUi: false,
+      validatorErrors: ["Missing required metric: reconciliation apply time."],
+    },
+    {
+      label: "out-of-run intervals",
+      phaseTimings: [
+        { phase: "reconciliation_apply_project", started_at: "2026-04-18T13:15:59.900Z",
+          completed_at: "2026-04-18T13:16:00.200Z", duration_ms: 300 },
+      ],
+      wallClockMs: null, aggregateMs: 300, semantics: "aggregate_only", assertUi: false, validatorErrors: [],
+    },
+    {
+      label: "interval-derived aggregate duration",
+      phaseTimings: [
+        { phase: "reconciliation_apply_project", started_at: "2026-04-18T13:16:00.100Z",
+          completed_at: "2026-04-18T13:16:00.400Z" },
+      ],
+      wallClockMs: 300, aggregateMs: 300, semantics: "wall_clock_interval_union_bounded_to_run",
+      assertUi: false, validatorErrors: [],
+    },
+    {
+      label: "tolerated explicit duration below interval",
+      phaseTimings: [
+        { phase: "reconciliation_apply_project", started_at: "2026-04-18T13:16:00.100Z",
+          completed_at: "2026-04-18T13:16:00.400Z", duration_ms: 299 },
+      ],
+      wallClockMs: 300, aggregateMs: 300, semantics: "wall_clock_interval_union_bounded_to_run",
+      assertUi: false, validatorErrors: [],
+    },
+    {
+      label: "tolerated explicit duration above interval",
+      phaseTimings: [
+        { phase: "reconciliation_apply_project", started_at: "2026-04-18T13:16:00.100Z",
+          completed_at: "2026-04-18T13:16:00.400Z", duration_ms: 301 },
+      ],
+      wallClockMs: 300, aggregateMs: 301, semantics: "wall_clock_interval_union_bounded_to_run",
+      assertUi: false, validatorErrors: [],
+    },
+    {
+      label: "uncovered aggregate entries",
+      phaseTimings: [
+        { phase: "reconciliation_apply_project", duration_ms: 200 },
+        { phase: "reconciliation_apply_project" },
+      ],
+      wallClockMs: null, aggregateMs: null, semantics: "not_reported", assertUi: false,
+      validatorErrors: ["Missing required metric: reconciliation apply time."],
+    },
+  ])("exports truthful apply timing for $label", async ({
+    phaseTimings, wallClockMs, aggregateMs, semantics, assertUi, validatorErrors,
+  }) => {
+    const user = userEvent.setup();
+    setSyncTransportStatus(normalizeSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: listenerEndpointHints,
+      last_sync: {
+        status: "completed",
+        selected_transport: irohTransportId,
+        attempted_transports: [irohTransportId],
+        started_at: "2026-04-18T13:16:00.000Z",
+        completed_at: "2026-04-18T13:16:00.600Z",
+        duration_ms: 600,
+        throughput_bytes_per_second: 1000,
+        total_received_bytes: 100,
+        total_served_bytes: 0,
+        served_artifact_requests: 0,
+        time_to_first_artifact_ms: 100,
+        project_results: [{ project_id: "proj_timing_truth", status: "skipped",
+          started_at: "2026-04-18T13:16:00.000Z", completed_at: "2026-04-18T13:16:00.600Z" }],
+        received_artifacts: [{ artifact_id: "art_timing_truth", size_bytes: 100,
+          status: "received", duration_ms: 100 }],
+        phase_timings: [
+          { phase: "staging_post", project_id: "proj_timing_truth",
+            started_at: "2026-04-18T13:16:00.000Z", completed_at: "2026-04-18T13:16:00.100Z",
+            duration_ms: 100 },
+          ...phaseTimings,
+        ],
+      },
+    }));
+
+    await openSyncTab(user);
+    if (assertUi) {
+      expect(screen.getByText(/Largest aggregate phase Reconciliation Apply Project 1\.0 s/)).toBeInTheDocument();
+    }
+    const exportedJson = await exportEvidenceFromCurrentSyncResult(user);
+
+    expect(exportedJson.metrics).toMatchObject({
+      reconciliation_apply_ms: wallClockMs,
+      reconciliation_apply_aggregate_ms: aggregateMs,
+      reconciliation_apply_timing: { semantics },
+    });
+    const validation = await validateExportedEvidence(exportedJson);
+    expect(validation.errors).toEqual(validatorErrors);
+    expect(validation).toMatchObject({
+      ok: validatorErrors.length === 0,
+      schemaPrivacyOk: validatorErrors.length === 0,
+    });
+  });
+
+  it("exports omitted legacy accounting as unknown rather than zero", async () => {
+    const user = userEvent.setup();
+    setSyncTransportStatus(normalizeSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: listenerEndpointHints,
+      last_sync: {
+        status: "completed",
+        message: "Legacy sync completed.",
+        selected_transport: "iroh",
+        duration_ms: 1000,
+        throughput_bytes_per_second: 0,
+        total_received_bytes: 0,
+        total_served_bytes: 0,
+        served_artifact_requests: 0,
+      },
+    }));
+
+    await openSyncTab(user);
+    expect(await screen.findByText("Legacy sync completed.")).toBeInTheDocument();
+    const exportedJson = await exportEvidenceFromCurrentSyncResult(user);
+    const metrics = exportedJson.metrics as {
+      transfer_counts: Record<string, number | null>;
+      transferCounts: Record<string, number | null>;
+    };
+
+    expect(metrics.transfer_counts).toEqual({
+      requested: null,
+      received: null,
+      skipped: null,
+      already_staged: null,
+      failed: null,
+      retried: null,
+    });
+    expect(metrics.transferCounts).toMatchObject({
+      importedProjectCount: null,
+      appliedProjectCount: null,
+      deletedProjectCount: null,
+      skippedProjectCount: null,
+      conflictedProjectCount: null,
+      failedProjectCount: null,
+      totalProjectCount: null,
+      manifestExportErrorCount: null,
+    });
+  });
+
+  it("exports manifest-only listener errors outside failed project counts", async () => {
+    const user = userEvent.setup();
+    const normalized = normalizeSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: listenerEndpointHints,
+      last_sync: syncRunStatus({
+        run_id: "sync_run_manifest_only",
+        session_id: "sync_session_manifest_only",
+        status: "completed_with_errors",
+        message: null,
+        local_manifest_count: 1,
+        remote_manifest_count: 1,
+        imported_project_count: 0,
+        applied_project_count: 0,
+        deleted_project_count: 0,
+        skipped_project_count: 0,
+        conflicted_project_count: 0,
+        failed_project_count: 0,
+        manifest_export_error_count: 0,
+        duration_ms: 1000,
+        throughput_bytes_per_second: 1000,
+        time_to_first_artifact_ms: 0,
+        served_artifact_requests: 1,
+        total_served_bytes: 1000,
+        project_results: [],
+        manifest_errors: [
+          {
+            project_id: "proj_manifest_only",
+            message: "Peer manifest export failed before apply.",
+          },
+        ],
+      }),
+    });
+    expect(normalized.last_sync?.manifest_export_error_count).toBe(1);
+    expect(normalized.last_sync?.message).toBe(canonicalSummary({ local: 1, remote: 1, manifestErrors: 1 }));
+    setSyncTransportStatus(normalized);
+
+    await openSyncTab(user);
+
+    expect(await screen.findByText(`No project changes. ${canonicalSummary({
+      local: 1,
+      remote: 1,
+      manifestErrors: 1,
+    })}`))
+      .toBeInTheDocument();
+    expect(screen.getByText(/0 skipped, 0 conflicted, 0 failed, 1 manifest export error/)).toBeInTheDocument();
+    const projectResults = await screen.findByRole("list", { name: "Last sync project evidence" });
+    expect(within(projectResults).getByText("Manifest Export Error")).toBeInTheDocument();
+
+    const exportedJson = await exportEvidenceFromCurrentSyncResult(user);
+
+    expect(exportedJson.metrics).toMatchObject({
+      projectResultsByStatus: {
+      },
+      transferCounts: {
+        failedProjectCount: 0,
+        conflictedProjectCount: 0,
+        totalProjectCount: 0,
+        manifestExportErrorCount: 1,
+      },
+    });
+    expect(exportedJson.validation).toMatchObject({
+      scope: "run_outcome",
+      ok: false,
+      outcomeOk: false,
+      issues: expect.arrayContaining([
+        "manifest_export_error_count",
+      ]),
+    });
+    expect((exportedJson.validation as { issues: string[] }).issues)
+      .not.toContain("project_status_manifest_export_error");
+    const validation = await validateExportedEvidence(exportedJson);
+    expect(validation).toMatchObject({ ok: true, schemaPrivacyOk: true });
+  });
+
+  it("exports multiple manifest errors for one project outside final outcome buckets", async () => {
+    const user = userEvent.setup();
+    setSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: listenerEndpointHints,
+      last_sync: syncRunStatus({
+        status: "completed_with_errors",
+        duration_ms: 1000,
+        throughput_bytes_per_second: 1000,
+        time_to_first_artifact_ms: 0,
+        served_artifact_requests: 1,
+        total_served_bytes: 1000,
+        manifest_export_error_count: 2,
+        project_results_complete: true,
+        received_artifacts_complete: true,
+        manifest_errors: [
+          { project_id: "proj_manifest_repeat", message: "Local manifest export failed." },
+          { project_id: "proj_manifest_repeat", message: "Peer manifest export failed." },
+        ],
+      }),
+    });
+
+    await openSyncTab(user);
+    const exportedJson = await exportEvidenceFromCurrentSyncResult(user);
+    const metrics = exportedJson.metrics as {
+      projectResultsByStatus: Record<string, number>;
+      transferCounts: Record<string, number>;
+      total_served_bytes: number;
+    };
+
+    expect(exportedJson.projects).toEqual([
+      expect.objectContaining({ label: "Project 1", status: "manifest_export_error" }),
+    ]);
+    expect(metrics.projectResultsByStatus).toEqual({});
+    expect(metrics.total_served_bytes).toBe(1000);
+    expect(metrics.transferCounts).toMatchObject({
+      failedProjectCount: 0,
+      totalProjectCount: 0,
+      manifestExportErrorCount: 2,
+    });
+    expect(metrics.transferCounts).not.toHaveProperty("manifestErrorCount");
+    expect((exportedJson.validation as { issues: string[] }).issues)
+      .not.toContain("project_status_manifest_export_error");
+    const validation = await validateExportedEvidence(exportedJson);
+    expect(validation.errors).toEqual([]);
+    expect(validation).toMatchObject({ ok: true, schemaPrivacyOk: true });
+  });
+
+  it("exports overlapping failed projects and manifest errors with validator-consistent status buckets", async () => {
+    const user = userEvent.setup();
+    setSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: listenerEndpointHints,
+      last_sync: syncRunStatus({
+        run_id: "sync_run_overlap_manifest_error",
+        session_id: "sync_session_overlap_manifest_error",
+        status: "completed_with_errors",
+        message: null,
+        started_at: "2026-04-18T13:16:00.000Z",
+        completed_at: "2026-04-18T13:16:01.000Z",
+        duration_ms: 1000,
+        time_to_first_artifact_ms: 100,
+        throughput_bytes_per_second: 1000,
+        total_received_bytes: 1000,
+        total_served_bytes: 0,
+        served_artifact_requests: 0,
+        failed_project_count: 1,
+        manifest_export_error_count: 1,
+        project_results: [
+          {
+            project_id: "proj_overlap_private",
+            status: "failed",
+            message: "Project failed after manifest export warning.",
+            is_final: true,
+            started_at: "2026-04-18T13:16:00.200Z",
+            completed_at: "2026-04-18T13:16:00.900Z",
+            failed_count: 1,
+          },
+        ],
+        manifest_errors: [
+          {
+            project_id: "proj_overlap_private",
+            message: "Manifest export failed for overlapping project.",
+          },
+        ],
+        phase_timings: [
+          {
+            phase: "staging_post",
+            started_at: "2026-04-18T13:16:00.000Z",
+            completed_at: "2026-04-18T13:16:00.200Z",
+            duration_ms: 200,
+          },
+          {
+            phase: "reconciliation_apply",
+            project_id: "proj_overlap_private",
+            started_at: "2026-04-18T13:16:00.200Z",
+            completed_at: "2026-04-18T13:16:00.500Z",
+            duration_ms: 300,
+          },
+        ],
+        received_artifacts: [
+          {
+            artifact_id: "art_overlap_private",
+            size_bytes: 1000,
+            status: "received",
+            duration_ms: 100,
+          },
+        ],
+      }),
+    });
+
+    await openSyncTab(user);
+    const exportedJson = await exportEvidenceFromCurrentSyncResult(user);
+    const exportedMetrics = exportedJson.metrics as {
+      projectResultsByStatus?: Record<string, number>;
+      transferCounts?: Record<string, number>;
+    };
+
+    expect(exportedJson.projects).toEqual([
+      expect.objectContaining({
+        label: "Project 1",
+        status: "failed",
+      }),
+    ]);
+    expect(exportedMetrics.projectResultsByStatus).toEqual({ failed: 1 });
+    expect(exportedMetrics.transferCounts).toMatchObject({
+      failedProjectCount: 1,
+      totalProjectCount: 1,
+      manifestExportErrorCount: 1,
+    });
+    expect((exportedJson.validation as { issues: string[] }).issues)
+      .not.toContain("project_status_manifest_export_error");
+    const validation = await validateExportedEvidence(exportedJson);
+    expect(validation).toMatchObject({ ok: true, schemaPrivacyOk: true });
+    expect(JSON.stringify(exportedJson)).not.toContain("proj_overlap_private");
+  });
+
+  it("exports no-change listener sync evidence as successful", async () => {
+    const user = userEvent.setup();
+    setSyncTransportStatus({
+      active: true,
+      status: "listening",
+      endpoint_hints: listenerEndpointHints,
+      last_sync: syncRunStatus({
+        run_id: "sync_run_no_change",
+        session_id: "sync_session_no_change",
+        status: "completed",
+        message: "Sync completed with no project changes.",
+        started_at: "2026-04-18T13:16:00.000Z",
+        completed_at: "2026-04-18T13:16:01.000Z",
+        duration_ms: 1000,
+        throughput_bytes_per_second: 0,
+        imported_project_count: 0,
+        applied_project_count: 0,
+        deleted_project_count: 0,
+        skipped_project_count: 2,
+        conflicted_project_count: 0,
+        failed_project_count: 0,
+        total_project_count: 2,
+        received_artifacts_complete: true,
+        project_results: [],
+      }),
+    });
+
+    await openSyncTab(user);
+
+    expect(await screen.findByText(`No project changes. ${canonicalSummary({ skipped: 2 })}`)).toBeInTheDocument();
+    expect(screen.queryByText("Sync completed with no project changes.")).not.toBeInTheDocument();
+    expect(screen.getByText(/2 skipped, 0 conflicted, 0 failed/)).toBeInTheDocument();
+
+    const exportedJson = await exportEvidenceFromCurrentSyncResult(user);
+
+    expect(exportedJson.validation).toMatchObject({
+      scope: "run_outcome",
+      ok: true,
+      outcomeOk: true,
+      issues: [],
+    });
+    expect(exportedJson.metrics).toMatchObject({
+      network_receive_throughput_bytes_per_second: null,
+      network_send_throughput_bytes_per_second: null,
+      project_imports_per_minute: 0,
+      projectResultsByStatus: {
+        skipped: 2,
+      },
+      transferCounts: {
+        skippedProjectCount: 2,
+        conflictedProjectCount: 0,
+        failedProjectCount: 0,
+        totalProjectCount: 2,
+        manifestExportErrorCount: 0,
+      },
+    });
+    expect(exportedJson.projects).toEqual([]);
   });
 
   it("exports evidence through the Tauri save command when available", async () => {
@@ -3340,7 +4291,7 @@ describe("Desktop app activity", () => {
     expect(await screen.findByText(/Sync evidence exported/)).toBeInTheDocument();
     expect(exportedJson.scenario).toBe("listener-last-sync");
     expect(exportedJson.run).toMatchObject({
-      label: "run_1",
+      label: "Run 1",
       hasRunId: true,
       hasSessionId: true,
       status: "completed",
@@ -3512,7 +4463,7 @@ describe("Desktop app activity", () => {
     expect(peerRow).not.toBeNull();
     await user.click(within(peerRow as HTMLElement).getByRole("button", { name: "Sync Now" }));
 
-    expect(await screen.findAllByText("Sync now imported proj_now_result.")).not.toHaveLength(0);
+    expect(await screen.findByText("proj_now_result")).toBeInTheDocument();
     const exportedJson = await exportEvidenceFromCurrentSyncResult(user);
 
     expect(exportedJson.scenario).toBe("sync-now-result");
@@ -3532,7 +4483,7 @@ describe("Desktop app activity", () => {
     });
     expect(exportedJson.projects).toEqual([
       expect.objectContaining({
-        label: "project_1",
+        label: "Project 1",
         status: "imported",
         counts: expect.objectContaining({
           imported: 1,
@@ -3571,8 +4522,11 @@ describe("Desktop app activity", () => {
             message: "Old listener result.",
           },
         ],
+        project_results_complete: true,
         manifest_errors: [],
+        manifest_errors_complete: true,
         received_artifacts: [],
+        received_artifacts_complete: true,
         served_artifact_requests: 0,
         local_manifest_count: 0,
         remote_manifest_count: 1,
@@ -3585,7 +4539,8 @@ describe("Desktop app activity", () => {
     expect(peerRow).not.toBeNull();
     await user.click(within(peerRow as HTMLElement).getByRole("button", { name: "Sync Now" }));
 
-    expect(await screen.findAllByText("Manifest exchange completed with 4 project results.")).not.toHaveLength(0);
+    expect(await screen.findAllByText(defaultSyncNowCanonicalSummary)).not.toHaveLength(0);
+    expect(screen.queryByText("Manifest exchange completed with 4 project results.")).not.toBeInTheDocument();
     expect(screen.getByText("proj_imported")).toBeInTheDocument();
 
     setSyncTransportStatus({
@@ -3604,8 +4559,11 @@ describe("Desktop app activity", () => {
             message: "New listener result.",
           },
         ],
+        project_results_complete: true,
         manifest_errors: [],
+        manifest_errors_complete: true,
         received_artifacts: [],
+        received_artifacts_complete: true,
         served_artifact_requests: 0,
         local_manifest_count: 0,
         remote_manifest_count: 1,
@@ -3616,7 +4574,7 @@ describe("Desktop app activity", () => {
     });
     await user.click(screen.getByRole("button", { name: "Answer Offer" }));
 
-    expect(await screen.findByText("Listener import completed after sync now.")).toBeInTheDocument();
+    expect(await screen.findByText(importedOneRemoteCanonicalSummary)).toBeInTheDocument();
     expect(screen.getByText("proj_listener_new")).toBeInTheDocument();
     expect(screen.queryByText("proj_imported")).not.toBeInTheDocument();
   });

--- a/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
+++ b/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
@@ -4,7 +4,12 @@ import { invoke, isTauri } from "@tauri-apps/api/core";
 import { QRCodeSVG } from "qrcode.react";
 import {
   api,
+  countSyncProjectResultsByStatus,
+  isFinalSyncProjectResult,
   mergeSyncProjectResults,
+  syncCanonicalSummaryMessage,
+  syncRunCanonicalCounts,
+  syncRunCanonicalSummaryMessage,
   type SyncPairingPayloadSchema,
   type SyncNearbyPeer,
   type SyncNearbyPeerTrustStatus,
@@ -42,6 +47,7 @@ const PROJECT_MUTATION_QUERY_KEYS = [
   ["jobs"],
 ] as const;
 const SYNC_PROJECT_MUTATION_STATUSES = new Set(["applied", "conflicted", "deleted", "imported"]);
+const SYNC_MANIFEST_EXPORT_ERROR_STATUS = "manifest_export_error";
 const SYNC_EVIDENCE_FILE_EXTENSIONS = "wav|mp3|flac|m4a|aac|ogg|aiff|aif|json|sqlite|db|txt|csv|log|zip|png|jpe?g";
 const SYNC_EVIDENCE_QUOTED_PATH_PATTERN = new RegExp(
   `(^|[\\s(])(["'])((?:file:\\/\\/(?:localhost)?(?:[A-Za-z]:[\\\\/]|\\/)?|[A-Za-z]:[\\\\/]|\\/)[^"'\\r\\n]*)\\2`,
@@ -58,6 +64,29 @@ const SYNC_EVIDENCE_FILENAME_PATTERN = new RegExp(
   `\\b[^/\\\\\\s]+\\.(?:${SYNC_EVIDENCE_FILE_EXTENSIONS})\\b`,
   "gi",
 );
+const SYNC_EVIDENCE_RAW_ID_TOKEN_PATTERN =
+  /\b(?:device|proj|art|session|run|project|artifact|sync)_[A-Za-z0-9][A-Za-z0-9._:-]*\b/gi;
+const SYNC_EVIDENCE_SAFE_PHASES = new Set([
+  "artifact_cleanup", "artifact_staging", "artifact_staging_check", "artifact_transfer", "initiator_import",
+  "local_manifest_export", "manifest_exchange", "peer_authentication", "peer_connect", "planning",
+  "reconciliation_apply", "reconciliation_apply_project", "reconciliation_plan", "reconciliation_staging",
+  "responder_import", "serve_artifact_requests",
+]);
+const SYNC_EVIDENCE_PHASE_ALIASES = new Map([
+  ["network_receive", "artifact_transfer"], ["staging_post", "artifact_staging"],
+  ["staging_apply_plan", "reconciliation_staging"], ["backend_staging", "artifact_staging"],
+]);
+const SYNC_EVIDENCE_PROBLEM_STATUSES = new Set(["failed", "completed_with_errors", "conflicted", "error", "errored"]);
+const SYNC_EVIDENCE_SAFE_RAW_TOKENS = new Set([
+  ...SYNC_EVIDENCE_SAFE_PHASES,
+  ...Array.from(SYNC_EVIDENCE_PROBLEM_STATUSES).flatMap((status) =>
+    [`run_status_${status}`, `project_status_${status}`, `artifact_status_${status}`]),
+  "failed_project_count", "conflicted_project_count", "manifest_export_error_count",
+  "project_failed_count", "project_counter_failed_count", "run_outcome",
+]);
+const SYNC_EVIDENCE_HASH_TOKEN_PATTERN =
+  /(?<![A-Za-z0-9])(?:sha(?:-?256)?|hash|checksum)[_:.-][A-Za-z0-9][A-Za-z0-9._:-]*\b|(?<![A-Za-z0-9])[a-f0-9]{32,}(?![A-Za-z0-9])/gi;
+const SYNC_EVIDENCE_SAFE_HASH_TOKENS = new Set(["checksum_mismatch", "hash_retry_pending", "sha256_mismatch"]);
 const SYNC_NOW_FAILURE_ENDPOINT_TOKEN_PATTERN = /^(?:\d{1,3}\.){3}\d{1,3}:\d{1,5}$/;
 
 type PairingOutputKind = "offer" | "response";
@@ -104,6 +133,12 @@ function statusLabel(value: string | null | undefined) {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ");
+}
+
+function syncEvidencePhase(value: string | null | undefined) {
+  const rawPhase = value?.trim().toLowerCase() ?? null;
+  const phase = rawPhase ? SYNC_EVIDENCE_PHASE_ALIASES.get(rawPhase) ?? rawPhase : null;
+  return phase && SYNC_EVIDENCE_SAFE_PHASES.has(phase) ? phase : phase ? "phase_redacted" : null;
 }
 
 function statusClassName(value: string | null | undefined) {
@@ -278,9 +313,38 @@ function syncStatusText(status: SyncTransportRunStatus | null | undefined, peers
   const peer = status.peer_device_id ? peersById.get(status.peer_device_id) : null;
   const peerName = peer ? peerLabel(peer) : status.peer_device_id ?? "peer";
   if (status.error) {
-    return `${statusLabel(status.status)} for ${peerName}: ${status.error}`;
+    return `${statusLabel(status.status)} for ${peerName}: ${
+      syncVisibleNativeDetailText(status.error, "details redacted.") ?? "details redacted."
+    }`;
   }
-  return status.message ?? `${statusLabel(status.status)} for ${peerName}.`;
+  const canonicalSummary = syncRunCanonicalSummaryMessage(status);
+  const explicitMessage = status.message?.trim() || null;
+  if (["failed", "error", "errored"].includes(status.status.trim().toLowerCase()) && explicitMessage) {
+    return syncNowFailureStatusMessage(explicitMessage);
+  }
+  const canonicalCounts = syncRunCanonicalCounts(status);
+  const explicitMessageIsCanonical = Boolean(
+    explicitMessage && canonicalCounts && explicitMessage === syncCanonicalSummaryMessage(canonicalCounts),
+  );
+  const noProjectChanges = canonicalCounts &&
+    canonicalCounts.importedProjectCount === 0 &&
+    canonicalCounts.appliedProjectCount === 0 &&
+    canonicalCounts.deletedProjectCount === 0 &&
+    typeof canonicalCounts.skippedProjectCount === "number" &&
+    canonicalCounts.conflictedProjectCount === 0 &&
+    canonicalCounts.failedProjectCount === 0;
+  if (canonicalSummary && noProjectChanges) {
+    return `No project changes. ${canonicalSummary}`;
+  }
+  if (canonicalSummary) {
+    return canonicalSummary;
+  }
+  if (explicitMessage && (explicitMessageIsCanonical || !syncNowFailureDetailIsSensitive(explicitMessage))) {
+    return explicitMessage;
+  }
+  return explicitMessage
+    ? `${statusLabel(status.status)} for ${peerName}: details redacted.`
+    : `${statusLabel(status.status)} for ${peerName}.`;
 }
 
 function retryableLifecycleEvent(source: SyncRetrySource | null | undefined) {
@@ -332,7 +396,37 @@ function retryableInterruptionFromSource(
 }
 
 function retryableInterruptionText(interruption: RetryableSyncInterruption) {
-  return interruption.guidance?.trim() || `${statusLabel(interruption.code)}. Retry when peer is reachable.`;
+  return syncVisibleNativeDetailText(interruption.guidance, `${statusLabel(interruption.code)}. Retry when peer is reachable.`) ||
+    `${statusLabel(interruption.code)}. Retry when peer is reachable.`;
+}
+
+const SYNC_SAFE_LIBRARY_PREFLIGHT_ISSUES = new Set([
+  "missing source hash project",
+  "missing source hash projects",
+  "invalid source hash project",
+  "invalid source hash projects",
+  "duplicate source hash project",
+  "duplicate source hash projects",
+  "noncanonical project id",
+  "noncanonical project ids",
+]);
+
+const SYNC_SAFE_TRANSPORT_PHASES = new Set([
+  "artifact request/transfer",
+  "local manifest export",
+  "manifest exchange",
+  "reconciliation plan",
+  "reconciliation staging",
+  "serve artifact requests",
+]);
+
+function syncTransportFailurePrefixIsKnownSafe(prefix: string) {
+  const normalized = prefix.trim().toLowerCase();
+  if (normalized === "sync transport failed" || normalized === "sync transport stalled") {
+    return true;
+  }
+  const match = normalized.match(/^sync transport (.+) (failed|stalled)$/);
+  return Boolean(match && SYNC_SAFE_TRANSPORT_PHASES.has(match[1] ?? ""));
 }
 
 function syncTransportFailurePrefix(message: string) {
@@ -341,15 +435,18 @@ function syncTransportFailurePrefix(message: string) {
     return null;
   }
   const prefix = message.slice(0, separatorIndex).trim();
-  return prefix.startsWith("Sync transport ") &&
-    (prefix.endsWith(" failed") || prefix.endsWith(" stalled"))
-    ? prefix
-    : null;
+  return syncTransportFailurePrefixIsKnownSafe(prefix) ? prefix : null;
 }
 
-function syncNowFailureTokenLooksLikeHash(token: string) {
-  const value = token.replace(/^sha256[:-]/i, "");
-  return value.length >= 32 && /^[a-f0-9]+$/i.test(value);
+function syncEvidencePatternMatches(pattern: RegExp, value: string) {
+  pattern.lastIndex = 0;
+  const matches = pattern.test(value);
+  pattern.lastIndex = 0;
+  return matches;
+}
+
+function syncEvidenceHasUnsafeToken(value: string, pattern: RegExp, safeTokens: Set<string>) {
+  return (value.match(pattern) ?? []).some((token) => !safeTokens.has(token.toLowerCase()));
 }
 
 function syncNowFailureTokenIsSensitive(token: string) {
@@ -359,12 +456,8 @@ function syncNowFailureTokenIsSensitive(token: string) {
     token.includes("\\"),
     SYNC_NOW_FAILURE_ENDPOINT_TOKEN_PATTERN.test(token),
     lower.startsWith("dev_"),
-    lower.startsWith("device_"),
-    lower.startsWith("proj_"),
-    lower.startsWith("art_"),
-    lower.startsWith("sync_"),
-    lower.startsWith("sha256"),
-    syncNowFailureTokenLooksLikeHash(token),
+    syncEvidenceHasUnsafeToken(token, SYNC_EVIDENCE_RAW_ID_TOKEN_PATTERN, SYNC_EVIDENCE_SAFE_RAW_TOKENS),
+    syncEvidenceHasUnsafeToken(token, SYNC_EVIDENCE_HASH_TOKEN_PATTERN, SYNC_EVIDENCE_SAFE_HASH_TOKENS),
   ].some(Boolean);
 }
 
@@ -391,6 +484,15 @@ function syncNowFailureDetailIsSensitive(message: string) {
   ) {
     return true;
   }
+  if (syncEvidencePatternMatches(SYNC_EVIDENCE_FILENAME_PATTERN, detail)) {
+    return true;
+  }
+  if (
+    syncEvidenceHasUnsafeToken(detail, SYNC_EVIDENCE_RAW_ID_TOKEN_PATTERN, SYNC_EVIDENCE_SAFE_RAW_TOKENS) ||
+    syncEvidenceHasUnsafeToken(detail, SYNC_EVIDENCE_HASH_TOKEN_PATTERN, SYNC_EVIDENCE_SAFE_HASH_TOKENS)
+  ) {
+    return true;
+  }
   return detail
     .split(/\s+/)
     .map((token) => token.replace(/^["'()[\]{}<>,;]+|["'()[\]{}<>,;.:]+$/g, ""))
@@ -401,6 +503,37 @@ function syncNowFailureDetailIsSensitive(message: string) {
 function syncNowFailureRedactedSummary(message: string) {
   const prefix = syncTransportFailurePrefix(message);
   return prefix ? `${prefix}: details redacted.` : "Sync transport failed: details redacted.";
+}
+
+function syncLibraryPreflightDetailIsKnownSafe(detail: string) {
+  if (detail === "Library preflight failed.") {
+    return true;
+  }
+  const prefix = "Library preflight failed:";
+  if (!detail.startsWith(prefix) || !detail.endsWith(".")) {
+    return false;
+  }
+  const issues = detail.slice(prefix.length, -1).split(",");
+  return issues.length > 0 && issues.every((issue) => {
+    const match = issue.trim().match(/^\d+ (.+)$/);
+    return Boolean(match && SYNC_SAFE_LIBRARY_PREFLIGHT_ISSUES.has(match[1]?.toLowerCase() ?? ""));
+  });
+}
+
+function syncTransportRedactedDetailIsKnownSafe(detail: string) {
+  const prefix = syncTransportFailurePrefix(detail);
+  return Boolean(prefix && detail.slice(prefix.length + 1).trim().toLowerCase() === "details redacted.");
+}
+
+function syncNativeDetailIsKnownSafe(message: string) {
+  const detail = message.trim();
+  if (!detail || syncNowFailureDetailIsSensitive(detail)) {
+    return false;
+  }
+  return detail.toLowerCase() === "artifact_transfer: timed out reading from iroh sync stream." ||
+    /^sync completed with no project changes\.?$/i.test(detail) ||
+    syncLibraryPreflightDetailIsKnownSafe(detail) ||
+    syncTransportRedactedDetailIsKnownSafe(detail);
 }
 
 function syncNowFailureStatusMessage(message: string) {
@@ -414,10 +547,20 @@ function syncNowFailureStatusMessage(message: string) {
   if (!detail) {
     return "Sync now failed.";
   }
-  const safeDetail = syncNowFailureDetailIsSensitive(detail)
-    ? syncNowFailureRedactedSummary(detail)
-    : detail;
+  const safeDetail = syncNowFailureDetailIsSensitive(detail) ? syncNowFailureRedactedSummary(detail) : detail;
   return `Sync now failed: ${safeDetail}`;
+}
+
+function syncVisibleNativeDetailText(message: string | null | undefined, redactedText = "details redacted.") {
+  const detail = message?.trim();
+  if (!detail) {
+    return null;
+  }
+  if (syncNowFailureDetailIsSensitive(detail)) {
+    const redactedFailure = syncNowFailureRedactedSummary(detail);
+    return syncTransportFailurePrefix(detail) ? redactedFailure : redactedText;
+  }
+  return detail;
 }
 
 function syncNowFailureText(error: unknown) {
@@ -441,10 +584,7 @@ function syncListenerLastErrorText(message: string | null | undefined) {
   if (!detail) {
     return null;
   }
-  if (syncNowFailureDetailIsSensitive(detail)) {
-    return "Sync listener error: details redacted.";
-  }
-  return detail;
+  return syncVisibleNativeDetailText(detail, "Sync listener error: details redacted.");
 }
 
 function pluralize(count: number, singular: string, plural = `${singular}s`) {
@@ -598,21 +738,19 @@ function syncResultKey(status: SyncTransportRunStatus | null | undefined) {
     appliedProjects: status.applied_project_count,
     deletedProjects: status.deleted_project_count,
     skippedProjects: status.skipped_project_count,
+    conflictedProjects: status.conflicted_project_count,
     failedProjects: status.failed_project_count,
+    manifestExportErrors: status.manifest_export_error_count,
   });
 }
 
-function positiveSyncCount(value: number | null | undefined) {
+function positiveSyncCount(value: number | null | undefined): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
 
 function syncEvidenceStatusIndicatesProblem(status: string | null | undefined) {
   const normalized = status?.trim().toLowerCase();
-  return normalized === "failed" ||
-    normalized === "completed_with_errors" ||
-    normalized === "conflicted" ||
-    normalized === "error" ||
-    normalized === "errored";
+  return SYNC_EVIDENCE_PROBLEM_STATUSES.has(normalized ?? "");
 }
 
 function syncEvidenceValidation(
@@ -621,13 +759,33 @@ function syncEvidenceValidation(
   artifactStatusCounts: Record<string, number>,
 ) {
   const issues = new Set<string>();
+  const finalProjectResults = mergedProjectResults.filter(
+    (result) => result.status !== SYNC_MANIFEST_EXPORT_ERROR_STATUS && isFinalSyncProjectResult(result),
+  );
+  const projectResultCountByStatus = countSyncProjectResultsByStatus(finalProjectResults);
+  const hasFinalProjectResults = finalProjectResults.length > 0;
+  const failedProjectCount = hasFinalProjectResults
+    ? projectResultCountByStatus.failed ?? 0
+    : status.failed_project_count;
+  const conflictedProjectCount = hasFinalProjectResults
+    ? projectResultCountByStatus.conflicted ?? 0
+    : status.conflicted_project_count;
   if (syncEvidenceStatusIndicatesProblem(status.status)) {
     issues.add(`run_status_${status.status}`);
   }
-  if (positiveSyncCount(status.failed_project_count)) {
+  if (positiveSyncCount(failedProjectCount)) {
     issues.add("failed_project_count");
   }
-  for (const result of mergedProjectResults) {
+  if (positiveSyncCount(conflictedProjectCount)) {
+    issues.add("conflicted_project_count");
+  }
+  if (status.manifest_errors.length > 0) {
+    issues.add("manifest_export_error_count");
+  }
+  if (positiveSyncCount(status.manifest_export_error_count)) {
+    issues.add("manifest_export_error_count");
+  }
+  for (const result of finalProjectResults) {
     if (syncEvidenceStatusIndicatesProblem(result.status)) {
       issues.add(`project_status_${result.status}`);
     }
@@ -642,6 +800,11 @@ function syncEvidenceValidation(
     if (positiveSyncCount(count) && syncEvidenceStatusIndicatesProblem(artifactStatus)) {
       issues.add(`artifact_status_${artifactStatus}`);
     }
+  }
+  const receivedCount = syncRunMetricValue(status, "received");
+  if (status.received_artifacts_complete === true && receivedCount !== null &&
+    (artifactStatusCounts.received ?? 0) !== receivedCount) {
+    issues.add("received_artifact_count_mismatch");
   }
   return {
     ok: issues.size === 0,
@@ -736,32 +899,33 @@ function syncRunDurationSeconds(status: SyncTransportRunStatus) {
 }
 
 function syncRunProjectCounterText(status: SyncTransportRunStatus) {
-  const counters: string[] = [];
-  if (typeof status.imported_project_count === "number") {
-    counters.push(`${status.imported_project_count} imported`);
-  }
-  if (typeof status.applied_project_count === "number") {
-    counters.push(`${status.applied_project_count} applied`);
-  }
-  if (typeof status.deleted_project_count === "number") {
-    counters.push(`${status.deleted_project_count} deleted`);
-  }
-  if (typeof status.skipped_project_count === "number") {
-    counters.push(`${status.skipped_project_count} skipped`);
-  }
-  if (typeof status.failed_project_count === "number") {
-    counters.push(`${status.failed_project_count} failed`);
-  }
-  return counters.length ? counters.join(", ") : null;
-}
-
-function syncRunTotalTransferBytes(status: SyncTransportRunStatus) {
-  const receivedBytes = typeof status.total_received_bytes === "number" ? status.total_received_bytes : null;
-  const servedBytes = typeof status.total_served_bytes === "number" ? status.total_served_bytes : null;
-  if (receivedBytes === null && servedBytes === null) {
+  const counts = syncRunCanonicalCounts(status);
+  if (!counts) {
     return null;
   }
-  return (receivedBytes ?? 0) + (servedBytes ?? 0);
+  const counters: string[] = [];
+  if (typeof counts.importedProjectCount === "number") {
+    counters.push(`${counts.importedProjectCount} imported`);
+  }
+  if (typeof counts.appliedProjectCount === "number") {
+    counters.push(`${counts.appliedProjectCount} applied`);
+  }
+  if (typeof counts.deletedProjectCount === "number") {
+    counters.push(`${counts.deletedProjectCount} deleted`);
+  }
+  if (typeof counts.skippedProjectCount === "number") {
+    counters.push(`${counts.skippedProjectCount} skipped`);
+  }
+  if (typeof counts.conflictedProjectCount === "number") {
+    counters.push(`${counts.conflictedProjectCount} conflicted`);
+  }
+  if (typeof counts.failedProjectCount === "number") {
+    counters.push(`${counts.failedProjectCount} failed`);
+  }
+  if (typeof counts.manifestExportErrorCount === "number") {
+    counters.push(pluralize(counts.manifestExportErrorCount, "manifest export error"));
+  }
+  return counters.length ? counters.join(", ") : null;
 }
 
 function syncRunPeakText(label: string, bytes: number | null | undefined) {
@@ -953,15 +1117,16 @@ function syncRunSlowestPhaseText(status: SyncTransportRunStatus) {
     }
     const key = timing.phase.trim().toLowerCase();
     const current = phaseDurations.get(key);
+    const safePhase = syncEvidencePhase(timing.phase);
     phaseDurations.set(key, {
-      label: statusLabel(timing.phase),
+      label: safePhase === "phase_redacted" ? "Sync Phase" : statusLabel(safePhase),
       durationMs: (current?.durationMs ?? 0) + timing.duration_ms,
     });
   });
   const slowest = Array.from(phaseDurations.values())
     .sort((left, right) => right.durationMs - left.durationMs)[0];
   const formatted = formatDurationMs(slowest?.durationMs);
-  return slowest && formatted ? `Slowest ${slowest.label} ${formatted}` : null;
+  return slowest && formatted ? `Largest aggregate phase ${slowest.label} ${formatted}` : null;
 }
 
 function syncRunSummaryText(status: SyncTransportRunStatus | null | undefined) {
@@ -987,7 +1152,7 @@ function syncRunSummaryText(status: SyncTransportRunStatus | null | undefined) {
     parts.push(`Transport ${selectedTransport}`);
   }
   if (status.fallback_reason) {
-    parts.push(`Fallback: ${status.fallback_reason}`);
+    parts.push(`Fallback: ${syncVisibleNativeDetailText(status.fallback_reason, "details redacted.")}`);
   }
   if (status.fallback_code) {
     parts.push(`Fallback code ${status.fallback_code}`);
@@ -1000,13 +1165,22 @@ function syncRunSummaryText(status: SyncTransportRunStatus | null | undefined) {
   if (timeToFirstArtifact) {
     parts.push(`TTFA ${timeToFirstArtifact}`);
   }
-  const totalTransferBytes = formatByteCount(syncRunTotalTransferBytes(status));
-  if (totalTransferBytes) {
-    parts.push(`${totalTransferBytes} total`);
-  }
-  const throughput = formatThroughput(status.throughput_bytes_per_second);
-  if (throughput) {
-    parts.push(throughput);
+  const profile = syncRunEvidenceProfile(status);
+  if (profile.role === "no_op") {
+    parts.push("No transfers");
+  } else {
+    const received = formatByteCount(profile.totalReceivedBytes);
+    const sent = formatByteCount(profile.totalServedBytes);
+    const receiveRate = formatThroughput(profile.receiveThroughput);
+    const sendRate = formatThroughput(profile.sendThroughput);
+    if (profile.receiverActive && received) parts.push(`${received} received`);
+    if (profile.senderActive && sent) parts.push(`${sent} sent`);
+    if (profile.receiverActive && receiveRate) parts.push(`Receive ${receiveRate}`);
+    if (profile.senderActive && sendRate) parts.push(`Send ${sendRate}`);
+    if (!receiveRate && !sendRate && profile.aggregateThroughput !== null) {
+      const combinedRate = formatThroughput(profile.aggregateThroughput);
+      if (combinedRate) parts.push(`Combined ${combinedRate}`);
+    }
   }
   const slowestPhase = syncRunSlowestPhaseText(status);
   if (slowestPhase) {
@@ -1099,16 +1273,24 @@ type SyncEvidenceRedactionContext = {
   tokenReplacements: Array<[string, string]>;
 };
 
-function createEvidenceLabelMap(values: Array<string | null | undefined>, prefix: string) {
+function createEvidenceLabelMap(
+  values: Array<string | null | undefined>,
+  prefix: string,
+  separator = "_",
+  options: { preserveOrder?: boolean } = {},
+) {
   const labels = new Map<string, string>();
-  values
-    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
-    .sort((left, right) => left.localeCompare(right))
-    .forEach((value) => {
-      if (!labels.has(value)) {
-        labels.set(value, `${prefix}_${labels.size + 1}`);
-      }
-    });
+  const usableValues = values.filter(
+    (value): value is string => typeof value === "string" && value.trim().length > 0,
+  );
+  const orderedValues = options.preserveOrder
+    ? usableValues
+    : [...usableValues].sort((left, right) => left.localeCompare(right));
+  orderedValues.forEach((value) => {
+    if (!labels.has(value)) {
+      labels.set(value, `${prefix}${separator}${labels.size + 1}`);
+    }
+  });
   return labels;
 }
 
@@ -1117,6 +1299,7 @@ function createSyncEvidenceRedactionContext(
   extraPeerDeviceIds: Array<string | null | undefined> = [],
   extraRunIds: Array<string | null | undefined> = [],
 ): SyncEvidenceRedactionContext {
+  const mergedProjectResults = mergeSyncProjectResults(status.project_results, status.manifest_errors);
   const peerLabels = createEvidenceLabelMap([
     status.peer_device_id,
     status.remote_device_id,
@@ -1126,21 +1309,20 @@ function createSyncEvidenceRedactionContext(
     ...extraPeerDeviceIds,
   ], "peer");
   const projectLabels = createEvidenceLabelMap([
-    ...status.project_results.map((result) => result.project_id),
-    ...status.manifest_errors.map((error) => error.project_id),
+    ...mergedProjectResults.map((result) => result.project_id),
     ...(status.phase_timings ?? []).map((timing) => timing.project_id),
-  ], "project");
+  ], "Project", " ", { preserveOrder: true });
   const artifactLabels = createEvidenceLabelMap([
     ...status.received_artifacts.map((artifact) => artifact.artifact_id),
     ...(status.phase_timings ?? []).map((timing) => timing.artifact_id),
-  ], "artifact");
+  ], "Artifact", " ", { preserveOrder: true });
   const runLabels = createEvidenceLabelMap([
     status.run_id,
     status.session_id,
     status.last_lifecycle_event?.run_id,
     ...(status.lifecycle_events ?? []).map((event) => event.run_id),
     ...extraRunIds,
-  ], "run");
+  ], "Run", " ");
   const tokenReplacements = [
     ...Array.from(peerLabels.entries()),
     ...Array.from(projectLabels.entries()),
@@ -1183,7 +1365,24 @@ function redactSyncEvidenceText(
     (_match, prefix: string) => `${prefix}[redacted_path]`,
   );
   redacted = redacted.replace(SYNC_EVIDENCE_FILENAME_PATTERN, "[redacted_filename]");
+  redacted = redacted.replace(SYNC_EVIDENCE_RAW_ID_TOKEN_PATTERN, (token) =>
+    SYNC_EVIDENCE_SAFE_RAW_TOKENS.has(token.toLowerCase()) ? token : "[redacted_id]");
+  redacted = redacted.replace(SYNC_EVIDENCE_HASH_TOKEN_PATTERN, (token) =>
+    SYNC_EVIDENCE_SAFE_HASH_TOKENS.has(token.toLowerCase()) ? token : "[redacted_hash]");
   return redacted;
+}
+
+function redactSyncEvidenceNativeDetailText(
+  value: string | null | undefined,
+  context: SyncEvidenceRedactionContext,
+) {
+  const detail = value?.trim();
+  if (!detail) {
+    return null;
+  }
+  return syncNativeDetailIsKnownSafe(detail)
+    ? redactSyncEvidenceText(detail, context)
+    : "details redacted.";
 }
 
 function syncEvidenceLifecycleEvent(
@@ -1196,10 +1395,10 @@ function syncEvidenceLifecycleEvent(
   return {
     kind: event.kind,
     occurredAt: event.occurred_at ?? null,
-    message: redactSyncEvidenceText(event.message, context),
+    message: redactSyncEvidenceNativeDetailText(event.message, context),
     retryable: event.retryable,
     interruptionCode: event.interruption_code ?? null,
-    retryGuidance: redactSyncEvidenceText(event.retry_guidance, context),
+    retryGuidance: redactSyncEvidenceNativeDetailText(event.retry_guidance, context),
     peer: event.peer_device_id ? context.peerLabels.get(event.peer_device_id) ?? "peer_1" : null,
     hasRunId: Boolean(event.run_id),
   };
@@ -1252,7 +1451,7 @@ function sumSyncPhaseDurations(status: SyncTransportRunStatus, matcher: RegExp) 
   return total > 0 ? total : null;
 }
 
-function syncRunTotalEvidenceBytes(status: SyncTransportRunStatus) {
+function syncRunTotalEvidenceBytes(status: SyncTransportRunStatus, receivedCount: number | null) {
   const directReceived = typeof status.total_received_bytes === "number" &&
     Number.isFinite(status.total_received_bytes)
     ? status.total_received_bytes
@@ -1260,12 +1459,14 @@ function syncRunTotalEvidenceBytes(status: SyncTransportRunStatus) {
   if (directReceived !== null) {
     return directReceived;
   }
-  const artifactBytes = status.received_artifacts.reduce((total, artifact) => (
-    typeof artifact.size_bytes === "number" && Number.isFinite(artifact.size_bytes)
-      ? total + artifact.size_bytes
-      : total
-  ), 0);
-  return artifactBytes > 0 ? artifactBytes : null;
+  const received = status.received_artifacts.filter((artifact) => artifact.status === "received");
+  const rowsComplete = receivedCount !== null
+    ? received.length === receivedCount : status.received_artifacts_complete === true;
+  if (!rowsComplete || received.some((artifact) =>
+    typeof artifact.size_bytes !== "number" || !Number.isFinite(artifact.size_bytes))) {
+    return null;
+  }
+  return received.reduce((total, artifact) => total + (artifact.size_bytes ?? 0), 0);
 }
 
 function throughputFromEvidenceBytes(bytes: number | null, durationMs: number | null) {
@@ -1275,41 +1476,213 @@ function throughputFromEvidenceBytes(bytes: number | null, durationMs: number | 
   return bytes / (durationMs / 1000);
 }
 
-function syncRunProjectApplyDurationMs(status: SyncTransportRunStatus) {
-  const directApply = sumSyncPhaseDurations(status, /reconciliation|apply/i);
-  if (directApply !== null) {
-    return directApply;
+type SyncApplyTimingEvidence = {
+  wallClockMs: number | null;
+  aggregateMs: number | null;
+  semantics: string;
+};
+
+type SyncApplyTimingEntry = {
+  startedAt: number | null;
+  completedAt: number | null;
+  durationMs: number | null;
+};
+
+function syncEvidenceTimestampMs(value: string | null | undefined) {
+  if (!value) {
+    return null;
   }
-  const projectDuration = status.project_results.reduce((durationMs, result) => {
-    if (!["applied", "deleted", "imported"].includes(result.status)) {
-      return durationMs;
+  const timestamp = new Date(normalizeApiDateTime(value)).getTime();
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function syncRunWallClockDurationMs(status: SyncTransportRunStatus) {
+  const durationSeconds = syncRunDurationSeconds(status);
+  return durationSeconds === null ? null : Math.round(durationSeconds * 1000);
+}
+
+function isSyncApplyPhaseName(phase: string | null | undefined) {
+  const normalized = phase?.trim().toLowerCase().replace(/[\s-]+/g, "_") ?? "";
+  if (!normalized || /(^|_)(plan|planning|stage|staging)($|_)/.test(normalized)) {
+    return false;
+  }
+  return normalized === "apply" ||
+    normalized === "reconciliation_apply" ||
+    normalized.startsWith("apply_") ||
+    normalized.startsWith("reconciliation_apply_") ||
+    normalized.endsWith("_apply");
+}
+
+function syncRunApplyTimingEvidence(
+  status: SyncTransportRunStatus,
+  mergedProjectResults: SyncTransportProjectResult[],
+): SyncApplyTimingEvidence {
+  const phaseApplyEntries = (status.phase_timings ?? [])
+    .filter((timing) => isSyncApplyPhaseName(timing.phase))
+    .map<SyncApplyTimingEntry>((timing) => ({
+      startedAt: syncEvidenceTimestampMs(timing.started_at),
+      completedAt: syncEvidenceTimestampMs(timing.completed_at),
+      durationMs: typeof timing.duration_ms === "number" &&
+          Number.isFinite(timing.duration_ms) &&
+          timing.duration_ms >= 0
+        ? timing.duration_ms
+        : null,
+    }));
+  const projectApplyEntries = mergedProjectResults
+    .filter((result) => ["applied", "deleted", "imported"].includes(result.status))
+    .map<SyncApplyTimingEntry>((result) => ({
+      startedAt: syncEvidenceTimestampMs(result.started_at),
+      completedAt: syncEvidenceTimestampMs(result.completed_at),
+      durationMs: typeof result.duration_ms === "number" &&
+          Number.isFinite(result.duration_ms) &&
+          result.duration_ms >= 0
+        ? result.duration_ms
+        : null,
+    }));
+  const entries = phaseApplyEntries.length ? phaseApplyEntries : projectApplyEntries;
+  const aggregateDurations = entries.map((entry) => {
+    const intervalDuration = entry.startedAt !== null && entry.completedAt !== null &&
+        entry.completedAt >= entry.startedAt
+      ? entry.completedAt - entry.startedAt
+      : null;
+    if (entry.durationMs !== null && intervalDuration !== null &&
+        Math.abs(entry.durationMs - intervalDuration) > 1) {
+      return null;
     }
-    if (typeof result.duration_ms === "number" && Number.isFinite(result.duration_ms)) {
-      return durationMs + result.duration_ms;
+    if (entry.durationMs !== null && intervalDuration !== null) {
+      return Math.max(entry.durationMs, intervalDuration);
     }
-    if (result.started_at && result.completed_at) {
-      const startedAt = new Date(normalizeApiDateTime(result.started_at)).getTime();
-      const completedAt = new Date(normalizeApiDateTime(result.completed_at)).getTime();
-      if (Number.isFinite(startedAt) && Number.isFinite(completedAt) && completedAt >= startedAt) {
-        return durationMs + (completedAt - startedAt);
+    if (entry.durationMs !== null) {
+      return entry.durationMs;
+    }
+    return intervalDuration;
+  });
+  const aggregateMs = entries.length > 0 && aggregateDurations.every((duration) => duration !== null)
+    ? aggregateDurations.reduce((total, duration) => total + (duration ?? 0), 0)
+    : null;
+  let runStartedAt = syncEvidenceTimestampMs(status.started_at);
+  let runCompletedAt = syncEvidenceTimestampMs(status.completed_at);
+  const runDurationMs = syncRunWallClockDurationMs(status);
+  if (runDurationMs !== null) {
+    if (runStartedAt !== null && runCompletedAt === null) {
+      runCompletedAt = runStartedAt + runDurationMs;
+    } else if (runStartedAt === null && runCompletedAt !== null) {
+      runStartedAt = runCompletedAt - runDurationMs;
+    }
+  }
+  const intervalCandidates = entries
+    .map((entry) => {
+      if (entry.startedAt === null || entry.completedAt === null || entry.completedAt < entry.startedAt) {
+        return null;
       }
+      if (entry.durationMs !== null && Math.abs(entry.durationMs - (entry.completedAt - entry.startedAt)) > 1) {
+        return null;
+      }
+      return [entry.startedAt, entry.completedAt] as const;
+    });
+  if (entries.length > 0 && intervalCandidates.every(
+    (interval): interval is readonly [number, number] => interval !== null,
+  )) {
+    const intervals = intervalCandidates.slice().sort((left, right) => left[0] - right[0]);
+    let unionDurationMs = 0;
+    let [currentStart, currentEnd] = intervals[0]!;
+    intervals.slice(1).forEach(([startedAt, completedAt]) => {
+      if (startedAt <= currentEnd) {
+        currentEnd = Math.max(currentEnd, completedAt);
+        return;
+      }
+      unionDurationMs += currentEnd - currentStart;
+      currentStart = startedAt;
+      currentEnd = completedAt;
+    });
+    unionDurationMs += currentEnd - currentStart;
+    const firstStartedAt = intervals[0]![0];
+    const lastCompletedAt = intervals.reduce((latest, interval) => Math.max(latest, interval[1]), firstStartedAt);
+    const runBoundsDurationMs = runStartedAt !== null && runCompletedAt !== null
+      ? runCompletedAt - runStartedAt
+      : null;
+    const runBoundsConsistent = runBoundsDurationMs === null || (
+      runBoundsDurationMs >= 0 &&
+      runDurationMs !== null &&
+      Math.abs(runBoundsDurationMs - runDurationMs) <= 1
+    );
+    const intervalsWithinRunBounds = intervals.every(([startedAt, completedAt]) =>
+      (runStartedAt === null || startedAt >= runStartedAt) &&
+      (runCompletedAt === null || completedAt <= runCompletedAt)
+    );
+    const unionWithinRunDuration = runDurationMs !== null &&
+      unionDurationMs <= runDurationMs &&
+      lastCompletedAt - firstStartedAt <= runDurationMs;
+    if (runBoundsConsistent && intervalsWithinRunBounds && unionWithinRunDuration) {
+      return {
+        wallClockMs: unionDurationMs,
+        aggregateMs,
+        semantics: "wall_clock_interval_union_bounded_to_run",
+      };
     }
-    return durationMs;
-  }, 0);
-  return projectDuration > 0 ? projectDuration : null;
+  }
+
+  if (aggregateMs !== null) {
+    return {
+      wallClockMs: null,
+      aggregateMs,
+      semantics: "aggregate_only",
+    };
+  }
+  return {
+    wallClockMs: null,
+    aggregateMs: null,
+    semantics: "not_reported",
+  };
 }
 
 function syncRunTransferCountsEvidence(
   status: SyncTransportRunStatus,
   artifactStatusCounts: Record<string, number>,
 ) {
+  const artifactsComplete = status.received_artifacts_complete ?? status.received_artifacts.length > 0;
+  const inferredCount = (statusKey: string) => artifactsComplete ? artifactStatusCounts[statusKey] ?? 0 : null;
   return {
-    requested: syncRunMetricValue(status, "requested") ?? status.received_artifacts.length,
-    received: syncRunMetricValue(status, "received") ?? artifactStatusCounts.received ?? 0,
-    skipped: syncRunMetricValue(status, "skipped") ?? syncRunMetricValue(status, "already_local") ?? 0,
-    already_staged: syncRunMetricValue(status, "already_staged") ?? artifactStatusCounts.already_staged ?? 0,
-    failed: syncRunMetricValue(status, "failed") ?? artifactStatusCounts.failed ?? 0,
-    retried: syncRunMetricValue(status, "retried") ?? syncRunMetricValue(status, "retries") ?? 0,
+    requested: syncRunMetricValue(status, "requested") ?? (artifactsComplete ? status.received_artifacts.length : null),
+    received: syncRunMetricValue(status, "received") ?? inferredCount("received"),
+    skipped: syncRunMetricValue(status, "skipped") ?? syncRunMetricValue(status, "already_local") ??
+      inferredCount("skipped"),
+    already_staged: syncRunMetricValue(status, "already_staged") ?? inferredCount("already_staged"),
+    failed: syncRunMetricValue(status, "failed") ?? inferredCount("failed"),
+    retried: syncRunMetricValue(status, "retried") ?? syncRunMetricValue(status, "retries") ??
+      (artifactsComplete ? 0 : null),
+  };
+}
+
+function syncRunEvidenceProfile(status: SyncTransportRunStatus) {
+  const artifactStatusCounts = status.received_artifacts.reduce<Record<string, number>>((counts, artifact) => {
+    counts[artifact.status] = (counts[artifact.status] ?? 0) + 1;
+    return counts;
+  }, {});
+  const transferCounts = syncRunTransferCountsEvidence(status, artifactStatusCounts);
+  const canonicalCounts = syncRunCanonicalCounts(status);
+  const mutationCounts = [canonicalCounts?.importedProjectCount, canonicalCounts?.appliedProjectCount,
+    canonicalCounts?.deletedProjectCount];
+  const mutationCount = mutationCounts.every((count): count is number => typeof count === "number")
+    ? mutationCounts.reduce((total, count) => total + count, 0) : null;
+  const totalReceivedBytes = syncRunTotalEvidenceBytes(status, syncRunMetricValue(status, "received")) ??
+    (transferCounts.received === 0 ? 0 : null);
+  const totalServedBytes = typeof status.total_served_bytes === "number" && Number.isFinite(status.total_served_bytes)
+    ? status.total_served_bytes : status.served_artifact_requests === 0 ? 0 : null;
+  const receiverCounts = Object.values(transferCounts);
+  const receiverActive = receiverCounts.some(positiveSyncCount) || positiveSyncCount(mutationCount) ||
+    positiveSyncCount(totalReceivedBytes);
+  const senderActive = positiveSyncCount(status.served_artifact_requests) || positiveSyncCount(totalServedBytes);
+  const noOp = receiverCounts.every((count) => count === 0) && mutationCount === 0 &&
+    totalReceivedBytes === 0 && status.served_artifact_requests === 0 && totalServedBytes === 0;
+  const role = receiverActive && senderActive ? "bidirectional" : receiverActive
+    ? "receiver_or_import" : senderActive ? "sender_only" : noOp ? "no_op" : "unknown";
+  const durationMs = status.duration_ms ?? (typeof status.duration_seconds === "number" ? status.duration_seconds * 1000 : null);
+  return {
+    role, receiverActive, senderActive, transferCounts, totalReceivedBytes, totalServedBytes,
+    receiveThroughput: receiverActive ? throughputFromEvidenceBytes(totalReceivedBytes, durationMs) : null,
+    sendThroughput: senderActive ? throughputFromEvidenceBytes(totalServedBytes, durationMs) : null,
+    aggregateThroughput: status.throughput_bytes_per_second ?? null,
   };
 }
 
@@ -1359,6 +1732,9 @@ function buildSyncEvidenceExport(
   ]);
   const projectAppearances = syncEvidenceProjectCadence(status);
   const mergedProjectResults = mergeSyncProjectResults(status.project_results, status.manifest_errors);
+  const finalProjectResults = mergedProjectResults.filter(
+    (result) => result.status !== SYNC_MANIFEST_EXPORT_ERROR_STATUS && isFinalSyncProjectResult(result),
+  );
   const artifactStatusCounts = status.received_artifacts.reduce<Record<string, number>>((counts, artifact) => {
     counts[artifact.status] = (counts[artifact.status] ?? 0) + 1;
     return counts;
@@ -1367,36 +1743,54 @@ function buildSyncEvidenceExport(
     counts[result.project_id] = (counts[result.project_id] ?? 0) + 1;
     return counts;
   }, {});
-  const projectResultCountByStatus = mergedProjectResults.reduce<Record<string, number>>((counts, result) => {
-    counts[result.status] = (counts[result.status] ?? 0) + 1;
-    return counts;
-  }, {});
+  const projectResultCountByStatus = countSyncProjectResultsByStatus(finalProjectResults);
+  const canonicalCounts = syncRunCanonicalCounts(status);
+  const evidenceProjectResultsByStatus = canonicalCounts
+    ? canonicalCounts.projectResultsByStatus
+    : projectResultCountByStatus;
+  const evidenceImportedProjectCount = canonicalCounts?.importedProjectCount ?? null;
+  const evidenceAppliedProjectCount = canonicalCounts?.appliedProjectCount ?? null;
+  const evidenceDeletedProjectCount = canonicalCounts?.deletedProjectCount ?? null;
+  const evidenceSkippedProjectCount = canonicalCounts?.skippedProjectCount ?? null;
+  const evidenceConflictedProjectCount = canonicalCounts?.conflictedProjectCount ?? null;
+  const evidenceFailedProjectCount = canonicalCounts?.failedProjectCount ?? null;
+  const evidenceManifestExportErrorCount = canonicalCounts?.manifestExportErrorCount ?? null;
+  const evidenceTotalProjectCount = canonicalCounts?.totalProjectCount ?? null;
+  const profile = syncRunEvidenceProfile(status);
+  const evidenceTransferCounts = profile.transferCounts;
+  const redactedStatusMessage = redactSyncEvidenceText(status.message, redactionContext);
   const retryIndicators = {
     duplicateProjectEvents: Object.values(projectRetryCount).some((count) => count > 1),
-    messageMentionsRetry: Boolean(
-      redactSyncEvidenceText(status.message, redactionContext)?.match(/\bretry|retried\b/i),
-    ),
+    messageMentionsRetry: Boolean(redactedStatusMessage?.match(/\bretry|retried\b/i)),
   };
+  const reusedArtifacts = positiveSyncCount(evidenceTransferCounts.already_staged);
+  const reusedProjectArtifacts = mergedProjectResults.some((result) => positiveSyncCount(result.reused_artifact_count));
   const reuseIndicators = {
-    reusedArtifacts: status.received_artifacts.some((artifact) => artifact.status === "already_staged"),
-    reusedProjectArtifacts: mergedProjectResults.some((result) => (result.reused_artifact_count ?? 0) > 0),
-    messageMentionsReuse: Boolean(
-      redactSyncEvidenceText(status.message, redactionContext)?.match(/\breused?|reuse\b/i),
-    ),
+    reusedArtifacts,
+    reusedProjectArtifacts,
+    messageMentionsReuse: (reusedArtifacts || reusedProjectArtifacts) &&
+      Boolean(redactedStatusMessage?.match(/\breused?|reuse\b/i)),
   };
-  const totalEvidenceBytes = syncRunTotalEvidenceBytes(status);
   const stagingDurationMs = sumSyncPhaseDurations(status, /staging|stage/i) ??
     syncRunMetricValue(status, "staging_post_ms_total");
-  const applyDurationMs = syncRunProjectApplyDurationMs(status);
+  const applyTimingEvidence = syncRunApplyTimingEvidence(status, mergedProjectResults);
   const durationMs = status.duration_ms ?? (
     typeof status.duration_seconds === "number" ? Math.round(status.duration_seconds * 1000) : null
   );
-  const importedProjectCount = status.imported_project_count ??
-    status.project_results.filter((result) => ["applied", "deleted", "imported"].includes(result.status)).length;
-  const projectImportsPerMinute = durationMs && durationMs > 0
-    ? importedProjectCount / (durationMs / 60000)
+  const mutationCounts = [
+    evidenceImportedProjectCount,
+    evidenceAppliedProjectCount,
+    evidenceDeletedProjectCount,
+  ];
+  const mutatedProjectCount = mutationCounts.every((count): count is number => count !== null)
+    ? mutationCounts.reduce((total, count) => total + count, 0)
     : null;
-  const evidenceTransferCounts = syncRunTransferCountsEvidence(status, artifactStatusCounts);
+  const projectImportsPerMinute = durationMs && durationMs > 0 && evidenceImportedProjectCount !== null
+    ? evidenceImportedProjectCount / (durationMs / 60000)
+    : null;
+  const projectMutationsPerMinute = durationMs && durationMs > 0 && mutatedProjectCount !== null
+    ? mutatedProjectCount / (durationMs / 60000)
+    : null;
   const evidenceLifecycleEvents = [
     ...options.listenerLifecycleEvents,
     ...(status.lifecycle_events ?? []),
@@ -1417,10 +1811,10 @@ function buildSyncEvidenceExport(
       listenerUpdatedAt: options.listenerUpdatedAt ?? null,
     },
     run: {
-      label: "run_1",
+      label: "Run 1",
       status: status.status,
-      message: redactSyncEvidenceText(status.message, redactionContext),
-      error: redactSyncEvidenceText(status.error, redactionContext),
+      message: redactSyncEvidenceNativeDetailText(status.message, redactionContext),
+      error: redactSyncEvidenceNativeDetailText(status.error, redactionContext),
       startedAt: status.started_at ?? null,
       completedAt: status.completed_at ?? null,
       durationMs: status.duration_ms ?? null,
@@ -1441,18 +1835,32 @@ function buildSyncEvidenceExport(
       attempted: status.attempted_transports ?? [],
       attemptedLabels: (status.attempted_transports ?? []).map((transport) => transportLabel(transport) ?? transport),
       fallback_code: status.fallback_code ?? null,
-      fallback_reason: redactSyncEvidenceText(status.fallback_reason, redactionContext),
+      fallback_reason: redactSyncEvidenceNativeDetailText(status.fallback_reason, redactionContext),
       fallback: {
         code: status.fallback_code ?? null,
-        reason: redactSyncEvidenceText(status.fallback_reason, redactionContext),
+        reason: redactSyncEvidenceNativeDetailText(status.fallback_reason, redactionContext),
       },
     },
     metrics: {
-      network_receive_throughput_bytes_per_second: status.throughput_bytes_per_second ?? null,
-      backend_staging_throughput_bytes_per_second: throughputFromEvidenceBytes(totalEvidenceBytes, stagingDurationMs),
-      reconciliation_apply_ms: applyDurationMs,
+      network_receive_throughput_bytes_per_second: profile.receiveThroughput,
+      network_send_throughput_bytes_per_second: profile.sendThroughput,
+      backend_staging_throughput_bytes_per_second: throughputFromEvidenceBytes(
+        profile.totalReceivedBytes,
+        stagingDurationMs,
+      ),
+      reconciliation_apply_ms: applyTimingEvidence.wallClockMs,
+      reconciliation_apply_aggregate_ms: applyTimingEvidence.aggregateMs,
+      reconciliation_apply_timing: {
+        wallClockField: "reconciliation_apply_ms",
+        aggregateField: "reconciliation_apply_aggregate_ms",
+        semantics: applyTimingEvidence.semantics,
+      },
       project_imports_per_minute: projectImportsPerMinute,
+      project_mutations_per_minute: projectMutationsPerMinute,
       project_availability_gap_ms: syncProjectAvailabilityGapMs(projectAppearances),
+      total_received_bytes: profile.totalReceivedBytes,
+      total_served_bytes: profile.totalServedBytes,
+      received_artifacts_complete: status.received_artifacts_complete ?? null,
       ttfa_ms: status.time_to_first_artifact_ms ?? null,
       transfer_counts: evidenceTransferCounts,
       timeToFirstArtifactMs: status.time_to_first_artifact_ms ?? null,
@@ -1463,14 +1871,16 @@ function buildSyncEvidenceExport(
         servedArtifactRequests: status.served_artifact_requests ?? null,
         localManifestCount: status.local_manifest_count ?? null,
         remoteManifestCount: status.remote_manifest_count ?? null,
-        importedProjectCount: status.imported_project_count ?? null,
-        appliedProjectCount: status.applied_project_count ?? null,
-        deletedProjectCount: status.deleted_project_count ?? null,
-        skippedProjectCount: status.skipped_project_count ?? null,
-        failedProjectCount: status.failed_project_count ?? null,
-        totalProjectCount: status.total_project_count ?? null,
+        importedProjectCount: evidenceImportedProjectCount,
+        appliedProjectCount: evidenceAppliedProjectCount,
+        deletedProjectCount: evidenceDeletedProjectCount,
+        skippedProjectCount: evidenceSkippedProjectCount,
+        conflictedProjectCount: evidenceConflictedProjectCount,
+        failedProjectCount: evidenceFailedProjectCount,
+        totalProjectCount: evidenceTotalProjectCount,
+        manifestExportErrorCount: evidenceManifestExportErrorCount,
       },
-      projectResultsByStatus: projectResultCountByStatus,
+      projectResultsByStatus: evidenceProjectResultsByStatus,
       retryIndicators,
       reuseIndicators,
       maxActiveStreams: syncRunEvidenceValue(status, "max_active_streams", [
@@ -1507,11 +1917,11 @@ function buildSyncEvidenceExport(
         )
         : null;
       return {
-        label: redactionContext.projectLabels.get(result.project_id) ?? "project_1",
+        label: redactionContext.projectLabels.get(result.project_id) ?? "Project 1",
         status: result.status,
-        phase: result.phase ?? null,
+        phase: syncEvidencePhase(result.phase),
         action: result.action ?? null,
-        message: redactSyncEvidenceText(result.message, redactionContext),
+        message: redactSyncEvidenceNativeDetailText(result.message, redactionContext),
         isFinal: result.is_final ?? null,
         startedAt: result.started_at ?? null,
         completedAt: result.completed_at ?? null,
@@ -1538,9 +1948,9 @@ function buildSyncEvidenceExport(
       };
     }),
     artifacts: status.received_artifacts.map((artifact) => ({
-      label: redactionContext.artifactLabels.get(artifact.artifact_id) ?? "artifact_1",
+      label: redactionContext.artifactLabels.get(artifact.artifact_id) ?? "Artifact 1",
       status: artifact.status,
-      message: redactSyncEvidenceText(artifact.message, redactionContext),
+      message: statusLabel(artifact.status),
       sizeBytes: artifact.size_bytes ?? null,
       startedAt: artifact.started_at ?? null,
       completedAt: artifact.completed_at ?? null,
@@ -1552,32 +1962,32 @@ function buildSyncEvidenceExport(
       events: syncEvidenceLifecycleEvents(evidenceLifecycleEvents, redactionContext),
       lastLifecycleEvent: syncEvidenceLifecycleEvent(lastLifecycleEvent, redactionContext),
       retryableInterruptionCode,
-      retryGuidance: redactSyncEvidenceText(retryGuidance, redactionContext),
+      retryGuidance: redactSyncEvidenceNativeDetailText(retryGuidance, redactionContext),
       listener: {
         active: options.listenerActive,
         status: options.listenerStatus,
-        activePhase: options.listenerActivePhase ?? null,
-        activeMessage: redactSyncEvidenceText(options.listenerActiveMessage, redactionContext),
+        activePhase: syncEvidencePhase(options.listenerActivePhase),
+        activeMessage: redactSyncEvidenceNativeDetailText(options.listenerActiveMessage, redactionContext),
         activeProgressAt: options.listenerActiveProgressAt ?? null,
         activeElapsedMs: options.listenerActiveElapsedMs ?? null,
-        lastStatus: redactSyncEvidenceText(options.listenerLastStatus, redactionContext),
+        lastStatus: redactSyncEvidenceNativeDetailText(options.listenerLastStatus, redactionContext),
         hasLastError: Boolean(options.listenerLastError),
         updatedAt: options.listenerUpdatedAt ?? null,
         lastLifecycleEvent: syncEvidenceLifecycleEvent(options.listenerLastLifecycleEvent, redactionContext),
         retryableInterruptionCode: options.listenerRetryableInterruptionCode ?? null,
-        retryGuidance: redactSyncEvidenceText(options.listenerRetryGuidance, redactionContext),
+        retryGuidance: redactSyncEvidenceNativeDetailText(options.listenerRetryGuidance, redactionContext),
       },
       run: {
         lastLifecycleEvent: syncEvidenceLifecycleEvent(status.last_lifecycle_event, redactionContext),
         retryableInterruptionCode: status.retryable_interruption_code ?? null,
-        retryGuidance: redactSyncEvidenceText(status.retry_guidance, redactionContext),
+        retryGuidance: redactSyncEvidenceNativeDetailText(status.retry_guidance, redactionContext),
       },
       phaseTimings: (status.phase_timings ?? []).map((timing, index) => ({
         label: `phase_${index + 1}`,
-        phase: timing.phase ?? null,
-        project: timing.project_id ? redactionContext.projectLabels.get(timing.project_id) ?? "project_1" : null,
+        phase: syncEvidencePhase(timing.phase),
+        project: timing.project_id ? redactionContext.projectLabels.get(timing.project_id) ?? "Project 1" : null,
         artifact: timing.artifact_id
-          ? redactionContext.artifactLabels.get(timing.artifact_id) ?? "artifact_1"
+          ? redactionContext.artifactLabels.get(timing.artifact_id) ?? "Artifact 1"
           : null,
         startedAt: timing.started_at ?? null,
         completedAt: timing.completed_at ?? null,
@@ -1609,7 +2019,9 @@ function buildSyncEvidenceExport(
     },
     validation: {
       schema: "tuneforge-sync-evidence-v1",
+      scope: "run_outcome",
       ok: validation.ok,
+      outcomeOk: validation.ok,
       issues: validation.issues,
       ui_visible: true,
       privacySafe: true,
@@ -1636,13 +2048,15 @@ function syncProjectResultList(status: SyncTransportRunStatus | null | undefined
     return null;
   }
   return (
-    <ul className="activity-sync-project-results" aria-label="Last sync project results">
+    <ul className="activity-sync-project-results" aria-label="Last sync project evidence">
       {results.map((result, index) => (
         <li
           className={`activity-sync-project-result activity-sync-project-result--${statusClassName(result.status)}`}
           key={`${result.project_id}-${result.status}-${index}`}
         >
-          <span className="activity-sync-project-result__status">{statusLabel(result.status)}</span>
+          <span className="activity-sync-project-result__status">
+            {statusLabel(result.status)}{isFinalSyncProjectResult(result) ? "" : " (event)"}
+          </span>
           <span className="activity-sync-project-result__project" title={result.project_id}>
             {syncProjectIdLabel(result.project_id)}
           </span>
@@ -1754,9 +2168,13 @@ export function ActivitySyncPanel() {
   const listenerSyncResult = listenerQuery.data?.last_sync ?? null;
   const listenerSyncKey = useMemo(() => syncResultKey(listenerSyncResult), [listenerSyncResult]);
   const showListenerSyncResult = listenerSyncResult !== null && listenerSyncKey !== hiddenListenerSyncKey;
+  const listenerLastStatus = syncVisibleNativeDetailText(
+    listenerQuery.data?.last_status,
+    "Sync listener status: details redacted.",
+  );
   const lastSyncStatus = listenerSyncResult
     ? syncStatusText(listenerSyncResult, peersById)
-    : listenerQuery.data?.last_status ?? syncStatusText(listenerSyncResult, peersById);
+    : listenerLastStatus ?? syncStatusText(listenerSyncResult, peersById);
   const visibleSyncResult = showListenerSyncResult ? listenerSyncResult : lastSyncResult;
   const displayedLastSyncMessage = !showListenerSyncResult
     ? lastSyncMessage ?? lastSyncStatus
@@ -2335,10 +2753,14 @@ export function ActivitySyncPanel() {
   const pairingInputInvalid = Boolean(pairingInputValue && decodedPairingInput.error);
   const trustedPeers = peersQuery.data ?? [];
   const lastListenerUpdatedAt = formatTimestamp(listenerQuery.data?.updated_at);
-  const currentSyncPhase = listenerQuery.data?.active_phase
-    ? statusLabel(listenerQuery.data.active_phase)
-    : null;
-  const currentSyncMessage = listenerQuery.data?.active_message?.trim() || null;
+  const currentSyncPhaseValue = syncEvidencePhase(listenerQuery.data?.active_phase);
+  const currentSyncPhase = currentSyncPhaseValue === "phase_redacted"
+    ? "Sync Phase"
+    : currentSyncPhaseValue ? statusLabel(currentSyncPhaseValue) : null;
+  const currentSyncMessage = syncVisibleNativeDetailText(
+    listenerQuery.data?.active_message,
+    "details redacted.",
+  );
   const currentSyncProgressAt = formatTimestamp(listenerQuery.data?.active_progress_at);
   const currentSyncElapsed = formatDurationMs(listenerQuery.data?.active_elapsed_ms);
   const currentSyncDetails = [
@@ -2447,7 +2869,9 @@ export function ActivitySyncPanel() {
             </div>
             <div>
               <dt>Device</dt>
-              <dd>{identityQuery.data?.display_name || identityQuery.data?.device_id || "Checking identity"}</dd>
+              <dd>
+                {identityQuery.data?.display_name || identityQuery.data?.device_id || "Checking identity"}
+              </dd>
             </div>
             <div>
               <dt>Endpoints</dt>

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -201,8 +201,11 @@ export type SyncTransportRunStatus = {
   retry_guidance?: string | null;
   error?: string | null;
   project_results: SyncTransportProjectResult[];
+  project_results_complete?: boolean;
   manifest_errors: SyncTransportManifestError[];
+  manifest_errors_complete?: boolean;
   received_artifacts: SyncTransportTransferResult[];
+  received_artifacts_complete?: boolean;
   served_artifact_requests?: number | null;
   local_manifest_count?: number | null;
   remote_manifest_count?: number | null;
@@ -210,7 +213,9 @@ export type SyncTransportRunStatus = {
   applied_project_count?: number | null;
   deleted_project_count?: number | null;
   skipped_project_count?: number | null;
+  conflicted_project_count?: number | null;
   failed_project_count?: number | null;
+  manifest_export_error_count?: number | null;
   total_project_count?: number | null;
 } & SyncTransportDiagnosticValues;
 export type SyncTransportProjectResult = {
@@ -1176,12 +1181,13 @@ const SYNC_PROJECT_RESULT_PROBLEM_STATES = new Set([
   "error",
   "failed",
 ]);
+const SYNC_MANIFEST_EXPORT_ERROR_STATUS = "manifest_export_error";
 
 function projectResultKey(result: SyncTransportProjectResult) {
   return result.project_id.trim() || "unknown";
 }
 
-function isFinalSyncProjectResult(result: SyncTransportProjectResult) {
+export function isFinalSyncProjectResult(result: SyncTransportProjectResult) {
   if (result.is_final !== null && result.is_final !== undefined) {
     return result.is_final;
   }
@@ -1251,7 +1257,7 @@ export function mergeSyncProjectResults(
     }
     const result: SyncTransportProjectResult = {
       project_id: key,
-      status: "failed",
+      status: SYNC_MANIFEST_EXPORT_ERROR_STATUS,
       message: error.message,
       is_final: true,
     };
@@ -1263,6 +1269,252 @@ export function mergeSyncProjectResults(
   });
 
   return Array.from(merged.values());
+}
+
+export function countSyncProjectResultsByStatus(projectResults: SyncTransportProjectResult[]) {
+  return projectResults.reduce<Record<string, number>>((counts, result) => {
+    counts[result.status] = (counts[result.status] ?? 0) + 1;
+    return counts;
+  }, {});
+}
+
+export function syncMessageShouldYieldToCanonicalSummary(message: string | null | undefined) {
+  const normalized = message?.trim();
+  if (!normalized) {
+    return false;
+  }
+  return /\b(?:imported|applied|deleted|skipped|failed|conflicted|received|served|offered)\s+\d+\b/i.test(normalized) ||
+    /\b\d+\s+(?:local|remote)\s+manifest\(s\)\b/i.test(normalized) ||
+    /\b\d+\s+manifest export error\(s\)\b/i.test(normalized) ||
+    /\b(?:project|artifact|manifest) request\(s\)\b/i.test(normalized) ||
+    /\bmanifest exchange completed\b/i.test(normalized) ||
+    /\b\d+\s+project results?\b/i.test(normalized) ||
+    /\bsync completed\b/i.test(normalized);
+}
+
+type SyncCanonicalSummaryCounts = {
+  localManifestCount: number | null;
+  remoteManifestCount: number | null;
+  importedProjectCount: number | null;
+  appliedProjectCount: number | null;
+  deletedProjectCount: number | null;
+  skippedProjectCount: number | null;
+  conflictedProjectCount: number | null;
+  failedProjectCount: number | null;
+  receivedArtifactCount: number | null;
+  reusedArtifactCount: number | null;
+  failedTransferCount: number | null;
+  hasCompleteTransferEvidence: boolean;
+  manifestExportErrorCount: number | null;
+};
+
+export type SyncRunCanonicalCounts = SyncCanonicalSummaryCounts & {
+  projectResultsByStatus: Record<string, number> | null;
+  totalProjectCount: number | null;
+};
+
+type SyncRunCanonicalCountParts = {
+  localManifestCount: number | null;
+  remoteManifestCount: number | null;
+  importedProjectCount: number | null;
+  appliedProjectCount: number | null;
+  deletedProjectCount: number | null;
+  skippedProjectCount: number | null;
+  conflictedProjectCount: number | null;
+  failedProjectCount: number | null;
+  totalProjectCount: number | null;
+  manifestExportErrorCount: number | null;
+  projectResults: SyncTransportProjectResult[];
+  projectResultsComplete: boolean;
+  manifestErrors: SyncTransportManifestError[];
+  manifestErrorsComplete: boolean;
+  receivedArtifacts: SyncTransportTransferResult[];
+  receivedArtifactsComplete: boolean;
+  transferCounts?: Record<string, number> | null;
+};
+
+export function syncCanonicalSummaryMessage(counts: SyncCanonicalSummaryCounts) {
+  const count = (value: number | null) => value ?? "unknown";
+  return `Exchanged ${count(counts.localManifestCount)} local and ${count(counts.remoteManifestCount)} remote manifest(s); final project outcomes: imported ${count(counts.importedProjectCount)}, applied ${count(counts.appliedProjectCount)}, deleted ${count(counts.deletedProjectCount)}, skipped ${count(counts.skippedProjectCount)}, conflicted ${count(counts.conflictedProjectCount)}, failed ${count(counts.failedProjectCount)}; transfers: received ${count(counts.receivedArtifactCount)}, reused/already staged ${count(counts.reusedArtifactCount)}, failed ${count(counts.failedTransferCount)}; manifest export errors (separate from final project outcomes): ${count(counts.manifestExportErrorCount)}.`;
+}
+
+function syncTransferCountValue(transferCounts: Record<string, number> | null | undefined, key: string) {
+  const value = transferCounts?.[key];
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function syncTransferCount(
+  receivedArtifacts: SyncTransportTransferResult[],
+  receivedArtifactsComplete: boolean,
+  transferCounts: Record<string, number> | null | undefined,
+  keys: string[],
+  statuses: string[],
+) {
+  for (const key of keys) {
+    const count = syncTransferCountValue(transferCounts, key);
+    if (count !== null) {
+      return count;
+    }
+  }
+  return receivedArtifactsComplete
+    ? receivedArtifacts.filter((artifact) => statuses.includes(artifact.status)).length
+    : null;
+}
+
+function hasSyncTransferCount(
+  transferCounts: Record<string, number> | null | undefined,
+  keys: string[],
+) {
+  return keys.some((key) => syncTransferCountValue(transferCounts, key) !== null);
+}
+
+function syncRunCanonicalCountsFromParts(parts: SyncRunCanonicalCountParts): SyncRunCanonicalCounts | null {
+  const finalProjectResults = mergeSyncProjectResults(parts.projectResults).filter(
+    (result) =>
+      result.status !== SYNC_MANIFEST_EXPORT_ERROR_STATUS && isFinalSyncProjectResult(result),
+  );
+  const rowProjectResultsByStatus = countSyncProjectResultsByStatus(finalProjectResults);
+  const hasProjectResults = finalProjectResults.length > 0;
+  const projectStatusCount = (statusKey: string, fallback: number | null) =>
+    hasProjectResults
+      ? rowProjectResultsByStatus[statusKey] ?? 0
+      : fallback ?? (parts.projectResultsComplete ? 0 : null);
+  const rawProjectCounts = [
+    projectStatusCount("imported", parts.importedProjectCount),
+    projectStatusCount("applied", parts.appliedProjectCount),
+    projectStatusCount("deleted", parts.deletedProjectCount),
+    projectStatusCount("skipped", parts.skippedProjectCount),
+    projectStatusCount("conflicted", parts.conflictedProjectCount),
+    projectStatusCount("failed", parts.failedProjectCount),
+  ];
+  const knownProjectCountTotal = rawProjectCounts.reduce<number>(
+    (total, count) => total + (count ?? 0),
+    0,
+  );
+  const suppliedTotalProjectCount = hasProjectResults ? finalProjectResults.length : parts.totalProjectCount;
+  const omittedProjectCountsAreZero = !hasProjectResults && suppliedTotalProjectCount !== null &&
+    knownProjectCountTotal === suppliedTotalProjectCount;
+  const finalProjectCounts = rawProjectCounts.map((count) =>
+    count ?? (omittedProjectCountsAreZero ? 0 : null)
+  );
+  const [
+    importedProjectCount,
+    appliedProjectCount,
+    deletedProjectCount,
+    skippedProjectCount,
+    conflictedProjectCount,
+    failedProjectCount,
+  ] = finalProjectCounts;
+  const totalProjectCount = suppliedTotalProjectCount ?? (
+    finalProjectCounts.every((count): count is number => count !== null)
+      ? finalProjectCounts.reduce((total, count) => total + count, 0)
+      : null
+  );
+  const aggregateProjectResultsByStatus = [
+    ["imported", importedProjectCount],
+    ["applied", appliedProjectCount],
+    ["deleted", deletedProjectCount],
+    ["skipped", skippedProjectCount],
+    ["conflicted", conflictedProjectCount],
+    ["failed", failedProjectCount],
+  ] as const;
+  const projectResultsByStatus = hasProjectResults
+    ? rowProjectResultsByStatus
+    : finalProjectCounts.every((count) => count !== null)
+      ? Object.fromEntries(
+        aggregateProjectResultsByStatus.filter(([, count]) => typeof count === "number" && count > 0),
+      ) as Record<string, number>
+      : null;
+  const concreteManifestExportErrorCount = Math.max(
+    parts.manifestErrors.length,
+    parts.projectResults.filter((result) => result.status === SYNC_MANIFEST_EXPORT_ERROR_STATUS).length,
+  );
+  const manifestExportErrorCount =
+    concreteManifestExportErrorCount > 0
+      ? concreteManifestExportErrorCount
+      : parts.manifestExportErrorCount ?? (parts.manifestErrorsComplete ? 0 : null);
+  const hasSummaryContext = [
+    parts.localManifestCount,
+    parts.remoteManifestCount,
+    importedProjectCount,
+    appliedProjectCount,
+    deletedProjectCount,
+    skippedProjectCount,
+    conflictedProjectCount,
+    failedProjectCount,
+    manifestExportErrorCount,
+  ].some((value) => value !== null && value !== undefined) ||
+    parts.receivedArtifacts.length > 0 ||
+    Object.keys(parts.transferCounts ?? {}).length > 0;
+  if (!hasSummaryContext) {
+    return null;
+  }
+  return {
+    localManifestCount: parts.localManifestCount,
+    remoteManifestCount: parts.remoteManifestCount,
+    importedProjectCount,
+    appliedProjectCount,
+    deletedProjectCount,
+    skippedProjectCount,
+    conflictedProjectCount,
+    failedProjectCount,
+    receivedArtifactCount: syncTransferCount(
+      parts.receivedArtifacts,
+      parts.receivedArtifactsComplete,
+      parts.transferCounts,
+      ["received", "received_count", "received_artifact_count"],
+      ["received"],
+    ),
+    reusedArtifactCount: syncTransferCount(
+      parts.receivedArtifacts,
+      parts.receivedArtifactsComplete,
+      parts.transferCounts,
+      ["already_staged", "reused", "reused_artifact_count"],
+      ["already_staged", "reused"],
+    ),
+    failedTransferCount: syncTransferCount(
+      parts.receivedArtifacts,
+      parts.receivedArtifactsComplete,
+      parts.transferCounts,
+      ["failed", "failed_transfer_count"],
+      ["failed"],
+    ),
+    hasCompleteTransferEvidence: parts.receivedArtifactsComplete || [
+      ["received", "received_count", "received_artifact_count"],
+      ["already_staged", "reused", "reused_artifact_count"],
+      ["failed", "failed_transfer_count"],
+    ].every((keys) => hasSyncTransferCount(parts.transferCounts, keys)),
+    manifestExportErrorCount,
+    projectResultsByStatus,
+    totalProjectCount,
+  };
+}
+
+export function syncRunCanonicalCounts(status: SyncTransportRunStatus) {
+  return syncRunCanonicalCountsFromParts({
+    localManifestCount: status.local_manifest_count ?? null,
+    remoteManifestCount: status.remote_manifest_count ?? null,
+    importedProjectCount: status.imported_project_count ?? null,
+    appliedProjectCount: status.applied_project_count ?? null,
+    deletedProjectCount: status.deleted_project_count ?? null,
+    skippedProjectCount: status.skipped_project_count ?? null,
+    conflictedProjectCount: status.conflicted_project_count ?? null,
+    failedProjectCount: status.failed_project_count ?? null,
+    totalProjectCount: status.total_project_count ?? null,
+    manifestExportErrorCount: status.manifest_export_error_count ?? null,
+    projectResults: status.project_results,
+    projectResultsComplete: status.project_results_complete ?? status.project_results.length > 0,
+    manifestErrors: status.manifest_errors,
+    manifestErrorsComplete: status.manifest_errors_complete ?? status.manifest_errors.length > 0,
+    receivedArtifacts: status.received_artifacts,
+    receivedArtifactsComplete: status.received_artifacts_complete ?? status.received_artifacts.length > 0,
+    transferCounts: status.transfer_counts,
+  });
+}
+
+export function syncRunCanonicalSummaryMessage(status: SyncTransportRunStatus) {
+  const counts = syncRunCanonicalCounts(status);
+  return counts?.hasCompleteTransferEvidence ? syncCanonicalSummaryMessage(counts) : null;
 }
 
 function normalizeSyncProjectResult(
@@ -1455,56 +1707,103 @@ export function normalizeSyncRunStatus(value: unknown): SyncTransportRunStatus |
   const runStartedAt = dateTimeField(record, ["started_at", "startedAt"]);
   const runCompletedAt = dateTimeField(record, ["completed_at", "completedAt", "finished_at", "finishedAt"]);
   const phaseTimings = phaseTimingField(record);
-  const manifestErrors = recordArrayField(record, ["manifest_errors", "manifestErrors"])
-    .map((item) => normalizeSyncManifestError(item))
-    .filter((item): item is SyncTransportManifestError => item !== null);
-  const importedProjectResults = recordArrayField(record, [
+  const projectResultKeys = [
     "project_results",
     "projectResults",
     "imported_projects",
     "importedProjects",
     "projects",
     "results",
-  ])
+  ];
+  const projectResultsComplete = projectResultKeys.some((key) => Array.isArray(record[key]));
+  const manifestErrorKeys = ["manifest_errors", "manifestErrors"];
+  const manifestErrorsComplete = manifestErrorKeys.some((key) => Array.isArray(record[key]));
+  const explicitManifestErrors = recordArrayField(record, manifestErrorKeys)
+    .map((item) => normalizeSyncManifestError(item))
+    .filter((item): item is SyncTransportManifestError => item !== null);
+  const importedProjectResults = recordArrayField(record, projectResultKeys)
     .map((item) => normalizeSyncProjectResult(item))
     .filter((item): item is SyncTransportProjectResult => item !== null)
     .map((result) => ({
       ...result,
       run_id: result.run_id ?? runId,
       session_id: result.session_id ?? sessionId,
-      started_at: result.started_at ?? runStartedAt,
-      completed_at: result.completed_at ?? runCompletedAt,
     }));
-  const finalProjectResultKeys = new Set(
-    importedProjectResults
-      .filter((result) => isFinalSyncProjectResult(result))
-      .map((result) => projectResultKey(result)),
+  const legacyManifestErrors = importedProjectResults.flatMap((result) =>
+    result.status === SYNC_MANIFEST_EXPORT_ERROR_STATUS && result.message
+      ? [{ project_id: result.project_id, message: result.message }]
+      : [],
   );
-  const uncoveredManifestErrorCount = manifestErrors.filter(
-    (error) => !finalProjectResultKeys.has(error.project_id.trim() || "unknown"),
-  ).length;
-  const projectResults = mergeSyncProjectResults(importedProjectResults, manifestErrors);
-  const receivedArtifacts = recordArrayField(record, ["received_artifacts", "receivedArtifacts", "artifacts"])
+  const manifestErrors = Array.from(
+    new Map(
+      [...explicitManifestErrors, ...legacyManifestErrors].map((error) => [
+        `${error.project_id}\0${error.message}`,
+        error,
+      ]),
+    ).values(),
+  );
+  const projectResults = mergeSyncProjectResults(
+    importedProjectResults.filter((result) => result.status !== SYNC_MANIFEST_EXPORT_ERROR_STATUS),
+  );
+  const receivedArtifactKeys = ["received_artifacts", "receivedArtifacts", "artifacts"];
+  const receivedArtifactsComplete = receivedArtifactKeys.some((key) => Array.isArray(record[key]));
+  const receivedArtifacts = recordArrayField(record, receivedArtifactKeys)
     .map((item) => normalizeSyncTransferResult(item))
     .filter((item): item is SyncTransportTransferResult => item !== null)
     .map((item) => enrichSyncTransferResult(item, phaseTimings));
   const localManifestCount = numberField(record, ["local_manifest_count", "localManifestCount"]);
   const remoteManifestCount = numberField(record, ["remote_manifest_count", "remoteManifestCount"]);
-  const importedProjectCount = numberField(record, ["imported_project_count", "importedProjectCount"]);
-  const appliedProjectCount = numberField(record, ["applied_project_count", "appliedProjectCount"]);
-  const deletedProjectCount = numberField(record, ["deleted_project_count", "deletedProjectCount"]);
-  const skippedProjectCount = numberField(record, ["skipped_project_count", "skippedProjectCount"]);
-  const failedProjectCount = numberField(record, ["failed_project_count", "failedProjectCount"]);
-  const totalProjectCount = numberField(record, ["total_project_count", "totalProjectCount", "project_count", "projectCount"]);
+  const explicitImportedProjectCount = numberField(record, ["imported_project_count", "importedProjectCount"]);
+  const explicitAppliedProjectCount = numberField(record, ["applied_project_count", "appliedProjectCount"]);
+  const explicitDeletedProjectCount = numberField(record, ["deleted_project_count", "deletedProjectCount"]);
+  const explicitSkippedProjectCount = numberField(record, ["skipped_project_count", "skippedProjectCount"]);
+  const explicitConflictedProjectCount = numberField(record, [
+    "conflicted_project_count",
+    "conflictedProjectCount",
+  ]);
+  const explicitFailedProjectCount = numberField(record, ["failed_project_count", "failedProjectCount"]);
+  const explicitManifestExportErrorCount = numberField(record, [
+    "manifest_export_error_count",
+    "manifestExportErrorCount",
+    "manifest_error_count",
+    "manifestErrorCount",
+  ]);
   const transferCountRecord = recordField(record, ["transfer_counts", "transferCounts"]);
   const explicitRunMetricRecord = recordField(record, ["counters", "counts", "metrics"]);
   const runMetricRecords = [record, transferCountRecord, explicitRunMetricRecord];
-  const diagnosticValues = syncTransportDiagnosticValues(runMetricRecords);
   const transferCounts = {
     ...numericMetricsFromRecord(record),
     ...numericMetricsFromRecord(explicitRunMetricRecord),
     ...numericMetricsFromRecord(transferCountRecord),
   };
+  const canonicalCounts = syncRunCanonicalCountsFromParts({
+    localManifestCount,
+    remoteManifestCount,
+    importedProjectCount: explicitImportedProjectCount,
+    appliedProjectCount: explicitAppliedProjectCount,
+    deletedProjectCount: explicitDeletedProjectCount,
+    skippedProjectCount: explicitSkippedProjectCount,
+    conflictedProjectCount: explicitConflictedProjectCount,
+    failedProjectCount: explicitFailedProjectCount,
+    totalProjectCount: numberField(record, ["total_project_count", "totalProjectCount", "project_count", "projectCount"]),
+    manifestExportErrorCount: explicitManifestExportErrorCount,
+    projectResults,
+    projectResultsComplete,
+    manifestErrors,
+    manifestErrorsComplete,
+    receivedArtifacts,
+    receivedArtifactsComplete,
+    transferCounts,
+  });
+  const importedProjectCount = canonicalCounts?.importedProjectCount ?? null;
+  const appliedProjectCount = canonicalCounts?.appliedProjectCount ?? null;
+  const deletedProjectCount = canonicalCounts?.deletedProjectCount ?? null;
+  const skippedProjectCount = canonicalCounts?.skippedProjectCount ?? null;
+  const conflictedProjectCount = canonicalCounts?.conflictedProjectCount ?? null;
+  const failedProjectCount = canonicalCounts?.failedProjectCount ?? null;
+  const manifestExportErrorCount = canonicalCounts?.manifestExportErrorCount ?? null;
+  const totalProjectCount = canonicalCounts?.totalProjectCount ?? null;
+  const diagnosticValues = syncTransportDiagnosticValues(runMetricRecords);
   const lifecycleEvents = lifecycleEventsField(record);
   const lastLifecycleEvent = lastLifecycleEventField(record, lifecycleEvents);
   const lifecycleInterruptionFields = syncLifecycleInterruptionFields(
@@ -1609,31 +1908,35 @@ export function normalizeSyncRunStatus(value: unknown): SyncTransportRunStatus |
     "credits_revoked",
     "creditsRevoked",
   ]);
-  const hasProjectProblems = projectResults.some((result) =>
-    SYNC_PROJECT_RESULT_PROBLEM_STATES.has(result.status),
-  );
+  const hasProjectProblems = (canonicalCounts?.failedProjectCount ?? 0) > 0 ||
+    (canonicalCounts?.conflictedProjectCount ?? 0) > 0 ||
+    Object.entries(canonicalCounts?.projectResultsByStatus ?? {}).some(
+      ([projectStatus, count]) => count > 0 && SYNC_PROJECT_RESULT_PROBLEM_STATES.has(projectStatus),
+    );
   const explicitError = firstStringField([record], ["error", "last_error", "lastError"]);
   const explicitStatus = firstStringField([record], ["status", "state"]);
+  const hasManifestErrors = (manifestExportErrorCount ?? 0) > 0;
   let status = normalizeTransportStatusToken(
-    explicitStatus ??
-      (uncoveredManifestErrorCount > 0 || hasProjectProblems ? "completed_with_errors" : "completed"),
+    explicitStatus ?? (hasManifestErrors || hasProjectProblems ? "completed_with_errors" : "completed"),
   );
+  if (status === "completed" && (hasManifestErrors || hasProjectProblems)) {
+    status = "completed_with_errors";
+  }
   if (
     status === "completed_with_errors" &&
     !explicitError &&
     !hasProjectProblems &&
-    uncoveredManifestErrorCount === 0
+    !hasManifestErrors
   ) {
     status = "completed";
   }
-  const summary =
-    localManifestCount !== null ||
-    remoteManifestCount !== null ||
-    importedProjectCount !== null ||
-    skippedProjectCount !== null ||
-    failedProjectCount !== null
-      ? `Exchanged ${localManifestCount ?? 0} local and ${remoteManifestCount ?? 0} remote manifest(s); imported ${importedProjectCount ?? 0} project(s), skipped ${skippedProjectCount ?? 0} project(s), failed ${failedProjectCount ?? 0} project(s), received ${receivedArtifacts.length} artifact(s).`
-      : null;
+  const summary = canonicalCounts?.hasCompleteTransferEvidence
+    ? syncCanonicalSummaryMessage(canonicalCounts)
+    : null;
+  const explicitMessage = firstStringField([record], ["message", "status_message", "statusMessage"]);
+  const message = explicitMessage && !(summary && syncMessageShouldYieldToCanonicalSummary(explicitMessage))
+    ? explicitMessage
+    : summary ?? explicitMessage;
   return {
     run_id: runId,
     session_id: sessionId,
@@ -1650,7 +1953,7 @@ export function normalizeSyncRunStatus(value: unknown): SyncTransportRunStatus |
       .filter((transport): transport is string => transport !== null),
     nearby_peers: nearbyPeersField(record),
     status,
-    message: firstStringField([record], ["message", "status_message", "statusMessage"]) ?? summary,
+    message,
     started_at: runStartedAt,
     completed_at: runCompletedAt,
     duration_seconds: durationSeconds,
@@ -1672,8 +1975,11 @@ export function normalizeSyncRunStatus(value: unknown): SyncTransportRunStatus |
     ...lifecycleInterruptionFields,
     error: explicitError,
     project_results: projectResults,
+    project_results_complete: projectResultsComplete,
     manifest_errors: manifestErrors,
+    manifest_errors_complete: manifestErrorsComplete,
     received_artifacts: receivedArtifacts,
+    received_artifacts_complete: receivedArtifactsComplete,
     served_artifact_requests: numberField(record, ["served_artifact_requests", "servedArtifactRequests"]),
     local_manifest_count: localManifestCount,
     remote_manifest_count: remoteManifestCount,
@@ -1681,7 +1987,9 @@ export function normalizeSyncRunStatus(value: unknown): SyncTransportRunStatus |
     applied_project_count: appliedProjectCount,
     deleted_project_count: deletedProjectCount,
     skipped_project_count: skippedProjectCount,
+    conflicted_project_count: conflictedProjectCount,
     failed_project_count: failedProjectCount,
+    manifest_export_error_count: manifestExportErrorCount,
     total_project_count: totalProjectCount,
     ...diagnosticValues,
   };

--- a/scripts/sync-privacy-token-cases.mjs
+++ b/scripts/sync-privacy-token-cases.mjs
@@ -1,0 +1,44 @@
+export const SYNC_PRIVACY_SAFE_PHASES = [
+  "artifact_cleanup", "artifact_staging", "artifact_staging_check", "artifact_transfer", "initiator_import",
+  "local_manifest_export", "manifest_exchange", "peer_authentication", "peer_connect", "planning",
+  "reconciliation_apply", "reconciliation_apply_project", "reconciliation_plan", "reconciliation_staging",
+  "responder_import", "serve_artifact_requests",
+];
+
+const PROBLEM_STATUSES = ["failed", "completed_with_errors", "conflicted", "error", "errored"];
+
+export const SYNC_PRIVACY_SAFE_OPERATIONAL_TOKENS = [
+  ...SYNC_PRIVACY_SAFE_PHASES,
+  ...PROBLEM_STATUSES.flatMap((status) =>
+    [`run_status_${status}`, `project_status_${status}`, `artifact_status_${status}`]),
+  "failed_project_count", "conflicted_project_count", "manifest_export_error_count",
+  "project_failed_count", "project_counter_failed_count", "run_outcome",
+  "checksum_mismatch",
+  "hash_retry_pending",
+  "sha256_mismatch",
+];
+
+export const SYNC_PRIVACY_RAW_ID_TOKENS = [
+  "device_shadow",
+  "proj_shadow",
+  "art_shadow",
+  "run_shadow",
+  "session_shadow",
+  "project_shadow",
+  "artifact_shadow",
+  "sync_shadow",
+];
+
+export const SYNC_PRIVACY_HASH_TOKENS = [
+  "checksum_mismatch_shadow",
+  "hash_retry_pending_shadow",
+  "sha256_mismatch_shadow",
+  "content_sha256_deadbeefcafebabefeedface01234567",
+  "content.hash_deadbeefcafebabefeedface01234567",
+  "content-hash_deadbeefcafebabefeedface01234567",
+  "abcdefabcdefabcdefabcdefabcdefab_checksum_mismatch",
+  "sha256-deadbeef",
+  "abcdefabcdefabcdefabcdefabcdefab",
+  "hash_deadbeefcafebabefeedface01234567",
+  "checksum_deadbeefcafebabe",
+];

--- a/scripts/sync-validation.mjs
+++ b/scripts/sync-validation.mjs
@@ -1,6 +1,7 @@
 import { lstatSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { SYNC_PRIVACY_SAFE_OPERATIONAL_TOKENS, SYNC_PRIVACY_SAFE_PHASES } from "./sync-privacy-token-cases.mjs";
 
 const SCHEMA_VERSION = "v1";
 const TOP_LEVEL_KEYS = [
@@ -29,6 +30,23 @@ const ENDPOINT_VALUE_PATTERN = /\b(localhost|(?:\d{1,3}\.){3}\d{1,3}|[a-f0-9:]{2
 const FILE_NAME_PATTERN = /\b[^/\s]+\.(?:wav|mp3|m4a|flac|aac|ogg|opus|json|sqlite|db|log|txt|csv|zip|png|jpe?g)\b/i;
 const PAIRING_KEY_PATTERN = /(pair(ing)?|qr|invite|secret|token|public_?key|private_?key|payload)/i;
 const RAW_ID_KEY_PATTERN = /(?:^|[_-])(id|ids|device_id|peer_id|project_id|artifact_id|run_id|session_id|listener_id)$/i;
+const RAW_ID_TOKEN_PATTERN =
+  /\b(?:device|proj|art|session|run|project|artifact|sync)_[A-Za-z0-9][A-Za-z0-9._:-]*\b/i;
+const SAFE_OPERATIONAL_TOKEN_SET = new Set(SYNC_PRIVACY_SAFE_OPERATIONAL_TOKENS.map((token) => token.toLowerCase()));
+const SAFE_PHASE_SET = new Set(SYNC_PRIVACY_SAFE_PHASES);
+const LEGACY_PHASE_ALIASES = new Map([["network_receive", "artifact_transfer"],
+  ["staging_post", "artifact_staging"], ["staging_apply_plan", "reconciliation_staging"],
+  ["backend_staging", "artifact_staging"]]);
+const ROLE_NETWORK_REQUIREMENTS = {
+  receiver_or_import: [["networkReceiveThroughputBytesPerSecond", "totalReceivedBytes", "receive"]],
+  sender_only: [["networkSendThroughputBytesPerSecond", "totalServedBytes", "send"]],
+  bidirectional: [["networkReceiveThroughputBytesPerSecond", "totalReceivedBytes", "receive"],
+    ["networkSendThroughputBytesPerSecond", "totalServedBytes", "send"]],
+  no_op: [],
+  unknown: [],
+};
+const HASH_TOKEN_PATTERN =
+  /(?<![A-Za-z0-9])(?:sha(?:-?256)?|hash|checksum)[_:.-][A-Za-z0-9][A-Za-z0-9._:-]*\b|(?<![A-Za-z0-9])[a-f0-9]{32,}(?![A-Za-z0-9])/i;
 const SUSPICIOUS_CONTENT_KEY_PATTERN = /(audio|file|bytes|blob|content|payload|waveform|sample)/i;
 const PATH_FILE_EXTENSION_PATTERN = "wav|mp3|m4a|flac|aac|ogg|opus|json|sqlite|db|log|txt|csv|zip|png|jpe?g";
 const ABSOLUTE_PATH_VALUE_PATTERN = new RegExp(
@@ -36,12 +54,12 @@ const ABSOLUTE_PATH_VALUE_PATTERN = new RegExp(
   "i",
 );
 const PHASE_CATEGORY_PATTERNS = [
-  { category: "reconciliation_apply", pattern: /(reconciliation|apply)/i },
   { category: "staging", pattern: /(staging|stage|temp|hash|write)/i },
   { category: "lifecycle", pattern: /(pause|resume|restart|listener|lifecycle|start|stop)/i },
   { category: "ui_visibility", pattern: /(visible|visibility|ui|hydrate|render)/i },
-  { category: "network", pattern: /(network|transport|receive|recv|send|serve|read|download|upload)/i },
+  { category: "network", pattern: /(network|transport|transfer|receive|recv|send|serve|read|download|upload)/i },
 ];
+const MANIFEST_EXPORT_ERROR_STATUS = "manifest_export_error";
 const TRANSFER_COUNT_KEYS = new Set([
   "requested",
   "requested_artifacts",
@@ -61,6 +79,16 @@ const PROJECT_MUTATION_COUNT_ALIASES = {
   imported: [["imported"], ["importedProjectCount"], ["imported_project_count"]],
   applied: [["applied"], ["appliedProjectCount"], ["applied_project_count"]],
   deleted: [["deleted"], ["deletedProjectCount"], ["deleted_project_count"]],
+};
+const PROJECT_COUNT_ALIASES = {
+  imported: [["importedProjectCount"], ["imported_project_count"]],
+  applied: [["appliedProjectCount"], ["applied_project_count"]],
+  deleted: [["deletedProjectCount"], ["deleted_project_count"]],
+  skipped: [["skippedProjectCount"], ["skipped_project_count"]],
+  conflicted: [["conflictedProjectCount"], ["conflicted_project_count"]],
+  failed: [["failedProjectCount"], ["failed_project_count"]],
+  total: [["totalProjectCount"], ["total_project_count"]],
+  manifestExportErrors: [["manifestErrorCount"], ["manifest_error_count"], ["manifestExportErrorCount"], ["manifest_export_error_count"]],
 };
 
 function usage() {
@@ -175,7 +203,8 @@ function readAggregateProjectMutationCount(scope) {
 function inferLocalProjectMutationCount(projects) {
   if (Array.isArray(projects)) {
     return projects.filter(
-      (entry) => isPlainObject(entry) && LOCAL_PROJECT_MUTATION_STATUSES.has(entry.status),
+      (entry) => isPlainObject(entry) && entry.isFinal !== false && entry.is_final !== false &&
+        LOCAL_PROJECT_MUTATION_STATUSES.has(entry.status),
     ).length;
   }
   if (isPlainObject(projects)) {
@@ -236,6 +265,123 @@ function isIsoTimestamp(value) {
   return /^\d{4}-\d{2}-\d{2}T/.test(value) && !Number.isNaN(Date.parse(value));
 }
 
+function timestampMs(value) {
+  return typeof value === "string" && !Number.isNaN(Date.parse(value)) ? Date.parse(value) : null;
+}
+
+function durationMsFromEvidenceRun(run) {
+  if (!isPlainObject(run)) {
+    return null;
+  }
+  const durationMs = asFiniteNumber(findAliasValue(run, [
+    ["durationMs"],
+    ["duration_ms"],
+    ["elapsedMs"],
+    ["elapsed_ms"],
+  ]));
+  if (durationMs !== null) {
+    return durationMs;
+  }
+  const durationSeconds = asFiniteNumber(findAliasValue(run, [
+    ["durationSeconds"],
+    ["duration_seconds"],
+    ["elapsedSeconds"],
+    ["elapsed_seconds"],
+  ]));
+  if (durationSeconds !== null) {
+    return durationSeconds * 1000;
+  }
+  const startedAt = timestampMs(run.startedAt ?? run.started_at);
+  const completedAt = timestampMs(run.completedAt ?? run.completed_at ?? run.finishedAt ?? run.finished_at);
+  return startedAt !== null && completedAt !== null && completedAt >= startedAt
+    ? completedAt - startedAt
+    : null;
+}
+
+function countFinalProjectsByStatus(projects) {
+  if (!Array.isArray(projects)) {
+    return {};
+  }
+  return projects.reduce((counts, project) => {
+    if (
+      isPlainObject(project) &&
+      typeof project.status === "string" &&
+      project.status &&
+      project.isFinal !== false &&
+      project.is_final !== false &&
+      project.status !== MANIFEST_EXPORT_ERROR_STATUS
+    ) {
+      counts[project.status] = (counts[project.status] ?? 0) + 1;
+    }
+    return counts;
+  }, {});
+}
+
+function hasProjectResultsByStatusMetrics(metrics) {
+  return isPlainObject(metrics.projectResultsByStatus) || isPlainObject(metrics.project_results_by_status);
+}
+
+function projectResultsByStatusFromMetrics(metrics) {
+  const counts = {};
+  for (const scope of [metrics.projectResultsByStatus, metrics.project_results_by_status]) {
+    if (!isPlainObject(scope)) {
+      continue;
+    }
+    for (const [status, count] of Object.entries(scope)) {
+      const normalizedCount = asNonNegativeInteger(count);
+      if (normalizedCount !== null) {
+        counts[status] = normalizedCount;
+      }
+    }
+  }
+  return counts;
+}
+
+function authoritativeProjectResultsByStatus(evidence) {
+  const metrics = isPlainObject(evidence.metrics) ? evidence.metrics : {};
+  const projectResultsByStatus = countFinalProjectsByStatus(evidence.projects);
+  if (Object.keys(projectResultsByStatus).length > 0) {
+    return {
+      projectResultsByStatus,
+      hasAuthoritativeProjectStatusMap: true,
+    };
+  }
+  const metricProjectResultsByStatus = projectResultsByStatusFromMetrics(metrics);
+  if (hasProjectResultsByStatusMetrics(metrics)) {
+    return {
+      projectResultsByStatus: metricProjectResultsByStatus,
+      hasAuthoritativeProjectStatusMap: true,
+    };
+  }
+  return {
+    projectResultsByStatus,
+    hasAuthoritativeProjectStatusMap: false,
+  };
+}
+
+function sumTrueProjectResultCounts(projectResultsByStatus) {
+  return Object.entries(projectResultsByStatus).reduce((total, [status, count]) => (
+    status === MANIFEST_EXPORT_ERROR_STATUS ? total : total + count
+  ), 0);
+}
+
+function projectCountFieldValue(metrics, status) {
+  return maxNonNull(projectCountCandidateValues(metrics, status).map(({ value }) => value));
+}
+
+function readProjectCountFromMetrics(metrics, status, projectResultsByStatus, hasAuthoritativeStatusMap) {
+  if (status === "manifestExportErrors") {
+    return projectCountFieldValue(metrics, status);
+  }
+  if (hasAuthoritativeStatusMap) {
+    if (status === "total") {
+      return sumTrueProjectResultCounts(projectResultsByStatus);
+    }
+    return projectResultsByStatus[status] ?? 0;
+  }
+  return projectCountFieldValue(metrics, status);
+}
+
 function collectPhaseTimings(evidence) {
   const phaseSets = [
     evidence?.run?.phaseTimings,
@@ -257,7 +403,7 @@ function collectPhaseTimings(evidence) {
       const phase = asString(entry.phase ?? entry.name ?? entry.label);
       const durationMs = asFiniteNumber(entry.durationMs ?? entry.duration_ms ?? entry.totalMs ?? entry.total_ms);
       if (phase && durationMs !== null) {
-        collected.push({ phase, durationMs });
+        collected.push({ phase: LEGACY_PHASE_ALIASES.get(phase) ?? phase, durationMs });
       }
     }
   }
@@ -265,11 +411,14 @@ function collectPhaseTimings(evidence) {
 }
 
 function canonicalizeEvidence(evidence) {
+  const run = isPlainObject(evidence.run) ? evidence.run : {};
   const metrics = isPlainObject(evidence.metrics) ? evidence.metrics : {};
   const transport = isPlainObject(evidence.transport) ? evidence.transport : {};
   const lifecycle = isPlainObject(evidence.lifecycle) ? evidence.lifecycle : {};
   const storage = isPlainObject(evidence.storage) ? evidence.storage : {};
   const validation = isPlainObject(evidence.validation) ? evidence.validation : {};
+  const { projectResultsByStatus, hasAuthoritativeProjectStatusMap } =
+    authoritativeProjectResultsByStatus(evidence);
 
   const transferCountCandidates = collectTransferCountCandidates(
     metrics.transfer_counts,
@@ -316,13 +465,13 @@ function canonicalizeEvidence(evidence) {
     ["servedArtifactRequests"],
     ["served_artifact_requests"],
   ]));
-  const totalServedBytes = asFiniteNumber(findAliasValue(metrics, [
-    ["diagnostics", "total_served_bytes"],
-    ["diagnostics", "totalServedBytes"],
-    ["total_served_bytes"],
-    ["totalServedBytes"],
-    ["served_bytes"],
-    ["servedBytes"],
+  const reportedServedBytes = asFiniteNumber(findAliasValue(metrics, [
+    ["diagnostics", "total_served_bytes"], ["diagnostics", "totalServedBytes"],
+    ["total_served_bytes"], ["totalServedBytes"], ["served_bytes"], ["servedBytes"],
+  ]));
+  const reportedReceivedBytes = asFiniteNumber(findAliasValue(metrics, [
+    ["diagnostics", "total_received_bytes"], ["diagnostics", "totalReceivedBytes"],
+    ["total_received_bytes"], ["totalReceivedBytes"], ["received_bytes"], ["receivedBytes"],
   ]));
   const projectMutationMetricScopes = [
     metrics.transferCounts,
@@ -340,27 +489,75 @@ function canonicalizeEvidence(evidence) {
     inferLocalProjectMutationCount(evidence.projects),
     aggregateProjectMutationCount,
   ]);
-  const senderOnly = received === 0 &&
-    localProjectMutationCount === 0 &&
-    servedArtifactRequests !== null &&
-    servedArtifactRequests > 0 &&
-    totalServedBytes !== null &&
-    totalServedBytes > 0;
+  const projectCounts = {
+    imported: readProjectCountFromMetrics(metrics, "imported", projectResultsByStatus, hasAuthoritativeProjectStatusMap),
+    applied: readProjectCountFromMetrics(metrics, "applied", projectResultsByStatus, hasAuthoritativeProjectStatusMap),
+    deleted: readProjectCountFromMetrics(metrics, "deleted", projectResultsByStatus, hasAuthoritativeProjectStatusMap),
+    skipped: readProjectCountFromMetrics(metrics, "skipped", projectResultsByStatus, hasAuthoritativeProjectStatusMap),
+    conflicted: readProjectCountFromMetrics(metrics, "conflicted", projectResultsByStatus, hasAuthoritativeProjectStatusMap),
+    failed: readProjectCountFromMetrics(metrics, "failed", projectResultsByStatus, hasAuthoritativeProjectStatusMap),
+    total: readProjectCountFromMetrics(metrics, "total", projectResultsByStatus, hasAuthoritativeProjectStatusMap),
+    manifestExportErrors: readProjectCountFromMetrics(metrics, "manifestExportErrors", projectResultsByStatus, hasAuthoritativeProjectStatusMap),
+  };
+  const receivedArtifactRows = Array.isArray(evidence.artifacts) ? evidence.artifacts
+    .filter((artifact) => isPlainObject(artifact) && artifact.status === "received") : [];
+  const receivedArtifactSizes = receivedArtifactRows
+    .map((artifact) => asFiniteNumber(artifact.sizeBytes ?? artifact.size_bytes));
+  const receivedArtifactsComplete = run.received_artifacts_complete === true ||
+    metrics.received_artifacts_complete === true;
+  const receivedArtifactCountMismatch = receivedArtifactsComplete && received !== null &&
+    receivedArtifactRows.length !== received;
+  const artifactRowsComplete = received !== null ? receivedArtifactRows.length === received
+    : receivedArtifactsComplete;
+  const artifactReceivedBytes = artifactRowsComplete && receivedArtifactSizes.every((size) => size !== null)
+    ? receivedArtifactSizes.reduce((total, size) => total + size, 0) : null;
+  const totalReceivedBytes = reportedReceivedBytes ?? artifactReceivedBytes ?? (received === 0 ? 0 : null);
+  const totalServedBytes = reportedServedBytes ?? (servedArtifactRequests === 0 ? 0 : null);
+  const receiverCounts = [requested, received, skipped, alreadyStaged, failed, retried];
+  const receiverActive = receiverCounts.some((count) => (count ?? 0) > 0) ||
+    (localProjectMutationCount ?? 0) > 0 || (totalReceivedBytes ?? 0) > 0;
+  const senderActive = (servedArtifactRequests ?? 0) > 0 || (totalServedBytes ?? 0) > 0;
+  const noOp = receiverCounts.every((count) => count === 0) && localProjectMutationCount === 0 &&
+    servedArtifactRequests === 0 && totalReceivedBytes === 0 && totalServedBytes === 0;
+  const runRole = receiverActive && senderActive ? "bidirectional" : senderActive ? "sender_only"
+    : receiverActive ? "receiver_or_import" : noOp ? "no_op" : "unknown";
+  const aggregateNetworkThroughput = asFiniteNumber(findAliasValue(metrics,
+    [["throughput_bytes_per_second"], ["throughputBytesPerSecond"]]));
+  const reportedReceiveThroughput = asFiniteNumber(findAliasValue(metrics, [
+    ["network_receive_throughput_bytes_per_second"], ["receive_throughput_bytes_per_second"],
+    ["transport_receive_throughput_bytes_per_second"],
+  ]));
+  const reportedSendThroughput = asFiniteNumber(findAliasValue(metrics, [
+    ["network_send_throughput_bytes_per_second"], ["send_throughput_bytes_per_second"],
+    ["transport_send_throughput_bytes_per_second"],
+  ]));
+  const runDurationMs = durationMsFromEvidenceRun(run);
+  const deriveRate = (bytes) => bytes !== null && runDurationMs !== null && runDurationMs > 0
+    ? bytes / (runDurationMs / 1000) : null;
+  const legacyBidirectionalAggregate = runRole === "bidirectional" && reportedSendThroughput === null &&
+    reportedReceiveThroughput === aggregateNetworkThroughput;
+  const oneWayAggregate = (runRole === "receiver_or_import" && totalServedBytes === 0) ||
+    (runRole === "sender_only" && totalReceivedBytes === 0)
+    ? aggregateNetworkThroughput : null;
+  const networkReceiveThroughput = receiverActive ? legacyBidirectionalAggregate
+    ? deriveRate(totalReceivedBytes)
+    : reportedReceiveThroughput ?? oneWayAggregate ?? deriveRate(totalReceivedBytes) : null;
+  const networkSendThroughput = senderActive
+    ? reportedSendThroughput ?? (runRole === "sender_only" ? reportedReceiveThroughput : null) ??
+      oneWayAggregate ?? deriveRate(totalServedBytes)
+    : null;
+  const combinedNetworkBytes = totalReceivedBytes !== null && totalServedBytes !== null
+    ? totalReceivedBytes + totalServedBytes : null;
 
   return {
-    runRole: senderOnly
-      ? "sender_only"
-      : received > 0 || localProjectMutationCount > 0
-        ? "receiver_or_import"
-        : "unknown",
+    runRole,
+    runDurationMs,
     selectedTransport,
     candidateTransports,
-    networkReceiveThroughputBytesPerSecond: asFiniteNumber(findAliasValue(metrics, [
-      ["network_receive_throughput_bytes_per_second"],
-      ["receive_throughput_bytes_per_second"],
-      ["transport_receive_throughput_bytes_per_second"],
-      ["throughput_bytes_per_second"],
-    ])),
+    networkReceiveThroughputBytesPerSecond: networkReceiveThroughput,
+    networkSendThroughputBytesPerSecond: networkSendThroughput,
+    aggregateNetworkThroughputBytesPerSecond: aggregateNetworkThroughput,
+    combinedNetworkBytes,
     backendStagingThroughputBytesPerSecond: asFiniteNumber(findAliasValue(metrics, [
       ["backend_staging_throughput_bytes_per_second"],
       ["staging_throughput_bytes_per_second"],
@@ -370,9 +567,22 @@ function canonicalizeEvidence(evidence) {
       ["apply_ms"],
       ["reconciliation", "apply_ms"],
     ])),
+    reconciliationApplyAggregateMs: asFiniteNumber(findAliasValue(metrics, [
+      ["reconciliation_apply_aggregate_ms"],
+      ["apply_aggregate_ms"],
+      ["reconciliation", "apply_aggregate_ms"],
+    ])),
+    reconciliationApplyTimingSemantics: asString(findAliasValue(metrics, [
+      ["reconciliation_apply_timing", "semantics"],
+      ["reconciliationApplyTiming", "semantics"],
+    ])),
     projectImportsPerMinute: asFiniteNumber(findAliasValue(metrics, [
       ["project_imports_per_minute"],
       ["projects_per_minute"],
+    ])),
+    projectMutationsPerMinute: asFiniteNumber(findAliasValue(metrics, [
+      ["project_mutations_per_minute"],
+      ["project_mutation_cadence_per_minute"],
     ])),
     projectAvailabilityGapMs: asFiniteNumber(findAliasValue(metrics, [
       ["project_availability_gap_ms"],
@@ -391,8 +601,12 @@ function canonicalizeEvidence(evidence) {
       failed,
       retried,
     },
+    projectResultsByStatus,
+    projectCounts,
     servedArtifactRequests,
+    totalReceivedBytes,
     totalServedBytes,
+    receivedArtifactCountMismatch,
     importedProjectCount,
     localProjectMutationCount,
     fallbackReason: asString(
@@ -427,11 +641,16 @@ function canonicalizeEvidence(evidence) {
       : validation.ui_visible === true || lifecycle.ui_visible === true
         ? true
         : null,
-    validationPassed: validation.ok === false || validation.valid === false
+    validationScope: asString(validation.scope),
+    runOutcomeOk: validation.outcomeOk === false || validation.outcome_ok === false
       ? false
-      : validation.ok === true || validation.valid === true
+      : validation.outcomeOk === true || validation.outcome_ok === true
         ? true
-        : null,
+        : validation.ok === false || validation.valid === false
+          ? false
+          : validation.ok === true || validation.valid === true
+            ? true
+            : null,
     bottleneckHint,
   };
 }
@@ -454,23 +673,34 @@ function validateTopLevel(evidence, errors) {
 
 function validateRequiredMetrics(evidence, errors) {
   const normalized = canonicalizeEvidence(evidence);
-  const requiresReceiverMetrics = normalized.runRole !== "sender_only";
-  if (normalized.networkReceiveThroughputBytesPerSecond === null) {
-    errors.push("Missing required metric: network receive throughput.");
+  const hasExplicitAggregateOnlyApplyTiming =
+    normalized.reconciliationApplyMs === null &&
+    normalized.reconciliationApplyAggregateMs !== null &&
+    normalized.reconciliationApplyTimingSemantics === "aggregate_only";
+  const aggregateFallback = normalized.runRole === "bidirectional" &&
+    normalized.aggregateNetworkThroughputBytesPerSecond !== null;
+  for (const [rateField, bytesField, direction] of ROLE_NETWORK_REQUIREMENTS[normalized.runRole]) {
+    if (normalized[bytesField] !== null && normalized[rateField] === null && !aggregateFallback) {
+      errors.push(`Missing required metric: network ${direction} throughput.`);
+    }
   }
-  if (requiresReceiverMetrics && normalized.backendStagingThroughputBytesPerSecond === null) {
+  if (normalized.totalReceivedBytes > 0 && normalized.backendStagingThroughputBytesPerSecond === null) {
     errors.push("Missing required metric: backend staging throughput.");
   }
-  if (requiresReceiverMetrics && normalized.reconciliationApplyMs === null) {
+  if (
+    ["receiver_or_import", "bidirectional"].includes(normalized.runRole) &&
+    normalized.reconciliationApplyMs === null &&
+    !hasExplicitAggregateOnlyApplyTiming
+  ) {
     errors.push("Missing required metric: reconciliation apply time.");
   }
-  if (normalized.projectImportsPerMinute === null) {
+  if (normalized.importedProjectCount > 0 && normalized.projectImportsPerMinute === null) {
     errors.push("Missing required metric: project import cadence (projects per minute).");
   }
-  if (requiresReceiverMetrics && normalized.projectAvailabilityGapMs === null) {
+  if (normalized.importedProjectCount > 0 && normalized.projectAvailabilityGapMs === null) {
     errors.push("Missing required metric: project import cadence gap.");
   }
-  if (normalized.ttfaMs === null) {
+  if ((normalized.totalReceivedBytes ?? 0) + (normalized.totalServedBytes ?? 0) > 0 && normalized.ttfaMs === null) {
     errors.push("Missing required metric: TTFA.");
   }
   for (const [key, value] of Object.entries(normalized.transferCounts)) {
@@ -483,6 +713,125 @@ function validateRequiredMetrics(evidence, errors) {
   }
 }
 
+function validateTimingConsistency(evidence, errors) {
+  const normalized = canonicalizeEvidence(evidence);
+  for (const [field, value] of [
+    ["run duration", normalized.runDurationMs],
+    ["reconciliation_apply_ms", normalized.reconciliationApplyMs],
+    ["reconciliation_apply_aggregate_ms", normalized.reconciliationApplyAggregateMs],
+    ["project_availability_gap_ms", normalized.projectAvailabilityGapMs],
+    ["ttfa_ms", normalized.ttfaMs],
+    ["network receive throughput", normalized.networkReceiveThroughputBytesPerSecond],
+    ["network send throughput", normalized.networkSendThroughputBytesPerSecond],
+    ["aggregate network throughput", normalized.aggregateNetworkThroughputBytesPerSecond],
+  ]) {
+    if (value !== null && value < 0) {
+      errors.push(`${field} must be non-negative.`);
+    }
+  }
+  if (collectPhaseTimings(evidence).some(({ durationMs }) => durationMs < 0)) {
+    errors.push("Phase timing durations must be non-negative.");
+  }
+  for (const [field, value] of [["received", normalized.totalReceivedBytes],
+    ["served", normalized.totalServedBytes], ["combined", normalized.combinedNetworkBytes]]) {
+    if (value !== null && value < 0) errors.push(`${field} byte total must be non-negative.`);
+  }
+  if (normalized.receivedArtifactCountMismatch) {
+    errors.push("Complete received artifact rows disagree with authoritative received count.");
+  }
+  if (
+    normalized.reconciliationApplyTimingSemantics === "aggregate_only" &&
+    normalized.reconciliationApplyMs !== null
+  ) {
+    errors.push("aggregate_only semantics require reconciliation_apply_ms to be null.");
+  }
+  if (
+    normalized.reconciliationApplyMs !== null &&
+    normalized.reconciliationApplyAggregateMs !== null &&
+    normalized.reconciliationApplyAggregateMs < normalized.reconciliationApplyMs
+  ) {
+    errors.push("reconciliation_apply_aggregate_ms must be at least reconciliation_apply_ms.");
+  }
+  if (
+    normalized.reconciliationApplyMs !== null &&
+    normalized.runDurationMs !== null &&
+    normalized.reconciliationApplyMs > normalized.runDurationMs
+  ) {
+    errors.push("reconciliation_apply_ms exceeds run wall-clock duration.");
+  }
+  for (const [rate, bytes, direction] of [
+    [normalized.networkReceiveThroughputBytesPerSecond, normalized.totalReceivedBytes, "network receive"],
+    [normalized.networkSendThroughputBytesPerSecond, normalized.totalServedBytes, "network send"],
+    [normalized.aggregateNetworkThroughputBytesPerSecond, normalized.combinedNetworkBytes, "aggregate network"],
+  ]) {
+    if (rate > 0 && !(bytes > 0)) errors.push(`Positive ${direction} throughput requires positive ${direction === "network receive" ? "received" : direction === "network send" ? "served" : "combined"} bytes.`);
+  }
+}
+
+function projectCountCandidateValues(metrics, status) {
+  const aliases = PROJECT_COUNT_ALIASES[status];
+  if (!aliases) {
+    return [];
+  }
+  const scopes = [
+    ["transferCounts", metrics.transferCounts],
+    ["transfer_counts", metrics.transfer_counts],
+    ["metrics", metrics],
+  ];
+  return scopes.flatMap(([scopeName, scope]) => {
+    if (!isPlainObject(scope)) {
+      return [];
+    }
+    return aliases.flatMap((alias) => {
+      const value = asNonNegativeInteger(getNestedValue(scope, alias));
+      return value === null ? [] : [{ fieldName: `${scopeName}.${alias.join(".")}`, value }];
+    });
+  });
+}
+
+function validateProjectCountConsistency(evidence, errors) {
+  const metrics = isPlainObject(evidence.metrics) ? evidence.metrics : {};
+  const concreteProjectResultsByStatus = countFinalProjectsByStatus(evidence.projects);
+  const metricProjectResultsByStatus = projectResultsByStatusFromMetrics(metrics);
+  if (Object.keys(concreteProjectResultsByStatus).length > 0 && hasProjectResultsByStatusMetrics(metrics)) {
+    const statuses = new Set([
+      ...Object.keys(concreteProjectResultsByStatus),
+      ...Object.keys(metricProjectResultsByStatus),
+    ]);
+    for (const status of statuses) {
+      if ((metricProjectResultsByStatus[status] ?? 0) !== (concreteProjectResultsByStatus[status] ?? 0)) {
+        errors.push(`metrics.projectResultsByStatus.${status} disagrees with projects.${status}.`);
+      }
+    }
+  }
+  const { projectResultsByStatus, hasAuthoritativeProjectStatusMap } =
+    authoritativeProjectResultsByStatus(evidence);
+  const statuses = ["imported", "applied", "deleted", "skipped", "conflicted", "failed"];
+  for (const status of [...statuses, "total", "manifestExportErrors"]) {
+    const candidates = projectCountCandidateValues(metrics, status);
+    if (new Set(candidates.map(({ value }) => value)).size > 1) {
+      errors.push(`${status} project count fields disagree.`);
+    }
+  }
+  if (!hasAuthoritativeProjectStatusMap) {
+    return;
+  }
+  for (const status of statuses) {
+    const expected = projectResultsByStatus[status] ?? 0;
+    for (const { fieldName, value } of projectCountCandidateValues(metrics, status)) {
+      if (value !== expected) {
+        errors.push(`${fieldName} disagrees with projectResultsByStatus.${status}.`);
+      }
+    }
+  }
+  const totalExpected = sumTrueProjectResultCounts(projectResultsByStatus);
+  for (const { fieldName, value } of projectCountCandidateValues(metrics, "total")) {
+    if (value !== totalExpected) {
+      errors.push(`${fieldName} disagrees with projectResultsByStatus total.`);
+    }
+  }
+}
+
 function validateScenario(evidence, expectedScenario, errors) {
   if (!expectedScenario) {
     return;
@@ -490,6 +839,11 @@ function validateScenario(evidence, expectedScenario, errors) {
   if (evidence.scenario !== expectedScenario) {
     errors.push(`Scenario mismatch: expected ${expectedScenario}, got ${String(evidence.scenario)}`);
   }
+}
+
+function hasUnsafeOperationalToken(value, pattern) {
+  return (value.match(new RegExp(pattern.source, "gi")) ?? [])
+    .some((token) => !SAFE_OPERATIONAL_TOKEN_SET.has(token.toLowerCase()));
 }
 
 function inspectPrivacy(value, trail, errors) {
@@ -511,6 +865,10 @@ function inspectPrivacy(value, trail, errors) {
     }
   }
   if (typeof value === "string") {
+    const phase = LEGACY_PHASE_ALIASES.get(value) ?? value;
+    if (/(?:^|[_-])phase$|Phase$/.test(key) && phase !== "phase_redacted" && !SAFE_PHASE_SET.has(phase)) {
+      errors.push(`Privacy guard: unknown phase at ${trail.join(".")}`);
+    }
     if (ABSOLUTE_PATH_VALUE_PATTERN.test(value)) {
       errors.push(`Privacy guard: absolute path at ${trail.join(".")}`);
     }
@@ -519,6 +877,12 @@ function inspectPrivacy(value, trail, errors) {
     }
     if (FILE_NAME_PATTERN.test(value)) {
       errors.push(`Privacy guard: filename-like value at ${trail.join(".")}`);
+    }
+    if (hasUnsafeOperationalToken(value, RAW_ID_TOKEN_PATTERN)) {
+      errors.push(`Privacy guard: raw identifier token at ${trail.join(".")}`);
+    }
+    if (hasUnsafeOperationalToken(value, HASH_TOKEN_PATTERN)) {
+      errors.push(`Privacy guard: hash-like token at ${trail.join(".")}`);
     }
     if (
       (SUSPICIOUS_CONTENT_KEY_PATTERN.test(key) || /^data:/i.test(value)) &&
@@ -549,25 +913,51 @@ export function validateEvidence(evidence, { scenario } = {}) {
   validateTopLevel(evidence, errors);
   if (isPlainObject(evidence)) {
     validateRequiredMetrics(evidence, errors);
+    validateTimingConsistency(evidence, errors);
+    validateProjectCountConsistency(evidence, errors);
     validateScenario(evidence, scenario, errors);
     inspectPrivacy(evidence, [], errors);
   }
   return {
     ok: errors.length === 0,
+    schemaPrivacyOk: errors.length === 0,
     schemaVersion: SCHEMA_VERSION,
     errors,
     normalized: isPlainObject(evidence) ? canonicalizeEvidence(evidence) : null,
   };
 }
 
+function normalizedPhaseName(phase) {
+  return phase.trim().toLowerCase().replace(/[\s-]+/g, "_");
+}
+
+function isReconciliationApplyPhase(phase) {
+  const normalized = normalizedPhaseName(phase);
+  if (!normalized || /(^|_)(plan|planning|stage|staging)($|_)/.test(normalized)) {
+    return false;
+  }
+  return normalized === "apply" ||
+    normalized === "reconciliation_apply" ||
+    normalized.startsWith("apply_") ||
+    normalized.startsWith("reconciliation_apply_") ||
+    normalized.endsWith("_apply");
+}
+
+function phaseCategory(phase) {
+  if (isReconciliationApplyPhase(phase)) {
+    return "reconciliation_apply";
+  }
+  return PHASE_CATEGORY_PATTERNS.find((item) => item.pattern.test(phase))?.category ?? null;
+}
+
 function phaseCategoryScore(phaseTimings) {
   const scores = new Map();
   for (const entry of phaseTimings) {
-    const matched = PHASE_CATEGORY_PATTERNS.find((item) => item.pattern.test(entry.phase));
-    if (!matched) {
+    const category = phaseCategory(entry.phase);
+    if (!category) {
       continue;
     }
-    scores.set(matched.category, (scores.get(matched.category) ?? 0) + entry.durationMs);
+    scores.set(category, (scores.get(category) ?? 0) + entry.durationMs);
   }
   return Array.from(scores.entries()).sort((left, right) => right[1] - left[1])[0] ?? null;
 }
@@ -583,9 +973,9 @@ export function summarizeEvidence(evidence) {
   } else if (normalized.uiVisible === false) {
     bottleneck = "ui_visibility";
     reasons.push("ui_not_visible");
-  } else if (normalized.validationPassed === false) {
+  } else if (normalized.runOutcomeOk === false) {
     bottleneck = "incomplete_evidence";
-    reasons.push("validation_flag_failed");
+    reasons.push("run_outcome_failed");
   } else if (normalized.fallbackCode || normalized.fallbackReason) {
     bottleneck = "lifecycle";
     reasons.push("fallback_used");
@@ -625,6 +1015,8 @@ export function summarizeEvidence(evidence) {
 
   return {
     ok: validation.ok,
+    schemaPrivacyOk: validation.schemaPrivacyOk,
+    runOutcomeOk: normalized?.runOutcomeOk ?? null,
     schemaVersion: SCHEMA_VERSION,
     scenario: evidence?.scenario ?? null,
     source: evidence?.source ?? null,
@@ -650,11 +1042,35 @@ function compareMetric(candidate, control, key, preferredDirection) {
   return { metric: key, candidate: candidateValue, control: controlValue, winner };
 }
 
+function networkComparisonValue(metrics) {
+  if (!metrics) return null;
+  if (metrics.runRole === "receiver_or_import") return metrics.networkReceiveThroughputBytesPerSecond;
+  if (metrics.runRole === "sender_only") return metrics.networkSendThroughputBytesPerSecond;
+  if (metrics.runRole === "no_op") return 0;
+  if (metrics.runRole === "bidirectional") {
+    return metrics.aggregateNetworkThroughputBytesPerSecond ?? (
+      metrics.networkReceiveThroughputBytesPerSecond !== null &&
+      metrics.networkSendThroughputBytesPerSecond !== null
+        ? metrics.networkReceiveThroughputBytesPerSecond + metrics.networkSendThroughputBytesPerSecond
+        : null
+    );
+  }
+  return metrics.aggregateNetworkThroughputBytesPerSecond;
+}
+
 export function compareEvidence(candidateEvidence, controlEvidence) {
   const candidateSummary = summarizeEvidence(candidateEvidence);
   const controlSummary = summarizeEvidence(controlEvidence);
+  const networkComparable = candidateSummary.metrics?.runRole === controlSummary.metrics?.runRole;
+  const candidateNetwork = networkComparable ? networkComparisonValue(candidateSummary.metrics) : null;
+  const controlNetwork = networkComparable ? networkComparisonValue(controlSummary.metrics) : null;
   const comparisons = [
-    compareMetric(candidateSummary.metrics, controlSummary.metrics, "networkReceiveThroughputBytesPerSecond", "higher"),
+    compareMetric(
+      { networkThroughputBytesPerSecond: candidateNetwork },
+      { networkThroughputBytesPerSecond: controlNetwork },
+      "networkThroughputBytesPerSecond",
+      "higher",
+    ),
     compareMetric(candidateSummary.metrics, controlSummary.metrics, "backendStagingThroughputBytesPerSecond", "higher"),
     compareMetric(candidateSummary.metrics, controlSummary.metrics, "reconciliationApplyMs", "lower"),
     compareMetric(candidateSummary.metrics, controlSummary.metrics, "projectImportsPerMinute", "higher"),

--- a/scripts/sync-validation.test.mjs
+++ b/scripts/sync-validation.test.mjs
@@ -10,6 +10,37 @@ import {
   summarizeEvidence,
   validateEvidence,
 } from "./sync-validation.mjs";
+import {
+  SYNC_PRIVACY_HASH_TOKENS,
+  SYNC_PRIVACY_RAW_ID_TOKENS,
+  SYNC_PRIVACY_SAFE_OPERATIONAL_TOKENS,
+} from "./sync-privacy-token-cases.mjs";
+
+const RECEIVER_TRANSFER_COUNTS = {
+  requested: 8,
+  received: 8,
+  skipped: 0,
+  already_staged: 0,
+  failed: 0,
+  retried: 0,
+};
+const ZERO_TRANSFER_COUNTS = Object.fromEntries(
+  Object.keys(RECEIVER_TRANSFER_COUNTS).map((key) => [key, 0]),
+);
+
+function makeReceiverMetrics(overrides = {}) {
+  return {
+    network_receive_throughput_bytes_per_second: 2_000_000,
+    total_received_bytes: 8_000_000,
+    backend_staging_throughput_bytes_per_second: 1_500_000,
+    reconciliation_apply_ms: 300,
+    project_imports_per_minute: 12,
+    project_availability_gap_ms: 5_000,
+    ttfa_ms: 900,
+    transfer_counts: { ...RECEIVER_TRANSFER_COUNTS },
+    ...overrides,
+  };
+}
 
 function makeEvidence(overrides = {}) {
   return {
@@ -21,6 +52,7 @@ function makeEvidence(overrides = {}) {
       phase_timings: [
         { phase: "network_receive", duration_ms: 1200 },
         { phase: "staging_post", duration_ms: 400 },
+        { phase: "backend_staging", duration_ms: 1 },
         { phase: "reconciliation_apply", duration_ms: 300 },
       ],
     },
@@ -30,22 +62,7 @@ function makeEvidence(overrides = {}) {
       fallback_code: null,
       fallback_reason: null,
     },
-    metrics: {
-      network_receive_throughput_bytes_per_second: 2_000_000,
-      backend_staging_throughput_bytes_per_second: 1_500_000,
-      reconciliation_apply_ms: 300,
-      project_imports_per_minute: 12,
-      project_availability_gap_ms: 5_000,
-      ttfa_ms: 900,
-      transfer_counts: {
-        requested: 8,
-        received: 8,
-        skipped: 0,
-        already_staged: 0,
-        failed: 0,
-        retried: 0,
-      },
-    },
+    metrics: makeReceiverMetrics(),
     projects: {
       imported: 2,
       labels: ["project-1", "project-2"],
@@ -77,6 +94,23 @@ function makeEvidence(overrides = {}) {
   };
 }
 
+function makeProjectAccountingEvidence({
+  projectResultsByStatus,
+  projectCounts,
+  projects = [],
+  metricOverrides = {},
+}) {
+  return makeEvidence({
+    metrics: makeReceiverMetrics({
+      project_imports_per_minute: 0,
+      ...metricOverrides,
+      transferCounts: projectCounts,
+      projectResultsByStatus,
+    }),
+    projects,
+  });
+}
+
 function makeSenderOnlyEvidence(overrides = {}) {
   const transferCounts = {
     requested: 0,
@@ -94,7 +128,7 @@ function makeSenderOnlyEvidence(overrides = {}) {
       listenerStatus: "listening",
     },
     run: {
-      label: "run_1",
+      label: "Run 1",
       status: "completed",
       message: "Exchanged 1 local and 0 remote manifest(s); imported 0 project(s), received 0 artifact(s).",
     },
@@ -107,6 +141,7 @@ function makeSenderOnlyEvidence(overrides = {}) {
     },
     metrics: {
       network_receive_throughput_bytes_per_second: 42_409_204.7,
+      throughputBytesPerSecond: 42_409_204.7,
       backend_staging_throughput_bytes_per_second: null,
       reconciliation_apply_ms: null,
       project_imports_per_minute: 0,
@@ -151,6 +186,24 @@ function makeSenderOnlyEvidence(overrides = {}) {
   });
 }
 
+function makeNoOpEvidence() {
+  const evidence = makeSenderOnlyEvidence();
+  Object.assign(evidence.metrics, { network_send_throughput_bytes_per_second: null,
+    throughputBytesPerSecond: 0, project_imports_per_minute: null, ttfa_ms: null });
+  Object.assign(evidence.metrics.transferCounts, { servedArtifactRequests: 0 });
+  Object.assign(evidence.metrics.diagnostics, { total_received_bytes: 0, total_served_bytes: 0 });
+  return evidence;
+}
+
+function makeReceiverMutationEvidence(overrides) {
+  const evidence = makeSenderOnlyEvidence(overrides);
+  evidence.metrics.network_send_throughput_bytes_per_second = null;
+  Object.assign(evidence.metrics, { network_receive_throughput_bytes_per_second: 0, throughputBytesPerSecond: 0 });
+  evidence.metrics.transferCounts.servedArtifactRequests = 0;
+  evidence.metrics.diagnostics.total_served_bytes = 0;
+  return evidence;
+}
+
 test("validateEvidence passes valid scenario evidence", () => {
   const result = validateEvidence(makeEvidence(), { scenario: "desktop-to-desktop" });
   assert.equal(result.ok, true);
@@ -162,9 +215,76 @@ test("validateEvidence passes sender-only evidence without receiver metrics", ()
   assert.equal(result.ok, true);
   assert.deepEqual(result.errors, []);
   assert.equal(result.normalized.runRole, "sender_only");
+  assert.equal(result.normalized.networkReceiveThroughputBytesPerSecond, null);
+  assert.equal(result.normalized.networkSendThroughputBytesPerSecond, 42_409_204.7);
   assert.equal(result.normalized.backendStagingThroughputBytesPerSecond, null);
   assert.equal(result.normalized.reconciliationApplyMs, null);
   assert.equal(result.normalized.projectAvailabilityGapMs, null);
+});
+
+test("validateEvidence accepts true no-op evidence without work metrics", () => {
+  const result = validateEvidence(makeNoOpEvidence(), { scenario: "listener-last-sync" });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.schemaPrivacyOk, true);
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.normalized.runRole, "no_op");
+  for (const metric of ["networkReceiveThroughputBytesPerSecond", "networkSendThroughputBytesPerSecond",
+    "backendStagingThroughputBytesPerSecond", "reconciliationApplyMs", "projectImportsPerMinute",
+    "projectAvailabilityGapMs", "ttfaMs"]) {
+    assert.equal(result.normalized[metric], null, metric);
+  }
+});
+
+test("validateEvidence requires positive byte proof for positive throughput", () => {
+  for (const [bytes, ok] of [[null, false], [0, false], [-1, false], [8_000_000, true]]) {
+    const result = validateEvidence(makeEvidence({ metrics: makeReceiverMetrics(
+      { total_received_bytes: bytes, total_served_bytes: 0 }) }));
+    assert.equal(result.ok, ok, String(bytes));
+    if (!ok) assert.match(result.errors.join(" "), /Positive network receive throughput requires positive/);
+    if (bytes === -1) assert.match(result.errors.join(" "), /received byte total.*combined byte total/);
+  }
+  for (const bytes of [null, -1]) {
+    const sender = makeSenderOnlyEvidence(); sender.metrics.diagnostics.total_served_bytes = bytes;
+    const errors = validateEvidence(sender).errors.join(" ");
+    assert.match(errors, /Positive network send throughput requires positive/);
+    if (bytes === -1) assert.match(errors, /served byte total/);
+  }
+  const aggregate = makeEvidence({ metrics: makeReceiverMetrics({ throughputBytesPerSecond: 1 }) });
+  assert.match(validateEvidence(aggregate).errors.join(" "), /Positive aggregate network throughput requires positive/);
+});
+
+test("validateEvidence remaps legacy bidirectional aggregate receive throughput", () => {
+  const evidence = makeEvidence();
+  evidence.run.durationMs = 1_000;
+  Object.assign(evidence.metrics, { total_received_bytes: 100, total_served_bytes: 200,
+    network_receive_throughput_bytes_per_second: 300, throughputBytesPerSecond: 300,
+    transferCounts: { servedArtifactRequests: 1 } });
+  const result = validateEvidence(evidence);
+  assert.equal(result.ok, true);
+  assert.deepEqual([result.normalized.networkReceiveThroughputBytesPerSecond,
+    result.normalized.networkSendThroughputBytesPerSecond,
+    result.normalized.aggregateNetworkThroughputBytesPerSecond], [100, 200, 300]);
+  delete evidence.metrics.network_receive_throughput_bytes_per_second;
+  delete evidence.run.durationMs;
+  const genericOnly = validateEvidence(evidence).normalized;
+  assert.deepEqual([genericOnly.networkReceiveThroughputBytesPerSecond,
+    genericOnly.networkSendThroughputBytesPerSecond], [null, null]);
+});
+
+test("validateEvidence trusts received artifact rows only when complete or count-matched", () => {
+  for (const [receivedCount, complete, expected] of [[2, false, null], [1, false, 100], [2, true, null]]) {
+    const mismatch = receivedCount === 2 && complete;
+    const evidence = makeEvidence({ artifacts: [{ status: "received", sizeBytes: 100 },
+      { status: "failed", sizeBytes: 900 }], run: { ...makeEvidence().run, received_artifacts_complete: complete },
+      metrics: makeReceiverMetrics({ total_received_bytes: null,
+        network_receive_throughput_bytes_per_second: mismatch ? null : 2_000_000,
+        transfer_counts: { ...RECEIVER_TRANSFER_COUNTS, received: receivedCount } }) });
+    const result = validateEvidence(evidence);
+    assert.equal(result.normalized.totalReceivedBytes, expected);
+    if (mismatch) assert.match(result.errors.join(" "),
+      /Complete received artifact rows disagree with authoritative received count/);
+  }
 });
 
 test("validateEvidence reads nested counts when transfer_counts is diagnostic", () => {
@@ -184,17 +304,40 @@ test("validateEvidence reads nested counts when transfer_counts is diagnostic", 
   assert.equal(result.normalized.transferCounts.received, 0);
 });
 
+test("validateEvidence preserves schema-v1 byte and directional rate aliases", () => {
+  const cases = [
+    ...["served_bytes", "servedBytes"].map((alias) => [alias, "served", "totalServedBytes", 227_671_416]),
+    ...["received_bytes", "receivedBytes"].map((alias) => [alias, "received", "totalReceivedBytes", 8_000_000]),
+    ...["receive_throughput_bytes_per_second", "transport_receive_throughput_bytes_per_second"]
+      .map((alias) => [alias, "receive", "networkReceiveThroughputBytesPerSecond", 1234]),
+    ...["send_throughput_bytes_per_second", "transport_send_throughput_bytes_per_second"]
+      .map((alias) => [alias, "send", "networkSendThroughputBytesPerSecond", 1234]),
+    ["throughput_bytes_per_second", "receive", "networkReceiveThroughputBytesPerSecond", 1234],
+    ["throughputBytesPerSecond", "send", "networkSendThroughputBytesPerSecond", 4321],
+  ];
+  for (const [alias, kind, field, expected] of cases) {
+    const evidence = ["served", "send"].includes(kind) ? makeSenderOnlyEvidence() : makeEvidence();
+    if (kind === "served") delete evidence.metrics.diagnostics.total_served_bytes;
+    else if (kind === "received") delete evidence.metrics.total_received_bytes;
+    else delete evidence.metrics[`network_${kind}_throughput_bytes_per_second`];
+    if (alias === "throughput_bytes_per_second") evidence.metrics.total_served_bytes = 0;
+    if (alias === "throughputBytesPerSecond") delete evidence.metrics.network_receive_throughput_bytes_per_second;
+    evidence.metrics[alias] = expected;
+    const result = validateEvidence(evidence);
+    assert.equal(result.ok, true, alias);
+    assert.equal(result.normalized[field], expected, alias);
+  }
+});
+
 test("validateEvidence treats local project mutations as receiver/import evidence", () => {
   for (const status of ["imported", "applied", "deleted"]) {
-    const result = validateEvidence(makeSenderOnlyEvidence({
-      projects: [{ label: "project_1", status }],
+    const result = validateEvidence(makeReceiverMutationEvidence({
+      projects: [{ label: "Project 1", status }],
     }));
     assert.equal(result.ok, false, status);
     assert.equal(result.normalized.runRole, "receiver_or_import", status);
     assert.equal(result.normalized.localProjectMutationCount, 1, status);
-    assert.match(result.errors.join(" "), /backend staging throughput/, status);
     assert.match(result.errors.join(" "), /reconciliation apply time/, status);
-    assert.match(result.errors.join(" "), /project import cadence gap/, status);
   }
 });
 
@@ -213,15 +356,13 @@ test("validateEvidence treats aggregate project mutations as receiver/import evi
   ];
 
   for (const [name, mutateMetrics] of cases) {
-    const evidence = makeSenderOnlyEvidence({ projects: [] });
+    const evidence = makeReceiverMutationEvidence({ projects: [] });
     mutateMetrics(evidence.metrics);
     const result = validateEvidence(evidence);
     assert.equal(result.ok, false, name);
     assert.equal(result.normalized.runRole, "receiver_or_import", name);
     assert.equal(result.normalized.localProjectMutationCount, 1, name);
-    assert.match(result.errors.join(" "), /backend staging throughput/, name);
     assert.match(result.errors.join(" "), /reconciliation apply time/, name);
-    assert.match(result.errors.join(" "), /project import cadence gap/, name);
   }
 });
 
@@ -243,7 +384,6 @@ test("validateEvidence fails scenario mismatch and missing metrics", () => {
   const result = validateEvidence(evidence, { scenario: "desktop-to-desktop" });
   assert.equal(result.ok, false);
   assert.match(result.errors.join(" "), /Scenario mismatch/);
-  assert.match(result.errors.join(" "), /network receive throughput/);
 });
 
 test("validateEvidence still requires receiver metrics for receiver evidence", () => {
@@ -288,6 +428,217 @@ test("validateEvidence still requires receiver metrics for receiver evidence", (
   assert.doesNotMatch(result.errors.join(" "), /Missing required transfer count/);
 });
 
+test("validateEvidence bounds wall-clock apply timing but not aggregate work", () => {
+  const valid = validateEvidence(makeEvidence({
+    run: { durationMs: 1_000 },
+    metrics: makeReceiverMetrics({
+      reconciliation_apply_ms: 900,
+      reconciliation_apply_aggregate_ms: 1_500,
+    }),
+  }));
+  assert.equal(valid.ok, true);
+  assert.equal(valid.normalized.reconciliationApplyAggregateMs, 1_500);
+
+  const invalid = validateEvidence(makeEvidence({
+    run: { durationMs: 1_000 },
+    metrics: makeReceiverMetrics({ reconciliation_apply_ms: 1_200 }),
+  }));
+  assert.equal(invalid.ok, false);
+  assert.match(invalid.errors.join(" "), /reconciliation_apply_ms exceeds run wall-clock duration/);
+});
+
+test("validateEvidence rejects impossible timing evidence", () => {
+  const cases = [
+    ["run duration", (evidence) => { evidence.run.durationMs = -1; }],
+    ["reconciliation_apply_ms", (evidence) => { evidence.metrics.reconciliation_apply_ms = -1; }],
+    ["reconciliation_apply_aggregate_ms", (evidence) => {
+      evidence.metrics.reconciliation_apply_aggregate_ms = -1;
+    }],
+    ["project_availability_gap_ms", (evidence) => { evidence.metrics.project_availability_gap_ms = -1; }],
+    ["ttfa_ms", (evidence) => { evidence.metrics.ttfa_ms = -1; }],
+    ["Phase timing durations", (evidence) => { evidence.run.phase_timings[0].duration_ms = -1; }],
+  ];
+  for (const [expectedError, mutate] of cases) {
+    const evidence = makeEvidence({ run: { ...makeEvidence().run, durationMs: 1_000 } });
+    mutate(evidence);
+    assert.match(validateEvidence(evidence).errors.join(" "), new RegExp(`${expectedError} must be non-negative`));
+  }
+
+  const aggregateOnlyWithWallClock = makeEvidence({
+    metrics: makeReceiverMetrics({
+      reconciliation_apply_ms: 300,
+      reconciliation_apply_aggregate_ms: 500,
+      reconciliation_apply_timing: { semantics: "aggregate_only" },
+    }),
+  });
+  assert.match(
+    validateEvidence(aggregateOnlyWithWallClock).errors.join(" "),
+    /aggregate_only semantics require reconciliation_apply_ms to be null/,
+  );
+
+  const aggregateBelowWallClock = makeEvidence({
+    metrics: makeReceiverMetrics({
+      reconciliation_apply_ms: 500,
+      reconciliation_apply_aggregate_ms: 300,
+    }),
+  });
+  assert.match(
+    validateEvidence(aggregateBelowWallClock).errors.join(" "),
+    /reconciliation_apply_aggregate_ms must be at least reconciliation_apply_ms/,
+  );
+});
+
+test("validateEvidence accepts exporter-shaped aggregate-only timing", () => {
+  const evidence = makeEvidence();
+  evidence.run.durationMs = 1_000;
+  evidence.run.phaseTimings = [
+    { phase: "reconciliation_apply", durationMs: 750 },
+    { phase: "reconciliation_apply", durationMs: 750 },
+  ];
+  Object.assign(evidence.metrics, makeReceiverMetrics({
+    project_imports_per_minute: 0,
+    reconciliation_apply_ms: null,
+    reconciliation_apply_aggregate_ms: 1_500,
+    reconciliation_apply_timing: { semantics: "aggregate_only" },
+    transfer_counts: ZERO_TRANSFER_COUNTS,
+    projectResultsByStatus: { skipped: 2 },
+    transferCounts: { skippedProjectCount: 2, totalProjectCount: 2 },
+  }));
+  evidence.projects = [
+    { label: "Project 1", status: "skipped" },
+    { label: "Project 2", status: "skipped" },
+  ];
+  evidence.validation = { ...evidence.validation, scope: "run_outcome", outcomeOk: true, privacySafe: true };
+  const result = validateEvidence(evidence);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.schemaPrivacyOk, true);
+  assert.equal(result.normalized.reconciliationApplyMs, null);
+  assert.equal(result.normalized.reconciliationApplyAggregateMs, 1_500);
+  assert.equal(result.normalized.reconciliationApplyTimingSemantics, "aggregate_only");
+  assert.equal(result.normalized.projectCounts.skipped, 2);
+  assert.equal(result.normalized.validationScope, "run_outcome");
+  assert.equal(result.normalized.runOutcomeOk, true);
+});
+
+test("validateEvidence still requires wall-clock apply timing without aggregate-only semantics", () => {
+  for (const timing of [
+    { reconciliation_apply_ms: null },
+    { reconciliation_apply_ms: null, reconciliation_apply_aggregate_ms: 1_500 },
+  ]) {
+    const result = validateEvidence(makeEvidence({ metrics: makeReceiverMetrics(timing) }));
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join(" "), /Missing required metric: reconciliation apply time/);
+  }
+});
+
+test("validateEvidence keeps failed and conflicted project counts separate", () => {
+  const result = validateEvidence(makeProjectAccountingEvidence({
+    projectResultsByStatus: { failed: 1, conflicted: 1, skipped: 1 },
+    projectCounts: {
+      failedProjectCount: 1,
+      conflictedProjectCount: 1,
+      skippedProjectCount: 1,
+      totalProjectCount: 3,
+    },
+    projects: [
+      { label: "Project 1", status: "failed" },
+      { label: "Project 2", status: "conflicted" },
+      { label: "Project 3", status: "skipped" },
+    ],
+  }));
+
+  assert.equal(result.ok, true);
+  assert.equal(result.normalized.transferCounts.failed, 0);
+  assert.equal(result.normalized.projectCounts.failed, 1);
+  assert.equal(result.normalized.projectCounts.conflicted, 1);
+});
+
+test("validateEvidence excludes explicitly non-final project rows from final accounting", () => {
+  const result = validateEvidence(makeProjectAccountingEvidence({
+    projectResultsByStatus: { skipped: 1 },
+    projectCounts: { skippedProjectCount: 1, totalProjectCount: 1 },
+    projects: [
+      { label: "Project 1", status: "failed", isFinal: false },
+      { label: "Project 2", status: "skipped", isFinal: true },
+    ],
+  }));
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.normalized.projectResultsByStatus, { skipped: 1 });
+  assert.equal(result.normalized.projectCounts.failed, 0);
+});
+
+test("validateEvidence accepts aggregate-only project status evidence when counts agree", () => {
+  const result = validateEvidence(makeProjectAccountingEvidence({
+    projectResultsByStatus: { failed: 1, conflicted: 1 },
+    projectCounts: { failedProjectCount: 1, conflictedProjectCount: 1, totalProjectCount: 2 },
+  }));
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.normalized.projectResultsByStatus, { failed: 1, conflicted: 1 });
+  assert.equal(result.normalized.projectCounts.total, 2);
+});
+
+test("validateEvidence keeps manifest errors explicit and outside failed project totals", () => {
+  const manifestOnly = validateEvidence(makeProjectAccountingEvidence({
+    projectResultsByStatus: {},
+    projectCounts: {
+      failedProjectCount: 0,
+      totalProjectCount: 0,
+      manifestExportErrorCount: 2,
+    },
+    projects: [{ label: "Project 1", status: "manifest_export_error" }],
+  }));
+  assert.equal(manifestOnly.ok, true);
+  assert.deepEqual(manifestOnly.normalized.projectResultsByStatus, {});
+  assert.equal(manifestOnly.normalized.projectCounts.failed, 0);
+  assert.equal(manifestOnly.normalized.projectCounts.total, 0);
+  assert.equal(manifestOnly.normalized.projectCounts.manifestExportErrors, 2);
+
+  const overlap = validateEvidence(makeProjectAccountingEvidence({
+    projectResultsByStatus: { failed: 1 },
+    projectCounts: { failedProjectCount: 1, totalProjectCount: 1, manifestExportErrorCount: 1 },
+    projects: [
+      { label: "Project 1", status: "failed" },
+      { label: "Project 1", status: "manifest_export_error" },
+    ],
+  }));
+  assert.equal(overlap.ok, true);
+  assert.equal(overlap.normalized.projectCounts.failed, 1);
+  assert.equal(overlap.normalized.projectCounts.manifestExportErrors, 1);
+});
+
+test("validateEvidence rejects inconsistent project maps and count claims", () => {
+  const evidence = makeProjectAccountingEvidence({
+    projectResultsByStatus: { failed: 1 },
+    projectCounts: { failedProjectCount: 1, totalProjectCount: 1 },
+  });
+  evidence.metrics.failedProjectCount = 2;
+  const result = validateEvidence(evidence);
+
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join(" "), /failed project count fields disagree/);
+  assert.match(result.errors.join(" "), /failedProjectCount disagrees with projectResultsByStatus\.failed/);
+});
+
+test("validateEvidence validates manifest count aliases independently", () => {
+  const evidence = makeProjectAccountingEvidence({
+    projectResultsByStatus: {},
+    projectCounts: {
+      failedProjectCount: 0,
+      totalProjectCount: 0,
+      manifestErrorCount: 2,
+      manifestExportErrorCount: 1,
+    },
+    projects: [{ label: "Project 1", status: "manifest_export_error" }],
+  });
+  const result = validateEvidence(evidence);
+
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join(" "), /manifestExportErrors project count fields disagree/);
+});
+
 test("summarizeEvidence classifies network bottleneck from phase timings", () => {
   const summary = summarizeEvidence(makeEvidence({
     run: {
@@ -299,6 +650,21 @@ test("summarizeEvidence classifies network bottleneck from phase timings", () =>
     },
   }));
   assert.equal(summary.bottleneck, "network");
+});
+
+test("summarizeEvidence does not classify planning phases as reconciliation apply", () => {
+  const summary = summarizeEvidence(makeEvidence({
+    run: {
+      phase_timings: [
+        { phase: "reconciliation_plan", duration_ms: 5_000 },
+        { phase: "staging_apply_plan", duration_ms: 4_000 },
+        { phase: "network_receive", duration_ms: 1_000 },
+      ],
+    },
+  }));
+
+  assert.equal(summary.bottleneck, "staging");
+  assert.deepEqual(summary.reasons, ["phase:staging"]);
 });
 
 test("validateEvidence rejects privacy leaks", () => {
@@ -329,6 +695,64 @@ test("validateEvidence rejects privacy leaks", () => {
   assert.match(result.errors.join(" "), /filename-like value/);
   assert.match(result.errors.join(" "), /disallowed key/);
   assert.match(result.errors.join(" "), /raw identifier/);
+});
+
+test("validateEvidence allows operational status tokens", () => {
+  const evidence = makeEvidence({
+    run: {
+      label: "Run 1",
+      status: "completed",
+      message: `${SYNC_PRIVACY_SAFE_OPERATIONAL_TOKENS.join(" ")} ` +
+        "prefix_checksum_mismatch prefix.hash_retry_pending prefix-sha256_mismatch",
+    },
+    validation: {
+      ok: false,
+      issues: SYNC_PRIVACY_SAFE_OPERATIONAL_TOKENS.filter((token) => token !== "artifact_transfer"),
+      ui_visible: true,
+    },
+  });
+  const result = validateEvidence(evidence);
+  const summary = summarizeEvidence(evidence);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.schemaPrivacyOk, true);
+  assert.equal(result.normalized.validationScope, null);
+  assert.equal(result.normalized.runOutcomeOk, false);
+  assert.equal(summary.schemaPrivacyOk, true);
+  assert.equal(summary.runOutcomeOk, false);
+  assert.deepEqual(summary.reasons, ["run_outcome_failed"]);
+});
+
+test("validateEvidence rejects near-miss phase identifiers", () => {
+  for (const token of ["artifact_shadow", "artifact_transfer_shadow", "artifact_staging_shadow", "artifact_cleanup_shadow"]) {
+    const result = validateEvidence(makeEvidence({ run: { label: "Run 1", message: token } }));
+    assert.equal(result.ok, false, token);
+    assert.match(result.errors.join(" "), /raw identifier token/, token);
+  }
+  for (const phase of ["network_receive_shadow", "staging_post_shadow", "staging_apply_plan_shadow",
+    "backend_staging_shadow"]) {
+    const result = validateEvidence(makeEvidence({ run: { phase_timings: [{ phase, duration_ms: 1 }] } }));
+    assert.equal(result.ok, false, phase);
+    assert.match(result.errors.join(" "), /unknown phase/, phase);
+  }
+});
+
+test("validateEvidence rejects raw identifier and hash tokens in free text", () => {
+  const result = validateEvidence(makeEvidence({
+    run: {
+      label: "Run 1",
+      status: "completed",
+      message: `Completed with ${SYNC_PRIVACY_RAW_ID_TOKENS.join(" ")} ${SYNC_PRIVACY_HASH_TOKENS.join(" ")}.`,
+      error: `Checksum failed for ${SYNC_PRIVACY_RAW_ID_TOKENS[4]}.`,
+    },
+    lifecycle: {
+      note: "Retry guidance available.",
+      ui_visible: true,
+    },
+  }));
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join(" "), /raw identifier token/);
+  assert.match(result.errors.join(" "), /hash-like token/);
 });
 
 test("validateEvidence rejects embedded path variants", () => {
@@ -415,6 +839,7 @@ test("compareEvidence compares candidate against Syncthing-like control without 
     source: "tuneforge-sync+iroh",
     metrics: {
       network_receive_throughput_bytes_per_second: 2_400_000,
+      total_received_bytes: 8_000_000,
       backend_staging_throughput_bytes_per_second: 1_700_000,
       reconciliation_apply_ms: 280,
       project_imports_per_minute: 14,
@@ -434,6 +859,7 @@ test("compareEvidence compares candidate against Syncthing-like control without 
     source: "syncthing-control",
     metrics: {
       network_receive_throughput_bytes_per_second: 2_100_000,
+      total_received_bytes: 8_000_000,
       backend_staging_throughput_bytes_per_second: 1_600_000,
       reconciliation_apply_ms: 400,
       project_imports_per_minute: 11,


### PR DESCRIPTION
## Summary

- Separate failed, conflicted, skipped, and manifest export outcomes in sync evidence.
- Report truthful no-op, directional throughput, timing, reuse, and privacy-safe diagnostics.
- Preserve schema-v1 compatibility and add sender, receiver, no-op, and adversarial regression coverage.
- Closes #336

## Testing

- `node --test scripts/sync-validation.test.mjs`
- `pnpm --filter @tuneforge/desktop test -- App.activity.test.tsx`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `cd apps/desktop/src-tauri && cargo test sync_transport`
- `cd apps/desktop/src-tauri && cargo check`
- Manual VM/host validation: empty no-op, one-project transfer, repeated unchanged sync, evidence export, and playback.
