### PR TITLE
chore(release): prepare v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,24 @@ download, installation, verification, signature, and publication instructions.
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-08-24
+
 ### Added
 
-- Added backend storage, processing-job, and desktop-sync foundations for durable WAV, FLAC, MP3,
-  and M4A audio artifacts ([#398](https://github.com/grazzolini/tuneforge/issues/398)).
-- Added a desktop Audio Storage preference for future imports, stems, and saved mixes, plus
-  byte-preserving Android receive and playback support for all four durable formats
-  ([#398](https://github.com/grazzolini/tuneforge/issues/398)).
-- Added desktop Activity re-processing for existing durable audio, with mixed-format project skips and timestamp-based sync replacement across trusted peers ([#399](https://github.com/grazzolini/tuneforge/issues/399)).
+- Added durable WAV, FLAC, MP3, and M4A storage, including byte-preserving Android receive and
+  playback support ([#465](https://github.com/grazzolini/tuneforge/pull/465),
+  [#467](https://github.com/grazzolini/tuneforge/pull/467)).
+- Added opt-in, memory-only, bounded, sanitized diagnostics for native playback
+  ([#464](https://github.com/grazzolini/tuneforge/pull/464)).
+- Added Activity re-processing for durable audio with timestamp-based last-write-wins sync
+  replacement ([#471](https://github.com/grazzolini/tuneforge/pull/471)).
 
 ### Fixed
 
-- Applied repeat desktop-to-Android sync changes to existing project metadata and artifacts.
-- Preserved project playback safely across native output route changes and interruptions by using
-  a guarded Web Audio fallback at the current position.
+- Applied repeat desktop-to-Android sync changes to existing project metadata and artifacts
+  ([#469](https://github.com/grazzolini/tuneforge/pull/469)).
+- Preserved project playback across native output-route changes and interruptions
+  ([#466](https://github.com/grazzolini/tuneforge/pull/466)).
 
 ## [1.1.0] - 2026-08-18
 
@@ -121,7 +125,8 @@ download, installation, verification, signature, and publication instructions.
 
 - Development used `0.1.0` metadata; `v1.0.0` was the first tagged release.
 
-[Unreleased]: https://github.com/grazzolini/tuneforge/compare/v1.1.0...main
+[Unreleased]: https://github.com/grazzolini/tuneforge/compare/v1.2.0...main
+[1.2.0]: https://github.com/grazzolini/tuneforge/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/grazzolini/tuneforge/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/grazzolini/tuneforge/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/grazzolini/tuneforge/releases/tag/v1.0.0

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tuneforge-backend"
-version = "1.1.0"
+version = "1.2.0"
 description = "Local API and processing backend for TuneForge."
 readme = "README.md"
 requires-python = ">=3.11,<3.12"

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -1919,7 +1919,7 @@ wheels = [
 
 [[package]]
 name = "tuneforge-backend"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tuneforge/desktop",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -7456,7 +7456,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuneforge"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "android_system_properties",
  "base64 0.23.1",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuneforge"
-version = "1.1.0"
+version = "1.2.0"
 description = "TuneForge desktop shell"
 edition = "2021"
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TuneForge",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "identifier": "com.tuneforge.desktop",
   "build": {
     "beforeDevCommand": "pnpm --filter @tuneforge/desktop dev",

--- a/apps/desktop/src/App.project-export.test.tsx
+++ b/apps/desktop/src/App.project-export.test.tsx
@@ -60,8 +60,8 @@ function health(defaultExportFormat: string): HealthResponse {
   return {
     name: "TuneForge",
     version: "backend-test-ref",
-    backend_version: { package_version: "1.1.0", git_ref: "backend-test-ref" },
-    frontend_version: { package_version: "1.1.0", git_ref: "frontend-test-ref" },
+    backend_version: { package_version: "1.2.0", git_ref: "backend-test-ref" },
+    frontend_version: { package_version: "1.2.0", git_ref: "frontend-test-ref" },
     status: "ok",
     api_base_url: "http://127.0.0.1:8765/api/v1",
     data_root: "/tmp/tuneforge",

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -1425,11 +1425,11 @@ const {
     name: "TuneForge",
     version: "backend-test-ref",
     backend_version: {
-      package_version: "1.1.0",
+      package_version: "1.2.0",
       git_ref: "backend-test-ref",
     },
     frontend_version: {
-      package_version: "1.1.0",
+      package_version: "1.2.0",
       git_ref: "frontend-test-ref",
     },
     status: "ok",

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tuneforge/shared-types",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packaging/flatpak/com.tuneforge.desktop.metainfo.xml
+++ b/packaging/flatpak/com.tuneforge.desktop.metainfo.xml
@@ -27,6 +27,7 @@
   </categories>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="1.2.0" date="2026-08-24" />
     <release version="1.1.0" date="2026-08-18" />
     <release version="1.0.1" date="2026-08-13" />
     <release version="1.0.0" date="2026-06-27" />

--- a/scripts/capture-release-media.mjs
+++ b/scripts/capture-release-media.mjs
@@ -1910,11 +1910,11 @@ function healthResponse() {
     name: "TuneForge",
     version: "release-media-fixture",
     backend_version: {
-      package_version: "1.1.0",
+      package_version: "1.2.0",
       git_ref: "release-media-fixture",
     },
     frontend_version: {
-      package_version: "1.1.0",
+      package_version: "1.2.0",
       git_ref: "release-media-fixture",
     },
     status: "ok",


### PR DESCRIPTION
## Summary

- Promote curated v1.2.0 changelog with 2026-08-24 release date.
- Align governed package versions, generated lock entries, and current-version fixtures.
- Preserve standard seven-asset release contract and manual signing/publication boundaries.

## Testing

- `CI=true pnpm test`
- `CI=true pnpm lint`
- `CI=true pnpm typecheck`
- `cd apps/backend && uv run --python 3.11 pytest`
- `cd apps/desktop/src-tauri && cargo check`
- `CI=true pnpm release:check-version`
- `CI=true pnpm release:license-inventory -- --check`
- `node scripts/capture-release-media.mjs --run` (visual inspection)
- `git diff --check`
