### PR TITLE
feat(flatpak): add durable build caches

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -24,6 +24,12 @@ This file is the source of truth for dependency and model-weight distribution po
 - **Source:** <https://github.com/microsoft/TypeScript>
 - **Notes:** Microsoft's TypeScript 7 CLI and official `@typescript/typescript6` compatibility package are build/development-only toolchain dependencies. They are not bundled into Tuneforge runtime artifacts.
 
+### sccache 0.17.0
+
+- **License:** Apache-2.0
+- **Source:** <https://github.com/mozilla/sccache/tree/v0.17.0>
+- **Notes:** The pinned x86_64 musl release binary accelerates Rust compilation during Linux Flatpak builds. It is build-only and is removed from the final Tuneforge package.
+
 ## Runtime Dependencies (bundled or required)
 
 ### Demucs

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -208,6 +208,49 @@ pnpm package:linux:flatpak -- --no-bundle
 
 The Flatpak build generates local dependency source manifests, builds inside the SDK sandbox, and installs the backend under `/app/lib/tuneforge/backend`. It bundles `pactl` for microphone volume control but does not bundle FFmpeg.
 
+### Flatpak Build Caches and Evidence
+
+Flatpak packaging runs `flatpak-builder --force-clean`, so `packaging/flatpak/build-dir` is always a
+clean output. Durable state and dependency/compiler caches default to
+`.flatpak-builder/tuneforge-state` and `.flatpak-builder/tuneforge-cache`. Set absolute
+`FLATPAK_STATE_DIR` and `FLATPAK_CACHE_DIR` paths to move them. Packaging rejects unsafe or
+overlapping roots; valid caches persist until deleted.
+
+Caches are namespaced by build schema, application, architecture, runtime, toolchain, and package
+options. Dependency installation remains frozen and offline. Integrity, lock, or cache failures stop
+the build without network fallback or automatic repair. Deterministic timestamps keep repeated build
+payloads comparable.
+
+Module inputs are separated so backend-only changes do not invalidate the Vite or Rust modules. The
+backend version in installed `version.json` describes the whole checkout. The frontend version uses
+the last commit affecting the exact Vite module inputs plus scoped dirty detection, so the displayed
+refs can intentionally differ. `TUNEFORGE_FRONTEND_GIT_REF` overrides only the frontend ref;
+`TUNEFORGE_GIT_REF` overrides the checkout/backend ref.
+
+Every successful build writes the ignored, sanitized
+`packaging/flatpak/generated/cache-report.json`. Override it with
+`FLATPAK_CACHE_REPORT_PATH`. It records cache integrity and usage, timings, and a deterministic
+installed-payload digest without exposing host cache paths.
+
+Use a Linux x86_64 Flatpak host and never-before-used evidence roots for a cold/warm comparison:
+
+```sh
+export FLATPAK_STATE_DIR="$PWD/.flatpak-builder/evidence-state"
+export FLATPAK_CACHE_DIR="$PWD/.flatpak-builder/evidence-cache"
+export FLATPAK_CACHE_EVIDENCE=1
+export FLATPAK_CACHE_REPORT_PATH="$PWD/packaging/flatpak/generated/cache-cold.json"
+pnpm package:linux:flatpak -- --no-bundle
+
+export FLATPAK_CACHE_BASELINE_REPORT="$FLATPAK_CACHE_REPORT_PATH"
+export FLATPAK_CACHE_REPORT_PATH="$PWD/packaging/flatpak/generated/cache-warm.json"
+export FLATPAK_CACHE_COMPARISON_REPORT_PATH="$PWD/packaging/flatpak/generated/cache-comparison.json"
+pnpm package:linux:flatpak -- --no-bundle
+```
+
+Evidence mode bypasses Flatpak's module-result cache while retaining the durable dependency and
+compiler caches. The warm build fails on cache errors, incompatible namespaces, or a changed payload
+digest. `FLATPAK_BUILD_DIR`, `FLATPAK_REPO_DIR`, and `FLATPAK_BUNDLE_PATH` configure output paths.
+
 Flatpak runtime lookups are not host `PATH` lookups. The manifest sets `TUNEFORGE_FFMPEG_PATH=/app/bin/ffmpeg` and `TUNEFORGE_FFPROBE_PATH=/app/bin/ffprobe`; those files are wrappers that search for `ffmpeg` and `ffprobe` inside the sandbox runtime/extension paths. If the runtime does not provide them, the Flatpak build or app reports the missing sandbox binary rather than falling back to the host shell.
 
 Plain Linux packages include ONNX Advanced Chords, beat-this Advanced Beat Analysis, and LV

--- a/packaging/flatpak/com.tuneforge.desktop.yml
+++ b/packaging/flatpak/com.tuneforge.desktop.yml
@@ -36,10 +36,147 @@ cleanup:
   - /share/man
   - /share/pkgconfig
   - /share/tuneforge/node-sources
+  - /share/tuneforge/build
+  - /bin/sccache
   - "*.a"
   - "*.la"
 
 modules:
