### PR TITLE
feat: add opt-in Crema ONNX runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ download, installation, verification, signature, and publication instructions.
 
 ### Added
 
+- Added an opt-in Crema ONNX implementation for Advanced Chords while retaining Crema/TensorFlow
+  as the default setup and package profile.
 - Added optional bundled LV Chordia submission chord detection for desktop; Advanced Chords remains
   the default while the new backend awaits manual comparison and approval.
 

--- a/LICENSES/crema-0.2.0-BSD-2-Clause.txt
+++ b/LICENSES/crema-0.2.0-BSD-2-Clause.txt
@@ -1,0 +1,25 @@
+BSD 2-Clause License
+
+Copyright (c) 2017, Brian McFee
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Current release limits:
 
 - Desktop is the supported full workflow. Android/mobile remains a local-first companion path in progress.
 - Packages are local build artifacts, not signed distribution releases.
-- Default packages do not include external Demucs, Whisper, or beat-this model weights. Those weights are cached locally and may download on first setup/use unless the caches already exist or a local/dev package was explicitly built with `--model-bundle`. Crema's wheel-embedded chord model assets are the dependency-owned exception and ship with Advanced Chords unless that stack is excluded.
+- Default packages do not include external Demucs, Whisper, or beat-this model weights. Those weights are cached locally and may download on first setup/use unless the caches already exist or a local/dev package was explicitly built with `--model-bundle`. Crema's wheel-embedded chord model assets are the dependency-owned exception and ship with default Advanced Chords. Opt-in Crema ONNX packages use the pinned model from the verified cache or from an explicit `--model-bundle` package.
 - Advanced Chords, Advanced Beat Analysis, GPU acceleration, loopback/browser playback smoke, and BlackHole or virtual-audio capture need manual or special coverage unless a specific CI job says otherwise.
 
 ## Features
@@ -109,6 +109,13 @@ pnpm setup:dev -- --no-crema
 pnpm setup:dev -- --no-advanced-chords
 pnpm setup:dev -- --no-beat-this
 pnpm setup:dev -- --no-advanced-beats
+```
+
+Select Crema ONNX explicitly to use ONNX Runtime and preload the pinned model into the
+verified TuneForge data cache:
+
+```sh
+pnpm setup:dev -- --crema-onnx
 ```
 
 The built-in chord and beat backends remain available as fallbacks when advanced dependencies are
@@ -235,13 +242,14 @@ for local/dev artifacts that explicitly copy model weights into the package:
 pnpm package:mac -- --no-crema --no-beat-this
 pnpm package:linux -- --no-advanced-chords --no-advanced-beats --legacy-nvidia
 pnpm package:mac -- --model-bundle
+pnpm package:mac -- --crema-onnx
+pnpm package:mac -- --crema-onnx --model-bundle
 ```
 
 `--model-bundle` stages Demucs and Whisper weights, and stages the beat-this `small0` checkpoint
-only when beat-this dependencies are included. It does not control whether advanced dependencies are
-installed. Crema is the dependency-owned exception to the external model-weight rule: its
-wheel-embedded chord model files ship when Advanced Chords is included unless `--no-crema` /
-`--no-advanced-chords` is used. See
+only when beat-this dependencies are included. With `--crema-onnx`, it also stages the exact pinned
+ONNX model and runtime state so packaged startup can seed the verified cache. Crema/TensorFlow
+remains the default Advanced Chords package profile and ships its wheel-embedded model files. See
 [Third-party notices and release package policy](./THIRD_PARTY_NOTICES.md) for the dependency and
 model-weight policy.
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -11,8 +11,8 @@ This file is the source of truth for dependency and model-weight distribution po
 - Default release package commands (`pnpm package:mac`, `pnpm package:linux:flatpak`) do not pass `--model-bundle`. They include Advanced Chords, Advanced Beat Analysis, and LV Chordia. LV Chordia's five dependency-owned checkpoints are included; external Demucs, Whisper, and beat-this weights are not.
 - FFmpeg and ffprobe are not bundled by Tuneforge. macOS and source runs use host-installed binaries on `PATH` or explicit `TUNEFORGE_FFMPEG_PATH` / `TUNEFORGE_FFPROBE_PATH` overrides. Flatpak builds use `/app/bin/ffmpeg` and `/app/bin/ffprobe` wrappers backed by the Flatpak runtime or extensions.
 - Demucs, Whisper, and beat-this weights are local cache assets by default. Setup/model-prewarm can prepare them ahead of time, and the app may download them on first use if they are missing. Fully offline use requires the relevant caches/assets to already exist.
-- `--model-bundle` is an explicit local/dev packaging option, not part of default release packaging. It stages Demucs and Whisper weights and, when beat-this is included, the beat-this `small0` checkpoint; redistribution needs separate review before publishable artifacts use it.
-- Crema chord model files are the dependency-owned exception to the external model-weight rule: they are wheel-embedded assets inside the published crema package, ship with default desktop packages when Advanced Chords is included, and are removed only when Advanced Chords is excluded with `--no-crema` / `--no-advanced-chords`.
+- `--model-bundle` is an explicit local/dev packaging option, not part of default release packaging. It stages Demucs and Whisper weights and, when selected, the beat-this `small0` checkpoint and Crema ONNX model/state; redistribution needs separate review before publishable artifacts use it.
+- Default Advanced Chords packages use Crema/TensorFlow and include Crema's wheel-owned model files. Plain opt-in `--crema-onnx` packages use ONNX Runtime and the verified TuneForge data cache. Combining `--crema-onnx` with `--model-bundle` includes the exact pinned converted model and runtime state so startup can seed that cache.
 - LV Chordia's five MIT checkpoints are bundled inside its pinned source dependency, total exactly 28,730,939 bytes, and are removed with `--no-lv-chordia`. They never use a downloader or user cache.
 - Tuneforge does not add cloud processing, accounts, telemetry, or track uploads for these features. Local-first does not mean first use is always offline.
 
@@ -59,7 +59,13 @@ This file is the source of truth for dependency and model-weight distribution po
 
 - **License:** PyPI metadata lists ISC; upstream `LICENSE.md` currently contains BSD-2-Clause terms.
 - **Source:** <https://github.com/bmcfee/crema>
-- **Notes:** Advanced Chords is part of the default desktop/dev/package dependency set and can be excluded with `--no-crema` / `--no-advanced-chords`. The published `crema-0.2.0` wheel includes pretrained chord model files (`model.h5`, `model_spec.pkl`, `muda.pkl`, `pump.pkl`, and `test_scores.json`) inside the package; they are dependency-owned assets, not Tuneforge-generated bundle sources, and are not downloaded separately at runtime. Standard packaged desktop builds redistribute those files as part of crema unless Advanced Chords is explicitly excluded.
+- **Notes:** TensorFlow remains the default implementation and can be excluded with `--no-crema` / `--no-advanced-chords`. The published `crema-0.2.0` wheel includes pretrained model and decoder files. The opt-in ONNX implementation is a format conversion of that model, not a TuneForge-trained model. Its model and runtime state are pinned to immutable Hugging Face revision `65af18f49af5101267fd28f15ac8c452d98b8e3d`. Plain ONNX packages download those files into the verified cache; the explicit local/dev `--crema-onnx --model-bundle` profile includes them. Distribution of a model-bundled application package remains an explicit package-review decision. Source/training provenance remains incomplete. The complete Brian McFee BSD-2-Clause notice is packaged at [`LICENSES/crema-0.2.0-BSD-2-Clause.txt`](./LICENSES/crema-0.2.0-BSD-2-Clause.txt).
+
+### ONNX Runtime / opt-in Crema ONNX backend
+
+- **License:** MIT
+- **Source:** <https://github.com/microsoft/onnxruntime>
+- **Notes:** Included only by the `advanced-chords-onnx` dependency profile. TuneForge uses CPU execution and an immutable converted-model revision. Plain ONNX packages use model and runtime-state files from the verified TuneForge data cache; `--crema-onnx --model-bundle` packages include those exact files and seed the same cache on startup. This profile removes Crema/TensorFlow's HDF5 model-loading closure; preserved LV Chordia support still brings its separately declared `h5py` dependency.
 
 ### beat-this / Advanced Beat Analysis backend
 

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -39,6 +39,11 @@ TensorFlow/Keras and may start and run more slowly. The advanced dependency extr
 stack because crema 0.2.0 uses legacy model-loading, encoder, and `pkg_resources` APIs that are not
 compatible with newer releases.
 
+An opt-in ONNX Runtime implementation preserves the same `crema-advanced` backend ID and output
+shape without installing Crema, TensorFlow, Keras, JAMS, pumpp, or Crema/TensorFlow's HDF5
+model-loading closure. Preserved LV Chordia support still installs its declared `h5py` dependency.
+Select exactly one Crema implementation; installing both is treated as an invalid package profile.
+
 The current mobile backend does not run the desktop Python/FastAPI stack and disables Advanced Chords through `TUNEFORGE_RUNTIME_PLATFORM`.
 
 Built-in Chords and Advanced Chords both analyze the source track first. When matching source stems exist, chord refresh also analyzes a non-vocal stem input and augments the source timeline, so chord jobs can report `source+stem`. For the 6 stems model, the non-vocal input is a temporary float mix of drums, bass, guitar, piano, and other that is deleted after analysis.
