### PR TITLE
fix: repair Flatpak legacy NVIDIA packaging

### DIFF
--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -214,13 +214,15 @@ Chordia dependency stacks by default. Feature flags are independent:
 ```sh
 pnpm package:linux -- --no-crema --no-beat-this --no-lv-chordia
 pnpm package:linux -- --no-advanced-chords --no-advanced-beats
-pnpm package:linux -- --legacy-nvidia --no-lv-chordia --model-bundle
+pnpm package:linux -- --legacy-nvidia --model-bundle
 ```
 
 - `--no-crema` / `--no-advanced-chords` exclude the Advanced Chords dependency stack.
 - `--no-beat-this` / `--no-advanced-beats` exclude the Advanced Beat Analysis dependency stack.
 - `--lv-chordia` / `--no-lv-chordia` include or exclude LV Chordia and its five checkpoints.
-- `--legacy-nvidia` swaps in the legacy CUDA 12.6 PyTorch/torchaudio wheels and broader GPU device access; it requires `--no-lv-chordia` because LV Chordia is audited only with Torch 2.11.0.
+- `--legacy-nvidia` swaps in matched PyTorch/torchaudio 2.11.0 CUDA 12.6 wheels and
+  grants broader GPU device access. LV Chordia remains included unless `--no-lv-chordia` is
+  passed.
 - `--model-bundle` includes required Demucs and Whisper weights, plus beat-this `small0` when beat-this dependencies are included.
 - `--sandbox-data` keeps app data under Flatpak-private `/var/data/tuneforge` instead of the host XDG data directory.
 

--- a/packaging/flatpak/com.tuneforge.desktop.yml
+++ b/packaging/flatpak/com.tuneforge.desktop.yml
@@ -63,14 +63,17 @@ modules:
       env:
         LD_LIBRARY_PATH: /app/lib/tuneforge/backend/python/lib
         PYTHONPATH: /app/lib/tuneforge/backend/site-packages
+        TMPDIR: /run/build/python-runtime-deps/.pip-tmp
     sources:
       - generated/python-sources.json
       - type: file
         path: generated/python-requirements.txt
     build-commands:
       - install -dm755 /app/lib/tuneforge/backend/site-packages
+      - install -dm700 /run/build/python-runtime-deps/.pip-tmp
       - /app/lib/tuneforge/backend/python/bin/python3.11 -m pip install --no-index --find-links=python-sources --target=/app/lib/tuneforge/backend/site-packages setuptools wheel
       - /app/lib/tuneforge/backend/python/bin/python3.11 -m pip install --no-index --no-build-isolation --find-links=python-sources --target=/app/lib/tuneforge/backend/site-packages -r python-requirements.txt
+      - rm -rf /run/build/python-runtime-deps/.pip-tmp
       - find /app/lib/tuneforge/backend/site-packages -type d -name __pycache__ -prune -exec rm -rf {} +
       - find /app/lib/tuneforge/backend/site-packages -type f -name '*.pyc' -delete
 

