### PR TITLE
fix: make export media capture format-aware

### DIFF
--- a/scripts/capture-release-media.mjs
+++ b/scripts/capture-release-media.mjs
@@ -66,7 +66,7 @@ const releaseMediaCaptureCatalog = [
     fileName: "export-workspace.png",
     title: "Selective export workspace",
     caption: "Package one practice mix and a custom set of stems as local files.",
-    alt: "TuneForge Export workspace with Practice Mix 1 and four M4A files selected",
+    alt: "TuneForge Export workspace with Practice Mix 1 and four audio files selected",
     fixture: "release-showcase-v1",
     viewport: { width: 1440, height: 1024 },
     route: "/projects/proj_release_showcase",
@@ -1404,7 +1404,11 @@ async function readyExportWorkspace({ page, timeoutMs }) {
   await page.getByText("Custom selection", { exact: true }).waitFor({ timeout: timeoutMs });
   await page.getByText("4 selected", { exact: true }).waitFor({ timeout: timeoutMs });
   await page.getByRole("button", { name: "Folder" }).waitFor({ timeout: timeoutMs });
-  await page.getByText("Midnight Count-In - Practice Mix 1 - Vocals.m4a", { exact: true })
+  const fileFormat = await page.getByLabel("File format").inputValue();
+  await page.locator(".export-preview").getByText(
+    `Midnight Count-In - Practice Mix 1 - Vocals.${fileFormat}`,
+    { exact: true },
+  )
     .waitFor({ timeout: timeoutMs });
 }
 

--- a/scripts/capture-release-media.test.mjs
+++ b/scripts/capture-release-media.test.mjs
@@ -59,6 +59,38 @@ test("release-media catalog has unique identifiers, files, and required callback
   }
 });
 
+test("Export readiness follows the selected file format in its preview", async () => {
+  const exportWorkspace = releaseMediaCaptureCatalog.find((entry) => entry.id === "export-workspace");
+
+  for (const fileFormat of ["wav", "flac", "mp3", "m4a"]) {
+    let previewRequest;
+    const waitFor = () => ({ waitFor: async () => {} });
+    const page = {
+      getByLabel: (label) => {
+        assert.equal(label, "File format");
+        return { inputValue: async () => fileFormat };
+      },
+      getByRole: () => waitFor(),
+      getByText: () => waitFor(),
+      locator: (selector) => {
+        assert.equal(selector, ".export-preview");
+        return {
+          getByText: (text, options) => {
+            previewRequest = { options, text };
+            return waitFor();
+          },
+        };
+      },
+    };
+
+    await exportWorkspace.ready({ page, timeoutMs: 1 });
+    assert.deepEqual(previewRequest, {
+      options: { exact: true },
+      text: `Midnight Count-In - Practice Mix 1 - Vocals.${fileFormat}`,
+    });
+  }
+});
+
 test("mobile Playback is one deterministic compact screenshot fixture", () => {
   const mobileScreenshots = releaseMediaCaptureCatalog.filter(
     (entry) => entry.kind === "screenshot" && entry.runtime === "mobile",


### PR DESCRIPTION
## Summary

- make Export release-media readiness follow the selected project format
- keep capture copy format-neutral
- cover WAV, FLAC, MP3, and M4A readiness
- Closes #434

## Testing

- `node --check scripts/capture-release-media.mjs`
- `node --test scripts/capture-release-media.test.mjs` (12/12 passed)
- `node scripts/capture-release-media.mjs --run --output-dir="$(mktemp -d)"` (9/9 captured)
