### PR TITLE
fix: reconcile backend project storage

### DIFF
--- a/apps/backend/app/db.py
+++ b/apps/backend/app/db.py
@@ -71,6 +71,31 @@ SessionLocal = sessionmaker(autoflush=False, expire_on_commit=False, class_=Sess
 SessionLocal.configure(bind=_engine)
 
 
+@event.listens_for(Session, "before_commit")
+def _prepare_project_storage_reconciliations(session: Session) -> None:
+    if session.get_nested_transaction() is not None:
+        return
+    from app.services.project_storage import prepare_project_storage_reconciliations
+
+    prepare_project_storage_reconciliations(session)
+
+
+@event.listens_for(Session, "after_commit")
+def _drain_project_storage_reconciliations(session: Session) -> None:
+    if session.get_nested_transaction() is not None:
+        return
+    from app.services.project_storage import drain_project_storage_reconciliations
+
+    drain_project_storage_reconciliations(session)
+
+
+@event.listens_for(Session, "after_rollback")
+def _discard_project_storage_reconciliations(session: Session) -> None:
+    from app.services.project_storage import discard_project_storage_reconciliations
+
+    discard_project_storage_reconciliations(session)
+
+
 class UnknownDatabaseRevisionError(RuntimeError):
     pass
 

--- a/apps/backend/app/services/artifacts.py
+++ b/apps/backend/app/services/artifacts.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 
 from app.errors import AppError
 from app.models import Artifact, Job
+from app.services.project_storage import queue_project_storage_reconciliation
 from app.services.stem_models import STEM_ARTIFACT_TYPES
 from app.services.sync_tombstones import record_artifact_delete_tombstone
 from app.utils.hashing import file_sha256
@@ -98,19 +99,8 @@ def prune_project_artifacts(
         Artifact.id != keep_artifact_id,
     )
     for artifact in session.scalars(stmt):
-        artifact_path = Path(artifact.path)
         session.delete(artifact)
-        if artifact_path.exists():
-            artifact_path.unlink(missing_ok=True)
-
-
-def _cleanup_artifact_path(path: Path) -> None:
-    if path.exists():
-        path.unlink(missing_ok=True)
-    try:
-        path.parent.rmdir()
-    except OSError:
-        pass
+    queue_project_storage_reconciliation(session, project_id)
 
 
 def _has_pending_audio_job(session: Session, *, project_id: str) -> bool:
@@ -146,8 +136,8 @@ def delete_project_artifact(session: Session, *, project_id: str, artifact_id: s
         )
     if artifact.type in STEM_ARTIFACT_TYPES:
         record_artifact_delete_tombstone(session, artifact)
-        _cleanup_artifact_path(Path(artifact.path))
         session.delete(artifact)
+        queue_project_storage_reconciliation(session, project_id)
         return
     if artifact.type != "preview_mix":
         raise AppError("INVALID_REQUEST", "Only saved practice mixes and stem tracks can be deleted.")
@@ -164,9 +154,8 @@ def delete_project_artifact(session: Session, *, project_id: str, artifact_id: s
 
     for stem in related_stems:
         record_artifact_delete_tombstone(session, stem)
-        _cleanup_artifact_path(Path(stem.path))
         session.delete(stem)
 
     record_artifact_delete_tombstone(session, artifact)
-    _cleanup_artifact_path(Path(artifact.path))
     session.delete(artifact)
+    queue_project_storage_reconciliation(session, project_id)

--- a/apps/backend/app/services/chords.py
+++ b/apps/backend/app/services/chords.py
@@ -92,6 +92,7 @@ def detect_project_chords(
     record_chord_revision(session, chords=existing, revision_type="generated")
 
     chord_path = project_analysis_dir(project.id) / "chords.json"
+    chord_path.parent.mkdir(parents=True, exist_ok=True)
     chord_path.write_text(
         json.dumps(
             {

--- a/apps/backend/app/services/jobs.py
+++ b/apps/backend/app/services/jobs.py
@@ -28,6 +28,7 @@ from app.services.beat_backends import beat_backend_runtime_device
 from app.services.chord_backends import chord_backend_runtime_device, resolve_chord_backend
 from app.services.chords import detect_project_chords, project_chord_detection_source
 from app.services.lyrics import generate_project_lyrics
+from app.services.project_storage import queue_project_storage_reconciliation
 from app.services.projects import get_mutable_project, get_project
 from app.services.stem_models import (
     STEM_ARTIFACT_TYPES,
@@ -831,6 +832,8 @@ class InProcessJobRunner:
                     job.runtime_device = result.runtime_device
                 self._ensure_terminal_runtime_status(job)
                 self._mark_job_finished(job)
+                if job.project_id is not None and job.type != "export":
+                    queue_project_storage_reconciliation(session, job.project_id)
                 session.commit()
         except JobCancelledError:
             self.update_job(job_id, status="cancelled", error_message=None)

--- a/apps/backend/app/services/lyrics.py
+++ b/apps/backend/app/services/lyrics.py
@@ -87,6 +87,7 @@ def _write_lyrics_snapshot(
     }
 
     lyrics_path = project_analysis_dir(project_id) / "lyrics.json"
+    lyrics_path.parent.mkdir(parents=True, exist_ok=True)
     lyrics_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
 

--- a/apps/backend/app/services/project_storage.py
+++ b/apps/backend/app/services/project_storage.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import errno
+import logging
+import os
+import stat
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.config import get_settings
+from app.models import Artifact, ChordTimeline, LyricsTranscript, Project
+from app.services.paths import project_root
+
+logger = logging.getLogger(__name__)
+
+_PENDING_PROJECT_IDS = "project_storage_pending_ids"
+_PREPARED_RECONCILIATIONS = "project_storage_prepared_reconciliations"
+_FAILED_PROJECT_IDS: set[str] = set()
+_FAILED_PROJECT_IDS_LOCK = threading.Lock()
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectStorageReconciliation:
+    project_id: str
+    data_root: Path
+    projects_root: Path
+    project_root: Path
+    owned_paths: frozenset[Path]
+    delete_project_root: bool
+
+
+class UnsafeProjectStorageError(RuntimeError):
+    pass
+
+
+def queue_project_storage_reconciliation(session: Session, project_id: str) -> None:
+    pending = session.info.setdefault(_PENDING_PROJECT_IDS, set())
+    if isinstance(pending, set):
+        pending.add(project_id)
+
+
+def prepare_project_storage_reconciliations(session: Session) -> None:
+    pending = session.info.get(_PENDING_PROJECT_IDS)
+    project_ids = pending.copy() if isinstance(pending, set) else set()
+    with _FAILED_PROJECT_IDS_LOCK:
+        project_ids.update(_FAILED_PROJECT_IDS)
+    if not project_ids:
+        return
+
+    session.flush()
+    artifact_paths = tuple(session.scalars(select(Artifact.path)))
+    plans = [
+        _build_reconciliation(session, project_id, artifact_paths=artifact_paths)
+        for project_id in sorted(project_ids)
+    ]
+    session.info[_PREPARED_RECONCILIATIONS] = plans
+
+
+def drain_project_storage_reconciliations(session: Session) -> None:
+    prepared_plans = session.info.pop(_PREPARED_RECONCILIATIONS, [])
+    session.info.pop(_PENDING_PROJECT_IDS, None)
+    plans = prepared_plans if isinstance(prepared_plans, list) else []
+    for plan in plans:
+        if not isinstance(plan, ProjectStorageReconciliation):
+            continue
+        try:
+            reconcile_project_storage(plan)
+        except (OSError, UnsafeProjectStorageError) as exc:
+            with _FAILED_PROJECT_IDS_LOCK:
+                _FAILED_PROJECT_IDS.add(plan.project_id)
+            logger.warning(
+                "Project storage cleanup deferred for %s after %s.",
+                plan.project_id,
+                type(exc).__name__,
+            )
+        else:
+            with _FAILED_PROJECT_IDS_LOCK:
+                _FAILED_PROJECT_IDS.discard(plan.project_id)
+
+
+def discard_project_storage_reconciliations(session: Session) -> None:
+    session.info.pop(_PREPARED_RECONCILIATIONS, None)
+    session.info.pop(_PENDING_PROJECT_IDS, None)
+
+
+def _build_reconciliation(
+    session: Session,
+    project_id: str,
+    *,
+    artifact_paths: tuple[str, ...],
+) -> ProjectStorageReconciliation:
+    settings = get_settings()
+    root = _lexical_absolute(project_root(project_id))
+    projects_root = _lexical_absolute(settings.projects_root)
+    data_root = _lexical_absolute(settings.data_root)
+    if _relative_path(root, projects_root) is None or _relative_path(projects_root, data_root) is None:
+        raise UnsafeProjectStorageError("Canonical project root escapes TuneForge data storage.")
+
+    project = session.get(Project, project_id)
+    delete_project_root = project is None or project.sync_status == "deleted"
+    owned_paths: set[Path] = set()
+    for artifact_path in artifact_paths:
+        relative = _relative_path(_lexical_absolute(Path(artifact_path)), root)
+        if relative is not None and relative.parts:
+            owned_paths.add(relative)
+
+    if not delete_project_root:
+        if session.get(ChordTimeline, project_id) is not None:
+            owned_paths.add(Path("analysis") / "chords.json")
+        if session.get(LyricsTranscript, project_id) is not None:
+            owned_paths.add(Path("analysis") / "lyrics.json")
+    owned_paths = _with_owned_prefixes(owned_paths)
+
+    return ProjectStorageReconciliation(
+        project_id=project_id,
+        data_root=data_root,
+        projects_root=projects_root,
+        project_root=root,
+        owned_paths=frozenset(owned_paths),
+        delete_project_root=delete_project_root,
+    )
+
+
+def reconcile_project_storage(plan: ProjectStorageReconciliation) -> None:
+    projects_root_identity = _validate_storage_roots(plan)
+    root_identity = _path_identity(plan.project_root)
+    _require_stable_directory(plan.projects_root, projects_root_identity)
+    if root_identity is None:
+        return
+
+    if stat.S_ISLNK(root_identity.st_mode):
+        _unlink_entry(
+            plan.projects_root,
+            projects_root_identity,
+            plan.project_root,
+            root_identity,
+        )
+        return
+    if not stat.S_ISDIR(root_identity.st_mode):
+        raise UnsafeProjectStorageError("Canonical project root is not a directory.")
+
+    _reconcile_directory(
+        plan.project_root,
+        root_identity,
+        relative_root=Path(),
+        owned_paths=plan.owned_paths,
+    )
+    if plan.delete_project_root:
+        _remove_directory(
+            plan.projects_root,
+            projects_root_identity,
+            plan.project_root,
+            root_identity,
+        )
+
+
+def _validate_storage_roots(plan: ProjectStorageReconciliation) -> os.stat_result:
+    if _relative_path(plan.projects_root, plan.data_root) is None:
+        raise UnsafeProjectStorageError("Projects root escapes TuneForge data storage.")
+    if _relative_path(plan.project_root, plan.projects_root) is None:
+        raise UnsafeProjectStorageError("Project root escapes TuneForge project storage.")
+
+    data_root_identity = _path_identity(plan.data_root)
+    if data_root_identity is None or not stat.S_ISDIR(data_root_identity.st_mode):
+        raise UnsafeProjectStorageError("TuneForge data root is unavailable or unsafe.")
+
+    current = plan.data_root
+    current_identity = data_root_identity
+    projects_relative = plan.projects_root.relative_to(plan.data_root)
+    for part in projects_relative.parts:
+        next_path = current / part
+        next_identity = _path_identity(next_path)
+        if next_identity is None or not stat.S_ISDIR(next_identity.st_mode):
+            raise UnsafeProjectStorageError("TuneForge projects root contains an unsafe component.")
+        _require_stable_directory(current, current_identity)
+        current = next_path
+        current_identity = next_identity
+    return current_identity
+
+
+def _reconcile_directory(
+    directory: Path,
+    directory_identity: os.stat_result,
+    *,
+    relative_root: Path,
+    owned_paths: frozenset[Path],
+) -> None:
+    _require_stable_directory(directory, directory_identity)
+    with os.scandir(directory) as iterator:
+        entries = list(iterator)
+    _require_stable_directory(directory, directory_identity)
+
+    for entry in entries:
+        child = directory / entry.name
+        relative = relative_root / entry.name
+        try:
+            child_identity = entry.stat(follow_symlinks=False)
+        except FileNotFoundError:
+            continue
+
+        if stat.S_ISDIR(child_identity.st_mode):
+            _reconcile_directory(
+                child,
+                child_identity,
+                relative_root=relative,
+                owned_paths=owned_paths,
+            )
+            if relative not in owned_paths:
+                _remove_directory(directory, directory_identity, child, child_identity, missing_ok=True)
+            continue
+
+        if relative in owned_paths:
+            continue
+        if stat.S_ISREG(child_identity.st_mode) or stat.S_ISLNK(child_identity.st_mode):
+            _unlink_entry(directory, directory_identity, child, child_identity)
+
+
+def _unlink_entry(
+    parent: Path,
+    parent_identity: os.stat_result,
+    path: Path,
+    expected_identity: os.stat_result,
+) -> None:
+    _require_stable_directory(parent, parent_identity)
+    current_identity = _path_identity(path)
+    if current_identity is None:
+        return
+    if not _same_identity(current_identity, expected_identity):
+        raise UnsafeProjectStorageError("Storage entry changed before cleanup.")
+    os.unlink(path)
+
+
+def _remove_directory(
+    parent: Path,
+    parent_identity: os.stat_result,
+    path: Path,
+    expected_identity: os.stat_result,
+    *,
+    missing_ok: bool = False,
+) -> None:
+    _require_stable_directory(parent, parent_identity)
+    current_identity = _path_identity(path)
+    if current_identity is None:
+        if missing_ok:
+            return
+        raise UnsafeProjectStorageError("Storage directory disappeared before cleanup.")
+    if not _same_identity(current_identity, expected_identity) or not stat.S_ISDIR(current_identity.st_mode):
+        raise UnsafeProjectStorageError("Storage directory changed before cleanup.")
+    try:
+        os.rmdir(path)
+    except OSError as exc:
+        if missing_ok and exc.errno == errno.ENOTEMPTY:
+            return
+        raise
+
+
+def _require_stable_directory(path: Path, expected_identity: os.stat_result) -> None:
+    current_identity = _path_identity(path)
+    if (
+        current_identity is None
+        or not stat.S_ISDIR(current_identity.st_mode)
+        or not _same_identity(current_identity, expected_identity)
+    ):
+        raise UnsafeProjectStorageError("Storage parent changed before cleanup.")
+
+
+def _path_identity(path: Path) -> os.stat_result | None:
+    try:
+        return os.lstat(path)
+    except FileNotFoundError:
+        return None
+
+
+def _same_identity(left: os.stat_result, right: os.stat_result) -> bool:
+    return (left.st_dev, left.st_ino, stat.S_IFMT(left.st_mode)) == (
+        right.st_dev,
+        right.st_ino,
+        stat.S_IFMT(right.st_mode),
+    )
+
+
+def _lexical_absolute(path: Path) -> Path:
+    return Path(os.path.abspath(os.path.normpath(path)))
+
+
+def _relative_path(path: Path, root: Path) -> Path | None:
+    try:
+        return path.relative_to(root)
+    except ValueError:
+        return None
+
+
+def _with_owned_prefixes(paths: set[Path]) -> set[Path]:
+    protected: set[Path] = set()
+    for path in paths:
+        for index in range(1, len(path.parts) + 1):
+            protected.add(Path(*path.parts[:index]))
+    return protected

--- a/apps/backend/app/services/projects.py
+++ b/apps/backend/app/services/projects.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import shutil
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -15,7 +14,8 @@ from app.errors import AppError
 from app.models import Artifact, Project, SyncDeleteTombstone, SyncEntityRevision, utcnow
 from app.services.artifacts import register_artifact
 from app.services.metadata import extract_audio_metadata, normalize_audio_to_wav
-from app.services.paths import ensure_project_dirs, project_root, project_source_dir
+from app.services.paths import ensure_project_dirs, project_source_dir
+from app.services.project_storage import queue_project_storage_reconciliation
 from app.services.sync_identity import source_hash_to_project_id
 from app.services.sync_project_status import require_project_sync_editable
 from app.services.sync_revisions import record_project_metadata_revision
@@ -136,10 +136,8 @@ def _discard_deleted_project_placeholder(
         return
 
     for project in placeholders:
-        root = project_root(project.id)
         session.delete(project)
-        if root.exists():
-            shutil.rmtree(root, ignore_errors=True)
+        queue_project_storage_reconciliation(session, project.id)
     session.flush()
 
 
@@ -238,12 +236,13 @@ def import_project(
         can_regenerate=False,
     )
 
+    queue_project_storage_reconciliation(session, project.id)
+
     return project
 
 
 def delete_project(session: Session, project_id: str) -> None:
     project = get_mutable_project(session, project_id)
-    root = project_root(project.id)
     deleted_at = utcnow()
     record_project_delete_tombstone(session, project, deleted_at=deleted_at)
     for artifact in list(session.scalars(select(Artifact).where(Artifact.project_id == project.id))):
@@ -254,8 +253,7 @@ def delete_project(session: Session, project_id: str) -> None:
         record_entity_revision_delete_tombstone(session, revision, deleted_at=deleted_at)
     session.delete(project)
     session.flush()
-    if root.exists():
-        shutil.rmtree(root, ignore_errors=True)
+    queue_project_storage_reconciliation(session, project.id)
 
 
 def update_project(session: Session, project_id: str, *, updates: dict[str, str | None]) -> Project:

--- a/apps/backend/app/services/stems.py
+++ b/apps/backend/app/services/stems.py
@@ -16,6 +16,7 @@ from app.errors import AppError, JobCancelledError
 from app.models import Artifact, Project, utcnow
 from app.services.artifacts import refresh_artifact_file_metadata, register_artifact
 from app.services.paths import project_stems_dir
+from app.services.project_storage import queue_project_storage_reconciliation
 from app.services.stem_models import (
     STEM_ARTIFACT_TYPES,
     TWO_STEMS_MODEL_ID,
@@ -186,9 +187,6 @@ def _upsert_stem_artifact(
         )
 
     old_path = Path(existing_artifact.path)
-    if old_path != path:
-        _cleanup_artifact_path(old_path)
-
     existing_artifact.format = artifact_format
     existing_artifact.path = str(path)
     refresh_artifact_file_metadata(existing_artifact, path)
@@ -198,6 +196,8 @@ def _upsert_stem_artifact(
     existing_artifact.metadata_json = metadata
     existing_artifact.created_at = utcnow()
     session.flush()
+    if old_path != path:
+        queue_project_storage_reconciliation(session, project_id)
     return existing_artifact
 
 
@@ -226,8 +226,8 @@ def _prune_extra_stem_artifacts(
     ):
         if artifact.id not in keep_ids:
             record_artifact_delete_tombstone(session, artifact)
-            _cleanup_artifact_path(Path(artifact.path))
             session.delete(artifact)
+    queue_project_storage_reconciliation(session, project_id)
 
 
 def _separate_with_model(

--- a/apps/backend/app/services/sync_manifest.py
+++ b/apps/backend/app/services/sync_manifest.py
@@ -30,6 +30,7 @@ from app.models import (
 from app.schemas import SUPPORTED_LYRICS_LANGUAGE_OVERRIDES
 from app.services.artifacts import register_artifact
 from app.services.paths import ensure_project_dirs, project_root
+from app.services.project_storage import queue_project_storage_reconciliation
 from app.services.sync_identity import source_hash_to_project_id
 from app.services.sync_metadata import (
     artifact_sync_metadata,
@@ -564,6 +565,7 @@ def import_staged_project_manifest(
         _cleanup_copied_artifacts(copied_paths, root)
         raise
 
+    queue_project_storage_reconciliation(session, project.id)
     return project
 
 
@@ -670,6 +672,7 @@ def _merge_staged_project_manifest(
         raise
 
     session.flush()
+    queue_project_storage_reconciliation(session, project.id)
     return project
 
 

--- a/apps/backend/app/services/sync_reconciliation_apply.py
+++ b/apps/backend/app/services/sync_reconciliation_apply.py
@@ -17,6 +17,7 @@ from app.errors import AppError
 from app.models import Artifact, Project, SyncDeleteTombstone, SyncEntityRevision
 from app.services.artifacts import register_artifact
 from app.services.paths import project_root
+from app.services.project_storage import queue_project_storage_reconciliation
 from app.services.sync_manifest import (
     SyncArtifactManifest,
     _coerce_project_manifest,
@@ -160,6 +161,14 @@ def apply_sync_reconciliation(
             details=cleanup_details,
         )
     summary = _summarize_apply_results(plan, results)
+    for result in results:
+        if result.status != APPLY_STATUS_APPLIED:
+            continue
+        project_id = result.action.project_id
+        if project_id is None and result.action.item_type == ITEM_PROJECT:
+            project_id = result.action.item_id
+        if project_id is not None:
+            queue_project_storage_reconciliation(session, project_id)
     _record_timing(
         timing_evidence,
         phase=TIMING_PHASE_APPLY,

--- a/apps/backend/app/services/sync_tombstones.py
+++ b/apps/backend/app/services/sync_tombstones.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
-import shutil
 from collections.abc import Mapping
 from datetime import datetime
-from pathlib import Path
 from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.models import Artifact, Project, SyncDeleteTombstone, SyncEntityRevision, utcnow
-from app.services.paths import project_root
+from app.services.project_storage import queue_project_storage_reconciliation
 from app.services.sync_revisions import sanitize_revision_payload
 from app.services.sync_trust import get_or_create_local_identity
 from app.utils.ids import new_id
@@ -110,21 +108,18 @@ def apply_delete_tombstone(session: Session, tombstone: SyncDeleteTombstone) -> 
         project = session.get(Project, tombstone.target_id)
         if project is None or project.id != tombstone.project_id:
             return
-        root = project_root(project.id)
         session.delete(project)
         session.flush()
-        if root.exists():
-            shutil.rmtree(root, ignore_errors=True)
+        queue_project_storage_reconciliation(session, project.id)
         return
 
     if tombstone.target_type == ARTIFACT_TARGET_TYPE:
         artifact = session.get(Artifact, tombstone.target_id)
         if artifact is None or artifact.project_id != tombstone.project_id:
             return
-        artifact_path = Path(artifact.path)
         session.delete(artifact)
-        _cleanup_artifact_path(artifact_path)
         session.flush()
+        queue_project_storage_reconciliation(session, artifact.project_id)
         return
 
     if tombstone.target_type == ENTITY_REVISION_TARGET_TYPE:
@@ -178,12 +173,3 @@ def _record_delete_tombstone(
     session.add(tombstone)
     session.flush()
     return tombstone
-
-
-def _cleanup_artifact_path(path: Path) -> None:
-    if path.exists():
-        path.unlink(missing_ok=True)
-    try:
-        path.parent.rmdir()
-    except OSError:
-        pass

--- a/apps/backend/tests/test_project_storage.py
+++ b/apps/backend/tests/test_project_storage.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from app.config import ensure_data_dirs, get_settings
+from app.db import SessionLocal, reconfigure_engine, run_migrations
+from app.models import Artifact, ChordTimeline, LyricsTranscript, Project, SyncDeleteTombstone
+from app.services.paths import project_root
+from app.services.project_storage import queue_project_storage_reconciliation
+from app.services.projects import delete_project
+from app.services.sync_tombstones import ARTIFACT_TARGET_TYPE, apply_delete_tombstone
+
+
+def _prepare_database() -> None:
+    settings = get_settings()
+    ensure_data_dirs(settings)
+    reconfigure_engine(settings)
+    run_migrations(settings)
+
+
+def _project(project_id: str, imported_path: Path) -> Project:
+    return Project(
+        id=project_id,
+        display_name="Storage Test",
+        source_sha256="a" * 64,
+        source_path=str(imported_path),
+        imported_path=str(imported_path),
+    )
+
+
+def _artifact(
+    artifact_id: str,
+    project_id: str,
+    path: Path,
+    *,
+    artifact_type: str = "preview_mix",
+) -> Artifact:
+    return Artifact(
+        id=artifact_id,
+        project_id=project_id,
+        type=artifact_type,
+        format=path.suffix.removeprefix(".") or "wav",
+        path=str(path),
+        content_sha256=None,
+        size_bytes=0,
+        generated_by="test",
+        can_delete=True,
+        can_regenerate=True,
+        metadata_json={},
+    )
+
+
+def test_reconciliation_preserves_live_ownership_and_never_follows_symlinks(
+    tmp_path: Path,
+) -> None:
+    _prepare_database()
+    project_id = "proj_storage_ownership"
+    root = project_root(project_id)
+    owned_audio = root / "previews" / "owned.wav"
+    missing_audio = root / "previews" / "missing.wav"
+    analysis_json = root / "analysis" / "analysis.json"
+    chords_json = root / "analysis" / "chords.json"
+    lyrics_json = root / "analysis" / "lyrics.json"
+    stale_json = root / "analysis" / "old.json"
+    stale_nested = root / "stems" / "old-stemset" / "vocals.wav"
+    empty_descendant = root / "previews" / "empty"
+    external_file = tmp_path / "external.wav"
+    external_target = tmp_path / "external-target.wav"
+    stale_link = root / "stems" / "external-link.wav"
+    linked_parent = root / "linked-parent"
+    linked_target = tmp_path / "linked-target"
+    linked_file = linked_target / "file.wav"
+    cross_project_file = root / "previews" / "cross-project.wav"
+
+    for path in (
+        owned_audio,
+        analysis_json,
+        chords_json,
+        lyrics_json,
+        stale_json,
+        stale_nested,
+        cross_project_file,
+    ):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(path.name.encode())
+    empty_descendant.mkdir(parents=True)
+    external_file.write_bytes(b"external artifact")
+    external_target.write_bytes(b"external target")
+    linked_target.mkdir()
+    linked_file.write_bytes(b"linked target")
+    stale_link.symlink_to(external_target)
+    linked_parent.symlink_to(linked_target, target_is_directory=True)
+
+    with SessionLocal() as session:
+        session.add(_project(project_id, owned_audio))
+        session.add(_project("proj_cross_owner", external_file))
+        session.add_all(
+            [
+                _artifact("art_owned_audio", project_id, owned_audio),
+                _artifact("art_missing_audio", project_id, missing_audio),
+                _artifact(
+                    "art_analysis_json",
+                    project_id,
+                    analysis_json,
+                    artifact_type="analysis_json",
+                ),
+                _artifact("art_external", project_id, external_file),
+                _artifact("art_linked", project_id, linked_parent / "file.wav"),
+                _artifact("art_cross_owner", "proj_cross_owner", cross_project_file),
+            ]
+        )
+        session.add(ChordTimeline(project_id=project_id))
+        session.add(LyricsTranscript(project_id=project_id))
+        queue_project_storage_reconciliation(session, project_id)
+        session.commit()
+
+    assert owned_audio.exists()
+    assert analysis_json.exists()
+    assert chords_json.exists()
+    assert lyrics_json.exists()
+    assert not stale_json.exists()
+    assert not stale_nested.exists()
+    assert not stale_nested.parent.exists()
+    assert not empty_descendant.exists()
+    assert not stale_link.exists()
+    assert linked_parent.is_symlink()
+    assert linked_file.read_bytes() == b"linked target"
+    assert cross_project_file.exists()
+    assert external_file.read_bytes() == b"external artifact"
+    assert external_target.read_bytes() == b"external target"
+    with SessionLocal() as session:
+        assert session.get(Artifact, "art_missing_audio") is not None
+        assert session.get(Artifact, "art_external") is not None
+
+
+def test_reconciliation_runs_after_commit_and_not_after_rollback() -> None:
+    _prepare_database()
+    project_id = "proj_storage_transaction"
+    root = project_root(project_id)
+    owned = root / "source" / "source.wav"
+    stale = root / "stems" / "stale.wav"
+    owned.parent.mkdir(parents=True, exist_ok=True)
+    stale.parent.mkdir(parents=True, exist_ok=True)
+    owned.write_bytes(b"owned")
+    stale.write_bytes(b"stale")
+
+    with SessionLocal() as session:
+        session.add(_project(project_id, owned))
+        session.add(_artifact("art_transaction", project_id, owned, artifact_type="source_audio"))
+        session.commit()
+
+    with SessionLocal() as session:
+        queue_project_storage_reconciliation(session, project_id)
+        session.rollback()
+    assert stale.exists()
+
+    with SessionLocal() as session:
+        queue_project_storage_reconciliation(session, project_id)
+        session.commit()
+    assert not stale.exists()
+    assert owned.exists()
+
+
+def test_parent_identity_change_aborts_cleanup_and_next_commit_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _prepare_database()
+    project_id = "proj_storage_race"
+    root = project_root(project_id)
+    owned = root / "source" / "source.wav"
+    late_owned = root / "previews" / "late.wav"
+    stale = root / "stems" / "stale.wav"
+    replacement = root.parent.parent / "replacement"
+    external_victim = replacement / "victim.wav"
+    owned.parent.mkdir(parents=True, exist_ok=True)
+    stale.parent.mkdir(parents=True, exist_ok=True)
+    replacement.mkdir()
+    external_victim.write_bytes(b"external victim")
+    owned.write_bytes(b"owned")
+    stale.write_bytes(b"stale")
+
+    with SessionLocal() as session:
+        session.add(_project(project_id, owned))
+        session.add(_artifact("art_race", project_id, owned, artifact_type="source_audio"))
+        session.commit()
+
+    from app.services import project_storage
+
+    original_path_identity = project_storage._path_identity
+    projects_root_checks = 0
+
+    def raced_path_identity(path: Path):
+        nonlocal projects_root_checks
+        if path == root.parent:
+            projects_root_checks += 1
+            if projects_root_checks >= 2:
+                return os.lstat(replacement)
+        return original_path_identity(path)
+
+    monkeypatch.setattr(project_storage, "_path_identity", raced_path_identity)
+    with SessionLocal() as session:
+        queue_project_storage_reconciliation(session, project_id)
+        session.commit()
+    assert stale.exists()
+    assert owned.exists()
+    assert external_victim.read_bytes() == b"external victim"
+
+    monkeypatch.setattr(project_storage, "_path_identity", original_path_identity)
+    late_owned.parent.mkdir(parents=True)
+    late_owned.write_bytes(b"late owned")
+    with SessionLocal() as session:
+        session.add(_artifact("art_race_late", project_id, late_owned))
+        session.commit()
+    assert not stale.exists()
+    assert owned.exists()
+    assert late_owned.exists()
+    assert external_victim.read_bytes() == b"external victim"
+
+
+def test_tombstones_and_project_delete_retire_storage_only_after_commit() -> None:
+    _prepare_database()
+    project_id = "proj_storage_delete"
+    root = project_root(project_id)
+    source = root / "source" / "source.wav"
+    deleted = root / "previews" / "deleted.wav"
+    for path in (source, deleted):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(path.name.encode())
+
+    with SessionLocal() as session:
+        session.add(_project(project_id, source))
+        session.add_all(
+            [
+                _artifact("art_delete_source", project_id, source, artifact_type="source_audio"),
+                _artifact("art_delete_preview", project_id, deleted),
+            ]
+        )
+        session.commit()
+
+    now = datetime.now(UTC)
+    tombstone = SyncDeleteTombstone(
+        id="del_storage_artifact",
+        sync_group_id="group_storage",
+        project_id=project_id,
+        target_type=ARTIFACT_TARGET_TYPE,
+        target_id="art_delete_preview",
+        author_device_id="device_storage",
+        deleted_at=now,
+        prior_metadata_json={},
+        created_at=now,
+        updated_at=now,
+    )
+    with SessionLocal() as session:
+        apply_delete_tombstone(session, tombstone)
+        assert deleted.exists()
+        session.commit()
+    assert not deleted.exists()
+    assert source.exists()
+
+    with SessionLocal() as session:
+        delete_project(session, project_id)
+        assert root.exists()
+        session.commit()
+    assert not root.exists()

--- a/apps/backend/tests/test_sync_reconciliation_apply_api.py
+++ b/apps/backend/tests/test_sync_reconciliation_apply_api.py
@@ -702,7 +702,7 @@ def test_reconciliation_apply_applies_trusted_delete_tombstone(
         assert tombstone.target_type == "artifact"
         assert tombstone.target_id == "art_apply_deleted"
         assert tombstone.author_device_id == "peer-apply-delete"
-    assert not artifact_path.exists()
+    assert artifact_path.read_bytes() == b"delete me"
 
 
 def test_reconciliation_apply_does_not_recreate_deleted_project_placeholder(


### PR DESCRIPTION
## Summary

- reconcile backend project storage after committed lifecycle mutations
- preserve live DB-owned files and external paths while pruning stale owned files
- retry failed cleanup using current database ownership

## Testing

- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `cd apps/backend && uv run --python 3.11 pytest`

Refs #291
