### PR TITLE
fix: apply repeated Android sync mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ download, installation, verification, signature, and publication instructions.
 
 ### Fixed
 
+- Applied repeat desktop-to-Android sync changes to existing project metadata and artifacts.
 - Preserved project playback safely across native output route changes and interruptions by using
   a guarded Web Audio fallback at the current position.
 

--- a/apps/desktop/src-tauri/src/mobile_backend/manifests.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/manifests.rs
@@ -1,6 +1,7 @@
 use super::storage_cleanup::{
-    capture_owned_project_file, cleanup_owned_project_files, prepare_owned_project_file,
-    project_storage_mutation_guard, require_owned_project_file,
+    capture_owned_project_file, cleanup_owned_project_files, move_owned_project_file,
+    prepare_owned_project_file, project_storage_mutation_guard, require_owned_project_file,
+    OwnedProjectFile,
 };
 use super::*;
 use crate::native_audio::decode::probe_mobile_durable_audio;
@@ -663,6 +664,95 @@ fn hydrate_lyrics_revision(
     Ok(())
 }
 
+fn apply_project_metadata_revision_state(
+    project: &mut ProjectSchema,
+    revision: &SyncProjectManifestEntityRevisionSchema,
+) -> Result<(), String> {
+    let payload = &revision.payload;
+    if payload
+        .get("project_id")
+        .and_then(Value::as_str)
+        .is_some_and(|project_id| project_id != revision.project_id)
+    {
+        return Err("Project metadata revision belongs to a different project.".to_string());
+    }
+    let display_name = match payload.get("display_name") {
+        Some(Value::String(value)) if !value.trim().is_empty() => value.trim().to_string(),
+        Some(_) => {
+            return Err(
+                "Project metadata revision display_name must be a non-empty string.".to_string(),
+            )
+        }
+        None => project.display_name.clone(),
+    };
+    let source_key_override = match payload.get("source_key_override") {
+        Some(Value::String(value)) => Some(value.clone()),
+        Some(Value::Null) => None,
+        Some(_) => {
+            return Err(
+                "Project metadata revision source_key_override must be a string or null."
+                    .to_string(),
+            )
+        }
+        None => project.source_key_override.clone(),
+    };
+    if let Some(value) = payload.get("source_sha256") {
+        let source_sha256 = value.as_str().ok_or_else(|| {
+            "Project metadata revision source_sha256 must be a string.".to_string()
+        })?;
+        validate_project_source_identity(&revision.project_id, Some(source_sha256))?;
+        if project.source_sha256.as_deref() != Some(source_sha256) {
+            return Err("Project metadata revision conflicts with the project source.".to_string());
+        }
+    }
+    let duration_seconds = match payload.get("duration_seconds") {
+        Some(Value::Null) => None,
+        Some(value) => Some(value.as_f64().ok_or_else(|| {
+            "Project metadata revision duration_seconds must be a number or null.".to_string()
+        })?),
+        None => project.duration_seconds,
+    };
+    let integer_field = |name: &str, current: Option<i64>| -> Result<Option<i64>, String> {
+        match payload.get(name) {
+            Some(Value::Null) => Ok(None),
+            Some(value) => value.as_i64().map(Some).ok_or_else(|| {
+                format!("Project metadata revision {name} must be an integer or null.")
+            }),
+            None => Ok(current),
+        }
+    };
+    project.display_name = display_name;
+    project.source_key_override = source_key_override;
+    project.duration_seconds = duration_seconds;
+    project.sample_rate = integer_field("sample_rate", project.sample_rate)?;
+    project.channels = integer_field("channels", project.channels)?;
+    project.updated_at = normalize_sync_timestamp_utc(&revision.updated_at, "revision updated_at")?;
+    Ok(())
+}
+
+fn hydrate_project_metadata_revision(
+    connection: &Connection,
+    revision: &SyncProjectManifestEntityRevisionSchema,
+) -> Result<(), String> {
+    let mut project = get_project_schema(connection, &revision.project_id)?;
+    apply_project_metadata_revision_state(&mut project, revision)?;
+    connection
+        .execute(
+            "UPDATE projects SET display_name = ?1, source_key_override = ?2, duration_seconds = ?3, sample_rate = ?4, channels = ?5, updated_at = ?6 WHERE id = ?7",
+            params![
+                project.display_name,
+                project.source_key_override,
+                project.duration_seconds,
+                project.sample_rate,
+                project.channels,
+                project.updated_at,
+                revision.project_id,
+            ],
+        )
+        .map_err(|error| error.to_string())?;
+    Ok(())
+}
+
 pub(super) fn hydrate_imported_read_models(
     connection: &Connection,
     project_id: &str,
@@ -670,6 +760,31 @@ pub(super) fn hydrate_imported_read_models(
     let project = get_project_schema(connection, project_id)?;
     if project.sync_status == "deleted" {
         return Ok(());
+    }
+    let project_metadata_revisions = {
+        let mut statement = connection
+            .prepare(
+                &format!(
+                    "SELECT {SYNC_ENTITY_REVISION_COLUMNS} FROM sync_entity_revisions WHERE project_id = ?1 AND state IN ('active', 'current') AND entity_type = 'project_metadata' ORDER BY created_at ASC, id ASC"
+                ),
+            )
+            .map_err(|error| error.to_string())?;
+        let revisions = statement
+            .query_map(params![project_id], row_entity_revision)
+            .map_err(|error| error.to_string())?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| error.to_string())?;
+        revisions
+    };
+    match project_metadata_revisions.as_slice() {
+        [] => {}
+        [revision] => hydrate_project_metadata_revision(connection, revision)?,
+        _ => {
+            return Err(
+                "Project manifest contains multiple current project_metadata revisions."
+                    .to_string(),
+            )
+        }
     }
     let mut statement = connection
         .prepare(
@@ -764,7 +879,188 @@ struct PreparedManifestArtifact {
     manifest: SyncProjectManifestArtifactSchema,
     destination_path: PathBuf,
     existing: Option<ArtifactSchema>,
-    staged_path: Option<PathBuf>,
+    merge: ManifestArtifactMerge,
+    copy_source_path: Option<PathBuf>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ManifestArtifactMerge {
+    Insert,
+    Update,
+    Replace,
+    KeepLocal,
+}
+
+pub(super) fn manifest_artifact_merge(
+    connection: &Connection,
+    artifact: &SyncProjectManifestArtifactSchema,
+) -> Result<(ManifestArtifactMerge, Option<ArtifactSchema>), String> {
+    let existing = connection
+        .query_row(
+            &format!("SELECT {ARTIFACT_COLUMNS} FROM artifacts WHERE id = ?1"),
+            params![artifact.artifact_id],
+            row_artifact,
+        )
+        .optional()
+        .map_err(|error| error.to_string())?;
+    let Some(existing_artifact) = existing else {
+        return Ok((ManifestArtifactMerge::Insert, None));
+    };
+    if existing_artifact.project_id != artifact.project_id {
+        return Err("A synced artifact conflicts with an existing local artifact.".to_string());
+    }
+    if existing_artifact.content_sha256.as_deref() == Some(&artifact.content_sha256) {
+        if existing_artifact.size_bytes != artifact.size_bytes {
+            return Err("A synced artifact conflicts with an existing local artifact.".to_string());
+        }
+        return Ok((ManifestArtifactMerge::Update, Some(existing_artifact)));
+    }
+    if existing_artifact.r#type.trim().to_ascii_lowercase()
+        != artifact.r#type.trim().to_ascii_lowercase()
+        || existing_artifact
+            .r#type
+            .trim()
+            .eq_ignore_ascii_case("analysis_json")
+        || !existing_artifact.can_regenerate
+        || !artifact.can_regenerate
+    {
+        return Err("A synced artifact conflicts with an existing local artifact.".to_string());
+    }
+    let local_created_at =
+        parse_sync_timestamp_utc(&existing_artifact.created_at, "local artifact created_at")?;
+    let remote_created_at = parse_sync_timestamp_utc(&artifact.created_at, "artifact created_at")?;
+    let merge = if remote_created_at > local_created_at {
+        ManifestArtifactMerge::Replace
+    } else {
+        ManifestArtifactMerge::KeepLocal
+    };
+    Ok((merge, Some(existing_artifact)))
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ProjectManifestMismatch {
+    ProjectCore,
+    ArtifactMissing,
+    ArtifactReplacement,
+    ArtifactMetadata,
+    RevisionMissing,
+    RevisionMetadata,
+}
+
+pub(super) fn project_manifest_mismatch(
+    connection: &Connection,
+    root: &Path,
+    manifest: &SyncProjectManifestSchema,
+) -> Result<Option<ProjectManifestMismatch>, String> {
+    let project = get_project_schema(connection, &manifest.project.project_id)?;
+    let mut expected = project.clone();
+    expected.display_name = manifest.project.display_name.clone();
+    expected.source_key_override = manifest.project.source_key_override.clone();
+    expected.source_sha256 = Some(manifest.project.source_sha256.clone());
+    expected.duration_seconds = manifest.project.duration_seconds;
+    expected.sample_rate = manifest.project.sample_rate;
+    expected.channels = manifest.project.channels;
+    expected.updated_at =
+        normalize_sync_timestamp_utc(&manifest.project.updated_at, "manifest project updated_at")?;
+    let mut current_metadata = {
+        let mut statement = connection
+            .prepare(&format!(
+                "SELECT {SYNC_ENTITY_REVISION_COLUMNS} FROM sync_entity_revisions WHERE project_id = ?1 AND entity_type = 'project_metadata' AND state IN ('active', 'current')"
+            ))
+            .map_err(|error| error.to_string())?;
+        let revisions = statement
+            .query_map(params![manifest.project.project_id], row_entity_revision)
+            .map_err(|error| error.to_string())?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| error.to_string())?;
+        revisions
+            .into_iter()
+            .map(|revision| (revision.revision_id.clone(), revision))
+            .collect::<BTreeMap<_, _>>()
+    };
+    for revision in manifest
+        .entity_revisions
+        .iter()
+        .filter(|revision| revision.entity_type == "project_metadata")
+    {
+        if matches!(revision.state.as_str(), "active" | "current") {
+            current_metadata.insert(revision.revision_id.clone(), revision.clone());
+        } else {
+            current_metadata.remove(&revision.revision_id);
+        }
+    }
+    let current_metadata = current_metadata.into_values().collect::<Vec<_>>();
+    match current_metadata.as_slice() {
+        [] => {}
+        [revision] => apply_project_metadata_revision_state(&mut expected, revision)?,
+        _ => {
+            return Err(
+                "Project manifest contains multiple current project_metadata revisions."
+                    .to_string(),
+            )
+        }
+    }
+    if project.display_name != expected.display_name
+        || project.source_key_override != expected.source_key_override
+        || project.source_sha256 != expected.source_sha256
+        || project.duration_seconds != expected.duration_seconds
+        || project.sample_rate != expected.sample_rate
+        || project.channels != expected.channels
+        || normalize_sync_timestamp_utc(&project.created_at, "project created_at")?
+            != manifest.project.created_at
+        || normalize_sync_timestamp_utc(&project.updated_at, "project updated_at")?
+            != expected.updated_at
+    {
+        return Ok(Some(ProjectManifestMismatch::ProjectCore));
+    }
+    for artifact in &manifest.artifacts {
+        let (merge, existing) = manifest_artifact_merge(connection, artifact)?;
+        match merge {
+            ManifestArtifactMerge::Insert => {
+                return Ok(Some(ProjectManifestMismatch::ArtifactMissing));
+            }
+            ManifestArtifactMerge::Replace => {
+                return Ok(Some(ProjectManifestMismatch::ArtifactReplacement));
+            }
+            ManifestArtifactMerge::KeepLocal => continue,
+            ManifestArtifactMerge::Update => {}
+        }
+        let local = super::storage::manifest_artifact_from_artifact(
+            root,
+            existing.expect("update has artifact"),
+        )?;
+        let mut expected = artifact.clone();
+        expected.metadata = sanitize_sync_manifest_value(&expected.metadata);
+        if serde_json::to_value(local).map_err(|error| error.to_string())?
+            != serde_json::to_value(expected).map_err(|error| error.to_string())?
+        {
+            return Ok(Some(ProjectManifestMismatch::ArtifactMetadata));
+        }
+    }
+    for revision in &manifest.entity_revisions {
+        let local = connection
+            .query_row(
+                &format!("SELECT {SYNC_ENTITY_REVISION_COLUMNS} FROM sync_entity_revisions WHERE id = ?1"),
+                params![revision.revision_id],
+                row_entity_revision,
+            )
+            .optional()
+            .map_err(|error| error.to_string())?;
+        let Some(local) = local else {
+            return Ok(Some(ProjectManifestMismatch::RevisionMissing));
+        };
+        if local.content_sha256 != revision.content_sha256 {
+            return Err(
+                "A synced entity revision conflicts with an existing local revision.".to_string(),
+            );
+        }
+        if serde_json::to_value(local).map_err(|error| error.to_string())?
+            != serde_json::to_value(revision).map_err(|error| error.to_string())?
+        {
+            return Ok(Some(ProjectManifestMismatch::RevisionMetadata));
+        }
+    }
+    Ok(None)
 }
 
 pub(super) fn artifact_file_matches(path: &Path, content_sha256: &str, size_bytes: i64) -> bool {
@@ -775,6 +1071,52 @@ pub(super) fn artifact_file_matches(path: &Path, content_sha256: &str, size_byte
         return false;
     };
     metadata.len() as i64 == size_bytes && file_sha256(path).ok().as_deref() == Some(content_sha256)
+}
+
+pub(super) fn reusable_local_artifact_path(
+    connection: &Connection,
+    root: &Path,
+    project_id: &str,
+    content_sha256: &str,
+    size_bytes: i64,
+) -> Option<PathBuf> {
+    let project_root = project_root_path(root, project_id).ok()?;
+    let mut statement = connection
+        .prepare(&format!(
+            "SELECT {ARTIFACT_COLUMNS} FROM artifacts WHERE project_id = ?1 AND content_sha256 = ?2 AND size_bytes = ?3"
+        ))
+        .ok()?;
+    let artifacts = statement
+        .query_map(
+            params![project_id, content_sha256, size_bytes],
+            row_artifact,
+        )
+        .ok()?;
+    for artifact in artifacts.flatten() {
+        let path = PathBuf::from(artifact.path);
+        let owned = match capture_owned_project_file(root, &project_root, &path) {
+            Ok(owned) => owned,
+            Err(_) => continue,
+        };
+        if require_owned_project_file(&owned).is_ok()
+            && artifact_file_matches(&path, content_sha256, size_bytes)
+        {
+            return Some(path);
+        }
+    }
+    None
+}
+
+fn rollback_manifest_files(
+    copied: &[OwnedProjectFile],
+    installed: &[OwnedProjectFile],
+    backups: &mut Vec<(OwnedProjectFile, PathBuf)>,
+) {
+    cleanup_owned_project_files(copied);
+    cleanup_owned_project_files(installed);
+    for (backup, destination) in backups.drain(..).rev() {
+        let _ = move_owned_project_file(&backup, &destination);
+    }
 }
 
 pub(super) fn import_sync_project_manifest(
@@ -808,7 +1150,6 @@ pub(super) fn import_sync_project_manifest(
     let timestamp = now_iso();
     let existing_project = get_project_schema(connection, &project_id).ok();
     let source_artifact = manifest_source_audio_artifact(&payload.manifest)?;
-    let source_path = project_root.join(safe_relative_path(&source_artifact.relative_path)?);
     let manifest_project_created_at = normalize_sync_timestamp_utc(
         &payload.manifest.project.created_at,
         "manifest project created_at",
@@ -821,24 +1162,7 @@ pub(super) fn import_sync_project_manifest(
     let mut prepared_artifacts = Vec::new();
     for artifact in &payload.manifest.artifacts {
         let destination_path = project_root.join(safe_relative_path(&artifact.relative_path)?);
-        let existing_artifact = connection
-            .query_row(
-                &format!("SELECT {ARTIFACT_COLUMNS} FROM artifacts WHERE id = ?1"),
-                params![artifact.artifact_id],
-                row_artifact,
-            )
-            .optional()
-            .map_err(|error| error.to_string())?;
-        if let Some(existing) = &existing_artifact {
-            if existing.project_id != artifact.project_id
-                || existing.content_sha256.as_deref() != Some(artifact.content_sha256.as_str())
-                || existing.size_bytes != artifact.size_bytes
-            {
-                return Err(
-                    "A synced artifact conflicts with an existing local artifact.".to_string(),
-                );
-            }
-        }
+        let (merge, existing_artifact) = manifest_artifact_merge(connection, artifact)?;
         let has_verified_destination = artifact_file_matches(
             &destination_path,
             &artifact.content_sha256,
@@ -851,77 +1175,149 @@ pub(super) fn import_sync_project_manifest(
                 artifact.size_bytes,
             )
         });
-        let staged_path = if has_verified_destination || has_verified_existing {
-            None
-        } else {
-            Some(artifact_staged_source_path(
+        let copy_source_path =
+            if merge == ManifestArtifactMerge::KeepLocal || has_verified_destination {
+                None
+            } else if has_verified_existing {
+                existing_artifact
+                    .as_ref()
+                    .map(|existing| PathBuf::from(&existing.path))
+            } else if let Some(path) = reusable_local_artifact_path(
                 connection,
                 root,
-                artifact,
-                staging_root.as_deref(),
-                use_content_addressed_staging,
-            )?)
-        };
+                &artifact.project_id,
+                &artifact.content_sha256,
+                artifact.size_bytes,
+            ) {
+                Some(path)
+            } else {
+                Some(artifact_staged_source_path(
+                    connection,
+                    root,
+                    artifact,
+                    staging_root.as_deref(),
+                    use_content_addressed_staging,
+                )?)
+            };
         prepared_artifacts.push(PreparedManifestArtifact {
             manifest: artifact.clone(),
             destination_path,
             existing: existing_artifact,
-            staged_path,
+            merge,
+            copy_source_path,
         });
     }
+    let source_path = prepared_artifacts
+        .iter()
+        .find(|prepared| prepared.manifest.artifact_id == source_artifact.artifact_id)
+        .and_then(|prepared| {
+            (prepared.merge == ManifestArtifactMerge::KeepLocal)
+                .then(|| {
+                    prepared
+                        .existing
+                        .as_ref()
+                        .map(|artifact| PathBuf::from(&artifact.path))
+                })
+                .flatten()
+                .or_else(|| Some(prepared.destination_path.clone()))
+        })
+        .ok_or_else(|| "Project manifest source artifact was not prepared.".to_string())?;
 
     let storage_guard = project_storage_mutation_guard();
-    let mut copied_paths = Vec::new();
-    for prepared in &prepared_artifacts {
-        prepare_owned_project_file(root, &project_root, &prepared.destination_path)?;
-        let Some(staged_path) = &prepared.staged_path else {
-            continue;
-        };
-        fs::copy(staged_path, &prepared.destination_path)
-            .inspect_err(|_| cleanup_owned_project_files(&copied_paths))
-            .map_err(|error| error.to_string())?;
-        let copied = capture_owned_project_file(root, &project_root, &prepared.destination_path)?;
-        copied_paths.push(copied);
-        if !artifact_file_matches(
-            &prepared.destination_path,
-            &prepared.manifest.content_sha256,
-            prepared.manifest.size_bytes,
-        ) {
-            cleanup_owned_project_files(&copied_paths);
-            return Err("A copied artifact file does not match its manifest.".to_string());
-        }
-        if let Err(message) =
-            require_owned_project_file(copied_paths.last().expect("copied artifact was recorded"))
-        {
-            cleanup_owned_project_files(&copied_paths);
-            return Err(message);
-        }
-    }
-
-    for copied in &copied_paths {
-        if let Err(message) = require_owned_project_file(copied) {
-            cleanup_owned_project_files(&copied_paths);
-            return Err(message);
-        }
-    }
-
-    for prepared in &prepared_artifacts {
-        if prepared.staged_path.is_none() {
-            continue;
-        }
-        let Some(format) = durable_manifest_audio_format(&prepared.manifest) else {
-            continue;
-        };
-        if let Err(message) = probe_mobile_durable_audio(&prepared.destination_path, format) {
-            cleanup_owned_project_files(&copied_paths);
-            return Err(format!(
-                "Synced durable audio failed bounded {format} validation: {message}"
+    let mut copied_files = Vec::new();
+    let mut installed_files = Vec::new();
+    let mut backups = Vec::new();
+    let copy_result = (|| -> Result<(), String> {
+        for prepared in &prepared_artifacts {
+            prepare_owned_project_file(root, &project_root, &prepared.destination_path)?;
+            let Some(source_path) = &prepared.copy_source_path else {
+                continue;
+            };
+            if prepared.merge != ManifestArtifactMerge::Replace {
+                if prepared.destination_path.exists() {
+                    return Err("A synced artifact destination already exists.".to_string());
+                }
+                fs::copy(source_path, &prepared.destination_path)
+                    .map_err(|error| error.to_string())?;
+                let copied =
+                    capture_owned_project_file(root, &project_root, &prepared.destination_path)?;
+                copied_files.push(copied);
+                if !artifact_file_matches(
+                    &prepared.destination_path,
+                    &prepared.manifest.content_sha256,
+                    prepared.manifest.size_bytes,
+                ) {
+                    return Err("A copied artifact file does not match its manifest.".to_string());
+                }
+                if let Some(format) = durable_manifest_audio_format(&prepared.manifest) {
+                    probe_mobile_durable_audio(&prepared.destination_path, format).map_err(
+                        |message| {
+                            format!(
+                                "Synced durable audio failed bounded {format} validation: {message}"
+                            )
+                        },
+                    )?;
+                }
+                require_owned_project_file(copied_files.last().expect("copied file was recorded"))?;
+                continue;
+            }
+            let mut candidate_path = project_root.join(format!(
+                ".sync-incoming-{}-{}",
+                prepared.manifest.artifact_id,
+                new_id("artifact")
             ));
+            if let Some(extension) = prepared.destination_path.extension() {
+                candidate_path.set_extension(extension);
+            }
+            prepare_owned_project_file(root, &project_root, &candidate_path)?;
+            if let Err(error) = fs::copy(source_path, &candidate_path) {
+                let _ = fs::remove_file(&candidate_path);
+                return Err(error.to_string());
+            }
+            let copied = capture_owned_project_file(root, &project_root, &candidate_path)?;
+            if !artifact_file_matches(
+                &candidate_path,
+                &prepared.manifest.content_sha256,
+                prepared.manifest.size_bytes,
+            ) {
+                cleanup_owned_project_files(std::slice::from_ref(&copied));
+                return Err("A copied artifact file does not match its manifest.".to_string());
+            }
+            if let Some(format) = durable_manifest_audio_format(&prepared.manifest) {
+                probe_mobile_durable_audio(&candidate_path, format).map_err(|message| {
+                    cleanup_owned_project_files(std::slice::from_ref(&copied));
+                    format!("Synced durable audio failed bounded {format} validation: {message}")
+                })?;
+            }
+            require_owned_project_file(&copied)?;
+            if prepared.destination_path.is_file() {
+                let existing_destination =
+                    capture_owned_project_file(root, &project_root, &prepared.destination_path)?;
+                let backup_path = project_root.join(format!(
+                    ".sync-backup-{}-{}",
+                    prepared.manifest.artifact_id,
+                    new_id("artifact")
+                ));
+                let backup = move_owned_project_file(&existing_destination, &backup_path)?;
+                backups.push((backup, prepared.destination_path.clone()));
+            }
+            match move_owned_project_file(&copied, &prepared.destination_path) {
+                Ok(installed) => installed_files.push(installed),
+                Err(message) => {
+                    cleanup_owned_project_files(std::slice::from_ref(&copied));
+                    return Err(message);
+                }
+            }
         }
+        Ok(())
+    })();
+    if let Err(message) = copy_result {
+        rollback_manifest_files(&copied_files, &installed_files, &mut backups);
+        return Err(message);
     }
 
     if let Err(error) = connection.execute_batch("BEGIN IMMEDIATE") {
-        cleanup_owned_project_files(&copied_paths);
+        rollback_manifest_files(&copied_files, &installed_files, &mut backups);
         return Err(error.to_string());
     }
     let db_result = (|| -> Result<(), String> {
@@ -959,14 +1355,20 @@ pub(super) fn import_sync_project_manifest(
                             payload.manifest.project.duration_seconds,
                             payload.manifest.project.sample_rate,
                             payload.manifest.project.channels,
-                            &timestamp,
+                            &manifest_project_updated_at,
                             &project_id,
                         ],
                     )
                     .map_err(|error| error.to_string())?;
         }
 
+        for tombstone in &payload.manifest.delete_tombstones {
+            apply_delete_tombstone(connection, tombstone)?;
+        }
         for prepared in &prepared_artifacts {
+            if prepared.merge == ManifestArtifactMerge::KeepLocal {
+                continue;
+            }
             let artifact = &prepared.manifest;
             let destination_path = prepared.destination_path.to_string_lossy().into_owned();
             let metadata = sanitize_sync_manifest_value(&artifact.metadata).to_string();
@@ -1021,26 +1423,26 @@ pub(super) fn import_sync_project_manifest(
         import_entity_revisions(connection, &payload.manifest.entity_revisions)?;
         connection
                 .execute(
-                    "UPDATE projects SET sync_status = 'local', sync_status_reason = ?1, sync_required_artifact_ids_json = ?2, sync_provider_device_ids_json = ?2, sync_conflict_count = 0, sync_status_updated_at = ?3, updated_at = ?3 WHERE id = ?4",
+                    "UPDATE projects SET sync_status = 'local', sync_status_reason = ?1, sync_required_artifact_ids_json = ?2, sync_provider_device_ids_json = ?2, sync_conflict_count = 0, sync_status_updated_at = ?3 WHERE id = ?4",
                     params!["Synced from desktop.", DEFAULT_SYNC_LIST_JSON, &timestamp, &project_id],
                 )
                 .map_err(|error| error.to_string())?;
-        for tombstone in &payload.manifest.delete_tombstones {
-            apply_delete_tombstone(connection, tombstone)?;
-        }
         hydrate_imported_read_models(connection, &project_id)?;
         Ok(())
     })();
 
     if let Err(message) = db_result {
         let _ = connection.execute_batch("ROLLBACK");
-        cleanup_owned_project_files(&copied_paths);
+        rollback_manifest_files(&copied_files, &installed_files, &mut backups);
         return Err(message);
     }
     if let Err(error) = connection.execute_batch("COMMIT") {
         let _ = connection.execute_batch("ROLLBACK");
-        cleanup_owned_project_files(&copied_paths);
+        rollback_manifest_files(&copied_files, &installed_files, &mut backups);
         return Err(error.to_string());
+    }
+    for (backup, _) in &backups {
+        cleanup_owned_project_files(std::slice::from_ref(backup));
     }
     drop(storage_guard);
     reconcile_project_storage_after_commit(connection, root, &project_id);
@@ -1242,6 +1644,170 @@ mod tests {
                 params![project_id, "a".repeat(64), live_at],
             )
             .unwrap();
+    }
+
+    fn metadata_revision(
+        project_id: &str,
+        revision_id: &str,
+        state: &str,
+        display_name: &str,
+        updated_at: &str,
+    ) -> SyncProjectManifestEntityRevisionSchema {
+        SyncProjectManifestEntityRevisionSchema {
+            revision_id: revision_id.to_string(),
+            project_id: project_id.to_string(),
+            entity_type: "project_metadata".to_string(),
+            entity_id: project_id.to_string(),
+            revision_type: "metadata_change".to_string(),
+            base_revision_id: None,
+            author_device_id: "device_peer_1".to_string(),
+            source_artifact_id: None,
+            content_sha256: revision_id
+                .bytes()
+                .fold(0_u8, u8::wrapping_add)
+                .to_string()
+                .repeat(64)
+                .chars()
+                .take(64)
+                .collect(),
+            state: state.to_string(),
+            metadata: json!({}),
+            payload: json!({
+                "project_id": project_id,
+                "display_name": display_name,
+                "source_sha256": project_id.trim_start_matches(PROJECT_ID_PREFIX),
+                "duration_seconds": 2.0,
+                "sample_rate": 16_000,
+                "channels": 2,
+            }),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: updated_at.to_string(),
+        }
+    }
+
+    fn metadata_manifest(
+        project_id: &str,
+        revisions: Vec<SyncProjectManifestEntityRevisionSchema>,
+    ) -> SyncProjectManifestSchema {
+        SyncProjectManifestSchema {
+            schema_version: SYNC_PROJECT_MANIFEST_SCHEMA_VERSION.to_string(),
+            exported_at: "2026-01-02T00:00:00Z".to_string(),
+            project: SyncProjectManifestProjectSchema {
+                project_id: project_id.to_string(),
+                display_name: "Manifest name".to_string(),
+                source_key_override: None,
+                source_sha256: project_id.trim_start_matches(PROJECT_ID_PREFIX).to_string(),
+                duration_seconds: Some(1.0),
+                sample_rate: Some(8_000),
+                channels: Some(1),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                updated_at: "2026-01-02T00:00:00Z".to_string(),
+            },
+            entity_revisions: revisions,
+            artifacts: Vec::new(),
+            delete_tombstones: Vec::new(),
+        }
+    }
+
+    fn insert_manifest_project(connection: &Connection, manifest: &SyncProjectManifestSchema) {
+        migrate_mobile_db(connection).unwrap();
+        connection
+            .execute(
+                "INSERT INTO projects (id, display_name, source_key_override, source_sha256, source_path, imported_path, duration_seconds, sample_rate, channels, sync_status, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, '', '', ?5, ?6, ?7, 'local', ?8, ?9)",
+                params![
+                    manifest.project.project_id,
+                    manifest.project.display_name,
+                    manifest.project.source_key_override,
+                    manifest.project.source_sha256,
+                    manifest.project.duration_seconds,
+                    manifest.project.sample_rate,
+                    manifest.project.channels,
+                    manifest.project.created_at,
+                    manifest.project.updated_at,
+                ],
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn retained_local_current_metadata_keeps_replay_satisfied() {
+        let connection = Connection::open_in_memory().unwrap();
+        let project_id = source_hash_to_project_id(&"d".repeat(64)).unwrap();
+        let manifest = metadata_manifest(&project_id, Vec::new());
+        insert_manifest_project(&connection, &manifest);
+        let local = metadata_revision(
+            &project_id,
+            "rev_metadata_local",
+            "active",
+            "Retained local name",
+            "2026-01-03T00:00:00Z",
+        );
+        import_entity_revisions(&connection, &[local]).unwrap();
+        hydrate_imported_read_models(&connection, &project_id).unwrap();
+
+        assert!(
+            project_manifest_mismatch(&connection, Path::new(""), &manifest)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn incoming_and_retained_local_currents_return_hydration_error() {
+        let connection = Connection::open_in_memory().unwrap();
+        let project_id = source_hash_to_project_id(&"e".repeat(64)).unwrap();
+        let local = metadata_revision(
+            &project_id,
+            "rev_metadata_local",
+            "active",
+            "Local current",
+            "2026-01-03T00:00:00Z",
+        );
+        let incoming = metadata_revision(
+            &project_id,
+            "rev_metadata_incoming",
+            "current",
+            "Incoming current",
+            "2026-01-04T00:00:00Z",
+        );
+        let manifest = metadata_manifest(&project_id, vec![incoming]);
+        insert_manifest_project(&connection, &manifest);
+        import_entity_revisions(&connection, &[local]).unwrap();
+
+        assert_eq!(
+            project_manifest_mismatch(&connection, Path::new(""), &manifest).unwrap_err(),
+            "Project manifest contains multiple current project_metadata revisions."
+        );
+    }
+
+    #[test]
+    fn multiple_incoming_currents_return_hydration_error() {
+        let connection = Connection::open_in_memory().unwrap();
+        let project_id = source_hash_to_project_id(&"f".repeat(64)).unwrap();
+        let revisions = vec![
+            metadata_revision(
+                &project_id,
+                "rev_metadata_one",
+                "active",
+                "First current",
+                "2026-01-03T00:00:00Z",
+            ),
+            metadata_revision(
+                &project_id,
+                "rev_metadata_two",
+                "current",
+                "Second current",
+                "2026-01-04T00:00:00Z",
+            ),
+        ];
+        let manifest = metadata_manifest(&project_id, revisions);
+        insert_manifest_project(&connection, &manifest);
+
+        assert_eq!(
+            project_manifest_mismatch(&connection, Path::new(""), &manifest).unwrap_err(),
+            "Project manifest contains multiple current project_metadata revisions."
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/mobile_backend/reconciliation.rs
+++ b/apps/desktop/src-tauri/src/mobile_backend/reconciliation.rs
@@ -71,33 +71,21 @@ fn providers_by_hash(
 fn local_content_available(
     connection: &Connection,
     root: &Path,
+    project_id: &str,
     content_sha256: &str,
     size_bytes: i64,
 ) -> bool {
     if get_staged_artifact(connection, root, content_sha256, Some(size_bytes)).is_ok() {
         return true;
     }
-    let mut statement = match connection.prepare(&format!(
-        "SELECT {ARTIFACT_COLUMNS} FROM artifacts WHERE content_sha256 = ?1"
-    )) {
-        Ok(statement) => statement,
-        Err(_) => return false,
-    };
-    let rows = match statement.query_map(params![content_sha256], row_artifact) {
-        Ok(rows) => rows,
-        Err(_) => return false,
-    };
-    for row in rows.flatten() {
-        if row.size_bytes != size_bytes {
-            continue;
-        }
-        if Path::new(&row.path).is_file()
-            && file_sha256(Path::new(&row.path)).ok().as_deref() == Some(content_sha256)
-        {
-            return true;
-        }
-    }
-    false
+    super::manifests::reusable_local_artifact_path(
+        connection,
+        root,
+        project_id,
+        content_sha256,
+        size_bytes,
+    )
+    .is_some()
 }
 
 fn manifest_by_project_id(
@@ -114,13 +102,54 @@ fn tombstones_for_request(
     remote_library: &SyncReconciliationRemoteLibrarySchema,
     manifests: &[SyncProjectManifestSchema],
 ) -> Vec<SyncDeleteTombstoneSchema> {
-    let mut tombstones = remote_library.delete_tombstones.clone();
+    let mut tombstones = BTreeMap::new();
+    let mut candidates = remote_library.delete_tombstones.clone();
     for manifest in manifests {
         if validate_manifest_delete_tombstone_targets(manifest).is_ok() {
-            tombstones.extend(manifest.delete_tombstones.clone());
+            candidates.extend(manifest.delete_tombstones.clone());
         }
     }
-    tombstones
+    for tombstone in candidates {
+        let key = (
+            tombstone.sync_group_id.clone(),
+            normalize_tombstone_target_type(&tombstone.target_type),
+            tombstone.target_id.clone(),
+        );
+        let replace = tombstones
+            .get(&key)
+            .is_none_or(|existing: &SyncDeleteTombstoneSchema| {
+                !sync_timestamp_is_newer_or_equal(&existing.deleted_at, &tombstone.deleted_at)
+            });
+        if replace {
+            tombstones.insert(key, tombstone);
+        }
+    }
+    tombstones.into_values().collect()
+}
+
+fn local_tombstone_already_applied(
+    connection: &Connection,
+    tombstone: &SyncDeleteTombstoneSchema,
+) -> Result<bool, String> {
+    let existing_deleted_at: Option<String> = connection
+        .query_row(
+            "SELECT deleted_at FROM sync_delete_tombstones WHERE sync_group_id = ?1 AND target_type = ?2 AND target_id = ?3",
+            params![
+                tombstone.sync_group_id,
+                normalize_tombstone_target_type(&tombstone.target_type),
+                tombstone.target_id,
+            ],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|error| error.to_string())?;
+    let Some(existing_deleted_at) = existing_deleted_at else {
+        return Ok(false);
+    };
+    Ok(
+        parse_sync_timestamp_utc(&existing_deleted_at, "existing tombstone deleted_at")?
+            >= parse_sync_timestamp_utc(&tombstone.deleted_at, "tombstone deleted_at")?,
+    )
 }
 
 fn remote_projects_with_manifest_metadata(
@@ -246,10 +275,24 @@ fn plan_sync_reconciliation_parts(
             ));
             continue;
         }
-        let (item, planned_actions, tombstone_is_effective) = plan_delete_tombstone_branch(
-            &tombstone,
-            local_tombstone_superseded_by_live_target(connection, &tombstone)?,
-        );
+        let superseded = local_tombstone_superseded_by_live_target(connection, &tombstone)?;
+        if !superseded && local_tombstone_already_applied(connection, &tombstone)? {
+            add_effective_tombstone_target(&mut effective_tombstone_targets, &tombstone);
+            items.push(reconciliation_item(
+                &normalize_tombstone_target_type(&tombstone.target_type),
+                &tombstone.target_id,
+                Some(tombstone.project_id.clone()),
+                "noop",
+                Some(ACTION_NOOP),
+                None,
+                None,
+                "Delete tombstone is already applied locally.",
+                json!({"tombstone_id": tombstone.tombstone_id}),
+            ));
+            continue;
+        }
+        let (item, planned_actions, tombstone_is_effective) =
+            plan_delete_tombstone_branch(&tombstone, superseded);
         if tombstone_is_effective {
             add_effective_tombstone_target(&mut effective_tombstone_targets, &tombstone);
         }
@@ -287,7 +330,13 @@ fn plan_sync_reconciliation_parts(
                 );
                 continue;
             }
-            if local_project.sync_status == DEFAULT_SYNC_STATUS {
+        }
+
+        let Some(manifest) = manifests_by_project.get(&project.project_id) else {
+            if local_project
+                .as_ref()
+                .is_some_and(|project| project.sync_status == DEFAULT_SYNC_STATUS)
+            {
                 items.push(reconciliation_item(
                     "project",
                     &project.project_id,
@@ -296,14 +345,11 @@ fn plan_sync_reconciliation_parts(
                     Some(ACTION_NOOP),
                     project.source_sha256.clone(),
                     None,
-                    "Project already exists locally.",
+                    "Project already exists locally and no manifest changes were supplied.",
                     json!({}),
                 ));
                 continue;
             }
-        }
-
-        let Some(manifest) = manifests_by_project.get(&project.project_id) else {
             let reason = "Project manifest is required before import.";
             items.push(reconciliation_item(
                 "project",
@@ -373,12 +419,73 @@ fn plan_sync_reconciliation_parts(
             continue;
         }
 
+        if local_project
+            .as_ref()
+            .is_some_and(|project| project.sync_status == DEFAULT_SYNC_STATUS)
+        {
+            match super::manifests::project_manifest_mismatch(connection, root, manifest) {
+                Ok(None) => {
+                    items.push(reconciliation_item(
+                        "project",
+                        &project.project_id,
+                        Some(project.project_id.clone()),
+                        "noop",
+                        Some(ACTION_NOOP),
+                        project.source_sha256.clone(),
+                        None,
+                        "Project manifest is already satisfied locally.",
+                        json!({}),
+                    ));
+                    continue;
+                }
+                Ok(Some(_)) => {}
+                Err(message) => {
+                    add_conflict(
+                        &mut items,
+                        &mut actions,
+                        "project",
+                        &project.project_id,
+                        Some(project.project_id.clone()),
+                        project.source_sha256.clone(),
+                        &message,
+                        json!({}),
+                    );
+                    continue;
+                }
+            }
+        }
+
         let mut artifact_providers = BTreeMap::new();
         let mut missing_provider_artifacts = Vec::new();
+        let mut artifact_conflict = false;
         for artifact in &manifest.artifacts {
+            let requires_remote_content =
+                match super::manifests::manifest_artifact_merge(connection, artifact) {
+                    Ok((super::manifests::ManifestArtifactMerge::Insert, _))
+                    | Ok((super::manifests::ManifestArtifactMerge::Replace, _)) => true,
+                    Ok(_) => false,
+                    Err(message) => {
+                        artifact_conflict = true;
+                        add_conflict(
+                            &mut items,
+                            &mut actions,
+                            "artifact",
+                            &artifact.artifact_id,
+                            Some(project.project_id.clone()),
+                            Some(artifact.content_sha256.clone()),
+                            &message,
+                            json!({}),
+                        );
+                        false
+                    }
+                };
+            if !requires_remote_content {
+                continue;
+            }
             if local_content_available(
                 connection,
                 root,
+                &artifact.project_id,
                 &artifact.content_sha256,
                 artifact.size_bytes,
             ) {
@@ -389,6 +496,10 @@ fn plan_sync_reconciliation_parts(
             } else {
                 missing_provider_artifacts.push(artifact.artifact_id.clone());
             }
+        }
+
+        if artifact_conflict {
+            continue;
         }
 
         if !missing_provider_artifacts.is_empty() {
@@ -472,9 +583,17 @@ fn plan_sync_reconciliation_parts(
             }),
         ));
         for artifact in &manifest.artifacts {
+            if !matches!(
+                super::manifests::manifest_artifact_merge(connection, artifact),
+                Ok((super::manifests::ManifestArtifactMerge::Insert, _))
+                    | Ok((super::manifests::ManifestArtifactMerge::Replace, _))
+            ) {
+                continue;
+            }
             if local_content_available(
                 connection,
                 root,
+                &artifact.project_id,
                 &artifact.content_sha256,
                 artifact.size_bytes,
             ) {
@@ -1011,7 +1130,154 @@ mod tests {
     use super::*;
     use rusqlite::{params, Connection};
     use serde_json::json;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
+
+    fn synthetic_root(slug: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "tuneforge-mobile-reconcile-{slug}-{}-{}",
+            std::process::id(),
+            new_id("test")
+        ));
+        fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    fn staged_wav(connection: &Connection, root: &Path, name: &str, phase: f32) -> (String, i64) {
+        let path = root.join("fixtures").join(format!("{name}.wav"));
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        write_mono_pcm_wav(
+            &path,
+            &crate::native_audio::decode::DecodedAudio {
+                samples: (0..800)
+                    .map(|index| ((index as f32 * 0.12 + phase).sin() * 0.2).clamp(-1.0, 1.0))
+                    .collect(),
+                sample_rate: 8_000,
+                channels: 1,
+            },
+        )
+        .unwrap();
+        let hash = file_sha256(&path).unwrap();
+        let size = fs::metadata(&path).unwrap().len() as i64;
+        super::storage::stage_sync_artifact(
+            connection,
+            root,
+            SyncArtifactStagingRequest {
+                source_path: path.to_string_lossy().into_owned(),
+                content_sha256: hash.clone(),
+                size_bytes: size,
+                provider_device_id: Some("device_peer_1".to_string()),
+                metadata: json!({}),
+            },
+        )
+        .unwrap();
+        (hash, size)
+    }
+
+    fn manifest_artifact(
+        project_id: &str,
+        id: &str,
+        artifact_type: &str,
+        relative_path: &str,
+        content_sha256: &str,
+        size_bytes: i64,
+        can_regenerate: bool,
+        created_at: &str,
+    ) -> SyncProjectManifestArtifactSchema {
+        SyncProjectManifestArtifactSchema {
+            artifact_id: id.to_string(),
+            project_id: project_id.to_string(),
+            r#type: artifact_type.to_string(),
+            format: "wav".to_string(),
+            relative_path: relative_path.to_string(),
+            content_sha256: content_sha256.to_string(),
+            size_bytes,
+            generated_by: "synthetic-test".to_string(),
+            can_delete: artifact_type != "source_audio",
+            can_regenerate,
+            cache_key: None,
+            metadata: json!({"fixture": id}),
+            created_at: created_at.to_string(),
+        }
+    }
+
+    fn metadata_revision(
+        project_id: &str,
+        id: &str,
+        state: &str,
+        name: &str,
+        key: Option<&str>,
+        timestamp: &str,
+    ) -> SyncProjectManifestEntityRevisionSchema {
+        SyncProjectManifestEntityRevisionSchema {
+            revision_id: id.to_string(),
+            project_id: project_id.to_string(),
+            entity_type: "project_metadata".to_string(),
+            entity_id: project_id.to_string(),
+            revision_type: "metadata_change".to_string(),
+            base_revision_id: None,
+            author_device_id: "device_peer_1".to_string(),
+            source_artifact_id: None,
+            content_sha256: if id.ends_with("2") { "2" } else { "1" }.repeat(64),
+            state: state.to_string(),
+            metadata: json!({}),
+            payload: json!({
+                "project_id": project_id,
+                "display_name": name,
+                "source_key_override": key,
+                "source_sha256": project_id.trim_start_matches(PROJECT_ID_PREFIX),
+                "duration_seconds": 0.1,
+                "sample_rate": 8000,
+                "channels": 1,
+            }),
+            created_at: timestamp.to_string(),
+            updated_at: timestamp.to_string(),
+        }
+    }
+
+    fn desktop_wire_manifest(manifest: SyncProjectManifestSchema) -> SyncProjectManifestSchema {
+        serde_json::from_value(serde_json::to_value(manifest).unwrap()).unwrap()
+    }
+
+    fn apply_manifest(
+        connection: &Connection,
+        root: &Path,
+        manifest: SyncProjectManifestSchema,
+    ) -> (
+        SyncReconciliationPlanResponse,
+        SyncReconciliationApplySummarySchema,
+        Vec<SyncReconciliationApplyActionResultSchema>,
+    ) {
+        let payload = SyncReconciliationApplyRequest {
+            remote_library: SyncReconciliationRemoteLibrarySchema {
+                projects: Vec::new(),
+                artifacts: Vec::new(),
+                entity_revisions: Vec::new(),
+                delete_tombstones: Vec::new(),
+            },
+            project_manifests: vec![manifest],
+            peer_inventory: Vec::new(),
+            staging_root: None,
+            use_content_addressed_staging: true,
+            project_ids: Vec::new(),
+            include_timing_evidence: false,
+        };
+        let plan = plan_sync_reconciliation_parts(
+            connection,
+            root,
+            &payload.remote_library,
+            &payload.project_manifests,
+            &payload.peer_inventory,
+        )
+        .unwrap();
+        let results = plan
+            .actions
+            .iter()
+            .cloned()
+            .map(|action| apply_reconciliation_action(connection, root, action, &payload))
+            .collect::<Vec<_>>();
+        let summary = summarize_apply_results(plan.actions.len(), &results);
+        (plan, summary, results)
+    }
 
     fn insert_trusted_peer(connection: &Connection, device_id: &str) -> String {
         migrate_mobile_db(connection).unwrap();
@@ -1079,5 +1345,369 @@ mod tests {
         assert!(!plan.actions.iter().any(|action| {
             action.action_type == ACTION_APPLY_DELETE_TOMBSTONE && action.item_id == project_id
         }));
+    }
+
+    #[test]
+    fn repeat_sync_merges_existing_project_artifacts_tombstones_and_replays_noop() {
+        let root = synthetic_root("repeat");
+        let connection = Connection::open_in_memory().unwrap();
+        let sync_group_id = insert_trusted_peer(&connection, "device_peer_1");
+        let (source_hash, source_size) = staged_wav(&connection, &root, "source", 0.0);
+        let (mix_hash, mix_size) = staged_wav(&connection, &root, "mix-old", 0.4);
+        let (stem_hash, stem_size) = staged_wav(&connection, &root, "stem-old", 0.8);
+        let (replacement_hash, replacement_size) = staged_wav(&connection, &root, "mix-new", 1.2);
+        let (new_mix_hash, new_mix_size) = staged_wav(&connection, &root, "mix-added", 1.6);
+        let project_id = source_hash_to_project_id(&source_hash).unwrap();
+        let created = "2026-01-01T00:00:00Z";
+        let initial_updated = "2026-01-02T00:00:00Z";
+        let source = manifest_artifact(
+            &project_id,
+            "art_source",
+            "source_audio",
+            "source/source.wav",
+            &source_hash,
+            source_size,
+            false,
+            created,
+        );
+        let old_mix = manifest_artifact(
+            &project_id,
+            "art_mix",
+            "preview_mix",
+            "previews/saved.wav",
+            &mix_hash,
+            mix_size,
+            true,
+            initial_updated,
+        );
+        let old_stem = manifest_artifact(
+            &project_id,
+            "art_stem_old",
+            "vocal_stem",
+            "stems/old/vocals.wav",
+            &stem_hash,
+            stem_size,
+            true,
+            initial_updated,
+        );
+        let reusable_replacement = manifest_artifact(
+            &project_id,
+            "art_reuse_replace",
+            "preview_mix",
+            "previews/reuse-replace.wav",
+            &replacement_hash,
+            replacement_size,
+            true,
+            initial_updated,
+        );
+        let reusable_insert = manifest_artifact(
+            &project_id,
+            "art_reuse_insert",
+            "preview_mix",
+            "previews/reuse-insert.wav",
+            &new_mix_hash,
+            new_mix_size,
+            true,
+            initial_updated,
+        );
+        let initial = SyncProjectManifestSchema {
+            schema_version: SYNC_PROJECT_MANIFEST_SCHEMA_VERSION.to_string(),
+            exported_at: initial_updated.to_string(),
+            project: SyncProjectManifestProjectSchema {
+                project_id: project_id.clone(),
+                display_name: "Initial name".to_string(),
+                source_key_override: None,
+                source_sha256: source_hash.clone(),
+                duration_seconds: Some(0.1),
+                sample_rate: Some(8_000),
+                channels: Some(1),
+                created_at: created.to_string(),
+                updated_at: initial_updated.to_string(),
+            },
+            entity_revisions: vec![metadata_revision(
+                &project_id,
+                "rev_metadata_1",
+                "active",
+                "Initial name",
+                None,
+                initial_updated,
+            )],
+            artifacts: vec![
+                source.clone(),
+                old_mix.clone(),
+                old_stem.clone(),
+                reusable_replacement,
+                reusable_insert,
+            ],
+            delete_tombstones: Vec::new(),
+        };
+        let (_, first_summary, first_results) = apply_manifest(&connection, &root, initial);
+        assert_eq!(
+            first_summary.applied_actions,
+            1,
+            "{:?}",
+            first_results
+                .iter()
+                .map(|result| result.reason.as_deref())
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(first_summary.failed_actions, 0);
+        for (hash, size) in [
+            (&replacement_hash, replacement_size),
+            (&new_mix_hash, new_mix_size),
+        ] {
+            let staged = get_staged_artifact(&connection, &root, hash, Some(size)).unwrap();
+            let staged_path =
+                super::storage::staged_artifact_path(&root, &staged.relative_path).unwrap();
+            fs::remove_file(staged_path).unwrap();
+            connection
+                .execute(
+                    "DELETE FROM sync_staged_artifacts WHERE content_sha256 = ?1",
+                    params![hash],
+                )
+                .unwrap();
+            assert!(get_staged_artifact(&connection, &root, hash, Some(size)).is_err());
+        }
+
+        let changed_at = "2026-01-03T00:00:00Z";
+        let metadata_updated = "2026-01-03T00:00:01Z";
+        let (new_stem_hash, new_stem_size) = staged_wav(&connection, &root, "stem-added", 2.0);
+        let mut replacement_mix = old_mix.clone();
+        replacement_mix.content_sha256 = replacement_hash.clone();
+        replacement_mix.size_bytes = replacement_size;
+        replacement_mix.created_at = changed_at.to_string();
+        replacement_mix.format = "wav".to_string();
+        let added_mix = manifest_artifact(
+            &project_id,
+            "art_mix_added",
+            "preview_mix",
+            "previews/added.wav",
+            &new_mix_hash,
+            new_mix_size,
+            true,
+            changed_at,
+        );
+        let mut added_stem = manifest_artifact(
+            &project_id,
+            "art_stem_added",
+            "drums_stem",
+            "stems/new/drums.wav",
+            &new_stem_hash,
+            new_stem_size,
+            true,
+            changed_at,
+        );
+        added_stem.metadata["model_repo"] = json!("/synthetic/model-repository");
+        let mut superseded = metadata_revision(
+            &project_id,
+            "rev_metadata_1",
+            "superseded",
+            "Initial name",
+            None,
+            initial_updated,
+        );
+        superseded.updated_at = changed_at.to_string();
+        let mut current_metadata = metadata_revision(
+            &project_id,
+            "rev_metadata_2",
+            "active",
+            "Renamed project",
+            Some("F#m"),
+            metadata_updated,
+        );
+        current_metadata.payload["duration_seconds"] = json!(0.2);
+        current_metadata.payload["sample_rate"] = json!(16_000);
+        current_metadata.payload["channels"] = json!(2);
+        let tombstone = SyncDeleteTombstoneSchema {
+            tombstone_id: "tomb_old_stem".to_string(),
+            sync_group_id,
+            project_id: project_id.clone(),
+            target_type: "artifact".to_string(),
+            target_id: old_stem.artifact_id.clone(),
+            author_device_id: "device_peer_1".to_string(),
+            deleted_at: changed_at.to_string(),
+            prior_metadata: json!({"type": old_stem.r#type}),
+            created_at: changed_at.to_string(),
+            updated_at: changed_at.to_string(),
+        };
+        let changed = desktop_wire_manifest(SyncProjectManifestSchema {
+            schema_version: SYNC_PROJECT_MANIFEST_SCHEMA_VERSION.to_string(),
+            exported_at: changed_at.to_string(),
+            project: SyncProjectManifestProjectSchema {
+                project_id: project_id.clone(),
+                display_name: "Renamed project".to_string(),
+                source_key_override: Some("F#m".to_string()),
+                source_sha256: source_hash,
+                duration_seconds: Some(0.2),
+                sample_rate: Some(16_000),
+                channels: Some(2),
+                created_at: created.to_string(),
+                updated_at: changed_at.to_string(),
+            },
+            entity_revisions: vec![superseded, current_metadata],
+            artifacts: vec![source, replacement_mix.clone(), added_mix, added_stem],
+            delete_tombstones: vec![tombstone],
+        });
+        let old_stem_path: String = connection
+            .query_row(
+                "SELECT path FROM artifacts WHERE id = ?1",
+                params![old_stem.artifact_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let (second_plan, second_summary, second_results) =
+            apply_manifest(&connection, &root, changed.clone());
+        assert_eq!(second_plan.summary.status_counts.get("deleted"), Some(&1));
+        assert!(second_plan
+            .actions
+            .iter()
+            .any(|action| action.action_type == ACTION_IMPORT_PROJECT_MANIFEST));
+        assert!(!second_plan
+            .actions
+            .iter()
+            .any(|action| action.action_type == ACTION_FETCH_ARTIFACT_CONTENT));
+        assert_eq!(second_summary.applied_actions, 2);
+        assert_eq!(second_summary.failed_actions, 0);
+        assert!(second_results.iter().any(|result| {
+            result.action.action_type == ACTION_APPLY_DELETE_TOMBSTONE && result.status == "applied"
+        }));
+        let project = get_project_schema(&connection, &project_id).unwrap();
+        assert_eq!(project.display_name, "Renamed project");
+        assert_eq!(project.source_key_override.as_deref(), Some("F#m"));
+        assert_eq!(project.duration_seconds, Some(0.2));
+        assert_eq!(project.sample_rate, Some(16_000));
+        assert_eq!(project.channels, Some(2));
+        assert_eq!(project.updated_at, metadata_updated);
+        let stored_hash: String = connection
+            .query_row(
+                "SELECT content_sha256 FROM artifacts WHERE id = 'art_mix'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored_hash, replacement_hash);
+        let inserted_hash: String = connection
+            .query_row(
+                "SELECT content_sha256 FROM artifacts WHERE id = 'art_mix_added'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(inserted_hash, new_mix_hash);
+        assert!(!Path::new(&old_stem_path).exists());
+        let artifact_count: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM artifacts WHERE project_id = ?1",
+                params![project_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(artifact_count, 6);
+
+        assert!(
+            super::manifests::project_manifest_mismatch(&connection, &root, &changed)
+                .unwrap()
+                .is_none()
+        );
+        let (replay_plan, replay_summary, _) = apply_manifest(&connection, &root, changed.clone());
+        assert_eq!(replay_plan.summary.status_counts.get("noop"), Some(&2));
+        assert_eq!(replay_summary.planned_actions, 0);
+        assert!(replay_plan.actions.is_empty());
+
+        let mut metadata_changed = changed.clone();
+        metadata_changed
+            .artifacts
+            .iter_mut()
+            .find(|artifact| artifact.artifact_id == "art_mix")
+            .unwrap()
+            .metadata["fixture"] = json!("changed");
+        assert_eq!(
+            super::manifests::project_manifest_mismatch(&connection, &root, &metadata_changed)
+                .unwrap(),
+            Some(super::manifests::ProjectManifestMismatch::ArtifactMetadata)
+        );
+
+        for (slug, phase, created_at) in [
+            ("mix-equal", 2.1, changed_at),
+            ("mix-older", 2.2, initial_updated),
+        ] {
+            let (ignored_hash, ignored_size) = staged_wav(&connection, &root, slug, phase);
+            let mut ignored = changed.clone();
+            let ignored_mix = ignored
+                .artifacts
+                .iter_mut()
+                .find(|artifact| artifact.artifact_id == "art_mix")
+                .unwrap();
+            ignored_mix.content_sha256 = ignored_hash;
+            ignored_mix.size_bytes = ignored_size;
+            ignored_mix.created_at = created_at.to_string();
+            super::manifests::import_sync_project_manifest(
+                &connection,
+                &root,
+                SyncProjectStagedImportRequest {
+                    manifest: ignored,
+                    staging_root: None,
+                    use_content_addressed_staging: Some(true),
+                },
+            )
+            .unwrap();
+            let preserved: String = connection
+                .query_row(
+                    "SELECT content_sha256 FROM artifacts WHERE id = 'art_mix'",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(preserved, replacement_hash);
+        }
+
+        let replacement_path: String = connection
+            .query_row(
+                "SELECT path FROM artifacts WHERE id = 'art_mix'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let replacement_bytes = fs::read(&replacement_path).unwrap();
+        let mut rejected = changed;
+        let (rejected_hash, rejected_size) = staged_wav(&connection, &root, "mix-reject", 2.4);
+        let rejected_mix = rejected
+            .artifacts
+            .iter_mut()
+            .find(|artifact| artifact.artifact_id == "art_mix")
+            .unwrap();
+        rejected_mix.content_sha256 = rejected_hash;
+        rejected_mix.size_bytes = rejected_size;
+        rejected_mix.can_regenerate = false;
+        rejected_mix.created_at = "2026-01-04T00:00:00Z".to_string();
+        let error = super::manifests::import_sync_project_manifest(
+            &connection,
+            &root,
+            SyncProjectStagedImportRequest {
+                manifest: rejected,
+                staging_root: None,
+                use_content_addressed_staging: Some(true),
+            },
+        )
+        .err()
+        .unwrap();
+        assert!(error.contains("conflicts"));
+        assert_eq!(fs::read(&replacement_path).unwrap(), replacement_bytes);
+        let preserved_hash: String = connection
+            .query_row(
+                "SELECT content_sha256 FROM artifacts WHERE id = 'art_mix'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(preserved_hash, replacement_hash);
+        assert!(fs::read_dir(root.join("projects").join(&project_id))
+            .unwrap()
+            .all(|entry| !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".sync-")));
+        fs::remove_dir_all(root).unwrap();
     }
 }


### PR DESCRIPTION
## Summary

- Apply project metadata, saved mix, stem, revision, and tombstone mutations when Android already has the project.
- Preserve verified same-ID artifact replacement while keeping stale or invalid remote replacements from overwriting local data.
- Canonicalize Android-sanitized artifact metadata so unchanged repeat sync remains idempotent.
- Closes #458.

## Testing

- `cd apps/desktop/src-tauri && cargo fmt --all -- --check`
- `cd apps/desktop/src-tauri && cargo test mobile_backend::` (81 passed)
- `cd apps/desktop/src-tauri && cargo check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- Physical-device desktop-to-Android validation: rename, mix, and stem mutations applied; immediate unchanged replay skipped every project with zero transfer.
- Physical-device metadata-only rename applied; immediate replay skipped every project with zero transfer.
- Tombstone and same-ID replacement paths are covered by Rust tests; they were not exercised on the physical device.
