### PR TITLE
fix: preserve stem playback controls and improve rename

### DIFF
--- a/apps/desktop/src/App.mobile.test.tsx
+++ b/apps/desktop/src/App.mobile.test.tsx
@@ -7,6 +7,7 @@ import { updateBrowserWakeLockStatus } from "./lib/powerInhibition";
 import {
   findAudioByArtifactId,
   markAudioReady,
+  mockCreateStems,
   mockGetChords,
   mockGetLyrics,
   mockGetMobileCapabilities,
@@ -164,6 +165,37 @@ describe("Desktop app mobile capability gates", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.queryByText("Generate stems from Project workspace for source track or selected mix.")).not.toBeInTheDocument();
+  });
+
+  it("resets synced stem controls from Android Practice Controls without leaving stems", async () => {
+    const user = userEvent.setup();
+    enableAndroidRuntime();
+    await mockCreateStems("proj_123", { source_artifact_id: "art_source" });
+    renderApp(["/projects/proj_123"]);
+
+    await user.click(await screen.findByRole("tab", { name: "Playback" }));
+    await user.click(screen.getByRole("button", { name: "Open Practice Controls" }));
+    const dialog = screen.getByRole("dialog", { name: "Practice Controls" });
+    const stemList = within(dialog).getByRole("group", { name: "Playback stem list" });
+    const resetButton = within(dialog).getByRole("button", { name: "Reset stem mute and solo" });
+    expect(resetButton).toBeDisabled();
+
+    await user.click(within(stemList).getAllByRole("button", { name: /Vocals/i })[0] as HTMLElement);
+    await user.click(within(stemList).getByRole("button", { name: "Mute Drums" }));
+    expect(resetButton).toBeEnabled();
+    expect(within(stemList).getByRole("button", { name: "Mute Drums" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    await user.click(resetButton);
+    expect(within(stemList).getByRole("button", { name: "Mute Drums" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(within(stemList).getAllByRole("button", { name: /Vocals/i })[0]).toHaveClass(
+      "artifact-pill--active",
+    );
   });
 
   it("allows emulator lyrics flow testing while keeping stems disabled", async () => {

--- a/apps/desktop/src/App.project-playback-artifacts.test.tsx
+++ b/apps/desktop/src/App.project-playback-artifacts.test.tsx
@@ -747,6 +747,61 @@ describe("Desktop app project playback artifacts", () => {
     expect(await screen.findByRole("heading", { name: "Practice Set" })).toBeInTheDocument();
   });
 
+  it("submits rename with Enter and cancels with Escape without toggling playback", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    const sourceAudio = findAudioByArtifactId("art_source");
+    markAudioReady(sourceAudio);
+    await user.click(screen.getByRole("button", { name: "Rename" }));
+    const nameInput = screen.getByLabelText("Project name");
+    await user.clear(nameInput);
+    await user.type(nameInput, "Practice Set");
+
+    expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+    await user.keyboard("{Enter}");
+
+    expect(mockUpdateProject).toHaveBeenCalledTimes(1);
+    expect(mockUpdateProject).toHaveBeenCalledWith("proj_123", { display_name: "Practice Set" });
+    expect(await screen.findByRole("heading", { name: "Practice Set" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Rename" }));
+    await user.clear(screen.getByLabelText("Project name"));
+    await user.type(screen.getByLabelText("Project name"), "Discard me");
+    screen.getByRole("button", { name: "Play playback" }).focus();
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByLabelText("Project name")).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Practice Set" })).toBeInTheDocument();
+    expect(mockUpdateProject).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
+  });
+
+  it("guards whitespace and pending rename submission", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Rename" }));
+    const nameInput = screen.getByLabelText("Project name");
+    await user.clear(nameInput);
+    await user.type(nameInput, "   ");
+    await user.keyboard("{Enter}");
+    expect(mockUpdateProject).not.toHaveBeenCalled();
+
+    await user.clear(nameInput);
+    await user.type(nameInput, "Practice Set");
+    mockUpdateProject.mockImplementationOnce(
+      () => new Promise<never>(() => undefined),
+    );
+    await user.keyboard("{Enter}");
+    await user.keyboard("{Enter}");
+
+    expect(mockUpdateProject).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+  });
+
   it("counts total stems across source audio and saved mixes in the collapsed sources rail", async () => {
     const user = userEvent.setup();
     renderApp(["/projects/proj_123"]);

--- a/apps/desktop/src/App.project-playback-stems.test.tsx
+++ b/apps/desktop/src/App.project-playback-stems.test.tsx
@@ -39,6 +39,7 @@ function readStoredProjectPlaybackState() {
         startSeconds: number;
         endSeconds: number;
       } | null;
+      stemControls?: Record<string, { muted: boolean; solo: boolean }>;
     }
   >;
 }
@@ -130,6 +131,181 @@ describe("Desktop app project playback stems", () => {
 
     expect(await screen.findByRole("heading", { name: "Vocals" })).toBeInTheDocument();
     expect(screen.getByRole("group", { name: "Playback stem list" })).toBeInTheDocument();
+  });
+
+  it("keeps stored practice-stem controls and selection while artifacts hydrate", async () => {
+    const artifacts = [
+      {
+        id: "art_preview",
+        project_id: "proj_123",
+        type: "preview_mix",
+        format: "wav",
+        path: "/tmp/demo-preview.wav",
+        metadata: { transpose: { semitones: 2 } },
+        created_at: "2026-04-18T13:16:00.000Z",
+      },
+      {
+        id: "art_source",
+        project_id: "proj_123",
+        type: "source_audio",
+        format: "wav",
+        path: "/tmp/demo.wav",
+        metadata: {},
+        created_at: "2026-04-18T13:16:00.000Z",
+      },
+      ...["source", "mix"].flatMap((source) =>
+        ["vocals", "drums"].map((stem) => ({
+          id: `art_${source}_${stem}`,
+          project_id: "proj_123",
+          type: stem === "vocals" ? "vocal_stem" : "drums_stem",
+          format: "wav",
+          path: `/tmp/${source}-${stem}.wav`,
+          metadata: {
+            source_artifact_id: source === "source" ? "art_source" : "art_preview",
+            stem_source: stem,
+          },
+          created_at: "2026-04-18T13:16:00.000Z",
+        })),
+      ),
+    ];
+    let resolveArtifacts: (value: { artifacts: typeof artifacts }) => void = () => undefined;
+    const defaultListArtifacts = mockListArtifacts.getMockImplementation();
+    if (!defaultListArtifacts) {
+      throw new Error("Expected the artifact-list mock implementation.");
+    }
+    mockListArtifacts
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ artifacts: typeof artifacts }>((resolve) => {
+            resolveArtifacts = resolve;
+          }),
+      )
+      .mockImplementation(() => Promise.resolve({ artifacts }));
+    window.localStorage.setItem(
+      "tuneforge.project-playback-state",
+      JSON.stringify({
+        proj_123: {
+          selectedArtifactId: "art_mix_vocals",
+          selectedPrimaryArtifactId: "art_preview",
+          selectedStemSourceArtifactId: "art_preview",
+          activeWorkspace: "playback",
+          stemControls: {
+            art_source_drums: { muted: true, solo: false },
+            art_mix_vocals: { muted: false, solo: true },
+            art_mix_drums: { muted: true, solo: false },
+          },
+        },
+      }),
+    );
+
+    try {
+      const firstRender = renderApp(["/projects/proj_123"]);
+      expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+      await waitFor(() =>
+        expect(readStoredProjectPlaybackState().proj_123).toMatchObject({
+          selectedArtifactId: "art_mix_vocals",
+          selectedPrimaryArtifactId: "art_preview",
+          stemControls: {
+            art_source_drums: { muted: true, solo: false },
+            art_mix_vocals: { muted: false, solo: true },
+          },
+        }),
+      );
+
+      await act(async () => {
+        resolveArtifacts({ artifacts });
+      });
+      expect(await screen.findByRole("heading", { name: "Vocals" })).toBeInTheDocument();
+      let stemList = screen.getByRole("group", { name: "Playback stem list" });
+      expect(within(stemList).getByRole("button", { name: "Solo Vocals" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      expect(within(stemList).getByRole("button", { name: "Mute Drums" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+
+      firstRender.unmount();
+      renderApp(["/projects/proj_123"]);
+      expect(await screen.findByRole("heading", { name: "Vocals" })).toBeInTheDocument();
+      stemList = screen.getByRole("group", { name: "Playback stem list" });
+      expect(within(stemList).getByRole("button", { name: "Solo Vocals" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+      expect(readStoredProjectPlaybackState().proj_123?.stemControls?.art_source_drums).toEqual({
+        muted: true,
+        solo: false,
+      });
+    } finally {
+      mockListArtifacts.mockImplementation(defaultListArtifacts);
+    }
+  });
+
+  it("keeps source and practice-mix stem controls independent and resets only the visible set", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await generateStems(user);
+    await openPlaybackWorkspace(user);
+
+    let stemList = await screen.findByRole("group", { name: "Playback stem list" });
+    await user.click(within(stemList).getAllByRole("button", { name: /Vocals/i })[0] as HTMLElement);
+    await user.click(within(stemList).getByRole("button", { name: "Mute Drums" }));
+    await user.click(within(stemList).getByRole("button", { name: "Solo Vocals" }));
+    expect(screen.getByRole("button", { name: "Reset stem mute and solo" })).toBeEnabled();
+
+    await user.click(screen.getByRole("tab", { name: "Project" }));
+    await openStudioPanel(user);
+    const savedMixList = screen.getByRole("group", { name: "Saved mix list" });
+    await user.click(within(savedMixList).getByRole("button", { name: /Practice Mix/i }));
+    await generateStems(user);
+    await openPlaybackWorkspace(user);
+
+    stemList = await screen.findByRole("group", { name: "Playback stem list" });
+    await user.click(within(stemList).getAllByRole("button", { name: /Vocals/i })[0] as HTMLElement);
+    await user.click(within(stemList).getByRole("button", { name: "Mute Drums" }));
+
+    const sourceList = screen.getByRole("group", { name: "Playback source and mix list" });
+    await user.click(within(sourceList).getByRole("button", { name: /Source Track/i }));
+    stemList = await screen.findByRole("group", { name: "Playback stem list" });
+    expect(within(stemList).getByRole("button", { name: "Mute Drums" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(within(stemList).getByRole("button", { name: "Solo Vocals" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Full Mix" }));
+    expect(await screen.findByRole("heading", { name: "Source Track" })).toBeInTheDocument();
+    expect(within(stemList).getByRole("button", { name: "Mute Drums" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    await user.click(within(stemList).getAllByRole("button", { name: /Vocals/i })[0] as HTMLElement);
+    expect(await screen.findByRole("heading", { name: "Vocals" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Reset stem mute and solo" }));
+    expect(await screen.findByRole("heading", { name: "Vocals" })).toBeInTheDocument();
+    expect(within(stemList).getByRole("button", { name: "Mute Drums" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(within(stemList).getByRole("button", { name: "Solo Vocals" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+
+    await user.click(within(sourceList).getByRole("button", { name: /Practice Mix/i }));
+    stemList = await screen.findByRole("group", { name: "Playback stem list" });
+    expect(within(stemList).getByRole("button", { name: "Mute Drums" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
   });
 
   it("restores mix-owned stems after reopening the project", async () => {

--- a/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
+++ b/apps/desktop/src/features/projects/components/PlaybackPracticeRail.tsx
@@ -47,6 +47,7 @@ export const PlaybackPracticeRail = forwardRef<
     handleSetPlaybackTempo,
     handleSetLoopAlignmentMode,
     handleResetPlaybackTempo,
+    handleResetStemControls,
     handleSelectPrimaryArtifact,
     handleSelectStemArtifact,
     higherCapoPreview,
@@ -56,6 +57,7 @@ export const PlaybackPracticeRail = forwardRef<
     handleSetPrecountLoopEnabled,
     canGenerateStems,
     informationDensity,
+    hasActiveStemControls,
     isMobileRuntime,
     isStemPlayback,
     lowerCapoPreview,
@@ -508,6 +510,15 @@ export const PlaybackPracticeRail = forwardRef<
                 type="button"
               >
                 Full Mix
+              </button>
+              <button
+                aria-label="Reset stem mute and solo"
+                className="chip"
+                disabled={!hasActiveStemControls}
+                onClick={handleResetStemControls}
+                type="button"
+              >
+                Reset
               </button>
             </div>
 

--- a/apps/desktop/src/features/projects/components/ProjectHeader.tsx
+++ b/apps/desktop/src/features/projects/components/ProjectHeader.tsx
@@ -35,10 +35,45 @@ export function ProjectHeader({
   } = useProjectViewModelContext();
   const showSyncStatus = projectSyncSummary.showBadge;
   const syncReason = projectSyncLockReason ? ` ${projectSyncLockReason}` : "";
+  const canSubmitRename =
+    !projectEditLocked && !renameMutation.isPending && Boolean(draftName.trim());
+  const submitRename = () => {
+    if (canSubmitRename) {
+      renameMutation.mutate();
+    }
+  };
+  const cancelRename = useCallback(() => {
+    if (renameMutation.isPending) {
+      return;
+    }
+    setIsRenaming(false);
+    setDraftName(projectQuery.data?.display_name ?? "");
+  }, [
+    projectQuery.data?.display_name,
+    renameMutation.isPending,
+    setDraftName,
+    setIsRenaming,
+  ]);
   const [overflowOpen, setOverflowOpen] = useState(false);
   const overflowRef = useRef<HTMLDivElement>(null);
   const overflowHistoryMarkerRef = useRef(`playback-overflow-${crypto.randomUUID()}`);
   const overflowTriggerRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!isRenaming) {
+      return;
+    }
+    const handleRenameKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape" && event.key !== "Esc") {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      cancelRename();
+    };
+    window.addEventListener("keydown", handleRenameKeyDown, true);
+    return () => window.removeEventListener("keydown", handleRenameKeyDown, true);
+  }, [cancelRename, isRenaming]);
 
   const dismissOverflowFromUi = useCallback((restoreFocus = true) => {
     setOverflowOpen(false);
@@ -212,7 +247,13 @@ export function ProjectHeader({
           <Link to="/">Library</Link> / Project
         </p>
         {isRenaming ? (
-          <div className="title-edit">
+          <form
+            className="title-edit"
+            onSubmit={(event) => {
+              event.preventDefault();
+              submitRename();
+            }}
+          >
             <input
               aria-label="Project name"
               className="title-input"
@@ -223,25 +264,21 @@ export function ProjectHeader({
             <div className="button-row">
               <button
                 className="button button--primary button--small"
-                type="button"
-                onClick={() => renameMutation.mutate()}
-                disabled={projectEditLocked || renameMutation.isPending || !draftName.trim()}
+                type="submit"
+                disabled={!canSubmitRename}
               >
                 {renameMutation.isPending ? "Saving..." : "Save"}
               </button>
               <button
                 className="button button--ghost button--small"
                 type="button"
-                onClick={() => {
-                  setIsRenaming(false);
-                  setDraftName(projectQuery.data?.display_name ?? "");
-                }}
+                onClick={cancelRename}
                 disabled={renameMutation.isPending}
               >
                 Cancel
               </button>
             </div>
-          </div>
+          </form>
         ) : (
           <div className="title-row">
             <h1>{projectQuery.data?.display_name ?? "Project"}</h1>

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -1283,6 +1283,10 @@ export function useProjectViewModel() {
     }
     return !state.muted;
   }).length;
+  const hasActiveStemControls = visibleStemArtifacts.some((artifact) => {
+    const state = stemControls[artifact.id];
+    return state?.muted || state?.solo;
+  });
 
   function handleSelectPrimaryArtifact(artifact: ArtifactSchema) {
     setSelectedPrimaryArtifactId(artifact.id);
@@ -1644,6 +1648,24 @@ export function useProjectViewModel() {
           [mode]: !previous[mode],
         },
       };
+    });
+  }
+
+  function handleResetStemControls() {
+    setStemControls((current) => {
+      let changed = false;
+      const next = { ...current };
+
+      visibleStemArtifacts.forEach((artifact) => {
+        const state = current[artifact.id];
+        if (!state?.muted && !state?.solo) {
+          return;
+        }
+        next[artifact.id] = { muted: false, solo: false };
+        changed = true;
+      });
+
+      return changed ? next : current;
     });
   }
 
@@ -2121,14 +2143,26 @@ export function useProjectViewModel() {
   ]);
 
   useEffect(() => {
+    if (hydratedProjectId !== projectId || !artifactsQuery.isSuccess) {
+      return;
+    }
+
     setStemControls((current) => {
+      const validStemIds = new Set(stemArtifacts.map((artifact) => artifact.id));
       const next: Record<string, StemControlState> = {};
-      visibleStemArtifacts.forEach((artifact) => {
-        next[artifact.id] = current[artifact.id] ?? { muted: false, solo: false };
+      validStemIds.forEach((artifactId) => {
+        next[artifactId] = current[artifactId] ?? { muted: false, solo: false };
       });
-      return next;
+
+      const didChange =
+        Object.keys(current).length !== Object.keys(next).length ||
+        Object.entries(next).some(
+          ([artifactId, state]) =>
+            current[artifactId]?.muted !== state.muted || current[artifactId]?.solo !== state.solo,
+        );
+      return didChange ? next : current;
     });
-  }, [visibleStemArtifacts]);
+  }, [artifactsQuery.isSuccess, hydratedProjectId, projectId, stemArtifacts]);
 
   useEffect(() => {
     if (hydratedProjectId !== projectId || !isProjectJobsLoaded) {
@@ -2555,6 +2589,7 @@ export function useProjectViewModel() {
     handleOpenTabImport,
     handleRejectTabSuggestionGroup,
     handleResetPlaybackTempo,
+    handleResetStemControls,
     handleTogglePlaybackLoop,
     handleSetPlaybackDisplayMode,
     handleStemAction,
@@ -2566,6 +2601,7 @@ export function useProjectViewModel() {
     hasTimedLyricsTranscript,
     hasTransformChange,
     hasVisibleStems,
+    hasActiveStemControls,
     hasNextProjectHistoryJobsPage: terminalProjectJobsQuery.hasNextPage,
     higherCapoPreview,
     higherCapoShiftOptions,

--- a/apps/desktop/src/styles/project-layout.css
+++ b/apps/desktop/src/styles/project-layout.css
@@ -563,6 +563,11 @@
   border-color: var(--button-hover-border);
 }
 
+.chip:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
 .artifact-pill--active,
 .chip--active,
 .stem-row__name--active {


### PR DESCRIPTION
## Summary

- preserve source and practice-mix stem mode plus mute and solo state across hydration and navigation
- add a scoped Reset control that clears only the visible stems without changing playback mode
- submit project renames with Enter and cancel with Escape while preserving the Space shortcut
- stop artifact reconciliation from pruning stored controls during loading and mix changes

## Testing

- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test -- src/App.project-playback-artifacts.test.tsx` — 713 passed
- `cd apps/backend && uv run --python 3.11 pytest` — 677 passed
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml -- --test-threads=1` — 311 passed
- `pnpm package:android:debug` and Android 16 install/launch smoke passed before the Escape-only follow-up
- manually verified stem persistence, Reset, Enter rename, and Space playback using an isolated data directory
- Android runtime smoke covered startup only; no live stem project was imported
