### PR TITLE
docs: make coordinator plan first

### DIFF
--- a/.agents/skills/coordinate-tuneforge-work/SKILL.md
+++ b/.agents/skills/coordinate-tuneforge-work/SKILL.md
@@ -1,183 +1,136 @@
 ---
 name: coordinate-tuneforge-work
-description: Coordinate bounded TuneForge implementation or evidence-based research without editing in the coordinator. Use for selecting the next issue from a canonical release-plan tracker, delivering a known issue, or carrying an ad hoc change or research question through scoped delegation, proportionate validation and review, single-versus-stacked PR planning when code changes are authorized, and one bounded remediation cycle; never create or update GitHub planning state unless requested, and require separate publication authority.
+description: Plan-first coordination for bounded TuneForge implementation or evidence-based research with local delivery by default. Use when selecting milestone work from a release-plan tracker, planning a known issue or ad hoc change, exploring a bug, or coordinating approved local execution, validation, and review; choose normal versus stacked delivery when relevant and publish only with later explicit authority.
 ---
 
 # Coordinate TuneForge Work
 
-Keep this chat coordinator-only and delegate work. Never alter
-installed-app data or start, stop, restart, or wipe a user-owned desktop app.
-Do not create a branch, commit, push, open a PR, or merge unless the user grants
-the corresponding authority.
+Keep this chat coordinator-only and delegate work. Never alter installed-app
+data or start, stop, restart, or wipe a user-owned desktop app.
 
-Read [prompt-examples.md](references/prompt-examples.md) when the user asks for
-a copyable invocation or a Plan-to-Goal workflow.
+## Lifecycle Contract
 
-## Select Entry Mode and Work Kind
+Use Plan-first as the core lifecycle:
 
-Classify the request before preflight:
+1. Without an approved plan, perform read-only preflight and produce a
+   decision-complete plan only.
+2. After plan approval and explicit local execution authority, implement,
+   validate, review, and remediate locally.
+3. Stop before publication unless the user later explicitly authorizes it.
+
+Collaboration mode selection and transitions are user-owned. Never invoke
+`/plan` or `/goal`, change modes, or create or expand a Goal. A Goal is
+optional and does not broaden execution or publication authority.
+
+Read [prompt-examples.md](references/prompt-examples.md) for initial
+Plan-first invocations and user-owned post-plan paths.
+
+## Select Work Scope and Kind
+
+Classify the **Work Scope** before preflight. Work Scope describes the source
+of work; it is not a Codex collaboration mode.
 
 - **Milestone:** Read the live milestone and its canonical `release-plan`
   tracker, then select the first open linked issue under `## Ordered work`.
-- **Known issue:** Deliver the specified issue whether or not it has a
-  milestone. Do not substitute a different issue.
-- **Ad hoc:** Build a local brief with outcome, evidence, assumptions,
-  acceptance criteria, and non-goals. Search live issues and PRs for overlap,
-  but do not require or create an issue unless requested.
+- **Known issue:** Use the specified issue whether or not it has a milestone;
+  never substitute another issue.
+- **Ad hoc:** Build a brief with outcome, evidence, assumptions, acceptance
+  criteria, and non-goals. Search live issues and PRs for overlap, but do not
+  require or create an issue unless requested.
 
-Identify the work item as an issue number or `ad hoc: <short label>`.
+Identify the work as an issue number or `ad hoc: <short label>`, then classify
+it as **implementation** or **research**. Implementation retains product code.
+Research produces evidence and a recommendation; its product-code envelope is
+zero. A research spike must be explicitly authorized, bounded, and disposable.
+Reclassify and re-plan before retaining product code.
 
-After selecting it, classify **implementation** or **research**. Implementation
-delivers or retains product code. Research produces evidence and a
-recommendation; its product-code envelope is zero. Research may use only an
-explicitly authorized bounded, disposable spike or report artifact; never
-retain or publish spike output as product code. If it should remain product
-code, reclassify as implementation and re-plan before editing.
+For a milestone, require exactly one open `release-plan` tracker. Parse links
+under `## Ordered work` in order and select the first still-open linked issue,
+excluding the tracker. If none remain, report refinement or release-handoff
+readiness. If a legacy milestone lacks a tracker, use explicit issue-body order
+and report that it has not adopted the canonical format.
 
-### Read Canonical Milestone Order
+## Read-Only Preflight and Plan
 
