### PR TITLE
docs: add release roadmap through 2.0

### DIFF
--- a/.agents/skills/coordinate-tuneforge-work/SKILL.md
+++ b/.agents/skills/coordinate-tuneforge-work/SKILL.md
@@ -1,119 +1,142 @@
 ---
 name: coordinate-tuneforge-work
-description: Coordinate bounded TuneForge work without implementing in the coordinator. Use for selecting the next milestone issue from issue-body order, delivering any known TuneForge issue whether or not it has a milestone, or carrying an ad hoc idea, bug, investigation, or change with no GitHub issue through scoped delegation, conditional product/contract/mobile/sync validation, and one bounded remediation cycle; never create or update a GitHub issue unless requested, and stop before commit, push, or PR unless later explicitly authorized.
+description: Coordinate bounded TuneForge implementation without editing in the coordinator. Use for selecting the next issue from a canonical release-plan tracker, delivering a known issue, or carrying an ad hoc change through scoped delegation, single-versus-stacked PR planning, conditional product, contract, mobile, and sync validation, and one bounded remediation cycle; never create or update GitHub planning state unless requested, and require separate publication authority.
 ---
 
 # Coordinate TuneForge Work
 
-Keep this chat coordinator-only. Delegate code changes to workers. Never alter
+Keep this chat coordinator-only and delegate implementation. Never alter
 installed-app data or start, stop, restart, or wipe a user-owned desktop app.
-Do not commit, push, or open a PR unless separately authorized.
+Do not create a branch, commit, push, open a PR, or merge unless the user grants
+the corresponding authority.
 
 ## Select Entry Mode
 
 Classify the request before preflight:
 
-- **Milestone:** Select the next issue from live issue-body ordering and verify
-  prior issue and PR coverage.
-- **Known issue:** Deliver the specified issue whether or not GitHub assigns it
-  to a milestone. Do not substitute a different issue.
-- **Ad hoc:** Turn the request into a local work brief with outcome, current
-  evidence and assumptions, acceptance criteria, and non-goals. Search live
-  issues and PRs only for overlap. Do not require, create, or update a GitHub
-  issue unless the user requests it; lack of an issue does not block otherwise
-  concrete work.
+- **Milestone:** Read the live milestone and its canonical `release-plan`
+  tracker, then select the first open linked issue under `## Ordered work`.
+- **Known issue:** Deliver the specified issue whether or not it has a
+  milestone. Do not substitute a different issue.
+- **Ad hoc:** Build a local brief with outcome, evidence, assumptions,
+  acceptance criteria, and non-goals. Search live issues and PRs for overlap,
+  but do not require or create an issue unless requested.
 
 Identify the work item as an issue number or `ad hoc: <short label>`.
+
+### Read Canonical Milestone Order
+
+1. Fetch the milestone, open issues, and relevant PRs live.
+2. Find the open issue labeled `release-plan` assigned to that milestone.
+3. Require exactly one tracker. If more than one exists, stop for refinement.
+4. Parse issue links under the tracker's `## Ordered work` heading in document
+   order. Select the first linked issue that is still open; do not select the
+   tracker itself.
+5. If no linked issue remains open, report that the milestone is ready for
+   refinement or release handoff. Do not invent work or publish a release.
+
+If a legacy milestone has no `release-plan` tracker, use its explicit issue-body
+ordering and report that the milestone has not adopted the canonical tracker
+format. A tracker always overrides legacy ordering.
 
 ## Preflight
 
 Before confirming a work item or spawning an agent:
 
 1. Read every applicable `AGENTS.md` and scoped instruction file.
