### PR TITLE
fix: Change vitest configuration to use fixed locale

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -72,6 +72,8 @@ export default defineConfig(() => {
     test: {
       environment: "jsdom",
       env: {
+        LANG: "C.UTF-8",
+        LC_ALL: "C.UTF-8",
         NODE_ENV: "test",
       },
       globals: true,


### PR DESCRIPTION
## Summary

Both LANG and LC_ALL are defined as C, so tests that expect a given localized string, work as expected

Closed #443 

## Motivation

Running tests from within coding tools, harness or even CI itself, used either en_US or C as locale, so they would
pass. We are now making sure that the tests all run with correct locale.

## Changes

- Add LANG and LC_ALL to vite.config.ts for the desktop app

## Test Plan

- Ran full test suite and also specific desktop tests with pnpm --filter @tuneforge/desktop test --run

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(backend): add chord smoothing window`) — it becomes the squash commit message on `main`
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (desktop + Tauri shell + backend)
- [ ] If backend routes or schemas changed, ran `pnpm contracts:generate` and committed the result
- [ ] If this PR includes noteworthy product behavior, updated `CHANGELOG.md`'s `[Unreleased]`
  section
- [ ] If release/package behavior changed or this PR prepares a release package, included Release Package Gate evidence from
  `docs/PACKAGING.md#release-package-gate` (package build plus packaged launch smoke with OS,
  artifact type, commit SHA, and pass/fail evidence); when release/package behavior changed, also
  refreshed license/dependency inventory evidence, documented model-weight download/cache policy,
  and verified no model weights, cache dirs, or package artifacts were added
- [ ] Updated relevant docs (README, backend README, THIRD_PARTY_NOTICES) if behavior changed
- [ ] No secrets, credentials, or copyrighted audio added to the repository
