### PR TITLE
test(desktop): reset shared wake-lock state

### DIFF
--- a/apps/desktop/src/App.project-media-controls.test.tsx
+++ b/apps/desktop/src/App.project-media-controls.test.tsx
@@ -174,6 +174,17 @@ function SharedWakeLockHarness({ playback, tuner }: { playback: boolean; tuner: 
   return null;
 }
 
+function deferWakeLockRequest() {
+  const sentinel = {
+    release: vi.fn(async () => undefined),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  };
+  let resolve!: (value: typeof sentinel) => void;
+  const request = () => new Promise<typeof sentinel>((resolveRequest) => { resolve = resolveRequest; });
+  return { resolve: () => resolve(sentinel), request, sentinel };
+}
+
 function PlaybackPowerProtectionHarness({
   backend,
   isPlaying,
@@ -1026,6 +1037,37 @@ describe("Desktop app project media controls", () => {
     await waitFor(() => expect(getMockWakeLock().sentinels[0]?.release).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(readBrowserWakeLockStatus().phase).toBe("inactive"));
     view.unmount();
+  });
+
+  it("keeps a fresh tuner Wake Lock request isolated from a reset owner", async () => {
+    const priorRequest = deferWakeLockRequest();
+    getMockWakeLock().request.mockImplementationOnce(priorRequest.request);
+    const priorView = render(<SharedWakeLockHarness playback tuner={false} />);
+    await waitFor(() => expect(getMockWakeLock().request).toHaveBeenCalledTimes(1));
+
+    resetAppTestHarness();
+
+    const freshRequest = deferWakeLockRequest();
+    getMockWakeLock().request.mockImplementationOnce(freshRequest.request);
+    const freshView = render(<SharedWakeLockHarness playback={false} tuner />);
+    await waitFor(() => expect(getMockWakeLock().request).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      priorRequest.resolve();
+      await Promise.resolve();
+    });
+    fireEvent(document, new Event("visibilitychange"));
+    expect(getMockWakeLock().request).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      freshRequest.resolve();
+      await Promise.resolve();
+    });
+    expect(readBrowserWakeLockStatus().phase).toBe("active");
+
+    freshView.unmount();
+    await waitFor(() => expect(freshRequest.sentinel.release).toHaveBeenCalledTimes(1));
+    priorView.unmount();
   });
 
   it("releases native power protection on stop, natural end, and unmount", async () => {

--- a/apps/desktop/src/lib/useScreenWakeLock.ts
+++ b/apps/desktop/src/lib/useScreenWakeLock.ts
@@ -23,6 +23,7 @@ const owners = new Set<ScreenWakeLockOwner>();
 let sentinel: WakeLockSentinelLike | null = null;
 let sentinelReleaseHandler: (() => void) | null = null;
 let requestInFlight = false;
+let wakeLockRequestId = 0;
 let ownershipGeneration = 0;
 let visibilitySubscribed = false;
 
@@ -136,6 +137,7 @@ async function acquireWakeLock() {
   }
 
   const generation = ownershipGeneration;
+  const requestId = ++wakeLockRequestId;
   requestInFlight = true;
   publish("acquiring", false);
   try {
@@ -164,14 +166,16 @@ async function acquireWakeLock() {
       publish("failed", false, "Screen Wake Lock could not be enabled.");
     }
   } finally {
-    requestInFlight = false;
-    if (
-      generation !== ownershipGeneration &&
-      owners.size > 0 &&
-      !sentinel &&
-      document.visibilityState === "visible"
-    ) {
-      void acquireWakeLock();
+    if (requestId === wakeLockRequestId) {
+      requestInFlight = false;
+      if (
+        generation !== ownershipGeneration &&
+        owners.size > 0 &&
+        !sentinel &&
+        document.visibilityState === "visible"
+      ) {
+        void acquireWakeLock();
+      }
     }
   }
 }
@@ -204,6 +208,16 @@ function setScreenWakeLockOwner(owner: ScreenWakeLockOwner, active: boolean) {
   } else {
     publish("inactive", false);
   }
+}
+
+export function resetScreenWakeLockForTests() {
+  ownershipGeneration += 1;
+  wakeLockRequestId += 1;
+  owners.clear();
+  requestInFlight = false;
+  clearSentinel();
+  setVisibilitySubscription(false);
+  publish("inactive", false);
 }
 
 export function useScreenWakeLock(owner: ScreenWakeLockOwner, active: boolean) {

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -23,6 +23,7 @@ import type {
 } from "../lib/api";
 import { resetPlaybackE2ETelemetry } from "../lib/playbackE2ETelemetry";
 import { resetPowerInhibitionDiagnostics } from "../lib/powerInhibition";
+import { resetScreenWakeLockForTests } from "../lib/useScreenWakeLock";
 
 const DEFAULT_PROJECTS_LIMIT = 50;
 const DEFAULT_JOBS_LIMIT = 50;
@@ -2977,6 +2978,7 @@ export function getMockWakeLock() {
 export function resetAppTestHarness() {
   resetMockApiState();
   resetPlaybackE2ETelemetry();
+  resetScreenWakeLockForTests();
   resetPowerInhibitionDiagnostics();
   delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
   window.localStorage.clear();


### PR DESCRIPTION
## Summary

- Reset module-level browser Wake Lock ownership between desktop app tests.
- Prevent stale pre-reset acquisitions from clearing fresh request state.
- Add deterministic playback-to-tuner reset interleaving coverage.
- Closes #385

## Testing

- `./node_modules/.bin/vitest run src/App.project-media-controls.test.tsx src/App.tools-tuner.test.tsx`
- `./node_modules/.bin/eslint .`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run`
- `git diff --check`