### PR TITLE
chore(release): prepare v1.1.0

### DIFF
--- a/.agents/skills/coordinate-tuneforge-work/SKILL.md
+++ b/.agents/skills/coordinate-tuneforge-work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coordinate-tuneforge-work
-description: Plan-first coordination for bounded TuneForge implementation or evidence-based research with local delivery by default. Use when selecting milestone work from a release-plan tracker, planning a known issue or ad hoc change, exploring a bug, or coordinating approved local execution, validation, and review; choose normal versus stacked delivery when relevant and publish only with later explicit authority.
+description: Plan-first coordination for bounded TuneForge implementation, evidence-based research, or release preparation with local delivery by default. Use when selecting milestone work from a release-plan tracker, planning a known issue or ad hoc change, exploring a bug, preparing a versioned release and its approval-gated artifacts, or coordinating approved execution, validation, and review; choose normal versus stacked delivery when relevant and publish only with later explicit authority.
 ---
 
 # Coordinate TuneForge Work
@@ -17,6 +17,11 @@ Use Plan-first as the core lifecycle:
 2. After plan approval and explicit local execution authority, implement,
    validate, review, and remediate locally.
 3. Stop before publication unless the user later explicitly authorizes it.
+
+Release preparation adds four narrower stop boundaries. Read
+[release-prep.md](references/release-prep.md) before planning or continuing any
+release-preparation work. Authority for one checkpoint never carries into the
+next checkpoint or authorizes final publication.
 
 Collaboration mode selection and transitions are user-owned. Never invoke
 `/plan` or `/goal`, change modes, or create or expand a Goal. A Goal is
@@ -37,12 +42,18 @@ of work; it is not a Codex collaboration mode.
 - **Ad hoc:** Build a brief with outcome, evidence, assumptions, acceptance
   criteria, and non-goals. Search live issues and PRs for overlap, but do not
   require or create an issue unless requested.
+- **Release preparation:** Use the specified version and release tracker. Plan
+  the metadata-preparation PR and the later approval-gated tag, draft release,
+  artifact build, signing, upload, verification, and closure workflow. Follow
+  [release-prep.md](references/release-prep.md).
 
-Identify the work as an issue number or `ad hoc: <short label>`, then classify
-it as **implementation** or **research**. Implementation retains product code.
-Research produces evidence and a recommendation; its product-code envelope is
-zero. A research spike must be explicitly authorized, bounded, and disposable.
-Reclassify and re-plan before retaining product code.
+For milestone, known-issue, and ad-hoc work, identify the work as an issue
+number or `ad hoc: <short label>`, then classify it as **implementation** or
+**research**. Implementation retains product code. Research produces evidence
+and a recommendation; its product-code envelope is zero. A research spike must
+be explicitly authorized, bounded, and disposable. Reclassify and re-plan
+before retaining product code. Identify release preparation by version and
+tracker; do not substitute another release.
 
 For a milestone, require exactly one open `release-plan` tracker. Parse links
 under `## Ordered work` in order and select the first still-open linked issue,
@@ -72,13 +83,15 @@ lanes or reporting evidence.
 ## Local Execution After Approval
 
 Only after the user approves the plan and explicitly requests local execution,
-delegate bounded implementation or research. Give workers the outcome,
-non-goals, owned files or evidence, envelope, current evidence, validation
-method, and stop-on-expansion instruction. Keep the coordinator out of edits.
+delegate bounded implementation, research, or release-preparation work. Give
+workers the outcome, non-goals, owned files or evidence, envelope, current
+evidence, validation method, and stop-on-expansion instruction. Keep the
+coordinator out of edits.
 
-Use one implementation or research worker by default. Use at most two only when
-responsibilities and owned files or evidence streams are independent; assign
-clear ownership. Use one implementation worker across dependent stack layers.
+Use one implementation, research, or release-preparation worker by default.
+Use at most two only when responsibilities and owned files or evidence streams
+are independent; assign clear ownership. Use one implementation worker across
+dependent stack layers.
 
 Select model and effort explicitly: Terra Medium for exploration; Terra High
 for bounded implementation; Sol High for ambiguity, cross-layer architecture,
