### PR TITLE
fix(android): keep screen awake during sync transfers

### DIFF
--- a/scripts/android-prepare-generated.sh
+++ b/scripts/android-prepare-generated.sh
@@ -521,7 +521,7 @@ class PowerInhibitionService : Service() {
     const val REASON_SYNC_LISTENER = 2
     const val REASON_SYNC_TRANSFER = 4
     const val REASON_TUNER_CAPTURE = 8
-    const val SCREEN_REASON_MASK = REASON_PLAYBACK or REASON_TUNER_CAPTURE
+    const val SCREEN_REASON_MASK = REASON_PLAYBACK or REASON_SYNC_TRANSFER or REASON_TUNER_CAPTURE
     const val SERVICE_REASON_MASK = REASON_PLAYBACK or REASON_SYNC_LISTENER or REASON_SYNC_TRANSFER
     private const val PARTIAL_WAKE_REASON_MASK = REASON_SYNC_LISTENER or REASON_SYNC_TRANSFER
     private const val CHANNEL_ID = "tuneforge_active_work"
@@ -680,7 +680,7 @@ verify_power_notification_wiring() {
     'buildTruthfulForegroundNotification()'
     'ERROR_NOTIFICATION_POST_FAILED'
     'const val REASON_TUNER_CAPTURE = 8'
-    'const val SCREEN_REASON_MASK = REASON_PLAYBACK or REASON_TUNER_CAPTURE'
+    'const val SCREEN_REASON_MASK = REASON_PLAYBACK or REASON_SYNC_TRANSFER or REASON_TUNER_CAPTURE'
     'const val SERVICE_REASON_MASK = REASON_PLAYBACK or REASON_SYNC_LISTENER or REASON_SYNC_TRANSFER'
     'val activeMask = if (serviceMatches) (confirmedServiceMask or screenOnlyMask) else 0'
     'notificationPermissionDenied && desiredServiceMask != 0'


### PR DESCRIPTION
## Summary

- keep Android screens awake while a sync transfer owns the power-inhibition lease
- leave passive sync listeners eligible for the normal screen timeout
- verify the generated Android screen-reason policy during packaging preparation

## Testing

- `bash -n scripts/android-prepare-generated.sh`
- `node --test scripts/package-android.test.mjs scripts/validate-android-release-jni.test.mjs`
- `cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml`
- optimized Android runtime kept the screen awake through a 55.7 GB full-library transfer; listener-only state locked normally
- the exact narrow branch package remains blocked by pre-existing `jni 0.22.4` Android call-site drift; no JNI pin is included
- known follow-up: one completed transfer left screen protection stale until app restart; cleanup is intentionally outside this PR