-1. Fetch the milestone, open issues, and relevant PRs live.
-2. Find the open issue labeled `release-plan` assigned to that milestone.
-3. Require exactly one tracker. If more than one exists, stop for refinement.
-4. Parse issue links under the tracker's `## Ordered work` heading in document
-   order. Select the first linked issue that is still open; do not select the
-   tracker itself.
-5. If no linked issue remains open, report that the milestone is ready for
-   refinement or release handoff. Do not invent work or publish a release.
+Before an approved plan, read applicable `AGENTS.md` files; inspect worktree
+dirt, branch, and fresh `origin/main` relationship; run the scope's live issue
+and PR checks; and classify affected surfaces and risks. Preserve user changes;
+do not update or rebase without authority.
 
-If a legacy milestone has no `release-plan` tracker, use its explicit issue-body
-ordering and report that the milestone has not adopted the canonical tracker
-format. A tracker always overrides legacy ordering.
+Produce a decision-complete plan containing:
 
-## Preflight
-
-Before confirming a work item or spawning an agent:
-
-1. Read every applicable `AGENTS.md` and scoped instruction file.
-2. Verify worktree dirt, branch, and relationship to freshly fetched
-   `origin/main`. Preserve user changes. Update or rebase only with authority
-   and a safe worktree.
-3. Run the selected entry mode's live issue and PR checks.
-4. Classify affected surfaces and risk: UI, contracts, Android runtime,
-   sync/transport, manual or hardware validation, privacy/security/data loss,
-   migration/transaction/concurrency, and cross-layer architecture.
-5. State either an implementation envelope (owned modules, production file and
-   line bounds, allowed interfaces, non-goals, lanes, delivery shape) or a
-   research evidence envelope (question, sources or datasets, non-goals,
-   lanes, report target), plus worker model and effort.
-
-Skill preflight is independent of Codex mode. In Plan mode, stop after
-preflight and plan. In Goal mode, bind work to exactly one selected item and
-the authorized publication boundary; never auto-advance a release-plan item or
-create or expand a goal implicitly.
+- selected item, work kind, outcome, non-goals, and acceptance evidence;
+- implementation envelope (modules, interfaces, line/file bounds) or research
+  evidence envelope (question, sources, method, report target);
+- normal-versus-stack decision, worker ownership/model/effort, validation lanes,
+  review plan, and explicit stop boundary;
+- assumptions, risks, and the exact authority still needed.
 
 Read [validation-lanes.md](references/validation-lanes.md) before selecting
 lanes or reporting evidence.
 
-## Research Workflow
+## Local Execution After Approval
 
-For research, define question, method and evidence matrix, fixtures or
-datasets, legal/licensing constraints, environment or hardware baseline,
-timebox, report target, and recommendation criteria before delegation. A
-negative or defer conclusion completes the work when evidence supports it.
-Do not require a PR or stack when no repository change is authorized. GitHub
-publication or issue closure still requires explicit authority.
+Only after the user approves the plan and explicitly requests local execution,
+delegate bounded implementation or research. Give workers the outcome,
+non-goals, owned files or evidence, envelope, current evidence, validation
+method, and stop-on-expansion instruction. Keep the coordinator out of edits.
 
-## Choose One PR or a Stack
+Use one implementation or research worker by default. Use at most two only when
+responsibilities and owned files or evidence streams are independent; assign
+clear ownership. Use one implementation worker across dependent stack layers.
 
-Apply this section when work includes repository changes; publication authority
-still governs branches, commits, pushes, and PRs.
+Select model and effort explicitly: Terra Medium for exploration; Terra High
+for bounded implementation; Sol High for ambiguity, cross-layer architecture,
+sync/concurrency, transactions, migrations, privacy/security/data-loss risk, or
+ambiguous test failures. Use the contract guard only at an actual contract
+boundary and Product Design only for UI work.
 
-Use a normal single PR by default.
+For implementation, treat production source as the scope tripwire, excluding
+tests, generated files, and lockfiles. Stop and re-plan if work reaches an
+unplanned module or interface, or production file count or changed lines exceed
+twice the declared envelope. Do not expand into broad cleanup, speculative
+hardening, or adjacent feature work. For research, define method, evidence
+matrix, fixtures/datasets, licensing constraints, baseline, timebox, report
+target, and recommendation criteria. A negative or defer conclusion can
+complete research. Never retain research product code without reclassification
+and a new approved plan. Research follows the same Plan-first contract and
+remains unpublished by default.
 
-Choose a stack only when a large feature or rewrite has all of these traits:
+## Delivery Shape and Publication Boundary
 
