### PR TITLE
docs: add power protection guide

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -17,6 +17,7 @@ Use the root `AGENTS.md` for global product/safety constraints. This file adds d
 - `SPEC.md`: product behavior/spec details.
 - `API.md`: API behavior and contracts.
 - `NATIVE_AUDIO.md`: native/Web Audio behavior and manual playback QA.
+- `POWER_PROTECTION.md`: cross-platform wake, sleep, and power-inhibition behavior.
 - `PACKAGING.md`: desktop package commands, package flags, and local install notes.
 - `ROADMAP.md`: planned work and sequencing.
 - `STEM_SEPARATION.md`: Demucs models, cache/bundle behavior, and stem validation notes.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -215,6 +215,7 @@ Validation failures return `INVALID_REQUEST` with serialized validation details.
 - Native desktop tempo playback uses `signalsmith-stretch` for pitch preservation.
 - Native desktop playback decodes local files through a WAV fast path or Symphonia. FFmpeg remains a host dependency for transform/export work.
 - Native audio development notes live in [NATIVE_AUDIO.md](NATIVE_AUDIO.md).
+- Cross-platform wake, sleep, and power-inhibition behavior lives in [POWER_PROTECTION.md](POWER_PROTECTION.md).
 - Desktop system microphone volume control uses CoreAudio on macOS, or host `wpctl`/`pactl` tools on Linux with an active PipeWire/PulseAudio session.
 - Advanced Chords and Advanced Beat Analysis are default desktop/dev/package engines. Packaged builds must treat crema, its bundled chord model files, TensorFlow/Keras, h5py/HDF5, gRPC/Protobuf, TensorBoard, beat-this, and its runtime dependencies as default-runtime notice scope. Built-in chord and beat engines remain fallback paths when advanced dependencies are unavailable, unsupported, or explicitly excluded.
 - Demucs and lyrics models follow first-use local download/cache behavior.

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -184,25 +184,28 @@ input level. Settings keeps native capability, selection policy, permission, cur
 confirmed path, and latest safe historical failure as separate facts. Active capture is never
 restored after reload.
 
-Android power protection follows confirmed work automatically; no manual toggle exists. Confirmed
-native tuner capture keeps the visible Activity screen on through `keepScreenOn`. Tuner-only
-protection starts no foreground service, notification, or partial wake lock and does not claim
-background microphone continuation. Confirmed native playback uses a `mediaPlayback` foreground
-service and also keeps the foreground Activity screen on. An active sync listener uses
-`connectedDevice`, and an active transfer also uses `dataSync`. Listener and transfer work hold a
-bounded, renewable partial wake lock; playback relies on Android's media path for CPU wakefulness.
-The ongoing notification states whether playback, sync, or both are active; tuner-only work never
-requests notification permission. Tuner capture, playback, listener, and transfer are independent
-owners. Stop, interruption, suspension, natural end, fallback, transfer completion/cancellation/
-failure, and app shutdown clear only the corresponding reason. Shared protection releases after the
-final owner exits.
+Android power protection follows confirmed work automatically; no manual toggle exists. See
+[POWER_PROTECTION.md](./POWER_PROTECTION.md) for the shared owner, backend, diagnostic, and
+validation model. Android-specific behavior remains:
+
+- Confirmed native tuner capture keeps the visible Activity screen on through `keepScreenOn`.
+  Tuner-only protection starts no foreground service, notification, or partial wake lock and does
+  not claim background microphone continuation.
+- Confirmed native playback uses a `mediaPlayback` foreground service and also keeps the foreground
+  Activity screen on.
+- An active sync listener uses `connectedDevice`, and an active transfer also uses `dataSync`.
+  Listener and transfer work hold a bounded, renewable partial wake lock; playback relies on
+  Android's media path for CPU wakefulness.
+- The ongoing notification states whether playback, sync, or both are active; tuner-only work never
+  requests notification permission.
+
 On Android 13 and newer, TuneForge requests notification permission only when a user action starts
 protected playback or sync work. Denial does not cancel that work; diagnostics report the missing
 notification visibility while Android's system active-app controls remain available.
 
 Settings diagnostics distinguish acquiring, active, unsupported, failed, releasing, and
-release-not-confirmed states. They report `android-activity-screen` with confirmed screen coverage
-and no background coverage only for tuner-only protection. Playback or sync service ownership uses
+`release-failed` states. They report `android-activity-screen` with confirmed screen coverage and no
+background coverage only for tuner-only protection. Playback or sync service ownership uses
 `android-foreground-service`; combined tuner/service transitions preserve both owners. Tuner,
 Activity -> Sync, and playback status show concise reliability warnings for unsupported or failed
 protection without changing capture or work state. Android 15 `dataSync` timeout is reported as a
@@ -272,7 +275,8 @@ network recovery/interruption. Offline interruptions may expose native retry gui
 peer ID; when they do, the UI shows Retry Sync and reuses the normal preflight plus Sync Now path,
 including nearby endpoint hints.
 
