### PR TITLE
fix: Repair Linux developer setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ download, installation, verification, signature, and publication instructions.
   explicit choice for mobile, dependency-excluded packages, and users who opt out; advanced beat
   runtime failures now fail the job.
 
+### Fixed
+
+- Restored Linux developer setup on unsupported default CUDA architectures and made the legacy
+  NVIDIA profile compatible with LV Chordia.
+
 ## [1.2.0] - 2026-08-24
 
 ### Added

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -72,9 +72,11 @@ The backend validates every checkpoint name, size, and SHA-256 before model load
 corrupt assets fail closed and are repaired by reinstalling or rebuilding the package; there is no
 download or user-cache lifecycle. Crema remains the default pending manual product evaluation.
 
-LV Chordia accepts local audio paths only. It tries CUDA or MPS when available and retries once on
-CPU for accelerator availability or allocation failures. Explicit generation, refresh, stem, and
-bulk requests never switch chord backends; import routes may record a Built-in fallback.
+LV Chordia accepts local audio paths only. It uses CUDA only when the installed PyTorch build
+supports a visible GPU architecture, otherwise it selects MPS or CPU. Model prewarm and inference
+retry once on CPU for accelerator availability or allocation failures. Explicit generation,
+refresh, stem, and bulk requests never switch chord backends; import routes may record a Built-in
+fallback.
 
 ### Advanced Beat Analysis backend
 
@@ -131,8 +133,8 @@ uv pip install \
   --torch-backend cu126 \
   --reinstall-package torch \
   --reinstall-package torchaudio \
-  "torch==2.6.0" \
-  "torchaudio==2.6.0"
+  "torch==2.11.0" \
+  "torchaudio==2.11.0"
 ```
 
 From the workspace root, the helper command is:
@@ -141,12 +143,14 @@ From the workspace root, the helper command is:
 pnpm setup:dev -- --legacy-nvidia
 ```
 
-The legacy NVIDIA profile includes the default advanced desktop engines unless you pass opt-outs.
+The legacy NVIDIA profile installs matched Torch and torchaudio 2.11.0 CUDA 12.6 wheels and includes
+the default advanced desktop engines, including LV Chordia, unless you pass opt-outs.
 If you later switch profiles with the standalone helpers, pass opt-outs only when you need the
 built-in fallback stack:
 
 ```sh
 pnpm sync:backend:legacy-nvidia -- --no-crema
+pnpm sync:backend:legacy-nvidia -- --no-lv-chordia
 pnpm sync:backend:default -- --no-crema
 ```
 

--- a/apps/backend/app/engines/lv_chordia.py
+++ b/apps/backend/app/engines/lv_chordia.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from app.engines.chord_labels import chord_label_to_segment
 from app.utils.model_cache import ExpectedModelFile, InvalidModelFile, invalid_model_files
+from app.utils.torch_runtime import choose_torch_device
 
 LV_CHORDIA_BACKEND_ID = "lv-chordia-submission"
 LV_CHORDIA_SOURCE_REVISION = "9d7de7bbf45efa6731ec8dc62d35280f141c0702"
@@ -201,14 +202,17 @@ def lv_chordia_runtime_device() -> str:
         import torch
     except Exception:
         return "cpu"
-    if torch.cuda.is_available():
-        return "cuda"
-    mps = getattr(torch.backends, "mps", None)
-    return "mps" if mps is not None and mps.is_available() else "cpu"
+    return choose_torch_device("auto", torch_module=torch)
 
 
 def preload_lv_chordia_session() -> None:
-    _session_for_device(lv_chordia_runtime_device())
+    preferred_device = lv_chordia_runtime_device()
+    try:
+        _session_for_device(preferred_device)
+    except Exception as exc:
+        if preferred_device == "cpu" or not _is_accelerator_failure(exc):
+            raise
+        _session_for_device("cpu")
 
 
 def clear_lv_chordia_session_cache() -> None:

--- a/apps/backend/tests/test_torch_runtime.py
+++ b/apps/backend/tests/test_torch_runtime.py
@@ -72,6 +72,63 @@ def test_choose_torch_device_auto_falls_back_when_cuda_arch_is_unsupported():
     )
 
 