@@ -56,7 +61,17 @@ pnpm setup:dev -- --no-crema
 pnpm setup:dev -- --no-advanced-chords
 ```
 
-If `crema`, TensorFlow, Keras, or JAMS are missing, `/api/v1/chord-backends` reports `crema-advanced` as unavailable and normal Built-in Chords detection keeps working.
+For ONNX development, select the ONNX dependency profile explicitly:
+
+```sh
+pnpm setup:dev -- --crema-onnx
+```
+
+Setup verifies or prewarms the immutable model and runtime state in the normal TuneForge data cache.
+TuneForge downloads missing files anonymously from the pinned Hugging Face revision.
+
+`/api/v1/chord-backends` reports Advanced Chords availability and the installed implementation.
+ONNX download, integrity, decoder, and inference failures are reported on the requested job.
 
 Release coverage label: full crema/TensorFlow runtime, package inclusion, and model-artifact review
 are manual or special checks unless a CI workflow explicitly installs and exercises the advanced

--- a/apps/backend/app/cli/prepare_model_bundle.py
+++ b/apps/backend/app/cli/prepare_model_bundle.py
@@ -15,6 +15,14 @@ from app.engines.beat_this import (
     invalid_beat_this_checkpoint_cache_files,
     preload_beat_this_checkpoint,
 )
+from app.engines.crema_onnx import (
+    MODEL_REVISION,
+    ensure_crema_onnx_files,
+    invalid_crema_onnx_files,
+)
+from app.engines.crema_onnx import (
+    expected_model_files as expected_crema_onnx_files,
+)
 from app.engines.demucs_cache import (
     expected_demucs_torch_cache_files,
     invalid_demucs_torch_cache_files,
@@ -38,6 +46,7 @@ def main(argv: list[str] | None = None) -> int:
         prepare_model_bundle(
             output_dir=args.output,
             include_beat_this=args.include_beat_this,
+            include_crema_onnx=args.include_crema_onnx,
             lyrics_models=lyrics_models,
         )
     except Exception as exc:
@@ -50,6 +59,7 @@ def prepare_model_bundle(
     *,
     output_dir: Path,
     include_beat_this: bool = False,
+    include_crema_onnx: bool = False,
     lyrics_models: Sequence[str],
 ) -> None:
     if output_dir.exists():
@@ -60,6 +70,7 @@ def prepare_model_bundle(
     whisper_entries = _prepare_whisper_entries(output_dir, lyrics_models)
     if include_beat_this:
         torch_entries.extend(_prepare_beat_this_entries(output_dir))
+    crema_onnx_entries = _prepare_crema_onnx_entries(output_dir) if include_crema_onnx else []
 
     (output_dir / "manifest.json").write_text(
         json.dumps(
@@ -68,6 +79,7 @@ def prepare_model_bundle(
                 "prepared_at": datetime.now(UTC).isoformat(),
                 "torch_checkpoints": torch_entries,
                 "whisper_models": whisper_entries,
+                "crema_onnx_files": crema_onnx_entries,
             },
             indent=2,
         ),
@@ -83,6 +95,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--include-beat-this", action="store_true")
+    parser.add_argument("--include-crema-onnx", action="store_true")
     parser.add_argument("--lyrics-model", default=None)
     return parser
 
@@ -132,6 +145,17 @@ def _prepare_beat_this_entries(output_dir: Path) -> list[dict[str, object]]:
     )
     entry["checkpoint"] = BEAT_THIS_CHECKPOINT
     return [entry]
+
+
+def _prepare_crema_onnx_entries(output_dir: Path) -> list[dict[str, object]]:
+    if invalid_crema_onnx_files():
+        ensure_crema_onnx_files()
+    _raise_if_invalid("Crema ONNX", invalid_crema_onnx_files())
+    relative_root = Path("crema") / "0.2.0" / MODEL_REVISION
+    return [
+        _copy_to_bundle(output_dir, expected_file, relative_root / expected_file.path.name)
+        for expected_file in expected_crema_onnx_files()
+    ]
 
 
 def _copy_to_bundle(

--- a/apps/backend/app/engines/crema_chords.py
+++ b/apps/backend/app/engines/crema_chords.py
@@ -12,6 +12,12 @@ from pathlib import Path
 from typing import Any
 
 from app.engines.chord_labels import chord_label_to_segment
+from app.engines.crema_onnx import (
+    crema_onnx_metadata,
+    detect_crema_onnx_timeline,
+    ensure_crema_onnx_files,
+    invalid_crema_onnx_files,
+)
 from app.utils.model_cache import ExpectedModelFile, InvalidModelFile, invalid_model_files
 
 CREMA_BACKEND_ID = "crema-advanced"
@@ -22,6 +28,11 @@ _CREMA_MODEL: Any | None = None
 def crema_dependency_status(*, runtime_platform: str = "desktop") -> tuple[bool, str | None]:
     if runtime_platform in {"android", "ios", "mobile"}:
         return False, "advanced chord backend is disabled on mobile"
+    implementation, reason = _crema_implementation()
+    if implementation is None:
+        return False, reason
+    if implementation == "onnx":
+        return True, None
     for module_name, display_name in (
         ("crema", "crema"),
         ("tensorflow", "TensorFlow backend"),
@@ -51,6 +62,16 @@ def detect_crema_chord_timeline(
     merge_adjacent: bool = True,
     min_segment_seconds: float = 0.0,
 ) -> list[dict[str, Any]]:
+    implementation, reason = _crema_implementation()
+    if implementation == "onnx":
+        segments = detect_crema_onnx_timeline(source_path)
+        if min_segment_seconds > 0:
+            segments = _drop_short_segments(segments, min_segment_seconds=min_segment_seconds)
+        if merge_adjacent:
+            segments = merge_adjacent_chord_segments(segments)
+        return segments
+    if implementation is None:
+        raise RuntimeError(reason or "Advanced chord backend is unavailable.")
     model = _get_crema_model()
     with _suppress_crema_runtime_noise(), redirect_stdout(io.StringIO()):
         annotation = model.predict(filename=str(source_path))
@@ -63,6 +84,9 @@ def detect_crema_chord_timeline(
 
 
 def crema_runtime_device() -> str:
+    implementation, _reason = _crema_implementation()
+    if implementation == "onnx":
+        return "cpu"
     try:
         import tensorflow as tf
     except Exception:
@@ -113,10 +137,19 @@ def clear_crema_model_cache() -> None:
 
 
 def preload_crema_model() -> None:
-    _get_crema_model()
+    implementation, reason = _crema_implementation()
+    if implementation == "onnx":
+        ensure_crema_onnx_files()
+    elif implementation == "tensorflow":
+        _get_crema_model()
+    else:
+        raise RuntimeError(reason or "Advanced chord backend is unavailable.")
 
 
 def invalid_crema_model_asset_files() -> tuple[InvalidModelFile, ...]:
+    implementation, _reason = _crema_implementation()
+    if implementation == "onnx":
+        return invalid_crema_onnx_files()
     try:
         package_files = importlib.metadata.files("crema")
     except importlib.metadata.PackageNotFoundError:
@@ -189,14 +222,53 @@ def invalid_crema_model_asset_files() -> tuple[InvalidModelFile, ...]:
 
 
 def crema_model_metadata() -> dict[str, Any]:
+    implementation, reason = _crema_implementation()
+    if implementation == "onnx":
+        return crema_onnx_metadata()
+    if implementation is None:
+        raise RuntimeError(reason or "Advanced chord backend is unavailable.")
     return {
         "backend_id": CREMA_BACKEND_ID,
+        "implementation": "crema-tensorflow",
         "output_format": "jams",
         "model": "crema.models.chord.ChordModel",
         "crema_version": _package_version("crema"),
         "tensorflow_version": _package_version("tensorflow"),
         "license_note": "PyPI metadata lists ISC; upstream LICENSE.md is BSD-2-Clause.",
     }
+
+
+def crema_backend_label() -> str:
+    implementation, _reason = _crema_implementation()
+    if implementation == "tensorflow":
+        return "Advanced Chords — Crema (TensorFlow)"
+    if implementation == "onnx":
+        return "Advanced Chords — Crema ONNX"
+    return "Advanced Chords — Crema"
+
+
+def _crema_implementation() -> tuple[str | None, str | None]:
+    tensorflow_installed = all(
+        _module_available(module_name)
+        for module_name in ("crema", "tensorflow", "keras", "jams")
+    )
+    onnx_installed = _module_available("onnxruntime")
+    if tensorflow_installed and onnx_installed:
+        return None, "both Crema TensorFlow and ONNX Runtime implementations are installed"
+    if onnx_installed:
+        return "onnx", None
+    if tensorflow_installed:
+        return "tensorflow", None
+    if not _module_available("crema") and not onnx_installed:
+        return None, "crema or ONNX Runtime is not installed"
+    return None, "Crema advanced chord dependencies are incomplete"
+
+
+def _module_available(module_name: str) -> bool:
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except (ImportError, ValueError):
+        return module_name in __import__("sys").modules
 
 
 def _get_crema_model() -> Any:

--- a/apps/backend/app/engines/crema_onnx.py
+++ b/apps/backend/app/engines/crema_onnx.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.metadata
+import json
+import math
+import os
+import shutil
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+from app.config import get_settings
+from app.engines.chord_labels import chord_label_to_segment
+from app.utils.model_cache import ExpectedModelFile, InvalidModelFile, invalid_model_files
+
+MODEL_REVISION = "65af18f49af5101267fd28f15ac8c452d98b8e3d"
+MODEL_FILENAME = "crema-0.2.0-opset18.onnx"
+STATE_FILENAME = "crema-0.2.0-runtime-state.json"
+MODEL_SHA256 = "a903f9709821fccebb31d4e93d7d783642faaa90859f45f308c0f9131cc7ca59"
+STATE_SHA256 = "3744bf9ecb47de7194cb9f250fba26678ea347911af32ec4813645d5e033aca2"
+MODEL_SIZE = 2_193_804
+STATE_SIZE = 3_790
+_BASE_URL = f"https://huggingface.co/grazzolini/tuneforge-models/resolve/{MODEL_REVISION}"
+_CLASSES_SHA256 = "e319b684db4725df87ab52c8c7b6df46508af23077c4b0a7dc662a6cbe6228c1"
+_OUTPUTS = ("Identity:0", "Identity_1:0", "Identity_2:0", "Identity_3:0")
+_OUTPUT_WIDTHS = (170, 12, 13, 13)
+_PITCHES = ("C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B")
+_DEGREES = ("1", "b2", "2", "b3", "3", "4", "b5", "5", "b6", "6", "b7", "7")
+_QUALITY_INTERVALS = {
+    "7": {0, 4, 7, 10}, "aug": {0, 4, 8}, "dim": {0, 3, 6}, "dim7": {0, 3, 6, 9},
+    "hdim7": {0, 3, 6, 10}, "maj": {0, 4, 7}, "maj6": {0, 4, 7, 9},
+    "maj7": {0, 4, 7, 11}, "min": {0, 3, 7}, "min6": {0, 3, 7, 9},
+    "min7": {0, 3, 7, 10}, "minmaj7": {0, 3, 7, 11}, "sus2": {0, 2, 7},
+    "sus4": {0, 5, 7},
+}
+
+
+def crema_onnx_cache_dir() -> Path:
+    return get_settings().cache_root / "models" / "crema" / "0.2.0" / MODEL_REVISION
+
+
+def expected_model_files(root: Path | None = None) -> tuple[ExpectedModelFile, ...]:
+    target = root or crema_onnx_cache_dir()
+    return (
+        ExpectedModelFile("Crema ONNX model", target / MODEL_FILENAME, MODEL_SIZE, MODEL_SHA256),
+        ExpectedModelFile("Crema ONNX runtime state", target / STATE_FILENAME, STATE_SIZE, STATE_SHA256),
+    )
+
+
+def invalid_crema_onnx_files(root: Path | None = None) -> tuple[InvalidModelFile, ...]:
+    return invalid_model_files(expected_model_files(root))
+
+
+def import_crema_onnx_model(source: Path) -> None:
+    destination = crema_onnx_cache_dir()
+    destination.mkdir(parents=True, exist_ok=True)
+    destination_files = expected_model_files()
+    cleanup_identities = {
+        expected.path.name: _file_identity(expected.path) for expected in destination_files
+    }
+    try:
+        invalid = invalid_crema_onnx_files(source)
+        if invalid:
+            raise RuntimeError("Crema ONNX import failed integrity verification.")
+        for expected in expected_model_files(source):
+            destination_path = destination / expected.path.name
+            _promote_local_file(expected.path, destination_path)
+            cleanup_identities[expected.path.name] = _file_identity(destination_path)
+        if invalid_crema_onnx_files():
+            raise RuntimeError("Crema ONNX cache failed integrity verification.")
+    except Exception:
+        for expected in destination_files:
+            _remove_if_still_invalid(expected, cleanup_identities[expected.path.name])
+        raise
+
+
+def ensure_crema_onnx_files() -> tuple[Path, Path]:
+    root = crema_onnx_cache_dir()
+    root.mkdir(parents=True, exist_ok=True)
+    for expected in expected_model_files():
+        if invalid_model_files((expected,)):
+            _download_file(f"{_BASE_URL}/{expected.path.name}", expected)
+    if invalid_crema_onnx_files():
+        raise RuntimeError("Crema ONNX model cache failed integrity verification.")
+    return root / MODEL_FILENAME, root / STATE_FILENAME
+
+
+def _promote_local_file(source: Path, destination: Path) -> None:
+    temporary = destination.with_name(f".{destination.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        with source.open("rb") as input_file, temporary.open("xb") as output_file:
+            shutil.copyfileobj(input_file, output_file, length=1024 * 1024)
+            output_file.flush()
+            os.fsync(output_file.fileno())
+        os.replace(temporary, destination)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _download_file(url: str, expected: ExpectedModelFile) -> None:
+    cleanup_identity = _file_identity(expected.path)
+    temporary = expected.path.with_name(f".{expected.path.name}.{uuid.uuid4().hex}.tmp")
+    digest = hashlib.sha256()
+    size = 0
+    try:
+        request = urllib.request.Request(url, headers={"User-Agent": "TuneForge/1"})
+        with urllib.request.urlopen(request, timeout=60) as response, temporary.open("xb") as output_file:
+            while chunk := response.read(min(1024 * 1024, expected.size + 1 - size)):
+                size += len(chunk)
+                if size > expected.size:
+                    raise RuntimeError("Crema ONNX download exceeded the expected size.")
+                digest.update(chunk)
+                output_file.write(chunk)
+            output_file.flush()
+            os.fsync(output_file.fileno())
+        if size != expected.size or digest.hexdigest() != expected.sha256:
+            raise RuntimeError("Crema ONNX download failed integrity verification.")
+        os.replace(temporary, expected.path)
+    except (OSError, urllib.error.URLError) as error:
+        raise RuntimeError("Crema ONNX download failed; seed the verified model cache and retry.") from error
+    finally:
+        temporary.unlink(missing_ok=True)
+        _remove_if_still_invalid(expected, cleanup_identity)
+
+
+def _file_identity(path: Path) -> tuple[int, int, int, int] | None:
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns
+
+
+def _remove_if_still_invalid(
+    expected: ExpectedModelFile,
+    cleanup_identity: tuple[int, int, int, int] | None,
+) -> None:
+    if cleanup_identity is None or _file_identity(expected.path) != cleanup_identity:
+        return
+    if invalid_model_files((expected,)):
+        try:
+            expected.path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def load_runtime_state(path: Path) -> dict[str, Any]:
+    try:
+        state: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+        decoder = state["decoder"]
+        preprocessing = state["preprocessing"]
+        labels = decoder["labels"]
+        transition = decoder["transition"]
+        classes_sha256 = hashlib.sha256("\n".join(labels).encode()).hexdigest()
+        valid = (
+            state["schema_version"] == 1
+            and state["source"]["name"] == "crema"
+            and state["source"]["version"] == "0.2.0"
+            and len(labels) == 170
+            and classes_sha256 == decoder["classes_sha256"] == _CLASSES_SHA256
+            and decoder["sample_rate"] == 44_100
+            and decoder["hop_length"] == 4_096
+            and transition["shape"] == [170, 170]
+            and transition["encoding"] == "uniform-off-diagonal"
+            and preprocessing["output_shape"] == [None, 216, 2]
+        )
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+        raise RuntimeError("Crema ONNX runtime state is invalid.") from error
+    if not valid:
+        raise RuntimeError("Crema ONNX runtime state is unsupported.")
+    return state
+
+
+def preprocess_audio(source_path: Path, state: dict[str, Any]) -> npt.NDArray[np.float32]:
+    import librosa
+
+    spec = state["preprocessing"]
+    sample_rate = int(spec["sample_rate"])
+    audio, native_sample_rate = librosa.load(source_path, sr=None, mono=True)
+    if native_sample_rate != sample_rate:
+        audio = librosa.resample(audio, orig_sr=native_sample_rate, target_sr=sample_rate)
+    duration = librosa.get_duration(y=audio, sr=sample_rate)
+    frames = int(librosa.time_to_frames(duration, sr=sample_rate, hop_length=int(spec["hop_length"])))
+    channels = []
+    for harmonic in spec["harmonics"]:
+        cqt = librosa.cqt(
+            audio,
+            sr=sample_rate,
+            hop_length=int(spec["hop_length"]),
+            fmin=float(spec["fmin"]) * int(harmonic),
+            n_bins=int(spec["octaves"]) * 12 * int(spec["oversample"]),
+            bins_per_octave=12 * int(spec["oversample"]),
+        )
+        magnitude = np.abs(librosa.util.fix_length(cqt, size=frames, axis=-1))
+        channels.append(librosa.amplitude_to_db(magnitude, ref=np.max).astype(np.float32))
+    return np.transpose(np.asarray(channels, dtype=np.float32), (2, 1, 0))[np.newaxis, ...]
+
+
+def run_inference(model_path: Path, features: npt.NDArray[np.float32]) -> tuple[npt.NDArray[np.float32], ...]:
+    os.environ["ORT_DISABLE_TELEMETRY"] = "1"
+    import onnxruntime as ort
+
+    if hasattr(ort, "disable_telemetry_events"):
+        ort.disable_telemetry_events()
+    session = ort.InferenceSession(str(model_path), providers=["CPUExecutionProvider"])
+    if [value.name for value in session.get_inputs()] != ["cqt_mag"]:
+        raise RuntimeError("Crema ONNX model input does not match the pinned specification.")
+    outputs = session.run(list(_OUTPUTS), {"cqt_mag": features})
+    normalized = tuple(np.asarray(value[0], dtype=np.float32) for value in outputs)
+    invalid_shape = any(
+        value.ndim != 2 or value.shape[1] != width
+        for value, width in zip(normalized, _OUTPUT_WIDTHS, strict=True)
+    )
+    if len(normalized) != 4 or invalid_shape:
+        raise RuntimeError("Crema ONNX model outputs do not match the pinned specification.")
+    return normalized
+
+
+def _viterbi(probabilities: npt.NDArray[np.float32], state: dict[str, Any]) -> npt.NDArray[np.int64]:
+    count = probabilities.shape[1]
+    transition = state["decoder"]["transition"]
+    matrix = np.full((count, count), transition["off_diagonal"], dtype=np.float64)
+    np.fill_diagonal(matrix, transition["diagonal"])
+    tiny = np.finfo(probabilities.dtype).tiny
+    log_prob = np.log(probabilities + tiny) - math.log(1.0 / count)
+    log_transition = np.log(matrix + tiny)
+    values = np.zeros(probabilities.shape, dtype=np.float64)
+    pointers = np.zeros(probabilities.shape, dtype=np.int64)
+    values[0] = log_prob[0] + math.log(1.0 / count)
+    for frame in range(1, probabilities.shape[0]):
+        candidates = values[frame - 1][:, np.newaxis] + log_transition
+        pointers[frame] = np.argmax(candidates, axis=0)
+        values[frame] = log_prob[frame] + candidates[pointers[frame], np.arange(count)]
+    path = np.zeros(probabilities.shape[0], dtype=np.int64)
+    path[-1] = int(np.argmax(values[-1]))
+    for frame in range(probabilities.shape[0] - 2, -1, -1):
+        path[frame] = pointers[frame + 1, path[frame + 1]]
+    return path
+
+
+def decode_timeline(
+    tag: npt.NDArray[np.float32], bass: npt.NDArray[np.float32], state: dict[str, Any]
+) -> list[dict[str, Any]]:
+    labels = state["decoder"]["labels"]
+    hop = int(state["decoder"]["hop_length"])
+    sample_rate = int(state["decoder"]["sample_rate"])
+    path = _viterbi(tag, state)
+    changes = np.where(path[1:] != path[:-1])[0]
+    ends = np.unique(np.append(changes, len(path)))
+    lengths = np.diff(np.append(-1, ends))
+    starts = np.cumsum(np.append(0, lengths))[:-1]
+    timeline: list[dict[str, Any]] = []
+    for start, length in zip(starts, lengths, strict=True):
+        end = int(start + length)
+        label_index = int(path[start])
+        label = labels[label_index]
+        confidence = float(np.mean(tag[start : end + 1, label_index]))
+        if label not in {"N", "X"}:
+            root, quality = label.split(":", 1)
+            stabilized = np.maximum(bass[start : end + 1], np.finfo(np.float32).tiny)
+            bass_index = int(np.argmax(np.exp(np.mean(np.log(stabilized), axis=0))))
+            relative = (bass_index - _PITCHES.index(root)) % 12 if bass_index < 12 else 0
+            if relative and relative in _QUALITY_INTERVALS[quality]:
+                label = f"{label}/{_DEGREES[relative]}"
+        timeline.append(chord_label_to_segment(
+            label,
+            start_seconds=float(start * hop / sample_rate),
+            end_seconds=float(end * hop / sample_rate),
+            confidence=round(confidence, 3),
+        ))
+    return timeline
+
+
+def detect_crema_onnx_timeline(source_path: Path) -> list[dict[str, Any]]:
+    try:
+        model_path, state_path = ensure_crema_onnx_files()
+    except RuntimeError:
+        raise
+    except Exception as error:
+        raise RuntimeError("Crema ONNX model preparation failed.") from error
+    try:
+        state = load_runtime_state(state_path)
+    except RuntimeError:
+        raise
+    except Exception as error:
+        raise RuntimeError("Crema ONNX runtime state could not be loaded.") from error
+    try:
+        features = preprocess_audio(source_path, state)
+    except Exception as error:
+        raise RuntimeError("Crema ONNX audio preprocessing failed.") from error
+    try:
+        tag, _pitch, _root, bass = run_inference(model_path, features)
+    except Exception as error:
+        raise RuntimeError("Crema ONNX inference failed.") from error
+    try:
+        return decode_timeline(tag, bass, state)
+    except Exception as error:
+        raise RuntimeError("Crema ONNX timeline decoding failed.") from error
+
+
+def crema_onnx_metadata() -> dict[str, Any]:
+    return {
+        "backend_id": "crema-advanced",
+        "implementation": "crema-onnx",
+        "source_crema_version": "0.2.0",
+        "model_revision": MODEL_REVISION,
+        "model_sha256": MODEL_SHA256,
+        "runtime_state_sha256": STATE_SHA256,
+        "onnxruntime_version": importlib.metadata.version("onnxruntime"),
+        "provider": "CPUExecutionProvider",
+    }

--- a/apps/backend/app/services/chord_backends.py
+++ b/apps/backend/app/services/chord_backends.py
@@ -8,6 +8,7 @@ from typing import Any, Literal, Protocol, cast
 from app.config import get_settings
 from app.engines.chords import detect_chord_timeline
 from app.engines.crema_chords import (
+    crema_backend_label,
     crema_dependency_status,
     crema_model_metadata,
     crema_runtime_device,
@@ -119,6 +120,9 @@ class CremaChordBackend:
     def availability(self) -> ChordBackendAvailability:
         available, reason = crema_dependency_status(runtime_platform=get_settings().runtime_platform)
         return ChordBackendAvailability(available=available, unavailable_reason=reason)
+
+    def display_label(self) -> str:
+        return crema_backend_label()
 
     def detect(self, source_path: Path) -> ChordDetectionResult:
         availability = self.availability()
@@ -264,7 +268,7 @@ def _backend_info(backend: ChordDetectionBackend) -> dict[str, Any]:
     capabilities = asdict(backend.capabilities)
     return {
         "id": backend.id,
-        "label": backend.label,
+        "label": backend.display_label() if isinstance(backend, CremaChordBackend) else backend.label,
         "description": backend.description,
         "availability": "available" if availability.available else "unavailable",
         "available": availability.available,

--- a/apps/backend/app/utils/model_bundle.py
+++ b/apps/backend/app/utils/model_bundle.py
@@ -7,6 +7,8 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from app.engines.crema_onnx import MODEL_REVISION
+from app.engines.crema_onnx import expected_model_files as expected_crema_onnx_files
 from app.utils.model_cache import ExpectedModelFile, invalid_model_files, torch_checkpoint_dir
 
 
@@ -30,6 +32,13 @@ def seed_model_bundle_caches(settings: Any) -> None:
         _entries(manifest, "whisper_models"),
         Path(settings.lyrics_cache_dir),
     )
+    crema_onnx_entries = _entries(manifest, "crema_onnx_files")
+    if crema_onnx_entries:
+        _seed_crema_onnx_entries(
+            resolved_bundle_dir,
+            crema_onnx_entries,
+            Path(settings.cache_root) / "models" / "crema" / "0.2.0" / MODEL_REVISION,
+        )
 
 
 def _entries(manifest: Mapping[str, Any], key: str) -> tuple[Mapping[str, Any], ...]:
@@ -57,6 +66,28 @@ def _seed_entries(bundle_dir: Path, entries: tuple[Mapping[str, Any], ...], cach
         if not invalid_model_files((destination_expected,)):
             continue
         _copy_verified_model_file(expected, destination)
+
+
+def _seed_crema_onnx_entries(
+    bundle_dir: Path,
+    entries: tuple[Mapping[str, Any], ...],
+    cache_dir: Path,
+) -> None:
+    expected_by_name = {expected.path.name: expected for expected in expected_crema_onnx_files(cache_dir)}
+    entry_names = [_required_string(entry, "file_name") for entry in entries]
+    if len(entry_names) != len(expected_by_name) or set(entry_names) != set(expected_by_name):
+        raise RuntimeError("Crema ONNX model bundle must contain the exact pinned file set")
+    for entry in entries:
+        name = _required_string(entry, "file_name")
+        expected = expected_by_name[name]
+        expected_relative_path = (Path("crema") / "0.2.0" / MODEL_REVISION / name).as_posix()
+        if (
+            _required_string(entry, "relative_path") != expected_relative_path
+            or entry.get("size") != expected.size
+            or _required_string(entry, "sha256") != expected.sha256
+        ):
+            raise RuntimeError(f"Crema ONNX model bundle metadata is invalid: {name}")
+    _seed_entries(bundle_dir, entries, cache_dir)
 
 
 def _expected_bundle_file(bundle_dir: Path, entry: Mapping[str, Any]) -> ExpectedModelFile:

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -26,6 +26,9 @@ advanced-chords = [
   "setuptools<85",
   "tensorflow>=2.15,<2.22",
 ]
+advanced-chords-onnx = [
+  "onnxruntime==1.29.0",
+]
 advanced-beats = [
   "beat-this>=1.1.0,<2.0.0",
 ]
@@ -34,6 +37,12 @@ lv-chordia = [
 ]
 
 [tool.uv]
+conflicts = [
+  [
+    { extra = "advanced-chords" },
+    { extra = "advanced-chords-onnx" },
+  ],
+]
 override-dependencies = [
   # Audited against lv-chordia's upstream golden fixture at the pinned commit.
   "numpy==1.26.4",

--- a/apps/backend/tests/test_chord_backends.py
+++ b/apps/backend/tests/test_chord_backends.py
@@ -93,6 +93,11 @@ def test_crema_annotation_conversion_preserves_confidence_and_bass():
 
 
 def test_crema_detection_suppresses_known_runtime_noise(monkeypatch, capsys, recwarn):
+    monkeypatch.setattr(
+        "app.engines.crema_chords.importlib.util.find_spec",
+        lambda name: None if name == "onnxruntime" else object(),
+    )
+
     class FakeModel:
         def predict(self, filename: str):
             assert filename == "/tmp/source.wav"
@@ -115,6 +120,10 @@ def test_crema_detection_suppresses_known_runtime_noise(monkeypatch, capsys, rec
 
 
 def test_crema_first_feature_use_instantiates_chord_model(monkeypatch):
+    monkeypatch.setattr(
+        "app.engines.crema_chords.importlib.util.find_spec",
+        lambda name: None if name == "onnxruntime" else object(),
+    )
     created: list[str] = []
     predicted: list[str] = []
 
@@ -149,7 +158,10 @@ def test_crema_first_feature_use_instantiates_chord_model(monkeypatch):
 
 
 def test_crema_backend_reports_tensorflow_runtime_device(monkeypatch):
-    monkeypatch.setattr("app.engines.crema_chords.importlib.util.find_spec", lambda _: object())
+    monkeypatch.setattr(
+        "app.engines.crema_chords.importlib.util.find_spec",
+        lambda name: None if name == "onnxruntime" else object(),
+    )
     monkeypatch.setattr(
         "app.services.chord_backends.detect_crema_chord_timeline",
         lambda _: [{"start_seconds": 0.0, "end_seconds": 1.0, "label": "C"}],
@@ -165,7 +177,7 @@ def test_crema_backend_reports_tensorflow_runtime_device(monkeypatch):
 
 def test_backend_registry_reports_fast_and_missing_crema(monkeypatch):
     def fake_find_spec(module_name: str):
-        return None if module_name == "crema" else object()
+        return None if module_name in {"crema", "onnxruntime"} else object()
 
     monkeypatch.setattr("app.engines.crema_chords.importlib.util.find_spec", fake_find_spec)
 
@@ -174,7 +186,22 @@ def test_backend_registry_reports_fast_and_missing_crema(monkeypatch):
     assert backends["tuneforge-fast"]["availability"] == "available"
     assert backends["tuneforge-fast"]["capabilities"]["supports_sevenths"] is True
     assert backends["crema-advanced"]["availability"] == "unavailable"
-    assert backends["crema-advanced"]["unavailable_reason"] == "crema is not installed"
+    assert backends["crema-advanced"]["unavailable_reason"] == "crema or ONNX Runtime is not installed"
+
+
+def test_crema_backend_rejects_ambiguous_runtime_and_labels_onnx(monkeypatch):
+    monkeypatch.setattr("app.engines.crema_chords.importlib.util.find_spec", lambda _name: object())
+    ambiguous = {backend["id"]: backend for backend in list_chord_backend_infos()}["crema-advanced"]
+    assert ambiguous["availability"] == "unavailable"
+    assert "both Crema TensorFlow and ONNX Runtime" in ambiguous["unavailable_reason"]
+
+    monkeypatch.setattr(
+        "app.engines.crema_chords.importlib.util.find_spec",
+        lambda name: object() if name == "onnxruntime" else None,
+    )
+    onnx = {backend["id"]: backend for backend in list_chord_backend_infos()}["crema-advanced"]
+    assert onnx["availability"] == "available"
+    assert onnx["label"] == "Advanced Chords — Crema ONNX"
 
 
 def test_default_chord_backend_prefers_crema_when_available(monkeypatch):
@@ -223,7 +250,7 @@ def test_lv_chordia_registry_reports_damaged_bundle(monkeypatch):
 
 def test_resolving_missing_advanced_backend_returns_structured_error(monkeypatch):
     def fake_find_spec(module_name: str):
-        return None if module_name == "crema" else object()
+        return None if module_name in {"crema", "onnxruntime"} else object()
 
     monkeypatch.setattr("app.engines.crema_chords.importlib.util.find_spec", fake_find_spec)
 
@@ -232,7 +259,10 @@ def test_resolving_missing_advanced_backend_returns_structured_error(monkeypatch
 
 
 def test_crema_backend_detects_keras_three_incompatibility(monkeypatch):
-    monkeypatch.setattr("app.engines.crema_chords.importlib.util.find_spec", lambda _: object())
+    monkeypatch.setattr(
+        "app.engines.crema_chords.importlib.util.find_spec",
+        lambda name: None if name == "onnxruntime" else object(),
+    )
 
     def fake_version(package_name: str) -> str:
         versions = {"keras": "3.14.0", "scikit-learn": "1.5.2"}
@@ -253,7 +283,10 @@ def test_crema_backend_detects_keras_three_incompatibility(monkeypatch):
 
 
 def test_crema_backend_detects_scikit_learn_incompatibility(monkeypatch):
-    monkeypatch.setattr("app.engines.crema_chords.importlib.util.find_spec", lambda _: object())
+    monkeypatch.setattr(
+        "app.engines.crema_chords.importlib.util.find_spec",
+        lambda name: None if name == "onnxruntime" else object(),
+    )
 
     def fake_version(package_name: str) -> str:
         versions = {"keras": "2.15.0", "scikit-learn": "1.8.0"}
@@ -275,7 +308,7 @@ def test_crema_backend_detects_scikit_learn_incompatibility(monkeypatch):
 
 def test_chord_backends_api_marks_crema_unavailable(client, monkeypatch):
     def fake_find_spec(module_name: str):
-        return None if module_name == "crema" else object()
+        return None if module_name in {"crema", "onnxruntime"} else object()
 
     monkeypatch.setattr("app.engines.crema_chords.importlib.util.find_spec", fake_find_spec)
 
@@ -286,14 +319,14 @@ def test_chord_backends_api_marks_crema_unavailable(client, monkeypatch):
     backends = {backend["id"]: backend for backend in payload["backends"]}
     assert backends["tuneforge-fast"]["availability"] == "available"
     assert backends["crema-advanced"]["availability"] == "unavailable"
-    assert backends["crema-advanced"]["unavailable_reason"] == "crema is not installed"
+    assert backends["crema-advanced"]["unavailable_reason"] == "crema or ONNX Runtime is not installed"
     assert backends["crema-advanced"]["capabilities"]["supportsSevenths"] is True
     assert backends["crema-advanced"]["desktopOnly"] is True
 
 
 def test_advanced_chords_request_fails_if_crema_missing(client, sample_chord_audio_file: Path, monkeypatch):
     def fake_find_spec(module_name: str):
-        return None if module_name == "crema" else object()
+        return None if module_name in {"crema", "onnxruntime"} else object()
 
     monkeypatch.setattr("app.engines.crema_chords.importlib.util.find_spec", fake_find_spec)
     project = client.post(
@@ -309,7 +342,7 @@ def test_advanced_chords_request_fails_if_crema_missing(client, sample_chord_aud
     assert response.status_code == 409
     payload = response.json()
     assert payload["error"]["code"] == "ADVANCED_CHORD_BACKEND_UNAVAILABLE"
-    assert payload["error"]["message"] == "crema is not installed"
+    assert payload["error"]["message"] == "crema or ONNX Runtime is not installed"
 
 
 def test_explicit_lv_chordia_request_fails_if_bundle_is_unavailable(

--- a/apps/backend/tests/test_crema_onnx.py
+++ b/apps/backend/tests/test_crema_onnx.py
@@ -1,0 +1,468 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import sys
+import urllib.error
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import numpy as np
+import pytest
+
+from app.benchmarks.chord_evaluation import SYNTHETIC_VERSION, _write_synthetic_wav, score_timeline
+from app.engines import crema_onnx
+from app.engines.crema_chords import merge_adjacent_chord_segments
+from app.utils.model_cache import ExpectedModelFile
+
+
+def _state() -> dict[str, Any]:
+    pitches = ("C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B")
+    qualities = (
+        "min", "maj", "dim", "aug", "min6", "maj6", "min7", "maj7", "7", "dim7",
+        "hdim7", "minmaj7", "sus2", "sus4",
+    )
+    labels = sorted(["N", "X", *(f"{pitch}:{quality}" for pitch in pitches for quality in qualities)])
+    return {
+        "schema_version": 1,
+        "source": {"name": "crema", "version": "0.2.0"},
+        "preprocessing": {
+            "sample_rate": 44_100,
+            "hop_length": 4_096,
+            "fmin": 32.70319566257483,
+            "harmonics": [1, 2],
+            "octaves": 6,
+            "oversample": 3,
+            "output_shape": [None, 216, 2],
+        },
+        "decoder": {
+            "sample_rate": 44_100,
+            "hop_length": 4_096,
+            "labels": labels,
+            "classes_sha256": hashlib.sha256("\n".join(labels).encode()).hexdigest(),
+            "transition": {
+                "encoding": "uniform-off-diagonal",
+                "shape": [170, 170],
+                "diagonal": 0.957154635467057,
+                "off_diagonal": 0.00025352286705883413,
+            },
+        },
+    }
+
+
+class _Response(io.BytesIO):
+    def __enter__(self) -> _Response:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()
+
+
+def test_download_streams_verifies_and_atomically_promotes(tmp_path: Path, monkeypatch) -> None:
+    payload = b"verified model"
+    expected = ExpectedModelFile(
+        "fixture", tmp_path / "model.onnx", len(payload), hashlib.sha256(payload).hexdigest()
+    )
+    monkeypatch.setattr(crema_onnx.urllib.request, "urlopen", lambda *_args, **_kwargs: _Response(payload))
+
+    crema_onnx._download_file("https://example.invalid/model", expected)
+
+    assert expected.path.read_bytes() == payload
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+@pytest.mark.parametrize("payload", [b"short", b"wrong size", b"too long for fixture"])
+def test_download_rejects_bad_integrity_and_cleans_partial(tmp_path: Path, monkeypatch, payload: bytes) -> None:
+    expected_payload = b"right size"
+    expected = ExpectedModelFile(
+        "fixture",
+        tmp_path / "model.onnx",
+        len(expected_payload),
+        hashlib.sha256(expected_payload).hexdigest(),
+    )
+    monkeypatch.setattr(crema_onnx.urllib.request, "urlopen", lambda *_args, **_kwargs: _Response(payload))
+
+    with pytest.raises(RuntimeError, match="integrity|expected size"):
+        crema_onnx._download_file("https://example.invalid/model", expected)
+
+    assert not expected.path.exists()
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_download_failure_is_sanitized_and_cleans_partial(tmp_path: Path, monkeypatch) -> None:
+    class PartialResponse(_Response):
+        def read(self, size: int = -1) -> bytes:
+            value = super().read(size)
+            if value:
+                return value
+            raise urllib.error.URLError("private fixture detail")
+
+    payload = b"partial"
+    expected = ExpectedModelFile(
+        "fixture", tmp_path / "model.onnx", len(payload) + 1, hashlib.sha256(payload).hexdigest()
+    )
+    monkeypatch.setattr(
+        crema_onnx.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: PartialResponse(payload),
+    )
+
+    with pytest.raises(RuntimeError, match="seed the verified model cache") as error:
+        crema_onnx._download_file("https://example.invalid/private-name", expected)
+
+    assert "private-name" not in str(error.value)
+    assert not expected.path.exists()
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_failed_download_removes_unchanged_corrupt_destination(tmp_path: Path, monkeypatch) -> None:
+    destination = tmp_path / "model.onnx"
+    destination.write_bytes(b"corrupt")
+    expected = ExpectedModelFile(
+        "fixture", destination, 5, hashlib.sha256(b"model").hexdigest()
+    )
+    monkeypatch.setattr(
+        crema_onnx.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(urllib.error.URLError("offline")),
+    )
+
+    with pytest.raises(RuntimeError, match="seed the verified model cache"):
+        crema_onnx._download_file("https://example.invalid/model", expected)
+
+    assert not destination.exists()
+
+
+def test_failed_download_preserves_concurrently_promoted_valid_file(tmp_path: Path, monkeypatch) -> None:
+    destination = tmp_path / "model.onnx"
+    destination.write_bytes(b"corrupt")
+    payload = b"model"
+    expected = ExpectedModelFile(
+        "fixture", destination, len(payload), hashlib.sha256(payload).hexdigest()
+    )
+
+    def promote_then_fail(*_args, **_kwargs):
+        temporary = tmp_path / "concurrent.tmp"
+        temporary.write_bytes(payload)
+        temporary.replace(destination)
+        raise urllib.error.URLError("offline")
+
+    monkeypatch.setattr(crema_onnx.urllib.request, "urlopen", promote_then_fail)
+
+    with pytest.raises(RuntimeError, match="seed the verified model cache"):
+        crema_onnx._download_file("https://example.invalid/model", expected)
+
+    assert destination.read_bytes() == payload
+
+
+def test_concurrent_downloads_use_unique_temporary_files(tmp_path: Path, monkeypatch) -> None:
+    payload = b"same verified bytes"
+    expected = ExpectedModelFile(
+        "fixture", tmp_path / "model.onnx", len(payload), hashlib.sha256(payload).hexdigest()
+    )
+    monkeypatch.setattr(
+        crema_onnx.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _Response(payload),
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [
+            executor.submit(crema_onnx._download_file, "https://example.invalid/model", expected)
+            for _ in range(2)
+        ]
+        for future in futures:
+            future.result()
+
+    assert expected.path.read_bytes() == payload
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_verified_cache_is_reused_without_network(tmp_path: Path, monkeypatch) -> None:
+    model = tmp_path / crema_onnx.MODEL_FILENAME
+    state = tmp_path / crema_onnx.STATE_FILENAME
+    model.write_bytes(b"model")
+    state.write_bytes(b"state")
+    expected = (
+        ExpectedModelFile("model", model, 5, hashlib.sha256(b"model").hexdigest()),
+        ExpectedModelFile("state", state, 5, hashlib.sha256(b"state").hexdigest()),
+    )
+    monkeypatch.setattr(crema_onnx, "crema_onnx_cache_dir", lambda: tmp_path)
+    monkeypatch.setattr(crema_onnx, "expected_model_files", lambda root=None: expected)
+    monkeypatch.setattr(
+        crema_onnx.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: pytest.fail("verified cache must remain offline"),
+    )
+
+    assert crema_onnx.ensure_crema_onnx_files() == (model, state)
+
+
+def test_verified_offline_import_promotes_both_files(tmp_path: Path, monkeypatch) -> None:
+    source = tmp_path / "download"
+    destination = tmp_path / "cache"
+    source.mkdir()
+    destination.mkdir()
+    payloads = {
+        crema_onnx.MODEL_FILENAME: b"model",
+        crema_onnx.STATE_FILENAME: b"state",
+    }
+    for name, payload in payloads.items():
+        (source / name).write_bytes(payload)
+
+    def expected(root: Path | None = None) -> tuple[ExpectedModelFile, ...]:
+        target = root or destination
+        return tuple(
+            ExpectedModelFile(name, target / name, len(payload), hashlib.sha256(payload).hexdigest())
+            for name, payload in payloads.items()
+        )
+
+    monkeypatch.setattr(crema_onnx, "crema_onnx_cache_dir", lambda: destination)
+    monkeypatch.setattr(crema_onnx, "expected_model_files", expected)
+
+    crema_onnx.import_crema_onnx_model(source)
+
+    assert {path.name: path.read_bytes() for path in destination.iterdir()} == payloads
+
+
+def test_failed_offline_import_removes_known_corrupt_cache_files(tmp_path: Path, monkeypatch) -> None:
+    source = tmp_path / "download"
+    destination = tmp_path / "cache"
+    source.mkdir()
+    destination.mkdir()
+    payloads = {
+        crema_onnx.MODEL_FILENAME: b"model",
+        crema_onnx.STATE_FILENAME: b"state",
+    }
+    for name in payloads:
+        (source / name).write_bytes(b"invalid")
+        (destination / name).write_bytes(b"corrupt")
+
+    def expected(root: Path | None = None) -> tuple[ExpectedModelFile, ...]:
+        target = root or destination
+        return tuple(
+            ExpectedModelFile(name, target / name, len(payload), hashlib.sha256(payload).hexdigest())
+            for name, payload in payloads.items()
+        )
+
+    monkeypatch.setattr(crema_onnx, "crema_onnx_cache_dir", lambda: destination)
+    monkeypatch.setattr(crema_onnx, "expected_model_files", expected)
+
+    with pytest.raises(RuntimeError, match="import failed integrity"):
+        crema_onnx.import_crema_onnx_model(source)
+
+    assert list(destination.iterdir()) == []
+
+
+def test_runtime_state_rejects_wrong_schema(tmp_path: Path) -> None:
+    state = _state()
+    state["schema_version"] = 2
+    path = tmp_path / "state.json"
+    path.write_text(json.dumps(state), encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="unsupported"):
+        crema_onnx.load_runtime_state(path)
+
+
+def test_runtime_state_rejects_wrong_source_version(tmp_path: Path) -> None:
+    state = _state()
+    state["source"]["version"] = "unexpected"
+    path = tmp_path / "state.json"
+    path.write_text(json.dumps(state), encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="unsupported"):
+        crema_onnx.load_runtime_state(path)
+
+
+def test_four_named_heads_are_mapped_in_order(monkeypatch, tmp_path: Path) -> None:
+    calls: list[tuple[list[str], dict[str, np.ndarray]]] = []
+
+    class Session:
+        def __init__(self, _path: str, *, providers: list[str]) -> None:
+            assert providers == ["CPUExecutionProvider"]
+
+        def get_inputs(self) -> list[SimpleNamespace]:
+            return [SimpleNamespace(name="cqt_mag")]
+
+        def run(self, outputs: list[str], inputs: dict[str, np.ndarray]) -> list[np.ndarray]:
+            calls.append((outputs, inputs))
+            return [np.zeros((1, 3, width), dtype=np.float32) for width in (170, 12, 13, 13)]
+
+    module = ModuleType("onnxruntime")
+    telemetry_disabled: list[bool] = []
+    module.disable_telemetry_events = lambda: telemetry_disabled.append(True)  # type: ignore[attr-defined]
+    module.InferenceSession = Session  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "onnxruntime", module)
+    features = np.zeros((1, 3, 216, 2), dtype=np.float32)
+
+    heads = crema_onnx.run_inference(tmp_path / "model.onnx", features)
+
+    assert [head.shape for head in heads] == [(3, 170), (3, 12), (3, 13), (3, 13)]
+    assert calls[0][0] == ["Identity:0", "Identity_1:0", "Identity_2:0", "Identity_3:0"]
+    assert calls[0][1] == {"cqt_mag": features}
+    assert telemetry_disabled == [True]
+
+
+def test_preprocessing_builds_exact_hcqt_layout(monkeypatch, tmp_path: Path) -> None:
+    cqt_calls: list[dict[str, Any]] = []
+    module = ModuleType("librosa")
+    module.load = lambda *_args, **_kwargs: (np.ones(44_100, dtype=np.float32), 44_100)  # type: ignore[attr-defined]
+    module.resample = lambda value, **_kwargs: value  # type: ignore[attr-defined]
+    module.get_duration = lambda **_kwargs: 1.0  # type: ignore[attr-defined]
+    module.time_to_frames = lambda *_args, **_kwargs: 10  # type: ignore[attr-defined]
+
+    def cqt(_audio: np.ndarray, **kwargs: Any) -> np.ndarray:
+        cqt_calls.append(kwargs)
+        return np.ones((216, 10), dtype=np.complex64)
+
+    module.cqt = cqt  # type: ignore[attr-defined]
+    module.util = SimpleNamespace(fix_length=lambda value, **_kwargs: value)  # type: ignore[attr-defined]
+    module.amplitude_to_db = lambda value, **_kwargs: value  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "librosa", module)
+
+    features = crema_onnx.preprocess_audio(tmp_path / "source.wav", _state())
+
+    assert features.shape == (1, 10, 216, 2)
+    assert features.dtype == np.float32
+    assert [call["fmin"] for call in cqt_calls] == [32.70319566257483, 65.40639132514966]
+    assert all(call["hop_length"] == 4_096 for call in cqt_calls)
+    assert all(call["n_bins"] == 216 and call["bins_per_octave"] == 36 for call in cqt_calls)
+
+
+def test_preprocessing_matches_frozen_quality_synthetic_reference(tmp_path: Path) -> None:
+    assert SYNTHETIC_VERSION == "synthetic-chords-v1"
+    source = tmp_path / "fixture.wav"
+    _write_synthetic_wav(source, ("C",))
+
+    features = crema_onnx.preprocess_audio(source, _state())
+
+    assert features.shape == (1, 10, 216, 2)
+    # Frozen from Crema 0.2.0 pumpp HCQT output during the conversion checkpoint.
+    np.testing.assert_allclose(
+        features[0, [0, 1, 5, 9], [0, 36, 108, 215], [0, 1, 0, 1]],
+        np.asarray([-59.071804, -4.4513607, -80.0, -80.0], dtype=np.float32),
+        atol=2e-3,
+    )
+    np.testing.assert_allclose(
+        [features.min(), features.max(), features.mean(), features.std()],
+        [-80.0, 0.0, -67.447784, 20.998577],
+        atol=2e-3,
+    )
+
+
+def test_decoder_preserves_inversion_confidence_and_repeat_determinism() -> None:
+    state = _state()
+    tag = np.full((4, 170), 1e-8, dtype=np.float32)
+    chord_index = state["decoder"]["labels"].index("C:maj")
+    tag[:, chord_index] = 1.0
+    tag /= tag.sum(axis=1, keepdims=True)
+    bass = np.full((4, 13), 1e-8, dtype=np.float32)
+    bass[:, 4] = 1.0
+
+    first = crema_onnx.decode_timeline(tag, bass, state)
+    second = crema_onnx.decode_timeline(tag, bass, state)
+
+    assert first == second
+    assert first[0]["label"] == "C/E"
+    assert first[0]["display_label"] == "C/E"
+    assert first[0]["bass_degree"] == "3"
+    assert first[0]["confidence"] == 1.0
+    assert first[0]["end_seconds"] == 0.464
+
+
+def test_decoder_matches_frozen_tensorflow_timeline_and_scorer_fixture() -> None:
+    state = _state()
+    labels = state["decoder"]["labels"]
+    tag = np.full((9, 170), 1e-8, dtype=np.float32)
+    for frames, label, confidence in (
+        ((0, 1), "C:maj7", 0.9),
+        ((2, 3), "G:7", 0.8),
+        ((4, 5), "N", 0.99),
+        ((6, 7, 8), "C:maj7", 0.85),
+    ):
+        tag[list(frames), labels.index(label)] = confidence
+    tag /= tag.sum(axis=1, keepdims=True)
+    bass = np.full((9, 13), 1e-8, dtype=np.float32)
+    for frames, bass_index in (((0, 1), 4), ((2, 3), 5), ((4, 5), 12), ((6, 7, 8), 4)):
+        bass[list(frames), bass_index] = 1.0
+
+    timeline = crema_onnx.decode_timeline(tag, bass, state)
+    projection = [
+        {
+            key: segment[key]
+            for key in (
+                "start_seconds", "end_seconds", "label", "raw_label", "confidence", "quality", "bass_degree"
+            )
+        }
+        for segment in timeline
+    ]
+
+    # Frozen TensorFlow Crema reference produced from the same head tensors.
+    assert projection == [
+        {
+            "start_seconds": 0.0, "end_seconds": 0.186, "label": "Cmaj7/E",
+            "raw_label": "C:maj7/3", "confidence": 0.667, "quality": "maj7", "bass_degree": "3",
+        },
+        {
+            "start_seconds": 0.186, "end_seconds": 0.372, "label": "G7/F",
+            "raw_label": "G:7/b7", "confidence": 0.667, "quality": "7", "bass_degree": "b7",
+        },
+        {
+            "start_seconds": 0.372, "end_seconds": 0.557, "label": "N.C.",
+            "raw_label": "N", "confidence": 0.667, "quality": "no_chord", "bass_degree": None,
+        },
+        {
+            "start_seconds": 0.557, "end_seconds": 0.929, "label": "Cmaj7/E",
+            "raw_label": "C:maj7/3", "confidence": 1.0, "quality": "maj7", "bass_degree": "3",
+        },
+    ]
+    split = [
+        {**timeline[0], "end_seconds": 0.093},
+        {**timeline[0], "start_seconds": 0.093},
+        *timeline[1:],
+    ]
+    assert merge_adjacent_chord_segments(split) == timeline
+    score = score_timeline(timeline, timeline)
+    assert score["root"] == score["quality"] == score["seventh_extension"] == 1.0
+    assert score["bass"] == score["full"] == 1.0
+    assert score["boundary"] == {"matched": 3, "reference": 3, "prediction": 3}
+
+
+def test_metadata_records_immutable_model_and_cpu_runtime(monkeypatch) -> None:
+    monkeypatch.setattr(crema_onnx.importlib.metadata, "version", lambda name: "1.29.0")
+
+    metadata = crema_onnx.crema_onnx_metadata()
+
+    assert metadata == {
+        "backend_id": "crema-advanced",
+        "implementation": "crema-onnx",
+        "source_crema_version": "0.2.0",
+        "model_revision": crema_onnx.MODEL_REVISION,
+        "model_sha256": crema_onnx.MODEL_SHA256,
+        "runtime_state_sha256": crema_onnx.STATE_SHA256,
+        "onnxruntime_version": "1.29.0",
+        "provider": "CPUExecutionProvider",
+    }
+
+
+def test_detection_boundary_sanitizes_preprocessing_failures(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        crema_onnx,
+        "ensure_crema_onnx_files",
+        lambda: (tmp_path / "model.onnx", tmp_path / "state.json"),
+    )
+    monkeypatch.setattr(crema_onnx, "load_runtime_state", lambda _path: _state())
+    monkeypatch.setattr(
+        crema_onnx,
+        "preprocess_audio",
+        lambda *_args: (_ for _ in ()).throw(ValueError("failed at /private/library/song.wav")),
+    )
+
+    with pytest.raises(RuntimeError) as captured:
+        crema_onnx.detect_crema_onnx_timeline(Path("/private/library/song.wav"))
+
+    assert str(captured.value) == "Crema ONNX audio preprocessing failed."
+    assert "/private" not in str(captured.value)

--- a/apps/backend/tests/test_prewarm_models.py
+++ b/apps/backend/tests/test_prewarm_models.py
@@ -112,6 +112,11 @@ def test_crema_model_asset_verifier_uses_distribution_record(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    monkeypatch.setattr(
+        crema_chords.importlib.util,
+        "find_spec",
+        lambda name: None if name == "onnxruntime" else object(),
+    )
     payload = b"crema-fixture"
     asset_path = tmp_path / "model.h5"
     asset_path.write_bytes(payload)

--- a/apps/backend/tests/test_torch_runtime.py
+++ b/apps/backend/tests/test_torch_runtime.py
@@ -461,6 +461,91 @@ def test_model_bundle_seeds_missing_caches(
     assert (lyrics_cache / "lyrics.pt").read_bytes() == b"whisper-model"
 
 
+def test_model_bundle_seeds_exact_crema_onnx_files(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    from app.engines import crema_onnx
+    from app.utils import model_bundle
+    from app.utils.model_cache import ExpectedModelFile
+
+    bundle_dir = tmp_path / "bundle"
+    relative_root = Path("crema") / "0.2.0" / crema_onnx.MODEL_REVISION
+    payloads = {
+        crema_onnx.MODEL_FILENAME: b"onnx-model",
+        crema_onnx.STATE_FILENAME: b"runtime-state",
+    }
+    for name, payload in payloads.items():
+        source = bundle_dir / relative_root / name
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_bytes(payload)
+    _write_model_bundle_manifest(
+        bundle_dir,
+        torch_payload=b"torch-model",
+        whisper_payload=b"whisper-model",
+        crema_onnx_payloads=payloads,
+    )
+    (bundle_dir / "torch" / "hub" / "checkpoints").mkdir(parents=True)
+    (bundle_dir / "torch" / "hub" / "checkpoints" / "model.th").write_bytes(b"torch-model")
+    (bundle_dir / "whisper").mkdir()
+    (bundle_dir / "whisper" / "lyrics.pt").write_bytes(b"whisper-model")
+    cache_root = tmp_path / "cache"
+
+    def expected_files(root: Path) -> tuple[ExpectedModelFile, ...]:
+        return tuple(
+            ExpectedModelFile(
+                label=f"fixture {name}",
+                path=root / name,
+                size=len(payload),
+                sha256=hashlib.sha256(payload).hexdigest(),
+            )
+            for name, payload in payloads.items()
+        )
+
+    monkeypatch.setattr(model_bundle, "expected_crema_onnx_files", expected_files)
+    monkeypatch.setenv("TORCH_HOME", str(tmp_path / "torch-home"))
+
+    model_bundle.seed_model_bundle_caches(
+        SimpleNamespace(
+            model_bundle_dir=bundle_dir,
+            lyrics_cache_dir=tmp_path / "lyrics",
+            cache_root=cache_root,
+        )
+    )
+
+    destination = cache_root / "models" / "crema" / "0.2.0" / crema_onnx.MODEL_REVISION
+    assert {path.name: path.read_bytes() for path in destination.iterdir()} == payloads
+
+
+def test_prepare_model_bundle_includes_crema_onnx_only_when_requested(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    from app.cli import prepare_model_bundle as bundle_cli
+
+    monkeypatch.setattr(bundle_cli, "_prepare_demucs_entries", lambda _output: [])
+    monkeypatch.setattr(bundle_cli, "_prepare_whisper_entries", lambda _output, _models: [])
+    monkeypatch.setattr(
+        bundle_cli,
+        "_prepare_crema_onnx_entries",
+        lambda _output: [{"file_name": "crema.onnx"}],
+    )
+
+    without_onnx = tmp_path / "without-onnx"
+    bundle_cli.prepare_model_bundle(output_dir=without_onnx, lyrics_models=[])
+    with_onnx = tmp_path / "with-onnx"
+    bundle_cli.prepare_model_bundle(
+        output_dir=with_onnx,
+        include_crema_onnx=True,
+        lyrics_models=[],
+    )
+
+    assert json.loads((without_onnx / "manifest.json").read_text())["crema_onnx_files"] == []
+    assert json.loads((with_onnx / "manifest.json").read_text())["crema_onnx_files"] == [
+        {"file_name": "crema.onnx"}
+    ]
+
+
 def test_model_bundle_skips_valid_cache(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -617,7 +702,9 @@ def _write_model_bundle_manifest(
     *,
     torch_payload: bytes,
     whisper_payload: bytes,
+    crema_onnx_payloads: dict[str, bytes] | None = None,
 ) -> None:
+    crema_onnx_payloads = crema_onnx_payloads or {}
     (bundle_dir / "manifest.json").write_text(
         json.dumps(
             {
@@ -639,6 +726,18 @@ def _write_model_bundle_manifest(
                         "size": len(whisper_payload),
                         "sha256": hashlib.sha256(whisper_payload).hexdigest(),
                     }
+                ],
+                "crema_onnx_files": [
+                    {
+                        "label": f"fixture {name}",
+                        "file_name": name,
+                        "relative_path": (
+                            f"crema/0.2.0/65af18f49af5101267fd28f15ac8c452d98b8e3d/{name}"
+                        ),
+                        "size": len(payload),
+                        "sha256": hashlib.sha256(payload).hexdigest(),
+                    }
+                    for name, payload in crema_onnx_payloads.items()
                 ],
             }
         ),

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -2,10 +2,16 @@ version = 1
 revision = 3
 requires-python = "==3.11.*"
 resolution-markers = [
-    "sys_platform == 'win32'",
-    "sys_platform == 'emscripten'",
-    "sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "extra != 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx'",
+    "sys_platform == 'win32' and extra == 'extra-17-tuneforge-backend-advanced-chords' and extra != 'extra-17-tuneforge-backend-advanced-chords-onnx'",
+    "sys_platform == 'emscripten' and extra == 'extra-17-tuneforge-backend-advanced-chords' and extra != 'extra-17-tuneforge-backend-advanced-chords-onnx'",
+    "sys_platform != 'emscripten' and sys_platform != 'win32' and extra == 'extra-17-tuneforge-backend-advanced-chords' and extra != 'extra-17-tuneforge-backend-advanced-chords-onnx'",
+    "extra != 'extra-17-tuneforge-backend-advanced-chords' and extra != 'extra-17-tuneforge-backend-advanced-chords-onnx'",
 ]
+conflicts = [[
+    { package = "tuneforge-backend", extra = "advanced-chords" },
+    { package = "tuneforge-backend", extra = "advanced-chords-onnx" },
+]]
 
 [manifest]
 overrides = [
@@ -158,7 +164,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -207,7 +213,7 @@ name = "click"
 version = "8.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
 wheels = [
@@ -257,7 +263,7 @@ name = "cryptography"
 version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
@@ -305,6 +311,7 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/3a8241c6e19483ac1f1dcf5c10238205dcb8a6e9d0d4d4709240dff28ff4/cuda_bindings-13.2.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:721104c603f059780d287969be3d194a18d0cc3b713ed9049065a1107706759d", size = 5730273, upload-time = "2026-03-11T00:12:37.18Z" },
     { url = "https://files.pythonhosted.org/packages/e9/94/2748597f47bb1600cd466b20cab4159f1530a3a33fe7f70fee199b3abb9e/cuda_bindings-13.2.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1eba9504ac70667dd48313395fe05157518fd6371b532790e96fbb31bbb5a5e1", size = 6313924, upload-time = "2026-03-11T00:12:39.462Z" },
+    { url = "https://files.pythonhosted.org/packages/29/5a/0ce1731c48bcd9f40996a4ef1abbf634f1a7fe4a15c5050b1e75ce3a7acf/cuda_bindings-13.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:debb51b211d246f8326f6b6e982506a5d0d9906672c91bc478b66addc7ecc60a", size = 5631363, upload-time = "2026-03-11T00:12:41.58Z" },
 ]
 
 [[package]]
@@ -325,37 +332,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 
 [[package]]
@@ -504,7 +511,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/c6/dba32cab7e3a625b011aa5647486e2d28423a48845a2998c126dd69c85e1/greenlet-3.4.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:805bebb4945094acbab757d34d6e1098be6de8966009ab9ca54f06ff492def58", size = 285504, upload-time = "2026-04-08T15:52:14.071Z" },
     { url = "https://files.pythonhosted.org/packages/54/f4/7cb5c2b1feb9a1f50e038be79980dfa969aa91979e5e3a18fdbcfad2c517/greenlet-3.4.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:439fc2f12b9b512d9dfa681c5afe5f6b3232c708d13e6f02c845e0d9f4c2d8c6", size = 605476, upload-time = "2026-04-08T16:24:37.064Z" },
     { url = "https://files.pythonhosted.org/packages/d6/af/b66ab0b2f9a4c5a867c136bf66d9599f34f21a1bcca26a2884a29c450bd9/greenlet-3.4.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a70ed1cb0295bee1df57b63bf7f46b4e56a5c93709eea769c1fec1bb23a95875", size = 618336, upload-time = "2026-04-08T16:30:56.59Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/31/56c43d2b5de476f77d36ceeec436328533bff960a4cba9a07616e93063ab/greenlet-3.4.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c5696c42e6bb5cfb7c6ff4453789081c66b9b91f061e5e9367fa15792644e76", size = 625045, upload-time = "2026-04-08T16:40:37.111Z" },
     { url = "https://files.pythonhosted.org/packages/e5/5c/8c5633ece6ba611d64bf2770219a98dd439921d6424e4e8cf16b0ac74ea5/greenlet-3.4.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c660bce1940a1acae5f51f0a064f1bc785d07ea16efcb4bc708090afc4d69e83", size = 613515, upload-time = "2026-04-08T15:56:32.478Z" },
+    { url = "https://files.pythonhosted.org/packages/80/ca/704d4e2c90acb8bdf7ae593f5cbc95f58e82de95cc540fb75631c1054533/greenlet-3.4.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:89995ce5ddcd2896d89615116dd39b9703bfa0c07b583b85b89bf1b5d6eddf81", size = 419745, upload-time = "2026-04-08T16:43:04.022Z" },
     { url = "https://files.pythonhosted.org/packages/a9/df/950d15bca0d90a0e7395eb777903060504cdb509b7b705631e8fb69ff415/greenlet-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ee407d4d1ca9dc632265aee1c8732c4a2d60adff848057cdebfe5fe94eb2c8a2", size = 1574623, upload-time = "2026-04-08T16:26:18.596Z" },
     { url = "https://files.pythonhosted.org/packages/1a/e7/0839afab829fcb7333c9ff6d80c040949510055d2d4d63251f0d1c7c804e/greenlet-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:956215d5e355fffa7c021d168728321fd4d31fd730ac609b1653b450f6a4bc71", size = 1639579, upload-time = "2026-04-08T15:57:29.231Z" },
     { url = "https://files.pythonhosted.org/packages/d9/2b/b4482401e9bcaf9f5c97f67ead38db89c19520ff6d0d6699979c6efcc200/greenlet-3.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:5cb614ace7c27571270354e9c9f696554d073f8aa9319079dcba466bbdead711", size = 238233, upload-time = "2026-04-08T17:02:54.286Z" },
@@ -973,7 +982,7 @@ version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ast-serialize" },
-    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
     { name = "mypy-extensions" },
     { name = "pathspec" },
     { name = "typing-extensions" },
@@ -1047,6 +1056,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/a5/fce49e2ae977e0ccc084e5adafceb4f0ac0c8333cb6863501618a7277f67/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c86fc7f7ae36d7528288c5d88098edcb7b02c633d262e7ddbb86b0ad91be5df2", size = 542851226, upload-time = "2025-10-09T08:59:04.818Z" },
     { url = "https://files.pythonhosted.org/packages/e7/44/423ac00af4dd95a5aeb27207e2c0d9b7118702149bf4704c3ddb55bb7429/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:ee8722c1f0145ab246bccb9e452153b5e0515fd094c3678df50b2a0888b8b171", size = 423133236, upload-time = "2025-10-09T08:59:32.536Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f5/f50bc3f5c2bb57ab8f5b4d78bc1146b57810d42cb8fcb28cbe2e14050376/nvidia_cublas-13.1.0.3-py3-none-win_amd64.whl", hash = "sha256:2a3b94a37def342471c59fad7856caee4926809a72dd5270155d6a31b5b277be", size = 404355960, upload-time = "2025-10-09T09:07:00.987Z" },
 ]
 
 [[package]]
@@ -1056,6 +1066,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
     { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/df/b74b10025c1205695c5676373f2edd3e87a7202cc62ead0dfbc373b0f6ea/nvidia_cuda_cupti-13.0.85-py3-none-win_amd64.whl", hash = "sha256:683f58d301548deeefcb8f6fac1b8d907691b9d8b18eccab417f51e362102f00", size = 7736776, upload-time = "2025-09-04T08:38:08.38Z" },
 ]
 
 [[package]]
@@ -1065,6 +1076,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
     { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/af/345fedb9f4c76c84ab4fa445b36bd4048a4d9db60e6bc76b4f913ff4b852/nvidia_cuda_nvrtc-13.0.88-py3-none-win_amd64.whl", hash = "sha256:6bcd4e7f8e205cbe644f5a98f2f799bef9556fefc89dd786e79a16312ce49872", size = 76807835, upload-time = "2025-09-04T08:39:15.274Z" },
 ]
 
 [[package]]
@@ -1074,6 +1086,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
     { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/94/6b867483bec07da24ffa32736c79fabb94ef3a7af4d787a9d4a974868576/nvidia_cuda_runtime-13.0.96-py3-none-win_amd64.whl", hash = "sha256:f79298c8a098cec150a597c8eba58ecdab96e3bdc4b9bc4f9983635031740492", size = 2927037, upload-time = "2025-10-09T09:04:23.782Z" },
 ]
 
 [[package]]
@@ -1086,6 +1099,7 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
     { url = "https://files.pythonhosted.org/packages/a3/22/0b4b932655d17a6da1b92fa92ab12844b053bb2ac2475e179ba6f043da1e/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:d20e1734305e9d68889a96e3f35094d733ff1f83932ebe462753973e53a572bf", size = 366066321, upload-time = "2026-02-03T20:44:52.837Z" },
+    { url = "https://files.pythonhosted.org/packages/91/a2/f020386683ee9ab2c9a9f7f79290d9b0d07f7241de54dc746af2abd188d2/nvidia_cudnn_cu13-9.19.0.56-py3-none-win_amd64.whl", hash = "sha256:40d8c375005bcb01495f8edf375230b203a411a0c05fb6dc92a3781edcb23eac", size = 350547366, upload-time = "2026-02-03T20:50:49.563Z" },
 ]
 
 [[package]]
@@ -1098,6 +1112,7 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
     { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b2/f8af21a2ed1beed337a6a02c5a28aeb85441f4d578ec3d529543c775ea4b/nvidia_cufft-12.0.0.61-py3-none-win_amd64.whl", hash = "sha256:2abce5b39d2f5ae12730fb7e5db6696533e36c26e2d3e8fd1750bdd2853364eb", size = 213342123, upload-time = "2025-09-04T08:40:51.145Z" },
 ]
 
 [[package]]
@@ -1116,6 +1131,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
     { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+    { url = "https://files.pythonhosted.org/packages/99/27/72103153b1ffc00e09fdc40ac970235343dcd1ea8bd762e84d2d73219ffa/nvidia_curand-10.4.0.35-py3-none-win_amd64.whl", hash = "sha256:65b1710aa6961d326b411e314b374290904c5ddf41dc3f766ebc3f1d7d4ca69f", size = 55242481, upload-time = "2025-08-04T10:30:41.831Z" },
 ]
 
 [[package]]
@@ -1130,6 +1146,7 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
     { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ef/332a0101260ca78a1daef046bf0b06199e8ed4dac1d2aa698289c358169c/nvidia_cusolver-12.0.4.66-py3-none-win_amd64.whl", hash = "sha256:16515bd33a8e76bb54d024cfa068fa68d30e80fc34b9e1090813ea9362e0cb65", size = 193551444, upload-time = "2025-09-04T08:41:46.813Z" },
 ]
 
 [[package]]
@@ -1142,6 +1159,7 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
     { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+    { url = "https://files.pythonhosted.org/packages/02/b0/b043d6f3480f102f885cf87fc3ffd3edcb5e23b855025a50e2ef4d059185/nvidia_cusparse-12.6.3.3-py3-none-win_amd64.whl", hash = "sha256:cbcf42feb737bd7ec15b4c0a63e62351886bd3f975027b8815d7f720a2b5ea79", size = 143783033, upload-time = "2025-09-04T08:42:12.391Z" },
 ]
 
 [[package]]
@@ -1151,6 +1169,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/10/8dcd1175260706a2fc92a16a52e306b71d4c1ea0b0cc4a9484183399818a/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:400c6ed1cf6780fc6efedd64ec9f1345871767e6a1a0a552a1ea0578117ea77c", size = 220791277, upload-time = "2025-08-13T19:22:40.982Z" },
     { url = "https://files.pythonhosted.org/packages/fd/53/43b0d71f4e702fa9733f8b4571fdca50a8813f1e450b656c239beff12315/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:25e30a8a7323935d4ad0340b95a0b69926eee755767e8e0b1cf8dd85b197d3fd", size = 169884119, upload-time = "2025-08-13T19:23:41.967Z" },
+    { url = "https://files.pythonhosted.org/packages/57/de/8f0578928b9b1246d7b1324db0528e6b9f9fb54496a49f40bf71f09f1a27/nvidia_cusparselt_cu13-0.8.0-py3-none-win_amd64.whl", hash = "sha256:e80212ed7b1afc97102fbb2b5c82487aa73f6a0edfa6d26c5a152593e520bb8f", size = 156459710, upload-time = "2025-08-13T19:24:18.043Z" },
 ]
 
 [[package]]
@@ -1169,6 +1188,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/7a/123e033aaff487c77107195fa5a2b8686795ca537935a24efae476c41f05/nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b", size = 40713933, upload-time = "2025-09-04T08:35:43.553Z" },
     { url = "https://files.pythonhosted.org/packages/ab/2c/93c5250e64df4f894f1cbb397c6fd71f79813f9fd79d7cd61de3f97b3c2d/nvidia_nvjitlink-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c", size = 38768748, upload-time = "2025-09-04T08:35:20.008Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/01/07530b0e37546231052e30234540289c42eaffa486f1a34a87fed340157b/nvidia_nvjitlink-13.0.88-py3-none-win_amd64.whl", hash = "sha256:634e96e3da9ef845ae744097a1f289238ecf946ce0b82e93cdce14b9782e682f", size = 36035115, upload-time = "2025-09-04T08:43:03.001Z" },
 ]
 
 [[package]]
@@ -1187,6 +1207,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
     { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/50/0e2220f8620a177de994211186ffc5bfa9f2ce1e1282797f8f90096f9f88/nvidia_nvtx-13.0.85-py3-none-win_amd64.whl", hash = "sha256:d66ea44254dd3c6eacc300047af6e1288d2269dd072b417e0adffbf479e18519", size = 137066, upload-time = "2025-09-04T08:39:25.649Z" },
 ]
 
 [[package]]
@@ -1212,6 +1233,24 @@ wheels = [
 ]
 
 [[package]]
+name = "onnxruntime"
+version = "1.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/a8/0520890321b8ff40b908cf165a93eb58fbc8f85c14db637277ea866c9544/onnxruntime-1.29.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:07c5907474dec4a2792fd7626b753dc66707808385a6d9eecf993db0066a9d0f", size = 21420890, upload-time = "2026-08-17T22:53:33.429Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/77/8bd3e0008ff8d386305351109a7329ea57e51a3ab57bc92340f29c4a5b5d/onnxruntime-1.29.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:16925ef8497e2c07e4b5ae15b504079b3ab3f65e22c58efd10dde0f3caea969a", size = 20803602, upload-time = "2026-08-17T22:53:36.47Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/91/a66cd77f28379ede419672edda3184f1eb286db215dce1e7b976fae2d63b/onnxruntime-1.29.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:85f8e8406c52658735fe5c7fbfd3ebaa1ed340768324f6252e4274e374580a23", size = 23113193, upload-time = "2026-08-17T22:53:39.732Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/82/2da968405c42340f03de0bcdb63be09ae1004f820b2295590d48951b5cf2/onnxruntime-1.29.0-cp311-cp311-win_amd64.whl", hash = "sha256:0d4f427afac434b0070fe992b540ddf20a7aff2265f760f314d91331935b6b98", size = 13999253, upload-time = "2026-08-17T22:53:43.184Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7a/70c9c893bf732ee66124c2d8de6a21fc9361ec62cf378f857043efcbf0eb/onnxruntime-1.29.0-cp311-cp311-win_arm64.whl", hash = "sha256:4eae472cf7dc3107dec1bb53cd6d142d1964616d08aae48654cd4254b2363c4b", size = 13741410, upload-time = "2026-08-17T22:53:45.521Z" },
+]
+
+[[package]]
 name = "openai-whisper"
 version = "20250625"
 source = { registry = "https://pypi.org/simple" }
@@ -1222,7 +1261,7 @@ dependencies = [
     { name = "tiktoken" },
     { name = "torch" },
     { name = "tqdm" },
-    { name = "triton", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'linux2'" },
+    { name = "triton", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx') or sys_platform == 'linux2' or (sys_platform != 'linux' and extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/35/8e/d36f8880bcf18ec026a55807d02fe4c7357da9f25aebd92f85178000c0dc/openai_whisper-20250625.tar.gz", hash = "sha256:37a91a3921809d9f44748ffc73c0a55c9f366c85a3ef5c2ae0cc09540432eb96", size = 803191, upload-time = "2025-06-26T01:06:13.34Z" }
 
@@ -1471,7 +1510,7 @@ name = "pytest"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
@@ -1771,7 +1810,7 @@ name = "sqlalchemy"
 version = "2.0.49"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
@@ -1953,19 +1992,19 @@ name = "torch"
 version = "2.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "cuda-bindings", marker = "sys_platform == 'linux' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx" },
-    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
     { name = "setuptools" },
     { name = "sympy" },
-    { name = "triton", marker = "sys_platform == 'linux'" },
+    { name = "triton", marker = "sys_platform == 'linux' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
     { name = "typing-extensions" },
 ]
 wheels = [
@@ -1991,7 +2030,7 @@ name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
@@ -2054,6 +2093,9 @@ advanced-chords = [
     { name = "setuptools" },
     { name = "tensorflow" },
 ]
+advanced-chords-onnx = [
+    { name = "onnxruntime" },
+]
 lv-chordia = [
     { name = "lv-chordia" },
 ]
@@ -2079,6 +2121,7 @@ requires-dist = [
     { name = "librosa", specifier = ">=0.10.2.post1,<1.0.0" },
     { name = "lv-chordia", marker = "extra == 'lv-chordia'", url = "https://github.com/openmirlab/lv-chordia/archive/9d7de7bbf45efa6731ec8dc62d35280f141c0702.tar.gz" },
     { name = "numpy", specifier = ">=1.26.4,<3.0.0" },
+    { name = "onnxruntime", marker = "extra == 'advanced-chords-onnx'", specifier = "==1.29.0" },
     { name = "openai-whisper", specifier = ">=20250625,<20260000" },
     { name = "pydantic", specifier = ">=2.11.3,<3.0.0" },
     { name = "scikit-learn", marker = "extra == 'advanced-chords'", specifier = ">=1.3,<1.10" },
@@ -2088,7 +2131,7 @@ requires-dist = [
     { name = "tensorflow", marker = "extra == 'advanced-chords'", specifier = ">=2.15,<2.22" },
     { name = "uvicorn", specifier = ">=0.34.2,<1.0.0" },
 ]
-provides-extras = ["advanced-chords", "advanced-beats", "lv-chordia"]
+provides-extras = ["advanced-chords", "advanced-chords-onnx", "advanced-beats", "lv-chordia"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/apps/desktop/src/App.settings-theme.test.tsx
+++ b/apps/desktop/src/App.settings-theme.test.tsx
@@ -137,7 +137,9 @@ describe("Desktop app settings theme", () => {
     ).toHaveTextContent("Advanced Beat Analysis");
     expect(
       within(screen.getByRole("group", { name: "Default chord backend" })).getAllByRole("button")[0],
-    ).toHaveTextContent("Advanced Chords");
+    ).toHaveTextContent("Advanced Chords — Crema (TensorFlow)");
+    expect(within(screen.getByRole("group", { name: "Default chord backend" })).getAllByRole("button"))
+      .toHaveLength(3);
     expect(screen.getByRole("button", { name: /^Enable lyrics follow by default/ })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^Enable chords follow by default/ })).toHaveAttribute("aria-pressed", "true");
     expect(window.localStorage.getItem("tuneforge.theme-preference")).toBe("system");
@@ -566,7 +568,7 @@ describe("Desktop app settings theme", () => {
         desktopOnly: true,
         experimental: true,
         id: "crema-advanced",
-        label: "Advanced Chords",
+        label: "Advanced Chords — Crema ONNX",
         unavailable_reason: "crema is not installed",
       },
     ]);
@@ -578,8 +580,75 @@ describe("Desktop app settings theme", () => {
     expect(screen.getByRole("button", { name: /^Built-in Chords/ })).not.toBeDisabled();
     expect(screen.getByRole("button", { name: /^Advanced Chords/ })).toBeDisabled();
     expect(screen.getByRole("button", { name: /^Advanced Chords/ })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getAllByText("Advanced Chords — Crema ONNX").length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: /^Built-in Chords/ })).toHaveAttribute("aria-pressed", "false");
     expect(screen.getByText(/Imports may use Built-in Chords if the saved backend is unavailable/)).toBeInTheDocument();
+  });
+
+  it("retains the cached implementation label while chord availability refetches and fails", async () => {
+    setChordBackends([
+      {
+        availability: "available",
+        available: true,
+        capabilities: {},
+        desktopOnly: true,
+        experimental: true,
+        id: "crema-advanced",
+        label: "Advanced Chords — Crema ONNX",
+        unavailable_reason: null,
+      },
+      {
+        availability: "available",
+        available: true,
+        capabilities: {},
+        desktopOnly: true,
+        experimental: true,
+        id: "lv-chordia-submission",
+        label: "LV Chordia (Submission)",
+        unavailable_reason: null,
+      },
+      {
+        availability: "available",
+        available: true,
+        capabilities: {},
+        desktopOnly: false,
+        experimental: false,
+        id: "tuneforge-fast",
+        label: "Built-in Chords",
+        unavailable_reason: null,
+      },
+    ]);
+    const { queryClient } = renderApp(["/settings"]);
+    expect((await screen.findAllByText("Advanced Chords — Crema ONNX")).length).toBeGreaterThan(0);
+
+    let rejectRefetch!: (reason: Error) => void;
+    mockListChordBackends.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectRefetch = reject;
+        }),
+    );
+    let refetch!: Promise<void>;
+    act(() => {
+      refetch = queryClient.refetchQueries({ queryKey: ["chord-backends"] });
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole("group", { name: "Default chord backend" })).toHaveAttribute("aria-busy", "true"),
+    );
+    expect(screen.getAllByText("Advanced Chords — Crema ONNX").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /^Advanced Chords/ })).toBeDisabled();
+
+    await act(async () => {
+      rejectRefetch(new Error("registry unavailable at /private/library"));
+      await refetch;
+    });
+
+    expect(await screen.findByText(
+      "Chord backend availability could not be checked. Saved selection was preserved.",
+    )).toBeInTheDocument();
+    expect(screen.getAllByText("Advanced Chords — Crema ONNX").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /^Advanced Chords/ })).toBeDisabled();
   });
 
   it("preserves the saved chord backend and offers retry when availability fails", async () => {
@@ -951,7 +1020,7 @@ describe("Desktop app settings theme", () => {
     expect(screen.getAllByText("Prefer sharps")).toHaveLength(2);
     expect(screen.getAllByText("Playback first").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Lyrics + chords").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Advanced Chords").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Advanced Chords — Crema (TensorFlow)").length).toBeGreaterThan(0);
     expect(document.documentElement.style.getPropertyValue("--color-bg-app")).toBe("#123456");
   });
 

--- a/apps/desktop/src/features/settings/SettingsView.tsx
+++ b/apps/desktop/src/features/settings/SettingsView.tsx
@@ -258,7 +258,7 @@ const fallbackBeatAnalysisBackendOptions: ChoiceOption<DefaultBeatAnalysisBacken
 const fallbackChordBackendOptions: ChoiceOption<DefaultChordBackend>[] = [
   {
     value: "crema-advanced",
-    label: "Advanced Chords",
+    label: "Advanced Chords — Crema",
     description: "Use the crema detector with richer chord vocabulary and inversion labels.",
   },
   {
@@ -364,10 +364,11 @@ function beatAnalysisBackendLabel(value: DefaultBeatAnalysisBackend) {
   return value === "beat-this" ? "Advanced Beat Analysis" : "Built-in Beat Analysis";
 }
 
-function chordBackendLabel(value: DefaultChordBackend) {
-  if (value === "crema-advanced") return "Advanced Chords";
-  if (value === "lv-chordia-submission") return "LV Chordia (Submission)";
-  return "Built-in Chords";
+function chordBackendLabel(
+  value: DefaultChordBackend,
+  options: ChoiceOption<DefaultChordBackend>[],
+) {
+  return options.find((option) => option.value === value)?.label ?? "Unknown chord backend";
 }
 
 function stemModelLabel(value: DefaultStemModel) {
@@ -498,17 +499,11 @@ function chordBackendOptions(
   error: boolean,
   selected: DefaultChordBackend,
 ): ChoiceOption<DefaultChordBackend>[] {
-  if (fetching || backends === undefined) {
+  if (backends === undefined) {
     return fallbackChordBackendOptions.map((option) => ({
       ...option,
       disabled: true,
-    }));
-  }
-  if (error) {
-    return fallbackChordBackendOptions.map((option) => ({
-      ...option,
-      disabled: true,
-      status: "Availability could not be checked",
+      status: error ? "Availability could not be checked" : "Checking availability",
     }));
   }
 
@@ -528,8 +523,12 @@ function chordBackendOptions(
       value: fallback.value,
       label: backend.label,
       description: fallback.description,
-      disabled: !backend.available,
-      status: unavailableReason
+      disabled: fetching || error || !backend.available,
+      status: fetching
+        ? "Checking availability…"
+        : error
+          ? "Availability could not be checked"
+          : unavailableReason
         ? fallback.value === selected ? `Selected · ${unavailableReason}` : unavailableReason
         : fallback.value === "tuneforge-fast" ? "Import fallback" : undefined,
     };
@@ -1095,7 +1094,7 @@ export function SettingsView() {
           <div className="settings-overview__stat">
             <dt>Chord backend</dt>
             <dd>
-              {chordBackendLabel(defaultChordBackend)}
+              {chordBackendLabel(defaultChordBackend, chordBackendChoices)}
               <span>{chordFallbackNotice}</span>
             </dd>
           </div>

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -2232,7 +2232,7 @@ const mobileChordBackendsResponse: ChordBackendsResponse = {
       desktopOnly: true,
       experimental: true,
       id: "crema-advanced",
-      label: "Advanced Chords",
+      label: "Advanced Chords — Crema",
       unavailable_reason: "advanced chord backend is disabled on mobile",
     },
     {

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -412,7 +412,7 @@ const {
         desktopOnly: true,
         experimental: true,
         id: "crema-advanced",
-        label: "Advanced Chords",
+        label: "Advanced Chords — Crema (TensorFlow)",
         unavailable_reason: null,
       },
     ];

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -10,9 +10,9 @@ See [Third-party notices](../THIRD_PARTY_NOTICES.md) for the dependency and mode
 - Linux Flatpak packaging creates either a single-file `.flatpak` bundle or, with `--no-bundle`, a local Flatpak repository install flow.
 - Source distribution is the repository checkout or source archive from version control. These package commands do not create a separate source tarball.
 - Packaging, model-bundle review, crema/TensorFlow, beat-this, CUDA/MPS/legacy NVIDIA GPU behavior, and install smoke checks are manual or special coverage unless a CI workflow explicitly runs them.
-- Release/default package commands must not use `--model-bundle`; publishable artifacts must not include Demucs, Whisper, or beat-this model weights unless redistribution has been explicitly reviewed.
+- Release/default package commands do not use `--model-bundle`. Publishable model-bundled artifacts require an explicit review of the selected weights and package distribution evidence.
 - Default packages may still download Demucs, Whisper, or beat-this weights on first use when caches are missing. Fully offline operation requires host/sandbox FFmpeg access plus the relevant local caches or package assets to already exist.
-- Crema chord model files come from the crema dependency and ship with Advanced Chords unless that dependency stack is excluded; Demucs, Whisper, and beat-this external weights remain cache/download assets unless `--model-bundle` is explicitly passed.
+- Crema/TensorFlow chord model files come from the crema dependency and ship with default Advanced Chords. The opt-in Crema ONNX profile uses the pinned model from the verified cache; combining it with `--model-bundle` includes those exact files and the Brian McFee BSD-2-Clause notice as an explicit reviewed package choice.
 - LV Chordia checkpoints ship inside its pinned dependency for offline first use. `--no-lv-chordia` excludes both the runtime and checkpoints; damaged assets fail closed and are repaired by reinstalling.
 
 ## Release Package Gate
@@ -116,6 +116,8 @@ pnpm package:mac -- --no-crema --no-beat-this --no-lv-chordia
 pnpm package:mac -- --no-advanced-chords --no-advanced-beats
 pnpm package:mac -- --lv-chordia
 pnpm package:mac -- --model-bundle
+pnpm package:mac -- --crema-onnx
+pnpm package:mac -- --crema-onnx --model-bundle
 ```
 
 Advanced Beat Analysis remains the default analysis request without bundled model weights. Its
