### PR TITLE
fix: standardize diagnostics git refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
           node-version: "22"
 
       - name: Test deterministic Node scripts
-        run: node --test scripts/package-options.test.mjs scripts/flatpak-options.test.mjs scripts/playback-smoke.test.mjs scripts/sync-validation.test.mjs scripts/release-license-inventory.test.mjs scripts/capture-release-media.test.mjs
+        run: node --test scripts/build-info.test.mjs scripts/package-options.test.mjs scripts/flatpak-options.test.mjs scripts/playback-smoke.test.mjs scripts/sync-validation.test.mjs scripts/release-license-inventory.test.mjs scripts/capture-release-media.test.mjs
 
       - name: Check release script syntax
         run: |

--- a/apps/backend/app/version.py
+++ b/apps/backend/app/version.py
@@ -116,7 +116,7 @@ def _git_ref(workspace_root: Path | None) -> str:
         return UNKNOWN_VERSION
     try:
         return subprocess.run(
-            ["git", "describe", "--tags", "--long", "--dirty", "--always"],
+            ["git", "describe", "--tags", "--long", "--dirty", "--always", "--abbrev=8"],
             cwd=workspace_root,
             check=True,
             capture_output=True,

--- a/apps/backend/tests/test_version.py
+++ b/apps/backend/tests/test_version.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+from unittest.mock import Mock
+
+from app import version
+
+
+def test_git_ref_requests_at_least_eight_hex_digits(monkeypatch) -> None:
+    monkeypatch.delenv("TUNEFORGE_GIT_REF", raising=False)
+    run = Mock(return_value=Mock(stdout="v1.2.3-4-g12345678-dirty\n"))
+    monkeypatch.setattr(version.subprocess, "run", run)
+    workspace_root = Path("/workspace")
+
+    assert version._git_ref(workspace_root) == "v1.2.3-4-g12345678-dirty"
+    run.assert_called_once_with(
+        ["git", "describe", "--tags", "--long", "--dirty", "--always", "--abbrev=8"],
+        cwd=workspace_root,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=2,
+    )

--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -12,7 +12,14 @@ fn git_ref() -> Option<String> {
         .filter(|value| !value.trim().is_empty())
         .or_else(|| {
             std::process::Command::new("git")
-                .args(["describe", "--tags", "--long", "--dirty", "--always"])
+                .args([
+                    "describe",
+                    "--tags",
+                    "--long",
+                    "--dirty",
+                    "--always",
+                    "--abbrev=8",
+                ])
                 .output()
                 .ok()
                 .filter(|output| output.status.success())

--- a/docs/API.md
+++ b/docs/API.md
@@ -140,7 +140,7 @@ Important fields:
 
 Returns backend name, legacy backend git ref in `version`, backend/frontend package versions and git refs, status,
 API base URL, data root, default export format, and preview format. Build git refs use the packaged build
-metadata when available, otherwise local development resolves them with `git describe --tags --long --dirty --always`.
+metadata when available, otherwise local development resolves them with `git describe --tags --long --dirty --always --abbrev=8`.
 
 ## Beat Backends
 

--- a/scripts/build-info.mjs
+++ b/scripts/build-info.mjs
@@ -59,7 +59,7 @@ function resolveGitRef(workspaceRoot) {
   }
 
   try {
-    return execFileSync("git", ["describe", "--tags", "--long", "--dirty", "--always"], {
+    return execFileSync("git", ["describe", "--tags", "--long", "--dirty", "--always", "--abbrev=8"], {
       cwd: workspaceRoot,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],

--- a/scripts/build-info.test.mjs
+++ b/scripts/build-info.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { resolveBuildInfo } from "./build-info.mjs";
+
+function runGit(repository, args) {
+  return execFileSync("git", args, {
+    cwd: repository,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+test("git fallback uses matching minimum eight-digit refs and preserves dirty state", () => {
+  const repository = mkdtempSync(path.join(os.tmpdir(), "tuneforge-build-info-"));
+  const originalGitRef = process.env.TUNEFORGE_GIT_REF;
+
+  try {
+    delete process.env.TUNEFORGE_GIT_REF;
+    runGit(repository, ["init", "--quiet"]);
+    runGit(repository, ["config", "core.abbrev", "7"]);
+    writeFileSync(path.join(repository, "tracked.txt"), "clean\n");
+    runGit(repository, ["add", "tracked.txt"]);
+    runGit(repository, [
+      "-c",
+      "user.name=TuneForge Tests",
+      "-c",
+      "user.email=tests@example.invalid",
+      "-c",
+      "commit.gpgSign=false",
+      "commit",
+      "--quiet",
+      "--no-gpg-sign",
+      "-m",
+      "initial",
+    ]);
+    runGit(repository, ["-c", "tag.gpgSign=false", "tag", "v1.2.3"]);
+
+    const clean = resolveBuildInfo({ workspaceRoot: repository, versionFilePath: null });
+    assert.match(clean.backend.git_ref, /^v1\.2\.3-0-g[0-9a-f]{8,}$/);
+    assert.equal(clean.frontend.git_ref, clean.backend.git_ref);
+
+    writeFileSync(path.join(repository, "tracked.txt"), "dirty\n");
+    const dirty = resolveBuildInfo({ workspaceRoot: repository, versionFilePath: null });
+    assert.equal(dirty.backend.git_ref, `${clean.backend.git_ref}-dirty`);
+    assert.equal(dirty.frontend.git_ref, dirty.backend.git_ref);
+  } finally {
+    if (originalGitRef === undefined) {
+      delete process.env.TUNEFORGE_GIT_REF;
+    } else {
+      process.env.TUNEFORGE_GIT_REF = originalGitRef;
+    }
+    rmSync(repository, { recursive: true, force: true });
+  }
+});

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -5,6 +5,15 @@ repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 
 total_start=${SECONDS}
 
+printf '\n[tests] Starting build info tests\n\n'
+build_info_start=${SECONDS}
+(
+  cd "${repo_root}"
+  node --test scripts/build-info.test.mjs
+)
+build_info_elapsed=$((SECONDS - build_info_start))
+printf '\n[tests] Build info tests finished in %ss\n' "${build_info_elapsed}"
+
 printf '\n[tests] Starting desktop tests\n\n'
 desktop_start=${SECONDS}
 (


### PR DESCRIPTION
## Summary

- Pin backend, frontend, and Tauri Git fallbacks to minimum eight-digit commit abbreviations.
- Fix cross-platform diagnostic drift caused by Git's environment-dependent default abbreviation.
- Add focused regression coverage, local and CI registration, and API documentation.

## Testing

- `node --test scripts/build-info.test.mjs` — 1 passed.
- `cd apps/backend && uv run --python 3.11 pytest tests/test_version.py` — 1 passed.
- Ruff, Node syntax, shell syntax, `cargo fmt --check`, `cargo check`, `pnpm lint`, `pnpm typecheck`, and `git diff --check` passed.
- `pnpm test` — desktop 718/718, Tauri 321/321, backend 678/679; `tests/test_lyrics_flow.py::test_import_queues_lyrics_generation` timed out once.
- Isolated rerun of the timed-out backend test passed in 2.17 seconds.
