### PR TITLE
feat: default to Beat This analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ download, installation, verification, signature, and publication instructions.
 
 ## [Unreleased]
 
+### Changed
+
+- Made Advanced Beat Analysis the default beat-analysis request. Built-in Beat Analysis remains an
+  explicit choice for mobile, dependency-excluded packages, and users who opt out; advanced beat
+  runtime failures now fail the job.
+
 ## [1.2.0] - 2026-08-24
 
 ### Added

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -64,23 +64,28 @@ dependency stack. Built-in Chords fallback should stay available when that stack
 
 ### Advanced Beat Analysis backend
 
-Advanced Beat Analysis is the default desktop timing-grid backend when the desktop dependency stack
-and `small0` checkpoint are available. Built-in Beat Analysis uses TuneForge's built-in
-librosa-derived beat tracker, sparse-gap stabilization, and downbeat heuristics, and stays available
-as the fallback.
+Advanced Beat Analysis is the default desktop timing-grid request. It uses the optional `beat-this`
+dependency and downloads or loads its `small0` checkpoint on first use. Built-in Beat Analysis uses
+TuneForge's local librosa-derived beat tracker, sparse-gap stabilization, and downbeat heuristics,
+and remains available as an explicit alternative.
 
-Advanced Beat Analysis is backed by [`beat-this`](https://github.com/CPJKU/beat_this). It runs when
-an analyze request uses `"beat_backend": "beat-this"`; desktop preferences and desktop import flows
-select it by default when available. For the default desktop setup:
+Advanced Beat Analysis is backed by [`beat-this`](https://github.com/CPJKU/beat_this). Analyze,
+import, and bulk analyze requests default to `"beat_backend": "beat-this"`; desktop actions send the
+saved choice to the backend. For the default desktop setup:
 
 ```sh
 pnpm setup:dev
 ```
 
-The backend loads `beat-this` lazily and uses its `small0` checkpoint on CPU. `pnpm setup:dev`
+The backend loads `beat-this` lazily and uses its `small0` checkpoint on CPU. An Advanced Beat
+Analysis request fails if its optional dependency is missing or if checkpoint download, load,
+runtime, or timing analysis ultimately fails. It never silently switches analysis engines. An
+explicit Built-in Beat Analysis request never probes `beat-this`. `pnpm setup:dev`
 verifies the checkpoint with size and SHA-256 before importing beat-this; if it is missing or
-invalid, setup preloads it. If the dependency or checkpoint is unavailable, the advanced settings
-option is disabled and Built-in Beat Analysis keeps working.
+invalid, setup preloads it. Normal desktop builds submit the saved Advanced Beat Analysis choice even
+if dependency diagnostics fail, so the job reports the failure instead of silently switching engines.
+Packages built with `--no-beat-this` embed that intentional opt-out and desktop actions explicitly
+select Built-in Beat Analysis.
 
 Release coverage label: full beat-this runtime and checkpoint behavior are manual or special checks
 unless a CI workflow explicitly installs the advanced beat dependency stack and exercises it.

--- a/apps/backend/app/models.py
+++ b/apps/backend/app/models.py
@@ -472,7 +472,9 @@ class Job(Base):
         if self.type != "analyze":
             return None
         value = self.payload_json.get("beat_backend")
-        return value if isinstance(value, str) else "built-in"
+        if isinstance(value, str):
+            return value
+        return "built-in" if self.status == "completed" else None
 
     @property
     def beat_input(self) -> str | None:

--- a/apps/backend/app/schemas.py
+++ b/apps/backend/app/schemas.py
@@ -149,7 +149,7 @@ class ProjectImportRequest(BaseModel):
     chord_backend: str | None = None
     chord_backend_fallback_from: str | None = None
     stem_model: str | None = None
-    beat_backend: AnalysisBeatBackend = "built-in"
+    beat_backend: AnalysisBeatBackend = "beat-this"
 
     @model_validator(mode="after")
     def validate_import_request(self) -> ProjectImportRequest:
@@ -962,7 +962,7 @@ class SyncTrustedPeersResponse(BaseModel):
 class AnalysisRequest(BaseModel):
     include_tempo: bool = False
     force: bool = False
-    beat_backend: AnalysisBeatBackend = "built-in"
+    beat_backend: AnalysisBeatBackend = "beat-this"
 
 
 class AnalysisTimingBeatSchema(BaseModel):
@@ -1368,7 +1368,7 @@ class BulkJobRequest(BaseModel):
     chord_backend: str | None = None
     chord_backend_fallback_from: str | None = None
     stem_model: str | None = None
-    beat_backend: AnalysisBeatBackend = "built-in"
+    beat_backend: AnalysisBeatBackend = "beat-this"
 
     @model_validator(mode="after")
     def validate_bulk_job_request(self) -> BulkJobRequest:

--- a/apps/backend/app/services/analysis.py
+++ b/apps/backend/app/services/analysis.py
@@ -28,7 +28,7 @@ def analyze_project(
     session: Session,
     project: Project,
     *,
-    beat_backend: str = BUILT_IN_BEAT_BACKEND,
+    beat_backend: str = BEAT_THIS_BACKEND,
 ) -> AnalysisResult:
     source_artifact = _project_source_artifact(project)
     source_stem_artifacts = (

--- a/apps/backend/app/services/beat_backends.py
+++ b/apps/backend/app/services/beat_backends.py
@@ -7,7 +7,7 @@ from app.engines.beat_this import beat_this_dependency_status
 
 BUILT_IN_BEAT_BACKEND_ID = "built-in"
 BEAT_THIS_BEAT_BACKEND_ID = "beat-this"
-DEFAULT_BEAT_BACKEND_ID = BUILT_IN_BEAT_BACKEND_ID
+DEFAULT_BEAT_BACKEND_ID = BEAT_THIS_BEAT_BACKEND_ID
 
 
 @dataclass(frozen=True)

--- a/apps/backend/tests/test_analysis_flow.py
+++ b/apps/backend/tests/test_analysis_flow.py
@@ -35,7 +35,7 @@ def test_analysis_job_persists_results(
 
     job = client.post(
         f"/api/v1/projects/{project['id']}/analyze",
-        json={"include_tempo": False, "force": False},
+        json={"include_tempo": False, "force": False, "beat_backend": "built-in"},
     ).json()["job"]
     final_job = wait_for_job(client, job["id"], timeout=90.0)
     assert final_job["status"] == "completed"
@@ -64,7 +64,7 @@ def test_analysis_job_persists_results(
 
     refresh_job = client.post(
         f"/api/v1/projects/{project['id']}/analyze",
-        json={"include_tempo": False, "force": False},
+        json={"include_tempo": False, "force": False, "beat_backend": "built-in"},
     ).json()["job"]
     assert wait_for_job(client, refresh_job["id"])["status"] == "completed"
 
@@ -120,7 +120,7 @@ def test_analysis_passes_latest_source_drums_and_bass_stems_only(
     with SessionLocal() as session:
         project = session.get(Project, project_id)
         assert project is not None
-        analysis = analysis_service.analyze_project(session, project)
+        analysis = analysis_service.analyze_project(session, project, beat_backend="built-in")
         session.commit()
 
     assert analysis.source_artifact_id == "art_analysis_source"
@@ -202,7 +202,7 @@ def test_reanalysis_updates_analysis_artifact_sync_metadata(
     with SessionLocal() as session:
         project = session.get(Project, project_id)
         assert project is not None
-        analysis_service.analyze_project(session, project)
+        analysis_service.analyze_project(session, project, beat_backend="built-in")
         first_artifact = _analysis_artifact(session, project_id)
         source_artifact = session.get(Artifact, "art_analysis_source")
         drums_artifact = session.get(Artifact, "art_source_drums")
@@ -314,7 +314,11 @@ def test_analysis_uses_beat_this_backend_when_requested(
         }
 
     monkeypatch.setattr(analysis_service, "beat_this_dependency_status", lambda: (True, None))
-    monkeypatch.setattr(analysis_service, "analyze_track_with_beat_this", fake_analyze_track_with_beat_this)
+    monkeypatch.setattr(
+        analysis_service,
+        "analyze_track_with_beat_this",
+        fake_analyze_track_with_beat_this,
+    )
 
     with SessionLocal() as session:
         project = session.get(Project, project_id)
@@ -377,7 +381,11 @@ def test_analysis_beat_this_uses_source_only_even_when_source_stems_have_signal_
             "timing": _timing_payload(source="beat-this"),
         }
 
-    monkeypatch.setattr(analysis_service, "analyze_track_with_beat_this", fake_analyze_track_with_beat_this)
+    monkeypatch.setattr(
+        analysis_service,
+        "analyze_track_with_beat_this",
+        fake_analyze_track_with_beat_this,
+    )
 
     with SessionLocal() as session:
         project = session.get(Project, project_id)
@@ -401,7 +409,6 @@ def test_analysis_beat_this_backend_fails_when_dependency_is_missing(
     project_id = "analysis_beat_this_unavailable_project"
     _seed_analysis_project(project_id, sample_audio_file)
     monkeypatch.setattr(analysis_service, "beat_this_dependency_status", lambda: (False, "beat-this is not installed"))
-
     with SessionLocal() as session:
         project = session.get(Project, project_id)
         assert project is not None
@@ -409,7 +416,7 @@ def test_analysis_beat_this_backend_fails_when_dependency_is_missing(
             analysis_service.analyze_project(session, project, beat_backend="beat-this")
 
 
-def test_analysis_beat_this_backend_reports_runtime_failure(
+def test_analysis_beat_this_backend_reports_known_runtime_failure(
     client,
     sample_audio_file: Path,
     monkeypatch,
@@ -420,10 +427,15 @@ def test_analysis_beat_this_backend_reports_runtime_failure(
     monkeypatch.setattr(analysis_service, "beat_this_dependency_status", lambda: (True, None))
 
     def fail_beat_this_analysis(*_args, **_kwargs):
-        raise analysis_service.BeatThisRuntimeError("Advanced Beat Analysis could not load the beat-this model.")
+        raise analysis_service.BeatThisRuntimeError(
+            "Advanced Beat Analysis could not load the beat-this model."
+        )
 
-    monkeypatch.setattr(analysis_service, "analyze_track_with_beat_this", fail_beat_this_analysis)
-
+    monkeypatch.setattr(
+        analysis_service,
+        "analyze_track_with_beat_this",
+        fail_beat_this_analysis,
+    )
     with SessionLocal() as session:
         project = session.get(Project, project_id)
         assert project is not None

--- a/apps/backend/tests/test_jobs_api.py
+++ b/apps/backend/tests/test_jobs_api.py
@@ -712,7 +712,10 @@ def test_analyze_job_exposes_source_beat_input(
         beat_backend: str = "built-in",
     ) -> AnalysisResult:
         assert beat_backend == "beat-this"
-        return AnalysisResult(project_id=project.id, timing_json=None if timing_json is None else dict(timing_json))
+        return AnalysisResult(
+            project_id=project.id,
+            timing_json=None if timing_json is None else dict(timing_json),
+        )
 
     monkeypatch.setattr("app.services.jobs.analyze_project", fake_analyze_project)
     with SessionLocal() as session:
@@ -722,9 +725,10 @@ def test_analyze_job_exposes_source_beat_input(
             session,
             project_id=project_id,
             job_type="analyze",
-            payload={"beat_backend": "beat-this"},
+            payload={},
         )
         assert job.payload_json["beat_input"] == "source"
+        assert "beat_backend" not in job.payload_json
         job_id = job.id
         session.commit()
 
@@ -804,6 +808,7 @@ def test_analyze_job_api_defaults_missing_or_unknown_beat_input_to_source(
     get_response = client.get("/api/v1/jobs/job_analyze_input")
     assert get_response.status_code == 200
     assert get_response.json()["job"]["beat_input"] == "source"
+    assert get_response.json()["job"]["beat_backend"] == "built-in"
 
     list_response = client.get("/api/v1/jobs")
     assert list_response.status_code == 200

--- a/apps/backend/tests/test_projects.py
+++ b/apps/backend/tests/test_projects.py
@@ -204,7 +204,7 @@ def test_import_project_without_copy_still_materializes_internal_wav(
         assert source_artifact.content_sha256 != expected_hash
 
         source_path.unlink()
-        analysis = analyze_project(session, project)
+        analysis = analyze_project(session, project, beat_backend="built-in")
 
         assert analysis.project_id == project.id
         assert imported_path.exists()
@@ -540,6 +540,7 @@ def test_import_project_enqueues_full_source_processing(
             "copy_into_project": True,
             "stem_model": "htdemucs_ft",
             "output_format": "flac",
+            "beat_backend": "built-in",
         },
     )
 

--- a/apps/backend/tests/test_transform_flow.py
+++ b/apps/backend/tests/test_transform_flow.py
@@ -123,7 +123,7 @@ def test_preview_generation_cache_and_export(client, sample_audio_file: Path):
 
     analyze_job = client.post(
         f"/api/v1/projects/{project['id']}/analyze",
-        json={"include_tempo": False, "force": False},
+        json={"include_tempo": False, "force": False, "beat_backend": "built-in"},
     ).json()["job"]
     assert wait_for_job(client, analyze_job["id"])["status"] == "completed"
 

--- a/apps/desktop/src/App.activity.test.tsx
+++ b/apps/desktop/src/App.activity.test.tsx
@@ -5641,7 +5641,7 @@ describe("Desktop app activity", () => {
     }
   });
 
-  it("falls back to built-in beats for bulk analyze when advanced beats are unavailable", async () => {
+  it("submits saved Beat This for bulk analyze when a normal install reports it unavailable", async () => {
     const user = userEvent.setup();
     window.localStorage.setItem(
       "tuneforge.ui-preferences",
@@ -5660,7 +5660,7 @@ describe("Desktop app activity", () => {
     await waitFor(() =>
       expect(mockBulkJobs).toHaveBeenCalledWith({
         job_type: "analyze",
-        beat_backend: "built-in",
+        beat_backend: "beat-this",
       }),
     );
   });

--- a/apps/desktop/src/App.library.test.tsx
+++ b/apps/desktop/src/App.library.test.tsx
@@ -868,7 +868,7 @@ describe("Desktop app library", () => {
     });
   });
 
-  it("falls back to built-in beat analysis when importing with unavailable advanced beats", async () => {
+  it("submits saved Beat This when importing from a normal install that reports it unavailable", async () => {
     const user = userEvent.setup();
     window.localStorage.setItem(
       "tuneforge.ui-preferences",
@@ -889,7 +889,7 @@ describe("Desktop app library", () => {
       source_path: "/tmp/new-song.mp4",
       copy_into_project: true,
       output_format: "wav",
-      beat_backend: "built-in",
+      beat_backend: "beat-this",
       chord_backend: "crema-advanced",
       stem_model: "htdemucs_6s",
     });

--- a/apps/desktop/src/App.project-analysis-mix.test.tsx
+++ b/apps/desktop/src/App.project-analysis-mix.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { LyricsResponse } from "./lib/api";
+import { resolveBeatBackendActionSelection } from "./features/projects/hooks/useBeatBackendActionSelection";
 import {
   resetAppTestHarness,
   findAudioByArtifactId,
@@ -33,6 +34,15 @@ import {
 
 describe("Desktop app project analysis mix", () => {
   beforeEach(resetAppTestHarness);
+
+  it("forces Built-in only when Beat This was intentionally excluded from the package", () => {
+    expect(
+      resolveBeatBackendActionSelection("beat-this", {
+        androidRuntime: false,
+        beatThisIncluded: false,
+      }),
+    ).toEqual({ beat_backend: "built-in" });
+  });
 
   async function openPlaybackWorkspace(user: ReturnType<typeof userEvent.setup>) {
     await user.click(screen.getByRole("tab", { name: "Playback" }));
@@ -185,7 +195,7 @@ describe("Desktop app project analysis mix", () => {
     expect(mockAnalyzeProject).toHaveBeenCalledWith("proj_123", { beat_backend: "beat-this" });
   });
 
-  it("falls back to built-in beats when the saved advanced backend is unavailable", async () => {
+  it("submits saved Beat This when a normal install reports it unavailable", async () => {
     const user = userEvent.setup();
     setProjectAnalysis("proj_123", null);
     window.localStorage.setItem(
@@ -203,7 +213,30 @@ describe("Desktop app project analysis mix", () => {
     await openStudioPanel(user);
     await user.click(screen.getByRole("button", { name: "Analyze Track" }));
 
-    expect(mockAnalyzeProject).toHaveBeenCalledWith("proj_123", { beat_backend: "built-in" });
+    expect(mockAnalyzeProject).toHaveBeenCalledWith("proj_123", { beat_backend: "beat-this" });
+  });
+
+  it("keeps Android analysis explicitly on Built-in", async () => {
+    const user = userEvent.setup();
+    const userAgent = vi
+      .spyOn(window.navigator, "userAgent", "get")
+      .mockReturnValue("Mozilla/5.0 (Linux; Android 15)");
+    setProjectAnalysis("proj_123", null);
+    window.localStorage.setItem(
+      "tuneforge.ui-preferences",
+      JSON.stringify({ defaultBeatAnalysisBackend: "beat-this" }),
+    );
+
+    try {
+      renderApp(["/projects/proj_123"]);
+      expect(await screen.findByRole("heading", { name: "Demo Song" })).toBeInTheDocument();
+      await openStudioPanel(user);
+      await user.click(screen.getByRole("button", { name: "Analyze Track" }));
+
+      expect(mockAnalyzeProject).toHaveBeenCalledWith("proj_123", { beat_backend: "built-in" });
+    } finally {
+      userAgent.mockRestore();
+    }
   });
 
   it("does not show the timing status panel in the playback rail", async () => {

--- a/apps/desktop/src/App.settings-theme.test.tsx
+++ b/apps/desktop/src/App.settings-theme.test.tsx
@@ -583,7 +583,7 @@ describe("Desktop app settings theme", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows unavailable advanced beat backend and selects built-in fallback", async () => {
+  it("shows unavailable advanced beat backend alongside the available Built-in choice", async () => {
     window.localStorage.setItem(
       "tuneforge.ui-preferences",
       JSON.stringify({ defaultBeatAnalysisBackend: "beat-this", defaultSourcesRailCollapsed: false }),
@@ -617,13 +617,9 @@ describe("Desktop app settings theme", () => {
       "aria-pressed",
       "true",
     );
+    expect(screen.getByRole("button", { name: /^Advanced Beat Analysis/ })).toHaveAttribute("aria-pressed", "false");
     expect(screen.getByRole("button", { name: /^Advanced Beat Analysis/ })).toBeDisabled();
-    expect(
-      screen.getByText(
-        "Advanced Beat Analysis unavailable: beat-this is not installed. Using Built-in Beat Analysis fallback.",
-      ),
-    ).toBeInTheDocument();
-    expect(screen.getAllByText("Built-in Beat Analysis").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Advanced Beat Analysis").length).toBeGreaterThan(0);
   });
 
   it("keeps engine defaults neutral while registry availability is loading", async () => {
@@ -661,7 +657,7 @@ describe("Desktop app settings theme", () => {
     expect(screen.queryByText("Checking availability")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^Advanced Beat Analysis/ })).toHaveAttribute("aria-pressed", "false");
     expect(screen.getByRole("button", { name: /^Advanced Chords/ })).toHaveAttribute("aria-pressed", "false");
-    expect(screen.getByText(/No beat analysis backend available/)).toBeInTheDocument();
+    expect(screen.getAllByText("No available backend")).toHaveLength(2);
     expect(screen.getByText(/No chord backend available/)).toBeInTheDocument();
   });
 
@@ -720,7 +716,7 @@ describe("Desktop app settings theme", () => {
     expect(screen.getByRole("button", { name: /^Built-in Beat Analysis/ })).toHaveAttribute("aria-pressed", "false");
     expect(screen.getByRole("button", { name: /^Advanced Chords/ })).toHaveAttribute("aria-pressed", "false");
     expect(screen.getByRole("button", { name: /^Built-in Chords/ })).toHaveAttribute("aria-pressed", "false");
-    expect(screen.getByText(/No beat analysis backend available/)).toBeInTheDocument();
+    expect(screen.getAllByText("No available backend")).toHaveLength(2);
     expect(screen.getByText(/No chord backend available/)).toBeInTheDocument();
     expect(screen.queryByText(/Using Built-in .* fallback/)).not.toBeInTheDocument();
   });

--- a/apps/desktop/src/features/projects/hooks/useBeatBackendActionSelection.ts
+++ b/apps/desktop/src/features/projects/hooks/useBeatBackendActionSelection.ts
@@ -1,48 +1,39 @@
 import { useCallback } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { api, type BeatBackendsResponse } from "../../../lib/api";
+import { isAndroidRuntime } from "../../../lib/nativeAudio";
 import { usePreferences, type DefaultBeatAnalysisBackend } from "../../../lib/preferences";
+
+declare const __TUNEFORGE_BEAT_THIS_INCLUDED__: boolean;
 
 export type BeatBackendActionSelection = {
   beat_backend: DefaultBeatAnalysisBackend;
 };
 
+type BeatBackendRuntime = {
+  androidRuntime: boolean;
+  beatThisIncluded: boolean;
+};
+
+export function resolveBeatBackendActionSelection(
+  defaultBeatAnalysisBackend: DefaultBeatAnalysisBackend,
+  runtime: BeatBackendRuntime = {
+    androidRuntime: isAndroidRuntime(),
+    beatThisIncluded: __TUNEFORGE_BEAT_THIS_INCLUDED__,
+  },
+): BeatBackendActionSelection {
+  return {
+    beat_backend:
+      runtime.androidRuntime || !runtime.beatThisIncluded
+        ? "built-in"
+        : defaultBeatAnalysisBackend,
+  };
+}
+
 export function useBeatBackendActionSelection() {
-  const queryClient = useQueryClient();
   const { defaultBeatAnalysisBackend } = usePreferences();
-  const beatBackendsQuery = useQuery({
-    queryKey: ["beat-backends"],
-    queryFn: api.listBeatBackends,
-  });
 
   const beatBackendForAction = useCallback(async (): Promise<BeatBackendActionSelection> => {
-    if (defaultBeatAnalysisBackend === "built-in") {
-      return { beat_backend: "built-in" };
-    }
+    return resolveBeatBackendActionSelection(defaultBeatAnalysisBackend);
+  }, [defaultBeatAnalysisBackend]);
 
-    let backendResponse: BeatBackendsResponse | undefined = beatBackendsQuery.data;
-    if (!backendResponse) {
-      try {
-        backendResponse = await queryClient.fetchQuery({
-          queryKey: ["beat-backends"],
-          queryFn: api.listBeatBackends,
-        });
-      } catch {
-        return { beat_backend: "built-in" };
-      }
-    }
-    if (!backendResponse) {
-      return { beat_backend: "built-in" };
-    }
-
-    const selectedBackend = backendResponse.backends.find(
-      (backend) => backend.id === defaultBeatAnalysisBackend,
-    );
-    if (selectedBackend?.available) {
-      return { beat_backend: defaultBeatAnalysisBackend };
-    }
-    return { beat_backend: "built-in" };
-  }, [beatBackendsQuery.data, defaultBeatAnalysisBackend, queryClient]);
-
-  return { beatBackendForAction, beatBackendsQuery };
+  return { beatBackendForAction };
 }

--- a/apps/desktop/src/features/projects/projectViewUtils.test.ts
+++ b/apps/desktop/src/features/projects/projectViewUtils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
-import type { ChordSegmentSchema, JobSchema, LyricsSegmentSchema } from "../../lib/api";
+import type { ArtifactSchema, ChordSegmentSchema, JobSchema, LyricsSegmentSchema } from "../../lib/api";
 import {
+  artifactSummary,
   buildLeadSheetRows,
   findActiveLyricsIndex,
   formatApiErrorMessage,
@@ -10,6 +11,23 @@ import {
   formatJobStatusSummary,
   transposeChordSegment,
 } from "./projectViewUtils";
+
+function analysisArtifact(metadata: Record<string, unknown>): ArtifactSchema {
+  return {
+    can_delete: true,
+    can_regenerate: true,
+    created_at: "2026-04-18T13:16:02.000Z",
+    format: "json",
+    generated_by: "analysis",
+    id: "artifact_analysis",
+    metadata,
+    path: "/tmp/analysis.json",
+    project_id: "proj_123",
+    size_bytes: 100,
+    type: "analysis_json",
+    updated_at: "2026-04-18T13:16:02.000Z",
+  };
+}
 
 function chord(startSeconds: number, endSeconds: number, label: string): ChordSegmentSchema {
   return {
@@ -39,6 +57,16 @@ function testJob(overrides: Partial<JobSchema>): JobSchema {
     ...overrides,
   };
 }
+
+describe("artifactSummary", () => {
+  it("shows the actual analysis backend", () => {
+    expect(artifactSummary(analysisArtifact({ analysis_backend: "beat-this" }))).toBe("advanced");
+  });
+
+  it("keeps legacy analysis metadata readable as Built-in", () => {
+    expect(artifactSummary(analysisArtifact({}))).toBe("built-in");
+  });
+});
 
 describe("buildLeadSheetRows", () => {
   it("anchors chords to active lyric words when word timestamps exist", () => {

--- a/apps/desktop/src/features/projects/projectViewUtils.ts
+++ b/apps/desktop/src/features/projects/projectViewUtils.ts
@@ -746,6 +746,14 @@ export function artifactSummary(artifact: ArtifactSchema) {
       .join(" / ");
   }
 
+  if (artifact.type === "analysis_json") {
+    const backend =
+      typeof artifact.metadata?.analysis_backend === "string"
+        ? artifact.metadata.analysis_backend
+        : "built-in";
+    return formatBeatBackend(backend) ?? "built-in";
+  }
+
   const metadata = artifact.metadata ?? {};
   const pieces: string[] = [];
   const transpose = metadata.transpose;

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -252,7 +252,6 @@ const fallbackBeatAnalysisBackendOptions: ChoiceOption<DefaultBeatAnalysisBacken
     value: "built-in",
     label: "Built-in Beat Analysis",
     description: "Use the local librosa heuristic for tempo and beat timing.",
-    status: "Fallback",
   },
 ];
 
@@ -539,7 +538,7 @@ function beatBackendOptions(backends: BeatBackendSchema[] | undefined): ChoiceOp
       label: backend.label,
       description: fallback.description,
       disabled: !backend.available,
-      status: unavailableReason ?? (fallback.value === "built-in" ? "Fallback" : undefined),
+      status: unavailableReason ?? undefined,
     };
   });
 }
@@ -824,15 +823,6 @@ export function SettingsView() {
   const androidSettings =
     androidRuntime || exportCapabilitiesQuery.data?.capabilities.platform === "android";
   const showAudioStoragePanel = !androidSettings;
-  const beatFallbackNotice = fallbackNotice(
-    defaultBeatAnalysisBackend,
-    effectiveBeatAnalysisBackend,
-    beatBackendChoices,
-    beatAnalysisBackendLabel,
-    beatAnalysisBackendLabel,
-    beatAvailabilityResolved,
-    "No beat analysis backend available",
-  );
   const chordFallbackNotice = fallbackNotice(
     defaultChordBackend,
     effectiveChordBackend,
@@ -1095,7 +1085,6 @@ export function SettingsView() {
               {effectiveBeatAnalysisBackend === null
                 ? "No available backend"
                 : beatAnalysisBackendLabel(effectiveBeatAnalysisBackend)}
-              {beatFallbackNotice ? <span>{beatFallbackNotice}</span> : null}
             </dd>
           </div>
           <div className="settings-overview__stat">

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -42,12 +42,14 @@ const reactRefreshPreamble = {
 export default defineConfig(() => {
   const versionFilePath = process.env.TUNEFORGE_VERSION_FILE;
   const buildInfo = resolveBuildInfo({ workspaceRoot, versionFilePath });
+  const beatThisIncluded = beatThisIncludedInBuild();
 
   return {
     plugins: [reactRefreshPreamble, react()],
     define: {
       __TUNEFORGE_FRONTEND_GIT_REF__: JSON.stringify(buildInfo.frontend.git_ref),
       __TUNEFORGE_FRONTEND_PACKAGE_VERSION__: JSON.stringify(buildInfo.frontend.package_version),
+      __TUNEFORGE_BEAT_THIS_INCLUDED__: JSON.stringify(beatThisIncluded),
     },
     server: {
       host: "127.0.0.1",
@@ -81,6 +83,15 @@ export default defineConfig(() => {
     },
   };
 });
+
+function beatThisIncludedInBuild() {
+  const encodedOptions = process.env.TUNEFORGE_PACKAGE_OPTIONS;
+  if (!encodedOptions) {
+    return true;
+  }
+  const packageOptions = JSON.parse(encodedOptions) as { beatThis?: unknown };
+  return packageOptions.beatThis !== false;
+}
 
 function realpathIfPresent(path: string) {
   return existsSync(path) ? realpathSync(path) : null;

--- a/docs/API.md
+++ b/docs/API.md
@@ -149,9 +149,10 @@ metadata when available, otherwise local development resolves them with `git des
 
 `GET /api/v1/beat-backends`
 
-Returns available beat analysis backends. Built-in Beat Analysis is always expected to be available.
-Advanced Beat Analysis is the default desktop/dev/package engine, but may be unavailable when
-desktop-only dependencies are explicitly excluded, unsupported, or missing.
+Returns available Advanced Beat Analysis and Built-in Beat Analysis backends. Built-in Beat Analysis
+is always expected to be available. Advanced Beat Analysis is the default desktop/dev/package
+request, but may be unavailable when desktop-only dependencies are explicitly excluded, unsupported,
+or missing.
 
 ## Chord Backends
 
@@ -636,8 +637,9 @@ Response: `ProjectResponse`.
 
 `stem_model` is optional. Desktop imports send the user's default stem model so automatic source stems match
 manual stem generation preferences; if omitted, the backend stem model default is used. `beat_backend`
-defaults to `built-in`; desktop preferences may send `beat-this` when Advanced Beat Analysis is
-available. Chord backend fields follow the same validation as explicit chord generation.
+defaults to `beat-this`. An Advanced Beat Analysis dependency, checkpoint download/load, runtime, or
+unusable-timing failure fails the analysis job; the backend does not switch to Built-in Beat Analysis.
+Chord backend fields follow the same validation as explicit chord generation.
 
 `source_path` records where the user imported the file from on this install. Sync treats it as local provenance, not a durable source of original bytes or an operational sync input. `copy_into_project=false` is accepted for compatibility, but new imports still create an app-managed durable source artifact under the project root. Project identity remains derived from the original selected bytes; the artifact hash describes the encoded durable bytes.
 
@@ -700,6 +702,10 @@ Request fields:
 - `beat_backend`
 
 Response: `JobResponse`.
+
+`beat_backend` defaults to `beat-this`. Analysis jobs expose the selected backend in `beat_backend`.
+Pending jobs reconstructed without a selection adopt Advanced Beat Analysis; legacy completed jobs
+without a backend remain readable as Built-in Beat Analysis.
 
 ### Get analysis
 
@@ -1049,6 +1055,10 @@ Response: `BulkJobsResponse`, with `created_jobs`, `total_projects`, and `skippe
 `GET /api/v1/jobs/{job_id}`
 
 Response: `JobResponse`.
+
+For analysis jobs, `beat_backend` is the backend selected for the run. Analysis artifact metadata
+records the completed engine as `analysis_backend`. Advanced Beat Analysis failures do not produce a
+Built-in Beat Analysis artifact.
 
 ### Cancel job
 

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -116,6 +116,12 @@ pnpm package:mac -- --no-advanced-chords --no-advanced-beats
 pnpm package:mac -- --model-bundle
 ```
 
+Advanced Beat Analysis remains the default analysis request without bundled model weights. Its
+`small0` checkpoint follows the normal first-use cache lifecycle. With `--no-beat-this`, the desktop
+backend registry marks Advanced Beat Analysis unavailable and the compile-time package option makes
+desktop actions send an explicit Built-in Beat Analysis selection. A broken normal installation still
+submits Advanced Beat Analysis and surfaces the dependency failure instead of silently changing engines.
+
 The generated artifacts are written under `apps/desktop/src-tauri/target/release/bundle/`:
 
 - `macos/TuneForge.app`
@@ -216,6 +222,10 @@ pnpm package:linux -- --legacy-nvidia --model-bundle
 - `--sandbox-data` keeps app data under Flatpak-private `/var/data/tuneforge` instead of the host XDG data directory.
 
 Like macOS packages, plain Flatpak packages rely on normal Demucs, Whisper, and beat-this caches unless `--model-bundle` is explicitly passed. Advanced Chords uses crema package assets instead of a separate first-use model download; this is the dependency-owned Crema exception, not an external model-bundle source.
+When beat-this is excluded, desktop actions explicitly select Built-in Beat Analysis. An Advanced
+Beat Analysis request that ultimately fails during first-use download, load, runtime, or timing
+analysis fails the job rather than switching engines; explicit Built-in Beat Analysis requests do
+not probe beat-this.
 
 By default, the Flatpak grants access to `xdg-data/tuneforge`, `xdg-cache/torch`, and
 `xdg-cache/whisper`. Packaged runs therefore use the same data root and model caches as

--- a/packages/shared-types/src/generated/openapi.ts
+++ b/packages/shared-types/src/generated/openapi.ts
@@ -811,7 +811,7 @@ export interface components {
             force?: boolean;
             /**
              * Beat Backend
-             * @default built-in
+             * @default beat-this
              * @enum {string}
              */
             beat_backend?: "built-in" | "beat-this";
@@ -972,7 +972,7 @@ export interface components {
             stem_model?: string | null;
             /**
              * Beat Backend
-             * @default built-in
+             * @default beat-this
              * @enum {string}
              */
             beat_backend?: "built-in" | "beat-this";
@@ -1584,7 +1584,7 @@ export interface components {
             stem_model?: string | null;
             /**
              * Beat Backend
-             * @default built-in
+             * @default beat-this
              * @enum {string}
              */
             beat_backend?: "built-in" | "beat-this";

--- a/scripts/package-flatpak.mjs
+++ b/scripts/package-flatpak.mjs
@@ -4,6 +4,7 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { writeBuildInfoFile } from "./build-info.mjs";
 import {
+  packageOptionsEnvironment,
   packageOptionsToGeneratorArgs,
   parsePackageOptions,
   printModelBundleWarning,
@@ -54,7 +55,7 @@ function checkCommand(command, installHint) {
 function generatedManifestPath(options) {
   const generatedManifestPath = path.join(flatpakRoot, "com.tuneforge.desktop.generated.yml");
   const baseManifest = readFileSync(baseManifestPath, "utf8");
-  let manifest = baseManifest;
+  let manifest = manifestWithPackageOptions(baseManifest, options);
   if (options.legacyNvidia) {
     manifest = replaceManifestFragment(manifest, "  - --device=dri\n", "  - --device=all\n");
   }
@@ -107,6 +108,21 @@ function generatedManifestPath(options) {
   mkdirSync(path.dirname(generatedManifestPath), { recursive: true });
   writeFileSync(generatedManifestPath, manifest);
   return generatedManifestPath;
+}
+
+export function manifestWithPackageOptions(manifest, options) {
+  const encodedPackageOptions = packageOptionsEnvironment(options).TUNEFORGE_PACKAGE_OPTIONS;
+  const tuneforgeEnvAnchor =
+    "  - name: tuneforge\n" +
+    "    buildsystem: simple\n" +
+    "    build-options:\n" +
+    "      append-path: /app/bin:/usr/lib/sdk/node26/bin:/usr/lib/sdk/llvm20/bin:/usr/lib/sdk/rust-stable/bin\n" +
+    "      env:\n";
+  return replaceManifestFragment(
+    manifest,
+    tuneforgeEnvAnchor,
+    `${tuneforgeEnvAnchor}        TUNEFORGE_PACKAGE_OPTIONS: '${encodedPackageOptions}'\n`,
+  );
 }
 
 function replaceManifestFragment(contents, search, replacement) {
@@ -214,9 +230,11 @@ function main() {
   process.stdout.write(`Flatpak bundle written to ${bundlePath}\n`);
 }
 
-try {
-  main();
-} catch (error) {
-  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-  process.exitCode = 1;
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
 }

--- a/scripts/package-options.test.mjs
+++ b/scripts/package-options.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
+import { manifestWithPackageOptions } from "./package-flatpak.mjs";
 import {
   backendSyncArgs,
+  packageOptionsEnvironment,
   packageOptionsToGeneratorArgs,
   parsePackageOptions,
 } from "./package-options.mjs";
@@ -69,8 +72,31 @@ test("package option parser accepts advanced dependency opt-outs", () => {
 
   assert.equal(options.crema, false);
   assert.equal(options.beatThis, false);
+  assert.equal(JSON.parse(packageOptionsEnvironment(options).TUNEFORGE_PACKAGE_OPTIONS).beatThis, false);
   assert.deepEqual(packageOptionsToGeneratorArgs(options), ["--no-crema", "--no-beat-this"]);
   assert.deepEqual(backendSyncArgs(options), ["sync", "--python", "3.11", "--all-groups"]);
+});
+
+test("Flatpak package options are scoped to the TuneForge module build environment", () => {
+  const baseManifest = readFileSync(
+    new URL("../packaging/flatpak/com.tuneforge.desktop.yml", import.meta.url),
+    "utf8",
+  );
+  const options = parsePackageOptions(["--no-beat-this"], { platform: "linux" });
+  const manifest = manifestWithPackageOptions(baseManifest, options);
+  const cpythonModule = manifest.slice(
+    manifest.indexOf("  - name: cpython-3.11"),
+    manifest.indexOf("  - name: python-runtime-deps"),
+  );
+  const tuneforgeModule = manifest.slice(manifest.indexOf("  - name: tuneforge"));
+
+  assert.equal(cpythonModule.includes("TUNEFORGE_PACKAGE_OPTIONS"), false);
+  assert.equal((tuneforgeModule.match(/\n    build-options:/g) ?? []).length, 1);
+  assert.equal((manifest.match(/TUNEFORGE_PACKAGE_OPTIONS:/g) ?? []).length, 1);
+  assert.match(
+    tuneforgeModule,
+    /      env:\n        TUNEFORGE_PACKAGE_OPTIONS: '.*"beatThis":false.*'/,
+  );
 });
 
 test("package option parser has no profile compatibility path", () => {


### PR DESCRIPTION
## Summary

- Default omitted desktop and API beat-analysis requests to Advanced Beat Analysis.
- Keep Built-in Beat Analysis explicit for Android, opt-out preferences, and `--no-beat-this` packages.
- Fail Advanced Beat Analysis jobs instead of silently switching engines, while preserving backend provenance.
- Update generated contracts, packaging profiles, documentation, and compatibility coverage.
- Closes #475

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm contracts:generate`
- `pnpm test` — desktop and helper lanes passed; one parallel Rust transport test failed, so the backend lane was not reached.
- `cd apps/desktop/src-tauri && cargo test sync_transport::desktop::tests::iroh_retry_reuses_staged_artifact_and_retransfers_incomplete_temp -- --nocapture`
- `cd apps/desktop/src-tauri && cargo test -- --test-threads=1`
- `cd apps/backend && uv run --python 3.11 pytest` — interrupted on the rebased branch at the request to publish; CI will run the complete suite.
- `pnpm package:mac:app`
- `pnpm package:mac:app -- --no-beat-this`