@@ -133,7 +135,7 @@ Run packaging from a normal macOS shell so `hdiutil` can create the disk image. 
 
 The packaged backend checks the inherited `PATH` plus common Homebrew and MacPorts install locations when looking for `ffmpeg` and `ffprobe`. System microphone volume control uses the built-in CoreAudio API on macOS.
 
-By default, Demucs, Whisper, and beat-this weights are read from their normal caches and downloaded on first use if missing. Crema and LV Chordia are dependency-owned exceptions: LV Chordia ships exactly five checkpoints totaling 28,730,939 bytes and validates them before loading. It performs no model download and uses no user checkpoint cache. `--model-bundle` stages required Demucs and Whisper weights, plus beat-this `small0` when included; it does not control LV Chordia.
+By default, Demucs, Whisper, and beat-this weights are read from their normal caches and downloaded on first use if missing. TensorFlow Crema and LV Chordia are dependency-owned package assets. An opt-in `--crema-onnx` package replaces the Crema/TensorFlow stack and its HDF5 model-loading closure with ONNX Runtime, while preserved LV Chordia support still brings its declared `h5py` dependency. Without `--model-bundle`, the pinned ONNX model downloads into `TUNEFORGE_DATA_DIR/cache/models/crema/` on first use. Combining `--crema-onnx` with `--model-bundle` stages the exact verified model and runtime state so packaged startup can seed that same cache. LV Chordia still ships exactly five validated checkpoints. `--model-bundle` also stages required Demucs and Whisper weights, plus beat-this `small0` when included.
 
 ## Android
 
