### PR TITLE
feat: polish export workflow defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ download, installation, verification, signature, and publication instructions.
   its track and stems as a file, folder, or ZIP.
 - Saved per-project Export choices that safely reconcile with available audio and device capabilities.
 
+### Changed
+
+- Polished Export destination controls and defaulted new stemmed selections to track plus all stems.
+
 ## [1.0.1] - 2026-08-13
 
 ### Added

--- a/apps/desktop/src/App.project-export.test.tsx
+++ b/apps/desktop/src/App.project-export.test.tsx
@@ -125,6 +125,40 @@ describe("project export workspace", () => {
     expect(within(preview as HTMLElement).getByText("Demo Song - Practice Mix 1 - Vocals.wav")).toBeInTheDocument();
   });
 
+  it("orders presets and defaults a newly selected stemmed set to a folder package", async () => {
+    const user = userEvent.setup();
+    installExportArtifacts();
+    renderApp(["/projects/proj_123"]);
+    await screen.findByRole("heading", { name: "Demo Song" });
+    await openExportPanel(user);
+
+    const presetButtons = within(screen.getByRole("group", { name: "Quick selections" }))
+      .getAllByRole("button");
+    expect(presetButtons.map((button) => button.textContent)).toEqual([
+      "Track + all stems",
+      "Track only",
+      "All stems",
+    ]);
+    await user.click(screen.getByRole("radio", { name: /Practice Mix 1/i }));
+    presetButtons[0]?.focus();
+    await user.tab();
+    expect(presetButtons[1]).toHaveFocus();
+    await user.tab();
+    expect(presetButtons[2]).toHaveFocus();
+
+    expect(screen.getByText("5 selected")).toBeInTheDocument();
+    expect(presetButtons[0]).toHaveAttribute("aria-pressed", "true");
+    const destinations = within(screen.getByRole("group", { name: "Destination" }))
+      .getAllByRole("button");
+    expect(destinations).toHaveLength(3);
+    expect(destinations[1]).toHaveAttribute("aria-pressed", "true");
+    expect(destinations.map((button) => button.querySelector(".export-destination-option__check")))
+      .not.toContain(null);
+    expect(destinations[0]?.querySelector(".export-destination-option__check svg")).toBeNull();
+    expect(destinations[1]?.querySelector(".export-destination-option__check svg")).not.toBeNull();
+    expect(destinations[2]?.querySelector(".export-destination-option__check svg")).toBeNull();
+  });
+
   it("retains a compatible folder target for manual many-to-many selection changes", async () => {
     const user = userEvent.setup();
     installExportArtifacts();

--- a/apps/desktop/src/features/projects/components/ExportWorkspace.tsx
+++ b/apps/desktop/src/features/projects/components/ExportWorkspace.tsx
@@ -191,6 +191,15 @@ export function ExportWorkspace() {
           <fieldset className="export-presets" disabled={controlsDisabled}>
             <legend>Quick selections</legend>
             <button
+              aria-describedby={isMobileRuntime ? "android-multi-export-reason" : undefined}
+              aria-pressed={preset === "track-and-stems"}
+              className="button button--small"
+              disabled={!audioSet.stems.length || isMobileRuntime}
+              title={isMobileRuntime ? "Android currently exports one file at a time." : undefined}
+              onClick={() => selectPreset("track-and-stems")}
+              type="button"
+            >Track + all stems</button>
+            <button
               aria-pressed={preset === "track"}
               className="button button--small"
               onClick={() => selectPreset("track")}
@@ -205,15 +214,6 @@ export function ExportWorkspace() {
               onClick={() => selectPreset("stems")}
               type="button"
             >All stems</button>
-            <button
-              aria-describedby={isMobileRuntime ? "android-multi-export-reason" : undefined}
-              aria-pressed={preset === "track-and-stems"}
-              className="button button--small"
-              disabled={!audioSet.stems.length || isMobileRuntime}
-              title={isMobileRuntime ? "Android currently exports one file at a time." : undefined}
-              onClick={() => selectPreset("track-and-stems")}
-              type="button"
-            >Track + all stems</button>
             <span className="export-presets__state">{preset === "custom" ? "Custom selection" : "Preset selection"}</span>
             {isMobileRuntime ? (
               <span className="field-reason" id="android-multi-export-reason">
@@ -312,7 +312,13 @@ export function ExportWorkspace() {
                         disabled={unavailable}
                         onClick={() => setDestinationType(id)}
                         type="button"
-                      ><Icon aria-hidden="true" /> {label}</button>
+                      >
+                        <Icon aria-hidden="true" />
+                        <span>{label}</span>
+                        <span aria-hidden="true" className="export-destination-option__check">
+                          {destinationType === id ? <Check /> : null}
+                        </span>
+                      </button>
                       {unavailable ? (
                         <small className="field-reason" id={reasonId}>
                           {capability?.available === false

--- a/apps/desktop/src/features/projects/exportWorkspaceUtils.test.ts
+++ b/apps/desktop/src/features/projects/exportWorkspaceUtils.test.ts
@@ -151,6 +151,42 @@ describe("export workspace utilities", () => {
     expect(createState("ogg", [])?.outputFormat).toBe("m4a");
   });
 
+  it("defaults to track-first audio selections and a compatible destination", () => {
+    const audioSets = buildExportAudioSets([
+      artifact("source", "source_audio", createdAt),
+      artifact("vocals", "vocal_stem", createdAt, "source"),
+      artifact("drums", "drums_stem", createdAt, "source"),
+    ]);
+    const createState = (maxArtifactCount: number | null, destinations?: string[]) =>
+      defaultExportWorkspaceState({
+        audioSets,
+        selectedPrimaryArtifactId: "source",
+        filenameBase: "Demo Song",
+        capabilities: capabilities({ maxArtifactCount, destinations }),
+        defaultOutputFormat: "wav",
+      });
+
+    expect(createState(null)).toMatchObject({
+      selectedArtifactIds: ["source", "vocals", "drums"],
+      destinationType: "folder",
+    });
+    expect(createState(2, ["single_file", "zip"])).toMatchObject({
+      selectedArtifactIds: ["source", "vocals"],
+      destinationType: "zip",
+    });
+    expect(createState(1)).toMatchObject({
+      selectedArtifactIds: ["source"],
+      destinationType: "single_file",
+    });
+    expect(defaultExportWorkspaceState({
+      audioSets: buildExportAudioSets([artifact("solo", "source_audio", createdAt)]),
+      selectedPrimaryArtifactId: "solo",
+      filenameBase: "Solo",
+      capabilities: capabilities(),
+      defaultOutputFormat: "wav",
+    })).toMatchObject({ selectedArtifactIds: ["solo"], destinationType: "single_file" });
+  });
+
   it("recovers a corrupt stored format to the backend default and clears its target", () => {
     const audioSets = buildExportAudioSets([artifact("source", "source_audio", createdAt)]);
 

--- a/apps/desktop/src/features/projects/exportWorkspaceUtils.ts
+++ b/apps/desktop/src/features/projects/exportWorkspaceUtils.ts
@@ -59,6 +59,18 @@ function availableOptionIds(
   return new Set(capabilities[kind].filter((option) => option.available).map((option) => option.id));
 }
 
+function compatibleDestinationTypes(artifactCount: number): ExportDestinationType[] {
+  return artifactCount === 1 ? ["single_file"] : ["folder", "zip"];
+}
+
+function preferredDestinationType(
+  artifactCount: number,
+  availableDestinations: Set<string>,
+) {
+  const compatibleDestinations = compatibleDestinationTypes(artifactCount);
+  return compatibleDestinations.find((type) => availableDestinations.has(type)) ?? compatibleDestinations[0];
+}
+
 export function defaultExportWorkspaceState({
   audioSets,
   selectedPrimaryArtifactId,
@@ -76,12 +88,18 @@ export function defaultExportWorkspaceState({
   if (!audioSet) return null;
   const availableFormats = availableOptionIds(capabilities, "formats");
   const outputFormat = preferredOutputFormat(defaultOutputFormat, availableFormats);
+  const artifactOrder = [audioSet.artifact, ...audioSet.stems].map((artifact) => artifact.id);
+  const maxArtifactCount = capabilities.max_artifact_count;
+  const selectedArtifactIds = maxArtifactCount === null || maxArtifactCount === undefined
+    ? artifactOrder
+    : artifactOrder.slice(0, Math.max(1, maxArtifactCount));
+  const availableDestinations = availableOptionIds(capabilities, "destinations");
   return {
     audioSetId: audioSet.artifact.id,
-    selectedArtifactIds: [audioSet.artifact.id],
+    selectedArtifactIds,
     outputFormat,
     filenameBase,
-    destinationType: "single_file",
+    destinationType: preferredDestinationType(selectedArtifactIds.length, availableDestinations),
     desktopDestinationTarget: null,
   };
 }
@@ -138,14 +156,12 @@ export function reconcileExportWorkspaceState({
   const outputFormat = storedState.outputFormat && availableFormats.has(storedState.outputFormat)
     ? storedState.outputFormat
     : preferredOutputFormat(defaultOutputFormat, availableFormats);
-  const compatibleDestinations: ExportDestinationType[] = selectedArtifactIds.length === 1
-    ? ["single_file"]
-    : ["folder", "zip"];
+  const compatibleDestinations = compatibleDestinationTypes(selectedArtifactIds.length);
   const availableDestinations = availableOptionIds(capabilities, "destinations");
   const destinationType = compatibleDestinations.includes(storedState.destinationType) &&
     availableDestinations.has(storedState.destinationType)
     ? storedState.destinationType
-    : compatibleDestinations.find((type) => availableDestinations.has(type)) ?? compatibleDestinations[0];
+    : preferredDestinationType(selectedArtifactIds.length, availableDestinations);
   const adjusted = !stateEquals(storedState, {
     audioSetId: audioSet.artifact.id,
     selectedArtifactIds,

--- a/apps/desktop/src/features/projects/hooks/useExportWorkspace.ts
+++ b/apps/desktop/src/features/projects/hooks/useExportWorkspace.ts
@@ -231,12 +231,20 @@ export function useExportWorkspace() {
 
   function selectAudioSet(nextAudioSetId: string) {
     const nextAudioSet = audioSets.find((audioSet) => audioSet.artifact.id === nextAudioSetId);
-    if (!nextAudioSet || !draft) return;
+    if (!nextAudioSet || !draft || !capabilities) return;
+    const nextDefault = defaultExportWorkspaceState({
+      audioSets: [nextAudioSet],
+      selectedPrimaryArtifactId: nextAudioSetId,
+      filenameBase: draft.filenameBase,
+      capabilities,
+      defaultOutputFormat,
+    });
+    if (!nextDefault) return;
     updateDraft({
       ...draft,
       audioSetId: nextAudioSetId,
-      selectedArtifactIds: [nextAudioSet.artifact.id],
-      destinationType: "single_file",
+      selectedArtifactIds: nextDefault.selectedArtifactIds,
+      destinationType: nextDefault.destinationType,
       desktopDestinationTarget: null,
     });
   }

--- a/apps/desktop/src/styles/project-export.css
+++ b/apps/desktop/src/styles/project-export.css
@@ -236,8 +236,34 @@
 
 .export-destination-option {
   display: grid;
+  flex: 1 1 5rem;
+  align-content: start;
   gap: 0.3rem;
   min-width: 5rem;
+}
+
+.export-destination-option .button {
+  display: grid;
+  width: 100%;
+  min-height: 44px;
+  grid-template-columns: 1rem minmax(0, 1fr) 1rem;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.56rem 0.9rem;
+  border-radius: 999px;
+  text-align: left;
+}
+
+.export-destination-option .button > svg,
+.export-destination-option__check,
+.export-destination-option__check svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.export-destination-option__check {
+  display: grid;
+  place-items: center;
 }
 
 .export-destination-option .field-reason {

--- a/apps/desktop/src/styles/project-export.source.test.mjs
+++ b/apps/desktop/src/styles/project-export.source.test.mjs
@@ -4,6 +4,21 @@ import { cwd } from "node:process";
 import { describe, expect, it } from "vitest";
 
 describe("narrow export package source", () => {
+  it("shares destination geometry and does not override it at narrow widths", () => {
+    const stylesheet = readFileSync(resolve(cwd(), "src/styles/project-export.css"), "utf8");
+    const narrowStyles = stylesheet.slice(stylesheet.indexOf("@media (max-width: 720px)"));
+    const geometry = stylesheet.match(/\.export-destination-option \.button\s*\{([^}]*)\}/)?.[1] ?? "";
+    const optionLayout = stylesheet.match(/\.export-destination-option\s*\{([^}]*)\}/)?.[1] ?? "";
+
+    expect(geometry).toMatch(/width:\s*100%/);
+    expect(geometry).toMatch(/min-height:\s*44px/);
+    expect(geometry).toMatch(/grid-template-columns:\s*1rem minmax\(0, 1fr\) 1rem/);
+    expect(geometry).toMatch(/padding:\s*0\.56rem 0\.9rem/);
+    expect(geometry).toMatch(/border-radius:\s*999px/);
+    expect(optionLayout).toMatch(/align-content:\s*start/);
+    expect(narrowStyles).not.toMatch(/\.export-destination-option \.button\s*\{/);
+  });
+
   it("keeps the package in flow and sticks only its compact summary", () => {
     const stylesheet = readFileSync(resolve(cwd(), "src/styles/project-export.css"), "utf8");
     const narrowStyles = stylesheet.slice(stylesheet.indexOf("@media (max-width: 720px)"));


### PR DESCRIPTION
## Summary

- make Track + all stems the fresh Export default while preserving saved selections and capability limits
- reorder quick selections and stabilize File, Folder, and ZIP controls when helper copy wraps
- add focused behavior and stylesheet regression coverage plus an Unreleased changelog entry

Closes #432

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `git diff --check origin/main...HEAD`
- `node scripts/capture-release-media.mjs --run`
