### PR TITLE
feat: add cross-platform wake inhibition

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -7404,6 +7404,7 @@ dependencies = [
  "if-addrs",
  "iroh",
  "iroh-blobs",
+ "jni 0.21.1",
  "ndk-context",
  "ndk-sys",
  "objc2",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -58,6 +58,7 @@ ed25519-dalek = "2.2.0"
 if-addrs = "0.15.0"
 iroh = "1.0.0-rc.0"
 iroh-blobs = { version = "0.103.0", features = ["fs-store"] }
+jni = "0.21.1"
 ndk-sys = { version = "0.6.0", features = ["media"] }
 ndk-context = "0.1.1"
 rand = "0.10.1"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ use tauri::{AppHandle, Manager, State};
 mod file_dialog_scope;
 mod mobile_backend;
 mod native_audio;
+pub mod power_inhibition;
 mod sync_transport;
 mod system_media;
 
@@ -368,14 +369,17 @@ pub fn run() {
             } else {
                 spawn_packaged_backend(app.handle())?
             };
+            let power_inhibition = power_inhibition::PowerInhibitionState::new();
             let sync_transport = sync_transport::SyncTransportState::new(
                 runtime.base_url.clone(),
                 app.handle().clone(),
+                power_inhibition.clone(),
             );
             app.manage(runtime);
             app.manage(native_audio::NativeAudioState::new());
             app.manage(sync_transport);
             app.manage(system_media::SystemMediaState::new(app.handle().clone()));
+            app.manage(power_inhibition);
             #[cfg(target_os = "linux")]
             install_linux_media_permission_handler(app.handle())?;
             Ok(())
@@ -404,7 +408,9 @@ pub fn run() {
             native_audio::audio_set_monitor,
             system_media::system_media_update_state,
             system_media::system_media_clear_state,
-            system_media::system_media_set_idle_inhibition,
+            power_inhibition::system_media_set_idle_inhibition,
+            power_inhibition::power_inhibition_set_activity,
+            power_inhibition::power_inhibition_status,
             sync_transport::sync_transport_start_listener,
             sync_transport::sync_transport_stop_listener,
             sync_transport::sync_transport_status,
@@ -457,6 +463,8 @@ pub fn run() {
         if let tauri::RunEvent::Exit = event {
             let sync_transport = app_handle.state::<sync_transport::SyncTransportState>();
             sync_transport.shutdown();
+            let power_inhibition = app_handle.state::<power_inhibition::PowerInhibitionState>();
+            power_inhibition.shutdown();
             let runtime = app_handle.state::<BackendRuntime>();
             runtime.shutdown();
         }

--- a/apps/desktop/src-tauri/src/power_inhibition.rs
+++ b/apps/desktop/src-tauri/src/power_inhibition.rs
@@ -1,0 +1,1164 @@
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{Arc, Mutex};
+use tauri::State;
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PowerInhibitionReason {
+    Playback,
+    SyncListener,
+    SyncTransfer,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PowerInhibitionPhase {
+    Inactive,
+    Acquiring,
+    Active,
+    Unsupported,
+    Failed,
+    Releasing,
+    ReleaseFailed,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PowerInhibitionStatus {
+    pub phase: PowerInhibitionPhase,
+    pub backend: Option<String>,
+    pub active_reasons: Vec<PowerInhibitionReason>,
+    pub screen_protected: bool,
+    pub background_protected: bool,
+    pub error_code: Option<String>,
+    pub error_message: Option<String>,
+}
+
+impl Default for PowerInhibitionStatus {
+    fn default() -> Self {
+        Self {
+            phase: PowerInhibitionPhase::Inactive,
+            backend: None,
+            active_reasons: Vec::new(),
+            screen_protected: false,
+            background_protected: false,
+            error_code: None,
+            error_message: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct PlatformDetails {
+    backend: &'static str,
+    screen_protected: bool,
+    background_protected: bool,
+}
+
+#[derive(Clone, Debug)]
+struct SafeError {
+    code: &'static str,
+    message: &'static str,
+}
+
+struct PlatformProbe {
+    details: Option<PlatformDetails>,
+    error: Option<SafeError>,
+    pending_phase: Option<PowerInhibitionPhase>,
+    data_sync_timeout_epoch: u64,
+}
+
+#[cfg(any(test, target_os = "android"))]
+fn parse_android_response(response: &str) -> Result<PlatformProbe, SafeError> {
+    let mut parts = response.split(';');
+    let phase = parts.next().unwrap_or_default();
+    let mask = parts
+        .next()
+        .and_then(|value| value.parse::<i32>().ok())
+        .unwrap_or(0);
+    let error_code = parts.next().unwrap_or("none");
+    let _requested_mask = parts.next();
+    let data_sync_timeout_epoch = parts
+        .next()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(0);
+    let screen_protected = parts.next() == Some("true");
+    let details = (mask != 0).then_some(PlatformDetails {
+        backend: "android-foreground-service",
+        screen_protected,
+        background_protected: true,
+    });
+    let confirmed = details.is_some();
+    let error = match error_code {
+        "none" if matches!(phase, "active" | "inactive" | "acquiring" | "releasing") => None,
+        "android-data-sync-timeout" => Some(SafeError {
+            code: "android-data-sync-timeout",
+            message: "Android stopped sync power protection after its system time limit.",
+        }),
+        "android-notification-permission-denied" => Some(SafeError {
+            code: "android-notification-permission-denied",
+            message: if confirmed {
+                "Power protection is active, but Android notification visibility is unavailable. Android still shows active work in system controls."
+            } else {
+                "Android notification permission is unavailable, and power protection is not confirmed."
+            },
+        }),
+        "android-notification-post-failed" => Some(SafeError {
+            code: "android-notification-post-failed",
+            message: if confirmed {
+                "Power protection is active, but Android notification visibility could not be confirmed."
+            } else {
+                "Android notification visibility and power protection could not be confirmed."
+            },
+        }),
+        _ => {
+            return Err(SafeError {
+                code: "android-inhibition-failed",
+                message: "Android power protection could not be updated.",
+            });
+        }
+    };
+    let pending_phase = match phase {
+        "acquiring" => Some(PowerInhibitionPhase::Acquiring),
+        "releasing" => Some(PowerInhibitionPhase::Releasing),
+        _ => None,
+    };
+    Ok(PlatformProbe {
+        details,
+        error,
+        pending_phase,
+        data_sync_timeout_epoch,
+    })
+}
+
+trait PlatformInhibitor: Send {
+    fn acquire(
+        &mut self,
+        reasons: &[PowerInhibitionReason],
+    ) -> Result<Option<PlatformDetails>, SafeError>;
+    fn release(&mut self) -> Result<(), SafeError>;
+
+    fn probe(&mut self) -> Option<PlatformProbe> {
+        None
+    }
+}
+
+#[derive(Clone)]
+pub struct PowerInhibitionState {
+    runtime: Arc<Mutex<PowerInhibitionRuntime>>,
+}
+
+struct PowerInhibitionRuntime {
+    platform: Box<dyn PlatformInhibitor>,
+    frontend_reasons: BTreeSet<PowerInhibitionReason>,
+    scoped_reasons: BTreeMap<PowerInhibitionReason, u32>,
+    confirmed: Option<PlatformDetails>,
+    platform_maybe_active: bool,
+    data_sync_timeout_epoch: u64,
+    status: PowerInhibitionStatus,
+}
+
+impl PowerInhibitionState {
+    pub fn new() -> Self {
+        Self::with_platform(platform::current())
+    }
+
+    fn with_platform(platform: Box<dyn PlatformInhibitor>) -> Self {
+        Self {
+            runtime: Arc::new(Mutex::new(PowerInhibitionRuntime {
+                platform,
+                frontend_reasons: BTreeSet::new(),
+                scoped_reasons: BTreeMap::new(),
+                confirmed: None,
+                platform_maybe_active: false,
+                data_sync_timeout_epoch: 0,
+                status: PowerInhibitionStatus::default(),
+            })),
+        }
+    }
+
+    pub fn set_activity(
+        &self,
+        reason: PowerInhibitionReason,
+        active: bool,
+    ) -> Result<PowerInhibitionStatus, String> {
+        let mut runtime = self.lock()?;
+        if active {
+            runtime.frontend_reasons.insert(reason);
+        } else {
+            runtime.frontend_reasons.remove(&reason);
+        }
+        runtime.reconcile();
+        Ok(runtime.status.clone())
+    }
+
+    pub fn acquire_scoped(
+        &self,
+        reason: PowerInhibitionReason,
+    ) -> Result<PowerInhibitionGuard, String> {
+        let mut runtime = self.lock()?;
+        let count = runtime.scoped_reasons.entry(reason).or_default();
+        *count = count.saturating_add(1);
+        runtime.reconcile();
+        Ok(PowerInhibitionGuard {
+            state: self.clone(),
+            reason,
+            active: true,
+        })
+    }
+
+    pub fn status(&self) -> Result<PowerInhibitionStatus, String> {
+        let mut runtime = self.lock()?;
+        runtime.refresh_platform_status();
+        Ok(runtime.status.clone())
+    }
+
+    pub fn shutdown(&self) {
+        if let Ok(mut runtime) = self.runtime.lock() {
+            runtime.frontend_reasons.clear();
+            runtime.scoped_reasons.clear();
+            runtime.reconcile();
+        }
+    }
+
+    pub fn data_sync_timeout_epoch(&self) -> u64 {
+        let Ok(mut runtime) = self.runtime.lock() else {
+            return 0;
+        };
+        runtime.refresh_platform_status();
+        runtime.data_sync_timeout_epoch
+    }
+
+    fn release_scoped(&self, reason: PowerInhibitionReason) {
+        if let Ok(mut runtime) = self.runtime.lock() {
+            if let Some(count) = runtime.scoped_reasons.get_mut(&reason) {
+                *count = count.saturating_sub(1);
+                if *count == 0 {
+                    runtime.scoped_reasons.remove(&reason);
+                }
+            }
+            runtime.reconcile();
+        }
+    }
+
+    fn lock(&self) -> Result<std::sync::MutexGuard<'_, PowerInhibitionRuntime>, String> {
+        self.runtime
+            .lock()
+            .map_err(|_| "Power protection state is unavailable.".to_string())
+    }
+}
+
+pub struct PowerInhibitionGuard {
+    state: PowerInhibitionState,
+    reason: PowerInhibitionReason,
+    active: bool,
+}
+
+impl PowerInhibitionGuard {
+    pub fn release(mut self) {
+        if self.active {
+            self.state.release_scoped(self.reason);
+            self.active = false;
+        }
+    }
+}
+
+impl Drop for PowerInhibitionGuard {
+    fn drop(&mut self) {
+        if self.active {
+            self.state.release_scoped(self.reason);
+            self.active = false;
+        }
+    }
+}
+
+impl PowerInhibitionRuntime {
+    fn reasons(&self) -> Vec<PowerInhibitionReason> {
+        self.frontend_reasons
+            .iter()
+            .copied()
+            .chain(
+                self.scoped_reasons
+                    .iter()
+                    .filter(|(_, count)| **count > 0)
+                    .map(|(reason, _)| *reason),
+            )
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
+    }
+
+    fn reconcile(&mut self) {
+        let reasons = self.reasons();
+        if reasons == self.status.active_reasons
+            && matches!(
+                self.status.phase,
+                PowerInhibitionPhase::Active | PowerInhibitionPhase::Unsupported
+            )
+        {
+            return;
+        }
+        self.status.error_code = None;
+        self.status.error_message = None;
+
+        if reasons.is_empty() {
+            if !self.platform_maybe_active
+                && !matches!(self.status.phase, PowerInhibitionPhase::ReleaseFailed)
+            {
+                self.status = PowerInhibitionStatus::default();
+                return;
+            }
+
+            self.status.phase = PowerInhibitionPhase::Releasing;
+            match self.platform.release() {
+                Ok(()) => {
+                    if let Some(probe) = self.platform.probe() {
+                        self.apply_release_probe(probe);
+                    } else {
+                        self.confirmed = None;
+                        self.platform_maybe_active = false;
+                        self.status = PowerInhibitionStatus::default();
+                    }
+                }
+                Err(error) => {
+                    self.status.phase = PowerInhibitionPhase::ReleaseFailed;
+                    self.set_error(error);
+                    self.apply_confirmed_details();
+                }
+            }
+            return;
+        }
+
+        self.status.active_reasons = reasons.clone();
+        self.status.phase = PowerInhibitionPhase::Acquiring;
+        self.platform_maybe_active = true;
+        match self.platform.acquire(&reasons) {
+            Ok(Some(details)) => {
+                self.confirmed = Some(details);
+                self.status.phase = PowerInhibitionPhase::Active;
+                self.apply_confirmed_details();
+            }
+            Ok(None) => {
+                if let Some(probe) = self.platform.probe() {
+                    self.apply_acquire_probe(probe);
+                } else {
+                    self.confirmed = None;
+                    self.platform_maybe_active = false;
+                    self.status.phase = PowerInhibitionPhase::Unsupported;
+                    self.status.backend = None;
+                    self.status.screen_protected = false;
+                    self.status.background_protected = false;
+                    self.set_error(SafeError {
+                        code: "power-inhibition-unsupported",
+                        message: "Power protection is unavailable on this platform.",
+                    });
+                }
+            }
+            Err(error) => {
+                self.status.phase = PowerInhibitionPhase::Failed;
+                self.set_error(error);
+                self.apply_confirmed_details();
+            }
+        }
+    }
+
+    fn refresh_platform_status(&mut self) {
+        let Some(probe) = self.platform.probe() else {
+            return;
+        };
+        self.data_sync_timeout_epoch = self
+            .data_sync_timeout_epoch
+            .max(probe.data_sync_timeout_epoch);
+        self.confirmed = probe.details;
+        if let Some(error) = probe.error {
+            self.status.phase = if self.reasons().is_empty() {
+                PowerInhibitionPhase::ReleaseFailed
+            } else {
+                PowerInhibitionPhase::Failed
+            };
+            self.set_error(error);
+        } else if let Some(phase) = probe.pending_phase {
+            self.status.phase = phase;
+            self.status.error_code = None;
+            self.status.error_message = None;
+        } else if self.confirmed.is_some() {
+            self.status.phase = PowerInhibitionPhase::Active;
+            self.status.error_code = None;
+            self.status.error_message = None;
+        } else if !self.reasons().is_empty() {
+            self.status.phase = PowerInhibitionPhase::Failed;
+            self.set_error(SafeError {
+                code: "power-inhibition-lost",
+                message: "Power protection stopped unexpectedly.",
+            });
+        } else {
+            self.platform_maybe_active = false;
+            self.status = PowerInhibitionStatus::default();
+            return;
+        }
+        self.apply_confirmed_details();
+    }
+
+    fn apply_acquire_probe(&mut self, probe: PlatformProbe) {
+        self.data_sync_timeout_epoch = self
+            .data_sync_timeout_epoch
+            .max(probe.data_sync_timeout_epoch);
+        self.confirmed = probe.details;
+        if let Some(error) = probe.error {
+            self.status.phase = PowerInhibitionPhase::Failed;
+            self.set_error(error);
+        } else if let Some(phase) = probe.pending_phase {
+            self.status.phase = phase;
+            self.status.error_code = None;
+            self.status.error_message = None;
+        } else if self.confirmed.is_some() {
+            self.status.phase = PowerInhibitionPhase::Active;
+            self.status.error_code = None;
+            self.status.error_message = None;
+        } else {
+            self.status.phase = PowerInhibitionPhase::Failed;
+            self.set_error(SafeError {
+                code: "power-inhibition-lost",
+                message: "Power protection stopped unexpectedly.",
+            });
+        }
+        self.apply_confirmed_details();
+    }
+
+    fn apply_release_probe(&mut self, probe: PlatformProbe) {
+        self.data_sync_timeout_epoch = self
+            .data_sync_timeout_epoch
+            .max(probe.data_sync_timeout_epoch);
+        self.confirmed = probe.details;
+        if let Some(error) = probe.error {
+            self.status.phase = PowerInhibitionPhase::ReleaseFailed;
+            self.set_error(error);
+            self.apply_confirmed_details();
+        } else if probe.pending_phase.is_some() || self.confirmed.is_some() {
+            self.status.phase = PowerInhibitionPhase::Releasing;
+            self.status.error_code = None;
+            self.status.error_message = None;
+            self.apply_confirmed_details();
+        } else {
+            self.platform_maybe_active = false;
+            self.status = PowerInhibitionStatus::default();
+        }
+    }
+
+    fn set_error(&mut self, error: SafeError) {
+        self.status.error_code = Some(error.code.to_string());
+        self.status.error_message = Some(error.message.to_string());
+    }
+
+    fn apply_confirmed_details(&mut self) {
+        if let Some(details) = &self.confirmed {
+            self.status.backend = Some(details.backend.to_string());
+            self.status.screen_protected = details.screen_protected;
+            self.status.background_protected = details.background_protected;
+        } else {
+            self.status.backend = None;
+            self.status.screen_protected = false;
+            self.status.background_protected = false;
+        }
+    }
+}
+
+#[tauri::command]
+pub fn power_inhibition_set_activity(
+    state: State<'_, PowerInhibitionState>,
+    reason: PowerInhibitionReason,
+    active: bool,
+) -> Result<PowerInhibitionStatus, String> {
+    state.set_activity(reason, active)
+}
+
+#[tauri::command]
+pub fn power_inhibition_status(
+    state: State<'_, PowerInhibitionState>,
+) -> Result<PowerInhibitionStatus, String> {
+    state.status()
+}
+
+#[tauri::command]
+pub fn system_media_set_idle_inhibition(
+    state: State<'_, PowerInhibitionState>,
+    active: bool,
+) -> Result<(), String> {
+    state
+        .set_activity(PowerInhibitionReason::Playback, active)
+        .map(|_| ())
+}
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use super::*;
+    use std::ffi::{c_char, c_void, CString};
+
+    type CFAllocatorRef = *const c_void;
+    type CFStringRef = *const c_void;
+    type IOPMAssertionID = u32;
+    type IOReturn = i32;
+
+    const K_CF_STRING_ENCODING_UTF8: u32 = 0x0800_0100;
+    const K_IOPM_ASSERTION_LEVEL_ON: u32 = 255;
+    const K_IO_RETURN_SUCCESS: IOReturn = 0;
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
+        fn CFStringCreateWithCString(
+            alloc: CFAllocatorRef,
+            c_str: *const c_char,
+            encoding: u32,
+        ) -> CFStringRef;
+        fn CFRelease(cf: *const c_void);
+    }
+
+    #[link(name = "IOKit", kind = "framework")]
+    extern "C" {
+        fn IOPMAssertionCreateWithName(
+            assertion_type: CFStringRef,
+            level: u32,
+            assertion_name: CFStringRef,
+            assertion_id: *mut IOPMAssertionID,
+        ) -> IOReturn;
+        fn IOPMAssertionRelease(assertion_id: IOPMAssertionID) -> IOReturn;
+    }
+
+    #[derive(Default)]
+    struct MacOsInhibitor {
+        assertion_id: Option<IOPMAssertionID>,
+    }
+
+    impl PlatformInhibitor for MacOsInhibitor {
+        fn acquire(
+            &mut self,
+            _reasons: &[PowerInhibitionReason],
+        ) -> Result<Option<PlatformDetails>, SafeError> {
+            if self.assertion_id.is_none() {
+                let assertion_type = cf_string("NoDisplaySleepAssertion")?;
+                let assertion_name = cf_string("TuneForge playback and sync")?;
+                let mut assertion_id = 0;
+                let result = unsafe {
+                    IOPMAssertionCreateWithName(
+                        assertion_type,
+                        K_IOPM_ASSERTION_LEVEL_ON,
+                        assertion_name,
+                        &mut assertion_id,
+                    )
+                };
+                unsafe {
+                    CFRelease(assertion_type);
+                    CFRelease(assertion_name);
+                }
+                if result != K_IO_RETURN_SUCCESS {
+                    return Err(acquire_error());
+                }
+                self.assertion_id = Some(assertion_id);
+            }
+            Ok(Some(PlatformDetails {
+                backend: "macos-iopm",
+                screen_protected: true,
+                background_protected: true,
+            }))
+        }
+
+        fn release(&mut self) -> Result<(), SafeError> {
+            let Some(assertion_id) = self.assertion_id else {
+                return Ok(());
+            };
+            if unsafe { IOPMAssertionRelease(assertion_id) } != K_IO_RETURN_SUCCESS {
+                return Err(SafeError {
+                    code: "macos-inhibition-release-failed",
+                    message: "macOS power protection could not be released.",
+                });
+            }
+            self.assertion_id = None;
+            Ok(())
+        }
+    }
+
+    fn cf_string(value: &str) -> Result<CFStringRef, SafeError> {
+        let value = CString::new(value).map_err(|_| acquire_error())?;
+        let value = unsafe {
+            CFStringCreateWithCString(std::ptr::null(), value.as_ptr(), K_CF_STRING_ENCODING_UTF8)
+        };
+        if value.is_null() {
+            return Err(acquire_error());
+        }
+        Ok(value)
+    }
+
+    fn acquire_error() -> SafeError {
+        SafeError {
+            code: "macos-inhibition-failed",
+            message: "macOS power protection could not be enabled.",
+        }
+    }
+
+    pub(super) fn current() -> Box<dyn PlatformInhibitor> {
+        Box::<MacOsInhibitor>::default()
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod platform {
+    use super::*;
+    use dbus::arg::{OwnedFd, PropMap, Variant};
+    use dbus::blocking::Connection;
+    use dbus::message::MatchRule;
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
+
+    const PORTAL_DESTINATION: &str = "org.freedesktop.portal.Desktop";
+    const PORTAL_PATH: &str = "/org/freedesktop/portal/desktop";
+    const PORTAL_INHIBIT_INTERFACE: &str = "org.freedesktop.portal.Inhibit";
+    const PORTAL_REQUEST_INTERFACE: &str = "org.freedesktop.portal.Request";
+    const LOGIND_DESTINATION: &str = "org.freedesktop.login1";
+    const LOGIND_PATH: &str = "/org/freedesktop/login1";
+    const LOGIND_INTERFACE: &str = "org.freedesktop.login1.Manager";
+
+    enum LinuxHandle {
+        Portal {
+            connection: Connection,
+            request_path: dbus::Path<'static>,
+        },
+        Logind {
+            _fd: OwnedFd,
+        },
+    }
+
+    #[derive(Default)]
+    struct LinuxInhibitor {
+        handle: Option<LinuxHandle>,
+    }
+
+    impl PlatformInhibitor for LinuxInhibitor {
+        fn acquire(
+            &mut self,
+            _reasons: &[PowerInhibitionReason],
+        ) -> Result<Option<PlatformDetails>, SafeError> {
+            if let Some(handle) = &self.handle {
+                return Ok(Some(details(handle)));
+            }
+
+            if let Ok(handle) = acquire_portal() {
+                let result = Some(details(&handle));
+                self.handle = Some(handle);
+                return Ok(result);
+            }
+            if let Ok(handle) = acquire_logind() {
+                let result = Some(details(&handle));
+                self.handle = Some(handle);
+                return Ok(result);
+            }
+            Err(SafeError {
+                code: "linux-inhibition-failed",
+                message: "Linux power protection is unavailable through the desktop portal or system service.",
+            })
+        }
+
+        fn release(&mut self) -> Result<(), SafeError> {
+            let Some(handle) = self.handle.as_ref() else {
+                return Ok(());
+            };
+            if let LinuxHandle::Portal {
+                connection,
+                request_path,
+            } = handle
+            {
+                let proxy = connection.with_proxy(
+                    PORTAL_DESTINATION,
+                    request_path.clone(),
+                    Duration::from_secs(2),
+                );
+                proxy
+                    .method_call::<(), _, _, _>(PORTAL_REQUEST_INTERFACE, "Close", ())
+                    .map_err(|_| SafeError {
+                        code: "linux-inhibition-release-failed",
+                        message: "Linux power protection could not be released.",
+                    })?;
+            }
+            self.handle = None;
+            Ok(())
+        }
+    }
+
+    fn details(handle: &LinuxHandle) -> PlatformDetails {
+        PlatformDetails {
+            backend: match handle {
+                LinuxHandle::Portal { .. } => "xdg-desktop-portal",
+                LinuxHandle::Logind { .. } => "systemd-logind",
+            },
+            screen_protected: true,
+            background_protected: true,
+        }
+    }
+
+    fn acquire_portal() -> Result<LinuxHandle, ()> {
+        let connection = Connection::new_session().map_err(|_| ())?;
+        let response = Arc::new(Mutex::new(None::<u32>));
+        let response_for_match = response.clone();
+        let rule = MatchRule::new_signal(PORTAL_REQUEST_INTERFACE, "Response");
+        connection
+            .add_match(rule, move |(code, _results): (u32, PropMap), _, _| {
+                if let Ok(mut response) = response_for_match.lock() {
+                    *response = Some(code);
+                }
+                true
+            })
+            .map_err(|_| ())?;
+
+        let token = format!("tuneforge_{}", std::process::id());
+        let mut options = PropMap::new();
+        options.insert("handle_token".into(), Variant(Box::new(token)));
+        let proxy = connection.with_proxy(PORTAL_DESTINATION, PORTAL_PATH, Duration::from_secs(2));
+        let (request_path,): (dbus::Path<'static>,) = proxy
+            .method_call(PORTAL_INHIBIT_INTERFACE, "Inhibit", ("", 12u32, options))
+            .map_err(|_| ())?;
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            connection
+                .process(Duration::from_millis(100))
+                .map_err(|_| ())?;
+            if let Some(code) = *response.lock().map_err(|_| ())? {
+                if code == 0 {
+                    return Ok(LinuxHandle::Portal {
+                        connection,
+                        request_path,
+                    });
+                }
+                break;
+            }
+        }
+        Err(())
+    }
+
+    fn acquire_logind() -> Result<LinuxHandle, ()> {
+        let connection = Connection::new_system().map_err(|_| ())?;
+        let proxy = connection.with_proxy(LOGIND_DESTINATION, LOGIND_PATH, Duration::from_secs(2));
+        let (fd,): (OwnedFd,) = proxy
+            .method_call(
+                LOGIND_INTERFACE,
+                "Inhibit",
+                (
+                    "sleep:idle",
+                    "TuneForge",
+                    "Playback or sync is active",
+                    "block",
+                ),
+            )
+            .map_err(|_| ())?;
+        Ok(LinuxHandle::Logind { _fd: fd })
+    }
+
+    pub(super) fn current() -> Box<dyn PlatformInhibitor> {
+        Box::<LinuxInhibitor>::default()
+    }
+}
+
+#[cfg(target_os = "android")]
+mod platform {
+    use super::*;
+    use jni::objects::{JObject, JValue};
+    use jni::JavaVM;
+
+    #[derive(Default)]
+    struct AndroidInhibitor;
+
+    impl PlatformInhibitor for AndroidInhibitor {
+        fn acquire(
+            &mut self,
+            reasons: &[PowerInhibitionReason],
+        ) -> Result<Option<PlatformDetails>, SafeError> {
+            let mask = reason_mask(reasons);
+            let response = call_android("setTuneForgePowerInhibition", mask)?;
+            let probe = parse_android_response(&response)?;
+            if let Some(error) = probe.error {
+                return Err(error);
+            }
+            if probe.pending_phase == Some(PowerInhibitionPhase::Acquiring) {
+                return Ok(None);
+            }
+            probe.details.map(Some).ok_or_else(android_error)
+        }
+
+        fn release(&mut self) -> Result<(), SafeError> {
+            let response = call_android("setTuneForgePowerInhibition", 0)?;
+            let probe = parse_android_response(&response)?;
+            if probe.error.is_some() {
+                return Err(SafeError {
+                    code: "android-inhibition-release-failed",
+                    message: "Android power protection could not be released.",
+                });
+            }
+            Ok(())
+        }
+
+        fn probe(&mut self) -> Option<PlatformProbe> {
+            Some(
+                call_android("getTuneForgePowerInhibitionStatus", 0)
+                    .and_then(|response| parse_android_response(&response))
+                    .unwrap_or_else(|error| PlatformProbe {
+                        details: None,
+                        error: Some(error),
+                        pending_phase: None,
+                        data_sync_timeout_epoch: 0,
+                    }),
+            )
+        }
+    }
+
+    fn reason_mask(reasons: &[PowerInhibitionReason]) -> i32 {
+        reasons.iter().fold(0, |mask, reason| {
+            mask | match reason {
+                PowerInhibitionReason::Playback => 1,
+                PowerInhibitionReason::SyncListener => 2,
+                PowerInhibitionReason::SyncTransfer => 4,
+            }
+        })
+    }
+
+    fn call_android(method: &str, mask: i32) -> Result<String, SafeError> {
+        use tauri::tao::platform::android::prelude::main_android_context;
+
+        let context = main_android_context().ok_or_else(android_error)?;
+        if context.java_vm.is_null() || context.context_jobject.is_null() {
+            return Err(android_error());
+        }
+        let vm =
+            unsafe { JavaVM::from_raw(context.java_vm.cast()) }.map_err(|_| android_error())?;
+        let mut env = vm.attach_current_thread().map_err(|_| android_error())?;
+        let activity = unsafe { JObject::from_raw(context.context_jobject.cast()) };
+        let result = if method == "setTuneForgePowerInhibition" {
+            env.call_method(
+                &activity,
+                method,
+                "(I)Ljava/lang/String;",
+                &[JValue::Int(mask)],
+            )
+        } else {
+            env.call_method(&activity, method, "()Ljava/lang/String;", &[])
+        }
+        .and_then(|value| value.l());
+        std::mem::forget(activity);
+        let result = result.map_err(|_| android_error())?;
+        let result = jni::objects::JString::from(result);
+        env.get_string(&result)
+            .map(|value| value.to_string_lossy().into_owned())
+            .map_err(|_| android_error())
+    }
+
+    fn android_error() -> SafeError {
+        SafeError {
+            code: "android-inhibition-failed",
+            message: "Android power protection could not be updated.",
+        }
+    }
+
+    pub(super) fn current() -> Box<dyn PlatformInhibitor> {
+        Box::<AndroidInhibitor>::default()
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
+mod platform {
+    use super::*;
+
+    struct UnsupportedInhibitor;
+
+    impl PlatformInhibitor for UnsupportedInhibitor {
+        fn acquire(
+            &mut self,
+            _reasons: &[PowerInhibitionReason],
+        ) -> Result<Option<PlatformDetails>, SafeError> {
+            Ok(None)
+        }
+
+        fn release(&mut self) -> Result<(), SafeError> {
+            Ok(())
+        }
+    }
+
+    pub(super) fn current() -> Box<dyn PlatformInhibitor> {
+        Box::new(UnsupportedInhibitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone, Default)]
+    struct FakeControl {
+        acquisitions: Arc<Mutex<Vec<Vec<PowerInhibitionReason>>>>,
+        releases: Arc<Mutex<u32>>,
+        acquire_error: Arc<Mutex<bool>>,
+        release_error: Arc<Mutex<bool>>,
+        unsupported: Arc<Mutex<bool>>,
+        probes: Arc<Mutex<VecDeque<PlatformProbe>>>,
+    }
+
+    struct FakePlatform(FakeControl);
+
+    impl PlatformInhibitor for FakePlatform {
+        fn acquire(
+            &mut self,
+            reasons: &[PowerInhibitionReason],
+        ) -> Result<Option<PlatformDetails>, SafeError> {
+            self.0.acquisitions.lock().unwrap().push(reasons.to_vec());
+            if *self.0.unsupported.lock().unwrap() {
+                return Ok(None);
+            }
+            if *self.0.acquire_error.lock().unwrap() {
+                return Err(SafeError {
+                    code: "test-acquire-failed",
+                    message: "Power protection could not be enabled.",
+                });
+            }
+            Ok(Some(PlatformDetails {
+                backend: "test",
+                screen_protected: reasons.contains(&PowerInhibitionReason::Playback),
+                background_protected: true,
+            }))
+        }
+
+        fn release(&mut self) -> Result<(), SafeError> {
+            *self.0.releases.lock().unwrap() += 1;
+            if *self.0.release_error.lock().unwrap() {
+                return Err(SafeError {
+                    code: "test-release-failed",
+                    message: "Power protection could not be released.",
+                });
+            }
+            Ok(())
+        }
+
+        fn probe(&mut self) -> Option<PlatformProbe> {
+            self.0.probes.lock().unwrap().pop_front()
+        }
+    }
+
+    fn state() -> (PowerInhibitionState, FakeControl) {
+        let control = FakeControl::default();
+        let state = PowerInhibitionState::with_platform(Box::new(FakePlatform(control.clone())));
+        (state, control)
+    }
+
+    #[test]
+    fn frontend_activity_is_idempotent() {
+        let (state, control) = state();
+        state
+            .set_activity(PowerInhibitionReason::Playback, true)
+            .unwrap();
+        state
+            .set_activity(PowerInhibitionReason::Playback, true)
+            .unwrap();
+        state
+            .set_activity(PowerInhibitionReason::Playback, false)
+            .unwrap();
+        state
+            .set_activity(PowerInhibitionReason::Playback, false)
+            .unwrap();
+
+        assert_eq!(*control.releases.lock().unwrap(), 1);
+        assert_eq!(control.acquisitions.lock().unwrap().len(), 1);
+        assert_eq!(
+            state.status().unwrap().phase,
+            PowerInhibitionPhase::Inactive
+        );
+    }
+
+    #[test]
+    fn scoped_holds_are_counted_and_reasons_do_not_release_each_other() {
+        let (state, control) = state();
+        let first = state
+            .acquire_scoped(PowerInhibitionReason::SyncTransfer)
+            .unwrap();
+        let second = state
+            .acquire_scoped(PowerInhibitionReason::SyncTransfer)
+            .unwrap();
+        let listener = state
+            .acquire_scoped(PowerInhibitionReason::SyncListener)
+            .unwrap();
+
+        drop(first);
+        drop(listener);
+        assert_eq!(*control.releases.lock().unwrap(), 0);
+        assert_eq!(
+            state.status().unwrap().active_reasons,
+            vec![PowerInhibitionReason::SyncTransfer]
+        );
+        drop(second);
+        assert_eq!(*control.releases.lock().unwrap(), 1);
+    }
+
+    #[test]
+    fn acquisition_failure_is_safe_and_retryable() {
+        let (state, control) = state();
+        *control.acquire_error.lock().unwrap() = true;
+        let failed = state
+            .set_activity(PowerInhibitionReason::Playback, true)
+            .unwrap();
+        assert_eq!(failed.phase, PowerInhibitionPhase::Failed);
+        assert_eq!(failed.error_code.as_deref(), Some("test-acquire-failed"));
+        assert_eq!(failed.backend, None);
+
+        *control.acquire_error.lock().unwrap() = false;
+        let active = state
+            .set_activity(PowerInhibitionReason::Playback, true)
+            .unwrap();
+        assert_eq!(active.phase, PowerInhibitionPhase::Active);
+    }
+
+    #[test]
+    fn failed_acquisition_is_rolled_back_before_retry() {
+        let (state, control) = state();
+        *control.acquire_error.lock().unwrap() = true;
+
+        let failed = state
+            .set_activity(PowerInhibitionReason::Playback, true)
+            .unwrap();
+        assert_eq!(failed.phase, PowerInhibitionPhase::Failed);
+
+        let inactive = state
+            .set_activity(PowerInhibitionReason::Playback, false)
+            .unwrap();
+        assert_eq!(inactive.phase, PowerInhibitionPhase::Inactive);
+        assert_eq!(*control.releases.lock().unwrap(), 1);
+
+        *control.acquire_error.lock().unwrap() = false;
+        let active = state
+            .set_activity(PowerInhibitionReason::Playback, true)
+            .unwrap();
+        assert_eq!(active.phase, PowerInhibitionPhase::Active);
+        assert_eq!(control.acquisitions.lock().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn failed_acquisition_release_failure_keeps_attributable_reason() {
+        let (state, control) = state();
+        *control.acquire_error.lock().unwrap() = true;
+        *control.release_error.lock().unwrap() = true;
+        state
+            .set_activity(PowerInhibitionReason::SyncListener, true)
+            .unwrap();
+
+        let failed = state
+            .set_activity(PowerInhibitionReason::SyncListener, false)
+            .unwrap();
+
+        assert_eq!(failed.phase, PowerInhibitionPhase::ReleaseFailed);
+        assert_eq!(
+            failed.active_reasons,
+            vec![PowerInhibitionReason::SyncListener]
+        );
+        assert_eq!(*control.releases.lock().unwrap(), 1);
+    }
+
+    #[test]
+    fn release_failure_preserves_confirmed_state_until_retry() {
+        let (state, control) = state();
+        state
+            .set_activity(PowerInhibitionReason::Playback, true)
+            .unwrap();
+        *control.release_error.lock().unwrap() = true;
+        let failed = state
+            .set_activity(PowerInhibitionReason::Playback, false)
+            .unwrap();
+        assert_eq!(failed.phase, PowerInhibitionPhase::ReleaseFailed);
+        assert_eq!(failed.backend.as_deref(), Some("test"));
+        assert!(failed.screen_protected);
+        assert_eq!(failed.active_reasons, vec![PowerInhibitionReason::Playback]);
+
+        *control.release_error.lock().unwrap() = false;
+        state.shutdown();
+        assert_eq!(
+            state.status().unwrap().phase,
+            PowerInhibitionPhase::Inactive
+        );
+    }
+
+    #[test]
+    fn async_release_completes_inactive_without_reporting_lost_protection() {
+        let (state, control) = state();
+        state
+            .set_activity(PowerInhibitionReason::Playback, true)
+            .unwrap();
+        control.probes.lock().unwrap().extend([
+            PlatformProbe {
+                details: None,
+                error: None,
+                pending_phase: Some(PowerInhibitionPhase::Releasing),
+                data_sync_timeout_epoch: 0,
+            },
+            PlatformProbe {
+                details: None,
+                error: None,
+                pending_phase: None,
+                data_sync_timeout_epoch: 0,
+            },
+        ]);
+
+        let releasing = state
+            .set_activity(PowerInhibitionReason::Playback, false)
+            .unwrap();
+        assert_eq!(releasing.phase, PowerInhibitionPhase::Releasing);
+        assert_eq!(
+            releasing.active_reasons,
+            vec![PowerInhibitionReason::Playback]
+        );
+
+        let inactive = state.status().unwrap();
+        assert_eq!(inactive, PowerInhibitionStatus::default());
+    }
+
+    #[test]
+    fn unsupported_state_never_claims_protection() {
+        let (state, control) = state();
+        *control.unsupported.lock().unwrap() = true;
+        let status = state
+            .set_activity(PowerInhibitionReason::Playback, true)
+            .unwrap();
+        assert_eq!(status.phase, PowerInhibitionPhase::Unsupported);
+        assert!(!status.screen_protected);
+        assert!(!status.background_protected);
+        assert_eq!(status.backend, None);
+    }
+
+    #[test]
+    fn android_notification_denial_without_confirmed_mask_never_claims_protection() {
+        let probe =
+            parse_android_response("failed;0;android-notification-permission-denied;2;0;false")
+                .expect("valid Android response");
+
+        assert!(probe.details.is_none());
+        let error = probe.error.expect("permission denial");
+        assert_eq!(error.code, "android-notification-permission-denied");
+        assert_eq!(
+            error.message,
+            "Android notification permission is unavailable, and power protection is not confirmed."
+        );
+        assert!(!error.message.contains("protection is active"));
+    }
+
+    #[test]
+    fn shutdown_releases_all_owners() {
+        let (state, control) = state();
+        let _guard = state
+            .acquire_scoped(PowerInhibitionReason::SyncListener)
+            .unwrap();
+        state
+            .set_activity(PowerInhibitionReason::Playback, true)
+            .unwrap();
+        state.shutdown();
+        assert_eq!(*control.releases.lock().unwrap(), 1);
+        assert_eq!(
+            state.status().unwrap().phase,
+            PowerInhibitionPhase::Inactive
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/sync_transport.rs
+++ b/apps/desktop/src-tauri/src/sync_transport.rs
@@ -1591,6 +1591,9 @@ mod desktop {
         SyncTransportSyncResult, SyncTransportTimingEvidence, SyncTransportTransferCounts,
         SyncTransportTransferResult,
     };
+    use crate::power_inhibition::{
+        PowerInhibitionGuard, PowerInhibitionReason, PowerInhibitionState,
+    };
     use chrono::{DateTime, Utc};
     use iroh::{
         endpoint::{
@@ -1677,8 +1680,6 @@ mod desktop {
         "Restore the device state, then retry sync.";
     const LIFECYCLE_INTERRUPTION_NETWORK_GUIDANCE: &str =
         "Restore network connectivity, then retry sync.";
-    const LIFECYCLE_INTERRUPTION_FOREGROUND_GUIDANCE: &str =
-        "Bring TuneForge back to the foreground, then retry sync.";
     #[cfg(not(target_os = "android"))]
     const HTTP_TIMEOUT: Duration = Duration::from_secs(45);
     #[cfg(not(target_os = "android"))]
@@ -1686,19 +1687,214 @@ mod desktop {
     #[cfg(not(target_os = "android"))]
     const BACKEND_PREFLIGHT_TIMEOUT: Duration = Duration::from_secs(3);
 
+    trait SyncInhibitionGuard: Send {}
+
+    impl SyncInhibitionGuard for PowerInhibitionGuard {}
+
+    trait SyncPowerManager: Send + Sync {
+        fn acquire_scoped(
+            &self,
+            reason: PowerInhibitionReason,
+        ) -> Option<Box<dyn SyncInhibitionGuard>>;
+
+        fn data_sync_timeout_epoch(&self) -> u64 {
+            0
+        }
+    }
+
+    impl SyncPowerManager for PowerInhibitionState {
+        fn acquire_scoped(
+            &self,
+            reason: PowerInhibitionReason,
+        ) -> Option<Box<dyn SyncInhibitionGuard>> {
+            PowerInhibitionState::acquire_scoped(self, reason)
+                .ok()
+                .map(|guard| Box::new(guard) as Box<dyn SyncInhibitionGuard>)
+        }
+
+        fn data_sync_timeout_epoch(&self) -> u64 {
+            PowerInhibitionState::data_sync_timeout_epoch(self)
+        }
+    }
+
+    #[derive(Clone)]
+    struct SyncPowerInhibition {
+        manager: Arc<dyn SyncPowerManager>,
+    }
+
+    impl SyncPowerInhibition {
+        fn new(manager: PowerInhibitionState) -> Self {
+            Self {
+                manager: Arc::new(manager),
+            }
+        }
+
+        #[cfg(test)]
+        fn with_manager(manager: Arc<dyn SyncPowerManager>) -> Self {
+            Self { manager }
+        }
+
+        fn acquire(&self, reason: PowerInhibitionReason) -> Option<Box<dyn SyncInhibitionGuard>> {
+            self.manager.acquire_scoped(reason)
+        }
+
+        fn data_sync_timeout_epoch(&self) -> u64 {
+            self.manager.data_sync_timeout_epoch()
+        }
+    }
+
+    struct ListenerPowerLease {
+        guard: Mutex<Option<Box<dyn SyncInhibitionGuard>>>,
+    }
+
+    impl ListenerPowerLease {
+        fn acquire(power: &SyncPowerInhibition) -> Self {
+            Self {
+                guard: Mutex::new(power.acquire(PowerInhibitionReason::SyncListener)),
+            }
+        }
+
+        fn release(&self) {
+            let guard = self
+                .guard
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .take();
+            drop(guard);
+        }
+    }
+
+    #[derive(Clone)]
+    struct ActiveTransferReservations {
+        power: SyncPowerInhibition,
+        guards: Arc<Mutex<HashMap<String, Box<dyn SyncInhibitionGuard>>>>,
+        shutdown: Arc<AtomicBool>,
+    }
+
+    impl ActiveTransferReservations {
+        fn new(power: SyncPowerInhibition) -> Self {
+            Self {
+                power,
+                guards: Arc::new(Mutex::new(HashMap::new())),
+                shutdown: Arc::new(AtomicBool::new(false)),
+            }
+        }
+
+        fn reserve(&self, run_id: &str) -> ActiveTransferReservation {
+            let timeout_baseline = self.power.data_sync_timeout_epoch();
+            let mut active = false;
+            if !self.shutdown.load(Ordering::SeqCst) {
+                let acquired = self.power.acquire(PowerInhibitionReason::SyncTransfer);
+                let mut guards = self
+                    .guards
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                let unneeded =
+                    if !self.shutdown.load(Ordering::SeqCst) && !guards.contains_key(run_id) {
+                        if let Some(guard) = acquired {
+                            guards.insert(run_id.to_string(), guard);
+                            active = true;
+                        }
+                        None
+                    } else {
+                        acquired
+                    };
+                drop(guards);
+                drop(unneeded);
+            }
+            ActiveTransferReservation {
+                reservations: self.clone(),
+                run_id: run_id.to_string(),
+                active,
+                timeout_baseline,
+                timeout_watcher_stop: Arc::new(AtomicBool::new(false)),
+            }
+        }
+
+        fn release(&self, run_id: &str) {
+            let guard = self
+                .guards
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .remove(run_id);
+            drop(guard);
+        }
+
+        fn shutdown(&self) {
+            self.shutdown.store(true, Ordering::SeqCst);
+            let guards = self
+                .guards
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .drain()
+                .map(|(_, guard)| guard)
+                .collect::<Vec<_>>();
+            drop(guards);
+        }
+    }
+
+    struct ActiveTransferReservation {
+        reservations: ActiveTransferReservations,
+        run_id: String,
+        active: bool,
+        timeout_baseline: u64,
+        timeout_watcher_stop: Arc<AtomicBool>,
+    }
+
+    impl ActiveTransferReservation {
+        fn watch_timeout(&self, cancel: RunCancellationToken) {
+            if !self.active {
+                return;
+            }
+            let power = self.reservations.power.clone();
+            let baseline = self.timeout_baseline;
+            let stop = Arc::clone(&self.timeout_watcher_stop);
+            let run_id = self.run_id.clone();
+            thread::spawn(move || {
+                while !stop.load(Ordering::SeqCst) && !cancel.is_cancelled() {
+                    if power.data_sync_timeout_epoch() > baseline {
+                        cancel.interrupt(android_data_sync_timeout_interruption(run_id));
+                        break;
+                    }
+                    thread::sleep(Duration::from_millis(250));
+                }
+            });
+        }
+    }
+
+    impl Drop for ActiveTransferReservation {
+        fn drop(&mut self) {
+            self.timeout_watcher_stop.store(true, Ordering::SeqCst);
+            if self.active {
+                self.reservations.release(&self.run_id);
+            }
+        }
+    }
+
     #[derive(Clone)]
     pub struct SyncTransportState {
         backend: BackendAccess,
         listener: Arc<Mutex<Option<ListenerHandle>>>,
         shared_status: Arc<Mutex<SharedStatus>>,
+        power_inhibition: SyncPowerInhibition,
+        active_transfer_reservations: ActiveTransferReservations,
     }
 
     impl SyncTransportState {
-        pub fn new(base_url: String, app: AppHandle) -> Self {
+        pub fn new(
+            base_url: String,
+            app: AppHandle,
+            power_inhibition: PowerInhibitionState,
+        ) -> Self {
+            let power_inhibition = SyncPowerInhibition::new(power_inhibition);
             Self {
                 backend: BackendAccess { base_url, app },
                 listener: Arc::new(Mutex::new(None)),
                 shared_status: Arc::new(Mutex::new(SharedStatus::default())),
+                active_transfer_reservations: ActiveTransferReservations::new(
+                    power_inhibition.clone(),
+                ),
+                power_inhibition,
             }
         }
 
@@ -1706,14 +1902,13 @@ mod desktop {
             &self,
             payload: SyncTransportStartListenerRequest,
         ) -> Result<SyncTransportStatus, String> {
-            {
-                let guard = self
-                    .listener
-                    .lock()
-                    .map_err(|_| "Sync transport listener state is unavailable.".to_string())?;
-                if guard.is_some() {
-                    return Ok(self.status());
-                }
+            let mut listener_slot = self
+                .listener
+                .lock()
+                .map_err(|_| "Sync transport listener state is unavailable.".to_string())?;
+            if listener_slot.is_some() {
+                drop(listener_slot);
+                return Ok(self.status());
             }
 
             let client = BackendClient::new(&self.backend)?;
@@ -1759,6 +1954,10 @@ mod desktop {
             let tcp_stop = Arc::clone(&stop);
             let backend = self.backend.clone();
             let shared_status = Arc::clone(&self.shared_status);
+            let active_transfer_reservations = self.active_transfer_reservations.clone();
+            let listener_power_inhibition =
+                Arc::new(ListenerPowerLease::acquire(&self.power_inhibition));
+            let tcp_listener_power_inhibition = Arc::clone(&listener_power_inhibition);
             let tcp_endpoint_hints_for_sessions = endpoint_hints.clone();
             let tcp_thread = thread::spawn(move || {
                 accept_loop(
@@ -1767,7 +1966,9 @@ mod desktop {
                     tcp_stop,
                     shared_status,
                     tcp_endpoint_hints_for_sessions,
+                    active_transfer_reservations,
                 );
+                tcp_listener_power_inhibition.release();
             });
             let iroh_thread = iroh_transport.as_ref().map(|transport| {
                 let transport = transport.clone();
@@ -1775,8 +1976,16 @@ mod desktop {
                 let shared_status = Arc::clone(&self.shared_status);
                 let iroh_stop = Arc::clone(&stop);
                 let endpoint_hints = endpoint_hints.clone();
+                let active_transfer_reservations = self.active_transfer_reservations.clone();
                 thread::spawn(move || {
-                    iroh_accept_loop(transport, backend, iroh_stop, shared_status, endpoint_hints);
+                    iroh_accept_loop(
+                        transport,
+                        backend,
+                        iroh_stop,
+                        shared_status,
+                        endpoint_hints,
+                        active_transfer_reservations,
+                    );
                 })
             });
             let mut discovery_error = None;
@@ -1801,14 +2010,10 @@ mod desktop {
                 tcp_thread: Some(tcp_thread),
                 iroh_thread,
                 discovery_thread,
+                _power_inhibition: listener_power_inhibition,
             };
-            {
-                let mut guard = self
-                    .listener
-                    .lock()
-                    .map_err(|_| "Sync transport listener state is unavailable.".to_string())?;
-                *guard = Some(handle);
-            }
+            *listener_slot = Some(handle);
+            drop(listener_slot);
             update_status(&self.shared_status, |status| {
                 status.last_status = Some(match discovery_error {
                     Some(error) => {
@@ -1870,6 +2075,7 @@ mod desktop {
 
         pub fn shutdown(&self) {
             let _ = self.stop_listener();
+            self.active_transfer_reservations.shutdown();
         }
 
         fn status(&self) -> SyncTransportStatus {
@@ -1959,7 +2165,28 @@ mod desktop {
                 &run_id,
                 Some(payload.peer_device_id.clone()),
             );
-            let result = self.run_sync_now(payload, run_id.clone(), run_cancel);
+            let power_inhibition = self.active_transfer_reservations.reserve(&run_id);
+            power_inhibition.watch_timeout(run_cancel.clone());
+            let result = self.run_sync_now(payload, run_id.clone(), run_cancel.clone());
+            let result = match (result, run_cancel.interruption()) {
+                (Ok(mut sync_result), Some(interruption)) => {
+                    sync_result.status = "failed".to_string();
+                    sync_result.message = format!(
+                        "Sync interrupted by lifecycle event {}. {}",
+                        interruption.event.kind, interruption.guidance
+                    );
+                    if !sync_result.lifecycle_events.iter().any(|event| {
+                        event.kind == interruption.event.kind
+                            && event.occurred_at == interruption.event.occurred_at
+                    }) {
+                        sync_result.lifecycle_events.push(interruption.event);
+                    }
+                    sync_result.retryable_interruption_code = Some(interruption.code);
+                    sync_result.retry_guidance = Some(interruption.guidance);
+                    Ok(sync_result)
+                }
+                (result, _) => result,
+            };
             update_status(&self.shared_status, |status| {
                 apply_sync_now_status_result(status, &result, &run_id);
             });
@@ -3742,6 +3969,7 @@ mod desktop {
         tcp_thread: Option<JoinHandle<()>>,
         iroh_thread: Option<JoinHandle<()>>,
         discovery_thread: Option<JoinHandle<()>>,
+        _power_inhibition: Arc<ListenerPowerLease>,
     }
 
     struct IncomingSessionResult {
@@ -3833,6 +4061,27 @@ mod desktop {
                 .lock()
                 .ok()
                 .and_then(|interruption| interruption.clone())
+        }
+    }
+
+    fn android_data_sync_timeout_interruption(run_id: String) -> LifecycleInterruptionEvidence {
+        const CODE: &str = "android_data_sync_timeout";
+        const GUIDANCE: &str = "Bring TuneForge to the foreground, then retry sync.";
+        LifecycleInterruptionEvidence {
+            code: CODE.to_string(),
+            guidance: GUIDANCE.to_string(),
+            event: SyncTransportLifecycleEvent {
+                kind: CODE.to_string(),
+                occurred_at: Utc::now().to_rfc3339(),
+                message: Some(
+                    "Android stopped this sync after its background time limit.".to_string(),
+                ),
+                retryable: true,
+                interruption_code: Some(CODE.to_string()),
+                retry_guidance: Some(GUIDANCE.to_string()),
+                peer_device_id: None,
+                run_id: Some(run_id),
+            },
         }
     }
 
@@ -4296,12 +4545,6 @@ mod desktop {
         match kind {
             "sleep" => Some("lifecycle_interrupted_sleep"),
             "network_offline" | "networkoffline" => Some("lifecycle_interrupted_network_offline"),
-            "android_background" | "androidbackground" => {
-                Some("lifecycle_interrupted_android_background")
-            }
-            "android_screen_lock" | "androidscreenlock" => {
-                Some("lifecycle_interrupted_android_screen_lock")
-            }
             _ => None,
         }
     }
@@ -4309,10 +4552,6 @@ mod desktop {
     fn lifecycle_retry_guidance(kind: &str) -> &'static str {
         match kind {
             "network_offline" | "networkoffline" => LIFECYCLE_INTERRUPTION_NETWORK_GUIDANCE,
-            "android_background"
-            | "androidbackground"
-            | "android_screen_lock"
-            | "androidscreenlock" => LIFECYCLE_INTERRUPTION_FOREGROUND_GUIDANCE,
             _ => LIFECYCLE_INTERRUPTION_DEFAULT_GUIDANCE,
         }
     }
@@ -4579,6 +4818,7 @@ mod desktop {
         stop: Arc<AtomicBool>,
         shared_status: Arc<Mutex<SharedStatus>>,
         endpoint_hints: Vec<String>,
+        active_transfer_reservations: ActiveTransferReservations,
     ) {
         while !stop.load(Ordering::SeqCst) {
             match listener.accept() {
@@ -4586,6 +4826,7 @@ mod desktop {
                     let backend = backend.clone();
                     let shared_status = Arc::clone(&shared_status);
                     let endpoint_hints = endpoint_hints.clone();
+                    let active_transfer_reservations = active_transfer_reservations.clone();
                     update_status(&shared_status, |status| {
                         status.accepted_sessions += 1;
                         status.last_status =
@@ -4601,6 +4842,7 @@ mod desktop {
                             None,
                             shared_status,
                             endpoint_hints,
+                            active_transfer_reservations,
                         ),
                         Err(error) => {
                             update_status(&shared_status, |status| {
@@ -4631,6 +4873,7 @@ mod desktop {
         stop: Arc<AtomicBool>,
         shared_status: Arc<Mutex<SharedStatus>>,
         endpoint_hints: Vec<String>,
+        active_transfer_reservations: ActiveTransferReservations,
     ) {
         tauri::async_runtime::block_on(async move {
             while !stop.load(Ordering::SeqCst) {
@@ -4639,6 +4882,7 @@ mod desktop {
                         let backend = backend.clone();
                         let shared_status = Arc::clone(&shared_status);
                         let endpoint_hints = endpoint_hints.clone();
+                        let active_transfer_reservations = active_transfer_reservations.clone();
                         update_status(&shared_status, |status| {
                             status.accepted_sessions += 1;
                             status.last_status =
@@ -4685,6 +4929,7 @@ mod desktop {
                                             Some(iroh_data),
                                             session_status,
                                             endpoint_hints,
+                                            active_transfer_reservations,
                                         );
                                     });
                                     if let Err(error) = join.await {
@@ -4839,11 +5084,14 @@ mod desktop {
         iroh_data: Option<IrohDataConnection>,
         shared_status: Arc<Mutex<SharedStatus>>,
         endpoint_hints: Vec<String>,
+        active_transfer_reservations: ActiveTransferReservations,
     ) {
         let run_id = sync_run_id();
         let run_started_at = Utc::now();
         let run_started_instant = Instant::now();
         let run_cancel = register_active_run(&shared_status, &run_id, None);
+        let power_inhibition = active_transfer_reservations.reserve(&run_id);
+        power_inhibition.watch_timeout(run_cancel.clone());
         record_active_progress(
             &shared_status,
             &run_id,
@@ -4872,6 +5120,23 @@ mod desktop {
             run_started_instant,
         );
         let result = match (result, run_cancel.interruption()) {
+            (Ok(mut result), Some(interruption)) => {
+                result.sync_result.status = "failed".to_string();
+                result.sync_result.message = format!(
+                    "Sync interrupted by lifecycle event {}. {}",
+                    interruption.event.kind, interruption.guidance
+                );
+                result.message = result.sync_result.message.clone();
+                if !result.sync_result.lifecycle_events.iter().any(|event| {
+                    event.kind == interruption.event.kind
+                        && event.occurred_at == interruption.event.occurred_at
+                }) {
+                    result.sync_result.lifecycle_events.push(interruption.event);
+                }
+                result.sync_result.retryable_interruption_code = Some(interruption.code);
+                result.sync_result.retry_guidance = Some(interruption.guidance);
+                Ok(result)
+            }
             (Err(_), Some(interruption)) => {
                 let peer_device_id = interruption
                     .event
@@ -12753,11 +13018,224 @@ mod desktop {
     mod tests {
         use super::*;
         use std::collections::VecDeque;
+        use std::sync::atomic::AtomicU64;
+
+        #[derive(Default)]
+        struct TestPowerCounts {
+            active: Mutex<BTreeMap<PowerInhibitionReason, usize>>,
+            timeout_epoch: AtomicU64,
+        }
+
+        impl TestPowerCounts {
+            fn active(&self, reason: PowerInhibitionReason) -> usize {
+                self.active
+                    .lock()
+                    .expect("test power counts")
+                    .get(&reason)
+                    .copied()
+                    .unwrap_or_default()
+            }
+        }
+
+        struct TestPowerGuard {
+            counts: Arc<TestPowerCounts>,
+            reason: PowerInhibitionReason,
+        }
+
+        impl SyncInhibitionGuard for TestPowerGuard {}
+
+        impl Drop for TestPowerGuard {
+            fn drop(&mut self) {
+                let mut active = self.counts.active.lock().expect("test power counts");
+                let count = active.entry(self.reason).or_default();
+                *count = count.saturating_sub(1);
+                if *count == 0 {
+                    active.remove(&self.reason);
+                }
+            }
+        }
+
+        struct TestPowerManager {
+            counts: Arc<TestPowerCounts>,
+        }
+
+        impl SyncPowerManager for TestPowerManager {
+            fn acquire_scoped(
+                &self,
+                reason: PowerInhibitionReason,
+            ) -> Option<Box<dyn SyncInhibitionGuard>> {
+                *self
+                    .counts
+                    .active
+                    .lock()
+                    .expect("test power counts")
+                    .entry(reason)
+                    .or_default() += 1;
+                Some(Box::new(TestPowerGuard {
+                    counts: Arc::clone(&self.counts),
+                    reason,
+                }))
+            }
+
+            fn data_sync_timeout_epoch(&self) -> u64 {
+                self.counts.timeout_epoch.load(Ordering::SeqCst)
+            }
+        }
+
+        fn test_power_inhibition() -> (SyncPowerInhibition, Arc<TestPowerCounts>) {
+            let counts = Arc::new(TestPowerCounts::default());
+            let manager = Arc::new(TestPowerManager {
+                counts: Arc::clone(&counts),
+            });
+            (SyncPowerInhibition::with_manager(manager), counts)
+        }
 
         const MISSING_SOURCE_HASH_GUIDANCE: &str =
             "Restore the original source file or re-import affected projects so TuneForge can compute source hashes.";
         const DUPLICATE_SOURCE_HASH_GUIDANCE: &str =
             "Delete duplicate same-source projects or keep one canonical project before enabling sync.";
+
+        #[test]
+        fn listener_power_lease_releases_on_thread_exit_or_handle_drop() {
+            let (power, counts) = test_power_inhibition();
+            let lease = ListenerPowerLease::acquire(&power);
+
+            assert_eq!(counts.active(PowerInhibitionReason::SyncListener), 1);
+
+            lease.release();
+
+            assert_eq!(counts.active(PowerInhibitionReason::SyncListener), 0);
+
+            let lease = ListenerPowerLease::acquire(&power);
+            assert_eq!(counts.active(PowerInhibitionReason::SyncListener), 1);
+
+            drop(lease);
+
+            assert_eq!(counts.active(PowerInhibitionReason::SyncListener), 0);
+        }
+
+        #[test]
+        fn transfer_reservation_releases_after_success_and_failure() {
+            let (power, counts) = test_power_inhibition();
+            let reservations = ActiveTransferReservations::new(power);
+
+            let success: Result<(), &str> = {
+                let _reservation = reservations.reserve("success");
+                assert_eq!(counts.active(PowerInhibitionReason::SyncTransfer), 1);
+                Ok(())
+            };
+            assert!(success.is_ok());
+            assert_eq!(counts.active(PowerInhibitionReason::SyncTransfer), 0);
+
+            let failure: Result<(), &str> = {
+                let _reservation = reservations.reserve("failure");
+                assert_eq!(counts.active(PowerInhibitionReason::SyncTransfer), 1);
+                Err("connection failed")
+            };
+            assert!(failure.is_err());
+            assert_eq!(counts.active(PowerInhibitionReason::SyncTransfer), 0);
+        }
+
+        #[test]
+        fn transfer_reservation_survives_cancellation_until_run_exits() {
+            let (power, counts) = test_power_inhibition();
+            let reservations = ActiveTransferReservations::new(power);
+            let cancellation = RunCancellationToken::default();
+            let reservation = reservations.reserve("cancelled");
+
+            cancellation.cancelled.store(true, Ordering::SeqCst);
+
+            assert!(cancellation.is_cancelled());
+            assert_eq!(counts.active(PowerInhibitionReason::SyncTransfer), 1);
+
+            drop(reservation);
+
+            assert_eq!(counts.active(PowerInhibitionReason::SyncTransfer), 0);
+        }
+
+        #[test]
+        fn transfer_timeout_cancels_run_without_releasing_other_power_owners() {
+            let (power, counts) = test_power_inhibition();
+            let listener = power.acquire(PowerInhibitionReason::SyncListener);
+            let reservations = ActiveTransferReservations::new(power);
+            let cancel = RunCancellationToken::default();
+            let reservation = reservations.reserve("timed_out");
+            reservation.watch_timeout(cancel.clone());
+
+            counts.timeout_epoch.store(1, Ordering::SeqCst);
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while !cancel.is_cancelled() && Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(10));
+            }
+
+            assert!(cancel.is_cancelled());
+            assert_eq!(
+                cancel.interruption().unwrap().code,
+                "android_data_sync_timeout"
+            );
+            assert_eq!(counts.active(PowerInhibitionReason::SyncListener), 1);
+            assert_eq!(counts.active(PowerInhibitionReason::SyncTransfer), 1);
+
+            drop(reservation);
+            assert_eq!(counts.active(PowerInhibitionReason::SyncTransfer), 0);
+            assert_eq!(counts.active(PowerInhibitionReason::SyncListener), 1);
+            drop(listener);
+            assert_eq!(counts.active(PowerInhibitionReason::SyncListener), 0);
+        }
+
+        #[test]
+        fn concurrent_transfer_reservations_release_independently_and_on_shutdown() {
+            let (power, counts) = test_power_inhibition();
+            let reservations = ActiveTransferReservations::new(power);
+            let first = reservations.reserve("first");
+            let second = reservations.reserve("second");
+
+            assert_eq!(counts.active(PowerInhibitionReason::SyncTransfer), 2);
+
+            drop(first);
+            assert_eq!(counts.active(PowerInhibitionReason::SyncTransfer), 1);
+
+            reservations.shutdown();
+            assert_eq!(counts.active(PowerInhibitionReason::SyncTransfer), 0);
+
+            let after_shutdown = reservations.reserve("after_shutdown");
+            assert_eq!(counts.active(PowerInhibitionReason::SyncTransfer), 0);
+
+            drop(second);
+            drop(after_shutdown);
+            assert_eq!(counts.active(PowerInhibitionReason::SyncTransfer), 0);
+        }
+
+        #[test]
+        fn duplicate_transfer_reservation_does_not_release_active_owner() {
+            let (power, counts) = test_power_inhibition();
+            let reservations = ActiveTransferReservations::new(power);
+            let owner = reservations.reserve("same_run");
+            let duplicate = reservations.reserve("same_run");
+
+            assert_eq!(counts.active(PowerInhibitionReason::SyncTransfer), 1);
+
+            drop(duplicate);
+            assert_eq!(counts.active(PowerInhibitionReason::SyncTransfer), 1);
+
+            drop(owner);
+            assert_eq!(counts.active(PowerInhibitionReason::SyncTransfer), 0);
+        }
+
+        #[test]
+        fn transfer_reservation_releases_when_run_panics() {
+            let (power, counts) = test_power_inhibition();
+            let reservations = ActiveTransferReservations::new(power);
+            let panic_reservations = reservations.clone();
+
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+                let _reservation = panic_reservations.reserve("panic");
+                panic!("test panic");
+            }));
+
+            assert!(result.is_err());
+            assert_eq!(counts.active(PowerInhibitionReason::SyncTransfer), 0);
+        }
 
         fn test_transfer_result(
             artifact_id: &str,
@@ -14185,6 +14663,38 @@ mod desktop {
                 Some("window blurred")
             );
             assert!(status.retryable_interruption_code.is_none());
+        }
+
+        #[test]
+        fn android_background_and_lock_do_not_interrupt_active_transfer() {
+            for kind in ["android_background", "android_screen_lock"] {
+                let cancel = RunCancellationToken::default();
+                let mut status = SharedStatus::default();
+                status.active_runs.insert(
+                    "sync_android_background".to_string(),
+                    ActiveSyncRun {
+                        peer_device_id: Some("dev_peer".to_string()),
+                        cancel: cancel.clone(),
+                        connection: None,
+                    },
+                );
+
+                let outcome = record_lifecycle_event_in_status(
+                    &mut status,
+                    SyncTransportLifecycleEventRequest {
+                        kind: kind.to_string(),
+                        occurred_at: Some("2026-01-01T00:00:00Z".to_string()),
+                        message: Some("Android lifecycle changed".to_string()),
+                    },
+                );
+                interrupt_active_runs_for_lifecycle(&outcome.event, outcome.interrupted_runs);
+
+                assert!(!cancel.is_cancelled());
+                assert!(!status.lifecycle_events[0].retryable);
+                assert!(status.lifecycle_events[0].interruption_code.is_none());
+                assert!(status.retryable_interruption_code.is_none());
+                assert!(status.active_runs.contains_key("sync_android_background"));
+            }
         }
 
         #[test]
@@ -16539,10 +17049,10 @@ mod desktop {
         fn sync_now_non_interrupted_result_clears_retryable_interruption() {
             let mut status = SharedStatus {
                 retryable_interruption_code: Some(
-                    "lifecycle_interrupted_android_background".to_string(),
+                    "lifecycle_interrupted_network_offline".to_string(),
                 ),
                 retryable_interruption_peer_device_id: Some("dev_peer".to_string()),
-                retry_guidance: Some(LIFECYCLE_INTERRUPTION_FOREGROUND_GUIDANCE.to_string()),
+                retry_guidance: Some(LIFECYCLE_INTERRUPTION_NETWORK_GUIDANCE.to_string()),
                 ..SharedStatus::default()
             };
             let result = Ok(failed_preflight_sync_result(

--- a/apps/desktop/src-tauri/src/system_media/mod.rs
+++ b/apps/desktop/src-tauri/src/system_media/mod.rs
@@ -35,23 +35,13 @@ impl SystemMediaState {
             .lock()
             .map_err(|_| "System media state is unavailable.".to_string())?;
         runtime.current = None;
-        runtime.idle.set_active(false)?;
         Ok(())
-    }
-
-    fn set_idle_inhibition(&self, active: bool) -> Result<(), String> {
-        let mut runtime = self
-            .runtime
-            .lock()
-            .map_err(|_| "System media state is unavailable.".to_string())?;
-        runtime.idle.set_active(active)
     }
 }
 
 #[derive(Default)]
 struct SystemMediaRuntime {
     current: Option<SystemMediaPayload>,
-    idle: platform::IdleInhibition,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -124,14 +114,6 @@ pub fn system_media_clear_state(state: State<'_, SystemMediaState>) -> Result<()
     state.clear()
 }
 
-#[tauri::command]
-pub fn system_media_set_idle_inhibition(
-    state: State<'_, SystemMediaState>,
-    active: bool,
-) -> Result<(), String> {
-    state.set_idle_inhibition(active)
-}
-
 #[cfg(target_os = "macos")]
 mod platform {
     use super::{
@@ -141,89 +123,13 @@ mod platform {
     use objc2::runtime::AnyObject;
     use objc2::{class, msg_send};
     use objc2_foundation::{NSMutableDictionary, NSNumber, NSObject, NSString};
-    use std::ffi::{c_char, c_void, CString};
     use std::sync::Once;
     use tauri::AppHandle;
-
-    type CFAllocatorRef = *const c_void;
-    type CFStringRef = *const c_void;
-    type IOPMAssertionID = u32;
-    type IOReturn = i32;
-
-    const K_CF_STRING_ENCODING_UTF8: u32 = 0x0800_0100;
-    const K_IOPM_ASSERTION_LEVEL_ON: u32 = 255;
-    const K_IO_RETURN_SUCCESS: IOReturn = 0;
-
-    #[link(name = "CoreFoundation", kind = "framework")]
-    extern "C" {
-        fn CFStringCreateWithCString(
-            alloc: CFAllocatorRef,
-            c_str: *const c_char,
-            encoding: u32,
-        ) -> CFStringRef;
-        fn CFRelease(cf: *const c_void);
-    }
-
-    #[link(name = "IOKit", kind = "framework")]
-    extern "C" {
-        fn IOPMAssertionCreateWithName(
-            assertion_type: CFStringRef,
-            level: u32,
-            assertion_name: CFStringRef,
-            assertion_id: *mut IOPMAssertionID,
-        ) -> IOReturn;
-        fn IOPMAssertionRelease(assertion_id: IOPMAssertionID) -> IOReturn;
-    }
 
     #[link(name = "MediaPlayer", kind = "framework")]
     extern "C" {}
 
     static REGISTER_REMOTE_COMMANDS: Once = Once::new();
-
-    #[derive(Default)]
-    pub struct IdleInhibition {
-        assertion_id: Option<IOPMAssertionID>,
-    }
-
-    impl IdleInhibition {
-        pub fn set_active(&mut self, active: bool) -> Result<(), String> {
-            if active {
-                if self.assertion_id.is_some() {
-                    return Ok(());
-                }
-                let assertion_type = cf_string("NoDisplaySleepAssertion")?;
-                let assertion_name = cf_string("TuneForge playback")?;
-                let mut assertion_id = 0;
-                let result = unsafe {
-                    IOPMAssertionCreateWithName(
-                        assertion_type,
-                        K_IOPM_ASSERTION_LEVEL_ON,
-                        assertion_name,
-                        &mut assertion_id,
-                    )
-                };
-                unsafe {
-                    CFRelease(assertion_type);
-                    CFRelease(assertion_name);
-                }
-                if result != K_IO_RETURN_SUCCESS {
-                    return Err(format!("Could not inhibit macOS display sleep: {result}"));
-                }
-                self.assertion_id = Some(assertion_id);
-                return Ok(());
-            }
-
-            if let Some(assertion_id) = self.assertion_id.take() {
-                let result = unsafe { IOPMAssertionRelease(assertion_id) };
-                if result != K_IO_RETURN_SUCCESS {
-                    return Err(format!(
-                        "Could not release macOS display sleep assertion: {result}"
-                    ));
-                }
-            }
-            Ok(())
-        }
-    }
 
     pub fn update_media_state(app: &AppHandle, payload: &SystemMediaPayload) -> Result<(), String> {
         register_remote_commands(app);
@@ -274,22 +180,6 @@ mod platform {
             let _: () = msg_send![center, setPlaybackState: 0isize];
         }
         Ok(())
-    }
-
-    fn cf_string(value: &str) -> Result<CFStringRef, String> {
-        let c_string = CString::new(value)
-            .map_err(|_| "System media string contained an interior null byte.".to_string())?;
-        let cf_string = unsafe {
-            CFStringCreateWithCString(
-                std::ptr::null(),
-                c_string.as_ptr(),
-                K_CF_STRING_ENCODING_UTF8,
-            )
-        };
-        if cf_string.is_null() {
-            return Err("Could not create macOS system media string.".to_string());
-        }
-        Ok(cf_string)
     }
 
     fn finite_non_negative(value: Option<f64>) -> Option<f64> {
@@ -530,9 +420,6 @@ mod platform {
     const MPRIS_PLAYER_INTERFACE: &str = "org.mpris.MediaPlayer2.Player";
     const DBUS_PROPERTIES_INTERFACE: &str = "org.freedesktop.DBus.Properties";
     const DBUS_INTROSPECTABLE_INTERFACE: &str = "org.freedesktop.DBus.Introspectable";
-    const SCREENSAVER_BUS_NAME: &str = "org.freedesktop.ScreenSaver";
-    const SCREENSAVER_OBJECT_PATH: &str = "/org/freedesktop/ScreenSaver";
-    const SCREENSAVER_INTERFACE: &str = "org.freedesktop.ScreenSaver";
 
     static MPRIS_RUNTIME: Mutex<Option<Arc<MprisRuntime>>> = Mutex::new(None);
 
@@ -540,53 +427,6 @@ mod platform {
     struct MprisRuntime {
         state: Arc<Mutex<Option<SystemMediaPayload>>>,
         active: Arc<AtomicBool>,
-    }
-
-    #[derive(Default)]
-    pub struct IdleInhibition {
-        connection: Option<Connection>,
-        cookie: Option<u32>,
-    }
-
-    impl IdleInhibition {
-        pub fn set_active(&mut self, active: bool) -> Result<(), String> {
-            if active {
-                if self.cookie.is_some() {
-                    return Ok(());
-                }
-                let connection = Connection::new_session()
-                    .map_err(|error| format!("D-Bus unavailable: {error}"))?;
-                let proxy = connection.with_proxy(
-                    SCREENSAVER_BUS_NAME,
-                    SCREENSAVER_OBJECT_PATH,
-                    Duration::from_millis(500),
-                );
-                let (cookie,): (u32,) = proxy
-                    .method_call(
-                        SCREENSAVER_INTERFACE,
-                        "Inhibit",
-                        ("TuneForge", "Native playback active"),
-                    )
-                    .map_err(|error| format!("Could not inhibit desktop idle: {error}"))?;
-                self.connection = Some(connection);
-                self.cookie = Some(cookie);
-                return Ok(());
-            }
-
-            if let (Some(connection), Some(cookie)) = (self.connection.take(), self.cookie.take()) {
-                let proxy = connection.with_proxy(
-                    SCREENSAVER_BUS_NAME,
-                    SCREENSAVER_OBJECT_PATH,
-                    Duration::from_millis(500),
-                );
-                proxy
-                    .method_call::<(), _, _, _>(SCREENSAVER_INTERFACE, "UnInhibit", (cookie,))
-                    .map_err(|error| {
-                        format!("Could not release desktop idle inhibition: {error}")
-                    })?;
-            }
-            Ok(())
-        }
     }
 
     pub fn update_media_state(app: &AppHandle, payload: &SystemMediaPayload) -> Result<(), String> {
@@ -967,18 +807,6 @@ mod platform {
 mod platform {
     use super::SystemMediaPayload;
     use tauri::AppHandle;
-
-    #[derive(Default)]
-    pub struct IdleInhibition {
-        active: bool,
-    }
-
-    impl IdleInhibition {
-        pub fn set_active(&mut self, active: bool) -> Result<(), String> {
-            self.active = active;
-            Ok(())
-        }
-    }
 
     pub fn update_media_state(app: &AppHandle, payload: &SystemMediaPayload) -> Result<(), String> {
         let _ = (app, payload);

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -1040,7 +1040,7 @@ describe("Desktop app activity", () => {
     }
 	  });
 
-	  it("records Android background and screen-lock lifecycle events as retryable", async () => {
+	  it("records Android background and screen-lock lifecycle events without retrying active sync", async () => {
 	    const user = userEvent.setup();
 	    mockGetMobileCapabilities.mockResolvedValue(androidCapabilities);
 	    setSyncTrustedPeers([
@@ -1054,7 +1054,7 @@ describe("Desktop app activity", () => {
 	      },
 	    ]);
 	    mockRecordSyncLifecycleEvent.mockImplementation(async (event) => {
-	      const retryableStatus = {
+	      const passiveStatus = {
 	        active: true,
 	        status: "listening",
 	        endpoint_hints: listenerEndpointHints,
@@ -1063,25 +1063,21 @@ describe("Desktop app activity", () => {
 	          kind: event.kind,
 	          occurred_at: event.occurredAt ?? "2026-04-18T13:16:30.000Z",
 	          message: event.message ?? null,
-	          retryable: true,
-	          interruption_code: event.kind === "android_screen_lock"
-	            ? "lifecycle_interrupted_android_screen_lock"
-	            : "lifecycle_interrupted_android_background",
-	          retry_guidance: "Bring Android back to the foreground, then retry sync.",
+	          retryable: false,
+	          interruption_code: null,
+	          retry_guidance: null,
 	          peer_device_id: "device_peer_1",
 	          run_id: "sync_run_android_lifecycle_1",
 	        },
 	        lifecycle_events: [],
-	        retryable_interruption_code: event.kind === "android_screen_lock"
-	          ? "lifecycle_interrupted_android_screen_lock"
-	          : "lifecycle_interrupted_android_background",
-	        retryable_interruption_peer_device_id: "device_peer_1",
-	        retry_guidance: "Bring Android back to the foreground, then retry sync.",
+	        retryable_interruption_code: null,
+	        retryable_interruption_peer_device_id: null,
+	        retry_guidance: null,
 	        last_sync: null,
 	        updated_at: "2026-04-18T13:16:30.000Z",
 	      };
-	      setSyncTransportStatus(retryableStatus);
-	      return retryableStatus;
+	      setSyncTransportStatus(passiveStatus);
+	      return passiveStatus;
 	    });
 
 	    try {
@@ -1100,7 +1096,7 @@ describe("Desktop app activity", () => {
 	      expect(mockRecordSyncLifecycleEvent).toHaveBeenCalledWith(
 	        expect.objectContaining({ kind: "android_background", message: "android background or screen lock" }),
 	      );
-	      expect(await screen.findByRole("button", { name: "Retry Sync" })).toBeInTheDocument();
+	      expect(screen.queryByRole("button", { name: "Retry Sync" })).not.toBeInTheDocument();
 	    } finally {
 	      setDocumentVisibility("visible");
 	    }

--- a/apps/desktop/src/App.power-inhibition.test.tsx
+++ b/apps/desktop/src/App.power-inhibition.test.tsx
@@ -1,0 +1,73 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  getMockInvoke,
+  renderApp,
+  resetAppTestHarness,
+  setMockPowerInhibitionState,
+} from "./test/appTestHarness";
+
+function mockTauriRuntime() {
+  Object.defineProperty(window, "__TAURI_INTERNALS__", {
+    configurable: true,
+    value: { invoke: getMockInvoke() },
+  });
+}
+
+describe("power protection UI", () => {
+  beforeEach(() => {
+    resetAppTestHarness();
+    mockTauriRuntime();
+  });
+
+  afterEach(() => {
+    delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  });
+
+  it("shows only confirmed native protection details in Settings diagnostics", async () => {
+    const user = userEvent.setup();
+    setMockPowerInhibitionState({
+      phase: "active",
+      backend: "android-foreground-service",
+      activeReasons: ["playback", "sync-listener"],
+      screenProtected: true,
+      backgroundProtected: true,
+      errorCode: null,
+      errorMessage: null,
+    });
+    renderApp(["/settings"]);
+
+    expect(await screen.findByRole("heading", { name: "Control Room" })).toBeInTheDocument();
+    await user.click(screen.getByText("Show diagnostics"));
+    const section = screen.getByRole("heading", { name: "Power Protection" }).closest("section");
+    expect(section).not.toBeNull();
+    await waitFor(() => {
+      expect(within(section!).getAllByText("Android foreground service")).toHaveLength(2);
+    });
+    expect(within(section!).queryByText("android-foreground-service")).not.toBeInTheDocument();
+    expect(within(section!).getByText("Playback, Sync listener")).toBeInTheDocument();
+    expect(within(section!).getAllByText("Confirmed")).toHaveLength(2);
+    expect(within(section!).getByText("Inactive")).toBeInTheDocument();
+  });
+
+  it("shows a sync reliability alert only for relevant protection failure", async () => {
+    const user = userEvent.setup();
+    setMockPowerInhibitionState({
+      phase: "failed",
+      backend: null,
+      activeReasons: ["sync-listener"],
+      screenProtected: false,
+      backgroundProtected: false,
+      errorCode: "linux-inhibition-failed",
+      errorMessage: "Linux power protection is unavailable.",
+    });
+    renderApp(["/activity"]);
+
+    await user.click(screen.getByRole("tab", { name: "Sync" }));
+    expect(await screen.findByRole("heading", { level: 2, name: "Sync" })).toBeInTheDocument();
+    expect(await screen.findByRole("alert", { name: "" })).toHaveTextContent(
+      "Linux power protection is unavailable.",
+    );
+  });
+});

--- a/apps/desktop/src/App.project-media-controls.test.tsx
+++ b/apps/desktop/src/App.project-media-controls.test.tsx
@@ -1,7 +1,8 @@
-import { act, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { readPlaybackLiveDiagnostics } from "./lib/playbackDiagnostics";
+import { readBrowserWakeLockStatus } from "./lib/powerInhibition";
 import {
   deferNextMockSystemMediaControlListen,
   emitMockNativePlaybackError,
@@ -10,6 +11,7 @@ import {
   findAudioByArtifactId,
   getMockInvoke,
   getMockMediaSession,
+  getMockSystemMediaControlListenerCount,
   getMockWakeLock,
   markAudioReady,
   rejectMockSystemMediaCommand,
@@ -19,6 +21,13 @@ import {
   setMockNativeAudioState,
 } from "./test/appTestHarness";
 
+let usePlaybackPowerProtection: typeof import("./features/projects/playbackEffects").usePlaybackPowerProtection;
+let useWebPlaybackWakeLock: typeof import("./features/projects/playbackEffects").useWebPlaybackWakeLock;
+
+beforeAll(async () => {
+  ({ usePlaybackPowerProtection, useWebPlaybackWakeLock } = await import("./features/projects/playbackEffects"));
+});
+
 async function openPlaybackWorkspace(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole("tab", { name: "Playback" }));
 }
@@ -26,7 +35,7 @@ async function openPlaybackWorkspace(user: ReturnType<typeof userEvent.setup>) {
 function mockTauriRuntime() {
   Object.defineProperty(window, "__TAURI_INTERNALS__", {
     configurable: true,
-    value: {},
+    value: { invoke: getMockInvoke() },
   });
 
   return () => {
@@ -56,16 +65,24 @@ function hasSystemMediaPlaybackState(playbackState: "playing" | "paused") {
   });
 }
 
-function hasNativeIdleInhibition(active: boolean) {
-  return invokeCalls("system_media_set_idle_inhibition").some(([, args]) => {
-    return (args as { active?: boolean } | undefined)?.active === active;
+function hasNativePowerProtection(active: boolean) {
+  return invokeCalls("power_inhibition_set_activity").some(([, args]) => {
+    const payload = args as { active?: boolean; reason?: string } | undefined;
+    return payload?.reason === "playback" && payload.active === active;
   });
+}
+
+function nativePowerProtectionCallCount(active: boolean) {
+  return invokeCalls("power_inhibition_set_activity").filter(([, args]) => {
+    const payload = args as { active?: boolean; reason?: string } | undefined;
+    return payload?.reason === "playback" && payload.active === active;
+  }).length;
 }
 
 function expectNoSystemMediaCommandCalls() {
   expect(invokeCalls("system_media_update_state")).toHaveLength(0);
   expect(invokeCalls("system_media_clear_state")).toHaveLength(0);
-  expect(invokeCalls("system_media_set_idle_inhibition")).toHaveLength(0);
+  expect(invokeCalls("power_inhibition_set_activity")).toHaveLength(0);
 }
 
 function expectNoNativePlaybackCommandCalls() {
@@ -91,12 +108,15 @@ async function waitForWebOwnerControls() {
   await waitFor(() => {
     expect(hasSystemMediaPlaybackState("playing")).toBe(true);
   });
+  await waitFor(() => expect(getMockSystemMediaControlListenerCount()).toBeGreaterThan(0));
   await waitFor(() => expect(getMockWakeLock().request).toHaveBeenCalledWith("screen"));
+  await waitFor(() => expect(hasNativePowerProtection(true)).toBe(true));
 }
 
 async function waitForNativeControls() {
   await waitFor(() => expect(hasSystemMediaPlaybackState("playing")).toBe(true));
-  await waitFor(() => expect(hasNativeIdleInhibition(true)).toBe(true));
+  await waitFor(() => expect(getMockSystemMediaControlListenerCount()).toBeGreaterThan(0));
+  await waitFor(() => expect(hasNativePowerProtection(true)).toBe(true));
 }
 
 async function startForcedWebPlayback(user: ReturnType<typeof userEvent.setup>) {
@@ -120,6 +140,28 @@ async function startForcedWebPlayback(user: ReturnType<typeof userEvent.setup>) 
   return restoreTauriRuntime;
 }
 
+function WebPlaybackWakeLockHarness({
+  backend = "web",
+  isPlaying,
+}: {
+  backend?: "native" | "web";
+  isPlaying: boolean;
+}) {
+  useWebPlaybackWakeLock({ backend, isPlaying });
+  return null;
+}
+
+function PlaybackPowerProtectionHarness({
+  backend,
+  isPlaying,
+}: {
+  backend: "native" | "web";
+  isPlaying: boolean;
+}) {
+  usePlaybackPowerProtection(isPlaying);
+  return <span data-testid="playback-power-backend">{backend}</span>;
+}
+
 describe("Desktop app project media controls", () => {
   beforeEach(resetAppTestHarness);
   afterEach(() => {
@@ -127,14 +169,14 @@ describe("Desktop app project media controls", () => {
     delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
   });
 
-  it("uses system media controls and browser wake lock when Web Audio is forced", async () => {
+  it("uses system controls with native power protection and supplemental browser wake lock when Web Audio is forced", async () => {
     const user = userEvent.setup();
     const restoreTauriRuntime = await startForcedWebPlayback(user);
 
     await waitForWebOwnerControls();
     expect(getMockMediaSession().actionHandlers.size).toBe(0);
     expect(getMockMediaSession().setActionHandler).not.toHaveBeenCalled();
-    expect(hasNativeIdleInhibition(true)).toBe(false);
+    expect(hasNativePowerProtection(true)).toBe(true);
     expectNoNativePlaybackCommandCalls();
 
     act(() => {
@@ -197,7 +239,28 @@ describe("Desktop app project media controls", () => {
     restoreTauriRuntime();
   });
 
-  it("uses native controls and native idle inhibition after native playback starts", async () => {
+  it("keeps native power protection stable when the active playback backend changes", async () => {
+    const restoreTauriRuntime = mockTauriRuntime();
+    const view = render(<PlaybackPowerProtectionHarness backend="native" isPlaying />);
+    await waitFor(() => expect(nativePowerProtectionCallCount(true)).toBe(1));
+    const releaseCount = nativePowerProtectionCallCount(false);
+
+    view.rerender(<PlaybackPowerProtectionHarness backend="web" isPlaying />);
+    expect(screen.getByTestId("playback-power-backend")).toHaveTextContent("web");
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(nativePowerProtectionCallCount(true)).toBe(1);
+    expect(nativePowerProtectionCallCount(false)).toBe(releaseCount);
+    view.unmount();
+    await waitFor(() => {
+      expect(nativePowerProtectionCallCount(false)).toBeGreaterThan(releaseCount);
+    });
+    restoreTauriRuntime();
+  });
+
+  it("uses native controls and power protection only after native playback starts", async () => {
     const restoreTauriRuntime = mockTauriRuntime();
     const user = userEvent.setup();
     setMockNativeAudioState({
@@ -223,7 +286,7 @@ describe("Desktop app project media controls", () => {
       emitMockSystemMediaPlaybackControl({ action: "pause" });
     });
     await waitFor(() => expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument());
-    await waitFor(() => expect(hasNativeIdleInhibition(false)).toBe(true));
+    await waitFor(() => expect(hasNativePowerProtection(false)).toBe(true));
 
     restoreTauriRuntime();
   });
@@ -343,7 +406,7 @@ describe("Desktop app project media controls", () => {
     markAudioReady(sourceAudio);
     await waitFor(() => expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument());
     await waitForWebOwnerControls();
-    expect(hasNativeIdleInhibition(true)).toBe(false);
+    expect(hasNativePowerProtection(true)).toBe(true);
     restoreTauriRuntime();
   });
 
@@ -410,6 +473,7 @@ describe("Desktop app project media controls", () => {
     });
     await waitFor(() => expect(screen.getByLabelText("Playback position")).toHaveValue("42"));
 
+    const releaseCount = nativePowerProtectionCallCount(false);
     act(() => {
       emitMockNativePlaybackError({
         sessionId,
@@ -423,7 +487,9 @@ describe("Desktop app project media controls", () => {
       nativeBufferHealth: [],
     });
 
-    await waitFor(() => expect(hasNativeIdleInhibition(false)).toBe(true));
+    await waitFor(() => {
+      expect(nativePowerProtectionCallCount(false)).toBeGreaterThan(releaseCount);
+    });
     await waitFor(() => {
       expect(invokeCalls("system_media_clear_state").length).toBeGreaterThan(0);
     });
@@ -600,6 +666,7 @@ describe("Desktop app project media controls", () => {
       await openPlaybackWorkspace(user);
       await user.click(screen.getByRole("button", { name: "Play playback" }));
       await waitFor(() => expect(nativePlayBlock.release).not.toBeNull());
+      expect(hasNativePowerProtection(true)).toBe(false);
 
       const sessionId = latestNativeSessionId();
       act(() => {
@@ -629,15 +696,192 @@ describe("Desktop app project media controls", () => {
     }
   });
 
-  it("pause releases the Web Audio wake lock without touching native idle inhibition", async () => {
+  it("pause releases both native power protection and the supplemental Web Audio wake lock", async () => {
     const user = userEvent.setup();
     const restoreTauriRuntime = await startForcedWebPlayback(user);
     await waitForWebOwnerControls();
+    const releaseCount = nativePowerProtectionCallCount(false);
 
     await user.click(screen.getByRole("button", { name: "Pause playback" }));
     await waitFor(() => expect(getMockWakeLock().sentinels[0]?.release).toHaveBeenCalled());
-    expect(hasNativeIdleInhibition(true)).toBe(false);
+    await waitFor(() => {
+      expect(nativePowerProtectionCallCount(false)).toBeGreaterThan(releaseCount);
+    });
 
+    restoreTauriRuntime();
+  });
+
+  it("reports Web Audio wake lock release failure after pause", async () => {
+    const user = userEvent.setup();
+    const restoreTauriRuntime = await startForcedWebPlayback(user);
+    await waitForWebOwnerControls();
+    getMockWakeLock().sentinels[0]?.release.mockRejectedValueOnce(new Error("release failed"));
+
+    await user.click(screen.getByRole("button", { name: "Pause playback" }));
+
+    await waitFor(() => {
+      expect(readBrowserWakeLockStatus()).toMatchObject({
+        phase: "release-failed",
+        backend: "browser-screen-wake-lock",
+        screenProtected: true,
+      });
+    });
+    restoreTauriRuntime();
+  });
+
+  it("ignores stale Web Audio release failure after a new owner starts", async () => {
+    const view = render(<WebPlaybackWakeLockHarness isPlaying />);
+    await waitFor(() => expect(getMockWakeLock().request).toHaveBeenCalledTimes(1));
+    let rejectRelease: (reason?: unknown) => void = () => undefined;
+    getMockWakeLock().sentinels[0]!.release.mockImplementationOnce(
+      () => new Promise<void>((_resolve, reject) => {
+        rejectRelease = reject;
+      }),
+    );
+
+    view.rerender(<WebPlaybackWakeLockHarness isPlaying={false} />);
+    view.rerender(<WebPlaybackWakeLockHarness isPlaying />);
+    await waitFor(() => expect(getMockWakeLock().request).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      rejectRelease(new Error("stale release failed"));
+      await Promise.resolve();
+    });
+
+    expect(readBrowserWakeLockStatus()).toMatchObject({
+      phase: "active",
+      backend: "browser-screen-wake-lock",
+      screenProtected: true,
+    });
+    view.unmount();
+  });
+
+  it("coalesces pending browser Wake Lock requests and releases a late sentinel", async () => {
+    const pendingSentinel = {
+      released: false,
+      release: vi.fn(async () => {
+        pendingSentinel.released = true;
+      }),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchRelease: vi.fn(),
+    };
+    let resolveRequest: (sentinel: typeof pendingSentinel) => void = () => undefined;
+    getMockWakeLock().request.mockImplementationOnce(
+      () => new Promise((resolve) => {
+        resolveRequest = resolve;
+      }),
+    );
+    const view = render(<WebPlaybackWakeLockHarness isPlaying />);
+    await waitFor(() => expect(getMockWakeLock().request).toHaveBeenCalledTimes(1));
+
+    fireEvent(document, new Event("visibilitychange"));
+    fireEvent(document, new Event("visibilitychange"));
+    fireEvent.focus(window);
+    expect(getMockWakeLock().request).toHaveBeenCalledTimes(1);
+
+    view.rerender(<WebPlaybackWakeLockHarness backend="native" isPlaying />);
+    await act(async () => {
+      resolveRequest(pendingSentinel);
+      await Promise.resolve();
+    });
+
+    expect(pendingSentinel.release).toHaveBeenCalledTimes(1);
+    expect(getMockWakeLock().request).toHaveBeenCalledTimes(1);
+    expect(readBrowserWakeLockStatus()).toMatchObject({
+      phase: "inactive",
+      backend: null,
+      screenProtected: false,
+    });
+    view.unmount();
+  });
+
+  it("releases native power protection on stop, natural end, and unmount", async () => {
+    const restoreTauriRuntime = mockTauriRuntime();
+    const user = userEvent.setup();
+    setMockNativeAudioState({
+      capabilities: {
+        nativePlaybackSupported: true,
+        fallbackRequired: false,
+        fallbackReason: null,
+        backend: "desktop-cpal",
+      },
+    });
+    const view = renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitForNativeControls();
+
+    let releaseCount = nativePowerProtectionCallCount(false);
+    await user.click(screen.getByRole("button", { name: "Stop playback" }));
+    await waitFor(() => {
+      expect(nativePowerProtectionCallCount(false)).toBeGreaterThan(releaseCount);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitForNativeControls();
+    releaseCount = nativePowerProtectionCallCount(false);
+    const sessionId = latestNativeSessionId();
+    act(() => {
+      emitMockNativePlaybackPosition({
+        sessionId,
+        positionSeconds: 182,
+        durationSeconds: 182,
+        state: "stopped",
+      });
+    });
+    await waitFor(() => {
+      expect(nativePowerProtectionCallCount(false)).toBeGreaterThan(releaseCount);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitForNativeControls();
+    releaseCount = nativePowerProtectionCallCount(false);
+    view.unmount();
+    await waitFor(() => {
+      expect(nativePowerProtectionCallCount(false)).toBeGreaterThan(releaseCount);
+    });
+    restoreTauriRuntime();
+  });
+
+  it("records supplemental browser Wake Lock acquisition failures while retaining native protection", async () => {
+    const user = userEvent.setup();
+    getMockWakeLock().request.mockRejectedValueOnce(new Error("denied"));
+    const restoreTauriRuntime = await startForcedWebPlayback(user);
+
+    await waitFor(() => {
+      expect(readBrowserWakeLockStatus()).toMatchObject({
+        phase: "failed",
+        screenProtected: false,
+      });
+    });
+    expect(hasNativePowerProtection(true)).toBe(true);
+    expect(screen.queryByText("Screen Wake Lock could not be enabled.")).not.toBeInTheDocument();
+
+    restoreTauriRuntime();
+  });
+
+  it("ignores a pending browser Wake Lock rejection after playback pauses", async () => {
+    const user = userEvent.setup();
+    let rejectRequest: (reason?: unknown) => void = () => undefined;
+    getMockWakeLock().request.mockImplementationOnce(
+      () => new Promise((_resolve, reject) => {
+        rejectRequest = reject;
+      }),
+    );
+    const restoreTauriRuntime = await startForcedWebPlayback(user);
+    await waitFor(() => expect(getMockWakeLock().request).toHaveBeenCalledWith("screen"));
+
+    await user.click(screen.getByRole("button", { name: "Pause playback" }));
+    await waitFor(() => expect(readBrowserWakeLockStatus().phase).toBe("inactive"));
+    await act(async () => {
+      rejectRequest(new Error("late denial"));
+      await Promise.resolve();
+    });
+
+    expect(readBrowserWakeLockStatus().phase).toBe("inactive");
+    expect(screen.queryByText("Screen Wake Lock could not be enabled.")).not.toBeInTheDocument();
     restoreTauriRuntime();
   });
 });

--- a/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
+++ b/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { invoke, isTauri } from "@tauri-apps/api/core";
 import { QRCodeSVG } from "qrcode.react";
@@ -24,6 +24,13 @@ import {
 } from "../../lib/api";
 import { formatLocalDateTime, normalizeApiDateTime } from "../../lib/datetime";
 import { scanPairingQrCode } from "../../lib/pairingQrScanner";
+import {
+  getPowerInhibitionVersion,
+  readPowerInhibitionStatus,
+  refreshPowerInhibitionStatus,
+  subscribePowerInhibition,
+  syncPowerProtectionMessage,
+} from "../../lib/powerInhibition";
 import {
   decodePairingCode,
   encodePairingCode,
@@ -2115,6 +2122,12 @@ export function ActivitySyncPanel() {
   const [syncNowPolling, setSyncNowPolling] = useState(false);
   const [evidenceMessage, setEvidenceMessage] = useState<string | null>(null);
   const [evidenceError, setEvidenceError] = useState<string | null>(null);
+	useSyncExternalStore(
+	  subscribePowerInhibition,
+	  getPowerInhibitionVersion,
+	  getPowerInhibitionVersion,
+	);
+	const powerInhibitionStatus = readPowerInhibitionStatus();
 	  const pairingCodeOutputRef = useRef<HTMLTextAreaElement | null>(null);
 	  const rawPairingOutputRef = useRef<HTMLTextAreaElement | null>(null);
 	  const refreshedProjectSyncKeyRef = useRef<string | null>(null);
@@ -2164,6 +2177,19 @@ export function ActivitySyncPanel() {
     return trustedNearbyPeers;
   }, [nearbyPeers, peersById]);
   const listenerActive = listenerQuery.data?.active ?? false;
+	useEffect(() => {
+	  if (!isTauri()) {
+	    return;
+	  }
+	  void refreshPowerInhibitionStatus();
+	  if (!listenerActive && !syncNowPolling) {
+	    return;
+	  }
+	  const intervalId = window.setInterval(() => {
+	    void refreshPowerInhibitionStatus();
+	  }, SYNC_LISTENER_POLL_INTERVAL_MS);
+	  return () => window.clearInterval(intervalId);
+	}, [listenerActive, syncNowPolling]);
   const listenerStatus = listenerQuery.isError ? "unavailable" : listenerQuery.data?.status ?? "checking";
   const listenerSyncResult = listenerQuery.data?.last_sync ?? null;
   const listenerSyncKey = useMemo(() => syncResultKey(listenerSyncResult), [listenerSyncResult]);
@@ -2794,6 +2820,7 @@ export function ActivitySyncPanel() {
   const preflightGuidance = preflight
     ? Array.from(new Set([...preflight.manual_cleanup_guidance, ...preflight.job_state.guidance]))
     : [];
+  const powerProtectionMessage = syncPowerProtectionMessage(powerInhibitionStatus);
 
   return (
     <section
@@ -2915,6 +2942,11 @@ export function ActivitySyncPanel() {
           {listenerLastErrorMessage ? (
             <p className="activity-sync-alert activity-sync-alert--error" role="alert">
               {listenerLastErrorMessage}
+            </p>
+          ) : null}
+          {powerProtectionMessage ? (
+            <p className="activity-sync-alert activity-sync-alert--error" role="alert">
+              {powerProtectionMessage}
             </p>
           ) : null}
           {retryableInterruption ? (

--- a/apps/desktop/src/features/projects/components/PlaybackTransport.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackTransport.tsx
@@ -5,6 +5,11 @@ import {
   readPlaybackLiveDiagnostics,
   subscribePlaybackDiagnostics,
 } from "../../../lib/playbackDiagnostics";
+import {
+  getPowerInhibitionVersion,
+  playbackPowerProtectionMessage,
+  subscribePowerInhibition,
+} from "../../../lib/powerInhibition";
 import { MetallicGlyphDefs, PlayPauseGlyph, SeekGlyph, StopGlyph } from "./TransportGlyphs";
 import { formatPlaybackClock } from "../projectViewUtils";
 import type { PlaybackLoopRange } from "../projectPlaybackState";
@@ -49,7 +54,13 @@ export function PlaybackTransport({
     getPlaybackDiagnosticsVersion,
     getPlaybackDiagnosticsVersion,
   );
+  useSyncExternalStore(
+    subscribePowerInhibition,
+    getPowerInhibitionVersion,
+    getPowerInhibitionVersion,
+  );
   const playbackDiagnostics = readPlaybackLiveDiagnostics();
+  const powerProtectionMessage = playbackPowerProtectionMessage();
   const tempoLabel =
     tempoDisplayBpm === null
       ? "--"
@@ -170,6 +181,14 @@ export function PlaybackTransport({
           role={playbackDiagnostics.currentState === "error" ? "alert" : "status"}
         >
           {playbackDiagnostics.statusMessage}
+        </p>
+      ) : null}
+      {powerProtectionMessage ? (
+        <p
+          className="transport__status transport__status--error"
+          role="status"
+        >
+          {powerProtectionMessage}
         </p>
       ) : null}
     </div>

--- a/apps/desktop/src/features/projects/playbackEffects.ts
+++ b/apps/desktop/src/features/projects/playbackEffects.ts
@@ -2,10 +2,13 @@ import { useEffect, useRef, type RefObject } from "react";
 import {
   clearSystemMediaState,
   listenSystemMediaControls,
-  setSystemMediaIdleInhibition,
   updateSystemMediaState,
   type SystemMediaControlEvent,
 } from "../../lib/systemMedia";
+import {
+  setPowerInhibitionActivity,
+  updateBrowserWakeLockStatus,
+} from "../../lib/powerInhibition";
 import type { ProjectPlaybackSession } from "./playback-context";
 import { isInteractiveTarget } from "./playbackUtils";
 
@@ -45,16 +48,32 @@ export function useWebPlaybackWakeLock({
   backend,
   isPlaying,
 }: Pick<PlaybackMediaControls, "backend" | "isPlaying">) {
+  const generationRef = useRef(0);
+  const pendingReleaseGenerationRef = useRef<number | null>(null);
   useEffect(() => {
-    if (backend !== "web" || !isPlaying || typeof navigator === "undefined") {
+    const ownsWakeLock = backend === "web" && isPlaying && typeof navigator !== "undefined";
+    const generation = ownsWakeLock ? ++generationRef.current : generationRef.current;
+    const publish = (status: Parameters<typeof updateBrowserWakeLockStatus>[0]) => {
+      if (generationRef.current === generation) {
+        updateBrowserWakeLockStatus(status);
+      }
+    };
+    if (!ownsWakeLock) {
       return;
     }
 
     let sentinel: WakeLockSentinelLike | null = null;
     let sentinelReleaseHandler: (() => void) | null = null;
+    let requestInFlight = false;
     let cancelled = false;
     const wakeLock = (navigator as NavigatorWithWakeLock).wakeLock;
     if (!wakeLock) {
+      publish({
+        phase: "unsupported",
+        backend: null,
+        screenProtected: false,
+        errorMessage: "Screen Wake Lock is unavailable in this browser.",
+      });
       return;
     }
 
@@ -67,16 +86,69 @@ export function useWebPlaybackWakeLock({
     }
 
     async function acquireWakeLock() {
-      if (cancelled || sentinel || document.visibilityState === "hidden") {
+      if (cancelled || sentinel || requestInFlight || document.visibilityState === "hidden") {
         return;
       }
+      requestInFlight = true;
+      publish({
+        phase: "acquiring",
+        backend: null,
+        screenProtected: false,
+        errorMessage: null,
+      });
       try {
         const nextSentinel = await wakeLock?.request("screen") ?? null;
         if (cancelled) {
-          void nextSentinel?.release().catch(() => undefined);
+          if (nextSentinel) {
+            pendingReleaseGenerationRef.current = generation;
+            publish({
+              phase: "releasing",
+              backend: "browser-screen-wake-lock",
+              screenProtected: true,
+              errorMessage: null,
+            });
+            void nextSentinel.release()
+              .then(() => {
+                if (pendingReleaseGenerationRef.current === generation) {
+                  pendingReleaseGenerationRef.current = null;
+                }
+                publish({
+                  phase: "inactive",
+                  backend: null,
+                  screenProtected: false,
+                  errorMessage: null,
+                });
+              })
+              .catch(() => {
+                if (pendingReleaseGenerationRef.current === generation) {
+                  pendingReleaseGenerationRef.current = null;
+                }
+                publish({
+                  phase: "release-failed",
+                  backend: "browser-screen-wake-lock",
+                  screenProtected: true,
+                  errorMessage: "Screen Wake Lock release could not be confirmed.",
+                });
+              });
+          }
+          return;
+        }
+        if (!nextSentinel) {
+          publish({
+            phase: "failed",
+            backend: null,
+            screenProtected: false,
+            errorMessage: "Screen Wake Lock could not be confirmed.",
+          });
           return;
         }
         sentinel = nextSentinel;
+        publish({
+          phase: "active",
+          backend: "browser-screen-wake-lock",
+          screenProtected: true,
+          errorMessage: null,
+        });
         sentinelReleaseHandler = () => {
           if (sentinel !== nextSentinel) {
             return;
@@ -84,11 +156,29 @@ export function useWebPlaybackWakeLock({
           clearSentinel();
           if (!cancelled && document.visibilityState === "visible") {
             void acquireWakeLock();
+          } else {
+            publish({
+              phase: "inactive",
+              backend: null,
+              screenProtected: false,
+              errorMessage: null,
+            });
           }
         };
         sentinel?.addEventListener?.("release", sentinelReleaseHandler);
       } catch {
         clearSentinel();
+        if (cancelled || generationRef.current !== generation) {
+          return;
+        }
+        publish({
+          phase: "failed",
+          backend: null,
+          screenProtected: false,
+          errorMessage: "Screen Wake Lock could not be enabled.",
+        });
+      } finally {
+        requestInFlight = false;
       }
     }
 
@@ -107,10 +197,78 @@ export function useWebPlaybackWakeLock({
       const activeSentinel = sentinel;
       clearSentinel();
       if (activeSentinel) {
-        void activeSentinel.release().catch(() => undefined);
+        pendingReleaseGenerationRef.current = generation;
+        publish({
+          phase: "releasing",
+          backend: "browser-screen-wake-lock",
+          screenProtected: true,
+          errorMessage: null,
+        });
+        void activeSentinel.release()
+          .then(() => {
+            if (pendingReleaseGenerationRef.current === generation) {
+              pendingReleaseGenerationRef.current = null;
+            }
+            publish({
+              phase: "inactive",
+              backend: null,
+              screenProtected: false,
+              errorMessage: null,
+            });
+          })
+          .catch(() => {
+            if (pendingReleaseGenerationRef.current === generation) {
+              pendingReleaseGenerationRef.current = null;
+            }
+            publish({
+              phase: "release-failed",
+              backend: "browser-screen-wake-lock",
+              screenProtected: true,
+              errorMessage: "Screen Wake Lock release could not be confirmed.",
+            });
+          });
+      } else {
+        pendingReleaseGenerationRef.current = null;
+        publish({
+          phase: "inactive",
+          backend: null,
+          screenProtected: false,
+          errorMessage: null,
+        });
       }
     };
   }, [backend, isPlaying]);
+}
+
+export function usePlaybackPowerProtection(isPlaying: boolean) {
+  const ownsPowerProtectionRef = useRef(false);
+
+  useEffect(() => {
+    if (!isTauriRuntime()) {
+      return;
+    }
+
+    if (isPlaying && !ownsPowerProtectionRef.current) {
+      ownsPowerProtectionRef.current = true;
+      void setPowerInhibitionActivity("playback", true);
+      return;
+    }
+
+    if (!isPlaying && ownsPowerProtectionRef.current) {
+      ownsPowerProtectionRef.current = false;
+      void setPowerInhibitionActivity("playback", false);
+    }
+  }, [isPlaying]);
+
+  useEffect(
+    () => () => {
+      if (ownsPowerProtectionRef.current) {
+        void setPowerInhibitionActivity("playback", false);
+        ownsPowerProtectionRef.current = false;
+      }
+    },
+    [],
+  );
 }
 
 export function useSystemPlaybackMediaControls({
@@ -127,12 +285,12 @@ export function useSystemPlaybackMediaControls({
   stopPlayback,
 }: PlaybackMediaControls) {
   const ownsSystemControlsRef = useRef(false);
+  usePlaybackPowerProtection(isPlaying);
 
   useEffect(() => {
     if (backend === "none" || !isTauriRuntime()) {
       if (ownsSystemControlsRef.current) {
         void clearSystemMediaState().catch(() => undefined);
-        void setSystemMediaIdleInhibition(false).catch(() => undefined);
         ownsSystemControlsRef.current = false;
       }
       return;
@@ -141,7 +299,6 @@ export function useSystemPlaybackMediaControls({
     if (!session) {
       if (ownsSystemControlsRef.current) {
         void clearSystemMediaState().catch(() => undefined);
-        void setSystemMediaIdleInhibition(false).catch(() => undefined);
         ownsSystemControlsRef.current = false;
       }
       return;
@@ -239,27 +396,10 @@ export function useSystemPlaybackMediaControls({
     stopPlayback,
   ]);
 
-  useEffect(() => {
-    if (!ownsSystemControlsRef.current) {
-      return;
-    }
-
-    if (backend !== "native" || !isPlaying) {
-      void setSystemMediaIdleInhibition(false).catch(() => undefined);
-      return;
-    }
-
-    void setSystemMediaIdleInhibition(true).catch(() => undefined);
-    return () => {
-      void setSystemMediaIdleInhibition(false).catch(() => undefined);
-    };
-  }, [backend, isPlaying]);
-
   useEffect(
     () => () => {
       if (ownsSystemControlsRef.current) {
         void clearSystemMediaState().catch(() => undefined);
-        void setSystemMediaIdleInhibition(false).catch(() => undefined);
         ownsSystemControlsRef.current = false;
       }
     },

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -1,4 +1,4 @@
-import { useState, useSyncExternalStore } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import { api, type BeatBackendSchema, type ChordBackendSchema, type StemModelSchema } from "../../lib/api";
@@ -14,6 +14,17 @@ import {
   subscribePlaybackDiagnostics,
   type PlaybackBackend,
 } from "../../lib/playbackDiagnostics";
+import {
+  getPowerInhibitionVersion,
+  readBrowserWakeLockStatus,
+  readPowerInhibitionStatus,
+  readRememberedPowerInhibitionBackend,
+  readRememberedPowerInhibitionError,
+  refreshPowerInhibitionStatus,
+  subscribePowerInhibition,
+  type PowerInhibitionPhase,
+  type PowerInhibitionReason,
+} from "../../lib/powerInhibition";
 import {
   getNativeAudioCapabilities,
   isWebAudioBackendForced,
@@ -62,6 +73,29 @@ type SnapshotStatus = {
   message: string;
   tone: "default" | "error";
 };
+
+const powerInhibitionPhaseLabels: Record<PowerInhibitionPhase, string> = {
+  inactive: "Inactive",
+  acquiring: "Acquiring",
+  active: "Active",
+  unsupported: "Unsupported",
+  failed: "Failed",
+  releasing: "Releasing",
+  "release-failed": "Release not confirmed",
+};
+
+const powerInhibitionReasonLabels: Record<PowerInhibitionReason, string> = {
+  playback: "Playback",
+  "sync-listener": "Sync listener",
+  "sync-transfer": "Sync transfer",
+};
+
+function powerInhibitionBackendLabel(backend: string | null) {
+  if (!backend) {
+    return "None confirmed";
+  }
+  return backend === "android-foreground-service" ? "Android foreground service" : backend;
+}
 
 const themeOptions: ChoiceOption<ThemePreference>[] = [
   {
@@ -615,7 +649,19 @@ export function SettingsView() {
     getPlaybackDiagnosticsVersion,
     getPlaybackDiagnosticsVersion,
   );
+  useSyncExternalStore(
+    subscribePowerInhibition,
+    getPowerInhibitionVersion,
+    getPowerInhibitionVersion,
+  );
   const livePlaybackDiagnostics = readPlaybackLiveDiagnostics();
+  const powerInhibitionStatus = readPowerInhibitionStatus();
+  const browserWakeLockStatus = readBrowserWakeLockStatus();
+  const rememberedPowerBackend = readRememberedPowerInhibitionBackend();
+  const rememberedPowerError = readRememberedPowerInhibitionError();
+  useEffect(() => {
+    void refreshPowerInhibitionStatus();
+  }, []);
   const healthQuery = useQuery({
     queryKey: ["health"],
     queryFn: api.getHealth,
@@ -1175,6 +1221,50 @@ export function SettingsView() {
                 <div>
                   <dt>Native Playback Buffer Health</dt>
                   <dd>{nativePlaybackHealthLabel(livePlaybackDiagnostics.nativeBufferHealth)}</dd>
+                </div>
+              </dl>
+            </section>
+
+            <section className="settings-diagnostics__group" aria-labelledby="diagnostics-power-protection">
+              <h3 id="diagnostics-power-protection">Power Protection</h3>
+              <dl className="details-grid details-grid--single-column">
+                <div>
+                  <dt>Current State</dt>
+                  <dd>{powerInhibitionPhaseLabels[powerInhibitionStatus.phase]}</dd>
+                </div>
+                <div>
+                  <dt>Current Backend</dt>
+                  <dd>{powerInhibitionBackendLabel(powerInhibitionStatus.backend)}</dd>
+                </div>
+                <div>
+                  <dt>Active Reasons</dt>
+                  <dd>
+                    {powerInhibitionStatus.activeReasons.length
+                      ? powerInhibitionStatus.activeReasons
+                          .map((reason) => powerInhibitionReasonLabels[reason])
+                          .join(", ")
+                      : "None"}
+                  </dd>
+                </div>
+                <div>
+                  <dt>Screen Protected</dt>
+                  <dd>{powerInhibitionStatus.screenProtected ? "Confirmed" : "Not confirmed"}</dd>
+                </div>
+                <div>
+                  <dt>Background Protected</dt>
+                  <dd>{powerInhibitionStatus.backgroundProtected ? "Confirmed" : "Not confirmed"}</dd>
+                </div>
+                <div>
+                  <dt>Browser Screen Wake Lock</dt>
+                  <dd>{powerInhibitionPhaseLabels[browserWakeLockStatus.phase]}</dd>
+                </div>
+                <div>
+                  <dt>Last Confirmed Backend</dt>
+                  <dd>{rememberedPowerBackend ? powerInhibitionBackendLabel(rememberedPowerBackend) : "None"}</dd>
+                </div>
+                <div>
+                  <dt>Latest Power Protection Error</dt>
+                  <dd>{powerInhibitionStatus.errorMessage ?? rememberedPowerError ?? "None"}</dd>
                 </div>
               </dl>
             </section>

--- a/apps/desktop/src/lib/powerInhibition.test.ts
+++ b/apps/desktop/src/lib/powerInhibition.test.ts
@@ -1,0 +1,288 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockInvoke } = vi.hoisted(() => ({
+  mockInvoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mockInvoke,
+}));
+
+import {
+  normalizePowerInhibitionStatus,
+  playbackPowerProtectionMessage,
+  readBrowserWakeLockStatus,
+  readPowerInhibitionStatus,
+  readRememberedPowerInhibitionBackend,
+  resetPowerInhibitionDiagnostics,
+  setPowerInhibitionActivity,
+  updateBrowserWakeLockStatus,
+} from "./powerInhibition";
+
+describe("power inhibition frontend boundary", () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+    window.localStorage.clear();
+    resetPowerInhibitionDiagnostics();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("normalizes untrusted status values and redacts unsafe diagnostics", () => {
+    expect(
+      normalizePowerInhibitionStatus({
+        phase: "failed",
+        backend: "/Users/example/private",
+        activeReasons: ["playback", "unknown", "playback"],
+        screenProtected: "yes",
+        backgroundProtected: true,
+        errorCode: "linux-inhibition-failed",
+        errorMessage: "Could not open /Users/example/private/song.wav for session_id=session_secret",
+      }),
+    ).toEqual({
+      phase: "failed",
+      backend: null,
+      activeReasons: ["playback"],
+      screenProtected: false,
+      backgroundProtected: true,
+      errorCode: "linux-inhibition-failed",
+      errorMessage: "Could not open [local path redacted] for session [redacted]",
+    });
+  });
+
+  it("persists confirmed backend history without restoring active state", async () => {
+    mockInvoke.mockResolvedValue({
+      phase: "active",
+      backend: "macos-iopm",
+      activeReasons: ["playback"],
+      screenProtected: true,
+      backgroundProtected: true,
+      errorCode: null,
+      errorMessage: null,
+    });
+
+    await setPowerInhibitionActivity("playback", true);
+    expect(readPowerInhibitionStatus().phase).toBe("active");
+    expect(readRememberedPowerInhibitionBackend()).toBe("macos-iopm");
+    expect([...Array(window.localStorage.length)].map((_, index) => window.localStorage.key(index))).toEqual([
+      "tuneforge.power-inhibition-backend",
+    ]);
+
+    resetPowerInhibitionDiagnostics();
+    expect(readPowerInhibitionStatus()).toMatchObject({
+      phase: "inactive",
+      activeReasons: [],
+      screenProtected: false,
+      backgroundProtected: false,
+    });
+    expect(readRememberedPowerInhibitionBackend()).toBe("macos-iopm");
+  });
+
+  it("keeps requested reason when release confirmation fails", async () => {
+    mockInvoke
+      .mockResolvedValueOnce({
+        phase: "active",
+        backend: "systemd-logind",
+        activeReasons: ["playback"],
+        screenProtected: true,
+        backgroundProtected: true,
+        errorCode: null,
+        errorMessage: null,
+      })
+      .mockRejectedValueOnce(new Error("release failed for /tmp/private.sock"));
+
+    await setPowerInhibitionActivity("playback", true);
+    await setPowerInhibitionActivity("playback", false);
+
+    expect(readPowerInhibitionStatus()).toMatchObject({
+      phase: "release-failed",
+      activeReasons: ["playback"],
+      backend: "systemd-logind",
+      screenProtected: true,
+      errorMessage: "release failed for [local path redacted]",
+    });
+  });
+
+  it("does not leak stale browser failure into confirmed native playback", async () => {
+    updateBrowserWakeLockStatus({
+      phase: "release-failed",
+      backend: "browser-screen-wake-lock",
+      screenProtected: true,
+      errorMessage: "Screen Wake Lock release could not be confirmed.",
+    });
+    mockInvoke.mockResolvedValue({
+      phase: "active",
+      backend: "macos-iopm",
+      activeReasons: ["playback"],
+      screenProtected: true,
+      backgroundProtected: true,
+      errorCode: null,
+      errorMessage: null,
+    });
+
+    await setPowerInhibitionActivity("playback", true);
+
+    expect(readBrowserWakeLockStatus().phase).toBe("release-failed");
+    expect(playbackPowerProtectionMessage()).toBeNull();
+  });
+
+  it("converges delayed Android acquisition to active", async () => {
+    vi.useFakeTimers();
+    mockInvoke
+      .mockResolvedValueOnce({
+        phase: "acquiring",
+        backend: null,
+        activeReasons: ["playback"],
+        screenProtected: false,
+        backgroundProtected: false,
+        errorCode: null,
+        errorMessage: null,
+      })
+      .mockResolvedValueOnce({
+        phase: "acquiring",
+        backend: null,
+        activeReasons: ["playback"],
+        screenProtected: false,
+        backgroundProtected: false,
+        errorCode: null,
+        errorMessage: null,
+      })
+      .mockResolvedValueOnce({
+        phase: "active",
+        backend: "android-foreground-service",
+        activeReasons: ["playback"],
+        screenProtected: true,
+        backgroundProtected: true,
+        errorCode: null,
+        errorMessage: null,
+      });
+
+    const activation = setPowerInhibitionActivity("playback", true);
+    await vi.advanceTimersByTimeAsync(200);
+
+    await expect(activation).resolves.toMatchObject({ phase: "active" });
+    expect(readPowerInhibitionStatus()).toMatchObject({
+      phase: "active",
+      backend: "android-foreground-service",
+      screenProtected: true,
+      backgroundProtected: true,
+    });
+    expect(mockInvoke.mock.calls.map(([command]) => command)).toEqual([
+      "power_inhibition_set_activity",
+      "power_inhibition_status",
+      "power_inhibition_status",
+    ]);
+  });
+
+  it("converges delayed Android acquisition to a truthful failure", async () => {
+    vi.useFakeTimers();
+    mockInvoke
+      .mockResolvedValueOnce({
+        phase: "acquiring",
+        backend: null,
+        activeReasons: ["playback"],
+        screenProtected: false,
+        backgroundProtected: false,
+        errorCode: null,
+        errorMessage: null,
+      })
+      .mockResolvedValueOnce({
+        phase: "failed",
+        backend: null,
+        activeReasons: ["playback"],
+        screenProtected: false,
+        backgroundProtected: false,
+        errorCode: "android-power-control-failed",
+        errorMessage: "Android could not start power protection.",
+      });
+
+    const activation = setPowerInhibitionActivity("playback", true);
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(activation).resolves.toMatchObject({
+      phase: "failed",
+      errorCode: "android-power-control-failed",
+    });
+    expect(playbackPowerProtectionMessage()).toBe("Android could not start power protection.");
+  });
+
+  it("converges delayed release to inactive", async () => {
+    vi.useFakeTimers();
+    mockInvoke
+      .mockResolvedValueOnce({
+        phase: "active",
+        backend: "android-foreground-service",
+        activeReasons: ["playback"],
+        screenProtected: true,
+        backgroundProtected: true,
+        errorCode: null,
+        errorMessage: null,
+      })
+      .mockResolvedValueOnce({
+        phase: "releasing",
+        backend: "android-foreground-service",
+        activeReasons: ["playback"],
+        screenProtected: true,
+        backgroundProtected: true,
+        errorCode: null,
+        errorMessage: null,
+      })
+      .mockResolvedValueOnce({
+        phase: "inactive",
+        backend: null,
+        activeReasons: [],
+        screenProtected: false,
+        backgroundProtected: false,
+        errorCode: null,
+        errorMessage: null,
+      });
+
+    await setPowerInhibitionActivity("playback", true);
+    const release = setPowerInhibitionActivity("playback", false);
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(release).resolves.toMatchObject({ phase: "inactive", activeReasons: [] });
+  });
+
+  it("supersedes an older pending convergence without publishing its result", async () => {
+    vi.useFakeTimers();
+    mockInvoke.mockImplementation(async (command, args) => {
+      if (command === "power_inhibition_status") {
+        throw new Error("A superseded operation must not poll.");
+      }
+      const active = (args as { active?: boolean } | undefined)?.active;
+      return active
+        ? {
+            phase: "acquiring",
+            backend: null,
+            activeReasons: ["playback"],
+            screenProtected: false,
+            backgroundProtected: false,
+            errorCode: null,
+            errorMessage: null,
+          }
+        : {
+            phase: "inactive",
+            backend: null,
+            activeReasons: [],
+            screenProtected: false,
+            backgroundProtected: false,
+            errorCode: null,
+            errorMessage: null,
+          };
+    });
+
+    const activation = setPowerInhibitionActivity("playback", true);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(readPowerInhibitionStatus().phase).toBe("acquiring");
+
+    const release = setPowerInhibitionActivity("playback", false);
+    await expect(release).resolves.toMatchObject({ phase: "inactive" });
+    await vi.advanceTimersByTimeAsync(500);
+    await expect(activation).resolves.toMatchObject({ phase: "inactive" });
+    expect(mockInvoke).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/src/lib/powerInhibition.ts
+++ b/apps/desktop/src/lib/powerInhibition.ts
@@ -1,0 +1,405 @@
+import { invoke } from "@tauri-apps/api/core";
+import { redactPlaybackDiagnosticText } from "./playbackDiagnostics";
+
+export type PowerInhibitionReason = "playback" | "sync-listener" | "sync-transfer";
+
+export type PowerInhibitionPhase =
+  | "inactive"
+  | "acquiring"
+  | "active"
+  | "unsupported"
+  | "failed"
+  | "releasing"
+  | "release-failed";
+
+export type PowerInhibitionStatus = {
+  phase: PowerInhibitionPhase;
+  backend: string | null;
+  activeReasons: PowerInhibitionReason[];
+  screenProtected: boolean;
+  backgroundProtected: boolean;
+  errorCode: string | null;
+  errorMessage: string | null;
+};
+
+export type BrowserWakeLockStatus = {
+  phase: PowerInhibitionPhase;
+  backend: "browser-screen-wake-lock" | null;
+  screenProtected: boolean;
+  errorMessage: string | null;
+};
+
+const POWER_BACKEND_KEY = "tuneforge.power-inhibition-backend";
+const POWER_ERROR_KEY = "tuneforge.power-inhibition-error";
+const REASONS = new Set<PowerInhibitionReason>([
+  "playback",
+  "sync-listener",
+  "sync-transfer",
+]);
+const PHASES = new Set<PowerInhibitionPhase>([
+  "inactive",
+  "acquiring",
+  "active",
+  "unsupported",
+  "failed",
+  "releasing",
+  "release-failed",
+]);
+const BACKENDS = new Set([
+  "macos-iopm",
+  "xdg-desktop-portal",
+  "systemd-logind",
+  "android-foreground-service",
+]);
+
+const INACTIVE_STATUS: PowerInhibitionStatus = {
+  phase: "inactive",
+  backend: null,
+  activeReasons: [],
+  screenProtected: false,
+  backgroundProtected: false,
+  errorCode: null,
+  errorMessage: null,
+};
+
+const INACTIVE_BROWSER_STATUS: BrowserWakeLockStatus = {
+  phase: "inactive",
+  backend: null,
+  screenProtected: false,
+  errorMessage: null,
+};
+
+let currentStatus = INACTIVE_STATUS;
+let browserStatus = INACTIVE_BROWSER_STATUS;
+let diagnosticsVersion = 0;
+let operationSequence = 0;
+let convergenceToken: { cancelled: boolean; sequence: number } | null = null;
+const listeners = new Set<() => void>();
+const CONVERGENCE_POLL_INTERVAL_MS = 100;
+const CONVERGENCE_MAX_POLLS = 30;
+
+function notify() {
+  diagnosticsVersion += 1;
+  listeners.forEach((listener) => listener());
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeToken(value: unknown) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return /^[a-z0-9][a-z0-9.-]{0,63}$/i.test(trimmed) ? trimmed : null;
+}
+
+function safeMessage(value: unknown, fallback: string | null = null) {
+  if (typeof value !== "string" || !value.trim()) {
+    return fallback;
+  }
+  return redactPlaybackDiagnosticText(value)
+    .replace(
+      /\b(device|project|run|sync)[-_ ]?(?:id)?\s*[:=]\s*["'][^"'\r\n]+["']/gi,
+      "$1 [redacted]",
+    )
+    .replace(
+      /\b(device|project|run|sync)[-_ ]?(?:id)?[:= ]+[^\s,;]+/gi,
+      "$1 [redacted]",
+    )
+    .slice(0, 240);
+}
+
+function rememberStatus(status: PowerInhibitionStatus) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  if (status.backend) {
+    window.localStorage.setItem(POWER_BACKEND_KEY, status.backend);
+  }
+  if (status.errorMessage) {
+    window.localStorage.setItem(POWER_ERROR_KEY, status.errorMessage);
+  }
+}
+
+function publishStatus(status: PowerInhibitionStatus) {
+  currentStatus = status;
+  rememberStatus(status);
+  notify();
+  return status;
+}
+
+function failedStatus(
+  phase: "failed" | "release-failed",
+  reason: PowerInhibitionReason,
+  error: unknown,
+) {
+  const activeReasons = new Set(currentStatus.activeReasons);
+  activeReasons.add(reason);
+  return publishStatus({
+    ...currentStatus,
+    phase,
+    activeReasons: [...activeReasons],
+    errorCode: phase === "failed" ? "power-inhibition-command-failed" : "power-inhibition-release-failed",
+    errorMessage: safeMessage(
+      error instanceof Error ? error.message : error,
+      phase === "failed"
+        ? "Power protection could not be enabled."
+        : "Power protection release could not be confirmed.",
+    ),
+  });
+}
+
+function isTauriRuntime() {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+function isPendingPhase(phase: PowerInhibitionPhase) {
+  return phase === "acquiring" || phase === "releasing";
+}
+
+function waitForConvergencePoll() {
+  return new Promise<void>((resolve) => {
+    window.setTimeout(resolve, CONVERGENCE_POLL_INTERVAL_MS);
+  });
+}
+
+function cancelPendingConvergence() {
+  if (convergenceToken) {
+    convergenceToken.cancelled = true;
+    convergenceToken = null;
+  }
+}
+
+async function convergePowerInhibitionStatus(
+  token: { cancelled: boolean; sequence: number },
+  initialStatus: PowerInhibitionStatus,
+  reason: PowerInhibitionReason,
+  active: boolean,
+) {
+  let status = initialStatus;
+  for (let attempt = 0; attempt < CONVERGENCE_MAX_POLLS && isPendingPhase(status.phase); attempt += 1) {
+    await waitForConvergencePoll();
+    if (token.cancelled || token.sequence !== operationSequence) {
+      return currentStatus;
+    }
+    try {
+      const rawStatus = await invoke<unknown>("power_inhibition_status");
+      if (token.cancelled || token.sequence !== operationSequence) {
+        return currentStatus;
+      }
+      status = publishStatus(normalizePowerInhibitionStatus(rawStatus));
+    } catch (error) {
+      return token.cancelled || token.sequence !== operationSequence
+        ? currentStatus
+        : failedStatus(active ? "failed" : "release-failed", reason, error);
+    }
+  }
+  if (token.cancelled || token.sequence !== operationSequence) {
+    return currentStatus;
+  }
+  if (isPendingPhase(status.phase)) {
+    return failedStatus(
+      active ? "failed" : "release-failed",
+      reason,
+      active
+        ? "Power protection did not confirm activation in time."
+        : "Power protection release could not be confirmed in time.",
+    );
+  }
+  return status;
+}
+
+export function normalizePowerInhibitionStatus(value: unknown): PowerInhibitionStatus {
+  if (!isRecord(value)) {
+    return {
+      ...INACTIVE_STATUS,
+      phase: "failed",
+      errorCode: "power-inhibition-invalid-status",
+      errorMessage: "Power protection returned an invalid status.",
+    };
+  }
+  const phase = PHASES.has(value.phase as PowerInhibitionPhase)
+    ? (value.phase as PowerInhibitionPhase)
+    : "failed";
+  const activeReasons = Array.isArray(value.activeReasons)
+    ? Array.from(
+        new Set(
+          value.activeReasons.filter(
+            (reason): reason is PowerInhibitionReason => REASONS.has(reason as PowerInhibitionReason),
+          ),
+        ),
+      )
+    : [];
+  const normalizedBackend = normalizeToken(value.backend);
+  const backend = normalizedBackend && BACKENDS.has(normalizedBackend) ? normalizedBackend : null;
+  const errorCode = normalizeToken(value.errorCode);
+  const invalidPhase = phase === "failed" && value.phase !== "failed";
+  return {
+    phase,
+    backend,
+    activeReasons,
+    screenProtected: value.screenProtected === true,
+    backgroundProtected: value.backgroundProtected === true,
+    errorCode: invalidPhase ? "power-inhibition-invalid-status" : errorCode,
+    errorMessage: invalidPhase
+      ? "Power protection returned an invalid status."
+      : safeMessage(value.errorMessage),
+  };
+}
+
+export function subscribePowerInhibition(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function getPowerInhibitionVersion() {
+  return diagnosticsVersion;
+}
+
+export function readPowerInhibitionStatus() {
+  return currentStatus;
+}
+
+export function readBrowserWakeLockStatus() {
+  return browserStatus;
+}
+
+export function updateBrowserWakeLockStatus(status: BrowserWakeLockStatus) {
+  browserStatus = {
+    phase: PHASES.has(status.phase) ? status.phase : "failed",
+    backend: status.backend === "browser-screen-wake-lock" ? status.backend : null,
+    screenProtected: status.screenProtected === true,
+    errorMessage: safeMessage(status.errorMessage),
+  };
+  notify();
+}
+
+export async function setPowerInhibitionActivity(
+  reason: PowerInhibitionReason,
+  active: boolean,
+) {
+  cancelPendingConvergence();
+  const sequence = ++operationSequence;
+  const token = { cancelled: false, sequence };
+  convergenceToken = token;
+  const pendingReasons = new Set(currentStatus.activeReasons);
+  if (active) {
+    pendingReasons.add(reason);
+  }
+  publishStatus({
+    ...currentStatus,
+    phase: active ? "acquiring" : "releasing",
+    activeReasons: active ? [...pendingReasons] : currentStatus.activeReasons,
+    errorCode: null,
+    errorMessage: null,
+  });
+  try {
+    const rawStatus = await invoke<unknown>("power_inhibition_set_activity", { reason, active });
+    const status = normalizePowerInhibitionStatus(rawStatus);
+    if (sequence !== operationSequence || token.cancelled) {
+      return currentStatus;
+    }
+    const published = publishStatus(status);
+    return isPendingPhase(published.phase)
+      ? await convergePowerInhibitionStatus(token, published, reason, active)
+      : published;
+  } catch (error) {
+    return sequence === operationSequence && !token.cancelled
+      ? failedStatus(active ? "failed" : "release-failed", reason, error)
+      : currentStatus;
+  } finally {
+    if (convergenceToken === token) {
+      convergenceToken = null;
+    }
+  }
+}
+
+export async function refreshPowerInhibitionStatus() {
+  if (!isTauriRuntime()) {
+    return currentStatus;
+  }
+  const sequence = operationSequence;
+  try {
+    const rawStatus = await invoke<unknown>("power_inhibition_status");
+    const status = normalizePowerInhibitionStatus(rawStatus);
+    return sequence === operationSequence ? publishStatus(status) : currentStatus;
+  } catch (error) {
+    if (sequence !== operationSequence) {
+      return currentStatus;
+    }
+    return publishStatus({
+      ...currentStatus,
+      phase: "failed",
+      errorCode: "power-inhibition-status-failed",
+      errorMessage: safeMessage(error instanceof Error ? error.message : error, "Power protection status is unavailable."),
+    });
+  }
+}
+
+export function readRememberedPowerInhibitionBackend() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  const backend = normalizeToken(window.localStorage.getItem(POWER_BACKEND_KEY));
+  return backend && BACKENDS.has(backend) ? backend : null;
+}
+
+export function readRememberedPowerInhibitionError() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return safeMessage(window.localStorage.getItem(POWER_ERROR_KEY));
+}
+
+export function resetPowerInhibitionDiagnostics() {
+  cancelPendingConvergence();
+  operationSequence += 1;
+  currentStatus = INACTIVE_STATUS;
+  browserStatus = INACTIVE_BROWSER_STATUS;
+  notify();
+}
+
+function phaseFailureMessage(phase: PowerInhibitionPhase, errorMessage: string | null) {
+  if (phase === "unsupported") {
+    return "Power protection is unavailable. Playback may pause when the device sleeps.";
+  }
+  if (phase === "failed") {
+    return errorMessage ?? "Power protection could not be enabled. Playback may pause when the device sleeps.";
+  }
+  if (phase === "release-failed") {
+    return errorMessage ?? "Power protection release could not be confirmed.";
+  }
+  return null;
+}
+
+export function playbackPowerProtectionMessage() {
+  const nativeRelevant = currentStatus.activeReasons.includes("playback");
+  if (nativeRelevant) {
+    return phaseFailureMessage(currentStatus.phase, currentStatus.errorMessage);
+  }
+  if (currentStatus.phase === "release-failed") {
+    return phaseFailureMessage(currentStatus.phase, currentStatus.errorMessage);
+  }
+  return phaseFailureMessage(browserStatus.phase, browserStatus.errorMessage);
+}
+
+export function syncPowerProtectionMessage(status = currentStatus) {
+  const syncRelevant = status.activeReasons.some(
+    (reason) => reason === "sync-listener" || reason === "sync-transfer",
+  );
+  if (!syncRelevant) {
+    return null;
+  }
+  if (status.phase === "unsupported") {
+    return "Power protection is unavailable. Sync may pause when the device sleeps.";
+  }
+  if (status.phase === "failed") {
+    return status.errorMessage ?? "Power protection could not be enabled. Sync may pause when the device sleeps.";
+  }
+  if (status.phase === "release-failed") {
+    return status.errorMessage ?? "Sync power protection release could not be confirmed.";
+  }
+  return null;
+}

--- a/apps/desktop/src/lib/systemMedia.ts
+++ b/apps/desktop/src/lib/systemMedia.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { setPowerInhibitionActivity } from "./powerInhibition";
 
 export const SYSTEM_MEDIA_CONTROL_EVENT = "system-media://control";
 
@@ -39,14 +40,10 @@ export function clearSystemMediaState() {
   return invoke<void>("system_media_clear_state");
 }
 
-export function setSystemMediaIdleInhibition(active: boolean) {
-  return invoke<void>("system_media_set_idle_inhibition", { active });
-}
-
 export async function releaseSystemMediaControls() {
   await Promise.all([
     clearSystemMediaState(),
-    setSystemMediaIdleInhibition(false),
+    setPowerInhibitionActivity("playback", false),
   ]);
 }
 

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -22,6 +22,7 @@ import type {
   SyncTrustedPeerResponse,
 } from "../lib/api";
 import { resetPlaybackE2ETelemetry } from "../lib/playbackE2ETelemetry";
+import { resetPowerInhibitionDiagnostics } from "../lib/powerInhibition";
 
 const DEFAULT_PROJECTS_LIMIT = 50;
 const DEFAULT_JOBS_LIMIT = 50;
@@ -97,10 +98,12 @@ const {
   mockScanPairingQrCode,
   setMockSystemInputVolume,
   setMockNativeAudio,
+  setMockPowerInhibition,
   emitMockNativeAudioError,
   emitMockNativeAudioInputFrame,
   emitMockNativeAudioPosition,
   emitMockSystemMediaControl,
+  getSystemMediaControlListenerCount,
   deferNextSystemMediaControlListen,
   mockListen,
   rejectSystemMediaCommand,
@@ -211,6 +214,15 @@ const {
     nativeAudioSnapshot: Record<string, unknown>;
     nativeAudioStartError: string | null;
     nativeAudioPlayFallbackReason: string | null;
+    powerInhibitionStatus: {
+      phase: string;
+      backend: string | null;
+      activeReasons: string[];
+      screenProtected: boolean;
+      backgroundProtected: boolean;
+      errorCode: string | null;
+      errorMessage: string | null;
+    };
     systemMediaState: Record<string, unknown> | null;
     systemMediaIdleInhibited: boolean;
     systemMediaCommandErrors: Partial<Record<SystemMediaCommand, string>>;
@@ -853,6 +865,15 @@ const {
       },
       nativeAudioStartError: null,
       nativeAudioPlayFallbackReason: null,
+      powerInhibitionStatus: {
+        phase: "inactive",
+        backend: null,
+        activeReasons: [],
+        screenProtected: false,
+        backgroundProtected: false,
+        errorCode: null,
+        errorMessage: null,
+      },
       systemMediaState: null,
       systemMediaIdleInhibited: false,
       systemMediaCommandErrors: {},
@@ -925,6 +946,15 @@ const {
       state.nativeAudioPlayFallbackReason = nextState.playFallbackReason ?? null;
     }
   }
+
+  function setMockPowerInhibition(
+    nextStatus: Partial<typeof state.powerInhibitionStatus>,
+  ) {
+    state.powerInhibitionStatus = {
+      ...state.powerInhibitionStatus,
+      ...clone(nextStatus),
+    };
+  }
   function effectiveNativeAudioLanes(
     lanes: Array<{
       id: string;
@@ -971,6 +1001,9 @@ const {
         payload: clone(payload),
       });
     });
+  }
+  function getSystemMediaControlListenerCount() {
+    return systemMediaControlListeners.size;
   }
   function deferNextSystemMediaControlListen() {
     state.deferNextSystemMediaControlListen = true;
@@ -1106,6 +1139,31 @@ const {
       }
       state.systemMediaIdleInhibited = Boolean(args?.active);
       return null;
+    }
+
+    if (command === "power_inhibition_set_activity") {
+      const reason = String(args?.reason ?? "");
+      const activeReasons = new Set(state.powerInhibitionStatus.activeReasons);
+      if (args?.active === true) {
+        activeReasons.add(reason);
+      } else {
+        activeReasons.delete(reason);
+      }
+      const hasActiveReasons = activeReasons.size > 0;
+      state.powerInhibitionStatus = {
+        phase: hasActiveReasons ? "active" : "inactive",
+        backend: hasActiveReasons ? "test-power" : null,
+        activeReasons: [...activeReasons],
+        screenProtected: hasActiveReasons,
+        backgroundProtected: hasActiveReasons,
+        errorCode: null,
+        errorMessage: null,
+      };
+      return clone(state.powerInhibitionStatus);
+    }
+
+    if (command === "power_inhibition_status") {
+      return clone(state.powerInhibitionStatus);
     }
 
     if (command === "audio_get_capabilities") {
@@ -2362,10 +2420,12 @@ const {
     mockScanPairingQrCode,
     setMockSystemInputVolume,
     setMockNativeAudio,
+    setMockPowerInhibition,
     emitMockNativeAudioError,
     emitMockNativeAudioInputFrame,
     emitMockNativeAudioPosition,
     emitMockSystemMediaControl,
+    getSystemMediaControlListenerCount,
     deferNextSystemMediaControlListen,
     mockListen,
     rejectSystemMediaCommand,
@@ -2754,6 +2814,12 @@ export function setMockNativeAudioState(
   setMockNativeAudio(nextState);
 }
 
+export function setMockPowerInhibitionState(
+  nextState: Parameters<typeof setMockPowerInhibition>[0],
+) {
+  setMockPowerInhibition(nextState);
+}
+
 export function emitMockNativeInputFrame(
   frame: Parameters<typeof emitMockNativeAudioInputFrame>[0],
 ) {
@@ -2776,6 +2842,10 @@ export function emitMockSystemMediaPlaybackControl(
   payload: Parameters<typeof emitMockSystemMediaControl>[0],
 ) {
   emitMockSystemMediaControl(payload);
+}
+
+export function getMockSystemMediaControlListenerCount() {
+  return getSystemMediaControlListenerCount();
 }
 
 export function deferNextMockSystemMediaControlListen() {
@@ -2847,6 +2917,7 @@ export function getMockWakeLock() {
 export function resetAppTestHarness() {
   resetMockApiState();
   resetPlaybackE2ETelemetry();
+  resetPowerInhibitionDiagnostics();
   delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
   window.localStorage.clear();
   window.sessionStorage.clear();

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -120,6 +120,23 @@ fallback after native failure or a build-time development override; it is not a 
 Playback state, clocks, and Settings diagnostics change only after the active native session or Web
 media confirms the transition.
 
+Android power protection follows confirmed work automatically; no manual toggle exists. Confirmed
+native playback uses a `mediaPlayback` foreground service and keeps the foreground activity screen
+on. An active sync listener uses `connectedDevice`, and an active transfer also uses `dataSync`.
+Listener and transfer work hold a bounded, renewable partial wake lock; playback relies on Android's
+media path for CPU wakefulness. The ongoing notification states whether playback, sync, or both are
+active. Pause, stop, natural end, fallback, listener stop, transfer completion/cancellation/failure,
+and app shutdown release their corresponding reason without releasing other active work.
+On Android 13 and newer, TuneForge requests notification permission only when a user action starts
+protected playback or sync work. Denial does not cancel that work; diagnostics report the missing
+notification visibility while Android's system active-app controls remain available.
+
+Settings diagnostics distinguish acquiring, active, unsupported, failed, releasing, and
+release-not-confirmed states. They report protection only after Android confirms it. Activity ->
+Sync and playback status show concise reliability warnings for unsupported or failed protection.
+Android 15 `dataSync` timeout is reported as a failure and releases protection; it is never shown as
+a completed transfer.
+
 `pnpm --filter @tuneforge/desktop android:prepare` updates the generated Android target before a
 build. It keeps these manifest permissions present:
 
@@ -127,6 +144,10 @@ build. It keeps these manifest permissions present:
 - `android.permission.RECORD_AUDIO` and `android.permission.MODIFY_AUDIO_SETTINGS` for mobile audio
   flows.
 - `android.permission.CAMERA` for the Android-only QR pairing scanner.
+- foreground-service permissions for `mediaPlayback`, `connectedDevice`, and `dataSync`, plus
+  `android.permission.WAKE_LOCK`, for truthful playback and sync lifetime ownership.
+- `android.permission.POST_NOTIFICATIONS` so supported Android versions can expose active work.
+- `android.permission.CHANGE_NETWORK_STATE` for connected-device foreground sync work.
 
 These are package-level permissions only. They do not change the local-only product rule, and they
 must not be used to add cloud, telemetry, account, or remote-processing behavior. Do not add
@@ -169,12 +190,20 @@ For listener lifecycle validation, start, stop, restart, pause, and resume the A
 the build supports it. The UI records native-only lifecycle events through
 `sync_transport_record_lifecycle_event`: desktop background events from `visibilitychange` hidden,
 window blur, and `pagehide` stay passive; Android hidden/pagehide records `android_background`, and
-Android window blur records `android_screen_lock` so active sync runs are interrupted for retry.
+Android window blur records `android_screen_lock`. Both Android events stay passive so the listener
+and active transfers continue while the app is backgrounded or the screen is locked.
 Foreground events from window focus, `visibilitychange` visible, and `pageshow` refresh listener
 state; Android foreground uses `android_foreground`. Browser `online` and `offline` events record
-network recovery/interruption. Offline or Android lifecycle interruptions may expose native retry
-guidance and a trusted peer ID; when they do, the UI shows Retry Sync and reuses the normal preflight
-plus Sync Now path, including nearby endpoint hints.
+network recovery/interruption. Offline interruptions may expose native retry guidance and a trusted
+peer ID; when they do, the UI shows Retry Sync and reuses the normal preflight plus Sync Now path,
+including nearby endpoint hints.
+
+Also inspect Android service and power state with `adb`: confirmed playback must show the
+`mediaPlayback` foreground-service type; listener and transfer must add `connectedDevice` and
+`dataSync` as applicable. Notification copy must match active work. Verify every terminal path clears
+its reason, and exercise a shortened Android 15 data-sync timeout in a synthetic debug run. A live
+transfer still requires an isolated desktop peer; automated lifecycle tests do not prove that
+end-to-end path.
 
 Desktop sleep/wake has no native command bridge. The UI uses an elapsed-time check while visible: a
 long timer gap records `sleep` followed by `wake`, while ordinary desktop hidden/blur/pagehide remains

--- a/docs/NATIVE_AUDIO.md
+++ b/docs/NATIVE_AUDIO.md
@@ -32,14 +32,16 @@ Playback also owns media-key controls and wake prevention through the active bac
 - TuneForge registers one desktop system-media adapter with the OS for media keys and headset
   controls. That adapter does not choose the audio engine; it routes play/pause/stop/seek events to
   the current playback owner.
-- Native playback owns the transport only after a matching native session confirms playback, and uses
-  native idle/display inhibition while playing.
+- Native playback owns the transport only after a matching native session confirms playback, and
+  requests OS power protection while playing. User intent or an in-flight start does not count as
+  confirmed protection.
 - Web Audio/HTML media playback owns the transport only after a `playing` event or confirmed media
   progress,
   including `VITE_TUNEFORGE_FORCE_WEB_AUDIO=1` and native fallback. It uses the browser Screen Wake
-  Lock while playing.
+  Lock while playing. Browser Screen Wake Lock protects the visible screen only; it does not claim
+  native background protection.
 - Native fallback is an explicit ownership transfer. TuneForge clears system media state and native
-  idle inhibition, starts the Web Audio path at the fallback position, then re-registers system
+  power protection, starts the Web Audio path at the fallback position, then re-registers system
   media state for the Web Audio owner and acquires the browser wake lock. Diagnostics keep the
   native fallback reason.
 - Failed native prepare/play attempts before audio starts never activate native transport ownership.
@@ -97,11 +99,16 @@ Settings -> Local Data -> Show diagnostics reports:
 - active native session lane count
 - native playback buffer health per lane, including fill level, underrun count, worker errors, and
   the last worker error when present
+- current power-protection phase, confirmed backend, active reasons, and separately confirmed screen
+  and background coverage
+- current browser Screen Wake Lock phase plus latest safe power-protection error and last confirmed
+  native backend
 
 Current state is live and starts as `Not playing` / `None` after reload. Only last-confirmed path and
 redacted failures are restored from local storage. A native failure does not claim Web fallback
 until Web playback is confirmed, and `android-null` is always reported as unavailable. Diagnostic
-reasons omit local paths, URLs, artifact IDs, and session IDs.
+reasons omit local paths, URLs, artifact IDs, and session IDs. Active power state is never restored
+from local storage; only a safe historical backend and error may survive reload.
 
 When `VITE_TUNEFORGE_FORCE_WEB_AUDIO=1` is active, diagnostics report the build-time override and
 `Web Audio forced` policy while continuing to report native capability independently.
@@ -140,9 +147,15 @@ BlackHole capture are release checks, not default `pnpm test` coverage.
 | Tempo control | tempo change applies and stays stable | tempo change applies and stays stable | tempo change applies and stays stable |
 | Metronome follow | follows active track tempo while BPM changes | follows active track tempo while BPM changes | follows active track tempo while BPM changes |
 | Media keys / headset controls | system media controls play/pause/stop/seek native transport only | MPRIS controls play/pause/stop/seek native transport only | system media controls play/pause/stop/seek browser transport only |
-| Wake prevention | native display idle inhibition while playing; released on pause/stop/end/fallback | desktop idle inhibition while playing; released on pause/stop/end/fallback | Screen Wake Lock while playing; released on pause/stop/end |
+| Wake prevention | native display idle inhibition while playing; released on pause/stop/end/fallback | portal or logind inhibition while playing; released on pause/stop/end/fallback | Screen Wake Lock while playing; released on pause/stop/end |
 | Native runtime fallback ownership | system state/inhibition clear before Web Audio starts at fallback position, then system controls route to Web Audio | same | not applicable; web owns controls from start |
 | Fallback + no output device | falls back (or errors and recovers) without crash when no native output exists | same | same |
+
+For manual Linux inhibition validation, record distro, desktop/session, and package type. Start
+confirmed native playback and verify TuneForge appears in the desktop inhibitor detector. Pause,
+stop, natural end, playback failure, fallback, and app exit must each clear it. Repeat one
+start/stop cycle to detect a leaked handle. Settings diagnostics must name the same live backend
+(`xdg-desktop-portal` or `systemd-logind`) and return to `Inactive` after release.
 
 ## Local-only Playwright Smoke Harness
 

--- a/scripts/android-prepare-generated.sh
+++ b/scripts/android-prepare-generated.sh
@@ -7,6 +7,7 @@ ANDROID_RES="$ANDROID_MAIN/res"
 ANDROID_ICONS="$ROOT_DIR/apps/desktop/src-tauri/target/android-icons/android"
 MANIFEST="$ANDROID_MAIN/AndroidManifest.xml"
 MAIN_ACTIVITY="$ANDROID_MAIN/java/com/tuneforge/desktop/MainActivity.kt"
+POWER_SERVICE="$ANDROID_MAIN/java/com/tuneforge/desktop/PowerInhibitionService.kt"
 
 if [[ ! -f "$MANIFEST" || ! -f "$MAIN_ACTIVITY" || ! -d "$ANDROID_RES" ]]; then
   echo "Android project is not initialized. Run pnpm --filter @tuneforge/desktop tauri android init first." >&2
@@ -79,16 +80,55 @@ ensure_permission() {
   mv "$temp_file" "$MANIFEST"
 }
 
+ensure_power_service() {
+  if grep -Fq 'android:name=".PowerInhibitionService"' "$MANIFEST"; then
+    return
+  fi
+
+  local temp_file
+  temp_file="$(mktemp)"
+  awk '
+    !inserted && /^[[:space:]]*<\/application>/ {
+      print "        <service"
+      print "            android:name=\".PowerInhibitionService\""
+      print "            android:exported=\"false\""
+      print "            android:foregroundServiceType=\"mediaPlayback|connectedDevice|dataSync\" />"
+      inserted = 1
+    }
+    { print }
+    END {
+      if (!inserted) {
+        exit 42
+      }
+    }
+  ' "$MANIFEST" > "$temp_file" || {
+    rm -f "$temp_file"
+    echo "Could not add Android power inhibition service to $MANIFEST" >&2
+    exit 1
+  }
+  mv "$temp_file" "$MANIFEST"
+}
+
 copy_android_icons
 
 ensure_permission "android.permission.INTERNET"
 ensure_permission "android.permission.RECORD_AUDIO"
 ensure_permission "android.permission.MODIFY_AUDIO_SETTINGS"
 ensure_permission "android.permission.CAMERA"
+ensure_permission "android.permission.FOREGROUND_SERVICE"
+ensure_permission "android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"
+ensure_permission "android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE"
+ensure_permission "android.permission.FOREGROUND_SERVICE_DATA_SYNC"
+ensure_permission "android.permission.POST_NOTIFICATIONS"
+ensure_permission "android.permission.WAKE_LOCK"
+ensure_permission "android.permission.CHANGE_NETWORK_STATE"
+ensure_power_service
 
 cat > "$MAIN_ACTIVITY" <<'KOTLIN'
 package com.tuneforge.desktop
 
+import android.Manifest
+import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.view.View
@@ -96,9 +136,17 @@ import android.view.WindowInsets
 import android.view.WindowInsetsController
 
 class MainActivity : TauriActivity() {
+  private var notificationPermissionOwnershipRevision = 0L
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    PowerInhibitionService.attachActivity(this)
     scheduleHideNavigationBar()
+  }
+
+  override fun onDestroy() {
+    PowerInhibitionService.detachActivity(this)
+    super.onDestroy()
   }
 
   override fun onWindowFocusChanged(hasFocus: Boolean) {
@@ -106,6 +154,59 @@ class MainActivity : TauriActivity() {
     if (hasFocus) {
       scheduleHideNavigationBar()
     }
+  }
+
+  fun setTuneForgePowerInhibition(reasonMask: Int): String {
+    if (reasonMask != 0) {
+      requestTuneForgeNotificationPermission()
+    }
+    PowerInhibitionService.requestScreenProtection(
+      reasonMask and PowerInhibitionService.REASON_PLAYBACK != 0,
+    )
+    return PowerInhibitionService.request(this, reasonMask)
+  }
+
+  fun getTuneForgePowerInhibitionStatus(): String = PowerInhibitionService.status()
+
+  fun applyTuneForgeScreenProtection() {
+    window.decorView.post {
+      val requested = PowerInhibitionService.screenProtectionRequested()
+      window.decorView.keepScreenOn = requested
+      PowerInhibitionService.confirmScreenProtection(requested)
+    }
+  }
+
+  override fun onRequestPermissionsResult(
+    requestCode: Int,
+    permissions: Array<out String>,
+    grantResults: IntArray,
+  ) {
+    super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+    if (requestCode == NOTIFICATION_PERMISSION_REQUEST) {
+      PowerInhibitionService.recordNotificationPermissionResult(
+        grantResults.firstOrNull() == PackageManager.PERMISSION_GRANTED,
+        notificationPermissionOwnershipRevision,
+      )
+    }
+  }
+
+  private fun requestTuneForgeNotificationPermission() {
+    window.decorView.post {
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+        checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
+      ) return@post
+      val expectedRevision = PowerInhibitionService.captureNotificationPermissionOwnershipRevision()
+      if (!PowerInhibitionService.beginNotificationPermissionRequest()) return@post
+      notificationPermissionOwnershipRevision = expectedRevision
+      requestPermissions(
+        arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+        NOTIFICATION_PERMISSION_REQUEST,
+      )
+    }
+  }
+
+  companion object {
+    private const val NOTIFICATION_PERMISSION_REQUEST = 2305
   }
 
   @Suppress("DEPRECATION")
@@ -135,3 +236,385 @@ class MainActivity : TauriActivity() {
   }
 }
 KOTLIN
+
+cat > "$POWER_SERVICE" <<'KOTLIN'
+package com.tuneforge.desktop
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.os.PowerManager
+import java.lang.ref.WeakReference
+import java.util.concurrent.atomic.AtomicLong
+
+class PowerInhibitionService : Service() {
+  private val handler = Handler(Looper.getMainLooper())
+  private var wakeLock: PowerManager.WakeLock? = null
+  private var reasonMask = 0
+
+  override fun onCreate() {
+    super.onCreate()
+    instance = this
+    createNotificationChannel()
+  }
+
+  override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+    // A queued start intent may predate a later release request. Always apply
+    // the latest process-wide desired mask so a stale intent cannot reacquire.
+    val requestedMask = desiredReasonMask()
+    applyReasons(requestedMask)
+    return START_NOT_STICKY
+  }
+
+  override fun onDestroy() {
+    releaseWakeLock()
+    reasonMask = 0
+    confirmedMask = 0
+    instance = null
+    super.onDestroy()
+    val remainingMask = desiredMask
+    if (remainingMask != 0) {
+      launch(applicationContext, remainingMask)
+    }
+  }
+
+  override fun onBind(intent: Intent?): IBinder? = null
+
+  override fun onTimeout(startId: Int, fgsType: Int) {
+    if (Build.VERSION.SDK_INT >= 35 && fgsType and ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC != 0) {
+      val remainingMask = reasonMask and REASON_SYNC_TRANSFER.inv()
+      ownershipRevision.incrementAndGet()
+      timeoutEpoch += 1
+      lastFailure = ERROR_DATA_SYNC_TIMEOUT
+      desiredMask = remainingMask
+      confirmedMask = 0
+      requestScreenProtection(remainingMask and REASON_PLAYBACK != 0)
+      releaseWakeLock()
+      reasonMask = 0
+      stopForeground(STOP_FOREGROUND_REMOVE)
+      stopSelf(startId)
+    }
+  }
+
+  private fun applyReasons(requestedMask: Int): String {
+    return try {
+      reasonMask = requestedMask
+      confirmedMask = requestedMask
+      updateWakeLock()
+      if (reasonMask == 0) {
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        stopSelf()
+        status()
+      } else {
+        startTruthfulForegroundNotification()
+        status()
+      }
+    } catch (_: RuntimeException) {
+      releaseWakeLock()
+      reasonMask = 0
+      confirmedMask = 0
+      desiredMask = 0
+      lastFailure = ERROR_POWER_CONTROL
+      requestScreenProtection(false)
+      stopForeground(STOP_FOREGROUND_REMOVE)
+      stopSelf()
+      status()
+    }
+  }
+
+  private fun startTruthfulForegroundNotification() {
+    val notification = buildTruthfulForegroundNotification()
+    val serviceTypes = foregroundServiceTypes()
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      startForeground(NOTIFICATION_ID, notification, serviceTypes)
+    } else {
+      startForeground(NOTIFICATION_ID, notification)
+    }
+  }
+
+  private fun buildTruthfulForegroundNotification(): Notification {
+    val builder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      Notification.Builder(this, CHANNEL_ID)
+    } else {
+      @Suppress("DEPRECATION")
+      Notification.Builder(this)
+    }
+    return builder
+      .setSmallIcon(applicationInfo.icon)
+      .setContentTitle("TuneForge active")
+      .setContentText(notificationText())
+      .setOngoing(true)
+      .setCategory(Notification.CATEGORY_SERVICE)
+      .build()
+  }
+
+  private fun repostNotificationAfterPermissionGrant(expectedRevision: Long) {
+    handler.post {
+      if (!matchesNotificationOwnership(expectedRevision)) return@post
+      try {
+        val notification = buildTruthfulForegroundNotification()
+        if (!matchesNotificationOwnership(expectedRevision)) return@post
+        getSystemService(NotificationManager::class.java).notify(
+          NOTIFICATION_ID,
+          notification,
+        )
+      } catch (_: RuntimeException) {
+        if (matchesNotificationOwnership(expectedRevision)) {
+          lastFailure = ERROR_NOTIFICATION_POST_FAILED
+        }
+      }
+    }
+  }
+
+  private fun matchesNotificationOwnership(expectedRevision: Long): Boolean =
+    expectedRevision == ownershipRevision.get() &&
+      reasonMask != 0 &&
+      reasonMask == desiredMask &&
+      reasonMask == confirmedMask
+
+  private fun foregroundServiceTypes(): Int {
+    var types = 0
+    if (reasonMask and REASON_PLAYBACK != 0) {
+      types = types or ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+    }
+    if (reasonMask and REASON_SYNC_LISTENER != 0) {
+      types = types or ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
+    }
+    if (reasonMask and REASON_SYNC_TRANSFER != 0) {
+      types = types or ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+    }
+    return types
+  }
+
+  private fun notificationText(): String {
+    val playback = reasonMask and REASON_PLAYBACK != 0
+    val listener = reasonMask and REASON_SYNC_LISTENER != 0
+    val transfer = reasonMask and REASON_SYNC_TRANSFER != 0
+    return when {
+      playback && (listener || transfer) -> "Playback and sync are active"
+      playback -> "Playback is active"
+      transfer -> "Sync transfer is active"
+      listener -> "Sync listener is active"
+      else -> "Finishing active work"
+    }
+  }
+
+  private fun updateWakeLock() {
+    val syncActive = reasonMask and (REASON_SYNC_LISTENER or REASON_SYNC_TRANSFER) != 0
+    if (!syncActive) {
+      releaseWakeLock()
+      return
+    }
+    val lock = wakeLock ?: (getSystemService(Context.POWER_SERVICE) as PowerManager)
+      .newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "TuneForge:Sync")
+      .also { wakeLock = it }
+    if (!lock.isHeld) {
+      lock.acquire(WAKE_LOCK_DURATION_MS)
+    }
+    handler.removeCallbacks(renewWakeLock)
+    handler.postDelayed(renewWakeLock, WAKE_LOCK_RENEW_MS)
+  }
+
+  private val renewWakeLock = object : Runnable {
+    override fun run() {
+      if (reasonMask and (REASON_SYNC_LISTENER or REASON_SYNC_TRANSFER) == 0) return
+      wakeLock?.let { lock ->
+        if (lock.isHeld) lock.release()
+        lock.acquire(WAKE_LOCK_DURATION_MS)
+      }
+      handler.postDelayed(this, WAKE_LOCK_RENEW_MS)
+    }
+  }
+
+  private fun releaseWakeLock() {
+    handler.removeCallbacks(renewWakeLock)
+    wakeLock?.let { if (it.isHeld) it.release() }
+    wakeLock = null
+  }
+
+  private fun createNotificationChannel() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+    val channel = NotificationChannel(
+      CHANNEL_ID,
+      "Playback and sync",
+      NotificationManager.IMPORTANCE_LOW,
+    ).apply {
+      description = "Shows when TuneForge keeps playback or sync active"
+      setShowBadge(false)
+    }
+    getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+  }
+
+  companion object {
+    const val REASON_PLAYBACK = 1
+    const val REASON_SYNC_LISTENER = 2
+    const val REASON_SYNC_TRANSFER = 4
+    private const val CHANNEL_ID = "tuneforge_active_work"
+    private const val NOTIFICATION_ID = 2304
+    private const val EXTRA_REASON_MASK = "reasonMask"
+    private const val WAKE_LOCK_DURATION_MS = 10 * 60 * 1000L
+    private const val WAKE_LOCK_RENEW_MS = 9 * 60 * 1000L
+    private const val ERROR_NONE = "none"
+    private const val ERROR_DATA_SYNC_TIMEOUT = "android-data-sync-timeout"
+    private const val ERROR_NOTIFICATION_PERMISSION_DENIED = "android-notification-permission-denied"
+    private const val ERROR_NOTIFICATION_POST_FAILED = "android-notification-post-failed"
+    private const val ERROR_POWER_CONTROL = "android-power-control-failed"
+
+    @Volatile private var instance: PowerInhibitionService? = null
+    @Volatile private var desiredMask = 0
+    @Volatile private var confirmedMask = 0
+    @Volatile private var lastFailure = ERROR_NONE
+    @Volatile private var timeoutEpoch = 0L
+    @Volatile private var screenRequested = false
+    @Volatile private var screenConfirmed = false
+    @Volatile private var notificationPermissionRequested = false
+    @Volatile private var notificationPermissionDenied = false
+    @Volatile private var activity = WeakReference<MainActivity>(null)
+    private val ownershipRevision = AtomicLong(0)
+
+    fun attachActivity(nextActivity: MainActivity) {
+      activity = WeakReference(nextActivity)
+      nextActivity.applyTuneForgeScreenProtection()
+    }
+
+    fun detachActivity(currentActivity: MainActivity) {
+      if (activity.get() === currentActivity) activity.clear()
+    }
+
+    fun requestScreenProtection(enabled: Boolean) {
+      screenRequested = enabled
+      activity.get()?.applyTuneForgeScreenProtection()
+    }
+
+    fun screenProtectionRequested(): Boolean = screenRequested
+
+    private fun desiredReasonMask(): Int = desiredMask
+
+    fun confirmScreenProtection(enabled: Boolean) {
+      screenConfirmed = enabled
+    }
+
+    fun beginNotificationPermissionRequest(): Boolean {
+      if (notificationPermissionRequested) return false
+      notificationPermissionRequested = true
+      return true
+    }
+
+    fun captureNotificationPermissionOwnershipRevision(): Long = ownershipRevision.get()
+
+    fun recordNotificationPermissionResult(granted: Boolean, expectedRevision: Long) {
+      notificationPermissionDenied = !granted
+      if (granted) {
+        instance?.repostNotificationAfterPermissionGrant(expectedRevision)
+      }
+    }
+
+    fun request(context: Context, reasonMask: Int): String {
+      val previousMask = desiredMask
+      ownershipRevision.incrementAndGet()
+      desiredMask = reasonMask
+      if (lastFailure == ERROR_DATA_SYNC_TIMEOUT &&
+        (reasonMask and REASON_SYNC_TRANSFER == 0 || previousMask and REASON_SYNC_TRANSFER == 0)
+      ) {
+        lastFailure = ERROR_NONE
+      } else if (lastFailure == ERROR_POWER_CONTROL || lastFailure == ERROR_NOTIFICATION_POST_FAILED) {
+        lastFailure = ERROR_NONE
+      }
+      val existing = instance
+      if (existing != null) {
+        existing.applyOnMainThread(reasonMask)
+        return status()
+      }
+      if (reasonMask == 0) {
+        confirmedMask = 0
+        return status()
+      }
+
+      launch(context, reasonMask)
+      return status()
+    }
+
+    fun status(): String {
+      val activeMask = confirmedMask
+      val screenMatches = screenConfirmed == (desiredMask and REASON_PLAYBACK != 0)
+      val statusError = when {
+        lastFailure != ERROR_NONE -> lastFailure
+        notificationPermissionDenied && desiredMask != 0 -> ERROR_NOTIFICATION_PERMISSION_DENIED
+        else -> ERROR_NONE
+      }
+      val phase = when {
+        statusError != ERROR_NONE -> "failed"
+        activeMask == desiredMask && screenMatches && activeMask == 0 -> "inactive"
+        activeMask == desiredMask && screenMatches -> "active"
+        desiredMask == 0 -> "releasing"
+        else -> "acquiring"
+      }
+      return "$phase;$activeMask;$statusError;$desiredMask;$timeoutEpoch;$screenConfirmed"
+    }
+
+    private fun launch(context: Context, reasonMask: Int) {
+      try {
+        val intent = Intent(context, PowerInhibitionService::class.java)
+          .putExtra(EXTRA_REASON_MASK, reasonMask)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+          context.startForegroundService(intent)
+        } else {
+          context.startService(intent)
+        }
+      } catch (_: RuntimeException) {
+        desiredMask = 0
+        confirmedMask = 0
+        lastFailure = ERROR_POWER_CONTROL
+        requestScreenProtection(false)
+      }
+    }
+  }
+
+  private fun applyOnMainThread(requestedMask: Int) {
+    if (Looper.myLooper() == Looper.getMainLooper()) {
+      applyReasons(requestedMask)
+    } else {
+      handler.post { applyReasons(requestedMask) }
+    }
+  }
+}
+KOTLIN
+
+verify_power_notification_wiring() {
+  local required_snippets=(
+    'fun recordNotificationPermissionResult(granted: Boolean, expectedRevision: Long)'
+    'instance?.repostNotificationAfterPermissionGrant(expectedRevision)'
+    'ownershipRevision.incrementAndGet()'
+    'expectedRevision == ownershipRevision.get()'
+    'reasonMask == desiredMask &&'
+    'reasonMask == confirmedMask'
+    'if (!matchesNotificationOwnership(expectedRevision)) return@post'
+    'if (matchesNotificationOwnership(expectedRevision)) {'
+    'buildTruthfulForegroundNotification()'
+    'ERROR_NOTIFICATION_POST_FAILED'
+  )
+  local snippet
+  for snippet in "${required_snippets[@]}"; do
+    if ! grep -Fq "$snippet" "$POWER_SERVICE"; then
+      echo "Generated Android notification grant wiring is incomplete: $snippet" >&2
+      exit 1
+    fi
+  done
+  if ! grep -Fq 'notificationPermissionOwnershipRevision,' "$MAIN_ACTIVITY" ||
+    ! grep -Fq 'val expectedRevision = PowerInhibitionService.captureNotificationPermissionOwnershipRevision()' "$MAIN_ACTIVITY" ||
+    ! grep -Fq 'if (!PowerInhibitionService.beginNotificationPermissionRequest()) return@post' "$MAIN_ACTIVITY" ||
+    ! grep -Fq 'notificationPermissionOwnershipRevision = expectedRevision' "$MAIN_ACTIVITY"; then
+    echo "Generated Android activity does not bind notification permission to ownership." >&2
+    exit 1
+  fi
+}
+
+verify_power_notification_wiring


### PR DESCRIPTION
## Summary

- Add counted power-inhibition ownership for confirmed playback, sync listeners, and sync transfers.
- Support macOS IOPM, Linux portal/logind, and Android foreground-service, wake-lock, and screen-protection lifecycles.
- Expose truthful native and browser protection diagnostics, including failure and release states.
- Preserve active work across Android background and screen-lock lifecycle events without cross-releasing other owners.
- Closes #334

## Testing

- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test` — 39 files, 667 tests passed
- `(cd apps/desktop/src-tauri && cargo fmt --all -- --check)`
- `(cd apps/desktop/src-tauri && cargo check --quiet)`
- `(cd apps/desktop/src-tauri && cargo test power_inhibition --lib)` — 10 tests passed
- Focused Rust and frontend lifecycle regressions passed for Android background/lock, offline interruption, Web Audio ownership, and release cleanup.
- `pnpm package:android:debug`
- macOS manual playback/listener checks confirmed `macos-iopm` acquisition and release.
- Linux manual playback/listener/transfer checks confirmed `systemd-logind` acquisition and release.
- Android physical-device and emulator checks confirmed playback screen protection, natural/explicit release, foreground notifications, and truthful inactive diagnostics.
- Post-repair live Android transfer across screen-off was not rerun; automated lifecycle regressions cover the repaired cancellation path.
