### PR TITLE
feat: add durable audio storage formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ download, installation, verification, signature, and publication instructions.
 
 ## [Unreleased]
 
+### Added
+
+- Added backend storage, processing-job, and desktop-sync foundations for durable WAV, FLAC, MP3,
+  and M4A audio artifacts ([#398](https://github.com/grazzolini/tuneforge/issues/398)).
+
 ### Fixed
 
 - Preserved project playback safely across native output route changes and interruptions by using

--- a/apps/backend/app/api/routes/projects.py
+++ b/apps/backend/app/api/routes/projects.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 
 from app.api.pagination import PaginationQuery, pagination_metadata
 from app.dependencies import get_db, get_job_runner
+from app.engines.audio_encoding import require_encoding_available
 from app.models import AnalysisResult, Artifact, ChordTimeline, LyricsTranscript
 from app.schemas import (
     AnalysisRequest,
@@ -92,6 +93,7 @@ def create_project(
         source_path=payload.source_path,
         copy_into_project=payload.copy_into_project,
         display_name=payload.display_name,
+        output_format=payload.output_format,
     )
     analyze_job = runner.create_job(
         session,
@@ -117,7 +119,7 @@ def create_project(
             **StemRequest(
                 mode="stems",
                 stem_model=selected_stem_model.id,
-                output_format="wav",
+                output_format=payload.output_format,
                 force=False,
                 source_artifact_id=source_artifact.id,
                 chord_backend=selected_chord_backend.id,
@@ -403,6 +405,7 @@ def project_preview(
     runner=Depends(get_job_runner),
 ) -> JobResponse:
     get_mutable_project(session, project_id)
+    require_encoding_available(payload.output_format)
     job = runner.create_job(
         session,
         project_id=project_id,

--- a/apps/backend/app/engines/audio_encoding.py
+++ b/apps/backend/app/engines/audio_encoding.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Callable
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Literal, cast
+
+from app.config import get_settings
+from app.dependency_diagnostics import missing_host_tool_error
+from app.errors import AppError, JobCancelledError
+
+DurableAudioFormat = Literal["wav", "flac", "mp3", "m4a"]
+DURABLE_AUDIO_FORMATS: tuple[DurableAudioFormat, ...] = ("wav", "flac", "mp3", "m4a")
+
+ENCODING_PROFILES: dict[DurableAudioFormat, tuple[str, ...]] = {
+    "wav": ("-c:a", "pcm_s16le"),
+    "flac": ("-c:a", "flac", "-compression_level", "5"),
+    "mp3": ("-c:a", "libmp3lame", "-b:a", "192k"),
+    "m4a": ("-c:a", "aac", "-profile:a", "aac_low", "-b:a", "192k", "-f", "mp4"),
+}
+
+_ENCODING_REQUIREMENTS: dict[DurableAudioFormat, tuple[str, str]] = {
+    "wav": ("pcm_s16le", "wav"),
+    "flac": ("flac", "flac"),
+    "mp3": ("libmp3lame", "mp3"),
+    "m4a": ("aac", "mp4"),
+}
+
+
+@lru_cache(maxsize=1)
+def probe_encoding_formats() -> dict[DurableAudioFormat, tuple[bool, str | None]]:
+    ffmpeg_path = get_settings().ffmpeg_path
+    try:
+        encoders = subprocess.run(
+            [ffmpeg_path, "-hide_banner", "-encoders"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout
+        muxers = subprocess.run(
+            [ffmpeg_path, "-hide_banner", "-muxers"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout
+    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        reason = "Configured FFmpeg is unavailable."
+        return {output_format: (False, reason) for output_format in DURABLE_AUDIO_FORMATS}
+
+    capabilities: dict[DurableAudioFormat, tuple[bool, str | None]] = {}
+    for output_format, (encoder, muxer) in _ENCODING_REQUIREMENTS.items():
+        encoder_available = any(
+            len(parts) >= 2 and parts[1] == encoder
+            for line in encoders.splitlines()
+            if (parts := line.split())
+        )
+        muxer_available = any(
+            len(parts) >= 2 and muxer in parts[1].split(",")
+            for line in muxers.splitlines()
+            if (parts := line.split())
+        )
+        available = encoder_available and muxer_available
+        capabilities[output_format] = (
+            available,
+            None if available else f"Configured FFmpeg cannot encode {output_format.upper()} audio.",
+        )
+    return capabilities
+
+
+def encoding_profile(output_format: str) -> tuple[str, ...]:
+    if output_format not in DURABLE_AUDIO_FORMATS:
+        raise AppError("INVALID_REQUEST", "Unsupported audio format.", status_code=422)
+    return ENCODING_PROFILES[cast(DurableAudioFormat, output_format)]
+
+
+def require_encoding_available(output_format: DurableAudioFormat) -> None:
+    available, reason = probe_encoding_formats()[output_format]
+    if not available:
+        raise AppError(
+            "AUDIO_ENCODING_UNAVAILABLE",
+            reason or f"Configured FFmpeg cannot encode {output_format.upper()} audio.",
+            status_code=422,
+            details={"format": output_format},
+        )
+
+
+def encode_audio(
+    source_path: Path,
+    destination_path: Path,
+    output_format: DurableAudioFormat,
+    *,
+    should_cancel: Callable[[], bool] | None = None,
+    register_process: Callable[[subprocess.Popen[str]], None] | None = None,
+    unregister_process: Callable[[], None] | None = None,
+) -> None:
+    destination_path.parent.mkdir(parents=True, exist_ok=True)
+    command = [
+        get_settings().ffmpeg_path,
+        "-y",
+        "-nostdin",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        str(source_path),
+        "-map",
+        "0:a:0",
+        "-vn",
+        *encoding_profile(output_format),
+        str(destination_path),
+    ]
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise missing_host_tool_error(
+            tool="ffmpeg",
+            operation="audio_encoding",
+            impact="encode durable audio",
+        ) from exc
+    if register_process:
+        register_process(process)
+    try:
+        while process.poll() is None:
+            if should_cancel and should_cancel():
+                process.terminate()
+                raise JobCancelledError()
+            try:
+                process.wait(timeout=0.1)
+            except subprocess.TimeoutExpired:
+                continue
+    finally:
+        if unregister_process:
+            unregister_process()
+    if process.returncode != 0:
+        raise AppError("PROCESSING_FAILED", "FFmpeg failed to encode audio.")
+
+
+def probe_audio_file(path: Path) -> dict[str, Any]:
+    command = [
+        get_settings().ffprobe_path,
+        "-v",
+        "error",
+        "-select_streams",
+        "a:0",
+        "-show_entries",
+        "stream=codec_name,profile,channels,sample_rate",
+        "-show_entries",
+        "format=format_name",
+        "-of",
+        "json",
+        str(path),
+    ]
+    try:
+        result = subprocess.run(command, check=True, capture_output=True, text=True)
+        payload = json.loads(result.stdout or "{}")
+    except FileNotFoundError as exc:
+        raise missing_host_tool_error(
+            tool="ffprobe",
+            operation="audio_validation",
+            impact="validate encoded audio",
+        ) from exc
+    except (json.JSONDecodeError, subprocess.CalledProcessError) as exc:
+        raise AppError("INVALID_AUDIO_FILE", "Audio file is unreadable.", status_code=422) from exc
+    if not isinstance(payload, dict):
+        raise AppError("INVALID_AUDIO_FILE", "Audio file is unreadable.", status_code=422)
+    return payload
+
+
+def validate_audio_file(
+    path: Path,
+    output_format: DurableAudioFormat,
+    *,
+    require_suffix: bool = True,
+) -> None:
+    if require_suffix and path.suffix.lower() != f".{output_format}":
+        raise AppError("INVALID_AUDIO_FILE", "Audio filename does not match its declared format.", status_code=422)
+    payload = probe_audio_file(path)
+    streams = payload.get("streams")
+    fmt = payload.get("format")
+    if not isinstance(streams, list) or not streams or not isinstance(fmt, dict):
+        raise AppError("INVALID_AUDIO_FILE", "Audio file is unreadable.", status_code=422)
+    stream = streams[0]
+    if not isinstance(stream, dict):
+        raise AppError("INVALID_AUDIO_FILE", "Audio file is unreadable.", status_code=422)
+    codec = stream.get("codec_name")
+    profile = stream.get("profile")
+    format_name = fmt.get("format_name")
+    format_names = (
+        {name.strip().lower() for name in format_name.split(",")}
+        if isinstance(format_name, str)
+        else set()
+    )
+    expected = {
+        "wav": ("pcm_s16le", {"wav"}),
+        "flac": ("flac", {"flac"}),
+        "mp3": ("mp3", {"mp3"}),
+        "m4a": ("aac", {"mov", "mp4", "m4a", "3gp", "3g2", "mj2"}),
+    }[output_format]
+    try:
+        valid_dimensions = int(stream.get("channels", 0)) > 0 and int(stream.get("sample_rate", 0)) > 0
+    except (TypeError, ValueError):
+        valid_dimensions = False
+    valid_profile = output_format != "m4a" or profile == "LC"
+    if (
+        codec != expected[0]
+        or not format_names.intersection(expected[1])
+        or not valid_dimensions
+        or not valid_profile
+    ):
+        raise AppError(
+            "INVALID_AUDIO_FILE",
+            f"Audio file is not valid {output_format.upper()} audio.",
+            status_code=422,
+        )

--- a/apps/backend/app/engines/transform.py
+++ b/apps/backend/app/engines/transform.py
@@ -3,75 +3,18 @@ from __future__ import annotations
 import math
 import subprocess
 from collections.abc import Callable
-from functools import lru_cache
 from pathlib import Path
 
 from app.config import get_settings
 from app.dependency_diagnostics import missing_host_tool_error
+from app.engines.audio_encoding import encoding_profile, probe_encoding_formats
 from app.errors import AppError, JobCancelledError
 
-_EXPORT_PROFILES: dict[str, tuple[str, ...]] = {
-    "wav": ("-c:a", "pcm_s16le"),
-    "flac": ("-c:a", "flac", "-compression_level", "5"),
-    "mp3": ("-c:a", "libmp3lame", "-b:a", "192k"),
-    "m4a": ("-c:a", "aac", "-profile:a", "aac_low", "-b:a", "192k", "-f", "mp4"),
-}
-
-_EXPORT_REQUIREMENTS = {
-    "wav": ("pcm_s16le", "wav"),
-    "flac": ("flac", "flac"),
-    "mp3": ("libmp3lame", "mp3"),
-    "m4a": ("aac", "mp4"),
-}
-
-
-@lru_cache(maxsize=1)
-def probe_export_formats() -> dict[str, tuple[bool, str | None]]:
-    ffmpeg_path = get_settings().ffmpeg_path
-    try:
-        encoders = subprocess.run(
-            [ffmpeg_path, "-hide_banner", "-encoders"],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=10,
-        ).stdout
-        muxers = subprocess.run(
-            [ffmpeg_path, "-hide_banner", "-muxers"],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=10,
-        ).stdout
-    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
-        reason = "Configured FFmpeg is unavailable."
-        return {output_format: (False, reason) for output_format in _EXPORT_PROFILES}
-
-    capabilities: dict[str, tuple[bool, str | None]] = {}
-    for output_format, (encoder, muxer) in _EXPORT_REQUIREMENTS.items():
-        encoder_available = any(
-            len(parts) >= 2 and parts[1] == encoder
-            for line in encoders.splitlines()
-            if (parts := line.split())
-        )
-        muxer_available = any(
-            len(parts) >= 2 and muxer in parts[1].split(",")
-            for line in muxers.splitlines()
-            if (parts := line.split())
-        )
-        available = encoder_available and muxer_available
-        capabilities[output_format] = (
-            available,
-            None if available else f"Configured FFmpeg does not support {output_format.upper()} export.",
-        )
-    return capabilities
+probe_export_formats = probe_encoding_formats
 
 
 def export_profile(output_format: str) -> tuple[str, ...]:
-    try:
-        return _EXPORT_PROFILES[output_format]
-    except KeyError as exc:
-        raise AppError("INVALID_REQUEST", "Unsupported export format.", status_code=422) from exc
+    return encoding_profile(output_format)
 
 
 def _tempo_filters(tempo_ratio: float) -> list[str]:

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -16,6 +16,7 @@ from pydantic import (
 )
 from typing_extensions import TypeAliasType
 
+from app.engines.audio_encoding import DurableAudioFormat
 from app.runtime_status import (
     JobRuntimeStage,
     safe_runtime_detail,
@@ -144,6 +145,7 @@ class ProjectImportRequest(BaseModel):
     source_path: str
     copy_into_project: bool = True
     display_name: str | None = None
+    output_format: DurableAudioFormat = "wav"
     chord_backend: str | None = None
     chord_backend_fallback_from: str | None = None
     stem_model: str | None = None
@@ -1340,6 +1342,7 @@ BulkJobSkipReason = Literal["active_job", "locked", "creation_failed", "no_exist
 
 class BulkJobRequest(BaseModel):
     job_type: BulkJobType = Field(description="Project job type to enqueue for every project.")
+    output_format: DurableAudioFormat = "wav"
     chord_backend: str | None = None
     chord_backend_fallback_from: str | None = None
     stem_model: str | None = None
@@ -1350,6 +1353,8 @@ class BulkJobRequest(BaseModel):
         _validate_chord_backend_fields(self.chord_backend, self.chord_backend_fallback_from)
         if self.stem_model is not None and self.stem_model not in SUPPORTED_STEM_MODELS:
             raise ValueError("Unsupported stem model.")
+        if self.job_type != "stems" and self.output_format != "wav":
+            raise ValueError("output_format is only supported for bulk stem jobs.")
         return self
 
 
@@ -1432,7 +1437,7 @@ class PreviewTransposeRequest(BaseModel):
 class PreviewRequest(BaseModel):
     retune: PreviewRetuneRequest | None = None
     transpose: PreviewTransposeRequest | None = None
-    output_format: str = "wav"
+    output_format: DurableAudioFormat = "wav"
 
     @model_validator(mode="after")
     def validate_preview(self) -> PreviewRequest:
@@ -1444,7 +1449,7 @@ class PreviewRequest(BaseModel):
 class StemRequest(BaseModel):
     mode: str = "stems"
     stem_model: str | None = None
-    output_format: str = "wav"
+    output_format: DurableAudioFormat = "wav"
     force: bool = False
     source_artifact_id: str | None = None
     chord_backend: str = "default"
@@ -1459,8 +1464,6 @@ class StemRequest(BaseModel):
             raise ValueError("Unsupported stem model.")
         if self.mode == "two_stem" and self.stem_model in SIX_STEM_MODEL_ALIASES:
             raise ValueError("two_stem mode requires a two-stem model.")
-        if self.output_format != "wav":
-            raise ValueError("Stem output must be wav in v1.")
         _validate_chord_backend_fields(self.chord_backend, self.chord_backend_fallback_from)
         return self
 

--- a/apps/backend/app/services/analysis.py
+++ b/apps/backend/app/services/analysis.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
+from contextlib import ExitStack
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
@@ -15,6 +16,7 @@ from app.engines.beat_this import BeatThisRuntimeError, analyze_track_with_beat_
 from app.errors import AppError
 from app.models import AnalysisResult, Artifact, Project
 from app.services.artifacts import refresh_artifact_file_metadata, register_artifact
+from app.services.audio_working import materialize_pcm_wav
 from app.services.paths import project_analysis_dir
 
 SOURCE_STEM_ARTIFACT_TYPES = ("drums_stem", "bass_stem")
@@ -32,12 +34,18 @@ def analyze_project(
     source_stem_artifacts = (
         _source_stem_artifacts(project, source_artifact) if source_artifact is not None else ()
     )
-    results = _analyze_track_with_backend(
-        Path(project.imported_path),
-        source_stem_paths=tuple(Path(artifact.path) for artifact in source_stem_artifacts),
-        beat_backend=beat_backend,
-        duration_seconds=project.duration_seconds,
-    )
+    with ExitStack() as stack:
+        source_path = stack.enter_context(materialize_pcm_wav(Path(project.imported_path)))
+        source_stem_paths = tuple(
+            stack.enter_context(materialize_pcm_wav(Path(artifact.path)))
+            for artifact in source_stem_artifacts
+        )
+        results = _analyze_track_with_backend(
+            source_path,
+            source_stem_paths=source_stem_paths,
+            beat_backend=beat_backend,
+            duration_seconds=project.duration_seconds,
+        )
     analysis = session.get(AnalysisResult, project.id)
     if analysis is None:
         analysis = AnalysisResult(project_id=project.id)

--- a/apps/backend/app/services/audio_working.py
+++ b/apps/backend/app/services/audio_working.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from subprocess import Popen
+
+from app.engines.audio_encoding import encode_audio, validate_audio_file
+
+
+@contextmanager
+def materialize_pcm_wav(
+    source_path: Path,
+    *,
+    should_cancel: Callable[[], bool] | None = None,
+    register_process: Callable[[Popen[str]], None] | None = None,
+    unregister_process: Callable[[], None] | None = None,
+) -> Iterator[Path]:
+    if source_path.suffix.lower() == ".wav":
+        yield source_path
+        return
+
+    with tempfile.TemporaryDirectory(prefix="tuneforge-working-audio-") as temp_dir:
+        working_path = Path(temp_dir) / "source.wav"
+        encode_audio(
+            source_path,
+            working_path,
+            "wav",
+            should_cancel=should_cancel,
+            register_process=register_process,
+            unregister_process=unregister_process,
+        )
+        validate_audio_file(working_path, "wav")
+        yield working_path

--- a/apps/backend/app/services/chords.py
+++ b/apps/backend/app/services/chords.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import tempfile
+from contextlib import ExitStack
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, cast
@@ -11,6 +12,7 @@ from sqlalchemy.orm import Session
 from app.engines.stems import mix_audio_files
 from app.errors import AppError
 from app.models import Artifact, ChordTimeline, Project, utcnow
+from app.services.audio_working import materialize_pcm_wav
 from app.services.chord_backends import (
     ChordDetectionResult,
     chord_backend_uses_source_instrumental_stem,
@@ -51,7 +53,8 @@ def detect_project_chords(
 
     source_artifact = _source_audio_artifact(project)
     source_path = Path(source_artifact.path) if source_artifact is not None else Path(project.imported_path)
-    source_result = _detect_timeline(source_path, selected_backend_id)
+    with materialize_pcm_wav(source_path) as working_source_path:
+        source_result = _detect_timeline(working_source_path, selected_backend_id)
     runtime_device = source_result.runtime_device
     source_timeline = source_result.segments
     augmented_timeline = (
@@ -179,7 +182,8 @@ def _detect_source_stem_timeline(
 ) -> list[dict[str, Any]]:
     instrumental_stem = _source_instrumental_stem(project, source_artifact)
     if instrumental_stem is not None:
-        return _detect_timeline(Path(instrumental_stem.path), backend_id).segments
+        with materialize_pcm_wav(Path(instrumental_stem.path)) as working_path:
+            return _detect_timeline(working_path, backend_id).segments
 
     non_vocal_stems = _source_non_vocal_stems(project, source_artifact)
     if not non_vocal_stems:
@@ -189,7 +193,12 @@ def _detect_source_stem_timeline(
     mix_path = Path(temp_file.name)
     temp_file.close()
     try:
-        mix_audio_files([Path(stem.path) for stem in non_vocal_stems], mix_path, subtype="FLOAT")
+        with ExitStack() as stack:
+            working_stems = [
+                stack.enter_context(materialize_pcm_wav(Path(stem.path)))
+                for stem in non_vocal_stems
+            ]
+            mix_audio_files(working_stems, mix_path, subtype="FLOAT")
         return _detect_timeline(mix_path, backend_id).segments
     finally:
         mix_path.unlink(missing_ok=True)

--- a/apps/backend/app/services/jobs.py
+++ b/apps/backend/app/services/jobs.py
@@ -12,6 +12,7 @@ from sqlalchemy import case, func, select
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.dependency_diagnostics import safe_dependency_remediation
+from app.engines.audio_encoding import require_encoding_available
 from app.errors import AppError, JobCancelledError
 from app.models import Artifact, ChordTimeline, Job, LyricsTranscript, Project, utcnow
 from app.runtime_status import (
@@ -264,6 +265,8 @@ def create_bulk_activity_jobs(
     payload: BulkJobRequest,
 ) -> BulkActivityJobCreationResult:
     validated_job_type = validate_bulk_activity_job_type(payload.job_type)
+    if validated_job_type == "stems":
+        require_encoding_available(payload.output_format)
     projects = list(
         session.scalars(
             select(Project)
@@ -368,7 +371,7 @@ def _bulk_activity_job_payloads(
         return [
             StemRequest(
                 mode="stems",
-                output_format="wav",
+                output_format=request.output_format,
                 force=True,
                 source_artifact_id=source_artifact_id,
                 stem_model=request.stem_model,
@@ -455,6 +458,7 @@ def _project_activity_job_payload(
     if job_type == "lyrics" and isinstance(payload, LyricsGenerateRequest):
         return payload.model_dump()
     if job_type == "stems" and isinstance(payload, StemRequest):
+        require_encoding_available(payload.output_format)
         source_artifact = resolve_stem_source_artifact(
             session,
             project=project,

--- a/apps/backend/app/services/lyrics.py
+++ b/apps/backend/app/services/lyrics.py
@@ -18,6 +18,7 @@ from app.engines.lyrics import transcribe_project_lyrics
 from app.errors import AppError, JobCancelledError
 from app.models import Artifact, LyricsTranscript, Project
 from app.schemas import LyricsEditSegmentSchema
+from app.services.audio_working import materialize_pcm_wav
 from app.services.paths import project_analysis_dir
 from app.services.stem_signal_metadata import stem_signal_analysis_usable
 from app.services.sync_revisions import record_lyrics_revision
@@ -148,17 +149,23 @@ def generate_project_lyrics(
         if lyrics_source_artifact is not None
         else Path(project.imported_path)
     )
-    transcription = transcribe_project_lyrics(
+    with materialize_pcm_wav(
         transcription_source_path,
-        model_name=get_settings().lyrics_model,
-        requested_device=get_settings().lyrics_device,
-        download_root=get_settings().lyrics_cache_dir,
-        language_override=language_override,
         should_cancel=should_cancel,
         register_process=register_process,
         unregister_process=unregister_process,
-        on_runtime_event=on_runtime_event,
-    )
+    ) as working_transcription_source:
+        transcription = transcribe_project_lyrics(
+            working_transcription_source,
+            model_name=get_settings().lyrics_model,
+            requested_device=get_settings().lyrics_device,
+            download_root=get_settings().lyrics_cache_dir,
+            language_override=language_override,
+            should_cancel=should_cancel,
+            register_process=register_process,
+            unregister_process=unregister_process,
+            on_runtime_event=on_runtime_event,
+        )
     _ensure_not_cancelled(should_cancel)
     if force:
         clear_project_tab_state(session, project_id=project.id)

--- a/apps/backend/app/services/projects.py
+++ b/apps/backend/app/services/projects.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -10,10 +11,16 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.config import get_settings
+from app.engines.audio_encoding import (
+    DurableAudioFormat,
+    encode_audio,
+    require_encoding_available,
+    validate_audio_file,
+)
 from app.errors import AppError
 from app.models import Artifact, Project, SyncDeleteTombstone, SyncEntityRevision, utcnow
 from app.services.artifacts import register_artifact
-from app.services.metadata import extract_audio_metadata, normalize_audio_to_wav
+from app.services.metadata import extract_audio_metadata
 from app.services.paths import ensure_project_dirs, project_source_dir
 from app.services.project_storage import queue_project_storage_reconciliation
 from app.services.sync_identity import source_hash_to_project_id
@@ -163,7 +170,9 @@ def import_project(
     source_path: str,
     copy_into_project: bool,
     display_name: str | None,
+    output_format: DurableAudioFormat = "wav",
 ) -> Project:
+    require_encoding_available(output_format)
     resolved_source = Path(source_path).expanduser().resolve()
     _validate_import_path(resolved_source)
     original_format = resolved_source.suffix.lower().lstrip(".")
@@ -192,10 +201,10 @@ def import_project(
 
     metadata = extract_audio_metadata(resolved_source)
     source_dir = project_source_dir(project_id)
-    imported_path = source_dir / f"{resolved_source.stem}.wav"
+    imported_path = source_dir / f"{resolved_source.stem}.{output_format}"
     artifact_metadata = {"source_path": str(resolved_source), "original_format": original_format}
     fallback_project_name = display_name or resolved_source.stem
-    _ = copy_into_project  # Historical API flag; imports always materialize an internal WAV.
+    _ = copy_into_project  # Historical API flag; imports always materialize an internal durable file.
 
     project = Project(
         id=project_id,
@@ -222,21 +231,37 @@ def import_project(
         raise _duplicate_project_source_error(project_id, fallback_project_name) from exc
 
     ensure_project_dirs(project_id)
-    normalize_audio_to_wav(resolved_source, imported_path)
+    with tempfile.NamedTemporaryFile(
+        dir=source_dir,
+        prefix=".tuneforge-import-",
+        suffix=f".{output_format}",
+        delete=False,
+    ) as temp_file:
+        staged_path = Path(temp_file.name)
+    try:
+        encode_audio(resolved_source, staged_path, output_format)
+        validate_audio_file(staged_path, output_format)
+        staged_path.replace(imported_path)
+    finally:
+        staged_path.unlink(missing_ok=True)
 
-    register_artifact(
-        session,
-        project_id=project.id,
-        artifact_type="source_audio",
-        artifact_format="wav",
-        path=Path(project.imported_path),
-        metadata=artifact_metadata,
-        generated_by="import",
-        can_delete=False,
-        can_regenerate=False,
-    )
+    try:
+        register_artifact(
+            session,
+            project_id=project.id,
+            artifact_type="source_audio",
+            artifact_format=output_format,
+            path=Path(project.imported_path),
+            metadata=artifact_metadata,
+            generated_by="import",
+            can_delete=False,
+            can_regenerate=False,
+        )
 
-    queue_project_storage_reconciliation(session, project.id)
+        queue_project_storage_reconciliation(session, project.id)
+    except Exception:
+        imported_path.unlink(missing_ok=True)
+        raise
 
     return project
 

--- a/apps/backend/app/services/stems.py
+++ b/apps/backend/app/services/stems.py
@@ -11,10 +11,17 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.config import get_settings
+from app.engines.audio_encoding import (
+    DurableAudioFormat,
+    encode_audio,
+    require_encoding_available,
+    validate_audio_file,
+)
 from app.engines.stems import separate_sources, separate_two_stems
 from app.errors import AppError, JobCancelledError
 from app.models import Artifact, Project, utcnow
 from app.services.artifacts import refresh_artifact_file_metadata, register_artifact
+from app.services.audio_working import materialize_pcm_wav
 from app.services.paths import project_stems_dir
 from app.services.project_storage import queue_project_storage_reconciliation
 from app.services.stem_models import (
@@ -124,6 +131,7 @@ def _complete_existing_stem_artifacts(
     project_id: str,
     source_artifact_id: str,
     stem_model: StemModelDefinition,
+    output_format: str | None = None,
 ) -> list[Artifact] | None:
     artifacts = _stem_artifacts_for_source(
         session,
@@ -139,7 +147,9 @@ def _complete_existing_stem_artifacts(
 
     complete = [artifact for artifact in existing if artifact is not None]
     if all(
-        artifact.metadata_json.get("stem_model") == stem_model.id and Path(artifact.path).exists()
+        artifact.metadata_json.get("stem_model") == stem_model.id
+        and (output_format is None or artifact.format == output_format)
+        and Path(artifact.path).exists()
         for artifact in complete
     ):
         return complete
@@ -273,19 +283,13 @@ def _temp_stem_plan(plan: list[StemOutputPlan]) -> tuple[tempfile.TemporaryDirec
     if not plan:
         raise AppError("INVALID_REQUEST", "At least one stem output is required.")
     final_dir = plan[0].path.parent
-    final_dir.mkdir(parents=True, exist_ok=True)
-    temp_dir = tempfile.TemporaryDirectory(prefix=".tuneforge-stems-", dir=final_dir)
+    final_dir.parent.mkdir(parents=True, exist_ok=True)
+    temp_dir = tempfile.TemporaryDirectory(prefix=".tuneforge-stems-", dir=final_dir.parent)
     temp_root = Path(temp_dir.name)
     return temp_dir, [
-        replace(output, path=temp_root / f"{output.source}.{output.output_format}")
+        replace(output, path=temp_root / "working" / f"{output.source}.wav", output_format="wav")
         for output in plan
     ]
-
-
-def _replace_stem_outputs(temp_plan: list[StemOutputPlan], final_plan: list[StemOutputPlan]) -> None:
-    for temp_output, final_output in zip(temp_plan, final_plan, strict=True):
-        final_output.path.parent.mkdir(parents=True, exist_ok=True)
-        temp_output.path.replace(final_output.path)
 
 
 def _ensure_not_cancelled(should_cancel: Callable[[], bool] | None) -> None:
@@ -329,7 +333,7 @@ def generate_stems(
     *,
     project: Project,
     source_artifact_id: str | None,
-    output_format: str,
+    output_format: DurableAudioFormat,
     force: bool,
     stem_model: str | None = None,
     on_progress: Callable[[int], None] | None = None,
@@ -337,8 +341,7 @@ def generate_stems(
     register_process: Callable[[Popen[str]], None] | None = None,
     unregister_process: Callable[[], None] | None = None,
 ) -> StemGenerationResult:
-    if output_format != "wav":
-        raise AppError("INVALID_REQUEST", "Stem output must be wav in v1.")
+    require_encoding_available(output_format)
 
     source_artifact = resolve_stem_source_artifact(
         session,
@@ -353,6 +356,7 @@ def generate_stems(
             project_id=project.id,
             source_artifact_id=source_artifact.id,
             stem_model=selected_model,
+            output_format=output_format,
         )
         if existing:
             signal_metadata_hydrated = False
@@ -373,18 +377,47 @@ def generate_stems(
         generation_id=new_id("stemset"),
     )
     temp_dir, temp_plan = _temp_stem_plan(plan)
+    signal_metadata_by_source: dict[str, dict[str, Any]] = {}
     with temp_dir:
-        metadata = _separate_with_model(
+        with materialize_pcm_wav(
             Path(source_artifact.path),
-            temp_plan,
-            stem_model=selected_model,
-            on_progress=on_progress,
             should_cancel=should_cancel,
             register_process=register_process,
             unregister_process=unregister_process,
-        )
+        ) as working_source:
+            metadata = _separate_with_model(
+                working_source,
+                temp_plan,
+                stem_model=selected_model,
+                on_progress=on_progress,
+                should_cancel=should_cancel,
+                register_process=register_process,
+                unregister_process=unregister_process,
+            )
+        if source_artifact.type == "source_audio":
+            signal_metadata_by_source = {
+                output.source: build_stem_signal_metadata(output.path)
+                for output in temp_plan
+            }
         _ensure_not_cancelled(should_cancel)
-        _replace_stem_outputs(temp_plan, plan)
+        publish_dir = Path(temp_dir.name) / "publish"
+        encoded_plan = [
+            replace(output, path=publish_dir / output.path.name)
+            for output in plan
+        ]
+        for working_output, encoded_output in zip(temp_plan, encoded_plan, strict=True):
+            encode_audio(
+                working_output.path,
+                encoded_output.path,
+                output_format,
+                should_cancel=should_cancel,
+                register_process=register_process,
+                unregister_process=unregister_process,
+            )
+            validate_audio_file(encoded_output.path, output_format)
+            _ensure_not_cancelled(should_cancel)
+        plan[0].path.parent.parent.mkdir(parents=True, exist_ok=True)
+        publish_dir.replace(plan[0].path.parent)
         try:
             _ensure_not_cancelled(should_cancel)
         except JobCancelledError:
@@ -412,7 +445,7 @@ def generate_stems(
             **metadata,
         }
         if source_artifact.type == "source_audio":
-            stem_metadata[STEM_SIGNAL_METADATA_KEY] = build_stem_signal_metadata(output.path)
+            stem_metadata[STEM_SIGNAL_METADATA_KEY] = signal_metadata_by_source[output.source]
         stem_output_metadatas.append((output, stem_metadata))
 
     if source_artifact.type == "source_audio":
@@ -428,25 +461,29 @@ def generate_stems(
             )
         ]
 
-    for output, stem_metadata in stem_output_metadatas:
-        saved_artifacts.append(
-            _upsert_stem_artifact(
-                session,
-                existing_artifact=existing_by_type.get(output.artifact_type),
-                project_id=project.id,
-                artifact_type=output.artifact_type,
-                artifact_format=output.output_format,
-                path=output.path,
-                metadata=stem_metadata,
+    try:
+        for output, stem_metadata in stem_output_metadatas:
+            saved_artifacts.append(
+                _upsert_stem_artifact(
+                    session,
+                    existing_artifact=existing_by_type.get(output.artifact_type),
+                    project_id=project.id,
+                    artifact_type=output.artifact_type,
+                    artifact_format=output.output_format,
+                    path=output.path,
+                    metadata=stem_metadata,
+                )
             )
-        )
 
-    _prune_extra_stem_artifacts(
-        session,
-        project_id=project.id,
-        source_artifact_id=source_artifact.id,
-        stem_model_id=None,
-        keep_ids={artifact.id for artifact in saved_artifacts},
-    )
+        _prune_extra_stem_artifacts(
+            session,
+            project_id=project.id,
+            source_artifact_id=source_artifact.id,
+            stem_model_id=None,
+            keep_ids={artifact.id for artifact in saved_artifacts},
+        )
+    except Exception:
+        _cleanup_stem_outputs(plan)
+        raise
 
     return StemGenerationResult(artifacts=saved_artifacts, generated_this_job=True)

--- a/apps/backend/app/services/sync_manifest.py
+++ b/apps/backend/app/services/sync_manifest.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess
 from collections.abc import Iterable, Mapping
 from copy import deepcopy
 from dataclasses import dataclass, replace
@@ -15,7 +14,11 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.config import get_settings
+from app.engines.audio_encoding import (
+    DURABLE_AUDIO_FORMATS,
+    DurableAudioFormat,
+    validate_audio_file,
+)
 from app.errors import AppError
 from app.models import (
     AnalysisResult,
@@ -31,6 +34,7 @@ from app.schemas import SUPPORTED_LYRICS_LANGUAGE_OVERRIDES
 from app.services.artifacts import register_artifact
 from app.services.paths import ensure_project_dirs, project_root
 from app.services.project_storage import queue_project_storage_reconciliation
+from app.services.stem_models import STEM_ARTIFACT_TYPES, STEM_SOURCE_ARTIFACT_TYPES
 from app.services.sync_identity import source_hash_to_project_id
 from app.services.sync_metadata import (
     artifact_sync_metadata,
@@ -857,8 +861,8 @@ def _export_artifact_manifest(artifact: Artifact) -> SyncArtifactManifest:
 
     _validate_export_artifact_relative_path(artifact, relative_path)
 
-    if artifact.type == "source_audio":
-        _validate_export_source_artifact(
+    if _is_durable_audio_artifact_type(artifact.type):
+        _validate_export_durable_audio_artifact(
             artifact=artifact,
             relative_path=relative_path,
         )
@@ -1392,14 +1396,8 @@ def _verify_staged_artifacts(
             assert staging_root is not None
             staged_path = (staging_root / relative_path).resolve(strict=False)
             _ensure_child_path(staging_root, staged_path, "staged artifact")
-            _verify_staged_file(artifact, staged_path)
-        if artifact.type == "source_audio":
-            _validate_wav_source_file(
-                artifact_id=artifact.artifact_id,
-                project_id=artifact.project_id,
-                relative_path=artifact.relative_path,
-                path=staged_path,
-            )
+        _verify_staged_file(artifact, staged_path)
+        validate_staged_durable_audio_artifact(artifact, staged_path)
 
         verified.append(
             _VerifiedStagedArtifact(
@@ -1494,30 +1492,65 @@ def _validate_source_artifact_present(manifest: SyncProjectManifest) -> None:
 
 def _validate_staged_import_source_artifact(manifest: SyncProjectManifest) -> SyncArtifactManifest:
     source_artifact = _source_artifact_manifest(manifest)
-    if source_artifact.format != "wav":
-        raise _invalid_manifest("Project manifest source_audio artifact format must be 'wav'.")
-
     relative_path = _safe_relative_path(source_artifact.relative_path)
-    if relative_path.suffix.lower() != ".wav":
-        raise _invalid_manifest("Project manifest source_audio artifact relative_path must end with .wav.")
+    expected_suffix = _source_audio_suffix(source_artifact.format)
+    if expected_suffix is None:
+        raise _invalid_manifest("Project manifest source_audio artifact format is unsupported.")
+    if relative_path.suffix.lower() != expected_suffix:
+        raise _invalid_manifest(
+            "Project manifest source_audio artifact format and relative_path suffix do not match."
+        )
     return source_artifact
 
 
-def _validate_export_source_artifact(
+def _is_durable_audio_artifact_type(artifact_type: str) -> bool:
+    return artifact_type in {
+        "source_audio",
+        "preview_mix",
+        *STEM_ARTIFACT_TYPES,
+        *STEM_SOURCE_ARTIFACT_TYPES,
+    }
+
+
+def validate_staged_durable_audio_artifact(
+    artifact: SyncArtifactManifest,
+    staged_path: Path,
+) -> None:
+    if not _is_durable_audio_artifact_type(artifact.type):
+        return
+    relative_path = _safe_relative_path(artifact.relative_path)
+    expected_suffix = _source_audio_suffix(artifact.format)
+    if expected_suffix is None or relative_path.suffix.lower() != expected_suffix:
+        raise _durable_audio_invalid_error(
+            artifact_id=artifact.artifact_id,
+            project_id=artifact.project_id,
+            relative_path=artifact.relative_path,
+        )
+    _validate_durable_audio_file(
+        artifact_id=artifact.artifact_id,
+        project_id=artifact.project_id,
+        relative_path=artifact.relative_path,
+        path=staged_path,
+        artifact_format=artifact.format,
+    )
+
+
+def _validate_export_durable_audio_artifact(
     *,
     artifact: Artifact,
     relative_path: str,
 ) -> None:
-    if artifact.format != "wav":
+    expected_suffix = _source_audio_suffix(artifact.format)
+    if expected_suffix is None:
         raise AppError(
             "SYNC_MANIFEST_SOURCE_ARTIFACT_UNSUPPORTED",
-            "Project source audio artifact must be an app-managed WAV before sync export.",
+            "Durable audio artifact format is unsupported for sync export.",
             details={"artifact_id": artifact.id, "project_id": artifact.project_id, "format": artifact.format},
         )
-    if PurePosixPath(relative_path).suffix.lower() != ".wav":
+    if PurePosixPath(relative_path).suffix.lower() != expected_suffix:
         raise AppError(
             "SYNC_MANIFEST_SOURCE_ARTIFACT_UNSUPPORTED",
-            "Project source audio artifact must use a .wav relative path before sync export.",
+            "Durable audio artifact format and relative path suffix do not match.",
             details={
                 "artifact_id": artifact.id,
                 "project_id": artifact.project_id,
@@ -1526,90 +1559,52 @@ def _validate_export_source_artifact(
         )
 
 
-def _validate_wav_source_file(
+def _source_audio_suffix(artifact_format: str) -> str | None:
+    if artifact_format not in DURABLE_AUDIO_FORMATS:
+        return None
+    return f".{artifact_format}"
+
+
+def _validate_durable_audio_file(
     *,
     artifact_id: str,
     project_id: str,
     relative_path: str,
     path: Path,
+    artifact_format: str,
 ) -> None:
-    command = [
-        get_settings().ffprobe_path,
-        "-v",
-        "error",
-        "-select_streams",
-        "a:0",
-        "-show_entries",
-        "stream=codec_name,channels,sample_rate",
-        "-show_entries",
-        "format=format_name",
-        "-of",
-        "json",
-        str(path),
-    ]
-    try:
-        result = subprocess.run(command, check=True, capture_output=True, text=True)
-        payload = json.loads(result.stdout or "{}")
-    except FileNotFoundError as exc:
-        raise AppError(
-            "DEPENDENCY_MISSING",
-            "ffprobe is required to validate source audio artifacts for sync.",
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        ) from exc
-    except (json.JSONDecodeError, subprocess.CalledProcessError) as exc:
-        raise _source_artifact_not_wav_error(
-            artifact_id=artifact_id,
-            project_id=project_id,
-            relative_path=relative_path,
-        ) from exc
-
-    if not _is_wav_pcm_probe(payload):
-        raise _source_artifact_not_wav_error(
+    expected_suffix = _source_audio_suffix(artifact_format)
+    if expected_suffix is None:
+        raise _durable_audio_invalid_error(
             artifact_id=artifact_id,
             project_id=project_id,
             relative_path=relative_path,
         )
-
-
-def _is_wav_pcm_probe(payload: Any) -> bool:
-    if not isinstance(payload, dict):
-        return False
-    fmt = payload.get("format")
-    streams = payload.get("streams")
-    if not isinstance(fmt, dict) or not isinstance(streams, list) or not streams:
-        return False
-    stream = streams[0]
-    if not isinstance(stream, dict):
-        return False
-    format_name = fmt.get("format_name")
-    codec_name = stream.get("codec_name")
-    if not isinstance(format_name, str) or not isinstance(codec_name, str):
-        return False
-    format_names = {name.strip().lower() for name in format_name.split(",")}
-    return (
-        "wav" in format_names
-        and codec_name.startswith("pcm_")
-        and _positive_int(stream.get("channels"))
-        and _positive_int(stream.get("sample_rate"))
-    )
-
-
-def _positive_int(value: Any) -> bool:
     try:
-        return int(value) > 0
-    except (TypeError, ValueError):
-        return False
+        validate_audio_file(
+            path,
+            cast(DurableAudioFormat, artifact_format),
+            require_suffix=False,
+        )
+    except AppError as exc:
+        if exc.code == "DEPENDENCY_MISSING":
+            raise
+        raise _durable_audio_invalid_error(
+            artifact_id=artifact_id,
+            project_id=project_id,
+            relative_path=relative_path,
+        ) from exc
 
 
-def _source_artifact_not_wav_error(
+def _durable_audio_invalid_error(
     *,
     artifact_id: str,
     project_id: str,
     relative_path: str,
 ) -> AppError:
     return AppError(
-        "SYNC_MANIFEST_SOURCE_ARTIFACT_NOT_WAV",
-        "Project source audio artifact file must be a readable PCM WAV.",
+        "SYNC_MANIFEST_DURABLE_AUDIO_INVALID",
+        "Durable audio artifact file does not match its declared format.",
         details={
             "artifact_id": artifact_id,
             "project_id": project_id,

--- a/apps/backend/app/services/sync_reconciliation.py
+++ b/apps/backend/app/services/sync_reconciliation.py
@@ -11,6 +11,7 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.engines.audio_encoding import DURABLE_AUDIO_FORMATS
 from app.errors import AppError
 from app.models import (
     Artifact,
@@ -2998,10 +2999,10 @@ def _importable_source_artifact_for_manifest(
         )
 
     source_artifact = source_artifacts[0]
-    if source_artifact.format != "wav":
+    if source_artifact.format not in DURABLE_AUDIO_FORMATS:
         return (
             None,
-            "Project manifest source_audio artifact format must be 'wav'.",
+            "Project manifest source_audio artifact format is unsupported.",
             {"artifact_id": source_artifact.artifact_id, "format": source_artifact.format},
         )
     path_error = _manifest_relative_path_error(source_artifact.relative_path)
@@ -3015,10 +3016,10 @@ def _importable_source_artifact_for_manifest(
             },
         )
     assert source_artifact.relative_path is not None
-    if PurePosixPath(source_artifact.relative_path).suffix.lower() != ".wav":
+    if PurePosixPath(source_artifact.relative_path).suffix.lower() != f".{source_artifact.format}":
         return (
             None,
-            "Project manifest source_audio artifact relative_path must end with .wav.",
+            "Project manifest source_audio artifact format and relative_path suffix do not match.",
             {
                 "artifact_id": source_artifact.artifact_id,
                 "relative_path": source_artifact.relative_path,

--- a/apps/backend/app/services/sync_reconciliation_apply.py
+++ b/apps/backend/app/services/sync_reconciliation_apply.py
@@ -26,6 +26,7 @@ from app.services.sync_manifest import (
     _safe_relative_path,
     hydrate_project_analysis_result_from_artifact,
     import_staged_project_manifest,
+    validate_staged_durable_audio_artifact,
 )
 from app.services.sync_project_status import update_project_sync_status
 from app.services.sync_reconciliation import (
@@ -361,6 +362,7 @@ def _import_artifact_manifest(
             and existing_path.stat().st_size == artifact_manifest.size_bytes
             and file_sha256(existing_path) == artifact_manifest.content_sha256
         ):
+            validate_staged_durable_audio_artifact(artifact_manifest, existing_path)
             return _result(action, APPLY_STATUS_SATISFIED, "Artifact manifest is already imported locally.")
         if overwrite_generated_artifact and artifact_manifest.type == "analysis_json":
             destination_path = _generated_analysis_overwrite_destination(project_id, existing_artifact)
@@ -376,7 +378,24 @@ def _import_artifact_manifest(
                 return _result(action, APPLY_STATUS_FAILED, "Artifact destination already exists locally.")
             destination_has_manifest_bytes = _copied_artifact_matches_manifest(destination_path, artifact_manifest)
         elif overwrite_generated_artifact:
-            destination_path = existing_path
+            destination_path = _resolve_project_destination_path(
+                project_id,
+                artifact_manifest.relative_path,
+            )
+            if _destination_conflicts_with_existing_artifact(
+                session,
+                destination_path,
+                existing_artifact,
+            ) or (
+                destination_path.exists()
+                and existing_resolved_path != destination_path.resolve(strict=False)
+                and not _copied_artifact_matches_manifest(destination_path, artifact_manifest)
+            ):
+                return _result(action, APPLY_STATUS_FAILED, "Artifact destination already exists locally.")
+            destination_has_manifest_bytes = _copied_artifact_matches_manifest(
+                destination_path,
+                artifact_manifest,
+            )
         else:
             destination_path = existing_path
     else:
@@ -413,6 +432,7 @@ def _import_artifact_manifest(
             return _result(action, APPLY_STATUS_FAILED, "Copied artifact bytes do not match the manifest.")
     if not _copied_artifact_matches_manifest(destination_path, artifact_manifest):
         return _result(action, APPLY_STATUS_FAILED, "Copied artifact bytes do not match the manifest.")
+    validate_staged_durable_audio_artifact(artifact_manifest, destination_path)
     if existing_artifact is None:
         imported_artifact = register_artifact(
             session,
@@ -537,6 +557,7 @@ def _copy_staged_artifact_verified(
         shutil.copy2(source_path, temp_path)
         if not _copied_artifact_matches_manifest(temp_path, artifact_manifest):
             return False
+        validate_staged_durable_audio_artifact(artifact_manifest, temp_path)
         temp_path.replace(destination_path)
     except OSError as exc:
         raise AppError(
@@ -593,6 +614,7 @@ def _update_existing_artifact_from_manifest(
     artifact_manifest: SyncArtifactManifest,
     destination_path: Path,
 ) -> None:
+    artifact.format = artifact_manifest.format
     artifact.path = str(destination_path.resolve(strict=False))
     artifact.metadata_json = deepcopy(artifact_manifest.metadata)
     artifact.cache_key = artifact_manifest.cache_key

--- a/apps/backend/app/services/transformations.py
+++ b/apps/backend/app/services/transformations.py
@@ -8,13 +8,19 @@ import zipfile
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from fastapi import status
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.config import get_settings
+from app.engines.audio_encoding import (
+    DURABLE_AUDIO_FORMATS,
+    DurableAudioFormat,
+    require_encoding_available,
+    validate_audio_file,
+)
 from app.engines.chord_labels import parse_chord_label
 from app.engines.transform import (
     cents_from_reference,
@@ -35,7 +41,7 @@ from app.utils.hashing import stable_hash
 class TransformPlan:
     artifact_type: str
     destination_path: Path
-    output_format: str
+    output_format: DurableAudioFormat
     total_cents: float
     cache_key: str | None
     metadata: dict[str, Any]
@@ -280,7 +286,12 @@ def prepare_export_job_payload(
         raise AppError("EXPORT_AUDIO_SET_MISMATCH", "Selected artifacts must belong to one audio set.")
     output_format = str(request_payload.get("output_format", "wav"))
     if artifact_ids:
-        format_available, reason = probe_export_formats().get(output_format, (False, "Unsupported export format."))
+        capability = (
+            probe_export_formats().get(cast(DurableAudioFormat, output_format))
+            if output_format in DURABLE_AUDIO_FORMATS
+            else None
+        )
+        format_available, reason = capability or (False, "Unsupported export format.")
         if not format_available:
             raise AppError("EXPORT_FORMAT_UNAVAILABLE", reason or "Export format is unavailable.", status_code=422)
 
@@ -401,14 +412,9 @@ def build_preview_plan(
     project: Project,
     retune: dict[str, Any] | None,
     transpose: dict[str, Any] | None,
-    output_format: str,
+    output_format: DurableAudioFormat,
 ) -> tuple[TransformPlan, Artifact | None]:
-    if output_format != get_settings().preview_format:
-        raise AppError(
-            "INVALID_REQUEST",
-            f"Preview output must be {get_settings().preview_format}.",
-            status_code=status.HTTP_400_BAD_REQUEST,
-        )
+    require_encoding_available(output_format)
     total_cents = 0.0
     metadata: dict[str, Any] = {"retune": retune, "transpose": transpose}
     if retune:
@@ -445,7 +451,10 @@ def build_single_transform_plan(
     transform_type: str,
     payload: dict[str, Any],
 ) -> TransformPlan:
-    output_format = payload.get("output_format", get_settings().preview_format)
+    raw_output_format = str(payload.get("output_format", get_settings().preview_format))
+    if raw_output_format not in DURABLE_AUDIO_FORMATS:
+        raise AppError("INVALID_REQUEST", "Unsupported audio format.", status_code=422)
+    output_format = cast(DurableAudioFormat, raw_output_format)
     preview_only = payload.get("preview_only", True)
     if transform_type == "retune":
         if payload.get("target_cents_offset") is not None:
@@ -481,28 +490,40 @@ def execute_transform_plan(
 ) -> Artifact:
     source_path = Path(project.imported_path)
     sample_rate = project.sample_rate or 44100
-    run_ffmpeg_transform(
-        source_path,
-        plan.destination_path.with_suffix(""),
-        sample_rate,
-        plan.total_cents,
-        plan.output_format,
-        on_progress=on_progress,
-        should_cancel=should_cancel,
-        register_process=register_process,
-        unregister_process=unregister_process,
-    )
     output_path = plan.destination_path.with_suffix(f".{plan.output_format}")
-    artifact = register_artifact(
-        session,
-        project_id=project.id,
-        artifact_type=plan.artifact_type,
-        artifact_format=plan.output_format,
-        path=output_path,
-        metadata=plan.metadata,
-        cache_key=plan.cache_key,
-        generated_by="ffmpeg",
-    )
+    temp_base_path, temp_path = _new_sibling_temp_paths(output_path, plan.output_format)
+    try:
+        run_ffmpeg_transform(
+            source_path,
+            temp_base_path,
+            sample_rate,
+            plan.total_cents,
+            plan.output_format,
+            on_progress=on_progress,
+            should_cancel=should_cancel,
+            register_process=register_process,
+            unregister_process=unregister_process,
+        )
+        validate_audio_file(temp_path, plan.output_format)
+        _ensure_not_cancelled(should_cancel)
+        temp_path.replace(output_path)
+    finally:
+        temp_base_path.unlink(missing_ok=True)
+        temp_path.unlink(missing_ok=True)
+    try:
+        artifact = register_artifact(
+            session,
+            project_id=project.id,
+            artifact_type=plan.artifact_type,
+            artifact_format=plan.output_format,
+            path=output_path,
+            metadata=plan.metadata,
+            cache_key=plan.cache_key,
+            generated_by="ffmpeg",
+        )
+    except Exception:
+        output_path.unlink(missing_ok=True)
+        raise
     return artifact
 
 

--- a/apps/backend/tests/test_audio_encoding.py
+++ b/apps/backend/tests/test_audio_encoding.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+import pytest
+
+from app.engines import audio_encoding
+from app.errors import AppError
+from app.services.audio_working import materialize_pcm_wav
+
+
+@pytest.mark.parametrize(
+    ("output_format", "profile"),
+    [
+        ("wav", ("-c:a", "pcm_s16le")),
+        ("flac", ("-c:a", "flac", "-compression_level", "5")),
+        ("mp3", ("-c:a", "libmp3lame", "-b:a", "192k")),
+        ("m4a", ("-c:a", "aac", "-profile:a", "aac_low", "-b:a", "192k", "-f", "mp4")),
+    ],
+)
+def test_durable_encoding_profiles_match_export_contract(
+    output_format: str,
+    profile: tuple[str, ...],
+) -> None:
+    assert audio_encoding.encoding_profile(output_format) == profile
+
+
+@pytest.mark.parametrize("profile", ["HE-AAC", "HE-AACv2", None])
+def test_m4a_validation_rejects_non_lc_aac(monkeypatch, profile: str | None) -> None:
+    monkeypatch.setattr(
+        audio_encoding,
+        "probe_audio_file",
+        lambda _path: {
+            "streams": [
+                {"codec_name": "aac", "profile": profile, "channels": 2, "sample_rate": 48000}
+            ],
+            "format": {"format_name": "mov,mp4,m4a,3gp,3g2,mj2"},
+        },
+    )
+
+    with pytest.raises(AppError, match="not valid M4A"):
+        audio_encoding.validate_audio_file(Path("fixture.m4a"), "m4a")
+
+
+def test_m4a_validation_accepts_aac_lc(monkeypatch) -> None:
+    monkeypatch.setattr(
+        audio_encoding,
+        "probe_audio_file",
+        lambda _path: {
+            "streams": [
+                {"codec_name": "aac", "profile": "LC", "channels": 2, "sample_rate": 48000}
+            ],
+            "format": {"format_name": "mov,mp4,m4a,3gp,3g2,mj2"},
+        },
+    )
+
+    audio_encoding.validate_audio_file(Path("fixture.m4a"), "m4a")
+
+
+def test_materialize_pcm_wav_cleans_compressed_working_file(sample_mp3_file: Path) -> None:
+    with materialize_pcm_wav(sample_mp3_file) as working_path:
+        working_root = working_path.parent
+        assert working_path.exists()
+        assert working_path.suffix == ".wav"
+        audio_encoding.validate_audio_file(working_path, "wav")
+
+    assert not working_root.exists()
+
+
+def test_materialize_pcm_wav_reuses_durable_pcm_wav(sample_audio_file: Path) -> None:
+    with materialize_pcm_wav(sample_audio_file) as working_path:
+        assert working_path == sample_audio_file
+
+    assert sample_audio_file.exists()

--- a/apps/backend/tests/test_jobs_api.py
+++ b/apps/backend/tests/test_jobs_api.py
@@ -354,6 +354,7 @@ def test_bulk_stems_refreshes_only_sources_with_existing_stems(
             "chord_backend": "tuneforge-fast",
             "chord_backend_fallback_from": "crema-advanced",
             "stem_model": "htdemucs_ft",
+            "output_format": "m4a",
         },
     )
 
@@ -378,6 +379,7 @@ def test_bulk_stems_refreshes_only_sources_with_existing_stems(
         assert all(job.payload_json["force"] is True for job in jobs)
         assert all(job.payload_json["chord_backend"] == "tuneforge-fast" for job in jobs)
         assert all(job.payload_json["chord_backend_fallback_from"] == "crema-advanced" for job in jobs)
+        assert all(job.payload_json["output_format"] == "m4a" for job in jobs)
         assert all(job.payload_json["stem_model"] == "htdemucs_ft" for job in jobs)
 
 
@@ -583,6 +585,16 @@ def test_analyze_job_api_defaults_missing_or_unknown_beat_input_to_source(
 
 def test_bulk_jobs_rejects_unsupported_job_type(client: TestClient) -> None:
     response = client.post("/api/v1/jobs/bulk", json={"job_type": "preview"})
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "INVALID_REQUEST"
+
+
+def test_bulk_non_stem_job_rejects_non_default_output_format(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/jobs/bulk",
+        json={"job_type": "analyze", "output_format": "mp3"},
+    )
 
     assert response.status_code == 422
     assert response.json()["error"]["code"] == "INVALID_REQUEST"

--- a/apps/backend/tests/test_projects.py
+++ b/apps/backend/tests/test_projects.py
@@ -105,6 +105,39 @@ def test_import_project_persists_metadata_and_source_artifact(client, sample_aud
         assert artifact_row.content_sha256 == file_sha256(imported_path)
 
 
+@pytest.mark.parametrize("output_format", ["wav", "flac", "mp3", "m4a"])
+def test_import_project_encodes_selected_durable_format(
+    sample_audio_file: Path,
+    tmp_path: Path,
+    output_format: str,
+) -> None:
+    source_path = tmp_path / f"fixture-{output_format}.wav"
+    source_path.write_bytes(sample_audio_file.read_bytes() + output_format.encode())
+    source_hash = file_sha256(source_path)
+    assert source_hash is not None
+
+    with SessionLocal() as session:
+        project = import_project(
+            session,
+            source_path=str(source_path),
+            copy_into_project=True,
+            display_name=None,
+            output_format=output_format,  # type: ignore[arg-type]
+        )
+        session.commit()
+        session.refresh(project)
+
+        source_artifact = next(
+            artifact for artifact in project.artifacts if artifact.type == "source_audio"
+        )
+        imported_path = Path(project.imported_path)
+        assert project.id == source_hash_to_project_id(source_hash)
+        assert project.source_sha256 == source_hash
+        assert imported_path.suffix == f".{output_format}"
+        assert source_artifact.format == output_format
+        assert source_artifact.content_sha256 == file_sha256(imported_path)
+
+
 def test_import_project_rejects_duplicate_source_hash(client, sample_audio_file: Path):
     source_hash = file_sha256(sample_audio_file)
     assert source_hash is not None
@@ -446,6 +479,7 @@ def test_import_project_enqueues_source_processing_after_stems(
             "source_path": str(sample_chord_audio_file),
             "copy_into_project": True,
             "stem_model": "htdemucs_ft",
+            "output_format": "flac",
         },
     )
 
@@ -505,6 +539,7 @@ def test_import_project_enqueues_full_source_processing(
             "source_path": str(sample_chord_audio_file),
             "copy_into_project": True,
             "stem_model": "htdemucs_ft",
+            "output_format": "flac",
         },
     )
 
@@ -515,6 +550,7 @@ def test_import_project_enqueues_full_source_processing(
         for artifact in client.get(f"/api/v1/projects/{project['id']}/artifacts").json()["artifacts"]
         if artifact["type"] == "source_audio"
     )
+    assert source_artifact["format"] == "flac"
 
     jobs = client.get("/api/v1/jobs").json()["jobs"]
     analyze_job = next(job for job in jobs if job["project_id"] == project["id"] and job["type"] == "analyze")
@@ -528,6 +564,10 @@ def test_import_project_enqueues_full_source_processing(
     assert completed_stem_job["source_artifact_id"] == source_artifact["id"]
     assert completed_stem_job["stem_model"] == "htdemucs_ft"
     assert completed_stem_job["stem_model_label"] == "2 stems model"
+    with SessionLocal() as session:
+        persisted_stem_job = session.get(Job, stem_job["id"])
+        assert persisted_stem_job is not None
+        assert persisted_stem_job.payload_json["output_format"] == "flac"
     completed_chord_job = wait_for_job(client, chord_job["id"], timeout=90.0)
     assert completed_chord_job["status"] == "completed"
     assert completed_chord_job["chord_backend"] == "tuneforge-fast"

--- a/apps/backend/tests/test_stem_flow.py
+++ b/apps/backend/tests/test_stem_flow.py
@@ -201,6 +201,52 @@ def test_default_stem_generation_creates_six_stem_artifacts(client, sample_stere
     assert not [artifact for artifact in remaining_artifacts if artifact["id"] == drums_artifact["id"]]
 
 
+@pytest.mark.parametrize("output_format", ["wav", "flac", "mp3", "m4a"])
+def test_stem_generation_encodes_selected_durable_format(
+    client,
+    sample_stereo_audio_file: Path,
+    tmp_path: Path,
+    monkeypatch,
+    output_format: str,
+) -> None:
+    source_path = tmp_path / f"stems-{output_format}.wav"
+    source_path.write_bytes(sample_stereo_audio_file.read_bytes() + output_format.encode())
+
+    def fake_separate_sources(
+        source_path: Path,
+        output_paths: dict[str, Path],
+        **_kwargs,
+    ) -> dict[str, str]:
+        signal, sample_rate = sf.read(source_path, always_2d=True)
+        for output_path in output_paths.values():
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            sf.write(output_path, signal * 0.5, sample_rate)
+        return {"engine": "demucs", "model": "htdemucs_6s", "device": "cpu"}
+
+    monkeypatch.setattr("app.services.stems.separate_sources", fake_separate_sources)
+    project_id = _create_project_without_import_jobs(source_path)
+
+    response = client.post(
+        f"/api/v1/projects/{project_id}/stems",
+        json={"mode": "stems", "output_format": output_format, "force": False},
+    )
+    assert response.status_code == 200
+    final_job = wait_for_job(client, response.json()["job"]["id"])
+    assert final_job["status"] == "completed"
+
+    artifacts = client.get(f"/api/v1/projects/{project_id}/artifacts").json()["artifacts"]
+    stem_artifacts = [
+        artifact
+        for artifact in artifacts
+        if artifact["metadata"].get("stem_model") == "htdemucs_6s"
+    ]
+    assert len(stem_artifacts) == 6
+    assert {artifact["format"] for artifact in stem_artifacts} == {output_format}
+    assert {Path(artifact["path"]).suffix for artifact in stem_artifacts} == {
+        f".{output_format}"
+    }
+
+
 def test_rebuilding_six_stems_with_two_stems_prunes_previous_model_artifacts(
     client,
     sample_stereo_audio_file: Path,

--- a/apps/backend/tests/test_sync_bundle.py
+++ b/apps/backend/tests/test_sync_bundle.py
@@ -920,7 +920,7 @@ def _create_project_with_artifacts(
     tmp_path: Path,
 ) -> BundleProjectFixture:
     source_bytes = _wav_bytes(frame_count=96)
-    stem_bytes = b"sync bundle stem bytes"
+    stem_bytes = _wav_bytes(frame_count=48)
     external_source = tmp_path / "user-library" / f"{hashlib.sha1(source_bytes).hexdigest()}.wav"
     source_sha256, _ = _write_bytes(external_source, source_bytes)
     project_id = source_hash_to_project_id(source_sha256)

--- a/apps/backend/tests/test_sync_manifest.py
+++ b/apps/backend/tests/test_sync_manifest.py
@@ -29,6 +29,7 @@ from app.models import (
 )
 from app.schemas import SyncMetadataResponse, SyncProjectManifestSchema
 from app.services.paths import project_root
+from app.services.projects import import_project
 from app.services.sync_identity import source_hash_to_project_id
 from app.services.sync_metadata import get_sync_metadata
 from app.services.sync_revisions import CURRENT_REVISION_STATE
@@ -252,10 +253,12 @@ def _create_project_with_artifacts(
     tmp_path: Path,
     *,
     source_bytes: bytes | None = None,
-    stem_bytes: bytes = b"sync vocal stem",
+    stem_bytes: bytes | None = None,
 ) -> ManifestProjectFixture:
     if source_bytes is None:
         source_bytes = _wav_bytes()
+    if stem_bytes is None:
+        stem_bytes = _wav_bytes()
     external_source = tmp_path / "user-library" / "fixture.wav"
     source_sha256, _ = _write_bytes(external_source, source_bytes)
     project_id = source_hash_to_project_id(source_sha256)
@@ -337,6 +340,56 @@ def _create_project_with_artifacts(
         },
         external_source_path=external_source,
     )
+
+
+@pytest.mark.parametrize("output_format", ["wav", "flac", "mp3", "m4a"])
+def test_sync_round_trip_preserves_durable_source_format_and_bytes(
+    client: object,
+    sample_audio_file: Path,
+    tmp_path: Path,
+    output_format: str,
+) -> None:
+    del client
+    export_manifest, import_manifest = _sync_manifest_services()
+    source_path = tmp_path / f"sync-source-{output_format}.wav"
+    source_path.write_bytes(sample_audio_file.read_bytes() + output_format.encode())
+    staging_root = tmp_path / "staging"
+
+    with SessionLocal() as session:
+        project = import_project(
+            session,
+            source_path=str(source_path),
+            copy_into_project=True,
+            display_name=None,
+            output_format=output_format,  # type: ignore[arg-type]
+        )
+        session.commit()
+        session.refresh(project)
+        project_id = project.id
+        root = project_root(project_id)
+        manifest = _plain_manifest(export_manifest(session, project_id=project_id))
+        _stage_manifest_files(manifest, staging_root=staging_root, source_root=root)
+        source_manifest = next(
+            artifact for artifact in manifest["artifacts"] if artifact["type"] == "source_audio"
+        )
+        staged_path = staging_root / source_manifest["relative_path"]
+        staged_bytes = staged_path.read_bytes()
+
+        session.delete(project)
+        session.commit()
+        shutil.rmtree(root)
+
+        imported = import_manifest(session, manifest=manifest, staging_root=staging_root)
+        session.commit()
+        session.refresh(imported)
+
+        source_artifact = next(
+            artifact for artifact in imported.artifacts if artifact.type == "source_audio"
+        )
+        assert source_artifact.format == output_format
+        assert Path(source_artifact.path).suffix == f".{output_format}"
+        assert Path(source_artifact.path).read_bytes() == staged_bytes
+        assert source_artifact.content_sha256 == source_manifest["content_sha256"]
 
 
 def _revision_content_hash(payload: dict[str, Any]) -> str:
@@ -1268,7 +1321,7 @@ def test_export_project_manifest_allows_source_artifact_hash_to_differ_from_proj
     assert source_artifact_manifest["content_sha256"] != fixture.source_sha256
 
 
-def test_export_project_manifest_rejects_non_wav_source_audio_artifact(
+def test_export_project_manifest_rejects_source_audio_format_suffix_mismatch(
     client: object,
     tmp_path: Path,
 ) -> None:
@@ -1285,7 +1338,7 @@ def test_export_project_manifest_rejects_non_wav_source_audio_artifact(
     assert exc.value.code == "SYNC_MANIFEST_SOURCE_ARTIFACT_UNSUPPORTED"
     assert exc.value.status_code == 400
     assert exc.value.details["artifact_id"] == "art_source_audio"
-    assert exc.value.details["format"] == "mp3"
+    assert exc.value.details["relative_path"] == fixture.source_relative_path
 
 
 def test_export_project_manifest_rejects_multiple_source_artifacts(
@@ -2187,7 +2240,7 @@ def test_import_staged_project_manifest_rejects_corrupt_content_addressed_stagin
         )
         corrupt_path = staged_paths[fixture.artifact_hashes["art_vocals"]]
         _delete_live_project(session, fixture)
-        corrupt_path.write_bytes(b"corrupt stem!!!")
+        corrupt_path.write_bytes(b"x" * corrupt_path.stat().st_size)
 
         with pytest.raises(AppError) as exc:
             import_manifest(
@@ -2218,7 +2271,8 @@ def test_import_staged_project_manifest_rejects_hash_mismatch(
         fixture = _create_project_with_artifacts(session, tmp_path)
         manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
         _stage_manifest_files(manifest, staging_root=staging_root, source_root=fixture.root)
-        (staging_root / fixture.stem_relative_path).write_bytes(b"corrupt stem!!!")
+        staged_stem = staging_root / fixture.stem_relative_path
+        staged_stem.write_bytes(b"x" * staged_stem.stat().st_size)
         _delete_live_project(session, fixture)
 
         with pytest.raises(AppError) as exc:
@@ -2362,10 +2416,39 @@ def test_import_staged_project_manifest_rejects_non_wav_source_audio_bytes(
 
         assert session.get(Project, fixture.project_id) is None
 
-    assert exc.value.code == "SYNC_MANIFEST_SOURCE_ARTIFACT_NOT_WAV"
+    assert exc.value.code == "SYNC_MANIFEST_DURABLE_AUDIO_INVALID"
     assert exc.value.status_code == 400
     assert exc.value.details["artifact_id"] == "art_source_audio"
     assert exc.value.details["relative_path"] == fixture.source_relative_path
+
+
+def test_import_staged_project_manifest_rejects_corrupt_durable_stem_bytes(
+    client: object,
+    tmp_path: Path,
+) -> None:
+    export_manifest, import_manifest = _sync_manifest_services()
+    staging_root = tmp_path / "staging"
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(session, tmp_path)
+        manifest = _plain_manifest(export_manifest(session, project_id=fixture.project_id))
+        _stage_manifest_files(manifest, staging_root=staging_root, source_root=fixture.root)
+
+        staged_stem_path = staging_root / fixture.stem_relative_path
+        invalid_hash, invalid_size = _write_bytes(staged_stem_path, b"not a wav stem")
+        stem_artifact = _artifacts_by_id(manifest)["art_vocals"]
+        stem_artifact["content_sha256"] = invalid_hash
+        stem_artifact["size_bytes"] = invalid_size
+        _delete_live_project(session, fixture)
+
+        with pytest.raises(AppError) as exc:
+            import_manifest(session, manifest=manifest, staging_root=staging_root)
+        session.rollback()
+
+        assert session.get(Project, fixture.project_id) is None
+
+    assert exc.value.code == "SYNC_MANIFEST_DURABLE_AUDIO_INVALID"
+    assert exc.value.details["artifact_id"] == "art_vocals"
 
 
 def test_import_staged_project_manifest_rejects_multiple_source_artifacts(

--- a/apps/backend/tests/test_sync_reconciliation.py
+++ b/apps/backend/tests/test_sync_reconciliation.py
@@ -2614,8 +2614,14 @@ def test_missing_project_import_requires_every_manifest_artifact_available(
         ("missing_source", "Project manifest must contain exactly one source_audio artifact."),
         ("ambiguous_source", "Project manifest must contain exactly one source_audio artifact."),
         ("wrong_type", "Project manifest must contain exactly one source_audio artifact."),
-        ("non_wav_format", "Project manifest source_audio artifact format must be 'wav'."),
-        ("non_wav_relative_path", "Project manifest source_audio artifact relative_path must end with .wav."),
+        (
+            "non_wav_format",
+            "Project manifest source_audio artifact format and relative_path suffix do not match.",
+        ),
+        (
+            "non_wav_relative_path",
+            "Project manifest source_audio artifact format and relative_path suffix do not match.",
+        ),
         ("unsafe_relative_path", "Sync manifest artifact relative path is invalid."),
         ("noncanonical_project_id", "Project manifest project_id must be derived from source_sha256."),
     ],

--- a/apps/backend/tests/test_sync_reconciliation_apply_batch_import.py
+++ b/apps/backend/tests/test_sync_reconciliation_apply_batch_import.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Session
 
 from app.config import get_settings
 from app.db import SessionLocal
+from app.engines.audio_encoding import DurableAudioFormat, encode_audio
 from app.models import (
     AnalysisResult,
     Artifact,
@@ -1357,7 +1358,7 @@ def test_issue119_staging_cleanup_keeps_shared_hash_until_all_references_import(
     tmp_path: Path,
 ) -> None:
     _ensure_identity_and_peers("peer-issue119-shared-hash")
-    shared_stem_bytes = b"shared issue119 stem bytes"
+    shared_stem_bytes = _wav_bytes(frame_count=72)
 
     with SessionLocal() as session:
         first = _create_project_with_artifacts(
@@ -2719,9 +2720,11 @@ def test_issue120_stale_inventory_cannot_import_without_verified_staged_size(
         } == {fixture.source_artifact_id, fixture.stem_artifact_id}
 
 
+@pytest.mark.parametrize("output_format", ["wav", "flac", "mp3", "m4a"])
 def test_issue120_existing_project_imports_late_manifest_artifacts(
     client: TestClient,
     tmp_path: Path,
+    output_format: DurableAudioFormat,
 ) -> None:
     _ensure_identity_and_peers("peer-issue120-late-artifact")
 
@@ -2738,11 +2741,29 @@ def test_issue120_existing_project_imports_late_manifest_artifacts(
         assert late_artifact is not None
         session.delete(late_artifact)
         late_artifact_path.unlink()
+        source_path = tmp_path / "issue120-late-artifact-source.wav"
+        source_path.write_bytes(fixture.artifact_bytes[fixture.stem_artifact_id])
+        encoded_path = tmp_path / f"issue120-late-artifact.{output_format}"
+        encode_audio(source_path, encoded_path, output_format)
+        encoded_bytes = encoded_path.read_bytes()
+        encoded_hash = file_sha256(encoded_path)
+        assert encoded_hash is not None
+        remote_artifact = _artifact_by_id(manifest, fixture.stem_artifact_id)
+        remote_artifact.update(
+            {
+                "format": output_format,
+                "relative_path": Path(fixture.stem_relative_path)
+                .with_suffix(f".{output_format}")
+                .as_posix(),
+                "content_sha256": encoded_hash,
+                "size_bytes": len(encoded_bytes),
+            }
+        )
         _stage_manifest_artifact_content(
             session,
             manifest,
             tmp_path=tmp_path,
-            artifact_bytes=fixture.artifact_bytes,
+            artifact_bytes={fixture.stem_artifact_id: encoded_bytes},
             provider_device_id="peer-issue120-late-artifact",
             artifact_id=fixture.stem_artifact_id,
         )
@@ -2783,8 +2804,82 @@ def test_issue120_existing_project_imports_late_manifest_artifacts(
         assert Path(restored_artifact.path).exists()
         assert restored_artifact.project_id == fixture.project_id
         assert restored_artifact.type == "vocals"
+        assert restored_artifact.format == output_format
+        assert Path(restored_artifact.path).suffix == f".{output_format}"
         assert restored_artifact.metadata_json == {"source_artifact_id": fixture.source_artifact_id}
-        assert restored_artifact.content_sha256 == fixture.artifact_hashes[fixture.stem_artifact_id]
+        assert restored_artifact.content_sha256 == encoded_hash
+        assert Path(restored_artifact.path).read_bytes() == encoded_bytes
+
+
+def test_issue120_late_durable_artifact_rejects_corrupt_staged_bytes(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    peer_id = "peer-issue120-corrupt-durable"
+    _ensure_identity_and_peers(peer_id)
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="issue120-corrupt-durable",
+            source_frames=129,
+        )
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        late_artifact = session.get(Artifact, fixture.stem_artifact_id)
+        assert late_artifact is not None
+        destination_path = Path(late_artifact.path)
+        session.delete(late_artifact)
+        destination_path.unlink()
+        corrupt_bytes = b"not an audio stream"
+        corrupt_path = tmp_path / "corrupt-durable.wav"
+        corrupt_hash, corrupt_size = _write_bytes(corrupt_path, corrupt_bytes)
+        remote_artifact = _artifact_by_id(manifest, fixture.stem_artifact_id)
+        remote_artifact.update(
+            {
+                "content_sha256": corrupt_hash,
+                "size_bytes": corrupt_size,
+            }
+        )
+        _stage_manifest_artifact_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes={fixture.stem_artifact_id: corrupt_bytes},
+            provider_device_id=peer_id,
+            artifact_id=fixture.stem_artifact_id,
+        )
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": _empty_remote_library(),
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": peer_id,
+                    "available_content_sha256": [corrupt_hash],
+                }
+            ],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 1
+    assert any(
+        result["action"]["action_type"] == "import_artifact_manifest"
+        and result["action"]["item_id"] == fixture.stem_artifact_id
+        and result["status"] == "failed"
+        and result["details"]["error_code"] == "SYNC_MANIFEST_DURABLE_AUDIO_INVALID"
+        for result in payload["results"]
+    )
+    with SessionLocal() as session:
+        assert session.get(Artifact, fixture.stem_artifact_id) is None
+        assert not destination_path.exists()
+        assert session.get(SyncStagedArtifact, corrupt_hash) is not None
 
 
 def test_issue120_late_manifest_copy_mismatch_does_not_persist_artifact(
@@ -3223,14 +3318,22 @@ def test_regenerated_stem_newer_than_local_tombstone_applies_without_conflict(
                 updated_at=deleted_at,
             )
         )
-        remote_bytes = f"remotely regenerated {slug} bytes".encode()
-        remote_hash, remote_size = _write_bytes(
-            tmp_path / slug / "remote-vocals.wav",
-            remote_bytes,
-        )
+        remote_wav_path = tmp_path / slug / "remote-vocals-source.wav"
+        remote_wav_path.parent.mkdir(parents=True, exist_ok=True)
+        remote_wav_path.write_bytes(_wav_bytes(frame_count=144))
+        remote_path = tmp_path / slug / "remote-vocals.flac"
+        encode_audio(remote_wav_path, remote_path, "flac")
+        remote_bytes = remote_path.read_bytes()
+        remote_hash = file_sha256(remote_path)
+        assert remote_hash is not None
+        remote_size = len(remote_bytes)
         remote_stem = _artifact_by_id(manifest, fixture.stem_artifact_id)
         remote_stem.update(
             {
+                "format": "flac",
+                "relative_path": Path(remote_stem["relative_path"])
+                .with_suffix(".flac")
+                .as_posix(),
                 "content_sha256": remote_hash,
                 "size_bytes": remote_size,
                 "created_at": remote_regenerated_at.isoformat(),
@@ -3249,15 +3352,27 @@ def test_regenerated_stem_newer_than_local_tombstone_applies_without_conflict(
         )
         remote_sibling_hash: str | None = None
         remote_sibling_size: int | None = None
+        old_sibling_path: Path | None = None
         if live_sibling_artifact_id is not None and sibling_metadata is not None:
-            remote_sibling_bytes = b"remotely regenerated sibling instrumental bytes"
-            remote_sibling_hash, remote_sibling_size = _write_bytes(
-                tmp_path / slug / "remote-instrumental.wav",
-                remote_sibling_bytes,
-            )
+            sibling_artifact = session.get(Artifact, live_sibling_artifact_id)
+            assert sibling_artifact is not None
+            old_sibling_path = Path(sibling_artifact.path)
+            sibling_wav_path = tmp_path / slug / "remote-instrumental-source.wav"
+            sibling_wav_path.parent.mkdir(parents=True, exist_ok=True)
+            sibling_wav_path.write_bytes(_wav_bytes(frame_count=152))
+            remote_sibling_path = tmp_path / slug / "remote-instrumental.flac"
+            encode_audio(sibling_wav_path, remote_sibling_path, "flac")
+            remote_sibling_bytes = remote_sibling_path.read_bytes()
+            remote_sibling_hash = file_sha256(remote_sibling_path)
+            assert remote_sibling_hash is not None
+            remote_sibling_size = len(remote_sibling_bytes)
             remote_sibling = _artifact_by_id(manifest, live_sibling_artifact_id)
             remote_sibling.update(
                 {
+                    "format": "flac",
+                    "relative_path": Path(remote_sibling["relative_path"])
+                    .with_suffix(".flac")
+                    .as_posix(),
                     "content_sha256": remote_sibling_hash,
                     "size_bytes": remote_sibling_size,
                     "created_at": remote_regenerated_at.isoformat(),
@@ -3326,6 +3441,8 @@ def test_regenerated_stem_newer_than_local_tombstone_applies_without_conflict(
         artifact = session.get(Artifact, fixture.stem_artifact_id)
         assert artifact is not None
         assert artifact.type == "vocal_stem"
+        assert artifact.format == "flac"
+        assert Path(artifact.path).suffix == ".flac"
         assert artifact.content_sha256 == remote_hash
         assert artifact.size_bytes == remote_size
         assert artifact.metadata_json["source_artifact_type"] == source_artifact_type
@@ -3334,10 +3451,137 @@ def test_regenerated_stem_newer_than_local_tombstone_applies_without_conflict(
         if live_sibling_artifact_id is not None:
             sibling = session.get(Artifact, live_sibling_artifact_id)
             assert sibling is not None
+            assert sibling.format == "flac"
+            assert Path(sibling.path).suffix == ".flac"
             assert sibling.content_sha256 == remote_sibling_hash
             assert sibling.size_bytes == remote_sibling_size
             assert sibling.created_at.replace(tzinfo=UTC) == remote_regenerated_at
+            assert old_sibling_path is not None
+            assert not old_sibling_path.exists()
         assert session.get(SyncDeleteTombstone, "tomb_local_deleted_regenerated_stem") is None
+
+    replay_response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": {
+                "projects": [manifest["project"]],
+                "artifacts": manifest["artifacts"],
+                "entity_revisions": [],
+                "delete_tombstones": [],
+            },
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": "peer-regenerated-stem",
+                    "available_content_sha256": available_hashes,
+                }
+            ],
+            "project_ids": [fixture.project_id],
+            "use_content_addressed_staging": True,
+        },
+    )
+    assert replay_response.status_code == 200
+    assert replay_response.json()["summary"]["failed_actions"] == 0
+
+
+def test_format_changing_regenerated_stem_failure_preserves_local_bytes(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    peer_id = "peer-invalid-regenerated-stem"
+    _ensure_identity_and_peers(peer_id)
+    remote_regenerated_at = datetime(2026, 1, 3, tzinfo=UTC)
+
+    with SessionLocal() as session:
+        fixture = _create_project_with_artifacts(
+            session,
+            tmp_path,
+            slug="invalid-regenerated-stem",
+            source_frames=136,
+        )
+        stem_artifact = session.get(Artifact, fixture.stem_artifact_id)
+        assert stem_artifact is not None
+        stem_metadata = {
+            "mode": "two_stems",
+            "stem_model": "htdemucs_ft",
+            "stem_model_label": "HTDemucs fine-tuned",
+            "stem_source": "vocals",
+            "source_artifact_id": fixture.source_artifact_id,
+            "source_artifact_type": "source_audio",
+        }
+        stem_artifact.type = "vocal_stem"
+        stem_artifact.metadata_json = stem_metadata
+        old_path = Path(stem_artifact.path)
+        old_bytes = old_path.read_bytes()
+        old_hash = stem_artifact.content_sha256
+        session.flush()
+        manifest = _jsonable_manifest(export_project_manifest(session, project_id=fixture.project_id))
+        corrupt_bytes = b"not flac audio"
+        corrupt_path = tmp_path / "invalid-regenerated-stem.flac"
+        corrupt_hash, corrupt_size = _write_bytes(corrupt_path, corrupt_bytes)
+        remote_stem = _artifact_by_id(manifest, fixture.stem_artifact_id)
+        remote_stem.update(
+            {
+                "format": "flac",
+                "relative_path": Path(remote_stem["relative_path"])
+                .with_suffix(".flac")
+                .as_posix(),
+                "content_sha256": corrupt_hash,
+                "size_bytes": corrupt_size,
+                "created_at": remote_regenerated_at.isoformat(),
+                "metadata": stem_metadata,
+                "can_regenerate": True,
+            }
+        )
+        _stage_manifest_artifact_content(
+            session,
+            manifest,
+            tmp_path=tmp_path,
+            artifact_bytes={fixture.stem_artifact_id: corrupt_bytes},
+            provider_device_id=peer_id,
+            artifact_id=fixture.stem_artifact_id,
+        )
+        session.commit()
+
+    response = client.post(
+        "/api/v1/sync/reconciliation/apply",
+        json={
+            "remote_library": {
+                "projects": [manifest["project"]],
+                "artifacts": manifest["artifacts"],
+                "entity_revisions": [],
+                "delete_tombstones": [],
+            },
+            "project_manifests": [manifest],
+            "peer_inventory": [
+                {
+                    "device_id": peer_id,
+                    "available_content_sha256": [corrupt_hash],
+                }
+            ],
+            "project_ids": [fixture.project_id],
+            "use_content_addressed_staging": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"]["failed_actions"] == 1
+    assert any(
+        result["action"]["action_type"] == "import_artifact_manifest"
+        and result["action"]["item_id"] == fixture.stem_artifact_id
+        and result["status"] == "failed"
+        and result["details"]["error_code"] == "SYNC_MANIFEST_DURABLE_AUDIO_INVALID"
+        for result in payload["results"]
+    )
+    with SessionLocal() as session:
+        stem_artifact = session.get(Artifact, fixture.stem_artifact_id)
+        assert stem_artifact is not None
+        assert stem_artifact.format == "wav"
+        assert Path(stem_artifact.path) == old_path
+        assert stem_artifact.content_sha256 == old_hash
+        assert old_path.read_bytes() == old_bytes
+        assert not old_path.with_suffix(".flac").exists()
 
 
 def _ensure_identity_and_peers(*peer_device_ids: str) -> dict[str, str]:
@@ -3373,7 +3617,7 @@ def _create_project_with_artifacts(
     stem_bytes: bytes | None = None,
 ) -> Issue119ProjectFixture:
     source_bytes = _wav_bytes(frame_count=source_frames)
-    stem_bytes = stem_bytes if stem_bytes is not None else f"issue119 stem {slug}".encode()
+    stem_bytes = stem_bytes if stem_bytes is not None else _wav_bytes(frame_count=max(1, source_frames // 2))
     external_source_path = tmp_path / "library" / f"{slug}.wav"
     source_sha256, _ = _write_bytes(external_source_path, source_bytes)
     project_id = source_hash_to_project_id(source_sha256)

--- a/apps/backend/tests/test_transform_flow.py
+++ b/apps/backend/tests/test_transform_flow.py
@@ -183,6 +183,31 @@ def test_preview_generation_cache_and_export(client, sample_audio_file: Path):
     assert any(Path(artifact["path"]).suffix == ".mp3" for artifact in exported)
 
 
+@pytest.mark.parametrize("output_format", ["wav", "flac", "mp3", "m4a"])
+def test_preview_mix_encodes_selected_durable_format(
+    client,
+    sample_audio_file: Path,
+    tmp_path: Path,
+    output_format: str,
+) -> None:
+    source_path = tmp_path / f"preview-{output_format}.wav"
+    source_path.write_bytes(sample_audio_file.read_bytes() + output_format.encode())
+    project = import_project_without_jobs(source_path)
+
+    response = client.post(
+        f"/api/v1/projects/{project['id']}/preview",
+        json={"transpose": {"semitones": 1}, "output_format": output_format},
+    )
+    assert response.status_code == 200
+    final_job = wait_for_job(client, response.json()["job"]["id"])
+    assert final_job["status"] == "completed"
+
+    artifacts = client.get(f"/api/v1/projects/{project['id']}/artifacts").json()["artifacts"]
+    preview = next(artifact for artifact in artifacts if artifact["type"] == "preview_mix")
+    assert preview["format"] == output_format
+    assert Path(preview["path"]).suffix == f".{output_format}"
+
+
 def test_export_uses_exact_destination_file_path(client, tmp_path: Path):
     project_id, artifact_id, source_path = _create_export_fixture(
         tmp_path,

--- a/apps/desktop/src/lib/api.mobile-sync.test.ts
+++ b/apps/desktop/src/lib/api.mobile-sync.test.ts
@@ -202,6 +202,7 @@ describe("mobile sync API adapter", () => {
       source_path: "/music/song.wav",
       copy_into_project: true,
       beat_backend: "built-in",
+      output_format: "wav",
     };
     const defaultRequest: ProjectImportRequest = {
       source_path: "/music/default.wav",
@@ -266,6 +267,26 @@ describe("mobile sync API adapter", () => {
 
     expect(mockInvoke).not.toHaveBeenCalled();
   });
+
+  it.each(["flac", "mp3", "m4a"] as const)(
+    "rejects %s durable import format on mobile before native invoke",
+    async (outputFormat) => {
+      const api = await loadMobileApi();
+
+      await expect(
+        api.importProject({
+          source_path: "/music/song.wav",
+          copy_into_project: true,
+          output_format: outputFormat,
+        }),
+      ).rejects.toMatchObject({
+        code: "UNSUPPORTED_RUNTIME",
+        details: { output_format: outputFormat },
+      });
+
+      expect(mockInvoke).not.toHaveBeenCalled();
+    },
+  );
 
   it("allows built-in mobile analysis requests", async () => {
     const api = await loadMobileApi();

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -2468,6 +2468,15 @@ function createMobileTuneForgeClient(capabilities: MobileCapabilities): TuneForg
       });
     }
   };
+  const requireSupportedMobileImportFormat = (request: ProjectImportRequest) => {
+    if (request.output_format !== undefined && request.output_format !== "wav") {
+      throw new ApiError({
+        code: "UNSUPPORTED_RUNTIME",
+        message: "Selecting a compressed durable audio format is not available on mobile yet.",
+        details: { output_format: request.output_format },
+      });
+    }
+  };
 
   return {
     getMobileCapabilities: async () => capabilities,
@@ -2514,6 +2523,7 @@ function createMobileTuneForgeClient(capabilities: MobileCapabilities): TuneForg
       invokeMobile("mobile_list_projects", { params: params ?? null }),
     importProject: async (body: ProjectImportRequest) => {
       requireSupportedMobileAnalysisBackend(body);
+      requireSupportedMobileImportFormat(body);
       return invokeMobile("mobile_import_project", { payload: body });
     },
     getProject: (projectId: string) => invokeMobile("mobile_get_project", { projectId }),

--- a/docs/API.md
+++ b/docs/API.md
@@ -604,7 +604,7 @@ Request fields:
 - `manifest`
 - `staging_root`
 
-`staging_root` is a local directory containing the staged project files at the relative paths declared in the manifest. During import, the backend requires exactly one `source_audio` artifact, and that artifact must use `format="wav"` with a `.wav` relative path. The backend verifies source and artifact bytes with SHA-256, rewrites accepted paths into this install's backend-managed project root, and persists the project through backend services instead of copying database rows from another device. Original absolute import paths are local provenance only and are not sync-operational inputs.
+`staging_root` is a local directory containing the staged project files at the relative paths declared in the manifest. During import, the backend requires exactly one `source_audio` artifact. Durable sources, stems, and practice mixes accept exact `wav`/`.wav`, `flac`/`.flac`, `mp3`/`.mp3`, or AAC-LC `m4a`/`.m4a` pairs. The backend verifies size, SHA-256, readability, container, and codec before commit, rewrites accepted paths into this install's backend-managed project root, and persists the project through backend services instead of copying database rows from another device. Original absolute import paths are local provenance only and are not sync-operational inputs.
 
 If the local library already contains the same canonical project or source SHA-256, staged import rejects the duplicate with HTTP `409` instead of creating a second project. The response uses the normal project wrapper shape:
 
@@ -625,6 +625,7 @@ Request fields:
 - `source_path`
 - `copy_into_project`
 - `display_name`
+- `output_format` - `wav`, `flac`, `mp3`, or `m4a`; defaults to `wav`.
 - `chord_backend`
 - `chord_backend_fallback_from`
 - `stem_model`
@@ -637,7 +638,7 @@ manual stem generation preferences; if omitted, the backend stem model default i
 defaults to `built-in`; desktop preferences may send `beat-this` when Advanced Beat Analysis is
 available. Chord backend fields follow the same validation as explicit chord generation.
 
-`source_path` records where the user imported the file from on this install. Sync treats it as local provenance, not a durable source of original bytes or an operational sync input. `copy_into_project=false` is accepted for compatibility, but new imports still create an app-managed operational WAV source artifact under the project root.
+`source_path` records where the user imported the file from on this install. Sync treats it as local provenance, not a durable source of original bytes or an operational sync input. `copy_into_project=false` is accepted for compatibility, but new imports still create an app-managed durable source artifact under the project root. Project identity remains derived from the original selected bytes; the artifact hash describes the encoded durable bytes.
 
 If the same source track has already been imported, the endpoint returns HTTP `409` with code `DUPLICATE_PROJECT_SOURCE`, message `This project is already imported with name "{name}".`, and details containing:
 
@@ -867,7 +868,7 @@ Request fields:
 - `transpose`
 - `output_format`
 
-At least one transform must be provided.
+At least one transform must be provided. Durable practice mixes support `wav`, `flac`, `mp3`, and `m4a`.
 
 Response: `JobResponse`.
 
@@ -890,7 +891,7 @@ Request fields:
 - `chord_backend_fallback_from`
 - `overwrite_chord_edits`
 
-Current validation allows `mode: "stems"` or `mode: "two_stem"` and `output_format: "wav"`. If `stem_model` is omitted, `mode: "stems"` uses the backend default `htdemucs_6s`; `mode: "two_stem"` maps to `htdemucs_ft` for compatibility.
+Current validation allows `mode: "stems"` or `mode: "two_stem"` and `output_format: "wav"`, `"flac"`, `"mp3"`, or `"m4a"`. If `stem_model` is omitted, `mode: "stems"` uses the backend default `htdemucs_6s`; `mode: "two_stem"` maps to `htdemucs_ft` for compatibility.
 
 `htdemucs_6s` creates visible `Vocals`, `Drums`, `Bass`, `Guitar`, `Piano`, and `Other` artifacts. `htdemucs_ft` creates visible `Vocals` and `Instrumental` artifacts.
 
@@ -1034,6 +1035,7 @@ Queues the same project activity job for eligible projects in the local library.
 Request fields:
 
 - `job_type` - `analyze`, `chords`, `lyrics`, or `stems`.
+- `output_format` - captured durable stem format; defaults to `wav` and must remain `wav` for non-stem jobs.
 - `chord_backend`
 - `chord_backend_fallback_from`
 - `stem_model`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -138,6 +138,12 @@ Filesystem storage holds:
 - export artifacts
 - future JSON artifacts such as tempo/beat maps
 
+App-owned source audio, stems, and saved practice mixes may use PCM16 WAV, FLAC level 5,
+MP3 at 192 kbps, or AAC-LC M4A at 192 kbps. Each creation job captures one format; mixed-format
+projects remain valid. Analysis, chord, lyric, and Demucs integrations receive scoped temporary
+PCM WAV materializations when their durable input is compressed. Working WAVs are never artifacts,
+never sync, and are removed when processing completes.
+
 Artifact rows include type, format, path, size, generation metadata, delete/regenerate flags, and creation time.
 
 ### Database Migrations

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,8 +19,8 @@ not viable, and completing a research issue never promises a shipped feature.
 | --- | --- | --- |
 | [v1.0.1 — Mobile and E2E hardening](https://github.com/grazzolini/tuneforge/milestone/13) | Consolidate completed mobile, E2E, test-performance, and Android packaging work. | [#391](https://github.com/grazzolini/tuneforge/issues/391) |
 | [v1.1.0 — Export workflows](https://github.com/grazzolini/tuneforge/milestone/14) | Make audio and stem export selective, explicit, and platform-truthful. | [#392](https://github.com/grazzolini/tuneforge/issues/392) |
-| [v1.2.0 — Storage format choice](https://github.com/grazzolini/tuneforge/milestone/15) | Choose WAV or FLAC for newly created durable audio. | [#393](https://github.com/grazzolini/tuneforge/issues/393) |
-| [v1.3.0 — Footprint and engine defaults](https://github.com/grazzolini/tuneforge/milestone/16) | Convert existing audio on demand and reduce the default chord-engine footprint. | [#394](https://github.com/grazzolini/tuneforge/issues/394) |
+| [v1.2.0 — Storage format choice](https://github.com/grazzolini/tuneforge/milestone/15) | Choose WAV, FLAC, MP3, or M4A for newly created durable audio and convert existing audio on demand. | [#393](https://github.com/grazzolini/tuneforge/issues/393) |
+| [v1.3.0 — Footprint and engine defaults](https://github.com/grazzolini/tuneforge/milestone/16) | Improve the lightweight chord engine and reduce the default package footprint. | [#394](https://github.com/grazzolini/tuneforge/issues/394) |
 | [v1.4.0 — Mobile runtime experiments](https://github.com/grazzolini/tuneforge/milestone/17) | Measure iOS simulator and Android model feasibility without shipment promises. | [#395](https://github.com/grazzolini/tuneforge/issues/395) |
 | [v2.0.0 — Android-first 2.0](https://github.com/grazzolini/tuneforge/milestone/18) | Deliver the complete Android-first workflow and truthful capability states. | [#396](https://github.com/grazzolini/tuneforge/issues/396) |
 
@@ -60,29 +60,30 @@ Chords-only and additional document formats remain outside this milestone.
 
 ## v1.2.0 — Storage Format Choice
 
-[#398](https://github.com/grazzolini/tuneforge/issues/398) adds a `wav | flac`
-preference for new durable audio, with WAV as the default. The value is captured
+[#398](https://github.com/grazzolini/tuneforge/issues/398) adds a
+`wav | flac | mp3 | m4a` preference for new durable audio, with WAV as the default.
+MP3 and M4A use 192 kbps lossy encoding and require an irreversible-quality warning. The value is captured
 when an import, generation job, or save action starts and applies to new sources,
 stems, saved mixes, and other durable audio created by that action.
 
 Changing the preference affects future artifacts only. Existing files stay
-unchanged, and mixed WAV/FLAC libraries and projects remain valid. TuneForge does
+unchanged, and mixed-format libraries and projects remain valid. TuneForge does
 not retain the original import as a separate canonical file under this plan.
 
 Sync preserves each received artifact's format regardless of the receiving
 peer's preference. Backend and Android source validation must accept matching
-WAV/FLAC media formats and suffixes. All peers are assumed to run the latest
+WAV, FLAC, MP3, and AAC-LC M4A media formats and suffixes. All peers are assumed to run the latest
 TuneForge; version negotiation, compatibility transcoding, and protocol redesign
 are out of scope. Any HTTP schema change must regenerate the committed OpenAPI
 TypeScript contract.
 
-## v1.3.0 — Footprint and Engine Defaults
-
 [#399](https://github.com/grazzolini/tuneforge/issues/399) adds an explicit
-background job to transcode existing durable audio to the current WAV/FLAC
+background job to transcode existing durable audio to the current four-format
 preference. It reuses progress and cancellation patterns, verifies each new
 file, and atomically updates the artifact path, format, size, and content hash.
 It does not rerun analysis, stems, lyrics, chords, beats, or other models.
+
+## v1.3.0 — Footprint and Engine Defaults
 
 [#400](https://github.com/grazzolini/tuneforge/issues/400) improves the
 lightweight chord engine and makes it the default. CREMA remains supported as an
@@ -109,7 +110,7 @@ unmilestoned until evidence justifies implementation.
 ## v2.0.0 — Android-First 2.0
 
 Android is the primary mobile target. The 2.0 gate is a functional Android flow
-for import, library, playback, editing, sync, export, WAV/FLAC storage, and
+for import, library, playback, editing, sync, export, four-format durable storage, and
 truthful model capability states.
 
 Heavy on-device models ship only when v1.4 evidence justifies them. A negative

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -953,6 +953,12 @@ export interface components {
              * @enum {string}
              */
             job_type: "analyze" | "chords" | "lyrics" | "stems";
+            /**
+             * Output Format
+             * @default wav
+             * @enum {string}
+             */
+            output_format?: "wav" | "flac" | "mp3" | "m4a";
             /** Chord Backend */
             chord_backend?: string | null;
             /** Chord Backend Fallback From */
@@ -1528,8 +1534,9 @@ export interface components {
             /**
              * Output Format
              * @default wav
+             * @enum {string}
              */
-            output_format?: string;
+            output_format?: "wav" | "flac" | "mp3" | "m4a";
         };
         /** PreviewRetuneRequest */
         PreviewRetuneRequest: {
@@ -1554,6 +1561,12 @@ export interface components {
             copy_into_project?: boolean;
             /** Display Name */
             display_name?: string | null;
+            /**
+             * Output Format
+             * @default wav
+             * @enum {string}
+             */
+            output_format?: "wav" | "flac" | "mp3" | "m4a";
             /** Chord Backend */
             chord_backend?: string | null;
             /** Chord Backend Fallback From */
@@ -1727,8 +1740,9 @@ export interface components {
             /**
              * Output Format
              * @default wav
+             * @enum {string}
              */
-            output_format?: string;
+            output_format?: "wav" | "flac" | "mp3" | "m4a";
             /**
              * Force
              * @default false


### PR DESCRIPTION
## Summary

- Add WAV, FLAC, MP3, and M4A durable encoding for imports, stems, saved mixes, and bulk stem jobs.
- Preserve default-WAV compatibility while publishing encoded artifacts atomically through validated staging.
- Materialize private temporary PCM WAV inputs for analysis, chords, lyrics, and Demucs processing.
- Validate and preserve all four formats through desktop sync, including format-changing regenerated stems.
- Regenerate OpenAPI types, update architecture/API/roadmap docs, and reject unsupported mobile encoding explicitly.
- Refs #398

## Testing

- `cd apps/backend && uv run --python 3.11 pytest` — 726 passed.
- `cd apps/backend && uv run --python 3.11 ruff check .` — passed.
- `cd apps/backend && uv run --python 3.11 mypy app` — 83 modules passed.
- `pnpm lint` — passed.
- `pnpm typecheck` — passed.
- `pnpm test` — desktop, Tauri, and backend gates passed.
- `pnpm --filter @tuneforge/desktop test` — 45 files and 780 tests passed after final contract fix.
- `pnpm contracts:generate` — generated twice with no drift on the second run.
