### PR TITLE
fix: gate release media capture in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       backend_static: ${{ steps.scope.outputs.backend_static }}
       backend_ffmpeg: ${{ steps.scope.outputs.backend_ffmpeg }}
       desktop: ${{ steps.scope.outputs.desktop }}
+      release_media: ${{ steps.scope.outputs.release_media }}
       site: ${{ steps.scope.outputs.site }}
     steps:
       - name: Check out code
@@ -35,6 +36,7 @@ jobs:
           backend_static=false
           backend_ffmpeg=false
           desktop=false
+          release_media=false
           site=false
           full_gate=false
           changed_files="${RUNNER_TEMP}/changed-files.txt"
@@ -57,6 +59,7 @@ jobs:
               case "${path}" in
                 scripts/capture-release-media.mjs|scripts/check-release-version.mjs)
                   site=true
+                  release_media=true
                   ;;
                 scripts/package-options*|scripts/flatpak-options*|scripts/desktop-e2e*|scripts/sync-validation*|scripts/setup-dev*)
                   ;;
@@ -65,6 +68,7 @@ jobs:
                   ;;
                 package.json|pnpm-lock.yaml|pnpm-workspace.yaml)
                   site=true
+                  release_media=true
                   ;;
                 apps/backend/pyproject.toml|apps/backend/uv.lock)
                   backend_static=true
@@ -83,7 +87,12 @@ jobs:
                   ;;
                 packages/shared-types/AGENTS.md)
                   ;;
