### PR TITLE
chore(release): prepare v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ download, installation, verification, signature, and publication instructions.
 
 ## [Unreleased]
 
-## [1.0.1] - Pending
+## [1.0.1] - 2026-08-13
 
 ### Added
 
@@ -19,7 +19,7 @@ download, installation, verification, signature, and publication instructions.
   ([#361](https://github.com/grazzolini/tuneforge/pull/361)).
 - Dedicated Android release signing for publishable APKs
   ([#422](https://github.com/grazzolini/tuneforge/pull/422)).
-- Added this curated product changelog.
+- Added this curated product changelog ([#424](https://github.com/grazzolini/tuneforge/pull/424)).
 
 ### Changed
 
@@ -82,5 +82,6 @@ download, installation, verification, signature, and publication instructions.
 
 - Development used `0.1.0` metadata; `v1.0.0` was the first tagged release.
 
-[1.0.1]: https://github.com/grazzolini/tuneforge/compare/v1.0.0...main
+[Unreleased]: https://github.com/grazzolini/tuneforge/compare/v1.0.1...main
+[1.0.1]: https://github.com/grazzolini/tuneforge/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/grazzolini/tuneforge/releases/tag/v1.0.0

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tuneforge-backend"
-version = "1.0.0"
+version = "1.0.1"
 description = "Local API and processing backend for TuneForge."
 readme = "README.md"
 requires-python = ">=3.11,<3.12"

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -1919,7 +1919,7 @@ wheels = [
 
 [[package]]
 name = "tuneforge-backend"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tuneforge/desktop",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -7456,7 +7456,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuneforge"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "android_system_properties",
  "base64 0.23.1",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuneforge"
-version = "1.0.0"
+version = "1.0.1"
 description = "TuneForge desktop shell"
 edition = "2021"
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TuneForge",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "identifier": "com.tuneforge.desktop",
   "build": {
     "beforeDevCommand": "pnpm --filter @tuneforge/desktop dev",

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -1395,11 +1395,11 @@ const {
     name: "TuneForge",
     version: "backend-test-ref",
     backend_version: {
-      package_version: "1.0.0",
+      package_version: "1.0.1",
       git_ref: "backend-test-ref",
     },
     frontend_version: {
-      package_version: "1.0.0",
+      package_version: "1.0.1",
       git_ref: "frontend-test-ref",
     },
     status: "ok",

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -21,25 +21,26 @@ packaged launch smoke pass are both recorded for each intended artifact. Missing
 or smoke evidence fails the gate closed; do not substitute `pnpm dev`, a dev server, or
 an unpackaged Tauri run for packaged-artifact proof.
 
-Before tagging, verify the release changelog section against changes since the previous tag. Promote
-and merge the completed `[Unreleased]` entries into the release section, then leave a new empty
-`[Unreleased]` section. Freeze the release comparison at `previous-tag...new-tag` and reset the
-`[Unreleased]` comparison to `new-tag...main`. Operational artifact, installation, checksum,
-signature, and upload instructions belong in the GitHub Release notes.
+Before tagging, verify the release changelog against changes since the previous tag. Promote completed
+`[Unreleased]` entries into the dated release section, leave `[Unreleased]` empty, freeze the release
+comparison at `previous-tag...new-tag`, and reset `[Unreleased]` to `new-tag...main`.
 
-Run the pre-tag checks from the intended release commit:
+Run these checks from the clean final release commit:
 
 ```sh
 node scripts/check-release-version.mjs
 node scripts/release-license-inventory.mjs --check
-pnpm package:mac
-pnpm package:linux:flatpak
 ```
 
+Create and push a signed annotated `v<version>` tag, then create a GitHub pre-release for that tag.
+Build each intended artifact from a clean checkout of the tag without a `TUNEFORGE_GIT_REF` override.
+Validate and sign the artifacts, upload them to the pre-release, and publish the final release only
+after the uploaded assets pass verification. Never move or delete a published tag; roll forward with a
+new version. Operational artifact, installation, checksum, signature, and upload instructions belong
+in the GitHub Release notes.
+
 Run `pnpm package:mac` only on supported macOS release hosts, and run
-`pnpm package:linux:flatpak` only on supported Linux hosts with Flatpak packaging
-tooling. If a release includes only one platform artifact, run and record the package
-command for that artifact.
+`pnpm package:linux:flatpak` only on supported Linux hosts with Flatpak packaging tooling.
 
 For the manual launch smoke, install or open the built package artifact and confirm:
 

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tuneforge/shared-types",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packaging/flatpak/com.tuneforge.desktop.metainfo.xml
+++ b/packaging/flatpak/com.tuneforge.desktop.metainfo.xml
@@ -27,6 +27,7 @@
   </categories>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="1.0.1" date="2026-08-13" />
     <release version="1.0.0" date="2026-06-27" />
   </releases>
 </component>

--- a/scripts/capture-release-media.mjs
+++ b/scripts/capture-release-media.mjs
@@ -1751,11 +1751,11 @@ function healthResponse() {
     name: "TuneForge",
     version: "release-media-fixture",
     backend_version: {
-      package_version: "1.0.0",
+      package_version: "1.0.1",
       git_ref: "release-media-fixture",
     },
     frontend_version: {
-      package_version: "1.0.0",
+      package_version: "1.0.1",
       git_ref: "release-media-fixture",
     },
     status: "ok",


### PR DESCRIPTION
## Summary

- Promote governed TuneForge release metadata and generated lock entries to `1.0.1`.
- Date and freeze the v1.0.1 changelog, link PR #424, and preserve Flatpak release history.
- Document signed-tag, GitHub pre-release, package validation, signing, upload, and publication order.
- Refs #391.

## Testing

- `git diff --check`
- `pnpm release:check-version`
- `pnpm release:license-inventory -- --check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `cd apps/backend && uv run --python 3.11 pytest`
- `cd apps/desktop/src-tauri && cargo check`
- Package builds were not run because release artifacts must be built from the merged signed `v1.0.1` tag. Run `pnpm package:mac`, `pnpm package:android:release`, and optionally `pnpm package:linux:flatpak -- --sandbox-data` during release execution.
