### PR TITLE
fix: recover playback after output route changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ download, installation, verification, signature, and publication instructions.
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserved project playback safely across native output route changes and interruptions by using
+  a guarded Web Audio fallback at the current position.
+
 ## [1.1.0] - 2026-08-18
 
 ### Added

--- a/apps/desktop/src-tauri/src/native_audio/diagnostics.rs
+++ b/apps/desktop/src-tauri/src/native_audio/diagnostics.rs
@@ -14,7 +14,7 @@ const ENABLE_ENV: &str = "TUNEFORGE_NATIVE_AUDIO_DIAGNOSTICS";
 const SCHEMA_VERSION: &str = "tuneforge-native-audio-diagnostics-v1";
 const MAX_OPERATIONS: usize = 256;
 const MAX_LANES: usize = 6;
-const SAFE_CODE_COUNT: usize = 5;
+const SAFE_CODE_COUNT: usize = 8;
 const TIMESTAMP_PENDING: u64 = u64::MAX;
 
 static DIAGNOSTICS: OnceLock<DiagnosticsRecorder> = OnceLock::new();
@@ -153,6 +153,9 @@ pub enum DiagnosticSafeCode {
     RuntimeStartFailure,
     DecoderWorkerFailure,
     OutputStreamFailure,
+    DeviceChanged,
+    DeviceNotAvailable,
+    StreamInvalidated,
 }
 
 const SAFE_CODES: [DiagnosticSafeCode; SAFE_CODE_COUNT] = [
@@ -161,6 +164,9 @@ const SAFE_CODES: [DiagnosticSafeCode; SAFE_CODE_COUNT] = [
     DiagnosticSafeCode::RuntimeStartFailure,
     DiagnosticSafeCode::DecoderWorkerFailure,
     DiagnosticSafeCode::OutputStreamFailure,
+    DiagnosticSafeCode::DeviceChanged,
+    DiagnosticSafeCode::DeviceNotAvailable,
+    DiagnosticSafeCode::StreamInvalidated,
 ];
 
 impl DiagnosticSafeCode {
@@ -171,6 +177,9 @@ impl DiagnosticSafeCode {
             Self::RuntimeStartFailure => 2,
             Self::DecoderWorkerFailure => 3,
             Self::OutputStreamFailure => 4,
+            Self::DeviceChanged => 5,
+            Self::DeviceNotAvailable => 6,
+            Self::StreamInvalidated => 7,
         }
     }
 }

--- a/apps/desktop/src-tauri/src/native_audio/diagnostics_tests.rs
+++ b/apps/desktop/src-tauri/src/native_audio/diagnostics_tests.rs
@@ -188,6 +188,24 @@ fn safe_code_recording_uses_fixed_atomic_slots_and_resets() {
 }
 
 #[test]
