### PR TITLE
feat(android): add native tuner capture

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -403,6 +403,8 @@ pub fn run() {
             native_audio::audio_list_input_devices,
             native_audio::audio_list_output_devices,
             native_audio::audio_get_input_state,
+            native_audio::audio_get_input_permission_status,
+            native_audio::audio_request_input_permission,
             native_audio::audio_start_input,
             native_audio::audio_stop_input,
             native_audio::audio_set_monitor,
@@ -460,6 +462,17 @@ pub fn run() {
         .expect("error while building tuneforge");
 
     app.run(|app_handle, event| {
+        #[cfg(target_os = "android")]
+        if matches!(
+            event,
+            tauri::RunEvent::WindowEvent {
+                event: tauri::WindowEvent::Suspended,
+                ..
+            }
+        ) {
+            let native_audio = app_handle.state::<native_audio::NativeAudioState>();
+            native_audio::stop_input_for_lifecycle(app_handle, native_audio.inner());
+        }
         if let tauri::RunEvent::Exit = event {
             let sync_transport = app_handle.state::<sync_transport::SyncTransportState>();
             sync_transport.shutdown();

--- a/apps/desktop/src-tauri/src/native_audio/capture.rs
+++ b/apps/desktop/src-tauri/src/native_audio/capture.rs
@@ -4,12 +4,12 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tauri::AppHandle;
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 use tauri::Emitter;
 
-use super::{AudioCapabilities, AUDIO_EVENT_INPUT_FRAME};
+use super::{AudioCapabilities, AUDIO_EVENT_INPUT_FRAME, AUDIO_EVENT_INPUT_STATE};
 
 const DEFAULT_INPUT_DEVICE_ID: &str = "default";
 const INPUT_FRAME_SAMPLES: usize = 2048;
@@ -72,6 +72,47 @@ pub struct AudioInputState {
     pub monitor_gain: f32,
     pub input_level: f32,
     pub sample_rate: Option<u32>,
+    pub capture_generation: u64,
+    pub capture_path: CapturePath,
+    pub permission_state: AudioInputPermissionState,
+    pub error: Option<AudioInputError>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+#[serde(rename_all = "kebab-case")]
+pub enum CapturePath {
+    None,
+    DesktopCpal,
+    AndroidAaudio,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+#[serde(rename_all = "kebab-case")]
+pub enum AudioInputPermissionState {
+    Prompt,
+    Prompting,
+    Granted,
+    Denied,
+    Blocked,
+    PrivacyBlocked,
+    Unavailable,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioInputError {
+    pub code: &'static str,
+    pub message: &'static str,
+    pub guidance: Option<&'static str>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioInputPermissionStatus {
+    pub state: AudioInputPermissionState,
+    pub error: Option<AudioInputError>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -82,6 +123,7 @@ pub struct AudioInputFrame {
     pub input_level: f32,
     pub samples: Vec<f32>,
     pub timestamp_ms: u64,
+    pub capture_generation: u64,
 }
 
 pub struct CaptureState {
@@ -91,36 +133,43 @@ pub struct CaptureState {
     monitor_gain: f32,
     input_level: f32,
     sample_rate: Option<u32>,
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    capture_generation: u64,
+    capture_path: CapturePath,
+    permission_state: AudioInputPermissionState,
+    error: Option<AudioInputError>,
+    permission_pending: bool,
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
     runtime: Option<CaptureRuntime>,
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 struct CaptureRuntime {
     stop_sender: mpsc::Sender<CaptureControl>,
     shared: Arc<Mutex<CaptureSharedState>>,
     worker_thread: Option<JoinHandle<()>>,
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(not(any(target_os = "android", target_os = "linux", target_os = "macos")))]
 struct CaptureRuntime;
 
 #[derive(Default)]
 struct CaptureSharedState {
     input_level: f32,
+    terminal_error: Option<AudioInputError>,
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 enum CaptureControl {
     Stop,
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 struct CaptureStreamStartup {
     effective_device_id: String,
     sample_rate: u32,
     stream: cpal::Stream,
     frame_receiver: mpsc::Receiver<AudioInputFrame>,
+    error_receiver: mpsc::Receiver<()>,
 }
 
 impl Default for CaptureState {
@@ -132,7 +181,12 @@ impl Default for CaptureState {
             monitor_gain: 0.0,
             input_level: 0.0,
             sample_rate: None,
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            capture_generation: 0,
+            capture_path: CapturePath::None,
+            permission_state: initial_permission_state(),
+            error: None,
+            permission_pending: false,
+            #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
             runtime: None,
         }
     }
@@ -184,26 +238,111 @@ impl CaptureState {
         request: AudioInputRequest,
     ) -> Result<AudioInputState, String> {
         self.stop_runtime();
+        self.clear_live_state();
+        self.capture_generation = self.capture_generation.wrapping_add(1).max(1);
+        self.error = None;
+        self.permission_pending = false;
         self.monitor_enabled = request.monitor_enabled.unwrap_or(false);
         self.monitor_gain = normalize_gain(request.monitor_gain);
         self.input_level = 0.0;
 
-        let (device_id, sample_rate, runtime) = start_desktop_input(app, request.device_id)?;
+        #[cfg(target_os = "android")]
+        {
+            self.permission_state = input_permission_status(true).state;
+            if self.permission_state != AudioInputPermissionState::Granted {
+                self.permission_pending = matches!(
+                    self.permission_state,
+                    AudioInputPermissionState::Prompt | AudioInputPermissionState::Prompting
+                );
+                self.error = permission_error(self.permission_state);
+                let state = self.state();
+                let _ = app.emit(AUDIO_EVENT_INPUT_STATE, state.clone());
+                return Ok(state);
+            }
+        }
+
+        let generation = self.capture_generation;
+        let (device_id, sample_rate, runtime) =
+            match start_native_input(app.clone(), request.device_id, generation) {
+                Ok(startup) => startup,
+                Err(_) => {
+                    self.error = Some(startup_error());
+                    let state = self.state();
+                    let _ = app.emit(AUDIO_EVENT_INPUT_STATE, state.clone());
+                    return Ok(state);
+                }
+            };
         self.active = true;
         self.device_id = Some(device_id);
         self.sample_rate = Some(sample_rate);
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        self.capture_path = current_capture_path();
+        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
         {
             self.runtime = Some(runtime);
         }
-        Ok(self.state())
+        let state = self.state();
+        let _ = app.emit(AUDIO_EVENT_INPUT_STATE, state.clone());
+        Ok(state)
     }
 
     pub fn stop(&mut self) -> AudioInputState {
         self.stop_runtime();
-        self.active = false;
-        self.input_level = 0.0;
-        self.sample_rate = None;
+        self.capture_generation = self.capture_generation.wrapping_add(1).max(1);
+        self.clear_live_state();
+        self.error = None;
+        self.permission_pending = false;
+        self.state()
+    }
+
+    #[cfg(target_os = "android")]
+    pub fn stop_for_background(&mut self, app: &AppHandle) {
+        if let Some(terminal) = self.take_background_terminal(background_error()) {
+            let _ = app.emit(AUDIO_EVENT_INPUT_STATE, terminal);
+        }
+    }
+
+    #[cfg(any(target_os = "android", test))]
+    fn take_background_terminal(&mut self, error: AudioInputError) -> Option<AudioInputState> {
+        if !self.active {
+            return None;
+        }
+        let terminal_generation = self.capture_generation;
+        self.stop_runtime();
+        self.clear_live_state();
+        self.permission_pending = false;
+        self.error = Some(error);
+        let terminal = self.state();
+        self.capture_generation = terminal_generation.wrapping_add(1).max(1);
+        Some(terminal)
+    }
+
+    pub fn refresh(&mut self, app: &AppHandle) -> AudioInputState {
+        #[cfg(target_os = "android")]
+        {
+            let permission = read_android_permission();
+            self.permission_state = permission;
+            if self.permission_pending {
+                self.permission_pending = matches!(
+                    permission,
+                    AudioInputPermissionState::Prompt | AudioInputPermissionState::Prompting
+                );
+                self.error = permission_error(permission);
+            }
+        }
+
+        let runtime_error = self.runtime_terminal_error();
+        if let Some(error) = runtime_error.or_else(|| {
+            if self.active && cfg!(target_os = "android") {
+                permission_error(self.permission_state)
+            } else {
+                None
+            }
+        }) {
+            self.stop_runtime();
+            self.clear_live_state();
+            self.error = Some(error);
+            let _ = app.emit(AUDIO_EVENT_INPUT_STATE, self.state());
+        }
         self.state()
     }
 
@@ -215,17 +354,45 @@ impl CaptureState {
 
     pub fn state(&self) -> AudioInputState {
         AudioInputState {
-            active: self.active,
+            active: self.effective_active(),
             device_id: self.device_id.clone(),
             monitor_enabled: self.monitor_enabled,
             monitor_gain: self.monitor_gain,
             input_level: self.current_input_level(),
             sample_rate: self.sample_rate,
+            capture_generation: self.capture_generation,
+            capture_path: if self.effective_active() {
+                self.capture_path
+            } else {
+                CapturePath::None
+            },
+            permission_state: self.permission_state,
+            error: self.current_error(),
         }
     }
 
+    fn effective_active(&self) -> bool {
+        self.active && self.runtime_terminal_error().is_none()
+    }
+
+    fn current_error(&self) -> Option<AudioInputError> {
+        self.runtime_terminal_error().or_else(|| self.error.clone())
+    }
+
+    fn runtime_terminal_error(&self) -> Option<AudioInputError> {
+        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+        if let Some(runtime) = &self.runtime {
+            return runtime
+                .shared
+                .lock()
+                .ok()
+                .and_then(|shared| shared.terminal_error.clone());
+        }
+        None
+    }
+
     fn current_input_level(&self) -> f32 {
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
         if let Some(runtime) = &self.runtime {
             if let Ok(shared) = runtime.shared.lock() {
                 return shared.input_level;
@@ -235,14 +402,169 @@ impl CaptureState {
         self.input_level
     }
 
+    fn clear_live_state(&mut self) {
+        self.active = false;
+        self.device_id = None;
+        self.input_level = 0.0;
+        self.sample_rate = None;
+        self.capture_path = CapturePath::None;
+    }
+
     fn stop_runtime(&mut self) {
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
         if let Some(mut runtime) = self.runtime.take() {
             let _ = runtime.stop_sender.send(CaptureControl::Stop);
             if let Some(worker_thread) = runtime.worker_thread.take() {
                 let _ = worker_thread.join();
             }
         }
+    }
+}
+
+pub fn input_permission_status(_request: bool) -> AudioInputPermissionStatus {
+    #[cfg(target_os = "android")]
+    let state = if _request {
+        request_android_permission()
+    } else {
+        read_android_permission()
+    };
+    #[cfg(not(target_os = "android"))]
+    let state = AudioInputPermissionState::Unavailable;
+    AudioInputPermissionStatus {
+        state,
+        error: if cfg!(target_os = "android") {
+            permission_error(state)
+        } else {
+            None
+        },
+    }
+}
+
+fn initial_permission_state() -> AudioInputPermissionState {
+    #[cfg(target_os = "android")]
+    return AudioInputPermissionState::Prompt;
+    #[cfg(not(target_os = "android"))]
+    AudioInputPermissionState::Unavailable
+}
+
+fn current_capture_path() -> CapturePath {
+    #[cfg(target_os = "android")]
+    return CapturePath::AndroidAaudio;
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    return CapturePath::DesktopCpal;
+    #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "macos")))]
+    CapturePath::None
+}
+
+fn startup_error() -> AudioInputError {
+    AudioInputError {
+        code: "startup-failure",
+        message: "The microphone could not start.",
+        guidance: Some(if cfg!(target_os = "android") {
+            "Check Android Settings > Apps > TuneForge > Permissions > Microphone, then choose Retry."
+        } else {
+            "Check microphone access, then choose Retry."
+        }),
+    }
+}
+
+fn interruption_error() -> AudioInputError {
+    AudioInputError {
+        code: "stream-interruption",
+        message: "Microphone capture was interrupted.",
+        guidance: Some(if cfg!(target_os = "android") {
+            "Check Android Settings > Apps > TuneForge > Permissions > Microphone, then choose Retry."
+        } else {
+            "Choose Retry when the microphone is available."
+        }),
+    }
+}
+
+#[cfg(target_os = "android")]
+fn background_error() -> AudioInputError {
+    AudioInputError {
+        code: "background-teardown",
+        message: "Microphone capture stopped when TuneForge left the foreground.",
+        guidance: Some("Return to TuneForge, check Android Settings > Apps > TuneForge > Permissions > Microphone, then choose Retry."),
+    }
+}
+
+fn permission_error(permission: AudioInputPermissionState) -> Option<AudioInputError> {
+    match permission {
+        AudioInputPermissionState::Denied => Some(AudioInputError {
+            code: "permission-denied",
+            message: "Microphone permission was denied.",
+            guidance: Some("Check Android Settings > Apps > TuneForge > Permissions > Microphone, then choose Retry."),
+        }),
+        AudioInputPermissionState::Blocked => Some(AudioInputError {
+            code: "permission-blocked",
+            message: "Microphone permission is blocked.",
+            guidance: Some(
+                "Allow Microphone for TuneForge in Android Settings > Apps > TuneForge > Permissions, then choose Retry.",
+            ),
+        }),
+        AudioInputPermissionState::PrivacyBlocked => Some(AudioInputError {
+            code: "privacy-blocked",
+            message: "Android microphone privacy controls are blocking capture.",
+            guidance: Some("Enable microphone access in Android Settings > Privacy > Microphone access, then choose Retry."),
+        }),
+        AudioInputPermissionState::Unavailable => Some(AudioInputError {
+            code: "unavailable",
+            message: "Native microphone capture is unavailable.",
+            guidance: Some("Check Android Settings > Apps > TuneForge > Permissions > Microphone, then choose Retry."),
+        }),
+        _ => None,
+    }
+}
+
+#[cfg(target_os = "android")]
+fn request_android_permission() -> AudioInputPermissionState {
+    call_android_permission("requestTuneForgeAudioPermission")
+}
+
+#[cfg(target_os = "android")]
+fn read_android_permission() -> AudioInputPermissionState {
+    call_android_permission("getTuneForgeAudioPermissionState")
+}
+
+#[cfg(target_os = "android")]
+fn call_android_permission(method: &str) -> AudioInputPermissionState {
+    use jni::objects::JObject;
+    use jni::JavaVM;
+    use tauri::tao::platform::android::prelude::main_android_context;
+
+    let Some(context) = main_android_context() else {
+        return AudioInputPermissionState::Unavailable;
+    };
+    if context.java_vm.is_null() || context.context_jobject.is_null() {
+        return AudioInputPermissionState::Unavailable;
+    }
+    let Ok(vm) = (unsafe { JavaVM::from_raw(context.java_vm.cast()) }) else {
+        return AudioInputPermissionState::Unavailable;
+    };
+    let Ok(mut env) = vm.attach_current_thread() else {
+        return AudioInputPermissionState::Unavailable;
+    };
+    let activity = unsafe { JObject::from_raw(context.context_jobject.cast()) };
+    let result = env
+        .call_method(&activity, method, "()Ljava/lang/String;", &[])
+        .and_then(|value| value.l());
+    std::mem::forget(activity);
+    let Ok(result) = result else {
+        return AudioInputPermissionState::Unavailable;
+    };
+    let result = jni::objects::JString::from(result);
+    let Ok(value) = env.get_string(&result) else {
+        return AudioInputPermissionState::Unavailable;
+    };
+    match value.to_string_lossy().as_ref() {
+        "prompt" => AudioInputPermissionState::Prompt,
+        "prompting" => AudioInputPermissionState::Prompting,
+        "granted" => AudioInputPermissionState::Granted,
+        "denied" => AudioInputPermissionState::Denied,
+        "blocked" => AudioInputPermissionState::Blocked,
+        "privacy-blocked" => AudioInputPermissionState::PrivacyBlocked,
+        _ => AudioInputPermissionState::Unavailable,
     }
 }
 
@@ -306,10 +628,11 @@ fn list_desktop_input_devices() -> Result<Vec<AudioInputDevice>, String> {
     Err("Native microphone capture is only available on macOS and Linux.".to_string())
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-fn start_desktop_input(
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+fn start_native_input(
     app: AppHandle,
     requested_device_id: Option<String>,
+    capture_generation: u64,
 ) -> Result<(String, u32, CaptureRuntime), String> {
     let (ready_sender, ready_receiver) = mpsc::sync_channel(1);
     let (stop_sender, stop_receiver) = mpsc::channel();
@@ -322,6 +645,7 @@ fn start_desktop_input(
             ready_sender,
             stop_receiver,
             worker_shared,
+            capture_generation,
         );
     });
 
@@ -345,19 +669,29 @@ fn start_desktop_input(
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 fn run_capture_worker(
     app: AppHandle,
     requested_device_id: Option<String>,
     ready_sender: mpsc::SyncSender<Result<(String, u32), String>>,
     stop_receiver: mpsc::Receiver<CaptureControl>,
     shared: Arc<Mutex<CaptureSharedState>>,
+    capture_generation: u64,
 ) {
-    let startup = start_capture_stream(requested_device_id, shared);
+    let startup =
+        start_capture_stream(requested_device_id, Arc::clone(&shared), capture_generation);
     match startup {
         Ok(startup) => {
             let _ = ready_sender.send(Ok((startup.effective_device_id, startup.sample_rate)));
-            emit_input_frames(app, startup.frame_receiver, stop_receiver, startup.stream);
+            emit_input_frames(
+                app,
+                startup.frame_receiver,
+                startup.error_receiver,
+                stop_receiver,
+                startup.stream,
+                shared,
+                capture_generation,
+            );
         }
         Err(error) => {
             let _ = ready_sender.send(Err(error));
@@ -365,10 +699,11 @@ fn run_capture_worker(
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 fn start_capture_stream(
     requested_device_id: Option<String>,
     shared: Arc<Mutex<CaptureSharedState>>,
+    capture_generation: u64,
 ) -> Result<CaptureStreamStartup, String> {
     let host = cpal::default_host();
     let (device, effective_device_id) = select_input_device(&host, requested_device_id.as_deref())?;
@@ -380,6 +715,7 @@ fn start_capture_stream(
     let sample_rate = config.sample_rate;
     let channels = usize::from(config.channels.max(1));
     let (sender, receiver) = mpsc::sync_channel::<AudioInputFrame>(2);
+    let (error_sender, error_receiver) = mpsc::sync_channel::<()>(1);
     let device_id = Some(effective_device_id.clone());
 
     let stream = match sample_format {
@@ -391,6 +727,8 @@ fn start_capture_stream(
             device_id.clone(),
             sender.clone(),
             Arc::clone(&shared),
+            error_sender.clone(),
+            capture_generation,
             convert_i8_sample,
         ),
         cpal::SampleFormat::F32 => build_input_stream(
@@ -401,6 +739,8 @@ fn start_capture_stream(
             device_id.clone(),
             sender.clone(),
             Arc::clone(&shared),
+            error_sender.clone(),
+            capture_generation,
             convert_f32_sample,
         ),
         cpal::SampleFormat::I16 => build_input_stream(
@@ -411,6 +751,8 @@ fn start_capture_stream(
             device_id.clone(),
             sender.clone(),
             Arc::clone(&shared),
+            error_sender.clone(),
+            capture_generation,
             convert_i16_sample,
         ),
         cpal::SampleFormat::I32 => build_input_stream(
@@ -421,6 +763,8 @@ fn start_capture_stream(
             device_id.clone(),
             sender.clone(),
             Arc::clone(&shared),
+            error_sender.clone(),
+            capture_generation,
             convert_i32_sample,
         ),
         cpal::SampleFormat::I64 => build_input_stream(
@@ -431,6 +775,8 @@ fn start_capture_stream(
             device_id.clone(),
             sender.clone(),
             Arc::clone(&shared),
+            error_sender.clone(),
+            capture_generation,
             convert_i64_sample,
         ),
         cpal::SampleFormat::U8 => build_input_stream(
@@ -441,6 +787,8 @@ fn start_capture_stream(
             device_id.clone(),
             sender.clone(),
             Arc::clone(&shared),
+            error_sender.clone(),
+            capture_generation,
             convert_u8_sample,
         ),
         cpal::SampleFormat::U16 => build_input_stream(
@@ -451,6 +799,8 @@ fn start_capture_stream(
             device_id,
             sender,
             Arc::clone(&shared),
+            error_sender.clone(),
+            capture_generation,
             convert_u16_sample,
         ),
         cpal::SampleFormat::U32 => build_input_stream(
@@ -461,6 +811,8 @@ fn start_capture_stream(
             device_id.clone(),
             sender.clone(),
             Arc::clone(&shared),
+            error_sender.clone(),
+            capture_generation,
             convert_u32_sample,
         ),
         cpal::SampleFormat::U64 => build_input_stream(
@@ -471,6 +823,8 @@ fn start_capture_stream(
             device_id.clone(),
             sender.clone(),
             Arc::clone(&shared),
+            error_sender.clone(),
+            capture_generation,
             convert_u64_sample,
         ),
         cpal::SampleFormat::F64 => build_input_stream(
@@ -481,6 +835,8 @@ fn start_capture_stream(
             device_id,
             sender,
             Arc::clone(&shared),
+            error_sender,
+            capture_generation,
             convert_f64_sample,
         ),
         unsupported => Err(format!(
@@ -497,13 +853,15 @@ fn start_capture_stream(
         sample_rate,
         stream,
         frame_receiver: receiver,
+        error_receiver,
     })
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
-fn start_desktop_input(
+#[cfg(not(any(target_os = "android", target_os = "linux", target_os = "macos")))]
+fn start_native_input(
     _app: AppHandle,
     _requested_device_id: Option<String>,
+    _capture_generation: u64,
 ) -> Result<(String, u32, CaptureRuntime), String> {
     Err("Native microphone capture is only available on macOS and Linux.".to_string())
 }
@@ -541,7 +899,17 @@ fn select_input_device(
     hash_match.ok_or_else(|| "Selected native input device was not found.".to_string())
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(target_os = "android")]
+fn select_input_device(
+    host: &cpal::Host,
+    _requested_device_id: Option<&str>,
+) -> Result<(cpal::Device, String), String> {
+    host.default_input_device()
+        .map(|device| (device, DEFAULT_INPUT_DEVICE_ID.to_string()))
+        .ok_or_else(|| "No default Android microphone is available.".to_string())
+}
+
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 fn build_input_stream<T, F>(
     device: &cpal::Device,
     config: &cpal::StreamConfig,
@@ -550,6 +918,8 @@ fn build_input_stream<T, F>(
     device_id: Option<String>,
     sender: mpsc::SyncSender<AudioInputFrame>,
     shared: Arc<Mutex<CaptureSharedState>>,
+    error_sender: mpsc::SyncSender<()>,
+    capture_generation: u64,
     convert_sample: F,
 ) -> Result<cpal::Stream, String>
 where
@@ -568,11 +938,14 @@ where
                     device_id.clone(),
                     &sender,
                     &shared,
+                    capture_generation,
                     convert_sample,
                     &mut pending_samples,
                 );
             },
-            |error| eprintln!("Native microphone input stream error: {error}"),
+            move |_| {
+                let _ = error_sender.try_send(());
+            },
             None,
         )
         .map_err(|error| format!("Could not build native input stream: {error}"))
@@ -585,6 +958,7 @@ fn process_interleaved_input<T, F>(
     device_id: Option<String>,
     sender: &mpsc::SyncSender<AudioInputFrame>,
     shared: &Arc<Mutex<CaptureSharedState>>,
+    capture_generation: u64,
     convert_sample: F,
     pending_samples: &mut Vec<f32>,
 ) where
@@ -605,6 +979,7 @@ fn process_interleaved_input<T, F>(
             input_level,
             samples,
             timestamp_ms: current_timestamp_ms(),
+            capture_generation,
         });
         pending_samples.drain(..INPUT_FRAME_HOP_SAMPLES.min(pending_samples.len()));
     }
@@ -632,16 +1007,46 @@ fn append_mono_samples<T, F>(
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 fn emit_input_frames(
     app: AppHandle,
     receiver: mpsc::Receiver<AudioInputFrame>,
+    error_receiver: mpsc::Receiver<()>,
     stop_receiver: mpsc::Receiver<CaptureControl>,
-    _stream: cpal::Stream,
+    stream: cpal::Stream,
+    shared: Arc<Mutex<CaptureSharedState>>,
+    capture_generation: u64,
 ) {
     let mut last_emit_at = Instant::now() - INPUT_FRAME_EVENT_INTERVAL;
+    #[cfg(target_os = "android")]
+    let mut last_permission_check = Instant::now();
     loop {
         if stop_receiver.try_recv().is_ok() {
+            break;
+        }
+        #[cfg(target_os = "android")]
+        if last_permission_check.elapsed() >= Duration::from_millis(250) {
+            last_permission_check = Instant::now();
+            let permission = read_android_permission();
+            if permission != AudioInputPermissionState::Granted {
+                finish_capture_with_error(
+                    &app,
+                    &shared,
+                    capture_generation,
+                    permission,
+                    permission_error(permission).unwrap_or_else(interruption_error),
+                );
+                break;
+            }
+        }
+        if error_receiver.try_recv().is_ok() {
+            finish_capture_with_error(
+                &app,
+                &shared,
+                capture_generation,
+                current_worker_permission_state(),
+                interruption_error(),
+            );
             break;
         }
         match receiver.recv_timeout(INPUT_FRAME_EVENT_INTERVAL) {
@@ -656,6 +1061,43 @@ fn emit_input_frames(
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
         }
     }
+    drop(stream);
+}
+
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+fn finish_capture_with_error(
+    app: &AppHandle,
+    shared: &Arc<Mutex<CaptureSharedState>>,
+    capture_generation: u64,
+    permission_state: AudioInputPermissionState,
+    error: AudioInputError,
+) {
+    if let Ok(mut shared) = shared.lock() {
+        shared.input_level = 0.0;
+        shared.terminal_error = Some(error.clone());
+    }
+    let _ = app.emit(
+        AUDIO_EVENT_INPUT_STATE,
+        AudioInputState {
+            active: false,
+            device_id: None,
+            monitor_enabled: false,
+            monitor_gain: 0.0,
+            input_level: 0.0,
+            sample_rate: None,
+            capture_generation,
+            capture_path: CapturePath::None,
+            permission_state,
+            error: Some(error),
+        },
+    );
+}
+
+fn current_worker_permission_state() -> AudioInputPermissionState {
+    #[cfg(target_os = "android")]
+    return read_android_permission();
+    #[cfg(not(target_os = "android"))]
+    AudioInputPermissionState::Unavailable
 }
 
 fn convert_f32_sample(sample: f32) -> f32 {
@@ -953,7 +1395,12 @@ mod tests {
             monitor_gain: 0.0,
             input_level: 0.42,
             sample_rate: Some(48_000),
-            #[cfg(any(target_os = "linux", target_os = "macos"))]
+            capture_generation: 7,
+            capture_path: CapturePath::DesktopCpal,
+            permission_state: AudioInputPermissionState::Unavailable,
+            error: None,
+            permission_pending: false,
+            #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
             runtime: None,
         };
 
@@ -962,5 +1409,62 @@ mod tests {
         assert!(!stopped.active);
         assert_eq!(stopped.input_level, 0.0);
         assert_eq!(stopped.sample_rate, None);
+        assert_eq!(stopped.capture_generation, 8);
+        assert_eq!(stopped.capture_path, CapturePath::None);
+    }
+
+    #[test]
+    fn permission_failures_use_fixed_safe_codes() {
+        let denied = permission_error(AudioInputPermissionState::Denied).expect("denied error");
+        let privacy =
+            permission_error(AudioInputPermissionState::PrivacyBlocked).expect("privacy error");
+
+        assert_eq!(denied.code, "permission-denied");
+        assert_eq!(privacy.code, "privacy-blocked");
+        assert!(!denied.message.contains('/'));
+    }
+
+    #[test]
+    fn background_invalidates_active_generation_but_not_pending_permission() {
+        let mut state = CaptureState::default();
+        state.capture_generation = 4;
+        state.permission_pending = true;
+
+        assert!(state
+            .take_background_terminal(interruption_error())
+            .is_none());
+        assert_eq!(state.capture_generation, 4);
+        assert!(state.permission_pending);
+
+        state.active = true;
+        state.device_id = Some("default".to_string());
+        state.sample_rate = Some(48_000);
+        state.capture_path = CapturePath::AndroidAaudio;
+        let terminal = state
+            .take_background_terminal(interruption_error())
+            .expect("active terminal");
+
+        assert_eq!(terminal.capture_generation, 4);
+        assert!(!terminal.active);
+        assert_eq!(state.capture_generation, 5);
+        assert_eq!(state.capture_path, CapturePath::None);
+    }
+
+    #[test]
+    fn clearing_live_state_removes_replaced_capture_facts() {
+        let mut state = CaptureState::default();
+        state.active = true;
+        state.device_id = Some("stale".to_string());
+        state.sample_rate = Some(48_000);
+        state.input_level = 0.8;
+        state.capture_path = CapturePath::DesktopCpal;
+
+        state.clear_live_state();
+
+        assert!(!state.active);
+        assert_eq!(state.device_id, None);
+        assert_eq!(state.sample_rate, None);
+        assert_eq!(state.input_level, 0.0);
+        assert_eq!(state.capture_path, CapturePath::None);
     }
 }

--- a/apps/desktop/src-tauri/src/native_audio/mod.rs
+++ b/apps/desktop/src-tauri/src/native_audio/mod.rs
@@ -18,6 +18,7 @@ pub const AUDIO_EVENT_ENDED: &str = "audio://ended";
 pub const AUDIO_EVENT_ERROR: &str = "audio://error";
 pub const AUDIO_EVENT_INPUT_LEVEL: &str = "audio://input-level";
 pub const AUDIO_EVENT_INPUT_FRAME: &str = "audio://input-frame";
+pub const AUDIO_EVENT_INPUT_STATE: &str = "audio://input-state";
 pub const AUDIO_EVENT_DEVICES_CHANGED: &str = "audio://devices-changed";
 
 #[derive(Clone)]
@@ -80,6 +81,7 @@ impl AudioCapabilities {
                 AUDIO_EVENT_ERROR,
                 AUDIO_EVENT_INPUT_LEVEL,
                 AUDIO_EVENT_INPUT_FRAME,
+                AUDIO_EVENT_INPUT_STATE,
                 AUDIO_EVENT_DEVICES_CHANGED,
             ],
             fallback_required: !platform.native_playback_supported,
@@ -236,13 +238,31 @@ pub fn audio_list_output_devices(
 
 #[tauri::command]
 pub fn audio_get_input_state(
+    app: AppHandle,
     state: State<'_, NativeAudioState>,
 ) -> Result<capture::AudioInputState, String> {
-    let capture = state
+    let mut capture = state
         .capture
         .lock()
         .map_err(|_| "Native audio capture state is unavailable.".to_string())?;
-    Ok(capture.state())
+    Ok(capture.refresh(&app))
+}
+
+#[tauri::command]
+pub fn audio_get_input_permission_status() -> capture::AudioInputPermissionStatus {
+    capture::input_permission_status(false)
+}
+
+#[tauri::command]
+pub fn audio_request_input_permission() -> capture::AudioInputPermissionStatus {
+    capture::input_permission_status(true)
+}
+
+#[cfg(target_os = "android")]
+pub fn stop_input_for_lifecycle(app: &AppHandle, state: &NativeAudioState) {
+    if let Ok(mut capture) = state.capture.lock() {
+        capture.stop_for_background(app);
+    }
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/native_audio/platform/android.rs
+++ b/apps/desktop/src-tauri/src/native_audio/platform/android.rs
@@ -2,7 +2,7 @@ use super::AudioPlatform;
 use std::sync::OnceLock;
 
 const ANDROID_CONTEXT_UNAVAILABLE: &str =
-    "Native audio playback is unavailable because the Android audio context could not be initialized.";
+    "Native Android audio is unavailable because its audio context could not be initialized.";
 
 static ANDROID_AUDIO_CONTEXT: OnceLock<Result<(), &'static str>> = OnceLock::new();
 
@@ -13,7 +13,7 @@ pub fn current_platform() -> AudioPlatform {
         backend: "android-aaudio",
         native_playback_supported: context_result.is_ok(),
         fallback_reason: context_result.err(),
-        mic_capture_supported: false,
+        mic_capture_supported: context_result.is_ok(),
         mic_monitoring_supported: false,
         system_input_volume_supported: false,
     }

--- a/apps/desktop/src/App.settings-theme.test.tsx
+++ b/apps/desktop/src/App.settings-theme.test.tsx
@@ -182,7 +182,8 @@ describe("Desktop app settings theme", () => {
     expect(screen.getByText("Frontend Package Version")).toBeInTheDocument();
     expect(screen.getByText("Frontend Git Ref")).toBeInTheDocument();
     expect(screen.getByText(FRONTEND_VERSION_INFO.git_ref)).toBeInTheDocument();
-    expect(screen.getAllByText("Native (desktop-cpal)")).toHaveLength(2);
+    expect(screen.getByText("Available (desktop-cpal)")).toBeInTheDocument();
+    expect(screen.getByText("Native (desktop-cpal)")).toBeInTheDocument();
     expect(screen.getByText(/^Unavailable —/)).toBeInTheDocument();
     expect(screen.getByText("Native microphone failed.")).toBeInTheDocument();
     expect(screen.getByText("Native output failed.")).toBeInTheDocument();
@@ -233,10 +234,39 @@ describe("Desktop app settings theme", () => {
 
     expect(await screen.findByText("/tmp/tuneforge")).toBeInTheDocument();
     expect(screen.getByText("Web Audio forced at build time")).toBeInTheDocument();
-    expect(screen.getByText("Web Audio forced")).toBeInTheDocument();
-    expect(screen.getAllByText("Native (desktop-cpal)")).toHaveLength(2);
+    expect(screen.getByText("Forced Web Audio")).toBeInTheDocument();
+    expect(screen.getByText("Available (desktop-cpal)")).toBeInTheDocument();
+    expect(screen.getByText("Native (desktop-cpal)")).toBeInTheDocument();
     expect(screen.getByText("Not playing")).toBeInTheDocument();
     expect(mockInvoke).toHaveBeenCalledWith("audio_get_capabilities");
+  });
+
+  it("keeps Android capture capability, live state, and history distinct", async () => {
+    const user = userEvent.setup();
+    setMockNativeAudioState({
+      capabilities: { platform: "android", backend: "android-aaudio", micCaptureSupported: true },
+      inputPermission: { state: "blocked", error: null },
+      inputState: { active: false, capturePath: "none", captureGeneration: 9, error: null },
+    });
+    window.localStorage.setItem(
+      "tuneforge.tuner-input-capture-backend",
+      JSON.stringify({ backend: "native", detail: "android-aaudio" }),
+    );
+    window.localStorage.setItem(
+      "tuneforge.tuner-native-capture-error",
+      "Microphone capture was interrupted. Check Android Settings, then choose Retry.",
+    );
+    renderApp(["/settings"]);
+
+    await user.click(await screen.findByText("Show diagnostics"));
+
+    expect(await screen.findByText("Available (android-aaudio)")).toBeInTheDocument();
+    expect(screen.getByText("Native required")).toBeInTheDocument();
+    expect(screen.getByText("Blocked")).toBeInTheDocument();
+    expect(screen.getAllByText("Inactive").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("None").length).toBeGreaterThan(0);
+    expect(screen.getByText("Native (android-aaudio)")).toBeInTheDocument();
+    expect(screen.getByText(/Microphone capture was interrupted/)).toBeInTheDocument();
   });
 
   it("persists playback follow defaults", async () => {

--- a/apps/desktop/src/App.tools-tuner.test.tsx
+++ b/apps/desktop/src/App.tools-tuner.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   emitMockNativeInputFrame,
+  emitMockNativeInputState,
   getMockAudioContexts,
   getMockInvoke,
   getMockMediaDevices,
@@ -263,6 +264,7 @@ describe("Desktop app tools tuner", () => {
     expect(window.localStorage.getItem("tuneforge.tuner-input-capture-backend")).toContain(
       "desktop-cpal",
     );
+    expect(screen.getByText("Listening", { selector: ".subpanel__copy" })).toHaveAttribute("aria-live", "polite");
     expect(getMockMediaDevices().getUserMedia).not.toHaveBeenCalled();
 
     act(() => {
@@ -272,6 +274,7 @@ describe("Desktop app tools tuner", () => {
         inputLevel: 0.25,
         samples: makeSineSamples(440, 48000, 2048),
         timestampMs: 1000,
+        captureGeneration: 1,
       });
     });
 
@@ -289,6 +292,43 @@ describe("Desktop app tools tuner", () => {
     await user.click(screen.getByRole("button", { name: "Stop" }));
 
     expect(getMockInvoke()).toHaveBeenCalledWith("audio_stop_input");
+    act(() => {
+      emitMockNativeInputFrame({
+        deviceId: "cpal:1:usb",
+        sampleRate: 48000,
+        inputLevel: 1,
+        samples: makeSineSamples(440, 48000, 2048),
+        timestampMs: 1100,
+        captureGeneration: 1,
+      });
+    });
+    expect(screen.getByRole("meter", { name: "Input signal level" })).toHaveAttribute("aria-valuenow", "0");
+
+    await user.click(screen.getByRole("button", { name: "Start" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument());
+    act(() => {
+      emitMockNativeInputFrame({
+        deviceId: "cpal:1:usb",
+        sampleRate: 48000,
+        inputLevel: 1,
+        samples: makeSineSamples(440, 48000, 2048),
+        timestampMs: 1200,
+        captureGeneration: 1,
+      });
+    });
+    expect(screen.getByRole("meter", { name: "Input signal level" })).toHaveAttribute("aria-valuenow", "0");
+  });
+
+  it("stops native capture when the tuner unmounts", async () => {
+    const user = userEvent.setup();
+    setMockNativeAudioState({ capabilities: { micCaptureSupported: true, backend: "desktop-cpal" } });
+    renderApp(["/tools"]);
+
+    await user.click(await screen.findByRole("button", { name: "Start" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument());
+    await user.click(screen.getByRole("tab", { name: "Metronome" }));
+
+    await waitFor(() => expect(getMockInvoke()).toHaveBeenCalledWith("audio_stop_input"));
   });
 
   it("does not query native microphone devices while the tuner is idle until the picker is opened", async () => {
@@ -462,6 +502,167 @@ describe("Desktop app tools tuner", () => {
     expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
   });
 
+  it("never falls back to Web Audio when packaged Android native capture fails", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      "tuneforge.tuner-microphone-devices",
+      JSON.stringify([{ deviceId: "cached", label: "Cached browser microphone" }]),
+    );
+    setMockNativeAudioState({
+      capabilities: {
+        platform: "android",
+        backend: "android-aaudio",
+        micCaptureSupported: true,
+      },
+      startError: "The microphone could not start. Check Android Settings > Apps > TuneForge > Permissions > Microphone, then choose Retry.",
+    });
+    renderApp(["/tools"]);
+
+    expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByRole("option", { name: "Cached browser microphone" })).not.toBeInTheDocument(),
+    );
+    await user.click(screen.getByRole("button", { name: "Start" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Android Settings");
+    expect(screen.getByRole("button", { name: "Retry" })).toBeEnabled();
+    expect(getMockMediaDevices().getUserMedia).not.toHaveBeenCalled();
+  });
+
+  it("continues Android startup after a prompted permission grant", async () => {
+    const user = userEvent.setup();
+    setMockNativeAudioState({
+      capabilities: { platform: "android", backend: "android-aaudio", micCaptureSupported: true },
+      inputPermission: { state: "prompt", error: null },
+    });
+    const mockInvoke = getMockInvoke();
+    const originalInvoke = mockInvoke.getMockImplementation();
+    if (!originalInvoke) throw new Error("Missing invoke mock implementation.");
+    let requested = false;
+    mockInvoke.mockImplementation((command, args) => {
+      if (command === "audio_request_input_permission") {
+        requested = true;
+        return Promise.resolve({ state: "prompting", error: null });
+      }
+      if (command === "audio_get_input_permission_status" && requested) {
+        return Promise.resolve({ state: "granted", error: null });
+      }
+      return originalInvoke(command, args);
+    });
+    renderApp(["/tools"]);
+
+    await user.click(await screen.findByRole("button", { name: "Start" }));
+
+    await waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith("audio_start_input", {
+        payload: { deviceId: null },
+      }),
+    );
+    expect(mockInvoke).toHaveBeenCalledWith("audio_request_input_permission");
+    expect(screen.getByText("Listening")).toBeInTheDocument();
+    expect(getMockMediaDevices().getUserMedia).not.toHaveBeenCalled();
+  });
+
+  it("keeps Android permission denial recoverable without starting capture", async () => {
+    const user = userEvent.setup();
+    const denial = {
+      code: "permission-denied",
+      message: "Microphone permission was denied.",
+      guidance: "Check Android Settings > Apps > TuneForge > Permissions > Microphone, then choose Retry.",
+    };
+    setMockNativeAudioState({
+      capabilities: { platform: "android", backend: "android-aaudio", micCaptureSupported: true },
+      inputPermission: { state: "prompt", error: null },
+    });
+    const mockInvoke = getMockInvoke();
+    const originalInvoke = mockInvoke.getMockImplementation();
+    if (!originalInvoke) throw new Error("Missing invoke mock implementation.");
+    let requested = false;
+    mockInvoke.mockImplementation((command, args) => {
+      if (command === "audio_request_input_permission") {
+        requested = true;
+        return Promise.resolve({ state: "prompting", error: null });
+      }
+      if (command === "audio_get_input_permission_status" && requested) {
+        return Promise.resolve({ state: "denied", error: denial });
+      }
+      return originalInvoke(command, args);
+    });
+    renderApp(["/tools"]);
+
+    await user.click(await screen.findByRole("button", { name: "Start" }));
+
+    expect(await screen.findByRole("alert", undefined, { timeout: 3_000 })).toHaveTextContent(
+      "Android Settings",
+    );
+    expect(screen.getByRole("button", { name: "Retry" })).toBeEnabled();
+    expect(mockInvoke).not.toHaveBeenCalledWith("audio_start_input", expect.anything());
+    expect(getMockMediaDevices().getUserMedia).not.toHaveBeenCalled();
+  });
+
+  it("reports permanently blocked Android permission without prompting or fallback", async () => {
+    const user = userEvent.setup();
+    setMockNativeAudioState({
+      capabilities: { platform: "android", backend: "android-aaudio", micCaptureSupported: true },
+      inputPermission: {
+        state: "blocked",
+        error: {
+          code: "permission-blocked",
+          message: "Microphone permission is blocked.",
+          guidance: "Check Android Settings > Apps > TuneForge > Permissions > Microphone, then choose Retry.",
+        },
+      },
+    });
+    renderApp(["/tools"]);
+
+    await user.click(await screen.findByRole("button", { name: "Start" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Android Settings");
+    expect(getMockInvoke()).not.toHaveBeenCalledWith("audio_request_input_permission");
+    expect(getMockInvoke()).not.toHaveBeenCalledWith("audio_start_input", expect.anything());
+    expect(getMockMediaDevices().getUserMedia).not.toHaveBeenCalled();
+  });
+
+  it("stops Android capture on a generation-matched terminal state event", async () => {
+    const user = userEvent.setup();
+    setMockNativeAudioState({
+      capabilities: {
+        platform: "android",
+        backend: "android-aaudio",
+        micCaptureSupported: true,
+      },
+    });
+    renderApp(["/tools"]);
+
+    expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Start" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument());
+
+    setMockNativeAudioState({
+      inputState: {
+        active: false,
+        captureGeneration: 0,
+        capturePath: "none",
+        inputLevel: 0,
+        sampleRate: null,
+        error: {
+          code: "stream-interruption",
+          message: "Microphone capture was interrupted.",
+          guidance: "Choose Retry when the microphone is available.",
+        },
+      },
+    });
+    act(() => emitMockNativeInputState());
+    expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
+
+    setMockNativeAudioState({ inputState: { captureGeneration: 1 } });
+    act(() => emitMockNativeInputState());
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Microphone capture was interrupted.");
+    expect(screen.getByRole("button", { name: "Retry" })).toBeEnabled();
+    expect(getMockMediaDevices().getUserMedia).not.toHaveBeenCalled();
+  });
+
   it("falls back to system-default Web Audio when a native microphone selection fails", async () => {
     const user = userEvent.setup();
     getMockMediaDevices().revealLabels();
@@ -495,7 +696,7 @@ describe("Desktop app tools tuner", () => {
       video: false,
     });
     expect(screen.getByLabelText("Microphone source")).toHaveValue("");
-    expect(screen.getByRole("option", { name: "Built-in Microphone" })).toBeDisabled();
+    expect(screen.queryByRole("option", { name: "Built-in Microphone" })).not.toBeInTheDocument();
     expect(window.localStorage.getItem("tuneforge.tuner-native-capture-error")).toBe(
       "Native microphone failed.",
     );
@@ -547,7 +748,7 @@ describe("Desktop app tools tuner", () => {
     await user.click(screen.getByRole("button", { name: "Start" }));
 
     expect(await screen.findByText("Microphone permission was denied.")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Start" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeEnabled();
   });
 });
 

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -27,9 +27,14 @@ import {
 } from "../../lib/powerInhibition";
 import {
   getNativeAudioCapabilities,
+  getNativeAudioInputPermissionStatus,
+  getNativeAudioInputState,
+  isAndroidRuntime,
   isWebAudioBackendForced,
   type NativeAudioBufferHealth,
   type NativeAudioCapabilities,
+  type NativeAudioInputState,
+  type NativeAudioInputPermissionStatus,
 } from "../../lib/nativeAudio";
 import { TunerPreferenceControls } from "../tools/TunerPreferenceControls";
 import {
@@ -324,7 +329,26 @@ function inputCaptureBackendLabel(
   if (!capabilities) {
     return "Unknown";
   }
-  return capabilities.micCaptureSupported ? `Native (${capabilities.backend})` : "Web Audio";
+  return capabilities.micCaptureSupported ? `Available (${capabilities.backend})` : "Unavailable";
+}
+
+function inputCaptureStateLabel(state: NativeAudioInputState | undefined) {
+  if (!state) return "Unknown";
+  if (state.active) return "Listening";
+  if (state.error) return "Error";
+  if (state.permissionState === "prompting") return "Starting";
+  return "Inactive";
+}
+
+function inputCapturePathLabel(state: NativeAudioInputState | undefined) {
+  if (!state || state.capturePath === "none") return "None";
+  return state.capturePath === "android-aaudio" ? "Android AAudio" : "Desktop CPAL";
+}
+
+function inputPermissionLabel(status: NativeAudioInputPermissionStatus | undefined) {
+  if (!status) return "Unknown";
+  if (status.state === "privacy-blocked") return "Privacy blocked";
+  return status.state[0].toUpperCase() + status.state.slice(1);
 }
 
 function nativePlaybackCapabilityLabel(capabilities: NativeAudioCapabilities | undefined) {
@@ -682,6 +706,14 @@ export function SettingsView() {
     queryKey: ["native-audio-capabilities"],
     queryFn: getNativeAudioCapabilities,
   });
+  const nativeInputQuery = useQuery({
+    queryKey: ["native-audio-input-state"],
+    queryFn: getNativeAudioInputState,
+  });
+  const nativePermissionQuery = useQuery({
+    queryKey: ["native-audio-input-permission"],
+    queryFn: getNativeAudioInputPermissionStatus,
+  });
   const lastInputCaptureBackend = readRememberedTunerInputCaptureBackend();
   const lastNativeCaptureError = readRememberedTunerNativeCaptureError();
   const lastPlaybackBackend = readRememberedPlaybackBackend();
@@ -988,7 +1020,7 @@ export function SettingsView() {
             onReferenceHzChange={setDefaultTunerReferenceHz}
             onVisualModeChange={setDefaultTunerVisualMode}
             referenceHz={defaultTunerReferenceHz}
-            systemDefaultOnly={webAudioForced}
+            systemDefaultOnly={webAudioForced || isAndroidRuntime() || nativeAudioQuery.data?.platform === "android"}
             visualMode={defaultTunerVisualMode}
           />
 
@@ -1171,15 +1203,31 @@ export function SettingsView() {
                   <dd>{healthQuery.data?.default_export_format ?? "wav"}</dd>
                 </div>
                 <div>
-                  <dt>Input Capture Available</dt>
+                  <dt>Native Capture Capability</dt>
                   <dd>{inputCaptureBackendLabel(nativeAudioQuery.data)}</dd>
                 </div>
                 <div>
-                  <dt>Last Tuner Capture</dt>
+                  <dt>Capture Selection Policy</dt>
+                  <dd>{webAudioForced ? "Forced Web Audio" : isAndroidRuntime() || nativeAudioQuery.data?.platform === "android" ? "Native required" : "Native preferred"}</dd>
+                </div>
+                <div>
+                  <dt>Current Microphone Permission</dt>
+                  <dd>{inputPermissionLabel(nativePermissionQuery.data)}</dd>
+                </div>
+                <div>
+                  <dt>Current Capture State</dt>
+                  <dd>{inputCaptureStateLabel(nativeInputQuery.data)}</dd>
+                </div>
+                <div>
+                  <dt>Current Capture Path</dt>
+                  <dd>{inputCapturePathLabel(nativeInputQuery.data)}</dd>
+                </div>
+                <div>
+                  <dt>Last Confirmed Capture Path</dt>
                   <dd>{lastInputCaptureBackendLabel(lastInputCaptureBackend)}</dd>
                 </div>
                 <div>
-                  <dt>Last Native Capture Error</dt>
+                  <dt>Latest Safe Capture Failure</dt>
                   <dd>{lastNativeCaptureError ?? "None"}</dd>
                 </div>
                 <div>

--- a/apps/desktop/src/features/tools/ToolsView.tsx
+++ b/apps/desktop/src/features/tools/ToolsView.tsx
@@ -2,12 +2,18 @@ import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import {
   getNativeAudioCapabilities,
+  getNativeAudioInputPermissionStatus,
+  getNativeAudioInputState,
+  isAndroidRuntime,
   isWebAudioBackendForced,
   listenNativeAudioInputFrames,
+  listenNativeAudioInputState,
+  requestNativeAudioInputPermission,
   startNativeAudioInput,
   stopNativeAudioInput,
   type NativeAudioCapabilities,
   type NativeAudioInputFrame,
+  type NativeAudioInputState,
 } from "../../lib/nativeAudio";
 import { useStableCallback } from "../../lib/useStableCallback";
 import { usePreferences, type TunerVisualMode } from "../../lib/preferences";
@@ -27,7 +33,6 @@ import {
   SimpleTunerMeter,
   WideArcTunerMeter,
 } from "./TunerMeters";
-import { getTunerStatusLabel } from "./tunerMeterState";
 import {
   createStabilizedTunerReadingState,
   updateStabilizedTunerReading,
@@ -130,6 +135,7 @@ function ChromaticTunerPage() {
   const [nativeAudioCapabilities, setNativeAudioCapabilities] =
     useState<NativeAudioCapabilities | null>(null);
   const webAudioForced = isWebAudioBackendForced();
+  const androidRuntime = isAndroidRuntime() || nativeAudioCapabilities?.platform === "android";
   const [reading, setReading] = useState<TunerPitchReading | null>(null);
   const [deviceRefreshToken, setDeviceRefreshToken] = useState(0);
   const [systemInputVolumeRefreshToken, setSystemInputVolumeRefreshToken] = useState(0);
@@ -139,7 +145,9 @@ function ChromaticTunerPage() {
   const inputDeviceIdRef = useRef(defaultTunerInputDeviceId);
   const mediaSourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
   const nativeCaptureActiveRef = useRef(false);
+  const nativeCaptureGenerationRef = useRef<number | null>(null);
   const nativeInputUnlistenRef = useRef<(() => void) | null>(null);
+  const nativeStateUnlistenRef = useRef<(() => void) | null>(null);
   const referenceHzRef = useRef(defaultTunerReferenceHz);
   const requestIdRef = useRef(0);
   const readingStabilizerRef = useRef(createStabilizedTunerReadingState());
@@ -204,6 +212,9 @@ function ChromaticTunerPage() {
 
     nativeInputUnlistenRef.current?.();
     nativeInputUnlistenRef.current = null;
+    nativeStateUnlistenRef.current?.();
+    nativeStateUnlistenRef.current = null;
+    nativeCaptureGenerationRef.current = null;
     if (nativeCaptureActiveRef.current) {
       nativeCaptureActiveRef.current = false;
       void stopNativeAudioInput().catch(() => undefined);
@@ -294,7 +305,12 @@ function ChromaticTunerPage() {
   const handleNativeInputFrame = useStableCallback(function handleNativeInputFrame(
     frame: NativeAudioInputFrame,
   ) {
-    if (!nativeCaptureActiveRef.current || frame.sampleRate <= 0 || frame.samples.length === 0) {
+    if (
+      !nativeCaptureActiveRef.current ||
+      frame.captureGeneration !== nativeCaptureGenerationRef.current ||
+      frame.sampleRate <= 0 ||
+      frame.samples.length === 0
+    ) {
       return;
     }
     processTunerSamples(
@@ -305,22 +321,79 @@ function ChromaticTunerPage() {
     );
   });
 
+  const handleNativeInputState = useStableCallback(function handleNativeInputState(
+    inputState: NativeAudioInputState,
+  ) {
+    if (
+      inputState.captureGeneration !== nativeCaptureGenerationRef.current ||
+      inputState.active ||
+      !inputState.error
+    ) {
+      return;
+    }
+    requestIdRef.current += 1;
+    const message = captureStateErrorMessage(inputState);
+    rememberTunerNativeCaptureError(message);
+    releaseCapture();
+    resetTunerDisplay();
+    setStatus("error");
+    setErrorMessage(message);
+  });
+
   const startNativeTuner = useStableCallback(async function startNativeTuner(
     deviceId: string | null,
     requestId: number,
     backend: string | null,
+    requireAndroidPermission: boolean,
   ) {
-    const unlisten = await listenNativeAudioInputFrames(handleNativeInputFrame);
+    const [unlistenFrames, unlistenState] = await Promise.all([
+      listenNativeAudioInputFrames(handleNativeInputFrame),
+      listenNativeAudioInputState(handleNativeInputState),
+    ]);
     if (requestIdRef.current !== requestId) {
-      unlisten();
+      unlistenFrames();
+      unlistenState();
       return;
     }
-    nativeInputUnlistenRef.current = unlisten;
-    const inputState = await startNativeAudioInput({ deviceId });
+    nativeInputUnlistenRef.current = unlistenFrames;
+    nativeStateUnlistenRef.current = unlistenState;
+    nativeCaptureActiveRef.current = true;
+    if (requireAndroidPermission) {
+      let permission = await getNativeAudioInputPermissionStatus();
+      if (permission.state === "prompt" || permission.state === "denied") {
+        permission = await requestNativeAudioInputPermission();
+      }
+      while (requestIdRef.current === requestId && permission.state === "prompting") {
+        await waitForPermissionPoll();
+        permission = await getNativeAudioInputPermissionStatus();
+      }
+      if (permission.error || permission.state !== "granted") {
+        throw new Error(captureSafeErrorMessage(permission.error));
+      }
+    }
+    let inputState = await startNativeAudioInput({ deviceId });
+    nativeCaptureGenerationRef.current = inputState.captureGeneration;
+    while (
+      requestIdRef.current === requestId &&
+      !inputState.active &&
+      !inputState.error &&
+      (inputState.permissionState === "prompt" || inputState.permissionState === "prompting")
+    ) {
+      await waitForPermissionPoll();
+      inputState = await getNativeAudioInputState();
+      nativeCaptureGenerationRef.current = inputState.captureGeneration;
+      if (inputState.permissionState === "granted" && !inputState.active) {
+        inputState = await startNativeAudioInput({ deviceId });
+        nativeCaptureGenerationRef.current = inputState.captureGeneration;
+      }
+    }
     nativeCaptureActiveRef.current = inputState.active;
     if (requestIdRef.current !== requestId) {
       releaseCapture();
       return;
+    }
+    if (!inputState.active || inputState.capturePath === "none") {
+      throw new Error(captureStateErrorMessage(inputState));
     }
     if (inputState.deviceId) {
       inputDeviceIdRef.current = deviceId;
@@ -393,10 +466,17 @@ function ChromaticTunerPage() {
     const selectedDeviceId = nextDeviceId ?? inputDeviceIdRef.current;
     const selectedNativeDevice = isNativeAudioInputDeviceId(selectedDeviceId);
     const nativeCapabilities = await resolveNativeAudioCapabilities();
+    const androidNativeRequired =
+      isAndroidRuntime() || nativeCapabilities?.platform === "android";
 
     if (!webAudioForced && nativeCapabilities?.micCaptureSupported) {
       try {
-        await startNativeTuner(selectedDeviceId, requestId, nativeCapabilities.backend);
+        await startNativeTuner(
+          selectedDeviceId,
+          requestId,
+          nativeCapabilities.backend,
+          androidNativeRequired,
+        );
         return;
       } catch (error) {
         rememberTunerNativeCaptureError(captureErrorMessage(error));
@@ -404,7 +484,18 @@ function ChromaticTunerPage() {
           return;
         }
         releaseCapture();
+        if (androidNativeRequired) {
+          setStatus("error");
+          setErrorMessage(captureErrorMessage(error));
+          return;
+        }
       }
+    } else if (!webAudioForced && androidNativeRequired) {
+      const message = "Native Android microphone capture is unavailable.";
+      rememberTunerNativeCaptureError(message);
+      setStatus("error");
+      setErrorMessage(message);
+      return;
     } else if (!webAudioForced && selectedNativeDevice) {
       rememberTunerNativeCaptureError(
         "Selected microphone requires native input capture, but native capture is unavailable.",
@@ -473,10 +564,14 @@ function ChromaticTunerPage() {
   const isBusy = status === "starting";
   const isListening = status === "listening";
   const canStart =
-    canUseTunerCapture(webAudioForced ? null : nativeAudioCapabilities) && !isBusy && !isListening;
-  const statusText = headerStatusLabel(status, reading);
+    ((!webAudioForced && androidRuntime) ||
+      canUseTunerCapture(webAudioForced ? null : nativeAudioCapabilities)) &&
+    !isBusy &&
+    !isListening;
+  const statusText = headerStatusLabel(status);
   const systemDefaultInputOnly =
     webAudioForced ||
+    androidRuntime ||
     activeCaptureBackend === "web" ||
     nativeAudioCapabilities?.micCaptureSupported === false;
   const inputVolumeDeviceId =
@@ -493,6 +588,7 @@ function ChromaticTunerPage() {
           canStart={canStart}
           isBusy={isBusy}
           isListening={isListening}
+          isError={status === "error"}
           onStart={() => void startTuner()}
           onStop={stopTuner}
           statusText={statusText}
@@ -518,7 +614,10 @@ function ChromaticTunerPage() {
           refreshToken={systemInputVolumeRefreshToken}
         />
 
-        {errorMessage ? <p className="inline-error">{errorMessage}</p> : null}
+        {errorMessage ? <p className="inline-error" role="alert">{errorMessage}</p> : null}
+        {webAudioForced ? (
+          <p className="tuner-preferences__status">Web Audio development override is active.</p>
+        ) : null}
 
         {defaultTunerVisualMode === "simple" ? (
           <SimpleTunerMeter
@@ -542,6 +641,7 @@ function TunerHeader({
   canStart,
   isBusy,
   isListening,
+  isError,
   onStart,
   onStop,
   statusText,
@@ -549,6 +649,7 @@ function TunerHeader({
   canStart: boolean;
   isBusy: boolean;
   isListening: boolean;
+  isError: boolean;
   onStart: () => void;
   onStop: () => void;
   statusText: string;
@@ -557,7 +658,7 @@ function TunerHeader({
     <div className="tuner-header">
       <div>
         <h2>Chromatic Tuner</h2>
-        <p className="subpanel__copy">{statusText}</p>
+        <p aria-live="polite" className="subpanel__copy">{statusText}</p>
       </div>
       <div className="button-row">
         {isListening || isBusy ? (
@@ -571,7 +672,7 @@ function TunerHeader({
             onClick={onStart}
             type="button"
           >
-            Start
+            {isError ? "Retry" : "Start"}
           </button>
         )}
       </div>
@@ -811,6 +912,20 @@ function captureErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : "Could not start microphone capture.";
 }
 
+function captureStateErrorMessage(inputState: NativeAudioInputState) {
+  return captureSafeErrorMessage(inputState.error);
+}
+
+function captureSafeErrorMessage(error: NativeAudioInputState["error"]) {
+  return error
+    ? [error.message, error.guidance].filter(Boolean).join(" ")
+    : "Native microphone capture did not start.";
+}
+
+function waitForPermissionPoll() {
+  return new Promise<void>((resolve) => window.setTimeout(resolve, 250));
+}
+
 function isMicrophonePermissionError(error: unknown) {
   return error instanceof DOMException && (error.name === "NotAllowedError" || error.name === "SecurityError");
 }
@@ -819,9 +934,9 @@ function getCurrentTunerTimeMs() {
   return typeof performance !== "undefined" ? performance.now() : Date.now();
 }
 
-function headerStatusLabel(status: TunerStatus, reading: TunerPitchReading | null) {
+function headerStatusLabel(status: TunerStatus) {
   if (status === "error" || status === "unsupported") return "Error";
-  if (status === "starting") return "Listening";
-  if (status === "listening") return getTunerStatusLabel(reading);
+  if (status === "starting") return "Starting microphone";
+  if (status === "listening") return "Listening";
   return "Ready";
 }

--- a/apps/desktop/src/features/tools/TunerPreferenceControls.tsx
+++ b/apps/desktop/src/features/tools/TunerPreferenceControls.tsx
@@ -49,7 +49,7 @@ export function TunerPreferenceControls({
   visualModeLabel = "Default tuner",
 }: TunerPreferenceControlsProps) {
   const [devices, setDevices] = useState<TunerMicrophoneDevice[]>(() =>
-    readRememberedTunerMicrophoneDevices(),
+    systemDefaultOnly ? [] : readRememberedTunerMicrophoneDevices(),
   );
   const [deviceError, setDeviceError] = useState<string | null>(null);
   const [isReferenceFocused, setIsReferenceFocused] = useState(false);
@@ -84,7 +84,18 @@ export function TunerPreferenceControls({
     setDeviceError(null);
   }, [nativeCaptureDisabled]);
 
+  useEffect(() => {
+    if (systemDefaultOnly) {
+      setDevices([]);
+      setDeviceError(null);
+      refreshRequestIdRef.current += 1;
+    }
+  }, [systemDefaultOnly]);
+
   const refreshDevices = useCallback(({ queueIfBusy = false } = {}) => {
+    if (systemDefaultOnly) {
+      return Promise.resolve();
+    }
     if (refreshPromiseRef.current) {
       if (queueIfBusy) {
         pendingRefreshRef.current = true;
@@ -127,7 +138,7 @@ export function TunerPreferenceControls({
       }
     });
     return refreshPromise;
-  }, [nativeCaptureDisabled]);
+  }, [nativeCaptureDisabled, systemDefaultOnly]);
 
   useEffect(() => {
     if (lastRefreshTokenRef.current === refreshToken) {

--- a/apps/desktop/src/lib/nativeAudio.test.ts
+++ b/apps/desktop/src/lib/nativeAudio.test.ts
@@ -22,16 +22,19 @@ vi.mock("@tauri-apps/api/event", () => ({
 
 import {
   getNativeAudioCapabilities,
+  getNativeAudioInputPermissionStatus,
   getNativeAudioInputState,
   getNativeAudioSnapshot,
   isWebAudioBackendForced,
   listNativeAudioInputDevices,
   listNativeAudioOutputDevices,
   listenNativeAudioInputFrames,
+  listenNativeAudioInputState,
   listenNativeAudioPositions,
   pauseNativeAudio,
   playNativeAudio,
   prepareNativeAudioSession,
+  requestNativeAudioInputPermission,
   seekNativeAudio,
   setNativeAudioClick,
   setNativeAudioLanes,
@@ -78,6 +81,10 @@ const inputState: NativeAudioInputState = {
   monitorGain: 0.5,
   inputLevel: 0,
   sampleRate: 48000,
+  captureGeneration: 4,
+  capturePath: "desktop-cpal",
+  permissionState: "unavailable",
+  error: null,
 };
 
 describe("native audio adapter", () => {
@@ -204,6 +211,18 @@ describe("native audio adapter", () => {
     expect(mockInvoke).toHaveBeenNthCalledWith(4, "audio_stop_input");
   });
 
+  it("keeps permission status and request separate from capture start", async () => {
+    const permission = { state: "granted" as const, error: null };
+    mockInvoke.mockResolvedValue(permission);
+
+    await expect(getNativeAudioInputPermissionStatus()).resolves.toEqual(permission);
+    await expect(requestNativeAudioInputPermission()).resolves.toEqual(permission);
+
+    expect(mockInvoke).toHaveBeenNthCalledWith(1, "audio_get_input_permission_status");
+    expect(mockInvoke).toHaveBeenNthCalledWith(2, "audio_request_input_permission");
+    expect(mockInvoke).not.toHaveBeenCalledWith("audio_start_input", expect.anything());
+  });
+
   it("wraps native input frame events", async () => {
     const unlisten = vi.fn();
     const frame: NativeAudioInputFrame = {
@@ -212,6 +231,7 @@ describe("native audio adapter", () => {
       inputLevel: 0.25,
       samples: [0, 0.5, -0.5],
       timestampMs: 1234,
+      captureGeneration: 4,
     };
     mockListen.mockImplementation(async (_eventName, callback) => {
       callback({ event: "audio://input-frame", id: 1, payload: frame });
@@ -223,6 +243,22 @@ describe("native audio adapter", () => {
 
     expect(mockListen).toHaveBeenCalledWith("audio://input-frame", expect.any(Function));
     expect(handler).toHaveBeenCalledWith(frame);
+    stopListening();
+    expect(unlisten).toHaveBeenCalled();
+  });
+
+  it("wraps generation-scoped native input state events", async () => {
+    const unlisten = vi.fn();
+    mockListen.mockImplementation(async (_eventName, callback) => {
+      callback({ event: "audio://input-state", id: 2, payload: inputState });
+      return unlisten;
+    });
+    const handler = vi.fn();
+
+    const stopListening = await listenNativeAudioInputState(handler);
+
+    expect(mockListen).toHaveBeenCalledWith("audio://input-state", expect.any(Function));
+    expect(handler).toHaveBeenCalledWith(inputState);
     stopListening();
     expect(unlisten).toHaveBeenCalled();
   });

--- a/apps/desktop/src/lib/nativeAudio.ts
+++ b/apps/desktop/src/lib/nativeAudio.ts
@@ -10,6 +10,7 @@ export type NativeAudioEventName =
   | "audio://error"
   | "audio://input-level"
   | "audio://input-frame"
+  | "audio://input-state"
   | "audio://devices-changed";
 
 export type NativeAudioCapabilities = {
@@ -147,6 +148,35 @@ export type NativeAudioInputState = {
   monitorGain: number;
   inputLevel: number;
   sampleRate: number | null;
+  captureGeneration: number;
+  capturePath: "none" | "desktop-cpal" | "android-aaudio";
+  permissionState:
+    | "prompt"
+    | "prompting"
+    | "granted"
+    | "denied"
+    | "blocked"
+    | "privacy-blocked"
+    | "unavailable";
+  error: NativeAudioInputError | null;
+};
+
+export type NativeAudioInputError = {
+  code:
+    | "permission-denied"
+    | "permission-blocked"
+    | "privacy-blocked"
+    | "unavailable"
+    | "startup-failure"
+    | "stream-interruption"
+    | "background-teardown";
+  message: string;
+  guidance: string | null;
+};
+
+export type NativeAudioInputPermissionStatus = {
+  state: NativeAudioInputState["permissionState"];
+  error: NativeAudioInputError | null;
 };
 
 export type NativeAudioInputFrame = {
@@ -155,6 +185,7 @@ export type NativeAudioInputFrame = {
   inputLevel: number;
   samples: number[];
   timestampMs: number;
+  captureGeneration: number;
 };
 
 export function isWebAudioBackendForced() {
@@ -163,6 +194,10 @@ export function isWebAudioBackendForced() {
     typeof configuredValue === "string" &&
     FORCE_WEB_AUDIO_VALUES.has(configuredValue.trim().toLowerCase())
   );
+}
+
+export function isAndroidRuntime() {
+  return typeof navigator !== "undefined" && /\bAndroid\b/i.test(navigator.userAgent);
 }
 
 export function getNativeAudioCapabilities() {
@@ -213,6 +248,14 @@ export function getNativeAudioInputState() {
   return invoke<NativeAudioInputState>("audio_get_input_state");
 }
 
+export function getNativeAudioInputPermissionStatus() {
+  return invoke<NativeAudioInputPermissionStatus>("audio_get_input_permission_status");
+}
+
+export function requestNativeAudioInputPermission() {
+  return invoke<NativeAudioInputPermissionStatus>("audio_request_input_permission");
+}
+
 export function startNativeAudioInput(payload: NativeAudioInputRequest = {}) {
   return invoke<NativeAudioInputState>("audio_start_input", { payload });
 }
@@ -229,6 +272,14 @@ export function listenNativeAudioInputFrames(
   handler: (frame: NativeAudioInputFrame) => void,
 ) {
   return listen<NativeAudioInputFrame>("audio://input-frame", (event) => {
+    handler(event.payload);
+  });
+}
+
+export function listenNativeAudioInputState(
+  handler: (state: NativeAudioInputState) => void,
+) {
+  return listen<NativeAudioInputState>("audio://input-state", (event) => {
     handler(event.payload);
   });
 }

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -54,6 +54,7 @@ const {
   mockSave,
   mockConfirm,
   mockInvoke,
+  mockInvokeImplementation,
   mockListProjects,
   mockImportProject,
   mockGetProject,
@@ -101,6 +102,7 @@ const {
   setMockPowerInhibition,
   emitMockNativeAudioError,
   emitMockNativeAudioInputFrame,
+  emitMockNativeAudioInputState,
   emitMockNativeAudioPosition,
   emitMockSystemMediaControl,
   getSystemMediaControlListenerCount,
@@ -122,6 +124,7 @@ const {
     inputLevel: number;
     samples: number[];
     timestampMs: number;
+    captureGeneration: number;
   };
   type NativeAudioInputFrameEvent = {
     event: "audio://input-frame";
@@ -139,7 +142,7 @@ const {
     message: string;
   };
   type NativeAudioRuntimeEvent = {
-    event: "audio://position" | "audio://ended" | "audio://error";
+    event: "audio://position" | "audio://ended" | "audio://error" | "audio://input-state";
     id: number;
     payload: Record<string, unknown>;
   };
@@ -210,6 +213,14 @@ const {
       monitorGain: number;
       inputLevel: number;
       sampleRate: number | null;
+      captureGeneration: number;
+      capturePath: "none" | "desktop-cpal" | "android-aaudio";
+      permissionState: string;
+      error: { code: string; message: string; guidance: string | null } | null;
+    };
+    nativeAudioInputPermission: {
+      state: string;
+      error: { code: string; message: string; guidance: string | null } | null;
     };
     nativeAudioSnapshot: Record<string, unknown>;
     nativeAudioStartError: string | null;
@@ -851,7 +862,12 @@ const {
         monitorGain: 0,
         inputLevel: 0,
         sampleRate: null,
+        captureGeneration: 0,
+        capturePath: "none",
+        permissionState: "unavailable",
+        error: null,
       },
+      nativeAudioInputPermission: { state: "unavailable", error: null },
       nativeAudioSnapshot: {
         sessionId: null,
         state: "stopped",
@@ -919,6 +935,7 @@ const {
     capabilities?: Record<string, unknown>;
     inputDevices?: Record<string, unknown>;
     inputState?: Partial<typeof state.nativeAudioInputState>;
+    inputPermission?: Partial<typeof state.nativeAudioInputPermission>;
     snapshot?: Record<string, unknown>;
     startError?: string | null;
     playFallbackReason?: string | null;
@@ -935,6 +952,13 @@ const {
       ...state.nativeAudioInputState,
       ...nextState.inputState,
     };
+    state.nativeAudioInputPermission = {
+      ...state.nativeAudioInputPermission,
+      ...nextState.inputPermission,
+    };
+    if (nextState.capabilities?.platform === "android" && !nextState.inputPermission) {
+      state.nativeAudioInputPermission = { state: "granted", error: null };
+    }
     state.nativeAudioSnapshot = {
       ...state.nativeAudioSnapshot,
       ...nextState.snapshot,
@@ -986,6 +1010,9 @@ const {
         payload: clone(frame),
       });
     });
+  }
+  function emitMockNativeAudioInputState() {
+    emitMockNativeRuntimeEvent("audio://input-state", state.nativeAudioInputState);
   }
   function emitMockNativeAudioPosition(position: NativeAudioPositionPayload) {
     emitMockNativeRuntimeEvent("audio://position", position);
@@ -1056,7 +1083,8 @@ const {
       if (
         eventName === "audio://position" ||
         eventName === "audio://ended" ||
-        eventName === "audio://error"
+        eventName === "audio://error" ||
+        eventName === "audio://input-state"
       ) {
         const listenerId = nextNativeRuntimeListenerId;
         nextNativeRuntimeListenerId += 1;
@@ -1078,7 +1106,10 @@ const {
       return () => nativeInputFrameListeners.delete(listenerId);
     },
   );
-  const mockInvoke = vi.fn(async (command: string, args?: Record<string, unknown>) => {
+  const mockInvokeImplementation = async (
+    command: string,
+    args?: Record<string, unknown>,
+  ) => {
     if (command === "backend_base_url") {
       return "http://127.0.0.1:8765";
     }
@@ -1176,6 +1207,14 @@ const {
 
     if (command === "audio_get_input_state") {
       return clone(state.nativeAudioInputState);
+    }
+
+    if (command === "audio_get_input_permission_status") {
+      return clone(state.nativeAudioInputPermission);
+    }
+
+    if (command === "audio_request_input_permission") {
+      return clone(state.nativeAudioInputPermission);
     }
 
     if (command === "audio_prepare_session") {
@@ -1324,6 +1363,12 @@ const {
         monitorGain: payload.monitorGain ?? 0,
         inputLevel: 0,
         sampleRate: 48000,
+        captureGeneration: state.nativeAudioInputState.captureGeneration + 1,
+        capturePath:
+          state.nativeAudioCapabilities.platform === "android" ? "android-aaudio" : "desktop-cpal",
+        permissionState:
+          state.nativeAudioCapabilities.platform === "android" ? "granted" : "unavailable",
+        error: null,
       };
       return clone(state.nativeAudioInputState);
     }
@@ -1334,12 +1379,16 @@ const {
         active: false,
         inputLevel: 0,
         sampleRate: null,
+        captureGeneration: state.nativeAudioInputState.captureGeneration + 1,
+        capturePath: "none",
+        error: null,
       };
       return clone(state.nativeAudioInputState);
     }
 
     throw new Error(`Unexpected invoke command: ${command}`);
-  });
+  };
+  const mockInvoke = vi.fn(mockInvokeImplementation);
   const mockGetHealth = vi.fn(async () => ({
     name: "TuneForge",
     version: "backend-test-ref",
@@ -2376,6 +2425,7 @@ const {
     mockSave,
     mockConfirm,
     mockInvoke,
+    mockInvokeImplementation,
     mockListProjects,
     mockImportProject,
     mockGetProject,
@@ -2423,6 +2473,7 @@ const {
     setMockPowerInhibition,
     emitMockNativeAudioError,
     emitMockNativeAudioInputFrame,
+    emitMockNativeAudioInputState,
     emitMockNativeAudioPosition,
     emitMockSystemMediaControl,
     getSystemMediaControlListenerCount,
@@ -2826,6 +2877,10 @@ export function emitMockNativeInputFrame(
   emitMockNativeAudioInputFrame(frame);
 }
 
+export function emitMockNativeInputState() {
+  emitMockNativeAudioInputState();
+}
+
 export function emitMockNativePlaybackPosition(
   position: Parameters<typeof emitMockNativeAudioPosition>[0],
 ) {
@@ -2926,6 +2981,7 @@ export function resetAppTestHarness() {
   mockOpen.mockReset();
   mockSave.mockReset();
   mockConfirm.mockReset();
+  mockInvoke.mockImplementation(mockInvokeImplementation);
   mockInvoke.mockClear();
   Object.defineProperty(navigator, "clipboard", {
     configurable: true,

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -143,6 +143,26 @@ fallback after native failure or a build-time development override; it is not a 
 Playback state, clocks, and Settings diagnostics change only after the active native session or Web
 media confirms the transition.
 
+## Android Tuner Capture
+
+The packaged Android tuner requires native CPAL/AAudio microphone capture. A native capability,
+permission, startup, or stream failure produces a truthful recoverable tuner error and never falls
+through to Web Audio. `VITE_TUNEFORGE_FORCE_WEB_AUDIO=1` remains an explicit development-only
+all-Web override shared with playback.
+
+The tuner requests `RECORD_AUDIO` at start and distinguishes prompt, prompting, granted, denied,
+blocked, microphone-privacy blocked, and unavailable states. A blocked state points to Android
+Settings > Apps > TuneForge > Permissions and offers Retry without opening Settings. Capture polls
+permission/privacy state while active, stops on revocation or privacy blocking, and emits only safe
+structured failure codes. Android suspension tears capture down; returning to the app never restarts
+the microphone automatically.
+
+Android input routing is `System Default` only, and microphone monitoring remains unavailable. Live
+state is generation-scoped so late samples from a stopped or replaced stream cannot update pitch or
+input level. Settings keeps native capability, selection policy, permission, current path/state, last
+confirmed path, and latest safe historical failure as separate facts. Active capture is never
+restored after reload.
+
 Android power protection follows confirmed work automatically; no manual toggle exists. Confirmed
 native playback uses a `mediaPlayback` foreground service and keeps the foreground activity screen
 on. An active sync listener uses `connectedDevice`, and an active transfer also uses `dataSync`.

--- a/docs/NATIVE_AUDIO.md
+++ b/docs/NATIVE_AUDIO.md
@@ -6,7 +6,8 @@ boundary.
 
 ## Current Scope
 
-- Tuner microphone capture uses native `cpal` on supported desktop builds.
+- Tuner microphone capture uses native `cpal` on supported desktop builds and CPAL/AAudio on
+  Android.
 - Tuner device listing uses native input enumeration first, then cached/browser labels as fallback.
 - Source, practice-mix, and stem playback prefer native `cpal` on macOS/Linux and CPAL/AAudio on
   Android when every active
@@ -20,12 +21,18 @@ boundary.
 - Linux native capture and playback currently use `cpal`'s ALSA host. On PipeWire/PulseAudio
   desktops this usually routes through the host ALSA compatibility layer, but device labels may
   still look like ALSA PCM names.
-- Android native playback reports the `android-aaudio` backend and requires Android API 26 or newer.
+- Android native playback and tuner capture report the `android-aaudio` backend and require Android
+  API 26 or newer. Tuner monitoring remains unsupported.
 
 ## Backend Selection
 
 The frontend prefers native audio when a feature is supported and falls back to Web Audio when
 native support is unavailable or startup fails.
+
+Packaged Android tuner capture is an exception: it requires the native AAudio path and never silently
+falls back to `getUserMedia` after a capability, permission, startup, or stream failure. The global
+`VITE_TUNEFORGE_FORCE_WEB_AUDIO=1` development override remains an explicit all-Web mode for both
+tuner capture and playback.
 
 Playback also owns media-key controls and wake prevention through the active backend only:
 
@@ -87,8 +94,8 @@ Settings -> Local Data -> Show diagnostics reports:
 - backend package version and git ref
 - frontend package version and git ref
 - input capture availability
-- last tuner capture backend
-- last native capture error
+- capture selection policy, current Android permission, current state, and current confirmed path
+- last confirmed tuner capture path and latest safe historical failure
 - audio override and playback selection policy
 - native playback capability, even while Web Audio is forced
 - current playback state and current confirmed path
@@ -113,6 +120,13 @@ from local storage; only a safe historical backend and error may survive reload.
 When `VITE_TUNEFORGE_FORCE_WEB_AUDIO=1` is active, diagnostics report the build-time override and
 `Web Audio forced` policy while continuing to report native capability independently.
 
+Android microphone permission is requested only from a tuner start or retry. TuneForge distinguishes
+the initial prompt, an in-progress prompt, denial, permanent blocking, the Android microphone privacy
+toggle, and unavailable hardware. Blocked states give an Android Settings path and Retry; TuneForge
+does not open Settings. Permission and privacy state are rechecked before every start and while the
+stream is active. Revocation, privacy blocking, stream interruption, or app suspension stops the
+stream, clears live pitch/input state, and requires an explicit retry after resume.
+
 On Web media `error`, playback stops with an error. After `waiting` or `stalled`, five seconds with
 no progress while the element is not paused, seeking, or ended is also treated as a failed path.
 
@@ -122,6 +136,10 @@ Native tuner capture can use a selected input device without changing the system
 Native selected-device volume uses host controls where available. Web Audio capture remains limited
 to the browser/system default input path, so non-default microphone choices are disabled while Web
 Audio is active.
+
+Android exposes only `System Default` because CPAL/AAudio does not provide a confirmed stable native
+device identity for this flow. Cached browser labels and browser device choices are not shown as
+Android native routes.
 
 ## Playback QA Matrix
 

--- a/scripts/android-prepare-generated.sh
+++ b/scripts/android-prepare-generated.sh
@@ -128,15 +128,19 @@ cat > "$MAIN_ACTIVITY" <<'KOTLIN'
 package com.tuneforge.desktop
 
 import android.Manifest
+import android.app.AppOpsManager
 import android.content.pm.PackageManager
+import android.hardware.SensorPrivacyManager
 import android.os.Build
 import android.os.Bundle
+import android.os.Process
 import android.view.View
 import android.view.WindowInsets
 import android.view.WindowInsetsController
 
 class MainActivity : TauriActivity() {
   private var notificationPermissionOwnershipRevision = 0L
+  @Volatile private var microphonePermissionRequestPending = false
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -188,6 +192,55 @@ class MainActivity : TauriActivity() {
         notificationPermissionOwnershipRevision,
       )
     }
+    if (requestCode == MICROPHONE_PERMISSION_REQUEST) {
+      microphonePermissionRequestPending = false
+    }
+  }
+
+  fun getTuneForgeAudioPermissionState(): String {
+    if (!packageManager.hasSystemFeature(PackageManager.FEATURE_MICROPHONE)) return "unavailable"
+    if (checkSelfPermission(Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED) {
+      return if (microphonePrivacyBlocked()) "privacy-blocked" else "granted"
+    }
+    if (microphonePermissionRequestPending) return "prompting"
+    val requestedBefore = getPreferences(MODE_PRIVATE)
+      .getBoolean(MICROPHONE_PERMISSION_REQUESTED, false)
+    if (!requestedBefore) return "prompt"
+    return if (shouldShowRequestPermissionRationale(Manifest.permission.RECORD_AUDIO)) {
+      "denied"
+    } else {
+      "blocked"
+    }
+  }
+
+  fun requestTuneForgeAudioPermission(): String {
+    val state = getTuneForgeAudioPermissionState()
+    if (state != "prompt" && state != "denied") return state
+    microphonePermissionRequestPending = true
+    getPreferences(MODE_PRIVATE).edit()
+      .putBoolean(MICROPHONE_PERMISSION_REQUESTED, true)
+      .apply()
+    window.decorView.post {
+      if (microphonePermissionRequestPending) {
+        requestPermissions(
+          arrayOf(Manifest.permission.RECORD_AUDIO),
+          MICROPHONE_PERMISSION_REQUEST,
+        )
+      }
+    }
+    return "prompting"
+  }
+
+  private fun microphonePrivacyBlocked(): Boolean {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return false
+    val privacy = getSystemService(SensorPrivacyManager::class.java) ?: return false
+    if (!privacy.supportsSensorToggle(SensorPrivacyManager.Sensors.MICROPHONE)) return false
+    val appOps = getSystemService(AppOpsManager::class.java) ?: return false
+    return appOps.checkOpNoThrow(
+      AppOpsManager.OPSTR_RECORD_AUDIO,
+      Process.myUid(),
+      packageName,
+    ) == AppOpsManager.MODE_IGNORED
   }
 
   private fun requestTuneForgeNotificationPermission() {
@@ -207,6 +260,8 @@ class MainActivity : TauriActivity() {
 
   companion object {
     private const val NOTIFICATION_PERMISSION_REQUEST = 2305
+    private const val MICROPHONE_PERMISSION_REQUEST = 2306
+    private const val MICROPHONE_PERMISSION_REQUESTED = "tuneforge_microphone_permission_requested"
   }
 
   @Suppress("DEPRECATION")


### PR DESCRIPTION
## Summary

- Add Android CPAL/AAudio tuner capture with runtime microphone permission and lifecycle handling.
- Scope frames and terminal events to capture generations, reject stale signals, and report truthful native-only recovery states.
- Keep Android routing system-default-only and extend diagnostics and docs without Web Audio fallback.
- Closes #357

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @tuneforge/desktop test -- App.tools-tuner.test.tsx`
- `pnpm --filter @tuneforge/desktop test -- src/lib/nativeAudio.test.ts`
- `cd apps/desktop/src-tauri && cargo test native_audio::capture`
- `pnpm package:android:debug`
- Pixel 10 Pro XL AVD: native AAudio start, Android permission prompt, one-time grant, live host-mic pitch movement, and Stop teardown passed.
- Physical-phone, Bluetooth/USB routing, native-playback coexistence, and full manual denial/background/privacy matrix were not run; physical validation was waived after successful AVD pitch capture.
- `bash scripts/android-arm64-env.sh cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml --target aarch64-linux-android` was blocked before crate compilation by stale global Cargo registry plugin cache entries; the supported Android packaging path passed.
