### PR TITLE
fix(packaging): allow Flatpak logind inhibition

### DIFF
--- a/packaging/flatpak/com.tuneforge.desktop.yml
+++ b/packaging/flatpak/com.tuneforge.desktop.yml
@@ -19,6 +19,7 @@ finish-args:
   - --filesystem=xdg-cache/whisper:create
   - --talk-name=org.freedesktop.portal.Desktop
   - --talk-name=org.freedesktop.portal.Documents
+  - --system-talk-name=org.freedesktop.login1
   - --env=TUNEFORGE_BUNDLED_BACKEND_ROOT=/app/lib/tuneforge/backend
   - --env=TUNEFORGE_DATA_DIR=~/.local/share/tuneforge
   - --env=TUNEFORGE_FFMPEG_PATH=/app/bin/ffmpeg

--- a/scripts/flatpak-options.test.mjs
+++ b/scripts/flatpak-options.test.mjs
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 import { buildModelBundlePlan } from "./model-bundle-metadata.mjs";
+
+const flatpakManifest = readFileSync(
+  new URL("../packaging/flatpak/com.tuneforge.desktop.yml", import.meta.url),
+  "utf8",
+);
 
 const demucsManifest = {
   rootUrl: "https://example.invalid/models/",
@@ -53,4 +59,8 @@ test("model bundle plan includes beat-this only when requested", () => {
     withBeatThis.sources.some((source) => source["dest-filename"] === "beat_this-small0.ckpt"),
     true,
   );
+});
+
+test("Flatpak manifest allows the logind inhibition fallback", () => {
+  assert.match(flatpakManifest, /^\s+- --system-talk-name=org\.freedesktop\.login1$/m);
 });


### PR DESCRIPTION
## Summary

- Grant the Linux Flatpak permission to talk to `org.freedesktop.login1`.
- Cover the permission with a focused manifest assertion test.

## Testing

- `node --test scripts/flatpak-options.test.mjs`
- `git diff --check HEAD~1..HEAD`
- Full Flatpak rebuild not run because it takes about one hour on this machine; runtime validation will happen from the PR/merge artifact.
