### PR TITLE
docs: expand TuneForge coordinator workflows

### DIFF
--- a/.agents/skills/coordinate-tuneforge-work/SKILL.md
+++ b/.agents/skills/coordinate-tuneforge-work/SKILL.md
@@ -1,16 +1,19 @@
 ---
 name: coordinate-tuneforge-work
-description: Coordinate bounded TuneForge implementation without editing in the coordinator. Use for selecting the next issue from a canonical release-plan tracker, delivering a known issue, or carrying an ad hoc change through scoped delegation, single-versus-stacked PR planning, conditional product, contract, mobile, and sync validation, and one bounded remediation cycle; never create or update GitHub planning state unless requested, and require separate publication authority.
+description: Coordinate bounded TuneForge implementation or evidence-based research without editing in the coordinator. Use for selecting the next issue from a canonical release-plan tracker, delivering a known issue, or carrying an ad hoc change or research question through scoped delegation, proportionate validation and review, single-versus-stacked PR planning when code changes are authorized, and one bounded remediation cycle; never create or update GitHub planning state unless requested, and require separate publication authority.
 ---
 
 # Coordinate TuneForge Work
 
-Keep this chat coordinator-only and delegate implementation. Never alter
+Keep this chat coordinator-only and delegate work. Never alter
 installed-app data or start, stop, restart, or wipe a user-owned desktop app.
 Do not create a branch, commit, push, open a PR, or merge unless the user grants
 the corresponding authority.
 
-## Select Entry Mode
+Read [prompt-examples.md](references/prompt-examples.md) when the user asks for
+a copyable invocation or a Plan-to-Goal workflow.
+
+## Select Entry Mode and Work Kind
 
 Classify the request before preflight:
 
@@ -23,6 +26,13 @@ Classify the request before preflight:
   but do not require or create an issue unless requested.
 
 Identify the work item as an issue number or `ad hoc: <short label>`.
+
+After selecting it, classify **implementation** or **research**. Implementation
+delivers or retains product code. Research produces evidence and a
+recommendation; its product-code envelope is zero. Research may use only an
+explicitly authorized bounded, disposable spike or report artifact; never
+retain or publish spike output as product code. If it should remain product
+code, reclassify as implementation and re-plan before editing.
 
 ### Read Canonical Milestone Order
 
@@ -51,14 +61,32 @@ Before confirming a work item or spawning an agent:
 4. Classify affected surfaces and risk: UI, contracts, Android runtime,
    sync/transport, manual or hardware validation, privacy/security/data loss,
    migration/transaction/concurrency, and cross-layer architecture.
-5. State the plan and change envelope: owned modules, expected production file
-   count, production changed-line upper bound, allowed interfaces, non-goals,
-   validation lanes, delivery shape, and worker model/effort.
+5. State either an implementation envelope (owned modules, production file and
+   line bounds, allowed interfaces, non-goals, lanes, delivery shape) or a
+   research evidence envelope (question, sources or datasets, non-goals,
+   lanes, report target), plus worker model and effort.
+
+Skill preflight is independent of Codex mode. In Plan mode, stop after
+preflight and plan. In Goal mode, bind work to exactly one selected item and
+the authorized publication boundary; never auto-advance a release-plan item or
+create or expand a goal implicitly.
 
 Read [validation-lanes.md](references/validation-lanes.md) before selecting
 lanes or reporting evidence.
 
+## Research Workflow
+
+For research, define question, method and evidence matrix, fixtures or
+datasets, legal/licensing constraints, environment or hardware baseline,
+timebox, report target, and recommendation criteria before delegation. A
+negative or defer conclusion completes the work when evidence supports it.
+Do not require a PR or stack when no repository change is authorized. GitHub
+publication or issue closure still requires explicit authority.
+
 ## Choose One PR or a Stack
+
+Apply this section when work includes repository changes; publication authority
+still governs branches, commits, pushes, and PRs.
 
 Use a normal single PR by default.
 
@@ -87,8 +115,9 @@ updating any stack. Never merge automatically.
 ## Delegate Deliberately
 
 Select model and effort explicitly before every spawn. Use one implementation
-worker by default. Use at most two only when responsibilities and files are
-independent; assign clear ownership. Keep the coordinator out of edits.
+or research worker by default. Use at most two only when responsibilities and
+files or evidence streams are independent; assign clear ownership. Keep the
+coordinator out of edits.
 
 - Use `gpt-5.6-terra` at Medium for exploration and read-heavy investigation.
 - Use `gpt-5.6-terra` at High for bounded implementation.
