### PR TITLE
test: allow cold analysis job startup

### DIFF
--- a/apps/backend/tests/test_analysis_flow.py
+++ b/apps/backend/tests/test_analysis_flow.py
@@ -26,7 +26,7 @@ def test_analysis_job_persists_results(client, sample_rhythmic_audio_file: Path)
         f"/api/v1/projects/{project['id']}/analyze",
         json={"include_tempo": False, "force": False},
     ).json()["job"]
-    final_job = wait_for_job(client, job["id"])
+    final_job = wait_for_job(client, job["id"], timeout=90.0)
     assert final_job["status"] == "completed"
     assert final_job["beat_backend"] == "built-in"
     assert final_job["beat_input"] == "source"


### PR DESCRIPTION
## Summary

- Allow the first real analysis job in the persistence flow test 90 seconds on cold runners.
- Restore headroom lost when test setup stopped warming analysis during import.
- Keep the shared job timeout and production behavior unchanged.

## Testing

- `cd apps/backend && uv run --frozen --python 3.11 ruff check .`
- `cd apps/backend && uv run --frozen --python 3.11 mypy app`
- `cd apps/backend && uv run --frozen --python 3.11 pytest -p no:cacheprovider` — 677 passed
