### PR TITLE
fix(android): stream Web Audio through ranged loopback

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ use tauri::{AppHandle, Manager, State};
 
 mod file_dialog_scope;
 mod mobile_backend;
+mod mobile_media_transport;
 mod native_audio;
 pub mod power_inhibition;
 mod sync_transport;
@@ -370,12 +371,15 @@ pub fn run() {
                 spawn_packaged_backend(app.handle())?
             };
             let power_inhibition = power_inhibition::PowerInhibitionState::new();
+            let mobile_media =
+                mobile_media_transport::MobileMediaTransportState::new(app.handle().clone())?;
             let sync_transport = sync_transport::SyncTransportState::new(
                 runtime.base_url.clone(),
                 app.handle().clone(),
                 power_inhibition.clone(),
             );
             app.manage(runtime);
+            app.manage(mobile_media);
             app.manage(native_audio::NativeAudioState::new());
             app.manage(sync_transport);
             app.manage(system_media::SystemMediaState::new(app.handle().clone()));
@@ -456,7 +460,8 @@ pub fn run() {
             mobile_backend::mobile_get_sync_staged_artifact,
             mobile_backend::mobile_import_sync_project,
             mobile_backend::mobile_plan_sync_reconciliation,
-            mobile_backend::mobile_apply_sync_reconciliation
+            mobile_backend::mobile_apply_sync_reconciliation,
+            mobile_media_transport::mobile_media_base_url
         ])
         .build(tauri::generate_context!())
         .expect("error while building tuneforge");
