### PR TITLE
test: make animation frame mocks deterministic

### DIFF
--- a/apps/desktop/src/App.project-tempo.test.tsx
+++ b/apps/desktop/src/App.project-tempo.test.tsx
@@ -1,7 +1,8 @@
-import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  advanceMockAnimationFrames,
   emitMockNativePlaybackError,
   emitMockNativePlaybackPosition,
   findAudioByArtifactId,
@@ -627,6 +628,10 @@ describe("Desktop app project playback tempo", () => {
     await user.click(screen.getByRole("button", { name: "Decrease playback tempo" }));
     await user.click(screen.getByRole("button", { name: "Increase playback tempo" }));
     await waitForTempoSummary("118 BPM (0.983x)");
+    await act(async () => {});
+    act(() => {
+      advanceMockAnimationFrames(5);
+    });
 
     await waitFor(() => expect(vocalAudio.playbackRate).toBeCloseTo(118 / 120, 4));
     expect(instrumentalAudio.playbackRate).toBeCloseTo(118 / 120, 4);

--- a/apps/desktop/src/App.tools-metronome.test.tsx
+++ b/apps/desktop/src/App.tools-metronome.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  advanceMockAnimationFrames,
   findAudioByArtifactId,
   getMockAudioContexts,
   markAudioReady,
@@ -154,6 +155,9 @@ describe("Desktop app tools metronome", () => {
     const sourceAudio = findAudioByArtifactId("art_source");
     markAudioReady(sourceAudio);
     await user.click(screen.getByRole("tab", { name: "Playback" }));
+    const playbackPosition = screen.getByLabelText("Playback position");
+    fireEvent.change(playbackPosition, { target: { value: "0.49" } });
+    expect(playbackPosition).toHaveValue("0.49");
     await user.click(screen.getByRole("button", { name: "Play playback" }));
     await waitFor(() =>
       expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument(),
@@ -162,6 +166,11 @@ describe("Desktop app tools metronome", () => {
     await user.click(screen.getByRole("link", { name: "Tools" }));
     await user.click(await screen.findByRole("tab", { name: "Metronome" }));
     await user.click(screen.getByLabelText("Follow project playback"));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getAllByText("Following Demo Song").length).toBeGreaterThan(0));
+    act(() => {
+      advanceMockAnimationFrames();
+    });
 
     await waitFor(() =>
       expect(getMetronomeAudioContext()?.createdOscillators.length).toBeGreaterThan(0),
@@ -173,9 +182,19 @@ describe("Desktop app tools metronome", () => {
     await waitFor(() =>
       expect(screen.getAllByText("Waiting for Demo Song playback").length).toBeGreaterThan(0),
     );
+    act(() => {
+      advanceMockAnimationFrames();
+    });
     expect(syncedContext?.close).not.toHaveBeenCalled();
 
     await user.click(screen.getByRole("button", { name: "Play background playback" }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Pause background playback" })).toBeInTheDocument(),
+    );
+    await waitFor(() => expect(screen.getAllByText("Following Demo Song").length).toBeGreaterThan(0));
+    act(() => {
+      advanceMockAnimationFrames();
+    });
     await waitFor(() =>
       expect(syncedContext?.createdOscillators.length).toBeGreaterThan(scheduledBeforePause),
     );
@@ -190,18 +209,21 @@ describe("Desktop app tools metronome", () => {
     const sourceAudio = findAudioByArtifactId("art_source");
     markAudioReady(sourceAudio);
     await user.click(screen.getByRole("tab", { name: "Playback" }));
+    const playbackPosition = screen.getByLabelText("Playback position");
+    fireEvent.change(playbackPosition, { target: { value: "0.45" } });
+    expect(playbackPosition).toHaveValue("0.45");
     await user.click(screen.getByRole("button", { name: "Play playback" }));
     await waitFor(() =>
       expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument(),
     );
-    act(() => {
-      sourceAudio.currentTime = 0.45;
-      fireEvent.timeUpdate(sourceAudio);
-    });
-
     await user.click(screen.getByRole("link", { name: "Tools" }));
     await user.click(await screen.findByRole("tab", { name: "Metronome" }));
     await user.click(screen.getByLabelText("Follow project playback"));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getAllByText("Following Demo Song").length).toBeGreaterThan(0));
+    act(() => {
+      advanceMockAnimationFrames();
+    });
 
     await waitFor(() => {
       const frequencies =
@@ -220,6 +242,9 @@ describe("Desktop app tools metronome", () => {
     const sourceAudio = findAudioByArtifactId("art_source");
     markAudioReady(sourceAudio);
     await user.click(screen.getByRole("tab", { name: "Playback" }));
+    const playbackPosition = screen.getByLabelText("Playback position");
+    fireEvent.change(playbackPosition, { target: { value: "0.49" } });
+    expect(playbackPosition).toHaveValue("0.49");
     await user.click(screen.getByRole("button", { name: "Play playback" }));
     await waitFor(() =>
       expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument(),
@@ -228,6 +253,11 @@ describe("Desktop app tools metronome", () => {
     await user.click(screen.getByRole("link", { name: "Tools" }));
     await user.click(await screen.findByRole("tab", { name: "Metronome" }));
     await user.click(screen.getByLabelText("Follow project playback"));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getAllByText("Following Demo Song").length).toBeGreaterThan(0));
+    act(() => {
+      advanceMockAnimationFrames();
+    });
     await waitFor(() =>
       expect(getMetronomeAudioContext()?.createdOscillators.length).toBeGreaterThan(0),
     );

--- a/apps/desktop/src/setupTests.ts
+++ b/apps/desktop/src/setupTests.ts
@@ -344,7 +344,7 @@ let mockAudioSourceStartError: Error | null = null;
 const RAF_STEP_SECONDS = 1 / 60;
 let nextAnimationFrameId = 1;
 let mockAnimationTimeMs = 0;
-const pendingAnimationFrames = new Map<number, ReturnType<typeof setTimeout>>();
+const pendingAnimationFrames = new Map<number, FrameRequestCallback>();
 
 function advanceMockAudioTime(seconds: number) {
   mockAudioContexts.forEach((audioContext) => {
@@ -352,31 +352,60 @@ function advanceMockAudioTime(seconds: number) {
   });
 }
 
+const mockRequestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+  const frameId = nextAnimationFrameId++;
+  pendingAnimationFrames.set(frameId, callback);
+  return frameId;
+});
+
+const mockCancelAnimationFrame = vi.fn((frameId: number) => {
+  pendingAnimationFrames.delete(frameId);
+});
+
 Object.defineProperty(window, "requestAnimationFrame", {
   writable: true,
-  value: vi.fn((callback: FrameRequestCallback) => {
-    const frameId = nextAnimationFrameId++;
-    const timer = setTimeout(() => {
-      pendingAnimationFrames.delete(frameId);
-      mockAnimationTimeMs += RAF_STEP_SECONDS * 1000;
-      advanceMockAudioTime(RAF_STEP_SECONDS);
-      callback(mockAnimationTimeMs);
-    }, 0);
-    pendingAnimationFrames.set(frameId, timer);
-    return frameId;
-  }),
+  value: mockRequestAnimationFrame,
 });
 
 Object.defineProperty(window, "cancelAnimationFrame", {
   writable: true,
-  value: vi.fn((frameId: number) => {
-    const timer = pendingAnimationFrames.get(frameId);
-    if (!timer) {
-      return;
+  value: mockCancelAnimationFrame,
+});
+
+function advanceMockAnimationFrames(count = 1) {
+  if (!Number.isInteger(count) || count < 0) {
+    throw new RangeError("Mock animation frame count must be a non-negative integer.");
+  }
+
+  for (let frame = 0; frame < count; frame += 1) {
+    mockAnimationTimeMs += RAF_STEP_SECONDS * 1000;
+    advanceMockAudioTime(RAF_STEP_SECONDS);
+    const frameIds = [...pendingAnimationFrames.keys()];
+    for (const frameId of frameIds) {
+      const callback = pendingAnimationFrames.get(frameId);
+      if (!callback) {
+        continue;
+      }
+      pendingAnimationFrames.delete(frameId);
+      callback(mockAnimationTimeMs);
     }
-    clearTimeout(timer);
-    pendingAnimationFrames.delete(frameId);
-  }),
+  }
+}
+
+function resetMockAnimationFrames() {
+  pendingAnimationFrames.clear();
+  nextAnimationFrameId = 1;
+  mockAnimationTimeMs = 0;
+  mockRequestAnimationFrame.mockClear();
+  mockCancelAnimationFrame.mockClear();
+}
+
+Object.defineProperty(globalThis, "__mockAnimationFrameController", {
+  writable: true,
+  value: {
+    advance: advanceMockAnimationFrames,
+    reset: resetMockAnimationFrames,
+  },
 });
 
 class MockAudioContext {

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -2829,10 +2829,19 @@ export function getMockAudioContexts() {
           start: ReturnType<typeof vi.fn>;
         }>;
         close: ReturnType<typeof vi.fn>;
+        currentTime: number;
         resume: ReturnType<typeof vi.fn>;
       }>;
     }
   ).__mockAudioContexts;
+}
+
+export function advanceMockAnimationFrames(count = 1) {
+  (
+    globalThis as typeof globalThis & {
+      __mockAnimationFrameController: { advance: (count?: number) => void };
+    }
+  ).__mockAnimationFrameController.advance(count);
 }
 
 export function setMockAudioContextInitialState(state: AudioContextState) {
@@ -2976,6 +2985,11 @@ export function getMockWakeLock() {
 
 
 export function resetAppTestHarness() {
+  (
+    globalThis as typeof globalThis & {
+      __mockAnimationFrameController: { reset: () => void };
+    }
+  ).__mockAnimationFrameController.reset();
   resetMockApiState();
   resetPlaybackE2ETelemetry();
   resetScreenWakeLockForTests();

--- a/apps/desktop/src/test/mockAnimationFrame.test.ts
+++ b/apps/desktop/src/test/mockAnimationFrame.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  advanceMockAnimationFrames,
+  getMockAudioContexts,
+  resetAppTestHarness,
+} from "./appTestHarness";
+
+describe("mock animation frames", () => {
+  beforeEach(resetAppTestHarness);
+
+  it("does not run callbacks until a frame is advanced and shares a frame timestamp", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+
+    window.requestAnimationFrame(first);
+    window.requestAnimationFrame(second);
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).not.toHaveBeenCalled();
+    advanceMockAnimationFrames();
+
+    expect(first).toHaveBeenCalledOnce();
+    expect(second).toHaveBeenCalledOnce();
+    expect(first.mock.calls[0]?.[0]).toBe(second.mock.calls[0]?.[0]);
+  });
+
+  it("defers nested callbacks to the next explicit frame", () => {
+    const nested = vi.fn();
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(nested);
+    });
+
+    advanceMockAnimationFrames();
+    expect(nested).not.toHaveBeenCalled();
+    advanceMockAnimationFrames();
+    expect(nested).toHaveBeenCalledOnce();
+  });
+
+  it("allows an earlier callback to cancel a later callback in the same frame", () => {
+    const later = vi.fn();
+    let laterId = 0;
+    window.requestAnimationFrame(() => {
+      window.cancelAnimationFrame(laterId);
+    });
+    laterId = window.requestAnimationFrame(later);
+    advanceMockAnimationFrames();
+    expect(later).not.toHaveBeenCalled();
+  });
+
+  it("clears queued callbacks and restarts timestamps when reset", () => {
+    const leaked = vi.fn();
+    window.requestAnimationFrame(leaked);
+    resetAppTestHarness();
+    const next = vi.fn();
+    const frameId = window.requestAnimationFrame(next);
+    advanceMockAnimationFrames();
+    expect(leaked).not.toHaveBeenCalled();
+    expect(frameId).toBe(1);
+    expect(next).toHaveBeenCalledWith(1000 / 60);
+  });
+
+  it("advances running audio time once per frame, not once per callback", () => {
+    const audioContext = new AudioContext();
+    window.requestAnimationFrame(vi.fn());
+    window.requestAnimationFrame(vi.fn());
+
+    advanceMockAnimationFrames();
+    expect(getMockAudioContexts()).toHaveLength(1);
+    expect(getMockAudioContexts()[0]?.currentTime).toBeCloseTo(1 / 60, 10);
+    advanceMockAnimationFrames(2);
+    expect(getMockAudioContexts()[0]?.currentTime).toBeCloseTo(3 / 60, 10);
+    void audioContext;
+  });
+
+  it("rejects invalid frame counts", () => {
+    expect(() => advanceMockAnimationFrames(-1)).toThrow(RangeError);
+    expect(() => advanceMockAnimationFrames(1.5)).toThrow(RangeError);
+    expect(() => advanceMockAnimationFrames(Number.NaN)).toThrow(RangeError);
+  });
+});


### PR DESCRIPTION
## Summary

- replace the recursively scheduled zero-delay RAF test mock with an explicitly advanced frame queue
- reset queued callbacks, frame IDs, timestamps, audio time, and mock histories between tests
- drive metronome and playback-rate tests through deterministic frames without changing production behavior or Vitest parallelism
- prevent the Web tuner test from exhausting its timeout while React processes an unbounded RAF chain

## Testing

- `pnpm --filter @tuneforge/desktop test --run src/App.activity.test.tsx src/App.tools-tuner.test.tsx -t 'shows nearby devices and syncs trusted matches with discovered endpoints|acquires Web tuner protection only after capture is listening and releases on stop' --reporter=dot` (10 consecutive runs)
- `pnpm --filter @tuneforge/desktop test --run --reporter=dot` (three consecutive runs before rebase and one after rebase)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
