### PR TITLE
ci: use digest-pinned CI image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  CI_IMAGE_REFERENCE: ghcr.io/grazzolini/tuneforge-ci@sha256:6b12309d6ce40b047567ce82f7a434b6a1a74f6c5f515480c49b374a3f289bb7
+
 jobs:
   ci-scope:
     runs-on: ubuntu-latest
@@ -236,7 +239,11 @@ jobs:
         run: bash scripts/android-arm64-env.test.sh
 
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    container: ghcr.io/grazzolini/tuneforge-ci@sha256:6b12309d6ce40b047567ce82f7a434b6a1a74f6c5f515480c49b374a3f289bb7
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Initialize E2E job
         shell: bash
@@ -254,6 +261,9 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify CI image
+        run: bash scripts/verify-ci-image.sh
 
       - name: Set up pnpm
         uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
@@ -284,23 +294,8 @@ jobs:
         working-directory: apps/backend
         run: uv sync --locked --all-groups
 
-      - name: Install FFmpeg
-        run: |
-          set -euo pipefail
-          started_at="$(date +%s)"
-          sudo apt-get update
-          sudo apt-get install -y ffmpeg
-          elapsed_seconds=$(($(date +%s) - started_at))
-          {
-            echo "## E2E FFmpeg setup"
-            echo
-            echo "- Duration: ${elapsed_seconds}s"
-            echo "- $(ffmpeg -version | sed -n '1p')"
-            echo "- $(ffprobe -version | sed -n '1p')"
-          } >> "${GITHUB_STEP_SUMMARY}"
-
       - name: Install Playwright Chromium
-        run: pnpm --filter @tuneforge/desktop exec playwright install --with-deps chromium
+        run: pnpm --filter @tuneforge/desktop exec playwright install chromium
 
       - name: Run desktop E2E suite
         shell: bash