+fn output_route_safe_codes_are_counted_distinctly_without_raw_details() {
+    let (recorder, _) = recorder();
+    let generation = recorder.begin_operation(DiagnosticOperationKind::Play, 1);
+    recorder.record_safe_code(generation, DiagnosticSafeCode::DeviceChanged);
+    recorder.record_safe_code(generation, DiagnosticSafeCode::DeviceNotAvailable);
+    recorder.record_safe_code(generation, DiagnosticSafeCode::StreamInvalidated);
+
+    let export = recorder.export().expect("export");
+    let json = serde_json::to_string(&export).expect("json");
+
+    assert_eq!(export.safe_codes.len(), 3);
+    assert!(json.contains("device_changed"));
+    assert!(json.contains("device_not_available"));
+    assert!(json.contains("stream_invalidated"));
+    assert!(!json.contains("CPAL failure: /private/audio.wav device-id=42"));
+}
+
+#[test]
 fn callback_timestamps_read_clock_only_for_first_winning_event() {
     let (recorder, clock) = recorder();
     let generation = recorder.begin_operation(DiagnosticOperationKind::Play, 1);

--- a/apps/desktop/src-tauri/src/native_audio/transport.rs
+++ b/apps/desktop/src-tauri/src/native_audio/transport.rs
@@ -19,7 +19,7 @@ use std::{
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
-use cpal::{FromSample, Sample, SampleFormat, SizedSample};
+use cpal::{ErrorKind, FromSample, Sample, SampleFormat, SizedSample};
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 use symphonia::core::{
     codecs::audio::{AudioDecoder, AudioDecoderOptions},
@@ -132,7 +132,29 @@ pub struct AudioStateEvent {
 #[serde(rename_all = "camelCase")]
 pub struct AudioErrorEvent {
     pub session_id: Option<String>,
-    pub message: String,
+    pub code: NativeAudioErrorCode,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NativeAudioErrorCode {
+    DeviceChanged,
+    DeviceNotAvailable,
+    StreamInvalidated,
+    OutputStreamFailure,
+    DecoderWorkerFailure,
+}
+
+impl NativeAudioErrorCode {
+    fn fallback_message(self) -> &'static str {
+        match self {
+            Self::DeviceChanged => "Native audio device changed.",
+            Self::DeviceNotAvailable => "Native playback device is unavailable.",
+            Self::StreamInvalidated => "Native playback stream was interrupted.",
+            Self::OutputStreamFailure => "Native playback output failed.",
+            Self::DecoderWorkerFailure => "Native playback decoder failed.",
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -345,8 +367,8 @@ struct PlaybackShared {
     snapshot_lanes: Vec<EffectiveAudioLane>,
     click: ClickState,
     ended_pending: bool,
-    error_pending: Option<String>,
-    terminal_error: Option<String>,
+    error_pending: Option<NativeAudioErrorCode>,
+    terminal_error: Option<NativeAudioErrorCode>,
     buffering: bool,
     sustained_underrun_frames: usize,
     underrun_error_pending: bool,
@@ -359,7 +381,7 @@ impl PlaybackShared {
     fn snapshot(&self) -> AudioSnapshot {
         let fallback_reason = self
             .terminal_error
-            .clone()
+            .map(|code| code.fallback_message().to_string())
             .or_else(|| self.fallback_reason.clone())
             .or_else(|| self.fallback_cause.map(|cause| cause.message().to_string()));
 
@@ -413,16 +435,52 @@ impl PlaybackShared {
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 fn mark_terminal_runtime_error(
     shared: &mut PlaybackShared,
-    message: String,
+    code: NativeAudioErrorCode,
     diagnostic_code: DiagnosticSafeCode,
 ) {
     if shared.terminal_error.is_none() {
-        shared.error_pending = Some(message.clone());
-        shared.terminal_error = Some(message);
+        shared.error_pending = Some(code);
+        shared.terminal_error = Some(code);
     }
     shared.status = TransportStatus::Paused;
     shared.buffering = false;
     diagnostics::record_callback_safe_code(shared.diagnostics_generation, diagnostic_code);
+}
+
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+fn output_stream_error_code(error: &cpal::Error) -> NativeAudioErrorCode {
+    match error.kind() {
+        ErrorKind::DeviceChanged => NativeAudioErrorCode::DeviceChanged,
+        ErrorKind::DeviceNotAvailable => NativeAudioErrorCode::DeviceNotAvailable,
+        ErrorKind::StreamInvalidated => NativeAudioErrorCode::StreamInvalidated,
+        _ => NativeAudioErrorCode::OutputStreamFailure,
+    }
+}
+
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+fn diagnostic_code_for_output_stream_error(code: NativeAudioErrorCode) -> DiagnosticSafeCode {
+    match code {
+        NativeAudioErrorCode::DeviceChanged => DiagnosticSafeCode::DeviceChanged,
+        NativeAudioErrorCode::DeviceNotAvailable => DiagnosticSafeCode::DeviceNotAvailable,
+        NativeAudioErrorCode::StreamInvalidated => DiagnosticSafeCode::StreamInvalidated,
+        NativeAudioErrorCode::OutputStreamFailure => DiagnosticSafeCode::OutputStreamFailure,
+        NativeAudioErrorCode::DecoderWorkerFailure => DiagnosticSafeCode::DecoderWorkerFailure,
+    }
+}
+
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+fn mark_device_changed(shared: &mut PlaybackShared) {
+    if shared.terminal_error.is_some()
+        || shared.fallback_cause.is_some()
+        || shared.error_pending.is_some()
+    {
+        return;
+    }
+    shared.error_pending = Some(NativeAudioErrorCode::DeviceChanged);
+    diagnostics::record_callback_safe_code(
+        shared.diagnostics_generation,
+        DiagnosticSafeCode::DeviceChanged,
+    );
 }
 
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
@@ -676,11 +734,14 @@ impl TransportState {
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
         let terminal_runtime = self.runtime.as_ref().and_then(|runtime| {
             let shared = runtime.shared.lock().ok()?;
-            let reason = shared.terminal_error.clone().or_else(|| {
-                shared
-                    .fallback_cause
-                    .map(|cause| cause.message().to_string())
-            })?;
+            let reason = shared
+                .terminal_error
+                .map(|code| code.fallback_message().to_string())
+                .or_else(|| {
+                    shared
+                        .fallback_cause
+                        .map(|cause| cause.message().to_string())
+                })?;
             Some((shared.position_seconds, reason))
         });
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
@@ -746,11 +807,15 @@ impl TransportState {
         if let Some(runtime) = &self.runtime {
             if let Ok(shared) = runtime.shared.lock() {
                 self.position_seconds = shared.position_seconds;
-                if let Some(reason) = shared.terminal_error.clone().or_else(|| {
-                    shared
-                        .fallback_cause
-                        .map(|cause| cause.message().to_string())
-                }) {
+                if let Some(reason) = shared
+                    .terminal_error
+                    .map(|code| code.fallback_message().to_string())
+                    .or_else(|| {
+                        shared
+                            .fallback_cause
+                            .map(|cause| cause.message().to_string())
+                    })
+                {
                     self.native_playback_supported = false;
                     self.fallback_reason = Some(reason);
                 }
@@ -765,11 +830,14 @@ impl TransportState {
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
         let failed_runtime = self.runtime.as_ref().and_then(|runtime| {
             let shared = runtime.shared.lock().ok()?;
-            let reason = shared.terminal_error.clone().or_else(|| {
-                shared
-                    .fallback_cause
-                    .map(|cause| cause.message().to_string())
-            })?;
+            let reason = shared
+                .terminal_error
+                .map(|code| code.fallback_message().to_string())
+                .or_else(|| {
+                    shared
+                        .fallback_cause
+                        .map(|cause| cause.message().to_string())
+                })?;
             Some((shared.position_seconds, reason))
         });
         #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
@@ -1540,7 +1608,7 @@ fn start_native_runtime(
                     }
                     mark_terminal_runtime_error(
                         &mut shared,
-                        worker_error.message,
+                        NativeAudioErrorCode::DecoderWorkerFailure,
                         DiagnosticSafeCode::DecoderWorkerFailure,
                     );
                 }
@@ -1661,13 +1729,17 @@ where
                 }
             },
             move |error| {
-                let message = format!("Native audio output stream error: {error}");
                 if let Ok(mut shared) = error_shared.lock() {
-                    mark_terminal_runtime_error(
-                        &mut shared,
-                        message,
-                        DiagnosticSafeCode::OutputStreamFailure,
-                    );
+                    let code = output_stream_error_code(&error);
+                    if code == NativeAudioErrorCode::DeviceChanged {
+                        mark_device_changed(&mut shared);
+                    } else {
+                        mark_terminal_runtime_error(
+                            &mut shared,
+                            code,
+                            diagnostic_code_for_output_stream_error(code),
+                        );
+                    }
                 }
             },
             None,
@@ -1678,24 +1750,29 @@ where
 
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
 fn emit_runtime_events(app: &AppHandle, shared: &Arc<Mutex<PlaybackShared>>) -> bool {
-    let (snapshot, ended, error) = {
+    let (snapshot, ended, error, requires_error_handling) = {
         let mut shared = match shared.lock() {
             Ok(shared) => shared,
             Err(_) => return false,
         };
         let snapshot = shared.snapshot();
-        let ended = shared.ended_pending;
+        let ended_pending = shared.ended_pending;
         shared.ended_pending = false;
         let mut error = shared.error_pending.take();
         if shared.underrun_error_pending {
             shared.underrun_error_pending = false;
             if error.is_none() {
-                error = shared
-                    .fallback_cause
-                    .map(|cause| cause.message().to_string());
+                error = Some(NativeAudioErrorCode::OutputStreamFailure);
             }
         }
-        (snapshot, ended, error)
+        let requires_error_handling =
+            shared.terminal_error.is_some() || shared.fallback_cause.is_some();
+        (
+            snapshot,
+            should_emit_ended(ended_pending, requires_error_handling),
+            error,
+            requires_error_handling,
+        )
     };
 
     let _ = app.emit(
@@ -1718,16 +1795,21 @@ fn emit_runtime_events(app: &AppHandle, shared: &Arc<Mutex<PlaybackShared>>) -> 
     if ended {
         let _ = app.emit(AUDIO_EVENT_ENDED, snapshot.clone());
     }
-    if let Some(message) = &error {
+    if let Some(code) = error {
         let _ = app.emit(
             AUDIO_EVENT_ERROR,
             AudioErrorEvent {
                 session_id: snapshot.session_id,
-                message: message.clone(),
+                code,
             },
         );
     }
-    ended || error.is_some()
+    ended || requires_error_handling
+}
+
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+fn should_emit_ended(ended_pending: bool, requires_error_handling: bool) -> bool {
+    ended_pending && !requires_error_handling
 }
 
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
@@ -2769,6 +2851,152 @@ mod tests {
         );
     }
 
+    #[test]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    fn classifies_cpal_output_errors_without_exposing_backend_details() {
+        let classified = [
+            (
+                ErrorKind::DeviceChanged,
+                NativeAudioErrorCode::DeviceChanged,
+            ),
+            (
+                ErrorKind::DeviceNotAvailable,
+                NativeAudioErrorCode::DeviceNotAvailable,
+            ),
+            (
+                ErrorKind::StreamInvalidated,
+                NativeAudioErrorCode::StreamInvalidated,
+            ),
+            (
+                ErrorKind::DeviceBusy,
+                NativeAudioErrorCode::OutputStreamFailure,
+            ),
+            (
+                ErrorKind::HostUnavailable,
+                NativeAudioErrorCode::OutputStreamFailure,
+            ),
+            (
+                ErrorKind::InvalidInput,
+                NativeAudioErrorCode::OutputStreamFailure,
+            ),
+            (
+                ErrorKind::PermissionDenied,
+                NativeAudioErrorCode::OutputStreamFailure,
+            ),
+            (
+                ErrorKind::RealtimeDenied,
+                NativeAudioErrorCode::OutputStreamFailure,
+            ),
+            (
+                ErrorKind::ResourceExhausted,
+                NativeAudioErrorCode::OutputStreamFailure,
+            ),
+            (
+                ErrorKind::UnsupportedConfig,
+                NativeAudioErrorCode::OutputStreamFailure,
+            ),
+            (
+                ErrorKind::UnsupportedOperation,
+                NativeAudioErrorCode::OutputStreamFailure,
+            ),
+            (ErrorKind::Xrun, NativeAudioErrorCode::OutputStreamFailure),
+            (
+                ErrorKind::BackendError,
+                NativeAudioErrorCode::OutputStreamFailure,
+            ),
+            (ErrorKind::Other, NativeAudioErrorCode::OutputStreamFailure),
+        ];
+
+        for (kind, expected) in classified {
+            assert_eq!(output_stream_error_code(&cpal::Error::new(kind)), expected);
+        }
+    }
+
+    #[test]
+    fn error_events_serialize_only_the_safe_code() {
+        let event = AudioErrorEvent {
+            session_id: Some("session-123".to_string()),
+            code: NativeAudioErrorCode::StreamInvalidated,
+        };
+
+        let serialized = serde_json::to_string(&event).expect("serialize event");
+
+        assert_eq!(
+            serialized,
+            r#"{"sessionId":"session-123","code":"stream_invalidated"}"#
+        );
+        assert!(!serialized.contains("message"));
+        assert!(!serialized.contains("/private/audio.wav"));
+    }
+
+    #[test]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    fn terminal_error_precedes_recoverable_and_device_changed_events() {
+        let mut device_changed_first =
+            shared_with_lane(Arc::new(Mutex::new(RingBuffer::new(1_000))), 1_000, 1, 1.0);
+        mark_device_changed(&mut device_changed_first);
+        assert_eq!(
+            device_changed_first.error_pending,
+            Some(NativeAudioErrorCode::DeviceChanged)
+        );
+        mark_terminal_runtime_error(
+            &mut device_changed_first,
+            NativeAudioErrorCode::OutputStreamFailure,
+            DiagnosticSafeCode::OutputStreamFailure,
+        );
+        mark_device_changed(&mut device_changed_first);
+        assert_eq!(
+            device_changed_first.error_pending,
+            Some(NativeAudioErrorCode::OutputStreamFailure)
+        );
+
+        let mut shared =
+            shared_with_lane(Arc::new(Mutex::new(RingBuffer::new(1_000))), 1_000, 1, 1.0);
+        shared.fallback_cause = Some(NativePlaybackFallbackCause::SustainedUnderrun);
+        shared.underrun_error_pending = true;
+
+        mark_device_changed(&mut shared);
+        assert_eq!(shared.error_pending, None);
+
+        mark_terminal_runtime_error(
+            &mut shared,
+            NativeAudioErrorCode::DecoderWorkerFailure,
+            DiagnosticSafeCode::DecoderWorkerFailure,
+        );
+        mark_device_changed(&mut shared);
+
+        assert_eq!(
+            shared.error_pending,
+            Some(NativeAudioErrorCode::DecoderWorkerFailure)
+        );
+        assert_eq!(
+            shared.terminal_error,
+            Some(NativeAudioErrorCode::DecoderWorkerFailure)
+        );
+    }
+
+    #[test]
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    fn terminal_error_suppresses_ended_notification_for_the_same_snapshot() {
+        let mut shared =
+            shared_with_lane(Arc::new(Mutex::new(RingBuffer::new(1_000))), 1_000, 1, 1.0);
+        shared.ended_pending = true;
+        mark_terminal_runtime_error(
+            &mut shared,
+            NativeAudioErrorCode::OutputStreamFailure,
+            DiagnosticSafeCode::OutputStreamFailure,
+        );
+
+        let requires_error_handling =
+            shared.terminal_error.is_some() || shared.fallback_cause.is_some();
+
+        assert!(!should_emit_ended(
+            shared.ended_pending,
+            requires_error_handling
+        ));
+        assert!(should_emit_ended(true, false));
+    }
+
     #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
     fn assert_sample_close(actual: f32, expected: f32) {
         assert!(
@@ -2861,7 +3089,7 @@ mod tests {
         )));
         mark_terminal_runtime_error(
             &mut shared.lock().expect("shared lock"),
-            "Native audio output stream disconnected.".to_string(),
+            NativeAudioErrorCode::OutputStreamFailure,
             DiagnosticSafeCode::OutputStreamFailure,
         );
         let (audio_stop_sender, _audio_stop_receiver) = mpsc::channel();
@@ -2887,11 +3115,11 @@ mod tests {
             .expect_err("reject terminal runtime error");
         let snapshot = state.snapshot();
 
-        assert_eq!(error, "Native audio output stream disconnected.");
+        assert_eq!(error, "Native playback output failed.");
         assert!(!snapshot.native_playback_supported);
         assert_eq!(
             snapshot.fallback_reason.as_deref(),
-            Some("Native audio output stream disconnected.")
+            Some("Native playback output failed.")
         );
         assert_eq!(snapshot.state, "paused");
     }

--- a/apps/desktop/src/App.project-media-controls.test.tsx
+++ b/apps/desktop/src/App.project-media-controls.test.tsx
@@ -304,6 +304,7 @@ describe("Desktop app project media controls", () => {
         fallbackReason: null,
         backend: "desktop-cpal",
       },
+      stopFallbackReason: "Native output stopped after an invalidated stream.",
     });
     renderApp(["/projects/proj_123"]);
 
@@ -537,7 +538,7 @@ describe("Desktop app project media controls", () => {
     act(() => {
       emitMockNativePlaybackError({
         sessionId,
-        message: "Native output failed.",
+        code: "output_stream_failure",
       });
     });
 
@@ -615,7 +616,7 @@ describe("Desktop app project media controls", () => {
     act(() => {
       emitMockNativePlaybackError({
         sessionId,
-        message: "Native output failed.",
+        code: "output_stream_failure",
       });
     });
 
@@ -659,7 +660,7 @@ describe("Desktop app project media controls", () => {
     act(() => {
       emitMockNativePlaybackError({
         sessionId,
-        message: "Native output failed.",
+        code: "output_stream_failure",
       });
     });
     expect(readPlaybackLiveDiagnostics()).toMatchObject({
@@ -691,7 +692,7 @@ describe("Desktop app project media controls", () => {
     restoreTauriRuntime();
   });
 
-  it("blocks a failed paused native session and resumes through Web Audio on demand", async () => {
+  it("keeps native playback active when CPAL reports a device change", async () => {
     const restoreTauriRuntime = mockTauriRuntime();
     const user = userEvent.setup();
     setMockNativeAudioState({
@@ -709,6 +710,45 @@ describe("Desktop app project media controls", () => {
     await user.click(screen.getByRole("button", { name: "Play playback" }));
     await waitForNativeControls();
     const sessionId = latestNativeSessionId();
+    const stopCount = invokeCalls("audio_stop").length;
+
+    act(() => {
+      emitMockNativePlaybackError({ sessionId, code: "device_changed" });
+    });
+
+    expect(screen.getByRole("button", { name: "Pause playback" })).toBeInTheDocument();
+    expect(invokeCalls("audio_stop")).toHaveLength(stopCount);
+    expect(document.querySelector("audio[src]")).toBeNull();
+    expect(readPlaybackLiveDiagnostics()).toMatchObject({
+      currentState: "playing",
+      currentPath: "native",
+    });
+    expect(window.localStorage.getItem("tuneforge.playback-native-error")).toBe(
+      "Native audio device changed.",
+    );
+    restoreTauriRuntime();
+  });
+
+  it("retries native playback once after a failed paused session", async () => {
+    const restoreTauriRuntime = mockTauriRuntime();
+    const user = userEvent.setup();
+    setMockNativeAudioState({
+      capabilities: {
+        nativePlaybackSupported: true,
+        fallbackRequired: false,
+        fallbackReason: null,
+        backend: "desktop-cpal",
+      },
+    });
+    renderApp(["/projects/proj_123"]);
+
+    expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+    await openPlaybackWorkspace(user);
+    await user.click(screen.getByRole("button", { name: "Play playback" }));
+    await waitForNativeControls();
+    const nativePlayCount = invokeCalls("audio_play").length;
+    const prepareCount = invokeCalls("audio_prepare_session").length;
+    const sessionId = latestNativeSessionId();
 
     await user.click(screen.getByRole("button", { name: "Pause playback" }));
     await waitFor(() =>
@@ -717,7 +757,7 @@ describe("Desktop app project media controls", () => {
     act(() => {
       emitMockNativePlaybackError({
         sessionId,
-        message: "Native output disconnected while paused.",
+        code: "stream_invalidated",
       });
     });
 
@@ -727,18 +767,126 @@ describe("Desktop app project media controls", () => {
       nativeSessionLaneCount: null,
     });
     expect(window.localStorage.getItem("tuneforge.playback-native-error")).toBe(
-      "Native output disconnected while paused.",
+      "Native playback stream was interrupted.",
     );
+    expect(invokeCalls("audio_play")).toHaveLength(nativePlayCount);
 
     await user.click(screen.getByRole("button", { name: "Play playback" }));
-    const sourceAudio = await waitFor(() => findAudioByArtifactId("art_source"));
-    markAudioReady(sourceAudio);
-    await waitForWebOwnerControls();
+    await waitForNativeControls();
+    expect(invokeCalls("audio_prepare_session")).toHaveLength(prepareCount + 1);
+    expect(invokeCalls("audio_play")).toHaveLength(nativePlayCount + 1);
     expect(readPlaybackLiveDiagnostics()).toMatchObject({
       currentState: "playing",
-      currentPath: "web-fallback",
+      currentPath: "native",
     });
     restoreTauriRuntime();
+  });
+
+  it("prepares a fresh native session after a playback command fails", async () => {
+    const restoreTauriRuntime = mockTauriRuntime();
+    const user = userEvent.setup();
+    const mockInvoke = getMockInvoke();
+    const defaultInvoke = mockInvoke.getMockImplementation();
+    if (!defaultInvoke) {
+      throw new Error("Mock invoke implementation was not installed.");
+    }
+    let failNextNativePlay = true;
+    mockInvoke.mockImplementation(async (command: string, args?: Record<string, unknown>) => {
+      if (command === "audio_play" && failNextNativePlay) {
+        failNextNativePlay = false;
+        throw new Error("Native audio output runtime could not start.");
+      }
+      return defaultInvoke(command, args);
+    });
+
+    try {
+      setMockNativeAudioState({
+        capabilities: {
+          nativePlaybackSupported: true,
+          fallbackRequired: false,
+          fallbackReason: null,
+          backend: "desktop-cpal",
+        },
+      });
+      renderApp(["/projects/proj_123"]);
+      expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+      await openPlaybackWorkspace(user);
+
+      await user.click(screen.getByRole("button", { name: "Play playback" }));
+      const sourceAudio = await waitFor(() => findAudioByArtifactId("art_source"));
+      markAudioReady(sourceAudio);
+      await waitForWebOwnerControls();
+      const prepareCount = invokeCalls("audio_prepare_session").length;
+      const nativePlayCount = invokeCalls("audio_play").length;
+
+      await user.click(screen.getByRole("button", { name: "Pause playback" }));
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument(),
+      );
+      await user.click(screen.getByRole("button", { name: "Play playback" }));
+      await waitForNativeControls();
+
+      expect(invokeCalls("audio_prepare_session")).toHaveLength(prepareCount + 1);
+      expect(invokeCalls("audio_play")).toHaveLength(nativePlayCount + 1);
+      expect(readPlaybackLiveDiagnostics()).toMatchObject({
+        currentState: "playing",
+        currentPath: "native",
+      });
+    } finally {
+      mockInvoke.mockImplementation(defaultInvoke);
+      restoreTauriRuntime();
+    }
+  });
+
+  it("coalesces repeated Play clicks while native playback is starting", async () => {
+    const restoreTauriRuntime = mockTauriRuntime();
+    const mockInvoke = getMockInvoke();
+    const defaultInvoke = mockInvoke.getMockImplementation();
+    if (!defaultInvoke) {
+      throw new Error("Mock invoke implementation was not installed.");
+    }
+    let releaseNativePlay!: () => void;
+    const nativePlayGate = new Promise<void>((resolve) => {
+      releaseNativePlay = resolve;
+    });
+    mockInvoke.mockImplementation(async (command: string, args?: Record<string, unknown>) => {
+      if (command === "audio_play") {
+        await nativePlayGate;
+      }
+      return defaultInvoke(command, args);
+    });
+
+    try {
+      setMockNativeAudioState({
+        capabilities: {
+          nativePlaybackSupported: true,
+          fallbackRequired: false,
+          fallbackReason: null,
+          backend: "desktop-cpal",
+        },
+      });
+      renderApp(["/projects/proj_123"]);
+      expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+      await openPlaybackWorkspace(userEvent.setup());
+
+      fireEvent.click(screen.getByRole("button", { name: "Play playback" }));
+      await waitFor(() => expect(invokeCalls("audio_play")).toHaveLength(1));
+      fireEvent.click(screen.getByRole("button", { name: "Play playback" }));
+      fireEvent.click(screen.getByRole("button", { name: "Play playback" }));
+      await Promise.resolve();
+      expect(invokeCalls("audio_play")).toHaveLength(1);
+
+      await act(async () => {
+        releaseNativePlay();
+        await nativePlayGate;
+      });
+      await waitForNativeControls();
+      expect(invokeCalls("audio_play")).toHaveLength(1);
+    } finally {
+      releaseNativePlay();
+      mockInvoke.mockImplementation(defaultInvoke);
+      restoreTauriRuntime();
+    }
   });
 
   it("honors a pending pause when a native stream error races its response", async () => {
@@ -780,7 +928,7 @@ describe("Desktop app project media controls", () => {
       act(() => {
         emitMockNativePlaybackError({
           sessionId,
-          message: "Native output disconnected during pause.",
+          code: "stream_invalidated",
         });
       });
 
@@ -802,12 +950,10 @@ describe("Desktop app project media controls", () => {
       expect(screen.getByRole("button", { name: "Play playback" })).toBeInTheDocument();
 
       await user.click(screen.getByRole("button", { name: "Play playback" }));
-      const sourceAudio = await waitFor(() => findAudioByArtifactId("art_source"));
-      markAudioReady(sourceAudio);
-      await waitForWebOwnerControls();
+      await waitForNativeControls();
       expect(readPlaybackLiveDiagnostics()).toMatchObject({
         currentState: "playing",
-        currentPath: "web-fallback",
+        currentPath: "native",
       });
     } finally {
       nativePauseBlock.release?.();
@@ -854,7 +1000,7 @@ describe("Desktop app project media controls", () => {
       act(() => {
         emitMockNativePlaybackError({
           sessionId,
-          message: "Native output disconnected during start.",
+          code: "stream_invalidated",
         });
       });
 
@@ -862,7 +1008,7 @@ describe("Desktop app project media controls", () => {
       markAudioReady(sourceAudio);
       await waitForWebOwnerControls();
       expect(window.localStorage.getItem("tuneforge.playback-native-error")).toBe(
-        "Native output disconnected during start.",
+        "Native playback stream was interrupted.",
       );
 
       nativePlayBlock.release?.();

--- a/apps/desktop/src/App.project-tempo.test.tsx
+++ b/apps/desktop/src/App.project-tempo.test.tsx
@@ -370,7 +370,7 @@ describe("Desktop app project playback tempo", () => {
 
       emitMockNativePlaybackError({
         sessionId: latestNativeSessionId(),
-        message: "Native playback underrun persisted; falling back to Web Audio.",
+        code: "output_stream_failure",
       });
       await waitFor(() => expect(nativeStopBlock.resolve).not.toBeNull());
       const sourceAudio = findAudioByArtifactId("art_source");
@@ -433,7 +433,7 @@ describe("Desktop app project playback tempo", () => {
 
     emitMockNativePlaybackError({
       sessionId: "stale-native-session",
-      message: "Stale native playback error.",
+      code: "output_stream_failure",
     });
     await waitFor(() => {
       expect(
@@ -444,7 +444,7 @@ describe("Desktop app project playback tempo", () => {
 
     emitMockNativePlaybackError({
       sessionId,
-      message: "Native playback underrun persisted; falling back to Web Audio.",
+      code: "output_stream_failure",
     });
 
     await waitFor(() => {
@@ -460,7 +460,7 @@ describe("Desktop app project playback tempo", () => {
       3,
     );
     expect(window.localStorage.getItem("tuneforge.playback-native-error")).toBe(
-      "Native playback underrun persisted; falling back to Web Audio.",
+      "Native playback output failed.",
     );
     expect(
       getMockInvoke().mock.calls.some(([command]) => command === "audio_stop"),

--- a/apps/desktop/src/features/projects/playback.tsx
+++ b/apps/desktop/src/features/projects/playback.tsx
@@ -30,6 +30,7 @@ import {
   markPlaybackPaused,
   markPlaybackStarting,
   markPlaybackStopped,
+  nativePlaybackErrorMessage,
   playbackErrorMessage,
   rememberNativePlaybackError,
   rememberNativeFallbackCause,
@@ -127,6 +128,11 @@ type PendingWebPlayback = {
   mode: "fallback" | "forced";
   signature: string;
   startTimeSeconds: number;
+};
+
+type PendingNativeRecovery = {
+  generation: number;
+  sessionId: string;
 };
 
 type WebMediaSourceEnablementOwner = {
@@ -385,6 +391,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   const nativeCapabilitiesPromiseRef = useRef<ReturnType<typeof getNativeAudioCapabilities> | null>(null);
   const nativeBackendRef = useRef<string | null>(null);
   const pendingNativeFallbackCauseRef = useRef<string | null>(null);
+  const pendingNativeRecoveryRef = useRef<PendingNativeRecovery | null>(null);
   const pendingWebPlaybackRef = useRef<PendingWebPlayback | null>(null);
   const webStallTimersRef = useRef(new Map<HTMLAudioElement, number>());
   const webMediaSourcesEnabledRef = useRef(initialWebMediaSourcesEnabled);
@@ -990,6 +997,13 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         markNativePlaybackInactive();
         clearPlaybackControlBackend();
         void requestNativeStop();
+        nativePlaybackRef.current = {
+          ...nativePlaybackRef.current,
+          preparePromise: null,
+          prepareSignature: null,
+          sessionSignature: null,
+          playbackSignature: null,
+        };
         return false;
       }
       if (
@@ -1037,6 +1051,14 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       nativePlaybackRef.current.blockedSessionSignature = sessionSignature;
       markNativePlaybackInactive();
       clearPlaybackControlBackend();
+      void requestNativeStop();
+      nativePlaybackRef.current = {
+        ...nativePlaybackRef.current,
+        preparePromise: null,
+        prepareSignature: null,
+        sessionSignature: null,
+        playbackSignature: null,
+      };
       return false;
     }
   });
@@ -2250,6 +2272,10 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
   const pausePlayback = useCallback(() => {
     allowFreshPlaybackRef.current = false;
+    if (pendingNativeRecoveryRef.current) {
+      pendingNativeRecoveryRef.current = null;
+      nativeControlGenerationRef.current += 1;
+    }
     cancelPrecount("playback-stopped");
     const pendingTransition = pendingTransitionRef.current;
     if (pendingTransition) {
@@ -2613,6 +2639,21 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       return;
     }
 
+    const pendingNativePlay = pendingNativePlayRef.current;
+    if (
+      pendingNativePlay?.generation === nativeControlGenerationRef.current &&
+      pendingNativePlay.sessionSignature === nativeSessionSignature(targetSession) &&
+      pendingNativePlay.playbackSignature === playbackSignature(targetSession)
+    ) {
+      return;
+    }
+
+    if (
+      nativePlaybackRef.current.blockedSessionSignature === nativeSessionSignature(targetSession)
+    ) {
+      nativePlaybackRef.current.blockedSessionSignature = null;
+    }
+
     tryCompletePendingTransition();
 
     const masterTime = playbackStartTimeForSession(
@@ -2734,6 +2775,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
   const stopPlayback = useCallback(() => {
     allowFreshPlaybackRef.current = true;
+    pendingNativeRecoveryRef.current = null;
+    nativeControlGenerationRef.current += 1;
     cancelPrecount("playback-stopped");
     clearPendingTransition();
     const targetSession = sessionRef.current;
@@ -2797,6 +2840,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     const nextSignature = playbackSignature(nextSession);
 
     if (previousSession && previousSession.projectId !== nextSession.projectId) {
+      pendingNativeRecoveryRef.current = null;
+      nativeControlGenerationRef.current += 1;
       const resetTime = playbackResetTimeForSession(nextSession);
       cancelPrecount("session-changed");
       clearPendingTransition();
@@ -3050,6 +3095,8 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
   useEffect(
     () => () => {
+      pendingNativeRecoveryRef.current = null;
+      nativeControlGenerationRef.current += 1;
       cancelPrecount("unavailable");
       closePlaybackAudioContext();
     },
@@ -3209,13 +3256,18 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
         ) {
           return;
         }
+        const message = nativePlaybackErrorMessage(error.code);
+        if (error.code === "device_changed") {
+          rememberNativePlaybackError(message);
+          return;
+        }
         const shouldContinuePlayback =
           (nativePlaybackRef.current.active || matchingPendingPlay) &&
           !matchingPendingPause;
         nativeControlGenerationRef.current += 1;
         pendingNativePlayRef.current = null;
         pendingNativePauseRef.current = null;
-        recordNativePlaybackFailure(error.message);
+        recordNativePlaybackFailure(message);
         const fallbackTime = clampTime(
           playbackTimeSecondsRef.current,
           playbackDurationSecondsRef.current || activeSession.durationHintSeconds || 0,
@@ -3232,7 +3284,18 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
           );
         }
         void requestNativeStop();
+        nativePlaybackRef.current = {
+          ...nativePlaybackRef.current,
+          preparePromise: null,
+          prepareSignature: null,
+          sessionSignature: null,
+          playbackSignature: null,
+        };
         const fallbackGeneration = nativeControlGenerationRef.current;
+        pendingNativeRecoveryRef.current = {
+          generation: fallbackGeneration,
+          sessionId: nativeSessionSignature(activeSession),
+        };
         syncStemElementTimes(activeSession.visibleStemArtifactIds, fallbackTime);
         getRenderedMediaElements(activeSession).forEach((element) => {
           element.pause();
@@ -3253,12 +3316,15 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
             const currentSession = sessionRef.current;
             if (
               nativeControlGenerationRef.current !== fallbackGeneration ||
+              pendingNativeRecoveryRef.current?.generation !== fallbackGeneration ||
+              pendingNativeRecoveryRef.current.sessionId !== error.sessionId ||
               !currentSession ||
               nativeSessionSignature(currentSession) !== error.sessionId ||
               nativePlaybackRef.current.blockedSessionSignature !== error.sessionId
             ) {
               return;
             }
+            pendingNativeRecoveryRef.current = null;
             void playPlaybackImmediately();
           })
           .catch(() => markPlaybackError("Playback stopped. Fallback could not start."));

--- a/apps/desktop/src/lib/nativeAudio.test.ts
+++ b/apps/desktop/src/lib/nativeAudio.test.ts
@@ -33,6 +33,7 @@ import {
   listNativeAudioOutputDevices,
   listenNativeAudioInputFrames,
   listenNativeAudioInputState,
+  listenNativeAudioErrors,
   listenNativeAudioPositions,
   pauseNativeAudio,
   playNativeAudio,
@@ -357,6 +358,23 @@ describe("native audio adapter", () => {
 
     expect(mockListen).toHaveBeenCalledWith("audio://position", expect.any(Function));
     expect(handler).toHaveBeenCalledWith(position);
+    stopListening();
+    expect(unlisten).toHaveBeenCalled();
+  });
+
+  it("wraps code-only native error events", async () => {
+    const unlisten = vi.fn();
+    const error = { sessionId: "session-1", code: "stream_invalidated" as const };
+    mockListen.mockImplementation(async (_eventName, callback) => {
+      callback({ event: "audio://error", id: 1, payload: error });
+      return unlisten;
+    });
+    const handler = vi.fn();
+
+    const stopListening = await listenNativeAudioErrors(handler);
+
+    expect(mockListen).toHaveBeenCalledWith("audio://error", expect.any(Function));
+    expect(handler).toHaveBeenCalledWith(error);
     stopListening();
     expect(unlisten).toHaveBeenCalled();
   });

--- a/apps/desktop/src/lib/nativeAudio.ts
+++ b/apps/desktop/src/lib/nativeAudio.ts
@@ -41,7 +41,10 @@ export type NativeAudioDiagnosticSafeCode =
   | "sustained_underrun"
   | "runtime_start_failure"
   | "decoder_worker_failure"
-  | "output_stream_failure";
+  | "output_stream_failure"
+  | "device_changed"
+  | "device_not_available"
+  | "stream_invalidated";
 
 export type NativeAudioDiagnosticCounters = {
   operationCount: number;
@@ -201,7 +204,12 @@ export type NativeAudioPositionEvent = {
 
 export type NativeAudioErrorEvent = {
   sessionId: string | null;
-  message: string;
+  code:
+    | "device_changed"
+    | "device_not_available"
+    | "stream_invalidated"
+    | "output_stream_failure"
+    | "decoder_worker_failure";
 };
 
 export type NativeAudioInputRequest = {

--- a/apps/desktop/src/lib/playbackDiagnostics.test.ts
+++ b/apps/desktop/src/lib/playbackDiagnostics.test.ts
@@ -5,6 +5,7 @@ import {
   markPlaybackPaused,
   markPlaybackStarting,
   markPlaybackStopped,
+  nativePlaybackErrorMessage,
   readPlaybackLiveDiagnostics,
   readRememberedPlaybackBackend,
   redactPlaybackDiagnosticText,
@@ -31,6 +32,17 @@ describe("playback diagnostics", () => {
       currentState: "not-playing",
       currentPath: "none",
     });
+  });
+
+  it.each([
+    ["device_changed", "Native audio device changed."],
+    ["device_not_available", "Native playback device is unavailable."],
+    ["stream_invalidated", "Native playback stream was interrupted."],
+    ["output_stream_failure", "Native playback output failed."],
+    ["decoder_worker_failure", "Native playback decoder failed."],
+  ] as const)("maps %s to fixed safe text", (code, expected) => {
+    expect(nativePlaybackErrorMessage(code)).toBe(expected);
+    expect(expected).not.toMatch(/\/(?:Users|private)|art_|session_/);
   });
 
   it("does not relabel legacy Web history without an explicit mode", () => {

--- a/apps/desktop/src/lib/playbackDiagnostics.ts
+++ b/apps/desktop/src/lib/playbackDiagnostics.ts
@@ -1,5 +1,6 @@
 import type {
   NativeAudioBufferHealth,
+  NativeAudioErrorEvent,
   NativeAudioSnapshot,
 } from "./nativeAudio";
 
@@ -324,4 +325,19 @@ export function playbackErrorMessage(error: unknown) {
     return redactPlaybackDiagnosticText(error);
   }
   return "Playback failed.";
+}
+
+export function nativePlaybackErrorMessage(code: NativeAudioErrorEvent["code"]) {
+  switch (code) {
+    case "device_changed":
+      return "Native audio device changed.";
+    case "device_not_available":
+      return "Native playback device is unavailable.";
+    case "stream_invalidated":
+      return "Native playback stream was interrupted.";
+    case "decoder_worker_failure":
+      return "Native playback decoder failed.";
+    case "output_stream_failure":
+      return "Native playback output failed.";
+  }
 }

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -144,7 +144,12 @@ const {
   };
   type NativeAudioErrorPayload = {
     sessionId: string | null;
-    message: string;
+    code:
+      | "device_changed"
+      | "device_not_available"
+      | "stream_invalidated"
+      | "output_stream_failure"
+      | "decoder_worker_failure";
   };
   type NativeAudioRuntimeEvent = {
     event: "audio://position" | "audio://ended" | "audio://error" | "audio://input-state";
@@ -230,6 +235,7 @@ const {
     nativeAudioSnapshot: Record<string, unknown>;
     nativeAudioStartError: string | null;
     nativeAudioPlayFallbackReason: string | null;
+    nativeAudioStopFallbackReason: string | null;
     powerInhibitionStatus: {
       phase: string;
       backend: string | null;
@@ -890,6 +896,7 @@ const {
       },
       nativeAudioStartError: null,
       nativeAudioPlayFallbackReason: null,
+      nativeAudioStopFallbackReason: null,
       powerInhibitionStatus: {
         phase: "inactive",
         backend: null,
@@ -948,6 +955,7 @@ const {
     snapshot?: Record<string, unknown>;
     startError?: string | null;
     playFallbackReason?: string | null;
+    stopFallbackReason?: string | null;
   }) {
     state.nativeAudioCapabilities = {
       ...state.nativeAudioCapabilities,
@@ -977,6 +985,9 @@ const {
     }
     if ("playFallbackReason" in nextState) {
       state.nativeAudioPlayFallbackReason = nextState.playFallbackReason ?? null;
+    }
+    if ("stopFallbackReason" in nextState) {
+      state.nativeAudioStopFallbackReason = nextState.stopFallbackReason ?? null;
     }
   }
 
@@ -1314,6 +1325,12 @@ const {
         ...state.nativeAudioSnapshot,
         state: "stopped",
         positionSeconds: 0,
+        ...(state.nativeAudioStopFallbackReason
+          ? {
+              nativePlaybackSupported: false,
+              fallbackReason: state.nativeAudioStopFallbackReason,
+            }
+          : {}),
       };
       return clone(state.nativeAudioSnapshot);
     }

--- a/docs/NATIVE_AUDIO.md
+++ b/docs/NATIVE_AUDIO.md
@@ -62,6 +62,13 @@ cross-platform owner, backend, diagnostic, and validation rules.
   power protection, starts the Web Audio path at the fallback position, then re-registers system
   media state for the Web Audio owner and acquires the browser wake lock. Diagnostics keep the
   native fallback reason.
+- Native output events carry only a session ID and one safe code: `device_changed`,
+  `device_not_available`, `stream_invalidated`, `output_stream_failure`, or
+  `decoder_worker_failure`. A device change is informational and leaves playback alone.
+  Device loss and stream invalidation retire native playback and hand off once to Web Audio at the
+  synchronously captured, clamped position. Pause, stop, project changes, and unmount cancel a
+  pending handoff. TuneForge never retries native playback automatically; the next explicit Play
+  makes one new native attempt.
 - Failed native prepare/play attempts before audio starts never activate native transport ownership.
 
 ## Linux Build Prerequisites
@@ -138,7 +145,8 @@ are available only when the desktop process starts with
 `TUNEFORGE_NATIVE_AUDIO_DIAGNOSTICS=1`. When enabled, Settings shows **Native Audio Diagnostics**;
 normal builds show no diagnostics panel and native playback takes a zero-generation no-op path. The
 export contains relative monotonic timings, safe counts, fixed buffer capacities, and process RSS
-where supported. Operation timestamps are elapsed from that command's zero point. It never
+where supported. Operation timestamps are elapsed from that command's zero point. Safe route codes
+include `device_changed`, `device_not_available`, and `stream_invalidated`. It never
 contains names, paths, URLs, artifact/project/device/session/lane identifiers, raw decoder errors,
 PCM, or wall-clock timestamps. It is not persisted automatically or sent; **Export sanitized JSON**
 writes a user-selected local copy only when requested.


### PR DESCRIPTION
## Summary

- classify native output-route failures into safe code-only events and diagnostics
- preserve playback position while handing recoverable failures to Web Audio once
- allow one fresh native retry on explicit Play and coalesce repeated pending Play commands
- Closes #459

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm --filter @tuneforge/desktop exec vitest run src/App.project-media-controls.test.tsx src/App.project-precount.test.tsx`
- macOS Bluetooth route testing exercised native recovery and Web Audio fallback; Linux hardware remains unverified
