### PR TITLE
feat: persist project export workspace state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ download, installation, verification, signature, and publication instructions.
 
 - A dedicated project Export workspace for selecting one source track or practice mix and packaging
   its track and stems as a file, folder, or ZIP.
+- Saved per-project Export choices that safely reconcile with available audio and device capabilities.
 
 ## [1.0.1] - 2026-08-13
 

--- a/apps/desktop/src/App.project-export.test.tsx
+++ b/apps/desktop/src/App.project-export.test.tsx
@@ -1,13 +1,18 @@
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it } from "vitest";
+import type { ExportCapabilitiesResponse, HealthResponse } from "./lib/api";
 import {
   mockCreateExport,
+  mockDeleteProject,
   mockGetExportCapabilities,
+  mockGetHealth,
   mockGetMobileCapabilities,
   mockOpen,
+  mockSave,
   resetAppTestHarness,
   renderApp,
+  setProjects,
   setProjectArtifacts,
   setJobs,
 } from "./test/appTestHarness";
@@ -38,6 +43,20 @@ function installExportArtifacts() {
   ]);
 }
 
+function health(defaultExportFormat: string): HealthResponse {
+  return {
+    name: "TuneForge",
+    version: "backend-test-ref",
+    backend_version: { package_version: "1.0.1", git_ref: "backend-test-ref" },
+    frontend_version: { package_version: "1.0.1", git_ref: "frontend-test-ref" },
+    status: "ok",
+    api_base_url: "http://127.0.0.1:8765/api/v1",
+    data_root: "/tmp/tuneforge",
+    default_export_format: defaultExportFormat,
+    preview_format: "wav",
+  };
+}
+
 describe("project export workspace", () => {
   beforeEach(resetAppTestHarness);
 
@@ -52,6 +71,7 @@ describe("project export workspace", () => {
     await openExportPanel(user);
     expect(screen.getByRole("tabpanel", { name: "Export" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Export audio" })).toBeInTheDocument();
+    expect(screen.getByLabelText("File format")).toHaveValue("wav");
   });
 
   it("keeps the empty Export view connected to its tabpanel", async () => {
@@ -102,7 +122,7 @@ describe("project export workspace", () => {
     const preview = screen.getByText("File preview").closest("div")?.parentElement;
     expect(preview).not.toBeNull();
     expect(within(preview as HTMLElement).getAllByRole("listitem")).toHaveLength(4);
-    expect(within(preview as HTMLElement).getByText("Demo Song - Practice Mix 1 - Vocals.m4a")).toBeInTheDocument();
+    expect(within(preview as HTMLElement).getByText("Demo Song - Practice Mix 1 - Vocals.wav")).toBeInTheDocument();
   });
 
   it("retains a compatible folder target for manual many-to-many selection changes", async () => {
@@ -121,6 +141,359 @@ describe("project export workspace", () => {
 
     expect(screen.getByText("/tmp/exports")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Folder" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("restores a saved export draft after returning to the project", async () => {
+    const user = userEvent.setup();
+    installExportArtifacts();
+    localStorage.setItem("tuneforge.project-playback-state", JSON.stringify({
+      proj_123: {
+        exportWorkspace: {
+          audioSetId: "art_mix",
+          selectedArtifactIds: ["art_mix", "art_vocals"],
+          outputFormat: "flac",
+          filenameBase: "Session take",
+          destinationType: "folder",
+          desktopDestinationTarget: "/tmp/exports",
+        },
+      },
+    }));
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openExportPanel(user);
+
+    expect(screen.getByRole("radio", { name: /Practice Mix 1/i })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: /Vocals/i })).toBeChecked();
+    expect(screen.getByLabelText("File format")).toHaveValue("flac");
+    expect(screen.getByLabelText("File name base")).toHaveValue("Session take");
+    expect(screen.getByText("/tmp/exports")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Folder" })).toHaveAttribute("aria-pressed", "true");
+    await user.click(screen.getByRole("button", { name: "Export 2 files" }));
+    expect(mockCreateExport).toHaveBeenCalledWith("proj_123", expect.objectContaining({
+      destination: { type: "folder", target: "/tmp/exports", overwrite: false },
+    }));
+  });
+
+  it("keeps stored private choices out of the pending and recovered workspace", async () => {
+    const user = userEvent.setup();
+    installExportArtifacts();
+    let resolveCapabilities!: (value: ExportCapabilitiesResponse) => void;
+    mockGetExportCapabilities.mockImplementationOnce(() => new Promise<ExportCapabilitiesResponse>((resolve) => {
+      resolveCapabilities = resolve;
+    }));
+    localStorage.setItem("tuneforge.project-playback-state", JSON.stringify({
+      proj_123: {
+        exportWorkspace: {
+          audioSetId: "stale-audio-set",
+          selectedArtifactIds: ["stale-audio-set"],
+          outputFormat: "flac",
+          filenameBase: "A private take",
+          destinationType: "folder",
+          desktopDestinationTarget: "/private/a-only",
+        },
+      },
+    }));
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openExportPanel(user);
+
+    expect(screen.queryByText("A private take")).not.toBeInTheDocument();
+    expect(screen.queryByText("/private/a-only")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Export 1 file" })).toBeDisabled();
+
+    resolveCapabilities({
+      capabilities: {
+        platform: "desktop",
+        formats: ["wav", "flac", "mp3", "m4a"].map((id) => ({ id, available: true, reason: null })),
+        destinations: ["single_file", "folder", "zip"].map((id) => ({ id, available: true, reason: null })),
+        max_artifact_count: null,
+      },
+    });
+    await waitFor(() => expect(screen.getByRole("button", { name: "Export 1 file" })).toBeEnabled());
+    expect(screen.queryByText("A private take")).not.toBeInTheDocument();
+    expect(screen.queryByText("/private/a-only")).not.toBeInTheDocument();
+  });
+
+  it("does not carry cached export choices into another project", async () => {
+    const user = userEvent.setup();
+    installExportArtifacts();
+    setProjects([
+      {
+        id: "proj_123", display_name: "Demo Song", source_key_override: null,
+        source_path: "/tmp/demo.wav", imported_path: "/tmp/demo.wav", duration_seconds: 182,
+        sample_rate: 44100, channels: 2, created_at: createdAt, updated_at: createdAt,
+      },
+      {
+        id: "proj_456", display_name: "Other Song", source_key_override: null,
+        source_path: "/tmp/other.wav", imported_path: "/tmp/other.wav", duration_seconds: 182,
+        sample_rate: 44100, channels: 2, created_at: createdAt, updated_at: createdAt,
+      },
+    ]);
+    setProjectArtifacts("proj_456", [{
+      ...artifact("other_source", "source_audio"), project_id: "proj_456",
+    }]);
+    localStorage.setItem("tuneforge.project-playback-state", JSON.stringify({
+      proj_123: {
+        exportWorkspace: {
+          audioSetId: "art_source", selectedArtifactIds: ["art_source"], outputFormat: "m4a",
+          filenameBase: "A private take", destinationType: "single_file",
+          desktopDestinationTarget: "/private/a-only.m4a",
+        },
+      },
+    }));
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openExportPanel(user);
+    expect(screen.getByText("/private/a-only.m4a")).toBeInTheDocument();
+
+    await user.click(screen.getAllByRole("link", { name: "Library" })[0]!);
+    await screen.findByRole("heading", { name: "Practice Projects" });
+    await user.click(screen.getByRole("link", { name: "Open Other Song project" }));
+    await screen.findByRole("heading", { name: "Other Song" });
+    await openExportPanel(user);
+
+    expect(screen.queryByText("A private take")).not.toBeInTheDocument();
+    expect(screen.queryByText("/private/a-only.m4a")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("File name base")).toHaveValue("Other Song");
+  });
+
+  it("clears an export recovery notice when navigating to another project", async () => {
+    const user = userEvent.setup();
+    installExportArtifacts();
+    setProjects([
+      {
+        id: "proj_123", display_name: "Demo Song", source_key_override: null,
+        source_path: "/tmp/demo.wav", imported_path: "/tmp/demo.wav", duration_seconds: 182,
+        sample_rate: 44100, channels: 2, created_at: createdAt, updated_at: createdAt,
+      },
+      {
+        id: "proj_456", display_name: "Other Song", source_key_override: null,
+        source_path: "/tmp/other.wav", imported_path: "/tmp/other.wav", duration_seconds: 182,
+        sample_rate: 44100, channels: 2, created_at: createdAt, updated_at: createdAt,
+      },
+    ]);
+    setProjectArtifacts("proj_456", [{ ...artifact("other_source", "source_audio"), project_id: "proj_456" }]);
+    localStorage.setItem("tuneforge.project-playback-state", JSON.stringify({
+      proj_123: {
+        exportWorkspace: {
+          audioSetId: "gone", selectedArtifactIds: ["gone"], outputFormat: "m4a",
+          filenameBase: "A stale take", destinationType: "single_file",
+          desktopDestinationTarget: "/private/a-stale.m4a",
+        },
+      },
+    }));
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openExportPanel(user);
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Saved Export choices were adjusted because this project or device changed.",
+    );
+
+    await user.click(screen.getAllByRole("link", { name: "Library" })[0]!);
+    await screen.findByRole("heading", { name: "Practice Projects" });
+    await user.click(screen.getByRole("link", { name: "Open Other Song project" }));
+    await screen.findByRole("heading", { name: "Other Song" });
+
+    expect(screen.queryByText("Saved Export choices were adjusted because this project or device changed.")).not.toBeInTheDocument();
+  });
+
+  it("removes only the deleted project's stored export workspace", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem("tuneforge.project-playback-state", JSON.stringify({
+      proj_123: { exportWorkspace: { audioSetId: "art_source", selectedArtifactIds: ["art_source"], outputFormat: "m4a", filenameBase: "Delete me", destinationType: "single_file", desktopDestinationTarget: "/tmp/delete.m4a" } },
+      proj_456: { exportWorkspace: { audioSetId: "other_source", selectedArtifactIds: ["other_source"], outputFormat: "m4a", filenameBase: "Keep me", destinationType: "single_file", desktopDestinationTarget: "/tmp/keep.m4a" } },
+    }));
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openAnalysisPanel(user);
+    await user.click(screen.getByRole("button", { name: "Delete Project" }));
+    await waitFor(() => expect(mockDeleteProject).toHaveBeenCalledWith("proj_123"));
+
+    const stored = JSON.parse(localStorage.getItem("tuneforge.project-playback-state") ?? "{}");
+    expect(stored.proj_123).toBeUndefined();
+    expect(stored.proj_456.exportWorkspace.filenameBase).toBe("Keep me");
+  });
+
+  it("offers a retry after export capabilities fail", async () => {
+    const user = userEvent.setup();
+    installExportArtifacts();
+    mockGetExportCapabilities.mockRejectedValueOnce(new Error("offline"));
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openExportPanel(user);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Export options couldn’t load. Retry to continue.");
+    expect(screen.getByRole("button", { name: "Export 1 file" })).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
+    expect(screen.getByRole("button", { name: "Export 1 file" })).toBeEnabled();
+  });
+
+  it("does not persist an uninitialized format while health is pending", async () => {
+    const user = userEvent.setup();
+    installExportArtifacts();
+    let resolveHealth!: (value: HealthResponse) => void;
+    mockGetHealth.mockImplementationOnce(() => new Promise<HealthResponse>((resolve) => {
+      resolveHealth = resolve;
+    }));
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openExportPanel(user);
+
+    expect(screen.getByRole("button", { name: "Export 1 file" })).toBeDisabled();
+    await waitFor(() => {
+      const stored = JSON.parse(localStorage.getItem("tuneforge.project-playback-state") ?? "{}");
+      expect(stored.proj_123?.exportWorkspace ?? null).toBeNull();
+    });
+
+    resolveHealth(health("wav"));
+    await waitFor(() => expect(screen.getByLabelText("File format")).toHaveValue("wav"));
+  });
+
+  it("restores an available saved format before health settles but waits to reset", async () => {
+    const user = userEvent.setup();
+    installExportArtifacts();
+    let resolveHealth!: (value: HealthResponse) => void;
+    mockGetHealth.mockImplementationOnce(() => new Promise<HealthResponse>((resolve) => {
+      resolveHealth = resolve;
+    }));
+    localStorage.setItem("tuneforge.project-playback-state", JSON.stringify({
+      proj_123: {
+        exportWorkspace: {
+          audioSetId: "art_source",
+          selectedArtifactIds: ["art_source"],
+          outputFormat: "flac",
+          filenameBase: "Saved take",
+          destinationType: "single_file",
+          desktopDestinationTarget: null,
+        },
+      },
+    }));
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openExportPanel(user);
+
+    await waitFor(() => expect(screen.getByLabelText("File format")).toHaveValue("flac"));
+    expect(screen.getByRole("button", { name: "Export 1 file" })).toBeEnabled();
+    const reset = screen.getByRole("button", { name: "Reset export workspace" });
+    expect(reset).toBeDisabled();
+    expect(screen.getByText("Export options are still loading.")).toBeVisible();
+    expect(JSON.parse(
+      localStorage.getItem("tuneforge.project-playback-state") ?? "{}",
+    ).proj_123.exportWorkspace.outputFormat).toBe("flac");
+
+    resolveHealth(health("wav"));
+    await waitFor(() => expect(reset).toBeEnabled());
+    expect(screen.getByLabelText("File format")).toHaveValue("flac");
+    await user.click(reset);
+    expect(screen.getByLabelText("File format")).toHaveValue("wav");
+  });
+
+  it("uses capability fallback and permits export when health fails", async () => {
+    const user = userEvent.setup();
+    installExportArtifacts();
+    mockGetHealth.mockRejectedValueOnce(new Error("health unavailable"));
+    mockSave.mockResolvedValueOnce("/tmp/demo-song.wav");
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openExportPanel(user);
+
+    expect(screen.getByLabelText("File format")).toHaveValue("wav");
+    const exportButton = screen.getByRole("button", { name: "Export 1 file" });
+    await waitFor(() => expect(exportButton).toBeEnabled());
+    await user.click(exportButton);
+    expect(mockCreateExport).toHaveBeenCalledWith("proj_123", expect.objectContaining({
+      output_format: "wav",
+    }));
+  });
+
+  it("resets only the export workspace and keeps focus on the reset action", async () => {
+    const user = userEvent.setup();
+    installExportArtifacts();
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openExportPanel(user);
+    await user.click(screen.getByRole("radio", { name: /Practice Mix 1/i }));
+    await user.click(screen.getByRole("button", { name: "Track + all stems" }));
+    await user.selectOptions(screen.getByLabelText("File format"), "flac");
+
+    const reset = screen.getByRole("button", { name: "Reset export workspace" });
+    await user.click(reset);
+
+    expect(reset).toHaveFocus();
+    expect(screen.getByRole("radio", { name: /Source Track/i })).toBeChecked();
+    expect(screen.getByText("1 selected")).toBeInTheDocument();
+    expect(screen.getByLabelText("File format")).toHaveValue("wav");
+    expect(screen.getByRole("button", { name: "File" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("keeps an export draft when leaving and returning to its tab", async () => {
+    const user = userEvent.setup();
+    installExportArtifacts();
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openExportPanel(user);
+    await user.click(screen.getByRole("radio", { name: /Practice Mix 1/i }));
+    await user.selectOptions(screen.getByLabelText("File format"), "flac");
+    await user.clear(screen.getByLabelText("File name base"));
+    await user.type(screen.getByLabelText("File name base"), "Return take");
+
+    await openAnalysisPanel(user);
+    await openExportPanel(user);
+
+    expect(screen.getByRole("radio", { name: /Practice Mix 1/i })).toBeChecked();
+    expect(screen.getByLabelText("File format")).toHaveValue("flac");
+    expect(screen.getByLabelText("File name base")).toHaveValue("Return take");
+  });
+
+  it("announces one private recovery notice without exposing the saved target", async () => {
+    const user = userEvent.setup();
+    installExportArtifacts();
+    localStorage.setItem("tuneforge.project-playback-state", JSON.stringify({
+      proj_123: {
+        exportWorkspace: {
+          audioSetId: "gone",
+          selectedArtifactIds: ["gone"],
+          outputFormat: "wav",
+          filenameBase: "Session",
+          destinationType: "zip",
+          desktopDestinationTarget: "/private/secret.wav",
+        },
+      },
+    }));
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openExportPanel(user);
+
+    const notice = await screen.findByRole("status");
+    expect(notice).toHaveTextContent("Saved Export choices were adjusted because this project or device changed.");
+    expect(notice).not.toHaveTextContent("/private/secret.wav");
+  });
+
+  it("clears a corrupt legacy format target and announces its recovery", async () => {
+    const user = userEvent.setup();
+    installExportArtifacts();
+    localStorage.setItem("tuneforge.project-playback-state", JSON.stringify({
+      proj_123: {
+        exportWorkspace: {
+          audioSetId: "art_source",
+          selectedArtifactIds: ["art_source"],
+          outputFormat: "aac",
+          filenameBase: "Legacy",
+          destinationType: "legacy-folder",
+          desktopDestinationTarget: "/private/legacy-export",
+        },
+      },
+    }));
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openExportPanel(user);
+
+    expect(screen.getByLabelText("File format")).toHaveValue("wav");
+    expect(screen.queryByText("/private/legacy-export")).not.toBeInTheDocument();
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Saved Export choices were adjusted because this project or device changed.",
+    );
   });
 
   it("keeps the narrow package in flow while its compact summary owns the export action", async () => {
@@ -179,7 +552,7 @@ describe("project export workspace", () => {
 
     expect(mockCreateExport).toHaveBeenCalledWith("proj_123", {
       artifact_ids: ["art_mix", "art_vocals", "art_drums", "art_bass", "art_guitar"],
-      output_format: "m4a",
+      output_format: "wav",
       filename_base: "Demo Song",
       destination: { type: "folder", target: "/tmp/exports", overwrite: false },
     });
@@ -216,11 +589,14 @@ describe("project export workspace", () => {
       ] } }]);
     await refreshJobs(queryClient);
     await waitFor(() => expect(screen.getByText("Demo Song - Source.m4a")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: "Reset export workspace" })).toBeDisabled();
+    expect(screen.getByText("Export options can’t be reset while an export is in progress.")).toBeVisible();
   });
 
   it("shows truthful Android limits and disabled export controls", async () => {
     const user = userEvent.setup();
     installExportArtifacts();
+    mockGetHealth.mockResolvedValueOnce(health("m4a"));
     mockGetMobileCapabilities.mockResolvedValue({ platform: "android" });
     mockGetExportCapabilities.mockResolvedValue({
       capabilities: {
@@ -254,6 +630,7 @@ describe("project export workspace", () => {
     expect(screen.getByText(/All stems and track plus stems require multiple files/)).toBeVisible();
     expect(screen.getAllByText("Android audio export is not available in this build.").length).toBeGreaterThan(0);
     expect(within(screen.getByRole("group", { name: "Audio selection" })).getAllByRole("radio")).toHaveLength(5);
+    expect(screen.getByLabelText("File format")).toHaveValue("m4a");
     expect(screen.getByLabelText("File format")).toHaveAttribute(
       "aria-describedby",
       "android-export-format-notice",

--- a/apps/desktop/src/App.project-playback-artifacts.test.tsx
+++ b/apps/desktop/src/App.project-playback-artifacts.test.tsx
@@ -633,7 +633,7 @@ describe("Desktop app project playback artifacts", () => {
 
   it("exports selected audio", async () => {
     const user = userEvent.setup();
-    mockSave.mockResolvedValue("/tmp/exports/Demo Song - Source.m4a");
+    mockSave.mockResolvedValue("/tmp/exports/Demo Song - Source.wav");
 
     renderApp(["/projects/proj_123"]);
 
@@ -641,19 +641,19 @@ describe("Desktop app project playback artifacts", () => {
 
     expect(mockSave).toHaveBeenCalledWith(
       expect.objectContaining({
-        defaultPath: "Demo Song - Source.m4a",
-        filters: [{ name: "M4A", extensions: ["m4a"] }],
+        defaultPath: "Demo Song - Source.wav",
+        filters: [{ name: "WAV", extensions: ["wav"] }],
       }),
     );
     expect(mockCreateExport).toHaveBeenCalledWith(
       "proj_123",
       expect.objectContaining({
         artifact_ids: ["art_source"],
-        output_format: "m4a",
+        output_format: "wav",
         filename_base: "Demo Song",
         destination: {
           type: "single_file",
-          target: "/tmp/exports/Demo Song - Source.m4a",
+          target: "/tmp/exports/Demo Song - Source.wav",
           overwrite: false,
         },
       }),
@@ -715,7 +715,7 @@ describe("Desktop app project playback artifacts", () => {
       "proj_123",
       expect.objectContaining({
         artifact_ids: ["art_source"],
-        output_format: "m4a",
+        output_format: "wav",
         destination: {
           type: "single_file",
           target: "/tmp/exports/Demo Song - Source.m4a",
@@ -728,7 +728,7 @@ describe("Desktop app project playback artifacts", () => {
       "proj_123",
       expect.objectContaining({
         artifact_ids: ["art_source"],
-        output_format: "m4a",
+        output_format: "wav",
         destination: {
           type: "single_file",
           target: "/tmp/exports/Demo Song - Source.m4a",

--- a/apps/desktop/src/features/projects/components/ExportWorkspace.tsx
+++ b/apps/desktop/src/features/projects/components/ExportWorkspace.tsx
@@ -54,10 +54,10 @@ export function ExportWorkspace() {
     audioSetId,
     audioSets,
     activeExportJob,
+    capabilitiesError,
     canExport,
     cancelMutation,
     capabilities,
-    capabilitiesQuery,
     chooseDestination,
     destinationTarget,
     destinationType,
@@ -71,7 +71,10 @@ export function ExportWorkspace() {
     partialExportJob,
     preset,
     retryFailed,
+    retryCapabilities,
     retryUnavailableReason,
+    resetUnavailableReason,
+    resetWorkspace,
     selectedDestinationCapability,
     selectedFormatCapability,
     selectedIds,
@@ -79,16 +82,16 @@ export function ExportWorkspace() {
     selectionAllowed,
     selectPreset,
     setAudioSetId,
-    setDestinationTarget,
     setDestinationType,
     setFilenameBase,
     setOutputFormat,
     toggleArtifact,
+    workspaceReady,
   } = workspace;
   const { projectQuery } = useProjectViewModelContext();
   const projectDuration = projectQuery.data?.duration_seconds;
   const selectionInputType = isMobileRuntime ? "radio" : "checkbox";
-  const controlsDisabled = Boolean(activeExportJob);
+  const controlsDisabled = Boolean(activeExportJob) || !workspaceReady;
   const destinationLabel = DESTINATIONS.find((destination) => destination.id === destinationType)?.label
     ?? "Destination";
 
@@ -99,7 +102,13 @@ export function ExportWorkspace() {
         className="panel export-workspace-empty"
         id="project-export-panel"
         role="tabpanel"
-      >No audio is available to export yet.</div>
+      >
+        {capabilitiesError ? (
+          <div className="notice notice--error" role="alert">
+            {capabilitiesError} <button className="button-link" onClick={retryCapabilities} type="button">Retry</button>
+          </div>
+        ) : "No audio is available to export yet."}
+      </div>
     );
   }
 
@@ -111,10 +120,26 @@ export function ExportWorkspace() {
           <h2 id="export-workspace-title">Export audio</h2>
           <p>Choose one audio set, select its tracks, then package local files.</p>
         </div>
-        <span className="export-workspace__selection-count" aria-live="polite">
-          {selectedIds.size} selected
-        </span>
+        <div className="export-workspace__header-actions">
+          <span className="export-workspace__selection-count" aria-live="polite">
+            {selectedIds.size} selected
+          </span>
+          <button
+            aria-describedby={resetUnavailableReason ? "export-reset-reason" : undefined}
+            className="button button--ghost button--small"
+            disabled={Boolean(resetUnavailableReason)}
+            onClick={resetWorkspace}
+            type="button"
+          >Reset export workspace</button>
+          {resetUnavailableReason ? <span className="field-reason" id="export-reset-reason">{resetUnavailableReason}</span> : null}
+        </div>
       </header>
+
+      {capabilitiesError ? (
+        <div className="notice notice--error" role="alert">
+          {capabilitiesError} <button className="button-link" onClick={retryCapabilities} type="button">Retry</button>
+        </div>
+      ) : null}
 
       {isMobileRuntime ? (
         <div className="notice notice--info" id="android-export-format-notice" role="status">
@@ -256,11 +281,8 @@ export function ExportWorkspace() {
                 <span>File format</span>
                 <select
                   aria-describedby={isMobileRuntime ? "android-export-format-notice" : undefined}
-                  disabled={capabilitiesQuery.isLoading}
-                  onChange={(event) => {
-                    setOutputFormat(event.target.value as typeof outputFormat);
-                    setDestinationTarget(null);
-                  }}
+                  disabled={!workspaceReady}
+                  onChange={(event) => setOutputFormat(event.target.value as typeof outputFormat)}
                   value={outputFormat}
                 >
                   {FORMATS.map((format) => {
@@ -288,7 +310,7 @@ export function ExportWorkspace() {
                         aria-pressed={destinationType === id}
                         className="button button--small"
                         disabled={unavailable}
-                        onClick={() => { setDestinationType(id); setDestinationTarget(null); }}
+                        onClick={() => setDestinationType(id)}
                         type="button"
                       ><Icon aria-hidden="true" /> {label}</button>
                       {unavailable ? (
@@ -305,7 +327,7 @@ export function ExportWorkspace() {
                 })}
               </fieldset>
               {selectedDestinationCapability?.available === false ? <p className="field-reason">{selectedDestinationCapability.reason}</p> : null}
-              <button className="button button--ghost export-destination-picker" disabled={!selectedIds.size} onClick={() => void chooseDestination()} type="button">
+              <button className="button button--ghost export-destination-picker" disabled={!selectedIds.size || !workspaceReady || isMobileRuntime} onClick={() => void chooseDestination()} type="button">
                 {destinationTarget ? "Change destination" : "Choose destination"}
               </button>
               {destinationTarget ? <p className="export-destination-target" title={destinationTarget}>{destinationTarget}</p> : null}

--- a/apps/desktop/src/features/projects/components/ProjectShell.tsx
+++ b/apps/desktop/src/features/projects/components/ProjectShell.tsx
@@ -5,8 +5,16 @@ import { ProjectHeader } from "./ProjectHeader";
 import { ProjectWorkspace } from "./ProjectWorkspace";
 
 export function ProjectShell() {
-  const { activeWorkspace, handleSelectWorkspace, isMobileRuntime } = useProjectViewModelContext();
+  const {
+    activeWorkspace,
+    exportRecoveryNoticeId,
+    exportRecoveryNoticeProjectId,
+    handleSelectWorkspace,
+    isMobileRuntime,
+    projectId,
+  } = useProjectViewModelContext();
   const [practiceControlsOpen, setPracticeControlsOpen] = useState(false);
+  const [showExportRecoveryNotice, setShowExportRecoveryNotice] = useState(false);
   const screenRef = useRef<HTMLElement>(null);
   const mobilePlayback = isMobileRuntime && activeWorkspace === "playback";
   const closePracticeControls = useCallback(() => setPracticeControlsOpen(false), []);
@@ -35,6 +43,16 @@ export function ProjectShell() {
       setPracticeControlsOpen(false);
     }
   }, [mobilePlayback]);
+
+  useEffect(() => {
+    if (!exportRecoveryNoticeId || exportRecoveryNoticeProjectId !== projectId) {
+      setShowExportRecoveryNotice(false);
+      return;
+    }
+    setShowExportRecoveryNotice(true);
+    const timeoutId = window.setTimeout(() => setShowExportRecoveryNotice(false), 4000);
+    return () => window.clearTimeout(timeoutId);
+  }, [exportRecoveryNoticeId, exportRecoveryNoticeProjectId, projectId]);
 
   return (
     <section
@@ -70,6 +88,11 @@ export function ProjectShell() {
           onClosePracticeControls={closePracticeControls}
         />
       )}
+      {showExportRecoveryNotice ? (
+        <div aria-atomic="true" aria-live="polite" className="project-export-recovery-toast" role="status">
+          Saved Export choices were adjusted because this project or device changed.
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/apps/desktop/src/features/projects/exportWorkspaceUtils.test.ts
+++ b/apps/desktop/src/features/projects/exportWorkspaceUtils.test.ts
@@ -2,9 +2,13 @@ import { describe, expect, it } from "vitest";
 import type { ArtifactSchema } from "../../lib/api";
 import {
   buildExportAudioSets,
+  defaultExportWorkspaceState,
+  reconcileExportWorkspaceState,
   exportOutputNames,
   exportPresetForSelection,
 } from "./exportWorkspaceUtils";
+
+const createdAt = "2026-08-13T10:00:00Z";
 
 function artifact(
   id: string,
@@ -24,6 +28,33 @@ function artifact(
     can_regenerate: false,
     metadata: sourceArtifactId ? { source_artifact_id: sourceArtifactId } : {},
     created_at: createdAt,
+  };
+}
+
+function capabilities({
+  platform = "desktop",
+  formats = ["wav", "flac", "mp3", "m4a"],
+  destinations = ["single_file", "folder", "zip"],
+  maxArtifactCount = null,
+}: {
+  platform?: "desktop" | "android";
+  formats?: string[];
+  destinations?: string[];
+  maxArtifactCount?: number | null;
+} = {}) {
+  return {
+    platform,
+    formats: ["wav", "flac", "mp3", "m4a"].map((id) => ({
+      id,
+      available: formats.includes(id),
+      reason: null,
+    })),
+    destinations: ["single_file", "folder", "zip"].map((id) => ({
+      id,
+      available: destinations.includes(id),
+      reason: null,
+    })),
+    max_artifact_count: maxArtifactCount,
   };
 }
 
@@ -65,5 +96,142 @@ describe("export workspace utilities", () => {
       "My take - Source.m4a",
       "My take - Source - Vocals.m4a",
     ]);
+  });
+
+  it("restores valid custom choices, including a desktop destination", () => {
+    const [audioSet] = buildExportAudioSets([
+      artifact("source", "source_audio", createdAt),
+      artifact("vocals", "vocal_stem", createdAt, "source"),
+    ]);
+    expect(audioSet).toBeDefined();
+    if (!audioSet) return;
+
+    expect(reconcileExportWorkspaceState({
+      storedState: {
+        audioSetId: "source",
+        selectedArtifactIds: ["vocals"],
+        outputFormat: "flac",
+        filenameBase: "Session",
+        destinationType: "single_file",
+        desktopDestinationTarget: "/tmp/exports/session.flac",
+      },
+      audioSets: [audioSet],
+      selectedPrimaryArtifactId: "source",
+      filenameBase: "Demo Song",
+      capabilities: capabilities(),
+      defaultOutputFormat: "wav",
+    })).toEqual({
+      recovery: false,
+      state: {
+        audioSetId: "source",
+        selectedArtifactIds: ["vocals"],
+        outputFormat: "flac",
+        filenameBase: "Session",
+        destinationType: "single_file",
+        desktopDestinationTarget: "/tmp/exports/session.flac",
+      },
+    });
+  });
+
+  it("uses the available backend default for fresh state and stable capability fallbacks", () => {
+    const audioSets = buildExportAudioSets([artifact("source", "source_audio", createdAt)]);
+    const createState = (defaultOutputFormat: string | null, formats: string[]) =>
+      defaultExportWorkspaceState({
+        audioSets,
+        selectedPrimaryArtifactId: "source",
+        filenameBase: "Demo Song",
+        capabilities: capabilities({ formats }),
+        defaultOutputFormat,
+      });
+
+    expect(createState("wav", ["wav", "flac"])?.outputFormat).toBe("wav");
+    expect(createState("ogg", ["flac", "m4a"])?.outputFormat).toBe("flac");
+    expect(createState("wav", ["flac", "m4a"])?.outputFormat).toBe("flac");
+    expect(createState("flac", [])?.outputFormat).toBe("flac");
+    expect(createState("ogg", [])?.outputFormat).toBe("m4a");
+  });
+
+  it("recovers a corrupt stored format to the backend default and clears its target", () => {
+    const audioSets = buildExportAudioSets([artifact("source", "source_audio", createdAt)]);
+
+    expect(reconcileExportWorkspaceState({
+      storedState: {
+        audioSetId: "source",
+        selectedArtifactIds: ["source"],
+        outputFormat: null,
+        filenameBase: "Session",
+        destinationType: "single_file",
+        desktopDestinationTarget: "/tmp/exports/session.aac",
+      },
+      audioSets,
+      selectedPrimaryArtifactId: "source",
+      filenameBase: "Demo Song",
+      capabilities: capabilities(),
+      defaultOutputFormat: "wav",
+    })).toMatchObject({
+      recovery: true,
+      state: { outputFormat: "wav", desktopDestinationTarget: null },
+    });
+  });
+
+  it("recovers stale cross-set choices with stable primary-first limits and safe fallbacks", () => {
+    const audioSets = buildExportAudioSets([
+      artifact("source", "source_audio", createdAt),
+      artifact("mix", "preview_mix", "2026-08-13T12:00:00Z"),
+      artifact("vocals", "vocal_stem", createdAt, "mix"),
+      artifact("drums", "drums_stem", createdAt, "mix"),
+    ]);
+    expect(reconcileExportWorkspaceState({
+      storedState: {
+        audioSetId: "gone",
+        selectedArtifactIds: ["drums", "mix", "missing", "source"],
+        outputFormat: "wav",
+        filenameBase: "Session",
+        destinationType: "zip",
+        desktopDestinationTarget: "\\\\server\\share\\take.zip",
+      },
+      audioSets,
+      selectedPrimaryArtifactId: "mix",
+      filenameBase: "Demo Song",
+      capabilities: capabilities({ formats: ["m4a"], maxArtifactCount: 1 }),
+      defaultOutputFormat: "wav",
+    })).toMatchObject({
+      recovery: true,
+      state: {
+        audioSetId: "mix",
+        selectedArtifactIds: ["mix"],
+        outputFormat: "m4a",
+        destinationType: "single_file",
+        desktopDestinationTarget: null,
+      },
+    });
+  });
+
+  it("clears stored targets for Android and invalid local-looking values", () => {
+    const audioSets = buildExportAudioSets([artifact("source", "source_audio", createdAt)]);
+    const draft = {
+      audioSetId: "source",
+      selectedArtifactIds: ["source"],
+      outputFormat: "m4a" as const,
+      filenameBase: "Session",
+      destinationType: "single_file" as const,
+      desktopDestinationTarget: "file:///private/secret.m4a",
+    };
+    expect(reconcileExportWorkspaceState({
+      storedState: draft,
+      audioSets,
+      selectedPrimaryArtifactId: "source",
+      filenameBase: "Demo Song",
+      capabilities: capabilities(),
+      defaultOutputFormat: "wav",
+    }).state?.desktopDestinationTarget).toBeNull();
+    expect(reconcileExportWorkspaceState({
+      storedState: { ...draft, desktopDestinationTarget: "C:\\exports\\session.m4a" },
+      audioSets,
+      selectedPrimaryArtifactId: "source",
+      filenameBase: "Demo Song",
+      capabilities: capabilities({ platform: "android" }),
+      defaultOutputFormat: "m4a",
+    }).state?.desktopDestinationTarget).toBeNull();
   });
 });

--- a/apps/desktop/src/features/projects/exportWorkspaceUtils.ts
+++ b/apps/desktop/src/features/projects/exportWorkspaceUtils.ts
@@ -1,4 +1,5 @@
-import type { ArtifactSchema } from "../../lib/api";
+import type { ArtifactSchema, ExportCapabilities } from "../../lib/api";
+import type { ExportWorkspaceState } from "./projectPlaybackState";
 import { artifactLabel, isStemArtifact } from "./projectViewUtils";
 
 export type ExportAudioSet = {
@@ -8,6 +9,167 @@ export type ExportAudioSet = {
 };
 
 export type ExportPreset = "track" | "stems" | "track-and-stems" | "custom";
+export type ExportFormat = NonNullable<ExportWorkspaceState["outputFormat"]>;
+export type ExportDestinationType = ExportWorkspaceState["destinationType"];
+
+const EXPORT_FORMATS: ExportFormat[] = ["wav", "flac", "mp3", "m4a"];
+
+function knownExportFormat(value: string | null | undefined): ExportFormat | null {
+  return EXPORT_FORMATS.find((format) => format === value) ?? null;
+}
+
+function preferredOutputFormat(
+  defaultOutputFormat: string | null | undefined,
+  availableFormats: Set<string>,
+) {
+  const knownDefault = knownExportFormat(defaultOutputFormat);
+  if (knownDefault && availableFormats.has(knownDefault)) return knownDefault;
+  return EXPORT_FORMATS.find((format) => availableFormats.has(format)) ?? knownDefault ?? "m4a";
+}
+
+function stateEquals(left: ExportWorkspaceState, right: ExportWorkspaceState) {
+  return left.audioSetId === right.audioSetId &&
+    left.outputFormat === right.outputFormat &&
+    left.filenameBase === right.filenameBase &&
+    left.destinationType === right.destinationType &&
+    left.desktopDestinationTarget === right.desktopDestinationTarget &&
+    left.selectedArtifactIds.length === right.selectedArtifactIds.length &&
+    left.selectedArtifactIds.every((id, index) => id === right.selectedArtifactIds[index]);
+}
+
+export function isDesktopDestinationTarget(value: string | null) {
+  if (!value) return false;
+  const target = value.trim();
+  return Boolean(target) &&
+    !target.includes("\0") &&
+    !/^(?:file|content):/i.test(target) &&
+    (/^\//.test(target) || /^[a-z]:[\\/]/i.test(target) || /^\\\\[^\\]+\\[^\\]+/.test(target));
+}
+
+function audioSetForArtifactId(audioSets: ExportAudioSet[], artifactId: string) {
+  return audioSets.find((audioSet) =>
+    audioSet.artifact.id === artifactId || audioSet.stems.some((stem) => stem.id === artifactId),
+  ) ?? null;
+}
+
+function availableOptionIds(
+  capabilities: ExportCapabilities,
+  kind: "formats" | "destinations",
+) {
+  return new Set(capabilities[kind].filter((option) => option.available).map((option) => option.id));
+}
+
+export function defaultExportWorkspaceState({
+  audioSets,
+  selectedPrimaryArtifactId,
+  filenameBase,
+  capabilities,
+  defaultOutputFormat,
+}: {
+  audioSets: ExportAudioSet[];
+  selectedPrimaryArtifactId: string | null;
+  filenameBase: string;
+  capabilities: ExportCapabilities;
+  defaultOutputFormat: string | null | undefined;
+}): ExportWorkspaceState | null {
+  const audioSet = audioSets.find((set) => set.artifact.id === selectedPrimaryArtifactId) ?? audioSets[0];
+  if (!audioSet) return null;
+  const availableFormats = availableOptionIds(capabilities, "formats");
+  const outputFormat = preferredOutputFormat(defaultOutputFormat, availableFormats);
+  return {
+    audioSetId: audioSet.artifact.id,
+    selectedArtifactIds: [audioSet.artifact.id],
+    outputFormat,
+    filenameBase,
+    destinationType: "single_file",
+    desktopDestinationTarget: null,
+  };
+}
+
+export function reconcileExportWorkspaceState({
+  storedState,
+  audioSets,
+  selectedPrimaryArtifactId,
+  filenameBase,
+  capabilities,
+  defaultOutputFormat,
+}: {
+  storedState: ExportWorkspaceState | null;
+  audioSets: ExportAudioSet[];
+  selectedPrimaryArtifactId: string | null;
+  filenameBase: string;
+  capabilities: ExportCapabilities;
+  defaultOutputFormat: string | null | undefined;
+}): { state: ExportWorkspaceState | null; recovery: boolean } {
+  if (!audioSets.length) return { state: null, recovery: storedState !== null };
+  if (!storedState) {
+    return {
+      state: defaultExportWorkspaceState({
+        audioSets,
+        selectedPrimaryArtifactId,
+        filenameBase,
+        capabilities,
+        defaultOutputFormat,
+      }),
+      recovery: false,
+    };
+  }
+
+  const savedSet = audioSets.find((set) => set.artifact.id === storedState.audioSetId) ?? null;
+  const survivingSets = Array.from(new Set(
+    storedState.selectedArtifactIds
+      .map((id) => audioSetForArtifactId(audioSets, id))
+      .filter((audioSet): audioSet is ExportAudioSet => audioSet !== null),
+  ));
+  const audioSet = savedSet ??
+    (survivingSets.length === 1 ? survivingSets[0] : null) ??
+    audioSets.find((set) => set.artifact.id === selectedPrimaryArtifactId) ??
+    audioSets[0];
+  const artifactOrder = [audioSet.artifact, ...audioSet.stems].map((artifact) => artifact.id);
+  const savedIds = new Set(storedState.selectedArtifactIds);
+  let selectedArtifactIds = artifactOrder.filter((id) => savedIds.has(id));
+  const maxArtifactCount = capabilities.max_artifact_count;
+  if (maxArtifactCount !== null && maxArtifactCount !== undefined) {
+    selectedArtifactIds = selectedArtifactIds.slice(0, Math.max(0, maxArtifactCount));
+  }
+  if (!selectedArtifactIds.length) selectedArtifactIds = [audioSet.artifact.id];
+
+  const availableFormats = availableOptionIds(capabilities, "formats");
+  const outputFormat = storedState.outputFormat && availableFormats.has(storedState.outputFormat)
+    ? storedState.outputFormat
+    : preferredOutputFormat(defaultOutputFormat, availableFormats);
+  const compatibleDestinations: ExportDestinationType[] = selectedArtifactIds.length === 1
+    ? ["single_file"]
+    : ["folder", "zip"];
+  const availableDestinations = availableOptionIds(capabilities, "destinations");
+  const destinationType = compatibleDestinations.includes(storedState.destinationType) &&
+    availableDestinations.has(storedState.destinationType)
+    ? storedState.destinationType
+    : compatibleDestinations.find((type) => availableDestinations.has(type)) ?? compatibleDestinations[0];
+  const adjusted = !stateEquals(storedState, {
+    audioSetId: audioSet.artifact.id,
+    selectedArtifactIds,
+    outputFormat,
+    filenameBase: storedState.filenameBase,
+    destinationType,
+    desktopDestinationTarget: storedState.desktopDestinationTarget,
+  });
+  const targetIsCompatible = capabilities.platform === "desktop" &&
+    availableFormats.has(outputFormat) &&
+    availableDestinations.has(destinationType) &&
+    isDesktopDestinationTarget(storedState.desktopDestinationTarget);
+  const state: ExportWorkspaceState = {
+    audioSetId: audioSet.artifact.id,
+    selectedArtifactIds,
+    outputFormat,
+    filenameBase: storedState.filenameBase,
+    destinationType,
+    desktopDestinationTarget: adjusted || !targetIsCompatible
+      ? null
+      : storedState.desktopDestinationTarget?.trim() ?? null,
+  };
+  return { state, recovery: !stateEquals(storedState, state) };
+}
 
 export function buildExportAudioSets(artifacts: ArtifactSchema[]): ExportAudioSet[] {
   const source = artifacts.find((artifact) => artifact.type === "source_audio") ?? null;

--- a/apps/desktop/src/features/projects/hooks/useExportWorkspace.ts
+++ b/apps/desktop/src/features/projects/hooks/useExportWorkspace.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { confirm, open, save } from "@tauri-apps/plugin-dialog";
 import { ApiError, api, type ExportRequest } from "../../../lib/api";
@@ -8,11 +8,16 @@ import {
   exportContextName,
   exportOutputNames,
   exportPresetForSelection,
+  isDesktopDestinationTarget,
+  defaultExportWorkspaceState,
+  reconcileExportWorkspaceState,
+  type ExportDestinationType,
+  type ExportFormat,
   type ExportPreset,
 } from "../exportWorkspaceUtils";
+import type { ExportWorkspaceState } from "../projectPlaybackState";
 
-type DestinationType = "single_file" | "folder" | "zip";
-type ExportFormat = "wav" | "flac" | "mp3" | "m4a";
+type DestinationType = ExportDestinationType;
 
 const FORMAT_LABELS: Record<ExportFormat, string> = {
   wav: "WAV",
@@ -38,49 +43,118 @@ function selectedIdsForPreset(
 export function useExportWorkspace() {
   const {
     displayArtifacts,
+    artifactsQuery,
+    exportWorkspace,
+    handleSetExportWorkspace,
+    handleShowExportRecoveryNotice,
     handleSelectProjectPanel,
+    hydratedProjectId,
     isMobileRuntime,
     projectEditLocked,
+    projectId,
     projectQuery,
     selectedPrimaryArtifactId,
     visibleJobs,
   } = useProjectViewModelContext();
   const queryClient = useQueryClient();
-  const audioSets = useMemo(() => buildExportAudioSets(displayArtifacts), [displayArtifacts]);
+  const isCurrentProjectHydrated =
+    hydratedProjectId === projectId && projectQuery.data?.id === projectId && artifactsQuery.isSuccess;
+  const audioSets = useMemo(
+    () => isCurrentProjectHydrated ? buildExportAudioSets(displayArtifacts) : [],
+    [displayArtifacts, isCurrentProjectHydrated],
+  );
   const defaultAudioSetId =
     audioSets.find((audioSet) => audioSet.artifact.id === selectedPrimaryArtifactId)?.artifact.id ??
     audioSets[0]?.artifact.id ??
     "";
-  const [audioSetId, setAudioSetId] = useState(defaultAudioSetId);
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [outputFormat, setOutputFormat] = useState<ExportFormat>("m4a");
-  const [filenameBase, setFilenameBase] = useState(projectQuery.data?.display_name ?? "TuneForge Export");
-  const [destinationType, setDestinationType] = useState<DestinationType>("single_file");
-  const [destinationTarget, setDestinationTarget] = useState<string | null>(null);
-  const skipAudioSetResetRef = useRef(false);
-  const audioSet = audioSets.find((candidate) => candidate.artifact.id === audioSetId) ?? audioSets[0] ?? null;
-
-  useEffect(() => {
-    if (!audioSetId && defaultAudioSetId) setAudioSetId(defaultAudioSetId);
-  }, [audioSetId, defaultAudioSetId]);
-
-  useEffect(() => {
-    if (!audioSet) return;
-    if (skipAudioSetResetRef.current) {
-      skipAudioSetResetRef.current = false;
-      return;
-    }
-    setSelectedIds(new Set([audioSet.artifact.id]));
-    setDestinationType("single_file");
-    setDestinationTarget(null);
-  }, [audioSet]);
-
+  const fallbackState = useMemo<ExportWorkspaceState | null>(() => {
+    if (!defaultAudioSetId) return null;
+    return {
+      audioSetId: defaultAudioSetId,
+      selectedArtifactIds: [defaultAudioSetId],
+      outputFormat: "m4a",
+      filenameBase: isCurrentProjectHydrated
+        ? projectQuery.data?.display_name ?? "TuneForge Export"
+        : "TuneForge Export",
+      destinationType: "single_file",
+      desktopDestinationTarget: null,
+    };
+  }, [defaultAudioSetId, isCurrentProjectHydrated, projectQuery.data?.display_name]);
+  const healthQuery = useQuery({
+    queryKey: ["health"],
+    queryFn: () => api.getHealth(),
+    staleTime: Infinity,
+  });
   const capabilitiesQuery = useQuery({
     queryKey: ["export-capabilities"],
     queryFn: () => api.getExportCapabilities(),
     staleTime: Infinity,
   });
   const capabilities = capabilitiesQuery.data?.capabilities ?? null;
+  const healthSettled = healthQuery.isSuccess || healthQuery.isError;
+  const defaultOutputFormat = healthQuery.isSuccess
+    ? healthQuery.data.default_export_format
+    : null;
+  const savedFormatIsAvailable = Boolean(
+    exportWorkspace?.outputFormat && capabilities?.formats.some(
+      (format) => format.id === exportWorkspace.outputFormat && format.available,
+    ),
+  );
+  const workspaceReady = Boolean(
+    isCurrentProjectHydrated &&
+      capabilitiesQuery.isSuccess &&
+      capabilities &&
+      (healthSettled || savedFormatIsAvailable),
+  );
+  const reconciliation = useMemo(
+    () => workspaceReady && capabilities
+      ? reconcileExportWorkspaceState({
+          storedState: exportWorkspace,
+          audioSets,
+          selectedPrimaryArtifactId,
+          filenameBase: projectQuery.data?.display_name ?? "TuneForge Export",
+          capabilities,
+          defaultOutputFormat,
+        })
+      : null,
+    [
+      audioSets,
+      capabilities,
+      defaultOutputFormat,
+      exportWorkspace,
+      projectQuery.data?.display_name,
+      selectedPrimaryArtifactId,
+      workspaceReady,
+    ],
+  );
+  const draft = reconciliation?.state ?? fallbackState;
+  const audioSetId = draft?.audioSetId ?? "";
+  const selectedIds = useMemo(() => new Set(draft?.selectedArtifactIds ?? []), [draft?.selectedArtifactIds]);
+  const outputFormat = draft?.outputFormat ?? "m4a";
+  const filenameBase = draft?.filenameBase ?? fallbackState?.filenameBase ?? "TuneForge Export";
+  const destinationType = draft?.destinationType ?? "single_file";
+  const destinationTarget = draft?.desktopDestinationTarget ?? null;
+  const recoveredDrafts = useRef(new Set<string>());
+  const audioSet = audioSets.find((candidate) => candidate.artifact.id === audioSetId) ?? audioSets[0] ?? null;
+
+  useEffect(() => {
+    if (!reconciliation) {
+      return;
+    }
+    if (JSON.stringify(reconciliation.state) === JSON.stringify(exportWorkspace)) return;
+    const storedFingerprint = JSON.stringify(exportWorkspace);
+    if (reconciliation.recovery && !recoveredDrafts.current.has(`${projectId}:${storedFingerprint}`)) {
+      recoveredDrafts.current.add(`${projectId}:${storedFingerprint}`);
+      handleShowExportRecoveryNotice();
+    }
+    handleSetExportWorkspace(reconciliation.state);
+  }, [
+    exportWorkspace,
+    handleSetExportWorkspace,
+    handleShowExportRecoveryNotice,
+    projectId,
+    reconciliation,
+  ]);
   const selectedArtifacts = audioSet
     ? [audioSet.artifact, ...audioSet.stems].filter((artifact) => selectedIds.has(artifact.id))
     : [];
@@ -114,18 +188,27 @@ export function useExportWorkspace() {
       selectedFormatCapability?.available &&
       selectedDestinationCapability?.available &&
       selectionAllowed &&
+      workspaceReady &&
       !projectEditLocked &&
       !activeExportJob,
   );
 
+  function updateDraft(next: ExportWorkspaceState) {
+    if (!workspaceReady) return;
+    handleSetExportWorkspace(next);
+  }
+
   function updateSelection(next: Set<string>) {
     const wasSingle = selectedIds.size === 1;
     const isSingle = next.size === 1;
-    setSelectedIds(next);
-    if (next.size === 0 || wasSingle !== isSingle) {
-      setDestinationTarget(null);
-      setDestinationType(isSingle ? "single_file" : "folder");
-    }
+    updateDraft({
+      ...(draft ?? fallbackState!),
+      selectedArtifactIds: [...next],
+      destinationType: next.size === 0 || wasSingle !== isSingle
+        ? isSingle ? "single_file" : "folder"
+        : destinationType,
+      desktopDestinationTarget: next.size === 0 || wasSingle !== isSingle ? null : destinationTarget,
+    });
   }
 
   function selectPreset(nextPreset: Exclude<ExportPreset, "custom">) {
@@ -146,8 +229,32 @@ export function useExportWorkspace() {
     updateSelection(next);
   }
 
+  function selectAudioSet(nextAudioSetId: string) {
+    const nextAudioSet = audioSets.find((audioSet) => audioSet.artifact.id === nextAudioSetId);
+    if (!nextAudioSet || !draft) return;
+    updateDraft({
+      ...draft,
+      audioSetId: nextAudioSetId,
+      selectedArtifactIds: [nextAudioSet.artifact.id],
+      destinationType: "single_file",
+      desktopDestinationTarget: null,
+    });
+  }
+
+  function resetWorkspace() {
+    if (!workspaceReady || !healthSettled || !capabilities || activeExportJob) return;
+    const next = defaultExportWorkspaceState({
+      audioSets,
+      selectedPrimaryArtifactId,
+      filenameBase: projectQuery.data?.display_name ?? "TuneForge Export",
+      capabilities,
+      defaultOutputFormat,
+    });
+    handleSetExportWorkspace(next);
+  }
+
   async function chooseDestination(type = destinationType) {
-    if (!audioSet) return null;
+    if (!audioSet || capabilities?.platform !== "desktop") return null;
     let target: string | string[] | null;
     if (type === "folder") {
       target = await open({ directory: true, multiple: false });
@@ -165,8 +272,13 @@ export function useExportWorkspace() {
       });
     }
     const normalized = Array.isArray(target) ? target[0] : target;
-    if (!normalized) return null;
-    setDestinationTarget(normalized);
+    if (
+      !normalized ||
+      !isDesktopDestinationTarget(normalized) ||
+      !selectedFormatCapability?.available ||
+      !selectedDestinationCapability?.available
+    ) return null;
+    if (draft) updateDraft({ ...draft, desktopDestinationTarget: normalized });
     return normalized;
   }
 
@@ -217,13 +329,14 @@ export function useExportWorkspace() {
     const failed = failedArtifactIds.filter(
       (id) => id === retryAudioSet.artifact.id || retryAudioSet.stems.some((stem) => stem.id === id),
     );
-    if (retryAudioSet.artifact.id !== audioSet?.artifact.id) {
-      skipAudioSetResetRef.current = true;
-      setAudioSetId(retryAudioSet.artifact.id);
-    }
-    setSelectedIds(new Set(failed));
-    setDestinationTarget(null);
-    setDestinationType(failed.length === 1 ? "single_file" : "folder");
+    if (!draft) return;
+    updateDraft({
+      ...draft,
+      audioSetId: retryAudioSet.artifact.id,
+      selectedArtifactIds: failed,
+      destinationType: failed.length === 1 ? "single_file" : "folder",
+      desktopDestinationTarget: null,
+    });
   }
 
   return {
@@ -235,6 +348,9 @@ export function useExportWorkspace() {
     cancelMutation,
     capabilities,
     capabilitiesQuery,
+    capabilitiesError: capabilitiesQuery.isError
+      ? "Export options couldn’t load. Retry to continue."
+      : null,
     chooseDestination,
     destinationTarget,
     destinationType,
@@ -250,6 +366,15 @@ export function useExportWorkspace() {
     preset,
     projectEditLocked,
     retryFailed,
+    retryCapabilities: () => void capabilitiesQuery.refetch(),
+    resetWorkspace,
+    resetUnavailableReason: activeExportJob
+      ? "Export options can’t be reset while an export is in progress."
+      : capabilitiesQuery.isError
+        ? "Export options couldn’t load. Retry to continue."
+        : !workspaceReady || !healthSettled
+        ? "Export options are still loading."
+        : null,
     retryUnavailableReason: partialExportJob && !retryAudioSet
       ? "Failed export items are no longer available in this project."
       : null,
@@ -259,11 +384,17 @@ export function useExportWorkspace() {
     selectedArtifacts,
     selectionAllowed,
     selectPreset,
-    setAudioSetId,
-    setDestinationTarget,
-    setDestinationType,
-    setFilenameBase,
-    setOutputFormat,
+    setAudioSetId: selectAudioSet,
+    setDestinationType: (nextDestinationType: DestinationType) => {
+      if (draft) updateDraft({ ...draft, destinationType: nextDestinationType, desktopDestinationTarget: null });
+    },
+    setFilenameBase: (nextFilenameBase: string) => {
+      if (draft) updateDraft({ ...draft, filenameBase: nextFilenameBase });
+    },
+    setOutputFormat: (nextOutputFormat: ExportFormat) => {
+      if (draft) updateDraft({ ...draft, outputFormat: nextOutputFormat, desktopDestinationTarget: null });
+    },
     toggleArtifact,
+    workspaceReady,
   };
 }

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -36,6 +36,7 @@ import {
   readProjectPlaybackState,
   writeProjectPlaybackState,
   type PlaybackLoopRange,
+  type ExportWorkspaceState,
   type ProjectPanelMode,
   type StemControlState,
 } from "../projectPlaybackState";
@@ -368,6 +369,9 @@ export function useProjectViewModel() {
   );
   const [stemControls, setStemControls] = useState<Record<string, StemControlState>>({});
   const [dismissedStemJobIds, setDismissedStemJobIds] = useState<string[]>([]);
+  const [exportWorkspace, setExportWorkspace] = useState<ExportWorkspaceState | null>(null);
+  const [exportRecoveryNoticeId, setExportRecoveryNoticeId] = useState(0);
+  const [exportRecoveryNoticeProjectId, setExportRecoveryNoticeProjectId] = useState<string | null>(null);
   const [isEditingLyrics, setIsEditingLyrics] = useState(false);
   const [lyricsDraft, setLyricsDraft] = useState<string[]>([]);
   const [selectedLyricsLanguageOverride, setSelectedLyricsLanguageOverride] =
@@ -1920,6 +1924,7 @@ export function useProjectViewModel() {
     );
     setStemControls(storedPlaybackState.stemControls);
     setDismissedStemJobIds(storedPlaybackState.dismissedStemJobIds);
+    setExportWorkspace(storedPlaybackState.exportWorkspace);
     setHydratedProjectId(projectId);
   }, [
     defaultChordsFollowEnabled,
@@ -2130,6 +2135,7 @@ export function useProjectViewModel() {
       chordsFollowEnabled,
       stemControls,
       dismissedStemJobIds,
+      exportWorkspace,
     });
   }, [
     activeProjectPanel,
@@ -2137,6 +2143,7 @@ export function useProjectViewModel() {
     capoSemitones,
     chordsFollowEnabled,
     dismissedStemJobIds,
+    exportWorkspace,
     hydratedProjectId,
     lyricsFollowEnabled,
     loopRange,
@@ -2432,6 +2439,7 @@ export function useProjectViewModel() {
     activeLyricsWordIndex,
     activeStemCount,
     analysisQuery,
+    artifactsQuery,
     analysisTimingGrid,
     analyzeMutation,
     canAnalyze,
@@ -2474,6 +2482,9 @@ export function useProjectViewModel() {
     displayedLyrics,
     draftName,
     enharmonicDisplayMode,
+    exportRecoveryNoticeId,
+    exportRecoveryNoticeProjectId,
+    exportWorkspace,
     acceptedTabSuggestionIds,
     handleAnalyzeAction,
     handleDeleteMix,
@@ -2491,6 +2502,11 @@ export function useProjectViewModel() {
     handleSelectStemArtifact,
     handleSelectWorkspace,
     handleSelectProjectPanel: setActiveProjectPanel,
+    handleSetExportWorkspace: setExportWorkspace,
+    handleShowExportRecoveryNotice: () => {
+      setExportRecoveryNoticeProjectId(projectId);
+      setExportRecoveryNoticeId((current) => current + 1);
+    },
     handleSetChordsFollowEnabled,
     handleSetLyricsFollowEnabled,
     handleSetPrecountClickCount,
@@ -2518,6 +2534,8 @@ export function useProjectViewModel() {
     hasTimedLyricsTranscript,
     hasTransformChange,
     hasVisibleStems,
+    hydratedProjectId,
+    projectId,
     hasActiveStemControls,
     hasNextProjectHistoryJobsPage: terminalProjectJobsQuery.hasNextPage,
     higherCapoPreview,

--- a/apps/desktop/src/features/projects/projectPlaybackState.ts
+++ b/apps/desktop/src/features/projects/projectPlaybackState.ts
@@ -22,6 +22,15 @@ export type PlaybackLoopRange = {
   endSeconds: number;
 };
 
+export type ExportWorkspaceState = {
+  audioSetId: string | null;
+  selectedArtifactIds: string[];
+  outputFormat: "wav" | "flac" | "mp3" | "m4a" | null;
+  filenameBase: string;
+  destinationType: "single_file" | "folder" | "zip";
+  desktopDestinationTarget: string | null;
+};
+
 export const DEFAULT_PRECOUNT_CLICK_COUNT = 4;
 export const MIN_PRECOUNT_CLICK_COUNT = 1;
 export const MAX_PRECOUNT_CLICK_COUNT = 8;
@@ -45,6 +54,7 @@ export type StoredProjectPlaybackState = {
   chordsFollowEnabled: boolean;
   stemControls: Record<string, StemControlState>;
   dismissedStemJobIds: string[];
+  exportWorkspace: ExportWorkspaceState | null;
 };
 
 const STORAGE_KEY = "tuneforge.project-playback-state";
@@ -67,6 +77,7 @@ const DEFAULT_STORED_PROJECT_PLAYBACK_STATE: StoredProjectPlaybackState = {
   chordsFollowEnabled: true,
   stemControls: {},
   dismissedStemJobIds: [],
+  exportWorkspace: null,
 };
 
 function normalizeTransposeSemitones(value: unknown) {
@@ -103,6 +114,34 @@ function normalizeLoopPoint(value: unknown) {
     return null;
   }
   return Math.max(0, value);
+}
+
+function normalizeExportWorkspaceState(value: unknown): ExportWorkspaceState | null {
+  if (!value || typeof value !== "object") return null;
+  const candidate = value as Partial<ExportWorkspaceState>;
+  const hasValidOutputFormat = ["wav", "flac", "mp3", "m4a"].includes(candidate.outputFormat ?? "");
+  const hasValidDestinationType = ["single_file", "folder", "zip"].includes(
+    candidate.destinationType ?? "",
+  );
+  const outputFormat = hasValidOutputFormat
+    ? candidate.outputFormat as ExportWorkspaceState["outputFormat"]
+    : null;
+  const destinationType = hasValidDestinationType
+    ? candidate.destinationType as ExportWorkspaceState["destinationType"]
+    : "single_file";
+  const invalidChoice = !hasValidOutputFormat || !hasValidDestinationType;
+  return {
+    audioSetId: !invalidChoice && typeof candidate.audioSetId === "string" ? candidate.audioSetId : null,
+    selectedArtifactIds: Array.isArray(candidate.selectedArtifactIds)
+      ? candidate.selectedArtifactIds.filter((id): id is string => typeof id === "string")
+      : [],
+    outputFormat,
+    filenameBase: typeof candidate.filenameBase === "string" ? candidate.filenameBase : "",
+    destinationType,
+    desktopDestinationTarget: !invalidChoice && typeof candidate.desktopDestinationTarget === "string"
+        ? candidate.desktopDestinationTarget
+        : null,
+  };
 }
 
 export function normalizePlaybackLoopRange(value: unknown): PlaybackLoopRange | null {
@@ -196,6 +235,7 @@ function normalizeStoredProjectPlaybackState(value: unknown): StoredProjectPlayb
         : DEFAULT_STORED_PROJECT_PLAYBACK_STATE.chordsFollowEnabled,
     stemControls,
     dismissedStemJobIds,
+    exportWorkspace: normalizeExportWorkspaceState(candidate.exportWorkspace),
   };
 }
 

--- a/apps/desktop/src/styles/project-export.css
+++ b/apps/desktop/src/styles/project-export.css
@@ -34,6 +34,34 @@
   font-weight: 700;
 }
 
+.export-workspace__header-actions {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.45rem;
+}
+
+.export-workspace__header-actions .field-reason {
+  flex-basis: 100%;
+  max-width: 16rem;
+  text-align: right;
+}
+
+.project-export-recovery-toast {
+  position: fixed;
+  z-index: 20;
+  right: max(1rem, env(safe-area-inset-right));
+  bottom: max(1rem, env(safe-area-inset-bottom));
+  max-width: min(28rem, calc(100vw - 2rem));
+  padding: 0.8rem 0.95rem;
+  border: 1px solid var(--divider);
+  border-radius: 14px;
+  background: var(--panel-strong);
+  box-shadow: 0 12px 28px color-mix(in srgb, var(--ink) 20%, transparent);
+}
+
 .export-workspace__grid {
   display: grid;
   grid-template-columns: minmax(12.5rem, 0.64fr) minmax(23rem, 1.25fr) minmax(20rem, 0.92fr);
@@ -398,6 +426,18 @@
 
   .export-workspace__header {
     align-items: flex-start;
+
+    flex-wrap: wrap;
+  }
+
+  .export-workspace__header-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .export-workspace__header-actions .field-reason {
+    max-width: none;
+    text-align: left;
   }
 
   .export-audio-sets__options {

--- a/apps/desktop/src/styles/project-export.source.test.mjs
+++ b/apps/desktop/src/styles/project-export.source.test.mjs
@@ -12,4 +12,18 @@ describe("narrow export package source", () => {
     expect(narrowStyles).toMatch(/\.export-package__summary\s*\{[^}]*position:\s*sticky;/s);
     expect(narrowStyles).not.toMatch(/\.export-package\s*\{[^}]*position:\s*sticky;/s);
   });
+
+  it("keeps export recovery notices below overlays and inside the viewport", () => {
+    const stylesheet = readFileSync(resolve(cwd(), "src/styles/project-export.css"), "utf8");
+    const shell = readFileSync(
+      resolve(cwd(), "src/features/projects/components/ProjectShell.tsx"),
+      "utf8",
+    );
+
+    expect(stylesheet).toMatch(/\.project-export-recovery-toast\s*\{[^}]*position:\s*fixed;/s);
+    expect(stylesheet).toMatch(/\.project-export-recovery-toast\s*\{[^}]*z-index:\s*20;/s);
+    expect(stylesheet).toMatch(/\.project-export-recovery-toast\s*\{[^}]*max-width:\s*min\(28rem, calc\(100vw - 2rem\)\);/s);
+    expect(shell).toMatch(/setTimeout\(\(\) => setShowExportRecoveryNotice\(false\), 4000\)/);
+    expect(shell).toMatch(/exportRecoveryNoticeProjectId !== projectId/);
+  });
 });


### PR DESCRIPTION
## Summary

- Persist each project's Export selection, format, naming, destination mode, and validated desktop target.
- Reconcile stale choices against current artifacts and capabilities without leaking state between projects.
- Use the backend export default for fresh and reset workspaces while preserving explicit project preferences.
- Add an Export-only reset action and a private recovery notice for adjusted saved state.
- Closes #431

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — desktop 757/757, Tauri 321/321, backend 682/682.
- `git diff --check`
- Manual desktop-app smoke not run because the user owns the app lifecycle; native-dialog visuals remain unverified.
