### PR TITLE
fix(android): support sync evidence copy and export

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -118,6 +118,12 @@ This file is the source of truth for dependency and model-weight distribution po
 - **Source:** <https://github.com/tauri-apps/plugins-workspace>
 - **Notes:** Used by the Android-only QR pairing scanner. The desktop shell does not enable the barcode scanner plugin.
 
+### Tauri clipboard manager plugin
+
+- **License:** MIT OR Apache-2.0
+- **Source:** <https://github.com/tauri-apps/plugins-workspace>
+- **Notes:** Used to write explicit user-requested pairing material and privacy-safe sync evidence as plain text to the system clipboard.
+
 ### TuneForge LAN sync transport Rust crates
 
 - **License:** Apache-2.0 / MIT for `snow`, `base64`, `rand`, `sha2`, and the RustCrypto AEAD/hash stack; BSD-3-Clause for `ed25519-dalek` and `curve25519-dalek`; MIT / BSD-3-Clause for `if-addrs`.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -21,6 +21,7 @@
     "@tanstack/react-query": "^5.101.4",
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-barcode-scanner": "~2.4.5",
+    "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-dialog": "^2.7.2",
     "@tuneforge/shared-types": "workspace:*",
     "lucide-react": "^1.30.0",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -111,6 +111,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,7 +161,7 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
  "rusticata-macros",
  "thiserror 2.0.18",
@@ -483,6 +504,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,7 +607,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -685,6 +712,15 @@ dependencies = [
  "glob",
  "libc",
  "libloading 0.8.9",
+]
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
 ]
 
 [[package]]
@@ -918,6 +954,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1265,7 +1307,7 @@ checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -1428,6 +1470,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,6 +1630,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "extended"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,6 +1670,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1653,6 +1713,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -2013,6 +2079,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2251,6 +2327,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2740,6 +2827,20 @@ dependencies = [
  "tokio",
  "url",
  "xmltree",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -3561,6 +3662,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3811,6 +3922,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "noq"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3979,6 +4099,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -4293,6 +4414,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4386,6 +4517,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
 
 [[package]]
 name = "pharos"
@@ -4620,7 +4762,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -4893,10 +5035,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -5293,7 +5456,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -6640,6 +6803,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6851,6 +7029,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -7246,6 +7438,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7281,6 +7484,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-barcode-scanner",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tokio",
@@ -7620,6 +7824,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016ccf01d1c58b6f8999612813e17c9b2390f7d70671428869913310f83f54b8"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.41.0",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7748,6 +8022,12 @@ dependencies = [
  "windows 0.61.3",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whisper-rs"
@@ -8402,6 +8682,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "wmi"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8507,6 +8805,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8516,7 +8831,7 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "oid-registry",
  "ring",
  "rusticata-macros",
@@ -8671,3 +8986,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ tauri-plugin-fs = "2.5.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["arbitrary_precision"] }
 chrono = { version = "0.4.44", features = ["serde"] }
+tauri-plugin-clipboard-manager = "2.3.2"
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 base64 = "0.23.0"

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:event:allow-listen",
     "core:event:allow-unlisten",
+    "clipboard-manager:allow-write-text",
     "dialog:allow-open",
     "dialog:allow-save",
     "dialog:allow-message"

--- a/apps/desktop/src-tauri/capabilities/mobile.json
+++ b/apps/desktop/src-tauri/capabilities/mobile.json
@@ -7,6 +7,7 @@
     "main"
   ],
   "permissions": [
-    "barcode-scanner:default"
+    "barcode-scanner:default",
+    "clipboard-manager:allow-write-text"
   ]
 }

--- a/apps/desktop/src-tauri/src/file_dialog_scope.rs
+++ b/apps/desktop/src-tauri/src/file_dialog_scope.rs
@@ -1,10 +1,12 @@
 use std::{
-    fs, io,
+    fs,
+    io::{self, Read, Write},
     path::{Path, PathBuf},
 };
 
 use tauri::AppHandle;
 use tauri_plugin_dialog::{DialogExt, FilePath};
+use tauri_plugin_fs::{FsExt, OpenOptions};
 
 const JSON_FILTER_NAME: &str = "JSON";
 const JSON_EXTENSION: &str = "json";
