### PR TITLE
ci: split desktop checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,10 @@ jobs:
                 apps/site/*|.github/workflows/pages.yml)
                   site=true
                   ;;
-                .github/workflows/ci.yml|.codex/environments/*|docs/*|README.md|CONTRIBUTING.md|CODE_OF_CONDUCT.md|LICENSE|THIRD_PARTY_NOTICES.md|SECURITY.md|AGENTS.md|.gitignore|packaging/flatpak/*|.github/ISSUE_TEMPLATE/*|.github/PULL_REQUEST_TEMPLATE.md)
+                .github/workflows/ci.yml)
+                  full_gate=true
+                  ;;
+                .agents/*|.codex/environments/*|docs/*|README.md|CONTRIBUTING.md|CODE_OF_CONDUCT.md|LICENSE|THIRD_PARTY_NOTICES.md|SECURITY.md|AGENTS.md|.gitignore|packaging/flatpak/*|.github/ISSUE_TEMPLATE/*|.github/PULL_REQUEST_TEMPLATE.md)
                   ;;
                 *)
                   full_gate=true
@@ -490,7 +493,7 @@ jobs:
         working-directory: apps/backend
         run: uv run --python 3.11 pytest
 
-  desktop:
+  desktop_frontend:
     needs: ci-scope
     if: ${{ always() && (needs.ci-scope.result != 'success' || needs.ci-scope.outputs.desktop == 'true') }}
     runs-on: ubuntu-latest
@@ -498,7 +501,7 @@ jobs:
       - name: Require CI scope
         if: needs.ci-scope.result != 'success'
         run: |
-          echo "ci-scope did not complete successfully; failing desktop required check."
+          echo "ci-scope did not complete successfully; failing desktop frontend checks."
           exit 1
 
       - name: Check out code
@@ -506,7 +509,7 @@ jobs:
 
       - name: Skip desktop checks
         if: needs.ci-scope.outputs.desktop != 'true'
-        run: echo "No desktop or contract paths changed; skipping desktop setup."
+        run: echo "No desktop or contract paths changed; skipping desktop frontend setup."
 
       - name: Set up pnpm
         if: needs.ci-scope.outputs.desktop == 'true'
@@ -533,25 +536,6 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           python-version: "3.11"
-
-      - name: Set up Rust
-        if: needs.ci-scope.outputs.desktop == 'true'
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
-
-      - name: Install Tauri system dependencies
-        if: needs.ci-scope.outputs.desktop == 'true'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libasound2-dev \
-            libwebkit2gtk-4.1-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            libxdo-dev \
-            libssl-dev
 
       - name: Install dependencies
         if: needs.ci-scope.outputs.desktop == 'true'
@@ -593,6 +577,43 @@ jobs:
       - name: Test desktop
         if: needs.ci-scope.outputs.desktop == 'true'
         run: pnpm --filter @tuneforge/desktop test --run
+
+  desktop_tauri:
+    needs: ci-scope
+    if: ${{ always() && (needs.ci-scope.result != 'success' || needs.ci-scope.outputs.desktop == 'true') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require CI scope
+        if: needs.ci-scope.result != 'success'
+        run: |
+          echo "ci-scope did not complete successfully; failing Tauri shell checks."
+          exit 1
+
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Skip Tauri shell checks
+        if: needs.ci-scope.outputs.desktop != 'true'
+        run: echo "No desktop or contract paths changed; skipping Tauri shell setup."
+
+      - name: Set up Rust
+        if: needs.ci-scope.outputs.desktop == 'true'
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Install Tauri system dependencies
+        if: needs.ci-scope.outputs.desktop == 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libasound2-dev \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libxdo-dev \
+            libssl-dev
 
       - name: Check Tauri shell
         if: needs.ci-scope.outputs.desktop == 'true'


### PR DESCRIPTION
## Summary

- Run desktop frontend and Tauri validation in parallel as independent checks.
- Treat CI workflow edits as full-gate changes and skip agent-only file changes.
- Replace the required `desktop` context with `desktop_frontend` and `desktop_tauri`; repository rules must be updated before merge.

## Testing

- `actionlint .github/workflows/ci.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `pnpm contracts:generate`
- `pnpm --filter @tuneforge/desktop lint`
- `pnpm --filter @tuneforge/desktop typecheck`
- `pnpm --filter @tuneforge/desktop test --run`
- `cd apps/desktop/src-tauri && cargo check`
- `cd apps/desktop/src-tauri && cargo test`
- Live Actions timing remains pending this draft PR run.