@@ -121,14 +134,16 @@ Run only applicable validation lanes and report command, result, proof boundary,
 and unverified behavior. Never treat a local validator, emulator, or mock as
 proof of live transport, external-device, or release behavior.
 
-Use one initial correctness review for implementation or one evidence review for
-research. Evidence review must check methodology, reproducibility, unsupported
-generalization, licensing, and evidence-to-conclusion fit. Add contract and
-Product Design review only when applicable. Route reviews to Sol High normally,
-Sol XHigh only for declared high risk, and Sol Max only for a focused unresolved
-critical dispute. Send actionable findings to the original worker for one
-remediation pass, then perform one focused re-review. Stop on unresolved
-critical findings.
+Use one initial correctness review for implementation, one evidence review for
+research, or one release-safety review for release preparation. Evidence review
+must check methodology, reproducibility, unsupported generalization, licensing,
+and evidence-to-conclusion fit. Release-safety review must check the asset
+contract, provenance, checkpoint authority, manual-only operations, and fail-closed
+gates. Add contract and Product Design review only when applicable. Route reviews
+to Sol High normally, Sol XHigh only for declared high risk, and Sol Max only for
+a focused unresolved critical dispute. Send actionable findings to the original
+worker for one remediation pass, then perform one focused re-review. Stop on
+unresolved critical findings.
 
 Finish with the selected scope, work kind, delivery/report target, envelope,
 agents and lanes used, validation/evidence, unverified boundaries, remaining

--- a/.agents/skills/coordinate-tuneforge-work/agents/openai.yaml
+++ b/.agents/skills/coordinate-tuneforge-work/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Coordinate TuneForge Work"
-  short_description: "Plan TuneForge work for local delivery"
-  default_prompt: "Use $coordinate-tuneforge-work to prepare a Plan-first TuneForge work plan for local delivery."
+  short_description: "Plan TuneForge work and release preparation"
+  default_prompt: "Use $coordinate-tuneforge-work to prepare a Plan-first TuneForge work or approval-gated release plan."