-2. Verify the current worktree, its dirt, branch, and relationship to freshly
-   fetched `origin/main`. Do not overwrite user changes. Rebase, merge, or
-   otherwise update only when the request authorizes it and the worktree is safe.
-3. Perform the selected mode's live issue and PR checks. For milestone mode,
-   treat issue-body order as authoritative. For known-issue mode, read the issue
-   body and current state. For ad hoc mode, report material overlap without
-   silently changing the requested outcome.
-4. Classify affected surfaces and risk before delegation: UI, contracts,
-   Android runtime, sync/transport, manual or hardware validation,
-   privacy/security/data-loss, migration/transaction/concurrency, and
-   cross-layer architecture.
-5. State a short work plan and change envelope: owned modules, expected
-   production file count, upper-bound production changed lines, allowed
-   interface changes, non-goals, validation lanes, and worker model/effort.
+2. Verify worktree dirt, branch, and relationship to freshly fetched
+   `origin/main`. Preserve user changes. Update or rebase only with authority
+   and a safe worktree.
+3. Run the selected entry mode's live issue and PR checks.
+4. Classify affected surfaces and risk: UI, contracts, Android runtime,
+   sync/transport, manual or hardware validation, privacy/security/data loss,
+   migration/transaction/concurrency, and cross-layer architecture.
+5. State the plan and change envelope: owned modules, expected production file
+   count, production changed-line upper bound, allowed interfaces, non-goals,
+   validation lanes, delivery shape, and worker model/effort.
 
 Read [validation-lanes.md](references/validation-lanes.md) before selecting
-lanes or reporting validation evidence.
+lanes or reporting evidence.
+
+## Choose One PR or a Stack
+
+Use a normal single PR by default.
+
+Choose a stack only when a large feature or rewrite has all of these traits:
+
+- two to four dependency-ordered layers;
+- each layer is independently reviewable and keeps the repository usable;
+- later layers genuinely depend on earlier layers;
+- separating layers materially improves review.
+
+Order stack layers foundations or contracts first, services and orchestration
+next, and UI or end-to-end integration last. Independent changes are not a
+stack; use one PR or separately deliverable PRs instead. Keep stacks small
+because repository rules and CI apply to every layer.
+
+Before starting stacked implementation, obtain explicit authority for all four
+actions: create or switch branches, create signed commits, push branches, and
+open draft PRs. If any authority is missing, stop after presenting the proposed
+layers and validation plan. Do not create a partial local stack.
+
+Use one implementation worker across dependent stack layers so ownership and
+rebases stay coherent. Use repository branch names and one signed commit per
+branch. Read [stacked-prs.md](references/stacked-prs.md) before creating or
+updating any stack. Never merge automatically.
 
 ## Delegate Deliberately
 
-Select a model and effort explicitly before every spawn. Use one implementation
+Select model and effort explicitly before every spawn. Use one implementation
 worker by default. Use at most two only when responsibilities and files are
-independent; assign each worker clear ownership. Keep coordinator out of edits.
+independent; assign clear ownership. Keep the coordinator out of edits.
 
 - Use `gpt-5.6-terra` at Medium for exploration and read-heavy investigation.
 - Use `gpt-5.6-terra` at High for bounded implementation.
-- Use `gpt-5.6-sol` at High for ambiguity, cross-cutting architecture,
+- Use `gpt-5.6-sol` at High for ambiguity, cross-layer architecture,
   sync/concurrency, transactions, migrations, privacy/security/data-loss risk,
   or ambiguous test failures.
-- Use Product Design on Sol High only for UI or user-facing work: first produce
-  a concise brief, then final UX/product QA. Product Design does not review
-  code correctness, music-theory math, or backend contracts.
-- Use `tuneforge_contract_guard` on Terra High only when a contract boundary may
-  change. Ask only for actual schema, OpenAPI, generated-type, or caller drift.
+- Use Product Design on Sol High only for UI or user-facing work: produce a
+  concise brief before implementation and final UX QA afterward.
+- Use `tuneforge_contract_guard` on Terra High only when a contract boundary
+  may change. Ask only for actual schema, OpenAPI, generated-type, or caller
+  drift.
 