@@ -103,14 +132,17 @@ independent; assign clear ownership. Keep the coordinator out of edits.
 
 For UI work, put user goals, mode boundaries, truthfulness rules, screens,
 states, interaction model, and UX acceptance criteria in the worker prompt.
-Give every worker the outcome, non-goals, owned files, change envelope, current
-evidence, validation commands, delivery layer, and an instruction to stop on
-scope expansion.
+Give every worker the outcome, non-goals, owned files or evidence sources,
+change envelope, current evidence, validation commands or method, delivery
+target, and an instruction to stop on scope expansion. For research, include
+the question, evidence matrix, reproducibility baseline, licensing limits,
+timebox, and recommendation criteria.
 
 ## Control Growth
 
-Treat production source as the tripwire. Exclude tests, generated files, and
-lockfiles from the estimate. Stop and re-plan when either condition occurs:
+For implementation, treat production source as the tripwire. Exclude tests,
+generated files, and lockfiles from the estimate. Stop and re-plan when either
+condition occurs:
 
 - work reaches an unplanned module or interface;
 - production file count or changed lines exceed twice the declared envelope.
@@ -118,25 +150,34 @@ lockfiles from the estimate. Stop and re-plan when either condition occurs:
 Do not turn findings into broad cleanup, speculative hardening, or adjacent
 feature work.
 
+For research, stop and re-plan before any product-code change. Keep an
+authorized spike bounded and disposable; reclassify and re-plan before editing
+anything intended to remain as product code.
+
 ## Validate and Review
 
 Run only applicable validation lanes. Report command, result, proof boundary,
 and unverified behavior. Never present a local validator, emulator, or mock as
 proof of live transport, external-device behavior, or release behavior.
 
-Use one initial correctness review. Add contract and Product Design reviews only
-when their lanes apply. Route normal reviews to Sol High, declared high risk to
-Sol XHigh, and a focused unresolved critical dispute only to Sol Max.
+Use one initial correctness review for implementation, or one evidence review
+for research covering methodology, reproducibility, unsupported generalization,
+licensing, and evidence-to-conclusion fit. Add contract and Product Design
+reviews only when their lanes apply. Route normal reviews to Sol High, declared
+high risk to Sol XHigh, and a focused unresolved critical dispute only to Sol
+Max.
 
-Require actionable correctness, regression, security, data-loss, contract, or
-necessary-test findings. Send valid findings to the original worker for one
-remediation pass, then run one focused re-review of changed areas. For a stack,
-amend the owning layer and cascade the update through every dependent layer.
-Stop if a critical finding remains unresolved.
+Require actionable correctness, evidence-quality, regression, security,
+data-loss, contract, or necessary-test findings. Send valid findings to the
+original worker for one remediation pass, then run one focused re-review of
+changed areas or evidence. For a stack, amend the owning layer and cascade the
+update through every dependent layer. Stop if a critical finding remains
+unresolved.
 
 ## Finish
 
-Summarize the issue or ad hoc label, delivery shape, change envelope, agents and
-lanes used, validation results, unverified boundaries, remaining risks, and
-worktree or stack status. Stop at the exact publication boundary authorized by
-the user. Never merge automatically.
+Summarize the issue or ad hoc label, work kind, delivery or report target,
+change envelope, agents and lanes used, validation or evidence results,
+unverified boundaries, remaining risks, and worktree or stack status when
+applicable. Stop at the exact publication boundary authorized by the user.
+Never merge automatically.

--- a/.agents/skills/coordinate-tuneforge-work/agents/openai.yaml
+++ b/.agents/skills/coordinate-tuneforge-work/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Coordinate TuneForge Work"
-  short_description: "Coordinate TuneForge work and reviewable PR stacks"
-  default_prompt: "Use $coordinate-tuneforge-work to select and deliver bounded TuneForge work with the appropriate single or stacked PR shape."
+  short_description: "Coordinate TuneForge delivery or evidence research"
+  default_prompt: "Use $coordinate-tuneforge-work to select and coordinate bounded TuneForge implementation or evidence-based research, with publication only when authorized."

