### PR TITLE
feat(site): add generated media gallery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
           node-version: "22"
 
       - name: Test deterministic Node scripts
-        run: node --test scripts/package-options.test.mjs scripts/flatpak-options.test.mjs scripts/playback-smoke.test.mjs scripts/sync-validation.test.mjs scripts/release-license-inventory.test.mjs
+        run: node --test scripts/package-options.test.mjs scripts/flatpak-options.test.mjs scripts/playback-smoke.test.mjs scripts/sync-validation.test.mjs scripts/release-license-inventory.test.mjs scripts/capture-release-media.test.mjs
 
       - name: Check release script syntax
         run: |
@@ -260,6 +260,10 @@ jobs:
       - name: Type-check site
         if: needs.ci-scope.outputs.site == 'true'
         run: pnpm --filter @tuneforge/site typecheck
+
+      - name: Test site
+        if: needs.ci-scope.outputs.site == 'true'
+        run: pnpm --filter @tuneforge/site test
 
       - name: Build site
         if: needs.ci-scope.outputs.site == 'true'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,12 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - apps/site/**
-      - .github/workflows/pages.yml
-      - package.json
-      - pnpm-lock.yaml
-      - pnpm-workspace.yaml
   workflow_dispatch:
 
 permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,23 @@ When asked to implement a change:
 - Prefer updating existing docs under `docs/` instead of adding near-duplicate pages.
 - Link docs with relative paths and keep section anchors stable where practical.
 
+## Release Media
+
+- Evaluate material user-visible features for coverage in the release-media capture catalog in
+  `scripts/capture-release-media.mjs`. The catalog is an explicit code list, not route discovery.
+- Add media only when the state is visually distinct, useful to visitors, and deterministic. Use a
+  screenshot for a stable state and a short silent video for behavior over time, such as playback,
+  sync progress, or tuner movement.
+- Skip backend-only, duplicate, trivial, hardware-dependent, or non-deterministic states.
+- Use synthetic fixtures only. Never capture user files, copyrighted audio, accounts, or external
+  services.
+- Every entry needs a semantic ready-state assertion, fixed viewport and theme, meaningful title,
+  caption, and alt text, plus a poster for video. Keep its metadata, fixture preparation, readiness,
+  and capture behavior together in the catalog.
+- Run `node scripts/capture-release-media.mjs --run` and inspect every generated screenshot, video,
+  poster, and manifest entry before finishing. Do not use `--allow-partial` for final validation.
+- Never commit generated media under `apps/site/public/media/generated/`.
+
 ## Generated Artifacts
 
 The following files are generated. **Do not edit by hand.**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,33 @@ pnpm dev
 
 The backend serves on `http://127.0.0.1:8765/api/v1`. The Tauri dev shell connects to it.
 
+## Release Media
+
+The GitHub Pages site presents screenshots and video generated from deterministic synthetic app
+states. Its release-media capture catalog is an explicit list in
+`scripts/capture-release-media.mjs`; it does not crawl every route automatically.
+
+When a material user-visible feature changes, evaluate whether it belongs in the catalog. Add media
+only when the feature is visually distinct, useful to site visitors, and deterministic:
+
+- Use a screenshot for a stable state.
+- Use a short silent video for behavior over time, such as playback, sync progress, or tuner
+  movement.
+- Skip backend-only, duplicate, trivial, hardware-dependent, or non-deterministic states.
+
+Use synthetic fixtures only. Never capture user files, copyrighted audio, accounts, or external
+services. Each catalog entry must use a fixed viewport and theme, wait for a semantic ready state,
+and provide meaningful visitor-facing metadata. Video entries also need a poster image.
+
+Generate the complete set locally, then inspect every screenshot, video, poster, and manifest entry:
+
+```sh
+node scripts/capture-release-media.mjs --run
+```
+
+Do not use `--allow-partial` for final validation. Generated output under
+`apps/site/public/media/generated/` is local build material and must never be committed.
+
 ## Before You Open a PR
 
 Run all of these locally and make sure they pass:

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import subprocess
+import tempfile
 import time
 from pathlib import Path
 
@@ -10,6 +12,14 @@ import numpy as np
 import pytest
 import soundfile as sf
 from fastapi.testclient import TestClient
+
+# Test modules import app.db during collection, before fixtures run. Force that
+# collection-time engine onto disposable storage instead of the user's app data.
+_TEST_BOOTSTRAP_DIRECTORY = tempfile.TemporaryDirectory(prefix="tuneforge-pytest-")
+_TEST_BOOTSTRAP_ROOT = Path(_TEST_BOOTSTRAP_DIRECTORY.name).resolve()
+_TEST_BOOTSTRAP_DATA_ROOT = _TEST_BOOTSTRAP_ROOT / "data"
+os.environ["TUNEFORGE_DATA_DIR"] = str(_TEST_BOOTSTRAP_DATA_ROOT)
+os.environ["XDG_CACHE_HOME"] = str(_TEST_BOOTSTRAP_ROOT / "xdg-cache")
 
 _EMPTY_SHA256 = hashlib.sha256(b"").hexdigest()
 
@@ -22,6 +32,25 @@ _TEST_DEMUCS_MODEL_FILES = (
     "92cfc3b6-ef3bcb9c.th",
     "04573f0d-f3cf25b2.th",
 )
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    _ = session
+    from app.config import ensure_data_dirs, get_settings
+    from app.db import reconfigure_engine, run_migrations
+
+    settings = get_settings()
+    ensure_data_dirs(settings)
+    reconfigure_engine(settings)
+    run_migrations(settings)
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    _ = session, exitstatus
+    from app.db import get_engine
+
+    get_engine().dispose()
+    _TEST_BOOTSTRAP_DIRECTORY.cleanup()
 
 
 @pytest.fixture(autouse=True)

--- a/apps/backend/tests/test_db_engine.py
+++ b/apps/backend/tests/test_db_engine.py
@@ -1,12 +1,24 @@
 from __future__ import annotations
 
+import tempfile
+from pathlib import Path
+
 from app.config import ensure_data_dirs, get_settings
 from app.db import (
     SQLITE_BUSY_TIMEOUT_MS,
     SQLITE_BUSY_TIMEOUT_SECONDS,
     _engine_for,
     _engine_options_for,
+    get_engine,
 )
+
+_COLLECTION_DATABASE_NAME = get_engine().url.database
+assert _COLLECTION_DATABASE_NAME is not None
+_COLLECTION_DATABASE_PATH = Path(_COLLECTION_DATABASE_NAME).resolve()
+
+
+def test_collection_database_uses_temporary_test_storage() -> None:
+    assert _COLLECTION_DATABASE_PATH.is_relative_to(Path(tempfile.gettempdir()).resolve())
 
 
 def test_sqlite_engine_sets_driver_busy_timeout() -> None:

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -10,6 +10,16 @@ Use the root `AGENTS.md` for global rules. This file adds desktop-specific guida
 - Use generated contracts from `@tuneforge/shared-types` for backend-facing types.
 - Prefer user-visible behavior tests (Vitest + Testing Library), not implementation details.
 
+## Release media
+
+- For material user-visible changes, evaluate whether the release-media capture catalog needs a
+  deterministic screenshot or short silent video. Follow the catalog selection and validation
+  rules in the root `AGENTS.md`.
+- Prefer screenshots for stable UI states and videos for time-based behavior. Do not add duplicate,
+  trivial, hardware-dependent, or non-deterministic coverage.
+- Capture synthetic fixture data only; never use user files, copyrighted audio, accounts, or
+  external services.
+
 ## Tauri conventions
 
 - Keep `src-tauri/src/main.rs` minimal; backend business logic stays in Python.

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc && vite build",
     "dev": "vite --host 127.0.0.1",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -14,10 +15,16 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^6.0.2",
+    "jsdom": "^29.1.1",
     "typescript": "~7.0.2",
-    "vite": "^8.1.4"
+    "vite": "^8.1.4",
+    "vitest": "^4.1.10"
   }
 }

--- a/apps/site/src/App.test.tsx
+++ b/apps/site/src/App.test.tsx
@@ -1,0 +1,153 @@
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { App } from "./App";
+
+const manifest = {
+  schemaVersion: 1,
+  status: "captured",
+  generatedAt: "2026-04-18T12:00:00.000Z",
+  source: "synthetic release capture",
+  items: [
+    {
+      id: "library",
+      title: "Practice library",
+      kind: "screenshot",
+      src: "media/generated/library.png",
+      alt: "TuneForge practice library with two synthetic projects",
+      caption: "Return to saved songs and practice state.",
+      label: "Library",
+    },
+    {
+      id: "overview",
+      title: "TuneForge overview",
+      kind: "video",
+      src: "media/generated/overview.webm",
+      poster: "media/generated/library.png",
+      caption: "A short tour through the local practice workflow.",
+      label: "Video",
+    },
+  ],
+};
+
+function mockManifest(value: unknown = manifest) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(value),
+    }),
+  );
+}
+
+describe("release media gallery", () => {
+  beforeEach(() => {
+    mockManifest();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("opens from the keyboard, closes, and restores launcher focus", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    const launcher = await screen.findByRole("button", {
+      name: "Open Practice library in gallery",
+    });
+
+    launcher.focus();
+    await user.keyboard("{Enter}");
+
+    const dialog = screen.getByRole("dialog", { name: "Practice library" });
+    expect(dialog).toBeVisible();
+    expect(within(dialog).getByText("1 of 2")).toBeVisible();
+
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(launcher).toHaveFocus();
+  });
+
+  it("wraps previous and next navigation with arrow keys", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(
+      await screen.findByRole("button", { name: "Open Practice library in gallery" }),
+    );
+
+    await user.keyboard("{ArrowLeft}");
+    expect(screen.getByRole("dialog", { name: "TuneForge overview" })).toBeVisible();
+    expect(screen.getByText("2 of 2")).toBeVisible();
+
+    await user.keyboard("{ArrowRight}");
+    expect(screen.getByRole("dialog", { name: "Practice library" })).toBeVisible();
+    expect(screen.getByText("1 of 2")).toBeVisible();
+  });
+
+  it("wraps navigation controls", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(
+      await screen.findByRole("button", { name: "Open TuneForge overview in gallery" }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByRole("dialog", { name: "Practice library" })).toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: "Previous" }));
+    expect(screen.getByRole("dialog", { name: "TuneForge overview" })).toBeVisible();
+  });
+
+  it("leaves arrow keys to focused video controls", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(
+      await screen.findByRole("button", { name: "Open TuneForge overview in gallery" }),
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "TuneForge overview" });
+    const video = dialog.querySelector("video");
+    expect(video).not.toBeNull();
+    video?.focus();
+    expect(video).toHaveFocus();
+
+    await user.keyboard("{ArrowLeft}{ArrowRight}");
+
+    expect(screen.getByRole("dialog", { name: "TuneForge overview" })).toBeVisible();
+    expect(screen.getByText("2 of 2")).toBeVisible();
+  });
+
+  it("pauses video before changing items and closing", async () => {
+    const pause = vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(
+      await screen.findByRole("button", { name: "Open TuneForge overview in gallery" }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Previous" }));
+    expect(pause).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Close gallery" }));
+    expect(pause).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows public fallback links for a malformed manifest", async () => {
+    mockManifest({ schemaVersion: 1, status: "captured", items: "broken" });
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "Release preview unavailable" })).toBeVisible();
+    expect(screen.getByRole("link", { name: "View releases" })).toHaveAttribute(
+      "href",
+      "https://github.com/grazzolini/tuneforge/releases",
+    );
+    expect(screen.getByRole("link", { name: "Browse repository" })).toHaveAttribute(
+      "href",
+      "https://github.com/grazzolini/tuneforge",
+    );
+    expect(screen.queryByText(/capture-release-media/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/site/src/App.tsx
+++ b/apps/site/src/App.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   BadgeCheck,
+  ChevronLeft,
+  ChevronRight,
   CircleAlert,
   Code2,
   Download,
@@ -11,10 +13,12 @@ import {
   Mic,
   Music2,
   PackageCheck,
+  Play,
   ShieldOff,
   SlidersHorizontal,
   Video,
   Wrench,
+  X,
 } from "lucide-react";
 
 type MediaItem = {
@@ -100,6 +104,77 @@ function mediaUrl(src: string) {
   return `${base}${src.replace(/^\/+/, "")}`;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isOptionalString(value: unknown) {
+  return value === undefined || typeof value === "string";
+}
+
+function parseMediaItem(value: unknown): MediaItem | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const { alt, caption, id, kind, label, poster, src, title } = value;
+  if (
+    typeof id !== "string" ||
+    !id ||
+    typeof title !== "string" ||
+    !title ||
+    (kind !== "screenshot" && kind !== "video") ||
+    typeof src !== "string" ||
+    !src ||
+    !isOptionalString(alt) ||
+    !isOptionalString(caption) ||
+    !isOptionalString(label) ||
+    !isOptionalString(poster) ||
+    (kind === "screenshot" && (typeof alt !== "string" || !alt)) ||
+    (kind === "video" && (typeof poster !== "string" || !poster))
+  ) {
+    return null;
+  }
+
+  return { id, title, kind, src, alt, caption, label, poster };
+}
+
+function parseMediaManifest(value: unknown): MediaManifest | null {
+  if (!isRecord(value) || !Array.isArray(value.items)) {
+    return null;
+  }
+
+  const { generatedAt, notes, schemaVersion, source, status } = value;
+  if (
+    schemaVersion !== 1 ||
+    (status !== "pending" && status !== "partial" && status !== "captured") ||
+    (generatedAt !== null && typeof generatedAt !== "string") ||
+    typeof source !== "string" ||
+    (notes !== undefined && (!Array.isArray(notes) || !notes.every((note) => typeof note === "string")))
+  ) {
+    return null;
+  }
+
+  const items = value.items.map(parseMediaItem);
+  if (items.some((item) => item === null)) {
+    return null;
+  }
+
+  const parsedItems = items as MediaItem[];
+  if (new Set(parsedItems.map((item) => item.id)).size !== parsedItems.length) {
+    return null;
+  }
+
+  return {
+    schemaVersion,
+    status,
+    generatedAt,
+    source,
+    items: parsedItems,
+    notes: notes as string[] | undefined,
+  };
+}
+
 function useMediaManifest() {
   const [manifest, setManifest] = useState<MediaManifest>(defaultManifest);
   const [loaded, setLoaded] = useState(false);
@@ -117,12 +192,11 @@ function useMediaManifest() {
         if (!response.ok) {
           throw new Error(`Media manifest returned ${response.status}.`);
         }
-        const data = (await response.json()) as MediaManifest;
-        setManifest({
-          ...defaultManifest,
-          ...data,
-          items: Array.isArray(data.items) ? data.items : [],
-        });
+        const data = parseMediaManifest(await response.json());
+        if (!data) {
+          throw new Error("Media manifest is malformed.");
+        }
+        setManifest(data);
       } catch {
         if (!controller.signal.aborted) {
           setManifest(defaultManifest);
@@ -175,19 +249,26 @@ function HeroPreview() {
   );
 }
 
-function MediaCard({ item }: { item: MediaItem }) {
+function MediaCard({
+  buttonRef,
+  item,
+  onOpen,
+}: {
+  buttonRef: (node: HTMLButtonElement | null) => void;
+  item: MediaItem;
+  onOpen: () => void;
+}) {
   return (
     <article className="media-card">
       <div className="media-card__asset">
         {item.kind === "video" ? (
-          <video
-            controls
-            muted
-            playsInline
-            poster={item.poster ? mediaUrl(item.poster) : undefined}
-            preload="metadata"
-            src={mediaUrl(item.src)}
-          />
+          <>
+            <img alt={item.alt ?? ""} src={mediaUrl(item.poster ?? "")} loading="lazy" />
+            <span className="media-card__play" aria-hidden="true">
+              <Play />
+              Watch video
+            </span>
+          </>
         ) : (
           <img alt={item.alt ?? item.title} src={mediaUrl(item.src)} loading="lazy" />
         )}
@@ -197,28 +278,158 @@ function MediaCard({ item }: { item: MediaItem }) {
         <h3>{item.title}</h3>
         {item.caption ? <p>{item.caption}</p> : null}
       </div>
+      <button
+        aria-label={`Open ${item.title} in gallery`}
+        className="media-card__launcher"
+        onClick={onOpen}
+        ref={buttonRef}
+        type="button"
+      />
     </article>
   );
 }
 
-function MediaFallback({ manifest }: { manifest: MediaManifest }) {
+function MediaViewer({
+  activeIndex,
+  items,
+  onClose,
+  onNavigate,
+}: {
+  activeIndex: number;
+  items: MediaItem[];
+  onClose: () => void;
+  onNavigate: (step: number) => void;
+}) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const item = items[activeIndex];
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (dialog && !dialog.open) {
+      dialog.showModal();
+    }
+  }, []);
+
+  function pauseVideo() {
+    videoRef.current?.pause();
+  }
+
+  function close() {
+    pauseVideo();
+    dialogRef.current?.close();
+  }
+
+  function navigate(step: number) {
+    pauseVideo();
+    onNavigate(step);
+  }
+
+  return (
+    <dialog
+      aria-describedby={item.caption ? "media-viewer-caption" : undefined}
+      aria-labelledby="media-viewer-title"
+      className="media-viewer"
+      onCancel={pauseVideo}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) {
+          close();
+        }
+      }}
+      onClose={onClose}
+      onKeyDown={(event) => {
+        const video = videoRef.current;
+        const isArrowKey = event.key === "ArrowLeft" || event.key === "ArrowRight";
+        const isVideoControlEvent =
+          video && (event.target === video || document.activeElement === video);
+        if (isArrowKey && isVideoControlEvent) {
+          return;
+        }
+
+        if (event.key === "ArrowLeft") {
+          event.preventDefault();
+          navigate(-1);
+        } else if (event.key === "ArrowRight") {
+          event.preventDefault();
+          navigate(1);
+        } else if (event.key === "Escape") {
+          event.preventDefault();
+          close();
+        }
+      }}
+      ref={dialogRef}
+    >
+      <div className="media-viewer__panel">
+        <header className="media-viewer__header">
+          <span className="media-viewer__counter">
+            {activeIndex + 1} of {items.length}
+          </span>
+          <div>
+            <span className="tag">{item.label ?? item.kind}</span>
+            <h2 id="media-viewer-title">{item.title}</h2>
+          </div>
+          <button
+            aria-label="Close gallery"
+            autoFocus
+            className="media-viewer__close"
+            onClick={close}
+            type="button"
+          >
+            <X aria-hidden="true" />
+          </button>
+        </header>
+
+        <div className="media-viewer__stage">
+          {item.kind === "video" ? (
+            <video
+              controls
+              muted
+              playsInline
+              poster={mediaUrl(item.poster ?? "")}
+              preload="metadata"
+              ref={videoRef}
+              src={mediaUrl(item.src)}
+              tabIndex={0}
+            />
+          ) : (
+            <img alt={item.alt ?? item.title} src={mediaUrl(item.src)} />
+          )}
+        </div>
+
+        <footer className="media-viewer__footer">
+          <button onClick={() => navigate(-1)} type="button">
+            <ChevronLeft aria-hidden="true" />
+            Previous
+          </button>
+          <p id="media-viewer-caption">{item.caption ?? "TuneForge release media"}</p>
+          <button onClick={() => navigate(1)} type="button">
+            Next
+            <ChevronRight aria-hidden="true" />
+          </button>
+        </footer>
+      </div>
+    </dialog>
+  );
+}
+
+function MediaFallback() {
   return (
     <div className="media-fallback">
       <Video aria-hidden="true" />
       <div>
-        <h3>Release media not captured yet</h3>
+        <h3>Release preview unavailable</h3>
         <p>
-          The site is ready for generated screenshots and video, but this checkout has only the
-          placeholder manifest. Capture output will appear from <code>apps/site/public/media/generated</code>.
+          Screenshots and video are unavailable right now. Explore the latest release or browse the
+          project while the gallery is refreshed.
         </p>
-        <pre>{`node scripts/capture-release-media.mjs --run`}</pre>
-        {manifest.notes?.length ? (
-          <ul>
-            {manifest.notes.map((note) => (
-              <li key={note}>{note}</li>
-            ))}
-          </ul>
-        ) : null}
+        <div className="media-fallback__links">
+          <a className="button button--primary" href={`${repoUrl}/releases`}>
+            View releases
+          </a>
+          <a className="button" href={repoUrl}>
+            Browse repository
+          </a>
+        </div>
       </div>
     </div>
   );
@@ -227,6 +438,28 @@ function MediaFallback({ manifest }: { manifest: MediaManifest }) {
 export function App() {
   const { loaded, manifest } = useMediaManifest();
   const mediaItems = useMemo(() => manifest.items.filter((item) => item.src), [manifest.items]);
+  const [activeMediaIndex, setActiveMediaIndex] = useState<number | null>(null);
+  const mediaButtonsRef = useRef<Array<HTMLButtonElement | null>>([]);
+  const lastTriggerRef = useRef<HTMLButtonElement | null>(null);
+
+  function openMedia(index: number) {
+    lastTriggerRef.current = mediaButtonsRef.current[index] ?? null;
+    setActiveMediaIndex(index);
+  }
+
+  function closeMedia() {
+    setActiveMediaIndex(null);
+    queueMicrotask(() => lastTriggerRef.current?.focus());
+  }
+
+  function navigateMedia(step: number) {
+    setActiveMediaIndex((current) => {
+      if (current === null) {
+        return current;
+      }
+      return (current + step + mediaItems.length) % mediaItems.length;
+    });
+  }
 
   return (
     <div className="site-shell">
@@ -310,18 +543,29 @@ export function App() {
               <p className="eyebrow">Screenshots and video</p>
               <h2 id="media-title">Release media</h2>
             </div>
-            <span className={`status-pill status-pill--${manifest.status}`}>
-              {loaded ? manifest.status : "loading"}
+            <span className="status-pill" aria-live="polite">
+              {loaded
+                ? `${mediaItems.length} media ${mediaItems.length === 1 ? "item" : "items"}`
+                : "Loading media"}
             </span>
           </div>
           {mediaItems.length ? (
             <div className="media-grid">
-              {mediaItems.map((item) => (
-                <MediaCard item={item} key={item.id} />
+              {mediaItems.map((item, index) => (
+                <MediaCard
+                  buttonRef={(node) => {
+                    mediaButtonsRef.current[index] = node;
+                  }}
+                  item={item}
+                  key={item.id}
+                  onOpen={() => openMedia(index)}
+                />
               ))}
             </div>
+          ) : loaded ? (
+            <MediaFallback />
           ) : (
-            <MediaFallback manifest={manifest} />
+            <p className="media-loading">Loading release media…</p>
           )}
         </section>
 
@@ -391,6 +635,14 @@ export function App() {
           Built from repository content and generated media only.
         </span>
       </footer>
+      {activeMediaIndex !== null && mediaItems[activeMediaIndex] ? (
+        <MediaViewer
+          activeIndex={activeMediaIndex}
+          items={mediaItems}
+          onClose={closeMedia}
+          onNavigate={navigateMedia}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/site/src/setupTests.ts
+++ b/apps/site/src/setupTests.ts
@@ -1,0 +1,20 @@
+import "@testing-library/jest-dom/vitest";
+
+Object.defineProperty(HTMLMediaElement.prototype, "pause", {
+  configurable: true,
+  value: () => {},
+  writable: true,
+});
+
+if (!HTMLDialogElement.prototype.showModal) {
+  HTMLDialogElement.prototype.showModal = function showModal() {
+    this.setAttribute("open", "");
+  };
+}
+
+if (!HTMLDialogElement.prototype.close) {
+  HTMLDialogElement.prototype.close = function close() {
+    this.removeAttribute("open");
+    this.dispatchEvent(new Event("close"));
+  };
+}

--- a/apps/site/src/styles.css
+++ b/apps/site/src/styles.css
@@ -41,6 +41,8 @@
   --code-ink: #f8f7f1;
   --card-shadow: 0 10px 30px rgba(48, 43, 34, 0.06);
   --shadow: 0 18px 50px rgba(48, 43, 34, 0.12);
+  --focus-ring: #0f766e;
+  --viewer-backdrop: rgba(15, 20, 16, 0.86);
   color: var(--ink);
   background: var(--bg);
 }
@@ -84,6 +86,8 @@
     --code-ink: #f7f6ef;
     --card-shadow: 0 12px 32px rgba(0, 0, 0, 0.26);
     --shadow: 0 18px 48px rgba(0, 0, 0, 0.3);
+    --focus-ring: #79d5b0;
+    --viewer-backdrop: rgba(4, 7, 5, 0.9);
   }
 }
 
@@ -528,22 +532,80 @@ h3 {
 }
 
 .media-card {
+  position: relative;
   overflow: hidden;
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.media-card:hover {
+  border-color: var(--green);
+  box-shadow: var(--shadow);
+  transform: translateY(-2px);
+}
+
+.media-card__launcher {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  border: 0;
+  border-radius: 8px;
+  padding: 0;
+  background: transparent;
+  cursor: zoom-in;
+}
+
+.media-card__launcher:focus-visible {
+  outline: 3px solid var(--focus-ring);
+  outline-offset: -4px;
 }
 
 .media-card__asset {
   display: grid;
   place-items: center;
+  position: relative;
   aspect-ratio: 16 / 10;
   background: var(--media-asset-bg);
+  overflow: hidden;
 }
 
-.media-card__asset img,
-.media-card__asset video {
+.media-card__asset img {
   display: block;
   inline-size: 100%;
   block-size: 100%;
   object-fit: contain;
+  transition: transform 180ms ease;
+}
+
+.media-card:hover .media-card__asset img {
+  transform: scale(1.012);
+}
+
+.media-card__play {
+  position: absolute;
+  inset: 50% auto auto 50%;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-block-size: 2.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 999px;
+  padding: 0.65rem 0.9rem;
+  color: #ffffff;
+  background: rgba(15, 20, 16, 0.82);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+  font-size: 0.86rem;
+  font-weight: 900;
+  transform: translate(-50%, -50%);
+  backdrop-filter: blur(8px);
+}
+
+.media-card__play svg {
+  inline-size: 1rem;
+  block-size: 1rem;
+  fill: currentColor;
 }
 
 .media-card__copy {
@@ -565,12 +627,156 @@ h3 {
   color: var(--gold);
 }
 
-.media-fallback pre {
-  overflow-x: auto;
+.media-fallback__links {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.media-loading {
+  min-block-size: 12rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--line);
   border-radius: 8px;
-  padding: 0.85rem;
-  background: var(--code-bg);
-  color: var(--code-ink);
+  color: var(--muted);
+  background: var(--panel);
+}
+
+.media-viewer {
+  position: fixed;
+  inset: 0;
+  inline-size: 100%;
+  max-inline-size: none;
+  block-size: 100%;
+  max-block-size: none;
+  margin: 0;
+  border: 0;
+  padding: clamp(0.5rem, 2.5vw, 2rem);
+  color: var(--ink);
+  background: transparent;
+}
+
+.media-viewer[open] {
+  display: grid;
+  place-items: center;
+}
+
+.media-viewer::backdrop {
+  background: var(--viewer-backdrop);
+}
+
+.media-viewer__panel {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  inline-size: min(100%, 88rem);
+  max-block-size: calc(100dvh - clamp(1rem, 5vw, 4rem));
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--panel);
+  box-shadow: 0 30px 100px rgba(0, 0, 0, 0.52);
+}
+
+.media-viewer__header {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem;
+  border-block-end: 1px solid var(--line);
+}
+
+.media-viewer__header > div {
+  min-inline-size: 0;
+}
+
+.media-viewer__header h2 {
+  margin: 0.45rem 0 0;
+  overflow: hidden;
+  font-size: clamp(1.25rem, 3vw, 2rem);
+  line-height: 1.1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.media-viewer__counter {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 900;
+  white-space: nowrap;
+}
+
+.media-viewer__close,
+.media-viewer__footer button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  min-block-size: 2.75rem;
+  border: 1px solid var(--button-border);
+  border-radius: 8px;
+  padding: 0.65rem 0.8rem;
+  color: var(--button-ink);
+  background: var(--button-bg);
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.media-viewer__close {
+  inline-size: 2.75rem;
+  padding: 0;
+}
+
+.media-viewer__close:hover,
+.media-viewer__footer button:hover {
+  border-color: var(--green);
+  background: var(--nav-hover);
+}
+
+.media-viewer__close:focus-visible,
+.media-viewer__footer button:focus-visible {
+  outline: 3px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.media-viewer__close svg,
+.media-viewer__footer svg {
+  inline-size: 1.15rem;
+  block-size: 1.15rem;
+}
+
+.media-viewer__stage {
+  display: grid;
+  place-items: center;
+  min-block-size: 0;
+  overflow: hidden;
+  background: var(--media-asset-bg);
+}
+
+.media-viewer__stage img,
+.media-viewer__stage video {
+  display: block;
+  inline-size: 100%;
+  block-size: 100%;
+  max-block-size: calc(100dvh - 13rem);
+  object-fit: contain;
+}
+
+.media-viewer__footer {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.85rem 1rem;
+  border-block-start: 1px solid var(--line);
+}
+
+.media-viewer__footer p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.45;
+  text-align: center;
 }
 
 .section--split {
@@ -714,5 +920,71 @@ h3 {
 
   .media-fallback {
     grid-template-columns: 1fr;
+  }
+
+  .media-viewer {
+    padding: 0.35rem;
+  }
+
+  .media-viewer__panel {
+    max-block-size: calc(100dvh - 0.7rem);
+  }
+
+  .media-viewer__header {
+    grid-template-columns: 1fr auto;
+    gap: 0.65rem;
+    padding: 0.75rem;
+  }
+
+  .media-viewer__counter {
+    grid-column: 1 / -1;
+    grid-row: 1;
+  }
+
+  .media-viewer__header > div {
+    grid-column: 1;
+    grid-row: 2;
+  }
+
+  .media-viewer__close {
+    grid-column: 2;
+    grid-row: 2;
+  }
+
+  .media-viewer__stage img,
+  .media-viewer__stage video {
+    max-block-size: calc(100dvh - 14.5rem);
+  }
+
+  .media-viewer__footer {
+    grid-template-columns: 1fr 1fr;
+    gap: 0.6rem;
+    padding: 0.75rem;
+  }
+
+  .media-viewer__footer p {
+    grid-column: 1 / -1;
+    grid-row: 1;
+    text-align: start;
+  }
+
+  .media-viewer__footer button {
+    inline-size: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .media-card,
+  .media-card__asset img {
+    transition: none;
+  }
+
+  .media-card:hover,
+  .media-card:hover .media-card__asset img {
+    transform: none;
   }
 }

--- a/apps/site/vite.config.ts
+++ b/apps/site/vite.config.ts
@@ -1,7 +1,11 @@
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   base: "./",
   plugins: [react()],
+  test: {
+    environment: "jsdom",
+    setupFiles: "./src/setupTests.ts",
+  },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,18 @@ importers:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -139,12 +151,18 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.2
         version: 6.0.3(vite@8.1.4(@types/node@26.1.1)(jiti@2.6.1))
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       typescript:
         specifier: ~7.0.2
         version: 7.0.2
       vite:
         specifier: ^8.1.4
         version: 8.1.4(@types/node@26.1.1)(jiti@2.6.1)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@8.1.4(@types/node@26.1.1)(jiti@2.6.1))
 
   packages/shared-types:
     devDependencies:

--- a/scripts/capture-release-media.mjs
+++ b/scripts/capture-release-media.mjs
@@ -14,50 +14,114 @@ const repoRoot = fileURLToPath(new URL("../", import.meta.url));
 const defaultOutputDir = resolve(repoRoot, "apps/site/public/media/generated");
 const fixtureTimestamp = "2026-04-18T13:16:00.000Z";
 const childTailLines = 40;
-const capturePlan = [
+const releaseMediaCaptureCatalog = [
   {
     id: "library",
+    enabled: true,
     kind: "screenshot",
     fileName: "library.png",
     title: "Library with practice projects",
+    caption: "A local practice library with analysis-ready projects.",
+    alt: "TuneForge library showing three synthetic practice projects",
+    fixture: "release-showcase-v1",
     route: "/",
+    prepare: noPreparation,
+    ready: readyLibrary,
+    capture: captureScreenshotEntry,
   },
   {
     id: "playback",
+    enabled: true,
     kind: "screenshot",
     fileName: "playback.png",
     title: "Playback workspace with lyrics and chords follow",
+    caption: "Playback keeps synthetic lyrics and chords in view while the song moves.",
+    alt: "TuneForge playback workspace following lyrics and chords for Midnight Count-In",
+    fixture: "release-showcase-v1",
     route: "/projects/proj_release_showcase",
+    prepare: preparePlayback,
+    ready: readyPlayback,
+    capture: captureScreenshotEntry,
   },
   {
     id: "tuner",
+    enabled: true,
     kind: "screenshot",
     fileName: "tuner.png",
     title: "Chromatic tuner, slightly sharp",
+    caption: "The chromatic tuner reading a deterministic 442 Hz synthetic tone.",
+    alt: "TuneForge chromatic tuner showing an A at 442 hertz, slightly sharp",
+    fixture: "release-showcase-v1",
     route: "/tools",
+    prepare: prepareTuner,
+    ready: readyTuner,
+    capture: captureScreenshotEntry,
   },
   {
     id: "chord-dictionary",
+    enabled: true,
     kind: "screenshot",
     fileName: "chord-dictionary.png",
     title: "Chord dictionary reference screen",
+    caption: "A built-in chord reference for quick practice checks.",
+    alt: "TuneForge chord dictionary reference screen",
+    fixture: "release-showcase-v1",
     route: "/tools?tool=chord-dictionary",
+    prepare: noPreparation,
+    ready: readyChordDictionary,
+    capture: captureScreenshotEntry,
   },
   {
     id: "jobs",
+    enabled: true,
     kind: "screenshot",
     fileName: "jobs.png",
     title: "Activity jobs screen",
+    caption: "Completed local analysis jobs for the synthetic release project.",
+    alt: "TuneForge activity screen showing completed synthetic analysis jobs",
+    fixture: "release-showcase-v1",
     route: "/activity",
+    prepare: noPreparation,
+    ready: readyJobs,
+    capture: captureScreenshotEntry,
   },
   {
     id: "settings",
+    enabled: true,
     kind: "screenshot",
     fileName: "settings.png",
     title: "Settings screen",
+    caption: "Local processing and practice preferences in the TuneForge control room.",
+    alt: "TuneForge settings control room",
+    fixture: "release-showcase-v1",
     route: "/settings",
+    prepare: noPreparation,
+    ready: readySettings,
+    capture: captureScreenshotEntry,
+  },
+  {
+    id: "overview-video",
+    enabled: true,
+    kind: "video",
+    fileName: "overview.webm",
+    title: "Release media capture overview",
+    caption: "A short, silent walkthrough of current TuneForge screens.",
+    fixture: "release-showcase-v1",
+    route: "/",
+    posterId: "library",
+    recordingItemIds: [
+      "library",
+      "playback",
+      "tuner",
+      "chord-dictionary",
+      "jobs",
+      "settings",
+    ],
+    record: recordOverviewVideo,
   },
 ];
+
+validateReleaseMediaCatalog(releaseMediaCaptureCatalog);
 
 if (isDirectRun()) {
   try {
@@ -197,16 +261,16 @@ Usage:
   node scripts/capture-release-media.mjs --manifest-only
 
 Options:
-  --run                  Capture screenshots and an overview video.
+  --run                  Capture every enabled release-media catalog entry.
   --app-url=<url>        Use an already running desktop Vite app. Defaults to starting one.
   --output-dir=<path>    Output directory. Defaults to apps/site/public/media/generated.
   --viewport=1920x980    Browser viewport for deterministic screenshots.
   --theme=<mode>         Theme to capture: dark, light, or system. Defaults to dark.
   --headed               Show the browser while capturing.
-  --no-video             Skip overview WebM recording.
+  --no-video             Intentionally capture screenshots only.
   --timeout-ms=<ms>      Startup and selector timeout. Defaults to 45000.
   --video-hold-ms=<ms>   Hold each captured screen in the overview video. Defaults to 1800.
-  --allow-partial        Write a partial manifest without failing when screenshots miss.
+  --allow-partial        Write a partial manifest without failing when media items miss.
   --manifest-only        Write a placeholder manifest without media files.
   --dry-run              Print planned outputs without writing files.
 
@@ -217,11 +281,8 @@ Notes:
 
 function printPlan(options) {
   console.log("[capture-release-media] Dry run. Planned outputs:");
-  for (const item of capturePlan) {
+  for (const item of expectedCatalogEntries(releaseMediaCaptureCatalog, options)) {
     console.log(`- ${join(options.outputDir, item.fileName)} (${item.title})`);
-  }
-  if (options.recordVideo) {
-    console.log(`- ${join(options.outputDir, "overview.webm")} (browser-recorded overview)`);
   }
   console.log(`- ${join(options.outputDir, "manifest.json")} (capture manifest)`);
 }
@@ -249,71 +310,63 @@ async function captureReleaseMedia(options) {
     }
 
     const browser = await chromium.launch({ headless: !options.headed });
-    const context = await browser.newContext({
-      colorScheme: options.theme === "light" ? "light" : "dark",
-      deviceScaleFactor: 1,
-      reducedMotion: "reduce",
-      recordVideo: options.recordVideo
-        ? { dir: options.outputDir, size: options.viewport }
-        : undefined,
-      viewport: options.viewport,
-    });
-    await context.route("**/*", async (route) => {
-      const handled = await maybeFulfillMockApi(route);
-      if (!handled) {
-        await route.continue();
+    try {
+      const screenshots = expectedCatalogEntries(releaseMediaCaptureCatalog, options)
+        .filter((item) => item.kind === "screenshot");
+      const screenshotItems = await captureCatalogScreenshots({
+        appUrl,
+        browser,
+        catalog: releaseMediaCaptureCatalog,
+        entries: screenshots,
+        notes,
+        options,
+      });
+      capturedItems.push(...screenshotItems);
+
+      const videos = expectedCatalogEntries(releaseMediaCaptureCatalog, options)
+        .filter((item) => item.kind === "video");
+      for (const entry of videos) {
+        try {
+          const item = await captureCatalogVideo({
+            appUrl,
+            browser,
+            catalog: releaseMediaCaptureCatalog,
+            entry,
+            options,
+          });
+          capturedItems.push(item);
+        } catch (error) {
+          const message = errorMessage(error);
+          notes.push(`${entry.id} capture skipped: ${message}`);
+          console.warn(`[capture-release-media] ${entry.id} skipped: ${message}`);
+        }
       }
-    });
-
-    const page = await context.newPage();
-    await installPageStabilizers(page, options);
-
-    for (const item of capturePlan) {
-      try {
-        await captureScreenshot(page, appUrl, item, options);
-        capturedItems.push(mediaItemForPlanItem(item));
-      } catch (error) {
-        notes.push(`${item.id} capture skipped: ${errorMessage(error)}`);
-        console.warn(`[capture-release-media] ${item.id} skipped: ${errorMessage(error)}`);
-      }
-    }
-
-    const video = options.recordVideo ? page.video() : null;
-
-    await context.close();
-    await browser.close();
-
-    const videoItem = video ? await saveOverviewVideo(video, options.outputDir) : null;
-    if (videoItem) {
-      capturedItems.push(videoItem);
+    } finally {
+      await browser.close();
     }
   } finally {
     await stopChildren(children);
   }
 