-For UI work, incorporate the brief into the plan and worker prompt: user goals,
-mode boundaries, truthfulness rules, core screens/states, interaction model,
-and UX acceptance criteria. For non-UI work, reference relevant guidance but do
-not block delivery on a design lane.
-
-Give every worker: work outcome and non-goals; owned files/modules; the change
-envelope; current evidence; explicit validation commands; and an instruction to
-stop and report scope expansion instead of silently broadening work.
+For UI work, put user goals, mode boundaries, truthfulness rules, screens,
+states, interaction model, and UX acceptance criteria in the worker prompt.
+Give every worker the outcome, non-goals, owned files, change envelope, current
+evidence, validation commands, delivery layer, and an instruction to stop on
+scope expansion.
 
 ## Control Growth
 
 Treat production source as the tripwire. Exclude tests, generated files, and
-lockfiles from the estimate. Stop implementation and re-plan before more edits
-when either condition occurs:
+lockfiles from the estimate. Stop and re-plan when either condition occurs:
 
-- A change reaches an unplanned module or interface surface.
-- Production file count exceeds twice the declared count.
-- Production changed lines exceed twice the declared upper bound.
+- work reaches an unplanned module or interface;
+- production file count or changed lines exceed twice the declared envelope.
 
-Do not convert validation findings into broad cleanup, refactors, speculative
-hardening, or adjacent feature work.
+Do not turn findings into broad cleanup, speculative hardening, or adjacent
+feature work.
 
 ## Validate and Review
 
-Run only applicable validation lanes. Report commands, results, and exact proof
-boundaries. Never represent a local validator, emulator result, or mocked path
-as proof of live transport, external-device behavior, or user-visible release
-behavior.
+Run only applicable validation lanes. Report command, result, proof boundary,
+and unverified behavior. Never present a local validator, emulator, or mock as
+proof of live transport, external-device behavior, or release behavior.
 
 Use one initial correctness review. Add contract and Product Design reviews only
-when their lanes apply. Reviewer routing:
+when their lanes apply. Route normal reviews to Sol High, declared high risk to
+Sol XHigh, and a focused unresolved critical dispute only to Sol Max.
 
-- Sol High normally.
-- Sol XHigh only for declared high risk.
-- Sol Max only for focused adjudication of an unresolved critical finding.
-
-Require actionable findings: correctness, regression, security, data loss,
-contract drift, or missing necessary tests. Exclude style-only findings and
-speculative hardening from remediation.
-
-If a valid finding remains, send it to the original implementation worker for
-one remediation pass. Then run one focused re-review of changed areas. If a
-critical finding remains disputed or unresolved, request one read-only Sol Max
-adjudication; make no further automatic edits. Stop and present the evidence,
-decision, and any required user choice.
+Require actionable correctness, regression, security, data-loss, contract, or
+necessary-test findings. Send valid findings to the original worker for one
+remediation pass, then run one focused re-review of changed areas. For a stack,
+amend the owning layer and cascade the update through every dependent layer.
+Stop if a critical finding remains unresolved.
 
 ## Finish
 
-Summarize the issue number or ad hoc label, change envelope, agents and lanes
-used, validation results, unverified boundaries, remaining risks, and worktree
-status. Stop before commit, push, or PR unless a later user request explicitly
-authorizes it.
+Summarize the issue or ad hoc label, delivery shape, change envelope, agents and
+lanes used, validation results, unverified boundaries, remaining risks, and
+worktree or stack status. Stop at the exact publication boundary authorized by
+the user. Never merge automatically.

--- a/.agents/skills/coordinate-tuneforge-work/agents/openai.yaml
+++ b/.agents/skills/coordinate-tuneforge-work/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Coordinate TuneForge Work"
-  short_description: "Run bounded TuneForge issues and ad hoc work"
-  default_prompt: "Use $coordinate-tuneforge-work to deliver a bounded TuneForge issue or ad hoc change locally."
+  short_description: "Coordinate TuneForge work and reviewable PR stacks"
+  default_prompt: "Use $coordinate-tuneforge-work to select and deliver bounded TuneForge work with the appropriate single or stacked PR shape."

