### PR TITLE
fix(android): migrate JNI bridges to 0.22

### DIFF
--- a/apps/desktop/src-tauri/src/native_audio/capture.rs
+++ b/apps/desktop/src-tauri/src/native_audio/capture.rs
@@ -521,18 +521,18 @@ fn permission_error(permission: AudioInputPermissionState) -> Option<AudioInputE
 
 #[cfg(target_os = "android")]
 fn request_android_permission() -> AudioInputPermissionState {
-    call_android_permission("requestTuneForgeAudioPermission")
+    call_android_permission(jni::jni_str!("requestTuneForgeAudioPermission"))
 }
 
 #[cfg(target_os = "android")]
 fn read_android_permission() -> AudioInputPermissionState {
-    call_android_permission("getTuneForgeAudioPermissionState")
+    call_android_permission(jni::jni_str!("getTuneForgeAudioPermissionState"))
 }
 
 #[cfg(target_os = "android")]
-fn call_android_permission(method: &str) -> AudioInputPermissionState {
-    use jni::objects::JObject;
-    use jni::JavaVM;
+fn call_android_permission(method: &jni::strings::JNIStr) -> AudioInputPermissionState {
+    use jni::objects::{Global, JObject, JString};
+    use jni::{jni_sig, JavaVM};
     use tauri::tao::platform::android::prelude::main_android_context;
 
     let Some(context) = main_android_context() else {
@@ -541,25 +541,19 @@ fn call_android_permission(method: &str) -> AudioInputPermissionState {
     if context.java_vm.is_null() || context.context_jobject.is_null() {
         return AudioInputPermissionState::Unavailable;
     }
-    let Ok(vm) = (unsafe { JavaVM::from_raw(context.java_vm.cast()) }) else {
+    let vm = unsafe { JavaVM::from_raw(context.java_vm.cast()) };
+    let result = vm.attach_current_thread(|env| {
+        let activity_raw = context.context_jobject.cast();
+        let activity = unsafe { env.as_cast_raw::<Global<JObject<'static>>>(&activity_raw)? };
+        let result = env
+            .call_method(&activity, method, jni_sig!(() -> JString), &[])?
+            .into_object()?;
+        JString::cast_local(env, result)?.try_to_string(env)
+    });
+    let Ok(value) = result else {
         return AudioInputPermissionState::Unavailable;
     };
-    let Ok(mut env) = vm.attach_current_thread() else {
-        return AudioInputPermissionState::Unavailable;
-    };
-    let activity = unsafe { JObject::from_raw(context.context_jobject.cast()) };
-    let result = env
-        .call_method(&activity, method, "()Ljava/lang/String;", &[])
-        .and_then(|value| value.l());
-    std::mem::forget(activity);
-    let Ok(result) = result else {
-        return AudioInputPermissionState::Unavailable;
-    };
-    let result = jni::objects::JString::from(result);
-    let Ok(value) = env.get_string(&result) else {
-        return AudioInputPermissionState::Unavailable;
-    };
-    match value.to_string_lossy().as_ref() {
+    match value.as_str() {
         "prompt" => AudioInputPermissionState::Prompt,
         "prompting" => AudioInputPermissionState::Prompting,
         "granted" => AudioInputPermissionState::Granted,

--- a/apps/desktop/src-tauri/src/power_inhibition.rs
+++ b/apps/desktop/src-tauri/src/power_inhibition.rs
@@ -779,11 +779,16 @@ mod platform {
 #[cfg(target_os = "android")]
 mod platform {
     use super::*;
-    use jni::objects::{JObject, JValue};
-    use jni::JavaVM;
+    use jni::objects::{Global, JObject, JString, JValue};
+    use jni::{jni_sig, jni_str, JavaVM};
 
     #[derive(Default)]
     struct AndroidInhibitor;
+
+    enum AndroidCall {
+        Set(i32),
+        Probe,
+    }
 
     impl PlatformInhibitor for AndroidInhibitor {
         fn acquire(
@@ -791,7 +796,7 @@ mod platform {
             reasons: &[PowerInhibitionReason],
         ) -> Result<Option<PlatformDetails>, SafeError> {
             let mask = android_reason_mask(reasons);
-            let response = call_android("setTuneForgePowerInhibition", mask)?;
+            let response = call_android(AndroidCall::Set(mask))?;
             let probe = parse_android_response(&response)?;
             if let Some(error) = probe.error {
                 return Err(error);
@@ -803,7 +808,7 @@ mod platform {
         }
 
         fn release(&mut self) -> Result<(), SafeError> {
-            let response = call_android("setTuneForgePowerInhibition", 0)?;
+            let response = call_android(AndroidCall::Set(0))?;
             let probe = parse_android_response(&response)?;
             if probe.error.is_some() {
                 return Err(SafeError {
@@ -816,7 +821,7 @@ mod platform {
 
         fn probe(&mut self) -> Option<PlatformProbe> {
             Some(
-                call_android("getTuneForgePowerInhibitionStatus", 0)
+                call_android(AndroidCall::Probe)
                     .and_then(|response| parse_android_response(&response))
                     .unwrap_or_else(|error| PlatformProbe {
                         details: None,
@@ -828,34 +833,35 @@ mod platform {
         }
     }
 
-    fn call_android(method: &str, mask: i32) -> Result<String, SafeError> {
+    fn call_android(call: AndroidCall) -> Result<String, SafeError> {
         use tauri::tao::platform::android::prelude::main_android_context;
 
         let context = main_android_context().ok_or_else(android_error)?;
         if context.java_vm.is_null() || context.context_jobject.is_null() {
             return Err(android_error());
         }
-        let vm =
-            unsafe { JavaVM::from_raw(context.java_vm.cast()) }.map_err(|_| android_error())?;
-        let mut env = vm.attach_current_thread().map_err(|_| android_error())?;
-        let activity = unsafe { JObject::from_raw(context.context_jobject.cast()) };
-        let result = if method == "setTuneForgePowerInhibition" {
-            env.call_method(
-                &activity,
-                method,
-                "(I)Ljava/lang/String;",
-                &[JValue::Int(mask)],
-            )
-        } else {
-            env.call_method(&activity, method, "()Ljava/lang/String;", &[])
-        }
-        .and_then(|value| value.l());
-        std::mem::forget(activity);
-        let result = result.map_err(|_| android_error())?;
-        let result = jni::objects::JString::from(result);
-        env.get_string(&result)
-            .map(|value| value.to_string_lossy().into_owned())
-            .map_err(|_| android_error())
+        let vm = unsafe { JavaVM::from_raw(context.java_vm.cast()) };
+        vm.attach_current_thread(|env| {
+            let activity_raw = context.context_jobject.cast();
+            let activity = unsafe { env.as_cast_raw::<Global<JObject<'static>>>(&activity_raw)? };
+            let result = match call {
+                AndroidCall::Set(mask) => env.call_method(
+                    &activity,
+                    jni_str!("setTuneForgePowerInhibition"),
+                    jni_sig!((i32) -> JString),
+                    &[JValue::Int(mask)],
+                ),
+                AndroidCall::Probe => env.call_method(
+                    &activity,
+                    jni_str!("getTuneForgePowerInhibitionStatus"),
+                    jni_sig!(() -> JString),
+                    &[],
+                ),
+            }?
+            .into_object()?;
+            JString::cast_local(env, result)?.try_to_string(env)
+        })
+        .map_err(|_| android_error())
     }
 
     fn android_error() -> SafeError {

--- a/scripts/package-android.mjs
+++ b/scripts/package-android.mjs
@@ -17,7 +17,7 @@ const generatedMarkers = [
   ["app/src/main/res", "directory"],
   ["gradle/wrapper/gradle-wrapper.jar", "file"], ["gradle/wrapper/gradle-wrapper.properties", "file"],
   ["gradlew", "executable"],
-  ["settings.gradle", "file"], ["tauri.settings.gradle", "file"],
+  ["settings.gradle", "file"],
 ];
 function capture(command, args, { cwd = repoRoot, env = process.env } = {}) {
   const result = spawnSync(command, args, { cwd, env, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });

--- a/scripts/package-android.test.mjs
+++ b/scripts/package-android.test.mjs
@@ -75,7 +75,7 @@ function completeGenerated(root) {
     "app/build.gradle.kts", "app/src/main/AndroidManifest.xml",
     "app/src/main/java/com/tuneforge/desktop/MainActivity.kt",
     "gradle/wrapper/gradle-wrapper.jar", "gradle/wrapper/gradle-wrapper.properties",
-    "settings.gradle", "tauri.settings.gradle",
+    "settings.gradle",
   ]) {
     const candidate = path.join(root, relative);
     fs.mkdirSync(path.dirname(candidate), { recursive: true });
@@ -85,10 +85,11 @@ function completeGenerated(root) {
   executable(path.join(root, "gradlew"));
 }
 
-test("generated state rejects absent markers and reuses complete state", (t) => {
+test("generated state accepts initialized projects and still requires source markers", (t) => {
   const root = path.join(temp(t), "android");
   assert.equal(generatedState(root).state, "absent");
   completeGenerated(root);
+  assert.equal(fs.existsSync(path.join(root, "tauri.settings.gradle")), false);
   assert.equal(generatedState(root).state, "complete");
   fs.rmSync(path.join(root, "app/src/main/java/com/tuneforge/desktop/MainActivity.kt"));
   assert.deepEqual(generatedState(root).missing, ["app/src/main/java/com/tuneforge/desktop/MainActivity.kt"]);


### PR DESCRIPTION
## Summary

- migrate Android permission and power-inhibition bridges to JNI 0.22 callback-scoped environments and borrowed global references
- accept Tauri's initialized Android project before build-time `tauri.settings.gradle` exists
- Fixes #409

## Testing

- passed `cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check`
- passed `cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml`
- passed `node --test scripts/package-android.test.mjs scripts/validate-android-release-jni.test.mjs` (14 tests)
- passed `pnpm lint` and `pnpm typecheck`
- `pnpm test`: frontend, helper, and 310/311 Tauri tests passed; unrelated `mobile_media_transport::tests::shutdown_interrupts_an_incomplete_request` flaked, then passed with an isolated outside-sandbox retry
- passed `cd apps/backend && uv run --python 3.11 pytest` (677 tests)
- passed `node scripts/check-release-version.mjs`, `node scripts/release-license-inventory.mjs --check`, and `git diff --check`
- passed `pnpm package:android`; optimized arm64 APK was non-debuggable, debug-key signed, and passed all four release DEX descriptor checks
- passed `bash scripts/android-arm64-env.sh cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml --target aarch64-linux-android`
- fresh API 36.1 (SDK 36) arm64 emulator: initial permission `Prompt`, Android permission request and grant, native AAudio `Listening`, active `KEEP_SCREEN_ON`, clean Stop/release, then permission `Granted`, capture/power `Inactive`, no active reasons or protection error, and `Android activity screen` as last backend
- physical-device microphone quality, vendor power behavior, and long-run behavior remain unverified
