### PR TITLE
feat(flatpak): ship CPU-only base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ download, installation, verification, signature, and publication instructions.
 - Upgraded the desktop backend to Python 3.14 and refreshed its dependency graph.
 - Made the ONNX implementation the sole Advanced Chords runtime while preserving its engine ID,
   default selection, package aliases, and pinned model; removed Crema, TensorFlow, and Keras.
+- Made default Flatpak packages resolve official CPU-only PyTorch 2.13.0 and torchaudio 2.11.0,
+  while retaining the explicit legacy NVIDIA CUDA 12.6 package path and adding size evidence.
 
 ## [1.3.0] - 2026-08-28
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -48,13 +48,13 @@ This file is the source of truth for dependency and model-weight distribution po
 
 - **License:** BSD-3-Clause
 - **Source:** <https://github.com/pytorch/pytorch>
-- **Notes:** The default Linux Flatpak uses the locked PyTorch runtime. The `--legacy-nvidia` Linux package option swaps in the legacy NVIDIA CUDA 12.6 PyTorch and torchaudio wheels for older supported NVIDIA GPUs. Its local verifier confirms wheel and CUDA-runtime versions, not GPU inference on every driver/hardware combination.
+- **Notes:** The default Linux Flatpak resolves official CPU-only PyTorch 2.13.0 and torchaudio 2.11.0 wheels for Python 3.14 x86_64 manylinux. The `--legacy-nvidia` Linux package option retains the NVIDIA CUDA 12.6 wheel closure for older supported NVIDIA GPUs. Its local verifier confirms wheel and CUDA-runtime versions, not GPU inference on every driver/hardware combination.
 
 ### NVIDIA CUDA runtime wheels
 
 - **License:** NVIDIA Software License Agreement and related NVIDIA component terms; see each wheel's bundled license metadata.
 - **Source:** <https://download.pytorch.org/whl/cu126/> and NVIDIA CUDA component packages on PyPI.
-- **Notes:** The `--legacy-nvidia` Linux package option redistributes the CUDA 12.6 runtime wheel set pulled by PyTorch 2.13.0+cu126 and torchaudio 2.11.0+cu126, including cuBLAS, cuDNN, cuFFT, cuSOLVER, cuSPARSE, NCCL, NVRTC, NVTX, and related runtime libraries.
+- **Notes:** Only the `--legacy-nvidia` Linux package option redistributes the CUDA 12.6 runtime wheel set pulled by PyTorch 2.13.0+cu126 and torchaudio 2.11.0+cu126, including cuBLAS, cuDNN, cuFFT, cuSOLVER, cuSPARSE, NCCL, NVRTC, NVTX, and related runtime libraries. Default Flatpaks reject CUDA, NVIDIA, and Triton packages from their generated Python closure.
 
 ### librosa
 

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -274,7 +274,7 @@ pnpm package:linux -- --crema-onnx --model-bundle
 - `--model-bundle` includes required Demucs and Whisper weights, plus beat-this `small0` when beat-this dependencies are included. Advanced Chords model/state files are always included when that engine is enabled.
 - `--sandbox-data` keeps app data under Flatpak-private `/var/data/tuneforge` instead of the host XDG data directory.
 
-Like macOS packages, plain Flatpak packages rely on normal Demucs, Whisper, and beat-this caches unless `--model-bundle` is explicitly passed. Advanced Chords always includes and seeds the exact pinned ONNX model and runtime-state files. Packages omit the Crema Python package, TensorFlow, Keras, and their HDF5 closure but retain LV Chordia's separately declared `h5py` dependency.
+Like macOS packages, plain Flatpak packages rely on normal Demucs, Whisper, and beat-this caches unless `--model-bundle` is explicitly passed. The default Flatpak resolves official CPU-only PyTorch and torchaudio wheels for its Linux x86_64 Python runtime; its generated closure rejects CUDA, NVIDIA, and Triton packages. `--legacy-nvidia` retains the legacy CUDA closure for older supported NVIDIA GPUs. Advanced Chords always includes and seeds the exact pinned ONNX model and runtime-state files. Packages omit the Crema Python package, TensorFlow, Keras, and their HDF5 closure but retain LV Chordia's separately declared `h5py` dependency.
 When beat-this is excluded, desktop actions explicitly select Built-in Beat Analysis. An Advanced
 Beat Analysis request that ultimately fails during first-use download, load, runtime, or timing
 analysis fails the job rather than switching engines; explicit Built-in Beat Analysis requests do
