### PR TITLE
feat: keep tuner capture screen awake

### DIFF
--- a/apps/desktop/src-tauri/src/native_audio/capture.rs
+++ b/apps/desktop/src-tauri/src/native_audio/capture.rs
@@ -7,9 +7,11 @@ use tauri::AppHandle;
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
-use tauri::Emitter;
+use tauri::{Emitter, Manager};
 
 use super::{AudioCapabilities, AUDIO_EVENT_INPUT_FRAME, AUDIO_EVENT_INPUT_STATE};
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+use crate::power_inhibition::{PowerInhibitionReason, PowerInhibitionState};
 
 const DEFAULT_INPUT_DEVICE_ID: &str = "default";
 const INPUT_FRAME_SAMPLES: usize = 2048;
@@ -682,6 +684,10 @@ fn run_capture_worker(
         start_capture_stream(requested_device_id, Arc::clone(&shared), capture_generation);
     match startup {
         Ok(startup) => {
+            let _power_guard = app
+                .state::<PowerInhibitionState>()
+                .acquire_scoped(PowerInhibitionReason::TunerCapture)
+                .ok();
             let _ = ready_sender.send(Ok((startup.effective_device_id, startup.sample_rate)));
             emit_input_frames(
                 app,

--- a/apps/desktop/src-tauri/src/power_inhibition.rs
+++ b/apps/desktop/src-tauri/src/power_inhibition.rs
@@ -9,6 +9,7 @@ pub enum PowerInhibitionReason {
     Playback,
     SyncListener,
     SyncTransfer,
+    TunerCapture,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
@@ -84,10 +85,15 @@ fn parse_android_response(response: &str) -> Result<PlatformProbe, SafeError> {
         .and_then(|value| value.parse::<u64>().ok())
         .unwrap_or(0);
     let screen_protected = parts.next() == Some("true");
+    let service_confirmed = mask & 0b0111 != 0;
     let details = (mask != 0).then_some(PlatformDetails {
-        backend: "android-foreground-service",
+        backend: if service_confirmed {
+            "android-foreground-service"
+        } else {
+            "android-activity-screen"
+        },
         screen_protected,
-        background_protected: true,
+        background_protected: service_confirmed,
     });
     let confirmed = details.is_some();
     let error = match error_code {
@@ -129,6 +135,18 @@ fn parse_android_response(response: &str) -> Result<PlatformProbe, SafeError> {
         error,
         pending_phase,
         data_sync_timeout_epoch,
+    })
+}
+
+#[cfg(any(test, target_os = "android"))]
+fn android_reason_mask(reasons: &[PowerInhibitionReason]) -> i32 {
+    reasons.iter().fold(0, |mask, reason| {
+        mask | match reason {
+            PowerInhibitionReason::Playback => 1,
+            PowerInhibitionReason::SyncListener => 2,
+            PowerInhibitionReason::SyncTransfer => 4,
+            PowerInhibitionReason::TunerCapture => 8,
+        }
     })
 }
 
@@ -537,7 +555,7 @@ mod platform {
         ) -> Result<Option<PlatformDetails>, SafeError> {
             if self.assertion_id.is_none() {
                 let assertion_type = cf_string("NoDisplaySleepAssertion")?;
-                let assertion_name = cf_string("TuneForge playback and sync")?;
+                let assertion_name = cf_string("TuneForge active audio and sync")?;
                 let mut assertion_id = 0;
                 let result = unsafe {
                     IOPMAssertionCreateWithName(
@@ -745,7 +763,7 @@ mod platform {
                 (
                     "sleep:idle",
                     "TuneForge",
-                    "Playback or sync is active",
+                    "Playback, tuner, or sync is active",
                     "block",
                 ),
             )
@@ -772,7 +790,7 @@ mod platform {
             &mut self,
             reasons: &[PowerInhibitionReason],
         ) -> Result<Option<PlatformDetails>, SafeError> {
-            let mask = reason_mask(reasons);
+            let mask = android_reason_mask(reasons);
             let response = call_android("setTuneForgePowerInhibition", mask)?;
             let probe = parse_android_response(&response)?;
             if let Some(error) = probe.error {
@@ -808,16 +826,6 @@ mod platform {
                     }),
             )
         }
-    }
-
-    fn reason_mask(reasons: &[PowerInhibitionReason]) -> i32 {
-        reasons.iter().fold(0, |mask, reason| {
-            mask | match reason {
-                PowerInhibitionReason::Playback => 1,
-                PowerInhibitionReason::SyncListener => 2,
-                PowerInhibitionReason::SyncTransfer => 4,
-            }
-        })
     }
 
     fn call_android(method: &str, mask: i32) -> Result<String, SafeError> {
@@ -921,7 +929,12 @@ mod tests {
             }
             Ok(Some(PlatformDetails {
                 backend: "test",
-                screen_protected: reasons.contains(&PowerInhibitionReason::Playback),
+                screen_protected: reasons.iter().any(|reason| {
+                    matches!(
+                        reason,
+                        PowerInhibitionReason::Playback | PowerInhibitionReason::TunerCapture
+                    )
+                }),
                 background_protected: true,
             }))
         }
@@ -993,6 +1006,49 @@ mod tests {
             vec![PowerInhibitionReason::SyncTransfer]
         );
         drop(second);
+        assert_eq!(*control.releases.lock().unwrap(), 1);
+    }
+
+    #[test]
+    fn all_four_reasons_hold_shared_protection_until_final_release() {
+        let (state, control) = state();
+        let tuner = state
+            .acquire_scoped(PowerInhibitionReason::TunerCapture)
+            .unwrap();
+        let transfer = state
+            .acquire_scoped(PowerInhibitionReason::SyncTransfer)
+            .unwrap();
+        state
+            .set_activity(PowerInhibitionReason::Playback, true)
+            .unwrap();
+        state
+            .set_activity(PowerInhibitionReason::SyncListener, true)
+            .unwrap();
+
+        assert_eq!(
+            state.status().unwrap().active_reasons,
+            vec![
+                PowerInhibitionReason::Playback,
+                PowerInhibitionReason::SyncListener,
+                PowerInhibitionReason::SyncTransfer,
+                PowerInhibitionReason::TunerCapture,
+            ]
+        );
+
+        drop(tuner);
+        state
+            .set_activity(PowerInhibitionReason::Playback, false)
+            .unwrap();
+        drop(transfer);
+        assert_eq!(*control.releases.lock().unwrap(), 0);
+        assert_eq!(
+            state.status().unwrap().active_reasons,
+            vec![PowerInhibitionReason::SyncListener]
+        );
+
+        state
+            .set_activity(PowerInhibitionReason::SyncListener, false)
+            .unwrap();
         assert_eq!(*control.releases.lock().unwrap(), 1);
     }
 
@@ -1143,6 +1199,32 @@ mod tests {
             "Android notification permission is unavailable, and power protection is not confirmed."
         );
         assert!(!error.message.contains("protection is active"));
+    }
+
+    #[test]
+    fn android_tuner_only_reports_activity_screen_without_background_protection() {
+        let probe =
+            parse_android_response("active;8;none;8;0;true").expect("valid Android response");
+        let details = probe.details.expect("confirmed tuner protection");
+
+        assert_eq!(details.backend, "android-activity-screen");
+        assert!(details.screen_protected);
+        assert!(!details.background_protected);
+        assert_eq!(
+            android_reason_mask(&[PowerInhibitionReason::TunerCapture]),
+            8
+        );
+    }
+
+    #[test]
+    fn android_tuner_with_service_owner_reports_foreground_service() {
+        let probe =
+            parse_android_response("active;9;none;9;0;true").expect("valid Android response");
+        let details = probe.details.expect("confirmed combined protection");
+
+        assert_eq!(details.backend, "android-foreground-service");
+        assert!(details.screen_protected);
+        assert!(details.background_protected);
     }
 
     #[test]

--- a/apps/desktop/src/App.power-inhibition.test.tsx
+++ b/apps/desktop/src/App.power-inhibition.test.tsx
@@ -51,6 +51,34 @@ describe("power protection UI", () => {
     expect(within(section!).getByText("Inactive")).toBeInTheDocument();
   });
 
+  it("labels tuner-only Android screen protection without claiming background coverage", async () => {
+    const user = userEvent.setup();
+    setMockPowerInhibitionState({
+      phase: "active",
+      backend: "android-activity-screen",
+      activeReasons: ["tuner-capture"],
+      screenProtected: true,
+      backgroundProtected: false,
+      errorCode: null,
+      errorMessage: null,
+    });
+    renderApp(["/settings"]);
+
+    await user.click(await screen.findByText("Show diagnostics"));
+    const section = screen.getByRole("heading", { name: "Power Protection" }).closest("section");
+    expect(section).not.toBeNull();
+    await waitFor(() => {
+      expect(within(section!).getAllByText("Android activity screen")).toHaveLength(2);
+    });
+    expect(within(section!).getByText("Tuner capture")).toBeInTheDocument();
+    expect(within(section!).getByText("Native Screen Protected").nextElementSibling).toHaveTextContent(
+      "Confirmed",
+    );
+    expect(
+      within(section!).getByText("Native Background Protected").nextElementSibling,
+    ).toHaveTextContent("Not confirmed");
+  });
+
   it("shows a sync reliability alert only for relevant protection failure", async () => {
     const user = userEvent.setup();
     setMockPowerInhibitionState({

--- a/apps/desktop/src/App.project-media-controls.test.tsx
+++ b/apps/desktop/src/App.project-media-controls.test.tsx
@@ -24,9 +24,11 @@ import {
 
 let usePlaybackPowerProtection: typeof import("./features/projects/playbackEffects").usePlaybackPowerProtection;
 let useWebPlaybackWakeLock: typeof import("./features/projects/playbackEffects").useWebPlaybackWakeLock;
+let useScreenWakeLock: typeof import("./lib/useScreenWakeLock").useScreenWakeLock;
 
 beforeAll(async () => {
   ({ usePlaybackPowerProtection, useWebPlaybackWakeLock } = await import("./features/projects/playbackEffects"));
+  ({ useScreenWakeLock } = await import("./lib/useScreenWakeLock"));
 });
 
 async function openPlaybackWorkspace(user: ReturnType<typeof userEvent.setup>) {
@@ -163,6 +165,12 @@ function WebPlaybackWakeLockHarness({
   isPlaying: boolean;
 }) {
   useWebPlaybackWakeLock({ backend, isPlaying });
+  return null;
+}
+
+function SharedWakeLockHarness({ playback, tuner }: { playback: boolean; tuner: boolean }) {
+  useScreenWakeLock("playback", playback);
+  useScreenWakeLock("tuner-capture", tuner);
   return null;
 }
 
@@ -955,6 +963,68 @@ describe("Desktop app project media controls", () => {
       backend: null,
       screenProtected: false,
     });
+    view.unmount();
+  });
+
+  it("reports a late browser Wake Lock release failure after the final owner exits", async () => {
+    let rejectRelease: (reason?: unknown) => void = () => undefined;
+    const pendingSentinel = {
+      release: vi.fn(
+        () => new Promise<void>((_resolve, reject) => {
+          rejectRelease = reject;
+        }),
+      ),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    let resolveRequest: (sentinel: typeof pendingSentinel) => void = () => undefined;
+    getMockWakeLock().request.mockImplementationOnce(
+      () => new Promise((resolve) => {
+        resolveRequest = resolve;
+      }),
+    );
+    const view = render(<WebPlaybackWakeLockHarness isPlaying />);
+    await waitFor(() => expect(getMockWakeLock().request).toHaveBeenCalledTimes(1));
+
+    view.rerender(<WebPlaybackWakeLockHarness backend="native" isPlaying />);
+    await act(async () => {
+      resolveRequest(pendingSentinel);
+      await Promise.resolve();
+    });
+    expect(readBrowserWakeLockStatus()).toMatchObject({
+      phase: "releasing",
+      backend: "browser-screen-wake-lock",
+      screenProtected: true,
+    });
+
+    await act(async () => {
+      rejectRelease(new Error("late release failed"));
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(readBrowserWakeLockStatus()).toMatchObject({
+        phase: "release-failed",
+        backend: "browser-screen-wake-lock",
+        screenProtected: true,
+      });
+    });
+    view.unmount();
+  });
+
+  it("keeps one browser Wake Lock while playback and tuner owners overlap", async () => {
+    const view = render(<SharedWakeLockHarness playback tuner />);
+    await waitFor(() => expect(getMockWakeLock().request).toHaveBeenCalledTimes(1));
+
+    view.rerender(<SharedWakeLockHarness playback={false} tuner />);
+    expect(getMockWakeLock().sentinels[0]?.release).not.toHaveBeenCalled();
+    expect(readBrowserWakeLockStatus()).toMatchObject({
+      phase: "active",
+      screenProtected: true,
+    });
+
+    view.rerender(<SharedWakeLockHarness playback={false} tuner={false} />);
+    await waitFor(() => expect(getMockWakeLock().sentinels[0]?.release).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(readBrowserWakeLockStatus().phase).toBe("inactive"));
     view.unmount();
   });
 

--- a/apps/desktop/src/App.tools-tuner.test.tsx
+++ b/apps/desktop/src/App.tools-tuner.test.tsx
@@ -7,11 +7,43 @@ import {
   getMockAudioContexts,
   getMockInvoke,
   getMockMediaDevices,
+  getMockWakeLock,
   resetAppTestHarness,
   renderApp,
   setMockNativeAudioState,
   setMockSystemInputVolumeState,
 } from "./test/appTestHarness";
+
+function mockTauriRuntime() {
+  Object.defineProperty(window, "__TAURI_INTERNALS__", {
+    configurable: true,
+    value: { invoke: getMockInvoke() },
+  });
+}
+
+function makeEndingMediaStream() {
+  const endedListeners = new Set<() => void>();
+  const track = {
+    addEventListener: vi.fn((type: string, listener: () => void) => {
+      if (type === "ended") endedListeners.add(listener);
+    }),
+    removeEventListener: vi.fn((type: string, listener: () => void) => {
+      if (type === "ended") endedListeners.delete(listener);
+    }),
+    stop: vi.fn(),
+  } as unknown as MediaStreamTrack;
+  const stream = {
+    getAudioTracks: vi.fn(() => [track]),
+    getTracks: vi.fn(() => [track]),
+  } as unknown as MediaStream;
+  return {
+    end() {
+      endedListeners.forEach((listener) => listener());
+    },
+    stream,
+    track,
+  };
+}
 
 describe("Desktop app tools tuner", () => {
   beforeEach(resetAppTestHarness);
@@ -233,6 +265,76 @@ describe("Desktop app tools tuner", () => {
     expect(screen.getByRole("button", { name: "Start" })).toBeEnabled();
   });
 
+  it("acquires Web tuner protection only after capture is listening and releases on stop", async () => {
+    const user = userEvent.setup();
+    const endingStream = makeEndingMediaStream();
+    let resolveCapture: (stream: MediaStream) => void = () => undefined;
+    getMockMediaDevices().getUserMedia.mockImplementationOnce(
+      () => new Promise<MediaStream>((resolve) => {
+        resolveCapture = resolve;
+      }),
+    );
+    mockTauriRuntime();
+    renderApp(["/tools"]);
+
+    await user.click(await screen.findByRole("button", { name: "Start" }));
+    await waitFor(() => expect(getMockMediaDevices().getUserMedia).toHaveBeenCalled());
+    expect(getMockWakeLock().request).not.toHaveBeenCalled();
+    expect(getMockInvoke()).not.toHaveBeenCalledWith("power_inhibition_set_activity", {
+      reason: "tuner-capture",
+      active: true,
+    });
+
+    await act(async () => {
+      resolveCapture(endingStream.stream);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(screen.getByText("Listening")).toBeInTheDocument());
+    await waitFor(() => expect(getMockWakeLock().request).toHaveBeenCalledWith("screen"));
+    await waitFor(() =>
+      expect(getMockInvoke()).toHaveBeenCalledWith("power_inhibition_set_activity", {
+        reason: "tuner-capture",
+        active: true,
+      }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Stop" }));
+    await waitFor(() => expect(getMockWakeLock().sentinels[0]?.release).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(getMockInvoke()).toHaveBeenCalledWith("power_inhibition_set_activity", {
+        reason: "tuner-capture",
+        active: false,
+      }),
+    );
+    expect(endingStream.track.removeEventListener).toHaveBeenCalledWith(
+      "ended",
+      expect.any(Function),
+    );
+    expect(endingStream.track.stop).toHaveBeenCalled();
+  });
+
+  it("ends Web tuner capture generation when its microphone track terminates", async () => {
+    const user = userEvent.setup();
+    const endingStream = makeEndingMediaStream();
+    getMockMediaDevices().getUserMedia.mockResolvedValueOnce(endingStream.stream);
+    renderApp(["/tools"]);
+
+    await user.click(await screen.findByRole("button", { name: "Start" }));
+    await waitFor(() => expect(screen.getByText("Listening")).toBeInTheDocument());
+
+    act(() => endingStream.end());
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Microphone capture ended. Choose Retry to start it again.",
+    );
+    expect(screen.getByRole("button", { name: "Retry" })).toBeEnabled();
+    expect(endingStream.track.removeEventListener).toHaveBeenCalledWith(
+      "ended",
+      expect.any(Function),
+    );
+    expect(endingStream.track.stop).toHaveBeenCalledTimes(1);
+  });
+
   it("uses native microphone capture when available", async () => {
     const user = userEvent.setup();
     setMockNativeAudioState({
@@ -266,6 +368,10 @@ describe("Desktop app tools tuner", () => {
     );
     expect(screen.getByText("Listening", { selector: ".subpanel__copy" })).toHaveAttribute("aria-live", "polite");
     expect(getMockMediaDevices().getUserMedia).not.toHaveBeenCalled();
+    expect(getMockInvoke()).not.toHaveBeenCalledWith("power_inhibition_set_activity", {
+      reason: "tuner-capture",
+      active: true,
+    });
 
     act(() => {
       emitMockNativeInputFrame({
@@ -460,6 +566,20 @@ describe("Desktop app tools tuner", () => {
     expect(window.localStorage.getItem("tuneforge.tuner-input-capture-backend")).toContain(
       '"web"',
     );
+  });
+
+  it("keeps Web tuner capture active when screen protection is unavailable", async () => {
+    const user = userEvent.setup();
+    getMockWakeLock().request.mockRejectedValueOnce(new Error("denied"));
+    renderApp(["/tools"]);
+
+    await user.click(await screen.findByRole("button", { name: "Start" }));
+
+    expect(await screen.findByText("Listening")).toBeInTheDocument();
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Screen protection is unavailable. The tuner may stop if the device sleeps.",
+    );
+    expect(screen.getByRole("button", { name: "Stop" })).toBeEnabled();
   });
 
   it("falls back to Web Audio when native capture fails", async () => {

--- a/apps/desktop/src/features/projects/playbackEffects.ts
+++ b/apps/desktop/src/features/projects/playbackEffects.ts
@@ -6,9 +6,9 @@ import {
   type SystemMediaControlEvent,
 } from "../../lib/systemMedia";
 import {
-  setPowerInhibitionActivity,
-  updateBrowserWakeLockStatus,
-} from "../../lib/powerInhibition";
+  usePowerInhibitionActivity,
+  useScreenWakeLock,
+} from "../../lib/useScreenWakeLock";
 import type { ProjectPlaybackSession } from "./playback-context";
 import { isInteractiveTarget } from "./playbackUtils";
 
@@ -28,18 +28,6 @@ type PlaybackMediaControls = {
   stopPlayback: () => void;
 };
 
-type WakeLockSentinelLike = {
-  release: () => Promise<void>;
-  addEventListener?: (type: "release", listener: () => void) => void;
-  removeEventListener?: (type: "release", listener: () => void) => void;
-};
-
-type NavigatorWithWakeLock = Navigator & {
-  wakeLock?: {
-    request: (type: "screen") => Promise<WakeLockSentinelLike>;
-  };
-};
-
 function isTauriRuntime() {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 }
@@ -48,227 +36,11 @@ export function useWebPlaybackWakeLock({
   backend,
   isPlaying,
 }: Pick<PlaybackMediaControls, "backend" | "isPlaying">) {
-  const generationRef = useRef(0);
-  const pendingReleaseGenerationRef = useRef<number | null>(null);
-  useEffect(() => {
-    const ownsWakeLock = backend === "web" && isPlaying && typeof navigator !== "undefined";
-    const generation = ownsWakeLock ? ++generationRef.current : generationRef.current;
-    const publish = (status: Parameters<typeof updateBrowserWakeLockStatus>[0]) => {
-      if (generationRef.current === generation) {
-        updateBrowserWakeLockStatus(status);
-      }
-    };
-    if (!ownsWakeLock) {
-      return;
-    }
-
-    let sentinel: WakeLockSentinelLike | null = null;
-    let sentinelReleaseHandler: (() => void) | null = null;
-    let requestInFlight = false;
-    let cancelled = false;
-    const wakeLock = (navigator as NavigatorWithWakeLock).wakeLock;
-    if (!wakeLock) {
-      publish({
-        phase: "unsupported",
-        backend: null,
-        screenProtected: false,
-        errorMessage: "Screen Wake Lock is unavailable in this browser.",
-      });
-      return;
-    }
-
-    function clearSentinel() {
-      if (sentinel && sentinelReleaseHandler) {
-        sentinel.removeEventListener?.("release", sentinelReleaseHandler);
-      }
-      sentinel = null;
-      sentinelReleaseHandler = null;
-    }
-
-    async function acquireWakeLock() {
-      if (cancelled || sentinel || requestInFlight || document.visibilityState === "hidden") {
-        return;
-      }
-      requestInFlight = true;
-      publish({
-        phase: "acquiring",
-        backend: null,
-        screenProtected: false,
-        errorMessage: null,
-      });
-      try {
-        const nextSentinel = await wakeLock?.request("screen") ?? null;
-        if (cancelled) {
-          if (nextSentinel) {
-            pendingReleaseGenerationRef.current = generation;
-            publish({
-              phase: "releasing",
-              backend: "browser-screen-wake-lock",
-              screenProtected: true,
-              errorMessage: null,
-            });
-            void nextSentinel.release()
-              .then(() => {
-                if (pendingReleaseGenerationRef.current === generation) {
-                  pendingReleaseGenerationRef.current = null;
-                }
-                publish({
-                  phase: "inactive",
-                  backend: null,
-                  screenProtected: false,
-                  errorMessage: null,
-                });
-              })
-              .catch(() => {
-                if (pendingReleaseGenerationRef.current === generation) {
-                  pendingReleaseGenerationRef.current = null;
-                }
-                publish({
-                  phase: "release-failed",
-                  backend: "browser-screen-wake-lock",
-                  screenProtected: true,
-                  errorMessage: "Screen Wake Lock release could not be confirmed.",
-                });
-              });
-          }
-          return;
-        }
-        if (!nextSentinel) {
-          publish({
-            phase: "failed",
-            backend: null,
-            screenProtected: false,
-            errorMessage: "Screen Wake Lock could not be confirmed.",
-          });
-          return;
-        }
-        sentinel = nextSentinel;
-        publish({
-          phase: "active",
-          backend: "browser-screen-wake-lock",
-          screenProtected: true,
-          errorMessage: null,
-        });
-        sentinelReleaseHandler = () => {
-          if (sentinel !== nextSentinel) {
-            return;
-          }
-          clearSentinel();
-          if (!cancelled && document.visibilityState === "visible") {
-            void acquireWakeLock();
-          } else {
-            publish({
-              phase: "inactive",
-              backend: null,
-              screenProtected: false,
-              errorMessage: null,
-            });
-          }
-        };
-        sentinel?.addEventListener?.("release", sentinelReleaseHandler);
-      } catch {
-        clearSentinel();
-        if (cancelled || generationRef.current !== generation) {
-          return;
-        }
-        publish({
-          phase: "failed",
-          backend: null,
-          screenProtected: false,
-          errorMessage: "Screen Wake Lock could not be enabled.",
-        });
-      } finally {
-        requestInFlight = false;
-      }
-    }
-
-    function handleVisibilityChange() {
-      if (document.visibilityState === "visible" && !sentinel) {
-        void acquireWakeLock();
-      }
-    }
-
-    void acquireWakeLock();
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-
-    return () => {
-      cancelled = true;
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-      const activeSentinel = sentinel;
-      clearSentinel();
-      if (activeSentinel) {
-        pendingReleaseGenerationRef.current = generation;
-        publish({
-          phase: "releasing",
-          backend: "browser-screen-wake-lock",
-          screenProtected: true,
-          errorMessage: null,
-        });
-        void activeSentinel.release()
-          .then(() => {
-            if (pendingReleaseGenerationRef.current === generation) {
-              pendingReleaseGenerationRef.current = null;
-            }
-            publish({
-              phase: "inactive",
-              backend: null,
-              screenProtected: false,
-              errorMessage: null,
-            });
-          })
-          .catch(() => {
-            if (pendingReleaseGenerationRef.current === generation) {
-              pendingReleaseGenerationRef.current = null;
-            }
-            publish({
-              phase: "release-failed",
-              backend: "browser-screen-wake-lock",
-              screenProtected: true,
-              errorMessage: "Screen Wake Lock release could not be confirmed.",
-            });
-          });
-      } else {
-        pendingReleaseGenerationRef.current = null;
-        publish({
-          phase: "inactive",
-          backend: null,
-          screenProtected: false,
-          errorMessage: null,
-        });
-      }
-    };
-  }, [backend, isPlaying]);
+  useScreenWakeLock("playback", backend === "web" && isPlaying);
 }
 
 export function usePlaybackPowerProtection(isPlaying: boolean) {
-  const ownsPowerProtectionRef = useRef(false);
-
-  useEffect(() => {
-    if (!isTauriRuntime()) {
-      return;
-    }
-
-    if (isPlaying && !ownsPowerProtectionRef.current) {
-      ownsPowerProtectionRef.current = true;
-      void setPowerInhibitionActivity("playback", true);
-      return;
-    }
-
-    if (!isPlaying && ownsPowerProtectionRef.current) {
-      ownsPowerProtectionRef.current = false;
-      void setPowerInhibitionActivity("playback", false);
-    }
-  }, [isPlaying]);
-
-  useEffect(
-    () => () => {
-      if (ownsPowerProtectionRef.current) {
-        void setPowerInhibitionActivity("playback", false);
-        ownsPowerProtectionRef.current = false;
-      }
-    },
-    [],
-  );
+  usePowerInhibitionActivity("playback", isPlaying);
 }
 
 export function useSystemPlaybackMediaControls({

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -93,13 +93,23 @@ const powerInhibitionReasonLabels: Record<PowerInhibitionReason, string> = {
   playback: "Playback",
   "sync-listener": "Sync listener",
   "sync-transfer": "Sync transfer",
+  "tuner-capture": "Tuner capture",
 };
 
 function powerInhibitionBackendLabel(backend: string | null) {
   if (!backend) {
     return "None confirmed";
   }
-  return backend === "android-foreground-service" ? "Android foreground service" : backend;
+  if (backend === "android-foreground-service") {
+    return "Android foreground service";
+  }
+  if (backend === "android-activity-screen") {
+    return "Android activity screen";
+  }
+  if (backend === "browser-screen-wake-lock") {
+    return "Browser Screen Wake Lock";
+  }
+  return backend;
 }
 
 const themeOptions: ChoiceOption<ThemePreference>[] = [
@@ -1281,7 +1291,7 @@ export function SettingsView() {
                   <dd>{powerInhibitionPhaseLabels[powerInhibitionStatus.phase]}</dd>
                 </div>
                 <div>
-                  <dt>Current Backend</dt>
+                  <dt>Native Backend</dt>
                   <dd>{powerInhibitionBackendLabel(powerInhibitionStatus.backend)}</dd>
                 </div>
                 <div>
@@ -1295,16 +1305,24 @@ export function SettingsView() {
                   </dd>
                 </div>
                 <div>
-                  <dt>Screen Protected</dt>
+                  <dt>Native Screen Protected</dt>
                   <dd>{powerInhibitionStatus.screenProtected ? "Confirmed" : "Not confirmed"}</dd>
                 </div>
                 <div>
-                  <dt>Background Protected</dt>
+                  <dt>Native Background Protected</dt>
                   <dd>{powerInhibitionStatus.backgroundProtected ? "Confirmed" : "Not confirmed"}</dd>
                 </div>
                 <div>
-                  <dt>Browser Screen Wake Lock</dt>
+                  <dt>Browser Screen Wake Lock State</dt>
                   <dd>{powerInhibitionPhaseLabels[browserWakeLockStatus.phase]}</dd>
+                </div>
+                <div>
+                  <dt>Browser Screen Wake Lock Backend</dt>
+                  <dd>{powerInhibitionBackendLabel(browserWakeLockStatus.backend)}</dd>
+                </div>
+                <div>
+                  <dt>Browser Screen Protected</dt>
+                  <dd>{browserWakeLockStatus.screenProtected ? "Confirmed" : "Not confirmed"}</dd>
                 </div>
                 <div>
                   <dt>Last Confirmed Backend</dt>

--- a/apps/desktop/src/features/tools/ToolsView.tsx
+++ b/apps/desktop/src/features/tools/ToolsView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { useSearchParams } from "react-router-dom";
 import {
   getNativeAudioCapabilities,
@@ -16,6 +16,16 @@ import {
   type NativeAudioInputState,
 } from "../../lib/nativeAudio";
 import { useStableCallback } from "../../lib/useStableCallback";
+import {
+  getPowerInhibitionVersion,
+  refreshPowerInhibitionStatus,
+  subscribePowerInhibition,
+  tunerPowerProtectionMessage,
+} from "../../lib/powerInhibition";
+import {
+  usePowerInhibitionActivity,
+  useScreenWakeLock,
+} from "../../lib/useScreenWakeLock";
 import { usePreferences, type TunerVisualMode } from "../../lib/preferences";
 import {
   activateWebAudioContext,
@@ -153,6 +163,7 @@ function ChromaticTunerPage() {
   const readingStabilizerRef = useRef(createStabilizedTunerReadingState());
   const statusRef = useRef(status);
   const streamRef = useRef<MediaStream | null>(null);
+  const webTrackEndCleanupRef = useRef<(() => void) | null>(null);
   const timeDomainDataRef = useRef<Float32Array<ArrayBuffer> | null>(null);
 
   useEffect(() => {
@@ -230,6 +241,8 @@ function ChromaticTunerPage() {
     analyserRef.current = null;
     timeDomainDataRef.current = null;
 
+    webTrackEndCleanupRef.current?.();
+    webTrackEndCleanupRef.current = null;
     streamRef.current?.getTracks().forEach((track) => track.stop());
     streamRef.current = null;
 
@@ -438,6 +451,22 @@ function ChromaticTunerPage() {
     analyserRef.current = analyser;
     mediaSourceRef.current = mediaSource;
 
+    const handleTrackEnded = () => {
+      if (requestIdRef.current !== requestId || streamRef.current !== stream) {
+        return;
+      }
+      requestIdRef.current += 1;
+      releaseCapture();
+      resetTunerDisplay();
+      setStatus("error");
+      setErrorMessage("Microphone capture ended. Choose Retry to start it again.");
+    };
+    const tracks = stream.getTracks();
+    tracks.forEach((track) => track.addEventListener?.("ended", handleTrackEnded));
+    webTrackEndCleanupRef.current = () => {
+      tracks.forEach((track) => track.removeEventListener?.("ended", handleTrackEnded));
+    };
+
     await activateWebAudioContext(audioContext);
 
     if (requestIdRef.current !== requestId) {
@@ -563,6 +592,20 @@ function ChromaticTunerPage() {
 
   const isBusy = status === "starting";
   const isListening = status === "listening";
+  const webTunerListening = isListening && activeCaptureBackend === "web";
+  useSyncExternalStore(
+    subscribePowerInhibition,
+    getPowerInhibitionVersion,
+    getPowerInhibitionVersion,
+  );
+  usePowerInhibitionActivity("tuner-capture", webTunerListening);
+  useScreenWakeLock("tuner-capture", webTunerListening);
+  useEffect(() => {
+    if (isListening) {
+      void refreshPowerInhibitionStatus();
+    }
+  }, [isListening]);
+  const protectionWarning = isListening ? tunerPowerProtectionMessage() : null;
   const canStart =
     ((!webAudioForced && androidRuntime) ||
       canUseTunerCapture(webAudioForced ? null : nativeAudioCapabilities)) &&
@@ -615,6 +658,9 @@ function ChromaticTunerPage() {
         />
 
         {errorMessage ? <p className="inline-error" role="alert">{errorMessage}</p> : null}
+        {protectionWarning ? (
+          <p className="tuner-preferences__status" role="status">{protectionWarning}</p>
+        ) : null}
         {webAudioForced ? (
           <p className="tuner-preferences__status">Web Audio development override is active.</p>
         ) : null}

--- a/apps/desktop/src/lib/powerInhibition.test.ts
+++ b/apps/desktop/src/lib/powerInhibition.test.ts
@@ -52,6 +52,28 @@ describe("power inhibition frontend boundary", () => {
     });
   });
 
+  it("normalizes tuner capture and Android activity-only screen protection", () => {
+    expect(
+      normalizePowerInhibitionStatus({
+        phase: "active",
+        backend: "android-activity-screen",
+        activeReasons: ["tuner-capture"],
+        screenProtected: true,
+        backgroundProtected: false,
+        errorCode: null,
+        errorMessage: null,
+      }),
+    ).toEqual({
+      phase: "active",
+      backend: "android-activity-screen",
+      activeReasons: ["tuner-capture"],
+      screenProtected: true,
+      backgroundProtected: false,
+      errorCode: null,
+      errorMessage: null,
+    });
+  });
+
   it("persists confirmed backend history without restoring active state", async () => {
     mockInvoke.mockResolvedValue({
       phase: "active",

--- a/apps/desktop/src/lib/powerInhibition.ts
+++ b/apps/desktop/src/lib/powerInhibition.ts
@@ -1,7 +1,11 @@
 import { invoke } from "@tauri-apps/api/core";
 import { redactPlaybackDiagnosticText } from "./playbackDiagnostics";
 
-export type PowerInhibitionReason = "playback" | "sync-listener" | "sync-transfer";
+export type PowerInhibitionReason =
+  | "playback"
+  | "sync-listener"
+  | "sync-transfer"
+  | "tuner-capture";
 
 export type PowerInhibitionPhase =
   | "inactive"
@@ -35,6 +39,7 @@ const REASONS = new Set<PowerInhibitionReason>([
   "playback",
   "sync-listener",
   "sync-transfer",
+  "tuner-capture",
 ]);
 const PHASES = new Set<PowerInhibitionPhase>([
   "inactive",
@@ -49,6 +54,7 @@ const BACKENDS = new Set([
   "macos-iopm",
   "xdg-desktop-portal",
   "systemd-logind",
+  "android-activity-screen",
   "android-foreground-service",
 ]);
 
@@ -383,6 +389,20 @@ export function playbackPowerProtectionMessage() {
     return phaseFailureMessage(currentStatus.phase, currentStatus.errorMessage);
   }
   return phaseFailureMessage(browserStatus.phase, browserStatus.errorMessage);
+}
+
+export function tunerPowerProtectionMessage() {
+  const nativeRelevant = currentStatus.activeReasons.includes("tuner-capture");
+  const nativeConfirmed = nativeRelevant && currentStatus.screenProtected;
+  const browserConfirmed = browserStatus.screenProtected;
+  if (nativeConfirmed || browserConfirmed) {
+    return null;
+  }
+  const nativeFailed = nativeRelevant && ["unsupported", "failed"].includes(currentStatus.phase);
+  const browserFailed = ["unsupported", "failed"].includes(browserStatus.phase);
+  return nativeFailed || browserFailed
+    ? "Screen protection is unavailable. The tuner may stop if the device sleeps."
+    : null;
 }
 
 export function syncPowerProtectionMessage(status = currentStatus) {

--- a/apps/desktop/src/lib/useScreenWakeLock.ts
+++ b/apps/desktop/src/lib/useScreenWakeLock.ts
@@ -1,0 +1,240 @@
+import { useEffect, useRef } from "react";
+import {
+  setPowerInhibitionActivity,
+  updateBrowserWakeLockStatus,
+  type PowerInhibitionReason,
+} from "./powerInhibition";
+
+export type ScreenWakeLockOwner = "playback" | "tuner-capture";
+
+type WakeLockSentinelLike = {
+  release: () => Promise<void>;
+  addEventListener?: (type: "release", listener: () => void) => void;
+  removeEventListener?: (type: "release", listener: () => void) => void;
+};
+
+type NavigatorWithWakeLock = Navigator & {
+  wakeLock?: {
+    request: (type: "screen") => Promise<WakeLockSentinelLike>;
+  };
+};
+
+const owners = new Set<ScreenWakeLockOwner>();
+let sentinel: WakeLockSentinelLike | null = null;
+let sentinelReleaseHandler: (() => void) | null = null;
+let requestInFlight = false;
+let ownershipGeneration = 0;
+let visibilitySubscribed = false;
+
+function publish(
+  phase: Parameters<typeof updateBrowserWakeLockStatus>[0]["phase"],
+  screenProtected: boolean,
+  errorMessage: string | null = null,
+) {
+  updateBrowserWakeLockStatus({
+    phase,
+    backend: screenProtected ? "browser-screen-wake-lock" : null,
+    screenProtected,
+    errorMessage,
+  });
+}
+
+function clearSentinel() {
+  if (sentinel && sentinelReleaseHandler) {
+    sentinel.removeEventListener?.("release", sentinelReleaseHandler);
+  }
+  sentinel = null;
+  sentinelReleaseHandler = null;
+}
+
+function handleVisibilityChange() {
+  if (document.visibilityState === "visible" && owners.size > 0 && !sentinel) {
+    void acquireWakeLock();
+  }
+}
+
+function setVisibilitySubscription(active: boolean) {
+  if (active && !visibilitySubscribed) {
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    visibilitySubscribed = true;
+  } else if (!active && visibilitySubscribed) {
+    document.removeEventListener("visibilitychange", handleVisibilityChange);
+    visibilitySubscribed = false;
+  }
+}
+
+function canPublishDetachedRelease(generation: number) {
+  return generation === ownershipGeneration && owners.size === 0 && !sentinel;
+}
+
+async function releaseDetachedSentinel(
+  nextSentinel: WakeLockSentinelLike,
+  generation: number,
+) {
+  if (canPublishDetachedRelease(generation)) {
+    publish("releasing", true);
+  }
+  try {
+    await nextSentinel.release();
+    if (canPublishDetachedRelease(generation)) {
+      publish("inactive", false);
+    }
+  } catch {
+    if (canPublishDetachedRelease(generation)) {
+      publish(
+        "release-failed",
+        true,
+        "Screen Wake Lock release could not be confirmed.",
+      );
+    }
+  }
+}
+
+function releaseCurrentSentinel(generation: number) {
+  const activeSentinel = sentinel;
+  clearSentinel();
+  if (!activeSentinel) {
+    if (generation === ownershipGeneration && owners.size === 0 && !requestInFlight) {
+      publish("inactive", false);
+    }
+    return;
+  }
+
+  publish("releasing", true);
+  void activeSentinel.release()
+    .then(() => {
+      if (generation !== ownershipGeneration || owners.size > 0 || sentinel || requestInFlight) {
+        return;
+      }
+      publish("inactive", false);
+    })
+    .catch(() => {
+      if (generation !== ownershipGeneration || owners.size > 0 || sentinel || requestInFlight) {
+        return;
+      }
+      publish(
+        "release-failed",
+        true,
+        "Screen Wake Lock release could not be confirmed.",
+      );
+    });
+}
+
+async function acquireWakeLock() {
+  if (
+    owners.size === 0 ||
+    sentinel ||
+    requestInFlight ||
+    document.visibilityState === "hidden"
+  ) {
+    return;
+  }
+  const wakeLock = (navigator as NavigatorWithWakeLock).wakeLock;
+  if (!wakeLock) {
+    publish("unsupported", false, "Screen Wake Lock is unavailable in this browser.");
+    return;
+  }
+
+  const generation = ownershipGeneration;
+  requestInFlight = true;
+  publish("acquiring", false);
+  try {
+    const nextSentinel = await wakeLock.request("screen");
+    if (generation !== ownershipGeneration || owners.size === 0) {
+      void releaseDetachedSentinel(nextSentinel, ownershipGeneration);
+      return;
+    }
+
+    sentinel = nextSentinel;
+    sentinelReleaseHandler = () => {
+      if (sentinel !== nextSentinel) {
+        return;
+      }
+      clearSentinel();
+      if (owners.size > 0 && document.visibilityState === "visible") {
+        void acquireWakeLock();
+      } else {
+        publish("inactive", false);
+      }
+    };
+    sentinel.addEventListener?.("release", sentinelReleaseHandler);
+    publish("active", true);
+  } catch {
+    if (generation === ownershipGeneration && owners.size > 0) {
+      publish("failed", false, "Screen Wake Lock could not be enabled.");
+    }
+  } finally {
+    requestInFlight = false;
+    if (
+      generation !== ownershipGeneration &&
+      owners.size > 0 &&
+      !sentinel &&
+      document.visibilityState === "visible"
+    ) {
+      void acquireWakeLock();
+    }
+  }
+}
+
+function setScreenWakeLockOwner(owner: ScreenWakeLockOwner, active: boolean) {
+  const wasOwned = owners.has(owner);
+  if (active === wasOwned) {
+    return;
+  }
+
+  if (active) {
+    const wasEmpty = owners.size === 0;
+    owners.add(owner);
+    if (wasEmpty) {
+      ownershipGeneration += 1;
+      setVisibilitySubscription(true);
+      void acquireWakeLock();
+    }
+    return;
+  }
+
+  owners.delete(owner);
+  if (owners.size > 0) {
+    return;
+  }
+  ownershipGeneration += 1;
+  setVisibilitySubscription(false);
+  if (sentinel) {
+    releaseCurrentSentinel(ownershipGeneration);
+  } else {
+    publish("inactive", false);
+  }
+}
+
+export function useScreenWakeLock(owner: ScreenWakeLockOwner, active: boolean) {
+  useEffect(() => {
+    setScreenWakeLockOwner(owner, active);
+    return () => {
+      if (active) {
+        setScreenWakeLockOwner(owner, false);
+      }
+    };
+  }, [active, owner]);
+}
+
+function isTauriRuntime() {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+export function usePowerInhibitionActivity(reason: PowerInhibitionReason, active: boolean) {
+  const ownsProtectionRef = useRef(false);
+
+  useEffect(() => {
+    if (!active || !isTauriRuntime()) {
+      return;
+    }
+    ownsProtectionRef.current = true;
+    void setPowerInhibitionActivity(reason, true);
+    return () => {
+      if (ownsProtectionRef.current) {
+        ownsProtectionRef.current = false;
+        void setPowerInhibitionActivity(reason, false);
+      }
+    };
+  }, [active, reason]);
+}

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -172,21 +172,29 @@ confirmed path, and latest safe historical failure as separate facts. Active cap
 restored after reload.
 
 Android power protection follows confirmed work automatically; no manual toggle exists. Confirmed
-native playback uses a `mediaPlayback` foreground service and keeps the foreground activity screen
-on. An active sync listener uses `connectedDevice`, and an active transfer also uses `dataSync`.
-Listener and transfer work hold a bounded, renewable partial wake lock; playback relies on Android's
-media path for CPU wakefulness. The ongoing notification states whether playback, sync, or both are
-active. Pause, stop, natural end, fallback, listener stop, transfer completion/cancellation/failure,
-and app shutdown release their corresponding reason without releasing other active work.
+native tuner capture keeps the visible Activity screen on through `keepScreenOn`. Tuner-only
+protection starts no foreground service, notification, or partial wake lock and does not claim
+background microphone continuation. Confirmed native playback uses a `mediaPlayback` foreground
+service and also keeps the foreground Activity screen on. An active sync listener uses
+`connectedDevice`, and an active transfer also uses `dataSync`. Listener and transfer work hold a
+bounded, renewable partial wake lock; playback relies on Android's media path for CPU wakefulness.
+The ongoing notification states whether playback, sync, or both are active; tuner-only work never
+requests notification permission. Tuner capture, playback, listener, and transfer are independent
+owners. Stop, interruption, suspension, natural end, fallback, transfer completion/cancellation/
+failure, and app shutdown clear only the corresponding reason. Shared protection releases after the
+final owner exits.
 On Android 13 and newer, TuneForge requests notification permission only when a user action starts
 protected playback or sync work. Denial does not cancel that work; diagnostics report the missing
 notification visibility while Android's system active-app controls remain available.
 
 Settings diagnostics distinguish acquiring, active, unsupported, failed, releasing, and
-release-not-confirmed states. They report protection only after Android confirms it. Activity ->
-Sync and playback status show concise reliability warnings for unsupported or failed protection.
-Android 15 `dataSync` timeout is reported as a failure and releases protection; it is never shown as
-a completed transfer.
+release-not-confirmed states. They report `android-activity-screen` with confirmed screen coverage
+and no background coverage only for tuner-only protection. Playback or sync service ownership uses
+`android-foreground-service`; combined tuner/service transitions preserve both owners. Tuner,
+Activity -> Sync, and playback status show concise reliability warnings for unsupported or failed
+protection without changing capture or work state. Android 15 `dataSync` timeout is reported as a
+failure and clears the transfer reason while preserving other owners; it is never shown as a
+completed transfer.
 
 `pnpm --filter @tuneforge/desktop android:prepare` updates the generated Android target before a
 build. It keeps these manifest permissions present:
@@ -251,10 +259,15 @@ including nearby endpoint hints.
 
 Also inspect Android service and power state with `adb`: confirmed playback must show the
 `mediaPlayback` foreground-service type; listener and transfer must add `connectedDevice` and
-`dataSync` as applicable. Notification copy must match active work. Verify every terminal path clears
-its reason, and exercise a shortened Android 15 data-sync timeout in a synthetic debug run. A live
-transfer still requires an isolated desktop peer; automated lifecycle tests do not prove that
-end-to-end path.
+`dataSync` as applicable. Confirmed tuner-only capture must keep the visible screen awake without a
+`PowerInhibitionService` foreground-service entry, notification, or partial wake lock. Verify tuner
+stop, interruption, and Android suspension restore normal screen timeout; then overlap tuner with
+playback and sync owners to confirm each release preserves remaining work. Notification copy must
+match active service work. Verify every terminal path clears its reason, and exercise a shortened
+Android 15 data-sync timeout in a synthetic debug run. A live transfer still requires an isolated
+desktop peer; automated lifecycle tests do not prove that end-to-end path. macOS `pmset` and Linux
+portal/logind inhibitor evidence also remain manual platform checks; unit tests prove ownership, not
+OS handle behavior.
 
 Desktop sleep/wake has no native command bridge. The UI uses an elapsed-time check while visible: a
 long timer gap records `sleep` followed by `wake`, while ordinary desktop hidden/blur/pagehide remains

--- a/docs/NATIVE_AUDIO.md
+++ b/docs/NATIVE_AUDIO.md
@@ -36,7 +36,7 @@ falls back to `getUserMedia` after a capability, permission, startup, or stream 
 `VITE_TUNEFORGE_FORCE_WEB_AUDIO=1` development override remains an explicit all-Web mode for both
 tuner capture and playback.
 
-Playback also owns media-key controls and wake prevention through the active backend only:
+Playback owns media-key controls, while playback and tuner capture share counted power protection:
 
 - TuneForge registers one desktop system-media adapter with the OS for media keys and headset
   controls. That adapter does not choose the audio engine; it routes play/pause/stop/seek events to
@@ -49,6 +49,13 @@ Playback also owns media-key controls and wake prevention through the active bac
   including `VITE_TUNEFORGE_FORCE_WEB_AUDIO=1` and native fallback. It uses the browser Screen Wake
   Lock while playing. Browser Screen Wake Lock protects the visible screen only; it does not claim
   native background protection.
+- Native tuner capture acquires the same OS power-protection manager only after the CPAL/AAudio
+  stream starts. Worker exit releases its scoped owner on stop, interruption, replacement, Android
+  suspension, or teardown even when WebView effects cannot run.
+- Confirmed Web Audio tuner capture owns the same shared browser Screen Wake Lock and a native
+  `tuner-capture` reason in packaged Tauri builds. Track termination, stop, error, replacement, and
+  unmount clear both. Pending permission and startup never acquire protection. Playback and tuner
+  browser owners share one sentinel, so either owner can stop without releasing the other.
 - Native fallback is an explicit ownership transfer. TuneForge clears system media state and native
   power protection, starts the Web Audio path at the fallback position, then re-registers system
   media state for the Web Audio owner and acquires the browser wake lock. Diagnostics keep the
@@ -110,8 +117,8 @@ Settings -> Local Data -> Show diagnostics reports:
   the last worker error when present
 - current power-protection phase, confirmed backend, active reasons, and separately confirmed screen
   and background coverage
-- current browser Screen Wake Lock phase plus latest safe power-protection error and last confirmed
-  native backend
+- current native backend, browser Screen Wake Lock phase/backend, and separately confirmed browser
+  screen coverage, plus latest safe power-protection error and last confirmed native backend
 
 Current state is live and starts as `Not playing` / `None` after reload. Only last-confirmed path and
 redacted failures are restored from local storage. A native failure does not claim Web fallback
@@ -128,6 +135,10 @@ toggle, and unavailable hardware. Blocked states give an Android Settings path a
 does not open Settings. Permission and privacy state are rechecked before every start and while the
 stream is active. Revocation, privacy blocking, stream interruption, or app suspension stops the
 stream, clears live pitch/input state, and requires an explicit retry after resume.
+
+Protection failure stays separate from capture truth. Listening continues with a compact warning
+when neither native screen protection nor browser Screen Wake Lock is confirmed. No active owner is
+restored from diagnostics history.
 
 On Web media `error`, playback stops with an error. After `waiting` or `stalled`, five seconds with
 no progress while the element is not paused, seeking, or ended is also treated as a failed path.

--- a/scripts/android-prepare-generated.sh
+++ b/scripts/android-prepare-generated.sh
@@ -161,12 +161,9 @@ class MainActivity : TauriActivity() {
   }
 
   fun setTuneForgePowerInhibition(reasonMask: Int): String {
-    if (reasonMask != 0) {
+    if (reasonMask and PowerInhibitionService.SERVICE_REASON_MASK != 0) {
       requestTuneForgeNotificationPermission()
     }
-    PowerInhibitionService.requestScreenProtection(
-      reasonMask and PowerInhibitionService.REASON_PLAYBACK != 0,
-    )
     return PowerInhibitionService.request(this, reasonMask)
   }
 
@@ -174,9 +171,9 @@ class MainActivity : TauriActivity() {
 
   fun applyTuneForgeScreenProtection() {
     window.decorView.post {
-      val requested = PowerInhibitionService.screenProtectionRequested()
-      window.decorView.keepScreenOn = requested
-      PowerInhibitionService.confirmScreenProtection(requested)
+      val requestedMask = PowerInhibitionService.screenProtectionRequestedMask()
+      window.decorView.keepScreenOn = requestedMask != 0
+      PowerInhibitionService.confirmScreenProtection(requestedMask)
     }
   }
 
@@ -324,7 +321,7 @@ class PowerInhibitionService : Service() {
   override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
     // A queued start intent may predate a later release request. Always apply
     // the latest process-wide desired mask so a stale intent cannot reacquire.
-    val requestedMask = desiredReasonMask()
+    val requestedMask = desiredServiceReasonMask()
     applyReasons(requestedMask)
     return START_NOT_STICKY
   }
@@ -332,12 +329,12 @@ class PowerInhibitionService : Service() {
   override fun onDestroy() {
     releaseWakeLock()
     reasonMask = 0
-    confirmedMask = 0
+    confirmedServiceMask = 0
     instance = null
     super.onDestroy()
-    val remainingMask = desiredMask
-    if (remainingMask != 0) {
-      launch(applicationContext, remainingMask)
+    val remainingServiceMask = desiredServiceMask
+    if (remainingServiceMask != 0) {
+      launch(applicationContext, remainingServiceMask)
     }
   }
 
@@ -345,13 +342,14 @@ class PowerInhibitionService : Service() {
 
   override fun onTimeout(startId: Int, fgsType: Int) {
     if (Build.VERSION.SDK_INT >= 35 && fgsType and ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC != 0) {
-      val remainingMask = reasonMask and REASON_SYNC_TRANSFER.inv()
+      val remainingMask = desiredMask and REASON_SYNC_TRANSFER.inv()
       ownershipRevision.incrementAndGet()
       timeoutEpoch += 1
       lastFailure = ERROR_DATA_SYNC_TIMEOUT
       desiredMask = remainingMask
-      confirmedMask = 0
-      requestScreenProtection(remainingMask and REASON_PLAYBACK != 0)
+      desiredServiceMask = remainingMask and SERVICE_REASON_MASK
+      requestScreenProtection(remainingMask and SCREEN_REASON_MASK)
+      confirmedServiceMask = 0
       releaseWakeLock()
       reasonMask = 0
       stopForeground(STOP_FOREGROUND_REMOVE)
@@ -362,7 +360,7 @@ class PowerInhibitionService : Service() {
   private fun applyReasons(requestedMask: Int): String {
     return try {
       reasonMask = requestedMask
-      confirmedMask = requestedMask
+      confirmedServiceMask = requestedMask
       updateWakeLock()
       if (reasonMask == 0) {
         stopForeground(STOP_FOREGROUND_REMOVE)
@@ -375,10 +373,11 @@ class PowerInhibitionService : Service() {
     } catch (_: RuntimeException) {
       releaseWakeLock()
       reasonMask = 0
-      confirmedMask = 0
-      desiredMask = 0
+      confirmedServiceMask = 0
+      desiredServiceMask = 0
+      desiredMask = desiredMask and SERVICE_REASON_MASK.inv()
       lastFailure = ERROR_POWER_CONTROL
-      requestScreenProtection(false)
+      requestScreenProtection(desiredMask and SCREEN_REASON_MASK)
       stopForeground(STOP_FOREGROUND_REMOVE)
       stopSelf()
       status()
@@ -432,8 +431,8 @@ class PowerInhibitionService : Service() {
   private fun matchesNotificationOwnership(expectedRevision: Long): Boolean =
     expectedRevision == ownershipRevision.get() &&
       reasonMask != 0 &&
-      reasonMask == desiredMask &&
-      reasonMask == confirmedMask
+      reasonMask == desiredServiceMask &&
+      reasonMask == confirmedServiceMask
 
   private fun foregroundServiceTypes(): Int {
     var types = 0
@@ -463,7 +462,7 @@ class PowerInhibitionService : Service() {
   }
 
   private fun updateWakeLock() {
-    val syncActive = reasonMask and (REASON_SYNC_LISTENER or REASON_SYNC_TRANSFER) != 0
+    val syncActive = reasonMask and PARTIAL_WAKE_REASON_MASK != 0
     if (!syncActive) {
       releaseWakeLock()
       return
@@ -480,7 +479,7 @@ class PowerInhibitionService : Service() {
 
   private val renewWakeLock = object : Runnable {
     override fun run() {
-      if (reasonMask and (REASON_SYNC_LISTENER or REASON_SYNC_TRANSFER) == 0) return
+      if (reasonMask and PARTIAL_WAKE_REASON_MASK == 0) return
       wakeLock?.let { lock ->
         if (lock.isHeld) lock.release()
         lock.acquire(WAKE_LOCK_DURATION_MS)
@@ -512,6 +511,10 @@ class PowerInhibitionService : Service() {
     const val REASON_PLAYBACK = 1
     const val REASON_SYNC_LISTENER = 2
     const val REASON_SYNC_TRANSFER = 4
+    const val REASON_TUNER_CAPTURE = 8
+    const val SCREEN_REASON_MASK = REASON_PLAYBACK or REASON_TUNER_CAPTURE
+    const val SERVICE_REASON_MASK = REASON_PLAYBACK or REASON_SYNC_LISTENER or REASON_SYNC_TRANSFER
+    private const val PARTIAL_WAKE_REASON_MASK = REASON_SYNC_LISTENER or REASON_SYNC_TRANSFER
     private const val CHANNEL_ID = "tuneforge_active_work"
     private const val NOTIFICATION_ID = 2304
     private const val EXTRA_REASON_MASK = "reasonMask"
@@ -525,11 +528,12 @@ class PowerInhibitionService : Service() {
 
     @Volatile private var instance: PowerInhibitionService? = null
     @Volatile private var desiredMask = 0
-    @Volatile private var confirmedMask = 0
+    @Volatile private var desiredServiceMask = 0
+    @Volatile private var confirmedServiceMask = 0
     @Volatile private var lastFailure = ERROR_NONE
     @Volatile private var timeoutEpoch = 0L
-    @Volatile private var screenRequested = false
-    @Volatile private var screenConfirmed = false
+    @Volatile private var desiredScreenMask = 0
+    @Volatile private var confirmedScreenMask = 0
     @Volatile private var notificationPermissionRequested = false
     @Volatile private var notificationPermissionDenied = false
     @Volatile private var activity = WeakReference<MainActivity>(null)
@@ -541,20 +545,23 @@ class PowerInhibitionService : Service() {
     }
 
     fun detachActivity(currentActivity: MainActivity) {
-      if (activity.get() === currentActivity) activity.clear()
+      if (activity.get() === currentActivity) {
+        activity.clear()
+        confirmedScreenMask = 0
+      }
     }
 
-    fun requestScreenProtection(enabled: Boolean) {
-      screenRequested = enabled
+    fun requestScreenProtection(reasonMask: Int) {
+      desiredScreenMask = reasonMask and SCREEN_REASON_MASK
       activity.get()?.applyTuneForgeScreenProtection()
     }
 
-    fun screenProtectionRequested(): Boolean = screenRequested
+    fun screenProtectionRequestedMask(): Int = desiredScreenMask
 
-    private fun desiredReasonMask(): Int = desiredMask
+    private fun desiredServiceReasonMask(): Int = desiredServiceMask
 
-    fun confirmScreenProtection(enabled: Boolean) {
-      screenConfirmed = enabled
+    fun confirmScreenProtection(reasonMask: Int) {
+      confirmedScreenMask = reasonMask and SCREEN_REASON_MASK
     }
 
     fun beginNotificationPermissionRequest(): Boolean {
@@ -573,11 +580,16 @@ class PowerInhibitionService : Service() {
     }
 
     fun request(context: Context, reasonMask: Int): String {
-      val previousMask = desiredMask
-      ownershipRevision.incrementAndGet()
+      val previousServiceMask = desiredServiceMask
+      val nextServiceMask = reasonMask and SERVICE_REASON_MASK
+      if (previousServiceMask != nextServiceMask) {
+        ownershipRevision.incrementAndGet()
+      }
       desiredMask = reasonMask
+      desiredServiceMask = nextServiceMask
+      requestScreenProtection(reasonMask and SCREEN_REASON_MASK)
       if (lastFailure == ERROR_DATA_SYNC_TIMEOUT &&
-        (reasonMask and REASON_SYNC_TRANSFER == 0 || previousMask and REASON_SYNC_TRANSFER == 0)
+        (reasonMask and REASON_SYNC_TRANSFER == 0 || previousServiceMask and REASON_SYNC_TRANSFER == 0)
       ) {
         lastFailure = ERROR_NONE
       } else if (lastFailure == ERROR_POWER_CONTROL || lastFailure == ERROR_NOTIFICATION_POST_FAILED) {
@@ -585,34 +597,36 @@ class PowerInhibitionService : Service() {
       }
       val existing = instance
       if (existing != null) {
-        existing.applyOnMainThread(reasonMask)
+        existing.applyOnMainThread(nextServiceMask)
         return status()
       }
-      if (reasonMask == 0) {
-        confirmedMask = 0
+      if (nextServiceMask == 0) {
+        confirmedServiceMask = 0
         return status()
       }
 
-      launch(context, reasonMask)
+      launch(context, nextServiceMask)
       return status()
     }
 
     fun status(): String {
-      val activeMask = confirmedMask
-      val screenMatches = screenConfirmed == (desiredMask and REASON_PLAYBACK != 0)
+      val screenMatches = confirmedScreenMask == desiredScreenMask
+      val serviceMatches = confirmedServiceMask == desiredServiceMask
+      val screenOnlyMask = confirmedScreenMask and SERVICE_REASON_MASK.inv()
+      val activeMask = if (serviceMatches) (confirmedServiceMask or screenOnlyMask) else 0
       val statusError = when {
         lastFailure != ERROR_NONE -> lastFailure
-        notificationPermissionDenied && desiredMask != 0 -> ERROR_NOTIFICATION_PERMISSION_DENIED
+        notificationPermissionDenied && desiredServiceMask != 0 -> ERROR_NOTIFICATION_PERMISSION_DENIED
         else -> ERROR_NONE
       }
       val phase = when {
         statusError != ERROR_NONE -> "failed"
-        activeMask == desiredMask && screenMatches && activeMask == 0 -> "inactive"
-        activeMask == desiredMask && screenMatches -> "active"
+        serviceMatches && screenMatches && activeMask == 0 -> "inactive"
+        serviceMatches && screenMatches -> "active"
         desiredMask == 0 -> "releasing"
         else -> "acquiring"
       }
-      return "$phase;$activeMask;$statusError;$desiredMask;$timeoutEpoch;$screenConfirmed"
+      return "$phase;$activeMask;$statusError;$desiredMask;$timeoutEpoch;${confirmedScreenMask != 0}"
     }
 
     private fun launch(context: Context, reasonMask: Int) {
@@ -625,10 +639,11 @@ class PowerInhibitionService : Service() {
           context.startService(intent)
         }
       } catch (_: RuntimeException) {
-        desiredMask = 0
-        confirmedMask = 0
+        desiredMask = desiredMask and SERVICE_REASON_MASK.inv()
+        desiredServiceMask = 0
+        confirmedServiceMask = 0
         lastFailure = ERROR_POWER_CONTROL
-        requestScreenProtection(false)
+        requestScreenProtection(desiredMask and SCREEN_REASON_MASK)
       }
     }
   }
@@ -649,12 +664,17 @@ verify_power_notification_wiring() {
     'instance?.repostNotificationAfterPermissionGrant(expectedRevision)'
     'ownershipRevision.incrementAndGet()'
     'expectedRevision == ownershipRevision.get()'
-    'reasonMask == desiredMask &&'
-    'reasonMask == confirmedMask'
+    'reasonMask == desiredServiceMask &&'
+    'reasonMask == confirmedServiceMask'
     'if (!matchesNotificationOwnership(expectedRevision)) return@post'
     'if (matchesNotificationOwnership(expectedRevision)) {'
     'buildTruthfulForegroundNotification()'
     'ERROR_NOTIFICATION_POST_FAILED'
+    'const val REASON_TUNER_CAPTURE = 8'
+    'const val SCREEN_REASON_MASK = REASON_PLAYBACK or REASON_TUNER_CAPTURE'
+    'const val SERVICE_REASON_MASK = REASON_PLAYBACK or REASON_SYNC_LISTENER or REASON_SYNC_TRANSFER'
+    'val activeMask = if (serviceMatches) (confirmedServiceMask or screenOnlyMask) else 0'
+    'notificationPermissionDenied && desiredServiceMask != 0'
   )
   local snippet
   for snippet in "${required_snippets[@]}"; do
@@ -666,7 +686,9 @@ verify_power_notification_wiring() {
   if ! grep -Fq 'notificationPermissionOwnershipRevision,' "$MAIN_ACTIVITY" ||
     ! grep -Fq 'val expectedRevision = PowerInhibitionService.captureNotificationPermissionOwnershipRevision()' "$MAIN_ACTIVITY" ||
     ! grep -Fq 'if (!PowerInhibitionService.beginNotificationPermissionRequest()) return@post' "$MAIN_ACTIVITY" ||
-    ! grep -Fq 'notificationPermissionOwnershipRevision = expectedRevision' "$MAIN_ACTIVITY"; then
+    ! grep -Fq 'notificationPermissionOwnershipRevision = expectedRevision' "$MAIN_ACTIVITY" ||
+    ! grep -Fq 'reasonMask and PowerInhibitionService.SERVICE_REASON_MASK != 0' "$MAIN_ACTIVITY" ||
+    ! grep -Fq 'window.decorView.keepScreenOn = requestedMask != 0' "$MAIN_ACTIVITY"; then
     echo "Generated Android activity does not bind notification permission to ownership." >&2
     exit 1
   fi


### PR DESCRIPTION
## Summary

- Add tuner capture as a fourth counted power-protection owner across native and Web Audio paths.
- Keep Android tuner-only protection on the visible Activity without starting the foreground service, notification, or TuneForge partial wake lock.
- Preserve playback and sync ownership while exposing truthful tuner and Android activity-screen diagnostics.
- Closes #360

## Testing

- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test` (39 files, 707 tests)
- `cd apps/desktop/src-tauri && cargo test power_inhibition` (13 passed)
- `cd apps/desktop/src-tauri && cargo test native_audio::capture` (14 passed)
- `cd apps/desktop/src-tauri && cargo check`
- `cd apps/desktop/src-tauri && cargo fmt --check`
- `pnpm package:android:debug`
- macOS `pmset -g assertions`: tuner and playback each held the TuneForge display-sleep assertion.
- Fresh Android 36.1 AVD: tuner-only capture kept the Activity awake past timeout without the TuneForge foreground service, notification, or sync wake lock; Stop restored timeout.
- Linux portal/logind runtime proof was not run because no Linux host was available; run the app on Linux, start and stop tuner capture, and inspect the portal/logind inhibitor lifecycle.
