### PR TITLE
ci: add digest-pinned CI image publisher

### DIFF
--- a/.github/ci/Dockerfile
+++ b/.github/ci/Dockerfile
@@ -1,0 +1,112 @@
+# syntax=docker/dockerfile:1
+
+FROM --platform=linux/amd64 ubuntu:24.04@sha256:1e0a86e57d247923571b75e0aaf48a1449cf8c543d51fb3e07a4a7d7bfa79316
+
+ARG FFMPEG_VERSION=7:6.1.1-3ubuntu5
+ARG FFMPEG_DEB_URL=https://archive.ubuntu.com/ubuntu/pool/universe/f/ffmpeg/ffmpeg_6.1.1-3ubuntu5_amd64.deb
+ARG FFMPEG_DEB_SHA256=1a23baace5f2688a47e28119aedae6993cd638e6279a7227dfc52d9a337a1c17
+ARG FFMPEG_SHA256=ed16af623947494a72e284b6eb8ff225f2da22b38b5d5069c2fd4b4ba3384e41
+ARG FFPROBE_SHA256=272f6ebc634a63d9c8b4ca68e964119d980f25154e5aa2c35e5487da48e9a58f
+ARG PLAYWRIGHT_VERSION=1.62.1
+ARG PLAYWRIGHT_SYSTEM_PACKAGES="\
+xvfb fonts-noto-color-emoji fonts-unifont libfontconfig1 libfreetype6 \
+xfonts-cyrillic xfonts-scalable fonts-liberation fonts-ipafont-gothic \
+fonts-wqy-zenhei fonts-tlwg-loma-otf fonts-freefont-ttf libasound2t64 \
+libatk-bridge2.0-0t64 libatk1.0-0t64 libatspi2.0-0t64 libcairo2 libcups2t64 \
+libdbus-1-3 libdrm2 libgbm1 libglib2.0-0t64 libnspr4 libnss3 libpango-1.0-0 \
+libx11-6 libxcb1 libxcomposite1 libxdamage1 libxext6 libxfixes3 \
+libxkbcommon0 libxrandr2"
+
+LABEL org.opencontainers.image.source="https://github.com/grazzolini/tuneforge" \
+      org.opencontainers.image.description="Ubuntu CI dependencies for TuneForge" \
+      org.opencontainers.image.licenses="LicenseRef-TuneForge-CI-Image"
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN set -eux; \
+    export DEBIAN_FRONTEND=noninteractive; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+      build-essential \
+      ca-certificates \
+      curl \
+      file \
+      git \
+      gzip \
+      libasound2-dev \
+      libayatana-appindicator3-dev \
+      libgtk-3-dev \
+      librsvg2-dev \
+      libssl-dev \
+      libwebkit2gtk-4.1-dev \
+      libxdo-dev \
+      openssh-client \
+      pkg-config \
+      tar \
+      unzip \
+      wget \
+      xz-utils \
+      zstd; \
+    read -r -a playwright_system_packages <<< "${PLAYWRIGHT_SYSTEM_PACKAGES}"; \
+    apt-get install -y --no-install-recommends "${playwright_system_packages[@]}"; \
+    ffmpeg_deb="$(mktemp --suffix=.deb)"; \
+    curl --proto '=https' --tlsv1.2 --fail --location --retry 5 \
+      --output "${ffmpeg_deb}" "${FFMPEG_DEB_URL}"; \
+    printf '%s  %s\n' "${FFMPEG_DEB_SHA256}" "${ffmpeg_deb}" | sha256sum -c -; \
+    apt-get install -y --no-install-recommends "${ffmpeg_deb}"; \
+    rm -f "${ffmpeg_deb}"; \
+    test "$(dpkg-query -W -f='${Version}' ffmpeg)" = "${FFMPEG_VERSION}"; \
+    printf '%s  %s\n' "${FFMPEG_SHA256}" /usr/bin/ffmpeg | sha256sum -c -; \
+    printf '%s  %s\n' "${FFPROBE_SHA256}" /usr/bin/ffprobe | sha256sum -c -; \
+    test -f /usr/share/doc/ffmpeg/copyright; \
+    install -d /usr/share/tuneforge-ci; \
+    printf '%s\n' \
+      'ubuntu:24.04@sha256:1e0a86e57d247923571b75e0aaf48a1449cf8c543d51fb3e07a4a7d7bfa79316' \
+      > /usr/share/tuneforge-ci/base-image.txt; \
+    printf '%s\n' "${PLAYWRIGHT_VERSION}" \
+      > /usr/share/tuneforge-ci/playwright-version.txt; \
+    printf 'ffmpeg package: %s\nffmpeg package URL: %s\nffmpeg package SHA-256: %s\n' \
+      "${FFMPEG_VERSION}" "${FFMPEG_DEB_URL}" "${FFMPEG_DEB_SHA256}" \
+      > /usr/share/tuneforge-ci/ffmpeg-source.txt; \
+    printf '%s  %s\n%s  %s\n' \
+      "${FFMPEG_SHA256}" /usr/bin/ffmpeg \
+      "${FFPROBE_SHA256}" /usr/bin/ffprobe \
+      > /usr/share/tuneforge-ci/ffmpeg.sha256; \
+    ffmpeg -version > /usr/share/tuneforge-ci/ffmpeg-version.txt; \
+    ffmpeg -buildconf > /usr/share/tuneforge-ci/ffmpeg-buildconf.txt; \
+    dpkg-query -W -f='${binary:Package}\t${Version}\n' | LC_ALL=C sort \
+      > /usr/share/tuneforge-ci/packages.txt; \
+    validation_dir="$(mktemp -d)"; \
+    ffmpeg -nostdin -hide_banner -loglevel error -y -f lavfi \
+      -i 'sine=frequency=440:sample_rate=48000:duration=1' \
+      -c:a pcm_s16le "${validation_dir}/tone.wav"; \
+    ffmpeg -nostdin -hide_banner -loglevel error -y -i "${validation_dir}/tone.wav" \
+      -c:a flac "${validation_dir}/tone.flac"; \
+    ffmpeg -nostdin -hide_banner -loglevel error -y -i "${validation_dir}/tone.wav" \
+      -c:a libmp3lame -b:a 192k "${validation_dir}/tone.mp3"; \
+    ffmpeg -nostdin -hide_banner -loglevel error -y -i "${validation_dir}/tone.wav" \
+      -c:a aac -profile:a aac_low -b:a 192k "${validation_dir}/tone.m4a"; \
+    test "$(ffprobe -v error -select_streams a:0 -show_entries stream=codec_name \
+      -of default=noprint_wrappers=1:nokey=1 "${validation_dir}/tone.wav")" = pcm_s16le; \
+    test "$(ffprobe -v error -select_streams a:0 -show_entries stream=codec_name \
+      -of default=noprint_wrappers=1:nokey=1 "${validation_dir}/tone.flac")" = flac; \
+    test "$(ffprobe -v error -select_streams a:0 -show_entries stream=codec_name \
+      -of default=noprint_wrappers=1:nokey=1 "${validation_dir}/tone.mp3")" = mp3; \
+    test "$(ffprobe -v error -select_streams a:0 -show_entries stream=codec_name \
+      -of default=noprint_wrappers=1:nokey=1 "${validation_dir}/tone.m4a")" = aac; \
+    test "$(ffprobe -v error -select_streams a:0 -show_entries stream=profile \
+      -of default=noprint_wrappers=1:nokey=1 "${validation_dir}/tone.m4a")" = LC; \
+    for artifact in tone.wav tone.flac tone.mp3 tone.m4a; do \
+      printf '%s\t' "${artifact}"; \
+      ffprobe -v error -select_streams a:0 \
+        -show_entries format=format_name:stream=codec_name,profile,sample_rate,channels \
+        -of json=compact=1 "${validation_dir}/${artifact}" | tr -d '\n'; \
+      printf '\n'; \
+    done > /usr/share/tuneforge-ci/codec-validation.jsonl; \
+    rm -rf "${validation_dir}"; \
+    cat /usr/share/tuneforge-ci/ffmpeg-source.txt; \
+    cat /usr/share/tuneforge-ci/ffmpeg.sha256; \
+    cat /usr/share/tuneforge-ci/codec-validation.jsonl; \
+    rm -rf /var/lib/apt/lists/*
+
+COPY README.md /usr/share/doc/tuneforge-ci/README.md

--- a/.github/ci/README.md
+++ b/.github/ci/README.md
@@ -1,0 +1,81 @@
+# TuneForge CI image
+
+`ghcr.io/grazzolini/tuneforge-ci` contains the stable Linux system layer used by
+TuneForge's AMD64 GitHub Actions jobs. It is CI infrastructure only. TuneForge
+release artifacts continue to require host-installed FFmpeg and do not copy
+anything from this image.
+
+## Contents and provenance
+
+- Base: Ubuntu 24.04, pinned in `Dockerfile` to a Linux AMD64 manifest digest.
+- FFmpeg: Ubuntu Noble `ffmpeg=7:6.1.1-3ubuntu5` from the official Ubuntu
+  archive. The downloaded package SHA-256 is
+  `1a23baace5f2688a47e28119aedae6993cd638e6279a7227dfc52d9a337a1c17`.
+- FFmpeg binaries: the build fails unless `/usr/bin/ffmpeg` and
+  `/usr/bin/ffprobe` match the SHA-256 values pinned in `Dockerfile`.
+- Playwright: Ubuntu 24.04 Chromium system dependencies reviewed against
+  Playwright `1.62.1`. Chromium itself remains a job-time download.
+- Tauri: the GTK, WebKitGTK, ALSA, AppIndicator, SVG, XDo, and OpenSSL
+  development packages previously installed by the CI workflow.
+- CI utilities: only tools needed by setup actions and native builds. No source
+  tree, dependency directory, build output, model, user data, or credential is
+  included.
+
+Each image records evidence under `/usr/share/tuneforge-ci/`:
+
+- `base-image.txt`
+- `packages.txt`
+- `ffmpeg-source.txt`
+- `ffmpeg.sha256`
+- `ffmpeg-version.txt`
+- `ffmpeg-buildconf.txt`
+- `playwright-version.txt`
+- `codec-validation.jsonl`
+
+The build generates a synthetic one-second sine wave and proves PCM/WAV, FLAC,
+`libmp3lame` MP3 at 192 kbps, and AAC-LC/M4A at 192 kbps. No user or copyrighted
+audio enters the image.
+
+## Licensing
+
+Ubuntu packages retain their upstream and distribution licenses. The Noble
+FFmpeg build enables GPL components and is GPL-2.0-or-later; its installed
+copyright file is `/usr/share/doc/ffmpeg/copyright`. The OCI license label uses
+`LicenseRef-TuneForge-CI-Image` because the aggregate image has multiple package
+licenses. The package inventory and installed copyright files are the detailed
+license record.
+
+This GPL-bearing CI tool is not linked into, copied into, or distributed with
+TuneForge application artifacts. `THIRD_PARTY_NOTICES.md` continues to describe
+the application's host-installed FFmpeg boundary.
+
+## Refresh and promotion
+
+1. Let Docker Dependabot update the Ubuntu digest, or update it from the
+   official `ubuntu:24.04` Linux AMD64 manifest.
+2. When Playwright changes in `apps/desktop/package.json` and `pnpm-lock.yaml`,
+   review its Ubuntu 24.04 Chromium dependency list. Update both the packages in
+   `Dockerfile` and `PLAYWRIGHT_VERSION`; the policy check rejects version drift.
+3. For an FFmpeg update, verify the official package checksum, extract the AMD64
+   package, update both binary hashes, then perform two clean builds:
+
+   ```sh
+   docker buildx build --no-cache --platform linux/amd64 --load \
+     --tag tuneforge-ci:check-1 .github/ci
+   docker buildx build --no-cache --platform linux/amd64 --load \
+     --tag tuneforge-ci:check-2 .github/ci
+   docker run --rm tuneforge-ci:check-1 sha256sum /usr/bin/ffmpeg /usr/bin/ffprobe
+   docker run --rm tuneforge-ci:check-2 sha256sum /usr/bin/ffmpeg /usr/bin/ffprobe
+   ```
+
+4. Merge the bootstrap change only with separate approval. Trusted `main`
+   publication creates only
+   `sha-<commit>-run-<run-id>-attempt-<attempt>` and prints its manifest digest,
+   package evidence paths, SBOM, and provenance status in the job summary.
+5. Review the build logs, inventory, licenses, codec evidence, SBOM, provenance,
+   tag, and digest. The first GHCR package is private; changing it to public is a
+   separate authorized GitHub operation.
+6. Verify repository linkage and an anonymous Linux AMD64 pull by digest.
+7. Promote that exact digest through a second normal PR. Never consume a moving
+   tag, delete a referenced image version, or migrate CI before publication and
+   public-pull proof succeed.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,3 +41,9 @@ updates:
     patterns:
       - "*"
     multi-ecosystem-group: dependencies
+
+  - package-ecosystem: docker
+    directory: "/.github/ci"
+    patterns:
+      - "*"
+    multi-ecosystem-group: dependencies

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -1,0 +1,101 @@
+name: Publish CI image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/ci/**
+      - .github/workflows/ci-image.yml
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ci-image-publish
+  cancel-in-progress: false
+
+env:
+  IMAGE_NAME: ghcr.io/grazzolini/tuneforge-ci
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish immutable image
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .github/ci
+          file: .github/ci/Dockerfile
+          platforms: linux/amd64
+          pull: true
+          no-cache: true
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:sha-${{ github.sha }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.description=Ubuntu CI dependencies for TuneForge
+            org.opencontainers.image.licenses=LicenseRef-TuneForge-CI-Image
+          provenance: mode=max
+          sbom: true
+
+      - name: Record publication evidence
+        shell: bash
+        env:
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${IMAGE_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Build did not return a valid immutable image digest." >&2
+            exit 1
+          fi
+
+          base_image="$(sed -n 's/^FROM --platform=linux\/amd64 //p' .github/ci/Dockerfile)"
+          ffmpeg_version="$(sed -n 's/^ARG FFMPEG_VERSION=//p' .github/ci/Dockerfile)"
+          ffmpeg_source="$(sed -n 's/^ARG FFMPEG_DEB_URL=//p' .github/ci/Dockerfile)"
+          ffmpeg_deb_sha="$(sed -n 's/^ARG FFMPEG_DEB_SHA256=//p' .github/ci/Dockerfile)"
+          ffmpeg_sha="$(sed -n 's/^ARG FFMPEG_SHA256=//p' .github/ci/Dockerfile)"
+          ffprobe_sha="$(sed -n 's/^ARG FFPROBE_SHA256=//p' .github/ci/Dockerfile)"
+          playwright_version="$(sed -n 's/^ARG PLAYWRIGHT_VERSION=//p' .github/ci/Dockerfile)"
+          immutable_tag="${IMAGE_NAME}:sha-${GITHUB_SHA}-run-${GITHUB_RUN_ID}-attempt-${GITHUB_RUN_ATTEMPT}"
+          immutable_reference="${IMAGE_NAME}@${IMAGE_DIGEST}"
+
+          {
+            echo "## CI image publication"
+            echo
+            echo "- Tag: \`${immutable_tag}\`"
+            echo "- Digest reference: \`${immutable_reference}\`"
+            echo "- Platform: \`linux/amd64\`"
+            echo "- Base: \`${base_image}\`"
+            echo "- FFmpeg package: \`${ffmpeg_version}\`"
+            echo "- FFmpeg source: \`${ffmpeg_source}\`"
+            echo "- FFmpeg package SHA-256: \`${ffmpeg_deb_sha}\`"
+            echo "- \`ffmpeg\` SHA-256: \`${ffmpeg_sha}\`"
+            echo "- \`ffprobe\` SHA-256: \`${ffprobe_sha}\`"
+            echo "- Playwright dependency review marker: \`${playwright_version}\`"
+            echo "- BuildKit SBOM: attached by the successful build"
+            echo "- BuildKit provenance: attached with \`mode=max\`"
+            echo "- Image inventory: \`/usr/share/tuneforge-ci/packages.txt\`"
+            echo "- Codec evidence: \`/usr/share/tuneforge-ci/codec-validation.jsonl\`"
+            echo
+            echo "> Publication does not authorize GHCR visibility changes or digest promotion."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
                 apps/site/*|.github/workflows/pages.yml)
                   site=true
                   ;;
-                .github/workflows/ci.yml)
+                .github/ci/*|.github/workflows/ci-image.yml|.github/workflows/ci.yml)
                   full_gate=true
                   ;;
                 .agents/*|.codex/environments/*|docs/*|CHANGELOG.md|README.md|CONTRIBUTING.md|CODE_OF_CONDUCT.md|LICENSE|THIRD_PARTY_NOTICES.md|SECURITY.md|AGENTS.md|.gitignore|packaging/flatpak/*|.github/ISSUE_TEMPLATE/*|.github/PULL_REQUEST_TEMPLATE.md)
@@ -218,7 +218,7 @@ jobs:
           node-version: "26"
 
       - name: Test deterministic Node scripts
-        run: node --test scripts/build-info.test.mjs scripts/package-options.test.mjs scripts/flatpak-options.test.mjs scripts/flatpak-pnpm.test.mjs scripts/desktop-e2e.test.mjs scripts/sync-validation.test.mjs scripts/release-license-inventory.test.mjs scripts/capture-release-media.test.mjs
+        run: node --test scripts/build-info.test.mjs scripts/package-options.test.mjs scripts/flatpak-options.test.mjs scripts/flatpak-pnpm.test.mjs scripts/desktop-e2e.test.mjs scripts/sync-validation.test.mjs scripts/release-license-inventory.test.mjs scripts/capture-release-media.test.mjs scripts/ci-image-policy.test.mjs
 
       - name: Check release script syntax
         run: |

--- a/scripts/ci-image-policy.mjs
+++ b/scripts/ci-image-policy.mjs
@@ -1,0 +1,229 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const paths = {
+  desktopPackage: "apps/desktop/package.json",
+  lockfile: "pnpm-lock.yaml",
+  dockerfile: ".github/ci/Dockerfile",
+  imageReadme: ".github/ci/README.md",
+  imageWorkflow: ".github/workflows/ci-image.yml",
+  mainWorkflow: ".github/workflows/ci.yml",
+  pagesWorkflow: ".github/workflows/pages.yml",
+  dependabot: ".github/dependabot.yml",
+};
+
+const playwrightNoblePackages = [
+  "xvfb",
+  "fonts-noto-color-emoji",
+  "fonts-unifont",
+  "libfontconfig1",
+  "libfreetype6",
+  "xfonts-cyrillic",
+  "xfonts-scalable",
+  "fonts-liberation",
+  "fonts-ipafont-gothic",
+  "fonts-wqy-zenhei",
+  "fonts-tlwg-loma-otf",
+  "fonts-freefont-ttf",
+  "libasound2t64",
+  "libatk-bridge2.0-0t64",
+  "libatk1.0-0t64",
+  "libatspi2.0-0t64",
+  "libcairo2",
+  "libcups2t64",
+  "libdbus-1-3",
+  "libdrm2",
+  "libgbm1",
+  "libglib2.0-0t64",
+  "libnspr4",
+  "libnss3",
+  "libpango-1.0-0",
+  "libx11-6",
+  "libxcb1",
+  "libxcomposite1",
+  "libxdamage1",
+  "libxext6",
+  "libxfixes3",
+  "libxkbcommon0",
+  "libxrandr2",
+];
+
+function read(root, relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+function dockerArg(dockerfile, name) {
+  return dockerfile.match(new RegExp(`^ARG ${name}=([^\\s]+)$`, "m"))?.[1];
+}
+
+function dockerQuotedArgWords(dockerfile, name) {
+  const value = dockerfile.match(new RegExp(`^ARG ${name}="([\\s\\S]*?)"$`, "m"))?.[1];
+  return value?.replace(/\\\r?\n/g, " ").trim().split(/\s+/);
+}
+
+function levelTwoMappingKey(line) {
+  const content = line.match(/^  (?!\s)(.+)$/)?.[1];
+  if (!content) return undefined;
+  const singleQuoted = content.match(/^'((?:[^']|'')*)'\s*:/)?.[1];
+  if (singleQuoted !== undefined) return singleQuoted.replaceAll("''", "'");
+  const doubleQuoted = content.match(/^"((?:[^"\\]|\\.)*)"\s*:/)?.[1];
+  if (doubleQuoted !== undefined) {
+    try {
+      return JSON.parse(`"${doubleQuoted}"`);
+    } catch {
+      return `"${doubleQuoted}"`;
+    }
+  }
+  return content.match(/^([^:]+?)\s*:/)?.[1].trimEnd() ?? `!unparsed:${content}`;
+}
+
+function topLevelMappingKeys(yaml, name) {
+  const lines = yaml.split("\n");
+  const start = lines.findIndex((line) => line === `${name}:`);
+  if (start === -1) return [];
+  const keys = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() === "" || line.trimStart().startsWith("#")) continue;
+    if (!line.startsWith(" ")) break;
+    const key = levelTwoMappingKey(line);
+    if (key !== undefined) keys.push(key);
+  }
+  return keys;
+}
+
+function desktopLockfilePlaywrightVersion(lockfile) {
+  const importer = lockfile.match(/\n  apps\/desktop:\n([\s\S]*?)(?=\n  \S)/)?.[1];
+  return importer?.match(/\n      playwright:\n(?:        .*\n)*?        version: ([^\s]+)/)?.[1];
+}
+
+function packagePlaywrightVersion(packageJson) {
+  const specifier = JSON.parse(packageJson).devDependencies?.playwright;
+  return typeof specifier === "string" ? specifier.replace(/^[~^]/, "") : undefined;
+}
+
+export function validateCiImagePolicy(root) {
+  const desktopPackage = read(root, paths.desktopPackage);
+  const lockfile = read(root, paths.lockfile);
+  const dockerfile = read(root, paths.dockerfile);
+  const imageReadme = read(root, paths.imageReadme);
+  const imageWorkflow = read(root, paths.imageWorkflow);
+  const mainWorkflow = read(root, paths.mainWorkflow);
+  const pagesWorkflow = read(root, paths.pagesWorkflow);
+  const dependabot = read(root, paths.dependabot);
+  const errors = [];
+  const check = (condition, message) => {
+    if (!condition) errors.push(message);
+  };
+
+  const packageVersion = packagePlaywrightVersion(desktopPackage);
+  const lockfileVersion = desktopLockfilePlaywrightVersion(lockfile);
+  const imageVersion = dockerArg(dockerfile, "PLAYWRIGHT_VERSION");
+  const imagePlaywrightPackages = dockerQuotedArgWords(
+    dockerfile,
+    "PLAYWRIGHT_SYSTEM_PACKAGES",
+  );
+  check(Boolean(packageVersion), "apps/desktop/package.json must declare Playwright");
+  check(
+    packageVersion === lockfileVersion,
+    `Playwright package/lock versions differ (${packageVersion} vs ${lockfileVersion})`,
+  );
+  check(
+    packageVersion === imageVersion,
+    `Dockerfile PLAYWRIGHT_VERSION must be reviewed with Playwright ${packageVersion}`,
+  );
+  check(
+    imageReadme.includes(`Playwright \`${imageVersion}\``),
+    "CI image notice must record the reviewed Playwright version",
+  );
+  check(
+    JSON.stringify(imagePlaywrightPackages) === JSON.stringify(playwrightNoblePackages) &&
+      dockerfile.includes(
+        'apt-get install -y --no-install-recommends "${playwright_system_packages[@]}"',
+      ),
+    "Dockerfile must contain the exact reviewed Playwright 1.62.1 Noble tools and Chromium packages",
+  );
+
+  check(
+    JSON.stringify(topLevelMappingKeys(imageWorkflow, "on")) ===
+      JSON.stringify(["push", "workflow_dispatch"]),
+    "CI image workflow events must be exactly push and workflow_dispatch",
+  );
+  check(/^permissions: \{\}$/m.test(imageWorkflow), "CI image workflow must default to no permissions");
+  check(
+    /publish:\n(?:[\s\S]*?)    permissions:\n      contents: read\n      packages: write/.test(
+      imageWorkflow,
+    ),
+    "Publish job must scope contents: read and packages: write",
+  );
+  check(
+    /push:\n    branches:\n      - main\n    paths:\n      - \.github\/ci\/\*\*\n      - \.github\/workflows\/ci-image\.yml\n  workflow_dispatch:/.test(imageWorkflow),
+    "CI image workflow must publish only for trusted main image inputs or manual dispatch",
+  );
+  check(
+    !/^\s+- (?:package\.json|pnpm-lock\.yaml)$/m.test(imageWorkflow),
+    "Package or lockfile changes must not publish the CI image",
+  );
+  check(imageWorkflow.includes("platforms: linux/amd64"), "CI image must build only linux/amd64");
+  check(
+    imageWorkflow.includes(
+      "tags: ${{ env.IMAGE_NAME }}:sha-${{ github.sha }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}",
+    ),
+    "CI image must publish a unique commit/run/attempt tag",
+  );
+  check(!/:latest\b|:main\b/.test(imageWorkflow), "CI image workflow must not publish moving tags");
+  check(imageWorkflow.includes("provenance: mode=max"), "CI image build must request provenance");
+  check(imageWorkflow.includes("sbom: true"), "CI image build must request an SBOM");
+  for (const line of imageWorkflow.matchAll(/^\s*uses:\s+[^@\n]+@([^\s#]+)/gm)) {
+    check(/^[0-9a-f]{40}$/.test(line[1]), `Action must use a full commit SHA: ${line[0].trim()}`);
+  }
+
+  const copyInstructions = [...dockerfile.matchAll(/^COPY\s+(.+)$/gm)].map((match) => match[1]);
+  const ffmpegDownload = dockerfile.indexOf(
+    '--output "${ffmpeg_deb}" "${FFMPEG_DEB_URL}"',
+  );
+  const ffmpegChecksum = dockerfile.indexOf(
+    '"${FFMPEG_DEB_SHA256}" "${ffmpeg_deb}" | sha256sum -c -',
+  );
+  const ffmpegInstall = dockerfile.indexOf(
+    'apt-get install -y --no-install-recommends "${ffmpeg_deb}"',
+  );
+  check(
+    ffmpegDownload >= 0 && ffmpegDownload < ffmpegChecksum && ffmpegChecksum < ffmpegInstall,
+    "FFmpeg AMD64 package must be downloaded, checksum-verified, then installed",
+  );
+  check(
+    copyInstructions.length === 1 && copyInstructions[0] === "README.md /usr/share/doc/tuneforge-ci/README.md",
+    "CI image build context must copy only its license/provenance notice",
+  );
+  check(
+    !pagesWorkflow.includes("ghcr.io/grazzolini/tuneforge-ci"),
+    "Pages/release media workflow must not consume the CI image",
+  );
+  check(
+    mainWorkflow.includes(
+      ".github/ci/*|.github/workflows/ci-image.yml|.github/workflows/ci.yml)",
+    ),
+    "CI image definitions and publisher changes must select the full CI gate",
+  );
+  check(
+    /package-ecosystem: docker\n    directory: "\/\.github\/ci"/.test(dependabot),
+    "Dependabot must track Docker base-image digests under .github/ci",
+  );
+
+  if (errors.length > 0) {
+    throw new Error(`CI image policy violations:\n- ${errors.join("\n- ")}`);
+  }
+
+  return {
+    playwrightVersion: packageVersion,
+    image: "ghcr.io/grazzolini/tuneforge-ci",
+  };
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  const root = path.resolve(process.argv[2] ?? path.join(path.dirname(fileURLToPath(import.meta.url)), ".."));
+  const result = validateCiImagePolicy(root);
+  console.log(`CI image policy valid for Playwright ${result.playwrightVersion}.`);
+}

--- a/scripts/ci-image-policy.test.mjs
+++ b/scripts/ci-image-policy.test.mjs
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { validateCiImagePolicy } from "./ci-image-policy.mjs";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const fixtureFiles = [
+  "apps/desktop/package.json",
+  "pnpm-lock.yaml",
+  ".github/ci/Dockerfile",
+  ".github/ci/README.md",
+  ".github/workflows/ci-image.yml",
+  ".github/workflows/ci.yml",
+  ".github/workflows/pages.yml",
+  ".github/dependabot.yml",
+];
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "tuneforge-ci-image-policy-"));
+  for (const relativePath of fixtureFiles) {
+    const destination = path.join(root, relativePath);
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.copyFileSync(path.join(repositoryRoot, relativePath), destination);
+  }
+  return root;
+}
+
+function replace(root, relativePath, before, after) {
+  const target = path.join(root, relativePath);
+  const original = fs.readFileSync(target, "utf8");
+  assert.ok(original.includes(before), `${relativePath} fixture must include replacement target`);
+  fs.writeFileSync(target, original.replaceAll(before, after));
+}
+
+test("repository satisfies CI image policy", () => {
+  assert.deepEqual(validateCiImagePolicy(repositoryRoot), {
+    playwrightVersion: "1.62.1",
+    image: "ghcr.io/grazzolini/tuneforge-ci",
+  });
+});
+
+test("Playwright drift requires an image dependency review", (context) => {
+  const root = fixture();
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  replace(root, "apps/desktop/package.json", "^1.62.1", "^1.63.0");
+  replace(root, "pnpm-lock.yaml", "1.62.1", "1.63.0");
+
+  assert.throws(() => validateCiImagePolicy(root), /PLAYWRIGHT_VERSION must be reviewed/);
+});
+
+test("Playwright dependency review requires the exact Noble package set", (context) => {
+  const root = fixture();
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  replace(root, ".github/ci/Dockerfile", "libxkbcommon0 libxrandr2", "libxkbcommon0");
+
+  assert.throws(() => validateCiImagePolicy(root), /exact reviewed Playwright 1\.62\.1 Noble/);
+});
+
+test("untrusted and broad publisher triggers fail closed", (context) => {
+  const root = fixture();
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  replace(root, ".github/workflows/ci-image.yml", "on:\n  push:", "on:\n  pull_request:\n  push:");
+  replace(
+    root,
+    ".github/workflows/ci-image.yml",
+    "      - .github/workflows/ci-image.yml",
+    "      - .github/workflows/ci-image.yml\n      - pnpm-lock.yaml",
+  );
+
+  assert.throws(
+    () => validateCiImagePolicy(root),
+    /events must be exactly push and workflow_dispatch[\s\S]*must publish only for trusted main image inputs[\s\S]*must not publish the CI image/,
+  );
+});
+
+test("publisher rejects every additional workflow event", (context) => {
+  const root = fixture();
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  replace(
+    root,
+    ".github/workflows/ci-image.yml",
+    "  workflow_dispatch:\n",
+    "  workflow_dispatch:\n  workflow_run:\n    workflows: [CI]\n    types: [completed]\n",
+  );
+
+  assert.throws(() => validateCiImagePolicy(root), /events must be exactly push and workflow_dispatch/);
+});
+
+test("publisher rejects a quoted additional workflow event", () => {
+  for (const key of ["'pull_request_target'", '"pull_request_target"']) {
+    const root = fixture();
+    try {
+      replace(root, ".github/workflows/ci-image.yml", "  workflow_dispatch:\n", `  workflow_dispatch:\n  ${key}:\n`);
+      assert.throws(
+        () => validateCiImagePolicy(root),
+        /events must be exactly push and workflow_dispatch/,
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("publisher tag is unique per run attempt", (context) => {
+  const root = fixture();
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  replace(
+    root,
+    ".github/workflows/ci-image.yml",
+    "sha-${{ github.sha }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}",
+    "sha-${{ github.sha }}",
+  );
+
+  assert.throws(() => validateCiImagePolicy(root), /unique commit\/run\/attempt tag/);
+});
+
+test("FFmpeg package checksum verification precedes installation", (context) => {
+  const root = fixture();
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  replace(root, ".github/ci/Dockerfile", "| sha256sum -c -;", "| cat; ");
+
+  assert.throws(() => validateCiImagePolicy(root), /checksum-verified, then installed/);
+});
+
+test("release-facing workflow stays separate from CI image", (context) => {
+  const root = fixture();
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const target = path.join(root, ".github/workflows/pages.yml");
+  fs.appendFileSync(target, "\n# ghcr.io/grazzolini/tuneforge-ci\n");
+
+  assert.throws(() => validateCiImagePolicy(root), /Pages\/release media workflow/);
+});


### PR DESCRIPTION
## Summary

- add a digest-pinned AMD64 Ubuntu CI image with FFmpeg, Playwright, and Tauri system dependencies
- publish only from trusted main/manual events with scoped GHCR permissions, unique tags, SBOM, and provenance
- add fail-closed dependency drift, trigger, checksum, and release-boundary policy checks
- keep CI jobs on existing runners until a follow-up PR pins the published manifest digest
- Refs #460

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `node --test scripts/ci-image-policy.test.mjs` (9 passed)
- `actionlint`
- `git diff --check`
- `cd apps/backend && uv run --python 3.11 pytest` (693 passed)
- `pnpm test` reached Tauri with 330/331 passing; one existing transport test hit a transient macOS connection reset
- `cd apps/desktop/src-tauri && cargo test mobile_media_transport::tests::serves_closed_open_and_suffix_ranges_without_a_response_cap -- --exact` (passed on retry)
- GHCR publication, public visibility, anonymous pull, manifest promotion, and timing evidence remain post-merge gates