--- a/.agents/skills/coordinate-tuneforge-work/references/prompt-examples.md
+++ b/.agents/skills/coordinate-tuneforge-work/references/prompt-examples.md
@@ -42,6 +42,12 @@ Use $coordinate-tuneforge-work to plan bug exploration for ad hoc: <symptom labe
 Symptom and evidence: <observed behavior and supporting evidence>.
 ```
 
+## Release Preparation
+
+```text
+Use $coordinate-tuneforge-work to plan release prep for v1.1.0.
+```
+
 ## User-Owned Post-Plan Paths
 
 After reviewing and approving the plan, choose one path. Collaboration-mode
@@ -53,6 +59,17 @@ change modes.
 Tell Codex to implement the approved plan locally. It may implement, validate,
 review, and remediate, but stops before branch creation, commit, push, PR or
 issue updates, and merge.
+
+### Continue Release Preparation
+
+After the release-preparation PR is merged, continue the approved release plan
+without granting signing or final-publication authority:
+
+```text
+Continue v1.1.0 release preparation with $coordinate-tuneforge-work. Pause
+before the signed tag, draft release, Android release APK, and artifact signing
+and upload. Do not sign artifacts or publish the final release.
+```
 
 ### Optional Goal
 

--- a/.agents/skills/coordinate-tuneforge-work/references/release-prep.md
+++ b/.agents/skills/coordinate-tuneforge-work/references/release-prep.md
@@ -1,0 +1,134 @@
+# TuneForge Release Preparation
+
+Use this workflow for a named TuneForge release. Treat the release-preparation
+PR and the later tagged-release operations as separate authority scopes.
+
+## Readiness and Release Contract
+
+- Read the release tracker, milestone, merged PRs since the previous tag,
+  `CHANGELOG.md`, governed version sources, packaging docs, and package scripts.
+- Require a clean worktree based on fresh `origin/main`. Before editing, fetch
+  `main` and tags and use the user-approved rebase/update strategy. Never
+  overwrite unrelated work.
+- Prepare one normal release PR unless the approved plan says otherwise. That
+  PR updates the curated changelog, all governed version sources, generated
+  lock entries, current version fixtures, and this skill when needed.
+- Regenerate lockfiles with their owning tools. Do not hand-edit generated
+  dependency or contract outputs.
+- Require green release-version, license-inventory, lint, typecheck, test,
+  backend, Tauri, and deterministic release-media gates before tagging. Report
+  only checks actually run and preserve generated release media as uncommitted
+  local output.
+
+Standard TuneForge releases upload exactly seven assets, using the release
+version in both binaries:
+
+1. `TuneForge_<version>_aarch64.dmg`
+2. `TuneForge_<version>_aarch64.dmg.asc`
+3. `TuneForge_<version>_android_aarch64_publishable.apk`
+4. `TuneForge_<version>_android_aarch64_publishable.apk.asc`
+5. `SHA256SUMS`
+6. `SHA256SUMS.asc`
+7. `release-key.asc`
+
+The ARM64 publishable APK is mandatory for every release. `SHA256SUMS` lists
+only the DMG and APK. For v1.1.0, do not build or upload a Flatpak.
+
+Create a named temporary staging directory and print its absolute path. Retain
+it through final publication and remote verification. Show its explicit
+cleanup command, but never run cleanup automatically.
+
+## Manual Steps and Automation Boundary
+
+Never run artifact-signing commands, `pnpm package:android:release`, or final
+release publication. Never access or automate KeePassXC, inspect private keys
+or passwords, request secrets in chat, or rely on a cached artifact-signing
+identity. An approved signed-tag command may use the repository-configured Git
+signing identity without accessing KeePassXC or inspecting or exporting key
+material.
+Manual steps export any temporary PKCS12 file, enter signing environment values,
+run the Android release build, create signatures, export the public key, and
+publish the verified draft.
+
+Codex may prepare exact commands; create a signed annotated tag only after its
+checkpoint stop and fresh explicit approval; and verify public artifacts,
+checksums, signatures, certificate fingerprints, tags, commits, package
+identities, and GitHub state. Each checkpoint needs fresh explicit authority
+for the actions after that stop. Merge authority is always separate.
+
+## Checkpoint 1: Before Signed Tag
+
+1. Require the release-preparation PR merged with green CI. Refresh the local
+   checkout, require a clean worktree, and prove `HEAD == origin/main`.
+2. Freeze the release commit SHA. Verify version sources, dated changelog, tag
+   absence, and release readiness from that exact commit.
+3. Stop. Show the exact signed annotated-tag command and await fresh explicit
+   approval.
+4. After approval, create the signed annotated tag, then verify its signature,
+   annotation, target, release SHA, `main` equality, and clean state.
+5. Push the verified tag only after separate explicit approval. Never move or
+   delete a pushed release tag. Any code correction requires a roll-forward
+   version and a new plan.
+
+## Checkpoint 2: Before Draft Release
+
+1. Create the staging directory, `release-notes.md`, and an expected-asset
+   manifest containing the exact seven filenames.
+2. Cover user-visible changes, downloads, installation, checksum/signature
+   verification, Android update identity, unsigned/not-notarized macOS status,
+   and known limitations. Keep operational details out of `CHANGELOG.md`.
+3. Stop with the notes preview and exact
+   `gh release create v<version> --draft --verify-tag --notes-file ...`
+   command; do not run it.
+4. Create the draft only after separate explicit approval. Keep final
+   publication manual-only.
+
+## Checkpoint 3: Before Android Release APK
+
+1. Require a clean checkout with `HEAD == v<version>^{commit}` and no
+   `TUNEFORGE_GIT_REF` override.
+2. Build and stage the unsigned Apple Silicon DMG. Verify filename, embedded
+   package version, and git ref `v<version>-0-g<release-sha8>`.
+3. Record manual launch-smoke evidence for the packaged DMG: OS, command,
+   artifact hash, launch without dev server, loopback backend, UI/navigation,
+   and visible release identity.
+4. Stop before Android signing/build work. Show the five documented release
+   environment variables, `pnpm package:android:release`, unset commands, and
+   temporary-key cleanup reminder. Do not execute them.
+5. After the manual Android release build supplies the APK, verify version, ARM64 ABI,
+   non-debuggable/release state, exactly one signer, certificate continuity
+   with the prior release, clean-tag provenance, and isolated emulator/device
+   smoke evidence.
+
+## Checkpoint 4: Before Signing and Upload
+
+1. Stage the verified DMG and APK. Generate `SHA256SUMS` over exactly those two
+   files. Confirm these are the only three pre-signing assets and the manifest
+   names the four manual-step signing assets still required.
+2. Stop with exact expected filenames and explicit-fingerprint GPG commands.
+   The manual step signs DMG, APK, and `SHA256SUMS`, then exports
+   `release-key.asc`.
+3. In an isolated temporary GPG home, verify the imported public-key
+   fingerprint, three detached signatures, checksums, APK certificate,
+   filenames, and exact asset set. Fail closed on any mismatch or missing
+   evidence.
+4. Upload exactly seven files to the draft only after separate explicit
+   approval. Do not publish it.
+5. Download all draft assets into a separate verification directory and repeat
+   checksum, signature, APK identity, DMG identity, tag provenance, asset-set,
+   and release-note checks against the frozen release SHA.
+
+## Failure Recovery and Closure
+
+- Fail closed for a missing DMG/APK, unexpected asset, dirty or mismatched tag
+  provenance, wrong Android signer, incomplete package/device smoke evidence,
+  bad or missing signature, checksum mismatch, or failed fresh download.
+- Preserve the draft and staging directory while investigating. Replace an
+  invalid draft asset only with explicit upload authority, then repeat the
+  complete fresh-download verification. Never repair a published tag in place.
+- A manual step publishes the verified draft. After publication, require separate
+  GitHub-write authority before posting release evidence, closing the release
+  tracker, or closing the milestone.
+- Final closure verifies published tag, release commit, `main`, seven remote
+  assets, checksums, signatures, Android certificate, notes, tracker, and
+  milestone. Report any intentionally unverified platform behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,29 @@ download, installation, verification, signature, and publication instructions.
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-08-18
+
 ### Added
 
 - A dedicated project Export workspace for selecting one source track or practice mix and packaging
-  its track and stems as a file, folder, or ZIP.
-- Saved per-project Export choices that safely reconcile with available audio and device capabilities.
-- Desktop TXT export for saved lyrics and lyrics with chords, alone or packaged with selected audio.
+  its track and stems as a file, folder, or ZIP
+  ([#428](https://github.com/grazzolini/tuneforge/pull/428),
+  [#429](https://github.com/grazzolini/tuneforge/pull/429)).
+- Saved per-project Export choices that safely reconcile with available audio and device capabilities
+  ([#433](https://github.com/grazzolini/tuneforge/pull/433)).
+- Desktop TXT export for saved lyrics and lyrics with chords, alone or packaged with selected audio
+  ([#440](https://github.com/grazzolini/tuneforge/pull/440)).
 - Android system-picker export for one existing WAV, Lyrics TXT, or mix-aware Lyrics + chords TXT,
-  with verified local receipt history when provider readback is available.
+  with verified local receipt history when provider readback is available
+  ([#451](https://github.com/grazzolini/tuneforge/pull/451)).
 
 ### Changed
 
-- Polished Export destination controls and defaulted new stemmed selections to track plus all stems.
+- Polished Export destination controls and defaulted new stemmed selections to track plus all stems
+  ([#437](https://github.com/grazzolini/tuneforge/pull/437)).
 - Matched Lyrics + chords TXT to the selected source or practice mix, including corrected key,
-  transpose, enharmonic spelling, slash chords, and compact chronological instrumental rows.
+  transpose, enharmonic spelling, slash chords, and compact chronological instrumental rows
+  ([#440](https://github.com/grazzolini/tuneforge/pull/440)).
 
 ## [1.0.1] - 2026-08-13
 
@@ -97,6 +106,7 @@ download, installation, verification, signature, and publication instructions.
 
 - Development used `0.1.0` metadata; `v1.0.0` was the first tagged release.
 
-[Unreleased]: https://github.com/grazzolini/tuneforge/compare/v1.0.1...main
+[Unreleased]: https://github.com/grazzolini/tuneforge/compare/v1.1.0...main
+[1.1.0]: https://github.com/grazzolini/tuneforge/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/grazzolini/tuneforge/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/grazzolini/tuneforge/releases/tag/v1.0.0

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tuneforge-backend"
-version = "1.0.1"
+version = "1.1.0"
 description = "Local API and processing backend for TuneForge."
 readme = "README.md"
 requires-python = ">=3.11,<3.12"

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -1919,7 +1919,7 @@ wheels = [
 
 [[package]]
 name = "tuneforge-backend"
-version = "1.0.1"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tuneforge/desktop",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -7456,7 +7456,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuneforge"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "android_system_properties",
  "base64 0.23.1",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuneforge"
-version = "1.0.1"
+version = "1.1.0"
 description = "TuneForge desktop shell"
 edition = "2021"
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TuneForge",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "identifier": "com.tuneforge.desktop",
   "build": {
     "beforeDevCommand": "pnpm --filter @tuneforge/desktop dev",

--- a/apps/desktop/src/App.project-export.test.tsx
+++ b/apps/desktop/src/App.project-export.test.tsx
@@ -60,8 +60,8 @@ function health(defaultExportFormat: string): HealthResponse {
   return {
     name: "TuneForge",
     version: "backend-test-ref",
-    backend_version: { package_version: "1.0.1", git_ref: "backend-test-ref" },
-    frontend_version: { package_version: "1.0.1", git_ref: "frontend-test-ref" },
+    backend_version: { package_version: "1.1.0", git_ref: "backend-test-ref" },
+    frontend_version: { package_version: "1.1.0", git_ref: "frontend-test-ref" },
     status: "ok",
     api_base_url: "http://127.0.0.1:8765/api/v1",
     data_root: "/tmp/tuneforge",

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -1402,11 +1402,11 @@ const {
     name: "TuneForge",
     version: "backend-test-ref",
     backend_version: {
-      package_version: "1.0.1",
+      package_version: "1.1.0",
       git_ref: "backend-test-ref",
     },
     frontend_version: {
-      package_version: "1.0.1",
+      package_version: "1.1.0",
       git_ref: "frontend-test-ref",
     },
     status: "ok",

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -32,38 +32,64 @@ node scripts/check-release-version.mjs
 node scripts/release-license-inventory.mjs --check
 ```
 
