### PR TITLE
test: add headless export e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
                 scripts/capture-release-media.mjs|scripts/check-release-version.mjs)
                   site=true
                   ;;
-                scripts/package-options*|scripts/flatpak-options*|scripts/playback-smoke*|scripts/sync-validation*|scripts/setup-dev*)
+                scripts/package-options*|scripts/flatpak-options*|scripts/desktop-e2e*|scripts/sync-validation*|scripts/setup-dev*)
                   ;;
                 scripts/*)
                   full_gate=true
@@ -198,7 +198,7 @@ jobs:
           node-version: "22"
 
       - name: Test deterministic Node scripts
-        run: node --test scripts/build-info.test.mjs scripts/package-options.test.mjs scripts/flatpak-options.test.mjs scripts/playback-smoke.test.mjs scripts/sync-validation.test.mjs scripts/release-license-inventory.test.mjs scripts/capture-release-media.test.mjs
+        run: node --test scripts/build-info.test.mjs scripts/package-options.test.mjs scripts/flatpak-options.test.mjs scripts/desktop-e2e.test.mjs scripts/sync-validation.test.mjs scripts/release-license-inventory.test.mjs scripts/capture-release-media.test.mjs
 
       - name: Check release script syntax
         run: |
@@ -282,7 +282,7 @@ jobs:
       - name: Install Playwright Chromium
         run: pnpm --filter @tuneforge/desktop exec playwright install --with-deps chromium
 
-      - name: Run E2E smoke
+      - name: Run desktop E2E suite
         shell: bash
         run: |
           set -uo pipefail
@@ -303,14 +303,14 @@ jobs:
             "${raw_log}" > "${sanitized_log}"
 
           {
-            echo "## E2E smoke"
+            echo "## Desktop E2E suite"
             echo
             echo "- E2E command duration: ${command_elapsed_seconds}s"
             echo
             echo "| Group | Result | Duration |"
             echo "| --- | --- | --- |"
             found_group_result=false
-            group_result_pattern='^\[playback-smoke\] group ([a-z-]+): (passed|failed) in ([0-9.]+s)\.$'
+            group_result_pattern='^\[desktop-e2e\] group ([a-z-]+): (passed|failed) in ([0-9.]+s)\.$'
             while IFS= read -r line; do
               if [[ "${line}" =~ ${group_result_pattern} ]]; then
                 printf '| %s | %s | %s |\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}"
@@ -339,8 +339,8 @@ jobs:
             mkdir -p "$(dirname "${destination}")"
             cp "${artifact}" "${destination}"
           done < <(find "${E2E_TMPDIR}" -type f \( \
-            -path "${E2E_TMPDIR}/tuneforge-playback-smoke-*/playback-failure.png" -o \
-            -path "${E2E_TMPDIR}/tuneforge-playback-smoke-*/playback-failure-summary.json" -o \
+            -path "${E2E_TMPDIR}/tuneforge-*-smoke-*/*-failure.png" -o \
+            -path "${E2E_TMPDIR}/tuneforge-*-smoke-*/*-failure-summary.json" -o \
             -path "${E2E_TMPDIR}/tuneforge-diagnostics-smoke-*/artifacts/diagnostics-failure.png" -o \
             -path "${E2E_TMPDIR}/tuneforge-diagnostics-smoke-*/artifacts/summary.json" \
           \) -print0)

--- a/apps/backend/app/cli/desktop_e2e_fixture.py
+++ b/apps/backend/app/cli/desktop_e2e_fixture.py
@@ -10,7 +10,9 @@ import struct
 import sys
 import wave
 from copy import deepcopy
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from shutil import copyfile
 from typing import Any
 
 from sqlalchemy import select
@@ -18,6 +20,8 @@ from sqlalchemy.orm import Session
 
 from app.errors import AppError
 from app.models import AnalysisResult, Artifact, ChordTimeline, LyricsTranscript, Project, SongSection
+from app.services.artifacts import register_artifact
+from app.services.paths import project_previews_dir, project_stems_dir
 from app.services.projects import import_project
 from app.services.sync_identity import source_hash_to_project_id
 from app.utils.hashing import file_sha256
@@ -29,9 +33,11 @@ FIXTURE_DURATION_SECONDS = 40.0
 FIXTURE_BPM = 120.0
 FIXTURE_SAMPLE_RATE = 22_050
 BEATS_PER_BAR = 4
+FIXTURE_ARTIFACT_MARKER = "desktop-e2e"
+FIXTURE_ARTIFACT_CREATED_AT = datetime(2024, 1, 1, tzinfo=UTC)
 
 
-class PlaybackE2EFixtureCliError(RuntimeError):
+class DesktopE2EFixtureCliError(RuntimeError):
     pass
 
 
@@ -43,7 +49,7 @@ def main(argv: list[str] | None = None) -> int:
     except AppError as exc:
         sys.stderr.write(f"error: {exc.message}\n")
         return 1
-    except PlaybackE2EFixtureCliError as exc:
+    except DesktopE2EFixtureCliError as exc:
         sys.stderr.write(f"error: {exc}\n")
         return 1
     except Exception as exc:
@@ -57,13 +63,13 @@ def main(argv: list[str] | None = None) -> int:
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        prog="python -m app.cli.playback_e2e_fixture",
-        description="Create a deterministic local playback E2E fixture project.",
+        prog="python -m app.cli.desktop_e2e_fixture",
+        description="Create a deterministic local desktop E2E fixture project.",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
     create_parser = subparsers.add_parser(
         "create",
-        help="Create or refresh the playback E2E fixture.",
+        help="Create or refresh the desktop E2E fixture.",
     )
     create_parser.add_argument("--data-dir", required=True, type=Path, metavar="PATH")
     create_parser.add_argument("--work-dir", required=True, type=Path, metavar="PATH")
@@ -77,7 +83,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
 def _run_command(args: argparse.Namespace) -> dict[str, Any]:
     if args.command != "create":
-        raise PlaybackE2EFixtureCliError(f"unsupported command: {args.command}")
+        raise DesktopE2EFixtureCliError(f"unsupported command: {args.command}")
 
     data_dir = _resolve_path(args.data_dir)
     work_dir = _resolve_path(args.work_dir)
@@ -98,6 +104,8 @@ def _run_command(args: argparse.Namespace) -> dict[str, Any]:
             session,
             project=project,
             source_artifact=source_artifact,
+            data_dir=data_dir,
+            work_dir=work_dir,
         )
         session.flush()
         session.refresh(project)
@@ -116,7 +124,7 @@ def _resolve_path(path: Path) -> Path:
 def _normalize_project_name(value: str) -> str:
     normalized = value.strip()
     if not normalized:
-        raise PlaybackE2EFixtureCliError("--project-name cannot be empty")
+        raise DesktopE2EFixtureCliError("--project-name cannot be empty")
     return normalized
 
 