@@ -98,12 +100,29 @@ pub(crate) fn write_user_selected_json_file(
 ) -> Result<bool, String> {
     validate_json_contents(&contents, purpose)?;
     let default_file_name = sanitized_json_file_name(&default_file_name, fallback_file_name);
-    let Some(path) = pick_user_selected_json_save_path(app, title, default_file_name)? else {
+    let Some(selection) = pick_user_selected_json_save_path(app, title, default_file_name)? else {
         return Ok(false);
     };
-    validate_user_selected_json_write_path(&path).map_err(|error| error.write_message(purpose))?;
-    fs::write(path, contents)
-        .map_err(|error| format!("Could not write selected {purpose} file: {error}"))?;
+    validate_user_selected_json_write_selection(&selection)
+        .map_err(|error| error.write_message(purpose))?;
+
+    let write_target = selection.clone();
+    let read_target = selection;
+    let mut write_options = OpenOptions::new();
+    write_options.write(true).truncate(true).create(true);
+    persist_and_verify_json(
+        &contents,
+        purpose,
+        || app.fs().open(write_target, write_options),
+        || {
+            let mut read_options = OpenOptions::new();
+            read_options.read(true);
+            let mut file = app.fs().open(read_target, read_options)?;
+            let mut verified = String::new();
+            file.read_to_string(&mut verified)?;
+            Ok(verified)
+        },
+    )?;
     Ok(true)
 }
 
@@ -124,16 +143,14 @@ fn pick_user_selected_json_save_path(
     app: &AppHandle,
     title: &str,
     default_file_name: String,
-) -> Result<Option<PathBuf>, String> {
-    app.dialog()
+) -> Result<Option<FilePath>, String> {
+    Ok(app
+        .dialog()
         .file()
         .set_title(title)
         .set_file_name(default_file_name)
         .add_filter(JSON_FILTER_NAME, &[JSON_EXTENSION])
-        .blocking_save_file()
-        .map(selected_file_path_to_local_path)
-        .transpose()
-        .map_err(|error| error.write_message("JSON file"))
+        .blocking_save_file())
 }
 
 fn selected_file_path_to_local_path(selection: FilePath) -> Result<PathBuf, JsonFilePathError> {
@@ -149,6 +166,27 @@ fn selected_file_path_to_local_path(selection: FilePath) -> Result<PathBuf, Json
         Ok(path)
     } else {
         Err(JsonFilePathError::NonLocalFileSelection)
+    }
+}
+
+fn validate_user_selected_json_write_selection(
+    selection: &FilePath,
+) -> Result<(), JsonFilePathError> {
+    validate_user_selected_json_write_selection_for_platform(selection, cfg!(target_os = "android"))
+}
+
+fn validate_user_selected_json_write_selection_for_platform(
+    selection: &FilePath,
+    allow_android_content: bool,
+) -> Result<(), JsonFilePathError> {
+    match selection {
+        FilePath::Url(url) if url.scheme() == "content" && allow_android_content => Ok(()),
+        FilePath::Url(url) if url.scheme() != "file" => {
+            Err(JsonFilePathError::NonLocalFileSelection)
+        }
+        _ => validate_user_selected_json_write_path(&selected_file_path_to_local_path(
+            selection.clone(),
+        )?),
     }
 }
 
