### PR TITLE
chore: prepare v1.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,23 +5,25 @@ download, installation, verification, signature, and publication instructions.
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-08-28
+
 ### Added
 
 - Added an opt-in Crema ONNX implementation for Advanced Chords while retaining Crema/TensorFlow
   as the default setup and package profile.
 - Added optional bundled LV Chordia submission chord detection for desktop; Advanced Chords remains
-  the default while the new backend awaits manual comparison and approval.
+  the default while further default evaluation is deferred.
 
 ### Changed
 
 - Made Advanced Beat Analysis the default beat-analysis request. Built-in Beat Analysis remains an
-  explicit choice for mobile, dependency-excluded packages, and users who opt out; advanced beat
-  runtime failures now fail the job.
+  explicit mobile, dependency-excluded-package, and opt-out choice; advanced beat runtime failures
+  fail the job without silently switching engines.
 
 ### Fixed
 
-- Restored Linux developer setup on unsupported default CUDA architectures and made the legacy
-  NVIDIA profile compatible with LV Chordia.
+- Restored Linux developer setup on unsupported default CUDA architectures and repaired legacy
+  NVIDIA Flatpak packaging while retaining LV Chordia support.
 
 ## [1.2.0] - 2026-08-24
 
@@ -143,7 +145,8 @@ download, installation, verification, signature, and publication instructions.
 
 - Development used `0.1.0` metadata; `v1.0.0` was the first tagged release.
 
-[Unreleased]: https://github.com/grazzolini/tuneforge/compare/v1.2.0...main
+[Unreleased]: https://github.com/grazzolini/tuneforge/compare/v1.3.0...main
+[1.3.0]: https://github.com/grazzolini/tuneforge/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/grazzolini/tuneforge/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/grazzolini/tuneforge/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/grazzolini/tuneforge/compare/v1.0.0...v1.0.1

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tuneforge-backend"
-version = "1.2.0"
+version = "1.3.0"
 description = "Local API and processing backend for TuneForge."
 readme = "README.md"
 requires-python = ">=3.11,<3.12"

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -306,7 +306,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx') or (sys_platform == 'emscripten' and extra != 'extra-17-tuneforge-backend-advanced-chords') or (sys_platform == 'win32' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx') or (sys_platform == 'win32' and extra != 'extra-17-tuneforge-backend-advanced-chords')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/3a8241c6e19483ac1f1dcf5c10238205dcb8a6e9d0d4d4709240dff28ff4/cuda_bindings-13.2.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:721104c603f059780d287969be3d194a18d0cc3b713ed9049065a1107706759d", size = 5730273, upload-time = "2026-03-11T00:12:37.18Z" },
@@ -332,37 +332,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or (sys_platform == 'win32' and extra != 'extra-17-tuneforge-backend-advanced-chords') or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or (sys_platform == 'win32' and extra != 'extra-17-tuneforge-backend-advanced-chords') or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or (sys_platform == 'win32' and extra != 'extra-17-tuneforge-backend-advanced-chords') or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 cufile = [
     { name = "nvidia-cufile", marker = "sys_platform == 'linux' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or (sys_platform == 'win32' and extra != 'extra-17-tuneforge-backend-advanced-chords') or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux' or (sys_platform == 'win32' and extra != 'extra-17-tuneforge-backend-advanced-chords') or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or (sys_platform == 'win32' and extra != 'extra-17-tuneforge-backend-advanced-chords') or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or (sys_platform == 'win32' and extra != 'extra-17-tuneforge-backend-advanced-chords') or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or (sys_platform == 'win32' and extra != 'extra-17-tuneforge-backend-advanced-chords') or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or (sys_platform == 'win32' and extra != 'extra-17-tuneforge-backend-advanced-chords') or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or (sys_platform == 'win32' and extra != 'extra-17-tuneforge-backend-advanced-chords') or (extra == 'extra-17-tuneforge-backend-advanced-chords' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx')" },
 ]
 
 [[package]]