-  const missingRequiredScreenshots = requiredScreenshotIds().filter((id) =>
-    !capturedItems.some((item) => item.id === id),
+  const accounting = captureAccounting(
+    releaseMediaCaptureCatalog,
+    capturedItems,
+    options,
   );
-  if (missingRequiredScreenshots.length) {
-    notes.push(`Required screenshots missing: ${missingRequiredScreenshots.join(", ")}.`);
+  if (accounting.missingIds.length) {
+    notes.push(`Required media missing: ${accounting.missingIds.join(", ")}.`);
   }
 
-  const status = capturedItems.length === capturePlan.length + (options.recordVideo ? 1 : 0)
-      ? "captured"
-      : capturedItems.length
-        ? "partial"
-        : "pending";
-
   await writeManifest(options.outputDir, {
-    status,
+    status: accounting.status,
     items: capturedItems,
     notes,
   });
   console.log(`[capture-release-media] Wrote ${capturedItems.length} media item(s) to ${options.outputDir}.`);
 
-  if (!options.allowPartial && missingRequiredScreenshots.length) {
+  if (!options.allowPartial && accounting.missingIds.length) {
     throw new Error(
-      `Required screenshot capture failed: ${missingRequiredScreenshots.join(", ")}. ` +
+      `Required media capture failed: ${accounting.missingIds.join(", ")}. ` +
         "Manifest was written for debugging; rerun with --allow-partial to keep exit 0.",
     );
   }
@@ -449,8 +502,9 @@ async function waitForHttp(url, { child, timeoutMs }) {
   throw new Error(`Timed out waiting for ${url}: ${errorMessage(lastError)}\n${child.tail()}`);
 }
 
-async function installPageStabilizers(page, options) {
-  await page.addInitScript(({ theme }) => {
+async function installPageStabilizers(page, options, captureKind) {
+  const motionPolicy = captureMotionPolicy(captureKind);
+  await page.addInitScript(({ animatePlayback, theme }) => {
     const fixedNow = Date.parse("2026-04-18T13:16:00.000Z");
     let callbackId = 1;
     const callbacks = new Map();
@@ -601,6 +655,10 @@ async function installPageStabilizers(page, options) {
         window.clearInterval(playbackPositionTimer);
       }
       emitPlaybackPosition();
+      if (!animatePlayback) {
+        playbackPositionTimer = null;
+        return;
+      }
       playbackPositionTimer = window.setInterval(() => {
         const nextPosition = Math.min(
           playbackSnapshot.durationSeconds,
@@ -898,96 +956,303 @@ async function installPageStabilizers(page, options) {
         }
       },
     };
-  }, { theme: options.theme });
+  }, { animatePlayback: motionPolicy.animatePlayback, theme: options.theme });
 }
 
-async function captureScreenshot(page, appUrl, item, options) {
-  await page.goto(`${appUrl}/#${item.route}`, { waitUntil: "domcontentloaded" });
-  await page.waitForLoadState("networkidle", { timeout: options.timeoutMs });
-  await waitForRouteContent(page, item, options.timeoutMs);
+function captureMotionPolicy(captureKind) {
+  if (captureKind !== "screenshot" && captureKind !== "video") {
+    throw new Error(`Unsupported capture kind ${captureKind}.`);
+  }
+  return { animatePlayback: captureKind === "video" };
+}
+
+async function createCaptureContext(browser, options, { recordVideo = false } = {}) {
+  const context = await browser.newContext({
+    colorScheme: options.theme === "light" ? "light" : "dark",
+    deviceScaleFactor: 1,
+    reducedMotion: "reduce",
+    recordVideo: recordVideo
+      ? { dir: options.outputDir, size: options.viewport }
+      : undefined,
+    viewport: options.viewport,
+  });
+  await context.route("**/*", async (route) => {
+    const handled = await maybeFulfillMockApi(route);
+    if (!handled) {
+      await route.continue();
+    }
+  });
+  return context;
+}
+
+async function captureCatalogScreenshots({ appUrl, browser, catalog, entries, notes, options }) {
+  if (!entries.length) {
+    return [];
+  }
+
+  const capturedItems = [];
+  const context = await createCaptureContext(browser, options);
+  try {
+    const page = await context.newPage();
+    await installPageStabilizers(page, options, "screenshot");
+    for (const entry of entries) {
+      try {
+        await entry.capture({ appUrl, entry, options, page });
+        capturedItems.push(manifestItemForCatalogEntry(entry, catalog));
+      } catch (error) {
+        const message = errorMessage(error);
+        notes.push(`${entry.id} capture skipped: ${message}`);
+        console.warn(`[capture-release-media] ${entry.id} skipped: ${message}`);
+      }
+    }
+  } finally {
+    await context.close();
+  }
+  return capturedItems;
+}
+
+async function captureScreenshotEntry({ appUrl, entry, options, page }) {
+  await prepareCatalogEntry(page, appUrl, entry, options.timeoutMs, "screenshot");
+  await settleScreenshotPaint(page);
   await page.screenshot({
     animations: "disabled",
     fullPage: false,
-    path: join(options.outputDir, item.fileName),
+    path: join(options.outputDir, entry.fileName),
   });
-  if (options.recordVideo && options.videoHoldMs > 0) {
-    await sleep(options.videoHoldMs);
+}
+
+async function settleScreenshotPaint(page) {
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+    await new Promise((resolveFrame) => {
+      window.requestAnimationFrame(() => window.requestAnimationFrame(resolveFrame));
+    });
+  });
+}
+
+async function captureCatalogVideo({ appUrl, browser, catalog, entry, options }) {
+  const context = await createCaptureContext(browser, options, { recordVideo: true });
+  let video = null;
+  try {
+    const page = await context.newPage();
+    await installPageStabilizers(page, options, "video");
+    video = page.video();
+    await entry.record({ appUrl, catalog, entry, options, page });
+  } finally {
+    await context.close();
   }
-}
 
-async function waitForRouteContent(page, item, timeoutMs) {
-  if (item.id === "library") {
-    await page.getByRole("heading", { name: "Practice Projects" }).waitFor({ timeout: timeoutMs });
-    await page.getByText(/3 projects ready/i).waitFor({ timeout: timeoutMs });
-    await page.getByRole("link", { name: /Open Midnight Count-In project/i }).waitFor({ timeout: timeoutMs });
-  } else if (item.id === "playback") {
-    await page.getByRole("heading", { name: "Midnight Count-In" }).waitFor({ timeout: timeoutMs });
-    await page.getByRole("tab", { name: "Playback" }).waitFor({ timeout: timeoutMs });
-    await page.getByRole("heading", { name: "Lyrics + chords" }).waitFor({ timeout: timeoutMs });
-    await page.locator(".lead-sheet").waitFor({ timeout: timeoutMs });
-    await page.locator(".lead-sheet-word .lyrics-word", { hasText: /^Count$/ }).waitFor({ timeout: timeoutMs });
-    const playButton = page.getByRole("button", { name: "Play playback" });
-    if (await playButton.count()) {
-      await playButton.click();
-    }
-    await page.getByRole("button", { name: "Pause playback" }).waitFor({ timeout: timeoutMs });
-  } else if (item.id === "tuner") {
-    await page.getByRole("heading", { name: "Tools" }).waitFor({ timeout: timeoutMs });
-    await page.getByRole("tab", { name: "Chromatic Tuner" }).waitFor({ timeout: timeoutMs });
-    const startButton = page.getByRole("button", { name: "Start" });
-    if (await startButton.count()) {
-      await startButton.click();
-    }
-    await page.locator(".tuner-readout__note", { hasText: /^A$/ }).waitFor({ timeout: timeoutMs });
-    await page.getByText(/442\.00 Hz -> target 440\.00 Hz/i).waitFor({ timeout: timeoutMs });
-  } else if (item.id === "chord-dictionary") {
-    await page.getByRole("heading", { name: "Tools" }).waitFor({ timeout: timeoutMs });
-    await page.getByRole("heading", { name: "Chord Dictionary" }).waitFor({ timeout: timeoutMs });
-    await page.getByRole("tab", { name: "Chord Dictionary" }).waitFor({ timeout: timeoutMs });
-  } else if (item.id === "jobs") {
-    await page.getByRole("heading", { name: "Activity" }).waitFor({ timeout: timeoutMs });
-    await page.getByRole("tab", { name: "Jobs" }).waitFor({ timeout: timeoutMs });
-    await page.getByRole("heading", { name: "Jobs" }).waitFor({ timeout: timeoutMs });
-    await page.getByText(/Transcript ready/i).waitFor({ timeout: timeoutMs });
-  } else if (item.id === "settings") {
-    await page.getByRole("heading", { name: "Control Room" }).waitFor({ timeout: timeoutMs });
+  if (!video) {
+    throw new Error(`${entry.id} did not create a browser video.`);
   }
-}
-
-function requiredScreenshotIds() {
-  return capturePlan.filter((item) => item.kind === "screenshot").map((item) => item.id);
-}
-
-async function saveOverviewVideo(video, outputDir) {
   const videoPath = await video.path();
-  const outputPath = join(outputDir, "overview.webm");
-  await rename(videoPath, outputPath);
-  return {
-    id: "overview-video",
-    title: "Release media capture overview",
-    kind: "video",
-    src: "media/generated/overview.webm",
-    poster: "media/generated/library.png",
-    caption: "Browser-recorded walkthrough of release media screens.",
-    label: "video",
-  };
+  await rename(videoPath, join(options.outputDir, entry.fileName));
+  return manifestItemForCatalogEntry(entry, catalog);
 }
 
-function mediaItemForPlanItem(item) {
+async function prepareCatalogEntry(page, appUrl, entry, timeoutMs, captureKind) {
+  await page.goto(`${appUrl}/#${entry.route}`, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: timeoutMs });
+  await entry.prepare({ captureKind, page, timeoutMs });
+  await entry.ready({ captureKind, page, timeoutMs });
+}
+
+async function noPreparation() {}
+
+async function preparePlayback({ captureKind, page, timeoutMs }) {
+  if (captureKind === "screenshot") {
+    return;
+  }
+  const playButton = page.getByRole("button", { name: "Play playback" });
+  await playButton.waitFor({ timeout: timeoutMs });
+  await playButton.click();
+}
+
+async function prepareTuner({ page, timeoutMs }) {
+  const startButton = page.getByRole("button", { name: "Start" });
+  await startButton.waitFor({ timeout: timeoutMs });
+  await startButton.click();
+}
+
+async function readyLibrary({ page, timeoutMs }) {
+  await page.getByRole("heading", { name: "Practice Projects" }).waitFor({ timeout: timeoutMs });
+  await page.getByText(/3 projects ready/i).waitFor({ timeout: timeoutMs });
+  await page.getByRole("link", { name: /Open Midnight Count-In project/i })
+    .waitFor({ timeout: timeoutMs });
+}
+
+async function readyPlayback({ captureKind, page, timeoutMs }) {
+  await page.getByRole("heading", { name: "Midnight Count-In" }).waitFor({ timeout: timeoutMs });
+  await page.getByRole("tab", { name: "Playback" }).waitFor({ timeout: timeoutMs });
+  await page.getByRole("heading", { name: "Lyrics + chords" }).waitFor({ timeout: timeoutMs });
+  await page.locator(".lead-sheet").waitFor({ timeout: timeoutMs });
+  await page.locator(".lead-sheet-word .lyrics-word", { hasText: /^Count$/ })
+    .waitFor({ timeout: timeoutMs });
+  if (captureKind === "screenshot") {
+    await page.getByRole("button", { name: "Play playback" }).waitFor({ timeout: timeoutMs });
+    const position = page.getByLabel("Playback position");
+    await position.waitFor({ timeout: timeoutMs });
+    const value = Number(await position.inputValue());
+    if (value !== 0) {
+      throw new Error(`Playback screenshot must stay stopped at 0 seconds; received ${value}.`);
+    }
+  } else {
+    await page.getByRole("button", { name: "Pause playback" }).waitFor({ timeout: timeoutMs });
+  }
+}
+
+async function readyTuner({ page, timeoutMs }) {
+  await page.getByRole("heading", { name: "Tools" }).waitFor({ timeout: timeoutMs });
+  await page.getByRole("tab", { name: "Chromatic Tuner" }).waitFor({ timeout: timeoutMs });
+  await page.locator(".tuner-readout__note", { hasText: /^A$/ }).waitFor({ timeout: timeoutMs });
+  await page.getByText(/442\.00 Hz -> target 440\.00 Hz/i).waitFor({ timeout: timeoutMs });
+}
+
+async function readyChordDictionary({ page, timeoutMs }) {
+  await page.getByRole("heading", { name: "Tools" }).waitFor({ timeout: timeoutMs });
+  await page.getByRole("heading", { name: "Chord Dictionary" }).waitFor({ timeout: timeoutMs });
+  await page.getByRole("tab", { name: "Chord Dictionary" }).waitFor({ timeout: timeoutMs });
+}
+
+async function readyJobs({ page, timeoutMs }) {
+  await page.getByRole("heading", { name: "Activity" }).waitFor({ timeout: timeoutMs });
+  await page.getByRole("tab", { name: "Jobs" }).waitFor({ timeout: timeoutMs });
+  await page.getByRole("heading", { name: "Jobs" }).waitFor({ timeout: timeoutMs });
+  await page.getByText(/Transcript ready/i).waitFor({ timeout: timeoutMs });
+}
+
+async function readySettings({ page, timeoutMs }) {
+  await page.getByRole("heading", { name: "Control Room" }).waitFor({ timeout: timeoutMs });
+}
+
+async function recordOverviewVideo({ appUrl, catalog, entry, options, page }) {
+  for (const itemId of entry.recordingItemIds) {
+    const item = catalog.find((candidate) => candidate.id === itemId);
+    if (!item || item.kind !== "screenshot") {
+      throw new Error(`${entry.id} references unavailable recording item ${itemId}.`);
+    }
+    await prepareCatalogEntry(page, appUrl, item, options.timeoutMs, "video");
+    if (options.videoHoldMs > 0) {
+      await sleep(options.videoHoldMs);
+    }
+  }
+}
+
+function validateReleaseMediaCatalog(catalog) {
+  if (!Array.isArray(catalog) || catalog.length === 0) {
+    throw new Error("Release-media capture catalog must contain at least one entry.");
+  }
+
+  const ids = new Set();
+  const fileNames = new Set();
+  for (const entry of catalog) {
+    for (const field of ["id", "fileName", "title", "caption", "fixture", "route"]) {
+      if (typeof entry[field] !== "string" || !entry[field].trim()) {
+        throw new Error(`Release-media entry ${entry.id ?? "<unknown>"} requires ${field}.`);
+      }
+    }
+    if (entry.enabled !== true && entry.enabled !== false) {
+      throw new Error(`Release-media entry ${entry.id} requires a boolean enabled value.`);
+    }
+    if (ids.has(entry.id)) {
+      throw new Error(`Release-media capture catalog has duplicate id ${entry.id}.`);
+    }
+    if (fileNames.has(entry.fileName)) {
+      throw new Error(`Release-media capture catalog has duplicate file ${entry.fileName}.`);
+    }
+    ids.add(entry.id);
+    fileNames.add(entry.fileName);
+
+    if (entry.kind === "screenshot") {
+      if (typeof entry.alt !== "string" || !entry.alt.trim()) {
+        throw new Error(`Screenshot ${entry.id} requires alt text.`);
+      }
+      for (const callback of ["prepare", "ready", "capture"]) {
+        if (typeof entry[callback] !== "function") {
+          throw new Error(`Screenshot ${entry.id} requires a ${callback} callback.`);
+        }
+      }
+    } else if (entry.kind === "video") {
+      if (typeof entry.posterId !== "string" || !entry.posterId.trim()) {
+        throw new Error(`Video ${entry.id} requires posterId.`);
+      }
+      if (typeof entry.record !== "function") {
+        throw new Error(`Video ${entry.id} requires a record callback.`);
+      }
+    } else {
+      throw new Error(`Release-media entry ${entry.id} has unsupported kind ${entry.kind}.`);
+    }
+  }
+
+  for (const entry of catalog.filter((candidate) => candidate.kind === "video")) {
+    const poster = catalog.find((candidate) => candidate.id === entry.posterId);
+    if (!poster || poster.kind !== "screenshot" || !poster.enabled) {
+      throw new Error(`Video ${entry.id} requires an enabled screenshot poster.`);
+    }
+    if (entry.recordingItemIds !== undefined) {
+      if (!Array.isArray(entry.recordingItemIds) || entry.recordingItemIds.length === 0) {
+        throw new Error(`Video ${entry.id} recordingItemIds must be a non-empty array.`);
+      }
+      for (const itemId of entry.recordingItemIds) {
+        const item = catalog.find((candidate) => candidate.id === itemId);
+        if (!item || item.kind !== "screenshot" || !item.enabled) {
+          throw new Error(`Video ${entry.id} references invalid recording item ${itemId}.`);
+        }
+      }
+    }
+  }
+
+  return catalog;
+}
+
+function manifestItemForCatalogEntry(entry, catalog = releaseMediaCaptureCatalog) {
+  const item = {
+    id: entry.id,
+    title: entry.title,
+    kind: entry.kind,
+    src: `media/generated/${entry.fileName}`,
+  };
+  if (entry.kind === "screenshot") {
+    item.alt = entry.alt;
+  } else {
+    const poster = catalog.find((candidate) => candidate.id === entry.posterId);
+    if (!poster) {
+      throw new Error(`${entry.id} references unknown poster ${entry.posterId}.`);
+    }
+    item.poster = `media/generated/${poster.fileName}`;
+  }
+  item.caption = entry.caption;
+  item.label = entry.kind;
+  return item;
+}
+
+function expectedCatalogEntries(catalog = releaseMediaCaptureCatalog, { recordVideo = true } = {}) {
+  return catalog.filter((entry) => entry.enabled && (recordVideo || entry.kind !== "video"));
+}
+
+function captureAccounting(catalog, capturedItems, options = {}) {
+  const expectedIds = expectedCatalogEntries(catalog, options).map((entry) => entry.id);
+  const capturedIds = new Set(capturedItems.map((item) => item.id));
+  const missingIds = expectedIds.filter((id) => !capturedIds.has(id));
   return {
-    id: item.id,
-    title: item.title,
-    kind: item.kind,
-    src: `media/generated/${item.fileName}`,
-    alt: item.title,
-    caption: "Captured from the current TuneForge UI.",
-    label: "screenshot",
+    expectedIds,
+    missingIds,
+    status: missingIds.length === 0
+      ? "captured"
+      : capturedIds.size > 0
+        ? "partial"
+        : "pending",
   };
 }
 
 async function writeManifest(outputDir, { status, items, notes }) {
   await mkdir(outputDir, { recursive: true });
-  const manifest = {
+  const manifest = buildManifest({ status, items, notes });
+  await writeFile(join(outputDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+}
+
+function buildManifest({ status, items, notes }) {
+  return {
     schemaVersion: 1,
     status,
     generatedAt: generatedAt(),
@@ -996,7 +1261,6 @@ async function writeManifest(outputDir, { status, items, notes }) {
     items,
     notes,
   };
-  await writeFile(join(outputDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
 }
 
 function generatedAt() {
@@ -1396,6 +1660,25 @@ function chordBackends() {
       label: "Built-in Chords",
       unavailable_reason: null,
     },
+    {
+      availability: "available",
+      available: true,
+      capabilities: {
+        desktopOnly: true,
+        estimatedSpeed: "slow",
+        experimental: true,
+        supportsConfidence: true,
+        supportsInversions: true,
+        supportsNoChord: true,
+        supportsSevenths: true,
+      },
+      description: "Optional crema chord detector with richer chord vocabulary and inversion estimates.",
+      desktopOnly: true,
+      experimental: true,
+      id: "crema-advanced",
+      label: "Advanced Chords",
+      unavailable_reason: null,
+    },
   ];
 }
 
@@ -1490,3 +1773,15 @@ function sleep(ms) {
 function errorMessage(error) {
   return error instanceof Error && error.message ? error.message : String(error);
 }
+
+export {
+  buildManifest,
+  captureAccounting,
+  captureMotionPolicy,
+  chordBackends,
+  expectedCatalogEntries,
+  manifestItemForCatalogEntry,
+  parseOptions,
+  releaseMediaCaptureCatalog,
+  validateReleaseMediaCatalog,
+};

--- a/scripts/capture-release-media.test.mjs
+++ b/scripts/capture-release-media.test.mjs
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import {
+  buildManifest,
+  captureAccounting,
+  captureMotionPolicy,
+  chordBackends,
+  expectedCatalogEntries,
+  manifestItemForCatalogEntry,
+  parseOptions,
+  releaseMediaCaptureCatalog,
+  validateReleaseMediaCatalog,
+} from "./capture-release-media.mjs";
+
+test("settings fixture exposes the available default advanced chord backend", () => {
+  const backends = chordBackends();
+  const advanced = backends.find((backend) => backend.id === "crema-advanced");
+
+  assert.equal(advanced?.available, true);
+  assert.equal(advanced?.availability, "available");
+  assert.equal(advanced?.label, "Advanced Chords");
+  assert.equal(advanced?.unavailable_reason, null);
+  assert.equal(advanced?.capabilities.supportsInversions, true);
+});
+
+test("capture motion policy freezes screenshots and preserves video movement", () => {
+  assert.deepEqual(captureMotionPolicy("screenshot"), { animatePlayback: false });
+  assert.deepEqual(captureMotionPolicy("video"), { animatePlayback: true });
+  assert.throws(() => captureMotionPolicy("unknown"), /Unsupported capture kind unknown/);
+});
+
+test("release-media catalog has unique identifiers, files, and required callbacks", () => {
+  assert.equal(validateReleaseMediaCatalog(releaseMediaCaptureCatalog), releaseMediaCaptureCatalog);
+  assert.equal(releaseMediaCaptureCatalog.length, 7);
+  assert.equal(releaseMediaCaptureCatalog.filter((entry) => entry.kind === "screenshot").length, 6);
+  assert.equal(releaseMediaCaptureCatalog.filter((entry) => entry.kind === "video").length, 1);
+
+  const ids = releaseMediaCaptureCatalog.map((entry) => entry.id);
+  const files = releaseMediaCaptureCatalog.map((entry) => entry.fileName);
+  assert.equal(new Set(ids).size, ids.length);
+  assert.equal(new Set(files).size, files.length);
+
+  for (const entry of releaseMediaCaptureCatalog) {
+    assert.equal(entry.enabled, true);
+    assert.ok(entry.title);
+    assert.ok(entry.caption);
+    assert.ok(entry.fixture);
+    assert.ok(entry.route);
+    if (entry.kind === "screenshot") {
+      assert.ok(entry.alt);
+      assert.equal(typeof entry.prepare, "function");
+      assert.equal(typeof entry.ready, "function");
+      assert.equal(typeof entry.capture, "function");
+    } else {
+      assert.ok(entry.posterId);
+      assert.equal(typeof entry.record, "function");
+    }
+  }
+});
+
+test("catalog validation rejects duplicate identifiers and output files", () => {
+  const duplicateId = cloneCatalog();
+  duplicateId[1].id = duplicateId[0].id;
+  assert.throws(() => validateReleaseMediaCatalog(duplicateId), /duplicate id library/);
+
+  const duplicateFile = cloneCatalog();
+  duplicateFile[1].fileName = duplicateFile[0].fileName;
+  assert.throws(() => validateReleaseMediaCatalog(duplicateFile), /duplicate file library\.png/);
+});
+
+test("video poster references resolve to enabled screenshots", () => {
+  const video = releaseMediaCaptureCatalog.find((entry) => entry.kind === "video");
+  const poster = releaseMediaCaptureCatalog.find((entry) => entry.id === video.posterId);
+  assert.equal(poster.kind, "screenshot");
+  assert.equal(poster.enabled, true);
+  assert.equal(
+    manifestItemForCatalogEntry(video).poster,
+    `media/generated/${poster.fileName}`,
+  );
+
+  const invalidPoster = cloneCatalog();
+  invalidPoster.find((entry) => entry.kind === "video").posterId = "missing-poster";
+  assert.throws(
+    () => validateReleaseMediaCatalog(invalidPoster),
+    /requires an enabled screenshot poster/,
+  );
+});
+
+test("capture accounting requires every enabled item unless video is intentionally disabled", () => {
+  const screenshots = expectedCatalogEntries(releaseMediaCaptureCatalog, { recordVideo: false });
+  const screenshotItems = screenshots.map((entry) => manifestItemForCatalogEntry(entry));
+
+  assert.deepEqual(captureAccounting(releaseMediaCaptureCatalog, screenshotItems, {
+    recordVideo: false,
+  }), {
+    expectedIds: screenshots.map((entry) => entry.id),
+    missingIds: [],
+    status: "captured",
+  });
+
+  const videoEnabled = captureAccounting(releaseMediaCaptureCatalog, screenshotItems, {
+    recordVideo: true,
+  });
+  assert.deepEqual(videoEnabled.missingIds, ["overview-video"]);
+  assert.equal(videoEnabled.status, "partial");
+
+  const oneDisabled = cloneCatalog();
+  oneDisabled.find((entry) => entry.id === "library").enabled = false;
+  assert.equal(
+    expectedCatalogEntries(oneDisabled, { recordVideo: false })
+      .some((entry) => entry.id === "library"),
+    false,
+  );
+
+  const allItems = releaseMediaCaptureCatalog.map((entry) => manifestItemForCatalogEntry(entry));
+  assert.deepEqual(
+    captureAccounting(releaseMediaCaptureCatalog, allItems, { recordVideo: true }).missingIds,
+    [],
+  );
+  assert.equal(
+    captureAccounting(releaseMediaCaptureCatalog, [], { recordVideo: true }).status,
+    "pending",
+  );
+});
+
+test("catalog entries map to the existing manifest version 1 wire format", () => {
+  const screenshot = releaseMediaCaptureCatalog.find((entry) => entry.id === "library");
+  const video = releaseMediaCaptureCatalog.find((entry) => entry.id === "overview-video");
+  assert.deepEqual(manifestItemForCatalogEntry(screenshot), {
+    id: screenshot.id,
+    title: screenshot.title,
+    kind: "screenshot",
+    src: "media/generated/library.png",
+    alt: screenshot.alt,
+    caption: screenshot.caption,
+    label: "screenshot",
+  });
+  assert.deepEqual(manifestItemForCatalogEntry(video), {
+    id: video.id,
+    title: video.title,
+    kind: "video",
+    src: "media/generated/overview.webm",
+    poster: "media/generated/library.png",
+    caption: video.caption,
+    label: "video",
+  });
+
+  const manifest = buildManifest({
+    status: "captured",
+    items: [manifestItemForCatalogEntry(screenshot), manifestItemForCatalogEntry(video)],
+    notes: ["Synthetic fixture."],
+  });
+  assert.equal(manifest.schemaVersion, 1);
+  assert.equal(manifest.status, "captured");
+  assert.equal(manifest.fixtureTimestamp, "2026-04-18T13:16:00.000Z");
+  assert.equal(manifest.items.length, 2);
+});
+
+test("capture flags distinguish partial acceptance from intentional screenshot-only mode", () => {
+  const options = parseOptions(["--run", "--allow-partial", "--no-video"]);
+  assert.equal(options.run, true);
+  assert.equal(options.allowPartial, true);
+  assert.equal(options.recordVideo, false);
+});
+
+test("importing capture script has no capture or console side effects", () => {
+  const scriptUrl = new URL("./capture-release-media.mjs", import.meta.url);
+  const result = spawnSync(
+    process.execPath,
+    ["--input-type=module", "--eval", `await import(${JSON.stringify(scriptUrl.href)})`],
+    { encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "");
+  assert.equal(result.stderr, "");
+});
+
+function cloneCatalog() {
+  return releaseMediaCaptureCatalog.map((entry) => ({
+    ...entry,
+    recordingItemIds: entry.recordingItemIds ? [...entry.recordingItemIds] : undefined,
+  }));
+}


### PR DESCRIPTION
## Summary

- add an accessible image and video gallery with keyboard, touch, focus restoration, and safe video controls
- introduce a deterministic release-media capture catalog with isolated video recording and manifest v1 compatibility
- keep Pages media current from main, add catalog and gallery CI coverage, and document maintenance rules
- isolate backend pytest collection in disposable storage so validation cannot mutate user app data

## Testing

- `node --test scripts/capture-release-media.test.mjs`
- `pnpm --filter @tuneforge/site test`
- `pnpm --filter @tuneforge/site typecheck`
- `pnpm --filter @tuneforge/site build`
- `node scripts/capture-release-media.mjs --run`
- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `cd apps/backend && uv run --python 3.11 pytest`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `actionlint .github/workflows/ci.yml .github/workflows/pages.yml`
- Codex in-app Browser QA for desktop and mobile gallery interactions
- verified the installed app database retained zero pytest projects after the full test suite
