### PR TITLE
ci: add libclang to CI image

### DIFF
--- a/.github/ci/Dockerfile
+++ b/.github/ci/Dockerfile
@@ -35,6 +35,7 @@ RUN set -eux; \
       gzip \
       libasound2-dev \
       libayatana-appindicator3-dev \
+      libclang-dev \
       libgtk-3-dev \
       librsvg2-dev \
       libssl-dev \

--- a/.github/ci/README.md
+++ b/.github/ci/README.md
@@ -16,7 +16,8 @@ anything from this image.
 - Playwright: Ubuntu 24.04 Chromium system dependencies reviewed against
   Playwright `1.62.1`. Chromium itself remains a job-time download.
 - Tauri: the GTK, WebKitGTK, ALSA, AppIndicator, SVG, XDo, and OpenSSL
-  development packages previously installed by the CI workflow.
+  development packages previously installed by the CI workflow, plus
+  `libclang-dev` for Rust bindgen.
 - CI utilities: only tools needed by setup actions and native builds. No source
   tree, dependency directory, build output, model, user data, or credential is
   included.

--- a/scripts/ci-image-policy.mjs
+++ b/scripts/ci-image-policy.mjs
@@ -143,6 +143,11 @@ export function validateCiImagePolicy(root) {
       ),
     "Dockerfile must contain the exact reviewed Playwright 1.62.1 Noble tools and Chromium packages",
   );
+  check(
+    dockerfile.includes("      libclang-dev \\\n") &&
+      imageReadme.includes("`libclang-dev` for Rust bindgen"),
+    "CI image must install and document libclang-dev for Rust bindgen",
+  );
 
   check(
     JSON.stringify(topLevelMappingKeys(imageWorkflow, "on")) ===

--- a/scripts/ci-image-policy.test.mjs
+++ b/scripts/ci-image-policy.test.mjs
@@ -60,6 +60,14 @@ test("Playwright dependency review requires the exact Noble package set", (conte
   assert.throws(() => validateCiImagePolicy(root), /exact reviewed Playwright 1\.62\.1 Noble/);
 });
 
+test("Rust bindgen requires libclang-dev in the CI image", (context) => {
+  const root = fixture();
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  replace(root, ".github/ci/Dockerfile", "      libclang-dev \\\n", "");
+
+  assert.throws(() => validateCiImagePolicy(root), /libclang-dev for Rust bindgen/);
+});
+
 test("untrusted and broad publisher triggers fail closed", (context) => {
   const root = fixture();
   context.after(() => fs.rmSync(root, { recursive: true, force: true }));


### PR DESCRIPTION
## Summary

- add `libclang-dev` required by Rust bindgen during Tauri container builds
- enforce and document the CI-image native dependency contract
- keep PR #462 on the existing digest until this image update publishes
- Refs #460

## Testing

- `node --test scripts/ci-image-policy.test.mjs` (10/10 passed)
- `node scripts/ci-image-policy.mjs`
- `actionlint .github/workflows/ci-image.yml`
- `git diff --check`
- Docker image build not run because the user-owned Docker daemon was stopped; after starting it manually, run `docker buildx build --no-cache --platform linux/amd64 --load --tag tuneforge-ci:libclang-check .github/ci`
- GHCR publication, digest inspection, and PR #462 digest promotion remain post-merge gates