--- a/scripts/generate-flatpak-sources.mjs
+++ b/scripts/generate-flatpak-sources.mjs
@@ -476,7 +476,7 @@ function run(command, args, options = {}) {
 function resolveLegacyTorchPackages() {
   const requirementsPath = path.join(generatedRoot, "python-legacy-torch.in");
   const pylockPath = path.join(generatedRoot, "pylock.legacy-torch.toml");
-  writeGeneratedFile("python-legacy-torch.in", "torch==2.6.0\ntorchaudio==2.6.0\n");
+  writeGeneratedFile("python-legacy-torch.in", "torch==2.11.0\ntorchaudio==2.11.0\n");
   run("uv", [
     "--quiet",
     "pip",
@@ -499,35 +499,38 @@ function resolveLegacyTorchPackages() {
   return parsePylock(readRequiredFile(pylockPath));
 }
 
-function mergeLegacyTorchPackages(packages) {
+function isLegacyTorchPackage(packageName) {
+  return (
+    packageName === "torch" ||
+    packageName === "torchaudio" ||
+    packageName === "triton" ||
+    packageName === "sympy" ||
+    packageName.startsWith("cuda-") ||
+    packageName.startsWith("nvidia-")
+  );
+}
+
+export function mergeLegacyTorchPackageSets(packages, legacyPackages) {
   const merged = new Map(packages.map((pkg) => [normalizePackageName(pkg.name), pkg]));
-  const legacyPackages = resolveLegacyTorchPackages();
 
   for (const packageName of Array.from(merged.keys())) {
-    if (
-      packageName === "torch" ||
-      packageName === "torchaudio" ||
-      packageName === "triton" ||
-      packageName === "sympy" ||
-      packageName.startsWith("nvidia-")
-    ) {
+    if (isLegacyTorchPackage(packageName)) {
       merged.delete(packageName);
     }
   }
 
-  for (const [packageName, pkg] of legacyPackages) {
-    if (
-      packageName === "torch" ||
-      packageName === "torchaudio" ||
-      packageName === "triton" ||
-      packageName === "sympy" ||
-      packageName.startsWith("nvidia-")
-    ) {
+  for (const pkg of legacyPackages.values()) {
+    const packageName = normalizePackageName(pkg.name);
+    if (isLegacyTorchPackage(packageName)) {
       merged.set(packageName, pkg);
     }
   }
 
   return Array.from(merged.values()).sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function mergeLegacyTorchPackages(packages) {
+  return mergeLegacyTorchPackageSets(packages, resolveLegacyTorchPackages());
 }
 
 function generatePythonSources() {
@@ -613,4 +616,6 @@ function main() {
   );
 }
 
-main();
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  main();
+}

--- a/scripts/package-flatpak.mjs
+++ b/scripts/package-flatpak.mjs
@@ -149,10 +149,12 @@ export function manifestWithPackageOptions(manifest, options) {
   if (options.lvChordia) {
     const runtimeInstall =
       "      - /app/lib/tuneforge/backend/python/bin/python3.11 -m pip install --no-index --no-build-isolation --find-links=python-sources --target=/app/lib/tuneforge/backend/site-packages -r python-requirements.txt\n";
+    const lvChordiaRuntimeInstall =
+      "      - /app/lib/tuneforge/backend/python/bin/python3.11 -m pip install --no-index --no-deps --no-build-isolation --find-links=python-sources --target=/app/lib/tuneforge/backend/site-packages -r python-requirements.txt\n";
     result = replaceManifestFragment(
       result,
       runtimeInstall,
-      runtimeInstall +
+      lvChordiaRuntimeInstall +
         "      - install -dm755 /app/lib/tuneforge/backend/python/share/lv-chordia\n" +
         "      - test -d /app/lib/tuneforge/backend/site-packages/share/lv-chordia/cache_data\n" +
         "      - mv /app/lib/tuneforge/backend/site-packages/share/lv-chordia/cache_data /app/lib/tuneforge/backend/python/share/lv-chordia/cache_data\n",

--- a/scripts/package-options.mjs
+++ b/scripts/package-options.mjs
@@ -62,9 +62,6 @@ export function validatePackageOptions(rawOptions, { platform } = {}) {
   if (platform === "mac" && options.sandboxData) {
     throw new Error("--sandbox-data is only supported for Linux Flatpak packaging.");
   }
-  if (options.legacyNvidia && options.lvChordia) {
-    throw new Error("--legacy-nvidia requires --no-lv-chordia because LV Chordia is audited only with Torch 2.11.0.");
-  }
   return {
     crema: Boolean(options.crema),
     lvChordia: Boolean(options.lvChordia),

--- a/scripts/package-options.test.mjs
+++ b/scripts/package-options.test.mjs
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { mergeLegacyTorchPackageSets } from "./generate-flatpak-sources.mjs";
 import { manifestWithPackageOptions } from "./package-flatpak.mjs";
 import { assertLvChordiaBundleLayout, LV_CHORDIA_CHECKPOINT_NAMES } from "./prepare-bundle.mjs";
 import {
@@ -11,6 +12,33 @@ import {
   packageOptionsToGeneratorArgs,
   parsePackageOptions,
 } from "./package-options.mjs";
+
+const flatpakPipTmpDir = "/run/build/python-runtime-deps/.pip-tmp";
+
+function pythonRuntimeDepsModule(manifest) {
+  return manifest.slice(
+    manifest.indexOf("  - name: python-runtime-deps"),
+    manifest.indexOf("  - name: pnpm"),
+  );
+}
+
+function assertFlatpakPipTempLifecycle(manifest) {
+  const module = pythonRuntimeDepsModule(manifest);
+  const createCommand = `      - install -dm700 ${flatpakPipTmpDir}`;
+  const cleanupCommand = `      - rm -rf ${flatpakPipTmpDir}`;
+  const createIndex = module.indexOf(createCommand);
+  const cleanupIndex = module.indexOf(cleanupCommand);
+  const pipCommands = [...module.matchAll(/ -m pip install /g)];
+
+  assert.match(module, new RegExp(`^        TMPDIR: ${flatpakPipTmpDir.replaceAll(".", "\\.")}$`, "m"));
+  assert.equal((module.match(new RegExp(flatpakPipTmpDir.replaceAll(".", "\\."), "g")) ?? []).length, 3);
+  assert.ok(createIndex >= 0);
+  assert.ok(cleanupIndex >= 0);
+  assert.equal(pipCommands.length, 2);
+  assert.ok(createIndex < pipCommands[0].index);
+  assert.ok(cleanupIndex > pipCommands[1].index);
+  assert.doesNotMatch(module, /(?:--target=|install -dm\d+ )\/app\/[^\n]*\.pip-tmp/);
+}
 
 test("package option parser accepts feature aliases", () => {
   assert.deepEqual(
@@ -110,6 +138,10 @@ test("Flatpak package options are scoped to the TuneForge module build environme
   assert.match(manifest, /-r python-build-requirements\.txt/);
   assert.match(
     manifest,
+    /pip install --no-index --no-deps --no-build-isolation .* -r python-requirements\.txt/,
+  );
+  assert.match(
+    manifest,
     /mv \/app\/lib\/tuneforge\/backend\/site-packages\/share\/lv-chordia\/cache_data \/app\/lib\/tuneforge\/backend\/python\/share\/lv-chordia\/cache_data/,
   );
   const optOutManifest = manifestWithPackageOptions(
@@ -118,6 +150,38 @@ test("Flatpak package options are scoped to the TuneForge module build environme
   );
   assert.doesNotMatch(optOutManifest, /site-packages\/share\/lv-chordia\/cache_data/);
   assert.doesNotMatch(optOutManifest, /python\/share\/lv-chordia\/cache_data/);
+  assert.doesNotMatch(optOutManifest, /pip install .*--no-deps/);
+  assert.match(
+    optOutManifest,
+    /pip install --no-index --no-build-isolation .* -r python-requirements\.txt/,
+  );
+});
+
+test("Flatpak pip temporary files use disk-backed module storage for all Flatpak profiles", () => {
+  const baseManifest = readFileSync(
+    new URL("../packaging/flatpak/com.tuneforge.desktop.yml", import.meta.url),
+    "utf8",
+  );
+  const manifests = [
+    baseManifest,
+    manifestWithPackageOptions(baseManifest, parsePackageOptions([], { platform: "linux" })),
+    manifestWithPackageOptions(
+      baseManifest,
+      parsePackageOptions(["--no-lv-chordia"], { platform: "linux" }),
+    ),
+    manifestWithPackageOptions(
+      baseManifest,
+      parsePackageOptions(["--legacy-nvidia"], { platform: "linux" }),
+    ),
+    manifestWithPackageOptions(
+      baseManifest,
+      parsePackageOptions(["--legacy-nvidia", "--no-lv-chordia"], { platform: "linux" }),
+    ),
+  ];
+
+  for (const manifest of manifests) {
+    assertFlatpakPipTempLifecycle(manifest);
+  }
 });
 
 test("macOS staged bundle has exactly one LV Chordia checkpoint set or none when opted out", () => {
@@ -161,11 +225,64 @@ test("package option parser rejects platform-specific options", () => {
   );
 });
 
-test("legacy nvidia rejects the audited LV Chordia dependency stack", () => {
-  assert.throws(
-    () => parsePackageOptions(["--legacy-nvidia"], { platform: "linux" }),
-    /requires --no-lv-chordia/,
+test("legacy nvidia includes LV Chordia by default", () => {
+  const options = parsePackageOptions(["--legacy-nvidia"], { platform: "linux" });
+
+  assert.deepEqual(
+    packageOptionsToGeneratorArgs(options),
+    ["--crema", "--beat-this", "--lv-chordia", "--legacy-nvidia"],
   );
+  assert.deepEqual(backendSyncArgs(options), [
+    "sync",
+    "--python",
+    "3.11",
+    "--all-groups",
+    "--extra",
+    "advanced-chords",
+    "--extra",
+    "advanced-beats",
+    "--extra",
+    "lv-chordia",
+  ]);
+});
+
+test("Flatpak legacy resolver requests matched Torch 2.11 CUDA 12.6 wheels", () => {
+  const generator = readFileSync(new URL("./generate-flatpak-sources.mjs", import.meta.url), "utf8");
+
+  assert.match(generator, /"torch==2\.11\.0\\ntorchaudio==2\.11\.0\\n"/);
+  assert.match(generator, /"--torch-backend",\n\s+"cu126"/);
+});
+
+test("Flatpak legacy resolver replaces the complete Torch CUDA package family", () => {
+  const basePackages = [
+    { name: "cuda-bindings", version: "13.2.0" },
+    { name: "cuda-pathfinder", version: "1.4.2" },
+    { name: "cuda-toolkit", version: "13.0.2" },
+    { name: "numpy", version: "1.26.4" },
+    { name: "nvidia-cublas-cu12", version: "13.0.0.19" },
+    { name: "torch", version: "2.13.0" },
+  ];
+  const legacyPackages = new Map(
+    [
+      { name: "cuda-bindings", version: "12.9.7" },
+      { name: "cuda-pathfinder", version: "1.3.2" },
+      { name: "cuda-toolkit", version: "12.6.3" },
+      { name: "nvidia-cublas-cu12", version: "12.6.4.1" },
+      { name: "torch", version: "2.11.0+cu126" },
+      { name: "unrelated-legacy-only", version: "9.0.0" },
+    ].map((pkg) => [pkg.name, pkg]),
+  );
+
+  const merged = mergeLegacyTorchPackageSets(basePackages, legacyPackages);
+  const versions = Object.fromEntries(merged.map((pkg) => [pkg.name, pkg.version]));
+
+  assert.equal(versions["cuda-bindings"], "12.9.7");
+  assert.equal(versions["cuda-pathfinder"], "1.3.2");
+  assert.equal(versions["cuda-toolkit"], "12.6.3");
+  assert.equal(versions["nvidia-cublas-cu12"], "12.6.4.1");
+  assert.equal(versions.torch, "2.11.0+cu126");
+  assert.equal(versions.numpy, "1.26.4");
+  assert.equal(versions["unrelated-legacy-only"], undefined);
 });
 
 test("legacy nvidia supports advanced dependency opt-outs", () => {


### PR DESCRIPTION
## Summary

- keep LV Chordia enabled by default for legacy NVIDIA Flatpak packages
- resolve matched Torch and torchaudio 2.11.0 CUDA 12.6 wheels and replace the complete CUDA package family
- install LV Chordia without re-resolving its incompatible metadata and use disk-backed pip temporary storage
- document the corrected legacy NVIDIA packaging behavior

Refs #483

## Testing

- `node --test scripts/package-options.test.mjs`
- `pnpm lint`
- `pnpm typecheck`
- manual `pnpm package:linux -- --no-bundle --legacy-nvidia` build completed through export; the installed Flatpak launched successfully with an isolated `TUNEFORGE_DATA_DIR`
- `pnpm test` was stopped at user request after completed phases passed; CI will run the full `pnpm test` command