@@ -171,7 +179,7 @@ def _import_or_get_project(
 ) -> Project:
     source_sha256 = file_sha256(source_path)
     if source_sha256 is None:
-        raise PlaybackE2EFixtureCliError(f"could not hash fixture WAV: {source_path}")
+        raise DesktopE2EFixtureCliError(f"could not hash fixture WAV: {source_path}")
 
     expected_project_id = source_hash_to_project_id(source_sha256)
     project = session.get(Project, expected_project_id)
@@ -194,7 +202,7 @@ def _source_artifact(session: Session, *, project_id: str) -> Artifact:
         .order_by(Artifact.created_at.desc(), Artifact.id.desc())
     )
     if artifact is None:
-        raise PlaybackE2EFixtureCliError(f"project {project_id} has no source_audio artifact")
+        raise DesktopE2EFixtureCliError(f"project {project_id} has no source_audio artifact")
     return artifact
 
 
@@ -203,11 +211,100 @@ def _seed_fixture_data(
     *,
     project: Project,
     source_artifact: Artifact,
+    data_dir: Path,
+    work_dir: Path,
 ) -> None:
+    _replace_export_artifacts(
+        session,
+        project=project,
+        source_artifact=source_artifact,
+        data_dir=data_dir,
+        work_dir=work_dir,
+    )
     _upsert_analysis(session, project=project, source_artifact=source_artifact)
     _upsert_lyrics(session, project=project, source_artifact=source_artifact)
     _upsert_chords(session, project=project, source_artifact=source_artifact)
     _replace_sections(session, project=project)