@@ -215,18 +217,21 @@ Chordia dependency stacks by default. Feature flags are independent:
 pnpm package:linux -- --no-crema --no-beat-this --no-lv-chordia
 pnpm package:linux -- --no-advanced-chords --no-advanced-beats
 pnpm package:linux -- --legacy-nvidia --model-bundle
+pnpm package:linux -- --crema-onnx
+pnpm package:linux -- --crema-onnx --model-bundle
 ```
 
 - `--no-crema` / `--no-advanced-chords` exclude the Advanced Chords dependency stack.
+- `--crema-onnx` / `--advanced-chords-onnx` select ONNX Runtime instead of the default Crema/TensorFlow stack.
 - `--no-beat-this` / `--no-advanced-beats` exclude the Advanced Beat Analysis dependency stack.
 - `--lv-chordia` / `--no-lv-chordia` include or exclude LV Chordia and its five checkpoints.
 - `--legacy-nvidia` swaps in matched PyTorch/torchaudio 2.11.0 CUDA 12.6 wheels and
   grants broader GPU device access. LV Chordia remains included unless `--no-lv-chordia` is
   passed.
-- `--model-bundle` includes required Demucs and Whisper weights, plus beat-this `small0` when beat-this dependencies are included.
+- `--model-bundle` includes required Demucs and Whisper weights, plus beat-this `small0` when beat-this dependencies are included and the Crema ONNX model/state when `--crema-onnx` is selected.
 - `--sandbox-data` keeps app data under Flatpak-private `/var/data/tuneforge` instead of the host XDG data directory.
 
-Like macOS packages, plain Flatpak packages rely on normal Demucs, Whisper, and beat-this caches unless `--model-bundle` is explicitly passed. Advanced Chords uses crema package assets instead of a separate first-use model download; this is the dependency-owned Crema exception, not an external model-bundle source.
+Like macOS packages, plain Flatpak packages rely on normal Demucs, Whisper, and beat-this caches unless `--model-bundle` is explicitly passed. Default Advanced Chords uses Crema package assets. Plain opt-in ONNX packages use the verified TuneForge data cache; combining `--crema-onnx` with `--model-bundle` stages the exact model and runtime-state files and seeds that cache on startup. ONNX packages omit Crema/TensorFlow's HDF5 closure but retain LV Chordia's declared `h5py` dependency.
 When beat-this is excluded, desktop actions explicitly select Built-in Beat Analysis. An Advanced
 Beat Analysis request that ultimately fails during first-use download, load, runtime, or timing
 analysis fails the job rather than switching engines; explicit Built-in Beat Analysis requests do

--- a/packaging/flatpak/com.tuneforge.desktop.yml
+++ b/packaging/flatpak/com.tuneforge.desktop.yml
@@ -182,6 +182,9 @@ modules:
       - type: file
         path: ../../THIRD_PARTY_NOTICES.md
       - type: file
+        path: ../../LICENSES/crema-0.2.0-BSD-2-Clause.txt
+        dest: LICENSES
+      - type: file
         path: ../../docs/PACKAGING.md
         dest: docs
       - type: file
@@ -285,6 +288,7 @@ modules:
       - install -Dm644 README.md /app/share/doc/tuneforge/README.md
       - install -Dm644 LICENSE /app/share/doc/tuneforge/LICENSE
       - install -Dm644 THIRD_PARTY_NOTICES.md /app/share/doc/tuneforge/THIRD_PARTY_NOTICES.md
+      - install -Dm644 LICENSES/crema-0.2.0-BSD-2-Clause.txt /app/share/doc/tuneforge/LICENSES/crema-0.2.0-BSD-2-Clause.txt
       - install -Dm644 docs/PACKAGING.md /app/share/doc/tuneforge/PACKAGING.md
       - install -Dm644 apps/desktop/src-tauri/icons/32x32.png /app/share/icons/hicolor/32x32/apps/com.tuneforge.desktop.png
       - install -Dm644 apps/desktop/src-tauri/icons/128x128.png /app/share/icons/hicolor/128x128/apps/com.tuneforge.desktop.png

--- a/scripts/flatpak-options.test.mjs
+++ b/scripts/flatpak-options.test.mjs
@@ -61,6 +61,25 @@ test("model bundle plan includes beat-this only when requested", () => {
   );
 });
 
+test("model bundle plan includes Crema ONNX only when requested", () => {
+  const withoutCremaOnnx = buildModelBundlePlan({ demucsManifest, lyricsModel: "base" });
+  const withCremaOnnx = buildModelBundlePlan({
+    demucsManifest,
+    includeCremaOnnx: true,
+    lyricsModel: "base",
+  });
+
+  assert.equal(withoutCremaOnnx.manifest.crema_onnx_files.length, 0);
+  assert.deepEqual(
+    withCremaOnnx.manifest.crema_onnx_files.map((entry) => entry.file_name).sort(),
+    ["crema-0.2.0-opset18.onnx", "crema-0.2.0-runtime-state.json"],
+  );
+  assert.equal(
+    withCremaOnnx.manifest.crema_onnx_files.reduce((total, entry) => total + entry.size, 0),
+    2_197_594,
+  );
+});
+
 test("Flatpak manifest allows the logind inhibition fallback", () => {
   assert.match(flatpakManifest, /^\s+- --system-talk-name=org\.freedesktop\.login1$/m);
 });

--- a/scripts/generate-flatpak-sources.mjs
+++ b/scripts/generate-flatpak-sources.mjs
@@ -18,7 +18,8 @@ const pnpmLockPath = path.join(workspaceRoot, "pnpm-lock.yaml");
 const uvLockPath = path.join(workspaceRoot, "apps", "backend", "uv.lock");
 const packageOptions = parsePackageOptions(process.argv.slice(2), { platform: "linux" });
 const selectedPythonExtras = [
-  ...(packageOptions.crema ? ["advanced-chords"] : []),
+  ...(packageOptions.crema === "tensorflow" ? ["advanced-chords"] : []),
+  ...(packageOptions.crema === "onnx" ? ["advanced-chords-onnx"] : []),
   ...(packageOptions.beatThis ? ["advanced-beats"] : []),
   ...(packageOptions.lvChordia ? ["lv-chordia"] : []),
 ];
@@ -596,6 +597,7 @@ function generateModelBundleSources() {
   }
   const plan = buildModelBundlePlan({
     includeBeatThis: packageOptions.beatThis,
+    includeCremaOnnx: packageOptions.crema === "onnx",
   });
   writeGeneratedJson("model-bundle-sources.json", plan.sources);
   writeGeneratedJson("model-bundle-manifest.json", {

--- a/scripts/model-bundle-metadata.mjs
+++ b/scripts/model-bundle-metadata.mjs
@@ -84,6 +84,22 @@ export const BEAT_THIS_CHECKPOINT_SPEC = {
   url: "https://cloud.cp.jku.at/public.php/dav/files/7ik4RrBKTS273gp/small0.ckpt",
 };
 
+export const CREMA_ONNX_REVISION = "65af18f49af5101267fd28f15ac8c452d98b8e3d";
+export const CREMA_ONNX_FILE_SPECS = [
+  {
+    label: "Crema ONNX model",
+    fileName: "crema-0.2.0-opset18.onnx",
+    sha256: "a903f9709821fccebb31d4e93d7d783642faaa90859f45f308c0f9131cc7ca59",
+    size: 2_193_804,
+  },
+  {
+    label: "Crema ONNX runtime state",
+    fileName: "crema-0.2.0-runtime-state.json",
+    sha256: "3744bf9ecb47de7194cb9f250fba26678ea347911af32ec4813645d5e033aca2",
+    size: 3_790,
+  },
+];
+
 const CUDA_MODEL_FALLBACKS = {
   turbo: ["small", "base"],
   "large-v3-turbo": ["small", "base"],
@@ -103,12 +119,14 @@ export function resolveWhisperBundleModels(modelName = DEFAULT_LYRICS_MODEL) {
 
 export function buildModelBundlePlan({
   includeBeatThis = false,
+  includeCremaOnnx = false,
   lyricsModel = process.env.TUNEFORGE_LYRICS_MODEL ?? DEFAULT_LYRICS_MODEL,
   demucsManifest = readDemucsModelManifest(),
 } = {}) {
   const entriesByPath = new Map();
   const torchCheckpoints = [];
   const whisperModels = [];
+  const cremaOnnxFiles = [];
 
   for (const model of demucsManifest.models) {
     for (const file of model.files) {
@@ -157,6 +175,18 @@ export function buildModelBundlePlan({
     torchCheckpoints.push(entry);
   }
 
+  if (includeCremaOnnx) {
+    for (const spec of CREMA_ONNX_FILE_SPECS) {
+      const relativePath = `crema/0.2.0/${CREMA_ONNX_REVISION}/${spec.fileName}`;
+      const entry = addEntry(entriesByPath, {
+        ...spec,
+        url: `https://huggingface.co/grazzolini/tuneforge-models/resolve/${CREMA_ONNX_REVISION}/${spec.fileName}`,
+        relativePath,
+      });
+      cremaOnnxFiles.push(entry);
+    }
+  }
+
   const sources = Array.from(entriesByPath.values()).map((entry) => ({
     type: "file",
     url: entry.url,
@@ -174,6 +204,7 @@ export function buildModelBundlePlan({
         ...manifestEntry(entry),
         model: entry.model,
       })),
+      crema_onnx_files: cremaOnnxFiles.map(manifestEntry),
     },
   };
 }