@@ -217,7 +255,44 @@ fn validate_json_extension(path: &Path) -> Result<(), JsonFilePathError> {
 fn validate_json_contents(contents: &str, purpose: &str) -> Result<(), String> {
     serde_json::from_str::<serde_json::Value>(contents)
         .map(|_| ())
-        .map_err(|error| format!("Selected {purpose} contents are not valid JSON: {error}"))
+        .map_err(|_| format!("Selected {purpose} contents are not valid JSON."))
+}
+
+trait SyncWrite: Write {
+    fn sync_all(&self) -> io::Result<()>;
+}
+
+impl SyncWrite for fs::File {
+    fn sync_all(&self) -> io::Result<()> {
+        fs::File::sync_all(self)
+    }
+}
+
+fn persist_and_verify_json<W: SyncWrite>(
+    contents: &str,
+    purpose: &str,
+    open_writer: impl FnOnce() -> io::Result<W>,
+    read_back: impl FnOnce() -> io::Result<String>,
+) -> Result<(), String> {
+    let mut writer =
+        open_writer().map_err(|_| format!("Could not write selected {purpose} file."))?;
+    writer
+        .write_all(contents.as_bytes())
+        .map_err(|_| format!("Could not write selected {purpose} file."))?;
+    writer
+        .flush()
+        .and_then(|_| writer.sync_all())
+        .map_err(|_| format!("Could not finish writing selected {purpose} file."))?;
+    drop(writer);
+
+    let verified = read_back().map_err(|_| format!("Could not verify selected {purpose} file."))?;
+    if verified.is_empty()
+        || verified != contents
+        || serde_json::from_str::<serde_json::Value>(&verified).is_err()
+    {
+        return Err(format!("Selected {purpose} file could not be verified."));
+    }
+    Ok(())
 }
 
 fn sanitized_json_file_name(default_file_name: &str, fallback_file_name: &str) -> String {
@@ -276,6 +351,49 @@ mod tests {
         fn drop(&mut self) {
             let _ = fs::remove_dir_all(&self.root);
         }
+    }
+
+    #[derive(Default)]
+    struct TestWriter {
+        fail_write: bool,
+        fail_flush: bool,
+        fail_sync: bool,
+    }
+
+    impl Write for TestWriter {
+        fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+            if self.fail_write {
+                Err(io::Error::other("private write detail"))
+            } else {
+                Ok(buffer.len())
+            }
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            if self.fail_flush {
+                Err(io::Error::other("private flush detail"))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    impl SyncWrite for TestWriter {
+        fn sync_all(&self) -> io::Result<()> {
+            if self.fail_sync {
+                Err(io::Error::other("private sync detail"))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    fn persist_test_json(
+        contents: &str,
+        writer: TestWriter,
+        read_back: io::Result<String>,
+    ) -> Result<(), String> {
+        persist_and_verify_json(contents, "sync evidence", || Ok(writer), || read_back)
     }
 
     #[test]
@@ -406,5 +524,120 @@ mod tests {
         File::create(&path).expect("create file fixture");
 
         assert_eq!(validate_user_selected_json_write_path(&path), Ok(()));
+    }
+
+    #[test]
+    fn write_selection_accepts_content_uri_only_for_android_policy() {
+        let selection = serde_json::from_str::<FilePath>(
+            "\"content://com.example.documents/document/sync-evidence\"",
+        )
+        .expect("parse content URI");
+
+        assert_eq!(
+            validate_user_selected_json_write_selection_for_platform(&selection, true),
+            Ok(())
+        );
+        assert_eq!(
+            validate_user_selected_json_write_selection_for_platform(&selection, false),
+            Err(JsonFilePathError::NonLocalFileSelection)
+        );
+    }
+
+    #[test]
+    fn write_selection_rejects_other_remote_schemes() {
+        let selection = serde_json::from_str::<FilePath>("\"https://example.test/evidence.json\"")
+            .expect("parse remote URL");
+
+        assert_eq!(
+            validate_user_selected_json_write_selection_for_platform(&selection, true),
+            Err(JsonFilePathError::NonLocalFileSelection)
+        );
+    }
+
+    #[test]
+    fn persistence_requires_exact_valid_readback() {
+        let contents = "{\"privacySafe\":true}";
+
+        assert_eq!(
+            persist_test_json(contents, TestWriter::default(), Ok(contents.to_string())),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn persistence_rejects_write_failure_without_private_detail() {
+        let result = persist_test_json(
+            "{}",
+            TestWriter {
+                fail_write: true,
+                ..Default::default()
+            },
+            Ok("{}".to_string()),
+        );
+
+        assert_eq!(
+            result,
+            Err("Could not write selected sync evidence file.".to_string())
+        );
+    }
+
+    #[test]
+    fn persistence_rejects_flush_and_sync_failures() {
+        let flush_result = persist_test_json(
+            "{}",
+            TestWriter {
+                fail_flush: true,
+                ..Default::default()
+            },
+            Ok("{}".to_string()),
+        );
+        let sync_result = persist_test_json(
+            "{}",
+            TestWriter {
+                fail_sync: true,
+                ..Default::default()
+            },
+            Ok("{}".to_string()),
+        );
+
+        let expected = Err("Could not finish writing selected sync evidence file.".to_string());
+        assert_eq!(flush_result, expected);
+        assert_eq!(sync_result, expected);
+    }
+
+    #[test]
+    fn persistence_rejects_reopen_failure_without_private_detail() {
+        let result = persist_test_json(
+            "{}",
+            TestWriter::default(),
+            Err(io::Error::other("private provider detail")),
+        );
+
+        assert_eq!(
+            result,
+            Err("Could not verify selected sync evidence file.".to_string())
+        );
+    }
+
+    #[test]
+    fn persistence_rejects_empty_malformed_and_mismatched_readback() {
+        let expected = Err("Selected sync evidence file could not be verified.".to_string());
+
+        assert_eq!(
+            persist_test_json("{}", TestWriter::default(), Ok(String::new())),
+            expected
+        );
+        assert_eq!(
+            persist_test_json("{}", TestWriter::default(), Ok("not json".to_string())),
+            expected
+        );
+        assert_eq!(
+            persist_test_json(
+                "{}",
+                TestWriter::default(),
+                Ok("{\"other\":true}".to_string())
+            ),
+            expected
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -359,6 +359,7 @@ pub fn run() {
     let builder = builder.plugin(tauri_plugin_barcode_scanner::init());
 
     let app = builder
+        .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .setup(|app| {

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -51,6 +51,12 @@ import {
   triggerMockIntersectionObserver,
 } from "./test/appTestHarness";
 
+const mockClipboardWriteText = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  writeText: mockClipboardWriteText,
+}));
+
 const irohTransportId = "tuneforge-sync+iroh";
 const tcpTransportId = "tuneforge-sync+tcp";
 const irohEndpointHint = `${irohTransportId}://device_peer_1`;
@@ -206,6 +212,25 @@ function syncRunStatus(overrides: Partial<SyncTransportRunStatus> = {}): SyncTra
       : {}),
     ...overrides,
   };
+}
+
+function setEvidenceSyncResult(suffix: string) {
+  setSyncTransportStatus({
+    active: true,
+    status: "listening",
+    endpoint_hints: listenerEndpointHints,
+    last_sync: syncRunStatus({
+      run_id: `sync_run_${suffix}`,
+      session_id: `sync_session_${suffix}`,
+      message: `Imported proj_${suffix} from device_peer_1.`,
+      project_results: [{
+        project_id: `proj_${suffix}`,
+        status: "imported",
+        message: `Imported proj_${suffix}.`,
+        imported_count: 1,
+      }],
+    }),
+  });
 }
 
 function syncPreflight(overrides: Partial<SyncPreflightResponse> = {}): SyncPreflightResponse {
@@ -406,6 +431,8 @@ function setDocumentVisibility(value: DocumentVisibilityState) {
 describe("Desktop app activity", () => {
   beforeEach(() => {
     resetAppTestHarness();
+    mockClipboardWriteText.mockReset();
+    mockClipboardWriteText.mockResolvedValue(undefined);
   });
 
   it("opens Activity from the sidebar with Jobs selected", async () => {
@@ -4246,8 +4273,98 @@ describe("Desktop app activity", () => {
     expect(exportedJson.projects).toEqual([]);
   });
 
+  it("copies exact privacy-safe evidence through the native Tauri clipboard", async () => {
+    const user = userEvent.setup();
+    const browserWriteText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: browserWriteText },
+    });
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: {},
+    });
+    setEvidenceSyncResult("native_copy_private");
+
+    await openSyncTab(user);
+    await user.click(screen.getByRole("button", { name: "Copy Evidence" }));
+
+    await waitFor(() => expect(mockClipboardWriteText).toHaveBeenCalledWith(expect.any(String)));
+    const copiedText = mockClipboardWriteText.mock.calls[0]?.[0] as string;
+    expect(JSON.parse(copiedText)).toMatchObject({
+      scenario: "listener-last-sync",
+      validation: { privacySafe: true },
+    });
+    expect(copiedText).not.toContain("proj_native_copy_private");
+    expect(copiedText).not.toContain("device_peer_1");
+    expect(browserWriteText).not.toHaveBeenCalled();
+    expect(await screen.findByText("Sync evidence copied.")).toBeInTheDocument();
+  });
+
+  it("reports native clipboard failure safely without browser fallback", async () => {
+    const user = userEvent.setup();
+    const browserWriteText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: browserWriteText },
+    });
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: {},
+    });
+    mockClipboardWriteText.mockRejectedValue(
+      new Error("Clipboard rejected /private/sync_run_native_copy_failure"),
+    );
+    setEvidenceSyncResult("native_copy_failure");
+
+    await openSyncTab(user);
+    await user.click(screen.getByRole("button", { name: "Copy Evidence" }));
+
+    expect(await screen.findByText("Could not copy sync evidence. Try again.")).toBeInTheDocument();
+    expect(screen.queryByText("Sync evidence copied.")).not.toBeInTheDocument();
+    expect(screen.queryByText(/private\/sync_run/)).not.toBeInTheDocument();
+    expect(browserWriteText).not.toHaveBeenCalled();
+  });
+
+  it("disables both evidence actions while a native copy is unresolved", async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: {},
+    });
+    let resolveClipboard: (() => void) | undefined;
+    const pendingClipboard = new Promise<void>((resolve) => {
+      resolveClipboard = resolve;
+    });
+    mockClipboardWriteText.mockReturnValue(pendingClipboard);
+    setEvidenceSyncResult("native_copy_pending");
+
+    await openSyncTab(user);
+    await user.click(screen.getByRole("button", { name: "Copy Evidence" }));
+    await waitFor(() => expect(mockClipboardWriteText).toHaveBeenCalledOnce());
+    const copyButton = screen.getByRole("button", { name: "Copy Evidence" });
+    const exportButton = screen.getByRole("button", { name: "Export Evidence" });
+    expect(copyButton).toBeDisabled();
+    expect(exportButton).toBeDisabled();
+
+    fireEvent.click(copyButton);
+    fireEvent.click(exportButton);
+    expect(mockClipboardWriteText).toHaveBeenCalledOnce();
+    expect(getMockInvoke().mock.calls.some(([command]) => command === "write_sync_evidence_file")).toBe(false);
+
+    await act(async () => resolveClipboard?.());
+    expect(await screen.findByText("Sync evidence copied.")).toBeInTheDocument();
+    expect(copyButton).toBeEnabled();
+    expect(exportButton).toBeEnabled();
+  });
+
   it("exports evidence through the Tauri save command when available", async () => {
     const user = userEvent.setup();
+    const browserWriteText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: browserWriteText },
+    });
     Object.defineProperty(window, "__TAURI_INTERNALS__", {
       configurable: true,
       value: {},
@@ -4283,8 +4400,11 @@ describe("Desktop app activity", () => {
     );
     const writeCall = mockInvoke.mock.calls.find(([command]) => command === "write_sync_evidence_file");
     expect(writeCall).toBeDefined();
-    const exportedJson = JSON.parse((writeCall?.[1] as { contents: string }).contents) as Record<string, unknown>;
-    expect(await screen.findByText(/Sync evidence exported/)).toBeInTheDocument();
+    const exportedText = (writeCall?.[1] as { contents: string }).contents;
+    const exportedJson = JSON.parse(exportedText) as Record<string, unknown>;
+    await waitFor(() => expect(mockClipboardWriteText).toHaveBeenCalledWith(exportedText));
+    expect(await screen.findByText("Sync evidence exported and copied.")).toBeInTheDocument();
+    expect(browserWriteText).not.toHaveBeenCalled();
     expect(exportedJson.scenario).toBe("listener-last-sync");
     expect(exportedJson.run).toMatchObject({
       label: "Run 1",
@@ -4296,13 +4416,25 @@ describe("Desktop app activity", () => {
     expect(JSON.stringify(exportedJson)).not.toContain("device_peer_1");
   });
 
+  it("keeps verified export success when opportunistic native copy fails", async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: {},
+    });
+    mockClipboardWriteText.mockRejectedValue(new Error("Clipboard unavailable at /private/provider"));
+    setEvidenceSyncResult("export_copy_failure");
+
+    await openSyncTab(user);
+    await user.click(screen.getByRole("button", { name: "Export Evidence" }));
+
+    expect(await screen.findByText("Sync evidence exported.")).toBeInTheDocument();
+    expect(screen.queryByText(/Could not copy sync evidence/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/private\/provider/)).not.toBeInTheDocument();
+  });
+
   it("keeps canceled Tauri evidence export quiet", async () => {
     const user = userEvent.setup();
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: { writeText },
-    });
     Object.defineProperty(window, "__TAURI_INTERNALS__", {
       configurable: true,
       value: {},
@@ -4344,7 +4476,7 @@ describe("Desktop app activity", () => {
         "write_sync_evidence_file",
         expect.objectContaining({ defaultFileName: expect.any(String) }),
       ));
-      expect(writeText).not.toHaveBeenCalled();
+      expect(mockClipboardWriteText).not.toHaveBeenCalled();
       expect(screen.queryByText(/Sync evidence exported/)).not.toBeInTheDocument();
       expect(screen.queryByText(/Could not export sync evidence/)).not.toBeInTheDocument();
     } finally {
@@ -4396,6 +4528,7 @@ describe("Desktop app activity", () => {
       ).toBeInTheDocument();
       expect(screen.queryByText(/\/Users\/test\/private/)).not.toBeInTheDocument();
       expect(screen.queryByText(/Sync evidence exported/)).not.toBeInTheDocument();
+      expect(mockClipboardWriteText).not.toHaveBeenCalled();
     } finally {
       mockInvoke.mockImplementation(defaultInvoke);
     }

--- a/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
+++ b/apps/desktop/src/features/activity/ActivitySyncPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { invoke, isTauri } from "@tauri-apps/api/core";
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { QRCodeSVG } from "qrcode.react";
 import {
   api,
@@ -192,6 +193,14 @@ function formatTimestamp(value: string | null | undefined) {
 }
 
 async function copyToClipboard(value: string, source?: HTMLTextAreaElement | null) {
+  if (isTauri()) {
+    try {
+      await writeText(value);
+      return true;
+    } catch {
+      return false;
+    }
+  }
   if (navigator.clipboard?.writeText) {
     try {
       await navigator.clipboard.writeText(value);
@@ -2122,6 +2131,7 @@ export function ActivitySyncPanel() {
   const [syncNowPolling, setSyncNowPolling] = useState(false);
   const [evidenceMessage, setEvidenceMessage] = useState<string | null>(null);
   const [evidenceError, setEvidenceError] = useState<string | null>(null);
+	const [evidenceActionPending, setEvidenceActionPending] = useState(false);
 	useSyncExternalStore(
 	  subscribePowerInhibition,
 	  getPowerInhibitionVersion,
@@ -2133,6 +2143,7 @@ export function ActivitySyncPanel() {
 	  const refreshedProjectSyncKeyRef = useRef<string | null>(null);
 	  const desktopLifecycleLastObservedAtRef = useRef(Date.now());
 	  const desktopLifecyclePassiveAwayRef = useRef(false);
+	  const evidenceActionPendingRef = useRef(false);
 
   const identityQuery = useQuery({
     queryKey: ["sync", "identity"],
@@ -2710,38 +2721,48 @@ export function ActivitySyncPanel() {
   }
 
   async function handleCopySyncEvidence() {
-    const evidence = buildCurrentSyncEvidenceFile();
-    if (!evidence) {
-      setEvidenceError("No sync result available to copy.");
-      setEvidenceMessage(null);
+    if (evidenceActionPendingRef.current) {
       return;
     }
+    evidenceActionPendingRef.current = true;
+    setEvidenceActionPending(true);
+    setEvidenceError(null);
+    setEvidenceMessage(null);
+    const evidence = buildCurrentSyncEvidenceFile();
     try {
-      const copied = await copyToClipboard(evidence.json);
-      if (!copied) {
-        setEvidenceMessage(null);
-        setEvidenceError("Could not copy sync evidence.");
+      if (!evidence) {
+        setEvidenceError("No sync result available to copy.");
         return;
       }
-      setEvidenceError(null);
+      const copied = await copyToClipboard(evidence.json);
+      if (!copied) {
+        setEvidenceError("Could not copy sync evidence. Try again.");
+        return;
+      }
       setEvidenceMessage("Sync evidence copied.");
     } catch {
-      setEvidenceMessage(null);
-      setEvidenceError("Could not copy sync evidence.");
+      setEvidenceError("Could not copy sync evidence. Try again.");
+    } finally {
+      evidenceActionPendingRef.current = false;
+      setEvidenceActionPending(false);
     }
   }
 
   async function handleExportSyncEvidence() {
-    const evidence = buildCurrentSyncEvidenceFile();
-    if (!evidence) {
-      setEvidenceError("No sync result available to export.");
-      setEvidenceMessage(null);
+    if (evidenceActionPendingRef.current) {
       return;
     }
+    evidenceActionPendingRef.current = true;
+    setEvidenceActionPending(true);
     setEvidenceError(null);
     setEvidenceMessage(null);
+    const evidence = buildCurrentSyncEvidenceFile();
 
     try {
+      if (!evidence) {
+        setEvidenceError("No sync result available to export.");
+        return;
+      }
       if (isTauri()) {
         const saved = await saveSyncEvidenceJson(evidence.fileName, evidence.json);
         if (!saved) {
@@ -2754,7 +2775,6 @@ export function ActivitySyncPanel() {
         } catch {
           copied = false;
         }
-        setEvidenceError(null);
         setEvidenceMessage(copied ? "Sync evidence exported and copied." : "Sync evidence exported.");
         return;
       }
@@ -2766,11 +2786,12 @@ export function ActivitySyncPanel() {
         copied = false;
       }
       downloadSyncEvidenceJson(evidence.fileName, evidence.json);
-      setEvidenceError(null);
       setEvidenceMessage(copied ? "Sync evidence exported and copied." : "Sync evidence exported.");
-    } catch (error) {
-      setEvidenceMessage(null);
-      setEvidenceError(error instanceof Error ? error.message : "Could not export sync evidence.");
+    } catch {
+      setEvidenceError("Could not export sync evidence. Choose another location and try again.");
+    } finally {
+      evidenceActionPendingRef.current = false;
+      setEvidenceActionPending(false);
     }
   }
 
@@ -2869,7 +2890,7 @@ export function ActivitySyncPanel() {
               ) : null}
               <button
                 className="button button--ghost button--small"
-                disabled={!visibleSyncResult}
+                disabled={!visibleSyncResult || evidenceActionPending}
                 onClick={handleCopySyncEvidence}
                 type="button"
               >
@@ -2877,7 +2898,7 @@ export function ActivitySyncPanel() {
               </button>
               <button
                 className="button button--ghost button--small"
-                disabled={!visibleSyncResult}
+                disabled={!visibleSyncResult || evidenceActionPending}
                 onClick={handleExportSyncEvidence}
                 type="button"
               >

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@tauri-apps/plugin-barcode-scanner':
         specifier: ~2.4.5
         version: 2.4.5
+      '@tauri-apps/plugin-clipboard-manager':
+        specifier: ^2.3.2
+        version: 2.3.2
       '@tauri-apps/plugin-dialog':
         specifier: ^2.7.2
         version: 2.7.2
@@ -684,6 +687,9 @@ packages:
 
   '@tauri-apps/plugin-barcode-scanner@2.4.5':
     resolution: {integrity: sha512-sIPRYEfxww8/y8skZ2LcAp/h5bwvlHkQiq+3w6QEl+2BHs13xnpn7hP+pv4fkBs8DyDfpUbOBIYS5YBwP7x1QQ==}
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
 
   '@tauri-apps/plugin-dialog@2.7.2':
     resolution: {integrity: sha512-pX0IGm1I3I6wc+zeKYcq1GSqogK6okCNX5fOdaNU5ab1AjGS6l1E5wFNjEb7meg7ZFSp0JUs+0jQGQNyOvLrsg==}
@@ -2540,6 +2546,10 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.11.4
 
   '@tauri-apps/plugin-barcode-scanner@2.4.5':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
     dependencies:
       '@tauri-apps/api': 2.11.1
 


### PR DESCRIPTION
## Summary

- Route sync-evidence copy through write-only native clipboard access in Tauri runtimes.
- Support Android content-provider exports and verify saved JSON by reopening and exact comparison.
- Serialize copy/export actions, preserve desktop path safety, and add regression coverage.
- Closes #411.

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `cd apps/desktop/src-tauri && cargo fmt --check`
- `cd apps/desktop/src-tauri && cargo check`
- `cd apps/desktop/src-tauri && cargo test file_dialog_scope`
- `cd apps/desktop && ./node_modules/.bin/vitest run src/App.activity.test.tsx`
- `pnpm package:android`
- `pnpm test` — changed suites passed; two unrelated timing flakes passed their exact reruns.
- Headed Android emulators: paired fresh AVDs, completed a no-op sync, validated clipboard JSON, and verified provider export readback.
- `pnpm dev` plus desktop-to-physical-device sync (user-performed).
