### PR TITLE
fix: contain wrapped Tools selector on mobile

### DIFF
--- a/apps/desktop/src/App.tools-tuner.test.tsx
+++ b/apps/desktop/src/App.tools-tuner.test.tsx
@@ -56,6 +56,9 @@ describe("Desktop app tools tuner", () => {
     renderApp(["/tools"]);
 
     expect(await screen.findByRole("heading", { name: "Tools" })).toBeInTheDocument();
+    expect(screen.getByRole("tablist", { name: "Tools" })).toHaveClass(
+      "project-workspace-tabs--tools",
+    );
     expect(screen.getByRole("tab", { name: "Chromatic Tuner" })).toHaveAttribute("aria-selected", "true");
     expect(screen.getByRole("button", { name: "Start" })).toBeEnabled();
     expect(screen.getByLabelText("Microphone source")).toHaveValue("");

--- a/apps/desktop/src/features/tools/ToolsView.tsx
+++ b/apps/desktop/src/features/tools/ToolsView.tsx
@@ -87,7 +87,7 @@ export function ToolsView() {
         </div>
       </div>
 
-      <div className="project-workspace-tabs" role="tablist" aria-label="Tools">
+      <div className="project-workspace-tabs project-workspace-tabs--tools" role="tablist" aria-label="Tools">
         {[
           { id: "tuner", label: "Chromatic Tuner" },
           { id: "metronome", label: "Metronome" },

--- a/apps/desktop/src/styles/project-layout.css
+++ b/apps/desktop/src/styles/project-layout.css
@@ -612,3 +612,20 @@
     writing-mode: horizontal-tb;
   }
 }
+
+@media (max-width: 720px) {
+  .project-workspace-tabs--tools {
+    display: flex;
+    width: 100%;
+    gap: 0.45rem;
+    padding: 0.5rem;
+    border-radius: 18px;
+  }
+
+  .project-workspace-tabs--tools .project-workspace-tabs__button {
+    flex: 1 1 calc((100% - 0.45rem) / 2);
+    min-inline-size: 0;
+    min-block-size: 3rem;
+    padding-inline: 0.75rem;
+  }
+}

--- a/apps/desktop/tests/tools-selector-responsive-css.test.ts
+++ b/apps/desktop/tests/tools-selector-responsive-css.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const projectLayoutCss = readFileSync("src/styles/project-layout.css", "utf8");
+
+function cssBlock(source: string, signature: string) {
+  const signatureIndex = source.indexOf(signature);
+  if (signatureIndex < 0) {
+    throw new Error(`CSS signature not found: ${signature}`);
+  }
+  const openBraceIndex = source.indexOf("{", signatureIndex + signature.length);
+  if (openBraceIndex < 0) {
+    throw new Error(`CSS block not found: ${signature}`);
+  }
+
+  let depth = 1;
+  for (let index = openBraceIndex + 1; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") depth -= 1;
+    if (depth === 0) return source.slice(openBraceIndex + 1, index);
+  }
+  throw new Error(`Unclosed CSS block: ${signature}`);
+}
+
+function lastCssBlock(source: string, signature: string) {
+  const signatureIndex = source.lastIndexOf(signature);
+  return cssBlock(source.slice(signatureIndex), signature);
+}
+
+function cssDeclarations(block: string) {
+  return Object.fromEntries(
+    block
+      .split(";")
+      .map((declaration) => declaration.trim())
+      .filter(Boolean)
+      .map((declaration) => {
+        const separatorIndex = declaration.indexOf(":");
+        return [
+          declaration.slice(0, separatorIndex).trim(),
+          declaration.slice(separatorIndex + 1).trim(),
+        ];
+      }),
+  );
+}
+
+describe("Tools selector responsive CSS", () => {
+  it("uses a contained two-row selector without changing shared workspace tabs", () => {
+    const mobileRules = lastCssBlock(projectLayoutCss, "@media (max-width: 720px)");
+    const selectorDeclarations = cssDeclarations(
+      cssBlock(mobileRules, ".project-workspace-tabs--tools"),
+    );
+    const buttonDeclarations = cssDeclarations(
+      cssBlock(mobileRules, ".project-workspace-tabs--tools .project-workspace-tabs__button"),
+    );
+
+    expect(selectorDeclarations).toMatchObject({
+      display: "flex",
+      width: "100%",
+      gap: "0.45rem",
+      padding: "0.5rem",
+      "border-radius": "18px",
+    });
+    expect(buttonDeclarations).toMatchObject({
+      flex: "1 1 calc((100% - 0.45rem) / 2)",
+      "min-inline-size": "0",
+      "min-block-size": "3rem",
+    });
+    expect(mobileRules).not.toContain(".project-workspace-tabs {\n    display: flex");
+  });
+});


### PR DESCRIPTION
## Summary

- contain the wrapped Tools selector within a Tools-only mobile panel
- preserve 48px tab targets, labels, selected state, and wide selector behavior
- add responsive CSS and rendered modifier coverage
- Closes #366

## Testing

- `pnpm --filter @tuneforge/desktop test --run`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm package:android:debug`
- Android emulator screenshots at 360dp, 448dp, and a Galaxy S26 Ultra approximation
- Android accessibility hierarchy check for labels, selection, focusability, and 49dp targets