--- a/scripts/package-flatpak.mjs
+++ b/scripts/package-flatpak.mjs
@@ -94,8 +94,10 @@ function generatedManifestPath(options) {
   }
 
   const imports = ["fastapi", "demucs", "whisper", "torch"];
-  if (options.crema) {
+  if (options.crema === "tensorflow") {
     imports.push("crema", "tensorflow", "keras");
+  } else if (options.crema === "onnx") {
+    imports.push("onnxruntime");
   }
   if (options.beatThis) {
     imports.push("beat_this");

--- a/scripts/package-options.mjs
+++ b/scripts/package-options.mjs
@@ -1,8 +1,10 @@
 const OPTION_ALIASES = new Map([
-  ["--crema", ["crema", true]],
-  ["--advanced-chords", ["crema", true]],
-  ["--no-crema", ["crema", false]],
-  ["--no-advanced-chords", ["crema", false]],
+  ["--crema", ["crema", "tensorflow"]],
+  ["--advanced-chords", ["crema", "tensorflow"]],
+  ["--crema-onnx", ["crema", "onnx"]],
+  ["--advanced-chords-onnx", ["crema", "onnx"]],
+  ["--no-crema", ["crema", "none"]],
+  ["--no-advanced-chords", ["crema", "none"]],
   ["--lv-chordia", ["lvChordia", true]],
   ["--no-lv-chordia", ["lvChordia", false]],
   ["--beat-this", ["beatThis", true]],
@@ -17,7 +19,7 @@ const OPTION_ALIASES = new Map([
 
 export function defaultPackageOptions() {
   return {
-    crema: true,
+    crema: "tensorflow",
     lvChordia: true,
     beatThis: true,
     legacyNvidia: false,
@@ -29,6 +31,7 @@ export function defaultPackageOptions() {
 
 export function parsePackageOptions(argv, { platform } = {}) {
   const options = defaultPackageOptions();
+  const cremaSelections = new Set();
   for (const arg of argv) {
     if (arg === "--") {
       continue;
@@ -38,6 +41,12 @@ export function parsePackageOptions(argv, { platform } = {}) {
       throw new Error(`Unknown option: ${arg}`);
     }
     const [optionName, value] = option;
+    if (optionName === "crema") {
+      cremaSelections.add(value);
+      if (cremaSelections.size > 1) {
+        throw new Error("Conflicting Advanced Chords selectors were provided.");
+      }
+    }
     options[optionName] = value;
   }
   return validatePackageOptions(options, { platform });
@@ -53,6 +62,10 @@ export function packageOptionsFromEnvironmentOrArgv(argv, { platform } = {}) {
 
 export function validatePackageOptions(rawOptions, { platform } = {}) {
   const options = { ...defaultPackageOptions(), ...rawOptions };
+  const crema = options.crema === true ? "tensorflow" : options.crema === false ? "none" : options.crema;
+  if (!["tensorflow", "onnx", "none"].includes(crema)) {
+    throw new Error("Advanced Chords package selection must be tensorflow, onnx, or none.");
+  }
   if (platform === "mac" && options.legacyNvidia) {
     throw new Error("--legacy-nvidia is only supported for Linux packaging.");
   }
@@ -63,7 +76,7 @@ export function validatePackageOptions(rawOptions, { platform } = {}) {
     throw new Error("--sandbox-data is only supported for Linux Flatpak packaging.");
   }
   return {
-    crema: Boolean(options.crema),
+    crema,
     lvChordia: Boolean(options.lvChordia),
     beatThis: Boolean(options.beatThis),
     legacyNvidia: Boolean(options.legacyNvidia),
@@ -82,8 +95,10 @@ export function packageOptionsEnvironment(options) {
 export function packageOptionsToGeneratorArgs(options) {
   const validated = validatePackageOptions(options);
   const args = [];
-  if (validated.crema) {
+  if (validated.crema === "tensorflow") {
     args.push("--crema");
+  } else if (validated.crema === "onnx") {
+    args.push("--crema-onnx");
   } else {
     args.push("--no-crema");
   }
@@ -109,8 +124,10 @@ export function packageOptionsToGeneratorArgs(options) {
 export function backendSyncArgs(options) {
   const validated = validatePackageOptions(options);
   const args = ["sync", "--python", "3.11", "--all-groups"];
-  if (validated.crema) {
+  if (validated.crema === "tensorflow") {
     args.push("--extra", "advanced-chords");
+  } else if (validated.crema === "onnx") {
+    args.push("--extra", "advanced-chords-onnx");
   }
   if (validated.beatThis) {
     args.push("--extra", "advanced-beats");

--- a/scripts/package-options.test.mjs
+++ b/scripts/package-options.test.mjs
@@ -5,7 +5,12 @@ import path from "node:path";
 import test from "node:test";
 import { mergeLegacyTorchPackageSets } from "./generate-flatpak-sources.mjs";
 import { manifestWithPackageOptions } from "./package-flatpak.mjs";
-import { assertLvChordiaBundleLayout, LV_CHORDIA_CHECKPOINT_NAMES } from "./prepare-bundle.mjs";
+import {
+  assertCremaOnnxBundleLayout,
+  assertLvChordiaBundleLayout,
+  CREMA_ONNX_BUNDLE_RELATIVE_PATHS,
+  LV_CHORDIA_CHECKPOINT_NAMES,
+} from "./prepare-bundle.mjs";
 import {
   backendSyncArgs,
   packageOptionsEnvironment,
@@ -44,7 +49,7 @@ test("package option parser accepts feature aliases", () => {
   assert.deepEqual(
     parsePackageOptions(["--crema", "--beat-this", "--model-bundle"], { platform: "mac" }),
     {
-      crema: true,
+      crema: "tensorflow",
       lvChordia: true,
       beatThis: true,
       legacyNvidia: false,
@@ -56,7 +61,7 @@ test("package option parser accepts feature aliases", () => {
   assert.deepEqual(
     parsePackageOptions(["--advanced-chords", "--advanced-beats"], { platform: "linux" }),
     {
-      crema: true,
+      crema: "tensorflow",
       lvChordia: true,
       beatThis: true,
       legacyNvidia: false,
@@ -71,7 +76,7 @@ test("package option parser includes advanced dependencies by default", () => {
   const options = parsePackageOptions([], { platform: "mac" });
 
   assert.deepEqual(options, {
-    crema: true,
+    crema: "tensorflow",
     lvChordia: true,
     beatThis: true,
     legacyNvidia: false,
@@ -106,12 +111,28 @@ test("release default package options do not bundle model weights", () => {
 test("package option parser accepts advanced dependency opt-outs", () => {
   const options = parsePackageOptions(["--no-crema", "--no-beat-this", "--no-lv-chordia"], { platform: "linux" });
 
-  assert.equal(options.crema, false);
+  assert.equal(options.crema, "none");
   assert.equal(options.beatThis, false);
   assert.equal(options.lvChordia, false);
   assert.equal(JSON.parse(packageOptionsEnvironment(options).TUNEFORGE_PACKAGE_OPTIONS).beatThis, false);
   assert.deepEqual(packageOptionsToGeneratorArgs(options), ["--no-crema", "--no-beat-this", "--no-lv-chordia"]);
   assert.deepEqual(backendSyncArgs(options), ["sync", "--python", "3.11", "--all-groups"]);
+});
+
+test("package option parser selects ONNX and rejects mixed implementations", () => {
+  const options = parsePackageOptions(["--crema-onnx"], { platform: "mac" });
+  assert.equal(options.crema, "onnx");
+  assert.deepEqual(packageOptionsToGeneratorArgs(options), ["--crema-onnx", "--beat-this", "--lv-chordia"]);
+  assert.deepEqual(backendSyncArgs(options).slice(4, 6), ["--extra", "advanced-chords-onnx"]);
+  assert.throws(
+    () => parsePackageOptions(["--crema", "--advanced-chords-onnx"], { platform: "mac" }),
+    /Conflicting Advanced Chords selectors/,
+  );
+});
+
+test("legacy boolean package data maps to TensorFlow or none", () => {
+  assert.equal(JSON.parse(packageOptionsEnvironment({ crema: true }).TUNEFORGE_PACKAGE_OPTIONS).crema, "tensorflow");
+  assert.equal(JSON.parse(packageOptionsEnvironment({ crema: false }).TUNEFORGE_PACKAGE_OPTIONS).crema, "none");
 });
 
 test("Flatpak package options are scoped to the TuneForge module build environment", () => {
@@ -198,6 +219,36 @@ test("macOS staged bundle has exactly one LV Chordia checkpoint set or none when
     rmSync(fixture, { recursive: true, force: true });
     mkdirSync(fixture, { recursive: true });
     assert.doesNotThrow(() => assertLvChordiaBundleLayout(fixture, false));
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
+test("staged bundles contain Crema ONNX files only in the explicit model-bundle layout", () => {
+  const fixture = mkdtempSync(path.join(tmpdir(), "tuneforge-crema-layout-"));
+  try {
+    assert.doesNotThrow(() => assertCremaOnnxBundleLayout(fixture, false));
+    const datasets = path.join(fixture, "site-packages", "onnxruntime", "datasets");
+    mkdirSync(datasets, { recursive: true });
+    writeFileSync(path.join(datasets, "logreg_iris.onnx"), "onnxruntime fixture");
+    assert.doesNotThrow(() => assertCremaOnnxBundleLayout(fixture, false));
+
+    for (const relativePath of CREMA_ONNX_BUNDLE_RELATIVE_PATHS) {
+      const artifact = path.join(fixture, relativePath);
+      mkdirSync(path.dirname(artifact), { recursive: true });
+      writeFileSync(artifact, "fixture");
+    }
+    assert.doesNotThrow(() => assertCremaOnnxBundleLayout(fixture, true));
+    assert.throws(
+      () => assertCremaOnnxBundleLayout(fixture, false),
+      /Unexpected Crema ONNX model bundle layout/,
+    );
+
+    rmSync(path.join(fixture, CREMA_ONNX_BUNDLE_RELATIVE_PATHS[0]));
+    assert.throws(
+      () => assertCremaOnnxBundleLayout(fixture, true),
+      /Unexpected Crema ONNX model bundle layout/,
+    );
   } finally {
     rmSync(fixture, { recursive: true, force: true });
   }

--- a/scripts/prepare-bundle.mjs
+++ b/scripts/prepare-bundle.mjs
@@ -29,6 +29,15 @@ const stagedSitePackagesRoot = path.join(stagedBackendRoot, "site-packages");
 const stagedModelBundleRoot = path.join(stagedBackendRoot, "models", "bundle");
 const stagedLvChordiaRoot = path.join(stagedPythonRoot, "share", "lv-chordia", "cache_data");
 const sourceLvChordiaRoot = path.join(backendRoot, ".venv", "share", "lv-chordia", "cache_data");
+const cremaLicensePath = path.join(workspaceRoot, "LICENSES", "crema-0.2.0-BSD-2-Clause.txt");
+const CREMA_ONNX_ARTIFACT_NAMES = new Set([
+  "crema-0.2.0-opset18.onnx",
+  "crema-0.2.0-runtime-state.json",
+]);
+const CREMA_ONNX_REVISION = "65af18f49af5101267fd28f15ac8c452d98b8e3d";
+export const CREMA_ONNX_BUNDLE_RELATIVE_PATHS = Array.from(CREMA_ONNX_ARTIFACT_NAMES, (name) =>
+  path.join("models", "bundle", "crema", "0.2.0", CREMA_ONNX_REVISION, name),
+).sort();
 export const LV_CHORDIA_CHECKPOINT_NAMES = [
   "joint_chord_net_ismir_naive_v1.0_reweight(0.0,10.0)_s0.best.sdict",
   "joint_chord_net_ismir_naive_v1.0_reweight(0.0,10.0)_s1.best.sdict",
@@ -60,6 +69,23 @@ function checkpointPaths(root) {
     const entryPath = path.join(root, entry.name);
     return entry.isDirectory() ? checkpointPaths(entryPath) : entry.name.endsWith(".sdict") ? [entryPath] : [];
   });
+}
+
+function cremaModelPaths(root) {
+  if (!existsSync(root)) return [];
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) return cremaModelPaths(entryPath);
+    return CREMA_ONNX_ARTIFACT_NAMES.has(entry.name) ? [entryPath] : [];
+  });
+}
+
+export function assertCremaOnnxBundleLayout(root, enabled) {
+  const actual = cremaModelPaths(root).map((filePath) => path.relative(root, filePath)).sort();
+  const expected = enabled ? CREMA_ONNX_BUNDLE_RELATIVE_PATHS : [];
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`Unexpected Crema ONNX model bundle layout: ${actual.join(", ") || "none"}`);
+  }
 }
 
 export function assertLvChordiaBundleLayout(root, enabled) {
@@ -133,6 +159,9 @@ function prepareModelBundle(options) {
   if (options.beatThis) {
     args.push("--include-beat-this");
   }
+  if (options.crema === "onnx") {
+    args.push("--include-crema-onnx");
+  }
   run(pythonPath, args, { cwd: backendRoot });
 }
 
@@ -203,10 +232,16 @@ async function main() {
   copyInto(path.join(backendRoot, "alembic"), path.join(stagedBackendSourceRoot, "alembic"));
   copyInto(path.join(backendRoot, "alembic.ini"), path.join(stagedBackendSourceRoot, "alembic.ini"));
   copyInto(path.join(backendRoot, "pyproject.toml"), path.join(stagedBackendSourceRoot, "pyproject.toml"));
+  mkdirSync(path.join(stagedBackendRoot, "licenses"), { recursive: true });
+  copyInto(cremaLicensePath, path.join(stagedBackendRoot, "licenses", path.basename(cremaLicensePath)));
   copyInto(pythonInstallRoot, stagedPythonRoot, { dereference: true });
   copyInto(sitePackagesRoot, stagedSitePackagesRoot, { filter: shouldIncludeBundledSitePackage });
   stageLvChordiaAssets(packageOptions);
   prepareModelBundle(packageOptions);
+  assertCremaOnnxBundleLayout(
+    stagedBackendRoot,
+    packageOptions.modelBundle && packageOptions.crema === "onnx",
+  );
   writeResolvedBuildInfoFile(path.join(stagedBackendRoot, "version.json"), buildInfo);
 
   const manifest = {

--- a/scripts/release-license-inventory.mjs
+++ b/scripts/release-license-inventory.mjs
@@ -57,7 +57,7 @@ export const releaseInventoryCommands = [
     cwd: "apps/backend",
     commands: [
       {
-        label: "Release dependency SBOM",
+        label: "Default TensorFlow release dependency SBOM",
         command: [
           "uv",
           "export",
@@ -65,7 +65,29 @@ export const releaseInventoryCommands = [
           "cyclonedx1.5",
           "--frozen",
           "--all-groups",
-          "--all-extras",
+          "--extra",
+          "advanced-chords",
+          "--extra",
+          "advanced-beats",
+          "--extra",
+          "lv-chordia",
+        ],
+      },
+      {
+        label: "Opt-in ONNX release dependency SBOM",
+        command: [
+          "uv",
+          "export",
+          "--format",
+          "cyclonedx1.5",
+          "--frozen",
+          "--all-groups",
+          "--extra",
+          "advanced-chords-onnx",
+          "--extra",
+          "advanced-beats",
+          "--extra",
+          "lv-chordia",
         ],
       },
       {
@@ -121,6 +143,11 @@ export function buildReleaseLicenseInventory({ includeToolStatus = false, checkT
     includeBeatThis: defaultOptions.beatThis,
     lyricsModel: DEFAULT_LYRICS_MODEL,
   });
+  const cremaOnnxBundledPlan = buildModelBundlePlan({
+    includeBeatThis: defaultOptions.beatThis,
+    includeCremaOnnx: true,
+    lyricsModel: DEFAULT_LYRICS_MODEL,
+  });
   const bundledManifestEntries = [
     ...bundledPlan.manifest.torch_checkpoints,
     ...bundledPlan.manifest.whisper_models,
@@ -147,9 +174,20 @@ export function buildReleaseLicenseInventory({ includeToolStatus = false, checkT
         { platform: "macOS", command: "pnpm package:mac" },
         { platform: "Linux Flatpak", command: "pnpm package:linux" },
       ],
+      onnxPackageCommands: [
+        { platform: "macOS", command: "pnpm package:mac -- --crema-onnx" },
+        { platform: "Linux Flatpak", command: "pnpm package:linux -- --crema-onnx" },
+      ],
       explicitModelBundleCommands: [
         { platform: "macOS", command: "pnpm package:mac -- --model-bundle" },
         { platform: "Linux Flatpak", command: "pnpm package:linux -- --model-bundle" },
+      ],
+      cremaOnnxModelBundleCommands: [
+        { platform: "macOS", command: "pnpm package:mac -- --crema-onnx --model-bundle" },
+        {
+          platform: "Linux Flatpak",
+          command: "pnpm package:linux -- --crema-onnx --model-bundle",
+        },
       ],
       cachePrewarmCommand:
         "cd apps/backend && uv run --python 3.11 --locked --all-groups " +
@@ -164,6 +202,7 @@ export function buildReleaseLicenseInventory({ includeToolStatus = false, checkT
         },
       },
       cachePaths: [
+        "$TUNEFORGE_DATA_DIR/cache/models/crema/0.2.0/65af18f49af5101267fd28f15ac8c452d98b8e3d",
         "$TORCH_HOME/hub/checkpoints",
         "$XDG_CACHE_HOME/torch/hub/checkpoints",
         "~/.cache/torch/hub/checkpoints",
@@ -180,9 +219,12 @@ export function buildReleaseLicenseInventory({ includeToolStatus = false, checkT
       defaultLyricsModel: DEFAULT_LYRICS_MODEL,
       explicitBundleSourceCount: bundledPlan.sources.length,
       explicitBundleBytes: sumBundleBytes(bundledManifestEntries),
+      cremaOnnxBundleSourceCount: cremaOnnxBundledPlan.manifest.crema_onnx_files.length,
+      cremaOnnxBundleBytes: sumBundleBytes(cremaOnnxBundledPlan.manifest.crema_onnx_files),
     },
     risks: [
       "Default release package commands must not pass --model-bundle.",
+      "Plain Crema ONNX packages must not include model bytes; the explicit model bundle contains only the pinned files.",
       "Demucs pretrained-weight redistribution is unclear/restricted upstream.",
       "FFmpeg and ffprobe are host-installed and are not bundled.",
       "Python package license metadata can be incomplete; review missing fields manually.",

--- a/scripts/release-license-inventory.test.mjs
+++ b/scripts/release-license-inventory.test.mjs
@@ -14,8 +14,10 @@ test("release inventory commands cover JS, Python, and Rust without writing repo
 
   assert.deepEqual(Array.from(commandsById.keys()), ["javascript", "python", "rust"]);
   assert.equal(commandsById.get("javascript").commands[0].shell, "pnpm licenses list --recursive");
-  assert.match(commandsById.get("python").commands[0].shell, /uv export .* --all-groups --all-extras/);
-  assert.match(commandsById.get("python").commands[1].shell, /python -m pip inspect --local/);
+  assert.match(commandsById.get("python").commands[0].shell, /--extra advanced-chords /);
+  assert.match(commandsById.get("python").commands[1].shell, /--extra advanced-chords-onnx /);
+  assert.doesNotMatch(commandsById.get("python").commands[0].shell, /--all-extras/);
+  assert.match(commandsById.get("python").commands[2].shell, /python -m pip inspect --local/);
   assert.equal(
     commandsById.get("rust").commands[0].shell,
     "cd apps/desktop/src-tauri && cargo about generate --format json --locked",
@@ -36,10 +38,18 @@ test("model policy documents default no-bundle packaging and explicit bundle com
   assert.ok(
     checklist.modelPolicy.explicitModelBundleCommands.every((entry) => entry.command.includes("--model-bundle")),
   );
+  assert.ok(
+    checklist.modelPolicy.cremaOnnxModelBundleCommands.every(
+      (entry) => entry.command.includes("--crema-onnx") && entry.command.includes("--model-bundle"),
+    ),
+  );
+  assert.ok(checklist.modelPolicy.onnxPackageCommands.every((entry) => entry.command.includes("--crema-onnx")));
   assert.ok(checklist.modelPolicy.cachePaths.includes("~/.cache/torch/hub/checkpoints"));
   assert.ok(checklist.modelPolicy.cachePaths.includes("~/.cache/whisper"));
   assert.ok(checklist.modelPolicy.explicitBundleSourceCount > 0);
   assert.ok(checklist.modelPolicy.explicitBundleBytes > 0);
+  assert.equal(checklist.modelPolicy.cremaOnnxBundleSourceCount, 2);
+  assert.equal(checklist.modelPolicy.cremaOnnxBundleBytes, 2_197_594);
   assert.deepEqual(checklist.modelPolicy.bundledDependencyWeights.lvChordia, {
     checkpointBytes: 28_730_939,
     checkpointCount: 5,

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -14,6 +14,9 @@ Runs the standard developer setup:
 
 Options:
   --advanced-chords, --crema  Include the default crema/TensorFlow chord backend.
+  --advanced-chords-onnx, --crema-onnx
+                              Use the Crema ONNX Runtime chord backend.
+  --crema-onnx-model-dir DIR  Verify and import a previously downloaded ONNX model directory.
   --no-advanced-chords, --no-crema
                               Skip the crema/TensorFlow chord backend.
   --advanced-beats, --beat-this
@@ -32,7 +35,9 @@ Options:
 EOF
 }
 
-advanced_chords=1
+advanced_chords="tensorflow"
+advanced_chords_selected=""
+crema_onnx_model_dir=""
 advanced_beats=1
 lv_chordia=1
 legacy_nvidia=0
@@ -45,10 +50,36 @@ skip_contracts=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --advanced-chords | --crema)
-      advanced_chords=1
+      if [[ -n "${advanced_chords_selected}" && "${advanced_chords_selected}" != "tensorflow" ]]; then
+        echo "Conflicting Advanced Chords selectors were provided." >&2
+        exit 2
+      fi
+      advanced_chords="tensorflow"
+      advanced_chords_selected="tensorflow"
+      ;;
+    --advanced-chords-onnx | --crema-onnx)
+      if [[ -n "${advanced_chords_selected}" && "${advanced_chords_selected}" != "onnx" ]]; then
+        echo "Conflicting Advanced Chords selectors were provided." >&2
+        exit 2
+      fi
+      advanced_chords="onnx"
+      advanced_chords_selected="onnx"
       ;;
     --no-advanced-chords | --no-crema)
-      advanced_chords=0
+      if [[ -n "${advanced_chords_selected}" && "${advanced_chords_selected}" != "none" ]]; then
+        echo "Conflicting Advanced Chords selectors were provided." >&2
+        exit 2
+      fi
+      advanced_chords="none"
+      advanced_chords_selected="none"
+      ;;
+    --crema-onnx-model-dir)
+      if [[ $# -lt 2 ]]; then
+        echo "--crema-onnx-model-dir requires a directory." >&2
+        exit 2
+      fi
+      crema_onnx_model_dir="$2"
+      shift
       ;;
     --advanced-beats | --beat-this)
       advanced_beats=1
@@ -111,9 +142,16 @@ if [[ "${legacy_nvidia}" -eq 1 ]]; then
   fi
 fi
 
+if [[ -n "${crema_onnx_model_dir}" && "${advanced_chords}" != "onnx" ]]; then
+  echo "--crema-onnx-model-dir requires --crema-onnx." >&2
+  exit 2
+fi
+
 backend_sync_args=(sync --python 3.11 --all-groups)
-if [[ "${advanced_chords}" -eq 1 ]]; then
+if [[ "${advanced_chords}" == "tensorflow" ]]; then
   backend_sync_args+=(--extra advanced-chords)
+elif [[ "${advanced_chords}" == "onnx" ]]; then
+  backend_sync_args+=(--extra advanced-chords-onnx)
 fi
 if [[ "${advanced_beats}" -eq 1 ]]; then
   backend_sync_args+=(--extra advanced-beats)
@@ -149,6 +187,13 @@ fi
 
 echo "Syncing backend dependencies..."
 uv "${backend_sync_args[@]}"
+
+if [[ -n "${crema_onnx_model_dir}" ]]; then
+  echo "Importing verified Crema ONNX model files..."
+  .venv/bin/python -c \
+    'import sys; from pathlib import Path; from app.engines.crema_onnx import import_crema_onnx_model; import_crema_onnx_model(Path(sys.argv[1]))' \
+    "${crema_onnx_model_dir}"
+fi
 
 if [[ "${legacy_nvidia}" -eq 1 ]]; then
   echo "Installing legacy NVIDIA Torch wheels..."
@@ -201,7 +246,7 @@ if [[ "${skip_model_prewarm}" -eq 0 ]]; then
   if [[ "${skip_demucs_models}" -eq 1 ]]; then
     prewarm_args+=(--skip-demucs)
   fi
-  if [[ "${advanced_chords}" -eq 1 ]]; then
+  if [[ "${advanced_chords}" != "none" ]]; then
     prewarm_args+=(--include-crema)
   fi
   if [[ "${advanced_beats}" -eq 1 ]]; then

--- a/scripts/setup-dev.test.sh
+++ b/scripts/setup-dev.test.sh
@@ -177,6 +177,25 @@ assert_python_args "opt-out" \
   -m \
   app.cli.prewarm_models
 
+run_setup_dev "onnx" --crema-onnx
+grep -Fx -- "advanced-chords-onnx" "${setup_uv_args_file}"
+assert_python_args "onnx" \
+  -m \
+  app.cli.prewarm_models \
+  --include-crema \
+  --include-beat-this \
+  --include-lv-chordia
+
+conflict_output_file="${fixture}/setup-output-conflict"
+if PATH="${fixture}/bin:${PATH}" \
+  /bin/bash "${fixture}/scripts/setup-dev.sh" \
+    --crema --crema-onnx \
+    --skip-contracts --skip-playwright-browsers --skip-pnpm-install > "${conflict_output_file}" 2>&1; then
+  echo "expected conflicting Advanced Chords selectors to fail" >&2
+  exit 1
+fi
+grep -F -- "Conflicting Advanced Chords selectors" "${conflict_output_file}"
+
 run_setup_dev "legacy-lv" --legacy-nvidia
 assert_python_args "legacy-lv" \
   -m \

--- a/scripts/sync-backend-default.sh
+++ b/scripts/sync-backend-default.sh
@@ -9,6 +9,8 @@ Recreates the backend environment with the default locked dependency set.
 
 Options:
   --advanced-chords, --crema  Include the default crema/TensorFlow chord backend.
+  --advanced-chords-onnx, --crema-onnx
+                              Use the Crema ONNX Runtime chord backend.
   --no-advanced-chords, --no-crema
                               Skip the crema/TensorFlow chord backend.
   --advanced-beats, --beat-this
@@ -21,17 +23,21 @@ Options:
 EOF
 }
 
-advanced_chords=1
+advanced_chords="tensorflow"
+advanced_chords_selected=""
 advanced_beats=1
 lv_chordia=1
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --advanced-chords | --crema)
-      advanced_chords=1
+      selection="tensorflow"
+      ;;
+    --advanced-chords-onnx | --crema-onnx)
+      selection="onnx"
       ;;
     --no-advanced-chords | --no-crema)
-      advanced_chords=0
+      selection="none"
       ;;
     --advanced-beats | --beat-this)
       advanced_beats=1
@@ -57,6 +63,15 @@ while [[ $# -gt 0 ]]; do
       exit 2
       ;;
   esac
+  if [[ -n "${selection:-}" ]]; then
+    if [[ -n "${advanced_chords_selected}" && "${advanced_chords_selected}" != "${selection}" ]]; then
+      echo "Conflicting Advanced Chords selectors were provided." >&2
+      exit 2
+    fi
+    advanced_chords="${selection}"
+    advanced_chords_selected="${selection}"
+    unset selection
+  fi
   shift
 done
 
@@ -66,8 +81,10 @@ marker_file="${backend_dir}/.venv/.tuneforge-legacy-nvidia"
 
 cd "${backend_dir}"
 backend_sync_args=(sync --python 3.11 --all-groups)
-if [[ "${advanced_chords}" -eq 1 ]]; then
+if [[ "${advanced_chords}" == "tensorflow" ]]; then
   backend_sync_args+=(--extra advanced-chords)
+elif [[ "${advanced_chords}" == "onnx" ]]; then
+  backend_sync_args+=(--extra advanced-chords-onnx)
 fi
 if [[ "${advanced_beats}" -eq 1 ]]; then
   backend_sync_args+=(--extra advanced-beats)

--- a/scripts/sync-backend-legacy-nvidia.sh
+++ b/scripts/sync-backend-legacy-nvidia.sh
@@ -9,6 +9,8 @@ Recreates the backend environment with the Linux x86_64 legacy NVIDIA Torch prof
 
 Options:
   --advanced-chords, --crema  Include the default crema/TensorFlow chord backend.
+  --advanced-chords-onnx, --crema-onnx
+                              Use the Crema ONNX Runtime chord backend.
   --no-advanced-chords, --no-crema
                               Skip the crema/TensorFlow chord backend.
   --advanced-beats, --beat-this
@@ -21,17 +23,21 @@ Options:
 EOF
 }
 
-advanced_chords=1
+advanced_chords="tensorflow"
+advanced_chords_selected=""
 advanced_beats=1
 lv_chordia=1
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --advanced-chords | --crema)
-      advanced_chords=1
+      selection="tensorflow"
+      ;;
+    --advanced-chords-onnx | --crema-onnx)
+      selection="onnx"
       ;;
     --no-advanced-chords | --no-crema)
-      advanced_chords=0
+      selection="none"
       ;;
     --advanced-beats | --beat-this)
       advanced_beats=1
@@ -57,6 +63,15 @@ while [[ $# -gt 0 ]]; do
       exit 2
       ;;
   esac
+  if [[ -n "${selection:-}" ]]; then
+    if [[ -n "${advanced_chords_selected}" && "${advanced_chords_selected}" != "${selection}" ]]; then
+      echo "Conflicting Advanced Chords selectors were provided." >&2
+      exit 2
+    fi
+    advanced_chords="${selection}"
+    advanced_chords_selected="${selection}"
+    unset selection
+  fi
   shift
 done
 
@@ -79,8 +94,10 @@ cd "${backend_dir}"
 # Start from the standard locked backend environment, then locally override
 # torch/torchaudio with the older CUDA 12.6 wheels for legacy NVIDIA cards.
 backend_sync_args=(sync --python 3.11 --all-groups)
-if [[ "${advanced_chords}" -eq 1 ]]; then
+if [[ "${advanced_chords}" == "tensorflow" ]]; then
   backend_sync_args+=(--extra advanced-chords)
+elif [[ "${advanced_chords}" == "onnx" ]]; then
+  backend_sync_args+=(--extra advanced-chords-onnx)
 fi
 if [[ "${advanced_beats}" -eq 1 ]]; then
   backend_sync_args+=(--extra advanced-beats)


### PR DESCRIPTION
## Summary

- Add an opt-in ONNX Runtime implementation behind the existing `crema-advanced` backend while keeping Crema/TensorFlow as the default.
- Verify and cache the immutable Crema ONNX model and runtime state, with offline import and explicit `--model-bundle` support.
- Add profile-specific setup and packaging selectors, runtime metadata, settings labels, licensing documentation, and regression coverage.

Closes #474

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `node --test scripts/package-options.test.mjs scripts/flatpak-options.test.mjs scripts/release-license-inventory.test.mjs`
- `bash scripts/setup-dev.test.sh`
- Anonymous exact-revision download, SHA-256 verification, fresh-cache prewarm, and offline ONNX Runtime CPU loading.
- GitHub provenance-attestation verification for the exact model and runtime-state bytes.
- User-run Linux Flatpak ONNX package build: 2.1 GB; too large for GitHub Actions artifact upload.