+def test_lv_chordia_uses_architecture_aware_torch_device(monkeypatch: pytest.MonkeyPatch):
+    from app.engines import lv_chordia
+
+    fake_torch = make_fake_torch(
+        has_mps=False,
+        has_cuda=True,
+        supported_arches=["sm_75", "sm_80"],
+        device_capability=(6, 1),
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    assert lv_chordia.lv_chordia_runtime_device() == "cpu"
+
+
+def test_lv_chordia_prewarm_retries_recognized_accelerator_failure_on_cpu(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from app.engines import lv_chordia
+
+    calls: list[str] = []
+
+    def fake_session_for_device(device: str) -> object:
+        calls.append(device)
+        if device == "mps":
+            raise RuntimeError("MPS backend out of memory")
+        return object()
+
+    monkeypatch.setattr(lv_chordia, "lv_chordia_runtime_device", lambda: "mps")
+    monkeypatch.setattr(lv_chordia, "_session_for_device", fake_session_for_device)
+
+    lv_chordia.preload_lv_chordia_session()
+
+    assert calls == ["mps", "cpu"]
+
+
+def test_lv_chordia_prewarm_propagates_unrecognized_failure_without_cpu_retry(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from app.engines import lv_chordia
+
+    calls: list[str] = []
+    original_error = RuntimeError("LV Chordia checkpoint is corrupt")
+
+    def fake_session_for_device(device: str) -> object:
+        calls.append(device)
+        raise original_error
+
+    monkeypatch.setattr(lv_chordia, "lv_chordia_runtime_device", lambda: "cuda")
+    monkeypatch.setattr(lv_chordia, "_session_for_device", fake_session_for_device)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        lv_chordia.preload_lv_chordia_session()
+
+    assert exc_info.value is original_error
+    assert calls == ["cuda"]
+
+
 def test_choose_torch_device_rejects_requested_cuda_when_arch_is_unsupported():
     with pytest.raises(RuntimeError, match="does not support the visible NVIDIA GPU architecture"):
         choose_torch_device(

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -109,11 +109,6 @@ if [[ "${legacy_nvidia}" -eq 1 ]]; then
     echo "Legacy NVIDIA backend profile is only supported on Linux x86_64." >&2
     exit 1
   fi
-
-  if [[ "${lv_chordia}" -eq 1 ]]; then
-    echo "--legacy-nvidia requires --no-lv-chordia because LV Chordia is audited only with Torch 2.11.0." >&2
-    exit 1
-  fi
 fi
 
 backend_sync_args=(sync --python 3.11 --all-groups)
@@ -162,21 +157,31 @@ if [[ "${legacy_nvidia}" -eq 1 ]]; then
     --torch-backend cu126 \
     --reinstall-package torch \
     --reinstall-package torchaudio \
-    "torch==2.6.0" \
-    "torchaudio==2.6.0"
+    "torch==2.11.0" \
+    "torchaudio==2.11.0"
 
   .venv/bin/python - <<'PY'
 import sys
 
 import torch
+import torchaudio
 
-if not torch.__version__.startswith("2.6.0"):
-    raise SystemExit(f"Expected torch 2.6.0 for the legacy NVIDIA profile, found {torch.__version__}.")
+expected_version = "2.11.0+cu126"
+if torch.__version__ != expected_version:
+    raise SystemExit(f"Expected torch {expected_version} for the legacy NVIDIA profile, found {torch.__version__}.")
+
+if torchaudio.__version__ != expected_version:
+    raise SystemExit(
+        f"Expected torchaudio {expected_version} for the legacy NVIDIA profile, found {torchaudio.__version__}."
+    )
 
 if torch.version.cuda != "12.6":
     raise SystemExit(f"Expected CUDA 12.6 for the legacy NVIDIA profile, found {torch.version.cuda}.")
 
-sys.stdout.write(f"Verified legacy NVIDIA Torch profile: torch {torch.__version__}, CUDA {torch.version.cuda}\n")
+sys.stdout.write(
+    f"Verified legacy NVIDIA Torch profile: torch {torch.__version__}, "
+    f"torchaudio {torchaudio.__version__}, CUDA {torch.version.cuda}\n"
+)
 PY
 
   touch "${marker_file}"

--- a/scripts/setup-dev.test.sh
+++ b/scripts/setup-dev.test.sh
@@ -13,6 +13,7 @@ mkdir -p \
 
 cp "${repo_root}/scripts/setup-dev.sh" "${fixture}/scripts/setup-dev.sh"
 cp "${repo_root}/scripts/sync-backend-default.sh" "${fixture}/scripts/sync-backend-default.sh"
+cp "${repo_root}/scripts/sync-backend-legacy-nvidia.sh" "${fixture}/scripts/sync-backend-legacy-nvidia.sh"
 
 cat > "${fixture}/scripts/configure-tauri-build-env.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -22,23 +23,28 @@ EOF
 cat > "${fixture}/bin/uv" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-if [[ -n "${SETUP_DEV_TEST_UV_CALLED:-}" ]]; then
-  : > "${SETUP_DEV_TEST_UV_CALLED}"
+if [[ -n "${SETUP_DEV_TEST_UV_ARGS:-}" ]]; then
+  printf '%s\n' '[call]' "$@" >> "${SETUP_DEV_TEST_UV_ARGS}"
 fi
-if [[ "$1" != "sync" ]]; then
-  echo "unexpected uv command: $*" >&2
-  exit 1
-fi
-if [[ -n "${SYNC_BACKEND_TEST_UV_ARGS:-}" ]]; then
-  printf '%s\n' "$@" > "${SYNC_BACKEND_TEST_UV_ARGS}"
+if [[ "$1" == "sync" ]]; then
+  if [[ -n "${SYNC_BACKEND_TEST_UV_ARGS:-}" ]]; then
+    printf '%s\n' "$@" > "${SYNC_BACKEND_TEST_UV_ARGS}"
+  fi
   mkdir -p .venv/bin
   cat > .venv/bin/python <<'PYTHON'
 #!/usr/bin/env bash
 set -euo pipefail
-: "${SYNC_BACKEND_TEST_PYTHON_ARGS:?}"
-printf '%s\n' "$@" > "${SYNC_BACKEND_TEST_PYTHON_ARGS}"
+python_args_file="${SETUP_DEV_TEST_PYTHON_ARGS:-${SYNC_BACKEND_TEST_PYTHON_ARGS:-}}"
+: "${python_args_file:?}"
+printf '%s\n' "$@" > "${python_args_file}"
+if [[ "${1:-}" == "-" ]]; then
+  /bin/cat > "${SETUP_DEV_TEST_PYTHON_STDIN:-/dev/null}"
+fi
 PYTHON
   chmod +x .venv/bin/python
+elif [[ "$1" != "pip" || "${2:-}" != "install" ]]; then
+  echo "unexpected uv command: $*" >&2
+  exit 1
 fi
 EOF
 
@@ -72,6 +78,8 @@ chmod +x \
   "${fixture}/apps/backend/.venv/bin/python"
 
 python_args_file="${fixture}/python-args"
+python_stdin_file="${fixture}/python-stdin"
+setup_uv_args_file="${fixture}/setup-uv-args"
 
 run_setup_dev() {
   local label="$1"
@@ -79,8 +87,12 @@ run_setup_dev() {
   local output_file="${fixture}/setup-output-${label}"
 
   : > "${python_args_file}"
+  : > "${python_stdin_file}"
+  : > "${setup_uv_args_file}"
   if ! PATH="${fixture}/bin:${PATH}" \
     SETUP_DEV_TEST_PYTHON_ARGS="${python_args_file}" \
+    SETUP_DEV_TEST_PYTHON_STDIN="${python_stdin_file}" \
+    SETUP_DEV_TEST_UV_ARGS="${setup_uv_args_file}" \
     /bin/bash "${fixture}/scripts/setup-dev.sh" \
       --skip-contracts \
       --skip-playwright-browsers \
@@ -105,6 +117,53 @@ assert_python_args() {
   fi
 }
 
+assert_legacy_version_verifier() {
+  local label="$1"
+  local fake_module_dir="${fixture}/fake-python-modules-${label}"
+  local output_file="${fixture}/version-verifier-output-${label}"
+
+  mkdir -p "${fake_module_dir}"
+  cat > "${fake_module_dir}/torch.py" <<'PYTHON'
+import os
+
+__version__ = os.environ["FAKE_TORCH_VERSION"]
+
+
+class _Version:
+    cuda = os.environ["FAKE_TORCH_CUDA"]
+
+
+version = _Version()
+PYTHON
+  cat > "${fake_module_dir}/torchaudio.py" <<'PYTHON'
+import os
+
+__version__ = os.environ["FAKE_TORCHAUDIO_VERSION"]
+PYTHON
+
+  if ! PYTHONPATH="${fake_module_dir}" \
+    FAKE_TORCH_VERSION="2.11.0+cu126" \
+    FAKE_TORCH_CUDA="12.6" \
+    FAKE_TORCHAUDIO_VERSION="2.11.0+cu126" \
+    python3 - < "${python_stdin_file}" > "${output_file}" 2>&1; then
+    cat "${output_file}" >&2
+    echo "${label} verifier rejected the matched legacy NVIDIA profile" >&2
+    exit 1
+  fi
+
+  if PYTHONPATH="${fake_module_dir}" \
+    FAKE_TORCH_VERSION="2.11.0+cu126" \
+    FAKE_TORCH_CUDA="12.6" \
+    FAKE_TORCHAUDIO_VERSION="2.6.0+cu126" \
+    python3 - < "${python_stdin_file}" > "${output_file}" 2>&1; then
+    echo "${label} verifier accepted mismatched torch and torchaudio versions" >&2
+    exit 1
+  fi
+  grep -F \
+    'Expected torchaudio 2.11.0+cu126 for the legacy NVIDIA profile, found 2.6.0+cu126.' \
+    "${output_file}" > /dev/null
+}
+
 run_setup_dev "default"
 assert_python_args "default" \
   -m \
@@ -118,25 +177,24 @@ assert_python_args "opt-out" \
   -m \
   app.cli.prewarm_models
 
-legacy_output_file="${fixture}/setup-output-legacy-lv"
-legacy_uv_called_file="${fixture}/legacy-uv-called"
-if PATH="${fixture}/bin:${PATH}" \
-  SETUP_DEV_TEST_UV_CALLED="${legacy_uv_called_file}" \
-  /bin/bash "${fixture}/scripts/setup-dev.sh" \
-    --legacy-nvidia \
-    --skip-contracts \
-    --skip-playwright-browsers \
-    --skip-pnpm-install > "${legacy_output_file}" 2>&1; then
-  echo "expected legacy NVIDIA with default LV Chordia to fail" >&2
-  exit 1
-fi
-grep -F -- \
-  "--legacy-nvidia requires --no-lv-chordia because LV Chordia is audited only with Torch 2.11.0." \
-  "${legacy_output_file}"
-if [[ -e "${legacy_uv_called_file}" ]]; then
-  echo "legacy NVIDIA compatibility rejection invoked uv" >&2
-  exit 1
-fi
+run_setup_dev "legacy-lv" --legacy-nvidia
+assert_python_args "legacy-lv" \
+  -m \
+  app.cli.prewarm_models \
+  --include-crema \
+  --include-beat-this \
+  --include-lv-chordia
+printf '%s\n' \
+  '[call]' sync --python 3.11 --all-groups --extra advanced-chords --extra advanced-beats --extra lv-chordia \
+  '[call]' pip install --python .venv/bin/python --torch-backend cu126 \
+  --reinstall-package torch --reinstall-package torchaudio \
+  'torch==2.11.0' 'torchaudio==2.11.0' > "${fixture}/expected-setup-legacy-uv-args"
+cmp "${fixture}/expected-setup-legacy-uv-args" "${setup_uv_args_file}"
+grep -F 'expected_version = "2.11.0+cu126"' "${python_stdin_file}" > /dev/null
+grep -F 'torch.__version__ != expected_version' "${python_stdin_file}" > /dev/null
+grep -F 'torchaudio.__version__ != expected_version' "${python_stdin_file}" > /dev/null
+grep -F 'torch.version.cuda != "12.6"' "${python_stdin_file}" > /dev/null
+assert_legacy_version_verifier "setup-dev"
 
 sync_uv_args_file="${fixture}/sync-uv-args"
 sync_python_args_file="${fixture}/sync-python-args"
@@ -179,4 +237,55 @@ if [[ -s "${sync_python_args_file}" ]]; then
   exit 1
 fi
 
-echo "setup-dev and sync-backend prewarm arg tests passed"
+run_sync_legacy_backend() {
+  local label="$1"
+  shift
+  local output_file="${fixture}/sync-legacy-output-${label}"
+
+  : > "${setup_uv_args_file}"
+  : > "${sync_uv_args_file}"
+  : > "${sync_python_args_file}"
+  : > "${python_stdin_file}"
+  if ! PATH="${fixture}/bin:${PATH}" \
+    SETUP_DEV_TEST_UV_ARGS="${setup_uv_args_file}" \
+    SETUP_DEV_TEST_PYTHON_STDIN="${python_stdin_file}" \
+    SYNC_BACKEND_TEST_UV_ARGS="${sync_uv_args_file}" \
+    SYNC_BACKEND_TEST_PYTHON_ARGS="${sync_python_args_file}" \
+    /bin/bash "${fixture}/scripts/sync-backend-legacy-nvidia.sh" \
+      --no-crema \
+      --no-beat-this \
+      "$@" > "${output_file}" 2>&1; then
+    cat "${output_file}" >&2
+    exit 1
+  fi
+}
+
+run_sync_legacy_backend "default"
+printf '%s\n' sync --python 3.11 --all-groups --extra lv-chordia > "${fixture}/expected-legacy-sync-uv-args"
+cmp "${fixture}/expected-legacy-sync-uv-args" "${sync_uv_args_file}"
+printf '%s\n' \
+  -m \
+  app.cli.prewarm_models \
+  --skip-demucs \
+  --skip-whisper \
+  --include-lv-chordia > "${fixture}/expected-legacy-sync-python-args"
+cmp "${fixture}/expected-legacy-sync-python-args" "${sync_python_args_file}"
+printf '%s\n' \
+  '[call]' sync --python 3.11 --all-groups --extra lv-chordia \
+  '[call]' pip install --python .venv/bin/python --torch-backend cu126 \
+  --reinstall-package torch --reinstall-package torchaudio \
+  'torch==2.11.0' 'torchaudio==2.11.0' > "${fixture}/expected-legacy-sync-all-uv-args"
+cmp "${fixture}/expected-legacy-sync-all-uv-args" "${setup_uv_args_file}"
+grep -F 'expected_version = "2.11.0+cu126"' "${python_stdin_file}" > /dev/null
+grep -F 'torch.__version__ != expected_version' "${python_stdin_file}" > /dev/null
+grep -F 'torchaudio.__version__ != expected_version' "${python_stdin_file}" > /dev/null
+grep -F 'torch.version.cuda != "12.6"' "${python_stdin_file}" > /dev/null
+assert_legacy_version_verifier "sync-backend-legacy-nvidia"
+
+run_sync_legacy_backend "opt-out" --no-lv-chordia
+printf '%s\n' sync --python 3.11 --all-groups > "${fixture}/expected-legacy-sync-opt-out-uv-args"
+cmp "${fixture}/expected-legacy-sync-opt-out-uv-args" "${sync_uv_args_file}"
+printf '%s\n' - > "${fixture}/expected-legacy-sync-opt-out-python-args"
+cmp "${fixture}/expected-legacy-sync-opt-out-python-args" "${sync_python_args_file}"
+
+echo "setup-dev and backend sync profile tests passed"

--- a/scripts/sync-backend-legacy-nvidia.sh
+++ b/scripts/sync-backend-legacy-nvidia.sh
@@ -15,12 +15,15 @@ Options:
                               Include the default beat-this backend.
   --no-advanced-beats, --no-beat-this
                               Skip the beat-this backend.
+  --lv-chordia               Include LV Chordia and verify bundled checkpoints (default).
+  --no-lv-chordia            Skip LV Chordia and its bundled checkpoints.
   -h, --help                  Show this help.
 EOF
 }
 
 advanced_chords=1
 advanced_beats=1
+lv_chordia=1
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -35,6 +38,12 @@ while [[ $# -gt 0 ]]; do
       ;;
     --no-advanced-beats | --no-beat-this)
       advanced_beats=0
+      ;;
+    --lv-chordia)
+      lv_chordia=1
+      ;;
+    --no-lv-chordia)
+      lv_chordia=0
       ;;
     --)
       ;;
@@ -76,6 +85,9 @@ fi
 if [[ "${advanced_beats}" -eq 1 ]]; then
   backend_sync_args+=(--extra advanced-beats)
 fi
+if [[ "${lv_chordia}" -eq 1 ]]; then
+  backend_sync_args+=(--extra lv-chordia)
+fi
 
 rm -rf .venv
 uv "${backend_sync_args[@]}"
@@ -84,21 +96,38 @@ uv pip install \
   --torch-backend cu126 \
   --reinstall-package torch \
   --reinstall-package torchaudio \
-  "torch==2.6.0" \
-  "torchaudio==2.6.0"
+  "torch==2.11.0" \
+  "torchaudio==2.11.0"
 
 .venv/bin/python - <<'PY'
 import sys
 
 import torch
+import torchaudio
 
-if not torch.__version__.startswith("2.6.0"):
-    raise SystemExit(f"Expected torch 2.6.0 for the legacy NVIDIA profile, found {torch.__version__}.")
+expected_version = "2.11.0+cu126"
+if torch.__version__ != expected_version:
+    raise SystemExit(f"Expected torch {expected_version} for the legacy NVIDIA profile, found {torch.__version__}.")
+
+if torchaudio.__version__ != expected_version:
+    raise SystemExit(
+        f"Expected torchaudio {expected_version} for the legacy NVIDIA profile, found {torchaudio.__version__}."
+    )
 
 if torch.version.cuda != "12.6":
     raise SystemExit(f"Expected CUDA 12.6 for the legacy NVIDIA profile, found {torch.version.cuda}.")
 
-sys.stdout.write(f"Verified legacy NVIDIA Torch profile: torch {torch.__version__}, CUDA {torch.version.cuda}\n")
+sys.stdout.write(
+    f"Verified legacy NVIDIA Torch profile: torch {torch.__version__}, "
+    f"torchaudio {torchaudio.__version__}, CUDA {torch.version.cuda}\n"
+)
 PY
 
 touch "${marker_file}"
+
+if [[ "${lv_chordia}" -eq 1 ]]; then
+  .venv/bin/python -m app.cli.prewarm_models \
+    --skip-demucs \
+    --skip-whisper \
+    --include-lv-chordia
+fi


### PR DESCRIPTION
## Summary

- Route LV Chordia through the architecture-aware Torch device chooser and retry recognized accelerator prewarm failures on CPU.
- Install and verify matched Torch and torchaudio 2.11.0 CUDA 12.6 wheels for the legacy NVIDIA profile while retaining LV Chordia support.
- Align the standalone legacy sync helper and add focused setup, runtime, documentation, and compatibility coverage.
- Closes #483

## Testing

- `bash scripts/setup-dev.test.sh`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `cd apps/backend && uv run --python 3.11 pytest` (758 passed, 1 skipped)
- GTX 1050 Ti: plain `pnpm setup:dev` completed with LV Chordia on CPU.
- GTX 1050 Ti: `pnpm setup:dev -- --legacy-nvidia` completed with matched `torch` / `torchaudio 2.11.0+cu126`; Crema used CPU and LV Chordia used CUDA.
- GTX 1050 Ti: synthetic LV Chordia inference reported `runtime_device == "cuda"`.
- `uv pip check --python .venv/bin/python` reports only the audited LV Chordia NumPy/Torch overrides tracked by #480.
- Whisper can fall back to CPU under GTX 1050 Ti VRAM pressure; newer codec/torchaudio investigation remains outside #483.
