### PR TITLE
test(backend): add reproducible chord benchmarks

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -215,8 +215,32 @@ Accepted backend aliases are `fast` / `tuneforge-fast` and `advanced` / `crema-a
 Benchmark Built-in Chords against Advanced Chords:
 
 ```sh
-bash scripts/run-backend-module.sh app.benchmarks.chords --audio /path/to/song.mp3
+pnpm chords:benchmark -- --audio /path/to/song.mp3
 ```
+
+### Chord quality benchmarks
+
+The quality benchmark is a manual-only evaluator; it is intentionally excluded from CI and never
+downloads datasets. It emits anonymous aggregate metrics only, without source paths, filenames,
+labels, timelines, or audio hashes. The deterministic synthetic suite contains generated tones only:
+
+```sh
+pnpm chords:benchmark -- --quality-synthetic --json-only
+```
+
+For an external normalized manifest, keep the manifest and its audio outside the repository. The
+manifest requires SHA-256-verified relative audio paths and only the fixed public musical strata.
+Pass an explicit root for those paths. Vendored public manifests resolve their declared safe
+`data_subdir` below that root, so GuitarSet and Tiny AAM can run together:
+
+```sh
+pnpm chords:benchmark -- \
+  --quality-manifest /secure/local/chords.json --data-root /secure/local/data --json-only
+```
+
+Vendored GuitarSet 1.1.0 and Tiny AAM 1.1.0 manifests pin official archive and selected-asset
+checksums plus deterministic six-track selection rules. The benchmark does not fetch data; corpus
+execution and archive/layout validation remain separate manual checks.
 
 Run from the repository root. The command writes machine-readable JSON to stdout and a short summary to stderr. Use `--json-only` for JSON-only output.
 

--- a/apps/backend/app/benchmarks/chord_evaluation.py
+++ b/apps/backend/app/benchmarks/chord_evaluation.py
@@ -1,0 +1,827 @@
+"""Privacy-preserving chord quality evaluation helpers.
+
+This module deliberately owns a small, backend-independent chord projection.  It
+does not reuse product display-label parsing: benchmark references and backend
+predictions must be normalized by the same stable scorer contract.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import math
+import re
+import tempfile
+import wave
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import soundfile as sf
+
+SCHEMA_VERSION = "chord-quality-report-v1"
+SCORER_VERSION = "chord-quality-scorer-v1"
+PROJECTION_VERSION = "chord-projection-v1"
+SYNTHETIC_VERSION = "synthetic-chords-v1"
+BOUNDARY_TOLERANCE_SECONDS = 0.25
+SAFE_STRATA = frozenset({"synthetic", "solo-guitar", "accompaniment", "full-mix"})
+_NOTE_TO_PC = {
+    "C": 0,
+    "B#": 0,
+    "C#": 1,
+    "DB": 1,
+    "D": 2,
+    "D#": 3,
+    "EB": 3,
+    "E": 4,
+    "FB": 4,
+    "F": 5,
+    "E#": 5,
+    "F#": 6,
+    "GB": 6,
+    "G": 7,
+    "G#": 8,
+    "AB": 8,
+    "A": 9,
+    "A#": 10,
+    "BB": 10,
+    "B": 11,
+    "CB": 11,
+}
+_SEVENTHS = frozenset({"7", "maj7", "m7", "dim7", "hdim7", "9", "maj9", "m9", "11", "13"})
+_QUALITY_ALIASES = {
+    "": ("major", None),
+    "maj": ("major", None),
+    "major": ("major", None),
+    "min": ("minor", None),
+    "m": ("minor", None),
+    "minor": ("minor", None),
+    "dim": ("diminished", None),
+    "aug": ("augmented", None),
+    "+": ("augmented", None),
+    "sus2": ("sus2", None),
+    "sus4": ("sus4", None),
+    "5": ("power", None),
+    "7": ("major", "7"),
+    "maj7": ("major", "maj7"),
+    "major7": ("major", "maj7"),
+    "min7": ("minor", "m7"),
+    "m7": ("minor", "m7"),
+    "dim7": ("diminished", "dim7"),
+    "hdim": ("diminished", "hdim7"),
+    "hdim7": ("diminished", "hdim7"),
+    "m7b5": ("diminished", "hdim7"),
+    "min7b5": ("diminished", "hdim7"),
+    "add9": ("major", "add9"),
+    "maj9": ("major", "maj9"),
+    "major9": ("major", "maj9"),
+    "m9": ("minor", "m9"),
+    "min9": ("minor", "m9"),
+    "9": ("major", "9"),
+    "11": ("major", "11"),
+    "13": ("major", "13"),
+}
+
+
+@dataclass(frozen=True)
+class ProjectedChord:
+    root: int | None
+    triad: str | None
+    extension: str | None
+    bass: int | None
+    no_chord: bool = False
+
+
+@dataclass(frozen=True)
+class QualityTrack:
+    dataset: str
+    slot: str
+    strata: tuple[str, ...]
+    audio_path: Path
+    reference: list[Any]
+    timeline: bool
+    extension_scoreable: bool
+    bass_scoreable: bool
+    audio_sha256: str | None = None
+    public_provenance: dict[str, Any] | None = None
+
+
+class ManifestError(ValueError):
+    """A deliberately non-identifying manifest validation error."""
+
+
+def project_chord(value: Mapping[str, Any] | str | None) -> ProjectedChord:
+    """Project a source-neutral segment or label into the scorer vocabulary."""
+    if value is None:
+        return ProjectedChord(None, None, None, None)
+    if isinstance(value, Mapping):
+        label = value.get("raw_label", value.get("label"))
+        quality = value.get("quality")
+        root = value.get("root_pitch_class", value.get("pitch_class"))
+        bass = value.get("bass_pitch_class")
+        if quality == "no_chord" or label in {"N", "N.C.", "NC", "X"}:
+            return ProjectedChord(None, None, None, None, quality == "no_chord" or label != "X")
+        parsed = _project_label(label) if isinstance(label, str) else None
+        root_pc = root if isinstance(root, int) and 0 <= root <= 11 else (parsed.root if parsed else None)
+        bass_pc = bass if isinstance(bass, int) and 0 <= bass <= 11 else (parsed.bass if parsed else None)
+        if parsed is not None and parsed.triad is not None:
+            # Product segments often carry a deliberately coarse ``quality``.
+            # The scorer's raw label retains extensions, omitted thirds, and bass.
+            return ProjectedChord(root_pc, parsed.triad, parsed.extension, bass_pc if bass_pc is not None else root_pc)
+        if isinstance(quality, str):
+            triad, extension = _quality_from_text(quality)
+            if triad is not None:
+                return ProjectedChord(root_pc, triad, extension, bass_pc if bass_pc is not None else root_pc)
+        if parsed is not None:
+            return parsed
+        return ProjectedChord(root_pc, None, None, bass_pc if bass_pc is not None else root_pc)
+    if isinstance(value, str):
+        return _project_label(value)
+    return ProjectedChord(None, None, None, None)
+
+
+def _project_label(label: str) -> ProjectedChord:
+    text = label.strip()
+    if text.upper() in {"N", "N.C.", "NC", "NO_CHORD"}:
+        return ProjectedChord(None, None, None, None, True)
+    match = re.fullmatch(r"([A-Ga-g])([#b]?)(?::)?([^/]*)?(?:/(.+))?", text)
+    if match is None:
+        return ProjectedChord(None, None, None, None)
+    note, accidental, raw_quality, bass_text = match.groups()
+    root = _NOTE_TO_PC.get((note + accidental).upper())
+    if root is None:
+        return ProjectedChord(None, None, None, None)
+    triad, extension = _quality_from_text(raw_quality or "")
+    bass = _bass_pitch_class(root, bass_text)
+    return ProjectedChord(root, triad, extension, root if bass is None else bass)
+
+
+def _quality_from_text(raw: str) -> tuple[str | None, str | None]:
+    text = raw.strip().lower().replace(" ", "")
+    if text.startswith("(") and text.endswith(")"):
+        values = {part.strip() for part in text[1:-1].split(",")}
+        if {"b3", "b5", "b7"}.issubset(values):
+            if "9" in values:
+                return "diminished", "hdim7"
+            return "diminished", "hdim7"
+        if {"1", "3", "5", "b7", "9", "13"}.issubset(values):
+            return "major", "13"
+        if {"1", "3", "5", "7", "9"}.issubset(values):
+            return "major", "maj9"
+        if {"1", "b3", "5", "b7", "9"}.issubset(values):
+            return "minor", "m9"
+        if {"1", "5", "b7"}.issubset(values):
+            return "power", "7"
+        if {"b3", "b5"}.issubset(values):
+            return "diminished", None
+        if "b3" in values:
+            return "minor", None
+        if "3" in values:
+            return "major", None
+        if "5" in values:
+            return "power", None
+        return None, None
+    text = text.replace(":", "")
+    direct = _QUALITY_ALIASES.get(text)
+    if direct is not None:
+        return direct
+    # Harte labels can carry an explicit major/minor token before alterations.
+    for prefix, projected in (("maj", "major"), ("min", "minor"), ("m", "minor")):
+        if text.startswith(prefix):
+            tail = text[len(prefix) :]
+            extension = {
+                "7": "maj7" if projected == "major" else "m7",
+                "9": "maj9" if projected == "major" else "m9",
+            }.get(tail)
+            return projected, extension
+    return None, None
+
+
+def _bass_pitch_class(root: int, value: str | None) -> int | None:
+    if not value:
+        return None
+    text = value.strip()
+    note = _NOTE_TO_PC.get(text.upper())
+    if note is not None:
+        return note
+    degree = {
+        "1": 0,
+        "b2": 1,
+        "2": 2,
+        "#2": 3,
+        "b3": 3,
+        "3": 4,
+        "4": 5,
+        "#4": 6,
+        "b5": 6,
+        "5": 7,
+        "#5": 8,
+        "b6": 8,
+        "6": 9,
+        "bb7": 9,
+        "b7": 10,
+        "7": 11,
+        "b9": 13,
+        "9": 14,
+        "#9": 15,
+        "b10": 15,
+        "10": 16,
+        "#10": 17,
+        "11": 17,
+        "#11": 18,
+        "b13": 20,
+        "13": 21,
+    }.get(text.lower())
+    return (root + degree) % 12 if degree is not None else None
+
+
+def score_timeline(
+    reference: Sequence[Mapping[str, Any]],
+    prediction: Sequence[Mapping[str, Any]],
+    *,
+    extension_scoreable: bool = True,
+    bass_scoreable: bool = True,
+) -> dict[str, Any]:
+    """Score a valid timeline. References fail closed; predictions are clamped."""
+    ref = _validate_reference(reference)
+    duration = float(ref[-1]["end_seconds"])
+    pred = _clamp_prediction(prediction, duration)
+    points = sorted({0.0, duration, *(_times(ref)), *(_times(pred))})
+    correct: defaultdict[str, float] = defaultdict(float)
+    wrong_spans = 0
+    was_wrong = False
+    for left, right in zip(points[:-1], points[1:], strict=True):
+        if right <= left:
+            continue
+        actual, observed = _segment_at(ref, (left + right) / 2), _segment_at(pred, (left + right) / 2)
+        a, b = project_chord(actual), project_chord(observed)
+        weight = right - left
+        explicit_nc_match = a.no_chord and b.no_chord
+        equal_root = explicit_nc_match if a.no_chord or b.no_chord else a.root == b.root
+        equal_quality = explicit_nc_match if a.no_chord or b.no_chord else a.triad == b.triad
+        equal_extension = explicit_nc_match if a.no_chord or b.no_chord else a.extension == b.extension
+        equal_bass = explicit_nc_match if a.no_chord or b.no_chord else a.bass == b.bass
+        equal_full = equal_root and equal_quality and equal_extension and equal_bass and a.no_chord == b.no_chord
+        correct["root"] += weight * equal_root
+        correct["quality"] += weight * equal_quality
+        correct["seventh_extension"] += weight * equal_extension
+        correct["bass"] += weight * equal_bass
+        correct["full"] += weight * equal_full
+        correct["nc_correct"] += weight * (a.no_chord and b.no_chord)
+        correct["nc_reference"] += weight * a.no_chord
+        correct["nc_prediction"] += weight * b.no_chord
+        wrong = not equal_full
+        wrong_spans += int(wrong and not was_wrong)
+        was_wrong = wrong
+    matched, missed, extra = match_boundaries(_boundaries(ref), _boundaries(pred))
+    return {
+        "kind": "timeline",
+        "duration_seconds": duration,
+        "root": _bounded(correct["root"] / duration),
+        "quality": _bounded(correct["quality"] / duration),
+        "seventh_extension": _bounded(correct["seventh_extension"] / duration) if extension_scoreable else None,
+        "seventh_extension_reason": None if extension_scoreable else "source_capability_unsupported",
+        "bass": _bounded(correct["bass"] / duration) if bass_scoreable else None,
+        "bass_reason": None if bass_scoreable else "source_capability_unsupported",
+        "full": _bounded(correct["full"] / duration) if bass_scoreable and extension_scoreable else None,
+        "full_reason": None if bass_scoreable and extension_scoreable else "source_capability_unsupported",
+        "boundary": {"matched": matched, "reference": len(_boundaries(ref)), "prediction": len(_boundaries(pred))},
+        "reference_segment_count": len(ref),
+        "prediction_segment_count": len(pred),
+        "wrong_spans": wrong_spans,
+        "unmatched_boundaries": missed + extra,
+        "nc": {
+            "correct_seconds": correct["nc_correct"],
+            "reference_seconds": correct["nc_reference"],
+            "prediction_seconds": correct["nc_prediction"],
+        },
+    }
+
+
+def score_sequence(
+    reference: Sequence[Mapping[str, Any] | str], prediction: Sequence[Mapping[str, Any] | str]
+) -> dict[str, Any]:
+    left = _collapse([project_chord(item) for item in reference])
+    right = _collapse([project_chord(item) for item in prediction])
+    distance = _edit_distance(left, right)
+    denominator = max(len(left), len(right))
+    return {
+        "kind": "sequence",
+        "sequence_edit_similarity": _bounded(1.0 - distance / denominator) if denominator else 1.0,
+        "root": None,
+        "quality": None,
+        "seventh_extension": None,
+        "bass": None,
+        "full": None,
+        "timeline_reason": "untimed_reference",
+        "reference_segment_count": len(left),
+        "prediction_segment_count": len(right),
+    }
+
+
+def match_boundaries(
+    reference: Sequence[float], prediction: Sequence[float], tolerance: float = BOUNDARY_TOLERANCE_SECONDS
+) -> tuple[int, int, int]:
+    # Ordered interval matching maximizes cardinality without crossing pairs.
+    left = right = matched = 0
+    while left < len(reference) and right < len(prediction):
+        if prediction[right] < reference[left] - tolerance:
+            right += 1
+        elif prediction[right] > reference[left] + tolerance:
+            left += 1
+        else:
+            matched += 1
+            left += 1
+            right += 1
+    return matched, len(reference) - matched, len(prediction) - matched
+
+
+def aggregate_scores(rows: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    timelines = [row for row in rows if row.get("kind") == "timeline"]
+    sequences = [row for row in rows if row.get("kind") == "sequence"]
+    duration = sum(float(row["duration_seconds"]) for row in timelines)
+    output: dict[str, Any] = {
+        "track_count": len(timelines) + len(sequences),
+        "timeline_track_count": len(timelines),
+        "sequence_track_count": len(sequences),
+        "duration_seconds": round(duration, 6),
+    }
+    for metric in ("root", "quality", "seventh_extension", "bass", "full"):
+        supported = [row for row in timelines if row.get(metric) is not None]
+        supported_duration = sum(float(row["duration_seconds"]) for row in supported)
+        output[metric] = (
+            _bounded(sum(float(row[metric]) * float(row["duration_seconds"]) for row in supported) / supported_duration)
+            if supported_duration
+            else None
+        )
+        output[f"{metric}_support_track_count"] = len(supported)
+        output[f"{metric}_support_duration_seconds"] = round(supported_duration, 6)
+        output[f"{metric}_reason"] = (
+            None
+            if len(supported) == len(timelines)
+            else "partial_metric_support"
+            if supported
+            else "metric_unsupported_by_source"
+        )
+    boundary_matched = sum(int(row["boundary"]["matched"]) for row in timelines)
+    boundary_reference = sum(int(row["boundary"]["reference"]) for row in timelines)
+    boundary_prediction = sum(int(row["boundary"]["prediction"]) for row in timelines)
+    precision = (
+        boundary_matched / boundary_prediction if boundary_prediction else (1.0 if not boundary_reference else 0.0)
+    )
+    recall = boundary_matched / boundary_reference if boundary_reference else (1.0 if not boundary_prediction else 0.0)
+    output["boundary_precision_250ms"] = _bounded(precision)
+    output["boundary_recall_250ms"] = _bounded(recall)
+    output["boundary_f1_250ms"] = _bounded(2 * precision * recall / (precision + recall)) if precision + recall else 0.0
+    nc_correct = sum(float(row["nc"]["correct_seconds"]) for row in timelines)
+    nc_reference = sum(float(row["nc"]["reference_seconds"]) for row in timelines)
+    nc_prediction = sum(float(row["nc"]["prediction_seconds"]) for row in timelines)
+    output["nc_recall"] = _bounded(nc_correct / nc_reference) if nc_reference else 1.0
+    output["nc_precision"] = (
+        _bounded(nc_correct / nc_prediction) if nc_prediction else (1.0 if not nc_reference else 0.0)
+    )
+    output["reference_segment_count"] = sum(int(row["reference_segment_count"]) for row in timelines)
+    output["prediction_segment_count"] = sum(int(row["prediction_segment_count"]) for row in timelines)
+    output["segment_count_absolute_error"] = sum(
+        abs(int(row["prediction_segment_count"]) - int(row["reference_segment_count"])) for row in timelines
+    )
+    output["segment_count_normalized_error"] = (
+        _bounded(output["segment_count_absolute_error"] / output["reference_segment_count"])
+        if output["reference_segment_count"]
+        else None
+    )
+    output["correction_proxy_per_minute"] = (
+        round((sum(int(row["wrong_spans"]) + int(row["unmatched_boundaries"]) for row in timelines) * 60 / duration), 6)
+        if duration
+        else None
+    )
+    output["sequence_edit_similarity"] = (
+        _bounded(sum(float(row["sequence_edit_similarity"]) for row in sequences) / len(sequences))
+        if sequences
+        else None
+    )
+    return output
+
+
+def load_manifest(path: Path, data_root: Path) -> list[QualityTrack]:
+    """Load an external normalized manifest without exposing its identifiers."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ManifestError("manifest_invalid") from exc
+    if not isinstance(payload, Mapping) or payload.get("schema_version") != "chord-quality-manifest-v1":
+        raise ManifestError("manifest_schema_invalid")
+    dataset = payload.get("dataset")
+    entries = payload.get("tracks")
+    if not isinstance(dataset, str) or not isinstance(entries, list) or not entries:
+        raise ManifestError("manifest_contract_invalid")
+    tracks: list[QualityTrack] = []
+    for index, entry in enumerate(entries, 1):
+        if not isinstance(entry, Mapping):
+            raise ManifestError("manifest_contract_invalid")
+        relative = entry.get("audio")
+        digest = entry.get("sha256")
+        strata = entry.get("strata")
+        timeline = entry.get("timeline")
+        sequence = entry.get("sequence")
+        if not isinstance(relative, str) or Path(relative).is_absolute() or ".." in Path(relative).parts:
+            raise ManifestError("manifest_audio_invalid")
+        if not isinstance(digest, str) or re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+            raise ManifestError("manifest_hash_invalid")
+        if (
+            not isinstance(strata, list)
+            or not strata
+            or any(not isinstance(item, str) or item not in SAFE_STRATA for item in strata)
+        ):
+            raise ManifestError("manifest_strata_invalid")
+        if (timeline is None) == (sequence is None) or not isinstance(
+            timeline if timeline is not None else sequence, list
+        ):
+            raise ManifestError("manifest_reference_invalid")
+        audio_path = (data_root / relative).resolve()
+        if data_root.resolve() not in audio_path.parents or not audio_path.is_file() or _sha256(audio_path) != digest:
+            raise ManifestError("manifest_audio_hash_invalid")
+        raw_reference = timeline if timeline is not None else sequence
+        assert isinstance(raw_reference, list)
+        reference = list(raw_reference)
+        if timeline is not None:
+            _validate_reference(reference)
+        tracks.append(
+            QualityTrack(
+                dataset,
+                f"dataset_{index:03d}",
+                tuple(sorted(strata)),
+                audio_path,
+                reference,
+                timeline is not None,
+                bool(entry.get("extension_scoreable", True)),
+                bool(entry.get("bass_scoreable", False)),
+                digest,
+            )
+        )
+    return tracks
+
+
+def load_public_manifest(path: Path, data_root: Path) -> list[QualityTrack]:
+    """Load a vendored public manifest via its stdlib-only dataset adapter."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ManifestError("manifest_invalid") from exc
+    if not isinstance(payload, Mapping) or payload.get("schema_version") != "chord-public-manifest-v1":
+        raise ManifestError("public_manifest_schema_invalid")
+    _validate_public_manifest(payload)
+    root = _public_data_root(payload, data_root)
+    adapter = payload.get("adapter")
+    if adapter == "guitarset-jams-v1":
+        return _load_guitarset(payload, root)
+    if adapter == "tiny-aam-arff-v1":
+        return _load_tiny_aam(payload, root)
+    raise ManifestError("public_manifest_adapter_invalid")
+
+
+def _load_guitarset(payload: Mapping[str, Any], root: Path) -> list[QualityTrack]:
+    pins = _public_selection_pins(payload, "selected_annotations", ("basename", "sha256", "audio_sha256"))
+    annotations = root / "annotations"
+    audio = root / "audio"
+    paths = sorted(
+        (path for path in annotations.glob("*.jams") if (audio / f"{path.stem}_mic.wav").is_file()),
+        key=lambda item: hashlib.sha256(item.name.encode()).digest(),
+    )[:6]
+    if len(paths) != 6:
+        raise ManifestError("public_dataset_selection_invalid")
+    if [path.stem for path in paths] != [str(pin["basename"]) for pin in pins] or any(
+        _sha256(path) != str(pin["sha256"]) or _sha256(audio / f"{path.stem}_mic.wav") != str(pin["audio_sha256"])
+        for path, pin in zip(paths, pins, strict=True)
+    ):
+        raise ManifestError("public_dataset_pin_invalid")
+    tracks: list[QualityTrack] = []
+    provenance = _public_provenance(payload)
+    for index, annotation in enumerate(paths, 1):
+        try:
+            data = json.loads(annotation.read_text(encoding="utf-8"))
+            chord_annotations = [
+                item
+                for item in data.get("annotations", [])
+                if item.get("namespace") == "chord"
+                and "manual verification" in str(item.get("annotation_metadata", {}).get("data_source", "")).lower()
+            ]
+            if len(chord_annotations) != 1:
+                raise ValueError
+            timeline = [
+                {
+                    "start_seconds": float(row["time"]),
+                    "end_seconds": float(row["time"]) + float(row["duration"]),
+                    "label": str(row["value"]),
+                }
+                for row in chord_annotations[0]["data"]
+            ]
+            _validate_reference(timeline)
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise ManifestError("public_dataset_annotation_invalid") from exc
+        tracks.append(
+            QualityTrack(
+                "guitarset",
+                f"track_{index:03d}",
+                ("solo-guitar",) if annotation.stem.endswith("_solo") else ("accompaniment",),
+                audio / f"{annotation.stem}_mic.wav",
+                timeline,
+                True,
+                True,
+                True,
+                None,
+                provenance,
+            )
+        )
+    return tracks
+
+
+def _load_tiny_aam(payload: Mapping[str, Any], root: Path) -> list[QualityTrack]:
+    pins = _public_selection_pins(
+        payload, "selected_assets", ("id", "audio_sha256", "beatinfo_sha256", "segments_sha256")
+    )
+    audio_paths = sorted(
+        [
+            path
+            for path in (root / "audio-mixes-mp3").glob("*_mix.mp3")
+            if (root / "annotations" / f"{path.stem.removesuffix('_mix')}_beatinfo.arff").is_file()
+            and (root / "annotations" / f"{path.stem.removesuffix('_mix')}_segments.arff").is_file()
+        ],
+        key=lambda item: hashlib.sha256(item.name.encode()).digest(),
+    )[:6]
+    if len(audio_paths) != 6:
+        raise ManifestError("public_dataset_selection_invalid")
+    if [path.stem.removesuffix("_mix") for path in audio_paths] != [str(pin["id"]) for pin in pins]:
+        raise ManifestError("public_dataset_pin_invalid")
+    tracks: list[QualityTrack] = []
+    provenance = _public_provenance(payload)
+    for index, (audio, pin) in enumerate(zip(audio_paths, pins, strict=True), 1):
+        identifier = audio.stem.removesuffix("_mix")
+        beat_path = root / "annotations" / f"{identifier}_beatinfo.arff"
+        segment_path = root / "annotations" / f"{identifier}_segments.arff"
+        if (
+            _sha256(audio) != str(pin["audio_sha256"])
+            or _sha256(beat_path) != str(pin["beatinfo_sha256"])
+            or _sha256(segment_path) != str(pin["segments_sha256"])
+        ):
+            raise ManifestError("public_dataset_pin_invalid")
+        rows = _arff_rows(beat_path)
+        if not rows or any(len(row) != 4 for row in rows):
+            raise ManifestError("public_dataset_annotation_invalid")
+        try:
+            duration = float(sf.info(str(audio)).duration)
+            starts = [float(row[0]) for row in rows]
+        except (RuntimeError, ValueError, IndexError) as exc:
+            raise ManifestError("public_dataset_annotation_invalid") from exc
+        timeline = [
+            {
+                "start_seconds": start,
+                "end_seconds": starts[position + 1] if position + 1 < len(starts) else duration,
+                "label": row[3],
+            }
+            for position, (start, row) in enumerate(zip(starts, rows, strict=True))
+        ]
+        _validate_reference(timeline)
+        tracks.append(
+            QualityTrack(
+                "tiny-aam", f"track_{index:03d}", ("full-mix",), audio, timeline, True, True, False, None, provenance
+            )
+        )
+    return tracks
+
+
+def synthetic_tracks() -> list[QualityTrack]:
+    """Create a deterministic, copyright-free acoustic fixture suite."""
+    root = Path(tempfile.mkdtemp(prefix="tuneforge-chord-quality-"))
+    specs = [("C", "G", "Am", "F"), ("C13", "Cmaj9", "Cm9", "C5"), ("N.C.", "C/E", "G:hdim7/5", "Cadd9/E")]
+    tracks: list[QualityTrack] = []
+    for index, labels in enumerate(specs, 1):
+        path = root / f"fixture-{index}.wav"
+        _write_synthetic_wav(path, labels)
+        timeline = [
+            {"start_seconds": float(step), "end_seconds": float(step + 1), "label": label}
+            for step, label in enumerate(labels)
+        ]
+        tracks.append(QualityTrack("synthetic", f"track_{index:03d}", ("synthetic",), path, timeline, True, True, True))
+    return tracks
+
+
+def cleanup_synthetic_tracks(tracks: Sequence[QualityTrack]) -> None:
+    for track in tracks:
+        try:
+            track.audio_path.unlink(missing_ok=True)
+            track.audio_path.parent.rmdir()
+        except OSError:
+            pass
+
+
+def _write_synthetic_wav(path: Path, labels: Sequence[str]) -> None:
+    sample_rate, amplitude = 8_000, 6_000
+    samples: list[int] = []
+    for label in labels:
+        chord = project_chord(label)
+        tones = _synthetic_tones(chord)
+        for frame in range(sample_rate):
+            if not tones:
+                samples.append(0)
+                continue
+            fade = min(1.0, frame / (sample_rate * 0.03), (sample_rate - frame - 1) / (sample_rate * 0.06))
+            value = int(
+                amplitude
+                * fade
+                * sum(math.sin(2 * math.pi * frequency * frame / sample_rate) for frequency in tones)
+                / len(tones)
+            )
+            samples.append(value)
+    with wave.open(str(path), "wb") as output:
+        output.setnchannels(1)
+        output.setsampwidth(2)
+        output.setframerate(sample_rate)
+        output.writeframes(b"".join(int(sample).to_bytes(2, "little", signed=True) for sample in samples))
+
+
+def _synthetic_tones(chord: ProjectedChord) -> list[float]:
+    if chord.no_chord or chord.root is None:
+        return []
+    triads = {
+        "major": (0, 4, 7),
+        "minor": (0, 3, 7),
+        "diminished": (0, 3, 6),
+        "augmented": (0, 4, 8),
+        "sus2": (0, 2, 7),
+        "sus4": (0, 5, 7),
+        "power": (0, 7),
+    }
+    extensions = {
+        "7": (10,),
+        "maj7": (11,),
+        "m7": (10,),
+        "hdim7": (10,),
+        "dim7": (9,),
+        "add9": (14,),
+        "9": (10, 14),
+        "maj9": (11, 14),
+        "m9": (10, 14),
+        "11": (10, 14, 17),
+        "13": (10, 14, 17, 21),
+    }
+    intervals = (*triads.get(chord.triad or "", (0,)), *extensions.get(chord.extension or "", ()))
+    bass = chord.bass if chord.bass is not None else chord.root
+    midi = [36 + bass, *(48 + chord.root + interval for interval in intervals)]
+    return [440.0 * 2 ** ((note - 69) / 12) for note in midi]
+
+
+def _validate_reference(segments: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    if not segments:
+        raise ManifestError("reference_empty")
+    normalized: list[dict[str, Any]] = []
+    expected = 0.0
+    for segment in segments:
+        try:
+            start, end = float(segment["start_seconds"]), float(segment["end_seconds"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ManifestError("reference_timing_invalid") from exc
+        if not math.isfinite(start) or not math.isfinite(end) or start != expected or end <= start:
+            raise ManifestError("reference_timeline_invalid")
+        projected = project_chord(segment)
+        if projected.root is None and not projected.no_chord:
+            raise ManifestError("reference_label_invalid")
+        normalized.append(dict(segment, start_seconds=start, end_seconds=end))
+        expected = end
+    return normalized
+
+
+def _clamp_prediction(segments: Sequence[Mapping[str, Any]], duration: float) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for segment in segments:
+        try:
+            start, end = float(segment["start_seconds"]), float(segment["end_seconds"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if not math.isfinite(start) or not math.isfinite(end):
+            raise ManifestError("prediction_timing_invalid")
+        start, end = max(0.0, min(duration, start)), max(0.0, min(duration, end))
+        if end > start:
+            result.append(dict(segment, start_seconds=start, end_seconds=end))
+    return sorted(result, key=lambda item: (float(item["start_seconds"]), float(item["end_seconds"])))
+
+
+def _times(segments: Sequence[Mapping[str, Any]]) -> list[float]:
+    return [float(segment[key]) for segment in segments for key in ("start_seconds", "end_seconds")]
+
+
+def _segment_at(segments: Sequence[Mapping[str, Any]], point: float) -> Mapping[str, Any] | None:
+    return next(
+        (segment for segment in segments if float(segment["start_seconds"]) <= point < float(segment["end_seconds"])),
+        None,
+    )
+
+
+def _boundaries(segments: Sequence[Mapping[str, Any]]) -> list[float]:
+    return [float(segment["end_seconds"]) for segment in segments[:-1]]
+
+
+def _collapse(values: Sequence[ProjectedChord]) -> list[ProjectedChord]:
+    return [value for index, value in enumerate(values) if index == 0 or value != values[index - 1]]
+
+
+def _edit_distance(left: Sequence[ProjectedChord], right: Sequence[ProjectedChord]) -> int:
+    row = list(range(len(right) + 1))
+    for index, item in enumerate(left, 1):
+        next_row = [index]
+        for column, other in enumerate(right, 1):
+            next_row.append(min(next_row[-1] + 1, row[column] + 1, row[column - 1] + (item != other)))
+        row = next_row
+    return row[-1]
+
+
+def _bounded(value: float) -> float:
+    return round(max(0.0, min(1.0, value)), 6)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _arff_rows(path: Path) -> list[list[str]]:
+    try:
+        return [
+            next(csv.reader([line], quotechar="'", skipinitialspace=True))
+            for raw in path.read_text(encoding="utf-8").splitlines()
+            if (line := raw.strip()) and not line.startswith("@")
+        ]
+    except (OSError, csv.Error) as exc:
+        raise ManifestError("public_dataset_annotation_invalid") from exc
+
+
+def _public_selection_pins(payload: Mapping[str, Any], name: str, keys: tuple[str, ...]) -> list[Mapping[str, Any]]:
+    selection = payload.get("selection")
+    pins = selection.get(name) if isinstance(selection, Mapping) else None
+    if (
+        not isinstance(pins, list)
+        or len(pins) != 6
+        or any(
+            not isinstance(pin, Mapping)
+            or any(
+                not isinstance(pin.get(key), str)
+                or (key.endswith("sha256") and re.fullmatch(r"[0-9a-f]{64}", str(pin[key])) is None)
+                for key in keys
+            )
+            for pin in pins
+        )
+    ):
+        raise ManifestError("public_manifest_pin_invalid")
+    return pins
+
+
+def _validate_public_manifest(payload: Mapping[str, Any]) -> None:
+    if payload.get("dataset_version") != "1.1.0" or payload.get("license") != "CC BY 4.0":
+        raise ManifestError("public_manifest_metadata_invalid")
+    source = payload.get("official_source")
+    pins = payload.get("archive_pins")
+    selection = payload.get("selection")
+    if not isinstance(source, str) or not source.startswith("https://doi.org/10.5281/zenodo."):
+        raise ManifestError("public_manifest_source_invalid")
+    if not isinstance(pins, list) or not pins or not isinstance(selection, Mapping) or selection.get("count") != 6:
+        raise ManifestError("public_manifest_pin_invalid")
+    for pin in pins:
+        if (
+            not isinstance(pin, Mapping)
+            or pin.get("checksum_algorithm") != "md5"
+            or not isinstance(pin.get("checksum"), str)
+            or re.fullmatch(r"[0-9a-f]{32}", str(pin["checksum"])) is None
+            or not isinstance(pin.get("bytes"), int)
+            or int(pin["bytes"]) <= 0
+        ):
+            raise ManifestError("public_manifest_pin_invalid")
+
+
+def _public_data_root(payload: Mapping[str, Any], data_root: Path) -> Path:
+    subdir = payload.get("data_subdir")
+    if not isinstance(subdir, str) or not subdir or Path(subdir).is_absolute() or ".." in Path(subdir).parts:
+        raise ManifestError("public_manifest_data_root_invalid")
+    root = data_root.resolve()
+    candidate = (root / subdir).resolve()
+    if root not in candidate.parents:
+        raise ManifestError("public_manifest_data_root_invalid")
+    return candidate
+
+
+def _public_provenance(payload: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "dataset": payload["dataset"],
+        "version": payload["dataset_version"],
+        "license": payload["license"],
+        "source": payload["official_source"],
+        "archive_checksums": [
+            {"algorithm": pin["checksum_algorithm"], "checksum": pin["checksum"]} for pin in payload["archive_pins"]
+        ],
+        "selection_rule": payload["selection"]["rule"],
+    }

--- a/apps/backend/app/benchmarks/chords.py
+++ b/apps/backend/app/benchmarks/chords.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 import time
 import tracemalloc
@@ -10,7 +11,23 @@ from typing import Any
 
 import soundfile as sf
 
+from app.benchmarks.chord_evaluation import (
+    PROJECTION_VERSION,
+    SCHEMA_VERSION,
+    SCORER_VERSION,
+    SYNTHETIC_VERSION,
+    ManifestError,
+    QualityTrack,
+    aggregate_scores,
+    cleanup_synthetic_tracks,
+    load_manifest,
+    load_public_manifest,
+    score_sequence,
+    score_timeline,
+    synthetic_tracks,
+)
 from app.engines.crema_chords import clear_crema_model_cache
+from app.services.audio_working import materialize_pcm_wav
 from app.services.chord_backends import (
     CREMA_CHORD_BACKEND_ID,
     FAST_CHORD_BACKEND_ID,
@@ -34,6 +51,13 @@ def build_benchmark_report(audio_path: Path, backend_ids: list[str] | None = Non
 
 
 def summarize_report(report: dict[str, Any]) -> str:
+    if report.get("schema_version") == SCHEMA_VERSION:
+        lines = ["Chord quality benchmark"]
+        for result in report.get("results", []):
+            backend_id = result.get("backend_id", "backend")
+            errors = result.get("error_count", 0)
+            lines.append(f"- {backend_id}: quality evaluation, {errors} sanitized errors")
+        return "\n".join(lines)
     lines = [
         f"Chord benchmark: {report['audio_path']}",
         f"Track duration: {report['track_duration_seconds']}",
@@ -60,7 +84,19 @@ def summarize_report(report: dict[str, Any]) -> str:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Benchmark TuneForge chord detection backends.")
-    parser.add_argument("--audio", required=True, type=Path, help="Path to an audio file.")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--audio", type=Path, help="Path to an audio file.")
+    mode.add_argument(
+        "--quality-synthetic", action="store_true", help="Run deterministic synthetic quality evaluation."
+    )
+    mode.add_argument(
+        "--quality-manifest",
+        action="append",
+        type=Path,
+        dest="quality_manifests",
+        help="Manifest path. Repeat for multiple manifests.",
+    )
+    parser.add_argument("--data-root", type=Path, help="Root used only to resolve quality-manifest audio paths.")
     parser.add_argument(
         "--backend",
         action="append",
@@ -71,13 +107,205 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     backend_ids = [resolve_chord_backend_id(backend) for backend in args.backends] if args.backends else None
-    report = build_benchmark_report(args.audio, backend_ids)
+    if args.audio is not None:
+        report = build_benchmark_report(args.audio, backend_ids)
+    else:
+        try:
+            report = build_quality_report(
+                synthetic=args.quality_synthetic,
+                manifest_paths=args.quality_manifests or [],
+                data_root=args.data_root,
+                backend_ids=backend_ids,
+            )
+        except ManifestError as exc:
+            sys.stderr.write(f"Chord quality benchmark failed: {exc}\n")
+            return 2
     sys.stdout.write(json.dumps(report, indent=2))
     sys.stdout.write("\n")
     if not args.json_only:
         sys.stderr.write(summarize_report(report))
         sys.stderr.write("\n")
     return 0
+
+
+def build_quality_report(
+    *,
+    synthetic: bool,
+    manifest_paths: list[Path],
+    data_root: Path | None,
+    backend_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    """Run an anonymous quality report; never retain source identities or labels."""
+    if not synthetic and (data_root is None or not manifest_paths):
+        raise ManifestError("quality_data_root_required")
+    selected_backend_ids = backend_ids or list(DEFAULT_BENCHMARK_BACKENDS)
+    tracks = synthetic_tracks() if synthetic else _load_quality_tracks(manifest_paths, data_root)
+    backends = {
+        backend_id: resolve_chord_backend(backend_id, require_available=False) for backend_id in selected_backend_ids
+    }
+    try:
+        per_backend: dict[str, list[dict[str, Any]]] = {backend_id: [] for backend_id in selected_backend_ids}
+        errors: dict[str, int] = {backend_id: 0 for backend_id in selected_backend_ids}
+        provenance = {
+            backend.id: _safe_backend_provenance(backend.id, backend.label, backend.availability().available)
+            for backend in backends.values()
+        }
+        for track in tracks:
+            # Exactly one decode/materialization scope per track; every backend sees this path.
+            try:
+                with materialize_pcm_wav(track.audio_path) as working_path:
+                    for backend in backends.values():
+                        availability = backend.availability()
+                        if not availability.available:
+                            errors[backend.id] = errors.get(backend.id, 0) + 1
+                            continue
+                        try:
+                            result = detect_with_chord_backend(working_path, backend.id)
+                            provenance[backend.id] = _safe_backend_provenance(
+                                backend.id, backend.label, True, result.metadata
+                            )
+                            score = (
+                                score_timeline(
+                                    track.reference,
+                                    result.segments,
+                                    extension_scoreable=track.extension_scoreable,
+                                    bass_scoreable=track.bass_scoreable,
+                                )
+                                if track.timeline
+                                else score_sequence(
+                                    track.reference,
+                                    [
+                                        value
+                                        if isinstance(value := segment.get("raw_label", segment.get("label")), str)
+                                        else "?"
+                                        for segment in result.segments
+                                    ],
+                                )
+                            )
+                            per_backend[backend.id].append(
+                                {
+                                    "dataset": track.dataset,
+                                    "strata": track.strata,
+                                    "score": score,
+                                    "public_provenance": track.public_provenance,
+                                }
+                            )
+                        except Exception:
+                            errors[backend.id] = errors.get(backend.id, 0) + 1
+            except Exception:
+                for backend in backends.values():
+                    errors[backend.id] = errors.get(backend.id, 0) + 1
+        return _anonymous_quality_report(per_backend, errors, provenance)
+    finally:
+        if synthetic:
+            cleanup_synthetic_tracks(tracks)
+
+
+def _load_quality_tracks(paths: list[Path], data_root: Path | None) -> list[QualityTrack]:
+    assert data_root is not None
+    tracks: list[QualityTrack] = []
+    for manifest_index, path in enumerate(paths, 1):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ManifestError("manifest_invalid") from exc
+        schema = payload.get("schema_version") if isinstance(payload, dict) else None
+        if schema == "chord-public-manifest-v1":
+            tracks.extend(load_public_manifest(path, data_root))
+        elif schema == "chord-quality-manifest-v1":
+            external_dataset = f"dataset_{manifest_index:03d}"
+            tracks.extend(
+                QualityTrack(
+                    external_dataset,
+                    track.slot,
+                    track.strata,
+                    track.audio_path,
+                    track.reference,
+                    track.timeline,
+                    track.extension_scoreable,
+                    track.bass_scoreable,
+                    track.audio_sha256,
+                    track.public_provenance,
+                )
+                for track in load_manifest(path, data_root)
+            )
+        else:
+            raise ManifestError("manifest_schema_invalid")
+    return tracks
+
+
+def _safe_backend_provenance(
+    backend_id: str, label: str, available: bool, metadata: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    safe_metadata: dict[str, str] = {}
+    for key, value in (metadata or {}).items():
+        if (
+            key
+            in {
+                "engine",
+                "analysis_version",
+                "model",
+                "model_version",
+                "runtime_device",
+                "crema_version",
+                "tensorflow_version",
+            }
+            and isinstance(value, (str, int, float))
+            and _is_safe_provenance_value(str(value))
+        ):
+            safe_metadata[key] = str(value)[:80]
+    return {"backend_id": backend_id, "backend_label": label, "available": available, "provenance": safe_metadata}
+
+
+def _anonymous_quality_report(
+    per_backend: dict[str, list[dict[str, Any]]],
+    errors: dict[str, int],
+    provenance: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    results: list[dict[str, Any]] = []
+    for backend_id in sorted(per_backend):
+        rows = per_backend[backend_id]
+        datasets: dict[str, Any] = {}
+        for dataset in sorted({str(row["dataset"]) for row in rows}):
+            selected = [row["score"] for row in rows if row["dataset"] == dataset]
+            strata: dict[str, Any] = {}
+            for stratum in sorted({item for row in rows if row["dataset"] == dataset for item in row["strata"]}):
+                strata[stratum] = aggregate_scores(
+                    [row["score"] for row in rows if row["dataset"] == dataset and stratum in row["strata"]]
+                )
+            public_provenance = next(
+                (row["public_provenance"] for row in rows if row["dataset"] == dataset and row["public_provenance"]),
+                None,
+            )
+            datasets[dataset] = {
+                "aggregate": aggregate_scores(selected),
+                "strata": strata,
+                **({"provenance": public_provenance} if public_provenance else {}),
+            }
+        results.append(
+            {
+                **provenance.get(backend_id, {"backend_id": backend_id, "available": False, "provenance": {}}),
+                "datasets": datasets,
+                "aggregate": aggregate_scores([row["score"] for row in rows]),
+                "error_count": errors.get(backend_id, 0),
+            }
+        )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "scorer": {
+            "version": SCORER_VERSION,
+            "projection_version": PROJECTION_VERSION,
+            "synthetic_version": SYNTHETIC_VERSION,
+            "tool_version": "app.benchmarks.chords-v1",
+        },
+        "results": results,
+    }
+
+
+def _is_safe_provenance_value(value: str) -> bool:
+    return bool(re.fullmatch(r"[A-Za-z0-9_.+-]+", value)) and not any(
+        token in value.lower() for token in ("private", "secret")
+    )
 
 
 def _benchmark_backend(audio_path: Path, backend_id: str) -> dict[str, Any]:

--- a/apps/backend/app/benchmarks/manifests/guitarset-1.1.0.json
+++ b/apps/backend/app/benchmarks/manifests/guitarset-1.1.0.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "chord-public-manifest-v1",
+  "dataset": "guitarset",
+  "dataset_version": "1.1.0",
+  "license": "CC BY 4.0",
+  "official_source": "https://doi.org/10.5281/zenodo.3371780",
+  "adapter": "guitarset-jams-v1",
+  "data_subdir": "guitarset",
+  "archive_pins": [
+    {
+      "kind": "annotations",
+      "checksum_algorithm": "md5",
+      "checksum": "b39b78e63d3446f2e54ddb7a54df9b10",
+      "bytes": 39132574
+    },
+    {
+      "kind": "mono_microphone_audio",
+      "checksum_algorithm": "md5",
+      "checksum": "275966d6610ac34999b58426beb119c3",
+      "bytes": 656927981
+    }
+  ],
+  "selection": {
+    "rule": "select six lowest SHA-256 digests of paired annotation basenames",
+    "count": 6,
+    "annotation_glob": "annotations/*.jams",
+    "audio_template": "audio/{basename}_mic.wav",
+    "selected_annotations": [
+      {"basename": "05_Funk3-98-A_solo", "sha256": "cece1d8b559e6a86a7a9265928060f2c9c8c812d9e19453bf76d41b3c415c65e", "audio_sha256": "62b9db961f832c0b893f64363b9963bd46c5cef0128fad31236d6aee4c9ef4e2"},
+      {"basename": "05_Jazz1-200-B_comp", "sha256": "1b831c294ee0c18e8299df4247ebc969d96cffd2d02f1cd24161046c9e3fa3a9", "audio_sha256": "00cdf3460ef31be49312fb7f3c520045a85b83b6b1b70b9efd9a986431490281"},
+      {"basename": "03_Rock1-130-A_comp", "sha256": "502ab4f7788bad71bafe9572ba185e698b3cf82576be105acd6d4112b711f1fa", "audio_sha256": "5e71387daf08213651f8b8f0d9b1db7d589cbc6b9fefd8e052e13a1f8f7286ca"},
+      {"basename": "02_SS2-107-Ab_solo", "sha256": "38ba295df29b31a842aa37d28a9b6ed6b3e36f648566dfab60a9647bc89e428b", "audio_sha256": "62dd76b1551d81484981161808a281eb5785027110b6ace56c701edd04320685"},
+      {"basename": "05_Funk3-112-C#_solo", "sha256": "b7ebab2a0e1c8b68f0359646704c9644a4b18fca4083f6816909a7f9bec693a7", "audio_sha256": "32862cde85f0a3f1d9b22e1c734a5b1433f4149a268edf9cc578b122f66ba00b"},
+      {"basename": "00_Funk1-97-C_solo", "sha256": "00c77a22d7a0022002926f186ec11cc6c66d4fd2704619e1869dab76a712aade", "audio_sha256": "8e0d08e0e2c8b1a66ff50cb7e0a7433d87068620d9c607394412ca4248238ee3"}
+    ]
+  },
+  "safe_strata": ["solo-guitar", "accompaniment"]
+}

--- a/apps/backend/app/benchmarks/manifests/tiny-aam-1.1.0.json
+++ b/apps/backend/app/benchmarks/manifests/tiny-aam-1.1.0.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "chord-public-manifest-v1",
+  "dataset": "tiny-aam",
+  "dataset_version": "1.1.0",
+  "license": "CC BY 4.0",
+  "official_source": "https://doi.org/10.5281/zenodo.6771120",
+  "adapter": "tiny-aam-arff-v1",
+  "data_subdir": "tiny-aam",
+  "archive_pins": [
+    {
+      "kind": "dataset_archive",
+      "checksum_algorithm": "md5",
+      "checksum": "9121d5ae106747e67721bde0d55f9e00",
+      "bytes": 168412253
+    }
+  ],
+  "selection": {
+    "rule": "select six lowest SHA-256 digests of paired audio basenames",
+    "count": 6,
+    "audio_glob": "audio-mixes-mp3/*_mix.mp3",
+    "annotation_templates": ["annotations/{basename}_beatinfo.arff", "annotations/{basename}_segments.arff"],
+    "selected_assets": [
+      {"id": "0758", "audio_sha256": "c348cfa14ed0996c343fb0b52a5f51db1d698b942f9dfd0821890eb35d3199e6", "beatinfo_sha256": "13a5ed1dc34de6523c64e7859edf0233e54bbbbf19a494e1424839ea0331563d", "segments_sha256": "826f804ffc0f47a5918d72af64baea648da42f1e46e4ee2d9ff2409538464133"},
+      {"id": "2395", "audio_sha256": "9cb0c6954a11b3b339a002e1cc65763ae5011aa558cc85ed9a1c0e4c3e23b314", "beatinfo_sha256": "98a228f1ed783e03e896907098e88426459a1642bb6fa2cfb3df78f0775716ba", "segments_sha256": "3130966fb3a7ebef1846dbe61aea8b38dec4516780d249598eaa1717fd94f632"},
+      {"id": "1941", "audio_sha256": "cfb0e8e32dc0ca2bb69147e2de7392c16a07711a14eadc0a0b3939360dacf6c3", "beatinfo_sha256": "07cc1718f37a20ba2b4f52c63d890af7da5d7db345c54961a58b5ae4e66c550d", "segments_sha256": "b995b425d2917e29426caed66a76e102deef8cb8d5cefd7945c91e7ff3f66054"},
+      {"id": "0001", "audio_sha256": "a5a1b0b4ed5e435106a0e4b5659f4849332b5dd611fdbc3bc4fb79f4958512e4", "beatinfo_sha256": "33e870a406ed13142b6ad7c7f28c9f6043b52fa17bb51aff943ec087df495afa", "segments_sha256": "62c0cf1c05c5ba2ec0fcba9d5a9e3dfcae3a84f869ea83a5fff7c02358b3e315"},
+      {"id": "2841", "audio_sha256": "c2e14c61e27dd616e9ea34453fdf511e1ae213b56683494d13751ae5a450fbf0", "beatinfo_sha256": "e94b7f1ff6530c9ec36d466aa6f7675d98db567a8b58094461c26ee03e4b3407", "segments_sha256": "866567461587dd57c56a08b22d9607a4f346f75c68830b48c360e868b368208d"},
+      {"id": "3000", "audio_sha256": "1f7b4f5e1866cefbd5174c8487f044a834d16122e6ddb7120f14be1f96529aa8", "beatinfo_sha256": "6bb40cdf68015c41ed343250aaa9ec0e075de516b9ac85a4da3ffe7d3d4bab43", "segments_sha256": "70a686dfcf26aeb9ef390e844e2956c6175a2c8b79f3cc6732f73bcbd6be1af7"}
+    ]
+  },
+  "safe_strata": ["full-mix"]
+}

--- a/apps/backend/tests/test_chord_benchmarks.py
+++ b/apps/backend/tests/test_chord_benchmarks.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import wave
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.benchmarks.chord_evaluation import (
+    ManifestError,
+    QualityTrack,
+    aggregate_scores,
+    cleanup_synthetic_tracks,
+    load_manifest,
+    load_public_manifest,
+    match_boundaries,
+    project_chord,
+    score_sequence,
+    score_timeline,
+    synthetic_tracks,
+)
+from app.benchmarks.chords import build_quality_report, main
+
+
+def _timeline(*labels: str) -> list[dict[str, Any]]:
+    return [
+        {"start_seconds": float(index), "end_seconds": float(index + 1), "label": label}
+        for index, label in enumerate(labels)
+    ]
+
+
+def test_projection_is_scorer_owned_and_normalizes_chord_equivalences() -> None:
+    assert project_chord("C13") == project_chord("C:13")
+    assert project_chord("Cmaj9") == project_chord("C:maj9")
+    assert project_chord("Cm9") == project_chord("C:min9")
+    assert project_chord("C5") == project_chord("C:(5)")
+    assert project_chord("C:maj/3").bass == 4
+    assert project_chord("Cadd9/E").bass == 4
+    assert project_chord("C:hdim7") == project_chord("Cm7b5")
+    assert project_chord("C:(1,b3,b5,b7)") == project_chord("C:hdim7")
+    assert project_chord("N.C.").no_chord is True
+    assert project_chord("not-a-chord").root is None
+
+
+def test_timeline_scoring_clamps_predictions_and_matches_boundaries() -> None:
+    score = score_timeline(
+        _timeline("C", "G"),
+        [{"start_seconds": -2, "end_seconds": 1, "label": "C"}, {"start_seconds": 1, "end_seconds": 9, "label": "G"}],
+    )
+    assert score["root"] == 1.0
+    assert score["boundary"] == {"matched": 1, "reference": 1, "prediction": 1}
+    assert match_boundaries([1.0], [1.24]) == (1, 0, 0)
+    assert match_boundaries([1.0], [1.251]) == (0, 1, 1)
+    assert match_boundaries([0.2, 0.5], [0.0, 0.3]) == (2, 0, 0)
+
+
+def test_prediction_nonfinite_times_fail_before_clamping() -> None:
+    with pytest.raises(ManifestError, match="prediction_timing_invalid"):
+        score_timeline(_timeline("C"), [{"start_seconds": math.nan, "end_seconds": math.inf, "label": "C"}])
+
+
+def test_reference_rejects_gaps_except_explicit_no_chord_segments() -> None:
+    with pytest.raises(ManifestError, match="reference_timeline_invalid"):
+        score_timeline(
+            [
+                {"start_seconds": 0, "end_seconds": 1, "label": "C"},
+                {"start_seconds": 1.1, "end_seconds": 2, "label": "N.C."},
+            ],
+            _timeline("C", "N.C."),
+        )
+
+
+def test_no_chord_and_source_unsupported_capabilities_are_explicit() -> None:
+    score = score_timeline(
+        _timeline("N.C.", "C"),
+        _timeline("N.C.", "C"),
+        bass_scoreable=False,
+        extension_scoreable=False,
+    )
+    assert score["nc"]["correct_seconds"] == 1.0
+    assert score["bass"] is None and score["bass_reason"]
+    assert score["seventh_extension"] is None and score["seventh_extension_reason"]
+    aggregate = aggregate_scores([score])
+    assert aggregate["nc_precision"] == aggregate["nc_recall"] == 1.0
+
+
+def test_capability_limited_backend_is_still_scored_and_unknown_is_not_no_chord() -> None:
+    score = score_timeline(_timeline("N.C.", "C13"), [{"start_seconds": 0, "end_seconds": 2, "label": "X"}])
+    assert score["root"] == 0.0
+    assert score["seventh_extension"] == 0.0
+    assert score["bass"] == 0.0
+
+
+def test_projection_mapping_raw_labels_and_harte_degree_sets_preserve_extensions() -> None:
+    for label, coarse in (("C13", "major"), ("Cmaj9", "major"), ("Cm9", "minor"), ("C5", "major")):
+        assert project_chord({"raw_label": label, "quality": coarse, "root_pitch_class": 0}) == project_chord(label)
+    assert project_chord("C:(1,3,5,b7,9,13)") == project_chord("C13")
+    assert project_chord("C:(1,3,5,7,9)") == project_chord("Cmaj9")
+    assert project_chord("C:(1,b3,5,b7,9)") == project_chord("Cm9")
+    assert project_chord("C:(1,5)") == project_chord("C5")
+    assert project_chord("C:(1,5,b7)").extension == "7"
+    assert project_chord("C:13/13").bass == 9
+    assert project_chord("C:maj/#11").bass == 6
+    assert project_chord("C:maj/b10").bass == 3
+
+
+def test_untimed_sequence_is_separate_from_timeline_metrics() -> None:
+    score = score_sequence(["C", "C", "G"], ["C", "G"])
+    assert score["sequence_edit_similarity"] == 1.0
+    assert score["root"] is None
+    assert score["timeline_reason"] == "untimed_reference"
+
+
+def test_pooled_aggregation_and_metric_bounds() -> None:
+    perfect = score_timeline(_timeline("C"), _timeline("C"))
+    wrong = score_timeline(_timeline("C", "G"), _timeline("F", "F"))
+    aggregate = aggregate_scores([perfect, wrong, score_sequence(["C"], ["G"])])
+    assert aggregate["timeline_track_count"] == 2
+    assert aggregate["sequence_track_count"] == 1
+    for value in (
+        aggregate["root"],
+        aggregate["quality"],
+        aggregate["boundary_f1_250ms"],
+        aggregate["nc_precision"],
+        aggregate["nc_recall"],
+        aggregate["sequence_edit_similarity"],
+    ):
+        assert value is None or 0 <= value <= 1
+    assert aggregate["correction_proxy_per_minute"] is not None
+
+
+def test_external_manifest_fails_closed_on_bad_hash_and_preserves_source(tmp_path: Path) -> None:
+    data_root = tmp_path / "data"
+    data_root.mkdir()
+    audio = data_root / "secret-input.wav"
+    audio.write_bytes(b"source bytes")
+    before = audio.stat().st_mtime_ns
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": "chord-quality-manifest-v1",
+                "dataset": "external",
+                "tracks": [
+                    {
+                        "audio": "secret-input.wav",
+                        "sha256": "0" * 64,
+                        "strata": ["full-mix"],
+                        "timeline": _timeline("C"),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ManifestError, match="manifest_audio_hash_invalid"):
+        load_manifest(manifest, data_root)
+    assert audio.read_bytes() == b"source bytes"
+    assert audio.stat().st_mtime_ns == before
+
+
+def test_quality_cli_hides_manifest_identifiers_and_labels(tmp_path: Path, monkeypatch, capsys) -> None:
+    data_root = tmp_path / "data"
+    data_root.mkdir()
+    audio = data_root / "very-secret-input.wav"
+    audio.write_bytes(b"source bytes")
+    digest = hashlib.sha256(audio.read_bytes()).hexdigest()
+    manifest = tmp_path / "private-manifest-name.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": "chord-quality-manifest-v1",
+                "dataset": "external",
+                "tracks": [{"audio": audio.name, "sha256": digest, "strata": ["full-mix"], "timeline": _timeline("C")}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    _patch_quality_backend(monkeypatch)
+    assert (
+        main(["--quality-manifest", str(manifest), "--data-root", str(data_root), "--backend", "fast", "--json-only"])
+        == 0
+    )
+    captured = capsys.readouterr()
+    assert "secret" not in captured.out.lower()
+    assert "private" not in captured.out.lower()
+    assert "very-secret" not in captured.err.lower()
+    assert "audio_path" not in captured.out
+    assert "dataset_001" in captured.out
+    assert '"external"' not in captured.out
+
+
+def test_quality_cli_non_json_summary_is_anonymous(monkeypatch, capsys) -> None:
+    _patch_quality_backend(monkeypatch)
+    assert main(["--quality-synthetic", "--backend", "fast"]) == 0
+    captured = capsys.readouterr()
+    assert "Chord quality benchmark" in captured.err
+    assert "fixture" not in captured.out.lower()
+
+
+def test_quality_materializes_once_per_track_and_cleans_synthetic_pcm(monkeypatch) -> None:
+    seen: list[Path] = []
+
+    @contextmanager
+    def materialize(path: Path):
+        seen.append(path)
+        yield path
+
+    _patch_quality_backend(monkeypatch)
+    monkeypatch.setattr("app.benchmarks.chords.materialize_pcm_wav", materialize)
+    first = build_quality_report(synthetic=True, manifest_paths=[], data_root=None, backend_ids=["tuneforge-fast"])
+    second = build_quality_report(synthetic=True, manifest_paths=[], data_root=None, backend_ids=["tuneforge-fast"])
+    assert first == second
+    assert len(seen) == 6
+    assert all(not path.exists() for path in seen)
+
+
+def test_synthetic_chords_render_distinct_harmonic_windows() -> None:
+    tracks = synthetic_tracks()
+    try:
+        with wave.open(str(tracks[1].audio_path), "rb") as handle:
+            c13 = handle.readframes(400)
+            handle.setpos(3 * 8_000)
+            power = handle.readframes(400)
+        assert c13 != power
+    finally:
+        cleanup_synthetic_tracks(tracks)
+
+
+def test_materialization_failures_are_sanitized_and_continue(monkeypatch, capsys) -> None:
+    @contextmanager
+    def broken_materialize(path: Path):
+        raise RuntimeError(f"private-source-sentinel:{path}")
+        yield path
+
+    _patch_quality_backend(monkeypatch)
+    monkeypatch.setattr("app.benchmarks.chords.materialize_pcm_wav", broken_materialize)
+    assert main(["--quality-synthetic", "--backend", "fast", "--json-only"]) == 0
+    captured = capsys.readouterr()
+    assert "private-source-sentinel" not in captured.out + captured.err
+    assert json.loads(captured.out)["results"][0]["error_count"] == 3
+
+
+def test_report_has_overall_dataset_and_stratum_aggregates(monkeypatch) -> None:
+    tracks = [
+        QualityTrack(
+            "alpha",
+            "track_001",
+            ("synthetic",),
+            Path("/tmp/a.wav"),
+            _timeline("C"),
+            True,
+            True,
+            True,
+            public_provenance={"dataset": "alpha", "version": "1", "license": "CC BY 4.0", "source": "https://safe"},
+        ),
+        QualityTrack("beta", "track_002", ("full-mix",), Path("/tmp/b.wav"), _timeline("G"), True, True, False),
+    ]
+
+    @contextmanager
+    def materialize(path: Path):
+        yield path
+
+    _patch_quality_backend(monkeypatch)
+    monkeypatch.setattr("app.benchmarks.chords.synthetic_tracks", lambda: tracks)
+    monkeypatch.setattr("app.benchmarks.chords.cleanup_synthetic_tracks", lambda _: None)
+    monkeypatch.setattr("app.benchmarks.chords.materialize_pcm_wav", materialize)
+    report = build_quality_report(synthetic=True, manifest_paths=[], data_root=None, backend_ids=["tuneforge-fast"])
+    result = report["results"][0]
+    assert result["aggregate"]["track_count"] == 2
+    assert set(result["datasets"]) == {"alpha", "beta"}
+    assert result["datasets"]["alpha"]["strata"]["synthetic"]["track_count"] == 1
+    assert result["datasets"]["alpha"]["provenance"]["license"] == "CC BY 4.0"
+    aggregate = result["aggregate"]
+    assert aggregate["bass_reason"] == "partial_metric_support"
+    assert aggregate["bass_support_track_count"] == 1
+    assert aggregate["segment_count_absolute_error"] >= 0
+
+
+def test_unsafe_backend_provenance_is_dropped_from_quality_report(monkeypatch) -> None:
+    _patch_quality_backend(monkeypatch)
+    monkeypatch.setattr(
+        "app.benchmarks.chords.detect_with_chord_backend",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            segments=_timeline("C", "G", "Am", "F"),
+            metadata={"engine": "/private/source/path", "crema_version": "secret-build"},
+        ),
+    )
+    report = build_quality_report(synthetic=True, manifest_paths=[], data_root=None, backend_ids=["tuneforge-fast"])
+    assert report["results"][0]["provenance"] == {}
+
+
+def test_vendored_public_manifest_pins_are_strict() -> None:
+    root = Path(__file__).parents[1] / "app" / "benchmarks" / "manifests"
+    for name in ("guitarset-1.1.0.json", "tiny-aam-1.1.0.json"):
+        payload = json.loads((root / name).read_text(encoding="utf-8"))
+        assert payload["schema_version"] == "chord-public-manifest-v1"
+        assert payload["dataset_version"] == "1.1.0"
+        assert payload["license"] == "CC BY 4.0"
+        assert payload["data_subdir"] in {"guitarset", "tiny-aam"}
+        assert payload["selection"]["count"] == 6
+        assert all(len(pin["checksum"]) == 32 for pin in payload["archive_pins"])
+        selected = payload["selection"].get("selected_annotations", payload["selection"].get("selected_assets"))
+        assert isinstance(selected, list) and len(selected) == 6
+        for asset in selected:
+            assert all(len(value) == 64 for key, value in asset.items() if key.endswith("sha256"))
+    guitarset = json.loads((root / "guitarset-1.1.0.json").read_text(encoding="utf-8"))
+    assert guitarset["safe_strata"] == ["solo-guitar", "accompaniment"]
+
+
+def test_public_manifest_data_subdirs_resolve_two_fake_corpora_with_timed_aam(tmp_path: Path, monkeypatch) -> None:
+    root = tmp_path / "corpora"
+    guitar = root / "guitarset"
+    tiny = root / "tiny-aam"
+    guitar_annotations, guitar_audio = guitar / "annotations", guitar / "audio"
+    tiny_audio, tiny_annotations = tiny / "audio-mixes-mp3", tiny / "annotations"
+    for directory in (guitar_annotations, guitar_audio, tiny_audio, tiny_annotations):
+        directory.mkdir(parents=True, exist_ok=True)
+    guitar_names = ["a_solo", "b_comp", "c_solo", "d_comp", "e_solo", "f_comp"]
+    for name in guitar_names:
+        (guitar_annotations / f"{name}.jams").write_text(
+            json.dumps(
+                {
+                    "annotations": [
+                        {
+                            "namespace": "chord",
+                            "annotation_metadata": {"data_source": "manual verification"},
+                            "data": [{"time": 0, "duration": 1, "value": "C"}],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        _write_fake_wav(guitar_audio / f"{name}_mic.wav")
+    tiny_ids = ["0001", "0002", "0003", "0004", "0005", "0006"]
+    for identifier in tiny_ids:
+        _write_fake_wav(tiny_audio / f"{identifier}_mix.mp3")
+        (tiny_annotations / f"{identifier}_beatinfo.arff").write_text("0,x,x,C\n0.5,x,x,G\n", encoding="utf-8")
+        (tiny_annotations / f"{identifier}_segments.arff").write_text("", encoding="utf-8")
+    monkeypatch.setattr("app.benchmarks.chord_evaluation._sha256", lambda _: "pinned")
+    guitar_paths = sorted(
+        guitar_annotations.glob("*.jams"), key=lambda path: hashlib.sha256(path.name.encode()).digest()
+    )
+    tiny_paths = sorted(tiny_audio.glob("*_mix.mp3"), key=lambda path: hashlib.sha256(path.name.encode()).digest())
+    monkeypatch.setattr(
+        "app.benchmarks.chord_evaluation._public_selection_pins",
+        lambda _payload, name, _keys: (
+            [{"basename": path.stem, "sha256": "pinned", "audio_sha256": "pinned"} for path in guitar_paths]
+            if name == "selected_annotations"
+            else [
+                {
+                    "id": path.stem.removesuffix("_mix"),
+                    "audio_sha256": "pinned",
+                    "beatinfo_sha256": "pinned",
+                    "segments_sha256": "pinned",
+                }
+                for path in tiny_paths
+            ]
+        ),
+    )
+    guitar_manifest = _fake_public_manifest("guitarset", "guitarset-jams-v1")
+    tiny_manifest = _fake_public_manifest("tiny-aam", "tiny-aam-arff-v1")
+    guitar_path, tiny_path = tmp_path / "guitar.json", tmp_path / "tiny.json"
+    guitar_path.write_text(json.dumps(guitar_manifest), encoding="utf-8")
+    tiny_path.write_text(json.dumps(tiny_manifest), encoding="utf-8")
+    guitar_tracks = load_public_manifest(guitar_path, root)
+    tiny_tracks = load_public_manifest(tiny_path, root)
+    assert {track.strata[0] for track in guitar_tracks} == {"solo-guitar", "accompaniment"}
+    assert all(track.timeline and not track.bass_scoreable for track in tiny_tracks)
+    assert all(track.reference[-1]["end_seconds"] == 1.0 for track in tiny_tracks)
+
+
+def _fake_public_manifest(subdir: str, adapter: str) -> dict[str, Any]:
+    return {
+        "schema_version": "chord-public-manifest-v1",
+        "dataset": subdir,
+        "dataset_version": "1.1.0",
+        "license": "CC BY 4.0",
+        "official_source": "https://doi.org/10.5281/zenodo.1",
+        "adapter": adapter,
+        "data_subdir": subdir,
+        "archive_pins": [{"checksum_algorithm": "md5", "checksum": "0" * 32, "bytes": 1}],
+        "selection": {"count": 6, "rule": "fake"},
+    }
+
+
+def _write_fake_wav(path: Path) -> None:
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(8_000)
+        handle.writeframes(b"\0\0" * 8_000)
+
+
+def _patch_quality_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    backend = SimpleNamespace(
+        id="tuneforge-fast",
+        label="Built-in Chords",
+        capabilities=SimpleNamespace(supports_sevenths=True, supports_inversions=False),
+        availability=lambda: SimpleNamespace(available=True),
+    )
+    monkeypatch.setattr("app.benchmarks.chords.resolve_chord_backend", lambda *_args, **_kwargs: backend)
+    monkeypatch.setattr(
+        "app.benchmarks.chords.detect_with_chord_backend",
+        lambda *_args, **_kwargs: SimpleNamespace(segments=_timeline("C", "G", "Am", "F"), metadata={"engine": "test"}),
+    )

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build:packaged-frontend": "node scripts/build-packaged-frontend.mjs",
     "bundle:prepare": "node scripts/prepare-bundle.mjs",
+    "chords:benchmark": "bash -c 'if [[ \"${1:-}\" == \"--\" ]]; then shift; fi; exec bash scripts/run-backend-module.sh app.benchmarks.chords \"$@\"' --",
     "contracts:generate": "pnpm --filter @tuneforge/shared-types generate",
     "dev": "concurrently -n backend,desktop -c blue,green \"pnpm dev:backend\" \"pnpm dev:desktop\"",
     "android:studio:shim": "bash scripts/android-studio-root-shim.sh",


### PR DESCRIPTION
## Summary

Adds reproducible, manual-only chord quality evaluation to the existing backend benchmark CLI.
Supports deterministic synthetic fixtures, verified external/public manifests, anonymous aggregate
reports, and a root package command. Regular CI remains unchanged.

## Motivation

TuneForge needs stable evidence for comparing current and future chord engines without retaining
private research runners, copyrighted audio, or source identities in the repository.

Fixes #473

## Changes

- Add one backend-independent chord projection and duration-weighted timeline scorer.
- Add boundary, no-chord, segmentation, correction-proxy, and untimed sequence metrics.
- Add deterministic synthetic fixtures plus pinned GuitarSet and Tiny AAM manifest adapters.
- Add fail-closed manifest checks, anonymous reports, sanitized errors, and safe provenance.
- Preserve existing runtime benchmark mode and add the manual `pnpm chords:benchmark` command.
- Document manual usage, privacy boundaries, and external dataset requirements.

## Test Plan

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 815 desktop, 365 Rust, and 750 backend tests passed, plus helper suites.
- `pnpm chords:benchmark -- --help`
- `pnpm chords:benchmark -- --quality-synthetic --backend tuneforge-fast --json-only`
- Ran synthetic evaluation twice with byte-identical JSON and zero errors.
- Ran the pinned 12-track GuitarSet/Tiny AAM public selection with zero processing errors.

## Checklist

- [x] PR title follows Conventional Commits.
- [x] `pnpm lint` passes.
- [x] `pnpm typecheck` passes.
- [x] `pnpm test` passes.
- [x] Backend routes and schemas are unchanged; contract generation is not applicable.
- [x] Product behavior is unchanged; a changelog entry is not applicable.
- [x] Release/package behavior is unchanged; release package evidence is not applicable.
- [x] Relevant backend documentation is updated.
- [x] No secrets, credentials, copyrighted audio, model weights, caches, or reports were added.
