### PR TITLE
docs: add curated changelog

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,6 +30,8 @@
 - [ ] `pnpm typecheck` passes
 - [ ] `pnpm test` passes (desktop + Tauri shell + backend)
 - [ ] If backend routes or schemas changed, ran `pnpm contracts:generate` and committed the result
+- [ ] If this PR includes noteworthy product behavior, updated `CHANGELOG.md`'s `[Unreleased]`
+  section
 - [ ] If release/package behavior changed or this PR prepares a release package, included Release Package Gate evidence from
   `docs/PACKAGING.md#release-package-gate` (package build plus packaged launch smoke with OS,
   artifact type, commit SHA, and pass/fail evidence); when release/package behavior changed, also

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
                 .github/workflows/ci.yml)
                   full_gate=true
                   ;;
-                .agents/*|.codex/environments/*|docs/*|README.md|CONTRIBUTING.md|CODE_OF_CONDUCT.md|LICENSE|THIRD_PARTY_NOTICES.md|SECURITY.md|AGENTS.md|.gitignore|packaging/flatpak/*|.github/ISSUE_TEMPLATE/*|.github/PULL_REQUEST_TEMPLATE.md)
+                .agents/*|.codex/environments/*|docs/*|CHANGELOG.md|README.md|CONTRIBUTING.md|CODE_OF_CONDUCT.md|LICENSE|THIRD_PARTY_NOTICES.md|SECURITY.md|AGENTS.md|.gitignore|packaging/flatpak/*|.github/ISSUE_TEMPLATE/*|.github/PULL_REQUEST_TEMPLATE.md)
                   ;;
                 *)
                   full_gate=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,10 @@ When asked to implement a change:
 - Keep docs aligned with behavior; if user-visible behavior changed, update docs in the same PR.
 - Prefer updating existing docs under `docs/` instead of adding near-duplicate pages.
 - Link docs with relative paths and keep section anchors stable where practical.
+- Add a concise `CHANGELOG.md` `[Unreleased]` entry in the same PR for noteworthy product
+  changes. Internal-only CI, test, dependency, and documentation changes do not need an entry.
+- During release preparation, reconcile Git and GitHub history, date and promote the release
+  section, and update compare links. The changelog is product history, not release operations.
 
 ## Release Media
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,86 @@
+# Changelog
+
+This is a curated history of noteworthy product changes. GitHub Releases own
+download, installation, verification, signature, and publication instructions.
+
+## [Unreleased]
+
+## [1.0.1] - Pending
+
+### Added
+
+- Mobile storage parity, a practice workspace, synced lyrics and chords, and native tuner capture
+  ([#339](https://github.com/grazzolini/tuneforge/pull/339),
+  [#354](https://github.com/grazzolini/tuneforge/pull/354),
+  [#364](https://github.com/grazzolini/tuneforge/pull/364),
+  [#367](https://github.com/grazzolini/tuneforge/pull/367),
+  [#369](https://github.com/grazzolini/tuneforge/pull/369)).
+- Cross-platform wake inhibition for playback and sync
+  ([#361](https://github.com/grazzolini/tuneforge/pull/361)).
+- Dedicated Android release signing for publishable APKs
+  ([#422](https://github.com/grazzolini/tuneforge/pull/422)).
+- Added this curated product changelog.
+
+### Changed
+
+- Improved synced mobile lyrics, native and Web Audio playback, and responsive controls
+  ([#352](https://github.com/grazzolini/tuneforge/pull/352),
+  [#359](https://github.com/grazzolini/tuneforge/pull/359),
+  [#368](https://github.com/grazzolini/tuneforge/pull/368),
+  [#370](https://github.com/grazzolini/tuneforge/pull/370)).
+- Strengthened sync and project-storage handling across mobile and desktop
+  ([#328](https://github.com/grazzolini/tuneforge/pull/328),
+  [#341](https://github.com/grazzolini/tuneforge/pull/341),
+  [#343](https://github.com/grazzolini/tuneforge/pull/343),
+  [#344](https://github.com/grazzolini/tuneforge/pull/344),
+  [#348](https://github.com/grazzolini/tuneforge/pull/348),
+  [#349](https://github.com/grazzolini/tuneforge/pull/349),
+  [#350](https://github.com/grazzolini/tuneforge/pull/350),
+  [#351](https://github.com/grazzolini/tuneforge/pull/351),
+  [#365](https://github.com/grazzolini/tuneforge/pull/365)).
+- Consolidated pre-v1 migration history into a v1 database baseline
+  ([#372](https://github.com/grazzolini/tuneforge/pull/372)).
+- Updated Android packaging prerequisites and made package commands self-contained
+  ([#378](https://github.com/grazzolini/tuneforge/pull/378),
+  [#382](https://github.com/grazzolini/tuneforge/pull/382)).
+
+### Fixed
+
+- Corrected playback layout and sync provenance/status display
+  ([#330](https://github.com/grazzolini/tuneforge/pull/330),
+  [#363](https://github.com/grazzolini/tuneforge/pull/363)).
+- Preserved stem playback controls and improved project renaming
+  ([#375](https://github.com/grazzolini/tuneforge/pull/375)).
+- Improved sync-transfer wake handling and stale-screen protection
+  ([#408](https://github.com/grazzolini/tuneforge/pull/408),
+  [#413](https://github.com/grazzolini/tuneforge/pull/413)).
+- Fixed Android sync-evidence copy and export
+  ([#414](https://github.com/grazzolini/tuneforge/pull/414)).
+- Allowed Flatpak logind inhibition during playback
+  ([#416](https://github.com/grazzolini/tuneforge/pull/416)).
+- Corrected generated Android app icons and JNI/release-build compatibility
+  ([#327](https://github.com/grazzolini/tuneforge/pull/327),
+  [#381](https://github.com/grazzolini/tuneforge/pull/381),
+  [#412](https://github.com/grazzolini/tuneforge/pull/412)).
+
+## [1.0.0] - 2026-07-03
+
+### Added
+
+- Imported local audio and video into projects stored in an on-device library.
+- Analyzed key, tempo, chords, and lyrics; edited lyrics and followed the transcript during playback.
+- Separated tracks into Demucs-generated stems for mix and practice control.
+- Practiced with persistent desktop playback, tempo changes, loops, count-in, and OS media
+  controls.
+- Previewed pitch-shifted and retuned mixes, then exported custom practice versions.
+- Included a chromatic tuner plus guitar, piano, and accordion chord dictionaries with live chord
+  follow.
+- Made import and processing work visible through Activity queues, runtime status, and progress.
+- Kept the desktop experience local-only and single-user: no account, upload, or cloud service.
+
+### Changed
+
+- Development used `0.1.0` metadata; `v1.0.0` was the first tagged release.
+
+[1.0.1]: https://github.com/grazzolini/tuneforge/compare/v1.0.0...main
+[1.0.0]: https://github.com/grazzolini/tuneforge/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Security reports follow the process in [SECURITY.md](./SECURITY.md). "There is n
 
 ## Documentation
 
+- [Changelog](./CHANGELOG.md)
 - [Product specification](./docs/SPEC.md)
 - [Third-party notices and release package policy](./THIRD_PARTY_NOTICES.md)
 - [Stem separation](./docs/STEM_SEPARATION.md)

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -21,6 +21,12 @@ packaged launch smoke pass are both recorded for each intended artifact. Missing
 or smoke evidence fails the gate closed; do not substitute `pnpm dev`, a dev server, or
 an unpackaged Tauri run for packaged-artifact proof.
 
+Before tagging, verify the release changelog section against changes since the previous tag. Promote
+and merge the completed `[Unreleased]` entries into the release section, then leave a new empty
+`[Unreleased]` section. Freeze the release comparison at `previous-tag...new-tag` and reset the
+`[Unreleased]` comparison to `new-tag...main`. Operational artifact, installation, checksum,
+signature, and upload instructions belong in the GitHub Release notes.
+
 Run the pre-tag checks from the intended release commit:
 
 ```sh


### PR DESCRIPTION
## Summary

- Add a curated changelog with pending v1.0.1 changes and detailed v1.0.0 launch highlights.
- Document continuous `[Unreleased]` maintenance and release-time promotion guidance.
- Link the changelog from the README and add a conditional PR checklist reminder.
- Keep root `CHANGELOG.md` changes on the documentation-only CI path.

## Testing

- `git diff --check`
- `actionlint .github/workflows/ci.yml`
- Bash path-classifier proof: `CHANGELOG.md` skips the full gate while unknown root files retain it.
- Product test suites not run because this changes documentation and CI scoping only. Run them with
  `pnpm lint && pnpm typecheck && pnpm test` if full regression coverage is required.