-                apps/desktop/*|packages/shared-types/*)
+                apps/desktop/*)
+                  desktop=true
+                  site=true
+                  release_media=true
+                  ;;
+                packages/shared-types/*)
                   desktop=true
                   ;;
                 apps/site/*|.github/workflows/pages.yml)
@@ -105,6 +114,7 @@ jobs:
             backend_static=true
             backend_ffmpeg=true
             desktop=true
+            release_media=true
             site=true
           fi
 
@@ -129,6 +139,7 @@ jobs:
             echo "backend_static=${backend_static}"
             echo "backend_ffmpeg=${backend_ffmpeg}"
             echo "desktop=${desktop}"
+            echo "release_media=${release_media}"
             echo "site=${site}"
           } >> "${GITHUB_OUTPUT}"
 
@@ -221,7 +232,7 @@ jobs:
           node-version: "26"
 
       - name: Test deterministic Node scripts
-        run: node --test scripts/build-info.test.mjs scripts/package-options.test.mjs scripts/flatpak-options.test.mjs scripts/flatpak-pnpm.test.mjs scripts/desktop-e2e.test.mjs scripts/sync-validation.test.mjs scripts/release-license-inventory.test.mjs scripts/capture-release-media.test.mjs scripts/ci-image-policy.test.mjs
+        run: node --test scripts/build-info.test.mjs scripts/package-options.test.mjs scripts/flatpak-options.test.mjs scripts/flatpak-pnpm.test.mjs scripts/desktop-e2e.test.mjs scripts/sync-validation.test.mjs scripts/release-license-inventory.test.mjs scripts/capture-release-media.test.mjs scripts/ci-image-policy.test.mjs scripts/ci-scope-policy.test.mjs
 
       - name: Check release script syntax
         run: |
@@ -437,6 +448,14 @@ jobs:
       - name: Test site
         if: needs.ci-scope.outputs.site == 'true'
         run: pnpm --filter @tuneforge/site test
+
+      - name: Install Chromium for release media
+        if: needs.ci-scope.outputs.release_media == 'true'
+        run: pnpm --filter @tuneforge/desktop exec playwright install --with-deps chromium
+
+      - name: Capture release media
+        if: needs.ci-scope.outputs.release_media == 'true'
+        run: node scripts/capture-release-media.mjs --run
 
       - name: Build site
         if: needs.ci-scope.outputs.site == 'true'

--- a/scripts/capture-release-media.mjs
+++ b/scripts/capture-release-media.mjs
@@ -1613,8 +1613,16 @@ async function readySettings({ page, timeoutMs }) {
   }
   const panel = page.locator('[aria-labelledby="audio-storage-title"]');
   await panel.scrollIntoViewIfNeeded();
-  const panelBounds = await panel.boundingBox();
   const viewport = page.viewportSize();
+  const initialPanelBounds = await panel.boundingBox();
+  const scrollDelta = overflowToScrollDelta(
+    initialPanelBounds?.y + initialPanelBounds?.height,
+    viewport?.height,
+  );
+  if (scrollDelta > 0) {
+    await panel.evaluate((element, delta) => element.closest(".main-content").scrollBy(0, delta), scrollDelta);
+  }
+  const panelBounds = await panel.boundingBox();
   if (
     !panelBounds
     || !viewport
@@ -1625,6 +1633,10 @@ async function readySettings({ page, timeoutMs }) {
   ) {
     throw new Error("Settings release media requires the full Audio Storage panel in frame.");
   }
+}
+
+function overflowToScrollDelta(panelBottom, viewportHeight) {
+  return Math.max(0, Math.ceil(panelBottom - viewportHeight));
 }
 
 async function recordOverviewVideo({ appUrl, catalog, entry, options, page }) {
@@ -2369,6 +2381,7 @@ export {
   expectedCatalogEntries,
   manifestItemForCatalogEntry,
   measureMobilePlaybackFollowLayouts,
+  overflowToScrollDelta,
   parseOptions,
   releaseMediaCaptureCatalog,
   validateReleaseMediaCatalog,

--- a/scripts/capture-release-media.test.mjs
+++ b/scripts/capture-release-media.test.mjs
@@ -9,6 +9,7 @@ import {
   chordBackends,
   expectedCatalogEntries,
   manifestItemForCatalogEntry,
+  overflowToScrollDelta,
   parseOptions,
   releaseMediaCaptureCatalog,
   validateReleaseMediaCatalog,
@@ -29,6 +30,12 @@ test("capture motion policy freezes screenshots and preserves video movement", (
   assert.deepEqual(captureMotionPolicy("screenshot"), { animatePlayback: false });
   assert.deepEqual(captureMotionPolicy("video"), { animatePlayback: true });
   assert.throws(() => captureMotionPolicy("unknown"), /Unsupported capture kind unknown/);
+});
+
+test("settings scroll delta rounds bottom overflow up to whole pixels", () => {
+  assert.equal(overflowToScrollDelta(980, 980), 0);
+  assert.equal(overflowToScrollDelta(980.15625, 980), 1);
+  assert.equal(overflowToScrollDelta(983, 980), 3);
 });
 
 test("release-media catalog has unique identifiers, files, and required callbacks", () => {

--- a/scripts/ci-scope-policy.test.mjs
+++ b/scripts/ci-scope-policy.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const workflow = readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
+
+function caseArm(pattern) {
+  const match = workflow.match(new RegExp(`${pattern}[\\s\\S]*?\\n\\s*;;`));
+  assert.ok(match, `Missing CI scope case arm: ${pattern}`);
+  return match[0];
+}
+
+test("release-media CI scope captures desktop-affecting changes without widening site-only checks", () => {
+  assert.match(workflow, /release_media: \$\{\{ steps\.scope\.outputs\.release_media \}\}/);
+  assert.match(workflow, /release_media=false/);
+  assert.match(workflow, /echo "release_media=\$\{release_media\}"/);
+  const captureScript = caseArm(String.raw`scripts/capture-release-media\.mjs\|scripts/check-release-version\.mjs\)`);
+  const dependencies = caseArm(String.raw`package\.json\|pnpm-lock\.yaml\|pnpm-workspace\.yaml\)`);
+  const desktop = caseArm(String.raw`apps/desktop/\*\)`);
+  const sharedTypes = caseArm(String.raw`packages/shared-types/\*\)`);
+  const siteOnly = caseArm(String.raw`apps/site/\*\|\.github/workflows/pages\.yml\)`);
+  for (const arm of [captureScript, dependencies]) {
+    assert.match(arm, /site=true/);
+    assert.match(arm, /release_media=true/);
+  }
+  assert.match(desktop, /desktop=true/);
+  assert.match(desktop, /site=true/);
+  assert.match(desktop, /release_media=true/);
+  assert.match(sharedTypes, /desktop=true/);
+  assert.doesNotMatch(sharedTypes, /site=true|release_media=true/);
+  assert.match(siteOnly, /site=true/);
+  assert.doesNotMatch(siteOnly, /release_media=true/);
+  const fullGateStart = workflow.indexOf('if [[ "${full_gate}" == "true" ]]; then');
+  const fullGateEnd = workflow.indexOf("\n          fi", fullGateStart);
+  assert.ok(fullGateStart >= 0 && fullGateEnd >= 0, "Missing full-gate scope block.");
+  assert.match(workflow.slice(fullGateStart, fullGateEnd), /release_media=true/);
+
+  const siteJob = workflow.slice(workflow.indexOf("  site:\n"), workflow.indexOf("\n  backend:"));
+  const installIndex = siteJob.indexOf("playwright install --with-deps chromium");
+  const captureIndex = siteJob.indexOf("node scripts/capture-release-media.mjs --run");
+  const buildIndex = siteJob.indexOf("pnpm --filter @tuneforge/site build");
+  assert.match(siteJob, /Install Chromium for release media\n        if: needs\.ci-scope\.outputs\.release_media == 'true'/);
+  assert.match(siteJob, /Capture release media\n        if: needs\.ci-scope\.outputs\.release_media == 'true'/);
+  assert.ok(installIndex >= 0 && installIndex < captureIndex && captureIndex < buildIndex);
+  assert.doesNotMatch(siteJob, /capture-release-media\.mjs --run.*--(?:allow-partial|no-video)/);
+});


### PR DESCRIPTION
## Summary

- fix fractional Settings release-media clipping without weakening full-panel validation
- run full release-media capture in the existing site CI job for desktop and capture-affecting changes
- add focused regression coverage for capture scrolling and CI scope policy

## Testing

- `node --test scripts/capture-release-media.test.mjs scripts/ci-scope-policy.test.mjs` (15/15 passed)
- `pnpm lint` (passed)
- `pnpm typecheck` (passed)
- `node scripts/capture-release-media.mjs --run` (passed; 8 screenshots plus overview video and poster inspected)
- `pnpm --filter @tuneforge/site typecheck` (passed)
- `pnpm --filter @tuneforge/site test` (6/6 passed)
- `pnpm --filter @tuneforge/site build` (passed)
- `pnpm test` (one Tauri loopback test failed after 358 passes; exact retry passed 1/1)
- `cd apps/backend && uv run --python 3.11 pytest` (started with isolated data, then stopped before completion to publish CI sooner)
