### PR TITLE
chore(deps): upgrade CI and flatpak node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22"
+          node-version: "26"
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
@@ -208,7 +208,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22"
+          node-version: "26"
 
       - name: Test deterministic Node scripts
         run: node --test scripts/build-info.test.mjs scripts/package-options.test.mjs scripts/flatpak-options.test.mjs scripts/desktop-e2e.test.mjs scripts/sync-validation.test.mjs scripts/release-license-inventory.test.mjs scripts/capture-release-media.test.mjs
@@ -254,7 +254,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22"
+          node-version: "26"
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
@@ -404,7 +404,7 @@ jobs:
         if: needs.ci-scope.outputs.site == 'true'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22"
+          node-version: "26"
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
@@ -524,7 +524,7 @@ jobs:
         if: needs.ci-scope.outputs.desktop == 'true'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22"
+          node-version: "26"
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22"
+          node-version: "26"
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 

--- a/packaging/flatpak/com.tuneforge.desktop.yml
+++ b/packaging/flatpak/com.tuneforge.desktop.yml
@@ -3,7 +3,7 @@ runtime: org.gnome.Platform
 runtime-version: "50"
 sdk: org.gnome.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.node22
+  - org.freedesktop.Sdk.Extension.node26
   - org.freedesktop.Sdk.Extension.llvm20
   - org.freedesktop.Sdk.Extension.rust-stable
 command: tuneforge
@@ -77,7 +77,7 @@ modules:
   - name: pnpm
     buildsystem: simple
     build-options:
-      append-path: /usr/lib/sdk/node22/bin
+      append-path: /usr/lib/sdk/node26/bin
     sources:
       - type: archive
         url: https://registry.npmjs.org/pnpm/-/pnpm-11.22.0.tgz
@@ -86,8 +86,8 @@ modules:
     build-commands:
       - install -dm755 /app/lib/pnpm /app/bin
       - cp -a pnpm/. /app/lib/pnpm/
-      - ln -sf ../lib/pnpm/bin/pnpm.cjs /app/bin/pnpm
-      - ln -sf ../lib/pnpm/bin/pnpx.cjs /app/bin/pnpx
+      - ln -sf ../lib/pnpm/bin/pnpm.mjs /app/bin/pnpm
+      - ln -sf ../lib/pnpm/bin/pnpx.mjs /app/bin/pnpx
 
   - name: node-sources
     buildsystem: simple
@@ -154,7 +154,7 @@ modules:
   - name: tuneforge
     buildsystem: simple
     build-options:
-      append-path: /app/bin:/usr/lib/sdk/node22/bin:/usr/lib/sdk/llvm20/bin:/usr/lib/sdk/rust-stable/bin
+      append-path: /app/bin:/usr/lib/sdk/node26/bin:/usr/lib/sdk/llvm20/bin:/usr/lib/sdk/rust-stable/bin
       env:
         CARGO_HOME: /run/build/tuneforge/cargo-home
         CARGO_NET_OFFLINE: "true"


### PR DESCRIPTION
## Summary

Upgrade CI and flatpak node version to 26

## Motivation

Node 26 was already used on development machine and after the pnpm updates,
upgrading it on CI and flatpak, makes sure we do not have environment discrepancy issues

## Changes

- Upgrade node from 22 to 26 on ci.yml
- Upgrade node from 22 to 26 on sites.yml
- Upgrade node from 22 to 26 on flatpak com.tuneforge.desktop.yml
- Fix bypassing the entry point on [pnpm](https://github.com/nodejs/corepack/issues/875) 

## Test Plan

- pnpm test
- pnpm lint
- pnpm contracts:generate
- pnpm config list also validates no execution environment in use and node 26
- Built flatpak on linux and validated it built correctly using node 26

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(backend): add chord smoothing window`) — it becomes the squash commit message on `main`
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (desktop + Tauri shell + backend)
- [ ] If backend routes or schemas changed, ran `pnpm contracts:generate` and committed the result
- [ ] If this PR includes noteworthy product behavior, updated `CHANGELOG.md`'s `[Unreleased]`
  section
- [ ] If release/package behavior changed or this PR prepares a release package, included Release Package Gate evidence from
  `docs/PACKAGING.md#release-package-gate` (package build plus packaged launch smoke with OS,
  artifact type, commit SHA, and pass/fail evidence); when release/package behavior changed, also
  refreshed license/dependency inventory evidence, documented model-weight download/cache policy,
  and verified no model weights, cache dirs, or package artifacts were added
- [ ] Updated relevant docs (README, backend README, THIRD_PARTY_NOTICES) if behavior changed
- [x] No secrets, credentials, or copyrighted audio added to the repository
