### PR TITLE
ci: cache Rust builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,10 +507,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Skip desktop checks
-        if: needs.ci-scope.outputs.desktop != 'true'
-        run: echo "No desktop or contract paths changed; skipping desktop frontend setup."
-
       - name: Set up pnpm
         if: needs.ci-scope.outputs.desktop == 'true'
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
@@ -582,6 +578,8 @@ jobs:
     needs: ci-scope
     if: ${{ always() && (needs.ci-scope.result != 'success' || needs.ci-scope.outputs.desktop == 'true') }}
     runs-on: ubuntu-latest
+    env:
+      RUST_VERSION: "1.97.1"
     steps:
       - name: Require CI scope
         if: needs.ci-scope.result != 'success'
@@ -592,15 +590,23 @@ jobs:
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Skip Tauri shell checks
-        if: needs.ci-scope.outputs.desktop != 'true'
-        run: echo "No desktop or contract paths changed; skipping Tauri shell setup."
-
       - name: Set up Rust
         if: needs.ci-scope.outputs.desktop == 'true'
         run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
+          rustup toolchain install "${RUST_VERSION}" --profile minimal
+          rustup default "${RUST_VERSION}"
+
+      - name: Cache Cargo dependencies and build output
+        if: needs.ci-scope.outputs.desktop == 'true'
+        continue-on-error: true
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            apps/desktop/src-tauri/target
+            !apps/desktop/src-tauri/target/debug/incremental
+          key: cargo-v1-${{ runner.os }}-${{ runner.arch }}-rust-${{ env.RUST_VERSION }}-${{ hashFiles('apps/desktop/src-tauri/Cargo.lock', 'apps/desktop/src-tauri/Cargo.toml') }}
 
       - name: Install Tauri system dependencies
         if: needs.ci-scope.outputs.desktop == 'true'

--- a/README.md
+++ b/README.md
@@ -266,7 +266,8 @@ macOS packages require host `ffmpeg` / `ffprobe`; Flatpak routes backend lookups
 GitHub Actions runs path-aware checks on pull requests and full checks on `main`:
 
 - `backend`: `uv sync`, `ruff`, `mypy`, and FFmpeg-backed `pytest` only when backend/runtime paths require it
-- `desktop`: `pnpm install`, `pnpm contracts:generate`, generated-contract drift check, desktop `lint`, `typecheck`, `test`
+- `desktop_frontend`: `pnpm install`, contract generation and drift check, desktop `lint`, `typecheck`, and `test`
+- `desktop_tauri`: Rust setup, Tauri system dependencies, `cargo check`, and `cargo test`
 
 Manual or special coverage unless a workflow explicitly runs it:
 


### PR DESCRIPTION
## Summary

- Pin desktop Tauri CI to Rust 1.97.1.
- Reuse Cargo registry, Git dependency, and build output caches.
- Keep cache failures non-blocking and preserve both Rust validation commands.
- Remove unreachable desktop skip steps and document the split required checks.

## Testing

- `actionlint .github/workflows/ci.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `git diff --check`
- Full product tests were not rerun locally because this change only affects CI caching; the draft PR's full CI run validates Rust installation, cache behavior, `cargo check`, and `cargo test`.