-- two to four dependency-ordered layers;
-- each layer is independently reviewable and keeps the repository usable;
-- later layers genuinely depend on earlier layers;
-- separating layers materially improves review.
+Use one normal PR by default. Choose a stack only for two to four genuinely
+dependent, independently reviewable layers that keep the repository usable and
+materially improve review. Independent changes are not a stack.
 
-Order stack layers foundations or contracts first, services and orchestration
-next, and UI or end-to-end integration last. Independent changes are not a
-stack; use one PR or separately deliverable PRs instead. Keep stacks small
-because repository rules and CI apply to every layer.
+If a true stack is required, stop after the plan until explicit stack
+publication authority covers branch creation or switching, signed commits,
+pushes, and draft PRs. A stack needs its layer branches and signed commits;
+never create a partial local stack. Read
+[stacked-prs.md](references/stacked-prs.md) before stack publication.
 
-Before starting stacked implementation, obtain explicit authority for all four
-actions: create or switch branches, create signed commits, push branches, and
-open draft PRs. If any authority is missing, stop after presenting the proposed
-layers and validation plan. Do not create a partial local stack.
+For normal work, also stop before branch creation, commit, push, PR or issue
+updates, or merge by default. A later explicit request such as “Commit and
+publish the completed work as a draft PR. Do not merge.” authorizes the required
+branch, signed-commit, push, and draft-PR actions. It never authorizes merge;
+merge needs a separate instruction.
 
-Use one implementation worker across dependent stack layers so ownership and
-rebases stay coherent. Use repository branch names and one signed commit per
-branch. Read [stacked-prs.md](references/stacked-prs.md) before creating or
-updating any stack. Never merge automatically.
+## Validate, Review, and Finish
 
-## Delegate Deliberately
+Run only applicable validation lanes and report command, result, proof boundary,
+and unverified behavior. Never treat a local validator, emulator, or mock as
+proof of live transport, external-device, or release behavior.
 
-Select model and effort explicitly before every spawn. Use one implementation
-or research worker by default. Use at most two only when responsibilities and
-files or evidence streams are independent; assign clear ownership. Keep the
-coordinator out of edits.
+Use one initial correctness review for implementation or one evidence review for
+research. Evidence review must check methodology, reproducibility, unsupported
+generalization, licensing, and evidence-to-conclusion fit. Add contract and
+Product Design review only when applicable. Route reviews to Sol High normally,
+Sol XHigh only for declared high risk, and Sol Max only for a focused unresolved
+critical dispute. Send actionable findings to the original worker for one
+remediation pass, then perform one focused re-review. Stop on unresolved
+critical findings.
 
-- Use `gpt-5.6-terra` at Medium for exploration and read-heavy investigation.
-- Use `gpt-5.6-terra` at High for bounded implementation.
-- Use `gpt-5.6-sol` at High for ambiguity, cross-layer architecture,
-  sync/concurrency, transactions, migrations, privacy/security/data-loss risk,
-  or ambiguous test failures.
-- Use Product Design on Sol High only for UI or user-facing work: produce a
-  concise brief before implementation and final UX QA afterward.
-- Use `tuneforge_contract_guard` on Terra High only when a contract boundary
-  may change. Ask only for actual schema, OpenAPI, generated-type, or caller
-  drift.
-
-For UI work, put user goals, mode boundaries, truthfulness rules, screens,
-states, interaction model, and UX acceptance criteria in the worker prompt.
-Give every worker the outcome, non-goals, owned files or evidence sources,
-change envelope, current evidence, validation commands or method, delivery
-target, and an instruction to stop on scope expansion. For research, include
-the question, evidence matrix, reproducibility baseline, licensing limits,
-timebox, and recommendation criteria.
-
-## Control Growth
-
-For implementation, treat production source as the tripwire. Exclude tests,
-generated files, and lockfiles from the estimate. Stop and re-plan when either
-condition occurs:
-
-- work reaches an unplanned module or interface;
-- production file count or changed lines exceed twice the declared envelope.
-
-Do not turn findings into broad cleanup, speculative hardening, or adjacent
-feature work.
-
-For research, stop and re-plan before any product-code change. Keep an
-authorized spike bounded and disposable; reclassify and re-plan before editing
-anything intended to remain as product code.
-
-## Validate and Review
-
-Run only applicable validation lanes. Report command, result, proof boundary,
-and unverified behavior. Never present a local validator, emulator, or mock as
-proof of live transport, external-device behavior, or release behavior.
-
-Use one initial correctness review for implementation, or one evidence review
-for research covering methodology, reproducibility, unsupported generalization,
-licensing, and evidence-to-conclusion fit. Add contract and Product Design
-reviews only when their lanes apply. Route normal reviews to Sol High, declared
-high risk to Sol XHigh, and a focused unresolved critical dispute only to Sol
-Max.
-
-Require actionable correctness, evidence-quality, regression, security,
-data-loss, contract, or necessary-test findings. Send valid findings to the
-original worker for one remediation pass, then run one focused re-review of
-changed areas or evidence. For a stack, amend the owning layer and cascade the
-update through every dependent layer. Stop if a critical finding remains
-unresolved.
-
-## Finish
-
-Summarize the issue or ad hoc label, work kind, delivery or report target,
-change envelope, agents and lanes used, validation or evidence results,
-unverified boundaries, remaining risks, and worktree or stack status when
-applicable. Stop at the exact publication boundary authorized by the user.
-Never merge automatically.
+Finish with the selected scope, work kind, delivery/report target, envelope,
+agents and lanes used, validation/evidence, unverified boundaries, remaining
+risks, and local worktree or stack status. Stop at the exact authorized boundary;
+never merge automatically.

