### PR TITLE
fix(android): release stale transfer screen protection

### DIFF
--- a/apps/desktop/src-tauri/src/power_inhibition.rs
+++ b/apps/desktop/src-tauri/src/power_inhibition.rs
@@ -938,7 +938,9 @@ mod tests {
                 screen_protected: reasons.iter().any(|reason| {
                     matches!(
                         reason,
-                        PowerInhibitionReason::Playback | PowerInhibitionReason::TunerCapture
+                        PowerInhibitionReason::Playback
+                            | PowerInhibitionReason::SyncTransfer
+                            | PowerInhibitionReason::TunerCapture
                     )
                 }),
                 background_protected: true,
@@ -1013,6 +1015,55 @@ mod tests {
         );
         drop(second);
         assert_eq!(*control.releases.lock().unwrap(), 1);
+    }
+
+    #[test]
+    fn transfer_screen_protection_releases_to_listener_only() {
+        let (state, _) = state();
+        let listener = state
+            .acquire_scoped(PowerInhibitionReason::SyncListener)
+            .unwrap();
+        let transfer = state
+            .acquire_scoped(PowerInhibitionReason::SyncTransfer)
+            .unwrap();
+
+        assert!(state.status().unwrap().screen_protected);
+        drop(transfer);
+
+        let listener_only = state.status().unwrap();
+        assert_eq!(
+            listener_only.active_reasons,
+            vec![PowerInhibitionReason::SyncListener]
+        );
+        assert!(!listener_only.screen_protected);
+        drop(listener);
+    }
+
+    #[test]
+    fn transfer_release_preserves_playback_and_tuner_screen_owners() {
+        let (state, _) = state();
+        let transfer = state
+            .acquire_scoped(PowerInhibitionReason::SyncTransfer)
+            .unwrap();
+        let tuner = state
+            .acquire_scoped(PowerInhibitionReason::TunerCapture)
+            .unwrap();
+        state
+            .set_activity(PowerInhibitionReason::Playback, true)
+            .unwrap();
+
+        drop(transfer);
+
+        let protected = state.status().unwrap();
+        assert_eq!(
+            protected.active_reasons,
+            vec![
+                PowerInhibitionReason::Playback,
+                PowerInhibitionReason::TunerCapture,
+            ]
+        );
+        assert!(protected.screen_protected);
+        drop(tuner);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/sync_transport.rs
+++ b/apps/desktop/src-tauri/src/sync_transport.rs
@@ -13235,7 +13235,23 @@ mod desktop {
         }
 
         #[test]
-        fn transfer_timeout_cancels_run_without_releasing_other_power_owners() {
+        fn transfer_reservation_survives_listener_release() {
+            let (power, counts) = test_power_inhibition();
+            let listener = ListenerPowerLease::acquire(&power);
+            let reservations = ActiveTransferReservations::new(power);
+            let transfer = reservations.reserve("listener_stopped");
+
+            listener.release();
+
+            assert_eq!(counts.active(PowerInhibitionReason::SyncListener), 0);
+            assert_eq!(counts.active(PowerInhibitionReason::SyncTransfer), 1);
+
+            drop(transfer);
+            assert_eq!(counts.active(PowerInhibitionReason::SyncTransfer), 0);
+        }
+
+        #[test]
+        fn transfer_reservation_timeout_cancels_run_without_releasing_other_power_owners() {
             let (power, counts) = test_power_inhibition();
             let listener = power.acquire(PowerInhibitionReason::SyncListener);
             let reservations = ActiveTransferReservations::new(power);

--- a/scripts/android-prepare-generated.sh
+++ b/scripts/android-prepare-generated.sh
@@ -146,6 +146,7 @@ import android.os.Process
 import android.view.View
 import android.view.WindowInsets
 import android.view.WindowInsetsController
+import android.view.WindowManager
 
 class MainActivity : TauriActivity() {
   private var notificationPermissionOwnershipRevision = 0L
@@ -178,11 +179,16 @@ class MainActivity : TauriActivity() {
 
   fun getTuneForgePowerInhibitionStatus(): String = PowerInhibitionService.status()
 
-  fun applyTuneForgeScreenProtection() {
+  fun applyTuneForgeScreenProtection(expectedRevision: Long) {
     window.decorView.post {
-      val requestedMask = PowerInhibitionService.screenProtectionRequestedMask()
-      window.decorView.keepScreenOn = requestedMask != 0
-      PowerInhibitionService.confirmScreenProtection(requestedMask)
+      val requestedMask = PowerInhibitionService
+        .screenProtectionRequestedMask(this, expectedRevision) ?: return@post
+      if (requestedMask != 0) {
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+      } else {
+        window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+      }
+      PowerInhibitionService.confirmScreenProtection(this, requestedMask, expectedRevision)
     }
   }
 
@@ -330,8 +336,7 @@ class PowerInhibitionService : Service() {
   override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
     // A queued start intent may predate a later release request. Always apply
     // the latest process-wide desired mask so a stale intent cannot reacquire.
-    val requestedMask = desiredServiceReasonMask()
-    applyReasons(requestedMask)
+    applyReasons(desiredServiceState())
     return START_NOT_STICKY
   }
 
@@ -341,9 +346,9 @@ class PowerInhibitionService : Service() {
     confirmedServiceMask = 0
     instance = null
     super.onDestroy()
-    val remainingServiceMask = desiredServiceMask
-    if (remainingServiceMask != 0) {
-      launch(applicationContext, remainingServiceMask)
+    val remainingState = desiredServiceState()
+    if (remainingState.serviceMask != 0) {
+      launch(applicationContext, remainingState)
     }
   }
 
@@ -351,13 +356,9 @@ class PowerInhibitionService : Service() {
 
   override fun onTimeout(startId: Int, fgsType: Int) {
     if (Build.VERSION.SDK_INT >= 35 && fgsType and ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC != 0) {
-      val remainingMask = desiredMask and REASON_SYNC_TRANSFER.inv()
-      ownershipRevision.incrementAndGet()
+      transitionDesiredState(null, REASON_SYNC_TRANSFER)
       timeoutEpoch += 1
       lastFailure = ERROR_DATA_SYNC_TIMEOUT
-      desiredMask = remainingMask
-      desiredServiceMask = remainingMask and SERVICE_REASON_MASK
-      requestScreenProtection(remainingMask and SCREEN_REASON_MASK)
       confirmedServiceMask = 0
       releaseWakeLock()
       reasonMask = 0
@@ -366,10 +367,10 @@ class PowerInhibitionService : Service() {
     }
   }
 
-  private fun applyReasons(requestedMask: Int): String {
+  private fun applyReasons(attemptedState: DesiredStateTransition): String {
     return try {
-      reasonMask = requestedMask
-      confirmedServiceMask = requestedMask
+      reasonMask = attemptedState.serviceMask
+      confirmedServiceMask = attemptedState.serviceMask
       updateWakeLock()
       if (reasonMask == 0) {
         stopForeground(STOP_FOREGROUND_REMOVE)
@@ -382,11 +383,7 @@ class PowerInhibitionService : Service() {
     } catch (_: RuntimeException) {
       releaseWakeLock()
       reasonMask = 0
-      confirmedServiceMask = 0
-      desiredServiceMask = 0
-      desiredMask = desiredMask and SERVICE_REASON_MASK.inv()
-      lastFailure = ERROR_POWER_CONTROL
-      requestScreenProtection(desiredMask and SCREEN_REASON_MASK)
+      recordPowerControlFailure(attemptedState)
       stopForeground(STOP_FOREGROUND_REMOVE)
       stopSelf()
       status()
@@ -547,29 +544,60 @@ class PowerInhibitionService : Service() {
     @Volatile private var notificationPermissionDenied = false
     @Volatile private var activity = WeakReference<MainActivity>(null)
     private val ownershipRevision = AtomicLong(0)
+    private val screenProtectionRevision = AtomicLong(0)
+    private val serviceOwnershipRevision = AtomicLong(0)
 
+    private data class DesiredStateTransition(
+      val previousServiceMask: Int,
+      val serviceMask: Int,
+      val serviceRevision: Long,
+    )
+
+    @Synchronized
     fun attachActivity(nextActivity: MainActivity) {
       activity = WeakReference(nextActivity)
-      nextActivity.applyTuneForgeScreenProtection()
+      confirmedScreenMask = 0
+      val revision = screenProtectionRevision.incrementAndGet()
+      nextActivity.applyTuneForgeScreenProtection(revision)
     }
 
+    @Synchronized
     fun detachActivity(currentActivity: MainActivity) {
       if (activity.get() === currentActivity) {
+        screenProtectionRevision.incrementAndGet()
         activity.clear()
         confirmedScreenMask = 0
       }
     }
 
-    fun requestScreenProtection(reasonMask: Int) {
-      desiredScreenMask = reasonMask and SCREEN_REASON_MASK
-      activity.get()?.applyTuneForgeScreenProtection()
+    @Synchronized
+    fun screenProtectionRequestedMask(
+      currentActivity: MainActivity,
+      expectedRevision: Long,
+    ): Int? {
+      if (activity.get() !== currentActivity || expectedRevision != screenProtectionRevision.get()) {
+        return null
+      }
+      return desiredScreenMask
     }
 
-    fun screenProtectionRequestedMask(): Int = desiredScreenMask
+    @Synchronized
+    private fun desiredServiceState(): DesiredStateTransition = DesiredStateTransition(
+      previousServiceMask = desiredServiceMask,
+      serviceMask = desiredServiceMask,
+      serviceRevision = serviceOwnershipRevision.get(),
+    )
 
-    private fun desiredServiceReasonMask(): Int = desiredServiceMask
-
-    fun confirmScreenProtection(reasonMask: Int) {
+    @Synchronized
+    fun confirmScreenProtection(
+      currentActivity: MainActivity,
+      reasonMask: Int,
+      expectedRevision: Long,
+    ) {
+      if (activity.get() !== currentActivity ||
+        expectedRevision != screenProtectionRevision.get() ||
+        reasonMask != desiredScreenMask
+      ) return
       confirmedScreenMask = reasonMask and SCREEN_REASON_MASK
     }
 
@@ -589,16 +617,10 @@ class PowerInhibitionService : Service() {
     }
 
     fun request(context: Context, reasonMask: Int): String {
-      val previousServiceMask = desiredServiceMask
-      val nextServiceMask = reasonMask and SERVICE_REASON_MASK
-      if (previousServiceMask != nextServiceMask) {
-        ownershipRevision.incrementAndGet()
-      }
-      desiredMask = reasonMask
-      desiredServiceMask = nextServiceMask
-      requestScreenProtection(reasonMask and SCREEN_REASON_MASK)
+      val transition = transitionDesiredState(reasonMask, 0)
       if (lastFailure == ERROR_DATA_SYNC_TIMEOUT &&
-        (reasonMask and REASON_SYNC_TRANSFER == 0 || previousServiceMask and REASON_SYNC_TRANSFER == 0)
+        (reasonMask and REASON_SYNC_TRANSFER == 0 ||
+          transition.previousServiceMask and REASON_SYNC_TRANSFER == 0)
       ) {
         lastFailure = ERROR_NONE
       } else if (lastFailure == ERROR_POWER_CONTROL || lastFailure == ERROR_NOTIFICATION_POST_FAILED) {
@@ -606,15 +628,15 @@ class PowerInhibitionService : Service() {
       }
       val existing = instance
       if (existing != null) {
-        existing.applyOnMainThread(nextServiceMask)
+        existing.applyOnMainThread()
         return status()
       }
-      if (nextServiceMask == 0) {
+      if (transition.serviceMask == 0) {
         confirmedServiceMask = 0
         return status()
       }
 
-      launch(context, nextServiceMask)
+      launch(context, transition)
       return status()
     }
 
@@ -638,30 +660,56 @@ class PowerInhibitionService : Service() {
       return "$phase;$activeMask;$statusError;$desiredMask;$timeoutEpoch;${confirmedScreenMask != 0}"
     }
 
-    private fun launch(context: Context, reasonMask: Int) {
+    private fun launch(context: Context, attemptedState: DesiredStateTransition) {
       try {
         val intent = Intent(context, PowerInhibitionService::class.java)
-          .putExtra(EXTRA_REASON_MASK, reasonMask)
+          .putExtra(EXTRA_REASON_MASK, attemptedState.serviceMask)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
           context.startForegroundService(intent)
         } else {
           context.startService(intent)
         }
       } catch (_: RuntimeException) {
-        desiredMask = desiredMask and SERVICE_REASON_MASK.inv()
-        desiredServiceMask = 0
-        confirmedServiceMask = 0
-        lastFailure = ERROR_POWER_CONTROL
-        requestScreenProtection(desiredMask and SCREEN_REASON_MASK)
+        recordPowerControlFailure(attemptedState)
       }
+    }
+
+    @Synchronized
+    private fun transitionDesiredState(
+      requestedMask: Int?,
+      clearedReasons: Int,
+    ): DesiredStateTransition {
+      val nextMask = requestedMask ?: (desiredMask and clearedReasons.inv())
+      val previousServiceMask = desiredServiceMask
+      val nextServiceMask = nextMask and SERVICE_REASON_MASK
+      if (previousServiceMask != nextServiceMask) {
+        ownershipRevision.incrementAndGet()
+      }
+      desiredMask = nextMask
+      desiredServiceMask = nextServiceMask
+      desiredScreenMask = nextMask and SCREEN_REASON_MASK
+      val serviceRevision = serviceOwnershipRevision.incrementAndGet()
+      val revision = screenProtectionRevision.incrementAndGet()
+      activity.get()?.applyTuneForgeScreenProtection(revision)
+      return DesiredStateTransition(previousServiceMask, nextServiceMask, serviceRevision)
+    }
+
+    @Synchronized
+    private fun recordPowerControlFailure(attemptedState: DesiredStateTransition) {
+      if (attemptedState.serviceRevision != serviceOwnershipRevision.get() ||
+        attemptedState.serviceMask != desiredServiceMask
+      ) return
+      transitionDesiredState(null, SERVICE_REASON_MASK)
+      confirmedServiceMask = 0
+      lastFailure = ERROR_POWER_CONTROL
     }
   }
 
-  private fun applyOnMainThread(requestedMask: Int) {
+  private fun applyOnMainThread() {
     if (Looper.myLooper() == Looper.getMainLooper()) {
-      applyReasons(requestedMask)
+      applyReasons(desiredServiceState())
     } else {
-      handler.post { applyReasons(requestedMask) }
+      handler.post { applyReasons(desiredServiceState()) }
     }
   }
 }
@@ -684,6 +732,20 @@ verify_power_notification_wiring() {
     'const val SERVICE_REASON_MASK = REASON_PLAYBACK or REASON_SYNC_LISTENER or REASON_SYNC_TRANSFER'
     'val activeMask = if (serviceMatches) (confirmedServiceMask or screenOnlyMask) else 0'
     'notificationPermissionDenied && desiredServiceMask != 0'
+    'private val screenProtectionRevision = AtomicLong(0)'
+    'private val serviceOwnershipRevision = AtomicLong(0)'
+    'val serviceRevision: Long'
+    'private fun transitionDesiredState('
+    'val transition = transitionDesiredState(reasonMask, 0)'
+    'transitionDesiredState(null, REASON_SYNC_TRANSFER)'
+    'desiredScreenMask = nextMask and SCREEN_REASON_MASK'
+    'activity.get()?.applyTuneForgeScreenProtection(revision)'
+    'activity.get() !== currentActivity'
+    'reasonMask != desiredScreenMask'
+    'private fun recordPowerControlFailure(attemptedState: DesiredStateTransition)'
+    'attemptedState.serviceRevision != serviceOwnershipRevision.get()'
+    'attemptedState.serviceMask != desiredServiceMask'
+    'handler.post { applyReasons(desiredServiceState()) }'
   )
   local snippet
   for snippet in "${required_snippets[@]}"; do
@@ -697,7 +759,10 @@ verify_power_notification_wiring() {
     ! grep -Fq 'if (!PowerInhibitionService.beginNotificationPermissionRequest()) return@post' "$MAIN_ACTIVITY" ||
     ! grep -Fq 'notificationPermissionOwnershipRevision = expectedRevision' "$MAIN_ACTIVITY" ||
     ! grep -Fq 'reasonMask and PowerInhibitionService.SERVICE_REASON_MASK != 0' "$MAIN_ACTIVITY" ||
-    ! grep -Fq 'window.decorView.keepScreenOn = requestedMask != 0' "$MAIN_ACTIVITY"; then
+    ! grep -Fq 'screenProtectionRequestedMask(this, expectedRevision) ?: return@post' "$MAIN_ACTIVITY" ||
+    ! grep -Fq 'window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)' "$MAIN_ACTIVITY" ||
+    ! grep -Fq 'window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)' "$MAIN_ACTIVITY" ||
+    ! grep -Fq 'PowerInhibitionService.confirmScreenProtection(this, requestedMask, expectedRevision)' "$MAIN_ACTIVITY"; then
     echo "Generated Android activity does not bind notification permission to ownership." >&2
     exit 1
   fi

--- a/scripts/android-prepare-generated.test.mjs
+++ b/scripts/android-prepare-generated.test.mjs
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const sourceScript = new URL("./android-prepare-generated.sh", import.meta.url);
+
+function section(source, startMarker, endMarker) {
+  const start = source.indexOf(startMarker);
+  const end = endMarker === null
+    ? source.length
+    : source.indexOf(endMarker, start + startMarker.length);
+  assert.ok(start >= 0 && end > start, `missing section ${startMarker}`);
+  return source.slice(start, end);
+}
+
+function generatedProject(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "tuneforge-android-generated-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const script = path.join(root, "scripts/android-prepare-generated.sh");
+  fs.mkdirSync(path.dirname(script), { recursive: true });
+  fs.copyFileSync(sourceScript, script);
+  fs.chmodSync(script, 0o755);
+
+  const tauri = path.join(root, "apps/desktop/src-tauri");
+  const main = path.join(tauri, "gen/android/app/src/main");
+  const java = path.join(main, "java/com/tuneforge/desktop");
+  fs.mkdirSync(java, { recursive: true });
+  fs.mkdirSync(path.join(main, "res"), { recursive: true });
+  fs.writeFileSync(path.join(main, "AndroidManifest.xml"), "<manifest>\n  <application>\n  </application>\n</manifest>\n");
+  fs.writeFileSync(path.join(java, "MainActivity.kt"), "placeholder\n");
+  fs.writeFileSync(path.join(tauri, "proguard-tuneforge.pro"), "# test\n");
+
+  const icons = path.join(tauri, "target/android-icons/android");
+  for (const density of ["mdpi", "hdpi", "xhdpi", "xxhdpi", "xxxhdpi", "anydpi-v26"]) {
+    fs.mkdirSync(path.join(icons, `mipmap-${density}`), { recursive: true });
+  }
+  fs.mkdirSync(path.join(icons, "values"), { recursive: true });
+  fs.writeFileSync(path.join(icons, "values/ic_launcher_background.xml"), "<resources />\n");
+
+  execFileSync(script, { cwd: root });
+  return {
+    activity: fs.readFileSync(path.join(java, "MainActivity.kt"), "utf8"),
+    service: fs.readFileSync(path.join(java, "PowerInhibitionService.kt"), "utf8"),
+  };
+}
+
+test("generated screen protection is revision-gated to the current activity", (t) => {
+  const { activity, service } = generatedProject(t);
+
+  assert.match(activity, /applyTuneForgeScreenProtection\(expectedRevision: Long\)/);
+  assert.match(activity, /screenProtectionRequestedMask\(this, expectedRevision\) \?: return@post/);
+  assert.match(service, /activity\.get\(\) !== currentActivity \|\| expectedRevision != screenProtectionRevision\.get\(\)/);
+
+  const desired = service.indexOf("desiredScreenMask = nextMask and SCREEN_REASON_MASK");
+  const revision = service.indexOf("val revision = screenProtectionRevision.incrementAndGet()", desired);
+  const apply = service.indexOf("activity.get()?.applyTuneForgeScreenProtection(revision)", revision);
+  assert.ok(desired >= 0 && desired < revision && revision < apply);
+});
+
+test("generated desired masks publish through one synchronized transition", (t) => {
+  const { service } = generatedProject(t);
+
+  assert.match(service, /@Synchronized\n    private fun transitionDesiredState\(/);
+  assert.match(service, /fun request\(context: Context, reasonMask: Int\): String \{\n      val transition = transitionDesiredState\(reasonMask, 0\)/);
+  assert.match(service, /override fun onTimeout[\s\S]*transitionDesiredState\(null, REASON_SYNC_TRANSFER\)/);
+
+  const desiredWrites = [...service.matchAll(
+    /^\s*(desiredMask|desiredServiceMask|desiredScreenMask)\s*=(?!=)/gm,
+  )];
+  assert.deepEqual(desiredWrites.map((match) => match[1]), [
+    "desiredMask", "desiredServiceMask", "desiredScreenMask",
+  ]);
+});
+
+test("generated service failures are gated by the attempted ownership snapshot", (t) => {
+  const { service } = generatedProject(t);
+  const applyReasons = section(
+    service,
+    "  private fun applyReasons(",
+    "  private fun startTruthfulForegroundNotification()",
+  );
+  const launch = section(
+    service,
+    "    private fun launch(",
+    "    @Synchronized\n    private fun transitionDesiredState(",
+  );
+  const failureGate = section(
+    service,
+    "    private fun recordPowerControlFailure(",
+    "  }\n\n  private fun applyOnMainThread()",
+  );
+
+  assert.match(service, /data class DesiredStateTransition\([\s\S]*serviceMask: Int,[\s\S]*serviceRevision: Long/);
+  assert.match(applyReasons, /recordPowerControlFailure\(attemptedState\)/);
+  assert.match(launch, /recordPowerControlFailure\(attemptedState\)/);
+  assert.match(failureGate, /attemptedState\.serviceRevision != serviceOwnershipRevision\.get\(\) \|\|[\s\S]*attemptedState\.serviceMask != desiredServiceMask[\s\S]*\) return\n      transitionDesiredState\(null, SERVICE_REASON_MASK\)[\s\S]*lastFailure = ERROR_POWER_CONTROL/);
+});
+
+test("generated activity directly adds and clears the window flag before guarded confirmation", (t) => {
+  const { activity, service } = generatedProject(t);
+
+  assert.match(activity, /window\.addFlags\(WindowManager\.LayoutParams\.FLAG_KEEP_SCREEN_ON\)/);
+  assert.match(activity, /window\.clearFlags\(WindowManager\.LayoutParams\.FLAG_KEEP_SCREEN_ON\)/);
+  assert.match(activity, /confirmScreenProtection\(this, requestedMask, expectedRevision\)/);
+  assert.match(service, /reasonMask != desiredScreenMask/);
+  assert.doesNotMatch(activity, /decorView\.keepScreenOn/);
+});
+
+test("generated queued service work applies the latest desired mask", (t) => {
+  const { service } = generatedProject(t);
+  const onStart = section(service, "  override fun onStartCommand(", "  override fun onDestroy() {");
+  const onDestroy = section(service, "  override fun onDestroy() {", "  override fun onBind(");
+  const request = section(
+    service,
+    "    fun request(context: Context, reasonMask: Int): String {",
+    "    fun status(): String {",
+  );
+  const mainThreadApply = section(service, "  private fun applyOnMainThread() {", null);
+
+  assert.match(onStart, /applyReasons\(desiredServiceState\(\)\)/);
+  assert.match(onDestroy, /val remainingState = desiredServiceState\(\)[\s\S]*launch\(applicationContext, remainingState\)/);
+  assert.match(request, /launch\(context, transition\)/);
+  assert.match(mainThreadApply, /handler\.post \{ applyReasons\(desiredServiceState\(\)\) \}/);
+  assert.doesNotMatch(mainThreadApply, /applyReasons\(requestedMask\)/);
+});

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -50,6 +50,15 @@ android_package_start=${SECONDS}
 android_package_elapsed=$((SECONDS - android_package_start))
 printf '\n[tests] Android packaging helper tests finished in %ss\n' "${android_package_elapsed}"
 
+printf '\n[tests] Starting Android generated power inhibition tests\n\n'
+android_generated_power_start=${SECONDS}
+(
+  cd "${repo_root}"
+  node --test scripts/android-prepare-generated.test.mjs
+)
+android_generated_power_elapsed=$((SECONDS - android_generated_power_start))
+printf '\n[tests] Android generated power inhibition tests finished in %ss\n' "${android_generated_power_elapsed}"
+
 printf '\n[tests] Starting setup-dev script tests\n\n'
 setup_dev_start=${SECONDS}
 (


### PR DESCRIPTION
## Summary

- Revision-gate Android window updates so stale activity callbacks cannot retain transfer screen protection.
- Publish service, screen, and raw reason masks atomically and ownership-gate failure cleanup.
- Preserve playback and tuner owners while allowing listener-only state to follow normal display timeout.
- Add focused generated-Kotlin and Rust transition coverage.
- Closes #410

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `node --test scripts/android-prepare-generated.test.mjs` (5 passed)
- `cd apps/desktop/src-tauri && cargo test power_inhibition --lib` (15 passed)
- `cd apps/desktop/src-tauri && cargo test transfer_reservation --lib` (7 passed)
- `cd apps/desktop/src-tauri && source ../../../scripts/configure-tauri-build-env.sh && cargo check`
- `cd apps/backend && uv run --python 3.11 pytest` (677 passed)
- `pnpm package:android` (optimized APK built; release JNI validation passed)
- `pnpm test` reached 714/714 frontend and 313/314 Rust tests before an existing socket-acceptance test flaked; its isolated rerun passed.
- Physical-device screen-timeout validation not run; real Android display/power behavior remains unverified.