--- a/.agents/skills/coordinate-tuneforge-work/references/prompt-examples.md
+++ b/.agents/skills/coordinate-tuneforge-work/references/prompt-examples.md
@@ -1,0 +1,92 @@
+# TuneForge Coordinator Prompt Examples
+
+Replace `#NNN` or the milestone name before sending. Select Plan mode first when
+the preflight and execution plan should pause for approval.
+
+## Full Issue Delivery
+
+```text
+Use $coordinate-tuneforge-work for #NNN.
+
+Carry the issue through bounded implementation, applicable validation, review,
+and publication. Decide whether this should use one normal PR or a small stacked
+PR series using the skill's delivery-shape criteria.
+
+I authorize branch creation and switching, signed commits, pushes, and draft
+PR creation for whichever shape you select. Do not merge.
+```
+
+## Milestone Delivery
+
+```text
+Use $coordinate-tuneforge-work.
+
+Continue the <milestone name> milestone. Select the first open issue from the
+canonical release-plan tracker.
+
+Carry it through bounded implementation, applicable validation, review, and
+publication. Decide whether the work needs one normal PR or a small stacked PR
+series.
+
+I authorize branch creation and switching, signed commits, pushes, and draft
+PR creation for whichever shape you select. Do not merge.
+```
+
+## Local-Only Implementation
+
+```text
+Use $coordinate-tuneforge-work for #NNN.
+
+Implement and validate the issue locally. Decide the appropriate delivery shape.
+
+If one normal PR is appropriate, complete local implementation and stop before
+branch creation, commit, push, or PR.
+
+If a stack is required, stop after presenting the layer plan because publication
+authority is not granted.
+```
+
+## Short Full Delivery
+
+```text
+Use $coordinate-tuneforge-work for #NNN.
+
+Decide normal versus stacked delivery. Implement, validate, review, and publish.
+I authorize branches, signed commits, pushes, and draft PRs. Do not merge.
+```
+
+## Plan Only
+
+```text
+Use $coordinate-tuneforge-work for #NNN.
+
+Prepare the preflight, delivery shape, worker ownership, validation lanes, and
+review plan. Stop before implementation or publication.
+```
+
+## Evidence-Based Research
+
+```text
+Use $coordinate-tuneforge-work for #NNN.
+
+Treat this as evidence-based research. Define the question, method, evidence
+matrix, fixtures or datasets, licensing constraints, baseline, timebox, report
+target, and recommendation criteria. Produce evidence and a recommendation.
+
+Do not retain product code or publish GitHub state unless I separately authorize
+it. A supported negative or defer recommendation is acceptable.
+```
+
+## Plan First, Then Start a Goal
+
+Enter Plan mode and send the full-delivery or milestone prompt above. Review and
+refine the resulting plan. Instead of choosing **Implement plan**, choose
+**Tell Codex to do something different** and enter:
+
+```text
+/goal Use $coordinate-tuneforge-work to deliver #NNN according to the approved plan. Carry it through bounded implementation, applicable validation, review, and authorized draft PR publication. Do not merge or advance to another release-plan item.
+```
+
+The goal command starts execution; do not choose **Implement plan** afterward.
+The same task retains the approved plan and the publication authority from the
+original delivery prompt.

--- a/.agents/skills/coordinate-tuneforge-work/references/validation-lanes.md
+++ b/.agents/skills/coordinate-tuneforge-work/references/validation-lanes.md
@@ -35,6 +35,16 @@ local state validation separately from proven live transport. A successful
 validator, mocked transport, pairing UI, or emulator-only flow does not prove
 cross-device delivery, import, persistence on a peer, or release behavior.
 
+## Research and Benchmark Evidence
+
+Define question, method, datasets or fixtures, environment or hardware
+baseline, licensing constraints, timebox, and recommendation criteria. Preserve
+only sanitized measurements and reproducible command templates; exclude
+secrets, private paths, raw IDs, endpoints, and pairing payloads, following
+surface-specific privacy and data rules. Report benchmark comparability limits;
+do not generalize beyond evidence or treat a local spike as production proof. A
+supported negative or defer recommendation is valid.
+
 ## Manual or Hardware Steps
 
 Pause before actions requiring user-owned devices, credentials, pairing,


### PR DESCRIPTION
## Summary

- expand the TuneForge coordinator to handle implementation and evidence-based research
- clarify Plan-to-Goal execution while preserving single-item and publication boundaries
- add reusable prompts for issue, milestone, local-only, research, and Goal-backed work
- require sanitized, reproducible research and benchmark evidence

## Testing

- `git diff --check`
- Skill Creator validator passed for `.agents/skills/coordinate-tuneforge-work`
- Product lint, typecheck, and tests were not run because only agent-skill Markdown and YAML changed
- Product commands, if desired: `pnpm lint`, `pnpm typecheck`, and `pnpm test`