--- a/.agents/skills/coordinate-tuneforge-work/agents/openai.yaml
+++ b/.agents/skills/coordinate-tuneforge-work/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Coordinate TuneForge Work"
-  short_description: "Coordinate TuneForge delivery or evidence research"
-  default_prompt: "Use $coordinate-tuneforge-work to select and coordinate bounded TuneForge implementation or evidence-based research, with publication only when authorized."
+  short_description: "Plan TuneForge work for local delivery"
+  default_prompt: "Use $coordinate-tuneforge-work to prepare a Plan-first TuneForge work plan for local delivery."

--- a/.agents/skills/coordinate-tuneforge-work/references/prompt-examples.md
+++ b/.agents/skills/coordinate-tuneforge-work/references/prompt-examples.md
@@ -1,119 +1,91 @@
 # TuneForge Coordinator Prompt Examples
 
-Replace `#NNN`, the milestone name, or `ad hoc: <short label>` before sending. Select Plan mode first when
-the preflight and execution plan should pause for approval.
+Start in Plan mode when you want the preflight and decision-complete plan to
+pause for approval. Replace placeholders before sending. These initial prompts
+intentionally authorize neither implementation nor publication.
 
-## Full Issue Delivery
+## Known Issue
 
 ```text
-Use $coordinate-tuneforge-work for #NNN.
-
-Carry the issue through bounded implementation, applicable validation, review,
-and publication. Decide whether this should use one normal PR or a small stacked
-PR series using the skill's delivery-shape criteria.
-
-I authorize branch creation and switching, signed commits, pushes, and draft
-PR creation for whichever shape you select. Do not merge.
+Use $coordinate-tuneforge-work to plan #NNN.
 ```
 
-## Milestone Delivery
+## Milestone
 
 ```text
-Use $coordinate-tuneforge-work.
-
-Continue the <milestone name> milestone. Select the first open issue from the
-canonical release-plan tracker.
-
-Carry it through bounded implementation, applicable validation, review, and
-publication. Decide whether the work needs one normal PR or a small stacked PR
-series.
-
-I authorize branch creation and switching, signed commits, pushes, and draft
-PR creation for whichever shape you select. Do not merge.
+Use $coordinate-tuneforge-work to plan the next item in <milestone name>.
 ```
 
-## Local-Only Implementation
+The skill selects the first open issue in the canonical `release-plan` tracker.
+
+## Ad Hoc Implementation
 
 ```text
-Use $coordinate-tuneforge-work for #NNN.
+Use $coordinate-tuneforge-work to plan ad hoc: <short label>.
 
-Implement and validate the issue locally. Decide the appropriate delivery shape.
-
-If one normal PR is appropriate, complete local implementation and stop before
-branch creation, commit, push, or PR.
-
-If a stack is required, stop after presenting the layer plan because publication
-authority is not granted.
-```
-
-## Short Full Delivery
-
-```text
-Use $coordinate-tuneforge-work for #NNN.
-
-Decide normal versus stacked delivery. Implement, validate, review, and publish.
-I authorize branches, signed commits, pushes, and draft PRs. Do not merge.
-```
-
-## Plan Only
-
-```text
-Use $coordinate-tuneforge-work for #NNN.
-
-Prepare the preflight, delivery shape, worker ownership, validation lanes, and
-review plan. Stop before implementation or publication.
+Outcome: <concrete change>. Acceptance: <observable result and validation>.
 ```
 
 ## Evidence-Based Research
 
 ```text
-Use $coordinate-tuneforge-work for #NNN.
+Use $coordinate-tuneforge-work to plan research for #NNN.
 
-Treat this as evidence-based research. Define the question, method, evidence
-matrix, fixtures or datasets, licensing constraints, baseline, timebox, report
-target, and recommendation criteria. Produce evidence and a recommendation.
-
-Do not retain product code or publish GitHub state unless I separately authorize
-it. A supported negative or defer recommendation is acceptable.
+Question: <decision to support>. Report target: <where the evidence belongs>.
 ```
 