+  - name: pnpm
+    buildsystem: simple
+    build-options:
+      append-path: /usr/lib/sdk/node26/bin
+    sources:
+      - type: archive
+        url: https://registry.npmjs.org/pnpm/-/pnpm-11.22.0.tgz
+        sha256: 57a97e6f23a3faffc03153a4ef8c770a0552612b8640aebe39bfdd5754d0ebdc
+        dest: pnpm
+    build-commands:
+      - install -dm755 /app/lib/pnpm /app/bin
+      - cp -a pnpm/. /app/lib/pnpm/
+      - ln -sf ../lib/pnpm/bin/pnpm.mjs /app/bin/pnpm
+      - ln -sf ../lib/pnpm/bin/pnpx.mjs /app/bin/pnpx
+      - /app/bin/pnpm --version
+
+  - name: node-sources
+    buildsystem: simple
+    sources:
+      - generated/node-sources.json
+    build-commands:
+      - install -dm755 /app/share/tuneforge/node-sources
+      - cp node-sources/*.tgz /app/share/tuneforge/node-sources/
+
+  - name: tuneforge-frontend
+    buildsystem: simple
+    build-options:
+      append-path: /app/bin:/usr/lib/sdk/node26/bin
+      build-args:
+        - "@@FLATPAK_CACHE_BIND@@"
+      env:
+        HUSKY: "0"
+        TUNEFORGE_VERSION_FILE: /run/build/tuneforge-frontend/frontend-version.json
+    sources:
+      - type: file
+        path: ../../package.json
+      - type: file
+        path: ../../pnpm-lock.yaml
+      - type: file
+        path: ../../pnpm-workspace.yaml
+      - type: file
+        path: ../../scripts/build-info.mjs
+        dest: scripts
+      - type: file
+        path: seed-pnpm-store.mjs
+      - type: file
+        path: ../../apps/desktop/package.json
+        dest: apps/desktop
+      - type: file
+        path: ../../apps/desktop/index.html
+        dest: apps/desktop
+      - type: file
+        path: ../../apps/desktop/tsconfig.json
+        dest: apps/desktop
+      - type: file
+        path: ../../apps/desktop/tsconfig.node.json
+        dest: apps/desktop
+      - type: file
+        path: ../../apps/desktop/vite.config.ts
+        dest: apps/desktop
+      - type: dir
+        path: ../../apps/desktop/src
+        dest: apps/desktop/src
+      - type: file
+        path: ../../packages/shared-types/package.json
+        dest: packages/shared-types
+      - type: dir
+        path: ../../packages/shared-types/src
+        dest: packages/shared-types/src
+      - type: file
+        path: generated/frontend-version.json
+        dest-filename: frontend-version.json
+    build-commands:
+      - node seed-pnpm-store.mjs /app/share/tuneforge/node-sources /run/tuneforge-cache/@@FLATPAK_CACHE_NAMESPACE@@/pnpm/store /run/tuneforge-cache/@@FLATPAK_CACHE_NAMESPACE@@/pnpm/cache /app/bin/pnpm /run/tuneforge-cache/@@FLATPAK_CACHE_NAMESPACE@@/pnpm-report.json
+      - /app/bin/pnpm --filter @tuneforge/desktop build
+      - install -dm755 /app/share/tuneforge/build/frontend-dist
+      - cp -a apps/desktop/dist/. /app/share/tuneforge/build/frontend-dist/
+
+  - name: sccache
+    buildsystem: simple
+    sources:
+      - type: archive
+        url: https://github.com/mozilla/sccache/releases/download/v0.17.0/sccache-v0.17.0-x86_64-unknown-linux-musl.tar.gz
+        sha256: 67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006
+    build-commands:
+      - install -Dm755 sccache /app/bin/sccache
+      - /app/bin/sccache --version
+
+  - name: tuneforge-desktop
+    buildsystem: simple
+    build-options:
+      append-path: /app/bin:/usr/lib/sdk/llvm20/bin:/usr/lib/sdk/rust-stable/bin
+      build-args:
+        - "@@FLATPAK_CACHE_BIND@@"
+      env:
+        CARGO_HOME: /run/build/tuneforge-desktop/cargo-home
+        CARGO_INCREMENTAL: "0"
+        CARGO_NET_OFFLINE: "true"
+        LIBCLANG_PATH: /usr/lib/sdk/llvm20/lib
+        RUSTC_WRAPPER: /app/bin/sccache
+        SCCACHE_DIR: /run/tuneforge-cache/@@FLATPAK_CACHE_NAMESPACE@@/sccache
+        TUNEFORGE_GIT_REF: '@@TUNEFORGE_FRONTEND_GIT_REF@@'
+    sources:
+      - type: file
+        path: ../../apps/desktop/src-tauri/Cargo.lock
+        dest: apps/desktop/src-tauri
+      - type: file
+        path: ../../apps/desktop/src-tauri/Cargo.toml
+        dest: apps/desktop/src-tauri
+      - type: file
+        path: ../../apps/desktop/src-tauri/build.rs
+        dest: apps/desktop/src-tauri
+      - type: file
+        path: ../../apps/desktop/src-tauri/tauri.conf.json
+        dest: apps/desktop/src-tauri
+      - type: dir
+        path: ../../apps/desktop/src-tauri/capabilities
+        dest: apps/desktop/src-tauri/capabilities
+      - type: dir
+        path: ../../apps/desktop/src-tauri/icons
+        dest: apps/desktop/src-tauri/icons
+      - type: dir
+        path: ../../apps/desktop/src-tauri/resources
+        dest: apps/desktop/src-tauri/resources
+      - type: dir
+        path: ../../apps/desktop/src-tauri/src
+        dest: apps/desktop/src-tauri/src
+      - generated/cargo-sources.json
+    build-commands:
+      - install -dm755 apps/desktop/dist
+      - cp -a /app/share/tuneforge/build/frontend-dist/. apps/desktop/dist/
+      - bash cargo-checksums.sh
+      - flock /run/tuneforge-cache/@@FLATPAK_CACHE_NAMESPACE@@/sccache.lock sh -c 'set -eu; sccache --start-server; trap "sccache --stop-server >/dev/null 2>&1 || true" EXIT; sccache --zero-stats; cargo build --release --locked --features custom-protocol --manifest-path apps/desktop/src-tauri/Cargo.toml; sccache --show-stats --stats-format=json > /run/tuneforge-cache/@@FLATPAK_CACHE_NAMESPACE@@/sccache-stats.json.tmp; mv /run/tuneforge-cache/@@FLATPAK_CACHE_NAMESPACE@@/sccache-stats.json.tmp /run/tuneforge-cache/@@FLATPAK_CACHE_NAMESPACE@@/sccache-stats.json'
+      - install -Dm755 apps/desktop/src-tauri/target/release/tuneforge /app/bin/tuneforge
+
   - name: cpython-3.14
     buildsystem: simple
     build-options:
@@ -76,30 +213,6 @@ modules:
       - rm -rf /run/build/python-runtime-deps/.pip-tmp
       - find /app/lib/tuneforge/backend/site-packages -type d -name __pycache__ -prune -exec rm -rf {} +
       - find /app/lib/tuneforge/backend/site-packages -type f -name '*.pyc' -delete
-
-  - name: pnpm
-    buildsystem: simple
-    build-options:
-      append-path: /usr/lib/sdk/node26/bin
-    sources:
-      - type: archive
-        url: https://registry.npmjs.org/pnpm/-/pnpm-11.22.0.tgz
-        sha256: 57a97e6f23a3faffc03153a4ef8c770a0552612b8640aebe39bfdd5754d0ebdc
-        dest: pnpm
-    build-commands:
-      - install -dm755 /app/lib/pnpm /app/bin
-      - cp -a pnpm/. /app/lib/pnpm/
-      - ln -sf ../lib/pnpm/bin/pnpm.mjs /app/bin/pnpm
-      - ln -sf ../lib/pnpm/bin/pnpx.mjs /app/bin/pnpx
-      - /app/bin/pnpm --version
-
-  - name: node-sources
-    buildsystem: simple
-    sources:
-      - generated/node-sources.json
-    build-commands:
-      - install -dm755 /app/share/tuneforge/node-sources
-      - cp node-sources/*.tgz /app/share/tuneforge/node-sources/
 
   - name: pulseaudio-client-tools
     buildsystem: meson
@@ -155,26 +268,13 @@ modules:
       - /share/bash-completion
       - /share/zsh
 
-  - name: tuneforge
+  - name: tuneforge-backend
     buildsystem: simple
     build-options:
-      append-path: /app/bin:/usr/lib/sdk/node26/bin:/usr/lib/sdk/llvm20/bin:/usr/lib/sdk/rust-stable/bin
       env:
-        CARGO_HOME: /run/build/tuneforge/cargo-home
-        CARGO_NET_OFFLINE: "true"
-        HUSKY: "0"
         LD_LIBRARY_PATH: /app/lib/tuneforge/backend/python/lib
-        LIBCLANG_PATH: /usr/lib/sdk/llvm20/lib
         PYTHONPATH: /app/lib/tuneforge/backend/site-packages
-        TUNEFORGE_BUNDLED_BACKEND_ROOT: /app/lib/tuneforge/backend
-        TUNEFORGE_VERSION_FILE: /run/build/tuneforge/version.json
     sources:
-      - type: file
-        path: ../../package.json
-      - type: file
-        path: ../../pnpm-lock.yaml
-      - type: file
-        path: ../../pnpm-workspace.yaml
       - type: file
         path: ../../README.md
       - type: file
@@ -187,57 +287,6 @@ modules:
       - type: file
         path: ../../docs/PACKAGING.md
         dest: docs
-      - type: file
-        path: ../../scripts/build-info.mjs
-        dest: scripts
-      - type: file
-        path: ../../apps/desktop/package.json
-        dest: apps/desktop
-      - type: file
-        path: ../../apps/desktop/index.html
-        dest: apps/desktop
-      - type: file
-        path: ../../apps/desktop/tsconfig.json
-        dest: apps/desktop
-      - type: file
-        path: ../../apps/desktop/tsconfig.node.json
-        dest: apps/desktop
-      - type: file
-        path: ../../apps/desktop/vite.config.ts
-        dest: apps/desktop
-      - type: dir
-        path: ../../apps/desktop/src
-        dest: apps/desktop/src
-      - type: file
-        path: ../../apps/desktop/src-tauri/Cargo.lock
-        dest: apps/desktop/src-tauri
-      - type: file
-        path: ../../apps/desktop/src-tauri/Cargo.toml
-        dest: apps/desktop/src-tauri
-      - type: file
-        path: ../../apps/desktop/src-tauri/build.rs
-        dest: apps/desktop/src-tauri
-      - type: file
-        path: ../../apps/desktop/src-tauri/tauri.conf.json
-        dest: apps/desktop/src-tauri
-      - type: dir
-        path: ../../apps/desktop/src-tauri/capabilities
-        dest: apps/desktop/src-tauri/capabilities
-      - type: dir
-        path: ../../apps/desktop/src-tauri/icons
-        dest: apps/desktop/src-tauri/icons
-      - type: dir
-        path: ../../apps/desktop/src-tauri/resources
-        dest: apps/desktop/src-tauri/resources
-      - type: dir
-        path: ../../apps/desktop/src-tauri/src
-        dest: apps/desktop/src-tauri/src
-      - type: file
-        path: ../../packages/shared-types/package.json
-        dest: packages/shared-types
-      - type: dir
-        path: ../../packages/shared-types/src
-        dest: packages/shared-types/src
       - type: dir
         path: ../../apps/backend/app
         dest: apps/backend/app
@@ -250,7 +299,6 @@ modules:
       - type: file
         path: ../../apps/backend/pyproject.toml
         dest: apps/backend
-      - generated/cargo-sources.json
       - type: file
         path: ffmpeg-wrapper.sh
         dest-filename: ffmpeg
@@ -258,11 +306,18 @@ modules:
         path: ffprobe-wrapper.sh
         dest-filename: ffprobe
       - type: file
-        path: seed-pnpm-store.mjs
-      - type: file
         path: com.tuneforge.desktop.desktop
       - type: file
         path: com.tuneforge.desktop.metainfo.xml
+      - type: file
+        path: ../../apps/desktop/src-tauri/icons/32x32.png
+        dest: icons
+      - type: file
+        path: ../../apps/desktop/src-tauri/icons/128x128.png
+        dest: icons
+      - type: file
+        path: ../../apps/desktop/src-tauri/icons/512x512.png
+        dest: icons
       - type: file
         path: generated/version.json
     build-commands:
@@ -271,12 +326,6 @@ modules:
       - /app/bin/ffmpeg -version
       - /app/bin/ffprobe -version
       - /app/bin/pactl --version
-      - bash cargo-checksums.sh
-      - node seed-pnpm-store.mjs /app/share/tuneforge/node-sources /run/build/tuneforge/pnpm-store /run/build/tuneforge/pnpm-cache /app/bin/pnpm
-      - /app/bin/pnpm --filter @tuneforge/desktop build
-      - rm -rf /app/lib/pnpm /app/bin/pnpm /app/bin/pnpx
-      - cargo build --release --locked --features custom-protocol --manifest-path apps/desktop/src-tauri/Cargo.toml
-      - install -Dm755 apps/desktop/src-tauri/target/release/tuneforge /app/bin/tuneforge
       - install -Dm644 version.json /app/lib/tuneforge/backend/version.json
       - install -dm755 /app/lib/tuneforge/backend/src
       - cp -a apps/backend/app /app/lib/tuneforge/backend/src/app
@@ -290,7 +339,8 @@ modules:
       - install -Dm644 THIRD_PARTY_NOTICES.md /app/share/doc/tuneforge/THIRD_PARTY_NOTICES.md
       - install -Dm644 LICENSES/crema-0.2.0-BSD-2-Clause.txt /app/share/doc/tuneforge/LICENSES/crema-0.2.0-BSD-2-Clause.txt
       - install -Dm644 docs/PACKAGING.md /app/share/doc/tuneforge/PACKAGING.md
-      - install -Dm644 apps/desktop/src-tauri/icons/32x32.png /app/share/icons/hicolor/32x32/apps/com.tuneforge.desktop.png
-      - install -Dm644 apps/desktop/src-tauri/icons/128x128.png /app/share/icons/hicolor/128x128/apps/com.tuneforge.desktop.png
-      - install -Dm644 apps/desktop/src-tauri/icons/512x512.png /app/share/icons/hicolor/512x512/apps/com.tuneforge.desktop.png
+      - install -Dm644 icons/32x32.png /app/share/icons/hicolor/32x32/apps/com.tuneforge.desktop.png
+      - install -Dm644 icons/128x128.png /app/share/icons/hicolor/128x128/apps/com.tuneforge.desktop.png
+      - install -Dm644 icons/512x512.png /app/share/icons/hicolor/512x512/apps/com.tuneforge.desktop.png
       - /app/lib/tuneforge/backend/python/bin/python3.14 -c "import fastapi, demucs, whisper, torch"
+      - rm -rf /app/share/tuneforge/build /app/share/tuneforge/node-sources /app/lib/pnpm /app/bin/pnpm /app/bin/pnpx /app/bin/sccache

--- a/packaging/flatpak/seed-pnpm-store.mjs
+++ b/packaging/flatpak/seed-pnpm-store.mjs
@@ -1,8 +1,13 @@
-import { createReadStream, readFileSync, realpathSync, rmSync, statSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { cpSync, createReadStream, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, statSync, writeFileSync } from "node:fs";
 import http from "node:http";
+import os from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { DatabaseSync } from "node:sqlite";
+
+const pnpmStoreVersion = "v11";
 
 function cleanYamlKey(key) {
   let cleaned = key.trim();
@@ -132,6 +137,116 @@ function resolveTarballs(packages, tarballRoot) {
   }));
 }
 
+export function assertTarballIntegrity(packages, tarballs) {
+  for (const pkg of packages) {
+    const [algorithm, expected] = pkg.integrity.split("-", 2);
+    const tarballPath = tarballs.get(new URL(pkg.url).pathname);
+    if (!algorithm || !expected || !tarballPath || createHash(algorithm).update(readFileSync(tarballPath)).digest("base64") !== expected) {
+      throw new Error(`Flatpak pnpm tarball integrity mismatch: ${pkg.name}@${pkg.version}`);
+    }
+  }
+}
+
+function optionalLstat(filePath) {
+  try {
+    return lstatSync(filePath);
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function assertDirectory(filePath, label) {
+  const stats = optionalLstat(filePath);
+  if (!stats || !stats.isDirectory() || stats.isSymbolicLink()) {
+    throw new Error(`Malformed pnpm ${label}: expected a directory.`);
+  }
+}
+
+function assertRegularFile(filePath, errorMessage) {
+  const stats = optionalLstat(filePath);
+  if (!stats || !stats.isFile() || stats.isSymbolicLink()) throw new Error(errorMessage);
+}
+
+function assertIndexIntegrity(indexPath) {
+  let database;
+  try {
+    database = new DatabaseSync(`${pathToFileURL(indexPath).href}?immutable=1`, { readOnly: true });
+    const rows = database.prepare("PRAGMA integrity_check").all();
+    if (rows.length !== 1 || Object.values(rows[0]).at(0) !== "ok") {
+      throw new Error("pnpm index integrity check did not return ok.");
+    }
+  } catch (error) {
+    throw new Error(`Malformed pnpm index database: ${error.message}`);
+  } finally {
+    database?.close();
+  }
+}
+
+export function validatePnpmStore(storeDir, { requireContent = false } = {}) {
+  assertDirectory(storeDir, "store root");
+  const versionRoot = path.join(storeDir, pnpmStoreVersion);
+  if (!optionalLstat(versionRoot)) {
+    if (readdirSync(storeDir).length !== 0) {
+      throw new Error(`Malformed pnpm store root layout: expected only ${pnpmStoreVersion}.`);
+    }
+    if (requireContent) throw new Error("pnpm store is not populated.");
+    return { pristine: true, contentFiles: 0, indexIntegrity: "empty" };
+  }
+
+  assertDirectory(versionRoot, `${pnpmStoreVersion} store root`);
+  const unexpectedRootEntry = readdirSync(storeDir).find((entry) => entry !== pnpmStoreVersion);
+  if (unexpectedRootEntry) throw new Error(`Malformed pnpm store root layout: ${unexpectedRootEntry}.`);
+  const allowedEntries = new Set(["files", "projects", "index.db", "index.db-shm", "index.db-wal"]);
+  const unexpectedEntry = readdirSync(versionRoot).find((entry) => !allowedEntries.has(entry));
+  if (unexpectedEntry) throw new Error(`Malformed pnpm ${pnpmStoreVersion} store layout: ${unexpectedEntry}.`);
+
+  const filesRoot = path.join(versionRoot, "files");
+  assertDirectory(filesRoot, `${pnpmStoreVersion} content root`);
+  if (optionalLstat(path.join(versionRoot, "projects"))) {
+    assertDirectory(path.join(versionRoot, "projects"), `${pnpmStoreVersion} projects root`);
+  }
+  assertRegularFile(path.join(versionRoot, "index.db"), "Malformed pnpm index database: expected a regular file.");
+  for (const sidecar of ["index.db-shm", "index.db-wal"]) {
+    const sidecarPath = path.join(versionRoot, sidecar);
+    if (optionalLstat(sidecarPath)) assertRegularFile(sidecarPath, `Malformed pnpm index sidecar: ${sidecar}.`);
+  }
+
+  let contentFiles = 0;
+  for (const prefix of readdirSync(filesRoot)) {
+    if (!/^[a-f0-9]{2}$/.test(prefix)) {
+      throw new Error(`Malformed pnpm content directory: ${prefix}.`);
+    }
+    const prefixPath = path.join(filesRoot, prefix);
+    assertDirectory(prefixPath, `content directory ${prefix}`);
+    const entries = readdirSync(prefixPath);
+    for (const entry of entries) {
+      const match = /^([a-f0-9]{126})(-exec)?$/.exec(entry);
+      const entryPath = path.join(prefixPath, entry);
+      const stats = optionalLstat(entryPath);
+      if (!match || !stats?.isFile() || stats.isSymbolicLink()) {
+        throw new Error(`Malformed pnpm content entry: ${prefix}/${entry}.`);
+      }
+      if (match[2] && (stats.mode & 0o111) === 0) {
+        throw new Error(`Malformed pnpm executable content entry: ${prefix}/${entry}.`);
+      }
+      if (!match[2] && (stats.mode & 0o111) !== 0) {
+        throw new Error(`Malformed pnpm non-executable content entry: ${prefix}/${entry}.`);
+      }
+      const digest = createHash("sha512").update(readFileSync(entryPath)).digest("hex");
+      if (digest !== `${prefix}${match[1]}`) {
+        throw new Error(`pnpm content integrity mismatch: ${prefix}/${entry}.`);
+      }
+      contentFiles += 1;
+    }
+  }
+  if (contentFiles === 0) throw new Error("pnpm store is partially initialized without content files.");
+
+  const indexPath = path.join(versionRoot, "index.db");
+  assertIndexIntegrity(indexPath);
+  return { pristine: false, contentFiles, indexIntegrity: "ok" };
+}
+
 function listen(server) {
   return new Promise((resolve, reject) => {
     server.once("error", reject);
@@ -168,9 +283,31 @@ export async function seedPnpmStore({
   storeDir,
   cacheDir,
   pnpmPath = "/app/bin/pnpm",
+  reportPath,
 }) {
   const packages = parsePnpmLock(readFileSync(lockfilePath, "utf8"));
   const tarballs = resolveTarballs(packages, tarballRoot);
+  mkdirSync(storeDir, { recursive: true });
+  mkdirSync(cacheDir, { recursive: true });
+  assertTarballIntegrity(packages, tarballs);
+  const initialStore = validatePnpmStore(storeDir);
+  const frozenStoreArgs = initialStore.pristine ? [] : ["--frozen-store"];
+  let snapshotRoot;
+  let activeStoreDir = storeDir;
+  let activeCacheDir = cacheDir;
+  if (!initialStore.pristine) {
+    snapshotRoot = mkdtempSync(path.join(os.tmpdir(), "tuneforge-pnpm-store-"));
+    activeStoreDir = path.join(snapshotRoot, "store");
+    activeCacheDir = path.join(snapshotRoot, "cache");
+    try {
+      cpSync(storeDir, activeStoreDir, { recursive: true, dereference: false, verbatimSymlinks: true });
+      cpSync(cacheDir, activeCacheDir, { recursive: true, dereference: false, verbatimSymlinks: true });
+    } catch (error) {
+      rmSync(snapshotRoot, { force: true, recursive: true });
+      throw error;
+    }
+  }
+  try {
   const versionsByName = new Map();
   for (const pkg of packages) {
     const versions = versionsByName.get(pkg.name) ?? new Map();
@@ -251,9 +388,11 @@ export async function seedPnpmStore({
   try {
     await run(pnpmPath, [
       `--config.registry=${origin}/`,
-      `--config.store-dir=${storeDir}`,
-      `--config.cache-dir=${cacheDir}`,
+      `--config.store-dir=${activeStoreDir}`,
+      `--config.cache-dir=${activeCacheDir}`,
       "--config.fetch-retries=0",
+      "--config.package-import-method=copy",
+      ...frozenStoreArgs,
       "fetch",
       "--frozen-lockfile",
     ]);
@@ -261,29 +400,51 @@ export async function seedPnpmStore({
     await close(server);
   }
 
+  assertTarballIntegrity(packages, tarballs);
   rmSync(tarballRoot, { recursive: true });
   await run(pnpmPath, [
     `--config.registry=${origin}/`,
-    `--config.store-dir=${storeDir}`,
-    `--config.cache-dir=${cacheDir}`,
+    `--config.store-dir=${activeStoreDir}`,
+    `--config.cache-dir=${activeCacheDir}`,
     "--config.fetch-retries=0",
+    "--config.package-import-method=copy",
+    "--frozen-store",
     "install",
     "--offline",
     "--frozen-lockfile",
   ]);
+  const storeValidation = validatePnpmStore(activeStoreDir, { requireContent: true });
+  await run(pnpmPath, [
+    `--config.store-dir=${activeStoreDir}`,
+    `--config.cache-dir=${activeCacheDir}`,
+    "store",
+    "status",
+  ]);
 
   process.stdout.write(`Installed from an isolated pnpm store with ${packages.length} packages.\n`);
-  return { origin, packageCount: packages.length };
+  const report = {
+    origin: "loopback",
+    packageCount: packages.length,
+    tarballIntegrityChecks: 2,
+    storeIntegrityChecks: 2,
+    storeStatusChecks: 1,
+    ...storeValidation,
+  };
+  if (reportPath) writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+  return { ...report, origin };
+  } finally {
+    if (snapshotRoot) rmSync(snapshotRoot, { force: true, recursive: true });
+  }
 }
 
 async function main() {
-  const [tarballRoot, storeDir, cacheDir, pnpmPath] = process.argv.slice(2);
+  const [tarballRoot, storeDir, cacheDir, pnpmPath, reportPath] = process.argv.slice(2);
   if (!tarballRoot || !storeDir || !cacheDir) {
     throw new Error(
       "Usage: node seed-pnpm-store.mjs <tarball-root> <store-dir> <cache-dir> [pnpm-path]",
     );
   }
-  await seedPnpmStore({ tarballRoot, storeDir, cacheDir, pnpmPath });
+  await seedPnpmStore({ tarballRoot, storeDir, cacheDir, pnpmPath, reportPath });
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/scripts/flatpak-cache.test.mjs
+++ b/scripts/flatpak-cache.test.mjs
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import {
+  cacheNamespace,
+  compareCacheReports,
+  digestBuildPayload,
+  frontendModuleInputPaths,
+  isValidPnpmCacheReport,
+  normalizeGeneratedModelBundleManifest,
+  parseSccacheStats,
+  resolveCacheRoots,
+  resolveFrontendGitRef,
+  resolveSourceDateEpoch,
+} from "./package-flatpak.mjs";
+import { parsePackageOptions } from "./package-options.mjs";
+
+const manifest = readFileSync(
+  new URL("../packaging/flatpak/com.tuneforge.desktop.yml", import.meta.url),
+  "utf8",
+);
+const packageScript = readFileSync(new URL("./package-flatpak.mjs", import.meta.url), "utf8");
+
+function runGit(root, ...args) {
+  const result = spawnSync("git", args, { cwd: root, encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
+function moduleSource(name, nextName) {
+  const start = manifest.indexOf(`  - name: ${name}`);
+  const end = nextName ? manifest.indexOf(`  - name: ${nextName}`, start) : manifest.length;
+  assert.ok(start >= 0 && end > start, `missing module ${name}`);
+  return manifest.slice(start, end);
+}
+
+test("Flatpak cache namespace includes every invalidation dimension", () => {
+  const defaults = parsePackageOptions([], { platform: "linux" });
+  const first = cacheNamespace(defaults, "1.3.0");
+  const second = cacheNamespace(defaults, "1.3.0");
+  const optOut = cacheNamespace(
+    parsePackageOptions(["--no-beat-this"], { platform: "linux" }),
+    "1.3.0",
+  );
+
+  assert.deepEqual(first, second);
+  assert.notEqual(first.name, optOut.name);
+  assert.notEqual(first.name, cacheNamespace(defaults, "1.3.1").name);
+  assert.match(first.name, /^flatpak-cache-v1-[a-f0-9]{16}$/);
+  assert.equal(first.inputs.arch, "x86_64");
+  assert.match(first.inputs.runtime, /org\.gnome\.Platform\/50/);
+  assert.match(first.inputs.tools, /pnpm11\.22\.0-sccache0\.17\.0/);
+});
+
+test("Flatpak state and cache roots reject force-clean overlap and unsafe roots", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-flatpak-roots-"));
+  const output = path.join(root, "build-dir");
+  const valid = resolveCacheRoots({
+    stateRoot: path.join(root, "state"),
+    cacheRoot: path.join(root, "cache"),
+    outputRoots: [output],
+  });
+  assert.equal(valid.stateRoot, path.join(root, "state"));
+  assert.throws(
+    () => resolveCacheRoots({ stateRoot: output, cacheRoot: path.join(root, "cache"), outputRoots: [output] }),
+    /Unsafe Flatpak stateRoot/,
+  );
+  assert.throws(
+    () => resolveCacheRoots({ stateRoot: path.join(root, "same"), cacheRoot: path.join(root, "same", "cache"), outputRoots: [output] }),
+    /must not overlap/,
+  );
+  assert.throws(
+    () => resolveCacheRoots({ stateRoot: path.parse(root).root, cacheRoot: path.join(root, "cache"), outputRoots: [output] }),
+    /Unsafe Flatpak stateRoot/,
+  );
+});
+
+test("source date epoch is validated, stable, and passed to Flatpak builder", () => {
+  assert.equal(resolveSourceDateEpoch({ override: "123" }), "123");
+  assert.throws(() => resolveSourceDateEpoch({ override: "0" }), /SOURCE_DATE_EPOCH/);
+  assert.equal(resolveSourceDateEpoch({ root: mkdtempSync(path.join(os.tmpdir(), "tuneforge-no-git-")), override: undefined }), "1");
+  assert.match(packageScript, /--override-source-date-epoch=\$\{sourceDateEpoch\}/);
+});
+
+test("generated model bundle manifest gets the source date epoch", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-model-manifest-"));
+  const manifestPath = path.join(root, "model-bundle-manifest.json");
+  writeFileSync(manifestPath, `${JSON.stringify({ prepared_at: "2026-08-29T18:21:39.773Z", files: [] })}\n`);
+  assert.equal(normalizeGeneratedModelBundleManifest({ filePath: manifestPath, sourceDateEpoch: "123" }), true);
+  assert.equal(JSON.parse(readFileSync(manifestPath, "utf8")).prepared_at, "1970-01-01T00:02:03.000Z");
+});
+
+test("frontend ref dirtiness is limited to exact frontend module inputs and supports override", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-flatpak-ref-"));
+  runGit(root, "init", "--quiet");
+  runGit(root, "config", "user.email", "test@example.invalid");
+  runGit(root, "config", "user.name", "TuneForge test");
+  runGit(root, "config", "commit.gpgsign", "false");
+  writeFileSync(path.join(root, "frontend.txt"), "frontend\n");
+  writeFileSync(path.join(root, "backend.txt"), "backend\n");
+  runGit(root, "add", ".");
+  runGit(root, "commit", "--quiet", "-m", "fixture");
+  assert.equal(resolveSourceDateEpoch({ root }), runGit(root, "log", "-1", "--format=%ct", "HEAD"));
+  const clean = resolveFrontendGitRef({ root, inputPaths: ["frontend.txt"] });
+
+  writeFileSync(path.join(root, "backend.txt"), "backend dirty\n");
+  assert.equal(resolveFrontendGitRef({ root, inputPaths: ["frontend.txt"] }), clean);
+  runGit(root, "add", "backend.txt");
+  runGit(root, "commit", "--quiet", "-m", "backend only");
+  assert.equal(resolveFrontendGitRef({ root, inputPaths: ["frontend.txt"] }), clean);
+  writeFileSync(path.join(root, "frontend.txt"), "frontend dirty\n");
+  assert.equal(resolveFrontendGitRef({ root, inputPaths: ["frontend.txt"] }), `${clean}-dirty`);
+  runGit(root, "add", "frontend.txt");
+  runGit(root, "commit", "--quiet", "-m", "frontend change");
+  assert.notEqual(resolveFrontendGitRef({ root, inputPaths: ["frontend.txt"] }), clean);
+  assert.equal(resolveFrontendGitRef({ root, override: "release-ref", inputPaths: [] }), "release-ref");
+  assert.deepEqual(frontendModuleInputPaths.slice(0, 3), ["package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml"]);
+});
+
+test("Flatpak modules split frontend, Rust, and backend source boundaries", () => {
+  assert.deepEqual(
+    [...manifest.matchAll(/^  - name: (.+)$/gm)].map((match) => match[1]),
+    [
+      "pnpm",
+      "node-sources",
+      "tuneforge-frontend",
+      "sccache",
+      "tuneforge-desktop",
+      "cpython-3.14",
+      "python-runtime-deps",
+      "pulseaudio-client-tools",
+      "tuneforge-backend",
+    ],
+  );
+  const frontend = moduleSource("tuneforge-frontend", "sccache");
+  const desktop = moduleSource("tuneforge-desktop", "cpython-3.14");
+  const backend = moduleSource("tuneforge-backend");
+  assert.match(frontend, /apps\/desktop\/src/);
+  assert.match(frontend, /frontend-version\.json/);
+  assert.doesNotMatch(frontend, /apps\/backend|src-tauri\/Cargo/);
+  assert.match(desktop, /frontend-dist\/. apps\/desktop\/dist/);
+  assert.match(desktop, /RUSTC_WRAPPER: \/app\/bin\/sccache/);
+  assert.doesNotMatch(desktop, /apps\/backend|apps\/desktop\/src$/m);
+  assert.match(backend, /apps\/backend\/app/);
+  assert.doesNotMatch(backend, /cargo-sources|seed-pnpm-store|vite\.config/);
+  assert.match(manifest, /sccache-v0\.17\.0-x86_64-unknown-linux-musl\.tar\.gz/);
+  assert.match(manifest, /67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006/);
+  assert.match(backend, /rm -rf .*\/app\/bin\/sccache/);
+});
+
+test("sccache JSON stats are normalized and fail closed on malformed or error data", () => {
+  const rawStats = {
+    compile_requests: 12,
+    cache_hits: { counts: { Rust: 7 }, adv_counts: { "Rust/rustc": 7 } },
+    cache_misses: { counts: { Rust: 3 }, adv_counts: { "Rust/rustc": 3 } },
+    cache_errors: { counts: {}, adv_counts: {} },
+    requests_not_cacheable: 2,
+    cache_read_errors: 0,
+    cache_write_errors: 0,
+    compile_fails: 7,
+  };
+  const stats = parseSccacheStats({ stats: rawStats });
+  assert.deepEqual(stats, {
+    compileRequests: 12,
+    cacheHits: 7,
+    cacheMisses: 3,
+    cacheErrors: 0,
+    compileFailures: 7,
+    notCacheable: 2,
+  });
+  assert.throws(() => parseSccacheStats("{"), /Malformed sccache JSON/);
+  assert.throws(
+    () => parseSccacheStats({ stats: { ...rawStats, cache_errors: { counts: { Rust: 1 } } } }),
+    /reported 1 cache errors/,
+  );
+  assert.throws(
+    () => parseSccacheStats({ stats: { ...rawStats, cache_read_errors: 1 } }),
+    /reported 1 cache errors/,
+  );
+  assert.throws(
+    () => parseSccacheStats({ stats: { ...rawStats, cache_write_errors: 1 } }),
+    /reported 1 cache errors/,
+  );
+});
+
+test("pnpm cache reports require explicit durable-store integrity evidence", () => {
+  const report = {
+    origin: "loopback",
+    packageCount: 2,
+    tarballIntegrityChecks: 2,
+    storeIntegrityChecks: 2,
+    storeStatusChecks: 1,
+    contentFiles: 8,
+    indexIntegrity: "ok",
+  };
+  assert.equal(isValidPnpmCacheReport(report), true);
+  assert.equal(isValidPnpmCacheReport({ ...report, contentFiles: 0 }), false);
+});
+
+test("payload digest is metadata-complete, order-stable, and content-sensitive", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-flatpak-digest-"));
+  mkdirSync(path.join(root, "dir"));
+  writeFileSync(path.join(root, "dir", "b"), "two");
+  writeFileSync(path.join(root, "a"), "one");
+  symlinkSync("a", path.join(root, "link"));
+  const first = digestBuildPayload(root);
+  utimesSync(path.join(root, "a"), new Date(1_000), new Date(2_000));
+  assert.deepEqual(digestBuildPayload(root), first);
+  writeFileSync(path.join(root, "a"), "changed");
+  assert.notEqual(digestBuildPayload(root).sha256, first.sha256);
+  assert.equal(first.entryCount, 4);
+});
+
+test("cold and warm reports compare payloads and propagate report errors", () => {
+  const cold = { namespace: "same", payload: { sha256: "abc", entryCount: 4 }, errors: [] };
+  const warm = { namespace: "same", payload: { sha256: "abc", entryCount: 4 }, errors: [] };
+  assert.equal(compareCacheReports(cold, warm).equivalent, true);
+  assert.deepEqual(
+    compareCacheReports(cold, { ...warm, payload: { sha256: "def", entryCount: 4 } }).errors,
+    ["Cold and warm payload digests differ."],
+  );
+  assert.equal(compareCacheReports(cold, { ...warm, errors: ["stats error"] }).equivalent, false);
+  assert.equal(compareCacheReports(cold, { ...warm, namespace: "different" }).equivalent, false);
+});

--- a/scripts/flatpak-pnpm.test.mjs
+++ b/scripts/flatpak-pnpm.test.mjs
@@ -1,22 +1,26 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, copyFileSync, cpSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, readlinkSync, rmSync, writeFileSync } from "node:fs";
 import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import "./flatpak-cache.test.mjs";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import {
+  assertTarballIntegrity,
   nodeTarballFileName,
   parsePnpmLock,
   seedPnpmStore,
+  validatePnpmStore,
 } from "../packaging/flatpak/seed-pnpm-store.mjs";
 
 const flatpakManifest = readFileSync(
   new URL("../packaging/flatpak/com.tuneforge.desktop.yml", import.meta.url),
   "utf8",
 );
+const pnpmSeeder = readFileSync(new URL("../packaging/flatpak/seed-pnpm-store.mjs", import.meta.url), "utf8");
 
 function run(command, args, cwd) {
   const result = spawnSync(command, args, { cwd, encoding: "utf8" });
@@ -29,6 +33,9 @@ function packFixture(root, sources, manifest) {
   mkdirSync(packageRoot, { recursive: true });
   writeFileSync(path.join(packageRoot, "package.json"), `${JSON.stringify(manifest, null, 2)}\n`);
   writeFileSync(path.join(packageRoot, "index.js"), `module.exports = ${JSON.stringify(manifest.name)};\n`);
+  const executablePath = path.join(packageRoot, "bin.js");
+  writeFileSync(executablePath, "#!/usr/bin/env node\n");
+  chmodSync(executablePath, 0o755);
   const fileName = run(
     "npm",
     ["pack", "--cache", path.join(root, "npm-cache"), "--pack-destination", sources],
@@ -43,41 +50,93 @@ function assertServerClosed(origin) {
     const request = http.get(origin, () => reject(new Error(`Registry still accepts requests at ${origin}`)));
     request.setTimeout(1_000, () => request.destroy(new Error("Registry close check timed out")));
     request.once("error", (error) => {
-      if (error.code === "ECONNREFUSED") {
-        resolve();
-        return;
-      }
+      if (error.code === "ECONNREFUSED") return resolve();
       reject(error);
     });
   });
+}
+
+function regularFileInodes(root) {
+  const inodes = new Set();
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      for (const inode of regularFileInodes(entryPath)) inodes.add(inode);
+      continue;
+    }
+    if (entry.isFile()) {
+      const { dev, ino } = lstatSync(entryPath);
+      inodes.add(`${dev}:${ino}`);
+    }
+  }
+  return inodes;
+}
+
+function firstPnpmContentFile(storeDir) {
+  const filesRoot = path.join(storeDir, "v11", "files");
+  for (const prefix of readdirSync(filesRoot)) {
+    const prefixPath = path.join(filesRoot, prefix);
+    for (const entry of readdirSync(prefixPath)) {
+      const entryPath = path.join(prefixPath, entry);
+      if (lstatSync(entryPath).isFile()) return entryPath;
+    }
+  }
+  throw new Error("Fixture pnpm store has no content file.");
+}
+
+function directorySnapshot(root) {
+  const snapshot = new Map();
+  const capture = (directory) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const entryPath = path.join(directory, entry.name);
+      const relativePath = path.relative(root, entryPath);
+      if (entry.isDirectory()) {
+        capture(entryPath);
+      } else if (entry.isFile()) {
+        snapshot.set(relativePath, createHash("sha512").update(readFileSync(entryPath)).digest("hex"));
+      } else if (entry.isSymbolicLink()) {
+        snapshot.set(relativePath, `symlink:${readlinkSync(entryPath)}`);
+      }
+    }
+  };
+  capture(root);
+  return snapshot;
 }
 
 test("Flatpak uses the executable pnpm 11 launcher and an offline frozen install", () => {
   assert.match(flatpakManifest, /org\.freedesktop\.Sdk\.Extension\.node26/);
   assert.match(flatpakManifest, /ln -sf \.\.\/lib\/pnpm\/bin\/pnpm\.mjs \/app\/bin\/pnpm/);
   assert.match(flatpakManifest, /\/app\/bin\/pnpm --version/);
-  assert.match(flatpakManifest, /node seed-pnpm-store\.mjs/);
+  assert.match(flatpakManifest, /pnpm\/store .*pnpm\/cache .*pnpm-report\.json/);
+  assert.equal([...pnpmSeeder.matchAll(/"store",\s*"status"/g)].length, 1);
+  assert.equal([...pnpmSeeder.matchAll(/--config\.package-import-method=copy/g)].length, 2);
+  assert.equal([...pnpmSeeder.matchAll(/--frozen-store/g)].length, 2);
   assert.doesNotMatch(flatpakManifest, /pnpm\.cjs|rewrite-pnpm-lock/);
+});
+
+test("pnpm tarball integrity rejects corrupt offline sources", async (context) => {
+  const fixtureRoot = await mkdtemp(path.join(os.tmpdir(), "tuneforge-flatpak-integrity-"));
+  context.after(() => rm(fixtureRoot, { force: true, recursive: true }));
+  const tarballPath = path.join(fixtureRoot, "fixture.tgz");
+  writeFileSync(tarballPath, "expected");
+  const pkg = { name: "fixture", version: "1.0.0", url: "https://registry.npmjs.org/fixture/-/fixture-1.0.0.tgz", integrity: `sha512-${createHash("sha512").update("expected").digest("base64")}` };
+  const tarballs = new Map([[new URL(pkg.url).pathname, tarballPath]]);
+  assert.doesNotThrow(() => assertTarballIntegrity([pkg], tarballs));
+  writeFileSync(tarballPath, "corrupt");
+  assert.throws(() => assertTarballIntegrity([pkg], tarballs), /integrity mismatch/);
 });
 
 test("pnpm lock parsing maps scoped and peer-suffixed entries to exact tarballs", () => {
   const packages = parsePnpmLock(`lockfileVersion: '9.0'\n\npackages:\n\n  '@scope/peer@1.2.3(peer@2.0.0)':\n    resolution: {integrity: sha512-first}\n\n  '@scope/peer@1.2.3(peer@3.0.0)':\n    resolution: {integrity: sha512-first}\n\n  plain@2.0.0:\n    resolution: {integrity: sha512-second}\n\nsnapshots:\n`);
-
-  assert.deepEqual(
-    packages.map(({ name, version, fileName }) => ({ name, version, fileName })),
-    [
-      { name: "@scope/peer", version: "1.2.3", fileName: "scope-peer-1.2.3.tgz" },
-      { name: "plain", version: "2.0.0", fileName: "plain-2.0.0.tgz" },
-    ],
-  );
+  assert.deepEqual(packages.map(({ name, version, fileName }) => ({ name, version, fileName })), [
+    { name: "@scope/peer", version: "1.2.3", fileName: "scope-peer-1.2.3.tgz" },
+    { name: "plain", version: "2.0.0", fileName: "plain-2.0.0.tgz" },
+  ]);
   assert.equal(nodeTarballFileName("@scope/peer", "1.2.3"), "scope-peer-1.2.3.tgz");
-  assert.throws(
-    () => parsePnpmLock("lockfileVersion: '9.0'\n\npackages:\n\n  '../../escape@1.0.0':\n    resolution: {integrity: sha512-bad}\n"),
-    /Unsafe pnpm package key/,
-  );
+  assert.throws(() => parsePnpmLock("lockfileVersion: '9.0'\n\npackages:\n\n  '../../escape@1.0.0':\n    resolution: {integrity: sha512-bad}\n"), /Unsafe pnpm package key/);
 });
 
-test("pnpm store seeding supports scoped peers and installs after sources are removed", async (context) => {
+test("pnpm store seeding preserves durable warm caches and rejects corrupt stores", async (context) => {
   const fixtureRoot = await mkdtemp(path.join(os.tmpdir(), "tuneforge-flatpak-pnpm-"));
   context.after(() => rm(fixtureRoot, { force: true, recursive: true }));
   const sources = path.join(fixtureRoot, "sources");
@@ -108,6 +167,23 @@ test("pnpm store seeding supports scoped peers and installs after sources are re
     path.join(fixtureRoot, "pnpm-lock.yaml"),
     `lockfileVersion: '9.0'\n\nsettings:\n  autoInstallPeers: true\n  excludeLinksFromLockfile: false\n\nimporters:\n\n  .:\n    dependencies:\n      '@scope/peer-fixture':\n        specifier: 1.0.0\n        version: 1.0.0(plain-fixture@1.0.0)\n      plain-fixture:\n        specifier: 1.0.0\n        version: 1.0.0\n\npackages:\n\n  '@scope/peer-fixture@1.0.0':\n    resolution: {integrity: ${scopedIntegrity}}\n    peerDependencies:\n      plain-fixture: 1.0.0\n\n  plain-fixture@1.0.0:\n    resolution: {integrity: ${plainIntegrity}}\n\nsnapshots:\n\n  '@scope/peer-fixture@1.0.0(plain-fixture@1.0.0)':\n    dependencies:\n      plain-fixture: 1.0.0\n\n  plain-fixture@1.0.0: {}\n`,
   );
+  writeFileSync(path.join(fixtureRoot, ".npmrc"), "package-import-method=hardlink\n");
+  const warmWorkspace = path.join(fixtureRoot, "warm-workspace");
+  const warmSources = path.join(fixtureRoot, "warm-sources");
+  const missingWorkspace = path.join(fixtureRoot, "missing-workspace");
+  const missingSources = path.join(fixtureRoot, "missing-sources");
+  mkdirSync(warmWorkspace);
+  mkdirSync(warmSources);
+  mkdirSync(missingWorkspace);
+  mkdirSync(missingSources);
+  for (const fileName of readdirSync(sources)) copyFileSync(path.join(sources, fileName), path.join(warmSources, fileName));
+  for (const fileName of readdirSync(sources)) copyFileSync(path.join(sources, fileName), path.join(missingSources, fileName));
+  for (const fileName of ["package.json", "pnpm-lock.yaml", ".npmrc"]) {
+    copyFileSync(path.join(fixtureRoot, fileName), path.join(warmWorkspace, fileName));
+    copyFileSync(path.join(fixtureRoot, fileName), path.join(missingWorkspace, fileName));
+  }
+  const storeDir = path.join(fixtureRoot, "store");
+  const cacheDir = path.join(fixtureRoot, "cache");
 
   const previousCwd = process.cwd();
   process.chdir(fixtureRoot);
@@ -115,8 +191,8 @@ test("pnpm store seeding supports scoped peers and installs after sources are re
   try {
     result = await seedPnpmStore({
       tarballRoot: sources,
-      storeDir: path.join(fixtureRoot, "store"),
-      cacheDir: path.join(fixtureRoot, "cache"),
+      storeDir,
+      cacheDir,
       pnpmPath: "pnpm",
     });
   } finally {
@@ -124,6 +200,11 @@ test("pnpm store seeding supports scoped peers and installs after sources are re
   }
 
   assert.equal(result.packageCount, 2);
+  assert.equal(result.tarballIntegrityChecks, 2);
+  assert.equal(result.storeIntegrityChecks, 2);
+  assert.equal(result.storeStatusChecks, 1);
+  assert.ok(result.contentFiles > 0);
+  assert.equal(result.indexIntegrity, "ok");
   assert.equal(existsSync(sources), false);
   assert.match(await readFile(path.join(fixtureRoot, "pnpm-lock.yaml"), "utf8"), /resolution: \{integrity:/);
   assert.doesNotMatch(await readFile(path.join(fixtureRoot, "pnpm-lock.yaml"), "utf8"), /tarball:/);
@@ -131,5 +212,73 @@ test("pnpm store seeding supports scoped peers and installs after sources are re
     JSON.parse(await readFile(path.join(fixtureRoot, "node_modules", "@scope", "peer-fixture", "package.json"))).name,
     "@scope/peer-fixture",
   );
+  const storeInodes = regularFileInodes(storeDir);
+  const installedInodes = regularFileInodes(path.join(fixtureRoot, "node_modules"));
+  assert.deepEqual([...installedInodes].filter((inode) => storeInodes.has(inode)), []);
   await assertServerClosed(result.origin);
+
+  const noProjectsStore = path.join(fixtureRoot, "no-projects-store");
+  cpSync(storeDir, noProjectsStore, { recursive: true });
+  rmSync(path.join(noProjectsStore, "v11", "projects"), { force: true, recursive: true });
+  assert.doesNotThrow(() => validatePnpmStore(noProjectsStore));
+
+  assert.equal(existsSync(path.join(warmWorkspace, "node_modules")), false);
+  const warmSnapshot = directorySnapshot(storeDir);
+  const warmCacheSnapshot = directorySnapshot(cacheDir);
+  process.chdir(warmWorkspace);
+  let warmResult;
+  try {
+    warmResult = await seedPnpmStore({
+      tarballRoot: warmSources,
+      storeDir,
+      cacheDir,
+      pnpmPath: "pnpm",
+    });
+  } finally {
+    process.chdir(previousCwd);
+  }
+  assert.equal(warmResult.contentFiles, result.contentFiles);
+  assert.equal(existsSync(warmSources), false);
+  assert.deepEqual(directorySnapshot(storeDir), warmSnapshot);
+  assert.deepEqual(directorySnapshot(cacheDir), warmCacheSnapshot);
+  const warmInodes = regularFileInodes(path.join(warmWorkspace, "node_modules"));
+  assert.deepEqual([...warmInodes].filter((inode) => storeInodes.has(inode)), []);
+  await assertServerClosed(warmResult.origin);
+
+  const missingBlobStore = path.join(fixtureRoot, "missing-blob-store");
+  cpSync(storeDir, missingBlobStore, { recursive: true });
+  const missingBlobPath = firstPnpmContentFile(missingBlobStore);
+  rmSync(missingBlobPath);
+  const missingCacheSnapshot = directorySnapshot(cacheDir);
+  assert.equal(existsSync(path.join(missingWorkspace, "node_modules")), false);
+  process.chdir(missingWorkspace);
+  try {
+    await assert.rejects(
+      () => seedPnpmStore({
+        tarballRoot: missingSources,
+        storeDir: missingBlobStore,
+        cacheDir,
+        pnpmPath: "pnpm",
+      }),
+    );
+  } finally {
+    process.chdir(previousCwd);
+  }
+  assert.equal(existsSync(missingBlobPath), false);
+  assert.equal(existsSync(missingSources), true);
+  assert.deepEqual(directorySnapshot(cacheDir), missingCacheSnapshot);
+
+  const corruptContentStore = path.join(fixtureRoot, "corrupt-content-store");
+  cpSync(storeDir, corruptContentStore, { recursive: true });
+  const corruptContentPath = firstPnpmContentFile(corruptContentStore);
+  writeFileSync(corruptContentPath, "corrupt content");
+  assert.throws(() => validatePnpmStore(corruptContentStore), /content integrity mismatch/);
+  assert.equal(readFileSync(corruptContentPath, "utf8"), "corrupt content");
+
+  const corruptIndexStore = path.join(fixtureRoot, "corrupt-index-store");
+  cpSync(storeDir, corruptIndexStore, { recursive: true });
+  const corruptIndexPath = path.join(corruptIndexStore, "v11", "index.db");
+  writeFileSync(corruptIndexPath, "corrupt index");
+  assert.throws(() => validatePnpmStore(corruptIndexStore), /Malformed pnpm index database/);
+  assert.equal(readFileSync(corruptIndexPath, "utf8"), "corrupt index");
 });

--- a/scripts/package-flatpak.mjs
+++ b/scripts/package-flatpak.mjs
@@ -1,8 +1,21 @@
-import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import {
+  closeSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readlinkSync,
+  readdirSync,
+  readSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { writeBuildInfoFile } from "./build-info.mjs";
+import { writeBuildInfoFile, writeResolvedBuildInfoFile } from "./build-info.mjs";
 import {
   packageOptionsEnvironment,
   packageOptionsToGeneratorArgs,
@@ -16,8 +29,10 @@ const workspaceRoot = path.resolve(scriptDir, "..");
 const flatpakRoot = path.join(workspaceRoot, "packaging", "flatpak");
 const baseManifestPath = path.join(flatpakRoot, "com.tuneforge.desktop.yml");
 const flatpakVersionInfoPath = path.join(flatpakRoot, "generated", "version.json");
+const frontendVersionInfoPath = path.join(flatpakRoot, "generated", "frontend-version.json");
 const appId = "com.tuneforge.desktop";
 const localRepoRemote = "tuneforge-local";
+const cacheSchema = "flatpak-cache-v1";
 const buildDir = process.env.FLATPAK_BUILD_DIR ?? path.join(flatpakRoot, "build-dir");
 const repoDir = process.env.FLATPAK_REPO_DIR ?? path.join(flatpakRoot, "repo");
 const appVersion = JSON.parse(
@@ -26,6 +41,12 @@ const appVersion = JSON.parse(
 const bundlePath =
   process.env.FLATPAK_BUNDLE_PATH ??
   path.join(flatpakRoot, `Tuneforge_${appVersion}_x86_64.flatpak`);
+export const frontendModuleInputPaths = [
+  "package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml", "scripts/build-info.mjs",
+  "packaging/flatpak/seed-pnpm-store.mjs", "apps/desktop/package.json",
+  "apps/desktop/index.html", "apps/desktop/tsconfig.json", "apps/desktop/tsconfig.node.json",
+  "apps/desktop/vite.config.ts", "apps/desktop/src", "packages/shared-types/package.json", "packages/shared-types/src",
+];
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
@@ -52,10 +73,18 @@ function checkCommand(command, installHint) {
   }
 }
 
-function generatedManifestPath(options) {
+function generatedManifestPath(options, cacheRoot, namespace, frontendGitRef) {
   const generatedManifestPath = path.join(flatpakRoot, "com.tuneforge.desktop.generated.yml");
   const baseManifest = readFileSync(baseManifestPath, "utf8");
   let manifest = manifestWithPackageOptions(baseManifest, options);
+  manifest = manifest
+    .replaceAll('"@@FLATPAK_CACHE_BIND@@"', JSON.stringify(`--bind-mount=/run/tuneforge-cache=${cacheRoot}`))
+    .replaceAll("@@FLATPAK_CACHE_NAMESPACE@@", namespace);
+  manifest = replaceManifestFragment(
+    manifest,
+    "@@TUNEFORGE_FRONTEND_GIT_REF@@",
+    frontendGitRef.replaceAll("'", "''"),
+  );
   if (options.legacyNvidia) {
     manifest = replaceManifestFragment(manifest, "  - --device=dri\n", "  - --device=all\n");
   }
@@ -76,8 +105,10 @@ function generatedManifestPath(options) {
     );
     manifest = replaceManifestFragment(
       manifest,
-      "      - generated/cargo-sources.json\n",
-      "      - generated/cargo-sources.json\n" +
+      "      - type: file\n" +
+        "        path: generated/version.json\n",
+      "      - type: file\n" +
+        "        path: generated/version.json\n" +
         "      - generated/model-bundle-sources.json\n" +
         "      - type: file\n" +
         "        path: generated/model-bundle-manifest.json\n" +
@@ -120,10 +151,12 @@ function generatedManifestPath(options) {
 export function manifestWithPackageOptions(manifest, options) {
   const encodedPackageOptions = packageOptionsEnvironment(options).TUNEFORGE_PACKAGE_OPTIONS;
   const tuneforgeEnvAnchor =
-    "  - name: tuneforge\n" +
+    "  - name: tuneforge-frontend\n" +
     "    buildsystem: simple\n" +
     "    build-options:\n" +
-    "      append-path: /app/bin:/usr/lib/sdk/node26/bin:/usr/lib/sdk/llvm20/bin:/usr/lib/sdk/rust-stable/bin\n" +
+    "      append-path: /app/bin:/usr/lib/sdk/node26/bin\n" +
+    "      build-args:\n" +
+    '        - "@@FLATPAK_CACHE_BIND@@"\n' +
     "      env:\n";
   let result = replaceManifestFragment(
     manifest,
@@ -168,6 +201,163 @@ function replaceManifestFragment(contents, search, replacement) {
     throw new Error(`Could not find expected Flatpak manifest fragment: ${search.trim()}`);
   }
   return contents.replace(search, replacement);
+}
+
+function gitOutput(args, cwd) {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+function validatedSourceDateEpoch(value, label) {
+  const epoch = Number(value);
+  if (typeof value !== "string" || !/^[1-9][0-9]*$/.test(value) || !Number.isSafeInteger(epoch) || epoch > 253402300799) {
+    throw new Error(`${label} must be a positive integer Unix timestamp.`);
+  }
+  return value;
+}
+
+export function resolveSourceDateEpoch({
+  root = workspaceRoot,
+  override = process.env.SOURCE_DATE_EPOCH,
+} = {}) {
+  if (override !== undefined) return validatedSourceDateEpoch(override, "SOURCE_DATE_EPOCH");
+  const commitEpoch = gitOutput(["log", "-1", "--format=%ct", "HEAD"], root);
+  return commitEpoch ? validatedSourceDateEpoch(commitEpoch, "Git HEAD commit timestamp") : "1";
+}
+
+export function normalizeGeneratedModelBundleManifest({
+  filePath = path.join(flatpakRoot, "generated", "model-bundle-manifest.json"),
+  sourceDateEpoch,
+} = {}) {
+  if (!existsSync(filePath)) return false;
+  const manifest = readJson(filePath);
+  if (!manifest || typeof manifest !== "object" || typeof manifest.prepared_at !== "string") throw new Error("Malformed generated model bundle manifest.");
+  const epoch = validatedSourceDateEpoch(sourceDateEpoch, "SOURCE_DATE_EPOCH");
+  manifest.prepared_at = new Date(Number(epoch) * 1_000).toISOString();
+  writeJson(filePath, manifest);
+  return true;
+}
+
+export function resolveFrontendGitRef({
+  root = workspaceRoot,
+  override = process.env.TUNEFORGE_FRONTEND_GIT_REF,
+  inputPaths = frontendModuleInputPaths,
+} = {}) {
+  if (override?.trim()) {
+    return override.trim();
+  }
+  const commit = gitOutput(["log", "-1", "--format=%H", "--", ...inputPaths], root);
+  const base = commit && gitOutput(["describe", "--tags", "--long", "--always", "--abbrev=8", commit], root);
+  if (!base) {
+    return "unknown";
+  }
+  const dirty = gitOutput(["status", "--porcelain=v1", "--untracked-files=all", "--", ...inputPaths], root);
+  return dirty ? `${base}-dirty` : base;
+}
+
+export function cacheNamespace(options, version = appVersion) {
+  const inputs = {
+    schema: cacheSchema,
+    app: `${appId}@${version}`,
+    arch: "x86_64",
+    runtime: "org.gnome.Platform/50",
+    tools: "node26-llvm20-rust-stable-pnpm11.22.0-sccache0.17.0",
+    profile: packageOptionsEnvironment(options).TUNEFORGE_PACKAGE_OPTIONS,
+  };
+  const digest = createHash("sha256").update(JSON.stringify(inputs)).digest("hex").slice(0, 16);
+  return { name: `${cacheSchema}-${digest}`, inputs };
+}
+
+function pathsOverlap(left, right) {
+  const relative = path.relative(path.resolve(left), path.resolve(right));
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+export function resolveCacheRoots({
+  stateRoot = process.env.FLATPAK_STATE_DIR ?? path.join(workspaceRoot, ".flatpak-builder", "tuneforge-state"),
+  cacheRoot = process.env.FLATPAK_CACHE_DIR ?? path.join(workspaceRoot, ".flatpak-builder", "tuneforge-cache"),
+  outputRoots = [buildDir, repoDir],
+} = {}) {
+  const roots = { stateRoot: path.resolve(stateRoot), cacheRoot: path.resolve(cacheRoot) };
+  const unsafe = [path.parse(workspaceRoot).root, workspaceRoot, flatpakRoot, process.env.HOME].filter(Boolean);
+  for (const [label, root] of Object.entries(roots)) {
+    if (unsafe.includes(root) || outputRoots.some((output) => pathsOverlap(root, output) || pathsOverlap(output, root))) {
+      throw new Error(`Unsafe Flatpak ${label}: it overlaps a packaging or force-clean output root.`);
+    }
+  }
+  if (pathsOverlap(roots.stateRoot, roots.cacheRoot) || pathsOverlap(roots.cacheRoot, roots.stateRoot)) {
+    throw new Error("FLATPAK_STATE_DIR and FLATPAK_CACHE_DIR must not overlap.");
+  }
+  return roots;
+}
+
+function numericTotal(value, label) {
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) return value;
+  if (value && typeof value === "object") {
+    return Object.values(value).reduce((total, entry) => total + numericTotal(entry, label), 0);
+  }
+  throw new Error(`Malformed sccache ${label} statistics.`);
+}
+
+export function parseSccacheStats(contents) {
+  let parsed;
+  try {
+    parsed = typeof contents === "string" ? JSON.parse(contents) : contents;
+  } catch {
+    throw new Error("Malformed sccache JSON statistics.");
+  }
+  const stats = parsed?.stats ?? parsed;
+  if (!stats || typeof stats !== "object") throw new Error("Malformed sccache JSON statistics.");
+  const metrics = {
+    compileRequests: numericTotal(stats.compile_requests, "compile_requests"),
+    cacheHits: numericTotal(stats.cache_hits?.counts ?? stats.cache_hits, "cache_hits"),
+    cacheMisses: numericTotal(stats.cache_misses?.counts ?? stats.cache_misses, "cache_misses"),
+    cacheErrors: numericTotal(stats.cache_errors?.counts ?? stats.cache_errors, "cache_errors") + numericTotal(stats.cache_read_errors ?? 0, "cache_read_errors") + numericTotal(stats.cache_write_errors ?? 0, "cache_write_errors"),
+    compileFailures: numericTotal(stats.compile_fails ?? 0, "compile_fails"),
+    notCacheable: numericTotal(stats.requests_not_cacheable ?? 0, "requests_not_cacheable"),
+  };
+  if (metrics.cacheErrors !== 0) throw new Error(`sccache reported ${metrics.cacheErrors} cache errors.`);
+  return metrics;
+}
+
+function fileSha256(filePath) {
+  const hash = createHash("sha256");
+  const descriptor = openSync(filePath, "r");
+  const buffer = Buffer.allocUnsafe(1024 * 1024);
+  try {
+    for (let bytes = readSync(descriptor, buffer, 0, buffer.length, null); bytes > 0;
+      bytes = readSync(descriptor, buffer, 0, buffer.length, null)) hash.update(buffer.subarray(0, bytes));
+  } finally {
+    closeSync(descriptor);
+  }
+  return hash.digest("hex");
+}
+
+export function digestBuildPayload(root) {
+  const entries = [];
+  function visit(relativePath) {
+    const absolutePath = path.join(root, relativePath);
+    const stats = lstatSync(absolutePath);
+    const entry = { path: relativePath.split(path.sep).join("/"), mode: (stats.mode & 0o7777).toString(8) };
+    if (stats.isSymbolicLink()) entries.push({ ...entry, type: "symlink", target: readlinkSync(absolutePath) });
+    else if (stats.isDirectory()) {
+      entries.push({ ...entry, type: "directory" });
+      for (const child of readdirSync(absolutePath).sort()) visit(path.join(relativePath, child));
+    } else if (stats.isFile()) entries.push({ ...entry, type: "file", size: stats.size, sha256: fileSha256(absolutePath) });
+    else throw new Error(`Unsupported Flatpak payload entry type: ${relativePath}`);
+  }
+  for (const child of readdirSync(root).sort()) visit(child);
+  return {
+    sha256: createHash("sha256").update(JSON.stringify(entries)).digest("hex"),
+    entryCount: entries.length,
+  };
+}
+
+export function compareCacheReports(cold, warm) {
+  const errors = [...(cold.errors ?? []), ...(warm.errors ?? [])];
+  if (cold.namespace !== warm.namespace) errors.push("Cold and warm cache namespaces differ.");
+  if (cold.payload?.sha256 !== warm.payload?.sha256) errors.push("Cold and warm payload digests differ.");
+  return { schema: cacheSchema, equivalent: errors.length === 0, errors, cold: cold.payload, warm: warm.payload };
 }
 
 function bytesToMiB(bytes) {
@@ -216,9 +406,58 @@ function printPythonWheelSizeReport() {
   }
 }
 
+function readJson(targetPath) {
+  return JSON.parse(readFileSync(targetPath, "utf8"));
+}
+
+function writeJson(targetPath, value) {
+  mkdirSync(path.dirname(targetPath), { recursive: true });
+  writeFileSync(targetPath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function isValidPnpmCacheReport(pnpm) {
+  return Boolean(
+    pnpm &&
+    pnpm.origin === "loopback" &&
+    Number.isInteger(pnpm.packageCount) && pnpm.packageCount >= 1 &&
+    pnpm.tarballIntegrityChecks === 2 &&
+    pnpm.storeIntegrityChecks === 2 &&
+    pnpm.storeStatusChecks === 1 &&
+    Number.isInteger(pnpm.contentFiles) && pnpm.contentFiles >= 1 &&
+    pnpm.indexIntegrity === "ok",
+  );
+}
+
+function cacheReport({ namespace, inputs, cacheRoot, timings, evidence }) {
+  const namespaceRoot = path.join(cacheRoot, namespace);
+  const pnpmPath = path.join(namespaceRoot, "pnpm-report.json");
+  const sccachePath = path.join(namespaceRoot, "sccache-stats.json");
+  const pnpm = existsSync(pnpmPath) ? readJson(pnpmPath) : null;
+  const sccache = existsSync(sccachePath) ? parseSccacheStats(readFileSync(sccachePath, "utf8")) : null;
+  if (evidence && (!pnpm || !sccache)) {
+    throw new Error("Flatpak cache evidence mode requires frontend and desktop modules to execute.");
+  }
+  if (pnpm && !isValidPnpmCacheReport(pnpm)) {
+    throw new Error("Malformed Flatpak pnpm integrity report.");
+  }
+  return {
+    schema: cacheSchema,
+    namespace,
+    namespaceInputs: inputs,
+    modules: { frontend: pnpm ? "executed" : "cached", desktop: sccache ? "executed" : "cached" },
+    pnpm: pnpm ?? { status: "module-cached" },
+    sccache: sccache ?? { status: "module-cached" },
+    timings,
+    payload: digestBuildPayload(path.join(buildDir, "files")),
+    errors: [],
+  };
+}
+
 function main() {
+  const startedAt = performance.now();
   const packageOptions = parsePackageOptions(process.argv.slice(2), { platform: "linux" });
   const skipBundle = packageOptions.noBundle || process.env.FLATPAK_NO_BUNDLE === "1";
+  const evidence = process.env.FLATPAK_CACHE_EVIDENCE === "1";
   if (process.arch !== "x64") {
     throw new Error("TuneForge Flatpak packaging currently targets Linux x86_64 only.");
   }
@@ -229,12 +468,32 @@ function main() {
     printModelBundleWarning();
   }
 
+  const namespace = cacheNamespace(packageOptions);
+  const sourceDateEpoch = resolveSourceDateEpoch();
+  const { stateRoot, cacheRoot } = resolveCacheRoots();
+  const stateDir = path.join(stateRoot, namespace.name);
+  const namespaceRoot = path.join(cacheRoot, namespace.name);
+  mkdirSync(stateDir, { recursive: true });
+  mkdirSync(namespaceRoot, { recursive: true });
+  rmSync(path.join(namespaceRoot, "pnpm-report.json"), { force: true });
+  rmSync(path.join(namespaceRoot, "sccache-stats.json"), { force: true });
+
+  const sourceStartedAt = performance.now();
   run(process.execPath, [
     path.join("scripts", "generate-flatpak-sources.mjs"),
     ...packageOptionsToGeneratorArgs(packageOptions),
   ]);
-  writeBuildInfoFile(flatpakVersionInfoPath, { workspaceRoot });
-  const manifestPath = generatedManifestPath(packageOptions);
+  normalizeGeneratedModelBundleManifest({ sourceDateEpoch });
+  const frontendGitRef = resolveFrontendGitRef();
+  const installedBuildInfo = writeBuildInfoFile(flatpakVersionInfoPath, { workspaceRoot });
+  installedBuildInfo.frontend.git_ref = frontendGitRef;
+  writeResolvedBuildInfoFile(flatpakVersionInfoPath, installedBuildInfo);
+  writeResolvedBuildInfoFile(frontendVersionInfoPath, {
+    backend: { ...installedBuildInfo.frontend },
+    frontend: { ...installedBuildInfo.frontend },
+  });
+  const manifestPath = generatedManifestPath(packageOptions, cacheRoot, namespace.name, frontendGitRef);
+  const sourceSeconds = (performance.now() - sourceStartedAt) / 1_000;
 
   checkCommand(
     "flatpak-builder",
@@ -242,8 +501,10 @@ function main() {
   );
   checkCommand("flatpak", "Install flatpak before running pnpm package:linux:flatpak.");
 
-  run("flatpak-builder", [
+  const builderArgs = [
     "--force-clean",
+    `--state-dir=${stateDir}`,
+    `--override-source-date-epoch=${sourceDateEpoch}`,
     "--arch=x86_64",
     "--default-branch=stable",
     "--install-deps-from=flathub",
@@ -251,7 +512,31 @@ function main() {
     repoDir,
     buildDir,
     manifestPath,
-  ]);
+  ];
+  if (evidence) builderArgs.unshift("--disable-cache");
+  const builderStartedAt = performance.now();
+  run("flatpak-builder", builderArgs);
+  const report = cacheReport({
+    namespace: namespace.name,
+    inputs: namespace.inputs,
+    cacheRoot,
+    evidence,
+    timings: {
+      sourceGenerationSeconds: Number(sourceSeconds.toFixed(3)),
+      builderSeconds: Number(((performance.now() - builderStartedAt) / 1_000).toFixed(3)),
+      elapsedSeconds: Number(((performance.now() - startedAt) / 1_000).toFixed(3)),
+    },
+  });
+  const reportPath = process.env.FLATPAK_CACHE_REPORT_PATH ?? path.join(flatpakRoot, "generated", "cache-report.json");
+  writeJson(reportPath, report);
+  const baselinePath = process.env.FLATPAK_CACHE_BASELINE_REPORT;
+  if (baselinePath) {
+    const comparison = compareCacheReports(readJson(baselinePath), report);
+    const comparisonPath = process.env.FLATPAK_CACHE_COMPARISON_REPORT_PATH ??
+      path.join(flatpakRoot, "generated", "cache-comparison-report.json");
+    writeJson(comparisonPath, comparison);
+    if (!comparison.equivalent) throw new Error(comparison.errors.join(" "));
+  }
   printAppDirectorySizeReport();
   printPythonWheelSizeReport();
   if (skipBundle) {

--- a/scripts/package-options.test.mjs
+++ b/scripts/package-options.test.mjs
@@ -29,7 +29,7 @@ const flatpakPipTmpDir = "/run/build/python-runtime-deps/.pip-tmp";
 function pythonRuntimeDepsModule(manifest) {
   return manifest.slice(
     manifest.indexOf("  - name: python-runtime-deps"),
-    manifest.indexOf("  - name: pnpm"),
+    manifest.indexOf("  - name: pulseaudio-client-tools"),
   );
 }
 
@@ -157,13 +157,16 @@ test("Flatpak package options are scoped to the TuneForge module build environme
     manifest.indexOf("  - name: cpython-3.14"),
     manifest.indexOf("  - name: python-runtime-deps"),
   );
-  const tuneforgeModule = manifest.slice(manifest.indexOf("  - name: tuneforge"));
+  const frontendModule = manifest.slice(
+    manifest.indexOf("  - name: tuneforge-frontend"),
+    manifest.indexOf("  - name: sccache"),
+  );
 
   assert.equal(cpythonModule.includes("TUNEFORGE_PACKAGE_OPTIONS"), false);
-  assert.equal((tuneforgeModule.match(/\n    build-options:/g) ?? []).length, 1);
+  assert.equal((frontendModule.match(/\n    build-options:/g) ?? []).length, 1);
   assert.equal((manifest.match(/TUNEFORGE_PACKAGE_OPTIONS:/g) ?? []).length, 1);
   assert.match(
-    tuneforgeModule,
+    frontendModule,
     /      env:\n        TUNEFORGE_PACKAGE_OPTIONS: '.*"beatThis":false.*'/,
   );
   assert.match(manifest, /path: generated\/python-build-requirements\.txt/);


### PR DESCRIPTION
## Summary

- Add durable, integrity-checked pnpm and sccache caches with deterministic namespaces and evidence reports.
- Split Flatpak modules so frontend, Rust, dependencies, and backend invalidate independently while builds remain offline.
- Make cold and warm installed payloads deterministic. Closes #489.

## Testing

- `node --check scripts/package-flatpak.mjs`
- `node --check packaging/flatpak/seed-pnpm-store.mjs`
- `node --test scripts/flatpak-cache.test.mjs scripts/package-options.test.mjs`
- `node --test scripts/flatpak-pnpm.test.mjs`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- Linux x86_64 cold/warm `pnpm package:linux:flatpak -- --no-bundle`: identical payload digest, 668 warm sccache hits, zero cache errors.
- Linux x86_64 cold/warm `pnpm package:linux:flatpak -- --legacy-nvidia --no-bundle`: identical payload digest, 668 warm sccache hits, zero cache errors.
