### PR TITLE
fix(ci): align commitlint toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,19 +157,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Lint commits
-        uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1
-        with:
-          configFile: commitlint.config.cjs
-
       - name: Set up pnpm
-        if: github.event_name == 'pull_request'
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 10.33.0
 
       - name: Set up Node
-        if: github.event_name == 'pull_request'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
@@ -177,8 +170,30 @@ jobs:
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Install commitlint
-        if: github.event_name == 'pull_request'
         run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Test commitlint configuration
+        run: node --test scripts/commitlint.test.mjs
+
+      - name: Lint commits
+        env:
+          EVENT_NAME: "${{ github.event_name }}"
+          PR_BASE_SHA: "${{ github.event.pull_request.base.sha }}"
+          PR_HEAD_SHA: "${{ github.event.pull_request.head.sha }}"
+          PUSH_BEFORE_SHA: "${{ github.event.before }}"
+          GITHUB_SHA: "${{ github.sha }}"
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            pnpm exec commitlint --config commitlint.config.cjs --verbose \
+              --from "$PR_BASE_SHA" --to "$PR_HEAD_SHA"
+          elif [[ "$PUSH_BEFORE_SHA" == "0000000000000000000000000000000000000000" ]]; then
+            pnpm exec commitlint --config commitlint.config.cjs --verbose --to "$GITHUB_SHA"
+          else
+            pnpm exec commitlint --config commitlint.config.cjs --verbose \
+              --from "$PUSH_BEFORE_SHA" --to "$GITHUB_SHA"
+          fi
 
       - name: Lint PR title (squash commit message)
         if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'

--- a/scripts/commitlint.test.mjs
+++ b/scripts/commitlint.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const workspaceRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+
+function lint(message, config) {
+  const result = spawnSync(
+    pnpmCommand,
+    ["exec", "commitlint", "--config", config],
+    {
+      cwd: workspaceRoot,
+      encoding: "utf8",
+      input: message,
+    },
+  );
+
+  assert.equal(result.error, undefined, result.error?.message);
+  return result;
+}
+
+function output(result) {
+  return `${result.stdout}${result.stderr}`;
+}
+
+test("accepts a commit body with an inline issue reference", () => {
+  const result = lint(
+    "fix(ci): align commitlint toolchain\n\nUse the pinned parser for issue #432.\n",
+    "commitlint.config.cjs",
+  );
+
+  assert.equal(result.status, 0, output(result));
+});
+
+test("accepts a commit body followed by a reference footer", () => {
+  const result = lint(
+    "fix(ci): align commitlint toolchain\n\nUse the pinned parser in CI.\n\nRefs #432\n",
+    "commitlint.config.cjs",
+  );
+
+  assert.equal(result.status, 0, output(result));
+});
+
+test("rejects a commit without a body", () => {
+  const result = lint("fix(ci): align commitlint toolchain\n", "commitlint.config.cjs");
+
+  assert.notEqual(result.status, 0);
+  assert.match(output(result), /body-empty/i);
+});
+
+test("accepts a body-less PR title", () => {
+  const result = lint("fix(ci): align commitlint toolchain\n", "commitlint.pr-title.config.cjs");
+
+  assert.equal(result.status, 0, output(result));
+});


### PR DESCRIPTION
## Summary

- Replace the action-bundled commitlint runtime with the repository-pinned toolchain used by Husky.
- Preserve pull-request and main-push commit-range validation, including zero-before pushes.
- Add regression coverage for inline issue references, reference footers, missing bodies, and PR titles.
- Closes #438

## Testing

- `pnpm install --frozen-lockfile --ignore-scripts`
- `node --test scripts/commitlint.test.mjs`
- `pnpm exec commitlint --config commitlint.config.cjs --verbose --from HEAD~1 --to HEAD`
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- Full suite not run; validation is scoped to this CI-only commitlint change.
