### PR TITLE
feat: add dedicated export workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ download, installation, verification, signature, and publication instructions.
 
 ## [Unreleased]
 
+### Added
+
+- A dedicated project Export workspace for selecting one source track or practice mix and packaging
+  its track and stems as a file, folder, or ZIP.
+
 ## [1.0.1] - 2026-08-13
 
 ### Added

--- a/apps/desktop/src/App.project-analysis-mix.test.tsx
+++ b/apps/desktop/src/App.project-analysis-mix.test.tsx
@@ -38,7 +38,10 @@ describe("Desktop app project analysis mix", () => {
     await user.click(screen.getByRole("tab", { name: "Playback" }));
   }
 
-  async function openProjectPanel(user: ReturnType<typeof userEvent.setup>, name: "Studio" | "Analysis") {
+  async function openProjectPanel(
+    user: ReturnType<typeof userEvent.setup>,
+    name: "Studio" | "Analysis" | "Export",
+  ) {
     const tab = screen.getByRole("tab", { name });
     if (tab.getAttribute("aria-selected") !== "true") {
       await user.click(tab);
@@ -263,11 +266,14 @@ describe("Desktop app project analysis mix", () => {
     fireEvent.click(sourceKeyButton);
     expect(screen.queryByRole("listbox", { name: "Project Source Key options" })).not.toBeInTheDocument();
 
-    const exportButton = screen.getByRole("button", { name: "Export Selected Audio" });
+    expect(screen.queryByRole("heading", { name: "Export" })).not.toBeInTheDocument();
+    await openProjectPanel(user, "Export");
+    const exportButton = screen.getByRole("button", { name: "Export 1 file" });
     expect(exportButton).toBeDisabled();
     fireEvent.click(exportButton);
     expect(mockCreateExport).not.toHaveBeenCalled();
 
+    await openAnalysisPanel(user);
     const deleteProjectButton = screen.getByRole("button", { name: "Delete Project" });
     expect(deleteProjectButton).toBeDisabled();
     fireEvent.click(deleteProjectButton);

--- a/apps/desktop/src/App.project-export.test.tsx
+++ b/apps/desktop/src/App.project-export.test.tsx
@@ -1,0 +1,263 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  mockCreateExport,
+  mockGetExportCapabilities,
+  mockGetMobileCapabilities,
+  mockOpen,
+  resetAppTestHarness,
+  renderApp,
+  setProjectArtifacts,
+  setJobs,
+} from "./test/appTestHarness";
+import { openAnalysisPanel, openExportPanel, refreshJobs } from "./test/projectTestActions";
+
+const createdAt = "2026-04-18T13:16:00.000Z";
+
+function artifact(id: string, type: string, sourceArtifactId?: string) {
+  return {
+    id,
+    project_id: "proj_123",
+    type,
+    format: "wav",
+    path: `/tmp/${id}.wav`,
+    metadata: sourceArtifactId ? { source_artifact_id: sourceArtifactId } : {},
+    created_at: createdAt,
+  };
+}
+
+function installExportArtifacts() {
+  setProjectArtifacts("proj_123", [
+    artifact("art_source", "source_audio"),
+    artifact("art_mix", "preview_mix"),
+    artifact("art_vocals", "vocal_stem", "art_mix"),
+    artifact("art_drums", "drums_stem", "art_mix"),
+    artifact("art_bass", "bass_stem", "art_mix"),
+    artifact("art_guitar", "guitar_stem", "art_mix"),
+  ]);
+}
+
+describe("project export workspace", () => {
+  beforeEach(resetAppTestHarness);
+
+  it("uses a dedicated project tab instead of the Analysis inspector", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openAnalysisPanel(user);
+    expect(screen.queryByRole("button", { name: /Export Selected Audio/i })).not.toBeInTheDocument();
+
+    await openExportPanel(user);
+    expect(screen.getByRole("tabpanel", { name: "Export" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Export audio" })).toBeInTheDocument();
+  });
+
+  it("keeps the empty Export view connected to its tabpanel", async () => {
+    const user = userEvent.setup();
+    setProjectArtifacts("proj_123", []);
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openExportPanel(user);
+
+    expect(screen.getByRole("tabpanel", { name: "Export" })).toHaveTextContent(
+      "No audio is available to export yet.",
+    );
+  });
+
+  it("supports keyboard tab navigation and persists the Export panel", async () => {
+    const user = userEvent.setup();
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+
+    const studioTab = screen.getByRole("tab", { name: "Studio" });
+    studioTab.focus();
+    await user.keyboard("{ArrowLeft}");
+
+    const exportTab = screen.getByRole("tab", { name: "Export" });
+    expect(exportTab).toHaveFocus();
+    expect(exportTab).toHaveAttribute("aria-selected", "true");
+    await waitFor(() => {
+      const stored = JSON.parse(localStorage.getItem("tuneforge.project-playback-state") ?? "{}");
+      expect(stored.proj_123?.activeProjectPanel).toBe("export");
+    });
+  });
+
+  it("shows custom selection and deterministic previews after a manual edit", async () => {
+    const user = userEvent.setup();
+    installExportArtifacts();
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openExportPanel(user);
+
+    await user.click(screen.getByRole("radio", { name: /Practice Mix 1/i }));
+    await user.click(screen.getByRole("button", { name: "Track + all stems" }));
+    expect(screen.getByRole("button", { name: "Track + all stems" })).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(screen.getByRole("checkbox", { name: /Guitar/i }));
+    expect(screen.getByText("Custom selection")).toBeInTheDocument();
+    expect(screen.getByText("4 selected")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Folder" })).toHaveAttribute("aria-pressed", "true");
+    const preview = screen.getByText("File preview").closest("div")?.parentElement;
+    expect(preview).not.toBeNull();
+    expect(within(preview as HTMLElement).getAllByRole("listitem")).toHaveLength(4);
+    expect(within(preview as HTMLElement).getByText("Demo Song - Practice Mix 1 - Vocals.m4a")).toBeInTheDocument();
+  });
+
+  it("retains a compatible folder target for manual many-to-many selection changes", async () => {
+    const user = userEvent.setup();
+    installExportArtifacts();
+    mockOpen.mockResolvedValue("/tmp/exports");
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openExportPanel(user);
+
+    await user.click(screen.getByRole("radio", { name: /Practice Mix 1/i }));
+    await user.click(screen.getByRole("button", { name: "Track + all stems" }));
+    await user.click(screen.getByRole("button", { name: "Choose destination" }));
+    expect(await screen.findByText("/tmp/exports")).toBeInTheDocument();
+    await user.click(screen.getByRole("checkbox", { name: /Guitar/i }));
+
+    expect(screen.getByText("/tmp/exports")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Folder" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("keeps the narrow package in flow while its compact summary owns the export action", async () => {
+    const user = userEvent.setup();
+    installExportArtifacts();
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openExportPanel(user);
+
+    const exportPackage = screen.getByRole("complementary", { name: "Export package" });
+    const compactSummary = within(exportPackage).getByTestId("export-compact-summary");
+    expect(compactSummary).toHaveTextContent("1 item");
+    expect(compactSummary).toHaveTextContent("File · Choose on export");
+    expect(within(compactSummary).getByRole("button", { name: "Export 1 file" })).toBeEnabled();
+    expect(within(exportPackage).getAllByRole("button", { name: /Export \d+ files?/ })).toHaveLength(1);
+
+  });
+
+  it("resets selection and target when changing audio sets while retaining format and base name", async () => {
+    const user = userEvent.setup();
+    installExportArtifacts();
+    mockOpen.mockResolvedValue("/tmp/exports");
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openExportPanel(user);
+
+    await user.click(screen.getByRole("radio", { name: /Practice Mix 1/i }));
+    await user.click(screen.getByRole("button", { name: "All stems" }));
+    await user.selectOptions(screen.getByLabelText("File format"), "flac");
+    await user.clear(screen.getByLabelText("File name base"));
+    await user.type(screen.getByLabelText("File name base"), "Session take");
+    await user.click(screen.getByRole("button", { name: "Choose destination" }));
+    expect(await screen.findByText("/tmp/exports")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("radio", { name: /Source Track/i }));
+    expect(screen.getByText("1 selected")).toBeInTheDocument();
+    expect(screen.getByLabelText("File format")).toHaveValue("flac");
+    expect(screen.getByLabelText("File name base")).toHaveValue("Session take");
+    expect(screen.queryByText("/tmp/exports")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "File" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("submits an ordered multi-file folder request for one audio set", async () => {
+    const user = userEvent.setup();
+    installExportArtifacts();
+    mockOpen.mockResolvedValue("/tmp/exports");
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openExportPanel(user);
+
+    await user.click(screen.getByRole("radio", { name: /Practice Mix 1/i }));
+    await user.click(screen.getByRole("button", { name: "Track + all stems" }));
+    await user.click(screen.getByRole("button", { name: "Choose destination" }));
+    await screen.findByText("/tmp/exports");
+    await user.click(screen.getByRole("button", { name: "Export 5 files" }));
+
+    expect(mockCreateExport).toHaveBeenCalledWith("proj_123", {
+      artifact_ids: ["art_mix", "art_vocals", "art_drums", "art_bass", "art_guitar"],
+      output_format: "m4a",
+      filename_base: "Demo Song",
+      destination: { type: "folder", target: "/tmp/exports", overwrite: false },
+    });
+  });
+
+  it("retry failed switches to the audio set that owns failed artifacts", async () => {
+    const user = userEvent.setup();
+    installExportArtifacts();
+    setJobs([{ id: "job_partial", project_id: "proj_123", type: "export", status: "completed", progress: 100,
+      export_result: { outcome: "partial", total_count: 2, completed_count: 1, failed_count: 1, items: [
+        { artifact_id: "art_vocals", output_name: "Demo Song - Practice Mix 1 - Vocals.m4a", status: "failed", progress: 100, result_artifact_id: null, error: "Failed" },
+      ] } }]);
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openExportPanel(user);
+    expect(screen.getByRole("radio", { name: /Source Track/i })).toBeChecked();
+
+    await user.click(screen.getByRole("button", { name: "Retry failed" }));
+
+    expect(screen.getByRole("radio", { name: /Practice Mix 1/i })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: /Vocals/i })).toBeChecked();
+    expect(screen.getByText("1 selected")).toBeInTheDocument();
+  });
+
+  it("shows the current output filename during export progress", async () => {
+    const user = userEvent.setup();
+    installExportArtifacts();
+    const { queryClient } = renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openExportPanel(user);
+    setJobs([{ id: "job_running", project_id: "proj_123", type: "export", status: "running", progress: 45,
+      stage_label: "Encoding audio", export_result: { outcome: "failed", total_count: 1, completed_count: 0, failed_count: 0, items: [
+        { artifact_id: "art_source", output_name: "Demo Song - Source.m4a", status: "running", progress: 45, result_artifact_id: null, error: null },
+      ] } }]);
+    await refreshJobs(queryClient);
+    await waitFor(() => expect(screen.getByText("Demo Song - Source.m4a")).toBeInTheDocument());
+  });
+
+  it("shows truthful Android limits and disabled export controls", async () => {
+    const user = userEvent.setup();
+    installExportArtifacts();
+    mockGetMobileCapabilities.mockResolvedValue({ platform: "android" });
+    mockGetExportCapabilities.mockResolvedValue({
+      capabilities: {
+        platform: "android",
+        formats: ["wav", "flac", "mp3", "m4a"].map((id) => ({
+          id,
+          available: false,
+          reason: "Android audio export is not available in this build.",
+        })),
+        destinations: ["single_file", "folder", "zip"].map((id) => ({
+          id,
+          available: false,
+          reason: "Android audio export is not available in this build.",
+        })),
+        max_artifact_count: 1,
+      },
+    });
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openExportPanel(user);
+
+    expect(screen.getByText(/Android currently exports one M4A file at a time/)).toBeInTheDocument();
+    await user.click(screen.getByRole("radio", { name: /Practice Mix 1/i }));
+    const trackOnly = screen.getByRole("button", { name: "Track only" });
+    const allStems = screen.getByRole("button", { name: "All stems" });
+    const trackAndStems = screen.getByRole("button", { name: "Track + all stems" });
+    expect(trackOnly).not.toHaveAttribute("aria-describedby");
+    expect(allStems).toBeDisabled();
+    expect(allStems).toHaveAttribute("aria-describedby", "android-multi-export-reason");
+    expect(trackAndStems).toHaveAttribute("aria-describedby", "android-multi-export-reason");
+    expect(screen.getByText(/All stems and track plus stems require multiple files/)).toBeVisible();
+    expect(screen.getAllByText("Android audio export is not available in this build.").length).toBeGreaterThan(0);
+    expect(within(screen.getByRole("group", { name: "Audio selection" })).getAllByRole("radio")).toHaveLength(5);
+    expect(screen.getByLabelText("File format")).toHaveAttribute(
+      "aria-describedby",
+      "android-export-format-notice",
+    );
+    expect(screen.getByRole("button", { name: "Export 1 file" })).toBeDisabled();
+  });
+});

--- a/apps/desktop/src/App.project-playback-artifacts.test.tsx
+++ b/apps/desktop/src/App.project-playback-artifacts.test.tsx
@@ -18,9 +18,9 @@ import {
 } from "./test/appTestHarness";
 import { ApiError } from "./lib/api";
 import {
-  ensureInspectorVisible,
   generateStems,
   openAnalysisPanel,
+  openExportPanel,
   openStudioPanel,
   refreshJobs,
   selectFirstStemInAnalysis,
@@ -87,11 +87,8 @@ function exportDestinationExistsError() {
 
 async function exportSelectedSourceAudio(user: ReturnType<typeof userEvent.setup>) {
   expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
-  await ensureInspectorVisible(user);
-  const sourceList = screen.getByRole("group", { name: "Source and mix list" });
-  await user.click(within(sourceList).getByRole("button", { name: /Source Track/i }));
-  await openAnalysisPanel(user);
-  await user.click(screen.getByRole("button", { name: "Export Selected Audio" }));
+  await openExportPanel(user);
+  await user.click(screen.getByRole("button", { name: "Export 1 file" }));
 }
 
 describe("Desktop app project playback artifacts", () => {
@@ -636,7 +633,7 @@ describe("Desktop app project playback artifacts", () => {
 
   it("exports selected audio", async () => {
     const user = userEvent.setup();
-    mockSave.mockResolvedValue("/tmp/exports/demo-source.flac");
+    mockSave.mockResolvedValue("/tmp/exports/Demo Song - Source.m4a");
 
     renderApp(["/projects/proj_123"]);
 
@@ -644,22 +641,24 @@ describe("Desktop app project playback artifacts", () => {
 
     expect(mockSave).toHaveBeenCalledWith(
       expect.objectContaining({
-        filters: expect.arrayContaining([
-          expect.objectContaining({ extensions: ["wav"] }),
-          expect.objectContaining({ extensions: ["mp3"] }),
-          expect.objectContaining({ extensions: ["flac"] }),
-        ]),
+        defaultPath: "Demo Song - Source.m4a",
+        filters: [{ name: "M4A", extensions: ["m4a"] }],
       }),
     );
     expect(mockCreateExport).toHaveBeenCalledWith(
       "proj_123",
       expect.objectContaining({
         artifact_ids: ["art_source"],
-        output_format: "flac",
-        destination_file_path: "/tmp/exports/demo-source.flac",
+        output_format: "m4a",
+        filename_base: "Demo Song",
+        destination: {
+          type: "single_file",
+          target: "/tmp/exports/Demo Song - Source.m4a",
+          overwrite: false,
+        },
       }),
     );
-    expect(mockCreateExport.mock.calls[0]?.[1]).not.toHaveProperty("destination_path");
+    expect(mockCreateExport.mock.calls[0]?.[1]).not.toHaveProperty("destination_file_path");
   });
 
   it("does not create an export when the save dialog is canceled", async () => {
@@ -676,7 +675,7 @@ describe("Desktop app project playback artifacts", () => {
 
   it("does not retry export when an existing destination warning is canceled", async () => {
     const user = userEvent.setup();
-    mockSave.mockResolvedValue("/tmp/exports/demo-source.wav");
+    mockSave.mockResolvedValue("/tmp/exports/Demo Song - Source.m4a");
     mockConfirm.mockResolvedValueOnce(false);
     mockCreateExport.mockRejectedValueOnce(exportDestinationExistsError());
 
@@ -686,7 +685,7 @@ describe("Desktop app project playback artifacts", () => {
 
     await waitFor(() =>
       expect(mockConfirm).toHaveBeenCalledWith(
-        expect.stringContaining("already exists"),
+        expect.stringContaining("export destinations"),
         expect.objectContaining({
           title: "Replace existing export?",
           kind: "warning",
@@ -695,12 +694,14 @@ describe("Desktop app project playback artifacts", () => {
       ),
     );
     expect(mockCreateExport).toHaveBeenCalledTimes(1);
-    expect(mockCreateExport.mock.calls[0]?.[1]).not.toHaveProperty("overwrite_existing");
+    expect(mockCreateExport.mock.calls[0]?.[1]).toMatchObject({
+      destination: { overwrite: false },
+    });
   });
 
   it("retries export once with overwrite when an existing destination warning is approved", async () => {
     const user = userEvent.setup();
-    mockSave.mockResolvedValue("/tmp/exports/demo-source.mp3");
+    mockSave.mockResolvedValue("/tmp/exports/Demo Song - Source.m4a");
     mockConfirm.mockResolvedValueOnce(true);
     mockCreateExport.mockRejectedValueOnce(exportDestinationExistsError());
 
@@ -714,22 +715,27 @@ describe("Desktop app project playback artifacts", () => {
       "proj_123",
       expect.objectContaining({
         artifact_ids: ["art_source"],
-        output_format: "mp3",
-        destination_file_path: "/tmp/exports/demo-source.mp3",
+        output_format: "m4a",
+        destination: {
+          type: "single_file",
+          target: "/tmp/exports/Demo Song - Source.m4a",
+          overwrite: false,
+        },
       }),
     );
-    expect(mockCreateExport.mock.calls[0]?.[1]).not.toHaveProperty("overwrite_existing");
     expect(mockCreateExport).toHaveBeenNthCalledWith(
       2,
       "proj_123",
       expect.objectContaining({
         artifact_ids: ["art_source"],
-        output_format: "mp3",
-        destination_file_path: "/tmp/exports/demo-source.mp3",
-        overwrite_existing: true,
+        output_format: "m4a",
+        destination: {
+          type: "single_file",
+          target: "/tmp/exports/Demo Song - Source.m4a",
+          overwrite: true,
+        },
       }),
     );
-    expect(mockCreateExport.mock.calls[1]?.[1]).not.toHaveProperty("destination_path");
   });
 
   it("renames project from the title row", async () => {

--- a/apps/desktop/src/features/projects/components/ExportWorkspace.tsx
+++ b/apps/desktop/src/features/projects/components/ExportWorkspace.tsx
@@ -1,0 +1,346 @@
+import { Link } from "react-router-dom";
+import {
+  Archive,
+  AudioLines,
+  Check,
+  Download,
+  Drum,
+  FileAudio,
+  Folder,
+  Guitar,
+  Layers3,
+  MicVocal,
+  Music2,
+  Piano,
+  X,
+} from "lucide-react";
+import type { ArtifactSchema } from "../../../lib/api";
+import { artifactLabel, isStemArtifact } from "../projectViewUtils";
+import { useExportWorkspace } from "../hooks/useExportWorkspace";
+import { useProjectViewModelContext } from "./useProjectViewModelContext";
+
+const FORMATS = ["wav", "flac", "mp3", "m4a"] as const;
+const DESTINATIONS = [
+  { id: "single_file", label: "File", icon: FileAudio },
+  { id: "folder", label: "Folder", icon: Folder },
+  { id: "zip", label: "ZIP", icon: Archive },
+] as const;
+
+function ArtifactIcon({ artifact }: { artifact: ArtifactSchema }) {
+  const Icon = artifact.type === "vocal_stem"
+    ? MicVocal
+    : artifact.type === "drums_stem"
+      ? Drum
+      : artifact.type === "guitar_stem" || artifact.type === "bass_stem"
+        ? Guitar
+        : artifact.type === "piano_stem"
+          ? Piano
+          : isStemArtifact(artifact)
+            ? AudioLines
+            : Music2;
+  return <Icon aria-hidden="true" />;
+}
+
+function formatDuration(seconds: number | null | undefined) {
+  if (typeof seconds !== "number") return "Duration unknown";
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}:${Math.round(seconds % 60).toString().padStart(2, "0")}`;
+}
+
+export function ExportWorkspace() {
+  const workspace = useExportWorkspace();
+  const {
+    audioSet,
+    audioSetId,
+    audioSets,
+    activeExportJob,
+    canExport,
+    cancelMutation,
+    capabilities,
+    capabilitiesQuery,
+    chooseDestination,
+    destinationTarget,
+    destinationType,
+    exportMutation,
+    filenameBase,
+    goToStudio,
+    isMobileRuntime,
+    latestExportJob,
+    outputFormat,
+    outputNames,
+    partialExportJob,
+    preset,
+    retryFailed,
+    retryUnavailableReason,
+    selectedDestinationCapability,
+    selectedFormatCapability,
+    selectedIds,
+    selectedArtifacts,
+    selectionAllowed,
+    selectPreset,
+    setAudioSetId,
+    setDestinationTarget,
+    setDestinationType,
+    setFilenameBase,
+    setOutputFormat,
+    toggleArtifact,
+  } = workspace;
+  const { projectQuery } = useProjectViewModelContext();
+  const projectDuration = projectQuery.data?.duration_seconds;
+  const selectionInputType = isMobileRuntime ? "radio" : "checkbox";
+  const controlsDisabled = Boolean(activeExportJob);
+  const destinationLabel = DESTINATIONS.find((destination) => destination.id === destinationType)?.label
+    ?? "Destination";
+
+  if (!audioSet) {
+    return (
+      <div
+        aria-labelledby="project-export-tab"
+        className="panel export-workspace-empty"
+        id="project-export-panel"
+        role="tabpanel"
+      >No audio is available to export yet.</div>
+    );
+  }
+
+  return (
+    <section className="export-workspace" aria-labelledby="project-export-tab" id="project-export-panel" role="tabpanel">
+      <header className="export-workspace__header">
+        <div>
+          <span className="eyebrow">Project delivery</span>
+          <h2 id="export-workspace-title">Export audio</h2>
+          <p>Choose one audio set, select its tracks, then package local files.</p>
+        </div>
+        <span className="export-workspace__selection-count" aria-live="polite">
+          {selectedIds.size} selected
+        </span>
+      </header>
+
+      {isMobileRuntime ? (
+        <div className="notice notice--info" id="android-export-format-notice" role="status">
+          Android currently exports one M4A file at a time.
+          {!capabilities?.formats.some((format) => format.available)
+            ? " Audio export is unavailable in this build."
+            : null}
+        </div>
+      ) : null}
+
+      <div className="export-workspace__grid">
+        <aside className="panel export-audio-sets" aria-label="Audio sets">
+          <div className="export-section-heading">
+            <span>Audio sets</span>
+            <span>{audioSets.length}</span>
+          </div>
+          <div className="export-audio-sets__options" role="radiogroup" aria-label="Export audio set">
+            {audioSets.map((candidate) => (
+              <label
+                className={`export-audio-set${candidate.artifact.id === audioSetId ? " export-audio-set--active" : ""}`}
+                key={candidate.artifact.id}
+              >
+                <input
+                  checked={candidate.artifact.id === audioSetId}
+                  disabled={controlsDisabled}
+                  name="export-audio-set"
+                  onChange={() => setAudioSetId(candidate.artifact.id)}
+                  type="radio"
+                />
+                <span className="export-audio-set__icon"><Music2 aria-hidden="true" /></span>
+                <span>
+                  <strong>{candidate.label}</strong>
+                  <small>{candidate.stems.length ? `${candidate.stems.length} stems` : "Track only"}</small>
+                </span>
+              </label>
+            ))}
+          </div>
+        </aside>
+
+        <div className="panel export-selection">
+          <div className="export-selection__identity">
+            <div>
+              <span className="eyebrow">Selected audio set</span>
+              <h3>{audioSet.label}</h3>
+            </div>
+            <span>{audioSet.artifact.format.toUpperCase()} · {formatDuration(projectDuration)}</span>
+          </div>
+
+          <fieldset className="export-presets" disabled={controlsDisabled}>
+            <legend>Quick selections</legend>
+            <button
+              aria-pressed={preset === "track"}
+              className="button button--small"
+              onClick={() => selectPreset("track")}
+              type="button"
+            >Track only</button>
+            <button
+              aria-describedby={isMobileRuntime ? "android-multi-export-reason" : undefined}
+              aria-pressed={preset === "stems"}
+              className="button button--small"
+              disabled={!audioSet.stems.length || isMobileRuntime}
+              title={isMobileRuntime ? "Android currently exports one file at a time." : undefined}
+              onClick={() => selectPreset("stems")}
+              type="button"
+            >All stems</button>
+            <button
+              aria-describedby={isMobileRuntime ? "android-multi-export-reason" : undefined}
+              aria-pressed={preset === "track-and-stems"}
+              className="button button--small"
+              disabled={!audioSet.stems.length || isMobileRuntime}
+              title={isMobileRuntime ? "Android currently exports one file at a time." : undefined}
+              onClick={() => selectPreset("track-and-stems")}
+              type="button"
+            >Track + all stems</button>
+            <span className="export-presets__state">{preset === "custom" ? "Custom selection" : "Preset selection"}</span>
+            {isMobileRuntime ? (
+              <span className="field-reason" id="android-multi-export-reason">
+                All stems and track plus stems require multiple files. Android exports one file at a time.
+              </span>
+            ) : null}
+          </fieldset>
+
+          <fieldset className="export-artifact-list" disabled={controlsDisabled}>
+            <legend>Audio selection</legend>
+            {[audioSet.artifact, ...audioSet.stems].map((artifact) => (
+              <label className="export-artifact-row" key={artifact.id}>
+                <input
+                  checked={selectedIds.has(artifact.id)}
+                  name={isMobileRuntime ? "export-artifact" : undefined}
+                  onChange={() => toggleArtifact(artifact.id)}
+                  type={selectionInputType}
+                />
+                <span className="export-artifact-row__icon"><ArtifactIcon artifact={artifact} /></span>
+                <span className="export-artifact-row__copy">
+                  <strong>{isStemArtifact(artifact) ? artifactLabel(artifact) : audioSet.label}</strong>
+                  <small>{artifact.format.toUpperCase()} · {formatDuration(projectDuration)}</small>
+                </span>
+                <span className="export-artifact-row__status">
+                  {selectedIds.has(artifact.id) ? <Check aria-hidden="true" /> : null}
+                  Available
+                </span>
+              </label>
+            ))}
+          </fieldset>
+
+          {!audioSet.stems.length ? (
+            <p className="export-empty-stems">No stems yet for this audio set. <button className="button-link" onClick={goToStudio} type="button">Go to Studio</button></p>
+          ) : null}
+        </div>
+
+        <aside className="panel export-package" aria-label="Export package">
+          {activeExportJob ? (
+            <div className="export-package__summary export-package__summary--progress export-progress" aria-live="polite">
+              <span className="eyebrow">Export in progress</span>
+              <h3>{activeExportJob.stage_label ?? "Preparing files"}</h3>
+              <p>{activeExportJob.export_result?.items.find((item) => item.status === "running")?.output_name
+                ?? activeExportJob.export_result?.items[0]?.output_name
+                ?? outputNames[0]
+                ?? "Export package"}</p>
+              <p>{activeExportJob.export_result?.total_count ?? selectedArtifacts.length} items · {activeExportJob.progress}%</p>
+              <progress aria-label="Export progress" max="100" value={activeExportJob.progress} />
+              <div className="export-progress__actions">
+                <button className="button" disabled={cancelMutation.isPending} onClick={() => cancelMutation.mutate()} type="button">
+                  <X aria-hidden="true" /> Cancel
+                </button>
+                <Link className="button button--ghost" to="/activity">View in Activity</Link>
+              </div>
+            </div>
+          ) : (
+            <>
+              <div className="export-section-heading"><span>Export package</span><PackageSummaryIcon /></div>
+              {latestExportJob ? (
+                <div className="export-latest" aria-live="polite">
+                  <span>Latest export</span>
+                  <strong>{latestExportJob.export_result?.outcome ?? latestExportJob.status}</strong>
+                </div>
+              ) : null}
+              <label className="export-field">
+                <span>File format</span>
+                <select
+                  aria-describedby={isMobileRuntime ? "android-export-format-notice" : undefined}
+                  disabled={capabilitiesQuery.isLoading}
+                  onChange={(event) => {
+                    setOutputFormat(event.target.value as typeof outputFormat);
+                    setDestinationTarget(null);
+                  }}
+                  value={outputFormat}
+                >
+                  {FORMATS.map((format) => {
+                    const capability = capabilities?.formats.find((candidate) => candidate.id === format);
+                    return <option disabled={capability?.available === false} key={format} value={format}>{format.toUpperCase()}{capability?.available === false ? " — unavailable" : ""}</option>;
+                  })}
+                </select>
+              </label>
+              {selectedFormatCapability?.available === false ? <p className="field-reason">{selectedFormatCapability.reason}</p> : null}
+              <label className="export-field">
+                <span>File name base</span>
+                <input onChange={(event) => setFilenameBase(event.target.value)} value={filenameBase} />
+              </label>
+              <fieldset className="export-destinations">
+                <legend>Destination</legend>
+                {DESTINATIONS.map(({ id, label, icon: Icon }) => {
+                  const countCompatible = selectedIds.size === 1 ? id === "single_file" : id !== "single_file";
+                  const capability = capabilities?.destinations.find((candidate) => candidate.id === id);
+                  const unavailable = !countCompatible || capability?.available === false;
+                  const reasonId = `export-destination-${id}-reason`;
+                  return (
+                    <span className="export-destination-option" key={id}>
+                      <button
+                        aria-describedby={unavailable ? reasonId : undefined}
+                        aria-pressed={destinationType === id}
+                        className="button button--small"
+                        disabled={unavailable}
+                        onClick={() => { setDestinationType(id); setDestinationTarget(null); }}
+                        type="button"
+                      ><Icon aria-hidden="true" /> {label}</button>
+                      {unavailable ? (
+                        <small className="field-reason" id={reasonId}>
+                          {capability?.available === false
+                            ? capability.reason
+                            : selectedIds.size === 1
+                              ? "Choose File for one item."
+                              : "Multiple items require Folder or ZIP."}
+                        </small>
+                      ) : null}
+                    </span>
+                  );
+                })}
+              </fieldset>
+              {selectedDestinationCapability?.available === false ? <p className="field-reason">{selectedDestinationCapability.reason}</p> : null}
+              <button className="button button--ghost export-destination-picker" disabled={!selectedIds.size} onClick={() => void chooseDestination()} type="button">
+                {destinationTarget ? "Change destination" : "Choose destination"}
+              </button>
+              {destinationTarget ? <p className="export-destination-target" title={destinationTarget}>{destinationTarget}</p> : null}
+
+              <div className="export-preview">
+                <div className="export-section-heading"><span>File preview</span><span>{outputNames.length}</span></div>
+                <ul>{outputNames.map((name) => <li key={name}>{name}</li>)}</ul>
+              </div>
+
+              {!selectionAllowed ? <p className="field-reason">This device supports one export item at a time.</p> : null}
+              {partialExportJob ? (
+                <>
+                  <button className="button button--ghost" disabled={Boolean(retryUnavailableReason)} onClick={retryFailed} type="button">Retry failed</button>
+                  {retryUnavailableReason ? <p className="field-reason">{retryUnavailableReason}</p> : null}
+                </>
+              ) : null}
+              <div className="export-package__summary" data-testid="export-compact-summary">
+                <div className="export-package__summary-copy" aria-live="polite">
+                  <span>{selectedIds.size} {selectedIds.size === 1 ? "item" : "items"}</span>
+                  <strong>{destinationLabel} · {destinationTarget ? "Selected" : "Choose on export"}</strong>
+                </div>
+                <button className="button export-package__submit" disabled={!canExport || exportMutation.isPending} onClick={() => exportMutation.mutate()} type="button">
+                  <Download aria-hidden="true" /> {exportMutation.isPending ? "Opening destination…" : `Export ${selectedIds.size || ""} ${selectedIds.size === 1 ? "file" : "files"}`}
+                </button>
+                {exportMutation.error ? <p className="error" role="alert">{exportMutation.error.message}</p> : null}
+              </div>
+              <Link className="export-activity-link" to="/activity">View export history in Activity</Link>
+            </>
+          )}
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+function PackageSummaryIcon() {
+  return <Layers3 aria-hidden="true" />;
+}

--- a/apps/desktop/src/features/projects/components/InspectorPanel.tsx
+++ b/apps/desktop/src/features/projects/components/InspectorPanel.tsx
@@ -17,7 +17,6 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
     deleteMutation,
     detectedKey,
     enharmonicDisplayMode,
-    exportMutation,
     handleDeleteAllMixes,
     handleDeleteAllStems,
     handleDeleteProject,
@@ -469,26 +468,6 @@ export function InspectorPanel({ mode = "studio" }: { mode?: "studio" | "analysi
             </div>
           </div>
         </details>
-      </div>
-
-      <div className="subpanel subpanel--compact analysis-export-panel">
-        <div className="subpanel__header">
-          <h3>Export</h3>
-          {showSupportingCopy ? (
-            <p className="subpanel__copy">
-              Export only when you need audio outside the app.
-            </p>
-          ) : null}
-        </div>
-        <button
-          className="button"
-          onClick={() => exportMutation.mutate()}
-          disabled={projectEditLocked || exportMutation.isPending}
-          title={editLockTitle}
-          type="button"
-        >
-          {exportMutation.isPending ? "Preparing..." : "Export Selected Audio"}
-        </button>
       </div>
 
       <div className="subpanel analysis-details-panel">

--- a/apps/desktop/src/features/projects/components/ProjectWorkspace.tsx
+++ b/apps/desktop/src/features/projects/components/ProjectWorkspace.tsx
@@ -1,4 +1,7 @@
-import { Activity, PanelRightOpen, SlidersHorizontal } from "lucide-react";
+import { Activity, Download, PanelRightOpen, SlidersHorizontal } from "lucide-react";
+import type { KeyboardEvent } from "react";
+import type { ProjectPanelMode } from "../projectPlaybackState";
+import { ExportWorkspace } from "./ExportWorkspace";
 import { useProjectViewModelContext } from "./useProjectViewModelContext";
 import { InspectorPanel } from "./InspectorPanel";
 import { JobsHistory } from "./JobsHistory";
@@ -14,43 +17,89 @@ export function ProjectWorkspace() {
     setInspectorOpen,
     sourcesRailCollapsed,
   } = useProjectViewModelContext();
+  const panelModes: ProjectPanelMode[] = ["studio", "analysis", "export"];
+
+  function handleTabKeyDown(event: KeyboardEvent<HTMLButtonElement>, currentMode: ProjectPanelMode) {
+    const currentIndex = panelModes.indexOf(currentMode);
+    const nextIndex = event.key === "Home"
+      ? 0
+      : event.key === "End"
+        ? panelModes.length - 1
+        : event.key === "ArrowRight"
+          ? (currentIndex + 1) % panelModes.length
+          : event.key === "ArrowLeft"
+            ? (currentIndex - 1 + panelModes.length) % panelModes.length
+            : null;
+    if (nextIndex === null) return;
+    event.preventDefault();
+    const nextMode = panelModes[nextIndex];
+    handleSelectProjectPanel(nextMode);
+    document.getElementById(`project-${nextMode}-tab`)?.focus();
+  }
 
   return (
     <div className="project-workspace">
       <div className="project-panel-toolbar">
         <div className="project-panel-tabs" role="tablist" aria-label="Project sections">
           <button
+            aria-controls="project-studio-panel"
             aria-selected={activeProjectPanel === "studio"}
             className={`project-panel-tabs__button${
               activeProjectPanel === "studio" ? " project-panel-tabs__button--active" : ""
             }`}
+            id="project-studio-tab"
+            onKeyDown={(event) => handleTabKeyDown(event, "studio")}
             onClick={() => handleSelectProjectPanel("studio")}
             role="tab"
+            tabIndex={activeProjectPanel === "studio" ? 0 : -1}
             type="button"
           >
             <SlidersHorizontal aria-hidden="true" className="project-panel-tabs__icon" />
             <span>Studio</span>
           </button>
           <button
+            aria-controls="project-analysis-panel"
             aria-selected={activeProjectPanel === "analysis"}
             className={`project-panel-tabs__button${
               activeProjectPanel === "analysis" ? " project-panel-tabs__button--active" : ""
             }`}
+            id="project-analysis-tab"
+            onKeyDown={(event) => handleTabKeyDown(event, "analysis")}
             onClick={() => handleSelectProjectPanel("analysis")}
             role="tab"
+            tabIndex={activeProjectPanel === "analysis" ? 0 : -1}
             type="button"
           >
             <Activity aria-hidden="true" className="project-panel-tabs__icon" />
             <span>Analysis</span>
+          </button>
+          <button
+            aria-controls="project-export-panel"
+            aria-selected={activeProjectPanel === "export"}
+            className={`project-panel-tabs__button${
+              activeProjectPanel === "export" ? " project-panel-tabs__button--active" : ""
+            }`}
+            id="project-export-tab"
+            onKeyDown={(event) => handleTabKeyDown(event, "export")}
+            onClick={() => handleSelectProjectPanel("export")}
+            role="tab"
+            tabIndex={activeProjectPanel === "export" ? 0 : -1}
+            type="button"
+          >
+            <Download aria-hidden="true" className="project-panel-tabs__icon" />
+            <span>Export</span>
           </button>
         </div>
       </div>
 
       {activeProjectPanel === "studio" ? (
         <div
+          aria-labelledby="project-studio-tab"
           className={`project-workbench project-workbench--studio${
             inspectorOpen ? "" : " project-workbench--inspector-collapsed"
           }${sourcesRailCollapsed ? " project-workbench--sources-collapsed" : ""}`}
+          id="project-studio-panel"
+          role="tabpanel"
         >
           <SourcesRail />
           <div className="stack project-studio-main">
@@ -72,11 +121,13 @@ export function ProjectWorkspace() {
             </button>
           )}
         </div>
-      ) : (
-        <div className="project-analysis-workspace">
+      ) : activeProjectPanel === "analysis" ? (
+        <div aria-labelledby="project-analysis-tab" className="project-analysis-workspace" id="project-analysis-panel" role="tabpanel">
           <InspectorPanel mode="analysis" />
           <JobsHistory />
         </div>
+      ) : (
+        <ExportWorkspace />
       )}
     </div>
   );

--- a/apps/desktop/src/features/projects/exportWorkspaceUtils.test.ts
+++ b/apps/desktop/src/features/projects/exportWorkspaceUtils.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { ArtifactSchema } from "../../lib/api";
+import {
+  buildExportAudioSets,
+  exportOutputNames,
+  exportPresetForSelection,
+} from "./exportWorkspaceUtils";
+
+function artifact(
+  id: string,
+  type: string,
+  createdAt: string,
+  sourceArtifactId?: string,
+): ArtifactSchema {
+  return {
+    id,
+    project_id: "project-1",
+    type,
+    format: "wav",
+    path: `/tmp/${id}.wav`,
+    size_bytes: 1,
+    generated_by: "test",
+    can_delete: true,
+    can_regenerate: false,
+    metadata: sourceArtifactId ? { source_artifact_id: sourceArtifactId } : {},
+    created_at: createdAt,
+  };
+}
+
+describe("export workspace utilities", () => {
+  it("numbers practice mixes by creation time with an ID tiebreaker", () => {
+    const audioSets = buildExportAudioSets([
+      artifact("mix-z", "preview_mix", "2026-08-13T12:00:00Z"),
+      artifact("source", "source_audio", "2026-08-13T10:00:00Z"),
+      artifact("mix-b", "preview_mix", "2026-08-13T11:00:00Z"),
+      artifact("mix-a", "preview_mix", "2026-08-13T11:00:00Z"),
+      artifact("vocals", "vocal_stem", "2026-08-13T12:01:00Z", "mix-a"),
+    ]);
+
+    expect(audioSets.map((audioSet) => [audioSet.artifact.id, audioSet.label])).toEqual([
+      ["source", "Source Track"],
+      ["mix-a", "Practice Mix 1"],
+      ["mix-b", "Practice Mix 2"],
+      ["mix-z", "Practice Mix 3"],
+    ]);
+    expect(audioSets[1]?.stems.map((stem) => stem.id)).toEqual(["vocals"]);
+  });
+
+  it("recognizes exact presets and keeps manual subsets custom", () => {
+    const [audioSet] = buildExportAudioSets([
+      artifact("source", "source_audio", "2026-08-13T10:00:00Z"),
+      artifact("vocals", "vocal_stem", "2026-08-13T10:01:00Z", "source"),
+      artifact("drums", "drums_stem", "2026-08-13T10:02:00Z", "source"),
+    ]);
+    expect(audioSet).toBeDefined();
+    if (!audioSet) return;
+
+    expect(exportPresetForSelection(audioSet, new Set(["source"]))).toBe("track");
+    expect(exportPresetForSelection(audioSet, new Set(["vocals", "drums"]))).toBe("stems");
+    expect(exportPresetForSelection(audioSet, new Set(["source", "vocals", "drums"]))).toBe(
+      "track-and-stems",
+    );
+    expect(exportPresetForSelection(audioSet, new Set(["source", "vocals"]))).toBe("custom");
+    expect(exportOutputNames(audioSet, new Set(["source", "vocals"]), "My take", "m4a")).toEqual([
+      "My take - Source.m4a",
+      "My take - Source - Vocals.m4a",
+    ]);
+  });
+});

--- a/apps/desktop/src/features/projects/exportWorkspaceUtils.ts
+++ b/apps/desktop/src/features/projects/exportWorkspaceUtils.ts
@@ -1,0 +1,68 @@
+import type { ArtifactSchema } from "../../lib/api";
+import { artifactLabel, isStemArtifact } from "./projectViewUtils";
+
+export type ExportAudioSet = {
+  artifact: ArtifactSchema;
+  label: string;
+  stems: ArtifactSchema[];
+};
+
+export type ExportPreset = "track" | "stems" | "track-and-stems" | "custom";
+
+export function buildExportAudioSets(artifacts: ArtifactSchema[]): ExportAudioSet[] {
+  const source = artifacts.find((artifact) => artifact.type === "source_audio") ?? null;
+  const mixes = artifacts
+    .filter((artifact) => artifact.type === "preview_mix")
+    .sort(
+      (left, right) =>
+        left.created_at.localeCompare(right.created_at) || left.id.localeCompare(right.id),
+    );
+  const stems = artifacts.filter(isStemArtifact);
+  const primaryArtifacts = [source, ...mixes].filter(Boolean) as ArtifactSchema[];
+  return primaryArtifacts.map((artifact) => ({
+    artifact,
+    label:
+      artifact.type === "source_audio"
+        ? "Source Track"
+        : `Practice Mix ${mixes.findIndex((mix) => mix.id === artifact.id) + 1}`,
+    stems: stems.filter((stem) => stem.metadata?.source_artifact_id === artifact.id),
+  }));
+}
+
+export function exportPresetForSelection(audioSet: ExportAudioSet, selectedIds: Set<string>): ExportPreset {
+  const stemIds = audioSet.stems.map((stem) => stem.id);
+  if (selectedIds.size === 1 && selectedIds.has(audioSet.artifact.id)) {
+    return "track";
+  }
+  if (stemIds.length && selectedIds.size === stemIds.length && stemIds.every((id) => selectedIds.has(id))) {
+    return "stems";
+  }
+  if (
+    stemIds.length &&
+    selectedIds.size === stemIds.length + 1 &&
+    selectedIds.has(audioSet.artifact.id) &&
+    stemIds.every((id) => selectedIds.has(id))
+  ) {
+    return "track-and-stems";
+  }
+  return "custom";
+}
+
+export function exportContextName(audioSet: ExportAudioSet) {
+  return audioSet.artifact.type === "source_audio" ? "Source" : audioSet.label;
+}
+
+export function exportOutputNames(
+  audioSet: ExportAudioSet,
+  selectedIds: Set<string>,
+  filenameBase: string,
+  outputFormat: string,
+) {
+  const context = exportContextName(audioSet);
+  return [audioSet.artifact, ...audioSet.stems]
+    .filter((artifact) => selectedIds.has(artifact.id))
+    .map((artifact) => {
+      const itemLabel = isStemArtifact(artifact) ? ` - ${artifactLabel(artifact)}` : "";
+      return `${filenameBase.trim() || "TuneForge Export"} - ${context}${itemLabel}.${outputFormat}`;
+    });
+}

--- a/apps/desktop/src/features/projects/hooks/useExportWorkspace.ts
+++ b/apps/desktop/src/features/projects/hooks/useExportWorkspace.ts
@@ -1,0 +1,269 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { confirm, open, save } from "@tauri-apps/plugin-dialog";
+import { ApiError, api, type ExportRequest } from "../../../lib/api";
+import { useProjectViewModelContext } from "../components/useProjectViewModelContext";
+import {
+  buildExportAudioSets,
+  exportContextName,
+  exportOutputNames,
+  exportPresetForSelection,
+  type ExportPreset,
+} from "../exportWorkspaceUtils";
+
+type DestinationType = "single_file" | "folder" | "zip";
+type ExportFormat = "wav" | "flac" | "mp3" | "m4a";
+
+const FORMAT_LABELS: Record<ExportFormat, string> = {
+  wav: "WAV",
+  flac: "FLAC",
+  mp3: "MP3",
+  m4a: "M4A",
+};
+
+function isExportDestinationExistsError(error: unknown) {
+  return error instanceof ApiError && error.code === "EXPORT_DESTINATION_EXISTS";
+}
+
+function selectedIdsForPreset(
+  preset: Exclude<ExportPreset, "custom">,
+  trackId: string,
+  stemIds: string[],
+) {
+  if (preset === "track") return new Set([trackId]);
+  if (preset === "stems") return new Set(stemIds);
+  return new Set([trackId, ...stemIds]);
+}
+
+export function useExportWorkspace() {
+  const {
+    displayArtifacts,
+    handleSelectProjectPanel,
+    isMobileRuntime,
+    projectEditLocked,
+    projectQuery,
+    selectedPrimaryArtifactId,
+    visibleJobs,
+  } = useProjectViewModelContext();
+  const queryClient = useQueryClient();
+  const audioSets = useMemo(() => buildExportAudioSets(displayArtifacts), [displayArtifacts]);
+  const defaultAudioSetId =
+    audioSets.find((audioSet) => audioSet.artifact.id === selectedPrimaryArtifactId)?.artifact.id ??
+    audioSets[0]?.artifact.id ??
+    "";
+  const [audioSetId, setAudioSetId] = useState(defaultAudioSetId);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [outputFormat, setOutputFormat] = useState<ExportFormat>("m4a");
+  const [filenameBase, setFilenameBase] = useState(projectQuery.data?.display_name ?? "TuneForge Export");
+  const [destinationType, setDestinationType] = useState<DestinationType>("single_file");
+  const [destinationTarget, setDestinationTarget] = useState<string | null>(null);
+  const skipAudioSetResetRef = useRef(false);
+  const audioSet = audioSets.find((candidate) => candidate.artifact.id === audioSetId) ?? audioSets[0] ?? null;
+
+  useEffect(() => {
+    if (!audioSetId && defaultAudioSetId) setAudioSetId(defaultAudioSetId);
+  }, [audioSetId, defaultAudioSetId]);
+
+  useEffect(() => {
+    if (!audioSet) return;
+    if (skipAudioSetResetRef.current) {
+      skipAudioSetResetRef.current = false;
+      return;
+    }
+    setSelectedIds(new Set([audioSet.artifact.id]));
+    setDestinationType("single_file");
+    setDestinationTarget(null);
+  }, [audioSet]);
+
+  const capabilitiesQuery = useQuery({
+    queryKey: ["export-capabilities"],
+    queryFn: () => api.getExportCapabilities(),
+    staleTime: Infinity,
+  });
+  const capabilities = capabilitiesQuery.data?.capabilities ?? null;
+  const selectedArtifacts = audioSet
+    ? [audioSet.artifact, ...audioSet.stems].filter((artifact) => selectedIds.has(artifact.id))
+    : [];
+  const preset = audioSet ? exportPresetForSelection(audioSet, selectedIds) : "custom";
+  const outputNames = audioSet
+    ? exportOutputNames(audioSet, selectedIds, filenameBase, outputFormat)
+    : [];
+  const activeExportJob = visibleJobs.find(
+    (job) => job.type === "export" && ["pending", "running"].includes(job.status),
+  );
+  const latestExportJob = visibleJobs.find((job) => job.type === "export") ?? null;
+  const partialExportJob = latestExportJob?.export_result?.outcome === "partial" ? latestExportJob : null;
+  const failedArtifactIds = partialExportJob?.export_result?.items
+    .filter((item) => item.status === "failed")
+    .map((item) => item.artifact_id) ?? [];
+  const retryAudioSet = audioSets.find((candidate) =>
+    failedArtifactIds.some(
+      (id) => id === candidate.artifact.id || candidate.stems.some((stem) => stem.id === id),
+    ),
+  ) ?? null;
+  const maxArtifactCount = capabilities?.max_artifact_count ?? null;
+  const selectedFormatCapability = capabilities?.formats.find((format) => format.id === outputFormat);
+  const selectedDestinationCapability = capabilities?.destinations.find(
+    (destination) => destination.id === destinationType,
+  );
+  const selectionAllowed = maxArtifactCount === null || selectedIds.size <= maxArtifactCount;
+  const canExport = Boolean(
+    audioSet &&
+      selectedIds.size &&
+      filenameBase.trim() &&
+      selectedFormatCapability?.available &&
+      selectedDestinationCapability?.available &&
+      selectionAllowed &&
+      !projectEditLocked &&
+      !activeExportJob,
+  );
+
+  function updateSelection(next: Set<string>) {
+    const wasSingle = selectedIds.size === 1;
+    const isSingle = next.size === 1;
+    setSelectedIds(next);
+    if (next.size === 0 || wasSingle !== isSingle) {
+      setDestinationTarget(null);
+      setDestinationType(isSingle ? "single_file" : "folder");
+    }
+  }
+
+  function selectPreset(nextPreset: Exclude<ExportPreset, "custom">) {
+    if (!audioSet || (isMobileRuntime && nextPreset !== "track")) return;
+    updateSelection(
+      selectedIdsForPreset(nextPreset, audioSet.artifact.id, audioSet.stems.map((stem) => stem.id)),
+    );
+  }
+
+  function toggleArtifact(artifactId: string) {
+    if (isMobileRuntime) {
+      updateSelection(new Set([artifactId]));
+      return;
+    }
+    const next = new Set(selectedIds);
+    if (next.has(artifactId)) next.delete(artifactId);
+    else next.add(artifactId);
+    updateSelection(next);
+  }
+
+  async function chooseDestination(type = destinationType) {
+    if (!audioSet) return null;
+    let target: string | string[] | null;
+    if (type === "folder") {
+      target = await open({ directory: true, multiple: false });
+    } else {
+      const defaultName =
+        type === "zip"
+          ? `${filenameBase.trim()} - ${exportContextName(audioSet)}.zip`
+          : outputNames[0];
+      target = await save({
+        defaultPath: defaultName,
+        filters:
+          type === "zip"
+            ? [{ name: "ZIP Archive", extensions: ["zip"] }]
+            : [{ name: FORMAT_LABELS[outputFormat], extensions: [outputFormat] }],
+      });
+    }
+    const normalized = Array.isArray(target) ? target[0] : target;
+    if (!normalized) return null;
+    setDestinationTarget(normalized);
+    return normalized;
+  }
+
+  const exportMutation = useMutation({
+    mutationFn: async () => {
+      if (!audioSet || !projectQuery.data) return null;
+      const target = destinationTarget ?? (await chooseDestination());
+      if (!target) return null;
+      const request: ExportRequest = {
+        artifact_ids: selectedArtifacts.map((artifact) => artifact.id),
+        output_format: outputFormat,
+        filename_base: filenameBase.trim(),
+        destination: { type: destinationType, target, overwrite: false },
+      };
+      try {
+        return await api.createExport(projectQuery.data.id, request);
+      } catch (error) {
+        if (!isExportDestinationExistsError(error)) throw error;
+        const overwrite = await confirm("One or more export destinations already exist. Replace them?", {
+          title: "Replace existing export?",
+          kind: "warning",
+          okLabel: "Replace",
+          cancelLabel: "Cancel",
+        });
+        if (!overwrite) return null;
+        return api.createExport(projectQuery.data.id, {
+          ...request,
+          destination: { ...request.destination!, overwrite: true },
+        });
+      }
+    },
+    onSuccess: async (response) => {
+      if (!response) return;
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["jobs"] }),
+        queryClient.invalidateQueries({ queryKey: ["artifacts", projectQuery.data?.id] }),
+      ]);
+    },
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: () => api.cancelJob(activeExportJob?.id ?? ""),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["jobs"] }),
+  });
+
+  function retryFailed() {
+    if (!retryAudioSet) return;
+    const failed = failedArtifactIds.filter(
+      (id) => id === retryAudioSet.artifact.id || retryAudioSet.stems.some((stem) => stem.id === id),
+    );
+    if (retryAudioSet.artifact.id !== audioSet?.artifact.id) {
+      skipAudioSetResetRef.current = true;
+      setAudioSetId(retryAudioSet.artifact.id);
+    }
+    setSelectedIds(new Set(failed));
+    setDestinationTarget(null);
+    setDestinationType(failed.length === 1 ? "single_file" : "folder");
+  }
+
+  return {
+    audioSet,
+    audioSetId,
+    audioSets,
+    activeExportJob,
+    canExport,
+    cancelMutation,
+    capabilities,
+    capabilitiesQuery,
+    chooseDestination,
+    destinationTarget,
+    destinationType,
+    exportMutation,
+    filenameBase,
+    goToStudio: () => handleSelectProjectPanel("studio"),
+    isMobileRuntime,
+    latestExportJob,
+    maxArtifactCount,
+    outputFormat,
+    outputNames,
+    partialExportJob,
+    preset,
+    projectEditLocked,
+    retryFailed,
+    retryUnavailableReason: partialExportJob && !retryAudioSet
+      ? "Failed export items are no longer available in this project."
+      : null,
+    selectedDestinationCapability,
+    selectedFormatCapability,
+    selectedIds,
+    selectedArtifacts,
+    selectionAllowed,
+    selectPreset,
+    setAudioSetId,
+    setDestinationTarget,
+    setDestinationType,
+    setFilenameBase,
+    setOutputFormat,
+    toggleArtifact,
+  };
+}

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -1,13 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
-import { confirm, save } from "@tauri-apps/plugin-dialog";
+import { confirm } from "@tauri-apps/plugin-dialog";
 import {
-  ApiError,
   api,
   getProjectSyncSummary,
   type ArtifactSchema,
-  type ExportRequest,
   type JobSchema,
   type LyricsGenerateRequest,
   type LyricsResponse,
@@ -101,11 +99,6 @@ const ACTIVE_PROJECT_JOBS_LIMIT = 200;
 const PROJECT_HISTORY_JOBS_PAGE_SIZE = 50;
 const EMPTY_JOBS: JobSchema[] = [];
 const PROJECT_PLAYBACK_FALLBACK_NAME = "Project playback";
-const DESKTOP_EXPORT_FILTERS = [
-  { name: "WAV Audio", extensions: ["wav"] },
-  { name: "MP3 Audio", extensions: ["mp3"] },
-  { name: "FLAC Audio", extensions: ["flac"] },
-];
 
 type DeleteArtifactsRequest = {
   artifactIds: string[];
@@ -173,24 +166,6 @@ function formatLyricsLanguageMetadata(lyrics: LyricsResponse | undefined) {
     return `Override: ${overrideLabel}`;
   }
   return effectiveLabel ? `Language: ${effectiveLabel}` : null;
-}
-
-function supportedExportFormat(format: string | null | undefined) {
-  const normalizedFormat = format?.toLowerCase();
-  if (normalizedFormat === "mp3" || normalizedFormat === "flac" || normalizedFormat === "wav") {
-    return normalizedFormat;
-  }
-  return "wav";
-}
-
-function exportFormatFromFilePath(filePath: string) {
-  const fileName = filePath.split(/[\\/]/).pop() ?? filePath;
-  const extension = fileName.includes(".") ? fileName.split(".").pop() : null;
-  return supportedExportFormat(extension);
-}
-
-function isExportDestinationExistsError(error: unknown) {
-  return error instanceof ApiError && error.code === "EXPORT_DESTINATION_EXISTS";
 }
 
 function resolveDefaultPlaybackDisplayMode(
@@ -699,63 +674,6 @@ export function useProjectViewModel() {
         queryClient.invalidateQueries({ queryKey: ["jobs"] }),
         queryClient.invalidateQueries({ queryKey: ["artifacts", projectId] }),
       ]);
-    },
-  });
-
-  const exportMutation = useMutation({
-    mutationFn: async () => {
-      assertProjectEditable();
-      const exportArtifact =
-        selectedArtifact ??
-        primaryArtifacts.find((artifact) => artifact.type === "preview_mix") ??
-        primaryArtifacts.find((artifact) => artifact.type === "source_audio");
-      if (!exportArtifact) {
-        throw new Error("Nothing available to export yet.");
-      }
-      const defaultExportName = projectQuery.data?.display_name ?? artifactLabel(exportArtifact);
-      const suggestedFormat = supportedExportFormat(exportArtifact.format);
-      const exportTarget = await save({
-        defaultPath: `${defaultExportName}.${suggestedFormat}`,
-        filters: DESKTOP_EXPORT_FILTERS,
-      });
-      if (exportTarget === null || exportTarget.length === 0) {
-        return null;
-      }
-      const exportRequest: ExportRequest = {
-        artifact_ids: [exportArtifact.id],
-        mixdown_mode: "copy",
-        output_format: exportFormatFromFilePath(exportTarget),
-        destination_file_path: exportTarget,
-      };
-      try {
-        return await api.createExport(projectId, exportRequest);
-      } catch (error) {
-        if (!isExportDestinationExistsError(error)) {
-          throw error;
-        }
-        const shouldOverwrite = await confirm(
-          "A file already exists with that name. Replace it?",
-          {
-            title: "Replace existing export?",
-            kind: "warning",
-            okLabel: "Replace",
-            cancelLabel: "Cancel",
-          },
-        );
-        if (!shouldOverwrite) {
-          return null;
-        }
-        return api.createExport(projectId, {
-          ...exportRequest,
-          overwrite_existing: true,
-        });
-      }
-    },
-    onSuccess: async (response) => {
-      if (!response) {
-        return;
-      }
-      await queryClient.invalidateQueries({ queryKey: ["jobs"] });
     },
   });
 
@@ -2556,7 +2474,6 @@ export function useProjectViewModel() {
     displayedLyrics,
     draftName,
     enharmonicDisplayMode,
-    exportMutation,
     acceptedTabSuggestionIds,
     handleAnalyzeAction,
     handleDeleteMix,

--- a/apps/desktop/src/features/projects/projectPlaybackState.ts
+++ b/apps/desktop/src/features/projects/projectPlaybackState.ts
@@ -10,7 +10,7 @@ import {
 } from "../../lib/timingGrid";
 import { normalizeTempoTargetBpm } from "./playbackTempo";
 
-export type ProjectPanelMode = "studio" | "analysis";
+export type ProjectPanelMode = "studio" | "analysis" | "export";
 
 export type StemControlState = {
   muted: boolean;
@@ -127,7 +127,7 @@ export function normalizePlaybackLoopRange(value: unknown): PlaybackLoopRange | 
 }
 
 function isProjectPanelMode(value: unknown): value is ProjectPanelMode {
-  return value === "studio" || value === "analysis";
+  return value === "studio" || value === "analysis" || value === "export";
 }
 
 function normalizeStoredProjectPlaybackState(value: unknown): StoredProjectPlaybackState {

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -45,6 +45,8 @@ export type ListJobsParams = NonNullable<paths["/api/v1/jobs"]["get"]["parameter
 export type PreviewRequest = components["schemas"]["PreviewRequest"];
 export type RetuneRequest = components["schemas"]["RetuneRequest"];
 export type ExportRequest = components["schemas"]["ExportRequest"];
+export type ExportCapabilities = components["schemas"]["ExportCapabilitiesSchema"];
+export type ExportCapabilitiesResponse = components["schemas"]["ExportCapabilitiesResponse"];
 export type ProjectUpdateRequest = components["schemas"]["ProjectUpdateRequest"];
 export type ProjectImportRequest = components["schemas"]["ProjectImportRequest"];
 export type StemRequest = components["schemas"]["StemRequest"];
@@ -2138,6 +2140,7 @@ export type TuneForgeClient = {
   getMobileCapabilities: () => Promise<RuntimeCapabilities>;
   ensureWebMediaTransport: () => Promise<void>;
   getHealth: () => Promise<HealthResponse>;
+  getExportCapabilities: () => Promise<ExportCapabilitiesResponse>;
   listProjects: (params?: ListProjectsParams) => Promise<components["schemas"]["ProjectsResponse"]>;
   importProject: (body: ProjectImportRequest) => Promise<components["schemas"]["ProjectResponse"]>;
   getProject: (projectId: string) => Promise<components["schemas"]["ProjectResponse"]>;
@@ -2334,6 +2337,7 @@ function createHttpTuneForgeClient(): TuneForgeClient {
     getMobileCapabilities: async () => null,
     ensureWebMediaTransport: async () => {},
     getHealth: () => unwrap(client.GET("/api/v1/health")),
+    getExportCapabilities: () => unwrap(client.GET("/api/v1/export-capabilities")),
     listProjects: (params?: ListProjectsParams) =>
       unwrap(client.GET("/api/v1/projects", params ? { params: { query: params } } : undefined)),
     importProject: (body: ProjectImportRequest) =>
@@ -2468,6 +2472,22 @@ function createMobileTuneForgeClient(capabilities: MobileCapabilities): TuneForg
     getMobileCapabilities: async () => capabilities,
     ensureWebMediaTransport,
     getHealth: () => invokeMobile("mobile_get_health"),
+    getExportCapabilities: async () => ({
+      capabilities: {
+        platform: "android",
+        formats: ["wav", "flac", "mp3", "m4a"].map((id) => ({
+          id,
+          available: false,
+          reason: "Android audio export is not available in this build.",
+        })),
+        destinations: ["single_file", "folder", "zip"].map((id) => ({
+          id,
+          available: false,
+          reason: "Android audio export is not available in this build.",
+        })),
+        max_artifact_count: 1,
+      },
+    }),
     listProjects: (params?: ListProjectsParams) =>
       invokeMobile("mobile_list_projects", { params: params ?? null }),
     importProject: async (body: ProjectImportRequest) => {
@@ -2601,6 +2621,7 @@ export const api: TuneForgeClient = {
   getMobileCapabilities: () => activeClient.getMobileCapabilities(),
   ensureWebMediaTransport: () => activeClient.ensureWebMediaTransport(),
   getHealth: () => activeClient.getHealth(),
+  getExportCapabilities: () => activeClient.getExportCapabilities(),
   listProjects: (params?: ListProjectsParams) => activeClient.listProjects(params),
   importProject: (body) => activeClient.importProject(body),
   getProject: (projectId: string) => activeClient.getProject(projectId),

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2,6 +2,7 @@
 @import "./styles/settings-theme.css";
 @import "./styles/library.css";
 @import "./styles/project-layout.css";
+@import "./styles/project-export.css";
 @import "./styles/project-playback.css";
 @import "./styles/project-history.css";
 @import "./styles/project-inspector.css";

--- a/apps/desktop/src/styles/project-export.css
+++ b/apps/desktop/src/styles/project-export.css
@@ -1,0 +1,443 @@
+.export-workspace {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.export-workspace__header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.35rem 0.2rem;
+}
+
+.export-workspace__header h2 {
+  margin: 0.12rem 0 0.2rem;
+  font-size: clamp(1.55rem, 2.2vw, 2.1rem);
+}
+
+.export-workspace__header p {
+  max-width: 48rem;
+  margin: 0;
+  color: var(--muted);
+}
+
+.export-workspace__selection-count {
+  flex: 0 0 auto;
+  padding: 0.48rem 0.7rem;
+  border: 1px solid var(--divider);
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+.export-workspace__grid {
+  display: grid;
+  grid-template-columns: minmax(12.5rem, 0.64fr) minmax(23rem, 1.25fr) minmax(20rem, 0.92fr);
+  gap: 0.85rem;
+  align-items: start;
+}
+
+.export-audio-sets,
+.export-selection,
+.export-package {
+  --panel-padding: 0.9rem;
+  min-width: 0;
+}
+
+.export-audio-sets,
+.export-selection,
+.export-package,
+.export-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.export-section-heading,
+.export-selection__identity {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.export-section-heading {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.055em;
+  text-transform: uppercase;
+}
+
+.export-latest {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.65rem;
+  padding: 0.65rem;
+  border: 1px solid var(--divider);
+  border-radius: 14px;
+  color: var(--muted);
+}
+
+.export-latest strong {
+  color: var(--ink);
+  text-transform: capitalize;
+}
+
+.export-section-heading svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.export-audio-sets__options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.export-audio-set {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr);
+  gap: 0.65rem;
+  align-items: center;
+  padding: 0.7rem;
+  border: 1px solid var(--divider);
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--panel) 72%, transparent);
+  cursor: pointer;
+}
+
+.export-audio-set--active {
+  border-color: color-mix(in srgb, var(--playback-accent) 50%, var(--divider));
+  background: color-mix(in srgb, var(--chip-active-bg) 75%, var(--panel));
+}
+
+.export-audio-set__icon,
+.export-artifact-row__icon {
+  display: grid;
+  width: 2.3rem;
+  height: 2.3rem;
+  place-items: center;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--playback-accent) 13%, var(--panel-strong));
+  color: var(--playback-accent);
+}
+
+.export-audio-set__icon svg,
+.export-artifact-row__icon svg {
+  width: 1.15rem;
+  height: 1.15rem;
+}
+
+.export-audio-set strong,
+.export-audio-set small,
+.export-artifact-row__copy strong,
+.export-artifact-row__copy small {
+  display: block;
+}
+
+.export-audio-set small,
+.export-artifact-row__copy small,
+.export-selection__identity > span {
+  margin-top: 0.2rem;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.export-selection__identity {
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--divider);
+}
+
+.export-selection__identity h3 {
+  margin: 0.18rem 0 0;
+  font-size: 1.35rem;
+}
+
+.export-presets,
+.export-artifact-list,
+.export-destinations {
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.export-presets legend,
+.export-artifact-list legend,
+.export-destinations legend,
+.export-field > span {
+  margin-bottom: 0.48rem;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.export-presets,
+.export-destinations {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.export-presets legend,
+.export-destinations legend {
+  width: 100%;
+}
+
+.export-presets .button[aria-pressed="true"],
+.export-destinations .button[aria-pressed="true"] {
+  border-color: var(--chip-active-border);
+  background: var(--chip-active-bg);
+}
+
+.export-presets__state {
+  align-self: center;
+  margin-left: auto;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.export-presets > .field-reason {
+  flex-basis: 100%;
+}
+
+.export-destination-option {
+  display: grid;
+  gap: 0.3rem;
+  min-width: 5rem;
+}
+
+.export-destination-option .field-reason {
+  max-width: 10rem;
+  font-size: 0.72rem;
+}
+
+.export-artifact-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.export-artifact-row {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr) auto;
+  gap: 0.65rem;
+  align-items: center;
+  padding: 0.65rem;
+  border: 1px solid var(--divider);
+  border-radius: 15px;
+  background: color-mix(in srgb, var(--panel) 70%, transparent);
+  cursor: pointer;
+}
+
+.export-artifact-row:has(input:checked) {
+  border-color: color-mix(in srgb, var(--playback-accent) 42%, var(--divider));
+}
+
+.export-artifact-row__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.export-artifact-row__status svg {
+  width: 0.9rem;
+  height: 0.9rem;
+  color: var(--playback-accent);
+}
+
+.export-empty-stems {
+  margin: 0;
+  padding: 0.7rem;
+  border: 1px dashed var(--divider);
+  border-radius: 14px;
+  color: var(--muted);
+}
+
+.export-field {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.export-field input,
+.export-field select {
+  width: 100%;
+}
+
+.field-reason,
+.export-destination-target,
+.export-activity-link {
+  margin: -0.35rem 0 0;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.export-destination-target {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.export-preview {
+  min-width: 0;
+  padding: 0.75rem;
+  border: 1px solid var(--divider);
+  border-radius: 15px;
+  background: color-mix(in srgb, var(--panel-strong) 60%, transparent);
+}
+
+.export-preview ul {
+  display: flex;
+  max-height: 10.5rem;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin: 0.65rem 0 0;
+  padding: 0;
+  overflow: auto;
+  list-style: none;
+}
+
+.export-preview li {
+  overflow: hidden;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.export-package__submit {
+  width: 100%;
+  min-height: 3rem;
+  justify-content: center;
+}
+
+.export-package__summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--divider);
+}
+
+.export-package__summary-copy {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.export-package__summary-copy strong {
+  color: var(--ink);
+  font-size: 0.78rem;
+}
+
+.export-package__summary--progress {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.export-progress progress {
+  width: 100%;
+}
+
+.export-progress__actions {
+  display: flex;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+}
+
+.export-progress__actions .button {
+  flex: 1 1 8rem;
+  justify-content: center;
+}
+
+.export-activity-link {
+  align-self: center;
+}
+
+@media (max-width: 1200px) {
+  .export-workspace__grid {
+    grid-template-columns: minmax(0, 1.15fr) minmax(19rem, 0.85fr);
+  }
+
+  .export-audio-sets {
+    grid-column: 1 / -1;
+  }
+
+  .export-audio-sets__options {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  }
+}
+
+@media (max-width: 1024px) {
+  .export-workspace__grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .export-audio-sets {
+    grid-column: auto;
+  }
+}
+
+@media (max-width: 720px) {
+  .export-workspace {
+    padding-bottom: 6rem;
+  }
+
+  .export-workspace__header {
+    align-items: flex-start;
+  }
+
+  .export-audio-sets__options {
+    display: flex;
+    flex-direction: row;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+  }
+
+  .export-audio-set {
+    min-width: 13.5rem;
+    scroll-snap-align: start;
+  }
+
+  .export-selection__identity,
+  .export-artifact-row {
+    align-items: flex-start;
+  }
+
+  .export-artifact-row {
+    grid-template-columns: auto auto minmax(0, 1fr);
+  }
+
+  .export-artifact-row__status {
+    grid-column: 3;
+  }
+
+  .export-package {
+    position: static;
+  }
+
+  .export-package__summary {
+    position: sticky;
+    bottom: 0.5rem;
+    z-index: 4;
+    margin: 0 -0.2rem -0.2rem;
+    padding: 0.75rem;
+    border: 1px solid var(--divider);
+    border-radius: 16px;
+    background: color-mix(in srgb, var(--panel-strong) 94%, transparent);
+    box-shadow: 0 18px 50px color-mix(in srgb, black 55%, transparent);
+  }
+}

--- a/apps/desktop/src/styles/project-export.source.test.mjs
+++ b/apps/desktop/src/styles/project-export.source.test.mjs
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { cwd } from "node:process";
+import { describe, expect, it } from "vitest";
+
+describe("narrow export package source", () => {
+  it("keeps the package in flow and sticks only its compact summary", () => {
+    const stylesheet = readFileSync(resolve(cwd(), "src/styles/project-export.css"), "utf8");
+    const narrowStyles = stylesheet.slice(stylesheet.indexOf("@media (max-width: 720px)"));
+
+    expect(narrowStyles).toMatch(/\.export-package\s*\{\s*position:\s*static;/);
+    expect(narrowStyles).toMatch(/\.export-package__summary\s*\{[^}]*position:\s*sticky;/s);
+    expect(narrowStyles).not.toMatch(/\.export-package\s*\{[^}]*position:\s*sticky;/s);
+  });
+});

--- a/apps/desktop/src/styles/project-inspector.css
+++ b/apps/desktop/src/styles/project-inspector.css
@@ -35,17 +35,12 @@
   grid-template-columns: minmax(0, 1.25fr) minmax(18rem, 0.75fr);
   grid-template-areas:
     "summary details"
-    "summary export"
     "danger danger";
   align-items: start;
 }
 
 .analysis-summary-panel {
   grid-area: summary;
-}
-
-.analysis-export-panel {
-  grid-area: export;
 }
 
 .analysis-details-panel {
@@ -62,7 +57,6 @@
     grid-template-areas:
       "summary"
       "details"
-      "export"
       "danger";
   }
 }

--- a/apps/desktop/src/styles/project-layout.css
+++ b/apps/desktop/src/styles/project-layout.css
@@ -599,7 +599,6 @@
     grid-template-areas:
       "summary"
       "details"
-      "export"
       "danger";
   }
 }

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -7,6 +7,7 @@ import type {
   AnalysisRequest,
   BulkJobRequest,
   BulkJobsResponse,
+  ExportCapabilitiesResponse,
   LyricsGenerateRequest,
   ListJobsParams,
   ListProjectsParams,
@@ -42,6 +43,7 @@ const {
   setProjectAnalysis,
   setProjectChords,
   setProjectLyrics,
+  setProjectArtifacts,
   setBeatBackends,
   setChordBackends,
   setStemModels,
@@ -96,6 +98,7 @@ const {
   mockDeleteArtifact,
   mockDeleteProject,
   mockGetHealth,
+  mockGetExportCapabilities,
   mockGetMobileCapabilities,
   mockEnsureWebMediaTransport,
   mockScanPairingQrCode,
@@ -702,6 +705,10 @@ const {
 
   function setSyncPreflight(preflight: Record<string, unknown> | null) {
     state.syncPreflight = preflight ? clone(preflight) : null;
+  }
+
+  function setProjectArtifacts(projectId: string, artifacts: Array<Record<string, unknown>>) {
+    state.artifactsByProject[projectId] = clone(artifacts);
   }
 
   function setSyncTrustedPeers(peers: Array<Record<string, unknown>>) {
@@ -1409,6 +1416,18 @@ const {
     preview_format: "wav",
   }));
   const mockGetMobileCapabilities = vi.fn(async (): Promise<unknown> => null);
+  const mockGetExportCapabilities = vi.fn(async (): Promise<ExportCapabilitiesResponse> => ({
+    capabilities: {
+      platform: "desktop",
+      formats: ["wav", "flac", "mp3", "m4a"].map((id) => ({ id, available: true, reason: null })),
+      destinations: ["single_file", "folder", "zip"].map((id) => ({
+        id,
+        available: true,
+        reason: null,
+      })),
+      max_artifact_count: null,
+    },
+  }));
   const mockEnsureWebMediaTransport = vi.fn(async () => {});
   const mockScanPairingQrCode = vi.fn(async (): Promise<string> => {
     throw new Error("QR scanner unavailable.");
@@ -2415,6 +2434,7 @@ const {
     setProjectAnalysis,
     setProjectChords,
     setProjectLyrics,
+    setProjectArtifacts,
     setBeatBackends,
     setChordBackends,
     setStemModels,
@@ -2469,6 +2489,7 @@ const {
     mockDeleteArtifact,
     mockDeleteProject,
     mockGetHealth,
+    mockGetExportCapabilities,
     mockGetMobileCapabilities,
     mockEnsureWebMediaTransport,
     mockScanPairingQrCode,
@@ -2494,6 +2515,7 @@ export {
   setProjectAnalysis,
   setProjectChords,
   setProjectLyrics,
+  setProjectArtifacts,
   setBeatBackends,
   setChordBackends,
   setStemModels,
@@ -2547,6 +2569,7 @@ export {
   mockDeleteArtifact,
   mockDeleteProject,
   mockGetHealth,
+  mockGetExportCapabilities,
   mockGetMobileCapabilities,
   mockEnsureWebMediaTransport,
   mockScanPairingQrCode,
@@ -2576,6 +2599,7 @@ vi.mock("../lib/api", async (importOriginal) => {
     api: {
       ...actual.api,
       getHealth: mockGetHealth,
+      getExportCapabilities: mockGetExportCapabilities,
       listProjects: mockListProjects,
       importProject: mockImportProject,
       getProject: mockGetProject,
@@ -3049,6 +3073,7 @@ export function resetAppTestHarness() {
   mockDeleteArtifact.mockClear();
   mockDeleteProject.mockClear();
   mockGetHealth.mockClear();
+  mockGetExportCapabilities.mockClear();
   mockGetMobileCapabilities.mockReset();
   mockGetMobileCapabilities.mockResolvedValue(null);
   mockEnsureWebMediaTransport.mockReset();

--- a/apps/desktop/src/test/projectTestActions.ts
+++ b/apps/desktop/src/test/projectTestActions.ts
@@ -13,7 +13,7 @@ export async function ensureInspectorVisible(user: UserEvent) {
   }
 }
 
-export async function openProjectPanel(user: UserEvent, name: "Studio" | "Analysis") {
+export async function openProjectPanel(user: UserEvent, name: "Studio" | "Analysis" | "Export") {
   const tab = screen.getByRole("tab", { name });
   if (tab.getAttribute("aria-selected") !== "true") {
     await user.click(tab);
@@ -26,6 +26,10 @@ export async function openStudioPanel(user: UserEvent) {
 
 export async function openAnalysisPanel(user: UserEvent) {
   await openProjectPanel(user, "Analysis");
+}
+
+export async function openExportPanel(user: UserEvent) {
+  await openProjectPanel(user, "Export");
 }
 
 export async function generateStems(user: UserEvent) {

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -120,7 +120,10 @@ Capo-relative display is a harmonic presentation feature. It should not alter au
 - Retune audio by reference frequency or cents offset.
 - Transpose audio by semitones.
 - Generate cached previews for practice before export.
-- Export selected artifacts or transformed outputs to supported local formats.
+- Use the dedicated project Export workspace to target one Source Track or Practice Mix at a time.
+- Export the track, selected stems, all stems, or the track with all stems. Desktop multi-file exports
+  can target a folder or ZIP; Android exposes only capabilities the installed build can complete.
+- Preserve deterministic, friendly output names based on the project, audio set, and stem label.
 - Desktop transform/export paths use host-installed FFmpeg.
 
 ### Playback and Practice UX

--- a/scripts/capture-release-media.mjs
+++ b/scripts/capture-release-media.mjs
@@ -60,6 +60,21 @@ const releaseMediaCaptureCatalog = [
     capture: captureScreenshotEntry,
   },
   {
+    id: "export-workspace",
+    enabled: true,
+    kind: "screenshot",
+    fileName: "export-workspace.png",
+    title: "Selective export workspace",
+    caption: "Package one practice mix and a custom set of stems as local files.",
+    alt: "TuneForge Export workspace with Practice Mix 1 and four M4A files selected",
+    fixture: "release-showcase-v1",
+    viewport: { width: 1440, height: 1024 },
+    route: "/projects/proj_release_showcase",
+    prepare: prepareExportWorkspace,
+    ready: readyExportWorkspace,
+    capture: captureScreenshotEntry,
+  },
+  {
     id: "tuner",
     enabled: true,
     kind: "screenshot",
@@ -128,6 +143,7 @@ const releaseMediaCaptureCatalog = [
     recordingItemIds: [
       "library",
       "playback",
+      "export-workspace",
       "tuner",
       "chord-dictionary",
       "jobs",
@@ -1340,6 +1356,16 @@ async function prepareMobilePlayback({ page, timeoutMs }) {
   }
 }
 
+async function prepareExportWorkspace({ page, timeoutMs }) {
+  await page.getByRole("tab", { name: "Project" }).click();
+  await page.getByRole("tab", { name: "Export" }).click();
+  await page.getByRole("radio", { name: /Practice Mix 1/i }).click();
+  await page.getByRole("button", { name: "Track + all stems" }).click();
+  const guitar = page.getByRole("checkbox", { name: /Guitar/i });
+  await guitar.waitFor({ timeout: timeoutMs });
+  await guitar.uncheck();
+}
+
 async function prepareTuner({ page, timeoutMs }) {
   const startButton = page.getByRole("button", { name: "Start" });
   await startButton.waitFor({ timeout: timeoutMs });
@@ -1371,6 +1397,15 @@ async function readyPlayback({ captureKind, page, timeoutMs }) {
   } else {
     await page.getByRole("button", { name: "Pause playback" }).waitFor({ timeout: timeoutMs });
   }
+}
+
+async function readyExportWorkspace({ page, timeoutMs }) {
+  await page.getByRole("heading", { name: "Export audio" }).waitFor({ timeout: timeoutMs });
+  await page.getByText("Custom selection", { exact: true }).waitFor({ timeout: timeoutMs });
+  await page.getByText("4 selected", { exact: true }).waitFor({ timeout: timeoutMs });
+  await page.getByRole("button", { name: "Folder" }).waitFor({ timeout: timeoutMs });
+  await page.getByText("Midnight Count-In - Practice Mix 1 - Vocals.m4a", { exact: true })
+    .waitFor({ timeout: timeoutMs });
 }
 
 async function readyMobilePlayback({ page, timeoutMs }) {
@@ -1705,6 +1740,26 @@ function mockApiResponse(method, url) {
   if (method === "GET" && path === "/api/v1/jobs") {
     return { body: jobsResponse(url.searchParams) };
   }
+  if (method === "GET" && path === "/api/v1/export-capabilities") {
+    return {
+      body: {
+        capabilities: {
+          platform: "desktop",
+          formats: ["wav", "flac", "mp3", "m4a"].map((id) => ({
+            id,
+            available: true,
+            reason: null,
+          })),
+          destinations: ["single_file", "folder", "zip"].map((id) => ({
+            id,
+            available: true,
+            reason: null,
+          })),
+          max_artifact_count: null,
+        },
+      },
+    };
+  }
   if (method === "GET" && path === "/api/v1/sync/preflight") {
     return { body: syncPreflight() };
   }
@@ -1946,6 +2001,20 @@ function artifacts(projectId) {
       },
       created_at: fixtureTimestamp,
     },
+    ...[
+      ["art_vocals", "vocal_stem"],
+      ["art_drums", "drums_stem"],
+      ["art_bass", "bass_stem"],
+      ["art_guitar", "guitar_stem"],
+    ].map(([id, type]) => ({
+      id,
+      project_id: projectId,
+      type,
+      format: "wav",
+      path: `/tmp/tuneforge-release-media/${id}.wav`,
+      metadata: { source_artifact_id: "art_preview" },
+      created_at: fixtureTimestamp,
+    })),
     {
       id: "art_source",
       project_id: projectId,

--- a/scripts/capture-release-media.test.mjs
+++ b/scripts/capture-release-media.test.mjs
@@ -32,8 +32,8 @@ test("capture motion policy freezes screenshots and preserves video movement", (
 
 test("release-media catalog has unique identifiers, files, and required callbacks", () => {
   assert.equal(validateReleaseMediaCatalog(releaseMediaCaptureCatalog), releaseMediaCaptureCatalog);
-  assert.equal(releaseMediaCaptureCatalog.length, 8);
-  assert.equal(releaseMediaCaptureCatalog.filter((entry) => entry.kind === "screenshot").length, 7);
+  assert.equal(releaseMediaCaptureCatalog.length, 9);
+  assert.equal(releaseMediaCaptureCatalog.filter((entry) => entry.kind === "screenshot").length, 8);
   assert.equal(releaseMediaCaptureCatalog.filter((entry) => entry.kind === "video").length, 1);
 
   const ids = releaseMediaCaptureCatalog.map((entry) => entry.id);


### PR DESCRIPTION
## Summary

- Add a dedicated Export project tab with audio-set selection, presets, package settings, and job status.
- Provide responsive desktop and narrow layouts with capability-gated controls and accessible disabled reasons.
- Remove the Analysis export card and add deterministic release-media coverage for the new workspace.
- Closes #397.
- Closes #388.

## Testing

- `cd apps/desktop && ./node_modules/.bin/vitest run` — 738 passed.
- `cd apps/desktop && ./node_modules/.bin/eslint .` — passed.
- `cd apps/desktop && ./node_modules/.bin/tsc --noEmit` — passed.
- Rendered visual validation was not run because the user owns the desktop app lifecycle.
