### PR TITLE
feat: Add synced lyrics and chords playback

### DIFF
--- a/apps/desktop/src/App.mobile.test.tsx
+++ b/apps/desktop/src/App.mobile.test.tsx
@@ -1,11 +1,61 @@
-import { screen, within } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LyricsResponse } from "./lib/api";
 import {
+  findAudioByArtifactId,
+  markAudioReady,
+  mockGetChords,
+  mockGetLyrics,
   mockGetMobileCapabilities,
   resetAppTestHarness,
   renderApp,
+  setProjectChords,
+  setProjectLyrics,
 } from "./test/appTestHarness";
+
+function enableAndroidRuntime() {
+  mockGetMobileCapabilities.mockResolvedValue({
+    platform: "android",
+    mediaBackend: "android_media_codec",
+    isEmulator: true,
+    gpuBackend: null,
+    analysisAvailable: true,
+    basicChordsAvailable: true,
+    whisperAvailable: false,
+    stemSeparationAvailable: false,
+    generationTestingAvailable: true,
+    maxRecommendedModel: null,
+    cpuFallbackAllowed: false,
+  });
+}
+
+function emptyLyrics(projectId = "proj_123"): LyricsResponse {
+  return {
+    project_id: projectId,
+    backend: null,
+    source_artifact_id: null,
+    source_kind: null,
+    source_segments: [],
+    segments: [],
+    has_user_edits: false,
+    created_at: null,
+    updated_at: null,
+  };
+}
+
+function setEmptyChords() {
+  setProjectChords("proj_123", {
+    project_id: "proj_123",
+    backend: null,
+    source_artifact_id: null,
+    source_segments: [],
+    timeline: [],
+    has_user_edits: false,
+    created_at: null,
+    updated_at: null,
+  });
+}
 
 describe("Desktop app mobile capability gates", () => {
   beforeEach(resetAppTestHarness);
@@ -120,6 +170,7 @@ describe("Desktop app mobile capability gates", () => {
 
   it("keeps generation controls out of the playback workspace", async () => {
     const user = userEvent.setup();
+    enableAndroidRuntime();
     renderApp(["/projects/proj_123"]);
 
     await user.click(await screen.findByRole("tab", { name: "Playback" }));
@@ -129,5 +180,304 @@ describe("Desktop app mobile capability gates", () => {
     expect(
       within(playbackSurface as HTMLElement).queryByRole("button", { name: /Generate|Refresh/i }),
     ).not.toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Lyrics and chords lead sheet" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Lyrics" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Chords" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("keeps mobile Practice controls reachable while switching every display mode", async () => {
+    const user = userEvent.setup();
+    enableAndroidRuntime();
+    renderApp(["/projects/proj_123"]);
+
+    await user.click(await screen.findByRole("tab", { name: "Playback" }));
+    const surface = screen.getByRole("heading", { name: "Lyrics + chords" }).closest("main");
+    expect(surface).not.toBeNull();
+    const header = (surface as HTMLElement).querySelector(".playback-practice-surface__header");
+    expect(header).not.toBeNull();
+    const modeToggle = within(header as HTMLElement).getByRole("group", {
+      name: "Playback display mode",
+    });
+    const lyricsToggle = within(modeToggle).getByRole("button", { name: "Lyrics" });
+    const chordsToggle = within(modeToggle).getByRole("button", { name: "Chords" });
+    expect(within(header as HTMLElement).getByRole("button", { name: "Lyrics Follow" })).toBeEnabled();
+    const combinedLeadSheet = within(surface as HTMLElement).getByRole("group", {
+      name: "Lyrics and chords lead sheet",
+    });
+    expect(header).not.toContainElement(combinedLeadSheet);
+
+    await user.click(lyricsToggle);
+    expect(await within(surface as HTMLElement).findByRole("heading", { name: "Chords" })).toBeInTheDocument();
+    expect(lyricsToggle).toHaveAttribute("aria-pressed", "false");
+    expect(chordsToggle).toHaveAttribute("aria-pressed", "true");
+    expect(within(surface as HTMLElement).getByRole("group", { name: "Chord timeline" })).toBeInTheDocument();
+    expect(within(header as HTMLElement).getByRole("button", { name: "Chords Follow" })).toBeEnabled();
+
+    await user.click(lyricsToggle);
+    expect(await within(surface as HTMLElement).findByRole("heading", { name: "Lyrics + chords" })).toBeInTheDocument();
+    expect(lyricsToggle).toHaveAttribute("aria-pressed", "true");
+    expect(chordsToggle).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(chordsToggle);
+    expect(await within(surface as HTMLElement).findByRole("heading", { name: "Lyrics" })).toBeInTheDocument();
+    expect(lyricsToggle).toHaveAttribute("aria-pressed", "true");
+    expect(chordsToggle).toHaveAttribute("aria-pressed", "false");
+    expect(within(surface as HTMLElement).getByRole("group", { name: "Lyrics transcript" })).toBeInTheDocument();
+    expect(within(header as HTMLElement).getByRole("button", { name: "Lyrics Follow" })).toBeEnabled();
+  });
+
+  it("keeps loading distinct from confirmed absence before resolving auto mode", async () => {
+    const user = userEvent.setup();
+    let resolveLyrics!: (lyrics: LyricsResponse) => void;
+    const lyricsPromise = new Promise<LyricsResponse>((resolve) => {
+      resolveLyrics = resolve;
+    });
+    enableAndroidRuntime();
+    mockGetLyrics.mockImplementationOnce(() => lyricsPromise);
+    setEmptyChords();
+
+    renderApp(["/projects/proj_123"]);
+
+    await user.click(await screen.findByRole("tab", { name: "Playback" }));
+    expect(await screen.findByText("Loading practice data…")).toBeInTheDocument();
+    expect(screen.queryByText(/Generate lyrics and chords/i)).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolveLyrics(emptyLyrics());
+      await lyricsPromise;
+    });
+
+    expect(
+      await screen.findByText(
+        "No lyrics or chords on this device. Sync them from desktop, or use available Project tools.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows synced chords with a privacy-safe partial read failure", async () => {
+    const user = userEvent.setup();
+    enableAndroidRuntime();
+    mockGetLyrics.mockRejectedValueOnce(new Error("private/device/path/lyrics.json"));
+
+    renderApp(["/projects/proj_123"]);
+
+    await user.click(await screen.findByRole("tab", { name: "Playback" }));
+    expect(await screen.findByRole("heading", { name: "Chords" })).toBeInTheDocument();
+    expect(
+      screen.getByText("Lyrics couldn’t be loaded; showing chords."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Chord timeline" })).toBeInTheDocument();
+    expect(screen.queryByText(/private\/device\/path/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Generate|Refresh/i })).not.toBeInTheDocument();
+  });
+
+  it("temporarily falls back from an unavailable stored lane without overwriting it", async () => {
+    const user = userEvent.setup();
+    enableAndroidRuntime();
+    setProjectLyrics("proj_123", emptyLyrics());
+    window.localStorage.setItem(
+      "tuneforge.project-playback-state",
+      JSON.stringify({
+        proj_123: {
+          activeWorkspace: "playback",
+          playbackDisplayMode: "lyrics",
+        },
+      }),
+    );
+
+    const { queryClient } = renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Chords" })).toBeInTheDocument();
+    expect(screen.getByText("No lyrics on this device; showing chords.")).toBeInTheDocument();
+    await waitFor(() => {
+      const storedState = JSON.parse(
+        window.localStorage.getItem("tuneforge.project-playback-state") ?? "{}",
+      ) as { proj_123?: { playbackDisplayMode?: string } };
+      expect(storedState.proj_123?.playbackDisplayMode).toBe("lyrics");
+    });
+
+    await user.click(screen.getByRole("button", { name: "Lyrics" }));
+    expect(screen.getByRole("button", { name: "Lyrics" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Chords" })).toHaveAttribute("aria-pressed", "true");
+
+    setProjectLyrics("proj_123", {
+      ...emptyLyrics(),
+      backend: "synced",
+      segments: [
+        {
+          start_seconds: 0,
+          end_seconds: 8,
+          text: "Recovered synced lyric",
+          words: [],
+        },
+      ],
+    });
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: ["lyrics", "proj_123"] });
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByText("No lyrics on this device; showing chords.")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByRole("heading", { name: "Lyrics + chords" })).toBeInTheDocument();
+    const recoveredStoredState = JSON.parse(
+      window.localStorage.getItem("tuneforge.project-playback-state") ?? "{}",
+    ) as { proj_123?: { playbackDisplayMode?: string } };
+    expect(recoveredStoredState.proj_123?.playbackDisplayMode).toBe("combined");
+  });
+
+  it("keeps untimed synced lyrics static without activating Lyrics Follow", async () => {
+    const user = userEvent.setup();
+    enableAndroidRuntime();
+    setEmptyChords();
+    setProjectLyrics("proj_123", {
+      ...emptyLyrics(),
+      backend: "synced",
+      segments: [
+        {
+          start_seconds: null,
+          end_seconds: null,
+          text: "Static synced lyric",
+          words: [],
+        },
+      ],
+    });
+
+    renderApp(["/projects/proj_123"]);
+
+    await user.click(await screen.findByRole("tab", { name: "Playback" }));
+    expect(await screen.findByRole("heading", { name: "Lyrics" })).toBeInTheDocument();
+    expect(screen.getByText("Static synced lyric")).toBeInTheDocument();
+    expect(screen.getByText("Static")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Lyrics Follow" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Lyrics Follow" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("keeps synced lyrics visible when chords fail to load", async () => {
+    const user = userEvent.setup();
+    enableAndroidRuntime();
+    mockGetChords.mockRejectedValueOnce(new Error("private/device/path/chords.json"));
+
+    renderApp(["/projects/proj_123"]);
+
+    await user.click(await screen.findByRole("tab", { name: "Playback" }));
+    expect(await screen.findByRole("heading", { name: "Lyrics" })).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Lyrics transcript" })).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Chords couldn’t be loaded; showing lyrics.",
+    );
+    expect(screen.queryByText(/private\/device\/path/i)).not.toBeInTheDocument();
+  });
+
+  it("reports both failed synced lanes without showing generation prompts", async () => {
+    const user = userEvent.setup();
+    enableAndroidRuntime();
+    mockGetLyrics.mockRejectedValueOnce(new Error("lyrics private path"));
+    mockGetChords.mockRejectedValueOnce(new Error("chords private path"));
+
+    renderApp(["/projects/proj_123"]);
+
+    await user.click(await screen.findByRole("tab", { name: "Playback" }));
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Lyrics and chords couldn’t be loaded on this device.",
+    );
+    expect(screen.queryByRole("button", { name: /Generate|Refresh/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/private path/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps retained lyrics visible when a refresh fails", async () => {
+    const user = userEvent.setup();
+    enableAndroidRuntime();
+    const { queryClient } = renderApp(["/projects/proj_123"]);
+
+    await user.click(await screen.findByRole("tab", { name: "Playback" }));
+    expect(await screen.findByText("Hello")).toBeInTheDocument();
+
+    mockGetLyrics.mockRejectedValueOnce(new Error("refresh private path"));
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: ["lyrics", "proj_123"] });
+    });
+
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Lyrics and chords lead sheet" })).toBeInTheDocument();
+    expect(
+      await screen.findByText("Lyrics couldn’t be refreshed; showing available lyrics."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/refresh private path/i)).not.toBeInTheDocument();
+  });
+
+  it("does not auto-scroll combined chord rows when synced lyrics are untimed", async () => {
+    const user = userEvent.setup();
+    enableAndroidRuntime();
+    setProjectLyrics("proj_123", {
+      ...emptyLyrics(),
+      backend: "synced",
+      segments: [
+        {
+          start_seconds: null,
+          end_seconds: null,
+          text: "Static synced lyric",
+          words: [],
+        },
+      ],
+    });
+
+    renderApp(["/projects/proj_123"]);
+
+    await user.click(await screen.findByRole("tab", { name: "Playback" }));
+    const leadSheet = screen.getByRole("group", { name: "Lyrics and chords lead sheet" });
+    const scrollTo = vi.fn();
+    Object.defineProperty(leadSheet, "scrollTo", { configurable: true, value: scrollTo });
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument(),
+    );
+    fireEvent.timeUpdate(sourceAudio);
+
+    expect(screen.getByRole("button", { name: "Lyrics Follow" })).toBeDisabled();
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("keeps Android-capability seek, pause, resume, highlight, and follow behavior", async () => {
+    const user = userEvent.setup();
+    enableAndroidRuntime();
+    renderApp(["/projects/proj_123"]);
+
+    await user.click(await screen.findByRole("tab", { name: "Playback" }));
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    await user.click(screen.getByRole("button", { name: "Chords" }));
+    const leadSheet = screen.getByRole("group", { name: "Lyrics transcript" });
+    const scrollTo = vi.fn();
+    Object.defineProperties(leadSheet, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, value: 500 },
+      scrollTo: { configurable: true, value: scrollTo },
+    });
+    const secondLyric = within(leadSheet).getByRole("button", { name: /0:08/i });
+
+    await user.click(secondLyric);
+    expect(sourceAudio.currentTime).toBeCloseTo(8, 3);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument(),
+    );
+    await waitFor(() => expect(secondLyric.className).toContain("lead-sheet__row--active"));
+    await waitFor(() => expect(scrollTo).toHaveBeenCalled());
+
+    await user.click(screen.getByRole("button", { name: "Pause playback" }));
+    expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+    const pausedTime = sourceAudio.currentTime;
+    expect(pausedTime).toBeGreaterThanOrEqual(8);
+    expect(pausedTime).toBeLessThan(9);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    expect(await screen.findByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+    expect(sourceAudio.currentTime).toBeCloseTo(pausedTime, 1);
   });
 });

--- a/apps/desktop/src/features/projects/components/PlaybackPracticeSurface.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackPracticeSurface.tsx
@@ -56,6 +56,7 @@ function PlaybackModeHeader() {
     handleSetLyricsFollowEnabled,
     handleTogglePlaybackDisplayLane,
     hasLyricsTranscript,
+    hasTimedLyricsTranscript,
     isEditingLyrics,
     isLyricsRunning,
     isTabImportOpen,
@@ -140,9 +141,13 @@ function PlaybackModeHeader() {
             {lyricsSelected ? (
               <>
                 <button
-                  aria-pressed={lyricsFollowEnabled}
-                  className={`chip playback-follow-chip${lyricsFollowEnabled ? " chip--active" : ""}`}
+                  aria-pressed={hasTimedLyricsTranscript && lyricsFollowEnabled}
+                  className={`chip playback-follow-chip${hasTimedLyricsTranscript && lyricsFollowEnabled ? " chip--active" : ""}`}
+                  disabled={!hasTimedLyricsTranscript}
                   onClick={() => handleSetLyricsFollowEnabled(!lyricsFollowEnabled)}
+                  title={
+                    hasTimedLyricsTranscript ? undefined : "Lyrics Follow requires timed lyrics."
+                  }
                   type="button"
                 >
                   Lyrics Follow
@@ -466,10 +471,14 @@ function LyricsPracticePanel() {
     hasLyricsTranscript,
     hasTimedLyricsTranscript,
     isEditingLyrics,
+    isMobileRuntime,
+    lyricsPracticeStatus,
+    lyricsPracticeRefreshFailed,
     lyricsJob,
     lyricsSaveMutation,
     lyricsSegmentRefs,
     lyricsTheaterRef,
+    practiceModeFallbackMessage,
     showSupportingCopy,
   } = useProjectViewModelContext();
 
@@ -481,7 +490,7 @@ function LyricsPracticePanel() {
 
   return (
     <div className="playback-practice-body">
-      {hasLyricsTranscript ? (
+      {lyricsPracticeStatus === "available" ? (
         <div
           className="lead-sheet lead-sheet--lyrics-only"
           role="group"
@@ -513,7 +522,10 @@ function LyricsPracticePanel() {
           <div aria-hidden="true" className="lead-sheet__edge" />
         </div>
       ) : (
-        <EmptyPracticeState copy="Generate a lyrics pass to keep transcription and playback together while you practice." />
+        <EmptyPracticeState
+          copy={practiceLaneStateCopy("lyrics", lyricsPracticeStatus, isMobileRuntime)}
+          announce
+        />
       )}
 
       {hasLyricsTranscript && !hasTimedLyricsTranscript ? (
@@ -525,6 +537,12 @@ function LyricsPracticePanel() {
         <div className="chord-context">
           <span className="artifact-meta">Follow keeps the active lyric in view while playback moves.</span>
         </div>
+      ) : null}
+      {practiceModeFallbackMessage ? (
+        <PracticeContextMessage copy={practiceModeFallbackMessage} />
+      ) : null}
+      {lyricsPracticeRefreshFailed ? (
+        <PracticeContextMessage copy="Lyrics couldn’t be refreshed; showing available lyrics." />
       ) : null}
       {lyricsSaveMutation.error ? (
         <p className="inline-error">
@@ -614,10 +632,26 @@ function ChordsPracticePanel() {
     handleSeekTo,
     hasChordTimeline,
     nextChord,
+    practiceModeFallbackMessage,
+    chordsPracticeStatus,
+    chordsPracticeRefreshFailed,
+    isMobileRuntime,
     showSupportingCopy,
   } = useProjectViewModelContext();
   const handlePracticeTargetSpacePlayback = usePracticeTargetSpacePlayback();
   const chordErrorMessage = formatJobErrorMessage(chordJob?.error_message, chordJob);
+
+  if (chordsPracticeStatus !== "available") {
+    return (
+      <div className="playback-practice-body playback-practice-body--chords">
+        <EmptyPracticeState
+          copy={practiceLaneStateCopy("chords", chordsPracticeStatus, isMobileRuntime)}
+          announce
+        />
+        {chordErrorMessage ? <p className="inline-error">{chordErrorMessage}</p> : null}
+      </div>
+    );
+  }
 
   return (
     <div className="playback-practice-body playback-practice-body--chords">
@@ -719,6 +753,12 @@ function ChordsPracticePanel() {
           <span className="artifact-meta">Follow keeps the active chord in view while playback moves.</span>
         </div>
       ) : null}
+      {practiceModeFallbackMessage ? (
+        <PracticeContextMessage copy={practiceModeFallbackMessage} />
+      ) : null}
+      {chordsPracticeRefreshFailed ? (
+        <PracticeContextMessage copy="Chords couldn’t be refreshed; showing available chords." />
+      ) : null}
       {chordErrorMessage ? <p className="inline-error">{chordErrorMessage}</p> : null}
     </div>
   );
@@ -729,13 +769,17 @@ function CombinedLeadSheetPanel() {
     combinedLeadSheetRef,
     combinedLeadSheetRowRefs,
     combinedLeadSheetRows,
+    chordsPracticeStatus,
+    chordsPracticeRefreshFailed,
     displayedChords,
     displayedLyrics,
-    hasChordTimeline,
-    hasLyricsTranscript,
     isEditingLyrics,
+    isMobileRuntime,
     lyricsJob,
+    lyricsPracticeStatus,
+    lyricsPracticeRefreshFailed,
     lyricsSaveMutation,
+    practiceModeFallbackMessage,
     showSupportingCopy,
   } = useProjectViewModelContext();
 
@@ -747,7 +791,7 @@ function CombinedLeadSheetPanel() {
 
   return (
     <div className="playback-practice-body">
-      {hasLyricsTranscript || hasChordTimeline ? (
+      {lyricsPracticeStatus === "available" || chordsPracticeStatus === "available" ? (
         <div
           className="lead-sheet"
           role="group"
@@ -767,18 +811,44 @@ function CombinedLeadSheetPanel() {
           <div aria-hidden="true" className="lead-sheet__edge" />
         </div>
       ) : (
-        <EmptyPracticeState copy="Generate lyrics and chords to build a timed lead sheet." />
+        <EmptyPracticeState
+          copy={combinedPracticeStateCopy(
+            lyricsPracticeStatus,
+            chordsPracticeStatus,
+            isMobileRuntime,
+          )}
+          announce
+        />
       )}
 
-      {!hasLyricsTranscript && hasChordTimeline ? (
-        <div className="chord-context">
-          <span className="artifact-meta">Lyrics are missing, so combined mode shows chord rows only.</span>
-        </div>
+      {chordsPracticeStatus === "available" && lyricsPracticeStatus !== "available" ? (
+        <PracticeContextMessage
+          copy={partialPracticeStateCopy(
+            "lyrics",
+            lyricsPracticeStatus,
+            "chords",
+            isMobileRuntime,
+          )}
+        />
       ) : null}
-      {hasLyricsTranscript && !hasChordTimeline ? (
-        <div className="chord-context">
-          <span className="artifact-meta">Chords are missing, so combined mode shows lyrics only.</span>
-        </div>
+      {lyricsPracticeStatus === "available" && chordsPracticeStatus !== "available" ? (
+        <PracticeContextMessage
+          copy={partialPracticeStateCopy(
+            "chords",
+            chordsPracticeStatus,
+            "lyrics",
+            isMobileRuntime,
+          )}
+        />
+      ) : null}
+      {practiceModeFallbackMessage ? (
+        <PracticeContextMessage copy={practiceModeFallbackMessage} />
+      ) : null}
+      {lyricsPracticeRefreshFailed ? (
+        <PracticeContextMessage copy="Lyrics couldn’t be refreshed; showing available lyrics." />
+      ) : null}
+      {chordsPracticeRefreshFailed ? (
+        <PracticeContextMessage copy="Chords couldn’t be refreshed; showing available chords." />
       ) : null}
       {displayedLyrics.length > 0 && displayedChords.length > 0 && showSupportingCopy ? (
         <div className="chord-context">
@@ -937,10 +1007,87 @@ function LeadSheetChordButton({ chord }: { chord: LeadSheetChord }) {
   );
 }
 
-function EmptyPracticeState({ copy }: { copy: string }) {
+function EmptyPracticeState({ copy, announce = false }: { copy: string; announce?: boolean }) {
   return (
-    <div className="chord-lane-empty playback-practice-empty">
+    <div
+      aria-atomic={announce ? "true" : undefined}
+      className="chord-lane-empty playback-practice-empty"
+      role={announce ? "status" : undefined}
+    >
       <p className="artifact-meta">{copy}</p>
     </div>
   );
+}
+
+function PracticeContextMessage({ copy }: { copy: string }) {
+  return (
+    <div aria-atomic="true" className="chord-context" role="status">
+      <span className="artifact-meta">{copy}</span>
+    </div>
+  );
+}
+
+function practiceLaneStateCopy(
+  lane: "lyrics" | "chords",
+  status: ReturnType<typeof useProjectViewModelContext>["lyricsPracticeStatus"],
+  isMobileRuntime: boolean,
+) {
+  const label = lane === "lyrics" ? "Lyrics" : "Chords";
+  if (status === "loading") {
+    return "Loading practice data…";
+  }
+  if (status === "error") {
+    return isMobileRuntime
+      ? `${label} couldn’t be loaded on this device.`
+      : `${label} couldn’t be loaded.`;
+  }
+  return isMobileRuntime
+    ? `No ${lane} on this device. Sync them from desktop, or use available Project tools.`
+    : `No ${lane} are available for this project. Use Project tools to generate them.`;
+}
+
+function partialPracticeStateCopy(
+  lane: "lyrics" | "chords",
+  status: ReturnType<typeof useProjectViewModelContext>["lyricsPracticeStatus"],
+  visibleLane: "lyrics" | "chords",
+  isMobileRuntime: boolean,
+) {
+  if (status === "loading") {
+    return "Loading practice data…";
+  }
+  const label = lane === "lyrics" ? "Lyrics" : "Chords";
+  if (status === "error") {
+    return `${label} couldn’t be loaded; showing ${visibleLane}.`;
+  }
+  return isMobileRuntime
+    ? `No ${lane} on this device; showing ${visibleLane}.`
+    : `No ${lane} are available; showing ${visibleLane}.`;
+}
+
+function combinedPracticeStateCopy(
+  lyricsStatus: ReturnType<typeof useProjectViewModelContext>["lyricsPracticeStatus"],
+  chordsStatus: ReturnType<typeof useProjectViewModelContext>["chordsPracticeStatus"],
+  isMobileRuntime: boolean,
+) {
+  if (lyricsStatus === "loading" || chordsStatus === "loading") {
+    return "Loading practice data…";
+  }
+  if (lyricsStatus === "empty" && chordsStatus === "empty") {
+    return isMobileRuntime
+      ? "No lyrics or chords on this device. Sync them from desktop, or use available Project tools."
+      : "No lyrics or chords are available for this project. Use Project tools to generate them.";
+  }
+  if (lyricsStatus === "error" && chordsStatus === "error") {
+    return isMobileRuntime
+      ? "Lyrics and chords couldn’t be loaded on this device."
+      : "Lyrics and chords couldn’t be loaded.";
+  }
+  if (lyricsStatus === "error") {
+    return isMobileRuntime
+      ? "Lyrics couldn’t be loaded. No chords are available on this device."
+      : "Lyrics couldn’t be loaded. No chords are available.";
+  }
+  return isMobileRuntime
+    ? "Chords couldn’t be loaded. No lyrics are available on this device."
+    : "Chords couldn’t be loaded. No lyrics are available.";
 }

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -93,6 +93,8 @@ import {
 } from "../playbackTempo";
 
 type PlaybackDisplayModeSource = "default" | "stored" | "user";
+type PracticeLaneStatus = "loading" | "available" | "empty" | "error";
+type PracticeLane = "lyrics" | "chords";
 const ACTIVE_PROJECT_JOB_STATUSES = ["running", "pending"] as const;
 const TERMINAL_PROJECT_JOB_STATUSES = ["completed", "failed", "cancelled"] as const;
 const ACTIVE_PROJECT_JOBS_LIMIT = 200;
@@ -211,6 +213,46 @@ function resolveDefaultPlaybackDisplayMode(
   return "combined";
 }
 
+function practiceModeFallbackCopy(
+  lane: PracticeLane,
+  status: PracticeLaneStatus,
+  isMobileRuntime: boolean,
+) {
+  if (status === "available") {
+    return null;
+  }
+  if (status === "loading") {
+    return "Loading practice data…";
+  }
+  const laneLabel = lane === "lyrics" ? "Lyrics" : "Chords";
+  const visibleLane = lane === "lyrics" ? "chords" : "lyrics";
+  return status === "error"
+    ? `${laneLabel} couldn’t be loaded; showing ${visibleLane}.`
+    : isMobileRuntime
+      ? `No ${lane} on this device; showing ${visibleLane}.`
+      : `No ${lane} are available; showing ${visibleLane}.`;
+}
+
+function resolvePracticeLaneStatus({
+  hasUsableContent,
+  isError,
+  isFetching,
+  isPending,
+}: {
+  hasUsableContent: boolean;
+  isError: boolean;
+  isFetching: boolean;
+  isPending: boolean;
+}): PracticeLaneStatus {
+  if (hasUsableContent) {
+    return "available";
+  }
+  if (isPending || isFetching) {
+    return "loading";
+  }
+  return isError ? "error" : "empty";
+}
+
 function clampPlaybackLoopPoint(value: number, durationSeconds: number) {
   const point = Number.isFinite(value) ? Math.max(0, value) : 0;
   return durationSeconds > 0 ? Math.min(durationSeconds, point) : point;
@@ -290,6 +332,7 @@ export function useProjectViewModel() {
     null,
   );
   const persistedStemSourceArtifactId = useRef<string | null>(null);
+  const practiceModeResolvedProjectId = useRef<string | null>(null);
   const wasPlayingRef = useRef(isPlaying);
   const targetSelectorRef = useRef<HTMLDivElement | null>(null);
   const targetOptionRefs = useRef<Record<number, HTMLButtonElement | null>>({});
@@ -330,8 +373,13 @@ export function useProjectViewModel() {
   const [activeWorkspace, setActiveWorkspace] = useState(defaultProjectWorkspace);
   const [activeProjectPanel, setActiveProjectPanel] = useState<ProjectPanelMode>("studio");
   const [playbackDisplayMode, setPlaybackDisplayMode] = useState<PlaybackDisplayMode>("combined");
+  const [persistedPlaybackDisplayMode, setPersistedPlaybackDisplayMode] =
+    useState<PlaybackDisplayMode>("combined");
   const [playbackDisplayModeSource, setPlaybackDisplayModeSource] =
     useState<PlaybackDisplayModeSource>("default");
+  const [practiceModeFallbackLane, setPracticeModeFallbackLane] = useState<PracticeLane | null>(
+    null,
+  );
   const [stemControls, setStemControls] = useState<Record<string, StemControlState>>({});
   const [dismissedStemJobIds, setDismissedStemJobIds] = useState<string[]>([]);
   const [isEditingLyrics, setIsEditingLyrics] = useState(false);
@@ -1060,6 +1108,27 @@ export function useProjectViewModel() {
   );
   const hasLyricsTranscript = displayedLyrics.length > 0;
   const hasTimedLyricsTranscript = displayedLyrics.some((segment) => hasTimedLyrics(segment));
+  const chordsPracticeStatus = resolvePracticeLaneStatus({
+    hasUsableContent: hasChordTimeline,
+    isError: chordsQuery.isError,
+    isFetching: chordsQuery.isFetching,
+    isPending: chordsQuery.isPending,
+  });
+  const lyricsPracticeStatus = resolvePracticeLaneStatus({
+    hasUsableContent: hasLyricsTranscript,
+    isError: lyricsQuery.isError,
+    isFetching: lyricsQuery.isFetching,
+    isPending: lyricsQuery.isPending,
+  });
+  const chordsPracticeRefreshFailed = chordsQuery.isRefetchError && hasChordTimeline;
+  const lyricsPracticeRefreshFailed = lyricsQuery.isRefetchError && hasLyricsTranscript;
+  const practiceModeFallbackMessage = practiceModeFallbackLane
+    ? practiceModeFallbackCopy(
+        practiceModeFallbackLane,
+        practiceModeFallbackLane === "lyrics" ? lyricsPracticeStatus : chordsPracticeStatus,
+        isMobileRuntime,
+      )
+    : null;
   const lyricsLanguageMetadata = formatLyricsLanguageMetadata(lyricsQuery.data);
   const activeLyricsIndex = findActiveLyricsIndex(displayedLyrics, playbackTimeSeconds);
   const activeLyricsSegment =
@@ -1224,7 +1293,9 @@ export function useProjectViewModel() {
 
   function handleSetPlaybackDisplayMode(displayMode: PlaybackDisplayMode) {
     setPlaybackDisplayMode(displayMode);
+    setPersistedPlaybackDisplayMode(displayMode);
     setPlaybackDisplayModeSource("user");
+    setPracticeModeFallbackLane(null);
   }
 
   function handleTogglePlaybackDisplayLane(lane: "lyrics" | "chords") {
@@ -1858,19 +1929,21 @@ export function useProjectViewModel() {
   useEffect(() => {
     const storedPlaybackState = readProjectPlaybackState(projectId);
     const hasStoredPlayback = hasProjectPlaybackState(projectId);
+    const initialPlaybackDisplayMode = hasStoredPlayback
+      ? storedPlaybackState.playbackDisplayMode
+      : resolveDefaultPlaybackDisplayMode(defaultPlaybackDisplayMode, false, false);
     pendingPreviewSelection.current = null;
     persistedStemSourceArtifactId.current = storedPlaybackState.selectedStemSourceArtifactId;
+    practiceModeResolvedProjectId.current = null;
     setSelectedArtifactId(storedPlaybackState.selectedArtifactId);
     setSelectedPrimaryArtifactId(storedPlaybackState.selectedPrimaryArtifactId);
     setActiveWorkspace(
       hasStoredPlayback ? storedPlaybackState.activeWorkspace : defaultProjectWorkspace,
     );
     setActiveProjectPanel(storedPlaybackState.activeProjectPanel);
-    setPlaybackDisplayMode(
-      hasStoredPlayback
-        ? storedPlaybackState.playbackDisplayMode
-        : resolveDefaultPlaybackDisplayMode(defaultPlaybackDisplayMode, false, false),
-    );
+    setPlaybackDisplayMode(initialPlaybackDisplayMode);
+    setPersistedPlaybackDisplayMode(initialPlaybackDisplayMode);
+    setPracticeModeFallbackLane(null);
     setCapoTransposeSemitones(storedPlaybackState.capoTransposeSemitones);
     setPrecountEnabled(storedPlaybackState.precountEnabled);
     setPrecountLoopEnabled(storedPlaybackState.precountLoopEnabled);
@@ -1921,24 +1994,59 @@ export function useProjectViewModel() {
   useEffect(() => {
     if (
       hydratedProjectId !== projectId ||
-      playbackDisplayModeSource !== "default"
+      playbackDisplayModeSource === "user" ||
+      practiceModeResolvedProjectId.current === projectId ||
+      lyricsPracticeStatus === "loading" ||
+      chordsPracticeStatus === "loading"
     ) {
       return;
     }
 
-    setPlaybackDisplayMode(
-      resolveDefaultPlaybackDisplayMode(
+    practiceModeResolvedProjectId.current = projectId;
+
+    if (playbackDisplayModeSource === "default") {
+      const resolvedDisplayMode = resolveDefaultPlaybackDisplayMode(
         defaultPlaybackDisplayMode,
-        hasLyricsTranscript,
-        hasChordTimeline,
-      ),
-    );
+        lyricsPracticeStatus === "available",
+        chordsPracticeStatus === "available",
+      );
+      setPlaybackDisplayMode(resolvedDisplayMode);
+      setPersistedPlaybackDisplayMode(resolvedDisplayMode);
+      if (defaultPlaybackDisplayMode === "auto") {
+        if (resolvedDisplayMode === "lyrics" && chordsPracticeStatus !== "available") {
+          setPracticeModeFallbackLane("chords");
+        } else if (resolvedDisplayMode === "chords" && lyricsPracticeStatus !== "available") {
+          setPracticeModeFallbackLane("lyrics");
+        }
+      }
+      return;
+    }
+
+    if (
+      persistedPlaybackDisplayMode === "lyrics" &&
+      lyricsPracticeStatus !== "available" &&
+      chordsPracticeStatus === "available"
+    ) {
+      setPlaybackDisplayMode("chords");
+      setPracticeModeFallbackLane("lyrics");
+      return;
+    }
+
+    if (
+      persistedPlaybackDisplayMode === "chords" &&
+      chordsPracticeStatus !== "available" &&
+      lyricsPracticeStatus === "available"
+    ) {
+      setPlaybackDisplayMode("lyrics");
+      setPracticeModeFallbackLane("chords");
+    }
   }, [
+    chordsPracticeStatus,
     defaultPlaybackDisplayMode,
-    hasChordTimeline,
-    hasLyricsTranscript,
     hydratedProjectId,
+    lyricsPracticeStatus,
     playbackDisplayModeSource,
+    persistedPlaybackDisplayMode,
     projectId,
   ]);
 
@@ -2047,7 +2155,7 @@ export function useProjectViewModel() {
       selectedStemSourceArtifactId,
       activeWorkspace,
       activeProjectPanel,
-      playbackDisplayMode,
+      playbackDisplayMode: persistedPlaybackDisplayMode,
       capoTransposeSemitones: capoSemitones,
       precountEnabled,
       precountLoopEnabled,
@@ -2070,7 +2178,7 @@ export function useProjectViewModel() {
     lyricsFollowEnabled,
     loopRange,
     loopAlignmentModeOverride,
-    playbackDisplayMode,
+    persistedPlaybackDisplayMode,
     precountClickCount,
     precountEnabled,
     precountLoopEnabled,
@@ -2141,6 +2249,7 @@ export function useProjectViewModel() {
       activeWorkspace !== "playback" ||
       playbackDisplayMode !== "lyrics" ||
       !lyricsFollowEnabled ||
+      !hasTimedLyricsTranscript ||
       !isPlaying ||
       isEditingLyrics ||
       activeLyricsIndex < 0
@@ -2189,6 +2298,7 @@ export function useProjectViewModel() {
     displayedLyrics,
     isEditingLyrics,
     isPlaying,
+    hasTimedLyricsTranscript,
     lyricsFollowEnabled,
     playbackDisplayMode,
   ]);
@@ -2198,6 +2308,7 @@ export function useProjectViewModel() {
       activeWorkspace !== "playback" ||
       playbackDisplayMode !== "combined" ||
       !lyricsFollowEnabled ||
+      !hasTimedLyricsTranscript ||
       !isPlaying ||
       isEditingLyrics
     ) {
@@ -2238,6 +2349,7 @@ export function useProjectViewModel() {
   }, [
     activeWorkspace,
     combinedLeadSheetRows,
+    hasTimedLyricsTranscript,
     isEditingLyrics,
     isPlaying,
     lyricsFollowEnabled,
@@ -2372,6 +2484,8 @@ export function useProjectViewModel() {
     chordSegmentRefs,
     chordTimelineRef,
     chordsFollowEnabled,
+    chordsPracticeStatus,
+    chordsPracticeRefreshFailed,
     combinedLeadSheetRef,
     combinedLeadSheetRowRefs,
     combinedLeadSheetRows,
@@ -2468,6 +2582,8 @@ export function useProjectViewModel() {
     mobileCapabilities,
     mobileGenerationMessage,
     lyricsFollowEnabled,
+    lyricsPracticeStatus,
+    lyricsPracticeRefreshFailed,
     lyricsLanguageMetadata,
     lyricsLanguageOptions: LYRICS_LANGUAGE_OPTIONS,
     lyricsDraft,
@@ -2478,6 +2594,7 @@ export function useProjectViewModel() {
     lyricsTheaterRef,
     nextChord,
     playbackDisplayMode,
+    practiceModeFallbackMessage,
     playbackDurationSeconds,
     playbackTransportRef,
     playbackTimeSeconds,

--- a/apps/desktop/src/styles/project-playback.css
+++ b/apps/desktop/src/styles/project-playback.css
@@ -1738,8 +1738,24 @@
 }
 
 @media (max-width: 720px) {
+  .project-screen--playback {
+    height: auto;
+    overflow: visible;
+  }
+
   .playback-workspace--practice {
-    grid-template-rows: minmax(0, 2.75rem) minmax(0, 1fr) auto;
+    flex: 0 0 auto;
+    grid-template-rows: minmax(0, 2.75rem) auto auto;
+    overflow: visible;
+  }
+
+  .playback-workspace--focus {
+    grid-template-rows: auto auto;
+  }
+
+  .playback-practice-surface {
+    height: auto;
+    overflow: visible;
   }
 
   .playback-practice-rail {
@@ -1747,8 +1763,9 @@
   }
 
   .playback-practice-surface__header {
-    max-height: 4.25rem;
-    overflow: auto;
+    flex: 0 0 auto;
+    max-height: none;
+    overflow: visible;
   }
 
   .playback-practice-surface__header h2 {
@@ -1756,23 +1773,76 @@
   }
 
   .playback-practice-surface__controls {
-    align-items: flex-start;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    padding-bottom: 0.15rem;
+    align-items: stretch;
+    flex-direction: column;
+    overflow: visible;
+    padding-bottom: 0;
+  }
+
+  .playback-practice-body {
+    flex: 0 0 auto;
+    min-block-size: 15rem;
   }
 
   .playback-mode-toggle,
   .playback-practice-actions {
-    flex: 0 0 auto;
+    width: 100%;
+  }
+
+  .playback-mode-toggle__button {
+    flex: 1;
+  }
+
+  .playback-practice-actions {
+    justify-content: flex-start;
+    flex-wrap: wrap;
   }
 
   .playback-mode-toggle__button,
   .playback-practice-actions .button,
   .playback-follow-chip {
+    min-block-size: 3rem;
     padding: 0.38rem 0.6rem;
     font-size: 0.78rem;
+  }
+
+  .lead-sheet-chord {
+    display: inline-grid;
+    min-inline-size: 3rem;
+    min-block-size: 3rem;
+    padding-inline: 0.55rem;
+    place-items: center;
+  }
+
+  .lead-sheet-chord .musical-label--chord-chip {
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+  }
+
+  .lead-sheet-chord .musical-label--chord-chip .musical-label__primary,
+  .lead-sheet-chord .musical-label--chord-chip .musical-label__secondary {
+    overflow: visible;
+    text-align: center;
+    text-overflow: clip;
+  }
+
+  .lead-sheet {
+    flex: 0 0 15rem;
+    block-size: 15rem;
+    min-block-size: 15rem;
+  }
+
+  .lead-sheet-lyrics-line {
+    padding-top: 3.25rem;
+  }
+
+  .lead-sheet-lyrics-line__floating-chords {
+    height: 3rem;
+  }
+
+  .lead-sheet-word__chords {
+    min-height: 3rem;
   }
 
   .transport--compact {
@@ -1780,7 +1850,7 @@
   }
 }
 
-@media (max-height: 760px) {
+@media (max-height: 760px) and (min-width: 721px) {
   .lead-sheet,
   .lyrics-theater--practice {
     min-height: 26rem;

--- a/apps/desktop/tests/project-playback-responsive-css.test.ts
+++ b/apps/desktop/tests/project-playback-responsive-css.test.ts
@@ -1,0 +1,190 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const projectPlaybackCss = readFileSync("src/styles/project-playback.css", "utf8");
+
+function cssBlock(source: string, signature: string) {
+  const signatureIndex = source.indexOf(signature);
+  if (signatureIndex < 0) {
+    throw new Error(`CSS signature not found: ${signature}`);
+  }
+  const openBraceIndex = source.indexOf("{", signatureIndex + signature.length);
+  if (openBraceIndex < 0) {
+    throw new Error(`CSS block not found: ${signature}`);
+  }
+  return cssBlockAfterOpenBrace(source, signature, openBraceIndex);
+}
+
+function cssRuleBlock(source: string, selector: string) {
+  let searchIndex = 0;
+  while (searchIndex < source.length) {
+    const selectorIndex = source.indexOf(selector, searchIndex);
+    if (selectorIndex < 0) {
+      break;
+    }
+    const remainder = source.slice(selectorIndex + selector.length);
+    const openBraceOffset = remainder.search(/^\s*\{/);
+    if (openBraceOffset === 0) {
+      const openBraceIndex = source.indexOf("{", selectorIndex + selector.length);
+      return cssBlockAfterOpenBrace(source, selector, openBraceIndex);
+    }
+    searchIndex = selectorIndex + selector.length;
+  }
+  throw new Error(`CSS rule not found: ${selector}`);
+}
+
+function cssBlockAfterOpenBrace(source: string, signature: string, openBraceIndex: number) {
+  let depth = 1;
+  for (let index = openBraceIndex + 1; index < source.length; index += 1) {
+    if (source[index] === "{") {
+      depth += 1;
+    } else if (source[index] === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(openBraceIndex + 1, index);
+      }
+    }
+  }
+  throw new Error(`Unclosed CSS block: ${signature}`);
+}
+
+function cssDeclarations(block: string) {
+  return Object.fromEntries(
+    block
+      .split(";")
+      .map((declaration) => declaration.trim())
+      .filter(Boolean)
+      .map((declaration) => {
+        const separatorIndex = declaration.indexOf(":");
+        return [
+          declaration.slice(0, separatorIndex).trim(),
+          declaration.slice(separatorIndex + 1).trim(),
+        ];
+      }),
+  );
+}
+
+describe("project Playback responsive CSS", () => {
+  it("keeps narrow Practice header and controls outside clipped nested scrolling", () => {
+    const narrowRules = cssBlock(projectPlaybackCss, "@media (max-width: 720px)");
+    const headerDeclarations = cssDeclarations(
+      cssRuleBlock(narrowRules, ".playback-practice-surface__header"),
+    );
+    const controlDeclarations = cssDeclarations(
+      cssRuleBlock(narrowRules, ".playback-practice-surface__controls"),
+    );
+
+    expect(headerDeclarations).toMatchObject({
+      flex: "0 0 auto",
+      "max-height": "none",
+      overflow: "visible",
+    });
+    expect(controlDeclarations).toMatchObject({
+      "align-items": "stretch",
+      "flex-direction": "column",
+      overflow: "visible",
+    });
+    expect(headerDeclarations).not.toMatchObject({
+      "max-height": "4.25rem",
+      overflow: "auto",
+    });
+  });
+
+  it("preserves a usable Practice body by letting the narrow project page grow", () => {
+    const narrowRules = cssBlock(projectPlaybackCss, "@media (max-width: 720px)");
+    const screenDeclarations = cssDeclarations(
+      cssRuleBlock(narrowRules, ".project-screen--playback"),
+    );
+    const workspaceDeclarations = cssDeclarations(
+      cssRuleBlock(narrowRules, ".playback-workspace--practice"),
+    );
+    const surfaceDeclarations = cssDeclarations(
+      cssRuleBlock(narrowRules, ".playback-practice-surface"),
+    );
+    const bodyDeclarations = cssDeclarations(
+      cssRuleBlock(narrowRules, ".playback-practice-body"),
+    );
+    const leadSheetDeclarations = cssDeclarations(cssRuleBlock(narrowRules, ".lead-sheet"));
+
+    expect(screenDeclarations).toMatchObject({
+      height: "auto",
+      overflow: "visible",
+    });
+    expect(workspaceDeclarations).toMatchObject({
+      flex: "0 0 auto",
+      "grid-template-rows": "minmax(0, 2.75rem) auto auto",
+      overflow: "visible",
+    });
+    expect(surfaceDeclarations).toMatchObject({
+      height: "auto",
+      overflow: "visible",
+    });
+    expect(bodyDeclarations).toMatchObject({
+      flex: "0 0 auto",
+      "min-block-size": "15rem",
+    });
+    expect(leadSheetDeclarations).toMatchObject({
+      "block-size": "15rem",
+      flex: "0 0 15rem",
+      "min-block-size": "15rem",
+    });
+  });
+
+  it("keeps short-height desktop expansion out of the narrow cascade", () => {
+    const shortDesktopRules = cssBlock(
+      projectPlaybackCss,
+      "@media (max-height: 760px) and (min-width: 721px)",
+    );
+    const desktopLeadSheetDeclarations = cssDeclarations(
+      cssBlock(shortDesktopRules, ".lead-sheet,"),
+    );
+    const narrowRules = cssBlock(projectPlaybackCss, "@media (max-width: 720px)");
+    const narrowLeadSheetDeclarations = cssDeclarations(
+      cssRuleBlock(narrowRules, ".lead-sheet"),
+    );
+
+    expect(desktopLeadSheetDeclarations).toMatchObject({
+      "max-height": "26rem",
+      "min-height": "26rem",
+    });
+    expect(narrowLeadSheetDeclarations).toMatchObject({
+      "block-size": "15rem",
+      "min-block-size": "15rem",
+    });
+    expect(projectPlaybackCss).not.toContain("@media (max-height: 760px) {");
+  });
+
+  it("centers narrow chord labels inside visible touch targets", () => {
+    const narrowRules = cssBlock(projectPlaybackCss, "@media (max-width: 720px)");
+    const markerDeclarations = cssDeclarations(
+      cssRuleBlock(narrowRules, ".lead-sheet-chord"),
+    );
+    const labelDeclarations = cssDeclarations(
+      cssRuleBlock(narrowRules, ".lead-sheet-chord .musical-label--chord-chip"),
+    );
+    const labelTextDeclarations = cssDeclarations(
+      cssBlock(
+        narrowRules,
+        ".lead-sheet-chord .musical-label--chord-chip .musical-label__primary,",
+      ),
+    );
+
+    expect(markerDeclarations).toMatchObject({
+      display: "inline-grid",
+      "min-block-size": "3rem",
+      "min-inline-size": "3rem",
+      "padding-inline": "0.55rem",
+      "place-items": "center",
+    });
+    expect(labelDeclarations).toMatchObject({
+      "align-items": "center",
+      "justify-content": "center",
+      "text-align": "center",
+    });
+    expect(labelTextDeclarations).toMatchObject({
+      overflow: "visible",
+      "text-align": "center",
+      "text-overflow": "clip",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add truthful loading, empty, error, and partial-failure states for synced lyrics and chords.
- Preserve Practice mode choices with temporary availability fallback and timed-only Lyrics Follow.
- Make shared Practice playback usable on narrow Android layouts while preserving desktop geometry.
- Add mobile interaction and responsive CSS regression coverage.
- Closes #333

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `git diff --check`
- Android emulator: synced a project and checked lane modes, scrolling, transport reachability, and paused highlighting within the available playback window.
- Reviewer, contract guard, and Product Design QA passed.
