### PR TITLE
feat: add selective export contract

### DIFF
--- a/apps/backend/app/api/routes/health.py
+++ b/apps/backend/app/api/routes/health.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from app.config import get_settings
-from app.schemas import HealthResponse, VersionInfo
+from app.schemas import ExportCapabilitiesResponse, ExportCapabilitiesSchema, HealthResponse, VersionInfo
+from app.services.transformations import export_capabilities
 from app.version import get_build_versions
 
 router = APIRouter(tags=["health"])
@@ -29,4 +30,11 @@ def health() -> HealthResponse:
         data_root=str(settings.data_root),
         default_export_format=settings.default_export_format,
         preview_format=settings.preview_format,
+    )
+
+
+@router.get("/export-capabilities", response_model=ExportCapabilitiesResponse)
+def get_export_capabilities() -> ExportCapabilitiesResponse:
+    return ExportCapabilitiesResponse(
+        capabilities=ExportCapabilitiesSchema.model_validate(export_capabilities())
     )

--- a/apps/backend/app/api/routes/projects.py
+++ b/apps/backend/app/api/routes/projects.py
@@ -6,7 +6,6 @@ from sqlalchemy.orm import Session
 
 from app.api.pagination import PaginationQuery, pagination_metadata
 from app.dependencies import get_db, get_job_runner
