### PR TITLE
test: speed cold analysis persistence test

### DIFF
--- a/apps/backend/tests/test_analysis_flow.py
+++ b/apps/backend/tests/test_analysis_flow.py
@@ -5,10 +5,12 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 import pytest
 from sqlalchemy import select
 
 from app.db import SessionLocal
+from app.engines import audio_features
 from app.errors import AppError
 from app.models import AnalysisResult, Artifact, Job, Project
 from app.services import analysis as analysis_service
@@ -19,7 +21,16 @@ from app.services.stem_signal_metadata import STEM_SIGNAL_METADATA_KEY, STEM_SIG
 from .conftest import import_project_without_jobs, wait_for_job
 
 
-def test_analysis_job_persists_results(client, sample_rhythmic_audio_file: Path):
+def test_analysis_job_persists_results(
+    client,
+    sample_rhythmic_audio_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Persistence test bypasses Librosa HPSS lazy import/JIT; full HPSS behavior remains engine-test responsibility.
+    def split_harmonic_percussive(signal: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        return signal, signal
+
+    monkeypatch.setattr(audio_features, "_split_harmonic_percussive", split_harmonic_percussive)
     project = import_project_without_jobs(sample_rhythmic_audio_file)
 
     job = client.post(


### PR DESCRIPTION
## Summary

- Bypass Librosa HPSS lazy import and JIT only in the analysis persistence test.
- Preserve the real built-in job, remaining analysis, database, artifact, and refresh assertions.
- Reduce isolated cold execution from 38.09 seconds to 22.40 seconds while retaining the 90-second allowance.
- Closes #380.

## Testing

- `cd apps/backend && uv run --isolated --frozen --python 3.11 pytest -p no:cacheprovider tests/test_analysis_flow.py::test_analysis_job_persists_results --durations=0 -vv` — passed; 22.40-second cold call.
- `cd apps/backend && uv run --python 3.11 pytest -p no:cacheprovider tests/test_analysis_flow.py::test_analysis_job_persists_results --durations=0 -vv` — passed; 2.35-second warm call.
- `cd apps/backend && uv run --python 3.11 ruff check .` — passed.
- `cd apps/backend && uv run --python 3.11 mypy app` — passed.
- `cd apps/backend && uv run --python 3.11 pytest -p no:cacheprovider` — 677 passed in 59.17 seconds.
- First full-suite run hit one unrelated lyrics queue timeout; its focused rerun and the full rerun passed.
- GitHub-hosted backend CI — 677 passed in 139.64 seconds; focused test took 29.60 seconds.
- Prior GitHub-hosted evidence was 32.99 seconds for the focused test and 143.12 seconds for the suite.