-Create and push a signed annotated `v<version>` tag, then create a GitHub pre-release for that tag.
-Build each intended artifact from a clean checkout of the tag without a `TUNEFORGE_GIT_REF` override.
-Validate and sign the artifacts, upload them to the pre-release, and publish the final release only
-after the uploaded assets pass verification. Never move or delete a published tag; roll forward with a
-new version. Operational artifact, installation, checksum, signature, and upload instructions belong
-in the GitHub Release notes.
+After the tag checkpoint stop and fresh explicit tag-signing approval, automation may create the signed
+annotated `v<version>` tag and must verify its signature, annotation, target, and release commit.
+Require separate draft-release authority before creating a draft GitHub Release for that tag. Build
+each intended artifact from a clean checkout of the tag without a `TUNEFORGE_GIT_REF` override.
+TuneForge's current release contract requires exactly seven uploaded assets:
 
-Run `pnpm package:mac` only on supported macOS release hosts, and run
-`pnpm package:linux:flatpak` only on supported Linux hosts with Flatpak packaging tooling.
+- Apple Silicon `TuneForge_<version>_aarch64.dmg` and its detached `.asc` signature;
+- publishable ARM64 `TuneForge_<version>_android_aarch64_publishable.apk` and its detached `.asc`
+  signature;
+- `SHA256SUMS`, containing only the DMG and APK, and its detached `.asc` signature;
+- armored public `release-key.asc` matching the signing fingerprint.
 
