### PR TITLE
build: require Android NDK 29 or newer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,9 @@ jobs:
       - name: Test setup-dev script
         run: bash scripts/setup-dev.test.sh
 
+      - name: Test Android toolchain helper
+        run: bash scripts/android-arm64-env.test.sh
+
   e2e:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/android-arm64-env.sh
+++ b/scripts/android-arm64-env.sh
@@ -4,17 +4,39 @@ set -euo pipefail
 ANDROID_HOME="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-$HOME/Library/Android/sdk}}"
 NDK_ROOT="${ANDROID_NDK_HOME:-${ANDROID_NDK_ROOT:-}}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIN_NDK_MAJOR=29
+NDK_INSTALL_HINT="Install NDK ${MIN_NDK_MAJOR} or newer: android sdk install ndk/29.0.14206865"
 
-if [[ -z "$NDK_ROOT" ]]; then
-  if [[ ! -d "$ANDROID_HOME/ndk" ]]; then
-    echo "Android NDK not found under $ANDROID_HOME/ndk" >&2
-    exit 1
-  fi
-  NDK_ROOT="$(find "$ANDROID_HOME/ndk" -mindepth 1 -maxdepth 1 -type d | sort | tail -n 1)"
+ndk_revision() {
+  local revision
+  revision="$(awk -F= '$1 ~ /^[[:space:]]*Pkg.Revision[[:space:]]*$/ { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); print $2; exit }' "$1/source.properties" 2>/dev/null)"
+  [[ "$revision" =~ ^[0-9]+(\.[0-9]+)*$ ]] && printf '%s\n' "$revision"
+}
+
+version_less() {
+  local IFS=. i
+  local -a left_parts=($1) right_parts=($2)
+  for ((i = 0; i < ${#left_parts[@]} || i < ${#right_parts[@]}; i++)); do
+    ((10#${left_parts[i]:-0} < 10#${right_parts[i]:-0})) && return 0; ((10#${left_parts[i]:-0} > 10#${right_parts[i]:-0})) && return 1
+  done
+  return 1
+}
+
+if [[ -n "$NDK_ROOT" ]]; then
+  NDK_REVISION="$(ndk_revision "$NDK_ROOT" || true)"
+else
+  NDK_REVISION=""
+  for candidate in "$ANDROID_HOME/ndk"/*; do
+    candidate_revision="$(ndk_revision "$candidate" || true)"
+    [[ -n "$candidate_revision" && $((10#${candidate_revision%%.*})) -ge $MIN_NDK_MAJOR ]] || continue
+    if [[ -z "$NDK_REVISION" ]] || version_less "$candidate_revision" "$NDK_REVISION"; then
+      NDK_ROOT="$candidate"
+      NDK_REVISION="$candidate_revision"
+    fi
+  done
 fi
-
-if [[ -z "$NDK_ROOT" || ! -d "$NDK_ROOT" ]]; then
-  echo "Android NDK not found. Set ANDROID_NDK_HOME or install it with Android Studio." >&2
+if [[ -z "$NDK_ROOT" || -z "$NDK_REVISION" || $((10#${NDK_REVISION%%.*})) -lt $MIN_NDK_MAJOR ]]; then
+  echo "Android NDK must have numeric Pkg.Revision >= ${MIN_NDK_MAJOR}: ${NDK_ROOT:-$ANDROID_HOME/ndk}. $NDK_INSTALL_HINT" >&2
   exit 1
 fi
 

--- a/scripts/android-arm64-env.test.sh
+++ b/scripts/android-arm64-env.test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/tuneforge-android-arm64-env-test.XXXXXX")"
+trap 'rm -rf "${fixture}"' EXIT
+
+mkdir -p "${fixture}/bin" "${fixture}/cargo/bin" "${fixture}/tmp"
+cat > "${fixture}/bin/uname" <<'EOF'
+#!/usr/bin/env bash
+echo Darwin
+EOF
+cat > "${fixture}/bin/rustup" <<EOF
+#!/usr/bin/env bash
+echo "${fixture}/cargo/bin/cargo"
+EOF
+cat > "${fixture}/bin/llvm-ar" <<'EOF'
+#!/usr/bin/env bash
+last=""
+for arg in "$@"; do last="$arg"; done
+: > "$last"
+EOF
+chmod +x "${fixture}/bin/uname" "${fixture}/bin/rustup" "${fixture}/bin/llvm-ar"
+
+make_ndk() {
+  local sdk="$1" directory="$2" revision="$3"
+  local ndk="${sdk}/ndk/${directory}"
+  mkdir -p "${ndk}/toolchains/llvm/prebuilt/darwin-x86_64/bin"
+  printf 'Pkg.Revision = %s\n' "$revision" > "${ndk}/source.properties"
+  for tool in aarch64-linux-android26-clang aarch64-linux-android26-clang++; do
+    ln -s "${fixture}/bin/llvm-ar" "${ndk}/toolchains/llvm/prebuilt/darwin-x86_64/bin/${tool}"
+  done
+  ln -s "${fixture}/bin/llvm-ar" "${ndk}/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar"
+}
+
+run_helper() {
+  local label="$1" sdk="$2"
+  shift 2
+  env -i PATH="${fixture}/bin:/usr/bin:/bin" HOME="${fixture}/home" TMPDIR="${fixture}/tmp" ANDROID_HOME="$sdk" "$@" \
+    /bin/bash "${repo_root}/scripts/android-arm64-env.sh" env > "${fixture}/${label}.out" 2>&1
+}
+
+assert_selected() {
+  local label="$1" expected="$2"
+  grep -Fx "ANDROID_NDK_HOME=${expected}" "${fixture}/${label}.out" >/dev/null
+  grep -Fx "ANDROID_NDK_ROOT=${expected}" "${fixture}/${label}.out" >/dev/null
+}
+
+sdk_auto="${fixture}/sdk-auto"
+make_ndk "$sdk_auto" 27.0.12077973 27.0.12077973
+make_ndk "$sdk_auto" 29.0.14206865 29.0.14206865
+run_helper auto "$sdk_auto"
+assert_selected auto "${sdk_auto}/ndk/29.0.14206865"
+
+make_ndk "$sdk_auto" 30.0.10000000 30.0.10000000
+run_helper preferred "$sdk_auto"
+assert_selected preferred "${sdk_auto}/ndk/29.0.14206865"
+
+sdk_order="${fixture}/sdk-order"
+make_ndk "$sdk_order" 29.0.9 29.0.9
+make_ndk "$sdk_order" 29.0.10 29.0.10
+run_helper same-major "$sdk_order"
+assert_selected same-major "${sdk_order}/ndk/29.0.9"
+
+make_ndk "$sdk_auto" malformed not-a-version
+run_helper malformed-skip "$sdk_auto"
+assert_selected malformed-skip "${sdk_auto}/ndk/29.0.14206865"
+
+sdk_old="${fixture}/sdk-old"
+make_ndk "$sdk_old" 28.0.13004108 28.0.13004108
+if run_helper incompatible "$sdk_old"; then
+  echo "expected incompatible installed NDKs to fail" >&2
+  exit 1
+fi
+grep -F "android sdk install ndk/29.0.14206865" "${fixture}/incompatible.out" >/dev/null
+
+if run_helper override-old "$sdk_auto" "ANDROID_NDK_HOME=${sdk_auto}/ndk/27.0.12077973"; then
+  echo "expected lower explicit NDK override to fail" >&2
+  exit 1
+fi
+
+if run_helper override-missing "$sdk_auto" "ANDROID_NDK_HOME=${fixture}/missing"; then
+  echo "expected missing explicit NDK override to fail" >&2
+  exit 1
+fi
+
+if run_helper override-malformed "$sdk_auto" "ANDROID_NDK_HOME=${sdk_auto}/ndk/malformed"; then
+  echo "expected malformed explicit NDK override to fail" >&2
+  exit 1
+fi
+
+run_helper override-new "$sdk_auto" "ANDROID_NDK_HOME=${sdk_auto}/ndk/30.0.10000000"
+assert_selected override-new "${sdk_auto}/ndk/30.0.10000000"
+
+echo "android-arm64-env NDK selection tests passed"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -41,6 +41,15 @@ setup_dev_start=${SECONDS}
 setup_dev_elapsed=$((SECONDS - setup_dev_start))
 printf '\n[tests] setup-dev script tests finished in %ss\n' "${setup_dev_elapsed}"
 
+printf '\n[tests] Starting Android toolchain helper tests\n\n'
+android_env_start=${SECONDS}
+(
+  cd "${repo_root}"
+  bash scripts/android-arm64-env.test.sh
+)
+android_env_elapsed=$((SECONDS - android_env_start))
+printf '\n[tests] Android toolchain helper tests finished in %ss\n' "${android_env_elapsed}"
+
 printf '\n[tests] Starting Tauri shell tests\n\n'
 tauri_start=${SECONDS}
 (


### PR DESCRIPTION
## Summary

- Require Android NDK 29 or newer using numeric `Pkg.Revision` validation.
- Prefer the lowest compatible installed revision and reject invalid explicit overrides.
- Add isolated selection tests to the local test runner and CI.
- Refs #377.

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `bash -n scripts/android-arm64-env.sh`
- `bash -n scripts/android-arm64-env.test.sh`
- `bash scripts/android-arm64-env.test.sh`
- `pnpm test` — desktop and script stages passed; one unrelated Rust timing test failed once.
- `cargo test mobile_media_transport::tests::shutdown_interrupts_an_incomplete_request --lib` — focused rerun passed.
- `uv run --python 3.11 pytest` — 676 passed; one unrelated analysis-job timeout failed once.
- `uv run --python 3.11 pytest tests/test_analysis_flow.py::test_analysis_job_persists_results` — focused rerun passed.
