### PR TITLE
fix: preserve backend storage ownership

### DIFF
--- a/apps/backend/app/services/project_storage.py
+++ b/apps/backend/app/services/project_storage.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.config import get_settings
-from app.models import Artifact, ChordTimeline, LyricsTranscript, Project
+from app.models import AnalysisResult, Artifact, ChordTimeline, LyricsTranscript, Project
 from app.services.paths import project_root
 
 logger = logging.getLogger(__name__)
@@ -52,9 +52,9 @@ def prepare_project_storage_reconciliations(session: Session) -> None:
         return
 
     session.flush()
-    artifact_paths = tuple(session.scalars(select(Artifact.path)))
+    artifacts = tuple(session.scalars(select(Artifact)))
     plans = [
-        _build_reconciliation(session, project_id, artifact_paths=artifact_paths)
+        _build_reconciliation(session, project_id, artifacts=artifacts)
         for project_id in sorted(project_ids)
     ]
     session.info[_PREPARED_RECONCILIATIONS] = plans
@@ -91,7 +91,7 @@ def _build_reconciliation(
     session: Session,
     project_id: str,
     *,
-    artifact_paths: tuple[str, ...],
+    artifacts: tuple[Artifact, ...],
 ) -> ProjectStorageReconciliation:
     settings = get_settings()
     root = _lexical_absolute(project_root(project_id))
@@ -103,12 +103,20 @@ def _build_reconciliation(
     project = session.get(Project, project_id)
     delete_project_root = project is None or project.sync_status == "deleted"
     owned_paths: set[Path] = set()
-    for artifact_path in artifact_paths:
-        relative = _relative_path(_lexical_absolute(Path(artifact_path)), root)
-        if relative is not None and relative.parts:
-            owned_paths.add(relative)
+    for artifact in artifacts:
+        _add_owned_path(owned_paths, artifact.path, root)
+        if artifact.type == "source_audio":
+            original_copy_path = artifact.metadata_json.get("original_copy_path")
+            if isinstance(original_copy_path, str):
+                _add_owned_path(owned_paths, original_copy_path, root)
 
     if not delete_project_root:
+        if project is None:
+            raise RuntimeError("Live project reconciliation requires a project row.")
+        _add_owned_path(owned_paths, project.source_path, root)
+        _add_owned_path(owned_paths, project.imported_path, root)
+        if session.get(AnalysisResult, project_id) is not None:
+            owned_paths.add(Path("analysis") / "analysis.json")
         if session.get(ChordTimeline, project_id) is not None:
             owned_paths.add(Path("analysis") / "chords.json")
         if session.get(LyricsTranscript, project_id) is not None:
@@ -123,6 +131,12 @@ def _build_reconciliation(
         owned_paths=frozenset(owned_paths),
         delete_project_root=delete_project_root,
     )
+
+
+def _add_owned_path(owned_paths: set[Path], raw_path: str, root: Path) -> None:
+    relative = _relative_path(_lexical_absolute(Path(raw_path)), root)
+    if relative is not None and relative.parts:
+        owned_paths.add(relative)
 
 
 def reconcile_project_storage(plan: ProjectStorageReconciliation) -> None:

--- a/apps/backend/tests/test_project_storage.py
+++ b/apps/backend/tests/test_project_storage.py
@@ -8,7 +8,14 @@ import pytest
 
 from app.config import ensure_data_dirs, get_settings
 from app.db import SessionLocal, reconfigure_engine, run_migrations
-from app.models import Artifact, ChordTimeline, LyricsTranscript, Project, SyncDeleteTombstone
+from app.models import (
+    AnalysisResult,
+    Artifact,
+    ChordTimeline,
+    LyricsTranscript,
+    Project,
+    SyncDeleteTombstone,
+)
 from app.services.paths import project_root
 from app.services.project_storage import queue_project_storage_reconciliation
 from app.services.projects import delete_project
@@ -22,12 +29,12 @@ def _prepare_database() -> None:
     run_migrations(settings)
 
 
-def _project(project_id: str, imported_path: Path) -> Project:
+def _project(project_id: str, imported_path: Path, *, source_path: Path | None = None) -> Project:
     return Project(
         id=project_id,
         display_name="Storage Test",
         source_sha256="a" * 64,
-        source_path=str(imported_path),
+        source_path=str(source_path or imported_path),
         imported_path=str(imported_path),
     )
 
@@ -60,6 +67,9 @@ def test_reconciliation_preserves_live_ownership_and_never_follows_symlinks(
     _prepare_database()
     project_id = "proj_storage_ownership"
     root = project_root(project_id)
+    source_audio = root / "source" / "source.wav"
+    imported_audio = root / "source" / "imported.wav"
+    original_copy = root / "source" / "original-copy.wav"
     owned_audio = root / "previews" / "owned.wav"
     missing_audio = root / "previews" / "missing.wav"
     analysis_json = root / "analysis" / "analysis.json"
@@ -77,6 +87,9 @@ def test_reconciliation_preserves_live_ownership_and_never_follows_symlinks(
     cross_project_file = root / "previews" / "cross-project.wav"
 
     for path in (
+        source_audio,
+        imported_audio,
+        original_copy,
         owned_audio,
         analysis_json,
         chords_json,
@@ -96,28 +109,33 @@ def test_reconciliation_preserves_live_ownership_and_never_follows_symlinks(
     linked_parent.symlink_to(linked_target, target_is_directory=True)
 
     with SessionLocal() as session:
-        session.add(_project(project_id, owned_audio))
+        session.add(_project(project_id, imported_audio, source_path=source_audio))
         session.add(_project("proj_cross_owner", external_file))
+        source_artifact = _artifact(
+            "art_owned_audio",
+            project_id,
+            owned_audio,
+            artifact_type="source_audio",
+        )
+        source_artifact.metadata_json = {"original_copy_path": str(original_copy)}
         session.add_all(
             [
-                _artifact("art_owned_audio", project_id, owned_audio),
+                source_artifact,
                 _artifact("art_missing_audio", project_id, missing_audio),
-                _artifact(
-                    "art_analysis_json",
-                    project_id,
-                    analysis_json,
-                    artifact_type="analysis_json",
-                ),
                 _artifact("art_external", project_id, external_file),
                 _artifact("art_linked", project_id, linked_parent / "file.wav"),
                 _artifact("art_cross_owner", "proj_cross_owner", cross_project_file),
             ]
         )
+        session.add(AnalysisResult(project_id=project_id))
         session.add(ChordTimeline(project_id=project_id))
         session.add(LyricsTranscript(project_id=project_id))
         queue_project_storage_reconciliation(session, project_id)
         session.commit()
 
+    assert source_audio.exists()
+    assert imported_audio.exists()
+    assert original_copy.exists()
     assert owned_audio.exists()
     assert analysis_json.exists()
     assert chords_json.exists()


### PR DESCRIPTION
## Summary

- preserve live app-managed project source and import paths during backend storage reconciliation
- retain legacy `original_copy_path` and `analysis/analysis.json` when matching DB ownership exists
- keep cleanup limited to normal app-created or migrated states without expanding adversarial scope

## Testing

- `cd apps/backend && uv run --python 3.11 ruff check .`
- `cd apps/backend && uv run --python 3.11 mypy app`
- `cd apps/backend && uv run --python 3.11 pytest` (685 passed)
- `git diff --check origin/main..HEAD`

Refs #291