-from app.errors import AppError
 from app.models import AnalysisResult, Artifact, ChordTimeline, LyricsTranscript
 from app.schemas import (
     AnalysisRequest,
@@ -61,7 +60,7 @@ from app.services.tabs import (
     get_tab_import,
     list_project_sections,
 )
-from app.services.transformations import ensure_export_destination_available
+from app.services.transformations import prepare_export_job_payload
 
 router = APIRouter(prefix="/projects", tags=["projects"])
 
@@ -457,19 +456,16 @@ def project_export(
     runner=Depends(get_job_runner),
 ) -> JobResponse:
     project = get_mutable_project(session, project_id)
-    for artifact_id in payload.artifact_ids:
-        artifact = session.get(Artifact, artifact_id)
-        if artifact is None or artifact.project_id != project.id:
-            raise AppError("ARTIFACT_NOT_FOUND", "Artifact does not belong to this project.", status_code=404)
-    ensure_export_destination_available(
-        destination_file_path=payload.destination_file_path,
-        overwrite_existing=payload.overwrite_existing,
+    job_payload = prepare_export_job_payload(
+        session,
+        project=project,
+        request_payload=payload.model_dump(exclude_none=True),
     )
     job = runner.create_job(
         session,
         project_id=project_id,
         job_type="export",
-        payload=payload.model_dump(),
+        payload=job_payload,
     )
     session.commit()
     session.refresh(job)

--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -77,7 +77,7 @@ def get_settings() -> Settings:
         backend_port=int(os.environ.get("TUNEFORGE_PORT", "8765")),
         default_export_format="wav",
         supported_import_formats=("mp3", "wav", "flac", "m4a", "aac", "ogg", "mp4", "webm"),
-        supported_export_formats=("wav", "mp3", "flac"),
+        supported_export_formats=("wav", "flac", "mp3", "m4a"),
         preview_format="wav",
         ffmpeg_path=os.environ.get("TUNEFORGE_FFMPEG_PATH", "ffmpeg"),
         ffprobe_path=os.environ.get("TUNEFORGE_FFPROBE_PATH", "ffprobe"),

--- a/apps/backend/app/engines/transform.py
+++ b/apps/backend/app/engines/transform.py
@@ -3,11 +3,75 @@ from __future__ import annotations
 import math
 import subprocess
 from collections.abc import Callable
+from functools import lru_cache
 from pathlib import Path
 
 from app.config import get_settings
 from app.dependency_diagnostics import missing_host_tool_error
 from app.errors import AppError, JobCancelledError
+
+_EXPORT_PROFILES: dict[str, tuple[str, ...]] = {
+    "wav": ("-c:a", "pcm_s16le"),
+    "flac": ("-c:a", "flac", "-compression_level", "5"),
+    "mp3": ("-c:a", "libmp3lame", "-b:a", "192k"),
+    "m4a": ("-c:a", "aac", "-profile:a", "aac_low", "-b:a", "192k", "-f", "mp4"),
+}
+
+_EXPORT_REQUIREMENTS = {
+    "wav": ("pcm_s16le", "wav"),
+    "flac": ("flac", "flac"),
+    "mp3": ("libmp3lame", "mp3"),
+    "m4a": ("aac", "mp4"),
+}
+
+
+@lru_cache(maxsize=1)
+def probe_export_formats() -> dict[str, tuple[bool, str | None]]:
+    ffmpeg_path = get_settings().ffmpeg_path
+    try:
+        encoders = subprocess.run(
+            [ffmpeg_path, "-hide_banner", "-encoders"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout
+        muxers = subprocess.run(
+            [ffmpeg_path, "-hide_banner", "-muxers"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout
+    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        reason = "Configured FFmpeg is unavailable."
+        return {output_format: (False, reason) for output_format in _EXPORT_PROFILES}
+
+    capabilities: dict[str, tuple[bool, str | None]] = {}
+    for output_format, (encoder, muxer) in _EXPORT_REQUIREMENTS.items():
+        encoder_available = any(
+            len(parts) >= 2 and parts[1] == encoder
+            for line in encoders.splitlines()
+            if (parts := line.split())
+        )
+        muxer_available = any(
+            len(parts) >= 2 and muxer in parts[1].split(",")
+            for line in muxers.splitlines()
+            if (parts := line.split())
+        )
+        available = encoder_available and muxer_available
+        capabilities[output_format] = (
+            available,
+            None if available else f"Configured FFmpeg does not support {output_format.upper()} export.",
+        )
+    return capabilities
+
+
+def export_profile(output_format: str) -> tuple[str, ...]:
+    try:
+        return _EXPORT_PROFILES[output_format]
+    except KeyError as exc:
+        raise AppError("INVALID_REQUEST", "Unsupported export format.", status_code=422) from exc
 
 
 def _tempo_filters(tempo_ratio: float) -> list[str]:
@@ -47,6 +111,7 @@ def run_ffmpeg_transform(
 ) -> None:
     destination_path.parent.mkdir(parents=True, exist_ok=True)
     filter_graph = build_pitch_filter(sample_rate, total_cents)
+    profile = export_profile(output_format)
     command = [
         get_settings().ffmpeg_path,
         "-y",
@@ -55,6 +120,7 @@ def run_ffmpeg_transform(
         "-vn",
         "-af",
         filter_graph,
+        *profile,
         str(destination_path.with_suffix(f".{output_format}")),
     ]
     try:

--- a/apps/backend/app/models.py
+++ b/apps/backend/app/models.py
@@ -431,6 +431,11 @@ class Job(Base):
     project: Mapped[Project | None] = relationship(back_populates="jobs")
 
     @property
+    def export_result(self) -> dict[str, Any] | None:
+        value = self.payload_json.get("export_result")
+        return value if self.type == "export" and isinstance(value, dict) else None
+
+    @property
     def source_artifact_id(self) -> str | None:
         value = self.payload_json.get("source_artifact_id")
         return value if isinstance(value, str) else None

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -1243,6 +1243,23 @@ class TabImportApplyResponse(BaseModel):
     project: ProjectSchema
 
 
+class ExportResultItemSchema(BaseModel):
+    artifact_id: str
+    output_name: str
+    status: Literal["pending", "running", "completed", "failed", "cancelled"]
+    progress: int = Field(default=0, ge=0, le=100)
+    result_artifact_id: str | None = None
+    error: str | None = None
+
+
+class ExportResultSchema(BaseModel):
+    outcome: Literal["completed", "partial", "failed", "cancelled"]
+    total_count: int = Field(ge=1)
+    completed_count: int = Field(ge=0)
+    failed_count: int = Field(ge=0)
+    items: list[ExportResultItemSchema]
+
+
 class JobSchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -1268,6 +1285,8 @@ class JobSchema(BaseModel):
     started_at: datetime | None = None
     completed_at: datetime | None = None
     duration_seconds: float | None = None
+    result_artifact_ids: list[str] = Field(default_factory=list, validation_alias="result_artifact_ids_json")
+    export_result: ExportResultSchema | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -1422,10 +1441,52 @@ class StemRequest(BaseModel):
         return self
 
 
+class ExportSingleFileDestinationSchema(BaseModel):
+    type: Literal["single_file"]
+    target: str = Field(min_length=1)
+    overwrite: bool = False
+
+
+class ExportFolderDestinationSchema(BaseModel):
+    type: Literal["folder"]
+    target: str = Field(min_length=1)
+    overwrite: bool = False
+
+
+class ExportZipDestinationSchema(BaseModel):
+    type: Literal["zip"]
+    target: str = Field(min_length=1)
+    overwrite: bool = False
+
+
+ExportDestinationSchema = (
+    ExportSingleFileDestinationSchema | ExportFolderDestinationSchema | ExportZipDestinationSchema
+)
+
+
+class ExportCapabilityOptionSchema(BaseModel):
+    id: str
+    available: bool
+    reason: str | None = None
+
+
+class ExportCapabilitiesSchema(BaseModel):
+    platform: Literal["desktop", "android"]
+    formats: list[ExportCapabilityOptionSchema]
+    destinations: list[ExportCapabilityOptionSchema]
+    max_artifact_count: int | None = None
+
+
+class ExportCapabilitiesResponse(BaseModel):
+    capabilities: ExportCapabilitiesSchema
+
+
 class ExportRequest(BaseModel):
     artifact_ids: list[str]
     mixdown_mode: str = "copy"
-    output_format: str = "wav"
+    output_format: Literal["wav", "flac", "mp3", "m4a"] = "wav"
+    filename_base: str | None = None
+    destination: ExportDestinationSchema | None = Field(default=None, discriminator="type")
     destination_path: str | None = None
     destination_file_path: str | None = None
     overwrite_existing: bool = False
@@ -1434,4 +1495,20 @@ class ExportRequest(BaseModel):
     def validate_export(self) -> ExportRequest:
         if not self.artifact_ids:
             raise ValueError("At least one artifact id is required.")
+        if len(self.artifact_ids) != len(set(self.artifact_ids)):
+            raise ValueError("Artifact ids must be unique.")
+        has_legacy_destination = bool(self.destination_path or self.destination_file_path)
+        if self.destination is not None and has_legacy_destination:
+            raise ValueError("Canonical and legacy export destinations cannot be combined.")
+        if self.destination is not None and self.overwrite_existing:
+            raise ValueError("Canonical overwrite approval belongs in destination.overwrite.")
+        if self.destination is None and len(self.artifact_ids) != 1:
+            raise ValueError("Legacy export requests support exactly one artifact.")
+        if self.destination is not None:
+            if len(self.artifact_ids) == 1 and self.destination.type != "single_file":
+                raise ValueError("Single-artifact exports require a single_file destination.")
+            if len(self.artifact_ids) > 1 and self.destination.type == "single_file":
+                raise ValueError("Multi-artifact exports require a folder or zip destination.")
+        if self.filename_base is not None and not self.filename_base.strip():
+            raise ValueError("Filename base cannot be empty.")
         return self

--- a/apps/backend/app/services/jobs.py
+++ b/apps/backend/app/services/jobs.py
@@ -49,6 +49,7 @@ from app.utils.ids import new_id
 class JobExecutionResult:
     artifact_ids: list[str]
     runtime_device: str | None = None
+    export_result: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -515,6 +516,13 @@ class JobExecutionContext:
     def set_progress(self, progress: int) -> None:
         self.update_runtime_status(progress=progress)
 
+    def set_export_result(self, export_result: dict[str, Any]) -> None:
+        job = self.session.get(Job, self.job_id)
+        if job is None or job.type != "export":
+            return
+        job.payload_json = {**job.payload_json, "export_result": export_result}
+        self.session.commit()
+
     def update_runtime_status(
         self,
         *,
@@ -828,6 +836,8 @@ class InProcessJobRunner:
                 job.status = "completed"
                 job.progress = 100
                 job.result_artifact_ids_json = result.artifact_ids
+                if result.export_result is not None:
+                    job.payload_json = {**job.payload_json, "export_result": result.export_result}
                 if result.runtime_device is not None:
                     job.runtime_device = result.runtime_device
                 self._ensure_terminal_runtime_status(job)
@@ -836,14 +846,17 @@ class InProcessJobRunner:
                     queue_project_storage_reconciliation(session, job.project_id)
                 session.commit()
         except JobCancelledError:
+            self._mark_export_result_cancelled(job_id)
             self.update_job(job_id, status="cancelled", error_message=None)
         except AppError as exc:
             if self.is_cancel_requested(job_id):
+                self._mark_export_result_cancelled(job_id)
                 self.update_job(job_id, status="cancelled", error_message=None)
             else:
                 self.update_job(job_id, status="failed", error_message=_job_error_message(exc))
         except Exception as exc:  # pragma: no cover - defensive fallback
             if self.is_cancel_requested(job_id):
+                self._mark_export_result_cancelled(job_id)
                 self.update_job(job_id, status="cancelled", error_message=None)
             else:
                 self.update_job(job_id, status="failed", error_message=str(exc))
@@ -1024,15 +1037,15 @@ class InProcessJobRunner:
             progress=25,
             runtime_device="cpu",
         )
-        artifact = export_artifacts(
+        batch = export_artifacts(
             session,
             project=project,
             artifact_ids=list(payload.get("artifact_ids", [])),
             output_format=payload.get("output_format", "wav"),
-            destination_path=payload.get("destination_path"),
-            destination_file_path=payload.get("destination_file_path"),
-            overwrite_existing=bool(payload.get("overwrite_existing", False)),
+            destination=dict(payload.get("destination", {})),
+            output_names=list(payload.get("output_names", [])),
             on_progress=context.progress_reporter(),
+            on_result=context.set_export_result,
             should_cancel=context.should_cancel,
             register_process=context.register_process,
             unregister_process=context.unregister_process,
@@ -1043,7 +1056,40 @@ class InProcessJobRunner:
             progress=90,
             runtime_device="cpu",
         )
-        return JobExecutionResult(artifact_ids=[artifact.id])
+        if batch.export_result["outcome"] == "failed":
+            job.payload_json = {**job.payload_json, "export_result": batch.export_result}
+            session.commit()
+            raise AppError("PROCESSING_FAILED", "No selected audio items could be exported.")
+        return JobExecutionResult(artifact_ids=batch.artifact_ids, export_result=batch.export_result)
+
+    def _mark_export_result_cancelled(self, job_id: str) -> None:
+        with self.session_factory() as session:
+            job = session.get(Job, job_id)
+            if job is None or job.type != "export":
+                return
+            result = job.payload_json.get("export_result")
+            if not isinstance(result, dict):
+                return
+            items = result.get("items")
+            if not isinstance(items, list):
+                return
+            cancelled_items: list[dict[str, Any]] = []
+            for raw_item in items:
+                if not isinstance(raw_item, dict):
+                    continue
+                item = dict(raw_item)
+                if item.get("status") in {"pending", "running"}:
+                    item["status"] = "cancelled"
+                cancelled_items.append(item)
+            job.payload_json = {
+                **job.payload_json,
+                "export_result": {
+                    **result,
+                    "outcome": "cancelled",
+                    "items": cancelled_items,
+                },
+            }
+            session.commit()
 
     def _handle_stems(self, context: JobExecutionContext, session: Session, job: Job) -> JobExecutionResult:
         project = get_project(session, job.project_id or "")

--- a/apps/backend/app/services/transformations.py
+++ b/apps/backend/app/services/transformations.py
@@ -1,23 +1,32 @@
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 import tempfile
+import zipfile
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from fastapi import status
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.config import get_settings
-from app.engines.transform import cents_from_reference, run_ffmpeg_transform, semitones_to_cents
+from app.engines.transform import (
+    cents_from_reference,
+    probe_export_formats,
+    run_ffmpeg_transform,
+    semitones_to_cents,
+)
 from app.errors import AppError, JobCancelledError
 from app.models import Artifact, Project
 from app.services.analysis import analyze_project
 from app.services.artifacts import find_cached_artifact, register_artifact
 from app.services.paths import project_exports_dir, project_previews_dir
+from app.services.stem_models import STEM_ARTIFACT_TYPE_SOURCES, STEM_ARTIFACT_TYPES
 from app.utils.hashing import stable_hash
 
 
@@ -29,6 +38,12 @@ class TransformPlan:
     total_cents: float
     cache_key: str | None
     metadata: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ExportBatchResult:
+    artifact_ids: list[str]
+    export_result: dict[str, Any]
 
 
 def _reference_cents(session: Session, project: Project, target_reference_hz: float) -> float:
@@ -47,7 +62,7 @@ def _ensure_not_cancelled(should_cancel: Callable[[], bool] | None) -> None:
         raise JobCancelledError()
 
 
-def _resolve_export_file_path(
+def _resolve_legacy_export_file_path(
     artifact: Artifact,
     *,
     output_format: str,
@@ -82,6 +97,167 @@ def ensure_export_destination_available(*, destination_file_path: str | None, ov
         return
     target = Path(destination_file_path).expanduser().resolve()
     if target.exists():
+        raise AppError(
+            "EXPORT_DESTINATION_EXISTS",
+            "Export destination already exists.",
+            status_code=status.HTTP_409_CONFLICT,
+            details={"destination_file_path": str(target)},
+        )
+
+
+def export_capabilities() -> dict[str, Any]:
+    formats = probe_export_formats()
+    return {
+        "platform": "desktop",
+        "formats": [
+            {"id": output_format, "available": available, "reason": reason}
+            for output_format, (available, reason) in formats.items()
+        ],
+        "destinations": [
+            {"id": destination, "available": True, "reason": None}
+            for destination in ("single_file", "folder", "zip")
+        ],
+        "max_artifact_count": None,
+    }
+
+
+def _safe_filename_base(value: str) -> str:
+    sanitized = re.sub(r"[\\/:*?\"<>|\x00-\x1f]", "-", value).strip(" .")
+    sanitized = re.sub(r"\s+", " ", sanitized)
+    return sanitized[:120] or "TuneForge Export"
+
+
+def _primary_audio_artifact(artifact: Artifact, artifacts_by_id: dict[str, Artifact]) -> Artifact | None:
+    if artifact.type in {"source_audio", "preview_mix"}:
+        return artifact
+    if artifact.type not in STEM_ARTIFACT_TYPES:
+        return None
+    source_artifact_id = artifact.metadata_json.get("source_artifact_id")
+    return artifacts_by_id.get(source_artifact_id) if isinstance(source_artifact_id, str) else None
+
+
+def _practice_mix_label(session: Session, project_id: str, artifact_id: str) -> str:
+    mixes = list(
+        session.scalars(
+            select(Artifact)
+            .where(Artifact.project_id == project_id, Artifact.type == "preview_mix")
+            .order_by(Artifact.created_at.asc(), Artifact.id.asc())
+        )
+    )
+    return f"Practice Mix {next((index for index, mix in enumerate(mixes, 1) if mix.id == artifact_id), 1)}"
+
+
+def _audio_set_label(session: Session, artifact: Artifact) -> str:
+    return (
+        "Source"
+        if artifact.type == "source_audio"
+        else _practice_mix_label(session, artifact.project_id, artifact.id)
+    )
+
+
+def _artifact_export_label(artifact: Artifact) -> str | None:
+    source = STEM_ARTIFACT_TYPE_SOURCES.get(artifact.type)
+    return source.replace("_", " ").title() if source else None
+
+
+def _deduplicate_output_names(names: list[str]) -> list[str]:
+    counts: dict[str, int] = {}
+    deduplicated: list[str] = []
+    for name in names:
+        path = Path(name)
+        key = name.casefold()
+        counts[key] = counts.get(key, 0) + 1
+        suffix = "" if counts[key] == 1 else f" ({counts[key]})"
+        deduplicated.append(f"{path.stem}{suffix}{path.suffix}")
+    return deduplicated
+
+
+def prepare_export_job_payload(
+    session: Session,
+    *,
+    project: Project,
+    request_payload: dict[str, Any],
+) -> dict[str, Any]:
+    artifact_ids = list(request_payload.get("artifact_ids", []))
+    artifacts = [session.get(Artifact, artifact_id) for artifact_id in artifact_ids]
+    if any(artifact is None or artifact.project_id != project.id for artifact in artifacts):
+        raise AppError("ARTIFACT_NOT_FOUND", "Artifact does not belong to this project.", status_code=404)
+    selected = [artifact for artifact in artifacts if artifact is not None]
+    all_project_artifacts = {
+        artifact.id: artifact
+        for artifact in session.scalars(select(Artifact).where(Artifact.project_id == project.id))
+    }
+    primary_artifacts = [_primary_audio_artifact(artifact, all_project_artifacts) for artifact in selected]
+    if any(primary is None for primary in primary_artifacts):
+        raise AppError("INVALID_REQUEST", "Only source tracks, practice mixes, and their stems can be exported.")
+    primary_ids = {primary.id for primary in primary_artifacts if primary is not None}
+    if len(primary_ids) != 1:
+        raise AppError("EXPORT_AUDIO_SET_MISMATCH", "Selected artifacts must belong to one audio set.")
+    output_format = str(request_payload.get("output_format", "wav"))
+    format_available, reason = probe_export_formats().get(output_format, (False, "Unsupported export format."))
+    if not format_available:
+        raise AppError("EXPORT_FORMAT_UNAVAILABLE", reason or "Export format is unavailable.", status_code=422)
+
+    primary = next(primary for primary in primary_artifacts if primary is not None)
+    destination = request_payload.get("destination")
+    if isinstance(destination, dict):
+        filename_base = _safe_filename_base(str(request_payload.get("filename_base") or project.display_name))
+        context_label = _audio_set_label(session, primary)
+        raw_names = [
+            f"{filename_base} - {context_label}"
+            f"{' - ' + label if (label := _artifact_export_label(artifact)) else ''}.{output_format}"
+            for artifact in selected
+        ]
+        output_names = _deduplicate_output_names(raw_names)
+        normalized_destination = {
+            "type": str(destination.get("type")),
+            "target": str(destination.get("target")),
+            "overwrite": bool(destination.get("overwrite", False)),
+        }
+    else:
+        artifact = selected[0]
+        target = _resolve_legacy_export_file_path(
+            artifact,
+            output_format=output_format,
+            destination_path=request_payload.get("destination_path"),
+            destination_file_path=request_payload.get("destination_file_path"),
+        )
+        output_names = [target.name]
+        normalized_destination = {
+            "type": "single_file",
+            "target": str(target),
+            "overwrite": bool(request_payload.get("overwrite_existing", False)),
+        }
+
+    _preflight_export_destination(normalized_destination, output_names)
+    return {
+        "artifact_ids": artifact_ids,
+        "mixdown_mode": "copy",
+        "output_format": output_format,
+        "filename_base": _safe_filename_base(str(request_payload.get("filename_base") or project.display_name)),
+        "destination": normalized_destination,
+        "output_names": output_names,
+        "audio_set_artifact_id": primary.id,
+    }
+
+
+def _preflight_export_destination(destination: dict[str, Any], output_names: list[str]) -> None:
+    target = Path(str(destination["target"])).expanduser().resolve()
+    overwrite = bool(destination.get("overwrite", False))
+    destination_type = destination["type"]
+    if destination_type == "folder":
+        if target.exists() and not target.is_dir():
+            raise AppError("INVALID_REQUEST", "Export folder destination is not a directory.")
+        collisions = [str(target / name) for name in output_names if (target / name).exists()]
+        if collisions and not overwrite:
+            raise AppError(
+                "EXPORT_DESTINATION_EXISTS",
+                "One or more export destinations already exist.",
+                status_code=status.HTTP_409_CONFLICT,
+                details={"destination_file_paths": collisions},
+            )
+        return
+    if target.exists() and not overwrite:
         raise AppError(
             "EXPORT_DESTINATION_EXISTS",
             "Export destination already exists.",
@@ -201,44 +377,28 @@ def execute_transform_plan(
     return artifact
 
 
-def export_artifacts(
-    session: Session,
+def _export_one_to_target(
     *,
-    project: Project,
-    artifact_ids: list[str],
+    source: Artifact,
+    target: Path,
     output_format: str,
-    destination_path: str | None,
-    destination_file_path: str | None = None,
-    overwrite_existing: bool = False,
-    on_progress: Callable[[int], None] | None = None,
-    should_cancel: Callable[[], bool] | None = None,
-    register_process: Callable[[subprocess.Popen[str]], None] | None = None,
-    unregister_process: Callable[[], None] | None = None,
-) -> Artifact:
-    if len(artifact_ids) != 1:
-        raise AppError("INVALID_REQUEST", "V1 export supports exactly one source artifact.")
-    artifact = session.get(Artifact, artifact_ids[0])
-    if artifact is None or artifact.project_id != project.id:
-        raise AppError("ARTIFACT_NOT_FOUND", "Artifact not found.", status_code=status.HTTP_404_NOT_FOUND)
-    source_path = Path(artifact.path)
-    target = _resolve_export_file_path(
-        artifact,
-        output_format=output_format,
-        destination_path=destination_path,
-        destination_file_path=destination_file_path,
-    )
-    ensure_export_destination_available(
-        destination_file_path=destination_file_path,
-        overwrite_existing=overwrite_existing,
-    )
+    overwrite: bool,
+    sample_rate: int,
+    should_cancel: Callable[[], bool] | None,
+    register_process: Callable[[subprocess.Popen[str]], None] | None,
+    unregister_process: Callable[[], None] | None,
+    on_progress: Callable[[int], None] | None,
+) -> None:
+    source_path = Path(source.path)
     temp_base_path, temp_path = _new_sibling_temp_paths(target, output_format)
     try:
-        if artifact.format == output_format:
+        if source.format == output_format:
             _ensure_not_cancelled(should_cancel)
             shutil.copy2(source_path, temp_path)
+            if on_progress:
+                on_progress(90)
             _ensure_not_cancelled(should_cancel)
         else:
-            sample_rate = project.sample_rate or 44100
             run_ffmpeg_transform(
                 source_path,
                 temp_base_path,
@@ -251,22 +411,167 @@ def export_artifacts(
                 unregister_process=unregister_process,
             )
             _ensure_not_cancelled(should_cancel)
-        ensure_export_destination_available(
-            destination_file_path=destination_file_path,
-            overwrite_existing=overwrite_existing,
-        )
+        if target.exists() and not overwrite:
+            raise AppError("EXPORT_DESTINATION_EXISTS", "An export destination already exists.", status_code=409)
         temp_path.replace(target)
     finally:
         temp_base_path.unlink(missing_ok=True)
         temp_path.unlink(missing_ok=True)
-    return register_artifact(
-        session,
-        project_id=project.id,
-        artifact_type="export_mix",
-        artifact_format=output_format,
-        path=target,
-        metadata={"source_artifact_id": artifact.id},
-        generated_by="ffmpeg",
-        can_delete=True,
-        can_regenerate=False,
-    )
+
+
+def _export_result_payload(items: list[dict[str, Any]]) -> dict[str, Any]:
+    completed_count = sum(item["status"] == "completed" for item in items)
+    failed_count = sum(item["status"] == "failed" for item in items)
+    outcome = "completed" if completed_count == len(items) else "partial" if completed_count else "failed"
+    return {
+        "outcome": outcome,
+        "total_count": len(items),
+        "completed_count": completed_count,
+        "failed_count": failed_count,
+        "items": [dict(item) for item in items],
+    }
+
+
+def export_artifacts(
+    session: Session,
+    *,
+    project: Project,
+    artifact_ids: list[str],
+    output_format: str,
+    destination: dict[str, Any],
+    output_names: list[str],
+    on_progress: Callable[[int], None] | None = None,
+    on_result: Callable[[dict[str, Any]], None] | None = None,
+    should_cancel: Callable[[], bool] | None = None,
+    register_process: Callable[[subprocess.Popen[str]], None] | None = None,
+    unregister_process: Callable[[], None] | None = None,
+) -> ExportBatchResult:
+    artifacts = [session.get(Artifact, artifact_id) for artifact_id in artifact_ids]
+    if len(artifacts) != len(output_names) or any(artifact is None for artifact in artifacts):
+        raise AppError("ARTIFACT_NOT_FOUND", "Artifact not found.", status_code=status.HTTP_404_NOT_FOUND)
+    selected = [artifact for artifact in artifacts if artifact is not None]
+    target = Path(str(destination["target"])).expanduser().resolve()
+    destination_type = str(destination["type"])
+    overwrite = bool(destination.get("overwrite", False))
+    _preflight_export_destination(destination, output_names)
+    sample_rate = project.sample_rate or 44100
+    items = [
+        {
+            "artifact_id": artifact.id,
+            "output_name": output_name,
+            "status": "pending",
+            "progress": 0,
+            "result_artifact_id": None,
+            "error": None,
+        }
+        for artifact, output_name in zip(selected, output_names, strict=True)
+    ]
+    result_artifact_ids: list[str] = []
+
+    def publish_result() -> None:
+        if on_result:
+            on_result(_export_result_payload(items))
+
+    with tempfile.TemporaryDirectory(prefix="tuneforge-export-stage-") as stage_dir_name:
+        stage_dir = Path(stage_dir_name)
+        completed_outputs: list[tuple[Artifact, Path, str]] = []
+        for index, (artifact, output_name) in enumerate(zip(selected, output_names, strict=True)):
+            _ensure_not_cancelled(should_cancel)
+            item = items[index]
+            item["status"] = "running"
+            item["progress"] = 5
+            publish_result()
+            item_target = stage_dir / output_name if destination_type == "zip" else (
+                target / output_name if destination_type == "folder" else target
+            )
+
+            def report_item_progress(value: int, *, item_index: int = index) -> None:
+                items[item_index]["progress"] = min(99, max(0, value))
+                if on_progress:
+                    on_progress(int(((item_index + value / 100) / len(items)) * 85) + 10)
+                publish_result()
+
+            try:
+                _export_one_to_target(
+                    source=artifact,
+                    target=item_target,
+                    output_format=output_format,
+                    overwrite=overwrite,
+                    sample_rate=sample_rate,
+                    should_cancel=should_cancel,
+                    register_process=register_process,
+                    unregister_process=unregister_process,
+                    on_progress=report_item_progress,
+                )
+            except JobCancelledError:
+                item["status"] = "cancelled"
+                publish_result()
+                raise
+            except (AppError, OSError):
+                item["status"] = "failed"
+                item["error"] = "Could not export this audio item."
+                publish_result()
+                continue
+
+            item["status"] = "completed"
+            item["progress"] = 100
+            completed_outputs.append((artifact, item_target, output_name))
+            if destination_type != "zip":
+                exported = register_artifact(
+                    session,
+                    project_id=project.id,
+                    artifact_type="export_mix",
+                    artifact_format=output_format,
+                    path=item_target,
+                    metadata={"source_artifact_id": artifact.id, "output_name": output_name},
+                    generated_by="ffmpeg",
+                    can_delete=True,
+                    can_regenerate=False,
+                )
+                item["result_artifact_id"] = exported.id
+                result_artifact_ids.append(exported.id)
+            publish_result()
+
+        if destination_type == "zip" and completed_outputs:
+            _ensure_not_cancelled(should_cancel)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with tempfile.NamedTemporaryFile(
+                dir=target.parent,
+                prefix="tuneforge-export-",
+                suffix=".zip",
+                delete=False,
+            ) as temp:
+                zip_path = Path(temp.name)
+            try:
+                with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+                    for _artifact, staged_path, output_name in completed_outputs:
+                        archive.write(staged_path, arcname=output_name)
+                _ensure_not_cancelled(should_cancel)
+                if target.exists() and not overwrite:
+                    _preflight_export_destination(destination, output_names)
+                zip_path.replace(target)
+            finally:
+                zip_path.unlink(missing_ok=True)
+            archive_artifact = register_artifact(
+                session,
+                project_id=project.id,
+                artifact_type="export_mix",
+                artifact_format="zip",
+                path=target,
+                metadata={
+                    "source_artifact_ids": [artifact.id for artifact, _, _ in completed_outputs],
+                    "output_names": [output_name for _, _, output_name in completed_outputs],
+                    "contained_format": output_format,
+                },
+                generated_by="ffmpeg",
+                can_delete=True,
+                can_regenerate=False,
+            )
+            result_artifact_ids.append(archive_artifact.id)
+            for item in items:
+                if item["status"] == "completed":
+                    item["result_artifact_id"] = archive_artifact.id
+            publish_result()
+
+    export_result = _export_result_payload(items)
+    return ExportBatchResult(artifact_ids=result_artifact_ids, export_result=export_result)

--- a/apps/backend/tests/test_transform_flow.py
+++ b/apps/backend/tests/test_transform_flow.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import shutil
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -213,6 +215,132 @@ def test_export_overwrites_existing_explicit_destination_when_requested(client, 
     assert selected_path.read_bytes() == b"replacement bytes"
 
 
+def test_export_batch_preserves_order_and_rejects_cross_audio_set(client, tmp_path: Path):
+    project_id, source_id, source_path = _create_export_fixture(
+        tmp_path,
+        project_id="proj_export_batch",
+        artifact_id="art_mix_one",
+    )
+    stem_path = tmp_path / "vocals.wav"
+    stem_path.write_bytes(source_path.read_bytes())
+    other_mix_path = tmp_path / "other.wav"
+    other_mix_path.write_bytes(source_path.read_bytes())
+    with SessionLocal() as session:
+        session.add_all(
+            [
+                Artifact(
+                    id="art_vocals",
+                    project_id=project_id,
+                    type="vocal_stem",
+                    format="wav",
+                    path=str(stem_path),
+                    generated_by="test",
+                    metadata_json={"source_artifact_id": source_id},
+                ),
+                Artifact(
+                    id="art_mix_two",
+                    project_id=project_id,
+                    type="preview_mix",
+                    format="wav",
+                    path=str(other_mix_path),
+                    generated_by="test",
+                    metadata_json={},
+                ),
+            ]
+        )
+        session.commit()
+
+    export_root = tmp_path / "batch"
+    created = client.post(
+        f"/api/v1/projects/{project_id}/export",
+        json={
+            "artifact_ids": [source_id, "art_vocals"],
+            "output_format": "wav",
+            "filename_base": "Practice / Export",
+            "destination": {"type": "folder", "target": str(export_root), "overwrite": False},
+        },
+    )
+    assert created.status_code == 200
+    final = wait_for_job(client, created.json()["job"]["id"])
+    assert final["status"] == "completed"
+    assert final["export_result"]["outcome"] == "completed"
+    assert [item["artifact_id"] for item in final["export_result"]["items"]] == [source_id, "art_vocals"]
+    assert sorted(path.name for path in export_root.iterdir()) == [
+        "Practice - Export - Practice Mix 1 - Vocals.wav",
+        "Practice - Export - Practice Mix 1.wav",
+    ]
+
+    rejected = client.post(
+        f"/api/v1/projects/{project_id}/export",
+        json={
+            "artifact_ids": [source_id, "art_mix_two"],
+            "output_format": "wav",
+            "filename_base": "Rejected",
+            "destination": {"type": "folder", "target": str(tmp_path / "rejected")},
+        },
+    )
+    assert rejected.status_code == 400
+    assert rejected.json()["error"]["code"] == "EXPORT_AUDIO_SET_MISMATCH"
+
+
+def test_export_capabilities_advertise_destination_contract(client):
+    response = client.get("/api/v1/export-capabilities")
+    assert response.status_code == 200
+    capabilities = response.json()["capabilities"]
+    assert capabilities["platform"] == "desktop"
+    assert capabilities["max_artifact_count"] is None
+    assert [destination["id"] for destination in capabilities["destinations"]] == [
+        "single_file",
+        "folder",
+        "zip",
+    ]
+
+
+def test_export_zip_publishes_one_archive_result(client, tmp_path: Path):
+    project_id, mix_id, source_path = _create_export_fixture(
+        tmp_path,
+        project_id="proj_export_zip",
+        artifact_id="art_zip_mix",
+    )
+    vocal_path = tmp_path / "zip-vocals.wav"
+    vocal_path.write_bytes(source_path.read_bytes())
+    with SessionLocal() as session:
+        session.add(
+            Artifact(
+                id="art_zip_vocals",
+                project_id=project_id,
+                type="vocal_stem",
+                format="wav",
+                path=str(vocal_path),
+                generated_by="test",
+                metadata_json={"source_artifact_id": mix_id},
+            )
+        )
+        session.commit()
+
+    archive_path = tmp_path / "Practice Mix 1.zip"
+    job = client.post(
+        f"/api/v1/projects/{project_id}/export",
+        json={
+            "artifact_ids": [mix_id, "art_zip_vocals"],
+            "output_format": "wav",
+            "filename_base": "Zip Test",
+            "destination": {"type": "zip", "target": str(archive_path)},
+        },
+    ).json()["job"]
+    final = wait_for_job(client, job["id"])
+    assert final["status"] == "completed"
+    assert len(final["result_artifact_ids"]) == 1
+    assert {item["result_artifact_id"] for item in final["export_result"]["items"]} == {
+        final["result_artifact_ids"][0]
+    }
+    with zipfile.ZipFile(archive_path) as archive:
+        assert archive.namelist() == [
+            "Zip Test - Practice Mix 1.wav",
+            "Zip Test - Practice Mix 1 - Vocals.wav",
+        ]
+
+
 def test_preview_mix_creation_does_not_auto_queue_stems(
     client,
     sample_audio_file: Path,
@@ -279,9 +407,8 @@ def test_same_format_export_cancelled_after_copy_skips_artifact_registration(cli
                 project=project,
                 artifact_ids=[source_artifact.id],
                 output_format="wav",
-                destination_path=None,
-                destination_file_path=str(destination),
-                overwrite_existing=True,
+                destination={"type": "single_file", "target": str(destination), "overwrite": True},
+                output_names=[destination.name],
                 should_cancel=should_cancel,
             )
 
@@ -294,4 +421,44 @@ def test_same_format_export_cancelled_after_copy_skips_artifact_registration(cli
 
     assert destination.read_bytes() == b"existing audio bytes"
     assert not list(destination.parent.glob("tuneforge-export-*"))
+    assert export_count is None
+
+
+def test_export_rechecks_collision_immediately_before_publish(monkeypatch, tmp_path: Path):
+    project_id, artifact_id, _source = _create_export_fixture(
+        tmp_path,
+        project_id="proj_export_collision_race",
+        artifact_id="art_export_collision_race",
+    )
+    destination = tmp_path / "exports" / "selected.wav"
+    destination.parent.mkdir(parents=True)
+    original_copy = shutil.copy2
+
+    def copy_then_race(source: Path, target: Path):
+        copied = original_copy(source, target)
+        destination.write_bytes(b"created by another process")
+        return copied
+
+    monkeypatch.setattr("app.services.transformations.shutil.copy2", copy_then_race)
+
+    with SessionLocal() as session:
+        project = session.get(Project, project_id)
+        result = export_artifacts(
+            session,
+            project=project,
+            artifact_ids=[artifact_id],
+            output_format="wav",
+            destination={"type": "single_file", "target": str(destination), "overwrite": False},
+            output_names=[destination.name],
+        )
+        export_count = session.scalar(
+            select(Artifact).where(
+                Artifact.project_id == project_id,
+                Artifact.type == "export_mix",
+            )
+        )
+
+    assert destination.read_bytes() == b"created by another process"
+    assert result.export_result["outcome"] == "failed"
+    assert result.export_result["items"][0]["status"] == "failed"
     assert export_count is None

--- a/docs/API.md
+++ b/docs/API.md
@@ -927,14 +927,29 @@ Queues an export job for selected project artifacts.
 
 Request fields:
 
-- `artifact_ids`
-- `mixdown_mode`
-- `output_format`
-- `destination_path`
+- `artifact_ids` - unique ordered IDs from one source track or practice mix and its stems.
+- `output_format` - `wav`, `flac`, `mp3`, or `m4a`, subject to runtime capabilities.
+- `filename_base` - sanitized base used for stable friendly output names.
+- `destination` - tagged `single_file`, `folder`, or `zip` object with opaque `target` and
+  explicit `overwrite` approval.
 
-At least one artifact ID is required.
+Legacy `mixdown_mode`, `destination_path`, `destination_file_path`, and `overwrite_existing`
+remain accepted for one artifact during migration. Canonical and legacy destinations cannot be
+combined. Multi-artifact requests require Folder or ZIP and reject artifacts from different audio
+sets before queuing.
 
 Response: `JobResponse`.
+
+Completed export jobs expose ordered `result_artifact_ids` and `export_result`. The result contains
+aggregate outcome/counts plus per-item progress, status, output name, registered result ID, and safe
+error. A mixed batch keeps global job status `completed` with export outcome `partial`.
+
+### Get export capabilities
+
+`GET /api/v1/export-capabilities`
+
+Returns runtime-probed format availability, destination availability, and maximum artifact count.
+Desktop probes configured host FFmpeg encoders and muxers once per backend process.
 
 ## Jobs
 

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -21,6 +21,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/export-capabilities": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Export Capabilities */
+        get: operations["get_export_capabilities_api_v1_export_capabilities_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/beat-backends": {
         parameters: {
             query?: never;
@@ -1108,6 +1125,48 @@ export interface components {
         ErrorResponse: {
             error: components["schemas"]["ErrorInfo"];
         };
+        /** ExportCapabilitiesResponse */
+        ExportCapabilitiesResponse: {
+            capabilities: components["schemas"]["ExportCapabilitiesSchema"];
+        };
+        /** ExportCapabilitiesSchema */
+        ExportCapabilitiesSchema: {
+            /**
+             * Platform
+             * @enum {string}
+             */
+            platform: "desktop" | "android";
+            /** Formats */
+            formats: components["schemas"]["ExportCapabilityOptionSchema"][];
+            /** Destinations */
+            destinations: components["schemas"]["ExportCapabilityOptionSchema"][];
+            /** Max Artifact Count */
+            max_artifact_count?: number | null;
+        };
+        /** ExportCapabilityOptionSchema */
+        ExportCapabilityOptionSchema: {
+            /** Id */
+            id: string;
+            /** Available */
+            available: boolean;
+            /** Reason */
+            reason?: string | null;
+        };
+        /** ExportFolderDestinationSchema */
+        ExportFolderDestinationSchema: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "folder";
+            /** Target */
+            target: string;
+            /**
+             * Overwrite
+             * @default false
+             */
+            overwrite?: boolean;
+        };
         /** ExportRequest */
         ExportRequest: {
             /** Artifact Ids */
@@ -1120,8 +1179,13 @@ export interface components {
             /**
              * Output Format
              * @default wav
+             * @enum {string}
              */
-            output_format?: string;
+            output_format?: "wav" | "flac" | "mp3" | "m4a";
+            /** Filename Base */
+            filename_base?: string | null;
+            /** Destination */
+            destination?: (components["schemas"]["ExportSingleFileDestinationSchema"] | components["schemas"]["ExportFolderDestinationSchema"] | components["schemas"]["ExportZipDestinationSchema"]) | null;
             /** Destination Path */
             destination_path?: string | null;
             /** Destination File Path */
@@ -1131,6 +1195,73 @@ export interface components {
              * @default false
              */
             overwrite_existing?: boolean;
+        };
+        /** ExportResultItemSchema */
+        ExportResultItemSchema: {
+            /** Artifact Id */
+            artifact_id: string;
+            /** Output Name */
+            output_name: string;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "pending" | "running" | "completed" | "failed" | "cancelled";
+            /**
+             * Progress
+             * @default 0
+             */
+            progress?: number;
+            /** Result Artifact Id */
+            result_artifact_id?: string | null;
+            /** Error */
+            error?: string | null;
+        };
+        /** ExportResultSchema */
+        ExportResultSchema: {
+            /**
+             * Outcome
+             * @enum {string}
+             */
+            outcome: "completed" | "partial" | "failed" | "cancelled";
+            /** Total Count */
+            total_count: number;
+            /** Completed Count */
+            completed_count: number;
+            /** Failed Count */
+            failed_count: number;
+            /** Items */
+            items: components["schemas"]["ExportResultItemSchema"][];
+        };
+        /** ExportSingleFileDestinationSchema */
+        ExportSingleFileDestinationSchema: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "single_file";
+            /** Target */
+            target: string;
+            /**
+             * Overwrite
+             * @default false
+             */
+            overwrite?: boolean;
+        };
+        /** ExportZipDestinationSchema */
+        ExportZipDestinationSchema: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "zip";
+            /** Target */
+            target: string;
+            /**
+             * Overwrite
+             * @default false
+             */
+            overwrite?: boolean;
         };
         /** HTTPValidationError */
         HTTPValidationError: {
@@ -1206,6 +1337,9 @@ export interface components {
             completed_at?: string | null;
             /** Duration Seconds */
             duration_seconds?: number | null;
+            /** Result Artifact Ids */
+            result_artifact_ids?: string[];
+            export_result?: components["schemas"]["ExportResultSchema"] | null;
             /**
              * Created At
              * Format: date-time
@@ -2747,6 +2881,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HealthResponse"];
+                };
+            };
+        };
+    };
+    get_export_capabilities_api_v1_export_capabilities_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExportCapabilitiesResponse"];
                 };
             };
         };


### PR DESCRIPTION
## Summary

- Add a canonical ordered selective-export request, platform capabilities, and structured per-item results.
- Support desktop File, Folder, and ZIP delivery with explicit collision handling and partial outcomes.
- Preserve the legacy single-file request while callers move to the new contract.
- Refs #397.

## Testing

- `cd apps/backend && uv run --python 3.11 pytest` — 682 passed.
- `cd apps/backend && uv run --python 3.11 ruff check .` — passed.
- `cd apps/backend && uv run --python 3.11 mypy app` — passed for 81 source files.
- `pnpm contracts:generate` — regenerated the committed TypeScript contract.