@@ -450,7 +445,11 @@ jobs:
   backend:
     needs: ci-scope
     if: ${{ always() && (needs.ci-scope.result != 'success' || needs.ci-scope.outputs.backend_static == 'true' || needs.ci-scope.outputs.backend_ffmpeg == 'true') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    container: ghcr.io/grazzolini/tuneforge-ci@sha256:6b12309d6ce40b047567ce82f7a434b6a1a74f6c5f515480c49b374a3f289bb7
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Require CI scope
         if: needs.ci-scope.result != 'success'
@@ -460,6 +459,9 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify CI image
+        run: bash scripts/verify-ci-image.sh
 
       - name: Skip backend checks
         if: needs.ci-scope.outputs.backend_static != 'true' && needs.ci-scope.outputs.backend_ffmpeg != 'true'
@@ -491,22 +493,6 @@ jobs:
         if: needs.ci-scope.outputs.backend_static == 'true'
         working-directory: apps/backend
         run: uv run --python 3.11 mypy app
-
-      - name: Install FFmpeg
-        if: needs.ci-scope.outputs.backend_ffmpeg == 'true'
-        run: |
-          set -euo pipefail
-          started_at="$(date +%s)"
-          sudo apt-get update
-          sudo apt-get install -y ffmpeg
-          elapsed_seconds=$(($(date +%s) - started_at))
-          {
-            echo "## Backend FFmpeg setup"
-            echo
-            echo "- Duration: ${elapsed_seconds}s"
-            echo "- $(ffmpeg -version | sed -n '1p')"
-            echo "- $(ffprobe -version | sed -n '1p')"
-          } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Test backend
         if: needs.ci-scope.outputs.backend_ffmpeg == 'true'
@@ -597,7 +583,11 @@ jobs:
   desktop_tauri:
     needs: ci-scope
     if: ${{ always() && (needs.ci-scope.result != 'success' || needs.ci-scope.outputs.desktop == 'true') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    container: ghcr.io/grazzolini/tuneforge-ci@sha256:6b12309d6ce40b047567ce82f7a434b6a1a74f6c5f515480c49b374a3f289bb7
+    defaults:
+      run:
+        shell: bash
     env:
       RUST_VERSION: "1.97.1"
     steps:
@@ -610,11 +600,16 @@ jobs:
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Verify CI image
+        run: bash scripts/verify-ci-image.sh
+
       - name: Set up Rust
         if: needs.ci-scope.outputs.desktop == 'true'
-        run: |
-          rustup toolchain install "${RUST_VERSION}" --profile minimal
-          rustup default "${RUST_VERSION}"
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          cache: false
+          rustflags: ""
 
       - name: Cache Cargo dependencies and build output
         if: needs.ci-scope.outputs.desktop == 'true'
@@ -627,19 +622,6 @@ jobs:
             apps/desktop/src-tauri/target
             !apps/desktop/src-tauri/target/debug/incremental
           key: cargo-v1-${{ runner.os }}-${{ runner.arch }}-rust-${{ env.RUST_VERSION }}-${{ hashFiles('apps/desktop/src-tauri/Cargo.lock', 'apps/desktop/src-tauri/Cargo.toml') }}
-
-      - name: Install Tauri system dependencies
-        if: needs.ci-scope.outputs.desktop == 'true'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libasound2-dev \
-            libwebkit2gtk-4.1-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            libxdo-dev \
-            libssl-dev
 
       - name: Check Tauri shell
         if: needs.ci-scope.outputs.desktop == 'true'

--- a/scripts/ci-image-policy.mjs
+++ b/scripts/ci-image-policy.mjs
@@ -49,6 +49,9 @@ const playwrightNoblePackages = [
   "libxrandr2",
 ];
 
+const ciImageReference =
+  "ghcr.io/grazzolini/tuneforge-ci@sha256:6b12309d6ce40b047567ce82f7a434b6a1a74f6c5f515480c49b374a3f289bb7";
+const ciImageConsumers = ["backend", "e2e", "desktop_tauri"];
 function read(root, relativePath) {
   return fs.readFileSync(path.join(root, relativePath), "utf8");
 }
@@ -62,9 +65,9 @@ function dockerQuotedArgWords(dockerfile, name) {
   return value?.replace(/\\\r?\n/g, " ").trim().split(/\s+/);
 }
 
-function levelTwoMappingKey(line) {
-  const content = line.match(/^  (?!\s)(.+)$/)?.[1];
-  if (!content) return undefined;
+function mappingKey(line, indentation) {
+  const content = line.match(new RegExp(`^ {${indentation}}(?!\\s)(.+)$`))?.[1];
+  if (!content || content.startsWith("#")) return undefined;
   const singleQuoted = content.match(/^'((?:[^']|'')*)'\s*:/)?.[1];
   if (singleQuoted !== undefined) return singleQuoted.replaceAll("''", "'");
   const doubleQuoted = content.match(/^"((?:[^"\\]|\\.)*)"\s*:/)?.[1];
@@ -72,10 +75,14 @@ function levelTwoMappingKey(line) {
     try {
       return JSON.parse(`"${doubleQuoted}"`);
     } catch {
-      return `"${doubleQuoted}"`;
+      return `!unparsed:${content}`;
     }
   }
   return content.match(/^([^:]+?)\s*:/)?.[1].trimEnd() ?? `!unparsed:${content}`;
+}
+
+function levelTwoMappingKey(line) {
+  return mappingKey(line, 2);
 }
 
 function topLevelMappingKeys(yaml, name) {
@@ -90,6 +97,108 @@ function topLevelMappingKeys(yaml, name) {
     if (key !== undefined) keys.push(key);
   }
   return keys;
+}
+
+function workflowJobs(workflow) {
+  const lines = workflow.split("\n");
+  const jobsStart = lines.findIndex((line) => line === "jobs:");
+  if (jobsStart === -1) return [];
+  const starts = [];
+  let jobsEnd = lines.length;
+  for (let index = jobsStart + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (line.trim() === "" || line.trimStart().startsWith("#")) continue;
+    if (!line.startsWith(" ")) {
+      jobsEnd = index;
+      break;
+    }
+    const name = levelTwoMappingKey(line);
+    if (name !== undefined) starts.push({ name, index });
+  }
+  return starts.map(({ name, index }, position) => ({
+    name,
+    block: `${lines.slice(index, starts[position + 1]?.index ?? jobsEnd).join("\n")}\n`,
+  }));
+}
+
+function workflowJobBlock(workflow, name) {
+  return workflowJobs(workflow).find((job) => job.name === name)?.block ?? "";
+}
+
+function verifierCallIndexes(block) {
+  return [...block.matchAll(/^(?: {8}run:| {6}- run:) bash scripts\/verify-ci-image\.sh$/gm)].map((match) => match.index);
+}
+
+function yamlScalar(value) {
+  const scalar = value.trim().replace(/\s+#.*$/, "");
+  if (scalar.startsWith("'") && scalar.endsWith("'")) {
+    return scalar.slice(1, -1).replaceAll("''", "'");
+  }
+  if (scalar.startsWith('"') && scalar.endsWith('"')) {
+    try {
+      return JSON.parse(scalar);
+    } catch {
+      return scalar;
+    }
+  }
+  return scalar;
+}
+
+function jobContainerImage(block) {
+  const lines = block.split("\n");
+  const jobKeys = lines.map((line) => mappingKey(line, 4));
+  if (jobKeys.some((key) => key?.startsWith("!unparsed:"))) return "!unparsed";
+  const containerIndex = jobKeys.findIndex((key) => key === "container");
+  if (containerIndex === -1) return undefined;
+  const value = lines[containerIndex].match(
+    /^    (?:container|'container'|"container")\s*:\s*(.*?)\s*$/,
+  )?.[1];
+  if (value === undefined) return undefined;
+  if (value === "") {
+    for (const line of lines.slice(containerIndex + 1)) {
+      if (line.trim() === "") continue;
+      const indentation = line.match(/^ */)?.[0].length ?? 0;
+      if (indentation <= 4) break;
+      const image = line.match(/^      (?:image|'image'|"image")\s*:\s*(.+?)\s*$/)?.[1];
+      if (image !== undefined) return yamlScalar(image);
+    }
+    return undefined;
+  }
+  if (value.startsWith("{")) {
+    const image = value.match(/(?:^\{\s*|,\s*)(?:image|'image'|"image")\s*:\s*([^,}]+)/)?.[1];
+    return image === undefined ? undefined : yamlScalar(image);
+  }
+  return yamlScalar(value);
+}
+
+function jobGrantsPackagesWrite(block) {
+  const lines = block.split("\n");
+  const permissionsIndex = lines.findIndex((line) =>
+    /^    (?:permissions|'permissions'|"permissions")\s*:/.test(line),
+  );
+  if (permissionsIndex === -1) return false;
+  const value = lines[permissionsIndex].match(
+    /^    (?:permissions|'permissions'|"permissions")\s*:\s*(.*?)\s*$/,
+  )?.[1];
+  if (value === undefined) return true;
+  if (yamlScalar(value) === "write-all") return true;
+  if (value.startsWith("{")) {
+    const packages = value.match(
+      /(?:^\{\s*|,\s*)(?:packages|'packages'|"packages")\s*:\s*([^,}]+)/,
+    )?.[1];
+    return packages !== undefined && yamlScalar(packages) === "write";
+  }
+  if (value !== "") return false;
+  for (const line of lines.slice(permissionsIndex + 1)) {
+    if (line.trim() === "") continue;
+    const indentation = line.match(/^ */)?.[0].length ?? 0;
+    if (indentation <= 4) break;
+    const packages = line.match(
+      /^      (?:packages|'packages'|"packages")\s*:\s*(.+?)\s*$/,
+    )?.[1];
+    if (packages !== undefined) return yamlScalar(packages) === "write";
+  }
+  return false;
 }
 
 function desktopLockfilePlaywrightVersion(lockfile) {
@@ -214,6 +323,74 @@ export function validateCiImagePolicy(root) {
   check(
     /package-ecosystem: docker\n    directory: "\/\.github\/ci"/.test(dependabot),
     "Dependabot must track Docker base-image digests under .github/ci",
+  );
+
+  const jobs = workflowJobs(mainWorkflow);
+  const workflowImageReference = mainWorkflow.match(
+    /^env:\n  CI_IMAGE_REFERENCE:\s+(\S+)$/m,
+  )?.[1];
+  const consumerBlocks = ciImageConsumers.map((name) => [
+    name,
+    workflowJobBlock(mainWorkflow, name),
+  ]);
+  const imageConsumers = jobs
+    .map(({ name, block }) => ({ name, block, image: jobContainerImage(block) }))
+    .filter(({ image }) =>
+      image?.match(/^ghcr\.io\/grazzolini\/tuneforge-ci(?::|@|$)/),
+    );
+  check(
+    jobs.every(({ block }) => jobContainerImage(block) !== "!unparsed") &&
+      workflowImageReference === ciImageReference &&
+      JSON.stringify(imageConsumers.map(({ name }) => name).sort()) ===
+      JSON.stringify([...ciImageConsumers].sort()) &&
+      imageConsumers.every(({ image }) => image === ciImageReference) &&
+      consumerBlocks.every(([, block]) => block.includes(`    container: ${ciImageReference}`)),
+    "Exactly backend, e2e, and desktop_tauri must consume the same pinned CI image digest",
+  );
+  for (const [name, block] of consumerBlocks) {
+    check(block.includes("    runs-on: ubuntu-24.04"), `${name} must use ubuntu-24.04`);
+    check(
+      block.includes("    defaults:\n      run:\n        shell: bash"),
+      `${name} must default run steps to Bash`,
+    );
+    const checkoutIndex = block.indexOf("uses: actions/checkout@");
+    const verifierCalls = verifierCallIndexes(block);
+    check(
+      verifierCalls.length === 1 &&
+        checkoutIndex >= 0 &&
+        verifierCalls[0] > checkoutIndex,
+      `${name} must call the shared CI image verifier once after checkout`,
+    );
+    check(!/\bapt(?:-get)?\b/.test(block), `${name} must not execute apt in PR CI`);
+    check(!block.includes("--with-deps"), `${name} must not use Playwright --with-deps`);
+    check(!/^\s+credentials:/m.test(block), `${name} must not configure container credentials`);
+    check(!jobGrantsPackagesWrite(block), `${name} must not receive packages: write`);
+  }
+  check(
+    JSON.stringify(
+      jobs
+        .filter(({ block }) => verifierCallIndexes(block).length > 0)
+        .map(({ name }) => name)
+        .sort(),
+    ) === JSON.stringify([...ciImageConsumers].sort()),
+    "Only CI image consumers may call the shared verifier",
+  );
+  const e2eBlock = workflowJobBlock(mainWorkflow, "e2e");
+  check(
+    e2eBlock.includes(
+      "pnpm --filter @tuneforge/desktop exec playwright install chromium",
+    ),
+    "e2e must install only the lockfile-matched Chromium browser at runtime",
+  );
+  const tauriBlock = workflowJobBlock(mainWorkflow, "desktop_tauri");
+  check(
+    tauriBlock.includes(
+      "uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1",
+    ) &&
+      tauriBlock.includes("toolchain: ${{ env.RUST_VERSION }}") &&
+      tauriBlock.includes("cache: false") &&
+      tauriBlock.includes('rustflags: ""'),
+    "desktop_tauri must bootstrap pinned Rust without action-managed caching or rustflags",
   );
 
   if (errors.length > 0) {

--- a/scripts/ci-image-policy.test.mjs
+++ b/scripts/ci-image-policy.test.mjs
@@ -8,6 +8,10 @@ import { fileURLToPath } from "node:url";
 import { validateCiImagePolicy } from "./ci-image-policy.mjs";
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const ciImageReference = fs
+  .readFileSync(path.join(repositoryRoot, ".github/workflows/ci.yml"), "utf8")
+  .match(/^  CI_IMAGE_REFERENCE:\s+(\S+)$/m)?.[1];
+assert.ok(ciImageReference, "CI workflow must declare CI_IMAGE_REFERENCE");
 const fixtureFiles = [
   "apps/desktop/package.json",
   "pnpm-lock.yaml",
@@ -34,6 +38,16 @@ function replace(root, relativePath, before, after) {
   const original = fs.readFileSync(target, "utf8");
   assert.ok(original.includes(before), `${relativePath} fixture must include replacement target`);
   fs.writeFileSync(target, original.replaceAll(before, after));
+}
+
+function assertMutationsFail(relativePath, mutations, expected) {
+  for (const [before, after] of mutations) {
+    const root = fixture();
+    try {
+      replace(root, relativePath, before, after);
+      assert.throws(() => validateCiImagePolicy(root), expected);
+    } finally { fs.rmSync(root, { recursive: true, force: true }); }
+  }
 }
 
 test("repository satisfies CI image policy", () => {
@@ -132,6 +146,103 @@ test("FFmpeg package checksum verification precedes installation", (context) => 
   replace(root, ".github/ci/Dockerfile", "| sha256sum -c -;", "| cat; ");
 
   assert.throws(() => validateCiImagePolicy(root), /checksum-verified, then installed/);
+});
+
+test("CI image consumers require independent exact env and container digests", () =>
+  assertMutationsFail(".github/workflows/ci.yml", [
+    [`env:\n  CI_IMAGE_REFERENCE: ${ciImageReference}`, "env:\n  CI_IMAGE_REFERENCE: ghcr.io/grazzolini/tuneforge-ci:main"],
+    [`    container: ${ciImageReference}`, "    container: ghcr.io/grazzolini/tuneforge-ci:main"],
+  ], /Exactly backend, e2e, and desktop_tauri/));
+
+test("CI image consumers reject valid container credentials", (context) => {
+  const root = fixture();
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  replace(
+    root,
+    ".github/workflows/ci.yml",
+    `    container: ${ciImageReference}`,
+    `    container:\n      image: ${ciImageReference}\n      credentials:\n        username: actor\n        password: token`,
+  );
+
+  assert.throws(() => validateCiImagePolicy(root), /backend must not configure container credentials/);
+});
+
+test("CI image consumers reject every valid packages write permission form", () => {
+  const permissions = [
+    "    permissions:\n      packages: write", '    permissions:\n      packages: "write"',
+    "    permissions:\n      packages: 'write'", "    permissions: { contents: read, packages: write }",
+    "    permissions: write-all", '    permissions: "write-all"', "    permissions: 'write-all'",
+  ];
+  assertMutationsFail(
+    ".github/workflows/ci.yml",
+    permissions.map((value) => ["  backend:\n    needs: ci-scope", `  backend:\n${value}\n    needs: ci-scope`]),
+    /backend must not receive packages: write/,
+  );
+});
+
+test("CI image consumer discovery rejects fourth-job container key variants", () => {
+  const containers = [
+    `    container:\n      image: ${ciImageReference}`, `    container: { image: ${ciImageReference} }`,
+    `    'container': ${ciImageReference}`, `    "container": ${ciImageReference}`,
+    `    'container':\n      image: ${ciImageReference}`, `    "container": { image: ${ciImageReference} }`,
+    `    ? container\n    : ${ciImageReference}`,
+  ];
+  assertMutationsFail(
+    ".github/workflows/ci.yml",
+    containers.map((value) => ["jobs:\n", `jobs:\n  unexpected_ci_image:\n    runs-on: ubuntu-24.04\n${value}\n    steps:\n      - run: echo unexpected\n\n`]),
+    /Exactly backend, e2e, and desktop_tauri/,
+  );
+});
+
+test("targeted jobs reject apt and Playwright system dependency installation", (context) => {
+  const root = fixture();
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  replace(
+    root,
+    ".github/workflows/ci.yml",
+    "run: pnpm --filter @tuneforge/desktop exec playwright install chromium",
+    "run: pnpm --filter @tuneforge/desktop exec playwright install --with-deps chromium\n\n      - run: sudo apt-get update",
+  );
+
+  assert.throws(
+    () => validateCiImagePolicy(root),
+    /e2e must not execute apt[\s\S]*e2e must not use Playwright --with-deps/,
+  );
+});
+
+test("shared verifier calls reject comments, wrong order, duplicates, and nonconsumers", () => {
+  const run = "        run: bash scripts/verify-ci-image.sh";
+  const step = `      - name: Verify CI image\n${run}`;
+  const checkout = "      - name: Check out code\n        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1";
+  assertMutationsFail(".github/workflows/ci.yml", [
+    [run, `        # ${run.trim()}`],
+    [`${checkout}\n\n${step}`, `${step}\n\n${checkout}`],
+    [step, `${step}\n\n${step}`],
+    ["          fetch-depth: 0", "          fetch-depth: 0\n\n      - run: bash scripts/verify-ci-image.sh"],
+  ], /must call the shared CI image verifier|Only CI image consumers/);
+});
+
+test("consumer runner and shell checks fail closed", (context) => {
+  const root = fixture();
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  replace(
+    root,
+    ".github/workflows/ci.yml",
+    `  e2e:\n    runs-on: ubuntu-24.04\n    container: ${ciImageReference}\n    defaults:\n      run:\n        shell: bash`,
+    `  e2e:\n    runs-on: ubuntu-latest\n    container: ${ciImageReference}\n    defaults:\n      run:\n        shell: sh`,
+  );
+  assert.throws(
+    () => validateCiImagePolicy(root),
+    /e2e must use ubuntu-24\.04[\s\S]*e2e must default run steps to Bash/,
+  );
+});
+
+test("pinned Rust bootstrap stays required", (context) => {
+  const root = fixture();
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  replace(root, ".github/workflows/ci.yml", "          cache: false\n", "          cache: true\n");
+
+  assert.throws(() => validateCiImagePolicy(root), /must bootstrap pinned Rust/);
 });
 
 test("release-facing workflow stays separate from CI image", (context) => {

--- a/scripts/verify-ci-image.sh
+++ b/scripts/verify-ci-image.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${CI_IMAGE_REFERENCE:?CI_IMAGE_REFERENCE is required}"
+: "${GITHUB_JOB:?GITHUB_JOB is required}"
+: "${GITHUB_STEP_SUMMARY:?GITHUB_STEP_SUMMARY is required}"
+
+ffmpeg_path="$(command -v ffmpeg)"
+ffprobe_path="$(command -v ffprobe)"
+test "${ffmpeg_path}" = /usr/bin/ffmpeg
+test "${ffprobe_path}" = /usr/bin/ffprobe
+
+{
+  printf '## %s CI image\n\n' "${GITHUB_JOB}"
+  printf -- '- Image: `%s`\n' "${CI_IMAGE_REFERENCE}"
+  printf -- '- FFmpeg: `%s` — `%s`\n' "${ffmpeg_path}" "$(ffmpeg -version | sed -n '1p')"
+  printf -- '- FFprobe: `%s` — `%s`\n' "${ffprobe_path}" "$(ffprobe -version | sed -n '1p')"
+} >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
## Summary

- run backend, E2E, and Tauri CI jobs in the public digest-pinned CI image
- remove repeated runtime APT setup while preserving job-time Node, Python, pnpm, uv, Rust, and Cargo setup/cache behavior
- centralize minimal FFmpeg image verification and enforce the consumer contract with mutation tests
- keep Pages, packaging, Flatpak, release workflows, and application runtime behavior unchanged
- Closes #460

## Testing

- `node --test scripts/ci-image-policy.test.mjs` (18 passed)
- `node scripts/ci-image-policy.mjs`
- `bash -n scripts/verify-ci-image.sh`
- `actionlint`
- `git diff --check`
- `pnpm lint`
- `pnpm typecheck`
- `cd apps/backend && uv run --python 3.11 pytest` (693 passed)
- `pnpm test` passed all preceding suites and 330/331 Tauri tests before a known macOS socket test hit a transient `NotConnected`; its exact retry passed
- Actions run 32426004874 passed all checks, including backend pytest, Chromium-only E2E, Tauri `cargo check`, and Tauri `cargo test`
- Three pre-image runs had median totals (range): E2E 126s (123–145), backend 254s (227–279), Tauri 118s (90–154)
- Removed runtime setup medians: E2E FFmpeg/Playwright OS 33s, backend FFmpeg 31s, Tauri native libraries 30s
- Current totals / container initialization: E2E 124s / 25s, backend 254s / 27s, Tauri 309s / 33s
- No APT mirror stall occurred in the baseline samples; E2E/backend were roughly flat, while Cargo cache restore and recompilation dominated Tauri, so no fixed-percentage improvement is claimed
- Fork-PR anonymous-pull proof and repeated post-merge timing samples remain follow-up evidence