@@ -300,6 +300,14 @@ Without `--no-bundle`, the Flatpak bundle is written under `packaging/flatpak/` 
 
 ## Size Expectations
 
-Linux Flatpak bundles are large because the default package includes Torch, NVIDIA CUDA Python wheels, beat-this, and the LV Chordia runtime. ONNX Advanced Chords is materially smaller than the removed TensorFlow stack. Report LV Chordia source/runtime bytes separately from its fixed 28,730,939 checkpoint bytes. `--legacy-nvidia` swaps in CUDA 12.6 runtime wheels, and `--model-bundle` adds other reviewed model weights.
+Linux Flatpak bundles are large because they include Torch, beat-this, and the LV Chordia runtime. ONNX Advanced Chords is materially smaller than the removed TensorFlow stack. Report LV Chordia source/runtime bytes separately from its fixed 28,730,939 checkpoint bytes. `--legacy-nvidia` adds CUDA 12.6 runtime wheels, and `--model-bundle` adds other reviewed model weights.
 
-Packaging prints a size report for the built `/app` tree and selected Python artifacts. Use that report to distinguish accidental copied build inputs from expected ML runtime payloads.
+Every Flatpak build writes an ignored structured size report at
+`packaging/flatpak/generated/size-report.json` (override with `FLATPAK_SIZE_REPORT_PATH`). It uses
+bytes, includes the compressed bundle when produced, installed `/app`, Python runtime,
+site-packages, separate wheel-input and source-archive entries, and descending `/app` top-level
+directories. Each Python input group reports `knownBytes`, `unknownCount`, and `complete`; a partial
+known-byte sum is never a total. A normal bundle
+fails at 2 GiB or more and meets the issue target only at 1.9 GiB or less; a 1.9–2 GiB bundle is
+buildable but leaves that target incomplete. `--no-bundle` records installed-size evidence with the
+compressed bundle unavailable and makes no bundle-compliance claim.