-For the manual launch smoke, install or open the built package artifact and confirm:
+Both the DMG and publishable APK are mandatory. Manual steps run
+`pnpm package:android:release` with the externally managed release key, create all detached
+signatures, export `release-key.asc`, and publish the verified draft. Automation may build the
+unsigned/not-notarized macOS DMG and verify public artifacts. It must never run the Android release
+build or artifact-signing commands. Pushing the verified tag and draft-asset upload each need separate explicit
+authority; final publication remains manual-only. Never move or delete a published tag; roll forward
+with a new version. Operational artifact, installation, checksum, signature, and upload instructions
+belong in the GitHub Release notes.
+
+Run `pnpm package:mac` only on supported macOS release hosts. Flatpak packaging remains available
+for local or future distribution work on supported Linux hosts, but v1.1.0 neither builds nor uploads
+a Flatpak.
+
+Use the artifact-specific checklist for the manual launch smoke.
+
+For the macOS DMG, install or open the packaged app and confirm:
 
 - the packaged app launches without a dev server;
-- the bundled backend starts and remains bound to `127.0.0.1`;
+- the bundled FastAPI backend starts and remains bound to `127.0.0.1`;
 - the UI loads and core navigation is usable;
-- Settings/About release identity is visible when that surface exists for the build;
-- observed behavior matches the package policy above: unsigned/not-notarized local
-  builds, no bundled FFmpeg, and no external Demucs, Whisper, or beat-this model
-  weights unless `--model-bundle` was explicitly reviewed and used.
+- Settings/About release identity is visible;
+- observed behavior matches the package policy above: unsigned/not-notarized local builds, no
+  bundled FFmpeg, and no external Demucs, Whisper, or beat-this model weights unless
+  `--model-bundle` was explicitly reviewed and used.
+
+For the Android APK, install it on an isolated emulator or device and confirm:
+
+- the packaged APK launches without a dev server;
+- the embedded mobile backend initializes and serves the packaged app's on-device workflow; do not
+  require or claim a desktop FastAPI listener or `127.0.0.1` bind;
+- the UI loads and core navigation is usable;
+- Settings/About release identity is visible.
 
 Record release gate evidence with:
 
 - OS and version;
