### PR TITLE
feat(android): add dedicated release signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,5 +76,7 @@ data/
 *.key
 *.p12
 *.pfx
+*.jks
+*.keystore
 *.cer
 *.crt

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,10 +5,11 @@
   "type": "module",
   "scripts": {
     "build": "tsc && vite build",
-    "android:prepare": "bash ../../scripts/android-prepare-generated.sh",
+    "android:prepare": "node ../../scripts/package-android.mjs --prepare",
     "android:icons": "tauri icon --output src-tauri/target/android-icons src-tauri/icons/icon.png",
     "android:build": "node ../../scripts/package-android.mjs",
     "android:build:debug": "node ../../scripts/package-android.mjs --debug",
+    "android:build:release": "node ../../scripts/package-android.mjs --publishable",
     "android:studio": "bash ../../scripts/android-arm64-env.sh tauri android dev --open",
     "dev": "vite",
     "lint": "eslint .",

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -132,24 +132,34 @@ transfer, recovery, or conflict states rather than where the data originated.
 Use the root commands to build Android APKs without opening Android Studio:
 
 ```sh
+pnpm package:android:prepare
 pnpm package:android:debug
 pnpm package:android
+pnpm package:android:release
 ```
 
-Packaging discovers a fresh JDK 17, Android SDK, and compatible installed NDK; checks the required
-Android, Rust, and Tauri tools; initializes an absent generated target noninteractively; rejects
-partial generated state; then runs the existing icon and preparation helpers. It requires the
-existing `~/.android/debug.keystore` and never creates signing credentials.
+Run `pnpm package:android:prepare` before the build commands. It validates the JDK 17, Android SDK,
+compatible NDK, Rust target, and Tauri tools; initializes an absent target; generates icons; and
+applies TuneForge's generated Android preparation. Build commands fail when that prepared state is
+absent or incomplete and never initialize or prepare it themselves.
 
 `pnpm package:android` produces an optimized local release-profile APK, debug-key signed.
-`pnpm package:android:debug` produces the corresponding debug APK:
+`pnpm package:android:debug` produces the corresponding debug APK. These local outputs remain under
+the generated Android project:
 
 - Debug: `apps/desktop/src-tauri/gen/android/app/build/outputs/apk/universal/debug/app-universal-debug.apk`
 - Release: `apps/desktop/src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release.apk`
 
 Packaging verifies the exact Gradle variant metadata and output path, a successful `apksigner`
-check, the expected debuggable state, and a non-empty release mapping. The release-profile APK is
-not for store publication. Packaging never installs or launches the app.
+check, the expected debuggable state, and a non-empty release mapping. The local release-profile APK
+is not the direct-distribution artifact.
+
+`pnpm package:android:release` builds the direct GitHub Release APK with TuneForge's stable signing
+identity. It requires the five environment
+variables documented in [Packaging](PACKAGING.md#android), verifies the PKCS12 file, private-key alias,
+passwords, expected certificate fingerprint, signer count, and manifest version, then atomically
+writes `apps/desktop/src-tauri/target/release/bundle/apk/TuneForge_<version>_android_aarch64_publishable.apk`.
+Packaging never installs, launches, uploads, tags, or publishes the app.
 
 Project playback prefers the native `android-aaudio` path. Web Audio is an automatic disclosed
 fallback after native failure or a build-time development override; it is not a mobile setting.
@@ -212,8 +222,8 @@ protection without changing capture or work state. Android 15 `dataSync` timeout
 failure and clears the transfer reason while preserving other owners; it is never shown as a
 completed transfer.
 
-`pnpm --filter @tuneforge/desktop android:prepare` updates the generated Android target before a
-build. It keeps these manifest permissions present:
+`pnpm package:android:prepare` updates the generated Android target before a build. It keeps these
+manifest permissions present:
 
 - `android.permission.INTERNET` for same-LAN TCP/QUIC/UDP sync sockets.
 - `android.permission.RECORD_AUDIO` and `android.permission.MODIFY_AUDIO_SETTINGS` for mobile audio

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -94,6 +94,61 @@ The packaged backend checks the inherited `PATH` plus common Homebrew and MacPor
 
 By default, Demucs, Whisper, and beat-this weights are read from their normal caches and downloaded on first use if missing. Crema is the dependency-owned exception: its wheel-embedded chord model files are part of the crema package and ship when Advanced Chords is included. `--model-bundle` stages required Demucs and Whisper weights into the package, and also stages the beat-this `small0` checkpoint when beat-this dependencies are included. On startup, bundled model files seed the normal caches; runtime loaders still use cache paths, not package resource paths. `--model-bundle` does not control dependency inclusion. The flag prints a warning because Demucs pretrained-weight redistribution is unclear/restricted upstream.
 
+## Android
+
+Prepare the generated project, then choose a debug, optimized local release-profile, or stable-key
+GitHub Release APK build:
+
+```sh
+pnpm package:android:prepare
+pnpm package:android:debug
+pnpm package:android
+pnpm package:android:release
+```
+
+Preparation owns toolchain validation, conditional Tauri Android initialization, icon generation,
+and generated-project preparation. All three build commands require this state and never prepare it.
+
+The release command creates a direct GitHub Release APK. Its dedicated long-lived key provides a
+stable signing/update identity for sideloaded APKs. PKCS12 is the only supported release-key
+container format. Inputs are environment-only:
+
+- `TUNEFORGE_ANDROID_RELEASE_KEYSTORE_PATH`: absolute path to a readable regular PKCS12 file.
+- `TUNEFORGE_ANDROID_RELEASE_KEY_ALIAS`: alias containing the private signing key.
+- `TUNEFORGE_ANDROID_RELEASE_STORE_PASSWORD`: PKCS12 password.
+- `TUNEFORGE_ANDROID_RELEASE_KEY_PASSWORD`: private-key password.
+- `TUNEFORGE_ANDROID_RELEASE_EXPECTED_CERT_SHA256`: expected certificate SHA-256 fingerprint (64
+  hexadecimal characters or 32 colon-separated bytes).
+
+Supply an externally managed PKCS12 file at a private absolute path outside the repository. TuneForge does
+not manage or need to know its storage/export workflow. The operator owns any temporary-file
+lifecycle and cleanup. Enter passwords silently, export the configuration, then clear it afterward:
+
+```sh
+read -rs "TUNEFORGE_ANDROID_RELEASE_STORE_PASSWORD?Keystore password: "; export TUNEFORGE_ANDROID_RELEASE_STORE_PASSWORD; echo
+read -rs "TUNEFORGE_ANDROID_RELEASE_KEY_PASSWORD?Key password: "; export TUNEFORGE_ANDROID_RELEASE_KEY_PASSWORD; echo
+export TUNEFORGE_ANDROID_RELEASE_KEYSTORE_PATH="/absolute/private/path/tuneforge-release.p12"
+export TUNEFORGE_ANDROID_RELEASE_KEY_ALIAS="tuneforge-release"
+export TUNEFORGE_ANDROID_RELEASE_EXPECTED_CERT_SHA256="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+pnpm package:android:release
+unset TUNEFORGE_ANDROID_RELEASE_KEYSTORE_PATH TUNEFORGE_ANDROID_RELEASE_KEY_ALIAS
+unset TUNEFORGE_ANDROID_RELEASE_STORE_PASSWORD TUNEFORGE_ANDROID_RELEASE_KEY_PASSWORD
+unset TUNEFORGE_ANDROID_RELEASE_EXPECTED_CERT_SHA256
+```
+
+The script never modifies the keystore. Before building, it verifies the PKCS12/store password, alias
+certificate and DER SHA-256 fingerprint, then proves the key password/private key by signing a
+temporary empty JAR. Credential subprocess output is suppressed; secrets stay out of arguments,
+generated Gradle configuration, metadata, logs, and errors.
+
+The verified result is atomically promoted to
+`apps/desktop/src-tauri/target/release/bundle/apk/TuneForge_<version>_android_aarch64_publishable.apk`.
+Android package commands serialize access to the generated project and never auto-remove a stale
+lock. If packaging reports one, first verify no package command is active, then remove
+`apps/desktop/src-tauri/target/.tuneforge-android-package.lock` manually. A failed attempt removes
+its disposable outputs and preserves an existing versioned APK. The command does not install,
+launch, upload, tag, create a release, or publish that file.
+
 ## Linux Flatpak
 
 Build the local Flatpak package with:

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "models:demucs:prepare": "node scripts/prepare-demucs-models.mjs",
     "package:android": "pnpm --filter @tuneforge/desktop android:build",
     "package:android:debug": "pnpm --filter @tuneforge/desktop android:build:debug",
+    "package:android:prepare": "pnpm --filter @tuneforge/desktop android:prepare",
+    "package:android:release": "pnpm --filter @tuneforge/desktop android:build:release",
     "package:linux": "pnpm package:linux:flatpak",
     "package:linux:flatpak": "node scripts/package-flatpak.mjs",
     "package:mac": "node scripts/package-mac.mjs",

--- a/scripts/package-android.mjs
+++ b/scripts/package-android.mjs
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -11,17 +12,32 @@ const androidDir = path.join(desktopDir, "src-tauri/gen/android");
 const tauriCli = path.join(desktopDir, "node_modules/.bin/tauri");
 const androidEnv = path.join(scriptDir, "android-arm64-env.sh");
 const prepareGenerated = path.join(scriptDir, "android-prepare-generated.sh");
+const packageLock = path.join(desktopDir, "src-tauri/target/.tuneforge-android-package.lock");
+const publishableVariables = [
+  "TUNEFORGE_ANDROID_RELEASE_KEYSTORE_PATH", "TUNEFORGE_ANDROID_RELEASE_KEY_ALIAS",
+  "TUNEFORGE_ANDROID_RELEASE_STORE_PASSWORD", "TUNEFORGE_ANDROID_RELEASE_KEY_PASSWORD",
+  "TUNEFORGE_ANDROID_RELEASE_EXPECTED_CERT_SHA256",
+];
+const signingBlocks = [["// TUNEFORGE-PUBLISHABLE-SIGNING-BEGIN", "// TUNEFORGE-PUBLISHABLE-SIGNING-END"],
+  ["// TUNEFORGE-PUBLISHABLE-RELEASE-BEGIN", "// TUNEFORGE-PUBLISHABLE-RELEASE-END"]];
+const debugSigningLine = '            signingConfig = signingConfigs.getByName("debug")';
 const generatedMarkers = [
   ["app/build.gradle.kts", "file"], ["app/src/main/AndroidManifest.xml", "file"],
   ["app/src/main/java/com/tuneforge/desktop/MainActivity.kt", "file"],
-  ["app/src/main/res", "directory"],
-  ["gradle/wrapper/gradle-wrapper.jar", "file"], ["gradle/wrapper/gradle-wrapper.properties", "file"],
-  ["gradlew", "executable"],
-  ["settings.gradle", "file"],
+  ["app/src/main/res", "directory"], ["gradle/wrapper/gradle-wrapper.jar", "file"],
+  ["gradle/wrapper/gradle-wrapper.properties", "file"], ["gradlew", "executable"], ["settings.gradle", "file"],
 ];
 function capture(command, args, { cwd = repoRoot, env = process.env } = {}) {
-  const result = spawnSync(command, args, { cwd, env, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  const result = spawnSync(command, args, {
+    cwd, env, encoding: "utf8", maxBuffer: 256 * 1024 * 1024, stdio: ["ignore", "pipe", "pipe"],
+  });
   return { ok: !result.error && result.status === 0, output: `${result.stdout ?? ""}\n${result.stderr ?? ""}`.trim() };
+}
+function sensitiveCapture(command, args, { cwd = repoRoot, env = process.env, binary = false } = {}) {
+  const result = spawnSync(command, args, {
+    cwd, env, encoding: binary ? null : "utf8", stdio: ["ignore", "pipe", "ignore"],
+  });
+  return { ok: !result.error && result.status === 0, output: result.stdout ?? (binary ? Buffer.alloc(0) : "") };
 }
 function run(command, args, { cwd = repoRoot, env = process.env, label } = {}) {
   const result = spawnSync(command, args, { cwd, env, stdio: "inherit" });
@@ -29,19 +45,138 @@ function run(command, args, { cwd = repoRoot, env = process.env, label } = {}) {
 }
 function executable(candidate) { try { fs.accessSync(candidate, fs.constants.X_OK); return true; } catch { return false; } }
 function directory(candidate) { try { return fs.statSync(candidate).isDirectory(); } catch { return false; } }
+export function parseMode(argv) {
+  if (argv.length === 0) return "local-release";
+  if (argv.length === 1 && argv[0] === "--prepare") return "prepare";
+  if (argv.length === 1 && argv[0] === "--debug") return "debug";
+  if (argv.length === 1 && argv[0] === "--publishable") return "publishable";
+  throw new Error("Usage: package-android.mjs [--prepare|--debug|--publishable]");
+}
+export function sanitizedEnv(env = process.env) {
+  const result = { ...env };
+  for (const name of publishableVariables) delete result[name];
+  return result;
+}
+export function publishableBuildEnv(baseEnv, sourceEnv) {
+  const result = sanitizedEnv(baseEnv);
+  for (const name of publishableVariables.slice(0, 4)) result[name] = sourceEnv[name];
+  return result;
+}
+export function acquirePackagingLock(lockPath = packageLock, {
+  token = crypto.randomUUID(), mkdir = fs.mkdirSync, write = fs.writeFileSync,
+  read = fs.readFileSync, remove = fs.rmSync,
+} = {}) {
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  try { mkdir(lockPath); } catch (error) {
+    if (error?.code === "EEXIST") {
+      throw new Error("Android packaging is already locked. If the lock is stale, verify no packaging process is active before removing it manually.");
+    }
+    throw error;
+  }
+  const owner = path.join(lockPath, "owner");
+  try { write(owner, token, { flag: "wx", mode: 0o600 }); } catch (error) {
+    remove(lockPath, { recursive: true, force: true });
+    throw error;
+  }
+  return {
+    token,
+    release() {
+      if (!fs.existsSync(lockPath)) return true;
+      let current;
+      try { current = read(owner, "utf8"); } catch { current = undefined; }
+      if (current !== token) return false;
+      try { remove(lockPath, { recursive: true, force: true }); } catch { return false; }
+      return true;
+    },
+  };
+}
+export function normalizeFingerprint(value) {
+  const fingerprint = value.trim();
+  if (/^[0-9a-f]{64}$/i.test(fingerprint)) return fingerprint.toLowerCase();
+  if (/^(?:[0-9a-f]{2}:){31}[0-9a-f]{2}$/i.test(fingerprint)) {
+    return fingerprint.replaceAll(":", "").toLowerCase();
+  }
+  throw new Error("Publishable certificate fingerprint must be 64 hex characters or 32 colon-separated bytes.");
+}
+export function readPublishableConfig(env = process.env, { statFile = fs.statSync, access = fs.accessSync } = {}) {
+  const missing = publishableVariables.filter((name) => typeof env[name] !== "string" || env[name].length === 0);
+  if (missing.length) throw new Error(`Publishable signing environment is incomplete: ${missing.join(", ")}.`);
+  const keystore = env.TUNEFORGE_ANDROID_RELEASE_KEYSTORE_PATH;
+  if (!path.isAbsolute(keystore)) throw new Error("Publishable keystore path must be absolute.");
+  let stat;
+  try { stat = statFile(keystore); access(keystore, fs.constants.R_OK); } catch {
+    throw new Error("Publishable keystore must be a readable regular file."); }
+  if (!stat.isFile()) throw new Error("Publishable keystore must be a readable regular file.");
+  return {
+    keystore,
+    alias: env.TUNEFORGE_ANDROID_RELEASE_KEY_ALIAS,
+    expectedFingerprint: normalizeFingerprint(env.TUNEFORGE_ANDROID_RELEASE_EXPECTED_CERT_SHA256),
+  };
+}
+export function validatePublishableCredentials(java, config, {
+  env = process.env, runSensitive = sensitiveCapture, tempRoot = os.tmpdir(),
+} = {}) {
+  const keytool = path.join(java.home, "bin/keytool");
+  const jar = path.join(java.home, "bin/jar");
+  const jarsigner = path.join(java.home, "bin/jarsigner");
+  requireExecutables([keytool, jar, jarsigner]);
+  const cleanEnv = sanitizedEnv(env);
+  const storeEnv = {
+    ...cleanEnv,
+    TUNEFORGE_ANDROID_RELEASE_STORE_PASSWORD: env.TUNEFORGE_ANDROID_RELEASE_STORE_PASSWORD,
+  };
+  const keyEnv = {
+    ...storeEnv,
+    TUNEFORGE_ANDROID_RELEASE_KEY_PASSWORD: env.TUNEFORGE_ANDROID_RELEASE_KEY_PASSWORD,
+  };
+  const storeArgs = ["-keystore", config.keystore, "-storetype", "PKCS12",
+    "-storepass:env", "TUNEFORGE_ANDROID_RELEASE_STORE_PASSWORD"];
+  if (!runSensitive(keytool, ["-list", ...storeArgs], { env: storeEnv }).ok) {
+    throw new Error("Publishable PKCS12 or store password validation failed.");
+  }
+  const certificate = runSensitive(keytool, ["-exportcert", "-alias", config.alias, ...storeArgs],
+    { env: storeEnv, binary: true });
+  if (!certificate.ok || !Buffer.isBuffer(certificate.output) || certificate.output.length === 0) {
+    throw new Error("Publishable certificate alias validation failed.");
+  }
+  const fingerprint = crypto.createHash("sha256").update(certificate.output).digest("hex");
+  if (fingerprint !== config.expectedFingerprint) {
+    throw new Error("Publishable certificate fingerprint does not match the expected SHA-256 value.");
+  }
+  const temporary = fs.mkdtempSync(path.join(tempRoot, "tuneforge-android-signing-"));
+  try {
+    const empty = path.join(temporary, "empty");
+    const unsigned = path.join(temporary, "unsigned.jar");
+    const signed = path.join(temporary, "signed.jar");
+    fs.mkdirSync(empty);
+    if (!runSensitive(jar, ["--create", "--file", unsigned, "-C", empty, "."], { env: cleanEnv }).ok) {
+      throw new Error("JDK signing probe preparation failed.");
+    }
+    const result = runSensitive(jarsigner, ["-keystore", config.keystore, "-storetype", "PKCS12",
+      "-storepass:env", "TUNEFORGE_ANDROID_RELEASE_STORE_PASSWORD",
+      "-keypass:env", "TUNEFORGE_ANDROID_RELEASE_KEY_PASSWORD", "-signedjar", signed,
+      unsigned, config.alias], { env: keyEnv });
+    if (!result.ok || !fs.statSync(signed, { throwIfNoEntry: false })?.isFile()) {
+      throw new Error("Publishable private key or key password validation failed.");
+    }
+  } finally {
+    fs.rmSync(temporary, { recursive: true, force: true });
+  }
+  return fingerprint;
+}
 export function resolveJava(
   { env = process.env, hostPlatform = process.platform, runCapture = capture, isExecutable = executable } = {},
 ) {
   const candidates = env.JAVA_HOME ? [env.JAVA_HOME] : [];
   if (hostPlatform === "darwin") {
-    const system = runCapture("/usr/libexec/java_home", ["-v", "17"]);
+    const system = runCapture("/usr/libexec/java_home", ["-v", "17"], { env });
     if (system.ok) candidates.push(system.output.split(/\r?\n/)[0]);
     candidates.push("/opt/homebrew/opt/openjdk@17", "/usr/local/opt/openjdk@17");
   }
   for (const home of candidates.map((candidate) => path.resolve(candidate))) {
     const java = path.join(home, "bin/java");
     if (!isExecutable(java) || !isExecutable(path.join(home, "bin/javac"))) continue;
-    const result = runCapture(java, ["-version"]);
+    const result = runCapture(java, ["-version"], { env });
     if (result.ok && /(?:java|openjdk) version "17(?:[."])/i.test(result.output)) {
       return { home, version: result.output.match(/17(?:\.\d+)+/)?.[0] ?? "17" };
     }
@@ -54,7 +189,7 @@ export function resolveSdk(
   const configured = [env.ANDROID_HOME, env.ANDROID_SDK_ROOT]
     .filter(Boolean).map((candidate) => path.resolve(candidate));
   if (new Set(configured).size > 1) throw new Error("ANDROID_HOME and ANDROID_SDK_ROOT must identify the same SDK.");
-  const info = runCapture("android", ["info", "sdk"]);
+  const info = runCapture("android", ["info", "sdk"], { env });
   const reported = info.ok ? info.output.split(/\r?\n/).map((line) => line.trim()).filter(Boolean).at(-1) : "";
   const candidates = [configured[0], reported, path.join(homeDir, "Library/Android/sdk")].filter(Boolean);
   const sdk = candidates.map((candidate) => path.resolve(candidate)).find(isDirectory);
@@ -75,13 +210,13 @@ export function requireExecutables(candidates, isExecutable = executable) {
   const missing = candidates.find((candidate) => !isExecutable(candidate));
   if (missing) throw new Error(`Required Android tool missing or not executable: ${missing}`);
 }
-function requireTools(sdk, runCapture = capture) {
+function requireTools(sdk, runCapture = capture, env = process.env) {
   const tools = selectAndroidTools(sdk);
   requireExecutables([...Object.values(tools).filter((value) => path.isAbsolute(value)), tauriCli]);
   if (!fs.existsSync(path.join(sdk, "platforms/android-36/android.jar"))) {
     throw new Error("Android API 36 platform is not installed.");
   }
-  const rust = runCapture("rustup", ["target", "list", "--installed"]);
+  const rust = runCapture("rustup", ["target", "list", "--installed"], { env });
   if (!rust.ok || !rust.output.split(/\s+/).includes("aarch64-linux-android")) {
     throw new Error("Rust target aarch64-linux-android is not installed.");
   }
@@ -99,30 +234,130 @@ export function generatedState(baseDir = androidDir) {
   }).map(([relative]) => relative);
   return missing.length ? { state: "partial", missing } : { state: "complete", missing: [] };
 }
+export function preparedState(baseDir = androidDir) {
+  const required = ["app/proguard-tuneforge.pro", "app/src/main/java/com/tuneforge/desktop/PowerInhibitionService.kt",
+    "app/src/main/res/values/ic_launcher_background.xml"];
+  const missing = required.filter((relative) => !fs.statSync(path.join(baseDir, relative),
+    { throwIfNoEntry: false })?.isFile());
+  return { ready: missing.length === 0, missing };
+}
+export function requirePrepared(baseDir = androidDir) {
+  const generated = generatedState(baseDir);
+  const prepared = generated.state === "complete" ? preparedState(baseDir) : { ready: false };
+  if (generated.state !== "complete" || !prepared.ready) throw new Error(
+    "Android project is not prepared. Run pnpm package:android:prepare first.");
+}
+export function removeOwnedSigning(contents) {
+  let result = contents;
+  for (const [begin, end] of signingBlocks) {
+    const pattern = new RegExp(`^[ \\t]*${begin.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&")}[\\s\\S]*?^[ \\t]*${end.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&")}\\r?\\n?`, "gm");
+    result = result.replace(pattern, "");
+  }
+  return result;
+}
 export function configureReleaseDebugSigning(buildFile = path.join(androidDir, "app/build.gradle.kts")) {
-  const contents = fs.readFileSync(buildFile, "utf8");
-  const line = '            signingConfig = signingConfigs.getByName("debug")';
-  if (contents.includes(line)) return false;
+  const contents = removeOwnedSigning(fs.readFileSync(buildFile, "utf8"));
+  if (contents.includes(debugSigningLine)) {
+    if (contents !== fs.readFileSync(buildFile, "utf8")) fs.writeFileSync(buildFile, contents);
+    return false;
+  }
   const marker = '        getByName("release") {\n            isMinifyEnabled = true';
   if (!contents.includes(marker)) throw new Error("Generated release build marker not found.");
-  fs.writeFileSync(buildFile, contents.replace(marker, `        getByName("release") {\n${line}\n            isMinifyEnabled = true`));
+  fs.writeFileSync(buildFile, contents.replace(marker, `        getByName("release") {\n${debugSigningLine}\n            isMinifyEnabled = true`));
   return true;
+}
+export function configurePublishableSigning(contents) {
+  const clean = removeOwnedSigning(contents);
+  const buildTypes = "    buildTypes {";
+  const release = '        getByName("release") {';
+  if (!clean.includes(buildTypes) || !clean.includes(release)) throw new Error(
+    "Generated signing insertion markers not found.");
+  const withoutDebug = clean.replace(`${debugSigningLine}\n`, "");
+  const signing = ["    // TUNEFORGE-PUBLISHABLE-SIGNING-BEGIN", "    signingConfigs {",
+    '        create("tuneforgePublishable") {',
+    '            storeFile = file(System.getenv("TUNEFORGE_ANDROID_RELEASE_KEYSTORE_PATH"))',
+    '            storeType = "PKCS12"',
+    '            storePassword = System.getenv("TUNEFORGE_ANDROID_RELEASE_STORE_PASSWORD")',
+    '            keyAlias = System.getenv("TUNEFORGE_ANDROID_RELEASE_KEY_ALIAS")',
+    '            keyPassword = System.getenv("TUNEFORGE_ANDROID_RELEASE_KEY_PASSWORD")',
+    "        }", "    }", "    // TUNEFORGE-PUBLISHABLE-SIGNING-END", ""].join("\n");
+  const selection = [release, "            // TUNEFORGE-PUBLISHABLE-RELEASE-BEGIN",
+    '            signingConfig = signingConfigs.getByName("tuneforgePublishable")',
+    "            // TUNEFORGE-PUBLISHABLE-RELEASE-END"].join("\n");
+  return withoutDebug.replace(buildTypes, `${signing}${buildTypes}`).replace(release, selection);
 }
 export function artifactFromMetadata(raw, debug, metadataPath) {
   const metadata = JSON.parse(raw);
   const mode = debug ? "debug" : "release";
   const variant = `universal${debug ? "Debug" : "Release"}`;
-  const outputFile = `app-universal-${mode}.apk`;
-  if (metadata.variantName !== variant || metadata.elements?.length !== 1 ||
-      metadata.elements[0].outputFile !== outputFile) throw new Error(`Expected exact ${variant} APK metadata.`);
-  return path.join(path.dirname(metadataPath), outputFile);
+  const element = metadata.elements?.[0];
+  if (metadata.variantName !== variant || metadata.artifactType?.type !== "APK" ||
+      metadata.elements?.length !== 1 || element?.type !== "SINGLE" ||
+      !Array.isArray(element.filters) || element.filters.length !== 0 ||
+      typeof element.outputFile !== "string" || path.isAbsolute(element.outputFile) ||
+      !element.outputFile.endsWith(`-${mode}.apk`)) throw new Error(`Expected one safe unfiltered ${variant} APK metadata element.`);
+  const output = path.resolve(path.dirname(metadataPath), element.outputFile);
+  if (path.relative(path.dirname(metadataPath), output).startsWith("..")) {
+    throw new Error(`Expected one safe unfiltered ${variant} APK metadata element.`);
+  }
+  return output;
 }
-export function pinnedEnv(java, sdk, ndk, { env = process.env, homeDir = os.homedir() } = {}) {
+export function pinnedEnv(java, sdk, ndk, { env = process.env, homeDir } = {}) {
+  if (!homeDir) throw new Error("An isolated Android home is required.");
   return { ...env, CI: "true", JAVA_HOME: java.home, ANDROID_HOME: sdk, ANDROID_SDK_ROOT: sdk,
     ANDROID_NDK_HOME: ndk.path, ANDROID_NDK_ROOT: ndk.path, ANDROID_USER_HOME: path.join(homeDir, ".android"),
-    ANDROID_SDK_HOME: homeDir, ANDROID_PREFS_ROOT: homeDir,
+    ANDROID_SDK_HOME: homeDir, ANDROID_PREFS_ROOT: homeDir, GRADLE_USER_HOME: path.join(homeDir, ".gradle"),
+    GRADLE_OPTS: `${env.GRADLE_OPTS ?? ""} -Dorg.gradle.daemon=false`.trim(),
     CARGO_TARGET_DIR: path.join(desktopDir, "src-tauri/target", `android-ndk-${ndk.version.replaceAll(".", "-")}`),
     PATH: `${path.join(java.home, "bin")}${path.delimiter}${env.PATH ?? ""}` };
+}
+export function verifyPublishable(apk, tools, expectedFingerprint, expectedVersion, { env = process.env, runCapture = capture } = {}) {
+  const signature = runCapture(tools.apksigner, ["verify", "--verbose", "--print-certs", "--Werr", apk], { env });
+  if (!signature.ok) throw new Error("Publishable APK signature verification failed.");
+  const signers = [...signature.output.matchAll(/^Signer #(\d+) certificate SHA-256 digest:\s*([0-9a-f:]+)\s*$/gim)];
+  if (signers.length !== 1 || signers[0][1] !== "1") {
+    throw new Error("Publishable APK must contain exactly one signer.");
+  }
+  if (normalizeFingerprint(signers[0][2]) !== expectedFingerprint) {
+    throw new Error("Publishable APK signer does not match the expected certificate SHA-256 fingerprint.");
+  }
+  const badging = runCapture(tools.aapt2, ["dump", "badging", apk], { env });
+  const version = badging.output.match(/\bversionName='([^']+)'/)?.[1];
+  if (!badging.ok || /application-debuggable/.test(badging.output) || !/native-code:.*'arm64-v8a'/.test(badging.output)) {
+    throw new Error("Publishable APK must be non-debuggable and contain arm64-v8a native code.");
+  }
+  if (version !== expectedVersion) throw new Error("Publishable APK versionName does not match Tauri configuration.");
+}
+export function runPublishableTransaction({
+  buildFile, configure, intermediates, metadataPath, staging, destination, tempHome, build, resolveRaw, validate,
+}, {
+  read = (file) => fs.readFileSync(file, "utf8"), write = fs.writeFileSync,
+  rename = fs.renameSync, copy = fs.copyFileSync, remove = fs.rmSync, mkdir = fs.mkdirSync,
+  cleanupTemp = (candidate) => fs.rmSync(candidate, { recursive: true, force: true }),
+} = {}) {
+  const snapshot = read(buildFile);
+  let committed = false;
+  try {
+    for (const file of intermediates) remove(file, { recursive: true, force: true });
+    write(buildFile, configure(snapshot));
+    build();
+    const rawApk = resolveRaw(metadataPath);
+    mkdir(path.dirname(staging), { recursive: true });
+    copy(rawApk, staging);
+    validate(staging);
+    write(buildFile, snapshot);
+    cleanupTemp(tempHome);
+    rename(staging, destination);
+    committed = true;
+    return destination;
+  } catch (error) {
+    if (!committed) {
+      remove(staging, { force: true });
+      for (const file of intermediates) remove(file, { recursive: true, force: true });
+      try { write(buildFile, snapshot); } finally { cleanupTemp(tempHome); }
+    }
+    throw error;
+  }
 }
 function verifySpecific(debug, tools, env) {
   const mode = debug ? "debug" : "release";
@@ -139,41 +374,95 @@ function verifySpecific(debug, tools, env) {
       throw new Error(`Debug APK is not debuggable: ${apk}`);
     }
   }
-  return apk;
+  return { apk, metadataPath };
 }
 export function main(argv = process.argv.slice(2)) {
-  if (argv.some((arg) => arg !== "--debug") || argv.length > 1) throw new Error("Usage: package-android.mjs [--debug]");
-  const debug = argv.includes("--debug");
-  const mode = debug ? "debug" : "release";
-  console.log(`[android package] preparation (${mode})`);
-  const java = resolveJava();
-  const sdk = resolveSdk();
-  const ndk = resolveNdk(sdk);
-  const env = pinnedEnv(java, sdk, ndk);
-  const tools = requireTools(sdk);
-  const keystore = path.join(os.homedir(), ".android/debug.keystore");
-  if (!fs.statSync(keystore, { throwIfNoEntry: false })?.isFile()) throw new Error(`Existing debug keystore required: ${keystore}`);
-  console.log(`[android package] JDK ${java.version}; SDK ${sdk}; NDK ${ndk.version} (${ndk.path})`);
-  const state = generatedState();
-  if (state.state === "partial") throw new Error(`Generated Android project is partial: ${state.missing.join(", ")}`);
-  if (state.state === "absent") run("bash", [androidEnv, tauriCli, "android", "init", "--ci", "--skip-targets-install"],
-    { cwd: desktopDir, env, label: "Tauri Android init" });
-  const ready = generatedState();
-  if (ready.state !== "complete") throw new Error(`Generated Android project incomplete: ${ready.missing.join(", ")}`);
-  configureReleaseDebugSigning();
-  run(tauriCli, ["icon", "--output", "src-tauri/target/android-icons", "src-tauri/icons/icon.png"],
-    { cwd: desktopDir, env, label: "Android icon generation" });
-  run("bash", [prepareGenerated], { env, label: "Generated Android preparation" });
-  console.log(`[android package] build (${mode})`);
-  const args = [androidEnv, tauriCli, "android", "build", "--ci", "--target", "aarch64", "--apk"];
-  if (debug) args.push("--debug");
-  run("bash", args, { cwd: desktopDir, env, label: `Tauri Android ${mode} build` });
-  requireExecutables(debug ? [tools.aapt2, tools.apksigner] : [tools.aapt2, tools.apksigner, tools.dexdump]);
-  const apk = verifySpecific(debug, tools, env);
-  if (!debug) run(process.execPath, [path.join(scriptDir, "validate-android-release-jni.mjs")],
-    { env, label: "Android release JNI validation" });
-  console.log(`[android package] ${debug ? "debug" : "optimized release-profile"} APK: ${apk}`);
-  console.log(`[android package] completion (${mode}, debug-key signed)`);
+  const mode = parseMode(argv);
+  const debug = mode === "debug";
+  const publishable = mode === "publishable";
+  const sourceEnv = { ...process.env };
+  const cleanEnv = sanitizedEnv(sourceEnv);
+  console.log(`[android package] start (${mode})`);
+  const lock = acquirePackagingLock();
+  let isolatedHome;
+  try {
+    if (mode !== "prepare") requirePrepared();
+    const config = publishable ? readPublishableConfig(sourceEnv) : undefined;
+    const java = resolveJava({ env: cleanEnv });
+    const sdk = resolveSdk({ env: cleanEnv });
+    const ndk = resolveNdk(sdk, { env: cleanEnv });
+    if (config) validatePublishableCredentials(java, config, { env: sourceEnv });
+    const tools = requireTools(sdk, capture, cleanEnv);
+    isolatedHome = fs.mkdtempSync(path.join(os.tmpdir(), "tuneforge-android-home-"));
+    const env = pinnedEnv(java, sdk, ndk, { env: cleanEnv, homeDir: isolatedHome });
+    const buildEnv = publishable ? publishableBuildEnv(env, sourceEnv) : env;
+    console.log(`[android package] JDK ${java.version}; SDK ${sdk}; NDK ${ndk.version} (${ndk.path})`);
+    if (mode === "prepare") {
+      const state = generatedState();
+      if (state.state === "partial") throw new Error(`Generated Android project is partial: ${state.missing.join(", ")}`);
+      if (state.state === "absent") run("bash", [androidEnv, tauriCli, "android", "init", "--ci", "--skip-targets-install"],
+        { cwd: desktopDir, env, label: "Tauri Android init" });
+      if (generatedState().state !== "complete") throw new Error("Generated Android project initialization failed.");
+      run(tauriCli, ["icon", "--output", "src-tauri/target/android-icons", "src-tauri/icons/icon.png"],
+        { cwd: desktopDir, env, label: "Android icon generation" });
+      run("bash", [prepareGenerated], { env, label: "Generated Android preparation" });
+      requirePrepared();
+      console.log("[android package] completion (prepare)");
+      return;
+    }
+    const buildFile = path.join(androidDir, "app/build.gradle.kts");
+    const rawApk = path.join(androidDir, "app/build/outputs/apk/universal/release/app-universal-release.apk");
+    const metadata = path.join(path.dirname(rawApk), "output-metadata.json");
+    const mapping = path.join(androidDir, "app/build/outputs/mapping/universalRelease/mapping.txt");
+    const cleanGradle = removeOwnedSigning(fs.readFileSync(buildFile, "utf8"));
+    if (cleanGradle !== fs.readFileSync(buildFile, "utf8")) fs.writeFileSync(buildFile, cleanGradle);
+    if (publishable) {
+      const tauriConfig = JSON.parse(fs.readFileSync(path.join(desktopDir, "src-tauri/tauri.conf.json"), "utf8"));
+      const outputDir = path.join(desktopDir, "src-tauri/target/release/bundle/apk");
+      const destination = path.join(outputDir, `TuneForge_${tauriConfig.version}_android_aarch64_publishable.apk`);
+      const staging = path.join(outputDir, `.${path.basename(destination)}.${lock.token}.tmp`);
+      const build = () => { console.log(`[android package] build (${mode})`);
+        run("bash", [androidEnv, tauriCli, "android", "build", "--ci", "--target", "aarch64", "--apk"],
+          { cwd: desktopDir, env: buildEnv, label: "Tauri Android publishable build" });
+        requireExecutables([tools.aapt2, tools.apksigner, tools.dexdump]);
+      };
+      const resolveRaw = (metadataPath) => {
+        const apk = artifactFromMetadata(fs.readFileSync(metadataPath, "utf8"), false, metadataPath);
+        if (!fs.statSync(apk, { throwIfNoEntry: false })?.isFile()) throw new Error("Publishable APK output is missing.");
+        if (!fs.statSync(mapping, { throwIfNoEntry: false })?.size) throw new Error("Publishable release mapping is missing or empty.");
+        return apk;
+      };
+      const validate = (apk) => { verifyPublishable(
+        apk, tools, config.expectedFingerprint, tauriConfig.version, { env });
+        run(process.execPath, [path.join(scriptDir, "validate-android-release-jni.mjs"), "--apk", apk],
+          { env, label: "Android release JNI validation" });
+      };
+      const output = runPublishableTransaction({ buildFile, configure: configurePublishableSigning,
+        intermediates: [path.dirname(rawApk), mapping], metadataPath: metadata, staging, destination,
+        tempHome: isolatedHome, build, resolveRaw, validate });
+      isolatedHome = undefined;
+      console.log(`[android package] publishable APK: ${output}`);
+      console.log("[android package] completion (publishable, release-key signed)");
+    } else {
+      if (!debug) configureReleaseDebugSigning(buildFile);
+      console.log(`[android package] build (${mode})`);
+      const args = [androidEnv, tauriCli, "android", "build", "--ci", "--target", "aarch64", "--apk"];
+      if (debug) args.push("--debug");
+      run("bash", args, { cwd: desktopDir, env, label: `Tauri Android ${mode} build` });
+      requireExecutables(debug ? [tools.aapt2, tools.apksigner] : [tools.aapt2, tools.apksigner, tools.dexdump]);
+      const artifact = verifySpecific(debug, tools, env);
+      if (!debug) run(process.execPath, [path.join(scriptDir, "validate-android-release-jni.mjs")],
+        { env, label: "Android release JNI validation" });
+      console.log(`[android package] ${debug ? "debug" : "optimized release-profile"} APK: ${artifact.apk}`);
+      console.log(`[android package] completion (${mode}, debug-key signed)`);
+    }
+  } finally {
+    try {
+      if (isolatedHome) fs.rmSync(isolatedHome, { recursive: true, force: true });
+    } finally {
+      lock.release();
+    }
+  }
 }
 if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
   try { main(); } catch (error) { console.error(`[android package] failure: ${error.message}`); process.exitCode = 1; }

--- a/scripts/package-android.test.mjs
+++ b/scripts/package-android.test.mjs
@@ -1,19 +1,33 @@
 import assert from "node:assert/strict";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
 import {
+  acquirePackagingLock,
   artifactFromMetadata,
+  configurePublishableSigning,
   configureReleaseDebugSigning,
   generatedState,
+  normalizeFingerprint,
+  parseMode,
   pinnedEnv,
+  preparedState,
+  publishableBuildEnv,
+  readPublishableConfig,
+  removeOwnedSigning,
+  requirePrepared,
   requireExecutables,
   resolveJava,
   resolveNdk,
   resolveSdk,
+  runPublishableTransaction,
+  sanitizedEnv,
+  validatePublishableCredentials,
+  verifyPublishable,
 } from "./package-android.mjs";
-
 function temp(t) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "tuneforge-android-"));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
@@ -24,7 +38,6 @@ function executable(candidate) {
   fs.writeFileSync(candidate, "#!/bin/sh\n");
   fs.chmodSync(candidate, 0o755);
 }
-
 test("stale Java falls back to discovered JDK 17", () => {
   const files = new Set(["/java8/bin/java", "/java8/bin/javac", "/java17/bin/java", "/java17/bin/javac"]);
   const result = resolveJava({
@@ -37,7 +50,6 @@ test("stale Java falls back to discovered JDK 17", () => {
   });
   assert.equal(result.home, "/java17");
 });
-
 test("SDK uses matching environment before CLI and default", (t) => {
   const root = temp(t);
   const envSdk = path.join(root, "env");
@@ -55,7 +67,6 @@ test("SDK uses matching environment before CLI and default", (t) => {
   assert.equal(resolveSdk({ env: {}, homeDir: root,
     runCapture: () => ({ ok: true, output: cliSdk }) }), cliSdk);
 });
-
 test("NDK discovery delegates selection to the shared helper", (t) => {
   const root = temp(t);
   const ndk = path.join(root, "ndk/29.0.14206865");
@@ -69,7 +80,6 @@ test("NDK discovery delegates selection to the shared helper", (t) => {
   assert.equal(invocation[2].env.ANDROID_HOME, root);
   assert.equal(invocation[2].env.ANDROID_NDK_HOME, ndk);
 });
-
 function completeGenerated(root) {
   for (const relative of [
     "app/build.gradle.kts", "app/src/main/AndroidManifest.xml",
@@ -84,7 +94,6 @@ function completeGenerated(root) {
   fs.mkdirSync(path.join(root, "app/src/main/res"), { recursive: true });
   executable(path.join(root, "gradlew"));
 }
-
 test("generated state accepts initialized projects and still requires source markers", (t) => {
   const root = path.join(temp(t), "android");
   assert.equal(generatedState(root).state, "absent");
@@ -94,7 +103,19 @@ test("generated state accepts initialized projects and still requires source mar
   fs.rmSync(path.join(root, "app/src/main/java/com/tuneforge/desktop/MainActivity.kt"));
   assert.deepEqual(generatedState(root).missing, ["app/src/main/java/com/tuneforge/desktop/MainActivity.kt"]);
 });
-
+test("prepared state requires outputs owned by the explicit preparation command", (t) => {
+  const root = path.join(temp(t), "android");
+  completeGenerated(root);
+  assert.throws(() => requirePrepared(root), /Run pnpm package:android:prepare/);
+  for (const relative of ["app/proguard-tuneforge.pro",
+    "app/src/main/java/com/tuneforge/desktop/PowerInhibitionService.kt",
+    "app/src/main/res/values/ic_launcher_background.xml"]) {
+    const candidate = path.join(root, relative); fs.mkdirSync(path.dirname(candidate), { recursive: true });
+    fs.writeFileSync(candidate, "prepared");
+  }
+  assert.deepEqual(preparedState(root), { ready: true, missing: [] });
+  assert.doesNotThrow(() => requirePrepared(root));
+});
 test("release debug signing is marker-based and idempotent", (t) => {
   const buildFile = path.join(temp(t), "build.gradle.kts");
   fs.writeFileSync(buildFile, '        getByName("release") {\n            isMinifyEnabled = true\n');
@@ -104,16 +125,286 @@ test("release debug signing is marker-based and idempotent", (t) => {
   assert.equal(configureReleaseDebugSigning(buildFile), false);
   assert.equal(fs.readFileSync(buildFile, "utf8"), configured);
 });
-
-test("artifact metadata requires the exact universal variant and path", () => {
-  const metadata = JSON.stringify({
-    variantName: "universalRelease", elements: [{ outputFile: "app-universal-release.apk" }],
+test("packaging exposes explicit prepare, debug, local-release, and publishable modes", () => {
+  for (const [args, expected] of [[[], "local-release"], [["--prepare"], "prepare"],
+    [["--debug"], "debug"], [["--publishable"], "publishable"]]) assert.equal(parseMode(args), expected);
+  for (const args of [["--debug", "--publishable"], ["--release"]]) assert.throws(() => parseMode(args), /Usage/);
+});
+function signingEnv(keystore, fingerprint = "ab".repeat(32)) {
+  return {
+    TUNEFORGE_ANDROID_RELEASE_KEYSTORE_PATH: keystore,
+    TUNEFORGE_ANDROID_RELEASE_KEY_ALIAS: "release-key",
+    TUNEFORGE_ANDROID_RELEASE_STORE_PASSWORD: "store secret",
+    TUNEFORGE_ANDROID_RELEASE_KEY_PASSWORD: "key secret",
+    TUNEFORGE_ANDROID_RELEASE_EXPECTED_CERT_SHA256: fingerprint,
+  };
+}
+test("publishable inputs require complete environment values, an absolute readable file, and fingerprint syntax", (t) => {
+  const root = temp(t);
+  const keystore = path.join(root, "release.p12");
+  fs.writeFileSync(keystore, "unchanged");
+  const env = signingEnv(keystore);
+  assert.equal(readPublishableConfig(env).expectedFingerprint, "ab".repeat(32));
+  assert.equal(normalizeFingerprint(Array(32).fill("AB").join(":")), "ab".repeat(32));
+  for (const name of Object.keys(env)) assert.throws(() => readPublishableConfig({ ...env, [name]: "" }), /incomplete/);
+  for (const [candidate, message] of [["release.p12", /absolute/],
+    [path.join(root, "missing.p12"), /readable regular file/], [root, /readable regular file/]]) {
+    assert.throws(() => readPublishableConfig({ ...env,
+      TUNEFORGE_ANDROID_RELEASE_KEYSTORE_PATH: candidate }), message);
+  }
+  assert.throws(() => readPublishableConfig(env, { access: () => { throw new Error("denied"); } }), /readable/);
+  assert.throws(() => readPublishableConfig({ ...env,
+    TUNEFORGE_ANDROID_RELEASE_EXPECTED_CERT_SHA256: "invalid" }), /fingerprint/);
+});
+function credentialHarness(t) {
+  const root = temp(t);
+  const javaHome = path.join(root, "jdk");
+  for (const name of ["keytool", "jar", "jarsigner"]) executable(path.join(javaHome, "bin", name));
+  const keystore = path.join(root, "release.p12");
+  fs.writeFileSync(keystore, "keystore bytes");
+  const certificate = Buffer.from("certificate der");
+  return { root, java: { home: javaHome }, keystore, certificate,
+    fingerprint: crypto.createHash("sha256").update(certificate).digest("hex") };
+}
+test("credential preflight is secret-safe and reports categorical failures", (t) => {
+  const harness = credentialHarness(t);
+  const env = signingEnv(harness.keystore, harness.fingerprint);
+  const config = readPublishableConfig(env);
+  const runner = (failure, calls = []) => (command, args, options) => {
+    calls.push({ command, args, options });
+    if (failure === "store" && args.includes("-list") || failure === "alias" && args.includes("-exportcert") ||
+        failure === "key" && command.endsWith("jarsigner")) return { ok: false, output: "secret diagnostic" };
+    if (command.endsWith("keytool") && args.includes("-exportcert")) return { ok: true,
+      output: failure === "fingerprint" ? Buffer.from("other cert") : harness.certificate };
+    if (command.endsWith("jarsigner")) fs.writeFileSync(args[args.indexOf("-signedjar") + 1], "signed");
+    return { ok: true, output: "" };
+  };
+  const calls = [];
+  assert.equal(validatePublishableCredentials(harness.java, config, { env,
+    runSensitive: runner(undefined, calls), tempRoot: harness.root }), harness.fingerprint);
+  const serializedArgs = JSON.stringify(calls.map((call) => call.args));
+  assert.doesNotMatch(serializedArgs, /store secret|key secret/);
+  for (const provider of ["storepass:env", "keypass:env"]) assert.match(serializedArgs, new RegExp(provider));
+  for (const { command, args, options } of calls) {
+    const sensitive = command.endsWith("keytool") || command.endsWith("jarsigner");
+    if (sensitive) assert.equal(args[args.indexOf("-storetype") + 1], "PKCS12");
+    assert.equal(options.env.TUNEFORGE_ANDROID_RELEASE_STORE_PASSWORD, sensitive ? "store secret" : undefined);
+    assert.equal(options.env.TUNEFORGE_ANDROID_RELEASE_KEY_PASSWORD, command.endsWith("jarsigner") ? "key secret" : undefined);
+    for (const name of ["KEYSTORE_PATH", "EXPECTED_CERT_SHA256"]) assert.equal(
+      options.env[`TUNEFORGE_ANDROID_RELEASE_${name}`], undefined);
+  }
+  for (const [failure, message] of [["store", /PKCS12 or store password/], ["alias", /certificate alias/],
+    ["fingerprint", /fingerprint does not match/], ["key", /private key or key password/]]) {
+    assert.throws(() => validatePublishableCredentials(harness.java, config,
+      { env, tempRoot: harness.root, runSensitive: runner(failure) }), (error) => {
+      assert.match(error.message, message);
+      assert.doesNotMatch(error.message, /store secret|key secret|secret diagnostic/);
+      return true;
+    });
+  }
+  assert.equal(fs.readFileSync(harness.keystore, "utf8"), "keystore bytes");
+  assert.equal(fs.readdirSync(harness.root).some((name) => name.startsWith("tuneforge-android-signing-")), false);
+});
+test("JDK 17 validates a synthetic PKCS12 with environment password providers", (t) => {
+  let java;
+  try { java = resolveJava(); } catch { t.skip("JDK 17 unavailable"); return; }
+  const root = temp(t);
+  const keystore = path.join(root, "synthetic.p12");
+  const keytool = path.join(java.home, "bin/keytool");
+  const hash = (file) =>
+    crypto.createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+  const fixtureEnv = { ...sanitizedEnv(process.env), FIXTURE_STORE_PASSWORD: "storepass",
+    FIXTURE_KEY_PASSWORD: "storepass" };
+  const generated = spawnSync(keytool, ["-genkeypair", "-alias", "synthetic-release", "-keyalg", "RSA",
+    "-keysize", "2048", "-validity", "1", "-dname", "CN=TuneForge Synthetic Test", "-keystore", keystore,
+    "-storetype", "PKCS12", "-storepass:env", "FIXTURE_STORE_PASSWORD", "-keypass:env", "FIXTURE_KEY_PASSWORD",
+    "-noprompt"], { env: fixtureEnv, stdio: "ignore" });
+  assert.equal(generated.status, 0);
+  const certificate = spawnSync(keytool, ["-exportcert", "-alias", "synthetic-release", "-keystore", keystore,
+    "-storetype", "PKCS12", "-storepass:env", "FIXTURE_STORE_PASSWORD"],
+  { env: fixtureEnv, encoding: null, stdio: ["ignore", "pipe", "ignore"] });
+  assert.equal(certificate.status, 0);
+  const fingerprint = crypto.createHash("sha256").update(certificate.stdout).digest("hex");
+  const before = hash(keystore);
+  const env = signingEnv(keystore, fingerprint);
+  env.TUNEFORGE_ANDROID_RELEASE_KEY_ALIAS = "synthetic-release";
+  env.TUNEFORGE_ANDROID_RELEASE_STORE_PASSWORD = "storepass";
+  env.TUNEFORGE_ANDROID_RELEASE_KEY_PASSWORD = "storepass";
+  assert.equal(validatePublishableCredentials(java, readPublishableConfig(env), { env, tempRoot: root }), fingerprint);
+  assert.equal(hash(keystore), before);
+  assert.equal(fs.readdirSync(root).some((name) => name.startsWith("tuneforge-android-signing-")), false);
+});
+test("publishable Gradle signing is marker-owned, environment-only, restored cleanly, and has no debug fallback", () => {
+  const original = [
+    "android {", "    buildTypes {", '        getByName("release") {',
+    debugSigningLineForTest(), "            isMinifyEnabled = true", "        }", "    }", "}", "",
+  ].join("\n");
+  const configured = configurePublishableSigning(original);
+  assert.doesNotMatch(configured, /getByName\("debug"\)/);
+  assert.match(configured, /getByName\("tuneforgePublishable"\)/);
+  assert.match(configured, /storeType = "PKCS12"/);
+  for (const name of ["KEYSTORE_PATH", "KEY_ALIAS", "STORE_PASSWORD", "KEY_PASSWORD"]) {
+    assert.match(configured, new RegExp(`System\\.getenv\\("TUNEFORGE_ANDROID_RELEASE_${name}"\\)`));
+  }
+  assert.doesNotMatch(configured, /store secret|key secret/);
+  assert.equal(removeOwnedSigning(configured),
+    original.replace(`${debugSigningLineForTest()}\n`, ""));
+  assert.equal(configurePublishableSigning(configured), configured);
+});
+function debugSigningLineForTest() {
+  return '            signingConfig = signingConfigs.getByName("debug")';
+}
+test("publishable verification requires strict apksigner flags, one signer, fingerprint, and Tauri version", () => {
+  const fingerprint = "ab".repeat(32);
+  const calls = [];
+  const success = (command, args) => {
+    calls.push([command, args]);
+    if (command === "/apksigner") return { ok: true, output: `Signer #1 certificate SHA-256 digest: ${fingerprint}` };
+    return { ok: true, output: "package: name='com.tuneforge.desktop' versionName='1.2.3'\nnative-code: 'arm64-v8a'" };
+  };
+  assert.doesNotThrow(() => verifyPublishable("/app.apk",
+    { apksigner: "/apksigner", aapt2: "/aapt2" }, fingerprint, "1.2.3", { runCapture: success }));
+  assert.deepEqual(calls[0][1], ["verify", "--verbose", "--print-certs", "--Werr", "/app.apk"]);
+  const verifyWith = (signature, badging = "versionName='1.2.3'\nnative-code: 'arm64-v8a'") => verifyPublishable("/app.apk",
+    { apksigner: "/apksigner", aapt2: "/aapt2" }, fingerprint, "1.2.3", {
+      runCapture: (command) => ({ ok: true, output: command === "/apksigner" ? signature : badging }),
+    });
+  const signer = `Signer #1 certificate SHA-256 digest: ${fingerprint}`;
+  for (const [signature, badging, message] of [
+    ["", undefined, /exactly one signer/],
+    [`${signer}\nSigner #2 certificate SHA-256 digest: ${fingerprint}`, undefined, /exactly one signer/],
+    [`Signer #1 certificate SHA-256 digest: ${"cd".repeat(32)}`, undefined, /expected certificate/],
+    [signer, "versionName='9.9.9'\nnative-code: 'arm64-v8a'", /versionName/],
+    [signer, "versionName='1.2.3' application-debuggable\nnative-code: 'arm64-v8a'", /non-debuggable/],
+  ]) assert.throws(() => verifyWith(signature, badging), message);
+  assert.throws(() => verifyPublishable("/app.apk", { apksigner: "/apksigner", aapt2: "/aapt2" },
+    fingerprint, "1.2.3", { runCapture: () => ({ ok: false, output: "secret diagnostic" }) }), /signature verification/);
+});
+test("release variables are removed from unrelated children and scoped to the publishable build", () => {
+  const source = { KEEP: "yes", ...signingEnv("/release.p12") };
+  const clean = sanitizedEnv(source);
+  assert.deepEqual(clean, { KEEP: "yes" });
+  assert.deepEqual(source, { KEEP: "yes", ...signingEnv("/release.p12") });
+  const build = publishableBuildEnv(clean, source);
+  assert.equal(build.KEEP, "yes");
+  for (const name of ["KEYSTORE_PATH", "KEY_ALIAS", "STORE_PASSWORD", "KEY_PASSWORD"]) {
+    assert.equal(build[`TUNEFORGE_ANDROID_RELEASE_${name}`], source[`TUNEFORGE_ANDROID_RELEASE_${name}`]);
+  }
+  assert.equal(build.TUNEFORGE_ANDROID_RELEASE_EXPECTED_CERT_SHA256, undefined);
+  const discoveryCalls = [];
+  const discoveryEnv = sanitizedEnv({ JAVA_HOME: "/java17", ...signingEnv("/release.p12") });
+  resolveJava({ env: discoveryEnv, hostPlatform: "darwin",
+    isExecutable: () => true,
+    runCapture: (command, args, options) => {
+      discoveryCalls.push({ command, args, options });
+      return { ok: true, output: command === "/usr/libexec/java_home" ? "/java17" : 'openjdk version "17.0.20"' };
+    },
   });
+  assert.equal(discoveryCalls.every((call) => call.options.env.TUNEFORGE_ANDROID_RELEASE_STORE_PASSWORD === undefined), true);
+});
+test("packaging lock rejects contention and never removes a lock whose ownership changed", (t) => {
+  const lockPath = path.join(temp(t), "target/package.lock");
+  const first = acquirePackagingLock(lockPath, { token: "owner-one" });
+  assert.throws(() => acquirePackagingLock(lockPath, { token: "owner-two" }), /already locked/);
+  const owner = path.join(lockPath, "owner");
+  assert.equal(fs.readFileSync(owner, "utf8"), "owner-one");
+  fs.writeFileSync(owner, "other-owner");
+  assert.equal(first.release(), false);
+  assert.equal(fs.existsSync(lockPath), true);
+  fs.writeFileSync(owner, "owner-one");
+  assert.equal(first.release(), true);
+  assert.equal(first.release(), true);
+  assert.equal(fs.existsSync(lockPath), false);
+});
+function transactionHarness(t) {
+  const root = temp(t);
+  const buildFile = path.join(root, "build.gradle.kts");
+  const originalGradle = "original generated Gradle bytes\n";
+  fs.writeFileSync(buildFile, originalGradle);
+  const intermediates = ["app.apk", "output-metadata.json", "mapping.txt"]
+    .map((name) => path.join(root, "generated", name));
+  const [rawApk, metadataPath, mapping] = intermediates;
+  for (const [index, file] of intermediates.entries()) {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, `prior-${index}`);
+  }
+  const outputDir = path.join(root, "bundle");
+  const destination = path.join(outputDir, "publishable.apk");
+  const staging = path.join(outputDir, ".publishable.attempt-one.tmp");
+  fs.mkdirSync(outputDir);
+  fs.writeFileSync(destination, "prior-final");
+  const tempHome = path.join(root, "android-home");
+  fs.mkdirSync(tempHome);
+  const build = () => {
+    assert.equal(intermediates.every((file) => !fs.existsSync(file)), true);
+    for (const [file, contents] of [[rawApk, "new-apk"], [metadataPath, "current metadata"],
+      [mapping, "new-mapping"]]) fs.writeFileSync(file, contents);
+  };
+  return { buildFile, originalGradle, rawApk, metadataPath, mapping,
+    intermediates, destination, staging, tempHome, build, resolveRaw: () => rawApk };
+}
+function runHarnessAttempt(harness, overrides = {}, operations = {}) {
+  return runPublishableTransaction({ ...harness, configure: () => "temporary signing config with environment names only\n",
+    validate: () => {}, ...overrides }, operations);
+}
+test("publishable transaction validates unique staged bytes before atomic destination rename", (t) => {
+  const harness = transactionHarness(t);
+  const otherAttempt = path.join(path.dirname(harness.staging), ".publishable.other-attempt.tmp");
+  fs.writeFileSync(otherAttempt, "other invocation");
+  const order = [];
+  const result = runHarnessAttempt(harness, { validate: (apk) => {
+    order.push("validate");
+    assert.equal(apk, harness.staging);
+    assert.equal(fs.readFileSync(apk, "utf8"), "new-apk");
+    assert.equal(fs.readFileSync(harness.destination, "utf8"), "prior-final");
+  } }, {
+    write: (file, contents) => { if (contents === harness.originalGradle) order.push("restore"); fs.writeFileSync(file, contents); },
+    cleanupTemp: (candidate) => {
+      order.push("temp-cleanup");
+      fs.rmSync(candidate, { recursive: true, force: true });
+    },
+    rename: (from, to) => { if (from === harness.staging) order.push("rename"); fs.renameSync(from, to); },
+  });
+  assert.equal(result, harness.destination);
+  assert.deepEqual(order, ["validate", "restore", "temp-cleanup", "rename"]);
+  assert.equal(fs.readFileSync(harness.destination, "utf8"), "new-apk");
+  assert.equal(fs.readFileSync(harness.buildFile, "utf8"), harness.originalGradle);
+  assert.deepEqual(harness.intermediates.map((file) => fs.readFileSync(file, "utf8")), ["new-apk", "current metadata", "new-mapping"]);
+  assert.equal(fs.existsSync(harness.tempHome), false);
+  assert.equal(fs.readFileSync(otherAttempt, "utf8"), "other invocation");
+});
+for (const failure of ["build", "validation", "temp cleanup"]) {
+  test(`publishable transaction removes attempt outputs and preserves final after ${failure} failure`, (t) => {
+    const harness = transactionHarness(t);
+    const build = () => { harness.build(); if (failure === "build") throw new Error("build failure"); };
+    const validate = () => { if (failure === "validation") throw new Error("validation failure"); };
+    const cleanupTemp = (candidate) => {
+      fs.rmSync(candidate, { recursive: true, force: true });
+      if (failure === "temp cleanup") throw new Error("temp cleanup failure");
+    };
+    assert.throws(() => runHarnessAttempt(harness, { build, validate }, { cleanupTemp }), new RegExp(failure));
+    assert.equal(fs.readFileSync(harness.buildFile, "utf8"), harness.originalGradle);
+    assert.equal(harness.intermediates.every((file) => !fs.existsSync(file)), true);
+    assert.equal(fs.readFileSync(harness.destination, "utf8"), "prior-final");
+    assert.equal(fs.existsSync(harness.staging), false);
+    assert.equal(fs.existsSync(harness.tempHome), false);
+  });
+}
+test("artifact metadata requires the exact universal variant and path", () => {
+  const valid = { artifactType: { type: "APK" }, variantName: "universalRelease",
+    elements: [{ type: "SINGLE", filters: [], outputFile: "app-universal-release.apk" }] };
+  const metadata = JSON.stringify(valid);
   assert.equal(artifactFromMetadata(metadata, false, "/out/output-metadata.json"),
     "/out/app-universal-release.apk");
   assert.throws(() => artifactFromMetadata(metadata, true, "/out/output-metadata.json"), /universalDebug/);
+  for (const invalid of [
+    { ...valid, artifactType: { type: "BUNDLE" } },
+    { ...valid, elements: [{ ...valid.elements[0], type: "SPLIT" }] },
+    { ...valid, elements: [{ ...valid.elements[0], filters: [{ filterType: "ABI", value: "arm64-v8a" }] }] },
+    { ...valid, elements: [{ ...valid.elements[0], outputFile: "../unsafe-release.apk" }] },
+  ]) assert.throws(() => artifactFromMetadata(JSON.stringify(invalid), false,
+    "/out/output-metadata.json"), /safe unfiltered/);
 });
-
 test("Android preference homes and tool executability are deterministic", (t) => {
   const root = temp(t);
   const env = pinnedEnv({ home: "/java" }, "/sdk", { path: "/ndk", version: "29.0.1" }, {
@@ -123,10 +414,33 @@ test("Android preference homes and tool executability are deterministic", (t) =>
   assert.equal(env.ANDROID_USER_HOME, path.join(root, ".android"));
   assert.equal(env.ANDROID_SDK_HOME, root);
   assert.equal(env.ANDROID_PREFS_ROOT, root);
+  assert.equal(env.GRADLE_USER_HOME, path.join(root, ".gradle"));
+  assert.match(env.GRADLE_OPTS, /-Dorg\.gradle\.daemon=false/);
   assert.match(env.CARGO_TARGET_DIR, /android-ndk-29-0-1$/);
   const tool = path.join(root, "apksigner");
   executable(tool);
   assert.doesNotThrow(() => requireExecutables([tool]));
   fs.chmodSync(tool, 0o644);
   assert.throws(() => requireExecutables([tool]), /apksigner/);
+});
+test("only the explicit prepare mode initializes, generates icons, and prepares generated Android", () => {
+  const source = fs.readFileSync(new URL("./package-android.mjs", import.meta.url), "utf8");
+  for (const pattern of [/"android", "init"/g, /Android icon generation/g, /\[prepareGenerated\]/g]) {
+    assert.equal(source.match(pattern)?.length, 1);
+  }
+  assert.match(source, /validate-android-release-jni\.mjs"\), "--apk", apk/);
+  assert.doesNotMatch(source, /\.android\/debug\.keystore|Existing debug keystore required/);
+  const rootScripts = JSON.parse(fs.readFileSync(new URL("../package.json", import.meta.url), "utf8")).scripts;
+  const desktopScripts = JSON.parse(fs.readFileSync(new URL("../apps/desktop/package.json", import.meta.url), "utf8")).scripts;
+  assert.equal(rootScripts["package:android:prepare"], "pnpm --filter @tuneforge/desktop android:prepare");
+  assert.equal(desktopScripts["android:prepare"], "node ../../scripts/package-android.mjs --prepare");
+  assert.equal(Object.values(desktopScripts).filter((command) => command.includes("--prepare")).length, 1);
+  const tracked = ["../.gitignore", "../docs/MOBILE.md", "../docs/PACKAGING.md"]
+    .map((file) => fs.readFileSync(new URL(file, import.meta.url), "utf8")).join("\n");
+  for (const extension of ["p12", "pfx", "jks", "keystore"]) {
+    assert.match(tracked, new RegExp(`^\\*\\.${extension}$`, "m"));
+  }
+  const privateSourceTerms = [["kee", "pass", "xc"], ["password", " manager"], ["attach", "ment"]]
+    .map((parts) => parts.join(""));
+  assert.doesNotMatch(tracked, new RegExp(privateSourceTerms.join("|"), "i"));
 });

--- a/scripts/validate-android-release-jni.mjs
+++ b/scripts/validate-android-release-jni.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -129,27 +129,36 @@ function parseDexXml(xml) {
   return targets;
 }
 
-export function validateReleaseJni({ root = workspaceRoot, run = runCommand } = {}) {
+export function validateReleaseJni({ root = workspaceRoot, run = runCommand, apk, sdkRoot,
+  env = process.env } = {}) {
   const rules = parseJniRules(readFileSync(path.join(root, "apps/desktop/src-tauri/proguard-tuneforge.pro"), "utf8"));
-  const apk = resolveReleaseArtifact(path.join(root, "apps/desktop/src-tauri/gen/android/app/build/outputs/apk/universal/release/output-metadata.json"));
-  const sdkRoot = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT || path.join(os.homedir(), "Library/Android/sdk");
-  const tools = selectAndroidTools(sdkRoot);
-  const badging = run(tools.aapt2, ["dump", "badging", apk]);
+  const artifact = apk ? path.resolve(apk) : resolveReleaseArtifact(path.join(root,
+    "apps/desktop/src-tauri/gen/android/app/build/outputs/apk/universal/release/output-metadata.json"));
+  if (!statSync(artifact, { throwIfNoEntry: false })?.isFile()) throw new Error("Release APK is missing or not a regular file.");
+  const tools = selectAndroidTools(sdkRoot || env.ANDROID_HOME || env.ANDROID_SDK_ROOT ||
+    path.join(os.homedir(), "Library/Android/sdk"));
+  const badging = run(tools.aapt2, ["dump", "badging", artifact]);
   if (/application-debuggable/.test(badging) || !/native-code:.*'arm64-v8a'/.test(badging)) {
     throw new Error("Release APK must be non-debuggable and contain arm64-v8a native code.");
   }
-  run(tools.apksigner, ["verify", "--verbose", apk]);
+  run(tools.apksigner, ["verify", "--verbose", artifact]);
   let tempDir;
   try {
-    const dexFiles = run("unzip", ["-Z1", apk]).split("\n").filter((file) => /^classes\d*\.dex$/.test(file)).sort(compareDexNames);
+    const dexFiles = run("unzip", ["-Z1", artifact]).split("\n").filter((file) => /^classes\d*\.dex$/.test(file)).sort(compareDexNames);
     if (!dexFiles.length) throw new Error("Release APK contains no classes*.dex files.");
     tempDir = mkdtempSync(path.join(os.tmpdir(), "tuneforge-jni-dex-"));
-    run("unzip", ["-qq", apk, ...dexFiles, "-d", tempDir]);
+    run("unzip", ["-qq", artifact, ...dexFiles, "-d", tempDir]);
     const xmlDocuments = dexFiles.map((file) => run(tools.dexdump, ["-l", "xml", path.join(tempDir, file)]));
     assertDexMethods(xmlDocuments, rules);
   } finally {
     if (tempDir) rmSync(tempDir, { recursive: true, force: true });
   }
+}
+
+export function parseCli(argv) {
+  if (argv.length === 0) return {};
+  if (argv.length === 2 && argv[0] === "--apk" && argv[1]) return { apk: argv[1] };
+  throw new Error("Usage: validate-android-release-jni.mjs [--apk <path>]");
 }
 
 function javaDescriptor(type) {
@@ -182,7 +191,7 @@ function runCommand(command, args) {
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   try {
-    validateReleaseJni();
+    validateReleaseJni(parseCli(process.argv.slice(2)));
     console.log("Android release JNI validation passed.");
   } catch (error) {
     console.error(`Android release JNI validation failed: ${error.message}`);

--- a/scripts/validate-android-release-jni.test.mjs
+++ b/scripts/validate-android-release-jni.test.mjs
@@ -3,7 +3,8 @@ import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { assertDexMethods, parseJniRules, resolveReleaseArtifact, selectAndroidTools } from "./validate-android-release-jni.mjs";
+import { assertDexMethods, parseCli, parseJniRules, resolveReleaseArtifact, selectAndroidTools,
+  validateReleaseJni } from "./validate-android-release-jni.mjs";
 
 const rules = `-keepclassmembers class com.tuneforge.desktop.MainActivity {
     public java.lang.String setTuneForgePowerInhibition(int);
@@ -36,6 +37,32 @@ test("accepts only one safe universal release APK output", () => {
   assert.equal(resolveReleaseArtifact(metadata), apk);
   writeFileSync(metadata, JSON.stringify({ artifactType: { type: "APK" }, variantName: "universalRelease", elements: [{ type: "SINGLE", filters: [], outputFile: "../unsafe.apk" }] }));
   assert.throws(() => resolveReleaseArtifact(metadata), /unsafe/);
+});
+
+test("validates an explicit APK, falls through empty SDK values, and rejects invalid CLI forms", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-jni-explicit-"));
+  const rulesPath = path.join(root, "apps/desktop/src-tauri/proguard-tuneforge.pro");
+  mkdirSync(path.dirname(rulesPath), { recursive: true }); writeFileSync(rulesPath, rules);
+  const apk = path.join(root, "staged.apk"); writeFileSync(apk, "apk");
+  const sdkRoot = path.join(root, "sdk");
+  for (const tool of ["aapt2", "apksigner", "dexdump"]) {
+    const candidate = path.join(sdkRoot, "build-tools/36.0.0", tool);
+    mkdirSync(path.dirname(candidate), { recursive: true }); writeFileSync(candidate, "");
+  }
+  const calls = [];
+  validateReleaseJni({ root, apk, sdkRoot: "", env: { ANDROID_HOME: "", ANDROID_SDK_ROOT: sdkRoot },
+    run: (command, args) => {
+      calls.push([command, args]);
+      if (command.endsWith("aapt2")) return "native-code: 'arm64-v8a'";
+      if (command === "unzip" && args[0] === "-Z1") return "classes.dex";
+      if (command.endsWith("dexdump")) return dexXml(parseJniRules(rules));
+      return "";
+    },
+  });
+  assert.equal(calls.filter(([, args]) => args.includes(apk)).length, 4);
+  assert.deepEqual(parseCli(["--apk", apk]), { apk });
+  for (const argv of [["--apk"], ["--other", apk], ["--apk", apk, "extra"]]) assert.throws(() => parseCli(argv), /Usage/);
+  assert.throws(() => validateReleaseJni({ root, apk: path.join(root, "missing.apk"), sdkRoot }), /missing/);
 });
 
 test("selects highest complete Android build-tools version", () => {


### PR DESCRIPTION
## Summary

- Separate Android preparation from three build modes: debug, local optimized, and publishable release.
- Add PKCS12-only dedicated release signing with credential, fingerprint, signer, artifact, and cleanup validation.
- Produce a versioned APK for direct GitHub Release distribution. Closes #418.

## Testing

- `node --test scripts/package-android.test.mjs scripts/validate-android-release-jni.test.mjs`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm release:check-version`
- `git diff --check`
- `pnpm package:android:prepare`
- `pnpm package:android:debug`
- `pnpm package:android`
- `pnpm package:android:release` passed with an externally supplied PKCS12 signer.