--- a/scripts/flatpak-cache.test.mjs
+++ b/scripts/flatpak-cache.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
@@ -8,6 +8,8 @@ import {
   cacheNamespace,
   compareCacheReports,
   digestBuildPayload,
+  enforceFlatpakBundleSize,
+  flatpakSizeReport,
   frontendModuleInputPaths,
   isValidPnpmCacheReport,
   normalizeGeneratedModelBundleManifest,
@@ -224,4 +226,83 @@ test("cold and warm reports compare payloads and propagate report errors", () =>
   );
   assert.equal(compareCacheReports(cold, { ...warm, errors: ["stats error"] }).equivalent, false);
   assert.equal(compareCacheReports(cold, { ...warm, namespace: "different" }).equivalent, false);
+});
+
+test("Flatpak size report is deterministic, byte-based, and has no compliance claim without a bundle", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-flatpak-size-"));
+  const buildRoot = path.join(root, "build");
+  const appRoot = path.join(buildRoot, "files");
+  const wheelReportPath = path.join(root, "python-size-report.json");
+  try {
+    mkdirSync(path.join(appRoot, "lib", "tuneforge", "backend", "python"), { recursive: true });
+    mkdirSync(path.join(appRoot, "lib", "tuneforge", "backend", "site-packages"), { recursive: true });
+    mkdirSync(path.join(appRoot, "share"), { recursive: true });
+    writeFileSync(path.join(appRoot, "lib", "tuneforge", "backend", "python", "python3.14"), "runtime");
+    writeFileSync(path.join(appRoot, "lib", "tuneforge", "backend", "site-packages", "torch.py"), "torch");
+    writeFileSync(path.join(appRoot, "share", "small"), "x");
+    writeFileSync(
+      wheelReportPath,
+      `${JSON.stringify([
+        { name: "torch", version: "2.13.0", fileName: "torch.whl", size: 12 },
+        { name: "torchaudio", version: "2.11.0", fileName: "torchaudio.whl", size: null },
+        { name: "source-only", version: "1.0.0", fileName: "source-only-1.0.0.tar.gz", size: 8 },
+      ])}\n`,
+    );
+
+    const first = flatpakSizeReport({ buildRoot, wheelReportPath, includeBundle: false });
+    const second = flatpakSizeReport({ buildRoot, wheelReportPath, includeBundle: false });
+    assert.deepEqual(second, first);
+    assert.equal(first.unit, "bytes");
+    assert.equal(first.compressedBundle.available, false);
+    assert.equal(first.compliance, undefined);
+    assert.equal(first.wheelInputs.knownBytes, 12);
+    assert.equal(first.wheelInputs.unknownCount, 1);
+    assert.equal(first.wheelInputs.complete, false);
+    assert.equal(first.wheelInputs.entries.length, 2);
+    assert.deepEqual(first.sourceArchives, {
+      knownBytes: 8,
+      unknownCount: 0,
+      complete: true,
+      entries: [{ name: "source-only", version: "1.0.0", fileName: "source-only-1.0.0.tar.gz", bytes: 8 }],
+    });
+    assert.deepEqual(first.installedApp.topLevelDirectories.map((entry) => entry.path), ["/app/lib", "/app/share"]);
+    assert.equal(first.pythonRuntime.path, "/app/lib/tuneforge/backend/python");
+    assert.equal(first.sitePackages.path, "/app/lib/tuneforge/backend/site-packages");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Flatpak bundle size gate hard-fails only at 2 GiB or above", () => {
+  const belowHardLimit = {
+    compressedBundle: { available: true, bytes: 2 * 1024 ** 3 - 1 },
+    compliance: { targetMet: true },
+  };
+  assert.doesNotThrow(() => enforceFlatpakBundleSize(belowHardLimit));
+  assert.throws(
+    () => enforceFlatpakBundleSize({ ...belowHardLimit, compressedBundle: { available: true, bytes: 2 * 1024 ** 3 } }),
+    /2 GiB hard limit/,
+  );
+});
+
+test("Flatpak bundle size follows a symlink target and requires a regular file", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tuneforge-flatpak-bundle-"));
+  const target = path.join(root, "bundle.flatpak");
+  const link = path.join(root, "configured-output.flatpak");
+  try {
+    writeFileSync(target, "bundle-target");
+    symlinkSync(path.basename(target), link);
+    const report = flatpakSizeReport({ buildRoot: path.join(root, "build"), bundle: link });
+    assert.deepEqual(report.compressedBundle, {
+      path: "configured-output.flatpak",
+      available: true,
+      bytes: Buffer.byteLength("bundle-target"),
+    });
+    assert.throws(
+      () => flatpakSizeReport({ buildRoot: path.join(root, "build"), bundle: root }),
+      /must be a regular file/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/scripts/generate-flatpak-sources.mjs
+++ b/scripts/generate-flatpak-sources.mjs
@@ -523,6 +523,31 @@ function resolveLegacyTorchPackages() {
   return parsePylock(readRequiredFile(pylockPath));
 }
 
+function resolveCpuTorchPackages() {
+  const requirementsPath = path.join(generatedRoot, "python-cpu-torch.in");
+  const pylockPath = path.join(generatedRoot, "pylock.cpu-torch.toml");
+  writeGeneratedFile("python-cpu-torch.in", "torch==2.13.0\ntorchaudio==2.11.0\n");
+  run("uv", [
+    "--quiet",
+    "pip",
+    "compile",
+    requirementsPath,
+    "--python-version",
+    "3.14",
+    "--python-platform",
+    "x86_64-manylinux_2_28",
+    "--torch-backend",
+    "cpu",
+    "--format",
+    "pylock.toml",
+    "--output-file",
+    pylockPath,
+    "--no-header",
+    "--no-annotate",
+  ]);
+  return parsePylock(readRequiredFile(pylockPath));
+}
+
 function isLegacyTorchPackage(packageName) {
   return (
     packageName === "torch" ||
@@ -549,12 +574,23 @@ export function mergeLegacyTorchPackageSets(packages, legacyPackages) {
   return Array.from(merged.values()).sort((left, right) => packageIdentity(left).localeCompare(packageIdentity(right)));
 }
 
+export function assertDefaultCpuTorchClosure(packages) {
+  const unwanted = packages
+    .map((pkg) => normalizePackageName(pkg.name))
+    .filter((name) => name === "triton" || name.startsWith("cuda-") || name.startsWith("nvidia-"));
+  if (unwanted.length > 0) {
+    throw new Error(`Default Flatpak CPU Torch closure includes unsupported packages: ${unwanted.join(", ")}`);
+  }
+}
+
 function generatePythonSources() {
   const lockedPackages = parseUvLock(readRequiredFile(uvLockPath));
   let runtimePackages = resolvePythonRuntimePackages(lockedPackages, { extras: selectedPythonExtras });
-  if (packageOptions.legacyNvidia) {
-    runtimePackages = mergeLegacyTorchPackageSets(runtimePackages, resolveLegacyTorchPackages());
-  }
+  runtimePackages = mergeLegacyTorchPackageSets(
+    runtimePackages,
+    packageOptions.legacyNvidia ? resolveLegacyTorchPackages() : resolveCpuTorchPackages(),
+  );
+  if (!packageOptions.legacyNvidia) assertDefaultCpuTorchClosure(runtimePackages);
   const buildRequirementNames = ["setuptools", "wheel", ...(packageOptions.lvChordia ? ["hatchling"] : [])];
   const buildPackages = resolveNamedPythonPackages(lockedPackages, buildRequirementNames);
   const runtimePackageNames = new Set(runtimePackages.map((pkg) => packageIdentity(pkg)));

--- a/scripts/package-flatpak.mjs
+++ b/scripts/package-flatpak.mjs
@@ -10,6 +10,7 @@ import {
   readdirSync,
   readSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
@@ -33,6 +34,10 @@ const frontendVersionInfoPath = path.join(flatpakRoot, "generated", "frontend-ve
 const appId = "com.tuneforge.desktop";
 const localRepoRemote = "tuneforge-local";
 const cacheSchema = "flatpak-cache-v1";
+const sizeReportSchema = "flatpak-size-v1";
+const gibibyte = 1024 ** 3;
+const flatpakBundleHardLimitBytes = 2 * gibibyte;
+const flatpakBundleTargetBytes = 1.9 * gibibyte;
 const buildDir = process.env.FLATPAK_BUILD_DIR ?? path.join(flatpakRoot, "build-dir");
 const repoDir = process.env.FLATPAK_REPO_DIR ?? path.join(flatpakRoot, "repo");
 const appVersion = JSON.parse(
@@ -360,7 +365,8 @@ export function compareCacheReports(cold, warm) {
   return { schema: cacheSchema, equivalent: errors.length === 0, errors, cold: cold.payload, warm: warm.payload };
 }
 
-function bytesToMiB(bytes) {
+function bytesToBinaryUnit(bytes) {
+  if (bytes >= gibibyte) return `${(bytes / gibibyte).toFixed(2)} GiB`;
   return `${(bytes / 1024 / 1024).toFixed(1)} MiB`;
 }
 
@@ -375,34 +381,96 @@ function directorySize(targetPath) {
   );
 }
 
-function printAppDirectorySizeReport() {
-  const appFilesRoot = path.join(buildDir, "files");
-  if (!existsSync(appFilesRoot)) {
-    return;
-  }
-  const rows = readdirSync(appFilesRoot)
+function directoryRows(rootPath, reportPath) {
+  if (!existsSync(rootPath)) return [];
+  return readdirSync(rootPath)
     .map((name) => {
-      const targetPath = path.join(appFilesRoot, name);
-      return { name: `/app/${name}`, size: directorySize(targetPath) };
+      const targetPath = path.join(rootPath, name);
+      return { path: `${reportPath}/${name}`, bytes: directorySize(targetPath) };
     })
-    .sort((left, right) => right.size - left.size)
-    .slice(0, 12);
-  process.stdout.write("Flatpak /app size report:\n");
-  for (const row of rows) {
-    process.stdout.write(`  ${bytesToMiB(row.size).padStart(10)} ${row.name}\n`);
+    .sort((left, right) => right.bytes - left.bytes || left.path.localeCompare(right.path))
+    .map(({ path: entryPath, bytes }) => ({ path: entryPath, bytes }));
+}
+
+function sizeEvidence(targetPath, reportPath) {
+  if (!existsSync(targetPath)) return { path: reportPath, available: false };
+  return { path: reportPath, available: true, bytes: directorySize(targetPath) };
+}
+
+function pythonArtifactEvidence(artifacts) {
+  const entries = artifacts
+    .map(({ name, version, fileName, size }) => ({ name, version, fileName, bytes: size ?? null }))
+    .sort((left, right) => (right.bytes ?? -1) - (left.bytes ?? -1) || left.name.localeCompare(right.name));
+  const unknownCount = entries.filter((entry) => entry.bytes === null).length;
+  return {
+    knownBytes: entries.reduce((total, entry) => total + (entry.bytes ?? 0), 0),
+    unknownCount,
+    complete: unknownCount === 0,
+    entries,
+  };
+}
+
+function compressedBundleEvidence(bundle, includeBundle) {
+  if (!includeBundle || !existsSync(bundle)) return { path: path.basename(bundle), available: false };
+  const stats = statSync(bundle);
+  if (!stats.isFile()) throw new Error(`Flatpak bundle target must be a regular file: ${bundle}`);
+  return { path: path.basename(bundle), available: true, bytes: stats.size };
+}
+
+export function flatpakSizeReport({
+  buildRoot = buildDir,
+  bundle = bundlePath,
+  wheelReportPath = path.join(flatpakRoot, "generated", "python-size-report.json"),
+  includeBundle = true,
+} = {}) {
+  const appFilesRoot = path.join(buildRoot, "files");
+  const pythonRuntimeRoot = path.join(appFilesRoot, "lib", "tuneforge", "backend", "python");
+  const sitePackagesRoot = path.join(appFilesRoot, "lib", "tuneforge", "backend", "site-packages");
+  const pythonArtifacts = existsSync(wheelReportPath) ? readJson(wheelReportPath) : [];
+  const compressedBundle = compressedBundleEvidence(bundle, includeBundle);
+  const report = {
+    schema: sizeReportSchema,
+    unit: "bytes",
+    compressedBundle,
+    installedApp: {
+      ...sizeEvidence(appFilesRoot, "/app"),
+      topLevelDirectories: directoryRows(appFilesRoot, "/app"),
+    },
+    pythonRuntime: sizeEvidence(pythonRuntimeRoot, "/app/lib/tuneforge/backend/python"),
+    sitePackages: sizeEvidence(sitePackagesRoot, "/app/lib/tuneforge/backend/site-packages"),
+    wheelInputs: pythonArtifactEvidence(pythonArtifacts.filter((entry) => entry.fileName.endsWith(".whl"))),
+    sourceArchives: pythonArtifactEvidence(pythonArtifacts.filter((entry) => !entry.fileName.endsWith(".whl"))),
+  };
+  if (compressedBundle.available) {
+    report.compliance = {
+      hardLimitBytes: flatpakBundleHardLimitBytes,
+      hardLimitPassed: compressedBundle.bytes < flatpakBundleHardLimitBytes,
+      targetBytes: flatpakBundleTargetBytes,
+      targetMet: compressedBundle.bytes <= flatpakBundleTargetBytes,
+    };
+  }
+  return report;
+}
+
+export function enforceFlatpakBundleSize(report) {
+  if (!report.compressedBundle.available) return;
+  if (report.compressedBundle.bytes >= flatpakBundleHardLimitBytes) {
+    throw new Error(`Flatpak bundle ${bytesToBinaryUnit(report.compressedBundle.bytes)} exceeds the 2 GiB hard limit.`);
+  }
+  if (!report.compliance.targetMet) {
+    process.stderr.write(
+      `Flatpak bundle ${bytesToBinaryUnit(report.compressedBundle.bytes)} is below the hard limit but misses the 1.9 GiB target; issue #490 remains incomplete.\n`,
+    );
   }
 }
 
-function printPythonWheelSizeReport() {
-  const reportPath = path.join(flatpakRoot, "generated", "python-size-report.json");
-  if (!existsSync(reportPath)) {
-    return;
+function printFlatpakSizeReport(report) {
+  process.stdout.write("Flatpak size report (binary bytes):\n");
+  for (const entry of report.installedApp.topLevelDirectories) {
+    process.stdout.write(`  ${bytesToBinaryUnit(entry.bytes).padStart(10)} ${entry.path}\n`);
   }
-  const entries = JSON.parse(readFileSync(reportPath, "utf8")).slice(0, 15);
-  process.stdout.write("Flatpak selected Python artifact report:\n");
-  for (const entry of entries) {
-    const size = typeof entry.size === "number" ? bytesToMiB(entry.size).padStart(10) : "unknown".padStart(10);
-    process.stdout.write(`  ${size} ${entry.name}==${entry.version} ${entry.fileName}\n`);
+  if (report.compressedBundle.available) {
+    process.stdout.write(`  ${bytesToBinaryUnit(report.compressedBundle.bytes).padStart(10)} ${report.compressedBundle.path}\n`);
   }
 }
 
@@ -537,9 +605,11 @@ function main() {
     writeJson(comparisonPath, comparison);
     if (!comparison.equivalent) throw new Error(comparison.errors.join(" "));
   }
-  printAppDirectorySizeReport();
-  printPythonWheelSizeReport();
   if (skipBundle) {
+    const sizeReportPath = process.env.FLATPAK_SIZE_REPORT_PATH ?? path.join(flatpakRoot, "generated", "size-report.json");
+    const sizeReport = flatpakSizeReport({ includeBundle: false });
+    writeJson(sizeReportPath, sizeReport);
+    printFlatpakSizeReport(sizeReport);
     process.stdout.write(`Flatpak repo exported to ${repoDir}\n`);
     process.stdout.write(
       `Install with: flatpak remote-add --user --if-not-exists --no-gpg-verify ${localRepoRemote} ${repoDir}\n`,
@@ -549,6 +619,11 @@ function main() {
   }
 
   run("flatpak", ["build-bundle", "--arch=x86_64", repoDir, bundlePath, appId, "stable"]);
+  const sizeReportPath = process.env.FLATPAK_SIZE_REPORT_PATH ?? path.join(flatpakRoot, "generated", "size-report.json");
+  const sizeReport = flatpakSizeReport();
+  writeJson(sizeReportPath, sizeReport);
+  printFlatpakSizeReport(sizeReport);
+  enforceFlatpakBundleSize(sizeReport);
 
   process.stdout.write(`Flatpak bundle written to ${bundlePath}\n`);
 }

--- a/scripts/package-options.test.mjs
+++ b/scripts/package-options.test.mjs
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import {
+  assertDefaultCpuTorchClosure,
   markerMatchesFlatpakTarget,
   mergeLegacyTorchPackageSets,
   parseUvLock,
@@ -303,12 +304,41 @@ test("legacy nvidia includes LV Chordia by default", () => {
   ]);
 });
 
-test("Flatpak legacy resolver requests compatible Torch 2.13 and torchaudio 2.11 CUDA 12.6 wheels", () => {
+test("Flatpak resolves official CPU Torch by default and preserves the legacy CUDA 12.6 resolver", () => {
   const generator = readFileSync(new URL("./generate-flatpak-sources.mjs", import.meta.url), "utf8");
 
   assert.match(generator, /"torch==2\.13\.0\\ntorchaudio==2\.11\.0\\n"/);
   assert.match(generator, /"--python-version",\n\s+"3\.14"/);
+  assert.match(generator, /"--torch-backend",\n\s+"cpu"/);
   assert.match(generator, /"--torch-backend",\n\s+"cu126"/);
+});
+
+test("Flatpak CPU resolver replaces the CUDA closure and rejects unwanted accelerator families", () => {
+  const basePackages = [
+    { name: "cuda-bindings", version: "13.2.0" },
+    { name: "nvidia-cublas-cu12", version: "13.0.0.19" },
+    { name: "triton", version: "3.4.0" },
+    { name: "torch", version: "2.10.0" },
+    { name: "torchaudio", version: "2.10.0" },
+    { name: "numpy", version: "1.26.4" },
+  ];
+  const cpuPackages = new Map(
+    [
+      { name: "torch", version: "2.13.0" },
+      { name: "torchaudio", version: "2.11.0" },
+    ].map((pkg) => [pkg.name, pkg]),
+  );
+
+  const merged = mergeLegacyTorchPackageSets(basePackages, cpuPackages);
+  assert.deepEqual(
+    Object.fromEntries(merged.map((pkg) => [pkg.name, pkg.version])),
+    { numpy: "1.26.4", torch: "2.13.0", torchaudio: "2.11.0" },
+  );
+  assert.doesNotThrow(() => assertDefaultCpuTorchClosure(merged));
+  assert.throws(
+    () => assertDefaultCpuTorchClosure([...merged, { name: "nvidia-cudnn-cu12", version: "9.0.0" }]),
+    /unsupported packages: nvidia-cudnn-cu12/,
+  );
 });
 
 test("Flatpak legacy resolver replaces the complete Torch CUDA package family", () => {


### PR DESCRIPTION
## Summary

- Resolve default Flatpak Torch and Torchaudio with official CPU-only wheels while preserving the legacy NVIDIA path.
- Add structured bundle-size evidence and CPU-base size enforcement.
- Closes #490.

## Testing

- `node --test scripts/package-options.test.mjs scripts/flatpak-cache.test.mjs scripts/flatpak-options.test.mjs scripts/flatpak-pnpm.test.mjs`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm release:license-inventory -- --check`
- Linux x86_64 isolated validation: default no-bundle and full Flatpak builds, plus headless packaged CPU engine checks; no GUI launch or accelerator-hardware validation.
