### PR TITLE
feat: add mobile playback practice workspace

### DIFF
--- a/apps/desktop/src/App.mobile.test.tsx
+++ b/apps/desktop/src/App.mobile.test.tsx
@@ -2,6 +2,8 @@ import { act, fireEvent, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { LyricsResponse } from "./lib/api";
+import { markPlaybackStarting } from "./lib/playbackDiagnostics";
+import { updateBrowserWakeLockStatus } from "./lib/powerInhibition";
 import {
   findAudioByArtifactId,
   markAudioReady,
@@ -10,6 +12,7 @@ import {
   mockGetMobileCapabilities,
   resetAppTestHarness,
   renderApp,
+  setProjectAnalysis,
   setProjectChords,
   setProjectLyrics,
 } from "./test/appTestHarness";
@@ -54,6 +57,50 @@ function setEmptyChords() {
     has_user_edits: false,
     created_at: null,
     updated_at: null,
+  });
+}
+
+function setAvailableChords() {
+  setProjectChords("proj_123", {
+    project_id: "proj_123",
+    backend: "tuneforge-fast",
+    source_artifact_id: "art_source",
+    source_segments: [
+      {
+        start_seconds: 0,
+        end_seconds: 16,
+        label: "G",
+        confidence: 0.81,
+        pitch_class: 7,
+        quality: "major",
+      },
+    ],
+    timeline: [
+      {
+        start_seconds: 0,
+        end_seconds: 16,
+        label: "G",
+        confidence: 0.81,
+        pitch_class: 7,
+        quality: "major",
+      },
+    ],
+    has_user_edits: false,
+    created_at: "2026-04-18T13:16:00.000Z",
+    updated_at: "2026-04-18T13:16:00.000Z",
+  });
+}
+
+function setTempoAnalysis(tempoBpm = 120) {
+  setProjectAnalysis("proj_123", {
+    project_id: "proj_123",
+    estimated_key: "G major",
+    key_confidence: 0.82,
+    estimated_reference_hz: 440,
+    tuning_offset_cents: 0,
+    tempo_bpm: tempoBpm,
+    analysis_version: "v1",
+    created_at: "2026-04-18T13:16:00.000Z",
   });
 }
 