-Also inspect Android service and power state with `adb`: confirmed playback must show the
+Also inspect Android service and power state with `adb` using the evidence model in
+[POWER_PROTECTION.md](./POWER_PROTECTION.md#validation): confirmed playback must show the
 `mediaPlayback` foreground-service type; listener and transfer must add `connectedDevice` and
 `dataSync` as applicable. Confirmed tuner-only capture must keep the visible screen awake without a
 `PowerInhibitionService` foreground-service entry, notification, or partial wake lock. Verify tuner
@@ -280,9 +284,7 @@ stop, interruption, and Android suspension restore normal screen timeout; then o
 playback and sync owners to confirm each release preserves remaining work. Notification copy must
 match active service work. Verify every terminal path clears its reason, and exercise a shortened
 Android 15 data-sync timeout in a synthetic debug run. A live transfer still requires an isolated
-desktop peer; automated lifecycle tests do not prove that end-to-end path. macOS `pmset` and Linux
-portal/logind inhibitor evidence also remain manual platform checks; unit tests prove ownership, not
-OS handle behavior.
+desktop peer; automated lifecycle tests do not prove that end-to-end path.
 
 Desktop sleep/wake has no native command bridge. The UI uses an elapsed-time check while visible: a
 long timer gap records `sleep` followed by `wake`, while ordinary desktop hidden/blur/pagehide remains

--- a/docs/NATIVE_AUDIO.md
+++ b/docs/NATIVE_AUDIO.md
@@ -36,7 +36,9 @@ falls back to `getUserMedia` after a capability, permission, startup, or stream 
 `VITE_TUNEFORGE_FORCE_WEB_AUDIO=1` development override remains an explicit all-Web mode for both
 tuner capture and playback.
 
-Playback owns media-key controls, while playback and tuner capture share counted power protection:
+Playback owns media-key controls, while playback and tuner capture participate in TuneForge's
+shared power-protection model. See [POWER_PROTECTION.md](./POWER_PROTECTION.md) for the
+cross-platform owner, backend, diagnostic, and validation rules.
 
 - TuneForge registers one desktop system-media adapter with the OS for media keys and headset
   controls. That adapter does not choose the audio engine; it routes play/pause/stop/seek events to
@@ -182,11 +184,8 @@ BlackHole capture are release checks, not default `pnpm test` coverage.
 | Native runtime fallback ownership | system state/inhibition clear before Web Audio starts at fallback position, then system controls route to Web Audio | same | not applicable; web owns controls from start |
 | Fallback + no output device | falls back (or errors and recovers) without crash when no native output exists | same | same |
 
-For manual Linux inhibition validation, record distro, desktop/session, and package type. Start
-confirmed native playback and verify TuneForge appears in the desktop inhibitor detector. Pause,
-stop, natural end, playback failure, fallback, and app exit must each clear it. Repeat one
-start/stop cycle to detect a leaked handle. Settings diagnostics must name the same live backend
-(`xdg-desktop-portal` or `systemd-logind`) and return to `Inactive` after release.
+For manual Linux, macOS, Android, and browser power validation, use the owner-specific evidence and
+release checks in [POWER_PROTECTION.md](./POWER_PROTECTION.md#validation).
 
 ## Local-only Playwright Smoke Harness
 

--- a/docs/POWER_PROTECTION.md
+++ b/docs/POWER_PROTECTION.md
@@ -1,0 +1,114 @@
+# Power Protection
+
+TuneForge power protection is the shared wake, sleep, and idle-inhibition model used while
+confirmed playback, tuner capture, or sync work is active. It is automatic; there is no user-facing
+toggle.
+
+Power protection prevents supported devices from sleeping, dimming, or suspending active work while
+TuneForge has a confirmed owner. It does not promise background microphone capture on platforms that
+do not support it, does not keep work alive after the final owner exits, and does not replace normal
+platform permission or notification rules.
+
+## Ownership Model
+
+TuneForge tracks power protection through counted owners:
+
+- `playback`: confirmed native or Web Audio playback.
+- `tuner-capture`: confirmed native or Web Audio tuner capture.
+- `sync-listener`: active sync listener.
+- `sync-transfer`: active sync transfer.
+
+Pending user intent, permission prompts, native prepare work, and failed starts do not acquire
+protection. Stop, interruption, suspension, natural end, fallback, transfer completion,
+cancellation, failure, and app shutdown release only the corresponding owner. Shared protection
+releases after the final owner exits.
+
+Native fallback is an explicit ownership transfer. TuneForge clears native playback ownership from
+system media state and power protection before starting Web Audio at the fallback position, then
+reacquires the browser wake lock after Web playback is confirmed. Other active owners continue to
+hold shared protection.
+
+## Platform Matrix
+
+| Platform or path | Backend label | Screen protected | Background protected | Notes |
+| --- | --- | --- | --- | --- |
+| macOS native | `macos-iopm` | Yes | Yes | Uses an IOPM display sleep assertion while confirmed work is active. |
+| Linux native portal | `xdg-desktop-portal` | Yes | Yes | Preferred Linux path when the desktop portal accepts inhibition. |
+| Linux native logind | `systemd-logind` | Yes | Yes | Fallback path through `org.freedesktop.login1`; TuneForge passes `sleep:idle`, `TuneForge`, the active-work reason, and `block`. |
+| Android tuner-only | `android-activity-screen` | Yes | No | Keeps the visible Activity screen on through `keepScreenOn`; no foreground service, notification, or partial wake lock. |
+| Android playback or sync | `android-foreground-service` | Playback or transfer only | Yes | Uses foreground-service ownership for playback and sync work; sync listener/transfer also hold a bounded renewable partial wake lock. |
+| Browser playback or tuner | `browser-screen-wake-lock` | Yes | No | Uses the browser Screen Wake Lock API for confirmed Web Audio owners only. |
+
+Android playback uses a `mediaPlayback` foreground service and keeps the foreground Activity screen
+on. An active sync listener uses `connectedDevice`; an active transfer also uses `dataSync`.
+Playback and transfer keep the foreground Activity screen on when visible; listener-only sync does
+not claim screen protection. Playback relies on Android's media path for CPU wakefulness, while
+listener and transfer work hold a bounded renewable partial wake lock. Android 15 `dataSync` timeout
+is reported as a power-protection failure, clears the transfer reason, and does not mark the
+transfer complete.
+
+On Android 13 and newer, TuneForge requests notification permission only when a user action starts
+protected playback or sync work. Denial does not cancel that work; diagnostics report missing
+notification visibility while Android's system active-app controls remain available. Tuner-only work
+never requests notification permission.
+
+## Diagnostics
+
+Settings -> Local Data -> Show diagnostics reports:
+
+- current power-protection phase: acquiring, active, unsupported, failed, releasing, or
+  `release-failed` shown as Release not confirmed;
+- confirmed backend;
+- active reasons;
+- separately confirmed screen and background coverage;
+- latest safe power-protection error;
+- last confirmed native backend remembered across reload.
+
+Active power state is never restored from local storage. Only a safe historical backend and safe
+historical error may survive reload. Reliability warnings for unsupported or failed protection do
+not change playback, capture, or sync truth.
+
+## Validation
+
+Manual validation must record platform, OS version, desktop/session when applicable, package type,
+backend label, active reasons, and release path.
+
+For each owner being validated:
+
+1. Confirm there is no stale inhibitor, wake lock, or foreground-service entry before the start.
+2. Start the work and wait for the relevant TuneForge owner to be confirmed.
+3. Verify diagnostics show the expected backend, phase, owner reasons, and screen/background
+   coverage.
+4. Verify platform evidence while work is active.
+5. Stop through every relevant terminal path and verify diagnostics return to inactive after the
+   final owner exits.
+6. Repeat one start/stop cycle to catch leaked handles.
+
+Recommended platform evidence:
+
+- macOS: inspect `pmset` inhibition state while confirmed native work is active and after release.
+- Linux: inspect desktop portal or `systemd-inhibit --list --mode=block --no-pager` evidence while
+  confirmed native work is active and after release.
+- Android: inspect foreground-service type, notification copy, screen state, and wake-lock behavior
+  with `adb`.
+- Browser/Web Audio: verify browser Screen Wake Lock activation and release through diagnostics and
+  visible screen behavior.
+
+Local unit tests prove TuneForge ownership transitions. They do not prove live OS handle behavior,
+portal behavior, Flatpak mediation, Android foreground-service behavior, or device power policy.
+
+## Linux Flatpak Attribution
+
+When the Linux Flatpak falls back to `systemd-logind`, host tools may show `COMM=xdg-dbus-proxy`.
+This is expected because Flatpak mediates DBus access through its proxy. Treat the run as valid when
+all of these are true:
+
+- `WHO=TuneForge`;
+- `WHAT=sleep:idle`;
+- `WHY` matches TuneForge active work;
+- `MODE=block`;
+- TuneForge diagnostics report `systemd-logind` and the expected owner state;
+- the inhibitor releases after pause, stop, fallback, natural end, failure, or app exit.
+
+Do not add host helpers, broader DBus access, telemetry, or new services only to change the host
+diagnostic `COMM` column.


### PR DESCRIPTION
## Summary

- Add a canonical cross-platform power protection guide.
- Link native audio, mobile, architecture, and docs guidance to the new guide.
- Document validation expectations and the Flatpak logind `COMM=xdg-dbus-proxy` caveat.

## Testing

- `git diff --check`
- `git diff --no-index --check /dev/null docs/POWER_PROTECTION.md`
- `rg -n "POWER_PROTECTION|power protection|inhibition|wake|sleep" docs`
