### PR TITLE
feat: finish durable audio storage formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ download, installation, verification, signature, and publication instructions.
 
 - Added backend storage, processing-job, and desktop-sync foundations for durable WAV, FLAC, MP3,
   and M4A audio artifacts ([#398](https://github.com/grazzolini/tuneforge/issues/398)).
+- Added a desktop Audio Storage preference for future imports, stems, and saved mixes, plus
+  byte-preserving Android receive and playback support for all four durable formats
+  ([#398](https://github.com/grazzolini/tuneforge/issues/398)).
 
 ### Fixed
 

--- a/apps/desktop/src-tauri/src/mobile_backend/helpers.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/helpers.rs
@@ -61,6 +61,68 @@ fn safe_sync_relative_path_parts(relative_path: &str) -> Result<Vec<String>, Str
 }
 
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
+fn durable_manifest_audio_format(
+    artifact: &SyncProjectManifestArtifactSchema,
+) -> Option<&'static str> {
+    if !is_durable_manifest_audio_type(&artifact.r#type) {
+        return None;
+    }
+    match artifact.format.as_str() {
+        "wav" => Some("wav"),
+        "flac" => Some("flac"),
+        "mp3" => Some("mp3"),
+        "m4a" => Some("m4a"),
+        _ => None,
+    }
+}
+
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+fn is_durable_manifest_audio_type(artifact_type: &str) -> bool {
+    matches!(
+        artifact_type,
+        "source_audio"
+            | "preview_mix"
+            | "vocal_stem"
+            | "instrumental_stem"
+            | "drums_stem"
+            | "bass_stem"
+            | "guitar_stem"
+            | "piano_stem"
+            | "other_stem"
+            | "vocals"
+            | "instrumental"
+            | "drums"
+            | "bass"
+            | "guitar"
+            | "piano"
+            | "other"
+    )
+}
+
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+fn validate_manifest_durable_audio_artifact(
+    artifact: &SyncProjectManifestArtifactSchema,
+) -> Result<(), String> {
+    if !is_durable_manifest_audio_type(&artifact.r#type) {
+        return Ok(());
+    }
+    let format = durable_manifest_audio_format(artifact).ok_or_else(|| {
+        "Durable project manifest audio must use wav, flac, mp3, or m4a format.".to_string()
+    })?;
+    let suffix = format!(".{format}");
+    if !artifact
+        .relative_path
+        .to_ascii_lowercase()
+        .ends_with(&suffix)
+    {
+        return Err(format!(
+            "Durable project manifest {format} audio relative_path must end in {suffix}."
+        ));
+    }
+    Ok(())
+}
+
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
 fn validate_manifest_source_audio_artifact(
     artifact: &SyncProjectManifestArtifactSchema,
     project_id: &str,
@@ -75,16 +137,7 @@ fn validate_manifest_source_audio_artifact(
     }
     normalize_sha256(&artifact.content_sha256, "content_sha256")?;
     safe_sync_relative_path_parts(&artifact.relative_path)?;
-    if !artifact.format.trim().eq_ignore_ascii_case("wav") {
-        return Err("Project manifest source_audio artifact must use wav format.".to_string());
-    }
-    if !artifact
-        .relative_path
-        .to_ascii_lowercase()
-        .ends_with(".wav")
-    {
-        return Err("Project manifest source_audio relative_path must end in .wav.".to_string());
-    }
+    validate_manifest_durable_audio_artifact(artifact)?;
     Ok(())
 }
 
@@ -137,6 +190,7 @@ fn validate_sync_project_manifest_identity(
         }
         normalize_sha256(&artifact.content_sha256, "content_sha256")?;
         safe_sync_relative_path_parts(&artifact.relative_path)?;
+        validate_manifest_durable_audio_artifact(artifact)?;
     }
     manifest_source_audio_artifact(manifest)?;
     for revision in &manifest.entity_revisions {
@@ -1519,6 +1573,8 @@ mod mobile_backend_tests {
     use super::*;
     use chrono::{TimeZone, Utc};
     use serde_json::json;
+    #[cfg(not(target_os = "android"))]
+    use std::process::Command;
 
     fn mobile_test_job(
         id: &str,
@@ -1605,6 +1661,86 @@ mod mobile_backend_tests {
         }
     }
 
+    #[test]
+    fn mobile_manifest_accepts_exact_four_format_durable_audio_pairs() {
+        let source_sha256 = "a".repeat(64);
+        let project_id = source_hash_to_project_id(&source_sha256).unwrap();
+        for format in ["wav", "flac", "mp3", "m4a"] {
+            let mut manifest = mobile_test_manifest(&project_id, &source_sha256);
+            manifest.artifacts[0].format = format.to_string();
+            manifest.artifacts[0].relative_path = format!("source/source.{format}");
+            manifest.artifacts.push(SyncProjectManifestArtifactSchema {
+                artifact_id: format!("art_mix_{format}"),
+                project_id: project_id.clone(),
+                r#type: "preview_mix".to_string(),
+                format: format.to_string(),
+                relative_path: format!("mixes/mix.{format}"),
+                content_sha256: "b".repeat(64),
+                size_bytes: 42,
+                generated_by: "preview".to_string(),
+                can_delete: true,
+                can_regenerate: true,
+                cache_key: None,
+                metadata: json!({}),
+                created_at: "2026-05-22T12:00:00.000Z".to_string(),
+            });
+            manifest.artifacts.push(SyncProjectManifestArtifactSchema {
+                artifact_id: format!("art_stem_{format}"),
+                project_id: project_id.clone(),
+                r#type: "vocal_stem".to_string(),
+                format: format.to_string(),
+                relative_path: format!("stems/vocals.{format}"),
+                content_sha256: "c".repeat(64),
+                size_bytes: 42,
+                generated_by: "stems".to_string(),
+                can_delete: true,
+                can_regenerate: true,
+                cache_key: None,
+                metadata: json!({}),
+                created_at: "2026-05-22T12:00:00.000Z".to_string(),
+            });
+            validate_sync_project_manifest_identity(&manifest).unwrap();
+        }
+    }
+
+    #[test]
+    fn mobile_manifest_rejects_durable_audio_format_suffix_mismatch() {
+        let source_sha256 = "d".repeat(64);
+        let project_id = source_hash_to_project_id(&source_sha256).unwrap();
+        let mut manifest = mobile_test_manifest(&project_id, &source_sha256);
+        manifest.artifacts[0].format = "flac".to_string();
+        assert!(validate_sync_project_manifest_identity(&manifest)
+            .unwrap_err()
+            .contains("must end in .flac"));
+
+        manifest.artifacts[0].format = "ogg".to_string();
+        manifest.artifacts[0].relative_path = "source/source.ogg".to_string();
+        assert!(validate_sync_project_manifest_identity(&manifest)
+            .unwrap_err()
+            .contains("wav, flac, mp3, or m4a"));
+
+        for noncanonical in ["WAV", " wav", "wav "] {
+            manifest.artifacts[0].format = noncanonical.to_string();
+            manifest.artifacts[0].relative_path = "source/source.wav".to_string();
+            assert!(validate_sync_project_manifest_identity(&manifest).is_err());
+        }
+
+        manifest.artifacts[0].format = "wav".to_string();
+        manifest.artifacts[0].relative_path = "source/source.WAV".to_string();
+        validate_sync_project_manifest_identity(&manifest).unwrap();
+
+        let mut legacy_stem = manifest.artifacts[0].clone();
+        legacy_stem.artifact_id = "art_legacy_vocals".to_string();
+        legacy_stem.r#type = "vocals".to_string();
+        legacy_stem.format = "ogg".to_string();
+        legacy_stem.relative_path = "stems/vocals.ogg".to_string();
+        manifest.artifacts[0].relative_path = "source/source.wav".to_string();
+        manifest.artifacts.push(legacy_stem);
+        assert!(validate_sync_project_manifest_identity(&manifest)
+            .unwrap_err()
+            .contains("wav, flac, mp3, or m4a"));
+    }
+
     fn mobile_test_tombstone(
         tombstone_id: &str,
         project_id: &str,
@@ -1643,6 +1779,237 @@ mod mobile_backend_tests {
         }
         std::fs::write(path, bytes).unwrap();
         (storage::file_sha256(path).unwrap(), bytes.len() as i64)
+    }
+
+    #[cfg(not(target_os = "android"))]
+    fn write_mobile_synthetic_wav(path: &std::path::Path) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        write_mono_pcm_wav(
+            path,
+            &crate::native_audio::decode::DecodedAudio {
+                samples: (0..800)
+                    .map(|index| ((index as f32 * 0.15).sin() * 0.2).clamp(-1.0, 1.0))
+                    .collect(),
+                sample_rate: 8_000,
+                channels: 1,
+            },
+        )
+        .unwrap();
+    }
+
+    #[cfg(not(target_os = "android"))]
+    fn encode_mobile_contract_fixture(source: &std::path::Path, output: &std::path::Path, format: &str) {
+        let mut command = Command::new("ffmpeg");
+        command.args(["-hide_banner", "-loglevel", "error", "-y", "-i"]);
+        command.arg(source);
+        match format {
+            "flac" => command.args(["-c:a", "flac", "-compression_level", "5"]),
+            "mp3" => command.args(["-c:a", "libmp3lame", "-b:a", "192k"]),
+            "m4a" => command.args(["-c:a", "aac", "-profile:a", "aac_low", "-b:a", "192k"]),
+            _ => panic!("unsupported mobile contract fixture format"),
+        };
+        assert!(command.arg(output).status().unwrap().success());
+    }
+
+    #[cfg(not(target_os = "android"))]
+    #[test]
+    fn mobile_manifest_import_preserves_four_format_durable_audio_bytes_and_identity() {
+        for format in ["wav", "flac", "mp3", "m4a"] {
+            let root = mobile_storage_contract_root(&format!("preserve-{format}"));
+            let connection = storage::db_at_root(&root).unwrap();
+            let fixture_wav = root.join("fixture.wav");
+            write_mobile_synthetic_wav(&fixture_wav);
+            let encoded_path = if format == "wav" {
+                fixture_wav.clone()
+            } else {
+                let path = root.join(format!("fixture.{format}"));
+                encode_mobile_contract_fixture(&fixture_wav, &path, format);
+                path
+            };
+            let expected_bytes = std::fs::read(&encoded_path).unwrap();
+            let content_sha256 = storage::hex_digest(&Sha256::digest(&expected_bytes));
+            let size_bytes = expected_bytes.len() as i64;
+            let source_sha256 = storage::hex_digest(&Sha256::digest(format.as_bytes()));
+            let project_id = source_hash_to_project_id(&source_sha256).unwrap();
+            let staging_root = root.join("incoming");
+            let artifacts = [
+                ("art_source", "source_audio", format!("source/source.{format}"), false, None),
+                ("art_mix", "preview_mix", format!("mixes/practice.{format}"), true, Some("mix:source")),
+                ("art_stem", "vocal_stem", format!("stems/vocals.{format}"), true, Some("stem:source:vocals")),
+            ]
+            .into_iter()
+            .map(|(artifact_id, artifact_type, relative_path, can_delete, cache_key)| {
+                write_mobile_contract_file(&staging_root.join(&relative_path), &expected_bytes);
+                SyncProjectManifestArtifactSchema {
+                    artifact_id: artifact_id.to_string(),
+                    project_id: project_id.clone(),
+                    r#type: artifact_type.to_string(),
+                    format: format.to_string(),
+                    relative_path,
+                    content_sha256: content_sha256.clone(),
+                    size_bytes,
+                    generated_by: "sync".to_string(),
+                    can_delete,
+                    can_regenerate: can_delete,
+                    cache_key: cache_key.map(ToString::to_string),
+                    metadata: json!({"preserved": format}),
+                    created_at: "2026-05-22T12:00:00.000Z".to_string(),
+                }
+            })
+            .collect::<Vec<_>>();
+            let manifest = SyncProjectManifestSchema {
+                schema_version: SYNC_PROJECT_MANIFEST_SCHEMA_VERSION.to_string(),
+                exported_at: "2026-05-22T12:01:00.000Z".to_string(),
+                project: SyncProjectManifestProjectSchema {
+                    project_id: project_id.clone(),
+                    display_name: format!("{format} project"),
+                    source_key_override: None,
+                    source_sha256,
+                    duration_seconds: Some(0.1),
+                    sample_rate: Some(8_000),
+                    channels: Some(1),
+                    created_at: "2026-05-22T12:00:00.000Z".to_string(),
+                    updated_at: "2026-05-22T12:00:00.000Z".to_string(),
+                },
+                entity_revisions: Vec::new(),
+                artifacts,
+                delete_tombstones: Vec::new(),
+            };
+
+            manifests::import_sync_project_manifest(
+                &connection,
+                &root,
+                SyncProjectStagedImportRequest {
+                    manifest,
+                    staging_root: Some(staging_root.to_string_lossy().into_owned()),
+                    use_content_addressed_staging: Some(false),
+                },
+            )
+            .unwrap();
+
+            for artifact_id in ["art_source", "art_mix", "art_stem"] {
+                let artifact = connection
+                    .query_row(
+                        &format!("SELECT {ARTIFACT_COLUMNS} FROM artifacts WHERE id = ?1"),
+                        rusqlite::params![artifact_id],
+                        storage::row_artifact,
+                    )
+                    .unwrap();
+                assert_eq!(artifact.project_id, project_id);
+                assert_eq!(artifact.format, format);
+                assert_eq!(artifact.content_sha256.as_deref(), Some(content_sha256.as_str()));
+                assert_eq!(artifact.size_bytes, size_bytes);
+                assert_eq!(artifact.generated_by, "sync");
+                assert_eq!(artifact.metadata, json!({"preserved": format}));
+                assert_eq!(std::fs::read(&artifact.path).unwrap(), expected_bytes);
+            }
+            let exported = storage::get_project_manifest(&connection, &root, &project_id).unwrap();
+            assert_eq!(exported.schema_version, SYNC_PROJECT_MANIFEST_SCHEMA_VERSION);
+            assert!(exported.artifacts.iter().all(|artifact| artifact.format == format));
+
+            drop(connection);
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[cfg(not(target_os = "android"))]
+    #[test]
+    fn mobile_manifest_rejects_corrupt_legacy_stem_before_commit_and_cleans_copy() {
+        let root = mobile_storage_contract_root("corrupt-durable-audio");
+        let connection = storage::db_at_root(&root).unwrap();
+        let staging_root = root.join("incoming");
+        let source_relative_path = "source/source.wav";
+        let source_path = staging_root.join(source_relative_path);
+        write_mobile_synthetic_wav(&source_path);
+        let source_bytes = std::fs::read(&source_path).unwrap();
+        let source_sha256 = storage::hex_digest(&Sha256::digest(&source_bytes));
+        let source_size_bytes = source_bytes.len() as i64;
+        let legacy_stem_relative_path = "stems/vocals.m4a";
+        let corrupt_bytes = b"\0\0\0\x18ftypM4A \0\0\0\0corrupt";
+        let (stem_sha256, stem_size_bytes) = write_mobile_contract_file(
+            &staging_root.join(legacy_stem_relative_path),
+            corrupt_bytes,
+        );
+        let project_id = source_hash_to_project_id(&source_sha256).unwrap();
+        let manifest = SyncProjectManifestSchema {
+            schema_version: SYNC_PROJECT_MANIFEST_SCHEMA_VERSION.to_string(),
+            exported_at: "2026-05-22T12:01:00.000Z".to_string(),
+            project: SyncProjectManifestProjectSchema {
+                project_id: project_id.clone(),
+                display_name: "Corrupt project".to_string(),
+                source_key_override: None,
+                source_sha256: source_sha256.clone(),
+                duration_seconds: None,
+                sample_rate: None,
+                channels: None,
+                created_at: "2026-05-22T12:00:00.000Z".to_string(),
+                updated_at: "2026-05-22T12:00:00.000Z".to_string(),
+            },
+            entity_revisions: Vec::new(),
+            artifacts: vec![
+                SyncProjectManifestArtifactSchema {
+                    artifact_id: "art_source".to_string(),
+                    project_id: project_id.clone(),
+                    r#type: "source_audio".to_string(),
+                    format: "wav".to_string(),
+                    relative_path: source_relative_path.to_string(),
+                    content_sha256: source_sha256,
+                    size_bytes: source_size_bytes,
+                    generated_by: "sync".to_string(),
+                    can_delete: false,
+                    can_regenerate: false,
+                    cache_key: None,
+                    metadata: json!({}),
+                    created_at: "2026-05-22T12:00:00.000Z".to_string(),
+                },
+                SyncProjectManifestArtifactSchema {
+                    artifact_id: "art_legacy_vocals".to_string(),
+                    project_id: project_id.clone(),
+                    r#type: "vocals".to_string(),
+                    format: "m4a".to_string(),
+                    relative_path: legacy_stem_relative_path.to_string(),
+                    content_sha256: stem_sha256,
+                    size_bytes: stem_size_bytes,
+                    generated_by: "sync".to_string(),
+                    can_delete: true,
+                    can_regenerate: true,
+                    cache_key: Some("stem:source:vocals".to_string()),
+                    metadata: json!({}),
+                    created_at: "2026-05-22T12:00:00.000Z".to_string(),
+                },
+            ],
+            delete_tombstones: Vec::new(),
+        };
+
+        let error = match manifests::import_sync_project_manifest(
+            &connection,
+            &root,
+            SyncProjectStagedImportRequest {
+                manifest,
+                staging_root: Some(staging_root.to_string_lossy().into_owned()),
+                use_content_addressed_staging: Some(false),
+            },
+        ) {
+            Ok(_) => panic!("corrupt durable audio must be rejected"),
+            Err(error) => error,
+        };
+        assert!(error.contains("failed bounded m4a validation"));
+        let project_count: i64 = connection
+            .query_row("SELECT COUNT(*) FROM projects", [], |row| row.get(0))
+            .unwrap();
+        let artifact_count: i64 = connection
+            .query_row("SELECT COUNT(*) FROM artifacts", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(project_count, 0);
+        assert_eq!(artifact_count, 0);
+        let project_root = root.join("projects").join(project_id);
+        assert!(!project_root.join(source_relative_path).exists());
+        assert!(!project_root.join(legacy_stem_relative_path).exists());
+
+        drop(connection);
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[cfg(not(target_os = "android"))]
@@ -1708,6 +2075,53 @@ mod mobile_backend_tests {
                 ],
             )
             .unwrap();
+    }
+
+    #[cfg(not(target_os = "android"))]
+    #[test]
+    fn mobile_local_import_with_uppercase_extension_exports_canonical_manifest() {
+        let root = mobile_storage_contract_root("uppercase-import-manifest-export");
+        let connection = storage::db_at_root(&root).unwrap();
+        let fixture_path = root.join("Song.WAV");
+        write_mobile_synthetic_wav(&fixture_path);
+        let source_sha256 = storage::file_sha256(&fixture_path).unwrap();
+        let project_id = source_hash_to_project_id(&source_sha256).unwrap();
+        let source_path = storage::project_root_path(&root, &project_id)
+            .unwrap()
+            .join("source")
+            .join("Song.WAV");
+        std::fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        std::fs::rename(&fixture_path, &source_path).unwrap();
+        let source_size_bytes = std::fs::metadata(&source_path).unwrap().len() as i64;
+
+        insert_mobile_contract_project(&connection, &project_id, &source_sha256, &source_path);
+        insert_mobile_contract_artifact(
+            &connection,
+            MobileContractArtifact {
+                artifact_id: "art_source_audio",
+                project_id: &project_id,
+                artifact_type: "source_audio",
+                format: "wav",
+                path: &source_path,
+                content_sha256: &source_sha256,
+                size_bytes: source_size_bytes,
+                generated_by: "import",
+                can_delete: false,
+                can_regenerate: false,
+                cache_key: None,
+                metadata: json!({"source_path": "Song.WAV"}),
+            },
+        );
+
+        let manifest = storage::get_project_manifest(&connection, &root, &project_id).unwrap();
+
+        assert_eq!(manifest.artifacts.len(), 1);
+        assert_eq!(manifest.artifacts[0].format, "wav");
+        assert_eq!(manifest.artifacts[0].relative_path, "source/Song.WAV");
+        validate_sync_project_manifest_identity(&manifest).unwrap();
+
+        drop(connection);
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[cfg(not(target_os = "android"))]
@@ -3065,7 +3479,7 @@ mod mobile_backend_tests {
         bad_format.artifacts[0].format = "m4a".to_string();
         assert!(validate_sync_project_manifest_identity(&bad_format)
             .unwrap_err()
-            .contains("wav format"));
+            .contains("must end in .m4a"));
 
         let mut bad_path = manifest;
         bad_path.artifacts[0].relative_path = "source/source.m4a".to_string();

--- a/apps/desktop/src-tauri/src/mobile_backend/manifests.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/manifests.rs
@@ -3,6 +3,7 @@ use super::storage_cleanup::{
     project_storage_mutation_guard, require_owned_project_file,
 };
 use super::*;
+use crate::native_audio::decode::probe_mobile_durable_audio;
 
 pub(super) fn normalize_sync_status(value: &str) -> Result<String, String> {
     let normalized = value.trim().to_ascii_lowercase();
@@ -901,6 +902,21 @@ pub(super) fn import_sync_project_manifest(
         if let Err(message) = require_owned_project_file(copied) {
             cleanup_owned_project_files(&copied_paths);
             return Err(message);
+        }
+    }
+
+    for prepared in &prepared_artifacts {
+        if prepared.staged_path.is_none() {
+            continue;
+        }
+        let Some(format) = durable_manifest_audio_format(&prepared.manifest) else {
+            continue;
+        };
+        if let Err(message) = probe_mobile_durable_audio(&prepared.destination_path, format) {
+            cleanup_owned_project_files(&copied_paths);
+            return Err(format!(
+                "Synced durable audio failed bounded {format} validation: {message}"
+            ));
         }
     }
 

--- a/apps/desktop/src-tauri/src/mobile_backend/schemas.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/schemas.rs
@@ -205,6 +205,7 @@ pub struct LyricsResponse {
 #[cfg_attr(not(target_os = "android"), allow(dead_code))]
 pub struct ProjectImportRequest {
     source_path: String,
+    #[serde(default = "default_true")]
     copy_into_project: bool,
     display_name: Option<String>,
 }
@@ -718,4 +719,17 @@ pub struct SyncReconciliationApplyResponse {
 
 fn default_true() -> bool {
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProjectImportRequest;
+
+    #[test]
+    fn project_import_request_defaults_copy_into_project_to_true() {
+        let request: ProjectImportRequest =
+            serde_json::from_str(r#"{"source_path":"/music/song.wav"}"#).unwrap();
+
+        assert!(request.copy_into_project);
+    }
 }

--- a/apps/desktop/src-tauri/src/mobile_media_transport.rs
+++ b/apps/desktop/src-tauri/src/mobile_media_transport.rs
@@ -627,6 +627,13 @@ mod tests {
     const MANIFEST_ID: &str = "manifest/source v1";
     const ORIGIN: &str = "http://tauri.localhost";
     static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(1);
+    static SERVER_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn server_test_guard() -> std::sync::MutexGuard<'static, ()> {
+        SERVER_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
 
     struct TestDirectory(PathBuf);
 
@@ -679,6 +686,7 @@ mod tests {
 
     #[test]
     fn lazy_server_starts_once_for_concurrent_callers() {
+        let _server_test_guard = server_test_guard();
         let directory = TestDirectory::new();
         let path = directory.0.join("fixture.wav");
         fs::write(&path, b"media").unwrap();
@@ -708,6 +716,7 @@ mod tests {
 
     #[test]
     fn lazy_server_can_retry_after_start_failure() {
+        let _server_test_guard = server_test_guard();
         let directory = TestDirectory::new();
         let path = directory.0.join("fixture.wav");
         fs::write(&path, b"media").unwrap();
@@ -732,13 +741,17 @@ mod tests {
 
     impl Fixture {
         fn new() -> Self {
+            Self::new_with_content_type("audio/wav")
+        }
+
+        fn new_with_content_type(content_type: &'static str) -> Self {
             let directory = TestDirectory::new();
             let path = directory.0.join("fixture.wav");
             let bytes = (0..STREAM_BUFFER_BYTES * 3 + 17)
                 .map(|index| (index % 251) as u8)
                 .collect::<Vec<_>>();
             fs::write(&path, &bytes).unwrap();
-            let server = start_server(&path, "audio/wav");
+            let server = start_server(&path, content_type);
             Self {
                 server,
                 _directory: directory,
@@ -805,6 +818,7 @@ mod tests {
 
     #[test]
     fn serves_full_head_options_and_rejects_methods_and_origins() {
+        let _server_test_guard = server_test_guard();
         let fixture = Fixture::new();
         let response = fixture.exchange(&fixture.request_text("GET", ""));
         let (headers, body) = split_response(&response);
@@ -882,6 +896,7 @@ mod tests {
 
     #[test]
     fn serves_closed_open_and_suffix_ranges_without_a_response_cap() {
+        let _server_test_guard = server_test_guard();
         let fixture = Fixture::new();
         for (range, start, end) in [
             ("bytes=10-19", 10, 19),
@@ -907,7 +922,20 @@ mod tests {
     }
 
     #[test]
+    fn maps_exact_manifest_durable_audio_formats_to_web_mime_types() {
+        for (format, content_type) in [
+            ("wav", "audio/wav"),
+            ("flac", "audio/flac"),
+            ("mp3", "audio/mpeg"),
+            ("m4a", "audio/mp4"),
+        ] {
+            assert_eq!(content_type_for_format(format), Some(content_type));
+        }
+    }
+
+    #[test]
     fn rejects_malformed_multiple_and_unsatisfiable_ranges_and_shuts_down() {
+        let _server_test_guard = server_test_guard();
         let fixture = Fixture::new();
         for headers in [
             "Range: items=0-1\r\n".to_string(),
@@ -929,6 +957,7 @@ mod tests {
 
     #[test]
     fn shutdown_interrupts_an_incomplete_request() {
+        let _server_test_guard = server_test_guard();
         let fixture = Fixture::new();
         let mut stream = TcpStream::connect(fixture.server.address).unwrap();
         write!(
@@ -946,6 +975,7 @@ mod tests {
 
     #[test]
     fn shutdown_interrupts_a_stalled_large_response() {
+        let _server_test_guard = server_test_guard();
         let directory = TestDirectory::new();
         let path = directory.0.join("large.wav");
         std::fs::File::create(&path)

--- a/apps/desktop/src-tauri/src/native_audio/decode.rs
+++ b/apps/desktop/src-tauri/src/native_audio/decode.rs
@@ -2,6 +2,23 @@
 
 use std::{fs, path::Path};
 
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+use std::{fs::File, io::Read};
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+use symphonia::core::{
+    codecs::audio::{
+        well_known::{
+            profiles::CODEC_PROFILE_AAC_LC, CODEC_ID_AAC, CODEC_ID_FLAC, CODEC_ID_MP3,
+            CODEC_ID_PCM_S16LE,
+        },
+        AudioDecoderOptions,
+    },
+    errors::Error as SymphoniaError,
+    formats::{probe::Hint, FormatOptions, TrackType},
+    io::MediaSourceStream,
+    meta::MetadataOptions,
+};
+
 use super::android_media;
 
 #[derive(Clone)]
@@ -16,6 +33,140 @@ pub struct DecodedInterleavedAudio {
     pub samples: Vec<f32>,
     pub sample_rate: u32,
     pub channels: u32,
+}
+
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+const DURABLE_PROBE_PACKET_LIMIT: usize = 32;
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+const DURABLE_PROBE_PACKET_BYTES: usize = 4 * 1024 * 1024;
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+const DURABLE_PROBE_HEADER_BYTES: usize = 64;
+
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+fn durable_container_matches(format: &str, header: &[u8]) -> bool {
+    match format {
+        "wav" => header.starts_with(b"RIFF") && header.get(8..12) == Some(b"WAVE"),
+        "flac" => header.starts_with(b"fLaC"),
+        "mp3" => {
+            header.starts_with(b"ID3")
+                || header
+                    .windows(2)
+                    .take(16)
+                    .any(|bytes| bytes[0] == 0xff && bytes[1] & 0xe0 == 0xe0)
+        }
+        "m4a" => header.get(4..8) == Some(b"ftyp"),
+        _ => false,
+    }
+}
+
+pub fn probe_mobile_durable_audio(path: &Path, expected_format: &str) -> Result<(), String> {
+    #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+    {
+        let expected_format = expected_format.trim().to_ascii_lowercase();
+        let expected_suffix = format!(".{expected_format}");
+        if !path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.to_ascii_lowercase().ends_with(&expected_suffix))
+        {
+            return Err(format!(
+                "Durable audio format {expected_format} requires a matching {expected_suffix} path."
+            ));
+        }
+
+        let mut header_file = File::open(path)
+            .map_err(|error| format!("Could not open durable audio for validation: {error}"))?;
+        let mut header = [0_u8; DURABLE_PROBE_HEADER_BYTES];
+        let header_len = header_file
+            .read(&mut header)
+            .map_err(|error| format!("Could not read durable audio for validation: {error}"))?;
+        if !durable_container_matches(&expected_format, &header[..header_len]) {
+            return Err(format!(
+                "Durable audio does not match the declared {expected_format} container."
+            ));
+        }
+
+        let file = File::open(path)
+            .map_err(|error| format!("Could not open durable audio for validation: {error}"))?;
+        let media_source = MediaSourceStream::new(Box::new(file), Default::default());
+        let mut hint = Hint::new();
+        hint.with_extension(&expected_format);
+        let mut reader = symphonia::default::get_probe()
+            .probe(
+                &hint,
+                media_source,
+                FormatOptions::default(),
+                MetadataOptions::default(),
+            )
+            .map_err(|error| format!("Durable audio container could not be read: {error}"))?;
+        let (track_id, codec_params) = {
+            let track = reader.default_track(TrackType::Audio).ok_or_else(|| {
+                "Durable audio container does not contain an audio track.".to_string()
+            })?;
+            let codec_params = track
+                .codec_params
+                .as_ref()
+                .and_then(|params| params.audio())
+                .cloned()
+                .ok_or_else(|| "Durable audio track is not decodable.".to_string())?;
+            (track.id, codec_params)
+        };
+        let codec_matches = match expected_format.as_str() {
+            "wav" => {
+                codec_params.codec == CODEC_ID_PCM_S16LE && codec_params.bits_per_sample == Some(16)
+            }
+            "flac" => codec_params.codec == CODEC_ID_FLAC,
+            "mp3" => codec_params.codec == CODEC_ID_MP3,
+            "m4a" => {
+                codec_params.codec == CODEC_ID_AAC
+                    && codec_params.profile == Some(CODEC_PROFILE_AAC_LC)
+            }
+            _ => false,
+        };
+        if !codec_matches {
+            return Err(format!(
+                "Durable audio codec does not match the declared {expected_format} format."
+            ));
+        }
+
+        let mut decoder = symphonia::default::get_codecs()
+            .make_audio_decoder(&codec_params, &AudioDecoderOptions::default())
+            .map_err(|error| format!("Durable audio codec is unavailable: {error}"))?;
+        for _ in 0..DURABLE_PROBE_PACKET_LIMIT {
+            let packet = match reader.next_packet() {
+                Ok(Some(packet)) => packet,
+                Ok(None) => break,
+                Err(SymphoniaError::DecodeError(_)) => continue,
+                Err(error) => {
+                    return Err(format!("Durable audio packet could not be read: {error}"));
+                }
+            };
+            if packet.track_id != track_id {
+                continue;
+            }
+            if packet.data.len() > DURABLE_PROBE_PACKET_BYTES {
+                return Err("Durable audio probe packet exceeds the validation bound.".to_string());
+            }
+            match decoder.decode(&packet) {
+                Ok(decoded) if decoded.samples_interleaved() > 0 => return Ok(()),
+                Ok(_) | Err(SymphoniaError::DecodeError(_)) => continue,
+                Err(error) => {
+                    return Err(format!(
+                        "Durable audio packet could not be decoded: {error}"
+                    ));
+                }
+            }
+        }
+        return Err(
+            "Durable audio did not yield readable audio within the probe bound.".to_string(),
+        );
+    }
+
+    #[cfg(not(any(target_os = "android", target_os = "linux", target_os = "macos")))]
+    {
+        let _ = (path, expected_format);
+        Err("Durable audio probing is unavailable on this platform.".to_string())
+    }
 }
 
 pub fn read_mobile_audio(path: &Path) -> Result<DecodedAudio, String> {
@@ -98,6 +249,89 @@ pub fn read_wav_audio(path: &Path) -> Result<DecodedAudio, String> {
         sample_rate: decoded.sample_rate,
         channels: decoded.channels,
     })
+}
+
+#[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
+mod durable_probe_tests {
+    use super::*;
+    use std::{path::PathBuf, process::Command};
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new(slug: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "tuneforge-durable-probe-{slug}-{}",
+                std::process::id()
+            ));
+            let _ = fs::remove_dir_all(&path);
+            fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn write_synthetic_wav(path: &Path) {
+        let audio = DecodedAudio {
+            samples: (0..800)
+                .map(|index| ((index as f32 * 0.15).sin() * 0.2).clamp(-1.0, 1.0))
+                .collect(),
+            sample_rate: 8_000,
+            channels: 1,
+        };
+        write_mono_pcm_wav(path, &audio).unwrap();
+    }
+
+    fn encode_fixture(source: &Path, destination: &Path, format: &str) {
+        let mut command = Command::new("ffmpeg");
+        command.args(["-hide_banner", "-loglevel", "error", "-y", "-i"]);
+        command.arg(source);
+        match format {
+            "flac" => command.args(["-c:a", "flac", "-compression_level", "5"]),
+            "mp3" => command.args(["-c:a", "libmp3lame", "-b:a", "192k"]),
+            "m4a" => command.args(["-c:a", "aac", "-profile:a", "aac_low", "-b:a", "192k"]),
+            _ => panic!("unsupported test format"),
+        };
+        let status = command.arg(destination).status().unwrap();
+        assert!(status.success());
+    }
+
+    #[test]
+    fn bounded_probe_accepts_exact_four_format_contract() {
+        let directory = TestDirectory::new("valid");
+        let wav = directory.0.join("fixture.wav");
+        write_synthetic_wav(&wav);
+        probe_mobile_durable_audio(&wav, "wav").unwrap();
+
+        for format in ["flac", "mp3", "m4a"] {
+            let path = directory.0.join(format!("fixture.{format}"));
+            encode_fixture(&wav, &path, format);
+            probe_mobile_durable_audio(&path, format).unwrap();
+        }
+    }
+
+    #[test]
+    fn bounded_probe_rejects_mismatch_and_corrupt_media() {
+        let directory = TestDirectory::new("invalid");
+        let wav = directory.0.join("fixture.wav");
+        write_synthetic_wav(&wav);
+        let mp3 = directory.0.join("fixture.mp3");
+        encode_fixture(&wav, &mp3, "mp3");
+        let mismatched = directory.0.join("mismatch.flac");
+        fs::copy(&mp3, &mismatched).unwrap();
+        assert!(probe_mobile_durable_audio(&mismatched, "flac")
+            .unwrap_err()
+            .contains("container"));
+
+        let corrupt = directory.0.join("corrupt.m4a");
+        fs::write(&corrupt, b"\0\0\0\x18ftypM4A \0\0\0\0corrupt").unwrap();
+        assert!(probe_mobile_durable_audio(&corrupt, "m4a").is_err());
+    }
 }
 
 pub fn read_wav_audio_interleaved(path: &Path) -> Result<DecodedInterleavedAudio, String> {

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -5560,6 +5560,7 @@ describe("Desktop app activity", () => {
       JSON.stringify({
         defaultBeatAnalysisBackend: "beat-this",
         defaultChordBackend: "crema-advanced",
+        defaultDurableAudioFormat: "m4a",
         defaultStemModel: "htdemucs_ft",
       }),
     );
@@ -5587,6 +5588,7 @@ describe("Desktop app activity", () => {
     await waitFor(() =>
       expect(mockBulkJobs).toHaveBeenCalledWith({
         job_type: "stems",
+        output_format: "m4a",
         chord_backend: "crema-advanced",
         stem_model: "htdemucs_ft",
       }),
@@ -5639,6 +5641,7 @@ describe("Desktop app activity", () => {
     await waitFor(() =>
       expect(mockBulkJobs).toHaveBeenCalledWith({
         job_type: "stems",
+        output_format: "wav",
         chord_backend: "tuneforge-fast",
         chord_backend_fallback_from: "crema-advanced",
         stem_model: "htdemucs_ft",

--- a/apps/desktop/src/App.library.test.tsx
+++ b/apps/desktop/src/App.library.test.tsx
@@ -5,6 +5,7 @@ import {
   resetAppTestHarness,
   mockDeleteProject,
   mockGetProject,
+  mockGetExportCapabilities,
   mockImportProject,
   mockListProjects,
   mockOpen,
@@ -394,6 +395,7 @@ describe("Desktop app library", () => {
     expect(mockImportProject).toHaveBeenCalledWith({
       source_path: "/tmp/new-song.mp4",
       copy_into_project: true,
+      output_format: "wav",
       beat_backend: "beat-this",
       chord_backend: "crema-advanced",
       stem_model: "htdemucs_6s",
@@ -408,6 +410,28 @@ describe("Desktop app library", () => {
     );
     expect(await screen.findByRole("heading", { name: "New Song" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Hide Inspector" })).toBeInTheDocument();
+  });
+
+  it("keeps Android imports on backend-default WAV and omits the hidden desktop preference", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({ defaultDurableAudioFormat: "m4a" }),
+    );
+    mockGetExportCapabilities.mockResolvedValueOnce({
+      capabilities: {
+        platform: "android",
+        formats: [{ id: "wav", available: true, reason: null }],
+        destinations: [],
+        max_artifact_count: 1,
+      },
+    });
+    mockOpen.mockResolvedValue("/tmp/mobile-song.wav");
+    renderApp(["/"]);
+
+    await user.click(await screen.findByRole("button", { name: "Import Track(s)" }));
+    await waitFor(() => expect(mockImportProject).toHaveBeenCalled());
+    expect(mockImportProject.mock.calls[0]?.[0]).not.toHaveProperty("output_format");
   });
 
   it("imports multiple tracks in order and stays on the library", async () => {
@@ -436,6 +460,7 @@ describe("Desktop app library", () => {
       expect(payload).toEqual(
         expect.objectContaining({
           copy_into_project: true,
+          output_format: "wav",
           beat_backend: "beat-this",
           chord_backend: "crema-advanced",
           stem_model: "htdemucs_ft",
@@ -451,6 +476,36 @@ describe("Desktop app library", () => {
     );
     expect(screen.getByRole("heading", { name: "Practice Projects" })).toBeInTheDocument();
     expect(mockGetProject).not.toHaveBeenCalled();
+  });
+
+  it("keeps one captured durable format across a batch when Settings changes after the picker opens", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({ defaultDurableAudioFormat: "flac" }),
+    );
+    let resolveSelection: ((value: string[]) => void) | null = null;
+    mockOpen.mockImplementationOnce(
+      () => new Promise<string[]>((resolve) => {
+        resolveSelection = resolve;
+      }),
+    );
+    renderApp(["/"]);
+
+    await user.click(await screen.findByRole("button", { name: "Import Track(s)" }));
+    await waitFor(() => expect(mockOpen).toHaveBeenCalled());
+    await user.click(screen.getByRole("link", { name: "Settings" }));
+    const m4a = await screen.findByRole("button", { name: /^M4A \(AAC-LC, 192 kbps\)/ });
+    await waitFor(() => expect(m4a).toBeEnabled());
+    await user.click(m4a);
+
+    await act(async () => {
+      resolveSelection?.(["/tmp/batch-one.wav", "/tmp/batch-two.wav"]);
+    });
+    await waitFor(() => expect(mockImportProject).toHaveBeenCalledTimes(2));
+    for (const [payload] of mockImportProject.mock.calls) {
+      expect(payload).toHaveProperty("output_format", "flac");
+    }
   });
 
   it("shows truthful pending guidance while choosing files and importing selected tracks", async () => {
@@ -745,6 +800,7 @@ describe("Desktop app library", () => {
       JSON.stringify({
         defaultChordBackend: "crema-advanced",
         defaultBeatAnalysisBackend: "beat-this",
+        defaultDurableAudioFormat: "flac",
         defaultSourcesRailCollapsed: false,
         defaultStemModel: "htdemucs_ft",
       }),
@@ -759,6 +815,7 @@ describe("Desktop app library", () => {
     expect(mockImportProject).toHaveBeenCalledWith({
       source_path: "/tmp/new-song.mp4",
       copy_into_project: true,
+      output_format: "flac",
       beat_backend: "beat-this",
       chord_backend: "crema-advanced",
       stem_model: "htdemucs_ft",
@@ -803,6 +860,7 @@ describe("Desktop app library", () => {
     expect(mockImportProject).toHaveBeenCalledWith({
       source_path: "/tmp/new-song.mp4",
       copy_into_project: true,
+      output_format: "wav",
       beat_backend: "beat-this",
       chord_backend: "tuneforge-fast",
       stem_model: "htdemucs_6s",
@@ -830,6 +888,7 @@ describe("Desktop app library", () => {
     expect(mockImportProject).toHaveBeenCalledWith({
       source_path: "/tmp/new-song.mp4",
       copy_into_project: true,
+      output_format: "wav",
       beat_backend: "built-in",
       chord_backend: "crema-advanced",
       stem_model: "htdemucs_6s",

--- a/apps/desktop/src/App.project-analysis-mix.test.tsx
+++ b/apps/desktop/src/App.project-analysis-mix.test.tsx
@@ -1152,6 +1152,10 @@ describe("Desktop app project analysis mix", () => {
 
   it("creates a new mix from the project source key override and target controls", async () => {
     const user = userEvent.setup();
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({ defaultDurableAudioFormat: "flac" }),
+    );
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
@@ -1169,7 +1173,7 @@ describe("Desktop app project analysis mix", () => {
     expect(mockCreatePreview).toHaveBeenCalledWith(
       "proj_123",
       expect.objectContaining({
-        output_format: "wav",
+        output_format: "flac",
         transpose: { semitones: 1 },
       }),
     );

--- a/apps/desktop/src/App.project-playback-stems.test.tsx
+++ b/apps/desktop/src/App.project-playback-stems.test.tsx
@@ -69,6 +69,10 @@ describe("Desktop app project playback stems", () => {
 
   it("switches between source playback and stems", async () => {
     const user = userEvent.setup();
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({ defaultDurableAudioFormat: "mp3" }),
+    );
     renderApp(["/projects/proj_123"]);
 
     expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
@@ -79,7 +83,7 @@ describe("Desktop app project playback stems", () => {
       expect.objectContaining({
         mode: "stems",
         stem_model: "htdemucs_6s",
-        output_format: "wav",
+        output_format: "mp3",
         force: false,
         source_artifact_id: "art_source",
       }),

--- a/apps/desktop/src/App.settings-theme.test.tsx
+++ b/apps/desktop/src/App.settings-theme.test.tsx
@@ -2,12 +2,15 @@ import { act, fireEvent, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FRONTEND_VERSION_INFO } from "./lib/buildInfo";
+import { DEFAULT_PREFERENCES } from "./lib/preferences";
 import {
   resetAppTestHarness,
   getAllByAriaKeyLabel,
   getByAriaKeyLabel,
   installMatchMediaMock,
   mockInvoke,
+  mockConfirm,
+  mockGetExportCapabilities,
   mockListBeatBackends,
   mockListChordBackends,
   queryByAriaKeyLabel,
@@ -36,6 +39,21 @@ describe("Desktop app settings theme", () => {
     if (showInspectorButton) {
       await user.click(showInspectorButton);
     }
+  }
+
+  function settingsSnapshotContents(
+    preferences: typeof DEFAULT_PREFERENCES,
+    themePreference: "dark" | "light" | "system",
+    themeOverrides: Record<string, Record<string, string>> = {},
+  ) {
+    return JSON.stringify({
+      exportedAt: "2026-04-18T13:16:00.000Z",
+      kind: "tuneforge.settings",
+      preferences,
+      themeOverrides,
+      themePreference,
+      version: 2,
+    });
   }
 
   it("applies enharmonic display overrides from settings", async () => {
@@ -102,6 +120,18 @@ describe("Desktop app settings theme", () => {
       expect(screen.getByRole("button", { name: /^Advanced Beat Analysis/ })).toHaveAttribute("aria-pressed", "true"),
     );
     expect(screen.getByRole("button", { name: /^Advanced Chords/ })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("heading", { name: "Audio Storage" })).toBeInTheDocument();
+    const durableFormats = screen.getByRole("group", { name: "New durable audio format" });
+    expect(within(durableFormats).getByRole("button", { name: /^WAV\/PCM/ }))
+      .toHaveTextContent("Available · Lossless · Default");
+    expect(within(durableFormats).getByRole("button", { name: /^FLAC/ }))
+      .toHaveTextContent("Available · Lossless");
+    expect(within(durableFormats).getByRole("button", { name: /^MP3/ }))
+      .toHaveTextContent("Available · Lossy");
+    expect(within(durableFormats).getByRole("button", { name: /^M4A/ }))
+      .toHaveTextContent("Available · Lossy");
+    expect(within(durableFormats).getByRole("button", { name: /^WAV\/PCM/ }))
+      .toHaveAttribute("aria-pressed", "true");
     expect(
       within(screen.getByRole("group", { name: "Default beat analysis" })).getAllByRole("button")[0],
     ).toHaveTextContent("Advanced Beat Analysis");
@@ -120,12 +150,165 @@ describe("Desktop app settings theme", () => {
       defaultPlaybackDisplayMode: "auto",
       defaultBeatAnalysisBackend: "beat-this",
       defaultChordBackend: "crema-advanced",
+      defaultDurableAudioFormat: "wav",
       defaultLyricsFollowEnabled: true,
       defaultChordsFollowEnabled: true,
       defaultTunerInputDeviceId: null,
       defaultTunerReferenceHz: 440,
       defaultTunerVisualMode: "wide-arc",
     });
+  });
+
+  it("confirms lossy audio storage choices and resets to WAV", async () => {
+    const user = userEvent.setup();
+    renderApp(["/settings"]);
+
+    expect(await screen.findByRole("heading", { name: "Audio Storage" })).toBeInTheDocument();
+    const audioFormats = screen.getByRole("group", { name: "New durable audio format" });
+    await waitFor(() => expect(within(audioFormats).getByRole("button", { name: /^MP3 \(192 kbps\)/ })).toBeEnabled());
+    await user.click(within(audioFormats).getByRole("button", { name: /^MP3 \(192 kbps\)/ }));
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.stringMatching(/irreversible.*cannot be recovered.*new imports.*bulk stem refreshes/is),
+      expect.objectContaining({ okLabel: "Use MP3" }),
+    );
+    expect(within(audioFormats).getByRole("button", { name: /^MP3 \(192 kbps\)/ }))
+      .toHaveAttribute("aria-pressed", "true");
+    expect(JSON.parse(window.localStorage.getItem("tuneforge.ui-preferences") ?? "{}"))
+      .toMatchObject({ defaultDurableAudioFormat: "mp3" });
+
+    await user.click(within(audioFormats).getByRole("button", { name: /^M4A \(AAC-LC, 192 kbps\)/ }));
+    expect(mockConfirm).toHaveBeenLastCalledWith(
+      expect.stringMatching(/irreversible.*cannot be recovered/is),
+      expect.objectContaining({ okLabel: "Use M4A" }),
+    );
+    expect(within(audioFormats).getByRole("button", { name: /^M4A \(AAC-LC, 192 kbps\)/ }))
+      .toHaveAttribute("aria-pressed", "true");
+
+    await user.click(screen.getByRole("button", { name: "Reset Audio Storage" }));
+    expect(within(audioFormats).getByRole("button", { name: /^WAV\/PCM/ }))
+      .toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("retains a persisted unavailable format without fallback", async () => {
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({ defaultDurableAudioFormat: "m4a" }),
+    );
+    mockGetExportCapabilities.mockResolvedValueOnce({
+      capabilities: {
+        platform: "desktop",
+        formats: [
+          { id: "wav", available: true, reason: null },
+          { id: "flac", available: true, reason: null },
+          { id: "mp3", available: false, reason: "MP3 encoder missing." },
+          { id: "m4a", available: false, reason: "AAC encoder missing." },
+        ],
+        destinations: [],
+        max_artifact_count: null,
+      },
+    });
+    renderApp(["/settings"]);
+
+    const savedChoice = await screen.findByRole("button", { name: /^M4A \(AAC-LC, 192 kbps\)/ });
+    await waitFor(() => expect(savedChoice).toBeDisabled());
+    expect(savedChoice).toHaveAttribute("aria-pressed", "true");
+    expect(savedChoice).toHaveTextContent("Selected · Unavailable — AAC encoder missing.");
+    expect(screen.getByRole("button", { name: /^MP3 \(192 kbps\)/ }))
+      .toHaveTextContent("Unavailable — MP3 encoder missing.");
+    expect(screen.getByText(
+      "M4A (AAC-LC, 192 kbps) is saved but unavailable on this desktop: AAC encoder missing. Choose an available format before creating new audio.",
+    )).toBeInTheDocument();
+  });
+
+  it("keeps the persisted format pressed while availability is loading", async () => {
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({ defaultDurableAudioFormat: "flac" }),
+    );
+    let resolveCapabilities: ((value: Awaited<ReturnType<typeof mockGetExportCapabilities>>) => void) | null = null;
+    mockGetExportCapabilities.mockImplementationOnce(
+      () => new Promise((resolve) => {
+        resolveCapabilities = resolve;
+      }),
+    );
+    renderApp(["/settings"]);
+
+    const group = await screen.findByRole("group", { name: "New durable audio format" });
+    expect(group).toHaveAttribute("aria-busy", "true");
+    expect(within(group).getByRole("button", { name: /^FLAC/ })).toHaveAttribute("aria-pressed", "true");
+    for (const button of within(group).getAllByRole("button")) {
+      expect(button).toBeDisabled();
+    }
+    expect(screen.getByText("Checking audio format availability…")).toHaveAttribute("aria-live", "polite");
+
+    await act(async () => {
+      resolveCapabilities?.({
+        capabilities: {
+          platform: "desktop",
+          formats: ["wav", "flac", "mp3", "m4a"].map((id) => ({ id, available: true, reason: null })),
+          destinations: [],
+          max_artifact_count: null,
+        },
+      });
+    });
+    await waitFor(() => expect(group).not.toHaveAttribute("aria-busy"));
+  });
+
+  it("disables audio choices and retry while an availability retry is fetching", async () => {
+    const user = userEvent.setup();
+    mockGetExportCapabilities.mockRejectedValueOnce(new Error("offline"));
+    renderApp(["/settings"]);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Audio format availability could not be checked. Check FFmpeg, then try again.",
+    );
+    let resolveRetry: ((value: Awaited<ReturnType<typeof mockGetExportCapabilities>>) => void) | null = null;
+    mockGetExportCapabilities.mockImplementationOnce(
+      () => new Promise((resolve) => {
+        resolveRetry = resolve;
+      }),
+    );
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    const retry = screen.getByRole("button", { name: "Retry" });
+    const group = screen.getByRole("group", { name: "New durable audio format" });
+    expect(retry).toBeDisabled();
+    expect(group).toHaveAttribute("aria-busy", "true");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    for (const choice of within(group).getAllByRole("button")) {
+      expect(choice).toBeDisabled();
+      expect(choice).toHaveTextContent("Checking availability…");
+    }
+    await user.click(retry);
+    expect(mockGetExportCapabilities).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      resolveRetry?.({
+        capabilities: {
+          platform: "desktop",
+          formats: ["wav", "flac", "mp3", "m4a"].map((id) => ({ id, available: true, reason: null })),
+          destinations: [],
+          max_artifact_count: null,
+        },
+      });
+    });
+    await waitFor(() => expect(screen.getByRole("button", { name: /^WAV\/PCM/ })).toBeEnabled());
+  });
+
+  it("hides audio storage settings when capabilities report Android", async () => {
+    mockGetExportCapabilities.mockResolvedValueOnce({
+      capabilities: {
+        platform: "android",
+        formats: [{ id: "wav", available: true, reason: null }],
+        destinations: [],
+        max_artifact_count: 1,
+      },
+    });
+    renderApp(["/settings"]);
+
+    await waitFor(() => expect(screen.queryByRole("heading", { name: "Audio Storage" })).not.toBeInTheDocument());
+    expect(screen.queryByText("New audio format")).not.toBeInTheDocument();
+    expect(screen.getByText("App-wide appearance, notation, and playback defaults.")).toBeInTheDocument();
+    expect(screen.queryByText(/audio storage/i)).not.toBeInTheDocument();
   });
 
   it("persists theme and visible UI preferences", async () => {
@@ -746,6 +929,129 @@ describe("Desktop app settings theme", () => {
     expect(screen.getAllByText("Lyrics + chords").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Advanced Chords").length).toBeGreaterThan(0);
     expect(document.documentElement.style.getPropertyValue("--color-bg-app")).toBe("#123456");
+  });
+
+  it("confirms a lossy desktop snapshot before atomically applying it", async () => {
+    const user = userEvent.setup();
+    const defaultInvoke = mockInvoke.getMockImplementation();
+    if (!defaultInvoke) throw new Error("Mock invoke implementation was not installed.");
+    const contents = settingsSnapshotContents(
+      { ...DEFAULT_PREFERENCES, defaultDurableAudioFormat: "mp3", informationDensity: "detailed" },
+      "dark",
+      { light: { "--color-bg-app": "#123456" } },
+    );
+    mockInvoke.mockImplementation(async (command: string, args?: Record<string, unknown>) =>
+      command === "read_settings_snapshot_file" ? contents : defaultInvoke(command, args));
+
+    try {
+      renderApp(["/settings"]);
+      await user.click(await screen.findByRole("button", { name: "Import Settings" }));
+
+      await waitFor(() => expect(mockInvoke).toHaveBeenCalledWith("read_settings_snapshot_file"));
+      await waitFor(() =>
+        expect(mockConfirm).toHaveBeenCalledWith(
+          expect.stringMatching(/irreversible.*cannot be recovered/is),
+          expect.objectContaining({ okLabel: "Use MP3" }),
+        ),
+      );
+      await waitFor(() => expect(document.documentElement).toHaveAttribute("data-theme", "dark"));
+      expect(screen.getByRole("button", { name: /^MP3 \(192 kbps\)/ }))
+        .toHaveAttribute("aria-pressed", "true");
+      expect(screen.getByText("Settings imported.")).toBeInTheDocument();
+    } finally {
+      mockInvoke.mockImplementation(defaultInvoke);
+    }
+  });
+
+  it("leaves theme and preferences unchanged when a lossy snapshot is declined", async () => {
+    const user = userEvent.setup();
+    const defaultInvoke = mockInvoke.getMockImplementation();
+    if (!defaultInvoke) throw new Error("Mock invoke implementation was not installed.");
+    const contents = settingsSnapshotContents(
+      { ...DEFAULT_PREFERENCES, defaultDurableAudioFormat: "m4a", informationDensity: "detailed" },
+      "dark",
+      { light: { "--color-bg-app": "#123456" } },
+    );
+    mockInvoke.mockImplementation(async (command: string, args?: Record<string, unknown>) =>
+      command === "read_settings_snapshot_file" ? contents : defaultInvoke(command, args));
+    mockConfirm.mockResolvedValueOnce(false);
+
+    try {
+      renderApp(["/settings"]);
+      await user.click(await screen.findByRole("button", { name: "Import Settings" }));
+
+      await waitFor(() => expect(mockConfirm).toHaveBeenCalled());
+      expect(screen.getByRole("button", { name: /^Follow system/ })).toHaveAttribute("aria-pressed", "true");
+      expect(screen.getByRole("button", { name: /^WAV\/PCM/ })).toHaveAttribute("aria-pressed", "true");
+      expect(screen.getByRole("button", { name: /^Minimal/ })).toHaveAttribute("aria-pressed", "true");
+      expect(document.documentElement.style.getPropertyValue("--color-bg-app")).not.toBe("#123456");
+      expect(screen.queryByText("Settings imported.")).not.toBeInTheDocument();
+    } finally {
+      mockInvoke.mockImplementation(defaultInvoke);
+    }
+  });
+
+  it("imports WAV from a v1 snapshot without a lossy confirmation", async () => {
+    const user = userEvent.setup();
+    const defaultInvoke = mockInvoke.getMockImplementation();
+    if (!defaultInvoke) throw new Error("Mock invoke implementation was not installed.");
+    const { defaultDurableAudioFormat, ...v1Preferences } = DEFAULT_PREFERENCES;
+    expect(defaultDurableAudioFormat).toBe("wav");
+    const contents = JSON.stringify({
+      exportedAt: "2026-04-18T13:16:00.000Z",
+      kind: "tuneforge.settings",
+      preferences: { ...v1Preferences, informationDensity: "detailed" },
+      themeOverrides: {},
+      themePreference: "dark",
+      version: 1,
+    });
+    mockInvoke.mockImplementation(async (command: string, args?: Record<string, unknown>) =>
+      command === "read_settings_snapshot_file" ? contents : defaultInvoke(command, args));
+
+    try {
+      renderApp(["/settings"]);
+      await user.click(await screen.findByRole("button", { name: "Import Settings" }));
+
+      await screen.findByText("Settings imported.");
+      expect(mockConfirm).not.toHaveBeenCalled();
+      expect(screen.getByRole("button", { name: /^WAV\/PCM/ })).toHaveAttribute("aria-pressed", "true");
+      expect(document.documentElement).toHaveAttribute("data-theme", "dark");
+    } finally {
+      mockInvoke.mockImplementation(defaultInvoke);
+    }
+  });
+
+  it("preserves a hidden compressed snapshot preference on Android without prompting", async () => {
+    const user = userEvent.setup();
+    const defaultInvoke = mockInvoke.getMockImplementation();
+    if (!defaultInvoke) throw new Error("Mock invoke implementation was not installed.");
+    mockGetExportCapabilities.mockResolvedValueOnce({
+      capabilities: {
+        platform: "android",
+        formats: [{ id: "wav", available: true, reason: null }],
+        destinations: [],
+        max_artifact_count: 1,
+      },
+    });
+    const contents = settingsSnapshotContents(
+      { ...DEFAULT_PREFERENCES, defaultDurableAudioFormat: "m4a" },
+      "system",
+    );
+    mockInvoke.mockImplementation(async (command: string, args?: Record<string, unknown>) =>
+      command === "read_settings_snapshot_file" ? contents : defaultInvoke(command, args));
+
+    try {
+      renderApp(["/settings"]);
+      await waitFor(() => expect(screen.queryByRole("heading", { name: "Audio Storage" })).not.toBeInTheDocument());
+      await user.click(screen.getByRole("button", { name: "Import Settings" }));
+
+      await screen.findByText("Settings imported.");
+      expect(mockConfirm).not.toHaveBeenCalled();
+      expect(JSON.parse(window.localStorage.getItem("tuneforge.ui-preferences") ?? "{}"))
+        .toMatchObject({ defaultDurableAudioFormat: "m4a" });
+    } finally {
+      mockInvoke.mockImplementation(defaultInvoke);
+    }
   });
 
   it("keeps settings snapshot cancel quiet", async () => {

--- a/apps/desktop/src/features/activity/ActivityView.tsx
+++ b/apps/desktop/src/features/activity/ActivityView.tsx
@@ -7,6 +7,12 @@ import { api, type BulkJobRequest, type BulkJobsResponse, type JobSchema, type P
 import { formatLocalDateTime, normalizeApiDateTime, parseApiDateTime } from "../../lib/datetime";
 import { useLazyLoadSentinel } from "../../lib/useLazyLoadSentinel";
 import { usePreferences } from "../../lib/preferences";
+import {
+  DURABLE_AUDIO_CAPABILITIES_QUERY_KEY,
+  durableAudioFormatLabel,
+  requireDurableAudioActionFormat,
+  type DurableAudioActionFormat,
+} from "../../lib/durableAudio";
 import { useBeatBackendActionSelection } from "../projects/hooks/useBeatBackendActionSelection";
 import { useChordBackendActionSelection } from "../projects/hooks/useChordBackendActionSelection";
 import {
@@ -78,6 +84,9 @@ const BULK_JOB_ACTIONS = [
 
 type ActivityTab = (typeof ACTIVITY_TABS)[number]["id"];
 type BulkJobAction = (typeof BULK_JOB_ACTIONS)[number];
+type BulkJobMutationAction = BulkJobAction & {
+  durableFormat?: DurableAudioActionFormat;
+};
 type BulkJobSkippedProject = BulkJobsResponse["skipped"][number];
 
 type DisplayJob = {
@@ -367,10 +376,11 @@ export function ActivityView() {
     action: BulkJobAction;
     response: BulkJobsResponse;
   } | null>(null);
+  const [bulkPreflightError, setBulkPreflightError] = useState<string | null>(null);
   const deferredSearch = useDeferredValue(searchDraft.trim());
   const previousActiveJobIds = useRef<Set<string>>(new Set());
   const queryClient = useQueryClient();
-  const { defaultStemModel } = usePreferences();
+  const { defaultDurableAudioFormat, defaultStemModel } = usePreferences();
   const { beatBackendForAction } = useBeatBackendActionSelection();
   const { chordBackendForAction } = useChordBackendActionSelection();
   const activeJobsQueryKey = useMemo(
@@ -475,7 +485,7 @@ export function ActivityView() {
     },
   });
   const bulkJobsMutation = useMutation({
-    mutationFn: async (action: BulkJobAction) => {
+    mutationFn: async (action: BulkJobMutationAction) => {
       const request: BulkJobRequest = { job_type: action.jobType };
       if (action.jobType === "analyze") {
         const beatBackendSelection = await beatBackendForAction();
@@ -490,6 +500,9 @@ export function ActivityView() {
       }
       if (action.jobType === "stems") {
         request.stem_model = defaultStemModel;
+        if (action.durableFormat?.outputFormat) {
+          request.output_format = action.durableFormat.outputFormat;
+        }
       }
       return api.bulkJobs(request);
     },
@@ -559,7 +572,28 @@ export function ActivityView() {
   async function handleBulkJobAction(action: BulkJobAction) {
     bulkJobsMutation.reset();
     setBulkJobResult(null);
-    const approved = await confirm(action.confirmBody, {
+    setBulkPreflightError(null);
+    let durableFormat: DurableAudioActionFormat | undefined;
+    try {
+      if (action.jobType === "stems") {
+        const preferredFormat = defaultDurableAudioFormat;
+        const { capabilities } = await queryClient.fetchQuery({
+          queryKey: DURABLE_AUDIO_CAPABILITIES_QUERY_KEY,
+          queryFn: api.getExportCapabilities,
+          staleTime: Infinity,
+        });
+        durableFormat = requireDurableAudioActionFormat(capabilities, preferredFormat);
+      }
+    } catch (error) {
+      setBulkPreflightError(
+        error instanceof Error ? error.message : "Could not check audio format availability.",
+      );
+      return;
+    }
+    const confirmBody = durableFormat
+      ? `${action.confirmBody} New stems will use ${durableAudioFormatLabel(durableFormat.format)}.`
+      : action.confirmBody;
+    const approved = await confirm(confirmBody, {
       title: action.confirmTitle,
       kind: "warning",
       okLabel: action.okLabel,
@@ -568,7 +602,7 @@ export function ActivityView() {
     if (!approved) {
       return;
     }
-    bulkJobsMutation.mutate(action);
+    bulkJobsMutation.mutate({ ...action, durableFormat });
   }
 
   return (
@@ -665,11 +699,11 @@ export function ActivityView() {
             </div>
           ) : null}
 
-          {bulkJobsMutation.isError ? (
+          {bulkPreflightError || bulkJobsMutation.isError ? (
             <div className="activity-jobs-panel__state activity-jobs-panel__state--error" role="alert">
-              {bulkJobsMutation.error instanceof Error
+              {bulkPreflightError ?? (bulkJobsMutation.error instanceof Error
                 ? bulkJobsMutation.error.message
-                : "Could not queue bulk jobs."}
+                : "Could not queue bulk jobs.")}
             </div>
           ) : null}
 

--- a/apps/desktop/src/features/projects/LibraryView.tsx
+++ b/apps/desktop/src/features/projects/LibraryView.tsx
@@ -6,6 +6,10 @@ import { Link, useNavigate } from "react-router-dom";
 import { api, getProjectSyncSummary, type ProjectSchema } from "../../lib/api";
 import { formatLocalDateTime, normalizeApiDateTime } from "../../lib/datetime";
 import { usePreferences } from "../../lib/preferences";
+import {
+  DURABLE_AUDIO_CAPABILITIES_QUERY_KEY,
+  requireDurableAudioActionFormat,
+} from "../../lib/durableAudio";
 import { useLazyLoadSentinel } from "../../lib/useLazyLoadSentinel";
 import { formatApiErrorMessage } from "./projectViewUtils";
 import { useBeatBackendActionSelection } from "./hooks/useBeatBackendActionSelection";
@@ -271,7 +275,7 @@ function getImportNoticeRole(importNotice: ImportNotice) {
 export function LibraryView() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { defaultStemModel, informationDensity } = usePreferences();
+  const { defaultDurableAudioFormat, defaultStemModel, informationDensity } = usePreferences();
   const { beatBackendForAction } = useBeatBackendActionSelection();
   const { chordBackendForAction } = useChordBackendActionSelection();
   const [searchDraft, setSearchDraft] = useState("");
@@ -306,6 +310,13 @@ export function LibraryView() {
 
   const importMutation = useMutation({
     mutationFn: async () => {
+      const preferredFormat = defaultDurableAudioFormat;
+      const { capabilities } = await queryClient.fetchQuery({
+        queryKey: DURABLE_AUDIO_CAPABILITIES_QUERY_KEY,
+        queryFn: api.getExportCapabilities,
+        staleTime: Infinity,
+      });
+      const durableFormat = requireDurableAudioActionFormat(capabilities, preferredFormat);
       const selection = await open({
         directory: false,
         multiple: true,
@@ -329,6 +340,7 @@ export function LibraryView() {
       const backendSelection = await chordBackendForAction();
       const importPayload = {
         copy_into_project: true,
+        ...(durableFormat.outputFormat ? { output_format: durableFormat.outputFormat } : {}),
         beat_backend: beatBackendSelection.beat_backend,
         chord_backend: backendSelection.backend,
         stem_model: defaultStemModel,

--- a/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
+++ b/apps/desktop/src/features/projects/hooks/useProjectViewModel.ts
@@ -13,6 +13,10 @@ import {
 } from "../../../lib/api";
 import { usePreferences } from "../../../lib/preferences";
 import {
+  DURABLE_AUDIO_CAPABILITIES_QUERY_KEY,
+  requireDurableAudioActionFormat,
+} from "../../../lib/durableAudio";
+import {
   normalizeAnalysisTimingGrid,
   normalizeLoopAlignmentMode,
   snapLoopPointToTiming,
@@ -302,6 +306,7 @@ export function useProjectViewModel() {
     defaultLyricsFollowEnabled,
     defaultProjectWorkspace,
     defaultSourcesRailCollapsed,
+    defaultDurableAudioFormat,
     defaultStemModel,
     enharmonicDisplayMode,
     informationDensity,
@@ -629,12 +634,20 @@ export function useProjectViewModel() {
         throw new Error("Choose a tuning or key change first.");
       }
 
+      const preferredFormat = defaultDurableAudioFormat;
+      const { capabilities } = await queryClient.fetchQuery({
+        queryKey: DURABLE_AUDIO_CAPABILITIES_QUERY_KEY,
+        queryFn: api.getExportCapabilities,
+        staleTime: Infinity,
+      });
+      const durableFormat = requireDurableAudioActionFormat(capabilities, preferredFormat);
+
       pendingPreviewSelection.current = {
         previousLatestPreviewArtifactId: latestPreviewArtifact?.id ?? null,
       };
 
       return api.createPreview(projectId, {
-        output_format: "wav",
+        ...(durableFormat.outputFormat ? { output_format: durableFormat.outputFormat } : {}),
         retune:
           retuneMode === "reference"
             ? { target_reference_hz: Number(referenceHz) }
@@ -661,11 +674,18 @@ export function useProjectViewModel() {
       if (!selectedPrimaryArtifactId) {
         throw new Error("Select source audio or practice mix first.");
       }
+      const preferredFormat = defaultDurableAudioFormat;
+      const { capabilities } = await queryClient.fetchQuery({
+        queryKey: DURABLE_AUDIO_CAPABILITIES_QUERY_KEY,
+        queryFn: api.getExportCapabilities,
+        staleTime: Infinity,
+      });
+      const durableFormat = requireDurableAudioActionFormat(capabilities, preferredFormat);
       const backendSelection = await chordBackendForAction();
       return api.createStems(projectId, {
         mode: "stems",
         stem_model: defaultStemModel,
-        output_format: "wav",
+        ...(durableFormat.outputFormat ? { output_format: durableFormat.outputFormat } : {}),
         chord_backend: backendSelection.backend,
         chord_backend_fallback_from: backendSelection.backend_fallback_from,
         force: hasVisibleStems,

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState, useSyncExternalStore } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
+import { confirm } from "@tauri-apps/plugin-dialog";
 import { api, type BeatBackendSchema, type ChordBackendSchema, type StemModelSchema } from "../../lib/api";
 import { FRONTEND_VERSION_INFO } from "../../lib/buildInfo";
+import { DURABLE_AUDIO_CAPABILITIES_QUERY_KEY } from "../../lib/durableAudio";
 import {
   getPlaybackDiagnosticsVersion,
   readPlaybackLiveDiagnostics,
@@ -53,6 +55,12 @@ import {
   type ProjectWorkspaceMode,
   type TunerVisualMode,
 } from "../../lib/preferences";
+import {
+  DURABLE_AUDIO_FORMAT_PROFILES,
+  durableAudioFormatIsLossy,
+  durableAudioFormatLabel,
+  type DurableAudioFormat,
+} from "../../lib/durableAudio";
 import {
   parseSettingsSnapshot,
   readSettingsSnapshotFile,
@@ -274,6 +282,37 @@ const fallbackStemModelOptions: ChoiceOption<DefaultStemModel>[] = [
     description: "Separate vocals and a single instrumental track.",
   },
 ];
+
+function durableAudioFormatOptions(
+  formats: Awaited<ReturnType<typeof api.getExportCapabilities>>["capabilities"]["formats"] | undefined,
+  fetching: boolean,
+  error: boolean,
+  selected: DurableAudioFormat,
+): ChoiceOption<DurableAudioFormat>[] {
+  return DURABLE_AUDIO_FORMAT_PROFILES.map((profile) => {
+    const capability = formats?.find((format) => format.id === profile.value);
+    let status: string;
+    if (fetching || formats === undefined) {
+      status = "Checking availability…";
+    } else if (error) {
+      status = "Availability could not be checked";
+    } else if (capability?.available) {
+      status = profile.value === "wav"
+        ? "Available · Lossless · Default"
+        : `Available · ${profile.lossy ? "Lossy" : "Lossless"}`;
+    } else {
+      const unavailable = `Unavailable — ${capability?.reason || "Not reported by backend"}`;
+      status = profile.value === selected ? `Selected · ${unavailable}` : unavailable;
+    }
+    return {
+      value: profile.value,
+      label: profile.label,
+      description: profile.description,
+      disabled: fetching || error || capability?.available !== true,
+      status,
+    };
+  });
+}
 
 function themePreferenceLabel(themePreference: ThemePreference) {
   if (themePreference === "system") {
@@ -570,12 +609,14 @@ function stemModelOptions(models: StemModelSchema[] | undefined): ChoiceOption<D
 }
 
 function ChoiceGroup<T extends string>({
+  ariaBusy,
   description,
   legend,
   onChange,
   options,
   value,
 }: {
+  ariaBusy?: boolean;
   description: string;
   legend: string;
   onChange: (value: T) => void;
@@ -583,7 +624,7 @@ function ChoiceGroup<T extends string>({
   value: T | null;
 }) {
   return (
-    <fieldset className="settings-fieldset">
+    <fieldset aria-busy={ariaBusy || undefined} className="settings-fieldset">
       <legend>{legend}</legend>
       <p className="setting-copy">{description}</p>
       <div className="settings-choice-grid">
@@ -653,6 +694,7 @@ export function SettingsView() {
     defaultBeatAnalysisBackend,
     defaultChordBackend,
     defaultStemModel,
+    defaultDurableAudioFormat,
     defaultLyricsFollowEnabled,
     defaultChordsFollowEnabled,
     defaultTunerInputDeviceId,
@@ -666,6 +708,7 @@ export function SettingsView() {
     setDefaultBeatAnalysisBackend,
     setDefaultChordBackend,
     setDefaultStemModel,
+    setDefaultDurableAudioFormat,
     setDefaultLyricsFollowEnabled,
     setDefaultChordsFollowEnabled,
     setDefaultTunerInputDeviceId,
@@ -674,6 +717,7 @@ export function SettingsView() {
     resetAppearancePreferences,
     resetNotationPreferences,
     resetAnalysisPreferences,
+    resetAudioStoragePreferences,
     resetTunerPreferences,
     resetVisibilityPreferences,
     resetPreferences,
@@ -681,9 +725,11 @@ export function SettingsView() {
   } = usePreferences();
   const [isSnapshotBusy, setIsSnapshotBusy] = useState(false);
   const [snapshotStatus, setSnapshotStatus] = useState<SnapshotStatus | null>(null);
+  const [availabilityRetrying, setAvailabilityRetrying] = useState(false);
   const [isNativeValidationBusy, setIsNativeValidationBusy] = useState(false);
   const [nativeValidationStatus, setNativeValidationStatus] = useState<SnapshotStatus | null>(null);
   const webAudioForced = isWebAudioBackendForced();
+  const androidRuntime = isAndroidRuntime();
   useSyncExternalStore(
     subscribePlaybackDiagnostics,
     getPlaybackDiagnosticsVersion,
@@ -717,6 +763,12 @@ export function SettingsView() {
   const stemModelsQuery = useQuery({
     queryKey: ["stem-models"],
     queryFn: api.listStemModels,
+  });
+  const exportCapabilitiesQuery = useQuery({
+    enabled: !androidRuntime,
+    queryKey: DURABLE_AUDIO_CAPABILITIES_QUERY_KEY,
+    queryFn: api.getExportCapabilities,
+    staleTime: Infinity,
   });
   const nativeAudioQuery = useQuery({
     queryKey: ["native-audio-capabilities"],
@@ -763,6 +815,15 @@ export function SettingsView() {
     chordAvailabilityResolved,
   );
   const stemModelChoices = stemModelOptions(stemModelsQuery.data?.models);
+  const durableAudioChoices = durableAudioFormatOptions(
+    exportCapabilitiesQuery.data?.capabilities.formats,
+    exportCapabilitiesQuery.isFetching,
+    exportCapabilitiesQuery.isError,
+    defaultDurableAudioFormat,
+  );
+  const androidSettings =
+    androidRuntime || exportCapabilitiesQuery.data?.capabilities.platform === "android";
+  const showAudioStoragePanel = !androidSettings;
   const beatFallbackNotice = fallbackNotice(
     defaultBeatAnalysisBackend,
     effectiveBeatAnalysisBackend,
@@ -800,6 +861,37 @@ export function SettingsView() {
     resetAnalysisPreferences();
   }
 
+  function handleResetAudioStorage() {
+    resetAudioStoragePreferences();
+  }
+
+  async function confirmLossyDurableAudioFormat(format: DurableAudioFormat) {
+    if (durableAudioFormatIsLossy(format)) {
+      const label = durableAudioFormatLabel(format);
+      const shortLabel = format === "mp3" ? "MP3" : "M4A";
+      const approved = await confirm(
+        `${label} uses irreversible lossy compression that permanently removes audio detail. That detail cannot be recovered later. This applies only to new imports, stems, saved mixes, and bulk stem refreshes; existing files and queued work stay unchanged.`,
+        {
+          title: `Use ${label}?`,
+          kind: "warning",
+          okLabel: `Use ${shortLabel}`,
+          cancelLabel: "Cancel",
+        },
+      );
+      if (!approved) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  async function handleDurableAudioFormatChange(format: DurableAudioFormat) {
+    if (format === defaultDurableAudioFormat || !await confirmLossyDurableAudioFormat(format)) {
+      return;
+    }
+    setDefaultDurableAudioFormat(format);
+  }
+
   function handleResetTunerDefaults() {
     resetTunerPreferences();
   }
@@ -823,6 +915,7 @@ export function SettingsView() {
           defaultChordBackend,
           defaultLoopAlignmentMode,
           defaultStemModel,
+          defaultDurableAudioFormat,
           defaultInspectorOpen,
           defaultPlaybackDisplayMode,
           defaultTunerInputDeviceId,
@@ -865,6 +958,13 @@ export function SettingsView() {
       }
 
       const snapshot = parseSettingsSnapshot(contents);
+      if (
+        !androidSettings
+        && snapshot.preferences.defaultDurableAudioFormat !== defaultDurableAudioFormat
+        && !await confirmLossyDurableAudioFormat(snapshot.preferences.defaultDurableAudioFormat)
+      ) {
+        return;
+      }
 
       replaceThemeState({
         themeOverrides: snapshot.themeOverrides,
@@ -879,6 +979,18 @@ export function SettingsView() {
       });
     } finally {
       setIsSnapshotBusy(false);
+    }
+  }
+
+  async function handleRetryAudioAvailability() {
+    if (availabilityRetrying || exportCapabilitiesQuery.isFetching) {
+      return;
+    }
+    setAvailabilityRetrying(true);
+    try {
+      await exportCapabilitiesQuery.refetch();
+    } finally {
+      setAvailabilityRetrying(false);
     }
   }
 
@@ -923,7 +1035,11 @@ export function SettingsView() {
         <div className="screen__title-block">
           <p className="eyebrow">Settings</p>
           <h1>Control Room</h1>
-          <p className="screen__subtitle">App-wide appearance, notation, and playback defaults.</p>
+          <p className="screen__subtitle">
+            {androidSettings
+              ? "App-wide appearance, notation, and playback defaults."
+              : "App-wide appearance, audio storage, notation, and playback defaults."}
+          </p>
         </div>
       </div>
 
@@ -939,6 +1055,7 @@ export function SettingsView() {
             <span className="pill">Beat analysis</span>
             <span className="pill">Chord backend</span>
             <span className="pill">Stem model</span>
+            {showAudioStoragePanel ? <span className="pill">Audio storage</span> : null}
             <span className="pill">Playback defaults</span>
           </div>
         </div>
@@ -992,6 +1109,12 @@ export function SettingsView() {
             <dt>Stem model</dt>
             <dd>{stemModelLabel(defaultStemModel)}</dd>
           </div>
+          {showAudioStoragePanel ? (
+            <div className="settings-overview__stat">
+              <dt>New audio format</dt>
+              <dd>{durableAudioFormatLabel(defaultDurableAudioFormat)}</dd>
+            </div>
+          ) : null}
           <div className="settings-overview__stat">
             <dt>Tuner mic</dt>
             <dd>{tunerInputDeviceLabel(defaultTunerInputDeviceId)}</dd>
@@ -1018,6 +1141,71 @@ export function SettingsView() {
           </div>
         </dl>
       </div>
+
+      {showAudioStoragePanel ? (
+        <div className="panel settings-panel" aria-labelledby="audio-storage-title">
+          <div className="panel-heading">
+            <div>
+              <h2 id="audio-storage-title">Audio Storage</h2>
+              <p className="subpanel__copy">
+                Choose the storage format for new audio created on this desktop.
+              </p>
+            </div>
+          </div>
+
+          <ChoiceGroup
+            ariaBusy={exportCapabilitiesQuery.isFetching}
+            description="The format is captured when an action starts. Future imports, stems, saved mixes, and bulk stem refreshes use it; existing files and already queued work stay unchanged. Temporary processing audio remains WAV."
+            legend="New durable audio format"
+            onChange={(format) => void handleDurableAudioFormatChange(format)}
+            options={durableAudioChoices}
+            value={defaultDurableAudioFormat}
+          />
+
+          {exportCapabilitiesQuery.isFetching ? (
+            <p aria-live="polite" className="settings-feedback" role="status">
+              Checking audio format availability…
+            </p>
+          ) : null}
+          {exportCapabilitiesQuery.isError || availabilityRetrying ? (
+            <>
+              {!exportCapabilitiesQuery.isFetching ? (
+                <p className="settings-feedback settings-feedback--error" role="alert">
+                  Audio format availability could not be checked. Check FFmpeg, then try again.
+                </p>
+              ) : null}
+              <div className="button-row">
+                <button
+                  className="button button--ghost button--small"
+                  disabled={exportCapabilitiesQuery.isFetching}
+                  onClick={() => void handleRetryAudioAvailability()}
+                  type="button"
+                >
+                  Retry
+                </button>
+              </div>
+            </>
+          ) : null}
+
+          {exportCapabilitiesQuery.isSuccess && !exportCapabilitiesQuery.isFetching
+          && exportCapabilitiesQuery.data.capabilities.formats.find(
+            (format) => format.id === defaultDurableAudioFormat && !format.available,
+          ) ? (
+            <p className="settings-feedback settings-feedback--error" role="status">
+              {durableAudioFormatLabel(defaultDurableAudioFormat)} is saved but unavailable on this desktop:{" "}
+              {exportCapabilitiesQuery.data.capabilities.formats.find(
+                (format) => format.id === defaultDurableAudioFormat,
+              )?.reason?.replace(/\.+$/, "") || "Not reported by backend"}. Choose an available format before creating new audio.
+            </p>
+          ) : null}
+
+          <div className="button-row">
+            <button className="button button--ghost button--small" onClick={handleResetAudioStorage} type="button">
+              Reset Audio Storage
+            </button>
+          </div>
+        </div>
+      ) : null}
 
       <div className="settings-column">
         <div className="panel settings-panel">

--- a/apps/desktop/src/lib/api.mobile-sync.test.ts
+++ b/apps/desktop/src/lib/api.mobile-sync.test.ts
@@ -206,7 +206,6 @@ describe("mobile sync API adapter", () => {
     };
     const defaultRequest: ProjectImportRequest = {
       source_path: "/music/default.wav",
-      copy_into_project: true,
     };
 
     await api.importProject(builtInRequest);

--- a/apps/desktop/src/lib/durableAudio.test.ts
+++ b/apps/desktop/src/lib/durableAudio.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import type { ExportCapabilities } from "./api";
+import {
+  requireDurableAudioActionFormat,
+} from "./durableAudio";
+
+function capabilities(platform: "desktop" | "android", unavailable?: string): ExportCapabilities {
+  return {
+    platform,
+    formats: ["wav", "flac", "mp3", "m4a"].map((id) => ({
+      id,
+      available: id !== unavailable,
+      reason: id === unavailable ? "Encoder missing." : null,
+    })),
+    destinations: [],
+    max_artifact_count: null,
+  };
+}
+
+describe("durable audio capability guard", () => {
+  it("returns the selected desktop output format", () => {
+    expect(requireDurableAudioActionFormat(capabilities("desktop"), "flac")).toEqual({
+      format: "flac",
+      outputFormat: "flac",
+    });
+  });
+
+  it("blocks an unavailable desktop encoder without fallback", () => {
+    expect(() => requireDurableAudioActionFormat(capabilities("desktop", "mp3"), "mp3"))
+      .toThrow("MP3 (192 kbps) is unavailable: Encoder missing.");
+  });
+
+  it("keeps Android actions on omitted-field WAV despite a hidden compressed preference", () => {
+    expect(requireDurableAudioActionFormat(capabilities("android"), "m4a")).toEqual({
+      format: "wav",
+    });
+  });
+});

--- a/apps/desktop/src/lib/durableAudio.ts
+++ b/apps/desktop/src/lib/durableAudio.ts
@@ -1,0 +1,80 @@
+import type { ExportCapabilities, ProjectImportRequest } from "./api";
+
+export type DurableAudioFormat = NonNullable<ProjectImportRequest["output_format"]>;
+
+export type DurableAudioFormatProfile = {
+  description: string;
+  label: string;
+  lossy: boolean;
+  value: DurableAudioFormat;
+};
+
+export const DURABLE_AUDIO_FORMAT_PROFILES: readonly DurableAudioFormatProfile[] = [
+  {
+    value: "wav",
+    label: "WAV/PCM",
+    description: "Uncompressed and lossless PCM16. Largest files and broadest compatibility. Default.",
+    lossy: false,
+  },
+  {
+    value: "flac",
+    label: "FLAC",
+    description: "Lossless compressed FLAC level 5. Smaller files without quality loss.",
+    lossy: false,
+  },
+  {
+    value: "mp3",
+    label: "MP3 (192 kbps)",
+    description: "Lossy MP3 at 192 kbps. Smaller files with broad compatibility.",
+    lossy: true,
+  },
+  {
+    value: "m4a",
+    label: "M4A (AAC-LC, 192 kbps)",
+    description: "Lossy AAC-LC in M4A at 192 kbps. Smaller files with modern playback support.",
+    lossy: true,
+  },
+] as const;
+
+export const DURABLE_AUDIO_CAPABILITIES_QUERY_KEY = ["export-capabilities"] as const;
+
+export function isDurableAudioFormat(value: unknown): value is DurableAudioFormat {
+  return value === "wav" || value === "flac" || value === "mp3" || value === "m4a";
+}
+
+export function durableAudioFormatLabel(value: DurableAudioFormat) {
+  return DURABLE_AUDIO_FORMAT_PROFILES.find((profile) => profile.value === value)?.label ?? value;
+}
+
+export function durableAudioFormatIsLossy(value: DurableAudioFormat) {
+  return DURABLE_AUDIO_FORMAT_PROFILES.some((profile) => profile.value === value && profile.lossy);
+}
+
+export type DurableAudioActionFormat = {
+  format: DurableAudioFormat;
+  outputFormat?: DurableAudioFormat;
+};
+
+export function requireDurableAudioActionFormat(
+  capabilities: ExportCapabilities,
+  preferredFormat: DurableAudioFormat,
+): DurableAudioActionFormat {
+  if (capabilities.platform === "android") {
+    const wav = capabilities.formats.find((format) => format.id === "wav");
+    if (!wav?.available) {
+      throw new Error(wav?.reason || "WAV durable audio is unavailable on this device.");
+    }
+    return { format: "wav" };
+  }
+
+  const capability = capabilities.formats.find((format) => format.id === preferredFormat);
+  if (!capability?.available) {
+    const label = durableAudioFormatLabel(preferredFormat);
+    throw new Error(
+      capability?.reason
+        ? `${label} is unavailable: ${capability.reason}`
+        : `${label} is unavailable because the backend did not report encoder support.`,
+    );
+  }
+  return { format: preferredFormat, outputFormat: preferredFormat };
+}

--- a/apps/desktop/src/lib/preferences.test.tsx
+++ b/apps/desktop/src/lib/preferences.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  PreferencesProvider,
+  normalizePreferences,
+  usePreferences,
+} from "./preferences";
+
+function PreferenceProbe() {
+  const {
+    defaultDurableAudioFormat,
+    resetAudioStoragePreferences,
+    setDefaultDurableAudioFormat,
+  } = usePreferences();
+  return (
+    <>
+      <output>{defaultDurableAudioFormat}</output>
+      <button onClick={() => setDefaultDurableAudioFormat("flac")} type="button">Set FLAC</button>
+      <button onClick={resetAudioStoragePreferences} type="button">Reset audio</button>
+    </>
+  );
+}
+
+describe("durable audio preferences", () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it("normalizes missing and invalid values to WAV", () => {
+    expect(normalizePreferences({}).defaultDurableAudioFormat).toBe("wav");
+    expect(normalizePreferences({ defaultDurableAudioFormat: "ogg" }).defaultDurableAudioFormat)
+      .toBe("wav");
+    expect(normalizePreferences({ defaultDurableAudioFormat: "m4a" }).defaultDurableAudioFormat)
+      .toBe("m4a");
+  });
+
+  it("sets, persists, and resets the dedicated preference", async () => {
+    const user = userEvent.setup();
+    render(<PreferencesProvider><PreferenceProbe /></PreferencesProvider>);
+
+    await user.click(screen.getByRole("button", { name: "Set FLAC" }));
+    expect(screen.getByText("flac")).toBeInTheDocument();
+    expect(JSON.parse(window.localStorage.getItem("tuneforge.ui-preferences") ?? "{}"))
+      .toMatchObject({ defaultDurableAudioFormat: "flac" });
+
+    await user.click(screen.getByRole("button", { name: "Reset audio" }));
+    expect(screen.getByText("wav")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/lib/preferences.tsx
+++ b/apps/desktop/src/lib/preferences.tsx
@@ -13,6 +13,10 @@ import {
   normalizeLoopAlignmentMode,
   type LoopAlignmentMode,
 } from "./timingGrid";
+import {
+  isDurableAudioFormat,
+  type DurableAudioFormat,
+} from "./durableAudio";
 
 export type InformationDensity = "minimal" | "balanced" | "detailed";
 export type ProjectWorkspaceMode = "project" | "playback";
@@ -39,6 +43,7 @@ export type UiPreferences = {
   defaultBeatAnalysisBackend: DefaultBeatAnalysisBackend;
   defaultChordBackend: DefaultChordBackend;
   defaultStemModel: DefaultStemModel;
+  defaultDurableAudioFormat: DurableAudioFormat;
   defaultLyricsFollowEnabled: boolean;
   defaultChordsFollowEnabled: boolean;
   defaultTunerInputDeviceId: string | null;
@@ -52,6 +57,7 @@ export type AnalysisPreferences = Pick<
   UiPreferences,
   "defaultBeatAnalysisBackend" | "defaultChordBackend" | "defaultStemModel"
 >;
+export type AudioStoragePreferences = Pick<UiPreferences, "defaultDurableAudioFormat">;
 export type TunerPreferences = Pick<
   UiPreferences,
   "defaultTunerInputDeviceId" | "defaultTunerReferenceHz" | "defaultTunerVisualMode"
@@ -78,6 +84,7 @@ type PreferencesContextValue = UiPreferences & {
   setDefaultBeatAnalysisBackend: (value: DefaultBeatAnalysisBackend) => void;
   setDefaultChordBackend: (value: DefaultChordBackend) => void;
   setDefaultStemModel: (value: DefaultStemModel) => void;
+  setDefaultDurableAudioFormat: (value: DurableAudioFormat) => void;
   setDefaultLyricsFollowEnabled: (value: boolean) => void;
   setDefaultChordsFollowEnabled: (value: boolean) => void;
   setDefaultTunerInputDeviceId: (value: string | null) => void;
@@ -87,6 +94,7 @@ type PreferencesContextValue = UiPreferences & {
   resetAppearancePreferences: () => void;
   resetNotationPreferences: () => void;
   resetAnalysisPreferences: () => void;
+  resetAudioStoragePreferences: () => void;
   resetTunerPreferences: () => void;
   resetVisibilityPreferences: () => void;
   resetPreferences: () => void;
@@ -106,6 +114,10 @@ export const DEFAULT_ANALYSIS_PREFERENCES: AnalysisPreferences = {
   defaultBeatAnalysisBackend: "beat-this",
   defaultChordBackend: "crema-advanced",
   defaultStemModel: "htdemucs_6s",
+};
+
+export const DEFAULT_AUDIO_STORAGE_PREFERENCES: AudioStoragePreferences = {
+  defaultDurableAudioFormat: "wav",
 };
 
 export const DEFAULT_TUNER_PREFERENCES: TunerPreferences = {
@@ -128,6 +140,7 @@ export const DEFAULT_PREFERENCES: UiPreferences = {
   ...DEFAULT_APPEARANCE_PREFERENCES,
   ...DEFAULT_NOTATION_PREFERENCES,
   ...DEFAULT_ANALYSIS_PREFERENCES,
+  ...DEFAULT_AUDIO_STORAGE_PREFERENCES,
   ...DEFAULT_TUNER_PREFERENCES,
   ...DEFAULT_VISIBILITY_PREFERENCES,
 };
@@ -232,6 +245,9 @@ export function normalizePreferences(value: unknown): UiPreferences {
     defaultStemModel: isDefaultStemModel(candidate.defaultStemModel)
       ? candidate.defaultStemModel
       : DEFAULT_PREFERENCES.defaultStemModel,
+    defaultDurableAudioFormat: isDurableAudioFormat(candidate.defaultDurableAudioFormat)
+      ? candidate.defaultDurableAudioFormat
+      : DEFAULT_PREFERENCES.defaultDurableAudioFormat,
     defaultTunerInputDeviceId: normalizeTunerInputDeviceId(candidate.defaultTunerInputDeviceId),
     defaultTunerReferenceHz: normalizeTunerReferenceHz(candidate.defaultTunerReferenceHz),
     defaultTunerVisualMode: isTunerVisualMode(candidate.defaultTunerVisualMode)
@@ -318,6 +334,9 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
       setDefaultStemModel: (defaultStemModel) => {
         setPreferences((current) => mergePreferences(current, { defaultStemModel }));
       },
+      setDefaultDurableAudioFormat: (defaultDurableAudioFormat) => {
+        setPreferences((current) => mergePreferences(current, { defaultDurableAudioFormat }));
+      },
       setDefaultLyricsFollowEnabled: (defaultLyricsFollowEnabled) => {
         setPreferences((current) => mergePreferences(current, { defaultLyricsFollowEnabled }));
       },
@@ -354,6 +373,9 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
       },
       resetAnalysisPreferences: () => {
         setPreferences((current) => mergePreferences(current, DEFAULT_ANALYSIS_PREFERENCES));
+      },
+      resetAudioStoragePreferences: () => {
+        setPreferences((current) => mergePreferences(current, DEFAULT_AUDIO_STORAGE_PREFERENCES));
       },
       resetTunerPreferences: () => {
         setPreferences((current) => mergePreferences(current, DEFAULT_TUNER_PREFERENCES));

--- a/apps/desktop/src/lib/settingsSnapshot.test.ts
+++ b/apps/desktop/src/lib/settingsSnapshot.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_PREFERENCES } from "./preferences";
+import {
+  SETTINGS_SNAPSHOT_KIND,
+  buildSettingsSnapshot,
+  parseSettingsSnapshot,
+} from "./settingsSnapshot";
+
+const exportedAt = "2026-08-21T12:00:00.000Z";
+
+function snapshot(version: number, preferences: Record<string, unknown>) {
+  return JSON.stringify({
+    exportedAt,
+    kind: SETTINGS_SNAPSHOT_KIND,
+    preferences,
+    themeOverrides: {},
+    themePreference: "system",
+    version,
+  });
+}
+
+describe("settings snapshot durable audio migration", () => {
+  it("writes v2 with the durable audio preference", () => {
+    expect(buildSettingsSnapshot({
+      exportedAt,
+      preferences: { ...DEFAULT_PREFERENCES, defaultDurableAudioFormat: "flac" },
+      themeOverrides: {},
+      themePreference: "system",
+    })).toMatchObject({
+      version: 2,
+      preferences: { defaultDurableAudioFormat: "flac" },
+    });
+  });
+
+  it("parses v1 by injecting WAV", () => {
+    const { defaultDurableAudioFormat, ...v1Preferences } = DEFAULT_PREFERENCES;
+    expect(defaultDurableAudioFormat).toBe("wav");
+    expect(parseSettingsSnapshot(snapshot(1, v1Preferences)).preferences.defaultDurableAudioFormat)
+      .toBe("wav");
+  });
+
+  it("rejects a bad v2 durable format", () => {
+    expect(() => parseSettingsSnapshot(snapshot(2, {
+      ...DEFAULT_PREFERENCES,
+      defaultDurableAudioFormat: "ogg",
+    }))).toThrow("Unsupported settings file.");
+  });
+});

--- a/apps/desktop/src/lib/settingsSnapshot.ts
+++ b/apps/desktop/src/lib/settingsSnapshot.ts
@@ -13,7 +13,7 @@ import {
 import { isThemeVariableName, type ThemeOverrides } from "./themeTokens";
 
 export const SETTINGS_SNAPSHOT_KIND = "tuneforge.settings";
-export const SETTINGS_SNAPSHOT_VERSION = 1;
+export const SETTINGS_SNAPSHOT_VERSION = 2;
 const SETTINGS_PARSE_ERROR = "Could not parse the settings file.";
 const SETTINGS_UNSUPPORTED_ERROR = "Unsupported settings file.";
 const REQUIRED_PREFERENCE_KEYS = [
@@ -27,6 +27,7 @@ const REQUIRED_PREFERENCE_KEYS = [
   "defaultBeatAnalysisBackend",
   "defaultChordBackend",
   "defaultStemModel",
+  "defaultDurableAudioFormat",
   "defaultLyricsFollowEnabled",
   "defaultChordsFollowEnabled",
   "defaultTunerInputDeviceId",
@@ -83,14 +84,17 @@ function requireSupported(condition: boolean): asserts condition {
   }
 }
 
-function validateExportedAt(value: unknown) {
+function validateExportedAt(value: unknown): asserts value is string {
   requireSupported(typeof value === "string" && value.trim().length > 0);
   requireSupported(Number.isFinite(Date.parse(value)));
 }
 
-function validatePreferences(value: unknown): UiPreferences {
+function validatePreferences(value: unknown, version: 1 | 2): UiPreferences {
   requireSupported(isRecord(value));
   for (const key of REQUIRED_PREFERENCE_KEYS) {
+    if (version === 1 && key === "defaultDurableAudioFormat") {
+      continue;
+    }
     requireSupported(hasOwn(value, key));
   }
   requireSupported(isOneOf(value.informationDensity, ["minimal", "balanced", "detailed"]));
@@ -103,6 +107,9 @@ function validatePreferences(value: unknown): UiPreferences {
   requireSupported(isOneOf(value.defaultBeatAnalysisBackend, ["built-in", "beat-this"]));
   requireSupported(isOneOf(value.defaultChordBackend, ["tuneforge-fast", "crema-advanced"]));
   requireSupported(isOneOf(value.defaultStemModel, ["htdemucs_6s", "htdemucs_ft"]));
+  if (version === 2) {
+    requireSupported(isOneOf(value.defaultDurableAudioFormat, ["wav", "flac", "mp3", "m4a"]));
+  }
   requireSupported(typeof value.defaultLyricsFollowEnabled === "boolean");
   requireSupported(typeof value.defaultChordsFollowEnabled === "boolean");
   requireSupported(value.defaultTunerInputDeviceId === null || typeof value.defaultTunerInputDeviceId === "string");
@@ -113,7 +120,9 @@ function validatePreferences(value: unknown): UiPreferences {
       value.defaultTunerReferenceHz <= MAX_TUNER_REFERENCE_HZ,
   );
   requireSupported(isOneOf(value.defaultTunerVisualMode, ["simple", "wide-arc"]));
-  return normalizePreferences(value);
+  return normalizePreferences(
+    version === 1 ? { ...value, defaultDurableAudioFormat: "wav" } : value,
+  );
 }
 
 function validateThemeOverrides(value: unknown): ThemeOverrides {
@@ -146,10 +155,11 @@ export function parseSettingsSnapshot(text: string): SettingsSnapshot {
     throw new Error(SETTINGS_PARSE_ERROR);
   }
 
-  const candidate = parsed as Partial<SettingsSnapshot>;
+  const candidate = parsed;
+  const version = candidate.version;
   if (
     candidate.kind !== SETTINGS_SNAPSHOT_KIND ||
-    candidate.version !== SETTINGS_SNAPSHOT_VERSION
+    (version !== 1 && version !== SETTINGS_SNAPSHOT_VERSION)
   ) {
     throw new Error(SETTINGS_UNSUPPORTED_ERROR);
   }
@@ -158,7 +168,7 @@ export function parseSettingsSnapshot(text: string): SettingsSnapshot {
 
   return buildSettingsSnapshot({
     exportedAt: candidate.exportedAt,
-    preferences: validatePreferences(candidate.preferences),
+    preferences: validatePreferences(candidate.preferences, version),
     themeOverrides: validateThemeOverrides(candidate.themeOverrides),
     themePreference: validateThemePreference(candidate.themePreference),
   });

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -84,8 +84,9 @@ Mobile does not bundle FFmpeg. Android uses platform media APIs instead.
 - Import keeps the original file inside app storage.
 - WAV/PCM can be read directly for CPU analysis and basic chord detection.
 - Compressed audio should decode through Android media APIs before waveform or ML processing.
-- Durable app-owned audio is planned to follow the shared WAV/FLAC storage preference; Android
-  platform codecs remain runtime and export capabilities rather than a separate canonical format.
+- Android receives and preserves app-owned PCM16 WAV, FLAC, MP3, and AAC-LC M4A audio. Platform
+  decoding remains a runtime capability; mobile does not expose the desktop storage preference or
+  add an encoder.
 - Desktop currently keeps WAV intermediates and `wav`/`mp3`/`flac` exports through host-installed FFmpeg.
 - Unsupported mobile export formats stay unavailable until a native encoder path exists.
 
@@ -113,19 +114,22 @@ If provider readback is unsupported, the job completes as unverified and no rece
 or mismatched readback fails the job and creates no receipt. Cancellation and app restart also create
 no receipt or automatic retry; a partial provider file may remain after an interrupted write.
 
-The planned durable-storage direction does not preserve the desktop original import as a separate
-canonical file. WAV remains the default, with FLAC as an optional preference for each new durable
-source, stem, saved mix, or other durable audio artifact. The preference is captured when an action
-or job starts; later changes affect future artifacts only. Existing files stay unchanged, so mixed
-WAV/FLAC libraries and mixed-format projects must remain readable. A later explicit background job
-may transcode existing durable files without rerunning analysis, stems, lyrics, chords, beats, or
-other model pipelines.
+Desktop does not preserve the original import as a separate canonical file. WAV/PCM remains the
+default; Settings can choose WAV/PCM, FLAC, MP3 at 192 kbps, or AAC-LC M4A at 192 kbps for each new
+durable source, stem set, saved mix, or bulk stem refresh. The choice is captured before the action
+starts. Later changes affect future artifacts only, existing and queued work remains unchanged, and
+temporary processing audio remains WAV. Mixed-format libraries and projects remain readable. MP3
+and M4A require an explicit irreversible-quality confirmation. A later explicit background job may
+transcode existing durable files without rerunning analysis, stems, lyrics, chords, beats, or other
+model pipelines.
 
-Sync preserves the format received from the sender instead of applying the receiving peer's local
-preference. The planned WAV/FLAC work must widen current backend and Android source validation to
-accept matching media formats and suffixes in both directions. It assumes all peers run the latest
-TuneForge and does not add version negotiation, compatibility transcoding, or a sync protocol
-redesign.
+Sync preserves the format received from the sender instead of applying a receiving preference.
+Android accepts exact `wav`/`.wav`, `flac`/`.flac`, `mp3`/`.mp3`, and `m4a`/`.m4a` pairs for sources,
+practice mixes, and stems. It verifies size and SHA-256, then performs a bounded container, codec,
+and first-packet readability probe before database commit. Received bytes are not transcoded or
+proxied, and project/artifact identity, format, path, hash, size, metadata, and manifest version are
+preserved. All peers are assumed to run the latest TuneForge; there is no version negotiation,
+compatibility transcode, or sync protocol redesign.
 
 ## Desktop vs Mobile Persistence Parity
 

--- a/docs/NATIVE_AUDIO.md
+++ b/docs/NATIVE_AUDIO.md
@@ -25,6 +25,10 @@ boundary.
   API 26 or newer. Tuner monitoring remains unsupported.
 - Android Web Audio fallback and forced-Web-Audio playback use a private seekable loopback
   transport so Chromium can request complete byte ranges without exposing arbitrary file paths.
+- Synced Android source, practice-mix, and stem artifacts accept PCM16 WAV, FLAC, MP3, and AAC-LC
+  M4A. Receive validation checks the declared suffix, container, codec, and a bounded first decoded
+  packet before commit without decoding the full file. Playback and the private range transport use
+  the preserved bytes; TuneForge does not create a receiver-side transcode or playback proxy.
 
 ## Backend Selection
 
@@ -157,6 +161,8 @@ Settings to reset or export the sanitized recorder. These diagnostics observe th
 path; they do not run an automated playback matrix, control an output device, measure audible output,
 or produce a performance verdict. Release-build, output-device, Linux, and Android measurements
 remain manual handoffs and must not be reported as a runtime PASS from the exported counters alone.
+Automated Android receive/probe and loopback MIME/range tests likewise do not prove physical-device
+codec availability, audible output, latency, or long-session behavior.
 
 Android microphone permission is requested only from a tuner start or retry. TuneForge distinguishes
 the initial prompt, an in-progress prompt, denial, permanent blocking, the Android microphone privacy

--- a/scripts/capture-release-media.mjs
+++ b/scripts/capture-release-media.mjs
@@ -122,9 +122,10 @@ const releaseMediaCaptureCatalog = [
     kind: "screenshot",
     fileName: "settings.png",
     title: "Settings screen",
-    caption: "Local processing and practice preferences in the TuneForge control room.",
-    alt: "TuneForge settings control room",
+    caption: "Choose WAV, FLAC, MP3, or M4A storage for future local audio alongside practice defaults.",
+    alt: "TuneForge Settings showing Audio Storage choices for WAV, FLAC, MP3, and M4A",
     fixture: "release-showcase-v1",
+    viewport: { width: 1920, height: 1280 },
     route: "/settings",
     prepare: noPreparation,
     ready: readySettings,
@@ -1587,6 +1588,43 @@ async function readyJobs({ page, timeoutMs }) {
 
 async function readySettings({ page, timeoutMs }) {
   await page.getByRole("heading", { name: "Control Room" }).waitFor({ timeout: timeoutMs });
+  await page.getByRole("heading", { name: "Audio Storage" }).waitFor({ timeout: timeoutMs });
+  const formats = page.getByRole("group", { name: "New durable audio format" });
+  const expectedFormats = [
+    ["WAV/PCM", "Available · Lossless · Default"],
+    ["FLAC", "Available · Lossless"],
+    ["MP3 (192 kbps)", "Available · Lossy"],
+    ["M4A (AAC-LC, 192 kbps)", "Available · Lossy"],
+  ];
+  for (const [label, status] of expectedFormats) {
+    const choice = formats.getByRole("button").filter({ hasText: label });
+    await choice.waitFor({ timeout: timeoutMs });
+    await choice.getByText(status, { exact: true }).waitFor({ timeout: timeoutMs });
+    if (await choice.isDisabled()) {
+      throw new Error(`Settings release media requires ${label} available.`);
+    }
+  }
+  const wav = formats.getByRole("button", { name: /^WAV\/PCM/ });
+  if (await wav.getAttribute("aria-pressed") !== "true") {
+    throw new Error("Settings release media requires WAV/PCM selected.");
+  }
+  if (await formats.getAttribute("aria-busy") === "true") {
+    throw new Error("Settings release media requires resolved audio availability.");
+  }
+  const panel = page.locator('[aria-labelledby="audio-storage-title"]');
+  await panel.scrollIntoViewIfNeeded();
+  const panelBounds = await panel.boundingBox();
+  const viewport = page.viewportSize();
+  if (
+    !panelBounds
+    || !viewport
+    || panelBounds.x < 0
+    || panelBounds.y < 0
+    || panelBounds.x + panelBounds.width > viewport.width
+    || panelBounds.y + panelBounds.height > viewport.height
+  ) {
+    throw new Error("Settings release media requires the full Audio Storage panel in frame.");
+  }
 }
 
 async function recordOverviewVideo({ appUrl, catalog, entry, options, page }) {

--- a/scripts/diagnostics-smoke.mjs
+++ b/scripts/diagnostics-smoke.mjs
@@ -141,6 +141,16 @@ async function installApiFixtures(page) {
       if (importCount === 2) return respond(route, 200, { project: PROJECT });
       return respond(route, 503, dependencyError("FFmpeg is required for import. stderr: RAW_STDERR_DIAGNOSTICS_CANARY"));
     }
+    if (path === "/api/v1/export-capabilities") {
+      return respond(route, 200, {
+        capabilities: {
+          platform: "desktop",
+          formats: ["wav", "flac", "mp3", "m4a"].map((id) => ({ id, available: true, reason: null })),
+          destinations: [],
+          max_artifact_count: null,
+        },
+      });
+    }
     if (path === "/api/v1/health") return respond(route, 200, { status: "ok" });
     if (path === "/api/v1/projects") return respond(route, 200, { projects: [PROJECT], total: 1, limit: 50, offset: 0, has_more: false });
     if (path === `/api/v1/projects/${PROJECT_ID}`) return respond(route, 200, { project: PROJECT });


### PR DESCRIPTION
## Summary

- Add a desktop Audio Storage preference for WAV, FLAC, MP3, and M4A with capability handling and lossy-format warnings.
- Capture the selected format for future imports, stems, saved mixes, and bulk stem refreshes without rewriting existing audio.
- Allow Android to validate, preserve, sync, and play received four-format durable artifacts without adding mobile encoding or reprocessing.
- Update mobile and native-audio documentation plus the existing Settings release-media capture.
- Closes #398

## Testing

- `pnpm contracts:generate`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — desktop 808, Tauri 359, backend 726 passed.
- `pnpm --filter @tuneforge/desktop test:e2e -- --ci`
- `cd apps/desktop/src-tauri && cargo check --locked`
- Manually created and played mixed FLAC, WAV, and M4A source, saved-mix, and stem families; exercised primary and stem switching, mute/solo, seek, loop, tempo changes, and native fallback retry.
- Physical Android first-sync and playback remain unverified and require isolated-device testing.
