### PR TITLE
fix(android): preserve JNI bridge methods in release builds

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,7 +7,7 @@
     "build": "tsc && vite build",
     "android:prepare": "bash ../../scripts/android-prepare-generated.sh",
     "android:icons": "tauri icon --output src-tauri/target/android-icons src-tauri/icons/icon.png",
-    "android:build": "pnpm android:icons && pnpm android:prepare && bash ../../scripts/android-arm64-env.sh tauri android build --target aarch64 --apk",
+    "android:build": "pnpm android:icons && pnpm android:prepare && bash ../../scripts/android-arm64-env.sh tauri android build --target aarch64 --apk && node ../../scripts/validate-android-release-jni.mjs",
     "android:build:debug": "pnpm android:icons && pnpm android:prepare && bash ../../scripts/android-arm64-env.sh tauri android build --debug --target aarch64 --apk",
     "android:studio": "bash ../../scripts/android-arm64-env.sh tauri android dev --open",
     "dev": "vite",

--- a/apps/desktop/src-tauri/proguard-tuneforge.pro
+++ b/apps/desktop/src-tauri/proguard-tuneforge.pro
@@ -1,0 +1,6 @@
+-keepclassmembers class com.tuneforge.desktop.MainActivity {
+    public java.lang.String setTuneForgePowerInhibition(int);
+    public java.lang.String getTuneForgePowerInhibitionStatus();
+    public java.lang.String getTuneForgeAudioPermissionState();
+    public java.lang.String requestTuneForgeAudioPermission();
+}

--- a/scripts/android-prepare-generated.sh
+++ b/scripts/android-prepare-generated.sh
@@ -8,11 +8,20 @@ ANDROID_ICONS="$ROOT_DIR/apps/desktop/src-tauri/target/android-icons/android"
 MANIFEST="$ANDROID_MAIN/AndroidManifest.xml"
 MAIN_ACTIVITY="$ANDROID_MAIN/java/com/tuneforge/desktop/MainActivity.kt"
 POWER_SERVICE="$ANDROID_MAIN/java/com/tuneforge/desktop/PowerInhibitionService.kt"
+PROGUARD_RULES="$ROOT_DIR/apps/desktop/src-tauri/proguard-tuneforge.pro"
+PROGUARD_DEST="$ROOT_DIR/apps/desktop/src-tauri/gen/android/app/proguard-tuneforge.pro"
 
 if [[ ! -f "$MANIFEST" || ! -f "$MAIN_ACTIVITY" || ! -d "$ANDROID_RES" ]]; then
   echo "Android project is not initialized. Run pnpm --filter @tuneforge/desktop tauri android init first." >&2
   exit 1
 fi