--- a/.agents/skills/coordinate-tuneforge-work/references/stacked-prs.md
+++ b/.agents/skills/coordinate-tuneforge-work/references/stacked-prs.md
@@ -1,0 +1,84 @@
+# Stacked Pull Requests
+
+Use this reference only after the coordinator selects a two-to-four-layer stack
+and the user authorizes branches, signed commits, pushes, and draft PRs.
+
+GitHub stacked pull requests remain a public-preview feature. Require GitHub CLI
+2.90 or newer, install the official `github/gh-stack` extension only with user
+authority, and inspect live help before every stack operation:
+
+```sh
+gh --version
+gh extension list
+gh stack --help
+gh stack link --help
+gh stack rebase --help
+gh stack push --help
+```
+
+References:
+
+- [Public-preview announcement](https://github.blog/changelog/2026-07-30-stacked-pull-requests-are-now-in-public-preview/)
+- [Quickstart](https://docs.github.com/en/pull-requests/get-started/stacked-prs-quickstart)
+- [Stack behavior and repository rules](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs)
+- [CI behavior](https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/optimizing-ci-for-stacked-pull-requests)
+
+## Design the Stack
+
+Keep two to four independently reviewable layers. Prefer this order:
+
+1. foundations, migrations, or generated contracts;
+2. services, persistence, and orchestration;
+3. UI and platform integration;
+4. end-to-end wiring only when it is a distinct reviewable layer.
+
+Every layer must keep the repository usable and have its own proportional tests.
+Do not stack unrelated or merely parallel changes. Every PR receives applicable
+base-branch rules and CI, so extra layers multiply review and runner cost.
+
+Record for each layer: branch name, parent branch, owned files, interface change,
+acceptance criteria, validation commands, and issue reference. Use repository
+`type/brief-description` branch names and one signed commit per branch.
+
+## Publish with Controlled PR Bodies
+
+Create the dependency chain locally and register it with `gh stack`. Push the
+tracked branches with `gh stack push`. Create every draft PR separately with a
+Markdown body file so repository PR-body policy remains intact:
+
+```sh
+gh pr create --draft --base <parent> --head <layer> --title <title> --body-file <body.md>
+```
+
+The bottom PR targets `main`; each later PR targets the preceding branch. Every
+body keeps concise `## Summary` and `## Testing` sections and references only the
+issue actually addressed by that layer.
+
+After all draft PRs exist, link their PR numbers or URLs in bottom-to-top order:
+
+```sh
+gh stack link <bottom-pr-url> <middle-pr-url> <top-pr-url>
+```
+
+Pass existing PR URLs or numbers so `gh stack link` does not create PRs. Do not
+use `gh stack submit`: its generated or interactive bodies bypass the required
+per-layer `--body-file` workflow.
+
+## Amend and Cascade Review Fixes
+
+Apply a review fix on the branch that owns the affected layer and amend that
+branch's single signed commit. Then cascade it through dependent layers and
+push the stack:
+
+```sh
+gh stack rebase --upstack
+gh stack push
+```
+
+Re-run the owning layer's gates and every affected upper-layer integration gate.
+Verify that each rebased branch still contains exactly one signed layer commit.
+Use the original implementation worker for the single remediation pass and run
+one focused re-review of changed areas.
+
+Never merge automatically. `gh stack merge` requires a new explicit user
+instruction after review and required checks are complete.

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -84,11 +84,24 @@ Mobile does not bundle FFmpeg. Android uses platform media APIs instead.
 - Import keeps the original file inside app storage.
 - WAV/PCM can be read directly for CPU analysis and basic chord detection.
 - Compressed audio should decode through Android media APIs before waveform or ML processing.
-- Mobile internal generated audio should prefer `m4a`/AAC first.
+- Durable app-owned audio is planned to follow the shared WAV/FLAC storage preference; Android
+  platform codecs remain runtime and export capabilities rather than a separate canonical format.
 - Desktop currently keeps WAV intermediates and `wav`/`mp3`/`flac` exports through host-installed FFmpeg.
 - Unsupported mobile export formats stay unavailable until a native encoder path exists.
 
-Future desktop refinement: consider matching the mobile storage model by keeping the original import as the canonical source and creating normalized PCM/WAV files only as disposable derived cache. Analysis, chords, and feature data should stay cached separately so repeated desktop workflows do not require persistent full-size WAV copies.
+The planned durable-storage direction does not preserve the desktop original import as a separate
+canonical file. WAV remains the default, with FLAC as an optional preference for each new durable
+source, stem, saved mix, or other durable audio artifact. The preference is captured when an action
+or job starts; later changes affect future artifacts only. Existing files stay unchanged, so mixed
+WAV/FLAC libraries and mixed-format projects must remain readable. A later explicit background job
+may transcode existing durable files without rerunning analysis, stems, lyrics, chords, beats, or
+other model pipelines.
+
+Sync preserves the format received from the sender instead of applying the receiving peer's local
+preference. The planned WAV/FLAC work must widen current backend and Android source validation to
+accept matching media formats and suffixes in both directions. It assumes all peers run the latest
+TuneForge and does not add version negotiation, compatibility transcoding, or a sync protocol
+redesign.
 
 ## Desktop vs Mobile Persistence Parity
 
@@ -234,10 +247,12 @@ Also record whether Android reports sync transport support. If `sync_transport_s
 `false`, the APK is still using the Android stub and cannot satisfy real transport validation; only
 pairing/storage/playback checks can proceed.
 
-For accepted mobile sync evidence, sync at least one desktop project to Android, play the synced WAV
-source and synced WAV stem artifacts from app-local storage, and compare battery, CPU, storage, and
-transfer costs against AAC/M4A or another compressed baseline. Mobile sync remains library sync
-only; remote processing stays out of scope.
+For accepted mobile sync evidence today, sync at least one desktop project to Android, play the
+synced WAV source and synced WAV stem artifacts from app-local storage, and compare battery, CPU,
+storage, and transfer costs against AAC/M4A or another compressed baseline. After WAV/FLAC storage
+support lands, add desktop-to-Android and Android-to-desktop mixed-format cases that prove matching
+format, suffix, size, and content hash are preserved. Mobile sync remains library sync only; remote
+processing stays out of scope.
 
 For Android-to-desktop validation, import or change durable library data on Android, sync it to a
 desktop peer, and record redacted project import cadence, TTFA, transfer counts, selected transport,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,87 +2,132 @@
 
 ## Purpose
 
-This roadmap describes current product direction. It does not repeat completed foundation work as future work. Completed capabilities include local desktop project import, analysis, chords, lyrics, stems, retune/transpose previews, exports, playback practice views, generated shared contracts, and CI gates.
+This roadmap records TuneForge's undated release train from v1.0.1 through
+v2.0.0. GitHub milestones define release scope, and each milestone has one
+`release-plan` tracker whose `## Ordered work` section is the canonical work
+order. The first open linked issue is next. When no linked issue remains open,
+the milestone is ready for refinement or release handoff; that state does not
+publish a release or create a tag.
 
-Roadmap items are grouped by track so related work can move independently.
+Release issues describe intended product work. Research issues collect evidence
+before TuneForge commits to implementation. Research may conclude that a path is
+not viable, and completing a research issue never promises a shipped feature.
 
-## Core / Desktop
+## Release Train
 
-- Keep the desktop app as the most complete supported workflow.
-- Improve project portability so a project can be backed up, moved, or handed off more predictably.
-- Keep generated audio, chord, lyrics, analysis, and job state tied to explicit project artifacts.
-- Preserve user edits when regeneration jobs rerun, with explicit overwrite confirmation for destructive refreshes.
-- Continue refining settings for default chord backend, playback display, follow behavior, and source-key overrides.
+| Milestone | Direction | Canonical tracker |
+| --- | --- | --- |
+| [v1.0.1 — Mobile and E2E hardening](https://github.com/grazzolini/tuneforge/milestone/13) | Consolidate completed mobile, E2E, test-performance, and Android packaging work. | [#391](https://github.com/grazzolini/tuneforge/issues/391) |
+| [v1.1.0 — Export workflows](https://github.com/grazzolini/tuneforge/milestone/14) | Make audio and stem export selective, explicit, and platform-truthful. | [#392](https://github.com/grazzolini/tuneforge/issues/392) |
+| [v1.2.0 — Storage format choice](https://github.com/grazzolini/tuneforge/milestone/15) | Choose WAV or FLAC for newly created durable audio. | [#393](https://github.com/grazzolini/tuneforge/issues/393) |
+| [v1.3.0 — Footprint and engine defaults](https://github.com/grazzolini/tuneforge/milestone/16) | Convert existing audio on demand and reduce the default chord-engine footprint. | [#394](https://github.com/grazzolini/tuneforge/issues/394) |
+| [v1.4.0 — Mobile runtime experiments](https://github.com/grazzolini/tuneforge/milestone/17) | Measure iOS simulator and Android model feasibility without shipment promises. | [#395](https://github.com/grazzolini/tuneforge/issues/395) |
+| [v2.0.0 — Android-first 2.0](https://github.com/grazzolini/tuneforge/milestone/18) | Deliver the complete Android-first workflow and truthful capability states. | [#396](https://github.com/grazzolini/tuneforge/issues/396) |
 
-## Audio Analysis
+Milestones are intentionally undated. Scope and order may be refined through
+their trackers as implementation evidence changes.
 
-- Add an offline beat-tracking and tempo-map artifact.
-- Store beat timestamps, bar numbers, beat numbers, and confidence as JSON.
-- Add first downbeat detection to improve chord, lyric, loop, and count-in synchronization.
-- Use timing artifacts as shared project data rather than recalculating timing independently in each UI feature.
-- Add a smart metronome that follows the tempo/bar map without rendering new audio.
-- Consider an optional click-track audio artifact after the metronome and beat-map behavior are useful.
+## v1.0.1 — Mobile and E2E Hardening
 
-## Playback & Practice UX
+v1.0.1 gathers work merged since v1.0.0: mobile storage, playback and sync;
+native Android audio, tuner and wake handling; E2E coverage; test performance;
+and Android packaging. The closed
+[E2E and Test Performance](https://github.com/grazzolini/tuneforge/milestone/11)
+and [Mobile First-Class App](https://github.com/grazzolini/tuneforge/milestone/12)
+milestones remain the historical record. Their issues are not reassigned.
 
-- Add current bar and beat highlighting during playback.
-- Add count-in support based on the beat/bar map.
-- Add loop-by-bars so practice loops can snap to musical boundaries.
-- Add section practice built on top of saved bar ranges or detected sections.
-- Keep source-track analysis independent from practice mixes so stems or saved mixes do not accidentally change project-level analysis.
-- Continue improving playback persistence and sync across source audio, stems, lyrics, and chords.
+The milestone stays open until release refinement and preparation are requested.
+No tag or release is implied by completing its tracker.
 
-## Chords & Harmony
+## v1.1.0 — Export Workflows
 
-- Add a bar-based chord view similar to a lead sheet or Chordify-style practice grid.
-- Align chord rendering with beat/bar data once the tempo-map artifact exists.
-- Improve chord refresh UX around existing user edits and source-vs-stem analysis differences.
-- Add tab import as a correction aid for lyrics and chords where users have a trusted local tab source.
-- Keep capo-relative chord display as a presentation layer only. Audio pitch, tuning, and speed should remain unchanged.
-- Keep Advanced Chords as the desktop default while improving fallback quality for unsupported, mobile, or explicitly excluded dependency profiles.
+The export foundation in [#397](https://github.com/grazzolini/tuneforge/issues/397)
+precedes the contributor request in
+[#388](https://github.com/grazzolini/tuneforge/issues/388). The intended workflow
+selects one, several, or all stems and other exportable audio artifacts; targets
+a file, folder, or ZIP as appropriate; and supports WAV, FLAC, MP3, and M4A/AAC.
 
-## Lyrics
+Desktop and Android must expose their real encoder and destination capabilities.
+An unavailable combination is disabled or explained, never presented as a
+working action. TuneForge remains local-only and continues to rely on
+host-installed FFmpeg on desktop rather than bundling it.
 
-- Keep desktop lyrics generation and editing as supported local functionality.
-- Improve editable lyrics timeline behavior for segment timing, text correction, and playback follow.
-- Add Android lyrics MVP using local Whisper or an equivalent local runtime behind the mobile capability model.
-- Support tab import for lyrics correction and chord/lyric alignment where useful.
-- Research local forced-alignment second passes, such as WhisperX- or Gentle-style alignment, after lyrics generation or accepted lyric/tab edits to refine word and phrase timing.
-- Keep generated lyrics positioned as editable draft output, not guaranteed transcription truth.
+Lyrics and chord text export in
+[#387](https://github.com/grazzolini/tuneforge/issues/387) is a non-gating
+pre-2.0 candidate and remains unmilestoned.
 
-## Mobile
+## v1.2.0 — Storage Format Choice
 
-- Move mobile from experimental toward a supported Android-first companion workflow.
-- Keep mobile local-first: no account, no cloud backend, no telemetry, no remote processing requirement.
-- Maintain a capability model with:
-  - local processing for analysis, chords, and lyrics where device support exists
-  - desktop-backed processing for stems and other heavy ML work
-  - clear disabled states when local acceleration is unavailable
-- Keep the embedded project/job/artifact model aligned with the desktop project model.
-- Treat mobile stems as a later experimental milestone after native media, storage, and acceleration paths are reliable.
-- Explore optional desktop/mobile pair for sending heavier jobs.
-- Explore optional LAN (no cloud) desktop/mobile sync where imported tracks on either device show and play on both.
+[#398](https://github.com/grazzolini/tuneforge/issues/398) adds a `wav | flac`
+preference for new durable audio, with WAV as the default. The value is captured
+when an import, generation job, or save action starts and applies to new sources,
+stems, saved mixes, and other durable audio created by that action.
 
-## Packaging & Distribution
+Changing the preference affects future artifacts only. Existing files stay
+unchanged, and mixed WAV/FLAC libraries and projects remain valid. TuneForge does
+not retain the original import as a separate canonical file under this plan.
 
-- Keep macOS app/DMG packaging available for local unsigned builds.
-- Keep Linux Flatpak packaging available for local unsigned builds and local repository installs.
-- Treat source distribution as the repository checkout or version-control source archive unless a dedicated source artifact is added.
-- Create package recipes for Arch Linux's pacman (`PKGBUILD`), rpm, and deb.
-- Document host-installed FFmpeg and FFprobe requirements clearly.
-- Avoid bundling FFmpeg for licensing and distribution reasons.
-- Keep the Linux legacy NVIDIA profile documented for older `x86_64` CUDA-capable GPUs that need the opt-in PyTorch override.
-- Keep Android packaging optional/manual while mobile remains in transition.
-- Keep packaged desktop dependency notices current now that crema/TensorFlow and beat-this are default desktop dependency scope.
-- Keep release/package changes backed by fresh dependency/license inventory evidence, explicit model-weight download/cache policy, and verification that model weights, caches, and package build artifacts are not tracked.
+Sync preserves each received artifact's format regardless of the receiving
+peer's preference. Backend and Android source validation must accept matching
+WAV/FLAC media formats and suffixes. All peers are assumed to run the latest
+TuneForge; version negotiation, compatibility transcoding, and protocol redesign
+are out of scope. Any HTTP schema change must regenerate the committed OpenAPI
+TypeScript contract.
 
-## Testing & Quality
+## v1.3.0 — Footprint and Engine Defaults
 
-- Keep backend gates: Ruff, mypy, and pytest.
-- Keep desktop gates: lint, typecheck, and Vitest.
-- Keep OpenAPI contract drift checks in CI.
-- Keep release copy honest about manual/special checks for packaging, crema/TensorFlow, beat-this, GPU profiles, loopback browser E2E, BlackHole capture, and virtual-output capture.
-- Keep release guidance explicit about what ships, what downloads or caches after use, and which host tools must be installed locally.
-- Add focused tests when new timing artifacts, practice loops, mobile capability gates, or destructive-regeneration flows are introduced.
-- Prefer deterministic timing tests over wall-clock-dependent assertions.
-- Keep generated or ignored mobile build artifacts out of commits unless they are intentionally tracked.
+[#399](https://github.com/grazzolini/tuneforge/issues/399) adds an explicit
+background job to transcode existing durable audio to the current WAV/FLAC
+preference. It reuses progress and cancellation patterns, verifies each new
+file, and atomically updates the artifact path, format, size, and content hash.
+It does not rerun analysis, stems, lyrics, chords, beats, or other models.
+
+[#400](https://github.com/grazzolini/tuneforge/issues/400) improves the
+lightweight chord engine and makes it the default. CREMA remains supported as an
+optional engine, while TensorFlow leaves the default package scope. Chord
+quality, runtime, memory, and package-size evidence are part of completion.
+
+## v1.4.0 — Mobile Runtime Experiments
+
+This milestone contains evidence work rather than release promises:
+
+1. [#401 — iOS simulator build and core runtime feasibility](https://github.com/grazzolini/tuneforge/issues/401)
+2. [#402 — Whisper, Demucs, and beat-this Android benchmarks](https://github.com/grazzolini/tuneforge/issues/402)
+3. [#403 — Drum sub-stem quality and mobile viability](https://github.com/grazzolini/tuneforge/issues/403)
+
+The iOS work is simulator-only and must not imply physical-device support.
+Android benchmarks record model size, runtime, memory, output quality, runtime
+dependencies, and capability recommendations. The drum spike references the
+feature request in [#389](https://github.com/grazzolini/tuneforge/issues/389) and
+evaluates candidates including
+[MIT DrumSep](https://github.com/inagoy/drumsep) and its registered
+[demucs-infer](https://github.com/openmirlab/demucs-infer) path. #389 remains
+unmilestoned until evidence justifies implementation.
+
+## v2.0.0 — Android-First 2.0
+
+Android is the primary mobile target. The 2.0 gate is a functional Android flow
+for import, library, playback, editing, sync, export, WAV/FLAC storage, and
+truthful model capability states.
+
+Heavy on-device models ship only when v1.4 evidence justifies them. A negative
+Whisper, Demucs, beat-this, or drum-separation result does not block 2.0. iOS
+remains simulator-only experimental work.
+
+Play Store, App Store, notarization, and distribution signing are not release
+gates. Attaching an APK to a GitHub release may be useful, but remains optional.
+
+## Continuing Product Boundaries
+
+- Keep TuneForge local-only: no account, cloud backend, telemetry, or remote
+  processing requirement.
+- Keep desktop as the most complete workflow while Android reaches functional
+  parity for the 2.0 gate.
+- Keep generated audio, analysis, chord, lyric, and job state tied to explicit
+  project artifacts.
+- Preserve user edits when regeneration jobs run, with explicit confirmation
+  for destructive refreshes.
+- Keep backend, desktop, contract, packaging, and privacy validation proportional
+  to the surfaces changed by each issue.
+- Keep release copy explicit about what ships, what remains experimental, which
+  models download or cache after use, and which host tools are required.


### PR DESCRIPTION
## Summary

- document the undated v1.0.1 through v2.0.0 release train and canonical tracker order
- align mobile storage planning around prospective WAV/FLAC artifacts and mixed-format sync
- update TuneForge coordination guidance for release trackers and bounded stacked pull requests

## Testing

- `git diff --cached --check`
- Skill Creator `quick_validate.py` for `.agents/skills/coordinate-tuneforge-work`
- read-only forward tests for one stacked cross-layer feature and one single-PR UI fix
- pnpm and backend gates not run because changes only affect documentation and agent instructions