+
+
+def _replace_export_artifacts(
+    session: Session,
+    *,
+    project: Project,
+    source_artifact: Artifact,
+    data_dir: Path,
+    work_dir: Path,
+) -> None:
+    """Create a small, local-only mix and stem set for the Export workspace."""
+    existing = list(
+        session.scalars(
+            select(Artifact)
+            .where(Artifact.project_id == project.id)
+            .where(Artifact.type.in_(("preview_mix", "vocal_stem", "drums_stem")))
+        )
+    )
+    for artifact in existing:
+        if artifact.metadata_json.get("fixture") == FIXTURE_ARTIFACT_MARKER:
+            session.delete(artifact)
+    session.flush()
+
+    source_file = Path(source_artifact.path).resolve()
+    _require_path_within(source_file, data_dir, "source artifact")
+    preview_path = project_previews_dir(project.id) / "fixture-practice-mix.wav"
+    vocal_path = project_stems_dir(project.id) / "fixture-export" / "vocals.wav"
+    drums_path = project_stems_dir(project.id) / "fixture-export" / "drums.wav"
+    for path in (preview_path, vocal_path, drums_path):
+        _require_path_within(path, data_dir, "fixture artifact")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        copyfile(source_file, path)
+        if not path.is_file() or not path.stat().st_size:
+            raise DesktopE2EFixtureCliError(f"could not create fixture artifact: {path.name}")
+
+    # Explicit timestamps make API order stable; the newest stems are listed first.
+    register_artifact(
+        session,
+        project_id=project.id,
+        artifact_type="preview_mix",
+        artifact_format="wav",
+        path=preview_path,
+        artifact_id="art_fixture_preview_mix",
+        metadata={"fixture": FIXTURE_ARTIFACT_MARKER, "source_artifact_id": source_artifact.id},
+        generated_by="fixture",
+        can_regenerate=False,
+        created_at=FIXTURE_ARTIFACT_CREATED_AT,
+    )
+    for offset, artifact_type, path, stem_source in (
+        (1, "vocal_stem", vocal_path, "vocals"),
+        (2, "drums_stem", drums_path, "drums"),
+    ):
+        register_artifact(
+            session,
+            project_id=project.id,
+            artifact_type=artifact_type,
+            artifact_format="wav",
+            path=path,
+            artifact_id=f"art_fixture_{stem_source}",
+            metadata={
+                "fixture": FIXTURE_ARTIFACT_MARKER,
+                "source_artifact_id": source_artifact.id,
+                "source_artifact_type": "source_audio",
+                "stem_source": stem_source,
+            },
+            generated_by="fixture",
+            can_regenerate=False,
+            created_at=FIXTURE_ARTIFACT_CREATED_AT + timedelta(seconds=offset),
+        )
+
+    _require_path_within(work_dir / FIXTURE_FILE_NAME, work_dir, "fixture source")
+
+
+def _require_path_within(path: Path, root: Path, label: str) -> None:
+    try:
+        path.resolve().relative_to(root.resolve())
+    except ValueError as exc:
+        raise DesktopE2EFixtureCliError(
+            f"{label} must stay inside the supplied fixture data or work directory"
+        ) from exc
 
 
 def _upsert_analysis(

--- a/apps/backend/tests/test_desktop_e2e_fixture.py
+++ b/apps/backend/tests/test_desktop_e2e_fixture.py
@@ -6,18 +6,18 @@ from pathlib import Path
 import pytest
 from sqlalchemy import select
 
-from app.cli import playback_e2e_fixture
+from app.cli import desktop_e2e_fixture
 from app.models import AnalysisResult, Artifact, ChordTimeline, LyricsTranscript, Project, SongSection
 
 
-def test_create_playback_e2e_fixture_seeds_project_data(
+def test_create_desktop_e2e_fixture_seeds_project_data(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     data_dir = tmp_path / "fixture-data"
     work_dir = tmp_path / "fixture-work"
 
-    exit_code = playback_e2e_fixture.main(
+    exit_code = desktop_e2e_fixture.main(
         [
             "create",
             "--data-dir",
@@ -65,6 +65,42 @@ def test_create_playback_e2e_fixture_seeds_project_data(
         assert source_artifact.content_sha256
         assert source_artifact.metadata_json["source_path"] == payload["source_path"]
         assert Path(source_artifact.path).exists()
+
+        export_artifacts = list(
+            session.scalars(
+                select(Artifact)
+                .where(Artifact.project_id == project.id)
+                .where(Artifact.type.in_(("preview_mix", "vocal_stem", "drums_stem")))
+                .order_by(Artifact.created_at.asc())
+            )
+        )
+        assert [artifact.type for artifact in export_artifacts] == [
+            "preview_mix",
+            "vocal_stem",
+            "drums_stem",
+        ]
+        preview_mix, vocal_stem, drums_stem = export_artifacts
+        assert preview_mix.metadata_json == {
+            "fixture": "desktop-e2e",
+            "source_artifact_id": source_artifact.id,
+        }
+        assert [stem.metadata_json["source_artifact_id"] for stem in (vocal_stem, drums_stem)] == [
+            source_artifact.id,
+            source_artifact.id,
+        ]
+        assert [stem.metadata_json["stem_source"] for stem in (vocal_stem, drums_stem)] == [
+            "vocals",
+            "drums",
+        ]
+        for artifact in export_artifacts:
+            artifact_path = Path(artifact.path).resolve()
+            assert artifact.format == "wav"
+            assert artifact.generated_by == "fixture"
+            assert artifact.can_regenerate is False
+            assert artifact.content_sha256
+            assert artifact.size_bytes > 0
+            assert artifact_path.is_file()
+            assert artifact_path.is_relative_to(data_dir.resolve())
 
         analysis = session.get(AnalysisResult, project.id)
         assert analysis is not None

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint .",
     "tauri": "bash ../../scripts/run-tauri-command.sh",
     "test": "vitest",
-    "test:e2e": "node ../../scripts/playback-smoke.mjs",
+    "test:e2e": "node ../../scripts/desktop-e2e.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/docs/NATIVE_AUDIO.md
+++ b/docs/NATIVE_AUDIO.md
@@ -162,7 +162,7 @@ Use this matrix for local regressions against source, practice-mix, and stems.
 Run once with native playback selected per platform, then rerun with forced Web Audio.
 
 Coverage label: manual/special unless a CI workflow explicitly runs the same command and capture
-mode. The matrix, loopback browser smoke, Linux `--route-output`, macOS AVFoundation capture, and
+mode. The matrix, loopback browser E2E suite, Linux `--route-output`, macOS AVFoundation capture, and
 BlackHole capture are release checks, not default `pnpm test` coverage.
 
 | Check | Native macOS | Native Linux | Forced Web Audio (`VITE_TUNEFORGE_FORCE_WEB_AUDIO=1`) |
@@ -187,42 +187,63 @@ BlackHole capture are release checks, not default `pnpm test` coverage.
 For manual Linux, macOS, Android, and browser power validation, use the owner-specific evidence and
 release checks in [POWER_PROTECTION.md](./POWER_PROTECTION.md#validation).
 
-## Local-only Playwright Smoke Harness
+## Local-only Playwright Desktop E2E Suite
 
-Scaffold file: `scripts/playback-smoke.mjs` (local only, not wired to CI or default gates). This is
-a browser-based smoke check for the frontend transport path; native output still needs the manual
-matrix above. The automated path uses generated fixture audio only; do not use copyrighted audio.
-The isolated smoke pass requires `window.__TUNEFORGE_PLAYBACK_E2E__.read()` and asserts song-start
+Suite file: `scripts/desktop-e2e.mjs`. `--run` executes all headless-capable groups in catalog order:
+generated-fixture playback, diagnostics, and the Export workspace. `--ci` separately expresses the
+CI-approved policy; it currently runs the same three groups, but can diverge without changing `--run`.
+Neither selector includes audio capture, and the suite is not part of the default `pnpm test` suite.
+This is a browser-based desktop E2E suite; its playback group checks the frontend transport path, while
+native output still needs the manual matrix above. The automated path uses generated fixture audio only;
+do not use copyrighted audio. The isolated playback group requires `window.__TUNEFORGE_PLAYBACK_E2E__.read()` and asserts song-start
 count-in scheduling/firing before loop setup, loop pre-count scheduling/firing during loop playback,
 and transport telemetry. Native transport/buffer health is checked only when telemetry reports native
 playback is the active path. Manual app mode remains backward-compatible and skips telemetry-only
 assertions when that bridge is unavailable.
 
-`pnpm setup:dev` installs the Playwright Chromium browser needed by this smoke check; use
+`pnpm setup:dev` installs the Playwright Chromium browser needed by this suite; use
 `pnpm setup:dev -- --skip-playwright-browsers` to skip that download.
 
-Check that the local smoke scaffold is available:
+Check that the local desktop E2E suite is available:
 
 ```sh
 pnpm --filter @tuneforge/desktop test:e2e
 ```
 
-Run the isolated smoke pass:
+Run all headless-capable groups:
 
 ```sh
 pnpm --filter @tuneforge/desktop test:e2e -- --run
 ```
 
-Run the optional Linux virtual-audio capture smoke:
+Run the CI-approved selector policy:
 
 ```sh
-pnpm --filter @tuneforge/desktop test:e2e -- --run --route-output
+pnpm --filter @tuneforge/desktop test:e2e -- --ci
 ```
 
-Run the optional macOS AVFoundation capture smoke with an explicit capture device:
+Run every group, including audio capture. A headed browser is currently recommended for working capture:
 
 ```sh
-pnpm --filter @tuneforge/desktop test:e2e -- --run --capture-provider=avfoundation --capture-device="BlackHole 2ch"
+pnpm --filter @tuneforge/desktop test:e2e -- --all --headed
+```
+
+Run only the CI-safe Export workspace journey without submitting an export or opening a native picker:
+
+```sh
+pnpm --filter @tuneforge/desktop test:e2e -- --group export
+```
+
+Run the optional Linux virtual-audio capture group:
+
+```sh
+pnpm --filter @tuneforge/desktop test:e2e -- --run --route-output --headed
+```
+
+Run the optional macOS AVFoundation capture group with an explicit capture device:
+
+```sh
+pnpm --filter @tuneforge/desktop test:e2e -- --run --capture-provider=avfoundation --capture-device="BlackHole 2ch" --headed
 ```
 
 Use the same local debugging flags when needed. On macOS, replace `--route-output` with the explicit
@@ -230,23 +251,26 @@ Use the same local debugging flags when needed. On macOS, replace `--route-outpu
 
 ```sh
 pnpm --filter @tuneforge/desktop test:e2e -- --run --route-output --headed
-pnpm --filter @tuneforge/desktop test:e2e -- --run --route-output --keep-artifacts
-pnpm --filter @tuneforge/desktop test:e2e -- --run --route-output --backend-port=<port> --app-port=<port>
+pnpm --filter @tuneforge/desktop test:e2e -- --run --route-output --keep-artifacts --headed
+pnpm --filter @tuneforge/desktop test:e2e -- --run --route-output --backend-port=<port> --app-port=<port> --headed
 ```
 
 The isolated run prepares temporary app data and a temporary database, creates a deterministic
-generated fixture project, starts the backend and frontend, runs the smoke flow, then cleans the
+generated fixture project, starts the backend and frontend, runs the E2E flow, then cleans the
 temporary data by default. Use `--keep-artifacts` to retain temporary paths and logs for debugging.
 If a local port is already in use, pass `--backend-port=<port>` or `--app-port=<port>`. The isolated
 backend allows only the selected loopback frontend origin so browser CORS stays enabled.
 
 `--route-output` is Linux-only and should be used only for isolated generated-fixture runs. It must
 not be combined with `--manual-app`, because virtual output capture is intended to avoid personal
-libraries and user audio. Without `--route-output`, the smoke does not change system audio routing.
-With `--route-output` on Linux, the smoke records the fixture playback through a temporary virtual
+libraries and user audio. `--headed` is a launch-mode option, not a capture policy: it is currently
+recommended (and typically needed) for working capture, but headless attempts are allowed so future
+browser and platform support can succeed without changing the selector contract. Without `--route-output`,
+the E2E suite does not change system audio routing.
+With `--route-output` on Linux, the capture group records fixture playback through a temporary virtual
 output path and restores the previous output route during cleanup. If routing, recording, or platform
 support is missing, the virtual-capture portion fails or skips with a clear message; the standard
-browser smoke still reports its own pass/fail result separately.
+browser E2E suite still reports its own pass/fail result separately.
 
 On Linux, use a PipeWire desktop with the PulseAudio compatibility service (`pipewire-pulse`) or a
 PulseAudio session, and make sure `pactl` plus either `pw-record` or `parecord` are available on
@@ -260,12 +284,12 @@ sudo pacman -S pipewire-pulse pipewire-audio libpulse
 sudo apt-get install pipewire-pulse pulseaudio-utils pipewire-bin
 ```
 
-The smoke creates a temporary null sink only when `--route-output` is present, routes playback to
+The capture group creates a temporary null sink only when `--route-output` is present, routes playback to
 that sink, records the sink through the selected local provider, then restores the previous default
 sink and unloads the temporary sink. With PipeWire, the smoke resolves the temp sink's
 `object.serial` and passes that serial to `pw-record --target`; the sidecar still records the
 Pulse/PipeWire monitor source as the logical device. If `pactl` cannot create the sink, no default
-sink can be restored, or capture is unavailable, keep artifacts and inspect the smoke logs before
+sink can be restored, or capture is unavailable, keep artifacts and inspect the E2E logs before
 rerunning.
 
 On macOS, install a local BlackHole device and `ffmpeg` first, then verify AVFoundation can see it:
@@ -282,10 +306,10 @@ Select the BlackHole device with `--capture-device=<name-or-id>` if more than on
 device is installed. macOS capture does not support `--route-output` and the smoke does not switch or
 restore the default output device. Configure any Multi-Output Device or output routing manually
 before running the smoke if you want to listen while capturing. Tauri WebDriver cannot automate the
-WKWebView on macOS, so this capture path validates the local browser smoke and explicit AVFoundation
+WKWebView on macOS, so this capture path validates the local browser E2E suite and explicit AVFoundation
 capture rather than automating the packaged Tauri WebView.
 
-With `--keep-artifacts`, virtual-capture runs retain the temporary root printed by the smoke. Expect
+With `--keep-artifacts`, virtual-capture runs retain the temporary root printed by the E2E suite. Expect
 the fixture data directory, backend/frontend child-process logs, the captured audio file, and any
 platform routing logs or metadata that describe the selected virtual sink/device. Custom
 `--capture-output` paths must end in `.wav`, because the capture analyzer reads WAV output. Without
@@ -302,6 +326,6 @@ pnpm --filter @tuneforge/desktop test:e2e -- --run --manual-app --project-id=<id
 Manual app mode requires the app to already be running. Use it only when you need an existing
 personal project instead of the generated fixture.
 
-For full coverage, use a fixture project with timed lyrics or chords. The smoke pass always checks
+For full coverage, use a fixture project with timed lyrics or chords. The playback group always checks
 stopped scrubber start, and it also checks stopped lyrics/chords start when a timed practice target
-is available. It remains a local/manual diagnostic, not a CI gate and not part of `pnpm test`.
+is available. Native output and virtual-audio capture remain local/manual diagnostics, not CI gates.

--- a/scripts/desktop-e2e.mjs
+++ b/scripts/desktop-e2e.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import assert from "node:assert/strict";
 import process from "node:process";
 import net from "node:net";
 import { spawn } from "node:child_process";
@@ -22,16 +23,19 @@ const CAPTURE_STARTUP_GRACE_MS = 1000;
 const CAPTURE_ANALYZER_TIMEOUT_MS = 120_000;
 const SUPPORTED_CAPTURE_PROVIDERS = new Set(["auto", "pipewire", "pulse", "avfoundation"]);
 const SMOKE_GROUPS = [
-  { name: "playback", description: "Generated-fixture playback controls smoke.", ci: true },
-  { name: "diagnostics", description: "Sanitized import and processing diagnostics smoke.", ci: true },
-  { name: "audio-capture", description: "Playback smoke with required local audio capture.", ci: false },
+  { name: "playback", description: "Generated-fixture playback controls smoke." },
+  { name: "diagnostics", description: "Sanitized import and processing diagnostics smoke." },
+  { name: "export", description: "Generated-fixture Export workspace smoke." },
+  { name: "audio-capture", description: "Playback smoke with required local audio capture." },
 ];
+export const HEADLESS_CAPABLE_GROUPS = ["playback", "diagnostics", "export"];
+export const CI_APPROVED_GROUPS = ["playback", "diagnostics", "export"];
 
 if (isDirectRun()) {
   try {
     await main();
   } catch (error) {
-    console.error(`[playback-smoke] ${errorMessage(error)}`);
+    console.error(`[desktop-e2e] ${errorMessage(error)}`);
     process.exitCode = 1;
   }
 }
@@ -64,7 +68,7 @@ async function main() {
   if (options.projectId) {
     throw new Error(
       [
-        "Isolated playback smoke creates its own fixture project.",
+        "Isolated desktop E2E creates its own fixture project.",
         'Use manual mode for an existing project: pnpm --filter @tuneforge/desktop test:e2e -- --run --manual-app --project-id="<id>"',
       ].join("\n"),
     );
@@ -74,7 +78,7 @@ async function main() {
 }
 
 async function runGroups(options) {
-  if (options.manualApp && options.groups.some((group) => group === "diagnostics")) {
+  if (options.manualApp && options.groups.some((group) => group === "diagnostics" || group === "export")) {
     throw new Error("Manual-app mode supports only playback and audio-capture groups.");
   }
   for (const group of options.groups) {
@@ -90,9 +94,9 @@ async function runGroups(options) {
           await runIsolatedSmoke(groupOptions);
         }
       }
-      console.log(`[playback-smoke] group ${group}: passed in ${formatDuration(performance.now() - startedAt)}.`);
+      console.log(`[desktop-e2e] group ${group}: passed in ${formatDuration(performance.now() - startedAt)}.`);
     } catch (error) {
-      console.error(`[playback-smoke] group ${group}: failed in ${formatDuration(performance.now() - startedAt)}.`);
+      console.error(`[desktop-e2e] group ${group}: failed in ${formatDuration(performance.now() - startedAt)}.`);
       throw error;
     }
   }
@@ -101,6 +105,7 @@ async function runGroups(options) {
 export function optionsForGroup(options, group) {
   return {
     ...options,
+    smokeGroup: group,
     captureAudio: group === "audio-capture",
     requireAudioCapture: group === "audio-capture",
   };
@@ -111,24 +116,29 @@ function formatDuration(durationMs) {
 }
 
 function printGroups() {
-  console.log("[playback-smoke] available groups:");
+  console.log("[desktop-e2e] available groups:");
   for (const group of SMOKE_GROUPS) {
-    console.log(`  ${group.name}${group.ci ? " (CI)" : ""}: ${group.description}`);
+    console.log(`  ${group.name}${CI_APPROVED_GROUPS.includes(group.name) ? " (CI)" : ""}: ${group.description}`);
   }
 }
 
 function printScaffold() {
-  console.log("[playback-smoke] Local smoke scaffold is available.");
-  console.log("Run isolated smoke with generated fixture data:");
+  console.log("[desktop-e2e] Local desktop E2E suite is available.");
+  console.log("Run all headless-capable groups (playback, diagnostics, export):");
   console.log("  pnpm --filter @tuneforge/desktop test:e2e -- --run");
+  console.log("Run the CI-approved group policy (currently the same three groups):");
+  console.log("  pnpm --filter @tuneforge/desktop test:e2e -- --ci");
+  console.log("Run every group, including audio capture (headed is currently recommended):");
+  console.log("  pnpm --filter @tuneforge/desktop test:e2e -- --all --headed");
   console.log("Run against an existing personal library app:");
   console.log(
     '  pnpm --filter @tuneforge/desktop test:e2e -- --run --manual-app --project-name="Demo Song"',
   );
-  console.log("Optional local virtual-audio capture:");
+  console.log("Optional local virtual-audio capture (headed is currently recommended):");
   console.log(
-    "  pnpm --filter @tuneforge/desktop test:e2e -- --run --capture-audio --route-output",
+    "  pnpm --filter @tuneforge/desktop test:e2e -- --run --capture-audio --route-output --headed",
   );
+  console.log("Headless capture attempts are allowed and report unsupported runtime behavior directly.");
 }
 
 async function runManualSmoke(options) {
@@ -182,7 +192,8 @@ async function runManualSmoke(options) {
 async function runIsolatedSmoke(options) {
   const appPort = await selectPort(options.appPort, new Set(), "desktop dev server");
   const backendPort = await selectPort(options.backendPort, new Set([appPort]), "backend");
-  const tempRoot = await mkdtemp(join(tmpdir(), "tuneforge-playback-smoke-"));
+  const smokeGroup = options.smokeGroup ?? "playback";
+  const tempRoot = await mkdtemp(join(tmpdir(), `tuneforge-${smokeGroup}-smoke-`));
   const dataDir = join(tempRoot, "data");
   const workDir = join(tempRoot, "work");
   const children = [];
@@ -194,7 +205,7 @@ async function runIsolatedSmoke(options) {
     await mkdir(dataDir, { recursive: true });
     await mkdir(workDir, { recursive: true });
     logStep(`Using temp root ${tempRoot}.`);
-    fixture = await createPlaybackFixture({ dataDir, workDir, projectName: options.projectName });
+    fixture = await createDesktopE2EFixture({ dataDir, workDir, projectName: options.projectName });
     logStep(
       `Seeded fixture project ${fixture.project_id} (${fixture.project_name ?? "unnamed"}) in ${dataDir}.`,
     );
@@ -250,7 +261,7 @@ async function runIsolatedSmoke(options) {
       onStop: (result) => {
         captureResult = result;
       },
-      run: async (capture) => runSmoke({
+      run: async (capture) => (smokeGroup === "export" ? runExportSmoke : runSmoke)({
         appUrl,
         projectId: fixture.project_id,
         projectName: fixture.project_name ?? "",
@@ -261,11 +272,14 @@ async function runIsolatedSmoke(options) {
         captureTiming: Boolean(capture),
         captureTimingRequired: Boolean(capture) && options.requireAudioCapture,
         failureArtifactRoot: tempRoot,
+        failureGroup: smokeGroup,
       }),
     });
   } catch (error) {
     failed = true;
-    await writeSmokeFailureSummary(tempRoot, "isolated playback setup");
+    if (!(await smokeFailureSummaryExists(tempRoot, smokeGroup))) {
+      await writeSmokeFailureSummary(tempRoot, smokeGroup, "isolated desktop E2E setup");
+    }
     throw error;
   } finally {
     await stopChildren(children);
@@ -288,6 +302,7 @@ async function runSmoke({
   captureTiming = false,
   captureTimingRequired = false,
   failureArtifactRoot = "",
+  failureGroup = "playback",
 }) {
   let chromium;
   try {
@@ -456,7 +471,7 @@ async function runSmoke({
 } catch (error) {
   recordPhase("smoke:error", { message: errorMessage(error) });
   if (failureArtifactRoot) {
-    await writeSmokeFailureArtifacts(failureArtifactRoot, page, stage);
+    await writeSmokeFailureArtifacts(failureArtifactRoot, page, failureGroup, stage);
   }
   throw error;
 } finally {
@@ -464,20 +479,211 @@ async function runSmoke({
 }
 }
 
-async function writeSmokeFailureArtifacts(root, page, stage) {
-  await mkdir(root, { recursive: true });
-  if (page) {
-    await page.screenshot({ path: join(root, "playback-failure.png"), fullPage: true }).catch(() => {});
+async function runExportSmoke({ appUrl, projectId, projectName, projectUrl, headed, failureArtifactRoot }) {
+  let chromium;
+  try {
+    ({ chromium } = desktopRequire("playwright"));
+  } catch {
+    throw new Error("Playwright is not installed locally. Run pnpm setup:dev before the Export smoke.");
   }
-  await writeSmokeFailureSummary(root, stage);
+
+  const browser = await chromium.launch({ headless: !headed });
+  let page;
+  let stage = "opening Export workspace";
+  try {
+    for (const viewport of [
+      { label: "wide", width: 1440, height: 1100 },
+      { label: "narrow", width: 600, height: 1000 },
+    ]) {
+      page = await browser.newPage({ viewport: { width: viewport.width, height: viewport.height } });
+      const exportPosts = [];
+      page.on("request", (request) => {
+        if (request.method() === "POST" && /\/api\/v1\/projects\/[^/]+\/export(?:\?|$)/.test(request.url())) {
+          exportPosts.push(request.url());
+        }
+      });
+      stage = `${viewport.label} Export workspace journey`;
+      await runExportJourney(page, {
+        appUrl,
+        projectId,
+        projectName,
+        projectUrl,
+        viewport,
+      });
+      assert.deepEqual(exportPosts, [], "Export smoke must not submit an export request.");
+      await page.close();
+      page = null;
+    }
+    logStep("Export workspace smoke passed at wide and narrow viewports without an export submission.");
+  } catch (error) {
+    if (failureArtifactRoot) {
+      await writeSmokeFailureArtifacts(failureArtifactRoot, page, "export", stage);
+    }
+    throw error;
+  } finally {
+    await browser.close();
+  }
 }
 
-async function writeSmokeFailureSummary(root, stage) {
+async function runExportJourney(page, { appUrl, projectId, projectName, projectUrl, viewport }) {
+  await openProject(page, { appUrl, projectId, projectName, projectUrl });
+  await activateExportWithKeyboard(page);
+  await page.getByRole("heading", { name: "Export files" }).waitFor();
+  await page.getByRole("button", { name: "Reset export workspace" }).click();
+  await assertExportSelection(page, { preset: "track-and-stems", selectedCount: 3 });
+
+  const presetButtons = page.locator(".export-presets > button");
+  assert.deepEqual(await presetButtons.allTextContents(), ["Track + all stems", "Track only", "All stems"]);
+  await assertExportPreview(page, [
+    "Tuneforge E2E Fixture - Source.wav",
+    "Tuneforge E2E Fixture - Source - Drums.wav",
+    "Tuneforge E2E Fixture - Source - Vocals.wav",
+  ]);
+
+  const fileButton = page.getByRole("button", { name: "File", exact: true });
+  const folderButton = page.getByRole("button", { name: "Folder", exact: true });
+  const zipButton = page.getByRole("button", { name: "ZIP", exact: true });
+  assert.equal(await fileButton.isDisabled(), true);
+  const multiItemReason = await fileButton.getAttribute("aria-describedby");
+  assert.ok(multiItemReason);
+  assert.match(await page.locator(`#${multiItemReason}`).innerText(), /Multiple items require Folder or ZIP/);
+  assert.equal(await folderButton.isEnabled(), true);
+  assert.equal(await zipButton.isEnabled(), true);
+
+  await folderButton.click();
+  await assertExportSummary(page, "3 items", "Folder · Choose on export");
+  await assertDestinationGeometry(page, viewport);
+
+  await activateButtonWithKeyboard(page.getByRole("button", { name: "Track only", exact: true }));
+  await assertExportSelection(page, { preset: "track", selectedCount: 1 });
+  assert.equal(await fileButton.isEnabled(), true);
+  assert.equal(await fileButton.getAttribute("aria-pressed"), "true");
+  assert.equal(await folderButton.isDisabled(), true);
+  assert.equal(await zipButton.isDisabled(), true);
+  const singleItemReason = await folderButton.getAttribute("aria-describedby");
+  assert.ok(singleItemReason);
+  assert.match(await page.locator(`#${singleItemReason}`).innerText(), /Choose File for one item/);
+  await assertExportSummary(page, "1 item", "File · Choose on export");
+  await assertExportPreview(page, ["Tuneforge E2E Fixture - Source.wav"]);
+
+  await activateButtonWithKeyboard(page.getByRole("button", { name: "All stems", exact: true }));
+  await assertExportSelection(page, { preset: "stems", selectedCount: 2 });
+  assert.equal(await fileButton.isDisabled(), true);
+  assert.equal(await folderButton.isEnabled(), true);
+  assert.equal(await folderButton.getAttribute("aria-pressed"), "true");
+  assert.equal(await zipButton.isEnabled(), true);
+  await assertExportSummary(page, "2 items", "Folder · Choose on export");
+  await assertExportPreview(page, [
+    "Tuneforge E2E Fixture - Source - Drums.wav",
+    "Tuneforge E2E Fixture - Source - Vocals.wav",
+  ]);
+
+  await activateButtonWithKeyboard(page.getByRole("button", { name: "Track + all stems", exact: true }));
+  await assertExportSelection(page, { preset: "track-and-stems", selectedCount: 3 });
+  await folderButton.click();
+  await assertExportSummary(page, "3 items", "Folder · Choose on export");
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await activateExportWithKeyboard(page);
+  await assertExportSelection(page, { preset: "track-and-stems", selectedCount: 3 });
+  await assertExportSummary(page, "3 items", "Folder · Choose on export");
+}
+
+async function activateExportWithKeyboard(page) {
+  const studioTab = page.getByRole("tab", { name: "Studio", exact: true });
+  await studioTab.focus();
+  await studioTab.press("ArrowRight");
+  await page.getByRole("tab", { name: "Analysis", exact: true }).press("ArrowRight");
+  const exportTab = page.getByRole("tab", { name: "Export", exact: true });
+  await exportTab.waitFor();
+  assert.equal(await exportTab.getAttribute("aria-selected"), "true");
+}
+
+async function activateButtonWithKeyboard(button) {
+  await button.focus();
+  await button.press("Enter");
+}
+
+async function assertExportSelection(page, { preset, selectedCount }) {
+  const selection = page.locator("fieldset.export-artifact-list").first();
+  await selection.waitFor();
+  const inputs = selection.locator('input[type="checkbox"]');
+  assert.equal(await inputs.count(), 3);
+  assert.deepEqual(await selection.locator("label.export-artifact-row strong").allTextContents(), [
+    "Source Track",
+    "Drums",
+    "Vocals",
+  ]);
+  assert.equal(await inputs.evaluateAll((items) => items.filter((item) => item.checked).length), selectedCount);
+  assert.equal(await page.locator(".export-presets > button[aria-pressed=\"true\"]").innerText(), {
+    track: "Track only",
+    stems: "All stems",
+    "track-and-stems": "Track + all stems",
+  }[preset]);
+}
+
+async function assertExportSummary(page, itemCount, destination) {
+  const summary = page.getByTestId("export-compact-summary");
+  assert.match(await summary.innerText(), new RegExp(`${itemCount}\\s+${destination.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}`));
+}
+
+async function assertExportPreview(page, names) {
+  assert.deepEqual(await page.locator('.export-preview__group[aria-label="Audio"] li').allTextContents(), names);
+}
+
+async function assertDestinationGeometry(page, viewport) {
+  const destinations = page.locator(".export-destination-option .button");
+  await destinations.first().scrollIntoViewIfNeeded();
+  const geometry = await destinations.evaluateAll((buttons) => ({
+    viewport: { width: window.innerWidth, height: window.innerHeight },
+    buttons: buttons.map((button) => {
+      const rect = button.getBoundingClientRect();
+      return { left: rect.left, right: rect.right, top: rect.top, bottom: rect.bottom, width: rect.width, height: rect.height };
+    }),
+  }));
+  assert.equal(geometry.viewport.width, viewport.width);
+  assert.equal(geometry.buttons.length, 3);
+  const widths = geometry.buttons.map((button) => button.width);
+  assert.ok(Math.max(...widths) - Math.min(...widths) <= 1, "Destination controls must have equal widths.");
+  for (const button of geometry.buttons) {
+    assert.ok(button.width >= 44, "Destination controls must be at least 44px wide.");
+    assert.ok(button.height >= 44, "Destination controls must be at least 44px tall.");
+    assert.ok(button.left >= 0 && button.right <= geometry.viewport.width, "Destination control leaves the viewport horizontally.");
+    assert.ok(button.top >= 0 && button.bottom <= geometry.viewport.height, "Destination control leaves the viewport vertically.");
+  }
+  for (let index = 0; index < geometry.buttons.length; index += 1) {
+    for (let other = index + 1; other < geometry.buttons.length; other += 1) {
+      const left = geometry.buttons[index];
+      const right = geometry.buttons[other];
+      const overlaps = left.left < right.right && left.right > right.left && left.top < right.bottom && left.bottom > right.top;
+      assert.equal(overlaps, false, "Destination controls must not overlap.");
+    }
+  }
+}
+
+async function writeSmokeFailureArtifacts(root, page, group, stage) {
   await mkdir(root, { recursive: true });
+  const files = failureArtifactNames(group);
+  if (page) {
+    await page.screenshot({ path: join(root, files.image), fullPage: true }).catch(() => {});
+  }
+  await writeSmokeFailureSummary(root, group, stage);
+}
+
+async function writeSmokeFailureSummary(root, group, stage) {
+  await mkdir(root, { recursive: true });
+  const files = failureArtifactNames(group);
   await writeFile(
-    join(root, "playback-failure-summary.json"),
-    JSON.stringify({ group: "playback", result: "failed", stage, error: "Playback smoke failed." }),
+    join(root, files.summary),
+    JSON.stringify({ group, result: "failed", stage, error: "Smoke group failed." }),
   );
+}
+
+async function smokeFailureSummaryExists(root, group) {
+  return stat(join(root, failureArtifactNames(group).summary)).then(() => true).catch(() => false);
+}
+
+export function failureArtifactNames(group) {
+  return { image: `${group}-failure.png`, summary: `${group}-failure-summary.json` };
 }
 
 export function parseOptions(argv) {
@@ -488,7 +694,8 @@ export function parseOptions(argv) {
   const captureProvider = readCaptureProviderOption(parsed);
   const captureDevice = readStringOption(parsed, "capture-device");
   const captureOutput = readStringOption(parsed, "capture-output");
-  const selectedGroups = selectGroups(parsed);
+  const explicitlySelectedGroups = selectGroups(parsed);
+  const runRequested = readFlag(parsed, "run");
   const captureAudio = readFlag(parsed, "capture-audio")
     || requireAudioCapture
     || routeOutput
@@ -501,14 +708,19 @@ export function parseOptions(argv) {
     || process.env.TUNEFORGE_SMOKE_PROJECT_NAME
     || "";
 
-  if (selectedGroups.length && captureAudio && !selectedGroups.includes("audio-capture")) {
+  const groups = explicitlySelectedGroups.length
+    ? explicitlySelectedGroups
+    : runRequested && !manualApp && !captureAudio
+      ? groupsInCatalogOrder(HEADLESS_CAPABLE_GROUPS)
+      : [];
+
+  if (groups.length && captureAudio && !groups.includes("audio-capture")) {
     throw new Error("Selected groups do not accept capture flags; include --group audio-capture or use --all.");
   }
-
   return {
-    run: readFlag(parsed, "run") || selectedGroups.length > 0,
+    run: runRequested || groups.length > 0,
     list: readFlag(parsed, "list"),
-    groups: selectedGroups,
+    groups,
     manualApp,
     keepArtifacts: readFlag(parsed, "keep-artifacts"),
     headed: readFlag(parsed, "headed"),
@@ -530,8 +742,10 @@ export function parseOptions(argv) {
 
 function selectGroups(parsed) {
   const rawGroups = parsed.values.get("group") ?? [];
+  const validGroups = SMOKE_GROUPS.map((group) => group.name);
+  const validGroupsMessage = `Valid groups: ${validGroups.join(", ")}.`;
   if (parsed.flags.has("group") || rawGroups.some((group) => !group.trim())) {
-    throw new Error("--group requires a group name. Valid groups: playback, diagnostics, audio-capture.");
+    throw new Error(`--group requires a group name. ${validGroupsMessage}`);
   }
   const requestedGroups = readStringOptions(parsed, "group");
   const ci = readFlag(parsed, "ci");
@@ -543,16 +757,20 @@ function selectGroups(parsed) {
     throw new Error("--ci cannot be combined with --all.");
   }
   const selected = all
-    ? SMOKE_GROUPS.map((group) => group.name)
+    ? groupsInCatalogOrder(SMOKE_GROUPS.map((group) => group.name))
     : ci
-      ? SMOKE_GROUPS.filter((group) => group.ci).map((group) => group.name)
+      ? groupsInCatalogOrder(CI_APPROVED_GROUPS)
       : requestedGroups;
-  const validGroups = SMOKE_GROUPS.map((group) => group.name);
   const unknown = selected.filter((group) => !validGroups.includes(group));
   if (unknown.length) {
-    throw new Error(`Unknown --group ${unknown.map((group) => `"${group}"`).join(", ")}. Valid groups: ${validGroups.join(", ")}.`);
+    throw new Error(`Unknown --group ${unknown.map((group) => `"${group}"`).join(", ")}. ${validGroupsMessage}`);
   }
   return validGroups.filter((group) => selected.includes(group));
+}
+
+function groupsInCatalogOrder(groupNames) {
+  const selected = new Set(groupNames);
+  return SMOKE_GROUPS.map((group) => group.name).filter((name) => selected.has(name));
 }
 
 function parseCliArgs(argv) {
@@ -1535,7 +1753,7 @@ function roundSeconds(value) {
 async function selectPort(preferredPort, excludedPorts, label) {
   if (preferredPort !== null) {
     if (excludedPorts.has(preferredPort)) {
-      throw new Error(`Port ${preferredPort} conflicts with another smoke process port.`);
+      throw new Error(`Port ${preferredPort} conflicts with another desktop E2E process port.`);
     }
     await assertPortAvailable(preferredPort, label);
     return preferredPort;
@@ -1548,7 +1766,7 @@ async function selectPort(preferredPort, excludedPorts, label) {
     }
   }
 
-  throw new Error("Could not allocate a free local port for isolated playback smoke.");
+  throw new Error("Could not allocate a free local port for isolated desktop E2E.");
 }
 
 async function getFreePort() {
@@ -1589,10 +1807,10 @@ async function assertPortAvailable(port, label) {
   }
 }
 
-async function createPlaybackFixture({ dataDir, workDir, projectName }) {
+async function createDesktopE2EFixture({ dataDir, workDir, projectName }) {
   const args = [
     "scripts/run-backend-module.sh",
-    "app.cli.playback_e2e_fixture",
+    "app.cli.desktop_e2e_fixture",
     "create",
     "--data-dir",
     dataDir,
@@ -1834,7 +2052,7 @@ function delay(ms) {
 }
 
 function logStep(message) {
-  console.log(`[playback-smoke] ${message}`);
+  console.log(`[desktop-e2e] ${message}`);
 }
 
 function formatSeconds(value) {

--- a/scripts/desktop-e2e.test.mjs
+++ b/scripts/desktop-e2e.test.mjs
@@ -2,37 +2,73 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  CI_APPROVED_GROUPS,
+  HEADLESS_CAPABLE_GROUPS,
   buildCaptureSidecar,
+  failureArtifactNames,
   findPactlSinkBlock,
   optionsForGroup,
   pactlProperty,
   parseOptions,
   validateCaptureOutputPath,
-} from "./playback-smoke.mjs";
+} from "./desktop-e2e.mjs";
 
-test("selects groups in catalog order and makes selectors runnable", () => {
+test("declares headless and CI group catalogs independently", () => {
+  assert.deepEqual(HEADLESS_CAPABLE_GROUPS, ["playback", "diagnostics", "export"]);
+  assert.deepEqual(CI_APPROVED_GROUPS, ["playback", "diagnostics", "export"]);
+});
+
+test("selects exact requested groups in catalog order and makes selectors runnable", () => {
   const options = parseOptions(["--group", "audio-capture", "--group=playback"]);
 
   assert.equal(options.run, true);
+  assert.equal(options.headed, false);
   assert.deepEqual(options.groups, ["playback", "audio-capture"]);
 });
 
-test("maps CI and all selectors to their intended groups", () => {
-  assert.deepEqual(parseOptions(["--ci"]).groups, ["playback", "diagnostics"]);
-  assert.deepEqual(parseOptions(["--all"]).groups, ["playback", "diagnostics", "audio-capture"]);
+test("maps bare run, CI, and all selectors to their intended groups", () => {
+  assert.deepEqual(parseOptions(["--run"]).groups, ["playback", "diagnostics", "export"]);
+  assert.deepEqual(parseOptions(["--ci"]).groups, ["playback", "diagnostics", "export"]);
+  const all = parseOptions(["--all"]);
+  assert.equal(all.headed, false);
+  assert.deepEqual(all.groups, ["playback", "diagnostics", "export", "audio-capture"]);
+});
+
+test("leaves no-flag invocation in scaffold mode", () => {
+  const options = parseOptions([]);
+
+  assert.equal(options.run, false);
+  assert.equal(options.list, false);
+  assert.deepEqual(options.groups, []);
 });
 
 test("rejects conflicting or unknown group selectors", () => {
   assert.throws(() => parseOptions(["--group", "playback", "--ci"]), /cannot be combined/);
-  assert.throws(() => parseOptions(["--group", "missing"]), /Valid groups: playback, diagnostics, audio-capture/);
-  assert.throws(() => parseOptions(["--group"]), /--group requires a group name/);
-  assert.throws(() => parseOptions(["--group="]), /--group requires a group name/);
+  assert.throws(
+    () => parseOptions(["--group", "missing"]),
+    (error) => error instanceof Error && error.message ===
+      "Unknown --group \"missing\". Valid groups: playback, diagnostics, export, audio-capture.",
+  );
+  assert.throws(
+    () => parseOptions(["--group"]),
+    (error) => error instanceof Error && error.message ===
+      "--group requires a group name. Valid groups: playback, diagnostics, export, audio-capture.",
+  );
+  assert.throws(
+    () => parseOptions(["--group="]),
+    (error) => error instanceof Error && error.message ===
+      "--group requires a group name. Valid groups: playback, diagnostics, export, audio-capture.",
+  );
 });
 
-test("keeps legacy capture optional but makes selected capture strict", () => {
+test("keeps capture launch mode optional while selected capture remains strict", () => {
   const legacy = parseOptions(["--run", "--capture-audio"]);
   assert.equal(legacy.requireAudioCapture, false);
+  assert.equal(legacy.headed, false);
   assert.deepEqual(legacy.groups, []);
+  const selected = parseOptions(["--group", "audio-capture"]);
+  assert.equal(selected.headed, false);
+  assert.deepEqual(selected.groups, ["audio-capture"]);
   assert.throws(
     () => parseOptions(["--group", "playback", "--capture-audio"]),
     /include --group audio-capture or use --all/,
@@ -41,11 +77,24 @@ test("keeps legacy capture optional but makes selected capture strict", () => {
     () => parseOptions(["--group", "playback", "--group", "diagnostics", "--capture-audio"]),
     /include --group audio-capture or use --all/,
   );
-  assert.deepEqual(parseOptions(["--group", "audio-capture"]).groups, ["audio-capture"]);
-  const all = parseOptions(["--all", "--capture-device", "Loopback"]);
-  assert.equal(optionsForGroup(all, "playback").captureAudio, false);
-  assert.equal(optionsForGroup(all, "audio-capture").captureAudio, true);
-  assert.equal(optionsForGroup(all, "audio-capture").requireAudioCapture, true);
+  const headedSelected = parseOptions(["--group", "audio-capture", "--headed"]);
+  assert.equal(headedSelected.headed, true);
+  assert.deepEqual(headedSelected.groups, ["audio-capture"]);
+  const manual = parseOptions(["--run", "--manual-app", "--project-name", "Demo Song"]);
+  assert.equal(manual.manualApp, true);
+  assert.deepEqual(manual.groups, []);
+  const headedAll = parseOptions(["--all", "--capture-device", "Loopback", "--headed"]);
+  assert.equal(headedAll.headed, true);
+  assert.equal(optionsForGroup(headedAll, "playback").captureAudio, false);
+  assert.equal(optionsForGroup(headedAll, "audio-capture").captureAudio, true);
+  assert.equal(optionsForGroup(headedAll, "audio-capture").requireAudioCapture, true);
+});
+
+test("names failure artifacts by smoke group", () => {
+  assert.deepEqual(failureArtifactNames("export"), {
+    image: "export-failure.png",
+    summary: "export-failure-summary.json",
+  });
 });
 
 test("parses PipeWire object serial from pactl sink output", () => {


### PR DESCRIPTION
## Summary

- Add isolated headless Export workspace coverage across wide and narrow viewports.
- Generalize the shared desktop E2E harness and fixture naming beyond playback.
- Separate headless-capable and CI-approved group selection while keeping audio capture opt-in.
- Closes #436

## Testing

- `node --test scripts/desktop-e2e.test.mjs` — 12/12 passed.
- `cd apps/backend && uv run --python 3.11 pytest tests/test_desktop_e2e_fixture.py` — 1 passed.
- `pnpm --filter @tuneforge/desktop test:e2e -- --group export` — passed.
- `pnpm --filter @tuneforge/desktop test:e2e -- --run` — playback, diagnostics, and Export passed.
- `pnpm --filter @tuneforge/desktop test:e2e -- --ci` — exited successfully.
- `pnpm lint` — passed.
- `pnpm typecheck` — passed.
- `pnpm test` — passed before final selector-only changes; not rerun by request. Rerun with `pnpm test`.