+
+if [[ ! -f "$PROGUARD_RULES" ]]; then
+  echo "TuneForge Android ProGuard rules are missing at $PROGUARD_RULES" >&2
+  exit 1
+fi
+
+cp "$PROGUARD_RULES" "$PROGUARD_DEST"
 
 copy_android_icons() {
   if [[ ! -d "$ANDROID_ICONS" ]]; then

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -23,6 +23,15 @@ sync_validation_start=${SECONDS}
 sync_validation_elapsed=$((SECONDS - sync_validation_start))
 printf '\n[tests] Sync validation harness tests finished in %ss\n' "${sync_validation_elapsed}"
 
+printf '\n[tests] Starting Android release JNI validation tests\n\n'
+android_jni_validation_start=${SECONDS}
+(
+  cd "${repo_root}"
+  node --test scripts/validate-android-release-jni.test.mjs
+)
+android_jni_validation_elapsed=$((SECONDS - android_jni_validation_start))
+printf '\n[tests] Android release JNI validation tests finished in %ss\n' "${android_jni_validation_elapsed}"
+
 printf '\n[tests] Starting release license inventory tests\n\n'
 release_license_start=${SECONDS}
 (

--- a/scripts/validate-android-release-jni.mjs
+++ b/scripts/validate-android-release-jni.mjs
@@ -1,0 +1,191 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = path.resolve(scriptDir, "..");
+const activityClass = "com.tuneforge.desktop.MainActivity";
+const requiredMethods = new Map([
+  ["setTuneForgePowerInhibition", "(I)Ljava/lang/String;"],
+  ["getTuneForgePowerInhibitionStatus", "()Ljava/lang/String;"],
+  ["getTuneForgeAudioPermissionState", "()Ljava/lang/String;"],
+  ["requestTuneForgeAudioPermission", "()Ljava/lang/String;"],
+]);
+
+export function parseJniRules(source) {
+  const lines = source.replace(/#.*/g, "").split("\n").map((line) => line.trim()).filter(Boolean);
+  if (lines.some((line) => /\*|\.\.\./.test(line)) ||
+    lines[0] !== `-keepclassmembers class ${activityClass} {` || lines.at(-1) !== "}") {
+    throw new Error("JNI rules must be one narrow MainActivity -keepclassmembers block without wildcards.");
+  }
+  const methods = lines.slice(1, -1).map((line) => {
+    const match = /^public\s+([\w.]+)\s+([A-Za-z_$][\w$]*)\(([^)]*)\);$/.exec(line);
+    if (!match) throw new Error(`Invalid JNI rule: ${line}`);
+    const parameters = match[3] ? match[3].split(",").map((item) => item.trim()) : [];
+    return { returnType: match[1], name: match[2], parameters, descriptor: `(${parameters.map(javaDescriptor).join("")})${javaDescriptor(match[1])}` };
+  });
+  if (lines.length !== 6 || methods.length !== requiredMethods.size ||
+    methods.some((method) => requiredMethods.get(method.name) !== method.descriptor) ||
+    new Set(methods.map((method) => method.name)).size !== methods.length) {
+    throw new Error("JNI rules must preserve exactly the four Rust-called MainActivity methods.");
+  }
+  return methods;
+}
+
+export function resolveReleaseArtifact(metadataPath) {
+  const metadataFile = path.resolve(metadataPath);
+  const metadata = JSON.parse(readFileSync(metadataFile, "utf8"));
+  if (metadata.variantName !== "universalRelease" || metadata.artifactType?.type !== "APK" ||
+    !Array.isArray(metadata.elements) || metadata.elements.length !== 1) {
+    throw new Error("Expected universalRelease APK output metadata with exactly one element.");
+  }
+  const element = metadata.elements[0];
+  if (element.type !== "SINGLE" || !Array.isArray(element.filters) || element.filters.length !== 0 ||
+    typeof element.outputFile !== "string" || path.isAbsolute(element.outputFile) ||
+    !element.outputFile.endsWith(".apk")) {
+    throw new Error("Release APK metadata element must be one unfiltered SINGLE relative .apk output.");
+  }
+  const output = path.resolve(path.dirname(metadataFile), element.outputFile);
+  if (path.relative(path.dirname(metadataFile), output).startsWith("..") || !existsSync(output)) {
+    throw new Error("Release APK output path is unsafe or missing.");
+  }
+  return output;
+}
+
+export function selectAndroidTools(sdkRoot) {
+  const buildTools = path.join(sdkRoot, "build-tools");
+  if (!existsSync(buildTools)) throw new Error(`Android build-tools directory is missing: ${buildTools}`);
+  const versions = readdirSync(buildTools).sort(compareVersions).reverse();
+  for (const version of versions) {
+    const root = path.join(buildTools, version);
+    const tools = Object.fromEntries(["aapt2", "apksigner", "dexdump"].map((name) => [name, path.join(root, name)]));
+    if (Object.values(tools).every(existsSync)) return { ...tools, version };
+  }
+  throw new Error("No Android build-tools version contains aapt2, apksigner, and dexdump.");
+}
+
+export function assertDexMethods(xmlDocuments, methods) {
+  const classes = (Array.isArray(xmlDocuments) ? xmlDocuments : [xmlDocuments]).flatMap(parseDexXml);
+  if (classes.length !== 1) throw new Error(`DEX must contain exactly one ${activityClass} class.`);
+  const declared = classes[0].methods;
+  for (const expected of methods) {
+    const matches = declared.filter((method) => method.name === expected.name);
+    if (matches.length !== 1) throw new Error(`DEX must contain exactly one ${expected.name} method.`);
+    const actual = matches[0];
+    const descriptor = `(${actual.parameters.map(javaDescriptor).join("")})${javaDescriptor(actual.returnType)}`;
+    if (descriptor !== expected.descriptor) {
+      throw new Error(`DEX signature mismatch for ${expected.name}: expected ${expected.descriptor}, got ${descriptor}.`);
+    }
+  }
+}
+
+function parseDexXml(xml) {
+  const stack = [];
+  const targets = [];
+  const tags = /<\/?(package|class|method|constructor|parameter)\b([^>]*)>/g;
+  for (const match of xml.matchAll(tags)) {
+    const [tag, element, rawAttributes] = match;
+    const closing = tag.startsWith("</");
+    const selfClosing = /\/\s*>$/.test(tag);
+    if (closing) {
+      const node = stack.pop();
+      if (!node || node.element !== element) throw new Error(`Malformed DEX XML: unexpected closing ${element}.`);
+      if (element === "parameter" && !/^\s*$/.test(xml.slice(node.contentStart, match.index))) {
+        throw new Error(`Malformed DEX XML: parameter ${node.type ?? ""} has content.`);
+      }
+      if (element === "class" && node.target) targets.push(node);
+      continue;
+    }
+    const attributes = rawAttributes.replace(/\/\s*$/, "");
+    const node = { element, name: xmlAttribute(attributes, "name"), contentStart: match.index + tag.length };
+    if (element === "package") node.packageName = node.name;
+    if (element === "class") {
+      const packageNode = [...stack].reverse().find((item) => item.element === "package");
+      node.target = packageNode?.packageName === "com.tuneforge.desktop" && node.name === "MainActivity";
+      node.methods = [];
+    }
+    if (element === "method" || element === "constructor") {
+      const classNode = [...stack].reverse().find((item) => item.element === "class");
+      if (!classNode) throw new Error(`Malformed DEX XML: ${element} outside class.`);
+      node.returnType = xmlAttribute(attributes, "return");
+      node.parameters = [];
+      if (element === "method" && classNode.target) classNode.methods.push(node);
+    }
+    if (element === "parameter") {
+      const memberNode = [...stack].reverse().find((item) => item.element === "method" || item.element === "constructor");
+      if (!memberNode) throw new Error("Malformed DEX XML: parameter outside method or constructor.");
+      node.type = xmlAttribute(attributes, "type");
+      if (memberNode.element === "method") memberNode.parameters.push(node.type);
+    }
+    if (selfClosing) {
+      if (element === "class" && node.target) targets.push(node);
+      continue;
+    }
+    stack.push(node);
+  }
+  if (stack.length) throw new Error(`Malformed DEX XML: unclosed ${stack.at(-1).element}.`);
+  return targets;
+}
+
+export function validateReleaseJni({ root = workspaceRoot, run = runCommand } = {}) {
+  const rules = parseJniRules(readFileSync(path.join(root, "apps/desktop/src-tauri/proguard-tuneforge.pro"), "utf8"));
+  const apk = resolveReleaseArtifact(path.join(root, "apps/desktop/src-tauri/gen/android/app/build/outputs/apk/universal/release/output-metadata.json"));
+  const sdkRoot = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT || path.join(os.homedir(), "Library/Android/sdk");
+  const tools = selectAndroidTools(sdkRoot);
+  const badging = run(tools.aapt2, ["dump", "badging", apk]);
+  if (/application-debuggable/.test(badging) || !/native-code:.*'arm64-v8a'/.test(badging)) {
+    throw new Error("Release APK must be non-debuggable and contain arm64-v8a native code.");
+  }
+  run(tools.apksigner, ["verify", "--verbose", apk]);
+  let tempDir;
+  try {
+    const dexFiles = run("unzip", ["-Z1", apk]).split("\n").filter((file) => /^classes\d*\.dex$/.test(file)).sort(compareDexNames);
+    if (!dexFiles.length) throw new Error("Release APK contains no classes*.dex files.");
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "tuneforge-jni-dex-"));
+    run("unzip", ["-qq", apk, ...dexFiles, "-d", tempDir]);
+    const xmlDocuments = dexFiles.map((file) => run(tools.dexdump, ["-l", "xml", path.join(tempDir, file)]));
+    assertDexMethods(xmlDocuments, rules);
+  } finally {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function javaDescriptor(type) {
+  const primitive = { void: "V", boolean: "Z", byte: "B", char: "C", short: "S", int: "I", long: "J", float: "F", double: "D" };
+  if (primitive[type]) return primitive[type];
+  if (!type || !/^[\w.]+(?:\[\])*$/.test(type)) throw new Error(`Unsupported Java type in JNI rule or DEX output: ${type}`);
+  const dimensions = (type.match(/\[\]/g) ?? []).length;
+  return `${"[".repeat(dimensions)}L${type.replace(/\[\]/g, "").replaceAll(".", "/")};`;
+}
+
+function xmlAttribute(attributes, name) {
+  return new RegExp(`\\b${name}="([^"]*)"`).exec(attributes)?.[1];
+}
+
+function compareVersions(left, right) {
+  return left.localeCompare(right, undefined, { numeric: true, sensitivity: "base" });
+}
+
+function compareDexNames(left, right) {
+  return left.localeCompare(right, undefined, { numeric: true });
+}
+
+function runCommand(command, args) {
+  return execFileSync(command, args, {
+    encoding: "utf8",
+    maxBuffer: 256 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    validateReleaseJni();
+    console.log("Android release JNI validation passed.");
+  } catch (error) {
+    console.error(`Android release JNI validation failed: ${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/validate-android-release-jni.test.mjs
+++ b/scripts/validate-android-release-jni.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { assertDexMethods, parseJniRules, resolveReleaseArtifact, selectAndroidTools } from "./validate-android-release-jni.mjs";
+
+const rules = `-keepclassmembers class com.tuneforge.desktop.MainActivity {
+    public java.lang.String setTuneForgePowerInhibition(int);
+    public java.lang.String getTuneForgePowerInhibitionStatus();
+    public java.lang.String getTuneForgeAudioPermissionState();
+    public java.lang.String requestTuneForgeAudioPermission();
+}`;
+
+test("parses only exact narrow JNI rules", () => {
+  const methods = parseJniRules(rules);
+  assert.deepEqual(methods.map(({ name, descriptor }) => [name, descriptor]), [
+    ["setTuneForgePowerInhibition", "(I)Ljava/lang/String;"],
+    ["getTuneForgePowerInhibitionStatus", "()Ljava/lang/String;"],
+    ["getTuneForgeAudioPermissionState", "()Ljava/lang/String;"],
+    ["requestTuneForgeAudioPermission", "()Ljava/lang/String;"],
+  ]);
+  assert.throws(() => parseJniRules(rules.replace("getTuneForgeAudioPermissionState()", "*")), /wildcards/);
+  assert.throws(() => parseJniRules(rules.replace("setTuneForgePowerInhibition(int)", "setTuneForgePowerInhibition()")), /exactly/);
+});
+
+test("accepts only one safe universal release APK output", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-jni-metadata-"));
+  const apk = path.join(root, "app-universal-release.apk");
+  writeFileSync(apk, "apk");
+  const metadata = path.join(root, "output-metadata.json");
+  writeFileSync(metadata, JSON.stringify({
+    artifactType: { type: "APK" }, variantName: "universalRelease",
+    elements: [{ type: "SINGLE", filters: [], outputFile: path.basename(apk) }],
+  }));
+  assert.equal(resolveReleaseArtifact(metadata), apk);
+  writeFileSync(metadata, JSON.stringify({ artifactType: { type: "APK" }, variantName: "universalRelease", elements: [{ type: "SINGLE", filters: [], outputFile: "../unsafe.apk" }] }));
+  assert.throws(() => resolveReleaseArtifact(metadata), /unsafe/);
+});
+
+test("selects highest complete Android build-tools version", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-jni-sdk-"));
+  for (const version of ["35.0.0", "36.0.0"]) {
+    const dir = path.join(root, "build-tools", version);
+    mkdirSync(dir, { recursive: true });
+    for (const tool of ["aapt2", "apksigner", "dexdump"]) writeFileSync(path.join(dir, tool), "");
+  }
+  assert.equal(selectAndroidTools(root).version, "36.0.0");
+});
+
+test("requires exact DEX class method descriptors", () => {
+  const methods = parseJniRules(rules);
+  const xml = dexXml(methods);
+  assert.doesNotThrow(() => assertDexMethods(xml, methods));
+  assert.throws(() => assertDexMethods(
+    xml.replace('return="java.lang.String"', 'return="int"'),
+    methods,
+  ), /signature mismatch/);
+});
+
+test("rejects duplicate MainActivity classes across DEX documents", () => {
+  const methods = parseJniRules(rules);
+  const xml = dexXml(methods);
+  assert.throws(() => assertDexMethods([xml, xml], methods), /exactly one/);
+});
+
+test("rejects malformed parameter XML", () => {
+  const methods = parseJniRules(rules);
+  const xml = dexXml(methods);
+  assert.throws(() => assertDexMethods(xml.replace("</parameter>", "</method>"), methods), /unexpected closing method/);
+  assert.throws(() => assertDexMethods(xml.replace("\n</parameter>", "content</parameter>"), methods), /parameter int has content/);
+});
+
+test("rejects unclosed classes, methods, and extra closing tags", () => {
+  const methods = parseJniRules(rules);
+  const xml = dexXml(methods);
+  assert.throws(() => assertDexMethods(xml.replace("</class></package>", ""), methods), /unclosed class/);
+  assert.throws(() => assertDexMethods(xml.replace("</method>", "</class>"), methods), /unexpected closing class/);
+  assert.throws(() => assertDexMethods(xml.replace("</constructor>", "</method>"), methods), /unexpected closing method/);
+  assert.throws(() => assertDexMethods(`${xml}</method>`, methods), /unexpected closing method/);
+});
+
+function dexXml(methods) {
+  return `<package name="com.tuneforge.desktop"><class name="MainActivity"><constructor name="&lt;init&gt;" return="void"><parameter name="arg0" type="int">\n</parameter></constructor>${methods.map((method) =>
+    `<method name="${method.name}" return="java.lang.String">${method.name === "setTuneForgePowerInhibition" ? '<parameter name="arg0" type="int">\n</parameter>' : ""}</method>`,
+  ).join("")}</class></package>`;
+}


### PR DESCRIPTION
## Summary

- preserve four Rust-called `MainActivity` JNI bridge methods through release R8 optimization
- validate the signed `universalRelease` APK, arm64 payload, debuggability, and exact final DEX descriptors
- run the validator after Android release packaging and cover rule, metadata, path, and DEX failure cases
- Closes #376

## Testing

- `bash -n scripts/android-prepare-generated.sh scripts/run-tests.sh scripts/android-arm64-env.sh scripts/android-arm64-env.test.sh`
- `node --test scripts/validate-android-release-jni.test.mjs`
- `bash scripts/android-arm64-env.test.sh`
- `pnpm package:android` with Android NDK 29.0.14206865
- final APK SHA-256: `a686138e55102fac5ad29f1d8d4c528577e608f32c343cd02a4296009be10fc2`
- isolated Android 36.1 arm64 emulator release smoke before rebase: tuner Ready -> Listening -> Ready
- physical-device validation deferred