@@ -1094,7 +1094,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx') or (sys_platform == 'emscripten' and extra != 'extra-17-tuneforge-backend-advanced-chords') or (sys_platform == 'win32' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx') or (sys_platform == 'win32' and extra != 'extra-17-tuneforge-backend-advanced-chords')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
@@ -1107,7 +1107,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx') or (sys_platform == 'emscripten' and extra != 'extra-17-tuneforge-backend-advanced-chords') or (sys_platform == 'win32' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx') or (sys_platform == 'win32' and extra != 'extra-17-tuneforge-backend-advanced-chords')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1139,9 +1139,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx') or (sys_platform == 'emscripten' and extra != 'extra-17-tuneforge-backend-advanced-chords') or (sys_platform == 'win32' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx') or (sys_platform == 'win32' and extra != 'extra-17-tuneforge-backend-advanced-chords')" },
+    { name = "nvidia-cusparse", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx') or (sys_platform == 'emscripten' and extra != 'extra-17-tuneforge-backend-advanced-chords') or (sys_platform == 'win32' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx') or (sys_platform == 'win32' and extra != 'extra-17-tuneforge-backend-advanced-chords')" },
+    { name = "nvidia-nvjitlink", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx') or (sys_platform == 'emscripten' and extra != 'extra-17-tuneforge-backend-advanced-chords') or (sys_platform == 'win32' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx') or (sys_platform == 'win32' and extra != 'extra-17-tuneforge-backend-advanced-chords')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1154,7 +1154,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx') or (sys_platform == 'emscripten' and extra != 'extra-17-tuneforge-backend-advanced-chords') or (sys_platform == 'win32' and extra == 'extra-17-tuneforge-backend-advanced-chords-onnx') or (sys_platform == 'win32' and extra != 'extra-17-tuneforge-backend-advanced-chords')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2066,7 +2066,7 @@ wheels = [
 
 [[package]]
 name = "tuneforge-backend"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tuneforge/desktop",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -7456,7 +7456,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuneforge"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "android_system_properties",
  "base64 0.23.1",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuneforge"
-version = "1.2.0"
+version = "1.3.0"
 description = "TuneForge desktop shell"
 edition = "2021"
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "TuneForge",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "identifier": "com.tuneforge.desktop",
   "build": {
     "beforeDevCommand": "pnpm --filter @tuneforge/desktop dev",

--- a/apps/desktop/src/App.project-export.test.tsx
+++ b/apps/desktop/src/App.project-export.test.tsx
@@ -60,8 +60,8 @@ function health(defaultExportFormat: string): HealthResponse {
   return {
     name: "TuneForge",
     version: "backend-test-ref",
-    backend_version: { package_version: "1.2.0", git_ref: "backend-test-ref" },
-    frontend_version: { package_version: "1.2.0", git_ref: "frontend-test-ref" },
+    backend_version: { package_version: "1.3.0", git_ref: "backend-test-ref" },
+    frontend_version: { package_version: "1.3.0", git_ref: "frontend-test-ref" },
     status: "ok",
     api_base_url: "http://127.0.0.1:8765/api/v1",
     data_root: "/tmp/tuneforge",

--- a/apps/desktop/src/test/appTestHarness.tsx
+++ b/apps/desktop/src/test/appTestHarness.tsx
@@ -1444,11 +1444,11 @@ const {
     name: "TuneForge",
     version: "backend-test-ref",
     backend_version: {
-      package_version: "1.2.0",
+      package_version: "1.3.0",
       git_ref: "backend-test-ref",
     },
     frontend_version: {
-      package_version: "1.2.0",
+      package_version: "1.3.0",
       git_ref: "frontend-test-ref",
     },
     status: "ok",

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tuneforge/shared-types",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packaging/flatpak/com.tuneforge.desktop.metainfo.xml
+++ b/packaging/flatpak/com.tuneforge.desktop.metainfo.xml
@@ -27,6 +27,7 @@
   </categories>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="1.3.0" date="2026-08-28" />
     <release version="1.2.0" date="2026-08-24" />
     <release version="1.1.0" date="2026-08-18" />
     <release version="1.0.1" date="2026-08-13" />

--- a/scripts/capture-release-media.mjs
+++ b/scripts/capture-release-media.mjs
@@ -1910,11 +1910,11 @@ function healthResponse() {
     name: "TuneForge",
     version: "release-media-fixture",
     backend_version: {
-      package_version: "1.2.0",
+      package_version: "1.3.0",
       git_ref: "release-media-fixture",
     },
     frontend_version: {
-      package_version: "1.2.0",
+      package_version: "1.3.0",
       git_ref: "release-media-fixture",
     },
     status: "ok",


### PR DESCRIPTION
## Summary

- Prepare v1.3.0 release metadata dated 2026-08-28.
- Update governed versions, generated locks, fixtures, and Flatpak metadata.
- Preserve current analysis defaults; defer LV Chordia and Crema ONNX default evaluation.
- Refs #394

## Testing

- `pnpm release:check-version` — passed.
- `pnpm release:license-inventory -- --check` — passed.
- `pnpm lint` and `pnpm typecheck` — passed.
- `pnpm test` — parallel Tauri transport lane failed: 362/365 passed.
- `cargo test -- --test-threads=1` — passed: 365/365.
- `TUNEFORGE_DATA_DIR=$TUNEFORGE_DATA_DIR uv run --project apps/backend --python 3.11 pytest -vv -x` — passed: 790/790.
- `node --test scripts/release-license-inventory.test.mjs scripts/capture-release-media.test.mjs` — passed: 18/18.
- `node --check scripts/capture-release-media.mjs`, `node --check scripts/check-release-version.mjs`, and `node --check scripts/release-license-inventory.mjs` — passed.
- `node scripts/capture-release-media.mjs --run` — captured and inspected 9 catalog items / 10 outputs.