@@ -109,6 +156,7 @@ describe("Desktop app mobile capability gates", () => {
     renderApp(["/projects/proj_123"]);
 
     await user.click(await screen.findByRole("tab", { name: "Playback" }));
+    await user.click(screen.getByRole("button", { name: "Open Practice Controls" }));
 
     expect(
       await screen.findByText(
@@ -181,8 +229,216 @@ describe("Desktop app mobile capability gates", () => {
       within(playbackSurface as HTMLElement).queryByRole("button", { name: /Generate|Refresh/i }),
     ).not.toBeInTheDocument();
     expect(screen.getByRole("group", { name: "Lyrics and chords lead sheet" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Lyrics" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Lyrics" })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByRole("button", { name: "Chords" })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByRole("button", { name: "Both" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("consolidates mobile playback navigation and infrequent actions in the app bar", async () => {
+    const user = userEvent.setup();
+    enableAndroidRuntime();
+    renderApp(["/projects/proj_123"]);
+
+    await user.click(await screen.findByRole("tab", { name: "Playback" }));
+
+    const appBar = screen.getByRole("banner");
+    expect(within(appBar).getByRole("link", { name: "Back to Library" })).toHaveAttribute(
+      "href",
+      "/",
+    );
+    expect(within(appBar).getByRole("heading", { name: "Demo Song" })).toHaveAttribute(
+      "title",
+      "Demo Song",
+    );
+    expect(within(appBar).getByText("Playback")).toBeInTheDocument();
+    expect(screen.queryByRole("tablist", { name: "Project workspace" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Edit Lyrics" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Import Tab" })).not.toBeInTheDocument();
+
+    const overflowTrigger = within(appBar).getByRole("button", {
+      name: "More playback actions",
+    });
+    await user.click(overflowTrigger);
+    const menu = within(appBar).getByRole("menu", { name: "Playback actions" });
+    expect(within(menu).getByRole("menuitem", { name: "Project workspace" })).toBeEnabled();
+    expect(within(menu).getByRole("menuitem", { name: "Edit Lyrics" })).toBeEnabled();
+    expect(within(menu).getByRole("menuitem", { name: "Import Tab" })).toBeEnabled();
+    expect(window.history.state).toMatchObject({
+      tuneforgePlaybackOverflow: expect.any(String),
+    });
+
+    act(() => {
+      window.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+    });
+    await waitFor(() =>
+      expect(within(appBar).queryByRole("menu", { name: "Playback actions" })).not.toBeInTheDocument(),
+    );
+    await waitFor(() => expect(overflowTrigger).toHaveFocus());
+    expect(within(appBar).getByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+
+    const historyBack = vi.spyOn(window.history, "back").mockImplementation(() => undefined);
+    await user.click(overflowTrigger);
+    expect(within(appBar).getByRole("menu", { name: "Playback actions" })).toBeInTheDocument();
+    fireEvent.pointerDown(document.body);
+    await waitFor(() =>
+      expect(within(appBar).queryByRole("menu", { name: "Playback actions" })).not.toBeInTheDocument(),
+    );
+    expect(historyBack).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(overflowTrigger).toHaveFocus());
+    historyBack.mockRestore();
+
+    await user.click(overflowTrigger);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(within(appBar).queryByRole("menu", { name: "Playback actions" })).not.toBeInTheDocument();
+    expect(overflowTrigger).toHaveFocus();
+  });
+
+  it("makes Practice Controls modal, inert, focus-trapped, and dismissible by every mobile path", async () => {
+    const user = userEvent.setup();
+    enableAndroidRuntime();
+    renderApp(["/projects/proj_123"]);
+
+    await user.click(await screen.findByRole("tab", { name: "Playback" }));
+    const trigger = screen.getByRole("button", { name: "Open Practice Controls" });
+    const appUnderlay = document.querySelector<HTMLElement>(".app-shell");
+    expect(appUnderlay).not.toBeNull();
+
+    await user.click(trigger);
+    let dialog = screen.getByRole("dialog", { name: "Practice Controls" });
+    let closeButton = within(dialog).getByRole("button", { name: "Close Practice Controls" });
+    expect(appUnderlay).toHaveAttribute("inert");
+    expect(appUnderlay).toHaveAttribute("aria-hidden", "true");
+    expect(closeButton).toHaveFocus();
+    await user.tab({ shift: true });
+    expect(dialog).toContainElement(document.activeElement as HTMLElement);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog", { name: "Practice Controls" })).not.toBeInTheDocument(),
+    );
+    await waitFor(() => expect(trigger).toHaveFocus());
+    expect(appUnderlay).not.toHaveAttribute("inert");
+
+    await user.click(trigger);
+    dialog = screen.getByRole("dialog", { name: "Practice Controls" });
+    expect(dialog).toBeInTheDocument();
+    const scrim = document.querySelector<HTMLElement>(".mobile-practice-controls__scrim");
+    expect(scrim).not.toBeNull();
+    fireEvent.click(scrim as HTMLElement);
+    await waitFor(() => expect(dialog).not.toBeInTheDocument());
+    await waitFor(() => expect(trigger).toHaveFocus());
+
+    await user.click(trigger);
+    dialog = screen.getByRole("dialog", { name: "Practice Controls" });
+    act(() => {
+      window.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+    });
+    await waitFor(() => expect(dialog).not.toBeInTheDocument());
+    await waitFor(() => expect(trigger).toHaveFocus());
+
+    await user.click(trigger);
+    dialog = screen.getByRole("dialog", { name: "Practice Controls" });
+    closeButton = within(dialog).getByRole("button", { name: "Close Practice Controls" });
+    await user.click(closeButton);
+    await waitFor(() => expect(dialog).not.toBeInTheDocument());
+    await waitFor(() => expect(trigger).toHaveFocus());
+  });
+
+  it("flushes typed and mixed debounced tempo edits through every drawer dismissal path", async () => {
+    const user = userEvent.setup();
+    enableAndroidRuntime();
+    setTempoAnalysis();
+    renderApp(["/projects/proj_123"]);
+
+    await user.click(await screen.findByRole("tab", { name: "Playback" }));
+    const trigger = screen.getByRole("button", { name: "Open Practice Controls" });
+
+    await user.click(trigger);
+    let dialog = screen.getByRole("dialog", { name: "Practice Controls" });
+    let bpmInput = within(dialog).getByRole("spinbutton", { name: "Playback BPM" });
+    fireEvent.change(bpmInput, { target: { value: "96" } });
+    fireEvent.keyDown(bpmInput, { key: "Escape" });
+    await waitFor(() => expect(dialog).not.toBeInTheDocument());
+
+    await user.click(trigger);
+    dialog = screen.getByRole("dialog", { name: "Practice Controls" });
+    bpmInput = within(dialog).getByRole("spinbutton", { name: "Playback BPM" });
+    expect(bpmInput).toHaveValue(96);
+    fireEvent.change(bpmInput, { target: { value: "97" } });
+    const scrim = document.querySelector<HTMLElement>(".mobile-practice-controls__scrim");
+    expect(scrim).not.toBeNull();
+    fireEvent.click(scrim as HTMLElement);
+    await waitFor(() => expect(dialog).not.toBeInTheDocument());
+
+    await user.click(trigger);
+    dialog = screen.getByRole("dialog", { name: "Practice Controls" });
+    bpmInput = within(dialog).getByRole("spinbutton", { name: "Playback BPM" });
+    expect(bpmInput).toHaveValue(97);
+    fireEvent.change(bpmInput, { target: { value: "98" } });
+    await user.click(
+      within(dialog).getByRole("button", { name: "Close Practice Controls" }),
+    );
+    await waitFor(() => expect(dialog).not.toBeInTheDocument());
+
+    await user.click(trigger);
+    dialog = screen.getByRole("dialog", { name: "Practice Controls" });
+    bpmInput = within(dialog).getByRole("spinbutton", { name: "Playback BPM" });
+    expect(bpmInput).toHaveValue(98);
+    await user.click(
+      within(dialog).getByRole("button", { name: "Increase playback tempo" }),
+    );
+    expect(bpmInput).toHaveValue(99);
+    expect(within(dialog).getByText("98 BPM (0.817x)")).toBeInTheDocument();
+    fireEvent.change(bpmInput, { target: { value: "104" } });
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 300));
+    });
+    expect(bpmInput).toHaveValue(104);
+    expect(within(dialog).getByText("98 BPM (0.817x)")).toBeInTheDocument();
+    act(() => {
+      window.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+    });
+    await waitFor(() => expect(dialog).not.toBeInTheDocument());
+
+    await user.click(trigger);
+    dialog = screen.getByRole("dialog", { name: "Practice Controls" });
+    expect(within(dialog).getByRole("spinbutton", { name: "Playback BPM" })).toHaveValue(104);
+    expect(within(dialog).getByText("104 BPM (0.867x)")).toBeInTheDocument();
+  });
+
+  it("preserves playback and lane preferences while opening mobile chrome", async () => {
+    const user = userEvent.setup();
+    enableAndroidRuntime();
+    renderApp(["/projects/proj_123"]);
+
+    await user.click(await screen.findByRole("tab", { name: "Playback" }));
+    await user.click(screen.getByRole("button", { name: "Chords" }));
+    const follow = screen.getByRole("button", { name: "Follow chords" });
+    await user.click(follow);
+    expect(follow).toHaveAttribute("aria-pressed", "false");
+
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    const pauseButton = await screen.findByRole("button", { name: "Pause playback" });
+    const playbackPosition = sourceAudio.currentTime;
+
+    const trigger = screen.getByRole("button", { name: "Open Practice Controls" });
+    await user.click(trigger);
+    const dialog = screen.getByRole("dialog", { name: "Practice Controls" });
+    expect(within(dialog).getByRole("group", { name: "Playback source and mix list" })).toBeInTheDocument();
+    expect(sourceAudio.currentTime).toBeCloseTo(playbackPosition, 3);
+    expect(pauseButton).toHaveAttribute("aria-label", "Pause playback");
+
+    await user.click(within(dialog).getByRole("button", { name: "Close Practice Controls" }));
+    await waitFor(() => expect(dialog).not.toBeInTheDocument());
     expect(screen.getByRole("button", { name: "Chords" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Follow chords" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+    expect(sourceAudio.currentTime).toBeCloseTo(playbackPosition, 3);
   });
 
   it("keeps mobile Practice controls reachable while switching every display mode", async () => {
@@ -195,35 +451,107 @@ describe("Desktop app mobile capability gates", () => {
     expect(surface).not.toBeNull();
     const header = (surface as HTMLElement).querySelector(".playback-practice-surface__header");
     expect(header).not.toBeNull();
+    const heading = (header as HTMLElement).querySelector(
+      ".playback-practice-surface__heading",
+    );
+    const controls = (header as HTMLElement).querySelector(
+      ".playback-practice-surface__controls",
+    );
+    expect(heading).not.toBeNull();
+    expect(controls).not.toBeNull();
     const modeToggle = within(header as HTMLElement).getByRole("group", {
       name: "Playback display mode",
     });
     const lyricsToggle = within(modeToggle).getByRole("button", { name: "Lyrics" });
     const chordsToggle = within(modeToggle).getByRole("button", { name: "Chords" });
-    expect(within(header as HTMLElement).getByRole("button", { name: "Lyrics Follow" })).toBeEnabled();
+    const bothToggle = within(modeToggle).getByRole("button", { name: "Both" });
+    const combinedFollow = within(header as HTMLElement).getByRole("button", {
+      name: "Follow lyrics and chords",
+    });
+    expect(combinedFollow).toBeEnabled();
+    expect(combinedFollow).toHaveTextContent(/^Follow$/);
+    expect(combinedFollow).toHaveAttribute("title", "Follow lyrics and chords");
+    expect(heading).toContainElement(combinedFollow);
+    expect(controls).toContainElement(modeToggle);
+    expect(controls).not.toContainElement(combinedFollow);
+    expect((header as HTMLElement).querySelector(".playback-practice-actions")).toBeNull();
+    expect(
+      combinedFollow.compareDocumentPosition(modeToggle) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     const combinedLeadSheet = within(surface as HTMLElement).getByRole("group", {
       name: "Lyrics and chords lead sheet",
     });
     expect(header).not.toContainElement(combinedLeadSheet);
 
-    await user.click(lyricsToggle);
+    await user.click(chordsToggle);
     expect(await within(surface as HTMLElement).findByRole("heading", { name: "Chords" })).toBeInTheDocument();
     expect(lyricsToggle).toHaveAttribute("aria-pressed", "false");
     expect(chordsToggle).toHaveAttribute("aria-pressed", "true");
+    expect(bothToggle).toHaveAttribute("aria-pressed", "false");
     expect(within(surface as HTMLElement).getByRole("group", { name: "Chord timeline" })).toBeInTheDocument();
-    expect(within(header as HTMLElement).getByRole("button", { name: "Chords Follow" })).toBeEnabled();
+    const chordsFollow = within(header as HTMLElement).getByRole("button", { name: "Follow chords" });
+    expect(chordsFollow).toBeEnabled();
+    await user.click(chordsFollow);
+    expect(chordsFollow).toHaveAttribute("aria-pressed", "false");
+
+    await user.click(bothToggle);
+    expect(await within(surface as HTMLElement).findByRole("heading", { name: "Lyrics + chords" })).toBeInTheDocument();
+    expect(lyricsToggle).toHaveAttribute("aria-pressed", "false");
+    expect(chordsToggle).toHaveAttribute("aria-pressed", "false");
+    expect(bothToggle).toHaveAttribute("aria-pressed", "true");
+    expect(
+      within(header as HTMLElement).getByRole("button", { name: "Follow lyrics and chords" }),
+    ).toHaveAttribute("aria-pressed", "true");
 
     await user.click(lyricsToggle);
-    expect(await within(surface as HTMLElement).findByRole("heading", { name: "Lyrics + chords" })).toBeInTheDocument();
-    expect(lyricsToggle).toHaveAttribute("aria-pressed", "true");
-    expect(chordsToggle).toHaveAttribute("aria-pressed", "true");
-
-    await user.click(chordsToggle);
     expect(await within(surface as HTMLElement).findByRole("heading", { name: "Lyrics" })).toBeInTheDocument();
     expect(lyricsToggle).toHaveAttribute("aria-pressed", "true");
     expect(chordsToggle).toHaveAttribute("aria-pressed", "false");
+    expect(bothToggle).toHaveAttribute("aria-pressed", "false");
     expect(within(surface as HTMLElement).getByRole("group", { name: "Lyrics transcript" })).toBeInTheDocument();
-    expect(within(header as HTMLElement).getByRole("button", { name: "Lyrics Follow" })).toBeEnabled();
+    expect(within(header as HTMLElement).getByRole("button", { name: "Follow lyrics" })).toBeEnabled();
+
+    await user.click(chordsToggle);
+    expect(within(header as HTMLElement).getByRole("button", { name: "Follow chords" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("disables Chords Follow truthfully when the timeline is unavailable", async () => {
+    const user = userEvent.setup();
+    enableAndroidRuntime();
+    setEmptyChords();
+    const { queryClient } = renderApp(["/projects/proj_123"]);
+
+    await user.click(await screen.findByRole("tab", { name: "Playback" }));
+    await user.click(screen.getByRole("button", { name: "Chords" }));
+
+    const follow = screen.getByRole("button", { name: "Follow chords" });
+    expect(follow).toBeDisabled();
+    expect(follow).toHaveAttribute("aria-pressed", "false");
+    expect(follow).toHaveAttribute("title", "Follow requires a chord timeline.");
+    expect(follow).toHaveAttribute(
+      "aria-describedby",
+      "playback-follow-unavailable-description",
+    );
+    const unavailableExplanation = screen.getByText("Follow requires a chord timeline.");
+    expect(unavailableExplanation).toBeInTheDocument();
+    expect(follow.closest(".playback-practice-surface__heading")).toContainElement(
+      unavailableExplanation,
+    );
+    const storedState = JSON.parse(
+      window.localStorage.getItem("tuneforge.project-playback-state") ?? "{}",
+    ) as { proj_123?: { chordsFollowEnabled?: boolean } };
+    expect(storedState.proj_123?.chordsFollowEnabled).toBe(true);
+
+    setAvailableChords();
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: ["chords", "proj_123"] });
+    });
+    await waitFor(() => expect(follow).toBeEnabled());
+    expect(follow).toHaveAttribute("aria-pressed", "true");
+    expect(screen.queryByText("Follow requires a chord timeline.")).not.toBeInTheDocument();
   });
 
   it("keeps loading distinct from confirmed absence before resolving auto mode", async () => {
@@ -296,10 +624,6 @@ describe("Desktop app mobile capability gates", () => {
       expect(storedState.proj_123?.playbackDisplayMode).toBe("lyrics");
     });
 
-    await user.click(screen.getByRole("button", { name: "Lyrics" }));
-    expect(screen.getByRole("button", { name: "Lyrics" })).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByRole("button", { name: "Chords" })).toHaveAttribute("aria-pressed", "true");
-
     setProjectLyrics("proj_123", {
       ...emptyLyrics(),
       backend: "synced",
@@ -319,11 +643,13 @@ describe("Desktop app mobile capability gates", () => {
     await waitFor(() =>
       expect(screen.queryByText("No lyrics on this device; showing chords.")).not.toBeInTheDocument(),
     );
-    expect(screen.getByRole("heading", { name: "Lyrics + chords" })).toBeInTheDocument();
     const recoveredStoredState = JSON.parse(
       window.localStorage.getItem("tuneforge.project-playback-state") ?? "{}",
     ) as { proj_123?: { playbackDisplayMode?: string } };
-    expect(recoveredStoredState.proj_123?.playbackDisplayMode).toBe("combined");
+    expect(recoveredStoredState.proj_123?.playbackDisplayMode).toBe("lyrics");
+
+    await user.click(screen.getByRole("button", { name: "Lyrics" }));
+    expect(screen.getByRole("heading", { name: "Lyrics" })).toBeInTheDocument();
   });
 
   it("keeps untimed synced lyrics static without activating Lyrics Follow", async () => {
@@ -349,8 +675,8 @@ describe("Desktop app mobile capability gates", () => {
     expect(await screen.findByRole("heading", { name: "Lyrics" })).toBeInTheDocument();
     expect(screen.getByText("Static synced lyric")).toBeInTheDocument();
     expect(screen.getByText("Static")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Lyrics Follow" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Lyrics Follow" })).toHaveAttribute(
+    expect(screen.getByRole("button", { name: "Follow lyrics" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Follow lyrics" })).toHaveAttribute(
       "aria-pressed",
       "false",
     );
@@ -440,7 +766,7 @@ describe("Desktop app mobile capability gates", () => {
     );
     fireEvent.timeUpdate(sourceAudio);
 
-    expect(screen.getByRole("button", { name: "Lyrics Follow" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Follow lyrics and chords" })).toBeDisabled();
     expect(scrollTo).not.toHaveBeenCalled();
   });
 
@@ -452,13 +778,45 @@ describe("Desktop app mobile capability gates", () => {
     await user.click(await screen.findByRole("tab", { name: "Playback" }));
     const sourceAudio = findAudioByArtifactId("art_source");
     markAudioReady(sourceAudio);
-    await user.click(screen.getByRole("button", { name: "Chords" }));
+
+    const combinedLeadSheet = screen.getByRole("group", {
+      name: "Lyrics and chords lead sheet",
+    });
+    const combinedBody = combinedLeadSheet.closest<HTMLElement>(".playback-practice-body");
+    expect(combinedBody).not.toBeNull();
+    const combinedScrollTo = vi.fn();
+    const combinedContentScrollTo = vi.fn();
+    Object.defineProperties(combinedBody as HTMLElement, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, value: 500 },
+      scrollTo: { configurable: true, value: combinedScrollTo },
+    });
+    Object.defineProperty(combinedLeadSheet, "scrollTo", {
+      configurable: true,
+      value: combinedContentScrollTo,
+    });
+    const secondCombinedLyric = within(combinedLeadSheet).getByRole("button", { name: /0:08/i });
+    await user.click(secondCombinedLyric);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(secondCombinedLyric.className).toContain("lead-sheet__row--active"));
+    await waitFor(() => expect(combinedScrollTo).toHaveBeenCalled());
+    expect(combinedContentScrollTo).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: "Pause playback" }));
+
+    await user.click(screen.getByRole("button", { name: "Lyrics" }));
     const leadSheet = screen.getByRole("group", { name: "Lyrics transcript" });
+    const lyricsBody = leadSheet.closest<HTMLElement>(".playback-practice-body");
+    expect(lyricsBody).not.toBeNull();
     const scrollTo = vi.fn();
-    Object.defineProperties(leadSheet, {
+    const contentScrollTo = vi.fn();
+    Object.defineProperties(lyricsBody as HTMLElement, {
       clientHeight: { configurable: true, value: 100 },
       scrollHeight: { configurable: true, value: 500 },
       scrollTo: { configurable: true, value: scrollTo },
+    });
+    Object.defineProperty(leadSheet, "scrollTo", {
+      configurable: true,
+      value: contentScrollTo,
     });
     const secondLyric = within(leadSheet).getByRole("button", { name: /0:08/i });
 
@@ -470,6 +828,7 @@ describe("Desktop app mobile capability gates", () => {
     );
     await waitFor(() => expect(secondLyric.className).toContain("lead-sheet__row--active"));
     await waitFor(() => expect(scrollTo).toHaveBeenCalled());
+    expect(contentScrollTo).not.toHaveBeenCalled();
 
     await user.click(screen.getByRole("button", { name: "Pause playback" }));
     expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
@@ -479,5 +838,53 @@ describe("Desktop app mobile capability gates", () => {
     await user.click(screen.getByRole("button", { name: "Play playback" }));
     expect(await screen.findByRole("button", { name: "Pause playback" })).toBeInTheDocument();
     expect(sourceAudio.currentTime).toBeCloseTo(pausedTime, 1);
+
+    await user.click(screen.getByRole("button", { name: "Pause playback" }));
+    await user.click(screen.getByRole("button", { name: "Chords" }));
+    const chordTimeline = screen.getByRole("group", { name: "Chord timeline" });
+    const chordScrollTo = vi.fn();
+    Object.defineProperties(chordTimeline, {
+      clientWidth: { configurable: true, value: 100 },
+      scrollWidth: { configurable: true, value: 500 },
+      scrollTo: { configurable: true, value: chordScrollTo },
+    });
+    const secondChord = within(chordTimeline).getByRole("button", { name: /0:16/i });
+    await user.click(secondChord);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(secondChord).toHaveAttribute("aria-pressed", "true"));
+    await waitFor(() => expect(chordScrollTo).toHaveBeenCalled());
+  });
+
+  it("keeps mobile fallback status beside an interactive scrubber and clocks", async () => {
+    enableAndroidRuntime();
+    renderApp(["/projects/proj_123"]);
+
+    fireEvent.click(await screen.findByRole("tab", { name: "Playback" }));
+    act(() => {
+      markPlaybackStarting("web-fallback");
+      updateBrowserWakeLockStatus({
+        phase: "failed",
+        backend: "browser-screen-wake-lock",
+        screenProtected: false,
+        errorMessage: "Screen wake lock is unavailable.",
+      });
+    });
+
+    const status = await screen.findByText(
+      "Native playback unavailable. Starting Web Audio fallback…",
+    );
+    const scrubber = screen.getByRole("slider", { name: "Playback position" });
+    const statusStack = status.closest<HTMLElement>(".transport__status-stack");
+    const scrubberLabel = scrubber.closest("label");
+    expect(statusStack).not.toBeNull();
+    expect(within(statusStack as HTMLElement).getByText("Screen wake lock is unavailable.")).toBeInTheDocument();
+    expect(within(statusStack as HTMLElement).getAllByRole("status")).toHaveLength(2);
+    expect(scrubberLabel).not.toBeNull();
+    expect(scrubberLabel).not.toContainElement(status);
+    expect(within(scrubberLabel as HTMLElement).getByText("0:00")).toBeInTheDocument();
+    expect(within(scrubberLabel as HTMLElement).getByText("3:02")).toBeInTheDocument();
+
+    fireEvent.change(scrubber, { target: { value: "10" } });
+    await waitFor(() => expect(scrubber).toHaveValue("10"));
   });
 });

--- a/apps/desktop/src/App.responsive-ui.test.tsx
+++ b/apps/desktop/src/App.responsive-ui.test.tsx
@@ -4,9 +4,26 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   findAudioByArtifactId,
   markAudioReady,
+  mockGetMobileCapabilities,
   renderApp,
   resetAppTestHarness,
 } from "./test/appTestHarness";
+
+function enableAndroidRuntime() {
+  mockGetMobileCapabilities.mockResolvedValue({
+    platform: "android",
+    mediaBackend: "android_media_codec",
+    isEmulator: true,
+    gpuBackend: null,
+    analysisAvailable: true,
+    basicChordsAvailable: true,
+    whisperAvailable: false,
+    stemSeparationAvailable: false,
+    generationTestingAvailable: true,
+    maxRecommendedModel: null,
+    cpuFallbackAllowed: false,
+  });
+}
 
 describe("Desktop app responsive UI revamp", () => {
   beforeEach(resetAppTestHarness);
@@ -87,6 +104,63 @@ describe("Desktop app responsive UI revamp", () => {
     expect(workspace).toContainElement(transportDock as HTMLElement);
     expect((transportDock as HTMLElement).parentElement).toBe(workspace);
     expect(within(transportDock as HTMLElement).getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+    expect(transportDock?.querySelector(".transport")).not.toHaveClass("transport--mobile");
+    expect(
+      within(transportDock as HTMLElement).getByRole("button", { name: "Tempo at original" }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps desktop Follow controls in the existing action row", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    await user.click(await screen.findByRole("tab", { name: "Playback" }));
+
+    const header = document.querySelector<HTMLElement>(".playback-practice-surface__header");
+    const heading = header?.querySelector<HTMLElement>(".playback-practice-surface__heading");
+    const actions = header?.querySelector<HTMLElement>(".playback-practice-actions");
+    const lyricsFollow = within(header as HTMLElement).getByRole("button", {
+      name: "Lyrics Follow",
+    });
+
+    expect(header).not.toBeNull();
+    expect(heading).not.toBeNull();
+    expect(actions).not.toBeNull();
+    expect(heading).not.toContainElement(lyricsFollow);
+    expect(actions).toContainElement(lyricsFollow);
+  });
+
+  it("uses a two-part mobile transport without duplicating Practice Controls tempo", async () => {
+    const user = userEvent.setup();
+    enableAndroidRuntime();
+    renderApp(["/projects/proj_123"]);
+
+    await user.click(await screen.findByRole("tab", { name: "Playback" }));
+
+    const transportDock = document.querySelector<HTMLElement>(".playback-transport-dock");
+    const transport = transportDock?.querySelector<HTMLElement>(".transport--mobile");
+    expect(transportDock).not.toBeNull();
+    expect(transport).not.toBeNull();
+    expect(transport?.querySelector(":scope > .transport__controls")).not.toBeNull();
+    expect(transport?.querySelector(":scope > .transport__timeline")).not.toBeNull();
+    expect(within(transportDock as HTMLElement).queryByText("Tempo")).not.toBeInTheDocument();
+    expect(
+      within(transportDock as HTMLElement).queryByRole("button", { name: /tempo/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(transportDock as HTMLElement).getByRole("slider", { name: "Playback position" }),
+    ).toBeInTheDocument();
+    expect(
+      within(transportDock as HTMLElement).getAllByRole("button").map((button) =>
+        button.getAttribute("aria-label"),
+      ),
+    ).toEqual([
+      "Seek back 10 seconds",
+      "Play playback",
+      "Stop playback",
+      "Seek forward 10 seconds",
+      "Set loop start",
+    ]);
   });
 
   it("collapses practice chrome while playback is active and restores it on pause", async () => {

--- a/apps/desktop/src/features/projects/components/PlaybackPracticeControlsDrawer.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackPracticeControlsDrawer.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+import {
+  PlaybackPracticeRail,
+  type PlaybackPracticeRailHandle,
+} from "./PlaybackPracticeRail";
+
+const HISTORY_KEY = "tuneforgePracticeControls";
+const FOCUSABLE_SELECTOR = [
+  "button:not([disabled])",
+  "[href]",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+export function PlaybackPracticeControlsDrawer({
+  onDismiss,
+  open,
+}: {
+  onDismiss: () => void;
+  open: boolean;
+}) {
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const dialogRef = useRef<HTMLElement>(null);
+  const practiceRailRef = useRef<PlaybackPracticeRailHandle>(null);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
+  const historyMarkerRef = useRef(`practice-controls-${crypto.randomUUID()}`);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    restoreFocusRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+    const marker = historyMarkerRef.current;
+    window.history.pushState(
+      { ...window.history.state, [HISTORY_KEY]: marker },
+      "",
+      window.location.href,
+    );
+    closeButtonRef.current?.focus();
+
+    const dismissFromUi = () => {
+      practiceRailRef.current?.flushPendingTempo();
+      onDismiss();
+      if (window.history.state?.[HISTORY_KEY] === marker) {
+        window.history.back();
+      }
+    };
+    const handlePopState = () => {
+      practiceRailRef.current?.flushPendingTempo();
+      onDismiss();
+    };
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        dismissFromUi();
+        return;
+      }
+      if (event.key !== "Tab") {
+        return;
+      }
+      const dialog = dialogRef.current;
+      if (!dialog) {
+        return;
+      }
+      const focusable = Array.from(dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+      if (!focusable.length) {
+        event.preventDefault();
+        dialog.focus();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      } else if (!dialog.contains(document.activeElement)) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    window.addEventListener("popstate", handlePopState);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+      document.removeEventListener("keydown", handleKeyDown);
+      const restoreTarget = restoreFocusRef.current;
+      window.setTimeout(() => restoreTarget?.focus(), 0);
+    };
+  }, [onDismiss, open]);
+
+  if (!open) {
+    return null;
+  }
+
+  const marker = historyMarkerRef.current;
+  const dismissFromUi = () => {
+    practiceRailRef.current?.flushPendingTempo();
+    onDismiss();
+    if (window.history.state?.[HISTORY_KEY] === marker) {
+      window.history.back();
+    }
+  };
+
+  return createPortal(
+    <div className="mobile-practice-controls-layer" data-mobile-practice-controls="open">
+      <div
+        aria-hidden="true"
+        className="mobile-practice-controls__scrim"
+        onClick={dismissFromUi}
+      />
+      <section
+        aria-labelledby="mobile-practice-controls-title"
+        aria-modal="true"
+        className="mobile-practice-controls"
+        ref={dialogRef}
+        role="dialog"
+        tabIndex={-1}
+      >
+        <div className="mobile-practice-controls__header">
+          <div>
+            <p className="metric-label">Playback</p>
+            <h2 id="mobile-practice-controls-title">Practice Controls</h2>
+          </div>
+          <button
+            aria-label="Close Practice Controls"
+            className="button button--ghost button--small mobile-practice-controls__close"
+            onClick={dismissFromUi}
+            ref={closeButtonRef}
+            type="button"
+          >
+            <X aria-hidden="true" />
+          </button>
+        </div>
+        <PlaybackPracticeRail ref={practiceRailRef} variant="drawer" />
+      </section>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
@@ -1,4 +1,11 @@
-import { type KeyboardEvent, useEffect, useRef, useState } from "react";
+import {
+  forwardRef,
+  type KeyboardEvent,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
 import {
   ArrowUpDown,
   AudioLines,
@@ -18,7 +25,14 @@ import {
 import { TargetKeySelector } from "./TargetKeySelector";
 import { useProjectViewModelContext } from "./useProjectViewModelContext";
 
-export function PlaybackPracticeRail() {
+export type PlaybackPracticeRailHandle = {
+  flushPendingTempo: () => void;
+};
+
+export const PlaybackPracticeRail = forwardRef<
+  PlaybackPracticeRailHandle,
+  { variant?: "desktop" | "drawer" }
+>(function PlaybackPracticeRail({ variant = "desktop" }, ref) {
   const {
     capoKey,
     capoOptionRefs,
@@ -101,6 +115,8 @@ export function PlaybackPracticeRail() {
         : tempoDisplayBpm.toFixed(1),
   );
   const tempoCommitTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const tempoDraftDirty = useRef(false);
+  const flushTempoDraftRef = useRef<() => void>(() => undefined);
   const skipNextTempoBlurCommit = useRef(false);
 
   const clampTempoBpm = (value: number) =>
@@ -110,16 +126,14 @@ export function PlaybackPracticeRail() {
     value === null ? "" : Number.isInteger(value) ? value.toFixed(0) : value.toFixed(1);
 
   useEffect(() => {
+    tempoDraftDirty.current = false;
     setTempoDraftText(
       tempoDisplayBpm === null ? "" : formatTempoDraftText(tempoDisplayBpm),
     );
   }, [tempoDisplayBpm]);
 
   useEffect(() => () => {
-    if (tempoCommitTimer.current !== null) {
-      clearTimeout(tempoCommitTimer.current);
-      tempoCommitTimer.current = null;
-    }
+    flushTempoDraftRef.current();
   }, []);
 
   const clearTempoCommitTimer = () => {
@@ -133,35 +147,49 @@ export function PlaybackPracticeRail() {
     setTempoDraftText(tempoDisplayBpm === null ? "" : formatTempoDraftText(tempoDisplayBpm));
   };
 
-  const commitTempoFromInput = () => {
+  const commitTempoFromInput = (updateDraft = true) => {
+    if (!tempoDraftDirty.current) {
+      return;
+    }
     const trimmedDraft = tempoDraftText.trim();
     const parsed = Number(trimmedDraft);
     if (!Number.isFinite(parsed) || trimmedDraft === "") {
-      restoreTempoDraft();
+      clearTempoCommitTimer();
+      tempoDraftDirty.current = false;
+      if (updateDraft) {
+        restoreTempoDraft();
+      }
       return;
     }
     clearTempoCommitTimer();
     const target = clampTempoBpm(parsed);
-    setTempoDraftText(formatTempoDraftText(target));
+    tempoDraftDirty.current = false;
+    if (updateDraft) {
+      setTempoDraftText(formatTempoDraftText(target));
+    }
     handleSetPlaybackTempo(target);
   };
 
   const scheduleTempoCommit = (value: number) => {
     const target = clampTempoBpm(value);
+    tempoDraftDirty.current = true;
     setTempoDraftText(formatTempoDraftText(target));
     clearTempoCommitTimer();
     tempoCommitTimer.current = setTimeout(() => {
       tempoCommitTimer.current = null;
+      tempoDraftDirty.current = false;
       handleSetPlaybackTempo(target);
     }, 250);
   };
 
-  const flushPendingTempoCommit = () => {
-    if (tempoCommitTimer.current === null) {
-      return;
-    }
-    commitTempoFromInput();
+  const flushTempoDraft = (updateDraft = true) => {
+    commitTempoFromInput(updateDraft);
   };
+
+  flushTempoDraftRef.current = () => flushTempoDraft(false);
+  useImperativeHandle(ref, () => ({
+    flushPendingTempo: flushTempoDraft,
+  }));
 
   const handleTempoInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === "Enter") {
@@ -170,8 +198,12 @@ export function PlaybackPracticeRail() {
       event.currentTarget.blur();
     }
     if (event.key === "Escape") {
+      if (variant === "drawer") {
+        return;
+      }
       event.preventDefault();
       clearTempoCommitTimer();
+      tempoDraftDirty.current = false;
       restoreTempoDraft();
       skipNextTempoBlurCommit.current = true;
       event.currentTarget.blur();
@@ -188,17 +220,19 @@ export function PlaybackPracticeRail() {
 
   const handleTempoReset = () => {
     clearTempoCommitTimer();
+    tempoDraftDirty.current = false;
     handleResetPlaybackTempo();
     setTempoDraftText(formatTempoDraftText(tempoOriginalBpm ?? tempoDisplayBpm ?? null));
   };
 
   return (
     <aside
-      className="panel playback-practice-rail"
+      className={`panel playback-practice-rail playback-practice-rail--${variant}`}
+      data-practice-controls-variant={variant}
       onBlur={(event) => {
         const nextTarget = event.relatedTarget;
         if (!(nextTarget instanceof Node) || !event.currentTarget.contains(nextTarget)) {
-          flushPendingTempoCommit();
+          flushTempoDraft();
         }
       }}
     >
@@ -390,7 +424,11 @@ export function PlaybackPracticeRail() {
                 }
                 commitTempoFromInput();
               }}
-              onChange={(event) => setTempoDraftText(event.target.value)}
+              onChange={(event) => {
+                clearTempoCommitTimer();
+                tempoDraftDirty.current = true;
+                setTempoDraftText(event.target.value);
+              }}
               onKeyDown={handleTempoInputKeyDown}
               step={1}
               type="number"
@@ -520,4 +558,4 @@ export function PlaybackPracticeRail() {
       </div>
     </aside>
   );
-}
+});

--- a/apps/desktop/src/features/projects/components/PlaybackPracticeSurface.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackPracticeSurface.tsx
@@ -54,11 +54,14 @@ function PlaybackModeHeader() {
     handleRejectTabSuggestionGroup,
     handleSetChordsFollowEnabled,
     handleSetLyricsFollowEnabled,
+    handleSetPlaybackDisplayMode,
     handleTogglePlaybackDisplayLane,
+    hasChordTimeline,
     hasLyricsTranscript,
     hasTimedLyricsTranscript,
     isEditingLyrics,
     isLyricsRunning,
+    isMobileRuntime,
     isTabImportOpen,
     lyricsFollowEnabled,
     lyricsMutation,
@@ -74,101 +77,179 @@ function PlaybackModeHeader() {
     tabImportDraft,
     tabImportMutation,
   } = useProjectViewModelContext();
-  const lyricsSelected = playbackDisplayMode === "lyrics" || playbackDisplayMode === "combined";
-  const chordsSelected = playbackDisplayMode === "chords" || playbackDisplayMode === "combined";
+  const lyricsSelected = playbackDisplayMode !== "chords";
+  const chordsSelected = playbackDisplayMode !== "lyrics";
+  const followUsesTimedLyrics = playbackDisplayMode !== "chords";
+  const followAvailable = followUsesTimedLyrics
+    ? hasTimedLyricsTranscript
+    : hasChordTimeline;
+  const followEnabled = followAvailable && (
+    followUsesTimedLyrics ? lyricsFollowEnabled : chordsFollowEnabled
+  );
+  const followUnavailableDescription = followUsesTimedLyrics
+    ? "Follow requires timed lyrics."
+    : "Follow requires a chord timeline.";
+  const followLabel = playbackDisplayMode === "combined"
+    ? "Follow lyrics and chords"
+    : playbackDisplayMode === "lyrics"
+      ? "Follow lyrics"
+      : "Follow chords";
 
   return (
     <>
       <div className="playback-practice-surface__header">
-        <div>
-          <p className="metric-label">Practice View</p>
-          <h2>
-            {playbackDisplayMode === "combined"
-              ? "Lyrics + chords"
-              : playbackDisplayMode === "lyrics"
-                ? "Lyrics"
-                : "Chords"}
-          </h2>
+        <div className="playback-practice-surface__heading">
+          <div>
+            <p className="metric-label">Practice View</p>
+            <h2>
+              {playbackDisplayMode === "combined"
+                ? "Lyrics + chords"
+                : playbackDisplayMode === "lyrics"
+                  ? "Lyrics"
+                  : "Chords"}
+            </h2>
+          </div>
+          {isMobileRuntime ? (
+            <button
+              aria-describedby={
+                !followAvailable ? "playback-follow-unavailable-description" : undefined
+              }
+              aria-label={followLabel}
+              aria-pressed={followEnabled}
+              className={`chip playback-follow-chip${followEnabled ? " chip--active" : ""}`}
+              disabled={!followAvailable}
+              onClick={() => {
+                if (followUsesTimedLyrics) {
+                  handleSetLyricsFollowEnabled(!lyricsFollowEnabled);
+                } else {
+                  handleSetChordsFollowEnabled(!chordsFollowEnabled);
+                }
+              }}
+              title={!followAvailable ? followUnavailableDescription : followLabel}
+              type="button"
+            >
+              Follow
+            </button>
+          ) : null}
+          {isMobileRuntime && !followAvailable ? (
+            <span
+              className="artifact-meta playback-follow-explanation"
+              id="playback-follow-unavailable-description"
+            >
+              {followUnavailableDescription}
+            </span>
+          ) : null}
         </div>
 
         <div className="playback-practice-surface__controls">
           <div className="playback-mode-toggle" role="group" aria-label="Playback display mode">
-            <button
-              aria-pressed={lyricsSelected}
-              className={lyricsSelected ? "playback-mode-toggle__button playback-mode-toggle__button--active" : "playback-mode-toggle__button"}
-              onClick={() => handleTogglePlaybackDisplayLane("lyrics")}
-              type="button"
-            >
-              Lyrics
-            </button>
-            <button
-              aria-pressed={chordsSelected}
-              className={chordsSelected ? "playback-mode-toggle__button playback-mode-toggle__button--active" : "playback-mode-toggle__button"}
-              onClick={() => handleTogglePlaybackDisplayLane("chords")}
-              type="button"
-            >
-              Chords
-            </button>
+            {isMobileRuntime ? (
+              (["lyrics", "chords", "combined"] as const).map((mode) => {
+                const selected = playbackDisplayMode === mode;
+                return (
+                  <button
+                    aria-pressed={selected}
+                    className={
+                      selected
+                        ? "playback-mode-toggle__button playback-mode-toggle__button--active"
+                        : "playback-mode-toggle__button"
+                    }
+                    key={mode}
+                    onClick={() => handleSetPlaybackDisplayMode(mode)}
+                    type="button"
+                  >
+                    {mode === "combined" ? "Both" : mode === "lyrics" ? "Lyrics" : "Chords"}
+                  </button>
+                );
+              })
+            ) : (
+              <>
+                <button
+                  aria-pressed={lyricsSelected}
+                  className={
+                    lyricsSelected
+                      ? "playback-mode-toggle__button playback-mode-toggle__button--active"
+                      : "playback-mode-toggle__button"
+                  }
+                  onClick={() => handleTogglePlaybackDisplayLane("lyrics")}
+                  type="button"
+                >
+                  Lyrics
+                </button>
+                <button
+                  aria-pressed={chordsSelected}
+                  className={
+                    chordsSelected
+                      ? "playback-mode-toggle__button playback-mode-toggle__button--active"
+                      : "playback-mode-toggle__button"
+                  }
+                  onClick={() => handleTogglePlaybackDisplayLane("chords")}
+                  type="button"
+                >
+                  Chords
+                </button>
+              </>
+            )}
           </div>
 
-          <div className="button-row playback-practice-actions">
-            {lyricsSelected && hasLyricsTranscript && !isEditingLyrics ? (
+          {!isMobileRuntime ? (
+            <div className="button-row playback-practice-actions">
+              {lyricsSelected && hasLyricsTranscript && !isEditingLyrics ? (
+                <button
+                  className="button button--ghost button--small"
+                  type="button"
+                  onClick={() => {
+                    if (projectEditLocked) {
+                      return;
+                    }
+                    setLyricsDraft(displayedLyrics.map((segment) => segment.text));
+                    setIsEditingLyrics(true);
+                  }}
+                  disabled={projectEditLocked || lyricsMutation.isPending || isLyricsRunning}
+                  title={projectSyncLockReason ?? undefined}
+                >
+                  Edit Lyrics
+                </button>
+              ) : null}
               <button
                 className="button button--ghost button--small"
                 type="button"
-                onClick={() => {
-                  if (projectEditLocked) {
-                    return;
-                  }
-                  setLyricsDraft(displayedLyrics.map((segment) => segment.text));
-                  setIsEditingLyrics(true);
-                }}
-                disabled={projectEditLocked || lyricsMutation.isPending || isLyricsRunning}
+                onClick={handleOpenTabImport}
+                disabled={projectEditLocked}
                 title={projectSyncLockReason ?? undefined}
               >
-                Edit Lyrics
+                Import Tab
               </button>
-            ) : null}
-            <button
-              className="button button--ghost button--small"
-              type="button"
-              onClick={handleOpenTabImport}
-              disabled={projectEditLocked}
-              title={projectSyncLockReason ?? undefined}
-            >
-              Import Tab
-            </button>
-            {lyricsSelected ? (
-              <>
+              {lyricsSelected ? (
                 <button
                   aria-pressed={hasTimedLyricsTranscript && lyricsFollowEnabled}
-                  className={`chip playback-follow-chip${hasTimedLyricsTranscript && lyricsFollowEnabled ? " chip--active" : ""}`}
+                  className={`chip playback-follow-chip${
+                    hasTimedLyricsTranscript && lyricsFollowEnabled ? " chip--active" : ""
+                  }`}
                   disabled={!hasTimedLyricsTranscript}
                   onClick={() => handleSetLyricsFollowEnabled(!lyricsFollowEnabled)}
                   title={
-                    hasTimedLyricsTranscript ? undefined : "Lyrics Follow requires timed lyrics."
+                    hasTimedLyricsTranscript
+                      ? undefined
+                      : "Lyrics Follow requires timed lyrics."
                   }
                   type="button"
                 >
                   Lyrics Follow
                 </button>
-              </>
-            ) : null}
-            {chordsSelected ? (
-              <>
-                {playbackDisplayMode === "chords" ? (
-                  <button
-                    aria-pressed={chordsFollowEnabled}
-                    className={`chip playback-follow-chip${chordsFollowEnabled ? " chip--active" : ""}`}
-                    onClick={() => handleSetChordsFollowEnabled(!chordsFollowEnabled)}
-                    type="button"
-                  >
-                    Chords Follow
-                  </button>
-                ) : null}
-              </>
-            ) : null}
-          </div>
+              ) : null}
+              {playbackDisplayMode === "chords" ? (
+                <button
+                  aria-pressed={chordsFollowEnabled}
+                  className={`chip playback-follow-chip${chordsFollowEnabled ? " chip--active" : ""}`}
+                  onClick={() => handleSetChordsFollowEnabled(!chordsFollowEnabled)}
+                  type="button"
+                >
+                  Chords Follow
+                </button>
+              ) : null}
+            </div>
+          ) : null}
         </div>
       </div>
       {isTabImportOpen ? (

--- a/apps/desktop/src/features/projects/components/PlaybackTransport.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackTransport.tsx
@@ -16,6 +16,7 @@ import type { PlaybackLoopRange } from "../projectPlaybackState";
 
 export function PlaybackTransport({
   compact = false,
+  mobile = false,
   isPlaying,
   loopRange,
   loopStatusMessage,
@@ -33,6 +34,7 @@ export function PlaybackTransport({
   onTogglePlayback,
 }: {
   compact?: boolean;
+  mobile?: boolean;
   isPlaying: boolean;
   loopRange: PlaybackLoopRange | null;
   loopStatusMessage: "Loop in" | "Loop set" | "Loop cleared" | null;
@@ -79,7 +81,11 @@ export function PlaybackTransport({
   const loopIconStroke = `url(#${loopGradientId})`;
 
   return (
-    <div className={`transport${compact ? " transport--compact" : ""}`}>
+    <div
+      className={`transport${compact ? " transport--compact" : ""}${
+        mobile ? " transport--mobile" : ""
+      }`}
+    >
       <div className="transport__controls">
         <button
           aria-label="Seek back 10 seconds"
@@ -147,50 +153,58 @@ export function PlaybackTransport({
         ) : null}
       </div>
 
-      <button
-        aria-label={tempoTargetBpm === null ? "Tempo at original" : "Reset tempo"}
-        className={`transport__tempo${tempoTargetBpm === null ? "" : " transport__tempo--active"}`}
-        disabled={tempoDisplayBpm === null || tempoTargetBpm === null}
-        onClick={onResetTempo}
-        type="button"
-      >
-        <span>Tempo</span>
-        <strong>{tempoLabel} BPM</strong>
-        {tempoTargetBpm !== null ? <RotateCcw aria-hidden="true" size={14} /> : null}
-      </button>
+      {!mobile ? (
+        <button
+          aria-label={tempoTargetBpm === null ? "Tempo at original" : "Reset tempo"}
+          className={`transport__tempo${tempoTargetBpm === null ? "" : " transport__tempo--active"}`}
+          disabled={tempoDisplayBpm === null || tempoTargetBpm === null}
+          onClick={onResetTempo}
+          type="button"
+        >
+          <span>Tempo</span>
+          <strong>{tempoLabel} BPM</strong>
+          {tempoTargetBpm !== null ? <RotateCcw aria-hidden="true" size={14} /> : null}
+        </button>
+      ) : null}
 
-      <label className="transport__scrubber">
-        <span className="metric-label">Playback position</span>
-        <input
-          aria-label="Playback position"
-          max={maxSeconds}
-          min={0}
-          onChange={(event) => onSeekTo(Number(event.target.value))}
-          step={0.001}
-          type="range"
-          value={Math.min(playbackTimeSeconds, maxSeconds)}
-        />
-        <div className="transport__times">
-          <strong>{formatPlaybackClock(playbackTimeSeconds)}</strong>
-          <span>{formatPlaybackClock(maxSeconds)}</span>
-        </div>
-      </label>
-      {playbackDiagnostics.statusMessage ? (
-        <p
-          className={`transport__status transport__status--${playbackDiagnostics.currentState}`}
-          role={playbackDiagnostics.currentState === "error" ? "alert" : "status"}
-        >
-          {playbackDiagnostics.statusMessage}
-        </p>
-      ) : null}
-      {powerProtectionMessage ? (
-        <p
-          className="transport__status transport__status--error"
-          role="status"
-        >
-          {powerProtectionMessage}
-        </p>
-      ) : null}
+      <div className="transport__timeline">
+        <label className="transport__scrubber">
+          <span className="metric-label">Playback position</span>
+          <input
+            aria-label="Playback position"
+            max={maxSeconds}
+            min={0}
+            onChange={(event) => onSeekTo(Number(event.target.value))}
+            step={0.001}
+            type="range"
+            value={Math.min(playbackTimeSeconds, maxSeconds)}
+          />
+          <div className="transport__times">
+            <strong>{formatPlaybackClock(playbackTimeSeconds)}</strong>
+            <span>{formatPlaybackClock(maxSeconds)}</span>
+          </div>
+        </label>
+        {playbackDiagnostics.statusMessage || powerProtectionMessage ? (
+          <div className="transport__status-stack">
+            {playbackDiagnostics.statusMessage ? (
+              <p
+                className={`transport__status transport__status--${playbackDiagnostics.currentState}`}
+                role={playbackDiagnostics.currentState === "error" ? "alert" : "status"}
+              >
+                {playbackDiagnostics.statusMessage}
+              </p>
+            ) : null}
+            {powerProtectionMessage ? (
+              <p
+                className="transport__status transport__status--error"
+                role="status"
+              >
+                {powerProtectionMessage}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/features/projects/components/PlaybackWorkspace.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackWorkspace.tsx
@@ -1,14 +1,22 @@
 import { PlaybackPracticeRail } from "./PlaybackPracticeRail";
+import { PlaybackPracticeControlsDrawer } from "./PlaybackPracticeControlsDrawer";
 import { PlaybackPracticeSurface } from "./PlaybackPracticeSurface";
 import { PlaybackTransport } from "./PlaybackTransport";
 import { useProjectViewModelContext } from "./useProjectViewModelContext";
 
-export function PlaybackWorkspace() {
+export function PlaybackWorkspace({
+  onClosePracticeControls,
+  practiceControlsOpen,
+}: {
+  onClosePracticeControls: () => void;
+  practiceControlsOpen: boolean;
+}) {
   const {
     handleSeek,
     handleSeekTo,
     handleResetPlaybackTempo,
     handleTogglePlaybackLoop,
+    isMobileRuntime,
     isPlaying,
     loopRange,
     loopStatusMessage,
@@ -27,11 +35,12 @@ export function PlaybackWorkspace() {
 
   return (
     <div className={`playback-workspace playback-workspace--practice${isPlaying ? " playback-workspace--focus" : ""}`}>
-      <PlaybackPracticeRail />
+      {!isMobileRuntime ? <PlaybackPracticeRail /> : null}
       <PlaybackPracticeSurface />
       <div className="panel playback-transport-dock" ref={playbackTransportRef}>
         <PlaybackTransport
           compact
+          mobile={isMobileRuntime}
           isPlaying={isPlaying}
           loopRange={loopRange}
           loopStatusMessage={loopStatusMessage}
@@ -49,6 +58,12 @@ export function PlaybackWorkspace() {
           onTogglePlayback={togglePlayback}
         />
       </div>
+      {isMobileRuntime ? (
+        <PlaybackPracticeControlsDrawer
+          open={practiceControlsOpen}
+          onDismiss={onClosePracticeControls}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/features/projects/components/ProjectHeader.tsx
+++ b/apps/desktop/src/features/projects/components/ProjectHeader.tsx
@@ -1,22 +1,205 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ArrowLeft, MoreVertical, SlidersHorizontal } from "lucide-react";
 import { Link } from "react-router-dom";
 import { useProjectViewModelContext } from "./useProjectViewModelContext";
 
-export function ProjectHeader() {
+const OVERFLOW_HISTORY_KEY = "tuneforgePlaybackOverflow";
+
+export function ProjectHeader({
+  onOpenPracticeControls,
+}: {
+  onOpenPracticeControls: () => void;
+}) {
   const {
     activeWorkspace,
+    displayedLyrics,
     draftName,
+    handleOpenTabImport,
+    handleSetPlaybackDisplayMode,
+    handleSelectWorkspace,
+    hasLyricsTranscript,
+    isLyricsRunning,
+    isMobileRuntime,
     isRenaming,
+    lyricsMutation,
     projectEditLocked,
     projectQuery,
     projectSyncLockReason,
     projectSyncSummary,
     renameMutation,
     setDraftName,
+    setIsEditingLyrics,
     setIsRenaming,
+    setLyricsDraft,
     showSupportingCopy,
   } = useProjectViewModelContext();
   const showSyncStatus = projectSyncSummary.showBadge;
   const syncReason = projectSyncLockReason ? ` ${projectSyncLockReason}` : "";
+  const [overflowOpen, setOverflowOpen] = useState(false);
+  const overflowRef = useRef<HTMLDivElement>(null);
+  const overflowHistoryMarkerRef = useRef(`playback-overflow-${crypto.randomUUID()}`);
+  const overflowTriggerRef = useRef<HTMLButtonElement>(null);
+
+  const dismissOverflowFromUi = useCallback((restoreFocus = true) => {
+    setOverflowOpen(false);
+    if (restoreFocus) {
+      window.setTimeout(() => overflowTriggerRef.current?.focus(), 0);
+    }
+    if (
+      window.history.state?.[OVERFLOW_HISTORY_KEY] === overflowHistoryMarkerRef.current
+    ) {
+      window.history.back();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!overflowOpen) {
+      return;
+    }
+    const marker = overflowHistoryMarkerRef.current;
+    window.history.pushState(
+      { ...window.history.state, [OVERFLOW_HISTORY_KEY]: marker },
+      "",
+      window.location.href,
+    );
+    const handlePointerDown = (event: PointerEvent) => {
+      if (event.target instanceof Node && !overflowRef.current?.contains(event.target)) {
+        dismissOverflowFromUi();
+      }
+    };
+    const handlePopState = () => {
+      setOverflowOpen(false);
+      window.setTimeout(() => overflowTriggerRef.current?.focus(), 0);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") {
+        return;
+      }
+      event.preventDefault();
+      dismissOverflowFromUi();
+    };
+    window.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("popstate", handlePopState);
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("popstate", handlePopState);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [dismissOverflowFromUi, overflowOpen]);
+
+  if (isMobileRuntime && activeWorkspace === "playback") {
+    return (
+      <header className="screen__header screen__header--project screen__header--compact mobile-playback-app-bar">
+        <Link
+          aria-label="Back to Library"
+          className="button button--ghost button--small mobile-playback-app-bar__back"
+          to="/"
+        >
+          <ArrowLeft aria-hidden="true" />
+        </Link>
+        <div className="mobile-playback-app-bar__identity">
+          <p className="eyebrow">Playback</p>
+          <h1 title={projectQuery.data?.display_name ?? "Project"}>
+            {projectQuery.data?.display_name ?? "Project"}
+          </h1>
+          {showSyncStatus ? (
+            <span
+              aria-label={`Sync status: ${projectSyncSummary.label}.${syncReason}`}
+              className={`sync-status-badge sync-status-badge--${projectSyncSummary.state}`}
+              title={projectSyncLockReason ?? undefined}
+            >
+              {projectSyncSummary.label}
+            </span>
+          ) : null}
+          {projectSyncLockReason ? (
+            <p className="project-sync-lock-reason" role="status">
+              {projectSyncLockReason}
+            </p>
+          ) : null}
+        </div>
+        <div className="mobile-playback-app-bar__actions">
+          <button
+            aria-label="Open Practice Controls"
+            className="button button--ghost button--small mobile-playback-app-bar__practice-controls"
+            onClick={onOpenPracticeControls}
+            type="button"
+          >
+            <SlidersHorizontal aria-hidden="true" />
+            <span>Practice Controls</span>
+          </button>
+          <div className="mobile-playback-overflow" ref={overflowRef}>
+            <button
+              aria-expanded={overflowOpen}
+              aria-haspopup="menu"
+              aria-label="More playback actions"
+              className="button button--ghost button--small mobile-playback-overflow__trigger"
+              onClick={() => {
+                if (overflowOpen) {
+                  dismissOverflowFromUi();
+                } else {
+                  setOverflowOpen(true);
+                }
+              }}
+              ref={overflowTriggerRef}
+              type="button"
+            >
+              <MoreVertical aria-hidden="true" />
+            </button>
+            {overflowOpen ? (
+              <div
+                aria-label="Playback actions"
+                className="mobile-playback-overflow__menu"
+                role="menu"
+              >
+                <button
+                  onClick={() => {
+                    dismissOverflowFromUi(false);
+                    handleSelectWorkspace("project");
+                  }}
+                  role="menuitem"
+                  type="button"
+                >
+                  Project workspace
+                </button>
+                {hasLyricsTranscript ? (
+                  <button
+                    disabled={projectEditLocked || lyricsMutation.isPending || isLyricsRunning}
+                    onClick={() => {
+                      if (projectEditLocked) {
+                        return;
+                      }
+                      handleSetPlaybackDisplayMode("lyrics");
+                      setLyricsDraft(displayedLyrics.map((segment) => segment.text));
+                      setIsEditingLyrics(true);
+                      dismissOverflowFromUi(false);
+                    }}
+                    role="menuitem"
+                    title={projectSyncLockReason ?? undefined}
+                    type="button"
+                  >
+                    Edit Lyrics
+                  </button>
+                ) : null}
+                <button
+                  disabled={projectEditLocked}
+                  onClick={() => {
+                    dismissOverflowFromUi(false);
+                    handleOpenTabImport();
+                  }}
+                  role="menuitem"
+                  title={projectSyncLockReason ?? undefined}
+                  type="button"
+                >
+                  Import Tab
+                </button>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </header>
+    );
+  }
 
   return (
     <div

--- a/apps/desktop/src/features/projects/components/ProjectShell.tsx
+++ b/apps/desktop/src/features/projects/components/ProjectShell.tsx
@@ -1,33 +1,75 @@
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useProjectViewModelContext } from "./useProjectViewModelContext";
 import { PlaybackWorkspace } from "./PlaybackWorkspace";
 import { ProjectHeader } from "./ProjectHeader";
 import { ProjectWorkspace } from "./ProjectWorkspace";
 
 export function ProjectShell() {
-  const { activeWorkspace, handleSelectWorkspace } = useProjectViewModelContext();
+  const { activeWorkspace, handleSelectWorkspace, isMobileRuntime } = useProjectViewModelContext();
+  const [practiceControlsOpen, setPracticeControlsOpen] = useState(false);
+  const screenRef = useRef<HTMLElement>(null);
+  const mobilePlayback = isMobileRuntime && activeWorkspace === "playback";
+  const closePracticeControls = useCallback(() => setPracticeControlsOpen(false), []);
+
+  useEffect(() => {
+    const screen = screenRef.current;
+    if (!screen) {
+      return;
+    }
+    const underlay = screen.closest<HTMLElement>(".app-shell") ?? screen;
+    if (practiceControlsOpen) {
+      underlay.setAttribute("inert", "");
+      underlay.setAttribute("aria-hidden", "true");
+    } else {
+      underlay.removeAttribute("inert");
+      underlay.removeAttribute("aria-hidden");
+    }
+    return () => {
+      underlay.removeAttribute("inert");
+      underlay.removeAttribute("aria-hidden");
+    };
+  }, [practiceControlsOpen]);
+
+  useEffect(() => {
+    if (!mobilePlayback) {
+      setPracticeControlsOpen(false);
+    }
+  }, [mobilePlayback]);
 
   return (
-    <section className={`screen project-screen project-screen--${activeWorkspace}`}>
-      <ProjectHeader />
+    <section
+      className={`screen project-screen project-screen--${activeWorkspace}`}
+      ref={screenRef}
+    >
+      <ProjectHeader onOpenPracticeControls={() => setPracticeControlsOpen(true)} />
 
-      <div className="project-workspace-tabs" role="tablist" aria-label="Project workspace">
-        {(["project", "playback"] as const).map((workspace) => (
-          <button
-            key={workspace}
-            aria-selected={activeWorkspace === workspace}
-            className={`project-workspace-tabs__button${
-              activeWorkspace === workspace ? " project-workspace-tabs__button--active" : ""
-            }`}
-            onClick={() => handleSelectWorkspace(workspace)}
-            role="tab"
-            type="button"
-          >
-            {workspace === "project" ? "Project" : "Playback"}
-          </button>
-        ))}
-      </div>
+      {!mobilePlayback ? (
+        <div className="project-workspace-tabs" role="tablist" aria-label="Project workspace">
+          {(["project", "playback"] as const).map((workspace) => (
+            <button
+              key={workspace}
+              aria-selected={activeWorkspace === workspace}
+              className={`project-workspace-tabs__button${
+                activeWorkspace === workspace ? " project-workspace-tabs__button--active" : ""
+              }`}
+              onClick={() => handleSelectWorkspace(workspace)}
+              role="tab"
+              type="button"
+            >
+              {workspace === "project" ? "Project" : "Playback"}
+            </button>
+          ))}
+        </div>
+      ) : null}
 
-      {activeWorkspace === "project" ? <ProjectWorkspace /> : <PlaybackWorkspace />}
+      {activeWorkspace === "project" ? (
+        <ProjectWorkspace />
+      ) : (
+        <PlaybackWorkspace
+          practiceControlsOpen={practiceControlsOpen}
+          onClosePracticeControls={closePracticeControls}
+        />
+      )}
     </section>
   );
 }

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -291,6 +291,17 @@ function loopRangeFromPoints(
   };
 }
 
+function verticalPracticeScrollContainer(
+  content: HTMLDivElement,
+  isMobileRuntime: boolean,
+) {
+  if (!isMobileRuntime) {
+    return content;
+  }
+  const nestedScroller = content.closest<HTMLElement>(".playback-practice-body");
+  return nestedScroller ?? content;
+}
+
 export function useProjectViewModel() {
   const { projectId = "" } = useParams();
   const navigate = useNavigate();
@@ -2264,10 +2275,14 @@ export function useProjectViewModel() {
       lyricsSegmentRefs.current[
         `${activeSegment.start_seconds}-${activeSegment.end_seconds}-${activeLyricsIndex}`
       ];
-    const lyricsContainer = lyricsTheaterRef.current;
-    if (!activeElement || !lyricsContainer) {
+    const lyricsContent = lyricsTheaterRef.current;
+    if (!activeElement || !lyricsContent) {
       return;
     }
+    const lyricsContainer = verticalPracticeScrollContainer(
+      lyricsContent,
+      isMobileRuntime,
+    );
     const containerRect = lyricsContainer.getBoundingClientRect();
     const elementRect = activeElement.getBoundingClientRect();
     const centerOffset =
@@ -2298,6 +2313,7 @@ export function useProjectViewModel() {
     displayedLyrics,
     isEditingLyrics,
     isPlaying,
+    isMobileRuntime,
     hasTimedLyricsTranscript,
     lyricsFollowEnabled,
     playbackDisplayMode,
@@ -2319,10 +2335,14 @@ export function useProjectViewModel() {
       return;
     }
     const activeElement = combinedLeadSheetRowRefs.current[activeRow.id];
-    const leadSheetContainer = combinedLeadSheetRef.current;
-    if (!activeElement || !leadSheetContainer) {
+    const leadSheetContent = combinedLeadSheetRef.current;
+    if (!activeElement || !leadSheetContent) {
       return;
     }
+    const leadSheetContainer = verticalPracticeScrollContainer(
+      leadSheetContent,
+      isMobileRuntime,
+    );
     const containerRect = leadSheetContainer.getBoundingClientRect();
     const elementRect = activeElement.getBoundingClientRect();
     const centerOffset =
@@ -2352,6 +2372,7 @@ export function useProjectViewModel() {
     hasTimedLyricsTranscript,
     isEditingLyrics,
     isPlaying,
+    isMobileRuntime,
     lyricsFollowEnabled,
     playbackDisplayMode,
   ]);

--- a/apps/desktop/src/styles/project-layout.css
+++ b/apps/desktop/src/styles/project-layout.css
@@ -7,6 +7,17 @@
   overflow: hidden;
 }
 
+@media (max-width: 720px) {
+  .project-screen--playback:has(.mobile-playback-app-bar) {
+    block-size: 100%;
+    min-block-size: 0;
+    min-inline-size: 0;
+    gap: 0.5rem;
+    overflow: hidden;
+    overscroll-behavior: none;
+  }
+}
+
 .project-workspace {
   display: flex;
   min-height: 0;

--- a/apps/desktop/src/styles/project-playback.css
+++ b/apps/desktop/src/styles/project-playback.css
@@ -391,6 +391,10 @@
   min-width: 0;
 }
 
+.transport__timeline {
+  display: contents;
+}
+
 @keyframes transport-seek-shift-forward {
   0% {
     opacity: 0;
@@ -443,6 +447,10 @@
   font-weight: 700;
 }
 
+.transport__status-stack {
+  display: contents;
+}
+
 .transport__status--error {
   color: var(--danger);
 }
@@ -489,6 +497,127 @@
 .transport--compact .metric-label,
 .transport--compact .transport__loop-status {
   font-size: 0.82rem;
+}
+
+.transport--mobile {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: 3rem 3rem;
+  gap: 0.35rem;
+  align-items: stretch;
+}
+
+.transport--mobile .transport__controls {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(3rem, 1fr));
+  align-items: center;
+  gap: clamp(0.2rem, 1.6vw, 0.5rem);
+  min-width: 0;
+}
+
+.transport--mobile .transport__button--play,
+.transport--mobile .transport__button--stop,
+.transport--mobile .transport__button--seek,
+.transport--mobile .transport__button--loop {
+  --transport-button-size: 3rem;
+  justify-self: center;
+  min-inline-size: 3rem;
+  min-block-size: 3rem;
+}
+
+.transport--mobile .transport__loop-status {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.transport--mobile .transport__timeline {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: 3rem;
+  align-items: center;
+  gap: 0.35rem;
+  min-width: 0;
+  min-height: 0;
+  overflow: visible;
+}
+
+.transport--mobile .transport__scrubber {
+  display: grid;
+  grid-template-columns: auto minmax(3rem, 1fr) auto;
+  grid-template-rows: 3rem;
+  align-items: center;
+  column-gap: 0.5rem;
+}
+
+.transport--mobile .transport__timeline:has(.transport__status-stack) {
+  grid-template-columns: minmax(0, 1fr) minmax(5rem, min(9rem, 38vw));
+}
+
+.transport--mobile .transport__scrubber > .metric-label {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.transport--mobile .transport__scrubber input[type="range"] {
+  grid-column: 2;
+  grid-row: 1;
+  min-block-size: 3rem;
+  margin: 0;
+}
+
+.transport--mobile .transport__times {
+  display: contents;
+  font-size: 0.75rem;
+  line-height: 1;
+}
+
+.transport--mobile .transport__times strong,
+.transport--mobile .transport__times span {
+  grid-row: 1;
+  white-space: nowrap;
+}
+
+.transport--mobile .transport__times strong {
+  grid-column: 1;
+}
+
+.transport--mobile .transport__times span {
+  grid-column: 3;
+}
+
+.transport--mobile .transport__status-stack {
+  display: grid;
+  grid-column: 2;
+  grid-row: 1;
+  align-content: center;
+  max-block-size: 3rem;
+  min-width: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.transport--mobile .transport__status {
+  display: grid;
+  place-items: center;
+  margin: 0;
+  padding: 0.1rem 0.25rem;
+  overflow: visible;
+  background: transparent;
+  font-size: 0.68rem;
+  line-height: 1.15;
+  overflow-wrap: anywhere;
+  text-align: center;
 }
 
 .playback-stage__lane,
@@ -856,6 +985,246 @@
   margin-bottom: 0;
   font-size: 0.66rem;
   letter-spacing: 0.14em;
+}
+
+.screen__header.mobile-playback-app-bar {
+  position: relative;
+  z-index: 4;
+  display: grid;
+  grid-template-columns: 3rem minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.mobile-playback-app-bar__back,
+.mobile-playback-app-bar__practice-controls,
+.mobile-playback-overflow__trigger {
+  min-inline-size: 3rem;
+  min-block-size: 3rem;
+}
+
+.mobile-playback-app-bar__back,
+.mobile-playback-overflow__trigger {
+  display: inline-grid;
+  place-items: center;
+  padding: 0;
+}
+
+.mobile-playback-app-bar__identity {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  column-gap: 0.45rem;
+  min-width: 0;
+}
+
+.mobile-playback-app-bar__identity .eyebrow {
+  grid-column: 1;
+  margin: 0;
+}
+
+.mobile-playback-app-bar__identity h1 {
+  grid-column: 1;
+  min-width: 0;
+  font-size: clamp(1rem, 4.8vw, 1.35rem);
+  line-height: 1.08;
+  overflow: visible;
+  overflow-wrap: anywhere;
+  text-overflow: clip;
+  white-space: normal;
+}
+
+.mobile-playback-app-bar__identity .sync-status-badge {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+}
+
+.mobile-playback-app-bar__identity .project-sync-lock-reason {
+  grid-column: 1 / -1;
+  margin-top: 0.25rem;
+  overflow-wrap: anywhere;
+}
+
+.mobile-playback-app-bar__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.mobile-playback-app-bar__practice-controls {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+}
+
+.mobile-playback-app-bar__practice-controls svg,
+.mobile-playback-app-bar__back svg,
+.mobile-playback-overflow__trigger svg,
+.mobile-practice-controls__close svg {
+  inline-size: 1.25rem;
+  block-size: 1.25rem;
+  flex: 0 0 auto;
+}
+
+.mobile-playback-app-bar .button:hover,
+.transport--mobile .transport__button:hover {
+  transform: none;
+}
+
+.mobile-playback-overflow {
+  position: relative;
+}
+
+.mobile-playback-overflow__menu {
+  position: absolute;
+  z-index: 6;
+  inset-block-start: calc(100% + 0.35rem);
+  inset-inline-end: 0;
+  display: grid;
+  inline-size: max-content;
+  min-inline-size: min(13rem, calc(100vw - var(--safe-area-left) - var(--safe-area-right) - 1rem));
+  max-inline-size: calc(100vw - var(--safe-area-left) - var(--safe-area-right) - 1rem);
+  padding: 0.35rem;
+  border: 1px solid var(--divider);
+  border-radius: 16px;
+  background: var(--panel-strong);
+  box-shadow: 0 18px 40px color-mix(in srgb, black 28%, transparent);
+}
+
+.mobile-playback-overflow__menu button {
+  min-block-size: 3rem;
+  border: 0;
+  border-radius: 12px;
+  padding: 0.65rem 0.75rem;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  text-align: start;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.mobile-playback-overflow__menu button:hover,
+.mobile-playback-overflow__menu button:focus-visible {
+  background: color-mix(in srgb, var(--playback-accent) 14%, transparent);
+}
+
+.mobile-practice-controls-layer {
+  position: fixed;
+  z-index: 50;
+  inset: 0;
+  display: grid;
+  align-items: end;
+  min-width: 0;
+}
+
+.mobile-practice-controls__scrim {
+  position: absolute;
+  inset: 0;
+  background: color-mix(in srgb, black 58%, transparent);
+  backdrop-filter: blur(4px);
+}
+
+.mobile-practice-controls {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  min-width: 0;
+  max-block-size: calc(100dvh - var(--safe-area-top) - 0.5rem);
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--divider);
+  border-block-end: 0;
+  border-radius: 24px 24px 0 0;
+  padding-block: 0.8rem var(--safe-area-bottom);
+  padding-inline: calc(0.8rem + var(--safe-area-left)) calc(0.8rem + var(--safe-area-right));
+  background: var(--panel);
+  box-shadow: 0 -18px 44px color-mix(in srgb, black 28%, transparent);
+}
+
+.mobile-practice-controls__header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 3rem;
+  align-items: start;
+  gap: 0.75rem;
+  flex: 0 0 auto;
+  padding-block-end: 0.75rem;
+}
+
+.mobile-practice-controls__header h2 {
+  margin: 0.15rem 0 0;
+  font-size: clamp(1.3rem, 6vw, 1.75rem);
+  overflow-wrap: anywhere;
+}
+
+.mobile-practice-controls__close {
+  display: inline-grid;
+  min-inline-size: 3rem;
+  min-block-size: 3rem;
+  place-items: center;
+  padding: 0;
+}
+
+.mobile-practice-controls .playback-practice-rail--drawer {
+  --panel-padding: 0;
+  grid-area: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: none;
+  overflow: hidden;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.mobile-practice-controls .playback-practice-rail--drawer .playback-practice-rail__content {
+  padding-inline: 0.1rem;
+  padding-block-end: 0.8rem;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+}
+
+.mobile-practice-controls .playback-practice-rail--drawer :is(button, input, select) {
+  min-block-size: 3rem;
+}
+
+.mobile-practice-controls .key-stepper--small .target-selector__trigger {
+  grid-template-columns: minmax(0, 0.55fr) minmax(0, 1.6fr) minmax(0, 0.55fr);
+  grid-template-rows: minmax(3rem, max-content) minmax(1rem, max-content);
+}
+
+.mobile-practice-controls .key-stepper--small :is(
+  .target-selector__preview,
+  .target-selector__current
+) {
+  grid-row: 1;
+}
+
+.mobile-practice-controls .key-stepper--small .target-selector__current {
+  gap: 0.35em;
+  padding-block: 0.45em;
+}
+
+.mobile-practice-controls .key-stepper--small .target-selector__current-key {
+  line-height: 1.1;
+}
+
+.mobile-practice-controls .key-stepper--small .target-selector__current-meta {
+  line-height: 1.2;
+}
+
+.mobile-practice-controls .key-stepper--small .target-selector__chevron {
+  position: static;
+  grid-column: 2;
+  grid-row: 2;
+  justify-self: center;
+  transform: none;
 }
 
 .playback-workspace--practice {
@@ -1859,6 +2228,270 @@
 
   .transport--compact {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) and (min-width: 0px) {
+  .screen__header.mobile-playback-app-bar {
+    flex: 0 0 auto;
+    grid-template-columns: 48px minmax(0, 1fr) auto;
+    gap: 5.6px;
+    max-inline-size: 100%;
+  }
+
+  .mobile-playback-app-bar__practice-controls {
+    inline-size: 48px;
+    padding: 0;
+  }
+
+  .mobile-playback-app-bar__back,
+  .mobile-playback-app-bar__practice-controls,
+  .mobile-playback-overflow__trigger {
+    min-inline-size: 48px;
+    min-block-size: 48px;
+  }
+
+  .mobile-playback-app-bar__identity {
+    column-gap: 7.2px;
+  }
+
+  .mobile-playback-app-bar__actions {
+    gap: 5.6px;
+  }
+
+  .mobile-playback-app-bar__practice-controls {
+    gap: 6.4px;
+  }
+
+  .mobile-playback-app-bar__practice-controls svg,
+  .mobile-playback-app-bar__back svg,
+  .mobile-playback-overflow__trigger svg {
+    inline-size: 20px;
+    block-size: 20px;
+  }
+
+  .mobile-playback-app-bar__practice-controls span {
+    position: absolute;
+    inline-size: 1px;
+    block-size: 1px;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+  }
+
+  .mobile-playback-app-bar__identity h1 {
+    font-size: clamp(1rem, 5.2vw, 1.3rem);
+  }
+
+  .playback-workspace--practice:has(.transport--mobile),
+  .playback-workspace--focus:has(.transport--mobile) {
+    display: grid;
+    flex: 1 1 0;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr) auto;
+    grid-template-areas:
+      "surface"
+      "transport";
+    gap: 8px;
+    min-block-size: 0;
+    min-inline-size: 0;
+    overflow: hidden;
+    overscroll-behavior: none;
+  }
+
+  .playback-workspace--practice:has(.transport--mobile) .playback-practice-surface {
+    --panel-padding: 8.8px;
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    gap: 8px;
+    block-size: 100%;
+    min-block-size: 0;
+    min-inline-size: 0;
+    overflow: hidden;
+  }
+
+  .playback-workspace--practice:has(.transport--mobile) .playback-practice-surface__header,
+  .playback-workspace--focus:has(.transport--mobile) .playback-practice-surface__header {
+    display: grid;
+    flex: 0 0 auto;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 6.4px;
+    max-height: none;
+    min-width: 0;
+    overflow: visible;
+    opacity: 1;
+    pointer-events: auto;
+    transform: none;
+  }
+
+  .playback-workspace--practice:has(.transport--mobile) .playback-practice-surface__header h2 {
+    margin-top: 0.1rem;
+    font-size: clamp(1.1rem, 5.6vw, 1.35rem);
+    line-height: 1.1;
+    overflow-wrap: anywhere;
+  }
+
+  .playback-workspace--practice:has(.transport--mobile) .playback-practice-surface__heading {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 7.2px;
+    min-width: 0;
+  }
+
+  .playback-workspace--practice:has(.transport--mobile) .playback-practice-surface__heading > div {
+    min-width: 0;
+  }
+
+  .playback-workspace--practice:has(.transport--mobile) .playback-practice-surface__controls {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    align-items: stretch;
+    gap: 5.6px;
+    min-width: 0;
+    overflow: visible;
+    padding: 0;
+  }
+
+  .playback-workspace--practice:has(.transport--mobile) .playback-mode-toggle {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    inline-size: 100%;
+    min-width: 0;
+    padding: 3.2px;
+  }
+
+  .playback-workspace--practice:has(.transport--mobile) .playback-mode-toggle__button {
+    min-inline-size: 0;
+    min-block-size: 48px;
+    padding: 5.6px;
+    line-height: 1.15;
+    overflow-wrap: anywhere;
+  }
+
+  .playback-workspace--practice:has(.transport--mobile) .playback-follow-chip {
+    justify-self: end;
+    min-inline-size: 48px;
+    min-block-size: 48px;
+    max-inline-size: 100%;
+    padding-inline: 13.6px;
+    overflow-wrap: anywhere;
+    white-space: normal;
+  }
+
+  .playback-workspace--practice:has(.transport--mobile) .playback-follow-explanation {
+    grid-column: 1 / -1;
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .playback-workspace--practice:has(.transport--mobile) .playback-practice-body,
+  .playback-workspace--practice:has(.transport--mobile) .lyrics-editor {
+    flex: 1 1 auto;
+    min-block-size: 50%;
+    min-inline-size: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+    touch-action: pan-y;
+  }
+
+  .playback-workspace--practice:has(.transport--mobile) .lead-sheet {
+    flex: 0 0 auto;
+    min-block-size: 100%;
+    block-size: auto;
+    max-block-size: none;
+    overflow: visible;
+  }
+
+  .playback-workspace--practice:has(.transport--mobile) .playback-transport-dock {
+    --panel-padding: 6.4px 8px;
+    box-sizing: border-box;
+    max-block-size: 128px;
+    min-block-size: 0;
+    min-inline-size: 0;
+    overflow: hidden;
+    border-radius: 18px;
+  }
+
+  .playback-workspace--practice:has(.transport--mobile) .transport--mobile {
+    block-size: 100%;
+    max-block-size: calc(128px - 12.8px - 2px);
+    min-inline-size: 0;
+    overflow: hidden;
+  }
+
+  .transport--mobile {
+    grid-template-rows: 48px 48px;
+    gap: 5.6px;
+  }
+
+  .transport--mobile .transport__controls {
+    grid-template-columns: repeat(5, minmax(48px, 1fr));
+    gap: clamp(3.2px, 1.6vw, 8px);
+  }
+
+  .transport--mobile .transport__button--play,
+  .transport--mobile .transport__button--stop,
+  .transport--mobile .transport__button--seek,
+  .transport--mobile .transport__button--loop {
+    --transport-button-size: 48px;
+    min-inline-size: 48px;
+    min-block-size: 48px;
+  }
+
+  .transport--mobile .transport__timeline {
+    grid-template-rows: 48px;
+    gap: 5.6px;
+  }
+
+  .transport--mobile .transport__scrubber {
+    grid-template-columns: auto minmax(48px, 1fr) auto;
+    grid-template-rows: 48px;
+    column-gap: 8px;
+  }
+
+  .transport--mobile .transport__timeline:has(.transport__status-stack) {
+    grid-template-columns: minmax(0, 1fr) minmax(80px, min(144px, 38vw));
+  }
+
+  .transport--mobile .transport__scrubber input[type="range"] {
+    min-block-size: 48px;
+  }
+
+  .transport--mobile .transport__status-stack {
+    max-block-size: 48px;
+  }
+
+  .transport--mobile .transport__status {
+    padding: 3.2px 8px;
+  }
+}
+
+@media (max-width: 400px) {
+  .playback-workspace--practice:has(.transport--mobile) .lead-sheet-word:has(
+    > .lead-sheet-word__chords:empty
+  ) {
+    min-block-size: 0;
+  }
+
+  .playback-workspace--practice:has(.transport--mobile) .lead-sheet-word__chords:empty {
+    min-block-size: 0;
+  }
+
+  .playback-workspace--practice:has(.transport--mobile) .lead-sheet {
+    gap: 0.55rem;
+    padding: 0.35rem 0.45rem;
+  }
+
+  .playback-workspace--practice:has(.transport--mobile) .lead-sheet__edge {
+    flex-basis: 0.5rem;
+  }
+
+  .playback-workspace--practice:has(.transport--mobile) .lead-sheet__row {
+    padding: 0.65rem 0.75rem;
   }
 }
 

--- a/apps/desktop/src/styles/utilities-responsive.css
+++ b/apps/desktop/src/styles/utilities-responsive.css
@@ -188,6 +188,23 @@
     width: 100%;
     justify-content: center;
   }
+
+  .app-shell:has(.mobile-playback-app-bar) {
+    grid-template-rows: minmax(0, 1fr);
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  .app-shell:has(.mobile-playback-app-bar) .sidebar {
+    display: none;
+  }
+
+  .app-shell:has(.mobile-playback-app-bar) .main-content {
+    --screen-padding: 0.5rem;
+    min-width: 0;
+    overflow: hidden;
+    overscroll-behavior: none;
+  }
 }
 
 @media (max-height: 900px) {

--- a/apps/desktop/tests/project-playback-responsive-css.test.ts
+++ b/apps/desktop/tests/project-playback-responsive-css.test.ts
@@ -2,6 +2,8 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 const projectPlaybackCss = readFileSync("src/styles/project-playback.css", "utf8");
+const projectLayoutCss = readFileSync("src/styles/project-layout.css", "utf8");
+const responsiveUtilitiesCss = readFileSync("src/styles/utilities-responsive.css", "utf8");
 
 function cssBlock(source: string, signature: string) {
   const signatureIndex = source.indexOf(signature);
@@ -65,6 +67,422 @@ function cssDeclarations(block: string) {
 }
 
 describe("project Playback responsive CSS", () => {
+  it("fixes Android Playback to the viewport while preserving narrow desktop page growth", () => {
+    const mobileLayoutRules = cssBlock(projectLayoutCss, "@media (max-width: 720px)");
+    const mobileScreenDeclarations = cssDeclarations(
+      cssRuleBlock(
+        mobileLayoutRules,
+        ".project-screen--playback:has(.mobile-playback-app-bar)",
+      ),
+    );
+    const narrowRules = cssBlock(projectPlaybackCss, "@media (max-width: 720px)");
+    const narrowDesktopScreenDeclarations = cssDeclarations(
+      cssRuleBlock(narrowRules, ".project-screen--playback"),
+    );
+
+    expect(mobileScreenDeclarations).toMatchObject({
+      "block-size": "100%",
+      "min-block-size": "0",
+      overflow: "hidden",
+      "overscroll-behavior": "none",
+    });
+    expect(narrowDesktopScreenDeclarations).toMatchObject({
+      height: "auto",
+      overflow: "visible",
+    });
+  });
+
+  it("removes mobile app chrome from the fixed Playback frame scroll chain", () => {
+    const narrowRules = cssBlock(responsiveUtilitiesCss, "@media (max-width: 720px)");
+    const shellDeclarations = cssDeclarations(
+      cssRuleBlock(narrowRules, ".app-shell:has(.mobile-playback-app-bar)"),
+    );
+    const sidebarDeclarations = cssDeclarations(
+      cssRuleBlock(narrowRules, ".app-shell:has(.mobile-playback-app-bar) .sidebar"),
+    );
+    const mainDeclarations = cssDeclarations(
+      cssRuleBlock(narrowRules, ".app-shell:has(.mobile-playback-app-bar) .main-content"),
+    );
+
+    expect(shellDeclarations).toMatchObject({
+      "grid-template-rows": "minmax(0, 1fr)",
+      overflow: "hidden",
+    });
+    expect(sidebarDeclarations).toMatchObject({ display: "none" });
+    expect(mainDeclarations).toMatchObject({
+      "--screen-padding": "0.5rem",
+      overflow: "hidden",
+      "overscroll-behavior": "none",
+    });
+  });
+
+  it("keeps short mobile titles compact while allowing intrinsic large-text reflow", () => {
+    const mobileRules = cssBlock(
+      projectPlaybackCss,
+      "@media (max-width: 720px) and (min-width: 0px)",
+    );
+    const appBarDeclarations = cssDeclarations(
+      cssRuleBlock(projectPlaybackCss, ".screen__header.mobile-playback-app-bar"),
+    );
+    const identityDeclarations = cssDeclarations(
+      cssRuleBlock(projectPlaybackCss, ".mobile-playback-app-bar__identity"),
+    );
+    const backDeclarations = cssDeclarations(
+      cssBlock(projectPlaybackCss, ".mobile-playback-app-bar__back,"),
+    );
+    const titleDeclarations = cssDeclarations(
+      cssRuleBlock(projectPlaybackCss, ".mobile-playback-app-bar__identity h1"),
+    );
+    const mobileHoverDeclarations = cssDeclarations(
+      cssBlock(projectPlaybackCss, ".mobile-playback-app-bar .button:hover,"),
+    );
+    const fixedTargetDeclarations = cssDeclarations(
+      cssBlock(mobileRules, ".mobile-playback-app-bar__back,"),
+    );
+    const mobileIdentityDeclarations = cssDeclarations(
+      cssRuleBlock(mobileRules, ".mobile-playback-app-bar__identity"),
+    );
+    const mobileActionsDeclarations = cssDeclarations(
+      cssRuleBlock(mobileRules, ".mobile-playback-app-bar__actions"),
+    );
+
+    expect(appBarDeclarations).toMatchObject({
+      display: "grid",
+      "grid-template-columns": "3rem minmax(0, 1fr) auto",
+      "min-width": "0",
+    });
+    expect(backDeclarations).toMatchObject({
+      "min-block-size": "3rem",
+      "min-inline-size": "3rem",
+    });
+    expect(identityDeclarations).toMatchObject({
+      "grid-template-columns": "minmax(0, 1fr) auto",
+      "min-width": "0",
+    });
+    expect(titleDeclarations).toMatchObject({
+      "line-height": "1.08",
+      overflow: "visible",
+      "overflow-wrap": "anywhere",
+      "text-overflow": "clip",
+      "white-space": "normal",
+    });
+    expect(mobileHoverDeclarations).toMatchObject({ transform: "none" });
+    expect(fixedTargetDeclarations).toMatchObject({
+      "min-block-size": "48px",
+      "min-inline-size": "48px",
+    });
+    expect(mobileIdentityDeclarations).toMatchObject({ "column-gap": "7.2px" });
+    expect(mobileActionsDeclarations).toMatchObject({ gap: "5.6px" });
+    expect(projectPlaybackCss).toContain(".transport--mobile .transport__button:hover");
+    expect(projectPlaybackCss).not.toContain("@media (max-width: 360px)");
+  });
+
+  it("reserves a dominant independent mobile Practice scroller above the dock", () => {
+    const mobileRules = cssBlock(
+      projectPlaybackCss,
+      "@media (max-width: 720px) and (min-width: 0px)",
+    );
+    const workspaceDeclarations = cssDeclarations(
+      cssBlock(
+        mobileRules,
+        ".playback-workspace--practice:has(.transport--mobile),",
+      ),
+    );
+    const surfaceDeclarations = cssDeclarations(
+      cssRuleBlock(
+        mobileRules,
+        ".playback-workspace--practice:has(.transport--mobile) .playback-practice-surface",
+      ),
+    );
+    const bodyDeclarations = cssDeclarations(
+      cssBlock(
+        mobileRules,
+        ".playback-workspace--practice:has(.transport--mobile) .playback-practice-body,",
+      ),
+    );
+    const leadSheetDeclarations = cssDeclarations(
+      cssRuleBlock(
+        mobileRules,
+        ".playback-workspace--practice:has(.transport--mobile) .lead-sheet",
+      ),
+    );
+
+    expect(workspaceDeclarations).toMatchObject({
+      flex: "1 1 0",
+      "grid-template-rows": "minmax(0, 1fr) auto",
+      overflow: "hidden",
+    });
+    expect(surfaceDeclarations).toMatchObject({
+      "block-size": "100%",
+      "grid-template-rows": "auto minmax(0, 1fr)",
+      overflow: "hidden",
+    });
+    expect(bodyDeclarations).toMatchObject({
+      "min-block-size": "50%",
+      "overflow-x": "hidden",
+      "overflow-y": "auto",
+      "overscroll-behavior": "contain",
+    });
+    expect(leadSheetDeclarations).toMatchObject({
+      "block-size": "auto",
+      "max-block-size": "none",
+      overflow: "visible",
+    });
+    expect(mobileRules).not.toContain(".lead-sheet-word__chords:empty");
+  });
+
+  it("fits active and adjacent Practice context at 360dp without shrinking targets", () => {
+    const narrowMobileRules = cssBlock(projectPlaybackCss, "@media (max-width: 400px)");
+    const leadSheetDeclarations = cssDeclarations(
+      cssRuleBlock(
+        narrowMobileRules,
+        ".playback-workspace--practice:has(.transport--mobile) .lead-sheet",
+      ),
+    );
+    const edgeDeclarations = cssDeclarations(
+      cssRuleBlock(
+        narrowMobileRules,
+        ".playback-workspace--practice:has(.transport--mobile) .lead-sheet__edge",
+      ),
+    );
+    const rowDeclarations = cssDeclarations(
+      cssRuleBlock(
+        narrowMobileRules,
+        ".playback-workspace--practice:has(.transport--mobile) .lead-sheet__row",
+      ),
+    );
+    const emptyWordChordDeclarations = cssDeclarations(
+      cssRuleBlock(
+        narrowMobileRules,
+        ".playback-workspace--practice:has(.transport--mobile) .lead-sheet-word__chords:empty",
+      ),
+    );
+    const emptyChordWordDeclarations = cssDeclarations(
+      cssBlock(
+        narrowMobileRules,
+        ".playback-workspace--practice:has(.transport--mobile) .lead-sheet-word:has(",
+      ),
+    );
+    const chordTargetDeclarations = cssDeclarations(
+      cssRuleBlock(cssBlock(projectPlaybackCss, "@media (max-width: 720px)"), ".lead-sheet-chord"),
+    );
+
+    expect(leadSheetDeclarations).toMatchObject({
+      gap: "0.55rem",
+      padding: "0.35rem 0.45rem",
+    });
+    expect(edgeDeclarations).toMatchObject({ "flex-basis": "0.5rem" });
+    expect(rowDeclarations).toMatchObject({ padding: "0.65rem 0.75rem" });
+    expect(emptyWordChordDeclarations).toMatchObject({ "min-block-size": "0" });
+    expect(emptyChordWordDeclarations).toMatchObject({ "min-block-size": "0" });
+    expect(chordTargetDeclarations).toMatchObject({
+      "min-block-size": "3rem",
+      "min-inline-size": "3rem",
+    });
+  });
+
+  it("caps the two-row mobile transport at 128dp with 48dp tap targets", () => {
+    const transportDeclarations = cssDeclarations(
+      cssRuleBlock(projectPlaybackCss, ".transport--mobile"),
+    );
+    const buttonDeclarations = cssDeclarations(
+      cssBlock(projectPlaybackCss, ".transport--mobile .transport__button--play,"),
+    );
+    const scrubberDeclarations = cssDeclarations(
+      cssRuleBlock(
+        projectPlaybackCss,
+        '.transport--mobile .transport__scrubber input[type="range"]',
+      ),
+    );
+    const timelineDeclarations = cssDeclarations(
+      cssRuleBlock(projectPlaybackCss, ".transport--mobile .transport__timeline"),
+    );
+    const mobileScrubberDeclarations = cssDeclarations(
+      cssRuleBlock(projectPlaybackCss, ".transport--mobile .transport__scrubber"),
+    );
+    const timesDeclarations = cssDeclarations(
+      cssRuleBlock(projectPlaybackCss, ".transport--mobile .transport__times"),
+    );
+    const statusDeclarations = cssDeclarations(
+      cssRuleBlock(projectPlaybackCss, ".transport--mobile .transport__status"),
+    );
+    const statusStackDeclarations = cssDeclarations(
+      cssRuleBlock(projectPlaybackCss, ".transport--mobile .transport__status-stack"),
+    );
+    const statusTimelineDeclarations = cssDeclarations(
+      cssRuleBlock(
+        projectPlaybackCss,
+        ".transport--mobile .transport__timeline:has(.transport__status-stack)",
+      ),
+    );
+    const mobileRules = cssBlock(
+      projectPlaybackCss,
+      "@media (max-width: 720px) and (min-width: 0px)",
+    );
+    const dockDeclarations = cssDeclarations(
+      cssRuleBlock(
+        mobileRules,
+        ".playback-workspace--practice:has(.transport--mobile) .playback-transport-dock",
+      ),
+    );
+    const fixedTransportDeclarations = cssDeclarations(
+      cssRuleBlock(mobileRules, "\n  .transport--mobile"),
+    );
+    const fixedControlsDeclarations = cssDeclarations(
+      cssRuleBlock(mobileRules, ".transport--mobile .transport__controls"),
+    );
+    const fixedButtonDeclarations = cssDeclarations(
+      cssBlock(mobileRules, ".transport--mobile .transport__button--play,"),
+    );
+    const fixedTimelineDeclarations = cssDeclarations(
+      cssRuleBlock(mobileRules, ".transport--mobile .transport__timeline"),
+    );
+    const fixedScrubberDeclarations = cssDeclarations(
+      cssRuleBlock(mobileRules, ".transport--mobile .transport__scrubber"),
+    );
+    const fixedRangeDeclarations = cssDeclarations(
+      cssRuleBlock(mobileRules, '.transport--mobile .transport__scrubber input[type="range"]'),
+    );
+    const fixedStatusDeclarations = cssDeclarations(
+      cssRuleBlock(mobileRules, ".transport--mobile .transport__status-stack"),
+    );
+
+    expect(transportDeclarations).toMatchObject({
+      "grid-template-columns": "minmax(0, 1fr)",
+      "grid-template-rows": "3rem 3rem",
+    });
+    expect(buttonDeclarations).toMatchObject({
+      "--transport-button-size": "3rem",
+      "min-block-size": "3rem",
+      "min-inline-size": "3rem",
+    });
+    expect(scrubberDeclarations).toMatchObject({
+      "grid-column": "2",
+      "grid-row": "1",
+      "min-block-size": "3rem",
+    });
+    expect(timelineDeclarations).toMatchObject({
+      display: "grid",
+      "grid-template-columns": "minmax(0, 1fr)",
+      "grid-template-rows": "3rem",
+      overflow: "visible",
+    });
+    expect(mobileScrubberDeclarations).toMatchObject({
+      "grid-template-columns": "auto minmax(3rem, 1fr) auto",
+      "grid-template-rows": "3rem",
+    });
+    expect(timesDeclarations).toMatchObject({ display: "contents" });
+    expect(statusDeclarations).toMatchObject({
+      background: "transparent",
+      overflow: "visible",
+      "overflow-wrap": "anywhere",
+    });
+    expect(statusDeclarations).not.toHaveProperty("inset");
+    expect(statusDeclarations).not.toHaveProperty("position");
+    expect(statusStackDeclarations).toMatchObject({
+      "grid-column": "2",
+      "grid-row": "1",
+      "max-block-size": "3rem",
+      "overflow-y": "auto",
+    });
+    expect(statusTimelineDeclarations).toMatchObject({
+      "grid-template-columns": "minmax(0, 1fr) minmax(5rem, min(9rem, 38vw))",
+    });
+    expect(dockDeclarations).toMatchObject({
+      "max-block-size": "128px",
+      overflow: "hidden",
+    });
+    expect(fixedTransportDeclarations).toMatchObject({
+      "grid-template-rows": "48px 48px",
+      gap: "5.6px",
+    });
+    expect(fixedControlsDeclarations).toMatchObject({
+      "grid-template-columns": "repeat(5, minmax(48px, 1fr))",
+      gap: "clamp(3.2px, 1.6vw, 8px)",
+    });
+    expect(fixedButtonDeclarations).toMatchObject({
+      "--transport-button-size": "48px",
+      "min-block-size": "48px",
+      "min-inline-size": "48px",
+    });
+    expect(fixedTimelineDeclarations).toMatchObject({ "grid-template-rows": "48px" });
+    expect(fixedScrubberDeclarations).toMatchObject({
+      "grid-template-columns": "auto minmax(48px, 1fr) auto",
+      "grid-template-rows": "48px",
+    });
+    expect(fixedRangeDeclarations).toMatchObject({ "min-block-size": "48px" });
+    expect(fixedStatusDeclarations).toMatchObject({ "max-block-size": "48px" });
+  });
+
+  it("gives the large-text drawer capo selector a dedicated chevron row", () => {
+    const triggerDeclarations = cssDeclarations(
+      cssRuleBlock(
+        projectPlaybackCss,
+        ".mobile-practice-controls .key-stepper--small .target-selector__trigger",
+      ),
+    );
+    const chevronDeclarations = cssDeclarations(
+      cssRuleBlock(
+        projectPlaybackCss,
+        ".mobile-practice-controls .key-stepper--small .target-selector__chevron",
+      ),
+    );
+    const drawerTargetDeclarations = cssDeclarations(
+      cssRuleBlock(
+        projectPlaybackCss,
+        ".mobile-practice-controls .playback-practice-rail--drawer :is(button, input, select)",
+      ),
+    );
+
+    expect(triggerDeclarations).toMatchObject({
+      "grid-template-columns": "minmax(0, 0.55fr) minmax(0, 1.6fr) minmax(0, 0.55fr)",
+      "grid-template-rows": "minmax(3rem, max-content) minmax(1rem, max-content)",
+    });
+    expect(chevronDeclarations).toMatchObject({
+      position: "static",
+      "grid-column": "2",
+      "grid-row": "2",
+      transform: "none",
+    });
+    expect(drawerTargetDeclarations).toMatchObject({ "min-block-size": "3rem" });
+  });
+
+  it("keeps drawer content scrollable and its close control reachable at large text", () => {
+    const drawerDeclarations = cssDeclarations(
+      cssRuleBlock(projectPlaybackCss, ".mobile-practice-controls"),
+    );
+    const headerDeclarations = cssDeclarations(
+      cssRuleBlock(projectPlaybackCss, ".mobile-practice-controls__header"),
+    );
+    const closeDeclarations = cssDeclarations(
+      cssRuleBlock(projectPlaybackCss, ".mobile-practice-controls__close"),
+    );
+    const railContentDeclarations = cssDeclarations(
+      cssRuleBlock(
+        projectPlaybackCss,
+        ".mobile-practice-controls .playback-practice-rail--drawer .playback-practice-rail__content",
+      ),
+    );
+
+    expect(drawerDeclarations).toMatchObject({
+      "max-block-size": "calc(100dvh - var(--safe-area-top) - 0.5rem)",
+      overflow: "hidden",
+    });
+    expect(headerDeclarations).toMatchObject({
+      "grid-template-columns": "minmax(0, 1fr) 3rem",
+      flex: "0 0 auto",
+    });
+    expect(closeDeclarations).toMatchObject({
+      "min-block-size": "3rem",
+      "min-inline-size": "3rem",
+    });
+    expect(railContentDeclarations).toMatchObject({
+      "overflow-x": "hidden",
+      "overflow-y": "auto",
+      "overscroll-behavior": "contain",
+    });
+  });
+
   it("keeps narrow Practice header and controls outside clipped nested scrolling", () => {
     const narrowRules = cssBlock(projectPlaybackCss, "@media (max-width: 720px)");
     const headerDeclarations = cssDeclarations(
@@ -87,6 +505,62 @@ describe("project Playback responsive CSS", () => {
     expect(headerDeclarations).not.toMatchObject({
       "max-height": "4.25rem",
       overflow: "auto",
+    });
+  });
+
+  it("places mobile Follow beside the reflowing heading above the full-width mode selector", () => {
+    const mobileRules = cssBlock(
+      projectPlaybackCss,
+      "@media (max-width: 720px) and (min-width: 0px)",
+    );
+    const headingDeclarations = cssDeclarations(
+      cssRuleBlock(
+        mobileRules,
+        ".playback-workspace--practice:has(.transport--mobile) .playback-practice-surface__heading",
+      ),
+    );
+    const followDeclarations = cssDeclarations(
+      cssRuleBlock(
+        mobileRules,
+        ".playback-workspace--practice:has(.transport--mobile) .playback-follow-chip",
+      ),
+    );
+    const explanationDeclarations = cssDeclarations(
+      cssRuleBlock(
+        mobileRules,
+        ".playback-workspace--practice:has(.transport--mobile) .playback-follow-explanation",
+      ),
+    );
+    const modeDeclarations = cssDeclarations(
+      cssRuleBlock(
+        mobileRules,
+        ".playback-workspace--practice:has(.transport--mobile) .playback-mode-toggle",
+      ),
+    );
+
+    expect(headingDeclarations).toMatchObject({
+      display: "grid",
+      "grid-template-columns": "minmax(0, 1fr) auto",
+      "min-width": "0",
+    });
+    expect(headingDeclarations).not.toHaveProperty("max-height");
+    expect(headingDeclarations).not.toHaveProperty("overflow");
+    expect(followDeclarations).toMatchObject({
+      "justify-self": "end",
+      "min-block-size": "48px",
+      "min-inline-size": "48px",
+      "max-inline-size": "100%",
+      "overflow-wrap": "anywhere",
+      "white-space": "normal",
+    });
+    expect(explanationDeclarations).toMatchObject({
+      "grid-column": "1 / -1",
+      "min-width": "0",
+      "overflow-wrap": "anywhere",
+    });
+    expect(modeDeclarations).toMatchObject({
+      "grid-template-columns": "repeat(3, minmax(0, 1fr))",
+      "inline-size": "100%",
     });
   });
 

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -11,6 +11,26 @@ The mobile app includes its backend inside the Tauri app. It does not run the de
 
 The frontend talks through a `TuneForgeClient` boundary. Desktop uses the existing generated OpenAPI HTTP client. Mobile uses Tauri commands that return the same project, job, artifact, lyrics, chord, and analysis response shapes where possible.
 
+## Mobile Playback
+
+Android Playback uses a practice-first layout at compact portrait sizes. Its app bar keeps the
+project identity, Library navigation, Practice Controls, and an overflow menu visible without
+reusing the desktop workspace tabs. The practice area scrolls independently above a fixed,
+two-row transport so seeking and play/pause controls remain available while lyrics or chords move.
+
+The mobile practice view has explicit `Lyrics`, `Chords`, and `Both` modes. `Follow` tracks the
+active mode: it follows timed lyrics in `Lyrics` and `Both`, and follows the active chord in
+`Chords`. Lyrics follow stays unavailable when the transcript has no timing data.
+
+`Practice Controls` opens the existing practice controls in a mobile sheet: transpose/capo,
+count-in and loop alignment, tempo, source and mix selection, and available stem controls.
+Less-frequent actions live in the app-bar overflow, including returning to the Project workspace,
+editing lyrics when a transcript exists, and importing a tab. Device capability gates still apply;
+the sheet does not make unavailable mobile generation paths available.
+
+These changes are mobile-runtime behavior only. Desktop Playback keeps its existing workspace tabs,
+practice rail, display toggles, follow controls, and transport layout.
+
 ## Android Embedded Backend
 
 Rust owns mobile project persistence, artifact records, job records, and app data paths. Kotlin/Android or Rust NDK bindings are the intended bridge for platform-only work:

--- a/scripts/capture-release-media.mjs
+++ b/scripts/capture-release-media.mjs
@@ -44,6 +44,22 @@ const releaseMediaCaptureCatalog = [
     capture: captureScreenshotEntry,
   },
   {
+    id: "mobile-playback",
+    enabled: true,
+    kind: "screenshot",
+    fileName: "mobile-playback.png",
+    title: "Mobile Playback practice view",
+    caption: "Compact Playback keeps synthetic lyrics, chords, and transport controls ready for practice.",
+    alt: "TuneForge mobile Playback ready screen showing synthetic lyrics and chords",
+    fixture: "release-showcase-mobile-playback-v1",
+    runtime: "mobile",
+    viewport: { width: 411, height: 891 },
+    route: "/projects/proj_release_showcase",
+    prepare: prepareMobilePlayback,
+    ready: readyMobilePlayback,
+    capture: captureScreenshotEntry,
+  },
+  {
     id: "tuner",
     enabled: true,
     kind: "screenshot",
@@ -502,9 +518,18 @@ async function waitForHttp(url, { child, timeoutMs }) {
   throw new Error(`Timed out waiting for ${url}: ${errorMessage(lastError)}\n${child.tail()}`);
 }
 
-async function installPageStabilizers(page, options, captureKind) {
+async function installPageStabilizers(
+  page,
+  options,
+  captureKind,
+  entry = null,
+  mobileFixtureOptions = {},
+) {
   const motionPolicy = captureMotionPolicy(captureKind);
-  await page.addInitScript(({ animatePlayback, theme }) => {
+  const mobileFixture = entry?.runtime === "mobile"
+    ? mobilePlaybackFixture(mobileFixtureOptions)
+    : null;
+  await page.addInitScript(({ animatePlayback, mobileFixture, theme }) => {
     const fixedNow = Date.parse("2026-04-18T13:16:00.000Z");
     let callbackId = 1;
     const callbacks = new Map();
@@ -734,7 +759,46 @@ async function installPageStabilizers(page, options, captureKind) {
         return "http://127.0.0.1:8765";
       }
       if (command === "mobile_capabilities") {
+        if (mobileFixture) {
+          return mobileFixture.capabilities;
+        }
         throw new Error("Mobile runtime unavailable in release media capture.");
+      }
+      if (mobileFixture && command === "mobile_get_health") {
+        return mobileFixture.health;
+      }
+      if (mobileFixture && command === "mobile_get_project") {
+        return mobileFixture.project;
+      }
+      if (mobileFixture && command === "mobile_get_analysis") {
+        return mobileFixture.analysis;
+      }
+      if (mobileFixture && command === "mobile_get_chords") {
+        return mobileFixture.chords;
+      }
+      if (mobileFixture && command === "mobile_get_lyrics") {
+        return mobileFixture.lyrics;
+      }
+      if (mobileFixture && command === "mobile_list_artifacts") {
+        return mobileFixture.artifacts;
+      }
+      if (mobileFixture && command === "mobile_list_jobs") {
+        const params = args?.params ?? {};
+        const statuses = Array.isArray(params.status) ? params.status : [];
+        const filtered = mobileFixture.jobs.filter((job) =>
+          (!params.project_id || job.project_id === params.project_id) &&
+          (!statuses.length || statuses.includes(job.status)),
+        );
+        const offset = Number(params.offset ?? 0);
+        const limit = Number(params.limit ?? 50);
+        const page = filtered.slice(offset, offset + limit);
+        return {
+          jobs: page,
+          total: filtered.length,
+          limit,
+          offset,
+          has_more: offset + page.length < filtered.length,
+        };
       }
       if (command === "audio_get_capabilities") {
         return {
@@ -956,7 +1020,7 @@ async function installPageStabilizers(page, options, captureKind) {
         }
       },
     };
-  }, { animatePlayback: motionPolicy.animatePlayback, theme: options.theme });
+  }, { animatePlayback: motionPolicy.animatePlayback, mobileFixture, theme: options.theme });
 }
 
 function captureMotionPolicy(captureKind) {
@@ -966,15 +1030,215 @@ function captureMotionPolicy(captureKind) {
   return { animatePlayback: captureKind === "video" };
 }
 
-async function createCaptureContext(browser, options, { recordVideo = false } = {}) {
+async function measureMobilePlaybackFollowLayouts(scenarios, { timeoutMs = 45_000 } = {}) {
+  if (!Array.isArray(scenarios) || scenarios.length === 0) {
+    throw new Error("Mobile Playback layout measurement requires at least one scenario.");
+  }
+
+  const mobileEntry = releaseMediaCaptureCatalog.find((entry) => entry.id === "mobile-playback");
+  if (!mobileEntry) {
+    throw new Error("Mobile Playback layout measurement requires the mobile-playback fixture.");
+  }
+
+  const { chromium } = loadPlaywright();
+  const port = await selectPort();
+  const appUrl = `http://127.0.0.1:${port}`;
+  const child = startDesktopDevServer(port);
+  let browser = null;
+
+  try {
+    await waitForHttp(appUrl, { child, timeoutMs });
+    browser = await chromium.launch({ headless: true });
+    const measurements = [];
+
+    for (const scenario of scenarios) {
+      const width = Number(scenario.width);
+      const height = Number(scenario.height ?? mobileEntry.viewport.height);
+      const textScale = Number(scenario.textScale ?? 1);
+      if (
+        !Number.isInteger(width) ||
+        !Number.isInteger(height) ||
+        width < 320 ||
+        height < 320 ||
+        !Number.isFinite(textScale) ||
+        textScale <= 0
+      ) {
+        throw new Error(`Invalid Mobile Playback layout scenario ${JSON.stringify(scenario)}.`);
+      }
+
+      const entry = { ...mobileEntry, viewport: { width, height } };
+      const context = await createCaptureContext(browser, {
+        outputDir: defaultOutputDir,
+        theme: "dark",
+        viewport: entry.viewport,
+      }, { entry });
+      try {
+        const page = await context.newPage();
+        await installPageStabilizers(page, { theme: "dark" }, "screenshot", entry, {
+          timedLyrics: scenario.followAvailable !== false,
+        });
+        await page.goto(`${appUrl}/#${entry.route}`, { waitUntil: "domcontentloaded" });
+        await page.waitForLoadState("networkidle", { timeout: timeoutMs });
+        await prepareMobilePlayback({ page, timeoutMs });
+        await page.getByRole("heading", { name: "Midnight Count-In" })
+          .waitFor({ timeout: timeoutMs });
+        await page.getByRole("button", { name: /^Follow/ })
+          .waitFor({ state: "visible", timeout: timeoutMs });
+        await page.getByRole("group", { name: "Playback display mode" })
+          .waitFor({ state: "visible", timeout: timeoutMs });
+        if (textScale !== 1) {
+          await page.addStyleTag({
+            content: `:root { font-size: ${textScale * 100}% !important; }`,
+          });
+        }
+        await settleScreenshotPaint(page);
+
+        const measurement = await page.evaluate(() => {
+          const requiredElement = (selector) => {
+            const element = document.querySelector(selector);
+            if (!(element instanceof HTMLElement)) {
+              throw new Error(`Missing Mobile Playback layout target ${selector}.`);
+            }
+            const rect = element.getBoundingClientRect();
+            const style = window.getComputedStyle(element);
+            return {
+              rect: {
+                bottom: rect.bottom,
+                height: rect.height,
+                left: rect.left,
+                right: rect.right,
+                top: rect.top,
+                width: rect.width,
+              },
+              visible:
+                style.display !== "none" &&
+                style.visibility !== "hidden" &&
+                rect.width > 0 &&
+                rect.height > 0,
+            };
+          };
+          const overflow = (selector) => {
+            const element = document.querySelector(selector);
+            if (!(element instanceof HTMLElement)) {
+              throw new Error(`Missing Mobile Playback overflow target ${selector}.`);
+            }
+            return {
+              clientHeight: element.clientHeight,
+              clientWidth: element.clientWidth,
+              scrollHeight: element.scrollHeight,
+              scrollWidth: element.scrollWidth,
+            };
+          };
+          const requiredElements = (selector) => {
+            const elements = [...document.querySelectorAll(selector)];
+            if (!elements.length || elements.some((element) => !(element instanceof HTMLElement))) {
+              throw new Error(`Missing Mobile Playback layout targets ${selector}.`);
+            }
+            return elements.map((element) => {
+              const rect = element.getBoundingClientRect();
+              return {
+                bottom: rect.bottom,
+                height: rect.height,
+                left: rect.left,
+                right: rect.right,
+                top: rect.top,
+                width: rect.width,
+              };
+            });
+          };
+          const explanation = document.querySelector(".playback-follow-explanation");
+          const clippingAncestors = [];
+          if (explanation instanceof HTMLElement) {
+            let ancestor = explanation.parentElement;
+            while (ancestor) {
+              const style = window.getComputedStyle(ancestor);
+              const clips = [style.overflow, style.overflowX, style.overflowY]
+                .some((value) => ["auto", "clip", "hidden", "scroll"].includes(value));
+              if (clips) {
+                const rect = ancestor.getBoundingClientRect();
+                clippingAncestors.push({
+                  bottom: rect.bottom,
+                  className: ancestor.className || ancestor.tagName.toLowerCase(),
+                  left: rect.left,
+                  right: rect.right,
+                  top: rect.top,
+                });
+              }
+              ancestor = ancestor.parentElement;
+            }
+          }
+
+          return {
+            appBar: {
+              actions: requiredElements(
+                ".mobile-playback-app-bar__back, " +
+                  ".mobile-playback-app-bar__practice-controls, " +
+                  ".mobile-playback-overflow__trigger",
+              ),
+              container: requiredElement(".mobile-playback-app-bar").rect,
+              overflow: overflow(".mobile-playback-app-bar"),
+              title: requiredElement(".mobile-playback-app-bar__identity h1").rect,
+            },
+            clippingAncestors,
+            explanation: explanation instanceof HTMLElement
+              ? requiredElement(".playback-follow-explanation")
+              : null,
+            follow: requiredElement(".playback-follow-chip"),
+            heading: requiredElement(".playback-practice-surface__heading > div"),
+            headingGrid: requiredElement(".playback-practice-surface__heading"),
+            mode: requiredElement(".playback-mode-toggle"),
+            practiceBody: requiredElement(".playback-practice-body"),
+            overflow: {
+              header: overflow(".playback-practice-surface__header"),
+              surface: overflow(".playback-practice-surface"),
+            },
+            containers: {
+              header: requiredElement(".playback-practice-surface__header").rect,
+              surface: requiredElement(".playback-practice-surface").rect,
+            },
+            transport: {
+              buttons: requiredElements(".transport--mobile .transport__button"),
+              container: requiredElement(".transport--mobile").rect,
+              controls: requiredElement(".transport--mobile .transport__controls").rect,
+              dock: requiredElement(".playback-transport-dock").rect,
+              overflow: {
+                container: overflow(".transport--mobile"),
+                controls: overflow(".transport--mobile .transport__controls"),
+                dock: overflow(".playback-transport-dock"),
+                timeline: overflow(".transport--mobile .transport__timeline"),
+              },
+              range: requiredElement('.transport--mobile input[type="range"]').rect,
+              scrubber: requiredElement(".transport--mobile .transport__scrubber").rect,
+              timeline: requiredElement(".transport--mobile .transport__timeline").rect,
+            },
+            viewport: { height: window.innerHeight, width: window.innerWidth },
+          };
+        });
+        measurements.push({ ...scenario, measurement });
+      } finally {
+        await context.close();
+      }
+    }
+
+    return measurements;
+  } finally {
+    if (browser) {
+      await browser.close();
+    }
+    await stopChildren([child]);
+  }
+}
+
+async function createCaptureContext(browser, options, { entry = null, recordVideo = false } = {}) {
+  const viewport = entry?.viewport ?? options.viewport;
   const context = await browser.newContext({
     colorScheme: options.theme === "light" ? "light" : "dark",
     deviceScaleFactor: 1,
     reducedMotion: "reduce",
     recordVideo: recordVideo
-      ? { dir: options.outputDir, size: options.viewport }
+      ? { dir: options.outputDir, size: viewport }
       : undefined,
-    viewport: options.viewport,
+    viewport,
   });
   await context.route("**/*", async (route) => {
     const handled = await maybeFulfillMockApi(route);
@@ -991,11 +1255,11 @@ async function captureCatalogScreenshots({ appUrl, browser, catalog, entries, no
   }
 
   const capturedItems = [];
-  const context = await createCaptureContext(browser, options);
-  try {
-    const page = await context.newPage();
-    await installPageStabilizers(page, options, "screenshot");
-    for (const entry of entries) {
+  for (const entry of entries) {
+    const context = await createCaptureContext(browser, options, { entry });
+    try {
+      const page = await context.newPage();
+      await installPageStabilizers(page, options, "screenshot", entry);
       try {
         await entry.capture({ appUrl, entry, options, page });
         capturedItems.push(manifestItemForCatalogEntry(entry, catalog));
@@ -1004,9 +1268,9 @@ async function captureCatalogScreenshots({ appUrl, browser, catalog, entries, no
         notes.push(`${entry.id} capture skipped: ${message}`);
         console.warn(`[capture-release-media] ${entry.id} skipped: ${message}`);
       }
+    } finally {
+      await context.close();
     }
-  } finally {
-    await context.close();
   }
   return capturedItems;
 }
@@ -1068,6 +1332,14 @@ async function preparePlayback({ captureKind, page, timeoutMs }) {
   await playButton.click();
 }
 
+async function prepareMobilePlayback({ page, timeoutMs }) {
+  const bothMode = page.getByRole("button", { name: "Both", exact: true });
+  await bothMode.waitFor({ state: "visible", timeout: timeoutMs });
+  if (await bothMode.getAttribute("aria-pressed") !== "true") {
+    await bothMode.click();
+  }
+}
+
 async function prepareTuner({ page, timeoutMs }) {
   const startButton = page.getByRole("button", { name: "Start" });
   await startButton.waitFor({ timeout: timeoutMs });
@@ -1098,6 +1370,109 @@ async function readyPlayback({ captureKind, page, timeoutMs }) {
     }
   } else {
     await page.getByRole("button", { name: "Pause playback" }).waitFor({ timeout: timeoutMs });
+  }
+}
+
+async function readyMobilePlayback({ page, timeoutMs }) {
+  const appBar = page.locator(".mobile-playback-app-bar");
+  const modeSelector = page.getByRole("group", { name: "Playback display mode" });
+  const practiceScroller = page.locator(".playback-practice-body");
+  const transport = page.locator(".playback-transport-dock");
+
+  await appBar.waitFor({ state: "visible", timeout: timeoutMs });
+  await page.getByRole("heading", { name: "Midnight Count-In" }).waitFor({ timeout: timeoutMs });
+  await page.getByRole("button", { name: "Open Practice Controls" })
+    .waitFor({ timeout: timeoutMs });
+  await page.getByRole("button", { name: "More playback actions" })
+    .waitFor({ timeout: timeoutMs });
+  await modeSelector.waitFor({ state: "visible", timeout: timeoutMs });
+  for (const mode of ["Lyrics", "Chords", "Both"]) {
+    await modeSelector.getByRole("button", { name: mode, exact: true })
+      .waitFor({ state: "visible", timeout: timeoutMs });
+  }
+  await page.getByRole("button", { name: "Follow" }).waitFor({ timeout: timeoutMs });
+  await practiceScroller.waitFor({ state: "visible", timeout: timeoutMs });
+  await page.locator(".lead-sheet-word .lyrics-word", { hasText: /^Count$/ })
+    .waitFor({ timeout: timeoutMs });
+  await transport.waitFor({ state: "visible", timeout: timeoutMs });
+  await page.getByRole("button", { name: "Play playback" }).waitFor({ timeout: timeoutMs });
+
+  const geometry = await page.evaluate(() => {
+    const requiredElement = (selector) => {
+      const element = document.querySelector(selector);
+      if (!(element instanceof HTMLElement)) {
+        throw new Error(`Missing mobile Playback geometry target ${selector}.`);
+      }
+      const rect = element.getBoundingClientRect();
+      const style = window.getComputedStyle(element);
+      if (
+        style.display === "none" ||
+        style.visibility === "hidden" ||
+        rect.width <= 0 ||
+        rect.height <= 0
+      ) {
+        throw new Error(`Mobile Playback geometry target ${selector} is not visible.`);
+      }
+      return {
+        bottom: rect.bottom,
+        height: rect.height,
+        left: rect.left,
+        right: rect.right,
+        top: rect.top,
+      };
+    };
+
+    return {
+      appBar: requiredElement(".mobile-playback-app-bar"),
+      modeSelector: requiredElement(".playback-mode-toggle"),
+      practiceScroller: requiredElement(".playback-practice-body"),
+      transport: requiredElement(".playback-transport-dock"),
+      viewport: { height: window.innerHeight, width: window.innerWidth },
+    };
+  });
+
+  const tolerance = 1;
+  const viewportContained = (rect) =>
+    rect.top >= -tolerance &&
+    rect.left >= -tolerance &&
+    rect.right <= geometry.viewport.width + tolerance &&
+    rect.bottom <= geometry.viewport.height + tolerance;
+  for (const [name, rect] of Object.entries({
+    appBar: geometry.appBar,
+    modeSelector: geometry.modeSelector,
+    practiceScroller: geometry.practiceScroller,
+    transport: geometry.transport,
+  })) {
+    if (!viewportContained(rect)) {
+      throw new Error(
+        `Mobile Playback ${name} must remain inside the capture viewport; ` +
+          `received ${JSON.stringify(rect)} in ${geometry.viewport.width}x${geometry.viewport.height}.`,
+      );
+    }
+  }
+  if (geometry.transport.height > 128 + tolerance) {
+    throw new Error(
+      `Mobile Playback transport must be at most 128 CSS px; received ${geometry.transport.height.toFixed(1)}.`,
+    );
+  }
+  if (geometry.appBar.bottom > geometry.modeSelector.top + tolerance) {
+    throw new Error("Mobile Playback app bar overlaps the mode selector.");
+  }
+  if (geometry.modeSelector.bottom > geometry.practiceScroller.top + tolerance) {
+    throw new Error("Mobile Playback mode selector overlaps the practice scroller.");
+  }
+  if (geometry.practiceScroller.bottom > geometry.transport.top + tolerance) {
+    throw new Error("Mobile Playback practice scroller overlaps the transport.");
+  }
+  if (geometry.practiceScroller.height < geometry.transport.height * 2) {
+    throw new Error("Mobile Playback practice scroller must materially dominate the transport.");
+  }
+
+  const position = page.getByLabel("Playback position");
+  await position.waitFor({ timeout: timeoutMs });
+  const value = Number(await position.inputValue());
+  if (value !== 0) {
+    throw new Error(`Mobile Playback screenshot must stay stopped at 0 seconds; received ${value}.`);
   }
 }
 
@@ -1170,6 +1545,15 @@ function validateReleaseMediaCatalog(catalog) {
       for (const callback of ["prepare", "ready", "capture"]) {
         if (typeof entry[callback] !== "function") {
           throw new Error(`Screenshot ${entry.id} requires a ${callback} callback.`);
+        }
+      }
+      if (entry.runtime !== undefined && !["desktop", "mobile"].includes(entry.runtime)) {
+        throw new Error(`Screenshot ${entry.id} has unsupported runtime ${entry.runtime}.`);
+      }
+      if (entry.viewport !== undefined) {
+        const { width, height } = entry.viewport;
+        if (!Number.isInteger(width) || !Number.isInteger(height) || width < 320 || height < 320) {
+          throw new Error(`Screenshot ${entry.id} requires a viewport of at least 320x320.`);
         }
       }
     } else if (entry.kind === "video") {
@@ -1423,6 +1807,45 @@ function project(id, displayName, sourcePath, durationSeconds, extra = {}) {
     created_at: fixtureTimestamp,
     updated_at: fixtureTimestamp,
     ...extra,
+  };
+}
+
+function mobilePlaybackFixture({ timedLyrics = true } = {}) {
+  const projectId = "proj_release_showcase";
+  const fixtureProject = projects().find((candidate) => candidate.id === projectId);
+  if (!fixtureProject) {
+    throw new Error(`Release media mobile fixture requires project ${projectId}.`);
+  }
+  const fixtureLyrics = lyrics(projectId);
+  const untimedSegments = fixtureLyrics.segments.map((segment) => ({
+    ...segment,
+    start_seconds: null,
+    end_seconds: null,
+    words: [],
+  }));
+  return {
+    capabilities: {
+      platform: "android",
+      mediaBackend: "android_media_codec",
+      isEmulator: true,
+      gpuBackend: null,
+      analysisAvailable: true,
+      basicChordsAvailable: true,
+      whisperAvailable: false,
+      stemSeparationAvailable: false,
+      generationTestingAvailable: false,
+      maxRecommendedModel: null,
+      cpuFallbackAllowed: false,
+    },
+    health: healthResponse(),
+    project: { project: fixtureProject },
+    analysis: { analysis: analysis(projectId) },
+    chords: chords(projectId),
+    lyrics: timedLyrics
+      ? fixtureLyrics
+      : { ...fixtureLyrics, source_segments: untimedSegments, segments: untimedSegments },
+    artifacts: { artifacts: artifacts(projectId) },
+    jobs: jobs().filter((job) => job.project_id === projectId),
   };
 }
 
@@ -1781,6 +2204,7 @@ export {
   chordBackends,
   expectedCatalogEntries,
   manifestItemForCatalogEntry,
+  measureMobilePlaybackFollowLayouts,
   parseOptions,
   releaseMediaCaptureCatalog,
   validateReleaseMediaCatalog,

--- a/scripts/capture-release-media.test.mjs
+++ b/scripts/capture-release-media.test.mjs
@@ -32,8 +32,8 @@ test("capture motion policy freezes screenshots and preserves video movement", (
 
 test("release-media catalog has unique identifiers, files, and required callbacks", () => {
   assert.equal(validateReleaseMediaCatalog(releaseMediaCaptureCatalog), releaseMediaCaptureCatalog);
-  assert.equal(releaseMediaCaptureCatalog.length, 7);
-  assert.equal(releaseMediaCaptureCatalog.filter((entry) => entry.kind === "screenshot").length, 6);
+  assert.equal(releaseMediaCaptureCatalog.length, 8);
+  assert.equal(releaseMediaCaptureCatalog.filter((entry) => entry.kind === "screenshot").length, 7);
   assert.equal(releaseMediaCaptureCatalog.filter((entry) => entry.kind === "video").length, 1);
 
   const ids = releaseMediaCaptureCatalog.map((entry) => entry.id);
@@ -59,6 +59,18 @@ test("release-media catalog has unique identifiers, files, and required callback
   }
 });
 
+test("mobile Playback is one deterministic compact screenshot fixture", () => {
+  const mobileScreenshots = releaseMediaCaptureCatalog.filter(
+    (entry) => entry.kind === "screenshot" && entry.runtime === "mobile",
+  );
+
+  assert.equal(mobileScreenshots.length, 1);
+  assert.equal(mobileScreenshots[0].id, "mobile-playback");
+  assert.equal(mobileScreenshots[0].fixture, "release-showcase-mobile-playback-v1");
+  assert.deepEqual(mobileScreenshots[0].viewport, { width: 411, height: 891 });
+  assert.equal(mobileScreenshots[0].route, "/projects/proj_release_showcase");
+});
+
 test("catalog validation rejects duplicate identifiers and output files", () => {
   const duplicateId = cloneCatalog();
   duplicateId[1].id = duplicateId[0].id;
@@ -67,6 +79,25 @@ test("catalog validation rejects duplicate identifiers and output files", () => 
   const duplicateFile = cloneCatalog();
   duplicateFile[1].fileName = duplicateFile[0].fileName;
   assert.throws(() => validateReleaseMediaCatalog(duplicateFile), /duplicate file library\.png/);
+});
+
+test("catalog validation rejects invalid screenshot runtimes and viewports", () => {
+  const invalidRuntime = cloneCatalog();
+  invalidRuntime.find((entry) => entry.id === "mobile-playback").runtime = "tablet";
+  assert.throws(
+    () => validateReleaseMediaCatalog(invalidRuntime),
+    /unsupported runtime tablet/,
+  );
+
+  const invalidViewport = cloneCatalog();
+  invalidViewport.find((entry) => entry.id === "mobile-playback").viewport = {
+    width: 311,
+    height: 891,
+  };
+  assert.throws(
+    () => validateReleaseMediaCatalog(invalidViewport),
+    /requires a viewport of at least 320x320/,
+  );
 });
 
 test("video poster references resolve to enabled screenshots", () => {
@@ -180,6 +211,7 @@ test("importing capture script has no capture or console side effects", () => {
 function cloneCatalog() {
   return releaseMediaCaptureCatalog.map((entry) => ({
     ...entry,
+    viewport: entry.viewport ? { ...entry.viewport } : undefined,
     recordingItemIds: entry.recordingItemIds ? [...entry.recordingItemIds] : undefined,
   }));
 }

--- a/scripts/mobile-playback-follow-layout.test.mjs
+++ b/scripts/mobile-playback-follow-layout.test.mjs
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { measureMobilePlaybackFollowLayouts } from "./capture-release-media.mjs";
+
+const scenarios = [
+  { name: "360 CSS px", width: 360 },
+  { name: "411 CSS px", width: 411 },
+  {
+    name: "360 CSS px at 200% text with Follow unavailable",
+    width: 360,
+    textScale: 2,
+    followAvailable: false,
+  },
+];
+
+test("mobile Follow relocation remains usable in real Chromium layout", { timeout: 120_000 }, async () => {
+  const results = await measureMobilePlaybackFollowLayouts(scenarios);
+
+  for (const { name, width, followAvailable = true, measurement } of results) {
+    const {
+      appBar,
+      clippingAncestors,
+      containers,
+      explanation,
+      follow,
+      heading,
+      headingGrid,
+      mode,
+      overflow,
+      practiceBody,
+      transport,
+      viewport,
+    } = measurement;
+    assert.equal(viewport.width, width, name);
+    assert.equal(follow.visible, true, `${name}: Follow must remain visible`);
+    assert.ok(follow.rect.width >= 48, `${name}: Follow width must be at least 48 CSS px`);
+    assert.ok(follow.rect.height >= 48, `${name}: Follow height must be at least 48 CSS px`);
+
+    assert.equal(rectanglesOverlap(heading.rect, follow.rect), false, `${name}: heading overlaps Follow`);
+    assert.equal(rectanglesOverlap(heading.rect, mode.rect), false, `${name}: heading overlaps mode selector`);
+    assert.equal(rectanglesOverlap(follow.rect, mode.rect), false, `${name}: Follow overlaps mode selector`);
+    assert.ok(
+      headingGrid.rect.bottom <= mode.rect.top + 1,
+      `${name}: heading row must remain above mode selector`,
+    );
+    assert.ok(practiceBody.rect.height > 0, `${name}: practice body must remain usable`);
+
+    for (const [index, action] of appBar.actions.entries()) {
+      assert.ok(action.width >= 48, `${name}: app-bar action ${index + 1} is narrower than 48px`);
+      assert.ok(action.height >= 48, `${name}: app-bar action ${index + 1} is shorter than 48px`);
+      assert.equal(
+        rectangleContains(appBar.container, action),
+        true,
+        `${name}: app-bar action ${index + 1} escapes the app bar`,
+      );
+      assert.equal(
+        rectanglesOverlap(appBar.title, action),
+        false,
+        `${name}: app-bar title overlaps action ${index + 1}`,
+      );
+    }
+    assert.ok(
+      appBar.overflow.scrollWidth <= appBar.overflow.clientWidth + 1,
+      `${name}: app bar has horizontal overflow`,
+    );
+
+    assert.equal(
+      rectanglesOverlap(transport.controls, transport.timeline),
+      false,
+      `${name}: transport controls overlap timeline`,
+    );
+    for (const [part, rect] of Object.entries({
+      controls: transport.controls,
+      timeline: transport.timeline,
+      scrubber: transport.scrubber,
+      range: transport.range,
+    })) {
+      assert.equal(
+        rectangleContains(transport.dock, rect),
+        true,
+        `${name}: transport ${part} escapes the dock`,
+      );
+    }
+    for (const [index, button] of transport.buttons.entries()) {
+      assert.ok(button.width >= 48, `${name}: transport button ${index + 1} is narrower than 48px`);
+      assert.ok(button.height >= 48, `${name}: transport button ${index + 1} is shorter than 48px`);
+      assert.equal(
+        rectangleContains(transport.controls, button),
+        true,
+        `${name}: transport button ${index + 1} escapes the controls row`,
+      );
+    }
+    for (const [part, dimensions] of Object.entries(transport.overflow)) {
+      if (part === "controls") {
+        assert.ok(
+          dimensions.scrollWidth <= dimensions.clientWidth + 1,
+          `${name}: transport controls have horizontal overflow`,
+        );
+      } else {
+        assertNoOverflow(name, `transport ${part}`, dimensions);
+      }
+    }
+
+    for (const [container, dimensions] of Object.entries(overflow)) {
+      assert.ok(
+        dimensions.scrollWidth <= dimensions.clientWidth + 1,
+        `${name}: ${container} has horizontal overflow ` +
+          `(${dimensions.scrollWidth} > ${dimensions.clientWidth})`,
+      );
+    }
+
+    if (followAvailable) {
+      assert.equal(explanation, null, `${name}: available Follow must not show disabled copy`);
+    } else {
+      assert.equal(explanation?.visible, true, `${name}: disabled explanation must remain visible`);
+      assert.equal(
+        rectangleContains({ top: 0, left: 0, right: viewport.width, bottom: viewport.height }, explanation.rect),
+        true,
+        `${name}: disabled explanation must be inside the viewport`,
+      );
+      for (const [container, rect] of Object.entries(containers)) {
+        assert.equal(
+          rectangleContains(rect, explanation.rect),
+          true,
+          `${name}: disabled explanation is clipped by ${container}`,
+        );
+      }
+      for (const ancestor of clippingAncestors) {
+        assert.equal(
+          rectangleContains(ancestor, explanation.rect),
+          true,
+          `${name}: disabled explanation is clipped by ${ancestor.className}`,
+        );
+      }
+      assert.ok(
+        explanation.rect.bottom <= mode.rect.top + 1,
+        `${name}: disabled explanation overlaps mode selector`,
+      );
+    }
+  }
+});
+
+function rectanglesOverlap(first, second, tolerance = 1) {
+  return (
+    first.left < second.right - tolerance &&
+    first.right > second.left + tolerance &&
+    first.top < second.bottom - tolerance &&
+    first.bottom > second.top + tolerance
+  );
+}
+
+function assertNoOverflow(name, container, dimensions, tolerance = 1) {
+  assert.ok(
+    dimensions.scrollWidth <= dimensions.clientWidth + tolerance,
+    `${name}: ${container} has horizontal overflow ` +
+      `(${dimensions.scrollWidth} > ${dimensions.clientWidth})`,
+  );
+  assert.ok(
+    dimensions.scrollHeight <= dimensions.clientHeight + tolerance,
+    `${name}: ${container} has vertical overflow ` +
+      `(${dimensions.scrollHeight} > ${dimensions.clientHeight})`,
+  );
+}
+
+function rectangleContains(container, content, tolerance = 1) {
+  return (
+    content.left >= container.left - tolerance &&
+    content.right <= container.right + tolerance &&
+    content.top >= container.top - tolerance &&
+    content.bottom <= container.bottom + tolerance
+  );
+}


### PR DESCRIPTION
## Summary

- Add a touch-native mobile Playback workspace with compact chrome, fixed transport, and independent practice scrolling.
- Add explicit Lyrics, Chords, Both, and Follow controls plus accessible Practice Controls and overflow sheets.
- Preserve desktop Playback behavior while adding safe-area, touch-target, text-scaling, and deterministic release-media coverage.
- Update mobile behavior documentation.
- Closes #356

## Testing

- `pnpm --filter @tuneforge/desktop test -- src/App.mobile.test.tsx src/App.responsive-ui.test.tsx tests/project-playback-responsive-css.test.ts`
- `node --test scripts/mobile-playback-follow-layout.test.mjs`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm package:android:debug`
- Android emulator at 360x780: ready, playing, and 200% text with synthetic native-bridge fixtures
- Local site gallery visual check for the mobile Playback release capture
- `git diff --check origin/main...HEAD`