-## Ad Hoc Small Change
+## Bug Exploration
 
 ```text
-Use $coordinate-tuneforge-work for ad hoc: <short label>.
-
-Outcome: <concrete change>. Acceptance: <observable result and validation>.
-Search live issues and PRs for overlap, but do not require or create an issue.
-Decide normal PR versus stack under the skill's criteria. Implement, validate,
-review, and publish the retained change.
-I authorize branch creation and switching, signed commits, pushes, and draft PR
-creation. Do not merge.
-```
-
-## Ad Hoc Bug Exploration
-
-```text
-Use $coordinate-tuneforge-work for ad hoc: <short symptom label>.
+Use $coordinate-tuneforge-work to plan bug exploration for ad hoc: <symptom label>.
 
 Symptom and evidence: <observed behavior and supporting evidence>.
-Attempt reproduction. Identify a likely cause only when evidence supports one;
-an inconclusive result is acceptable. Report attempted methods, evidence,
-remaining hypotheses, and a recommended next step. Search live issues and PRs
-for overlap, but do not require or create an issue.
-Treat this as research-only: report in this chat. Do not retain product code or
-publish to GitHub. If a fix should follow, reclassify and re-plan before editing.
 ```
 
-## Plan First, Then Start a Goal
+## User-Owned Post-Plan Paths
 
-Enter Plan mode and send the full-delivery or milestone prompt above. Review and
-refine the resulting plan. Instead of choosing **Implement plan**, choose
-**Tell Codex to do something different** and enter:
+After reviewing and approving the plan, choose one path. Collaboration-mode
+selection and transitions remain yours; the skill does not invoke commands or
+change modes.
+
+### Implement Locally
+
+Tell Codex to implement the approved plan locally. It may implement, validate,
+review, and remediate, but stops before branch creation, commit, push, PR or
+issue updates, and merge.
+
+### Optional Goal
+
+Instead of choosing **Implement plan**, choose **Tell Codex to do something
+different** and enter:
 
 ```text
-/goal Use $coordinate-tuneforge-work to deliver #NNN according to the approved plan. Carry it through bounded implementation, applicable validation, review, and authorized draft PR publication. Do not merge or advance to another release-plan item.
+/goal Implement the approved plan with $coordinate-tuneforge-work.
 ```
 
-The goal command starts execution; do not choose **Implement plan** afterward.
-The same task retains the approved plan and the publication authority from the
-original delivery prompt.
+This has the same local-only boundary. Do not choose **Implement plan** after
+starting the Goal.
+
+### Later Publication
+
+After local work is complete, authorize normal publication explicitly:
+
+```text
+Commit and publish the completed work as a draft PR. Do not merge.
+```
+
+This authorizes the required branch creation or switching, signed commit, push,
+and draft PR. Merge still requires a separate instruction.
+
+### Rare Stacked Publication
+
+If the approved plan requires a true stack, grant stack publication authority
+only after the plan is approved:
+
+```text
+Create the approved stack: create or switch branches, make signed commits,
+push them, and open draft PRs. Do not merge.
+```
+
+Without that authority, the skill stops after the stack plan and never creates
+a partial local stack.


### PR DESCRIPTION
## Summary

- make TuneForge coordination plan-first, with decision-complete planning before execution
- keep approved implementation local by default and leave collaboration-mode changes to the user
- replace one-step delivery prompts with minimal planning and separately authorized publication paths

## Testing

- `cd apps/backend && uv run --python 3.11 python "${CODEX_HOME:-$HOME/.codex}/skills/.system/skill-creator/scripts/quick_validate.py" ../../.agents/skills/coordinate-tuneforge-work`
- `git diff --check origin/main...HEAD`
- forward-tested issue, milestone, ad hoc, research, local, Goal, publication, and stack boundaries
- focused Sol High review, one remediation pass, and clean focused re-review