-- artifact type, such as macOS `.app`/DMG or Linux `.flatpak`;
+- artifact type, such as macOS `.app`/DMG, publishable ARM64 Android APK, or Linux `.flatpak`;
 - commit SHA;
 - command run;
 - repo-relative output path, artifact filename/hash, or sanitized artifact identity;
 - launch-smoke checklist source, such as this manual checklist or a named release
   checklist;
-- per-check proof for packaged launch without a dev server, backend startup,
-  `127.0.0.1` bind, UI load, core navigation, and Settings/About release identity
-  when that surface exists;
+- per-check proof for the applicable platform checklist: macOS packaged launch, bundled FastAPI
+  startup and loopback bind, UI/navigation, and release identity; or Android packaged launch on the
+  isolated emulator/device, embedded mobile backend initialization, UI/navigation, and release
+  identity;
 - pass/fail result for each package build and launch-smoke check;
 - sanitized notes or log excerpt.
 

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tuneforge/shared-types",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packaging/flatpak/com.tuneforge.desktop.metainfo.xml
+++ b/packaging/flatpak/com.tuneforge.desktop.metainfo.xml
@@ -27,6 +27,7 @@
   </categories>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="1.1.0" date="2026-08-18" />
     <release version="1.0.1" date="2026-08-13" />
     <release version="1.0.0" date="2026-06-27" />
   </releases>

--- a/scripts/capture-release-media.mjs
+++ b/scripts/capture-release-media.mjs
@@ -1860,11 +1860,11 @@ function healthResponse() {
     name: "TuneForge",
     version: "release-media-fixture",
     backend_version: {
-      package_version: "1.0.1",
+      package_version: "1.1.0",
       git_ref: "release-media-fixture",
     },
     frontend_version: {
-      package_version: "1.0.1",
+      package_version: "1.1.0",
       git_ref: "release-media-fixture",
     },
     status: "ok",


### PR DESCRIPTION
## Summary

- Prepare v1.1.0 version metadata, lockfiles, changelog, and release fixtures.
- Add approval-gated release preparation with the exact seven-asset contract.
- Keep Android release builds, artifact signing, and final publication manual-only.
- Refs #392

## Testing

- Passed: skill `quick_validate.py` validation.
- Passed: `git diff --check`.
- Passed: `pnpm release:check-version`.
- Passed: `pnpm release:license-inventory -- --check`.
- Passed: focused `App.project-export.test.tsx` Vitest coverage (33 tests).
- Passed: `node --test scripts/capture-release-media.test.mjs` (13 tests).
- Passed: `cd apps/desktop/src-tauri && cargo check`.
- Not run locally by request; deferred to PR CI: `pnpm lint`, `pnpm typecheck`, `pnpm test`, `cd apps/backend && uv run --python 3.11 pytest`, and `node scripts/capture-release-media.mjs --run`.