@@ -474,6 +479,9 @@ pub fn run() {
             native_audio::stop_input_for_lifecycle(app_handle, native_audio.inner());
         }
         if let tauri::RunEvent::Exit = event {
+            let mobile_media =
+                app_handle.state::<mobile_media_transport::MobileMediaTransportState>();
+            mobile_media.shutdown();
             let sync_transport = app_handle.state::<sync_transport::SyncTransportState>();
             sync_transport.shutdown();
             let power_inhibition = app_handle.state::<power_inhibition::PowerInhibitionState>();

--- a/apps/desktop/src-tauri/src/mobile_backend/storage.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/storage.rs
@@ -48,6 +48,14 @@ fn ensure_source_playback_proxy_metadata(
 pub struct MobileSyncTransportArtifactFile {
     pub path: PathBuf,
     pub size_bytes: u64,
+    pub media: Result<MobileMediaArtifactFile, String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct MobileMediaArtifactFile {
+    pub path: PathBuf,
+    pub size_bytes: u64,
+    pub format: String,
 }
 pub(super) const DEFAULT_PROJECTS_LIMIT: usize = 50;
 pub(super) const MAX_PROJECTS_LIMIT: usize = 200;
@@ -2029,11 +2037,19 @@ pub fn mobile_sync_transport_artifact_file(
     app: AppHandle,
     artifact_id: &str,
 ) -> Result<MobileSyncTransportArtifactFile, String> {
+    let connection = db(&app)?;
+    let root = app_data_root(&app)?;
+    mobile_sync_transport_artifact_file_at_root(&connection, &root, artifact_id)
+}
+
+fn mobile_sync_transport_artifact_file_at_root(
+    connection: &Connection,
+    root: &Path,
+    artifact_id: &str,
+) -> Result<MobileSyncTransportArtifactFile, String> {
     if artifact_id.trim().is_empty() || artifact_id != artifact_id.trim() {
         return Err("artifact_id must be canonical.".to_string());
     }
-    let connection = db(&app)?;
-    let root = app_data_root(&app)?;
     let artifact = connection
         .query_row(
             &format!("SELECT {ARTIFACT_COLUMNS} FROM artifacts WHERE id = ?1"),
@@ -2043,10 +2059,13 @@ pub fn mobile_sync_transport_artifact_file(
         .optional()
         .map_err(|error| error.to_string())?
         .ok_or_else(|| "Artifact is unknown.".to_string())?;
+    if get_project_schema(&connection, &artifact.project_id)?.sync_status == "deleted" {
+        return Err("Artifact is unknown.".to_string());
+    }
     if artifact.size_bytes < 0 {
         return Err("Artifact size_bytes must be non-negative.".to_string());
     }
-    let relative_path = relative_artifact_path(&root, &artifact)
+    let relative_path = relative_artifact_path(root, &artifact)
         .ok_or_else(|| "Project artifact path is outside the mobile app data root.".to_string())?;
     safe_relative_path(&relative_path)?;
     let content_sha256 = artifact
@@ -2055,6 +2074,18 @@ pub fn mobile_sync_transport_artifact_file(
         .ok_or_else(|| "Project artifact is missing content SHA-256 metadata.".to_string())
         .and_then(|value| normalize_sha256(value, "content_sha256"))?;
     let path = PathBuf::from(&artifact.path);
+    let canonical_root = root.canonicalize().map_err(|error| error.to_string())?;
+    let canonical_project = project_root_path(root, &artifact.project_id)?
+        .canonicalize()
+        .map_err(|error| error.to_string())?;
+    let path = path
+        .canonicalize()
+        .map_err(|_| "Project artifact file is missing or unreadable.".to_string())?;
+    if !canonical_project.starts_with(canonical_root.join("projects"))
+        || !path.starts_with(&canonical_project)
+    {
+        return Err("Project artifact path is outside the mobile app data root.".to_string());
+    }
     let metadata = fs::metadata(&path)
         .map_err(|_| "Project artifact file is missing or unreadable.".to_string())?;
     if metadata.len() as i64 != artifact.size_bytes {
@@ -2063,8 +2094,241 @@ pub fn mobile_sync_transport_artifact_file(
     if file_sha256(&path)? != content_sha256 {
         return Err("Project artifact file SHA-256 does not match its metadata.".to_string());
     }
+    let original = MobileMediaArtifactFile {
+        path: path.clone(),
+        size_bytes: artifact.size_bytes as u64,
+        format: artifact.format.clone(),
+    };
+    let media = mobile_media_artifact_file_at_root(&artifact, &canonical_project, original);
     Ok(MobileSyncTransportArtifactFile {
         path,
         size_bytes: artifact.size_bytes as u64,
+        media,
     })
+}
+
+fn mobile_media_artifact_file_at_root(
+    artifact: &ArtifactSchema,
+    canonical_project: &Path,
+    original: MobileMediaArtifactFile,
+) -> Result<MobileMediaArtifactFile, String> {
+    if !matches!(
+        artifact.format.to_ascii_lowercase().as_str(),
+        "webm" | "mkv" | "mka"
+    ) {
+        return Ok(original);
+    }
+    let Some(playback_path) = artifact
+        .metadata
+        .get("playback_path")
+        .and_then(Value::as_str)
+    else {
+        return Ok(original);
+    };
+    let playback_format = artifact
+        .metadata
+        .get("playback_format")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty() && *value == value.trim())
+        .ok_or_else(|| "Project playback proxy metadata is invalid.".to_string())?;
+    let path = Path::new(playback_path)
+        .canonicalize()
+        .map_err(|_| "Project playback proxy is missing or unreadable.".to_string())?;
+    if !path.starts_with(canonical_project) || !path.is_file() {
+        return Err("Project playback proxy is outside the mobile app data root.".to_string());
+    }
+    let size_bytes = fs::metadata(&path)
+        .map_err(|_| "Project playback proxy is missing or unreadable.".to_string())?
+        .len();
+    Ok(MobileMediaArtifactFile {
+        path,
+        size_bytes,
+        format: playback_format.to_ascii_lowercase(),
+    })
+}
+
+#[cfg(test)]
+mod mobile_media_tests {
+    use super::*;
+
+    const ARTIFACT_ID: &str = "art_0123456789ab";
+    const MANIFEST_ARTIFACT_ID: &str = "manifest/source v1";
+
+    #[test]
+    fn media_resolution_rejects_invalid_stale_unauthorized_and_changed_artifacts() {
+        let root = std::env::temp_dir().join(format!(
+            "tuneforge-mobile-media-storage-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let connection = db_at_root(&root).unwrap();
+        let bytes = b"synthetic media fixture";
+        let hash = {
+            let mut hasher = Sha256::new();
+            hasher.update(bytes);
+            hex_digest(&hasher.finalize())
+        };
+        let project_id = source_hash_to_project_id(&hash).unwrap();
+        let project_root = project_root_path(&root, &project_id).unwrap();
+        let path = project_root.join("source/fixture.wav");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, bytes).unwrap();
+        let now = "2026-07-22T17:00:00.000Z";
+        connection
+            .execute(
+                "INSERT INTO projects (id, display_name, source_sha256, source_path, imported_path, sync_status, created_at, updated_at)
+                 VALUES (?1, 'Fixture', ?2, ?3, ?3, 'local', ?4, ?4)",
+                params![project_id, hash, path.to_string_lossy(), now],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO artifacts (id, project_id, type, format, path, content_sha256, size_bytes, generated_by, can_delete, can_regenerate, metadata_json, created_at)
+                 VALUES (?1, ?2, 'source_audio', 'wav', ?3, ?4, ?5, 'sync', 0, 0, '{}', ?6)",
+                params![
+                    ARTIFACT_ID,
+                    project_id,
+                    path.to_string_lossy(),
+                    hash,
+                    bytes.len() as i64,
+                    now
+                ],
+            )
+            .unwrap();
+
+        let resolved =
+            mobile_sync_transport_artifact_file_at_root(&connection, &root, ARTIFACT_ID).unwrap();
+        assert_eq!(resolved.size_bytes, bytes.len() as u64);
+        assert_eq!(resolved.media.unwrap().path, path.canonicalize().unwrap());
+        connection
+            .execute(
+                "INSERT INTO artifacts (id, project_id, type, format, path, content_sha256, size_bytes, generated_by, can_delete, can_regenerate, metadata_json, created_at)
+                 SELECT ?1, project_id, type, format, path, content_sha256, size_bytes, generated_by, can_delete, can_regenerate, metadata_json, created_at FROM artifacts WHERE id = ?2",
+                params![MANIFEST_ARTIFACT_ID, ARTIFACT_ID],
+            )
+            .unwrap();
+        assert!(mobile_sync_transport_artifact_file_at_root(
+            &connection,
+            &root,
+            MANIFEST_ARTIFACT_ID
+        )
+        .is_ok());
+        assert!(mobile_sync_transport_artifact_file_at_root(&connection, &root, " bad").is_err());
+        assert!(mobile_sync_transport_artifact_file_at_root(
+            &connection,
+            &root,
+            "art_ffffffffffffffffffffffffffff"
+        )
+        .is_err());
+
+        let proxy = project_root.join("playback/source-playback.wav");
+        fs::create_dir_all(proxy.parent().unwrap()).unwrap();
+        fs::write(&proxy, b"synthetic playback proxy").unwrap();
+        connection
+            .execute(
+                "UPDATE artifacts SET format = 'webm', metadata_json = ?1 WHERE id = ?2",
+                params![
+                    json!({"playback_path": proxy, "playback_format": "wav"}).to_string(),
+                    ARTIFACT_ID
+                ],
+            )
+            .unwrap();
+        let resolved =
+            mobile_sync_transport_artifact_file_at_root(&connection, &root, ARTIFACT_ID).unwrap();
+        assert_eq!(resolved.path, path.canonicalize().unwrap());
+        assert_eq!(resolved.size_bytes, bytes.len() as u64);
+        let media = resolved.media.unwrap();
+        assert_eq!(media.path, proxy.canonicalize().unwrap());
+        assert_eq!(media.size_bytes, b"synthetic playback proxy".len() as u64);
+        assert_eq!(media.format, "wav");
+
+        let outside_proxy = root.join("outside-proxy.wav");
+        fs::write(&outside_proxy, b"outside").unwrap();
+        connection
+            .execute(
+                "UPDATE artifacts SET metadata_json = ?1 WHERE id = ?2",
+                params![
+                    json!({"playback_path": outside_proxy, "playback_format": "wav"}).to_string(),
+                    ARTIFACT_ID
+                ],
+            )
+            .unwrap();
+        assert!(
+            mobile_sync_transport_artifact_file_at_root(&connection, &root, ARTIFACT_ID)
+                .unwrap()
+                .media
+                .is_err()
+        );
+        connection
+            .execute(
+                "UPDATE artifacts SET metadata_json = ?1 WHERE id = ?2",
+                params![
+                    json!({"playback_path": project_root.join("missing.wav"), "playback_format": "wav"}).to_string(),
+                    ARTIFACT_ID
+                ],
+            )
+            .unwrap();
+        assert!(
+            mobile_sync_transport_artifact_file_at_root(&connection, &root, ARTIFACT_ID)
+                .unwrap()
+                .media
+                .is_err()
+        );
+        connection
+            .execute(
+                "UPDATE artifacts SET format = 'wav', metadata_json = '{}' WHERE id = ?1",
+                params![ARTIFACT_ID],
+            )
+            .unwrap();
+
+        connection
+            .execute(
+                "UPDATE artifacts SET size_bytes = size_bytes + 1 WHERE id = ?1",
+                params![ARTIFACT_ID],
+            )
+            .unwrap();
+        assert!(
+            mobile_sync_transport_artifact_file_at_root(&connection, &root, ARTIFACT_ID).is_err()
+        );
+        connection
+            .execute(
+                "UPDATE artifacts SET size_bytes = ?1, content_sha256 = ?2 WHERE id = ?3",
+                params![bytes.len() as i64, "0".repeat(64), ARTIFACT_ID],
+            )
+            .unwrap();
+        assert!(
+            mobile_sync_transport_artifact_file_at_root(&connection, &root, ARTIFACT_ID).is_err()
+        );
+
+        let outside = root.join("outside.wav");
+        fs::write(&outside, bytes).unwrap();
+        connection
+            .execute(
+                "UPDATE artifacts SET path = ?1, content_sha256 = ?2 WHERE id = ?3",
+                params![outside.to_string_lossy(), hash, ARTIFACT_ID],
+            )
+            .unwrap();
+        assert!(
+            mobile_sync_transport_artifact_file_at_root(&connection, &root, ARTIFACT_ID).is_err()
+        );
+        connection
+            .execute(
+                "UPDATE artifacts SET path = ?1 WHERE id = ?2",
+                params![path.to_string_lossy(), ARTIFACT_ID],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "UPDATE projects SET sync_status = 'deleted' WHERE id = ?1",
+                params![project_id],
+            )
+            .unwrap();
+        assert!(
+            mobile_sync_transport_artifact_file_at_root(&connection, &root, ARTIFACT_ID).is_err()
+        );
+
+        drop(connection);
+        fs::remove_dir_all(root).unwrap();
+    }
 }

--- a/apps/desktop/src-tauri/src/mobile_media_transport.rs
+++ b/apps/desktop/src-tauri/src/mobile_media_transport.rs
@@ -1,0 +1,980 @@
+use std::sync::Mutex;
+#[cfg(any(target_os = "android", test))]
+use std::{
+    io::{Read, Seek, SeekFrom, Write},
+    net::{Shutdown, SocketAddr, TcpListener, TcpStream},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc::{self, Receiver},
+        Arc,
+    },
+    thread::{self, JoinHandle},
+    time::Duration,
+};
+
+#[cfg(any(target_os = "android", test))]
+use rand::{rngs::SysRng, TryRng};
+
+use tauri::AppHandle;
+
+#[cfg(any(target_os = "android", test))]
+const MAX_REQUEST_BYTES: usize = 8 * 1024;
+#[cfg(any(target_os = "android", test))]
+const STREAM_BUFFER_BYTES: usize = 64 * 1024;
+#[cfg(any(target_os = "android", test))]
+const WORKER_COUNT: usize = 4;
+#[cfg(any(target_os = "android", test))]
+const QUEUE_DEPTH: usize = 8;
+
+#[cfg(any(target_os = "android", test))]
+type Resolver = Arc<dyn Fn(&str) -> Result<ResolvedMedia, String> + Send + Sync>;
+
+#[cfg(any(target_os = "android", test))]
+struct ResolvedMedia {
+    file: std::fs::File,
+    size_bytes: u64,
+    content_type: &'static str,
+}
+
+#[cfg(any(target_os = "android", test))]
+struct ServerRuntime {
+    base_url: String,
+    address: SocketAddr,
+    stop: Arc<AtomicBool>,
+    active: Arc<Mutex<Vec<Option<TcpStream>>>>,
+    listener: Mutex<Option<JoinHandle<()>>>,
+    workers: Mutex<Vec<JoinHandle<()>>>,
+}
+
+#[cfg(not(any(target_os = "android", test)))]
+struct ServerRuntime;
+
+#[cfg(any(target_os = "android", test))]
+impl ServerRuntime {
+    fn start(resolver: Resolver) -> Result<Self, String> {
+        Self::start_internal(resolver, None)
+    }
+
+    fn start_internal(
+        resolver: Resolver,
+        stream_chunk_delay: Option<Duration>,
+    ) -> Result<Self, String> {
+        let listener = TcpListener::bind(("127.0.0.1", 0))
+            .map_err(|_| "Mobile media transport could not start.".to_string())?;
+        let address = listener
+            .local_addr()
+            .map_err(|_| "Mobile media transport could not start.".to_string())?;
+        listener
+            .set_nonblocking(true)
+            .map_err(|_| "Mobile media transport could not start.".to_string())?;
+        let capability = capability_token()?;
+        let artifact_route_prefix: Arc<str> = format!("/{capability}/artifacts/").into();
+        let stop = Arc::new(AtomicBool::new(false));
+        let active = Arc::new(Mutex::new(
+            (0..WORKER_COUNT).map(|_| None).collect::<Vec<_>>(),
+        ));
+        let (sender, receiver) = mpsc::sync_channel::<TcpStream>(QUEUE_DEPTH);
+        let receiver = Arc::new(Mutex::new(receiver));
+        let workers = (0..WORKER_COUNT)
+            .map(|worker_index| {
+                let receiver = receiver.clone();
+                let resolver = resolver.clone();
+                let stop = stop.clone();
+                let active = active.clone();
+                let artifact_route_prefix = artifact_route_prefix.clone();
+                thread::spawn(move || {
+                    worker_loop(
+                        worker_index,
+                        receiver,
+                        resolver,
+                        artifact_route_prefix,
+                        stop,
+                        active,
+                        stream_chunk_delay,
+                    )
+                })
+            })
+            .collect();
+        let listener_stop = stop.clone();
+        let listener_thread = thread::spawn(move || {
+            while !listener_stop.load(Ordering::Acquire) {
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        let _ = sender.try_send(stream);
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+        Ok(Self {
+            base_url: format!("http://{address}/{capability}"),
+            address,
+            stop,
+            active,
+            listener: Mutex::new(Some(listener_thread)),
+            workers: Mutex::new(workers),
+        })
+    }
+
+    fn shutdown(&self) {
+        if self.stop.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let _ = TcpStream::connect(self.address);
+        if let Ok(active) = self.active.lock() {
+            for stream in active.iter().flatten() {
+                let _ = stream.shutdown(Shutdown::Both);
+            }
+        }
+        if let Ok(mut listener) = self.listener.lock() {
+            if let Some(handle) = listener.take() {
+                let _ = handle.join();
+            }
+        }
+        if let Ok(mut workers) = self.workers.lock() {
+            for handle in workers.drain(..) {
+                let _ = handle.join();
+            }
+        }
+    }
+}
+
+#[cfg(any(target_os = "android", test))]
+fn capability_token() -> Result<String, String> {
+    let mut bytes = [0_u8; 32];
+    SysRng
+        .try_fill_bytes(&mut bytes)
+        .map_err(|_| "Mobile media transport could not start.".to_string())?;
+    let mut token = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write as _;
+
+        write!(&mut token, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    Ok(token)
+}
+
+#[cfg(any(target_os = "android", test))]
+impl Drop for ServerRuntime {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+#[cfg(not(any(target_os = "android", test)))]
+impl ServerRuntime {
+    fn shutdown(&self) {}
+}
+
+pub struct MobileMediaTransportState {
+    #[cfg(target_os = "android")]
+    resolver: Resolver,
+    server: Mutex<Option<ServerRuntime>>,
+}
+
+impl MobileMediaTransportState {
+    pub fn new(app: AppHandle) -> Result<Self, String> {
+        #[cfg(target_os = "android")]
+        {
+            let resolver = Arc::new(move |artifact_id: &str| {
+                let artifact = crate::mobile_backend::mobile_sync_transport_artifact_file(
+                    app.clone(),
+                    artifact_id,
+                )?;
+                let media = artifact.media?;
+                let content_type = content_type_for_format(&media.format)
+                    .ok_or_else(|| "Media artifact is unavailable.".to_string())?;
+                Ok(ResolvedMedia {
+                    file: std::fs::File::open(media.path)
+                        .map_err(|_| "Media artifact is unavailable.".to_string())?,
+                    size_bytes: media.size_bytes,
+                    content_type,
+                })
+            });
+            return Ok(Self {
+                resolver,
+                server: Mutex::new(None),
+            });
+        }
+        #[cfg(not(target_os = "android"))]
+        {
+            let _ = app;
+            Ok(Self {
+                server: Mutex::new(None),
+            })
+        }
+    }
+
+    pub fn shutdown(&self) {
+        shutdown_server(&self.server);
+    }
+
+    fn base_url(&self) -> Result<String, String> {
+        #[cfg(target_os = "android")]
+        {
+            return ensure_server_with(&self.server, || {
+                ServerRuntime::start(self.resolver.clone())
+            });
+        }
+        #[cfg(not(target_os = "android"))]
+        {
+            Err("Mobile media transport is unavailable.".to_string())
+        }
+    }
+}
+
+fn shutdown_server(server: &Mutex<Option<ServerRuntime>>) {
+    let server = server
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .take();
+    if let Some(server) = server {
+        server.shutdown();
+    }
+}
+
+#[tauri::command]
+pub fn mobile_media_base_url(
+    state: tauri::State<'_, MobileMediaTransportState>,
+) -> Result<String, String> {
+    state.base_url()
+}
+
+#[cfg(any(target_os = "android", test))]
+fn ensure_server_with(
+    server: &Mutex<Option<ServerRuntime>>,
+    start: impl FnOnce() -> Result<ServerRuntime, String>,
+) -> Result<String, String> {
+    let mut server = server
+        .lock()
+        .map_err(|_| "Mobile media transport could not start.".to_string())?;
+    if let Some(server) = server.as_ref() {
+        return Ok(server.base_url.clone());
+    }
+    let started = start()?;
+    let base_url = started.base_url.clone();
+    *server = Some(started);
+    Ok(base_url)
+}
+
+#[cfg(any(target_os = "android", test))]
+fn worker_loop(
+    worker_index: usize,
+    receiver: Arc<Mutex<Receiver<TcpStream>>>,
+    resolver: Resolver,
+    artifact_route_prefix: Arc<str>,
+    stop: Arc<AtomicBool>,
+    active: Arc<Mutex<Vec<Option<TcpStream>>>>,
+    stream_chunk_delay: Option<Duration>,
+) {
+    while !stop.load(Ordering::Acquire) {
+        let stream = receiver
+            .lock()
+            .ok()
+            .and_then(|receiver| receiver.recv_timeout(Duration::from_millis(100)).ok());
+        if let Some(stream) = stream {
+            let tracked = match stream.try_clone() {
+                Ok(tracked) => tracked,
+                Err(_) => continue,
+            };
+            if let Ok(mut sockets) = active.lock() {
+                sockets[worker_index] = Some(tracked);
+            }
+            if stop.load(Ordering::Acquire) {
+                let _ = stream.shutdown(Shutdown::Both);
+            } else {
+                let _ = serve(
+                    stream,
+                    &resolver,
+                    &artifact_route_prefix,
+                    &stop,
+                    stream_chunk_delay,
+                );
+            }
+            if let Ok(mut sockets) = active.lock() {
+                sockets[worker_index] = None;
+            }
+        }
+    }
+}
+
+#[cfg(any(target_os = "android", test))]
+fn serve(
+    mut stream: TcpStream,
+    resolver: &Resolver,
+    artifact_route_prefix: &str,
+    stop: &AtomicBool,
+    stream_chunk_delay: Option<Duration>,
+) -> std::io::Result<()> {
+    stream.set_read_timeout(Some(Duration::from_secs(3)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(10)))?;
+    let request = match read_request(&mut stream) {
+        Ok(request) => request,
+        Err(status) => return write_empty(&mut stream, status, &[], None),
+    };
+    let cors = match request.origin.as_deref() {
+        Some(origin) if is_allowed_origin(origin) => Some(origin),
+        Some(_) => return write_empty(&mut stream, 403, &[], None),
+        None => None,
+    };
+    let artifact_id = match request.path.strip_prefix(artifact_route_prefix) {
+        Some(value) if !value.is_empty() && !value.contains('/') => decode_path_segment(value),
+        _ => return write_empty(&mut stream, 404, &[], cors),
+    };
+    let Some(artifact_id) = artifact_id else {
+        return write_empty(&mut stream, 404, &[], cors);
+    };
+    if request.method == "OPTIONS" {
+        if cors.is_none() || request.requested_headers.as_deref() != Some("range") {
+            return write_empty(&mut stream, 403, &[], cors);
+        }
+        return write_empty(
+            &mut stream,
+            204,
+            &[
+                ("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS".into()),
+                ("Access-Control-Allow-Headers", "Range".into()),
+                ("Access-Control-Max-Age", "600".into()),
+            ],
+            cors,
+        );
+    }
+    if request.method != "GET" && request.method != "HEAD" {
+        return write_empty(
+            &mut stream,
+            405,
+            &[("Allow", "GET, HEAD, OPTIONS".into())],
+            cors,
+        );
+    }
+    let mut media = match resolver(&artifact_id) {
+        Ok(media) => media,
+        Err(_) => return write_empty(&mut stream, 404, &[], cors),
+    };
+    let range = match request.range.as_deref() {
+        Some(value) => match parse_range(value, media.size_bytes) {
+            Ok(range) => Some(range),
+            Err(()) => {
+                return write_empty(
+                    &mut stream,
+                    416,
+                    &[("Content-Range", format!("bytes */{}", media.size_bytes))],
+                    cors,
+                )
+            }
+        },
+        None => None,
+    };
+    let (status, start, end) = range.map(|(start, end)| (206, start, end)).unwrap_or((
+        200,
+        0,
+        media.size_bytes.saturating_sub(1),
+    ));
+    let length = if media.size_bytes == 0 {
+        0
+    } else {
+        end - start + 1
+    };
+    let mut headers = vec![
+        ("Accept-Ranges", "bytes".into()),
+        ("Content-Length", length.to_string()),
+        ("Content-Type", media.content_type.into()),
+    ];
+    if status == 206 {
+        headers.push((
+            "Content-Range",
+            format!("bytes {start}-{end}/{}", media.size_bytes),
+        ));
+    }
+    write_head(&mut stream, status, &headers, cors)?;
+    if request.method == "HEAD" || length == 0 {
+        return Ok(());
+    }
+    media.file.seek(SeekFrom::Start(start))?;
+    let mut remaining = length;
+    let mut buffer = [0_u8; STREAM_BUFFER_BYTES];
+    while remaining > 0 {
+        if stop.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        let count = media
+            .file
+            .read(&mut buffer[..remaining.min(STREAM_BUFFER_BYTES as u64) as usize])?;
+        if count == 0 {
+            break;
+        }
+        stream.write_all(&buffer[..count])?;
+        remaining -= count as u64;
+        if let Some(delay) = stream_chunk_delay {
+            let deadline = std::time::Instant::now() + delay;
+            while std::time::Instant::now() < deadline {
+                if stop.load(Ordering::Acquire) {
+                    return Ok(());
+                }
+                thread::sleep(Duration::from_millis(5));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "android", test))]
+fn decode_path_segment(value: &str) -> Option<String> {
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' {
+            let high = bytes.get(index + 1).and_then(|value| hex_digit(*value))?;
+            let low = bytes.get(index + 2).and_then(|value| hex_digit(*value))?;
+            decoded.push(high << 4 | low);
+            index += 3;
+        } else {
+            decoded.push(bytes[index]);
+            index += 1;
+        }
+    }
+    String::from_utf8(decoded).ok()
+}
+
+#[cfg(any(target_os = "android", test))]
+fn hex_digit(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
+    }
+}
+
+#[cfg(any(target_os = "android", test))]
+fn content_type_for_format(format: &str) -> Option<&'static str> {
+    match format.to_ascii_lowercase().as_str() {
+        "aac" => Some("audio/aac"),
+        "flac" => Some("audio/flac"),
+        "m4a" | "mp4" => Some("audio/mp4"),
+        "mka" => Some("audio/x-matroska"),
+        "mkv" => Some("video/x-matroska"),
+        "mp3" => Some("audio/mpeg"),
+        "ogg" | "oga" | "opus" => Some("audio/ogg"),
+        "wav" | "wave" => Some("audio/wav"),
+        "webm" => Some("audio/webm"),
+        _ => None,
+    }
+}
+
+#[cfg(any(target_os = "android", test))]
+struct Request {
+    method: String,
+    path: String,
+    origin: Option<String>,
+    range: Option<String>,
+    requested_headers: Option<String>,
+}
+
+#[cfg(any(target_os = "android", test))]
+fn read_request(stream: &mut TcpStream) -> Result<Request, u16> {
+    let mut bytes = Vec::with_capacity(1024);
+    let mut chunk = [0_u8; 1024];
+    while !bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+        let count = stream.read(&mut chunk).map_err(|_| 408_u16)?;
+        if count == 0 {
+            return Err(400);
+        }
+        bytes.extend_from_slice(&chunk[..count]);
+        if bytes.len() > MAX_REQUEST_BYTES {
+            return Err(431);
+        }
+    }
+    let text = std::str::from_utf8(&bytes).map_err(|_| 400_u16)?;
+    let mut lines = text.split("\r\n");
+    let mut parts = lines.next().ok_or(400_u16)?.split_whitespace();
+    let method = parts.next().ok_or(400_u16)?.to_string();
+    let path = parts.next().ok_or(400_u16)?.to_string();
+    if parts
+        .next()
+        .filter(|value| value.starts_with("HTTP/1."))
+        .is_none()
+        || parts.next().is_some()
+    {
+        return Err(400);
+    }
+    let mut request = Request {
+        method,
+        path,
+        origin: None,
+        range: None,
+        requested_headers: None,
+    };
+    for line in lines.take_while(|line| !line.is_empty()) {
+        let (name, value) = line.split_once(':').ok_or(400_u16)?;
+        let value = value.trim();
+        match name.to_ascii_lowercase().as_str() {
+            "origin" => request.origin = Some(value.to_string()),
+            "range" => match request.range.as_mut() {
+                Some(existing) => {
+                    existing.push(',');
+                    existing.push_str(value);
+                }
+                None => request.range = Some(value.to_string()),
+            },
+            "access-control-request-headers" => {
+                request.requested_headers = Some(value.to_ascii_lowercase())
+            }
+            _ => {}
+        }
+    }
+    Ok(request)
+}
+
+#[cfg(any(target_os = "android", test))]
+fn parse_range(value: &str, length: u64) -> Result<(u64, u64), ()> {
+    let value = value.strip_prefix("bytes=").ok_or(())?;
+    if value.contains(',') || length == 0 {
+        return Err(());
+    }
+    let (start, end) = value.split_once('-').ok_or(())?;
+    if start.is_empty() {
+        let suffix = end.parse::<u64>().map_err(|_| ())?;
+        if suffix == 0 {
+            return Err(());
+        }
+        return Ok((length.saturating_sub(suffix), length - 1));
+    }
+    let start = start.parse::<u64>().map_err(|_| ())?;
+    let end = if end.is_empty() {
+        length - 1
+    } else {
+        end.parse::<u64>().map_err(|_| ())?.min(length - 1)
+    };
+    if start >= length || end < start {
+        return Err(());
+    }
+    Ok((start, end))
+}
+
+#[cfg(any(target_os = "android", test))]
+fn is_allowed_origin(origin: &str) -> bool {
+    matches!(
+        origin,
+        "http://tauri.localhost"
+            | "https://tauri.localhost"
+            | "http://127.0.0.1:1420"
+            | "http://localhost:1420"
+    )
+}
+
+#[cfg(any(target_os = "android", test))]
+fn write_empty(
+    stream: &mut TcpStream,
+    status: u16,
+    headers: &[(&str, String)],
+    origin: Option<&str>,
+) -> std::io::Result<()> {
+    let mut headers = headers.to_vec();
+    headers.push(("Content-Length", "0".into()));
+    write_head(stream, status, &headers, origin)
+}
+
+#[cfg(any(target_os = "android", test))]
+fn write_head(
+    stream: &mut TcpStream,
+    status: u16,
+    headers: &[(&str, String)],
+    origin: Option<&str>,
+) -> std::io::Result<()> {
+    let reason = match status {
+        200 => "OK",
+        204 => "No Content",
+        206 => "Partial Content",
+        400 => "Bad Request",
+        403 => "Forbidden",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        408 => "Request Timeout",
+        416 => "Range Not Satisfiable",
+        431 => "Request Header Fields Too Large",
+        _ => "Error",
+    };
+    write!(stream, "HTTP/1.1 {status} {reason}\r\nVary: Origin\r\n")?;
+    if let Some(origin) = origin {
+        write!(stream, "Access-Control-Allow-Origin: {origin}\r\n")?;
+        write!(
+            stream,
+            "Access-Control-Expose-Headers: Accept-Ranges, Content-Length, Content-Range\r\n"
+        )?;
+    }
+    for (name, value) in headers {
+        write!(stream, "{name}: {value}\r\n")?;
+    }
+    write!(stream, "Connection: close\r\n\r\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        sync::atomic::{AtomicU64, AtomicUsize},
+        time::Instant,
+    };
+
+    const ID: &str = "art_0123456789ab";
+    const MANIFEST_ID: &str = "manifest/source v1";
+    const ORIGIN: &str = "http://tauri.localhost";
+    static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(1);
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new() -> Self {
+            loop {
+                let sequence = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+                let path = std::env::temp_dir().join(format!(
+                    "tuneforge-mobile-media-{}-{sequence}",
+                    std::process::id()
+                ));
+                match fs::create_dir(&path) {
+                    Ok(()) => return Self(path),
+                    Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                    Err(error) => panic!("create exclusive test directory: {error}"),
+                }
+            }
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn resolver(path: &Path, content_type: &'static str) -> Resolver {
+        let resolver_path = path.to_path_buf();
+        Arc::new(move |artifact_id| {
+            if artifact_id != ID && artifact_id != MANIFEST_ID {
+                return Err("unavailable".into());
+            }
+            Ok(ResolvedMedia {
+                file: std::fs::File::open(&resolver_path).unwrap(),
+                size_bytes: fs::metadata(&resolver_path).unwrap().len(),
+                content_type,
+            })
+        })
+    }
+
+    fn start_server(path: &Path, content_type: &'static str) -> ServerRuntime {
+        ServerRuntime::start(resolver(path, content_type)).unwrap()
+    }
+
+    struct Fixture {
+        server: ServerRuntime,
+        _directory: TestDirectory,
+        bytes: Vec<u8>,
+    }
+
+    #[test]
+    fn lazy_server_starts_once_for_concurrent_callers() {
+        let directory = TestDirectory::new();
+        let path = directory.0.join("fixture.wav");
+        fs::write(&path, b"media").unwrap();
+        let server = Arc::new(Mutex::new(None));
+        let starts = Arc::new(AtomicUsize::new(0));
+        let mut callers = Vec::new();
+        for _ in 0..8 {
+            let server = server.clone();
+            let starts = starts.clone();
+            let resolver = resolver(&path, "audio/wav");
+            callers.push(thread::spawn(move || {
+                ensure_server_with(&server, || {
+                    starts.fetch_add(1, Ordering::Relaxed);
+                    ServerRuntime::start(resolver)
+                })
+                .unwrap()
+            }));
+        }
+        let urls = callers
+            .into_iter()
+            .map(|caller| caller.join().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(starts.load(Ordering::Relaxed), 1);
+        assert!(urls.iter().all(|url| url == &urls[0]));
+        server.lock().unwrap().take().unwrap().shutdown();
+    }
+
+    #[test]
+    fn lazy_server_can_retry_after_start_failure() {
+        let directory = TestDirectory::new();
+        let path = directory.0.join("fixture.wav");
+        fs::write(&path, b"media").unwrap();
+        let server = Mutex::new(None);
+        assert_eq!(
+            ensure_server_with(&server, || Err("first start failed".to_string())),
+            Err("first start failed".to_string())
+        );
+        assert!(server.lock().unwrap().is_none());
+
+        let base_url = ensure_server_with(&server, || {
+            ServerRuntime::start(resolver(&path, "audio/wav"))
+        })
+        .unwrap();
+        assert_eq!(
+            ensure_server_with(&server, || panic!("cached server should be reused")).unwrap(),
+            base_url
+        );
+        shutdown_server(&server);
+        shutdown_server(&server);
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let directory = TestDirectory::new();
+            let path = directory.0.join("fixture.wav");
+            let bytes = (0..STREAM_BUFFER_BYTES * 3 + 17)
+                .map(|index| (index % 251) as u8)
+                .collect::<Vec<_>>();
+            fs::write(&path, &bytes).unwrap();
+            let server = start_server(&path, "audio/wav");
+            Self {
+                server,
+                _directory: directory,
+                bytes,
+            }
+        }
+
+        fn artifact_path(&self, artifact_id: &str) -> String {
+            let origin = format!("http://{}", self.server.address);
+            format!(
+                "{}/artifacts/{artifact_id}",
+                self.server.base_url.strip_prefix(&origin).unwrap()
+            )
+        }
+
+        fn request_text(&self, method: &str, headers: &str) -> String {
+            format!(
+                "{method} {} HTTP/1.1\r\nHost: 127.0.0.1\r\nOrigin: {ORIGIN}\r\n{headers}\r\n",
+                self.artifact_path(ID)
+            )
+        }
+
+        fn exchange(&self, request: &str) -> Vec<u8> {
+            let mut stream = TcpStream::connect(self.server.address).unwrap();
+            stream.write_all(request.as_bytes()).unwrap();
+            stream.shutdown(Shutdown::Write).unwrap();
+            let mut response = Vec::new();
+            stream.read_to_end(&mut response).unwrap();
+            response
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            self.server.shutdown();
+        }
+    }
+
+    fn split_response(response: &[u8]) -> (&str, &[u8]) {
+        let split = response
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .unwrap();
+        (
+            std::str::from_utf8(&response[..split]).unwrap(),
+            &response[split + 4..],
+        )
+    }
+
+    fn active_connection_count(server: &ServerRuntime) -> usize {
+        server.active.lock().unwrap().iter().flatten().count()
+    }
+
+    fn wait_for_active_connection(server: &ServerRuntime) {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while active_connection_count(server) == 0 {
+            assert!(
+                Instant::now() < deadline,
+                "worker did not accept test connection"
+            );
+            thread::yield_now();
+        }
+    }
+
+    #[test]
+    fn serves_full_head_options_and_rejects_methods_and_origins() {
+        let fixture = Fixture::new();
+        let response = fixture.exchange(&fixture.request_text("GET", ""));
+        let (headers, body) = split_response(&response);
+        assert!(headers.starts_with("HTTP/1.1 200"));
+        assert!(headers.contains("Accept-Ranges: bytes"));
+        assert!(headers.contains("Content-Type: audio/wav"));
+        assert!(headers.contains(&format!("Content-Length: {}", fixture.bytes.len())));
+        assert!(headers.contains(&format!("Access-Control-Allow-Origin: {ORIGIN}")));
+        assert!(headers.contains("Vary: Origin"));
+        assert_eq!(body, fixture.bytes);
+
+        let response = fixture.exchange(&fixture.request_text("HEAD", ""));
+        let (headers, body) = split_response(&response);
+        assert!(headers.starts_with("HTTP/1.1 200"));
+        assert!(body.is_empty());
+
+        let response = fixture.exchange(
+            &fixture.request_text("OPTIONS", "Access-Control-Request-Headers: Range\r\n"),
+        );
+        let (headers, body) = split_response(&response);
+        assert!(headers.starts_with("HTTP/1.1 204"));
+        assert!(headers.contains("Access-Control-Allow-Headers: Range"));
+        assert!(body.is_empty());
+
+        assert!(
+            split_response(&fixture.exchange(&fixture.request_text("POST", "")))
+                .0
+                .starts_with("HTTP/1.1 405")
+        );
+        let unknown = fixture
+            .request_text("GET", "")
+            .replace(ID, "manifest-preserved-unknown");
+        assert!(split_response(&fixture.exchange(&unknown))
+            .0
+            .starts_with("HTTP/1.1 404"));
+        let foreign = fixture
+            .request_text("GET", "")
+            .replace(ORIGIN, "https://example.invalid");
+        assert!(split_response(&fixture.exchange(&foreign))
+            .0
+            .starts_with("HTTP/1.1 403"));
+        let missing = fixture
+            .request_text("GET", "")
+            .replace(&format!("Origin: {ORIGIN}\r\n"), "");
+        let response = fixture.exchange(&missing);
+        let (headers, body) = split_response(&response);
+        assert!(headers.starts_with("HTTP/1.1 200"));
+        assert!(!headers.contains("Access-Control-Allow-Origin"));
+        assert_eq!(body, fixture.bytes);
+
+        let manifest_request = fixture
+            .request_text("GET", "")
+            .replace(ID, "manifest%2Fsource%20v1");
+        let response = fixture.exchange(&manifest_request);
+        let (headers, body) = split_response(&response);
+        assert!(headers.starts_with("HTTP/1.1 200"));
+        assert_eq!(body, fixture.bytes);
+
+        for invalid_path in [
+            format!("/artifacts/{ID}"),
+            format!("/{}/artifacts/{ID}", "f".repeat(64)),
+        ] {
+            let request = format!(
+                "GET {invalid_path} HTTP/1.1\r\nHost: 127.0.0.1\r\nOrigin: {ORIGIN}\r\n\r\n"
+            );
+            let response = fixture.exchange(&request);
+            let (headers, body) = split_response(&response);
+            assert!(headers.starts_with("HTTP/1.1 404"));
+            assert!(body.is_empty());
+        }
+        assert_eq!(content_type_for_format("aac"), Some("audio/aac"));
+        assert_eq!(content_type_for_format("webm"), Some("audio/webm"));
+        assert_eq!(content_type_for_format("m4a"), Some("audio/mp4"));
+    }
+
+    #[test]
+    fn serves_closed_open_and_suffix_ranges_without_a_response_cap() {
+        let fixture = Fixture::new();
+        for (range, start, end) in [
+            ("bytes=10-19", 10, 19),
+            ("bytes=65530-", 65530, fixture.bytes.len() - 1),
+            (
+                "bytes=-25",
+                fixture.bytes.len() - 25,
+                fixture.bytes.len() - 1,
+            ),
+        ] {
+            let response =
+                fixture.exchange(&fixture.request_text("GET", &format!("Range: {range}\r\n")));
+            let (headers, body) = split_response(&response);
+            assert!(headers.starts_with("HTTP/1.1 206"));
+            assert!(headers.contains(&format!(
+                "Content-Range: bytes {start}-{end}/{}",
+                fixture.bytes.len()
+            )));
+            assert_eq!(body, &fixture.bytes[start..=end]);
+        }
+        assert!(fixture.bytes.len() > STREAM_BUFFER_BYTES * 3);
+        assert!(STREAM_BUFFER_BYTES <= 64 * 1024);
+    }
+
+    #[test]
+    fn rejects_malformed_multiple_and_unsatisfiable_ranges_and_shuts_down() {
+        let fixture = Fixture::new();
+        for headers in [
+            "Range: items=0-1\r\n".to_string(),
+            "Range: bytes=1-2,4-5\r\n".to_string(),
+            "Range: bytes=1-2\r\nRange: bytes=4-5\r\n".to_string(),
+            "Range: bytes=999999-\r\n".to_string(),
+            "Range: bytes=-0\r\n".to_string(),
+        ] {
+            let response = fixture.exchange(&fixture.request_text("GET", &headers));
+            let (headers, body) = split_response(&response);
+            assert!(headers.starts_with("HTTP/1.1 416"));
+            assert!(headers.contains(&format!("Content-Range: bytes */{}", fixture.bytes.len())));
+            assert!(body.is_empty());
+        }
+        let address = fixture.server.address;
+        fixture.server.shutdown();
+        assert!(TcpStream::connect(address).is_err());
+    }
+
+    #[test]
+    fn shutdown_interrupts_an_incomplete_request() {
+        let fixture = Fixture::new();
+        let mut stream = TcpStream::connect(fixture.server.address).unwrap();
+        write!(
+            stream,
+            "GET {} HTTP/1.1\r\nHost: 127.0.0.1\r\n",
+            fixture.artifact_path(ID)
+        )
+        .unwrap();
+        wait_for_active_connection(&fixture.server);
+
+        let started = Instant::now();
+        fixture.server.shutdown();
+        assert!(started.elapsed() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn shutdown_interrupts_a_stalled_large_response() {
+        let directory = TestDirectory::new();
+        let path = directory.0.join("large.wav");
+        std::fs::File::create(&path)
+            .unwrap()
+            .set_len(16 * 1024 * 1024)
+            .unwrap();
+        let server = ServerRuntime::start_internal(
+            resolver(&path, "audio/wav"),
+            Some(Duration::from_millis(250)),
+        )
+        .unwrap();
+        let origin = format!("http://{}", server.address);
+        let route = format!(
+            "{}/artifacts/{ID}",
+            server.base_url.strip_prefix(&origin).unwrap()
+        );
+        let mut stream = TcpStream::connect(server.address).unwrap();
+        write!(
+            stream,
+            "GET {route} HTTP/1.1\r\nHost: 127.0.0.1\r\nOrigin: {ORIGIN}\r\n\r\n"
+        )
+        .unwrap();
+        wait_for_active_connection(&server);
+        thread::sleep(Duration::from_millis(50));
+        assert_eq!(active_connection_count(&server), 1);
+
+        let started = Instant::now();
+        server.shutdown();
+        assert!(started.elapsed() < Duration::from_secs(1));
+        drop(stream);
+    }
+}

--- a/apps/desktop/src/App.project-media-controls.test.tsx
+++ b/apps/desktop/src/App.project-media-controls.test.tsx
@@ -10,6 +10,7 @@ import {
   emitMockSystemMediaPlaybackControl,
   findAudioByArtifactId,
   getMockInvoke,
+  mockEnsureWebMediaTransport,
   getMockMediaSession,
   getMockSystemMediaControlListenerCount,
   getMockWakeLock,
@@ -41,6 +42,17 @@ function mockTauriRuntime() {
   return () => {
     delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
   };
+}
+
+function deferWebMediaTransport() {
+  let resolve!: () => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<void>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  mockEnsureWebMediaTransport.mockImplementationOnce(() => promise);
+  return { reject, resolve };
 }
 
 function latestNativeSessionId() {
@@ -133,9 +145,12 @@ async function startForcedWebPlayback(user: ReturnType<typeof userEvent.setup>) 
   renderApp(["/projects/proj_123"]);
   expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
   await openPlaybackWorkspace(user);
-  const sourceAudio = findAudioByArtifactId("art_source");
-  markAudioReady(sourceAudio);
   await user.click(screen.getByRole("button", { name: "Play playback" }));
+  let sourceAudio: HTMLAudioElement | null = null;
+  await waitFor(() => {
+    sourceAudio = findAudioByArtifactId("art_source");
+  });
+  markAudioReady(sourceAudio!);
   await waitFor(() => expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument());
   return restoreTauriRuntime;
 }
@@ -281,12 +296,160 @@ describe("Desktop app project media controls", () => {
     expect(getMockMediaSession().actionHandlers.size).toBe(0);
     expect(getMockMediaSession().setActionHandler).not.toHaveBeenCalled();
     expect(getMockWakeLock().request).not.toHaveBeenCalled();
+    expect(mockEnsureWebMediaTransport).not.toHaveBeenCalled();
 
     act(() => {
       emitMockSystemMediaPlaybackControl({ action: "pause" });
     });
     await waitFor(() => expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument());
     await waitFor(() => expect(hasNativePowerProtection(false)).toBe(true));
+
+    restoreTauriRuntime();
+  });
+
+  it("keeps Web Audio sources disabled when lazy transport startup fails", async () => {
+    vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
+    mockEnsureWebMediaTransport.mockRejectedValueOnce(
+      new Error("Mobile media transport could not start."),
+    );
+    const restoreTauriRuntime = mockTauriRuntime();
+    const user = userEvent.setup();
+    setMockNativeAudioState({
+      capabilities: {
+        nativePlaybackSupported: true,
+        fallbackRequired: false,
+        fallbackReason: null,
+        backend: "desktop-cpal",
+      },
+    });
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    await waitFor(() => expect(mockEnsureWebMediaTransport).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      expect(readPlaybackLiveDiagnostics()).toMatchObject({
+        currentState: "error",
+        currentPath: "none",
+        statusMessage: "Playback stopped. Web Audio could not start.",
+      });
+    });
+    expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+    expect(
+      Array.from(document.querySelectorAll("audio")).every(
+        (element) => !element.hasAttribute("src"),
+      ),
+    ).toBe(true);
+
+    restoreTauriRuntime();
+  });
+
+  it("waits for lazy transport before exposing native fallback media sources", async () => {
+    const transport = deferWebMediaTransport();
+    const restoreTauriRuntime = mockTauriRuntime();
+    const user = userEvent.setup();
+    setMockNativeAudioState({
+      capabilities: {
+        nativePlaybackSupported: true,
+        fallbackRequired: false,
+        fallbackReason: null,
+        backend: "desktop-cpal",
+      },
+      playFallbackReason: "Native playback could not start.",
+    });
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+
+    await waitFor(() => expect(mockEnsureWebMediaTransport).toHaveBeenCalledTimes(1));
+    expect(
+      Array.from(document.querySelectorAll("audio")).every(
+        (element) => !element.hasAttribute("src"),
+      ),
+    ).toBe(true);
+    expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+
+    await act(async () => transport.resolve());
+    const sourceAudio = await waitFor(() => findAudioByArtifactId("art_source"));
+    markAudioReady(sourceAudio);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument(),
+    );
+
+    restoreTauriRuntime();
+  });
+
+  it("ignores lazy transport success after playback is stopped", async () => {
+    vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
+    const transport = deferWebMediaTransport();
+    const restoreTauriRuntime = mockTauriRuntime();
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(mockEnsureWebMediaTransport).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByRole("button", { name: "Stop playback" }));
+    await act(async () => transport.resolve());
+
+    expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+    expect(
+      Array.from(document.querySelectorAll("audio")).every(
+        (element) => !element.hasAttribute("src"),
+      ),
+    ).toBe(true);
+    expect(readPlaybackLiveDiagnostics()).toMatchObject({
+      currentState: "not-playing",
+      currentPath: "none",
+    });
+
+    restoreTauriRuntime();
+  });
+
+  it("ignores lazy transport rejection after a newer native owner starts", async () => {
+    vi.stubEnv("VITE_TUNEFORGE_FORCE_WEB_AUDIO", "1");
+    const transport = deferWebMediaTransport();
+    const restoreTauriRuntime = mockTauriRuntime();
+    const user = userEvent.setup();
+    setMockNativeAudioState({
+      capabilities: {
+        nativePlaybackSupported: true,
+        fallbackRequired: false,
+        fallbackReason: null,
+        backend: "desktop-cpal",
+      },
+    });
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitFor(() => expect(mockEnsureWebMediaTransport).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByRole("button", { name: "Stop playback" }));
+    vi.unstubAllEnvs();
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitForNativeControls();
+
+    await act(async () => transport.reject(new Error("Stale Web transport failure.")));
+
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+    expect(
+      Array.from(document.querySelectorAll("audio")).every(
+        (element) => !element.hasAttribute("src"),
+      ),
+    ).toBe(true);
+    expect(window.localStorage.getItem("tuneforge.playback-web-error")).toBeNull();
+    expect(readPlaybackLiveDiagnostics()).toMatchObject({
+      currentState: "playing",
+      currentPath: "native",
+    });
 
     restoreTauriRuntime();
   });

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -129,6 +129,13 @@ type PendingWebPlayback = {
   startTimeSeconds: number;
 };
 
+type WebMediaSourceEnablementOwner = {
+  nativeControlGeneration: number;
+  shouldPlay: boolean;
+  signature: string;
+  transitionId: number;
+};
+
 type PlaybackE2ECountInEvent = PlaybackE2ECountInSchedule;
 type PlaybackE2ETelemetryOverrides = Omit<PlaybackE2ETelemetryPatch, "countIn">;
 
@@ -345,7 +352,7 @@ function nativeLaneUpdateForSession(session: ProjectPlaybackSession) {
 }
 
 export function PlaybackProvider({ children }: { children: ReactNode }) {
-  const initialWebMediaSourcesEnabled = isWebAudioBackendForced() || !isTauriRuntime();
+  const initialWebMediaSourcesEnabled = !isTauriRuntime();
   const primaryAudioRef = useRef<HTMLAudioElement | null>(null);
   const activePrecountRef = useRef<ActivePrecount | null>(null);
   const precountAudioContextRef = useRef<AudioContext | null>(null);
@@ -595,12 +602,42 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     [canUseStemClock],
   );
 
-  const enableWebMediaSources = useStableCallback(function enableWebMediaSources() {
+  const enableWebMediaSources = useStableCallback(async function enableWebMediaSources(
+    owner: WebMediaSourceEnablementOwner,
+  ) {
+    const ownerIsCurrent = () => {
+      const pendingTransition = pendingTransitionRef.current;
+      return Boolean(
+        pendingTransition &&
+          pendingTransition.id === owner.transitionId &&
+          pendingTransition.signature === owner.signature &&
+          pendingTransition.shouldPlay === owner.shouldPlay &&
+          nativeControlGenerationRef.current === owner.nativeControlGeneration &&
+          playbackSignature(sessionRef.current) === owner.signature &&
+          playbackControlBackendRef.current !== "native" &&
+          !nativePlaybackRef.current.active,
+      );
+    };
     if (webMediaSourcesEnabledRef.current) {
-      return;
+      return ownerIsCurrent();
+    }
+    try {
+      await api.ensureWebMediaTransport();
+    } catch (error) {
+      if (!ownerIsCurrent()) {
+        return false;
+      }
+      pendingTransitionRef.current = null;
+      rememberWebPlaybackError(playbackErrorMessage(error));
+      markWebPlaybackStartResult(false);
+      return false;
+    }
+    if (!ownerIsCurrent()) {
+      return false;
     }
     webMediaSourcesEnabledRef.current = true;
     setWebMediaSourcesEnabled(true);
+    return true;
   });
 
   const getNativeAudioCapabilityState = useStableCallback(async function getNativeAudioCapabilityState() {
@@ -2096,7 +2133,12 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       }
 
       if (!webMediaSourcesEnabledRef.current) {
-        enableWebMediaSources();
+        await enableWebMediaSources({
+          nativeControlGeneration: nativeControlGenerationRef.current,
+          shouldPlay: pendingTransition.shouldPlay,
+          signature: pendingTransition.signature,
+          transitionId: pendingTransition.id,
+        });
         return;
       }
 
@@ -2355,7 +2397,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       if (!activeKeys.length) {
         return;
       }
-      pendingTransitionRef.current = {
+      const pendingTransition: PendingTransition = {
         id: ++transitionCounterRef.current,
         signature: playbackSignature(targetSession),
         shouldPlay: true,
@@ -2366,7 +2408,13 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         awaitingSeekKeys: activeKeys,
         forceSeekKeys: activeKeys,
       };
-      enableWebMediaSources();
+      pendingTransitionRef.current = pendingTransition;
+      await enableWebMediaSources({
+        nativeControlGeneration: nativeControlGenerationRef.current,
+        shouldPlay: pendingTransition.shouldPlay,
+        signature: pendingTransition.signature,
+        transitionId: pendingTransition.id,
+      });
       return;
     }
 

--- a/apps/desktop/src/lib/api.mobile-sync.test.ts
+++ b/apps/desktop/src/lib/api.mobile-sync.test.ts
@@ -84,6 +84,9 @@ describe("mobile sync API adapter", () => {
       if (command === "mobile_capabilities") {
         return mobileCapabilities;
       }
+      if (command === "mobile_media_base_url") {
+        return "http://127.0.0.1:43123/session-capability";
+      }
       return {};
     });
     Object.defineProperty(window, "__TAURI_INTERNALS__", {
@@ -140,6 +143,57 @@ describe("mobile sync API adapter", () => {
     await api.listJobs(params);
 
     expect(mockInvoke).toHaveBeenCalledWith("mobile_list_jobs", { params });
+  });
+
+  it("starts mobile media lazily and caches the ephemeral loopback transport", async () => {
+    const apiModule = await import("./api");
+    await apiModule.initializeApi();
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+    expect(mockInvoke).toHaveBeenCalledWith("mobile_capabilities");
+    mockInvoke.mockClear();
+    const api = apiModule.api;
+
+    expect(api.streamArtifactUrl("art_0123456789abcdef0123456789ab")).toBe("");
+    expect(mockInvoke).not.toHaveBeenCalled();
+    await api.ensureWebMediaTransport();
+    await api.ensureWebMediaTransport();
+    expect(api.streamArtifactUrl("art_0123456789abcdef0123456789ab")).toBe(
+      "http://127.0.0.1:43123/session-capability/artifacts/art_0123456789abcdef0123456789ab",
+    );
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+    expect(mockInvoke).toHaveBeenCalledWith("mobile_media_base_url", undefined);
+    expect(mockConvertFileSrc).not.toHaveBeenCalled();
+  });
+
+  it("shares an in-flight mobile media start", async () => {
+    const api = await loadMobileApi();
+    let resolveBaseUrl: (value: string) => void = () => {};
+    const baseUrl = new Promise<string>((resolve) => {
+      resolveBaseUrl = resolve;
+    });
+    mockInvoke.mockImplementation((command: string) =>
+      command === "mobile_media_base_url" ? baseUrl : Promise.resolve({}),
+    );
+
+    const first = api.ensureWebMediaTransport();
+    const second = api.ensureWebMediaTransport();
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+    resolveBaseUrl("http://127.0.0.1:43123/session-capability");
+    await Promise.all([first, second]);
+    expect(api.streamArtifactUrl("art_1")).toContain("/artifacts/art_1");
+  });
+
+  it("retries mobile media start after a failure", async () => {
+    const api = await loadMobileApi();
+    mockInvoke
+      .mockRejectedValueOnce(new Error("transport failed"))
+      .mockResolvedValueOnce("http://127.0.0.1:43123/retry-capability");
+
+    await expect(api.ensureWebMediaTransport()).rejects.toThrow("transport failed");
+    expect(api.streamArtifactUrl("art_1")).toBe("");
+    await expect(api.ensureWebMediaTransport()).resolves.toBeUndefined();
+    expect(api.streamArtifactUrl("art_1")).toContain("/retry-capability/artifacts/art_1");
+    expect(mockInvoke).toHaveBeenCalledTimes(2);
   });
 
   it("allows built-in mobile import requests", async () => {

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -1,5 +1,5 @@
 import createClient from "openapi-fetch";
-import { convertFileSrc, invoke } from "@tauri-apps/api/core";
+import { invoke } from "@tauri-apps/api/core";
 import type { components, MobileCapabilities, paths } from "@tuneforge/shared-types";
 import { normalizeApiDateTime } from "./datetime";
 
@@ -2136,6 +2136,7 @@ async function createNativeSyncPairingOffer(body: SyncPairingOfferRequest): Prom
 
 export type TuneForgeClient = {
   getMobileCapabilities: () => Promise<RuntimeCapabilities>;
+  ensureWebMediaTransport: () => Promise<void>;
   getHealth: () => Promise<HealthResponse>;
   listProjects: (params?: ListProjectsParams) => Promise<components["schemas"]["ProjectsResponse"]>;
   importProject: (body: ProjectImportRequest) => Promise<components["schemas"]["ProjectResponse"]>;
@@ -2190,7 +2191,6 @@ export type TuneForgeClient = {
 };
 
 let client = createClient<paths>({ baseUrl: apiBaseUrl });
-const mobileArtifactPaths = new Map<string, string>();
 const mobileChordBackendsResponse: ChordBackendsResponse = {
   backends: [
     {
@@ -2329,19 +2329,10 @@ async function invokeMobile<T>(command: string, args?: Record<string, unknown>) 
   return invoke<T>(command, args);
 }
 
-function rememberArtifactPaths(artifacts: ArtifactSchema[]) {
-  artifacts.forEach((artifact) => {
-    const playbackPath =
-      typeof artifact.metadata.playback_path === "string"
-        ? artifact.metadata.playback_path
-        : artifact.path;
-    mobileArtifactPaths.set(artifact.id, playbackPath);
-  });
-}
-
 function createHttpTuneForgeClient(): TuneForgeClient {
   return {
     getMobileCapabilities: async () => null,
+    ensureWebMediaTransport: async () => {},
     getHealth: () => unwrap(client.GET("/api/v1/health")),
     listProjects: (params?: ListProjectsParams) =>
       unwrap(client.GET("/api/v1/projects", params ? { params: { query: params } } : undefined)),
@@ -2442,6 +2433,27 @@ function createHttpTuneForgeClient(): TuneForgeClient {
 }
 
 function createMobileTuneForgeClient(capabilities: MobileCapabilities): TuneForgeClient {
+  let mediaBaseUrl: string | null = null;
+  let mediaInitialization: Promise<void> | null = null;
+  const ensureWebMediaTransport = () => {
+    if (mediaBaseUrl) {
+      return Promise.resolve();
+    }
+    if (!mediaInitialization) {
+      mediaInitialization = invokeMobile<string>("mobile_media_base_url")
+        .then((baseUrl) => {
+          if (!baseUrl) {
+            throw new Error("Mobile media transport returned an invalid URL.");
+          }
+          mediaBaseUrl = baseUrl;
+        })
+        .catch((error: unknown) => {
+          mediaInitialization = null;
+          throw error;
+        });
+    }
+    return mediaInitialization;
+  };
   const requireSupportedMobileAnalysisBackend = (request?: { beat_backend?: BeatAnalysisBackend }) => {
     if (request?.beat_backend === "beat-this") {
       throw new ApiError({
@@ -2454,6 +2466,7 @@ function createMobileTuneForgeClient(capabilities: MobileCapabilities): TuneForg
 
   return {
     getMobileCapabilities: async () => capabilities,
+    ensureWebMediaTransport,
     getHealth: () => invokeMobile("mobile_get_health"),
     listProjects: (params?: ListProjectsParams) =>
       invokeMobile("mobile_list_projects", { params: params ?? null }),
@@ -2511,11 +2524,7 @@ function createMobileTuneForgeClient(capabilities: MobileCapabilities): TuneForg
       invokeMobile("mobile_submit_retune", { projectId, payload: body }),
     createTranspose: (projectId: string, body: components["schemas"]["TransposeRequest"]) =>
       invokeMobile("mobile_submit_transpose", { projectId, payload: body }),
-    listArtifacts: async (projectId: string) => {
-      const response = await invokeMobile<components["schemas"]["ArtifactsResponse"]>("mobile_list_artifacts", { projectId });
-      rememberArtifactPaths(response.artifacts);
-      return response;
-    },
+    listArtifacts: (projectId: string) => invokeMobile("mobile_list_artifacts", { projectId }),
     deleteArtifact: (projectId: string, artifactId: string) =>
       invokeMobile("mobile_delete_artifact", { projectId, artifactId }),
     createExport: (projectId: string, body: ExportRequest) =>
@@ -2543,10 +2552,8 @@ function createMobileTuneForgeClient(capabilities: MobileCapabilities): TuneForg
     stopSyncListener,
     recordSyncLifecycleEvent,
     syncTrustedPeerNow,
-    streamArtifactUrl: (artifactId: string) => {
-      const artifactPath = mobileArtifactPaths.get(artifactId);
-      return artifactPath ? convertFileSrc(artifactPath) : "";
-    },
+    streamArtifactUrl: (artifactId: string) =>
+      mediaBaseUrl ? `${mediaBaseUrl}/artifacts/${encodeURIComponent(artifactId)}` : "",
   };
 }
 
@@ -2592,6 +2599,7 @@ export function getApiBaseUrl() {
 
 export const api: TuneForgeClient = {
   getMobileCapabilities: () => activeClient.getMobileCapabilities(),
+  ensureWebMediaTransport: () => activeClient.ensureWebMediaTransport(),
   getHealth: () => activeClient.getHealth(),
   listProjects: (params?: ListProjectsParams) => activeClient.listProjects(params),
   importProject: (body) => activeClient.importProject(body),

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -96,6 +96,7 @@ const {
   mockDeleteProject,
   mockGetHealth,
   mockGetMobileCapabilities,
+  mockEnsureWebMediaTransport,
   mockScanPairingQrCode,
   setMockSystemInputVolume,
   setMockNativeAudio,
@@ -1407,6 +1408,7 @@ const {
     preview_format: "wav",
   }));
   const mockGetMobileCapabilities = vi.fn(async (): Promise<unknown> => null);
+  const mockEnsureWebMediaTransport = vi.fn(async () => {});
   const mockScanPairingQrCode = vi.fn(async (): Promise<string> => {
     throw new Error("QR scanner unavailable.");
   });
@@ -2467,6 +2469,7 @@ const {
     mockDeleteProject,
     mockGetHealth,
     mockGetMobileCapabilities,
+    mockEnsureWebMediaTransport,
     mockScanPairingQrCode,
     setMockSystemInputVolume,
     setMockNativeAudio,
@@ -2544,6 +2547,7 @@ export {
   mockDeleteProject,
   mockGetHealth,
   mockGetMobileCapabilities,
+  mockEnsureWebMediaTransport,
   mockScanPairingQrCode,
   mockListen,
 };
@@ -2611,6 +2615,7 @@ vi.mock("../lib/api", async (importOriginal) => {
       deleteArtifact: mockDeleteArtifact,
       deleteProject: mockDeleteProject,
       getMobileCapabilities: mockGetMobileCapabilities,
+      ensureWebMediaTransport: mockEnsureWebMediaTransport,
     },
   };
 });
@@ -3030,6 +3035,8 @@ export function resetAppTestHarness() {
   mockGetHealth.mockClear();
   mockGetMobileCapabilities.mockReset();
   mockGetMobileCapabilities.mockResolvedValue(null);
+  mockEnsureWebMediaTransport.mockReset();
+  mockEnsureWebMediaTransport.mockResolvedValue();
   mockScanPairingQrCode.mockReset();
   mockScanPairingQrCode.mockRejectedValue(new Error("QR scanner unavailable."));
   vi.mocked(window.HTMLMediaElement.prototype.play).mockImplementation(function play(

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -143,6 +143,14 @@ fallback after native failure or a build-time development override; it is not a 
 Playback state, clocks, and Settings diagnostics change only after the active native session or Web
 media confirms the transition.
 
+On Android, Web Audio reads project artifacts through a private seekable server bound to an
+ephemeral `127.0.0.1` port. Routes contain only opaque artifact IDs, revalidate the current
+app-owned project file for every request, and support bounded streaming plus single byte ranges.
+The URL includes an unguessable per-process capability segment. Origin-less Android media requests
+are accepted, while requests that name a foreign browser origin are rejected. The server starts only
+when Web Audio is selected and stops with the app. Desktop Web Audio keeps using its existing asset
+or backend transport.
+
 ## Android Tuner Capture
 
 The packaged Android tuner requires native CPAL/AAudio microphone capture. A native capability,

--- a/docs/NATIVE_AUDIO.md
+++ b/docs/NATIVE_AUDIO.md
@@ -23,6 +23,8 @@ boundary.
   still look like ALSA PCM names.
 - Android native playback and tuner capture report the `android-aaudio` backend and require Android
   API 26 or newer. Tuner monitoring remains unsupported.
+- Android Web Audio fallback and forced-Web-Audio playback use a private seekable loopback
+  transport so Chromium can request complete byte ranges without exposing arbitrary file paths.
 
 ## Backend Selection
 


### PR DESCRIPTION
## Summary

- add a capability-scoped Android loopback transport with correct single-range delivery for app-owned artifacts
- start Web Audio transport only when forced or native playback falls back, keeping native AAudio independent
- preserve playback proxies and legacy synced artifact IDs while rejecting stale or unauthorized media
- Closes #355

## Testing

- `cd apps/desktop/src-tauri && cargo fmt --all -- --check`
- `cd apps/desktop/src-tauri && cargo check`
- `cd apps/desktop/src-tauri && cargo test mobile_media_transport --lib` (7 passed)
- `cd apps/desktop/src-tauri && cargo test mobile_backend --lib` (61 passed)
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test` (700 passed)
- `pnpm package:android:debug`
- Android emulator: native AAudio opened without a Web media listener; forced Web Audio lazily opened one loopback listener and passed range, capability, seek, and former byte-boundary checks